### PR TITLE
test(memory): reset Qdrant breaker after each test to contain cross-file leak

### DIFF
--- a/assistant/src/__tests__/jobs-store-qdrant-breaker.test.ts
+++ b/assistant/src/__tests__/jobs-store-qdrant-breaker.test.ts
@@ -1,4 +1,11 @@
-import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 
 import { eq } from "drizzle-orm";
 
@@ -23,6 +30,12 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
   beforeEach(() => {
     const db = getMemoryDb()!;
     db.run("DELETE FROM memory_jobs");
+    _resetQdrantBreaker();
+  });
+
+  // bun shares module state across a run, so a breaker left open by these cases
+  // (the last one leaves it open) would leak into later test files — reset here.
+  afterEach(() => {
     _resetQdrantBreaker();
   });
 

--- a/assistant/src/persistence/migrations/341-sweep-cacheless-graph-node-vectors.test.ts
+++ b/assistant/src/persistence/migrations/341-sweep-cacheless-graph-node-vectors.test.ts
@@ -9,7 +9,7 @@
  * DB. The sweep function is exercised directly with a fake Qdrant client so its
  * scroll → diff → delete logic is covered without a live Qdrant.
  */
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 const { getDb, getMemorySqlite, getSqliteFrom } =
   await import("../db-connection.js");
@@ -85,6 +85,12 @@ function fakeQdrant(indexedTargetIds: string[]) {
 beforeEach(() => {
   mainRaw().run("DELETE FROM memory_graph_nodes");
   getMemorySqlite()!.run("DELETE FROM memory_jobs");
+  _resetQdrantBreaker();
+});
+
+// bun shares module state across a run, so a breaker left open by the
+// QdrantCircuitOpenError case would leak into later test files — reset it here.
+afterEach(() => {
   _resetQdrantBreaker();
 });
 


### PR DESCRIPTION
Addresses Codex review feedback on #38427.

## Problem
The migration-341 sweep test trips the singleton Qdrant circuit breaker open in its `QdrantCircuitOpenError` case but only reset it in `beforeEach`. bun shares module state across a test run, so the breaker stayed open after the file finished — later suites that claim embed jobs without resetting it (for example the `enqueuePkbIndexJob` cases in `assistant/src/plugins/defaults/memory/jobs/embed-pkb-file.test.ts`) could see `claimMemoryJobs` skip the embed lane and fail depending on file order.

## Fix
- Add an `afterEach(() => _resetQdrantBreaker())` guard to `341-sweep-cacheless-graph-node-vectors.test.ts` so the global breaker state cannot leak out of the file.
- Swept the repo for the same pattern. `jobs-store-qdrant-breaker.test.ts` is the one sibling that uses the real breaker, trips it open across several tests (its last test leaves it open), and reset only in `beforeEach` — applied the same `afterEach` guard there. Other breaker-touching test files either mock the breaker (pass-through, no real state) or reset defensively in `beforeEach` without ever tripping it, so they do not leak.

## Verification
- Both touched files pass solo.
- The two source files followed by `embed-pkb-file.test.ts` in one bun process are green (21/21).