### PR TITLE
fix(outbound-proxy): destroy CONNECT tunnel partner socket on close to stop fd leak

### DIFF
--- a/assistant/src/__tests__/script-proxy-connect-tunnel.test.ts
+++ b/assistant/src/__tests__/script-proxy-connect-tunnel.test.ts
@@ -1,7 +1,9 @@
 import { type Server } from "node:http";
 import { connect, createServer as createTcpServer } from "node:net";
+import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, test } from "bun:test";
 
+import { handleConnect } from "../outbound-proxy/connect-tunnel.js";
 import { createProxyServer } from "../outbound-proxy/index.js";
 
 /** Start an HTTP server and return its address + cleanup handle. */
@@ -42,6 +44,40 @@ function listenTcpEcho(): Promise<{
       }
       resolve({
         port: addr.port,
+        close: () =>
+          new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r()))),
+      });
+    });
+    server.on("error", reject);
+  });
+}
+
+/**
+ * Start a raw TCP echo server that also tracks every accepted upstream socket
+ * and exposes how many remain open. The proxy's upstream leg connects here, so
+ * a leaked tunnel socket shows up as an accepted socket that never closes.
+ */
+function listenTrackingTcpEcho(): Promise<{
+  port: number;
+  openSocketCount: () => number;
+  close: () => Promise<void>;
+}> {
+  return new Promise((resolve, reject) => {
+    const accepted = new Set<import("node:net").Socket>();
+    const server = createTcpServer((socket) => {
+      accepted.add(socket);
+      socket.on("close", () => accepted.delete(socket));
+      socket.pipe(socket);
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        reject(new Error("Failed to get address"));
+        return;
+      }
+      resolve({
+        port: addr.port,
+        openSocketCount: () => accepted.size,
         close: () =>
           new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r()))),
       });
@@ -199,5 +235,40 @@ describe("CONNECT tunnel", () => {
 
     // Give a moment for cleanup to propagate
     await new Promise((r) => setTimeout(r, 50));
+  });
+
+  test("upstream socket is destroyed when the client closes without an error", async () => {
+    // The leak path: a client socket torn down via `.destroy()` with no error
+    // emits `'close'` but never `'error'` or `'end'`, and `pipe()` does not
+    // propagate a bare close to its partner. Without a `'close'` handler the
+    // upstream leg is orphaned and its descriptor leaks. A duplex stub stands
+    // in for the client so the close arrives purely as `'close'` (a real TCP
+    // client `.destroy()` would send a RST and surface as `'error'`, which the
+    // existing error handler already covers — a different path).
+    const echo = await listenTrackingTcpEcho();
+    cleanups.push(echo);
+
+    const fakeClient = new PassThrough();
+    handleConnect(
+      { url: `127.0.0.1:${echo.port}` } as import("node:http").IncomingMessage,
+      fakeClient as unknown as import("node:net").Socket,
+      Buffer.alloc(0),
+    );
+
+    // Wait for the upstream leg to connect and be accepted by the echo server.
+    for (let i = 0; i < 40 && echo.openSocketCount() === 0; i++) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(echo.openSocketCount()).toBe(1);
+
+    // Close the client with no error — the exact path `pipe()` + the error
+    // handler both miss.
+    fakeClient.destroy();
+
+    // The upstream leg must be destroyed in response, so no descriptor leaks.
+    for (let i = 0; i < 40 && echo.openSocketCount() > 0; i++) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(echo.openSocketCount()).toBe(0);
   });
 });

--- a/assistant/src/outbound-proxy/connect-tunnel.ts
+++ b/assistant/src/outbound-proxy/connect-tunnel.ts
@@ -81,4 +81,23 @@ export function handleConnect(
   clientSocket.on("error", () => {
     upstream.destroy();
   });
+
+  // `pipe()` only propagates a graceful FIN (end -> end), and the `'error'`
+  // handlers above only fire on a RST or a socket error. A socket torn down
+  // with a bare `.destroy()` (no error) — e.g. an aborted TLS/fetch stream, or
+  // the HTTP server closing a detached CONNECT socket — emits only `'close'`,
+  // which neither `pipe()` nor the error handlers propagate, so its partner is
+  // left open and its descriptor orphaned. This is the daemon's
+  // highest-frequency socket path (every proxied outbound HTTPS connection),
+  // so one orphaned descriptor per such teardown accumulates into a descriptor
+  // leak over the process lifetime. Destroying each socket when its partner
+  // closes guarantees neither half is ever left open. `destroy()` is
+  // idempotent, so the mutual handlers cannot loop.
+  clientSocket.on("close", () => {
+    upstream.destroy();
+  });
+
+  upstream.on("close", () => {
+    clientSocket.destroy();
+  });
 }


### PR DESCRIPTION
## Prompt / plan

ATL-1000: _"File descriptor leak: assistant holds 1k open file handles."_ The long-running daemon accumulated ~1000 open file descriptors over its lifetime.

After auditing every recurring resource-open site in `assistant/src` (fs watchers, `bun:sqlite` handles, `openSync`, spawned-process stdio, sockets, streams) and ruling out the config/app/skill watchers, the MCP reload path, the git service, and the per-call DB connections (all correctly cleaned up), the leak traced to the outbound proxy's HTTPS `CONNECT` tunnel — the daemon's highest-frequency socket path.

## Root cause

`handleConnect` in `assistant/src/outbound-proxy/connect-tunnel.ts` wired the client and upstream sockets together with `pipe()` plus `'error'` handlers only:

- `pipe()` propagates a graceful FIN (`end` → `end`).
- The `'error'` handlers fire on a RST or socket error.

But a socket torn down with a bare `.destroy()` **and no error** — an aborted TLS/fetch stream, or the HTTP server closing a detached CONNECT socket — emits only `'close'`, which neither `pipe()` nor the error handlers propagate. The partner socket was left open and its descriptor orphaned. Every proxied outbound HTTPS connection (LLM streaming, `fetch`/`curl` tools, MCP HTTP) runs through this path, so one orphaned descriptor per such teardown accumulated into ~1k open handles.

## Fix

Destroy each socket when its partner emits `'close'`, so neither half is ever left open regardless of how it was torn down. `destroy()` is idempotent, so the mutual handlers cannot loop.

## Test plan

`assistant/src/__tests__/script-proxy-connect-tunnel.test.ts`:

- The pre-existing _"socket cleanup on client disconnect"_ test only asserted "no crash" and passed **both** with and without the fix — a real TCP client `.destroy()` sends a RST that surfaces as `'error'`, which was already handled, so it never exercised the leak.
- Added _"upstream socket is destroyed when the client closes without an error"_, which drives the actual leak path: a duplex stub emits a bare `'close'` (no error/no RST) and the test asserts the upstream leg is destroyed via a tracking echo server's live-socket count.
- Verified the new test **fails without the fix** (`Received: 1` — the leaked upstream socket) and **passes with it**. Full file: `7 pass, 0 fail`.

Type-check/lint tooling (`tsgo`, `eslint`) could not run in the sandbox (npm registry blocked), but Bun transpiles and runs the suite green.

Closes ATL-1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFdTA4wopPbcTsQaAiK4as

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFdTA4wopPbcTsQaAiK4as)_