### PR TITLE
fix(empty-response): keep sibling-thread tool pairs in refusal quarantine

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -6400,6 +6400,122 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(serialized).toContain("hi assistant");
     expect(serialized).toContain("back to normal");
   });
+
+  test("keeps a sibling thread's tool pair interleaved inside a refused exchange", () => {
+    // @alice's flagged prompt roots her thread and the refusal fallback lands
+    // back in it. In between, @bob's own thread runs a tool call: the assistant
+    // posts a Slack-visible interim + `tool_use` (keyed to @bob's thread) and
+    // the tool returns a synthetic `tool_result` with no Slack provenance (keys
+    // `null`).
+    //
+    // The null-keyed result must be tied back to its @bob `tool_use` and kept —
+    // dropping it as refused-exchange churn would orphan the sibling `tool_use`
+    // the walk-back leaves in place, and orphan-tool pruning already ran during
+    // rendering, so that half-pair would ship to the provider and hard-fail.
+    const CHANNEL_ID = "C0MULTI03";
+    const SLACK_CAPS_CHANNEL: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "channel",
+    };
+    const T_HI = "1699971900.000100";
+    const T_PROMPT = "1699972000.000200"; // roots @alice's thread (refused)
+    const T_BOB_PROMPT = "1699972010.000250"; // roots @bob's sibling thread
+    const T_BOB_TOOLUSE = "1699972020.000300"; // assistant interim + tool_use, @bob's thread
+    const T_FALLBACK = "1699972060.000400"; // assistant refusal, in @alice's thread
+    const T_LATER = "1699972200.000500";
+    const meta = (
+      channelTs: string,
+      displayName: string,
+      threadTs?: string,
+    ): SlackMessageMetadata => ({
+      source: "slack",
+      channelId: CHANNEL_ID,
+      channelTs,
+      ...(threadTs ? { threadTs } : {}),
+      eventKind: "message",
+      displayName,
+    });
+    const rows: SlackTranscriptInputRow[] = [
+      row(
+        "user",
+        "hi assistant",
+        1699971900_000,
+        metadataEnvelope(meta(T_HI, "@alice")),
+      ),
+      row(
+        "user",
+        "disallowed question",
+        1699972000_000,
+        metadataEnvelope(meta(T_PROMPT, "@alice")),
+      ),
+      // @bob opens a sibling thread with a request that runs a tool.
+      row(
+        "user",
+        "bob needs help",
+        1699972010_000,
+        metadataEnvelope(meta(T_BOB_PROMPT, "@bob")),
+      ),
+      // Assistant interim reply + tool_use for @bob — Slack-visible, threaded
+      // under @bob's prompt, so it keys to @bob's thread.
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "checking for bob" },
+          { type: "tool_use", id: "tu_sib", name: "search", input: { q: "y" } },
+        ]),
+        createdAt: 1699972020_000,
+        metadata: metadataEnvelope(
+          meta(T_BOB_TOOLUSE, "@assistant", T_BOB_PROMPT),
+        ),
+      },
+      // @bob's synthetic tool_result — NOT sent to Slack, so no slackMeta.
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu_sib", content: "for bob" },
+        ]),
+        createdAt: 1699972030_000,
+        metadata: metadataEnvelope(null),
+      },
+      row(
+        "assistant",
+        REFUSAL_FALLBACK_TEXT,
+        1699972060_000,
+        metadataEnvelope(meta(T_FALLBACK, "@assistant", T_PROMPT)),
+      ),
+      row(
+        "user",
+        "back to normal",
+        1699972200_000,
+        metadataEnvelope(meta(T_LATER, "@alice")),
+      ),
+    ];
+
+    const result = assembleSlackChronologicalMessages(rows, SLACK_CAPS_CHANNEL);
+    expect(result).not.toBeNull();
+    const blocks = result!.flatMap((m) => m.content);
+    // @bob's tool pair survives intact — both halves, same id, no orphan.
+    const toolUseIds = blocks.flatMap((b) =>
+      b.type === "tool_use" ? [b.id] : [],
+    );
+    const toolResultIds = blocks.flatMap((b) =>
+      b.type === "tool_result" ? [b.tool_use_id] : [],
+    );
+    expect(toolUseIds).toEqual(["tu_sib"]);
+    expect(toolResultIds).toEqual(["tu_sib"]);
+    const serialized = JSON.stringify(result);
+    // The refusal and the prompt that tripped it are both gone …
+    expect(serialized).not.toContain(REFUSAL_FALLBACK_TEXT);
+    expect(serialized).not.toContain("disallowed question");
+    // … @bob's whole sibling exchange and the benign turns are untouched.
+    expect(serialized).toContain("bob needs help");
+    expect(serialized).toContain("checking for bob");
+    expect(serialized).toContain("hi assistant");
+    expect(serialized).toContain("back to normal");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/empty-response-hook.test.ts
+++ b/assistant/src/__tests__/empty-response-hook.test.ts
@@ -720,6 +720,42 @@ describe("computeRefusedExchangeDrops — thread-scoped pairing", () => {
     const kept = messages.filter((_, i) => !dropIndices.has(i));
     expect(kept).toEqual([userPrompt("legacy provenance-less prompt")]);
   });
