### PR TITLE
feat(memory): add `--kind skill|cli` filter to `memory nodes list`

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17052,6 +17052,15 @@ paths:
           schema:
             type: integer
           description: Max results (default 50, max 200)
+        - name: kind
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - skill
+              - cli
+          description: "Restrict to auto-seeded capability nodes: 'skill' or 'cli'"
       responses:
         "200":
           description: Successful response

--- a/assistant/src/cli/commands/memory/index.help.ts
+++ b/assistant/src/cli/commands/memory/index.help.ts
@@ -85,6 +85,11 @@ Examples:
               description: "Filter nodes whose content contains <query>",
             },
             {
+              flags: "--kind <kind>",
+              description:
+                "Restrict to auto-seeded capability nodes: 'skill' or 'cli'",
+            },
+            {
               flags: "--limit <n>",
               description: "Max results (default 50, max 200)",
             },
@@ -96,12 +101,20 @@ Examples:
           helpText: `
 Behavior:
   Returns active (non-deleted) memory graph nodes ordered by significance.
-  With --search, all nodes are scanned so the filter is exhaustive regardless
-  of graph size. Without --search the query is capped at --limit rows at the
-  DB level for efficiency.
+  With --search or --kind, all nodes are scanned so the filter is exhaustive
+  regardless of graph size. With neither, the query is capped at --limit rows
+  at the DB level for efficiency.
+
+  --kind filters to the capability nodes auto-seeded from the assistant's
+  own catalog — one 'skill' node per enabled/catalog skill, one 'cli' node
+  per CLI command. This answers "which skills have a node in memory": each
+  matching row's content names the skill and its id. Combine with --search
+  to narrow to a specific capability. Filters compose (both must match).
 
 Examples:
   $ assistant memory nodes list
+  $ assistant memory nodes list --kind skill
+  $ assistant memory nodes list --kind skill --search "pdf"
   $ assistant memory nodes list --search "coffee" --limit 10
   $ assistant memory nodes list --json`,
         },

