### PR TITLE
fix(web): keep Stop control visible when the turn phase is stranded at awaiting_user_input

### DIFF
--- a/clients/web/src/domains/chat/turn-selectors.test.ts
+++ b/clients/web/src/domains/chat/turn-selectors.test.ts
@@ -77,3 +77,57 @@ describe("isAssistantBusy — authoritative processing close-gate", () => {
     );
   });
 });
+
+describe("isAssistantBusy — awaiting_user_input without a pending prompt", () => {
+  test("stays busy when a prompt resolved but the turn keeps streaming (LUM-2786)", () => {
+    // The incident state: the phase is stranded at `awaiting_user_input` after
+    // an ask_question card resolved, yet the assistant is still processing —
+    // an assistant message is streaming, the conversation is processing, the
+    // snapshot reports processing, and no prompt/surface is actually pending.
+    expect(
+      isAssistantBusy(
+        "awaiting_user_input",
+        ctx({
+          hasStreamingAssistantMessage: true,
+          activeConversationIsProcessing: true,
+          snapshotProcessing: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("not busy when a question prompt is actually pending", () => {
+    expect(
+      isAssistantBusy(
+        "awaiting_user_input",
+        ctx({
+          hasStreamingAssistantMessage: true,
+          activeConversationIsProcessing: true,
+          snapshotProcessing: true,
+          hasPendingQuestion: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("not busy when an interactive surface is still uncompleted", () => {
+    expect(
+      isAssistantBusy(
+        "awaiting_user_input",
+        ctx({
+          hasUncompletedVisibleSurface: true,
+          snapshotProcessing: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("close-gate wins: not busy when the server reports the turn idle", () => {
+    expect(
+      isAssistantBusy(
+        "awaiting_user_input",
+        ctx({ snapshotProcessing: false }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/turn-selectors.ts
+++ b/clients/web/src/domains/chat/turn-selectors.ts
@@ -115,7 +115,10 @@ export function shouldShowThinkingIndicator(
  * When the assistant is waiting for the user to resolve a prompt (secret,
  * confirmation, question, contact request) or an interactive surface, it is
  * not busy — the prompt IS the UI, and neither a spinner nor a stop button
- * should be shown.
+ * should be shown. Not-busy is driven exclusively by an actually-pending
+ * prompt or surface: `phase` alone does not suppress busy, so a turn that
+ * keeps streaming after a prompt resolves stays busy even if the phase is
+ * momentarily stale at `awaiting_user_input`.
  *
  * External-channel conversations (Slack, Telegram, phone) can stream into an
  * already-open web tab without the web app ever calling `requestSend()`. In
@@ -135,8 +138,10 @@ export function isAssistantBusy(
     return false;
   }
 
+  // Only an actually-pending prompt or interactive surface suppresses busy —
+  // the `phase` can lag at `awaiting_user_input` after a prompt resolves while
+  // the turn keeps streaming, so it must not gate this on its own.
   if (
-    phase === "awaiting_user_input" ||
     ctx.hasPendingSecret ||
     ctx.hasPendingConfirmation ||
     ctx.hasPendingQuestion ||

--- a/clients/web/src/domains/chat/turn-store.test.ts
+++ b/clients/web/src/domains/chat/turn-store.test.ts
@@ -8,11 +8,13 @@ import {
 } from "@/domains/chat/turn-selectors";
 import {
   type TurnState,
+  type TurnPhase,
   type DomainEvent,
   INITIAL_TURN_STATE,
   turnReducer,
   isSending,
   isThinking,
+  useTurnStore,
 } from "@/domains/chat/turn-store";
 
 // ---------------------------------------------------------------------------
@@ -1709,5 +1711,38 @@ describe("queue management", () => {
     const result = turnReducer(idle, { type: "MESSAGE_DEQUEUED" });
     expect(result.phase).toBe("idle");
     expect(result.pendingQueuedCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recoverFromAwaitingUserInput (live store action)
+// ---------------------------------------------------------------------------
+
+describe("recoverFromAwaitingUserInput", () => {
+  const resetStore = () => {
+    useTurnStore.setState({ ...INITIAL_TURN_STATE });
+  };
+
+  test("recovers awaiting_user_input to thinking", () => {
+    resetStore();
+    useTurnStore.setState({ phase: "awaiting_user_input" });
+    useTurnStore.getState().recoverFromAwaitingUserInput();
+    expect(useTurnStore.getState().phase).toBe("thinking");
+  });
+
+  test("no-ops on every other phase", () => {
+    const otherPhases: TurnPhase[] = [
+      "idle",
+      "thinking",
+      "streaming",
+      "queued",
+      "errored",
+    ];
+    for (const phase of otherPhases) {
+      resetStore();
+      useTurnStore.setState({ phase });
+      useTurnStore.getState().recoverFromAwaitingUserInput();
+      expect(useTurnStore.getState().phase).toBe(phase);
+    }
   });
 });

--- a/clients/web/src/domains/chat/turn-store.ts
+++ b/clients/web/src/domains/chat/turn-store.ts
@@ -265,6 +265,7 @@ export interface TurnActions {
       canStartFromIdle?: boolean;
     },
   ) => void;
+  recoverFromAwaitingUserInput: () => void;
   showSurface: (interactive?: boolean) => void;
   updateSurface: () => void;
   dismissSurface: () => void;
@@ -406,6 +407,23 @@ const useTurnStoreBase = create<TurnStore>()((set, get) => ({
     }
     if (s.phase === "awaiting_user_input") return;
     set({ phase: "thinking", statusText: statusText ?? null });
+  },
+
+  /**
+   * Rejoin the live turn when a phase is stranded at `awaiting_user_input`.
+   *
+   * Server activity signals call this when no pending prompt or interactive
+   * surface remains: the prompt that moved the phase to `awaiting_user_input`
+   * resolved without a turn-state transition, so the phase would otherwise
+   * stay stuck while the turn keeps streaming. Restoring `thinking` re-enables
+   * the live-turn affordances (Stop control, busy indicators).
+   */
+  recoverFromAwaitingUserInput: () => {
+    const s = get();
+    if (s.phase !== "awaiting_user_input") {
+      return;
+    }
+    set({ phase: "thinking" });
   },
 
   // ----- UI surfaces -----

--- a/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
@@ -15,6 +15,7 @@ import {
 } from "@/domains/chat/utils/stream-handlers/message-handlers";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useConversationStore } from "@/stores/conversation-store";
+import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { conversationsQueryKey } from "@/utils/conversation-list-fetchers";
 import { findConversation } from "@/utils/conversation-cache";
 import type { Conversation } from "@/types/conversation-types";
@@ -262,6 +263,69 @@ describe("handleAssistantActivityState", () => {
     ).toBe(1);
     expect(ctx.turnActions.onActivityThinking).not.toHaveBeenCalled();
     expect(ctx.endTurn).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleAssistantActivityState — stranded-phase recovery (LUM-2786)", () => {
+  beforeEach(() => {
+    useConversationStore.getState().setActiveConversationId("conv-1");
+    useInteractionStore.getState().resetAll();
+    useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+  });
+
+  afterEach(() => {
+    useConversationStore.getState().setActiveConversationId(null);
+    useInteractionStore.getState().resetAll();
+    useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+  });
+
+  it("recovers on a thinking event for the active conversation with no pending interaction", () => {
+    const ctx = makeCtx();
+    handleAssistantActivityState(
+      {
+        type: "assistant_activity_state",
+        activityVersion: 1,
+        phase: "thinking",
+        anchor: "assistant_turn",
+        reason: "tool_result_received",
+        conversationId: "conv-1",
+      },
+      ctx,
+    );
+    expect(ctx.turnActions.recoverFromAwaitingUserInput).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not recover on a thinking event while a question prompt is pending", () => {
+    useInteractionStore.getState().showQuestion({ requestId: "q1", entries: [] });
+    const ctx = makeCtx();
+    handleAssistantActivityState(
+      {
+        type: "assistant_activity_state",
+        activityVersion: 1,
+        phase: "thinking",
+        anchor: "assistant_turn",
+        reason: "tool_result_received",
+        conversationId: "conv-1",
+      },
+      ctx,
+    );
+    expect(ctx.turnActions.recoverFromAwaitingUserInput).not.toHaveBeenCalled();
+  });
+
+  it("recovers on a tool_running event with no pending interaction", () => {
+    const ctx = makeCtx();
+    handleAssistantActivityState(
+      {
+        type: "assistant_activity_state",
+        activityVersion: 1,
+        phase: "tool_running",
+        anchor: "assistant_turn",
+        reason: "tool_use_start",
+        conversationId: "conv-1",
+      },
+      ctx,
+    );
+    expect(ctx.turnActions.recoverFromAwaitingUserInput).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
@@ -17,6 +17,8 @@ import type {
 } from "@vellumai/assistant-api";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useInteractionStore } from "@/domains/chat/interaction-store";
+import { hasAnyInteractiveSurface } from "@/domains/chat/utils/chat";
 
 /**
  * Resolve the conversation id for SSE handlers — events that carry it on
@@ -147,6 +149,42 @@ export function handleAssistantThinkingDelta(
   }
 }
 
+/**
+ * Recover a phase stranded at `awaiting_user_input` from a live server
+ * activity signal.
+ *
+ * When the activity event belongs to the active conversation and no prompt
+ * (secret / confirmation / question / contact) or interactive transcript
+ * surface is actually pending, the phase that a resolved prompt left stuck at
+ * `awaiting_user_input` rejoins the live turn — restoring the Stop control and
+ * busy indicators (LUM-2786). A still-pending interaction is left untouched:
+ * the prompt is the UI, and the turn is genuinely waiting on the user.
+ */
+function maybeRecoverStrandedPhase(
+  convId: string | undefined,
+  ctx: StreamHandlerContext,
+): void {
+  const activeConversationId =
+    useConversationStore.getState().activeConversationId;
+  if (convId == null || convId !== activeConversationId) {
+    return;
+  }
+  const interaction = useInteractionStore.getState();
+  if (
+    interaction.pendingSecret != null ||
+    interaction.pendingConfirmation != null ||
+    interaction.pendingQuestion != null ||
+    interaction.pendingContactRequest != null
+  ) {
+    return;
+  }
+  const snapshot = useChatSessionStore.getState().snapshot;
+  if (hasAnyInteractiveSurface(snapshot?.messages ?? [])) {
+    return;
+  }
+  ctx.turnActions.recoverFromAwaitingUserInput();
+}
+
 export function handleAssistantActivityState(
   event: AssistantActivityStateEvent,
   ctx: StreamHandlerContext,
@@ -168,6 +206,10 @@ export function handleAssistantActivityState(
   }
 
   if (event.phase === "thinking") {
+    // A prompt may have resolved without a turn-state transition, stranding
+    // the phase at `awaiting_user_input`; recover it before routing the
+    // thinking signal (which otherwise no-ops on that phase).
+    maybeRecoverStrandedPhase(convId, ctx);
     // Daemon-initiated work (e.g. summarize-up-to-here) reports thinking
     // without a client-initiated turn. Allow the signal to start activity
     // from an idle turn store only when the event belongs to the active
@@ -187,6 +229,13 @@ export function handleAssistantActivityState(
   }
 
   if (event.phase !== "idle") {
+    // Live streaming/tool activity for the active conversation proves the
+    // turn is running, so recover a phase stranded at `awaiting_user_input`.
+    // `awaiting_confirmation` is excluded — the turn is genuinely paused on a
+    // confirmation prompt.
+    if (event.phase === "streaming" || event.phase === "tool_running") {
+      maybeRecoverStrandedPhase(convId, ctx);
+    }
     recordDiagnostic("sse_activity_state_non_idle", {
       convId,
       phase: event.phase,

--- a/clients/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
@@ -49,6 +49,7 @@ export function makeCtx(
       onToolResult: mock(() => {}),
       onToolActivityMetadata: mock(() => {}),
       onActivityThinking: mock(() => {}),
+      recoverFromAwaitingUserInput: mock(() => {}),
       showSurface: mock(() => {}),
       updateSurface: mock(() => {}),
       dismissSurface: mock(() => {}),


### PR DESCRIPTION
## Summary

Fixes the user-reported bug where the voice-mode button replaced the Stop button while the assistant was still running a prompt, leaving no way to stop the turn (feedback `019f8506-700c-70a7-a39a-47e26a0a5330`).

Root cause: prompt-resolution paths (e.g. the `ask_question` card's submit and its X/dismiss control) clear the interaction store but never restore the turn phase, so the phase strands at `awaiting_user_input` while the turn keeps streaming — and `isAssistantBusy` treated that phase as not-busy on its own, hiding the composer's Stop button (the only main-turn cancel affordance). With the `voiceMode` flag on, the live-voice button renders in Stop's slot; with it off, the send arrow does — the bug is not voice-gated.

## The fix (two layers)

1. **Selector (render truth):** `isAssistantBusy` suppresses busy only for actually-pending prompts/surfaces (`hasPendingSecret/Confirmation/Question/ContactRequest`, `hasUncompletedVisibleSurface`) — the phase alone no longer gates it. `isSending()` already counts `awaiting_user_input`, so live turns fall through to busy; the `snapshotProcessing === false` close-gate still handles genuinely-ended turns. While a prompt is actually on screen, behavior is unchanged.
2. **State-machine recovery (self-healing):** server activity signals (`thinking` / `streaming` / `tool_running`) for the active conversation recover a stranded phase back to `thinking` via a new `recoverFromAwaitingUserInput` turn action, gated on no pending interaction or interactive surface remaining. `awaiting_confirmation` activity is excluded (the turn is genuinely paused). This restores phase-derived UI (thinking dots between tool calls, status text) that layer 1 alone wouldn't fix.

## Repro

With a mid-turn `ask_question`: answer the card (or click its X) while the turn continues with tool work — the Stop button disappeared for the remainder of the turn. Whether the phase strands is timing-dependent (a freshly-loaded tab's stale-guard skips the phase transition entirely), which is why layer 1 keys off pending state rather than phase.

## Tests

- `turn-selectors.test.ts`: the captured incident shape (phase `awaiting_user_input` + `activeConversationIsProcessing` + no pending prompt) stays busy; still-pending question/surface suppress busy; close-gate wins.
- `turn-store.test.ts`: `recoverFromAwaitingUserInput` recovers only from `awaiting_user_input`.
- `message-handlers.test.ts`: recovery fires on thinking/tool_running activity for the active conversation only when nothing is pending.

313 tests pass across the 8 files touching this state; lint 0 errors; pre-commit full typecheck green.

Fixes LUM-2786

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->