### PR TITLE
fix(runtime): never serve or import test files from route directories

### DIFF
--- a/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
@@ -201,8 +201,8 @@ describe("default plugin route dispatch", () => {
 
   test("never dispatches test files or __tests__ paths (mock.module containment)", async () => {
     // Importing a test file into the live daemon executes its process-global
-    // mock.module calls, replacing production modules (the 2026-07-21 dev
-    // crash-loop). Dispatch must 404 without importing the file.
+    // mock.module calls, replacing production modules. Dispatch must 404
+    // without importing the file.
     writeWorkspacePluginHandler(
       DEFAULT_PLUGIN,
       "poison.test.ts",
@@ -233,7 +233,7 @@ describe("default plugin route dispatch", () => {
   test("tripwire: no default plugin ships test files under its routes/ dir", () => {
     // Everything under a default plugin's routes/ is served from the source
     // tree and dynamically imported by discovery — test files belong in src/
-    // or __tests__ outside routes/ (see #38609).
+    // or a __tests__ dir outside routes/.
     const offenders: string[] = [];
     const walk = (dir: string, routesDir: string): void => {
       for (const entry of readdirSync(dir, { withFileTypes: true })) {

--- a/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
@@ -10,8 +10,14 @@
  * running the handler's heavy background-turn logic.
  */
 
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
 import {
@@ -24,6 +30,7 @@ import { AssistantEventHub } from "../../assistant-event-hub.js";
 import type { UserRouteContext } from "../user-route-dispatcher.js";
 import { UserRouteDispatcher } from "../user-route-dispatcher.js";
 import {
+  isRouteTestPath,
   listPluginRouteRoots,
   resolveHandlerFile,
   resolveRouteLocation,
@@ -190,6 +197,58 @@ describe("default plugin route dispatch", () => {
     );
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ source: "workspace" });
+  });
+
+  test("never dispatches test files or __tests__ paths (mock.module containment)", async () => {
+    // Importing a test file into the live daemon executes its process-global
+    // mock.module calls, replacing production modules (the 2026-07-21 dev
+    // crash-loop). Dispatch must 404 without importing the file.
+    writeWorkspacePluginHandler(
+      DEFAULT_PLUGIN,
+      "poison.test.ts",
+      `export const GET = () => Response.json({ imported: true });`,
+    );
+    writeWorkspacePluginHandler(
+      DEFAULT_PLUGIN,
+      "__tests__/poison.ts",
+      `export const GET = () => Response.json({ imported: true });`,
+    );
+
+    const routesDir = join(getWorkspacePluginsDir(), DEFAULT_PLUGIN, "routes");
+    expect(resolveHandlerFile(routesDir, "poison.test")).toBeNull();
+    expect(resolveHandlerFile(routesDir, "__tests__/poison")).toBeNull();
+
+    const dispatcher = makeDispatcher();
+    for (const path of ["poison.test", "__tests__/poison"]) {
+      const response = await dispatcher.dispatch(
+        `plugins/${DEFAULT_PLUGIN}/${path}`,
+        new Request(`http://localhost/v1/x/plugins/${DEFAULT_PLUGIN}/${path}`, {
+          method: "GET",
+        }),
+      );
+      expect(response.status).toBe(404);
+    }
+  });
+
+  test("tripwire: no default plugin ships test files under its routes/ dir", () => {
+    // Everything under a default plugin's routes/ is served from the source
+    // tree and dynamically imported by discovery — test files belong in src/
+    // or __tests__ outside routes/ (see #38609).
+    const offenders: string[] = [];
+    const walk = (dir: string, routesDir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = join(dir, entry.name);
+        if (isRouteTestPath(relative(routesDir, fullPath))) {
+          offenders.push(fullPath);
+        } else if (entry.isDirectory()) {
+          walk(fullPath, routesDir);
+        }
+      }
+    };
+    for (const { routesDir } of getDefaultPluginRouteRoots()) {
+      walk(routesDir, routesDir);
+    }
+    expect(offenders).toEqual([]);
   });
 
   test("disabling the default does not disable an installed override of the same namespace", async () => {

--- a/assistant/src/runtime/routes/__tests__/user-routes-cli.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-routes-cli.test.ts
@@ -98,8 +98,8 @@ describe("routes list", () => {
   test("excludes test files and __tests__ dirs (never imported into the daemon)", async () => {
     writePluginRoute("demo", "status.ts");
     // A test file's top-level mock.module calls are process-global — importing
-    // one into the live daemon replaces production modules (the 2026-07-21 dev
-    // crash-loop). Discovery must skip them entirely, not just fail to list.
+    // one into the live daemon replaces production modules. Discovery must
+    // skip test paths entirely, not just fail to list them.
     writePluginRoute("demo", "status.test.ts");
     writePluginRoute("demo", "__tests__/helpers.ts");
     writePluginRoute("demo", "__tests__/status.test.ts");

--- a/assistant/src/runtime/routes/__tests__/user-routes-cli.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-routes-cli.test.ts
@@ -95,6 +95,30 @@ describe("routes list", () => {
     expect(paths).not.toContain("/x/plugins/foo");
   });
 
+  test("excludes test files and __tests__ dirs (never imported into the daemon)", async () => {
+    writePluginRoute("demo", "status.ts");
+    // A test file's top-level mock.module calls are process-global — importing
+    // one into the live daemon replaces production modules (the 2026-07-21 dev
+    // crash-loop). Discovery must skip them entirely, not just fail to list.
+    writePluginRoute("demo", "status.test.ts");
+    writePluginRoute("demo", "__tests__/helpers.ts");
+    writePluginRoute("demo", "__tests__/status.test.ts");
+    writeWorkspaceRoute("ping.ts");
+    writeWorkspaceRoute("ping.test.ts");
+    writeWorkspaceRoute("__tests__/ping.test.ts");
+
+    const { routes } = await listHandler();
+    const paths = routes.map((r) => r.routePath);
+
+    expect(paths).toContain("/x/plugins/demo/status");
+    expect(paths).toContain("/x/ping");
+    expect(paths).not.toContain("/x/plugins/demo/status.test");
+    expect(paths).not.toContain("/x/plugins/demo/__tests__/helpers");
+    expect(paths).not.toContain("/x/plugins/demo/__tests__/status.test");
+    expect(paths).not.toContain("/x/ping.test");
+    expect(paths).not.toContain("/x/__tests__/ping.test");
+  });
+
   test("excludes disabled plugins' routes", async () => {
     writePluginRoute("live", "status.ts");
     writePluginRoute("dead", "status.ts");
@@ -131,6 +155,18 @@ describe("routes inspect", () => {
     const res = await inspectHandler({ body: { path: "ping" } });
     expect(res.route.routePath).toBe("/x/ping");
     expect(res.route.filePath).toBe("routes/ping.ts");
+  });
+
+  test("404s test files and paths under __tests__", async () => {
+    writePluginRoute("demo", "status.test.ts");
+    writePluginRoute("demo", "__tests__/helpers.ts");
+
+    await expect(
+      inspectHandler({ body: { path: "plugins/demo/status.test" } }),
+    ).rejects.toThrow();
+    await expect(
+      inspectHandler({ body: { path: "plugins/demo/__tests__/helpers" } }),
+    ).rejects.toThrow();
   });
 
   test("404s a shadowed, missing, or disabled route", async () => {

--- a/assistant/src/runtime/routes/user-route-resolution.ts
+++ b/assistant/src/runtime/routes/user-route-resolution.ts
@@ -20,7 +20,7 @@
  */
 
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 
 import {
   getDefaultPluginManifestName,
@@ -35,6 +35,25 @@ import {
 
 /** Supported file extensions for handler modules (`.js` preferred over `.ts`). */
 export const HANDLER_EXTENSIONS = [".ts", ".js"] as const;
+
+/** Directory basename reserved for co-located tests — never a route segment. */
+const TEST_DIR_NAME = "__tests__";
+
+/**
+ * True when a path under a routes directory is test machinery rather than a
+ * servable handler: any `__tests__` segment, or a `*.test.ts` / `*.test.js`
+ * filename. Discovery and dispatch both exclude these so a co-located test
+ * file is never dynamically imported into the daemon — a test file's
+ * top-level `mock.module(...)` calls are process-global and would replace
+ * production modules (DB, platform paths) in the live process.
+ */
+export function isRouteTestPath(relPath: string): boolean {
+  const segments = relPath.split(sep);
+  return (
+    segments.includes(TEST_DIR_NAME) ||
+    /\.test\.(ts|js)$/.test(segments.at(-1) ?? "")
+  );
+}
 
 /** Path segment reserved for plugin-namespaced routes under `/x/`. */
 export const PLUGIN_ROUTE_SEGMENT = "plugins";
@@ -141,28 +160,30 @@ function resolvePluginRoutesDir(pluginName: string): {
  * Checks for direct file matches first (`<path>.ts`, `<path>.js`), then falls
  * back to index files (`<path>/index.ts`, `<path>/index.js`). Returns the
  * absolute path to the handler file, or `null` if not found. Rejects any path
- * that escapes `routesDir` (traversal backstop).
+ * that escapes `routesDir` (traversal backstop) and any test path
+ * ({@link isRouteTestPath}), so test files are never served or imported.
  */
 export function resolveHandlerFile(
   routesDir: string,
   subPath: string,
 ): string | null {
+  const base = resolve(routesDir);
   const resolved = resolve(join(routesDir, subPath));
 
-  if (!resolved.startsWith(resolve(routesDir))) {
+  if (!resolved.startsWith(base)) {
     return null;
   }
 
   for (const ext of HANDLER_EXTENSIONS) {
     const candidate = `${resolved}${ext}`;
-    if (existsSync(candidate)) {
+    if (existsSync(candidate) && !isRouteTestPath(relative(base, candidate))) {
       return candidate;
     }
   }
 
   for (const ext of HANDLER_EXTENSIONS) {
     const candidate = join(resolved, `index${ext}`);
-    if (existsSync(candidate)) {
+    if (existsSync(candidate) && !isRouteTestPath(relative(base, candidate))) {
       return candidate;
     }
   }

--- a/assistant/src/runtime/routes/user-routes-cli.ts
+++ b/assistant/src/runtime/routes/user-routes-cli.ts
@@ -20,6 +20,7 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 import {
   HANDLER_EXTENSIONS,
   isReservedWorkspaceRoutePath,
+  isRouteTestPath,
   listPluginRouteRoots,
   resolveHandlerFile,
   resolveRouteLocation,
@@ -93,6 +94,12 @@ async function discoverRoutes(routesDir: string): Promise<DiscoveredRoute[]> {
     const entries = readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
       const fullPath = join(dir, entry.name);
+      // Test dirs/files are not servable handlers and must never be imported
+      // into the daemon (a test file's top-level mock.module calls are
+      // process-global) — mirrors resolveHandlerFile's dispatch-side gate.
+      if (isRouteTestPath(relative(routesDir, fullPath))) {
+        continue;
+      }
       if (entry.isDirectory()) {
         scanDir(fullPath);
       } else if (entry.isFile()) {


### PR DESCRIPTION
## Summary
- Add `isRouteTestPath` to the shared route resolution: any `__tests__` path segment or `*.test.ts`/`*.test.js` filename is excluded from both route discovery (`assistant routes list`) and dispatch (`resolveHandlerFile`), so test files are never dynamically imported into the live daemon.
- Regression tests: test files/dirs under workspace and plugin `routes/` are neither listed, inspectable, nor dispatchable (404 without import).
- Tripwire test: no default plugin may ship `__tests__`/`*.test.*` under its `routes/` dir (they are served from the source tree and imported by discovery — see #38609).

## Context: 2026-07-21 dev crash-loop incident
After #38505 (serve default-plugin routes from the source tree) deployed to dev (build `dev.202607211337.6d2617c`), any `assistant routes list` made the daemon recursively import `plugins/defaults/memory/routes/__tests__/*.test.ts`. Those files call `mock.module("…persistence/db-connection.js")` / `util/platform.js` at module scope; bun's `mock.module` is process-global, so the live daemon's `getDb()`/`getSqlite()`/`ensureDataDir` were replaced with test stubs → "db.insert is not a function" TypeError storm, schedule-worker respawn failure, unhandled-rejection shutdown → CrashLoopBackOff (assistant 019f84fa…, pod assistant-be77fe5c…; reproduced deliberately via `kubectl exec assistant routes list`). #38609 moved memory's modules out of `routes/`, which fixes that instance, but nothing prevented recurrence — any workspace plugin or future default plugin shipping test files under `routes/` re-triggers it. This PR closes the class.

## Original prompt
Triage of feedback bundle `feedback-019f8535-70b6-70e5-b20a-77b30108cb50` (dev assistant crash loop). Root cause traced to route discovery importing co-located test files into the daemon; asked to exclude `__tests__/` dirs and `*.test.*` files from enumeration and dispatch resolution so they are never imported, with regression + tripwire tests, based on latest origin/main (coordinating with, not reverting, #38609/#38612).