### PR TITLE
fix(web): hide the close button on the pro provisioning takeover

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -365,6 +365,8 @@ describe("BillingOnboardingModal", () => {
     const takeover = document.body.querySelector('[data-slot="modal-content"]');
     expect(takeover?.getAttribute("data-theme")).toBe("dark");
     expect(takeover?.className).toContain("w-screen");
+    // The takeover renders no persistent close button — exits live in the step.
+    expect(document.body.querySelector('[aria-label="Close"]')).toBeNull();
 
     // Domain step: standard card — no dark theme, no full-bleed sizing.
     await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy(), {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -377,6 +377,46 @@ describe("BillingOnboardingModal", () => {
     expect(card?.className).not.toContain("w-screen");
   });
 
+  test(
+    "a terminal takeover stays dismissable via the backdrop when routing is still resolving",
+    async () => {
+      // DONE lands from the reconcile verdict while the onboarding refetch is
+      // held open: routing never settles, so the celebration auto-advance can't
+      // fire. The backdrop must still dismiss — otherwise the user is stranded.
+      onboardingHold = new Promise(() => {});
+      subscriptionPlanId = "pro";
+      ensureResponse = makeEnsureResponse("already_done");
+      const { getByText, onClose } = renderModal();
+
+      await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
+        timeout: 5000,
+      });
+      // The X stays hidden throughout — the exit is the backdrop, not a button.
+      expect(document.body.querySelector('[aria-label="Close"]')).toBeNull();
+
+      const overlay = document.body.querySelector('[data-slot="modal-overlay"]');
+      expect(overlay).not.toBeNull();
+      fireEvent.click(overlay as Element);
+      expect(onClose).toHaveBeenCalled();
+    },
+    20_000,
+  );
+
+  test("an active provisioning takeover stays locked against backdrop dismissal", async () => {
+    subscriptionPlanId = "pro";
+    const { getByText, onClose } = renderModal();
+
+    await waitFor(
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+
+    const overlay = document.body.querySelector('[data-slot="modal-overlay"]');
+    expect(overlay).not.toBeNull();
+    fireEvent.click(overlay as Element);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   test("stall surfaces Apply & Restart; a successful apply resumes resizing through DONE", async () => {
     subscriptionPlanId = "pro";
     const { client, getByText, getByTestId } = renderModal();

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -574,12 +574,12 @@ describe("BillingOnboardingModal", () => {
 
       await waitFor(
         () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
-        { timeout: 5000 },
+        { timeout: 15_000 },
       );
       dateNowOffsetMs = 61_000;
       await waitFor(
         () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
-        { timeout: 5000 },
+        { timeout: 15_000 },
       );
       fireEvent.click(getByTestId("provisioning-escape"));
 
@@ -589,10 +589,10 @@ describe("BillingOnboardingModal", () => {
       assistantResponse = makeAssistant("large", 50);
       await client.invalidateQueries();
       await waitFor(() => expect(queryByText(BACKGROUND_LINE)).toBeNull(), {
-        timeout: 5000,
+        timeout: 15_000,
       });
     },
-    20_000,
+    30_000,
   );
 
   test(
@@ -689,12 +689,12 @@ describe("BillingOnboardingModal", () => {
 
       await waitFor(
         () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
-        { timeout: 5000 },
+        { timeout: 15_000 },
       );
       dateNowOffsetMs = 61_000;
       await waitFor(
         () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
-        { timeout: 5000 },
+        { timeout: 15_000 },
       );
       fireEvent.click(getByTestId("provisioning-escape"));
       await waitFor(() => expect(getByText("You're all set!")).toBeTruthy());
@@ -705,7 +705,7 @@ describe("BillingOnboardingModal", () => {
       dateNowOffsetMs = 200_000;
       await waitFor(
         () => expect(getByTestId("complete-stalled-apply")).toBeTruthy(),
-        { timeout: 5000 },
+        { timeout: 15_000 },
       );
       expect(queryByText(BACKGROUND_LINE)).toBeNull();
 
@@ -713,18 +713,18 @@ describe("BillingOnboardingModal", () => {
       fireEvent.click(getByTestId("complete-stalled-apply"));
       await waitFor(() => expect(ensureCalls).toBe(2));
       await waitFor(() => expect(getByText(BACKGROUND_LINE)).toBeTruthy(), {
-        timeout: 5000,
+        timeout: 15_000,
       });
 
       // …and the resize landing clears it.
       assistantResponse = makeAssistant("large", 50);
       await client.invalidateQueries();
       await waitFor(() => expect(queryByText(BACKGROUND_LINE)).toBeNull(), {
-        timeout: 5000,
+        timeout: 15_000,
       });
       expect(queryByTestId("complete-stalled-apply")).toBeNull();
     },
-    20_000,
+    30_000,
   );
 
   test(

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -122,6 +122,11 @@ export function BillingOnboardingModal({
   // actions) live inside the step content.
   const isTakeover = step === "provisioning" && !provisioningError;
 
+  // Lock Esc/backdrop only while provisioning is active — the terminal ready
+  // states unlock dismissal, so a hung routing refetch that blocks the
+  // auto-advance is never a dead-end.
+  const lockTakeover = isTakeover && !provisioningSettled;
+
   // Full-bleed dark content that fills the viewport for the takeover.
   const provisioningContentClass =
     "overflow-hidden inset-0 max-w-none w-screen h-screen max-h-none rounded-none border-0";
@@ -131,9 +136,9 @@ export function BillingOnboardingModal({
       <Modal.Content
         size="md"
         hideCloseButton
-        dismissOnOverlayClick={!isTakeover}
-        onEscapeKeyDown={isTakeover ? (e) => e.preventDefault() : undefined}
-        onInteractOutside={isTakeover ? (e) => e.preventDefault() : undefined}
+        dismissOnOverlayClick={!lockTakeover}
+        onEscapeKeyDown={lockTakeover ? (e) => e.preventDefault() : undefined}
+        onInteractOutside={lockTakeover ? (e) => e.preventDefault() : undefined}
         data-theme={isTakeover ? "dark" : undefined}
         overlayClassName={isTakeover ? "bg-black p-0" : undefined}
         className={isTakeover ? provisioningContentClass : "overflow-hidden"}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -5,8 +5,6 @@ import {
     readCheckoutIntent,
     type CheckoutIntent,
 } from "@/lib/billing/checkout-intent";
-import { isElectron } from "@/runtime/is-electron";
-import { cn } from "@/utils/misc";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -120,23 +118,19 @@ export function BillingOnboardingModal({
 
   // The live provisioning takeover is the user's first real touchpoint with the
   // flow; we lock it so an accidental backdrop click or Esc can't bail them out
-  // mid-provisioning. The explicit X (shown only here) is the deliberate exit.
+  // mid-provisioning. Sanctioned exits (escape hatch, stalled apply, timeout
+  // actions) live inside the step content.
   const isTakeover = step === "provisioning" && !provisioningError;
 
-  // data-theme="dark" also themes Modal.Content's close button so it reads on
-  // the dark backdrop. In Electron the X clears the title-bar drag strip (a
-  // fixed z-100 band over the top 28px) so it stays clickable.
-  const provisioningContentClass = cn(
-    "overflow-hidden inset-0 max-w-none w-screen h-screen max-h-none rounded-none border-0",
-    "[&_[aria-label=Close]]:[-webkit-app-region:no-drag]",
-    isElectron() && "[&_[aria-label=Close]]:top-12",
-  );
+  // Full-bleed dark content that fills the viewport for the takeover.
+  const provisioningContentClass =
+    "overflow-hidden inset-0 max-w-none w-screen h-screen max-h-none rounded-none border-0";
 
   return (
     <Modal.Root open={open} onOpenChange={(o) => { if (!o) handleClose(); }}>
       <Modal.Content
         size="md"
-        hideCloseButton={!isTakeover}
+        hideCloseButton
         dismissOnOverlayClick={!isTakeover}
         onEscapeKeyDown={isTakeover ? (e) => e.preventDefault() : undefined}
         onInteractOutside={isTakeover ? (e) => e.preventDefault() : undefined}


### PR DESCRIPTION
## Summary
- Hide the persistent X on the provisioning loading takeover; escape hatch / stalled / timeout actions remain the sanctioned exits; Esc+backdrop stay locked.

Part of plan: pro-manage-downgrade-loading.md (PR 1 of 6)