### PR TITLE
feat(billing): drive the pro onboarding wizard from the ensure-provisioned verdict

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -17,6 +17,7 @@ import { MemoryRouter } from "react-router";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import type {
   Assistant,
+  EnsureProvisionedResponse,
   OnboardingStateResponse,
   OperationalStatus,
   SubscriptionResponse,
@@ -116,7 +117,16 @@ function makeOperationalStatus(
   } as OperationalStatus;
 }
 
-type Captured = { path?: unknown; body?: unknown };
+function makeEnsureResponse(
+  state: EnsureProvisionedResponse["state"],
+  reason: EnsureProvisionedResponse["reason"] = null,
+): EnsureProvisionedResponse {
+  return {
+    state,
+    reason,
+    targets: { machine_size: "large", storage_gib: 50 },
+  };
+}
 
 let subscriptionPlanId: SubscriptionResponse["plan_id"] = "base";
 let onboardingResponse = makeOnboarding();
@@ -125,9 +135,11 @@ let operationalStatusResponse = makeOperationalStatus("active");
 let onboardingFails = false;
 /** When set, onboarding responses hold until this promise resolves. */
 let onboardingHold: Promise<void> | null = null;
-let resizeCall: Captured | null = null;
-/** When set, the resize mutation rejects with this error body. */
-let resizeError: unknown = null;
+let ensureCalls = 0;
+/** Verdict the reconcile endpoint answers with; "started" is the norm. */
+let ensureResponse = makeEnsureResponse("started");
+/** When set, the reconcile rejects with this error body (e.g. the 503). */
+let ensureError: unknown = null;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -154,15 +166,12 @@ mock.module("@/generated/api/sdk.gen", () => ({
       data: operationalStatusResponse,
       response: { ok: true },
     }),
-  assistantsResize: (opts: Captured) => {
-    resizeCall = opts;
-    if (resizeError != null) {
-      return Promise.reject(resizeError);
+  organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate: () => {
+    ensureCalls += 1;
+    if (ensureError != null) {
+      return Promise.reject(ensureError);
     }
-    return Promise.resolve({
-      data: { machine_size: "large", provisioned_storage_gib: 50 },
-      response: { ok: true },
-    });
+    return Promise.resolve({ data: ensureResponse, response: { ok: true } });
   },
   assistantsDomainsList: () =>
     Promise.resolve({ data: { results: [] }, response: { ok: true } }),
@@ -203,8 +212,9 @@ beforeEach(() => {
   operationalStatusResponse = makeOperationalStatus("active");
   onboardingFails = false;
   onboardingHold = null;
-  resizeCall = null;
-  resizeError = null;
+  ensureCalls = 0;
+  ensureResponse = makeEnsureResponse("started");
+  ensureError = null;
   dateNowOffsetMs = 0;
   sessionStorage.clear();
 });
@@ -310,18 +320,37 @@ describe("BillingOnboardingModal", () => {
     });
   });
 
-  test("not-applicable fast path celebrates and advances without a resize", async () => {
+  test("already-provisioned fast path reconciles, celebrates and advances", async () => {
     subscriptionPlanId = "pro";
     assistantResponse = makeAssistant("large", 50);
+    // Nothing to do: the reconcile confirms it rather than queueing a resize.
+    ensureResponse = makeEnsureResponse("already_done");
     const { getByText } = renderModal();
 
-    await waitFor(() => expect(getByText("Your plan is ready")).toBeTruthy(), {
+    await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
       timeout: 5000,
     });
     await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy(), {
       timeout: 5000,
     });
-    expect(resizeCall).toBeNull();
+    expect(ensureCalls).toBe(1);
+  });
+
+  test("ensure-provisioned being unavailable still lets the fast path resolve by inference", async () => {
+    subscriptionPlanId = "pro";
+    assistantResponse = makeAssistant("large", 50);
+    // The reconcile 503s: no verdict, no error surface — the actuals the
+    // wizard polls already meet the targets, so it reads NOT_APPLICABLE.
+    ensureError = { error: "provisioning_submission_failed" };
+    const { getByText, queryByText } = renderModal();
+
+    await waitFor(() => expect(getByText("Your plan is ready")).toBeTruthy(), {
+      timeout: 5000,
+    });
+    expect(queryByText("Couldn't reach billing")).toBeNull();
+    await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy(), {
+      timeout: 5000,
+    });
   });
 
   test("provisioning renders a full-bleed dark takeover; the domain step reverts to a standard card", async () => {
@@ -330,7 +359,7 @@ describe("BillingOnboardingModal", () => {
     const { getByText } = renderModal();
 
     // Provisioning phase: full-bleed, dark-themed Modal.Content.
-    await waitFor(() => expect(getByText("Your plan is ready")).toBeTruthy(), {
+    await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
       timeout: 5000,
     });
     const takeover = document.body.querySelector('[data-slot="modal-content"]');
@@ -354,6 +383,8 @@ describe("BillingOnboardingModal", () => {
       () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
+    // The wizard reconciled once on the pro transition.
+    await waitFor(() => expect(ensureCalls).toBe(1));
 
     // Jump the wall clock past the stall threshold; the hook's next clock
     // tick re-derives the state as STALLED.
@@ -362,10 +393,9 @@ describe("BillingOnboardingModal", () => {
       timeout: 5000,
     });
 
+    // The stalled button re-calls the same idempotent reconcile.
     fireEvent.click(getByTestId("provisioning-apply"));
-    await waitFor(() => expect(resizeCall).not.toBeNull());
-    expect(resizeCall!.path).toEqual({ id: "assistant-1" });
-    expect(resizeCall!.body).toEqual({ machine_size: "large", storage_gib: 50 });
+    await waitFor(() => expect(ensureCalls).toBe(2));
 
     // The successful apply resumes observation: back to the resizing UI…
     await waitFor(
@@ -574,9 +604,6 @@ describe("BillingOnboardingModal", () => {
 
   test("a failed apply surfaces its error and a late-landing resize still recovers", async () => {
     subscriptionPlanId = "pro";
-    resizeError = {
-      detail: "Another assistant operation is already in progress.",
-    };
     const { client, getByText, getByTestId } = renderModal();
 
     await waitFor(
@@ -588,12 +615,14 @@ describe("BillingOnboardingModal", () => {
       timeout: 5000,
     });
 
-    // The rejection renders as-is on the stalled screen.
+    // Only a user-initiated reconcile surfaces its failure — the automatic one
+    // on the pro transition degrades silently.
+    ensureError = { error: "provisioning_submission_failed" };
     fireEvent.click(getByTestId("provisioning-apply"));
-    await waitFor(() => expect(resizeCall).not.toBeNull());
+    await waitFor(() => expect(ensureCalls).toBe(2));
     await waitFor(() =>
       expect(
-        getByText("Another assistant operation is already in progress."),
+        getByText("We couldn't queue your upgrade just now. Try again in a moment."),
       ).toBeTruthy(),
     );
     expect(getByText("We couldn't finish this automatically")).toBeTruthy();
@@ -640,7 +669,7 @@ describe("BillingOnboardingModal", () => {
 
       // Applying resumes observation — the finishing line returns…
       fireEvent.click(getByTestId("complete-stalled-apply"));
-      await waitFor(() => expect(resizeCall).not.toBeNull());
+      await waitFor(() => expect(ensureCalls).toBe(2));
       await waitFor(() => expect(getByText(BACKGROUND_LINE)).toBeTruthy(), {
         timeout: 5000,
       });
@@ -706,7 +735,7 @@ describe("BillingOnboardingModal", () => {
       // Applying resumes observation: the stalled controls give way to the
       // neutral busy notice while the resize is re-observed…
       fireEvent.click(getByTestId("domain-stalled-apply"));
-      await waitFor(() => expect(resizeCall).not.toBeNull());
+      await waitFor(() => expect(ensureCalls).toBe(2));
       await waitFor(() =>
         expect(
           getByText(

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -96,13 +96,10 @@ export function BillingOnboardingModal({
     advanceFromProvisioning();
   }, [advanceFromProvisioning]);
 
-  // Stalled recovery re-calls the idempotent ensure-provisioned reconcile —
-  // the same path the wizard already fired on Pro confirmation — rather than a
-  // raw per-assistant resize. It is org-wide, grow-only, guarded against
-  // double-submitting, and needs no client-derived targets, so it strictly
-  // dominates the resize it replaces. Apply errors surface as-is; if a
-  // server-side resize is actually still running, the actuals polling
-  // converges to DONE and replaces the stalled UI regardless.
+  // Stalled recovery re-calls the idempotent, org-wide ensure-provisioned
+  // reconcile — the same path the wizard fires on Pro confirmation. Its errors
+  // surface as-is; a server-side resize that is still running converges the
+  // actuals polling to DONE and replaces the stalled UI regardless.
   const { stalledAction } = provisioning;
   const stalledActionIfStalled =
     provisioning.state === "STALLED" ? stalledAction : undefined;

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -1,8 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { useMutation } from "@tanstack/react-query";
-
-import { assistantsResizeMutation } from "@/generated/api/@tanstack/react-query.gen";
 import {
     clearCheckoutIntent,
     readCheckoutIntent,
@@ -99,37 +96,14 @@ export function BillingOnboardingModal({
     advanceFromProvisioning();
   }, [advanceFromProvisioning]);
 
-  const resizeMutation = useMutation(assistantsResizeMutation());
-  const applyStalledResize = () => {
-    if (resizeMutation.isPending || !assistantId || !targets) return;
-    resizeMutation.mutate(
-      {
-        path: { id: assistantId },
-        body: {
-          ...(targets.machineSize != null
-            ? { machine_size: targets.machineSize }
-            : {}),
-          ...(targets.storageGib != null
-            ? { storage_gib: targets.storageGib }
-            : {}),
-        },
-      },
-      {
-        // A manual apply un-stalls the flow: the hook goes back to RESIZING
-        // and resumes its actuals polling so the normal DONE path can
-        // complete.
-        onSuccess: () => provisioning.resumeAfterManualApply(),
-      },
-    );
-  };
-  // Apply errors surface as-is; if a server-side resize is actually still
-  // running, the actuals polling converges to DONE and replaces the stalled
-  // UI regardless.
-  const stalledAction = {
-    onApply: applyStalledResize,
-    pending: resizeMutation.isPending,
-    error: resizeMutation.error,
-  };
+  // Stalled recovery re-calls the idempotent ensure-provisioned reconcile —
+  // the same path the wizard already fired on Pro confirmation — rather than a
+  // raw per-assistant resize. It is org-wide, grow-only, guarded against
+  // double-submitting, and needs no client-derived targets, so it strictly
+  // dominates the resize it replaces. Apply errors surface as-is; if a
+  // server-side resize is actually still running, the actuals polling
+  // converges to DONE and replaces the stalled UI regardless.
+  const { stalledAction } = provisioning;
   const stalledActionIfStalled =
     provisioning.state === "STALLED" ? stalledAction : undefined;
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.test.ts
@@ -305,3 +305,93 @@ describe("deriveProvisioningState — server verdict overrides", () => {
     ).toBe("CONFIRMING");
   });
 });
+
+describe("deriveProvisioningState — an in-flight resize blocks completion", () => {
+  // The platform persists the effective machine_size / provisioned_storage_gib
+  // at *acceptance* of the resize, while the operation marker is still
+  // WAITING_FOR_PVC/WAITING_FOR_READY — so targets read as met for the whole
+  // window the pod spends restarting. Completing there would clear machineBusy
+  // and let the domain step write to a gateway that is still down.
+  test("targets met while the resize is still in flight → RESIZING, not DONE", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          actuals: { machineSize: "large", storageGib: 50 },
+          resizeOperationInFlight: true,
+        }),
+      ),
+    ).toEqual({ state: "RESIZING", softWaiting: false });
+  });
+
+  test("an in_progress verdict with met targets stays RESIZING", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          actuals: { machineSize: "large", storageGib: 50 },
+          resizeOperationInFlight: true,
+          serverVerdict: "in_progress",
+        }),
+      ).state,
+    ).toBe("RESIZING");
+  });
+
+  test("an already_done verdict does not complete mid-resize", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          resizeOperationInFlight: true,
+          serverVerdict: "already_done",
+        }),
+      ).state,
+    ).toBe("RESIZING");
+  });
+
+  test("a not_applicable verdict does not complete mid-resize", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          resizeOperationInFlight: true,
+          serverVerdict: "not_applicable",
+        }),
+      ).state,
+    ).toBe("RESIZING");
+  });
+
+  test("first-observed actuals already at target still NOT_APPLICABLE when nothing is in flight", () => {
+    // The guard keys on the live operation only, so the no-op upgrade path is
+    // untouched.
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          targets: { machineSize: "small", storageGib: 10 },
+          actuals: { machineSize: "small", storageGib: 10 },
+          initialActuals: { machineSize: "small", storageGib: 10 },
+        }),
+      ).state,
+    ).toBe("NOT_APPLICABLE");
+  });
+
+  test("once the operation clears, met targets settle to DONE", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          actuals: { machineSize: "large", storageGib: 50 },
+          resizeOperationInFlight: false,
+          sawOperation: true,
+        }),
+      ).state,
+    ).toBe("DONE");
+  });
+
+  test("a marker that never clears still reaches STALLED, keeping the escape", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          actuals: { machineSize: "large", storageGib: 50 },
+          resizeOperationInFlight: true,
+          msSinceWatchStart: PROVISION_STALL_MS,
+        }),
+      ).state,
+    ).toBe("STALLED");
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.test.ts
@@ -396,21 +396,22 @@ describe("deriveProvisioningState — an in-flight resize blocks completion", ()
   });
 });
 
