### PR TITLE
fix(streaming): stop the SSE stale-frontier clear from firing on benign snapshot overlaps

### DIFF
--- a/clients/web/src/assistant/sse-service.test.ts
+++ b/clients/web/src/assistant/sse-service.test.ts
@@ -54,6 +54,8 @@ mock.module("@/assistant/lifecycle-service", () => ({
 const resetReconnectCursorMock = mock(() => {});
 mock.module("@/lib/streaming/reconnect-cursor", () => ({
   getReconnectCursor: () => null,
+  getAbandonedGenerationCeiling: () => null,
+  recordAbandonedGeneration: () => {},
   advanceReconnectCursor: () => {},
   replaceReconnectCursor: () => {},
   resetReconnectCursor: resetReconnectCursorMock,

--- a/clients/web/src/domains/chat/streaming/sse-event-consumer.test.ts
+++ b/clients/web/src/domains/chat/streaming/sse-event-consumer.test.ts
@@ -17,12 +17,22 @@ mock.module("@/domains/chat/stream-store", () => ({
 
 // Single global cursor mock mirroring reconnect-cursor.ts semantics.
 let globalCursor: number | null = null;
+// The abandoned-generation ceiling, recorded on a seq generation reset and
+// read by the stale-frontier guard. Mirrors reconnect-cursor.ts semantics.
+let abandonedGenerationCeiling: number | null = null;
 mock.module("@/lib/streaming/reconnect-cursor", () => ({
   getReconnectCursor: () => globalCursor,
+  getAbandonedGenerationCeiling: () => abandonedGenerationCeiling,
   // Monotonic — matches the real implementation (won't lower the cursor).
   advanceReconnectCursor: (seq: number) => {
     if (globalCursor === null || seq > globalCursor) {
       globalCursor = seq;
+    }
+  },
+  // Monotonic — retains the highest abandoned ceiling seen.
+  recordAbandonedGeneration: (seq: number) => {
+    if (abandonedGenerationCeiling === null || seq > abandonedGenerationCeiling) {
+      abandonedGenerationCeiling = seq;
     }
   },
   // Unconditional — used for generation resets and gap resolves.
@@ -31,6 +41,7 @@ mock.module("@/lib/streaming/reconnect-cursor", () => ({
   },
   resetReconnectCursor: () => {
     globalCursor = null;
+    abandonedGenerationCeiling = null;
   },
 }));
 
@@ -81,6 +92,7 @@ const makeDeps = (override: {
 beforeEach(() => {
   mockStreamEpoch = 7;
   globalCursor = null;
+  abandonedGenerationCeiling = null;
   __resetLocalSeqForTesting();
   recordDiagnosticMock.mockClear();
 });
@@ -735,34 +747,52 @@ describe("sse-event-consumer — stale seq-generation recovery", () => {
     );
   });
 
-  test("a frontier further ahead than the replay ring is dropped as stale generation", () => {
+  test("a stale /messages anchor re-poisoning the frontier after an observed reset is dropped as stale generation", () => {
     /**
-     * A `/messages` snapshot anchor persisted before a daemon counter
-     * reset re-poisons the frontier even after the cursor healed. A
-     * genuine replay can only trail the frontier by what the ring can
-     * re-deliver, so a larger lead proves a stale generation.
+     * After the client observes the generation reset and clears its
+     * frontiers, a `/messages` request that raced the reset can still land
+     * the dead generation's anchor back on the frontier. The next live
+     * event trails that poisoned frontier by more than the ring; because a
+     * reset abandoned a ceiling the live cursor has not re-climbed to, the
+     * frontier is proven stale, dropped, and re-seeded from the live event.
      */
-    // GIVEN a cursor already in the live seq space but a frontier from
-    // the old one (re-recorded from a stale snapshot anchor)
-    globalCursor = 905853;
-    recordLocalSeq("conv-1", 907779);
+    // GIVEN a warm cursor from the pre-restart generation
+    globalCursor = 907779;
     const { deps, handleStreamEvent } = makeDeps({
       activeConversationId: "conv-1",
     });
     const consumer = createSseEventConsumer(deps);
 
-    // WHEN the next live event arrives contiguously
+    // WHEN the first event of the new (lower) seq space arrives, the client
+    // observes the generation reset — cursor replaced, frontiers cleared,
+    // and the abandoned ceiling (907779) recorded
+    consumer.handleSseEvent(
+      makeEnvelope({
+        conversationId: "conv-1",
+        seq: 905853,
+        message: { type: "assistant_text_delta", text: "a" },
+      }),
+    );
+    expect(abandonedGenerationCeiling).toBe(907779);
+
+    // AND a `/messages` request that raced the reset re-poisons the frontier
+    // with the dead generation's anchor
+    recordLocalSeq("conv-1", 907779);
+
+    // AND the next live event arrives contiguously, trailing the poisoned
+    // frontier by far more than the ring
     consumer.handleSseEvent(
       makeEnvelope({
         conversationId: "conv-1",
         seq: 905854,
-        message: { type: "assistant_text_delta", text: "a" },
+        message: { type: "assistant_text_delta", text: "b" },
       }),
     );
 
     // THEN the stale frontier is dropped and the event applies as the
-    // conversation's new frontier
-    expect(handleStreamEvent).toHaveBeenCalledTimes(1);
+    // conversation's new frontier (both the reset event and this one
+    // dispatched — the poisoned frontier did not swallow the stream)
+    expect(handleStreamEvent).toHaveBeenCalledTimes(2);
     expect(getLocalSeq("conv-1")).toBe(905854);
     expect(recordDiagnosticMock).toHaveBeenCalledWith(
       "sse_local_seq_stale_generation",
@@ -770,31 +800,114 @@ describe("sse-event-consumer — stale seq-generation recovery", () => {
     );
   });
 
-  test("a frontier lead within the replay ring still skips as an ordinary replay", () => {
-    // GIVEN a frontier ahead of the live event by less than the ring
-    // window (a snapshot applied slightly ahead of the stream)
-    const frontier = 100 + SSE_REPLAY_RING_COUNT_LIMIT - 1;
+  test("a large snapshot overlap with no generation reset is an idempotent replay, not a stale generation", () => {
+    /**
+     * The false-positive Codex flagged: a `/messages` reseed or reconcile
+     * advances the frontier far past the live cursor during a bursty turn
+     * or a main-thread stall, so the queued live backlog trails it by more
+     * than the ring — WITHOUT any daemon reset. Those events are contained
+     * in the snapshot, so they must drop as ordinary replays with the
+     * frontier held. Clearing the frontier here would re-run old handlers
+     * and let the whole backlog re-apply (duplicated deltas / rolled-back
+     * control state).
+     */
+    // GIVEN a warm cursor and frontier seeded by the live stream
+    const base = 1200;
+    const { deps, handleStreamEvent } = makeDeps({
+      activeConversationId: "conv-1",
+    });
+    const consumer = createSseEventConsumer(deps);
+    consumer.handleSseEvent(
+      makeEnvelope({
+        conversationId: "conv-1",
+        seq: base,
+        message: { type: "assistant_text_delta", text: "seed" },
+      }),
+    );
+
+    // AND a bursty-turn snapshot that jumps the frontier far ahead of the
+    // live cursor (no generation reset — the abandoned ceiling stays null).
+    // Only the seed has dispatched so far.
+    const frontier = base + SSE_REPLAY_RING_COUNT_LIMIT + 50;
+    recordLocalSeq("conv-1", frontier);
+    expect(abandonedGenerationCeiling).toBeNull();
+    expect(handleStreamEvent).toHaveBeenCalledTimes(1);
+
+    // WHEN a queued live frame, contiguous with the cursor, trails the
+    // frontier by more than the ring
+    consumer.handleSseEvent(
+      makeEnvelope({
+        conversationId: "conv-1",
+        seq: base + 1,
+        message: { type: "assistant_text_delta", text: "backlog-1" },
+      }),
+    );
+
+    // THEN it drops as an ordinary replay (no new dispatch beyond the seed)
+    // and the frontier holds — the stale-generation clear must NOT fire
+    expect(handleStreamEvent).toHaveBeenCalledTimes(1);
+    expect(getLocalSeq("conv-1")).toBe(frontier);
+    expect(recordDiagnosticMock).toHaveBeenCalledWith(
+      "sse_event_seq_replayed",
+      expect.objectContaining({ eventSeq: base + 1, localSeq: frontier }),
+    );
+    expect(recordDiagnosticMock).not.toHaveBeenCalledWith(
+      "sse_local_seq_stale_generation",
+      expect.anything(),
+    );
+
+    // AND a second queued frame also drops — the backlog stays suppressed
+    // below the held frontier rather than re-applying
+    consumer.handleSseEvent(
+      makeEnvelope({
+        conversationId: "conv-1",
+        seq: base + 2,
+        message: { type: "assistant_text_delta", text: "backlog-2" },
+      }),
+    );
+    expect(handleStreamEvent).toHaveBeenCalledTimes(1);
+    expect(getLocalSeq("conv-1")).toBe(frontier);
+  });
+
+  test("after the new generation re-climbs past the abandoned ceiling, a large overlap is an ordinary replay", () => {
+    /**
+     * The stale-generation window closes once the live cursor re-passes the
+     * abandoned ceiling: from there every old anchor sits below the live
+     * stream, so a frontier ahead of a live event is again just a snapshot
+     * overlap. A reset earlier in a long session must not permanently arm
+     * the stale-generation clear.
+     */
+    // GIVEN a past reset whose ceiling the live cursor has since climbed past
+    abandonedGenerationCeiling = 1000;
+    globalCursor = 1600;
+    // AND a snapshot that advanced the frontier ahead of the live cursor
+    const frontier = 1600 + SSE_REPLAY_RING_COUNT_LIMIT + 50;
     recordLocalSeq("conv-1", frontier);
     const { deps, handleStreamEvent } = makeDeps({
       activeConversationId: "conv-1",
     });
     const consumer = createSseEventConsumer(deps);
 
-    // WHEN an event below the frontier arrives on a cold cursor
+    // WHEN a queued live frame contiguous with the cursor trails the
+    // frontier by more than the ring
     consumer.handleSseEvent(
       makeEnvelope({
         conversationId: "conv-1",
-        seq: 100,
+        seq: 1601,
         message: { type: "assistant_text_delta", text: "a" },
       }),
     );
 
-    // THEN it is skipped as a replay and the frontier holds
+    // THEN it is an ordinary replay, not a stale-generation clear
     expect(handleStreamEvent).not.toHaveBeenCalled();
     expect(getLocalSeq("conv-1")).toBe(frontier);
     expect(recordDiagnosticMock).toHaveBeenCalledWith(
       "sse_event_seq_replayed",
-      expect.objectContaining({ eventSeq: 100, localSeq: frontier }),
+      expect.objectContaining({ eventSeq: 1601, localSeq: frontier }),
+    );
+    expect(recordDiagnosticMock).not.toHaveBeenCalledWith(
+      "sse_local_seq_stale_generation",
+      expect.anything(),
     );
   });
 });

--- a/clients/web/src/domains/chat/streaming/sse-event-consumer.ts
+++ b/clients/web/src/domains/chat/streaming/sse-event-consumer.ts
@@ -78,11 +78,15 @@
  *   so it is skipped rather than re-applied — re-running a delta handler
  *   would double-append. This is the stream-side half of the monotonic
  *   merge: the frontier is what tells the snapshot/stream reconcile how
- *   far the stream has carried the conversation. A frontier further
- *   ahead of a live event than the replay ring can re-deliver is not a
- *   replay but a stale-generation anchor (recorded from a snapshot of a
- *   pre-reset seq space) — it is dropped and re-seeded from the live
- *   event rather than allowed to swallow the stream.
+ *   far the stream has carried the conversation. A snapshot legitimately
+ *   advances the frontier far past the live cursor (a bursty turn or a
+ *   main-thread stall), so a large under-frontier gap is an ordinary
+ *   idempotent replay — dropped, frontier held. The exception is a
+ *   stale-generation anchor (a snapshot of a pre-reset seq space recorded
+ *   onto the frontier by a `/messages` request that raced a counter
+ *   reset): provable only inside the re-climb window of an observed
+ *   generation reset, where the frontier is dropped and re-seeded from the
+ *   live event rather than allowed to swallow the stream.
  *
  * Reconnect handling:
  *   On reconnect the transport sends the cursor as `lastSeenSeq` and
@@ -109,7 +113,9 @@ import {
 } from "@/lib/streaming/local-seq";
 import {
   advanceReconnectCursor,
+  getAbandonedGenerationCeiling,
   getReconnectCursor,
+  recordAbandonedGeneration,
   replaceReconnectCursor,
 } from "@/lib/streaming/reconnect-cursor";
 import type { AssistantEvent } from "@/types/event-types";
@@ -200,6 +206,11 @@ export function createSseEventConsumer(
             observed: eventSeq,
           });
           replaceReconnectCursor(eventSeq);
+          // Remember the abandoned generation's ceiling so the stale-frontier
+          // guard below can tell a dead-generation anchor (recorded from a
+          // `/messages` snapshot that raced this reset) from an ordinary
+          // large snapshot overlap.
+          recordAbandonedGeneration(stored);
           resetLocalSeqs();
           gapDeferred = true;
           // Fire-and-forget: cursor is already replaced above (the old
@@ -310,20 +321,11 @@ export function createSseEventConsumer(
         eventConversationId === deps.activeConversationIdRef.current
       ) {
         // Idempotent apply: an event whose seq is at or below the
-        // conversation's local seq has already been applied to
-        // the transcript (a replay after reconnect, or overlap with an
-        // in-flight reconcile). Re-applying would double-append deltas,
-        // so skip it and leave the frontier untouched.
-        //
-        // Stale-frontier guard: a genuine replay can only trail the
-        // frontier by what the daemon's ring can re-deliver
-        // (`SSE_REPLAY_RING_COUNT_LIMIT`). A frontier further ahead of a
-        // live event than that was recorded against a stale seq
-        // generation — a `/messages` snapshot anchor persisted before the
-        // daemon's counter reset — and treating the live stream as
-        // replayed against it would silently drop every event until the
-        // counter re-passes the stale anchor. Drop the frontier and apply
-        // the live event as the conversation's new frontier instead.
+        // conversation's local seq has already been applied to the
+        // transcript (a replay after reconnect, or overlap with an
+        // in-flight reconcile). Re-applying would double-append deltas, so
+        // skip it and leave the frontier untouched — unless the frontier is
+        // a stale-generation anchor (see the guard below).
         const localSeq = getLocalSeq(eventConversationId);
         const applyAndAdvance = () => {
           deps.handleStreamEvent(event, useStreamStore.getState().streamEpoch);
@@ -345,7 +347,33 @@ export function createSseEventConsumer(
             eventSeq,
             localSeq,
           };
-          if (localSeq - eventSeq >= SSE_REPLAY_RING_COUNT_LIMIT) {
+          // Stale-frontier guard. A `/messages` snapshot legitimately
+          // advances the frontier far past the live cursor whenever a
+          // conversation is caught up out-of-band — a bursty turn or a
+          // main-thread stall lets the snapshot jump ahead while live frames
+          // queue in the browser, so the queued backlog trails the frontier
+          // by MORE than the replay ring. That overlap is an idempotent
+          // replay the snapshot already contains, so dropping it (frontier
+          // held) is correct; clearing the frontier would re-run old
+          // delta/completion handlers and duplicate or roll back chat state.
+          // Gap SIZE is therefore not the signal.
+          //
+          // The frontier is genuinely new content — a stale-generation
+          // anchor recorded by a `/messages` request that raced the daemon's
+          // counter reset — only inside the re-climb window of an OBSERVED
+          // generation reset: the reset abandoned a seq ceiling the live
+          // cursor has not yet climbed back to, and the frontier sits at or
+          // above it. There, a replay drop would silently swallow every live
+          // event until the counter re-passes the stale anchor, so clear the
+          // frontier and apply the live event as the new frontier instead.
+          const abandonedCeiling = getAbandonedGenerationCeiling();
+          const liveCursor = getReconnectCursor();
+          const frontierFromDeadGeneration =
+            abandonedCeiling != null &&
+            liveCursor != null &&
+            liveCursor < abandonedCeiling &&
+            localSeq >= abandonedCeiling;
+          if (frontierFromDeadGeneration) {
             recordDiagnostic("sse_local_seq_stale_generation", seqDiagnostic);
             clearLocalSeq(eventConversationId);
             applyAndAdvance();

--- a/clients/web/src/lib/streaming/cold-anchor.test.ts
+++ b/clients/web/src/lib/streaming/cold-anchor.test.ts
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 let globalCursor: number | null = null;
 mock.module("@/lib/streaming/reconnect-cursor", () => ({
   getReconnectCursor: () => globalCursor,
+  getAbandonedGenerationCeiling: () => null,
+  recordAbandonedGeneration: () => {},
   // Monotonic — matches the real implementation (won't lower the cursor).
   advanceReconnectCursor: (seq: number) => {
     if (globalCursor === null || seq > globalCursor) {

--- a/clients/web/src/lib/streaming/reconnect-cursor.test.ts
+++ b/clients/web/src/lib/streaming/reconnect-cursor.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
   advanceReconnectCursor,
+  getAbandonedGenerationCeiling,
   getReconnectCursor,
+  recordAbandonedGeneration,
   replaceReconnectCursor,
   resetReconnectCursor,
 } from "@/lib/streaming/reconnect-cursor";
@@ -62,5 +64,45 @@ describe("reconnect-cursor", () => {
 
     // THEN it reads null again — the next connect starts cold
     expect(getReconnectCursor()).toBeNull();
+  });
+});
+
+describe("reconnect-cursor — abandoned generation ceiling", () => {
+  test("starts null before any generation reset is observed", () => {
+    expect(getAbandonedGenerationCeiling()).toBeNull();
+  });
+
+  test("records the ceiling of an observed generation reset", () => {
+    // WHEN a reset abandons the seqs up to 907779
+    recordAbandonedGeneration(907779);
+
+    // THEN that ceiling is retained
+    expect(getAbandonedGenerationCeiling()).toBe(907779);
+  });
+
+  test("is monotonic — retains the highest ceiling across resets", () => {
+    // GIVEN a recorded ceiling
+    recordAbandonedGeneration(907779);
+
+    // WHEN a later reset abandons a lower ceiling
+    recordAbandonedGeneration(500);
+
+    // THEN the higher ceiling stands (a lower one must not narrow the window)
+    expect(getAbandonedGenerationCeiling()).toBe(907779);
+
+    // AND a higher ceiling still moves it forward
+    recordAbandonedGeneration(1_000_000);
+    expect(getAbandonedGenerationCeiling()).toBe(1_000_000);
+  });
+
+  test("reset clears the ceiling with the cursor (a new seq space)", () => {
+    // GIVEN a recorded ceiling
+    recordAbandonedGeneration(907779);
+
+    // WHEN the connection resets for a new assistant
+    resetReconnectCursor();
+
+    // THEN the ceiling clears too — the old seq space is gone
+    expect(getAbandonedGenerationCeiling()).toBeNull();
   });
 });

--- a/clients/web/src/lib/streaming/reconnect-cursor.ts
+++ b/clients/web/src/lib/streaming/reconnect-cursor.ts
@@ -31,11 +31,52 @@
 let reconnectCursor: number | null = null;
 
 /**
+ * The ceiling of the most recently abandoned seq generation, or `null` when
+ * no generation reset has been observed on this connection's seq space.
+ *
+ * A generation reset (the daemon's counter restarting below the live cursor)
+ * proves every seq up to the pre-reset cursor belonged to a now-dead
+ * generation. A `/messages` request that raced the reset can still land a
+ * dead-generation anchor on a per-conversation frontier afterwards; that
+ * poisoned frontier sits at or above this ceiling while the new generation
+ * re-climbs toward it. That re-climb window is the only place a live event
+ * trailing its conversation's frontier is a stale-generation anchor rather
+ * than an ordinary snapshot-overlap replay — see the stale-frontier guard in
+ * `sse-event-consumer`. Held monotonically (highest ceiling wins) so a second
+ * reset never narrows the window, and cleared with the cursor on an assistant
+ * switch, which is a fresh seq space.
+ */
+let abandonedGenerationCeiling: number | null = null;
+
+/**
  * The highest global seq applied so far, or `null` if no event with a
  * seq has been seen yet.
  */
 export function getReconnectCursor(): number | null {
   return reconnectCursor;
+}
+
+/**
+ * Record a seq-generation reset that abandoned every seq up to
+ * `abandonedCeiling` — the cursor value observed immediately before the
+ * daemon's counter restarted lower. Monotonic: retains the highest ceiling
+ * seen so a later, smaller reset never narrows the stale-frontier window.
+ */
+export function recordAbandonedGeneration(abandonedCeiling: number): void {
+  if (
+    abandonedGenerationCeiling === null ||
+    abandonedCeiling > abandonedGenerationCeiling
+  ) {
+    abandonedGenerationCeiling = abandonedCeiling;
+  }
+}
+
+/**
+ * The ceiling of the most recent abandoned seq generation, or `null` when no
+ * generation reset has been observed on this connection's seq space.
+ */
+export function getAbandonedGenerationCeiling(): number | null {
+  return abandonedGenerationCeiling;
 }
 
 /**
@@ -68,4 +109,5 @@ export function replaceReconnectCursor(seq: number): void {
  */
 export function resetReconnectCursor(): void {
   reconnectCursor = null;
+  abandonedGenerationCeiling = null;
 }

--- a/clients/web/src/lib/streaming/stream-transport.test.ts
+++ b/clients/web/src/lib/streaming/stream-transport.test.ts
@@ -26,6 +26,8 @@ mock.module("@sentry/react", () => ({
 let mockReconnectCursor: number | null = null;
 mock.module("@/lib/streaming/reconnect-cursor", () => ({
   getReconnectCursor: () => mockReconnectCursor,
+  getAbandonedGenerationCeiling: () => null,
+  recordAbandonedGeneration: () => {},
 }));
 
 import { getLifecycleDiagnosticsEvents } from "@/lib/diagnostics";


### PR DESCRIPTION
Addresses Codex review feedback on #38483.

## Problem

#38483 added a client-side stale-frontier guard: when a live SSE event's `seq` trailed its conversation's local-seq frontier by ≥ `SSE_REPLAY_RING_COUNT_LIMIT`, the frontier was treated as a stale seq-generation anchor — cleared, and the event applied.

Codex (P2) flagged that gap **size** is not a sound signal. `recordLocalSeq` is also called from the `/messages` snapshot paths (`use-conversation-history.ts:178`, `use-message-reconciliation.ts:118`), and `seq` is a single **global** counter across all conversations. During a bursty turn or a main-thread stall, a snapshot advances the frontier far past where the queued live backlog sits, so a valid old queued frame trails the frontier by more than the ring — with **no daemon reset**. The old heuristic then cleared the frontier and re-applied that frame (and, because the frontier was re-seeded low, the rest of the queued backlog too), duplicating deltas / rolling back chat control state until reconciliation repaired it.

## Invariant chosen

A frontier is a stale (dead-generation) anchor **only** inside the re-climb window of an **observed** generation reset:

- the client saw a backwards `seq` jump (`eventSeq < stored` — the daemon's counter restarted), recording the abandoned generation's ceiling via `recordAbandonedGeneration(stored)`;
- the live cursor has **not yet** re-climbed to that ceiling (`liveCursor < abandonedCeiling`); and
- the frontier sits at or above the ceiling (`localSeq >= abandonedCeiling`).

Only then is the frontier provably from a dead generation the live stream hasn't reached, so clearing + applying is safe. Outside that window (no reset, or the cursor already re-passed the ceiling) a large under-frontier gap is a legitimate snapshot overlap: the events are contained in the snapshot, so they drop as ordinary replays and the frontier is **held** — the whole backlog stays suppressed rather than re-applying. Gap size is no longer consulted for this decision.

The abandoned-ceiling is a seq-generation / connection fact (like the reconnect cursor), so it lives in `reconnect-cursor.ts` and is cleared on assistant switch (a fresh seq space), monotonic across resets.

## Why the stale-anchor self-heal is preserved

The incident #38483 fixed: a warm client observes the daemon crash-restart (backwards `seq` → generation reset), clears its frontiers, then a `/messages` request that raced the reset re-poisons a frontier with the dead generation's anchor. Because the reset **was** observed, `abandonedGenerationCeiling` is set; the re-poisoned frontier sits at the abandoned ceiling while the live cursor is below it → the guard fires, clears the frontier, and live events resume applying. Covered end-to-end by the rewritten test (it now drives a real generation reset first, matching the incident sequence).

## Trade-off (documented in code)

One exotic poison variant is no longer covered by the client guard: a fresh page load where the SSE first event seeds the cursor **before** a stale `/messages` anchor arrives (so no backwards jump is observed) against an un-updated daemon. #38483's daemon-side fix (counter floored above every persisted anchor on restart) eliminates that variant at the source; absent the fix it degrades to pre-#38483 behavior — self-recovers as the counter climbs / on the next reconcile — not a hard regression. This is the deliberate cost of refusing to false-positive on the common benign overlap, which the two cases are otherwise numerically indistinguishable from.

## Tests

- `sse-event-consumer.test.ts`:
  - faithful re-poison-after-reset **heal** (drives a real generation reset first, then a racing stale anchor);
  - **NEW** benign large-overlap-with-no-reset case: the over-ring event drops as an ordinary replay, the frontier is held, a second backlog frame also drops, and `sse_local_seq_stale_generation` does **not** fire;
  - **NEW** window-boundary case: reset observed but the cursor re-climbed past the ceiling → ordinary replay.
- `reconnect-cursor.test.ts`: `recordAbandonedGeneration` monotonicity + cleared on reset.
- Completed the `reconnect-cursor` mock surface in `cold-anchor` / `sse-service` / `stream-transport` tests (shared-process `mock.module`-leakage hygiene; CI runs each file isolated so this only affects local multi-file runs).

Touched web tests pass in CI-style per-file isolation (`bun scripts/run-tests.ts`). `stream-transport.test.ts` / `use-message-reconciliation.test.tsx` fail only on absent gitignored generated code in this worktree — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)