### PR TITLE
feat(voice-room): rAF hook mapping TTS playback progress to a word cursor

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Tests for `useSpokenWordCursor`.
+ *
+ * `requestAnimationFrame` is monkey-patched to capture callbacks so frames are
+ * pumped manually inside `act()` (same harness as
+ * `voice-timeline-waveform.test.tsx`). Playback progress is driven through the
+ * real live-voice store by registering a provider that reads a mutable local
+ * value; the store is reset between tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
+import { useSpokenWordCursor } from "@/domains/chat/voice/voice-room/use-spoken-word-cursor";
+
+// ---------------------------------------------------------------------------
+// requestAnimationFrame harness
+// ---------------------------------------------------------------------------
+
+let rafCallbacks: Map<number, FrameRequestCallback>;
+let nextRafId = 1;
+let originalRaf: typeof globalThis.requestAnimationFrame;
+let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
+
+/** Fire every pending rAF callback once, inside `act()`. */
+function pumpFrame() {
+  act(() => {
+    const callbacks = [...rafCallbacks.values()];
+    rafCallbacks.clear();
+    for (const cb of callbacks) {
+      cb(performance.now());
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Playback-progress fake
+// ---------------------------------------------------------------------------
+
+let progress: LiveVoicePlaybackProgress | null;
+
+beforeEach(() => {
+  rafCallbacks = new Map();
+  nextRafId = 1;
+  originalRaf = globalThis.requestAnimationFrame;
+  originalCancelRaf = globalThis.cancelAnimationFrame;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    const id = nextRafId++;
+    rafCallbacks.set(id, cb);
+    return id;
+  }) as typeof globalThis.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((id: number) => {
+    rafCallbacks.delete(id);
+  }) as typeof globalThis.cancelAnimationFrame;
+
+  progress = null;
+  useLiveVoiceStore.getState().reset();
+  useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.requestAnimationFrame = originalRaf;
+  globalThis.cancelAnimationFrame = originalCancelRaf;
+  useLiveVoiceStore.getState().reset();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useSpokenWordCursor — mapping", () => {
+  test("null progress maps to the first word", () => {
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(0);
+  });
+
+  test("fraction 0.5 over 10 words maps to index 5", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(5);
+  });
+
+  test("fraction 1.0 clamps to the last word", () => {
+    progress = { playedSeconds: 10, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(9);
+  });
+
+  test("zero-duration progress holds the floor instead of dividing by zero", () => {
+    progress = { playedSeconds: 0, totalSeconds: 0 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(0);
+  });
+});
+
+describe("useSpokenWordCursor — monotonicity", () => {
+  test("a smaller fraction does not move the cursor backward", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(5);
+
+    // Total grows faster than played (a new audio burst), dipping the ratio.
+    progress = { playedSeconds: 6, totalSeconds: 20 };
+    pumpFrame();
+    expect(result.current).toBe(5);
+  });
+
+  test("progress flipping to null (barge-in flush) freezes the cursor", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(5);
+
+    progress = null;
+    pumpFrame();
+    pumpFrame();
+    expect(result.current).toBe(5);
+  });
+});
+
+describe("useSpokenWordCursor — per-response reset", () => {
+  test("shrinking wordCount resets the floor and the cursor restarts at 0", () => {
+    progress = { playedSeconds: 8, totalSeconds: 10 };
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => useSpokenWordCursor(count),
+      { initialProps: { count: 10 } },
+    );
+    pumpFrame();
+    expect(result.current).toBe(8);
+
+    // New response: the transcript clears (shorter word list), progress resets.
+    progress = null;
+    rerender({ count: 3 });
+    expect(result.current).toBe(0);
+
+    progress = { playedSeconds: 1, totalSeconds: 3 };
+    pumpFrame();
+    expect(result.current).toBe(1);
+  });
+
+  test("growing wordCount (streaming append) keeps the floor", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => useSpokenWordCursor(count),
+      { initialProps: { count: 10 } },
+    );
+    pumpFrame();
+    expect(result.current).toBe(5);
+
+    progress = null;
+    rerender({ count: 12 });
+    pumpFrame();
+    expect(result.current).toBe(5);
+  });
+});
+
+describe("useSpokenWordCursor — render economy and lifecycle", () => {
+  test("frames with an unchanged index do not re-render", () => {
+    let renders = 0;
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useSpokenWordCursor(10);
+    });
+    pumpFrame();
+    expect(result.current).toBe(5);
+    const rendersAfterFirstIndex = renders;
+
+    pumpFrame();
+    pumpFrame();
+    pumpFrame();
+    expect(renders).toBe(rendersAfterFirstIndex);
+
+    progress = { playedSeconds: 6, totalSeconds: 10 };
+    pumpFrame();
+    expect(result.current).toBe(6);
+    expect(renders).toBe(rendersAfterFirstIndex + 1);
+  });
+
+  test("wordCount 0 schedules no frames", () => {
+    renderHook(() => useSpokenWordCursor(0));
+    expect(rafCallbacks.size).toBe(0);
+  });
+
+  test("unmount cancels the pending frame", () => {
+    const { unmount } = renderHook(() => useSpokenWordCursor(10));
+    expect(rafCallbacks.size).toBe(1);
+    unmount();
+    expect(rafCallbacks.size).toBe(0);
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -13,8 +13,7 @@
  * lag the displayed LLM text mid-stream, so the fraction maps a shorter spoken
  * prefix onto the longer displayed transcript and can overshoot the truly
  * spoken word slightly. The error is bounded by the synthesis lag and
- * self-corrects as synthesis catches up — and it still tracks speech far more
- * closely than the text-arrival edge it replaces.
+ * self-corrects as synthesis catches up.
  *
  * The cursor is monotonic within a response: a smaller fraction (e.g. the
  * played/total ratio dipping when a new audio burst grows the total) never

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -1,0 +1,90 @@
+/**
+ * Word cursor driven by the TTS audio playhead, for the voice-room transcript's
+ * leading-edge highlight.
+ *
+ * A `requestAnimationFrame` loop polls {@link getLiveVoicePlaybackProgress}
+ * (played/total seconds of the current response's scheduled audio) and maps the
+ * played fraction onto the caller's word count:
+ * `floor((playedSeconds / totalSeconds) * wordCount)`, clamped to the last
+ * word. The mapping assumes words take roughly equal speaking time — close
+ * enough for a caption highlight.
+ *
+ * Accepted bias: scheduled audio corresponds to *synthesized* text, which can
+ * lag the displayed LLM text mid-stream, so the fraction maps a shorter spoken
+ * prefix onto the longer displayed transcript and can overshoot the truly
+ * spoken word slightly. The error is bounded by the synthesis lag and
+ * self-corrects as synthesis catches up — and it still tracks speech far more
+ * closely than the text-arrival edge it replaces.
+ *
+ * The cursor is monotonic within a response: a smaller fraction (e.g. the
+ * played/total ratio dipping when a new audio burst grows the total) never
+ * moves it backward, and a `null` progress read (barge-in flush clearing the
+ * player) freezes it where speech stopped. The floor resets when `wordCount`
+ * shrinks below its previous value — the transcript cleared for a new
+ * response — so each response starts at the first word.
+ *
+ * State updates land only when the mapped index changes, so the poll runs at
+ * frame rate but the subscriber re-renders at word granularity. Reduced
+ * motion: the cursor advances regardless — the visual it drives is a
+ * color-only change owned by `VoiceTranscriptText`, which already gates its
+ * motion separately.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import { getLiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+/**
+ * Index (into the caller's word segmentation) of the word the TTS playhead is
+ * speaking. Returns 0 while no audio progress exists. `wordCount` of 0 idles
+ * the loop entirely (the assistant caption unmounts on an empty transcript).
+ */
+export function useSpokenWordCursor(wordCount: number): number {
+  const [index, setIndex] = useState(0);
+  // Monotonic floor for the current response; always equals the last returned
+  // index, so the loop skips the state write when the index is unchanged.
+  const floorRef = useRef(0);
+  const prevCountRef = useRef(wordCount);
+
+  // Declared before the loop effect so a shrink (transcript cleared for a new
+  // response) zeroes the floor before the restarted loop reads it. Synced in
+  // an effect, not during render (no render-phase ref writes).
+  useEffect(() => {
+    if (wordCount < prevCountRef.current) {
+      floorRef.current = 0;
+      setIndex(0);
+    }
+    prevCountRef.current = wordCount;
+  }, [wordCount]);
+
+  useEffect(() => {
+    if (wordCount <= 0) {
+      return;
+    }
+    let raf = 0;
+    const tick = () => {
+      const progress = getLiveVoicePlaybackProgress();
+      // `null` progress → hold the floor: 0 for a fresh response, or frozen
+      // where speech stopped after a barge-in flush.
+      let candidate = floorRef.current;
+      if (progress !== null && progress.totalSeconds > 0) {
+        const mapped = Math.floor(
+          (progress.playedSeconds / progress.totalSeconds) * wordCount,
+        );
+        if (Number.isFinite(mapped)) {
+          candidate = Math.min(mapped, wordCount - 1);
+        }
+      }
+      const next = Math.max(candidate, floorRef.current);
+      if (next !== floorRef.current) {
+        floorRef.current = next;
+        setIndex(next);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [wordCount]);
+
+  return index;
+}


### PR DESCRIPTION
## Summary
- useSpokenWordCursor(wordCount) polls the live-voice playback-progress provider in a rAF loop and maps played/total audio fraction to a word index
- Monotonic within a response (floor resets when the transcript clears), re-renders only on index changes

Part of plan: voice-room-spoken-word-cursor.md (PR 4 of 5)