### PR TITLE
feat(web): route Pro Manage to the plan-aware plans takeover

### DIFF
--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -161,7 +161,15 @@ function makeClient(
   plans: PlanListResponse,
 ): QueryClient {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        gcTime: Infinity,
+      },
+    },
   });
   client.setQueryData(
     organizationsBillingSubscriptionRetrieveQueryKey(),

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -1,9 +1,8 @@
 /**
- * Tests for the PlanCard: verifies the plan name, renewal text, the action
- * button (now in the plan row), and the recommended-upgrade banner render
- * correctly, plus the action button's navigation wiring. The card no longer
- * shows a credit bundle label or an invoices button (invoices moved to an
- * inline table on the billing page).
+ * Tests for the PlanCard: verifies the plan name, renewal text, the plan-row
+ * action button, and the recommended-upgrade banner render correctly, plus the
+ * action button's navigation wiring. The card shows no credit bundle label and
+ * no invoices button; invoices render in an inline table on the billing page.
  *
  * Content tests pre-populate the React Query cache so the card's `useQuery`
  * calls resolve synchronously — `renderToStaticMarkup` is single-pass, so a
@@ -16,7 +15,7 @@
 import * as reactRouter from "react-router";
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -305,7 +304,11 @@ describe("PlanCard action button", () => {
 
     fireEvent.click(await findByTestId("plan-card-manage-button"));
 
-    expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+    // navigate() fires from the click handler; await it so the assertion never
+    // races the handler's commit in the CI runner.
+    await waitFor(() => {
+      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+    });
     expect(onManage).not.toHaveBeenCalled();
   });
 
@@ -319,7 +322,11 @@ describe("PlanCard action button", () => {
 
     fireEvent.click(await findByTestId("plan-card-upgrade-button"));
 
-    expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+    // navigate() fires from the click handler; await it so the assertion never
+    // races the handler's commit in the CI runner.
+    await waitFor(() => {
+      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+    });
     expect(onManage).not.toHaveBeenCalled();
   });
 
@@ -333,7 +340,11 @@ describe("PlanCard action button", () => {
 
     fireEvent.click(await findByTestId("plan-card-manage-button"));
 
-    expect(onManage).toHaveBeenCalledTimes(1);
+    // The empty catalog wires the button to onManage; await it so the assertion
+    // never races the handler's commit in the CI runner.
+    await waitFor(() => {
+      expect(onManage).toHaveBeenCalledTimes(1);
+    });
     expect(navigateArgs).toEqual([]);
   });
 });

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -1,20 +1,24 @@
 /**
  * Tests for the PlanCard: verifies the plan name, renewal text, the action
  * button (now in the plan row), and the recommended-upgrade banner render
- * correctly. The card no longer shows a credit bundle label or an invoices
- * button (invoices moved to an inline table on the billing page).
+ * correctly, plus the action button's navigation wiring. The card no longer
+ * shows a credit bundle label or an invoices button (invoices moved to an
+ * inline table on the billing page).
  *
- * Strategy: pre-populate the React Query cache so the card's `useQuery` calls
- * resolve synchronously — `renderToStaticMarkup` is single-pass, so a pending
- * query would otherwise report `isLoading` and render the spinner. The avatar
- * compositor loads lazily via `useEffect`, which doesn't fire under
- * `renderToStaticMarkup`, so avatars render as same-size placeholders here.
+ * Content tests pre-populate the React Query cache so the card's `useQuery`
+ * calls resolve synchronously — `renderToStaticMarkup` is single-pass, so a
+ * pending query would otherwise report `isLoading` and render the spinner.
+ * The action-button tests render interactively (happy-dom) and mock
+ * `useNavigate` so the takeover navigation can be asserted without a Router;
+ * the avatar compositor is mocked to a same-size placeholder.
  */
 
-import { describe, expect, test } from "bun:test";
+import * as reactRouter from "react-router";
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router";
 
 import {
   organizationsBillingPlansRetrieveQueryKey,
@@ -24,8 +28,25 @@ import type {
   PlanListResponse,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
+import { routes } from "@/utils/routes";
 
-import { PlanCard } from "./plan-card";
+// Capture navigate() targets so the action-button wiring can be asserted
+// without a live Router.
+let navigateArgs: Array<[unknown, unknown]> = [];
+mock.module("react-router", () => ({
+  ...reactRouter,
+  useNavigate: () => (to: unknown, opts: unknown) => {
+    navigateArgs.push([to, opts]);
+  },
+}));
+
+// Render avatar placeholders; skip the lazy compositor bundle in the DOM test.
+mock.module("@/utils/use-bundled-avatar-components", () => ({
+  preloadBundledAvatarComponents: () => {},
+  useBundledAvatarComponents: () => null,
+}));
+
+const { PlanCard } = await import("./plan-card");
 
 function basePlansResponse(): PlanListResponse {
   return {
@@ -126,10 +147,20 @@ function proMightySubscription(): SubscriptionResponse {
   };
 }
 
-function renderCard(
+/** A catalog with the `pro-packages` flag off — the Pro plan has no packages. */
+function emptyCatalogPlans(): PlanListResponse {
+  const plans = basePlansResponse();
+  const pro = plans.plans.find((p) => p.id === "pro");
+  if (pro && "packages" in pro) {
+    pro.packages = [];
+  }
+  return plans;
+}
+
+function makeClient(
   subscription: SubscriptionResponse,
   plans: PlanListResponse,
-): string {
+): QueryClient {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -137,19 +168,46 @@ function renderCard(
     organizationsBillingSubscriptionRetrieveQueryKey(),
     subscription,
   );
-  client.setQueryData(
-    organizationsBillingPlansRetrieveQueryKey(),
-    plans,
-  );
+  client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
+  return client;
+}
+
+function renderCard(
+  subscription: SubscriptionResponse,
+  plans: PlanListResponse,
+): string {
+  const client = makeClient(subscription, plans);
   return renderToStaticMarkup(
     // MemoryRouter supplies the router context PlanCard's useNavigate needs.
-    <MemoryRouter>
+    <reactRouter.MemoryRouter>
       <QueryClientProvider client={client}>
         <PlanCard onManage={() => {}} />
       </QueryClientProvider>
-    </MemoryRouter>,
+    </reactRouter.MemoryRouter>,
   );
 }
+
+function renderCardInteractive(
+  subscription: SubscriptionResponse,
+  plans: PlanListResponse,
+  onManage: () => void,
+) {
+  const client = makeClient(subscription, plans);
+  // useNavigate is mocked, so no Router wrapper is needed here.
+  return render(
+    <QueryClientProvider client={client}>
+      <PlanCard onManage={onManage} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  navigateArgs = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("PlanCard", () => {
   test("shows the plan name and renewal text for a base plan", () => {
@@ -179,12 +237,7 @@ describe("PlanCard", () => {
   });
 
   test("no upgrade banner when the package catalog is empty (flag off)", () => {
-    const plans = basePlansResponse();
-    const pro = plans.plans.find((p) => p.id === "pro");
-    if (pro && "packages" in pro) {
-      pro.packages = [];
-    }
-    const html = renderCard(baseSubscription(), plans);
+    const html = renderCard(baseSubscription(), emptyCatalogPlans());
     expect(html).not.toContain("recommended-upgrade-button");
     expect(html).not.toContain("Recommended Upgrade");
   });
@@ -238,5 +291,49 @@ describe("PlanCard", () => {
     // A plan whose tiers diverged from the pinned package reads "Mighty
     // (Custom)" so it doesn't masquerade as the stock package.
     expect(html).toContain("Mighty (Custom)");
+  });
+});
+
+describe("PlanCard action button", () => {
+  test("a Pro user's Manage click opens the plan-aware plans takeover", async () => {
+    const onManage = mock(() => {});
+    const { findByTestId } = renderCardInteractive(
+      proMightySubscription(),
+      plansWithSuper(),
+      onManage,
+    );
+
+    fireEvent.click(await findByTestId("plan-card-manage-button"));
+
+    expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+    expect(onManage).not.toHaveBeenCalled();
+  });
+
+  test("a base user's View Plans click opens the plans takeover", async () => {
+    const onManage = mock(() => {});
+    const { findByTestId } = renderCardInteractive(
+      baseSubscription(),
+      basePlansResponse(),
+      onManage,
+    );
+
+    fireEvent.click(await findByTestId("plan-card-upgrade-button"));
+
+    expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+    expect(onManage).not.toHaveBeenCalled();
+  });
+
+  test("an empty catalog falls back to onManage (AdjustPlanModal)", async () => {
+    const onManage = mock(() => {});
+    const { findByTestId } = renderCardInteractive(
+      proMightySubscription(),
+      emptyCatalogPlans(),
+      onManage,
+    );
+
+    fireEvent.click(await findByTestId("plan-card-manage-button"));
+
+    expect(onManage).toHaveBeenCalledTimes(1);
+    expect(navigateArgs).toEqual([]);
   });
 });

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -156,9 +156,9 @@ interface RecommendedUpgradeProps {
     currentKey: string | null;
     /**
      * Delegate for subscribers who are already on Pro — the upgrade endpoint
-     * no-ops for active Pro orgs, so package step-ups go through the manage
-     * flow instead. When absent (base plan), the CTA starts the Stripe
-     * package checkout directly.
+     * no-ops for active Pro orgs, so package step-ups route to the plan-aware
+     * plans takeover instead. When absent (base plan), the CTA starts the
+     * Stripe package checkout directly.
      */
     onUpgrade?: () => void;
 }
@@ -381,10 +381,10 @@ export function PlanCard({ onManage }: PlanCardProps) {
                     <Button
                         variant={display.actionVariant}
                         onClick={
-                            // Base plan with a live catalog opens the full-screen
-                            // plans takeover; Pro "Manage" (and the flag-off empty
-                            // catalog) keep the modal.
-                            currentPlan.id === "base" && packages.length > 0
+                            // A live catalog opens the plan-aware plans takeover
+                            // for both base and Pro users; an empty catalog (flag
+                            // off) falls back to the manage modal.
+                            packages.length > 0
                                 ? () => navigate(routes.plans)
                                 : onManage
                         }
@@ -440,7 +440,9 @@ export function PlanCard({ onManage }: PlanCardProps) {
                         packages={packages}
                         currentKey={currentKey}
                         onUpgrade={
-                            currentPlan.id === "base" ? undefined : onManage
+                            currentPlan.id === "base"
+                                ? undefined
+                                : () => navigate(routes.plans)
                         }
                     />
                 </div>


### PR DESCRIPTION
## Summary
- A Pro user's Manage button now opens the plan-aware plans takeover (like base users' View Plans); falls back to AdjustPlanModal only when the catalog is empty.

Part of plan: pro-manage-downgrade-loading.md (PR 6 of 6)