### PR TITLE
fix(memory): extend logs/telemetry delete resilience to the gentle delete path

### DIFF
--- a/assistant/src/__tests__/conversation-delete-missing-logs-db.test.ts
+++ b/assistant/src/__tests__/conversation-delete-missing-logs-db.test.ts
@@ -1,15 +1,19 @@
 /**
  * Regression test for the memory worker's startup orphan sweep choking on a
- * not-yet-migrated logs DB.
+ * not-yet-migrated logs/telemetry DB.
  *
- * The sweep runs in a separate process (`memory worker`) that can race ahead
- * of the daemon's async migrations. Its per-orphan `deleteConversation` deletes
- * `llm_request_logs` (logs DB) and pending `telemetry_events` (telemetry DB).
- * Before this fix, opening either connection created an empty, table-less file
- * on disk, so every delete threw `no such table: llm_request_logs` (observed
- * ~2,752×/boot). The fix opens both with `createIfMissing: false`: a missing
- * file means there are no rows to delete, so the sub-delete is skipped and the
- * file is NOT fabricated. The conversation itself (main DB) still deletes.
+ * The sweep runs in a separate process (`memory worker`) that can race ahead of
+ * the daemon's async migrations. Its per-orphan delete clears `llm_request_logs`
+ * (logs DB) and pending `telemetry_events` (telemetry DB). Before the fix,
+ * opening either connection created an empty, table-less file on disk, so every
+ * delete threw `no such table: llm_request_logs` (observed ~2,752×/boot).
+ *
+ * The sweep reaches `@vellumai/plugin-api.deleteConversation`, which routes to
+ * `deleteConversationGently` — so BOTH delete variants are exercised here: the
+ * synchronous `deleteConversation` (used by the HTTP route) and the off-loop
+ * `deleteConversationGently` (used by the sweep). Both must skip the dedicated
+ * sub-deletes when the file is absent (no file → no rows) and must not
+ * fabricate an empty file. The conversation itself (main DB) still deletes.
  */
 
 import { existsSync } from "node:fs";
