### PR TITLE
feat(voice-room): accept an explicit highlight index in VoiceTranscriptText

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
@@ -62,7 +62,7 @@ describe("VoiceTranscriptText", () => {
     const { container } = render(
       <VoiceTranscriptText text="one two three" highlightIndex={1} />,
     );
-    // The last-arrived word no longer leads — the cursor owns the highlight.
+    // The cursor owns the highlight — the last-arrived word renders the muted base.
     expect(leadingFlags(container)).toEqual([false, true, false]);
   });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
@@ -80,6 +80,15 @@ describe("VoiceTranscriptText", () => {
     expect(leadingFlags(container)).toEqual([true, false, false]);
   });
 
+  test("non-finite highlightIndex normalizes to the first word", () => {
+    // NaN would otherwise propagate through the clamp and leave no word
+    // carrying the leading tone.
+    const { container } = render(
+      <VoiceTranscriptText text="one two three" highlightIndex={Number.NaN} />,
+    );
+    expect(leadingFlags(container)).toEqual([true, false, false]);
+  });
+
   test("color override still flattens every word when highlightIndex is set", () => {
     const { container } = render(
       <VoiceTranscriptText

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
@@ -1,21 +1,39 @@
 /**
  * Tests for `VoiceTranscriptText`.
  *
- * Two load-bearing contracts: the plain sentence is exactly the rendered
- * `textContent` (so the caller's `aria-live` region announces it verbatim),
- * and an optional `color` flattens every word to that single tone (the default
- * two-tone leading-edge look applies only when `color` is omitted).
+ * Load-bearing contracts: the plain sentence is exactly the rendered
+ * `textContent` (so the caller's `aria-live` region announces it verbatim);
+ * an optional `color` flattens every word to that single tone (the default
+ * two-tone leading-edge look applies only when `color` is omitted); and an
+ * optional `highlightIndex` moves the bright leading-edge tone to that word
+ * (clamped) so an audio-playhead cursor can track the spoken word.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
 
 import { cleanup, render } from "@testing-library/react";
 
-import { VoiceTranscriptText } from "@/domains/chat/voice/voice-room/voice-transcript-text";
+import {
+  splitTranscriptWords,
+  VoiceTranscriptText,
+} from "@/domains/chat/voice/voice-room/voice-transcript-text";
 
 afterEach(() => {
   cleanup();
 });
+
+/**
+ * Which word carries the bright leading-edge tone. The tone is a `var()` color
+ * with a fallback, which happy-dom drops from inline style entirely — so the
+ * component marks the leading word with `data-leading` and the tests assert on
+ * that (the `color`-override tests below still assert on `style.color`, which
+ * happy-dom preserves for concrete values).
+ */
+function leadingFlags(container: HTMLElement): boolean[] {
+  return [...container.querySelectorAll("span")].map((span) =>
+    span.hasAttribute("data-leading"),
+  );
+}
 
 describe("VoiceTranscriptText", () => {
   test("exposes the plain sentence as textContent", () => {
@@ -33,5 +51,64 @@ describe("VoiceTranscriptText", () => {
     for (const span of spans) {
       expect(span.style.color).toBe("rgb(1, 2, 3)");
     }
+  });
+
+  test("last word carries the leading tone when highlightIndex is omitted", () => {
+    const { container } = render(<VoiceTranscriptText text="one two three" />);
+    expect(leadingFlags(container)).toEqual([false, false, true]);
+  });
+
+  test("highlightIndex moves the leading tone to that word", () => {
+    const { container } = render(
+      <VoiceTranscriptText text="one two three" highlightIndex={1} />,
+    );
+    // The last-arrived word no longer leads — the cursor owns the highlight.
+    expect(leadingFlags(container)).toEqual([false, true, false]);
+  });
+
+  test("out-of-range highlightIndex clamps to the last word", () => {
+    const { container } = render(
+      <VoiceTranscriptText text="one two three" highlightIndex={99} />,
+    );
+    expect(leadingFlags(container)).toEqual([false, false, true]);
+  });
+
+  test("negative highlightIndex clamps to the first word", () => {
+    const { container } = render(
+      <VoiceTranscriptText text="one two three" highlightIndex={-3} />,
+    );
+    expect(leadingFlags(container)).toEqual([true, false, false]);
+  });
+
+  test("color override still flattens every word when highlightIndex is set", () => {
+    const { container } = render(
+      <VoiceTranscriptText
+        text="one two three"
+        color="rgb(1, 2, 3)"
+        highlightIndex={1}
+      />,
+    );
+    const spans = container.querySelectorAll("span");
+    expect(spans.length).toBe(3);
+    for (const span of spans) {
+      expect(span.style.color).toBe("rgb(1, 2, 3)");
+    }
+  });
+
+  test("textContent is unchanged when highlightIndex is set", () => {
+    const { container } = render(
+      <VoiceTranscriptText text="hello world" highlightIndex={0} />,
+    );
+    expect(container.textContent).toBe("hello world");
+  });
+
+  test("splitTranscriptWords matches the rendered segmentation", () => {
+    // The cursor maps audio progress onto this segmentation, so it must be
+    // exactly what the component renders — one span per returned word.
+    const text = "  hello   brave\nworld ";
+    expect(splitTranscriptWords(text)).toEqual(["hello", "brave", "world"]);
+    const { container } = render(<VoiceTranscriptText text={text} />);
+    expect(container.querySelectorAll("span").length).toBe(3);
+    expect(container.textContent).toBe("hello brave world");
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
@@ -9,9 +9,9 @@
  * a brighter "leading edge" tone that cools to the muted base as the next word
  * arrives, so the caption reads as speech flowing forward rather than a block
  * appearing. When the caller supplies an audio-playhead cursor via
- * `highlightIndex` (JARVIS-1309), the leading edge tracks the *spoken* word
- * instead of the last-arrived one, so the highlight stays with the voice even
- * while the streamed text runs ahead of TTS.
+ * `highlightIndex`, the leading edge tracks the *spoken* word instead of the
+ * last-arrived one, so the highlight stays with the voice even while the
+ * streamed text runs ahead of TTS.
  *
  * Index keys (not content) are deliberate: a streaming append leaves earlier
  * indices unchanged so they never re-animate, and a partial-transcript revision
@@ -69,10 +69,15 @@ export function VoiceTranscriptText({
   // `textContent` reads back as the plain sentence).
   const words = useMemo(() => splitTranscriptWords(text), [text]);
   const lastIndex = words.length - 1;
+  // Non-finite cursors (e.g. a NaN from not-yet-initialized playhead math)
+  // normalize to the first word — clamping alone would propagate NaN and leave
+  // no word carrying the leading tone.
   const leadingIndex =
     highlightIndex === undefined
       ? lastIndex
-      : Math.min(Math.max(0, Math.floor(highlightIndex)), lastIndex);
+      : Number.isFinite(highlightIndex)
+        ? Math.min(Math.max(0, Math.floor(highlightIndex)), lastIndex)
+        : 0;
 
   return (
     <>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
@@ -5,9 +5,13 @@
  * flat string makes each update land as a hard text swap. This splits the text
  * into words keyed by position so that, as the string grows, only the newly
  * arrived words mount — each fading + rising + de-blurring into place — while
- * the words already on screen stay put. The most recent word carries a brighter
- * "leading edge" tone that cools to the muted base as the next word arrives, so
- * the caption reads as speech flowing forward rather than a block appearing.
+ * the words already on screen stay put. By default the most recent word carries
+ * a brighter "leading edge" tone that cools to the muted base as the next word
+ * arrives, so the caption reads as speech flowing forward rather than a block
+ * appearing. When the caller supplies an audio-playhead cursor via
+ * `highlightIndex` (JARVIS-1309), the leading edge tracks the *spoken* word
+ * instead of the last-arrived one, so the highlight stays with the voice even
+ * while the streamed text runs ahead of TTS.
  *
  * Index keys (not content) are deliberate: a streaming append leaves earlier
  * indices unchanged so they never re-animate, and a partial-transcript revision
@@ -26,17 +30,34 @@
 import { Fragment, useMemo } from "react";
 import { motion, useReducedMotion } from "motion/react";
 
+/**
+ * The exact word segmentation the component renders (whitespace runs collapse,
+ * empty tokens drop). Exported so the spoken-word cursor maps audio progress
+ * onto the same words the render uses.
+ */
+export function splitTranscriptWords(text: string): string[] {
+  return text.split(/\s+/).filter(Boolean);
+}
+
 export function VoiceTranscriptText({
   text,
   color,
+  highlightIndex,
 }: {
   text: string;
   /**
    * Paints every word this single tone (a flat reveal). Omit to keep the
    * two-tone look — the leading-edge word brighter (`--room-fg`), the settled
-   * words muted (`--room-fg-muted`).
+   * words muted (`--room-fg-muted`). Takes precedence over `highlightIndex`.
    */
   color?: string;
+  /**
+   * Index (into `splitTranscriptWords(text)`) of the word carrying the bright
+   * leading-edge tone — supplied by an audio-playhead cursor so the highlight
+   * tracks the currently *spoken* word. Clamped to the rendered words; the
+   * caller owns monotonicity. Omit to keep the default last-word leading edge.
+   */
+  highlightIndex?: number;
 }) {
   const reduce = useReducedMotion();
   // A caller-supplied `color` flattens the reveal to one tone; otherwise the
@@ -46,13 +67,17 @@ export function VoiceTranscriptText({
   // Collapse runs of whitespace to single spaces — the words are laid out with
   // real space text nodes between them (so they wrap and select naturally, and
   // `textContent` reads back as the plain sentence).
-  const words = useMemo(() => text.split(/\s+/).filter(Boolean), [text]);
+  const words = useMemo(() => splitTranscriptWords(text), [text]);
   const lastIndex = words.length - 1;
+  const leadingIndex =
+    highlightIndex === undefined
+      ? lastIndex
+      : Math.min(Math.max(0, Math.floor(highlightIndex)), lastIndex);
 
   return (
     <>
       {words.map((word, i) => {
-        const leading = i === lastIndex;
+        const leading = i === leadingIndex;
         return (
           <Fragment key={i}>
             <motion.span
@@ -60,6 +85,11 @@ export function VoiceTranscriptText({
               // wraps within its container instead of overflowing the narrow
               // transcript rail and being clipped.
               className="inline-block max-w-full [overflow-wrap:anywhere]"
+              // Marks the word carrying the bright leading-edge tone. The tone
+              // itself is the `color` below; the attribute is the observable
+              // for tests (happy-dom drops `var()` colors with fallbacks from
+              // inline style) and for debugging the spoken-word cursor.
+              data-leading={leading || undefined}
               style={{
                 color: leading ? leadingColor : baseColor,
                 // The leading-edge tone eases back to the base as the next word

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
@@ -210,7 +210,7 @@ export const Reveal: Story = {
 };
 
 /**
- * The spoken-word cursor look (JARVIS-1309): the full sentence has already
+ * The spoken-word cursor look: the full sentence has already
  * streamed in, but a static mid-sentence `highlightIndex` keeps the bright
  * leading-edge tone on the word currently being spoken — the text ahead of the
  * cursor stays muted instead of the highlight parking on the final word.

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 // The transcript reveal leans on the app's global CSS (content tokens, the
@@ -208,6 +209,40 @@ export const Reveal: Story = {
   render: (args) => <RevealScene wordMs={args.wordMs} replay={args.replay} />,
 };
 
+/**
+ * The spoken-word cursor look (JARVIS-1309): the full sentence has already
+ * streamed in, but a static mid-sentence `highlightIndex` keeps the bright
+ * leading-edge tone on the word currently being spoken — the text ahead of the
+ * cursor stays muted instead of the highlight parking on the final word.
+ */
+export const SpokenWordHighlight: Story = {
+  argTypes: {
+    role: { table: { disable: true } },
+    wordMs: { table: { disable: true } },
+    replay: { table: { disable: true } },
+  },
+  render: () => (
+    <CaptionSurface>
+      <VoiceTranscriptText text={ASSISTANT_LINE} highlightIndex={9} />
+    </CaptionSurface>
+  ),
+};
+
+/** Neutral dark surface for the isolated caption scenes (no room plumbing). */
+function CaptionSurface({ children }: { children: ReactNode }) {
+  return (
+    <div
+      data-theme="dark"
+      className="flex min-h-[240px] items-center justify-center rounded-lg p-10"
+      style={{ backgroundColor: "#17191C" }}
+    >
+      <p className="max-w-[36rem] text-center text-[15px] leading-relaxed text-balance">
+        {children}
+      </p>
+    </div>
+  );
+}
+
 function RevealScene({ wordMs, replay }: { wordMs: number; replay: number }) {
   const [text, setText] = useState("");
   const words = ASSISTANT_LINE.split(" ");
@@ -219,14 +254,8 @@ function RevealScene({ wordMs, replay }: { wordMs: number; replay: number }) {
     useCallback(() => setText(""), []),
   );
   return (
-    <div
-      data-theme="dark"
-      className="flex min-h-[240px] items-center justify-center rounded-lg p-10"
-      style={{ backgroundColor: "#17191C" }}
-    >
-      <p className="max-w-[36rem] text-center text-[15px] leading-relaxed text-balance">
-        <VoiceTranscriptText text={text} />
-      </p>
-    </div>
+    <CaptionSurface>
+      <VoiceTranscriptText text={text} />
+    </CaptionSurface>
   );
 }


### PR DESCRIPTION
## Summary
- Optional highlightIndex prop moves the bright leading-edge tone to an arbitrary word (clamped), for the audio-playhead cursor (JARVIS-1309)
- Export splitTranscriptWords so the cursor maps onto the same segmentation the render uses

Part of plan: voice-room-spoken-word-cursor.md (PR 3 of 5)