### PR TITLE
fix(voice): only an exact "0" answer holds the endpoint decision

### DIFF
--- a/assistant/src/live-voice/__tests__/front-decision.test.ts
+++ b/assistant/src/live-voice/__tests__/front-decision.test.ts
@@ -205,6 +205,15 @@ describe("createVoiceFrontDecider — decideEndpoint", () => {
     });
     expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
   });
+
+  test('prose starting with "0" (truncated label echo) → release', async () => {
+    const decider = createVoiceFrontDecider({
+      config,
+      getProvider: async () =>
+        stubProvider(async () => textResponse("0 if the speaker")),
+    });
+    expect(await decider.decideEndpoint(input)).toEqual({ action: "release" });
+  });
 });
 
 describe("createVoiceFrontDecider — generateAckText", () => {

--- a/assistant/src/live-voice/front-decision.ts
+++ b/assistant/src/live-voice/front-decision.ts
@@ -89,9 +89,10 @@ const HOLD: VoiceEndpointDecision = { action: "hold" };
 // Single-token wire protocol: the model answers with one bare character
 // instead of a forced tool call. A tool call spends 10-15 output tokens on
 // name + JSON scaffolding to convey one bit; a bare digit is one token, and
-// dropping the tool schema also shrinks the prompt. Only an exact leading
-// "0" holds — every other output (including non-compliance) releases, so the
-// fail-open contract carries the parsing risk.
+// dropping the tool schema also shrinks the prompt. Only an exact (trimmed)
+// "0" holds — every other output, including prose that merely starts with
+// "0" (a truncated label echo like "0 if the speaker..."), releases, so
+// protocol non-compliance always lands on the fail-open side.
 const HOLD_TOKEN = "0";
 
 // Output budget for the single-character answer: one token for the digit
@@ -309,7 +310,7 @@ export function createVoiceFrontDecider(options: {
           },
         });
         const answer = response ? extractText(response) : "";
-        const held = answer.startsWith(HOLD_TOKEN);
+        const held = answer === HOLD_TOKEN;
         log.info(
           {
             action: held ? "hold" : "release",
@@ -332,7 +333,7 @@ export function createVoiceFrontDecider(options: {
           return HOLD;
         }
         // No provider, "1", an empty response, or any non-protocol output
-        // all release — only an explicit leading "0" holds.
+        // all release — only an exact "0" answer holds.
         return RELEASE;
       } catch (error) {
         // providerResolveMs null here means resolution itself never settled


### PR DESCRIPTION
## Summary
- Follow-up to #38563, addressing the Codex P2: `answer.startsWith("0")` treated a truncated label echo like `"0 if the speaker..."` as a hold, contradicting the fail-open contract for protocol non-compliance. The hold check is now exact equality — only a trimmed `"0"` holds; any other output (prose, `"0."`, empty) releases.
- Whitespace tolerance preserved (`extractText` trims, so `" 0\n"` still holds); comments updated to state the exact-match rule; regression test added for the truncated-echo case.

## Original prompt
Codex left a P2 review comment on merged PR #38563 pointing out that prose answers starting with "0" would parse as a hold. Assessment was to forward-fix rather than revert (blast radius is bounded at one or two 1500ms extensions). Pragun asked for the fix as a standalone PR to review and merge manually, not auto-merged via /mainline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)