### PR TITLE
fix(plugins): scope default disabled sentinel; generate OpenAPI from the ROUTES barrel

### DIFF
--- a/assistant/scripts/generate-openapi.ts
+++ b/assistant/scripts/generate-openapi.ts
@@ -4,8 +4,8 @@
  * HTTP route definitions.
  *
  * Pipeline:
- *   1. Programmatically import every route module under src/runtime/routes/
- *      and collect all exported ROUTES arrays — no regex, no source-text parsing.
+ *   1. Import the assembled `ROUTES` table from src/runtime/routes/index.ts —
+ *      the same single source of truth the HTTP and IPC servers serve.
  *   2. Combine with pre-auth / non-v1 routes.
  *   3. Convert to OpenAPI path items.
  *   4. Write to openapi.yaml.
@@ -16,8 +16,8 @@
  *   cd assistant && bun run generate:openapi -- --check  # CI: fail if stale
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { readdir, readFile, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 import { stringify } from "yaml";
@@ -30,6 +30,7 @@ import type {
 } from "zod-openapi";
 import { createDocument } from "zod-openapi";
 
+import { ROUTES } from "../src/runtime/routes/index.js";
 import { jsonValueSchema } from "../src/telemetry/telemetry-wire.generated.js";
 
 // The recursive wire JSON-value schema (`claims`/`suggestions` item type) must
@@ -39,8 +40,6 @@ import { jsonValueSchema } from "../src/telemetry/telemetry-wire.generated.js";
 z.globalRegistry.add(jsonValueSchema, { id: "TelemetryJsonValue" });
 
 const ROOT = resolve(import.meta.dir, "..");
-const ROUTES_DIR = join(ROOT, "src/runtime/routes");
-const PLUGIN_DEFAULTS_DIR = join(ROOT, "src/plugins/defaults");
 const OUTPUT_PATH = join(ROOT, "openapi.yaml");
 const PKG_PATH = join(ROOT, "package.json");
 
@@ -120,8 +119,6 @@ const RouteEntrySchema = z.object({
   additionalResponses: z
     .record(z.string(), RouteAdditionalResponseSchema)
     .optional(),
-  /** Source module filename, used for auto-deriving tags. */
-  sourceModule: z.string().optional(),
 });
 
 type RouteEntry = z.infer<typeof RouteEntrySchema>;
@@ -156,104 +153,23 @@ function resolveSchemaForDocument(schemaSource: unknown): ContentSchema {
 // ---------------------------------------------------------------------------
 
 /**
- * Directories holding `RouteDefinition` modules: the host `runtime/routes`
- * tree plus each default plugin's `src/` directory (where a plugin keeps the
- * shared-table `RouteDefinition` modules it registers into the runtime route
- * table — a plugin's `routes/` directory is reserved for userland-format
- * `export const GET`/`POST` handlers served by the `/x/plugins/<name>/`
- * dispatcher, which the OpenAPI spec does not cover). Non-`ROUTES` modules
- * under a scanned dir are simply ignored.
- *
- * The generator walks these source files rather than importing the assembled
- * `runtime/routes/index.ts` barrel because it derives each operation's OpenAPI
- * tag from the *source filename* (see `deriveTagFromModule`) for the routes
- * that don't set `tags` explicitly — information the barrel's flat, already-
- * merged `RouteDefinition[]` no longer carries. Sorted for reproducible output
- * (see {@link collectRoutesFromModules}).
+ * Collect the OpenAPI-relevant fields of every route from the assembled
+ * `runtime/routes/index.ts` `ROUTES` table — the same single source of truth
+ * the HTTP and IPC servers serve. Each `RouteDefinition` is parsed through
+ * {@link RouteEntrySchema}, which keeps only the documentable fields (method,
+ * endpoint, summary, tags, request/response bodies, …) and drops the runtime
+ * ones (handler, policy). Routes that omit `tags` are surfaced without a tag —
+ * a lint-style guard test asserts every route sets one, so the spec never
+ * loses grouping.
  */
-async function routeModuleDirs(): Promise<string[]> {
-  const dirs = [ROUTES_DIR];
-  for (const entry of await readdir(PLUGIN_DEFAULTS_DIR, {
-    withFileTypes: true,
-  })) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
-    const srcDir = join(PLUGIN_DEFAULTS_DIR, entry.name, "src");
-    if (existsSync(srcDir)) {
-      dirs.push(srcDir);
-    }
-  }
-  return dirs.sort();
-}
-
-/**
- * Dynamically import every route module under each {@link routeModuleDirs}
- * entry and collect all exported `ROUTES` / `*_ROUTES` arrays. Each route
- * module exports a `RouteDefinition[]`; new modules are picked up without
- * manual updates.
- */
-async function collectRoutesFromModules(): Promise<RouteEntry[]> {
+function collectRoutes(): RouteEntry[] {
   const routes: RouteEntry[] = [];
-
-  for (const dir of await routeModuleDirs()) {
-    // Skip the `index.ts` barrel: it re-exports every other route module's
-    // ROUTES into a single combined array, so importing it would double-count
-    // every entry. The duplicate `method:endpoint` keys are deduped later by
-    // first-seen, but the surviving entry's `sourceModule` (used to derive
-    // OpenAPI `tags`) depends on `readdir` order — which is filesystem
-    // dependent and diverges between local sandbox and the CI runner, making
-    // the generator non-reproducible. Sort the file list as well so directory
-    // entry order can never affect the output.
-    const files = (await readdir(dir, { recursive: true }))
-      .filter(
-        (f) =>
-          typeof f === "string" &&
-          f.endsWith(".ts") &&
-          !f.endsWith(".test.ts") &&
-          !f.endsWith(".benchmark.test.ts") &&
-          !f.includes("node_modules") &&
-          f !== "index.ts" &&
-          !f.endsWith("/index.ts"),
-      )
-      .sort();
-
-    for (const file of files) {
-      const filePath = join(dir, file);
-      let mod: Record<string, unknown>;
-      try {
-        mod = (await import(filePath)) as Record<string, unknown>;
-      } catch (err) {
-        console.warn(
-          `Warning: could not import ${file}: ${err instanceof Error ? err.message : err}`,
-        );
-        continue;
-      }
-
-      // Collect every export whose name is `ROUTES` or ends in `_ROUTES`.
-      // A handful of route files (e.g. `channel-route-definitions.ts`,
-      // `contact-prompt-routes.ts`) export under domain-prefixed names like
-      // `CHANNEL_ROUTES` and `CONTACT_PROMPT_ROUTES` rather than the
-      // canonical `ROUTES`. Without this fan-out the only way those routes
-      // reached the spec was via the `index.ts` barrel — which is excluded
-      // above for reproducibility.
-      const exportNames = Object.keys(mod)
-        .filter((k) => k === "ROUTES" || k.endsWith("_ROUTES"))
-        .sort();
-      for (const name of exportNames) {
-        const arr = mod[name];
-        if (!Array.isArray(arr)) continue;
-        for (const raw of arr) {
-          const result = RouteEntrySchema.safeParse({
-            ...(typeof raw === "object" && raw !== null ? raw : {}),
-            sourceModule: file,
-          });
-          if (result.success) routes.push(result.data);
-        }
-      }
+  for (const raw of ROUTES) {
+    const result = RouteEntrySchema.safeParse(raw);
+    if (result.success) {
+      routes.push(result.data);
     }
   }
-
   return routes;
 }
 
@@ -399,14 +315,6 @@ function resolveBodyContent(body: unknown): {
   return { contentType: "application/json", schemaSource: body };
 }
 
-/** Derive a tag name from a route module filename (e.g. "secret-routes.ts" → "secrets"). */
-function deriveTagFromModule(filename: string): string {
-  // Strip directory prefix and extension
-  const base = filename.replace(/^.*[\/]/, "").replace(/\.ts$/, "");
-  // Remove trailing "-routes" suffix
-  return base.replace(/-routes$/, "");
-}
-
 function buildSpec(
   routes: RouteEntry[],
   version: string,
@@ -509,13 +417,8 @@ function buildSpec(
       }
     }
 
-    // Determine tags: explicit tags > auto-derived from source module
     const tags: string[] | undefined =
-      entry.tags && entry.tags.length > 0
-        ? entry.tags
-        : entry.sourceModule
-          ? [deriveTagFromModule(entry.sourceModule)]
-          : undefined;
+      entry.tags && entry.tags.length > 0 ? entry.tags : undefined;
 
     // Build the operation. Default success status is 200; async endpoints
     // that enqueue a job and return immediately set responseStatus: "202"
@@ -617,11 +520,8 @@ async function main() {
   };
   const version = pkg.version;
 
-  // Collect routes programmatically from route modules
-  const moduleRoutes = await collectRoutesFromModules();
-
-  // Combine all route sources
-  const allRoutes: RouteEntry[] = moduleRoutes;
+  // Collect routes from the assembled shared route table
+  const allRoutes: RouteEntry[] = collectRoutes();
 
   // Build the spec
   const spec = buildSpec(allRoutes, version);

--- a/assistant/scripts/generate-openapi.ts
+++ b/assistant/scripts/generate-openapi.ts
@@ -157,27 +157,31 @@ function resolveSchemaForDocument(schemaSource: unknown): ContentSchema {
 
 /**
  * Directories holding `RouteDefinition` modules: the host `runtime/routes`
- * tree plus each default plugin's internal module directories. A default plugin
- * that owns model-facing HTTP/IPC routes (registered into the shared route
- * table at runtime) keeps those `RouteDefinition` modules in its `src/`
- * directory — its `routes/` directory is reserved for userland-format
- * (`export const GET`/`POST`) handlers served by the `/x/plugins/<name>/`
- * dispatcher, which the OpenAPI spec does not cover. Scanning both keeps the
- * spec complete no matter which package a shared-table route lives in
- * (non-`ROUTES` modules under either dir are simply ignored). Sorted for
- * reproducible output (see {@link collectRoutesFromModules}).
+ * tree plus each default plugin's `src/` directory (where a plugin keeps the
+ * shared-table `RouteDefinition` modules it registers into the runtime route
+ * table — a plugin's `routes/` directory is reserved for userland-format
+ * `export const GET`/`POST` handlers served by the `/x/plugins/<name>/`
+ * dispatcher, which the OpenAPI spec does not cover). Non-`ROUTES` modules
+ * under a scanned dir are simply ignored.
+ *
+ * The generator walks these source files rather than importing the assembled
+ * `runtime/routes/index.ts` barrel because it derives each operation's OpenAPI
+ * tag from the *source filename* (see `deriveTagFromModule`) for the routes
+ * that don't set `tags` explicitly — information the barrel's flat, already-
+ * merged `RouteDefinition[]` no longer carries. Sorted for reproducible output
+ * (see {@link collectRoutesFromModules}).
  */
 async function routeModuleDirs(): Promise<string[]> {
   const dirs = [ROUTES_DIR];
   for (const entry of await readdir(PLUGIN_DEFAULTS_DIR, {
     withFileTypes: true,
   })) {
-    if (!entry.isDirectory()) continue;
-    for (const sub of ["src", "routes"]) {
-      const dir = join(PLUGIN_DEFAULTS_DIR, entry.name, sub);
-      if (existsSync(dir)) {
-        dirs.push(dir);
-      }
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const srcDir = join(PLUGIN_DEFAULTS_DIR, entry.name, "src");
+    if (existsSync(srcDir)) {
+      dirs.push(srcDir);
     }
   }
   return dirs.sort();

--- a/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
@@ -191,4 +191,37 @@ describe("default plugin route dispatch", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ source: "workspace" });
   });
+
+  test("disabling the default does not disable an installed override of the same namespace", async () => {
+    // Installed workspace plugin shadows the namespace...
+    writeWorkspacePluginHandler(
+      DEFAULT_PLUGIN,
+      "reengage.ts",
+      `export const GET = () => Response.json({ source: "workspace" });`,
+    );
+    // ...and the bundled default is separately disabled by its manifest name.
+    const disabledDir = join(getWorkspacePluginsDir(), DEFAULT_PLUGIN_MANIFEST);
+    mkdirSync(disabledDir, { recursive: true });
+    writeFileSync(join(disabledDir, ".disabled"), "");
+
+    // The manifest-name sentinel gates only the default fallback, so the
+    // installed override still resolves and serves.
+    const location = resolveRouteLocation(`plugins/${DEFAULT_PLUGIN}/reengage`);
+    expect(location!.routesDir).toBe(
+      join(getWorkspacePluginsDir(), DEFAULT_PLUGIN, "routes"),
+    );
+    expect(
+      listPluginRouteRoots().some((r) => r.pluginName === DEFAULT_PLUGIN),
+    ).toBe(true);
+
+    const dispatcher = makeDispatcher();
+    const response = await dispatcher.dispatch(
+      `plugins/${DEFAULT_PLUGIN}/reengage`,
+      new Request(`http://localhost/v1/x/plugins/${DEFAULT_PLUGIN}/reengage`, {
+        method: "GET",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ source: "workspace" });
+  });
 });

--- a/assistant/src/runtime/routes/__tests__/route-tags-guard.test.ts
+++ b/assistant/src/runtime/routes/__tests__/route-tags-guard.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Guard: every route in the shared `ROUTES` table declares an explicit
+ * `tags` array.
+ *
+ * The OpenAPI generator (`scripts/generate-openapi.ts`) builds the spec by
+ * importing this assembled table and reads each operation's tag straight from
+ * `RouteDefinition.tags` — it no longer derives a fallback tag from the source
+ * filename. A route that omits `tags` would therefore land in the spec (and the
+ * generated client SDK) untagged, silently losing its grouping. Requiring an
+ * explicit tag keeps that contract enforced at the source rather than in the
+ * generator.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { ROUTES } from "../index.js";
+
+describe("shared route table tags", () => {
+  test("every route declares a non-empty tags array", () => {
+    const untagged = ROUTES.filter(
+      (r) => !Array.isArray(r.tags) || r.tags.length === 0,
+    ).map((r) => `${r.method} ${r.endpoint} (${r.operationId})`);
+
+    expect(untagged).toEqual([]);
+  });
+});

--- a/assistant/src/runtime/routes/content-source-routes.ts
+++ b/assistant/src/runtime/routes/content-source-routes.ts
@@ -76,6 +76,7 @@ export const ROUTES: RouteDefinition[] = [
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
     summary: "Validate and persist a content source URL",
+    tags: ["content-source"],
     requestBody: z.object({ url: z.string() }),
     handler: handleContentSource,
   },

--- a/assistant/src/runtime/routes/sanity-routes.ts
+++ b/assistant/src/runtime/routes/sanity-routes.ts
@@ -145,6 +145,7 @@ export const ROUTES: RouteDefinition[] = [
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
     summary: "Discover Sanity projects and datasets using the stored API token",
+    tags: ["sanity"],
     requestBody: z.object({ projectId: z.string().optional() }).optional(),
     handler: handleDiscover,
   },
@@ -157,6 +158,7 @@ export const ROUTES: RouteDefinition[] = [
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
     summary: "Finalise Sanity connection and write sidecar file",
+    tags: ["sanity"],
     requestBody: z.object({
       projectId: z.string(),
       dataset: z.string(),

--- a/assistant/src/runtime/routes/user-route-resolution.ts
+++ b/assistant/src/runtime/routes/user-route-resolution.ts
@@ -68,11 +68,15 @@ export function resolveRouteLocation(routePath: string): RouteLocation | null {
   const segments = routePath.split("/");
   if (segments[0] === PLUGIN_ROUTE_SEGMENT) {
     const pluginName = segments[1];
-    if (!pluginName || isPluginNamespaceDisabled(pluginName)) {
+    if (!pluginName) {
+      return null;
+    }
+    const { routesDir, isDefault } = resolvePluginRoutesDir(pluginName);
+    if (isPluginRouteDirDisabled(pluginName, isDefault)) {
       return null;
     }
     return {
-      routesDir: resolvePluginRoutesDir(pluginName),
+      routesDir,
       subPath: segments.slice(2).join("/"),
     };
   }
@@ -80,17 +84,24 @@ export function resolveRouteLocation(routePath: string): RouteLocation | null {
 }
 
 /**
- * Whether a plugin route namespace is disabled by a `.disabled` sentinel.
+ * Whether the `.disabled` sentinel disables the resolved route directory.
  *
- * The sentinel is keyed by directory name for installed plugins but by the
- * `default-…` manifest name for default plugins (the CLI/bootstrap write it as
- * `<workspace>/plugins/<manifest-name>/.disabled`). A route namespace is the
- * plugin's *directory* name, so a default plugin is checked under both its
- * namespace and its manifest name; installed plugins only match the first.
+ * The sentinel is keyed by the plugin's directory name for installed plugins
+ * but by the `default-…` manifest name for default plugins (the CLI/bootstrap
+ * write it as `<workspace>/plugins/<manifest-name>/.disabled`). The manifest
+ * check therefore applies *only* when the resolved directory is a default
+ * plugin's source routes — so disabling a bundled default never takes down an
+ * installed workspace plugin that shadows the same namespace, and vice versa.
  */
-function isPluginNamespaceDisabled(pluginName: string): boolean {
+function isPluginRouteDirDisabled(
+  pluginName: string,
+  isDefault: boolean,
+): boolean {
   if (isPluginDisabled(pluginName)) {
     return true;
+  }
+  if (!isDefault) {
+    return false;
   }
   const manifestName = getDefaultPluginManifestName(pluginName);
   return manifestName !== null && isPluginDisabled(manifestName);
@@ -98,26 +109,30 @@ function isPluginNamespaceDisabled(pluginName: string): boolean {
 
 /**
  * Resolve the `routes/` directory that backs a plugin's `/x/plugins/<name>/`
- * namespace. An installed plugin that ships a `routes/` directory takes
- * precedence (so it can override a same-named default); otherwise a default
- * plugin's source `routes/` directory is used. Falls back to the (missing)
- * workspace path when the name matches neither, so {@link resolveHandlerFile}
- * reports a 404.
+ * namespace, and whether that directory is a first-party default's source
+ * tree. An installed plugin that ships a `routes/` directory takes precedence
+ * (so it can override a same-named default); otherwise a default plugin's
+ * source `routes/` directory is used. Falls back to the (missing) workspace
+ * path when the name matches neither, so {@link resolveHandlerFile} reports a
+ * 404.
  */
-function resolvePluginRoutesDir(pluginName: string): string {
+function resolvePluginRoutesDir(pluginName: string): {
+  routesDir: string;
+  isDefault: boolean;
+} {
   const workspaceRoutesDir = join(
     getWorkspacePluginsDir(),
     pluginName,
     "routes",
   );
   if (existsSync(workspaceRoutesDir)) {
-    return workspaceRoutesDir;
+    return { routesDir: workspaceRoutesDir, isDefault: false };
   }
   const defaultRoutesDir = getDefaultPluginRoutesDir(pluginName);
   if (defaultRoutesDir && existsSync(defaultRoutesDir)) {
-    return defaultRoutesDir;
+    return { routesDir: defaultRoutesDir, isDefault: true };
   }
-  return workspaceRoutesDir;
+  return { routesDir: workspaceRoutesDir, isDefault: false };
 }
 
 /**
@@ -185,7 +200,7 @@ export function listPluginRouteRoots(): {
   const byName = new Map<string, string>();
 
   for (const { pluginName, routesDir } of getDefaultPluginRouteRoots()) {
-    if (!isPluginNamespaceDisabled(pluginName)) {
+    if (!isPluginRouteDirDisabled(pluginName, true)) {
       byName.set(pluginName, routesDir);
     }
   }
@@ -193,7 +208,7 @@ export function listPluginRouteRoots(): {
   const pluginsDir = getWorkspacePluginsDir();
   if (existsSync(pluginsDir)) {
     for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
-      if (!entry.isDirectory() || isPluginNamespaceDisabled(entry.name)) {
+      if (!entry.isDirectory() || isPluginRouteDirDisabled(entry.name, false)) {
         continue;
       }
       const routesDir = join(pluginsDir, entry.name, "routes");


### PR DESCRIPTION
## Prompt / plan

Resolves the two review comments on #38609.

## 1. P2 (Codex) — a disabled default must not disable an installed override

The default-plugin `.disabled` gate ran **before** route resolution, so a manifest-name sentinel (`default-platform-hosted`) also disabled an *installed* workspace plugin shadowing the same namespace — its `/x/plugins/platform-hosted/*` routes 404'd even though only the bundled default was disabled.

Fix: resolve the route dir first, then gate. The **dir-name** sentinel always applies; the **manifest-name** sentinel applies only when the resolved dir is the default plugin's source tree — `isPluginRouteDirDisabled(pluginName, isDefault)`. `resolvePluginRoutesDir` now returns `{ routesDir, isDefault }`, applied consistently in `resolveRouteLocation` and `listPluginRouteRoots`.

## 2. dvargas — generate the spec from the barrel, drop `routeModuleDirs`

Rather than have the generator re-discover routes by walking directories, it now imports the assembled `runtime/routes/index.ts` `ROUTES` table directly — the same single source of truth the HTTP/IPC servers serve.

The scan existed only to derive a route's OpenAPI tag from its **source filename** when the route didn't set `tags`. It turned out only **3 routes** relied on that (`content-source` + the two `sanity` routes; my earlier "~38" was route *files* mentioning tags, not untagged routes). Those now set `tags` explicitly, so the generator reads tags straight off each `RouteDefinition`. Removed: `routeModuleDirs`, `collectRoutesFromModules`, `deriveTagFromModule`, the `sourceModule` field, and the fs-scanning imports.

New guard test `route-tags-guard.test.ts` asserts every route in `ROUTES` declares `tags`, keeping the "must have a tag" contract at the source instead of silently defaulting in the generator.

**`openapi.yaml` is unchanged** (493 paths / 561 operations), verified via `--check`.

## Test plan

- `route-tags-guard.test.ts` (new) — every shared-table route has explicit `tags`. Passes.
- `default-plugin-routes.test.ts` (11 tests) — includes the P2 regression: installed override + default disabled by manifest name → override still resolves, is listed, serves `200`.
- `generate:openapi --check`, `typecheck:fast`, eslint (0 errors), Prettier all clean.
- `user-route-dispatcher` / `user-routes-cli` suites pass.

## CLI verb checklist

- [ ] Does this route need an `assistant` CLI verb? **No** — a route-resolution fix plus an OpenAPI build change; no new operation.