### PR TITLE
fix(web): route fork navigation through navigateToConversation

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
@@ -26,6 +26,7 @@ import {
 import { ApiError } from "@/utils/api-errors";
 import { isElectron } from "@/runtime/is-electron";
 import { openPopoutWindow } from "@/runtime/popout-window";
+import { navigateToConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 import { haptic } from "@/utils/haptics";
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
@@ -120,7 +121,11 @@ export function useConversationSecondaryActions({
           throwOnError: true,
         });
         refreshConversations();
-        void navigate(routes.conversation(data.conversation.id));
+        // The haptic already fired at action start; silence the navigator's
+        // own tap so forking doesn't double-buzz.
+        navigateToConversation(navigate, data.conversation.id, {
+          silent: true,
+        });
       } catch (err) {
         captureError(err, { context: "fork_conversation" });
       }

--- a/clients/web/src/utils/conversation-navigation.test.ts
+++ b/clients/web/src/utils/conversation-navigation.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for the imperative `navigateToConversation` navigator.
+ *
+ * Focus: it resets stale viewer state (main view, subagent / workflow panels),
+ * updates the active conversation, and fires exactly one haptic tap — unless
+ * the caller opts out via `{ silent: true }`. The fork action taps at action
+ * start and routes navigation through this helper, so it relies on `silent`
+ * to avoid a double buzz.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { NavigateFunction } from "react-router";
+
+import { routes } from "@/utils/routes";
+
+const hapticLight = mock(() => {});
+const setMainView = mock((_view: string) => {});
+const subagentReset = mock(() => {});
+const workflowReset = mock(() => {});
+const setActiveConversationId = mock((_id: string) => {});
+
+mock.module("@/utils/haptics", () => ({
+  haptic: {
+    light: hapticLight,
+    medium: () => {},
+    success: () => {},
+    error: () => {},
+  },
+}));
+mock.module("@/stores/viewer-store", () => ({
+  useViewerStore: { getState: () => ({ setMainView }) },
+}));
+mock.module("@/domains/chat/subagent-store", () => ({
+  useSubagentStore: { getState: () => ({ reset: subagentReset }) },
+}));
+mock.module("@/domains/chat/workflow-store", () => ({
+  useWorkflowStore: { getState: () => ({ reset: workflowReset }) },
+}));
+mock.module("@/stores/conversation-store", () => ({
+  useConversationStore: { getState: () => ({ setActiveConversationId }) },
+}));
+
+const { navigateToConversation } = await import(
+  "@/utils/conversation-navigation"
+);
+
+beforeEach(() => {
+  hapticLight.mockClear();
+  setMainView.mockClear();
+  subagentReset.mockClear();
+  workflowReset.mockClear();
+  setActiveConversationId.mockClear();
+});
+
+describe("navigateToConversation", () => {
+  test("resets viewer state, sets the active conversation, taps once, navigates", () => {
+    const navigate = mock((_to: string) => {});
+    navigateToConversation(navigate as unknown as NavigateFunction, "conv-1");
+
+    expect(hapticLight).toHaveBeenCalledTimes(1);
+    expect(setMainView).toHaveBeenCalledWith("chat");
+    expect(subagentReset).toHaveBeenCalledTimes(1);
+    expect(workflowReset).toHaveBeenCalledTimes(1);
+    expect(setActiveConversationId).toHaveBeenCalledWith("conv-1");
+    expect(navigate).toHaveBeenCalledWith(routes.conversation("conv-1"));
+  });
+
+  test("silent suppresses the haptic but still resets state and navigates", () => {
+    const navigate = mock((_to: string) => {});
+    navigateToConversation(navigate as unknown as NavigateFunction, "conv-2", {
+      silent: true,
+    });
+
+    expect(hapticLight).not.toHaveBeenCalled();
+    expect(setMainView).toHaveBeenCalledWith("chat");
+    expect(subagentReset).toHaveBeenCalledTimes(1);
+    expect(workflowReset).toHaveBeenCalledTimes(1);
+    expect(setActiveConversationId).toHaveBeenCalledWith("conv-2");
+    expect(navigate).toHaveBeenCalledWith(routes.conversation("conv-2"));
+  });
+
+  test("messageId anchors navigation to that message and still taps", () => {
+    const navigate = mock((_to: string) => {});
+    navigateToConversation(navigate as unknown as NavigateFunction, "conv-3", {
+      messageId: "msg-9",
+    });
+
+    expect(hapticLight).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith(
+      routes.conversationAtMessage("conv-3", "msg-9"),
+    );
+  });
+});

--- a/clients/web/src/utils/conversation-navigation.ts
+++ b/clients/web/src/utils/conversation-navigation.ts
@@ -11,19 +11,31 @@ import { useViewerStore } from "@/stores/viewer-store";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { getSoundManager } from "@/lib/sounds/sound-manager";
 
+export interface NavigateToConversationOptions {
+  /** Anchor the transcript to a specific message on load. */
+  messageId?: string;
+  /**
+   * Suppress the haptic tap. For callers that already fired their own haptic
+   * at action start (e.g. fork), so the navigation doesn't double-buzz.
+   */
+  silent?: boolean;
+}
+
 /**
- * Navigate to an existing conversation, resetting subagent state and updating
- * the active conversation in the store. Pass `messageId` to anchor the
- * transcript to a specific message on load.
+ * Navigate to an existing conversation, resetting stale viewer state (main
+ * view, subagent / workflow panels) and updating the active conversation in
+ * the store.
  *
  * Pure imperative function — reads stores via `.getState()`, no React hooks.
  */
 export function navigateToConversation(
   navigate: NavigateFunction,
   conversationId: string,
-  options?: { messageId?: string },
+  options?: NavigateToConversationOptions,
 ): void {
-  haptic.light();
+  if (!options?.silent) {
+    haptic.light();
+  }
   useViewerStore.getState().setMainView("chat");
   useSubagentStore.getState().reset();
   useWorkflowStore.getState().reset();


### PR DESCRIPTION
## Summary

Routes `handleForkConversation`'s post-fork navigation through the shared `navigateToConversation()` helper (in `use-conversation-secondary-actions`), so opening the forked conversation resets stale viewer state (main view → chat, subagent/workflow panels) and updates the active-conversation store before navigating — the same stale-viewer bug class fixed in #38411 / #38429. #38429 explicitly flagged the fork path as the intended follow-up in its "deliberately left alone" section.

Previously the fork handler navigated with a bare `navigate(routes.conversation(id))`, so if a full-screen viewer (app viewer, subagent panel, workflow panel) was active when the user forked, the transcript stayed hidden behind that stale viewer.

## Haptic timing decision

Kept the existing immediate `haptic.light()` at action start so the tap is acknowledged instantly, and added a `silent` option to `navigateToConversation` (mirroring `navigateToNewConversation`'s existing `silent`). The fork path passes `{ silent: true }` so the navigator does **not** fire a second haptic on the post-fork navigation — no double-buzz, and feedback is not delayed until after the async fork round-trip completes.

## Files

- `clients/web/src/utils/conversation-navigation.ts` — extracted `NavigateToConversationOptions` and added `silent?: boolean` (guards `haptic.light()`). Existing two/three-arg callers are unaffected (backward compatible).
- `clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts` — fork path routes through `navigateToConversation(navigate, id, { silent: true })`.
- `clients/web/src/utils/conversation-navigation.test.ts` — new unit test covering the `silent` branch plus the existing reset / navigate / `messageId` behavior.

## Tests

`bun test src/utils/conversation-navigation.test.ts` → 3 pass. `bun run typecheck` clean. eslint clean on touched files (the 4 remaining `curly` warnings are pre-existing braceless one-liners on untouched lines).

## Risk

Low — mechanical routing change plus a backward-compatible optional flag on the shared navigator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)