### PR TITLE
feat(memory-graph): named theme legend + drop node tooltip + zoom-out on close

### DIFF
--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-legend.tsx
@@ -8,12 +8,18 @@ import {
 } from "./constants";
 import type { ConceptNodeKind } from "./types";
 
+/** Cap the theme list so a big graph's legend stays compact. */
+const MAX_THEMES = 8;
+
 interface ConceptGraphLegendProps {
   /** Node kinds actually present in the graph, in display order. */
   nodeKinds: ConceptNodeKind[];
   /** When true (concept-only graph), nodes are colored by cluster/theme, so a
-   * lone kind swatch would be meaningless — show a caption instead. */
+   * lone kind swatch would be meaningless — show the theme list instead. */
   coloredByTheme?: boolean;
+  /** Named themes (hub concept + cluster color), largest first. When present
+   * with `coloredByTheme`, the legend lists them so color maps to a theme. */
+  themes?: readonly { color: string; name: string }[];
   hasLinks: boolean;
   hasLearned: boolean;
   /** When provided (both edge kinds present), the Link / Learned rows become
@@ -29,6 +35,7 @@ interface ConceptGraphLegendProps {
 export function ConceptGraphLegend({
   nodeKinds,
   coloredByTheme,
+  themes,
   hasLinks,
   hasLearned,
   onToggleLink,
@@ -59,11 +66,41 @@ export function ConceptGraphLegend({
           </span>
         </div>
       ))}
-      {coloredByTheme && (
-        <span className="text-[11px]" style={{ color: "var(--content-tertiary)" }}>
-          Colored by theme
-        </span>
-      )}
+      {coloredByTheme &&
+        (themes && themes.length > 0 ? (
+          <>
+            {themes.slice(0, MAX_THEMES).map((theme, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <span
+                  className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: theme.color }}
+                />
+                <span
+                  className="max-w-[9rem] truncate text-[11px]"
+                  style={{ color: "var(--content-tertiary)" }}
+                  title={theme.name}
+                >
+                  {theme.name}
+                </span>
+              </div>
+            ))}
+            {themes.length > MAX_THEMES && (
+              <span
+                className="text-[11px]"
+                style={{ color: "var(--content-tertiary)" }}
+              >
+                +{themes.length - MAX_THEMES} more
+              </span>
+            )}
+          </>
+        ) : (
+          <span
+            className="text-[11px]"
+            style={{ color: "var(--content-tertiary)" }}
+          >
+            Colored by theme
+          </span>
+        ))}
       {(nodeKinds.length > 0 || coloredByTheme) && (hasLinks || hasLearned) && (
         <div
           className="mt-0.5 border-t pt-1.5"

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -283,6 +283,9 @@ export function ConceptGraphView({
   // Set by search jump-to. While non-null the render loop eases the camera each
   // frame to center this concept, then clears it once the view has settled.
   const focusTargetRef = useRef<string | null>(null);
+  // Set on dismiss so the 60fps loop eases the camera back out to the overview
+  // framing (zoom + pitch), then clears itself once settled.
+  const resetViewRef = useRef(false);
 
   // Bumped only when the focused node changes, so the DOM tooltip re-renders.
   // The canvas itself never needs React state.
@@ -414,16 +417,6 @@ export function ConceptGraphView({
     searchEmittedRef.current = false;
   }, [assistantId]);
 
-  const labelFor = useCallback(
-    (id: string | null): string | null => {
-      if (!id) {return null;}
-      const node = layout.nodes.find((n) => n.id === id);
-      if (!node) {return null;}
-      return node.summary ? `${node.label} — ${node.summary}` : node.label;
-    },
-    [layout.nodes],
-  );
-
   const resetView = useCallback(() => {
     const v = view.current;
     v.yaw = 0.5;
@@ -469,6 +462,10 @@ export function ConceptGraphView({
     setTrail([]);
     setSearch("");
     setFocusLabel(null);
+    // Zoom back out to the overview after closing the drawer: clear any focus
+    // target (so it doesn't fight the ease) and let the loop ease zoom/pitch home.
+    focusTargetRef.current = null;
+    resetViewRef.current = true;
   }, []);
 
   // Jump to a breadcrumb (the ‹ back control and crumb clicks): truncate the
@@ -632,6 +629,19 @@ export function ConceptGraphView({
           ) {
             focusTargetRef.current = null;
           }
+        }
+      }
+
+      // After the drawer is dismissed, ease the camera back out to the overview
+      // framing (default zoom + pitch); yaw keeps its idle drift. Skipped while
+      // dragging so a manual orbit isn't fought; clears itself once settled.
+      if (resetViewRef.current && !v.dragging) {
+        const k = reduceMotion ? 1 : 0.15;
+        v.pitch += (0.32 - v.pitch) * k;
+        v.zoom += (1 - v.zoom) * k;
+        v.dirty = true;
+        if (Math.abs(0.32 - v.pitch) < 0.01 && Math.abs(1 - v.zoom) < 0.02) {
+          resetViewRef.current = false;
         }
       }
 
@@ -1029,7 +1039,6 @@ export function ConceptGraphView({
       if (hit !== v.hoveredId) {
         v.hoveredId = hit;
         v.dirty = true;
-        setFocusLabel(labelFor(hit));
       }
       // Node hover wins: only probe edges when no node is under the cursor.
       if (hit) {
@@ -1039,7 +1048,7 @@ export function ConceptGraphView({
         setEdgeLabel(edge ? labelForEdge(edge) : null);
       }
     },
-    [hitTest, labelFor, edgeHitTest],
+    [hitTest, edgeHitTest],
   );
 
   const onPointerUp = useCallback(

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -202,13 +202,15 @@ export function ConceptGraphView({
   // force-labels these ids so a theme always reads with at least one word.
   // Disconnected nodes (degree 0) each form their own singleton cluster; they're
   // not themes, so skipping them keeps orphans from turning into label soup.
-  const clusterHubs = useMemo(() => {
+  const themes = useMemo(() => {
     const bestByCluster = new Map<number, GraphLayoutNode>();
+    const sizeByCluster = new Map<number, number>();
     for (const node of layout.nodes) {
       const cluster = clusters.get(node.id);
       if (cluster == null || node.degree === 0) {
         continue;
       }
+      sizeByCluster.set(cluster, (sizeByCluster.get(cluster) ?? 0) + 1);
       const current = bestByCluster.get(cluster);
       if (
         !current ||
@@ -218,12 +220,23 @@ export function ConceptGraphView({
         bestByCluster.set(cluster, node);
       }
     }
-    const hubIds = new Set<string>();
-    for (const node of bestByCluster.values()) {
-      hubIds.add(node.id);
-    }
-    return hubIds;
+    // Largest themes first; each named by its hub concept and colored to match
+    // the cluster palette, so the legend can map color → theme.
+    return [...bestByCluster.entries()]
+      .map(([cluster, hub]) => ({
+        hubId: hub.id,
+        color: CLUSTER_PALETTE[cluster % CLUSTER_PALETTE.length],
+        name: hub.label,
+        size: sizeByCluster.get(cluster) ?? 0,
+      }))
+      .sort((a, b) => b.size - a.size);
   }, [clusters, layout.nodes]);
+
+  // Hub node ids the render loop force-labels (one per theme).
+  const clusterHubs = useMemo(
+    () => new Set(themes.map((t) => t.hubId)),
+    [themes],
+  );
 
   // Neighbor adjacency for hover highlighting.
   const adjacency = useMemo(() => {
@@ -1316,6 +1329,7 @@ export function ConceptGraphView({
         <ConceptGraphLegend
           nodeKinds={presentKinds.filter((k) => k !== "concept")}
           coloredByTheme={presentKinds.includes("concept")}
+          themes={themes}
           hasLinks={hasLinks}
           hasLearned={hasLearned}
           {...(hasLinks && hasLearned


### PR DESCRIPTION
Three memory-graph UI tweaks (behind the memory-concept-graph flag):

- **Named theme legend** — the legend said 'Colored by theme' with no color→theme mapping. Now lists each theme (color swatch + its **hub concept** name, largest first, capped at 8 with '+N more'), so you can tell which color is which. Zero-cost (reuses the cluster hubs we already compute).
- **Remove the hovered-node text tooltip** — the long `label — summary` pill that bled across the top on node hover (kept the edge-hover pill).
- **Zoom back out on close** — dismissing the drawer (X / Esc / backdrop) now eases the camera back to the overview framing instead of staying zoomed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)