### PR TITLE
fix(memory): make conversation delete resilient to a not-yet-migrated logs DB

### DIFF
--- a/assistant/src/__tests__/conversation-delete-missing-logs-db.test.ts
+++ b/assistant/src/__tests__/conversation-delete-missing-logs-db.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Regression test for the memory worker's startup orphan sweep choking on a
+ * not-yet-migrated logs DB.
+ *
+ * The sweep runs in a separate process (`memory worker`) that can race ahead
+ * of the daemon's async migrations. Its per-orphan `deleteConversation` deletes
+ * `llm_request_logs` (logs DB) and pending `telemetry_events` (telemetry DB).
+ * Before this fix, opening either connection created an empty, table-less file
+ * on disk, so every delete threw `no such table: llm_request_logs` (observed
+ * ~2,752×/boot). The fix opens both with `createIfMissing: false`: a missing
+ * file means there are no rows to delete, so the sub-delete is skipped and the
+ * file is NOT fabricated. The conversation itself (main DB) still deletes.
+ */
+
+import { existsSync } from "node:fs";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+import type { Database } from "bun:sqlite";
+
+import {
+  createConversation,
+  deleteConversation,
+  getConversation,
+} from "../persistence/conversation-crud.js";
+import {
+  getDb,
+  getLogsDb,
+  getLogsSqlite,
+  getTelemetryDb,
+  getTelemetrySqlite,
+} from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { getLogsDbPath } from "../util/logs-db-path.js";
+import { getTelemetryDbPath } from "../util/telemetry-db-path.js";
+import { removeTestDbFiles } from "./assert-not-live-db.js";
+import { resetDbForTesting } from "./db-test-helpers.js";
+
+await initializeDb();
+
+// Capture the logs/telemetry schema up front so `afterAll` can rebuild it.
+// `bun test` runs every file in one process against one shared workspace, and
+// these tests physically remove the two dedicated files to simulate the race —
+// so without a rebuild a later test file that touches `llm_request_logs` would
+// hit the empty file this suite left behind. Replaying the captured DDL is
+// schema-agnostic (no duplicated column lists to drift).
+function captureSchemaDdl(db: Database): string[] {
+  return db
+    .query<{ sql: string }, []>(
+      `SELECT sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY rowid`,
+    )
+    .all()
+    .map((r) => r.sql);
+}
+
+const logsSchemaDdl = captureSchemaDdl(getLogsSqlite()!);
+const telemetrySchemaDdl = captureSchemaDdl(getTelemetrySqlite()!);
+
+function getRawDb(): Database {
+  return (getDb() as unknown as { $client: Database }).$client;
+}
+
+/**
+ * Simulate the pre-migration race: close every connection and remove the logs
+ * and telemetry files so the next accessor sees them as not-yet-created.
+ */
+function dropDedicatedLogFiles(): void {
+  resetDbForTesting();
+  removeTestDbFiles(getLogsDbPath());
+  removeTestDbFiles(getTelemetryDbPath());
+}
+
+describe("deleteConversation with a missing logs/telemetry DB", () => {
+  beforeEach(() => {
+    getRawDb().run("DELETE FROM messages");
+    getRawDb().run("DELETE FROM conversations");
+  });
+
+  // Rebuild the logs/telemetry files (which these tests delete) with their
+  // original schema so later suites in the same process see healthy tables.
+  afterAll(() => {
+    resetDbForTesting();
+    const logs = getLogsSqlite()!;
+    for (const sql of logsSchemaDdl) {
+      logs.run(sql);
+    }
+    const telemetry = getTelemetrySqlite()!;
+    for (const sql of telemetrySchemaDdl) {
+      telemetry.run(sql);
+    }
+  });
+
+  test("does not throw and deletes the conversation when the logs file is absent", () => {
+    const conv = createConversation("orphan-retrospective");
+    dropDedicatedLogFiles();
+
+    expect(() => deleteConversation(conv.id)).not.toThrow();
+    expect(getConversation(conv.id)).toBeNull();
+  });
+
+  test("does not fabricate an empty logs or telemetry file on delete", () => {
+    const conv = createConversation("orphan-retrospective");
+    dropDedicatedLogFiles();
+
+    deleteConversation(conv.id);
+
+    // The delete must not have re-created either dedicated file — recreating it
+    // empty (no tables) is exactly what produced the `no such table` storm.
+    expect(existsSync(getLogsDbPath())).toBe(false);
+    expect(existsSync(getTelemetryDbPath())).toBe(false);
+  });
+
+  test("getLogsDb/getTelemetryDb return null for a missing file without creating it", () => {
+    dropDedicatedLogFiles();
+
+    expect(getLogsDb({ createIfMissing: false })).toBeNull();
+    expect(getTelemetryDb({ createIfMissing: false })).toBeNull();
+    expect(existsSync(getLogsDbPath())).toBe(false);
+    expect(existsSync(getTelemetryDbPath())).toBe(false);
+
+    // The default (open-or-create) path still creates the file — the migration
+    // runner and write path depend on it.
+    expect(getLogsDb()).not.toBeNull();
+    expect(existsSync(getLogsDbPath())).toBe(true);
+  });
+});

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -1712,14 +1712,29 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   // conversation intact for a retried delete. Telemetry redaction keys on
   // conversation_id regardless of event name, so every conversation-scoped
   // pending event is covered.
