### PR TITLE
fix(plugins): install from GitHub branches whose names contain slashes

### DIFF
--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -195,7 +195,7 @@ export function registerPluginsCommand(program: Command): void {
               }
             } else {
               const installOpts = direct
-                ? resolveDirectInstallOptions(nameOrUrl, opts)
+                ? await resolveDirectInstallOptions(nameOrUrl, opts)
                 : await resolveInstallOptions(nameOrUrl, opts);
               if (installOpts === null) {
                 process.exitCode = 1;
@@ -837,7 +837,7 @@ async function resolveInstallOptions(
  * rejected. The install name defaults to the repo / sub-path leaf and can be
  * overridden with `--name`.
  */
-function resolveDirectInstallOptions(
+async function resolveDirectInstallOptions(
   spec: string,
   opts: {
     force?: boolean;
@@ -846,7 +846,7 @@ function resolveDirectInstallOptions(
     allowUnreviewed?: boolean;
     name?: string;
   },
-): InstallPluginOptions | null {
+): Promise<InstallPluginOptions | null> {
   if (opts.ref) {
     console.error(
       "--ref does not apply to a GitHub-URL install; put the ref in the URL (e.g. .../tree/<ref>/...).",
@@ -871,7 +871,24 @@ function resolveDirectInstallOptions(
     throw err;
   }
 
-  const requested = opts.name ?? parsed.defaultName;
+  // A `/tree/<ref>/<path>` locator whose branch name may contain slashes has an
+  // ambiguous ref/path boundary. Confirm the real split against the remote,
+  // falling back to the parser's default (shortest-ref) split when the remote
+  // can't be reached. The chosen split also decides the default install name,
+  // since it depends on the resolved sub-path leaf.
+  let chosen: { ref: string; path: string; defaultName: string } = parsed;
+  if (parsed.refCandidates) {
+    const resolved = await libs.installGitHub.resolveTreeRefPath(
+      parsed.owner,
+      parsed.repo,
+      parsed.refCandidates,
+    );
+    if (resolved) {
+      chosen = resolved;
+    }
+  }
+
+  const requested = opts.name ?? chosen.defaultName;
   let name: string;
   try {
     name = libs.installGitHub.sanitizePluginName(requested);
@@ -880,7 +897,7 @@ function resolveDirectInstallOptions(
       console.error(
         opts.name
           ? err.message
-          : `Could not derive a valid plugin name from "${parsed.defaultName}". ` +
+          : `Could not derive a valid plugin name from "${chosen.defaultName}". ` +
               "Pass --name <name> to choose one (lowercase letters, digits, '-', '_').",
       );
       return null;
@@ -891,8 +908,8 @@ function resolveDirectInstallOptions(
   const directSource: PluginFetchSource = {
     owner: parsed.owner,
     repo: parsed.repo,
-    rootPath: parsed.path,
-    ref: parsed.ref,
+    rootPath: chosen.path,
+    ref: chosen.ref,
   };
   return { name, force: opts.force ?? false, directSource };
 }

--- a/assistant/src/cli/lib/__tests__/install-from-github.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-github.test.ts
@@ -33,6 +33,7 @@ import {
   PluginSourceUnavailableError,
   type PostinstallRunner,
   readInstallMeta,
+  resolveTreeRefPath,
   sanitizePluginName,
 } from "../install-from-github.js";
 
@@ -1402,4 +1403,119 @@ describe("sanitizePluginName", () => {
       );
     },
   );
+});
+
+describe("resolveTreeRefPath", () => {
+  // A slashed branch parses into two candidate splits, longest ref first: the
+  // whole thing as a branch (root path), or `feat` as a branch + a sub-path.
+  const SLASH_BRANCH_CANDIDATES = [
+    { ref: "feat/results-viewer", path: "", defaultName: "repo" },
+    { ref: "feat", path: "results-viewer", defaultName: "results-viewer" },
+  ] as const;
+
+  /** A fake `ls-remote` that reports the given short-name refs as heads/tags. */
+  function lsRemoteRunner(
+    refs: { heads?: string[]; tags?: string[] },
+    opts: { calls?: string[][] } = {},
+  ): GitRunner {
+    return async (args) => {
+      opts.calls?.push([...args]);
+      if (args[0] !== "ls-remote") {
+        throw new Error(`unexpected git ${args.join(" ")}`);
+      }
+      const lines = [
+        ...(refs.heads ?? []).map(
+          (r, i) => `${String(i).padStart(40, "0")}\trefs/heads/${r}`,
+        ),
+        ...(refs.tags ?? []).map(
+          (r, i) => `${String(i).padStart(40, "1")}\trefs/tags/${r}`,
+        ),
+      ];
+      return { stdout: `${lines.join("\n")}\n` };
+    };
+  }
+
+  test("picks the slashed branch when it exists on the remote", async () => {
+    const runGit = lsRemoteRunner({ heads: ["main", "feat/results-viewer"] });
+    const chosen = await resolveTreeRefPath(
+      "owner",
+      "repo",
+      SLASH_BRANCH_CANDIDATES,
+      runGit,
+    );
+    expect(chosen).toEqual(SLASH_BRANCH_CANDIDATES[0]);
+  });
+
+  test("falls back to the shorter branch + sub-path when only `feat` exists", async () => {
+    const runGit = lsRemoteRunner({ heads: ["main", "feat"] });
+    const chosen = await resolveTreeRefPath(
+      "owner",
+      "repo",
+      SLASH_BRANCH_CANDIDATES,
+      runGit,
+    );
+    expect(chosen).toEqual(SLASH_BRANCH_CANDIDATES[1]);
+  });
+
+  test("matches a slashed tag, ignoring its peeled `^{}` line", async () => {
+    const runGit: GitRunner = async () => ({
+      stdout:
+        "0000000000000000000000000000000000000000\trefs/tags/feat/results-viewer\n" +
+        "1111111111111111111111111111111111111111\trefs/tags/feat/results-viewer^{}\n",
+    });
+    const chosen = await resolveTreeRefPath(
+      "owner",
+      "repo",
+      SLASH_BRANCH_CANDIDATES,
+      runGit,
+    );
+    expect(chosen?.ref).toBe("feat/results-viewer");
+  });
+
+  test("returns null when the remote names none of the candidates", async () => {
+    const runGit = lsRemoteRunner({ heads: ["main", "other"] });
+    const chosen = await resolveTreeRefPath(
+      "owner",
+      "repo",
+      SLASH_BRANCH_CANDIDATES,
+      runGit,
+    );
+    expect(chosen).toBeNull();
+  });
+
+  test("returns null (fall back) when the remote is unreachable", async () => {
+    const runGit: GitRunner = async () => {
+      throw new Error("fatal: unable to access remote: network is unreachable");
+    };
+    const chosen = await resolveTreeRefPath(
+      "owner",
+      "repo",
+      SLASH_BRANCH_CANDIDATES,
+      runGit,
+    );
+    expect(chosen).toBeNull();
+  });
+
+  test("lists heads and tags in a single ls-remote round-trip", async () => {
+    const calls: string[][] = [];
+    const runGit = lsRemoteRunner(
+      { heads: ["feat/results-viewer"] },
+      { calls },
+    );
+    await resolveTreeRefPath("owner", "repo", SLASH_BRANCH_CANDIDATES, runGit);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual([
+      "ls-remote",
+      "--heads",
+      "--tags",
+      "https://github.com/owner/repo.git",
+    ]);
+  });
+
+  test("returns null for an empty candidate list without touching git", async () => {
+    const runGit: GitRunner = async () => {
+      throw new Error("git should not run");
+    };
+    expect(await resolveTreeRefPath("owner", "repo", [], runGit)).toBeNull();
+  });
 });

--- a/assistant/src/cli/lib/__tests__/parse-github-plugin-spec.test.ts
+++ b/assistant/src/cli/lib/__tests__/parse-github-plugin-spec.test.ts
@@ -50,13 +50,57 @@ describe("parseGitHubPluginSpec", () => {
     const spec = parseGitHubPluginSpec(
       "https://github.com/owner/repo/tree/my-branch/packages/cool-plugin",
     );
-    expect(spec).toEqual({
-      owner: "owner",
-      repo: "repo",
-      path: "packages/cool-plugin",
-      ref: "my-branch",
-      defaultName: "cool-plugin",
-    });
+    expect(spec.owner).toBe("owner");
+    expect(spec.repo).toBe("repo");
+    // The shortest-ref split is the default; the caller confirms the real split
+    // against the remote via `refCandidates`.
+    expect(spec.path).toBe("packages/cool-plugin");
+    expect(spec.ref).toBe("my-branch");
+    expect(spec.defaultName).toBe("cool-plugin");
+  });
+
+  test("enumerates every ref/path split, longest-ref-first, for an ambiguous /tree form", () => {
+    const spec = parseGitHubPluginSpec(
+      "https://github.com/owner/repo/tree/feat/results-viewer",
+    );
+    // `feat/results-viewer` could be branch `feat` + path `results-viewer`, or
+    // branch `feat/results-viewer` at the repo root. Both are offered, longer
+    // ref first, each carrying the install name derived from its sub-path.
+    expect(spec.refCandidates).toEqual([
+      { ref: "feat/results-viewer", path: "", defaultName: "repo" },
+      { ref: "feat", path: "results-viewer", defaultName: "results-viewer" },
+    ]);
+    // The default (shortest ref) mirrors the pre-resolution behavior.
+    expect(spec.ref).toBe("feat");
+    expect(spec.path).toBe("results-viewer");
+  });
+
+  test("carries candidates when a slashed branch precedes a real sub-path", () => {
+    const spec = parseGitHubPluginSpec(
+      "github.com/owner/repo/tree/feat/results-viewer/integrations/vellum",
+    );
+    expect(spec.refCandidates).toEqual([
+      {
+        ref: "feat/results-viewer/integrations/vellum",
+        path: "",
+        defaultName: "repo",
+      },
+      {
+        ref: "feat/results-viewer/integrations",
+        path: "vellum",
+        defaultName: "vellum",
+      },
+      {
+        ref: "feat/results-viewer",
+        path: "integrations/vellum",
+        defaultName: "vellum",
+      },
+      {
+        ref: "feat",
+        path: "results-viewer/integrations/vellum",
+        defaultName: "vellum",
+      },
+    ]);
   });
 
   test("a /tree/<ref> with no sub-path keeps the root and uses the repo name", () => {
@@ -66,6 +110,13 @@ describe("parseGitHubPluginSpec", () => {
     expect(spec.path).toBe("");
     expect(spec.ref).toBe("v1.2.3");
     expect(spec.defaultName).toBe("repo");
+    // A single post-`tree` segment is unambiguous — no candidate list.
+    expect(spec.refCandidates).toBeUndefined();
+  });
+
+  test("a non-tree sub-path carries no ref candidates", () => {
+    const spec = parseGitHubPluginSpec("github.com/owner/repo/sub/leaf");
+    expect(spec.refCandidates).toBeUndefined();
   });
 
   test("treats a non-tree trailing segment as the sub-path", () => {

--- a/assistant/src/cli/lib/__tests__/plugins-install-direct-slash-branch.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugins-install-direct-slash-branch.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Direct (GitHub-URL) install from a branch whose name contains a slash.
+ *
+ * `assistant plugins install https://github.com/<owner>/<repo>/tree/feat/x`
+ * used to misparse the slashed branch `feat/x` as ref `feat` + sub-path `x`,
+ * because `/tree/<ref>/<path>` joins the ref and sub-path with a bare `/`. The
+ * command now resolves the ambiguous boundary against the remote
+ * (`resolveTreeRefPath`), so the whole branch reaches the installer as the ref.
+ * These tests drive the real command with those two collaborators faked.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+
+import { Command } from "commander";
+
+import type {
+  InstallPluginOptions,
+  PluginFetchSource,
+} from "../install-from-github.js";
+
+const installPluginCalls: InstallPluginOptions[] = [];
+/** Ref short-names the faked remote reports as existing (heads + tags). */
+let remoteRefs: Set<string>;
+
+const realGithub = await import("../install-from-github.js");
+
+mock.module("../install-from-github.js", () => ({
+  ...realGithub,
+  installPlugin: async (opts: InstallPluginOptions) => {
+    installPluginCalls.push(opts);
+    return {
+      name: opts.name,
+      target: `/plugins/${opts.name}`,
+      fileCount: 3,
+      ref: opts.directSource?.ref ?? "HEAD",
+      commit: "abc1234def",
+      committedAt: null,
+    };
+  },
+  // Resolve against `remoteRefs` instead of the network: return the first
+  // candidate (longest-ref-first) whose ref the fake remote reports.
+  resolveTreeRefPath: async <T extends { readonly ref: string }>(
+    _owner: string,
+    _repo: string,
+    candidates: readonly T[],
+  ): Promise<T | null> => candidates.find((c) => remoteRefs.has(c.ref)) ?? null,
+}));
+
+const { registerPluginsCommand } = await import("../../commands/plugins.js");
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerPluginsCommand(program);
+  return program;
+}
+
+async function runInstall(url: string, ...extra: string[]): Promise<void> {
+  await buildProgram().parseAsync([
+    "node",
+    "assistant",
+    "plugins",
+    "install",
+    url,
+    ...extra,
+  ]);
+}
+
+describe("plugins install — direct GitHub URL with a slashed branch", () => {
+  const savedExitCode = process.exitCode;
+
+  beforeEach(() => {
+    installPluginCalls.length = 0;
+    remoteRefs = new Set();
+    process.exitCode = undefined;
+    spyOn(console, "log").mockImplementation(() => {});
+    spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.exitCode = savedExitCode;
+    mock.restore();
+  });
+
+  test("installs from the full slashed branch when it exists on the remote", async () => {
+    remoteRefs = new Set(["main", "feat/results-viewer"]);
+
+    await runInstall(
+      "https://github.com/ZeebBoyBlue/virlo-integrations/tree/feat/results-viewer",
+    );
+
+    expect(installPluginCalls).toHaveLength(1);
+    const source = installPluginCalls[0]!.directSource as PluginFetchSource;
+    // The whole branch is the ref, and nothing is left over as a sub-path.
+    expect(source.ref).toBe("feat/results-viewer");
+    expect(source.rootPath).toBe("");
+    // With an empty sub-path the install name falls back to the repo name.
+    expect(installPluginCalls[0]!.name).toBe("virlo-integrations");
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  test("keeps ref and sub-path apart for a slashed branch plus a real sub-path", async () => {
+    remoteRefs = new Set(["feat/results-viewer"]);
+
+    await runInstall(
+      "https://github.com/ZeebBoyBlue/virlo-integrations/tree/feat/results-viewer/integrations/vellum",
+    );
+
+    const source = installPluginCalls[0]!.directSource as PluginFetchSource;
+    expect(source.ref).toBe("feat/results-viewer");
+    expect(source.rootPath).toBe("integrations/vellum");
+    // The name derives from the resolved sub-path leaf.
+    expect(installPluginCalls[0]!.name).toBe("vellum");
+  });
+
+  test("resolves to the short branch + sub-path when only that branch exists", async () => {
+    remoteRefs = new Set(["feat"]);
+
+    await runInstall("https://github.com/owner/repo/tree/feat/results-viewer");
+
+    const source = installPluginCalls[0]!.directSource as PluginFetchSource;
+    expect(source.ref).toBe("feat");
+    expect(source.rootPath).toBe("results-viewer");
+  });
+
+  test("falls back to the shortest-ref split when the remote confirms nothing", async () => {
+    remoteRefs = new Set(); // unreachable / no matching ref
+
+    await runInstall("https://github.com/owner/repo/tree/feat/results-viewer");
+
+    // Same behavior as before this fix — the install still proceeds and the
+    // clone surfaces any real not-found itself.
+    const source = installPluginCalls[0]!.directSource as PluginFetchSource;
+    expect(source.ref).toBe("feat");
+    expect(source.rootPath).toBe("results-viewer");
+  });
+});

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -1367,6 +1367,71 @@ export async function resolveRefCommit(
   return peeled ?? direct;
 }
 
+/**
+ * Confirm the real ref/path split of an ambiguous `/tree/<ref>/<path>` locator
+ * against the remote.
+ *
+ * GitHub joins the ref and sub-path after `/tree/` with a bare `/`, so a branch
+ * whose name contains slashes (`feat/results-viewer`) is indistinguishable from
+ * a shorter ref plus a leading path segment by string parsing alone. Only the
+ * remote knows which ref exists, so we list its heads and tags once with
+ * `git ls-remote` and return the first candidate whose ref is real. Candidates
+ * arrive longest-ref-first, so that first hit is the longest matching ref —
+ * exactly how GitHub itself resolves the URL. This is safe because git forbids
+ * one branch name being a path-prefix of another (a directory/file conflict in
+ * `refs/heads/`), so at most one candidate can exist.
+ *
+ * Returns `null` — signalling the caller to fall back to the parser's default
+ * (shortest-ref) split — when the remote is unreachable/offline or names none
+ * of the candidates. A genuine problem then resurfaces when the subsequent
+ * clone runs against that ref, where transient-vs-hard failures are classified.
+ */
+export async function resolveTreeRefPath<T extends { readonly ref: string }>(
+  owner: string,
+  repo: string,
+  candidates: readonly T[],
+  runGit: GitRunner = defaultGitRunner,
+): Promise<T | null> {
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const repoUrl = `https://github.com/${owner}/${repo}.git`;
+  let stdout: string;
+  try {
+    // `--heads --tags` trims pull/merge refs we'd never install from, and the
+    // explicit URL means the cwd is irrelevant — the always-present temp dir is
+    // a safe choice, mirroring {@link resolveRefCommit}.
+    ({ stdout } = await runGit(["ls-remote", "--heads", "--tags", repoUrl], {
+      cwd: tmpdir(),
+    }));
+  } catch {
+    return null;
+  }
+
+  // Each line is `<sha>\t<refname>`; collect the branch/tag short-names.
+  const existing = new Set<string>();
+  for (const line of stdout.split("\n")) {
+    const [, refName] = line.trim().split(/\s+/);
+    if (refName === undefined) {
+      continue;
+    }
+    const peeled = refName.endsWith("^{}") ? refName.slice(0, -3) : refName;
+    for (const prefix of ["refs/heads/", "refs/tags/"]) {
+      if (peeled.startsWith(prefix)) {
+        existing.add(peeled.slice(prefix.length));
+      }
+    }
+  }
+
+  for (const candidate of candidates) {
+    if (existing.has(candidate.ref)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 /** Inputs for {@link writeInstallMeta}, resolved during a fresh install. */
 interface WriteInstallMetaParams {
   readonly name: string;

--- a/assistant/src/cli/lib/parse-github-plugin-spec.ts
+++ b/assistant/src/cli/lib/parse-github-plugin-spec.ts
@@ -22,10 +22,16 @@
  *   - `github.com/<owner>/<repo>/<sub/path>`
  *   - `<owner>/<repo>[/<sub/path>]`
  *
- * The `tree`/`blob` segment is GitHub's own way of expressing a ref + sub-path;
- * when present the segment after it is the ref and the remainder is the
- * sub-path. Otherwise everything past `<owner>/<repo>` is the sub-path and the
- * ref defaults to the repository's default branch ({@link DEFAULT_DIRECT_REF}).
+ * The `tree`/`blob` segment is GitHub's own way of expressing a ref + sub-path.
+ * The two are joined by a bare `/` with no delimiter, so when the branch name
+ * itself contains slashes (`feat/results-viewer`) the boundary between ref and
+ * sub-path is ambiguous from the string alone — GitHub resolves it server-side
+ * by knowing which refs exist. This parser therefore enumerates every possible
+ * split as {@link GitHubPluginSpec.refCandidates} (longest-ref-first) and
+ * defaults `ref`/`path` to the shortest-ref split; the caller confirms the real
+ * one against the remote (see `resolveTreeRefPath` in `./install-from-github`).
+ * Otherwise everything past `<owner>/<repo>` is the sub-path and the ref
+ * defaults to the repository's default branch ({@link DEFAULT_DIRECT_REF}).
  */
 
 /**
@@ -40,20 +46,38 @@ const OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/;
 /** GitHub repo slug: alphanumerics plus `.`, `_`, `-`. */
 const REPO_RE = /^[A-Za-z0-9_.-]+$/;
 
-/** Concrete coordinates a direct GitHub install resolves to. */
-export interface GitHubPluginSpec {
-  readonly owner: string;
-  readonly repo: string;
-  /** Repo-relative directory holding the plugin root; `""` = repo root. */
-  readonly path: string;
+/**
+ * One possible split of a `/tree/<ref>/<path>` locator into a concrete ref and
+ * sub-path, plus the install name derived from that sub-path. A slashed branch
+ * name makes several splits plausible; the remote decides which is real.
+ */
+export interface GitHubRefPath {
   /** Git ref (branch, tag, or commit SHA) to fetch from. */
   readonly ref: string;
+  /** Repo-relative directory holding the plugin root; `""` = repo root. */
+  readonly path: string;
   /**
-   * Default install name derived from the locator (the sub-path leaf, or the
+   * Default install name derived from this split (the sub-path leaf, or the
    * repo name), lower-cased. May still fail {@link sanitizePluginName}, in which
    * case the caller asks the user to supply `--name`.
    */
   readonly defaultName: string;
+}
+
+/** Concrete coordinates a direct GitHub install resolves to. */
+export interface GitHubPluginSpec extends GitHubRefPath {
+  readonly owner: string;
+  readonly repo: string;
+  /**
+   * When the locator is a `/tree/<ref>/<path>` form whose ref/path boundary is
+   * ambiguous (two or more segments follow `tree`), every possible split,
+   * ordered longest-ref-first. The {@link GitHubRefPath.ref}/`path` above are
+   * the shortest-ref split — the offline default — while the caller confirms the
+   * real split against the remote by picking the first candidate whose ref
+   * exists. Absent when there is no ambiguity (a single or no post-`tree`
+   * segment, or a non-`tree` locator).
+   */
+  readonly refCandidates?: readonly GitHubRefPath[];
 }
 
 /** The locator could not be parsed as a GitHub plugin source. */
@@ -134,19 +158,66 @@ export function parseGitHubPluginSpec(input: string): GitHubPluginSpec {
   const rest = segments.slice(2);
   let ref = DEFAULT_DIRECT_REF;
   let pathSegments: string[];
+  let refCandidates: GitHubRefPath[] | undefined;
   // `/tree/<ref>/<path>` (and the equivalent `/blob/…`) is GitHub's canonical
-  // encoding of a ref + sub-path. A ref containing slashes (e.g. `feature/x`)
-  // is not expressible this way — the first segment after `tree` is taken as
-  // the whole ref — so such refs must instead be a single segment or a commit
-  // SHA. The non-`tree` form treats everything past the repo as the sub-path.
+  // encoding of a ref + sub-path, but the two are joined by a bare `/` with no
+  // delimiter — so a ref containing slashes (e.g. `feat/x`) is indistinguishable
+  // from a ref plus a leading sub-path segment. Enumerate every split so the
+  // caller can pick the real one against the remote; the shortest-ref split is
+  // the offline default. The non-`tree` form treats everything past the repo as
+  // the sub-path at the default ref.
   if (rest.length > 0 && (rest[0] === "tree" || rest[0] === "blob")) {
-    if (rest.length >= 2) ref = rest[1]!;
-    pathSegments = rest.slice(2);
+    const afterKeyword = rest.slice(1);
+    // A '.'/'..' segment can be neither a valid git ref component nor a safe
+    // sub-path, so reject it before it can appear on either side of any split.
+    assertNoDotSegments(input, afterKeyword);
+    if (afterKeyword.length === 0) {
+      // `/tree` with nothing after it: the repo root at the default ref.
+      pathSegments = [];
+    } else {
+      // Default split: the shortest ref (first segment after `tree`).
+      ref = afterKeyword[0]!;
+      pathSegments = afterKeyword.slice(1);
+      // Ambiguous only when 2+ segments follow `tree`. Enumerate every split,
+      // longest-ref-first, so resolution prefers the longer branch (GitHub's
+      // own tie-break; git forbids one branch being a path-prefix of another,
+      // so at most one candidate can actually exist on the remote).
+      if (afterKeyword.length >= 2) {
+        refCandidates = [];
+        for (let refLen = afterKeyword.length; refLen >= 1; refLen--) {
+          const candidatePath = afterKeyword.slice(refLen);
+          refCandidates.push({
+            ref: afterKeyword.slice(0, refLen).join("/"),
+            path: candidatePath.join("/"),
+            defaultName: deriveDefaultName(candidatePath, repo),
+          });
+        }
+      }
+    }
   } else {
     pathSegments = rest;
+    assertNoDotSegments(input, pathSegments);
   }
 
-  for (const seg of pathSegments) {
+  const path = pathSegments.join("/");
+  const defaultName = deriveDefaultName(pathSegments, repo);
+
+  return {
+    owner,
+    repo,
+    path,
+    ref,
+    defaultName,
+    ...(refCandidates ? { refCandidates } : {}),
+  };
+}
+
+/**
+ * Throw when any segment is `.` or `..` — a locator sub-path or ref component
+ * that could escape the repo root or is not a legal git ref.
+ */
+function assertNoDotSegments(input: string, segments: readonly string[]): void {
+  for (const seg of segments) {
     if (seg === "." || seg === "..") {
       throw new InvalidGitHubPluginSpecError(
         input,
@@ -154,10 +225,12 @@ export function parseGitHubPluginSpec(input: string): GitHubPluginSpec {
       );
     }
   }
+}
 
-  const path = pathSegments.join("/");
-  const leaf = pathSegments.at(-1) ?? repo;
-  const defaultName = leaf.toLowerCase();
-
-  return { owner, repo, path, ref, defaultName };
+/** Derive the lower-cased default install name: the sub-path leaf, or the repo. */
+function deriveDefaultName(
+  pathSegments: readonly string[],
+  repo: string,
+): string {
+  return (pathSegments.at(-1) ?? repo).toLowerCase();
 }


### PR DESCRIPTION
## Prompt / plan

Reported bug: `assistant plugins install <github-url>` fails when the branch in the URL has a slash in it (e.g. `.../tree/feat/results-viewer`).

**Root cause.** GitHub encodes a ref + sub-path after `/tree/` by joining them with a bare `/` and no delimiter. `parseGitHubPluginSpec` greedily took only the *first* segment after `tree` as the ref, so `.../tree/feat/results-viewer` parsed as ref `feat` + sub-path `results-viewer`. The clone then failed because branch `feat` doesn't exist — only `feat/results-viewer` does. This was even documented as a known limitation in the parser.

**Approach.** The ref/path boundary is genuinely ambiguous from the string alone (GitHub resolves it server-side by knowing which refs exist), so the fix defers the decision to the remote:

- `parse-github-plugin-spec.ts` now enumerates *every* possible ref/path split for an ambiguous `/tree/` locator as `refCandidates`, ordered longest-ref-first, and keeps the shortest-ref split as the offline default (preserving prior behavior).
- `install-from-github.ts` adds `resolveTreeRefPath`, which lists the remote's heads and tags once with a single `git ls-remote --heads --tags` and returns the first candidate whose ref actually exists. Preferring the longest match mirrors GitHub, and is unambiguous because git forbids one branch name being a path-prefix of another (a directory/file conflict in `refs/heads/`), so at most one candidate can exist.
- The direct-install command (`commands/plugins.ts`) resolves the split against the remote before building the install source, and derives the default plugin name from the *resolved* sub-path leaf. When the remote is unreachable it falls back to the previous shortest-ref split, and the subsequent clone surfaces any real not-found itself.

No new environment variables, routes, or dependencies. The parser stays a pure string parser; all network work lives in the git-owning module and is fully injectable for tests.

## Test plan

Unit + command-level tests, all run per-package from `assistant/`:

- `parse-github-plugin-spec.test.ts` — candidate enumeration (longest-ref-first), name derivation per split, and that unambiguous / non-`tree` locators carry no candidates. **27 pass.**
- `install-from-github.test.ts` — new `resolveTreeRefPath` suite: picks the slashed branch when it exists, falls back to the short branch + sub-path when only that exists, ignores a tag's peeled `^{}` line, returns `null` on no-match / unreachable remote, and issues exactly one `ls-remote --heads --tags` round-trip. **48 pass.**
- `plugins-install-direct-slash-branch.test.ts` (new) — drives the real `plugins install` command end-to-end with the network faked, reproducing the reported `.../tree/feat/results-viewer` case and confirming the full branch reaches the installer as the ref. **4 pass.**

Also verified: `bunx tsc --noEmit` reports 0 errors project-wide; `eslint` reports 0 errors on the changed files; Prettier formatting clean (all enforced by the pre-commit/pre-push hooks, which passed).

## CLI verb checklist

No new IPC routes added — the change is confined to the existing `assistant plugins install` command and its supporting CLI libs, so no new verb is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWUfKy4RBbr75QJer5NTna)_