### PR TITLE
fix(voice-room): hold the spoken-word cursor through queue underruns and audio-less responses

### DIFF
--- a/clients/web/src/domains/chat/voice/raf.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/raf.test-helper.ts
@@ -1,0 +1,69 @@
+/**
+ * Manual `requestAnimationFrame` pump for tests of rAF-driven loops.
+ *
+ * `installRafTestHarness` swaps the global `requestAnimationFrame` /
+ * `cancelAnimationFrame` pair for an id-tracking capture so tests drive frames
+ * deterministically: `fireFrame` runs every pending callback once with a
+ * controlled timestamp, and callbacks that reschedule land in the next frame's
+ * batch. The harness also exposes the pending callbacks, the total number of
+ * frame requests, and the ids passed to cancel — enough to assert loop
+ * lifecycle (started, rescheduled, canceled on unmount).
+ *
+ * Install in `beforeEach` and call `restore` in `afterEach` to reinstate the
+ * real globals. Callers whose frame callbacks update React state wrap
+ * `fireFrame` in `act()` themselves — the harness stays render-library
+ * agnostic.
+ */
+
+export interface RafTestHarness {
+  /**
+   * Fire every currently pending callback once with the given timestamp
+   * (defaults to `performance.now()`).
+   */
+  fireFrame(timestamp?: number): void;
+  /** Callbacks scheduled but not yet fired or canceled. */
+  pendingCallbacks(): FrameRequestCallback[];
+  /** Total `requestAnimationFrame` calls since install. */
+  requestCount(): number;
+  /** Ids passed to `cancelAnimationFrame` since install. */
+  canceledIds(): readonly number[];
+  /** Reinstate the real `requestAnimationFrame` / `cancelAnimationFrame`. */
+  restore(): void;
+}
+
+export function installRafTestHarness(): RafTestHarness {
+  const callbacks = new Map<number, FrameRequestCallback>();
+  let nextId = 1;
+  let requests = 0;
+  const canceled: number[] = [];
+  const originalRaf = globalThis.requestAnimationFrame;
+  const originalCancelRaf = globalThis.cancelAnimationFrame;
+
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    requests += 1;
+    const id = nextId++;
+    callbacks.set(id, cb);
+    return id;
+  }) as typeof globalThis.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((id: number) => {
+    canceled.push(id);
+    callbacks.delete(id);
+  }) as typeof globalThis.cancelAnimationFrame;
+
+  return {
+    fireFrame(timestamp = performance.now()) {
+      const pending = [...callbacks.values()];
+      callbacks.clear();
+      for (const cb of pending) {
+        cb(timestamp);
+      }
+    },
+    pendingCallbacks: () => [...callbacks.values()],
+    requestCount: () => requests,
+    canceledIds: () => canceled,
+    restore() {
+      globalThis.requestAnimationFrame = originalRaf;
+      globalThis.cancelAnimationFrame = originalCancelRaf;
+    },
+  };
+}

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
@@ -1,11 +1,10 @@
 /**
  * Tests for `useSpokenWordCursor`.
  *
- * `requestAnimationFrame` is monkey-patched to capture callbacks so frames are
- * pumped manually inside `act()` (same harness as
- * `voice-timeline-waveform.test.tsx`). Playback progress is driven through the
- * real live-voice store by registering a provider that reads a mutable local
- * value; the store is reset between tests.
+ * Frames are driven manually through the shared rAF harness
+ * (`raf.test-helper.ts`), pumped inside `act()`. Playback progress is driven
+ * through the real live-voice store by registering a provider that reads a
+ * mutable local value; the store is reset between tests.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -14,48 +13,24 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 
 import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
 import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
+import {
+  installRafTestHarness,
+  type RafTestHarness,
+} from "@/domains/chat/voice/raf.test-helper";
 import { useSpokenWordCursor } from "@/domains/chat/voice/voice-room/use-spoken-word-cursor";
 
-// ---------------------------------------------------------------------------
-// requestAnimationFrame harness
-// ---------------------------------------------------------------------------
-
-let rafCallbacks: Map<number, FrameRequestCallback>;
-let nextRafId = 1;
-let originalRaf: typeof globalThis.requestAnimationFrame;
-let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
+let raf: RafTestHarness;
+let progress: LiveVoicePlaybackProgress | null;
 
 /** Fire every pending rAF callback once, inside `act()`. */
 function pumpFrame() {
   act(() => {
-    const callbacks = [...rafCallbacks.values()];
-    rafCallbacks.clear();
-    for (const cb of callbacks) {
-      cb(performance.now());
-    }
+    raf.fireFrame();
   });
 }
 
