### PR TITLE
fix(chat): preserve non-interactive mode when retrying a background turn

### DIFF
--- a/assistant/src/__tests__/conversation-retry-route.test.ts
+++ b/assistant/src/__tests__/conversation-retry-route.test.ts
@@ -29,6 +29,8 @@ mock.module("../daemon/conversation-process.js", () => ({
   ) =>
     metadata?.hidden === true ||
     typeof metadata?.backgroundEventSource === "string",
+  isBackgroundEventMetadata: (metadata: Record<string, unknown> | undefined) =>
+    typeof metadata?.backgroundEventSource === "string",
 }));
 
 mock.module("../daemon/handlers/conversations.js", () => ({
@@ -314,7 +316,7 @@ describe("POST /v1/conversations/:id/retry", () => {
     expect(typeof (options as { onEvent?: unknown }).onEvent).toBe("function");
   });
 
-  test("hidden machine-signal anchor re-runs as a hidden prompt", async () => {
+  test("background-event anchor re-runs hidden AND non-interactive", async () => {
     discardResult = {
       anchor: anchorRow({
         metadata: JSON.stringify({ backgroundEventSource: "schedule" }),
@@ -333,8 +335,40 @@ describe("POST /v1/conversations/:id/retry", () => {
     expect(res.status).toBe(202);
     await settle();
 
+    // A scheduled/wake anchor was dispatched non-interactively, so the retry
+    // reproduces that background permission mode instead of a foreground chat.
     const [, , options] = ctx.runAgentLoop.mock.calls[0];
-    expect(options).toMatchObject({ isHiddenPrompt: true });
+    expect(options).toMatchObject({
+      isHiddenPrompt: true,
+      isInteractive: false,
+    });
+  });
+
+  test("hidden non-background anchor re-runs hidden but stays interactive", async () => {
+    // A hidden `POST /messages` send (e.g. a proactive greeting from the web
+    // client) is echo-suppressed but was dispatched interactively — only the
+    // background-event marker flips a retry to non-interactive.
+    discardResult = {
+      anchor: anchorRow({ metadata: JSON.stringify({ hidden: true }) }),
+      deletedMessageIds: ["assistant-msg-1"],
+    };
+    const ctx = makeConversation();
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      retryHandler,
+      makeRequest(),
+      { id: "conv-retry-test" },
+      202,
+    );
+    expect(res.status).toBe(202);
+    await settle();
+
+    const [, , options] = ctx.runAgentLoop.mock.calls[0];
+    expect(options).toMatchObject({
+      isHiddenPrompt: true,
+      isInteractive: true,
+    });
   });
 
   test("busy conversation → 409 without claiming processing", async () => {

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -89,8 +89,20 @@ export function isEchoSuppressedUserMessage(
     isHiddenMessageMetadata(metadata) ||
     metadata?.subagentNotification != null ||
     metadata?.acpNotification != null ||
-    typeof metadata?.backgroundEventSource === "string"
+    isBackgroundEventMetadata(metadata)
   );
+}
+
+/**
+ * True when the row is a persisted `<background_event source="...">` trigger —
+ * every wake, scheduled run, and backgrounded-tool completion stamps one (see
+ * {@link persistWakeTriggerMessage}). Such turns are dispatched
+ * non-interactively (clientless/headless).
+ */
+export function isBackgroundEventMetadata(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  return typeof metadata?.backgroundEventSource === "string";
 }
 
 /** Locale-formatted count for the user-facing context stats cards. */

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -31,6 +31,7 @@ import {
 } from "../../daemon/conversation-history.js";
 import {
   formatSummarizeUpToResult,
+  isBackgroundEventMetadata,
   isEchoSuppressedUserMessage,
 } from "../../daemon/conversation-process.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
@@ -708,12 +709,18 @@ async function handleRetryLastAssistantTurn({
   }
 
   const anchor = discarded.anchor;
+  const anchorMetadata = anchor.metadata
+    ? safeParseRecord(anchor.metadata)
+    : undefined;
   // A machine-signal anchor (wake trigger, subagent/ACP notification, hidden
   // send) re-runs as a hidden turn so it stays out of the titler, mirroring
   // how the original turn ran.
-  const isHiddenPrompt = isEchoSuppressedUserMessage(
-    anchor.metadata ? safeParseRecord(anchor.metadata) : undefined,
-  );
+  const isHiddenPrompt = isEchoSuppressedUserMessage(anchorMetadata);
+  // Reproduce the anchor's original permission mode: a background-event turn
+  // ran non-interactively (trust-rule auto-resolution, not blocking prompts),
+  // so forcing interactive would stall a retried scheduled turn on approvals
+  // the original never asked for.
+  const isInteractive = !isBackgroundEventMetadata(anchorMetadata);
   const contentText = extractUserPromptText(anchor.content);
 
   // Fire-and-forget: return 202 immediately, stream the re-run over SSE. The
@@ -731,7 +738,7 @@ async function handleRetryLastAssistantTurn({
       await conversation.runAgentLoop(contentText, anchor.id, {
         onEvent: broadcastMessage,
         isUserMessage: true,
-        isInteractive: true,
+        isInteractive,
         ...(isHiddenPrompt ? { isHiddenPrompt: true } : {}),
       });
     } catch (err) {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -52,6 +52,7 @@ import {
   buildModelInfoEvent,
   formatCleanResult,
   formatCompactResult,
+  isBackgroundEventMetadata,
   isModelSlashCommand,
 } from "../../daemon/conversation-process.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
@@ -891,7 +892,7 @@ export function handleListMessages({
         // row so clients hide it from the transcript like a subagent/ACP
         // notification — the user-facing "Conversation Woke" card (or, for a
         // backgrounded bash run, the inline terminal card) carries the status.
-        if (typeof meta.backgroundEventSource === "string") {
+        if (isBackgroundEventMetadata(meta)) {
           backgroundEventNotification = true;
         }
         // `persistWakeTriggerMessage` stamps the structured completion onto the


### PR DESCRIPTION
## Summary
Addresses Codex review feedback on #38490.

`POST /v1/conversations/:id/retry` already mirrors a hidden anchor's hidden-ness (`isHiddenPrompt`) so a re-run "mirrors how the original turn ran", but it hardcoded `isInteractive: true`. Scheduled/wake/background-tool turns are dispatched non-interactively (clientless/headless), where side-effecting tools resolve against trust rules instead of blocking on prompts. Forcing interactive made a retried background turn rerun as a foreground chat that stalls waiting for approvals the original never asked for.

## Change
- Derive `isInteractive` from the anchor metadata: a `backgroundEventSource` marker (stamped by every wake/scheduled/backgrounded-tool trigger via `persistWakeTriggerMessage`) → re-run non-interactive; every other anchor stays interactive.
- Extracted the `backgroundEventSource` check — previously inlined in `isEchoSuppressedUserMessage` and the list-messages display filter — into a shared `isBackgroundEventMetadata()` predicate and reused it in all three sites (SOT).
- Parse the anchor metadata once and share it between the `isHiddenPrompt` and `isInteractive` derivations.

## Design note
Keyed off `backgroundEventSource` rather than the broader `isEchoSuppressedUserMessage` (`!isHiddenPrompt`) on purpose. Echo-suppression also covers hidden `POST /messages` sends (e.g. a proactive greeting) and subagent/ACP notifications, which run *interactively* when a client is present — `!isHiddenPrompt` would have wrongly flipped those to non-interactive. `backgroundEventSource` is the deterministic "ran headless" signal, so it reproduces the original mode without regressing interactive hidden turns. The retry is user-initiated, but the feature's design principle is that a retry reproduces the original turn, and background permission semantics are part of a faithful reproduction.

## Tests
Extended `conversation-retry-route.test.ts`:
- background-event anchor → `runAgentLoop` called with `isInteractive: false` (and still `isHiddenPrompt: true`).
- hidden-but-non-background anchor → `isHiddenPrompt: true` but `isInteractive: true` (proves the distinction).
- normal user anchor → `isInteractive: true` (existing case, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)