+
+  test("keeps a sibling thread's intact tool pair interleaved before the fallback", () => {
+    // A sibling thread's exchange lands between the refused prompt and the
+    // fallback: its assistant `tool_use` is Slack-visible (keyed to the sibling
+    // thread B) but its synthetic `tool_result` has no provenance (keyed null).
+    // The null-keyed result must be tied back to its sibling `tool_use` and left
+    // in place — dropping it as generic churn would orphan the kept `tool_use`
+    // (the transcript's orphan-tool prune has already run) and hard-fail the
+    // provider, the exact failure this pairing guards against.
+    const messages = [
+      userPrompt("flagged prompt"), // 0, thread P (refused)
+      toolUseTurn("tu_sib"), // 1, thread B (sibling, Slack-visible)
+      toolResultTurn("tu_sib"), // 2, null (sibling synthetic result)
+      refusalFallbackTurn, // 3, thread P
+    ];
+    const threadKeys = ["P", "B", null, "P"];
+    const { dropIndices, droppedExchanges } = computeRefusedExchangeDrops(
+      messages,
+      { threadKeys },
+    );
+    expect(droppedExchanges).toBe(1);
+    // Only the refused prompt and its fallback go; the sibling pair is intact.
+    expect([...dropIndices].sort((a, b) => a - b)).toEqual([0, 3]);
+    const kept = messages.filter((_, i) => !dropIndices.has(i));
+    expect(kept).toEqual([toolUseTurn("tu_sib"), toolResultTurn("tu_sib")]);
+    // No half-pair: every surviving tool_use is matched by its tool_result.
+    const producedIds = kept.flatMap((m) =>
+      m.content.flatMap((b) => (b.type === "tool_use" ? [b.id] : [])),
+    );
+    const consumedIds = kept.flatMap((m) =>
+      m.content.flatMap((b) =>
+        b.type === "tool_result" ? [b.tool_use_id] : [],
+      ),
+    );
+    expect(consumedIds).toEqual(producedIds);
+  });
 });
 
 describe("empty-response user-prompt-submit hook", () => {

--- a/assistant/src/context/refusal-quarantine.ts
+++ b/assistant/src/context/refusal-quarantine.ts
@@ -64,6 +64,33 @@ export function isRefusalFallbackMessage(message: Message): boolean {
 }
 
 /**
+ * Whether a synthetic (always null-keyed) `tool_result` row pairs with a
+ * `tool_use` produced in a *sibling* Slack thread — a non-null thread other than
+ * the refused fallback's. Such a result belongs to that sibling exchange, so the
+ * thread-scoped walk-back must leave it in place: it keeps the sibling
+ * `tool_use`, and dropping only the result would strand a half-pair past the
+ * transcript's earlier orphan-tool prune. Returns false for a result whose
+ * `tool_use` is same-thread, itself null-keyed, or absent — that churn is the
+ * refused exchange's and is dropped.
+ */
+function pairsWithSiblingThreadToolUse(
+  message: Message,
+  toolUseThreadKey: ReadonlyMap<string, string | null>,
+  fallbackThreadKey: string | null,
+): boolean {
+  if (!isToolResultMessage(message)) {
+    return false;
+  }
+  return message.content.some((block) => {
+    if (block.type !== "tool_result") {
+      return false;
+    }
+    const toolUseKey = toolUseThreadKey.get(block.tool_use_id);
+    return toolUseKey != null && toolUseKey !== fallbackThreadKey;
+  });
+}
+
+/**
  * Indices of every message belonging to a previously-refused exchange: for each
  * assistant message that is exactly the refusal fallback, its own index plus the
  * run back to (and including) the genuine user prompt that tripped it — the
@@ -84,13 +111,16 @@ export function isRefusalFallbackMessage(message: Message): boolean {
  *   walk-back keeps only the refused exchange and leaves the rest in place:
  *     - a row in another (non-null) thread is a genuine interleaved post —
  *       left in place;
- *     - a null-keyed row has no Slack provenance. Synthetic tool churn
- *       (assistant `tool_use` turns and their `tool_result` rows) is never
- *       Slack-visible, so it always keys `null` even mid-thread; it belongs to
- *       the refused exchange and is dropped. Leaving it behind would strand
- *       half a tool pair, and the Slack transcript's orphan-tool prune runs
- *       *before* this sweep, so nothing would repair the resulting invalid
- *       history. A null-keyed genuine user prompt is a different turn
+ *     - a null-keyed row has no Slack provenance. A synthetic `tool_result`
+ *       (never Slack-visible, so always null-keyed) is tied back to its
+ *       `tool_use` by id: if that `tool_use` sits in another (non-null) thread,
+ *       the pair is a sibling exchange's — the walk-back keeps the `tool_use`,
+ *       so its result is kept too rather than stranded as a half-pair. Any other
+ *       null-keyed tool churn (its `tool_use` is same-thread or itself
+ *       null-keyed) belongs to the refused exchange and is dropped; the Slack
+ *       transcript's orphan-tool prune runs *before* this sweep, so a stranded
+ *       half-pair would otherwise reach the provider as invalid history. A
+ *       null-keyed genuine user prompt is a different turn
  *       (legacy/provenance-less), so it is left in place and the walk continues
  *       to the same-thread prompt.
  *   A `null` fallback key (non-Slack / legacy) always uses adjacency.
@@ -108,21 +138,32 @@ export function computeRefusedExchangeDrops(
   droppedExchanges: number;
 } {
   const { threadKeys } = opts;
-  // A thread key only carries pairing signal when it is shared: a lone
-  // top-level or DM row has its own `channelTs` as its key, so treating it as a
-  // one-message "thread" would strand the prompt. Count keys once so each
-  // fallback can tell whether it sits in a real (multi-row) thread.
+  // Two lookups derived from the per-message thread keys (aligned 1:1 with
+  // `messages`):
+  //  - `sharedThreadKeys`: keys appearing on more than one row. A thread key
+  //    only carries pairing signal when it is shared — a lone top-level/DM row
+  //    keys by its own `channelTs`, so treating it as a one-message "thread"
+  //    would strand the prompt.
+  //  - `toolUseThreadKey`: each `tool_use` id → the thread key of the row that
+  //    produced it, so a synthetic (always null-keyed) `tool_result` can be tied
+  //    back to the thread its `tool_use` belongs to.
   const sharedThreadKeys = new Set<string>();
+  const toolUseThreadKey = new Map<string, string | null>();
   if (threadKeys) {
     const seen = new Set<string>();
-    for (const key of threadKeys) {
-      if (key === null) {
-        continue;
+    for (let i = 0; i < messages.length; i++) {
+      const key = threadKeys[i] ?? null;
+      if (key !== null) {
+        if (seen.has(key)) {
+          sharedThreadKeys.add(key);
+        } else {
+          seen.add(key);
+        }
       }
-      if (seen.has(key)) {
-        sharedThreadKeys.add(key);
-      } else {
-        seen.add(key);
+      for (const block of messages[i].content) {
+        if (block.type === "tool_use") {
+          toolUseThreadKey.set(block.id, key);
+        }
       }
     }
   }
@@ -145,15 +186,25 @@ export function computeRefusedExchangeDrops(
     for (let s = r - 1; s >= 0; s--) {
       const isGenuinePrompt =
         messages[s].role === "user" && !isToolResultMessage(messages[s]);
-      // Under thread scope, leave rows outside the fallback's thread in place —
-      // genuine interleaved posts from other (non-null) threads, and
-      // provenance-less genuine prompts (someone else's turn). Drop only
-      // null-keyed tool churn: this refused exchange's own synthetic
-      // tool_use / tool_result rows, which would otherwise strand half a tool
-      // pair past the earlier orphan prune.
+      // Under thread scope, leave rows outside the fallback's thread in place:
+      //  - a genuine interleaved post from another (non-null) thread;
+      //  - a provenance-less genuine prompt (someone else's turn);
+      //  - a synthetic `tool_result` whose `tool_use` sits in a sibling thread —
+      //    dropping it would orphan that kept sibling `tool_use`.
+      // Everything else outside the thread is this refused exchange's own
+      // null-keyed tool churn, dropped so it can't strand half a tool pair past
+      // the earlier orphan prune.
       if (threadScope) {
         const key = threadScope[s] ?? null;
-        if (key !== fallbackThreadKey && (key !== null || isGenuinePrompt)) {
+        const keepOutsideThread =
+          key !== null ||
+          isGenuinePrompt ||
+          pairsWithSiblingThreadToolUse(
+            messages[s],
+            toolUseThreadKey,
+            fallbackThreadKey,
+          );
+        if (key !== fallbackThreadKey && keepOutsideThread) {
           continue;
         }
       }


### PR DESCRIPTION
Addresses Codex review feedback on #38425.

## Problem

The thread-scoped walk-back in `computeRefusedExchangeDrops` dropped **every** null-keyed tool row as refused-exchange churn. When a sibling thread's exchange interleaves between the refused prompt and its fallback, the sibling's Slack-visible `tool_use` carries that thread's key (correctly left in place), but its synthetic `tool_result` is null-keyed and was dropped as churn — orphaning the kept `tool_use`.

`renderSlackTranscriptWithProvenance` runs `filterOrphanToolPairs` *before* this quarantine in `assembleSlackChronologicalContext`, so there is no later pass to remove the now-orphaned sibling `tool_use`, and the next provider request hard-fails on invalid history — the exact failure class #38425 was fixing.

## Fix (Option A — exchange semantics)

Tie each null-keyed synthetic `tool_result` back to its `tool_use` by id via a new `toolUseThreadKey` lookup (`tool_use` id → the thread key of the row that produced it). During the walk-back, a null-keyed `tool_result` whose `tool_use` sits in a **sibling** (non-null) thread is left in place — the pair belongs to that sibling exchange, and dropping only the result would strand a half-pair past the earlier orphan prune.

All other null-keyed tool churn — a `tool_result` whose `tool_use` is same-thread or itself null-keyed — is still dropped as the refused exchange's own, preserving #38425's semantics (the whole point: excise the refused turn's orphan/stale tool rows). A sibling exchange whose `tool_use` is *itself* null-keyed drops as a whole pair (no orphan), which is safe; only the half-drop that produced invalid history is fixed.

This keeps the fix in the one place that already owns the walk-back, rather than adding a post-quarantine orphan-prune pass (Option B), matching #38425's stated preference for exchange semantics.

## Tests

- `empty-response-hook.test.ts`: unit case on `computeRefusedExchangeDrops` — a sibling thread's keyed `tool_use` + null-keyed `tool_result` interleaved before the fallback survives **intact**; only the refused prompt + fallback drop.
- `conversation-runtime-assembly.test.ts`: integration case through `assembleSlackChronologicalMessages` — @bob's sibling tool exchange survives intact (both halves, same id, no orphan) while @alice's refused prompt + fallback are quarantined.

Both new tests were verified to **fail** on the pre-fix walk-back (orphaned sibling `tool_use`). Existing quarantine tests, `typecheck:fast`, eslint, and prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)