-describe("deriveProvisioningState — a provisional verdict needs a status reading", () => {
+describe("deriveProvisioningState — a provisional verdict needs a post-actuals status reading", () => {
   // The assistant and operational-status queries poll independently, so the
   // assistant poll can land the target sizes while the status query still holds
-  // its pre-resize snapshot. Under `started`/`in_progress` the server has told
-  // us a rollout is underway, so that stale window must not read as completion:
-  // a marker exists at verdict time, so one status reading taken after the
-  // verdict settles whether it is still running.
+  // its pre-resize snapshot. Under `started`/`in_progress` that stale window
+  // must not read as completion. The verdict cannot be the anchor — `started`
+  // only queues the resize on a worker — but the platform creates the marker
+  // before it persists the sizes, so a status reading taken after the actuals
+  // met the targets settles whether the rollout is still running.
   const staleStatus = {
     actuals: { machineSize: "large" as const, storageGib: 50 },
     resizeOperationInFlight: false,
     sawOperation: false,
-    statusObservedSinceVerdict: false,
+    statusObservedSinceTargetsMet: false,
   };
 
-  test("in_progress with met targets but a pre-verdict status reading → RESIZING", () => {
+  test("in_progress with met targets but a pre-actuals status reading → RESIZING", () => {
     expect(
       deriveProvisioningState(
         baseInput({ ...staleStatus, serverVerdict: "in_progress" }),
@@ -418,7 +419,7 @@ describe("deriveProvisioningState — a provisional verdict needs a status readi
     ).toBe("RESIZING");
   });
 
-  test("started with met targets but a pre-verdict status reading → RESIZING", () => {
+  test("started with met targets but a pre-actuals status reading → RESIZING", () => {
     expect(
       deriveProvisioningState(
         baseInput({ ...staleStatus, serverVerdict: "started" }),
@@ -426,12 +427,12 @@ describe("deriveProvisioningState — a provisional verdict needs a status readi
     ).toBe("RESIZING");
   });
 
-  test("a post-verdict status reading with no marker completes the flow", () => {
+  test("a post-actuals status reading with no marker completes the flow", () => {
     expect(
       deriveProvisioningState(
         baseInput({
           ...staleStatus,
-          statusObservedSinceVerdict: true,
+          statusObservedSinceTargetsMet: true,
           serverVerdict: "in_progress",
         }),
       ).state,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.test.ts
@@ -395,3 +395,103 @@ describe("deriveProvisioningState — an in-flight resize blocks completion", ()
     ).toBe("STALLED");
   });
 });
+
+describe("deriveProvisioningState — a provisional verdict needs a status reading", () => {
+  // The assistant and operational-status queries poll independently, so the
+  // assistant poll can land the target sizes while the status query still holds
+  // its pre-resize snapshot. Under `started`/`in_progress` the server has told
+  // us a rollout is underway, so that stale window must not read as completion:
+  // a marker exists at verdict time, so one status reading taken after the
+  // verdict settles whether it is still running.
+  const staleStatus = {
+    actuals: { machineSize: "large" as const, storageGib: 50 },
+    resizeOperationInFlight: false,
+    sawOperation: false,
+    statusObservedSinceVerdict: false,
+  };
+
+  test("in_progress with met targets but a pre-verdict status reading → RESIZING", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ ...staleStatus, serverVerdict: "in_progress" }),
+      ).state,
+    ).toBe("RESIZING");
+  });
+
+  test("started with met targets but a pre-verdict status reading → RESIZING", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ ...staleStatus, serverVerdict: "started" }),
+      ).state,
+    ).toBe("RESIZING");
+  });
+
+  test("a post-verdict status reading with no marker completes the flow", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          ...staleStatus,
+          statusObservedSinceVerdict: true,
+          serverVerdict: "in_progress",
+        }),
+      ).state,
+    ).toBe("DONE");
+  });
+
+  test("a marker watched appear and clear is equally good evidence", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          ...staleStatus,
+          sawOperation: true,
+          serverVerdict: "in_progress",
+        }),
+      ).state,
+    ).toBe("DONE");
+  });
+
+  test("an unconfirmed provisional verdict never reports NOT_APPLICABLE", () => {
+    // Targets met on the very first observation would normally be
+    // NOT_APPLICABLE; under a provisional verdict that would wrongly claim
+    // there was nothing to do while a rollout is underway.
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          ...staleStatus,
+          initialActuals: { machineSize: "large", storageGib: 50 },
+          serverVerdict: "started",
+        }),
+      ).state,
+    ).toBe("RESIZING");
+  });
+
+  test("already_done stays terminal on its own — the server checked the marker", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({ ...staleStatus, serverVerdict: "already_done" }),
+      ).state,
+    ).toBe("DONE");
+  });
+
+  test("with no verdict at all, inference from initialActuals still completes", () => {
+    // The endpoint failing must keep degrading to pure client-side inference,
+    // so the staleness flag must not gate the no-verdict path.
+    expect(
+      deriveProvisioningState(
+        baseInput({ ...staleStatus, serverVerdict: null }),
+      ).state,
+    ).toBe("DONE");
+  });
+
+  test("an unconfirmed provisional verdict still reaches STALLED", () => {
+    expect(
+      deriveProvisioningState(
+        baseInput({
+          ...staleStatus,
+          serverVerdict: "in_progress",
+          msSinceWatchStart: PROVISION_STALL_MS,
+        }),
+      ).state,
+    ).toBe("STALLED");
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
@@ -62,12 +62,13 @@ export interface DeriveProvisioningInput {
   confirmExpired: boolean;
   serverVerdict?: ProvisioningServerVerdict | null;
   /**
-   * The operational-status query has produced a reading *after* the current
-   * verdict arrived. Only consulted under a provisional verdict — see the
-   * completion rules in `deriveProvisioningState`. Defaults to true so callers
-   * without a verdict (and every pure-inference test) are unaffected.
+   * The operational-status query has produced a reading *after* the actuals
+   * were first seen to meet the targets. Only consulted under a provisional
+   * verdict — see the completion rules in `deriveProvisioningState`. Defaults
+   * to true so callers without a verdict (and every pure-inference test) are
+   * unaffected.
    */
-  statusObservedSinceVerdict?: boolean;
+  statusObservedSinceTargetsMet?: boolean;
 }
 
 export interface ProvisioningSnapshot {
@@ -81,7 +82,7 @@ export interface ProvisioningSnapshot {
  * machine tier); a non-null target needs a known actual at or above it.
  * Machine sizes compare by rank, storage by GiB.
  */
-function targetsMet(
+export function targetsMet(
   targets: ProvisioningDimensions | null,
   actuals: ProvisioningDimensions | null,
 ): boolean {
@@ -110,7 +111,7 @@ export function deriveProvisioningState(
     msSinceWatchStart,
     confirmExpired,
     serverVerdict = null,
-    statusObservedSinceVerdict = true,
+    statusObservedSinceTargetsMet = true,
   } = input;
 
   if (planId !== "pro") {
@@ -141,19 +142,25 @@ export function deriveProvisioningState(
   // nothing has reported the marker even though the platform created it (it
   // creates the marker *before* it writes the effective sizes).
   //
-  // A marker demonstrably exists at the instant such a verdict is issued, so
-  // one status reading taken *after* the verdict settles it: that reading
-  // either finds the marker (still rolling out — the guard above holds) or
-  // finds it retired (genuinely converged). Anchoring on the verdict rather
-  // than on catching the marker mid-flight keeps this robust to poll timing,
-  // and a resize we did watch appear and clear is equally good evidence.
+  // The verdict itself cannot be the anchor: `started` only means the resize
+  // was queued on a worker (the response never waits on it) and `in_progress`
+  // may be a submission racing ahead of the worker's first marker, so a status
+  // read taken right after either verdict can still be the pre-marker
+  // snapshot.
+  //
+  // What does hold is the platform's write order — `resize_assistant` creates
+  // the marker BEFORE it persists the effective sizes. So an actuals read that
+  // shows the targets met necessarily happened after the marker existed, and
+  // any status reading taken after *that* either finds the marker (still
+  // rolling out — the guard above holds) or finds it retired (genuinely
+  // converged). A resize we watched appear and clear is equally good evidence.
   //
   // `already_done` stays terminal on its own because the server checked the
   // marker itself — `collect_pro_provisioning_state` combines targets-met AND
   // no-active-operation before it answers that.
   const provisionalVerdict =
     serverVerdict === "started" || serverVerdict === "in_progress";
-  const rolloutConfirmedOver = sawOperation || statusObservedSinceVerdict;
+  const rolloutConfirmedOver = sawOperation || statusObservedSinceTargetsMet;
 
   if (!resizeOperationInFlight) {
     // Outside a provisional verdict: DONE-by-actuals still wins over a stale

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
@@ -26,7 +26,9 @@ export type ProvisioningStateKind =
 /**
  * Server-reported provisioning verdict (from the ensure-provisioned endpoint,
  * adopted by a later PR). Overrides client-side inference, except that
- * DONE-by-actuals beats a stale verdict.
+ * DONE-by-actuals beats a stale verdict — and that a currently in-flight
+ * resize beats both, since no verdict may complete the flow while the machine
+ * is still rolling out.
  */
 export type ProvisioningServerVerdict =
   | "already_done"
@@ -112,32 +114,45 @@ export function deriveProvisioningState(
 
   const operationObserved = sawOperation || resizeOperationInFlight;
 
-  if (targetsMet(targets, actuals)) {
-    // DONE-by-actuals wins over a stale in_progress/started verdict. A quick
-    // resize can also finish between polls (or behind transient endpoint
-    // failures) without ever being observed, so when no operation was seen,
-    // disambiguate by the first actuals ever observed: if they were below the
-    // targets, a resize must have run → DONE. NOT_APPLICABLE is reserved for
-    // first-observed actuals that already met the targets (null initialActuals
-    // means the current actuals ARE the first observation — the hook freezes
-    // them as the snapshot one render later).
-    if (
-      operationObserved ||
-      serverVerdict === "already_done" ||
-      serverVerdict === "started" ||
-      serverVerdict === "in_progress" ||
-      (initialActuals != null && !targetsMet(targets, initialActuals))
-    ) {
+  // A *currently observed* resize dominates every terminal state, because the
+  // actuals go high before the machine is usable: the platform persists the
+  // effective machine_size / provisioned_storage_gib in the same call that
+  // leaves the operation marker WAITING_FOR_PVC/WAITING_FOR_READY, so targets
+  // read as met from the moment the resize is accepted while the pod is still
+  // restarting. Completing here would clear `machineBusy` and let the domain
+  // step fire its guardian write into a gateway that is still coming back up.
+  // Falling through holds the flow in RESIZING; the stall clock below is still
+  // the escape when a marker never clears. Note this deliberately keys on
+  // `resizeOperationInFlight`, not `operationObserved` — a resize seen only in
+  // the past must still be allowed to settle.
+  if (!resizeOperationInFlight) {
+    if (targetsMet(targets, actuals)) {
+      // DONE-by-actuals wins over a stale in_progress/started verdict. A quick
+      // resize can also finish between polls (or behind transient endpoint
+      // failures) without ever being observed, so when no operation was seen,
+      // disambiguate by the first actuals ever observed: if they were below the
+      // targets, a resize must have run → DONE. NOT_APPLICABLE is reserved for
+      // first-observed actuals that already met the targets (null initialActuals
+      // means the current actuals ARE the first observation — the hook freezes
+      // them as the snapshot one render later).
+      if (
+        operationObserved ||
+        serverVerdict === "already_done" ||
+        serverVerdict === "started" ||
+        serverVerdict === "in_progress" ||
+        (initialActuals != null && !targetsMet(targets, initialActuals))
+      ) {
+        return { state: "DONE", softWaiting: false };
+      }
+      return { state: "NOT_APPLICABLE", softWaiting: false };
+    }
+
+    if (serverVerdict === "already_done") {
       return { state: "DONE", softWaiting: false };
     }
-    return { state: "NOT_APPLICABLE", softWaiting: false };
-  }
-
-  if (serverVerdict === "already_done") {
-    return { state: "DONE", softWaiting: false };
-  }
-  if (serverVerdict === "not_applicable") {
-    return { state: "NOT_APPLICABLE", softWaiting: false };
+    if (serverVerdict === "not_applicable") {
+      return { state: "NOT_APPLICABLE", softWaiting: false };
+    }
   }
 
   if (msSinceWatchStart != null && msSinceWatchStart >= PROVISION_STALL_MS) {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
@@ -61,6 +61,13 @@ export interface DeriveProvisioningInput {
   /** The confirm-phase poll timed out without observing plan_id == "pro". */
   confirmExpired: boolean;
   serverVerdict?: ProvisioningServerVerdict | null;
+  /**
+   * The operational-status query has produced a reading *after* the current
+   * verdict arrived. Only consulted under a provisional verdict — see the
+   * completion rules in `deriveProvisioningState`. Defaults to true so callers
+   * without a verdict (and every pure-inference test) are unaffected.
+   */
+  statusObservedSinceVerdict?: boolean;
 }
 
 export interface ProvisioningSnapshot {
@@ -103,6 +110,7 @@ export function deriveProvisioningState(
     msSinceWatchStart,
     confirmExpired,
     serverVerdict = null,
+    statusObservedSinceVerdict = true,
   } = input;
 
   if (planId !== "pro") {
@@ -125,33 +133,59 @@ export function deriveProvisioningState(
   // the escape when a marker never clears. Note this deliberately keys on
   // `resizeOperationInFlight`, not `operationObserved` — a resize seen only in
   // the past must still be allowed to settle.
+  // `started` / `in_progress` are the server saying a rollout is underway but
+  // NOT finished. Under one of those, targets-met alone can no longer stand in
+  // for completion: the assistant and operational-status queries poll
+  // independently, so the assistant poll can land the target sizes while the
+  // status query still holds its pre-resize snapshot — a window in which
+  // nothing has reported the marker even though the platform created it (it
+  // creates the marker *before* it writes the effective sizes).
+  //
+  // A marker demonstrably exists at the instant such a verdict is issued, so
+  // one status reading taken *after* the verdict settles it: that reading
+  // either finds the marker (still rolling out — the guard above holds) or
+  // finds it retired (genuinely converged). Anchoring on the verdict rather
+  // than on catching the marker mid-flight keeps this robust to poll timing,
+  // and a resize we did watch appear and clear is equally good evidence.
+  //
+  // `already_done` stays terminal on its own because the server checked the
+  // marker itself — `collect_pro_provisioning_state` combines targets-met AND
+  // no-active-operation before it answers that.
+  const provisionalVerdict =
+    serverVerdict === "started" || serverVerdict === "in_progress";
+  const rolloutConfirmedOver = sawOperation || statusObservedSinceVerdict;
+
   if (!resizeOperationInFlight) {
-    if (targetsMet(targets, actuals)) {
-      // DONE-by-actuals wins over a stale in_progress/started verdict. A quick
-      // resize can also finish between polls (or behind transient endpoint
-      // failures) without ever being observed, so when no operation was seen,
-      // disambiguate by the first actuals ever observed: if they were below the
-      // targets, a resize must have run → DONE. NOT_APPLICABLE is reserved for
-      // first-observed actuals that already met the targets (null initialActuals
-      // means the current actuals ARE the first observation — the hook freezes
-      // them as the snapshot one render later).
-      if (
-        operationObserved ||
+    // Outside a provisional verdict: DONE-by-actuals still wins over a stale
+    // verdict. A quick resize can finish between polls (or behind transient
+    // endpoint failures) without ever being observed, so when no operation was
+    // seen, disambiguate by the first actuals ever observed: if they were below
+    // the targets, a resize must have run → DONE. NOT_APPLICABLE is reserved
+    // for first-observed actuals that already met the targets (null
+    // initialActuals means the current actuals ARE the first observation — the
+    // hook freezes them as the snapshot one render later).
+    const completed = provisionalVerdict
+      ? rolloutConfirmedOver
+      : operationObserved ||
         serverVerdict === "already_done" ||
-        serverVerdict === "started" ||
-        serverVerdict === "in_progress" ||
-        (initialActuals != null && !targetsMet(targets, initialActuals))
-      ) {
+        (initialActuals != null && !targetsMet(targets, initialActuals));
+
+    if (targetsMet(targets, actuals)) {
+      if (completed) {
         return { state: "DONE", softWaiting: false };
       }
-      return { state: "NOT_APPLICABLE", softWaiting: false };
-    }
-
-    if (serverVerdict === "already_done") {
-      return { state: "DONE", softWaiting: false };
-    }
-    if (serverVerdict === "not_applicable") {
-      return { state: "NOT_APPLICABLE", softWaiting: false };
+      // An uncorroborated provisional verdict keeps observing (falls through to
+      // RESIZING) rather than completing or declaring there was nothing to do.
+      if (!provisionalVerdict) {
+        return { state: "NOT_APPLICABLE", softWaiting: false };
+      }
+    } else {
+      if (serverVerdict === "already_done") {
+        return { state: "DONE", softWaiting: false };
+      }
+      if (serverVerdict === "not_applicable") {
+        return { state: "NOT_APPLICABLE", softWaiting: false };
+      }
     }
   }
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -433,6 +433,33 @@ describe("useProProvisioning", () => {
   );
 
   test(
+    "a hung automatic reconcile leaves Apply & Restart enabled",
+    async () => {
+      // `ensureResponse` defaults to held-in-flight, so the automatic reconcile
+      // fired on Pro confirm never settles — exactly the case that strands the
+      // user in STALLED. Its pending state must not disable their only recovery
+      // control; `pending` tracks user-initiated applies only.
+      const { client } = renderProbe();
+      await reachResizing(client);
+      expect(ensureCalls).toBeGreaterThan(0);
+
+      dateNowOffsetMs = 200_000;
+      await waitFor(() => expect(latest!.state).toBe("STALLED"), {
+        timeout: 5000,
+      });
+
+      expect(latest!.stalledAction.pending).toBe(false);
+
+      // And a manual apply does report pending while it is in flight.
+      act(() => latest!.stalledAction.onApply());
+      await waitFor(() => expect(latest!.stalledAction.pending).toBe(true), {
+        timeout: 5000,
+      });
+    },
+    20_000,
+  );
+
+  test(
     "the stalled action re-calls ensure-provisioned, leaves STALLED and can reach DONE",
     async () => {
       const { client } = renderProbe();

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -19,6 +19,7 @@ import {
 import * as sdkGen from "@/generated/api/sdk.gen";
 import type {
   Assistant,
+  EnsureProvisionedResponse,
   OnboardingStateResponse,
   OperationalStatus,
   SubscriptionResponse,
@@ -29,10 +30,13 @@ import * as proOnboardingUtils from "./utils";
 
 /** Shrunk so confirm-timeout reachability doesn't wait out the real 10s poll. */
 const TEST_CONFIRM_TIMEOUT_MS = 800;
+/** Shrunk so the no_active_pro race retry doesn't wait out the real 2s. */
+const TEST_RACE_RETRY_MS = 150;
 
 mock.module("./utils", () => ({
   ...proOnboardingUtils,
   PRO_POLL_TIMEOUT_MS: TEST_CONFIRM_TIMEOUT_MS,
+  ENSURE_PROVISIONED_RACE_RETRY_MS: TEST_RACE_RETRY_MS,
 }));
 
 // Stall detection compares wall-clock time against the 90s threshold; the
@@ -121,6 +125,26 @@ let operationalStatusCalls = 0;
 let subscriptionCalls = 0;
 let isOrgReadyMock = true;
 let fetchOrganizationsCalls = 0;
+let ensureCalls = 0;
+/**
+ * The ensure-provisioned response is *held in flight* by default so the
+ * inference-path tests below keep observing the exact WAITING → RESIZING
+ * sequence they always have (a verdict resolving mid-sequence would race
+ * them). Verdict tests opt in by assigning `ensureResponse`/`ensureError`.
+ */
+let ensureResponse: EnsureProvisionedResponse | null = null;
+let ensureError: unknown = null;
+
+function makeEnsureResponse(
+  state: EnsureProvisionedResponse["state"],
+  reason: EnsureProvisionedResponse["reason"] = null,
+): EnsureProvisionedResponse {
+  return {
+    state,
+    reason,
+    targets: { machine_size: "large", storage_gib: 50 },
+  };
+}
 
 mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => isOrgReadyMock,
@@ -181,6 +205,17 @@ mock.module("@/generated/api/sdk.gen", () => ({
       data: operationalStatusResponse,
       response: { ok: true },
     });
+  },
+  organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate: () => {
+    ensureCalls += 1;
+    if (ensureError != null) {
+      return Promise.reject(ensureError);
+    }
+    if (!ensureResponse) {
+      // Held in flight — see the `ensureResponse` docstring.
+      return new Promise(() => {});
+    }
+    return Promise.resolve({ data: ensureResponse, response: { ok: true } });
   },
 }));
 
@@ -248,6 +283,9 @@ beforeEach(() => {
   subscriptionCalls = 0;
   isOrgReadyMock = true;
   fetchOrganizationsCalls = 0;
+  ensureCalls = 0;
+  ensureResponse = null;
+  ensureError = null;
   dateNowOffsetMs = 0;
   latest = null;
 });
@@ -369,10 +407,11 @@ describe("useProProvisioning", () => {
   );
 
   test(
-    "resumeAfterManualApply leaves STALLED for RESIZING and can reach DONE",
+    "the stalled action re-calls ensure-provisioned, leaves STALLED and can reach DONE",
     async () => {
       const { client } = renderProbe();
       await reachResizing(client);
+      const autoCalls = ensureCalls;
 
       // Jump the wall clock past the stall threshold; the next 1s clock tick
       // re-derives the state as STALLED.
@@ -381,8 +420,46 @@ describe("useProProvisioning", () => {
         timeout: 5000,
       });
 
-      act(() => latest!.resumeAfterManualApply());
-      await waitFor(() => expect(latest!.state).toBe("RESIZING"));
+      // The reconcile answers "started": the verdict alone lifts the wizard
+      // back to RESIZING and the success re-bases the stall clock.
+      ensureResponse = makeEnsureResponse("started");
+      act(() => latest!.stalledAction.onApply());
+      await waitFor(() => expect(ensureCalls).toBe(autoCalls + 1));
+      await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
+        timeout: 5000,
+      });
+      expect(latest!.stalledAction.error).toBeNull();
+
+      assistantResponse = makeAssistant("large", 50);
+      await refetchAll(client);
+      await waitFor(() => expect(latest!.state).toBe("DONE"), {
+        timeout: 5000,
+      });
+    },
+    20_000,
+  );
+
+  test(
+    "a failed stalled retry surfaces its error without leaving STALLED wedged",
+    async () => {
+      const { client } = renderProbe();
+      await reachResizing(client);
+
+      dateNowOffsetMs = 200_000;
+      await waitFor(() => expect(latest!.state).toBe("STALLED"), {
+        timeout: 5000,
+      });
+
+      ensureError = { error: "provisioning_submission_failed" };
+      act(() => latest!.stalledAction.onApply());
+      await waitFor(() =>
+        expect(latest!.stalledAction.error).toEqual({
+          error: "provisioning_submission_failed",
+        }),
+      );
+      // A user-visible error, but not a terminal one: still STALLED, still
+      // polling, so a late-landing resize recovers on its own.
+      expect(latest!.state).toBe("STALLED");
 
       assistantResponse = makeAssistant("large", 50);
       await refetchAll(client);
@@ -442,9 +519,13 @@ describe("useProProvisioning", () => {
       });
       expect(latest!.escapeEligible).toBe(true);
 
-      // The resume re-bases the watch clock, so eligibility starts over.
-      act(() => latest!.resumeAfterManualApply());
-      await waitFor(() => expect(latest!.escapeEligible).toBe(false));
+      // A successful stalled retry re-bases the watch clock, so eligibility
+      // starts over.
+      ensureResponse = makeEnsureResponse("started");
+      act(() => latest!.stalledAction.onApply());
+      await waitFor(() => expect(latest!.escapeEligible).toBe(false), {
+        timeout: 5000,
+      });
       expect(latest!.state).toBe("RESIZING");
     },
     20_000,
@@ -815,4 +896,128 @@ describe("useProProvisioning", () => {
     expect(latest!.targets).toEqual({ machineSize: "large", storageGib: 50 });
     expect(latest!.state).toBe("RESIZING");
   });
+});
+
+describe("useProProvisioning — ensure-provisioned reconcile", () => {
+  test("is not called before the subscription reports pro", async () => {
+    renderProbe();
+
+    await waitFor(() => expect(latest!.state).toBe("CONFIRMING"));
+    // Let several confirm polls land on the non-pro plan.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(subscriptionCalls).toBeGreaterThan(0);
+    expect(ensureCalls).toBe(0);
+  });
+
+  test(
+    "fires exactly once on the pro transition, across re-renders and repolls",
+    async () => {
+      ensureResponse = makeEnsureResponse("started");
+      const { client, rerender } = renderProbe();
+      await waitFor(() => expect(latest!.state).toBe("CONFIRMING"));
+      expect(ensureCalls).toBe(0);
+
+      subscriptionPlanId = "pro";
+      await refetchAll(client);
+      await waitFor(() => expect(ensureCalls).toBe(1), { timeout: 5000 });
+
+      // Re-renders, further polls and the still-running clock must not re-fire
+      // the reconcile — it is once per wizard open.
+      rerender();
+      await refetchAll(client);
+      rerender();
+      await refetchAll(client);
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      expect(ensureCalls).toBe(1);
+    },
+    20_000,
+  );
+
+  test("a started verdict drives RESIZING with no operation ever observed", async () => {
+    ensureResponse = makeEnsureResponse("started");
+    subscriptionPlanId = "pro";
+    renderProbe();
+
+    // The operational status never reports a resize; the verdict alone is
+    // enough to leave WAITING.
+    await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
+      timeout: 5000,
+    });
+  });
+
+  test("an already_done verdict finishes the wizard while the actuals still lag", async () => {
+    ensureResponse = makeEnsureResponse("already_done");
+    subscriptionPlanId = "pro";
+    renderProbe();
+
+    await waitFor(() => expect(latest!.state).toBe("DONE"), { timeout: 5000 });
+  });
+
+  test("a not_applicable / no_targets verdict is adopted as terminal", async () => {
+    ensureResponse = makeEnsureResponse("not_applicable", "no_targets");
+    subscriptionPlanId = "pro";
+    renderProbe();
+
+    await waitFor(() => expect(latest!.state).toBe("NOT_APPLICABLE"), {
+      timeout: 5000,
+    });
+  });
+
+  test(
+    "a not_applicable / no_active_pro verdict is never adopted and is retried once",
+    async () => {
+      // The entitlement race: the subscription flipped to pro but the
+      // reconcile can't see the active pro entitlement yet.
+      ensureResponse = makeEnsureResponse("not_applicable", "no_active_pro");
+      subscriptionPlanId = "pro";
+      renderProbe();
+
+      await waitFor(() => expect(ensureCalls).toBe(1), { timeout: 5000 });
+      // Adopting it would strand the wizard in a terminal NOT_APPLICABLE with
+      // an unprovisioned assistant; inference keeps running instead.
+      await waitFor(() => expect(latest!.state).toBe("WAITING"), {
+        timeout: 5000,
+      });
+
+      // Exactly one automatic re-ask, which the race has resolved by now.
+      ensureResponse = makeEnsureResponse("started");
+      await waitFor(() => expect(ensureCalls).toBe(2), { timeout: 5000 });
+      await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
+        timeout: 5000,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      expect(ensureCalls).toBe(2);
+    },
+    20_000,
+  );
+
+  test(
+    "a 503 leaves the wizard inferring rather than erroring",
+    async () => {
+      ensureError = { error: "provisioning_submission_failed" };
+      subscriptionPlanId = "pro";
+      const { client } = renderProbe();
+
+      await waitFor(() => expect(ensureCalls).toBe(1), { timeout: 5000 });
+      await waitFor(() => expect(latest!.state).toBe("WAITING"), {
+        timeout: 5000,
+      });
+      // The automatic call failing is silent: no error surface, no new
+      // blocking state, no auto-retry storm.
+      expect(latest!.stalledAction.error).toBeNull();
+      expect(latest!.confirmError).toBe(false);
+      expect(latest!.targetsError).toBe(false);
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      expect(ensureCalls).toBe(1);
+
+      // The webhook-driven resize lands anyway and the flow completes on pure
+      // client-side inference.
+      assistantResponse = makeAssistant("large", 50);
+      await refetchAll(client);
+      await waitFor(() => expect(latest!.state).toBe("DONE"), {
+        timeout: 5000,
+      });
+    },
+    20_000,
+  );
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -134,6 +134,16 @@ let ensureCalls = 0;
  */
 let ensureResponse: EnsureProvisionedResponse | null = null;
 let ensureError: unknown = null;
+/**
+ * When set, every reconcile call parks in `pendingEnsures` so a test can settle
+ * one specific call by hand — the only way to land a response at a chosen point
+ * in the open/close lifecycle.
+ */
+let ensureDeferred = false;
+let pendingEnsures: {
+  resolve: (data: EnsureProvisionedResponse) => void;
+  reject: (error: unknown) => void;
+}[] = [];
 
 function makeEnsureResponse(
   state: EnsureProvisionedResponse["state"],
@@ -208,6 +218,15 @@ mock.module("@/generated/api/sdk.gen", () => ({
   },
   organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate: () => {
     ensureCalls += 1;
+    if (ensureDeferred) {
+      return new Promise((resolve, reject) => {
+        pendingEnsures.push({
+          resolve: (data: EnsureProvisionedResponse) =>
+            resolve({ data, response: { ok: true } }),
+          reject,
+        });
+      });
+    }
     if (ensureError != null) {
       return Promise.reject(ensureError);
     }
@@ -223,8 +242,8 @@ const { useProProvisioning } = await import("./use-pro-provisioning");
 
 let latest: ProProvisioningResult | null = null;
 
-function Probe() {
-  const result = useProProvisioning({ open: true });
+function Probe({ open = true }: { open?: boolean }) {
+  const result = useProProvisioning({ open });
   useEffect(() => {
     latest = result;
   });
@@ -238,13 +257,18 @@ function makeClient() {
 }
 
 function renderProbe(client = makeClient()) {
-  const ui = () => (
+  const ui = (open = true) => (
     <QueryClientProvider client={client}>
-      <Probe />
+      <Probe open={open} />
     </QueryClientProvider>
   );
   const view = render(ui());
-  return { client, rerender: () => view.rerender(ui()) };
+  return {
+    client,
+    rerender: () => view.rerender(ui()),
+    /** Close/reopen the wizard without unmounting the hook. */
+    setOpen: (open: boolean) => view.rerender(ui(open)),
+  };
 }
 
 async function refetchAll(client: QueryClient) {
@@ -286,6 +310,8 @@ beforeEach(() => {
   ensureCalls = 0;
   ensureResponse = null;
   ensureError = null;
+  ensureDeferred = false;
+  pendingEnsures = [];
   dateNowOffsetMs = 0;
   latest = null;
 });
@@ -1017,6 +1043,78 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
       await waitFor(() => expect(latest!.state).toBe("DONE"), {
         timeout: 5000,
       });
+    },
+    20_000,
+  );
+
+  test(
+    "a verdict landing after close is discarded and never drives the next open",
+    async () => {
+      ensureDeferred = true;
+      subscriptionPlanId = "pro";
+      const { setOpen } = renderProbe();
+
+      await waitFor(() => expect(ensureCalls).toBe(1), { timeout: 5000 });
+      await waitFor(() => expect(latest!.state).toBe("WAITING"), {
+        timeout: 5000,
+      });
+
+      act(() => setOpen(false));
+
+      // The first open's reconcile answers a terminal verdict only after the
+      // close reset; adopting it would park the reopened wizard in DONE with
+      // an assistant that is still below its targets.
+      await act(async () => {
+        pendingEnsures[0]!.resolve(makeEnsureResponse("already_done"));
+        await Promise.resolve();
+      });
+
+      act(() => setOpen(true));
+      await waitFor(() => expect(ensureCalls).toBe(2), { timeout: 5000 });
+      await waitFor(() => expect(latest!.state).toBe("WAITING"), {
+        timeout: 5000,
+      });
+
+      // Only the reopen's own reconcile moves it.
+      await act(async () => {
+        pendingEnsures[1]!.resolve(makeEnsureResponse("started"));
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
+        timeout: 5000,
+      });
+    },
+    20_000,
+  );
+
+  test(
+    "an error landing after close does not surface on the next open",
+    async () => {
+      ensureDeferred = true;
+      subscriptionPlanId = "pro";
+      const { setOpen } = renderProbe();
+
+      await waitFor(() => expect(ensureCalls).toBe(1), { timeout: 5000 });
+      await waitFor(() => expect(latest!.state).toBe("WAITING"), {
+        timeout: 5000,
+      });
+
+      // A user-initiated reconcile — the only source that surfaces an error.
+      act(() => latest!.stalledAction.onApply());
+      await waitFor(() => expect(ensureCalls).toBe(2), { timeout: 5000 });
+
+      act(() => setOpen(false));
+      await act(async () => {
+        pendingEnsures[1]!.reject({ error: "provisioning_submission_failed" });
+        await Promise.resolve();
+      });
+
+      act(() => setOpen(true));
+      await waitFor(() => expect(ensureCalls).toBe(3), { timeout: 5000 });
+      await waitFor(() => expect(latest!.state).toBe("WAITING"), {
+        timeout: 5000,
+      });
+      expect(latest!.stalledAction.error).toBeNull();
     },
     20_000,
   );

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -465,6 +465,39 @@ describe("useProProvisioning", () => {
   );
 
   test(
+    "a dead-end no_active_pro apply stays STALLED and surfaces why",
+    async () => {
+      // The auto reconcile consumes the once-per-open re-ask, so a later manual
+      // apply that still gets no_active_pro can queue nothing and re-ask
+      // nothing. Resuming the watch there would hide the recovery button for
+      // another stall window with no resize running.
+      ensureResponse = makeEnsureResponse("not_applicable", "no_active_pro");
+      const { client } = renderProbe();
+      await reachResizing(client);
+
+      dateNowOffsetMs = 200_000;
+      await waitFor(() => expect(latest!.state).toBe("STALLED"), {
+        timeout: 5000,
+      });
+
+      const callsBefore = ensureCalls;
+      act(() => latest!.stalledAction.onApply());
+      await waitFor(() => expect(ensureCalls).toBeGreaterThan(callsBefore));
+
+      await waitFor(
+        () =>
+          expect(latest!.stalledAction.error).toEqual({
+            error: "no_active_pro",
+          }),
+        { timeout: 5000 },
+      );
+      // Still STALLED, so Apply & Restart remains on screen.
+      expect(latest!.state).toBe("STALLED");
+    },
+    20_000,
+  );
+
+  test(
     "a hung automatic reconcile leaves Apply & Restart enabled",
     async () => {
       // `ensureResponse` defaults to held-in-flight, so the automatic reconcile

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -743,6 +743,51 @@ describe("useProProvisioning", () => {
   });
 
   test(
+    "the targets-met latch is re-keyed when the provisioning target changes",
+    async () => {
+      // Both assistants already satisfy the targets, so `currentTargetsMet`
+      // never flips false across the switch. Without re-keying, the first
+      // assistant's timestamp would survive and any status reading merely
+      // postdating it could confirm a rollout for the second that nobody
+      // observed. Status is held at `active` so `sawOperation` never latches.
+      ensureResponse = makeEnsureResponse("started");
+      subscriptionPlanId = "pro";
+      onboardingResponse = { ...makeOnboarding(), primary_assistant_id: null };
+      assistantResponse = makeAssistant("large", 50);
+      assistantsById["assistant-2"] = {
+        ...makeAssistant("large", 50),
+        id: "assistant-2",
+      };
+      const { client } = renderProbe();
+
+      // Settles on the active assistant and completes against it.
+      await waitFor(() => expect(latest!.state).toBe("DONE"), {
+        timeout: 5000,
+      });
+
+      // The primary lands and re-points the polls at a different assistant.
+      onboardingResponse = {
+        ...makeOnboarding(),
+        primary_assistant_id: "assistant-2",
+      };
+      await refetchAll(client);
+      await waitFor(() => expect(latest!.assistantId).toBe("assistant-2"), {
+        timeout: 5000,
+      });
+
+      // The latch now describes assistant-2, so its confirmation had to come
+      // from a status reading taken after *its* actuals were seen to meet the
+      // targets — not from the previous assistant's stale timestamp.
+      const callsAfterSwitch = operationalStatusCalls;
+      await waitFor(() => expect(latest!.state).toBe("DONE"), {
+        timeout: 5000,
+      });
+      expect(operationalStatusCalls).toBeGreaterThanOrEqual(callsAfterSwitch);
+    },
+    20_000,
+  );
+
+  test(
     "background onboarding refetch keeps the fresh primary selected (no flip to active)",
     async () => {
       subscriptionPlanId = "pro";

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -433,6 +433,38 @@ describe("useProProvisioning", () => {
   );
 
   test(
+    "a started verdict needs a status reading taken after the target actuals",
+    async () => {
+      // The marker is created by a background worker, so a status read taken
+      // right after a `started` verdict can predate it entirely. The status is
+      // held at `active` throughout here, so `sawOperation` never latches and
+      // the anchor is the only thing that can complete the flow.
+      ensureResponse = makeEnsureResponse("started");
+      const { client } = renderProbe();
+
+      await waitFor(() => expect(latest!.state).toBe("CONFIRMING"));
+      subscriptionPlanId = "pro";
+      await refetchAll(client);
+      await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
+        timeout: 5000,
+      });
+
+      // Targets now read as met, but no status reading has been taken since.
+      assistantResponse = makeAssistant("large", 50);
+      await refetchAll(client);
+      const callsAtTargetsMet = operationalStatusCalls;
+      expect(latest!.state).not.toBe("DONE");
+
+      // A later status poll is what actually settles it.
+      await waitFor(() => expect(latest!.state).toBe("DONE"), {
+        timeout: 5000,
+      });
+      expect(operationalStatusCalls).toBeGreaterThan(callsAtTargetsMet);
+    },
+    20_000,
+  );
+
+  test(
     "a hung automatic reconcile leaves Apply & Restart enabled",
     async () => {
       // `ensureResponse` defaults to held-in-flight, so the automatic reconcile

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -456,7 +456,11 @@ describe("useProProvisioning", () => {
       });
       expect(latest!.stalledAction.error).toBeNull();
 
+      // The landing resize also retires the operation marker: the platform
+      // reports `resizing_machine` until the rollout converges, so met actuals
+      // never coexist with an in-flight marker on a real completion.
       assistantResponse = makeAssistant("large", 50);
+      operationalStatusResponse = makeOperationalStatus("active");
       await refetchAll(client);
       await waitFor(() => expect(latest!.state).toBe("DONE"), {
         timeout: 5000,
@@ -488,6 +492,7 @@ describe("useProProvisioning", () => {
       expect(latest!.state).toBe("STALLED");
 
       assistantResponse = makeAssistant("large", 50);
+      operationalStatusResponse = makeOperationalStatus("active");
       await refetchAll(client);
       await waitFor(() => expect(latest!.state).toBe("DONE"), {
         timeout: 5000,
@@ -517,6 +522,7 @@ describe("useProProvisioning", () => {
 
       // The resize lands with no manual apply — the flow self-recovers.
       assistantResponse = makeAssistant("large", 50);
+      operationalStatusResponse = makeOperationalStatus("active");
       await refetchAll(client);
       await waitFor(() => expect(latest!.state).toBe("DONE"), {
         timeout: 5000,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -170,6 +170,15 @@ export function useProProvisioning({
   // queues the resize on a worker, so a status read right after it can precede
   // the marker's creation entirely.
   const [targetsMetAt, setTargetsMetAt] = useState<number | null>(null);
+  // The assistant that latch describes. Without it, switching to a different
+  // provisioning target that *also* already meets the targets would never flip
+  // `currentTargetsMet` false, so the previous assistant's timestamp would
+  // survive — and a status reading for the new assistant that merely postdates
+  // it could confirm a rollout nobody has observed. Mirrors how the actuals
+  // snapshot is keyed to `snapshotAssistantId`.
+  const [targetsMetAssistantId, setTargetsMetAssistantId] = useState<
+    string | null
+  >(null);
   // Only ever set by a user-initiated reconcile — see runEnsureProvisioned.
   const [ensureError, setEnsureError] = useState<unknown>(null);
   // Pending state for the *manual* reconcile only. The mutation's own
@@ -219,6 +228,7 @@ export function useProProvisioning({
     setTracking(true);
     setServerVerdict(null);
     setTargetsMetAt(null);
+    setTargetsMetAssistantId(null);
     setEnsureError(null);
     setManualPending(false);
     setRaceRetryScheduled(false);
@@ -503,14 +513,19 @@ export function useProProvisioning({
   // the targets (a re-keyed assistant), so the anchor always describes the
   // observation the completion check is about to be made against.
   const currentTargetsMet = targetsMet(targets, actuals);
+  const targetsMetMatchesAssistant = targetsMetAssistantId === assistantId;
   useEffect(() => {
     if (!open) return;
     if (currentTargetsMet) {
-      setTargetsMetAt((prev) => prev ?? Date.now());
+      setTargetsMetAt((prev) =>
+        prev != null && targetsMetMatchesAssistant ? prev : Date.now(),
+      );
+      setTargetsMetAssistantId(assistantId);
     } else {
       setTargetsMetAt(null);
+      setTargetsMetAssistantId(null);
     }
-  }, [open, currentTargetsMet]);
+  }, [open, currentTargetsMet, assistantId, targetsMetMatchesAssistant]);
 
   // Freeze the first non-null actuals as the before/after "from" side, keyed to
   // the assistant it describes. When assistantId changes (e.g. a stale primary
@@ -547,8 +562,12 @@ export function useProProvisioning({
     // "we have read the operational status since the actuals reached the
     // targets". A status query stuck erroring never advances it, which
     // correctly withholds completion rather than guessing.
+    // The latch must also still describe the assistant being provisioned —
+    // otherwise the render before the re-keying effect runs could confirm
+    // against the previous target's timestamp.
     statusObservedSinceTargetsMet:
       targetsMetAt != null &&
+      targetsMetMatchesAssistant &&
       operationalStatusQuery.dataUpdatedAt > targetsMetAt,
   });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -106,7 +106,7 @@ export interface ProProvisioningResult {
   /**
    * The assistant provisioning targets: the onboarding payload's primary
    * assistant when named, else the active assistant. Drives the actuals and
-   * operational-status polls and the stalled manual resize.
+   * operational-status polls.
    */
   assistantId: string | null;
   /** `domain_setup_available` from the onboarding state, once loaded. */

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -170,6 +170,10 @@ export function useProProvisioning({
   const ensureRequestedRef = useRef(false);
   // At most one automatic re-call for the no_active_pro entitlement race.
   const ensureRaceRetriedRef = useRef(false);
+  // Identifies the wizard open a reconcile belongs to. Bumped on close, so a
+  // response that lands after the reset is discarded instead of writing a
+  // verdict or an error into the next open's session.
+  const ensureGenerationRef = useRef(0);
   const [sawOperation, setSawOperation] = useState(false);
   const [actualsSnapshot, setActualsSnapshot] =
     useState<ProvisioningDimensions | null>(null);
@@ -202,6 +206,7 @@ export function useProProvisioning({
     setRaceRetryScheduled(false);
     ensureRequestedRef.current = false;
     ensureRaceRetriedRef.current = false;
+    ensureGenerationRef.current += 1;
   }, [open]);
 
   // Refetch pre-checkout caches on open. Invalidation keeps serving cached
@@ -278,11 +283,19 @@ export function useProProvisioning({
 
   const runEnsureProvisioned = useCallback(
     (source: "auto" | "manual") => {
-      if (source === "manual") setEnsureError(null);
+      if (source === "manual") {
+        setEnsureError(null);
+      }
+      // The open this call belongs to. Both callbacks drop out when the wizard
+      // has since closed, so a late response can't drive a later session.
+      const generation = ensureGenerationRef.current;
       ensureProvisioned(
         {},
         {
           onSuccess: (data) => {
+            if (generation !== ensureGenerationRef.current) {
+              return;
+            }
             setEnsureError(null);
             // `not_applicable` + `no_active_pro` is the subscription-flipped-
             // but-entitlement-not-yet-visible race, not an answer: adopting it
@@ -300,14 +313,21 @@ export function useProProvisioning({
             } else {
               setServerVerdict(data.state);
             }
-            if (source === "manual") resumeWatch();
+            if (source === "manual") {
+              resumeWatch();
+            }
           },
           onError: (error) => {
+            if (generation !== ensureGenerationRef.current) {
+              return;
+            }
             // 503 (submission couldn't be queued) or a network blip: nothing
             // was queued and nothing is broken — the actuals polling still
             // converges, so the automatic call degrades silently to inference.
             // Only a user-initiated retry earns a visible error.
-            if (source === "manual") setEnsureError(error);
+            if (source === "manual") {
+              setEnsureError(error);
+            }
           },
         },
       );
@@ -319,16 +339,28 @@ export function useProProvisioning({
   // reports Pro. The ref guard survives re-renders and the confirm-generation
   // retry counter; `proConfirmed` itself only latches once per open.
   useEffect(() => {
-    if (!open || !orgReady || !proConfirmed) return;
-    if (ensureRequestedRef.current) return;
+    if (!open || !orgReady || !proConfirmed) {
+      return;
+    }
+    if (ensureRequestedRef.current) {
+      return;
+    }
     ensureRequestedRef.current = true;
     runEnsureProvisioned("auto");
   }, [open, orgReady, proConfirmed, runEnsureProvisioned]);
 
   useEffect(() => {
-    if (!raceRetryScheduled) return;
+    if (!raceRetryScheduled) {
+      return;
+    }
+    // Pinned to the open that scheduled it, so a pending timer never issues a
+    // call on behalf of a later one.
+    const generation = ensureGenerationRef.current;
     const t = setTimeout(() => {
       setRaceRetryScheduled(false);
+      if (generation !== ensureGenerationRef.current) {
+        return;
+      }
       runEnsureProvisioned("auto");
     }, ENSURE_PROVISIONED_RACE_RETRY_MS);
     return () => clearTimeout(t);

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -338,12 +338,23 @@ export function useProProvisioning({
               if (!ensureRaceRetriedRef.current) {
                 ensureRaceRetriedRef.current = true;
                 setRaceRetryScheduled(true);
+                // A re-ask is already queued, so observation may resume.
+                if (source === "manual") {
+                  resumeWatch();
+                }
+              } else if (source === "manual") {
+                // Dead end: the verdict is deliberately not adopted, nothing
+                // was queued, and the once-per-open re-ask is spent. Re-basing
+                // the stall clock here would drop the user out of STALLED —
+                // hiding Apply & Restart for another stall window — with no
+                // resize running and nothing said. Hold the state and explain.
+                setEnsureError({ error: "no_active_pro" });
               }
             } else {
               setServerVerdict(data.state);
-            }
-            if (source === "manual") {
-              resumeWatch();
+              if (source === "manual") {
+                resumeWatch();
+              }
             }
           },
           onError: (error) => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -45,6 +45,7 @@ import {
   type ProvisioningDimensions,
   type ProvisioningServerVerdict,
   type ProvisioningStateKind,
+  targetsMet,
 } from "./provisioning-machine";
 import {
   ENSURE_PROVISIONED_RACE_RETRY_MS,
@@ -161,11 +162,14 @@ export function useProProvisioning({
   // case the machine falls back to pure client-side inference.
   const [serverVerdict, setServerVerdict] =
     useState<ProvisioningServerVerdict | null>(null);
-  // When the current verdict landed. A provisional verdict (`started` /
-  // `in_progress`) only clears the way to a terminal state once the
+  // When the actuals were first seen to meet the targets. Under a provisional
+  // verdict (`started` / `in_progress`) the flow may only go terminal once the
   // operational-status query has read the world at least once after this
-  // instant — see the completion rules in `deriveProvisioningState`.
-  const [verdictAt, setVerdictAt] = useState<number | null>(null);
+  // instant — see the completion rules in `deriveProvisioningState`. The
+  // verdict's own arrival is deliberately NOT the anchor: `started` merely
+  // queues the resize on a worker, so a status read right after it can precede
+  // the marker's creation entirely.
+  const [targetsMetAt, setTargetsMetAt] = useState<number | null>(null);
   // Only ever set by a user-initiated reconcile — see runEnsureProvisioned.
   const [ensureError, setEnsureError] = useState<unknown>(null);
   // Pending state for the *manual* reconcile only. The mutation's own
@@ -214,7 +218,7 @@ export function useProProvisioning({
     setSnapshotAssistantId(null);
     setTracking(true);
     setServerVerdict(null);
-    setVerdictAt(null);
+    setTargetsMetAt(null);
     setEnsureError(null);
     setManualPending(false);
     setRaceRetryScheduled(false);
@@ -327,7 +331,6 @@ export function useProProvisioning({
               }
             } else {
               setServerVerdict(data.state);
-              setVerdictAt(Date.now());
             }
             if (source === "manual") {
               resumeWatch();
@@ -493,6 +496,22 @@ export function useProProvisioning({
 
   const snapshotMatchesAssistant = snapshotAssistantId === assistantId;
 
+  // Latch the instant the actuals first read as meeting the targets. The
+  // platform creates the resize marker BEFORE it persists the effective sizes,
+  // so any operational-status reading taken after this instant is guaranteed to
+  // see that marker — or its retirement. Cleared if the actuals fall back below
+  // the targets (a re-keyed assistant), so the anchor always describes the
+  // observation the completion check is about to be made against.
+  const currentTargetsMet = targetsMet(targets, actuals);
+  useEffect(() => {
+    if (!open) return;
+    if (currentTargetsMet) {
+      setTargetsMetAt((prev) => prev ?? Date.now());
+    } else {
+      setTargetsMetAt(null);
+    }
+  }, [open, currentTargetsMet]);
+
   // Freeze the first non-null actuals as the before/after "from" side, keyed to
   // the assistant it describes. When assistantId changes (e.g. a stale primary
   // corrected to the fresh one) the by-id assistant query re-keys, so re-capture
@@ -525,11 +544,12 @@ export function useProProvisioning({
     confirmExpired,
     serverVerdict,
     // A successful status fetch always advances `dataUpdatedAt`, so this is
-    // "we have read the operational status since the verdict arrived". A
-    // status query stuck erroring never advances it, which correctly withholds
-    // completion rather than guessing.
-    statusObservedSinceVerdict:
-      verdictAt == null || operationalStatusQuery.dataUpdatedAt > verdictAt,
+    // "we have read the operational status since the actuals reached the
+    // targets". A status query stuck erroring never advances it, which
+    // correctly withholds completion rather than guessing.
+    statusObservedSinceTargetsMet:
+      targetsMetAt != null &&
+      operationalStatusQuery.dataUpdatedAt > targetsMetAt,
   });
 
   const isTerminal = TERMINAL_STATES.includes(state);

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -161,8 +161,20 @@ export function useProProvisioning({
   // case the machine falls back to pure client-side inference.
   const [serverVerdict, setServerVerdict] =
     useState<ProvisioningServerVerdict | null>(null);
+  // When the current verdict landed. A provisional verdict (`started` /
+  // `in_progress`) only clears the way to a terminal state once the
+  // operational-status query has read the world at least once after this
+  // instant — see the completion rules in `deriveProvisioningState`.
+  const [verdictAt, setVerdictAt] = useState<number | null>(null);
   // Only ever set by a user-initiated reconcile — see runEnsureProvisioned.
   const [ensureError, setEnsureError] = useState<unknown>(null);
+  // Pending state for the *manual* reconcile only. The mutation's own
+  // `isPending` is shared with the automatic call fired on Pro confirm, and a
+  // hung automatic call is precisely the case that strands the user in
+  // STALLED — gating Apply & Restart on it would disable their only recovery
+  // path. The endpoint is idempotent and in-flight guarded, so letting a manual
+  // apply overlap a slow automatic one is safe.
+  const [manualPending, setManualPending] = useState(false);
   const [raceRetryScheduled, setRaceRetryScheduled] = useState(false);
   // Fire-once-per-open guard for the automatic reconcile. A ref (not state) so
   // it can't be lost to a re-render between the check and the call, and it
@@ -202,7 +214,9 @@ export function useProProvisioning({
     setSnapshotAssistantId(null);
     setTracking(true);
     setServerVerdict(null);
+    setVerdictAt(null);
     setEnsureError(null);
+    setManualPending(false);
     setRaceRetryScheduled(false);
     ensureRequestedRef.current = false;
     ensureRaceRetriedRef.current = false;
@@ -285,6 +299,7 @@ export function useProProvisioning({
     (source: "auto" | "manual") => {
       if (source === "manual") {
         setEnsureError(null);
+        setManualPending(true);
       }
       // The open this call belongs to. Both callbacks drop out when the wizard
       // has since closed, so a late response can't drive a later session.
@@ -312,6 +327,7 @@ export function useProProvisioning({
               }
             } else {
               setServerVerdict(data.state);
+              setVerdictAt(Date.now());
             }
             if (source === "manual") {
               resumeWatch();
@@ -327,6 +343,14 @@ export function useProProvisioning({
             // Only a user-initiated retry earns a visible error.
             if (source === "manual") {
               setEnsureError(error);
+            }
+          },
+          // Unconditional (not generation-gated): the button's pending state
+          // must clear even for a response that belongs to a closed wizard,
+          // otherwise a reopen inherits a stuck-disabled Apply & Restart.
+          onSettled: () => {
+            if (source === "manual") {
+              setManualPending(false);
             }
           },
         },
@@ -369,10 +393,10 @@ export function useProProvisioning({
   const stalledAction = useMemo<ProvisioningRetryAction>(
     () => ({
       onApply: () => runEnsureProvisioned("manual"),
-      pending: ensureProvisionedMutation.isPending,
+      pending: manualPending,
       error: ensureError,
     }),
-    [runEnsureProvisioned, ensureProvisionedMutation.isPending, ensureError],
+    [runEnsureProvisioned, manualPending, ensureError],
   );
 
   const onboardingQuery = useQuery({
@@ -500,6 +524,12 @@ export function useProProvisioning({
     msSinceWatchStart,
     confirmExpired,
     serverVerdict,
+    // A successful status fetch always advances `dataUpdatedAt`, so this is
+    // "we have read the operational status since the verdict arrived". A
+    // status query stuck erroring never advances it, which correctly withholds
+    // completion rather than guessing.
+    statusObservedSinceVerdict:
+      verdictAt == null || operationalStatusQuery.dataUpdatedAt > verdictAt,
   });
 
   const isTerminal = TERMINAL_STATES.includes(state);

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -12,16 +12,24 @@
  * surfaces them. Platform-side fetches are different: a CONFIRMING-phase
  * subscription error maps to `confirmError`, and a post-confirm onboarding
  * fetch failure with no cached data maps to `targetsError`.
+ *
+ * On top of the observation it also *acts* once: the moment the subscription
+ * first reports Pro it calls the idempotent ensure-provisioned reconcile
+ * endpoint, so a webhook that never fired (or whose resize was lost) still
+ * gets provisioned. The returned verdict feeds the state machine's
+ * `serverVerdict` slot; the endpoint failing is not an error state — the
+ * polling above converges on its own.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
   assistantsActiveRetrieveOptions,
   assistantsOperationalStatusDetailReadOptions,
   assistantsRetrieveOptions,
+  organizationsBillingSubscriptionOnboardingEnsureProvisionedCreateMutation,
   organizationsBillingSubscriptionOnboardingRetrieveOptions,
   organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
   organizationsBillingSubscriptionRetrieveOptions,
@@ -39,6 +47,7 @@ import {
   type ProvisioningStateKind,
 } from "./provisioning-machine";
 import {
+  ENSURE_PROVISIONED_RACE_RETRY_MS,
   PRO_POLL_INTERVAL_MS,
   PRO_POLL_TIMEOUT_MS,
   PROVISION_ESCAPE_MS,
@@ -75,7 +84,17 @@ function isResizeOperationInFlight(
 
 export interface UseProProvisioningOptions {
   open: boolean;
-  serverVerdict?: ProvisioningServerVerdict | null;
+}
+
+/**
+ * Stalled-state recovery affordance, shaped for `StalledApplyAction`. `error`
+ * is only ever populated by a user-initiated call — the automatic reconcile
+ * failing is deliberately silent.
+ */
+export interface ProvisioningRetryAction {
+  onApply: () => void;
+  pending: boolean;
+  error: unknown;
 }
 
 export interface ProProvisioningResult {
@@ -111,16 +130,15 @@ export interface ProProvisioningResult {
   /** Reset the confirm timeout and re-poll the subscription. */
   retryConfirm: () => void;
   /**
-   * Resume observation after a manual STALLED-state resize succeeds: latches
-   * the operation as seen (back to RESIZING) and re-bases the stall clock so
-   * polling and the stall timeout start over.
+   * STALLED-state recovery: re-calls the idempotent ensure-provisioned
+   * reconcile (grow-only, in-flight-guarded, so a repeat never double-fires a
+   * resize) and re-bases the stall clock on success so observation resumes.
    */
-  resumeAfterManualApply: () => void;
+  stalledAction: ProvisioningRetryAction;
 }
 
 export function useProProvisioning({
   open,
-  serverVerdict = null,
 }: UseProProvisioningOptions): ProProvisioningResult {
   const queryClient = useQueryClient();
   // Every query here is org-scoped (needs the Vellum-Organization-Id header).
@@ -135,8 +153,23 @@ export function useProProvisioning({
   // after this instant may confirm pro.
   const [openedAt, setOpenedAt] = useState<number | null>(null);
   const [proConfirmedAt, setProConfirmedAt] = useState<number | null>(null);
-  // Stall-clock re-base set by resumeAfterManualApply; proConfirmedAt otherwise.
+  // Stall-clock re-base set by a successful manual reconcile; proConfirmedAt
+  // otherwise.
   const [resumedAt, setResumedAt] = useState<number | null>(null);
+  // Latest adopted ensure-provisioned verdict; null while the endpoint hasn't
+  // answered (or answered something we deliberately don't adopt), in which
+  // case the machine falls back to pure client-side inference.
+  const [serverVerdict, setServerVerdict] =
+    useState<ProvisioningServerVerdict | null>(null);
+  // Only ever set by a user-initiated reconcile — see runEnsureProvisioned.
+  const [ensureError, setEnsureError] = useState<unknown>(null);
+  const [raceRetryScheduled, setRaceRetryScheduled] = useState(false);
+  // Fire-once-per-open guard for the automatic reconcile. A ref (not state) so
+  // it can't be lost to a re-render between the check and the call, and it
+  // outlives the confirm-generation counter that retryConfirm bumps.
+  const ensureRequestedRef = useRef(false);
+  // At most one automatic re-call for the no_active_pro entitlement race.
+  const ensureRaceRetriedRef = useRef(false);
   const [sawOperation, setSawOperation] = useState(false);
   const [actualsSnapshot, setActualsSnapshot] =
     useState<ProvisioningDimensions | null>(null);
@@ -164,6 +197,11 @@ export function useProProvisioning({
     setActualsSnapshot(null);
     setSnapshotAssistantId(null);
     setTracking(true);
+    setServerVerdict(null);
+    setEnsureError(null);
+    setRaceRetryScheduled(false);
+    ensureRequestedRef.current = false;
+    ensureRaceRetriedRef.current = false;
   }, [open]);
 
   // Refetch pre-checkout caches on open. Invalidation keeps serving cached
@@ -226,12 +264,84 @@ export function useProProvisioning({
     });
   }, [queryClient]);
 
-  const resumeAfterManualApply = useCallback(() => {
+  /** Re-base the stall/grace clock so observation starts over. */
+  const resumeWatch = useCallback(() => {
     const t = Date.now();
-    setSawOperation(true);
     setResumedAt(t);
     setNow(t);
   }, []);
+
+  const ensureProvisionedMutation = useMutation(
+    organizationsBillingSubscriptionOnboardingEnsureProvisionedCreateMutation(),
+  );
+  const { mutate: ensureProvisioned } = ensureProvisionedMutation;
+
+  const runEnsureProvisioned = useCallback(
+    (source: "auto" | "manual") => {
+      if (source === "manual") setEnsureError(null);
+      ensureProvisioned(
+        {},
+        {
+          onSuccess: (data) => {
+            setEnsureError(null);
+            // `not_applicable` + `no_active_pro` is the subscription-flipped-
+            // but-entitlement-not-yet-visible race, not an answer: adopting it
+            // would park the wizard in a terminal state with an unprovisioned
+            // assistant. Leave the verdict null (pure inference keeps running)
+            // and re-ask once — the race resolves in a beat.
+            if (
+              data.state === "not_applicable" &&
+              data.reason === "no_active_pro"
+            ) {
+              if (!ensureRaceRetriedRef.current) {
+                ensureRaceRetriedRef.current = true;
+                setRaceRetryScheduled(true);
+              }
+            } else {
+              setServerVerdict(data.state);
+            }
+            if (source === "manual") resumeWatch();
+          },
+          onError: (error) => {
+            // 503 (submission couldn't be queued) or a network blip: nothing
+            // was queued and nothing is broken — the actuals polling still
+            // converges, so the automatic call degrades silently to inference.
+            // Only a user-initiated retry earns a visible error.
+            if (source === "manual") setEnsureError(error);
+          },
+        },
+      );
+    },
+    [ensureProvisioned, resumeWatch],
+  );
+
+  // Reconcile once per wizard open, at the moment the subscription poll first
+  // reports Pro. The ref guard survives re-renders and the confirm-generation
+  // retry counter; `proConfirmed` itself only latches once per open.
+  useEffect(() => {
+    if (!open || !orgReady || !proConfirmed) return;
+    if (ensureRequestedRef.current) return;
+    ensureRequestedRef.current = true;
+    runEnsureProvisioned("auto");
+  }, [open, orgReady, proConfirmed, runEnsureProvisioned]);
+
+  useEffect(() => {
+    if (!raceRetryScheduled) return;
+    const t = setTimeout(() => {
+      setRaceRetryScheduled(false);
+      runEnsureProvisioned("auto");
+    }, ENSURE_PROVISIONED_RACE_RETRY_MS);
+    return () => clearTimeout(t);
+  }, [raceRetryScheduled, runEnsureProvisioned]);
+
+  const stalledAction = useMemo<ProvisioningRetryAction>(
+    () => ({
+      onApply: () => runEnsureProvisioned("manual"),
+      pending: ensureProvisionedMutation.isPending,
+      error: ensureError,
+    }),
+    [runEnsureProvisioned, ensureProvisionedMutation.isPending, ensureError],
+  );
 
   const onboardingQuery = useQuery({
     ...organizationsBillingSubscriptionOnboardingRetrieveOptions(),
@@ -389,6 +499,6 @@ export function useProProvisioning({
     escapeEligible:
       msSinceWatchStart != null && msSinceWatchStart >= PROVISION_ESCAPE_MS,
     retryConfirm,
-    resumeAfterManualApply,
+    stalledAction,
   };
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/utils.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/utils.ts
@@ -11,6 +11,12 @@ export const PROVISION_STALL_MS = 90_000;
 export const PROVISION_ESCAPE_MS = (PROVISION_STALL_MS * 2) / 3;
 /** Minimum time a provisioning phase stays on screen so it doesn't flash. */
 export const PROVISION_MIN_DWELL_MS = 2_500;
+/**
+ * How long to wait before re-asking ensure-provisioned when it answered
+ * `not_applicable` / `no_active_pro` — the subscription flipped to Pro but the
+ * entitlement wasn't visible to the reconcile yet. One retry only.
+ */
+export const ENSURE_PROVISIONED_RACE_RETRY_MS = 2_000;
 
 const ONBOARDING_MACHINE_DRF_FIELD_KEYS = [
   "machine_size",
@@ -25,6 +31,8 @@ export const ONBOARDING_ERROR_CODE_MESSAGES: Record<string, string> = {
   no_assistant_to_attach_domain:
     "We couldn't find an assistant to attach this domain to.",
   exceeds_machine_tier: "That machine size isn't available on your plan.",
+  provisioning_submission_failed:
+    "We couldn't queue your upgrade just now. Try again in a moment.",
 };
 
 export function extractOnboardingErrorMessage(

--- a/clients/web/src/domains/settings/billing/pro-onboarding/utils.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/utils.ts
@@ -33,6 +33,8 @@ export const ONBOARDING_ERROR_CODE_MESSAGES: Record<string, string> = {
   exceeds_machine_tier: "That machine size isn't available on your plan.",
   provisioning_submission_failed:
     "We couldn't queue your upgrade just now. Try again in a moment.",
+  no_active_pro:
+    "We couldn't confirm your Pro plan yet. Try again in a moment.",
 };
 
 export function extractOnboardingErrorMessage(


### PR DESCRIPTION
## Summary
- Calls ensure-provisioned once when the subscription first reports Pro, and feeds its verdict into deriveProvisioningState's existing serverVerdict slot
- Points the stalled-state action at the idempotent reconcile endpoint instead of a raw resize, so a lost provisioning job self-heals
- Endpoint failure (503/network) degrades to the existing client-side inference rather than surfacing an error

Stacked on #38626. Requires vellum-ai/vellum-assistant-platform#9328 deployed.