### PR TITLE
fix: narrow tool_use_start detail + daemon-level toolName emission tests

### DIFF
--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -6,6 +6,7 @@
  * - handleToolUsePreviewStart emits activity state with "tool_running" phase
  * - handleInputJsonDelta includes toolUseId in emitted tool_input_delta
  * - handleToolResult includes toolUseId in emitted tool_result
+ * - handleToolResult resolves toolName from the tool_use correlation map
  * - Event ordering: tool_use_preview_start → input_json_delta → tool_use
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -795,6 +796,110 @@ describe("tool preview lifecycle", () => {
       expect(state.pendingToolResults.size).toBe(0);
       expect(state.pendingToolResultRowReservation).toBeUndefined();
       expect(state.persistedToolUseIds.has("toolu_a")).toBe(true);
+    });
+  });
+
+  describe("tool_result toolName resolution", () => {
+    /** Deps wired to a fresh collector. */
+    function makeCollectingDeps(): {
+      deps: EventHandlerDeps;
+      events: ServerMessage[];
+    } {
+      const collector = createEventCollector();
+      const deps = createMockDeps({
+        onEvent: collector.onEvent,
+        ctx: {
+          ...createMockDeps().ctx,
+          emitActivityState: collector.emitActivityState,
+        } as unknown as EventHandlerDeps["ctx"],
+      });
+      return { deps, events: collector.events };
+    }
+
+    function emittedToolResult(
+      events: ServerMessage[],
+    ): Record<string, unknown> {
+      const toolResult = events.find((e) => e.type === "tool_result");
+      expect(toolResult).toBeDefined();
+      return toolResult as unknown as Record<string, unknown>;
+    }
+
+    test("a result following its tool_use carries the resolved tool name", async () => {
+      // GIVEN a tool whose tool_use event was observed
+      const { deps, events } = makeCollectingDeps();
+      handleToolUse(state, deps, {
+        type: "tool_use",
+        id: "toolu_named",
+        name: "web_search",
+        input: { query: "weather" },
+      });
+
+      // WHEN its result arrives
+      await handleToolResult(state, deps, {
+        type: "tool_result",
+        toolUseId: "toolu_named",
+        content: "sunny",
+        isError: false,
+      });
+
+      // THEN the emitted event carries the name from the correlation map
+      expect(emittedToolResult(events).toolName).toBe("web_search");
+    });
+
+    test("a result for a never-observed toolUseId carries an empty toolName", async () => {
+      // GIVEN no tool_use event was ever observed for the id
+      const { deps, events } = makeCollectingDeps();
+
+      // WHEN a result arrives anyway
+      await handleToolResult(state, deps, {
+        type: "tool_result",
+        toolUseId: "toolu_unobserved",
+        content: "orphan",
+        isError: false,
+      });
+
+      // THEN the emitted event falls back to the empty name
+      expect(emittedToolResult(events).toolName).toBe("");
+    });
+
+    test("a cancelled synthesis resolves the name when its tool_use was observed", async () => {
+      // GIVEN a tool whose tool_use event was observed
+      const { deps, events } = makeCollectingDeps();
+      handleToolUse(state, deps, {
+        type: "tool_use",
+        id: "toolu_cancelled",
+        name: "bash",
+        input: { command: "sleep 60" },
+      });
+
+      // WHEN a synthesized cancellation result arrives (the tool never ran)
+      await handleToolResult(state, deps, {
+        type: "tool_result",
+        toolUseId: "toolu_cancelled",
+        content: "cancelled by user",
+        isError: true,
+        cancelled: true,
+      });
+
+      // THEN the cancellation-path emit still resolves the real name
+      expect(emittedToolResult(events).toolName).toBe("bash");
+    });
+
+    test("a cancelled synthesis for a never-observed toolUseId carries an empty toolName", async () => {
+      // GIVEN no tool_use event was ever observed for the id
+      const { deps, events } = makeCollectingDeps();
+
+      // WHEN a synthesized cancellation result arrives
+      await handleToolResult(state, deps, {
+        type: "tool_result",
+        toolUseId: "toolu_cancelled_unobserved",
+        content: "cancelled by user",
+        isError: true,
+        cancelled: true,
+      });
+
+      // THEN the emitted event falls back to the empty name
+      expect(emittedToolResult(events).toolName).toBe("");
     });
   });
 

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1040,7 +1040,7 @@ describe("startVoiceTurn tool-event forwarding", () => {
     fakeConversation = fake.conversation;
   }
 
-  test("tool_use_start delivers the tool name with input and toolUseId", async () => {
+  test("tool_use_start delivers the tool name and toolUseId", async () => {
     makeEventEmittingConversation([
       {
         type: "tool_use_start",
@@ -1060,10 +1060,7 @@ describe("startVoiceTurn tool-event forwarding", () => {
     await flushMicrotasks();
 
     expect(starts).toEqual([
-      {
-        toolName: "web_search",
-        detail: { input: { query: "weather" }, toolUseId: "toolu-1" },
-      },
+      { toolName: "web_search", detail: { toolUseId: "toolu-1" } },
     ]);
   });
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -210,10 +210,7 @@ export interface VoiceTurnCallbacks {
   persisted_user_message_id?: (messageId: string) => void;
   persisted_assistant_message_id?: (messageId: string) => void;
   /** Fired when the agent run starts a definitive tool use this turn. */
-  tool_use_start?: (
-    toolName: string,
-    detail?: { input: Record<string, unknown>; toolUseId?: string },
-  ) => void;
+  tool_use_start?: (toolName: string, detail?: { toolUseId?: string }) => void;
   /** Fired when a tool invocation finishes. */
   tool_result?: (event: VoiceToolResultEvent) => void;
 }
@@ -456,7 +453,7 @@ export async function startVoiceTurn(
     },
     onToolUse: (toolName, input, toolUseId) => {
       log.debug({ toolName, input }, "Voice turn tool_use event");
-      opts.callbacks?.tool_use_start?.(toolName, { input, toolUseId });
+      opts.callbacks?.tool_use_start?.(toolName, { toolUseId });
     },
     onToolResult: (event) => {
       opts.callbacks?.tool_result?.(event);

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -202,7 +202,7 @@ function emitToolStart(
   toolName: string,
   toolUseId: string,
 ): void {
-  getCallbacks()?.tool_use_start?.(toolName, { input: {}, toolUseId });
+  getCallbacks()?.tool_use_start?.(toolName, { toolUseId });
 }
 
 function emitToolResult(


### PR DESCRIPTION
## Summary
Fixes round-2 review gaps for front-model-progress-narration.md.

**Gaps:** tool_use_start detail forwarded a full input payload nothing consumes (narrowed to toolUseId); daemon-side tool_result toolName resolution (#38556) now pinned by emission-site tests