### PR TITLE
feat(tips): wrap the tip carousel's next chevron back to the first tip

### DIFF
--- a/clients/web/src/components/tips/tip-card.test.tsx
+++ b/clients/web/src/components/tips/tip-card.test.tsx
@@ -110,7 +110,7 @@ describe("TipCard", () => {
     expect(onNextTip).toHaveBeenCalledTimes(1);
   });
 
-  test("disables the back chevron on the first tip and forward on the last", () => {
+  test("disables the back chevron on the first tip; forward stays enabled to wrap", () => {
     const first = renderCard(LINKED_TIP, { carouselIndex: 0, carouselCount: 4 });
     expect(
       first.getByLabelText("Previous tip").hasAttribute("disabled"),
@@ -124,7 +124,9 @@ describe("TipCard", () => {
     expect(last.getByLabelText("Previous tip").hasAttribute("disabled")).toBe(
       false,
     );
-    expect(last.getByLabelText("Next tip").hasAttribute("disabled")).toBe(true);
+    expect(last.getByLabelText("Next tip").hasAttribute("disabled")).toBe(
+      false,
+    );
   });
 
   test("renders one dot per tip up to the window, then caps at five", () => {

--- a/clients/web/src/components/tips/tip-card.tsx
+++ b/clients/web/src/components/tips/tip-card.tsx
@@ -157,7 +157,6 @@ export function TipCard({
           <button
             type="button"
             onClick={onNextTip}
-            disabled={carouselIndex === carouselCount - 1}
             aria-label="Next tip"
             data-slot="tip-card-next"
             className={carouselButtonClassName}

--- a/clients/web/src/hooks/use-tip-card.test.ts
+++ b/clients/web/src/hooks/use-tip-card.test.ts
@@ -343,7 +343,7 @@ describe("useTipCard carousel", () => {
     expect(result.current.carouselIndex).toBe(0);
   });
 
-  test("clamps at the catalog edges instead of wrapping", () => {
+  test("clamps prev at the start and wraps next past the end", () => {
     openAllGates();
 
     const { result } = renderHook(() => useTipCard());
@@ -352,13 +352,19 @@ describe("useTipCard carousel", () => {
     });
     expect(result.current.tip?.id).toBe(FIRST_TIP_ID);
 
-    for (let click = 0; click < UNGATED_TIPS.length + 3; click++) {
+    for (let click = 0; click < UNGATED_TIPS.length - 1; click++) {
       act(() => {
         result.current.onNextTip();
       });
     }
     expect(result.current.tip?.id).toBe(UNGATED_TIPS.at(-1)?.id);
     expect(result.current.carouselIndex).toBe(UNGATED_TIPS.length - 1);
+
+    act(() => {
+      result.current.onNextTip();
+    });
+    expect(result.current.tip?.id).toBe(FIRST_TIP_ID);
+    expect(result.current.carouselIndex).toBe(0);
   });
 
   test("browsing includes previously dismissed tips", () => {

--- a/clients/web/src/hooks/use-tip-card.ts
+++ b/clients/web/src/hooks/use-tip-card.ts
@@ -83,7 +83,7 @@ export interface UseTipCardResult {
   carouselCount: number;
   onDismiss: () => void;
   onLearnMore: () => void;
-  /** Carousel navigation — clamped at the catalog edges. */
+  /** Carousel navigation — prev clamps at the start, next wraps to the first tip. */
   onPrevTip: () => void;
   onNextTip: () => void;
 }
@@ -247,7 +247,9 @@ export function useTipCard(): UseTipCardResult {
   }, [carouselIndex]);
 
   const onNextTip = useCallback(() => {
-    setBrowseIndex(Math.min(carouselIndex + 1, carouselCount - 1));
+    // Wraps past the last tip back to the first, so forward browsing never
+    // dead-ends. The chevron only renders when carouselCount > 1.
+    setBrowseIndex((carouselIndex + 1) % carouselCount);
   }, [carouselIndex, carouselCount]);
 
   const onDismiss = useCallback(() => {


### PR DESCRIPTION
## Summary
- Clicking the next chevron on the last tip now wraps back to the first tip instead of dead-ending on a disabled chevron, making forward browsing an "infinite" carousel.
- `useTipCard.onNextTip` advances with `(carouselIndex + 1) % carouselCount`; the next chevron in `TipCard` no longer sets `disabled` at the end.
- The prev chevron is intentionally unchanged: it still clamps and disables on the first tip (only forward wrapping was requested).

## Testing
- Updated the hook test to assert N−1 next-clicks reach the last tip and one more returns to index 0, and the card test to assert the next chevron stays enabled on the last tip.
- `bun test` on both tip test files: 27/27 pass; `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)