### PR TITLE
fix(assistant): capture Qdrant stdout so startup failures are diagnosable

### DIFF
--- a/assistant/src/__tests__/qdrant-manager.test.ts
+++ b/assistant/src/__tests__/qdrant-manager.test.ts
@@ -357,6 +357,25 @@ describe("QdrantManager", () => {
       // THEN the error includes the stderr output
       await expect(mgr.start()).rejects.toThrow("storage corrupted");
     }, 10_000);
+
+    test("includes stdout in error when process crashes", async () => {
+      // GIVEN a binary that reports its failure on stdout, as Qdrant does for
+      // panics, while stderr carries only unrelated allocator noise
+      placeFakeBinary(
+        '#!/bin/sh\necho "<jemalloc>: option background_thread currently supports pthread only" >&2\n' +
+          'echo "Panic occurred: Failed to load local shard"\nexit 101',
+      );
+
+      const port = getTestPort();
+      const mgr = new QdrantManager({
+        url: `http://127.0.0.1:${port}`,
+        ...FAST_TIMEOUTS,
+      });
+
+      // WHEN we start the manager
+      // THEN the error carries the stdout explanation, not just the noise
+      await expect(mgr.start()).rejects.toThrow("Failed to load local shard");
+    }, 10_000);
   });
 
   // ── Binary Detection ─────────────────────────────────────────

--- a/assistant/src/persistence/embeddings/qdrant-manager.ts
+++ b/assistant/src/persistence/embeddings/qdrant-manager.ts
@@ -26,6 +26,13 @@ const READYZ_POLL_INTERVAL_MS = 200;
 const READYZ_TIMEOUT_MS = 30_000;
 const SHUTDOWN_GRACE_MS = 5_000;
 
+// Qdrant routes its own logging to stdout, including the panic reports its
+// panic hook emits on a failed start. Stderr only ever carries the jemalloc
+// allocator notice printed before Qdrant's logging initializes, so stdout is
+// where a startup failure actually explains itself and needs the larger cap.
+const STDOUT_CAPTURE_LIMIT = 16_384;
+const STDERR_CAPTURE_LIMIT = 4_096;
+
 export interface QdrantManagerConfig {
   url: string;
   storagePath?: string;
@@ -50,8 +57,9 @@ export interface QdrantManagerConfig {
  */
 export class QdrantManager {
   private process: Subprocess | null = null;
+  private stdoutBuffer = "";
   private stderrBuffer = "";
-  private stderrDrained: Promise<void> = Promise.resolve();
+  private outputDrained: Promise<void> = Promise.resolve();
   private readonly url: string;
   private readonly host: string;
   private readonly port: number;
@@ -116,11 +124,11 @@ export class QdrantManager {
         QDRANT__STORAGE__STORAGE_PATH: this.storagePath,
         QDRANT__LOG_LEVEL: "WARN",
       },
-      stdout: "ignore",
+      stdout: "pipe",
       stderr: "pipe",
     });
     this.process = proc;
-    this.drainStderrFrom(proc.stderr);
+    this.drainOutputFrom(proc.stdout, proc.stderr);
 
     if (this.process.pid) {
       this.writePid(this.process.pid);
@@ -160,6 +168,7 @@ export class QdrantManager {
     }
 
     this.process = null;
+    this.stdoutBuffer = "";
     this.stderrBuffer = "";
     this.cleanupPid();
     log.info("Qdrant stopped");
@@ -282,11 +291,10 @@ export class QdrantManager {
         : new Promise<ExitedOutcome>(() => {});
 
     const throwOnExit = async (code: number): Promise<never> => {
-      await this.stderrDrained;
-      const stderr = this.stderrBuffer.trim();
+      await this.outputDrained;
       throw new Error(
         `Qdrant process exited with code ${code} before becoming ready` +
-          (stderr ? `\nstderr:\n${stderr}` : ""),
+          this.formatCapturedOutput(),
       );
     };
 
@@ -314,30 +322,68 @@ export class QdrantManager {
       ]);
       if (sleepOutcome.type === "exited") await throwOnExit(sleepOutcome.code);
     }
-    const stderr = this.stderrBuffer.trim();
     throw new Error(
       `Qdrant did not become ready within ${this.readyzTimeoutMs}ms at ${this.url}` +
-        (stderr ? `\nstderr:\n${stderr}` : ""),
+        this.formatCapturedOutput(),
     );
   }
 
