### PR TITLE
feat(assistant): stamp triggering conversation id on auto-tracked LLM usage

### DIFF
--- a/assistant/src/__tests__/context-search-agent-runner.test.ts
+++ b/assistant/src/__tests__/context-search-agent-runner.test.ts
@@ -884,6 +884,7 @@ describe("runAgenticRecall", () => {
     };
     expect(options.config).toEqual({
       callSite: "recall",
+      conversationId: "conv-xyz",
       temperature: 0,
       thinking: { type: "disabled" },
     });
@@ -936,6 +937,7 @@ describe("runAgenticRecall", () => {
     };
     expect(finalizeOptions.config).toEqual({
       callSite: "recall",
+      conversationId: "conv-xyz",
       temperature: 0,
       thinking: { type: "disabled" },
     });

--- a/assistant/src/__tests__/provider-usage-tracking.test.ts
+++ b/assistant/src/__tests__/provider-usage-tracking.test.ts
@@ -91,6 +91,37 @@ describe("UsageTrackingProvider", () => {
     expect(events[0].estimatedCostUsd ?? 0).toBeCloseTo(0.00975, 10);
   });
 
+  test("stamps the triggering conversation id when the config carries one", async () => {
+    const provider = new UsageTrackingProvider(
+      makeProvider({
+        content: [{ type: "text", text: "Title" }],
+        model: "gpt-5.4-mini",
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 2_000,
+        },
+        stopReason: "end_turn",
+      }),
+    );
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Summarize" }] }],
+      {
+        config: {
+          callSite: "conversationTitle",
+          conversationId: "conv-123",
+        },
+      },
+    );
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      callSite: "conversationTitle",
+      conversationId: "conv-123",
+    });
+  });
+
   test("uses the transport provider when resolved attribution points elsewhere", async () => {
     setLlmConfig({
       callSites: {
@@ -174,6 +205,7 @@ describe("UsageTrackingProvider", () => {
       {
         config: {
           model: "gpt-5.4-mini",
+          conversationId: "conv-456",
         },
       },
     );
@@ -184,6 +216,7 @@ describe("UsageTrackingProvider", () => {
       callSite: "mainAgent",
       provider: "openai",
       model: "gpt-5.4-mini",
+      conversationId: "conv-456",
     });
   });
 });

--- a/assistant/src/conversations/job-handlers/summarization.ts
+++ b/assistant/src/conversations/job-handlers/summarization.ts
@@ -94,6 +94,7 @@ export async function buildConversationSummaryJob(
     existing?.summary ?? null,
     segmentTexts,
     "conversation",
+    conversationId,
   );
 
   const now = Date.now();
@@ -153,6 +154,7 @@ async function summarizeWithLLM(
   existingSummary: string | null,
   newContent: string,
   label: string,
+  conversationId: string,
 ): Promise<string> {
   const summarizationConfig = config.memory.summarization;
   if (!summarizationConfig.useLLM) {
@@ -188,6 +190,7 @@ async function summarizeWithLLM(
           systemPrompt,
           config: {
             callSite: "conversationSummarization" as const,
+            conversationId,
             max_tokens: SUMMARY_MAX_TOKENS,
           },
           signal,

--- a/assistant/src/persistence/conversation-title-service.ts
+++ b/assistant/src/persistence/conversation-title-service.ts
@@ -178,7 +178,12 @@ export async function generateAndPersistConversationTitle(
   }
 
   const prompt = buildTitlePrompt(context, userMessage, assistantResponse);
-  const title = await generateTitleViaLLM(provider, prompt, signal);
+  const title = await generateTitleViaLLM(
+    provider,
+    prompt,
+    conversationId,
+    signal,
+  );
   if (title) {
     // Re-check replaceability before persisting (race guard)
     const current = getConversation(conversationId);
@@ -316,7 +321,12 @@ export async function regenerateConversationTitle(
   if (!/\n(?:User|Assistant): /.test(prompt)) {
     return { title: conversation.title ?? UNTITLED_FALLBACK, updated: false };
   }
-  const title = await generateTitleViaLLM(provider, prompt, signal);
+  const title = await generateTitleViaLLM(
+    provider,
+    prompt,
+    conversationId,
+    signal,
+  );
   if (title) {
     // Re-check isAutoTitle before persisting (race guard against manual rename)
     const current = getConversation(conversationId);
@@ -425,6 +435,7 @@ function buildTitleTool(): ToolDefinition {
 async function generateTitleViaLLM(
   provider: Provider,
   prompt: string,
+  conversationId: string,
   signal?: AbortSignal,
 ): Promise<string> {
   const { signal: timeoutSignal, cleanup } = createTimeout(15_000);
@@ -438,6 +449,7 @@ async function generateTitleViaLLM(
       config: {
         max_tokens: 256,
         callSite: "conversationTitle",
+        conversationId,
         tool_choice: { type: "tool", name: TITLE_TOOL_NAME },
         disableCache: true,
       },

--- a/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
@@ -102,6 +102,7 @@ export async function captionImage(
         systemPrompt: CAPTION_SYSTEM_PROMPT,
         config: {
           callSite: "vision",
+          conversationId,
           overrideProfile: profileKey,
           forceOverrideProfile: true,
           tool_choice: { type: "none" },

--- a/assistant/src/plugins/defaults/memory/context-search/agent-runner.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/agent-runner.ts
@@ -301,6 +301,7 @@ export async function runAgenticRecall(
           // matters more than extended chain-of-thought.
           config: {
             callSite: "recall",
+            conversationId: context.conversationId,
             temperature: 0,
             thinking: { type: "disabled" },
           },
@@ -598,6 +599,7 @@ async function tryFinalFinishRecall(options: {
         // thinking is enabled or in adaptive mode.
         config: {
           callSite: "recall",
+          conversationId: options.context.conversationId,
           temperature: 0,
           thinking: { type: "disabled" },
         },

--- a/assistant/src/plugins/defaults/memory/graph/bootstrap.ts
+++ b/assistant/src/plugins/defaults/memory/graph/bootstrap.ts
@@ -250,6 +250,7 @@ export async function bootstrapFromJournal(): Promise<{
         await runGraphExtraction(`journal:${slug}:${file}`, config, {
           transcript,
           conversationTimestamp: journalTimestamp,
+          syntheticConversationId: true,
         });
         extracted++;
       } catch (err) {

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -586,6 +586,7 @@ export class ConversationGraphMemory {
     const result = await loadContextMemory({
       recentSummaries,
       userQuery,
+      conversationId: this.conversationId,
       config,
       signal,
     });
@@ -752,6 +753,7 @@ export class ConversationGraphMemory {
       assistantLastMessage: assistantLast,
       userLastMessage: userLast,
       userLastMessageBlocks: userLastBlocks,
+      conversationId: this.conversationId,
       config,
       tracker: this.tracker,
       signal,

--- a/assistant/src/plugins/defaults/memory/graph/extraction.ts
+++ b/assistant/src/plugins/defaults/memory/graph/extraction.ts
@@ -1113,6 +1113,11 @@ export async function runGraphExtraction(
     /** Embed nodes synchronously instead of enqueuing jobs. Used by bootstrap
      *  so nodes are searchable immediately without the jobs worker running. */
     embedInline?: boolean;
+    /** The `conversationId` argument is a synthetic source key (e.g. journal
+     *  bootstrap's `journal:<slug>:<file>`), not a `conversations` row. Skips
+     *  stamping it on the usage-ledger event so the cost stays unattributed
+     *  instead of surfacing as a phantom conversation. */
+    syntheticConversationId?: boolean;
   },
 ): Promise<ExtractionResult> {
   const emptyResult: ExtractionResult = {
@@ -1227,7 +1232,9 @@ export async function runGraphExtraction(
     systemPrompt,
     config: {
       callSite: "memoryExtraction" as const,
-      conversationId,
+      conversationId: opts?.syntheticConversationId
+        ? undefined
+        : conversationId,
       tool_choice: { type: "tool" as const, name: "extract_graph_diff" },
     },
   });

--- a/assistant/src/plugins/defaults/memory/graph/extraction.ts
+++ b/assistant/src/plugins/defaults/memory/graph/extraction.ts
@@ -1227,6 +1227,7 @@ export async function runGraphExtraction(
     systemPrompt,
     config: {
       callSite: "memoryExtraction" as const,
+      conversationId,
       tool_choice: { type: "tool" as const, name: "extract_graph_diff" },
     },
   });

--- a/assistant/src/plugins/defaults/memory/graph/retriever.ts
+++ b/assistant/src/plugins/defaults/memory/graph/retriever.ts
@@ -93,6 +93,7 @@ async function rerankAndDedup(
   candidates: ScoredNode[],
   maxNodes: number,
   _config: AssistantConfig,
+  conversationId?: string,
 ): Promise<ScoredNode[]> {
   if (candidates.length <= maxNodes) {
     return candidates;
@@ -130,6 +131,7 @@ Your job:
 3. Return the IDs in order of importance (most important first).`,
       config: {
         callSite: "memoryRetrieval" as const,
+        conversationId,
         tool_choice: { type: "tool" as const, name: "select_memories" },
         thinking: { type: "disabled" },
         temperature: 0,
@@ -201,6 +203,7 @@ async function dedupForTurn(
   candidates: ScoredNode[],
   maxNodes: number,
   query: string,
+  conversationId?: string,
 ): Promise<{ nodes: ScoredNode[]; llmApplied: boolean }> {
   try {
     const provider = await getConfiguredProvider("memoryRetrieval");
@@ -227,6 +230,7 @@ async function dedupForTurn(
         systemPrompt: `Dedupe + rerank the following numbered items. Pick the most relevant items to the query. Call the select_items tool.\n\nBe aggressive on dedup — when multiple items describe the same event, fact, or status, keep ONLY the richest version. But be generous on relevance — only cut items that are completely irrelevant to the query. If it's even tangentially related, keep it.`,
         config: {
           callSite: "memoryRetrieval" as const,
+          conversationId,
           tool_choice: { type: "tool" as const, name: "select_items" },
           thinking: { type: "disabled" },
           temperature: 0,
@@ -297,6 +301,7 @@ const DEDUP_ITEMS_TOOL = {
 async function dedupCrossCategory(
   candidates: ScoredNode[],
   maxNodes: number,
+  conversationId?: string,
 ): Promise<ScoredNode[]> {
   try {
     const provider = await getConfiguredProvider("memoryRetrieval");
@@ -321,6 +326,7 @@ async function dedupCrossCategory(
       systemPrompt: `Deduplicate the following numbered items. When multiple items describe the same event, fact, or status, keep ONLY the richest version. Keep ALL items that are not duplicates — do not filter by relevance or topic. Call the select_items tool with every item that survives dedup.`,
       config: {
         callSite: "memoryRetrieval" as const,
+        conversationId,
         tool_choice: { type: "tool" as const, name: "select_items" },
         thinking: { type: "disabled" },
         temperature: 0,
@@ -366,6 +372,11 @@ async function dedupCrossCategory(
 interface ContextLoadOpts {
   /** Recent conversation summaries (used as retrieval queries). */
   recentSummaries: string[];
+  /**
+   * Conversation being loaded, stamped on the rerank/dedup provider configs
+   * for usage-ledger attribution.
+   */
+  conversationId?: string;
   /** Embedding config. */
   config: AssistantConfig;
   /** Abort signal. */
@@ -816,6 +827,7 @@ export async function loadContextMemory(
     mainPool.slice(0, 100),
     mainSlots,
     opts.config,
+    opts.conversationId,
   );
 
   // 8. Combine: reserved capabilities + reranked main pool
@@ -846,6 +858,7 @@ export async function loadContextMemory(
     const deduped = await dedupCrossCategory(
       combined,
       combined.length, // preserve all non-duplicate nodes
+      opts.conversationId,
     );
 
     // Re-split into deterministic vs serendipity by checking original membership
@@ -898,6 +911,11 @@ export async function loadContextMemory(
 interface TurnRetrievalOpts {
   /** The assistant's last message content. */
   assistantLastMessage: string;
+  /**
+   * Conversation the turn belongs to, stamped on the dedup provider config
+   * for usage-ledger attribution.
+   */
+  conversationId?: string;
   /** The user's last message content. */
   userLastMessage: string;
   /** Raw content blocks from the user's last message (for image extraction). */
@@ -1327,6 +1345,7 @@ export async function retrieveForTurn(
       pool,
       maxGeneralNodes,
       opts.userLastMessage,
+      opts.conversationId,
     );
     injected = result.nodes;
     llmDedupApplied = result.llmApplied;

--- a/assistant/src/plugins/defaults/memory/v2/injection.ts
+++ b/assistant/src/plugins/defaults/memory/v2/injection.ts
@@ -614,6 +614,7 @@ async function injectViaRouter(args: {
 
   const routerResult = await runRouter({
     workspaceDir,
+    conversationId,
     recentTurnPairs,
     nowText,
     priorEverInjected,

--- a/assistant/src/plugins/defaults/memory/v2/router.ts
+++ b/assistant/src/plugins/defaults/memory/v2/router.ts
@@ -172,6 +172,11 @@ export interface RouterTurnPair {
 interface RunRouterParams {
   workspaceDir: string;
   /**
+   * Conversation the routed turn belongs to, stamped on the provider config
+   * for usage-ledger attribution. Simulator callers leave it unset.
+   */
+  conversationId?: string;
+  /**
    * Recent assistant/user turn pairs, oldest first. Must contain at
    * least one entry. The last entry's `userMessage` is the just-arrived
    * user turn the router is routing for; entries before it are walked
@@ -446,6 +451,7 @@ async function runRouterBatch(
       systemPrompt,
       config: {
         callSite: "memoryRouter" as const,
+        conversationId: params.conversationId,
         tool_choice: { type: "tool" as const, name: ROUTER_TOOL_NAME },
         disableTurnStartCache: true,
       },

--- a/assistant/src/plugins/defaults/memory/v3/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory/v3/pool-select.ts
@@ -482,6 +482,7 @@ export async function selectPool(
         systemPrompt,
         config: {
           callSite: MEMORY_V3_SELECT_CALL_SITE,
+          conversationId: turn.conversationId,
           tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },
           // The last block of this one-shot message varies every turn; the
           // provider's auto-applied turn-start breakpoint would land on it and

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -117,6 +117,31 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.modelIntent).toBeUndefined();
   });
 
+  test("strips conversationId before delegating to the inner provider", async () => {
+    setLlmConfig({
+      callSites: {
+        memoryRetrieval: {
+          provider: "anthropic",
+          model: "claude-haiku-4-5-20251001",
+        },
+      },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "memoryRetrieval", conversationId: "conv-123" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.conversationId).toBeUndefined();
+  });
+
   test("attaches sanitized stable attribution headers only when enabled", async () => {
     setLlmConfig({
       profiles: {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -354,15 +354,17 @@ function normalizeSendMessageOptions(
     nextConfig.promptCacheKey = config.selectionSeed;
   }
 
-  // `overrideProfile`, `forceOverrideProfile`, and `selectionSeed` are
-  // routing/resolution-time concerns (consumed by the resolver below and
-  // `CallSiteRoutingProvider`'s provider selection); none is a wire-format
+  // `overrideProfile`, `forceOverrideProfile`, `selectionSeed`, and
+  // `conversationId` are routing/resolution-time concerns (consumed by the
+  // resolver below, `CallSiteRoutingProvider`'s provider selection, and
+  // `UsageTrackingProvider`'s ledger attribution); none is a wire-format
   // field. Strip unconditionally (after the `openai` promptCacheKey copy
   // above) so they never leak into provider request bodies even when callers
   // set them without a `callSite`.
   delete nextConfig.overrideProfile;
   delete nextConfig.forceOverrideProfile;
   delete nextConfig.selectionSeed;
+  delete nextConfig.conversationId;
 
   if (config.callSite !== undefined) {
     const resolved = resolveCallSiteConfig(config.callSite, getConfig().llm, {

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -255,6 +255,13 @@ export interface SendMessageConfig {
    */
   selectionSeed?: string;
   /**
+   * Id of the user conversation that causally triggered this call, stamped by
+   * call sites so `UsageTrackingProvider` can attribute the usage-ledger event
+   * to the conversation (and, at flush time, its turn). A resolution/routing-
+   * time concern only; stripped before any provider wire request.
+   */
+  conversationId?: string;
+  /**
    * Per-conversation prompt-cache key for providers with explicit prompt
    * caching (sent as the OpenAI `prompt_cache_key` request param). Set by
    * `RetryProvider` from `selectionSeed` (the durable conversation id) for

--- a/assistant/src/providers/usage-tracking.ts
+++ b/assistant/src/providers/usage-tracking.ts
@@ -87,7 +87,7 @@ export class UsageTrackingProvider implements Provider {
           cacheCreationInputTokens: pricingUsage.cacheCreationInputTokens,
           cacheReadInputTokens: pricingUsage.cacheReadInputTokens,
           rawUsage: extractRawUsage(response.rawResponse),
-          conversationId: null,
+          conversationId: config.conversationId ?? null,
           runId: null,
           requestId: null,
           callSite: attribution.callSite,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -2556,6 +2556,7 @@ async function generateLlmSuggestion(
   provider: Provider,
   assistantText: string,
   priorUserText: string | null,
+  conversationId: string,
 ): Promise<string | null> {
   const log = (await import("../../util/logger.js")).getLogger("runtime-http");
   const truncatedAssistant = escapeXmlContent(
@@ -2611,6 +2612,7 @@ async function generateLlmSuggestion(
       systemPrompt,
       config: {
         callSite: "replySuggestion",
+        conversationId,
         max_tokens: 60,
         stop_sequences: ["</reply>"],
         temperature: 0.7,
@@ -2758,7 +2760,12 @@ export async function handleGetSuggestion(
         // Deduplicate concurrent requests
         let promise = suggestionInFlight.get(msg.id);
         if (!promise) {
-          promise = generateLlmSuggestion(provider, text, priorUserText);
+          promise = generateLlmSuggestion(
+            provider,
+            text,
+            priorUserText,
+            resolvedConversationId,
+          );
           suggestionInFlight.set(msg.id, promise);
         }
 


### PR DESCRIPTION
## Summary
- Add optional `conversationId` to `SendMessageConfig`; `UsageTrackingProvider.recordUsage` now stamps it on auto-tracked `llm_usage_events` rows instead of hardcoding `null`, and `RetryProvider` strips it unconditionally before any provider wire request (strict-schema providers reject unknown fields).
- Thread the triggering conversation id through 10 auto-tracked call-site configs: `memoryV3SelectL2`, `vision`, `recall` (×2), `memoryExtraction`, `conversationTitle`, `replySuggestion`, `memoryRouter`, `conversationSummarization`, and `memoryRetrieval` (×3 configs). Since `turn_index` is computed at flush time from the stamped conversation id, this also gets turn attribution for free — no schema or wire change needed.
- Tests: usage-tracking stamping (direct + through `CallSiteConfiguredProvider`), and a `RetryProvider` normalization test asserting the id never reaches the inner provider.

Explicitly skipped (system-initiated or no stable parent conversation): `heartbeatAgent`, `homeGreeting`, `homeSuggestedPrompts`, `conversationStarters`, `patternScan`, `memoryConsolidation`, `workflowLeaf`, `notificationDecision`.

Known caveat: `memoryExtraction`/`conversationSummarization` run async after the turn, so the flush-time subquery attributes them to the latest turn at run time, which can drift from the triggering turn if the user has since sent messages. Conversation-level attribution is still correct; precise turn attribution for background jobs is a Phase 2 concern (along with subagent parent attribution, which needs new wire fields).

## Original prompt
Stamp the triggering conversation id on auto-tracked LLM usage records. ~$620/week of LLM cost lands in `llm_usage_events` with `conversation_id = NULL` because every auto-tracked one-shot call site flows through `UsageTrackingProvider.recordUsage`, which hardcoded `conversationId: null` even though most call sites already have the triggering conversation id in scope. The fix is daemon-side only (`assistant/src`): add the field to `SendMessageConfig`, strip it at the retry layer so it never leaks into provider request bodies, stamp it at usage-recording time, and thread the id through the ten call sites that have a stable parent conversation.