### PR TITLE
refactor(web): pro-onboarding self-review slop cleanup

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
@@ -8,7 +8,6 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import type { StalledApplyAction } from "./primitives";
 import {
   CreatureCorners,
-  STALLED_UPGRADE_WARNING,
   StalledApplyControls,
   WizardCardHeading,
 } from "./primitives";
@@ -48,16 +47,11 @@ export function CompleteState({
 
         <div className="mt-8 flex w-full flex-col items-center gap-4">
           {stalledAction ? (
-            <div className="flex w-full flex-col items-center gap-2">
-              <Notice tone="warning" className="w-full text-left">
-                {STALLED_UPGRADE_WARNING}
-              </Notice>
-              <StalledApplyControls
-                action={stalledAction}
-                buttonVariant="outlined"
-                buttonTestId="complete-stalled-apply"
-              />
-            </div>
+            <StalledApplyControls
+              action={stalledAction}
+              buttonTestId="complete-stalled-apply"
+              className="w-full"
+            />
           ) : (
             finishedInBackground && (
               <Notice tone="neutral" className="w-full text-left">

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -17,7 +17,6 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import type { StalledApplyAction } from "./primitives";
 import {
     CreatureCorners,
-    STALLED_UPGRADE_WARNING,
     StalledApplyControls,
     WizardCardHeading,
 } from "./primitives";
@@ -193,16 +192,10 @@ export function DomainStep({
         </div>
 
         {stalledAction && !isLocked ? (
-          <div className="flex flex-col items-center gap-2">
-            <Notice tone="warning" className="w-full text-left">
-              {STALLED_UPGRADE_WARNING}
-            </Notice>
-            <StalledApplyControls
-              action={stalledAction}
-              buttonVariant="outlined"
-              buttonTestId="domain-stalled-apply"
-            />
-          </div>
+          <StalledApplyControls
+            action={stalledAction}
+            buttonTestId="domain-stalled-apply"
+          />
         ) : (
           machineBusy &&
           !isLocked && (

--- a/clients/web/src/domains/settings/billing/pro-onboarding/error-states.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/error-states.tsx
@@ -8,7 +8,7 @@ import { IconBadge } from "./primitives";
 export function FetchErrorState({ onGoToBilling }: { onGoToBilling: () => void }) {
   return (
     <div className="flex flex-col items-center gap-4 px-6 py-10 text-center">
-      <IconBadge icon={AlertCircle} tone="negative" />
+      <IconBadge icon={AlertCircle} />
       <div className="space-y-1.5">
         <Typography variant="title-small" as="h1">
           Couldn&apos;t reach billing

--- a/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
@@ -2,11 +2,11 @@ import type { CSSProperties } from "react";
 import type { LucideIcon } from "lucide-react";
 import { ArrowRight } from "lucide-react";
 
-import type { ButtonVariant } from "@vellumai/design-library/components/button";
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
 
 import { AvatarRenderer } from "@/components/avatar-renderer";
+import { cn } from "@/utils/misc";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
 import { extractOnboardingErrorMessage } from "./utils";
@@ -19,25 +19,29 @@ export interface StalledApplyAction {
 }
 
 /** Warning shown when a backgrounded resize stalls mid-wizard. */
-export const STALLED_UPGRADE_WARNING =
+const STALLED_UPGRADE_WARNING =
   "We couldn't finish your machine upgrade automatically. Apply it now to finish — your assistant will briefly restart.";
 
 /**
- * Error notice + Apply & Restart button for recovering a stalled resize.
- * Shared by the provisioning screen, the complete screen, and the domain
- * step so the recovery affordance can't drift between them.
+ * Warning notice + Apply & Restart button for recovering a stalled resize.
+ * Shared by the complete screen and the domain step so the recovery affordance
+ * can't drift between them. (The dark provisioning takeover renders its own
+ * inline button by design.)
  */
 export function StalledApplyControls({
   action,
-  buttonVariant = "primary",
   buttonTestId,
+  className,
 }: {
   action: StalledApplyAction;
-  buttonVariant?: ButtonVariant;
   buttonTestId: string;
+  className?: string;
 }) {
   return (
-    <>
+    <div className={cn("flex flex-col items-center gap-2", className)}>
+      <Notice tone="warning" className="w-full text-left">
+        {STALLED_UPGRADE_WARNING}
+      </Notice>
       {action.error != null && (
         <Notice tone="error" className="w-full text-left">
           {extractOnboardingErrorMessage(
@@ -47,40 +51,29 @@ export function StalledApplyControls({
         </Notice>
       )}
       <Button
-        variant={buttonVariant}
+        variant="outlined"
         data-testid={buttonTestId}
         disabled={action.pending}
         onClick={action.onApply}
       >
         Apply &amp; Restart
       </Button>
-    </>
+    </div>
   );
 }
 
-export function IconBadge({
-  icon: Icon,
-  tone = "positive",
-}: {
-  icon: LucideIcon;
-  tone?: "positive" | "negative" | "warning";
-}) {
-  const toneVar =
-    tone === "positive"
-      ? "--system-positive-strong"
-      : tone === "warning"
-        ? "--system-mid-strong"
-        : "--system-negative-strong";
+export function IconBadge({ icon: Icon }: { icon: LucideIcon }) {
   return (
     <span
       className="flex h-11 w-11 items-center justify-center rounded-full"
       style={{
-        backgroundColor: `color-mix(in oklab, var(${toneVar}) 12%, transparent)`,
+        backgroundColor:
+          "color-mix(in oklab, var(--system-negative-strong) 12%, transparent)",
       }}
     >
       <Icon
         className="h-5 w-5"
-        style={{ color: `var(${toneVar})` }}
+        style={{ color: "var(--system-negative-strong)" }}
         aria-hidden="true"
       />
     </span>


### PR DESCRIPTION
## Summary
- Fix the StalledApplyControls docstring (provisioning does not use it — dark takeover button is inline by design)
- Remove IconBadge's dead tone branches (single negative consumer)
- Fold the stalled warning Notice into StalledApplyControls so complete/domain don't duplicate the composite

Part of plan: pro-onboarding-figma-polish.md (self-review remediation round 2)