### PR TITLE
fix(memory-v3): inject CLI commands as one-line summaries, keep full help in the index lanes

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/capabilities.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/capabilities.test.ts
@@ -4,6 +4,7 @@ import {
   capabilityOrDiskBody,
   type CapabilityResolvers,
   isCapabilitySlug,
+  renderCapabilityBody,
   renderCapabilityContent,
 } from "../capabilities.js";
 
@@ -16,26 +17,33 @@ describe("isCapabilitySlug", () => {
   });
 });
 
-describe("renderCapabilityContent", () => {
-  const resolvers: CapabilityResolvers = {
-    skill: (slug) =>
-      slug === "skills/foo" ? { id: "foo", content: "foo capability" } : null,
-    cli: (slug) =>
-      slug === "cli-commands/bar"
-        ? { id: "bar", content: "bar capability" }
-        : null,
-  };
+const resolvers: CapabilityResolvers = {
+  skill: (slug) =>
+    slug === "skills/foo" ? { id: "foo", content: "foo capability" } : null,
+  cli: (slug) =>
+    slug === "cli-commands/bar"
+      ? {
+          id: "bar",
+          description: "manages bars",
+          content:
+            'The "assistant bar" CLI command is available. manages bars.\n\nFull help:\n  --baz  a very long flag description',
+        }
+      : null,
+};
 
-  test("renders a skill slug with a Skill header", () => {
+describe("renderCapabilityContent (injection form)", () => {
+  test("renders a skill slug with a Skill header and its content", () => {
     expect(renderCapabilityContent("skills/foo", resolvers)).toBe(
       "# Skill: foo\nfoo capability",
     );
   });
 
-  test("renders a CLI-command slug with a CLI header", () => {
-    expect(renderCapabilityContent("cli-commands/bar", resolvers)).toBe(
-      "# CLI command: bar\nbar capability",
+  test("renders a CLI-command slug as its one-line summary, never the full help", () => {
+    const rendered = renderCapabilityContent("cli-commands/bar", resolvers);
+    expect(rendered).toBe(
+      '# CLI command: bar\nThe "assistant bar" CLI command is available. manages bars. Run `assistant bar --help` for full usage.',
     );
+    expect(rendered).not.toContain("Full help:");
   });
 
   test("degrades to '' for a capability slug the cache cannot resolve", () => {
@@ -47,15 +55,34 @@ describe("renderCapabilityContent", () => {
   });
 });
 
+describe("renderCapabilityBody (index form)", () => {
+  test("renders a CLI-command slug with its full content for the section index", () => {
+    expect(renderCapabilityBody("cli-commands/bar", resolvers)).toBe(
+      '# CLI command: bar\nThe "assistant bar" CLI command is available. manages bars.\n\nFull help:\n  --baz  a very long flag description',
+    );
+  });
+
+  test("renders a skill slug identically to the injection form", () => {
+    expect(renderCapabilityBody("skills/foo", resolvers)).toBe(
+      renderCapabilityContent("skills/foo", resolvers),
+    );
+  });
+
+  test("degrades to '' / null on the same contract as the injection form", () => {
+    expect(renderCapabilityBody("cli-commands/missing", resolvers)).toBe("");
+    expect(renderCapabilityBody("relationship/vows", resolvers)).toBeNull();
+  });
+});
+
 describe("capabilityOrDiskBody", () => {
-  test("a capability slug routes through renderCapabilityContent and never reads disk", async () => {
+  test("a capability slug routes through renderCapabilityBody and never reads disk", async () => {
     let diskReads = 0;
     const readDiskBody = async (): Promise<string> => {
       diskReads += 1;
       return "disk body — should not be read";
     };
     // A capability slug whose production cache has no entry degrades to "" (the
-    // `renderCapabilityContent` contract) rather than falling through to the
+    // `renderCapabilityBody` contract) rather than falling through to the
     // injected disk reader, which must stay untouched.
     expect(await capabilityOrDiskBody("skills/example", readDiskBody)).toBe("");
     expect(diskReads).toBe(0);

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
@@ -628,6 +628,29 @@ describe("memoryV3SpotlightInjector — ephemeral section spotlight", () => {
     expect(block!.text).not.toContain("page-c.md");
   });
 
+  test("capability slugs never spotlight — their sections are full-help index slices", async () => {
+    liveEnabled = true;
+    const cliSection = section(
+      "cli-commands/schedules",
+      "CLI command: schedules",
+      "Full help:\n  --cron <expr>  the schedule to run on",
+    );
+    turnResults.set(
+      0,
+      result(
+        ["cli-commands/schedules", "page-a"],
+        [
+          ["cli-commands/schedules", cliSection],
+          ["page-a", sectionA],
+        ],
+      ),
+    );
+    const block = await produceSpotlight("conv-1", 0);
+    expect(block!.text).toContain("page-a.md § Alpha");
+    expect(block!.text).not.toContain("cli-commands/schedules");
+    expect(block!.text).not.toContain("Full help:");
+  });
+
   test("carries the previous windowTurns turns' entries, ages older ones out, never accumulates", async () => {
     liveEnabled = true;
     spotlightConfig = { n: 6, windowTurns: 1 };

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/maintain-job.test.ts
@@ -7,7 +7,7 @@ import { EmbeddingBackendUnavailableError } from "../../../../../persistence/emb
 import { EmbeddingBillingBlockError } from "../../../../../persistence/embeddings/embedding-billing-breaker.js";
 import type { MemoryJob } from "../../../../../persistence/jobs-store.js";
 import type { SkillInstallMeta } from "../../../../../skills/install-meta.js";
-import { renderCapabilityContent } from "../capabilities.js";
+import { renderCapabilityBody } from "../capabilities.js";
 import {
   backfillAllSections,
   type BackfillJobDeps,
@@ -566,7 +566,7 @@ describe("backfillAllSections", () => {
       cli: () => null,
     };
     const readPageBody = async (slug: Slug): Promise<string> =>
-      renderCapabilityContent(slug, resolvers) ?? `body for ${slug}`;
+      renderCapabilityBody(slug, resolvers) ?? `body for ${slug}`;
 
     const { deps: d, calls } = deps({
       selectAllPages: async () => ["page-a", "skills/example"],

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -10,7 +10,7 @@
  *   - lazy-init runs the lane builders only once across multiple turns, and
  *     `invalidateLanes` forces exactly one rebuild;
  *   - `initLanes` feeds synthetic capability pages (skills / CLI commands) into
- *     the section index via `renderCapabilityContent`, so the needle lane ranks
+ *     the section index via `renderCapabilityBody`, so the needle lane ranks
  *     them like any other page (they are no longer always-added to the pool).
  *
  * All heavy dependencies (config, flag resolver, conversation reads, v2 page
@@ -355,10 +355,11 @@ mock.module("../../../../../util/platform.js", () => ({
     join(realPlatform.getWorkspaceDir(), "config.json"),
 }));
 
-// Capability stores: `renderCapabilityContent` (reached from `initLanes`' pageBody
-// and from the live injector) resolves synthetic slugs through these. Spread the
-// real module so the prefix predicates (`isSkillSlug`/`isCliCommandSlug`) stay
-// intact; override only the content lookup so the capability slug resolves.
+// Capability stores: `renderCapabilityBody` (reached from `initLanes`' pageBody)
+// and `renderCapabilityContent` (the live injector's short form) resolve
+// synthetic slugs through these. Spread the real module so the prefix
+// predicates (`isSkillSlug`/`isCliCommandSlug`) stay intact; override only the
+// content lookup so the capability slug resolves.
 mock.module("../substrate/skill-store.js", () => ({
   ...realSkillStore,
   getSkillCapability: (idOrSlug: string) =>

--- a/assistant/src/plugins/defaults/memory/v3/capabilities.ts
+++ b/assistant/src/plugins/defaults/memory/v3/capabilities.ts
@@ -6,12 +6,18 @@
  * (`skills/<id>`, `cli-commands/<name>`). The section-lane retrieval pipeline
  * surfaces the relevant ones per turn, same as concept pages.
  *
- * Page summaries for synthetic slugs already resolve through the existing
- * `pageSummary` lane (the v2 page index appends skill/CLI rows with a summary),
- * so only full-content rendering for the live `<memory>` block needs a synthetic
- * fallback — see {@link renderCapabilityContent}.
+ * Capability slugs have two render forms with different budgets:
+ *  - the INJECTION form ({@link renderCapabilityContent}) — what surfaces put
+ *    in front of the model. Skills render their capability statement (already
+ *    description-sized); CLI commands render a one-line summary with a
+ *    `--help` pointer, never their full help.
+ *  - the INDEX form ({@link renderCapabilityBody}) — the full `content`
+ *    (for CLI commands, the complete help text). It feeds the section index
+ *    and dense/needle lanes, where flag descriptions and examples are what
+ *    make a command semantically findable.
  */
 
+import { buildCliCommandSummary } from "./substrate/cli-command-content.js";
 import {
   getCliCommandCapability,
   isCliCommandSlug,
@@ -24,14 +30,20 @@ export function isCapabilitySlug(slug: Slug): boolean {
   return isSkillSlug(slug) || isCliCommandSlug(slug);
 }
 
-interface CapabilityEntry {
+interface SkillCapabilityEntry {
   id: string;
   content: string;
 }
 
+interface CliCapabilityEntry {
+  id: string;
+  description: string;
+  content: string;
+}
+
 export interface CapabilityResolvers {
-  skill: (idOrSlug: string) => CapabilityEntry | null;
-  cli: (idOrSlug: string) => CapabilityEntry | null;
+  skill: (idOrSlug: string) => SkillCapabilityEntry | null;
+  cli: (idOrSlug: string) => CliCapabilityEntry | null;
 }
 
 const defaultResolvers: CapabilityResolvers = {
@@ -40,21 +52,18 @@ const defaultResolvers: CapabilityResolvers = {
 };
 
 /**
- * Render a synthetic skill/CLI slug's full capability content for the live
- * `<memory>` block, mirroring {@link renderV3PageContent}'s `# header\n<content>`
- * shape. Returns:
+ * Shared dispatch for the two render forms. Returns:
  *  - the rendered block when the slug is a capability slug and resolves;
  *  - `""` when it is a capability slug but the cache has no entry (degrade to a
  *    blank section rather than throwing or falling through to an on-disk read
  *    that would also miss);
  *  - `null` when the slug is NOT a capability slug, so the caller falls through
  *    to its normal on-disk page rendering.
- *
- * `resolvers` is injectable for tests; production uses the v2 store caches.
  */
-export function renderCapabilityContent(
+function renderCapability(
   slug: Slug,
-  resolvers: CapabilityResolvers = defaultResolvers,
+  resolvers: CapabilityResolvers,
+  cliText: (entry: CliCapabilityEntry) => string,
 ): string | null {
   if (isSkillSlug(slug)) {
     const entry = resolvers.skill(slug);
@@ -62,27 +71,62 @@ export function renderCapabilityContent(
   }
   if (isCliCommandSlug(slug)) {
     const entry = resolvers.cli(slug);
-    return entry ? `# CLI command: ${entry.id}\n${entry.content}` : "";
+    return entry ? `# CLI command: ${entry.id}\n${cliText(entry)}` : "";
   }
   return null;
 }
 
 /**
+ * Render a synthetic skill/CLI slug's INJECTION form for the live `<memory>`
+ * block (and the graph node detail / inspector renders), mirroring
+ * {@link renderV3PageContent}'s `# header\n<content>` shape. CLI commands
+ * render {@link buildCliCommandSummary} — description plus a `--help`
+ * pointer — NOT their full help: the model fetches full usage itself, and a
+ * turn can select dozens of commands, so per-entry cost dominates the block.
+ * Return contract (block / `""` / `null`) is {@link renderCapability}'s.
+ *
+ * `resolvers` is injectable for tests; production uses the substrate caches.
+ */
+export function renderCapabilityContent(
+  slug: Slug,
+  resolvers: CapabilityResolvers = defaultResolvers,
+): string | null {
+  return renderCapability(slug, resolvers, (entry) =>
+    buildCliCommandSummary(entry.id, entry.description),
+  );
+}
+
+/**
+ * Render a synthetic skill/CLI slug's INDEX form: the full capability
+ * `content` (for CLI commands, the complete help text) under the same header
+ * as the injection form. This is the body the section index, needle/dense
+ * lanes, and section-embedding backfill see — retrieval keeps the full help
+ * for findability even though injection renders only the summary.
+ * Return contract (block / `""` / `null`) is {@link renderCapability}'s.
+ */
+export function renderCapabilityBody(
+  slug: Slug,
+  resolvers: CapabilityResolvers = defaultResolvers,
+): string | null {
+  return renderCapability(slug, resolvers, (entry) => entry.content);
+}
+
+/**
  * Resolve a slug's frontmatter-stripped body for the section index: synthetic
  * skill/CLI capability slugs have no on-disk page, so they contribute their
- * rendered capability content (exactly what `page-content.ts` injects for them),
- * while real pages fall through to `readDiskBody`. Shared by `initLanes`'
- * `pageBody` and the full-backfill body reader so the capability-or-disk dispatch
- * lives in one place.
+ * full INDEX-form capability content ({@link renderCapabilityBody}), while
+ * real pages fall through to `readDiskBody`. Shared by `initLanes`'
+ * `pageBody` and the full-backfill body reader so the capability-or-disk
+ * dispatch lives in one place.
  *
- * `readDiskBody` is injected (rather than imported) so this helper does not pull
- * the page store into `capabilities.ts` — each caller supplies its own cached or
- * direct disk reader.
+ * `readDiskBody` is injected (rather than imported) so this helper does not
+ * pull the page store into `capabilities.ts` — each caller supplies its own
+ * cached or direct disk reader.
  */
 export async function capabilityOrDiskBody(
   slug: Slug,
   readDiskBody: (slug: Slug) => Promise<string>,
 ): Promise<string> {
-  if (isCapabilitySlug(slug)) return renderCapabilityContent(slug) ?? "";
+  if (isCapabilitySlug(slug)) return renderCapabilityBody(slug) ?? "";
   return readDiskBody(slug);
 }

--- a/assistant/src/plugins/defaults/memory/v3/injector.ts
+++ b/assistant/src/plugins/defaults/memory/v3/injector.ts
@@ -194,6 +194,10 @@ function computeSpotlightEntries(
   for (const candidate of result.lanes.finder) {
     if (entries.length >= n) break;
     if (!selected.has(candidate.slug)) continue;
+    // Capability slugs never spotlight: their card already carries the whole
+    // injection form, and their index "sections" are slices of the full-help
+    // body the injection layer deliberately keeps out of context.
+    if (isCapabilitySlug(candidate.slug)) continue;
     const section = result.matchedSections.get(candidate.slug);
     if (!section) continue;
     entries.push({

--- a/assistant/src/plugins/defaults/memory/v3/page-content.ts
+++ b/assistant/src/plugins/defaults/memory/v3/page-content.ts
@@ -54,9 +54,9 @@ export async function renderV3PageContent(slug: Slug): Promise<string> {
  * unit — frozen into history once and deduped by the everInjected store.
  *
  * - Capability slugs (skills, `assistant` CLI commands) have no on-disk page
- *   and no meaningful head/TOC split, so they render their full capability
- *   content via {@link renderCapabilityContent} (its own `# Skill:` /
- *   `# CLI command:` header) instead of a card.
+ *   and no meaningful head/TOC split, so they render their injection-form
+ *   capability content via {@link renderCapabilityContent} (its own
+ *   `# Skill:` / `# CLI command:` header) instead of a card.
  * - A missing page or any read failure degrades to "" — the injector skips
  *   empty cards rather than throwing into the turn.
  */

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -38,7 +38,10 @@ import { stripCommentLines } from "../host-utils.js";
 import { getLogger } from "../logging.js";
 import { memorySqliteOrNull } from "../memory-db.js";
 import { getWorkspaceDir, getWorkspacePromptPath } from "../paths.js";
-import { capabilityOrDiskBody } from "./capabilities.js";
+import {
+  capabilityOrDiskBody,
+  renderCapabilityContent,
+} from "./capabilities.js";
 import { renderCard } from "./card.js";
 import { loadCoreSet } from "./core-set.js";
 import type { EdgeGraph } from "./edge.js";
@@ -193,12 +196,12 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     return loaded;
   }
   // Synthetic capability slugs (skills / CLI commands) have no on-disk page, so
-  // they contribute their rendered capability content to the section index —
-  // exactly the content `page-content.ts` injects for them. This puts them in
-  // the section index, so the needle lane (and, once a backfill embeds them, the
-  // dense lane) ranks them by relevance like any other page, instead of being
-  // blindly added to the select pool every turn. Real pages read their body
-  // through the cached `loadPage`.
+  // they contribute their full INDEX-form capability content (for CLI commands,
+  // the complete help text — injection renders only the short summary). This
+  // puts them in the section index, so the needle lane (and, once a backfill
+  // embeds them, the dense lane) ranks them by relevance like any other page,
+  // instead of being blindly added to the select pool every turn. Real pages
+  // read their body through the cached `loadPage`.
   const pageBody = async (slug: Slug): Promise<string> =>
     capabilityOrDiskBody(slug, async (s) => (await loadPage(s))?.body ?? "");
   const pageRaw = async (slug: Slug): Promise<string> => {
@@ -268,11 +271,14 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   // stable prefix must be byte-identical across turns to ride the provider KV
   // cache, so the cards are frozen here (lane invalidation at consolidation is
   // the recompute point) instead of being re-read per turn. Capability slugs
-  // render their capability content; disk pages render raw (frontmatter +
-  // body) so `kind: index` pages surface their `links:` map in the card TOC.
-  // Each card carries its lane annotation; fresh cards additionally carry the
-  // page's last-modified time (an absolute stamp — it only changes when the
-  // page does, so the card stays byte-stable between lane recomputes).
+  // card as their short injection form (matching the net-new capability
+  // cards) — a CLI command in the hot set must not pin its full-help index
+  // body into the byte-stable prefix. Disk pages render raw (frontmatter +
+  // body) through `renderCard` so `kind: index` pages surface their `links:`
+  // map in the card TOC. Each disk card carries its lane annotation; fresh
+  // cards additionally carry the page's last-modified time (an absolute
+  // stamp — it only changes when the page does, so the card stays byte-stable
+  // between lane recomputes).
   const modifiedAtBySlug = new Map(
     pageIndex.entries.map((entry) => [entry.slug, entry.modifiedAt]),
   );
@@ -305,10 +311,12 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     ["always", alwaysCandidateSlugs],
   ] as const) {
     for (const slug of slugs) {
-      const raw = await capabilityOrDiskBody(
-        slug,
-        async (s) => (await loadPage(s))?.raw ?? "",
-      );
+      const capability = renderCapabilityContent(slug);
+      if (capability !== null) {
+        prefixCards.set(slug, capability);
+        continue;
+      }
+      const raw = (await loadPage(slug))?.raw ?? "";
       prefixCards.set(slug, renderCard(slug, raw, laneAnnotation(slug, lane)));
     }
   }

--- a/assistant/src/plugins/defaults/memory/v3/substrate/cli-command-content.ts
+++ b/assistant/src/plugins/defaults/memory/v3/substrate/cli-command-content.ts
@@ -9,6 +9,10 @@
  * (browser, oauth) hits ~3.4 KB. The embedding backend handles inputs of this
  * size without trouble, and trimming would drop the very examples and flag
  * descriptions that make commands semantically findable.
+ *
+ * The full-help content is the EMBEDDING/INDEX text only. Injection surfaces
+ * render {@link buildCliCommandSummary} instead — the model fetches the full
+ * help itself via `--help` when it needs it.
  */
 
 import type { CLI_COMMAND_HELP } from "@vellumai/plugin-api";
@@ -18,12 +22,31 @@ type CliCommandHelp = (typeof CLI_COMMAND_HELP)[number];
 /** Subcommand element type — recursive via its own `subcommands` field. */
 type CliSubcommandHelp = NonNullable<CliCommandHelp["subcommands"]>[number];
 
+/** Availability lead-in shared by the summary and the full embedding content. */
+function buildCliCommandLead(name: string, description: string): string {
+  return `The "assistant ${name}" CLI command is available. ${description}.`;
+}
+
+/**
+ * One-line injection form of a CLI command: the availability lead-in plus a
+ * pointer to the live `--help`. Every surface that puts a CLI capability in
+ * front of the model (memory cards, graph node detail, inspector renders)
+ * uses this — never the full-help `content`, which exists only so flags and
+ * examples keep the command semantically findable in the retrieval lanes.
+ */
+export function buildCliCommandSummary(
+  name: string,
+  description: string,
+): string {
+  return `${buildCliCommandLead(name, description)} Run \`assistant ${name} --help\` for full usage.`;
+}
+
 function buildCliCommandContent(
   name: string,
   description: string,
   helpText: string,
 ): string {
-  return `The "assistant ${name}" CLI command is available. ${description}.\n\nFull help:\n${helpText}`;
+  return `${buildCliCommandLead(name, description)}\n\nFull help:\n${helpText}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- CLI-command capability rows no longer inject their full `--help` text into model context: all injection surfaces (frozen net-new cards, stable-prefix hot/core lane cards, spotlight) now render a one-line summary — `The "assistant <name>" CLI command is available. <description>. Run \`assistant <name> --help\` for full usage.` — cutting per-entry cost ~10–20x on turns that select many commands.
- The full help remains the embedding/index text (`renderCapabilityBody` feeds the section index, needle/dense lanes, and the section-embedding backfill), so flag descriptions and examples keep commands semantically findable.
- Capability slugs are excluded from the ephemeral spotlight, since their index "sections" are slices of the full-help body the injection layer deliberately keeps out of context.

## Original prompt
Vargas reported (Loom feedback) that a short user message ("what influencers can help me promote my music on TikTok and Instagram") produced a ~47k-token memory injection on a fresh dev assistant, dominated by CLI-command entries that each carried their full help output — while skills correctly rendered only a title and top line. The requested fix: drop the full help from the CLI-command injection (the assistant can run `--help` itself), while keeping the full help in the embedding/index lanes so retrieval findability is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)