### PR TITLE
fix(voice): assistant-initiated voice change routes to the active TTS provider (JARVIS-1307)

### DIFF
--- a/assistant/src/__tests__/voice-config-update.test.ts
+++ b/assistant/src/__tests__/voice-config-update.test.ts
@@ -203,7 +203,7 @@ describe("voice_config_update — tts_voice_id", () => {
     expect((config.elevenlabs as any)?.voiceId).toBeUndefined();
   });
 
-  test("rejects non-alphanumeric voice ID", async () => {
+  test("rejects non-alphanumeric voice ID when provider is elevenlabs", async () => {
     const result = await run(
       { setting: "tts_voice_id", value: "abc-123!" },
       makeContext(),
@@ -211,6 +211,97 @@ describe("voice_config_update — tts_voice_id", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("alphanumeric");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: tts_voice_id targets the active provider's voice field
+// ---------------------------------------------------------------------------
+
+describe("voice_config_update — tts_voice_id (managed/vellum active)", () => {
+  function makeVellumActive(): void {
+    writeConfig({ services: { tts: { provider: "vellum" } } });
+    invalidateConfigCache();
+  }
+
+  test("writes a Deepgram Aura model id to services.tts.providers.vellum.model", async () => {
+    makeVellumActive();
+
+    const result = await run(
+      { setting: "tts_voice_id", value: "aura-2-zeus-en" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const config = readConfig();
+    expect((config.services as any)?.tts?.providers?.vellum?.model).toBe(
+      "aura-2-zeus-en",
+    );
+    // The ElevenLabs field is never touched when vellum is active.
+    expect(
+      (config.services as any)?.tts?.providers?.elevenlabs?.voiceId,
+    ).toBeUndefined();
+  });
+
+  test("accepts an ElevenLabs voice id as a managed model (managed serves ElevenLabs voices)", async () => {
+    makeVellumActive();
+
+    const result = await run(
+      { setting: "tts_voice_id", value: "EXAVITQu4vr4xnSDxMaL" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect((readConfig().services as any)?.tts?.providers?.vellum?.model).toBe(
+      "EXAVITQu4vr4xnSDxMaL",
+    );
+  });
+
+  test("does not broadcast the ElevenLabs ttsVoiceId key for a managed voice", async () => {
+    makeVellumActive();
+    const messages: any[] = [];
+    const ctx = makeContext({
+      sendToClient: (msg: any) => messages.push(msg),
+    });
+
+    const result = await run(
+      { setting: "tts_voice_id", value: "aura-2-zeus-en" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(messages).toHaveLength(0);
+    expect(result.content).not.toContain("broadcast");
+  });
+
+  test("rejects a value with characters invalid for any voice id", async () => {
+    makeVellumActive();
+
+    const result = await run(
+      { setting: "tts_voice_id", value: "a british man" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect((readConfig().services as any)?.tts?.providers?.vellum?.model).toBe(
+      undefined,
+    );
+  });
+
+  test("broadcasts the ElevenLabs ttsVoiceId key when elevenlabs is active", async () => {
+    writeConfig({ services: { tts: { provider: "elevenlabs" } } });
+    invalidateConfigCache();
+    const messages: any[] = [];
+    const ctx = makeContext({
+      sendToClient: (msg: any) => messages.push(msg),
+    });
+
+    const result = await run({ setting: "tts_voice_id", value: "abc123" }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].key).toBe("ttsVoiceId");
+    expect(messages[0].value).toBe("abc123");
   });
 });
 

--- a/assistant/src/cli/commands/__tests__/tts.test.ts
+++ b/assistant/src/cli/commands/__tests__/tts.test.ts
@@ -21,11 +21,20 @@ import { Command } from "commander";
 /** The last `cliIpcCall` invocation captured for assertions. */
 let lastIpcCall: { method: string; params?: any } | null = null;
 
+/** Every `cliIpcCall` invocation in order (the `voice` command makes two). */
+let ipcCalls: Array<{ method: string; params?: any }> = [];
+
 /** The result that cliIpcCall will return. */
 let mockIpcResult: { ok: boolean; result?: unknown; error?: string } = {
   ok: true,
   result: { audioBase64: "dGVzdA==", contentType: "audio/mpeg" },
 };
+
+/** Optional per-method result overrides (falls back to `mockIpcResult`). */
+let ipcResponders: Record<
+  string,
+  { ok: boolean; result?: unknown; error?: string }
+> = {};
 
 /** Captured writeFileSync calls. */
 let writeFileCalls: Array<{ path: string; data: Buffer }> = [];
@@ -40,7 +49,8 @@ let stdinReturnsText = false;
 mock.module("../../../ipc/cli-client.js", () => ({
   cliIpcCall: async (method: string, params?: any) => {
     lastIpcCall = { method, params };
-    return mockIpcResult;
+    ipcCalls.push({ method, params });
+    return ipcResponders[method] ?? mockIpcResult;
   },
   exitFromIpcResult: (r: any) => {
     process.exitCode = 1;
@@ -156,6 +166,8 @@ async function runCommand(
 
 beforeEach(() => {
   lastIpcCall = null;
+  ipcCalls = [];
+  ipcResponders = {};
   mockIpcResult = {
     ok: true,
     result: { audioBase64: "dGVzdA==", contentType: "audio/mpeg" },
@@ -324,5 +336,113 @@ describe("tts synthesize — base64 round-trip", () => {
     expect(Buffer.from(writeFileCalls[0].data).equals(originalBytes)).toBe(
       true,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// voice — routes to the active provider's config key
+// ---------------------------------------------------------------------------
+
+describe("tts voice — active-provider routing", () => {
+  function respondProvider(provider: string): void {
+    ipcResponders.config_get = {
+      ok: true,
+      result: { services: { tts: { provider } } },
+    };
+    ipcResponders.config_set = { ok: true, result: {} };
+  }
+
+  test("managed (vellum) writes to services.tts.providers.vellum.model", async () => {
+    respondProvider("vellum");
+
+    const { exitCode } = await runCommand(["tts", "voice", "aura-2-zeus-en"]);
+
+    expect(exitCode).toBe(0);
+    const setCall = ipcCalls.find((c) => c.method === "config_set");
+    expect(setCall).toBeDefined();
+    expect(setCall!.params.body.path).toBe(
+      "services.tts.providers.vellum.model",
+    );
+    expect(setCall!.params.body.value).toBe("aura-2-zeus-en");
+  });
+
+  test("an ElevenLabs voice id on a managed assistant still writes vellum.model", async () => {
+    respondProvider("vellum");
+
+    const { exitCode } = await runCommand([
+      "tts",
+      "voice",
+      "pqHfZKP75CvOlQylNhV4",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const setCall = ipcCalls.find((c) => c.method === "config_set");
+    expect(setCall!.params.body.path).toBe(
+      "services.tts.providers.vellum.model",
+    );
+  });
+
+  test("elevenlabs writes to services.tts.providers.elevenlabs.voiceId", async () => {
+    respondProvider("elevenlabs");
+
+    const { exitCode } = await runCommand(["tts", "voice", "abc123"]);
+
+    expect(exitCode).toBe(0);
+    const setCall = ipcCalls.find((c) => c.method === "config_set");
+    expect(setCall!.params.body.path).toBe(
+      "services.tts.providers.elevenlabs.voiceId",
+    );
+  });
+
+  test("defaults to elevenlabs when no provider is configured", async () => {
+    ipcResponders.config_get = { ok: true, result: {} };
+    ipcResponders.config_set = { ok: true, result: {} };
+
+    const { exitCode } = await runCommand(["tts", "voice", "abc123"]);
+
+    expect(exitCode).toBe(0);
+    const setCall = ipcCalls.find((c) => c.method === "config_set");
+    expect(setCall!.params.body.path).toBe(
+      "services.tts.providers.elevenlabs.voiceId",
+    );
+  });
+
+  test("no voice id exits code 1 without touching config", async () => {
+    respondProvider("vellum");
+
+    const { exitCode } = await runCommand(["tts", "voice"]);
+
+    expect(exitCode).toBe(1);
+    expect(ipcCalls.find((c) => c.method === "config_set")).toBeUndefined();
+  });
+
+  test("--json emits the provider and path it wrote", async () => {
+    respondProvider("vellum");
+
+    const { exitCode, stdout } = await runCommand([
+      "tts",
+      "voice",
+      "aura-2-luna-en",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.ok).toBe(true);
+    expect(parsed.provider).toBe("vellum");
+    expect(parsed.path).toBe("services.tts.providers.vellum.model");
+    expect(parsed.voiceId).toBe("aura-2-luna-en");
+  });
+
+  test("a config_set failure sets a non-zero exit code", async () => {
+    ipcResponders.config_get = {
+      ok: true,
+      result: { services: { tts: { provider: "vellum" } } },
+    };
+    ipcResponders.config_set = { ok: false, error: "daemon error" };
+
+    const { exitCode } = await runCommand(["tts", "voice", "aura-2-zeus-en"]);
+
+    expect(exitCode).not.toBe(0);
   });
 });

--- a/assistant/src/cli/commands/tts.help.ts
+++ b/assistant/src/cli/commands/tts.help.ts
@@ -84,5 +84,38 @@ Examples:
   $ assistant tts synthesize --text "hi" --use-case phone-call
   $ assistant tts synthesize --text "hi" --json`,
     },
+    {
+      name: "voice",
+      description:
+        "Set the TTS voice for the currently active provider (routes to the right config key automatically)",
+      arguments: [
+        {
+          name: "[id...]",
+          description:
+            "Voice/model id to set (joined with spaces). ElevenLabs voice id for elevenlabs; managed voice model id (ElevenLabs id or Deepgram Aura model like aura-2-thalia-en) for vellum; Aura model id for deepgram",
+        },
+      ],
+      options: [
+        {
+          flags: "--json",
+          description:
+            "Output a single-line JSON object on stdout instead of a plain message",
+        },
+      ],
+      helpText: `
+Set the assistant's TTS voice on whichever provider is currently active
+(services.tts.provider). This writes to the config key that provider actually
+reads — e.g. services.tts.providers.vellum.model for managed speech — so the
+change takes effect on the next spoken turn.
+
+Prefer this over 'assistant config set services.tts.providers.elevenlabs.voiceId'
+directly: on a managed (vellum) assistant that field is ignored, so the voice
+would silently not change.
+
+Examples:
+  $ assistant tts voice pqHfZKP75CvOlQylNhV4      # ElevenLabs voice id (also valid on managed)
+  $ assistant tts voice aura-2-thalia-en          # Deepgram Aura model (managed/deepgram)
+  $ assistant tts voice aura-2-zeus-en --json`,
+    },
   ],
 };

--- a/assistant/src/cli/commands/tts.ts
+++ b/assistant/src/cli/commands/tts.ts
@@ -192,6 +192,86 @@ export function registerTtsCommand(program: Command): void {
           }
         },
       );
+
+      // ── voice ───────────────────────────────────────────────────────────
+
+      subcommand(ttsCmd, "voice").action(
+        async (
+          positionalParts: string[],
+          opts: { json?: boolean },
+          cmd: Command,
+        ) => {
+          const jsonOutput = opts.json ?? false;
+          const emitError = (msg: string): void => {
+            if (jsonOutput) {
+              process.stdout.write(
+                JSON.stringify({ ok: false, error: msg }) + "\n",
+              );
+            } else {
+              log.error(msg);
+            }
+          };
+
+          const voiceId = positionalParts.join(" ").trim();
+          if (!voiceId) {
+            emitError(
+              "No voice id provided. Usage: assistant tts voice <voice-id>",
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          // Read the active TTS provider so the voice lands on the field that
+          // provider actually reads. Writing the ElevenLabs field while the
+          // active provider is `vellum` is a silent no-op.
+          const cfg = await cliIpcCall<{
+            services?: { tts?: { provider?: string } };
+          }>("config_get");
+          if (!cfg.ok) {
+            return exitFromIpcResult(
+              { ok: false, error: cfg.error, statusCode: cfg.statusCode },
+              cmd,
+            );
+          }
+          const provider = cfg.result?.services?.tts?.provider ?? "elevenlabs";
+          // Lazy-import to keep this daemon-internal module out of the CLI's
+          // static graph (cli/no-daemon-internals — see src/cli/AGENTS.md).
+          const { ttsVoiceFieldFor } =
+            await import("../../tts/tts-voice-field.js");
+          const field = ttsVoiceFieldFor(provider);
+
+          const r = await cliIpcCall("config_set", {
+            body: { path: field.path, value: voiceId },
+          });
+          if (!r.ok) {
+            if (jsonOutput) {
+              emitError(r.error ?? "Failed to set voice");
+              process.exitCode = 1;
+              return;
+            }
+            return exitFromIpcResult(
+              { ok: false, error: r.error, statusCode: r.statusCode },
+              cmd,
+            );
+          }
+
+          if (jsonOutput) {
+            process.stdout.write(
+              JSON.stringify({
+                ok: true,
+                provider,
+                path: field.path,
+                voiceId,
+              }) + "\n",
+            );
+          } else {
+            process.stdout.write(
+              `Set ${field.label} to "${voiceId}" (${field.path}). ` +
+                "Takes effect on the next spoken turn.\n",
+            );
+          }
+        },
+      );
     },
   });
 }

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "voice_config_update",
-      "description": "Update a voice configuration setting. Use tts_provider / stt_provider to switch the active TTS / STT provider. Provider \"vellum\" is Vellum-managed speech (billed to your organization; requires a Vellum platform connection via 'assistant platform connect'); any other provider uses the user's own API key. Valid TTS providers come from the provider catalog (vellum, elevenlabs, fish-audio, deepgram, xai); valid STT providers: vellum, deepgram, google-gemini, openai-whisper, xai. Use tts_voice_id to set the ElevenLabs voice ID, fish_audio_reference_id for Fish Audio voice reference. Deepgram uses the same API key for TTS and STT and requires no additional voice config. Changes persist to services.stt / services.tts config and take effect immediately.",
+      "description": "Update a voice configuration setting. Use tts_provider / stt_provider to switch the active TTS / STT provider. Provider \"vellum\" is Vellum-managed speech (billed to your organization; requires a Vellum platform connection via 'assistant platform connect'); any other provider uses the user's own API key. Valid TTS providers come from the provider catalog (vellum, elevenlabs, fish-audio, deepgram, xai); valid STT providers: vellum, deepgram, google-gemini, openai-whisper, xai. Use tts_voice_id to change the voice; it targets whichever TTS provider is currently active. For elevenlabs, pass an ElevenLabs voice ID. For vellum (managed), pass a managed voice model ID — this may be an ElevenLabs voice ID (managed speech serves the same ElevenLabs voices) or a Deepgram Aura model ID (e.g. aura-2-thalia-en); only rate-carded voices synthesize, so prefer models from the managed catalog (daemon route GET tts/managed-voices, also used by the web voice picker). For deepgram, pass a Deepgram Aura model ID. Use fish_audio_reference_id for Fish Audio voice reference. Deepgram uses the same API key for TTS and STT. Changes persist to services.stt / services.tts config and take effect immediately.",
       "category": "system",
       "risk": "low",
       "input_schema": {
@@ -19,10 +19,10 @@
               "tts_provider",
               "tts_voice_id"
             ],
-            "description": "The voice setting to change. tts_provider / stt_provider select the active provider for each service (\"vellum\" = Vellum-managed speech; anything else = the user's own API key). tts_voice_id sets the ElevenLabs voice. fish_audio_reference_id sets the Fish Audio voice reference. Deepgram uses its default model and shares one API key across TTS and STT."
+            "description": "The voice setting to change. tts_provider / stt_provider select the active provider for each service (\"vellum\" = Vellum-managed speech; anything else = the user's own API key). tts_voice_id sets the voice for the currently active TTS provider (ElevenLabs voice ID for elevenlabs; a managed voice model ID for vellum — an ElevenLabs voice ID or a Deepgram Aura model ID like aura-2-thalia-en; a Deepgram Aura model ID for deepgram; voice ID for xai). fish_audio_reference_id sets the Fish Audio voice reference. Deepgram shares one API key across TTS and STT."
           },
           "value": {
-            "description": "The new value for the setting. For tts_provider: one of vellum, elevenlabs, fish-audio, deepgram, xai. For stt_provider: one of vellum, deepgram, google-gemini, openai-whisper, xai. For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string."
+            "description": "The new value for the setting. For tts_provider: one of vellum, elevenlabs, fish-audio, deepgram, xai. For stt_provider: one of vellum, deepgram, google-gemini, openai-whisper, xai. For tts_voice_id: a voice ID for the active TTS provider — an alphanumeric ElevenLabs voice ID (elevenlabs), a managed voice model ID which may be an ElevenLabs voice ID or a Deepgram Aura model ID like aura-2-thalia-en (vellum), or a Deepgram Aura model ID (deepgram). For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string."
           }
         }
       },

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -5,7 +5,9 @@ import type {
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 import { listCatalogProviderIds } from "../../../../tts/provider-catalog.js";
+import { ttsVoiceFieldFor } from "../../../../tts/tts-voice-field.js";
 import {
+  getConfig,
   invalidateConfigCache,
   loadRawConfig,
   saveRawConfig,
@@ -44,9 +46,7 @@ const VOICE_SETTINGS = {
 type VoiceSettingName = keyof typeof VOICE_SETTINGS;
 
 /** Exported so tests can assert parity with the TOOLS.json `setting` enum. */
-export const VALID_SETTINGS = Object.keys(
-  VOICE_SETTINGS,
-) as VoiceSettingName[];
+export const VALID_SETTINGS = Object.keys(VOICE_SETTINGS) as VoiceSettingName[];
 
 const VALID_TIMEOUTS: readonly number[] = VALID_CONVERSATION_TIMEOUTS;
 
@@ -62,6 +62,7 @@ const FRIENDLY_NAMES: Record<VoiceSettingName, string> = {
 function validateSetting(
   setting: string,
   value: unknown,
+  activeTtsProviderId?: string,
 ):
   | { ok: true; coerced: string | boolean | number }
   | { ok: false; error: string } {
@@ -104,16 +105,27 @@ function validateSetting(
       if (typeof value !== "string" || value.trim().length === 0) {
         return {
           ok: false,
-          error:
-            "tts_voice_id must be a non-empty string (ElevenLabs voice ID)",
+          error: "tts_voice_id must be a non-empty string",
         };
       }
       const trimmed = value.trim();
-      if (!/^[a-zA-Z0-9]+$/.test(trimmed)) {
+      const field = ttsVoiceFieldFor(activeTtsProviderId);
+      if (field.alphanumericOnly) {
+        if (!/^[a-zA-Z0-9]+$/.test(trimmed)) {
+          return {
+            ok: false,
+            error:
+              "tts_voice_id must contain only alphanumeric characters (ElevenLabs voice ID format)",
+          };
+        }
+      } else if (!/^[a-zA-Z0-9._-]+$/.test(trimmed)) {
+        // Managed (vellum) / deepgram voices are Deepgram Aura model ids and
+        // the other providers' voice references are also hyphenated.
         return {
           ok: false,
           error:
-            "tts_voice_id must contain only alphanumeric characters (ElevenLabs voice ID format)",
+            "tts_voice_id must contain only letters, numbers, '.', '_', or '-' " +
+            "(e.g. a Deepgram Aura model id like aura-2-thalia-en)",
         };
       }
       return { ok: true, coerced: trimmed };
@@ -197,7 +209,12 @@ export async function run(
     };
   }
 
-  const validation = validateSetting(setting, value);
+  // A tts_voice_id change targets the *active* TTS provider's voice field, so
+  // validation and the write below both need to know which provider is live.
+  const activeTtsProviderId =
+    setting === "tts_voice_id" ? getConfig().services.tts.provider : undefined;
+
+  const validation = validateSetting(setting, value, activeTtsProviderId);
   if (!validation.ok) {
     return { content: `Error: ${validation.error}`, isError: true };
   }
@@ -214,12 +231,22 @@ export async function run(
   }
 
   const meta: VoiceSettingMeta = VOICE_SETTINGS[setting as VoiceSettingName];
-  const friendlyName = FRIENDLY_NAMES[setting as VoiceSettingName];
+  const friendlyName =
+    setting === "tts_voice_id"
+      ? ttsVoiceFieldFor(activeTtsProviderId).label
+      : FRIENDLY_NAMES[setting as VoiceSettingName];
+
+  // The `ttsVoiceId` UserDefaults key is an ElevenLabs concept on the desktop
+  // client. A managed (vellum) or other-provider voice lives only in daemon
+  // config and hot-applies per turn — broadcasting its id under the ElevenLabs
+  // key would pollute the client's ElevenLabs voice, so skip the broadcast.
+  const skipClientBroadcast =
+    setting === "tts_voice_id" && activeTtsProviderId !== "elevenlabs";
 
   // Send client_settings_update message to write to UserDefaults.
   // Always stringify the value — Swift's ClientSettingsUpdate.value is typed
   // as String, so a bare JSON number would fail to decode.
-  if (context.sendToClient && meta.userDefaultsKey) {
+  if (context.sendToClient && meta.userDefaultsKey && !skipClientBroadcast) {
     context.sendToClient({
       type: "client_settings_update",
       key: meta.userDefaultsKey,
@@ -240,7 +267,7 @@ export async function run(
   if (setting === "tts_voice_id") {
     setNestedValue(
       raw,
-      "services.tts.providers.elevenlabs.voiceId",
+      ttsVoiceFieldFor(activeTtsProviderId).path,
       validation.coerced,
     );
     saveRawConfig(raw);
@@ -274,9 +301,10 @@ export async function run(
     invalidateConfigCache();
   }
 
-  const broadcastNote = meta.userDefaultsKey
-    ? " The change has been broadcast to the desktop client."
-    : "";
+  const broadcastNote =
+    meta.userDefaultsKey && !skipClientBroadcast
+      ? " The change has been broadcast to the desktop client."
+      : "";
   return {
     content: `${friendlyName} updated to ${JSON.stringify(
       validation.coerced,

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -11,6 +11,7 @@ import { isAbsolute, resolve, sep } from "node:path";
 
 import { addAppConversationId, getApp } from "../apps/app-store.js";
 import { findActiveSession } from "../channels/gateway-verification-sessions.js";
+import { getConfig } from "../config/loader.js";
 import { generateAppIcon } from "../media/app-icon-generator.js";
 import { invalidateEdgeIndex } from "../plugins/defaults/memory/v2/edge-index.js";
 import { invalidatePageIndex } from "../plugins/defaults/memory/v2/page-index.js";
@@ -191,6 +192,18 @@ registerHook("voice_config_update", (_name, input) => {
   };
   const key = SETTING_TO_KEY[setting];
   if (!key) return;
+
+  // `ttsVoiceId` is an ElevenLabs concept on the desktop client. When the
+  // active provider is managed (vellum) or anything else, the voice lives only
+  // in daemon config and hot-applies per turn — the tool skips the client
+  // broadcast in that case, so this hook must too, else it would pollute the
+  // client's ElevenLabs voice with, e.g., a Deepgram Aura model id.
+  if (
+    setting === "tts_voice_id" &&
+    getConfig().services.tts.provider !== "elevenlabs"
+  ) {
+    return;
+  }
 
   // Coerce the value to the correct type before broadcasting, matching
   // the validation logic in the tool's execute method.

--- a/assistant/src/tts/__tests__/tts-voice-field.test.ts
+++ b/assistant/src/tts/__tests__/tts-voice-field.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  TTS_VOICE_FIELD_BY_PROVIDER,
+  ttsVoiceFieldFor,
+} from "../tts-voice-field.js";
+import { TTS_PROVIDER_IDS } from "../types.js";
+
+describe("ttsVoiceFieldFor", () => {
+  test("maps each provider to its own voice field under services.tts.providers.<id>", () => {
+    expect(ttsVoiceFieldFor("elevenlabs").path).toBe(
+      "services.tts.providers.elevenlabs.voiceId",
+    );
+    expect(ttsVoiceFieldFor("vellum").path).toBe(
+      "services.tts.providers.vellum.model",
+    );
+    expect(ttsVoiceFieldFor("deepgram").path).toBe(
+      "services.tts.providers.deepgram.model",
+    );
+  });
+
+  test("only ElevenLabs enforces the alphanumeric id format", () => {
+    expect(ttsVoiceFieldFor("elevenlabs").alphanumericOnly).toBe(true);
+    expect(ttsVoiceFieldFor("vellum").alphanumericOnly).toBe(false);
+    expect(ttsVoiceFieldFor("deepgram").alphanumericOnly).toBe(false);
+  });
+
+  test("defaults to ElevenLabs for undefined or unknown providers", () => {
+    expect(ttsVoiceFieldFor(undefined).path).toBe(
+      "services.tts.providers.elevenlabs.voiceId",
+    );
+    expect(ttsVoiceFieldFor("nonexistent").path).toBe(
+      "services.tts.providers.elevenlabs.voiceId",
+    );
+  });
+
+  test("every catalog provider has a voice-field mapping", () => {
+    for (const id of TTS_PROVIDER_IDS) {
+      expect(TTS_VOICE_FIELD_BY_PROVIDER[id]).toBeDefined();
+      expect(TTS_VOICE_FIELD_BY_PROVIDER[id].path).toContain(
+        `services.tts.providers.${id}.`,
+      );
+    }
+  });
+});

--- a/assistant/src/tts/tts-voice-field.ts
+++ b/assistant/src/tts/tts-voice-field.ts
@@ -1,0 +1,67 @@
+/**
+ * Where each TTS provider stores its "voice" selection under
+ * `services.tts.providers.<id>`.
+ *
+ * A voice change (the `voice_config_update` tool's `tts_voice_id` setting and
+ * the `assistant tts voice` CLI command) must write to the entry for the
+ * *active* provider — a managed (vellum) assistant's voice is a Deepgram Aura
+ * model id (or an ElevenLabs voice id, since managed speech serves both) at
+ * `.vellum.model`, not an ElevenLabs voice id at `.elevenlabs.voiceId`.
+ * Writing the wrong field is a silent no-op: the write "succeeds" but the
+ * active provider keeps its old voice.
+ *
+ * Only ElevenLabs voice ids are alphanumeric; Aura model ids (and the other
+ * providers' voice references) are hyphenated, so the alphanumeric validation
+ * rule is ElevenLabs-only.
+ */
+
+export interface TtsVoiceField {
+  /** Canonical config path the voice id/model is written to. */
+  path: string;
+  /** Human-facing label for tool/CLI success messages. */
+  label: string;
+  /** Whether the id must be alphanumeric (ElevenLabs voice-id format). */
+  alphanumericOnly: boolean;
+}
+
+export const TTS_VOICE_FIELD_BY_PROVIDER: Record<string, TtsVoiceField> = {
+  elevenlabs: {
+    path: "services.tts.providers.elevenlabs.voiceId",
+    label: "ElevenLabs voice",
+    alphanumericOnly: true,
+  },
+  vellum: {
+    path: "services.tts.providers.vellum.model",
+    label: "Vellum managed voice",
+    alphanumericOnly: false,
+  },
+  deepgram: {
+    path: "services.tts.providers.deepgram.model",
+    label: "Deepgram voice",
+    alphanumericOnly: false,
+  },
+  xai: {
+    path: "services.tts.providers.xai.voiceId",
+    label: "xAI voice",
+    alphanumericOnly: false,
+  },
+  "fish-audio": {
+    path: "services.tts.providers.fish-audio.referenceId",
+    label: "Fish Audio voice",
+    alphanumericOnly: false,
+  },
+};
+
+/**
+ * The voice field for a provider, defaulting to ElevenLabs for any provider
+ * without a dedicated voice field (its adapter validates required fields
+ * itself).
+ */
+export function ttsVoiceFieldFor(
+  providerId: string | undefined,
+): TtsVoiceField {
+  return (
+    TTS_VOICE_FIELD_BY_PROVIDER[providerId ?? "elevenlabs"] ??
+    TTS_VOICE_FIELD_BY_PROVIDER.elevenlabs
+  );
+}

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -283,6 +283,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "trust list",
   "tts",
   "tts synthesize",
+  "tts voice",
   "ui",
   "ui request",
   "ui confirm",
@@ -827,6 +828,9 @@ const riskOverrides: AssistantRiskOverride[] = [
   { path: "skills add", risk: "high" },
   { path: "stt transcribe", risk: "medium" },
   { path: "tts synthesize", risk: "medium" },
+  // Mutates the active provider's voice config (via config_set) — same
+  // low-risk class as `config set`.
+  { path: "tts voice", risk: "low" },
   { path: "watchers create", risk: "medium" },
   { path: "watchers update", risk: "medium" },
   { path: "watchers delete", risk: "medium" },

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -199,7 +199,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-21T14:02:30.000Z"
+      "updatedAt": "2026-07-21T14:41:00.000Z"
     },
     {
       "id": "email-setup",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -199,7 +199,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-02T21:39:37.000Z"
+      "updatedAt": "2026-07-21T14:02:30.000Z"
     },
     {
       "id": "email-setup",
@@ -716,7 +716,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-16T14:06:51.000Z"
+      "updatedAt": "2026-07-16T14:25:01.000Z"
     },
     {
       "id": "public-ingress",

--- a/skills/elevenlabs-voice/SKILL.md
+++ b/skills/elevenlabs-voice/SKILL.md
@@ -12,11 +12,28 @@ metadata:
 
 ## Overview
 
-ElevenLabs provides text-to-speech voices for both **in-app TTS** and **phone calls**. The config key `services.tts.providers.elevenlabs.voiceId` controls the voice across all channels. Use the `voice_config_update` tool to change the voice - it writes to the config file and pushes to the macOS app via SSE in one call.
+ElevenLabs provides text-to-speech voices for both **in-app TTS** and **phone calls**. Change the voice with the **`voice_config_update`** tool — it writes the voice to **whichever TTS provider is currently active** and pushes to the macOS app via SSE in one call:
+
+```
+voice_config_update setting="tts_voice_id" value="<voice-id>"
+```
+
+> **The voice lives under the _active_ provider, not always ElevenLabs.** The config key depends on `services.tts.provider`: `elevenlabs` → `services.tts.providers.elevenlabs.voiceId`, `vellum` (managed) → `services.tts.providers.vellum.model`, `deepgram` → `services.tts.providers.deepgram.model`. The `voice_config_update` tool (and the `assistant tts voice <id>` CLI command) handle this routing for you. **Do NOT `assistant config set services.tts.providers.elevenlabs.voiceId ...` blindly** — on a managed (`vellum`) assistant that field is ignored, so the write "succeeds" but the voice never changes. See [Setting the voice](#setting-the-voice) for the CLI fallback.
+>
+> **Managed (`vellum`) assistants can only use a curated subset of voices** — the platform bills per rate-carded model, and voices outside that list are rejected at synthesis (so the write succeeds but the voice fails on the next turn). That subset is a handful of ElevenLabs voices **plus** Deepgram Aura voices, all set through `vellum.model`. **If the active provider is `vellum`, pick from [Managed (Vellum) voices](#managed-vellum-voices), NOT the full ElevenLabs tables below** — most voices below (Bill, George, Amelia, …) are not offered on managed and will fail.
 
 ## Choose a Voice
 
-Pick a voice that matches the your identity and the user's preferences. Offer to show the full list if they want to choose themselves.
+**First, check the active provider** — it decides which list to pick from:
+
+```bash
+assistant config get services.tts.provider
+```
+
+- `vellum` (managed) → choose from [Managed (Vellum) voices](#managed-vellum-voices). The ElevenLabs tables below do **not** all work on managed.
+- `elevenlabs` (BYO key) → choose from the tables below.
+
+Pick a voice that matches your identity and the user's preferences. Offer to show the full list if they want to choose themselves.
 
 ### Female voices
 
@@ -45,19 +62,67 @@ Pick a voice that matches the your identity and the user's preferences. Offer to
 
 ### Setting the voice
 
-To set the chosen voice, use `voice_config_update`. This writes to the config file (`services.tts.providers.elevenlabs.voiceId`) for phone calls **and** pushes to the macOS app via SSE (`ttsVoiceId`) for in-app TTS in one call:
+**Preferred — the tool.** It writes to the active provider's voice field **and** pushes to the macOS app via SSE (`ttsVoiceId`) in one call:
 
 ```
 voice_config_update setting="tts_voice_id" value="<selected-voice-id>"
 ```
 
-Verify it worked:
+**CLI fallback (only if the `voice_config_update` tool is unavailable).** Use `assistant tts voice`, which routes to the active provider's config key for you — do **not** hand-write `assistant config set services.tts.providers.elevenlabs.voiceId ...`:
 
 ```bash
-assistant config get services.tts.providers.elevenlabs.voiceId
+assistant tts voice "<selected-voice-id>"
+```
+
+Setting `services.tts.providers.elevenlabs.voiceId` directly while the active provider is `vellum` (or any non-elevenlabs provider) is the #1 cause of "I changed the voice but it didn't change" — that field is ignored by the active provider, so the write reports success but nothing changes. If you must use `config set`, first check `assistant config get services.tts.provider` and write the matching key (`vellum` → `services.tts.providers.vellum.model`, `deepgram` → `services.tts.providers.deepgram.model`).
+
+Verify it worked by reading back the key for the **active** provider, e.g. for a managed assistant:
+
+```bash
+assistant config get services.tts.providers.vellum.model
 ```
 
 Tell the user what voice you chose and why, but also offer to show all available voices so they can choose for themselves.
+
+## Managed (Vellum) voices
+
+When the active provider is **vellum** (managed speech, common for voice-mode assistants), pick a voice from the two tables below **and only these** — they are the rate-carded models the platform actually offers. Set the chosen `Model` id exactly as you would an ElevenLabs voice (the tool routes it to `vellum.model`):
+
+```
+voice_config_update setting="tts_voice_id" value="aura-2-zeus-en"
+```
+
+The change hot-applies to the next voice turn (live voice and phone read the config fresh each turn). This list mirrors the daemon `GET /v1/tts/managed-voices` route (which the web voice picker uses); if a requested voice isn't here, don't guess an id — offer the closest one below.
+
+### Managed ElevenLabs voices
+
+| Voice | Style                                    | Model                  |
+| ----- | ---------------------------------------- | ---------------------- |
+| Sarah | American · professional, reassuring      | `EXAVITQu4vr4xnSDxMaL` |
+| Roger | American · laid-back, casual, resonant   | `CwhRBWXzGAHq8TQ4Fs17` |
+| Alice | British · clear, engaging, professional  | `Xb7hH8MSUJpSbSDYk0k2` |
+| River | American · relaxed, neutral, informative | `SAz9YHcvj6GT2YYXdXww` |
+| Eric  | American · smooth, trustworthy, classy   | `cjVigY5qzO86Huf0OWal` |
+| Adam  | American · deep, dominant, firm          | `pNInz6obpgDQGcFmaJgB` |
+
+### Deepgram Aura voices
+
+| Voice    | Style                                  | Model                |
+| -------- | -------------------------------------- | -------------------- |
+| Thalia   | American · clear, confident, energetic | `aura-2-thalia-en`   |
+| Andromeda| American · casual, expressive          | `aura-2-andromeda-en`|
+| Helena   | American · caring, natural, friendly   | `aura-2-helena-en`   |
+| Athena   | American · calm, smooth, professional  | `aura-2-athena-en`   |
+| Luna     | American · friendly, natural, engaging | `aura-2-luna-en`     |
+| Pandora  | British · smooth, calm, melodic        | `aura-2-pandora-en`  |
+| Theia    | Australian · expressive, polite        | `aura-2-theia-en`    |
+| Apollo   | American · confident, casual           | `aura-2-apollo-en`   |
+| Arcas    | American · natural, smooth, clear      | `aura-2-arcas-en`    |
+| Zeus     | American · deep, trustworthy, smooth   | `aura-2-zeus-en`     |
+| Draco    | British · warm, approachable, baritone | `aura-2-draco-en`    |
+| Hyperion | Australian · caring, warm, empathetic  | `aura-2-hyperion-en` |
+
+**"American male" on managed** → Eric, Adam, Roger (ElevenLabs) or Apollo, Arcas, Zeus (Aura). (Bill/George from the ElevenLabs tables above are **not** offered on managed.)
 
 ## ElevenLabs API Key Setup
 

--- a/skills/elevenlabs-voice/SKILL.md
+++ b/skills/elevenlabs-voice/SKILL.md
@@ -107,20 +107,20 @@ The change hot-applies to the next voice turn (live voice and phone read the con
 
 ### Deepgram Aura voices
 
-| Voice    | Style                                  | Model                |
-| -------- | -------------------------------------- | -------------------- |
-| Thalia   | American · clear, confident, energetic | `aura-2-thalia-en`   |
-| Andromeda| American · casual, expressive          | `aura-2-andromeda-en`|
-| Helena   | American · caring, natural, friendly   | `aura-2-helena-en`   |
-| Athena   | American · calm, smooth, professional  | `aura-2-athena-en`   |
-| Luna     | American · friendly, natural, engaging | `aura-2-luna-en`     |
-| Pandora  | British · smooth, calm, melodic        | `aura-2-pandora-en`  |
-| Theia    | Australian · expressive, polite        | `aura-2-theia-en`    |
-| Apollo   | American · confident, casual           | `aura-2-apollo-en`   |
-| Arcas    | American · natural, smooth, clear      | `aura-2-arcas-en`    |
-| Zeus     | American · deep, trustworthy, smooth   | `aura-2-zeus-en`     |
-| Draco    | British · warm, approachable, baritone | `aura-2-draco-en`    |
-| Hyperion | Australian · caring, warm, empathetic  | `aura-2-hyperion-en` |
+| Voice     | Style                                  | Model                 |
+| --------- | -------------------------------------- | --------------------- |
+| Thalia    | American · clear, confident, energetic | `aura-2-thalia-en`    |
+| Andromeda | American · casual, expressive          | `aura-2-andromeda-en` |
+| Helena    | American · caring, natural, friendly   | `aura-2-helena-en`    |
+| Athena    | American · calm, smooth, professional  | `aura-2-athena-en`    |
+| Luna      | American · friendly, natural, engaging | `aura-2-luna-en`      |
+| Pandora   | British · smooth, calm, melodic        | `aura-2-pandora-en`   |
+| Theia     | Australian · expressive, polite        | `aura-2-theia-en`     |
+| Apollo    | American · confident, casual           | `aura-2-apollo-en`    |
+| Arcas     | American · natural, smooth, clear      | `aura-2-arcas-en`     |
+| Zeus      | American · deep, trustworthy, smooth   | `aura-2-zeus-en`      |
+| Draco     | British · warm, approachable, baritone | `aura-2-draco-en`     |
+| Hyperion  | Australian · caring, warm, empathetic  | `aura-2-hyperion-en`  |
 
 **"American male" on managed** → Eric, Adam, Roger (ElevenLabs) or Apollo, Arcas, Zeus (Aura). (Bill/George from the ElevenLabs tables above are **not** offered on managed.)
 


### PR DESCRIPTION
## Problem

When a user asks the assistant to change its own voice, it reports success but nothing changes on **managed (Vellum) assistants**. The `voice_config_update` tool, the `elevenlabs-voice` skill, and the raw CLI fallback all wrote `services.tts.providers.elevenlabs.voiceId`, but a `vellum` assistant reads its voice from `services.tts.providers.vellum.model`. The write lands on an ignored field → old voice retained, false success. The manual web voice picker (JARVIS-1303) already worked; this was the tool/CLI path only.

Two entry points hit the same root: (1) the `voice_config_update` tool, and (2) the raw CLI `assistant config set …elevenlabs.voiceId` the model falls back to when the tool isn't loaded.

## Fix

- **Shared source of truth** — `assistant/src/tts/tts-voice-field.ts` maps each active provider to its voice config key + validation shape (`elevenlabs`→`.elevenlabs.voiceId`, `vellum`→`.vellum.model`, `deepgram`→`.deepgram.model`, etc.).
- **`voice_config_update` `tts_voice_id`** now writes the **active** provider's field (from `getConfig().services.tts.provider`). Validation stays alphanumeric-only for `elevenlabs` and relaxes to `[A-Za-z0-9._-]` for others (hyphenated Aura ids; ElevenLabs ids still pass). The ElevenLabs-specific `ttsVoiceId` client broadcast is skipped for non-elevenlabs providers — in both the tool and the `tool-side-effects.ts` post-hook.
- **New `assistant tts voice <id>` CLI command** reads the active provider and writes the matching key (reuses `config_get`/`config_set`), so the skill's CLI fallback can't land on the wrong field. Lazy-imports the shared helper per `cli/no-daemon-internals`.
- **Docs** — `TOOLS.json` + `elevenlabs-voice/SKILL.md`: voice key is per-active-provider; managed serves ElevenLabs + Deepgram Aura voices; explicit warning against `config set …elevenlabs.voiceId` on a managed assistant.

## Safety / scope

- **ElevenLabs BYOK is unchanged** — same field written, same alphanumeric validation, same `ttsVoiceId` broadcast. The new routing only diverges when the active provider isn't `elevenlabs`.
- `resolveManagedVoice` already reads `vellum.model` fresh per turn, so the corrected write hot-applies on the next spoken turn.

## Not in scope

ElevenLabs-sourced managed voices still fail in **live-voice streaming** (Deepgram-only relay) — tracked separately in **JARVIS-1310**. This PR only fixes *which config field the voice is written to*.

## Tests

`tsc` clean; new/updated tests pass: `voice-config-update.test.ts` (managed routing, ElevenLabs id → `vellum.model`, broadcast gating), `tts.test.ts` (CLI active-provider routing), `tts-voice-field.test.ts` (shared map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)