### PR TITLE
fix(live-voice): resolve effective speech providers at runtime (JARVIS-1314)

### DIFF
--- a/assistant/src/config/managed-speech-defaults.ts
+++ b/assistant/src/config/managed-speech-defaults.ts
@@ -1,12 +1,19 @@
 /**
- * Managed-speech defaulting on Vellum connection.
+ * Managed-speech defaulting.
  *
- * When the platform connection completes and a speech service has no working
- * BYOK credential, default that service to `provider: "vellum"` so a fresh
+ * When the platform connection is usable and a speech service has no working
+ * BYOK credential, that service's effective provider is `"vellum"` so a fresh
  * Vellum connection gets voice features with zero configuration. A service
- * whose BYOK credential is already configured is never modified — connecting
- * Vellum must not silently reroute an existing voice setup — and a service
- * already on Vellum is left alone.
+ * whose BYOK credential is configured is never redirected — connecting Vellum
+ * must not silently reroute an existing voice setup — and a service already on
+ * Vellum is left alone.
+ *
+ * {@link resolveEffectiveSpeechProviders} is the single definition of that
+ * rule. It writes nothing, so runtime paths that only need to know which
+ * provider they will actually use (live-voice readiness, transcription,
+ * synthesis) resolve the same ids the scope-gated writer
+ * {@link maybeDefaultSpeechToManaged} would persist, without needing write
+ * access to the config.
  */
 
 import { ttsSecretResolves } from "../calls/telephony-tts-capability.js";
@@ -15,6 +22,7 @@ import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.j
 import { sttProviderKeyResolves } from "../providers/speech-to-text/resolve.js";
 import type { SttProviderId } from "../stt/types.js";
 import { getCatalogProvider } from "../tts/provider-catalog.js";
