### PR TITLE
feat(web): plan-aware downgrade/current CTAs in the plans takeover for Pro users

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plans-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/plans-copy.ts
@@ -54,3 +54,8 @@ export const PLAN_TIER_COPY: Record<PlanTierKey, PlanTierCopy> = {
 export function getPlanTierCopy(key: string): PlanTierCopy | undefined {
   return PLAN_TIER_COPY[key as PlanTierKey];
 }
+
+/** CTA label for a tier that sits below the user's current tier. */
+export function downgradeLabel(name: string): string {
+  return `Downgrade to ${name}`;
+}

--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -235,8 +235,9 @@ describe("PlansPage checkout — base subscriber", () => {
 });
 
 describe("PlansPage checkout — Pro subscriber", () => {
-  // Below Mighty, Free reads "Downgrade to Free"; the downgrade CTA still
-  // routes to the manage modal and fires no checkout (dispatch unchanged).
+  // Below Mighty, Free reads "Downgrade to Free". For a Pro subscriber the
+  // tier CTA routes to the manage-plan flow via `?adjust_plan` and fires no
+  // checkout.
   test("routes a downgrade CTA to the manage modal instead of a checkout", async () => {
     const { getByRole, getByTestId } = renderPage(proMightySubscription());
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -235,10 +235,12 @@ describe("PlansPage checkout — base subscriber", () => {
 });
 
 describe("PlansPage checkout — Pro subscriber", () => {
-  test("routes to the manage modal instead of a package checkout", async () => {
+  // Below Mighty, Free reads "Downgrade to Free"; the downgrade CTA still
+  // routes to the manage modal and fires no checkout (dispatch unchanged).
+  test("routes a downgrade CTA to the manage modal instead of a checkout", async () => {
     const { getByRole, getByTestId } = renderPage(proMightySubscription());
 
-    fireEvent.click(getByRole("button", { name: "Go Super" }));
+    fireEvent.click(getByRole("button", { name: "Downgrade to Free" }));
 
     await waitFor(() => {
       expect(getByTestId("loc").textContent).toBe(

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -230,12 +230,16 @@ describe("PlansPage — current-plan state", () => {
     expect(count(html, /disabled=""/g)).toBe(1);
   });
 
-  test("pro subscriber on Mighty: Mighty is current, Free reverts to Start Free", () => {
+  test("pro subscriber on Mighty: Mighty is current, lower tiers downgrade, higher tiers upgrade", () => {
     const html = renderPage(proMightySubscription(), fullCatalog());
     // Only the Mighty column is the current plan.
     expect(count(html, /Current Plan/g)).toBe(1);
-    // Free is no longer current, so it shows its own CTA again.
-    expect(html).toContain("Start Free");
+    // Free sits below Mighty, so its CTA becomes a downgrade.
+    expect(html).toContain("Downgrade to Free");
+    expect(html).not.toContain("Start Free");
+    // Super and Ultra sit above Mighty, so they keep their upgrade CTAs.
+    expect(html).toContain("Go Super");
+    expect(html).toContain("Unleash Ultra");
     expect(count(html, /disabled=""/g)).toBe(1);
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -7,6 +7,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   PACKAGE_ORDER,
   type ProPackage,
+  tierRelation,
 } from "@/domains/settings/billing/package-types";
 import { FREE_STORAGE_GIB } from "@/domains/settings/billing/plan-tier-meta";
 import {
@@ -15,7 +16,10 @@ import {
 } from "@/domains/settings/billing/plans/custom-plan-modal";
 import { CustomPlanRow } from "@/domains/settings/billing/plans/custom-plan-row";
 import { PlanColumnCard } from "@/domains/settings/billing/plans/plan-column-card";
-import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
+import {
+  downgradeLabel,
+  getPlanTierCopy,
+} from "@/domains/settings/billing/plans/plans-copy";
 import { extractMutationError } from "@/domains/settings/components/adjust-plan-utils";
 import { formatDollars } from "@/domains/settings/components/tier-pricing";
 import {
@@ -242,6 +246,7 @@ export function PlansPage() {
         PACKAGE_ORDER.indexOf(b.key as (typeof PACKAGE_ORDER)[number]),
     );
     const freeCopy = getPlanTierCopy("free");
+    const freeRelation = tierRelation(currentTierKey, "free");
 
     body = (
       <div className="my-auto flex w-full flex-col items-center">
@@ -273,15 +278,21 @@ export function PlansPage() {
             tagline={freeCopy?.tagline ?? ""}
             priceLabel="$0/month"
             priceCaption={freeCopy?.priceCaption ?? "Forever"}
-            ctaLabel={freeCopy?.cta ?? "Start Free"}
+            ctaLabel={
+              freeRelation === "downgrade"
+                ? downgradeLabel("Free")
+                : (freeCopy?.cta ?? "Start Free")
+            }
             features={FREE_FEATURES}
             tone="dark"
             isCurrent={currentTierKey === "free"}
+            intent={freeRelation}
             pending={pending}
             onCta={() => selectTier("free")}
           />
           {orderedPackages.map((pkg) => {
             const copy = getPlanTierCopy(pkg.key);
+            const relation = tierRelation(currentTierKey, pkg.key);
             return (
               <PlanColumnCard
                 key={pkg.key}
@@ -290,11 +301,16 @@ export function PlansPage() {
                 tagline={copy?.tagline ?? ""}
                 priceLabel={priceLabelFromCents(pkg.total_price_cents)}
                 priceCaption={copy?.priceCaption ?? "Billed monthly"}
-                ctaLabel={copy?.cta ?? pkg.name}
+                ctaLabel={
+                  relation === "downgrade"
+                    ? downgradeLabel(pkg.name)
+                    : (copy?.cta ?? pkg.name)
+                }
                 features={packageFeatures(pkg, copy?.extraFeatures ?? [])}
                 mostPopular={copy?.mostPopular}
                 tone={copy?.mostPopular ? "light" : "dark"}
                 isCurrent={currentTierKey === pkg.key}
+                intent={relation}
                 pending={pending}
                 onCta={() => selectTier(pkg.key)}
               />


### PR DESCRIPTION
## Summary
- The plans takeover is now plan-aware for Pro users: current tier marked Current Plan, lower tiers labeled Downgrade to {name} (outlined). Dispatch unchanged — Pro CTAs still route to the existing manage flow.

Part of plan: pro-manage-downgrade-loading.md (PR 5 of 6)