-  private drainStderrFrom(stream: ReadableStream<Uint8Array>): void {
+  private drainOutputFrom(
+    stdout: ReadableStream<Uint8Array>,
+    stderr: ReadableStream<Uint8Array>,
+  ): void {
+    // Both streams must be drained for the lifetime of the process, not just
+    // until startup settles. An unread pipe fills and then blocks Qdrant on its
+    // next write.
+    this.outputDrained = Promise.all([
+      this.drainStream(stdout, STDOUT_CAPTURE_LIMIT, (text) => {
+        this.stdoutBuffer = text;
+      }),
+      this.drainStream(stderr, STDERR_CAPTURE_LIMIT, (text) => {
+        this.stderrBuffer = text;
+      }),
+    ]).then(() => undefined);
+  }
+
+  /**
+   * Accumulates a stream into a bounded buffer, keeping the most recent
+   * `limit` characters. Qdrant prints the panic reason after the backtrace, so
+   * retaining the tail keeps the explanation and drops the frames above it.
+   */
+  private async drainStream(
+    stream: ReadableStream<Uint8Array>,
+    limit: number,
+    assign: (text: string) => void,
+  ): Promise<void> {
     const reader = stream.getReader();
     const decoder = new TextDecoder();
-    this.stderrDrained = (async () => {
-      try {
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          this.stderrBuffer += decoder.decode(value, { stream: true });
-          if (this.stderrBuffer.length > 4096) {
-            this.stderrBuffer = this.stderrBuffer.slice(-4096);
-          }
+    let buffer = "";
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.length > limit) {
+          buffer = buffer.slice(-limit);
         }
-      } catch {
-        // Stream closed or error — expected during shutdown
+        assign(buffer);
       }
-    })();
+    } catch {
+      // Stream closed or errored, which is expected during shutdown
+    }
+  }
+
+  /**
+   * Renders whatever Qdrant printed for attachment to a startup error. Stdout
+   * leads because that is where Qdrant explains itself.
+   */
+  private formatCapturedOutput(): string {
+    const stdout = this.stdoutBuffer.trim();
+    const stderr = this.stderrBuffer.trim();
+    return (
+      (stdout ? `\nstdout:\n${stdout}` : "") +
+      (stderr ? `\nstderr:\n${stderr}` : "")
+    );
   }
 
   private getBinaryPath(): string {


### PR DESCRIPTION
Qdrant writes its own logging to stdout, including the panic reports from its panic hook. We spawned it with `stdout: "ignore"` and built the startup error from stderr alone. On macOS stderr carries nothing but a benign jemalloc notice, so every failed start looked like this:

```
Qdrant process exited with code 101 before becoming ready
stderr:
<jemalloc>: option background_thread currently supports pthread only
```

The actual cause was written to stdout and discarded. Now both streams are piped and attached to the error:

```
Qdrant process exited with code 101 before becoming ready
stdout:
ERROR qdrant::startup: Panic occurred in ... replica_set/mod.rs at line 301:
Failed to load local shard ".../collections/testcol/0": Service internal error:
RocksDB open error: Corruption: no log_file_number ... MANIFEST-000005 may be corrupted.
stderr:
<jemalloc>: option background_thread currently supports pthread only
```

Buffers keep the tail, since Qdrant prints the panic reason after the backtrace. Stdout gets 16 KiB because it carries the backtrace; stderr stays at 4 KiB.

Note the jemalloc line is benign and unrelated. It prints on every Apple Silicon start because Qdrant's baked-in allocator config requests a feature macOS builds don't have, and Qdrant runs fine regardless. ATL-1050 is filed as an arm64 incompatibility on that basis; it isn't one.

Refs ATL-1050.