### PR TITLE
feat(telemetry): persist subagent parent conversation linkage for usage attribution

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -1845,6 +1845,75 @@ describe("queryUnreportedUsageEvents", () => {
     expect(events[0].turnIndex).toBe(0);
   });
 
+  // -------------------------------------------------------------------------
+  // Parent linkage (parentConversationId + parentTurnIndex): subagent spawns
+  // stamp `parent_conversation_id` on their background conversation; the
+  // query resolves it (with a fork-parent fallback) so the reporter can
+  // attribute the child's usage to the parent turn in flight at spawn.
+  // -------------------------------------------------------------------------
+
+  test("parentConversationId links a subagent conversation and parentTurnIndex counts the parent turn in flight at spawn", () => {
+    const db = getDb();
+    // Parent user turns at t=1000 and t=3000; the child conversation is
+    // created at t=2000, i.e. while the parent's turn 1 is in flight.
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('parent-1', 'standard', 500, 500)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('p1', 'parent-1', 'user', 'first', 1000)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('p2', 'parent-1', 'user', 'second', 3000)`,
+    );
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, parent_conversation_id) VALUES ('child-1', 'background', 2000, 2000, 'parent-1')`,
+    );
+    // The usage event fires after the parent's turn 2, but attribution is
+    // anchored to the child's creation time, not the event time.
+    insertEventAt(5000, { conversationId: "child-1" });
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    expect(events[0].parentConversationId).toBe("parent-1");
+    expect(events[0].parentTurnIndex).toBe(1);
+  });
+
+  test("parent linkage falls back to fork_parent_conversation_id (retrospective forks)", () => {
+    const db = getDb();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('source-1', 'standard', 500, 500)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('s1', 'source-1', 'user', 'hello', 1000)`,
+    );
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, fork_parent_conversation_id) VALUES ('retro-1', 'background', 2000, 2000, 'source-1')`,
+    );
+    insertEventAt(3000, { conversationId: "retro-1" });
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    expect(events[0].parentConversationId).toBe("source-1");
+    expect(events[0].parentTurnIndex).toBe(1);
+  });
+
+  test("parent fields are null for parentless conversations and no-conversation events", () => {
+    const db = getDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('conv-solo', 'background', ${now}, ${now})`,
+    );
+    insertEventAt(1000, { conversationId: "conv-solo" });
+    insertEventAt(2000, { conversationId: null });
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(2);
+    expect(events[0].parentConversationId).toBeNull();
+    expect(events[0].parentTurnIndex).toBeNull();
+    expect(events[1].parentConversationId).toBeNull();
+    expect(events[1].parentTurnIndex).toBeNull();
+  });
+
   test("surfaces llmCallCount on unreported events", () => {
     insertEventAt(1000, { llmCallCount: 4 });
     insertEventAt(2000, {});

--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -54,6 +54,8 @@ let runLoopInvoked = false;
 let lastPersistedUserMessage: string | undefined;
 /** Records `setSubagentDenySideEffects` on the most recent FakeConversation. */
 let lastDenySideEffects: boolean | undefined;
+/** Options the most recent `bootstrapConversation` call received. */
+let lastBootstrapOptions: Record<string, unknown> | undefined;
 
 class FakeConversation {
   messages: Message[];
@@ -143,7 +145,10 @@ mock.module("../daemon/conversation.js", () => ({
 }));
 
 mock.module("../persistence/conversation-bootstrap.js", () => ({
-  bootstrapConversation: () => ({ id: `conv-${Math.random()}` }),
+  bootstrapConversation: (opts: Record<string, unknown>) => {
+    lastBootstrapOptions = opts;
+    return { id: `conv-${Math.random()}` };
+  },
 }));
 
 mock.module("../prompts/system-prompt.js", () => ({
@@ -244,6 +249,18 @@ describe("SubagentManager.spawnAndAwait", () => {
     await manager.spawnAndAwait(makeConfig(), () => {});
 
     expect(lastDenySideEffects).toBeUndefined();
+  });
+
+  test("stamps the parent conversation id on the subagent's conversation", async () => {
+    nextConversationConfig = {};
+
+    const manager = new SubagentManager();
+    const config = makeConfig();
+    await manager.spawnAndAwait(config, () => {});
+
+    expect(lastBootstrapOptions?.parentConversationId).toBe(
+      config.parentConversationId,
+    );
   });
 
   test("resolves to the child's final assistant text", async () => {

--- a/assistant/src/persistence/conversation-bootstrap.ts
+++ b/assistant/src/persistence/conversation-bootstrap.ts
@@ -21,6 +21,14 @@ export interface BootstrapConversationOptions {
    * most recent retrospective for this source").
    */
   forkParentConversationId?: string;
+  /**
+   * When set, persisted as the new conversation's `parent_conversation_id` —
+   * the conversation that spawned this one (subagent spawns). Telemetry
+   * resolves it at flush time to attribute the child's LLM usage back to the
+   * parent's in-flight user turn. Unlike `forkParentConversationId` it
+   * implies no history inheritance.
+   */
+  parentConversationId?: string;
 }
 
 /**
@@ -52,6 +60,9 @@ export async function bootstrapConversation(
         ...(opts.groupId && { groupId: opts.groupId }),
         ...(opts.forkParentConversationId && {
           forkParentConversationId: opts.forkParentConversationId,
+        }),
+        ...(opts.parentConversationId && {
+          parentConversationId: opts.parentConversationId,
         }),
       }),
     { op: "bootstrapConversation" },

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -791,6 +791,12 @@ export function createConversation(
         scheduleJobId?: string;
         groupId?: string;
         forkParentConversationId?: string;
+        /**
+         * Id of the conversation that spawned this one (subagent spawns).
+         * Persisted for telemetry attribution; unlike
+         * `forkParentConversationId` it implies no history inheritance.
+         */
+        parentConversationId?: string;
       },
 ) {
   const db = getDb();
@@ -833,6 +839,7 @@ export function createConversation(
     source,
     scheduleJobId: opts.scheduleJobId ?? null,
     forkParentConversationId: opts.forkParentConversationId ?? null,
+    parentConversationId: opts.parentConversationId ?? null,
     // Snapshot↔stream alignment baseline, captured at the creation instant.
     // 0 (nothing stamped yet this process) is stored as NULL so `/messages`
     // reports null and the client cold-starts rather than aligning to seq 0.

--- a/assistant/src/persistence/llm-usage-store.ts
+++ b/assistant/src/persistence/llm-usage-store.ts
@@ -10,6 +10,7 @@ import type {
 import { APP_VERSION } from "../version.js";
 import { getDb } from "./db-connection.js";
 import { rawAll } from "./raw-query.js";
+import { realUserTurnContentFilter } from "./real-user-turn-filter.js";
 import {
   buildScheduleAttributionSubquery,
   buildScheduleRunWindowExists,
@@ -286,8 +287,7 @@ export function queryUnreportedUsageEvents(
           SELECT COUNT(*) FROM messages AS m2
           WHERE m2.conversation_id = ${llmUsageEvents.conversationId}
             AND m2.role = 'user'
-            AND m2.content NOT LIKE '%"type":"tool\\_result"%' ESCAPE '\\'
-            AND m2.content NOT LIKE '%"type":"web\\_search\\_tool\\_result"%' ESCAPE '\\'
+            AND ${realUserTurnContentFilter("m2")}
             AND m2.created_at <= ${llmUsageEvents.createdAt}
         )
         END
@@ -303,8 +303,7 @@ export function queryUnreportedUsageEvents(
           SELECT COUNT(*) FROM messages AS m3
           WHERE m3.conversation_id = ${parentIdSql}
             AND m3.role = 'user'
-            AND m3.content NOT LIKE '%"type":"tool\\_result"%' ESCAPE '\\'
-            AND m3.content NOT LIKE '%"type":"web\\_search\\_tool\\_result"%' ESCAPE '\\'
+            AND ${realUserTurnContentFilter("m3")}
             AND m3.created_at <= ${conversations.createdAt}
         )
         END

--- a/assistant/src/persistence/llm-usage-store.ts
+++ b/assistant/src/persistence/llm-usage-store.ts
@@ -207,6 +207,23 @@ export interface UnreportedUsageEvent extends UsageEvent {
    * agent starts).
    */
   turnIndex: number | null;
+  /**
+   * Id of the conversation that spawned this LLM call's conversation:
+   * `parent_conversation_id` (subagent spawns), falling back to
+   * `fork_parent_conversation_id` (retrospective forks). Null when the
+   * conversation was not spawned by another conversation, or when the
+   * LLM call has no `conversationId` at all.
+   */
+  parentConversationId: string | null;
+  /**
+   * 1-indexed position of the user turn that was in flight in the parent
+   * conversation when this LLM call's conversation was created — i.e. the
+   * parent turn that spawned it. Computed as the count of real user turns
+   * in the parent conversation with `created_at <=` the child
+   * conversation's `created_at` (same eligibility filter as `turnIndex`).
+   * Null when there's no parent conversation.
+   */
+  parentTurnIndex: number | null;
 }
 
 export function queryUnreportedUsageEvents(
@@ -215,6 +232,14 @@ export function queryUnreportedUsageEvents(
   limit: number,
 ): UnreportedUsageEvent[] {
   const db = getTelemetryMainDb();
+  // Spawn linkage: `parent_conversation_id` (subagent spawns) with a
+  // fallback to `fork_parent_conversation_id` (retrospective forks — one
+  // hop up the fork chain is the intended attribution). Null when the
+  // LEFT JOIN below misses or the conversation has no parent.
+  const parentIdSql = sql<string | null>`COALESCE(
+    ${conversations.parentConversationId},
+    ${conversations.forkParentConversationId}
+  )`;
   // JOIN to `conversations` to attach `conversationType`. LEFT JOIN
   // because `llm_usage_events.conversationId` is nullable — calls that
   // aren't tied to a conversation (memory consolidation, etc.) still
@@ -267,6 +292,23 @@ export function queryUnreportedUsageEvents(
         )
         END
       )`.as("turn_index"),
+      parentConversationId: parentIdSql.as("parent_conversation_id"),
+      // The parent turn in flight when the child conversation was created:
+      // count of the PARENT conversation's real user turns with
+      // `created_at <=` the CHILD conversation's `created_at`. Same
+      // eligibility filter as `turnIndex` above.
+      parentTurnIndex: sql<number | null>`(
+        CASE WHEN ${parentIdSql} IS NULL THEN NULL
+        ELSE (
+          SELECT COUNT(*) FROM messages AS m3
+          WHERE m3.conversation_id = ${parentIdSql}
+            AND m3.role = 'user'
+            AND m3.content NOT LIKE '%"type":"tool\\_result"%' ESCAPE '\\'
+            AND m3.content NOT LIKE '%"type":"web\\_search\\_tool\\_result"%' ESCAPE '\\'
+            AND m3.created_at <= ${conversations.createdAt}
+        )
+        END
+      )`.as("parent_turn_index"),
     })
     .from(llmUsageEvents)
     .leftJoin(
@@ -295,6 +337,9 @@ export function queryUnreportedUsageEvents(
     // Convert the integer column to `number | null` for the typed
     // return value.
     turnIndex: row.turnIndex === null ? null : Number(row.turnIndex),
+    parentConversationId: row.parentConversationId,
+    parentTurnIndex:
+      row.parentTurnIndex === null ? null : Number(row.parentTurnIndex),
   }));
 }
 

