### PR TITLE
fix(plugins): advance SHA-pinned direct installs by following the default branch

### DIFF
--- a/assistant/src/cli/lib/__tests__/upgrade-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/upgrade-plugin.test.ts
@@ -479,19 +479,54 @@ describe("upgradePlugin — direct GitHub-URL installs", () => {
     expect(result.toCommit).toBe(SHA_A);
   });
 
-  test("a SHA-pinned direct install is already up to date without any git", async () => {
-    // GIVEN a direct install pinned to an immutable full SHA
+  test("a SHA-pinned direct install follows the repo's default branch", async () => {
+    // GIVEN a direct install pinned to an immutable full SHA (SHA_A)
     installCopy(pluginsDir, "level-up", { commit: SHA_A, ref: SHA_A });
     const fetch = makeFetch({ manifest: undefined });
+    // AND the repo's default branch (HEAD) now points at SHA_B — a full SHA has
+    // no later revision of itself, so the upgrade follows the default branch
+    const calls: string[][] = [];
+    const runGit = directGitRunner({ HEAD: SHA_B }, SHA_B, { calls });
 
-    // WHEN the plugin is upgraded (git must never run — a SHA resolves to itself)
+    // WHEN the plugin is upgraded
     const result = await upgradePlugin(
       { name: "level-up" },
-      { fetch, runGit: unusedGitRunner, workspacePluginsDir: pluginsDir },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
     );
 
-    // THEN there is nothing to advance to
+    // THEN it advances to the default branch tip and records the move
+    expect(result.outcome).toBe("upgraded");
+    expect(result.fromCommit).toBe(SHA_A);
+    expect(result.toCommit).toBe(SHA_B);
+    expect(result.fileCount).toBeGreaterThan(0);
+    expect(sidecarCommit(pluginsDir, "level-up")).toBe(SHA_B);
+    // AND the recorded ref becomes HEAD, so later upgrades follow the branch
+    // through the ordinary path instead of freezing on a SHA again
+    const meta = JSON.parse(
+      readFileSync(join(pluginsDir, "level-up", "install-meta.json"), "utf-8"),
+    );
+    expect(meta.source.ref).toBe("HEAD");
+    // AND it resolved the default branch via ls-remote before cloning
+    expect(calls[0]?.[0]).toBe("ls-remote");
+    expect(calls[0]?.at(-1)).toBe("HEAD");
+  });
+
+  test("a SHA-pinned direct install is up to date when it sits at the default branch tip", async () => {
+    // GIVEN a direct install pinned to SHA_A that is still the default branch tip
+    installCopy(pluginsDir, "level-up", { commit: SHA_A, ref: SHA_A });
+    const fetch = makeFetch({ manifest: undefined });
+    // AND HEAD still resolves to SHA_A (resolved via ls-remote, no clone)
+    const runGit = directGitRunner({ HEAD: SHA_A }, SHA_A);
+
+    // WHEN the plugin is upgraded
+    const result = await upgradePlugin(
+      { name: "level-up" },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN there is nothing newer on the default branch, so it is a no-op
     expect(result.outcome).toBe("already-up-to-date");
+    expect(result.fileCount).toBeNull();
     expect(result.toCommit).toBe(SHA_A);
   });
 
@@ -787,7 +822,10 @@ describe("upgradePlugin --strategy", () => {
     // GIVEN an install whose only divergence from the pin auto-merges cleanly
     const cleanOurs: Tree = { "package.json": PKG, "common.txt": "A\nb\nc\n" };
     const cleanBase: Tree = { "package.json": PKG, "common.txt": "a\nb\nc\n" };
-    const cleanTheirs: Tree = { "package.json": PKG, "common.txt": "a\nb\nC\n" };
+    const cleanTheirs: Tree = {
+      "package.json": PKG,
+      "common.txt": "a\nb\nC\n",
+    };
     installMergeCopy("level-up", cleanOurs, SHA_A, cleanBase);
     const fetch = makeFetch({ manifest: manifestWith("level-up", SHA_B) });
     const runGit = treeGitRunner({ [SHA_A]: cleanBase, [SHA_B]: cleanTheirs });

--- a/assistant/src/cli/lib/upgrade-plugin.ts
+++ b/assistant/src/cli/lib/upgrade-plugin.ts
@@ -10,10 +10,12 @@
  * A plugin installed directly from a GitHub URL (untrusted, not in the
  * marketplace) is upgraded against its *recorded* source instead: its
  * `install-meta.json` names the owner/repo/path/ref it was cloned from, and the
- * upgrade target is whatever that ref resolves to now — a pinned SHA is
- * immutable (a no-op), a branch / tag / `HEAD` advances as upstream does. Such
- * an upgrade re-materializes verbatim, with no curated adapter overlay, exactly
- * as the original untrusted install was (see {@link directUpgrade}).
+ * upgrade target is whatever that ref resolves to now — a branch / tag / `HEAD`
+ * advances as upstream does, and an install pinned to an immutable full SHA
+ * follows the repo's default branch rather than freezing forever (a full SHA
+ * has no "later" revision of itself to move to). Such an upgrade re-materializes
+ * verbatim, with no curated adapter overlay, exactly as the original untrusted
+ * install was (see {@link directUpgrade}).
  *
  * This is deliberately a distinct operation from install: `install` is
  * first-time materialization (and errors on an existing install unless
@@ -54,6 +56,7 @@ import {
   finalizeStagedInstall,
   type GitRunner,
   installPlugin,
+  isFullCommitSha,
   materializePluginTree,
   type PluginFetchSource,
   PluginNotFoundError,
@@ -65,6 +68,7 @@ import {
 } from "./install-from-github.js";
 import type { DependencyInstaller } from "./install-plugin-dependencies.js";
 import { type ConflictLabels, mergePluginTree } from "./merge-plugin-tree.js";
+import { DEFAULT_DIRECT_REF } from "./parse-github-plugin-spec.js";
 /**
  * How local edits to an installed plugin are reconciled with the marketplace
  * pin during an upgrade.
@@ -396,16 +400,21 @@ export async function upgradePlugin(
  * A direct install (`plugins install <github-url>`) records the exact
  * owner/repo/path/ref it was cloned from in its `install-meta.json`. Its
  * "latest" is whatever that ref currently resolves to, so the upgrade target is
- * {@link resolveRefCommit} of the recorded ref — a pinned full SHA is immutable
- * (nothing to advance to), while a branch / tag / `HEAD` moves as upstream does.
- * The move is then materialized verbatim, with no curated adapter overlay,
- * exactly as the original untrusted install was.
+ * {@link resolveRefCommit} of the recorded ref — a branch / tag / `HEAD` moves
+ * as upstream does. An install pinned to an immutable full SHA has no later
+ * revision of that SHA to advance to, so rather than freezing forever it
+ * follows the repo's default branch ({@link DEFAULT_DIRECT_REF}); the first
+ * upgrade that advances re-records that tracking ref, so later upgrades follow
+ * the branch through the ordinary path with no SHA special-casing. The move is
+ * then materialized verbatim, with no curated adapter overlay, exactly as the
+ * original untrusted install was.
  *
  * Throws {@link PluginNotUpgradableError} when no resolvable GitHub source was
  * recorded (a manually-copied install), {@link PluginNotFoundError} when the
- * recorded ref has vanished from the remote, {@link PluginMergeBaselineError}
- * when a merge strategy's install-time baseline cannot be reconstructed, and
- * {@link PluginSourceUnavailableError} on a transient source outage.
+ * recorded ref (or the followed default branch) has vanished from the remote,
+ * {@link PluginMergeBaselineError} when a merge strategy's install-time baseline
+ * cannot be reconstructed, and {@link PluginSourceUnavailableError} on a
+ * transient source outage.
  */
 async function directUpgrade(
   ctx: {
@@ -427,11 +436,22 @@ async function directUpgrade(
       "it has no marketplace entry and no recorded GitHub source to re-fetch from",
     );
   }
+  // An install pinned to an immutable full SHA has no later revision of that
+  // SHA to advance to. Rather than make `upgrade` a permanent no-op, follow the
+  // repo's default branch (DEFAULT_DIRECT_REF, "HEAD") instead — a direct
+  // install is already the untrusted, dev-oriented path that fetches and
+  // imports mutable-ref code, and this matches a bare `owner/repo` install,
+  // which records HEAD. The first upgrade that advances re-records this
+  // tracking ref, so later upgrades follow the branch through the ordinary
+  // branch/tag/HEAD path with no SHA special-casing.
+  const trackingRef = isFullCommitSha(source.ref)
+    ? DEFAULT_DIRECT_REF
+    : source.ref;
   const fetchSource: PluginFetchSource = {
     owner: source.owner,
     repo: source.repo,
     rootPath: source.path ?? "",
-    ref: source.ref,
+    ref: trackingRef,
   };
 
   const fromCommit = local.commit;
@@ -518,6 +538,11 @@ async function directUpgrade(
         toTimestamp: null,
         provenanceWasUnknown,
         theirsSource: { ...fetchSource, ref: toCommit },
+        // Materialize the exact resolved commit, but record the tracking ref so
+        // a merged install keeps following its branch (or the default branch,
+        // for a former SHA pin) on the next upgrade rather than re-pinning to
+        // the just-resolved SHA.
+        recordSourceRef: trackingRef,
         baseStubRef: null,
         theirsStubRef: null,
       },
@@ -576,6 +601,13 @@ async function mergeUpgrade(
     readonly provenanceWasUnknown: boolean;
     /** Coordinates of the revision being merged in (`theirs`), pinned to {@link ctx.toCommit}. */
     readonly theirsSource: PluginFetchSource;
+    /**
+     * Ref recorded in the merged install's provenance sidecar, when it must
+     * differ from the concrete commit `theirs` materialized at — e.g. a direct
+     * install that keeps following a branch (or the default branch) rather than
+     * re-pinning to the resolved SHA. Defaults to {@link ctx.theirsSource}'s ref.
+     */
+    readonly recordSourceRef?: string;
     /**
      * Curated-adapter-stub ref overlaid when re-materializing the install
      * baseline, or `null` for a direct (untrusted) install that carries no
@@ -690,7 +722,7 @@ async function mergeUpgrade(
     await finalizeStagedInstall(stagingDir, {
       name,
       source: theirsSource,
-      ref: theirsSource.ref,
+      ref: ctx.recordSourceRef ?? theirsSource.ref,
       commit: toCommit,
       committedAt: toTimestamp,
       pluginsDir,


### PR DESCRIPTION
## Prompt / plan

Investigating why `assistant plugins upgrade` sometimes fails to pick up recent commits on a plugin's remote repo. One deterministic cause: a plugin installed directly from a GitHub URL that recorded a **full commit SHA** as its ref could never advance. `resolveRefCommit` short-circuits an immutable SHA to itself, so `directUpgrade` always reported `already-up-to-date` regardless of how far upstream moved on.

The fix follows the repo's default branch when the recorded ref is a full SHA, rather than freezing forever (a full SHA has no "later" revision of itself to move to).

## Test plan

- `bun test src/cli/lib/__tests__/upgrade-plugin.test.ts` — 25 pass. Replaced the old "SHA pin → no-op without any git" test with two new cases: a SHA-pinned direct install now advances to the default-branch tip (and re-records its ref as `HEAD`), and is a no-op only when it already sits at the tip.
- Related suites pass in isolation: `install-from-github`, `inspect-plugin`, `plugins-routes`.
- `bunx tsc --noEmit` clean; `eslint` clean on changed files (the 2 remaining warnings are pre-existing, outside the edited lines); Prettier clean.

## What changed

- **`directUpgrade`** computes a `trackingRef`: when the recorded `source.ref` is a full SHA it uses `DEFAULT_DIRECT_REF` (`HEAD`, the repo's default branch); otherwise the recorded branch/tag/`HEAD` as before. This mirrors a bare `owner/repo` install (which already records `HEAD`) and adds no new exposure — a direct install is already the untrusted, dev-oriented path that fetches and imports mutable-ref code.
- The first upgrade that advances re-records the tracking ref, so subsequent upgrades follow the branch through the ordinary path with no SHA special-casing.
- The **merge-strategy path** now records the tracking ref rather than the just-resolved SHA (new optional `recordSourceRef` on `mergeUpgrade`), so a merge-upgraded direct install keeps following its branch on the next upgrade instead of being re-pinned to a SHA. This also fixes a pre-existing quirk where merge-upgrading any branch-tracked direct install silently re-pinned it to a SHA.

No new routes; the CLI verb checklist does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dhbvX8z4HYwNT9g5dj79C

---
_Generated by [Claude Code](https://claude.ai/code/session_019dhbvX8z4HYwNT9g5dj79C)_