### PR TITLE
Increase voice room close button hit area

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -343,7 +343,7 @@ function VoiceRoomOverlay() {
             type="button"
             onClick={endLiveVoiceSession}
             aria-label="Exit voice session"
-            className={ROOM_CONTROL_CLASS}
+            className={cn(ROOM_CONTROL_CLASS, "size-12")}
           >
             <X className="size-5" />
           </button>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -112,7 +112,7 @@ const SAFE_AREA_RIGHT =
  * tone-derived over an avatar color).
  */
 const ROOM_CONTROL_CLASS =
-  "flex size-10 items-center justify-center rounded-full text-[var(--room-fg-muted)] transition hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--room-fg-muted)]";
+  "flex size-12 items-center justify-center rounded-full text-[var(--room-fg-muted)] transition hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--room-fg-muted)]";
 
 /** Bottom-row circular session controls (mute / ■ stop), same toning. */
 const SESSION_CONTROL_CLASS =
@@ -343,7 +343,7 @@ function VoiceRoomOverlay() {
             type="button"
             onClick={endLiveVoiceSession}
             aria-label="Exit voice session"
-            className={cn(ROOM_CONTROL_CLASS, "size-12")}
+            className={ROOM_CONTROL_CLASS}
           >
             <X className="size-5" />
           </button>


### PR DESCRIPTION
## Summary
- Increase the shared voice room top-control hit area from 40×40 px to 48×48 px.
- Keep the visible settings and close icons unchanged while giving the adjacent controls consistent, easier-to-tap targets.

## Original prompt
The user asked to make the click target for the voice room close button larger. They also requested that the change be isolated in a new clean worktree created from the latest main branch, then suggested applying the size at the shared room-control class for consistency.