### PR TITLE
fix: round-2 self-review gaps for pro onboarding wizard

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -38,6 +38,7 @@ let onboardingResponse: OnboardingStateResponse;
 let domainsResponse: PaginatedAssistantDomainList;
 let onboardingCalls = 0;
 let domainsCalls = 0;
+let domainsListPaths: string[] = [];
 
 const ACTIVE_ASSISTANT = { id: "assistant-1" } as unknown as Assistant;
 
@@ -54,8 +55,11 @@ mock.module("@/generated/api/sdk.gen", () => ({
     },
     assistantsActiveRetrieve: () =>
         Promise.resolve({ data: ACTIVE_ASSISTANT, response: { ok: true } }),
-    assistantsDomainsList: () => {
+    assistantsDomainsList: (opts: { path?: { assistant_id?: string } }) => {
         domainsCalls += 1;
+        if (opts?.path?.assistant_id) {
+            domainsListPaths.push(opts.path.assistant_id);
+        }
         return Promise.resolve({ data: domainsResponse, response: { ok: true } });
     },
 }));
@@ -190,6 +194,7 @@ beforeEach(() => {
     domainsResponse = makeDomains(false);
     onboardingCalls = 0;
     domainsCalls = 0;
+    domainsListPaths = [];
 });
 
 afterEach(() => {
@@ -262,6 +267,21 @@ describe("Finish Pro setup nudge", () => {
         expect(queryByTestId("finish-pro-setup-notice")).toBeNull();
         expect(onboardingCalls).toBe(0);
         expect(domainsCalls).toBe(0);
+    });
+
+    test("checks domains on the onboarding payload's primary assistant", async () => {
+        onboardingResponse = {
+            ...makeOnboarding(true),
+            primary_assistant_id: "assistant-2",
+        };
+        const { getByTestId } = renderPage();
+
+        // The onboarding payload names the wizard's server-side target; the
+        // nudge must check that assistant's domains, not the active one's.
+        await waitFor(() => expect(domainsListPaths).toContain("assistant-2"));
+        await waitFor(() =>
+            expect(getByTestId("finish-pro-setup-notice")).toBeTruthy(),
+        );
     });
 
     test("hidden for Pro when domain setup is unavailable, without querying domains", async () => {

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -89,7 +89,10 @@ function FinishProSetupNotice({ onFinishSetup }: { onFinishSetup: () => void }) 
     // signal is the assistant's domains list being loaded and empty.
     const domainSetupOffered =
         isPro && onboarding?.domain_setup_available === true;
-    const { domains } = useAssistantDomains(domainSetupOffered);
+    const { domains } = useAssistantDomains(
+        domainSetupOffered,
+        onboarding?.primary_assistant_id,
+    );
     const domainMissing = domains !== undefined && domains.results.length === 0;
 
     if (!domainSetupOffered || !domainMissing) {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -37,6 +37,12 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => true,
 }));
 
+mock.module("@/stores/organization-store", () => ({
+  useOrganizationStore: {
+    getState: () => ({ fetchOrganizations: () => Promise.resolve() }),
+  },
+}));
+
 const realDateNow = Date.now.bind(Date);
 let dateNowOffsetMs = 0;
 Date.now = () => realDateNow() + dateNowOffsetMs;
@@ -482,7 +488,7 @@ describe("BillingOnboardingModal", () => {
     );
   });
 
-  test("apply racing the still-running platform resize is treated as success", async () => {
+  test("a failed apply surfaces its error and a late-landing resize still recovers", async () => {
     subscriptionPlanId = "pro";
     resizeError = {
       detail: "Another assistant operation is already in progress.",
@@ -498,15 +504,18 @@ describe("BillingOnboardingModal", () => {
       timeout: 5000,
     });
 
-    // The concurrent-operation rejection means the server resize is still
-    // running — observation resumes instead of surfacing an error.
+    // The rejection renders as-is on the stalled screen.
     fireEvent.click(getByTestId("provisioning-apply"));
     await waitFor(() => expect(resizeCall).not.toBeNull());
-    await waitFor(
-      () => expect(getByText("Resizing your assistant…")).toBeTruthy(),
-      { timeout: 5000 },
+    await waitFor(() =>
+      expect(
+        getByText("Another assistant operation is already in progress."),
+      ).toBeTruthy(),
     );
+    expect(getByText("One more step")).toBeTruthy();
 
+    // If a server-side resize was in fact still running, its landing is
+    // observed by the actuals polling and replaces the stalled UI.
     assistantResponse = makeAssistant("large", 50);
     await client.invalidateQueries();
     await waitFor(
@@ -559,9 +568,10 @@ describe("BillingOnboardingModal", () => {
     expect(queryByTestId("complete-stalled-apply")).toBeNull();
   });
 
-  test("a stall while the user is on the domain step keeps the submit locked", async () => {
+  test("a stall while the user is on the domain step offers the apply controls and keeps the submit locked", async () => {
     subscriptionPlanId = "pro";
-    const { client, getByText, getByTestId, getByLabelText } = renderModal();
+    const { client, getByText, getByTestId, getByLabelText, queryByText, queryByTestId } =
+      renderModal();
 
     await waitFor(
       () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
@@ -581,15 +591,36 @@ describe("BillingOnboardingModal", () => {
     );
 
     // The flow stalls while the user is on the domain step: the machine may
-    // still be mid-restart, so the guardian-channel submit stays locked.
+    // still be mid-restart, so the guardian-channel submit stays locked and
+    // the neutral busy notice swaps for the stalled warning + manual apply.
     dateNowOffsetMs = 200_000;
-    await new Promise((resolve) => setTimeout(resolve, 1200));
+    await waitFor(
+      () => expect(getByTestId("domain-stalled-apply")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+    expect(
+      queryByText(
+        "Your assistant is restarting — you can set the domain in a moment.",
+      ),
+    ).toBeNull();
     expect(
       (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
     ).toBe(true);
 
-    // Polling stays alive through the stall, so the resize landing late
-    // self-recovers and lifts the guard.
+    // Applying resumes observation: the stalled controls give way to the
+    // neutral busy notice while the resize is re-observed…
+    fireEvent.click(getByTestId("domain-stalled-apply"));
+    await waitFor(() => expect(resizeCall).not.toBeNull());
+    await waitFor(() =>
+      expect(
+        getByText(
+          "Your assistant is restarting — you can set the domain in a moment.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(queryByTestId("domain-stalled-apply")).toBeNull();
+
+    // …and the resize landing lifts the guard.
     assistantResponse = makeAssistant("large", 50);
     await client.invalidateQueries();
     await waitFor(

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -17,7 +17,6 @@ import { FetchErrorState } from "./error-states";
 import type { ProvisioningDimensions } from "./provisioning-machine";
 import { ProvisioningState } from "./provisioning-state";
 import { useProProvisioning } from "./use-pro-provisioning";
-import { isOperationAlreadyInProgressError } from "./utils";
 
 type WizardStep = "provisioning" | "domain" | "complete";
 
@@ -118,27 +117,19 @@ export function BillingOnboardingModal({
         // and resumes its actuals polling so the normal DONE path can
         // complete.
         onSuccess: () => provisioning.resumeAfterManualApply(),
-        onError: (error) => {
-          // The platform's concurrent-operation guard rejecting the apply
-          // means the resize we stalled on is in fact still running — that is
-          // success-equivalent, so resume observing instead of surfacing it.
-          if (isOperationAlreadyInProgressError(error)) {
-            provisioning.resumeAfterManualApply();
-          }
-        },
       },
     );
   };
-  const stalledApplyError = isOperationAlreadyInProgressError(
-    resizeMutation.error,
-  )
-    ? null
-    : resizeMutation.error;
+  // Apply errors surface as-is; if a server-side resize is actually still
+  // running, the actuals polling converges to DONE and replaces the stalled
+  // UI regardless.
   const stalledAction = {
     onApply: applyStalledResize,
     pending: resizeMutation.isPending,
-    error: stalledApplyError,
+    error: resizeMutation.error,
   };
+  const stalledActionIfStalled =
+    provisioning.state === "STALLED" ? stalledAction : undefined;
 
   const handleClose = () => {
     if (step === "provisioning" && machineBusy) {
@@ -199,6 +190,7 @@ export function BillingOnboardingModal({
       return (
         <DomainStep
           machineBusy={machineBusy}
+          stalledAction={stalledActionIfStalled}
           onExit={() => setStep("complete")}
         />
       );
@@ -207,8 +199,7 @@ export function BillingOnboardingModal({
     return (
       <CompleteState
         finishedInBackground={finishedInBackground && !provisioningSettled}
-        stalled={provisioning.state === "STALLED"}
-        stalledAction={stalledAction}
+        stalledAction={stalledActionIfStalled}
       />
     );
   }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
@@ -10,18 +10,16 @@ import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
 
-import type { StalledApplyAction } from "./provisioning-state";
-import { extractOnboardingErrorMessage } from "./utils";
+import type { StalledApplyAction } from "./primitives";
+import { STALLED_UPGRADE_WARNING, StalledApplyControls } from "./primitives";
 
 export function CompleteState({
   finishedInBackground = false,
-  stalled = false,
   stalledAction,
 }: {
   /** The user backgrounded the machine resize; hidden once it completes. */
   finishedInBackground?: boolean;
-  /** The backgrounded resize stalled — offer the manual apply instead. */
-  stalled?: boolean;
+  /** Set only while the backgrounded resize is stalled — offers manual apply. */
   stalledAction?: StalledApplyAction;
 }) {
   const navigate = useNavigate();
@@ -83,28 +81,16 @@ export function CompleteState({
         Your assistant just got a serious upgrade.
       </p>
 
-      {stalled && stalledAction ? (
+      {stalledAction ? (
         <div className="relative -mt-4 mb-6 flex w-full flex-col items-center gap-2 [animation:welcome-reveal_600ms_ease-out_350ms_both] motion-reduce:[animation:none]">
           <Notice tone="warning" className="w-full text-left">
-            We couldn&apos;t finish your machine upgrade automatically. Apply
-            it now to finish — your assistant will briefly restart.
+            {STALLED_UPGRADE_WARNING}
           </Notice>
-          {stalledAction.error != null && (
-            <Notice tone="error" className="w-full text-left">
-              {extractOnboardingErrorMessage(
-                stalledAction.error,
-                "Couldn't apply changes. Please try again.",
-              )}
-            </Notice>
-          )}
-          <Button
-            variant="outlined"
-            data-testid="complete-stalled-apply"
-            disabled={stalledAction.pending}
-            onClick={stalledAction.onApply}
-          >
-            Apply &amp; Restart
-          </Button>
+          <StalledApplyControls
+            action={stalledAction}
+            buttonVariant="outlined"
+            buttonTestId="complete-stalled-apply"
+          />
         </div>
       ) : (
         finishedInBackground && (

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
@@ -8,7 +8,7 @@
  * mutation resolves, then spy on the query client's invalidations.
  */
 
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
@@ -18,9 +18,18 @@ import {
   organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
 import * as sdkGen from "@/generated/api/sdk.gen";
-import type { Assistant } from "@/generated/api/types.gen";
+import type {
+  Assistant,
+  OnboardingStateResponse,
+} from "@/generated/api/types.gen";
 
 let domainCreateCalls = 0;
+let primaryAssistantId: string | null = "assistant-1";
+let domainsListPaths: string[] = [];
+
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => true,
+}));
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -29,9 +38,25 @@ mock.module("@/generated/api/sdk.gen", () => ({
       data: { id: "assistant-1", handle: "velly" } as unknown as Assistant,
       response: { ok: true },
     }),
-  assistantsDomainsList: () =>
-    Promise.resolve({
+  assistantsDomainsList: (opts: { path?: { assistant_id?: string } }) => {
+    if (opts?.path?.assistant_id) {
+      domainsListPaths.push(opts.path.assistant_id);
+    }
+    return Promise.resolve({
       data: { count: 0, next: null, previous: null, results: [] },
+      response: { ok: true },
+    });
+  },
+  organizationsBillingSubscriptionOnboardingRetrieve: () =>
+    Promise.resolve({
+      data: {
+        max_machine_tier: "large",
+        selected_storage_tier: "md",
+        selected_storage_gib: 50,
+        pvc_ready: true,
+        domain_setup_available: true,
+        primary_assistant_id: primaryAssistantId,
+      } satisfies OnboardingStateResponse,
       response: { ok: true },
     }),
   organizationsBillingSubscriptionOnboardingDomainCreate: () => {
@@ -42,13 +67,18 @@ mock.module("@/generated/api/sdk.gen", () => ({
 
 const { DomainStep } = await import("./domain-step");
 
+beforeEach(() => {
+  domainCreateCalls = 0;
+  primaryAssistantId = "assistant-1";
+  domainsListPaths = [];
+});
+
 afterEach(() => {
   cleanup();
 });
 
 describe("DomainStep domain registration", () => {
   test("invalidates the domains-list and onboarding caches on success", async () => {
-    domainCreateCalls = 0;
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -88,5 +118,83 @@ describe("DomainStep domain registration", () => {
         organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
       ),
     );
+  });
+
+  test("checks domains on the onboarding payload's primary assistant", async () => {
+    primaryAssistantId = "assistant-2";
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <DomainStep onExit={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    // The onboarding payload's primary assistant wins over the active one.
+    await waitFor(() => expect(domainsListPaths).toContain("assistant-2"));
+  });
+});
+
+describe("DomainStep stalled resize", () => {
+  test("stalledAction swaps the busy notice for the warning and apply controls", async () => {
+    const onApply = mock(() => {});
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { getByText, getByTestId, queryByText } = render(
+      <QueryClientProvider client={client}>
+        <DomainStep
+          onExit={() => {}}
+          machineBusy
+          stalledAction={{ onApply, pending: false, error: null }}
+        />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("domain-stalled-apply")).toBeTruthy(),
+    );
+    expect(
+      getByText(/We couldn't finish your machine upgrade automatically/),
+    ).toBeTruthy();
+    expect(
+      queryByText(
+        "Your assistant is restarting — you can set the domain in a moment.",
+      ),
+    ).toBeNull();
+
+    fireEvent.click(getByTestId("domain-stalled-apply"));
+    expect(onApply).toHaveBeenCalledTimes(1);
+
+    // The guardian-channel submit stays locked while the machine is busy.
+    await waitFor(() =>
+      expect(
+        (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
+      ).toBe(true),
+    );
+  });
+
+  test("plain machine-busy keeps the neutral notice without apply controls", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { getByText, queryByTestId } = render(
+      <QueryClientProvider client={client}>
+        <DomainStep onExit={() => {}} machineBusy />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        getByText(
+          "Your assistant is restarting — you can set the domain in a moment.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(queryByTestId("domain-stalled-apply")).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -1,14 +1,16 @@
 import { Mail } from "lucide-react";
 import { useEffect, useState } from "react";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
     assistantsDomainsListQueryKey,
     assistantsListQueryKey,
     organizationsBillingSubscriptionOnboardingDomainCreateMutation,
+    organizationsBillingSubscriptionOnboardingRetrieveOptions,
     organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { useEnvironmentStore } from "@/stores/environment-store";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
@@ -16,21 +18,39 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import { DomainField } from "@/domains/settings/components/domain-field";
-import { IconBadge } from "./primitives";
+import type { StalledApplyAction } from "./primitives";
+import {
+    IconBadge,
+    STALLED_UPGRADE_WARNING,
+    StalledApplyControls,
+} from "./primitives";
 import { useAssistantDomains } from "./use-assistant-domains";
 import { DOMAIN_EXIT_DELAY_MS, extractOnboardingErrorMessage } from "./utils";
 
 export function DomainStep({
   onExit,
   machineBusy = false,
+  stalledAction,
 }: {
   onExit: () => void;
   /** The assistant machine is restarting (webhook-driven resize in flight). */
   machineBusy?: boolean;
+  /** Set only while the resize is stalled — offers the manual apply here. */
+  stalledAction?: StalledApplyAction;
 }) {
   const queryClient = useQueryClient();
   const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
-  const { activeAssistant, assistantId, domains } = useAssistantDomains();
+  const isOrgReady = useIsOrgReady();
+  // The onboarding payload names the assistant the domain registration
+  // targets server-side; prefer it over the active assistant.
+  const { data: onboarding } = useQuery({
+    ...organizationsBillingSubscriptionOnboardingRetrieveOptions(),
+    enabled: isOrgReady,
+  });
+  const { activeAssistant, assistantId, domains } = useAssistantDomains(
+    true,
+    onboarding?.primary_assistant_id,
+  );
   const existingDomain = domains?.results[0];
 
   const [subdomain, setSubdomain] = useState("");
@@ -167,10 +187,25 @@ export function DomainStep({
           />
         </div>
 
-        {machineBusy && !isLocked && (
-          <Notice tone="neutral">
-            Your assistant is restarting — you can set the domain in a moment.
-          </Notice>
+        {stalledAction && !isLocked ? (
+          <div className="flex flex-col items-center gap-2">
+            <Notice tone="warning" className="w-full text-left">
+              {STALLED_UPGRADE_WARNING}
+            </Notice>
+            <StalledApplyControls
+              action={stalledAction}
+              buttonVariant="outlined"
+              buttonTestId="domain-stalled-apply"
+            />
+          </div>
+        ) : (
+          machineBusy &&
+          !isLocked && (
+            <Notice tone="neutral">
+              Your assistant is restarting — you can set the domain in a
+              moment.
+            </Notice>
+          )
         )}
         {!isLocked && (
           <Notice tone="info">

--- a/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
@@ -1,6 +1,59 @@
 import type { LucideIcon } from "lucide-react";
 import { ArrowRight, Loader2 } from "lucide-react";
 
+import type { ButtonVariant } from "@vellumai/design-library/components/button";
+import { Button } from "@vellumai/design-library/components/button";
+import { Notice } from "@vellumai/design-library/components/notice";
+
+import { extractOnboardingErrorMessage } from "./utils";
+
+/** The manual Apply & Restart recovery threaded down from the modal. */
+export interface StalledApplyAction {
+  onApply: () => void;
+  pending: boolean;
+  error: unknown;
+}
+
+/** Warning shown when a backgrounded resize stalls mid-wizard. */
+export const STALLED_UPGRADE_WARNING =
+  "We couldn't finish your machine upgrade automatically. Apply it now to finish — your assistant will briefly restart.";
+
+/**
+ * Error notice + Apply & Restart button for recovering a stalled resize.
+ * Shared by the provisioning screen, the complete screen, and the domain
+ * step so the recovery affordance can't drift between them.
+ */
+export function StalledApplyControls({
+  action,
+  buttonVariant = "primary",
+  buttonTestId,
+}: {
+  action: StalledApplyAction;
+  buttonVariant?: ButtonVariant;
+  buttonTestId: string;
+}) {
+  return (
+    <>
+      {action.error != null && (
+        <Notice tone="error" className="w-full text-left">
+          {extractOnboardingErrorMessage(
+            action.error,
+            "Couldn't apply changes. Please try again.",
+          )}
+        </Notice>
+      )}
+      <Button
+        variant={buttonVariant}
+        data-testid={buttonTestId}
+        disabled={action.pending}
+        onClick={action.onApply}
+      >
+        Apply &amp; Restart
+      </Button>
+    </>
+  );
+}
+
 export function IconBadge({
   icon: Icon,
   tone = "positive",

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -16,15 +16,14 @@ import type {
     ProvisioningStateKind,
 } from "./provisioning-machine";
 import { TimeoutState } from "./error-states";
-import { GlowSpinner, IconBadge, ResourceCard } from "./primitives";
-import { extractOnboardingErrorMessage, PROVISION_MIN_DWELL_MS } from "./utils";
-
-/** The manual Apply & Restart recovery threaded down from the modal. */
-export interface StalledApplyAction {
-  onApply: () => void;
-  pending: boolean;
-  error: unknown;
-}
+import type { StalledApplyAction } from "./primitives";
+import {
+    GlowSpinner,
+    IconBadge,
+    ResourceCard,
+    StalledApplyControls,
+} from "./primitives";
+import { PROVISION_MIN_DWELL_MS } from "./utils";
 
 export interface ProvisioningStateProps {
   state: ProvisioningStateKind;
@@ -281,22 +280,10 @@ export function ProvisioningState({
             to finish setting up your upgrade.
           </Notice>
           <ResourceCardList targets={targets} fromSnapshot={fromSnapshot} />
-          {stalledAction.error != null && (
-            <Notice tone="error" className="w-full text-left">
-              {extractOnboardingErrorMessage(
-                stalledAction.error,
-                "Couldn't apply changes. Please try again.",
-              )}
-            </Notice>
-          )}
-          <Button
-            variant="primary"
-            data-testid="provisioning-apply"
-            disabled={stalledAction.pending}
-            onClick={stalledAction.onApply}
-          >
-            Apply &amp; Restart
-          </Button>
+          <StalledApplyControls
+            action={stalledAction}
+            buttonTestId="provisioning-apply"
+          />
         </>
       );
     }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-assistant-domains.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-assistant-domains.ts
@@ -6,17 +6,23 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 
 /**
- * The active assistant and its registered email domains — the single source
- * for "does the assistant have a domain yet", shared by the onboarding
- * wizard's domain step and the billing page's finish-setup nudge so the two
- * can't drift apart.
+ * The assistant targeted by domain setup and its registered email domains —
+ * the single source for "does the assistant have a domain yet", shared by the
+ * onboarding wizard's domain step and the billing page's finish-setup nudge
+ * so the two can't drift apart.
+ *
+ * `preferredAssistantId` (the onboarding payload's `primary_assistant_id`)
+ * wins over the active assistant when the two diverge (multi-assistant orgs).
  */
-export function useAssistantDomains(enabled = true) {
+export function useAssistantDomains(
+  enabled = true,
+  preferredAssistantId?: string | null,
+) {
   const { data: activeAssistant } = useQuery({
     ...assistantsActiveRetrieveOptions(),
     enabled,
   });
-  const assistantId = activeAssistant?.id;
+  const assistantId = preferredAssistantId ?? activeAssistant?.id;
   const { data: domains } = useQuery({
     ...assistantsDomainsListOptions({
       path: { assistant_id: assistantId ?? "" },

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -12,6 +12,7 @@ import { useEffect } from "react";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
+import { organizationsBillingSubscriptionRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import type {
   Assistant,
@@ -20,6 +21,16 @@ import type {
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
 import type { ProProvisioningResult } from "./use-pro-provisioning";
+
+import * as proOnboardingUtils from "./utils";
+
+/** Shrunk so confirm-timeout reachability doesn't wait out the real 10s poll. */
+const TEST_CONFIRM_TIMEOUT_MS = 800;
+
+mock.module("./utils", () => ({
+  ...proOnboardingUtils,
+  PRO_POLL_TIMEOUT_MS: TEST_CONFIRM_TIMEOUT_MS,
+}));
 
 // Stall detection compares wall-clock time against the 90s threshold; the
 // stall tests jump this offset instead of waiting it out.
@@ -88,9 +99,21 @@ let assistantCalls = 0;
 let operationalStatusCalls = 0;
 let subscriptionCalls = 0;
 let isOrgReadyMock = true;
+let fetchOrganizationsCalls = 0;
 
 mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => isOrgReadyMock,
+}));
+
+mock.module("@/stores/organization-store", () => ({
+  useOrganizationStore: {
+    getState: () => ({
+      fetchOrganizations: () => {
+        fetchOrganizationsCalls += 1;
+        return Promise.resolve();
+      },
+    }),
+  },
 }));
 
 mock.module("@/generated/api/sdk.gen", () => ({
@@ -137,10 +160,13 @@ function Probe() {
   return null;
 }
 
-function renderProbe() {
-  const client = new QueryClient({
+function makeClient() {
+  return new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+}
+
+function renderProbe(client = makeClient()) {
   const ui = () => (
     <QueryClientProvider client={client}>
       <Probe />
@@ -182,6 +208,7 @@ beforeEach(() => {
   operationalStatusCalls = 0;
   subscriptionCalls = 0;
   isOrgReadyMock = true;
+  fetchOrganizationsCalls = 0;
   dateNowOffsetMs = 0;
   latest = null;
 });
@@ -376,7 +403,7 @@ describe("useProProvisioning", () => {
     20_000,
   );
 
-  test("org-scoped queries hold until the org store is ready", async () => {
+  test("org-scoped queries hold until the org id is available", async () => {
     isOrgReadyMock = false;
     const { rerender } = renderProbe();
 
@@ -393,6 +420,70 @@ describe("useProProvisioning", () => {
       timeout: 5000,
     });
     expect(subscriptionCalls).toBeGreaterThan(0);
+  });
+
+  test("org never ready: confirm timeout still fires and retry kicks the org fetch", async () => {
+    isOrgReadyMock = false;
+    renderProbe();
+
+    // The confirm timer runs regardless of org readiness, so a wedged org
+    // hydration still lands on the payment-safe retry screen.
+    await waitFor(() => expect(latest!.state).toBe("CONFIRM_TIMEOUT"), {
+      timeout: TEST_CONFIRM_TIMEOUT_MS + 3000,
+    });
+    expect(subscriptionCalls).toBe(0);
+
+    // Retry also refetches the org list so it can heal a failed hydration.
+    act(() => latest!.retryConfirm());
+    expect(fetchOrganizationsCalls).toBe(1);
+    await waitFor(() => expect(latest!.state).toBe("CONFIRMING"));
+  });
+
+  test("reopen with a stale cached pro plan never confirms from cache", async () => {
+    const client = makeClient();
+    // A pre-downgrade "pro" response is still cached from an earlier session
+    // of the wizard; the live subscription is back on base.
+    client.setQueryData(
+      organizationsBillingSubscriptionRetrieveQueryKey(),
+      makeSubscription("pro"),
+      { updatedAt: realDateNow() - 60_000 },
+    );
+    subscriptionPlanId = "base";
+    renderProbe(client);
+
+    // The on-open refetch lands base; the stale cached pro must not latch.
+    await waitFor(() => expect(subscriptionCalls).toBeGreaterThan(0));
+    expect(latest!.state).toBe("CONFIRMING");
+    expect(latest!.targets).toBeNull();
+
+    // No wedge: the flow still reaches the payment-safe timeout screen.
+    await waitFor(() => expect(latest!.state).toBe("CONFIRM_TIMEOUT"), {
+      timeout: TEST_CONFIRM_TIMEOUT_MS + 3000,
+    });
+    expect(latest!.targets).toBeNull();
+  });
+
+  test("assistantId prefers the onboarding primary assistant over the active one", async () => {
+    subscriptionPlanId = "pro";
+    onboardingResponse = {
+      ...makeOnboarding(),
+      primary_assistant_id: "assistant-2",
+    };
+    renderProbe();
+
+    await waitFor(() => expect(latest!.assistantId).toBe("assistant-2"), {
+      timeout: 5000,
+    });
+  });
+
+  test("assistantId falls back to the active assistant without a primary", async () => {
+    subscriptionPlanId = "pro";
+    onboardingResponse = { ...makeOnboarding(), primary_assistant_id: null };
+    renderProbe();
+
+    await waitFor(() => expect(latest!.assistantId).toBe("assistant-1"), {
+      timeout: 5000,
+    });
   });
 
   test("unknown machine tier from a newer backend yields no machine target", async () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -29,6 +29,7 @@ import {
 import type { OperationalStatus } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { allowedMachineSizesForTier } from "@/lib/billing/machine-sizes";
+import { useOrganizationStore } from "@/stores/organization-store";
 
 import {
   deriveProvisioningState,
@@ -82,7 +83,11 @@ export interface ProProvisioningResult {
   targets: ProvisioningDimensions | null;
   /** First actuals observed, frozen — the "from" side of before/after cards. */
   actualsSnapshot: ProvisioningDimensions | null;
-  /** Last-known active assistant id from the actuals poll. */
+  /**
+   * The assistant provisioning targets: the onboarding payload's primary
+   * assistant when known, else the active assistant from the actuals poll.
+   * Drives the operational-status poll and the stalled manual resize.
+   */
   assistantId: string | null;
   /** `domain_setup_available` from the onboarding state, once loaded. */
   domainSetupAvailable: boolean | undefined;
@@ -119,10 +124,15 @@ export function useProProvisioning({
   const queryClient = useQueryClient();
   // Every query here is org-scoped (needs the Vellum-Organization-Id header).
   // On the cold return from Stripe the org store may not be hydrated yet, so
-  // hold all fetches — and the confirm timeout they feed — until it is.
+  // hold the fetches until it is. The confirm timeout deliberately runs
+  // regardless: if org readiness never arrives, the user still lands on the
+  // payment-safe retry screen instead of an indefinite spinner.
   const orgReady = useIsOrgReady();
   const [confirmExpired, setConfirmExpired] = useState(false);
   const [confirmGeneration, setConfirmGeneration] = useState(0);
+  // Wall-clock fence for confirm latching: only subscription data fetched
+  // after this instant may confirm pro.
+  const [openedAt, setOpenedAt] = useState<number | null>(null);
   const [proConfirmedAt, setProConfirmedAt] = useState<number | null>(null);
   // Stall-clock re-base set by resumeAfterManualApply; proConfirmedAt otherwise.
   const [resumedAt, setResumedAt] = useState<number | null>(null);
@@ -141,6 +151,7 @@ export function useProProvisioning({
     if (open) return;
     setConfirmExpired(false);
     setConfirmGeneration(0);
+    setOpenedAt(null);
     setProConfirmedAt(null);
     setResumedAt(null);
     setSawOperation(false);
@@ -148,10 +159,12 @@ export function useProProvisioning({
     setTracking(true);
   }, [open]);
 
-  // Drop pre-checkout caches so we never confirm on a stale plan_id or read a
-  // pre-upgrade tier ceiling as the resize target.
+  // Refetch pre-checkout caches on open. Invalidation keeps serving cached
+  // data while the refetch is in flight, so `openedAt` fences confirm
+  // latching to data that actually landed after this open.
   useEffect(() => {
     if (!open) return;
+    setOpenedAt(Date.now());
     void queryClient.invalidateQueries({
       queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
     });
@@ -173,7 +186,12 @@ export function useProProvisioning({
     enabled: open && orgReady && !proConfirmed,
   });
 
-  const observedPlanId = subscriptionQuery.data?.plan_id ?? null;
+  // Reopening the wizard can serve a cached pre-downgrade "pro" while the
+  // on-open refetch is still in flight; only post-open data may confirm.
+  const subscriptionFresh =
+    openedAt != null && subscriptionQuery.dataUpdatedAt >= openedAt;
+  const observedPlanId =
+    (subscriptionFresh ? subscriptionQuery.data?.plan_id : null) ?? null;
 
   useEffect(() => {
     if (!open || proConfirmed || observedPlanId !== "pro") return;
@@ -183,16 +201,19 @@ export function useProProvisioning({
   }, [open, proConfirmed, observedPlanId]);
 
   useEffect(() => {
-    if (!open || !orgReady || proConfirmed) {
+    if (!open || proConfirmed) {
       return;
     }
     const t = setTimeout(() => setConfirmExpired(true), PRO_POLL_TIMEOUT_MS);
     return () => clearTimeout(t);
-  }, [open, orgReady, proConfirmed, confirmGeneration]);
+  }, [open, proConfirmed, confirmGeneration]);
 
   const retryConfirm = useCallback(() => {
     setConfirmExpired(false);
     setConfirmGeneration((g) => g + 1);
+    // A failed org-list fetch leaves every org-gated query here disabled;
+    // refetching it lets the retry heal that alongside the subscription poll.
+    void useOrganizationStore.getState().fetchOrganizations();
     void queryClient.invalidateQueries({
       queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
     });
@@ -218,7 +239,12 @@ export function useProProvisioning({
     refetchInterval: pollInterval,
     retry: false,
   });
-  const assistantId = activeAssistantQuery.data?.id ?? null;
+  // The onboarding payload names the server-side provisioning target; it wins
+  // over the active assistant when the two diverge (multi-assistant orgs).
+  const assistantId =
+    onboardingQuery.data?.primary_assistant_id ??
+    activeAssistantQuery.data?.id ??
+    null;
 
   const operationalStatusQuery = useQuery({
     ...assistantsOperationalStatusDetailReadOptions({

--- a/clients/web/src/domains/settings/billing/pro-onboarding/utils.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/utils.ts
@@ -27,24 +27,6 @@ export const ONBOARDING_ERROR_CODE_MESSAGES: Record<string, string> = {
   exceeds_machine_tier: "That machine size isn't available on your plan.",
 };
 
-/**
- * The platform's concurrent-operation guard: a resize submitted while another
- * assistant operation (e.g. the webhook-driven auto-resize) is still running is
- * rejected with this detail. For the stalled Apply & Restart flow that
- * rejection means the resize we were waiting on is in fact in progress, so
- * callers treat it as success-equivalent.
- */
-export function isOperationAlreadyInProgressError(error: unknown): boolean {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-  const detail = (error as Record<string, unknown>).detail;
-  return (
-    typeof detail === "string" &&
-    detail.toLowerCase().includes("operation is already in progress")
-  );
-}
-
 export function extractOnboardingErrorMessage(
   error: unknown,
   fallback: string,

--- a/clients/web/src/hooks/use-is-org-ready.test.tsx
+++ b/clients/web/src/hooks/use-is-org-ready.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * `useIsOrgReady` must align with the request-header source
+ * (`getActiveOrganizationIdForRequests()`): a failed org-list fetch must not
+ * wedge org-gated queries when sessionStorage still carries the active org id
+ * from an earlier page load.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { useEffect } from "react";
+import { cleanup, render } from "@testing-library/react";
+
+import * as authStore from "@/stores/auth-store";
+
+let hasPlatformSessionMock = true;
+
+mock.module("@/stores/auth-store", () => ({
+  ...authStore,
+  useHasPlatformSession: () => hasPlatformSessionMock,
+}));
+
+const { useIsOrgReady } = await import("./use-is-org-ready");
+const { useOrganizationStore } = await import("@/stores/organization-store");
+
+const STORAGE_KEY = "vellum_active_organization_id";
+
+let latest: boolean | null = null;
+
+function Probe() {
+  const ready = useIsOrgReady();
+  useEffect(() => {
+    latest = ready;
+  });
+  return null;
+}
+
+beforeEach(() => {
+  hasPlatformSessionMock = true;
+  latest = null;
+  sessionStorage.clear();
+  useOrganizationStore.setState({
+    organizations: [],
+    currentOrganizationId: null,
+    status: "idle",
+    error: null,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useIsOrgReady", () => {
+  test("not ready with a platform session and no org id anywhere", () => {
+    render(<Probe />);
+    expect(latest).toBe(false);
+  });
+
+  test("ready once the store has hydrated", () => {
+    useOrganizationStore.setState({
+      currentOrganizationId: "org-1",
+      status: "ready",
+    });
+    render(<Probe />);
+    expect(latest).toBe(true);
+  });
+
+  test("ready via the sessionStorage fallback when the org fetch failed", () => {
+    sessionStorage.setItem(STORAGE_KEY, "org-1");
+    useOrganizationStore.setState({
+      status: "error",
+      error: "Failed to load organizations.",
+    });
+    render(<Probe />);
+    expect(latest).toBe(true);
+  });
+
+  test("ready without a platform session (self-hosted auth)", () => {
+    hasPlatformSessionMock = false;
+    render(<Probe />);
+    expect(latest).toBe(true);
+  });
+});

--- a/clients/web/src/hooks/use-is-org-ready.ts
+++ b/clients/web/src/hooks/use-is-org-ready.ts
@@ -1,13 +1,25 @@
 import { useHasPlatformSession } from "@/stores/auth-store";
-import { useOrganizationStore } from "@/stores/organization-store";
+import {
+  getActiveOrganizationIdForRequests,
+  useOrganizationStore,
+} from "@/stores/organization-store";
 
 /**
  * Gate for queries that need the `Vellum-Organization-Id` header.
- * Returns `true` when the org store has hydrated, or when no
- * platform session exists (self-hosted / gateway-only auth).
+ *
+ * Ready when the header source (`getActiveOrganizationIdForRequests()`)
+ * can produce an id — the hydrated store or its sessionStorage fallback —
+ * or when no platform session exists (self-hosted / gateway-only auth).
+ * Matching the interceptor's own fallback means a failed org-list fetch
+ * can't wedge gated queries when a previous session already knows the org.
  */
 export function useIsOrgReady(): boolean {
+  // Subscribed for reactivity: the sessionStorage fallback only changes
+  // through store actions, so store updates cover every readiness change.
   const currentOrgId = useOrganizationStore.use.currentOrganizationId();
   const hasPlatformSession = useHasPlatformSession();
-  return !hasPlatformSession || currentOrgId != null;
+  if (!hasPlatformSession) {
+    return true;
+  }
+  return currentOrgId != null || getActiveOrganizationIdForRequests() != null;
 }


### PR DESCRIPTION
## Summary
Round-2 remediation for pro-onboarding-wizard-revamp.md: org-ready gate aligned with the request-header source + timeout always reachable, dead 409 success-equivalence removed, stale-cache reopen can't false-confirm pro, domain/provisioning target prefers the onboarding primary assistant, stalled recovery controls shared and added to the domain step.