### PR TITLE
fix(design-library): single scroll container on fenced code blocks (LUM-2787)

### DIFF
--- a/packages/design-library/src/components/markdown-message.stories.tsx
+++ b/packages/design-library/src/components/markdown-message.stories.tsx
@@ -26,6 +26,24 @@ export const Default: Story = {
 };
 
 /**
+ * A fenced block that overflows both axes: the `<pre>` is the only scroll
+ * container, so exactly one vertical and one horizontal scrollbar appear.
+ */
+export const LongCodeBlock: Story = {
+  args: {
+    content: [
+      "```sql",
+      ...Array.from(
+        { length: 40 },
+        (_, i) =>
+          `SELECT column_${i}, another_long_column_name_${i}, yet_another_column_${i} FROM analytics_events_table WHERE tenant_id = ${i};`,
+      ),
+      "```",
+    ].join("\n"),
+  },
+};
+
+/**
  * Regression guard for JARVIS-1006: monetary values must render as plain text
  * rather than being greedily paired into italic LaTeX math by remark-math.
  */

--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -199,6 +199,34 @@ describe("MarkdownMessage", () => {
     expect(html.match(/<code[\s\S]*?<\/code>/)?.[0]).not.toContain("<br");
   });
 
+  test("fenced code renders a single scroll container — pre scrolls, code does not", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "```sql\nSELECT 1;\n```",
+      }),
+    );
+
+    const preTag = html.match(/<pre[^>]*>/)?.[0] ?? "";
+    const codeTag = html.match(/<code[^>]*>/)?.[0] ?? "";
+
+    expect(preTag).toContain("overflow-auto");
+    expect(preTag).toContain("max-height:400px");
+    expect(codeTag).toContain("w-max");
+    expect(codeTag).toContain("min-w-full");
+    expect(codeTag).not.toContain("overflow-");
+  });
+
+  test("inline code renders a chip with no scroll container", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, { content: "an `x` value" }),
+    );
+
+    const codeTag = html.match(/<code[^>]*>/)?.[0] ?? "";
+
+    expect(codeTag).toContain("rounded bg-stone-100 px-1 py-0.5");
+    expect(codeTag).not.toContain("overflow-");
+  });
+
   test("hardLineBreaks does not break table parsing", () => {
     const html = renderToStaticMarkup(
       createElement(MarkdownMessage, {

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -144,8 +144,8 @@ function CodeBlockWrapper({ children }: { children: ReactNode }) {
       )}
       <pre
         ref={preRef}
-        className="overflow-x-auto p-3"
-        style={{ maxHeight: MAX_CODE_BLOCK_HEIGHT, overflowY: "auto" }}
+        className="overflow-auto p-3"
+        style={{ maxHeight: MAX_CODE_BLOCK_HEIGHT }}
       >
         {children}
       </pre>
@@ -352,7 +352,9 @@ function buildMarkdownComponents(
         return (
           <code
             className={cn(
-              "block overflow-x-auto font-mono text-body-small-default",
+              // No overflow here — the `<pre>` is the only scroll container.
+              // `w-max min-w-full` keeps its padding inside the scrolled area.
+              "block w-max min-w-full font-mono text-body-small-default",
               className,
             )}
             {...props}


### PR DESCRIPTION
## Summary
- Remove `overflow-x-auto` from the block `<code>` override so it is no longer a nested scroll container (setting `overflow-x: auto` forces computed `overflow-y: auto`, which produced the second scrollbar)
- Size block code with `w-max min-w-full` so the `<pre>`'s right padding stays inside the scrollable area
- Consolidate the `<pre>` to `overflow-auto` + `maxHeight`, add a regression test and a `LongCodeBlock` story

Fixes LUM-2787

Part of plan: lum-2787-double-scrollbar.md (PR 1 of 2)