### PR TITLE
fix: round-3 self-review gaps for pro onboarding wizard

### DIFF
--- a/clients/web/src/assistant/use-lifecycle.ts
+++ b/clients/web/src/assistant/use-lifecycle.ts
@@ -24,7 +24,10 @@ import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isAuthenticated, type SessionStatus } from "@/stores/session-status";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { useOrganizationStore } from "@/stores/organization-store";
+import {
+  getActiveOrganizationIdForRequests,
+  useOrganizationStore,
+} from "@/stores/organization-store";
 
 interface UseAssistantLifecycleOptions {
   sessionStatus: SessionStatus;
@@ -65,9 +68,15 @@ export function useAssistantLifecycle({
   // Subscribe so the hook re-renders (and the lockfile-local check below
   // re-evaluates) when the resolved list / lockfile change.
   useResolvedAssistantsStore.use.assistants();
+  // Resolve the org id from the same source as the `shouldQueryServer` gate
+  // (hydrated store, then sessionStorage fallback): when the gate opens via
+  // the fallback while the store fetch failed, resolving from the store alone
+  // would drop the user's selection and project the default assistant.
+  const activeOrganizationId =
+    currentOrganizationId ?? getActiveOrganizationIdForRequests();
   const resolvedSelectionId =
-    multiAssistantEnabled && !isGatewayAuthMode() && currentOrganizationId
-      ? resolveSelectedAssistantId(currentOrganizationId)
+    multiAssistantEnabled && !isGatewayAuthMode() && activeOrganizationId
+      ? resolveSelectedAssistantId(activeOrganizationId)
       : null;
   // Keep only lockfile-only LOCAL assistants off the platform retrieve path:
   // they're gateway-based, never registered on the platform, so getAssistant(id)

--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -55,6 +55,11 @@ mock.module("@/generated/api/sdk.gen", () => ({
     },
     assistantsActiveRetrieve: () =>
         Promise.resolve({ data: ACTIVE_ASSISTANT, response: { ok: true } }),
+    assistantsRetrieve: (opts: { path: { id: string } }) =>
+        Promise.resolve({
+            data: { id: opts.path.id } as unknown as Assistant,
+            response: { ok: true },
+        }),
     assistantsDomainsList: (opts: { path?: { assistant_id?: string } }) => {
         domainsCalls += 1;
         if (opts?.path?.assistant_id) {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -134,6 +134,8 @@ mock.module("@/generated/api/sdk.gen", () => ({
   },
   assistantsActiveRetrieve: () =>
     Promise.resolve({ data: assistantResponse, response: { ok: true } }),
+  assistantsRetrieve: () =>
+    Promise.resolve({ data: assistantResponse, response: { ok: true } }),
   assistantsOperationalStatusDetailRead: () =>
     Promise.resolve({
       data: operationalStatusResponse,
@@ -249,6 +251,12 @@ describe("BillingOnboardingModal", () => {
       () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
       { timeout: 5000 },
     );
+    // Wait for the pre-resize actuals to land (the "from" card) before
+    // mutating: an invalidate that races the initial actuals fetch is
+    // swallowed, leaving the update to the next 2s poll.
+    await waitFor(() => expect(getByText("10 GiB")).toBeTruthy(), {
+      timeout: 5000,
+    });
 
     assistantResponse = makeAssistant("large", 50);
     await client.invalidateQueries();
@@ -274,6 +282,12 @@ describe("BillingOnboardingModal", () => {
       timeout: 5000,
     });
     expect(queryByText("Machine")).toBeNull();
+    // Wait for the pre-resize actuals to land (the "from" card) before
+    // mutating: an invalidate that races the initial actuals fetch is
+    // swallowed, leaving the update to the next 2s poll.
+    await waitFor(() => expect(getByText("10 GiB")).toBeTruthy(), {
+      timeout: 5000,
+    });
 
     assistantResponse = makeAssistant("small", 50);
     await client.invalidateQueries();
@@ -417,51 +431,59 @@ describe("BillingOnboardingModal", () => {
     );
   });
 
-  test("escape advances to complete with the background-finishing line, which clears on DONE", async () => {
-    subscriptionPlanId = "pro";
-    onboardingResponse = makeOnboarding({ domain_setup_available: false });
-    const { client, getByText, getByTestId, queryByText } = renderModal();
+  test(
+    "escape advances to complete with the background-finishing line, which clears on DONE",
+    async () => {
+      subscriptionPlanId = "pro";
+      onboardingResponse = makeOnboarding({ domain_setup_available: false });
+      const { client, getByText, getByTestId, queryByText } = renderModal();
 
-    await waitFor(
-      () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    dateNowOffsetMs = 61_000;
-    await waitFor(
-      () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    fireEvent.click(getByTestId("provisioning-escape"));
+      await waitFor(
+        () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      dateNowOffsetMs = 61_000;
+      await waitFor(
+        () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      fireEvent.click(getByTestId("provisioning-escape"));
 
-    await waitFor(() => expect(getByText("You're all set")).toBeTruthy());
-    expect(getByText(BACKGROUND_LINE)).toBeTruthy();
+      await waitFor(() => expect(getByText("You're all set")).toBeTruthy());
+      expect(getByText(BACKGROUND_LINE)).toBeTruthy();
 
-    assistantResponse = makeAssistant("large", 50);
-    await client.invalidateQueries();
-    await waitFor(() => expect(queryByText(BACKGROUND_LINE)).toBeNull(), {
-      timeout: 5000,
-    });
-  });
+      assistantResponse = makeAssistant("large", 50);
+      await client.invalidateQueries();
+      await waitFor(() => expect(queryByText(BACKGROUND_LINE)).toBeNull(), {
+        timeout: 5000,
+      });
+    },
+    20_000,
+  );
 
-  test("escape hatch stays hidden until the escape window elapses", async () => {
-    subscriptionPlanId = "pro";
-    const { getByText, getByTestId, queryByTestId } = renderModal();
+  test(
+    "escape hatch stays hidden until the escape window elapses",
+    async () => {
+      subscriptionPlanId = "pro";
+      const { getByText, getByTestId, queryByTestId } = renderModal();
 
-    await waitFor(
-      () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    // Give the routing latch time to settle: still no escape hatch, because
-    // the watch hasn't run long enough.
-    await new Promise((resolve) => setTimeout(resolve, 1200));
-    expect(queryByTestId("provisioning-escape")).toBeNull();
+      await waitFor(
+        () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      // Give the routing latch time to settle: still no escape hatch, because
+      // the watch hasn't run long enough.
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      expect(queryByTestId("provisioning-escape")).toBeNull();
 
-    dateNowOffsetMs = 61_000;
-    await waitFor(
-      () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-  });
+      dateNowOffsetMs = 61_000;
+      await waitFor(
+        () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+    },
+    20_000,
+  );
 
   test("escape hatch waits for fresh routing data even once time-eligible", async () => {
     let releaseOnboarding!: () => void;
@@ -524,111 +546,126 @@ describe("BillingOnboardingModal", () => {
     );
   });
 
-  test("a stall after escaping to complete offers Apply & Restart there", async () => {
-    subscriptionPlanId = "pro";
-    onboardingResponse = makeOnboarding({ domain_setup_available: false });
-    const { client, getByText, getByTestId, queryByText, queryByTestId } =
-      renderModal();
+  test(
+    "a stall after escaping to complete offers Apply & Restart there",
+    async () => {
+      subscriptionPlanId = "pro";
+      onboardingResponse = makeOnboarding({ domain_setup_available: false });
+      const { client, getByText, getByTestId, queryByText, queryByTestId } =
+        renderModal();
 
-    await waitFor(
-      () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    dateNowOffsetMs = 61_000;
-    await waitFor(
-      () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    fireEvent.click(getByTestId("provisioning-escape"));
-    await waitFor(() => expect(getByText("You're all set")).toBeTruthy());
-    expect(getByText(BACKGROUND_LINE)).toBeTruthy();
+      await waitFor(
+        () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      dateNowOffsetMs = 61_000;
+      await waitFor(
+        () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      fireEvent.click(getByTestId("provisioning-escape"));
+      await waitFor(() => expect(getByText("You're all set")).toBeTruthy());
+      expect(getByText(BACKGROUND_LINE)).toBeTruthy();
 
-    // The backgrounded resize stalls: the finishing line swaps for a warning
-    // with a manual apply.
-    dateNowOffsetMs = 200_000;
-    await waitFor(
-      () => expect(getByTestId("complete-stalled-apply")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    expect(queryByText(BACKGROUND_LINE)).toBeNull();
+      // The backgrounded resize stalls: the finishing line swaps for a warning
+      // with a manual apply.
+      dateNowOffsetMs = 200_000;
+      await waitFor(
+        () => expect(getByTestId("complete-stalled-apply")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      expect(queryByText(BACKGROUND_LINE)).toBeNull();
 
-    // Applying resumes observation — the finishing line returns…
-    fireEvent.click(getByTestId("complete-stalled-apply"));
-    await waitFor(() => expect(resizeCall).not.toBeNull());
-    await waitFor(() => expect(getByText(BACKGROUND_LINE)).toBeTruthy(), {
-      timeout: 5000,
-    });
+      // Applying resumes observation — the finishing line returns…
+      fireEvent.click(getByTestId("complete-stalled-apply"));
+      await waitFor(() => expect(resizeCall).not.toBeNull());
+      await waitFor(() => expect(getByText(BACKGROUND_LINE)).toBeTruthy(), {
+        timeout: 5000,
+      });
 
-    // …and the resize landing clears it.
-    assistantResponse = makeAssistant("large", 50);
-    await client.invalidateQueries();
-    await waitFor(() => expect(queryByText(BACKGROUND_LINE)).toBeNull(), {
-      timeout: 5000,
-    });
-    expect(queryByTestId("complete-stalled-apply")).toBeNull();
-  });
+      // …and the resize landing clears it.
+      assistantResponse = makeAssistant("large", 50);
+      await client.invalidateQueries();
+      await waitFor(() => expect(queryByText(BACKGROUND_LINE)).toBeNull(), {
+        timeout: 5000,
+      });
+      expect(queryByTestId("complete-stalled-apply")).toBeNull();
+    },
+    20_000,
+  );
 
-  test("a stall while the user is on the domain step offers the apply controls and keeps the submit locked", async () => {
-    subscriptionPlanId = "pro";
-    const { client, getByText, getByTestId, getByLabelText, queryByText, queryByTestId } =
-      renderModal();
+  test(
+    "a stall while the user is on the domain step offers the apply controls and keeps the submit locked",
+    async () => {
+      subscriptionPlanId = "pro";
+      const {
+        client,
+        getByText,
+        getByTestId,
+        getByLabelText,
+        queryByText,
+        queryByTestId,
+      } = renderModal();
 
-    await waitFor(
-      () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    dateNowOffsetMs = 61_000;
-    await waitFor(
-      () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    fireEvent.click(getByTestId("provisioning-escape"));
-    await waitFor(() => expect(getByText("Assistant email")).toBeTruthy());
-    await waitFor(() =>
-      expect((getByLabelText("Subdomain") as HTMLInputElement).value).toBe(
-        "casey",
-      ),
-    );
+      await waitFor(
+        () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      dateNowOffsetMs = 61_000;
+      await waitFor(
+        () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      fireEvent.click(getByTestId("provisioning-escape"));
+      await waitFor(() => expect(getByText("Assistant email")).toBeTruthy());
+      await waitFor(() =>
+        expect((getByLabelText("Subdomain") as HTMLInputElement).value).toBe(
+          "casey",
+        ),
+      );
 
-    // The flow stalls while the user is on the domain step: the machine may
-    // still be mid-restart, so the guardian-channel submit stays locked and
-    // the neutral busy notice swaps for the stalled warning + manual apply.
-    dateNowOffsetMs = 200_000;
-    await waitFor(
-      () => expect(getByTestId("domain-stalled-apply")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    expect(
-      queryByText(
-        "Your assistant is restarting — you can set the domain in a moment.",
-      ),
-    ).toBeNull();
-    expect(
-      (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
-    ).toBe(true);
-
-    // Applying resumes observation: the stalled controls give way to the
-    // neutral busy notice while the resize is re-observed…
-    fireEvent.click(getByTestId("domain-stalled-apply"));
-    await waitFor(() => expect(resizeCall).not.toBeNull());
-    await waitFor(() =>
+      // The flow stalls while the user is on the domain step: the machine may
+      // still be mid-restart, so the guardian-channel submit stays locked and
+      // the neutral busy notice swaps for the stalled warning + manual apply.
+      dateNowOffsetMs = 200_000;
+      await waitFor(
+        () => expect(getByTestId("domain-stalled-apply")).toBeTruthy(),
+        { timeout: 5000 },
+      );
       expect(
-        getByText(
+        queryByText(
           "Your assistant is restarting — you can set the domain in a moment.",
         ),
-      ).toBeTruthy(),
-    );
-    expect(queryByTestId("domain-stalled-apply")).toBeNull();
+      ).toBeNull();
+      expect(
+        (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
+      ).toBe(true);
 
-    // …and the resize landing lifts the guard.
-    assistantResponse = makeAssistant("large", 50);
-    await client.invalidateQueries();
-    await waitFor(
-      () =>
+      // Applying resumes observation: the stalled controls give way to the
+      // neutral busy notice while the resize is re-observed…
+      fireEvent.click(getByTestId("domain-stalled-apply"));
+      await waitFor(() => expect(resizeCall).not.toBeNull());
+      await waitFor(() =>
         expect(
-          (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
-        ).toBe(false),
-      { timeout: 5000 },
-    );
-  });
+          getByText(
+            "Your assistant is restarting — you can set the domain in a moment.",
+          ),
+        ).toBeTruthy(),
+      );
+      expect(queryByTestId("domain-stalled-apply")).toBeNull();
+
+      // …and the resize landing lifts the guard.
+      assistantResponse = makeAssistant("large", 50);
+      await client.invalidateQueries();
+      await waitFor(
+        () =>
+          expect(
+            (getByTestId("onboarding-domain-set") as HTMLButtonElement)
+              .disabled,
+          ).toBe(false),
+        { timeout: 5000 },
+      );
+    },
+    20_000,
+  );
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -191,6 +191,7 @@ export function BillingOnboardingModal({
         <DomainStep
           machineBusy={machineBusy}
           stalledAction={stalledActionIfStalled}
+          assistantId={assistantId}
           onExit={() => setStep("complete")}
         />
       );
@@ -200,6 +201,7 @@ export function BillingOnboardingModal({
       <CompleteState
         finishedInBackground={finishedInBackground && !provisioningSettled}
         stalledAction={stalledActionIfStalled}
+        assistantId={assistantId}
       />
     );
   }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
@@ -2,9 +2,6 @@ import { PartyPopper } from "lucide-react";
 
 import { useNavigate } from "react-router";
 
-import { useQuery } from "@tanstack/react-query";
-
-import { assistantsActiveRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
@@ -12,23 +9,24 @@ import { Notice } from "@vellumai/design-library/components/notice";
 
 import type { StalledApplyAction } from "./primitives";
 import { STALLED_UPGRADE_WARNING, StalledApplyControls } from "./primitives";
+import { usePreferredOrActiveAssistant } from "./use-preferred-or-active-assistant";
 
 export function CompleteState({
   finishedInBackground = false,
   stalledAction,
+  assistantId,
 }: {
   /** The user backgrounded the machine resize; hidden once it completes. */
   finishedInBackground?: boolean;
   /** Set only while the backgrounded resize is stalled — offers manual apply. */
   stalledAction?: StalledApplyAction;
+  /** The provisioning target assistant (onboarding primary, else active). */
+  assistantId?: string | null;
 }) {
   const navigate = useNavigate();
   const isOrgReady = useIsOrgReady();
-  const { data: activeAssistant } = useQuery({
-    ...assistantsActiveRetrieveOptions(),
-    enabled: isOrgReady,
-  });
-  const assistantName = activeAssistant?.name || "your assistant";
+  const assistant = usePreferredOrActiveAssistant(assistantId, isOrgReady);
+  const assistantName = assistant?.name || "your assistant";
 
   return (
     <div className="relative flex min-h-[320px] flex-col items-center justify-center overflow-hidden px-8 text-center">

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
@@ -3,9 +3,9 @@
  * the "Finish Pro setup" nudge reads (domains list + onboarding state) in
  * addition to the assistants list.
  *
- * Strategy mirrors billing-page.test.tsx: mock the generated SDK so the active
- * assistant loads (prefilling the subdomain from its handle) and the domain
- * mutation resolves, then spy on the query client's invalidations.
+ * Strategy mirrors billing-page.test.tsx: mock the generated SDK so the
+ * targeted assistant loads (prefilling the subdomain from its handle) and the
+ * domain mutation resolves, then spy on the query client's invalidations.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
@@ -18,24 +18,21 @@ import {
   organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
 import * as sdkGen from "@/generated/api/sdk.gen";
-import type {
-  Assistant,
-  OnboardingStateResponse,
-} from "@/generated/api/types.gen";
+import type { Assistant } from "@/generated/api/types.gen";
 
 let domainCreateCalls = 0;
-let primaryAssistantId: string | null = "assistant-1";
 let domainsListPaths: string[] = [];
-
-mock.module("@/hooks/use-is-org-ready", () => ({
-  useIsOrgReady: () => true,
-}));
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
   assistantsActiveRetrieve: () =>
     Promise.resolve({
       data: { id: "assistant-1", handle: "velly" } as unknown as Assistant,
+      response: { ok: true },
+    }),
+  assistantsRetrieve: (opts: { path: { id: string } }) =>
+    Promise.resolve({
+      data: { id: opts.path.id, handle: "velly" } as unknown as Assistant,
       response: { ok: true },
     }),
   assistantsDomainsList: (opts: { path?: { assistant_id?: string } }) => {
@@ -47,18 +44,6 @@ mock.module("@/generated/api/sdk.gen", () => ({
       response: { ok: true },
     });
   },
-  organizationsBillingSubscriptionOnboardingRetrieve: () =>
-    Promise.resolve({
-      data: {
-        max_machine_tier: "large",
-        selected_storage_tier: "md",
-        selected_storage_gib: 50,
-        pvc_ready: true,
-        domain_setup_available: true,
-        primary_assistant_id: primaryAssistantId,
-      } satisfies OnboardingStateResponse,
-      response: { ok: true },
-    }),
   organizationsBillingSubscriptionOnboardingDomainCreate: () => {
     domainCreateCalls += 1;
     return Promise.resolve({ data: {}, response: { ok: true } });
@@ -69,7 +54,6 @@ const { DomainStep } = await import("./domain-step");
 
 beforeEach(() => {
   domainCreateCalls = 0;
-  primaryAssistantId = "assistant-1";
   domainsListPaths = [];
 });
 
@@ -120,20 +104,20 @@ describe("DomainStep domain registration", () => {
     );
   });
 
-  test("checks domains on the onboarding payload's primary assistant", async () => {
-    primaryAssistantId = "assistant-2";
+  test("checks domains on the assistant id the wizard passes in", async () => {
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
 
     render(
       <QueryClientProvider client={client}>
-        <DomainStep onExit={() => {}} />
+        <DomainStep onExit={() => {}} assistantId="assistant-2" />
       </QueryClientProvider>,
     );
 
-    // The onboarding payload's primary assistant wins over the active one.
+    // The provisioning target assistant wins over the active one.
     await waitFor(() => expect(domainsListPaths).toContain("assistant-2"));
+    expect(domainsListPaths).not.toContain("assistant-1");
   });
 });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -1,16 +1,14 @@
 import { Mail } from "lucide-react";
 import { useEffect, useState } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
     assistantsDomainsListQueryKey,
     assistantsListQueryKey,
     organizationsBillingSubscriptionOnboardingDomainCreateMutation,
-    organizationsBillingSubscriptionOnboardingRetrieveOptions,
     organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
-import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { useEnvironmentStore } from "@/stores/environment-store";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
@@ -31,25 +29,21 @@ export function DomainStep({
   onExit,
   machineBusy = false,
   stalledAction,
+  assistantId: preferredAssistantId,
 }: {
   onExit: () => void;
   /** The assistant machine is restarting (webhook-driven resize in flight). */
   machineBusy?: boolean;
   /** Set only while the resize is stalled — offers the manual apply here. */
   stalledAction?: StalledApplyAction;
+  /** The provisioning target assistant (onboarding primary, else active). */
+  assistantId?: string | null;
 }) {
   const queryClient = useQueryClient();
   const emailRootDomain = useEnvironmentStore.use.emailRootDomain();
-  const isOrgReady = useIsOrgReady();
-  // The onboarding payload names the assistant the domain registration
-  // targets server-side; prefer it over the active assistant.
-  const { data: onboarding } = useQuery({
-    ...organizationsBillingSubscriptionOnboardingRetrieveOptions(),
-    enabled: isOrgReady,
-  });
-  const { activeAssistant, assistantId, domains } = useAssistantDomains(
+  const { assistant, assistantId, domains } = useAssistantDomains(
     true,
-    onboarding?.primary_assistant_id,
+    preferredAssistantId,
   );
   const existingDomain = domains?.results[0];
 
@@ -64,10 +58,12 @@ export function DomainStep({
       setPrefilled(true);
       return;
     }
-    if (!activeAssistant?.handle || subdomain) return;
-    setSubdomain(activeAssistant.handle);
+    if (!assistant?.handle || subdomain) {
+      return;
+    }
+    setSubdomain(assistant.handle);
     setPrefilled(true);
-  }, [activeAssistant?.handle, existingDomain, prefilled, subdomain]);
+  }, [assistant?.handle, existingDomain, prefilled, subdomain]);
 
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [confirmed, setConfirmed] = useState(false);

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-assistant-domains.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-assistant-domains.ts
@@ -1,9 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 
-import {
-  assistantsActiveRetrieveOptions,
-  assistantsDomainsListOptions,
-} from "@/generated/api/@tanstack/react-query.gen";
+import { assistantsDomainsListOptions } from "@/generated/api/@tanstack/react-query.gen";
+
+import { usePreferredOrActiveAssistant } from "./use-preferred-or-active-assistant";
 
 /**
  * The assistant targeted by domain setup and its registered email domains —
@@ -13,21 +12,20 @@ import {
  *
  * `preferredAssistantId` (the onboarding payload's `primary_assistant_id`)
  * wins over the active assistant when the two diverge (multi-assistant orgs).
+ * The returned `assistant` is resolved by the same preference so it always
+ * matches the domains being read.
  */
 export function useAssistantDomains(
   enabled = true,
   preferredAssistantId?: string | null,
 ) {
-  const { data: activeAssistant } = useQuery({
-    ...assistantsActiveRetrieveOptions(),
-    enabled,
-  });
-  const assistantId = preferredAssistantId ?? activeAssistant?.id;
+  const assistant = usePreferredOrActiveAssistant(preferredAssistantId, enabled);
+  const assistantId = preferredAssistantId ?? assistant?.id;
   const { data: domains } = useQuery({
     ...assistantsDomainsListOptions({
       path: { assistant_id: assistantId ?? "" },
     }),
     enabled: enabled && !!assistantId,
   });
-  return { activeAssistant, assistantId, domains };
+  return { assistant, assistantId, domains };
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-preferred-or-active-assistant.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-preferred-or-active-assistant.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  assistantsActiveRetrieveOptions,
+  assistantsRetrieveOptions,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type { Assistant } from "@/generated/api/types.gen";
+
+/**
+ * The assistant the pro-onboarding flow is acting on: the preferred assistant
+ * (the onboarding payload's provisioning target) fetched by id when named,
+ * else the active assistant.
+ */
+export function usePreferredOrActiveAssistant(
+  preferredAssistantId?: string | null,
+  enabled = true,
+): Assistant | undefined {
+  const { data: activeAssistant } = useQuery({
+    ...assistantsActiveRetrieveOptions(),
+    enabled: enabled && preferredAssistantId == null,
+  });
+  const { data: preferredAssistant } = useQuery({
+    ...assistantsRetrieveOptions({ path: { id: preferredAssistantId ?? "" } }),
+    enabled: enabled && preferredAssistantId != null,
+  });
+  return preferredAssistantId != null ? preferredAssistant : activeAssistant;
+}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -92,10 +92,13 @@ function makeOperationalStatus(
 let subscriptionPlanId: SubscriptionResponse["plan_id"] = "base";
 let onboardingResponse = makeOnboarding();
 let assistantResponse = makeAssistant("small", 10);
+/** Per-id overrides for the by-id retrieve; falls back to assistantResponse. */
+let assistantsById: Record<string, Assistant> = {};
 let operationalStatusResponse = makeOperationalStatus("active");
 let assistantEndpointsFail = false;
 let onboardingFails = false;
 let assistantCalls = 0;
+let assistantByIdCalls = 0;
 let operationalStatusCalls = 0;
 let subscriptionCalls = 0;
 let isOrgReadyMock = true;
@@ -135,6 +138,16 @@ mock.module("@/generated/api/sdk.gen", () => ({
       return Promise.reject(new Error("502 Bad Gateway"));
     }
     return Promise.resolve({ data: assistantResponse, response: { ok: true } });
+  },
+  assistantsRetrieve: (opts: { path: { id: string } }) => {
+    assistantByIdCalls += 1;
+    if (assistantEndpointsFail) {
+      return Promise.reject(new Error("502 Bad Gateway"));
+    }
+    return Promise.resolve({
+      data: assistantsById[opts.path.id] ?? assistantResponse,
+      response: { ok: true },
+    });
   },
   assistantsOperationalStatusDetailRead: () => {
     operationalStatusCalls += 1;
@@ -201,10 +214,12 @@ beforeEach(() => {
   subscriptionPlanId = "base";
   onboardingResponse = makeOnboarding();
   assistantResponse = makeAssistant("small", 10);
+  assistantsById = {};
   operationalStatusResponse = makeOperationalStatus("active");
   assistantEndpointsFail = false;
   onboardingFails = false;
   assistantCalls = 0;
+  assistantByIdCalls = 0;
   operationalStatusCalls = 0;
   subscriptionCalls = 0;
   isOrgReadyMock = true;
@@ -298,28 +313,36 @@ describe("useProProvisioning", () => {
     await waitFor(() => expect(latest!.state).toBe("DONE"), { timeout: 5000 });
   });
 
-  test("polling stops once DONE", async () => {
-    const { client } = renderProbe();
-    await reachResizing(client);
+  test(
+    "polling stops once DONE",
+    async () => {
+      const { client } = renderProbe();
+      await reachResizing(client);
 
-    assistantResponse = makeAssistant("large", 50);
-    operationalStatusResponse = makeOperationalStatus("active");
-    await refetchAll(client);
-    await waitFor(() => expect(latest!.state).toBe("DONE"), { timeout: 5000 });
+      assistantResponse = makeAssistant("large", 50);
+      operationalStatusResponse = makeOperationalStatus("active");
+      await refetchAll(client);
+      await waitFor(() => expect(latest!.state).toBe("DONE"), {
+        timeout: 5000,
+      });
 
-    // One clock tick may still be in flight when DONE lands; let it drain,
-    // then assert no further polls fire across a full poll interval.
-    await new Promise((resolve) => setTimeout(resolve, 1100));
-    const settledAssistantCalls = assistantCalls;
-    const settledStatusCalls = operationalStatusCalls;
-    const settledSubscriptionCalls = subscriptionCalls;
-    await new Promise((resolve) => setTimeout(resolve, 2600));
+      // One clock tick may still be in flight when DONE lands; let it drain,
+      // then assert no further polls fire across a full poll interval.
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+      const settledAssistantCalls = assistantCalls;
+      const settledByIdCalls = assistantByIdCalls;
+      const settledStatusCalls = operationalStatusCalls;
+      const settledSubscriptionCalls = subscriptionCalls;
+      await new Promise((resolve) => setTimeout(resolve, 2600));
 
-    expect(assistantCalls).toBe(settledAssistantCalls);
-    expect(operationalStatusCalls).toBe(settledStatusCalls);
-    expect(subscriptionCalls).toBe(settledSubscriptionCalls);
-    expect(latest!.state).toBe("DONE");
-  });
+      expect(assistantCalls).toBe(settledAssistantCalls);
+      expect(assistantByIdCalls).toBe(settledByIdCalls);
+      expect(operationalStatusCalls).toBe(settledStatusCalls);
+      expect(subscriptionCalls).toBe(settledSubscriptionCalls);
+      expect(latest!.state).toBe("DONE");
+    },
+    20_000,
+  );
 
   test(
     "resumeAfterManualApply leaves STALLED for RESIZING and can reach DONE",
@@ -359,9 +382,9 @@ describe("useProProvisioning", () => {
 
       // STALLED is not terminal: the actuals polls keep firing so a
       // late-completing server resize can still be observed.
-      const stalledAssistantCalls = assistantCalls;
+      const stalledByIdCalls = assistantByIdCalls;
       await waitFor(
-        () => expect(assistantCalls).toBeGreaterThan(stalledAssistantCalls),
+        () => expect(assistantByIdCalls).toBeGreaterThan(stalledByIdCalls),
         { timeout: 5000 },
       );
 
@@ -484,6 +507,43 @@ describe("useProProvisioning", () => {
     await waitFor(() => expect(latest!.assistantId).toBe("assistant-1"), {
       timeout: 5000,
     });
+  });
+
+  test("actuals track the primary assistant, not the active one", async () => {
+    subscriptionPlanId = "pro";
+    onboardingResponse = {
+      ...makeOnboarding(),
+      primary_assistant_id: "assistant-2",
+    };
+    // The active assistant already satisfies the targets; judging DONE against
+    // it would falsely complete while the primary is still being resized.
+    assistantResponse = makeAssistant("large", 50);
+    assistantsById["assistant-2"] = {
+      ...makeAssistant("small", 10),
+      id: "assistant-2",
+    };
+    const { client } = renderProbe();
+
+    await waitFor(() => expect(latest!.assistantId).toBe("assistant-2"), {
+      timeout: 5000,
+    });
+    await waitFor(
+      () =>
+        expect(latest!.actualsSnapshot).toEqual({
+          machineSize: "small",
+          storageGib: 10,
+        }),
+      { timeout: 5000 },
+    );
+    expect(latest!.state).toBe("WAITING");
+
+    // The resize lands on the primary — only then does the wizard converge.
+    assistantsById["assistant-2"] = {
+      ...makeAssistant("large", 50),
+      id: "assistant-2",
+    };
+    await refetchAll(client);
+    await waitFor(() => expect(latest!.state).toBe("DONE"), { timeout: 5000 });
   });
 
   test("unknown machine tier from a newer backend yields no machine target", async () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -21,6 +21,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   assistantsActiveRetrieveOptions,
   assistantsOperationalStatusDetailReadOptions,
+  assistantsRetrieveOptions,
   organizationsBillingSubscriptionOnboardingRetrieveOptions,
   organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
   organizationsBillingSubscriptionRetrieveOptions,
@@ -85,8 +86,8 @@ export interface ProProvisioningResult {
   actualsSnapshot: ProvisioningDimensions | null;
   /**
    * The assistant provisioning targets: the onboarding payload's primary
-   * assistant when known, else the active assistant from the actuals poll.
-   * Drives the operational-status poll and the stalled manual resize.
+   * assistant when named, else the active assistant. Drives the actuals and
+   * operational-status polls and the stalled manual resize.
    */
   assistantId: string | null;
   /** `domain_setup_available` from the onboarding state, once loaded. */
@@ -233,18 +234,33 @@ export function useProProvisioning({
 
   const pollInterval = tracking ? ACTUALS_POLL_INTERVAL_MS : false;
 
+  // Only resolves the fallback id when the onboarding payload doesn't name a
+  // primary assistant; polls just until an id lands (transient failures while
+  // the pod restarts would otherwise leave the id — and the flow — unresolved).
   const activeAssistantQuery = useQuery({
     ...assistantsActiveRetrieveOptions(),
     enabled: open && orgReady && proConfirmed,
-    refetchInterval: pollInterval,
+    refetchInterval: (query) =>
+      query.state.data?.id != null ? false : pollInterval,
     retry: false,
   });
   // The onboarding payload names the server-side provisioning target; it wins
   // over the active assistant when the two diverge (multi-assistant orgs).
+  // The fallback waits for the onboarding fetch to settle so a slow payload
+  // can't briefly point the polls (and the actuals snapshot) at the wrong
+  // assistant.
   const assistantId =
     onboardingQuery.data?.primary_assistant_id ??
-    activeAssistantQuery.data?.id ??
-    null;
+    (onboardingQuery.isPending ? null : (activeAssistantQuery.data?.id ?? null));
+
+  // Actuals must track the same assistant the wizard targets — under
+  // multi-assistant the active assistant may not be the one being resized.
+  const assistantQuery = useQuery({
+    ...assistantsRetrieveOptions({ path: { id: assistantId ?? "unresolved" } }),
+    enabled: open && orgReady && proConfirmed && assistantId != null,
+    refetchInterval: pollInterval,
+    retry: false,
+  });
 
   const operationalStatusQuery = useQuery({
     ...assistantsOperationalStatusDetailReadOptions({
@@ -276,7 +292,7 @@ export function useProProvisioning({
     };
   }, [onboarding]);
 
-  const assistant = activeAssistantQuery.data;
+  const assistant = assistantQuery.data;
   const actuals = useMemo<ProvisioningDimensions | null>(() => {
     if (!assistant) return null;
     return {

--- a/clients/web/src/hooks/use-is-org-ready.test.tsx
+++ b/clients/web/src/hooks/use-is-org-ready.test.tsx
@@ -6,7 +6,7 @@
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { useEffect } from "react";
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 
 import * as authStore from "@/stores/auth-store";
 
@@ -77,5 +77,23 @@ describe("useIsOrgReady", () => {
     hasPlatformSessionMock = false;
     render(<Probe />);
     expect(latest).toBe(true);
+  });
+
+  test("clearOrganization revokes fallback-only readiness", () => {
+    // Readiness comes solely from the sessionStorage fallback — the store's
+    // id slice is null and stays null through clearOrganization(), so only
+    // the status subscription can deliver the re-render.
+    sessionStorage.setItem(STORAGE_KEY, "org-1");
+    useOrganizationStore.setState({
+      status: "error",
+      error: "Failed to load organizations.",
+    });
+    render(<Probe />);
+    expect(latest).toBe(true);
+
+    act(() => {
+      useOrganizationStore.getState().clearOrganization();
+    });
+    expect(latest).toBe(false);
   });
 });

--- a/clients/web/src/hooks/use-is-org-ready.ts
+++ b/clients/web/src/hooks/use-is-org-ready.ts
@@ -14,9 +14,12 @@ import {
  * can't wedge gated queries when a previous session already knows the org.
  */
 export function useIsOrgReady(): boolean {
-  // Subscribed for reactivity: the sessionStorage fallback only changes
-  // through store actions, so store updates cover every readiness change.
+  // Reactivity: the sessionStorage fallback only changes through store
+  // actions, but not every readiness-affecting action moves the id slice —
+  // `clearOrganization()` while the fallback carried readiness is null → null.
+  // The status slice changes on those transitions, so subscribe to both.
   const currentOrgId = useOrganizationStore.use.currentOrganizationId();
+  useOrganizationStore.use.status();
   const hasPlatformSession = useHasPlatformSession();
   if (!hasPlatformSession) {
     return true;


### PR DESCRIPTION
## Summary
Round-3 remediation for pro-onboarding-wizard-revamp.md: explicit timeouts on the slow escape-flow modal tests (CI-red), actuals/snapshot now track the resolved primary assistant, DomainStep receives the assistant id as a prop, lifecycle selection resolution uses the same org-id fallback as query gating, org-ready hook subscribes to status for full reactivity.