### PR TITLE
feat(providers): identity-aware preflight, availability, materialization, and backfill

### DIFF
--- a/assistant/src/__tests__/provider-connections-backfill.test.ts
+++ b/assistant/src/__tests__/provider-connections-backfill.test.ts
@@ -117,6 +117,19 @@ test("managed-owned entries keep the vellum stamp even when a user connection ex
   expect(backfilledConnection("byok")).toBe("anthropic-personal");
 });
 
+test("routing-identity providers are never stamped with a connection", () => {
+  process.env.IS_PLATFORM = "true";
+  seedConfig({
+    managedRoute: { provider: "vellum", model: "claude-fable-5" },
+    subscription: { provider: "chatgpt", model: "gpt-5.5" },
+  });
+
+  runProviderConnectionsBackfill(getDb());
+
+  expect(backfilledConnection("managedRoute")).toBeUndefined();
+  expect(backfilledConnection("subscription")).toBeUndefined();
+});
+
 test("your-own mode reuses a custom-named connection instead of creating -personal", () => {
   delete process.env.IS_PLATFORM;
   const created = createConnection(getDb(), {

--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -94,6 +94,17 @@ describe("completeCustomProfile", () => {
     expect(completed.provider_connection).toBeUndefined();
   });
 
+  test("routing-identity providers never receive a connection stamp", () => {
+    for (const provider of ["vellum", "chatgpt"] as const) {
+      const completed = completeCustomProfile(fullDefault, {
+        provider,
+        model: "claude-fable-5",
+      });
+      expect(completed.provider).toBe(provider);
+      expect(completed.provider_connection).toBeUndefined();
+    }
+  });
+
   test("keeps an explicit provider_connection even when the provider is implied", () => {
     const completed = completeCustomProfile(fullDefault, {
       model: "gpt-5.5",

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -1,3 +1,4 @@
+import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
 import {
   getCatalogProviderForModel,
   isModelInCatalog,
@@ -92,6 +93,16 @@ export function completeCustomProfile(
   // dispatch routes it via `expectedProvider` — but only onto providers it
   // can actually route; a non-managed-routable provider (openrouter, ollama)
   // would hit the mismatch path instead of auto-resolution.
+  // Routing-identity providers resolve their connection per-request from
+  // the provider value; a stamped provider_connection would be dead weight
+  // at best and a misroute at worst.
+  if (
+    completed.provider !== undefined &&
+    ROUTING_IDENTITY_PROVIDERS.has(completed.provider)
+  ) {
+    return structuredClone(completed);
+  }
+
   const vellumRoutable =
     dflt.provider_connection === VELLUM_MANAGED_CONNECTION_NAME &&
     completed.provider !== undefined &&

--- a/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
+++ b/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
@@ -120,6 +120,75 @@ describe("preflightResolvedConfig", () => {
     expect(err?.reason).toBe("provider_mismatch");
   });
 
+  test("a vellum identity preflights through the sentinel row with the derived upstream", async () => {
+    connectionsByName["vellum"] = {
+      name: "vellum",
+      provider: "vellum",
+      auth: { type: "platform" },
+    };
+    platformLoggedIn = true;
+    await expect(
+      preflightResolvedConfig(
+        resolved({ provider: "vellum", provider_connection: "" }),
+        {},
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  test("a vellum identity without a platform login throws platform_unauthenticated", async () => {
+    connectionsByName["vellum"] = {
+      name: "vellum",
+      provider: "vellum",
+      auth: { type: "platform" },
+    };
+    platformLoggedIn = false;
+    const err = await preflightError(
+      resolved({ provider: "vellum", provider_connection: "" }),
+    );
+    expect(err?.reason).toBe("platform_unauthenticated");
+  });
+
+  test("an unroutable vellum model throws unroutable_managed_model", async () => {
+    const err = await preflightError(
+      resolved({
+        provider: "vellum",
+        provider_connection: "",
+        model: "not-a-real-model",
+      }),
+    );
+    expect(err?.reason).toBe("unroutable_managed_model");
+  });
+
+  test("a chatgpt identity preflights the subscription row's credential", async () => {
+    connectionsByName["chatgpt-subscription"] = {
+      name: "chatgpt-subscription",
+      provider: "openai",
+      auth: {
+        type: "oauth_subscription",
+        credential: "credential/chatgpt/access_token",
+      },
+    };
+    const missing = await preflightError(
+      resolved({ provider: "chatgpt", provider_connection: "" }),
+    );
+    expect(missing?.reason).toBe("missing_credential");
+
+    secureKeys["credential/chatgpt/access_token"] = "tok";
+    await expect(
+      preflightResolvedConfig(
+        resolved({ provider: "chatgpt", provider_connection: "" }),
+        {},
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  test("a chatgpt identity with no subscription row throws not_found", async () => {
+    const err = await preflightError(
+      resolved({ provider: "chatgpt", provider_connection: "" }),
+    );
+    expect(err?.reason).toBe("not_found");
+  });
+
   test("the vellum managed connection serves managed-routable providers when logged in", async () => {
     connectionsByName = {
       vellum: {

--- a/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
+++ b/assistant/src/providers/__tests__/preflight-resolved-config.test.ts
@@ -169,14 +169,22 @@ describe("preflightResolvedConfig", () => {
       },
     };
     const missing = await preflightError(
-      resolved({ provider: "chatgpt", provider_connection: "" }),
+      resolved({
+        provider: "chatgpt",
+        provider_connection: "",
+        model: "gpt-5.5",
+      }),
     );
     expect(missing?.reason).toBe("missing_credential");
 
     secureKeys["credential/chatgpt/access_token"] = "tok";
     await expect(
       preflightResolvedConfig(
-        resolved({ provider: "chatgpt", provider_connection: "" }),
+        resolved({
+          provider: "chatgpt",
+          provider_connection: "",
+          model: "gpt-5.5",
+        }),
         {},
       ),
     ).resolves.toBeUndefined();
@@ -184,9 +192,20 @@ describe("preflightResolvedConfig", () => {
 
   test("a chatgpt identity with no subscription row throws not_found", async () => {
     const err = await preflightError(
-      resolved({ provider: "chatgpt", provider_connection: "" }),
+      resolved({
+        provider: "chatgpt",
+        provider_connection: "",
+        model: "gpt-5.5",
+      }),
     );
     expect(err?.reason).toBe("not_found");
+  });
+
+  test("a chatgpt identity with a non-Codex model throws model_incompatible", async () => {
+    const err = await preflightError(
+      resolved({ provider: "chatgpt", provider_connection: "" }),
+    );
+    expect(err?.reason).toBe("model_incompatible");
   });
 
   test("the vellum managed connection serves managed-routable providers when logged in", async () => {

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -405,7 +405,13 @@ export async function preflightResolvedConfig(
   },
   attribution: { profileName?: string } = {},
 ): Promise<void> {
-  const connectionName = resolved.provider_connection;
+  // Routing identities preflight through their canonical row and derived
+  // upstream; an unroutable vellum model throws here — it is statically
+  // detectable, exactly what preflight exists to surface.
+  const identity = resolveRoutingIdentity(resolved.provider, resolved.model);
+  const provider = identity?.expectedProvider ?? resolved.provider;
+  const connectionName =
+    identity?.connectionName ?? resolved.provider_connection;
   if (!connectionName) {
     return;
   }
@@ -433,11 +439,11 @@ export async function preflightResolvedConfig(
   }
 
   if (isVellumManagedConnection(connection)) {
-    if (!MANAGED_ROUTABLE_PROVIDERS.has(resolved.provider)) {
+    if (!MANAGED_ROUTABLE_PROVIDERS.has(provider)) {
       throw new ConnectionResolutionError(
         connectionName,
         "provider_mismatch",
-        `provider_connection "${connectionName}" is the Vellum-managed connection, which cannot serve provider "${resolved.provider}"`,
+        `provider_connection "${connectionName}" is the Vellum-managed connection, which cannot serve provider "${provider}"`,
         errorOptions,
       );
     }
@@ -451,11 +457,11 @@ export async function preflightResolvedConfig(
     }
     return;
   }
-  if (connection.provider !== resolved.provider) {
+  if (connection.provider !== provider) {
     throw new ConnectionResolutionError(
       connectionName,
       "provider_mismatch",
-      `provider_connection "${connectionName}" has provider="${connection.provider}" but the resolved config declares provider="${resolved.provider}"`,
+      `provider_connection "${connectionName}" has provider="${connection.provider}" but the resolved config declares provider="${provider}"`,
       errorOptions,
     );
   }

--- a/assistant/src/providers/inference/auth.ts
+++ b/assistant/src/providers/inference/auth.ts
@@ -121,6 +121,19 @@ export type ConnectionProvider = string;
  */
 export const CHATGPT_SUBSCRIPTION_CONNECTION_NAME = "chatgpt-subscription";
 
+/**
+ * Provider values that are routing identities rather than adapters: the
+ * value names HOW a request routes (vellum = the platform-managed route,
+ * chatgpt = the subscription route), and dispatch translates it to a real
+ * upstream + connection row per-request (resolveRoutingIdentity). Identity
+ * profiles carry no provider_connection; backfill and materialization must
+ * not stamp one.
+ */
+export const ROUTING_IDENTITY_PROVIDERS: ReadonlySet<string> = new Set([
+  "vellum",
+  "chatgpt",
+]);
+
 export const ConnectionProviderSchema = z
   .enum(VALID_CONNECTION_PROVIDERS as readonly [string, ...string[]])
   .meta({ id: "ConnectionProvider" });

--- a/assistant/src/providers/inference/backfill.ts
+++ b/assistant/src/providers/inference/backfill.ts
@@ -24,7 +24,10 @@ import { credentialKey } from "../../security/credential-key.js";
 import { getLogger } from "../../util/logger.js";
 import { isConnectionCompatibleWithModel } from "../connection-model-compat.js";
 import { MANAGED_ROUTABLE_PROVIDERS } from "../vellum-model-routing.js";
-import { PROVIDERS_REQUIRING_BASE_URL_AND_MODELS } from "./auth.js";
+import {
+  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
+  ROUTING_IDENTITY_PROVIDERS,
+} from "./auth.js";
 import {
   createConnection,
   getConnection,
@@ -181,6 +184,14 @@ function ensureProviderConnection(
       { entry: entryLabel, provider },
       "Skipping backfill for provider that requires per-connection base_url/models",
     );
+    return false;
+  }
+
+  // Routing identities carry their target in the provider value itself —
+  // dispatch resolves the row per-request (vellum via the model's managed
+  // upstream, chatgpt via the subscription row). Stamping a provider-keyed
+  // row here would misroute them.
+  if (ROUTING_IDENTITY_PROVIDERS.has(provider)) {
     return false;
   }
 

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -17,6 +17,7 @@ import {
 // Per-connection provider cache (mix-and-match support)
 // ---------------------------------------------------------------------------
 import type { ProviderConnection } from "./inference/auth.js";
+import { ROUTING_IDENTITY_PROVIDERS } from "./inference/auth.js";
 import { resolveAuth } from "./inference/resolve-auth.js";
 import { isModelInCatalog, PROVIDER_CATALOG } from "./model-catalog.js";
 import { getProviderDefaultModel } from "./model-intents.js";
@@ -200,11 +201,15 @@ export async function initializeProviders(
     if (isKeyless) {
       const key = await getProviderKeyAsync(entry.id);
       const isConfiguredMainAgent = mainAgentProvider === entry.id;
-      if (!key && !isConfiguredMainAgent) continue;
+      if (!key && !isConfiguredMainAgent) {
+        continue;
+      }
       apiKey = key ?? "";
     } else {
       const creds = await resolveProviderCredentials(entry.id);
-      if (!creds) continue;
+      if (!creds) {
+        continue;
+      }
       apiKey = creds.apiKey;
       baseURL = creds.baseURL;
       source = creds.source;
@@ -276,7 +281,7 @@ export async function resolveProviderFromConnection(
   // point (resolveRoutingIdentity in connection-resolution) — an identity
   // reaching adapter construction would silently yield no adapter and the
   // retry wire-normalization keys off real adapter provider names.
-  if (effectiveProvider === "vellum" || effectiveProvider === "chatgpt") {
+  if (ROUTING_IDENTITY_PROVIDERS.has(effectiveProvider)) {
     throw new Error(
       `resolveProviderFromConnection received unresolved routing identity "${effectiveProvider}" — translate to a real upstream before adapter construction`,
     );
@@ -288,7 +293,9 @@ export async function resolveProviderFromConnection(
     effectiveProvider,
   );
   const cached = connectionProviders.get(cacheKey);
-  if (cached) return cached;
+  if (cached) {
+    return cached;
+  }
 
   const authResult = await resolveAuth(connection.auth, effectiveProvider, {
     baseUrl: connection.baseUrl,

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -34,7 +34,10 @@ import {
   WRITE_LOCKED_PROVIDERS,
 } from "../../config/schemas/llm.js";
 import { getDb } from "../../persistence/db-connection.js";
-import { resolveRoutingIdentity } from "../../providers/connection-resolution.js";
+import {
+  ConnectionResolutionError,
+  resolveRoutingIdentity,
+} from "../../providers/connection-resolution.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
 import { computeConnectionAvailability } from "../../providers/inference/connection-availability.js";
 import { getConnection } from "../../providers/inference/connections.js";
@@ -206,9 +209,9 @@ async function profileAvailability(
     return null;
   }
   // Routing-identity profiles carry no provider_connection; availability is
-  // judged against the identity's canonical row and derived upstream. An
-  // unroutable vellum model reports as a mismatch rather than throwing —
-  // availability annotates, it must not fail the profiles read.
+  // judged against the identity's canonical row and derived upstream. A
+  // model the identity cannot route reports as a mismatch rather than
+  // throwing — availability annotates, it must not fail the profiles read.
   if (ROUTING_IDENTITY_PROVIDERS.has(provider)) {
     const model = typeof entry.model === "string" ? entry.model : undefined;
     try {
@@ -220,10 +223,13 @@ async function profileAvailability(
         identity.expectedProvider,
         identity.connectionName,
       );
-    } catch {
+    } catch (err) {
       return {
         status: "provider_mismatch",
-        message: `Model "${model ?? "<unset>"}" is not served by the Vellum managed route. Pick a model from the Vellum catalog.`,
+        message:
+          err instanceof ConnectionResolutionError
+            ? err.message
+            : `Model "${model ?? "<unset>"}" cannot be routed by provider "${provider}".`,
       };
     }
   }

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -34,6 +34,8 @@ import {
   WRITE_LOCKED_PROVIDERS,
 } from "../../config/schemas/llm.js";
 import { getDb } from "../../persistence/db-connection.js";
+import { resolveRoutingIdentity } from "../../providers/connection-resolution.js";
+import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
 import { computeConnectionAvailability } from "../../providers/inference/connection-availability.js";
 import { getConnection } from "../../providers/inference/connections.js";
 import { isModelInCatalog } from "../../providers/model-catalog.js";
@@ -200,7 +202,32 @@ async function profileAvailability(
 ): Promise<Awaited<ReturnType<typeof computeConnectionAvailability>> | null> {
   const provider = entry.provider;
   const connection = entry.provider_connection;
-  if (typeof provider !== "string" || typeof connection !== "string") {
+  if (typeof provider !== "string") {
+    return null;
+  }
+  // Routing-identity profiles carry no provider_connection; availability is
+  // judged against the identity's canonical row and derived upstream. An
+  // unroutable vellum model reports as a mismatch rather than throwing —
+  // availability annotates, it must not fail the profiles read.
+  if (ROUTING_IDENTITY_PROVIDERS.has(provider)) {
+    const model = typeof entry.model === "string" ? entry.model : undefined;
+    try {
+      const identity = resolveRoutingIdentity(provider, model);
+      if (!identity) {
+        return null;
+      }
+      return computeConnectionAvailability(
+        identity.expectedProvider,
+        identity.connectionName,
+      );
+    } catch {
+      return {
+        status: "provider_mismatch",
+        message: `Model "${model ?? "<unset>"}" is not served by the Vellum managed route. Pick a model from the Vellum catalog.`,
+      };
+    }
+  }
+  if (typeof connection !== "string") {
     return null;
   }
   return computeConnectionAvailability(provider, connection);

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -5,6 +5,7 @@ import {
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { resolveRoutingIdentity } from "../providers/connection-resolution.js";
+import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
 import { safeStringSlice } from "../util/unicode.js";
 
 const MAX_METADATA_VALUE_LENGTH = 128;
@@ -112,7 +113,7 @@ function attributedProvider(
   provider: string | undefined,
   model: string | undefined,
 ): string | undefined {
-  if (provider !== "vellum" && provider !== "chatgpt") {
+  if (provider === undefined || !ROUTING_IDENTITY_PROVIDERS.has(provider)) {
     return provider;
   }
   try {

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -1,5 +1,6 @@
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
+import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
 import { resolveConfiguredProvider } from "../providers/provider-send-message.js";
 import type { Message } from "../providers/types.js";
 import { getProviderKeyAsync } from "../security/secure-keys.js";
@@ -161,13 +162,14 @@ class ProviderCommitMessageGenerator {
     const providerName = resolved.configuredProviderName;
 
     // Step 2b: API key preflight for the configured provider. Skipped for
-    // keyless providers and for routing identities ("vellum"/"chatgpt"),
-    // which authenticate through their connection row (platform token /
-    // ChatGPT OAuth) — no provider API key exists for them, and resolution
-    // already verified the connection credential.
-    const isRoutingIdentity =
-      providerName === "vellum" || providerName === "chatgpt";
-    if (!KEYLESS_PROVIDERS.has(providerName) && !isRoutingIdentity) {
+    // keyless providers and for routing identities, which authenticate
+    // through their connection row (platform token / ChatGPT OAuth) — no
+    // provider API key exists for them, and resolution already verified the
+    // connection credential.
+    if (
+      !KEYLESS_PROVIDERS.has(providerName) &&
+      !ROUTING_IDENTITY_PROVIDERS.has(providerName)
+    ) {
       const providerApiKey = await getProviderKeyAsync(providerName);
       if (!providerApiKey) {
         log.debug(


### PR DESCRIPTION
## Summary
- **`ROUTING_IDENTITY_PROVIDERS`** (new, in `providers/inference/auth.ts`) is the durable shared set naming the provider values that are routes rather than adapters — distinct from the temporary `WRITE_LOCKED_PROVIDERS` (which dies with the lock lift). PR 3's registry guard and attribution helper are retrofitted onto it, so no call site re-enumerates the identities.
- **Preflight** translates identities to the canonical row + derived upstream before its static checks (an unroutable vellum model throws `unroutable_managed_model` — statically detectable, exactly what preflight surfaces); **profile availability** judges the identity's row and credential (unroutable models *report* as a mismatch instead of throwing — availability annotates, it must not fail the profiles read).
- **Materialization and the boot backfill never stamp a `provider_connection` on identity profiles** — dispatch resolves the row per-request. This is the adjusted-plan requirement from the billing-incident review: the backfill's prefer-user-connection rule (#38338) is exempted for identities, so a `provider: "vellum"` profile can never be silently rebound to a user's BYOK row (or vice versa). #38338's managed-ownership rule is untouched.
- Tests: 5 preflight identity cases (sentinel routing, platform_unauthenticated, unroutable, chatgpt credential presence/absence, missing subscription row), materialization no-stamp, backfill no-stamp for both identities.

## Original prompt
PR 4 of Milestone B ("vellum dispatches") of the connection-removal plan — papertrail on #38102, stacked on #38629 (PR 3), which stacks on #38298 (PR 2); the chain retargets to main as each merges. With this, everything that reasons about profiles understands the identities; the write-lock lift (PR 5) closes the milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->