### PR TITLE
feat(providers): resolve provider:"vellum"/"chatgpt" to real upstream adapters at dispatch

### DIFF
--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -333,4 +333,23 @@ describe("ProviderCommitMessageGenerator", () => {
     const options = callArgs[1] as SendMessageOptions | undefined;
     expect(options?.config?.callSite).toBe("commitMessage");
   });
+
+  // 13. Routing identity — no provider API key exists under an identity name;
+  // the preflight skips it because resolution already verified the
+  // connection credential.
+  test("routing identity (vellum) — skips the API-key preflight", async () => {
+    mockSecureKeys = {};
+    resolvedProvider = {
+      provider: mockProvider,
+      configuredProviderName: "vellum",
+    };
+    const commitMsg = "fix: managed-route commit";
+    mockSendMessage.mockResolvedValueOnce(makeSuccessResponse(commitMsg));
+    const gen = getCommitMessageGenerator();
+    const result = await gen.generateCommitMessage(baseContext, {
+      changedFiles: baseContext.changedFiles,
+    });
+    expect(result.source).toBe("llm");
+    expect(result.message).toBe(commitMsg);
+  });
 });

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -325,6 +325,8 @@ function connectionResolutionUserMessage(
       return `${connection}${usedBy} is bound to a different provider than the profile declares. Update the profile's connection in ${fixPath}.`;
     case "missing_connection":
       return `No provider connection is configured${usedBy}. Add an API key or log in via ${fixPath}.`;
+    case "unroutable_managed_model":
+      return `The model "${error.model ?? "<unset>"}"${usedBy} isn't served by the Vellum managed route. Pick a model from the Vellum catalog, or choose a concrete provider in ${fixPath}.`;
     case "missing_credential":
       // Provider-neutral: api_key connections store keys, oauth_subscription
       // connections store login tokens — the fix differs but the location

--- a/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
@@ -326,6 +326,19 @@ describe("routing identities", () => {
     });
   });
 
