### PR TITLE
feat(web): tier-relation helper and downgrade CTA state for plan columns

### DIFF
--- a/clients/web/src/domains/settings/billing/package-types.test.ts
+++ b/clients/web/src/domains/settings/billing/package-types.test.ts
@@ -32,4 +32,9 @@ describe("tierRelation", () => {
   test("defaults to upgrade when current key is unknown", () => {
     expect(tierRelation("bogus", "super")).toBe("upgrade");
   });
+
+  test("defaults to upgrade when target key is unknown", () => {
+    expect(tierRelation("super", "enterprise")).toBe("upgrade");
+    expect(tierRelation("mighty", "bogus")).toBe("upgrade");
+  });
 });

--- a/clients/web/src/domains/settings/billing/package-types.test.ts
+++ b/clients/web/src/domains/settings/billing/package-types.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { packageRank, tierRelation } from "./package-types";
+
+describe("packageRank", () => {
+  test("ranks tiers in ascending order", () => {
+    expect(packageRank("free")).toBe(0);
+    expect(packageRank("mighty")).toBe(1);
+    expect(packageRank("super")).toBe(2);
+    expect(packageRank("ultra")).toBe(3);
+  });
+
+  test("returns -1 for unknown keys", () => {
+    expect(packageRank("bogus")).toBe(-1);
+  });
+});
+
+describe("tierRelation", () => {
+  test("classifies targets for a Pro-on-super user", () => {
+    expect(tierRelation("super", "super")).toBe("current");
+    expect(tierRelation("super", "mighty")).toBe("downgrade");
+    expect(tierRelation("super", "free")).toBe("downgrade");
+    expect(tierRelation("super", "ultra")).toBe("upgrade");
+  });
+
+  test("defaults every tier to upgrade when current is null", () => {
+    expect(tierRelation(null, "free")).toBe("upgrade");
+    expect(tierRelation(null, "mighty")).toBe("upgrade");
+    expect(tierRelation(null, "ultra")).toBe("upgrade");
+  });
+
+  test("defaults to upgrade when current key is unknown", () => {
+    expect(tierRelation("bogus", "super")).toBe("upgrade");
+  });
+});

--- a/clients/web/src/domains/settings/billing/package-types.ts
+++ b/clients/web/src/domains/settings/billing/package-types.ts
@@ -31,18 +31,25 @@ export type TierRelation = "current" | "downgrade" | "upgrade";
 
 /**
  * Classify a target tier relative to the user's current tier. When the current
- * tier is unknown (null, or an unrecognized key) every target defaults to
- * "upgrade", preserving base-user behavior.
+ * tier is unknown (null, or an unrecognized key), or the target tier is
+ * unrecognized, the result defaults to "upgrade", preserving base-user
+ * behavior and avoiding a false "downgrade" for keys this bundle doesn't know.
  */
 export function tierRelation(
   currentTierKey: string | null,
   targetKey: string,
 ): TierRelation {
-  if (currentTierKey === null) return "upgrade";
+  if (currentTierKey === null) {
+    return "upgrade";
+  }
   const current = packageRank(currentTierKey);
   const target = packageRank(targetKey);
-  if (current === -1) return "upgrade";
-  if (target === current) return "current";
+  if (current === -1 || target === -1) {
+    return "upgrade";
+  }
+  if (target === current) {
+    return "current";
+  }
   return target < current ? "downgrade" : "upgrade";
 }
 

--- a/clients/web/src/domains/settings/billing/package-types.ts
+++ b/clients/web/src/domains/settings/billing/package-types.ts
@@ -16,6 +16,36 @@ export type { ProPackage };
  */
 export const PACKAGE_ORDER = ["mighty", "super", "ultra"] as const;
 
