### PR TITLE
fix(workers): arm the PID-file identity guard before workers begin work

### DIFF
--- a/assistant/src/__tests__/worker-entrypoint-guards.test.ts
+++ b/assistant/src/__tests__/worker-entrypoint-guards.test.ts
@@ -23,6 +23,19 @@ import { Glob } from "bun";
 const DISABLE_CALL = "disableStreamSeqStamping()";
 const PID_GUARD_CALL = "startWorkerPidFileGuard(";
 
+/**
+ * The first call each entrypoint makes that can run orphaned schedule/job
+ * work. The PID guard must be armed before this — its on-arm identity check
+ * evicts a worker superseded at startup before the call runs. Every discovered
+ * entrypoint must have an entry here, so a new worker forces its author to
+ * declare (and order) its work-start.
+ */
+const WORK_START_MARKERS: Record<string, string> = {
+  "schedule/worker.ts": "void tick()",
+  "monitoring/worker.ts": "startResourceSampler(",
+  "plugins/defaults/memory/worker.ts": "startMemoryJobsWorkerLoop(",
+};
+
 function findWorkerEntrypoints(): string[] {
   const srcRoot = join(process.cwd(), "src");
   const glob = new Glob("**/worker.ts");
@@ -62,6 +75,25 @@ describe("worker entrypoint guards", () => {
       entrypointsMissing(PID_GUARD_CALL),
       `Worker entrypoints must call ${PID_GUARD_CALL}...) so an orphaned ` +
         "worker (one its PID file stops naming) evicts itself.",
+    ).toEqual([]);
+  });
+
+  test("every worker entrypoint arms the PID guard before starting work", () => {
+    const offenders = findWorkerEntrypoints().filter((file) => {
+      const marker = WORK_START_MARKERS[file];
+      if (marker == null) {
+        return true; // unregistered entrypoint — force a marker to be added
+      }
+      const source = readFileSync(join(process.cwd(), "src", file), "utf8");
+      const guardAt = source.indexOf(PID_GUARD_CALL);
+      const workAt = source.indexOf(marker);
+      return guardAt < 0 || workAt < 0 || guardAt > workAt;
+    });
+    expect(
+      offenders,
+      "Each worker must arm the PID guard before its work-start call " +
+        `(see WORK_START_MARKERS) so the guard's on-arm check evicts a ` +
+        "worker superseded at startup before it runs orphaned work.",
     ).toEqual([]);
   });
 });

--- a/assistant/src/__tests__/worker-pid-file-guard.test.ts
+++ b/assistant/src/__tests__/worker-pid-file-guard.test.ts
@@ -73,6 +73,30 @@ describe("startWorkerPidFileGuard", () => {
     expect(evictions).toEqual([]);
   });
 
