### PR TITLE
feat(memory-v3): record selector_kept_all and net_new_count per turn

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -1515,6 +1515,85 @@ describe("orchestrate — injection gate", () => {
     ).toBeGreaterThan(0);
   });
 
+  test("the recall-safe fallback (omitted ids) records selector_kept_all: true", async () => {
+    const lanes = await buildLanes();
+    // The model omitting `ids` keeps the whole pool — indistinguishable from an
+    // explicit large selection by `selected_count` alone. This is the flag that
+    // separates "gave up judging" from "judged everything relevant".
+    denseHits = [{ article: "topic-b", section: 0, score: 0.9 }];
+    providerStub = {
+      name: "stub",
+      sendMessage: async () => toolUseResponse({}), // omitted ids → keep all
+    };
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        coreSlugs: ["topic-c"],
+        denseK: 100,
+        gateConfig: gateConfigOf(),
+      }),
+    );
+
+    expect(recordedSelectionEvents).toHaveLength(1);
+    expect(recordedSelectionEvents[0]!.detail).toMatchObject({
+      selector_ran: true,
+      selector_kept_all: true,
+    });
+  });
+
+  test("an explicit selection records selector_kept_all: false", async () => {
+    const lanes = await buildLanes();
+    denseHits = [{ article: "topic-b", section: 0, score: 0.9 }];
+    providerStub = selectProvider(["topic-a"]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { denseK: 100, gateConfig: gateConfigOf() }),
+    );
+
+    expect(recordedSelectionEvents[0]!.detail).toMatchObject({
+      selector_kept_all: false,
+    });
+  });
+
+  test("net_new_count counts only selections not already live in the conversation", async () => {
+    const lanes = await buildLanes();
+    denseHits = [{ article: "topic-b", section: 0, score: 0.9 }];
+    // Selector picks topic-a and topic-b; topic-a is already resident, so only
+    // topic-b is a net-new injection this turn.
+    providerStub = selectProvider(["topic-a", "topic-b"]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        denseK: 100,
+        activeSlugs: new Set<Slug>(["topic-a"]),
+        gateConfig: gateConfigOf(),
+      }),
+    );
+
+    expect(recordedSelectionEvents[0]!.detail).toMatchObject({
+      selected_count: 2,
+      net_new_count: 1,
+    });
+  });
+
+  test("net_new_count is omitted when activeSlugs is not threaded", async () => {
+    const lanes = await buildLanes();
+    denseHits = [{ article: "topic-b", section: 0, score: 0.9 }];
+    providerStub = selectProvider(["topic-a"]);
+
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { denseK: 100, gateConfig: gateConfigOf() }),
+    );
+
+    expect(recordedSelectionEvents[0]!.detail).not.toHaveProperty(
+      "net_new_count",
+    );
+  });
+
   test("an empty pool is not a selector judgment", async () => {
     const lanes = await buildLanes();
     // `selectPool` returns [] before it ever reaches the provider when the pool

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
@@ -219,10 +219,11 @@ describe("selectPool — id mapping", () => {
       toolUseResponse({ ids: [3, 1], pinned_ids: [1] }),
     );
     const result = await selectPool(makePool(), makeTurn("how's the rollout?"));
-    expect(result).toEqual([
+    expect(result.pages).toEqual([
       { slug: "topic-x", pinned: false },
       { slug: "page-a", pinned: true },
     ]);
+    expect(result.keptAll).toBe(false);
   });
 
   test("a page selected as both card and finder line dedupes to one slug, pinned ORed", async () => {
@@ -232,35 +233,42 @@ describe("selectPool — id mapping", () => {
       toolUseResponse({ ids: [1, 4], pinned_ids: [4] }),
     );
     const result = await selectPool(makePool(), makeTurn("the alpha plan"));
-    expect(result).toEqual([{ slug: "page-a", pinned: true }]);
+    expect(result.pages).toEqual([{ slug: "page-a", pinned: true }]);
+    expect(result.keptAll).toBe(false);
   });
 
-  test("omitted ids keeps ALL candidates, deduped by slug (recall-safe)", async () => {
+  test("omitted ids keeps ALL candidates, deduped by slug (recall-safe), flags keptAll", async () => {
     providerStub = makeProvider(toolUseResponse({}));
     const result = await selectPool(makePool(), makeTurn("anything"));
-    expect(result).toEqual([
+    expect(result.pages).toEqual([
       { slug: "page-a", pinned: false },
       { slug: "page-b", pinned: false },
       { slug: "topic-x", pinned: false },
     ]);
+    // The fallback fired — the model gave up judging, not "selected everything".
+    expect(result.keptAll).toBe(true);
   });
 
-  test("explicit empty ids keeps no candidates (abstention)", async () => {
+  test("explicit empty ids keeps no candidates (abstention), not keptAll", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [] }));
     const result = await selectPool(makePool(), makeTurn("nothing relevant"));
-    expect(result).toEqual([]);
+    expect(result.pages).toEqual([]);
+    // An explicit [] is a judgment, not the recall-safe fallback.
+    expect(result.keptAll).toBe(false);
   });
 
   test("out-of-range and duplicate IDs are ignored without throwing", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [2, 99, 0, -1, 2] }));
     const result = await selectPool(makePool(), makeTurn("the metrics"));
-    expect(result).toEqual([{ slug: "page-b", pinned: false }]);
+    expect(result.pages).toEqual([{ slug: "page-b", pinned: false }]);
+    expect(result.keptAll).toBe(false);
   });
 
   test("empty pool returns no pages and never calls the provider", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [1] }));
     const result = await selectPool({ stable: [], finder: [] }, makeTurn("hi"));