+/** Tier keys in ascending order, base/free first. */
+const TIER_RANK_ORDER = ["free", ...PACKAGE_ORDER] as const;
+
+/**
+ * Rank of a tier key across `free → mighty → super → ultra` (0..3). Unknown
+ * keys return -1 so callers can treat them defensively.
+ */
+export function packageRank(key: string): number {
+  return TIER_RANK_ORDER.indexOf(key as (typeof TIER_RANK_ORDER)[number]);
+}
+
+export type TierRelation = "current" | "downgrade" | "upgrade";
+
+/**
+ * Classify a target tier relative to the user's current tier. When the current
+ * tier is unknown (null, or an unrecognized key) every target defaults to
+ * "upgrade", preserving base-user behavior.
+ */
+export function tierRelation(
+  currentTierKey: string | null,
+  targetKey: string,
+): TierRelation {
+  if (currentTierKey === null) return "upgrade";
+  const current = packageRank(currentTierKey);
+  const target = packageRank(targetKey);
+  if (current === -1) return "upgrade";
+  if (target === current) return "current";
+  return target < current ? "downgrade" : "upgrade";
+}
+
 /**
  * Given a current package key (or null for base/free), return the next
  * package up in the catalog ordering. Returns null if the user is already

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
@@ -32,16 +32,16 @@ afterEach(() => {
 });
 
 describe("PlanColumnCard CTA", () => {
-  test("renders a disabled Current Plan button when isCurrent", () => {
-    const { getByRole } = render(
+  test("renders a disabled Current Plan button when isCurrent", async () => {
+    const { findByRole } = render(
       <PlanColumnCard {...baseProps} isCurrent intent="current" />,
     );
-    const button = getByRole("button", { name: "Current Plan" });
+    const button = await findByRole("button", { name: "Current Plan" });
     expect(button).toHaveProperty("disabled", true);
   });
 
-  test("renders an outlined CTA with ctaLabel for a downgrade", () => {
-    const { getByRole } = render(
+  test("renders an outlined CTA with ctaLabel for a downgrade", async () => {
+    const { findByRole } = render(
       <PlanColumnCard
         {...baseProps}
         isCurrent={false}
@@ -49,18 +49,18 @@ describe("PlanColumnCard CTA", () => {
         ctaLabel="Downgrade to Mighty"
       />,
     );
-    const button = getByRole("button", { name: "Downgrade to Mighty" });
+    const button = await findByRole("button", { name: "Downgrade to Mighty" });
     expect(button).toHaveProperty("disabled", false);
     // Outlined variant paints a transparent background rather than the
     // primary fill.
     expect(button.className).toContain("bg-transparent");
   });
 
-  test("renders a primary CTA with ctaLabel when intent is omitted", () => {
-    const { getByRole } = render(
+  test("renders a primary CTA with ctaLabel when intent is omitted", async () => {
+    const { findByRole } = render(
       <PlanColumnCard {...baseProps} isCurrent={false} />,
     );
-    const button = getByRole("button", { name: "Power Up" });
+    const button = await findByRole("button", { name: "Power Up" });
     expect(button).toHaveProperty("disabled", false);
     expect(button.className).toContain("bg-[var(--primary-base)]");
   });

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Rendering tests for PlanColumnCard's CTA chrome. The `intent` prop selects
+ * the button variant (outlined for downgrade) without changing the current /
+ * upgrade rendering. The avatar compositor is mocked out — it's a lazy bundle
+ * irrelevant to the CTA.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+mock.module("@/utils/use-bundled-avatar-components", () => ({
+  preloadBundledAvatarComponents: () => {},
+  useBundledAvatarComponents: () => null,
+}));
+
+const { PlanColumnCard } = await import("./plan-column-card");
+
+const baseProps = {
+  tierKey: "mighty",
+  name: "Mighty",
+  tagline: "Starter Pro",
+  priceLabel: "$30/month",
+  priceCaption: "billed monthly",
+  ctaLabel: "Power Up",
+  features: ["Feature A"],
+  pending: false,
+  onCta: () => {},
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PlanColumnCard CTA", () => {
+  test("renders a disabled Current Plan button when isCurrent", () => {
+    const { getByRole } = render(
+      <PlanColumnCard {...baseProps} isCurrent intent="current" />,
+    );
+    const button = getByRole("button", { name: "Current Plan" });
+    expect(button).toHaveProperty("disabled", true);
+  });
+
+  test("renders an outlined CTA with ctaLabel for a downgrade", () => {
+    const { getByRole } = render(
+      <PlanColumnCard
+        {...baseProps}
+        isCurrent={false}
+        intent="downgrade"
+        ctaLabel="Downgrade to Mighty"
+      />,
+    );
+    const button = getByRole("button", { name: "Downgrade to Mighty" });
+    expect(button).toHaveProperty("disabled", false);
+    // Outlined variant paints a transparent background rather than the
+    // primary fill.
+    expect(button.className).toContain("bg-transparent");
+  });
+
+  test("renders a primary CTA with ctaLabel when intent is omitted", () => {
+    const { getByRole } = render(
+      <PlanColumnCard {...baseProps} isCurrent={false} />,
+    );
+    const button = getByRole("button", { name: "Power Up" });
+    expect(button).toHaveProperty("disabled", false);
+    expect(button.className).toContain("bg-[var(--primary-base)]");
+  });
+});

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
@@ -1,6 +1,7 @@
 import { CircleCheck } from "lucide-react";
 
 import { PlanTierAvatar } from "@/domains/settings/billing/plan-tier-meta";
+import type { TierRelation } from "@/domains/settings/billing/package-types";
 import { Button } from "@vellumai/design-library/components/button";
 import { Tag } from "@vellumai/design-library/components/tag";
 
@@ -23,6 +24,12 @@ export interface PlanColumnCardProps {
    */
   tone?: "dark" | "light";
   isCurrent: boolean;
+  /**
+   * How this tier relates to the user's current tier. Drives the CTA chrome:
+   * "downgrade" renders an outlined button; "upgrade" (default) and "current"
+   * keep the existing primary / disabled rendering.
+   */
+  intent?: TierRelation;
   /** A checkout is in flight — disable every CTA until it resolves. */
   pending: boolean;
   onCta: () => void;
@@ -43,9 +50,11 @@ export function PlanColumnCard({
   mostPopular = false,
   tone = "dark",
   isCurrent,
+  intent = "upgrade",
   pending,
   onCta,
 }: PlanColumnCardProps) {
+  const isDowngrade = intent === "downgrade" && !isCurrent;
   return (
     <div
       data-theme={tone}
@@ -82,7 +91,7 @@ export function PlanColumnCard({
       </div>
 
       <Button
-        variant="primary"
+        variant={isDowngrade ? "outlined" : "primary"}
         fullWidth
         disabled={isCurrent || pending}
         onClick={onCta}


### PR DESCRIPTION
## Summary
- Add packageRank/tierRelation helpers and an outlined downgrade CTA variant on PlanColumnCard (intent prop). No wiring yet.

Part of plan: pro-manage-downgrade-loading.md (PR 4 of 6)