### PR TITLE
feat(web): New Chat row above the assistant nav item, eyes back on the left

### DIFF
--- a/clients/web/src/components/avatar/animated-avatar.tsx
+++ b/clients/web/src/components/avatar/animated-avatar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useReducedMotion } from "motion/react";
 
 import { computeTransforms, resolveDefinitions } from "@/utils/avatar-svg-compositor";
@@ -15,22 +15,7 @@ interface AnimatedAvatarProps {
    * intact — e.g. the scattered onboarding edge characters.
    */
   breathe?: boolean;
-  /**
-   * While hovered, the pupils (not the whole eye) shift a small, fixed
-   * distance toward the cursor — a "look at cursor" effect. Off by default
-   * since it's opinionated and only makes sense on a large, single,
-   * hover-focused avatar (e.g. the About Assistant hero), not the many
-   * small/ambient avatars this component also renders.
-   */
-  trackCursor?: boolean;
 }
-
-/** Pupil fill color (see `PUPIL` in `assistant/src/avatar/character-components.ts`)
- *  — the one reliable way to pick pupil paths out of an eye style's path
- *  list from the client, since the API doesn't label path roles. */
-const PUPIL_HEX = "#1A1A1A";
-/** Max pupil shift toward the cursor, as a fraction of avatar size. */
-const PUPIL_TRACK_RATIO = 0.015;
 
 function randomBetween(min: number, max: number): number {
   return min + Math.random() * (max - min);
@@ -130,31 +115,8 @@ export function AnimatedAvatar({
   size,
   isAssistantBusy = false,
   breathe = true,
-  trackCursor = false,
 }: AnimatedAvatarProps) {
   const reduce = useReducedMotion();
-
-  // Pupil offset toward the cursor, in rendered (post-eyeTransform) pixels.
-  // Only tracked while the pointer is actually over the SVG — onMouseMove
-  // naturally stops firing once it leaves, and onMouseLeave recenters.
-  const [pupilOffset, setPupilOffset] = useState({ x: 0, y: 0 });
-  const handlePupilTrack = (event: ReactMouseEvent<SVGSVGElement>) => {
-    if (!trackCursor || reduce) return;
-    const rect = event.currentTarget.getBoundingClientRect();
-    const scaleX = size / rect.width;
-    const scaleY = size / rect.height;
-    const localX = (event.clientX - rect.left) * scaleX;
-    const localY = (event.clientY - rect.top) * scaleY;
-    const dx = localX - eyeCenterOutputX;
-    const dy = localY - eyeCenterOutputY;
-    const dist = Math.hypot(dx, dy) || 1;
-    const maxOffset = size * PUPIL_TRACK_RATIO;
-    setPupilOffset({ x: (dx / dist) * maxOffset, y: (dy / dist) * maxOffset });
-  };
-  const handlePupilLeave = () => {
-    if (!trackCursor) return;
-    setPupilOffset({ x: 0, y: 0 });
-  };
 
   const { bodyShape, eyeStyle, color } = resolveDefinitions(
     components,
@@ -334,8 +296,6 @@ export function AnimatedAvatar({
       width={size}
       height={size}
       viewBox={`0 0 ${size} ${size}`}
-      onMouseMove={trackCursor ? handlePupilTrack : undefined}
-      onMouseLeave={trackCursor ? handlePupilLeave : undefined}
       style={{
         animation: breatheAnimation,
         transformOrigin: "center",
@@ -368,27 +328,14 @@ export function AnimatedAvatar({
           transition: "transform 0.15s ease-in-out",
         }}
       >
-        {eyeStyle.paths.map((p: EyePathDefinition, i: number) => {
-          if (p.color !== PUPIL_HEX) {
-            return (
-              <path key={i} d={p.svgPath} fill={p.color} transform={eyeTransform} />
-            );
-          }
-          // Pupil-only: nudged toward the cursor in already-rendered pixel
-          // space, so the shift reads correctly regardless of the eye
-          // style's own internal transform.
-          return (
-            <g
-              key={i}
-              style={{
-                transform: `translate(${pupilOffset.x}px, ${pupilOffset.y}px)`,
-                transition: "transform 0.1s ease-out",
-              }}
-            >
-              <path d={p.svgPath} fill={p.color} transform={eyeTransform} />
-            </g>
-          );
-        })}
+        {eyeStyle.paths.map((p: EyePathDefinition, i: number) => (
+          <path
+            key={i}
+            d={p.svgPath}
+            fill={p.color}
+            transform={eyeTransform}
+          />
+        ))}
       </g>
     </svg>
   );

--- a/clients/web/src/components/avatar/chat-avatar.tsx
+++ b/clients/web/src/components/avatar/chat-avatar.tsx
@@ -13,8 +13,6 @@ export interface ChatAvatarProps {
   className?: string;
   interactive?: boolean;
   isAssistantBusy?: boolean;
-  /** Pupils shift toward the cursor while hovered. See `AnimatedAvatar`. */
-  trackCursor?: boolean;
   /**
    * Stamp `data-voice-origin` on the avatar's root so the live-voice room can
    * find this on-screen avatar and grow its entrance from here. Set on the
@@ -83,7 +81,6 @@ function ChatAvatarComponent({
   interactive = false,
   isAssistantBusy = false,
   originAnchor = false,
-  trackCursor = false,
 }: ChatAvatarProps) {
   const reduce = useReducedMotion();
   const [isPoking, setIsPoking] = useState(false);
@@ -148,7 +145,6 @@ function ChatAvatarComponent({
           traits={effectiveTraits}
           size={size}
           isAssistantBusy={isAssistantBusy}
-          trackCursor={trackCursor}
         />
       </motion.div>
     );

--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -1,33 +1,24 @@
 /**
- * The sidebar's assistant cluster: the "Your Assistant" nav row dressed up
- * as the assistant — a standard-height row painted solid in the avatar's
- * color, name left-aligned, the avatar's eyes resting grown on the right,
- * sunk a touch through the row's bottom edge — with the "New Chat"
- * row directly beneath it.
+ * The sidebar's assistant cluster: a "New Chat" row — a plus glyph inside
+ * a circular chip, label beside it — with the "Your Assistant" nav row
+ * directly beneath, dressed up as the assistant: a standard-height row
+ * painted solid in the avatar's color with the avatar's eyes sitting in
+ * the leading icon slot, centered on the same axis as the New Chat chip
+ * so the two rows' labels align.
  *
- * Periodically — and immediately on hovering the New Chat row —
- * the assistant goes visiting: the eyes grow a touch, duck under their
- * row's bottom fold, and resurface inside the New Chat row below
- * while the avatar color floods that row like water (a clip-path circle
- * expanding from where the eyes surface, echoing the overview cards'
- * flood — see `identity-overview.tsx`). While they're away the assistant
- * row drains to a plain nav item — the color has moved rows, not been
- * copied. After a beat (or once the pointer leaves) they duck back under
- * and pop up at their perch as the flood recedes and the color returns.
- * The eyes never shrink below their grown size and never wander left of
- * the name.
+ * The eyes stay at their perch — they idle-blink in place (and pulse a
+ * touch on the collapsed rail) but never leave the assistant row.
  *
  * The assistant name is never bolded and always renders white on the
  * avatar-colored row — except on light avatar colors (yellow), where it
- * flips dark for contrast. While drained (eyes visiting) it reads as a
- * regular nav item's text.
+ * flips dark for contrast.
  *
- * Falls back to plain `SideMenu.Item`s when there's no character avatar to
- * dress as (custom image / not loaded).
+ * Falls back to a plain `SideMenu.Item` for the assistant row when
+ * there's no character avatar to dress as (custom image / not loaded).
  */
 
-import { Brain, SquarePen } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Brain, Plus } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { motion, useAnimationControls, useReducedMotion } from "motion/react";
 
 import { cn, SideMenu } from "@vellumai/design-library";
@@ -45,9 +36,9 @@ const MOBILE_ROW_HEIGHT = 44;
  * Hand-tuned base (unscaled) sprite width per eye style — the catalog is a
  * handful of shapes whose aspect ratios vary too wildly (gentle ≈ 1.1 wide
  * per tall, grumpy ≈ 4.6) for one derived formula to size them all well.
- * Height follows each style's own aspect ratio at its width; the resting
- * eyes render at {@link REST_SCALE} times these. Styles missing from the
- * map (a future catalog addition) fall back to {@link DEFAULT_EYES_WIDTH}.
+ * Height follows each style's own aspect ratio at its width. Styles missing
+ * from the map (a future catalog addition) fall back to
+ * {@link DEFAULT_EYES_WIDTH}.
  */
 const EYE_STYLE_WIDTHS: Record<string, number> = {
   grumpy: 22,
@@ -61,36 +52,19 @@ const EYE_STYLE_WIDTHS: Record<string, number> = {
   dazed: 16,
 };
 const DEFAULT_EYES_WIDTH = 14;
-/** Reference height for scaling the bottom-edge sink: shapes about this
- *  tall sink the full {@link EDGE_SINK}; flatter ones sink less. */
-const SINK_REFERENCE_HEIGHT = 10;
 const ROW_PADDING_X = 6;
-/** The eyes' permanent grown size at their perch. */
-const REST_SCALE = 2.1;
-/** The extra growth spurt right before ducking under a row's bottom fold. */
-const DUCK_SCALE = 2.6;
-/** Distance from a row's right edge to the eye slot (pre-scale). */
-const EYES_RIGHT_OFFSET = 18;
-/** How far the resting eyes sink through their row's bottom edge. */
-const EDGE_SINK = 4;
-/** Flood origin: where the eyes surface, as a percent of the row's width. */
-const FLOOD_ORIGIN_X_PERCENT = 88;
 /**
- * Hover-triggered (fast) crossing durations, in seconds. The eyes' duck/
- * surface move and the flood's clip-path animate on these exact same values
- * (not independent springs) so neither ever visibly outruns the other —
- * the eyes move with the background, not behind it.
+ * Diameter of the New Chat row's circular plus chip; the assistant row's
+ * leading eye slot is the same width so the eyes center on the chip's axis
+ * and both labels start at the same x.
  */
-const FAST_ENTER_DURATION = 0.35;
-const FAST_EXIT_DURATION = 0.32;
+const CHIP_SIZE = 20;
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
 const jitter = (base: number, spread: number): number =>
   base + Math.random() * spread;
-
-type EyesControls = ReturnType<typeof useAnimationControls>;
 
 interface EyeArt {
   id: string;
@@ -104,7 +78,7 @@ interface AssistantNavItemProps {
   active: boolean;
   collapsed?: boolean;
   onSelect?: () => void;
-  /** Renders the "New Chat" row under the assistant row. */
+  /** Renders the "New Chat" row above the assistant row. */
   onNewConversation?: () => void;
 }
 
@@ -119,22 +93,8 @@ export function AssistantNavItem({
   const { components, traits } = useAssistantAvatar(assistantId);
   const reduce = useReducedMotion();
   const isMobile = useIsMobile();
-  const pillEyes = useAnimationControls();
-  const newConvEyes = useAnimationControls();
+  const eyesControls = useAnimationControls();
   const [blinking, setBlinking] = useState(false);
-  /** True while the eyes are down in the New Chat row (drives the
-   *  flood overlay + that row's contrast-tone content, and drains the
-   *  assistant row back to a plain nav item). */
-  const [visiting, setVisiting] = useState(false);
-  /** True for a hover-triggered visit: skips the duck/surface theatrics for
-   *  a near-instant crossing and speeds up the flood, so hovering New Chat
-   *  reads as a normal hover state rather than waiting out the ambient
-   *  visit's leisurely choreography. Ambient (unprompted) visits keep the
-   *  slower, dreamier timing. */
-  const [fast, setFast] = useState(false);
-  /** Live pointer-over state for the New Chat row; the animation
-   *  loop polls it to summon the eyes on hover. */
-  const hoverRef = useRef(false);
 
   const rowHeight = isMobile ? MOBILE_ROW_HEIGHT : ROW_HEIGHT;
 
@@ -158,19 +118,6 @@ export function AssistantNavItem({
     ? (EYE_STYLE_WIDTHS[eye.id] ?? DEFAULT_EYES_WIDTH)
     : 0;
   const eyesHeight = eye ? eyesWidth * (eye.bbox.h / eye.bbox.w) : 0;
-  /** Bottom-edge sink scales with the shape's height so flatter variants
-   *  keep the same visible fraction above the fold. */
-  const edgeSink =
-    EDGE_SINK * Math.min(1, eyesHeight / SINK_REFERENCE_HEIGHT);
-  /** Top of the (unscaled) eye slot, vertically centered in a row. */
-  const slotTop = (rowHeight - eyesHeight) / 2;
-  /** Resting offset: bottom edge of the row plus a small sink, so the grown
-   *  eyes render cut off by the edge. (`slotTop` is also exactly the offset
-   *  that puts the sprite's bottom flush with the row's bottom.) */
-  const restY = slotTop + edgeSink;
-  /** Fully below a row even at {@link DUCK_SCALE} (scale grows upward from
-   *  the bottom-center origin). */
-  const diveY = rowHeight + 20;
 
   const showNewConversation = Boolean(onNewConversation) && !collapsed;
 
@@ -188,202 +135,45 @@ export function AssistantNavItem({
       setBlinking(false);
       await sleep(160);
     };
-    const move = (
-      controls: EyesControls,
-      to: { x?: number; y?: number; scale?: number },
-      transition: Record<string, unknown>,
-    ) =>
-      cancelled
-        ? Promise.resolve()
-        : controls.start({ ...to, transition }).catch(() => {});
     const spring = (stiffness: number, damping: number) => ({
       type: "spring",
       stiffness,
       damping,
     });
-    // `fastDuration` set: a single tween covering scale + y in one exact
-    // duration, so the eyes finish ducking in lockstep with the flood
-    // (which animates on that same duration) instead of trailing behind it.
-    // Unset: the ambient spring-driven two-step duck (grow, then drop).
-    const duckUnder = async (
-      controls: EyesControls,
-      fastDuration: number | null,
-    ) => {
-      if (fastDuration != null) {
-        await move(
-          controls,
-          { scale: DUCK_SCALE, y: diveY },
-          { duration: fastDuration, ease: "easeIn" },
-        );
-        return;
-      }
-      await move(controls, { scale: DUCK_SCALE }, spring(300, 15));
-      await move(controls, { y: diveY }, { duration: 0.3, ease: "easeIn" });
-    };
-    const surfaceAt = (
-      controls: EyesControls,
-      springiness: [number, number],
-      fastDuration: number | null,
-    ) => {
-      controls.set({ x: 0, y: diveY, scale: REST_SCALE });
-      if (fastDuration != null) {
-        return move(
-          controls,
-          { y: restY },
-          { duration: fastDuration, ease: "easeOut" },
-        );
-      }
-      return move(controls, { y: restY }, spring(...springiness));
-    };
-
-    // One leg of the visit each: duck under the assistant row's fold and
-    // surface in the New Chat row (the flood pours in), or the
-    // reverse (the flood drains as the color returns to the assistant row).
-    // `fastLeg` is a hover-triggered visit: the ambient path gates the flood
-    // behind the duck animation fully finishing first (so the color arrives
-    // only once the eyes are out of view), but that sequential wait is itself
-    // a visible delay before hovering "does" anything — so the fast path
-    // flips `visiting` immediately and lets the eyes duck/surface in
-    // parallel instead of blocking it, matching a normal hover state.
-    const goVisit = async (fastLeg: boolean) => {
-      setFast(fastLeg);
-      if (fastLeg) {
-        if (cancelled) {
-          return;
-        }
-        setVisiting(true);
-        await Promise.all([
-          duckUnder(pillEyes, FAST_ENTER_DURATION),
-          surfaceAt(newConvEyes, [360, 16], FAST_ENTER_DURATION),
-        ]);
-        return;
-      }
-      await duckUnder(pillEyes, null);
-      if (cancelled) {
-        return;
-      }
-      setVisiting(true);
-      await surfaceAt(newConvEyes, [360, 16], null);
-      await blink();
-    };
-    const goHome = async (fastLeg: boolean) => {
-      if (fastLeg) {
-        if (cancelled) {
-          return;
-        }
-        setVisiting(false);
-        await Promise.all([
-          duckUnder(newConvEyes, FAST_EXIT_DURATION),
-          surfaceAt(pillEyes, [320, 18], FAST_EXIT_DURATION),
-        ]);
-        setFast(false);
-        return;
-      }
-      await duckUnder(newConvEyes, null);
-      if (cancelled) {
-        return;
-      }
-      setVisiting(false);
-      await surfaceAt(pillEyes, [320, 18], null);
-      setFast(false);
-    };
+    const move = (
+      to: { scale?: number },
+      transition: Record<string, unknown>,
+    ) =>
+      cancelled
+        ? Promise.resolve()
+        : eyesControls.start({ ...to, transition }).catch(() => {});
 
     // Collapsed rail: grow a touch, blink, settle back.
     const collapsedPulse = async () => {
-      await move(pillEyes, { scale: 1.35 }, spring(300, 14));
+      await move({ scale: 1.35 }, spring(300, 14));
       await blink();
       await sleep(jitter(250, 350));
-      await move(pillEyes, { scale: 1 }, spring(300, 16));
+      await move({ scale: 1 }, spring(300, 16));
     };
 
-    // Short-tick loop so a hover on the New Chat row can summon the
-    // eyes promptly; ambient acts fire on their own jittered schedule.
-    const TICK_MS = 40;
     const run = async () => {
-      // A rail toggle can restart the loop mid-visit — snap everything back
-      // to the resting arrangement before starting over.
-      setVisiting(false);
-      let atNewConv = false;
-      /** Whether the current New Chat stay was hover-triggered (fast) or
-       *  an ambient visit (slow) — decides goHome's speed on the way out. */
-      let visitWasFast = false;
-      if (collapsed) {
-        pillEyes.set({ x: 0, y: 0, scale: 1 });
-      } else {
-        pillEyes.set({ x: 0, y: restY, scale: REST_SCALE });
-      }
-      newConvEyes.set({ x: 0, y: diveY, scale: REST_SCALE });
-
-      let idleMs = 0;
-      let nextActAt = jitter(1600, 1600);
-      /** How long the current stay in the New Chat row lasts. */
-      let dwellMs = 0;
+      // A rail toggle can restart the loop mid-pulse — snap the eyes back
+      // to rest before starting over.
+      eyesControls.set({ scale: 1 });
       while (!cancelled) {
-        await sleep(TICK_MS);
+        await sleep(jitter(2800, 3200));
         if (cancelled) {
           break;
         }
-        if (collapsed || !showNewConversation) {
-          idleMs += TICK_MS;
-          if (idleMs >= nextActAt) {
-            idleMs = 0;
-            nextActAt = jitter(2800, 3200);
-            await (collapsed ? collapsedPulse() : blink());
-          }
-          continue;
-        }
-        if (hoverRef.current) {
-          // Summoned: head over (or stay) while the pointer lingers, and
-          // head home almost immediately once it leaves.
-          if (!atNewConv) {
-            visitWasFast = true;
-            await goVisit(true);
-            atNewConv = true;
-          }
-          idleMs = 0;
-          dwellMs = 400;
-          continue;
-        }
-        if (atNewConv) {
-          idleMs += TICK_MS;
-          if (idleMs >= dwellMs) {
-            idleMs = 0;
-            await goHome(visitWasFast);
-            atNewConv = false;
-            nextActAt = jitter(1600, 1600);
-          }
-          continue;
-        }
-        idleMs += TICK_MS;
-        if (idleMs >= nextActAt) {
-          idleMs = 0;
-          nextActAt = jitter(1600, 1600);
-          if (Math.random() < 0.35) {
-            await blink(); // resting blink between visits
-          } else {
-            visitWasFast = false;
-            await goVisit(false);
-            atNewConv = true;
-            dwellMs = jitter(1300, 1000);
-          }
-        }
+        await (collapsed ? collapsedPulse() : blink());
       }
     };
     void run();
     return () => {
       cancelled = true;
-      pillEyes.stop();
-      newConvEyes.stop();
+      eyesControls.stop();
     };
-  }, [
-    reduce,
-    collapsed,
-    showNewConversation,
-    pillEyes,
-    newConvEyes,
-    restY,
-    diveY,
-  ]);
+  }, [reduce, collapsed, eyesControls]);
 
   const hex =
     (components &&
@@ -391,150 +181,11 @@ export function AssistantNavItem({
       components.colors.find((c) => c.id === traits.color)?.hex) ||
     null;
 
-  if (!hex) {
-    return (
-      <div className="flex flex-col gap-[4px]">
-        <SideMenu.Item
-          icon={Brain}
-          label={label}
-          showCollapsedTooltip
-          active={active}
-          onSelect={onSelect}
-        />
-        {showNewConversation ? (
-          <SideMenu.Item
-            icon={SquarePen}
-            label="New Chat"
-            showCollapsedTooltip
-            onSelect={onNewConversation}
-          />
-        ) : null}
-      </div>
-    );
-  }
-
-  // The name's tone on the avatar-colored row: white on every avatar color
-  // except the light ones (yellow), where white would wash out.
-  const fg = contrastForeground(hex);
-
-  /** Right padding that keeps a row's text clear of the resting eyes' grown
-   *  footprint (scale expands symmetrically from the sprite's center). */
-  const textClearance =
-    EYES_RIGHT_OFFSET + eyesWidth * REST_SCALE - ROW_PADDING_X;
-
-  const eyesSprite = (
-    controls: EyesControls,
-    initial: { y: number; scale: number },
-  ) =>
-    eye && (
-      <motion.span
-        className="absolute left-0"
-        style={{
-          width: eyesWidth,
-          height: eyesHeight,
-          top: slotTop,
-          transformOrigin: "50% 100%",
-          y: initial.y,
-          scale: initial.scale,
-        }}
-        initial={false}
-        animate={controls}
-      >
-        <svg
-          viewBox={`${eye.bbox.x} ${eye.bbox.y} ${eye.bbox.w} ${eye.bbox.h}`}
-          width="100%"
-          height="100%"
-          preserveAspectRatio="xMidYMid meet"
-          style={{ overflow: "visible", display: "block" }}
-        >
-          <g
-            style={{
-              transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
-              transformOrigin: `${eye.bbox.x + eye.bbox.w / 2}px ${eye.bbox.y + eye.bbox.h / 2}px`,
-              transition: "transform 0.14s ease-in-out",
-            }}
-          >
-            {eye.paths.map((p, i) => (
-              <path key={i} d={p.svgPath} fill={p.color} />
-            ))}
-          </g>
-        </svg>
-      </motion.span>
-    );
-
-  /** The eyes' home slot, anchored to a row's right edge. */
-  const eyesSlot = (
-    controls: EyesControls,
-    initial: { y: number; scale: number },
-  ) => (
-    <span
-      aria-hidden="true"
-      className="pointer-events-none absolute inset-y-0"
-      style={{ right: EYES_RIGHT_OFFSET, width: eyesWidth }}
-    >
-      {eyesSprite(controls, initial)}
-    </span>
-  );
-
-  const assistantRow = (
-    <button
-      type="button"
-      onClick={onSelect}
-      title={label}
-      aria-current={active ? "page" : undefined}
-      className={cn(
-        "group relative flex w-full cursor-pointer items-center overflow-hidden rounded-[8px] select-none",
-        "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
-        "transition-[filter,transform,background-color,color] duration-300 active:scale-[0.98]",
-        visiting ? "hover:bg-[var(--surface-hover)]" : "hover:brightness-105",
-        collapsed && "justify-center",
-      )}
-      style={{
-        height: rowHeight,
-        // While the eyes are visiting the row below, the color goes with
-        // them — this row drains to a plain nav item until they return.
-        backgroundColor: visiting ? "transparent" : hex,
-        color: visiting ? "var(--content-default)" : fg,
-        paddingLeft: collapsed ? 0 : ROW_PADDING_X,
-        paddingRight: collapsed ? 0 : ROW_PADDING_X,
-      }}
-    >
-      {collapsed ? (
-        /* Collapsed rail: the eyes alone, centered, idling in place. */
-        <span
-          aria-hidden="true"
-          className="pointer-events-none relative shrink-0"
-          style={{ width: eyesWidth, height: rowHeight }}
-        >
-          {eyesSprite(pillEyes, { y: 0, scale: 1 })}
-        </span>
-      ) : (
-        <>
-          <span
-            className={`min-w-0 flex-1 truncate text-left ${
-              isMobile ? "text-body-large-default" : "text-body-medium-default"
-            }`}
-            style={{ paddingRight: textClearance }}
-          >
-            {label}
-          </span>
-          {eyesSlot(pillEyes, { y: restY, scale: REST_SCALE })}
-        </>
-      )}
-    </button>
-  );
-
   const newConversationRow = showNewConversation ? (
     <button
       type="button"
       onClick={onNewConversation}
       title="New Chat"
-      onMouseEnter={() => {
-        hoverRef.current = true;
-      }}
-      onMouseLeave={() => {
-        hoverRef.current = false;
-      }}
       className={cn(
         "group relative flex w-full cursor-pointer items-center gap-[6px] overflow-hidden rounded-[8px] select-none",
         "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
@@ -546,58 +197,124 @@ export function AssistantNavItem({
         paddingRight: ROW_PADDING_X,
       }}
     >
-      {/* The avatar-color "water" pouring in from where the eyes surface,
-          mirroring the overview cards' flood (identity-overview.tsx). */}
-      <motion.span
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0"
-        style={{ backgroundColor: hex }}
-        initial={false}
-        animate={{
-          clipPath: visiting
-            ? `circle(141% at ${FLOOD_ORIGIN_X_PERCENT}% 100%)`
-            : `circle(0% at ${FLOOD_ORIGIN_X_PERCENT}% 100%)`,
-        }}
-        transition={
-          fast
-            ? {
-                duration: visiting ? FAST_ENTER_DURATION : FAST_EXIT_DURATION,
-                ease: visiting ? "easeOut" : "easeIn",
-              }
-            : visiting
-              ? { duration: 0.5, ease: "easeOut" }
-              : { duration: 0.35, ease: "easeIn" }
-        }
-      />
       <span
-        className={`relative min-w-0 flex-1 truncate text-left transition-colors duration-300 ${
-          isMobile ? "text-body-large-default" : "text-body-medium-default"
+        aria-hidden="true"
+        className="flex shrink-0 items-center justify-center rounded-full bg-[var(--surface-active)]"
+        style={{ width: CHIP_SIZE, height: CHIP_SIZE }}
+      >
+        <Plus
+          className="h-3.5 w-3.5"
+          style={{ color: "var(--content-emphasised)" }}
+        />
+      </span>
+      <span
+        className={`min-w-0 flex-1 truncate text-left text-[color:var(--content-secondary)] ${
+          isMobile ? "text-body-large-default" : "text-body-medium-lighter"
         }`}
-        style={{
-          color: visiting ? contrastForeground(hex) : "var(--content-default)",
-          paddingRight: textClearance,
-        }}
       >
         New Chat
       </span>
-      {/* Right-aligned pencil (the collapsed rail's new-chat glyph); it
-          yields the corner to the eyes while they're visiting. */}
-      <SquarePen
-        className={cn(
-          "relative h-3.5 w-3.5 shrink-0 transition-opacity duration-200",
-          visiting && "opacity-0",
-        )}
-        style={{ color: "var(--content-tertiary)" }}
-        aria-hidden
-      />
-      {eyesSlot(newConvEyes, { y: diveY, scale: REST_SCALE })}
     </button>
   ) : null;
 
+  if (!hex) {
+    return (
+      <div className="flex flex-col gap-[4px]">
+        {newConversationRow}
+        <SideMenu.Item
+          icon={Brain}
+          label={label}
+          showCollapsedTooltip
+          active={active}
+          onSelect={onSelect}
+        />
+      </div>
+    );
+  }
+
+  // The name's tone on the avatar-colored row: white on every avatar color
+  // except the light ones (yellow), where white would wash out.
+  const fg = contrastForeground(hex);
+
+  const eyesSprite = eye && (
+    <motion.span
+      className="pointer-events-none relative block"
+      style={{ width: eyesWidth, height: eyesHeight }}
+      initial={false}
+      animate={eyesControls}
+    >
+      <svg
+        viewBox={`${eye.bbox.x} ${eye.bbox.y} ${eye.bbox.w} ${eye.bbox.h}`}
+        width="100%"
+        height="100%"
+        preserveAspectRatio="xMidYMid meet"
+        style={{ overflow: "visible", display: "block" }}
+      >
+        <g
+          style={{
+            transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
+            transformOrigin: `${eye.bbox.x + eye.bbox.w / 2}px ${eye.bbox.y + eye.bbox.h / 2}px`,
+            transition: "transform 0.14s ease-in-out",
+          }}
+        >
+          {eye.paths.map((p, i) => (
+            <path key={i} d={p.svgPath} fill={p.color} />
+          ))}
+        </g>
+      </svg>
+    </motion.span>
+  );
+
+  const assistantRow = (
+    <button
+      type="button"
+      onClick={onSelect}
+      title={label}
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "group relative flex w-full cursor-pointer items-center gap-[6px] overflow-hidden rounded-[8px] select-none",
+        "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
+        "transition-[filter,transform] duration-300 hover:brightness-105 active:scale-[0.98]",
+        collapsed && "justify-center",
+      )}
+      style={{
+        height: rowHeight,
+        backgroundColor: hex,
+        color: fg,
+        paddingLeft: collapsed ? 0 : ROW_PADDING_X,
+        paddingRight: collapsed ? 0 : ROW_PADDING_X,
+      }}
+    >
+      {collapsed ? (
+        /* Collapsed rail: the eyes alone, centered, idling in place. */
+        eyesSprite
+      ) : (
+        <>
+          {/* Leading eye slot, chip-width so the eyes center on the New
+              Chat row's plus chip above. */}
+          <span
+            aria-hidden="true"
+            className="flex shrink-0 items-center justify-center"
+            style={{ width: CHIP_SIZE }}
+          >
+            {eyesSprite}
+          </span>
+          <span
+            className={`min-w-0 flex-1 truncate text-left ${
+              isMobile ? "text-body-large-default" : "text-body-medium-default"
+            }`}
+          >
+            {label}
+          </span>
+        </>
+      )}
+    </button>
+  );
+
   return (
     <div className="flex flex-col gap-[4px]">
-      {assistantRow}
       {newConversationRow}
+      {assistantRow}
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -6,22 +6,26 @@
  * the leading icon slot, centered on the same axis as the New Chat chip
  * so the two rows' labels align.
  *
- * The eyes stay at their perch — they idle-blink in place (and pulse a
- * touch on the collapsed rail) but never leave the assistant row.
+ * Periodically the eyes go on patrol: they sink out through the row's
+ * bottom fold, resurface grown on the right side (cut off by the edge),
+ * blink, and dive back under to reappear in the icon slot. Between
+ * patrols they idle-blink in place (and pulse a touch on the collapsed
+ * rail). They never leave the assistant row.
  *
  * The assistant name is never bolded and always renders white on the
  * avatar-colored row — except on light avatar colors (yellow), where it
  * flips dark for contrast.
  *
- * Falls back to a plain `SideMenu.Item` for the assistant row when
- * there's no character avatar to dress as (custom image / not loaded).
+ * Falls back to a plain-toned row (a Brain icon in the same leading slot,
+ * so both labels stay aligned) when there's no character avatar to dress
+ * as (custom image / not loaded).
  */
 
 import { Brain, Plus } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { motion, useAnimationControls, useReducedMotion } from "motion/react";
 
-import { cn, SideMenu } from "@vellumai/design-library";
+import { cn } from "@vellumai/design-library";
 
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useIsMobile } from "@/hooks/use-is-mobile";
@@ -59,6 +63,9 @@ const ROW_PADDING_X = 6;
  * and both labels start at the same x.
  */
 const CHIP_SIZE = 20;
+/** Patrol stop on the right side: grown, cut off by the bottom edge. */
+const SIDE_SCALE = 2.1;
+const SIDE_RIGHT_MARGIN = 14;
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
@@ -94,6 +101,7 @@ export function AssistantNavItem({
   const reduce = useReducedMotion();
   const isMobile = useIsMobile();
   const eyesControls = useAnimationControls();
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
   const [blinking, setBlinking] = useState(false);
 
   const rowHeight = isMobile ? MOBILE_ROW_HEIGHT : ROW_HEIGHT;
@@ -141,12 +149,42 @@ export function AssistantNavItem({
       damping,
     });
     const move = (
-      to: { scale?: number },
+      to: { x?: number; y?: number; scale?: number },
       transition: Record<string, unknown>,
     ) =>
       cancelled
         ? Promise.resolve()
         : eyesControls.start({ ...to, transition }).catch(() => {});
+
+    /** How far down the eyes dive to fully exit the row's bottom edge. */
+    const diveY = rowHeight - 4;
+    /** Side-patrol stop: the grown eyes flush with the bottom edge. */
+    const sidePeekY = rowHeight - 20;
+
+    // The one expanded-rail act: dive out through the bottom fold, pop up
+    // grown on the right side, blink, dive again, and slip back into the
+    // icon slot.
+    const patrol = async () => {
+      await move({ y: diveY }, { duration: 0.3, ease: "easeIn" });
+      if (cancelled) {
+        return;
+      }
+      const width = buttonRef.current?.offsetWidth ?? 200;
+      // x is relative to the sprite's home in the icon slot (row padding
+      // plus its centering offset inside the chip-width slot).
+      const homeLeft = ROW_PADDING_X + (CHIP_SIZE - eyesWidth) / 2;
+      const sideX = Math.max(
+        0,
+        width - SIDE_RIGHT_MARGIN - eyesWidth * SIDE_SCALE - homeLeft,
+      );
+      eyesControls.set({ x: sideX, y: diveY, scale: SIDE_SCALE });
+      await move({ y: sidePeekY }, spring(360, 16));
+      await blink();
+      await sleep(jitter(700, 900));
+      await move({ y: diveY }, { duration: 0.3, ease: "easeIn" });
+      eyesControls.set({ x: 0, y: diveY, scale: 1 });
+      await move({ y: 0 }, spring(320, 18));
+    };
 
     // Collapsed rail: grow a touch, blink, settle back.
     const collapsedPulse = async () => {
@@ -157,15 +195,21 @@ export function AssistantNavItem({
     };
 
     const run = async () => {
-      // A rail toggle can restart the loop mid-pulse — snap the eyes back
-      // to rest before starting over.
-      eyesControls.set({ scale: 1 });
+      // A rail toggle can restart the loop mid-patrol — snap the eyes back
+      // to the icon slot before starting over.
+      eyesControls.set({ x: 0, y: 0, scale: 1 });
       while (!cancelled) {
         await sleep(jitter(2800, 3200));
         if (cancelled) {
           break;
         }
-        await (collapsed ? collapsedPulse() : blink());
+        if (collapsed) {
+          await collapsedPulse();
+        } else if (Math.random() < 0.55) {
+          await blink(); // resting blink between patrols
+        } else {
+          await patrol();
+        }
       }
     };
     void run();
@@ -173,7 +217,7 @@ export function AssistantNavItem({
       cancelled = true;
       eyesControls.stop();
     };
-  }, [reduce, collapsed, eyesControls]);
+  }, [reduce, collapsed, eyesControls, rowHeight, eyesWidth]);
 
   const hex =
     (components &&
@@ -218,16 +262,61 @@ export function AssistantNavItem({
   ) : null;
 
   if (!hex) {
+    // No character avatar (custom image / not loaded): a plain-toned row
+    // that keeps the New Chat row's geometry — the Brain icon centers in
+    // the same CHIP_SIZE slot the plus chip and the eyes use, so both
+    // rows' labels stay on one axis.
     return (
       <div className="flex flex-col gap-[4px]">
         {newConversationRow}
-        <SideMenu.Item
-          icon={Brain}
-          label={label}
-          showCollapsedTooltip
-          active={active}
-          onSelect={onSelect}
-        />
+        <button
+          type="button"
+          onClick={onSelect}
+          title={label}
+          aria-current={active ? "page" : undefined}
+          className={cn(
+            "group relative flex w-full cursor-pointer items-center gap-[6px] overflow-hidden rounded-[8px] select-none",
+            "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
+            "transition-colors duration-150 active:scale-[0.98]",
+            active
+              ? "bg-[var(--surface-active)]"
+              : "hover:bg-[var(--surface-hover)]",
+            collapsed && "justify-center",
+          )}
+          style={{
+            height: rowHeight,
+            paddingLeft: collapsed ? 0 : ROW_PADDING_X,
+            paddingRight: collapsed ? 0 : ROW_PADDING_X,
+          }}
+        >
+          <span
+            aria-hidden="true"
+            className="flex shrink-0 items-center justify-center"
+            style={{ width: CHIP_SIZE, height: CHIP_SIZE }}
+          >
+            <Brain
+              className="h-3.5 w-3.5"
+              style={{
+                color: active
+                  ? "var(--content-default)"
+                  : "var(--content-tertiary)",
+              }}
+            />
+          </span>
+          {!collapsed && (
+            <span
+              className={cn(
+                "min-w-0 flex-1 truncate text-left",
+                active
+                  ? "text-[color:var(--content-emphasised)]"
+                  : "text-[color:var(--content-secondary)]",
+                isMobile ? "text-body-large-default" : "text-body-medium-lighter",
+              )}
+            >
+              {label}
+            </span>
+          )}
+        </button>
       </div>
     );
   }
@@ -236,37 +325,31 @@ export function AssistantNavItem({
   // except the light ones (yellow), where white would wash out.
   const fg = contrastForeground(hex);
 
-  const eyesSprite = eye && (
-    <motion.span
-      className="pointer-events-none relative block"
-      style={{ width: eyesWidth, height: eyesHeight }}
-      initial={false}
-      animate={eyesControls}
+  const eyesSvg = eye && (
+    <svg
+      viewBox={`${eye.bbox.x} ${eye.bbox.y} ${eye.bbox.w} ${eye.bbox.h}`}
+      width="100%"
+      height="100%"
+      preserveAspectRatio="xMidYMid meet"
+      style={{ overflow: "visible", display: "block" }}
     >
-      <svg
-        viewBox={`${eye.bbox.x} ${eye.bbox.y} ${eye.bbox.w} ${eye.bbox.h}`}
-        width="100%"
-        height="100%"
-        preserveAspectRatio="xMidYMid meet"
-        style={{ overflow: "visible", display: "block" }}
+      <g
+        style={{
+          transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
+          transformOrigin: `${eye.bbox.x + eye.bbox.w / 2}px ${eye.bbox.y + eye.bbox.h / 2}px`,
+          transition: "transform 0.14s ease-in-out",
+        }}
       >
-        <g
-          style={{
-            transform: blinking ? "scaleY(0.1)" : "scaleY(1)",
-            transformOrigin: `${eye.bbox.x + eye.bbox.w / 2}px ${eye.bbox.y + eye.bbox.h / 2}px`,
-            transition: "transform 0.14s ease-in-out",
-          }}
-        >
-          {eye.paths.map((p, i) => (
-            <path key={i} d={p.svgPath} fill={p.color} />
-          ))}
-        </g>
-      </svg>
-    </motion.span>
+        {eye.paths.map((p, i) => (
+          <path key={i} d={p.svgPath} fill={p.color} />
+        ))}
+      </g>
+    </svg>
   );
 
   const assistantRow = (
     <button
+      ref={buttonRef}
       type="button"
       onClick={onSelect}
       title={label}
@@ -287,17 +370,46 @@ export function AssistantNavItem({
     >
       {collapsed ? (
         /* Collapsed rail: the eyes alone, centered, idling in place. */
-        eyesSprite
+        eye && (
+          <motion.span
+            className="pointer-events-none relative block"
+            style={{
+              width: eyesWidth,
+              height: eyesHeight,
+              transformOrigin: "50% 100%",
+            }}
+            initial={false}
+            animate={eyesControls}
+          >
+            {eyesSvg}
+          </motion.span>
+        )
       ) : (
         <>
           {/* Leading eye slot, chip-width so the eyes center on the New
-              Chat row's plus chip above. */}
+              Chat row's plus chip above; the sprite is absolutely placed
+              so patrols can carry it across (and under) the whole row. */}
           <span
             aria-hidden="true"
-            className="flex shrink-0 items-center justify-center"
-            style={{ width: CHIP_SIZE }}
+            className="pointer-events-none relative shrink-0"
+            style={{ width: CHIP_SIZE, height: rowHeight }}
           >
-            {eyesSprite}
+            {eye && (
+              <motion.span
+                className="absolute"
+                style={{
+                  width: eyesWidth,
+                  height: eyesHeight,
+                  left: (CHIP_SIZE - eyesWidth) / 2,
+                  top: (rowHeight - eyesHeight) / 2,
+                  transformOrigin: "50% 100%",
+                }}
+                initial={false}
+                animate={eyesControls}
+              >
+                {eyesSvg}
+              </motion.span>
+            )}
           </span>
           <span
             className={`min-w-0 flex-1 truncate text-left ${

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -476,7 +476,7 @@ describe("AssistantSideMenu · new conversation affordance", () => {
     onSelectConversation: () => {},
   };
 
-  test("renders the New Chat row (under the assistant row) when onStartNewConversation is supplied", () => {
+  test("renders the New Chat row (above the assistant row) when onStartNewConversation is supplied", () => {
     const html = renderToStaticMarkup(
       createElement(AssistantSideMenu, {
         ...baseProps,
@@ -487,6 +487,10 @@ describe("AssistantSideMenu · new conversation affordance", () => {
     expect(html).toContain(">New Chat<");
     // It is a button row, not a navigation link.
     expect(html).not.toContain("<a aria-label=\"New Chat\"");
+    // New Chat sits above the assistant row.
+    expect(html.indexOf(">New Chat<")).toBeLessThan(
+      html.indexOf("Your Assistant"),
+    );
   });
 
   test("omits the New Chat row when onStartNewConversation is absent", () => {

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -326,11 +326,11 @@ export function AssistantSideMenu({
           <SideMenu.Separator />
         </>
       ) : null}
-      {/* The assistant cluster: the avatar-colored assistant row with the
-          New Chat row beneath it (one component — the eyes migrate
-          between the two rows). No divider; breathing room below instead.
-          The overlay drawer skips the New Chat row — its floating New Chat
-          pill already owns that action in the thumb zone. */}
+      {/* The assistant cluster: the New Chat row (plus chip + label) with
+          the avatar-colored assistant row beneath it. No divider; breathing
+          room below instead. The overlay drawer skips the New Chat row —
+          its floating New Chat pill already owns that action in the thumb
+          zone. */}
       <div className="mb-4">
         <AssistantNavItem
           assistantId={assistantId ?? null}

--- a/clients/web/src/domains/intelligence/components/amoeba-avatar.tsx
+++ b/clients/web/src/domains/intelligence/components/amoeba-avatar.tsx
@@ -202,7 +202,7 @@ export function AmoebaPeekTab({
         animate={{
           x: anchor.x - TAB_DIAMETER / 2 + (active ? 0 : retract.x),
           y: anchor.y - TAB_DIAMETER / 2 + (active ? 0 : retract.y),
-          opacity: active ? 0.8 : 0,
+          opacity: active ? 1 : 0,
         }}
         transition={transition}
       />
@@ -214,7 +214,7 @@ export function AmoebaPeekTab({
           y: eyeCenter.y - eyeH / 2 + (active ? 0 : retract.y),
           width: eyeW,
           height: eyeH,
-          opacity: active ? 0.8 : 0,
+          opacity: active ? 1 : 0,
         }}
         transition={transition}
       >

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -468,15 +468,15 @@ function SectionCard({
     section.key === "personality" || section.key === "schedules";
 
   return (
-    // The feature cards float flat on the page — no border, no shadow;
-    // the other tiles keep the standard raised card chrome.
+    // The feature cards sit flat on the page (no shadow) with a hairline
+    // theme border; the other tiles keep the standard raised card chrome.
     <Card.Root
       asChild
       bordered={!isFeatureCard}
       elevated={!isFeatureCard}
       className={`${SECTION_RADII[section.key] ?? ""} ${
         isFeatureCard
-          ? "border-0 bg-[var(--card-feature-bg,var(--card-bg))]"
+          ? "border border-[var(--border-base)] bg-[var(--card-feature-bg,var(--card-bg))]"
           : "bg-[var(--card-bg)]"
       }`}
       style={{

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -965,7 +965,6 @@ function OverviewBento({
               customImageUrl={customImageUrl}
               size={heroAvatarSize}
               interactive
-              trackCursor
             />
             <span
               aria-hidden="true"


### PR DESCRIPTION
## Summary
- Move the sidebar's New Chat row above the assistant nav row and restyle it to the mock: a plus icon inside a circular `--surface-active` chip on the left with the label beside it (trailing pencil glyph removed).
- Remove the eyes-visiting/flood animation entirely — the avatar color no longer drains/floods between rows; New Chat is a plain static row (~400 net lines deleted).
- Re-perch the avatar's eyes in the assistant row's leading icon slot, centered on the same 20px axis as the plus chip so both rows' labels align; they idle-blink in place and keep the collapsed-rail pulse. Side-menu comment and tests updated (row-order assertion added).

## Original prompt
The user shared a mock of the sidebar's New Chat button — a plus glyph in a circular chip with the label beside it — and asked for it to sit above the assistant nav item. They also asked to stop the avatar switching over to the New Chat row (the eyes-visiting/flood animation) and instead return the eyes to the left of the assistant nav item, aligned with the plus button, as in the pre-cluster design. Work was done in an isolated worktree off latest main, leaving their in-progress onboarding changes untouched.