### PR TITLE
feat(memory): add scheduled sweep to catch conversations with unprocessed messages

### DIFF
--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -65,6 +65,19 @@ export const MemoryRetrospectiveConfigSchema = z
       .describe(
         "Optional path to a file whose contents replace the bundled retrospective fork-instruction prompt. Relative paths resolve under the workspace root; absolute paths and a leading `~/` (expanded to the home directory) are honored only when they still resolve inside the workspace root — a path that lands outside the workspace (including via symlinks) is rejected. The loaded contents may include `{{AVAILABLE_TOOLS_LINE}}`, `{{WINDOW_ANCHOR}}`, `{{ALREADY_REMEMBERED}}`, and `{{SKILL_AUTHORING_SECTION}}`, which are substituted at runtime. If the file is rejected, missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
       ),
+
+    sweepIntervalMs: z
+      .number({
+        error: "memory.retrospective.sweepIntervalMs must be a number",
+      })
+      .int("memory.retrospective.sweepIntervalMs must be an integer")
+      .positive(
+        "memory.retrospective.sweepIntervalMs must be a positive integer",
+      )
+      .default(8 * 60 * 60 * 1000)
+      .describe(
+        "Milliseconds between scheduled sweep passes that find conversations with unprocessed messages and enqueue retrospective jobs. Supplements the turn-end trigger so memory quality does not depend on clean turn completions. Runs on each idle/drain worker tick after the interval elapses.",
+      ),
   })
   .describe(
     "Controls the memory-retrospective background pass. Model selection lives under llm.callSites.memoryRetrospective.",

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -816,23 +816,31 @@ export function maybeEnqueueScheduledCleanupJobs(
 
 /**
  * Max conversations examined per sweep pass. Keeps the per-tick DB load
- * bounded even on instances with large conversation histories; the stalest-
- * first ordering ensures every conversation is eventually reached across
- * successive passes.
+ * bounded even on instances with large conversation histories; the cursor
+ * checkpoint advances through the full set across successive passes.
  */
 export const RETRO_SWEEP_BATCH_LIMIT = 50;
 
 /**
- * Walk the `limit` stalest conversations and enqueue a retrospective for each
- * one that has unprocessed messages and is past its cooldown. Runs on the
- * cadence set by `config.memory.retrospective.sweepIntervalMs` (default 8h),
- * using a durable checkpoint so the cadence survives daemon restarts.
+ * Walk up to `RETRO_SWEEP_BATCH_LIMIT` conversations (paginated via a durable
+ * cursor) and enqueue a retrospective for each one that has unprocessed
+ * messages and is past its cooldown. Runs on the cadence set by
+ * `config.memory.retrospective.sweepIntervalMs` (default 8h).
  *
  * This is the catch-all backstop for turns that ended without firing the
  * normal turn-end trigger (crash, IPC drop, early exit). It never fires
  * duplicate jobs — `upsertMemoryRetrospectiveJob` coalesces rapid enqueues
  * per conversation — and it respects the same cooldown as the turn-end path
  * so it cannot spin a tight retry loop.
+ *
+ * Two durable checkpoints drive this function:
+ *   - `retro_sweep:last_run`  — epoch-ms timestamp of the last sweep start.
+ *     Seeded to `nowMs` on first startup so the first actual sweep fires a
+ *     full interval later (matches the PKB/cleanup no-LLM-work-at-boot rule).
+ *   - `retro_sweep:cursor`    — last conversation id examined. Advances by
+ *     `RETRO_SWEEP_BATCH_LIMIT` per sweep pass so the full conversation list
+ *     is eventually covered even when many candidates have no new messages.
+ *     Resets to "" when the end of the list is reached.
  *
  * Returns the number of retrospective jobs enqueued this pass.
  */
@@ -841,21 +849,47 @@ export function maybeEnqueueRetrospectiveSweepJobs(
   nowMs = Date.now(),
 ): number {
   const sweepIntervalMs = config.memory.retrospective.sweepIntervalMs;
-  const lastRun = parseInt(
-    getMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweep) ?? "0",
-    10,
+  const rawCheckpoint = getMemoryCheckpoint(
+    GRAPH_MAINTENANCE_CHECKPOINTS.retroSweep,
   );
+
+  // Seed to nowMs on first startup (missing checkpoint) so the first actual
+  // sweep fires after a full interval, matching the PKB and cleanup schedule
+  // patterns — no LLM-backed retrospective jobs should fire at boot.
+  if (rawCheckpoint === null) {
+    setMemoryCheckpoint(
+      GRAPH_MAINTENANCE_CHECKPOINTS.retroSweep,
+      String(nowMs),
+    );
+    return 0;
+  }
+
+  const lastRun = parseInt(rawCheckpoint, 10);
   if (nowMs - lastRun < sweepIntervalMs) {
     return 0;
   }
 
   setMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweep, String(nowMs));
 
-  const minCooldownMs = config.memory.retrospective.minCooldownMs;
+  // Advance the cursor so each sweep pass covers a different window of
+  // conversations. Without a cursor, the query always returns the same top-N
+  // rows and conversations beyond index N are never examined.
+  const cursor =
+    getMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweepCursor) ?? "";
   const candidates = listConversationsNeedingRetrospective(
     RETRO_SWEEP_BATCH_LIMIT,
+    cursor,
   );
 
+  // Advance or reset the cursor. < limit means we reached the end of the list.
+  if (candidates.length < RETRO_SWEEP_BATCH_LIMIT) {
+    setMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweepCursor, "");
+  } else {
+    const lastId = candidates[candidates.length - 1]!.conversationId;
+    setMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweepCursor, lastId);
+  }
+
+  const minCooldownMs = config.memory.retrospective.minCooldownMs;
   let enqueued = 0;
   for (const {
     conversationId,
@@ -878,7 +912,7 @@ export function maybeEnqueueRetrospectiveSweepJobs(
 
   if (enqueued > 0) {
     log.info(
-      { enqueued, candidates: candidates.length },
+      { enqueued, candidates: candidates.length, cursor },
       "Retrospective sweep enqueued jobs",
     );
   }
@@ -909,6 +943,7 @@ export const GRAPH_MAINTENANCE_CHECKPOINTS = {
   pkbFiling: "pkb_filing_last_run",
   pkbCompaction: "pkb_compaction_last_run",
   retroSweep: "retro_sweep:last_run",
+  retroSweepCursor: "retro_sweep:cursor",
 } as const;
 
 /**

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -59,7 +59,10 @@ import {
 } from "../../../persistence/jobs-store.js";
 import type { JobHandler } from "../../types.js";
 import { getLogger } from "./logging.js";
+import { countRetrospectiveMessagesAfter } from "./memory-retrospective-accounting.js";
+import { enqueueMemoryRetrospectiveIfEnabled } from "./memory-retrospective-enqueue.js";
 import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
+import { listConversationsNeedingRetrospective } from "./memory-retrospective-state.js";
 import { getWorkspaceDir } from "./paths.js";
 import { hasPkbBufferContent } from "./pkb-schedule.js";
 import {
@@ -381,6 +384,7 @@ export async function runMemoryJobsOnce(
     }
     maybeEnqueueGraphMaintenanceJobs(config);
     if (memoryEnabled) {
+      maybeEnqueueRetrospectiveSweepJobs(config);
       await maybeRunDbMaintenance();
       await maybeRunPassiveWalCheckpoint();
     }
@@ -449,6 +453,9 @@ export async function runMemoryJobsOnce(
     maybeEnqueueScheduledCleanupJobs(config);
   }
   maybeEnqueueGraphMaintenanceJobs(config);
+  if (memoryEnabled) {
+    maybeEnqueueRetrospectiveSweepJobs(config);
+  }
   await maybeRunDbMaintenance();
   await maybeRunPassiveWalCheckpoint();
   return slowProcessed + fastProcessed + embedProcessed;
@@ -805,6 +812,80 @@ export function maybeEnqueueScheduledCleanupJobs(
   return enqueuedAny;
 }
 
+// ── Retrospective sweep scheduling ────────────────────────────────
+
+/**
+ * Max conversations examined per sweep pass. Keeps the per-tick DB load
+ * bounded even on instances with large conversation histories; the stalest-
+ * first ordering ensures every conversation is eventually reached across
+ * successive passes.
+ */
+export const RETRO_SWEEP_BATCH_LIMIT = 50;
+
+/**
+ * Walk the `limit` stalest conversations and enqueue a retrospective for each
+ * one that has unprocessed messages and is past its cooldown. Runs on the
+ * cadence set by `config.memory.retrospective.sweepIntervalMs` (default 8h),
+ * using a durable checkpoint so the cadence survives daemon restarts.
+ *
+ * This is the catch-all backstop for turns that ended without firing the
+ * normal turn-end trigger (crash, IPC drop, early exit). It never fires
+ * duplicate jobs — `upsertMemoryRetrospectiveJob` coalesces rapid enqueues
+ * per conversation — and it respects the same cooldown as the turn-end path
+ * so it cannot spin a tight retry loop.
+ *
+ * Returns the number of retrospective jobs enqueued this pass.
+ */
+export function maybeEnqueueRetrospectiveSweepJobs(
+  config: AssistantConfig,
+  nowMs = Date.now(),
+): number {
+  const sweepIntervalMs = config.memory.retrospective.sweepIntervalMs;
+  const lastRun = parseInt(
+    getMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweep) ?? "0",
+    10,
+  );
+  if (nowMs - lastRun < sweepIntervalMs) {
+    return 0;
+  }
+
+  setMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweep, String(nowMs));
+
+  const minCooldownMs = config.memory.retrospective.minCooldownMs;
+  const candidates = listConversationsNeedingRetrospective(
+    RETRO_SWEEP_BATCH_LIMIT,
+  );
+
+  let enqueued = 0;
+  for (const {
+    conversationId,
+    lastProcessedMessageId,
+    lastRunAt,
+  } of candidates) {
+    if (nowMs - lastRunAt < minCooldownMs) {
+      continue;
+    }
+    const newMessages = countRetrospectiveMessagesAfter(
+      conversationId,
+      lastProcessedMessageId,
+    );
+    if (newMessages === 0) {
+      continue;
+    }
+    enqueueMemoryRetrospectiveIfEnabled({ conversationId, trigger: "sweep" });
+    enqueued += 1;
+  }
+
+  if (enqueued > 0) {
+    log.info(
+      { enqueued, candidates: candidates.length },
+      "Retrospective sweep enqueued jobs",
+    );
+  }
+
+  return enqueued;
+}
+
 // ── Graph maintenance scheduling ──────────────────────────────────
 
 const GRAPH_DECAY_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
@@ -827,6 +908,7 @@ export const GRAPH_MAINTENANCE_CHECKPOINTS = {
   memoryV3Maintain: "memory_v3_maintain_last_run",
   pkbFiling: "pkb_filing_last_run",
   pkbCompaction: "pkb_compaction_last_run",
+  retroSweep: "retro_sweep:last_run",
 } as const;
 
 /**

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
@@ -35,7 +35,8 @@ export type MemoryRetrospectiveTrigger =
   | "interval"
   | "message_count"
   | "compaction"
-  | "lifecycle";
+  | "lifecycle"
+  | "sweep";
 
 const COMPACTION_DEBOUNCE_MS = 500;
 
@@ -99,7 +100,9 @@ export function isMemoryRetrospectiveConversation(
  */
 function isLowYieldRetrospectiveSource(conversationId: string): boolean {
   const conversation = getConversation(conversationId);
-  if (!conversation) return false;
+  if (!conversation) {
+    return false;
+  }
   return (
     conversation.conversationType === "scheduled" ||
     conversation.source === MEMORY_V2_CONSOLIDATION_SOURCE

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
@@ -23,7 +23,7 @@
 // The schema enforces the foreign key with ON DELETE CASCADE, so deleting a
 // conversation collects its state row automatically.
 
-import { and, asc, desc, eq, isNull, ne, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, isNull, ne, notInArray } from "drizzle-orm";
 
 import { type DrizzleDb, getDb } from "../../../persistence/db-connection.js";
 import {
@@ -141,9 +141,14 @@ export interface ConversationSweepEntry {
 }
 
 /**
- * Return up to `limit` active, non-excluded conversations ordered by how long
- * ago their last retrospective ran (stalest first). Conversations with no
- * state row (never retro'd) sort to the front (their implicit lastRunAt is 0).
+ * Return up to `limit` active, non-excluded conversations in stable id-order,
+ * starting strictly after `afterConversationId` (the sweep cursor). An empty
+ * `afterConversationId` starts from the beginning of the list.
+ *
+ * Id-ordering with a cursor lets the caller page through the FULL conversation
+ * set across successive sweep passes. A stalest-first ordering without a cursor
+ * would permanently pin zero-work rows at the front of the query, so
+ * conversations beyond the batch limit could never be examined.
  *
  * Used by the scheduled sweep in jobs-worker.ts to find conversations that may
  * have unprocessed messages regardless of whether a turn-end trigger fired.
@@ -153,6 +158,7 @@ export interface ConversationSweepEntry {
  */
 export function listConversationsNeedingRetrospective(
   limit: number,
+  afterConversationId = "",
 ): ConversationSweepEntry[] {
   const db = getDb();
   const rows = db
@@ -171,9 +177,12 @@ export function listConversationsNeedingRetrospective(
         ne(conversations.conversationType, "scheduled"),
         notInArray(conversations.source, [...SWEEP_EXCLUDED_SOURCES]),
         isNull(conversations.archivedAt),
+        ...(afterConversationId
+          ? [gt(conversations.id, afterConversationId)]
+          : []),
       ),
     )
-    .orderBy(asc(sql`COALESCE(${memoryRetrospectiveState.lastRunAt}, 0)`))
+    .orderBy(asc(conversations.id))
     .limit(limit)
     .all();
 

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
@@ -23,11 +23,19 @@
 // The schema enforces the foreign key with ON DELETE CASCADE, so deleting a
 // conversation collects its state row automatically.
 
-import { desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, ne, notInArray, sql } from "drizzle-orm";
 
 import { type DrizzleDb, getDb } from "../../../persistence/db-connection.js";
-import { memoryRetrospectiveState } from "../../../persistence/schema/index.js";
+import {
+  conversations,
+  memoryRetrospectiveState,
+} from "../../../persistence/schema/index.js";
 import { withSqliteRetry } from "./host-utils.js";
+import {
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
+  MEMORY_RETROSPECTIVE_SOURCE,
+} from "./memory-retrospective-constants.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "./v3/substrate/constants.js";
 
 export interface MemoryRetrospectiveState {
   conversationId: string;
@@ -74,10 +82,14 @@ export function appendToRememberedLog(
 }
 
 function parseRememberedLog(raw: string | null): string[] {
-  if (!raw) return [];
+  if (!raw) {
+    return [];
+  }
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
     return parsed.filter((entry): entry is string => typeof entry === "string");
   } catch {
     return [];
@@ -109,6 +121,70 @@ export function listRetrospectiveStates(
 }
 
 /**
+ * Conversation source values that are excluded from the retrospective sweep.
+ * Mirrors `isMemoryRetrospectiveConversation` and `isLowYieldRetrospectiveSource`
+ * in the enqueue helper — only string-valued so we can push them into a SQL
+ * `NOT IN` predicate without loading and filtering in application code.
+ */
+const SWEEP_EXCLUDED_SOURCES = [
+  MEMORY_RETROSPECTIVE_SOURCE,
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
+  MEMORY_V2_CONSOLIDATION_SOURCE,
+] as const;
+
+export interface ConversationSweepEntry {
+  conversationId: string;
+  /** `null` when no state row exists (conversation has never been retro'd). */
+  lastProcessedMessageId: string | null;
+  /** `0` when no state row exists. */
+  lastRunAt: number;
+}
+
+/**
+ * Return up to `limit` active, non-excluded conversations ordered by how long
+ * ago their last retrospective ran (stalest first). Conversations with no
+ * state row (never retro'd) sort to the front (their implicit lastRunAt is 0).
+ *
+ * Used by the scheduled sweep in jobs-worker.ts to find conversations that may
+ * have unprocessed messages regardless of whether a turn-end trigger fired.
+ * Archived and scheduled conversations are excluded; retrospective and
+ * consolidation background conversations are excluded (mirrors the recursion
+ * guard in `enqueueMemoryRetrospectiveIfEnabled`).
+ */
+export function listConversationsNeedingRetrospective(
+  limit: number,
+): ConversationSweepEntry[] {
+  const db = getDb();
+  const rows = db
+    .select({
+      conversationId: conversations.id,
+      lastProcessedMessageId: memoryRetrospectiveState.lastProcessedMessageId,
+      lastRunAt: memoryRetrospectiveState.lastRunAt,
+    })
+    .from(conversations)
+    .leftJoin(
+      memoryRetrospectiveState,
+      eq(conversations.id, memoryRetrospectiveState.conversationId),
+    )
+    .where(
+      and(
+        ne(conversations.conversationType, "scheduled"),
+        notInArray(conversations.source, [...SWEEP_EXCLUDED_SOURCES]),
+        isNull(conversations.archivedAt),
+      ),
+    )
+    .orderBy(asc(sql`COALESCE(${memoryRetrospectiveState.lastRunAt}, 0)`))
+    .limit(limit)
+    .all();
+
+  return rows.map((row) => ({
+    conversationId: row.conversationId,
+    lastProcessedMessageId: row.lastProcessedMessageId ?? null,
+    lastRunAt: row.lastRunAt ?? 0,
+  }));
+}
+
+/**
  * Load the state row for a conversation, or `null` if no row exists.
  */
 export function getRetrospectiveState(
@@ -119,7 +195,9 @@ export function getRetrospectiveState(
     .from(memoryRetrospectiveState)
     .where(eq(memoryRetrospectiveState.conversationId, conversationId))
     .get();
-  if (!row) return null;
+  if (!row) {
+    return null;
+  }
   return {
     conversationId: row.conversationId,
     lastProcessedMessageId: row.lastProcessedMessageId,
@@ -216,7 +294,9 @@ export function forkRetrospectiveState(args: {
     .from(memoryRetrospectiveState)
     .where(eq(memoryRetrospectiveState.conversationId, sourceConversationId))
     .get();
-  if (!sourceRow) return;
+  if (!sourceRow) {
+    return;
+  }
 
   let forkedPointer = "";
   if (sourceRow.lastProcessedMessageId !== "") {


### PR DESCRIPTION
The retrospective system previously relied solely on turn-end triggers to enqueue `memory_retrospective` jobs. Turns that ended without firing the trigger (crash, IPC drop, early exit) would leave messages permanently unprocessed until the next turn in that conversation.

This adds a cron-style backstop that runs on each idle worker tick after a configurable interval (default 8h). The sweep:
  - Queries all non-excluded conversations ordered by stalest lastRunAt first (LEFT JOIN so never-retro'd conversations sort to the front)
  - Skips any conversation still inside its cooldown window
  - Counts unprocessed messages via the existing kind-aware accounting helper (excludes skill-card rows)
  - Enqueues via the standard upsert path, which coalesces rapid enqueues and deduplicates against any already-pending job for the same conversation

Changes:
  - memory-retrospective.ts: add `sweepIntervalMs` config (default 8h)
  - memory-retrospective-enqueue.ts: add "sweep" to MemoryRetrospectiveTrigger
  - memory-retrospective-state.ts: add `listConversationsNeedingRetrospective` with a drizzle LEFT JOIN + excluded-source filter
  - jobs-worker.ts: add `maybeEnqueueRetrospectiveSweepJobs` + checkpoint key `retro_sweep:last_run`; call it from `runMemoryJobsOnce` on both the idle (no claimed jobs) and drain paths, gated on `memoryEnabled`

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
