### PR TITLE
feat(voice-room): drive the transcript highlight from the TTS audio playhead

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
@@ -6,7 +6,11 @@
  * selectors: transcript fields via the live-voice store, the two visibility
  * toggles via the voice-prefs store. The load-bearing contract is the
  * pref-gating — both prefs default OFF, so the room stays text-free — plus the
- * user-before-assistant DOM ordering.
+ * user-before-assistant DOM ordering. The spoken-word cursor block additionally
+ * stubs `requestAnimationFrame` with a manual pump (same harness as
+ * `use-spoken-word-cursor.test.tsx`) and drives playback progress through the
+ * store's provider, asserting the leading tone via the `data-leading`
+ * attribute on word spans.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -17,6 +21,7 @@ import {
   type LiveVoiceSessionState,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 import { VoiceAmbientTranscript } from "@/domains/chat/voice/voice-room/voice-ambient-transcript";
@@ -183,5 +188,84 @@ describe("VoiceAmbientTranscript — sourcing and ordering", () => {
       useLiveVoiceStore.getState().appendAssistantTranscript("lo world");
     });
     expect(assistantText()?.textContent).toContain("Hello world");
+  });
+});
+
+describe("VoiceAmbientTranscript — spoken-word cursor", () => {
+  let rafCallbacks: Map<number, FrameRequestCallback>;
+  let nextRafId: number;
+  let originalRaf: typeof globalThis.requestAnimationFrame;
+  let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
+  let progress: LiveVoicePlaybackProgress | null;
+
+  /** Fire every pending rAF callback once, inside `act()`. */
+  function pumpFrame() {
+    act(() => {
+      const callbacks = [...rafCallbacks.values()];
+      rafCallbacks.clear();
+      for (const cb of callbacks) {
+        cb(performance.now());
+      }
+    });
+  }
+
+  /** Text of the word span carrying the bright leading-edge tone. */
+  function leadingWordIn(half: HTMLElement) {
+    return half.querySelector("[data-leading]")?.textContent;
+  }
+
+  beforeEach(() => {
+    rafCallbacks = new Map();
+    nextRafId = 1;
+    originalRaf = globalThis.requestAnimationFrame;
+    originalCancelRaf = globalThis.cancelAnimationFrame;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = nextRafId++;
+      rafCallbacks.set(id, cb);
+      return id;
+    }) as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      rafCallbacks.delete(id);
+    }) as typeof globalThis.cancelAnimationFrame;
+    progress = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.requestAnimationFrame = originalRaf;
+    globalThis.cancelAnimationFrame = originalCancelRaf;
+  });
+
+  test("highlight sits on the mid-transcript word at playback fraction 0.5", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    act(() => {
+      useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
+    });
+    seedAssistant("alpha beta gamma delta");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    pumpFrame();
+    // floor(0.5 * 4 words) = index 2 — mid-transcript, not the last word.
+    expect(leadingWordIn(assistantText()!)).toBe("gamma");
+  });
+
+  test("no registered provider keeps the highlight on the first word", () => {
+    seedAssistant("alpha beta gamma delta");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    pumpFrame();
+    expect(leadingWordIn(assistantText()!)).toBe("alpha");
+  });
+
+  test("user bubble keeps its default last-word leading edge", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    act(() => {
+      useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
+    });
+    seedUser("one two three four");
+    setPrefs({ user: true, assistant: false });
+    render(<VoiceAmbientTranscript />);
+    pumpFrame();
+    expect(leadingWordIn(userText()!)).toBe("four");
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -16,23 +16,34 @@
  * Both prefs default OFF, so by default this renders nothing and the room stays
  * text-free. The rail is `pointer-events-none`, so it never blocks the room's
  * ✕/gear controls or the mic/stop cluster. Words reveal one at a time via
- * {@link VoiceTranscriptText}.
+ * {@link VoiceTranscriptText}. The assistant half's bright leading-edge tone
+ * tracks the TTS playhead — {@link useSpokenWordCursor} maps audio progress
+ * onto the word list, so the highlight sits on the word being *spoken* rather
+ * than the last-arrived one while the streamed text runs ahead of speech.
  *
  * Subscriptions are deliberately narrow — the three transcript fields, the two
  * prefs, and the low-frequency `state`/`reconnecting` (per-turn, for the
  * listening gate) — so the high-frequency `inputAmplitude` churn on the
- * live-voice store never re-renders this component. The full transcript still
- * lands in the chat thread on exit via the engine path; this is a live, ambient
- * echo of the current turn only.
+ * live-voice store never re-renders this component. The spoken-word cursor
+ * keeps that invariant: it polls playback progress outside React and re-renders
+ * only when the word index changes. The full transcript still lands in the chat
+ * thread on exit via the engine path; this is a live, ambient echo of the
+ * current turn only.
  */
+
+import { useMemo } from "react";
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
+import { useSpokenWordCursor } from "./use-spoken-word-cursor";
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
-import { VoiceTranscriptText } from "./voice-transcript-text";
+import {
+  splitTranscriptWords,
+  VoiceTranscriptText,
+} from "./voice-transcript-text";
 
 export function VoiceAmbientTranscript() {
   const showUser = useVoicePrefsStore.use.showUserTranscript();
@@ -47,6 +58,14 @@ export function VoiceAmbientTranscript() {
   const reconnecting = useLiveVoiceStore.use.reconnecting();
   const assistantAudioActive = useLiveVoiceStore.use.assistantAudioActive();
   const reduce = useReducedMotion();
+
+  // The same word segmentation `VoiceTranscriptText` renders, so the spoken
+  // cursor indexes the exact words on screen.
+  const assistantWords = useMemo(
+    () => splitTranscriptWords(assistantTranscript),
+    [assistantTranscript],
+  );
+  const spokenIndex = useSpokenWordCursor(assistantWords.length);
 
   // In-flight partial wins over the last finalized transcript — same precedence
   // as the underneath composer transcript (`VoiceLiveTranscript`).
@@ -129,7 +148,10 @@ export function VoiceAmbientTranscript() {
                 {...fade}
               >
                 <div className="max-w-[95%] break-words text-[clamp(15px,2vmin,19px)] leading-relaxed">
-                  <VoiceTranscriptText text={assistantTranscript} />
+                  <VoiceTranscriptText
+                    text={assistantTranscript}
+                    highlightIndex={spokenIndex}
+                  />
                 </div>
               </motion.div>
             ) : null}


### PR DESCRIPTION
## Summary
- Assistant caption in the voice room's transcript rail highlights the word the TTS playhead is speaking (useSpokenWordCursor + highlightIndex) instead of the last-arrived word
- User bubble path unchanged

Part of plan: voice-room-spoken-word-cursor.md (PR 5 of 5)