### PR TITLE
fix: progress-narration correctness — toolName, op order, pending-ack guard

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1097,6 +1097,50 @@ describe("startVoiceTurn tool-event forwarding", () => {
     ]);
   });
 
+  test("tool_result forwards prod-shaped local-tool payloads, including one without a toolUseId", async () => {
+    // Local tools emit tool_result with the tool's real name; toolUseId is
+    // optional on the wire, so the name must survive the bridge for the
+    // session's name-fallback correlation.
+    makeEventEmittingConversation([
+      {
+        type: "tool_result",
+        toolName: "bash",
+        result: "total 4",
+        isError: false,
+        toolUseId: "toolu-1",
+      },
+      {
+        type: "tool_result",
+        toolName: "file_read",
+        result: "file contents",
+      },
+    ]);
+
+    const results: unknown[] = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_result: (event) => results.push(event),
+      },
+    });
+    await flushMicrotasks();
+
+    expect(results).toEqual([
+      {
+        toolName: "bash",
+        toolUseId: "toolu-1",
+        isError: false,
+        resultPreview: "total 4",
+      },
+      {
+        toolName: "file_read",
+        toolUseId: undefined,
+        isError: undefined,
+        resultPreview: "file contents",
+      },
+    ]);
+  });
+
   test("a callbacks object without the tool-event members doesn't throw", async () => {
     makeEventEmittingConversation([
       {

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -204,10 +204,14 @@ export interface VoiceTurnCallbacks {
     detail?: { input: Record<string, unknown>; toolUseId?: string },
   ) => void;
   /**
-   * Fired when a tool invocation finishes. `resultPreview` is the result
-   * truncated to {@link TOOL_RESULT_PREVIEW_MAX_CHARS} at the bridge — the
-   * raw result can be huge and must never travel further into the voice
-   * layer.
+   * Fired when a tool invocation finishes. `toolName` is the name of the
+   * tool that produced the result; it is empty only when the daemon loop
+   * never observed a tool_use event for the id (e.g. a tool cancelled before
+   * it was proposed). `toolUseId` is optional on the wire, so consumers
+   * correlate by id when present and fall back to the name. `resultPreview`
+   * is the result truncated to {@link TOOL_RESULT_PREVIEW_MAX_CHARS} at the
+   * bridge — the raw result can be huge and must never travel further into
+   * the voice layer.
    */
   tool_result?: (event: {
     toolName: string;

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -2035,7 +2035,9 @@ export async function handleToolResult(
     state.currentToolUseId = undefined;
     deps.onEvent({
       type: "tool_result",
-      toolName: "",
+      // Resolved from the tool_use correlation map; empty only when the tool
+      // was cancelled before its tool_use event was ever observed.
+      toolName: state.toolUseIdToName.get(event.toolUseId) ?? "",
       result: redactedContent,
       isError: event.isError,
       conversationId: deps.ctx.conversationId,
@@ -2188,7 +2190,8 @@ export async function handleToolResult(
   // card never shows a revealed plaintext the persisted row hides.
   deps.onEvent({
     type: "tool_result",
-    toolName: "",
+    // Empty only when no tool_use event was observed for this id.
+    toolName: toolName ?? "",
     result: redactedContent,
     isError: event.isError,
     diff: event.diff,

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -289,6 +289,77 @@ describe("LiveVoiceSession progress narration", () => {
     emitMessageComplete(getCallbacks);
   });
 
+  test("tool_result without a toolUseId completes the op via the name fallback", async () => {
+    // Prod tool_result events may omit toolUseId (optional on the wire), so
+    // correlation must succeed on the tool name alone.
+    const inputs: VoiceProgressTextInput[] = [];
+    const generateProgressText = mock(async (input: VoiceProgressTextInput) => {
+      inputs.push(input);
+      return GENERATED_NARRATION;
+    });
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ opsThreshold: 3, minGapMs: 10 }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 1);
+
+    // Name-only result: no toolUseId to correlate by.
+    getCallbacks()?.tool_result?.({
+      toolName: "web_search",
+      resultPreview: "found it",
+    });
+    emitToolStart(getCallbacks, "file_read", "tool-2");
+    // Let the ack's minGapMs spacing elapse before the threshold-crossing op.
+    await sleep(30);
+    emitToolStart(getCallbacks, "bash", "tool-3");
+    await waitFor(() => ttsTexts.length === 2);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK, GENERATED_NARRATION]);
+
+    // The name fallback completed the web_search op: it reports as completed
+    // (with its preview) rather than lingering incomplete.
+    expect(inputs[0]?.completedOps).toEqual([
+      { toolName: "web_search", resultPreview: "found it" },
+    ]);
+    expect(inputs[0]?.currentOp?.toolName).toBe("bash");
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("completedOps reach the decider in completion order, not start order", async () => {
+    const inputs: VoiceProgressTextInput[] = [];
+    const generateProgressText = mock(async (input: VoiceProgressTextInput) => {
+      inputs.push(input);
+      return GENERATED_NARRATION;
+    });
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ opsThreshold: 3, minGapMs: 10 }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    // Two parallel tools start in one order…
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 1);
+    emitToolStart(getCallbacks, "file_read", "tool-2");
+    // …and complete in the other. The sleep separates the completion
+    // timestamps (millisecond clock) and lets the ack's minGapMs elapse.
+    emitToolResult(getCallbacks, "file_read", "tool-2", "file contents");
+    await sleep(30);
+    emitToolResult(getCallbacks, "web_search", "tool-1", "found 3 results");
+    emitToolStart(getCallbacks, "bash", "tool-3");
+    await waitFor(() => ttsTexts.length === 2);
+
+    expect(inputs[0]?.completedOps).toEqual([
+      { toolName: "file_read", resultPreview: "file contents" },
+      { toolName: "web_search", resultPreview: "found 3 results" },
+    ]);
+
+    emitMessageComplete(getCallbacks);
+  });
+
   test("idle trigger: dead air narrates with the decider text, audio-only", async () => {
     const inputs: VoiceProgressTextInput[] = [];
     const generateProgressText = mock(async (input: VoiceProgressTextInput) => {
@@ -415,7 +486,7 @@ describe("LiveVoiceSession progress narration", () => {
     emitMessageComplete(getCallbacks);
   });
 
-  test("llmAckText: narration resolving during ack generation bails instead of stacking filler", async () => {
+  test("llmAckText: no narration generation launches while an ack generation is pending", async () => {
     const ackGeneration = deferred<string | null>();
     const generateAckText = mock(() => ackGeneration.promise);
     const generateProgressText = mock(async () => GENERATED_NARRATION);
@@ -434,13 +505,12 @@ describe("LiveVoiceSession progress narration", () => {
 
     await startReleasedTurn(session, getCallbacks);
     // The tool start speaks a generated ack (generation still pending) and
-    // simultaneously crosses the ops threshold; with no floor-holder stamped
-    // yet, the entry guard lets a narration generation start concurrently.
+    // simultaneously crosses the ops threshold; the entry guard must stand
+    // down instead of launching a narration generation whose result the
+    // post-await re-check would only discard.
     emitToolStart(getCallbacks, "web_search", "tool-1");
-    await waitFor(() => generateProgressText.mock.calls.length === 1);
-    // The narration resolves while the ack is still generating: it must bail
-    // rather than enqueue ahead of (and back-to-back with) the ack.
     await sleep(30);
+    expect(generateProgressText).not.toHaveBeenCalled();
     expect(ttsTexts).toEqual([]);
 
     ackGeneration.resolve("Generated ack.");
@@ -451,14 +521,16 @@ describe("LiveVoiceSession progress narration", () => {
     // activity continues.
     emitToolResult(getCallbacks, "web_search", "tool-1");
     await sleep(30);
+    expect(generateProgressText).not.toHaveBeenCalled();
     expect(ttsTexts).toEqual(["Generated ack."]);
 
-    // The bail preserved the update budget: once the gap elapses, the next
-    // ops trigger narrates normally.
+    // The stand-down preserved the update budget: once the gap elapses, the
+    // next ops trigger narrates normally.
     await sleep(150);
     emitToolStart(getCallbacks, "file_read", "tool-2");
     await waitFor(() => ttsTexts.length === 2);
     expect(ttsTexts).toEqual(["Generated ack.", GENERATED_NARRATION]);
+    expect(generateProgressText).toHaveBeenCalledTimes(1);
 
     emitMessageComplete(getCallbacks);
   });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -2810,6 +2810,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       turn.firstDeltaSeen ||
       turn.escalationHandedOff ||
       turn.assistantCompleted ||
+      // A pending ack generation is a floor-holder-in-waiting: starting a
+      // narration generation now would only be discarded by the post-await
+      // re-check once the ack enqueues — a guaranteed wasted provider call.
+      turn.ackGenerationPending ||
       progress.narrationInFlight ||
       progress.updatesSpoken >= cfg.maxPerTurn ||
       (progress.lastFloorHolderAtMs !== null &&
@@ -2843,7 +2847,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           .join(" ")
           .trim(),
         completedOps: progress.ops
-          .filter((op) => op.completedAtMs !== undefined)
+          .filter(
+            (op): op is TurnProgressOp & { completedAtMs: number } =>
+              op.completedAtMs !== undefined,
+          )
+          // `ops` is in start order; the decider contract wants completion
+          // order, which differs when parallel tools finish out of order.
+          .sort((a, b) => a.completedAtMs - b.completedAtMs)
           .map((op) => ({
             toolName: op.toolName,
             ...(op.isError !== undefined ? { isError: op.isError } : {}),
@@ -2868,13 +2878,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // have been cancelled or finalized, the brain's first delta may have
       // arrived, an escalation hand-off may have enqueued its bridge phrase,
       // or the turn may have completed outright — in every such case the
-      // narration is moot and must not speak over real output. The floor
-      // re-check covers a generated ack (llmAckText) that raced this
-      // generation: while the ack is pending it has not yet stamped
-      // `lastFloorHolderAtMs` (so the entry guard could not see it), and once
-      // it enqueues the minGapMs spacing must be re-applied from that stamp —
-      // either way, enqueueing now would stack back-to-back filler. A bail
-      // here is silent and keeps the update budget, exactly like the
+      // narration is moot and must not speak over real output. The
+      // ack-generation and floor re-checks close the race with a generated
+      // ack (llmAckText) that STARTED after this generation did — the entry
+      // guard rejects a narration while an ack generation is already
+      // pending, but cannot see one that begins mid-generation: while that
+      // ack is pending it has not yet stamped `lastFloorHolderAtMs`, and
+      // once it enqueues the minGapMs spacing must be re-applied from that
+      // stamp — either way, enqueueing now would stack back-to-back filler.
+      // A bail here is silent and keeps the update budget, exactly like the
       // stale-turn bail.
       if (
         !this.isActiveAssistantTurn(token) ||


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for front-model-progress-narration.md.

**Gaps:** prod tool_result events carried empty toolName (name-fallback dead + untested); completedOps start-order vs documented completion-order; wasted narration LLM call while ack generation pending