--- a/assistant/src/cli/commands/memory/nodes.ts
+++ b/assistant/src/cli/commands/memory/nodes.ts
@@ -50,7 +50,12 @@ export function registerMemoryNodesCommand(memory: Command): void {
     .alias("ls")
     .action(
       async (
-        opts: { search?: string; limit?: string; json?: boolean },
+        opts: {
+          search?: string;
+          limit?: string;
+          kind?: string;
+          json?: boolean;
+        },
         cmd: Command,
       ) => {
         const queryParams: Record<string, string> = {};
@@ -59,6 +64,9 @@ export function registerMemoryNodesCommand(memory: Command): void {
         }
         if (opts.limit) {
           queryParams.limit = opts.limit;
+        }
+        if (opts.kind) {
+          queryParams.kind = opts.kind;
         }
         const r = await cliIpcCall<ListMemoryNodesResult>("listMemoryNodes", {
           queryParams,
@@ -80,9 +88,10 @@ export function registerMemoryNodesCommand(memory: Command): void {
         }
 
         if (result.nodes.length === 0) {
+          const suffix = describeFilters(opts);
           log.info(
-            opts.search
-              ? `No memory nodes found matching "${opts.search}".`
+            suffix
+              ? `No memory nodes found ${suffix}.`
               : "No memory nodes found. The memory graph is empty.",
           );
           return;
@@ -121,9 +130,10 @@ export function registerMemoryNodesCommand(memory: Command): void {
           );
         }
 
+        const suffix = describeFilters(opts);
         console.log(
           `\n${result.total} node${result.total === 1 ? "" : "s"}${
-            opts.search ? ` matching "${opts.search}"` : ""
+            suffix ? ` ${suffix}` : ""
           }`,
         );
       },
@@ -235,6 +245,21 @@ export function registerMemoryNodesCommand(memory: Command): void {
       printStats(result.stats!);
     },
   );
+}
+
+/**
+ * Human-readable trailing clause describing the active list filters, e.g.
+ * `of kind "skill" matching "coffee"`. Returns "" when no filter is set.
+ */
+function describeFilters(opts: { kind?: string; search?: string }): string {
+  const parts: string[] = [];
+  if (opts.kind) {
+    parts.push(`of kind "${opts.kind}"`);
+  }
+  if (opts.search) {
+    parts.push(`matching "${opts.search}"`);
+  }
+  return parts.join(" ");
 }
 
 const MEMORY_TYPES = [

--- a/assistant/src/plugins/defaults/memory/graph/capability-seed.ts
+++ b/assistant/src/plugins/defaults/memory/graph/capability-seed.ts
@@ -28,6 +28,10 @@ import {
 import { getLogger } from "../logging.js";
 import type { SkillCapabilityInput } from "../v2/skill-content.js";
 import { createNode } from "./store.js";
+import {
+  CAPABILITY_CLI_SOURCE_PREFIX as CLI_SOURCE_PREFIX,
+  CAPABILITY_SKILL_SOURCE_PREFIX as SKILL_SOURCE_PREFIX,
+} from "./types.js";
 
 const log = getLogger("graph-capability-seed");
 
@@ -61,10 +65,6 @@ function fromCatalogSkill(entry: RemoteCatalogSkill): SkillCapabilityInput {
 
 /** Default significance for capability nodes. */
 const CAPABILITY_SIGNIFICANCE = 0.6;
-
-/** Stable prefix for capability node source tracking. */
-const SKILL_SOURCE_PREFIX = "capability:skill:";
-const CLI_SOURCE_PREFIX = "capability:cli:";
 
 /**
  * Upsert a graph node for a skill capability.

--- a/assistant/src/plugins/defaults/memory/graph/tool-handlers.ts
+++ b/assistant/src/plugins/defaults/memory/graph/tool-handlers.ts
@@ -22,6 +22,7 @@ import {
   recordNodeEdit,
   updateNode,
 } from "./store.js";
+import { type CapabilityKind, capabilityKind } from "./types.js";
 
 const log = getLogger("graph-tool-handlers");
 
@@ -376,6 +377,12 @@ export function handleUpdateMemory(
 export interface ListMemoryInput {
   search?: string;
   limit?: number;
+  /**
+   * Restrict results to auto-seeded capability nodes of a given flavor:
+   * `skill` (one node per enabled/catalog skill) or `cli` (one per CLI
+   * command). Omit to list every kind of node.
+   */
+  kind?: CapabilityKind;
 }
 
 export interface ListMemoryItem {
@@ -408,20 +415,26 @@ export function handleListMemory(
 
   const limit = Math.min(Math.max(1, input.limit ?? 50), 200);
   const search = input.search?.trim().toLowerCase();
+  const kind = input.kind;
 
-  // When searching, fetch all active nodes (no limit) so content filtering is
-  // exhaustive regardless of graph size. Without a limit the DB still orders by
-  // significance DESC, so the most relevant matches surface first after slicing.
+  // When a filter (search or kind) is active, fetch all active nodes (no
+  // limit) so filtering is exhaustive regardless of graph size — capability
+  // nodes carry only middling significance and would otherwise fall outside a
+  // significance-capped page. The DB still orders by significance DESC, so the
+  // most relevant matches surface first after slicing.
   const allNodes = queryNodes({
     fidelityNot: ["gone"],
-    ...(search ? {} : { limit }),
+    ...(search || kind ? {} : { limit }),
   });
 
-  const filtered = search
-    ? allNodes
-        .filter((n) => n.content.toLowerCase().includes(search))
-        .slice(0, limit)
-    : allNodes.slice(0, limit);
+  let matches = allNodes;
+  if (kind) {
+    matches = matches.filter((n) => capabilityKind(n) === kind);
+  }
+  if (search) {
+    matches = matches.filter((n) => n.content.toLowerCase().includes(search));
+  }
+  const filtered = matches.slice(0, limit);
 
   return {
     success: true,

--- a/assistant/src/plugins/defaults/memory/graph/types.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/types.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+
+import { capabilityKind, type MemoryNode } from "./types.js";
+
+function makeNode(overrides: Partial<MemoryNode> = {}): MemoryNode {
+  return {
+    id: "node-1",
+    content: "Test memory",
+    type: "procedural",
+    created: 0,
+    lastAccessed: 0,
+    lastConsolidated: 0,
+    eventDate: null,
+    emotionalCharge: {
+      valence: 0,
+      intensity: 0,
+      decayCurve: "linear",
+      decayRate: 0.05,
+      originalIntensity: 0,
+    },
+    fidelity: "vivid",
+    confidence: 0.8,
+    significance: 0.6,
+    stability: 14,
+    reinforcementCount: 0,
+    lastReinforced: 0,
+    sourceConversations: [],
+    sourceType: "direct",
+    narrativeRole: null,
+    partOfStory: null,
+    imageRefs: null,
+    ...overrides,
+  };
+}
+
+describe("capabilityKind", () => {
+  test("classifies a skill node by its source key", () => {
+    const node = makeNode({
+      content: 'The "PDF" skill (pdf) is available.',
+      sourceConversations: ["capability:skill:pdf"],
+    });
+    expect(capabilityKind(node)).toBe("skill");
+  });
+
+  test("classifies a CLI node by its source key", () => {
+    const node = makeNode({
+      content: 'The "assistant status" CLI command is available.',
+      sourceConversations: ["capability:cli:status"],
+    });
+    expect(capabilityKind(node)).toBe("cli");
+  });
+
+  test("falls back to content shape when the source key is absent", () => {
+    expect(
+      capabilityKind(
+        makeNode({ content: 'The "Docx" skill (docx) is available.' }),
+      ),
+    ).toBe("skill");
+    expect(
+      capabilityKind(
+        makeNode({ content: 'The "assistant ps" CLI command is available.' }),
+      ),
+    ).toBe("cli");
+  });
+
+  test("recognizes the legacy content prefixes", () => {
+    expect(capabilityKind(makeNode({ content: "skill:pdf\n..." }))).toBe(
+      "skill",
+    );
+    expect(capabilityKind(makeNode({ content: "cli:status\n..." }))).toBe(
+      "cli",
+    );
+  });
+
+  test("returns null for an organic procedural memory", () => {
+    const node = makeNode({
+      content: "FFmpeg needs -ac 2 for stereo output",
+      sourceConversations: ["conv-42"],
+    });
+    expect(capabilityKind(node)).toBeNull();
+  });
+
+  test("returns null for a non-procedural node even with a capability key", () => {
+    const node = makeNode({
+      type: "semantic",
+      content: 'The "PDF" skill (pdf) is available.',
+      sourceConversations: ["capability:skill:pdf"],
+    });
+    expect(capabilityKind(node)).toBeNull();
+  });
+});

--- a/assistant/src/plugins/defaults/memory/graph/types.ts
+++ b/assistant/src/plugins/defaults/memory/graph/types.ts
@@ -134,6 +134,53 @@ export function isCapabilityNode(node: MemoryNode): boolean {
   return false;
 }
 
+/**
+ * Stable source keys the capability seeder writes to `sourceConversations[0]`
+ * (see `capability-seed.ts`). Capability nodes aren't tied to a real
+ * conversation, so this slot doubles as the node's kind + identity key:
+ * `capability:skill:<skillId>` / `capability:cli:<commandName>`.
+ */
+export const CAPABILITY_SKILL_SOURCE_PREFIX = "capability:skill:";
+export const CAPABILITY_CLI_SOURCE_PREFIX = "capability:cli:";
+
+/** The two auto-seeded capability flavors. */
+export type CapabilityKind = "skill" | "cli";
+
+/**
+ * Classify a capability node as a skill or CLI command, or `null` if it is not
+ * an auto-seeded capability at all (organic procedural memories included).
+ *
+ * The stable source key is authoritative — every node the current seeder
+ * writes carries one. Content-shape detection is a fallback for nodes that
+ * predate the source key, mirroring the same shapes `isCapabilityNode` and
+ * `extractCapabilityId` recognize.
+ */
+export function capabilityKind(node: MemoryNode): CapabilityKind | null {
+  if (node.type !== "procedural") return null;
+
+  const source = node.sourceConversations[0];
+  if (source?.startsWith(CAPABILITY_SKILL_SOURCE_PREFIX)) return "skill";
+  if (source?.startsWith(CAPABILITY_CLI_SOURCE_PREFIX)) return "cli";
+
+  // Fallback: classify by seeded content shape when the source key is absent.
+  if (node.content.startsWith("cli:")) return "cli";
+  if (node.content.startsWith("skill:")) return "skill";
+  if (
+    node.content.startsWith('The "assistant ') &&
+    node.content.includes(" CLI command")
+  ) {
+    return "cli";
+  }
+  if (
+    node.content.startsWith('The "') &&
+    node.content.includes(" skill (") &&
+    node.content.includes(" is available.")
+  ) {
+    return "skill";
+  }
+  return null;
+}
+
 /** Relationship type between two memory nodes. */
 export type EdgeRelationship =
   | "caused-by"

--- a/assistant/src/plugins/defaults/memory/src/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-item-routes.test.ts
@@ -160,6 +160,7 @@ function insertItem(opts: {
   significance?: number;
   created?: number;
   lastAccessed?: number;
+  sourceConversations?: string[];
 }) {
   const db = getDb();
   const now = Date.now();
@@ -185,7 +186,7 @@ function insertItem(opts: {
       stability: 14,
       reinforcementCount: 0,
       lastReinforced: now,
-      sourceConversations: JSON.stringify([]),
+      sourceConversations: JSON.stringify(opts.sourceConversations ?? []),
       sourceType: "direct",
       narrativeRole: null,
       partOfStory: null,
@@ -982,6 +983,87 @@ describe("Memory Item Routes", () => {
       ).json()) as NodesListBody;
       expect(filtered.success).toBe(true);
       expect(filtered.nodes.map((n) => n.id)).toEqual(["n1"]);
+    });
+
+    test("listMemoryNodes filters to skill capability nodes with kind=skill", async () => {
+      // Skill node addressed by its stable source key.
+      insertItem({
+        id: "skill-pdf",
+        type: "procedural",
+        content: 'The "PDF" skill (pdf) is available. Work with PDF files.',
+        sourceConversations: ["capability:skill:pdf"],
+        significance: 0.6,
+      });
+      // CLI capability node — must be excluded by kind=skill.
+      insertItem({
+        id: "cli-status",
+        type: "procedural",
+        content: 'The "assistant status" CLI command is available.',
+        sourceConversations: ["capability:cli:status"],
+        significance: 0.6,
+      });
+      // High-significance organic memory that would otherwise top the list.
+      insertItem({
+        id: "organic",
+        type: "semantic",
+        content: "User prefers TypeScript",
+        significance: 0.99,
+      });
+
+      const route = getRoute("memory-nodes", "GET");
+      const body = (await (
+        await callHandler(route, { queryParams: { kind: "skill" } })
+      ).json()) as NodesListBody;
+
+      expect(body.success).toBe(true);
+      expect(body.nodes.map((n) => n.id)).toEqual(["skill-pdf"]);
+    });
+
+    test("listMemoryNodes classifies skill nodes by content when the source key is absent", async () => {
+      insertItem({
+        id: "skill-legacy",
+        type: "procedural",
+        content: 'The "Docx" skill (docx) is available. Edit Word docs.',
+        significance: 0.6,
+      });
+
+      const route = getRoute("memory-nodes", "GET");
+      const body = (await (
+        await callHandler(route, { queryParams: { kind: "skill" } })
+      ).json()) as NodesListBody;
+
+      expect(body.nodes.map((n) => n.id)).toEqual(["skill-legacy"]);
+    });
+
+    test("listMemoryNodes composes kind and search filters", async () => {
+      insertItem({
+        id: "skill-pdf",
+        type: "procedural",
+        content: 'The "PDF" skill (pdf) is available. Work with PDF files.',
+        sourceConversations: ["capability:skill:pdf"],
+      });
+      insertItem({
+        id: "skill-docx",
+        type: "procedural",
+        content: 'The "Docx" skill (docx) is available. Edit Word docs.',
+        sourceConversations: ["capability:skill:docx"],
+      });
+
+      const route = getRoute("memory-nodes", "GET");
+      const body = (await (
+        await callHandler(route, {
+          queryParams: { kind: "skill", search: "PDF" },
+        })
+      ).json()) as NodesListBody;
+
+      expect(body.nodes.map((n) => n.id)).toEqual(["skill-pdf"]);
+    });
+
+    test("listMemoryNodes rejects an unknown kind as 400", async () => {
+      const res = await callHandler(getRoute("memory-nodes", "GET"), {
+        queryParams: { kind: "bogus" },
+      });
+      expect(res.status).toBe(400);
     });
 
     test("listMemoryNodes reports memory v2 disabled as a business failure", async () => {

--- a/assistant/src/plugins/defaults/memory/src/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-item-routes.ts
@@ -60,6 +60,7 @@ import {
   handleUpdateMemory,
 } from "../graph/tool-handlers.js";
 import type {
+  CapabilityKind,
   Fidelity,
   ImageRef,
   MemoryNode,
@@ -96,6 +97,9 @@ const VALID_SORT_FIELDS = [
 
 type SortField = (typeof VALID_SORT_FIELDS)[number];
 
+/** Capability flavors accepted by the `memory-nodes` list `kind` filter. */
+const CAPABILITY_KINDS: readonly CapabilityKind[] = ["skill", "cli"];
+
 const SORT_COLUMN_MAP = {
   lastSeenAt: memoryGraphNodes.lastAccessed,
   importance: memoryGraphNodes.significance,
@@ -113,6 +117,10 @@ function isValidType(value: string): value is MemoryType {
 
 function isValidSortField(value: string): value is SortField {
   return (VALID_SORT_FIELDS as readonly string[]).includes(value);
+}
+
+function isCapabilityKind(value: string): value is CapabilityKind {
+  return (CAPABILITY_KINDS as readonly string[]).includes(value);
 }
 
 /**
@@ -887,6 +895,12 @@ export const ROUTES: RouteDefinition[] = [
         schema: { type: "integer" },
         description: "Max results (default 50, max 200)",
       },
+      {
+        name: "kind",
+        schema: { type: "string", enum: [...CAPABILITY_KINDS] },
+        description:
+          "Restrict to auto-seeded capability nodes: 'skill' or 'cli'",
+      },
     ],
     responseBody: z.object({
       success: z.boolean(),
@@ -911,8 +925,16 @@ export const ROUTES: RouteDefinition[] = [
           throw new BadRequestError("limit must be an integer");
         }
       }
+
+      const kindRaw = queryParams?.kind;
+      if (kindRaw !== undefined && !isCapabilityKind(kindRaw)) {
+        throw new BadRequestError(
+          `Invalid kind "${kindRaw}". Must be one of: ${CAPABILITY_KINDS.join(", ")}`,
+        );
+      }
+
       return handleListMemory(
-        { search: queryParams?.search, limit },
+        { search: queryParams?.search, limit, kind: kindRaw },
         getConfig(),
       );
     },


### PR DESCRIPTION
## Prompt / plan

Answering a recurring question — *"how do I ask the memory system which skills have a node?"* — that had no clean CLI answer.

Skills and CLI commands are auto-seeded into the memory v2 graph as procedural **capability nodes**, keyed by a stable source key in `sourceConversations[0]` (`capability:skill:<id>` / `capability:cli:<name>`, see `graph/capability-seed.ts`). But `assistant memory nodes list` could only filter by content text, so there was no exact way to enumerate the skills (or CLI commands) that have a node. This adds a first-class filter.

Approach:
- Add `capabilityKind(node)` to `graph/types.ts` — classifies a node as `skill` / `cli` / `null`. Source-key first (authoritative), with a content-shape fallback for nodes predating the key (mirrors the shapes `isCapabilityNode` / `extractCapabilityId` already recognize). Promote the source-key prefixes to exported constants and reuse them from `capability-seed.ts` so there's a single source of truth.
- Thread an optional `kind` through `handleListMemory` and the existing `listMemoryNodes` route (query param, validated → `400` on unknown). Like `search`, an active `kind` makes the scan exhaustive so mid-significance capability nodes aren't dropped by the significance-capped page.
- Add `--kind <kind>` to `assistant memory nodes list`, with filter-aware output/empty-state messages and help text/examples. No new route or CLI verb — this extends the existing `listMemoryNodes` route and its `nodes list` command.

Usage:

```
assistant memory nodes list --kind skill
assistant memory nodes list --kind skill --search "pdf"
assistant memory nodes list --kind cli
```

Each matching row's content names the skill and its id.

## Test plan

- New unit tests for `capabilityKind` (source-key classification, content fallback, legacy prefixes, organic-procedural and non-procedural → null).
- New route-level tests for the `kind` filter: skill classification via source key and via content fallback, `kind`+`search` composition, CLI-node exclusion, and invalid-kind → `400`.
- `bun test` green for the memory-item-routes, `graph/types`, and `graph/retriever` suites (retriever exercises the shared capability logic I touched).
- `bun run typecheck` clean; pre-commit lint/format hooks pass (only pre-existing `curly` style warnings remain).
- Pre-existing failures in the `memory v2`/`v3` maintenance CLI tests were confirmed to fail identically on the base branch (unrelated IPC-mock/env issue).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGAJu5NiuRcwA47XXdbMCh)_