### PR TITLE
fix(web): narrow profile editor provider state to ConnectionProvider

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -228,9 +228,17 @@ function ProfileEditorModalInner({
   // prove the bound row is the managed sentinel (see the effect below) — a
   // user-owned row merely named "vellum" must never enter Vellum mode, even
   // in the pre-load window.
-  const [provider, setProvider] = useState<
-    NonNullable<ProfileEntry["provider"]> | "vellum" | ""
-  >(initialValues?.provider ?? "");
+  // The editor tracks connection providers ("vellum" among them). `LlmProvider`
+  // also admits "chatgpt", a routing identity no write may store (it is
+  // write-locked at parse time, at the config write choke point, and at the
+  // profile write route), so no stored profile carries one — ChatGPT is offered
+  // as an OpenAI connection sub-option in the create form, never as a provider
+  // selection here.
+  const [provider, setProvider] = useState<ConnectionProvider | "">(
+    initialValues?.provider && initialValues.provider !== "chatgpt"
+      ? initialValues.provider
+      : "",
+  );
   const [model, setModel] = useState(initialValues?.model ?? "");
   // Per-profile provider-connection binding. Empty string means no explicit
   // binding — daemon falls back to its first-connection dispatch. Snake_case
@@ -529,8 +537,7 @@ function ProfileEditorModalInner({
   // and invalidate the connections query so the dropdown picks up the row.
   function handleProviderCreated(connection: ProviderConnection) {
     // The create form can't produce a vellum connection; bail before touching
-    // any state so the sub-form can't get stuck, and narrow the
-    // ConnectionProvider to the LlmProvider that setProvider accepts.
+    // any state so the sub-form can't get stuck.
     const newProvider = connection.provider;
     if (newProvider === "vellum") return;
     // Optimistically register the new connection locally so the binding is


### PR DESCRIPTION
## Summary

`CI Main Web` is currently **red on main** (edfdf43d1, 73033840f, e852ee6dd) and every open PR inherits the failure through its merge ref. This is the repair.

`LlmProvider` gained a `"chatgpt"` member, but `profile-editor-modal.tsx` typed its `provider` state off `ProfileEntry["provider"]` and then fed that value into props, handlers, and dropdown options that all accept `ConnectionProvider`. The new member isn't assignable, so `bun run typecheck` fails with 4 errors:

```
src/domains/settings/ai/profile-editor-modal.tsx(887,34): error TS2345: Argument of type '"chatgpt" | ConnectionProvider' is not assignable to parameter of type 'ConnectionProvider'.
src/domains/settings/ai/profile-editor-modal.tsx(909,11): error TS2322: ...
src/domains/settings/ai/profile-editor-modal.tsx(915,11): error TS2322: ...
src/domains/settings/ai/profile-editor-modal.tsx(998,15): error TS2322: ...
```

## Change

Type the state as `ConnectionProvider | ""` and drop `"chatgpt"` when seeding from `initialValues`.

`ConnectionProvider` is exactly `LlmProvider` minus `"chatgpt"` — same 14 members, no other narrowing. The seed guard is **defensive only and unreachable in practice**: `"chatgpt"` is in `WRITE_LOCKED_PROVIDERS` (`assistant/src/config/schemas/llm.ts`), enforced at parse time, at the config write choke point, and at the profile write route — so no stored profile can carry it. ChatGPT reaches users as an OpenAI connection sub-option in the create form, never as a provider selection in this editor.

Also drops a comment clause that described a type narrowing this change makes obsolete.

## Verification

- `bun run typecheck` — clean against current `main`
- `bun run lint` — 0 errors
- `bun test src/domains/settings/ai/profile-editor-modal.test.tsx` — 37 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)