### PR TITLE
fix(providers): fall back to configured model when usage report omits model

### DIFF
--- a/assistant/src/__tests__/estimator-calibration.test.ts
+++ b/assistant/src/__tests__/estimator-calibration.test.ts
@@ -197,6 +197,32 @@ describe("estimator calibration", () => {
     expect(getCorrection("anthropic", "claude-opus-4-7")).toBeCloseTo(1.2, 1);
   });
 
+  test("an undefined model is tolerated and folded into the per-provider aggregate", () => {
+    // Some OpenAI-compatible providers (opencode/OpenRouter) omit `model` in
+    // their usage report, so `recordEstimate` can be called with a runtime
+    // undefined despite the static `string` type. It must not throw — an
+    // unhandled rejection here crashes the whole assistant process — and the
+    // sample should still land on the per-provider aggregate key.
+    expect(() =>
+      recordEstimate(
+        "openrouter",
+        undefined as unknown as string,
+        100_000,
+        120_000,
+      ),
+    ).not.toThrow();
+    expect(getCorrection("openrouter", "")).toBeCloseTo(1.2, 5);
+
+    // Exactly one sample landed on the aggregate — the undefined-model path
+    // must not double-count into a specific key.
+    const snap = getCalibrationSnapshot().filter(
+      (e) => e.provider === "openrouter",
+    );
+    expect(snap).toHaveLength(1);
+    expect(snap[0].model).toBe("");
+    expect(snap[0].samples).toBe(1);
+  });
+
   test("explicit empty-model recording does not double-count the aggregate", () => {
     // When a caller passes an empty model string (degenerate case), the
     // aggregate update path must not run — otherwise the sample would be

--- a/assistant/src/context/estimator-calibration.ts
+++ b/assistant/src/context/estimator-calibration.ts
@@ -76,12 +76,19 @@ export function recordEstimate(
   const ratio = actual / estimated;
   if (ratio < MIN_ACCEPTABLE_RATIO || ratio > MAX_ACCEPTABLE_RATIO) return;
 
-  applyEwmaUpdate(provider, model, ratio);
+  // A provider can echo back a usage report with no model field (some
+  // OpenAI-compatible providers omit it), leaving `model` null/undefined at
+  // runtime despite its static type. Normalize to the per-provider aggregate
+  // key rather than dereferencing it — an unhandled throw here crashes the
+  // whole process.
+  const safeModel = model ?? "";
+
+  applyEwmaUpdate(provider, safeModel, ratio);
 
   // Also fold into the per-provider aggregate so callers without a modelId
   // fall back to a meaningful rolling correction instead of the 1.0 default.
   // Skip when the caller already passed an empty model (avoids double-counting).
-  if (model.length > 0) {
+  if (safeModel.length > 0) {
     applyEwmaUpdate(provider, "", ratio);
   }
 }

--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
@@ -741,3 +741,42 @@ describe("OpenAIChatCompletionsProvider cache usage parsing", () => {
     expect(response.usage).not.toHaveProperty("cacheCreationInputTokens");
   });
 });
+
+describe("OpenAIChatCompletionsProvider response model", () => {
+  test("reports the model echoed back by the provider chunks", async () => {
+    const { provider } = stubProvider([
+      { choices: [{ delta: { content: "ok" } }], model: "server-model-xyz" },
+      {
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 2, completion_tokens: 1 },
+        model: "server-model-xyz",
+      },
+    ]);
+
+    const response = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ]);
+
+    expect(response.model).toBe("server-model-xyz");
+  });
+
+  test("falls back to the configured model when chunks omit `model`", async () => {
+    // opencode/OpenRouter can stream a usage report with no `model` field.
+    // The response must carry the configured model rather than an undefined
+    // that crashes the downstream calibrator and violates the usage-event
+    // NOT NULL constraint on `model`.
+    const { provider } = stubProvider([
+      { choices: [{ delta: { content: "ok" } }] },
+      {
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 2, completion_tokens: 1 },
+      },
+    ]);
+
+    const response = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ]);
+
+    expect(response.model).toBe("test-model");
+  });
+});

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -656,7 +656,13 @@ export class OpenAIChatCompletionsProvider implements Provider {
             cacheWritePromptTokens = promptDetails?.cache_write_tokens ?? 0;
           }
 
-          responseModel = chunk.model;
+          // OpenAI-compatible providers (e.g. opencode/OpenRouter) may omit
+          // `model` in their usage-report chunk. Only overwrite when the chunk
+          // actually names one so the configured model (`modelOverride ??
+          // this.model`) survives as the fallback.
+          if (chunk.model) {
+            responseModel = chunk.model;
+          }
         }
       } finally {
         cleanupTimeout();


### PR DESCRIPTION
## Prompt / plan

Runtime bug report: a usage event with `model=undefined` from an OpenAI-compatible provider (opencode/OpenRouter, which don't return a `model` field in their usage report) crashed the entire assistant process. `recordEstimate` called `model.length` on `undefined` → `TypeError` → unhandled promise rejection → lifecycle-initiated shutdown (exit 1), 3–5 seconds *after* the chat reply was already delivered. Separately, `recordUsageEvent` failed with `NOT NULL constraint failed: llm_usage_events.model` (marked non-fatal) — same root cause.

### Root cause

`OpenAIChatCompletionsProvider` seeds `responseModel` from the configured `modelOverride ?? this.model`, then unconditionally overwrote it with `chunk.model` for every streamed chunk. When the provider's usage-report chunk omits `model`, that overwrote the good value with `undefined`, so `response.model` became `undefined`. Every symptom flowed from that single undefined — both the calibrator crash and the usage-event NOT NULL violation consume `response.model`.

### Fix

- **Root cause** (`chat-completions-provider.ts`): only overwrite `responseModel` when the chunk actually names a model, so the configured model survives as the fallback. This mirrors the existing guards already present in the Responses (`if (response.model)`) and Gemini (`if (chunk.modelVersion)`) providers, and covers every OpenAI-compatible subclass (OpenRouter, Together, Fireworks, Baseten, AtlasCloud, Minimax, Vercel AI Gateway, Ollama).
- **Defense-in-depth** (`estimator-calibration.ts`): normalize a null/undefined `model` to the per-provider aggregate key inside `recordEstimate` instead of dereferencing it, so a bad model value can never again crash the process regardless of caller — the failure mode here is a full daemon shutdown.

## Test plan

- `estimator-calibration.test.ts`: new case asserting `recordEstimate` tolerates an `undefined` model without throwing and folds the sample into the per-provider aggregate key.
- `chat-completions-provider-reasoning.test.ts`: new cases asserting `response.model` is the model echoed by the provider when present, and falls back to the configured model when chunks omit `model`.
- `bun test` on both files (39 pass, 0 fail), `bun run typecheck:fast` clean, `eslint` 0 errors on changed files.

<!-- No new routes added; CLI verb checklist omitted. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6vkm1wvWH4APRQ5KRbjE9)_