### PR TITLE
fix(voice-room): keep the spoken-word cursor honest at drain boundaries and idle when captions are off

### DIFF
--- a/clients/web/src/domains/chat/voice/raf.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/raf.test-helper.ts
@@ -10,10 +10,12 @@
  * lifecycle (started, rescheduled, canceled on unmount).
  *
  * Install in `beforeEach` and call `restore` in `afterEach` to reinstate the
- * real globals. Callers whose frame callbacks update React state wrap
- * `fireFrame` in `act()` themselves — the harness stays render-library
- * agnostic.
+ * real globals. Callers whose frame callbacks update React state pump through
+ * `pumpFrame`, which wraps `fireFrame` in `act()`; `fireFrame` stays raw for
+ * loops with no React state involved (canvas draw loops).
  */
+
+import { act } from "@testing-library/react";
 
 export interface RafTestHarness {
   /**
@@ -21,6 +23,8 @@ export interface RafTestHarness {
    * (defaults to `performance.now()`).
    */
   fireFrame(timestamp?: number): void;
+  /** `fireFrame` wrapped in `act()`, for callbacks that update React state. */
+  pumpFrame(timestamp?: number): void;
   /** Callbacks scheduled but not yet fired or canceled. */
   pendingCallbacks(): FrameRequestCallback[];
   /** Total `requestAnimationFrame` calls since install. */
@@ -50,13 +54,20 @@ export function installRafTestHarness(): RafTestHarness {
     callbacks.delete(id);
   }) as typeof globalThis.cancelAnimationFrame;
 