-  logsDb()
-    .delete(llmRequestLogs)
-    .where(eq(llmRequestLogs.conversationId, id))
-    .run();
-  telemetryDb()
-    .delete(telemetryEvents)
-    .where(eq(telemetryEvents.conversationId, id))
-    .run();
+  //
+  // Both files are created and schema-migrated by the daemon's migration
+  // runner. Open them with `createIfMissing: false`: when a file does not
+  // exist yet there are no rows to delete, so skip rather than let the opener
+  // fabricate an empty, table-less file. The memory worker's startup orphan
+  // sweep runs as a separate process that can race ahead of the daemon's async
+  // migrations — without this it would create an empty logs file and throw
+  // `no such table: llm_request_logs` on every orphan delete. No file, nothing
+  // to sweep.
+  const logsForDelete = getLogsDb({ createIfMissing: false });
+  if (logsForDelete) {
+    logsForDelete
+      .delete(llmRequestLogs)
+      .where(eq(llmRequestLogs.conversationId, id))
+      .run();
+  }
+  const telemetryForDelete = getTelemetryDb({ createIfMissing: false });
+  if (telemetryForDelete) {
+    telemetryForDelete
+      .delete(telemetryEvents)
+      .where(eq(telemetryEvents.conversationId, id))
+      .run();
+  }
 
   db.transaction((tx) => {
     // Collect all message IDs for this conversation.

--- a/assistant/src/persistence/db-connection.ts
+++ b/assistant/src/persistence/db-connection.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { Database } from "bun:sqlite";
@@ -239,14 +239,37 @@ function openDedicatedDb(
 }
 
 /**
+ * Options shared by the dedicated-DB accessors (`getLogsDb`,
+ * `getTelemetryDb`).
+ */
+export interface DedicatedDbAccessOptions {
+  /**
+   * Whether to create the file when it does not exist yet. Defaults to
+   * `true` (open-or-create), which the migration runner and the write path
+   * rely on. Callers that only read or clean up — a conversation delete, or
+   * the memory worker's startup orphan sweep, which run as a separate process
+   * that can race the daemon's async migrations — pass `false` so a
+   * not-yet-created file yields `null` ("nothing there") instead of an empty,
+   * table-less file that then throws `no such table` on every query.
+   */
+  createIfMissing?: boolean;
+}
+
+/**
  * The append-only logs database (`assistant-logs.db`), opened lazily as its
  * own connection. Houses `llm_request_logs`. Returns `null` if the file
- * cannot be opened (logged; the daemon stays up).
+ * cannot be opened (logged; the daemon stays up), or — when
+ * `createIfMissing` is `false` — if the file does not exist yet.
  */
-export function getLogsDb(): DrizzleDb | null {
+export function getLogsDb(
+  options?: DedicatedDbAccessOptions,
+): DrizzleDb | null {
   const existing = getStoredDb<DrizzleDb>("logs");
   if (existing) {
     return existing;
+  }
+  if (options?.createIfMissing === false && !existsSync(getLogsDbPath())) {
+    return null;
   }
   return openDedicatedDb("logs", getLogsDbPath());
 }
@@ -281,12 +304,18 @@ export function getMemorySqlite(): Database | null {
  * connection. Houses the `telemetry_events` outbox (wire payloads recorded at
  * emit time, deleted on successful flush) and `flush_checkpoints` (watermark
  * cursors for the main-DB-backed telemetry sources).
- * Returns `null` if the file cannot be opened (logged; the daemon stays up).
+ * Returns `null` if the file cannot be opened (logged; the daemon stays up),
+ * or — when `createIfMissing` is `false` — if the file does not exist yet.
  */
-export function getTelemetryDb(): DrizzleDb | null {
+export function getTelemetryDb(
+  options?: DedicatedDbAccessOptions,
+): DrizzleDb | null {
   const existing = getStoredDb<DrizzleDb>("telemetry");
   if (existing) {
     return existing;
+  }
+  if (options?.createIfMissing === false && !existsSync(getTelemetryDbPath())) {
+    return null;
   }
   return openDedicatedDb("telemetry", getTelemetryDbPath());
 }


### PR DESCRIPTION
## Prompt / plan

Investigating the memory-jobs-worker breaking on every boot: on startup it runs `sweepOrphanMemoryRetrospectiveConversations` (`jobs-worker.ts:250` → `memory-retrospective-startup-cleanup.ts:210` → `deleteConversation` in `conversation-crud.ts`), which threw `SQLiteError: no such table: llm_request_logs` ~2,752×/boot.

Two things to confirm/fix:
1. Confirm a failure like this doesn't crash the memory worker.
2. Make the sweep resilient to the existence/non-existence of the logs SQLite file — "if there's no file, nothing to sweep."

### Root cause

The memory jobs worker is its own OS process (`worker.ts`), and its startup orphan sweep can run **before** the daemon's async DB migrations create the `llm_request_logs` table (`migration 297`). `deleteConversation` deletes `llm_request_logs` (logs DB) and pending `telemetry_events` (telemetry DB), and `bun:sqlite`'s default create-on-open fabricated an **empty, table-less** file for whichever dedicated DB wasn't migrated yet — so every per-orphan delete threw `no such table`.

### On worker resilience (question 1)

Confirmed: **this does not crash the worker.** The failures are caught at three levels — the per-orphan `try/catch` in the sweep loop (`memory-retrospective-startup-cleanup.ts:212`), the sweep's fire-and-forget `.catch` (`jobs-worker.ts:250`), and the tick loop's `try/catch` (`jobs-worker.ts:284`). The process-level `unhandledRejection`/`uncaughtException` handlers only fire for genuinely unhandled errors, which these are not. No worker-loop change was needed; the noise came entirely from the sweep, which this PR fixes at the source.

## Changes

- `getLogsDb` / `getTelemetryDb` gain a `createIfMissing` option (default `true`, preserving the migration-runner and write paths). When `false`, a not-yet-created file returns `null` instead of an empty, table-less file.
- `deleteConversation` opens both dedicated connections with `createIfMissing: false`. A missing file means there are no rows to delete, so the sub-delete is skipped and the file is not fabricated. The conversation itself (main DB) still deletes. Telemetry gets the same treatment because it deletes immediately after logs and would otherwise become the next `no such table` in the same race.

## Test plan

- New `assistant/src/__tests__/conversation-delete-missing-logs-db.test.ts`:
  - `deleteConversation` does not throw and still deletes the conversation when the logs/telemetry files are absent.
  - the delete does not fabricate an empty logs/telemetry file.
  - `getLogsDb`/`getTelemetryDb` with `createIfMissing: false` return `null` without creating the file, while the default path still creates it.
  - The suite captures and replays the logs/telemetry schema in `afterAll` so it leaves the shared test workspace healthy for later files; verified order-independent against the existing delete/log/fork suites.
- Existing suites pass: `conversation-delete-schedule-cleanup`, `db-logs-attach`, `conversation-row-batch-delete`, `memory-retrospective-startup-cleanup`, `llm-request-log-turn-query`, `conversation-fork-retrospective`.
- `tsc --noEmit`, `prettier --check`, and `eslint` clean.

<!-- CLI verb checklist omitted: this PR adds no new IPC routes. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd4UVHEyiQcx1guYpey5vV)_