### PR TITLE
feat(live-voice): publish TTS playback progress through the live-voice store

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -30,6 +30,7 @@ import type {
   LiveVoiceAudioCaptureOptions,
   LiveVoiceCaptureResult,
 } from "@/domains/chat/voice/live-voice/pcm-capture";
+import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
 import {
   useLiveVoiceStore,
   type LiveVoiceSessionControls,
@@ -179,11 +180,20 @@ export class FakePlayer {
   stopCount = 0;
   disposeCount = 0;
   prewarmCount = 0;
+  resetPlaybackProgressCount = 0;
   isPlaying = false;
+  /** Progress the fake reports; tests set it to drive the store's provider. */
+  playbackProgress: LiveVoicePlaybackProgress | null = null;
   private drainResolvers: Array<() => void> = [];
 
   prewarm(): void {
     this.prewarmCount++;
+  }
+  getPlaybackProgress(): LiveVoicePlaybackProgress | null {
+    return this.playbackProgress;
+  }
+  resetPlaybackProgress(): void {
+    this.resetPlaybackProgressCount++;
   }
   enqueue(chunk: unknown): void {
     this.enqueued.push(chunk);

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -12,6 +12,7 @@ import {
   dismissLiveVoiceFailure,
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
+  getLiveVoicePlaybackProgress,
   isLiveVoiceMicLive,
   isLiveVoiceSessionActive,
   isLiveVoiceSessionOwnedBy,
@@ -347,5 +348,38 @@ describe("getLiveVoiceInputAmplitude", () => {
     expect(getLiveVoiceInputAmplitude()).toBe(0);
     useLiveVoiceStore.getState().setInputAmplitude(0.42);
     expect(getLiveVoiceInputAmplitude()).toBe(0.42);
+  });
+});
+
+describe("useLiveVoiceStore — playback-progress provider", () => {
+  test("defaults to null when idle", () => {
+    expect(useLiveVoiceStore.getState().playbackProgressProvider).toBeNull();
+  });
+
+  test("setPlaybackProgressProvider registers and deregisters the provider", () => {
+    const provider = mock(() => null);
+    useLiveVoiceStore.getState().setPlaybackProgressProvider(provider);
+    expect(useLiveVoiceStore.getState().playbackProgressProvider).toBe(provider);
+    useLiveVoiceStore.getState().setPlaybackProgressProvider(null);
+    expect(useLiveVoiceStore.getState().playbackProgressProvider).toBeNull();
+  });
+
+  test("reset clears the registered provider", () => {
+    useLiveVoiceStore.getState().setPlaybackProgressProvider(() => null);
+    useLiveVoiceStore.getState().reset();
+    expect(useLiveVoiceStore.getState().playbackProgressProvider).toBeNull();
+  });
+
+  test("getLiveVoicePlaybackProgress returns null with no provider", () => {
+    expect(getLiveVoicePlaybackProgress()).toBeNull();
+  });
+
+  test("getLiveVoicePlaybackProgress forwards the provider's value", () => {
+    const progress = { playedSeconds: 1.5, totalSeconds: 4 };
+    useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
+    expect(getLiveVoicePlaybackProgress()).toBe(progress);
+
+    useLiveVoiceStore.getState().setPlaybackProgressProvider(() => null);
+    expect(getLiveVoicePlaybackProgress()).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -24,6 +24,7 @@
 import { create } from "zustand";
 
 import type { LiveVoiceMetricsServerFrame } from "@/domains/chat/voice/live-voice/protocol";
+import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
 import { createSelectors } from "@/utils/create-selectors";
 
 // ---------------------------------------------------------------------------
@@ -268,6 +269,16 @@ export interface LiveVoiceState {
    * so a non-`speaking` read costs nothing and it clears on session reset.
    */
   outputAmplitudeProvider: (() => number) | null;
+  /**
+   * Provider for the current response's TTS playback progress (played/total
+   * seconds of scheduled audio), registered by the controller from the active
+   * session's {@link LiveVoiceAudioPlayer}. `null` when there is no session.
+   * Read via {@link getLiveVoicePlaybackProgress} — the voice-room transcript's
+   * spoken-word cursor polls it per animation frame. A registered provider
+   * (like `outputAmplitudeProvider`) so a non-speaking read costs nothing and
+   * it clears on session reset.
+   */
+  playbackProgressProvider: (() => LiveVoicePlaybackProgress | null) | null;
   /** Human-readable error message when `state === "failed"`, `null` otherwise. */
   error: string | null;
 }
@@ -322,6 +333,10 @@ export interface LiveVoiceActions {
   setLastTurnLatency: (lastTurnLatency: LiveVoiceTurnLatency) => void;
   /** Register (or clear) the active player's output-amplitude provider. */
   setOutputAmplitudeProvider: (provider: (() => number) | null) => void;
+  /** Register (or clear) the active player's playback-progress provider. */
+  setPlaybackProgressProvider: (
+    provider: (() => LiveVoicePlaybackProgress | null) | null,
+  ) => void;
   /** Transition to `failed` with a message. */
   fail: (message: string) => void;
   /**
@@ -421,6 +436,7 @@ const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   entryOrigin: null,
   lastTurnLatency: null,
   outputAmplitudeProvider: null,
+  playbackProgressProvider: null,
   error: null,
 };
 
@@ -457,6 +473,8 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   setLastTurnLatency: (lastTurnLatency) => set({ lastTurnLatency }),
   setOutputAmplitudeProvider: (outputAmplitudeProvider) =>
     set({ outputAmplitudeProvider }),
+  setPlaybackProgressProvider: (playbackProgressProvider) =>
+    set({ playbackProgressProvider }),
   fail: (message) => set({ state: "failed", error: message }),
   reset: () => set({ ...INITIAL_SESSION_STATE }),
 }));
@@ -483,6 +501,20 @@ export function getLiveVoiceInputAmplitude(): number {
  */
 export function getLiveVoiceOutputAmplitude(): number {
   return useLiveVoiceStore.getState().outputAmplitudeProvider?.() ?? 0;
+}
+
+/**
+ * Playback progress (played/total seconds) of the current response's TTS
+ * audio, read from the active player via the controller-registered provider.
+ * Returns `null` when no session is active or nothing has been scheduled for
+ * the current response. Polled per animation frame by the voice-room
+ * transcript's spoken-word cursor, so it is module-level (stable identity)
+ * and reads through `getState()` — subscribing would re-render the poller on
+ * every register/clear (see STATE_MANAGEMENT.md, as with
+ * {@link getLiveVoiceOutputAmplitude}).
+ */
+export function getLiveVoicePlaybackProgress(): LiveVoicePlaybackProgress | null {
+  return useLiveVoiceStore.getState().playbackProgressProvider?.() ?? null;
 }
 
 /**

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -47,7 +47,7 @@ import {
 // static import graph.
 const { useLiveVoice } =
   await import("@/domains/chat/voice/live-voice/use-live-voice");
-const { useLiveVoiceStore } =
+const { useLiveVoiceStore, getLiveVoicePlaybackProgress } =
   await import("@/domains/chat/voice/live-voice/live-voice-store");
 const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
 
@@ -2137,6 +2137,54 @@ describe("session context and controls", () => {
     expect(store.controls).toBeNull();
     expect(store.assistantId).toBeNull();
     expect(store.conversationId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Playback-progress provider — feeds the transcript's spoken-word cursor
+// ---------------------------------------------------------------------------
+
+describe("playback-progress provider", () => {
+  test("start() registers a provider that reads the active player's progress", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+
+    expect(getLiveVoicePlaybackProgress()).toBeNull();
+
+    h.player.playbackProgress = { playedSeconds: 1.25, totalSeconds: 3.5 };
+    expect(getLiveVoicePlaybackProgress()).toEqual({
+      playedSeconds: 1.25,
+      totalSeconds: 3.5,
+    });
+  });
+
+  test("teardown clears the registered provider", async () => {
+    const h = renderController();
+    await startListening(h);
+    h.player.playbackProgress = { playedSeconds: 1, totalSeconds: 2 };
+    expect(getLiveVoicePlaybackProgress()).not.toBeNull();
+
+    act(() => {
+      h.view.unmount();
+    });
+
+    expect(useLiveVoiceStore.getState().playbackProgressProvider).toBeNull();
+    expect(getLiveVoicePlaybackProgress()).toBeNull();
+  });
+
+  test("a thinking frame resets the player's progress with the transcript clear", async () => {
+    const h = renderController();
+    await startListening(h);
+    expect(h.player.resetPlaybackProgressCount).toBe(0);
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+    });
+
+    expect(h.player.resetPlaybackProgressCount).toBe(1);
+    expect(useLiveVoiceStore.getState().assistantTranscript).toBe("");
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -599,6 +599,10 @@ export function useLiveVoice(
       // speaks, so the avatar looked inverted — pulsing on the user's voice, not
       // the assistant's. Cleared by the store reset in teardown()/stop().
       store.setOutputAmplitudeProvider(() => player.getOutputAmplitude());
+      // Feed the voice-room transcript's spoken-word cursor: it maps the
+      // player's played/total seconds onto the caption's words each animation
+      // frame. Cleared by the store reset in teardown()/stop().
+      store.setPlaybackProgressProvider(() => player.getPlaybackProgress());
 
       const session: SessionContext = {
         assistantId,
@@ -775,6 +779,10 @@ export function useLiveVoice(
           // previous response's audio can never consume it.
           session.turnHeardStampMs = session.speechEndedAtMs;
           session.speechEndedAtMs = null;
+          // Playback progress resets with the transcript so the new
+          // response's spoken-word cursor starts at the first word instead of
+          // counting the previous response's audio.
+          session.player.resetPlaybackProgress();
           const s = useLiveVoiceStore.getState();
           s.clearAssistantTranscript();
           s.setState("thinking");


### PR DESCRIPTION
## Summary
- Register a playbackProgressProvider on the live-voice store (outputAmplitudeProvider pattern) exposing the player's played/total TTS seconds
- Controller registers the active player's accessor at session start and resets progress alongside the transcript clear on each thinking frame

Part of plan: voice-room-spoken-word-cursor.md (PR 2 of 5)