+  test("evicts synchronously on arm when the file already names a successor", () => {
+    const path = mkPidFile(String(process.pid + 1));
+    const { evictions } = startGuard(path);
+    // No await: the on-arm check runs synchronously inside the guard, so a
+    // worker superseded before it starts work evicts without any interval
+    // elapsing. This is the property the workers rely on when they arm the
+    // guard right before their first tick.
+    expect(evictions.length).toBe(1);
+    expect(evictions[0]).toContain(String(process.pid + 1));
+  });
+
+  test("evicts synchronously on arm when the file is already missing", () => {
+    const path = mkPidFile(String(process.pid));
+    rmSync(path);
+    const { evictions } = startGuard(path);
+    expect(evictions.length).toBe(1);
+  });
+
+  test("does not evict on arm while the file names this process", () => {
+    const path = mkPidFile(String(process.pid));
+    const { evictions } = startGuard(path);
+    expect(evictions).toEqual([]);
+  });
+
   test("evicts exactly once when the file names a successor", async () => {
     const path = mkPidFile(String(process.pid));
     const { evictions } = startGuard(path);

--- a/assistant/src/monitoring/worker.ts
+++ b/assistant/src/monitoring/worker.ts
@@ -79,27 +79,9 @@ async function main(): Promise<void> {
   // user context instead of shipping with those fields empty.
   await rehydratePlatformCredentials();
 
-  const sampler: ResourceSamplerHandle = startResourceSampler(
-    config.monitoring,
-  );
-  const sourceWatch: PluginSourceWatchHandle = startPluginSourceWatch(
-    config.monitoring.pluginSourceScanIntervalMs,
-  );
-  // Crash recovery runs here, off the daemon's boot path and event loop.
-  const recovery: RecoveryHandle = startRecovery();
-
-  // Flush the non-turn telemetry sources from this process, off the daemon's
-  // event loop. The reporter's share_analytics gate reads the consent cache,
-  // so this process runs its own refresh loop.
-  startConsentRefresh();
-  startMonitorUsageTelemetryReporter();
-
-  // Emit the tracked config settings into the config_setting pipeline this
-  // process flushes.
-  startConfigSnapshotReporter();
-
-  // Emit the coarse memory tier as a periodic per-assistant watchdog heartbeat.
-  startMemoryTierReporter();
+  let sampler: ResourceSamplerHandle | null = null;
+  let sourceWatch: PluginSourceWatchHandle | null = null;
+  let recovery: RecoveryHandle | null = null;
 
   let shuttingDown = false;
   let disposePidGuard: (() => void) | null = null;
@@ -109,11 +91,11 @@ async function main(): Promise<void> {
     }
     shuttingDown = true;
     log.info({ signal }, "Resource monitor process shutting down");
-    recovery.stop();
+    recovery?.stop();
     stopConfigSnapshotReporter();
     stopMemoryTierReporter();
-    sourceWatch.stop();
-    sampler.stop();
+    sourceWatch?.stop();
+    sampler?.stop();
     // Bounded final telemetry flush, mirroring the daemon's shutdown. This
     // is load-bearing for the opt-out contract: when share_analytics is
     // off, flush() is what advances this process's watermarks past rows
@@ -136,6 +118,10 @@ async function main(): Promise<void> {
   process.on("SIGTERM", () => void shutdown("SIGTERM"));
   process.on("SIGINT", () => void shutdown("SIGINT"));
 
+  // Arm the identity guard before the monitoring subsystems start. Its on-arm
+  // check runs synchronously, so a worker superseded during startup begins
+  // shutting down here. shutdown() is async (it flushes telemetry), so bail
+  // out explicitly rather than fall through and start the subsystems.
   disposePidGuard = startWorkerPidFileGuard(pidPath, {
     onEvicted: (reason) => {
       log.warn(
@@ -145,6 +131,29 @@ async function main(): Promise<void> {
       void shutdown("pid-file-eviction");
     },
   });
+  if (shuttingDown) {
+    return;
+  }
+
+  sampler = startResourceSampler(config.monitoring);
+  sourceWatch = startPluginSourceWatch(
+    config.monitoring.pluginSourceScanIntervalMs,
+  );
+  // Crash recovery runs here, off the daemon's boot path and event loop.
+  recovery = startRecovery();
+
+  // Flush the non-turn telemetry sources from this process, off the daemon's
+  // event loop. The reporter's share_analytics gate reads the consent cache,
+  // so this process runs its own refresh loop.
+  startConsentRefresh();
+  startMonitorUsageTelemetryReporter();
+
+  // Emit the tracked config settings into the config_setting pipeline this
+  // process flushes.
+  startConfigSnapshotReporter();
+
+  // Emit the coarse memory tier as a periodic per-assistant watchdog heartbeat.
+  startMemoryTierReporter();
 
   process.on("SIGUSR1", () => {
     log.info("Received SIGUSR1 — refreshing database connections");
@@ -153,26 +162,26 @@ async function main(): Promise<void> {
 
   process.on("uncaughtException", (err) => {
     log.error({ err }, "Uncaught exception in resource monitor process");
-    recovery.stop();
-    sourceWatch.stop();
-    sampler.stop();
+    recovery?.stop();
+    sourceWatch?.stop();
+    sampler?.stop();
     cleanupWorkerPidFile(getMonitoringPidPath());
     process.exit(1);
   });
 
   process.on("unhandledRejection", (reason) => {
     log.error({ reason }, "Unhandled rejection in resource monitor process");
-    recovery.stop();
-    sourceWatch.stop();
-    sampler.stop();
+    recovery?.stop();
+    sourceWatch?.stop();
+    sampler?.stop();
     cleanupWorkerPidFile(getMonitoringPidPath());
     process.exit(1);
   });
 
   process.on("exit", () => {
-    recovery.stop();
-    sourceWatch.stop();
-    sampler.stop();
+    recovery?.stop();
+    sourceWatch?.stop();
+    sampler?.stop();
     cleanupWorkerPidFile(getMonitoringPidPath());
   });
 }

--- a/assistant/src/plugins/defaults/memory/worker.ts
+++ b/assistant/src/plugins/defaults/memory/worker.ts
@@ -75,17 +75,15 @@ async function main(): Promise<void> {
     );
   }
 
-  const worker = startMemoryJobsWorkerLoop();
-
-  // Keep-alive: the worker's setTimeout timers are unref'd, so without
-  // this interval the process would exit immediately.
-  const keepAlive = setInterval(() => {}, 60_000);
-
+  let worker: ReturnType<typeof startMemoryJobsWorkerLoop> | null = null;
+  let keepAlive: ReturnType<typeof setInterval> | null = null;
   let disposePidGuard: (() => void) | null = null;
   const shutdown = (signal: string) => {
     log.info({ signal }, "Memory worker process shutting down");
-    worker.stop();
-    clearInterval(keepAlive);
+    worker?.stop();
+    if (keepAlive != null) {
+      clearInterval(keepAlive);
+    }
     disposePidGuard?.();
     cleanupWorkerPidFile(pidPath);
     process.exit(0);
@@ -94,6 +92,9 @@ async function main(): Promise<void> {
   process.on("SIGTERM", () => shutdown("SIGTERM"));
   process.on("SIGINT", () => shutdown("SIGINT"));
 
+  // Arm the identity guard before the worker loop starts. Its on-arm check
+  // runs synchronously, so a worker superseded during startup runs shutdown()
+  // — which calls process.exit — here, before it dispatches any jobs.
   disposePidGuard = startWorkerPidFileGuard(pidPath, {
     onEvicted: (reason) => {
       log.warn(
@@ -103,6 +104,12 @@ async function main(): Promise<void> {
       shutdown("pid-file-eviction");
     },
   });
+
+  worker = startMemoryJobsWorkerLoop();
+
+  // Keep-alive: the worker's setTimeout timers are unref'd, so without
+  // this interval the process would exit immediately.
+  keepAlive = setInterval(() => {}, 60_000);
 
   process.on("SIGUSR1", () => {
     log.info("Received SIGUSR1 — refreshing database connections");
@@ -128,7 +135,7 @@ async function main(): Promise<void> {
 
   // Clean up if the process exits unexpectedly through any other path.
   process.on("exit", () => {
-    worker.stop();
+    worker?.stop();
     cleanupWorkerPidFile(getMemoryWorkerPidPath());
   });
 }

--- a/assistant/src/schedule/worker.ts
+++ b/assistant/src/schedule/worker.ts
@@ -67,6 +67,35 @@ async function main(): Promise<void> {
 
   let stopped = false;
   let tickRunning = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let disposePidGuard: (() => void) | null = null;
+  const shutdown = (signal: string) => {
+    log.info({ signal }, "Schedule worker process shutting down");
+    stopped = true;
+    if (timer != null) {
+      clearInterval(timer);
+    }
+    disposePidGuard?.();
+    cleanupWorkerPidFile(pidPath);
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+
+  // Arm the identity guard before the first tick. Its on-arm check runs
+  // synchronously, so a worker superseded during startup runs shutdown() —
+  // which calls process.exit — here, before it can execute any schedule work.
+  disposePidGuard = startWorkerPidFileGuard(pidPath, {
+    onEvicted: (reason) => {
+      log.warn(
+        { reason },
+        "Evicted — the PID file no longer names this worker",
+      );
+      shutdown("pid-file-eviction");
+    },
+  });
+
   const tick = async () => {
     if (stopped || tickRunning) {
       return;
@@ -87,33 +116,10 @@ async function main(): Promise<void> {
 
   // Deliberately ref'd (unlike the daemon scheduler's timer): this interval
   // is what keeps the standalone process alive between ticks.
-  const timer = setInterval(() => {
+  timer = setInterval(() => {
     void tick();
   }, TICK_INTERVAL_MS);
   void tick();
-
-  let disposePidGuard: (() => void) | null = null;
-  const shutdown = (signal: string) => {
-    log.info({ signal }, "Schedule worker process shutting down");
-    stopped = true;
-    clearInterval(timer);
-    disposePidGuard?.();
-    cleanupWorkerPidFile(pidPath);
-    process.exit(0);
-  };
-
-  process.on("SIGTERM", () => shutdown("SIGTERM"));
-  process.on("SIGINT", () => shutdown("SIGINT"));
-
-  disposePidGuard = startWorkerPidFileGuard(pidPath, {
-    onEvicted: (reason) => {
-      log.warn(
-        { reason },
-        "Evicted — the PID file no longer names this worker",
-      );
-      shutdown("pid-file-eviction");
-    },
-  });
 
   process.on("SIGUSR1", () => {
     log.info("Received SIGUSR1 — refreshing database connections");
@@ -140,7 +146,9 @@ async function main(): Promise<void> {
   // Clean up if the process exits unexpectedly through any other path.
   process.on("exit", () => {
     stopped = true;
-    clearInterval(timer);
+    if (timer != null) {
+      clearInterval(timer);
+    }
     cleanupWorkerPidFile(getScheduleWorkerPidPath());
   });
 }

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -306,12 +306,15 @@ export function cleanupWorkerPidFile(pidPath: string): void {
  * daemon reuses via the `alreadyRunning` path is still named by the file,
  * so the guard never fires for it.
  *
- * Checks every `intervalMs` (default 15s) on an unref'd timer so the
- * guard never keeps the process alive, calls `onEvicted` at most once,
- * and stops checking after eviction. Returns a disposer; call it before
- * {@link cleanupWorkerPidFile} on the normal shutdown path so shutdown
- * never reads as an eviction. The eviction path must not delete the PID
- * file — it names the successor.
+ * Checks immediately on arm and then every `intervalMs` (default 15s) on an
+ * unref'd timer so the guard never keeps the process alive, calls `onEvicted`
+ * at most once, and stops checking after eviction. The synchronous on-arm
+ * check is what closes the startup window: a worker superseded before it
+ * begins work evicts during arm — so callers arm the guard just before their
+ * first tick — instead of running one orphaned interval's work first. Returns
+ * a disposer; call it before {@link cleanupWorkerPidFile} on the normal
+ * shutdown path so shutdown never reads as an eviction. The eviction path must
+ * not delete the PID file — it names the successor.
  */
 export function startWorkerPidFileGuard(
   pidPath: string,
@@ -319,7 +322,8 @@ export function startWorkerPidFileGuard(
 ): () => void {
   const intervalMs = opts.intervalMs ?? 15_000;
   let evicted = false;
-  const timer = setInterval(() => {
+
+  const check = (): void => {
     if (evicted) {
       return;
     }
@@ -337,8 +341,15 @@ export function startWorkerPidFileGuard(
       clearInterval(timer);
       opts.onEvicted(reason);
     }
-  }, intervalMs);
+  };
+
+  const timer = setInterval(check, intervalMs);
   timer.unref();
+
+  // Synchronous check on arm: a worker already superseded at startup evicts
+  // here, before its caller starts work, rather than waiting a full interval.
+  check();
+
   return () => clearInterval(timer);
 }
 


### PR DESCRIPTION
## Summary
Addresses Codex review feedback on #38489.

The PID-file identity guard from #38489 only checked ownership on a 15s interval, and every worker entrypoint armed it *after* starting its work: `void tick()` (schedule), `startMemoryJobsWorkerLoop()` (memory), and the sampler/recovery/telemetry subsystems (monitoring). A worker superseded during startup — the exact race #38489 was motivated by — could run one orphaned round of user-facing work before the first interval check noticed the PID file now named its successor.

## Changes
- **`startWorkerPidFileGuard`**: performs a synchronous identity check on arm (sharing one `check()` with the interval), so a worker already superseded evicts before its caller starts work instead of waiting a full interval.
- **Schedule / memory workers**: arm the guard immediately before the first tick / job loop. Their shutdown is synchronous (`process.exit`), so a superseded worker exits before any work runs.
- **Monitoring worker**: arms the guard before the sampler/recovery/telemetry subsystems and bails out (`if (shuttingDown) return`) because its shutdown is async (it flushes telemetry). Shutdown and the exit/exception handlers tolerate not-yet-initialized handles.
- Preserves the `alreadyRunning` adoption path and `cleanupWorkerPidFile`'s successor-safe unlink semantics.

## Tests
- New unit tests pin synchronous on-arm eviction (successor / missing / owned) in `worker-pid-file-guard.test.ts`.
- New sweep assertion in `worker-entrypoint-guards.test.ts` requires every entrypoint to arm the guard before its registered work-start call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)