### PR TITLE
fix(memory): cap lexical-index upsert payload size below Qdrant's 32 MiB limit

### DIFF
--- a/assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/messages-lexical-index.test.ts
@@ -257,6 +257,51 @@ describe("MessagesLexicalIndex", () => {
     expect(ids).toEqual([messagePointId("m1"), messagePointId("m2")]);
   });
 
+  test("upsertMessagesBatch splits a batch that would exceed Qdrant's request-size limit", async () => {
+    const index = makeIndex();
+
+    // A point's estimated serialized size is dominated by its sparse arrays.
+    // Size each point at ~10 MiB so two fit under the ~24 MiB cap but a third
+    // forces a new sub-batch — exercising both the split and multi-point
+    // sub-batches.
+    const termCount = 375_000;
+    const bigSparse: SparseEmbedding = {
+      indices: Array.from({ length: termCount }, (_, i) => i),
+      values: Array.from({ length: termCount }, () => 0.123456789),
+    };
+
+    await index.upsertMessagesBatch([
+      {
+        messageId: "m1",
+        sparse: bigSparse,
+        conversationId: "c1",
+        createdAt: 1,
+      },
+      {
+        messageId: "m2",
+        sparse: bigSparse,
+        conversationId: "c2",
+        createdAt: 2,
+      },
+      {
+        messageId: "m3",
+        sparse: bigSparse,
+        conversationId: "c3",
+        createdAt: 3,
+      },
+    ]);
+
+    // Three ~10 MiB points split into two upserts: [m1, m2] then [m3]. Every
+    // point is preserved across the sub-batches — none is dropped.
+    expect(upsertCalls.length).toBe(2);
+    expect(
+      upsertCalls[0].opts.points.map((p) => (p as { id: string }).id),
+    ).toEqual([messagePointId("m1"), messagePointId("m2")]);
+    expect(
+      upsertCalls[1].opts.points.map((p) => (p as { id: string }).id),
+    ).toEqual([messagePointId("m3")]);
+  });
+
   test("searchLexical queries the sparse named vector and returns {messageId, score}", async () => {
     mockQueryPoints = [
       { id: "pt-1", score: 0.91, payload: { message_id: "msg-A" } },

--- a/assistant/src/persistence/embeddings/messages-lexical-index.ts
+++ b/assistant/src/persistence/embeddings/messages-lexical-index.ts
@@ -48,6 +48,61 @@ export interface MessageLexicalSearchResult {
   score: number;
 }
 
+/**
+ * Qdrant rejects any HTTP request body larger than 32 MiB with a 400. A batch
+ * selected purely by row count can exceed that when messages carry large sparse
+ * vectors, so upserts are split into sub-batches whose estimated serialized size
+ * stays under this cap. Deliberately well below 32 MiB to leave headroom for the
+ * request envelope and for estimate error.
+ */
+const MAX_UPSERT_BYTES = 24 * 1024 * 1024;
+
+/**
+ * Conservative estimate of a point's JSON-serialized size, dominated by the
+ * sparse vector's parallel `indices`/`values` arrays (`indices.length ===
+ * values.length`). Overestimating is the safe direction: it yields smaller
+ * sub-batches, never a request larger than intended.
+ */
+function estimateUpsertPointBytes(sparseTermCount: number): number {
+  // One index integer (~8 bytes with delimiter) plus one float value (~20
+  // bytes with delimiter) per term.
+  const PER_TERM_BYTES = 28;
+  // Point id (uuid), payload keys/values, and structural punctuation.
+  const FIXED_OVERHEAD_BYTES = 350;
+  return sparseTermCount * PER_TERM_BYTES + FIXED_OVERHEAD_BYTES;
+}
+
+/**
+ * Split sparse points into sub-batches whose combined estimated size stays
+ * under {@link MAX_UPSERT_BYTES}. A single point larger than the cap is emitted
+ * alone (it cannot be split) so no data is silently dropped.
+ */
+function* chunkPointsBySparseSize<
+  T extends { vector: { sparse: { indices: number[] } } },
+>(points: T[]): Generator<T[]> {
+  let current: T[] = [];
+  let currentBytes = 0;
+  for (const point of points) {
+    const size = estimateUpsertPointBytes(point.vector.sparse.indices.length);
+    if (current.length > 0 && currentBytes + size > MAX_UPSERT_BYTES) {
+      yield current;
+      current = [];
+      currentBytes = 0;
+    }
+    if (current.length === 0 && size > MAX_UPSERT_BYTES) {
+      log.warn(
+        { estimatedBytes: size, maxBytes: MAX_UPSERT_BYTES },
+        "Single lexical point exceeds the Qdrant upsert size cap — sending it alone",
+      );
+    }
+    current.push(point);
+    currentBytes += size;
+  }
+  if (current.length > 0) {
+    yield current;
+  }
+}
+
 let _instance: MessagesLexicalIndex | null = null;
 
 export function getMessagesLexicalIndex(): MessagesLexicalIndex {
@@ -192,6 +247,24 @@ export class MessagesLexicalIndex {
       },
     }));
 
+    // Split into size-bounded sub-batches so no single upsert exceeds Qdrant's
+    // 32 MiB request-body limit — a row-count batch of large messages can.
+    for (const chunk of chunkPointsBySparseSize(qdrantPoints)) {
+      await this.upsertPointsChunk(chunk);
+    }
+  }
+
+  private async upsertPointsChunk(
+    qdrantPoints: Array<{
+      id: string;
+      vector: { sparse: { indices: number[]; values: number[] } };
+      payload: {
+        message_id: string;
+        conversation_id: string;
+        created_at: number;
+      };
+    }>,
+  ): Promise<void> {
     const doUpsert = () =>
       this.client.upsert(this.collection, {
         wait: true,


### PR DESCRIPTION
## Prompt / plan

A user reported a 0.10.10 startup failure: the `backfill_lexical_index` job batches 200 messages by **row count** with no cap on payload size. A batch of large messages carries large sparse vectors, so a single upsert can exceed Qdrant's **32 MiB** HTTP request-body limit → HTTP 400 → the backfill job fails (~38.7 MiB upsert observed). The user rolled back to 0.10.3 to recover.

### Approach

The fix lives in `MessagesLexicalIndex.upsertMessagesBatch` — the shared primitive that owns the Qdrant HTTP interaction and therefore owns the 32 MiB request-body limit. Rather than teach the backfill about Qdrant's wire limit, `upsertMessagesBatch` now splits any batch into size-bounded sub-batches, so **every** caller is protected, not just the backfill:

- `MAX_UPSERT_BYTES = 24 MiB` — deliberately well under 32 MiB to leave headroom for the request envelope and estimate error.
- Per-point size is estimated conservatively from the sparse vector's term count (its dominant contributor). Overestimating is the safe direction — smaller sub-batches, never a larger request than intended.
- A lone point larger than the cap is still sent (never silently dropped), with a warning logged.
- The existing collection-missing retry logic is preserved per sub-batch (extracted into `upsertPointsChunk`).

The backfill's `BATCH_SIZE = 200` cursor stride is unchanged — it still advances 200 rows per job invocation, just upserting them in size-safe chunks underneath.

## Test plan

- New unit test in `messages-lexical-index.test.ts`: three ~10 MiB points split into two upserts (`[m1, m2]` then `[m3]`), verifying both the split and that no point is dropped across sub-batches.
- `bun test src/persistence/embeddings/__tests__/messages-lexical-index.test.ts` — 15 pass.
- `bun test src/persistence/job-handlers/__tests__/message-lexical-backfill.test.ts` — 15 pass (backfill unaffected).
- `bun run typecheck:fast` — clean.
- Prettier + ESLint clean on changed files (the 4 remaining `curly` warnings are pre-existing, on lines untouched by this change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8Qb5z41AFrgx9sPbAUfcf)_