### PR TITLE
fix(web): make the FileMarkdown pre the single scroll container for block code

### DIFF
--- a/clients/web/src/components/file-markdown.test.tsx
+++ b/clients/web/src/components/file-markdown.test.tsx
@@ -48,6 +48,21 @@ describe("FileMarkdown", () => {
     expect(html).not.toContain("alert(1)");
   });
 
+  test("leaves the pre as the only scroll container for block code", () => {
+    const html = renderToStaticMarkup(
+      <FileMarkdown content={"```ts\nconst a = 1;\n```"} />,
+    );
+
+    const codeTag = html.match(/<code[^>]*>/)?.[0] ?? "";
+    expect(codeTag).not.toContain("overflow-");
+    expect(codeTag).not.toContain("p-3");
+    expect(codeTag).not.toContain("background-color");
+
+    const preTag = html.match(/<pre[^>]*>/)?.[0] ?? "";
+    expect(preTag).toContain("overflow-x-auto");
+    expect(preTag).toContain("p-3");
+  });
+
   test("still renders ordinary markdown", () => {
     const html = renderToStaticMarkup(
       <FileMarkdown content={"# Title\n\nSome **bold** text."} />,

--- a/clients/web/src/components/file-markdown.tsx
+++ b/clients/web/src/components/file-markdown.tsx
@@ -127,12 +127,8 @@ export const fileMarkdownComponents: Components = {
       return (
         <code
           {...rest}
-          className={`block overflow-x-auto rounded p-3 font-mono text-body-small-default ${className ?? ""}`}
-          style={{
-            backgroundColor:
-              "color-mix(in oklab, var(--content-default) 8%, transparent)",
-            color: "var(--content-default)",
-          }}
+          className={`block w-max min-w-full font-mono text-body-small-default ${className ?? ""}`}
+          style={{ color: "var(--content-default)" }}
         >
           {children}
         </code>


### PR DESCRIPTION
## Summary
- Remove `overflow-x-auto` from FileMarkdown's block `<code>` so the `<pre>` is the only scroll container (`overflow-x: auto` forces computed `overflow-y: auto`, creating a nested scroll box)
- Drop the duplicated `p-3` inset and background from the `<code>`, leaving the `<pre>` as the single padding/background owner (fixes a doubled 24px inset in file viewers)

Related to LUM-2787

Part of plan: lum-2787-double-scrollbar.md (PR 2 of 2)