### PR TITLE
fix(voice-room): spend frame-earned cursor allowance before clamping the bank

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
@@ -198,11 +198,29 @@ describe("useSpokenWordCursor — rate cap", () => {
     }
 
     // Underrun sweep: the fraction jumps near 1 (candidate 97) while only
-    // 0.5s more audio played. The bank is clamped to one second of
-    // advancement, so the cursor moves at most 5 words past its floor.
+    // 0.5s more audio played. Spendable this frame = the stored bank
+    // (clamped to 5 words) + the 0.5s of newly played audio (2.5 words), so
+    // the cursor moves at most 7 words past its floor instead of sweeping to
+    // the candidate.
     progress = { playedSeconds: 16.5, totalSeconds: 17 };
     raf.pumpFrame();
-    expect(result.current).toBe(45);
+    expect(result.current).toBe(47);
+  });
+
+  test("a delayed frame spends its full earned allowance at once", () => {
+    // Adoption zeroes the bank.
+    progress = { playedSeconds: 0.4, totalSeconds: 40 };
+    const { result } = renderHook(() => useSpokenWordCursor(100));
+    raf.pumpFrame();
+    expect(result.current).toBe(1);
+
+    // A 2s gap between frames (throttled tab while audio plays on) earns
+    // 2 × 5 = 10 words, all spendable in the frame that observes it — even
+    // against a near-1 fraction (candidate 96) the cursor advances by the
+    // full earned allowance instead of crawling at the stored-bank ceiling.
+    progress = { playedSeconds: 2.4, totalSeconds: 2.5 };
+    raf.pumpFrame();
+    expect(result.current).toBe(11);
   });
 
   test("the adoption jump is uncapped", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -130,33 +130,32 @@ export function useSpokenWordCursor(wordCount: number): number | null {
             budgetRef.current = 0;
           }
         } else {
-          // Accrue advancement budget from real played audio. A non-positive
-          // delta (a fresh player restarting the clock) accrues nothing. The
-          // bank is clamped to about one second of advancement: real speech
-          // consumes less than the accrual rate, and an unclamped surplus
-          // banked over a long response would let a later text burst spend it
-          // all in one frame — a sweep onto unspoken words that the cap
-          // exists to prevent. The clamp keeps just enough headroom for the
-          // cursor to catch up after rAF jank.
+          // Advancement allowance for this frame: the stored bank plus the
+          // words earned by audio that actually played since the previous
+          // frame (a non-positive delta — a fresh player restarting the
+          // clock — earns nothing). The full frame allowance is spendable at
+          // once, so a long gap between frames (a throttled background tab
+          // while audio plays on) catches the cursor up in step with the real
+          // playhead. Only the leftover STORED bank is clamped, to about one
+          // second of advancement: real speech consumes less than the accrual
+          // rate, and an unclamped stored surplus would let a later text
+          // burst spend it all in one frame — a sweep onto unspoken words
+          // that the cap exists to prevent.
+          let available = budgetRef.current;
           if (prevPlayedRef.current !== null) {
             const playedDelta = progress.playedSeconds - prevPlayedRef.current;
             if (playedDelta > 0) {
-              budgetRef.current = Math.min(
-                budgetRef.current + playedDelta * MAX_CURSOR_WORDS_PER_SECOND,
-                MAX_CURSOR_WORDS_PER_SECOND,
-              );
+              available += playedDelta * MAX_CURSOR_WORDS_PER_SECOND;
             }
           }
           prevPlayedRef.current = progress.playedSeconds;
           const floor = cursorRef.current;
           if (candidate !== null && candidate > floor) {
-            const advance = Math.min(
-              candidate - floor,
-              Math.floor(budgetRef.current),
-            );
+            const advance = Math.min(candidate - floor, Math.floor(available));
             next = floor + advance;
-            budgetRef.current -= advance;
+            available -= advance;
           }
+          budgetRef.current = Math.min(available, MAX_CURSOR_WORDS_PER_SECOND);
         }
       }
       if (next !== cursorRef.current) {


### PR DESCRIPTION
## Summary
Follow-up to the advancement-bank clamp, addressing the Codex review on #38672.

- The clamp truncated allowance earned within the current frame, so a multi-second rAF gap (throttled background tab while audio plays on) under-advanced the cursor and, if playback drained inside the gap, froze it short of the response's final words
- The frame's full allowance (stored bank + words earned by audio played since the previous frame) is spendable at once; only the leftover stored bank is clamped to one second of advancement — a text burst still cannot sweep the highlight onto unspoken words
- Regression tests updated: banked-surplus sweep bounds at bank + frame earnings; a delayed frame catches up with the real playhead in one step