### PR TITLE
feat(web): full-screen upgrade takeover for the provisioning step

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -43,6 +43,19 @@ mock.module("@/stores/organization-store", () => ({
   },
 }));
 
+// Stub the takeover avatar hook so the provisioning target's avatar doesn't
+// fire (404-ing) fetches that each invalidateQueries() would await, slowing
+// the polls past the test budget.
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    components: null,
+    traits: null,
+    customImageUrl: null,
+    isLoading: false,
+    invalidate: () => {},
+  }),
+}));
+
 const realDateNow = Date.now.bind(Date);
 let dateNowOffsetMs = 0;
 Date.now = () => realDateNow() + dateNowOffsetMs;

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -210,7 +210,7 @@ describe("BillingOnboardingModal", () => {
 
     await waitFor(() =>
       expect(
-        getByText("Payment confirmed — setting up your upgrade…"),
+        getByText("Confirming your upgrade…"),
       ).toBeTruthy(),
     );
     expect(getByText("Super package")).toBeTruthy();
@@ -218,21 +218,21 @@ describe("BillingOnboardingModal", () => {
     subscriptionPlanId = "pro";
     await client.invalidateQueries();
     await waitFor(
-      () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
 
     operationalStatusResponse = makeOperationalStatus("resizing_machine");
     await client.invalidateQueries();
     await waitFor(
-      () => expect(getByText("Resizing your assistant…")).toBeTruthy(),
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
 
     assistantResponse = makeAssistant("large", 50);
     operationalStatusResponse = makeOperationalStatus("active");
     await client.invalidateQueries();
-    await waitFor(() => expect(getByText("Your upgrade is ready")).toBeTruthy(), {
+    await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
       timeout: 5000,
     });
     // The celebration dwell elapses and the wizard advances to the domain step.
@@ -248,7 +248,7 @@ describe("BillingOnboardingModal", () => {
     const { client, getByText, queryByText } = renderModal();
 
     await waitFor(
-      () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
     // Wait for the pre-resize actuals to land (the "from" card) before
@@ -274,7 +274,7 @@ describe("BillingOnboardingModal", () => {
     const { client, getByText, queryByText } = renderModal();
 
     await waitFor(
-      () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
     // The resource cards appear once the onboarding targets land.
@@ -315,14 +315,14 @@ describe("BillingOnboardingModal", () => {
     const { client, getByText, getByTestId } = renderModal();
 
     await waitFor(
-      () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
 
     // Jump the wall clock past the stall threshold; the hook's next clock
     // tick re-derives the state as STALLED.
     dateNowOffsetMs = 200_000;
-    await waitFor(() => expect(getByText("One more step")).toBeTruthy(), {
+    await waitFor(() => expect(getByText("We couldn't finish this automatically")).toBeTruthy(), {
       timeout: 5000,
     });
 
@@ -333,7 +333,7 @@ describe("BillingOnboardingModal", () => {
 
     // The successful apply resumes observation: back to the resizing UI…
     await waitFor(
-      () => expect(getByText("Resizing your assistant…")).toBeTruthy(),
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
 
@@ -341,7 +341,7 @@ describe("BillingOnboardingModal", () => {
     assistantResponse = makeAssistant("large", 50);
     await client.invalidateQueries();
     await waitFor(
-      () => expect(getByText("Your upgrade is ready")).toBeTruthy(),
+      () => expect(getByText("All done!")).toBeTruthy(),
       { timeout: 5000 },
     );
     await waitFor(() => expect(getByText("Assistant email")).toBeTruthy(), {
@@ -370,7 +370,7 @@ describe("BillingOnboardingModal", () => {
       () =>
         expect(
           getByText(
-            "Your payment went through safely — we're still confirming your upgrade with Stripe. This can take a minute.",
+            "Your payment went through safely — this can take a minute.",
           ),
         ).toBeTruthy(),
       { timeout: TEST_CONFIRM_TIMEOUT_MS + 3000 },
@@ -379,7 +379,7 @@ describe("BillingOnboardingModal", () => {
     subscriptionPlanId = "pro";
     fireEvent.click(getByTestId("onboarding-retry"));
     await waitFor(
-      () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
   });
@@ -389,7 +389,7 @@ describe("BillingOnboardingModal", () => {
     const { client, getByText, getByTestId, getByLabelText } = renderModal();
 
     await waitFor(
-      () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
 
@@ -439,7 +439,7 @@ describe("BillingOnboardingModal", () => {
       const { client, getByText, getByTestId, queryByText } = renderModal();
 
       await waitFor(
-        () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+        () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
         { timeout: 5000 },
       );
       dateNowOffsetMs = 61_000;
@@ -468,7 +468,7 @@ describe("BillingOnboardingModal", () => {
       const { getByText, getByTestId, queryByTestId } = renderModal();
 
       await waitFor(
-        () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+        () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
         { timeout: 5000 },
       );
       // Give the routing latch time to settle: still no escape hatch, because
@@ -494,7 +494,7 @@ describe("BillingOnboardingModal", () => {
     const { getByText, getByTestId, queryByTestId } = renderModal();
 
     await waitFor(
-      () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
     dateNowOffsetMs = 61_000;
@@ -518,11 +518,11 @@ describe("BillingOnboardingModal", () => {
     const { client, getByText, getByTestId } = renderModal();
 
     await waitFor(
-      () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
     dateNowOffsetMs = 200_000;
-    await waitFor(() => expect(getByText("One more step")).toBeTruthy(), {
+    await waitFor(() => expect(getByText("We couldn't finish this automatically")).toBeTruthy(), {
       timeout: 5000,
     });
 
@@ -534,14 +534,14 @@ describe("BillingOnboardingModal", () => {
         getByText("Another assistant operation is already in progress."),
       ).toBeTruthy(),
     );
-    expect(getByText("One more step")).toBeTruthy();
+    expect(getByText("We couldn't finish this automatically")).toBeTruthy();
 
     // If a server-side resize was in fact still running, its landing is
     // observed by the actuals polling and replaces the stalled UI.
     assistantResponse = makeAssistant("large", 50);
     await client.invalidateQueries();
     await waitFor(
-      () => expect(getByText("Your upgrade is ready")).toBeTruthy(),
+      () => expect(getByText("All done!")).toBeTruthy(),
       { timeout: 5000 },
     );
   });
@@ -555,7 +555,7 @@ describe("BillingOnboardingModal", () => {
         renderModal();
 
       await waitFor(
-        () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+        () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
         { timeout: 5000 },
       );
       dateNowOffsetMs = 61_000;
@@ -608,7 +608,7 @@ describe("BillingOnboardingModal", () => {
       } = renderModal();
 
       await waitFor(
-        () => expect(getByText("Setting up your new resources…")).toBeTruthy(),
+        () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
         { timeout: 5000 },
       );
       dateNowOffsetMs = 61_000;

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -172,6 +172,7 @@ export function BillingOnboardingModal({
           fromSnapshot={provisioning.actualsSnapshot ?? EMPTY_DIMENSIONS}
           celebrating={routingSettled}
           onCelebrationEnd={advanceFromProvisioning}
+          assistantId={assistantId}
           escapeAvailable={
             machineBusy && routingSettled && provisioning.escapeEligible
           }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -1,17 +1,41 @@
 /**
  * Tests for the pure-props `ProvisioningState` takeover. Renders via
  * `@testing-library/react` (happy-dom registered in test-setup.ts) wrapped in
- * a `QueryClientProvider` because the takeover avatar reads the active
- * assistant's avatar through React Query — no active assistant is set, so the
- * avatar resolves to its neutral fallback and every phase is still driven
- * entirely through props.
+ * a `QueryClientProvider`. The takeover avatar hook is mocked to record the id
+ * it's queried with — the avatar resolves to its neutral fallback (null
+ * components) — so every phase stays driven through props while the
+ * avatar-target wiring can be asserted directly.
  */
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
 import type { ProvisioningStateProps } from "./provisioning-state";
-import { ProvisioningState } from "./provisioning-state";
+
+/** The id handed to the avatar hook, captured so the target-selection wiring
+ *  can be asserted without a network fetch. */
+let avatarQueryId: string | null | undefined;
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: (assistantId: string | null) => {
+    avatarQueryId = assistantId;
+    return {
+      components: null,
+      traits: null,
+      customImageUrl: null,
+      isLoading: false,
+      invalidate: () => {},
+    };
+  },
+}));
+
+const { ProvisioningState } = await import("./provisioning-state");
+
+beforeEach(() => {
+  avatarQueryId = undefined;
+  useResolvedAssistantsStore.setState({ activeAssistantId: null });
+});
 
 afterEach(() => {
   cleanup();
@@ -287,5 +311,25 @@ describe("escape hatch", () => {
       escapeAvailable: false,
     });
     expect(queryByTestId("provisioning-escape")).toBeNull();
+  });
+});
+
+describe("takeover avatar", () => {
+  test("queries the avatar for the passed provisioning target assistant", () => {
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "active-assistant",
+    });
+    renderState({ assistantId: "primary-assistant" });
+
+    expect(avatarQueryId).toBe("primary-assistant");
+  });
+
+  test("falls back to the active-store assistant when no target is passed", () => {
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "active-assistant",
+    });
+    renderState();
+
+    expect(avatarQueryId).toBe("active-assistant");
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -1,9 +1,13 @@
 /**
- * Tests for the pure-props `ProvisioningState` screen. Renders via
- * `@testing-library/react` (happy-dom registered in test-setup.ts); no
- * network mocks — every phase is driven entirely through props.
+ * Tests for the pure-props `ProvisioningState` takeover. Renders via
+ * `@testing-library/react` (happy-dom registered in test-setup.ts) wrapped in
+ * a `QueryClientProvider` because the takeover avatar reads the active
+ * assistant's avatar through React Query — no active assistant is set, so the
+ * avatar resolves to its neutral fallback and every phase is still driven
+ * entirely through props.
  */
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
 import type { ProvisioningStateProps } from "./provisioning-state";
@@ -33,23 +37,34 @@ function baseProps(
 }
 
 function renderState(overrides: Partial<ProvisioningStateProps> = {}) {
-  return render(<ProvisioningState {...baseProps(overrides)} />);
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ProvisioningState {...baseProps(overrides)} />
+    </QueryClientProvider>,
+  );
 }
 
 describe("confirming", () => {
-  test("renders the payment-confirmed headline with a package chip", () => {
+  test("renders the confirming status line and caption", () => {
+    const { getByText } = renderState({ state: "CONFIRMING" });
+
+    expect(getByText("Confirming your upgrade…")).toBeTruthy();
+    expect(getByText("This might take a couple seconds.")).toBeTruthy();
+  });
+
+  test("renders a package chip from the stashed intent", () => {
     const { getByText } = renderState({
       state: "CONFIRMING",
       intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
     });
 
-    expect(
-      getByText("Payment confirmed — setting up your upgrade…"),
-    ).toBeTruthy();
     expect(getByText("Mighty package")).toBeTruthy();
   });
 
-  test("renders custom-intent tier chips, omitting the credits chip when null", () => {
+  test("renders custom-intent machine/storage chips, omitting credits when null", () => {
     const { getByText, queryByText } = renderState({
       state: "CONFIRMING",
       intent: {
@@ -61,8 +76,10 @@ describe("confirming", () => {
       },
     });
 
-    expect(getByText("Large machine")).toBeTruthy();
-    expect(getByText("XL storage")).toBeTruthy();
+    expect(getByText("Machine")).toBeTruthy();
+    expect(getByText("Large")).toBeTruthy();
+    expect(getByText("Storage")).toBeTruthy();
+    expect(getByText("XL")).toBeTruthy();
     expect(queryByText(/credits/)).toBeNull();
   });
 
@@ -80,39 +97,33 @@ describe("confirming", () => {
 
     expect(getByText("50 credits")).toBeTruthy();
   });
-
 });
 
 describe("waiting / resizing", () => {
-  test("renders machine and storage cards with the from-snapshot and restart warning", () => {
+  test("renders the upgrading status with machine and storage from→to chips", () => {
     const { getByText } = renderState({
       state: "WAITING",
       targets: { machineSize: "large", storageGib: 100 },
       fromSnapshot: { machineSize: "small", storageGib: 30 },
     });
 
-    expect(getByText("Setting up your new resources…")).toBeTruthy();
+    expect(getByText("Upgrading your assistant…")).toBeTruthy();
     expect(getByText("Machine")).toBeTruthy();
     expect(getByText("Small")).toBeTruthy();
     expect(getByText("Large")).toBeTruthy();
     expect(getByText("Storage")).toBeTruthy();
     expect(getByText("30 GiB")).toBeTruthy();
     expect(getByText("100 GiB")).toBeTruthy();
-    expect(
-      getByText(
-        "Your assistant is restarting itself — it may look offline for a minute.",
-      ),
-    ).toBeTruthy();
   });
 
-  test("storage-only targets render a single storage card and no machine card", () => {
+  test("storage-only targets render a single storage chip and no machine chip", () => {
     const { getByText, queryByText } = renderState({
       state: "RESIZING",
       targets: { machineSize: null, storageGib: 100 },
       fromSnapshot: { machineSize: "small", storageGib: 30 },
     });
 
-    expect(getByText("Resizing your assistant…")).toBeTruthy();
+    expect(getByText("Upgrading your assistant…")).toBeTruthy();
     expect(getByText("Storage")).toBeTruthy();
     expect(queryByText("Machine")).toBeNull();
   });
@@ -123,36 +134,44 @@ describe("waiting / resizing", () => {
       targets: { machineSize: "medium", storageGib: null },
     });
 
-    expect(getByText("This usually takes under a minute.")).toBeTruthy();
+    expect(getByText("This might take a couple seconds.")).toBeTruthy();
 
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     rerender(
-      <ProvisioningState
-        {...baseProps({
-          state: "WAITING",
-          softWaiting: true,
-          targets: { machineSize: "medium", storageGib: null },
-        })}
-      />,
+      <QueryClientProvider client={client}>
+        <ProvisioningState
+          {...baseProps({
+            state: "WAITING",
+            softWaiting: true,
+            targets: { machineSize: "medium", storageGib: null },
+          })}
+        />
+      </QueryClientProvider>,
     );
     expect(
-      getByText(
-        "Still working — this can take a few minutes. Everything is on track.",
-      ),
+      getByText("Still working — this can take a minute or two."),
     ).toBeTruthy();
   });
 });
 
 describe("done / not_applicable", () => {
-  test("done renders the celebration headline and fires onCelebrationEnd after the dwell", async () => {
+  test("done renders the all-done status, target chips, and fires onCelebrationEnd after the dwell", async () => {
     const onCelebrationEnd = mock(() => {});
     const { getByText } = renderState({
       state: "DONE",
+      targets: { machineSize: "large", storageGib: 100 },
+      fromSnapshot: { machineSize: "small", storageGib: 30 },
       celebrating: true,
       onCelebrationEnd,
       dwellMs: 10,
     });
 
-    expect(getByText("Your upgrade is ready")).toBeTruthy();
+    expect(getByText("All done!")).toBeTruthy();
+    expect(getByText("Large")).toBeTruthy();
+    expect(getByText("100 GiB")).toBeTruthy();
+    // The "from" side is dropped once done — only the achieved target shows.
     await waitFor(() => expect(onCelebrationEnd).toHaveBeenCalledTimes(1));
   });
 
@@ -169,7 +188,7 @@ describe("done / not_applicable", () => {
     expect(onCelebrationEnd).not.toHaveBeenCalled();
   });
 
-  test("not_applicable renders the plan-ready notice without cards or an Apply button", async () => {
+  test("not_applicable renders the plan-ready status without chips or an Apply button", async () => {
     const onCelebrationEnd = mock(() => {});
     const { getByText, queryByText, queryByTestId } = renderState({
       state: "NOT_APPLICABLE",
@@ -179,17 +198,15 @@ describe("done / not_applicable", () => {
     });
 
     expect(getByText("Your plan is ready")).toBeTruthy();
-    expect(
-      getByText("No resource changes were needed — you're all set."),
-    ).toBeTruthy();
     expect(queryByText("Machine")).toBeNull();
+    expect(queryByText("Storage")).toBeNull();
     expect(queryByTestId("provisioning-apply")).toBeNull();
     await waitFor(() => expect(onCelebrationEnd).toHaveBeenCalledTimes(1));
   });
 });
 
 describe("stalled", () => {
-  test("renders the amber notice and Apply & Restart invokes the callback", () => {
+  test("renders the stalled status, keeps the chips, and Apply & Restart invokes the callback", () => {
     const onApply = mock(() => {});
     const { getByText, getByTestId } = renderState({
       state: "STALLED",
@@ -198,16 +215,18 @@ describe("stalled", () => {
       stalledAction: { onApply, pending: false, error: null },
     });
 
+    expect(getByText("We couldn't finish this automatically")).toBeTruthy();
     expect(
       getByText(
-        "We couldn't finish this automatically. Apply the changes below to finish setting up your upgrade.",
+        "Apply the changes below to finish setting up your upgrade.",
       ),
     ).toBeTruthy();
+    expect(getByText("Machine")).toBeTruthy();
     fireEvent.click(getByTestId("provisioning-apply"));
     expect(onApply).toHaveBeenCalledTimes(1);
   });
 
-  test("disables the Apply button while pending and renders the extracted error", () => {
+  test("disables the Apply button while pending and renders the extracted error as the caption", () => {
     const onApply = mock(() => {});
     const { getByText, getByTestId } = renderState({
       state: "STALLED",
@@ -227,7 +246,7 @@ describe("stalled", () => {
 });
 
 describe("confirm_timeout", () => {
-  test("renders the payment-safety reassurance with retry and billing actions", () => {
+  test("renders the still-confirming reassurance with retry and billing actions", () => {
     const onRetry = mock(() => {});
     const onGoToBilling = mock(() => {});
     const { getByText, getByTestId } = renderState({
@@ -235,9 +254,10 @@ describe("confirm_timeout", () => {
       confirm: { onRetry, onGoToBilling },
     });
 
+    expect(getByText("Still confirming your upgrade")).toBeTruthy();
     expect(
       getByText(
-        "Your payment went through safely — we're still confirming your upgrade with Stripe. This can take a minute.",
+        "Your payment went through safely — this can take a minute.",
       ),
     ).toBeTruthy();
     fireEvent.click(getByTestId("onboarding-retry"));

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -36,6 +36,8 @@ export interface ProvisioningStateProps {
   fromSnapshot: ProvisioningDimensions;
   celebrating: boolean;
   onCelebrationEnd: () => void;
+  /** The assistant being provisioned — drives the takeover avatar. */
+  assistantId?: string | null;
   escapeAvailable: boolean;
   onEscape: () => void;
   stalledAction: StalledApplyAction;
@@ -50,9 +52,10 @@ export interface ProvisioningStateProps {
  * the avatar resolves or when none is configured. The idle breathe + reduced
  * -motion gating come from `AnimatedAvatar` inside `ChatAvatar`.
  */
-function TakeoverAvatar() {
-  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const { components, traits, customImageUrl } = useAssistantAvatar(assistantId);
+function TakeoverAvatar({ assistantId }: { assistantId?: string | null }) {
+  const activeId = useResolvedAssistantsStore.use.activeAssistantId();
+  const resolvedId = assistantId ?? activeId;
+  const { components, traits, customImageUrl } = useAssistantAvatar(resolvedId);
   const fallbackComponents = useBundledAvatarComponents();
   return (
     <div aria-hidden className="flex flex-col items-center">
@@ -255,6 +258,7 @@ export function ProvisioningState({
   fromSnapshot,
   celebrating,
   onCelebrationEnd,
+  assistantId,
   escapeAvailable,
   onEscape,
   stalledAction,
@@ -282,7 +286,7 @@ export function ProvisioningState({
       className="relative flex h-full min-h-[420px] w-full flex-col items-center justify-center gap-6 px-6 py-10 text-center"
       style={{ backgroundColor: TAKEOVER_BACKGROUND }}
     >
-      <TakeoverAvatar />
+      <TakeoverAvatar assistantId={assistantId} />
       <div className="flex flex-col items-center gap-2 [animation:onboarding-step-in_350ms_ease-out] motion-reduce:[animation:none]">
         {renderPhase()}
       </div>

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -1,29 +1,29 @@
-import { AlertCircle, Check, Cpu, HardDrive, PartyPopper } from "lucide-react";
-import { useEffect, useRef } from "react";
+import type { LucideIcon } from "lucide-react";
+import { ArrowRight, Check, Cpu, HardDrive } from "lucide-react";
+import { useEffect, useRef, type ReactNode } from "react";
 
+import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
-import {
-    MACHINE_TIER_LABEL,
-    SIZE_DESCRIPTION,
-    SIZE_LABEL,
-} from "@/lib/billing/machine-sizes";
+import { MACHINE_TIER_LABEL, SIZE_LABEL } from "@/lib/billing/machine-sizes";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { Button } from "@vellumai/design-library/components/button";
-import { Notice } from "@vellumai/design-library/components/notice";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import type {
     ProvisioningDimensions,
     ProvisioningStateKind,
 } from "./provisioning-machine";
-import { TimeoutState } from "./error-states";
 import type { StalledApplyAction } from "./primitives";
-import {
-    GlowSpinner,
-    IconBadge,
-    ResourceCard,
-    StalledApplyControls,
-} from "./primitives";
-import { PROVISION_MIN_DWELL_MS } from "./utils";
+import { extractOnboardingErrorMessage, PROVISION_MIN_DWELL_MS } from "./utils";
+
+// The mock's takeover tint, matched to the green Vellum creature. No token
+// holds this, so it follows the plans-page PAGE_BACKGROUND raw-hex precedent.
+const TAKEOVER_BACKGROUND = "#1D271E";
+
+const CHIP_BACKGROUND =
+  "color-mix(in srgb, var(--content-emphasised) 10%, transparent)";
 
 export interface ProvisioningStateProps {
   state: ProvisioningStateKind;
@@ -32,7 +32,7 @@ export interface ProvisioningStateProps {
   /** The checkout selection stashed before the Stripe redirect. */
   intent: CheckoutIntent | null;
   targets: ProvisioningDimensions;
-  /** Pre-resize actuals rendered as the "from" side of the resource cards. */
+  /** Pre-resize actuals rendered as the "from" side of the resource chips. */
   fromSnapshot: ProvisioningDimensions;
   celebrating: boolean;
   onCelebrationEnd: () => void;
@@ -44,100 +44,206 @@ export interface ProvisioningStateProps {
   dwellMs?: number;
 }
 
-function intentChipLabels(intent: CheckoutIntent): string[] {
-  if (intent.kind === "package") {
-    const name =
-      intent.packageKey.charAt(0).toUpperCase() + intent.packageKey.slice(1);
-    return [`${name} package`];
-  }
-  const labels: string[] = [];
-  if (intent.machineTier != null) {
-    const tierLabel = MACHINE_TIER_LABEL[intent.machineTier] ?? intent.machineTier;
-    labels.push(`${tierLabel} machine`);
-  }
-  if (intent.storageTier != null) {
-    labels.push(`${intent.storageTier.toUpperCase()} storage`);
-  }
-  if (intent.creditTier != null) {
-    labels.push(`${intent.creditTier.replace("credits_", "")} credits`);
-  }
-  return labels;
-}
-
-function IntentChips({ intent }: { intent: CheckoutIntent }) {
+/**
+ * The user's assistant avatar, centered and oversized as the takeover's focal
+ * point. Falls back to a neutral bundled creature (and finally the "V") while
+ * the avatar resolves or when none is configured. The idle breathe + reduced
+ * -motion gating come from `AnimatedAvatar` inside `ChatAvatar`.
+ */
+function TakeoverAvatar() {
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const { components, traits, customImageUrl } = useAssistantAvatar(assistantId);
+  const fallbackComponents = useBundledAvatarComponents();
   return (
-    <div className="flex flex-wrap items-center justify-center gap-1.5">
-      {intentChipLabels(intent).map((label) => (
-        <span
-          key={label}
-          className="rounded-full border border-[var(--border-element)] bg-[var(--surface-base)] px-2.5 py-1 text-label-small-default text-[var(--content-secondary)]"
-        >
-          {label}
-        </span>
-      ))}
+    <div aria-hidden className="flex flex-col items-center">
+      <ChatAvatar
+        components={components ?? fallbackComponents}
+        traits={traits}
+        customImageUrl={customImageUrl}
+        size={240}
+      />
+      <div
+        className="mt-1 h-4 w-40"
+        style={{
+          background:
+            "radial-gradient(ellipse at center, rgba(0, 0, 0, 0.45), transparent 70%)",
+        }}
+      />
     </div>
   );
 }
 
-function ResourceCardList({
-  targets,
-  fromSnapshot,
-}: {
-  targets: ProvisioningDimensions;
-  fromSnapshot: ProvisioningDimensions;
-}) {
+function Copy({ status, caption }: { status: string; caption?: string }) {
   return (
-    <div className="flex w-full flex-col gap-2">
-      {targets.machineSize != null && (
-        <ResourceCard
-          icon={Cpu}
-          label="Machine"
-          from={
-            fromSnapshot.machineSize != null
-              ? SIZE_LABEL[fromSnapshot.machineSize]
-              : "—"
-          }
-          fromDetail={
-            fromSnapshot.machineSize != null
-              ? SIZE_DESCRIPTION[fromSnapshot.machineSize]
-              : undefined
-          }
-          to={SIZE_LABEL[targets.machineSize]}
-          toDetail={SIZE_DESCRIPTION[targets.machineSize]}
-        />
-      )}
-      {targets.storageGib != null && (
-        <ResourceCard
-          icon={HardDrive}
-          label="Storage"
-          from={
-            fromSnapshot.storageGib != null
-              ? `${fromSnapshot.storageGib} GiB`
-              : "—"
-          }
-          to={`${targets.storageGib} GiB`}
-        />
-      )}
-    </div>
-  );
-}
-
-function Headline({ title, body }: { title: string; body?: string }) {
-  return (
-    <div className="space-y-1.5">
-      <Typography variant="title-small" as="h1">
-        {title}
-      </Typography>
-      {body && (
+    <div className="flex flex-col items-center gap-1.5">
+      <h1
+        className="text-[var(--content-emphasised)]"
+        style={{
+          fontFamily: "var(--font-serif)",
+          fontSize: "32px",
+          fontWeight: 400,
+          letterSpacing: "0.64px",
+          lineHeight: 1.2,
+        }}
+      >
+        {status}
+      </h1>
+      {caption && (
         <Typography
           variant="body-medium-lighter"
           as="p"
-          className="text-[var(--content-secondary)]"
+          className="max-w-sm text-[var(--content-secondary)]"
         >
-          {body}
+          {caption}
         </Typography>
       )}
     </div>
+  );
+}
+
+function DimensionChip({
+  icon: Icon,
+  label,
+  from,
+  to,
+  done = false,
+}: {
+  icon: LucideIcon;
+  label: string;
+  from?: string;
+  to: string;
+  done?: boolean;
+}) {
+  return (
+    <div
+      className="flex items-center gap-2.5 rounded-lg px-3 py-2"
+      style={{ backgroundColor: CHIP_BACKGROUND }}
+    >
+      <Icon
+        className="h-6 w-6 shrink-0 text-[var(--content-secondary)]"
+        aria-hidden="true"
+      />
+      <div className="flex flex-col text-left">
+        <span className="text-[12px] leading-tight text-[var(--content-tertiary)]">
+          {label}
+        </span>
+        <span className="flex items-center gap-1.5 text-[14px] leading-tight text-[var(--content-emphasised)]">
+          {from && (
+            <>
+              <span>{from}</span>
+              <ArrowRight
+                className="h-3 w-3 shrink-0 text-[var(--content-tertiary)]"
+                aria-hidden="true"
+              />
+            </>
+          )}
+          <span>{to}</span>
+          {done && (
+            <Check
+              className="h-3.5 w-3.5 shrink-0 text-[var(--system-positive-strong)]"
+              aria-hidden="true"
+            />
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function TextChip({ label }: { label: string }) {
+  return (
+    <span
+      className="rounded-lg px-3 py-2 text-[14px] text-[var(--content-emphasised)]"
+      style={{ backgroundColor: CHIP_BACKGROUND }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function ChipRow({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-2">
+      {children}
+    </div>
+  );
+}
+
+/** CONFIRMING chips: derived from the stashed intent before any API data lands. */
+function IntentChips({ intent }: { intent: CheckoutIntent }) {
+  if (intent.kind === "package") {
+    const name =
+      intent.packageKey.charAt(0).toUpperCase() + intent.packageKey.slice(1);
+    return (
+      <ChipRow>
+        <TextChip label={`${name} package`} />
+      </ChipRow>
+    );
+  }
+  return (
+    <ChipRow>
+      {intent.machineTier != null && (
+        <DimensionChip
+          icon={Cpu}
+          label="Machine"
+          to={MACHINE_TIER_LABEL[intent.machineTier] ?? intent.machineTier}
+        />
+      )}
+      {intent.storageTier != null && (
+        <DimensionChip
+          icon={HardDrive}
+          label="Storage"
+          to={intent.storageTier.toUpperCase()}
+        />
+      )}
+      {intent.creditTier != null && (
+        <TextChip
+          label={`${intent.creditTier.replace("credits_", "")} credits`}
+        />
+      )}
+    </ChipRow>
+  );
+}
+
+/** Machine/Storage from→to chips, driven by the resolved provisioning targets. */
+function TargetChips({
+  targets,
+  fromSnapshot,
+  done = false,
+}: {
+  targets: ProvisioningDimensions;
+  fromSnapshot: ProvisioningDimensions;
+  done?: boolean;
+}) {
+  return (
+    <ChipRow>
+      {targets.machineSize != null && (
+        <DimensionChip
+          icon={Cpu}
+          label="Machine"
+          from={
+            !done && fromSnapshot.machineSize != null
+              ? SIZE_LABEL[fromSnapshot.machineSize]
+              : undefined
+          }
+          to={SIZE_LABEL[targets.machineSize]}
+          done={done}
+        />
+      )}
+      {targets.storageGib != null && (
+        <DimensionChip
+          icon={HardDrive}
+          label="Storage"
+          from={
+            !done && fromSnapshot.storageGib != null
+              ? `${fromSnapshot.storageGib} GiB`
+              : undefined
+          }
+          to={`${targets.storageGib} GiB`}
+          done={done}
+        />
+      )}
+    </ChipRow>
   );
 }
 
@@ -170,45 +276,44 @@ export function ProvisioningState({
     return () => clearTimeout(t);
   }, [dwelling, dwellMs]);
 
-  if (state === "CONFIRM_TIMEOUT") {
-    return (
-      <TimeoutState
-        message="Your payment went through safely — we're still confirming your upgrade with Stripe. This can take a minute."
-        onRetry={confirm.onRetry}
-        onGoToBilling={confirm.onGoToBilling}
-      />
-    );
-  }
-
   return (
-    <div className="flex min-h-[320px] flex-col items-center justify-center gap-4 px-6 py-10 text-center [animation:onboarding-step-in_350ms_ease-out] motion-reduce:[animation:none]">
-      {renderPhase()}
-      {escapeAvailable && (
-        <Button
-          variant="ghost"
-          data-testid="provisioning-escape"
-          onClick={onEscape}
-        >
-          Continue in the background
-        </Button>
-      )}
+    <div
+      data-theme="dark"
+      className="relative flex h-full min-h-[420px] w-full flex-col items-center justify-center gap-6 px-6 py-10 text-center"
+      style={{ backgroundColor: TAKEOVER_BACKGROUND }}
+    >
+      <TakeoverAvatar />
+      <div className="flex flex-col items-center gap-2 [animation:onboarding-step-in_350ms_ease-out] motion-reduce:[animation:none]">
+        {renderPhase()}
+      </div>
     </div>
   );
+
+  function escapeButton() {
+    if (!escapeAvailable) {
+      return null;
+    }
+    return (
+      <Button
+        variant="ghost"
+        data-testid="provisioning-escape"
+        onClick={onEscape}
+      >
+        Continue in the background
+      </Button>
+    );
+  }
 
   function renderPhase() {
     if (state === "CONFIRMING") {
       return (
         <>
-          <GlowSpinner />
-          <Headline
-            title="Payment confirmed — setting up your upgrade…"
-            body="We're getting your new plan's resources ready. This usually takes a few seconds."
+          <Copy
+            status="Confirming your upgrade…"
+            caption="This might take a couple seconds."
           />
-          {intent && (
-            <div className="[animation:welcome-reveal_600ms_ease-out_150ms_both] motion-reduce:[animation:none]">
-              <IntentChips intent={intent} />
-            </div>
-          )}
+          {intent && <IntentChips intent={intent} />}
+          {escapeButton()}
         </>
       );
     }
@@ -216,24 +321,16 @@ export function ProvisioningState({
     if (state === "WAITING" || state === "RESIZING") {
       return (
         <>
-          <GlowSpinner />
-          <Headline
-            title={
-              state === "RESIZING"
-                ? "Resizing your assistant…"
-                : "Setting up your new resources…"
-            }
-            body={
+          <Copy
+            status="Upgrading your assistant…"
+            caption={
               softWaiting
-                ? "Still working — this can take a few minutes. Everything is on track."
-                : "This usually takes under a minute."
+                ? "Still working — this can take a minute or two."
+                : "This might take a couple seconds."
             }
           />
-          <ResourceCardList targets={targets} fromSnapshot={fromSnapshot} />
-          <Notice tone="neutral" className="w-full text-left">
-            Your assistant is restarting itself — it may look offline for a
-            minute.
-          </Notice>
+          <TargetChips targets={targets} fromSnapshot={fromSnapshot} />
+          {escapeButton()}
         </>
       );
     }
@@ -241,49 +338,63 @@ export function ProvisioningState({
     if (state === "DONE") {
       return (
         <>
-          <div className="[animation:welcome-reveal_600ms_ease-out_both] motion-reduce:[animation:none]">
-            <IconBadge icon={PartyPopper} />
-          </div>
-          <div className="[animation:welcome-reveal_600ms_ease-out_150ms_both] motion-reduce:[animation:none]">
-            <Headline
-              title="Your upgrade is ready"
-              body="Your assistant is back online with its new resources."
-            />
-          </div>
+          <Copy status="All done!" />
+          <TargetChips targets={targets} fromSnapshot={fromSnapshot} done />
         </>
       );
     }
 
     if (state === "NOT_APPLICABLE") {
-      return (
-        <>
-          <div className="[animation:welcome-reveal_600ms_ease-out_both] motion-reduce:[animation:none]">
-            <IconBadge icon={Check} />
-          </div>
-          <div className="[animation:welcome-reveal_600ms_ease-out_150ms_both] motion-reduce:[animation:none]">
-            <Headline title="Your plan is ready" />
-          </div>
-          <Notice tone="neutral" className="w-full text-left">
-            No resource changes were needed — you&apos;re all set.
-          </Notice>
-        </>
-      );
+      return <Copy status="Your plan is ready" />;
     }
 
     if (state === "STALLED") {
       return (
         <>
-          <IconBadge icon={AlertCircle} tone="warning" />
-          <Headline title="One more step" />
-          <Notice tone="warning" className="w-full text-left">
-            We couldn&apos;t finish this automatically. Apply the changes below
-            to finish setting up your upgrade.
-          </Notice>
-          <ResourceCardList targets={targets} fromSnapshot={fromSnapshot} />
-          <StalledApplyControls
-            action={stalledAction}
-            buttonTestId="provisioning-apply"
+          <Copy
+            status="We couldn't finish this automatically"
+            caption={extractOnboardingErrorMessage(
+              stalledAction.error,
+              "Apply the changes below to finish setting up your upgrade.",
+            )}
           />
+          <TargetChips targets={targets} fromSnapshot={fromSnapshot} />
+          <Button
+            variant="primary"
+            data-testid="provisioning-apply"
+            disabled={stalledAction.pending}
+            onClick={stalledAction.onApply}
+          >
+            Apply &amp; Restart
+          </Button>
+          {escapeButton()}
+        </>
+      );
+    }
+
+    if (state === "CONFIRM_TIMEOUT") {
+      return (
+        <>
+          <Copy
+            status="Still confirming your upgrade"
+            caption="Your payment went through safely — this can take a minute."
+          />
+          <div className="flex items-center gap-2 pt-1">
+            <Button
+              variant="outlined"
+              data-testid="onboarding-go-to-billing"
+              onClick={confirm.onGoToBilling}
+            >
+              Go to billing
+            </Button>
+            <Button
+              variant="primary"
+              data-testid="onboarding-retry"
+              onClick={confirm.onRetry}
+            >
+              Try again
+            </Button>
+          </div>
         </>
       );
     }


### PR DESCRIPTION
## Summary
- Restyle ProvisioningState into a dark full-screen takeover with centered assistant avatar, serif status line, caption, and Machine/Storage from→to chips driven by the polling state machine.

Part of plan: pro-onboarding-figma-polish.md (PR 2 of 5)