### PR TITLE
fix(attachments): sniff magic bytes on file-backed uploads and stop mislabeling web re-encodes

### DIFF
--- a/assistant/src/__tests__/attachments-store-heic-normalize.test.ts
+++ b/assistant/src/__tests__/attachments-store-heic-normalize.test.ts
@@ -18,10 +18,21 @@ mock.module("../config/env.js", () => ({
 
 const FAKE_JPEG = Buffer.from("fake-jpeg-master-bytes");
 const FAKE_JPEG_B64 = FAKE_JPEG.toString("base64");
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
 
 mock.module("../util/image-conversion.js", () => ({
   convertImageToJpeg: () => FAKE_JPEG,
   isHeifImage: (bytes: Uint8Array) => bytes.length >= 12,
+  // Minimal stand-in for the real on-disk sniff (covered in
+  // image-conversion.test.ts) — only PNG, which is all these wiring cases need.
+  sniffImageFileMimeType: (path: string) => {
+    try {
+      const head = readFileSync(path).subarray(0, 4);
+      return head.equals(PNG_MAGIC) ? "image/png" : null;
+    } catch {
+      return null;
+    }
+  },
   jpegFilenameFor: (filename: string) =>
     `${filename.replace(/\.[^./\\]+$/, "")}.jpg`,
   normalizeImageBytes: (mimeType: string, bytes: Uint8Array) =>
@@ -65,7 +76,7 @@ import {
 } from "../runtime/routes/attachment-routes.js";
 import type { RouteHandlerArgs } from "../runtime/routes/types.js";
 import { getWorkspaceDir } from "../util/platform.js";
-import { fakeHeifHeaderBytes } from "./heic-fixture.js";
+import { fakeHeifHeaderBytes, PNG_1PX_BYTES } from "./heic-fixture.js";
 
 const uploadRoute = ROUTES.find((r) => r.operationId === "attachment_upload")!;
 const registerRoute = ROUTES.find(
@@ -226,5 +237,27 @@ describe("HEIC upload normalization wiring", () => {
     // Registered files are referenced in place, never rewritten.
     expect(existsSync(registeredPath)).toBe(true);
     expect(readFileSync(registeredPath).equals(HEIC_BYTES)).toBe(true);
+  });
+
+  test("attachment register corrects a mislabeled image MIME", async () => {
+    // A PNG named .jpg — callers hand this path an extension-derived MIME, and
+    // the stored value becomes the media_type on every replay of the message.
+    const registerDir = join(getWorkspaceDir(), "register-fixtures");
+    mkdirSync(registerDir, { recursive: true });
+    const registeredPath = join(registerDir, "renamed.jpg");
+    writeFileSync(registeredPath, PNG_1PX_BYTES);
+
+    const result = (await registerRoute.handler(
+      jsonUploadArgs({
+        path: registeredPath,
+        mimeType: "image/jpeg",
+        filename: "renamed.jpg",
+      }),
+    )) as { id: string; mimeType: string };
+
+    expect(result.mimeType).toBe("image/png");
+    expect(getAttachmentById(result.id)?.mimeType).toBe("image/png");
+    // Only the label is corrected — the registered file is left in place.
+    expect(readFileSync(registeredPath).equals(PNG_1PX_BYTES)).toBe(true);
   });
 });

--- a/assistant/src/__tests__/image-conversion.test.ts
+++ b/assistant/src/__tests__/image-conversion.test.ts
@@ -6,6 +6,9 @@
  * gated on darwin.
  */
 
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeAll, describe, expect, test } from "bun:test";
 
 import {
@@ -15,6 +18,7 @@ import {
   normalizeImageBase64,
   normalizeImageBytes,
   sniffBase64ImageMimeType,
+  sniffImageFileMimeType,
   sniffImageMimeType,
 } from "../util/image-conversion.js";
 import {
@@ -110,6 +114,20 @@ describe("sniffImageMimeType", () => {
     expect(
       sniffBase64ImageMimeType(Buffer.from("not an image").toString("base64")),
     ).toBeNull();
+  });
+
+  test("file variant sniffs from the on-disk head", () => {
+    const dir = mkdtempSync(join(tmpdir(), "vellum-sniff-file-"));
+    // A PNG named .jpg — what arrives when the MIME is extension-derived.
+    const pngPath = join(dir, "photo.jpg");
+    writeFileSync(pngPath, PNG_1PX_BYTES);
+    expect(sniffImageFileMimeType(pngPath)).toBe("image/png");
+
+    const textPath = join(dir, "notes.txt");
+    writeFileSync(textPath, "plain text content");
+    expect(sniffImageFileMimeType(textPath)).toBeNull();
+
+    expect(sniffImageFileMimeType(join(dir, "missing.png"))).toBeNull();
   });
 });
 

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -24,6 +24,7 @@ import {
   jpegFilenameFor,
   normalizeImageBase64,
   normalizeImageBytes,
+  sniffImageFileMimeType,
 } from "../util/image-conversion.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
@@ -612,6 +613,13 @@ export function uploadAttachmentFromBytes(
  *
  * The file stays on disk; the attachment row stores an empty dataBase64 and
  * records the on-disk path in the `file_path` column.
+ *
+ * A declared image MIME that disagrees with the file's magic bytes is
+ * corrected before the row is written. Callers here pass a MIME they were
+ * handed (a signal's attachment metadata, a tool's `mimeType` argument), which
+ * is ultimately extension-derived — and the stored value becomes the
+ * `media_type` on every replay of the message, so a wrong one makes the
+ * provider reject the conversation on every later turn.
  */
 export function uploadFileBackedAttachment(
   filename: string,
@@ -620,7 +628,9 @@ export function uploadFileBackedAttachment(
   sizeBytes: number,
 ): StoredAttachment & { filePath: string } {
   const now = Date.now();
-  const kind = classifyKind(mimeType);
+  const sniffed = sniffImageFileMimeType(filePath);
+  const storedMimeType = sniffed && sniffed !== mimeType ? sniffed : mimeType;
+  const kind = classifyKind(storedMimeType);
   const id = uuid();
   const db = getDb();
 
@@ -628,7 +638,7 @@ export function uploadFileBackedAttachment(
     .values({
       id,
       originalFilename: filename,
-      mimeType,
+      mimeType: storedMimeType,
       sizeBytes,
       kind,
       dataBase64: "",
@@ -647,7 +657,7 @@ export function uploadFileBackedAttachment(
   return {
     id,
     originalFilename: filename,
-    mimeType,
+    mimeType: storedMimeType,
     sizeBytes,
     kind,
     thumbnailBase64: null,

--- a/assistant/src/signals/user-message.ts
+++ b/assistant/src/signals/user-message.ts
@@ -95,7 +95,10 @@ async function dispatchUserMessage(params: {
         resolvedAttachments.push({
           id: stored.id,
           filename: a.filename,
-          mimeType: a.mimeType,
+          // The stored MIME, not the declared one: the store corrects a
+          // declared type that disagrees with the file's magic bytes, and the
+          // queued turn must send what the persisted row says.
+          mimeType: stored.mimeType,
           data: "",
           filePath: a.path,
         });

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -16,10 +16,13 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+  closeSync,
   existsSync,
   mkdirSync,
+  openSync,
   readdirSync,
   readFileSync,
+  readSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -271,6 +274,30 @@ export function sniffImageMimeType(bytes: Uint8Array): string | null {
 export function sniffBase64ImageMimeType(dataBase64: string): string | null {
   // 16 base64 chars decode to the 12 bytes the longest signature needs.
   return sniffImageMimeType(Buffer.from(dataBase64.slice(0, 16), "base64"));
+}
+
+/**
+ * On-disk variant of {@link sniffImageMimeType}, for file-backed attachments
+ * that are never read into memory (recordings can exceed the upload limit).
+ * Reads only the 12-byte head. Returns null when the file is unreadable or the
+ * format is unrecognized, so callers keep the declared MIME.
+ */
+export function sniffImageFileMimeType(filePath: string): string | null {
+  let fd: number;
+  try {
+    fd = openSync(filePath, "r");
+  } catch {
+    return null;
+  }
+  try {
+    const head = Buffer.alloc(12);
+    const bytesRead = readSync(fd, head, 0, 12, 0);
+    return sniffImageMimeType(head.subarray(0, bytesRead));
+  } catch {
+    return null;
+  } finally {
+    closeSync(fd);
+  }
 }
 
 const HEIF_FILENAME_RE = /\.(heic|heif)$/i;

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-image-resize.test.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-image-resize.test.ts
@@ -72,4 +72,18 @@ describe("filenameForResizedImage", () => {
     expect(filenameForResizedImage("photo.jpg")).toBe("photo.jpg");
     expect(filenameForResizedImage("photo.JPEG")).toBe("photo.JPEG");
   });
+
+  test("follows the encoded type when the canvas fell back to PNG", () => {
+    expect(filenameForResizedImage("IMG_5487.HEIC", "image/png")).toBe("IMG_5487.png");
+    expect(filenameForResizedImage("photo.png", "image/png")).toBe("photo.png");
+  });
+
+  test("follows any well-formed image subtype", () => {
+    expect(filenameForResizedImage("photo.png", "image/webp")).toBe("photo.webp");
+  });
+
+  test("falls back to .jpg for a malformed encoded type", () => {
+    expect(filenameForResizedImage("photo.png", "image/svg+xml")).toBe("photo.jpg");
+    expect(filenameForResizedImage("photo.png", "")).toBe("photo.jpg");
+  });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-image-resize.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-image-resize.ts
@@ -74,15 +74,32 @@ export function shouldPrepareImageAttachment(file: Pick<File, "name" | "size" | 
   return shouldAutoResizeImageAttachment(file) || isHeicAttachment(file);
 }
 
-export function filenameForResizedImage(name: string): string {
+/** `image/png` → `png`; both JPEG spellings → `jpg`; anything odd → `jpg`. */
+function extensionForImageType(mimeType: string): string {
+  if (/^image\/jpe?g$/i.test(mimeType)) {
+    return "jpg";
+  }
+  const subtype = mimeType.slice("image/".length).toLowerCase();
+  return /^[a-z0-9]+$/.test(subtype) ? subtype : "jpg";
+}
+
+/**
+ * Rename a re-encoded image to match what the canvas actually produced.
+ * `encodedType` defaults to JPEG because that is what {@link encodeJpeg}
+ * requests — but a UA that cannot encode JPEG falls back to PNG silently, and
+ * the extension has to follow the bytes or the daemon stores a lie.
+ */
+export function filenameForResizedImage(name: string, encodedType = "image/jpeg"): string {
   const fallback = "attachment";
   const trimmedName = name.trim() || fallback;
-  if (/\.(?:jpe?g)$/i.test(trimmedName)) {
+  const extension = extensionForImageType(encodedType);
+  const currentExtension = trimmedName.match(/\.([^./\\]+)$/)?.[1]?.toLowerCase();
+  if (currentExtension === extension || (extension === "jpg" && currentExtension === "jpeg")) {
     return trimmedName;
   }
 
   const withoutExtension = trimmedName.replace(/\.[^./\\]+$/, "") || fallback;
-  return `${withoutExtension}.jpg`;
+  return `${withoutExtension}.${extension}`;
 }
 
 export async function prepareImageAttachmentForUpload(
@@ -130,10 +147,16 @@ export async function prepareImageAttachmentForUpload(
       };
     }
 
+    // `toBlob` may silently fall back to PNG when the UA cannot encode JPEG,
+    // so the File takes the blob's real type rather than the requested one.
+    const encodedType = resizedBlob.type.startsWith("image/")
+      ? resizedBlob.type
+      : "image/jpeg";
+
     return {
       status: "resized",
-      file: new File([resizedBlob], filenameForResizedImage(file.name), {
-        type: "image/jpeg",
+      file: new File([resizedBlob], filenameForResizedImage(file.name, encodedType), {
+        type: encodedType,
         lastModified: file.lastModified,
       }),
     };


### PR DESCRIPTION
## Summary

- `uploadFileBackedAttachment` now corrects a declared image MIME that disagrees with the file's magic bytes, via a new `sniffImageFileMimeType` that reads only the 12-byte head (file-backed attachments are deliberately never read into memory). This closes the last ingress that could persist a wrong `media_type` — signal attachments and `attachment_register` previously needed a provider rejection before the image-recovery plugin healed them.
- The web resize path no longer stamps `image/jpeg` on the re-encoded File regardless of what `canvas.toBlob` produced; per spec a UA that cannot encode JPEG silently falls back to PNG. The File type and its extension now follow the actual blob.
- Tests: on-disk sniff (PNG named .jpg, non-image, missing file), `attachment_register` correcting a mislabeled row, and the web filename following the encoded type.

## Original prompt

Investigating a doctor session where a user was told their conversation had "poisoned history" — old PNG images tagged as JPEG replaying on every turn and 400ing the request, with a new chat as the only escape. That diagnosis was correct: the declared MIME is extension-derived, trusted end-to-end, persisted, and replayed on every subsequent turn.

Most of the intended fix turned out to already be on main as of #38446 (sniffing in `normalizeImageBytes`/`normalizeImageBase64`, the media-type-mismatch pattern in image-recovery `detect.ts`, plus the recovery transform and user-facing classification). This PR covers the two pieces that were still outstanding: the file-backed upload path, which bypassed the sniff entirely, and the web re-encode mislabel.

## Test plan

- Per-file `bun test` (as `scripts/test.ts` runs them — one process per file, because `mock.module` is process-global): `image-conversion` 24 pass, `attachments-store` 56 pass, `attachments-store-heic-normalize` 9 pass, plus `recording-handler`, `attachments`, `conversation-attachments` green.
- `attachment-image-resize.test.ts` (web) 10 pass.
- `tsc --noEmit` and `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSDGhWrDstdrof2cJtFaWk

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->