### PR TITLE
fix(inference): reject an unusable --profile instead of silently answering from the managed default

### DIFF
--- a/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
@@ -10,6 +10,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { LLMSchema } from "../../../config/schemas/llm.js";
 import type { ConfiguredProviderOptions } from "../../../providers/provider-send-message.js";
 import type {
   ProviderResponse,
@@ -48,7 +49,16 @@ mock.module("../../../providers/provider-send-message.js", () => ({
   }),
 }));
 
+// The route reads `llm` for the profile checks only; drive it from the test so
+// a case can present an unusable profile without touching the workspace config.
+let configuredLlm = LLMSchema.parse({});
+mock.module("../../../config/loader.js", () => ({
+  getConfigReadOnly: () => ({ llm: configuredLlm }),
+  getConfig: () => ({ llm: configuredLlm }),
+}));
+
 const { ROUTES } = await import("../inference-send-routes.js");
+const { BadRequestError } = await import("../errors.js");
 
 function inferenceSendHandler() {
   const route = ROUTES.find((r) => r.operationId === "inference_send");
@@ -69,6 +79,7 @@ function baseResponse(overrides: Partial<ProviderResponse>): ProviderResponse {
 }
 
 beforeEach(() => {
+  configuredLlm = LLMSchema.parse({});
   nextResponse = baseResponse({});
   getConfiguredProviderOptions = undefined;
   sendMessageOptions = undefined;
@@ -131,5 +142,45 @@ describe("inference_send evidence", () => {
 
     // THEN no evidence object is fabricated — the endpoint stays unknown
     expect(result.evidence).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Existence in `llm.profiles` is weaker than usability: the resolver also
+// requires the entry to be enabled and to carry its own provider + model, and
+// silently falls through to this call site's `cost-optimized` default when it
+// does not. The route must reject rather than answer from that other model.
+// ---------------------------------------------------------------------------
+
+describe("inference_send profile usability", () => {
+  const hermes = {
+    provider: "openrouter",
+    model: "nousresearch/hermes-3-llama-3.1-405b",
+    source: "user",
+  };
+
+  function rejection(entry: Record<string, unknown>): Promise<Error> {
+    configuredLlm = LLMSchema.parse({ profiles: { "hermes-405b": entry } });
+    return Promise.resolve(
+      inferenceSendHandler()({
+        body: { message: "hi", profile: "hermes-405b" },
+      }),
+    ).then(
+      () => new Error("expected the request to be rejected"),
+      (err: Error) => err,
+    );
+  }
+
+  test("rejects a disabled profile instead of running the managed default", async () => {
+    const err = await rejection({ ...hermes, status: "disabled" });
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect(err.message).toContain("disabled");
+    expect(err.message).toContain("deepseek-v4-flash");
+  });
+
+  test("rejects a profile that lost its provider", async () => {
+    const err = await rejection({ model: hermes.model, source: "user" });
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect(err.message).toContain("incomplete");
   });
 });

--- a/assistant/src/runtime/routes/inference-send-routes.ts
+++ b/assistant/src/runtime/routes/inference-send-routes.ts
@@ -8,6 +8,8 @@
 import { z } from "zod";
 
 import { getEffectiveProfiles } from "../../config/default-profile-catalog.js";
+import type { ResolutionFallbackReason } from "../../config/llm-resolver.js";
+import { selectWinningProfile } from "../../config/llm-resolver.js";
 import { getConfigReadOnly } from "../../config/loader.js";
 import {
   extractAllText,
@@ -33,6 +35,8 @@ async function handleInferenceSend({ body = {} }: RouteHandlerArgs) {
   const profile = body.profile as string | undefined;
   const maxTokens = body.maxTokens as number | undefined;
 
+  const selectionSeed = crypto.randomUUID();
+
   // Validate --profile against the configured profile catalog.
   if (profile !== undefined) {
     const profiles = getEffectiveProfiles(getConfigReadOnly().llm?.profiles);
@@ -46,9 +50,34 @@ async function handleInferenceSend({ body = {} }: RouteHandlerArgs) {
         `Profile "${profile}" is not defined in llm.profiles.${hint}`,
       );
     }
+    // Existence is weaker than usability: the resolver additionally requires
+    // the entry to be enabled and to carry its own provider + model, and
+    // silently falls through to this call site's default (`cost-optimized`)
+    // when it does not. Ask the resolver itself so the check cannot drift from
+    // dispatch, and report the reason it gives rather than answering from a
+    // different — managed, billed — model than the caller named.
+    let reason: ResolutionFallbackReason | undefined;
+    const winner = selectWinningProfile("inference", getConfigReadOnly().llm, {
+      overrideProfile: profile,
+      selectionSeed,
+      onResolutionFallback: (info) => {
+        if (info.requested === profile) {
+          reason = info.reason;
+        }
+      },
+    });
+    if (winner.profileName !== profile) {
+      const target = winner.entry
+        ? `${winner.entry.provider}/${winner.entry.model}`
+        : "the code default";
+      throw new BadRequestError(
+        `Profile "${profile}" is ${reason ?? "unusable"} — the request would silently run on ` +
+          `${winner.profileName ?? "the call-site default"} (${target}) instead. ` +
+          `Fix the profile or omit it.`,
+      );
+    }
   }
 
-  const selectionSeed = crypto.randomUUID();
   const provider = await getConfiguredProvider("inference", {
     overrideProfile: profile,
     selectionSeed,


### PR DESCRIPTION
## What

`POST /v1/inference/send` validated `profile` by key presence in `llm.profiles`. The resolver's gate is stricter — the entry must also be enabled and carry its own `provider` **and** `model` (`config/llm-resolver.ts:256-294`) — and when it fails, selection falls through to the next rung: this call site's `cost-optimized` default, i.e. `accounts/fireworks/models/deepseek-v4-flash`.

The route also passed no `onResolutionFallback`, so the reason the resolver reports (`missing` / `disabled` / `incomplete`) was thrown away. The caller got back an upstream Fireworks 400 naming a model they never asked for.

This route is what Doctor's `probe_symptom` drives, so the failure mode is expensive: it reads as "the runtime is rewriting my model at the provider-connection layer". Nothing is rewritten — the named profile is silently dropped from selection.

## How

Ask `selectWinningProfile` — the same function dispatch uses — whether the named profile actually wins, and 400 with the reported reason plus the model that *would* have run:

```
Profile "hermes-405b" is disabled — the request would silently run on
cost-optimized (fireworks/accounts/fireworks/models/deepseek-v4-flash)
instead. Fix the profile or omit it.
```

Reusing the resolver (rather than duplicating its rules) is the point: the precheck can't drift from dispatch again. Mix profiles still pass — the winner reports the mix's own name. The existing `selectionSeed` is threaded in so the check resolves the same arm the request will.

## Test

Two cases added to the existing route test: a `status: disabled` profile and one that lost its `provider` both 400 instead of returning a deepseek-backed answer. 5/5 in the file pass; typecheck clean.

## Not in scope

`conversation-routes.ts` pins `requestedInferenceProfile` into `conversations.inference_profile` with no validation at all. That pin is rung 1 of the resolution chain — it outranks `llm.activeProfile`, is invisible in `config.json`, and survives a daemon restart. Separate fix, separate call (validate-on-write vs clear-on-unresolvable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bTkrGbhf4YsLDhiWj1tgm
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->