### PR TITLE
feat(web): resource-change model and rotation hook for the provisioning takeover

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
@@ -11,7 +11,7 @@ describe("buildResourceChanges", () => {
     const changes = buildResourceChanges({
       targets,
       fromSnapshot: from,
-      creditsLabel: "500 credits",
+      credits: { from: "0", to: "50 credits" },
     });
 
     expect(changes.map((c) => c.key)).toEqual(["machine", "storage", "credits"]);
@@ -30,7 +30,8 @@ describe("buildResourceChanges", () => {
     expect(changes[2]).toEqual({
       key: "credits",
       label: "Credits",
-      to: "500 credits",
+      from: "0",
+      to: "50 credits",
     });
   });
 
@@ -38,7 +39,7 @@ describe("buildResourceChanges", () => {
     const changes = buildResourceChanges({
       targets: { machineSize: null, storageGib: 50 },
       fromSnapshot: from,
-      creditsLabel: null,
+      credits: null,
     });
 
     expect(changes.map((c) => c.key)).toEqual(["storage"]);
@@ -48,17 +49,17 @@ describe("buildResourceChanges", () => {
     const changes = buildResourceChanges({
       targets: { machineSize: "large", storageGib: null },
       fromSnapshot: from,
-      creditsLabel: null,
+      credits: null,
     });
 
     expect(changes.map((c) => c.key)).toEqual(["machine"]);
   });
 
-  test("omits credits when creditsLabel is null", () => {
+  test("omits credits when credits is null", () => {
     const changes = buildResourceChanges({
       targets,
       fromSnapshot: from,
-      creditsLabel: null,
+      credits: null,
     });
 
     expect(changes.map((c) => c.key)).toEqual(["machine", "storage"]);
@@ -68,7 +69,7 @@ describe("buildResourceChanges", () => {
     const changes = buildResourceChanges({
       targets,
       fromSnapshot: { machineSize: null, storageGib: null },
-      creditsLabel: null,
+      credits: null,
     });
 
     expect(changes[0].from).toBeUndefined();
@@ -79,7 +80,7 @@ describe("buildResourceChanges", () => {
     const changes = buildResourceChanges({
       targets,
       fromSnapshot: { machineSize: "large", storageGib: 50 },
-      creditsLabel: null,
+      credits: null,
     });
 
     expect(changes[0].from).toBeUndefined();
@@ -90,7 +91,7 @@ describe("buildResourceChanges", () => {
     const changes = buildResourceChanges({
       targets,
       fromSnapshot: from,
-      creditsLabel: null,
+      credits: null,
     });
 
     expect(changes[0].from).toBe("Small");

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ProvisioningDimensions } from "./provisioning-machine";
+import { buildResourceChanges } from "./resource-changes";
+
+const targets: ProvisioningDimensions = { machineSize: "large", storageGib: 50 };
+const from: ProvisioningDimensions = { machineSize: "small", storageGib: 10 };
+
+describe("buildResourceChanges", () => {
+  test("all three present, ordered machine → storage → credits", () => {
+    const changes = buildResourceChanges({
+      targets,
+      fromSnapshot: from,
+      creditsLabel: "500 credits",
+    });
+
+    expect(changes.map((c) => c.key)).toEqual(["machine", "storage", "credits"]);
+    expect(changes[0]).toEqual({
+      key: "machine",
+      label: "Machine",
+      from: "Small",
+      to: "Large",
+    });
+    expect(changes[1]).toEqual({
+      key: "storage",
+      label: "Storage",
+      from: "10 GiB",
+      to: "50 GiB",
+    });
+    expect(changes[2]).toEqual({
+      key: "credits",
+      label: "Credits",
+      to: "500 credits",
+    });
+  });
+
+  test("omits machine when the target machineSize is null", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: null, storageGib: 50 },
+      fromSnapshot: from,
+      creditsLabel: null,
+    });
+
+    expect(changes.map((c) => c.key)).toEqual(["storage"]);
+  });
+
+  test("omits storage when the target storageGib is null", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: "large", storageGib: null },
+      fromSnapshot: from,
+      creditsLabel: null,
+    });
+
+    expect(changes.map((c) => c.key)).toEqual(["machine"]);
+  });
+
+  test("omits credits when creditsLabel is null", () => {
+    const changes = buildResourceChanges({
+      targets,
+      fromSnapshot: from,
+      creditsLabel: null,
+    });
+
+    expect(changes.map((c) => c.key)).toEqual(["machine", "storage"]);
+  });
+
+  test("omits `from` when the snapshot dimension is null", () => {
+    const changes = buildResourceChanges({
+      targets,
+      fromSnapshot: { machineSize: null, storageGib: null },
+      creditsLabel: null,
+    });
+
+    expect(changes[0].from).toBeUndefined();
+    expect(changes[1].from).toBeUndefined();
+  });
+
+  test("omits `from` when the snapshot equals the target", () => {
+    const changes = buildResourceChanges({
+      targets,
+      fromSnapshot: { machineSize: "large", storageGib: 50 },
+      creditsLabel: null,
+    });
+
+    expect(changes[0].from).toBeUndefined();
+    expect(changes[1].from).toBeUndefined();
+  });
+
+  test("includes `from` when the snapshot differs from the target", () => {
+    const changes = buildResourceChanges({
+      targets,
+      fromSnapshot: from,
+      creditsLabel: null,
+    });
+
+    expect(changes[0].from).toBe("Small");
+    expect(changes[1].from).toBe("10 GiB");
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
@@ -1,0 +1,60 @@
+import { SIZE_LABEL } from "@/lib/billing/machine-sizes";
+
+import type { ProvisioningDimensions } from "./provisioning-machine";
+
+export type ResourceChangeKey = "machine" | "storage" | "credits";
+
+export interface ResourceChange {
+  key: ResourceChangeKey;
+  label: string;
+  from?: string;
+  to: string;
+}
+
+/**
+ * Flattens the provisioning targets into the ordered list of resource changes
+ * the takeover rotates through, each as a current→new pair. Order is fixed at
+ * machine → storage → credits to mirror the chip order in provisioning-state.
+ * A dimension is included only when it has something to show; `from` is present
+ * only when the pre-resize snapshot differs from the target.
+ */
+export function buildResourceChanges(input: {
+  targets: ProvisioningDimensions;
+  fromSnapshot: ProvisioningDimensions;
+  creditsLabel: string | null;
+}): ResourceChange[] {
+  const { targets, fromSnapshot, creditsLabel } = input;
+  const changes: ResourceChange[] = [];
+
+  if (targets.machineSize != null) {
+    changes.push({
+      key: "machine",
+      label: "Machine",
+      from:
+        fromSnapshot.machineSize != null &&
+        fromSnapshot.machineSize !== targets.machineSize
+          ? SIZE_LABEL[fromSnapshot.machineSize]
+          : undefined,
+      to: SIZE_LABEL[targets.machineSize],
+    });
+  }
+
+  if (targets.storageGib != null) {
+    changes.push({
+      key: "storage",
+      label: "Storage",
+      from:
+        fromSnapshot.storageGib != null &&
+        fromSnapshot.storageGib !== targets.storageGib
+          ? `${fromSnapshot.storageGib} GiB`
+          : undefined,
+      to: `${targets.storageGib} GiB`,
+    });
+  }
+
+  if (creditsLabel != null) {
+    changes.push({ key: "credits", label: "Credits", to: creditsLabel });
+  }
+
+  return changes;
+}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
@@ -21,9 +21,9 @@ export interface ResourceChange {
 export function buildResourceChanges(input: {
   targets: ProvisioningDimensions;
   fromSnapshot: ProvisioningDimensions;
-  creditsLabel: string | null;
+  credits: { from: string; to: string } | null;
 }): ResourceChange[] {
-  const { targets, fromSnapshot, creditsLabel } = input;
+  const { targets, fromSnapshot, credits } = input;
   const changes: ResourceChange[] = [];
 
   if (targets.machineSize != null) {
@@ -52,8 +52,13 @@ export function buildResourceChanges(input: {
     });
   }
 
-  if (creditsLabel != null) {
-    changes.push({ key: "credits", label: "Credits", to: creditsLabel });
+  if (credits != null) {
+    changes.push({
+      key: "credits",
+      label: "Credits",
+      from: credits.from,
+      to: credits.to,
+    });
   }
 
   return changes;

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-rotating-index.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-rotating-index.test.ts
@@ -111,6 +111,23 @@ describe("useRotatingIndex", () => {
     expect(result.current).toBeLessThanOrEqual(1);
   });
 
+  test("returns 0 on the render where rotation is disabled", () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useRotatingIndex(3, { intervalMs: 1000, enabled }),
+      { initialProps: { enabled: true } },
+    );
+
+    tick();
+    tick();
+    expect(result.current).toBe(2);
+
+    // Disabling rotation must expose the static first item immediately; the
+    // reset effect only runs after commit, so the returned value cannot be the
+    // stale advanced index.
+    rerender({ enabled: false });
+    expect(result.current).toBe(0);
+  });
+
   test("clears the interval on unmount — no advance afterwards", () => {
     const { result, unmount } = renderHook(() =>
       useRotatingIndex(3, { intervalMs: 1000, enabled: true }),

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-rotating-index.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-rotating-index.test.ts
@@ -95,6 +95,22 @@ describe("useRotatingIndex", () => {
     expect(result.current).toBe(0);
   });
 
+  test("clamps to 0..count-1 on the render where count shrinks", () => {
+    const { result, rerender } = renderHook(
+      ({ count }) => useRotatingIndex(count, { intervalMs: 1000, enabled: true }),
+      { initialProps: { count: 3 } },
+    );
+
+    tick();
+    tick();
+    expect(result.current).toBe(2);
+
+    // Shrink the list below the current index. The reset effect only runs after
+    // commit, so the returned value must already be clamped on this render.
+    rerender({ count: 2 });
+    expect(result.current).toBeLessThanOrEqual(1);
+  });
+
   test("clears the interval on unmount — no advance afterwards", () => {
     const { result, unmount } = renderHook(() =>
       useRotatingIndex(3, { intervalMs: 1000, enabled: true }),

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-rotating-index.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-rotating-index.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for `useRotatingIndex`.
+ *
+ * bun:test ships no `useFakeTimers` equivalent, so the hook's `setInterval` is
+ * driven by monkey-patching the global: each interval the hook registers is
+ * captured, then fired from `act()` to advance the index without real time.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { useRotatingIndex } from "./use-rotating-index";
+
+interface IntervalHandle {
+  id: number;
+  fn: () => void;
+  cleared: boolean;
+}
+
+let intervals: IntervalHandle[] = [];
+let nextId = 1;
+let originalSetInterval: typeof globalThis.setInterval;
+let originalClearInterval: typeof globalThis.clearInterval;
+
+/** Fires every live captured interval once, inside act(). */
+function tick() {
+  act(() => {
+    for (const handle of intervals) {
+      if (!handle.cleared) {
+        handle.fn();
+      }
+    }
+  });
+}
+
+beforeEach(() => {
+  intervals = [];
+  nextId = 1;
+  originalSetInterval = globalThis.setInterval;
+  originalClearInterval = globalThis.clearInterval;
+  globalThis.setInterval = ((fn: () => void) => {
+    const handle: IntervalHandle = { id: nextId++, fn, cleared: false };
+    intervals.push(handle);
+    return handle.id as unknown as ReturnType<typeof setInterval>;
+  }) as typeof globalThis.setInterval;
+  globalThis.clearInterval = ((id: number) => {
+    const handle = intervals.find((h) => h.id === id);
+    if (handle) {
+      handle.cleared = true;
+    }
+  }) as typeof globalThis.clearInterval;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.setInterval = originalSetInterval;
+  globalThis.clearInterval = originalClearInterval;
+});
+
+describe("useRotatingIndex", () => {
+  test("advances each interval and wraps at count", () => {
+    const { result } = renderHook(() =>
+      useRotatingIndex(3, { intervalMs: 1000, enabled: true }),
+    );
+
+    expect(result.current).toBe(0);
+    tick();
+    expect(result.current).toBe(1);
+    tick();
+    expect(result.current).toBe(2);
+    tick();
+    expect(result.current).toBe(0);
+  });
+
+  test("stays at 0 when count <= 1", () => {
+    const { result } = renderHook(() =>
+      useRotatingIndex(1, { intervalMs: 1000, enabled: true }),
+    );
+
+    expect(result.current).toBe(0);
+    // No interval should have been registered.
+    expect(intervals.length).toBe(0);
+    tick();
+    expect(result.current).toBe(0);
+  });
+
+  test("stays at 0 when disabled", () => {
+    const { result } = renderHook(() =>
+      useRotatingIndex(3, { intervalMs: 1000, enabled: false }),
+    );
+
+    expect(result.current).toBe(0);
+    expect(intervals.length).toBe(0);
+    tick();
+    expect(result.current).toBe(0);
+  });
+
+  test("clears the interval on unmount — no advance afterwards", () => {
+    const { result, unmount } = renderHook(() =>
+      useRotatingIndex(3, { intervalMs: 1000, enabled: true }),
+    );
+
+    tick();
+    expect(result.current).toBe(1);
+
+    unmount();
+    expect(intervals.every((h) => h.cleared)).toBe(true);
+    tick();
+    // The value is captured at unmount; firing a cleared interval is a no-op.
+    expect(result.current).toBe(1);
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-rotating-index.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-rotating-index.ts
@@ -27,5 +27,8 @@ export function useRotatingIndex(
     };
   }, [count, intervalMs, enabled]);
 
-  return index;
+  // Clamp to the current count so the returned index satisfies `0..count-1`
+  // even on the render where `count` shrinks below `index`, before the reset
+  // effect commits.
+  return count > 0 ? Math.min(index, count - 1) : 0;
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-rotating-index.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-rotating-index.ts
@@ -27,8 +27,11 @@ export function useRotatingIndex(
     };
   }, [count, intervalMs, enabled]);
 
-  // Clamp to the current count so the returned index satisfies `0..count-1`
-  // even on the render where `count` shrinks below `index`, before the reset
-  // effect commits.
-  return count > 0 ? Math.min(index, count - 1) : 0;
+  // Satisfy the documented contract on the same render that disables rotation
+  // or shrinks the list, before the reset effect commits: return 0 whenever
+  // rotation is inactive, otherwise clamp to the current count.
+  if (!enabled || count <= 1) {
+    return 0;
+  }
+  return Math.min(index, count - 1);
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-rotating-index.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-rotating-index.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Cycles an index through `0..count-1` on a fixed interval while enabled.
+ * Rotation only runs when `enabled` and `count > 1`; otherwise the index stays
+ * at 0. The interval is cleared and the index reset on unmount and whenever the
+ * inputs change.
+ */
+export function useRotatingIndex(
+  count: number,
+  opts: { intervalMs: number; enabled: boolean },
+): number {
+  const { intervalMs, enabled } = opts;
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (!enabled || count <= 1) {
+      setIndex(0);
+      return;
+    }
+    const timer = setInterval(() => {
+      setIndex((i) => (i + 1) % count);
+    }, intervalMs);
+    return () => {
+      clearInterval(timer);
+      setIndex(0);
+    };
+  }, [count, intervalMs, enabled]);
+
+  return index;
+}


### PR DESCRIPTION
## Summary
- Add pure buildResourceChanges (machine/storage/credits, current→new) and a local useRotatingIndex hook. No UI adoption yet.

Part of plan: pro-manage-downgrade-loading.md (PR 2 of 6)