+  const fireFrame = (timestamp = performance.now()) => {
+    const pending = [...callbacks.values()];
+    callbacks.clear();
+    for (const cb of pending) {
+      cb(timestamp);
+    }
+  };
+
   return {
-    fireFrame(timestamp = performance.now()) {
-      const pending = [...callbacks.values()];
-      callbacks.clear();
-      for (const cb of pending) {
-        cb(timestamp);
-      }
+    fireFrame,
+    pumpFrame(timestamp?: number) {
+      act(() => {
+        fireFrame(timestamp);
+      });
     },
     pendingCallbacks: () => [...callbacks.values()],
     requestCount: () => requests,

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
@@ -2,14 +2,14 @@
  * Tests for `useSpokenWordCursor`.
  *
  * Frames are driven manually through the shared rAF harness
- * (`raf.test-helper.ts`), pumped inside `act()`. Playback progress is driven
- * through the real live-voice store by registering a provider that reads a
- * mutable local value; the store is reset between tests.
+ * (`raf.test-helper.ts`) via its act-aware `pumpFrame`. Playback progress is
+ * driven through the real live-voice store by registering a provider that
+ * reads a mutable local value; the store is reset between tests.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { cleanup, renderHook } from "@testing-library/react";
 
 import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
 import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
@@ -21,13 +21,6 @@ import { useSpokenWordCursor } from "@/domains/chat/voice/voice-room/use-spoken-
 
 let raf: RafTestHarness;
 let progress: LiveVoicePlaybackProgress | null;
-
-/** Fire every pending rAF callback once, inside `act()`. */
-function pumpFrame() {
-  act(() => {
-    raf.fireFrame();
-  });
-}
 
 beforeEach(() => {
   raf = installRafTestHarness();
@@ -45,21 +38,21 @@ afterEach(() => {
 describe("useSpokenWordCursor — mapping", () => {
   test("null progress yields a null cursor (caller keeps its default highlight)", () => {
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBeNull();
   });
 
   test("fraction 0.5 over 10 words maps to index 5", () => {
     progress = { playedSeconds: 5, totalSeconds: 10 };
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
   });
 
   test("zero-duration progress is not usable audio and keeps the cursor null", () => {
     progress = { playedSeconds: 0, totalSeconds: 0 };
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBeNull();
   });
 });
@@ -68,13 +61,13 @@ describe("useSpokenWordCursor — drained-queue hold", () => {
   test("a caught-up queue (played == total) does not advance the cursor past its floor", () => {
     progress = { playedSeconds: 5, totalSeconds: 10 };
     const { result } = renderHook(() => useSpokenWordCursor(20));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(10);
 
     // Mid-response silence: the queue drains while the LLM text streams ahead.
     progress = { playedSeconds: 10, totalSeconds: 10 };
-    pumpFrame();
-    pumpFrame();
+    raf.pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(10);
   });
 
@@ -84,27 +77,50 @@ describe("useSpokenWordCursor — drained-queue hold", () => {
       ({ count }: { count: number }) => useSpokenWordCursor(count),
       { initialProps: { count: 10 } },
     );
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
 
     progress = { playedSeconds: 10, totalSeconds: 10 };
     rerender({ count: 20 });
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
 
     rerender({ count: 30 });
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
+  });
+
+  test("a first read that is already drained keeps the cursor null", () => {
+    // The audio finished before the loop ever observed a sub-total frame
+    // (short response under a throttled or busy main thread): the caller
+    // keeps its default highlight instead of a pinned early word.
+    progress = { playedSeconds: 10, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    raf.pumpFrame();
+    raf.pumpFrame();
+    expect(result.current).toBeNull();
+  });
+
+  test("adoption happens on the first frame with audio still scheduled", () => {
+    progress = { playedSeconds: 10, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    raf.pumpFrame();
+    expect(result.current).toBeNull();
+
+    // A new audio burst grows the total: audio is scheduled again.
+    progress = { playedSeconds: 10, totalSeconds: 12 };
+    raf.pumpFrame();
+    expect(result.current).toBe(8);
   });
 
   test("the cursor reaches the last word during final-buffer playback and holds after the drain", () => {
     progress = { playedSeconds: 9.9, totalSeconds: 10 };
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(9);
 
     progress = { playedSeconds: 10, totalSeconds: 10 };
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(9);
   });
 });
@@ -113,36 +129,80 @@ describe("useSpokenWordCursor — monotonicity", () => {
   test("a smaller fraction does not move the cursor backward", () => {
     progress = { playedSeconds: 5, totalSeconds: 10 };
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
 
     // Total grows faster than played (a new audio burst), dipping the ratio.
     progress = { playedSeconds: 6, totalSeconds: 20 };
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
   });
 
   test("progress flipping to null (barge-in flush) freezes the cursor", () => {
     progress = { playedSeconds: 5, totalSeconds: 10 };
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
 
     progress = null;
-    pumpFrame();
-    pumpFrame();
+    raf.pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
+  });
+});
+
+describe("useSpokenWordCursor — rate cap", () => {
+  test("a mapped candidate sweeping far ahead advances only by the played-audio budget", () => {
+    progress = { playedSeconds: 1, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(50));
+    raf.pumpFrame();
+    // Adoption: floor(0.1 * 50) = 5.
+    expect(result.current).toBe(5);
+
+    // Near-underrun: played approaches total, so the fraction sweeps toward 1
+    // and the candidate lands near the end of the transcript
+    // (floor((1.5 / 1.6) * 50) = 46) while only 0.5s of audio actually
+    // played. Budget = 0.5 * 5 words/sec = 2 whole words.
+    progress = { playedSeconds: 1.5, totalSeconds: 1.6 };
+    raf.pumpFrame();
+    expect(result.current).toBe(7);
+  });
+
+  test("a normal speaking cadence is never rate-limited", () => {
+    // ~1 word per 0.4s of played audio (2.5 words/sec), under the cap.
+    progress = { playedSeconds: 0.4, totalSeconds: 4 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    raf.pumpFrame();
+    expect(result.current).toBe(1);
+
+    for (let step = 2; step <= 9; step += 1) {
+      progress = { playedSeconds: 0.4 * step, totalSeconds: 4 };
+      raf.pumpFrame();
+      expect(result.current).toBe(step);
+    }
+  });
+
+  test("the adoption jump is uncapped", () => {
+    const { result } = renderHook(() => useSpokenWordCursor(40));
+    raf.pumpFrame();
+    expect(result.current).toBeNull();
+
+    // Mid-response mount: the first usable frame syncs straight to the
+    // playhead, floor(0.8 * 40) = 32, with no budget accrued yet.
+    progress = { playedSeconds: 8, totalSeconds: 10 };
+    raf.pumpFrame();
+    expect(result.current).toBe(32);
   });
 });
 
 describe("useSpokenWordCursor — audio-less responses", () => {
   test("the cursor takes over once the response's first progress arrives", () => {
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBeNull();
 
     progress = { playedSeconds: 4, totalSeconds: 10 };
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(4);
   });
 });
@@ -154,17 +214,17 @@ describe("useSpokenWordCursor — per-response reset", () => {
       ({ count }: { count: number }) => useSpokenWordCursor(count),
       { initialProps: { count: 10 } },
     );
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(8);
 
     // New response: the transcript clears (shorter word list), progress resets.
     progress = null;
     rerender({ count: 3 });
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBeNull();
 
     progress = { playedSeconds: 1, totalSeconds: 3 };
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(1);
   });
 
@@ -174,12 +234,12 @@ describe("useSpokenWordCursor — per-response reset", () => {
       ({ count }: { count: number }) => useSpokenWordCursor(count),
       { initialProps: { count: 10 } },
     );
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
 
     progress = null;
     rerender({ count: 12 });
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
   });
 });
@@ -192,17 +252,17 @@ describe("useSpokenWordCursor — render economy and lifecycle", () => {
       renders += 1;
       return useSpokenWordCursor(10);
     });
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
     const rendersAfterFirstIndex = renders;
 
-    pumpFrame();
-    pumpFrame();
-    pumpFrame();
+    raf.pumpFrame();
+    raf.pumpFrame();
+    raf.pumpFrame();
     expect(renders).toBe(rendersAfterFirstIndex);
 
     progress = { playedSeconds: 6, totalSeconds: 10 };
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(6);
     expect(renders).toBe(rendersAfterFirstIndex + 1);
   });

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -19,16 +19,25 @@
  * during the final buffer's playback, carrying the cursor onto the last word
  * before the drain.
  *
- * Until the current response schedules audio the hook returns `null`, letting
- * the caller keep its default highlight — a response that produces no TTS
- * audio at all (text streaming through a TTS failure) is not pinned to the
- * first word.
+ * Until the loop observes audio still scheduled the hook returns `null`,
+ * letting the caller keep its default highlight. Adoption (the `null` →
+ * numeric transition) requires a frame with `playedSeconds < totalSeconds`: a
+ * first read that is already drained keeps the `null` cursor, so a response
+ * whose audio finished before the loop ever saw it (a short ack under a
+ * throttled or busy main thread) — like one that produces no TTS audio at all
+ * — is not pinned to an early word.
  *
- * Accepted bias: scheduled audio corresponds to *synthesized* text, which can
- * lag the displayed LLM text mid-stream, so the fraction maps a shorter spoken
- * prefix onto the longer displayed transcript and can overshoot the truly
- * spoken word slightly. The error is bounded by the synthesis lag and
- * self-corrects as synthesis catches up.
+ * Advancement is rate-capped to a plausible speaking cadence. Each frame
+ * accrues a fractional word budget from the played-audio delta
+ * ({@link MAX_CURSOR_WORDS_PER_SECOND}), and the cursor moves at most the
+ * accrued whole words past its current position, consuming the budget it uses.
+ * While displayed text leads synthesis the mapped fraction can sweep far ahead
+ * of real speech (approaching an underrun it lands near the end of the
+ * displayed transcript); the cap keeps the highlight near the truly spoken
+ * word instead of letting the monotonic floor pin the overshoot. The adoption
+ * frame is exempt — a mid-response mount (a caption toggle) jumps straight to
+ * the playhead — and the budget resets on adoption and with the per-response
+ * reset.
  *
  * The cursor is monotonic within a response: a smaller fraction (e.g. the
  * played/total ratio dipping when a new audio burst grows the total) never
@@ -50,10 +59,18 @@ import { useEffect, useRef, useState } from "react";
 import { getLiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/live-voice-store";
 
 /**
+ * Ceiling on cursor advancement, in words per second of played audio.
+ * Comfortably above real speech (~2–3 words/sec) so the cap never binds while
+ * the mapping tracks actual playback; it only clamps the sweep when the
+ * fraction maps a short spoken prefix onto a much longer displayed transcript.
+ */
+const MAX_CURSOR_WORDS_PER_SECOND = 5;
+
+/**
  * Index (into the caller's word segmentation) of the word the TTS playhead is
  * speaking, or `null` while the current response has produced no audio (the
  * caller keeps its default highlight). `wordCount` of 0 idles the loop
- * entirely (the assistant caption unmounts on an empty transcript).
+ * entirely (the caller passes 0 for an empty or hidden caption).
  */
 export function useSpokenWordCursor(wordCount: number): number | null {
   const [index, setIndex] = useState<number | null>(null);
@@ -61,6 +78,10 @@ export function useSpokenWordCursor(wordCount: number): number | null {
   // last returned value, serving as both the monotonic floor and the guard
   // that skips the state write when a frame leaves the index unchanged.
   const cursorRef = useRef<number | null>(null);
+  // Rate-cap state: playedSeconds at the previous frame, and the fractional
+  // word budget accrued from played-audio deltas since the last consumption.
+  const prevPlayedRef = useRef<number | null>(null);
+  const budgetRef = useRef(0);
   const prevCountRef = useRef(wordCount);
 
   // Declared before the loop effect so a shrink (transcript cleared for a new
@@ -69,6 +90,8 @@ export function useSpokenWordCursor(wordCount: number): number | null {
   useEffect(() => {
     if (wordCount < prevCountRef.current) {
       cursorRef.current = null;
+      prevPlayedRef.current = null;
+      budgetRef.current = 0;
       setIndex(null);
     }
     prevCountRef.current = wordCount;
@@ -85,18 +108,45 @@ export function useSpokenWordCursor(wordCount: number): number | null {
       let next = cursorRef.current;
       const progress = getLiveVoicePlaybackProgress();
       if (progress !== null && progress.totalSeconds > 0) {
-        // Audio exists for this response, so the cursor is numeric from here:
-        // at least the floor (0 for a fresh response), advancing only while
-        // audio remains scheduled — a caught-up queue (played == total) holds
-        // rather than mapping the drained fraction onto unspoken words.
-        const floor = cursorRef.current ?? 0;
-        next = floor;
-        if (progress.playedSeconds < progress.totalSeconds) {
-          const mapped = Math.floor(
-            (progress.playedSeconds / progress.totalSeconds) * wordCount,
-          );
-          if (Number.isFinite(mapped)) {
-            next = Math.max(Math.min(mapped, wordCount - 1), floor);
+        // A caught-up queue (played == total) yields no candidate: the drained
+        // fraction of 1.0 says nothing about displayed words with no
+        // synthesized audio yet, so a null cursor stays null (default
+        // highlight) and a numeric one holds its floor.
+        const mapped = Math.floor(
+          (progress.playedSeconds / progress.totalSeconds) * wordCount,
+        );
+        const candidate =
+          progress.playedSeconds < progress.totalSeconds &&
+          Number.isFinite(mapped)
+            ? Math.min(mapped, wordCount - 1)
+            : null;
+        if (cursorRef.current === null) {
+          if (candidate !== null) {
+            // Adoption: jump straight to the playhead, uncapped, so a
+            // mid-response mount (a caption toggle) syncs instantly. The rate
+            // cap applies from here on.
+            next = candidate;
+            prevPlayedRef.current = progress.playedSeconds;
+            budgetRef.current = 0;
+          }
+        } else {
+          // Accrue advancement budget from real played audio. A non-positive
+          // delta (a fresh player restarting the clock) accrues nothing.
+          if (prevPlayedRef.current !== null) {
+            const playedDelta = progress.playedSeconds - prevPlayedRef.current;
+            if (playedDelta > 0) {
+              budgetRef.current += playedDelta * MAX_CURSOR_WORDS_PER_SECOND;
+            }
+          }
+          prevPlayedRef.current = progress.playedSeconds;
+          const floor = cursorRef.current;
+          if (candidate !== null && candidate > floor) {
+            const advance = Math.min(
+              candidate - floor,
+              Math.floor(budgetRef.current),
+            );
+            next = floor + advance;
+            budgetRef.current -= advance;
           }
         }
       }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
@@ -198,13 +198,6 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
   let raf: RafTestHarness;
   let progress: LiveVoicePlaybackProgress | null;
 
-  /** Fire every pending rAF callback once, inside `act()`. */
-  function pumpFrame() {
-    act(() => {
-      raf.fireFrame();
-    });
-  }
-
   /** Text of the word span carrying the bright leading-edge tone. */
   function leadingWordIn(half: HTMLElement) {
     return half.querySelector("[data-leading]")?.textContent;
@@ -232,16 +225,39 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
     seedAssistant("alpha beta gamma delta");
     setPrefs({ user: false, assistant: true });
     render(<VoiceAmbientTranscript />);
-    pumpFrame();
+    raf.pumpFrame();
     // floor(0.5 * 4 words) = index 2 — mid-transcript, not the last word.
     expect(leadingWordIn(assistantText()!)).toBe("gamma");
+  });
+
+  test("a first read that is already drained keeps the default last-word edge", () => {
+    // The response's audio finished before the cursor loop ever observed a
+    // sub-total frame: the rail keeps the default reveal, not a pinned first
+    // word.
+    progress = { playedSeconds: 3, totalSeconds: 3 };
+    registerProgressProvider();
+    seedAssistant("alpha beta gamma delta");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    raf.pumpFrame();
+    raf.pumpFrame();
+    expect(leadingWordIn(assistantText()!)).toBe("delta");
+  });
+
+  test("schedules no frames while assistant captions are off", () => {
+    registerProgressProvider();
+    seedAssistant("alpha beta gamma delta");
+    setPrefs({ user: false, assistant: false });
+    render(<VoiceAmbientTranscript />);
+    expect(raf.requestCount()).toBe(0);
+    expect(raf.pendingCallbacks()).toHaveLength(0);
   });
 
   test("no registered provider keeps the default last-word leading edge", () => {
     seedAssistant("alpha beta gamma delta");
     setPrefs({ user: false, assistant: true });
     render(<VoiceAmbientTranscript />);
-    pumpFrame();
+    raf.pumpFrame();
     expect(leadingWordIn(assistantText()!)).toBe("delta");
   });
 
@@ -250,12 +266,12 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
     seedAssistant("alpha beta gamma delta");
     setPrefs({ user: false, assistant: true });
     render(<VoiceAmbientTranscript />);
-    pumpFrame();
+    raf.pumpFrame();
     // No audio yet: default reveal, the newest word leads.
     expect(leadingWordIn(assistantText()!)).toBe("delta");
 
     progress = { playedSeconds: 5, totalSeconds: 10 };
-    pumpFrame();
+    raf.pumpFrame();
     expect(leadingWordIn(assistantText()!)).toBe("gamma");
   });
 
@@ -265,17 +281,17 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
     seedAssistant("alpha beta gamma delta");
     setPrefs({ user: false, assistant: true });
     render(<VoiceAmbientTranscript />);
-    pumpFrame();
+    raf.pumpFrame();
     expect(leadingWordIn(assistantText()!)).toBe("gamma");
 
     // Next response: the transcript clears (shorter word list), no audio yet.
     progress = null;
     seedAssistant("fresh words");
-    pumpFrame();
+    raf.pumpFrame();
     expect(leadingWordIn(assistantText()!)).toBe("words");
 
     progress = { playedSeconds: 1, totalSeconds: 4 };
-    pumpFrame();
+    raf.pumpFrame();
     // floor(0.25 * 2 words) = index 0 — the cursor is live again.
     expect(leadingWordIn(assistantText()!)).toBe("fresh");
   });
@@ -286,7 +302,7 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
     seedUser("one two three four");
     setPrefs({ user: true, assistant: false });
     render(<VoiceAmbientTranscript />);
-    pumpFrame();
+    raf.pumpFrame();
     expect(leadingWordIn(userText()!)).toBe("four");
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -28,8 +28,9 @@
  * prefs, and the low-frequency `state`/`reconnecting` (per-turn, for the
  * listening gate) — so the high-frequency `inputAmplitude` churn on the
  * live-voice store never re-renders this component. The spoken-word cursor
- * keeps that invariant: it polls playback progress outside React and re-renders
- * only when the word index changes. The full transcript still lands in the chat
+ * keeps that invariant: it polls playback progress outside React, re-renders
+ * only when the word index changes, and idles entirely (no frames scheduled)
+ * while assistant captions are off. The full transcript still lands in the chat
  * thread on exit via the engine path; this is a live, ambient echo of the
  * current turn only.
  */
@@ -68,7 +69,12 @@ export function VoiceAmbientTranscript() {
     () => splitTranscriptWords(assistantTranscript),
     [assistantTranscript],
   );
-  const spokenIndex = useSpokenWordCursor(assistantWords.length);
+  // A word count of 0 idles the cursor's rAF loop while assistant captions
+  // are off, so the hidden caption costs no per-frame work; toggling the pref
+  // on mid-response re-syncs on the next frame via the cursor's adoption path.
+  const spokenIndex = useSpokenWordCursor(
+    showAssistant ? assistantWords.length : 0,
+  );
 
   // In-flight partial wins over the last finalized transcript — same precedence
   // as the underneath composer transcript (`VoiceLiveTranscript`).


### PR DESCRIPTION
## Summary
Fixes round-2 review gaps for voice-room-spoken-word-cursor.md.

- A first progress read that is already drained keeps the null cursor (default reveal) instead of pinning word 0
- Cursor advancement is rate-capped to a plausible speaking cadence so text-ahead-of-audio underruns cannot sweep the highlight onto unspoken words (adoption jump stays uncapped)
- The rAF loop idles entirely while assistant captions are off
- Shared act-aware pumpFrame in raf.test-helper.ts replaces per-file wrappers