### PR TITLE
fix(plugins): install a plugin from a slash-named GitHub branch

### DIFF
--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -51,7 +51,7 @@ Examples:
         { flags: "--force", description: "Overwrite an existing install" },
         {
           flags: "--ref <ref>",
-          description: `For a marketplace install, the manifest revision to read the pin from (default: ${DEFAULT_PLUGIN_REF}). For a GitHub URL, the git ref (branch/tag/SHA) to clone — required for a ref whose name contains a slash (e.g. feature/x), which the /tree/<ref>/ URL cannot express on its own`,
+          description: `For a marketplace install, the manifest revision to read the pin from (default: ${DEFAULT_PLUGIN_REF}). For a GitHub URL, the git ref (branch/tag/SHA) to clone — states a slash-containing branch (e.g. feature/x) explicitly and skips the remote ref lookup a bare /tree/ URL otherwise does`,
         },
         {
           flags: "--pin <sha>",
@@ -75,13 +75,15 @@ bypassing the marketplace whitelist. Such a plugin is UNTRUSTED — it has not
 been reviewed and its hooks/tools run with full assistant access — so the
 install prints a warning. Use it for a plugin still under development that is
 not in the catalog yet. The ref comes from the URL's /tree/<ref>/ segment, or
-defaults to the repository's default branch. A ref whose name contains a slash
-(e.g. feature/x) can't be read from the URL alone — pass it with --ref.
+defaults to the repository's default branch. A branch whose name contains a
+slash (e.g. feature/x) is resolved automatically against the repo's refs, just
+as github.com does — paste the /tree/ URL as-is, or pass --ref to skip the
+lookup (e.g. offline, or to force a specific ref).
 
 Examples:
   $ assistant plugins install https://github.com/owner/repo
   $ assistant plugins install https://github.com/owner/repo/tree/my-branch/path/to/plugin
-  $ assistant plugins install https://github.com/owner/repo/tree/feat/results-viewer/path --ref feat/results-viewer
+  $ assistant plugins install https://github.com/owner/repo/tree/feat/results-viewer/path
   $ assistant plugins install owner/repo --name my-plugin --force`,
     },
     {

--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -51,7 +51,7 @@ Examples:
         { flags: "--force", description: "Overwrite an existing install" },
         {
           flags: "--ref <ref>",
-          description: `Marketplace manifest revision to read the pin from (default: ${DEFAULT_PLUGIN_REF}). Marketplace installs only — for a GitHub URL, put the ref in the URL (.../tree/<ref>/...)`,
+          description: `For a marketplace install, the manifest revision to read the pin from (default: ${DEFAULT_PLUGIN_REF}). For a GitHub URL, the git ref (branch/tag/SHA) to clone — required for a ref whose name contains a slash (e.g. feature/x), which the /tree/<ref>/ URL cannot express on its own`,
         },
         {
           flags: "--pin <sha>",
@@ -75,11 +75,13 @@ bypassing the marketplace whitelist. Such a plugin is UNTRUSTED — it has not
 been reviewed and its hooks/tools run with full assistant access — so the
 install prints a warning. Use it for a plugin still under development that is
 not in the catalog yet. The ref comes from the URL's /tree/<ref>/ segment, or
-defaults to the repository's default branch.
+defaults to the repository's default branch. A ref whose name contains a slash
+(e.g. feature/x) can't be read from the URL alone — pass it with --ref.
 
 Examples:
   $ assistant plugins install https://github.com/owner/repo
   $ assistant plugins install https://github.com/owner/repo/tree/my-branch/path/to/plugin
+  $ assistant plugins install https://github.com/owner/repo/tree/feat/results-viewer/path --ref feat/results-viewer
   $ assistant plugins install owner/repo --name my-plugin --force`,
     },
     {

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -832,10 +832,11 @@ async function resolveInstallOptions(
  * untrusted direct install, or `null` when the URL or flag combination is
  * invalid (a message is printed in that case, and the caller exits non-zero).
  *
- * The marketplace-only flags (`--ref`, `--pin`, `--allow-unreviewed`) do not
- * apply to a direct install — the ref lives in the URL — so combining them is
- * rejected. The install name defaults to the repo / sub-path leaf and can be
- * overridden with `--name`.
+ * `--ref` names the git ref to clone from; it is the only way to install from a
+ * ref whose name contains a slash (`feature/x`), which GitHub's
+ * `/tree/<ref>/<path>` URL cannot express unambiguously. `--pin` and
+ * `--allow-unreviewed` are marketplace-only and rejected here. The install name
+ * defaults to the repo / sub-path leaf and can be overridden with `--name`.
  */
 function resolveDirectInstallOptions(
   spec: string,
@@ -847,12 +848,6 @@ function resolveDirectInstallOptions(
     name?: string;
   },
 ): InstallPluginOptions | null {
-  if (opts.ref) {
-    console.error(
-      "--ref does not apply to a GitHub-URL install; put the ref in the URL (e.g. .../tree/<ref>/...).",
-    );
-    return null;
-  }
   if (opts.pin || opts.allowUnreviewed) {
     console.error(
       "--pin and --allow-unreviewed only apply to marketplace installs by name, not a GitHub URL.",
@@ -862,7 +857,7 @@ function resolveDirectInstallOptions(
 
   let parsed;
   try {
-    parsed = parseGitHubPluginSpec(spec);
+    parsed = parseGitHubPluginSpec(spec, opts.ref);
   } catch (err) {
     if (err instanceof InvalidGitHubPluginSpecError) {
       console.error(err.message);

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -195,7 +195,7 @@ export function registerPluginsCommand(program: Command): void {
               }
             } else {
               const installOpts = direct
-                ? resolveDirectInstallOptions(nameOrUrl, opts)
+                ? await resolveDirectInstallOptions(nameOrUrl, opts)
                 : await resolveInstallOptions(nameOrUrl, opts);
               if (installOpts === null) {
                 process.exitCode = 1;
@@ -832,13 +832,16 @@ async function resolveInstallOptions(
  * untrusted direct install, or `null` when the URL or flag combination is
  * invalid (a message is printed in that case, and the caller exits non-zero).
  *
- * `--ref` names the git ref to clone from; it is the only way to install from a
- * ref whose name contains a slash (`feature/x`), which GitHub's
- * `/tree/<ref>/<path>` URL cannot express unambiguously. `--pin` and
- * `--allow-unreviewed` are marketplace-only and rejected here. The install name
- * defaults to the repo / sub-path leaf and can be overridden with `--name`.
+ * A `/tree/<ref>/<path>` URL cannot mark where a slash-containing branch name
+ * (`feature/x`) ends and the sub-path begins, so when the ref is left implicit
+ * the real split is resolved against the repository's refs — exactly as
+ * github.com does — before building the install coordinates. `--ref` states the
+ * ref explicitly and skips that lookup (useful offline, or to force a specific
+ * ref). `--pin` and `--allow-unreviewed` are marketplace-only and rejected here.
+ * The install name defaults to the resolved sub-path leaf (or the repo) and can
+ * be overridden with `--name`.
  */
-function resolveDirectInstallOptions(
+async function resolveDirectInstallOptions(
   spec: string,
   opts: {
     force?: boolean;
@@ -847,7 +850,7 @@ function resolveDirectInstallOptions(
     allowUnreviewed?: boolean;
     name?: string;
   },
-): InstallPluginOptions | null {
+): Promise<InstallPluginOptions | null> {
   if (opts.pin || opts.allowUnreviewed) {
     console.error(
       "--pin and --allow-unreviewed only apply to marketplace installs by name, not a GitHub URL.",
@@ -866,7 +869,24 @@ function resolveDirectInstallOptions(
     throw err;
   }
 
-  const requested = opts.name ?? parsed.defaultName;
+  // The offline parse guesses the first `/tree/` segment is the whole ref; when
+  // the tail could hide a slash-containing ref, ask the remote which leading
+  // prefix is a real branch/tag and re-derive the sub-path (and default name)
+  // from the answer. Falls back to the guess when the remote can't be listed.
+  let { path, ref, defaultName } = parsed;
+  if (parsed.ambiguousTreeSegments) {
+    const resolved = await libs.installGitHub.resolveTreeRefPath(
+      parsed.owner,
+      parsed.repo,
+      parsed.ambiguousTreeSegments,
+    );
+    ref = resolved.ref;
+    path = resolved.path;
+    const leaf = path.split("/").filter(Boolean).at(-1) ?? parsed.repo;
+    defaultName = leaf.toLowerCase();
+  }
+
+  const requested = opts.name ?? defaultName;
   let name: string;
   try {
     name = libs.installGitHub.sanitizePluginName(requested);
@@ -875,7 +895,7 @@ function resolveDirectInstallOptions(
       console.error(
         opts.name
           ? err.message
-          : `Could not derive a valid plugin name from "${parsed.defaultName}". ` +
+          : `Could not derive a valid plugin name from "${defaultName}". ` +
               "Pass --name <name> to choose one (lowercase letters, digits, '-', '_').",
       );
       return null;
@@ -886,8 +906,8 @@ function resolveDirectInstallOptions(
   const directSource: PluginFetchSource = {
     owner: parsed.owner,
     repo: parsed.repo,
-    rootPath: parsed.path,
-    ref: parsed.ref,
+    rootPath: path,
+    ref,
   };
   return { name, force: opts.force ?? false, directSource };
 }

--- a/assistant/src/cli/lib/__tests__/install-from-github.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-github.test.ts
@@ -33,6 +33,7 @@ import {
   PluginSourceUnavailableError,
   type PostinstallRunner,
   readInstallMeta,
+  resolveTreeRefPath,
   sanitizePluginName,
 } from "../install-from-github.js";
 
@@ -1402,4 +1403,97 @@ describe("sanitizePluginName", () => {
       );
     },
   );
+});
+
+describe("resolveTreeRefPath", () => {
+  /**
+   * Fake runner that answers `git ls-remote --heads --tags` with the given
+   * branch/tag short-names in GitHub's `<sha>\t<refname>` wire format, and
+   * throws for any other git invocation (these tests only exercise ls-remote).
+   */
+  function lsRemoteRunner(refNames: string[]): GitRunner {
+    return async (args) => {
+      if (args[0] !== "ls-remote") {
+        throw new Error(`unexpected git call: ${args.join(" ")}`);
+      }
+      const stdout = refNames
+        .map(
+          (name, i) =>
+            `${String(i + 1).padStart(40, "0")}\trefs/${
+              name.startsWith("v") ? "tags" : "heads"
+            }/${name}`,
+        )
+        .join("\n");
+      return { stdout };
+    };
+  }
+
+  test("picks the longest leading prefix that names a real branch", async () => {
+    const result = await resolveTreeRefPath(
+      "ZeebBoyBlue",
+      "virlo-integrations",
+      ["feat", "results-viewer", "integrations", "vellum"],
+      lsRemoteRunner(["main", "feat/results-viewer"]),
+    );
+    expect(result).toEqual({
+      ref: "feat/results-viewer",
+      path: "integrations/vellum",
+    });
+  });
+
+  test("prefers the longer of two matching branch prefixes", async () => {
+    const result = await resolveTreeRefPath(
+      "owner",
+      "repo",
+      ["feat", "x", "pkg"],
+      // Both `feat` and `feat/x` exist; the longer wins, mirroring github.com.
+      lsRemoteRunner(["feat", "feat/x"]),
+    );
+    expect(result).toEqual({ ref: "feat/x", path: "pkg" });
+  });
+
+  test("resolves a single-segment ref with the rest as the sub-path", async () => {
+    const result = await resolveTreeRefPath(
+      "owner",
+      "repo",
+      ["main", "packages", "cool"],
+      lsRemoteRunner(["main"]),
+    );
+    expect(result).toEqual({ ref: "main", path: "packages/cool" });
+  });
+
+  test("treats a full commit SHA as the ref without listing refs", async () => {
+    const sha = "d0403988fdf1d3c220c25f7aaf7632359eec4d91";
+    const result = await resolveTreeRefPath(
+      "owner",
+      "repo",
+      [sha, "sub", "dir"],
+      async () => {
+        throw new Error("ls-remote must not run for a full SHA");
+      },
+    );
+    expect(result).toEqual({ ref: sha, path: "sub/dir" });
+  });
+
+  test("falls back to the first-segment guess when no prefix matches a ref", async () => {
+    const result = await resolveTreeRefPath(
+      "owner",
+      "repo",
+      ["mystery", "sub"],
+      lsRemoteRunner(["main", "develop"]),
+    );
+    expect(result).toEqual({ ref: "mystery", path: "sub" });
+  });
+
+  test("falls back to the guess when the remote can't be listed", async () => {
+    const result = await resolveTreeRefPath(
+      "owner",
+      "repo",
+      ["feat", "x", "sub"],
+      async () => {
+        throw new Error("network down");
+      },
+    );
+    expect(result).toEqual({ ref: "feat", path: "x/sub" });
+  });
 });

--- a/assistant/src/cli/lib/__tests__/parse-github-plugin-spec.test.ts
+++ b/assistant/src/cli/lib/__tests__/parse-github-plugin-spec.test.ts
@@ -56,6 +56,9 @@ describe("parseGitHubPluginSpec", () => {
       path: "packages/cool-plugin",
       ref: "my-branch",
       defaultName: "cool-plugin",
+      // The URL alone can't rule out a slash-containing branch, so the raw tail
+      // is exposed for the install path to resolve against the remote.
+      ambiguousTreeSegments: ["my-branch", "packages", "cool-plugin"],
     });
   });
 
@@ -66,6 +69,9 @@ describe("parseGitHubPluginSpec", () => {
     expect(spec.path).toBe("");
     expect(spec.ref).toBe("v1.2.3");
     expect(spec.defaultName).toBe("repo");
+    // A single trailing segment is unambiguously the whole ref — nothing to
+    // resolve.
+    expect(spec.ambiguousTreeSegments).toBeUndefined();
   });
 
   test("treats a non-tree trailing segment as the sub-path", () => {

--- a/assistant/src/cli/lib/__tests__/parse-github-plugin-spec.test.ts
+++ b/assistant/src/cli/lib/__tests__/parse-github-plugin-spec.test.ts
@@ -118,4 +118,58 @@ describe("parseGitHubPluginSpec", () => {
       parseGitHubPluginSpec("github.com/owner/repo/tree/main/../etc"),
     ).toThrow(InvalidGitHubPluginSpecError);
   });
+
+  describe("with an explicit refOverride", () => {
+    test("recovers a slash-containing ref from a copied /tree/ URL, stripping it from the sub-path", () => {
+      const spec = parseGitHubPluginSpec(
+        "https://github.com/ZeebBoyBlue/virlo-integrations/tree/feat/results-viewer/integrations/vellum",
+        "feat/results-viewer",
+      );
+      expect(spec).toEqual({
+        owner: "ZeebBoyBlue",
+        repo: "virlo-integrations",
+        path: "integrations/vellum",
+        ref: "feat/results-viewer",
+        defaultName: "vellum",
+      });
+    });
+
+    test("applies the ref to the non-tree form, keeping all trailing segments as the sub-path", () => {
+      const spec = parseGitHubPluginSpec(
+        "github.com/owner/repo/integrations/vellum",
+        "feature/x",
+      );
+      expect(spec.ref).toBe("feature/x");
+      expect(spec.path).toBe("integrations/vellum");
+    });
+
+    test("wins over a single-segment ref present in the URL", () => {
+      const spec = parseGitHubPluginSpec(
+        "https://github.com/owner/repo/tree/main/pkg",
+        "release/2.0",
+      );
+      // The URL's `main` is not a prefix of the override, so it is treated as
+      // part of the sub-path rather than silently dropped.
+      expect(spec.ref).toBe("release/2.0");
+      expect(spec.path).toBe("main/pkg");
+    });
+
+    test("strips a matching single-segment ref just like the URL-only path would", () => {
+      const spec = parseGitHubPluginSpec(
+        "https://github.com/owner/repo/tree/main/pkg",
+        "main",
+      );
+      expect(spec.ref).toBe("main");
+      expect(spec.path).toBe("pkg");
+    });
+
+    test("is ignored when blank, falling back to the URL-derived ref", () => {
+      const spec = parseGitHubPluginSpec(
+        "https://github.com/owner/repo/tree/my-branch/pkg",
+        "   ",
+      );
+      expect(spec.ref).toBe("my-branch");
+      expect(spec.path).toBe("pkg");
+    });
+  });
 });

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -66,6 +66,7 @@ const execFileAsync = promisify(execFile);
 const PLUGIN_SOURCE_OWNER = "vellum-ai";
 const PLUGIN_SOURCE_REPO = "vellum-assistant";
 const PLUGIN_SOURCE_PATH_PREFIX = "plugins";
+import { DEFAULT_DIRECT_REF } from "./parse-github-plugin-spec.js";
 import { DEFAULT_PLUGIN_REF } from "./plugin-constants.js";
 
 /** Full Git commit SHA — 40 hex chars (SHA-1) or 64 (SHA-256). */
@@ -1365,6 +1366,79 @@ export async function resolveRefCommit(
     }
   }
   return peeled ?? direct;
+}
+
+/**
+ * List the branch and tag short-names a remote publishes, via a single
+ * `git ls-remote --heads --tags`. Best-effort: any failure (unreachable repo,
+ * a private one we can't authenticate to, network loss) yields an empty set so
+ * the caller falls back to its offline guess rather than aborting — a genuinely
+ * missing ref still surfaces later when the clone itself fails.
+ */
+async function listRemoteRefNames(
+  owner: string,
+  repo: string,
+  runGit: GitRunner,
+): Promise<Set<string>> {
+  const repoUrl = `https://github.com/${owner}/${repo}.git`;
+  let stdout: string;
+  try {
+    ({ stdout } = await runGit(["ls-remote", "--heads", "--tags", repoUrl], {
+      cwd: tmpdir(),
+    }));
+  } catch {
+    return new Set();
+  }
+  const names = new Set<string>();
+  for (const line of stdout.split("\n")) {
+    // Each line is `<sha>\t<refname>`; keep the branch/tag short-name, dropping
+    // the `refs/heads/` | `refs/tags/` prefix and an annotated tag's `^{}` peel.
+    const refname = line.trim().split(/\s+/)[1];
+    if (!refname) continue;
+    const name = refname
+      .replace(/^refs\/(?:heads|tags)\//, "")
+      .replace(/\^\{\}$/, "");
+    if (name) names.add(name);
+  }
+  return names;
+}
+
+/**
+ * Split a `/tree/<segments>` GitHub URL's tail into the ref and sub-path it
+ * actually denotes — the ambiguity github.com resolves by consulting the
+ * repository's refs, since a branch name can itself contain slashes
+ * (`feature/x`) and the URL can't mark where it ends. Picks the LONGEST leading
+ * prefix of `segments` that names a real branch or tag; the remainder is the
+ * sub-path.
+ *
+ * Falls back to treating the first segment as the ref (the offline heuristic)
+ * when the remote can't be listed or no prefix matches — including a full commit
+ * SHA, which `ls-remote` never enumerates but a clone can still fetch.
+ */
+export async function resolveTreeRefPath(
+  owner: string,
+  repo: string,
+  segments: readonly string[],
+  runGit: GitRunner = defaultGitRunner,
+): Promise<{ ref: string; path: string }> {
+  if (segments.length === 0) {
+    return { ref: DEFAULT_DIRECT_REF, path: "" };
+  }
+  const firstSegmentGuess = {
+    ref: segments[0]!,
+    path: segments.slice(1).join("/"),
+  };
+  if (isFullCommitSha(segments[0]!)) {
+    return firstSegmentGuess;
+  }
+  const refNames = await listRemoteRefNames(owner, repo, runGit);
+  for (let k = segments.length; k >= 1; k--) {
+    const candidate = segments.slice(0, k).join("/");
+    if (refNames.has(candidate)) {
+      return { ref: candidate, path: segments.slice(k).join("/") };
+    }
+  }
+  return firstSegmentGuess;
 }
 
 /** Inputs for {@link writeInstallMeta}, resolved during a fresh install. */

--- a/assistant/src/cli/lib/parse-github-plugin-spec.ts
+++ b/assistant/src/cli/lib/parse-github-plugin-spec.ts
@@ -61,6 +61,19 @@ export interface GitHubPluginSpec {
    * case the caller asks the user to supply `--name`.
    */
   readonly defaultName: string;
+  /**
+   * Raw path segments after `/tree/` (or `/blob/`) when the ref/sub-path split
+   * is only a heuristic guess a remote lookup can improve — a `/tree/…` URL with
+   * no explicit ref and more than one trailing segment, where the ref could be
+   * any leading prefix (a branch like `feature/x` spans several segments). The
+   * install path resolves the real split against the repository's ref list,
+   * exactly as github.com does; {@link GitHubPluginSpec.ref} /
+   * {@link GitHubPluginSpec.path} carry the offline first-segment guess as a
+   * fallback for when the remote can't be listed. Absent when the ref is already
+   * unambiguous: an explicit `refOverride`, a single trailing segment, the
+   * non-`tree` form, or a bare repo.
+   */
+  readonly ambiguousTreeSegments?: readonly string[];
 }
 
 /** The locator could not be parsed as a GitHub plugin source. */
@@ -167,12 +180,15 @@ export function parseGitHubPluginSpec(
   const override = refOverride?.trim() || undefined;
   let ref = DEFAULT_DIRECT_REF;
   let pathSegments: string[];
+  let ambiguousTreeSegments: readonly string[] | undefined;
   // `/tree/<ref>/<path>` (and the equivalent `/blob/…`) is GitHub's canonical
   // encoding of a ref + sub-path. A ref containing slashes (e.g. `feature/x`)
-  // is not expressible this way: without an explicit `refOverride` the first
-  // segment after `tree` is taken as the whole ref, so such refs must instead
-  // be disambiguated with `--ref` (or given as a single segment / commit SHA).
-  // The non-`tree` form treats everything past the repo as the sub-path.
+  // spans several segments, and the URL alone can't say where it ends. github.com
+  // resolves this by consulting the repo's refs; an explicit `refOverride`
+  // states it directly. Absent both, take the first segment as the ref but
+  // surface the raw tail (`ambiguousTreeSegments`) so the install path can
+  // resolve the real split against the remote. The non-`tree` form treats
+  // everything past the repo as the sub-path.
   if (rest.length > 0 && (rest[0] === "tree" || rest[0] === "blob")) {
     const afterMarker = rest.slice(1);
     if (override) {
@@ -181,6 +197,8 @@ export function parseGitHubPluginSpec(
     } else {
       if (afterMarker.length >= 1) ref = afterMarker[0]!;
       pathSegments = afterMarker.slice(1);
+      // Only meaningful when a prefix beyond the first segment could be the ref.
+      if (afterMarker.length >= 2) ambiguousTreeSegments = afterMarker;
     }
   } else {
     if (override) ref = override;
@@ -200,5 +218,12 @@ export function parseGitHubPluginSpec(
   const leaf = pathSegments.at(-1) ?? repo;
   const defaultName = leaf.toLowerCase();
 
-  return { owner, repo, path, ref, defaultName };
+  return {
+    owner,
+    repo,
+    path,
+    ref,
+    defaultName,
+    ...(ambiguousTreeSegments ? { ambiguousTreeSegments } : {}),
+  };
 }

--- a/assistant/src/cli/lib/parse-github-plugin-spec.ts
+++ b/assistant/src/cli/lib/parse-github-plugin-spec.ts
@@ -26,6 +26,13 @@
  * when present the segment after it is the ref and the remainder is the
  * sub-path. Otherwise everything past `<owner>/<repo>` is the sub-path and the
  * ref defaults to the repository's default branch ({@link DEFAULT_DIRECT_REF}).
+ *
+ * The `/tree/<ref>/<path>` form cannot express a ref that contains a slash
+ * (`feature/x`): the URL is genuinely ambiguous about where the ref ends and
+ * the sub-path begins. Pass `refOverride` (from the CLI's `--ref`) to state the
+ * ref explicitly — it then wins over whatever the URL implies, and when the
+ * URL's `/tree/<ref>/…` segments start with that ref they are stripped so the
+ * remainder is taken as the sub-path.
  */
 
 /**
@@ -81,12 +88,37 @@ export function looksLikeGitHubSpec(arg: string): boolean {
 }
 
 /**
+ * Drop `ref`'s own path segments from the front of `segments` when they match,
+ * so a copied `/tree/<ref>/<sub/path>` URL yields just the sub-path once the
+ * ref is known explicitly. A non-matching prefix (the URL names a different or
+ * shorter ref than the override) is left intact — every segment is then the
+ * sub-path, since the override already fully specifies the ref.
+ */
+function stripRefPrefix(segments: string[], ref: string): string[] {
+  const refParts = ref.split("/").filter((p) => p.length > 0);
+  if (refParts.length === 0 || refParts.length > segments.length) {
+    return segments;
+  }
+  for (let i = 0; i < refParts.length; i++) {
+    if (segments[i] !== refParts[i]) return segments;
+  }
+  return segments.slice(refParts.length);
+}
+
+/**
  * Parse a GitHub locator into the coordinates a direct install clones from.
  * Throws {@link InvalidGitHubPluginSpecError} when the string is not a usable
  * GitHub source (wrong host, missing owner/repo, or a sub-path that escapes the
  * repo).
+ *
+ * `refOverride` (the CLI's `--ref`) disambiguates a ref that contains a slash,
+ * which the `/tree/<ref>/<path>` URL form cannot express on its own; when given
+ * it becomes the ref verbatim.
  */
-export function parseGitHubPluginSpec(input: string): GitHubPluginSpec {
+export function parseGitHubPluginSpec(
+  input: string,
+  refOverride?: string,
+): GitHubPluginSpec {
   const raw = input.trim();
   if (raw === "") {
     throw new InvalidGitHubPluginSpecError(input, "empty locator.");
@@ -132,17 +164,26 @@ export function parseGitHubPluginSpec(input: string): GitHubPluginSpec {
   }
 
   const rest = segments.slice(2);
+  const override = refOverride?.trim() || undefined;
   let ref = DEFAULT_DIRECT_REF;
   let pathSegments: string[];
   // `/tree/<ref>/<path>` (and the equivalent `/blob/…`) is GitHub's canonical
   // encoding of a ref + sub-path. A ref containing slashes (e.g. `feature/x`)
-  // is not expressible this way — the first segment after `tree` is taken as
-  // the whole ref — so such refs must instead be a single segment or a commit
-  // SHA. The non-`tree` form treats everything past the repo as the sub-path.
+  // is not expressible this way: without an explicit `refOverride` the first
+  // segment after `tree` is taken as the whole ref, so such refs must instead
+  // be disambiguated with `--ref` (or given as a single segment / commit SHA).
+  // The non-`tree` form treats everything past the repo as the sub-path.
   if (rest.length > 0 && (rest[0] === "tree" || rest[0] === "blob")) {
-    if (rest.length >= 2) ref = rest[1]!;
-    pathSegments = rest.slice(2);
+    const afterMarker = rest.slice(1);
+    if (override) {
+      ref = override;
+      pathSegments = stripRefPrefix(afterMarker, override);
+    } else {
+      if (afterMarker.length >= 1) ref = afterMarker[0]!;
+      pathSegments = afterMarker.slice(1);
+    }
   } else {
+    if (override) ref = override;
     pathSegments = rest;
   }
 


### PR DESCRIPTION
## Prompt / plan

Triage of a user feedback bundle: *"New assistant just broke after asking it to update a plugin from a git repo."*

Reconstructing the failed conversation from the diagnostics showed the incident started with one concrete defect and cascaded from there:

1. The user asked to update the `virlo-integrations` plugin from the latest PR — branch **`feat/results-viewer`**, a **branch name containing a slash**.
2. Every supported install/upgrade path failed:
   - `assistant plugins install .../tree/feat/results-viewer/integrations/vellum` → *"Plugin not found at …/results-viewer/integrations/vellum (ref feat)"*. The `/tree/<ref>/<path>` parser took only the **first** segment after `tree` as the ref (`feat`) and folded the rest of the branch name into the sub-path.
   - `... --ref feat/results-viewer` → *"--ref does not apply to a GitHub-URL install"* — the obvious escape hatch was rejected.
   - `assistant plugins upgrade virlo-integrations` → *"no recorded GitHub source"* (its `install-meta.json` had been hand-written by an earlier manual workaround, in a schema `readInstallMeta` can't parse).
3. With no supported path, the assistant fell back to `rm -rf`/`cp` of the plugin dir plus a hand-rolled `install-meta.json`. Shortly after the manual swap + plugin reload, conversation processing crashed (`ENOENT: … mkdir` in `ensureDataDir`, and `getDb().select is not a function`) — the "just broke" the user reported.

This PR fixes the **root-cause trigger** so a plugin in a sub-path of a slash-named branch installs from a plain GitHub URL.

## What changed

**GitHub's `/tree/<ref>/<path>` URL is genuinely ambiguous** about where a slash-containing branch name ends and the sub-path begins — `feat/results-viewer/integrations/vellum` could split at any point. github.com resolves it by consulting the repository's **actual refs**. This PR does the same:

- `parseGitHubPluginSpec` (pure/offline) no longer commits to a first-segment guess for an ambiguous `/tree/` tail; it surfaces the raw segments as `ambiguousTreeSegments`, keeping the first-segment split as an offline fallback.
- `resolveTreeRefPath` (fetch layer, where the git runner already lives) does a single `git ls-remote --heads --tags` and picks the **longest leading prefix that names a real branch/tag**; the remainder is the sub-path. Best-effort: on a full commit SHA (which `ls-remote` doesn't enumerate) or an unreachable remote, it falls back to the offline guess.
- The direct-install path resolves the split up front, so the untrusted-install warning, the clone, the derived install name, and the recorded provenance are all consistent.
- `--ref` is now accepted on URL installs as an **explicit override** that skips the lookup (offline, private repos, or forcing a specific ref) — not the only way to handle slashes.

Net effect: `assistant plugins install https://github.com/ZeebBoyBlue/virlo-integrations/tree/feat/results-viewer/integrations/vellum` now resolves to ref `feat/results-viewer` + path `integrations/vellum`, matching what a browser shows for the same URL.

## Test plan

- `bun test src/cli/lib/__tests__/parse-github-plugin-spec.test.ts` — 29 pass. Covers `ambiguousTreeSegments` being emitted for multi-segment tree tails and suppressed for single-segment / non-tree / explicit-`--ref` forms, plus the `--ref` override + prefix-strip behavior.
- `bun test src/cli/lib/__tests__/install-from-github.test.ts` — 47 pass, incl. 6 new `resolveTreeRefPath` cases: longest-prefix match, prefer-longer of two matching prefixes, single-segment ref, full-SHA short-circuit (no ls-remote), no-match fallback, and remote-unreachable fallback.
- `bun test` on `plugins-install-offline`, `upgrade-plugin`, `diff-plugin`, `list-installed-plugins` — all pass individually.
- `prettier --check`, `eslint` (0 errors), and `tsc --noEmit` all clean (verified by the repo's pre-commit hook).
- Note: these CLI suites share global module-mock state and cross-contaminate when several are run in **one** `bun test` process (reproduces identically on `main`); each passes in isolation.

## Follow-ups (out of scope, surfaced by the triage)

- **`plugins upgrade` can't read a hand-written `install-meta.json`.** `readInstallMeta` requires `source` to be an object `{kind, owner, repo, ref}`; the ad-hoc `{source:"github", repo:"owner/name", commitSha, subPath}` shape parses to `null`, so `directUpgrade` reports "no recorded GitHub source." Worth tolerating the legacy shape or documenting the canonical one.
- **A plugin update should never take down conversation processing.** The post-swap crashes (`ENOENT … mkdir` on the per-turn `loadConfig` path, and a `main` DB singleton left holding a non-Drizzle handle) point at a resilience gap in the plugin-reload path that deserves its own investigation.

<!-- PR does not add any new routes; CLI verb checklist omitted. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01977BrvrLRcLgdj9UfCHQF6