### PR TITLE
feat(web): serif heading and creature-corner chrome for pro onboarding cards

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/primitives.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/primitives.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for the pure-presentational card-chrome primitives. Renders via
+ * `@testing-library/react` (happy-dom registered in test-setup.ts). The lazy
+ * avatar-components hook and the SVG-compositing renderer are mocked so the
+ * tests exercise placement/gating logic, not the bundled avatar payload.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+let avatarComponents: unknown = { colors: [] };
+mock.module("@/utils/use-bundled-avatar-components", () => ({
+  preloadBundledAvatarComponents: () => {},
+  useBundledAvatarComponents: () => avatarComponents,
+}));
+mock.module("@/components/avatar-renderer", () => ({
+  AvatarRenderer: () => <span data-testid="creature-avatar" />,
+}));
+
+const { CreatureCorners, WizardCardHeading } = await import("./primitives");
+
+afterEach(() => {
+  cleanup();
+  avatarComponents = { colors: [] };
+});
+
+describe("WizardCardHeading", () => {
+  test("renders the title", () => {
+    const { getByText } = render(<WizardCardHeading title="Confirm your email" />);
+    expect(getByText("Confirm your email")).toBeTruthy();
+  });
+
+  test("renders the subtitle when provided", () => {
+    const { getByText } = render(
+      <WizardCardHeading title="Confirm your email" subtitle="We'll send a code" />,
+    );
+    expect(getByText("Confirm your email")).toBeTruthy();
+    expect(getByText("We'll send a code")).toBeTruthy();
+  });
+
+  test("omits the subtitle paragraph when not provided", () => {
+    const { container } = render(<WizardCardHeading title="Just a title" />);
+    expect(container.querySelector("p")).toBeNull();
+  });
+});
+
+describe("CreatureCorners", () => {
+  test("renders three creatures for the top variant", () => {
+    const { getAllByTestId } = render(<CreatureCorners variant="top" />);
+    expect(getAllByTestId("creature-avatar")).toHaveLength(3);
+  });
+
+  test("renders six creatures for the full variant (default)", () => {
+    const { getAllByTestId } = render(<CreatureCorners />);
+    expect(getAllByTestId("creature-avatar")).toHaveLength(6);
+  });
+
+  test("the decoration layer is aria-hidden", () => {
+    const { getByTestId } = render(<CreatureCorners variant="full" />);
+    expect(getByTestId("creature-corners").getAttribute("aria-hidden")).toBe(
+      "true",
+    );
+  });
+
+  test("renders nothing until the avatar components resolve", () => {
+    avatarComponents = null;
+    const { queryByTestId } = render(<CreatureCorners variant="full" />);
+    expect(queryByTestId("creature-corners")).toBeNull();
+    expect(queryByTestId("creature-avatar")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
@@ -5,6 +5,9 @@ import type { ButtonVariant } from "@vellumai/design-library/components/button";
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
 
+import { AvatarRenderer } from "@/components/avatar-renderer";
+import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
+
 import { extractOnboardingErrorMessage } from "./utils";
 
 /** The manual Apply & Restart recovery threaded down from the modal. */
@@ -163,6 +166,111 @@ export function ResourceCard({
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Centered serif card heading (Instrument Serif via `--font-serif`) with an
+ * optional supporting subtitle, matching the takeover-header treatment used
+ * on the plans page. Pure presentation.
+ */
+export function WizardCardHeading({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle?: string;
+}) {
+  return (
+    <header className="flex flex-col items-center gap-2 pt-12 text-center">
+      <h2
+        className="text-[var(--content-emphasised)]"
+        style={{
+          fontFamily: "var(--font-serif)",
+          fontSize: "32px",
+          fontWeight: 400,
+          lineHeight: 1.2,
+          letterSpacing: "0.64px",
+        }}
+      >
+        {title}
+      </h2>
+      {subtitle && (
+        <p className="text-[14px] font-normal text-[var(--content-secondary)]">
+          {subtitle}
+        </p>
+      )}
+    </header>
+  );
+}
+
+/** A single decorative creature: fixed traits + placement, no randomness. */
+interface CreaturePlacement {
+  bodyShape: string;
+  eyeStyle: string;
+  color: string;
+  size: number;
+  /** Absolute-position offset classes; negative offsets clip at the card edge. */
+  position: string;
+  /** Static rotation (deg); no animation, so reduced-motion is a no-op here. */
+  rotate: number;
+}
+
+/**
+ * Deterministic creature scatter per variant. Ordered top-edge first so the
+ * `"top"` variant is simply the first three of the `"full"` set.
+ */
+const CREATURE_PLACEMENTS: CreaturePlacement[] = [
+  { bodyShape: "blob", eyeStyle: "goofy", color: "green", size: 56, position: "-left-4 -top-6", rotate: -12 },
+  { bodyShape: "sprout", eyeStyle: "curious", color: "orange", size: 48, position: "left-1/2 -top-8 -translate-x-1/2", rotate: 6 },
+  { bodyShape: "urchin", eyeStyle: "surprised", color: "teal", size: 56, position: "-right-4 -top-6", rotate: 14 },
+  { bodyShape: "star", eyeStyle: "gentle", color: "purple", size: 44, position: "-left-6 top-1/2 -translate-y-1/2", rotate: -20 },
+  { bodyShape: "ghost", eyeStyle: "bashful", color: "pink", size: 44, position: "-right-6 top-1/2 -translate-y-1/2", rotate: 18 },
+  { bodyShape: "flower", eyeStyle: "quirky", color: "yellow", size: 52, position: "left-1/2 -bottom-8 -translate-x-1/2", rotate: -8 },
+];
+
+/**
+ * Absolutely-positioned decoration layer that scatters bundled Vellum
+ * creatures around a card's edges (clipped by the card's `overflow-hidden`).
+ * `variant="top"` places three across the top edge (email card); `variant="full"`
+ * scatters six around all edges (all-set card). Renders nothing until the lazy
+ * avatar-components chunk resolves. Decorative only — `aria-hidden`.
+ */
+export function CreatureCorners({
+  variant = "full",
+}: {
+  variant?: "top" | "full";
+}) {
+  const components = useBundledAvatarComponents();
+  if (!components) {
+    return null;
+  }
+
+  const placements =
+    variant === "top" ? CREATURE_PLACEMENTS.slice(0, 3) : CREATURE_PLACEMENTS;
+
+  return (
+    <div
+      aria-hidden="true"
+      data-testid="creature-corners"
+      className="pointer-events-none absolute inset-0 select-none"
+    >
+      {placements.map((creature, index) => (
+        <span
+          key={index}
+          className={`absolute ${creature.position}`}
+          style={{ rotate: `${creature.rotate}deg` }}
+        >
+          <AvatarRenderer
+            components={components}
+            bodyShapeId={creature.bodyShape}
+            eyeStyleId={creature.eyeStyle}
+            colorId={creature.color}
+            size={creature.size}
+          />
+        </span>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add WizardCardHeading (serif title + subtitle) and CreatureCorners decoration to pro-onboarding primitives.

Part of plan: pro-onboarding-figma-polish.md (PR 1 of 5)