### PR TITLE
feat(web): restyle the pro onboarding complete step to the serif card mock

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Tests for the restyled `CompleteState` completion card. Renders via
+ * `@testing-library/react` (happy-dom registered in test-setup.ts). The lazy
+ * avatar-components hook and the SVG-compositing renderer are mocked so the
+ * creature scatter resolves to stub spans; the assistant hook is stubbed to a
+ * fixed name so the dynamic Return label is deterministic; and `useNavigate`
+ * is captured so the return handler can be asserted without a Router.
+ */
+import * as reactRouter from "react-router";
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { routes } from "@/utils/routes";
+
+const OFFLINE_NOTICE =
+  "Assistant will go offline briefly while it resizes. Chat might not work during that time.";
+
+let avatarComponents: unknown = { colors: [] };
+mock.module("@/utils/use-bundled-avatar-components", () => ({
+  preloadBundledAvatarComponents: () => {},
+  useBundledAvatarComponents: () => avatarComponents,
+}));
+mock.module("@/components/avatar-renderer", () => ({
+  AvatarRenderer: () => <span data-testid="creature-avatar" />,
+}));
+
+let assistantName: string | null = "Velly";
+mock.module("./use-preferred-or-active-assistant", () => ({
+  usePreferredOrActiveAssistant: () =>
+    assistantName == null ? undefined : { name: assistantName },
+}));
+
+let navigateArgs: Array<[unknown, unknown]> = [];
+mock.module("react-router", () => ({
+  ...reactRouter,
+  useNavigate: () => (to: unknown, opts: unknown) => {
+    navigateArgs.push([to, opts]);
+  },
+}));
+
+const { CompleteState } = await import("./complete-state");
+
+beforeEach(() => {
+  avatarComponents = { colors: [] };
+  assistantName = "Velly";
+  navigateArgs = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CompleteState heading and creatures", () => {
+  test("renders the all-set serif heading and subtitle", () => {
+    const { getByText } = render(<CompleteState />);
+    expect(getByText("You're all set!")).toBeTruthy();
+    expect(getByText("Enjoy the new found power.")).toBeTruthy();
+  });
+
+  test("renders the full six-creature corner layer, aria-hidden", () => {
+    const { getByTestId, getAllByTestId } = render(<CompleteState />);
+    expect(getAllByTestId("creature-avatar")).toHaveLength(6);
+    expect(getByTestId("creature-corners").getAttribute("aria-hidden")).toBe(
+      "true",
+    );
+  });
+});
+
+describe("CompleteState return button", () => {
+  test("keeps the dynamic assistant name and navigates home on click", () => {
+    const { getByTestId } = render(<CompleteState />);
+
+    const button = getByTestId("onboarding-complete-return");
+    expect(button.textContent).toBe("Return to Velly");
+
+    fireEvent.click(button);
+    expect(navigateArgs).toEqual([[routes.assistant, { replace: true }]]);
+  });
+
+  test("falls back to a generic label when no assistant resolves", () => {
+    assistantName = null;
+    const { getByTestId } = render(<CompleteState />);
+    expect(getByTestId("onboarding-complete-return").textContent).toBe(
+      "Return to your assistant",
+    );
+  });
+});
+
+describe("CompleteState offline notice", () => {
+  test("is absent when not finishing in the background", () => {
+    const { queryByText } = render(<CompleteState />);
+    expect(queryByText(OFFLINE_NOTICE)).toBeNull();
+  });
+
+  test("shows only while finishing in background and clears once done", () => {
+    const { queryByText, rerender } = render(
+      <CompleteState finishedInBackground />,
+    );
+    expect(queryByText(OFFLINE_NOTICE)).toBeTruthy();
+    // The still-mounted provisioning hook reaching DONE flips the prop off;
+    // mirror that transition and confirm the notice clears.
+    rerender(<CompleteState finishedInBackground={false} />);
+    expect(queryByText(OFFLINE_NOTICE)).toBeNull();
+  });
+
+  test("stalled recovery controls take precedence over the offline notice", () => {
+    const onApply = mock(() => {});
+    const { getByTestId, getByText, queryByText } = render(
+      <CompleteState
+        finishedInBackground
+        stalledAction={{ onApply, pending: false, error: null }}
+      />,
+    );
+
+    expect(
+      getByText(/We couldn't finish your machine upgrade automatically/),
+    ).toBeTruthy();
+    expect(queryByText(OFFLINE_NOTICE)).toBeNull();
+
+    fireEvent.click(getByTestId("complete-stalled-apply"));
+    expect(onApply).toHaveBeenCalledTimes(1);
+
+    // The Return button stays available across all completion variants.
+    expect(getByTestId("onboarding-complete-return")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
@@ -1,5 +1,3 @@
-import { PartyPopper } from "lucide-react";
-
 import { useNavigate } from "react-router";
 
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
@@ -8,8 +6,17 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
 
 import type { StalledApplyAction } from "./primitives";
-import { STALLED_UPGRADE_WARNING, StalledApplyControls } from "./primitives";
+import {
+  CreatureCorners,
+  STALLED_UPGRADE_WARNING,
+  StalledApplyControls,
+  WizardCardHeading,
+} from "./primitives";
 import { usePreferredOrActiveAssistant } from "./use-preferred-or-active-assistant";
+
+/** Shown while a backgrounded resize is still finishing; cleared once done. */
+const OFFLINE_WHILE_RESIZING =
+  "Assistant will go offline briefly while it resizes. Chat might not work during that time.";
 
 export function CompleteState({
   finishedInBackground = false,
@@ -29,83 +36,44 @@ export function CompleteState({
   const assistantName = assistant?.name || "your assistant";
 
   return (
-    <div className="relative flex min-h-[320px] flex-col items-center justify-center overflow-hidden px-8 text-center">
-      <div
-        className="pointer-events-none absolute inset-0"
-        style={{
-          background:
-            "radial-gradient(ellipse 60% 50% at 50% 38%, color-mix(in oklab, var(--system-positive-strong) 14%, transparent), transparent)",
-        }}
-        aria-hidden="true"
-      />
+    <div className="relative flex min-h-[320px] flex-col items-center overflow-hidden px-8 pb-10 [animation:onboarding-step-in_350ms_ease-out] motion-reduce:[animation:none]">
+      <CreatureCorners variant="full" />
 
-      <div className="relative mb-5 flex items-center justify-center [animation:welcome-reveal_600ms_ease-out_both] motion-reduce:[animation:none]">
-        <div
-          className="absolute h-24 w-24 rounded-full [animation:welcome-crown-glow_3s_ease-in-out_infinite] motion-reduce:[animation:none]"
-          style={{
-            background:
-              "radial-gradient(circle, color-mix(in oklab, var(--system-positive-strong) 18%, transparent), transparent 70%)",
-          }}
-          aria-hidden="true"
+      {/* `relative` lifts the content above the absolute creature layer. */}
+      <div className="relative flex w-full flex-col items-center">
+        <WizardCardHeading
+          title="You're all set!"
+          subtitle="Enjoy the new found power."
         />
-        <div
-          className="absolute h-16 w-16 rounded-full [animation:welcome-crown-glow_3s_ease-in-out_infinite_0.5s] motion-reduce:[animation:none]"
-          style={{
-            background:
-              "radial-gradient(circle, color-mix(in oklab, var(--system-positive-strong) 12%, transparent), transparent 70%)",
-          }}
-          aria-hidden="true"
-        />
-        <PartyPopper
-          className="relative h-8 w-8 text-[var(--system-positive-strong)]"
-          strokeWidth={1.5}
-          aria-hidden="true"
-        />
-      </div>
 
-      <h1
-        className="relative mb-2 text-[var(--content-emphasised)] [animation:welcome-reveal_600ms_ease-out_150ms_both] motion-reduce:[animation:none]"
-        style={{
-          fontFamily: "var(--font-serif)",
-          fontSize: "28px",
-          lineHeight: 1,
-          fontWeight: 400,
-        }}
-      >
-        You&apos;re all set
-      </h1>
+        <div className="mt-8 flex w-full flex-col items-center gap-4">
+          {stalledAction ? (
+            <div className="flex w-full flex-col items-center gap-2">
+              <Notice tone="warning" className="w-full text-left">
+                {STALLED_UPGRADE_WARNING}
+              </Notice>
+              <StalledApplyControls
+                action={stalledAction}
+                buttonVariant="outlined"
+                buttonTestId="complete-stalled-apply"
+              />
+            </div>
+          ) : (
+            finishedInBackground && (
+              <Notice tone="neutral" className="w-full text-left">
+                {OFFLINE_WHILE_RESIZING}
+              </Notice>
+            )
+          )}
 
-      <p className="relative mb-6 max-w-[320px] text-body-medium-lighter text-[var(--content-secondary)] [animation:welcome-reveal_600ms_ease-out_300ms_both] motion-reduce:[animation:none]">
-        Your assistant just got a serious upgrade.
-      </p>
-
-      {stalledAction ? (
-        <div className="relative -mt-4 mb-6 flex w-full flex-col items-center gap-2 [animation:welcome-reveal_600ms_ease-out_350ms_both] motion-reduce:[animation:none]">
-          <Notice tone="warning" className="w-full text-left">
-            {STALLED_UPGRADE_WARNING}
-          </Notice>
-          <StalledApplyControls
-            action={stalledAction}
-            buttonVariant="outlined"
-            buttonTestId="complete-stalled-apply"
-          />
+          <Button
+            variant="primary"
+            data-testid="onboarding-complete-return"
+            onClick={() => navigate(routes.assistant, { replace: true })}
+          >
+            Return to {assistantName}
+          </Button>
         </div>
-      ) : (
-        finishedInBackground && (
-          <p className="relative -mt-4 mb-6 max-w-[320px] text-body-small-default text-[var(--content-tertiary)] [animation:welcome-reveal_600ms_ease-out_350ms_both] motion-reduce:[animation:none]">
-            We&apos;re finishing your machine upgrade in the background.
-          </p>
-        )
-      )}
-
-      <div className="[animation:welcome-reveal_600ms_ease-out_450ms_both] motion-reduce:[animation:none]">
-        <Button
-          variant="primary"
-          data-testid="onboarding-complete-return"
-          onClick={() => navigate(routes.assistant, { replace: true })}
-        >
-          Return to {assistantName}
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Restyle the 'You're all set!' step to the serif card mock: WizardCardHeading + full creature corners, centered Return-to-assistant button, offline Notice only when finishing in background. No behavioral change.

Part of plan: pro-onboarding-figma-polish.md (PR 5 of 5)