### PR TITLE
feat(web): daily credit limit banner and billing settings card

### DIFF
--- a/clients/web/openapi-schemas/platform.yaml
+++ b/clients/web/openapi-schemas/platform.yaml
@@ -4288,6 +4288,71 @@ paths:
           description: ''
       x-vellum-api-clients:
       - platform
+  /v1/organizations/billing/daily-credit-limit/:
+    get:
+      operationId: organizations_billing_daily_credit_limit_retrieve
+      description: Return the daily limit (or null) and the read-only spend counter.
+      parameters:
+      - in: header
+        name: Vellum-Organization-Id
+        schema:
+          type: string
+          format: uuid
+        description: Required if using Cookie-based or X-Session-Token authentication
+          methods.
+      tags:
+      - organizations
+      security:
+      - VellumAPIKey: []
+      - cookieAuth: []
+      - XSessionTokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DailyCreditLimitResponse'
+          description: ''
+      x-vellum-api-clients:
+      - platform
+    put:
+      operationId: organizations_billing_daily_credit_limit_update
+      description: Set (or clear, via null) the organization's daily credit limit.
+      parameters:
+      - in: header
+        name: Vellum-Organization-Id
+        schema:
+          type: string
+          format: uuid
+        description: Required if using Cookie-based or X-Session-Token authentication
+          methods.
+      tags:
+      - organizations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DailyCreditLimitRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/DailyCreditLimitRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/DailyCreditLimitRequestRequest'
+        required: true
+      security:
+      - VellumAPIKey: []
+      - cookieAuth: []
+      - XSessionTokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DailyCreditLimitResponse'
+          description: ''
+      x-vellum-api-clients:
+      - platform
   /v1/organizations/billing/invoices/:
     get:
       operationId: organizations_billing_invoices_retrieve
@@ -6211,8 +6276,24 @@ components:
         is_degraded:
           type: boolean
           description: True when pending-compute data may be stale or unavailable.
+        daily_credit_limit_usd:
+          type: string
+          nullable: true
+          description: Per-org daily credit spend limit as a decimal string, or null
+            when no daily limit is set.
+        daily_spend_usd:
+          type: string
+          description: Today's (UTC) credit spend as a decimal string. Reported as
+            "0.00" when the stored counter is from a prior UTC day.
+        daily_limit_reached:
+          type: boolean
+          description: True when a daily limit is set and today's spend has reached
+            it.
       required:
       - allowed_top_up_amounts
+      - daily_credit_limit_usd
+      - daily_limit_reached
+      - daily_spend_usd
       - effective_balance
       - effective_balance_usd
       - is_degraded
@@ -6490,6 +6571,32 @@ components:
         * `credits_100` - credits_100
         * `credits_115` - credits_115
         * `credits_200` - credits_200
+    DailyCreditLimitRequestRequest:
+      type: object
+      description: PUT /…/daily-credit-limit/ request body. ``null`` clears the limit.
+      properties:
+        daily_credit_limit_usd:
+          type: string
+          nullable: true
+          minLength: 1
+      required:
+      - daily_credit_limit_usd
+    DailyCreditLimitResponse:
+      type: object
+      description: GET/PUT /…/daily-credit-limit/ response shape.
+      properties:
+        daily_credit_limit_usd:
+          type: string
+          nullable: true
+        current_day_spent_usd:
+          type: string
+        day_bucket:
+          type: string
+          nullable: true
+      required:
+      - current_day_spent_usd
+      - daily_credit_limit_usd
+      - day_bucket
     DetailResponse:
       type: object
       properties:

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -57,6 +57,7 @@ import { ComposerNotices } from "@/domains/chat/components/composer-notices";
 import { ComposerSettingsMenu } from "@/domains/chat/components/composer-settings-menu";
 import { ContextWindowIndicator } from "@/domains/chat/components/context-window-indicator";
 import { CreditsExhaustedBanner } from "@/domains/chat/components/credits-exhausted-banner";
+import { DailyLimitBanner } from "@/domains/chat/components/daily-limit-banner";
 import { MicPermissionPrimer } from "@/domains/chat/components/mic-permission-primer";
 import { OnboardingChoiceCard } from "@/domains/chat/components/onboarding-choice-card";
 import { ProviderBillingBanner } from "@/domains/chat/components/provider-billing-banner";
