### PR TITLE
refactor(tts): remove the static managed-voice fallback

### DIFF
--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -6,7 +6,6 @@ import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import {
   configGetOptions,
   configGetQueryKey,
-  ttsManagedvoicesGetOptions,
   ttsProvidersGetOptions,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { configPatch, credentialsSetPost } from "@/generated/daemon/sdk.gen";
@@ -31,11 +30,8 @@ import {
   LS_TTS_PROVIDER,
   LS_TTS_VOICE_ID_PREFIX,
 } from "@/domains/settings/ai/local-storage-keys";
-import {
-  DEFAULT_MANAGED_VOICE,
-  MANAGED_VOICE_SOURCE_LABELS,
-  MANAGED_VOICES,
-} from "@/lib/tts/managed-voice-catalog";
+import { MANAGED_VOICE_SOURCE_LABELS } from "@/lib/tts/managed-voice-catalog";
+import { useManagedVoices } from "@/lib/tts/use-managed-voices";
 import { TTS_PROVIDERS } from "@/domains/settings/ai/provider-catalogs";
 
 /**
@@ -119,26 +115,13 @@ export function TextToSpeechCard() {
   const [saving, setSaving] = useState(false);
 
   // Managed (Vellum) voices, fetched live from the platform via the daemon so
-  // the offered list and default track the platform's rate card. The static
-  // catalog stands in while loading and for daemons that predate the route.
-  const { data: managedVoiceData } = useQuery({
-    ...ttsManagedvoicesGetOptions({ path: { assistant_id: assistantId } }),
-    enabled: isOrgReady && draftProvider === "vellum",
-    staleTime: 60_000,
-    // Old daemons 404 this route; the static fallback covers them.
-    retry: false,
-  });
-  // A successful response is authoritative even when empty — an empty
-  // catalog means the platform offers nothing right now, and substituting
-  // the static list would show voices the platform would reject. The static
-  // catalog only stands in when there is no response at all (loading,
-  // errors, daemons that predate the route).
-  const managedVoices = managedVoiceData
-    ? managedVoiceData.voices
-    : MANAGED_VOICES;
-  const defaultManagedVoice = managedVoiceData
-    ? managedVoiceData.defaultModel
-    : DEFAULT_MANAGED_VOICE;
+  // the offered list and default track the platform's rate card. Empty until
+  // loaded — the picker renders only from platform data.
+  const {
+    voices: managedVoices,
+    defaultModel: defaultManagedVoice,
+    fetched,
+  } = useManagedVoices(assistantId, { enabled: draftProvider === "vellum" });
 
   // Managed voice selection. Server value comes from daemon config; absent
   // means the platform default voice.
@@ -464,7 +447,8 @@ export function TextToSpeechCard() {
             </p>
           </div>
         )}
-        {managedVoiceSupported && !selectedManagedVoice && (
+        {/* Gated on `fetched` so the note never flashes while loading. */}
+        {managedVoiceSupported && fetched && !selectedManagedVoice && (
           <p className="text-body-small-default text-[var(--content-tertiary)]">
             No managed voices are currently available.
           </p>

--- a/clients/web/src/lib/tts/managed-voice-catalog.ts
+++ b/clients/web/src/lib/tts/managed-voice-catalog.ts
@@ -1,34 +1,19 @@
 /**
- * Curated voices offered by Vellum managed TTS.
+ * Display helpers for managed (Vellum) TTS voices.
  *
- * The platform gates voices by its billing rate card, so this list must stay
- * a subset of the rate-carded models in vellum-assistant-platform
- * (`BILLING_MANAGED_SPEECH_RATE_CARDS`) — an unlisted model is rejected with
- * `missing_price`. Sample URLs are the upstream provider's public hosted
- * previews.
+ * The voice list itself is fetched from the platform (`useManagedVoices`) —
+ * the platform's billing rate card is the single source of truth for which
+ * voices are offered. This module only holds client-side presentation
+ * helpers for whatever the platform serves.
  */
 
-/**
- * Upstream provider a managed voice is synthesized by.
- */
-export type ManagedVoiceSource = "deepgram" | "elevenlabs";
-
-// Keyed loosely (not by ManagedVoiceSource) so labels also resolve for
-// sources that arrive from the platform voices endpoint before this file
-// learns about them; callers fall back to the raw source string on a miss.
+// Keyed loosely (by string) so labels also resolve for sources that arrive
+// from the platform voices endpoint before this file learns about them;
+// callers fall back to the raw source string on a miss.
 export const MANAGED_VOICE_SOURCE_LABELS: Record<string, string> = {
   deepgram: "Deepgram",
   elevenlabs: "ElevenLabs",
 };
-
-export interface ManagedVoice {
-  /** Upstream model id, e.g. "aura-2-thalia-en". */
-  model: string;
-  label: string;
-  description: string;
-  sampleUrl: string;
-  source: ManagedVoiceSource;
-}
 
 /**
  * Split a voice `description` ("American · calm, smooth, professional") into its
@@ -49,153 +34,3 @@ export function splitVoiceDescription(description: string): {
     traits: description.slice(index + separator.length),
   };
 }
-
-export const DEFAULT_MANAGED_VOICE = "EXAVITQu4vr4xnSDxMaL";
-
-function sample(name: string): string {
-  return `https://static.deepgram.com/examples/Aura-2-${name}.wav`;
-}
-
-const ELEVENLABS_PREVIEWS =
-  "https://storage.googleapis.com/eleven-public-prod/premade/voices";
-
-// Current ElevenLabs default ("premade") voices with their public hosted
-// preview assets; legacy premades (Rachel, Domi, Josh, Antoni) are
-// deliberately absent — the platform no longer offers them.
-function elevenlabs(
-  model: string,
-  label: string,
-  description: string,
-  previewFile: string,
-): ManagedVoice {
-  return {
-    model,
-    label,
-    description,
-    source: "elevenlabs",
-    sampleUrl: `${ELEVENLABS_PREVIEWS}/${model}/${previewFile}`,
-  };
-}
-
-export const MANAGED_VOICES: ManagedVoice[] = [
-  elevenlabs(
-    "EXAVITQu4vr4xnSDxMaL",
-    "Sarah",
-    "American · professional, reassuring, confident",
-    "01a3e33c-6e99-4ee7-8543-ff2216a32186.mp3",
-  ),
-  elevenlabs(
-    "CwhRBWXzGAHq8TQ4Fs17",
-    "Roger",
-    "American · laid-back, casual, resonant",
-    "58ee3ff5-f6f2-4628-93b8-e38eb31806b0.mp3",
-  ),
-  elevenlabs(
-    "Xb7hH8MSUJpSbSDYk0k2",
-    "Alice",
-    "British · clear, engaging, professional",
-    "d10f7534-11f6-41fe-a012-2de1e482d336.mp3",
-  ),
-  elevenlabs(
-    "SAz9YHcvj6GT2YYXdXww",
-    "River",
-    "American · relaxed, neutral, informative",
-    "e6c95f0b-2227-491a-b3d7-2249240decb7.mp3",
-  ),
-  elevenlabs(
-    "cjVigY5qzO86Huf0OWal",
-    "Eric",
-    "American · smooth, trustworthy, classy",
-    "d098fda0-6456-4030-b3d8-63aa048c9070.mp3",
-  ),
-  elevenlabs(
-    "pNInz6obpgDQGcFmaJgB",
-    "Adam",
-    "American · deep, dominant, firm",
-    "d6905d7a-dd26-4187-bfff-1bd3a5ea7cac.mp3",
-  ),
-  {
-    model: "aura-2-thalia-en",
-    label: "Thalia",
-    description: "American · clear, confident, energetic",
-    source: "deepgram",
-    sampleUrl: sample("thalia"),
-  },
-  {
-    model: "aura-2-andromeda-en",
-    label: "Andromeda",
-    description: "American · casual, expressive, comfortable",
-    source: "deepgram",
-    sampleUrl: sample("andromeda"),
-  },
-  {
-    model: "aura-2-helena-en",
-    label: "Helena",
-    description: "American · caring, natural, friendly",
-    source: "deepgram",
-    sampleUrl: sample("helena"),
-  },
-  {
-    model: "aura-2-athena-en",
-    label: "Athena",
-    description: "American · calm, smooth, professional",
-    source: "deepgram",
-    sampleUrl: sample("athena"),
-  },
-  {
-    model: "aura-2-luna-en",
-    label: "Luna",
-    description: "American · friendly, natural, engaging",
-    source: "deepgram",
-    sampleUrl: sample("luna"),
-  },
-  {
-    model: "aura-2-pandora-en",
-    label: "Pandora",
-    description: "British · smooth, calm, melodic",
-    source: "deepgram",
-    sampleUrl: sample("pandora"),
-  },
-  {
-    model: "aura-2-theia-en",
-    label: "Theia",
-    description: "Australian · expressive, polite, sincere",
-    source: "deepgram",
-    sampleUrl: sample("theia"),
-  },
-  {
-    model: "aura-2-apollo-en",
-    label: "Apollo",
-    description: "American · confident, comfortable, casual",
-    source: "deepgram",
-    sampleUrl: sample("apollo"),
-  },
-  {
-    model: "aura-2-arcas-en",
-    label: "Arcas",
-    description: "American · natural, smooth, clear",
-    source: "deepgram",
-    sampleUrl: sample("arcas"),
-  },
-  {
-    model: "aura-2-zeus-en",
-    label: "Zeus",
-    description: "American · deep, trustworthy, smooth",
-    source: "deepgram",
-    sampleUrl: sample("zeus"),
-  },
-  {
-    model: "aura-2-draco-en",
-    label: "Draco",
-    description: "British · warm, approachable, baritone",
-    source: "deepgram",
-    sampleUrl: sample("draco"),
-  },
-  {
-    model: "aura-2-hyperion-en",
-    label: "Hyperion",
-    description: "Australian · caring, warm, empathetic",
-    source: "deepgram",
-    sampleUrl: sample("hyperion"),
-  },
-];

--- a/clients/web/src/lib/tts/use-managed-voices.ts
+++ b/clients/web/src/lib/tts/use-managed-voices.ts
@@ -1,30 +1,25 @@
 /**
  * Fetches the managed (Vellum) TTS voice catalog from the platform via the
- * daemon, with the static catalog standing in while loading and for daemons
- * that predate the `tts/managed-voices` route.
+ * daemon. Fetch-only: the platform is the single source of truth for offered
+ * voices and the default, so until the catalog loads (or when it fails)
+ * `voices` is empty and pickers render nothing rather than a stale local
+ * list. No shipped daemon release predates the `tts/managed-voices` route
+ * (it landed alongside the voice picker itself, before v0.10.11), so there
+ * is no old-daemon population for a static fallback to serve.
  *
  * Shared by the Settings → Voice card and the live-voice voice picker so both
  * offer the same voices and default, tracking the platform's rate card.
- *
- * A successful response is authoritative even when empty — an empty catalog
- * means the platform offers nothing right now, and substituting the static list
- * would surface voices the platform would reject. The static fallback applies
- * only when there is no response at all (loading, errors, old daemons).
  */
 
 import { useQuery } from "@tanstack/react-query";
 
 import { ttsManagedvoicesGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
-import {
-  DEFAULT_MANAGED_VOICE,
-  MANAGED_VOICES,
-} from "@/lib/tts/managed-voice-catalog";
 
 /**
- * A managed voice as offered to the UI. Widens the static catalog's
- * `ManagedVoiceSource` union to `string` so voices the platform serves before
- * this client learns their source still type-check.
+ * A managed voice as offered to the UI. `source` is a plain `string` so
+ * voices the platform serves before this client learns their source still
+ * type-check.
  */
 export interface ManagedVoiceOption {
   model: string;
@@ -35,10 +30,11 @@ export interface ManagedVoiceOption {
 }
 
 export interface UseManagedVoices {
+  /** Offered voices; empty until the platform catalog loads (or on failure). */
   voices: readonly ManagedVoiceOption[];
-  /** Platform default model, or the static default when unfetched. May be null. */
+  /** Platform default model; null until fetched or when none is offered. */
   defaultModel: string | null;
-  /** True once the platform catalog has loaded (vs. the static fallback). */
+  /** True once the platform catalog has loaded. */
   fetched: boolean;
 }
 
@@ -53,13 +49,12 @@ export function useManagedVoices(
     }),
     enabled: isOrgReady && !!assistantId && (options.enabled ?? true),
     staleTime: 60_000,
-    // Old daemons 404 this route; the static fallback covers them.
     retry: false,
   });
 
   return {
-    voices: data ? data.voices : MANAGED_VOICES,
-    defaultModel: data ? data.defaultModel : DEFAULT_MANAGED_VOICE,
+    voices: data?.voices ?? [],
+    defaultModel: data?.defaultModel ?? null,
     fetched: !!data,
   };
 }


