### PR TITLE
refactor(routes): remove assistantId from user-route context

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/references/CUSTOM_ROUTES.md
+++ b/assistant/src/config/bundled-skills/app-builder/references/CUSTOM_ROUTES.md
@@ -83,7 +83,6 @@ Every handler receives a frozen `context` object as its second argument. This pr
 ```typescript
 export async function POST(request: Request, context): Promise<Response> {
   // context.assistantEventHub — publish events to connected SSE clients
-  // context.assistantId       — the daemon's logical assistant ID ("self")
   // context.conversations     — post messages into conversations as real turns
 }
 ```
@@ -99,7 +98,7 @@ export async function POST(request: Request, context): Promise<Response> {
 
   await context.assistantEventHub.publish({
     id: crypto.randomUUID(),
-    assistantId: context.assistantId,
+    assistantId: "self",
     conversationId,
     emittedAt: new Date().toISOString(),
     message: { type: "open_conversation", conversationId },

--- a/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
@@ -42,7 +42,6 @@ const DEFAULT_PLUGIN_MANIFEST = getDefaultPluginManifestName(DEFAULT_PLUGIN)!;
 function makeDispatcher(): UserRouteDispatcher {
   const context: UserRouteContext = {
     assistantEventHub: new AssistantEventHub(),
-    assistantId: "test-assistant",
     conversations: { postMessage: async () => ({ messageId: "m" }) },
   };
   return new UserRouteDispatcher({ context });

--- a/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-route-dispatcher.test.ts
@@ -21,7 +21,6 @@ import { UserRouteDispatcher } from "../user-route-dispatcher.js";
 function makeContext(overrides?: Partial<UserRouteContext>): UserRouteContext {
   return {
     assistantEventHub: new AssistantEventHub(),
-    assistantId: "test-assistant",
     conversations: {
       postMessage: async () => ({ messageId: "test-msg" }),
     },
@@ -429,18 +428,17 @@ describe("context injection", () => {
       `export function GET(request, context) {
         return Response.json({
           hasHub: typeof context.assistantEventHub?.publish === "function",
-          assistantId: context.assistantId,
+          hasConversations: typeof context.conversations?.postMessage === "function",
         });
       }`,
     );
 
-    const ctx = makeContext({ assistantId: "custom-id" });
-    const dispatcher = makeDispatcher({ context: ctx });
+    const dispatcher = makeDispatcher();
     const res = await dispatcher.dispatch("ctx-echo", makeRequest("GET"));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.hasHub).toBe(true);
-    expect(body.assistantId).toBe("custom-id");
+    expect(body.hasConversations).toBe(true);
   });
 
   test("handler can publish events through injected hub", async () => {
@@ -450,7 +448,7 @@ describe("context injection", () => {
         const body = await request.json();
         await context.assistantEventHub.publish({
           id: "test-event-1",
-          assistantId: context.assistantId,
+          assistantId: "self",
           conversationId: body.conversationId,
           emittedAt: new Date().toISOString(),
           message: { type: "open_conversation", conversationId: body.conversationId },
@@ -506,22 +504,25 @@ describe("context injection", () => {
       `export function GET(request, context) {
         let threw = false;
         try {
-          context.assistantId = "hacked";
+          context.assistantEventHub = "hacked";
         } catch {
           threw = true;
         }
-        return Response.json({ threw, assistantId: context.assistantId });
+        // Reassignment must not take — the hub reference stays intact.
+        return Response.json({
+          threw,
+          hubIntact: typeof context.assistantEventHub?.publish === "function",
+        });
       }`,
     );
 
-    const ctx = makeContext({ assistantId: "original" });
-    const dispatcher = makeDispatcher({ context: ctx });
+    const dispatcher = makeDispatcher();
     const res = await dispatcher.dispatch("ctx-mutate", makeRequest("GET"));
     expect(res.status).toBe(200);
     const body = await res.json();
     // Object.freeze makes property assignment throw in strict mode (ESM)
     // and silently fail in sloppy mode — either way the value is unchanged.
-    expect(body.assistantId).toBe("original");
+    expect(body.hubIntact).toBe(true);
   });
 });
 
@@ -535,7 +536,10 @@ describe("plugin routes", () => {
       "my-plugin",
       "status.ts",
       `export function GET(request, context) {
-        return Response.json({ plugin: true, assistantId: context.assistantId });
+        return Response.json({
+          plugin: true,
+          hasHub: typeof context.assistantEventHub?.publish === "function",
+        });
       }`,
     );
 
@@ -548,7 +552,7 @@ describe("plugin routes", () => {
     const body = await res.json();
     expect(body.plugin).toBe(true);
     // Plugin handlers receive the same runtime context as workspace routes.
-    expect(body.assistantId).toBe("test-assistant");
+    expect(body.hasHub).toBe(true);
   });
 
   test("resolves nested paths and the index (namespace root)", async () => {

--- a/assistant/src/runtime/routes/user-route-dispatcher.ts
+++ b/assistant/src/runtime/routes/user-route-dispatcher.ts
@@ -17,9 +17,9 @@
  * etc.) using the standard Web API Request/Response signature.
  *
  * Handlers receive a second `context` argument with runtime singletons
- * (event hub, assistant ID, etc.) that would otherwise be unreachable
- * from dynamically imported modules because Bun's cache-busting import
- * creates separate module instances.
+ * (event hub, etc.) that would otherwise be unreachable from dynamically
+ * imported modules because Bun's cache-busting import creates separate
+ * module instances.
  *
  * Modules are lazily loaded on first request and cached by file path +
  * mtime. When a file changes on disk, the next request reloads it via
@@ -55,8 +55,6 @@ const log = getLogger("user-routes");
 export interface UserRouteContext {
   /** The daemon's event hub singleton — use this to publish events to connected SSE clients. */
   readonly assistantEventHub: AssistantEventHub;
-  /** The logical assistant ID used by the daemon (typically "self"). */
-  readonly assistantId: string;
   /** Conversation operations available to route handlers (e.g. posting integration events as turns). */
   readonly conversations: RouteConversationsApi;
 }
@@ -107,9 +105,9 @@ type HttpMethod = (typeof HTTP_METHODS)[number];
  * The function signature that user-defined route handlers must follow.
  *
  * Handlers may accept an optional second `context` argument with runtime
- * singletons (event hub, assistant ID). Legacy handlers that only accept
- * `request` continue to work — the context is passed positionally but
- * ignored if the handler doesn't declare the parameter.
+ * singletons (event hub). Legacy handlers that only accept `request`
+ * continue to work — the context is passed positionally but ignored if
+ * the handler doesn't declare the parameter.
  */
 type RouteHandler = (
   request: Request,

--- a/assistant/src/runtime/routes/user-routes.ts
+++ b/assistant/src/runtime/routes/user-routes.ts
@@ -17,7 +17,6 @@
 
 import { postRouteConversationMessage } from "../../daemon/route-conversation-post.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 import { RouteResponse } from "./types.js";
@@ -26,7 +25,6 @@ import { UserRouteDispatcher } from "./user-route-dispatcher.js";
 const dispatcher = new UserRouteDispatcher({
   context: {
     assistantEventHub,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     conversations: {
       postMessage: postRouteConversationMessage,
     },


### PR DESCRIPTION
## Prompt / plan

First step of hardening user-defined `/x/*` routes. The daemon serves a single assistant, so the `assistantId` field on `UserRouteContext` carried no real information — it was always wired to the constant `DAEMON_INTERNAL_ASSISTANT_ID` (`"self"`). This PR drops it from the handler-facing context so the API only exposes what's actually meaningful (the event hub and conversation operations).

Changes:
- Remove `readonly assistantId` from `UserRouteContext` (`user-route-dispatcher.ts`) and its wiring/import in `user-routes.ts`.
- Handlers that stamp an `assistantId` on a published event now use the `"self"` literal directly instead of reading it from context (updated in the `CUSTOM_ROUTES.md` app-builder reference and in tests).
- Update dispatcher/plugin-route tests to assert on the remaining context surface (event hub, conversations) instead of `assistantId`.

The other `context.assistantId` references in the repo are unrelated contexts (auth `RequestContext`, tool `ToolContext`) and are untouched.

The worker-thread pool follow-up (the actual fix for stalling routes) is a separate PR.

## Test plan

- `bun test src/runtime/routes/__tests__/user-route-dispatcher.test.ts src/runtime/routes/__tests__/default-plugin-routes.test.ts` → 41 pass / 0 fail.
- `bunx tsc --noEmit` → clean.
- Pre-commit hooks (prettier, eslint, typecheck, secret scan) pass.

## CLI verb checklist

No new routes added — this only trims a field from the existing user-route handler context, so no CLI verb is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FosQeirkpt7G1K2SSbMx1N