### PR TITLE
Voice room: sync transcript highlight to the spoken word (JARVIS-1309)

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -30,6 +30,7 @@ import type {
   LiveVoiceAudioCaptureOptions,
   LiveVoiceCaptureResult,
 } from "@/domains/chat/voice/live-voice/pcm-capture";
+import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
 import {
   useLiveVoiceStore,
   type LiveVoiceSessionControls,
@@ -179,11 +180,20 @@ export class FakePlayer {
   stopCount = 0;
   disposeCount = 0;
   prewarmCount = 0;
+  resetPlaybackProgressCount = 0;
   isPlaying = false;
+  /** Progress the fake reports; tests set it to drive the store's provider. */
+  playbackProgress: LiveVoicePlaybackProgress | null = null;
   private drainResolvers: Array<() => void> = [];
 
   prewarm(): void {
     this.prewarmCount++;
+  }
+  getPlaybackProgress(): LiveVoicePlaybackProgress | null {
+    return this.playbackProgress;
+  }
+  resetPlaybackProgress(): void {
+    this.resetPlaybackProgressCount++;
   }
   enqueue(chunk: unknown): void {
     this.enqueued.push(chunk);

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -12,6 +12,7 @@ import {
   dismissLiveVoiceFailure,
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
+  getLiveVoicePlaybackProgress,
   isLiveVoiceMicLive,
   isLiveVoiceSessionActive,
   isLiveVoiceSessionOwnedBy,
@@ -347,5 +348,38 @@ describe("getLiveVoiceInputAmplitude", () => {
     expect(getLiveVoiceInputAmplitude()).toBe(0);
     useLiveVoiceStore.getState().setInputAmplitude(0.42);
     expect(getLiveVoiceInputAmplitude()).toBe(0.42);
+  });
+});
+
+describe("useLiveVoiceStore — playback-progress provider", () => {
+  test("defaults to null when idle", () => {
+    expect(useLiveVoiceStore.getState().playbackProgressProvider).toBeNull();
+  });
+
+  test("setPlaybackProgressProvider registers and deregisters the provider", () => {
+    const provider = mock(() => null);
+    useLiveVoiceStore.getState().setPlaybackProgressProvider(provider);
+    expect(useLiveVoiceStore.getState().playbackProgressProvider).toBe(provider);
+    useLiveVoiceStore.getState().setPlaybackProgressProvider(null);
+    expect(useLiveVoiceStore.getState().playbackProgressProvider).toBeNull();
+  });
+
+  test("reset clears the registered provider", () => {
+    useLiveVoiceStore.getState().setPlaybackProgressProvider(() => null);
+    useLiveVoiceStore.getState().reset();
+    expect(useLiveVoiceStore.getState().playbackProgressProvider).toBeNull();
+  });
+
+  test("getLiveVoicePlaybackProgress returns null with no provider", () => {
+    expect(getLiveVoicePlaybackProgress()).toBeNull();
+  });
+
+  test("getLiveVoicePlaybackProgress forwards the provider's value", () => {
+    const progress = { playedSeconds: 1.5, totalSeconds: 4 };
+    useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
+    expect(getLiveVoicePlaybackProgress()).toBe(progress);
+
+    useLiveVoiceStore.getState().setPlaybackProgressProvider(() => null);
+    expect(getLiveVoicePlaybackProgress()).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -24,6 +24,7 @@
 import { create } from "zustand";
 
 import type { LiveVoiceMetricsServerFrame } from "@/domains/chat/voice/live-voice/protocol";
+import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
 import { createSelectors } from "@/utils/create-selectors";
 
 // ---------------------------------------------------------------------------
@@ -268,6 +269,16 @@ export interface LiveVoiceState {
    * so a non-`speaking` read costs nothing and it clears on session reset.
    */
   outputAmplitudeProvider: (() => number) | null;
+  /**
+   * Provider for the current response's TTS playback progress (played/total
+   * seconds of scheduled audio), registered by the controller from the active
+   * session's {@link LiveVoiceAudioPlayer}. `null` when there is no session.
+   * Read via {@link getLiveVoicePlaybackProgress} — the voice-room transcript's
+   * spoken-word cursor polls it per animation frame. A registered provider
+   * (like `outputAmplitudeProvider`) so a non-speaking read costs nothing and
+   * it clears on session reset.
+   */
+  playbackProgressProvider: (() => LiveVoicePlaybackProgress | null) | null;
   /** Human-readable error message when `state === "failed"`, `null` otherwise. */
   error: string | null;
 }
@@ -322,6 +333,10 @@ export interface LiveVoiceActions {
   setLastTurnLatency: (lastTurnLatency: LiveVoiceTurnLatency) => void;
   /** Register (or clear) the active player's output-amplitude provider. */
   setOutputAmplitudeProvider: (provider: (() => number) | null) => void;
+  /** Register (or clear) the active player's playback-progress provider. */
+  setPlaybackProgressProvider: (
+    provider: (() => LiveVoicePlaybackProgress | null) | null,
+  ) => void;
   /** Transition to `failed` with a message. */
   fail: (message: string) => void;
   /**
@@ -421,6 +436,7 @@ const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   entryOrigin: null,
   lastTurnLatency: null,
   outputAmplitudeProvider: null,
+  playbackProgressProvider: null,
   error: null,
 };
 
@@ -457,6 +473,8 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   setLastTurnLatency: (lastTurnLatency) => set({ lastTurnLatency }),
   setOutputAmplitudeProvider: (outputAmplitudeProvider) =>
     set({ outputAmplitudeProvider }),
+  setPlaybackProgressProvider: (playbackProgressProvider) =>
+    set({ playbackProgressProvider }),
   fail: (message) => set({ state: "failed", error: message }),
   reset: () => set({ ...INITIAL_SESSION_STATE }),
 }));
@@ -483,6 +501,20 @@ export function getLiveVoiceInputAmplitude(): number {
  */
 export function getLiveVoiceOutputAmplitude(): number {
   return useLiveVoiceStore.getState().outputAmplitudeProvider?.() ?? 0;
+}
+
+/**
+ * Playback progress (played/total seconds) of the current response's TTS
+ * audio, read from the active player via the controller-registered provider.
+ * Returns `null` when no session is active or nothing has been scheduled for
+ * the current response. Polled per animation frame by the voice-room
+ * transcript's spoken-word cursor, so it is module-level (stable identity)
+ * and reads through `getState()` — subscribing would re-render the poller on
+ * every register/clear (see STATE_MANAGEMENT.md, as with
+ * {@link getLiveVoiceOutputAmplitude}).
+ */
+export function getLiveVoicePlaybackProgress(): LiveVoicePlaybackProgress | null {
+  return useLiveVoiceStore.getState().playbackProgressProvider?.() ?? null;
 }
 
 /**

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -433,6 +433,109 @@ describe("LiveVoiceAudioPlayer", () => {
   });
 
   // -------------------------------------------------------------------------
+  // playback progress (spoken-word cursor)
+  // -------------------------------------------------------------------------
+
+  describe("getPlaybackProgress", () => {
+    test("returns null before any enqueue", () => {
+      expect(player.getPlaybackProgress()).toBeNull();
+    });
+
+    test("returns null after dispose()", async () => {
+      player.enqueue(chunk(new Array(24000).fill(1)));
+      await player.dispose();
+      expect(player.getPlaybackProgress()).toBeNull();
+    });
+
+    test("tracks a single PCM chunk: total is the buffer duration, played follows currentTime", () => {
+      // One 24000-sample frame at 24 kHz => 1.0s scheduled at t=0.
+      player.enqueue(chunk(new Array(24000).fill(1)));
+
+      expect(player.getPlaybackProgress()).toEqual({
+        playedSeconds: 0,
+        totalSeconds: 1,
+      });
+
+      ctx.currentTime = 0.5;
+      expect(player.getPlaybackProgress()!.playedSeconds).toBeCloseTo(0.5, 6);
+
+      // Past the scheduled tail: played clamps to total.
+      ctx.currentTime = 3;
+      expect(player.getPlaybackProgress()).toEqual({
+        playedSeconds: 1,
+        totalSeconds: 1,
+      });
+    });
+
+    test("accumulates totalSeconds across chunks", () => {
+      player.enqueue(chunk(new Array(24000).fill(1))); // 1.0s
+      player.enqueue(chunk(new Array(12000).fill(1))); // 0.5s
+
+      const progress = player.getPlaybackProgress()!;
+      expect(progress.totalSeconds).toBeCloseTo(1.5, 6);
+      expect(progress.playedSeconds).toBe(0);
+    });
+
+    test("reports played == total after the queue drains (not null)", () => {
+      player.enqueue(chunk(new Array(24000).fill(1)));
+      ctx.currentTime = 1;
+      ctx.sources[0]!.finish(); // drain -> settleIfIdle zeroes the playhead
+
+      // Mid-turn silence: the cursor holds at the end, it doesn't reset.
+      expect(player.getPlaybackProgress()).toEqual({
+        playedSeconds: 1,
+        totalSeconds: 1,
+      });
+    });
+
+    test("a burst after a drain grows total; the silent gap never counts as played", () => {
+      player.enqueue(chunk(new Array(24000).fill(1))); // 1.0s at t=0
+      ctx.currentTime = 1;
+      ctx.sources[0]!.finish();
+
+      // 4s of silence (ack -> tool run), then a second 1.0s burst at t=5.
+      ctx.currentTime = 5;
+      player.enqueue(chunk(new Array(24000).fill(1)));
+
+      // total grew to 2.0s; played is still just the first second — the gap
+      // between bursts did not inflate it.
+      expect(player.getPlaybackProgress()).toEqual({
+        playedSeconds: 1,
+        totalSeconds: 2,
+      });
+
+      ctx.currentTime = 5.5;
+      expect(player.getPlaybackProgress()!.playedSeconds).toBeCloseTo(1.5, 6);
+    });
+
+    test("stop() resets progress to null", () => {
+      player.enqueue(chunk(new Array(24000).fill(1)));
+      player.stop();
+      expect(player.getPlaybackProgress()).toBeNull();
+    });
+
+    test("resetPlaybackProgress() resets progress to null", () => {
+      player.enqueue(chunk(new Array(24000).fill(1)));
+      player.resetPlaybackProgress();
+      expect(player.getPlaybackProgress()).toBeNull();
+    });
+
+    test("container path: a resolved async decode contributes its duration to total", async () => {
+      player.enqueue(frame("audio/wav"));
+      // Not scheduled yet: no progress until the decode resolves.
+      expect(player.getPlaybackProgress()).toBeNull();
+
+      await flushMicrotasks();
+
+      // Default mock decode yields a 1.0s buffer.
+      expect(player.getPlaybackProgress()).toEqual({
+        playedSeconds: 0,
+        totalSeconds: 1,
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // dispose: release the underlying AudioContext (resource-leak guard)
   // -------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -53,6 +53,23 @@ export interface TtsAudioChunk {
 }
 
 /**
+ * Playback progress of the current response's TTS audio.
+ *
+ * `totalSeconds` is the cumulative duration of every buffer scheduled since the
+ * last reset (new response / stop); `playedSeconds` is how much of it has
+ * actually sounded, derived from the audio playhead. During a mid-turn silence
+ * (queue drained, more speech coming) `playedSeconds === totalSeconds`, so a
+ * consumer's cursor holds at the last spoken word rather than resetting — the
+ * next audio burst grows `totalSeconds` and the cursor advances again.
+ */
+export interface LiveVoicePlaybackProgress {
+  /** Seconds of scheduled audio already played, in [0, totalSeconds]. */
+  playedSeconds: number;
+  /** Total seconds of audio scheduled for the current response so far. */
+  totalSeconds: number;
+}
+
+/**
  * Container MIME types decoded via `AudioContext.decodeAudioData` (which
  * derives sample rate/channels from the container itself). Providers without
  * raw-PCM streaming (e.g. Fish Audio) fall back to one of these.
@@ -174,6 +191,19 @@ export class LiveVoiceAudioPlayer {
   private playheadTime = 0;
 
   private playingState = false;
+
+  /**
+   * Cumulative duration (seconds) of every buffer scheduled since the last
+   * progress reset. Backs {@link getPlaybackProgress}.
+   *
+   * Deliberately NOT reset in {@link settleIfIdle}: a drain mid-turn (ack →
+   * tool run → more speech) zeroes only the playhead, so progress reports
+   * `played == total` and a consumer's word cursor holds at the last spoken
+   * word instead of snapping back. Reset only on {@link stop} (barge-in
+   * flush), {@link resetPlaybackProgress} (new response), and context
+   * (re)creation.
+   */
+  private totalScheduledSeconds = 0;
 
   /**
    * Analyser tapping the output bus for amplitude metering. Sources connect
@@ -345,6 +375,7 @@ export class LiveVoiceAudioPlayer {
     const startAt = Math.max(this.playheadTime, context.currentTime);
     source.start(startAt);
     this.playheadTime = startAt + buffer.duration;
+    this.totalScheduledSeconds += buffer.duration;
 
     this.activeSources.add(source);
     source.onended = () => {
@@ -381,6 +412,7 @@ export class LiveVoiceAudioPlayer {
     }
     this.activeSources.clear();
     this.pendingContainerDecodes = 0;
+    this.totalScheduledSeconds = 0;
     // Reset the decode chain so the next response's container frames don't queue
     // behind the abandoned (now generation-invalidated) decode — a slow/stuck
     // `decodeAudioData` from the interrupted utterance must not delay or silence
@@ -440,6 +472,7 @@ export class LiveVoiceAudioPlayer {
       const context = this.createContext();
       this.context = context;
       this.playheadTime = 0;
+      this.totalScheduledSeconds = 0;
       // Tap the output bus for amplitude metering when the context supports it.
       // Scheduled sources connect through this analyser to the destination; a
       // context without createAnalyser (test mock) skips metering entirely and
@@ -490,6 +523,36 @@ export class LiveVoiceAudioPlayer {
       OUTPUT_AMPLITUDE_SMOOTHING * scaled +
       (1 - OUTPUT_AMPLITUDE_SMOOTHING) * this.smoothedOutputAmplitude;
     return this.smoothedOutputAmplitude;
+  }
+
+  /**
+   * Playback progress of the current response's TTS audio, or `null` when
+   * nothing has been scheduled since the last reset (no context yet, fresh
+   * response, or post-stop/dispose).
+   *
+   * Played time is derived from the playhead rather than accumulated:
+   * `remaining = playheadTime - currentTime` is the unplayed tail of the
+   * scheduled timeline, so silent gaps between bursts never inflate played
+   * time, and after a drain (`playheadTime` zeroed) progress reports
+   * `played == total`. Side-effect-free: reading never advances state.
+   */
+  getPlaybackProgress(): LiveVoicePlaybackProgress | null {
+    if (this.context === null || this.totalScheduledSeconds === 0) return null;
+    const remaining = Math.max(0, this.playheadTime - this.context.currentTime);
+    const played = Math.min(
+      this.totalScheduledSeconds,
+      Math.max(0, this.totalScheduledSeconds - remaining),
+    );
+    return { playedSeconds: played, totalSeconds: this.totalScheduledSeconds };
+  }
+
+  /**
+   * Zero the playback-progress accumulator for a new response. Called by the
+   * controller at the start of each response, paired with the transcript
+   * clear, so the word cursor starts fresh with the new caption.
+   */
+  resetPlaybackProgress(): void {
+    this.totalScheduledSeconds = 0;
   }
 
   private handleSourceEnded(source: AudioBufferSourceNode): void {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -47,7 +47,7 @@ import {
 // static import graph.
 const { useLiveVoice } =
   await import("@/domains/chat/voice/live-voice/use-live-voice");
-const { useLiveVoiceStore } =
+const { useLiveVoiceStore, getLiveVoicePlaybackProgress } =
   await import("@/domains/chat/voice/live-voice/live-voice-store");
 const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
 
@@ -2137,6 +2137,54 @@ describe("session context and controls", () => {
     expect(store.controls).toBeNull();
     expect(store.assistantId).toBeNull();
     expect(store.conversationId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Playback-progress provider — feeds the transcript's spoken-word cursor
+// ---------------------------------------------------------------------------
+
+describe("playback-progress provider", () => {
+  test("start() registers a provider that reads the active player's progress", async () => {
+    const h = renderController();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+
+    expect(getLiveVoicePlaybackProgress()).toBeNull();
+
+    h.player.playbackProgress = { playedSeconds: 1.25, totalSeconds: 3.5 };
+    expect(getLiveVoicePlaybackProgress()).toEqual({
+      playedSeconds: 1.25,
+      totalSeconds: 3.5,
+    });
+  });
+
+  test("teardown clears the registered provider", async () => {
+    const h = renderController();
+    await startListening(h);
+    h.player.playbackProgress = { playedSeconds: 1, totalSeconds: 2 };
+    expect(getLiveVoicePlaybackProgress()).not.toBeNull();
+
+    act(() => {
+      h.view.unmount();
+    });
+
+    expect(useLiveVoiceStore.getState().playbackProgressProvider).toBeNull();
+    expect(getLiveVoicePlaybackProgress()).toBeNull();
+  });
+
+  test("a thinking frame resets the player's progress with the transcript clear", async () => {
+    const h = renderController();
+    await startListening(h);
+    expect(h.player.resetPlaybackProgressCount).toBe(0);
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+    });
+
+    expect(h.player.resetPlaybackProgressCount).toBe(1);
+    expect(useLiveVoiceStore.getState().assistantTranscript).toBe("");
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -599,6 +599,10 @@ export function useLiveVoice(
       // speaks, so the avatar looked inverted — pulsing on the user's voice, not
       // the assistant's. Cleared by the store reset in teardown()/stop().
       store.setOutputAmplitudeProvider(() => player.getOutputAmplitude());
+      // Feed the voice-room transcript's spoken-word cursor: it maps the
+      // player's played/total seconds onto the caption's words each animation
+      // frame. Cleared by the store reset in teardown()/stop().
+      store.setPlaybackProgressProvider(() => player.getPlaybackProgress());
 
       const session: SessionContext = {
         assistantId,
@@ -775,6 +779,10 @@ export function useLiveVoice(
           // previous response's audio can never consume it.
           session.turnHeardStampMs = session.speechEndedAtMs;
           session.speechEndedAtMs = null;
+          // Playback progress resets with the transcript so the new
+          // response's spoken-word cursor starts at the first word instead of
+          // counting the previous response's audio.
+          session.player.resetPlaybackProgress();
           const s = useLiveVoiceStore.getState();
           s.clearAssistantTranscript();
           s.setState("thinking");

--- a/clients/web/src/domains/chat/voice/raf.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/raf.test-helper.ts
@@ -1,0 +1,69 @@
+/**
+ * Manual `requestAnimationFrame` pump for tests of rAF-driven loops.
+ *
+ * `installRafTestHarness` swaps the global `requestAnimationFrame` /
+ * `cancelAnimationFrame` pair for an id-tracking capture so tests drive frames
+ * deterministically: `fireFrame` runs every pending callback once with a
+ * controlled timestamp, and callbacks that reschedule land in the next frame's
+ * batch. The harness also exposes the pending callbacks, the total number of
+ * frame requests, and the ids passed to cancel — enough to assert loop
+ * lifecycle (started, rescheduled, canceled on unmount).
+ *
+ * Install in `beforeEach` and call `restore` in `afterEach` to reinstate the
+ * real globals. Callers whose frame callbacks update React state wrap
+ * `fireFrame` in `act()` themselves — the harness stays render-library
+ * agnostic.
+ */
+
+export interface RafTestHarness {
+  /**
+   * Fire every currently pending callback once with the given timestamp
+   * (defaults to `performance.now()`).
+   */
+  fireFrame(timestamp?: number): void;
+  /** Callbacks scheduled but not yet fired or canceled. */
+  pendingCallbacks(): FrameRequestCallback[];
+  /** Total `requestAnimationFrame` calls since install. */
+  requestCount(): number;
+  /** Ids passed to `cancelAnimationFrame` since install. */
+  canceledIds(): readonly number[];
+  /** Reinstate the real `requestAnimationFrame` / `cancelAnimationFrame`. */
+  restore(): void;
+}
+
+export function installRafTestHarness(): RafTestHarness {
+  const callbacks = new Map<number, FrameRequestCallback>();
+  let nextId = 1;
+  let requests = 0;
+  const canceled: number[] = [];
+  const originalRaf = globalThis.requestAnimationFrame;
+  const originalCancelRaf = globalThis.cancelAnimationFrame;
+
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    requests += 1;
+    const id = nextId++;
+    callbacks.set(id, cb);
+    return id;
+  }) as typeof globalThis.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((id: number) => {
+    canceled.push(id);
+    callbacks.delete(id);
+  }) as typeof globalThis.cancelAnimationFrame;
+
+  return {
+    fireFrame(timestamp = performance.now()) {
+      const pending = [...callbacks.values()];
+      callbacks.clear();
+      for (const cb of pending) {
+        cb(timestamp);
+      }
+    },
+    pendingCallbacks: () => [...callbacks.values()],
+    requestCount: () => requests,
+    canceledIds: () => canceled,
+    restore() {
+      globalThis.requestAnimationFrame = originalRaf;
+      globalThis.cancelAnimationFrame = originalCancelRaf;
+    },
+  };
+}

--- a/clients/web/src/domains/chat/voice/raf.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/raf.test-helper.ts
@@ -10,10 +10,12 @@
  * lifecycle (started, rescheduled, canceled on unmount).
  *
  * Install in `beforeEach` and call `restore` in `afterEach` to reinstate the
- * real globals. Callers whose frame callbacks update React state wrap
- * `fireFrame` in `act()` themselves — the harness stays render-library
- * agnostic.
+ * real globals. Callers whose frame callbacks update React state pump through
+ * `pumpFrame`, which wraps `fireFrame` in `act()`; `fireFrame` stays raw for
+ * loops with no React state involved (canvas draw loops).
  */
+
+import { act } from "@testing-library/react";
 
 export interface RafTestHarness {
   /**
@@ -21,6 +23,8 @@ export interface RafTestHarness {
    * (defaults to `performance.now()`).
    */
   fireFrame(timestamp?: number): void;
+  /** `fireFrame` wrapped in `act()`, for callbacks that update React state. */
+  pumpFrame(timestamp?: number): void;
   /** Callbacks scheduled but not yet fired or canceled. */
   pendingCallbacks(): FrameRequestCallback[];
   /** Total `requestAnimationFrame` calls since install. */
@@ -50,13 +54,20 @@ export function installRafTestHarness(): RafTestHarness {
     callbacks.delete(id);
   }) as typeof globalThis.cancelAnimationFrame;
 
+  const fireFrame = (timestamp = performance.now()) => {
+    const pending = [...callbacks.values()];
+    callbacks.clear();
+    for (const cb of pending) {
+      cb(timestamp);
+    }
+  };
+
   return {
-    fireFrame(timestamp = performance.now()) {
-      const pending = [...callbacks.values()];
-      callbacks.clear();
-      for (const cb of pending) {
-        cb(timestamp);
-      }
+    fireFrame,
+    pumpFrame(timestamp?: number) {
+      act(() => {
+        fireFrame(timestamp);
+      });
     },
     pendingCallbacks: () => [...callbacks.values()],
     requestCount: () => requests,

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Tests for `useSpokenWordCursor`.
+ *
+ * `requestAnimationFrame` is monkey-patched to capture callbacks so frames are
+ * pumped manually inside `act()` (same harness as
+ * `voice-timeline-waveform.test.tsx`). Playback progress is driven through the
+ * real live-voice store by registering a provider that reads a mutable local
+ * value; the store is reset between tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
+import { useSpokenWordCursor } from "@/domains/chat/voice/voice-room/use-spoken-word-cursor";
+
+// ---------------------------------------------------------------------------
+// requestAnimationFrame harness
+// ---------------------------------------------------------------------------
+
+let rafCallbacks: Map<number, FrameRequestCallback>;
+let nextRafId = 1;
+let originalRaf: typeof globalThis.requestAnimationFrame;
+let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
+
+/** Fire every pending rAF callback once, inside `act()`. */
+function pumpFrame() {
+  act(() => {
+    const callbacks = [...rafCallbacks.values()];
+    rafCallbacks.clear();
+    for (const cb of callbacks) {
+      cb(performance.now());
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Playback-progress fake
+// ---------------------------------------------------------------------------
+
+let progress: LiveVoicePlaybackProgress | null;
+
+beforeEach(() => {
+  rafCallbacks = new Map();
+  nextRafId = 1;
+  originalRaf = globalThis.requestAnimationFrame;
+  originalCancelRaf = globalThis.cancelAnimationFrame;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    const id = nextRafId++;
+    rafCallbacks.set(id, cb);
+    return id;
+  }) as typeof globalThis.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((id: number) => {
+    rafCallbacks.delete(id);
+  }) as typeof globalThis.cancelAnimationFrame;
+
+  progress = null;
+  useLiveVoiceStore.getState().reset();
+  useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.requestAnimationFrame = originalRaf;
+  globalThis.cancelAnimationFrame = originalCancelRaf;
+  useLiveVoiceStore.getState().reset();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useSpokenWordCursor — mapping", () => {
+  test("null progress maps to the first word", () => {
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(0);
+  });
+
+  test("fraction 0.5 over 10 words maps to index 5", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(5);
+  });
+
+  test("fraction 1.0 clamps to the last word", () => {
+    progress = { playedSeconds: 10, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(9);
+  });
+
+  test("zero-duration progress holds the floor instead of dividing by zero", () => {
+    progress = { playedSeconds: 0, totalSeconds: 0 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(0);
+  });
+});
+
+describe("useSpokenWordCursor — monotonicity", () => {
+  test("a smaller fraction does not move the cursor backward", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(5);
+
+    // Total grows faster than played (a new audio burst), dipping the ratio.
+    progress = { playedSeconds: 6, totalSeconds: 20 };
+    pumpFrame();
+    expect(result.current).toBe(5);
+  });
+
+  test("progress flipping to null (barge-in flush) freezes the cursor", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(5);
+
+    progress = null;
+    pumpFrame();
+    pumpFrame();
+    expect(result.current).toBe(5);
+  });
+});
+
+describe("useSpokenWordCursor — per-response reset", () => {
+  test("shrinking wordCount resets the floor and the cursor restarts at 0", () => {
+    progress = { playedSeconds: 8, totalSeconds: 10 };
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => useSpokenWordCursor(count),
+      { initialProps: { count: 10 } },
+    );
+    pumpFrame();
+    expect(result.current).toBe(8);
+
+    // New response: the transcript clears (shorter word list), progress resets.
+    progress = null;
+    rerender({ count: 3 });
+    expect(result.current).toBe(0);
+
+    progress = { playedSeconds: 1, totalSeconds: 3 };
+    pumpFrame();
+    expect(result.current).toBe(1);
+  });
+
+  test("growing wordCount (streaming append) keeps the floor", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => useSpokenWordCursor(count),
+      { initialProps: { count: 10 } },
+    );
+    pumpFrame();
+    expect(result.current).toBe(5);
+
+    progress = null;
+    rerender({ count: 12 });
+    pumpFrame();
+    expect(result.current).toBe(5);
+  });
+});
+
+describe("useSpokenWordCursor — render economy and lifecycle", () => {
+  test("frames with an unchanged index do not re-render", () => {
+    let renders = 0;
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useSpokenWordCursor(10);
+    });
+    pumpFrame();
+    expect(result.current).toBe(5);
+    const rendersAfterFirstIndex = renders;
+
+    pumpFrame();
+    pumpFrame();
+    pumpFrame();
+    expect(renders).toBe(rendersAfterFirstIndex);
+
+    progress = { playedSeconds: 6, totalSeconds: 10 };
+    pumpFrame();
+    expect(result.current).toBe(6);
+    expect(renders).toBe(rendersAfterFirstIndex + 1);
+  });
+
+  test("wordCount 0 schedules no frames", () => {
+    renderHook(() => useSpokenWordCursor(0));
+    expect(rafCallbacks.size).toBe(0);
+  });
+
+  test("unmount cancels the pending frame", () => {
+    const { unmount } = renderHook(() => useSpokenWordCursor(10));
+    expect(rafCallbacks.size).toBe(1);
+    unmount();
+    expect(rafCallbacks.size).toBe(0);
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
@@ -153,19 +153,31 @@ describe("useSpokenWordCursor — monotonicity", () => {
 
 describe("useSpokenWordCursor — rate cap", () => {
   test("a mapped candidate sweeping far ahead advances only by the played-audio budget", () => {
-    progress = { playedSeconds: 1, totalSeconds: 10 };
-    const { result } = renderHook(() => useSpokenWordCursor(50));
+    progress = { playedSeconds: 10, totalSeconds: 100 };
+    const { result } = renderHook(() => useSpokenWordCursor(100));
     raf.pumpFrame();
-    // Adoption: floor(0.1 * 50) = 5.
-    expect(result.current).toBe(5);
+    // Adoption: floor(0.1 * 100) = 10 (spoken ceiling floor(10 × 3.3) = 33
+    // does not bind).
+    expect(result.current).toBe(10);
 
     // Near-underrun: played approaches total, so the fraction sweeps toward 1
-    // and the candidate lands near the end of the transcript
-    // (floor((1.5 / 1.6) * 50) = 46) while only 0.5s of audio actually
-    // played. Budget = 0.5 * 5 words/sec = 2 whole words.
-    progress = { playedSeconds: 1.5, totalSeconds: 1.6 };
+    // (candidate bounded by the spoken ceiling floor(10.5 × 3.3) = 34) while
+    // only 0.5s of audio actually played. Budget = 0.5 * 5 words/sec = 2
+    // whole words.
+    progress = { playedSeconds: 10.5, totalSeconds: 10.6 };
     raf.pumpFrame();
-    expect(result.current).toBe(7);
+    expect(result.current).toBe(12);
+  });
+
+  test("while text streams ahead of audio, the cursor advances at speech pace", () => {
+    // Mid-stream: 100 words are displayed but only 4s of audio is scheduled
+    // (the synthesized prefix). The raw fraction maps 2s played onto word 50;
+    // the spoken ceiling floor(2 × 3.3) = 6 keeps the highlight where real
+    // speech can actually be.
+    progress = { playedSeconds: 2, totalSeconds: 4 };
+    const { result } = renderHook(() => useSpokenWordCursor(100));
+    raf.pumpFrame();
+    expect(result.current).toBe(6);
   });
 
   test("a normal speaking cadence is never rate-limited", () => {
@@ -208,31 +220,34 @@ describe("useSpokenWordCursor — rate cap", () => {
   });
 
   test("a delayed frame spends its full earned allowance at once", () => {
-    // Adoption zeroes the bank.
-    progress = { playedSeconds: 0.4, totalSeconds: 40 };
+    // Adoption: floor(0.2 * 100) = 20 (spoken ceiling floor(8 × 3.3) = 26
+    // does not bind); bank zeroed.
+    progress = { playedSeconds: 8, totalSeconds: 40 };
     const { result } = renderHook(() => useSpokenWordCursor(100));
     raf.pumpFrame();
-    expect(result.current).toBe(1);
+    expect(result.current).toBe(20);
 
     // A 2s gap between frames (throttled tab while audio plays on) earns
     // 2 × 5 = 10 words, all spendable in the frame that observes it — even
-    // against a near-1 fraction (candidate 96) the cursor advances by the
-    // full earned allowance instead of crawling at the stored-bank ceiling.
-    progress = { playedSeconds: 2.4, totalSeconds: 2.5 };
+    // against a near-1 fraction (candidate bounded to the spoken ceiling 33)
+    // the cursor advances by the full earned allowance instead of crawling at
+    // the stored-bank ceiling.
+    progress = { playedSeconds: 10, totalSeconds: 10.4 };
     raf.pumpFrame();
-    expect(result.current).toBe(11);
+    expect(result.current).toBe(30);
   });
 
   test("the adoption jump is uncapped", () => {
-    const { result } = renderHook(() => useSpokenWordCursor(40));
+    const { result } = renderHook(() => useSpokenWordCursor(30));
     raf.pumpFrame();
     expect(result.current).toBeNull();
 
     // Mid-response mount: the first usable frame syncs straight to the
-    // playhead, floor(0.8 * 40) = 32, with no budget accrued yet.
+    // playhead, floor(0.8 * 30) = 24, with no budget accrued yet (spoken
+    // ceiling floor(8 × 3.3) = 26 does not bind).
     progress = { playedSeconds: 8, totalSeconds: 10 };
     raf.pumpFrame();
-    expect(result.current).toBe(32);
+    expect(result.current).toBe(24);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
@@ -2,14 +2,14 @@
  * Tests for `useSpokenWordCursor`.
  *
  * Frames are driven manually through the shared rAF harness
- * (`raf.test-helper.ts`), pumped inside `act()`. Playback progress is driven
- * through the real live-voice store by registering a provider that reads a
- * mutable local value; the store is reset between tests.
+ * (`raf.test-helper.ts`) via its act-aware `pumpFrame`. Playback progress is
+ * driven through the real live-voice store by registering a provider that
+ * reads a mutable local value; the store is reset between tests.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { cleanup, renderHook } from "@testing-library/react";
 
 import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
 import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
@@ -21,13 +21,6 @@ import { useSpokenWordCursor } from "@/domains/chat/voice/voice-room/use-spoken-
 
 let raf: RafTestHarness;
 let progress: LiveVoicePlaybackProgress | null;
-
-/** Fire every pending rAF callback once, inside `act()`. */
-function pumpFrame() {
-  act(() => {
-    raf.fireFrame();
-  });
-}
 
 beforeEach(() => {
   raf = installRafTestHarness();
@@ -45,21 +38,21 @@ afterEach(() => {
 describe("useSpokenWordCursor — mapping", () => {
   test("null progress yields a null cursor (caller keeps its default highlight)", () => {
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBeNull();
   });
 
   test("fraction 0.5 over 10 words maps to index 5", () => {
     progress = { playedSeconds: 5, totalSeconds: 10 };
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
   });
 
   test("zero-duration progress is not usable audio and keeps the cursor null", () => {
     progress = { playedSeconds: 0, totalSeconds: 0 };
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBeNull();
   });
 });
@@ -68,13 +61,13 @@ describe("useSpokenWordCursor — drained-queue hold", () => {
   test("a caught-up queue (played == total) does not advance the cursor past its floor", () => {
     progress = { playedSeconds: 5, totalSeconds: 10 };
     const { result } = renderHook(() => useSpokenWordCursor(20));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(10);
 
     // Mid-response silence: the queue drains while the LLM text streams ahead.
     progress = { playedSeconds: 10, totalSeconds: 10 };
-    pumpFrame();
-    pumpFrame();
+    raf.pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(10);
   });
 
@@ -84,27 +77,50 @@ describe("useSpokenWordCursor — drained-queue hold", () => {
       ({ count }: { count: number }) => useSpokenWordCursor(count),
       { initialProps: { count: 10 } },
     );
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
 
     progress = { playedSeconds: 10, totalSeconds: 10 };
     rerender({ count: 20 });
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
 
     rerender({ count: 30 });
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
+  });
+
+  test("a first read that is already drained keeps the cursor null", () => {
+    // The audio finished before the loop ever observed a sub-total frame
+    // (short response under a throttled or busy main thread): the caller
+    // keeps its default highlight instead of a pinned early word.
+    progress = { playedSeconds: 10, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    raf.pumpFrame();
+    raf.pumpFrame();
+    expect(result.current).toBeNull();
+  });
+
+  test("adoption happens on the first frame with audio still scheduled", () => {
+    progress = { playedSeconds: 10, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    raf.pumpFrame();
+    expect(result.current).toBeNull();
+
+    // A new audio burst grows the total: audio is scheduled again.
+    progress = { playedSeconds: 10, totalSeconds: 12 };
+    raf.pumpFrame();
+    expect(result.current).toBe(8);
   });
 
   test("the cursor reaches the last word during final-buffer playback and holds after the drain", () => {
     progress = { playedSeconds: 9.9, totalSeconds: 10 };
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(9);
 
     progress = { playedSeconds: 10, totalSeconds: 10 };
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(9);
   });
 });
@@ -113,36 +129,80 @@ describe("useSpokenWordCursor — monotonicity", () => {
   test("a smaller fraction does not move the cursor backward", () => {
     progress = { playedSeconds: 5, totalSeconds: 10 };
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
 
     // Total grows faster than played (a new audio burst), dipping the ratio.
     progress = { playedSeconds: 6, totalSeconds: 20 };
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
   });
 
   test("progress flipping to null (barge-in flush) freezes the cursor", () => {
     progress = { playedSeconds: 5, totalSeconds: 10 };
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
 
     progress = null;
-    pumpFrame();
-    pumpFrame();
+    raf.pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
+  });
+});
+
+describe("useSpokenWordCursor — rate cap", () => {
+  test("a mapped candidate sweeping far ahead advances only by the played-audio budget", () => {
+    progress = { playedSeconds: 1, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(50));
+    raf.pumpFrame();
+    // Adoption: floor(0.1 * 50) = 5.
+    expect(result.current).toBe(5);
+
+    // Near-underrun: played approaches total, so the fraction sweeps toward 1
+    // and the candidate lands near the end of the transcript
+    // (floor((1.5 / 1.6) * 50) = 46) while only 0.5s of audio actually
+    // played. Budget = 0.5 * 5 words/sec = 2 whole words.
+    progress = { playedSeconds: 1.5, totalSeconds: 1.6 };
+    raf.pumpFrame();
+    expect(result.current).toBe(7);
+  });
+
+  test("a normal speaking cadence is never rate-limited", () => {
+    // ~1 word per 0.4s of played audio (2.5 words/sec), under the cap.
+    progress = { playedSeconds: 0.4, totalSeconds: 4 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    raf.pumpFrame();
+    expect(result.current).toBe(1);
+
+    for (let step = 2; step <= 9; step += 1) {
+      progress = { playedSeconds: 0.4 * step, totalSeconds: 4 };
+      raf.pumpFrame();
+      expect(result.current).toBe(step);
+    }
+  });
+
+  test("the adoption jump is uncapped", () => {
+    const { result } = renderHook(() => useSpokenWordCursor(40));
+    raf.pumpFrame();
+    expect(result.current).toBeNull();
+
+    // Mid-response mount: the first usable frame syncs straight to the
+    // playhead, floor(0.8 * 40) = 32, with no budget accrued yet.
+    progress = { playedSeconds: 8, totalSeconds: 10 };
+    raf.pumpFrame();
+    expect(result.current).toBe(32);
   });
 });
 
 describe("useSpokenWordCursor — audio-less responses", () => {
   test("the cursor takes over once the response's first progress arrives", () => {
     const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBeNull();
 
     progress = { playedSeconds: 4, totalSeconds: 10 };
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(4);
   });
 });
@@ -154,17 +214,17 @@ describe("useSpokenWordCursor — per-response reset", () => {
       ({ count }: { count: number }) => useSpokenWordCursor(count),
       { initialProps: { count: 10 } },
     );
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(8);
 
     // New response: the transcript clears (shorter word list), progress resets.
     progress = null;
     rerender({ count: 3 });
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBeNull();
 
     progress = { playedSeconds: 1, totalSeconds: 3 };
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(1);
   });
 
@@ -174,12 +234,12 @@ describe("useSpokenWordCursor — per-response reset", () => {
       ({ count }: { count: number }) => useSpokenWordCursor(count),
       { initialProps: { count: 10 } },
     );
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
 
     progress = null;
     rerender({ count: 12 });
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
   });
 });
@@ -192,17 +252,17 @@ describe("useSpokenWordCursor — render economy and lifecycle", () => {
       renders += 1;
       return useSpokenWordCursor(10);
     });
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(5);
     const rendersAfterFirstIndex = renders;
 
-    pumpFrame();
-    pumpFrame();
-    pumpFrame();
+    raf.pumpFrame();
+    raf.pumpFrame();
+    raf.pumpFrame();
     expect(renders).toBe(rendersAfterFirstIndex);
 
     progress = { playedSeconds: 6, totalSeconds: 10 };
-    pumpFrame();
+    raf.pumpFrame();
     expect(result.current).toBe(6);
     expect(renders).toBe(rendersAfterFirstIndex + 1);
   });

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
@@ -198,11 +198,29 @@ describe("useSpokenWordCursor — rate cap", () => {
     }
 
     // Underrun sweep: the fraction jumps near 1 (candidate 97) while only
-    // 0.5s more audio played. The bank is clamped to one second of
-    // advancement, so the cursor moves at most 5 words past its floor.
+    // 0.5s more audio played. Spendable this frame = the stored bank
+    // (clamped to 5 words) + the 0.5s of newly played audio (2.5 words), so
+    // the cursor moves at most 7 words past its floor instead of sweeping to
+    // the candidate.
     progress = { playedSeconds: 16.5, totalSeconds: 17 };
     raf.pumpFrame();
-    expect(result.current).toBe(45);
+    expect(result.current).toBe(47);
+  });
+
+  test("a delayed frame spends its full earned allowance at once", () => {
+    // Adoption zeroes the bank.
+    progress = { playedSeconds: 0.4, totalSeconds: 40 };
+    const { result } = renderHook(() => useSpokenWordCursor(100));
+    raf.pumpFrame();
+    expect(result.current).toBe(1);
+
+    // A 2s gap between frames (throttled tab while audio plays on) earns
+    // 2 × 5 = 10 words, all spendable in the frame that observes it — even
+    // against a near-1 fraction (candidate 96) the cursor advances by the
+    // full earned allowance instead of crawling at the stored-bank ceiling.
+    progress = { playedSeconds: 2.4, totalSeconds: 2.5 };
+    raf.pumpFrame();
+    expect(result.current).toBe(11);
   });
 
   test("the adoption jump is uncapped", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
@@ -182,6 +182,29 @@ describe("useSpokenWordCursor — rate cap", () => {
     }
   });
 
+  test("budget banked during long tracking cannot fund a one-frame sweep", () => {
+    // Track a 100-word response at a normal ~2.5 words/sec cadence: accrual
+    // (5 words/sec) outpaces consumption, so an unclamped bank would grow by
+    // ~1 word per step and later fund a full sweep in a single frame.
+    progress = { playedSeconds: 0.4, totalSeconds: 40 };
+    const { result } = renderHook(() => useSpokenWordCursor(100));
+    raf.pumpFrame();
+    expect(result.current).toBe(1);
+
+    for (let step = 2; step <= 40; step += 1) {
+      progress = { playedSeconds: 0.4 * step, totalSeconds: 40 };
+      raf.pumpFrame();
+      expect(result.current).toBe(step);
+    }
+
+    // Underrun sweep: the fraction jumps near 1 (candidate 97) while only
+    // 0.5s more audio played. The bank is clamped to one second of
+    // advancement, so the cursor moves at most 5 words past its floor.
+    progress = { playedSeconds: 16.5, totalSeconds: 17 };
+    raf.pumpFrame();
+    expect(result.current).toBe(45);
+  });
+
   test("the adoption jump is uncapped", () => {
     const { result } = renderHook(() => useSpokenWordCursor(40));
     raf.pumpFrame();

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
@@ -1,11 +1,10 @@
 /**
  * Tests for `useSpokenWordCursor`.
  *
- * `requestAnimationFrame` is monkey-patched to capture callbacks so frames are
- * pumped manually inside `act()` (same harness as
- * `voice-timeline-waveform.test.tsx`). Playback progress is driven through the
- * real live-voice store by registering a provider that reads a mutable local
- * value; the store is reset between tests.
+ * Frames are driven manually through the shared rAF harness
+ * (`raf.test-helper.ts`), pumped inside `act()`. Playback progress is driven
+ * through the real live-voice store by registering a provider that reads a
+ * mutable local value; the store is reset between tests.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -14,48 +13,24 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 
 import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
 import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
+import {
+  installRafTestHarness,
+  type RafTestHarness,
+} from "@/domains/chat/voice/raf.test-helper";
 import { useSpokenWordCursor } from "@/domains/chat/voice/voice-room/use-spoken-word-cursor";
 
-// ---------------------------------------------------------------------------
-// requestAnimationFrame harness
-// ---------------------------------------------------------------------------
-
-let rafCallbacks: Map<number, FrameRequestCallback>;
-let nextRafId = 1;
-let originalRaf: typeof globalThis.requestAnimationFrame;
-let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
+let raf: RafTestHarness;
+let progress: LiveVoicePlaybackProgress | null;
 
 /** Fire every pending rAF callback once, inside `act()`. */
 function pumpFrame() {
   act(() => {
-    const callbacks = [...rafCallbacks.values()];
-    rafCallbacks.clear();
-    for (const cb of callbacks) {
-      cb(performance.now());
-    }
+    raf.fireFrame();
   });
 }
 
-// ---------------------------------------------------------------------------
-// Playback-progress fake
-// ---------------------------------------------------------------------------
-
-let progress: LiveVoicePlaybackProgress | null;
-
 beforeEach(() => {
-  rafCallbacks = new Map();
-  nextRafId = 1;
-  originalRaf = globalThis.requestAnimationFrame;
-  originalCancelRaf = globalThis.cancelAnimationFrame;
-  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
-    const id = nextRafId++;
-    rafCallbacks.set(id, cb);
-    return id;
-  }) as typeof globalThis.requestAnimationFrame;
-  globalThis.cancelAnimationFrame = ((id: number) => {
-    rafCallbacks.delete(id);
-  }) as typeof globalThis.cancelAnimationFrame;
-
+  raf = installRafTestHarness();
   progress = null;
   useLiveVoiceStore.getState().reset();
   useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
@@ -63,20 +38,15 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
-  globalThis.requestAnimationFrame = originalRaf;
-  globalThis.cancelAnimationFrame = originalCancelRaf;
+  raf.restore();
   useLiveVoiceStore.getState().reset();
 });
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe("useSpokenWordCursor — mapping", () => {
-  test("null progress maps to the first word", () => {
+  test("null progress yields a null cursor (caller keeps its default highlight)", () => {
     const { result } = renderHook(() => useSpokenWordCursor(10));
     pumpFrame();
-    expect(result.current).toBe(0);
+    expect(result.current).toBeNull();
   });
 
   test("fraction 0.5 over 10 words maps to index 5", () => {
@@ -86,18 +56,56 @@ describe("useSpokenWordCursor — mapping", () => {
     expect(result.current).toBe(5);
   });
 
-  test("fraction 1.0 clamps to the last word", () => {
-    progress = { playedSeconds: 10, totalSeconds: 10 };
-    const { result } = renderHook(() => useSpokenWordCursor(10));
-    pumpFrame();
-    expect(result.current).toBe(9);
-  });
-
-  test("zero-duration progress holds the floor instead of dividing by zero", () => {
+  test("zero-duration progress is not usable audio and keeps the cursor null", () => {
     progress = { playedSeconds: 0, totalSeconds: 0 };
     const { result } = renderHook(() => useSpokenWordCursor(10));
     pumpFrame();
-    expect(result.current).toBe(0);
+    expect(result.current).toBeNull();
+  });
+});
+
+describe("useSpokenWordCursor — drained-queue hold", () => {
+  test("a caught-up queue (played == total) does not advance the cursor past its floor", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(20));
+    pumpFrame();
+    expect(result.current).toBe(10);
+
+    // Mid-response silence: the queue drains while the LLM text streams ahead.
+    progress = { playedSeconds: 10, totalSeconds: 10 };
+    pumpFrame();
+    pumpFrame();
+    expect(result.current).toBe(10);
+  });
+
+  test("text deltas growing wordCount while drained do not move the cursor", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => useSpokenWordCursor(count),
+      { initialProps: { count: 10 } },
+    );
+    pumpFrame();
+    expect(result.current).toBe(5);
+
+    progress = { playedSeconds: 10, totalSeconds: 10 };
+    rerender({ count: 20 });
+    pumpFrame();
+    expect(result.current).toBe(5);
+
+    rerender({ count: 30 });
+    pumpFrame();
+    expect(result.current).toBe(5);
+  });
+
+  test("the cursor reaches the last word during final-buffer playback and holds after the drain", () => {
+    progress = { playedSeconds: 9.9, totalSeconds: 10 };
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBe(9);
+
+    progress = { playedSeconds: 10, totalSeconds: 10 };
+    pumpFrame();
+    expect(result.current).toBe(9);
   });
 });
 
@@ -127,8 +135,20 @@ describe("useSpokenWordCursor — monotonicity", () => {
   });
 });
 
+describe("useSpokenWordCursor — audio-less responses", () => {
+  test("the cursor takes over once the response's first progress arrives", () => {
+    const { result } = renderHook(() => useSpokenWordCursor(10));
+    pumpFrame();
+    expect(result.current).toBeNull();
+
+    progress = { playedSeconds: 4, totalSeconds: 10 };
+    pumpFrame();
+    expect(result.current).toBe(4);
+  });
+});
+
 describe("useSpokenWordCursor — per-response reset", () => {
-  test("shrinking wordCount resets the floor and the cursor restarts at 0", () => {
+  test("shrinking wordCount resets the cursor to null until the new response's audio starts", () => {
     progress = { playedSeconds: 8, totalSeconds: 10 };
     const { result, rerender } = renderHook(
       ({ count }: { count: number }) => useSpokenWordCursor(count),
@@ -140,7 +160,8 @@ describe("useSpokenWordCursor — per-response reset", () => {
     // New response: the transcript clears (shorter word list), progress resets.
     progress = null;
     rerender({ count: 3 });
-    expect(result.current).toBe(0);
+    pumpFrame();
+    expect(result.current).toBeNull();
 
     progress = { playedSeconds: 1, totalSeconds: 3 };
     pumpFrame();
@@ -188,13 +209,13 @@ describe("useSpokenWordCursor — render economy and lifecycle", () => {
 
   test("wordCount 0 schedules no frames", () => {
     renderHook(() => useSpokenWordCursor(0));
-    expect(rafCallbacks.size).toBe(0);
+    expect(raf.pendingCallbacks()).toHaveLength(0);
   });
 
   test("unmount cancels the pending frame", () => {
     const { unmount } = renderHook(() => useSpokenWordCursor(10));
-    expect(rafCallbacks.size).toBe(1);
+    expect(raf.pendingCallbacks()).toHaveLength(1);
     unmount();
-    expect(rafCallbacks.size).toBe(0);
+    expect(raf.pendingCallbacks()).toHaveLength(0);
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -130,33 +130,32 @@ export function useSpokenWordCursor(wordCount: number): number | null {
             budgetRef.current = 0;
           }
         } else {
-          // Accrue advancement budget from real played audio. A non-positive
-          // delta (a fresh player restarting the clock) accrues nothing. The
-          // bank is clamped to about one second of advancement: real speech
-          // consumes less than the accrual rate, and an unclamped surplus
-          // banked over a long response would let a later text burst spend it
-          // all in one frame — a sweep onto unspoken words that the cap
-          // exists to prevent. The clamp keeps just enough headroom for the
-          // cursor to catch up after rAF jank.
+          // Advancement allowance for this frame: the stored bank plus the
+          // words earned by audio that actually played since the previous
+          // frame (a non-positive delta — a fresh player restarting the
+          // clock — earns nothing). The full frame allowance is spendable at
+          // once, so a long gap between frames (a throttled background tab
+          // while audio plays on) catches the cursor up in step with the real
+          // playhead. Only the leftover STORED bank is clamped, to about one
+          // second of advancement: real speech consumes less than the accrual
+          // rate, and an unclamped stored surplus would let a later text
+          // burst spend it all in one frame — a sweep onto unspoken words
+          // that the cap exists to prevent.
+          let available = budgetRef.current;
           if (prevPlayedRef.current !== null) {
             const playedDelta = progress.playedSeconds - prevPlayedRef.current;
             if (playedDelta > 0) {
-              budgetRef.current = Math.min(
-                budgetRef.current + playedDelta * MAX_CURSOR_WORDS_PER_SECOND,
-                MAX_CURSOR_WORDS_PER_SECOND,
-              );
+              available += playedDelta * MAX_CURSOR_WORDS_PER_SECOND;
             }
           }
           prevPlayedRef.current = progress.playedSeconds;
           const floor = cursorRef.current;
           if (candidate !== null && candidate > floor) {
-            const advance = Math.min(
-              candidate - floor,
-              Math.floor(budgetRef.current),
-            );
+            const advance = Math.min(candidate - floor, Math.floor(available));
             next = floor + advance;
-            budgetRef.current -= advance;
+            available -= advance;
           }
+          budgetRef.current = Math.min(available, MAX_CURSOR_WORDS_PER_SECOND);
         }
       }
       if (next !== cursorRef.current) {

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -19,16 +19,25 @@
  * during the final buffer's playback, carrying the cursor onto the last word
  * before the drain.
  *
- * Until the current response schedules audio the hook returns `null`, letting
- * the caller keep its default highlight — a response that produces no TTS
- * audio at all (text streaming through a TTS failure) is not pinned to the
- * first word.
+ * Until the loop observes audio still scheduled the hook returns `null`,
+ * letting the caller keep its default highlight. Adoption (the `null` →
+ * numeric transition) requires a frame with `playedSeconds < totalSeconds`: a
+ * first read that is already drained keeps the `null` cursor, so a response
+ * whose audio finished before the loop ever saw it (a short ack under a
+ * throttled or busy main thread) — like one that produces no TTS audio at all
+ * — is not pinned to an early word.
  *
- * Accepted bias: scheduled audio corresponds to *synthesized* text, which can
- * lag the displayed LLM text mid-stream, so the fraction maps a shorter spoken
- * prefix onto the longer displayed transcript and can overshoot the truly
- * spoken word slightly. The error is bounded by the synthesis lag and
- * self-corrects as synthesis catches up.
+ * Advancement is rate-capped to a plausible speaking cadence. Each frame
+ * accrues a fractional word budget from the played-audio delta
+ * ({@link MAX_CURSOR_WORDS_PER_SECOND}), and the cursor moves at most the
+ * accrued whole words past its current position, consuming the budget it uses.
+ * While displayed text leads synthesis the mapped fraction can sweep far ahead
+ * of real speech (approaching an underrun it lands near the end of the
+ * displayed transcript); the cap keeps the highlight near the truly spoken
+ * word instead of letting the monotonic floor pin the overshoot. The adoption
+ * frame is exempt — a mid-response mount (a caption toggle) jumps straight to
+ * the playhead — and the budget resets on adoption and with the per-response
+ * reset.
  *
  * The cursor is monotonic within a response: a smaller fraction (e.g. the
  * played/total ratio dipping when a new audio burst grows the total) never
@@ -50,10 +59,18 @@ import { useEffect, useRef, useState } from "react";
 import { getLiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/live-voice-store";
 
 /**
+ * Ceiling on cursor advancement, in words per second of played audio.
+ * Comfortably above real speech (~2–3 words/sec) so the cap never binds while
+ * the mapping tracks actual playback; it only clamps the sweep when the
+ * fraction maps a short spoken prefix onto a much longer displayed transcript.
+ */
+const MAX_CURSOR_WORDS_PER_SECOND = 5;
+
+/**
  * Index (into the caller's word segmentation) of the word the TTS playhead is
  * speaking, or `null` while the current response has produced no audio (the
  * caller keeps its default highlight). `wordCount` of 0 idles the loop
- * entirely (the assistant caption unmounts on an empty transcript).
+ * entirely (the caller passes 0 for an empty or hidden caption).
  */
 export function useSpokenWordCursor(wordCount: number): number | null {
   const [index, setIndex] = useState<number | null>(null);
@@ -61,6 +78,10 @@ export function useSpokenWordCursor(wordCount: number): number | null {
   // last returned value, serving as both the monotonic floor and the guard
   // that skips the state write when a frame leaves the index unchanged.
   const cursorRef = useRef<number | null>(null);
+  // Rate-cap state: playedSeconds at the previous frame, and the fractional
+  // word budget accrued from played-audio deltas since the last consumption.
+  const prevPlayedRef = useRef<number | null>(null);
+  const budgetRef = useRef(0);
   const prevCountRef = useRef(wordCount);
 
   // Declared before the loop effect so a shrink (transcript cleared for a new
@@ -69,6 +90,8 @@ export function useSpokenWordCursor(wordCount: number): number | null {
   useEffect(() => {
     if (wordCount < prevCountRef.current) {
       cursorRef.current = null;
+      prevPlayedRef.current = null;
+      budgetRef.current = 0;
       setIndex(null);
     }
     prevCountRef.current = wordCount;
@@ -85,18 +108,45 @@ export function useSpokenWordCursor(wordCount: number): number | null {
       let next = cursorRef.current;
       const progress = getLiveVoicePlaybackProgress();
       if (progress !== null && progress.totalSeconds > 0) {
-        // Audio exists for this response, so the cursor is numeric from here:
-        // at least the floor (0 for a fresh response), advancing only while
-        // audio remains scheduled — a caught-up queue (played == total) holds
-        // rather than mapping the drained fraction onto unspoken words.
-        const floor = cursorRef.current ?? 0;
-        next = floor;
-        if (progress.playedSeconds < progress.totalSeconds) {
-          const mapped = Math.floor(
-            (progress.playedSeconds / progress.totalSeconds) * wordCount,
-          );
-          if (Number.isFinite(mapped)) {
-            next = Math.max(Math.min(mapped, wordCount - 1), floor);
+        // A caught-up queue (played == total) yields no candidate: the drained
+        // fraction of 1.0 says nothing about displayed words with no
+        // synthesized audio yet, so a null cursor stays null (default
+        // highlight) and a numeric one holds its floor.
+        const mapped = Math.floor(
+          (progress.playedSeconds / progress.totalSeconds) * wordCount,
+        );
+        const candidate =
+          progress.playedSeconds < progress.totalSeconds &&
+          Number.isFinite(mapped)
+            ? Math.min(mapped, wordCount - 1)
+            : null;
+        if (cursorRef.current === null) {
+          if (candidate !== null) {
+            // Adoption: jump straight to the playhead, uncapped, so a
+            // mid-response mount (a caption toggle) syncs instantly. The rate
+            // cap applies from here on.
+            next = candidate;
+            prevPlayedRef.current = progress.playedSeconds;
+            budgetRef.current = 0;
+          }
+        } else {
+          // Accrue advancement budget from real played audio. A non-positive
+          // delta (a fresh player restarting the clock) accrues nothing.
+          if (prevPlayedRef.current !== null) {
+            const playedDelta = progress.playedSeconds - prevPlayedRef.current;
+            if (playedDelta > 0) {
+              budgetRef.current += playedDelta * MAX_CURSOR_WORDS_PER_SECOND;
+            }
+          }
+          prevPlayedRef.current = progress.playedSeconds;
+          const floor = cursorRef.current;
+          if (candidate !== null && candidate > floor) {
+            const advance = Math.min(
+              candidate - floor,
+              Math.floor(budgetRef.current),
+            );
+            next = floor + advance;
+            budgetRef.current -= advance;
           }
         }
       }

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -9,6 +9,21 @@
  * word. The mapping assumes words take roughly equal speaking time — close
  * enough for a caption highlight.
  *
+ * The cursor advances only while audio remains scheduled
+ * (`playedSeconds < totalSeconds`). When the queue is caught up
+ * (played == total — a mid-response silence while synthesis lags the streamed
+ * text, or the post-response drain) the drained fraction of 1.0 says nothing
+ * about displayed words that have no synthesized audio yet, so the cursor
+ * holds at the last spoken word; the next audio burst grows the total and the
+ * cursor advances again. End-of-response landing: the fraction sweeps toward 1
+ * during the final buffer's playback, carrying the cursor onto the last word
+ * before the drain.
+ *
+ * Until the current response schedules audio the hook returns `null`, letting
+ * the caller keep its default highlight — a response that produces no TTS
+ * audio at all (text streaming through a TTS failure) is not pinned to the
+ * first word.
+ *
  * Accepted bias: scheduled audio corresponds to *synthesized* text, which can
  * lag the displayed LLM text mid-stream, so the fraction maps a shorter spoken
  * prefix onto the longer displayed transcript and can overshoot the truly
@@ -18,9 +33,10 @@
  * The cursor is monotonic within a response: a smaller fraction (e.g. the
  * played/total ratio dipping when a new audio burst grows the total) never
  * moves it backward, and a `null` progress read (barge-in flush clearing the
- * player) freezes it where speech stopped. The floor resets when `wordCount`
- * shrinks below its previous value — the transcript cleared for a new
- * response — so each response starts at the first word.
+ * player) freezes it where speech stopped. The cursor resets to `null` when
+ * `wordCount` shrinks below its previous value — the transcript cleared for a
+ * new response — so each response starts on the caller's default highlight
+ * until its own audio arrives.
  *
  * State updates land only when the mapped index changes, so the poll runs at
  * frame rate but the subscriber re-renders at word granularity. Reduced
@@ -35,23 +51,25 @@ import { getLiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/li
 
 /**
  * Index (into the caller's word segmentation) of the word the TTS playhead is
- * speaking. Returns 0 while no audio progress exists. `wordCount` of 0 idles
- * the loop entirely (the assistant caption unmounts on an empty transcript).
+ * speaking, or `null` while the current response has produced no audio (the
+ * caller keeps its default highlight). `wordCount` of 0 idles the loop
+ * entirely (the assistant caption unmounts on an empty transcript).
  */
-export function useSpokenWordCursor(wordCount: number): number {
-  const [index, setIndex] = useState(0);
-  // Monotonic floor for the current response; always equals the last returned
-  // index, so the loop skips the state write when the index is unchanged.
-  const floorRef = useRef(0);
+export function useSpokenWordCursor(wordCount: number): number | null {
+  const [index, setIndex] = useState<number | null>(null);
+  // Single source of truth for the cursor between renders: always equals the
+  // last returned value, serving as both the monotonic floor and the guard
+  // that skips the state write when a frame leaves the index unchanged.
+  const cursorRef = useRef<number | null>(null);
   const prevCountRef = useRef(wordCount);
 
   // Declared before the loop effect so a shrink (transcript cleared for a new
-  // response) zeroes the floor before the restarted loop reads it. Synced in
+  // response) clears the cursor before the restarted loop reads it. Synced in
   // an effect, not during render (no render-phase ref writes).
   useEffect(() => {
     if (wordCount < prevCountRef.current) {
-      floorRef.current = 0;
-      setIndex(0);
+      cursorRef.current = null;
+      setIndex(null);
     }
     prevCountRef.current = wordCount;
   }, [wordCount]);
@@ -62,21 +80,28 @@ export function useSpokenWordCursor(wordCount: number): number {
     }
     let raf = 0;
     const tick = () => {
+      // `null` progress → hold: `null` for a fresh response, or frozen where
+      // speech stopped after a barge-in flush.
+      let next = cursorRef.current;
       const progress = getLiveVoicePlaybackProgress();
-      // `null` progress → hold the floor: 0 for a fresh response, or frozen
-      // where speech stopped after a barge-in flush.
-      let candidate = floorRef.current;
       if (progress !== null && progress.totalSeconds > 0) {
-        const mapped = Math.floor(
-          (progress.playedSeconds / progress.totalSeconds) * wordCount,
-        );
-        if (Number.isFinite(mapped)) {
-          candidate = Math.min(mapped, wordCount - 1);
+        // Audio exists for this response, so the cursor is numeric from here:
+        // at least the floor (0 for a fresh response), advancing only while
+        // audio remains scheduled — a caught-up queue (played == total) holds
+        // rather than mapping the drained fraction onto unspoken words.
+        const floor = cursorRef.current ?? 0;
+        next = floor;
+        if (progress.playedSeconds < progress.totalSeconds) {
+          const mapped = Math.floor(
+            (progress.playedSeconds / progress.totalSeconds) * wordCount,
+          );
+          if (Number.isFinite(mapped)) {
+            next = Math.max(Math.min(mapped, wordCount - 1), floor);
+          }
         }
       }
-      const next = Math.max(candidate, floorRef.current);
-      if (next !== floorRef.current) {
-        floorRef.current = next;
+      if (next !== cursorRef.current) {
+        cursorRef.current = next;
         setIndex(next);
       }
       raf = requestAnimationFrame(tick);

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -131,11 +131,20 @@ export function useSpokenWordCursor(wordCount: number): number | null {
           }
         } else {
           // Accrue advancement budget from real played audio. A non-positive
-          // delta (a fresh player restarting the clock) accrues nothing.
+          // delta (a fresh player restarting the clock) accrues nothing. The
+          // bank is clamped to about one second of advancement: real speech
+          // consumes less than the accrual rate, and an unclamped surplus
+          // banked over a long response would let a later text burst spend it
+          // all in one frame — a sweep onto unspoken words that the cap
+          // exists to prevent. The clamp keeps just enough headroom for the
+          // cursor to catch up after rAF jank.
           if (prevPlayedRef.current !== null) {
             const playedDelta = progress.playedSeconds - prevPlayedRef.current;
             if (playedDelta > 0) {
-              budgetRef.current += playedDelta * MAX_CURSOR_WORDS_PER_SECOND;
+              budgetRef.current = Math.min(
+                budgetRef.current + playedDelta * MAX_CURSOR_WORDS_PER_SECOND,
+                MAX_CURSOR_WORDS_PER_SECOND,
+              );
             }
           }
           prevPlayedRef.current = progress.playedSeconds;

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -1,0 +1,89 @@
+/**
+ * Word cursor driven by the TTS audio playhead, for the voice-room transcript's
+ * leading-edge highlight.
+ *
+ * A `requestAnimationFrame` loop polls {@link getLiveVoicePlaybackProgress}
+ * (played/total seconds of the current response's scheduled audio) and maps the
+ * played fraction onto the caller's word count:
+ * `floor((playedSeconds / totalSeconds) * wordCount)`, clamped to the last
+ * word. The mapping assumes words take roughly equal speaking time — close
+ * enough for a caption highlight.
+ *
+ * Accepted bias: scheduled audio corresponds to *synthesized* text, which can
+ * lag the displayed LLM text mid-stream, so the fraction maps a shorter spoken
+ * prefix onto the longer displayed transcript and can overshoot the truly
+ * spoken word slightly. The error is bounded by the synthesis lag and
+ * self-corrects as synthesis catches up.
+ *
+ * The cursor is monotonic within a response: a smaller fraction (e.g. the
+ * played/total ratio dipping when a new audio burst grows the total) never
+ * moves it backward, and a `null` progress read (barge-in flush clearing the
+ * player) freezes it where speech stopped. The floor resets when `wordCount`
+ * shrinks below its previous value — the transcript cleared for a new
+ * response — so each response starts at the first word.
+ *
+ * State updates land only when the mapped index changes, so the poll runs at
+ * frame rate but the subscriber re-renders at word granularity. Reduced
+ * motion: the cursor advances regardless — the visual it drives is a
+ * color-only change owned by `VoiceTranscriptText`, which already gates its
+ * motion separately.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import { getLiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/live-voice-store";
+
+/**
+ * Index (into the caller's word segmentation) of the word the TTS playhead is
+ * speaking. Returns 0 while no audio progress exists. `wordCount` of 0 idles
+ * the loop entirely (the assistant caption unmounts on an empty transcript).
+ */
+export function useSpokenWordCursor(wordCount: number): number {
+  const [index, setIndex] = useState(0);
+  // Monotonic floor for the current response; always equals the last returned
+  // index, so the loop skips the state write when the index is unchanged.
+  const floorRef = useRef(0);
+  const prevCountRef = useRef(wordCount);
+
+  // Declared before the loop effect so a shrink (transcript cleared for a new
+  // response) zeroes the floor before the restarted loop reads it. Synced in
+  // an effect, not during render (no render-phase ref writes).
+  useEffect(() => {
+    if (wordCount < prevCountRef.current) {
+      floorRef.current = 0;
+      setIndex(0);
+    }
+    prevCountRef.current = wordCount;
+  }, [wordCount]);
+
+  useEffect(() => {
+    if (wordCount <= 0) {
+      return;
+    }
+    let raf = 0;
+    const tick = () => {
+      const progress = getLiveVoicePlaybackProgress();
+      // `null` progress → hold the floor: 0 for a fresh response, or frozen
+      // where speech stopped after a barge-in flush.
+      let candidate = floorRef.current;
+      if (progress !== null && progress.totalSeconds > 0) {
+        const mapped = Math.floor(
+          (progress.playedSeconds / progress.totalSeconds) * wordCount,
+        );
+        if (Number.isFinite(mapped)) {
+          candidate = Math.min(mapped, wordCount - 1);
+        }
+      }
+      const next = Math.max(candidate, floorRef.current);
+      if (next !== floorRef.current) {
+        floorRef.current = next;
+        setIndex(next);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [wordCount]);
+
+  return index;
+}

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -5,9 +5,13 @@
  * A `requestAnimationFrame` loop polls {@link getLiveVoicePlaybackProgress}
  * (played/total seconds of the current response's scheduled audio) and maps the
  * played fraction onto the caller's word count:
- * `floor((playedSeconds / totalSeconds) * wordCount)`, clamped to the last
- * word. The mapping assumes words take roughly equal speaking time — close
- * enough for a caption highlight.
+ * `floor((playedSeconds / totalSeconds) * wordCount)`, bounded by the spoken
+ * ceiling `playedSeconds × MAX_SPEECH_WORDS_PER_SECOND` and clamped to the
+ * last word. The fraction assumes words take roughly equal speaking time and
+ * that the scheduled audio covers every displayed word; while the response is
+ * still streaming the audio covers only a synthesized prefix, and the ceiling
+ * keeps the cursor at the pace of real speech until the mapping becomes
+ * trustworthy.
  *
  * The cursor advances only while audio remains scheduled
  * (`playedSeconds < totalSeconds`). When the queue is caught up
@@ -67,6 +71,19 @@ import { getLiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/li
 const MAX_CURSOR_WORDS_PER_SECOND = 5;
 
 /**
+ * Ceiling on the cursor's absolute position, in words per second of played
+ * audio (~200 words/min, an upper bound on real TTS cadence). While a
+ * response streams, the scheduled audio covers only a synthesized prefix of
+ * the displayed words, so the played fraction maps onto too many words and
+ * runs ahead of speech; `playedSeconds` × this rate bounds the cursor to what
+ * real speech could have reached. Once the response has fully streamed the
+ * fraction mapping implies the voice's true (lower) rate and this ceiling
+ * stops binding. A voice faster than this rate trails slightly instead of
+ * leading — the lesser artifact.
+ */
+const MAX_SPEECH_WORDS_PER_SECOND = 3.3;
+
+/**
  * Index (into the caller's word segmentation) of the word the TTS playhead is
  * speaking, or `null` while the current response has produced no audio (the
  * caller keeps its default highlight). `wordCount` of 0 idles the loop
@@ -112,8 +129,17 @@ export function useSpokenWordCursor(wordCount: number): number | null {
         // fraction of 1.0 says nothing about displayed words with no
         // synthesized audio yet, so a null cursor stays null (default
         // highlight) and a numeric one holds its floor.
-        const mapped = Math.floor(
-          (progress.playedSeconds / progress.totalSeconds) * wordCount,
+        // The fraction mapping assumes the scheduled audio covers every
+        // displayed word — true once the response has fully streamed, but
+        // while text is still arriving the audio covers only a synthesized
+        // prefix and the fraction overshoots. The spoken ceiling bounds the
+        // cursor to the words real speech could have reached in the played
+        // seconds.
+        const mapped = Math.min(
+          Math.floor(
+            (progress.playedSeconds / progress.totalSeconds) * wordCount,
+          ),
+          Math.floor(progress.playedSeconds * MAX_SPEECH_WORDS_PER_SECOND),
         );
         const candidate =
           progress.playedSeconds < progress.totalSeconds &&

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
@@ -198,13 +198,6 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
   let raf: RafTestHarness;
   let progress: LiveVoicePlaybackProgress | null;
 
-  /** Fire every pending rAF callback once, inside `act()`. */
-  function pumpFrame() {
-    act(() => {
-      raf.fireFrame();
-    });
-  }
-
   /** Text of the word span carrying the bright leading-edge tone. */
   function leadingWordIn(half: HTMLElement) {
     return half.querySelector("[data-leading]")?.textContent;
@@ -232,16 +225,39 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
     seedAssistant("alpha beta gamma delta");
     setPrefs({ user: false, assistant: true });
     render(<VoiceAmbientTranscript />);
-    pumpFrame();
+    raf.pumpFrame();
     // floor(0.5 * 4 words) = index 2 — mid-transcript, not the last word.
     expect(leadingWordIn(assistantText()!)).toBe("gamma");
+  });
+
+  test("a first read that is already drained keeps the default last-word edge", () => {
+    // The response's audio finished before the cursor loop ever observed a
+    // sub-total frame: the rail keeps the default reveal, not a pinned first
+    // word.
+    progress = { playedSeconds: 3, totalSeconds: 3 };
+    registerProgressProvider();
+    seedAssistant("alpha beta gamma delta");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    raf.pumpFrame();
+    raf.pumpFrame();
+    expect(leadingWordIn(assistantText()!)).toBe("delta");
+  });
+
+  test("schedules no frames while assistant captions are off", () => {
+    registerProgressProvider();
+    seedAssistant("alpha beta gamma delta");
+    setPrefs({ user: false, assistant: false });
+    render(<VoiceAmbientTranscript />);
+    expect(raf.requestCount()).toBe(0);
+    expect(raf.pendingCallbacks()).toHaveLength(0);
   });
 
   test("no registered provider keeps the default last-word leading edge", () => {
     seedAssistant("alpha beta gamma delta");
     setPrefs({ user: false, assistant: true });
     render(<VoiceAmbientTranscript />);
-    pumpFrame();
+    raf.pumpFrame();
     expect(leadingWordIn(assistantText()!)).toBe("delta");
   });
 
@@ -250,12 +266,12 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
     seedAssistant("alpha beta gamma delta");
     setPrefs({ user: false, assistant: true });
     render(<VoiceAmbientTranscript />);
-    pumpFrame();
+    raf.pumpFrame();
     // No audio yet: default reveal, the newest word leads.
     expect(leadingWordIn(assistantText()!)).toBe("delta");
 
     progress = { playedSeconds: 5, totalSeconds: 10 };
-    pumpFrame();
+    raf.pumpFrame();
     expect(leadingWordIn(assistantText()!)).toBe("gamma");
   });
 
@@ -265,17 +281,17 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
     seedAssistant("alpha beta gamma delta");
     setPrefs({ user: false, assistant: true });
     render(<VoiceAmbientTranscript />);
-    pumpFrame();
+    raf.pumpFrame();
     expect(leadingWordIn(assistantText()!)).toBe("gamma");
 
     // Next response: the transcript clears (shorter word list), no audio yet.
     progress = null;
     seedAssistant("fresh words");
-    pumpFrame();
+    raf.pumpFrame();
     expect(leadingWordIn(assistantText()!)).toBe("words");
 
     progress = { playedSeconds: 1, totalSeconds: 4 };
-    pumpFrame();
+    raf.pumpFrame();
     // floor(0.25 * 2 words) = index 0 — the cursor is live again.
     expect(leadingWordIn(assistantText()!)).toBe("fresh");
   });
@@ -286,7 +302,7 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
     seedUser("one two three four");
     setPrefs({ user: true, assistant: false });
     render(<VoiceAmbientTranscript />);
-    pumpFrame();
+    raf.pumpFrame();
     expect(leadingWordIn(userText()!)).toBe("four");
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
@@ -7,10 +7,9 @@
  * toggles via the voice-prefs store. The load-bearing contract is the
  * pref-gating — both prefs default OFF, so the room stays text-free — plus the
  * user-before-assistant DOM ordering. The spoken-word cursor block additionally
- * stubs `requestAnimationFrame` with a manual pump (same harness as
- * `use-spoken-word-cursor.test.tsx`) and drives playback progress through the
- * store's provider, asserting the leading tone via the `data-leading`
- * attribute on word spans.
+ * drives frames through the shared rAF harness (`raf.test-helper.ts`) and
+ * playback progress through the store's provider, asserting the leading tone
+ * via the `data-leading` attribute on word spans.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -22,6 +21,10 @@ import {
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
+import {
+  installRafTestHarness,
+  type RafTestHarness,
+} from "@/domains/chat/voice/raf.test-helper";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 import { VoiceAmbientTranscript } from "@/domains/chat/voice/voice-room/voice-ambient-transcript";
@@ -192,20 +195,13 @@ describe("VoiceAmbientTranscript — sourcing and ordering", () => {
 });
 
 describe("VoiceAmbientTranscript — spoken-word cursor", () => {
-  let rafCallbacks: Map<number, FrameRequestCallback>;
-  let nextRafId: number;
-  let originalRaf: typeof globalThis.requestAnimationFrame;
-  let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
+  let raf: RafTestHarness;
   let progress: LiveVoicePlaybackProgress | null;
 
   /** Fire every pending rAF callback once, inside `act()`. */
   function pumpFrame() {
     act(() => {
-      const callbacks = [...rafCallbacks.values()];
-      rafCallbacks.clear();
-      for (const cb of callbacks) {
-        cb(performance.now());
-      }
+      raf.fireFrame();
     });
   }
 
@@ -214,33 +210,25 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
     return half.querySelector("[data-leading]")?.textContent;
   }
 
+  function registerProgressProvider() {
+    act(() => {
+      useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
+    });
+  }
+
   beforeEach(() => {
-    rafCallbacks = new Map();
-    nextRafId = 1;
-    originalRaf = globalThis.requestAnimationFrame;
-    originalCancelRaf = globalThis.cancelAnimationFrame;
-    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
-      const id = nextRafId++;
-      rafCallbacks.set(id, cb);
-      return id;
-    }) as typeof globalThis.requestAnimationFrame;
-    globalThis.cancelAnimationFrame = ((id: number) => {
-      rafCallbacks.delete(id);
-    }) as typeof globalThis.cancelAnimationFrame;
+    raf = installRafTestHarness();
     progress = null;
   });
 
   afterEach(() => {
     cleanup();
-    globalThis.requestAnimationFrame = originalRaf;
-    globalThis.cancelAnimationFrame = originalCancelRaf;
+    raf.restore();
   });
 
   test("highlight sits on the mid-transcript word at playback fraction 0.5", () => {
     progress = { playedSeconds: 5, totalSeconds: 10 };
-    act(() => {
-      useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
-    });
+    registerProgressProvider();
     seedAssistant("alpha beta gamma delta");
     setPrefs({ user: false, assistant: true });
     render(<VoiceAmbientTranscript />);
@@ -249,19 +237,52 @@ describe("VoiceAmbientTranscript — spoken-word cursor", () => {
     expect(leadingWordIn(assistantText()!)).toBe("gamma");
   });
 
-  test("no registered provider keeps the highlight on the first word", () => {
+  test("no registered provider keeps the default last-word leading edge", () => {
     seedAssistant("alpha beta gamma delta");
     setPrefs({ user: false, assistant: true });
     render(<VoiceAmbientTranscript />);
     pumpFrame();
-    expect(leadingWordIn(assistantText()!)).toBe("alpha");
+    expect(leadingWordIn(assistantText()!)).toBe("delta");
+  });
+
+  test("cursor takes over from the default reveal once playback progress arrives", () => {
+    registerProgressProvider();
+    seedAssistant("alpha beta gamma delta");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    pumpFrame();
+    // No audio yet: default reveal, the newest word leads.
+    expect(leadingWordIn(assistantText()!)).toBe("delta");
+
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    pumpFrame();
+    expect(leadingWordIn(assistantText()!)).toBe("gamma");
+  });
+
+  test("new response reverts to the default reveal until its own audio starts", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    registerProgressProvider();
+    seedAssistant("alpha beta gamma delta");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    pumpFrame();
+    expect(leadingWordIn(assistantText()!)).toBe("gamma");
+
+    // Next response: the transcript clears (shorter word list), no audio yet.
+    progress = null;
+    seedAssistant("fresh words");
+    pumpFrame();
+    expect(leadingWordIn(assistantText()!)).toBe("words");
+
+    progress = { playedSeconds: 1, totalSeconds: 4 };
+    pumpFrame();
+    // floor(0.25 * 2 words) = index 0 — the cursor is live again.
+    expect(leadingWordIn(assistantText()!)).toBe("fresh");
   });
 
   test("user bubble keeps its default last-word leading edge", () => {
     progress = { playedSeconds: 5, totalSeconds: 10 };
-    act(() => {
-      useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
-    });
+    registerProgressProvider();
     seedUser("one two three four");
     setPrefs({ user: true, assistant: false });
     render(<VoiceAmbientTranscript />);

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.test.tsx
@@ -6,7 +6,11 @@
  * selectors: transcript fields via the live-voice store, the two visibility
  * toggles via the voice-prefs store. The load-bearing contract is the
  * pref-gating — both prefs default OFF, so the room stays text-free — plus the
- * user-before-assistant DOM ordering.
+ * user-before-assistant DOM ordering. The spoken-word cursor block additionally
+ * stubs `requestAnimationFrame` with a manual pump (same harness as
+ * `use-spoken-word-cursor.test.tsx`) and drives playback progress through the
+ * store's provider, asserting the leading tone via the `data-leading`
+ * attribute on word spans.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -17,6 +21,7 @@ import {
   type LiveVoiceSessionState,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 import { VoiceAmbientTranscript } from "@/domains/chat/voice/voice-room/voice-ambient-transcript";
@@ -183,5 +188,84 @@ describe("VoiceAmbientTranscript — sourcing and ordering", () => {
       useLiveVoiceStore.getState().appendAssistantTranscript("lo world");
     });
     expect(assistantText()?.textContent).toContain("Hello world");
+  });
+});
+
+describe("VoiceAmbientTranscript — spoken-word cursor", () => {
+  let rafCallbacks: Map<number, FrameRequestCallback>;
+  let nextRafId: number;
+  let originalRaf: typeof globalThis.requestAnimationFrame;
+  let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
+  let progress: LiveVoicePlaybackProgress | null;
+
+  /** Fire every pending rAF callback once, inside `act()`. */
+  function pumpFrame() {
+    act(() => {
+      const callbacks = [...rafCallbacks.values()];
+      rafCallbacks.clear();
+      for (const cb of callbacks) {
+        cb(performance.now());
+      }
+    });
+  }
+
+  /** Text of the word span carrying the bright leading-edge tone. */
+  function leadingWordIn(half: HTMLElement) {
+    return half.querySelector("[data-leading]")?.textContent;
+  }
+
+  beforeEach(() => {
+    rafCallbacks = new Map();
+    nextRafId = 1;
+    originalRaf = globalThis.requestAnimationFrame;
+    originalCancelRaf = globalThis.cancelAnimationFrame;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      const id = nextRafId++;
+      rafCallbacks.set(id, cb);
+      return id;
+    }) as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((id: number) => {
+      rafCallbacks.delete(id);
+    }) as typeof globalThis.cancelAnimationFrame;
+    progress = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.requestAnimationFrame = originalRaf;
+    globalThis.cancelAnimationFrame = originalCancelRaf;
+  });
+
+  test("highlight sits on the mid-transcript word at playback fraction 0.5", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    act(() => {
+      useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
+    });
+    seedAssistant("alpha beta gamma delta");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    pumpFrame();
+    // floor(0.5 * 4 words) = index 2 — mid-transcript, not the last word.
+    expect(leadingWordIn(assistantText()!)).toBe("gamma");
+  });
+
+  test("no registered provider keeps the highlight on the first word", () => {
+    seedAssistant("alpha beta gamma delta");
+    setPrefs({ user: false, assistant: true });
+    render(<VoiceAmbientTranscript />);
+    pumpFrame();
+    expect(leadingWordIn(assistantText()!)).toBe("alpha");
+  });
+
+  test("user bubble keeps its default last-word leading edge", () => {
+    progress = { playedSeconds: 5, totalSeconds: 10 };
+    act(() => {
+      useLiveVoiceStore.getState().setPlaybackProgressProvider(() => progress);
+    });
+    seedUser("one two three four");
+    setPrefs({ user: true, assistant: false });
+    render(<VoiceAmbientTranscript />);
+    pumpFrame();
+    expect(leadingWordIn(userText()!)).toBe("four");
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -28,8 +28,9 @@
  * prefs, and the low-frequency `state`/`reconnecting` (per-turn, for the
  * listening gate) — so the high-frequency `inputAmplitude` churn on the
  * live-voice store never re-renders this component. The spoken-word cursor
- * keeps that invariant: it polls playback progress outside React and re-renders
- * only when the word index changes. The full transcript still lands in the chat
+ * keeps that invariant: it polls playback progress outside React, re-renders
+ * only when the word index changes, and idles entirely (no frames scheduled)
+ * while assistant captions are off. The full transcript still lands in the chat
  * thread on exit via the engine path; this is a live, ambient echo of the
  * current turn only.
  */
@@ -68,7 +69,12 @@ export function VoiceAmbientTranscript() {
     () => splitTranscriptWords(assistantTranscript),
     [assistantTranscript],
   );
-  const spokenIndex = useSpokenWordCursor(assistantWords.length);
+  // A word count of 0 idles the cursor's rAF loop while assistant captions
+  // are off, so the hidden caption costs no per-frame work; toggling the pref
+  // on mid-response re-syncs on the next frame via the cursor's adoption path.
+  const spokenIndex = useSpokenWordCursor(
+    showAssistant ? assistantWords.length : 0,
+  );
 
   // In-flight partial wins over the last finalized transcript — same precedence
   // as the underneath composer transcript (`VoiceLiveTranscript`).

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -19,7 +19,10 @@
  * {@link VoiceTranscriptText}. The assistant half's bright leading-edge tone
  * tracks the TTS playhead — {@link useSpokenWordCursor} maps audio progress
  * onto the word list, so the highlight sits on the word being *spoken* rather
- * than the last-arrived one while the streamed text runs ahead of speech.
+ * than the last-arrived one while the streamed text runs ahead of speech. A
+ * `null` cursor (the response has produced no audio yet) falls back to the
+ * default last-word reveal, so an audio-less response keeps a live leading
+ * edge instead of a dead first-word highlight.
  *
  * Subscriptions are deliberately narrow — the three transcript fields, the two
  * prefs, and the low-frequency `state`/`reconnecting` (per-turn, for the
@@ -150,7 +153,7 @@ export function VoiceAmbientTranscript() {
                 <div className="max-w-[95%] break-words text-[clamp(15px,2vmin,19px)] leading-relaxed">
                   <VoiceTranscriptText
                     text={assistantTranscript}
-                    highlightIndex={spokenIndex}
+                    highlightIndex={spokenIndex ?? undefined}
                   />
                 </div>
               </motion.div>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -16,23 +16,34 @@
  * Both prefs default OFF, so by default this renders nothing and the room stays
  * text-free. The rail is `pointer-events-none`, so it never blocks the room's
  * ✕/gear controls or the mic/stop cluster. Words reveal one at a time via
- * {@link VoiceTranscriptText}.
+ * {@link VoiceTranscriptText}. The assistant half's bright leading-edge tone
+ * tracks the TTS playhead — {@link useSpokenWordCursor} maps audio progress
+ * onto the word list, so the highlight sits on the word being *spoken* rather
+ * than the last-arrived one while the streamed text runs ahead of speech.
  *
  * Subscriptions are deliberately narrow — the three transcript fields, the two
  * prefs, and the low-frequency `state`/`reconnecting` (per-turn, for the
  * listening gate) — so the high-frequency `inputAmplitude` churn on the
- * live-voice store never re-renders this component. The full transcript still
- * lands in the chat thread on exit via the engine path; this is a live, ambient
- * echo of the current turn only.
+ * live-voice store never re-renders this component. The spoken-word cursor
+ * keeps that invariant: it polls playback progress outside React and re-renders
+ * only when the word index changes. The full transcript still lands in the chat
+ * thread on exit via the engine path; this is a live, ambient echo of the
+ * current turn only.
  */
+
+import { useMemo } from "react";
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
+import { useSpokenWordCursor } from "./use-spoken-word-cursor";
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
-import { VoiceTranscriptText } from "./voice-transcript-text";
+import {
+  splitTranscriptWords,
+  VoiceTranscriptText,
+} from "./voice-transcript-text";
 
 export function VoiceAmbientTranscript() {
   const showUser = useVoicePrefsStore.use.showUserTranscript();
@@ -47,6 +58,14 @@ export function VoiceAmbientTranscript() {
   const reconnecting = useLiveVoiceStore.use.reconnecting();
   const assistantAudioActive = useLiveVoiceStore.use.assistantAudioActive();
   const reduce = useReducedMotion();
+
+  // The same word segmentation `VoiceTranscriptText` renders, so the spoken
+  // cursor indexes the exact words on screen.
+  const assistantWords = useMemo(
+    () => splitTranscriptWords(assistantTranscript),
+    [assistantTranscript],
+  );
+  const spokenIndex = useSpokenWordCursor(assistantWords.length);
 
   // In-flight partial wins over the last finalized transcript — same precedence
   // as the underneath composer transcript (`VoiceLiveTranscript`).
@@ -129,7 +148,10 @@ export function VoiceAmbientTranscript() {
                 {...fade}
               >
                 <div className="max-w-[95%] break-words text-[clamp(15px,2vmin,19px)] leading-relaxed">
-                  <VoiceTranscriptText text={assistantTranscript} />
+                  <VoiceTranscriptText
+                    text={assistantTranscript}
+                    highlightIndex={spokenIndex}
+                  />
                 </div>
               </motion.div>
             ) : null}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.test.tsx
@@ -1,21 +1,39 @@
 /**
  * Tests for `VoiceTranscriptText`.
  *
- * Two load-bearing contracts: the plain sentence is exactly the rendered
- * `textContent` (so the caller's `aria-live` region announces it verbatim),
- * and an optional `color` flattens every word to that single tone (the default
- * two-tone leading-edge look applies only when `color` is omitted).
+ * Load-bearing contracts: the plain sentence is exactly the rendered
+ * `textContent` (so the caller's `aria-live` region announces it verbatim);
+ * an optional `color` flattens every word to that single tone (the default
+ * two-tone leading-edge look applies only when `color` is omitted); and an
+ * optional `highlightIndex` moves the bright leading-edge tone to that word
+ * (clamped) so an audio-playhead cursor can track the spoken word.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
 
 import { cleanup, render } from "@testing-library/react";
 
-import { VoiceTranscriptText } from "@/domains/chat/voice/voice-room/voice-transcript-text";
+import {
+  splitTranscriptWords,
+  VoiceTranscriptText,
+} from "@/domains/chat/voice/voice-room/voice-transcript-text";
 
 afterEach(() => {
   cleanup();
 });
+
+/**
+ * Which word carries the bright leading-edge tone. The tone is a `var()` color
+ * with a fallback, which happy-dom drops from inline style entirely — so the
+ * component marks the leading word with `data-leading` and the tests assert on
+ * that (the `color`-override tests below still assert on `style.color`, which
+ * happy-dom preserves for concrete values).
+ */
+function leadingFlags(container: HTMLElement): boolean[] {
+  return [...container.querySelectorAll("span")].map((span) =>
+    span.hasAttribute("data-leading"),
+  );
+}
 
 describe("VoiceTranscriptText", () => {
   test("exposes the plain sentence as textContent", () => {
@@ -33,5 +51,73 @@ describe("VoiceTranscriptText", () => {
     for (const span of spans) {
       expect(span.style.color).toBe("rgb(1, 2, 3)");
     }
+  });
+
+  test("last word carries the leading tone when highlightIndex is omitted", () => {
+    const { container } = render(<VoiceTranscriptText text="one two three" />);
+    expect(leadingFlags(container)).toEqual([false, false, true]);
+  });
+
+  test("highlightIndex moves the leading tone to that word", () => {
+    const { container } = render(
+      <VoiceTranscriptText text="one two three" highlightIndex={1} />,
+    );
+    // The cursor owns the highlight — the last-arrived word renders the muted base.
+    expect(leadingFlags(container)).toEqual([false, true, false]);
+  });
+
+  test("out-of-range highlightIndex clamps to the last word", () => {
+    const { container } = render(
+      <VoiceTranscriptText text="one two three" highlightIndex={99} />,
+    );
+    expect(leadingFlags(container)).toEqual([false, false, true]);
+  });
+
+  test("negative highlightIndex clamps to the first word", () => {
+    const { container } = render(
+      <VoiceTranscriptText text="one two three" highlightIndex={-3} />,
+    );
+    expect(leadingFlags(container)).toEqual([true, false, false]);
+  });
+
+  test("non-finite highlightIndex normalizes to the first word", () => {
+    // NaN would otherwise propagate through the clamp and leave no word
+    // carrying the leading tone.
+    const { container } = render(
+      <VoiceTranscriptText text="one two three" highlightIndex={Number.NaN} />,
+    );
+    expect(leadingFlags(container)).toEqual([true, false, false]);
+  });
+
+  test("color override still flattens every word when highlightIndex is set", () => {
+    const { container } = render(
+      <VoiceTranscriptText
+        text="one two three"
+        color="rgb(1, 2, 3)"
+        highlightIndex={1}
+      />,
+    );
+    const spans = container.querySelectorAll("span");
+    expect(spans.length).toBe(3);
+    for (const span of spans) {
+      expect(span.style.color).toBe("rgb(1, 2, 3)");
+    }
+  });
+
+  test("textContent is unchanged when highlightIndex is set", () => {
+    const { container } = render(
+      <VoiceTranscriptText text="hello world" highlightIndex={0} />,
+    );
+    expect(container.textContent).toBe("hello world");
+  });
+
+  test("splitTranscriptWords matches the rendered segmentation", () => {
+    // The cursor maps audio progress onto this segmentation, so it must be
+    // exactly what the component renders — one span per returned word.
+    const text = "  hello   brave\nworld ";
+    expect(splitTranscriptWords(text)).toEqual(["hello", "brave", "world"]);
+    const { container } = render(<VoiceTranscriptText text={text} />);
+    expect(container.querySelectorAll("span").length).toBe(3);
+    expect(container.textContent).toBe("hello brave world");
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript-text.tsx
@@ -5,9 +5,13 @@
  * flat string makes each update land as a hard text swap. This splits the text
  * into words keyed by position so that, as the string grows, only the newly
  * arrived words mount — each fading + rising + de-blurring into place — while
- * the words already on screen stay put. The most recent word carries a brighter
- * "leading edge" tone that cools to the muted base as the next word arrives, so
- * the caption reads as speech flowing forward rather than a block appearing.
+ * the words already on screen stay put. By default the most recent word carries
+ * a brighter "leading edge" tone that cools to the muted base as the next word
+ * arrives, so the caption reads as speech flowing forward rather than a block
+ * appearing. When the caller supplies an audio-playhead cursor via
+ * `highlightIndex`, the leading edge tracks the *spoken* word instead of the
+ * last-arrived one, so the highlight stays with the voice even while the
+ * streamed text runs ahead of TTS.
  *
  * Index keys (not content) are deliberate: a streaming append leaves earlier
  * indices unchanged so they never re-animate, and a partial-transcript revision
@@ -26,17 +30,34 @@
 import { Fragment, useMemo } from "react";
 import { motion, useReducedMotion } from "motion/react";
 
+/**
+ * The exact word segmentation the component renders (whitespace runs collapse,
+ * empty tokens drop). Exported so the spoken-word cursor maps audio progress
+ * onto the same words the render uses.
+ */
+export function splitTranscriptWords(text: string): string[] {
+  return text.split(/\s+/).filter(Boolean);
+}
+
 export function VoiceTranscriptText({
   text,
   color,
+  highlightIndex,
 }: {
   text: string;
   /**
    * Paints every word this single tone (a flat reveal). Omit to keep the
    * two-tone look — the leading-edge word brighter (`--room-fg`), the settled
-   * words muted (`--room-fg-muted`).
+   * words muted (`--room-fg-muted`). Takes precedence over `highlightIndex`.
    */
   color?: string;
+  /**
+   * Index (into `splitTranscriptWords(text)`) of the word carrying the bright
+   * leading-edge tone — supplied by an audio-playhead cursor so the highlight
+   * tracks the currently *spoken* word. Clamped to the rendered words; the
+   * caller owns monotonicity. Omit to keep the default last-word leading edge.
+   */
+  highlightIndex?: number;
 }) {
   const reduce = useReducedMotion();
   // A caller-supplied `color` flattens the reveal to one tone; otherwise the
@@ -46,13 +67,22 @@ export function VoiceTranscriptText({
   // Collapse runs of whitespace to single spaces — the words are laid out with
   // real space text nodes between them (so they wrap and select naturally, and
   // `textContent` reads back as the plain sentence).
-  const words = useMemo(() => text.split(/\s+/).filter(Boolean), [text]);
+  const words = useMemo(() => splitTranscriptWords(text), [text]);
   const lastIndex = words.length - 1;
+  // Non-finite cursors (e.g. a NaN from not-yet-initialized playhead math)
+  // normalize to the first word — clamping alone would propagate NaN and leave
+  // no word carrying the leading tone.
+  const leadingIndex =
+    highlightIndex === undefined
+      ? lastIndex
+      : Number.isFinite(highlightIndex)
+        ? Math.min(Math.max(0, Math.floor(highlightIndex)), lastIndex)
+        : 0;
 
   return (
     <>
       {words.map((word, i) => {
-        const leading = i === lastIndex;
+        const leading = i === leadingIndex;
         return (
           <Fragment key={i}>
             <motion.span
@@ -60,6 +90,11 @@ export function VoiceTranscriptText({
               // wraps within its container instead of overflowing the narrow
               // transcript rail and being clipped.
               className="inline-block max-w-full [overflow-wrap:anywhere]"
+              // Marks the word carrying the bright leading-edge tone. The tone
+              // itself is the `color` below; the attribute is the observable
+              // for tests (happy-dom drops `var()` colors with fallbacks from
+              // inline style) and for debugging the spoken-word cursor.
+              data-leading={leading || undefined}
               style={{
                 color: leading ? leadingColor : baseColor,
                 // The leading-edge tone eases back to the base as the next word

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 // The transcript reveal leans on the app's global CSS (content tokens, the
@@ -208,6 +209,40 @@ export const Reveal: Story = {
   render: (args) => <RevealScene wordMs={args.wordMs} replay={args.replay} />,
 };
 
+/**
+ * The spoken-word cursor look: the full sentence has already
+ * streamed in, but a static mid-sentence `highlightIndex` keeps the bright
+ * leading-edge tone on the word currently being spoken — the text ahead of the
+ * cursor stays muted instead of the highlight parking on the final word.
+ */
+export const SpokenWordHighlight: Story = {
+  argTypes: {
+    role: { table: { disable: true } },
+    wordMs: { table: { disable: true } },
+    replay: { table: { disable: true } },
+  },
+  render: () => (
+    <CaptionSurface>
+      <VoiceTranscriptText text={ASSISTANT_LINE} highlightIndex={9} />
+    </CaptionSurface>
+  ),
+};
+
+/** Neutral dark surface for the isolated caption scenes (no room plumbing). */
+function CaptionSurface({ children }: { children: ReactNode }) {
+  return (
+    <div
+      data-theme="dark"
+      className="flex min-h-[240px] items-center justify-center rounded-lg p-10"
+      style={{ backgroundColor: "#17191C" }}
+    >
+      <p className="max-w-[36rem] text-center text-[15px] leading-relaxed text-balance">
+        {children}
+      </p>
+    </div>
+  );
+}
+
 function RevealScene({ wordMs, replay }: { wordMs: number; replay: number }) {
   const [text, setText] = useState("");
   const words = ASSISTANT_LINE.split(" ");
@@ -219,14 +254,8 @@ function RevealScene({ wordMs, replay }: { wordMs: number; replay: number }) {
     useCallback(() => setText(""), []),
   );
   return (
-    <div
-      data-theme="dark"
-      className="flex min-h-[240px] items-center justify-center rounded-lg p-10"
-      style={{ backgroundColor: "#17191C" }}
-    >
-      <p className="max-w-[36rem] text-center text-[15px] leading-relaxed text-balance">
-        <VoiceTranscriptText text={text} />
-      </p>
-    </div>
+    <CaptionSurface>
+      <VoiceTranscriptText text={text} />
+    </CaptionSurface>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-timeline-waveform.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-timeline-waveform.test.tsx
@@ -3,9 +3,8 @@
  *
  * happy-dom's `canvas.getContext("2d")` returns `null`, so a minimal fake 2D
  * context is installed on `HTMLCanvasElement.prototype` to let the draw loop
- * run. `requestAnimationFrame` is monkey-patched to capture callbacks so
- * frames are driven manually with controlled timestamps (same approach as the
- * `setTimeout` harness in `website-carousel.test.tsx`).
+ * run. Frames are driven manually with controlled timestamps through the
+ * shared rAF harness (`raf.test-helper.ts`).
  *
  * The reduced-motion branch is verified by stubbing `motion/react` so
  * `useReducedMotion()` returns `true` and asserting the animation loop never
@@ -17,27 +16,13 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, render } from "@testing-library/react";
 
+import {
+  installRafTestHarness,
+  type RafTestHarness,
+} from "@/domains/chat/voice/raf.test-helper";
 import { VoiceTimelineWaveform } from "@/domains/chat/voice/voice-timeline-waveform";
 
-// ---------------------------------------------------------------------------
-// requestAnimationFrame harness
-// ---------------------------------------------------------------------------
-
-let rafCallbacks: Map<number, FrameRequestCallback>;
-let nextRafId = 1;
-let rafCallCount = 0;
-let canceledRafIds: number[];
-let originalRaf: typeof globalThis.requestAnimationFrame;
-let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
-
-/** Fire every pending rAF callback once with the given timestamp. */
-function fireFrame(ts: number) {
-  const callbacks = [...rafCallbacks.values()];
-  rafCallbacks.clear();
-  for (const cb of callbacks) {
-    cb(ts);
-  }
-}
+let raf: RafTestHarness;
 
 // ---------------------------------------------------------------------------
 // Fake 2D context — happy-dom has no canvas implementation.
@@ -58,22 +43,7 @@ let fakeCtx: ReturnType<typeof makeFakeContext>;
 let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
 
 beforeEach(() => {
-  rafCallbacks = new Map();
-  nextRafId = 1;
-  rafCallCount = 0;
-  canceledRafIds = [];
-  originalRaf = globalThis.requestAnimationFrame;
-  originalCancelRaf = globalThis.cancelAnimationFrame;
-  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
-    rafCallCount += 1;
-    const id = nextRafId++;
-    rafCallbacks.set(id, cb);
-    return id;
-  }) as typeof globalThis.requestAnimationFrame;
-  globalThis.cancelAnimationFrame = ((id: number) => {
-    canceledRafIds.push(id);
-    rafCallbacks.delete(id);
-  }) as typeof globalThis.cancelAnimationFrame;
+  raf = installRafTestHarness();
 
   fakeCtx = makeFakeContext();
   originalGetContext = HTMLCanvasElement.prototype.getContext;
@@ -82,8 +52,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  globalThis.requestAnimationFrame = originalRaf;
-  globalThis.cancelAnimationFrame = originalCancelRaf;
+  raf.restore();
   HTMLCanvasElement.prototype.getContext = originalGetContext;
   cleanup();
 });
@@ -129,26 +98,26 @@ describe("VoiceTimelineWaveform — rendering", () => {
 describe("VoiceTimelineWaveform — animation loop", () => {
   test("starts the rAF loop and reschedules each frame", () => {
     render(<VoiceTimelineWaveform active getAmplitude={() => 0.5} />);
-    expect(rafCallCount).toBe(1);
-    fireFrame(100);
-    expect(rafCallCount).toBe(2);
-    fireFrame(200);
-    expect(rafCallCount).toBe(3);
+    expect(raf.requestCount()).toBe(1);
+    raf.fireFrame(100);
+    expect(raf.requestCount()).toBe(2);
+    raf.fireFrame(200);
+    expect(raf.requestCount()).toBe(3);
   });
 
   test("polls getAmplitude while active", () => {
     const getAmplitude = mock(() => 0.5);
     render(<VoiceTimelineWaveform active getAmplitude={getAmplitude} />);
-    fireFrame(100);
-    fireFrame(200);
+    raf.fireFrame(100);
+    raf.fireFrame(200);
     expect(getAmplitude.mock.calls.length).toBe(2);
   });
 
   test("stops sampling (but keeps drawing) when not active", () => {
     const getAmplitude = mock(() => 0.5);
     render(<VoiceTimelineWaveform active={false} getAmplitude={getAmplitude} />);
-    fireFrame(100);
-    fireFrame(200);
+    raf.fireFrame(100);
+    raf.fireFrame(200);
     expect(getAmplitude.mock.calls.length).toBe(0);
     expect(fakeCtx.clearRect.mock.calls.length).toBe(2);
   });
@@ -157,11 +126,11 @@ describe("VoiceTimelineWaveform — animation loop", () => {
     const { unmount } = render(<VoiceTimelineWaveform active getAmplitude={() => 0.5} />);
     // Capture the pending callback before unmount cancels it, simulating a
     // frame already dispatched when cleanup runs.
-    const pending = [...rafCallbacks.values()];
+    const pending = raf.pendingCallbacks();
     expect(pending).toHaveLength(1);
     unmount();
-    expect(canceledRafIds).toHaveLength(1);
-    expect(rafCallbacks.size).toBe(0);
+    expect(raf.canceledIds()).toHaveLength(1);
+    expect(raf.pendingCallbacks()).toHaveLength(0);
     expect(() => pending[0]!(300)).not.toThrow();
   });
 
@@ -171,7 +140,7 @@ describe("VoiceTimelineWaveform — animation loop", () => {
     const { unmount } = render(
       <VoiceTimelineWaveform active getAmplitude={() => 0} />,
     );
-    expect(rafCallCount).toBe(0);
+    expect(raf.requestCount()).toBe(0);
     expect(() => unmount()).not.toThrow();
   });
 });
@@ -199,7 +168,7 @@ describe("VoiceTimelineWaveform — reduced motion", () => {
 
     expect(container.querySelector("canvas")).toBeTruthy();
     // No animation loop — the static branch draws once, synchronously.
-    expect(rafCallCount).toBe(0);
+    expect(raf.requestCount()).toBe(0);
     expect(fakeCtx.clearRect.mock.calls.length).toBe(1);
     expect(() => unmount()).not.toThrow();
   });


### PR DESCRIPTION
## Summary
The voice-room transcript's bright leading-edge highlight tracked *text arrival* (the LLM stream races ahead of TTS), parking on the final word while speech was mid-sentence. The highlight is now a spoken-word cursor driven by the TTS audio playhead: the player exposes played/total scheduled-audio progress, the live-voice store publishes it via a registered provider (`outputAmplitudeProvider` pattern), and a rAF hook maps playback fraction → word index with drain-hold, per-response reset, barge-in freeze, monotonic advance rate-capped to speaking cadence, and an audio-less fallback to the default reveal. Captions off ⇒ the loop idles entirely.

Fixes JARVIS-1309.

## Self-review result
PASS — 5 rounds, 14 fresh-eyes reviewer passes; 4 fix PRs merged before this PR was opened.

## PRs merged into feature branch
- #38645: feat(live-voice): expose TTS playback progress from LiveVoiceAudioPlayer
- #38646: feat(voice-room): accept an explicit highlight index in VoiceTranscriptText
- #38648: feat(live-voice): publish TTS playback progress through the live-voice store
- #38652: feat(voice-room): rAF hook mapping TTS playback progress to a word cursor
- #38657: feat(voice-room): drive the transcript highlight from the TTS audio playhead

### Fix PRs
- #38665: hold the cursor through queue underruns and audio-less responses
- #38670: drain-boundary honesty + idle when captions are off
- #38672: clamp the advancement bank
- #38674: spend frame-earned allowance before clamping the bank

Part of plan: voice-room-spoken-word-cursor.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)