### PR TITLE
fix: one tool-result event type through both bridge hops

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -27,7 +27,10 @@ mock.module("../../daemon/conversation-store.js", () => ({
 import { setConfig } from "../../__tests__/helpers/set-config.js";
 import { ABORT_WATCHDOG_MS } from "../../daemon/abort-watchdog.js";
 import { CALL_OPENING_MARKER } from "../voice-control-protocol.js";
-import { startVoiceTurn } from "../voice-session-bridge.js";
+import {
+  startVoiceTurn,
+  TOOL_RESULT_PREVIEW_MAX_CHARS,
+} from "../voice-session-bridge.js";
 import {
   escalatedContinuationRule,
   ESCALATION_CONTINUATION_CONTENT,
@@ -1064,8 +1067,8 @@ describe("startVoiceTurn tool-event forwarding", () => {
     ]);
   });
 
-  test("tool_result delivers name, id, isError, and a 200-char-truncated preview", async () => {
-    const longResult = "x".repeat(500);
+  test("tool_result delivers name, id, isError, and a preview truncated to the max preview length", async () => {
+    const longResult = "x".repeat(TOOL_RESULT_PREVIEW_MAX_CHARS + 100);
     makeEventEmittingConversation([
       {
         type: "tool_result",
@@ -1085,14 +1088,19 @@ describe("startVoiceTurn tool-event forwarding", () => {
     });
     await flushMicrotasks();
 
+    // The shared `truncate` util caps at the max preview length including
+    // its "..." truncation marker.
+    const truncationMarker = "...";
+    const expectedPreview =
+      "x".repeat(TOOL_RESULT_PREVIEW_MAX_CHARS - truncationMarker.length) +
+      truncationMarker;
+    expect(expectedPreview).toHaveLength(TOOL_RESULT_PREVIEW_MAX_CHARS);
     expect(results).toEqual([
       {
         toolName: "web_search",
         toolUseId: "toolu-1",
         isError: true,
-        // The shared `truncate` util caps at 200 chars including its "..."
-        // truncation marker.
-        resultPreview: `${"x".repeat(197)}...`,
+        resultPreview: expectedPreview,
       },
     ]);
   });

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -157,6 +157,19 @@ export function getConversationTurnTeardown(
 export const TOOL_RESULT_PREVIEW_MAX_CHARS = 200;
 
 /**
+ * A finished tool invocation as forwarded to the voice layer.
+ * `resultPreview` is the result truncated to
+ * {@link TOOL_RESULT_PREVIEW_MAX_CHARS} at the bridge — the raw result can
+ * be huge and must never travel further into the voice layer.
+ */
+export interface VoiceToolResultEvent {
+  toolName: string;
+  toolUseId?: string;
+  isError?: boolean;
+  resultPreview: string;
+}
+
+/**
  * Real-time event sink for voice TTS streaming. Agent-loop events are
  * forwarded here for real-time text-to-speech without modifying the
  * standard channel path.
@@ -177,13 +190,7 @@ export interface VoiceRunEventSink {
     input: Record<string, unknown>,
     toolUseId?: string,
   ): void;
-  /** Optional: sinks that don't consume tool results can omit this. */
-  onToolResult?(
-    toolName: string,
-    toolUseId: string | undefined,
-    isError: boolean | undefined,
-    resultPreview: string,
-  ): void;
+  onToolResult(event: VoiceToolResultEvent): void;
 }
 
 export interface VoiceTurnCallbacks {
@@ -203,18 +210,8 @@ export interface VoiceTurnCallbacks {
     toolName: string,
     detail?: { input: Record<string, unknown>; toolUseId?: string },
   ) => void;
-  /**
-   * Fired when a tool invocation finishes. `resultPreview` is the result
-   * truncated to {@link TOOL_RESULT_PREVIEW_MAX_CHARS} at the bridge — the
-   * raw result can be huge and must never travel further into the voice
-   * layer.
-   */
-  tool_result?: (event: {
-    toolName: string;
-    toolUseId?: string;
-    isError?: boolean;
-    resultPreview: string;
-  }) => void;
+  /** Fired when a tool invocation finishes. */
+  tool_result?: (event: VoiceToolResultEvent) => void;
 }
 
 export interface VoiceTurnOptions {
@@ -457,13 +454,8 @@ export async function startVoiceTurn(
       log.debug({ toolName, input }, "Voice turn tool_use event");
       opts.callbacks?.tool_use_start?.(toolName, { input, toolUseId });
     },
-    onToolResult: (toolName, toolUseId, isError, resultPreview) => {
-      opts.callbacks?.tool_result?.({
-        toolName,
-        toolUseId,
-        isError,
-        resultPreview,
-      });
+    onToolResult: (event) => {
+      opts.callbacks?.tool_result?.(event);
     },
   };
 
@@ -1054,12 +1046,15 @@ export async function startVoiceTurn(
           } else if (msg.type === "tool_use_start") {
             eventSink.onToolUse(msg.toolName, msg.input, msg.toolUseId);
           } else if (msg.type === "tool_result") {
-            eventSink.onToolResult?.(
-              msg.toolName,
-              msg.toolUseId,
-              msg.isError,
-              truncate(msg.result, TOOL_RESULT_PREVIEW_MAX_CHARS),
-            );
+            eventSink.onToolResult({
+              toolName: msg.toolName,
+              toolUseId: msg.toolUseId,
+              isError: msg.isError,
+              resultPreview: truncate(
+                msg.result,
+                TOOL_RESULT_PREVIEW_MAX_CHARS,
+              ),
+            });
           }
           // Note: tool_use_preview_start is intentionally not handled here.
           // Voice only reacts to the definitive tool_use_start event.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for front-model-progress-narration.md.

**Gaps:** onToolResult positional params repackaged into the callback's object shape (now one exported event type through both hops); truncation test hardcoded 197+ellipsis instead of deriving from TOOL_RESULT_PREVIEW_MAX_CHARS