### PR TITLE
fix(streaming): give worker-persisted turns an honest snapshot anchor via the daemon

### DIFF
--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -57,6 +57,7 @@ import {
 } from "./ipc-framing.js";
 import { CONTACTS_INFO_IPC_METHODS } from "./routes/contacts-info-ipc-routes.js";
 import { CONTACTS_MIRROR_IPC_METHODS } from "./routes/contacts-mirror-ipc-routes.js";
+import { CONVERSATION_SYNC_IPC_METHODS } from "./routes/conversation-sync-ipc-routes.js";
 import { type DbProxyParams, handleDbProxy } from "./routes/db-proxy.js";
 import { GUARDIAN_LABEL_IPC_METHODS } from "./routes/guardian-label-ipc-routes.js";
 import { INVITE_IPC_METHODS } from "./routes/invite-ipc-routes.js";
@@ -210,6 +211,7 @@ export class AssistantIpcServer {
       CONTACTS_INFO_IPC_METHODS,
       CONTACTS_MIRROR_IPC_METHODS,
       GUARDIAN_LABEL_IPC_METHODS,
+      CONVERSATION_SYNC_IPC_METHODS,
     ]) {
       for (const [operationId, handler] of Object.entries(methodMap)) {
         this.methods.set(operationId, handler);

--- a/assistant/src/ipc/routes/__tests__/conversation-sync-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/conversation-sync-ipc-routes.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The daemon-side handler for the worker → daemon conversation-persist
+ * hand-off. Workers persist a turn's rows then ask the daemon (the sole seq
+ * authority) to record the honest snapshot anchor and republish the
+ * messages-changed invalidation to real subscribers.
+ *
+ * `recordConversationPersistedSeq` and `publishConversationMessagesChanged`
+ * are stubbed to capture calls (their own behavior is covered in their own
+ * suites); the seq authority (`assistant-stream-state`) is exercised for real
+ * so the anchor value the handler records is the daemon's genuine `getCurrentSeq()`.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const recordCalls: Array<[string, number]> = [];
+const publishCalls: string[] = [];
+
+mock.module("../../../persistence/conversation-crud.js", () => ({
+  recordConversationPersistedSeq: (id: string, seq: number) => {
+    recordCalls.push([id, seq]);
+  },
+}));
+
+mock.module("../../../runtime/sync/resource-sync-events.js", () => ({
+  publishConversationMessagesChanged: (id: string) => {
+    publishCalls.push(id);
+  },
+}));
+
+import { DB_MIGRATION_READINESS_EXEMPT_OPERATIONS } from "../../../daemon/daemon-readiness.js";
+import type { AssistantEvent } from "../../../runtime/assistant-event.js";
+import {
+  _resetStreamStateForTesting,
+  stampAndBuffer,
+} from "../../../runtime/assistant-stream-state.js";
+import { NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD } from "../../../runtime/sync/worker-daemon-notify.js";
+import {
+  CONVERSATION_SYNC_IPC_METHODS,
+  handleNotifyConversationPersisted,
+} from "../conversation-sync-ipc-routes.js";
+
+function stampEvent(): void {
+  stampAndBuffer({
+    conversationId: "conv-x",
+    message: { type: "assistant_text_delta", text: "x" },
+  } as unknown as AssistantEvent);
+}
+
+describe("conversation-sync IPC route", () => {
+  beforeEach(() => {
+    recordCalls.length = 0;
+    publishCalls.length = 0;
+    _resetStreamStateForTesting();
+  });
+
+  test("records the anchor at the daemon's current seq and republishes the invalidation", () => {
+    // Advance the daemon's real seq counter so the recorded anchor is a
+    // concrete, non-zero daemon-issued position — never above what it has served.
+    stampEvent();
+    stampEvent();
+    stampEvent(); // getCurrentSeq() === 3
+
+    const result = handleNotifyConversationPersisted({
+      body: { conversationId: "conv-1" },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(recordCalls).toEqual([["conv-1", 3]]);
+    expect(publishCalls).toEqual(["conv-1"]);
+  });
+
+  test("rejects a payload without a conversationId", () => {
+    expect(() => handleNotifyConversationPersisted({ body: {} })).toThrow();
+    expect(recordCalls).toEqual([]);
+    expect(publishCalls).toEqual([]);
+  });
+
+  test("is reachable on the IPC surface under the shared method name", () => {
+    expect(
+      typeof CONVERSATION_SYNC_IPC_METHODS[
+        NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD
+      ],
+    ).toBe("function");
+  });
+
+  test("is DB-migration readiness gated (absent from the exempt set)", () => {
+    // The IPC server gates every non-exempt method on migration readiness, so
+    // the handler's DB touch (`recordConversationPersistedSeq`) never runs
+    // against a partially-migrated schema.
+    expect(
+      DB_MIGRATION_READINESS_EXEMPT_OPERATIONS.has(
+        NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD,
+      ),
+    ).toBe(false);
+  });
+});

--- a/assistant/src/ipc/routes/conversation-sync-ipc-routes.ts
+++ b/assistant/src/ipc/routes/conversation-sync-ipc-routes.ts
@@ -1,0 +1,65 @@
+/**
+ * IPC-only route the sidecar workers (schedule, memory) call after persisting
+ * a conversation's turn rows.
+ *
+ * Workers disable SSE seq stamping (`disableStreamSeqStamping`) so the daemon
+ * is the sole seq authority; a worker's own `getCurrentSeq()` reports `0` and
+ * its `publishConversationMessagesChanged` broadcast reaches no SSE subscriber.
+ * Left there, a worker-persisted turn records no snapshot anchor
+ * (`conversations.seq` stays NULL/stale) and no live client learns the
+ * conversation changed, so an already-open conversation updates only on
+ * switch/reload.
+ *
+ * This route runs the notification on the daemon instead: it records the
+ * snapshot anchor at the daemon's own `getCurrentSeq()` and republishes the
+ * messages-changed invalidation on the daemon's hub, where real subscribers
+ * observe it. (Why anchoring at the current seq is honest: see the handler.)
+ *
+ * IPC-only: registered directly on the assistant IPC server (see
+ * `assistant-server.ts`), never in the shared `ROUTES` array. DB-migration
+ * readiness gating is applied uniformly by the IPC server (the method is not in
+ * `DB_MIGRATION_READINESS_EXEMPT_OPERATIONS`), so it is unavailable until
+ * migrations settle; the worker's call is best-effort and tolerates that.
+ */
+
+import { z } from "zod";
+
+import { recordConversationPersistedSeq } from "../../persistence/conversation-crud.js";
+import { getCurrentSeq } from "../../runtime/assistant-stream-state.js";
+import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
+import { publishConversationMessagesChanged } from "../../runtime/sync/resource-sync-events.js";
+import { NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD } from "../../runtime/sync/worker-daemon-notify.js";
+
+const NotifyConversationPersistedParamsSchema = z.object({
+  conversationId: z.string().min(1),
+});
+
+/**
+ * Record the daemon-issued snapshot anchor for a worker-persisted turn and
+ * republish its messages-changed invalidation to the daemon's subscribers.
+ */
+export function handleNotifyConversationPersisted({
+  body = {},
+}: RouteHandlerArgs) {
+  const { conversationId } =
+    NotifyConversationPersistedParamsSchema.parse(body);
+  // The daemon's live counter is at or above every seq it has served for this
+  // conversation, and the worker's freshly written rows carry no higher seq, so
+  // anchoring at the current seq is honest — never above the served frontier.
+  // `recordConversationPersistedSeq` is monotonic (raise-only) and ignores a
+  // non-positive seq, so a cold daemon (seq 0) simply leaves the anchor as-is.
+  recordConversationPersistedSeq(conversationId, getCurrentSeq());
+  publishConversationMessagesChanged(conversationId);
+  return { ok: true };
+}
+
+/**
+ * IPC-only conversation-sync methods, keyed by operationId. Registered directly
+ * on the assistant IPC server (see `assistant-server.ts`).
+ */
+export const CONVERSATION_SYNC_IPC_METHODS: Record<
+  string,
+  (args: RouteHandlerArgs) => unknown
+> = {
+  [NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD]: handleNotifyConversationPersisted,
+};

--- a/assistant/src/runtime/assistant-stream-state.ts
+++ b/assistant/src/runtime/assistant-stream-state.ts
@@ -189,6 +189,17 @@ export function disableStreamSeqStamping(): void {
 }
 
 /**
+ * Whether seq stamping is disabled in this process ({@link
+ * disableStreamSeqStamping}). `true` in sidecar worker processes, `false` in
+ * the daemon. Callers use it to route seq/anchor authority to the daemon
+ * instead of acting on this process's inert counter — a worker's
+ * `getCurrentSeq()` reports `0` and its hub publishes reach no SSE subscriber.
+ */
+export function isStreamSeqStampingDisabled(): boolean {
+  return stampingDisabled;
+}
+
+/**
  * Assign a monotonic global `seq` to a conversation-scoped event and push
  * it onto the ring buffer. No-op when `event.conversationId` is absent
  * (unscoped broadcasts are never replayable) and in processes where

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -7,7 +7,9 @@ import {
 } from "../../daemon/message-types/sync.js";
 import { getAvatarImagePath } from "../../util/platform.js";
 import { broadcastMessage } from "../assistant-event-hub.js";
+import { isStreamSeqStampingDisabled } from "../assistant-stream-state.js";
 import { publishSyncInvalidation } from "./sync-publisher.js";
+import { notifyDaemonConversationPersisted } from "./worker-daemon-notify.js";
 
 /**
  * Derive the initiating client's id from request headers so a sync publish can
@@ -121,6 +123,16 @@ export function publishConversationMessagesChanged(
   conversationId: string,
   originClientId?: string,
 ): void {
+  // In a sidecar worker (seq stamping disabled) the local hub has no SSE
+  // subscribers and the seq counter is inert, so a local publish reaches no
+  // client and records no honest anchor. Hand off to the daemon — the seq
+  // authority clients subscribe to — which records the anchor at its own seq
+  // and republishes the invalidation. A background worker turn has no
+  // originating client, so no `originClientId` is forwarded.
+  if (isStreamSeqStampingDisabled()) {
+    void notifyDaemonConversationPersisted(conversationId);
+    return;
+  }
   void publishSyncInvalidation(
     [conversationMessagesSyncTag(conversationId)],
     originClientId,

--- a/assistant/src/runtime/sync/worker-daemon-notify.test.ts
+++ b/assistant/src/runtime/sync/worker-daemon-notify.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The worker → daemon notify is fire-and-forget: it hands a conversation id to
+ * the daemon over IPC and must never surface a failure to the caller (a busy or
+ * down daemon just leaves the anchor stale until the client repairs it). IPC is
+ * mocked — no daemon process is spawned.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface CapturedCall {
+  method: string;
+  params?: Record<string, unknown>;
+  options?: unknown;
+}
+
+const calls: CapturedCall[] = [];
+let nextResult: { ok: boolean; error?: string } = { ok: true };
+let shouldThrow = false;
+
+mock.module("../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    options?: unknown,
+  ) => {
+    calls.push({ method, params, options });
+    if (shouldThrow) {
+      throw new Error("connection refused");
+    }
+    return nextResult;
+  },
+}));
+
+import {
+  NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD,
+  notifyDaemonConversationPersisted,
+} from "./worker-daemon-notify.js";
+
+describe("notifyDaemonConversationPersisted", () => {
+  beforeEach(() => {
+    calls.length = 0;
+    nextResult = { ok: true };
+    shouldThrow = false;
+  });
+
+  test("hands the conversation id to the daemon over the shared IPC method", async () => {
+    await notifyDaemonConversationPersisted("conv-1");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.method).toBe(NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD);
+    expect(calls[0]!.params).toEqual({ body: { conversationId: "conv-1" } });
+  });
+
+  test("swallows a failed IPC result (best-effort, no throw)", async () => {
+    nextResult = { ok: false, error: "daemon unreachable" };
+
+    const result = await notifyDaemonConversationPersisted("conv-1");
+    expect(result).toBeUndefined();
+    expect(calls).toHaveLength(1);
+  });
+
+  test("swallows a thrown IPC error (best-effort, no throw)", async () => {
+    shouldThrow = true;
+
+    const result = await notifyDaemonConversationPersisted("conv-1");
+    expect(result).toBeUndefined();
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/assistant/src/runtime/sync/worker-daemon-notify.ts
+++ b/assistant/src/runtime/sync/worker-daemon-notify.ts
@@ -1,0 +1,63 @@
+/**
+ * Worker → daemon hand-off for conversation message-persist notifications.
+ *
+ * Sidecar worker processes (schedule, memory) disable SSE seq stamping — the
+ * daemon is the sole seq authority — so a worker's own `getCurrentSeq()`
+ * reports `0` and its `publishConversationMessagesChanged` broadcast reaches no
+ * SSE subscriber (those live in the daemon). After a worker persists a turn's
+ * rows it hands the notification here; the daemon records an honest snapshot
+ * anchor at its own seq and republishes the invalidation to real subscribers
+ * (see `ipc/routes/conversation-sync-ipc-routes.ts`).
+ */
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import { getLogger } from "../../util/logger.js";
+
+const log = getLogger("worker-daemon-notify");
+
+/**
+ * IPC method the daemon exposes for the worker hand-off. Shared by the worker
+ * caller and the daemon route registration so the wire name cannot drift.
+ */
+export const NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD =
+  "notify_conversation_persisted_externally";
+
+/**
+ * Short timeout: this is a fire-and-forget invalidation, not a request whose
+ * result the worker consumes. A busy or unreachable daemon simply leaves the
+ * anchor stale until the client repairs it on its next snapshot fetch.
+ */
+const NOTIFY_TIMEOUT_MS = 3_000;
+
+/**
+ * Ask the daemon to record the snapshot anchor and republish the
+ * messages-changed invalidation for `conversationId`.
+ *
+ * Best-effort by design: a daemon that is down, unreachable, or still running
+ * migrations (the IPC method is DB-migration gated) yields a failed result that
+ * is logged at debug and swallowed. No retries or queueing — the worker
+ * persisted the rows regardless, and clients self-repair the stale anchor on
+ * their next `/messages` fetch (switch/reload).
+ */
+export async function notifyDaemonConversationPersisted(
+  conversationId: string,
+): Promise<void> {
+  try {
+    const result = await cliIpcCall(
+      NOTIFY_CONVERSATION_PERSISTED_IPC_METHOD,
+      { body: { conversationId } },
+      { timeoutMs: NOTIFY_TIMEOUT_MS },
+    );
+    if (!result.ok) {
+      log.debug(
+        { conversationId, error: result.error },
+        "daemon conversation-persisted notify was not acknowledged",
+      );
+    }
+  } catch (err) {
+    log.debug(
+      { err, conversationId },
+      "daemon conversation-persisted notify failed",
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Addresses Codex review feedback on #38486.

#38486 made the daemon the sole SSE seq authority by having sidecar workers (schedule, memory) call `disableStreamSeqStamping()`. A side effect: inside a worker, `getCurrentSeq()` returns `0` and the local hub has no SSE subscribers, so when a worker persists a real turn for a conversation:

- `recordConversationPersistedSeq(id, getCurrentSeq())` is ignored (seq ≤ 0), leaving the `conversations.seq` snapshot anchor **NULL/stale**, and
- `publishConversationMessagesChanged(id)` broadcasts on the worker's own hub, reaching **no real client**.

The web client drops an anchorless (`seq: null`) `/messages` snapshot when the open conversation already has a numeric live seq (`chat-session-store.ts`'s anchorless guard), and no invalidation reaches it to trigger a refetch anyway — so a background/scheduled update to an already-open conversation stays invisible until the user switches away or reloads.

## Fix

Route the worker's "conversation messages changed" signal through the daemon over the existing Unix-socket IPC. `publishConversationMessagesChanged` — the single shared choke point every worker turn-persist path funnels through — detects a stamping-disabled process and, instead of the no-op local publish, best-effort notifies the daemon. The daemon (the seq authority, and the process real clients subscribe to) then:

1. records the anchor at its **own** `getCurrentSeq()` — honest, since the daemon's counter is at or above every seq it has served for the conversation and the worker's freshly written rows carry no higher seq, so the anchor is never above the served frontier; and
2. republishes the messages-changed invalidation on its own hub, where real SSE subscribers observe it.

This fixes both halves at the root: the snapshot regains a numeric anchor (no longer dropped as anchorless) **and** live clients actually learn to refetch — rather than only patching the anchor.

### Constraint compliance

- **No worker seq stamping / reservation writes.** The worker never touches `stream-seq.json` or stamps events (that would reintroduce the #38486 duplicate-seq incident). It only sends an IPC notification.
- **No anchor above served seqs.** The anchor is the daemon's own `getCurrentSeq()`, never a fabricated or worker-side value — an anchor ahead of live seqs is the #38483 frontier-poisoning class.
- **Best-effort, no retries/queues.** A down / unreachable / mid-migration daemon yields a failed IPC result that is logged at debug and swallowed; the anchor stays stale (today's behavior) and clients self-repair on switch/reload. The new IPC method is DB-migration-readiness gated by the IPC server (it is not in the exempt set), so its DB touch never races an in-flight migration.

## Files

- `runtime/assistant-stream-state.ts` — export `isStreamSeqStampingDisabled()` (the worker/daemon predicate; `getCurrentSeq() === 0` is ambiguous with cold start).
- `runtime/sync/worker-daemon-notify.ts` (new) — best-effort `notifyDaemonConversationPersisted()` over `cliIpcCall`, plus the shared IPC method-name constant so caller and registration can't drift.
- `runtime/sync/resource-sync-events.ts` — `publishConversationMessagesChanged` routes to the daemon when stamping is disabled.
- `ipc/routes/conversation-sync-ipc-routes.ts` (new) — IPC-only daemon handler that records the honest anchor and republishes the invalidation.
- `ipc/assistant-server.ts` — register the new IPC method map.

## Tests

- `ipc/routes/__tests__/conversation-sync-ipc-routes.test.ts` — handler records the anchor at the daemon's current seq, republishes the invalidation, rejects a missing `conversationId`, and is absent from the DB-migration exempt set (so it is readiness-gated).
- `runtime/sync/worker-daemon-notify.test.ts` — notify sends the shared method + `{ body: { conversationId } }`, and swallows both a failed IPC result and a thrown IPC error (best-effort, no throw). IPC is mocked; no process is spawned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)