@@ -370,6 +371,10 @@ export function ChatMainPanel({
 
   const pushToAiSettings = useCallback(() => {
     void navigate(routes.settings.ai);
+  }, [navigate]);
+
+  const pushToBillingSettings = useCallback(() => {
+    void navigate(routes.settings.usageBilling);
   }, [navigate]);
 
   const checkAssistant = useCallback(() => lifecycleService.checkAssistant(), []);
@@ -978,7 +983,9 @@ export function ChatMainPanel({
           onOpenMicSettings={handleOpenMicSettings}
           onOpenTextInsertionSettings={handleOpenTextInsertionSettings}
           billingBannerSlot={
-            billingBannerDecision === "managed_credits" ? (
+            billingBannerDecision === "daily_limit" ? (
+              <DailyLimitBanner onAdjustLimit={pushToBillingSettings} />
+            ) : billingBannerDecision === "managed_credits" ? (
               <CreditsExhaustedBanner
                 onAddFunds={() => setShowAddCreditsModal(true)}
               />

--- a/clients/web/src/domains/chat/components/daily-limit-banner.tsx
+++ b/clients/web/src/domains/chat/components/daily-limit-banner.tsx
@@ -1,0 +1,26 @@
+
+import { CalendarClock } from "lucide-react";
+
+import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
+
+interface DailyLimitBannerProps {
+  onAdjustLimit: () => void;
+}
+
+export function DailyLimitBanner({ onAdjustLimit }: DailyLimitBannerProps) {
+  return (
+    <BillingErrorBanner
+      ariaLabel="Daily credit limit reached"
+      icon={
+        <CalendarClock
+          className="size-5"
+          style={{ color: "var(--content-tertiary)" }}
+        />
+      }
+      title="Daily credit limit reached"
+      subtitle="This limit applies to Vellum credit spend and resets at midnight UTC."
+      ctaLabel="Adjust Limit"
+      onAction={onAdjustLimit}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/utils/error-classification.test.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.test.ts
@@ -36,6 +36,25 @@ describe("chat error classification", () => {
     ).toBe("provider_billing");
   });
 
+  test("classifies daily_limit_reached category as a daily limit banner", () => {
+    const error = {
+      code: "PROVIDER_BILLING",
+      errorCategory: "daily_limit_reached",
+    };
+
+    expect(getChatBillingBannerDecision(error)).toBe("daily_limit");
+    expect(shouldSuppressGenericChatErrorNotice(error)).toBe(true);
+    expect(shouldShowGenericChatErrorNotice(error)).toBe(false);
+  });
+
+  test("matches a namespaced daily_limit_reached category suffix", () => {
+    expect(
+      getChatBillingBannerDecision({
+        errorCategory: "billing.daily_limit_reached",
+      }),
+    ).toBe("daily_limit");
+  });
+
   test("falls back to managed credits for legacy errors with no category", () => {
     const error = { code: "PROVIDER_BILLING" };
 

--- a/clients/web/src/domains/chat/utils/error-classification.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.ts
@@ -8,13 +8,17 @@ export interface ChatErrorLike {
   displayAs?: "inline" | "modal";
 }
 
-export type ChatBillingBannerDecision = "managed_credits" | "provider_billing";
+export type ChatBillingBannerDecision =
+  | "managed_credits"
+  | "provider_billing"
+  | "daily_limit";
 
 const PROVIDER_BILLING_CODE = "PROVIDER_BILLING";
 const PROVIDER_NOT_CONFIGURED_CODE = "PROVIDER_NOT_CONFIGURED";
 const MANAGED_KEY_INVALID_CODE = "MANAGED_KEY_INVALID";
 const MANAGED_CREDITS_EXHAUSTED_CATEGORY = "credits_exhausted";
 const PROVIDER_BILLING_CATEGORY = "provider_billing";
+const DAILY_LIMIT_REACHED_CATEGORY = "daily_limit_reached";
 
 function isManagedCreditsExhausted(
   error: ChatErrorLike | null | undefined,
@@ -36,9 +40,23 @@ function isProviderBilling(
   return error.errorCategory.endsWith(PROVIDER_BILLING_CATEGORY);
 }
 
+function isDailyLimitReached(
+  error: ChatErrorLike | null | undefined,
+): boolean {
+  if (!error?.errorCategory) {
+    return false;
+  }
+
+  return error.errorCategory.endsWith(DAILY_LIMIT_REACHED_CATEGORY);
+}
+
 export function getChatBillingBannerDecision(
   error: ChatErrorLike | null | undefined,
 ): ChatBillingBannerDecision | null {
+  if (isDailyLimitReached(error)) {
+    return "daily_limit";
+  }
+
   if (isManagedCreditsExhausted(error)) {
     return "managed_credits";
   }

--- a/clients/web/src/domains/chat/utils/stream-handlers/error-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/error-handlers.test.ts
@@ -40,6 +40,28 @@ describe("handleConversationErrorEvent", () => {
     expect(ctx.setError).toHaveBeenCalled();
   });
 
+  it("keeps the stream alive for a daily-limit billing error (banner only)", () => {
+    const ctx = makeCtx();
+    handleConversationErrorEvent(
+      {
+        type: "conversation_error",
+        conversationId: "conv-1",
+        code: "PROVIDER_BILLING",
+        errorCategory: "daily_limit_reached",
+        userMessage: "Daily credit limit reached",
+        retryable: false,
+      },
+      ctx,
+    );
+    expect(ctx.setError).toHaveBeenCalledWith({
+      message: "Daily credit limit reached",
+      code: "PROVIDER_BILLING",
+      errorCategory: "daily_limit_reached",
+    });
+    // Billing banner errors are surfaced inline without tearing down the stream.
+    expect(ctx.cancelAndClearStream).not.toHaveBeenCalled();
+  });
+
   it("prefers event.conversationId over streamContext when both differ", () => {
     // Mirror of the same guarantee in `handleMessageComplete` and
     // `handleGenerationCancelled`: a stream teardown that races the

--- a/clients/web/src/domains/settings/components/billing-panel.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel.tsx
@@ -16,6 +16,7 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { StatSquare } from "@vellumai/design-library/components/stat-square";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 import { Typography } from "@vellumai/design-library/components/typography";
+import { DailyCreditLimitCard } from "./daily-credit-limit-card";
 import { LowBalanceAlertCard } from "./low-balance-alert-card";
 
 export const BOOTSTRAP_MAX_RETRIES = 3;
@@ -202,6 +203,9 @@ export function BillingPanel() {
                 </div>
                 <div className="mt-6 border-t border-[var(--border-base)] pt-6">
                     <AutoTopUpCard />
+                </div>
+                <div className="mt-6 border-t border-[var(--border-base)] pt-6">
+                    <DailyCreditLimitCard />
                 </div>
             </Card>
 

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.test.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Tests for DailyCreditLimitCard:
+ *  - renders the current per-org limit in the input when one is set
+ *  - saving a new value PUTs the two-decimal limit body
+ *  - turning the toggle off PUTs `daily_credit_limit_usd: null` to clear it
+ *  - below-minimum input shows an inline error and does NOT call the API
+ *  - `validateDailyLimit` bounds checks (pure)
+ *
+ * The GET is seeded directly into the React Query cache so `useQuery` resolves
+ * synchronously; the PUT SDK function is mocked to capture the request body.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+
+let updateCalls: Array<Record<string, unknown>> = [];
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingDailyCreditLimitUpdate: (
+    opts: Record<string, unknown>,
+  ) => {
+    updateCalls.push(opts);
+    const body = (opts.body ?? {}) as { daily_credit_limit_usd: string | null };
+    return Promise.resolve({
+      data: {
+        daily_credit_limit_usd: body.daily_credit_limit_usd,
+        current_day_spent_usd: "0.00",
+        day_bucket: body.daily_credit_limit_usd == null ? null : "2026-07-20",
+      },
+      response: { ok: true },
+    });
+  },
+}));
+
+import { organizationsBillingDailyCreditLimitRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type { DailyCreditLimitResponse } from "@/generated/api/types.gen";
+
+const { DailyCreditLimitCard, validateDailyLimit } = await import(
+  "./daily-credit-limit-card"
+);
+
+function makeClient(config: DailyCreditLimitResponse): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  client.setQueryData(
+    organizationsBillingDailyCreditLimitRetrieveQueryKey(),
+    config,
+  );
+  return client;
+}
+
+function renderCard(
+  config: DailyCreditLimitResponse,
+): ReturnType<typeof render> {
+  return render(
+    <QueryClientProvider client={makeClient(config)}>
+      <DailyCreditLimitCard />
+    </QueryClientProvider>,
+  );
+}
+
+const OFF: DailyCreditLimitResponse = {
+  daily_credit_limit_usd: null,
+  current_day_spent_usd: "0.00",
+  day_bucket: null,
+};
+
+beforeEach(() => {
+  updateCalls = [];
+});
+
+afterEach(cleanup);
+
+describe("validateDailyLimit", () => {
+  test("rejects empty, below-min, and over-precision values", () => {
+    expect(validateDailyLimit("")).toBe("Enter a daily limit");
+    expect(validateDailyLimit("0.50")).toBe("Must be at least $1");
+    expect(validateDailyLimit("10.123")).toBe("Use at most two decimal places");
+  });
+
+  test("accepts valid amounts ≥ $1", () => {
+    expect(validateDailyLimit("1")).toBeUndefined();
+    expect(validateDailyLimit("25.50")).toBeUndefined();
+  });
+});
+
+describe("DailyCreditLimitCard", () => {
+  test("renders the current limit in the input when set", () => {
+    const { getByTestId } = renderCard({ ...OFF, daily_credit_limit_usd: "25.00" });
+    const input = getByTestId("daily-credit-limit-input") as HTMLInputElement;
+    expect(input.value).toBe("25.00");
+  });
+
+  test("hides the input when the limit is off until the toggle is on", () => {
+    const { queryByTestId, getByRole } = renderCard(OFF);
+    expect(queryByTestId("daily-credit-limit-input")).toBeNull();
+    fireEvent.click(getByRole("switch"));
+    expect(queryByTestId("daily-credit-limit-input")).not.toBeNull();
+  });
+
+  test("saving a new value PUTs the two-decimal limit", async () => {
+    const { getByTestId, getByRole } = renderCard(OFF);
+    fireEvent.click(getByRole("switch"));
+    fireEvent.change(getByTestId("daily-credit-limit-input"), {
+      target: { value: "50" },
+    });
+    fireEvent.click(getByTestId("daily-credit-limit-save-button"));
+
+    await waitFor(() => {
+      if (updateCalls.length === 0) {
+        throw new Error("PUT not called");
+      }
+    });
+    expect(updateCalls[0]!.body).toEqual({ daily_credit_limit_usd: "50.00" });
+  });
+
+  test("turning the toggle off PUTs daily_credit_limit_usd: null", async () => {
+    const { getByRole } = renderCard({ ...OFF, daily_credit_limit_usd: "25.00" });
+    fireEvent.click(getByRole("switch"));
+
+    await waitFor(() => {
+      if (updateCalls.length === 0) {
+        throw new Error("PUT not called");
+      }
+    });
+    expect(updateCalls[0]!.body).toEqual({ daily_credit_limit_usd: null });
+  });
+
+  test("below-minimum input shows an error and does not call the API", () => {
+    const { getByTestId, getByRole, container } = renderCard(OFF);
+    fireEvent.click(getByRole("switch"));
+    fireEvent.change(getByTestId("daily-credit-limit-input"), {
+      target: { value: "0.50" },
+    });
+    fireEvent.click(getByTestId("daily-credit-limit-save-button"));
+
+    expect(container.textContent).toContain("Must be at least $1");
+    expect(updateCalls.length).toBe(0);
+  });
+});

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
@@ -167,6 +167,10 @@ export function DailyCreditLimitCard() {
         <Toggle
           checked={enabled}
           onChange={handleToggleChange}
+          // Locked while a save is in flight: toggling off during a pending
+          // enable would skip the clearing PUT, then the save's onSuccess
+          // would re-enable the limit against the user's last action.
+          disabled={updateMutation.isPending}
           label="Set a daily credit limit"
         />
 

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
@@ -1,0 +1,245 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState, type ChangeEvent } from "react";
+
+import {
+    organizationsBillingDailyCreditLimitRetrieveOptions,
+    organizationsBillingDailyCreditLimitRetrieveQueryKey,
+    organizationsBillingDailyCreditLimitRetrieveSetQueryData,
+    organizationsBillingDailyCreditLimitUpdateMutation,
+    organizationsBillingSummaryRetrieveOptions,
+    organizationsBillingSummaryRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
+import { Button } from "@vellumai/design-library/components/button";
+import { Input } from "@vellumai/design-library/components/input";
+import { Notice } from "@vellumai/design-library/components/notice";
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+/** Format a USD decimal string ("5.00") as "$5.00" for display copy. */
+function formatUsd(value: string): string {
+  const n = parseFloat(value);
+  return Number.isFinite(n) ? `$${n.toFixed(2)}` : `$${value}`;
+}
+
+/**
+ * Validate the daily-limit input against the bounds the backend enforces
+ * (decimal ≥ $1, two decimal places). Exported so unit tests can exercise it
+ * without rendering the card. An empty string is invalid here — turning the
+ * limit off is done via the toggle (which clears it to `null`), not by saving
+ * a blank amount.
+ */
+export function validateDailyLimit(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return "Enter a daily limit";
+  }
+  const n = parseFloat(trimmed);
+  if (!Number.isFinite(n) || n < 1) {
+    return "Must be at least $1";
+  }
+  // Reject more than two decimal places (backend requires exactly two; we pad
+  // on save, but can't silently round away cents the user typed).
+  if (!/^\d+(\.\d{1,2})?$/.test(trimmed)) {
+    return "Use at most two decimal places";
+  }
+  return undefined;
+}
+
+/**
+ * Settings → Billing daily credit limit control. Embedded directly inside the
+ * Credit Balance card by `BillingPanel.tsx`, under its own enable toggle. When
+ * on, an always-visible input caps how much Vellum credit the org can spend per
+ * UTC day; the spend counter resets at midnight UTC. Turning the toggle off
+ * clears the limit (`null`).
+ *
+ * The editable limit comes from the daily-credit-limit endpoint; today's spend
+ * for the progress readout comes from the billing summary. Saving invalidates
+ * both so the summary's `daily_limit_reached`/`daily_spend_usd` stay in sync.
+ */
+export function DailyCreditLimitCard() {
+  const queryClient = useQueryClient();
+  const limitQuery = useQuery(
+    organizationsBillingDailyCreditLimitRetrieveOptions(),
+  );
+  const summaryQuery = useQuery(organizationsBillingSummaryRetrieveOptions());
+  const updateMutation = useMutation(
+    organizationsBillingDailyCreditLimitUpdateMutation(),
+  );
+
+  // `draft === null` means "not yet edited"; seed from the query below. Tracking
+  // the edited value separately keeps the input controlled without an effect
+  // that copies server state into local state.
+  const [draft, setDraft] = useState<string | null>(null);
+  const [touched, setTouched] = useState(false);
+  // Reflects the user's intent to turn the limit on before they've saved an
+  // amount. `null` limit + `pendingEnable` shows the input without a value yet.
+  const [pendingEnable, setPendingEnable] = useState(false);
+
+  if (limitQuery.isLoading) {
+    return (
+      <div data-testid="daily-credit-limit-card">
+        <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
+          Loading…
+        </p>
+      </div>
+    );
+  }
+  if (limitQuery.isError || !limitQuery.data) {
+    return (
+      <div data-testid="daily-credit-limit-card">
+        <Notice tone="error">Failed to load daily credit limit settings.</Notice>
+      </div>
+    );
+  }
+
+  const config = limitQuery.data;
+  const hasLimit = config.daily_credit_limit_usd != null;
+  const enabled = hasLimit || pendingEnable;
+
+  const value = draft ?? (config.daily_credit_limit_usd ?? "");
+  const clientError = validateDailyLimit(value);
+
+  const summary = summaryQuery.data;
+  const dailySpend = summary?.daily_spend_usd ?? config.current_day_spent_usd;
+  const limitReached = summary?.daily_limit_reached === true;
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setDraft(e.target.value);
+  };
+
+  const persist = (dailyCreditLimitUsd: string | null) => {
+    updateMutation.mutate(
+      { body: { daily_credit_limit_usd: dailyCreditLimitUsd } },
+      {
+        onSuccess: (data) => {
+          organizationsBillingDailyCreditLimitRetrieveSetQueryData(
+            queryClient,
+            undefined,
+            data,
+          );
+          void queryClient.invalidateQueries({
+            queryKey: organizationsBillingDailyCreditLimitRetrieveQueryKey(),
+          });
+          // The summary carries the derived `daily_limit_reached` /
+          // `daily_credit_limit_usd` fields the chat banner and this readout
+          // depend on, so refresh it too.
+          void queryClient.invalidateQueries({
+            queryKey: organizationsBillingSummaryRetrieveQueryKey(),
+          });
+          setDraft(null);
+          setTouched(false);
+          if (dailyCreditLimitUsd === null) {
+            setPendingEnable(false);
+          }
+        },
+      },
+    );
+  };
+
+  const handleToggleChange = (next: boolean) => {
+    if (next) {
+      setPendingEnable(true);
+      return;
+    }
+    // Turning off: clear a saved limit; if it was only pending (never saved),
+    // just drop the intent without hitting the API.
+    setPendingEnable(false);
+    setDraft(null);
+    setTouched(false);
+    if (hasLimit) {
+      persist(null);
+    }
+  };
+
+  const handleSave = () => {
+    setTouched(true);
+    if (clientError) {
+      return;
+    }
+    persist(parseFloat(value.trim()).toFixed(2));
+  };
+
+  const showGenericError = updateMutation.isError;
+  const visibleError = touched ? clientError : undefined;
+
+  return (
+    <div data-testid="daily-credit-limit-card">
+      <div className="flex flex-col gap-4">
+        <Toggle
+          checked={enabled}
+          onChange={handleToggleChange}
+          label="Set a daily credit limit"
+        />
+
+        {enabled && (
+          <>
+            <div className="flex flex-wrap items-start gap-3">
+              <div className="w-60 max-w-full">
+                <Input
+                  type="number"
+                  step="0.01"
+                  min="1"
+                  label="Stop spending Vellum credits after"
+                  helperText="Per UTC day. Resets at midnight UTC."
+                  placeholder="0.00"
+                  value={value}
+                  onChange={onChange}
+                  onBlur={() => setTouched(true)}
+                  errorText={visibleError}
+                  data-testid="daily-credit-limit-input"
+                  fullWidth
+                />
+              </div>
+              {/*
+               * `pt-[18px]` aligns the button with the input box (12px label +
+               * 6px gap before the input starts), matching the sibling cards.
+               */}
+              <div className="flex shrink-0 items-center gap-2 pt-[18px]">
+                <Button
+                  variant="primary"
+                  onClick={handleSave}
+                  disabled={updateMutation.isPending}
+                  data-testid="daily-credit-limit-save-button"
+                >
+                  Save
+                </Button>
+              </div>
+            </div>
+
+            {hasLimit && config.daily_credit_limit_usd != null && (
+              <p
+                className="text-body-small-default text-[var(--content-tertiary)]"
+                data-testid="daily-credit-limit-progress"
+              >
+                {formatUsd(dailySpend)} of {formatUsd(config.daily_credit_limit_usd)}{" "}
+                spent today
+              </p>
+            )}
+
+            {limitReached && (
+              <Notice tone="warning" data-testid="daily-credit-limit-reached">
+                Today&apos;s Vellum credit spend has reached this limit.
+                Generation resumes after midnight UTC or when you raise the
+                limit.
+              </Notice>
+            )}
+          </>
+        )}
+      </div>
+
+      <p className="mt-3 text-body-small-default text-[var(--content-tertiary)]">
+        Applies to Vellum credit spend only. Usage billed to your own provider
+        API keys isn&apos;t limited. Resets at midnight UTC.
+      </p>
+
+      {showGenericError && (
+        <Notice
+          tone="error"
+          className="mt-4"
+          data-testid="daily-credit-limit-update-error"
+        >
+          Failed to save daily credit limit. Please try again.
+        </Notice>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Web-client surfaces for the org-configurable **Daily Credit Limit** ([plan](https://app.notion.com/p/3a39035c57bd81bd9d98c1502c56463c)):

- **Chat banner**: new `daily_limit` billing-banner decision when a `conversation_error` carries `errorCategory: daily_limit_reached` (emitted by the daemon per #38573). Renders `DailyLimitBanner` (shared `BillingErrorBanner` shell) in the same composer slot as the Out of Credit banner — CTA "Adjust Limit" → Billing settings. Generic notice suppressed and stream kept alive, matching the other billing decisions.
- **Settings card**: `DailyCreditLimitCard` on the Billing & Usage page beside the low-balance/auto-top-up cards. Toggle (null = off) + dollar amount (≥ $1, 2 decimals), today's spend vs limit readout from the billing summary. Saves via the new platform `daily-credit-limit` GET/PUT endpoints; invalidates both the limit and summary queries. Copy notes it applies to Vellum credit spend only (BYO keys unaffected) and resets at midnight UTC.
- **Schema sync**: `openapi-schemas/platform.yaml` synced from the platform branch (vellum-ai/vellum-assistant-platform#9320); generated client output is gitignored and produced on install.

No client-side flag gate: the `daily-credit-limit` flag gates server-side enforcement and isn't consumable by the client flag registry (gateway/env flags only). The card inherits the billing panel's platform-hosted gating; the banner can only fire when the platform actually emits the error code.

## Merge order

After vellum-ai/vellum-assistant-platform#9320 is merged/deployed (the card's GET hits the new endpoint; until then it shows its error state on platform-hosted orgs).

Part of the Daily Cost Limits plan; companion PRs: platform#9319 (flag), platform#9320 (schema+API), #38573 (daemon).

## Testing

- Scoped `bun test` on the three touched suites: 22 pass, 0 fail.
- `bunx tsc --noEmit` clean; lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->