### PR TITLE
fix(macos): give dev:electron wait-on 180s so cold Vite starts survive

### DIFF
--- a/clients/macos/package.json
+++ b/clients/macos/package.json
@@ -11,7 +11,7 @@
     "dev:electron-only": "bun install && bun run setup && bun run prepare:electron-dev && electron-vite dev",
     "install:all": "bun install && bun run setup",
     "dev:web": "cd ../web && bun run dev -- --port 5173 --strictPort",
-    "dev:electron": "wait-on --timeout 30000 http://localhost:5173 && bun run prepare:electron-dev && electron-vite dev",
+    "dev:electron": "wait-on --timeout 180000 http://localhost:5173 && bun run prepare:electron-dev && electron-vite dev",
     "prepare:electron-dev": "bun scripts/prepare-electron-dev-app.ts",
     "build": "electron-vite build",
     "typecheck": "bunx tsc --noEmit",


### PR DESCRIPTION
## Summary
- Bump `dev:electron`'s `wait-on --timeout` from 30s to 180s in `clients/macos/package.json`.
- The 30s clock starts when `concurrently` launches both halves, but `dev:web` spends several seconds on the openapi-ts prestep before Vite even starts, and a cold-file-cache Vite startup under system load was observed taking 29s — the total overran 30s, `wait-on` timed out, and `--kill-others` tore down the whole dev orchestration just as Vite became ready.
- `wait-on` returns as soon as 5173 responds, so the larger ceiling costs nothing on the happy path (warm startup is ~250ms).

## Original prompt
Sidd hit a `wait-on` timeout running `bun run dev` in `clients/macos` — the electron half timed out at exactly 30s while the Vite banner showed `ready in 29139 ms`, and a rerun failed the same way. Investigation showed Vite is healthy in isolation (~250-370ms ready with the same warm cache), so the slow starts were machine-load / cold-page-cache effects; the fix is headroom on the race rather than any change to the web side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)