-// ---------------------------------------------------------------------------
-// Playback-progress fake
-// ---------------------------------------------------------------------------
-
-let progress: LiveVoicePlaybackProgress | null;
-
 beforeEach(() => {
-  rafCallbacks = new Map();
-  nextRafId = 1;
-  originalRaf = globalThis.requestAnimationFrame;
-  originalCancelRaf = globalThis.cancelAnimationFrame;
-  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
-    const id = nextRafId++;
-    rafCallbacks.set(id, cb);
-    return id;
-  }) as typeof globalThis.requestAnimationFrame;
-  globalThis.cancelAnimationFrame = ((id: number) => {
-    rafCallbacks.delete(id);
-  }) as typeof globalThis.cancelAnimationFrame;
-
+  raf = installRafTestHarness();
   progress = null;
   useLiveVoiceStore.getState().reset();
   useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
@@ -63,20 +38,15 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
-  globalThis.requestAnimationFrame = originalRaf;
-  globalThis.cancelAnimationFrame = originalCancelRaf;
+  raf.restore();
   useLiveVoiceStore.getState().reset();
 });
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe("useSpokenWordCursor — mapping", () => {
-  test("null progress maps to the first word", () => {
+  test("null progress yields a null cursor (caller keeps its default highlight)", () => {
     const { result } = renderHook(() => useSpokenWordCursor(10));
     pumpFrame();
-    expect(result.current).toBe(0);
+    expect(result.current).toBeNull();
   });
 
   test("fraction 0.5 over 10 words maps to index 5", () => {
@@ -86,18 +56,56 @@ describe("useSpokenWordCursor — mapping", () => {
     expect(result.current).toBe(5);
   });
 
-  test("fraction 1.0 clamps to the last word", () => {
-    progress = { playedSeconds: 10, totalSeconds: 10 };
-    const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
-    expect(result.current).toBe(9);
-  });
-
-  test("zero-duration progress holds the floor instead of dividing by zero", () => {
+  test("zero-duration progress is not usable audio and keeps the cursor null", () => {
     progress = { playedSeconds: 0, totalSeconds: 0 };
     const { result } = renderHook(() => useSpokenWordCursor(10));
     pumpFrame();
-    expect(result.current).toBe(0);
+    expect(result.current).toBeNull();
+  });
+});
+
+describe("useSpokenWordCursor — drained-queue hold", () => {
+  test("a caught-up queue (played == total) does not advance the cursor past its floor", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(20));
+    pumpFrame();
+    expect(result.current).toBe(10);
+
+    // Mid-response silence: the queue drains while the LLM text streams ahead.
+    progress = { playedSeconds: 10, totalSeconds: 10 };
+    pumpFrame();
+    pumpFrame();
+    expect(result.current).toBe(10);
+  });
+
+  test("text deltas growing wordCount while drained do not move the cursor", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => useSpokenWordCursor(count),
+      { initialProps: { count: 10 } },
+    );
+    pumpFrame();
+    expect(result.current).toBe(5);
+
+    progress = { playedSeconds: 10, totalSeconds: 10 };
+    rerender({ count: 20 });
+    pumpFrame();
+    expect(result.current).toBe(5);
+
+    rerender({ count: 30 });
+    pumpFrame();
+    expect(result.current).toBe(5);
+  });
+
+  test("the cursor reaches the last word during final-buffer playback and holds after the drain", () => {
+    progress = { playedSeconds: 9.9, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(9);
+
+    progress = { playedSeconds: 10, totalSeconds: 10 };
+    pumpFrame();
+    expect(result.current).toBe(9);
   });
 });
 
@@ -127,8 +135,20 @@ describe("useSpokenWordCursor — monotonicity", () => {
   });
 });
 
+describe("useSpokenWordCursor — audio-less responses", () => {
+  test("the cursor takes over once the response's first progress arrives", () => {
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBeNull();
+
+    progress = { playedSeconds: 4, totalSeconds: 10 };
+    pumpFrame();
+    expect(result.current).toBe(4);
+  });
+});
+
 describe("useSpokenWordCursor — per-response reset", () => {
-  test("shrinking wordCount resets the floor and the cursor restarts at 0", () => {
+  test("shrinking wordCount resets the cursor to null until the new response's audio starts", () => {
     progress = { playedSeconds: 8, totalSeconds: 10 };
     const { result, rerender } = renderHook(
       ({ count }: { count: number }) => useSpokenWordCursor(count),
@@ -140,7 +160,8 @@ describe("useSpokenWordCursor — per-response reset", () => {
     // New response: the transcript clears (shorter word list), progress resets.
     progress = null;
     rerender({ count: 3 });
-    expect(result.current).toBe(0);
+    pumpFrame();
+    expect(result.current).toBeNull();
 
     progress = { playedSeconds: 1, totalSeconds: 3 };
     pumpFrame();
@@ -188,13 +209,13 @@ describe("useSpokenWordCursor — render economy and lifecycle", () => {
 
   test("wordCount 0 schedules no frames", () => {
     renderHook(() => useSpokenWordCursor(0));
-    expect(rafCallbacks.size).toBe(0);
+    expect(raf.pendingCallbacks()).toHaveLength(0);
   });
 
   test("unmount cancels the pending frame", () => {
     const { unmount } = renderHook(() => useSpokenWordCursor(10));
-    expect(rafCallbacks.size).toBe(1);
+    expect(raf.pendingCallbacks()).toHaveLength(1);
     unmount();
-    expect(rafCallbacks.size).toBe(0);
+    expect(raf.pendingCallbacks()).toHaveLength(0);
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -9,6 +9,21 @@
  * word. The mapping assumes words take roughly equal speaking time — close
  * enough for a caption highlight.
  *
+ * The cursor advances only while audio remains scheduled
+ * (`playedSeconds < totalSeconds`). When the queue is caught up
+ * (played == total — a mid-response silence while synthesis lags the streamed
+ * text, or the post-response drain) the drained fraction of 1.0 says nothing
+ * about displayed words that have no synthesized audio yet, so the cursor
+ * holds at the last spoken word; the next audio burst grows the total and the
+ * cursor advances again. End-of-response landing: the fraction sweeps toward 1
+ * during the final buffer's playback, carrying the cursor onto the last word
+ * before the drain.
+ *
+ * Until the current response schedules audio the hook returns `null`, letting
+ * the caller keep its default highlight — a response that produces no TTS
+ * audio at all (text streaming through a TTS failure) is not pinned to the
+ * first word.
+ *
  * Accepted bias: scheduled audio corresponds to *synthesized* text, which can
  * lag the displayed LLM text mid-stream, so the fraction maps a shorter spoken
  * prefix onto the longer displayed transcript and can overshoot the truly
@@ -18,9 +33,10 @@
  * The cursor is monotonic within a response: a smaller fraction (e.g. the
  * played/total ratio dipping when a new audio burst grows the total) never
  * moves it backward, and a `null` progress read (barge-in flush clearing the
- * player) freezes it where speech stopped. The floor resets when `wordCount`
- * shrinks below its previous value — the transcript cleared for a new
- * response — so each response starts at the first word.
+ * player) freezes it where speech stopped. The cursor resets to `null` when
+ * `wordCount` shrinks below its previous value — the transcript cleared for a
+ * new response — so each response starts on the caller's default highlight
+ * until its own audio arrives.
  *
  * State updates land only when the mapped index changes, so the poll runs at
  * frame rate but the subscriber re-renders at word granularity. Reduced
@@ -35,23 +51,25 @@ import { getLiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/li
 
 /**
  * Index (into the caller's word segmentation) of the word the TTS playhead is
- * speaking. Returns 0 while no audio progress exists. `wordCount` of 0 idles
- * the loop entirely (the assistant caption unmounts on an empty transcript).
+ * speaking, or `null` while the current response has produced no audio (the
+ * caller keeps its default highlight). `wordCount` of 0 idles the loop
+ * entirely (the assistant caption unmounts on an empty transcript).
  */
-export function useSpokenWordCursor(wordCount: number): number {
-  const [index, setIndex] = useState(0);
-  // Monotonic floor for the current response; always equals the last returned
-  // index, so the loop skips the state write when the index is unchanged.
-  const floorRef = useRef(0);
+export function useSpokenWordCursor(wordCount: number): number | null {
+  const [index, setIndex] = useState<number | null>(null);
+  // Single source of truth for the cursor between renders: always equals the
+  // last returned value, serving as both the monotonic floor and the guard
+  // that skips the state write when a frame leaves the index unchanged.
+  const cursorRef = useRef<number | null>(null);
   const prevCountRef = useRef(wordCount);
 
   // Declared before the loop effect so a shrink (transcript cleared for a new
-  // response) zeroes the floor before the restarted loop reads it. Synced in
+  // response) clears the cursor before the restarted loop reads it. Synced in
   // an effect, not during render (no render-phase ref writes).
   useEffect(() => {
     if (wordCount < prevCountRef.current) {
-      floorRef.current = 0;
-      setIndex(0);
+      cursorRef.current = null;
+      setIndex(null);
     }
     prevCountRef.current = wordCount;
   }, [wordCount]);
@@ -62,21 +80,28 @@ export function useSpokenWordCursor(wordCount: number): number {
     }
     let raf = 0;
     const tick = () => {
+      // `null` progress → hold: `null` for a fresh response, or frozen where
+      // speech stopped after a barge-in flush.
+      let next = cursorRef.current;
       const progress = getLiveVoicePlaybackProgress();
-      // `null` progress → hold the floor: 0 for a fresh response, or frozen
-      // where speech stopped after a barge-in flush.
-      let candidate = floorRef.current;
       if (progress !== null && progress.totalSeconds > 0) {
-        const mapped = Math.floor(
-          (progress.playedSeconds / progress.totalSeconds) * wordCount,
-        );
-        if (Number.isFinite(mapped)) {
-          candidate = Math.min(mapped, wordCount - 1);
+        // Audio exists for this response, so the cursor is numeric from here:
+        // at least the floor (0 for a fresh response), advancing only while
+        // audio remains scheduled — a caught-up queue (played == total) holds
+        // rather than mapping the drained fraction onto unspoken words.
+        const floor = cursorRef.current ?? 0;
+        next = floor;
+        if (progress.playedSeconds < progress.totalSeconds) {
+          const mapped = Math.floor(
+            (progress.playedSeconds / progress.totalSeconds) * wordCount,
+          );
+          if (Number.isFinite(mapped)) {
+            next = Math.max(Math.min(mapped, wordCount - 1), floor);
+          }
         }
       }
-      const next = Math.max(candidate, floorRef.current);
-      if (next !== floorRef.current) {
-        floorRef.current = next;
+      if (next !== cursorRef.current) {
+        cursorRef.current = next;
         setIndex(next);
       }
       raf = requestAnimationFrame(tick);

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
@@ -7,10 +7,9 @@
  * toggles via the voice-prefs store. The load-bearing contract is the
  * pref-gating — both prefs default OFF, so the room stays text-free — plus the
  * user-before-assistant DOM ordering. The spoken-word cursor block additionally
- * stubs `requestAnimationFrame` with a manual pump (same harness as
- * `use-spoken-word-cursor.test.tsx`) and drives playback progress through the
- * store's provider, asserting the leading tone via the `data-leading`
- * attribute on word spans.
+ * drives frames through the shared rAF harness (`raf.test-helper.ts`) and
+ * playback progress through the store's provider, asserting the leading tone
+ * via the `data-leading` attribute on word spans.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -22,6 +21,10 @@ import {
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
+import {
+  installRafTestHarness,
+  type RafTestHarness,
+} from "@/domains/chat/voice/raf.test-helper";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 import { VoiceAmbientTranscript } from "@/domains/chat/voice/voice-room/voice-ambient-transcript";
@@ -192,20 +195,13 @@ describe("VoiceAmbientTranscript — sourcing and ordering", () => {
 });
 
 describe("VoiceAmbientTranscript — spoken-word cursor", () => {
-  let rafCallbacks: Map<number, FrameRequestCallback>;
-  let nextRafId: number;
-  let originalRaf: typeof globalThis.requestAnimationFrame;
-  let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
+  let raf: RafTestHarness;
   let progress: LiveVoicePlaybackProgress | null;
 
   /** Fire every pending rAF callback once, inside `act()`. */
   function pumpFrame() {
     act(() => {
-      const callbacks = [...rafCallbacks.values()];
-      rafCallbacks.clear();
-      for (const cb of callbacks) {
-        cb(performance.now());
-      }
+      raf.fireFrame();
     });
   }
 
@@ -214,33 +210,25 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
     return half.querySelector("[data-leading]")?.textContent;
   }
 
+  function registerProgressProvider() {
+    act(() => {
+      useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
+    });
+  }
+
   beforeEach(() => {
-    rafCallbacks = new Map();
-    nextRafId = 1;
-    originalRaf = globalThis.requestAnimationFrame;
-    originalCancelRaf = globalThis.cancelAnimationFrame;
-    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
-      const id = nextRafId++;
-      rafCallbacks.set(id, cb);
-      return id;
-    }) as typeof globalThis.requestAnimationFrame;
-    globalThis.cancelAnimationFrame = ((id: number) => {
-      rafCallbacks.delete(id);
-    }) as typeof globalThis.cancelAnimationFrame;
+    raf = installRafTestHarness();
     progress = null;
   });
 
   afterEach(() => {
     cleanup();
-    globalThis.requestAnimationFrame = originalRaf;
-    globalThis.cancelAnimationFrame = originalCancelRaf;
+    raf.restore();
   });
 
   test("highlight sits on the mid-transcript word at playback fraction 0.5", () => {
     progress = { playedSeconds: 5, totalSeconds: 10 };
-    act(() => {
-      useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
-    });
+    registerProgressProvider();
     seedAssistant("alpha beta gamma delta");
     setPrefs({ user: false, assistant: true });
     render(<VoiceAmbientTranscript />);
@@ -249,19 +237,52 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
     expect(leadingWordIn(assistantText()!)).toBe("gamma");
   });
 
-  test("no registered provider keeps the highlight on the first word", () => {
+  test("no registered provider keeps the default last-word leading edge", () => {
     seedAssistant("alpha beta gamma delta");
     setPrefs({ user: false, assistant: true });
     render(<VoiceAmbientTranscript />);
     pumpFrame();
-    expect(leadingWordIn(assistantText()!)).toBe("alpha");
+    expect(leadingWordIn(assistantText()!)).toBe("delta");
+  });
+
+  test("cursor takes over from the default reveal once playback progress arrives", () => {
+    registerProgressProvider();
+    seedAssistant("alpha beta gamma delta");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    pumpFrame();
+    // No audio yet: default reveal, the newest word leads.
+    expect(leadingWordIn(assistantText()!)).toBe("delta");
+
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    pumpFrame();
+    expect(leadingWordIn(assistantText()!)).toBe("gamma");
+  });
+
+  test("new response reverts to the default reveal until its own audio starts", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    registerProgressProvider();
+    seedAssistant("alpha beta gamma delta");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    pumpFrame();
+    expect(leadingWordIn(assistantText()!)).toBe("gamma");
+
+    // Next response: the transcript clears (shorter word list), no audio yet.
+    progress = null;
+    seedAssistant("fresh words");
+    pumpFrame();
+    expect(leadingWordIn(assistantText()!)).toBe("words");
+
+    progress = { playedSeconds: 1, totalSeconds: 4 };
+    pumpFrame();
+    // floor(0.25 * 2 words) = index 0 — the cursor is live again.
+    expect(leadingWordIn(assistantText()!)).toBe("fresh");
   });
 
   test("user bubble keeps its default last-word leading edge", () => {
     progress = { playedSeconds: 5, totalSeconds: 10 };
-    act(() => {
-      useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
-    });
+    registerProgressProvider();
     seedUser("one two three four");
     setPrefs({ user: true, assistant: false });
     render(<VoiceAmbientTranscript />);

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -19,7 +19,10 @@
  * {@link VoiceTranscriptText}. The assistant half's bright leading-edge tone
  * tracks the TTS playhead — {@link useSpokenWordCursor} maps audio progress
  * onto the word list, so the highlight sits on the word being *spoken* rather
- * than the last-arrived one while the streamed text runs ahead of speech.
+ * than the last-arrived one while the streamed text runs ahead of speech. A
+ * `null` cursor (the response has produced no audio yet) falls back to the
+ * default last-word reveal, so an audio-less response keeps a live leading
+ * edge instead of a dead first-word highlight.
  *
  * Subscriptions are deliberately narrow — the three transcript fields, the two
  * prefs, and the low-frequency `state`/`reconnecting` (per-turn, for the
@@ -150,7 +153,7 @@ export function VoiceAmbientTranscript() {
                 <div className="max-w-[95%] break-words text-[clamp(15px,2vmin,19px)] leading-relaxed">
                   <VoiceTranscriptText
                     text={assistantTranscript}
-                    highlightIndex={spokenIndex}
+                    highlightIndex={spokenIndex ?? undefined}
                   />
                 </div>
               </motion.div>

--- a/clients/web/src/domains/chat/voice/voice-timeline-waveform.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-timeline-waveform.test.tsx
@@ -3,9 +3,8 @@
  *
  * happy-dom's `canvas.getContext("2d")` returns `null`, so a minimal fake 2D
  * context is installed on `HTMLCanvasElement.prototype` to let the draw loop
- * run. `requestAnimationFrame` is monkey-patched to capture callbacks so
- * frames are driven manually with controlled timestamps (same approach as the
- * `setTimeout` harness in `website-carousel.test.tsx`).
+ * run. Frames are driven manually with controlled timestamps through the
+ * shared rAF harness (`raf.test-helper.ts`).
  *
  * The reduced-motion branch is verified by stubbing `motion/react` so
  * `useReducedMotion()` returns `true` and asserting the animation loop never
@@ -17,27 +16,13 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, render } from "@testing-library/react";
 
+import {
+  installRafTestHarness,
+  type RafTestHarness,
+} from "@/domains/chat/voice/raf.test-helper";
 import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-waveform";
 
-// ---------------------------------------------------------------------------
-// requestAnimationFrame harness
-// ---------------------------------------------------------------------------
-
-let rafCallbacks: Map<number, FrameRequestCallback>;
-let nextRafId = 1;
-let rafCallCount = 0;
-let canceledRafIds: number[];
-let originalRaf: typeof globalThis.requestAnimationFrame;
-let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
-
-/** Fire every pending rAF callback once with the given timestamp. */
-function fireFrame(ts: number) {
-  const callbacks = [...rafCallbacks.values()];
-  rafCallbacks.clear();
-  for (const cb of callbacks) {
-    cb(ts);
-  }
-}
+let raf: RafTestHarness;
 
 // ---------------------------------------------------------------------------
 // Fake 2D context — happy-dom has no canvas implementation.
@@ -58,22 +43,7 @@ let fakeCtx: ReturnType<typeof makeFakeContext>;
 let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
 
 beforeEach(() => {
-  rafCallbacks = new Map();
-  nextRafId = 1;
-  rafCallCount = 0;
-  canceledRafIds = [];
-  originalRaf = globalThis.requestAnimationFrame;
-  originalCancelRaf = globalThis.cancelAnimationFrame;
-  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
-    rafCallCount += 1;
-    const id = nextRafId++;
-    rafCallbacks.set(id, cb);
-    return id;
-  }) as typeof globalThis.requestAnimationFrame;
-  globalThis.cancelAnimationFrame = ((id: number) => {
-    canceledRafIds.push(id);
-    rafCallbacks.delete(id);
-  }) as typeof globalThis.cancelAnimationFrame;
+  raf = installRafTestHarness();
 
   fakeCtx = makeFakeContext();
   originalGetContext = HTMLCanvasElement.prototype.getContext;
@@ -82,8 +52,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  globalThis.requestAnimationFrame = originalRaf;
-  globalThis.cancelAnimationFrame = originalCancelRaf;
+  raf.restore();
   HTMLCanvasElement.prototype.getContext = originalGetContext;
   cleanup();
 });
@@ -129,26 +98,26 @@ describe("VoiceTimelineWaveform — rendering", () => {
 describe("VoiceTimelineWaveform — animation loop", () => {
   test("starts the rAF loop and reschedules each frame", () => {
     render(<VoiceTimelineWaveform active getAmplitude={() => 0.5} />);
-    expect(rafCallCount).toBe(1);
-    fireFrame(100);
-    expect(rafCallCount).toBe(2);
-    fireFrame(200);
-    expect(rafCallCount).toBe(3);
+    expect(raf.requestCount()).toBe(1);
+    raf.fireFrame(100);
+    expect(raf.requestCount()).toBe(2);
+    raf.fireFrame(200);
+    expect(raf.requestCount()).toBe(3);
   });
 
   test("polls getAmplitude while active", () => {
     const getAmplitude = mock(() => 0.5);
     render(<VoiceTimelineWaveform active getAmplitude={getAmplitude} />);
-    fireFrame(100);
-    fireFrame(200);
+    raf.fireFrame(100);
+    raf.fireFrame(200);
     expect(getAmplitude.mock.calls.length).toBe(2);
   });
 
   test("stops sampling (but keeps drawing) when not active", () => {
     const getAmplitude = mock(() => 0.5);
     render(<VoiceTimelineWaveform active={false} getAmplitude={getAmplitude} />);
-    fireFrame(100);
-    fireFrame(200);
+    raf.fireFrame(100);
+    raf.fireFrame(200);
     expect(getAmplitude.mock.calls.length).toBe(0);
     expect(fakeCtx.clearRect.mock.calls.length).toBe(2);
   });
@@ -157,11 +126,11 @@ describe("VoiceTimelineWaveform — animation loop", () => {
     const { unmount } = render(<VoiceTimelineWaveform active getAmplitude={() => 0.5} />);
     // Capture the pending callback before unmount cancels it, simulating a
     // frame already dispatched when cleanup runs.
-    const pending = [...rafCallbacks.values()];
+    const pending = raf.pendingCallbacks();
     expect(pending).toHaveLength(1);
     unmount();
-    expect(canceledRafIds).toHaveLength(1);
-    expect(rafCallbacks.size).toBe(0);
+    expect(raf.canceledIds()).toHaveLength(1);
+    expect(raf.pendingCallbacks()).toHaveLength(0);
     expect(() => pending[0]!(300)).not.toThrow();
   });
 
@@ -171,7 +140,7 @@ describe("VoiceTimelineWaveform — animation loop", () => {
     const { unmount } = render(
       <VoiceTimelineWaveform active getAmplitude={() => 0} />,
     );
-    expect(rafCallCount).toBe(0);
+    expect(raf.requestCount()).toBe(0);
     expect(() => unmount()).not.toThrow();
   });
 });
@@ -199,7 +168,7 @@ describe("VoiceTimelineWaveform — reduced motion", () => {
 
     expect(container.querySelector("canvas")).toBeTruthy();
     // No animation loop — the static branch draws once, synchronously.
-    expect(rafCallCount).toBe(0);
+    expect(raf.requestCount()).toBe(0);
     expect(fakeCtx.clearRect.mock.calls.length).toBe(1);
     expect(() => unmount()).not.toThrow();
   });


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for voice-room-spoken-word-cursor.md.

- A drained TTS queue reads as fraction 1.0; the cursor advances only while audio remains scheduled, so mid-response underruns hold at the last spoken word instead of ratcheting onto newly streamed text
- The cursor is null until a response produces audio; audio-less captions keep the default last-word reveal instead of a dead word-0 highlight
- The rAF pump test harness is extracted to a shared raf.test-helper.ts (three duplicate copies migrated)