### PR TITLE
fix(voice-room): clamp the spoken-word cursor's advancement bank

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
@@ -182,6 +182,29 @@ describe("useSpokenWordCursor — rate cap", () => {
     }
   });
 
+  test("budget banked during long tracking cannot fund a one-frame sweep", () => {
+    // Track a 100-word response at a normal ~2.5 words/sec cadence: accrual
+    // (5 words/sec) outpaces consumption, so an unclamped bank would grow by
+    // ~1 word per step and later fund a full sweep in a single frame.
+    progress = { playedSeconds: 0.4, totalSeconds: 40 };
+    const { result } = renderHook(() => useSpokenWordCursor(100));
+    raf.pumpFrame();
+    expect(result.current).toBe(1);
+
+    for (let step = 2; step <= 40; step += 1) {
+      progress = { playedSeconds: 0.4 * step, totalSeconds: 40 };
+      raf.pumpFrame();
+      expect(result.current).toBe(step);
+    }
+
+    // Underrun sweep: the fraction jumps near 1 (candidate 97) while only
+    // 0.5s more audio played. The bank is clamped to one second of
+    // advancement, so the cursor moves at most 5 words past its floor.
+    progress = { playedSeconds: 16.5, totalSeconds: 17 };
+    raf.pumpFrame();
+    expect(result.current).toBe(45);
+  });
+
   test("the adoption jump is uncapped", () => {
     const { result } = renderHook(() => useSpokenWordCursor(40));
     raf.pumpFrame();

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -131,11 +131,20 @@ export function useSpokenWordCursor(wordCount: number): number | null {
           }
         } else {
           // Accrue advancement budget from real played audio. A non-positive
-          // delta (a fresh player restarting the clock) accrues nothing.
+          // delta (a fresh player restarting the clock) accrues nothing. The
+          // bank is clamped to about one second of advancement: real speech
+          // consumes less than the accrual rate, and an unclamped surplus
+          // banked over a long response would let a later text burst spend it
+          // all in one frame — a sweep onto unspoken words that the cap
+          // exists to prevent. The clamp keeps just enough headroom for the
+          // cursor to catch up after rAF jank.
           if (prevPlayedRef.current !== null) {
             const playedDelta = progress.playedSeconds - prevPlayedRef.current;
             if (playedDelta > 0) {
-              budgetRef.current += playedDelta * MAX_CURSOR_WORDS_PER_SECOND;
+              budgetRef.current = Math.min(
+                budgetRef.current + playedDelta * MAX_CURSOR_WORDS_PER_SECOND,
+                MAX_CURSOR_WORDS_PER_SECOND,
+              );
             }
           }
           prevPlayedRef.current = progress.playedSeconds;


### PR DESCRIPTION
## Summary
Fixes the round-3 review gap for voice-room-spoken-word-cursor.md.

- The rate-cap budget banked unspent surplus without bound (~2.5 words per played second at normal cadence), so a later text burst could spend it all in one frame and sweep the highlight onto unspoken words — the exact failure the cap prevents
- The bank is clamped to one second of advancement (MAX_CURSOR_WORDS_PER_SECOND), keeping catch-up headroom for rAF jank while making the cap a true rate limit
- Regression test: 16s of normal-cadence tracking followed by an underrun sweep advances at most 5 words