### PR TITLE
feat(web): full-bleed provisioning phase in the pro onboarding modal

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -323,6 +323,28 @@ describe("BillingOnboardingModal", () => {
     expect(resizeCall).toBeNull();
   });
 
+  test("provisioning renders a full-bleed dark takeover; the domain step reverts to a standard card", async () => {
+    subscriptionPlanId = "pro";
+    assistantResponse = makeAssistant("large", 50);
+    const { getByText } = renderModal();
+
+    // Provisioning phase: full-bleed, dark-themed Modal.Content.
+    await waitFor(() => expect(getByText("Your plan is ready")).toBeTruthy(), {
+      timeout: 5000,
+    });
+    const takeover = document.body.querySelector('[data-slot="modal-content"]');
+    expect(takeover?.getAttribute("data-theme")).toBe("dark");
+    expect(takeover?.className).toContain("w-screen");
+
+    // Domain step: standard card — no dark theme, no full-bleed sizing.
+    await waitFor(() => expect(getByText("Assistant email")).toBeTruthy(), {
+      timeout: 5000,
+    });
+    const card = document.body.querySelector('[data-slot="modal-content"]');
+    expect(card?.getAttribute("data-theme")).toBeNull();
+    expect(card?.className).not.toContain("w-screen");
+  });
+
   test("stall surfaces Apply & Restart; a successful apply resumes resizing through DONE", async () => {
     subscriptionPlanId = "pro";
     const { client, getByText, getByTestId } = renderModal();

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -8,6 +8,8 @@ import {
     readCheckoutIntent,
     type CheckoutIntent,
 } from "@/lib/billing/checkout-intent";
+import { isElectron } from "@/runtime/is-electron";
+import { cn } from "@/utils/misc";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -143,6 +145,15 @@ export function BillingOnboardingModal({
   // mid-provisioning. The explicit X (shown only here) is the deliberate exit.
   const isFirstCard = step === "provisioning";
 
+  // data-theme="dark" also themes Modal.Content's close button so it reads on
+  // the dark backdrop. In Electron the X clears the title-bar drag strip (a
+  // fixed z-100 band over the top 28px) so it stays clickable.
+  const provisioningContentClass = cn(
+    "overflow-hidden inset-0 max-w-none w-screen h-screen max-h-none rounded-none border-0",
+    "[&_[aria-label=Close]]:[-webkit-app-region:no-drag]",
+    isElectron() && "[&_[aria-label=Close]]:top-12",
+  );
+
   return (
     <Modal.Root open={open} onOpenChange={(o) => { if (!o) handleClose(); }}>
       <Modal.Content
@@ -151,9 +162,17 @@ export function BillingOnboardingModal({
         dismissOnOverlayClick={!isFirstCard}
         onEscapeKeyDown={isFirstCard ? (e) => e.preventDefault() : undefined}
         onInteractOutside={isFirstCard ? (e) => e.preventDefault() : undefined}
-        className="overflow-hidden"
+        data-theme={isFirstCard ? "dark" : undefined}
+        overlayClassName={isFirstCard ? "bg-black p-0" : undefined}
+        className={isFirstCard ? provisioningContentClass : "overflow-hidden"}
       >
-        {renderStep()}
+        {/* Keyed on step so the fade replays as we swap takeover ⇄ card. */}
+        <div
+          key={step}
+          className="flex min-h-0 flex-1 flex-col [animation:fadeIn_0.25s_ease-out_both] motion-reduce:[animation:none]"
+        >
+          {renderStep()}
+        </div>
       </Modal.Content>
     </Modal.Root>
   );


### PR DESCRIPTION
## Summary
- Render the provisioning step as a full-bleed dark-themed Modal.Content (opaque overlay, data-theme=dark themes the close button), card chrome for domain/complete, with a reduced-motion-safe crossfade.

Part of plan: pro-onboarding-figma-polish.md (PR 3 of 5)