+import type { TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import {
   getConfig,
@@ -23,6 +31,7 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "./loader.js";
+import type { AssistantConfig } from "./types.js";
 
 const log = getLogger("managed-speech-defaults");
 
@@ -51,35 +60,70 @@ async function ttsByokCredentialsResolve(provider: string): Promise<boolean> {
   return true;
 }
 
+/** The speech providers a runtime path uses, after managed-speech defaulting. */
+export interface EffectiveSpeechProviders {
+  stt: SttProviderId;
+  tts: TtsProviderId;
+}
+
 /**
- * Default unconfigured speech services to the Vellum provider.
+ * Resolve the speech providers the runtime actually uses.
  *
- * Safe to call repeatedly (idempotent) and safe to fire-and-forget: it
- * no-ops unless the platform connection is fully usable, and it only ever
- * repoints `provider` at `"vellum"` for services with no working BYOK
- * credential.
+ * A configured service whose BYOK credential does not resolve is reported as
+ * `"vellum"` while managed speech is available; every other service keeps its
+ * configured provider. Read-only — callers that hold no `settings.write`
+ * scope (the live-voice WebSocket transport) resolve the same verdict the
+ * preflight route does without persisting anything.
+ *
+ * `config` selects the configuration to read the configured providers from,
+ * for callers already holding one (defaults to the loaded config).
+ */
+export async function resolveEffectiveSpeechProviders(
+  config?: AssistantConfig,
+): Promise<EffectiveSpeechProviders> {
+  const services = (config ?? getConfig()).services;
+  const configuredStt = services.stt.provider as SttProviderId;
+  const configuredTts = services.tts.provider as TtsProviderId;
+
+  if (!(await managedSpeechAvailable())) {
+    return { stt: configuredStt, tts: configuredTts };
+  }
+
+  const stt =
+    configuredStt !== "vellum" &&
+    !(await sttByokCredentialResolves(configuredStt))
+      ? "vellum"
+      : configuredStt;
+
+  const tts =
+    configuredTts !== "vellum" &&
+    !(await ttsByokCredentialsResolve(configuredTts))
+      ? "vellum"
+      : configuredTts;
+
+  return { stt, tts };
+}
+
+/**
+ * Persist the effective speech providers resolved by
+ * {@link resolveEffectiveSpeechProviders} whenever they differ from the
+ * configured ones.
+ *
+ * Safe to call repeatedly (idempotent) and safe to fire-and-forget. Callers
+ * must hold the `settings.write` scope — this is the only path that writes
+ * `services.stt/tts.provider` on behalf of managed-speech defaulting.
  */
 export async function maybeDefaultSpeechToManaged(): Promise<void> {
   try {
-    if (!(await managedSpeechAvailable())) {
-      return;
-    }
-
     const services = getConfig().services;
-    const updates: string[] = [];
+    const effective = await resolveEffectiveSpeechProviders();
 
-    if (
-      services.stt.provider !== "vellum" &&
-      !(await sttByokCredentialResolves(services.stt.provider))
-    ) {
-      updates.push("services.stt.provider");
+    const updates: { path: string; provider: string }[] = [];
+    if (effective.stt !== services.stt.provider) {
+      updates.push({ path: "services.stt.provider", provider: effective.stt });
     }
-
-    if (
-      services.tts.provider !== "vellum" &&
-      !(await ttsByokCredentialsResolve(services.tts.provider))
-    ) {
-      updates.push("services.tts.provider");
+    if (effective.tts !== services.tts.provider) {
+      updates.push({ path: "services.tts.provider", provider: effective.tts });
     }
 
     if (updates.length === 0) {
@@ -87,13 +131,13 @@ export async function maybeDefaultSpeechToManaged(): Promise<void> {
     }
 
     const raw = loadRawConfig();
-    for (const path of updates) {
-      setNestedValue(raw, path, "vellum");
+    for (const { path, provider } of updates) {
+      setNestedValue(raw, path, provider);
     }
     saveRawConfig(raw);
     invalidateConfigCache();
     log.info(
-      { defaulted: updates },
+      { defaulted: updates.map(({ path }) => path) },
       "Defaulted unconfigured speech services to the Vellum provider after connection",
     );
   } catch (err) {

--- a/assistant/src/live-voice/__tests__/live-voice-managed-speech-fallback.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-managed-speech-fallback.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Live voice on managed speech without a config write.
+ *
+ * `/v1/live-voice` validates guardian identity only — it does not enforce the
+ * caller's `settings.write` scope — so the WebSocket transport must never
+ * persist `services.stt/tts.provider`. Instead every live-voice leg resolves
+ * the EFFECTIVE providers: while managed speech is available, a configured
+ * BYOK provider whose credential does not resolve is served by `"vellum"`.
+ * These tests pin both halves of that contract — the readiness verdict and
+ * the runtime legs agree, and `config.json` is byte-identical afterwards.
+ *
+ * `mock.module` is process-global in Bun and leaks into sibling files that run
+ * later in the same `bun test` invocation, so each stub delegates to the real
+ * implementation unless this file's tests are active (`fallbackMocksActive`,
+ * toggled in beforeAll/afterAll). Run this file on its own.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import type { ResolveStreamingTranscriberOptions } from "../../providers/speech-to-text/resolve.js";
+import type { StreamingTranscriber } from "../../stt/types.js";
+
+let fallbackMocksActive = false;
+
+const realSttResolveModule = {
+  ...(await import("../../providers/speech-to-text/resolve.js")),
+};
+const realSecureKeysModule = {
+  ...(await import("../../security/secure-keys.js")),
+};
+const realManagedSpeechModule = {
+  ...(await import("../../platform/managed-speech.js")),
+};
+
+// -- Mutable stub state -------------------------------------------------------
+
+/** Whether the platform connection can serve managed speech. */
+let managedAvailable = false;
+/** Credential-store keys that resolve to a value. */
+let providerKeys: Record<string, string>;
+/** Provider ids `resolveStreamingTranscriber` was asked for, in call order. */
+let requestedSttProviders: (string | undefined)[];
+
+/** A provider yields a streaming transcriber when its credential resolves. */
+function transcriberFor(providerId: string | undefined): boolean {
+  return providerId === "vellum"
+    ? managedAvailable
+    : providerId !== undefined && providerKeys[providerId] !== undefined;
+}
+
+mock.module("../../providers/speech-to-text/resolve.js", () => ({
+  ...realSttResolveModule,
+  resolveStreamingTranscriber: async (
+    options: ResolveStreamingTranscriberOptions = {},
+  ) => {
+    if (!fallbackMocksActive) {
+      return realSttResolveModule.resolveStreamingTranscriber(options);
+    }
+    requestedSttProviders.push(options.providerId);
+    return transcriberFor(options.providerId)
+      ? ({} as StreamingTranscriber)
+      : null;
+  },
+}));
+
+mock.module("../../security/secure-keys.js", () => ({
+  ...realSecureKeysModule,
+  getProviderKeyAsync: async (provider: string) =>
+    fallbackMocksActive
+      ? providerKeys[provider]
+      : realSecureKeysModule.getProviderKeyAsync(provider),
+  getSecureKeyAsync: async (account: string) =>
+    fallbackMocksActive
+      ? providerKeys[account]
+      : realSecureKeysModule.getSecureKeyAsync(account),
+}));
+
+mock.module("../../platform/managed-speech.js", () => ({
+  ...realManagedSpeechModule,
+  managedSpeechAvailable: async () =>
+    fallbackMocksActive
+      ? managedAvailable
+      : realManagedSpeechModule.managedSpeechAvailable(),
+}));
+
+import { getConfig, invalidateConfigCache } from "../../config/loader.js";
+import { resolveEffectiveSpeechProviders } from "../../config/managed-speech-defaults.js";
+import {
+  _resetTtsProviderOverridesForTests,
+  _setTtsProviderForTests,
+} from "../../tts/provider-catalog.js";
+import type {
+  TtsProvider,
+  TtsSynthesisRequest,
+  TtsSynthesisResult,
+} from "../../tts/types.js";
+import { resolveLiveVoiceCredentialReadiness } from "../live-voice-credential-preflight.js";
+import { streamLiveVoiceTtsAudio } from "../live-voice-tts.js";
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+/** Config with both speech services pointed at BYOK providers. */
+const BYOK_CONFIG = {
+  services: {
+    stt: { provider: "deepgram", providers: {} },
+    tts: { provider: "elevenlabs", providers: {} },
+  },
+};
+
+function writeConfig(obj: unknown): void {
+  if (!existsSync(WORKSPACE_DIR)) {
+    mkdirSync(WORKSPACE_DIR, { recursive: true });
+  }
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj));
+  invalidateConfigCache();
+}
+
+function readConfigFile(): string {
+  return readFileSync(CONFIG_PATH, "utf8");
+}
+
+/** A streaming TTS adapter standing in for the managed `vellum` provider. */
+function registerManagedTtsProvider(): TtsProvider {
+  const provider: TtsProvider = {
+    id: "vellum",
+    capabilities: { supportsStreaming: true, supportedFormats: ["pcm", "mp3"] },
+    async synthesize(): Promise<TtsSynthesisResult> {
+      throw new Error("buffered synthesis should not be used");
+    },
+    async synthesizeStream(
+      _request: TtsSynthesisRequest,
+      onChunk: (chunk: Uint8Array) => void,
+    ): Promise<TtsSynthesisResult> {
+      onChunk(Buffer.from("managed!"));
+      return { audio: Buffer.from("managed!"), contentType: "audio/pcm" };
+    },
+  };
+  _setTtsProviderForTests(provider);
+  return provider;
+}
+
+beforeAll(() => {
+  fallbackMocksActive = true;
+});
+
+afterAll(() => {
+  fallbackMocksActive = false;
+});
+
+afterEach(() => {
+  _resetTtsProviderOverridesForTests();
+});
+
+beforeEach(() => {
+  writeConfig(BYOK_CONFIG);
+  managedAvailable = false;
+  providerKeys = {};
+  requestedSttProviders = [];
+});
+
+describe("live voice on managed speech", () => {
+  test("unkeyed BYOK TTS resolves the managed provider and reports ready", async () => {
+    managedAvailable = true;
+    providerKeys = { deepgram: "test-key" };
+    const configBefore = readConfigFile();
+
+    const effective = await resolveEffectiveSpeechProviders();
+    expect(effective).toEqual({ stt: "deepgram", tts: "vellum" });
+
+    const readiness = await resolveLiveVoiceCredentialReadiness();
+    expect(readiness).toEqual({ status: "ready" });
+
+    expect(readConfigFile()).toBe(configBefore);
+  });
+
+  test("synthesis runs on the managed provider while the config still names the BYOK one", async () => {
+    managedAvailable = true;
+    providerKeys = { deepgram: "test-key" };
+    registerManagedTtsProvider();
+    const configBefore = readConfigFile();
+
+    const chunks: string[] = [];
+    const result = await streamLiveVoiceTtsAudio({
+      text: "hello",
+      config: getConfig(),
+      onAudioChunk: (chunk) => {
+        chunks.push(chunk.dataBase64);
+      },
+    });
+
+    expect(result.provider).toBe("vellum");
+    expect(chunks).toHaveLength(1);
+    expect(getConfig().services.tts.provider).toBe("elevenlabs");
+    expect(readConfigFile()).toBe(configBefore);
+  });
+
+  test("unkeyed BYOK STT resolves the managed provider and reports ready", async () => {
+    managedAvailable = true;
+    providerKeys = { elevenlabs: "test-key" };
+    const configBefore = readConfigFile();
+
+    const effective = await resolveEffectiveSpeechProviders();
+    expect(effective).toEqual({ stt: "vellum", tts: "elevenlabs" });
+
+    const readiness = await resolveLiveVoiceCredentialReadiness();
+    expect(readiness).toEqual({ status: "ready" });
+
+    // The transcriber the session arms is asked for the same provider the
+    // readiness verdict was earned on.
+    expect(requestedSttProviders).toEqual(["vellum"]);
+    expect(readConfigFile()).toBe(configBefore);
+  });
+
+  test("managed speech unavailable keeps the configured providers and reports not-ready", async () => {
+    managedAvailable = false;
+    const configBefore = readConfigFile();
+
+    const effective = await resolveEffectiveSpeechProviders();
+    expect(effective).toEqual({ stt: "deepgram", tts: "elevenlabs" });
+
+    const readiness = await resolveLiveVoiceCredentialReadiness();
+    expect(readiness.status).toBe("not-ready");
+    if (readiness.status !== "not-ready") {
+      throw new Error("expected not-ready");
+    }
+    expect(readiness.missing.map((gap) => gap.providerId)).toEqual([
+      "deepgram",
+      "elevenlabs",
+    ]);
+    expect(requestedSttProviders).toEqual(["deepgram"]);
+    expect(readConfigFile()).toBe(configBefore);
+  });
+});

--- a/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
@@ -517,6 +517,7 @@ function makeConfig(
 ): LiveVoiceTtsConfig {
   return {
     services: {
+      stt: { provider: "deepgram", providers: {} },
       tts: {
         provider: overrides.provider ?? "fish-audio",
         providers: {

--- a/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
+++ b/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
@@ -325,6 +325,7 @@ describe("RuntimeHttpServer live voice WebSocket shell", () => {
     expect(typeof ready.sessionId).toBe("string");
     expect(resolveStreamingTranscriberMock).toHaveBeenCalledWith({
       sampleRate: 24_000,
+      providerId: "deepgram",
     });
     expect(resolvedTranscribers).toHaveLength(1);
     expect(resolvedTranscribers[0]?.started).toBe(true);

--- a/assistant/src/live-voice/live-voice-credential-preflight.ts
+++ b/assistant/src/live-voice/live-voice-credential-preflight.ts
@@ -6,16 +6,22 @@
  * assistant audio. This resolver combines the two checks into a single
  * ready / not-ready verdict with a user-facing message suitable for the
  * client `error` frame, so a session fails at the `start` frame instead of
- * mid-conversation. It opens no live connections and performs no session
- * wiring — the session gates startup on the verdict. Mirrors
- * `calls/telephony-credential-preflight.ts` for the phone-call transport.
+ * mid-conversation. It opens no live connections, performs no session
+ * wiring, and writes no config — the session gates startup on the verdict.
+ * Mirrors `calls/telephony-credential-preflight.ts` for the phone-call
+ * transport.
+ *
+ * Both legs are checked against the effective providers
+ * (`resolveEffectiveSpeechProviders`), which is what the transcriber and
+ * synthesis paths resolve too — so a `ready` verdict earned on managed
+ * speech is a verdict the runtime can honour.
  */
 
 import {
   fishAudioReferenceIdConfigured,
   ttsSecretResolves,
 } from "../calls/telephony-tts-capability.js";
-import { getConfig } from "../config/loader.js";
+import { resolveEffectiveSpeechProviders } from "../config/managed-speech-defaults.js";
 import { managedSpeechAvailable } from "../platform/managed-speech.js";
 import { getProviderEntry } from "../providers/speech-to-text/provider-catalog.js";
 import {
@@ -26,7 +32,7 @@ import {
 import type { SttProviderId } from "../stt/types.js";
 import type { TtsProviderCatalogEntry } from "../tts/provider-catalog.js";
 import { getCatalogProvider, getTtsProvider } from "../tts/provider-catalog.js";
-import { resolveTtsConfig } from "../tts/tts-config-resolver.js";
+import type { TtsProviderId } from "../tts/types.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -61,18 +67,22 @@ export type LiveVoiceCredentialReadiness =
  * session.
  *
  * Readiness requires:
- * - STT: the configured `services.stt.provider` resolves a streaming
- *   transcriber (the session arms one per utterance — there is no batch
- *   fallback on the live-voice transport).
- * - TTS: the configured `services.tts.provider` supports streaming
- *   synthesis (`synthesizeStream`), all of its required secrets resolve,
- *   and provider-specific config invariants hold (fish-audio requires a
+ * - STT: the effective STT provider resolves a streaming transcriber (the
+ *   session arms one per utterance — there is no batch fallback on the
+ *   live-voice transport).
+ * - TTS: the effective TTS provider supports streaming synthesis
+ *   (`synthesizeStream`), all of its required secrets resolve, and
+ *   provider-specific config invariants hold (fish-audio requires a
  *   configured `referenceId` — live voice supplies no per-request voiceId).
  */
 export async function resolveLiveVoiceCredentialReadiness(): Promise<LiveVoiceCredentialReadiness> {
-  const gaps = (await Promise.all([resolveSttGap(), resolveTtsGap()])).filter(
-    (gap) => gap !== null,
-  );
+  const effective = await resolveEffectiveSpeechProviders();
+  const gaps = (
+    await Promise.all([
+      resolveSttGap(effective.stt),
+      resolveTtsGap(effective.tts),
+    ])
+  ).filter((gap) => gap !== null);
 
   if (gaps.length === 0) {
     return { status: "ready" };
@@ -98,17 +108,18 @@ interface GapWithClause {
 }
 
 /**
- * Resolve the STT leg: no gap when the configured provider yields a
- * streaming transcriber. When none resolves, classify why so the gap
- * names the missing piece.
+ * Resolve the STT leg: no gap when the given provider yields a streaming
+ * transcriber. When none resolves, classify why so the gap names the
+ * missing piece.
  */
-async function resolveSttGap(): Promise<GapWithClause | null> {
-  if ((await resolveStreamingTranscriber()) !== null) {
+async function resolveSttGap(
+  providerId: SttProviderId,
+): Promise<GapWithClause | null> {
+  if ((await resolveStreamingTranscriber({ providerId })) !== null) {
     return null;
   }
 
-  const providerId = getConfig().services.stt.provider;
-  const entry = getProviderEntry(providerId as SttProviderId);
+  const entry = getProviderEntry(providerId);
   if (!entry) {
     return {
       gap: {
@@ -145,14 +156,14 @@ async function resolveSttGap(): Promise<GapWithClause | null> {
 }
 
 /**
- * Resolve the TTS leg: no gap when the configured provider supports
- * streaming synthesis, every secret its catalog entry requires resolves
- * to a value, and fish-audio (which live voice drives without a
- * per-request voiceId) has a configured `referenceId`.
+ * Resolve the TTS leg: no gap when the given provider supports streaming
+ * synthesis, every secret its catalog entry requires resolves to a value,
+ * and fish-audio (which live voice drives without a per-request voiceId)
+ * has a configured `referenceId`.
  */
-async function resolveTtsGap(): Promise<GapWithClause | null> {
-  const { provider: providerId } = resolveTtsConfig(getConfig());
-
+async function resolveTtsGap(
+  providerId: TtsProviderId,
+): Promise<GapWithClause | null> {
   let entry: TtsProviderCatalogEntry;
   try {
     entry = getCatalogProvider(providerId);

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -3980,9 +3980,12 @@ async function defaultSpawnBackgroundContinuation(args: {
 async function defaultResolveStreamingTranscriber(
   options: ResolveStreamingTranscriberOptions,
 ): Promise<StreamingTranscriber | null> {
+  const { resolveEffectiveSpeechProviders } =
+    await import("../config/managed-speech-defaults.js");
   const { resolveStreamingTranscriber } =
     await import("../providers/speech-to-text/resolve.js");
-  return resolveStreamingTranscriber(options);
+  const { stt } = await resolveEffectiveSpeechProviders();
+  return resolveStreamingTranscriber({ ...options, providerId: stt });
 }
 
 async function defaultResolveLiveVoiceCredentialReadiness(): Promise<LiveVoiceCredentialReadiness> {

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -186,7 +186,14 @@ async function resolveLiveVoiceStreamingTtsProvider(
   configOverride?: LiveVoiceTtsConfig,
 ): Promise<ResolvedStreamingTtsProvider> {
   const config = configOverride ?? (await loadAssistantConfig());
-  const { provider: providerId, providerConfig } = resolveTtsConfig(config);
+  const { resolveEffectiveSpeechProviders } =
+    await import("../config/managed-speech-defaults.js");
+  const { tts: effectiveProviderId } =
+    await resolveEffectiveSpeechProviders(config);
+  const { provider: providerId, providerConfig } = resolveTtsConfig(
+    config,
+    effectiveProviderId,
+  );
 
   let provider: TtsProvider;
   try {

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -259,6 +259,14 @@ export interface ResolveStreamingTranscriberOptions {
   /** Audio sample rate in Hz from the client WebSocket connection. */
   sampleRate?: number;
   /**
+   * Provider to resolve a transcriber for. Defaults to
+   * `services.stt.provider`. Callers that derive the provider themselves
+   * (e.g. live voice, which runs on the managed-speech effective provider)
+   * pass it here so the resolved transcriber matches the provider their own
+   * readiness check approved.
+   */
+  providerId?: SttProviderId;
+  /**
    * Speaker diarization preference. Default: `"off"`.
    *
    * See {@link DiarizePreference} for semantics.
@@ -286,38 +294,36 @@ export interface ResolveStreamingTranscriberOptions {
 /**
  * Resolve a `StreamingTranscriber` for daemon-hosted streaming transcription.
  *
- * Reads `services.stt.provider` from the assistant config to determine which
- * STT provider to use, verifies it supports the `daemon-streaming` boundary,
- * and constructs the appropriate streaming adapter. Credential lookup is
- * centralized here (an authorized secure-keys importer) so callers don't
- * need to import secure-keys directly.
+ * Uses `options.providerId`, falling back to `services.stt.provider` from the
+ * assistant config, verifies the provider supports the `daemon-streaming`
+ * boundary, and constructs the appropriate streaming adapter. Credential
+ * lookup is centralized here (an authorized secure-keys importer) so callers
+ * don't need to import secure-keys directly.
  *
  * Returns `null` when:
- * - The configured provider is not in the catalog.
- * - The configured provider doesn't support the `daemon-streaming` boundary.
+ * - The resolved provider is not in the catalog.
+ * - The resolved provider doesn't support the `daemon-streaming` boundary.
  * - No credentials are configured for the resolved provider.
- * - No streaming adapter exists for the configured provider.
- * - `diarize` is `"required"` but the configured provider cannot diarize.
- * - `utteranceBoundaryFinals` is set but the configured provider's catalog
+ * - No streaming adapter exists for the resolved provider.
+ * - `diarize` is `"required"` but the resolved provider cannot diarize.
+ * - `utteranceBoundaryFinals` is set but the resolved provider's catalog
  *   `telephonyMode` is not `"realtime-ws"`.
  */
 export async function resolveStreamingTranscriber(
   options: ResolveStreamingTranscriberOptions = {},
 ): Promise<StreamingTranscriber | null> {
-  const config = getConfig();
-  const provider = config.services.stt.provider;
+  const provider =
+    options.providerId ?? (getConfig().services.stt.provider as SttProviderId);
   const diarizePreference: DiarizePreference = options.diarize ?? "off";
 
   // Look up credential provider via the catalog.
-  const credentialProviderName = getCredentialProvider(
-    provider as SttProviderId,
-  );
+  const credentialProviderName = getCredentialProvider(provider);
   if (!credentialProviderName) {
     return null;
   }
 
   // Verify the provider supports the daemon-streaming boundary.
-  if (!supportsBoundary(provider as SttProviderId, "daemon-streaming")) {
+  if (!supportsBoundary(provider, "daemon-streaming")) {
     return null;
   }
 
@@ -329,9 +335,7 @@ export async function resolveStreamingTranscriber(
   // hangup, or mid-sentence replies. Resolve to null so the caller falls
   // back to per-turn batch transcription.
   if (options.utteranceBoundaryFinals) {
-    const telephonyMode = getProviderEntry(
-      provider as SttProviderId,
-    )?.telephonyMode;
+    const telephonyMode = getProviderEntry(provider)?.telephonyMode;
     if (telephonyMode !== "realtime-ws") {
       log.warn(
         { providerId: provider, telephonyMode },
@@ -344,9 +348,7 @@ export async function resolveStreamingTranscriber(
   // Resolve diarization capability against the catalog. For `"required"`
   // callers, bail early (with a warning) when the configured provider can't
   // diarize so the caller can surface a clear error to the user.
-  const providerSupportsDiarization = supportsDiarization(
-    provider as SttProviderId,
-  );
+  const providerSupportsDiarization = supportsDiarization(provider);
   if (diarizePreference === "required" && !providerSupportsDiarization) {
     log.warn(
       { providerId: provider },
@@ -370,7 +372,7 @@ export async function resolveStreamingTranscriber(
     return null;
   }
 
-  return createStreamingTranscriber(apiKey ?? "", provider as SttProviderId, {
+  return createStreamingTranscriber(apiKey ?? "", provider, {
     sampleRate: options.sampleRate,
     diarize: enableDiarization,
     utteranceBoundaryFinals: options.utteranceBoundaryFinals ?? false,

--- a/assistant/src/tts/tts-config-resolver.ts
+++ b/assistant/src/tts/tts-config-resolver.ts
@@ -33,11 +33,19 @@ export interface ResolvedTtsConfig {
  *
  * Reads exclusively from `services.tts.provider` and
  * `services.tts.providers.<id>`. No legacy fallback logic.
+ *
+ * `providerOverride` selects a provider other than the configured one and
+ * returns that provider's config block — used by callers that resolve the
+ * provider themselves (e.g. live voice, which runs on the managed-speech
+ * effective provider).
  */
-export function resolveTtsConfig(config: AssistantConfig): ResolvedTtsConfig {
+export function resolveTtsConfig(
+  config: AssistantConfig,
+  providerOverride?: TtsProviderId,
+): ResolvedTtsConfig {
   const ttsService = config.services.tts;
 
-  const provider = ttsService.provider as TtsProviderId;
+  const provider = providerOverride ?? (ttsService.provider as TtsProviderId);
 
   // Resolve provider-specific config from the canonical providers map.
   const providerConfig = resolveProviderConfig(config, provider);


### PR DESCRIPTION
Fixes JARVIS-1314.

## The gap

JARVIS-1300 removed managed-speech defaulting from the live-voice WebSocket `start` path: `/v1/live-voice` validates guardian identity only and does **not** enforce the caller's `settings.write` scope, so any token accepted for live voice could otherwise persist `services.stt/tts.provider` by sending a `start` frame.

That left defaulting running at three scoped sites only — daemon startup, secret write, and `POST /v1/live-voice/preflight`. A session opened without the preflight (the web client's `preflightLiveVoice` returns `null` on any non-OK response and the composer deliberately fails open; `createLiveVoiceConnection` is also exported on the plugin API) can still be rejected at the `start` frame with `credentials_unavailable`, even though managed speech is available and would work.

## The fix

Managed-speech defaulting is now a *resolution* rule, not only a write:

- **`resolveEffectiveSpeechProviders()`** (`config/managed-speech-defaults.ts`) applies the existing predicate — managed speech available AND the configured provider's BYOK credential does not resolve → `"vellum"`, otherwise the configured provider — and **returns** the ids. It persists nothing.
- **`maybeDefaultSpeechToManaged()`** is reimplemented on top of it: compute the effective ids, persist only the delta vs. configured. One definition of the rule, so the preflight verdict and the WS `start` verdict cannot drift apart. Its non-fatal try/catch ("convenience defaulting must never break credential storage") is unchanged.
- Three live-voice consumers resolve against the effective ids: the credential preflight (both the STT and TTS gaps), `live-voice-tts.ts` at synthesis time, and `defaultResolveStreamingTranscriber` in `live-voice-session.ts`.

`LiveVoiceSession.start()` is unchanged — it already reads readiness through the injected `resolveCredentialReadiness`. What changed is that the read now matches what the runtime will actually do.

Two small seams carry the effective id down to the resolvers that previously always read config: `resolveTtsConfig(config, providerOverride?)` and `ResolveStreamingTranscriberOptions.providerId`. Both default to `services.*.provider`, so every other caller (telephony, chat-composer STT streaming, TTS routes) is untouched.

## The no-write constraint, and how it is upheld

**No config write is reintroduced on the live-voice WebSocket path.** Persistence stays exclusively on the three `settings.write`-scoped sites. `resolveEffectiveSpeechProviders()` only reads config and credentials; the preflight module, `live-voice-tts.ts`, and `live-voice-session.ts` import nothing that writes. Each new test asserts `config.json` is byte-identical after the live-voice path resolves managed speech.

## Telephony precedent

This mirrors `calls/telephony-credential-preflight.ts`: readiness reports `ready` when the configured TTS provider is unplayable but a credentialed fallback exists, because `resolve-call-tts-provider.ts` swaps that fallback in at synthesis time — no config write anywhere. The invariant carried over here is that readiness must never report `ready` on the strength of managed availability unless the runtime will actually use the managed provider, so **both** legs swap: the preflight, the transcriber resolution, and TTS synthesis all resolve the same effective ids.

## Tests

New `src/live-voice/__tests__/live-voice-managed-speech-fallback.test.ts` (4 tests):

- managed available + unkeyed BYOK TTS → effective TTS is `vellum`, readiness `ready`, config untouched
- synthesis actually runs on the managed provider while `config.services.tts.provider` still names the BYOK one
- managed available + unkeyed BYOK STT → effective STT is `vellum`, readiness `ready`, and the transcriber is requested for `vellum`; config untouched
- managed unavailable → configured providers retained, readiness `not-ready` naming both, config untouched

Three of the four fail without the resolver change (verified by temporarily short-circuiting `resolveEffectiveSpeechProviders` to the configured ids).

Run single-file (`mock.module` leaks across files in this repo) — all green:

`managed-speech-defaults` (6), `live-voice-credential-preflight` (11), `live-voice-routes` (3), `live-voice-tts` (12), `live-voice-tts-session` (27), `live-voice-stt` (24), `live-voice-session-preflight` (3), `runtime-websocket-shell` (5), `speech-to-text/resolve` (63), `tts/provider-resolution` (7), `tts-routes` (15), `media-stream-stt-session` (36), `media-stream-server-integration` (55), `voice-config-update` (37), `telephony-tts-guard` (27), `config-schema` (171). Plus `bunx tsc --noEmit` clean for `assistant/`.

Two existing tests were updated because the wiring is now observable: `runtime-websocket-shell` asserts the transcriber is resolved with the effective `providerId`, and the `live-voice-tts` config fixture gained the `services.stt` block it always implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
