### PR TITLE
feat(web): restyle the assistant email step to the serif card mock

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -172,7 +172,8 @@ mock.module("@/generated/api/sdk.gen", () => ({
 
 const { BillingOnboardingModal } = await import("./billing-onboarding-modal");
 
-const BACKGROUND_LINE = "We're finishing your machine upgrade in the background.";
+const BACKGROUND_LINE =
+  "Assistant will go offline briefly while it resizes. Chat might not work during that time.";
 
 /**
  * Fast celebration dwell. Long enough for waitFor (50ms polls) to reliably
@@ -249,7 +250,7 @@ describe("BillingOnboardingModal", () => {
       timeout: 5000,
     });
     // The celebration dwell elapses and the wizard advances to the domain step.
-    await waitFor(() => expect(getByText("Assistant email")).toBeTruthy(), {
+    await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy(), {
       timeout: 5000,
     });
   });
@@ -273,10 +274,10 @@ describe("BillingOnboardingModal", () => {
 
     assistantResponse = makeAssistant("large", 50);
     await client.invalidateQueries();
-    await waitFor(() => expect(getByText("You're all set")).toBeTruthy(), {
+    await waitFor(() => expect(getByText("You're all set!")).toBeTruthy(), {
       timeout: 5000,
     });
-    expect(queryByText("Assistant email")).toBeNull();
+    expect(queryByText("Assistant Email")).toBeNull();
     expect(queryByText(BACKGROUND_LINE)).toBeNull();
     expect(readCheckoutIntent()).toBeNull();
   });
@@ -304,7 +305,7 @@ describe("BillingOnboardingModal", () => {
 
     assistantResponse = makeAssistant("small", 50);
     await client.invalidateQueries();
-    await waitFor(() => expect(getByText("Assistant email")).toBeTruthy(), {
+    await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy(), {
       timeout: 5000,
     });
   });
@@ -317,7 +318,7 @@ describe("BillingOnboardingModal", () => {
     await waitFor(() => expect(getByText("Your plan is ready")).toBeTruthy(), {
       timeout: 5000,
     });
-    await waitFor(() => expect(getByText("Assistant email")).toBeTruthy(), {
+    await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy(), {
       timeout: 5000,
     });
     expect(resizeCall).toBeNull();
@@ -337,7 +338,7 @@ describe("BillingOnboardingModal", () => {
     expect(takeover?.className).toContain("w-screen");
 
     // Domain step: standard card — no dark theme, no full-bleed sizing.
-    await waitFor(() => expect(getByText("Assistant email")).toBeTruthy(), {
+    await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy(), {
       timeout: 5000,
     });
     const card = document.body.querySelector('[data-slot="modal-content"]');
@@ -379,7 +380,7 @@ describe("BillingOnboardingModal", () => {
       () => expect(getByText("All done!")).toBeTruthy(),
       { timeout: 5000 },
     );
-    await waitFor(() => expect(getByText("Assistant email")).toBeTruthy(), {
+    await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy(), {
       timeout: 5000,
     });
   });
@@ -436,7 +437,7 @@ describe("BillingOnboardingModal", () => {
       { timeout: 5000 },
     );
     fireEvent.click(getByTestId("provisioning-escape"));
-    await waitFor(() => expect(getByText("Assistant email")).toBeTruthy());
+    await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy());
 
     expect(
       getByText(
@@ -446,7 +447,7 @@ describe("BillingOnboardingModal", () => {
     // Wait for the handle prefill: with an empty subdomain the submit would be
     // disabled regardless, masking a missing machine-busy guard.
     await waitFor(() =>
-      expect((getByLabelText("Subdomain") as HTMLInputElement).value).toBe(
+      expect((getByLabelText("Handle (public)") as HTMLInputElement).value).toBe(
         "casey",
       ),
     );
@@ -484,7 +485,7 @@ describe("BillingOnboardingModal", () => {
       );
       fireEvent.click(getByTestId("provisioning-escape"));
 
-      await waitFor(() => expect(getByText("You're all set")).toBeTruthy());
+      await waitFor(() => expect(getByText("You're all set!")).toBeTruthy());
       expect(getByText(BACKGROUND_LINE)).toBeTruthy();
 
       assistantResponse = makeAssistant("large", 50);
@@ -599,7 +600,7 @@ describe("BillingOnboardingModal", () => {
         { timeout: 5000 },
       );
       fireEvent.click(getByTestId("provisioning-escape"));
-      await waitFor(() => expect(getByText("You're all set")).toBeTruthy());
+      await waitFor(() => expect(getByText("You're all set!")).toBeTruthy());
       expect(getByText(BACKGROUND_LINE)).toBeTruthy();
 
       // The backgrounded resize stalls: the finishing line swaps for a warning
@@ -652,9 +653,9 @@ describe("BillingOnboardingModal", () => {
         { timeout: 5000 },
       );
       fireEvent.click(getByTestId("provisioning-escape"));
-      await waitFor(() => expect(getByText("Assistant email")).toBeTruthy());
+      await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy());
       await waitFor(() =>
-        expect((getByLabelText("Subdomain") as HTMLInputElement).value).toBe(
+        expect((getByLabelText("Handle (public)") as HTMLInputElement).value).toBe(
           "casey",
         ),
       );

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
@@ -1,11 +1,16 @@
 /**
- * DomainStep query invalidation: registering a domain must refresh the caches
- * the "Finish Pro setup" nudge reads (domains list + onboarding state) in
- * addition to the assistants list.
+ * DomainStep behavior: registering a domain must refresh the caches the
+ * "Finish Pro setup" nudge reads (domains list + onboarding state) in addition
+ * to the assistants list, and the prefix/handle fields must submit as the
+ * domain body. The serif-card restyle is presentation-only — every behavioral
+ * assertion here (endpoints, validation, skip/advance, restart guard) is
+ * unchanged.
  *
  * Strategy mirrors billing-page.test.tsx: mock the generated SDK so the
  * targeted assistant loads (prefilling the subdomain from its handle) and the
- * domain mutation resolves, then spy on the query client's invalidations.
+ * domain mutation resolves, then spy on the query client's invalidations. The
+ * bundled-avatar hook is stubbed so the decorative CreatureCorners layer stays
+ * a no-op instead of loading the SVG payload.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
@@ -22,6 +27,12 @@ import type { Assistant } from "@/generated/api/types.gen";
 
 let domainCreateCalls = 0;
 let domainsListPaths: string[] = [];
+let lastDomainCreateBody: Record<string, unknown> | null = null;
+
+mock.module("@/utils/use-bundled-avatar-components", () => ({
+  preloadBundledAvatarComponents: () => {},
+  useBundledAvatarComponents: () => null,
+}));
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -44,8 +55,11 @@ mock.module("@/generated/api/sdk.gen", () => ({
       response: { ok: true },
     });
   },
-  organizationsBillingSubscriptionOnboardingDomainCreate: () => {
+  organizationsBillingSubscriptionOnboardingDomainCreate: (opts: {
+    body?: Record<string, unknown>;
+  }) => {
     domainCreateCalls += 1;
+    lastDomainCreateBody = opts?.body ?? null;
     return Promise.resolve({ data: {}, response: { ok: true } });
   },
 }));
@@ -55,10 +69,31 @@ const { DomainStep } = await import("./domain-step");
 beforeEach(() => {
   domainCreateCalls = 0;
   domainsListPaths = [];
+  lastDomainCreateBody = null;
 });
 
 afterEach(() => {
   cleanup();
+});
+
+describe("DomainStep chrome", () => {
+  test("renders the serif heading, immutability notice, and footer buttons", () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={client}>
+        <DomainStep onExit={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    expect(getByText("Assistant Email")).toBeTruthy();
+    expect(getByText("Set up an email for your assistant.")).toBeTruthy();
+    expect(getByText(/be able to change the handle once set/)).toBeTruthy();
+    expect(getByTestId("onboarding-domain-skip")).toBeTruthy();
+    expect(getByTestId("onboarding-domain-set")).toBeTruthy();
+  });
 });
 
 describe("DomainStep domain registration", () => {
@@ -102,6 +137,58 @@ describe("DomainStep domain registration", () => {
         organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
       ),
     );
+  });
+
+  test("submits the prefix and handle fields as the domain body", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { getByTestId, getByLabelText } = render(
+      <QueryClientProvider client={client}>
+        <DomainStep onExit={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      const btn = getByTestId("onboarding-domain-set") as HTMLButtonElement;
+      if (btn.disabled) {
+        throw new Error("button not enabled yet");
+      }
+    });
+
+    fireEvent.change(getByLabelText("Prefix"), {
+      target: { value: "hello" },
+    });
+    fireEvent.change(getByLabelText("Handle (public)"), {
+      target: { value: "MyBot" },
+    });
+    fireEvent.click(getByTestId("onboarding-domain-set"));
+
+    await waitFor(() => expect(domainCreateCalls).toBe(1));
+    expect(lastDomainCreateBody).toEqual({
+      subdomain: "mybot",
+      email_username: "hello",
+    });
+  });
+
+  test("Skip submits the skipped flag and exits", async () => {
+    const onExit = mock(() => {});
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { getByTestId } = render(
+      <QueryClientProvider client={client}>
+        <DomainStep onExit={onExit} />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(getByTestId("onboarding-domain-skip"));
+
+    await waitFor(() => expect(domainCreateCalls).toBe(1));
+    expect(lastDomainCreateBody).toEqual({ skipped: true });
+    await waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
   });
 
   test("checks domains on the assistant id the wizard passes in", async () => {
@@ -161,12 +248,12 @@ describe("DomainStep stalled resize", () => {
     );
   });
 
-  test("plain machine-busy keeps the neutral notice without apply controls", async () => {
+  test("plain machine-busy keeps the neutral notice and disables Next", async () => {
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
 
-    const { getByText, queryByTestId } = render(
+    const { getByText, getByTestId, queryByTestId } = render(
       <QueryClientProvider client={client}>
         <DomainStep onExit={() => {}} machineBusy />
       </QueryClientProvider>,
@@ -180,5 +267,9 @@ describe("DomainStep stalled resize", () => {
       ).toBeTruthy(),
     );
     expect(queryByTestId("domain-stalled-apply")).toBeNull();
+    // The restart guard keeps Next disabled while the machine is busy.
+    expect(
+      (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
+    ).toBe(true);
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -157,7 +157,7 @@ export function DomainStep({
             <span className="flex h-8 items-center text-[var(--content-secondary)]">
               @
             </span>
-            <div className="flex flex-1 flex-col gap-1.5">
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
               <label htmlFor="onboarding-email-handle" className={LABEL_CLASSES}>
                 Handle (public)
               </label>
@@ -173,7 +173,7 @@ export function DomainStep({
                 autoFocus
                 placeholder="my-assistant"
                 aria-invalid={!!errorMsg}
-                className={`${FIELD_CLASSES} w-full`}
+                className={`${FIELD_CLASSES} w-full min-w-0`}
               />
             </div>
             <span className="flex h-8 shrink-0 items-center text-[14px] text-[var(--content-tertiary)]">

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -1,4 +1,4 @@
-import { Mail } from "lucide-react";
+import { Info } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -13,17 +13,20 @@ import { useEnvironmentStore } from "@/stores/environment-store";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Notice } from "@vellumai/design-library/components/notice";
-import { Typography } from "@vellumai/design-library/components/typography";
 
-import { DomainField } from "@/domains/settings/components/domain-field";
 import type { StalledApplyAction } from "./primitives";
 import {
-    IconBadge,
+    CreatureCorners,
     STALLED_UPGRADE_WARNING,
     StalledApplyControls,
+    WizardCardHeading,
 } from "./primitives";
 import { useAssistantDomains } from "./use-assistant-domains";
 import { DOMAIN_EXIT_DELAY_MS, extractOnboardingErrorMessage } from "./utils";
+
+const FIELD_CLASSES =
+  "h-8 rounded-lg border border-[var(--border-element)] bg-[var(--field-bg)] px-2.5 text-[14px] text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] outline-none transition-[border-color] duration-150 focus:border-[var(--border-active)] disabled:cursor-not-allowed disabled:opacity-60";
+const LABEL_CLASSES = "text-[11px] font-medium text-[var(--content-secondary)]";
 
 export function DomainStep({
   onExit,
@@ -127,60 +130,66 @@ export function DomainStep({
 
   return (
     <>
-      <Modal.Body className="min-h-[320px] animate-[onboarding-step-in_350ms_ease-out] space-y-5 pt-10 pb-4 motion-reduce:animate-none">
-        <div className="flex flex-col items-center gap-3 pb-2 text-center">
-          <IconBadge icon={Mail} />
-          <div className="space-y-2">
-            <Typography variant="title-small" as="h1">
-              Assistant email
-            </Typography>
-            <Typography
-              variant="body-medium-lighter"
-              as="p"
-              className="text-[var(--content-secondary)]"
-            >
-              Set up an email address for your assistant.
-            </Typography>
-          </div>
-        </div>
+      <Modal.Body className="min-h-[320px] animate-[onboarding-step-in_350ms_ease-out] space-y-5 pb-4 motion-reduce:animate-none">
+        <WizardCardHeading
+          title="Assistant Email"
+          subtitle="Set up an email for your assistant."
+        />
 
         <div className="space-y-1.5">
-          <Typography
-            variant="body-small-default"
-            as="label"
-            className="text-[var(--content-secondary)]"
-          >
-            Email address
-          </Typography>
-          <DomainField
-            subdomain={subdomain}
-            autoFocus
-            onSubdomainChange={(v) => {
-              setSubdomain(v);
-              if (errorMsg) setErrorMsg(null);
-            }}
-            domainSuffix={emailRootDomain}
-            disabled={busy}
-            error={errorMsg}
-            locked={isLocked}
-            lockedMessage="This domain has been set and cannot be changed."
-            prefix={
-              <>
-                <input
-                  value={emailUsername}
-                  onChange={(e) => setEmailUsername(e.target.value.toLowerCase().trim())}
-                  disabled={busy || isLocked}
-                  readOnly={isLocked}
-                  placeholder="hi"
-                  aria-label="Email username"
-                  size={Math.max(emailUsername.length, 2)}
-                  className="h-full w-0 min-w-[2ch] flex-none bg-transparent pl-3 pr-1.5 text-[var(--content-default)] placeholder:text-[var(--content-tertiary)] outline-none disabled:cursor-not-allowed disabled:opacity-60"
-                  style={{ width: `${Math.max(emailUsername.length, 2) + 1.5}ch` }}
-                />
-                <span className="shrink-0 font-mono text-[var(--content-secondary)]">@</span>
-              </>
-            }
-          />
+          <div className="flex items-end gap-2">
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor="onboarding-email-prefix" className={LABEL_CLASSES}>
+                Prefix
+              </label>
+              <input
+                id="onboarding-email-prefix"
+                value={emailUsername}
+                onChange={(e) =>
+                  setEmailUsername(e.target.value.toLowerCase().trim())
+                }
+                disabled={busy || isLocked}
+                readOnly={isLocked}
+                placeholder="hi"
+                className={`${FIELD_CLASSES} w-24`}
+              />
+            </div>
+            <span className="flex h-8 items-center text-[var(--content-secondary)]">
+              @
+            </span>
+            <div className="flex flex-1 flex-col gap-1.5">
+              <label htmlFor="onboarding-email-handle" className={LABEL_CLASSES}>
+                Handle (public)
+              </label>
+              <input
+                id="onboarding-email-handle"
+                value={subdomain}
+                onChange={(e) => {
+                  setSubdomain(e.target.value.toLowerCase().trim());
+                  if (errorMsg) setErrorMsg(null);
+                }}
+                disabled={busy || isLocked}
+                readOnly={isLocked}
+                autoFocus
+                placeholder="my-assistant"
+                aria-invalid={!!errorMsg}
+                className={`${FIELD_CLASSES} w-full`}
+              />
+            </div>
+            <span className="flex h-8 shrink-0 items-center text-[14px] text-[var(--content-tertiary)]">
+              .{emailRootDomain}
+            </span>
+          </div>
+          {errorMsg && (
+            <p className="text-body-small-default text-[var(--system-negative-strong)]">
+              {errorMsg}
+            </p>
+          )}
+          {isLocked && (
+            <p className="text-body-small-default text-[var(--content-tertiary)]">
+              This domain has been set and cannot be changed.
+            </p>
+          )}
         </div>
 
         {stalledAction && !isLocked ? (
@@ -204,14 +213,17 @@ export function DomainStep({
           )
         )}
         {!isLocked && (
-          <Notice tone="info">
-            <span className="font-mono">{subdomain || "<subdomain>"}</span> will also become your assistant&apos;s public handle.
-            You won&apos;t be able to change it once set.
+          <Notice
+            tone="neutral"
+            icon={<Info className="h-4 w-4" aria-hidden="true" />}
+          >
+            You won&apos;t be able to change the handle once set.
           </Notice>
         )}
         {confirmed ? (
           <Notice tone="success">Domain set — redirecting…</Notice>
         ) : null}
+        <CreatureCorners variant="top" />
       </Modal.Body>
       <Modal.Footer className="items-center">
         {isLocked ? (
@@ -225,12 +237,12 @@ export function DomainStep({
         ) : (
           <>
             <Button
-              variant="ghost"
+              variant="outlined"
               data-testid="onboarding-domain-skip"
               disabled={busy}
               onClick={handleSkip}
             >
-              Do later
+              Skip
             </Button>
             <Button
               variant="primary"
@@ -238,7 +250,7 @@ export function DomainStep({
               disabled={!subdomain || busy || machineBusy}
               onClick={handleSet}
             >
-              Set domain
+              Next
             </Button>
           </>
         )}


### PR DESCRIPTION
## Summary
- Restyle the pro-onboarding email step to the serif card mock: WizardCardHeading + top creature corners, prefix @ handle suffix row, immutability Notice, Skip/Next footer (no Back). No behavioral change.

Part of plan: pro-onboarding-figma-polish.md (PR 4 of 5)