### PR TITLE
feat(assistant): hero avatar hover polish + pupil cursor tracking

### DIFF
--- a/clients/web/src/components/avatar/animated-avatar.tsx
+++ b/clients/web/src/components/avatar/animated-avatar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import { useReducedMotion } from "motion/react";
 
 import { computeTransforms, resolveDefinitions } from "@/utils/avatar-svg-compositor";
@@ -15,7 +15,22 @@ interface AnimatedAvatarProps {
    * intact — e.g. the scattered onboarding edge characters.
    */
   breathe?: boolean;
+  /**
+   * While hovered, the pupils (not the whole eye) shift a small, fixed
+   * distance toward the cursor — a "look at cursor" effect. Off by default
+   * since it's opinionated and only makes sense on a large, single,
+   * hover-focused avatar (e.g. the About Assistant hero), not the many
+   * small/ambient avatars this component also renders.
+   */
+  trackCursor?: boolean;
 }
+
+/** Pupil fill color (see `PUPIL` in `assistant/src/avatar/character-components.ts`)
+ *  — the one reliable way to pick pupil paths out of an eye style's path
+ *  list from the client, since the API doesn't label path roles. */
+const PUPIL_HEX = "#1A1A1A";
+/** Max pupil shift toward the cursor, as a fraction of avatar size. */
+const PUPIL_TRACK_RATIO = 0.015;
 
 function randomBetween(min: number, max: number): number {
   return min + Math.random() * (max - min);
@@ -115,8 +130,31 @@ export function AnimatedAvatar({
   size,
   isAssistantBusy = false,
   breathe = true,
+  trackCursor = false,
 }: AnimatedAvatarProps) {
   const reduce = useReducedMotion();
+
+  // Pupil offset toward the cursor, in rendered (post-eyeTransform) pixels.
+  // Only tracked while the pointer is actually over the SVG — onMouseMove
+  // naturally stops firing once it leaves, and onMouseLeave recenters.
+  const [pupilOffset, setPupilOffset] = useState({ x: 0, y: 0 });
+  const handlePupilTrack = (event: ReactMouseEvent<SVGSVGElement>) => {
+    if (!trackCursor || reduce) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const scaleX = size / rect.width;
+    const scaleY = size / rect.height;
+    const localX = (event.clientX - rect.left) * scaleX;
+    const localY = (event.clientY - rect.top) * scaleY;
+    const dx = localX - eyeCenterOutputX;
+    const dy = localY - eyeCenterOutputY;
+    const dist = Math.hypot(dx, dy) || 1;
+    const maxOffset = size * PUPIL_TRACK_RATIO;
+    setPupilOffset({ x: (dx / dist) * maxOffset, y: (dy / dist) * maxOffset });
+  };
+  const handlePupilLeave = () => {
+    if (!trackCursor) return;
+    setPupilOffset({ x: 0, y: 0 });
+  };
 
   const { bodyShape, eyeStyle, color } = resolveDefinitions(
     components,
@@ -296,6 +334,8 @@ export function AnimatedAvatar({
       width={size}
       height={size}
       viewBox={`0 0 ${size} ${size}`}
+      onMouseMove={trackCursor ? handlePupilTrack : undefined}
+      onMouseLeave={trackCursor ? handlePupilLeave : undefined}
       style={{
         animation: breatheAnimation,
         transformOrigin: "center",
@@ -328,14 +368,27 @@ export function AnimatedAvatar({
           transition: "transform 0.15s ease-in-out",
         }}
       >
-        {eyeStyle.paths.map((p: EyePathDefinition, i: number) => (
-          <path
-            key={i}
-            d={p.svgPath}
-            fill={p.color}
-            transform={eyeTransform}
-          />
-        ))}
+        {eyeStyle.paths.map((p: EyePathDefinition, i: number) => {
+          if (p.color !== PUPIL_HEX) {
+            return (
+              <path key={i} d={p.svgPath} fill={p.color} transform={eyeTransform} />
+            );
+          }
+          // Pupil-only: nudged toward the cursor in already-rendered pixel
+          // space, so the shift reads correctly regardless of the eye
+          // style's own internal transform.
+          return (
+            <g
+              key={i}
+              style={{
+                transform: `translate(${pupilOffset.x}px, ${pupilOffset.y}px)`,
+                transition: "transform 0.1s ease-out",
+              }}
+            >
+              <path d={p.svgPath} fill={p.color} transform={eyeTransform} />
+            </g>
+          );
+        })}
       </g>
     </svg>
   );

--- a/clients/web/src/components/avatar/chat-avatar.tsx
+++ b/clients/web/src/components/avatar/chat-avatar.tsx
@@ -13,6 +13,8 @@ export interface ChatAvatarProps {
   className?: string;
   interactive?: boolean;
   isAssistantBusy?: boolean;
+  /** Pupils shift toward the cursor while hovered. See `AnimatedAvatar`. */
+  trackCursor?: boolean;
   /**
    * Stamp `data-voice-origin` on the avatar's root so the live-voice room can
    * find this on-screen avatar and grow its entrance from here. Set on the
@@ -81,6 +83,7 @@ function ChatAvatarComponent({
   interactive = false,
   isAssistantBusy = false,
   originAnchor = false,
+  trackCursor = false,
 }: ChatAvatarProps) {
   const reduce = useReducedMotion();
   const [isPoking, setIsPoking] = useState(false);
@@ -145,6 +148,7 @@ function ChatAvatarComponent({
           traits={effectiveTraits}
           size={size}
           isAssistantBusy={isAssistantBusy}
+          trackCursor={trackCursor}
         />
       </motion.div>
     );

--- a/clients/web/src/domains/intelligence/components/amoeba-avatar.tsx
+++ b/clients/web/src/domains/intelligence/components/amoeba-avatar.tsx
@@ -202,7 +202,7 @@ export function AmoebaPeekTab({
         animate={{
           x: anchor.x - TAB_DIAMETER / 2 + (active ? 0 : retract.x),
           y: anchor.y - TAB_DIAMETER / 2 + (active ? 0 : retract.y),
-          opacity: active ? 1 : 0,
+          opacity: active ? 0.8 : 0,
         }}
         transition={transition}
       />
@@ -214,7 +214,7 @@ export function AmoebaPeekTab({
           y: eyeCenter.y - eyeH / 2 + (active ? 0 : retract.y),
           width: eyeW,
           height: eyeH,
-          opacity: active ? 1 : 0,
+          opacity: active ? 0.8 : 0,
         }}
         transition={transition}
       >

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -16,6 +16,7 @@ import {
   CalendarClock,
   FolderOpen,
   LayoutGrid,
+  Pencil,
   Radio,
   Sparkles,
   Users,
@@ -413,9 +414,10 @@ function SectionCard({
     return (
       <Card.Root
         asChild
+        bordered={false}
         elevated
         clipContents
-        className="rounded-[12px] bg-[var(--card-bg)]"
+        className="rounded-[12px] border-0 bg-[var(--card-bg)]"
       >
         <Link
           to={section.to}
@@ -433,7 +435,7 @@ function SectionCard({
               aria-hidden
             />
           </span>
-          <span className="relative flex min-w-0 flex-col gap-1">
+          <span className="relative flex min-w-0 flex-col gap-0">
             <span
               className={`truncate text-title-small leading-normal transition-colors duration-300 ${fgStrong}`}
             >
@@ -474,7 +476,7 @@ function SectionCard({
       elevated={!isFeatureCard}
       className={`${SECTION_RADII[section.key] ?? ""} ${
         isFeatureCard
-          ? "bg-[var(--card-feature-bg,var(--card-bg))]"
+          ? "border-0 bg-[var(--card-feature-bg,var(--card-bg))]"
           : "bg-[var(--card-bg)]"
       }`}
       style={{
@@ -955,7 +957,7 @@ function OverviewBento({
                 onOpenAvatarModal();
               }
             }}
-            className="avatar-edit-cursor pointer-events-auto relative h-full w-full outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]"
+            className="avatar-edit-cursor group pointer-events-auto relative h-full w-full scale-100 outline-none transition-transform duration-200 ease-out hover:scale-105 keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]"
           >
             <ChatAvatar
               components={components}
@@ -963,7 +965,16 @@ function OverviewBento({
               customImageUrl={customImageUrl}
               size={heroAvatarSize}
               interactive
+              trackCursor
             />
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+            >
+              <span className="flex h-11 w-11 items-center justify-center rounded-full bg-black/40">
+                <Pencil className="h-5 w-5 text-white" />
+              </span>
+            </span>
           </div>
         </motion.div>
       ) : (

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -874,15 +874,10 @@ body {
   --card-surface: #000000;
 }
 
-/* About Assistant hero avatar: clicking it opens the avatar/name modal,
-   so the pointer itself becomes a pencil while over it. White-filled,
-   dark-stroked so it reads on any avatar color; hotspot at the tip.
+/* About Assistant hero avatar: clicking it opens the avatar/name modal.
    `!important` + the descendant selector out-rank ChatAvatar's inline
    `cursor: pointer` on its interactive inner elements. */
 .avatar-edit-cursor,
 .avatar-edit-cursor * {
-  cursor:
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='white' stroke='%2324292E' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z'/%3E%3C/svg%3E")
-      2 22,
-    pointer !important;
+  cursor: pointer !important;
 }


### PR DESCRIPTION
## Summary
- The About Assistant hero avatar now grows 5% and shows a pencil icon on hover, with a plain pointer cursor (replacing the old custom pencil-shaped cursor).
- Its pupils shift toward the mouse while hovered (a "look at cursor" effect) via a new opt-in `trackCursor` prop on `AnimatedAvatar`/`ChatAvatar`, so the many other avatars this component renders elsewhere are unaffected.
- Removed the residual transparent 1px border from the section cards (mini and feature variants) via `border-0`.
- Tightened the mini card's title/stat spacing by 4px.
- Lowered the peeking amoeba avatar's hover opacity to 0.8.

## Test plan
- [ ] Hover the hero avatar on the About Assistant page: it should grow slightly, show a pencil icon, and the pupils should track the cursor
- [ ] Confirm the section cards (Personality, Schedules, Memory, Library, Workspace, Contacts, Channels) have no visible border
- [ ] Confirm the mini card title/stat spacing and the amoeba hover opacity look right
