### PR TITLE
docs(design-library): tighten code-block comment and story docstring

### DIFF
--- a/packages/design-library/src/components/markdown-message.stories.tsx
+++ b/packages/design-library/src/components/markdown-message.stories.tsx
@@ -25,10 +25,7 @@ export const Default: Story = {
   },
 };
 
-/**
- * A fenced block that overflows both axes: the `<pre>` is the only scroll
- * container, so exactly one vertical and one horizontal scrollbar appear.
- */
+/** A fenced block that overflows both axes. */
 export const LongCodeBlock: Story = {
   args: {
     content: [

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -352,8 +352,7 @@ function buildMarkdownComponents(
         return (
           <code
             className={cn(
-              // No overflow here — the `<pre>` is the only scroll container.
-              // `w-max min-w-full` keeps its padding inside the scrolled area.
+              // w-max min-w-full keeps the <pre>'s right padding visible when scrolled horizontally.
               "block w-max min-w-full font-mono text-body-small-default",
               className,
             )}


### PR DESCRIPTION
## Summary
- Collapse the two-line block-code comment to a single accurate line. The first line described what was removed (diff narration, banned by AGENTS.md) and the second misattributed the padding to the `<code>` rather than the `<pre>`.
- Trim the `LongCodeBlock` story docstring to describe the fixture instead of narrating the fix outcome.

No logic changes.

Gap found during plan self-review for lum-2787-double-scrollbar.md