### PR TITLE
fix(macos): capture Vite hang diagnostics when dev:electron wait times out

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -139,7 +139,6 @@
         "electron-vite": "5.0.0",
         "typescript": "5.9.3",
         "vite": "7.3.3",
-        "wait-on": "8.0.1",
       },
     },
     "clients/web": {
@@ -703,10 +702,6 @@
 
     "@google/genai": ["@google/genai@1.45.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-+sNRWhKiRibVgc4OKi7aBJJ0A7RcoVD8tGG+eFkqxAWRjASDW+ktS9lLwTDnAxZICzCVoeAdu8dYLJVTX60N9w=="],
 
-    "@hapi/hoek": ["@hapi/hoek@9.3.0", "", {}, "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="],
-
-    "@hapi/topo": ["@hapi/topo@5.1.0", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg=="],
-
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.2", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.2" } }, "sha512-/DC0hluanNJDVPUu69cidD46sGwzt8MJATiGx7WgCScn+ZH48fJQ0fvTfMPXY82/ASXWxnNo8P4BdHyU/dI/EA=="],
 
     "@hey-api/codegen-core": ["@hey-api/codegen-core@0.8.1", "", { "dependencies": { "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "c12": "3.3.4", "color-support": "1.1.3" } }, "sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA=="],
@@ -1243,12 +1238,6 @@
 
     "@sentry/vite-plugin": ["@sentry/vite-plugin@5.3.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.3.0", "@sentry/rollup-plugin": "5.3.0" } }, "sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A=="],
 
-    "@sideway/address": ["@sideway/address@4.1.5", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q=="],
-
-    "@sideway/formula": ["@sideway/formula@3.0.1", "", {}, "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="],
-
-    "@sideway/pinpoint": ["@sideway/pinpoint@2.0.0", "", {}, "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="],
-
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@slack/types": ["@slack/types@2.21.1", "", {}, "sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ=="],
@@ -1689,8 +1678,6 @@
 
     "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
 
-    "axios": ["axios@1.18.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g=="],
-
     "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
@@ -2121,8 +2108,6 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
-    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
-
     "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
@@ -2350,8 +2335,6 @@
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "jju": ["jju@1.4.0", "", {}, "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="],
-
-    "joi": ["joi@17.13.4", "", { "dependencies": { "@hapi/hoek": "^9.3.0", "@hapi/topo": "^5.1.0", "@sideway/address": "^4.1.5", "@sideway/formula": "^3.0.1", "@sideway/pinpoint": "^2.0.0" } }, "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
@@ -2835,7 +2818,7 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
-    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
@@ -3269,8 +3252,6 @@
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
-    "wait-on": ["wait-on@8.0.1", "", { "dependencies": { "axios": "^1.7.7", "joi": "^17.13.3", "lodash": "^4.17.21", "minimist": "^1.2.8", "rxjs": "^7.8.1" }, "bin": { "wait-on": "bin/wait-on" } }, "sha512-1wWQOyR2LVVtaqrcIL2+OM+x7bkpmzVROa0Nf6FryXkS+er5Sa1kzFGjzZRqLnHa3n1rACFLeTwUqE1ETL9Mig=="],
-
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "walkdir": ["walkdir@0.4.1", "", {}, "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ=="],
@@ -3649,8 +3630,6 @@
 
     "@sentry/cli/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
-    "@sentry/cli/proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
-
     "@sentry/cli/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "@sentry/electron/@sentry/browser": ["@sentry/browser@10.50.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.50.0", "@sentry-internal/feedback": "10.50.0", "@sentry-internal/replay": "10.50.0", "@sentry-internal/replay-canvas": "10.50.0", "@sentry/core": "10.50.0" } }, "sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA=="],
@@ -3790,8 +3769,6 @@
     "app-builder-lib/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "ast-v8-to-istanbul/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
-    "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -4274,8 +4251,6 @@
     "@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 
     "ajv-keywords/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "buffer-image-size/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -90,9 +90,12 @@ proxy) with a 1.5s timeout and picks one of two paths:
      local Vite (8.x) and plugin tree, not whatever older Vite happens
      to live in `clients/macos/node_modules`. Pinning the port via the
      Vite CLI overrides `clients/web/.env` if `PORT` is set there.
-   - `dev:electron` → [`wait-on`](https://github.com/jeffbski/wait-on)
-     polls `:5173` (30s timeout), then runs `electron-vite dev` against
-     it. The wait avoids Electron racing the renderer.
+   - `dev:electron` → `scripts/wait-for-web.ts` polls `:5173` (180s
+     timeout), then runs `electron-vite dev` against it. The wait avoids
+     Electron racing the renderer. On timeout the script captures stack
+     samples of the Vite processes plus the port state to `/tmp` before
+     exiting — a hung Vite gets un-wedged by the ensuing teardown, so
+     that capture is the only record of where it was stuck.
 
    `concurrently --kill-others` tears both down on Ctrl+C or on either
    child exiting. Logs are prefixed and color-coded (`[web]` blue,
@@ -149,7 +152,7 @@ bun run dev:standalone     # explicit: spawn our Vite (:5173) + electron-vite de
 bun run dev:electron-only  # explicit: electron-vite dev only, honors $VELLUM_DEV_URL (default :5173)
 bun run install:all        # bun install in clients/macos and clients/web (called automatically by dev)
 bun run dev:web            # clients/web Vite (port 5173, strict) — invoked by dev:standalone
-bun run dev:electron       # wait-on :5173 then electron-vite dev — invoked by dev:standalone
+bun run dev:electron       # wait for :5173 (hang capture on timeout) then electron-vite dev — invoked by dev:standalone
 bun run build              # electron-vite build — bundles main + preload to out/
 bun run typecheck          # tsc --noEmit
 bun run test               # bun test — single Bun process (fastest for local iteration)

--- a/clients/macos/package.json
+++ b/clients/macos/package.json
@@ -11,7 +11,7 @@
     "dev:electron-only": "bun install && bun run setup && bun run prepare:electron-dev && electron-vite dev",
     "install:all": "bun install && bun run setup",
     "dev:web": "cd ../web && bun run dev -- --port 5173 --strictPort",
-    "dev:electron": "wait-on --timeout 180000 http://localhost:5173 && bun run prepare:electron-dev && electron-vite dev",
+    "dev:electron": "bun scripts/wait-for-web.ts --timeout 180000 http://localhost:5173 && bun run prepare:electron-dev && electron-vite dev",
     "prepare:electron-dev": "bun scripts/prepare-electron-dev-app.ts",
     "build": "electron-vite build",
     "typecheck": "bunx tsc --noEmit",
@@ -32,8 +32,7 @@
     "electron-builder": "26.8.1",
     "electron-vite": "5.0.0",
     "typescript": "5.9.3",
-    "vite": "7.3.3",
-    "wait-on": "8.0.1"
+    "vite": "7.3.3"
   },
   "dependencies": {
     "@sentry/electron": "7.13.0",

--- a/clients/macos/scripts/wait-for-web.ts
+++ b/clients/macos/scripts/wait-for-web.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env bun
+/**
+ * Wait for the standalone web dev server (Vite on :5173) to answer, then exit
+ * 0 — a drop-in for `wait-on http://localhost:5173`, with a diagnostic tail
+ * for hung Vite startups.
+ *
+ * Vite startup can wedge indefinitely before it binds the port, and the
+ * teardown that follows this script's failure exit is what un-wedges it:
+ * `concurrently --kill-others` SIGTERMs the web half, Vite completes startup
+ * while dying, and its log reads "ready in <≈ the timeout>". The hang
+ * therefore leaves no trace of where it was stuck unless that trace is
+ * captured from the outside, before teardown. On timeout this script writes
+ * that capture to /tmp: a wall-clock stack sample (`sample`) of each Vite
+ * process on the dev port, the port's listener state, and a reachability
+ * probe taken after polling has stopped.
+ *
+ * Best-effort by design: capture failures are logged and the script still
+ * exits 1, so the dev orchestration behaves exactly as it did with `wait-on`.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+
+const DEFAULT_URL = "http://localhost:5173";
+const DEFAULT_TIMEOUT_MS = 180_000;
+const POLL_INTERVAL_MS = 250;
+const PROBE_TIMEOUT_MS = 2_000;
+const SAMPLE_SECONDS = 2;
+const MAX_SAMPLED_PROCESSES = 4;
+
+const args = process.argv.slice(2);
+let timeoutMs = DEFAULT_TIMEOUT_MS;
+let url = DEFAULT_URL;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--timeout") {
+    const value = Number(args[++i]);
+    if (!Number.isFinite(value) || value <= 0) {
+      console.error(`[dev] invalid --timeout value: ${args[i]}`);
+      process.exit(2);
+    }
+    timeoutMs = value;
+  } else {
+    url = args[i]!;
+  }
+}
+const port = Number(new URL(url).port || "80");
+
+async function isUp(target: string, probeTimeoutMs: number): Promise<boolean> {
+  try {
+    const res = await fetch(target, {
+      signal: AbortSignal.timeout(probeTimeoutMs),
+    });
+    // Any non-5xx response counts — even a 404 means the server is up and
+    // serving HTTP (Vite answers the bare root with a base-URL hint page).
+    return res.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+/** Run a command and capture stdout, with a hard timeout so a wedged
+ * diagnostic tool can't hang the diagnostics. */
+function run(cmd: string, argv: string[], commandTimeoutMs = 20_000): string {
+  return execFileSync(cmd, argv, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: commandTimeoutMs,
+  });
+}
+
+/** Every process whose command names `vite` and carries `--port <port>` —
+ * catches both the `bun --bun vite` wrapper and the node Vite it spawns,
+ * while excluding `electron-vite` (different port) and shell wrappers. */
+function viteProcessesOnPort(targetPort: number): Array<{ pid: number; command: string }> {
+  let psOut: string;
+  try {
+    psOut = run("ps", ["ax", "-o", "pid=,command="]);
+  } catch {
+    return [];
+  }
+  const procs: Array<{ pid: number; command: string }> = [];
+  for (const line of psOut.split("\n")) {
+    const match = line.match(/^\s*(\d+)\s+(.*)$/);
+    if (!match) {
+      continue;
+    }
+    const pid = Number(match[1]);
+    const command = match[2]!;
+    if (pid === process.pid) {
+      continue;
+    }
+    if (/\bvite\b/.test(command) && command.includes(`--port ${targetPort}`)) {
+      procs.push({ pid, command });
+    }
+  }
+  return procs;
+}
+
+/** Wall-clock stack sample of a process via macOS `sample` — shows the exact
+ * frames a stuck process is blocked in. */
+function sampleProcess(pid: number): string {
+  const sampleFile = `/tmp/vellum-dev-vite-hang-sample-${pid}.txt`;
+  try {
+    run("sample", [String(pid), String(SAMPLE_SECONDS), "-mayDie", "-file", sampleFile]);
+    const text = fs.readFileSync(sampleFile, "utf8");
+    fs.rmSync(sampleFile, { force: true });
+    return text;
+  } catch (err) {
+    return `sample failed for PID ${pid}: ${(err as Error).message}\n`;
+  }
+}
+
+async function captureHangDiagnostics(): Promise<string> {
+  const stamp = new Date().toISOString().replace(/:/g, "-");
+  const reportPath = `/tmp/vellum-dev-vite-hang-${stamp}.txt`;
+  const sections: string[] = [
+    `Vite dev-server hang capture — ${new Date().toISOString()}`,
+    `Waited ${timeoutMs}ms for ${url} with no response.`,
+  ];
+
+  const procs = viteProcessesOnPort(port);
+  if (procs.length > 0) {
+    sections.push(
+      `Vite processes on port ${port}:\n${procs.map((p) => `  ${p.pid}  ${p.command}`).join("\n")}`,
+    );
+  } else {
+    sections.push(`No Vite processes matching --port ${port} found in ps output.`);
+  }
+
+  try {
+    sections.push(`lsof -nP -iTCP:${port}:\n${run("lsof", ["-nP", `-iTCP:${port}`])}`);
+  } catch {
+    sections.push(`lsof -nP -iTCP:${port}: no sockets (nothing bound or listening).`);
+  }
+
+  for (const proc of procs.slice(0, MAX_SAMPLED_PROCESSES)) {
+    sections.push(`===== sample of PID ${proc.pid} (${proc.command}) =====\n${sampleProcess(proc.pid)}`);
+  }
+
+  // Polling stopped when the wait deadline passed; a server that answers here
+  // but never answered during the wait implicates the polling itself.
+  const reachable = await isUp(url, 1_000);
+  sections.push(
+    `Reachability probe after polling stopped and samples were taken: ${reachable ? "SERVER ANSWERED" : "still unreachable"}.`,
+  );
+
+  fs.writeFileSync(reportPath, `${sections.join("\n\n")}\n`);
+  return reportPath;
+}
+
+const deadline = Date.now() + timeoutMs;
+let up = false;
+while (Date.now() < deadline) {
+  if (await isUp(url, PROBE_TIMEOUT_MS)) {
+    up = true;
+    break;
+  }
+  await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+}
+
+if (up) {
+  process.exit(0);
+}
+
+console.error(
+  `[dev] timed out after ${Math.round(timeoutMs / 1000)}s waiting for ${url} — capturing hang diagnostics before exiting.`,
+);
+try {
+  const reportPath = await captureHangDiagnostics();
+  console.error(`[dev] wrote hang diagnostics (stack samples + port state) to:`);
+  console.error(`[dev]   ${reportPath}`);
+  console.error(`[dev] attach that file when investigating the Vite startup hang.`);
+} catch (err) {
+  console.error(`[dev] hang diagnostics capture failed: ${(err as Error).message}`);
+}
+process.exit(1);


### PR DESCRIPTION
## Summary
- Replace the bare `wait-on --timeout 180000 http://localhost:5173` gate in `dev:electron` with `scripts/wait-for-web.ts`: identical happy-path behavior (poll until :5173 answers, exit 0), and on timeout it captures a macOS `sample` wall-clock stack of every Vite process on the dev port, the port's `lsof` state, and a post-polling reachability probe into `/tmp/vellum-dev-vite-hang-<timestamp>.txt` before exiting 1 — teardown then proceeds exactly as before.
- Motivation: `bun run dev` has died twice with Vite's `ready in` tracking the wait cap almost exactly — 29139 ms under the 30 s cap (bumped to 180 s in #38598), then 179174 ms under the 180 s cap the next day — while Vite in isolation starts in ~300 ms with the same cold cache. That pattern means Vite's startup hangs indefinitely and the `--kill-others` teardown is what un-wedges it (it completes startup while dying), so no timeout value can fix it and the hang leaves no post-hoc trace. The stack sample taken at timeout, before teardown, records exactly where the process is stuck for the next occurrence.
- Remove the now-unused `wait-on` devDependency. Readiness semantics: any HTTP response with status < 500 counts as up, matching the `dev.ts` vel-up probe's philosophy.

## Original prompt
While debugging a `bun run dev` failure in `clients/macos`, we established that Vite's dev-server startup intermittently hangs until the wait-on timeout tears the orchestration down (ready-in ≈ timeout−1 s on two consecutive days at two different cap values), so bumping the timeout again cannot fix it. Sidd asked for the proposed instrumentation PR: replace the bare `wait-on` with a wrapper that behaves identically on the happy path but, on timeout, captures evidence of the hung Vite process (macOS `sample` stack, `lsof` port state) to a file before exiting non-zero, so the bug self-diagnoses on its next occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)