### PR TITLE
fix(web): add missing /v1 prefix in window.vellum.fetch

### DIFF
--- a/clients/web/src/utils/sandbox-bridge.test.ts
+++ b/clients/web/src/utils/sandbox-bridge.test.ts
@@ -211,6 +211,15 @@ describe("injectBridge", () => {
     expect(out).not.toContain("vellum_fetch_request");
     expect(out).not.toContain("window.vellum.fetch");
   });
+
+  it("normalizes a missing /v1 prefix on custom-route fetch paths", () => {
+    const html = "<html><body></body></html>";
+    const out = injectBridge(html, FRAME_ID, { fetch: true });
+    // The bridge prepends "/v1" to "/x/..." paths so the host's strict
+    // "/v1/x/" check accepts callers that omit the version prefix.
+    expect(out).toContain("path.indexOf('/x/') === 0");
+    expect(out).toContain("'/v1' + path");
+  });
 });
 
 describe("buildLinkInterceptorScript", () => {

--- a/clients/web/src/utils/sandbox-bridge.ts
+++ b/clients/web/src/utils/sandbox-bridge.ts
@@ -271,6 +271,12 @@ function buildBridgeLogicScript(
   });
   window.vellum.fetch = function(path, options) {
     options = options || {};
+    // Custom routes are served under "/v1/x/". Tolerate callers that omit the
+    // "/v1" prefix ("/x/foo" -> "/v1/x/foo") so the host's strict "/v1/x/"
+    // check doesn't reject an otherwise-valid route path.
+    if (typeof path === 'string' && path.indexOf('/x/') === 0) {
+      path = '/v1' + path;
+    }
     return new Promise(function(resolve, reject) {
       var callId = 'f' + (window.vellum._fetchNextId++);
       window.vellum._pendingFetches[callId] = { resolve: resolve, reject: reject };


### PR DESCRIPTION
## Prompt / plan

> window.vellum.fetch should add the v1 prefix when it's missing

Custom routes are served under `/v1/x/`, and the parent-side fetch proxy (`use-sandbox-fetch-proxy.ts`) strictly rejects any path that doesn't match `/^\/v1\/x\//`. App authors who call `window.vellum.fetch("/x/foo")` without the `/v1` prefix hit that rejection ("Request blocked: only /v1/x/ custom routes are allowed") even though the route is otherwise valid.

This normalizes the path inside the in-iframe bridge (`sandbox-bridge.ts`): when a fetch path begins with `/x/`, it prepends `/v1` so the request becomes `/v1/x/...` before it reaches the host. Canonical `/v1/x/...` paths are unaffected (they don't start with `/x/`, so no double-prefixing).

The host's strict `/v1/x/` validation is deliberately left untouched — it remains the security boundary; the bridge change is purely an ergonomics tolerance for callers that omit the version prefix.

## Test plan

- Added a unit test in `sandbox-bridge.test.ts` asserting the emitted bridge script contains the prefix-normalization logic.
- `bun test src/utils/sandbox-bridge.test.ts` — 32 pass.
- `bunx tsc --noEmit` — clean.
- `bun run lint` — 0 errors.

<!-- CLI verb checklist omitted: this PR adds no IPC routes under assistant/src/runtime/routes/. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mxvYRxcjUhYF3VrDkRQsT

---
_Generated by [Claude Code](https://claude.ai/code/session_018mxvYRxcjUhYF3VrDkRQsT)_