### PR TITLE
feat(daemon): classify managed-proxy daily credit limit rejections

### DIFF
--- a/assistant/src/__tests__/anthropic-error-formatting.test.ts
+++ b/assistant/src/__tests__/anthropic-error-formatting.test.ts
@@ -206,6 +206,15 @@ describe("AnthropicProvider — semantic reason stamping", () => {
       reason: "insufficient_credits",
     },
     {
+      name: "daily-limit body code → daily_limit_reached (before insufficient_credits)",
+      error: new FakeAPIError(
+        402,
+        '{"code":"daily_limit_reached","detail":"Daily credit limit reached"}',
+        anthropicBody("invalid_request_error"),
+      ),
+      reason: "daily_limit_reached",
+    },
+    {
       name: "5xx → server_error",
       error: new FakeAPIError(503, "internal", anthropicBody("api_error")),
       reason: "server_error",

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -1033,7 +1033,10 @@ describe("classifyConversationError", () => {
       expect(result.userMessage).toContain("Billing settings");
     });
 
-    it("falls back to provider_billing for reason=daily_limit_reached under a user key", () => {
+    it("classifies reason=daily_limit_reached as daily_limit_reached even when the routing map says user-key", () => {
+      // Per-connection platform-auth routes can leave the global routing map
+      // at user-key; the stamped reason comes only from the platform proxy's
+      // body code, so it must win regardless of the map.
       providerRoutingSources.openai = "user-key";
       const err = new ProviderError(
         'OpenAI API error (402): {"code":"daily_limit_reached","detail":"Daily credit limit reached"}',
@@ -1045,7 +1048,7 @@ describe("classifyConversationError", () => {
       const result = classifyConversationError(err, baseCtx);
 
       expect(result.code).toBe("PROVIDER_BILLING");
-      expect(result.errorCategory).toBe("provider_billing");
+      expect(result.errorCategory).toBe("daily_limit_reached");
       expect(result.retryable).toBe(false);
     });
 

--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -1015,6 +1015,56 @@ describe("classifyConversationError", () => {
       expect(result.errorCategory).toBe("context_too_large");
     });
 
+    it("routes reason=daily_limit_reached to PROVIDER_BILLING/daily_limit_reached under managed-proxy", () => {
+      providerRoutingSources["vercel-ai-gateway"] = "managed-proxy";
+      const err = new ProviderError(
+        'Vercel AI Gateway API error (402): {"code":"daily_limit_reached","detail":"Daily credit limit reached"}',
+        "vercel-ai-gateway",
+        402,
+        { reason: "daily_limit_reached" },
+      );
+
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_BILLING");
+      expect(result.errorCategory).toBe("daily_limit_reached");
+      expect(result.retryable).toBe(false);
+      expect(result.userMessage).toContain("daily credit limit");
+      expect(result.userMessage).toContain("Billing settings");
+    });
+
+    it("falls back to provider_billing for reason=daily_limit_reached under a user key", () => {
+      providerRoutingSources.openai = "user-key";
+      const err = new ProviderError(
+        'OpenAI API error (402): {"code":"daily_limit_reached","detail":"Daily credit limit reached"}',
+        "openai",
+        402,
+        { reason: "daily_limit_reached" },
+      );
+
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_BILLING");
+      expect(result.errorCategory).toBe("provider_billing");
+      expect(result.retryable).toBe(false);
+    });
+
+    it("keeps a plain managed-proxy 402 without the daily-limit code as credits_exhausted", () => {
+      providerRoutingSources.openrouter = "managed-proxy";
+      const err = new ProviderError(
+        "OpenRouter API error (402): Payment Required",
+        "openrouter",
+        402,
+        { reason: "insufficient_credits" },
+      );
+
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_BILLING");
+      expect(result.errorCategory).toBe("credits_exhausted");
+      expect(result.retryable).toBe(false);
+    });
+
     it("honors a stamped reason on a statusless ProviderError (no HTTP status)", () => {
       // SDK streaming failures throw with statusCode undefined but can still
       // carry a reason; it must classify semantically, not fall to the fallback.

--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -1457,6 +1457,15 @@ describe("GeminiProvider", () => {
     }
   });
 
+  test("maps a daily-limit 402 body code to daily_limit_reached", async () => {
+    expect(
+      await reasonForApiError(
+        402,
+        '{"code":"daily_limit_reached","detail":"Daily credit limit reached"}',
+      ),
+    ).toBe("daily_limit_reached");
+  });
+
   test("maps 404 / NOT_FOUND to model_not_found", async () => {
     expect(
       await reasonForApiError(404, "NOT_FOUND: model does not exist"),

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -562,6 +562,12 @@ function reasonToClassification(
       return managed
         ? managedBalanceClassification()
         : providerBillingClassification();
+    case "daily_limit_reached":
+      // Only the managed proxy emits the daily-credit-limit code; a user-key
+      // route never produces it, so fall back to the generic billing surface.
+      return managed
+        ? dailyLimitClassification()
+        : providerBillingClassification();
     case "overloaded":
       return providerOverloadedClassification();
     case "server_error":
@@ -695,6 +701,19 @@ function providerBillingClassification(): Omit<
       "Your API provider account or key needs credits. Add funds with the provider or update the key in Settings → Models & Services.",
     retryable: false,
     errorCategory: "provider_billing",
+  };
+}
+
+function dailyLimitClassification(): Omit<
+  ClassifiedConversationError,
+  "debugDetails"
+> {
+  return {
+    code: "PROVIDER_BILLING",
+    userMessage:
+      "You've hit your daily credit limit. Raise the limit in Billing settings to keep going today.",
+    retryable: false,
+    errorCategory: "daily_limit_reached",
   };
 }
 

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -563,11 +563,11 @@ function reasonToClassification(
         ? managedBalanceClassification()
         : providerBillingClassification();
     case "daily_limit_reached":
-      // Only the managed proxy emits the daily-credit-limit code; a user-key
-      // route never produces it, so fall back to the generic billing surface.
-      return managed
-        ? dailyLimitClassification()
-        : providerBillingClassification();
+      // The reason is stamped only from the platform proxy's
+      // `"code":"daily_limit_reached"` body, so it is authoritative on its
+      // own — the global routing map can lag per-connection platform-auth
+      // routes and must not downgrade this to the generic billing surface.
+      return dailyLimitClassification();
     case "overloaded":
       return providerOverloadedClassification();
     case "server_error":

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -4,7 +4,10 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
 import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError, type ProviderErrorReason } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
-import { INSUFFICIENT_CREDITS_PATTERNS } from "../../util/provider-error-patterns.js";
+import {
+  DAILY_LIMIT_PATTERNS,
+  INSUFFICIENT_CREDITS_PATTERNS,
+} from "../../util/provider-error-patterns.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { stripOrphanedSurrogatesDeep } from "../../util/unicode.js";
 import { base64Source, resolveMediaReferences } from "../media-resolve.js";
@@ -116,6 +119,11 @@ export function deriveAnthropicReason(
   const status = error.status;
   const haystack = `${apiType ?? ""} ${error.message ?? ""}`;
 
+  // The managed proxy's daily-limit 402 shares the status with generic credit
+  // exhaustion; match its specific body code first so it isn't swallowed.
+  if (DAILY_LIMIT_PATTERNS.some((re) => re.test(haystack))) {
+    return "daily_limit_reached";
+  }
   if (
     status === 402 ||
     INSUFFICIENT_CREDITS_PATTERNS.some((re) => re.test(haystack)) ||

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -9,6 +9,7 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
 import { isAbortReason } from "../../util/abort-reasons.js";
 import { ProviderError, type ProviderErrorReason } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
+import { DAILY_LIMIT_PATTERNS } from "../../util/provider-error-patterns.js";
 import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { createStreamTimeout } from "../stream-timeout.js";
@@ -241,6 +242,11 @@ export function deriveGeminiReason(error: ApiError): ProviderErrorReason {
   const upper = message.toUpperCase();
   const hasName = (name: string) => upper.includes(name);
 
+  // The managed proxy's daily-limit 402 body carries a specific code; match it
+  // before the status branches so it isn't classified as a generic 4xx.
+  if (DAILY_LIMIT_PATTERNS.some((re) => re.test(message))) {
+    return "daily_limit_reached";
+  }
   if (status === 401 || hasName("UNAUTHENTICATED")) {
     return "invalid_credentials";
   }
@@ -560,9 +566,7 @@ export class GeminiProvider implements Provider {
           error.status,
           // Skip reason on caller-abort: abortReason already carries the intent
           // and short-circuits classification/retry (mirrors the Anthropic client).
-          abortReason
-            ? { abortReason }
-            : { reason: deriveGeminiReason(error) },
+          abortReason ? { abortReason } : { reason: deriveGeminiReason(error) },
         );
       }
       throw new ProviderError(

--- a/assistant/src/providers/openai/__tests__/api-error-normalization.test.ts
+++ b/assistant/src/providers/openai/__tests__/api-error-normalization.test.ts
@@ -375,6 +375,17 @@ describe("deriveReason", () => {
     expect(deriveReason(n(), 402)).toBe("insufficient_credits");
   });
 
+  test("daily-limit body code → daily_limit_reached (before insufficient_credits)", () => {
+    // Both are 402s from the managed proxy; the specific daily-limit code must
+    // win over the generic status-402 → insufficient_credits mapping.
+    expect(
+      deriveReason(
+        n({ rawBody: '{"code":"daily_limit_reached","detail":"limit"}' }),
+        402,
+      ),
+    ).toBe("daily_limit_reached");
+  });
+
   test("billing prose → insufficient_credits", () => {
     expect(
       deriveReason(n({ message: "Your credit balance is too low" }), 400),

--- a/assistant/src/providers/openai/api-error-normalization.ts
+++ b/assistant/src/providers/openai/api-error-normalization.ts
@@ -2,6 +2,7 @@ import type OpenAI from "openai";
 
 import type { ProviderErrorReason } from "../../util/errors.js";
 import {
+  DAILY_LIMIT_PATTERNS,
   INSUFFICIENT_CREDITS_PATTERNS,
   VISION_NOT_SUPPORTED_PATTERNS,
 } from "../../util/provider-error-patterns.js";
@@ -78,6 +79,12 @@ export function deriveReason(
 
   if (VISION_NOT_SUPPORTED_PATTERNS.some((re) => re.test(haystack))) {
     return "vision_unsupported";
+  }
+
+  // The managed proxy's daily-limit 402 shares the status with generic credit
+  // exhaustion; match its specific body code first so it isn't swallowed.
+  if (DAILY_LIMIT_PATTERNS.some((re) => re.test(haystack))) {
+    return "daily_limit_reached";
   }
 
   if (

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -113,6 +113,7 @@ export type ProviderErrorReason =
   | "model_restricted"
   | "model_not_found"
   | "insufficient_credits"
+  | "daily_limit_reached"
   | "rate_limited"
   | "overloaded"
   | "context_overflow"

--- a/assistant/src/util/provider-error-patterns.ts
+++ b/assistant/src/util/provider-error-patterns.ts
@@ -36,3 +36,9 @@ export const INSUFFICIENT_CREDITS_PATTERNS = [
   /insufficient.*credits?/i,
   /key limit (?:has been )?(?:exceeded|reached)/i,
 ];
+
+// Managed-proxy daily-credit-limit rejection: the platform emits a 402 whose
+// body carries `"code": "daily_limit_reached"`. More specific than the generic
+// credit-exhaustion prose above — both are 402s from the same proxy — so
+// classification sites must test this before INSUFFICIENT_CREDITS_PATTERNS.
+export const DAILY_LIMIT_PATTERNS = [/"code"\s*:\s*"daily_limit_reached"/i];


### PR DESCRIPTION
## Summary

When the platform's managed proxy rejects an inference request with HTTP 402 and body code `daily_limit_reached` (org-configured Daily Credit Limit, enforcement landing platform-side), the daemon now classifies it distinctly so clients can render a "Daily Limit Hit" CTA instead of the generic Out of Credit banner:

- New `ProviderErrorReason` `daily_limit_reached`, stamped in the OpenAI/Anthropic/Gemini error normalization when the body matches `"code":"daily_limit_reached"` — checked before the generic insufficient-credits 402 branch so the more specific code isn't swallowed.
- New classification: `code: PROVIDER_BILLING` (reused for wire skew-safety per `assistant/docs/error-handling.md`), `errorCategory: "daily_limit_reached"`, non-retryable, with a raise-your-limit user message. User-key routing falls through to the existing `provider_billing` classification (unreachable in practice — only the managed proxy emits this code).
- Plain 402s without the body code keep the existing `credits_exhausted` behavior (covered by tests).

Safe to ship before platform enforcement exists: the category simply never fires until the platform starts emitting the code. Web banner + settings UI come in a follow-up PR.

Part of the Daily Cost Limits plan: https://app.notion.com/p/3a39035c57bd81bd9d98c1502c56463c

## Testing

- `bun test` on the four touched test suites: 275 pass, 0 fail (new cases: managed-proxy vs user-key routing, plain-402 regression, per-provider reason stamping).
- `bunx tsc --noEmit` clean; lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->