### PR TITLE
revert(web): leave FileMarkdown code blocks unchanged

### DIFF
--- a/clients/web/src/components/file-markdown.test.tsx
+++ b/clients/web/src/components/file-markdown.test.tsx
@@ -48,18 +48,6 @@ describe("FileMarkdown", () => {
     expect(html).not.toContain("alert(1)");
   });
 
-  test("leaves the pre as the only scroll container for block code", () => {
-    const html = renderToStaticMarkup(
-      <FileMarkdown content={"```ts\nconst a = 1;\n```"} />,
-    );
-
-    const codeTag = html.match(/<code[^>]*>/)?.[0] ?? "";
-    expect(codeTag).not.toContain("overflow-");
-
-    const preTag = html.match(/<pre[^>]*>/)?.[0] ?? "";
-    expect(preTag).toContain("overflow-x-auto");
-  });
-
   test("still renders ordinary markdown", () => {
     const html = renderToStaticMarkup(
       <FileMarkdown content={"# Title\n\nSome **bold** text."} />,

--- a/clients/web/src/components/file-markdown.tsx
+++ b/clients/web/src/components/file-markdown.tsx
@@ -127,7 +127,7 @@ export const fileMarkdownComponents: Components = {
       return (
         <code
           {...rest}
-          className={`block rounded p-3 font-mono text-body-small-default ${className ?? ""}`}
+          className={`block overflow-x-auto rounded p-3 font-mono text-body-small-default ${className ?? ""}`}
           style={{
             backgroundColor:
               "color-mix(in oklab, var(--content-default) 8%, transparent)",


### PR DESCRIPTION
## Summary
Reverts `file-markdown.tsx` and its test to their state on `main`, scoping LUM-2787 to the design library where the reported bug actually is.

`FileMarkdown` never had a user-visible double scrollbar. Its block `<code>` is a self-contained padded/tinted scroll box, so the `<pre>`'s own `overflow-x-auto` never activates and the code's inset and background stay in view while text scrolls inside it. The nested overflow is latent redundancy, and the two-layer padding/tint turns out to be load-bearing for that scroll behavior.

Three successive attempts to clean it up each regressed something:
- Dropping the code's padding/background made raw-HTML `<code class="language-x">` outside a `<pre>` render unstyled, and `w-max` in a wrapping context made it overflow its container (`FileMarkdown` parses raw HTML by default).
- It also dropped the composited background tint from ~15% to 8% across the file viewers.
- Restoring padding/background without `w-max` left the tinted box viewport-width, so scrolling right moved it off-screen and text overflowed onto bare `<pre>` background (flagged by Codex on #38660).

The remaining redundancy is worth a follow-up ticket, not a drive-by on a chat-scrollbar fix.

Gap found during plan self-review for lum-2787-double-scrollbar.md