### PR DESCRIPTION
## What

Deletes the `MANAGED_VOICES` static catalog and `DEFAULT_MANAGED_VOICE`, making managed voice pickers **fetch-only** — the platform's voices endpoint (backed by the billing rate card) is now the single source of truth end to end, with no client-side copy to drift.

## Why it's safe now (and why waiting doesn't help)

The static fallback existed for one compat case: a daemon with the voice picker (#38373) but without the `tts/managed-voices` route (#38471). **No release was ever cut from that window** — `v0.10.10` (2026-07-16, the latest tag) predates both PRs, verified via `git merge-base --is-ancestor`. So:

- Daemons ≤ v0.10.10 report `supportsVoiceSelection: false` for vellum → no picker renders → the fallback is unreachable.
- Daemons ≥ v0.10.11 have the fetch route → the fallback is unused.

There is no daemon version for which the static list is ever shown. Removing it before v0.10.11 ships means no released bundle ever carried it.

## Changes

- `useManagedVoices`: `voices: []` / `defaultModel: null` until the catalog loads (was: static list / static default).
- Settings card: drops its inline duplicate of the query + fallback logic and consumes the shared hook (it predated the hook and was never migrated); the "No managed voices are currently available" note is gated on `fetched` so it can't flash during load.
- `managed-voice-catalog.ts`: reduced to presentation helpers (`MANAGED_VOICE_SOURCE_LABELS`, `splitVoiceDescription`).

## Behavior change

Only in degraded states: while the catalog loads (or if the fetch fails), the picker renders nothing briefly instead of a static list. The voice-room picker already gated on `voices.length > 0`, so it behaves identically.

## Checks

- `bunx tsc --noEmit` clean; zero remaining references to the removed symbols repo-wide
- Card + voice-list suites: 16/16 pass unmodified (they already exercised fetched-data paths)
- Broad settings/voice-room/lib-tts sweep: failure count identical to clean main (pre-existing env flakiness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wzyf9DgGaff6ALaUnwcdzh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->