### PR TITLE
fix(providers): stop dropping the stored override profile when a caller names its call site

### DIFF
--- a/assistant/src/__tests__/provider-send-message-override-profile.test.ts
+++ b/assistant/src/__tests__/provider-send-message-override-profile.test.ts
@@ -98,6 +98,72 @@ describe("SendMessageOptions.config.overrideProfile", () => {
     expect(captured?.config?.callSite).toBe("conversationTitle");
   });
 
+  test("CallSiteConfiguredProvider forwards its stored overrideProfile when the caller sets callSite", async () => {
+    let captured: SendMessageOptions | undefined;
+    const inner: Provider = {
+      name: "anthropic",
+      async sendMessage(
+        _messages: Message[],
+        options?: SendMessageOptions,
+      ): Promise<ProviderResponse> {
+        captured = options;
+        return makeResponse("anthropic");
+      },
+    };
+
+    const provider = new CallSiteConfiguredProvider(
+      inner,
+      "inference",
+      "byok-sonnet",
+    );
+    await provider.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "inference" },
+    });
+
+    // Naming a call site must not opt the caller out of profile propagation:
+    // the two fields are independent, and downstream resolution reads the
+    // override off the config it is handed.
+    expect(captured?.config?.overrideProfile).toBe("byok-sonnet");
+  });
+
+  test("a profile-pinned send resolves the profile's model, not the call-site default", async () => {
+    setLlmConfig({
+      profiles: {
+        "balanced-together": {
+          provider: "together",
+          model: "moonshotai/Kimi-K2-Instruct",
+        },
+      },
+    });
+
+    let captured: Record<string, unknown> | undefined;
+    const inner: Provider = {
+      name: "together",
+      async sendMessage(
+        _messages: Message[],
+        options?: SendMessageOptions,
+      ): Promise<ProviderResponse> {
+        captured = options?.config as Record<string, unknown> | undefined;
+        return makeResponse("together");
+      },
+    };
+
+    const provider = new CallSiteConfiguredProvider(
+      new RetryProvider(inner),
+      "inference",
+      "balanced-together",
+    );
+    await provider.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "inference" },
+    });
+
+    // Losing the override strands a Together connection on the `inference`
+    // call-site default (`cost-optimized`), whose model is a Fireworks id —
+    // the provider half stays correct, so the upstream 400 names a model the
+    // caller never chose.
+    expect(captured?.model).toBe("moonshotai/Kimi-K2-Instruct");
+  });
+
   test("RetryProvider resolves model from named profile when overrideProfile is set", async () => {
     setLlmConfig({
       profiles: {

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -77,15 +77,15 @@ export class CallSiteConfiguredProvider implements Provider {
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
     const config = options?.config;
-    if (config?.callSite) {
-      return this.inner.sendMessage(messages, options);
-    }
-
+    // Each field falls back independently. Naming a call site per-call must
+    // not suppress the stored override — they are orthogonal, and dropping
+    // the override leaves the transport bound to the requested profile while
+    // the model resolves from the call-site default.
     return this.inner.sendMessage(messages, {
       ...options,
       config: {
         ...config,
-        callSite: this.callSite,
+        callSite: config?.callSite ?? this.callSite,
         ...(config?.overrideProfile === undefined &&
         this.overrideProfile !== undefined
           ? { overrideProfile: this.overrideProfile }


### PR DESCRIPTION
## Problem

A profile-pinned request dispatches the **right provider** with the **wrong model**.

`CallSiteConfiguredProvider.sendMessage` returned early whenever the caller supplied `config.callSite`:

```ts
const config = options?.config;
if (config?.callSite) {
  return this.inner.sendMessage(messages, options);   // passes through untouched
}
// only here does it stamp callSite + overrideProfile
```

`callSite` and `overrideProfile` are independent fields, but the check on one skipped the stamping of the other. Naming a call site per-call silently opted the caller out of profile propagation.

That splits resolution across two sources:

| | resolved from | result |
|---|---|---|
| provider / connection | `overrideProfile`, captured at construction | correct |
| model | `callSite` alone, via `retry.ts` → `resolveCallSiteConfig` | **call-site default** |

`CALL_SITE_DEFAULTS.inference` is `cost-optimized`, whose model is a Fireworks id. So a Together-backed profile sent a Fireworks model name over a Together connection:

```
Together AI API error (400): Model 'accounts/fireworks/models/deepseek-v4-flash' is not yet supported
```

The same shape hits Anthropic as a 404 naming the model while the key authenticates fine — which is what makes this read as upstream model injection rather than a local resolution bug. Nothing is injected: `cost-optimized` is our own Speed profile, reached because the requested one was forgotten.

## Fix

Each field falls back independently. An explicit per-call `callSite` still wins; it just no longer suppresses the override.

```diff
-    if (config?.callSite) {
-      return this.inner.sendMessage(messages, options);
-    }
-        callSite: this.callSite,
+        callSite: config?.callSite ?? this.callSite,
```

## Why in the wrapper

Three call sites already hit this trap and each worked around it locally by re-passing `overrideProfile`: `workflows/leaf-runner.ts` (whose comment describes the trap in full), AgentLoop's tool path, and #38472 for the inference route. Fixing the wrapper closes it for callers that haven't been written yet. #38472's explicit pass-through becomes redundant but stays correct — caller still wins per-field — so nothing needs reverting.

## Tests

Two cases added to the existing override-profile suite, both failing on `main` before this change:

- the wrapper forwards its stored `overrideProfile` when the caller sets `callSite`
- a profile-pinned send resolves the profile's model, not the call-site default — this one reproduces the reported failure exactly:

```
Expected: "moonshotai/Kimi-K2-Instruct"
Received: "accounts/fireworks/models/deepseek-v4-flash"
```

## Verification

`bun test src/providers src/workflows` plus the two override-profile suites, on this branch vs. the same commit with the fix reverted:

| | pass | fail |
|---|---|---|
| main (baseline) | 835 | 61 |
| main + fix | **837** | **59** |

Exactly +2/−2 — the two new tests. The 59 remaining failures are pre-existing on `main` and identical in both runs. `tsgo --noEmit` clean after `meta/sync-bundled-copies.ts`; prettier and eslint clean.

## Note

This does not explain a report of *all* chat failing. The bug requires an `overrideProfile` — a `--profile` flag or a conversation pin. Plain chat resolves from `llm.activeProfile` and is unaffected, so if chat is also failing there is a second cause worth chasing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZ5KC1LYku5qxNZFPqy4QX
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->