### PR TITLE
fix(web): narrow FileMarkdown cleanup to the redundant overflow only

### DIFF
--- a/clients/web/src/components/file-markdown.test.tsx
+++ b/clients/web/src/components/file-markdown.test.tsx
@@ -55,12 +55,9 @@ describe("FileMarkdown", () => {
 
     const codeTag = html.match(/<code[^>]*>/)?.[0] ?? "";
     expect(codeTag).not.toContain("overflow-");
-    expect(codeTag).not.toContain("p-3");
-    expect(codeTag).not.toContain("background-color");
 
     const preTag = html.match(/<pre[^>]*>/)?.[0] ?? "";
     expect(preTag).toContain("overflow-x-auto");
-    expect(preTag).toContain("p-3");
   });
 
   test("still renders ordinary markdown", () => {

--- a/clients/web/src/components/file-markdown.tsx
+++ b/clients/web/src/components/file-markdown.tsx
@@ -127,8 +127,12 @@ export const fileMarkdownComponents: Components = {
       return (
         <code
           {...rest}
-          className={`block w-max min-w-full font-mono text-body-small-default ${className ?? ""}`}
-          style={{ color: "var(--content-default)" }}
+          className={`block rounded p-3 font-mono text-body-small-default ${className ?? ""}`}
+          style={{
+            backgroundColor:
+              "color-mix(in oklab, var(--content-default) 8%, transparent)",
+            color: "var(--content-default)",
+          }}
         >
           {children}
         </code>


### PR DESCRIPTION
## Summary
Narrows PR #38651 to the single change it needed: removing `overflow-x-auto` from the block `<code>`.

Restores the `rounded p-3` classes and the `backgroundColor` inline style, and drops `w-max min-w-full`, because the wider change had two real side effects:
- `FileMarkdown` parses raw HTML by default (`rehypeRaw` + `rehypeSanitize`, which whitelists `language-*` classes on `<code>`), so a raw `<code class="language-x">` outside a `<pre>` hit the block branch and rendered unstyled and non-wrapping (`w-max` in a `white-space: normal` context), overflowing its container. Reachable from third-party plugin READMEs.
- Both layers used the same translucent `color-mix(… 8%, transparent)`, so removing one dropped the composited tint from ~15% to 8% — a visible background change across the file viewers.

The nested scroll container is still gone, which was the point.

Gap found during plan self-review for lum-2787-double-scrollbar.md