@@ -25,6 +29,7 @@ import type { Database } from "bun:sqlite";
 import {
   createConversation,
   deleteConversation,
+  deleteConversationGently,
   getConversation,
 } from "../persistence/conversation-crud.js";
 import {
@@ -42,12 +47,12 @@ import { resetDbForTesting } from "./db-test-helpers.js";
 
 await initializeDb();
 
-// Capture the logs/telemetry schema up front so `afterAll` can rebuild it.
-// `bun test` runs every file in one process against one shared workspace, and
-// these tests physically remove the two dedicated files to simulate the race —
-// so without a rebuild a later test file that touches `llm_request_logs` would
-// hit the empty file this suite left behind. Replaying the captured DDL is
-// schema-agnostic (no duplicated column lists to drift).
+// Capture the logs/telemetry schema up front so the module `afterAll` can
+// rebuild it. `bun test` runs every file in one process against one shared
+// workspace, and these tests physically remove the two dedicated files to
+// simulate the race — so without a rebuild a later test file that touches
+// `llm_request_logs` would hit the empty file this suite left behind. Replaying
+// the captured DDL is schema-agnostic (no duplicated column lists to drift).
 function captureSchemaDdl(db: Database): string[] {
   return db
     .query<{ sql: string }, []>(
@@ -74,26 +79,26 @@ function dropDedicatedLogFiles(): void {
   removeTestDbFiles(getTelemetryDbPath());
 }
 
-describe("deleteConversation with a missing logs/telemetry DB", () => {
-  beforeEach(() => {
-    getRawDb().run("DELETE FROM messages");
-    getRawDb().run("DELETE FROM conversations");
-  });
+beforeEach(() => {
+  getRawDb().run("DELETE FROM messages");
+  getRawDb().run("DELETE FROM conversations");
+});
 
-  // Rebuild the logs/telemetry files (which these tests delete) with their
-  // original schema so later suites in the same process see healthy tables.
-  afterAll(() => {
-    resetDbForTesting();
-    const logs = getLogsSqlite()!;
-    for (const sql of logsSchemaDdl) {
-      logs.run(sql);
-    }
-    const telemetry = getTelemetrySqlite()!;
-    for (const sql of telemetrySchemaDdl) {
-      telemetry.run(sql);
-    }
-  });
+// Rebuild the logs/telemetry files (which these tests delete) with their
+// original schema so later suites in the same process see healthy tables.
+afterAll(() => {
+  resetDbForTesting();
+  const logs = getLogsSqlite()!;
+  for (const sql of logsSchemaDdl) {
+    logs.run(sql);
+  }
+  const telemetry = getTelemetrySqlite()!;
+  for (const sql of telemetrySchemaDdl) {
+    telemetry.run(sql);
+  }
+});
 
+describe("synchronous deleteConversation with a missing logs/telemetry DB", () => {
   test("does not throw and deletes the conversation when the logs file is absent", () => {
     const conv = createConversation("orphan-retrospective");
     dropDedicatedLogFiles();
@@ -126,5 +131,28 @@ describe("deleteConversation with a missing logs/telemetry DB", () => {
     // runner and write path depend on it.
     expect(getLogsDb()).not.toBeNull();
     expect(existsSync(getLogsDbPath())).toBe(true);
+  });
+});
+
+describe("deleteConversationGently (sweep path) with a missing logs/telemetry DB", () => {
+  test("does not throw and deletes the conversation when the logs file is absent", async () => {
+    const conv = createConversation("orphan-retrospective");
+    dropDedicatedLogFiles();
+
+    await expect(deleteConversationGently(conv.id)).resolves.toBeDefined();
+    expect(getConversation(conv.id)).toBeNull();
+  });
+
+  test("does not fabricate an empty logs or telemetry file on delete", async () => {
+    const conv = createConversation("orphan-retrospective");
+    dropDedicatedLogFiles();
+
+    await deleteConversationGently(conv.id);
+
+    // The batched logs drain (and the telemetry delete) must be skipped, not
+    // run against a freshly-created empty file — the `no such table` storm was
+    // the batch subprocess creating the file and then failing on it.
+    expect(existsSync(getLogsDbPath())).toBe(false);
+    expect(existsSync(getTelemetryDbPath())).toBe(false);
   });
 });

--- a/assistant/src/__tests__/conversation-delete-missing-logs-db.test.ts
+++ b/assistant/src/__tests__/conversation-delete-missing-logs-db.test.ts
@@ -1,19 +1,20 @@
 /**
- * Regression test for the memory worker's startup orphan sweep choking on a
- * not-yet-migrated logs/telemetry DB.
+ * Invariant: deleting a conversation tolerates a logs/telemetry DB whose target
+ * table is not present yet, and never fabricates a table-less file.
  *
- * The sweep runs in a separate process (`memory worker`) that can race ahead of
- * the daemon's async migrations. Its per-orphan delete clears `llm_request_logs`
- * (logs DB) and pending `telemetry_events` (telemetry DB). Before the fix,
- * opening either connection created an empty, table-less file on disk, so every
- * delete threw `no such table: llm_request_logs` (observed ~2,752×/boot).
- *
- * The sweep reaches `@vellumai/plugin-api.deleteConversation`, which routes to
- * `deleteConversationGently` — so BOTH delete variants are exercised here: the
+ * The memory worker's startup orphan sweep runs in a separate process that can
+ * race ahead of the daemon's async migrations. Its per-orphan delete clears
+ * `llm_request_logs` (logs DB) and pending `telemetry_events` (telemetry DB),
+ * and reaches `@vellumai/plugin-api.deleteConversation`, which routes to
+ * `deleteConversationGently`. So BOTH delete variants are exercised here: the
  * synchronous `deleteConversation` (used by the HTTP route) and the off-loop
- * `deleteConversationGently` (used by the sweep). Both must skip the dedicated
- * sub-deletes when the file is absent (no file → no rows) and must not
- * fabricate an empty file. The conversation itself (main DB) still deletes.
+ * `deleteConversationGently` (used by the sweep).
+ *
+ * Each dedicated file can be in three pre-migration states — absent, an empty
+ * create-on-open shell, or present-with-other-tables (the files accrue tables
+ * over several migrations). In all three the target table is missing, so the
+ * sub-delete must be skipped (no table → no rows) without creating or querying
+ * a table-less file. The conversation itself (main DB) still deletes.
  */
 
 import { existsSync } from "node:fs";
@@ -79,6 +80,18 @@ function dropDedicatedLogFiles(): void {
   removeTestDbFiles(getTelemetryDbPath());
 }
 
+/**
+ * Simulate the mid-migration state where the dedicated files exist but their
+ * target tables do not yet: drop the files, then re-open them via the default
+ * open-or-create path, which runs no DDL — so both files exist as empty,
+ * table-less shells.
+ */
+function createTableLessDedicatedShells(): void {
+  dropDedicatedLogFiles();
+  getLogsDb();
+  getTelemetryDb();
+}
+
 beforeEach(() => {
   getRawDb().run("DELETE FROM messages");
   getRawDb().run("DELETE FROM conversations");
@@ -119,6 +132,20 @@ describe("synchronous deleteConversation with a missing logs/telemetry DB", () =
     expect(existsSync(getTelemetryDbPath())).toBe(false);
   });
 
+  test("does not throw when the files exist without their tables", () => {
+    const conv = createConversation("orphan-retrospective");
+    createTableLessDedicatedShells();
+
+    // The files exist (create-on-open shells), but the tables were never
+    // migrated in — a file-existence guard alone would still run the DELETE and
+    // throw `no such table`. The table-existence guard skips it.
+    expect(existsSync(getLogsDbPath())).toBe(true);
+    expect(existsSync(getTelemetryDbPath())).toBe(true);
+
+    expect(() => deleteConversation(conv.id)).not.toThrow();
+    expect(getConversation(conv.id)).toBeNull();
+  });
+
   test("getLogsDb/getTelemetryDb return null for a missing file without creating it", () => {
     dropDedicatedLogFiles();
 
@@ -154,5 +181,18 @@ describe("deleteConversationGently (sweep path) with a missing logs/telemetry DB
     // the batch subprocess creating the file and then failing on it.
     expect(existsSync(getLogsDbPath())).toBe(false);
     expect(existsSync(getTelemetryDbPath())).toBe(false);
+  });
+
+  test("does not throw when the files exist without their tables", async () => {
+    const conv = createConversation("orphan-retrospective");
+    createTableLessDedicatedShells();
+
+    // File-present-but-table-absent: the batched logs drain must be skipped on
+    // the table-existence check, not run against the shell and fail.
+    expect(existsSync(getLogsDbPath())).toBe(true);
+    expect(existsSync(getTelemetryDbPath())).toBe(true);
+
+    await expect(deleteConversationGently(conv.id)).resolves.toBeDefined();
+    expect(getConversation(conv.id)).toBeNull();
   });
 });

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync } from "node:fs";
 
 import {
   and,
@@ -134,25 +134,45 @@ function logsDb(): DrizzleDb {
 // ---------------------------------------------------------------------------
 //
 // `llm_request_logs` (logs DB) and pending `telemetry_events` (telemetry DB)
-// live in their own files, created and schema-migrated by the daemon's
-// migration runner. Both conversation-delete variants — the synchronous
+// live in their own files. Both conversation-delete variants — the synchronous
 // `deleteConversation` and the off-loop `deleteConversationGently` — must clear
-// them, and both must tolerate the file not existing yet: the memory worker's
-// startup orphan sweep runs as a separate process that can race ahead of the
-// daemon's async migrations, so a dedicated file may be absent (or, if opened
-// with create-on-open, an empty table-less shell). A missing file means there
-// are no rows to delete, so these helpers skip rather than fabricate an empty
-// file that then throws `no such table` on every orphan the sweep processes.
+// them, and both must tolerate the target table not existing yet. The memory
+// worker's startup orphan sweep runs as a separate process that can race ahead
+// of the daemon's async migrations, and a dedicated file accrues its tables
+// over several migrations — so the file can be absent, an empty create-on-open
+// shell, or present-with-other-tables (e.g. the telemetry file exists for an
+// earlier table before `telemetry_events` is created). In every one of those
+// states there are no rows to delete, so the helpers below skip when the table
+// is not yet present rather than fabricate/hit a table-less file and throw
+// `no such table` on every orphan the sweep processes.
+
+/**
+ * Whether `table` exists on the given dedicated connection. Cheap
+ * `sqlite_master` lookup that distinguishes "file present but this migration
+ * has not created the table yet" from "table ready" — checking file existence
+ * alone is not enough because the dedicated logs/telemetry files hold tables
+ * created across several migrations.
+ */
+function dedicatedTableExists(db: DrizzleDb, table: string): boolean {
+  return (
+    getSqliteFrom(db)
+      .query<
+        { name: string },
+        [string]
+      >(`SELECT name FROM sqlite_master WHERE type='table' AND name = ? LIMIT 1`)
+      .get(table) != null
+  );
+}
 
 /**
  * Delete a conversation's pending `telemetry_events` rows from the dedicated
- * telemetry DB, or skip when that file does not exist yet. Telemetry redaction
+ * telemetry DB, or skip when that table does not exist yet. Telemetry redaction
  * keys on `conversation_id` regardless of event name, so this covers every
  * conversation-scoped pending event.
  */
 function deletePendingTelemetryEventsForConversation(id: string): void {
   const telemetry = getTelemetryDb({ createIfMissing: false });
-  if (!telemetry) {
+  if (!telemetry || !dedicatedTableExists(telemetry, "telemetry_events")) {
     return;
   }
   telemetry
@@ -163,14 +183,14 @@ function deletePendingTelemetryEventsForConversation(id: string): void {
 
 /**
  * Delete a conversation's `llm_request_logs` rows in-process from the dedicated
- * logs DB, or skip when that file does not exist yet. Used by the synchronous
+ * logs DB, or skip when that table does not exist yet. Used by the synchronous
  * delete path; {@link deleteConversationGently} drains the same table off the
- * event loop in batches (guarded by the same file-existence check) because its
+ * event loop in batches (guarded by the same table-existence check) because its
  * rows can be bulky.
  */
 function deleteRequestLogsForConversation(id: string): void {
   const logs = getLogsDb({ createIfMissing: false });
-  if (!logs) {
+  if (!logs || !dedicatedTableExists(logs, "llm_request_logs")) {
     return;
   }
   logs
@@ -1876,12 +1896,18 @@ export async function deleteConversationGently(
 
   // llm_request_logs lives in the dedicated logs connection, and each row is
   // bulky, so drain it off the event loop in batches against the logs DB file.
-  // Skip entirely when the file does not exist yet: the batch runs a sqlite3
+  // Skip entirely when the table does not exist yet: the batch runs a sqlite3
   // subprocess (or in-process fallback) against getLogsDbPath(), which would
-  // otherwise create an empty, table-less file and fail with `no such table`
-  // on every orphan the worker's startup sweep processes before the daemon's
-  // async migrations create the table. No file, nothing to drain.
-  if (existsSync(getLogsDbPath())) {
+  // otherwise hit (or create) a table-less file and fail with `no such table`
+  // on every orphan the worker's startup sweep processes before migration 297
+  // lands. The in-process connection sees the same committed schema as the
+  // subprocess, so it is the authority on whether the table is ready. No table,
+  // nothing to drain.
+  const logsDbForBatch = getLogsDb({ createIfMissing: false });
+  if (
+    logsDbForBatch &&
+    dedicatedTableExists(logsDbForBatch, "llm_request_logs")
+  ) {
     const logsDel = await deleteConversationRowsInBatches({
       conversationId: id,
       table: "llm_request_logs",

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
 
 import {
   and,
@@ -129,18 +129,54 @@ function logsDb(): DrizzleDb {
   return db;
 }
 
+// ---------------------------------------------------------------------------
+// Dedicated-DB cleanup for conversation deletes.
+// ---------------------------------------------------------------------------
+//
+// `llm_request_logs` (logs DB) and pending `telemetry_events` (telemetry DB)
+// live in their own files, created and schema-migrated by the daemon's
+// migration runner. Both conversation-delete variants — the synchronous
+// `deleteConversation` and the off-loop `deleteConversationGently` — must clear
+// them, and both must tolerate the file not existing yet: the memory worker's
+// startup orphan sweep runs as a separate process that can race ahead of the
+// daemon's async migrations, so a dedicated file may be absent (or, if opened
+// with create-on-open, an empty table-less shell). A missing file means there
+// are no rows to delete, so these helpers skip rather than fabricate an empty
+// file that then throws `no such table` on every orphan the sweep processes.
+
 /**
- * The telemetry connection (`assistant-telemetry.db`), where the
- * `telemetry_events` outbox lives. Throws if the file cannot be opened — the
- * conversation-delete call sites must not report success while unshipped
- * events referencing the deleted conversation survive to be flushed.
+ * Delete a conversation's pending `telemetry_events` rows from the dedicated
+ * telemetry DB, or skip when that file does not exist yet. Telemetry redaction
+ * keys on `conversation_id` regardless of event name, so this covers every
+ * conversation-scoped pending event.
  */
-function telemetryDb(): DrizzleDb {
-  const db = getTelemetryDb();
-  if (!db) {
-    throw new Error("telemetry database unavailable");
+function deletePendingTelemetryEventsForConversation(id: string): void {
+  const telemetry = getTelemetryDb({ createIfMissing: false });
+  if (!telemetry) {
+    return;
   }
-  return db;
+  telemetry
+    .delete(telemetryEvents)
+    .where(eq(telemetryEvents.conversationId, id))
+    .run();
+}
+
+/**
+ * Delete a conversation's `llm_request_logs` rows in-process from the dedicated
+ * logs DB, or skip when that file does not exist yet. Used by the synchronous
+ * delete path; {@link deleteConversationGently} drains the same table off the
+ * event loop in batches (guarded by the same file-existence check) because its
+ * rows can be bulky.
+ */
+function deleteRequestLogsForConversation(id: string): void {
+  const logs = getLogsDb({ createIfMissing: false });
+  if (!logs) {
+    return;
+  }
+  logs
+    .delete(llmRequestLogs)
+    .where(eq(llmRequestLogs.conversationId, id))
+    .run();
 }
 
 // ── Message metadata Zod schema ──────────────────────────────────────
@@ -1709,32 +1745,10 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   // llm_request_logs and pending telemetry_events rows live in the dedicated
   // logs and telemetry connections, so they are deleted there — separately
   // from (and before) the main-DB transaction below, so a failure leaves the
-  // conversation intact for a retried delete. Telemetry redaction keys on
-  // conversation_id regardless of event name, so every conversation-scoped
-  // pending event is covered.
-  //
-  // Both files are created and schema-migrated by the daemon's migration
-  // runner. Open them with `createIfMissing: false`: when a file does not
-  // exist yet there are no rows to delete, so skip rather than let the opener
-  // fabricate an empty, table-less file. The memory worker's startup orphan
-  // sweep runs as a separate process that can race ahead of the daemon's async
-  // migrations — without this it would create an empty logs file and throw
-  // `no such table: llm_request_logs` on every orphan delete. No file, nothing
-  // to sweep.
-  const logsForDelete = getLogsDb({ createIfMissing: false });
-  if (logsForDelete) {
-    logsForDelete
-      .delete(llmRequestLogs)
-      .where(eq(llmRequestLogs.conversationId, id))
-      .run();
-  }
-  const telemetryForDelete = getTelemetryDb({ createIfMissing: false });
-  if (telemetryForDelete) {
-    telemetryForDelete
-      .delete(telemetryEvents)
-      .where(eq(telemetryEvents.conversationId, id))
-      .run();
-  }
+  // conversation intact for a retried delete. Both helpers skip when their
+  // dedicated file does not exist yet (see the block comment on those helpers).
+  deleteRequestLogsForConversation(id);
+  deletePendingTelemetryEventsForConversation(id);
 
   db.transaction((tx) => {
     // Collect all message IDs for this conversation.
@@ -1853,26 +1867,31 @@ export async function deleteConversationGently(
     .map((r) => r.id);
 
   // Pending telemetry_events rows live in the dedicated telemetry connection;
-  // delete them there (by conversation_id, regardless of event name) before
-  // ANY destructive work so a telemetry failure leaves the conversation fully
+  // delete them (by conversation_id, regardless of event name) before ANY
+  // destructive work so a telemetry failure leaves the conversation fully
   // intact for a retried delete — a throw after the bulk drains below would
-  // strand unredacted rows that could still flush.
-  telemetryDb()
-    .delete(telemetryEvents)
-    .where(eq(telemetryEvents.conversationId, id))
-    .run();
+  // strand unredacted rows that could still flush. Skips when the telemetry
+  // file does not exist yet.
+  deletePendingTelemetryEventsForConversation(id);
 
   // llm_request_logs lives in the dedicated logs connection, and each row is
   // bulky, so drain it off the event loop in batches against the logs DB file.
-  const logsDel = await deleteConversationRowsInBatches({
-    conversationId: id,
-    table: "llm_request_logs",
-    dbPath: getLogsDbPath(),
-  });
-  if (!logsDel.ok) {
-    throw new Error(
-      `gentle conversation delete failed (llm_request_logs, ${logsDel.backend}): ${logsDel.error ?? "unknown"}`,
-    );
+  // Skip entirely when the file does not exist yet: the batch runs a sqlite3
+  // subprocess (or in-process fallback) against getLogsDbPath(), which would
+  // otherwise create an empty, table-less file and fail with `no such table`
+  // on every orphan the worker's startup sweep processes before the daemon's
+  // async migrations create the table. No file, nothing to drain.
+  if (existsSync(getLogsDbPath())) {
+    const logsDel = await deleteConversationRowsInBatches({
+      conversationId: id,
+      table: "llm_request_logs",
+      dbPath: getLogsDbPath(),
+    });
+    if (!logsDel.ok) {
+      throw new Error(
+        `gentle conversation delete failed (llm_request_logs, ${logsDel.backend}): ${logsDel.error ?? "unknown"}`,
+      );
+    }
   }
 
   // Bulk message delete off the event loop, in lock-friendly batches. Cascades


### PR DESCRIPTION
## Prompt / plan

Follow-up to #38639, prompted by a Codex review comment on that PR ([discussion r3624951752](https://github.com/vellum-ai/vellum-assistant/pull/38639#discussion_r3624951752), P1).

#38639 hardened the **synchronous** `deleteConversation`, but the memory worker's startup orphan sweep reaches `@vellumai/plugin-api.deleteConversation` → `conversation-plugin-facade.deleteConversation` → **`deleteConversationGently`** — the variant #38639 did not touch. So the actual sweep path still:
- called `telemetryDb().delete(...)` (the throwing helper), and
- ran the `llm_request_logs` batch directly against `getLogsDbPath()`

…meaning a not-yet-migrated logs or telemetry DB during the daemon's async migrations still produced `no such table` for every orphan the sweep processed. In other words, #38639 fixed the interactive HTTP-route delete but not the reported ~2,752×/boot sweep. This PR closes that gap.

## Changes

Moved the dedicated-DB cleanup into two shared helpers used by **both** delete variants (per Codex's suggestion to share the handling rather than duplicate it):

- `deletePendingTelemetryEventsForConversation(id)` — opens telemetry with `createIfMissing: false`, skips when the file is absent.
- `deleteRequestLogsForConversation(id)` — the in-process `llm_request_logs` delete for the synchronous path, same `createIfMissing: false` guard.

`deleteConversationGently` now:
- calls the shared telemetry helper (was the throwing `telemetryDb()`), and
- guards its batched logs drain with `existsSync(getLogsDbPath())`, so it skips — rather than letting the sqlite3 subprocess fabricate an empty, table-less file and then fail on it — when the logs DB has not been created yet.

The now-unused throwing `telemetryDb()` helper is removed. The synchronous `deleteConversation` behaviour is unchanged; it just routes through the shared helpers now.

Migration/writer paths are untouched: `getLogsDb`/`getTelemetryDb` still default to open-or-create.

## Test plan

- Extended `conversation-delete-missing-logs-db.test.ts` to exercise **both** variants against absent logs/telemetry files: a new `deleteConversationGently (sweep path)` describe block asserts it resolves, deletes the conversation, and does not fabricate an empty logs/telemetry file — alongside the existing synchronous-variant cases. The suite still captures + replays the dedicated-DB schema in a module `afterAll` so it leaves the shared test workspace healthy for later files.
- Related suites pass together (no cross-file contamination): `conversation-delete-missing-logs-db`, `conversation-delete-schedule-cleanup`, `conversation-row-batch-delete`, `db-logs-attach`, `memory-retrospective-startup-cleanup`, `conversation-fork-retrospective`, `llm-request-log-turn-query` — 60 pass / 1 skip.
- Pre-commit hook: `prettier --check`, `eslint`, and `tsc --noEmit` all clean.

<!-- CLI verb checklist omitted: this PR adds no new IPC routes. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd4UVHEyiQcx1guYpey5vV)_