### PR TITLE
perf(voice): single-token endpoint decision + tighter classifier prompt

### DIFF
--- a/assistant/src/live-voice/__tests__/front-decision.test.ts
+++ b/assistant/src/live-voice/__tests__/front-decision.test.ts
@@ -32,7 +32,7 @@ function stubProvider(sendMessage: Provider["sendMessage"]): Provider {
 
 function toolResponse(
   inputBlock: Record<string, unknown>,
-  name = "turn_decision",
+  name = "ack",
 ): ProviderResponse {
   return {
     content: [{ type: "tool_use", id: "tu_1", name, input: inputBlock }],
@@ -42,33 +42,48 @@ function toolResponse(
   };
 }
 
+function textResponse(text: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text }],
+    model: "stub-model",
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "end_turn",
+  };
+}
+
 describe("createVoiceFrontDecider — decideEndpoint", () => {
-  test("tool result complete:false → hold", async () => {
+  test('answer "0" → hold', async () => {
     const decider = createVoiceFrontDecider({
       config,
-      getProvider: async () =>
-        stubProvider(async () => toolResponse({ complete: false })),
+      getProvider: async () => stubProvider(async () => textResponse("0")),
     });
     expect(await decider.decideEndpoint(input)).toEqual({ action: "hold" });
   });
 
-  test("tool result complete:true → release", async () => {
+  test('answer "1" → release', async () => {
     const decider = createVoiceFrontDecider({
       config,
-      getProvider: async () =>
-        stubProvider(async () => toolResponse({ complete: true })),
+      getProvider: async () => stubProvider(async () => textResponse("1")),
     });
     expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
   });
 
-  test("sends transcript, forced turn_decision tool, and call-site config", async () => {
+  test('answer "0" with trailing delimiter → hold', async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () => stubProvider(async () => textResponse(" 0\n")),
+    });
+    expect(await decider.decideEndpoint(input)).toEqual({ action: "hold" });
+  });
+
+  test("sends transcript, tight token budget, no tools, and call-site config", async () => {
     let captured: Parameters<Provider["sendMessage"]> | undefined;
     const decider = createVoiceFrontDecider({
       config,
       getProvider: async () =>
         stubProvider(async (...args) => {
           captured = args;
-          return toolResponse({ complete: true });
+          return textResponse("1");
         }),
     });
     await decider.decideEndpoint({ ...input, latestPartial: "and then" });
@@ -79,12 +94,14 @@ describe("createVoiceFrontDecider — decideEndpoint", () => {
     expect(text).toContain("so what I was thinking is");
     expect(text).toContain("and then");
     expect(options?.config).toMatchObject({
-      max_tokens: 64,
+      max_tokens: 4,
       callSite: "voiceFrontDecision",
-      tool_choice: { type: "tool", name: "turn_decision" },
       disableCache: true,
     });
-    expect(options?.tools?.map((t) => t.name)).toEqual(["turn_decision"]);
+    // Single-token text protocol: no tool schema in the prompt, no forced
+    // tool call in the output — the latency-critical path stays minimal.
+    expect(options?.tools).toBeUndefined();
+    expect(options?.config?.tool_choice).toBeUndefined();
     expect(options?.systemPrompt).toContain("finished");
   });
 
@@ -163,21 +180,28 @@ describe("createVoiceFrontDecider — decideEndpoint", () => {
     expect(Date.now() - start).toBeLessThan(1000);
   });
 
-  test("missing/foreign tool block → release", async () => {
+  test("response without a text block → release", async () => {
     const decider = createVoiceFrontDecider({
       config,
       getProvider: async () =>
-        stubProvider(async () =>
-          toolResponse({ complete: false }, "some_other_tool"),
-        ),
+        stubProvider(async () => toolResponse({ complete: false })),
     });
     expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
   });
 
-  test("malformed tool input (complete not boolean) → release", async () => {
+  test("empty text answer → release", async () => {
     const decider = createVoiceFrontDecider({
       config,
-      getProvider: async () => stubProvider(async () => toolResponse({})),
+      getProvider: async () => stubProvider(async () => textResponse("   ")),
+    });
+    expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
+  });
+
+  test("non-protocol prose answer → release (fail-open)", async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async () => textResponse("The speaker seems unsure")),
     });
     expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
   });

--- a/assistant/src/live-voice/front-decision.ts
+++ b/assistant/src/live-voice/front-decision.ts
@@ -20,14 +20,15 @@
 
 import type { LiveVoiceFrontModelConfig } from "../config/schemas/live-voice.js";
 import {
+  extractText,
   extractToolUse,
   getConfiguredProvider,
   userMessage,
 } from "../providers/provider-send-message.js";
 import type {
   Provider,
+  ProviderResponse,
   ToolDefinition,
-  ToolUseContent,
 } from "../providers/types.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
@@ -85,30 +86,37 @@ export interface VoiceFrontDecider {
 const RELEASE: VoiceEndpointDecision = { action: "release" };
 const HOLD: VoiceEndpointDecision = { action: "hold" };
 
-const TURN_DECISION_TOOL_NAME = "turn_decision";
+// Single-token wire protocol: the model answers with one bare character
+// instead of a forced tool call. A tool call spends 10-15 output tokens on
+// name + JSON scaffolding to convey one bit; a bare digit is one token, and
+// dropping the tool schema also shrinks the prompt. Only an exact leading
+// "0" holds — every other output (including non-compliance) releases, so the
+// fail-open contract carries the parsing risk.
+const HOLD_TOKEN = "0";
 
-const TURN_DECISION_TOOL: ToolDefinition = {
-  name: TURN_DECISION_TOOL_NAME,
-  description:
-    "Record whether the speaker's turn is complete. Call this exactly once.",
-  input_schema: {
-    type: "object",
-    properties: {
-      complete: {
-        type: "boolean",
-        description:
-          "true when the speaker has finished their thought; false when they are mid-thought and more speech is likely coming.",
-      },
-    },
-    required: ["complete"],
-  },
-};
+// Output budget for the single-character answer: one token for the digit
+// plus headroom for a stray delimiter. Deliberately tiny — a model that
+// starts writing prose gets cut off and the unparseable prefix releases.
+const ENDPOINT_DECISION_MAX_TOKENS = 4;
 
+// Tie-break is 0 (hold): a wrong hold costs one bounded extension of silence
+// and self-corrects on the replay, while a wrong release cuts the speaker off
+// mid-thought — the failure this feature exists to prevent. The extension
+// ratchet below keeps chronic uncertainty from burning every extension. This
+// is deliberately the opposite of the code-level fail-open (timeouts and
+// failures still release) — that one protects turn-taking from outages.
 const SYSTEM_PROMPT =
-  "You decide whether the speaker has finished their thought or is mid-thought/thinking. " +
-  "You see a live-voice transcript captured up to a pause. Treat trailing conjunctions, " +
-  "dangling prepositions, or an obviously unfinished clause as mid-thought. " +
-  "Bias toward finished: when in doubt, mark the turn complete.";
+  "You classify end-of-turn for a live voice assistant from a transcript captured up " +
+  "to a pause. Respond with exactly one character: 0 if the speaker is mid-thought, " +
+  "1 if finished. Never answer or explain.\n" +
+  "0 when the wording signals more speech: a trailing conjunction (and, but, or, so, " +
+  "because), dangling preposition or article, hesitation filler (um, uh, like, let me " +
+  "think), unfinished list, or clause cut off before its verb or object.\n" +
+  "1 when the wording stands alone: a complete sentence, question, command, or short " +
+  "reply (yes, no, stop).\n" +
+  "Judge wording only, not content. Missing punctuation or casing is not mid-thought. " +
+  "Longer pauses and more prior extensions favor 1. When unclear, answer 0 — a brief " +
+  "extra pause beats cutting the speaker off.";
 
 const ACK_TOOL_NAME = "ack";
 
@@ -194,20 +202,21 @@ function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
 }
 
 /**
- * One bounded front-model call with a forced tool: arm the `timeoutMs` bound
- * first, then resolve the provider and the request both raced against it (and
- * the caller's signal, when given), and return the response's tool_use block.
- * Provider resolution can await lazy initialization, so it must sit inside
- * the timeout — otherwise a stalled resolver would breach the contract that
- * every call settles within `timeoutMs`. `undefined` when no provider is
- * configured or the response carries no tool block; throws on provider
- * failure, timeout, or abort — callers map every failure to their fail-open
- * value.
+ * One bounded front-model call: arm the `timeoutMs` bound first, then resolve
+ * the provider and the request both raced against it (and the caller's
+ * signal, when given), and return the raw response. When `tool` is given the
+ * call forces that tool (`tool_choice`); otherwise it is a plain text
+ * request. Provider resolution can await lazy initialization, so it must sit
+ * inside the timeout — otherwise a stalled resolver would breach the
+ * contract that every call settles within `timeoutMs`. `undefined` when no
+ * provider is configured; throws on provider failure, timeout, or abort —
+ * callers map every failure to their fail-open value.
  */
-async function requestForcedToolUse(args: {
+async function requestBoundedResponse(args: {
   getProvider: () => Promise<Provider | null>;
   timeoutMs: number;
-  tool: ToolDefinition;
+  maxTokens: number;
+  tool?: ToolDefinition;
   systemPrompt: string;
   prompt: string;
   signal?: AbortSignal;
@@ -218,7 +227,7 @@ async function requestForcedToolUse(args: {
    * roundtrip was slow" without changing this function's return contract.
    */
   onProviderResolved?: (elapsedMs: number, provider: Provider | null) => void;
-}): Promise<ToolUseContent | undefined> {
+}): Promise<ProviderResponse | undefined> {
   // Deadline abort carries a tagged AbortReason: the provider catch-site
   // classifies untagged caller aborts as retryable transport failures, so a
   // plain-signal timeout would log an ERROR per expired budget and then be
@@ -246,19 +255,21 @@ async function requestForcedToolUse(args: {
     }
     const response = await raceAbort(
       provider.sendMessage([userMessage(args.prompt)], {
-        tools: [args.tool],
+        ...(args.tool ? { tools: [args.tool] } : {}),
         systemPrompt: args.systemPrompt,
         config: {
-          max_tokens: 64,
+          max_tokens: args.maxTokens,
           callSite: "voiceFrontDecision",
-          tool_choice: { type: "tool", name: args.tool.name },
+          ...(args.tool
+            ? { tool_choice: { type: "tool", name: args.tool.name } }
+            : {}),
           disableCache: true,
         },
         signal: combinedSignal,
       }),
       combinedSignal,
     );
-    return extractToolUse(response);
+    return response;
   } finally {
     cleanup();
   }
@@ -285,10 +296,10 @@ export function createVoiceFrontDecider(options: {
       let providerResolveMs: number | null = null;
       let providerName: string | null = null;
       try {
-        const toolBlock = await requestForcedToolUse({
+        const response = await requestBoundedResponse({
           getProvider,
           timeoutMs: config.endpointDecisionTimeoutMs,
-          tool: TURN_DECISION_TOOL,
+          maxTokens: ENDPOINT_DECISION_MAX_TOKENS,
           systemPrompt: SYSTEM_PROMPT,
           prompt: buildPrompt(input),
           signal,
@@ -297,19 +308,18 @@ export function createVoiceFrontDecider(options: {
             providerName = provider?.name ?? null;
           },
         });
-        const held =
-          toolBlock?.name === TURN_DECISION_TOOL_NAME &&
-          (toolBlock.input as { complete?: unknown }).complete === false;
+        const answer = response ? extractText(response) : "";
+        const held = answer.startsWith(HOLD_TOKEN);
         log.info(
           {
             action: held ? "hold" : "release",
             // "model" = the LLM answered; "no-provider" = call site resolved
-            // nothing; "no-tool-block" = provider answered without the tool.
-            cause: toolBlock
+            // nothing; "no-text" = provider answered without a text block.
+            cause: answer
               ? "model"
               : providerName === null
                 ? "no-provider"
-                : "no-tool-block",
+                : "no-text",
             providerName,
             providerResolveMs,
             totalMs: Math.round(performance.now() - startedAt),
@@ -321,8 +331,8 @@ export function createVoiceFrontDecider(options: {
         if (held) {
           return HOLD;
         }
-        // No provider, `complete: true`, a missing/foreign tool block, or a
-        // malformed input all release — only an explicit "not finished" holds.
+        // No provider, "1", an empty response, or any non-protocol output
+        // all release — only an explicit leading "0" holds.
         return RELEASE;
       } catch (error) {
         // providerResolveMs null here means resolution itself never settled
@@ -349,9 +359,10 @@ export function createVoiceFrontDecider(options: {
       const startedAt = performance.now();
       let providerResolveMs: number | null = null;
       try {
-        const toolBlock = await requestForcedToolUse({
+        const response = await requestBoundedResponse({
           getProvider,
           timeoutMs: config.ackGenerationTimeoutMs,
+          maxTokens: 64,
           tool: ACK_TOOL,
           systemPrompt: ACK_SYSTEM_PROMPT,
           prompt: buildAckPrompt(input),
@@ -360,6 +371,7 @@ export function createVoiceFrontDecider(options: {
             providerResolveMs = Math.round(elapsedMs);
           },
         });
+        const toolBlock = response ? extractToolUse(response) : undefined;
         if (toolBlock?.name !== ACK_TOOL_NAME) {
           return null;
         }


### PR DESCRIPTION
## Summary
- Endpoint decision now uses a single-character text protocol instead of a forced `turn_decision` tool call: `1` = finished, `0` = mid-thought, `max_tokens: 4`. Cuts ~15 output tokens of tool scaffolding to 1 (~50-150ms of serial decode at Haiku speeds) and drops the tool schema from the input. Hold-strict, fail-open parsing: only a trimmed leading `0` holds; everything else — including protocol non-compliance, timeout, or no provider — releases exactly as pre-feature.
- System prompt rewritten as an explicit binary classifier (enumerated mid-thought vs finished criteria, judge-wording-not-content scope, missing-punctuation guard, pause/extension ratchet) with the uncertainty tie-break flipped from release to hold: a wrong hold costs one bounded 1500ms extension (capped by `endpointMaxExtensions`) and self-corrects on replay, while a wrong release cuts the speaker off mid-thought. The code-level fail-open is deliberately not flipped, so outages can only reproduce pre-feature behavior.
- `requestForcedToolUse` generalized to `requestBoundedResponse` (optional tool, parameterized `maxTokens`); the ack path keeps its forced `ack` tool and 64-token budget unchanged.

## Original prompt
Iterating on the live-voice front-model endpoint decision (JARVIS-1302 presence layer): make the system prompt an explicitly binary, constrained classifier; optimize the call for latency in thinking and output-token generation (thinking was already disabled at the call site, so the win is the single-token wire protocol); flip the uncertainty tie-break so ambiguous pauses hold rather than release; and compress the prompt. Then ship to main via /mainline.