--- a/assistant/src/persistence/migrations/342-add-conversation-parent-id.test.ts
+++ b/assistant/src/persistence/migrations/342-add-conversation-parent-id.test.ts
@@ -8,16 +8,30 @@ import { migrateAddConversationParentId } from "./342-add-conversation-parent-id
 
 function createTestDb() {
   const sqlite = new Database(":memory:");
-  // Pre-342 shape: only the columns the migration and tests touch.
+  // Pre-342 shape: only the columns the migration and tests touch. The
+  // `subagents` table (migration 311) always precedes 342 in the step order
+  // and is the backfill source.
   sqlite.exec(/*sql*/ `
     CREATE TABLE conversations (
       id TEXT PRIMARY KEY,
       title TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
-    )
+    );
+    CREATE TABLE subagents (
+      id TEXT PRIMARY KEY,
+      parent_conversation_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL
+    );
   `);
   return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function parentOf(sqlite: Database, conversationId: string): unknown {
+  const row = sqlite
+    .query("SELECT parent_conversation_id FROM conversations WHERE id = ?")
+    .get(conversationId) as { parent_conversation_id: unknown };
+  return row.parent_conversation_id;
 }
 
 function columnInfo(sqlite: Database) {
@@ -63,12 +77,7 @@ describe("migration 342: conversations.parent_conversation_id", () => {
 
     migrateAddConversationParentId(db);
 
-    const row = sqlite
-      .query(
-        "SELECT parent_conversation_id FROM conversations WHERE id = 'conv-1'",
-      )
-      .get() as { parent_conversation_id: unknown };
-    expect(row.parent_conversation_id).toBeNull();
+    expect(parentOf(sqlite, "conv-1")).toBeNull();
   });
 
   test("round-trips an insert that sets the new column", () => {
@@ -80,12 +89,42 @@ describe("migration 342: conversations.parent_conversation_id", () => {
       VALUES ('child-1', 2000, 2000, 'parent-1')
     `);
 
-    const row = sqlite
-      .query(
-        "SELECT parent_conversation_id FROM conversations WHERE id = 'child-1'",
-      )
-      .get() as { parent_conversation_id: unknown };
-    expect(row.parent_conversation_id).toBe("parent-1");
+    expect(parentOf(sqlite, "child-1")).toBe("parent-1");
+  });
+
+  test("backfills parent ids from surviving subagents rows", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO conversations (id, created_at, updated_at) VALUES
+        ('sub-conv-1', 1000, 1000),
+        ('sub-conv-2', 2000, 2000),
+        ('plain-conv', 3000, 3000);
+      INSERT INTO subagents (id, parent_conversation_id, conversation_id) VALUES
+        ('s1', 'parent-a', 'sub-conv-1'),
+        ('s2', 'parent-b', 'sub-conv-2');
+    `);
+
+    migrateAddConversationParentId(db);
+
+    expect(parentOf(sqlite, "sub-conv-1")).toBe("parent-a");
+    expect(parentOf(sqlite, "sub-conv-2")).toBe("parent-b");
+    // Conversations with no surviving subagents row stay parentless.
+    expect(parentOf(sqlite, "plain-conv")).toBeNull();
+  });
+
+  test("backfill does not overwrite an already-set parent id", () => {
+    const { sqlite, db } = createTestDb();
+    migrateAddConversationParentId(db);
+    sqlite.exec(/*sql*/ `
+      INSERT INTO conversations (id, created_at, updated_at, parent_conversation_id)
+      VALUES ('stamped', 1000, 1000, 'parent-live');
+      INSERT INTO subagents (id, parent_conversation_id, conversation_id)
+      VALUES ('s1', 'parent-stale', 'stamped');
+    `);
+
+    migrateAddConversationParentId(db);
+
+    expect(parentOf(sqlite, "stamped")).toBe("parent-live");
   });
 
   test("is idempotent — re-run is a no-op", () => {

--- a/assistant/src/persistence/migrations/342-add-conversation-parent-id.test.ts
+++ b/assistant/src/persistence/migrations/342-add-conversation-parent-id.test.ts
@@ -1,0 +1,102 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateAddConversationParentId } from "./342-add-conversation-parent-id.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Pre-342 shape: only the columns the migration and tests touch.
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function columnInfo(sqlite: Database) {
+  return sqlite.query("PRAGMA table_info(conversations)").all() as Array<{
+    name: string;
+    notnull: number;
+  }>;
+}
+
+function indexNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA index_list(conversations)").all() as Array<{
+      name: string;
+    }>
+  ).map((i) => i.name);
+}
+
+describe("migration 342: conversations.parent_conversation_id", () => {
+  test("adds the nullable column and its index", () => {
+    const { sqlite, db } = createTestDb();
+    expect(columnInfo(sqlite).map((c) => c.name)).not.toContain(
+      "parent_conversation_id",
+    );
+
+    migrateAddConversationParentId(db);
+
+    const column = columnInfo(sqlite).find(
+      (c) => c.name === "parent_conversation_id",
+    );
+    expect(column).toBeDefined();
+    expect(column?.notnull).toBe(0);
+    expect(indexNames(sqlite)).toContain(
+      "idx_conversations_parent_conversation_id",
+    );
+  });
+
+  test("existing rows read back with null parent_conversation_id", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO conversations (id, created_at, updated_at)
+      VALUES ('conv-1', 1000, 1000)
+    `);
+
+    migrateAddConversationParentId(db);
+
+    const row = sqlite
+      .query(
+        "SELECT parent_conversation_id FROM conversations WHERE id = 'conv-1'",
+      )
+      .get() as { parent_conversation_id: unknown };
+    expect(row.parent_conversation_id).toBeNull();
+  });
+
+  test("round-trips an insert that sets the new column", () => {
+    const { sqlite, db } = createTestDb();
+    migrateAddConversationParentId(db);
+
+    sqlite.exec(/*sql*/ `
+      INSERT INTO conversations (id, created_at, updated_at, parent_conversation_id)
+      VALUES ('child-1', 2000, 2000, 'parent-1')
+    `);
+
+    const row = sqlite
+      .query(
+        "SELECT parent_conversation_id FROM conversations WHERE id = 'child-1'",
+      )
+      .get() as { parent_conversation_id: unknown };
+    expect(row.parent_conversation_id).toBe("parent-1");
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateAddConversationParentId(db);
+    expect(() => migrateAddConversationParentId(db)).not.toThrow();
+
+    const names = columnInfo(sqlite).map((c) => c.name);
+    expect(
+      names.filter((n) => n === "parent_conversation_id"),
+    ).toHaveLength(1);
+  });
+});

--- a/assistant/src/persistence/migrations/342-add-conversation-parent-id.ts
+++ b/assistant/src/persistence/migrations/342-add-conversation-parent-id.ts
@@ -14,12 +14,16 @@ const COLUMN_DEFINITION = "parent_conversation_id TEXT";
  * a watermark that can trail the parent conversation's lifetime, so the
  * linkage must survive parent deletion without cascade churn.
  *
- * No backfill is needed — all existing rows default to NULL (not spawned by
- * another conversation), which is correct for any pre-migration conversation.
+ * Backfills from the `subagents` table (migration 311), which stores the
+ * same parent ↔ child linkage for subagents that have not yet been disposed
+ * (rows are deleted on TTL sweep / parent eviction). This links unflushed
+ * usage rows of pre-migration subagents; long-disposed subagents have no
+ * surviving linkage anywhere and correctly stay NULL.
  *
  * Idempotent: guarded with `tableHasColumn` so a crash between the `ALTER
  * TABLE` and the checkpoint write doesn't cause a duplicate-column error on
- * the next boot. The index uses `IF NOT EXISTS` for the same reason.
+ * the next boot. The index uses `IF NOT EXISTS` and the backfill only fills
+ * NULL rows for the same reason.
  */
 export function migrateAddConversationParentId(database: DrizzleDb): void {
   if (!tableHasColumn(database, "conversations", COLUMN_NAME)) {
@@ -28,4 +32,15 @@ export function migrateAddConversationParentId(database: DrizzleDb): void {
   database.run(
     `CREATE INDEX IF NOT EXISTS idx_conversations_parent_conversation_id ON conversations(parent_conversation_id)`,
   );
+  database.run(`
+    UPDATE conversations
+    SET parent_conversation_id = (
+      SELECT s.parent_conversation_id FROM subagents s
+      WHERE s.conversation_id = conversations.id
+    )
+    WHERE parent_conversation_id IS NULL
+      AND EXISTS (
+        SELECT 1 FROM subagents s WHERE s.conversation_id = conversations.id
+      )
+  `);
 }

--- a/assistant/src/persistence/migrations/342-add-conversation-parent-id.ts
+++ b/assistant/src/persistence/migrations/342-add-conversation-parent-id.ts
@@ -1,0 +1,31 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+const COLUMN_NAME = "parent_conversation_id";
+const COLUMN_DEFINITION = "parent_conversation_id TEXT";
+
+/**
+ * Add `parent_conversation_id` column to the `conversations` table.
+ *
+ * The column is a nullable, free-form id of the conversation that spawned
+ * this one (subagent spawns stamp their parent's conversation id), enabling
+ * telemetry to attribute a subagent's LLM usage to the user turn that
+ * triggered it. It is intentionally NOT a foreign key: usage events flush on
+ * a watermark that can trail the parent conversation's lifetime, so the
+ * linkage must survive parent deletion without cascade churn.
+ *
+ * No backfill is needed — all existing rows default to NULL (not spawned by
+ * another conversation), which is correct for any pre-migration conversation.
+ *
+ * Idempotent: guarded with `tableHasColumn` so a crash between the `ALTER
+ * TABLE` and the checkpoint write doesn't cause a duplicate-column error on
+ * the next boot. The index uses `IF NOT EXISTS` for the same reason.
+ */
+export function migrateAddConversationParentId(database: DrizzleDb): void {
+  if (!tableHasColumn(database, "conversations", COLUMN_NAME)) {
+    database.run(`ALTER TABLE conversations ADD COLUMN ${COLUMN_DEFINITION}`);
+  }
+  database.run(
+    `CREATE INDEX IF NOT EXISTS idx_conversations_parent_conversation_id ON conversations(parent_conversation_id)`,
+  );
+}

--- a/assistant/src/persistence/real-user-turn-filter.ts
+++ b/assistant/src/persistence/real-user-turn-filter.ts
@@ -1,0 +1,26 @@
+import { sql } from "drizzle-orm";
+
+/**
+ * SQL fragment that excludes tool-result rows persisted with role="user" —
+ * these are system-generated and must not count as user turns.
+ *
+ * Single source of truth for the "real user turn" notion shared by the
+ * turn-event eligibility predicate, the `turn_index` / `parent_turn_index`
+ * correlated counts (llm-usage-store), and the turn-trace window. If any
+ * copy drifted, a turn index could disagree with the visible turn stream
+ * and break "first turn" / "turns per conversation" / parent-attribution
+ * math.
+ *
+ * `alias` is interpolated as the SQL identifier for the table whose
+ * `content` column is filtered (e.g. `messages` for an outer query, `m2`
+ * for a correlated subquery). ESCAPE '\\' makes the underscores match
+ * literally rather than as single-character wildcards.
+ */
+export function realUserTurnContentFilter(
+  alias: string,
+): ReturnType<typeof sql> {
+  return sql.raw(
+    `${alias}.content NOT LIKE '%"type":"tool\\_result"%' ESCAPE '\\' ` +
+      `AND ${alias}.content NOT LIKE '%"type":"web\\_search\\_tool\\_result"%' ESCAPE '\\'`,
+  );
+}

--- a/assistant/src/persistence/schema/conversations.ts
+++ b/assistant/src/persistence/schema/conversations.ts
@@ -36,6 +36,14 @@ export const conversations = sqliteTable(
     originInterface: text("origin_interface"),
     forkParentConversationId: text("fork_parent_conversation_id"),
     forkParentMessageId: text("fork_parent_message_id"),
+    /**
+     * Id of the conversation that spawned this one (subagent spawns stamp
+     * their parent's conversation id). Distinct from
+     * `forkParentConversationId`, which records message-history inheritance;
+     * this column records spawn attribution for telemetry. NULL for
+     * conversations not spawned by another conversation.
+     */
+    parentConversationId: text("parent_conversation_id"),
     isAutoTitle: integer("is_auto_title").notNull().default(1),
     scheduleJobId: text("schedule_job_id"),
     lastMessageAt: integer("last_message_at"),
@@ -92,6 +100,9 @@ export const conversations = sqliteTable(
     index("idx_conversations_surfaced_at").on(table.surfacedAt),
     index("idx_conversations_fork_parent_conversation_id").on(
       table.forkParentConversationId,
+    ),
+    index("idx_conversations_parent_conversation_id").on(
+      table.parentConversationId,
     ),
   ],
 );

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -449,6 +449,7 @@ import { migrateMoveMemoryV3SelectionsToMemoryDb } from "./migrations/338-move-m
 import { migrateMoveActivationSessionsToMemoryDb } from "./migrations/339-move-activation-sessions-to-memory-db.js";
 import { migrateSweepOrphanedGraphNodeVectors } from "./migrations/340-sweep-orphaned-graph-node-vectors.js";
 import { migrateSweepCachelessGraphNodeVectors } from "./migrations/341-sweep-cacheless-graph-node-vectors.js";
+import { migrateAddConversationParentId } from "./migrations/342-add-conversation-parent-id.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1397,4 +1398,5 @@ export const migrationSteps: MigrationStep[] = [
   },
   migrateSweepOrphanedGraphNodeVectors,
   migrateSweepCachelessGraphNodeVectors,
+  migrateAddConversationParentId,
 ];

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -377,6 +377,7 @@ export class SubagentManager {
       source: "subagent",
       origin: "subagent",
       systemHint: `Subagent: ${config.label}`,
+      parentConversationId: config.parentConversationId,
     });
 
     // ── Build conversation dependencies ─────────────────────────────

--- a/assistant/src/telemetry/turn-events-store.ts
+++ b/assistant/src/telemetry/turn-events-store.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, gt, or, sql } from "drizzle-orm";
 
 import { getDb } from "../persistence/db-connection.js";
+import { realUserTurnContentFilter } from "../persistence/real-user-turn-filter.js";
 import { conversations, messages } from "../persistence/schema/index.js";
 
 export interface TurnEvent {
@@ -89,24 +90,6 @@ export interface TurnEvent {
 }
 
 /**
- * SQL fragment that excludes tool-result rows persisted with role="user".
- * Kept as a single source of truth so the eligibility predicate and the
- * correlated `turn_index` count stay in lockstep — otherwise the index
- * can drift from the visible turn stream and break "first turn" /
- * "turns per conversation" math.
- *
- * `<alias>` is interpolated as the SQL identifier for the table whose
- * `content` column should be filtered (e.g. `messages` for the outer
- * query, `m2` for the correlated subquery).
- */
-function realUserTurnContentFilter(alias: string): ReturnType<typeof sql> {
-  return sql.raw(
-    `${alias}.content NOT LIKE '%"type":"tool\\_result"%' ESCAPE '\\' ` +
-      `AND ${alias}.content NOT LIKE '%"type":"web\\_search\\_tool\\_result"%' ESCAPE '\\'`,
-  );
-}
-
-/**
  * Query user messages (turns) that haven't been reported to telemetry yet.
  * Uses a compound cursor (createdAt + id) for reliable watermarking.
  *
@@ -185,12 +168,7 @@ export function queryUnreportedTurnEvents(
     .where(
       and(
         eq(messages.role, "user"),
-        // Exclude tool-result rows persisted with role "user" — these are
-        // system-generated and should not count as user turns.
-        // Use ESCAPE '\\' so underscores are matched literally, not as
-        // single-character wildcards.
-        sql`${messages.content} NOT LIKE '%"type":"tool\\_result"%' ESCAPE '\\'`,
-        sql`${messages.content} NOT LIKE '%"type":"web\\_search\\_tool\\_result"%' ESCAPE '\\'`,
+        realUserTurnContentFilter("messages"),
         afterId
           ? or(
               gt(messages.createdAt, afterCreatedAt),

--- a/assistant/src/telemetry/turn-trace-store.ts
+++ b/assistant/src/telemetry/turn-trace-store.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, gt, lt, lte, or, sql } from "drizzle-orm";
 
 import { findConversation } from "../daemon/conversation-registry.js";
 import { getDb } from "../persistence/db-connection.js";
+import { realUserTurnContentFilter } from "../persistence/real-user-turn-filter.js";
 import { messages, toolInvocations } from "../persistence/schema/index.js";
 import { getLogger } from "../util/logger.js";
 import type {
@@ -12,21 +13,6 @@ import type {
 } from "./types.js";
 
 const log = getLogger("turn-trace-store");
-
-/**
- * SQL fragment that excludes tool-result rows persisted with role="user".
- * Duplicated from `turn-events-store.ts` on purpose: a turn boundary in the
- * trace must use exactly the same notion of "real user turn" the eligibility
- * predicate / `turn_index` count use, so the trace window can never disagree
- * with the `turn` event it rides on. `<alias>` is interpolated as the SQL
- * identifier for the table whose `content` column is filtered.
- */
-function realUserTurnContentFilter(alias: string): ReturnType<typeof sql> {
-  return sql.raw(
-    `${alias}.content NOT LIKE '%"type":"tool\\_result"%' ESCAPE '\\' ` +
-      `AND ${alias}.content NOT LIKE '%"type":"web\\_search\\_tool\\_result"%' ESCAPE '\\'`,
-  );
-}
 
 /**
  * Identifies the user message a trace is being assembled for. Mirrors the

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -251,12 +251,15 @@ await initializeDb();
 let eventIdCounter = 0;
 
 // The reporter consumes `UnreportedUsageEvent` (UsageEvent + the
-// JOIN-computed fields `conversationType` and `turnIndex`). Build that
-// shape directly so the mock matches `queryUnreportedUsageEvents`'
-// return type exactly.
+// JOIN-computed fields `conversationType`, `turnIndex`,
+// `parentConversationId`, and `parentTurnIndex`). Build that shape
+// directly so the mock matches `queryUnreportedUsageEvents`' return type
+// exactly.
 type UnreportedUsageEventFixture = UsageEvent & {
   conversationType: string | null;
   turnIndex: number | null;
+  parentConversationId: string | null;
+  parentTurnIndex: number | null;
 };
 
 function makeUsageEvent(
@@ -285,6 +288,8 @@ function makeUsageEvent(
     assistantVersion: "test-app-version",
     conversationType: "standard",
     turnIndex: 1,
+    parentConversationId: null,
+    parentTurnIndex: null,
     llmCallCount: 1,
     ...overrides,
   };


### PR DESCRIPTION
## Summary
- Migration 342 adds `conversations.parent_conversation_id` (nullable, indexed, no FK), and subagent spawns now stamp their parent's conversation id on the child's `background` conversation row via `bootstrapConversation` → `createConversation`. The one spawn-time call covers regular subagents, fork subagents, and advisor consults.
- `queryUnreportedUsageEvents` now resolves two new JOIN-computed fields on `UnreportedUsageEvent`: `parentConversationId` (`COALESCE(parent_conversation_id, fork_parent_conversation_id)`, which also links memory-retrospective forks) and `parentTurnIndex` (the parent conversation's real user turn in flight when the child conversation was created).
- This is Stage A of a two-stage plan and is intentionally inert on the wire: the fields are computed at flush time but not yet emitted on `llm_usage`. Stage B adds them to the telemetry event once the platform serializer + wire-sync PR land (the `_llmUsageKeysExist` drift guard enforces that ordering).

## Original prompt
Execute Stage A of the plan in `~/.claude/plans/compressed-chasing-sky.md`: parent-conversation attribution for subagent LLM usage in this repo. Subagent LLM calls are the single largest unattributable cost in warehouse turn analysis because their background conversations carry no parent linkage. The plan persists the parent id on the subagent's `conversations` row at spawn (a durable column, chosen over the reapable `subagents` table), resolves parent id + parent turn index at telemetry flush time, and defers wire emission to Stage B pending the platform wire-contract sync.