### PR TITLE
test(workflows): widen sandbox CPU-guard timing margins to stop CI flakes

### DIFF
--- a/assistant/src/workflows/sandbox.test.ts
+++ b/assistant/src/workflows/sandbox.test.ts
@@ -202,38 +202,47 @@ describe("createWorkflowSandbox — CPU guard", () => {
     ).rejects.toThrow(WorkflowResourceError);
   });
 
+  // Margins for the two long-await tests below. The host await must exceed the
+  // deadline so the reset is load-bearing — without it, the script resumes
+  // against an already-expired guard and trips. The deadline itself leaves a
+  // full second of post-resume headroom: on shared CI runners, CPU contention
+  // can stall the resume path for hundreds of milliseconds, and that stall
+  // counts against the contiguous-CPU deadline.
+  const LONG_HOST_AWAIT_MS = 1500;
+  const LONG_AWAIT_DEADLINE_MS = 1000;
+
   test("a genuinely long host call does not trip the deadline (latency excused)", async () => {
-    // A single host call whose await (1000ms) far exceeds the deadline (200ms)
-    // must NOT trip: the reset excuses real leaf/agent latency. With the reset
-    // gated on a 50ms threshold, this 1000ms call still resets.
+    // A single host call whose await exceeds the deadline must NOT trip: the
+    // reset excuses real leaf/agent latency. With the reset gated on a 50ms
+    // threshold, this call still resets.
     const sandbox = createWorkflowSandbox({
       hostFunctions: {
         slow: async () => {
-          await new Promise((r) => setTimeout(r, 1000));
+          await new Promise((r) => setTimeout(r, LONG_HOST_AWAIT_MS));
           return "ok";
         },
       },
-      interruptDeadlineMs: 200,
+      interruptDeadlineMs: LONG_AWAIT_DEADLINE_MS,
     });
     const result = await sandbox.run(`return slow();`, null);
     expect(result).toBe("ok");
   });
 
   test("a host call that REJECTS after a long await still resets the deadline (catch survives)", async () => {
-    // A leaf that fails after a multi-second round-trip must not leave the
-    // script's catch block resuming against an already-expired CPU deadline.
-    // The reject-path reset (finally) excuses the awaited latency on failure
-    // too, so the catch — which does enough work to hit an interrupt check —
-    // runs instead of being killed as a WorkflowResourceError. Without the
-    // reset, this run rejects.
+    // A leaf that fails after a long round-trip must not leave the script's
+    // catch block resuming against an already-expired CPU deadline. The
+    // reject-path reset (finally) excuses the awaited latency on failure too,
+    // so the catch — which does enough work to hit an interrupt check — runs
+    // instead of being killed as a WorkflowResourceError. Without the reset,
+    // this run rejects.
     const sandbox = createWorkflowSandbox({
       hostFunctions: {
         slowFail: async () => {
-          await new Promise((r) => setTimeout(r, 1000));
+          await new Promise((r) => setTimeout(r, LONG_HOST_AWAIT_MS));
           throw new Error("leaf failed");
         },
       },
-      interruptDeadlineMs: 300,
+      interruptDeadlineMs: LONG_AWAIT_DEADLINE_MS,
     });
     const result = await sandbox.run(
       `try {


### PR DESCRIPTION
## Summary
- De-flakes `sandbox.test.ts` CPU-guard tests that failed on main ([run 29793578135](https://github.com/vellum-ai/vellum-assistant/actions/runs/29793578135/job/88520255753)): the reject-path test gave the VM only 300ms of real-time budget after the host-call deadline reset, and CPU contention on the shared runner stalled the resume path past it, tripping the interrupt as a spurious `WorkflowResourceError`.
- Introduces shared `LONG_HOST_AWAIT_MS` (1500) / `LONG_AWAIT_DEADLINE_MS` (1000) constants for the two long-await tests, encoding the invariant once: the await still exceeds the deadline (so the tests still fail if the deadline reset is removed — the property under test stays load-bearing), while the deadline now leaves a full second of post-resume headroom.
- No product code changes — the reset provably happens before the VM resumes (it runs in a `finally` inside the async host wrapper, so the host promise cannot settle before it), so this was a test-margin flake, not a sandbox bug.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29793578135/job/88520255753 — the assistant Test job on main failed in `src/workflows/sandbox.test.ts` ("a host call that REJECTS after a long await still resets the deadline"), on a commit that didn't touch the sandbox. Scope was limited to this job's failure; the other recent main failures were a different, already-fixed test.