-    expect(result).toEqual([]);
+    expect(result.pages).toEqual([]);
+    expect(result.keptAll).toBe(false);
     expect(providerCalls).toHaveLength(0);
   });
 });
@@ -447,7 +455,8 @@ describe("selectPool — infrastructure failures throw", () => {
       toolUseResponse({ ids: [2] }),
     ]);
     const result = await selectPool(makePool(), makeTurn("the metrics"));
-    expect(result).toEqual([{ slug: "page-b", pinned: false }]);
+    expect(result.pages).toEqual([{ slug: "page-b", pinned: false }]);
+    expect(result.keptAll).toBe(false);
     expect(providerCalls).toHaveLength(2);
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -230,6 +230,13 @@ export interface OrchestrateDeps {
    *  `MEMORY_V3_FULL_PROFILE_MIN_PAGES`; omitted drops the field from the
    *  telemetry detail (the gate itself never reads it). */
   realConceptPageCount?: number;
+  /** Slugs already live in this conversation (prior turns' injected cards). Used
+   *  ONLY to compute the `net_new_count` telemetry field — selections minus this
+   *  set are what the injector actually renders. Read-only and side-effect-free:
+   *  selection never consults it, and omitting it just drops the field. The
+   *  injector reads the same store, so the two agree for a turn that has not yet
+   *  committed. */
+  activeSlugs?: ReadonlySet<Slug>;
 }
 
 /** A finder-lane candidate: the slug, the descriptor that justified it, and
@@ -325,13 +332,24 @@ export async function orchestrate(
   // Run the selector over a pool, or pass its candidates straight through when
   // the selector LLM is disabled (`selectorEnabled: false`, the new-user
   // profile). Shared by the normal step-3 selection and the gate's
-  // bypass-to-stable path so the two cannot diverge.
-  const runSelection = async (pool: SelectorPool): Promise<SelectedPage[]> =>
-    timeLatencySubSpan("v3_selection", "Memory selection", () =>
-      deps.selectorEnabled === false
-        ? selectAllPoolCandidates(pool)
-        : selectPool(pool, turn, deps.selectorPrompt),
-    );
+  // bypass-to-stable path so the two cannot diverge. `keptAll` marks the
+  // selector's recall-safe fallback ONLY — the disabled passthrough is not a
+  // selector judgment, so it reports `false` (its turns are excluded from any
+  // relevance read by `selector_ran` anyway).
+  const runSelection = (
+    pool: SelectorPool,
+  ): Promise<{ selections: SelectedPage[]; keptAll: boolean }> =>
+    timeLatencySubSpan("v3_selection", "Memory selection", async () => {
+      if (deps.selectorEnabled === false) {
+        return { selections: selectAllPoolCandidates(pool), keptAll: false };
+      }
+      const { pages, keptAll } = await selectPool(
+        pool,
+        turn,
+        deps.selectorPrompt,
+      );
+      return { selections: pages, keptAll };
+    });
 
   // Step 1: needle (sync BM25) and the enabled dense lane (async embed +
   // Qdrant) run in parallel. Both return distinct articles each tagged with
@@ -545,17 +563,35 @@ export async function orchestrate(
   // The last is why `poolSize` decides this rather than each call site: an empty
   // pool is not a judgment that nothing was relevant, and no caller has to
   // remember that.
+  // `selector_kept_all` and `net_new_count` separate what the selector JUDGED
+  // from what actually reaches the turn, which `selected_count` alone conflates:
+  //   - kept_all: the recall-safe fallback fired (model omitted `ids`), so every
+  //     candidate was kept without a real judgment. Distinguishes "kept the whole
+  //     pool because it gave up" from "explicitly selected a large set", which
+  //     otherwise look identical and inflate the same way.
+  //   - net_new: selections not already live in the conversation — the injector
+  //     renders only these (prior turns' cards ride history), so it is the real
+  //     incremental injection, where `selected_count` re-counts the whole
+  //     standing set every turn. Omitted when the caller did not supply
+  //     `activeSlugs` (tests, shadow-less paths).
   const recordSelection = (
     selections: SelectedPage[],
     poolSize: number,
+    keptAll: boolean,
   ): void => {
     const detail: Record<string, unknown> = {
       gate_reason: gateOutcome?.reason ?? null,
       gate_pass: gateOutcome?.pass ?? null,
       selector_ran: deps.selectorEnabled !== false && poolSize > 0,
+      selector_kept_all: keptAll,
       selected_count: selections.length,
       pool_size: poolSize,
     };
+    if (deps.activeSlugs !== undefined) {
+      detail.net_new_count = selections.filter(
+        (s) => !deps.activeSlugs!.has(s.slug),
+      ).length;
+    }
     if (deps.realConceptPageCount !== undefined) {
       detail.real_concept_page_count = deps.realConceptPageCount;
     }
@@ -633,17 +669,17 @@ export async function orchestrate(
             // `denseK > 0` (the dense-gated gate only runs with dense hits; the
             // new-user profile sets `denseK: 0`, so the gate never runs for it).
             const stableOnly = buildStable();
-            const bypassed = await runSelection({
+            const { selections: bypassed, keptAll } = await runSelection({
               stable: stableOnly,
               finder: [],
             });
-            recordSelection(bypassed, stableOnly.length);
+            recordSelection(bypassed, stableOnly.length, keptAll);
             return closed(bypassed);
           }
           // Hard skip: the selector is never consulted, so this is a zero
           // selection BY CONSTRUCTION, not a judgment that nothing was relevant.
           // `selector_ran: false` keeps it out of any relevance rate.
-          recordSelection([], 0);
+          recordSelection([], 0, false);
           return closed([]);
         }
       }
@@ -741,8 +777,8 @@ export async function orchestrate(
     "Gate & edge expansion",
     Date.now() - expandStartedAt,
   );
-  const selections = await runSelection(pool);
-  recordSelection(selections, stable.length + finderTail.length);
+  const { selections, keptAll } = await runSelection(pool);
+  recordSelection(selections, stable.length + finderTail.length, keptAll);
 
   return {
     selections,

--- a/assistant/src/plugins/defaults/memory/v3/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/pool-select.test.ts
@@ -124,22 +124,27 @@ describe("selectPool", () => {
           input: { ids: [1] },
         },
       ]);
-    expect(await selectPool(pool, turn)).toEqual([
-      { slug: "page-a", pinned: false },
-    ]);
+    expect(await selectPool(pool, turn)).toEqual({
+      pages: [{ slug: "page-a", pinned: false }],
+      keptAll: false,
+    });
   });
 
-  test("omitted ids keep all candidates (recall-safe)", async () => {
+  test("omitted ids keep all candidates (recall-safe) and flag keptAll", async () => {
     sendMessageImpl = async () =>
       response([
         { type: "tool_use", id: "call-1", name: "select_pages", input: {} },
       ]);
-    expect(await selectPool(pool, turn)).toEqual([
-      { slug: "page-a", pinned: false },
-    ]);
+    expect(await selectPool(pool, turn)).toEqual({
+      pages: [{ slug: "page-a", pinned: false }],
+      keptAll: true,
+    });
   });
 
   test("an empty candidate pool returns no selections", async () => {
-    expect(await selectPool({ stable: [], finder: [] }, turn)).toEqual([]);
+    expect(await selectPool({ stable: [], finder: [] }, turn)).toEqual({
+      pages: [],
+      keptAll: false,
+    });
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory/v3/pool-select.ts
@@ -363,15 +363,26 @@ export function selectAllPoolCandidates(pool: SelectorPool): SelectedPage[] {
   return dedupeBySlug(ordered.map((slug) => ({ slug, pinned: false })));
 }
 
+/** A selection plus whether it came from the recall-safe keep-all fallback. */
+export interface PoolSelection {
+  pages: SelectedPage[];
+  /** True only when the model OMITTED `ids` and every candidate was kept as the
+   *  recall-safe fallback — NOT when it explicitly selected a large set. The two
+   *  produce the same pages but mean different things (the model gave up judging
+   *  vs it judged everything relevant), and only telemetry can tell them apart. */
+  keptAll: boolean;
+}
+
 /**
  * Run the single forced-tool selector over the unified candidate pool. Returns
  * the pages to inject, deduped by slug (a page that appeared as both a card
- * and a finder line yields one entry, pinned flags ORed).
+ * and a finder line yields one entry, pinned flags ORed), plus a `keptAll` flag
+ * marking the recall-safe fallback.
  *
  * An omitted `ids` keeps ALL candidates (the recall-safe "all of these are
- * relevant" signal); an explicit `[]` keeps none; an infrastructure failure
- * (after a short re-prompt retry) keeps none, degrading to the deterministic
- * recall lanes the orchestrator unions in.
+ * relevant" signal, `keptAll: true`); an explicit `[]` keeps none; an
+ * infrastructure failure (after a short re-prompt retry) keeps none, degrading
+ * to the deterministic recall lanes the orchestrator unions in.
  *
  * `systemPrompt` is the selector's instruction scaffold; it defaults to the
  * bundled {@link SYSTEM_PROMPT} and is overridable via `memory.v3.selectorPromptPath`
@@ -381,14 +392,14 @@ export async function selectPool(
   pool: SelectorPool,
   turn: MemoryRoutingTurn,
   systemPrompt: string = SYSTEM_PROMPT,
-): Promise<SelectedPage[]> {
+): Promise<PoolSelection> {
   // The concatenated numbering: ids 1…m are the stable-prefix cards, ids
   // m+1… are the finder lines.
   const ordered: Slug[] = [
     ...pool.stable.map((c) => c.slug),
     ...pool.finder.map((c) => c.slug),
   ];
-  if (ordered.length === 0) return [];
+  if (ordered.length === 0) return { pages: [], keptAll: false };
 
   const keepAll = (): SelectedPage[] => selectAllPoolCandidates(pool);
 
@@ -570,7 +581,7 @@ export async function selectPool(
   }
 
   // Omitted `ids` is the recall-safe "keep all candidates" signal.
-  if (parsed.ids === undefined) return keepAll();
+  if (parsed.ids === undefined) return { pages: keepAll(), keptAll: true };
 
   const pinned = new Set(parsed.pinned_ids ?? []);
 
@@ -581,5 +592,5 @@ export async function selectPool(
     if (id < 1 || id > ordered.length) continue;
     selected.push({ slug: ordered[id - 1]!, pinned: pinned.has(id) });
   }
-  return dedupeBySlug(selected);
+  return { pages: dedupeBySlug(selected), keptAll: false };
 }

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -47,6 +47,7 @@ import type { EdgeGraph } from "./edge.js";
 import { buildEdgeGraph } from "./edge.js";
 import type { EntityIndex } from "./entity-lane.js";
 import { buildEntityIndex } from "./entity-lane.js";
+import { getActiveSlugs } from "./ever-injected-store.js";
 import { computeFreshSet } from "./fresh-set.js";
 import { isMemoryV3InjectionGateEnabled } from "./gate-flag.js";
 import { computeHotSet } from "./hot-set.js";
@@ -661,6 +662,10 @@ export async function observeTurn(
       needleK: tuning.needleK,
       denseK: tuning.denseK,
       realConceptPageCount: lanes.realConceptPageCount,
+      // Read-only: lets orchestrate compute the `net_new_count` telemetry field
+      // against the same store the injector renders from. This turn has not
+      // committed yet, so the set matches what the injector will see.
+      activeSlugs: getActiveSlugs(conversationId),
       entityCap: v3.entity.cap,
       replyQueryK: tuning.replyQueryK,
       edgeSeeds: tuning.edgeSeedCount,


### PR DESCRIPTION
Follow-up to #38345. Answers "why is Avg Pages Selected so high" (43 for `dense_pass`, 192 for `sparse_only_strong`) by splitting the one number that conflates three different things.

## The problem

`selected_count` can't distinguish:
1. The selector explicitly picking a large set.
2. The **recall-safe fallback** firing — the model omits `ids` and `selectPool` keeps the *entire* pool (`pool-select.ts:573`). Same pages, but the model gave up judging rather than judging everything relevant.
3. **Re-selection of resident pages** — the prompt explicitly tells the selector to re-select pages already in context ("harmless"), and the injector only renders *net-new* selections (`injector.ts:289`). So on turn 10, `selected_count` re-counts the whole standing set; the actual incremental injection is a handful.

So "Avg Pages 56" is undiagnosable. These two fields fix that.

## `selector_kept_all`

True only when the recall-safe fallback fired. `selectPool` now returns `{ pages, keptAll }`; the disabled-selector passthrough reports `false` (its turns are already excluded by `selector_ran`). This is the difference between "the model kept everything because it gave up" and "the model judged everything relevant" — behaviorally identical, diagnostically opposite.

## `net_new_count`

Selections minus slugs already live in the conversation — what the injector actually renders. Computed from a new **read-only** `activeSlugs` dep that `observeTurn` threads from the same `ever-injected-store` the injector reads, so the two agree for a not-yet-committed turn. Selection logic never consults it; omitting it (tests, shadow-less paths) just drops the field.

A large `selected_count` next to a small `net_new_count` is the benign case — the selector re-affirming standing memory, not injecting 43 new pages a turn.

## Neither changes behavior

Pure instrumentation. `checkV3Gate` and the selection logic are untouched.

## Testing

`orchestrate.test.ts` 64 pass (4 new: kept-all true/false, net-new counted, net-new omitted). Both `pool-select.test.ts` suites updated for the new return shape, with keptAll assertions on the omitted-ids/explicit paths. `shadow-plugin` 30, `shadow-integration` 7, `tsc` clean.

Dashboard: vellum-ai/vellum-assistant-platform#9312 surfaces both as Avg New + Kept-All.

🤖 Generated with [Claude Code](https://claude.com/claude-code)