### PR TITLE
fix(daemon): stop reposting an already-streamed Slack reply on deduped crash-window recovery

### DIFF
--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -5,11 +5,13 @@
  * finding messages by source identifiers, and managing raw payload storage.
  */
 
-import { and, eq, isNotNull, or } from "drizzle-orm";
+import { and, eq, isNotNull, ne, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { readSlackMetadataFromMessageMetadata } from "../messaging/providers/slack/message-metadata.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { parseJsonSafe } from "../util/json.js";
+import { isPlainObject } from "../util/object.js";
 import { selectSlackMetaCandidateMetadata } from "./conversation-crud.js";
 import {
   getConversationByKey,
@@ -314,6 +316,20 @@ export function storePayload(
 }
 
 /**
+ * Parse a stored `rawPayload` string into a plain object, or `undefined` when
+ * it is absent, malformed, or not a JSON object.
+ */
+function parseRawPayloadObject(
+  rawPayload: string | null | undefined,
+): Record<string, unknown> | undefined {
+  if (!rawPayload) {
+    return undefined;
+  }
+  const parsed = parseJsonSafe(rawPayload);
+  return isPlainObject(parsed) ? parsed : undefined;
+}
+
+/**
  * Merge a patch into an inbound event's stored payload, preserving existing
  * keys. No-ops when the event has no payload or the stored value is not a JSON
  * object.
@@ -328,20 +344,8 @@ function mergeRawPayload(
     .from(channelInboundEvents)
     .where(eq(channelInboundEvents.id, eventId))
     .get();
-  if (!row?.rawPayload) return;
-
-  let payload: Record<string, unknown>;
-  try {
-    const parsed = JSON.parse(row.rawPayload) as unknown;
-    if (
-      parsed === null ||
-      typeof parsed !== "object" ||
-      Array.isArray(parsed)
-    ) {
-      return;
-    }
-    payload = parsed as Record<string, unknown>;
-  } catch {
+  const payload = parseRawPayloadObject(row?.rawPayload);
+  if (!payload) {
     return;
   }
 
@@ -373,6 +377,41 @@ export function storeReplyMessageId(
  */
 export function storeStreamedReplyTs(eventId: string, streamTs: string): void {
   mergeRawPayload(eventId, { slackStreamMessageTs: streamTs });
+}
+
+/**
+ * Return the `slackStreamMessageTs` durably recorded by any sibling inbound
+ * event linked to the given user message (excluding `excludeEventId`).
+ *
+ * A deduplicated redelivery is `linkMessage`d to the original turn's
+ * `messageId`, so the two events share it. When the original attempt streamed
+ * its reply live into Slack but crashed before finalizing delivery, its `ts`
+ * survives on the sibling row — the redelivery reads it here to edit that
+ * message in place instead of posting the persisted reply a second time.
+ */
+export function getSiblingStreamedReplyTs(
+  messageId: string,
+  excludeEventId: string,
+): string | undefined {
+  const db = getDb();
+  const rows = db
+    .select({ rawPayload: channelInboundEvents.rawPayload })
+    .from(channelInboundEvents)
+    .where(
+      and(
+        eq(channelInboundEvents.messageId, messageId),
+        ne(channelInboundEvents.id, excludeEventId),
+      ),
+    )
+    .all();
+
+  for (const row of rows) {
+    const ts = parseRawPayloadObject(row.rawPayload)?.slackStreamMessageTs;
+    if (typeof ts === "string" && ts.length > 0) {
+      return ts;
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -24,6 +24,7 @@ const replyDeliveryCalls: Array<{
   messageTs?: string;
 }> = [];
 let siblingDeliveryStatuses: string[] = [];
+let siblingStreamedReplyTs: string | undefined;
 let deliverChannelReplyImpl: (
   callbackUrl: string,
   payload: Record<string, unknown>,
@@ -47,6 +48,7 @@ mock.module("../../../persistence/delivery-crud.js", () => ({
     operationOrder.push("store-streamed-ts");
     storedStreamedReplyTs.push({ eventId, messageTs });
   },
+  getSiblingStreamedReplyTs: () => siblingStreamedReplyTs,
 }));
 
 mock.module("../../../persistence/delivery-status.js", () => ({
@@ -121,6 +123,7 @@ beforeEach(() => {
   storedStreamedReplyTs.length = 0;
   replyDeliveryCalls.length = 0;
   siblingDeliveryStatuses = [];
+  siblingStreamedReplyTs = undefined;
   deliverChannelReplyImpl = async () => ({ ok: true });
   deliverReplyViaCallbackImpl = async () => {};
 });
@@ -455,6 +458,49 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
     clearThreadTs(conversationId);
   });
 
+  test("edits the sibling's streamed Slack reply in place when recovering a deduplicated redelivery in the crash window", async () => {
+    const conversationId = "conv-dedup-pending-streamed";
+    const channelId = "C-DEDUP-PENDING-STREAMED";
+    const streamTs = "1700000000.000099";
+
+    // The original attempt streamed its reply live into Slack — its message
+    // `ts` is durably recorded on the sibling row — but crashed before
+    // finalizing delivery, leaving the sibling stuck `pending`. Reposting the
+    // persisted reply would duplicate the already-visible streamed message, so
+    // recovery must reuse the recorded `ts` to edit that message in place.
+    siblingDeliveryStatuses = ["pending"];
+    siblingStreamedReplyTs = streamTs;
+    const processMessage: MessageProcessor = async () => ({
+      messageId: "user-msg-dedup",
+      deduplicated: true,
+    });
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-dedup-pending-streamed",
+      content: "redelivered message",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}`,
+    });
+
+    await flush();
+
+    // The reply is delivered onto the existing streamed message (`messageTs`
+    // reused) rather than posted anew, and the event is marked delivered.
+    expect(markedProcessedEvents).toEqual(["evt-dedup-pending-streamed"]);
+    expect(replyDeliveryCalls).toEqual([
+      { messageId: undefined, startFromSegment: 0, messageTs: streamTs },
+    ]);
+    expect(deliveredEvents).toEqual(["evt-dedup-pending-streamed"]);
+
+    clearThreadTs(conversationId);
+  });
+
   test("falls back to durable delivery for a non-threaded Slack DM", async () => {
     const conversationId = "conv-dm-no-thread";
     const channelId = "D-NO-THREAD";
@@ -568,6 +614,11 @@ describe("processChannelMessageInBackground — slack thread mapping", () => {
         startFromSegment: 1,
         messageTs: streamTs,
       },
+    ]);
+    // The stream `ts` is durably recorded the moment the stream opens, so a
+    // crash before delivery finalizes leaves a breadcrumb for recovery.
+    expect(storedStreamedReplyTs).toEqual([
+      { eventId: "evt-streamed", messageTs: streamTs },
     ]);
     expect(deliveredEvents).toEqual(["evt-streamed"]);
 

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -25,6 +25,7 @@ import { CONVERSATION_BUSY_MESSAGE } from "../../../daemon/conversation-messagin
 import type { ServerMessage } from "../../../daemon/message-protocol.js";
 import type { TrustContext } from "../../../daemon/trust-context-types.js";
 import {
+  getSiblingStreamedReplyTs,
   linkMessage,
   storeReplyMessageId,
   storeStreamedReplyTs,
@@ -248,6 +249,10 @@ export function processChannelMessageInBackground(
         assistantId,
         recipientUserId: slackInbound?.actorExternalUserId,
         recipientTeamId: slackInbound?.actorTeamId,
+        // Durably record the streamed message `ts` the instant the stream
+        // opens, so a crash before `finalizeEventDelivery` leaves a breadcrumb
+        // the redelivery path can reuse to edit the reply in place.
+        onStreamOpen: (streamTs) => storeStreamedReplyTs(eventId, streamTs),
       });
       const observeAgentEvent = (msg: ServerMessage): void => {
         if (
@@ -317,12 +322,10 @@ export function processChannelMessageInBackground(
           { err, conversationId },
           "Background channel message processing failed",
         );
-        if (slackReplySession) {
-          const reconciliation = await slackReplySession.finish();
-          if (reconciliation.mode === "streamed") {
-            storeStreamedReplyTs(eventId, reconciliation.messageTs);
-          }
-        }
+        // Stop any live Slack stream cleanly. Its `ts` is already durably
+        // recorded via `onStreamOpen`, so the retry sweep can reconcile
+        // against that message rather than posting a duplicate.
+        await slackReplySession?.finish();
         recordProcessingFailure(eventId, err);
         return;
       }
@@ -341,13 +344,27 @@ export function processChannelMessageInBackground(
       //   - all siblings `pending` → the first process persisted the turn but
       //     died before recording a delivery outcome. The sweep never selects
       //     `pending`, so this redelivery is the only path that can recover the
-      //     undelivered reply → fall through and deliver.
-      const priorDeduplicatedDeliveryOwned =
-        deduplicatedIngress &&
-        userMessageId !== undefined &&
-        getSiblingEventDeliveryStatuses(userMessageId, eventId).some(
-          (status) => status !== "pending",
+      //     undelivered reply → fall through and deliver. If that first attempt
+      //     had already streamed its reply live into Slack, its message `ts` is
+      //     durably recorded on the sibling row (via `onStreamOpen`); reuse it so
+      //     recovery edits that visible message in place instead of posting the
+      //     persisted reply a second time.
+      let priorDeduplicatedDeliveryOwned = false;
+      let recoveredStreamMessageTs: string | undefined;
+      if (deduplicatedIngress && userMessageId !== undefined) {
+        const siblingStatuses = getSiblingEventDeliveryStatuses(
+          userMessageId,
+          eventId,
         );
+        if (siblingStatuses.some((status) => status !== "pending")) {
+          priorDeduplicatedDeliveryOwned = true;
+        } else {
+          recoveredStreamMessageTs = getSiblingStreamedReplyTs(
+            userMessageId,
+            eventId,
+          );
+        }
+      }
 
       if (priorDeduplicatedDeliveryOwned) {
         log.info(
@@ -365,6 +382,9 @@ export function processChannelMessageInBackground(
             replyMessageId,
             userMessageId,
             slackReplySession,
+            ...(recoveredStreamMessageTs
+              ? { priorStreamMessageTs: recoveredStreamMessageTs }
+              : {}),
           });
         } catch (err) {
           log.error(

--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -114,6 +114,14 @@ export function createSlackReplySession(params: {
   recipientTeamId?: string;
   /** Gap between coalesced `appendStream` calls. Defaults to {@link STREAM_COALESCE_MS}. */
   coalesceMs?: number;
+  /**
+   * Invoked once with the streamed message `ts` the moment the Slack stream
+   * opens. Lets the caller durably record the `ts` before delivery finalizes,
+   * so a crash mid-turn leaves a breadcrumb: a retry or deduplicated
+   * redelivery reconciles against the already-visible message instead of
+   * posting a duplicate reply.
+   */
+  onStreamOpen?: (streamTs: string) => void;
 }): SlackReplySession | undefined {
   if (!shouldStreamSlackReply(params) || !params.replyCallbackUrl) {
     return undefined;
@@ -226,6 +234,7 @@ export function createSlackReplySession(params: {
           confirmedLength = firstChunk.length;
           deliveredProgressKey = progressKey(title, tasks);
           state = "streaming";
+          params.onStreamOpen?.(result.ts);
         } else {
           state = "fallback";
         }


### PR DESCRIPTION
Addresses Codex review feedback on #38424.

## Problem

#38424 recovers a deduplicated at-least-once redelivery whose original attempt crashed in the window after `markProcessed` but before `finalizeEventDelivery` (all siblings left `pending`). But for a Slack thread/DM turn, the reply is streamed **live** into Slack *during* the agent loop via `slackReplySession`. The stream `ts` was persisted (`storeStreamedReplyTs`) only in the failure catch path — never on the success-then-crash path.

So if the process died after linking/processing the inbound row but before `finalizeEventDelivery`, the sibling read as `pending`, the crash-window predicate fell through, and `finalizeEventDelivery` ran with a fresh empty session (no `messageTs`) — **posting the already-visible streamed reply a second time**.

## Fix

- Persist the streamed message `ts` **eagerly**, the instant the Slack stream opens, via a new `onStreamOpen` callback on `createSlackReplySession` wired to `storeStreamedReplyTs`. The breadcrumb now survives a hard crash mid-turn (previously it was written only when processing threw).
- In the crash-window recovery branch, consult any sibling's recorded stream `ts` (`getSiblingStreamedReplyTs`) and pass it to `finalizeEventDelivery` as `priorStreamMessageTs`, so recovery **edits the already-visible streamed message in place** (idempotent, and completes any tail the crash cut off) instead of reposting.
- The failure-path `storeStreamedReplyTs` is now redundant with the eager callback and is removed; `finish()` is kept to stop the stream cleanly.

### Behavior preserved

Non-streamed channels (and Slack turns with no reply session) still re-deliver on all-pending recovery — a `pending` row is never swept, so the reply would otherwise be lost. Only the pending-but-**already-streamed** Slack case now edits in place rather than double-posting. The `delivered` / `failed` / `dead_letter` sibling skips from #38424 are unchanged.

## Tests

- New `background-dispatch` case: crash-window recovery with a sibling stream `ts` reuses that `ts` (delivery carries `messageTs`, edits in place) — no fresh post.
- Strengthened the streamed-success case to assert the eager breadcrumb is written the moment the stream opens.

## Note

Small reuse cleanup: the JSON-object parse/guard that `mergeRawPayload` hand-rolled (and the new sibling reader needed) is extracted into `parseRawPayloadObject`, composed from the existing `parseJsonSafe` + `isPlainObject` utils.