### PR TITLE
fix: fence stale primary assistant before polling provisioning actuals

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -12,7 +12,10 @@ import { useEffect } from "react";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-import { organizationsBillingSubscriptionRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import {
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
+  organizationsBillingSubscriptionRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import type {
   Assistant,
@@ -37,6 +40,19 @@ mock.module("./utils", () => ({
 const realDateNow = Date.now.bind(Date);
 let dateNowOffsetMs = 0;
 Date.now = () => realDateNow() + dateNowOffsetMs;
+
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+function makeDeferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 
 function makeSubscription(
   planId: SubscriptionResponse["plan_id"],
@@ -97,6 +113,8 @@ let assistantsById: Record<string, Assistant> = {};
 let operationalStatusResponse = makeOperationalStatus("active");
 let assistantEndpointsFail = false;
 let onboardingFails = false;
+/** Holds the onboarding fetch in flight so isFetching can be observed. */
+let onboardingGate: Deferred | null = null;
 let assistantCalls = 0;
 let assistantByIdCalls = 0;
 let operationalStatusCalls = 0;
@@ -128,10 +146,15 @@ mock.module("@/generated/api/sdk.gen", () => ({
       response: { ok: true },
     });
   },
-  organizationsBillingSubscriptionOnboardingRetrieve: () =>
-    onboardingFails
-      ? Promise.reject(new Error("500 Internal Server Error"))
-      : Promise.resolve({ data: onboardingResponse, response: { ok: true } }),
+  organizationsBillingSubscriptionOnboardingRetrieve: async () => {
+    if (onboardingFails) {
+      throw new Error("500 Internal Server Error");
+    }
+    if (onboardingGate) {
+      await onboardingGate.promise;
+    }
+    return { data: onboardingResponse, response: { ok: true } };
+  },
   assistantsActiveRetrieve: () => {
     assistantCalls += 1;
     if (assistantEndpointsFail) {
@@ -218,6 +241,7 @@ beforeEach(() => {
   operationalStatusResponse = makeOperationalStatus("active");
   assistantEndpointsFail = false;
   onboardingFails = false;
+  onboardingGate = null;
   assistantCalls = 0;
   assistantByIdCalls = 0;
   operationalStatusCalls = 0;
@@ -545,6 +569,143 @@ describe("useProProvisioning", () => {
     await refetchAll(client);
     await waitFor(() => expect(latest!.state).toBe("DONE"), { timeout: 5000 });
   });
+
+  test(
+    "reopen with a stale cached onboarding primary tracks the fresh assistant, not the stale one",
+    async () => {
+      const client = makeClient();
+      // Hold the on-open onboarding refetch in flight so react-query keeps
+      // serving the stale cached payload (isFetching true, isPending false).
+      const gate = makeDeferred();
+      onboardingGate = gate;
+      // A prior wizard session cached onboarding naming assistant-A, which is
+      // already at the purchased targets — the trap the fence must avoid.
+      client.setQueryData(
+        organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+        { ...makeOnboarding(), primary_assistant_id: "assistant-A" },
+        { updatedAt: realDateNow() - 60_000 },
+      );
+      subscriptionPlanId = "pro";
+      // The fresh payload names assistant-B, which is still below the targets.
+      onboardingResponse = {
+        ...makeOnboarding(),
+        primary_assistant_id: "assistant-B",
+      };
+      assistantResponse = {
+        ...makeAssistant("small", 10),
+        id: "assistant-active",
+      };
+      assistantsById["assistant-A"] = {
+        ...makeAssistant("large", 50),
+        id: "assistant-A",
+      };
+      assistantsById["assistant-B"] = {
+        ...makeAssistant("small", 10),
+        id: "assistant-B",
+      };
+      renderProbe(client);
+
+      // While the refetch is in flight the stale primary (assistant-A) must not
+      // drive the polls; the hook falls back to the active assistant and never
+      // latches assistant-A's already-at-target (NOT_APPLICABLE) verdict.
+      await waitFor(
+        () => expect(latest!.assistantId).toBe("assistant-active"),
+        { timeout: 5000 },
+      );
+      expect(latest!.state).toBe("WAITING");
+
+      // Release the refetch: the freshly-settled primary (B, below target) now
+      // drives the polls and freezes the snapshot against B.
+      await act(async () => {
+        gate.resolve();
+        await gate.promise;
+      });
+      await waitFor(() => expect(latest!.assistantId).toBe("assistant-B"), {
+        timeout: 5000,
+      });
+      await waitFor(
+        () =>
+          expect(latest!.actualsSnapshot).toEqual({
+            machineSize: "small",
+            storageGib: 10,
+          }),
+        { timeout: 5000 },
+      );
+      expect(latest!.state).toBe("WAITING");
+
+      // The resize lands on B: because the snapshot tracks B's below-target
+      // "from", the flow converges to DONE rather than NOT_APPLICABLE off A.
+      assistantsById["assistant-B"] = {
+        ...makeAssistant("large", 50),
+        id: "assistant-B",
+      };
+      await refetchAll(client);
+      await waitFor(() => expect(latest!.state).toBe("DONE"), {
+        timeout: 5000,
+      });
+    },
+    20_000,
+  );
+
+  test(
+    "assistantId changing mid-open re-captures the snapshot against the new assistant",
+    async () => {
+      subscriptionPlanId = "pro";
+      onboardingResponse = {
+        ...makeOnboarding(),
+        primary_assistant_id: "assistant-1",
+      };
+      // assistant-1 starts below the large/50 targets; assistant-2 is already
+      // fully provisioned before the wizard ever observes it.
+      assistantsById["assistant-1"] = {
+        ...makeAssistant("small", 10),
+        id: "assistant-1",
+      };
+      assistantsById["assistant-2"] = {
+        ...makeAssistant("large", 50),
+        id: "assistant-2",
+      };
+      const { client } = renderProbe();
+
+      await waitFor(() => expect(latest!.assistantId).toBe("assistant-1"), {
+        timeout: 5000,
+      });
+      await waitFor(
+        () =>
+          expect(latest!.actualsSnapshot).toEqual({
+            machineSize: "small",
+            storageGib: 10,
+          }),
+        { timeout: 5000 },
+      );
+      expect(latest!.state).toBe("WAITING");
+
+      // The fresh onboarding payload re-targets the wizard at assistant-2.
+      onboardingResponse = {
+        ...makeOnboarding(),
+        primary_assistant_id: "assistant-2",
+      };
+      await refetchAll(client);
+      await waitFor(() => expect(latest!.assistantId).toBe("assistant-2"), {
+        timeout: 5000,
+      });
+
+      // The "from" snapshot re-keys to assistant-2's own actuals. A stale
+      // assistant-1 snapshot ({small,10}) would make an already-provisioned
+      // assistant-2 look freshly resized (DONE); tracking the correct "from"
+      // reads it as NOT_APPLICABLE.
+      await waitFor(
+        () =>
+          expect(latest!.actualsSnapshot).toEqual({
+            machineSize: "large",
+            storageGib: 50,
+          }),
+        { timeout: 5000 },
+      );
+      expect(latest!.state).toBe("NOT_APPLICABLE");
+    },
+    20_000,
+  );
 
   test("unknown machine tier from a newer backend yields no machine target", async () => {
     subscriptionPlanId = "pro";

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -140,6 +140,11 @@ export function useProProvisioning({
   const [sawOperation, setSawOperation] = useState(false);
   const [actualsSnapshot, setActualsSnapshot] =
     useState<ProvisioningDimensions | null>(null);
+  // The assistant the frozen snapshot describes, so it can be re-captured when
+  // the provisioning target changes rather than mismatched against new actuals.
+  const [snapshotAssistantId, setSnapshotAssistantId] = useState<string | null>(
+    null,
+  );
   // Wall-clock time as React state so elapsed-time transitions (grace/stall)
   // re-derive between poll responses without impure Date.now() calls in render.
   const [now, setNow] = useState(() => Date.now());
@@ -157,6 +162,7 @@ export function useProProvisioning({
     setResumedAt(null);
     setSawOperation(false);
     setActualsSnapshot(null);
+    setSnapshotAssistantId(null);
     setTracking(true);
   }, [open]);
 
@@ -244,13 +250,21 @@ export function useProProvisioning({
       query.state.data?.id != null ? false : pollInterval,
     retry: false,
   });
+  // The post-confirm onboarding fetch has settled — neither the cold load nor
+  // the refetch from the on-open invalidation is in flight.
+  const onboardingSettled =
+    proConfirmed && !onboardingQuery.isPending && !onboardingQuery.isFetching;
+
   // The onboarding payload names the server-side provisioning target; it wins
-  // over the active assistant when the two diverge (multi-assistant orgs).
-  // The fallback waits for the onboarding fetch to settle so a slow payload
-  // can't briefly point the polls (and the actuals snapshot) at the wrong
-  // assistant.
+  // over the active assistant when the two diverge (multi-assistant orgs). On
+  // reopen the on-open invalidation refetches onboarding while react-query keeps
+  // serving the cached payload (isPending false, isFetching true), so a stale
+  // primary_assistant_id from a prior run must not be trusted until onboarding
+  // has freshly settled — until then fall back to the active assistant so a slow
+  // payload can't briefly point the polls (and the actuals snapshot) at the
+  // wrong assistant.
   const assistantId =
-    onboardingQuery.data?.primary_assistant_id ??
+    (onboardingSettled ? onboardingQuery.data?.primary_assistant_id : null) ??
     (onboardingQuery.isPending ? null : (activeAssistantQuery.data?.id ?? null));
 
   // Actuals must track the same assistant the wizard targets — under
@@ -301,10 +315,23 @@ export function useProProvisioning({
     };
   }, [assistant]);
 
+  const snapshotMatchesAssistant = snapshotAssistantId === assistantId;
+
+  // Freeze the first non-null actuals as the before/after "from" side, keyed to
+  // the assistant it describes. When assistantId changes (e.g. a stale primary
+  // corrected to the fresh one) the by-id assistant query re-keys, so re-capture
+  // the snapshot against the new assistant instead of keeping the previous
+  // one's value.
   useEffect(() => {
-    if (!open || !actuals) return;
-    setActualsSnapshot((prev) => prev ?? actuals);
-  }, [open, actuals]);
+    if (!open || !actuals) {
+      return;
+    }
+    if (actualsSnapshot != null && snapshotMatchesAssistant) {
+      return;
+    }
+    setActualsSnapshot(actuals);
+    setSnapshotAssistantId(assistantId);
+  }, [open, actuals, assistantId, actualsSnapshot, snapshotMatchesAssistant]);
 
   const watchStartedAt = resumedAt ?? proConfirmedAt;
   const msSinceWatchStart =
@@ -313,7 +340,9 @@ export function useProProvisioning({
     planId: proConfirmed ? "pro" : observedPlanId,
     targets,
     actuals,
-    initialActuals: actualsSnapshot,
+    // Only the "from" side captured against the current assistant is valid; a
+    // snapshot from a prior target must never drive the before/after verdict.
+    initialActuals: snapshotMatchesAssistant ? actualsSnapshot : null,
     resizeOperationInFlight,
     sawOperation,
     msSinceWatchStart,
@@ -341,8 +370,7 @@ export function useProProvisioning({
     actualsSnapshot,
     assistantId,
     domainSetupAvailable: onboarding?.domain_setup_available,
-    onboardingSettled:
-      proConfirmed && !onboardingQuery.isPending && !onboardingQuery.isFetching,
+    onboardingSettled,
     confirmError: !proConfirmed && subscriptionQuery.isError,
     // The onboarding endpoint is platform-side (not the restarting assistant
     // machine), so its failure is surfaced — but only when there's no cached


### PR DESCRIPTION
## Summary
Round-4 remediation for pro-onboarding-wizard-revamp.md: gate the primary_assistant_id selection on a freshly-settled onboarding payload (mirror onboardingSettled's isFetching check) so a stale cached id can't be chosen on reopen, and re-key actualsSnapshot on assistantId change so the before/after 'from' snapshot always matches the assistant the actuals describe.