+  test("resolveRoutingIdentity rejects non-Codex models on the chatgpt route", () => {
+    expect(() => resolveRoutingIdentity("chatgpt", "gpt-5")).toThrow(
+      ConnectionResolutionError,
+    );
+    try {
+      resolveRoutingIdentity("chatgpt", "gpt-5");
+    } catch (err) {
+      expect((err as ConnectionResolutionError).reason).toBe(
+        "model_incompatible",
+      );
+    }
+  });
+
   test("resolveRoutingIdentity passes real providers through untouched", () => {
     expect(resolveRoutingIdentity("anthropic", "claude-opus-4-8")).toBeNull();
     expect(resolveRoutingIdentity(undefined, "claude-opus-4-8")).toBeNull();

--- a/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
@@ -52,6 +52,7 @@ type Connection = {
 };
 
 const resolveProviderCalls: Connection[] = [];
+const resolveProviderOpts: { providerOverride?: string }[] = [];
 
 // Each connection name maps to a distinct fake Provider instance. Returning
 // distinguishable instances lets the test assert that two profiles with
@@ -75,8 +76,13 @@ mock.module("../registry.js", () => ({
   initializeProviders: async () => {},
   listProviders: () => Array.from(fakeProviders.values()),
   // The function under test — wraps the dispatcher's connection-aware path.
-  resolveProviderFromConnection: async (connection: Connection) => {
+  resolveProviderFromConnection: async (
+    connection: Connection,
+    _config: unknown,
+    opts?: { providerOverride?: string },
+  ) => {
     resolveProviderCalls.push(connection);
+    resolveProviderOpts.push(opts ?? {});
     return fakeProviders.get(`conn:${connection.name}`) ?? null;
   },
 }));
@@ -85,7 +91,11 @@ mock.module("../registry.js", () => ({
 // Imports (after mocks).
 // ---------------------------------------------------------------------------
 
-import { ConnectionResolutionError } from "../connection-resolution.js";
+import {
+  ConnectionResolutionError,
+  resolveRoutingIdentity,
+  tryResolveProviderForConnectionName,
+} from "../connection-resolution.js";
 import { getConfiguredProvider } from "../provider-send-message.js";
 
 // ---------------------------------------------------------------------------
@@ -269,5 +279,114 @@ describe("dispatch routes through provider_connection (Phase 1: connection-only)
     // however they want (rollup producer skips, others throw a domain-
     // specific error).
     expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Routing identities ("vellum"/"chatgpt") — resolution-unit coverage. Config-
+// driven dispatch of identity profiles stays impossible while the write-lock
+// holds; the end-to-end config test lands with the lock lift.
+// ---------------------------------------------------------------------------
+
+describe("routing identities", () => {
+  beforeEach(() => {
+    resolveProviderCalls.length = 0;
+    resolveProviderOpts.length = 0;
+    fakeConnections.clear();
+    fakeProviders.clear();
+  });
+
+  test("resolveRoutingIdentity derives the vellum upstream from the model", () => {
+    expect(resolveRoutingIdentity("vellum", "claude-opus-4-8")).toEqual({
+      connectionName: "vellum",
+      expectedProvider: "anthropic",
+    });
+    expect(
+      resolveRoutingIdentity("vellum", "accounts/fireworks/models/glm-5p2"),
+    ).toEqual({ connectionName: "vellum", expectedProvider: "fireworks" });
+  });
+
+  test("resolveRoutingIdentity throws loudly for an unroutable vellum model", () => {
+    expect(() => resolveRoutingIdentity("vellum", "not-a-real-model")).toThrow(
+      ConnectionResolutionError,
+    );
+    try {
+      resolveRoutingIdentity("vellum", "not-a-real-model");
+    } catch (err) {
+      expect((err as ConnectionResolutionError).reason).toBe(
+        "unroutable_managed_model",
+      );
+    }
+  });
+
+  test("resolveRoutingIdentity maps chatgpt to the subscription row with an openai upstream", () => {
+    expect(resolveRoutingIdentity("chatgpt", "gpt-5.5")).toEqual({
+      connectionName: "chatgpt-subscription",
+      expectedProvider: "openai",
+    });
+  });
+
+  test("resolveRoutingIdentity passes real providers through untouched", () => {
+    expect(resolveRoutingIdentity("anthropic", "claude-opus-4-8")).toBeNull();
+    expect(resolveRoutingIdentity(undefined, "claude-opus-4-8")).toBeNull();
+  });
+
+  test("vellum identity resolves through the canonical row with the derived upstream override", async () => {
+    fakeConnections.set("vellum", {
+      name: "vellum",
+      provider: "vellum",
+      auth: { type: "platform" },
+    });
+    fakeProviders.set("conn:vellum", { name: "anthropic", tag: "managed" });
+
+    const provider = await tryResolveProviderForConnectionName(
+      "ignored-stale-name",
+      { llm: {} } as never,
+      "vellum",
+      "claude-opus-4-8",
+    );
+
+    expect(provider).toEqual({ name: "anthropic", tag: "managed" } as never);
+    expect(resolveProviderCalls[0]?.name).toBe("vellum");
+    expect(resolveProviderOpts[0]?.providerOverride).toBe("anthropic");
+  });
+
+  test("chatgpt identity resolves the subscription row by name with an openai override", async () => {
+    fakeConnections.set("chatgpt-subscription", {
+      name: "chatgpt-subscription",
+      provider: "openai",
+      auth: {
+        type: "oauth_subscription",
+        credential: "credential/chatgpt/access_token",
+      },
+    });
+    fakeProviders.set("conn:chatgpt-subscription", {
+      name: "openai",
+      tag: "subscription",
+    });
+
+    const provider = await tryResolveProviderForConnectionName(
+      "ignored",
+      { llm: {} } as never,
+      "chatgpt",
+      "gpt-5.5",
+    );
+
+    expect(provider).toEqual({ name: "openai", tag: "subscription" } as never);
+    expect(resolveProviderCalls[0]?.name).toBe("chatgpt-subscription");
+    // No override needed: the subscription row itself carries provider
+    // "openai", so the adapter resolves from the row.
+    expect(resolveProviderCalls[0]?.provider).toBe("openai");
+  });
+
+  test("chatgpt identity with no subscription row throws not_found (never a silent fallback)", async () => {
+    await expect(
+      tryResolveProviderForConnectionName(
+        "ignored",
+        { llm: {} } as never,
+        "chatgpt",
+        "gpt-5.5",
+      ),
+    ).rejects.toMatchObject({ reason: "not_found" });
   });
 });

--- a/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
@@ -283,9 +283,9 @@ describe("dispatch routes through provider_connection (Phase 1: connection-only)
 });
 
 // ---------------------------------------------------------------------------
-// Routing identities ("vellum"/"chatgpt") — resolution-unit coverage. Config-
-// driven dispatch of identity profiles stays impossible while the write-lock
-// holds; the end-to-end config test lands with the lock lift.
+// Routing identities ("vellum"/"chatgpt") — resolution-unit coverage. The
+// config write-lock keeps identity providers out of stored profiles, so
+// config-driven dispatch of them is untestable here by construction.
 // ---------------------------------------------------------------------------
 
 describe("routing identities", () => {

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -24,12 +24,14 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { getDb } from "../persistence/db-connection.js";
+import { getLogger } from "../util/logger.js";
 import {
   describeSubscriptionModelIncompatibility,
   isConnectionCompatibleWithModel,
 } from "./connection-model-compat.js";
 import {
   ConnectionResolutionError,
+  resolveRoutingIdentity,
   tryResolveProviderForConnectionName,
 } from "./connection-resolution.js";
 import { listConnections } from "./inference/connections.js";
@@ -42,6 +44,7 @@ import type {
   SendMessageOptions,
 } from "./types.js";
 
+const log = getLogger("providers/call-site-routing");
 export class CallSiteRoutingProvider implements Provider {
   public readonly tokenEstimationProvider?: string;
   // Forward native web-search capability so it survives the wrapper chain
@@ -217,6 +220,18 @@ export class CallSiteRoutingProvider implements Provider {
 
     let connectionName = resolved.provider_connection;
 
+    // A routing-identity provider ("vellum"/"chatgpt") names its own
+    // connection row; the provider-keyed scan below cannot find it (the
+    // chatgpt row stores provider "openai"), so short-circuit to the
+    // canonical name. Unroutable vellum models throw here — loudly —
+    // instead of falling through to the default transport.
+    if (!connectionName) {
+      connectionName = resolveRoutingIdentity(
+        resolved.provider,
+        resolved.model,
+      )?.connectionName;
+    }
+
     // When no connection is set, auto-resolve one for the resolved provider —
     // including when the provider matches the default's name. The default
     // transport may ride the managed (platform-billed) connection, so reusing
@@ -253,6 +268,20 @@ export class CallSiteRoutingProvider implements Provider {
       if (connectionProvider) {
         return connectionProvider;
       }
+      // Soft credential failure: the routed connection yielded no usable
+      // adapter and dispatch is landing on the default transport, which may
+      // be the platform-billed route — keep every such degradation
+      // observable.
+      log.warn(
+        {
+          callSite,
+          connectionName,
+          provider: resolved.provider,
+          model: resolved.model,
+          reason: "credential_unavailable",
+        },
+        "Routed connection yielded no adapter — falling back to the default transport",
+      );
       return this.defaultProvider;
     }
 

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -39,6 +39,7 @@ import {
   describeSubscriptionModelIncompatibility,
   isConnectionCompatibleWithModel,
 } from "./connection-model-compat.js";
+import { CHATGPT_SUBSCRIPTION_CONNECTION_NAME } from "./inference/auth.js";
 import { getConnection, listConnections } from "./inference/connections.js";
 import { resolveManagedProxyContext } from "./platform-proxy/context.js";
 import { checkCredentialPresence } from "./provider-availability.js";
@@ -46,8 +47,10 @@ import type { ProvidersConfig } from "./registry.js";
 import { resolveProviderFromConnection } from "./registry.js";
 import type { Provider } from "./types.js";
 import {
+  getManagedUpstream,
   isVellumManagedConnection,
   MANAGED_ROUTABLE_PROVIDERS,
+  VELLUM_MANAGED_CONNECTION_NAME,
 } from "./vellum-model-routing.js";
 
 const log = getLogger("providers/connection-resolution");
@@ -72,7 +75,8 @@ export class ConnectionResolutionError extends ConfigError {
       | "missing_connection"
       | "model_incompatible"
       | "missing_credential"
-      | "platform_unauthenticated",
+      | "platform_unauthenticated"
+      | "unroutable_managed_model",
     message: string,
     options?: { cause?: unknown; model?: string; profileName?: string },
   ) {
@@ -81,6 +85,43 @@ export class ConnectionResolutionError extends ConfigError {
     this.model = options?.model;
     this.profileName = options?.profileName;
   }
+}
+
+/**
+ * Translate a routing-identity provider into its dispatch target. "vellum"
+ * derives the managed upstream from the model and routes through the
+ * canonical vellum connection; "chatgpt" routes through the
+ * chatgpt-subscription connection with an openai upstream. Returns null for
+ * real providers. Throws `unroutable_managed_model` when a vellum model has
+ * no managed upstream — loud and explainable, never a soft fall-through to
+ * the (possibly platform-billed) default transport.
+ */
+export function resolveRoutingIdentity(
+  provider: string | undefined,
+  model: string | undefined,
+): { connectionName: string; expectedProvider: string } | null {
+  if (provider === "vellum") {
+    const upstream = model ? getManagedUpstream(model) : null;
+    if (!upstream) {
+      throw new ConnectionResolutionError(
+        VELLUM_MANAGED_CONNECTION_NAME,
+        "unroutable_managed_model",
+        `provider "vellum" cannot route model "${model ?? "<unset>"}" — no managed upstream serves it. Pick a model from the Vellum catalog or set a concrete provider.`,
+        { model },
+      );
+    }
+    return {
+      connectionName: VELLUM_MANAGED_CONNECTION_NAME,
+      expectedProvider: upstream,
+    };
+  }
+  if (provider === "chatgpt") {
+    return {
+      connectionName: CHATGPT_SUBSCRIPTION_CONNECTION_NAME,
+      expectedProvider: "openai",
+    };
+  }
+  return null;
 }
 
 /**
@@ -113,6 +154,15 @@ export async function tryResolveProviderForConnectionName(
   expectedProvider?: string,
   model?: string,
 ): Promise<Provider | null> {
+  // Routing identities carry no upstream of their own: translate to the
+  // identity's canonical connection row and derived upstream before any
+  // lookup. The stored connectionName is overridden — an identity has
+  // exactly one authoritative row.
+  const identity = resolveRoutingIdentity(expectedProvider, model);
+  if (identity) {
+    connectionName = identity.connectionName;
+    expectedProvider = identity.expectedProvider;
+  }
   let connection;
   try {
     connection = getConnection(getDb(), connectionName);
@@ -249,6 +299,15 @@ export async function resolveDefaultProvider(
 ): Promise<Provider | null> {
   const resolved = resolveCallSiteConfig("mainAgent", config.llm);
   let connectionName = resolved.provider_connection;
+  // A routing-identity provider names its own connection row; the
+  // provider-keyed auto-resolve scan below cannot find it ("chatgpt" rows
+  // store provider "openai"), so short-circuit to the canonical name.
+  if (!connectionName) {
+    connectionName = resolveRoutingIdentity(
+      resolved.provider,
+      resolved.model,
+    )?.connectionName;
+  }
   if (!connectionName) {
     // The merged config has no provider_connection — the profile likely set
     // provider without a connection ("Any active" selection), and the merge

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -41,6 +41,7 @@ import {
 } from "./connection-model-compat.js";
 import { CHATGPT_SUBSCRIPTION_CONNECTION_NAME } from "./inference/auth.js";
 import { getConnection, listConnections } from "./inference/connections.js";
+import { isCodexSubscriptionModel } from "./openai/codex-models.js";
 import { resolveManagedProxyContext } from "./platform-proxy/context.js";
 import { checkCredentialPresence } from "./provider-availability.js";
 import type { ProvidersConfig } from "./registry.js";
@@ -93,8 +94,9 @@ export class ConnectionResolutionError extends ConfigError {
  * canonical vellum connection; "chatgpt" routes through the
  * chatgpt-subscription connection with an openai upstream. Returns null for
  * real providers. Throws `unroutable_managed_model` when a vellum model has
- * no managed upstream — loud and explainable, never a soft fall-through to
- * the (possibly platform-billed) default transport.
+ * no managed upstream, and `model_incompatible` when a chatgpt model is
+ * outside the Codex subscription set — loud and explainable, never a soft
+ * fall-through to the (possibly platform-billed) default transport.
  */
 export function resolveRoutingIdentity(
   provider: string | undefined,
@@ -116,6 +118,17 @@ export function resolveRoutingIdentity(
     };
   }
   if (provider === "chatgpt") {
+    // The subscription endpoint rejects non-Codex models with HTTP 400;
+    // gate here so the misconfiguration surfaces as a config error instead
+    // of an upstream request failure.
+    if (model && !isCodexSubscriptionModel(model)) {
+      throw new ConnectionResolutionError(
+        CHATGPT_SUBSCRIPTION_CONNECTION_NAME,
+        "model_incompatible",
+        `provider "chatgpt" cannot route model "${model}" — the ChatGPT subscription serves Codex models only. Pick a Codex model or set a concrete provider.`,
+        { model },
+      );
+    }
     return {
       connectionName: CHATGPT_SUBSCRIPTION_CONNECTION_NAME,
       expectedProvider: "openai",

--- a/assistant/src/providers/inference/auth.ts
+++ b/assistant/src/providers/inference/auth.ts
@@ -114,6 +114,13 @@ export const VALID_CONNECTION_PROVIDERS: readonly string[] = [
 
 export type ConnectionProvider = string;
 
+/**
+ * Name of the single ChatGPT-subscription connection row (created by the
+ * ChatGPT sign-in flows). The "chatgpt" routing identity dispatches through
+ * this row with an openai upstream.
+ */
+export const CHATGPT_SUBSCRIPTION_CONNECTION_NAME = "chatgpt-subscription";
+
 export const ConnectionProviderSchema = z
   .enum(VALID_CONNECTION_PROVIDERS as readonly [string, ...string[]])
   .meta({ id: "ConnectionProvider" });

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -16,7 +16,10 @@ import {
   describeSubscriptionModelIncompatibility,
   isConnectionCompatibleWithModel,
 } from "./connection-model-compat.js";
-import { tryResolveProviderForConnectionName } from "./connection-resolution.js";
+import {
+  resolveRoutingIdentity,
+  tryResolveProviderForConnectionName,
+} from "./connection-resolution.js";
 import { listConnections } from "./inference/connections.js";
 import { initializeProviders, listProviders } from "./registry.js";
 import type {
@@ -146,6 +149,14 @@ export async function resolveConfiguredProvider(
   // skip backfill, freshly-installed configs not yet backfilled, or users
   // who manually cleared the field), try to auto-resolve from the provider
   // before falling back to null.
+  if (!connectionName) {
+    // Routing identities name their own connection row; the provider-keyed
+    // scan below cannot find them ("chatgpt" rows store provider "openai").
+    connectionName = resolveRoutingIdentity(
+      inferenceProvider,
+      resolved.model,
+    )?.connectionName;
+  }
   if (!connectionName) {
     if (inferenceProvider) {
       try {

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -272,6 +272,15 @@ export async function resolveProviderFromConnection(
   // For every other connection this is `undefined` and the effective provider
   // is the connection's own — no behavior change.
   const effectiveProvider = opts.providerOverride ?? connection.provider;
+  // Routing identities must be translated to a real upstream before this
+  // point (resolveRoutingIdentity in connection-resolution) — an identity
+  // reaching adapter construction would silently yield no adapter and the
+  // retry wire-normalization keys off real adapter provider names.
+  if (effectiveProvider === "vellum" || effectiveProvider === "chatgpt") {
+    throw new Error(
+      `resolveProviderFromConnection received unresolved routing identity "${effectiveProvider}" — translate to a real upstream before adapter construction`,
+    );
+  }
   const model = opts.model ?? resolveModel(config, effectiveProvider);
   const cacheKey = getConnectionProviderCacheKey(
     connection,

--- a/assistant/src/runtime/routes/chatgpt-subscription-auth-routes.ts
+++ b/assistant/src/runtime/routes/chatgpt-subscription-auth-routes.ts
@@ -12,6 +12,7 @@
 import { z } from "zod";
 
 import { getDb } from "../../persistence/db-connection.js";
+import { CHATGPT_SUBSCRIPTION_CONNECTION_NAME } from "../../providers/inference/auth.js";
 import {
   createConnection,
   getConnection,
@@ -45,7 +46,7 @@ const OPENAI_OAUTH_CONFIG: OAuth2Config = {
 };
 
 const REDIRECT_URI = "http://localhost:1455/auth/callback";
-const CONNECTION_NAME = "chatgpt-subscription";
+const CONNECTION_NAME = CHATGPT_SUBSCRIPTION_CONNECTION_NAME;
 
 // ---------------------------------------------------------------------------
 // Module-level PKCE state storage

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -4,6 +4,7 @@ import {
 } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
+import { resolveRoutingIdentity } from "../providers/connection-resolution.js";
 import { safeStringSlice } from "../util/unicode.js";
 
 const MAX_METADATA_VALUE_LENGTH = 128;
@@ -100,6 +101,29 @@ export function sanitizeUsageMetadataValue(value: unknown): string | null {
   return safeStringSlice(trimmed, 0, MAX_METADATA_VALUE_LENGTH);
 }
 
+/**
+ * Attribution records the billed upstream: a routing-identity provider
+ * ("vellum"/"chatgpt") translates to the upstream that actually serves the
+ * request, matching what dispatch resolves. Unroutable identity models fall
+ * back to the stored value rather than throwing — attribution must never
+ * take dispatch down.
+ */
+function attributedProvider(
+  provider: string | undefined,
+  model: string | undefined,
+): string | undefined {
+  if (provider !== "vellum" && provider !== "chatgpt") {
+    return provider;
+  }
+  try {
+    return (
+      resolveRoutingIdentity(provider, model)?.expectedProvider ?? provider
+    );
+  } catch {
+    return provider;
+  }
+}
+
 export function resolveUsageAttribution(
   input: UsageAttributionInput,
 ): UsageAttributionSnapshot {
@@ -120,7 +144,11 @@ export function resolveUsageAttribution(
       callSiteProfile: null,
       appliedProfile: null,
       profileSource: "unknown",
-      resolvedProvider: resolvedMainAgent.provider,
+      resolvedProvider:
+        attributedProvider(
+          resolvedMainAgent.provider,
+          resolvedMainAgent.model,
+        ) ?? resolvedMainAgent.provider,
       resolvedModel: resolvedMainAgent.model,
       resolvedMixArm: null,
     };
@@ -161,7 +189,9 @@ export function resolveUsageAttribution(
     callSiteProfile,
     appliedProfile: profile.appliedProfile,
     profileSource: profile.profileSource,
-    resolvedProvider: resolved.provider,
+    resolvedProvider:
+      attributedProvider(resolved.provider, resolved.model) ??
+      resolved.provider,
     resolvedModel: resolved.model,
     resolvedMixArm:
       profile.appliedProfile != null

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -160,8 +160,14 @@ class ProviderCommitMessageGenerator {
     const provider = resolved.provider;
     const providerName = resolved.configuredProviderName;
 
-    // Step 2b: API key preflight for the configured provider (skip keyless).
-    if (!KEYLESS_PROVIDERS.has(providerName)) {
+    // Step 2b: API key preflight for the configured provider. Skipped for
+    // keyless providers and for routing identities ("vellum"/"chatgpt"),
+    // which authenticate through their connection row (platform token /
+    // ChatGPT OAuth) — no provider API key exists for them, and resolution
+    // already verified the connection credential.
+    const isRoutingIdentity =
+      providerName === "vellum" || providerName === "chatgpt";
+    if (!KEYLESS_PROVIDERS.has(providerName) && !isRoutingIdentity) {
       const providerApiKey = await getProviderKeyAsync(providerName);
       if (!providerApiKey) {
         log.debug(


### PR DESCRIPTION
## Summary
- **`resolveRoutingIdentity`** (new, in `connection-resolution.ts`) translates an identity provider into its dispatch target before any lookup: `"vellum"` → canonical `vellum` row + upstream derived from the model via `getManagedUpstream` (an unroutable model throws `unroutable_managed_model` with a user-facing classification — **loud, never a soft fall-through to the possibly-billed default transport**); `"chatgpt"` → the `chatgpt-subscription` row **by name** (its provider column is `openai`, so provider-keyed auto-resolve scans can't find it) with an openai upstream.
- Wired at every dispatch entry: `tryResolveProviderForConnectionName` (single choke point), the auto-resolve paths in `provider-send-message` and `CallSiteRoutingProvider.selectProvider`, and `resolveDefaultProvider`. `resolveProviderFromConnection` hard-throws if an untranslated identity reaches adapter construction; usage attribution records the **billed upstream**; the call-site soft-credential fallback onto the default transport gets a structured warn.
- `CHATGPT_SUBSCRIPTION_CONNECTION_NAME` hoisted to `providers/inference/auth.ts`. Tests are at the resolution-unit level by design: the write-lock (PR 2) keeps config-driven identity profiles impossible until the lift PR, which will carry the end-to-end config test.

## Original prompt
PR 3 of Milestone B ("vellum dispatches") of the connection-removal plan — papertrail on #38102, stacked on #38298 (retargets to main when it merges). Built on the post-#38338 dispatch baseline per the adjusted plan, including the billing-incident-driven requirements: identity-aware auto-resolution and observability for silent default-transport fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->