### PR TITLE
feat(web-search): add vellum to the search provider catalog

### DIFF
--- a/assistant/src/providers/__tests__/search-provider-catalog.test.ts
+++ b/assistant/src/providers/__tests__/search-provider-catalog.test.ts
@@ -72,6 +72,12 @@ describe("search-provider-catalog", () => {
     expect(SEARCH_PROVIDER_FALLBACK_ORDER).toEqual(sorted);
   });
 
+  test("vellum is a managed provider outside the BYOK fallback chain", () => {
+    expect(getSearchProvider("vellum")?.kind).toBe("managed");
+    expect(BYOK_SEARCH_PROVIDERS.map((p) => p.id)).not.toContain("vellum");
+    expect(SEARCH_PROVIDER_FALLBACK_ORDER).not.toContain("vellum");
+  });
+
   test("getSearchProvider returns the matching entry", () => {
     expect(getSearchProvider("tavily")?.id).toBe("tavily");
     expect(getSearchProvider("brave")?.displayName).toBe("Brave");

--- a/assistant/src/providers/search-provider-catalog.ts
+++ b/assistant/src/providers/search-provider-catalog.ts
@@ -46,12 +46,15 @@ export interface SearchProviderCatalogEntry {
    * Authentication style for the search provider choice.
    *
    * `managed` means the choice does not require a user-supplied search API key.
-   * For `inference-provider-native`, the daemon uses the inference API's native
+   * `vellum` searches through the Vellum platform search proxy, billed to
+   * Vellum credits; the platform connection is the credential. For
+   * `inference-provider-native`, the daemon uses the inference API's native
    * hosted web-search tool only when the selected inference provider/model
-   * supports it. Managed non-native inference providers keep the app-executed
-   * `web_search` tool, which can route through the platform search proxy.
+   * supports it; otherwise the app-executed `web_search` tool runs, falling
+   * back to the platform search proxy only when no user search key is
+   * configured.
    *
-   * `byok` providers require a user-supplied key in Your Own mode.
+   * `byok` providers require a user-supplied API key.
    */
   readonly kind: SearchProviderKind;
   /** Placeholder shown in the API-key input. BYOK providers only. */
@@ -69,6 +72,13 @@ export interface SearchProviderCatalogEntry {
 }
 
 export const SEARCH_PROVIDER_CATALOG: readonly SearchProviderCatalogEntry[] = [
+  // vellum leads: it is the managed option, selected like any other provider.
+  {
+    id: "vellum",
+    displayName: "Vellum",
+    displayNameLong: "Vellum Managed Search",
+    kind: "managed",
+  },
   {
     id: "inference-provider-native",
     displayName: "Provider Native",

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -108,6 +108,15 @@ describe("web_search tool", () => {
     expect(result.content).toContain("No web search API key configured");
   });
 
+  test("provider vellum in your-own mode is coerced instead of crashing", async () => {
+    // "vellum" has no BYOK adapter; until the managed routing ships it must
+    // coerce into the BYOK chain rather than dereference an undefined adapter.
+    seedWebSearch("your-own", "vellum");
+    const result = await execute({ query: "test" });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("No web search API key configured");
+  });
+
   // ---- Perplexity provider ------------------------------------------------
 
   test("executes Perplexity search successfully", async () => {

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -137,8 +137,12 @@ function getWebSearchProvider(): WebSearchProvider {
   // inference provider swaps this tool for a native hosted-search definition.
   // If this app-executed tool is still invoked, fall back to the existing BYOK
   // provider chain. Managed mode short-circuits before this function and uses
-  // the platform search proxy instead.
-  if (configured === "inference-provider-native") return "perplexity";
+  // the platform search proxy instead. `vellum` is coerced the same way so a
+  // config that names it before the managed routing ships can never reach an
+  // undefined WEB_SEARCH_ADAPTERS lookup.
+  if (configured === "inference-provider-native" || configured === "vellum") {
+    return "perplexity";
+  }
   return configured as WebSearchProvider;
 }
 

--- a/clients/web/src/assistant/generated/web-search-provider-catalog.gen.ts
+++ b/clients/web/src/assistant/generated/web-search-provider-catalog.gen.ts
@@ -3,7 +3,6 @@
 
 /** Ordered list of provider ids — drives the picker option order. */
 export const WEB_SEARCH_PROVIDER_IDS: readonly string[] = [
-  "vellum",
   "inference-provider-native",
   "perplexity",
   "brave",
@@ -15,7 +14,6 @@ export const WEB_SEARCH_PROVIDER_IDS: readonly string[] = [
 export const WEB_SEARCH_PROVIDER_DISPLAY_NAMES: Readonly<
   Record<string, string>
 > = {
-  vellum: "Vellum",
   "inference-provider-native": "Provider Native",
   perplexity: "Perplexity",
   brave: "Brave",

--- a/clients/web/src/assistant/generated/web-search-provider-catalog.gen.ts
+++ b/clients/web/src/assistant/generated/web-search-provider-catalog.gen.ts
@@ -3,6 +3,7 @@
 
 /** Ordered list of provider ids — drives the picker option order. */
 export const WEB_SEARCH_PROVIDER_IDS: readonly string[] = [
+  "vellum",
   "inference-provider-native",
   "perplexity",
   "brave",
@@ -14,6 +15,7 @@ export const WEB_SEARCH_PROVIDER_IDS: readonly string[] = [
 export const WEB_SEARCH_PROVIDER_DISPLAY_NAMES: Readonly<
   Record<string, string>
 > = {
+  vellum: "Vellum",
   "inference-provider-native": "Provider Native",
   perplexity: "Perplexity",
   brave: "Brave",

--- a/meta/web-search-provider-catalog.json
+++ b/meta/web-search-provider-catalog.json
@@ -2,6 +2,12 @@
   "version": 1,
   "providers": [
     {
+      "id": "vellum",
+      "displayName": "Vellum",
+      "displayNameLong": "Vellum Managed Search",
+      "kind": "managed"
+    },
+    {
       "id": "inference-provider-native",
       "displayName": "Provider Native",
       "kind": "managed"


### PR DESCRIPTION
## Summary
- Add a `vellum` entry (kind `managed`, no key fields) leading `SEARCH_PROVIDER_CATALOG`, so the config-schema enum, secret catalog, and env-var map all pick it up derivationally; regenerate `meta/web-search-provider-catalog.json`
- Coerce `vellum` in `getWebSearchProvider()` alongside `inference-provider-native` so a config naming it before the managed routing ships can never dereference the missing `WEB_SEARCH_ADAPTERS` entry (regression-tested)
- Update the `SearchProviderKind` doc block and add catalog test assertions (managed kind, outside the BYOK fallback chain)
- Web client catalog (`web-search-provider-catalog.gen.ts`) is deliberately untouched: adding vellum there would expose it in the legacy card's picker before the card conversion — it moves to that PR (review feedback from Devin + Codex)

## Original prompt
First PR of the plan to remove the Managed/Your Own toggle from the Web Search settings card and make Vellum a provider like any other, the way the STT/TTS cards were converted. Selecting Vellum will route through the Vellum platform search proxy billed to credits; other providers bring their own API key. This PR only adds the daemon-side catalog entry — routing (PR 2), migration 132 (PR 4), and the card change (PR 5) follow.

## Plan
<details>
<summary>Full plan: web-search-vellum-provider.md</summary>

# Web Search: replace the Managed/Your Own toggle with provider "vellum"

## Overview

Web search is the last settings card carrying the two-axis `mode` ("managed" | "your-own") + `provider` model. Fold it to one axis exactly like STT/TTS (migration 130): add a `vellum` entry to the search provider catalog, route it to the existing Vellum platform search proxy, migrate `mode: "managed"` configs onto `provider: "vellum"`, and swap the card from `ServiceCard` (which renders the `ModeToggle`) to `ByoServiceCard`.

Two decisions baked into this plan:

- **`vellum` and `inference-provider-native` stay separate dropdown options.** `vellum` means exactly one thing: search through the Vellum platform search proxy (Brave-backed), billed to Vellum credits. `inference-provider-native` keeps its own meaning: let the inference model run its own hosted search.

  The wrinkle this creates: today `mode: "managed"` + `provider: "inference-provider-native"` (the platform default) is a *pair* — native hosted search when the model supports it (`registry.ts:129-138`), managed Brave proxy when it doesn't (`web-search.ts:1183-1217`). Dropping `mode` strands the second half, and a non-capable model would fall into the BYOK chain with no key. So PR 2 gives `inference-provider-native` a fixed app-executed fallback order: the user's own search keys first, the managed proxy as the last resort when no key is configured and a platform connection exists. Keys-first is deliberate — the `your-own` + `inference-provider-native` config also collapses onto this id, and those users' searches must keep hitting the vendor they pay, not Vellum credits (see PR 2's billing rule).
- **The legacy `mode` bridge in the card stays**, same as the speech cards, because an old daemon rejects `provider: "vellum"` without `mode: "managed"`.

Out of scope: image-generation and the OAuth services still use `mode` and still receive `getDeploymentContextDefaults` injection; `ServiceModeSchema`, `ModeToggle`, and `getServiceMode` all survive for them.

## PR 1: Add the `vellum` entry to the search provider catalog

### Depends on
None

### Branch
web-search-vellum/pr-1-catalog-entry

### Title
feat(web-search): add vellum to the search provider catalog

### Files
- `assistant/src/providers/search-provider-catalog.ts`
- `meta/web-search-provider-catalog.json`
- `clients/web/src/assistant/generated/web-search-provider-catalog.gen.ts`
- `assistant/src/providers/__tests__/search-provider-catalog.test.ts`

### Implementation steps
1. In `search-provider-catalog.ts`, prepend a new entry to `SEARCH_PROVIDER_CATALOG` (before `inference-provider-native` at `:72-76`) so Vellum leads the list, matching `TTS_PROVIDERS[0]` / `STT_PROVIDERS[0]` in `clients/web/src/domains/settings/ai/provider-catalogs.ts`:
   ```ts
   {
     id: "vellum",
     displayName: "Vellum",
     displayNameLong: "Vellum Managed Search",
     kind: "managed",
   },
   ```
   No `apiKeyPrefix`, no `envVar`, no `secretKey`, no `fallbackOrder` — the platform connection is the credential (mirrors `stt.ts:46-50`).
2. Update the doc block at `:45-55` describing `SearchProviderKind`: `vellum` searches through the Vellum platform search proxy, billed to Vellum credits, no user key. `inference-provider-native` is unchanged and distinct — the inference model runs its own hosted search, falling back to the platform proxy only when the model has no native search.
3. Confirm the derived exports stay correct without edits: `SEARCH_PROVIDER_IDS` (`:121`) picks up `vellum`; `BYOK_SEARCH_PROVIDERS` (`:125`) filters it out by `kind`; `SEARCH_PROVIDER_FALLBACK_ORDER` (`:129`) skips it (no `fallbackOrder`). This automatically keeps `provider-secret-catalog.ts:52-58` and `provider-env-vars.ts:29-46` from demanding a key for it.
4. Regenerate the one genuinely generated artifact: `cd assistant && bun run sync:web-search-catalog` (writes `meta/web-search-provider-catalog.json`).
5. Hand-edit `clients/web/src/assistant/generated/web-search-provider-catalog.gen.ts`. Despite the `.gen.ts` name and the `generated/` directory there is **no generator for it in this repo** — its own header says *"Originally generated in the platform repo; maintained as a static file here."* Add `"vellum"` to `WEB_SEARCH_PROVIDER_IDS` (first, so it leads the picker — that array drives option order) and to `WEB_SEARCH_PROVIDER_DISPLAY_NAMES`. Leave it out of `WEB_SEARCH_PROVIDER_KEY_PLACEHOLDERS`, `WEB_SEARCH_PROVIDER_KEY_STORAGE`, and `WEB_SEARCH_BYOK_PROVIDER_IDS` — that last omission is what makes the card hide the API-key field in PR 5.
6. The platform repo carries its own stale copy at `web/src/lib/generated/web-search-provider-catalog.gen.ts`. It currently has **zero importers** in `web/src`, so it does not need to be updated for this feature. Do not spend time syncing it.
7. In `search-provider-catalog.test.ts`, add assertions that `vellum` is present, has `kind: "managed"`, and appears in neither `BYOK_SEARCH_PROVIDERS` nor `SEARCH_PROVIDER_FALLBACK_ORDER`.

### Acceptance criteria
- `bun run sync:web-search-catalog -- --check` passes (artifact is not stale).
- `assistant/src/__tests__/web-search-catalog-parity.test.ts` and `cli/src/__tests__/search-provider-env-var-parity.test.ts` pass unchanged.
- `WebSearchServiceSchema` accepts `provider: "vellum"` (it derives its enum from `SEARCH_PROVIDER_IDS` at `services.ts:30`).
- No runtime behavior changes: nothing yet reads `provider === "vellum"`.

---

## PR 2: Route `provider: "vellum"` to managed search

### Depends on
PR 1

### Branch
web-search-vellum/pr-2-runtime-routing

### Title
feat(web-search): route provider vellum through managed search

### Files
- `assistant/src/tools/network/managed-search-proxy.ts`
- `assistant/src/tools/network/web-search.ts`
- `assistant/src/tools/network/__tests__/web-search.test.ts`

`registry.ts` is deliberately untouched: `shouldUseNativeWebSearch` stays keyed on `provider === "inference-provider-native"` only, because Provider Native and Vellum are separate options.

### The billing rule this PR must enforce

Dropping `mode` collapses two distinct configs onto one provider id, and one of them is a silent-billing trap:

| Config today | Behavior today | After migration 132 |
|---|---|---|
| `managed` + `inference-provider-native` | native search; platform proxy when the model can't | `inference-provider-native` |
| `your-own` + `inference-provider-native` | native search; **user's own API key** when the model can't | `inference-provider-native` |

Both land on the same id, so the app-executed fallback order decides whether the second group starts burning Vellum credits instead of the Perplexity key they already pay for. That is the exact failure mode of PR #38338 (a connection-less profile silently reusing the billed managed transport). So:

- **`inference-provider-native`** — native search first; then the user's own keys; the platform proxy only as a last resort when no key is configured at all. Nobody's billing changes without them choosing it.
- **`vellum`** — unconditionally managed. It is an explicit choice, so it gets explicit billing: a 402 is a hard error telling the user to add funds or pick a different provider. It must **never** silently fall through to the BYOK chain, even when a key happens to be sitting in the secret store.

### Implementation steps
1. In `managed-search-proxy.ts`, export a small availability predicate mirroring `managedSpeechAvailable()` (`assistant/src/platform/managed-speech.ts:77-79`). It checks the same two conditions `callManagedSearchProxy` already guards at `:51-66`:
   ```ts
   export async function managedSearchAvailable(): Promise<boolean> {
     const client = await VellumPlatformClient.create();
     return client !== null && Boolean(client.platformAssistantId);
   }
   ```
   Do not try to reach the `{ ok: false, kind: "unavailable" }` discriminant from the caller instead — it is flattened into a message string by `managedSearchProxyErrorMessage` before `executeManagedBraveSearch` returns, and that function's return type is an opaque `ToolExecutionResult`. Surfacing it would mean restructuring the return type for no gain.
2. In `web-search.ts`, change `getWebSearchMode()` (`:145-150`) to treat the provider as an equal signal, keeping `mode` readable so this PR is deploy-safe on unmigrated configs:
   ```ts
   function getWebSearchMode(): WebSearchMode {
     const services = getConfig().services["web-search"];
     // ponytail: `mode` is the pre-migration-132 signal; delete this half once
     // migration 132 has shipped everywhere (see PR 6).
     return services.provider === "vellum" || services.mode === "managed"
       ? "managed"
       : "your-own";
   }
   ```
   The managed branch at `:1196-1217` is unchanged and stays terminal — it returns the proxy result, error or not. That is what makes a `vellum` 402 a hard error rather than a BYOK fallback.
3. Give `inference-provider-native` its last-resort proxy. In the BYOK branch, the `if (!apiKey)` block at `:1226-1247` currently ends in a terminal `errorResult` ("No web search API key configured…"). Insert the proxy attempt immediately before that error, inside the same block:
   ```ts
   if (!apiKey) {
     for (const fallback of fallbackProvidersFor(provider)) { /* unchanged */ }

     if (!apiKey) {
       // Provider Native reaches this path only when the inference model had no
       // hosted search of its own. The user's own keys win above; the platform
       // proxy is the last resort, which is what `mode: "managed"` did for the
       // installs that never configured a search key.
       if (
         getConfig().services["web-search"].provider === "inference-provider-native" &&
         (await managedSearchAvailable())
       ) {
         return await managedBraveSearchAdapter.execute({
           query, count, offset, freshness, apiKey: "", signal: context.signal,
         });
       }
       return errorResult(query, provider, startedAt, "No web search API key configured. …");
     }
   }
   ```
   Two details the snippet elides:
   - Read the provider off config rather than the local `provider` variable — the local one has already been coerced to `"perplexity"` by `getWebSearchProvider()`.
   - Wrap the `managedBraveSearchAdapter.execute` call in the same try/catch → `networkFailureResult` the managed branch uses at `:1196-1217`; this insertion point sits *before* the BYOK `try` block, so a network throw would otherwise escape the tool. Load `managedSearchAvailable` via the same lazy `await import("./managed-search-proxy.js")` pattern `executeManagedBraveSearch` uses (`:684`).
4. In `getWebSearchProvider()` (`:133-143`), add `vellum` to the coercion alongside `inference-provider-native`: `if (configured === "vellum" || configured === "inference-provider-native") return "perplexity";`. Update the comment: `vellum` never reaches this function (the managed branch is terminal), and `inference-provider-native` reaches it only to drive the BYOK chain, so this line just satisfies the return type.
5. Update the user-facing copy in `managedSearchProxyErrorMessage` (`:763-779`), which references a mode that will no longer exist. The `unavailable` string becomes "Log in to Vellum or choose a different web search provider in Settings."; the 402 string becomes "Managed web search is unavailable because your Vellum account balance is too low. Add funds or choose a different web search provider in Settings."
6. Tests, in `web-search.test.ts`. Extend `seedWebSearch` (`:18-20`) so `mode` is optional and omitted from the written config when undefined, then add:
   - `provider: "vellum"`, no `mode` → platform proxy (mirrors `:379`).
   - `provider: "vellum"` + a Perplexity key in the store + proxy 402 → returns the add-funds error and **does not** call Perplexity. This is the regression guard for the billing rule; assert the updated copy.
   - `provider: "inference-provider-native"` + a Perplexity key → Perplexity is called, proxy is not.
   - `provider: "inference-provider-native"` + no keys + platform available → platform proxy.
   - `provider: "inference-provider-native"` + no keys + platform unavailable → the existing "No web search API key configured" error.
   - Existing `mode: "managed"` cases stay green (back-compat).

### Acceptance criteria
- `provider: "vellum"` always uses the platform proxy; proxy errors surface to the user and never fall back to a BYOK key.
- `provider: "inference-provider-native"` prefers native search, then the user's own keys, then the proxy — a user with a working search key never gets billed Vellum credits.
- Legacy `mode: "managed"` configs behave exactly as before.
- No user-facing string references "Your Own mode".

---

## PR 3: Stop injecting a web-search mode into platform deployments

### Depends on
PR 2

### Branch
web-search-vellum/pr-3-deployment-defaults

### Title
fix(config): drop the platform web-search mode injection

### Files
- `assistant/src/config/loader.ts`
- `assistant/src/config/__tests__/deployment-context-defaults.test.ts`
- `assistant/src/__tests__/config-loader-platform-defaults.test.ts`

### Implementation steps
1. In `getDeploymentContextDefaults()` (`loader.ts:138-170`), delete the `"web-search": managed,` line (`:158`). No replacement entry is needed: the schema already defaults `provider` to `"inference-provider-native"` (`services.ts:59-67`), and PR 2 makes that id fall back to the platform proxy when the model has no native search, the user has no search key of their own, and a platform connection exists — which reproduces today's platform behavior exactly (a fresh platform install has no search keys). Leave `image-generation` and the OAuth services on the shared `managed` object; they still use `mode`.
2. Update the comment at `:142-145` to note web-search is no longer mode-driven and needs no deployment-context default.
3. `deployment-context-defaults.test.ts:156-163`: replace the `webSearchRaw.mode === "managed"` assertion with one asserting the defaults object contains no `web-search` key, and that a fresh platform boot leaves `services["web-search"]` at the schema default with no `mode`.
4. `config-loader-platform-defaults.test.ts:432`: same swap.

### Acceptance criteria
- A fresh platform-context boot leaves web-search at `{ provider: "inference-provider-native" }` with no `mode`.
- Managed search on platform still works for models without native hosted search (covered by PR 2's tests).
- Because these are fill-only defaults (`:186-209`), existing configs are untouched.

---

## PR 4: Workspace migration 132 — fold web-search mode into provider

### Depends on
PR 2 (hard runtime dependency, not just ordering: without PR 2, a migrated `provider: "vellum"` config falls into the BYOK branch, `getWebSearchProvider()` returns `"vellum"` uncoerced, and `WEB_SEARCH_ADAPTERS["vellum"]` is undefined — every web search crashes for migrated managed users)

### Branch
web-search-vellum/pr-4-migration-132

### Title
feat(config): migrate web-search mode onto provider vellum

### Files
- `assistant/src/workspace/migrations/132-web-search-mode-to-provider.ts`
- `assistant/src/workspace/migrations/registry.ts`
- `assistant/src/__tests__/workspace-migration-132-web-search-mode-to-provider.test.ts`

### Implementation steps
1. Create `132-web-search-mode-to-provider.ts` modeled directly on `130-speech-mode-to-provider.ts:18-80`. `run()`:
   - Read `raw.services?.["web-search"]`; if absent, no-op.
   - If `service.mode === "managed"` **and** `service.provider !== "inference-provider-native"` → `service.provider = "vellum"`.
   - `inference-provider-native` is preserved verbatim: it is a distinct user-facing option, and PR 2 keeps its managed fallback working without a `mode`.
   - `delete service.mode` in all cases.
   - Idempotent: a config with no `mode` is unchanged.
2. `down()`: reconstruct `mode = provider === "vellum" ? "managed" : "your-own"`. Document, as 130 does at `:53-84`, that the pre-migration BYOK provider stored under managed mode is not recoverable, and that `inference-provider-native` rolls back to `your-own` even if it was previously paired with `managed`.
3. In `registry.ts`, import the migration and **append it last** in the array (after `dropWebFetchModeMigration` at `:266-272`) — the comment there is load-bearing: `getLastWorkspaceMigrationId()` (`runner.ts:14-18`) reports the final entry as the registry ceiling.
4. Test file modeled on `workspace-migration-130-speech-mode-to-provider.test.ts`:
   - Pin the ceiling: `numericId(getLastWorkspaceMigrationId(...)) === max(all ids)` (copy `:64-78`).
   - `mode: "managed"`, `provider: "brave"` → `provider: "vellum"`, no `mode`.
   - `mode: "your-own"`, `provider: "firecrawl"` → provider preserved, no `mode`.
   - `mode: "managed"`, `provider: "inference-provider-native"` → provider **preserved**, no `mode` (the platform default config; this is the case that must not become `vellum`).
   - Idempotency (run twice).
   - `down()` round-trip.
   - Post-migration config re-parses cleanly through `AssistantConfigSchema`.
5. Existing migration fixtures that carry `services["web-search"].mode` (`workspace-migration-076-*:167,178`, `-131-drop-web-fetch-mode:84,92`, `-130-speech-mode-to-provider:131,136`, `-006-services-config:157`, `-007-web-search-provider-rename:256`, `workspace-migration-down-functions:294,438,485`) only assert their own migration's behavior — verify they still pass; adjust only if they run the full registry.

### Acceptance criteria
- `bun test assistant/src/__tests__/workspace-migration-132*` passes.
- The registry ceiling reported by `identity-routes.ts:274` is 132.
- Running the full migration chain on a legacy managed web-search config produces `{ provider: "vellum" }`.

---

## PR 5: Web Search card — drop the mode toggle, add Vellum to the dropdown

### Depends on
PR 1 (PR 2 is NOT required, unlike PR 4: the write bridge pairs every save with a `mode`, so a pre-PR-2 daemon routes `vellum` saves through the legacy managed branch and never hits the missing adapter)

### Branch
web-search-vellum/pr-5-web-card

### Title
feat(web): make Vellum a web search provider instead of a mode

### Files
- `clients/web/src/domains/settings/ai/web-search-card.tsx`
- `clients/web/src/domains/settings/ai/web-search-card.test.tsx`
- `clients/web/src/domains/settings/ai/local-storage-keys.ts`

### Implementation steps
1. Swap `ServiceCard` for `ByoServiceCard` (`shared-ui.tsx:100-107`) at `:181`; drop the `mode` / `onModeChange` props. This is the change that removes the Managed | Your Own segmented control from the header. Compare `web-fetch-card.tsx:157` and `speech-to-text-card.tsx:283`.
2. Delete the mode state entirely: remove `serverWebSearchMode` (`:52-70`), the `webSearchMode` draft, `parseServiceMode` and `LS_WEB_SEARCH_MODE` imports (`:22-24`). Remove `LS_WEB_SEARCH_MODE` from `local-storage-keys.ts:11`.
3. Add the legacy read bridge, copied from `speech-to-text-card.tsx:97-103`:
   ```ts
   const daemonWebSearch = daemonConfig?.services?.["web-search"] as
     | { provider?: string; mode?: string }
     | undefined;
   // A config written by the legacy mode toggle marks managed via `mode` while
   // `provider` holds the BYOK restore value — the daemon routes it to Vellum,
   // so the card must render it as Vellum too. Provider Native is exempt: it
   // stays itself under managed mode (see migration 132).
   const daemonProvider =
     daemonWebSearch?.mode === "managed" &&
     daemonWebSearch?.provider !== "inference-provider-native"
       ? "vellum"
       : daemonWebSearch?.provider;
   ```
   Keep the `LS_WEB_SEARCH_PROVIDER` localStorage fallback and its `"inference-provider-native"` default.
4. Provider dropdown (`:196-231`): render it unconditionally (delete the `webSearchMode === "managed"` branch at `:186-195`, including the static "Web search is included with managed inference." copy). Build the option list from the full `WEB_SEARCH_PROVIDER_IDS` — Vellum and Provider Native are both real, distinct options. Vellum leads the list (PR 1 ordering).
5. API key field: keep the `requiresProviderCredential = WEB_SEARCH_BYOK_PROVIDER_IDS.has(provider)` gate at `:78` — `vellum` is not in that set, so the key input and `needsKeyBeforeSave` fall out for free. Delete the now-dead `webSearchMode === "your-own"` conditions at `:89-100` and `:113`. Add an explanatory line under the dropdown when `provider === "vellum"`, mirroring `speech-to-text-card.tsx:329-333`: "Search runs through your Vellum account."
6. Save (`:106-167`): drop the `providerToSave` remap (`:109-110`) — save the selected provider verbatim. Keep the legacy write bridge in the PATCH body (`:122`), copied from `speech-to-text-card.tsx:225-232`:
   ```ts
   // Older daemon schemas reject provider "vellum" without mode "managed", and a
   // stale `mode: "managed"` from the legacy toggle would win over a BYOK choice
   // unless reset.
   "web-search": {
     provider,
     mode: provider === "vellum" ? "managed" : "your-own",
   },
   ```
   Stop writing `LS_WEB_SEARCH_MODE` (`:136-137`).
7. `handleReset` (`:169-177`): keep resetting provider to `"inference-provider-native"` (the schema default).
8. Write `web-search-card.test.tsx` from scratch, modeled on `speech-to-text-card.test.tsx` (there is no existing test for this card). Cover: no Managed/Your Own control renders; Vellum is selectable and hides the API-key input; selecting Vellum saves `{ provider: "vellum", mode: "managed" }`; selecting Firecrawl saves `{ provider: "firecrawl", mode: "your-own" }` and requires a key; Provider Native is present in the dropdown and needs no key; a daemon config of `{ mode: "managed", provider: "brave" }` renders as Vellum; a daemon config of `{ mode: "managed", provider: "inference-provider-native" }` renders as Provider Native, not Vellum.

### Acceptance criteria
- The card header shows no segmented control (matches the Web Fetch and Speech-to-Text cards).
- Dropdown options: Vellum, Provider Native, Perplexity, Brave, Tavily, Firecrawl.
- Vellum and Provider Native selected → no API Key field, Save enabled without a key.
- A daemon still running the pre-migration schema accepts the card's writes (the `mode` pair is still sent).
- `bun test clients/web/src/domains/settings/ai/web-search-card.test.tsx` passes.

---

## PR 6: Drop `mode` from the web-search schema and wire contracts

### Depends on
PR 2, PR 3, PR 4, PR 5

### Branch
web-search-vellum/pr-6-drop-mode

### Title
refactor(config): drop mode from the web-search schema

### Files
- `assistant/src/config/schemas/services.ts`
- `assistant/src/runtime/routes/conversation-query-routes.ts`
- `assistant/src/tools/network/web-search.ts`
- `assistant/src/providers/registry.ts`
- `assistant/src/cli/commands/config.ts`
- `clients/web/src/domains/settings/ai/use-daemon-config.ts` (the web client's daemon-config surface — NOTE: the previously listed `clients/web/openapi-schemas/daemon.json` and `clients/web/src/generated/daemon/types.gen.ts` do not exist in this repo; verified during PR 1)
- `assistant/src/__tests__/config-schema.test.ts`, `config-set-platform-guard.test.ts`, and the fixtures listed below

### Implementation steps
1. `services.ts:59-67`: stop extending `BaseServiceSchema`. Make `WebSearchServiceSchema` a plain `z.object({ provider: z.enum(VALID_WEB_SEARCH_PROVIDERS).default("inference-provider-native") })`. Replace the two-axis comment at `:60-63` with the one-axis statement used by `stt.ts:46-50` and `WebFetchServiceSchema` (`:69-79`): *"`provider` is the only axis: `"vellum"` searches through the platform, billed to Vellum credits; any other provider uses the user's own API key."* Unknown keys are stripped at parse, so a legacy `mode` from an old client is inert. Leave `ServiceModeSchema`, `BaseServiceSchema`, and `getServiceMode` alone — image-generation and the OAuth services still use them.
2. `conversation-query-routes.ts`: remove `mode` from the web-search entry in `ConfigGetResponseSchema` (`:691-697`) and `ConfigPatchRequestSchema` (`:794-801`), matching web-fetch at `:698-703` / `:802-808`. Then update the web client's mirror of that contract: check `clients/web/src/domains/settings/ai/use-daemon-config.ts` (and any hand-maintained daemon config types it imports) for a web-search `mode` field and drop it. (The originally listed `daemon.json` / `types.gen.ts` artifacts do not exist in this repo — verified during PR 1.)
3. `web-search.ts`: delete `getWebSearchMode()` and the `WebSearchMode` type (`:39-40`, `:145-150`). Replace the `mode === "managed"` branch condition at the dispatch site with `getConfig().services["web-search"].provider === "vellum"`. PR 2's last-resort proxy call inside the `if (!apiKey)` block already reads the provider off config and needs no change.
4. `registry.ts:81-84`: drop `mode` from the `ProvidersConfig` web-search type. `shouldUseNativeWebSearch` is unchanged.
5. `config.ts:33-34,69-75`: the generic `SERVICE_MODE_PATH_RE` guard no longer matches web-search. Add an equivalent platform-connection guard for `config set services.web-search.provider vellum`, mirroring `voice-config-update.ts:204-213` ("managed web search requires a Vellum platform connection. Run 'assistant platform connect' first.").
6. Tests: update `config-schema.test.ts:75,104-120` (default has no `mode`; an explicit `mode` is stripped) and `config-set-platform-guard.test.ts:248-255` (replace the mode case with the provider-vellum case). Then update the fixture configs to drop `mode`, picking the provider that matches what each test is actually exercising — `satellite-connection-routing.test.ts:162` and `provider-platform-proxy-integration.test.ts:179,527` want `{ provider: "vellum" }` (proxy routing), while `provider-registry-ollama.test.ts:62` and `inference-no-mode-boot-e2e.test.ts:160` are native-search-preference tests and want `{ provider: "inference-provider-native" }`.
7. Leave the card's legacy `mode` write bridge (PR 5 step 6) in place — the daemon strips it, and old daemons still need it. Do NOT remove it in this PR.

### Acceptance criteria
- `services["web-search"]` parses to `{ provider }` only; a stale `mode` in a config file is silently dropped.
- `bun run typecheck` clean across `assistant/`, `cli/`, `clients/web/`.
- Full `assistant` and `clients/web` test suites pass.
- The daemon config GET/PATCH contract for web-search exposes `provider` only.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)