### PR TITLE
fix(web): soften voice-room transcript user bubble to app design language (JARVIS-1308)

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -109,7 +109,7 @@ export function VoiceAmbientTranscript() {
               >
                 <div
                   data-testid="voice-ambient-user-bubble"
-                  className="max-w-[85%] break-words rounded-2xl px-4 py-2.5 text-[clamp(15px,2vmin,19px)] leading-snug"
+                  className="max-w-[85%] break-words rounded-lg border border-[var(--room-border)] px-4 py-2.5 text-[clamp(15px,2vmin,19px)] leading-snug"
                   style={{ backgroundColor: "var(--room-bubble-bg)" }}
                 >
                   <VoiceTranscriptText

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -191,8 +191,8 @@ function VoiceRoomOverlay() {
     "--room-fg-muted": tone?.fgMuted ?? "rgba(255,255,255,0.7)",
     "--room-wash": tone?.wash ?? "rgba(255,255,255,0.1)",
     "--room-border": tone?.wash ?? "rgba(255,255,255,0.15)",
-    "--room-bubble-bg": tone?.bubbleBg ?? "#FFFFFF",
-    "--room-bubble-fg": tone?.bubbleFg ?? "#1A1A1A",
+    "--room-bubble-bg": tone?.bubbleBg ?? "rgba(255,255,255,0.16)",
+    "--room-bubble-fg": tone?.bubbleFg ?? "#FFFFFF",
   } as CSSProperties;
 
   // Global Escape, live only while the room is mounted: ends the session,

--- a/clients/web/src/utils/avatar-tone.test.ts
+++ b/clients/web/src/utils/avatar-tone.test.ts
@@ -1,10 +1,10 @@
 /**
  * Tests for `toneForBg`'s user-bubble surface tokens (`bubbleBg`/`bubbleFg`).
  *
- * Pins the contract that the bubble is a raised surface contrasting the
- * avatar color — white/near-black over dark or saturated avatars, inverted
- * to dark/white over the one light avatar color (yellow) — while the base
- * tone fields (`fg`/`fgMuted`) keep their established values.
+ * Pins the contract that the bubble is a soft translucent raised lift toned to
+ * the room — a subtle white wash + white text over dark or saturated avatars, a
+ * subtle dark wash + near-black text over the one light avatar color (yellow) —
+ * while the base tone fields (`fg`/`fgMuted`) keep their established values.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -12,21 +12,21 @@ import { describe, expect, test } from "bun:test";
 import { toneForBg } from "./avatar-tone";
 
 describe("toneForBg bubble tokens", () => {
-  test("dark bg yields a white bubble with near-black text", () => {
+  test("dark bg yields a soft white lift with white text", () => {
     const surface = toneForBg("#17191C");
-    expect(surface.bubbleBg).toBe("#FFFFFF");
-    expect(surface.bubbleFg).toBe("#1A1A1A");
+    expect(surface.bubbleBg).toBe("rgba(255,255,255,0.16)");
+    expect(surface.bubbleFg).toBe("#FFFFFF");
 
     const teal = toneForBg("#3E9B87");
-    expect(teal.bubbleBg).toBe("#FFFFFF");
-    expect(teal.bubbleFg).toBe("#1A1A1A");
+    expect(teal.bubbleBg).toBe("rgba(255,255,255,0.16)");
+    expect(teal.bubbleFg).toBe("#FFFFFF");
   });
 
-  test("light bg (yellow) inverts to a dark bubble with white text", () => {
+  test("light bg (yellow) yields a soft dark lift with near-black text", () => {
     const tone = toneForBg("#F2C94C");
     expect(tone.isLight).toBe(true);
-    expect(tone.bubbleBg).toBe("#1A1A1A");
-    expect(tone.bubbleFg).toBe("#FFFFFF");
+    expect(tone.bubbleBg).toBe("rgba(0,0,0,0.10)");
+    expect(tone.bubbleFg).toBe("#1A1A1A");
   });
 
   test("base tone fields keep their established values", () => {

--- a/clients/web/src/utils/avatar-tone.test.ts
+++ b/clients/web/src/utils/avatar-tone.test.ts
@@ -1,32 +1,82 @@
 /**
  * Tests for `toneForBg`'s user-bubble surface tokens (`bubbleBg`/`bubbleFg`).
  *
- * Pins the contract that the bubble is a soft translucent raised lift toned to
- * the room — a subtle white wash + white text over dark or saturated avatars, a
- * subtle dark wash + near-black text over the one light avatar color (yellow) —
- * while the base tone fields (`fg`/`fgMuted`) keep their established values.
+ * Pins the contract that the bubble is a soft translucent raised lift — a
+ * subtle white wash over dark/saturated avatars, a subtle dark wash over the
+ * one light avatar color (yellow) — whose text is chosen for WCAG-AA contrast
+ * against the *blended* bubble pixel (white over dark avatars, near-black over
+ * lighter/mid-tone ones), while the base tone fields (`fg`/`fgMuted`) keep their
+ * established values.
  */
 
 import { describe, expect, test } from "bun:test";
 
 import { toneForBg } from "./avatar-tone";
 
+/** WCAG relative luminance of a #rrggbb hex, mirroring avatar-tone internals. */
+function luminance(hex: string): number {
+  const n = parseInt(hex.replace("#", ""), 16);
+  const ch = (shift: number) => {
+    const c = ((n >> shift) & 0xff) / 255;
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * ch(16) + 0.7152 * ch(8) + 0.0722 * ch(0);
+}
+
+/** Composite a solid base under a white(255)/black(0) overlay at `alpha`. */
+function composite(base: string, overlay: 0 | 255, alpha: number): string {
+  const n = parseInt(base.replace("#", ""), 16);
+  const mix = (shift: number) =>
+    Math.round(((n >> shift) & 0xff) * (1 - alpha) + overlay * alpha);
+  return `#${((1 << 24) | (mix(16) << 16) | (mix(8) << 8) | mix(0)).toString(16).slice(1)}`;
+}
+
+function contrastRatio(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi! + 0.05) / (lo! + 0.05);
+}
+
 describe("toneForBg bubble tokens", () => {
-  test("dark bg yields a soft white lift with white text", () => {
+  test("dark avatar → soft white lift, white text (dark blended surface)", () => {
     const surface = toneForBg("#17191C");
     expect(surface.bubbleBg).toBe("rgba(255,255,255,0.16)");
     expect(surface.bubbleFg).toBe("#FFFFFF");
-
-    const teal = toneForBg("#3E9B87");
-    expect(teal.bubbleBg).toBe("rgba(255,255,255,0.16)");
-    expect(teal.bubbleFg).toBe("#FFFFFF");
   });
 
-  test("light bg (yellow) yields a soft dark lift with near-black text", () => {
+  test("mid-tone saturated avatar → soft white lift, near-black text for AA", () => {
+    // White-on-color would fail AA here; the bubble text flips to near-black
+    // against the lightened blended surface.
+    const teal = toneForBg("#3E9B87");
+    expect(teal.bubbleBg).toBe("rgba(255,255,255,0.16)");
+    expect(teal.bubbleFg).toBe("#1A1A1A");
+  });
+
+  test("light avatar (yellow) → soft dark lift, near-black text", () => {
     const tone = toneForBg("#F2C94C");
     expect(tone.isLight).toBe(true);
     expect(tone.bubbleBg).toBe("rgba(0,0,0,0.10)");
     expect(tone.bubbleFg).toBe("#1A1A1A");
+  });
+
+  test("bubble text meets WCAG AA against the blended surface on every palette color", () => {
+    // A spread across the room's avatar palette (dark + the mid-tone saturated
+    // greens/oranges/pinks/purples/teals Codex flagged) plus the light yellow.
+    const avatars = [
+      "#17191C",
+      "#4C9B50",
+      "#3E9B87",
+      "#E08A3C",
+      "#D96BA0",
+      "#8E6BD9",
+      "#F2C94C",
+    ];
+    for (const bg of avatars) {
+      const { isLight, bubbleFg } = toneForBg(bg);
+      const surface = isLight
+        ? composite(bg, 0, 0.1)
+        : composite(bg, 255, 0.16);
+      expect(contrastRatio(bubbleFg, surface)).toBeGreaterThanOrEqual(4.5);
+    }
   });
 
   test("base tone fields keep their established values", () => {

--- a/clients/web/src/utils/avatar-tone.ts
+++ b/clients/web/src/utils/avatar-tone.ts
@@ -27,11 +27,13 @@ export interface AvatarTone {
   /** A subtle hover/fill wash at the matching tone. */
   wash: string;
   /**
-   * Solid raised-surface fill for a user speech bubble that contrasts the
-   * avatar color: white over dark/saturated avatars, dark over the light one.
+   * Soft raised-surface fill for a user speech bubble — the room's analog of
+   * the app's `--surface-lift`: a translucent lift of the foreground over the
+   * avatar color (a subtle white wash over dark/saturated avatars, a subtle
+   * dark wash over the light one), not an opaque max-contrast chip.
    */
   bubbleBg: string;
-  /** Text color drawn on that bubble (the inverse of {@link bubbleBg}). */
+  /** Text color drawn on that bubble — the room's own foreground ({@link fg}). */
   bubbleFg: string;
 }
 
@@ -100,8 +102,10 @@ export function toneForBg(bg: string): AvatarTone {
     fgDeep: darkenHex(bg, 0.6),
     fgMuted: isLight ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.65)",
     wash: isLight ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.12)",
-    // A raised surface reads as the foreground tone; its text is the inverse.
-    bubbleBg: fg,
-    bubbleFg: isLight ? FG_LIGHT : FG_DARK,
+    // A soft raised surface (the room's analog of the app's --surface-lift user
+    // bubble): a translucent lift of the foreground over the avatar color, with
+    // the room's own foreground text — not an opaque max-contrast chip.
+    bubbleBg: isLight ? "rgba(0,0,0,0.10)" : "rgba(255,255,255,0.16)",
+    bubbleFg: fg,
   };
 }

--- a/clients/web/src/utils/avatar-tone.ts
+++ b/clients/web/src/utils/avatar-tone.ts
@@ -33,7 +33,12 @@ export interface AvatarTone {
    * dark wash over the light one), not an opaque max-contrast chip.
    */
   bubbleBg: string;
-  /** Text color drawn on that bubble — the room's own foreground ({@link fg}). */
+  /**
+   * Text color for that bubble, chosen for WCAG-AA contrast against the
+   * *blended* bubble pixel (the lift composited over the avatar fill) — white
+   * over dark avatars, near-black over lighter/mid-tone ones — so live captions
+   * stay legible on every palette color, not a fixed room foreground.
+   */
   bubbleFg: string;
 }
 
@@ -63,6 +68,24 @@ export function darkenHex(hex: string, factor: number): string {
   const ch = (shift: number) =>
     Math.max(0, Math.min(255, Math.round(((n >> shift) & 0xff) * factor)));
   return `#${((1 << 24) | (ch(16) << 16) | (ch(8) << 8) | ch(0)).toString(16).slice(1)}`;
+}
+
+/**
+ * Composite a solid `base` #rrggbb under a white (255) or black (0) overlay at
+ * `alpha`, returning the resulting opaque #rrggbb — the actual pixel color a
+ * translucent bubble lift resolves to when painted over the avatar fill. Bubble
+ * text is picked against this, not the raw avatar color, so contrast reflects
+ * what the eye sees.
+ */
+function compositeOverlay(base: string, overlay: 0 | 255, alpha: number): string {
+  const m = /^#?([0-9a-f]{6})$/i.exec(base);
+  if (!m) {
+    return base;
+  }
+  const n = parseInt(m[1]!, 16);
+  const mix = (shift: number) =>
+    Math.round(((n >> shift) & 0xff) * (1 - alpha) + overlay * alpha);
+  return `#${((1 << 24) | (mix(16) << 16) | (mix(8) << 8) | mix(0)).toString(16).slice(1)}`;
 }
 
 /** WCAG relative luminance (sRGB-linearized), 0–1. */
@@ -103,9 +126,13 @@ export function toneForBg(bg: string): AvatarTone {
     fgMuted: isLight ? "rgba(0,0,0,0.6)" : "rgba(255,255,255,0.65)",
     wash: isLight ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.12)",
     // A soft raised surface (the room's analog of the app's --surface-lift user
-    // bubble): a translucent lift of the foreground over the avatar color, with
-    // the room's own foreground text — not an opaque max-contrast chip.
+    // bubble): a translucent lift of the foreground over the avatar color — not
+    // an opaque max-contrast chip. Its text is chosen for WCAG-AA contrast
+    // against the *blended* bubble pixel (lift over the avatar fill), so mid-tone
+    // saturated avatars get near-black text instead of failing white-on-color.
     bubbleBg: isLight ? "rgba(0,0,0,0.10)" : "rgba(255,255,255,0.16)",
-    bubbleFg: fg,
+    bubbleFg: isLight
+      ? contrastForeground(compositeOverlay(bg, 0, 0.1))
+      : contrastForeground(compositeOverlay(bg, 255, 0.16)),
   };
 }


### PR DESCRIPTION
## Summary
- The live-voice transcript rail's user-turn bubble read "too hard" in live tryout — it was an opaque, max-contrast fill (`bubbleBg = fg` → pure white / near-black text), stamping a hard white chip on the avatar color instead of a soft lift.
- Retones it to the room's analog of the app's real user bubble (`transcript-message-body.tsx`: `rounded-lg` + `surface-lift` + default text): `bubbleBg` becomes a translucent foreground lift, `bubbleFg` becomes the room's own foreground, and the bubble gains `rounded-lg` + a hairline `--room-border` (matching the room's existing bordered translucent mic/stop controls). Void-look fallback vars follow suit.
- Tests: `avatar-tone.test.ts` re-pinned to the soft-lift contract; `voice-ambient-transcript.test.tsx` unchanged (still asserts the `--room-bubble-bg` binding). Both green + typecheck clean.

## Original prompt
Follow-up polish on the merged transcript rail (JARVIS-1306, PR #38549). On live tryout the user turn felt too hard and off from the rest of the app's design language. This PR addresses that softening only. The separate feedback — that the caption highlight should track the word being spoken rather than parking on the last word — is deferred to its own ticket **JARVIS-1309** (needs an audio-playhead-driven cursor; the transcript is fed by the LLM text stream, which races ahead of TTS).