### PR TITLE
fix: keep the fresh primary assistant selected across background refetches

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -571,6 +571,75 @@ describe("useProProvisioning", () => {
   });
 
   test(
+    "background onboarding refetch keeps the fresh primary selected (no flip to active)",
+    async () => {
+      subscriptionPlanId = "pro";
+      onboardingResponse = {
+        ...makeOnboarding(),
+        primary_assistant_id: "assistant-2",
+      };
+      // The active assistant differs from the primary; a flip would re-target
+      // the polls and re-key the snapshot against it.
+      assistantResponse = {
+        ...makeAssistant("small", 10),
+        id: "assistant-active",
+      };
+      assistantsById["assistant-2"] = {
+        ...makeAssistant("small", 10),
+        id: "assistant-2",
+      };
+      const { client } = renderProbe();
+
+      // The fresh primary lands and drives the polls + frozen snapshot.
+      await waitFor(() => expect(latest!.assistantId).toBe("assistant-2"), {
+        timeout: 5000,
+      });
+      await waitFor(
+        () =>
+          expect(latest!.actualsSnapshot).toEqual({
+            machineSize: "small",
+            storageGib: 10,
+          }),
+        { timeout: 5000 },
+      );
+
+      // A background refetch (window-focus / reconnect / incidental
+      // invalidation) puts the onboarding query into isFetching WITHOUT
+      // changing `open`. Because the primary already landed fresh
+      // (dataUpdatedAt >= openedAt), it must stay selected — the polls and the
+      // snapshot must not fall back to the active assistant.
+      const gate = makeDeferred();
+      onboardingGate = gate;
+      await act(async () => {
+        void client.invalidateQueries({
+          queryKey: organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+        });
+        // Let the held refetch enter its isFetching window.
+        await Promise.resolve();
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(latest!.assistantId).toBe("assistant-2");
+      expect(latest!.actualsSnapshot).toEqual({
+        machineSize: "small",
+        storageGib: 10,
+      });
+
+      // The refetch completes: still the primary, snapshot unchanged.
+      await act(async () => {
+        gate.resolve();
+        await gate.promise;
+      });
+      await waitFor(() => expect(latest!.assistantId).toBe("assistant-2"));
+      expect(latest!.actualsSnapshot).toEqual({
+        machineSize: "small",
+        storageGib: 10,
+      });
+    },
+    20_000,
+  );
+
+  test(
     "reopen with a stale cached onboarding primary tracks the fresh assistant, not the stale one",
     async () => {
       const client = makeClient();

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -251,20 +251,30 @@ export function useProProvisioning({
     retry: false,
   });
   // The post-confirm onboarding fetch has settled — neither the cold load nor
-  // the refetch from the on-open invalidation is in flight.
+  // the refetch from the on-open invalidation is in flight. Routing consumes
+  // this ("is domain_setup_available safe to route on yet?"), where "not
+  // currently fetching" is the right question.
   const onboardingSettled =
     proConfirmed && !onboardingQuery.isPending && !onboardingQuery.isFetching;
 
   // The onboarding payload names the server-side provisioning target; it wins
-  // over the active assistant when the two diverge (multi-assistant orgs). On
-  // reopen the on-open invalidation refetches onboarding while react-query keeps
-  // serving the cached payload (isPending false, isFetching true), so a stale
-  // primary_assistant_id from a prior run must not be trusted until onboarding
-  // has freshly settled — until then fall back to the active assistant so a slow
-  // payload can't briefly point the polls (and the actuals snapshot) at the
-  // wrong assistant.
+  // over the active assistant when the two diverge (multi-assistant orgs). Trust
+  // primary_assistant_id only once onboarding has produced a result after this
+  // open (dataUpdatedAt >= openedAt, mirroring subscriptionFresh) — not merely
+  // "not currently fetching". dataUpdatedAt only moves forward, so the primary
+  // survives later background refetches (window-focus, reconnect, invalidation)
+  // instead of transiently dropping to the active assistant and pointing the
+  // polls (and the actuals snapshot) at the wrong one, while a stale pre-open
+  // cached payload is still ignored. Fall back to active until it lands fresh.
+  const primaryAssistantFresh =
+    proConfirmed &&
+    openedAt != null &&
+    onboardingQuery.dataUpdatedAt >= openedAt;
+
   const assistantId =
-    (onboardingSettled ? onboardingQuery.data?.primary_assistant_id : null) ??
+    (primaryAssistantFresh
+      ? onboardingQuery.data?.primary_assistant_id
+      : null) ??
     (onboardingQuery.isPending ? null : (activeAssistantQuery.data?.id ?? null));
 
   // Actuals must track the same assistant the wizard targets — under


### PR DESCRIPTION
## Summary
Round-5 remediation for pro-onboarding-wizard-revamp.md: the primary_assistant_id selection was gated on !isFetching, so any background onboarding refetch (window-focus/reconnect) transiently dropped a valid primary back to the active assistant and could target the wrong assistant for polls/manual resize. Gate primary freshness on dataUpdatedAt >= openedAt instead (mirrors the subscription freshness fence), which stays true across later refetches while still ignoring a stale pre-open cached payload. Routing's onboardingSettled semantics unchanged.