### PR TITLE
feat(web): current → new resource chips on the provisioning loading takeover

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -9,7 +9,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import * as motionReact from "motion/react";
 
+import { organizationsBillingPlansRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type { PlanListResponse } from "@/generated/api/types.gen";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 import type { ProvisioningStateProps } from "./provisioning-state";
@@ -30,10 +33,20 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
   },
 }));
 
+// `useReducedMotion` reads a cached media-query singleton, so a per-test
+// `matchMedia` stub can't flip it. Override just that export (real `motion` /
+// `AnimatePresence` are preserved) and drive it through this toggle instead.
+let reducedMotion = false;
+mock.module("motion/react", () => ({
+  ...motionReact,
+  useReducedMotion: () => reducedMotion,
+}));
+
 const { ProvisioningState } = await import("./provisioning-state");
 
 beforeEach(() => {
   avatarQueryId = undefined;
+  reducedMotion = false;
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
 });
 
@@ -60,10 +73,68 @@ function baseProps(
   };
 }
 
-function renderState(overrides: Partial<ProvisioningStateProps> = {}) {
+/** A pro catalog with a `credits_50` tier and a Mighty package that maps to it. */
+function plansResponse(): PlanListResponse {
+  return {
+    plans: [
+      {
+        id: "pro",
+        name: "Pro",
+        base_lookup_key: "pro_base",
+        base_price_cents: 2000,
+        billing_interval: "month",
+        included_features: [],
+        machine_tiers: [],
+        storage_tiers: [],
+        credit_tiers: [
+          {
+            tier: "credits_50",
+            label: "$50 credits/mo",
+            credits_usd: 50,
+            price_cents: 5000,
+            lookup_key: "credits_50_key",
+          },
+        ],
+        packages: [
+          {
+            key: "mighty",
+            name: "Mighty",
+            description: "",
+            version: 1,
+            machine_tier: null,
+            storage_tier: "xs",
+            credit_tier: "credits_50",
+            machine_size: null,
+            storage_gib: 10,
+            credits_usd: 50,
+            include_platform_fee: false,
+            base_price_cents: 4000,
+            machine_price_cents: 0,
+            storage_price_cents: 0,
+            credit_price_cents: 0,
+            total_price_cents: 4000,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/**
+ * Renders the takeover with the plan catalog seeded into the query cache so the
+ * credits hook resolves without a fetch. Pass `plans: null` to leave it
+ * unresolved (credits omitted).
+ */
+function renderState(
+  overrides: Partial<ProvisioningStateProps> = {},
+  plans: PlanListResponse | null = plansResponse(),
+) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+  if (plans) {
+    client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
+  }
   return render(
     <QueryClientProvider client={client}>
       <ProvisioningState {...baseProps(overrides)} />
@@ -88,8 +159,8 @@ describe("confirming", () => {
     expect(getByText("Mighty package")).toBeTruthy();
   });
 
-  test("renders custom-intent machine/storage chips, omitting credits when null", () => {
-    const { getByText, queryByText } = renderState({
+  test("renders custom-intent machine/storage chips, target-only with no from-arrow, omitting credits when null", () => {
+    const { getByText, queryByText, container } = renderState({
       state: "CONFIRMING",
       intent: {
         kind: "custom",
@@ -105,6 +176,8 @@ describe("confirming", () => {
     expect(getByText("Storage")).toBeTruthy();
     expect(getByText("XL")).toBeTruthy();
     expect(queryByText(/credits/)).toBeNull();
+    // CONFIRMING is target-only: no current→new arrow while actuals are unknown.
+    expect(container.querySelector(".lucide-arrow-right")).toBeNull();
   });
 
   test("renders a credits chip when the custom intent bundles credits", () => {
@@ -125,7 +198,7 @@ describe("confirming", () => {
 
 describe("waiting / resizing", () => {
   test("renders the upgrading status with machine and storage from→to chips", () => {
-    const { getByText } = renderState({
+    const { getByText, container } = renderState({
       state: "WAITING",
       targets: { machineSize: "large", storageGib: 100 },
       fromSnapshot: { machineSize: "small", storageGib: 30 },
@@ -138,6 +211,9 @@ describe("waiting / resizing", () => {
     expect(getByText("Storage")).toBeTruthy();
     expect(getByText("30 GiB")).toBeTruthy();
     expect(getByText("100 GiB")).toBeTruthy();
+    // Two changed dimensions (≤ MAX_CHIPS_IN_ROW) show together, each with a
+    // current→new arrow.
+    expect(container.querySelector(".lucide-arrow-right")).toBeTruthy();
   });
 
   test("storage-only targets render a single storage chip and no machine chip", () => {
@@ -177,6 +253,65 @@ describe("waiting / resizing", () => {
     expect(
       getByText("Still working — this can take a minute or two."),
     ).toBeTruthy();
+  });
+
+  test("renders a 0 → label credits chip when the catalog resolves a label", () => {
+    const { getByText } = renderState({
+      state: "WAITING",
+      intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
+      targets: { machineSize: null, storageGib: null },
+      fromSnapshot: { machineSize: null, storageGib: null },
+    });
+
+    expect(getByText("Credits")).toBeTruthy();
+    expect(getByText("0")).toBeTruthy();
+    expect(getByText("$50 credits/mo")).toBeTruthy();
+  });
+
+  test("omits the credits chip when the catalog can't resolve a label", () => {
+    const { queryByText } = renderState(
+      {
+        state: "WAITING",
+        intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
+        targets: { machineSize: null, storageGib: null },
+        fromSnapshot: { machineSize: null, storageGib: null },
+      },
+      null,
+    );
+
+    expect(queryByText("Credits")).toBeNull();
+  });
+
+  test("under reduced motion, machine + storage + credits all render together", () => {
+    reducedMotion = true;
+    const { getByText } = renderState({
+      state: "WAITING",
+      intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
+      targets: { machineSize: "large", storageGib: 100 },
+      fromSnapshot: { machineSize: "small", storageGib: 30 },
+    });
+
+    expect(getByText("Machine")).toBeTruthy();
+    expect(getByText("Large")).toBeTruthy();
+    expect(getByText("Storage")).toBeTruthy();
+    expect(getByText("100 GiB")).toBeTruthy();
+    expect(getByText("Credits")).toBeTruthy();
+    expect(getByText("$50 credits/mo")).toBeTruthy();
+  });
+
+  test("under full motion, three changes rotate — only the first chip renders", () => {
+    reducedMotion = false;
+    const { getByText, queryByText } = renderState({
+      state: "WAITING",
+      intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
+      targets: { machineSize: "large", storageGib: 100 },
+      fromSnapshot: { machineSize: "small", storageGib: 30 },
+    });
+
+    // Rotation starts at the machine change; storage/credits are off-screen.
+    expect(getByText("Machine")).toBeTruthy();
+    expect(queryByText("Storage")).toBeNull();
+    expect(queryByText("Credits")).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -1,5 +1,6 @@
 import type { LucideIcon } from "lucide-react";
-import { ArrowRight, Check, Cpu, HardDrive } from "lucide-react";
+import { ArrowRight, Check, Coins, Cpu, HardDrive } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useEffect, useRef, type ReactNode } from "react";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
@@ -16,6 +17,12 @@ import type {
     ProvisioningStateKind,
 } from "./provisioning-machine";
 import { SERIF_HEADING_STYLE, type StalledApplyAction } from "./primitives";
+import {
+  buildResourceChanges,
+  type ResourceChangeKey,
+} from "./resource-changes";
+import { useProvisioningCredits } from "./use-provisioning-credits";
+import { useRotatingIndex } from "./use-rotating-index";
 import { extractOnboardingErrorMessage, PROVISION_MIN_DWELL_MS } from "./utils";
 
 // The mock's takeover tint, matched to the green Vellum creature. No token
@@ -24,6 +31,18 @@ const TAKEOVER_BACKGROUND = "#1D271E";
 
 const CHIP_BACKGROUND =
   "color-mix(in srgb, var(--content-emphasised) 10%, transparent)";
+
+// Above this many applicable resource changes the row rotates one chip at a
+// time instead of showing them all together. Two fit the mock's `flex-1` row
+// cleanly; a third (machine + storage + credits) is what triggers rotation.
+const MAX_CHIPS_IN_ROW = 2;
+const RESOURCE_ROTATE_MS = 2500;
+
+const RESOURCE_CHIP_ICON: Record<ResourceChangeKey, LucideIcon> = {
+  machine: Cpu,
+  storage: HardDrive,
+  credits: Coins,
+};
 
 export interface ProvisioningStateProps {
   state: ProvisioningStateKind;
@@ -111,7 +130,7 @@ function DimensionChip({
 }) {
   return (
     <div
-      className="flex items-center gap-2.5 rounded-lg px-3 py-2"
+      className="flex flex-1 items-center gap-2 rounded-lg px-2 py-1.5"
       style={{ backgroundColor: CHIP_BACKGROUND }}
     >
       <Icon
@@ -119,10 +138,10 @@ function DimensionChip({
         aria-hidden="true"
       />
       <div className="flex flex-col text-left">
-        <span className="text-[12px] leading-tight text-[var(--content-tertiary)]">
+        <span className="text-[12px] font-medium leading-tight text-[var(--content-tertiary)]">
           {label}
         </span>
-        <span className="flex items-center gap-1.5 text-[14px] leading-tight text-[var(--content-emphasised)]">
+        <span className="flex items-center gap-1.5 text-[14px] font-medium leading-[18px] text-[var(--content-emphasised)]">
           {from && (
             <>
               <span>{from}</span>
@@ -158,9 +177,84 @@ function TextChip({ label }: { label: string }) {
 
 function ChipRow({ children }: { children: ReactNode }) {
   return (
-    <div className="flex flex-wrap items-center justify-center gap-2">
+    <div className="flex w-full max-w-sm flex-wrap items-stretch justify-center gap-2">
       {children}
     </div>
+  );
+}
+
+/**
+ * WAITING/RESIZING resource chips: each changed dimension as a `{current} →
+ * {new}` chip (machine/storage from `targets` + `fromSnapshot`, credits from the
+ * catalog with a fixed `0` current for the base→pro upgrade). All apply-able
+ * chips show together per the mock; once more than `MAX_CHIPS_IN_ROW` apply and
+ * motion is allowed, they rotate one at a time on a timed opacity crossfade.
+ */
+function ResourceChangeChips({
+  intent,
+  targets,
+  fromSnapshot,
+}: {
+  intent: CheckoutIntent | null;
+  targets: ProvisioningDimensions;
+  fromSnapshot: ProvisioningDimensions;
+}) {
+  const creditsLabel = useProvisioningCredits(intent);
+  const reduce = useReducedMotion();
+  const changes = buildResourceChanges({
+    targets,
+    fromSnapshot,
+    credits: creditsLabel ? { from: "0", to: creditsLabel } : null,
+  });
+  const rotating = changes.length > MAX_CHIPS_IN_ROW && !reduce;
+  const index = useRotatingIndex(changes.length, {
+    intervalMs: RESOURCE_ROTATE_MS,
+    enabled: rotating,
+  });
+
+  if (changes.length === 0) {
+    return null;
+  }
+
+  if (rotating) {
+    const change = changes[index];
+    return (
+      <ChipRow>
+        <AnimatePresence mode="popLayout" initial={false}>
+          <motion.div
+            key={change.key}
+            className="flex flex-1"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.25 }}
+          >
+            <DimensionChip
+              icon={RESOURCE_CHIP_ICON[change.key]}
+              label={change.label}
+              from={change.from}
+              to={change.to}
+              done={false}
+            />
+          </motion.div>
+        </AnimatePresence>
+      </ChipRow>
+    );
+  }
+
+  return (
+    <ChipRow>
+      {changes.map((change) => (
+        <DimensionChip
+          key={change.key}
+          icon={RESOURCE_CHIP_ICON[change.key]}
+          label={change.label}
+          from={change.from}
+          to={change.to}
+          done={false}
+        />
+      ))}
+    </ChipRow>
   );
 }
 
@@ -325,7 +419,11 @@ export function ProvisioningState({
                 : "This might take a couple seconds."
             }
           />
-          <TargetChips targets={targets} fromSnapshot={fromSnapshot} />
+          <ResourceChangeChips
+            intent={intent}
+            targets={targets}
+            fromSnapshot={fromSnapshot}
+          />
           {escapeButton()}
         </>
       );

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Tests for `useProvisioningCredits`. The plan catalog is seeded straight into
+ * the React Query cache so `useQuery` resolves synchronously without a fetch —
+ * mirrors the `plan-card.test.tsx` `setQueryData` pattern.
+ */
+import { describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import { organizationsBillingPlansRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type { PlanListResponse } from "@/generated/api/types.gen";
+import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
+
+import { useProvisioningCredits } from "./use-provisioning-credits";
+
+/** A pro-plan catalog with a `credits_50` tier and a Mighty package on it. */
+function plansResponse(): PlanListResponse {
+  return {
+    plans: [
+      {
+        id: "pro",
+        name: "Pro",
+        base_lookup_key: "pro_base",
+        base_price_cents: 2000,
+        billing_interval: "month",
+        included_features: [],
+        machine_tiers: [],
+        storage_tiers: [],
+        credit_tiers: [
+          {
+            tier: "credits_50",
+            label: "$50 credits/mo",
+            credits_usd: 50,
+            price_cents: 5000,
+            lookup_key: "credits_50_key",
+          },
+        ],
+        packages: [
+          {
+            key: "mighty",
+            name: "Mighty",
+            description: "",
+            version: 1,
+            machine_tier: null,
+            storage_tier: "xs",
+            credit_tier: "credits_50",
+            machine_size: null,
+            storage_gib: 10,
+            credits_usd: 50,
+            include_platform_fee: false,
+            base_price_cents: 4000,
+            machine_price_cents: 0,
+            storage_price_cents: 0,
+            credit_price_cents: 0,
+            total_price_cents: 4000,
+          },
+          {
+            key: "orphan",
+            name: "Orphan",
+            description: "",
+            version: 1,
+            machine_tier: null,
+            storage_tier: "xs",
+            credit_tier: "credits_999",
+            machine_size: null,
+            storage_gib: 10,
+            credits_usd: 30,
+            include_platform_fee: false,
+            base_price_cents: 4000,
+            machine_price_cents: 0,
+            storage_price_cents: 0,
+            credit_price_cents: 0,
+            total_price_cents: 4000,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function renderCredits(
+  intent: CheckoutIntent | null,
+  plans?: PlanListResponse,
+): string | null {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  if (plans) {
+    client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
+  }
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+  return renderHook(() => useProvisioningCredits(intent), { wrapper }).result
+    .current;
+}
+
+describe("useProvisioningCredits", () => {
+  test("returns null for a null intent", () => {
+    expect(renderCredits(null, plansResponse())).toBeNull();
+  });
+
+  test("returns null while the catalog is unresolved", () => {
+    expect(
+      renderCredits({ kind: "package", packageKey: "mighty", savedAt: 0 }),
+    ).toBeNull();
+  });
+
+  test("resolves a package's credit tier label", () => {
+    expect(
+      renderCredits(
+        { kind: "package", packageKey: "mighty", savedAt: 0 },
+        plansResponse(),
+      ),
+    ).toBe("$50 credits/mo");
+  });
+
+  test("falls back to the package's credits_usd when no tier matches", () => {
+    expect(
+      renderCredits(
+        { kind: "package", packageKey: "orphan", savedAt: 0 },
+        plansResponse(),
+      ),
+    ).toBe("30 credits");
+  });
+
+  test("returns null for an unknown package key", () => {
+    expect(
+      renderCredits(
+        { kind: "package", packageKey: "nope", savedAt: 0 },
+        plansResponse(),
+      ),
+    ).toBeNull();
+  });
+
+  test("resolves a custom intent's credit tier label", () => {
+    expect(
+      renderCredits(
+        {
+          kind: "custom",
+          machineTier: null,
+          storageTier: null,
+          creditTier: "credits_50",
+          savedAt: 0,
+        },
+        plansResponse(),
+      ),
+    ).toBe("$50 credits/mo");
+  });
+
+  test("returns null for a custom intent without credits", () => {
+    expect(
+      renderCredits(
+        {
+          kind: "custom",
+          machineTier: "large",
+          storageTier: "xl",
+          creditTier: null,
+          savedAt: 0,
+        },
+        plansResponse(),
+      ),
+    ).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -1,0 +1,44 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { organizationsBillingPlansRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+import type { ProPlan } from "@/generated/api/types.gen";
+import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
+
+/**
+ * Resolves the human-readable monthly-credit label for the purchased plan from
+ * the shared plan catalog, so the provisioning takeover can render a
+ * `0 → {credits}` chip for the base→pro upgrade. Reads the same query
+ * `plans-page.tsx` uses, so React Query dedupes when the takeover follows a page
+ * that already fetched it. Returns null while the catalog loads, when the intent
+ * carries no credits, or when the label can't be resolved. Display-only.
+ */
+export function useProvisioningCredits(
+  intent: CheckoutIntent | null,
+): string | null {
+  const { data } = useQuery(organizationsBillingPlansRetrieveOptions());
+
+  if (intent == null) {
+    return null;
+  }
+
+  const proPlan = data?.plans.find((p): p is ProPlan => p.id === "pro");
+  if (proPlan == null) {
+    return null;
+  }
+  const creditTiers = proPlan.credit_tiers ?? [];
+
+  if (intent.kind === "package") {
+    const pkg = proPlan.packages.find((p) => p.key === intent.packageKey);
+    const label = creditTiers.find((t) => t.tier === pkg?.credit_tier)?.label;
+    if (label != null) {
+      return label;
+    }
+    return pkg?.credits_usd != null ? `${pkg.credits_usd} credits` : null;
+  }
+
+  if (intent.creditTier != null) {
+    return creditTiers.find((t) => t.tier === intent.creditTier)?.label ?? null;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Loading takeover now shows each changed resource as a two-line current→new chip (machine/storage/credits), together by default, rotating only when more than two apply. Credits shown as 0→{new} for the base→pro upgrade.

Part of plan: pro-manage-downgrade-loading.md (PR 3 of 6)