### PR TITLE
fix(voice-room): bound the spoken-word cursor to real speech pace while the response streams

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.test.tsx
@@ -153,19 +153,31 @@ describe("useSpokenWordCursor — monotonicity", () => {
 
 describe("useSpokenWordCursor — rate cap", () => {
   test("a mapped candidate sweeping far ahead advances only by the played-audio budget", () => {
-    progress = { playedSeconds: 1, totalSeconds: 10 };
-    const { result } = renderHook(() => useSpokenWordCursor(50));
+    progress = { playedSeconds: 10, totalSeconds: 100 };
+    const { result } = renderHook(() => useSpokenWordCursor(100));
     raf.pumpFrame();
-    // Adoption: floor(0.1 * 50) = 5.
-    expect(result.current).toBe(5);
+    // Adoption: floor(0.1 * 100) = 10 (spoken ceiling floor(10 × 3.3) = 33
+    // does not bind).
+    expect(result.current).toBe(10);
 
     // Near-underrun: played approaches total, so the fraction sweeps toward 1
-    // and the candidate lands near the end of the transcript
-    // (floor((1.5 / 1.6) * 50) = 46) while only 0.5s of audio actually
-    // played. Budget = 0.5 * 5 words/sec = 2 whole words.
-    progress = { playedSeconds: 1.5, totalSeconds: 1.6 };
+    // (candidate bounded by the spoken ceiling floor(10.5 × 3.3) = 34) while
+    // only 0.5s of audio actually played. Budget = 0.5 * 5 words/sec = 2
+    // whole words.
+    progress = { playedSeconds: 10.5, totalSeconds: 10.6 };
     raf.pumpFrame();
-    expect(result.current).toBe(7);
+    expect(result.current).toBe(12);
+  });
+
+  test("while text streams ahead of audio, the cursor advances at speech pace", () => {
+    // Mid-stream: 100 words are displayed but only 4s of audio is scheduled
+    // (the synthesized prefix). The raw fraction maps 2s played onto word 50;
+    // the spoken ceiling floor(2 × 3.3) = 6 keeps the highlight where real
+    // speech can actually be.
+    progress = { playedSeconds: 2, totalSeconds: 4 };
+    const { result } = renderHook(() => useSpokenWordCursor(100));
+    raf.pumpFrame();
+    expect(result.current).toBe(6);
   });
 
   test("a normal speaking cadence is never rate-limited", () => {
@@ -208,31 +220,34 @@ describe("useSpokenWordCursor — rate cap", () => {
   });
 
   test("a delayed frame spends its full earned allowance at once", () => {
-    // Adoption zeroes the bank.
-    progress = { playedSeconds: 0.4, totalSeconds: 40 };
+    // Adoption: floor(0.2 * 100) = 20 (spoken ceiling floor(8 × 3.3) = 26
+    // does not bind); bank zeroed.
+    progress = { playedSeconds: 8, totalSeconds: 40 };
     const { result } = renderHook(() => useSpokenWordCursor(100));
     raf.pumpFrame();
-    expect(result.current).toBe(1);
+    expect(result.current).toBe(20);
 
     // A 2s gap between frames (throttled tab while audio plays on) earns
     // 2 × 5 = 10 words, all spendable in the frame that observes it — even
-    // against a near-1 fraction (candidate 96) the cursor advances by the
-    // full earned allowance instead of crawling at the stored-bank ceiling.
-    progress = { playedSeconds: 2.4, totalSeconds: 2.5 };
+    // against a near-1 fraction (candidate bounded to the spoken ceiling 33)
+    // the cursor advances by the full earned allowance instead of crawling at
+    // the stored-bank ceiling.
+    progress = { playedSeconds: 10, totalSeconds: 10.4 };
     raf.pumpFrame();
-    expect(result.current).toBe(11);
+    expect(result.current).toBe(30);
   });
 
   test("the adoption jump is uncapped", () => {
-    const { result } = renderHook(() => useSpokenWordCursor(40));
+    const { result } = renderHook(() => useSpokenWordCursor(30));
     raf.pumpFrame();
     expect(result.current).toBeNull();
 
     // Mid-response mount: the first usable frame syncs straight to the
-    // playhead, floor(0.8 * 40) = 32, with no budget accrued yet.
+    // playhead, floor(0.8 * 30) = 24, with no budget accrued yet (spoken
+    // ceiling floor(8 × 3.3) = 26 does not bind).
     progress = { playedSeconds: 8, totalSeconds: 10 };
     raf.pumpFrame();
-    expect(result.current).toBe(32);
+    expect(result.current).toBe(24);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -5,9 +5,13 @@
  * A `requestAnimationFrame` loop polls {@link getLiveVoicePlaybackProgress}
  * (played/total seconds of the current response's scheduled audio) and maps the
  * played fraction onto the caller's word count:
- * `floor((playedSeconds / totalSeconds) * wordCount)`, clamped to the last
- * word. The mapping assumes words take roughly equal speaking time — close
- * enough for a caption highlight.
+ * `floor((playedSeconds / totalSeconds) * wordCount)`, bounded by the spoken
+ * ceiling `playedSeconds × MAX_SPEECH_WORDS_PER_SECOND` and clamped to the
+ * last word. The fraction assumes words take roughly equal speaking time and
+ * that the scheduled audio covers every displayed word; while the response is
+ * still streaming the audio covers only a synthesized prefix, and the ceiling
+ * keeps the cursor at the pace of real speech until the mapping becomes
+ * trustworthy.
  *
  * The cursor advances only while audio remains scheduled
  * (`playedSeconds < totalSeconds`). When the queue is caught up
@@ -67,6 +71,19 @@ import { getLiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/li
 const MAX_CURSOR_WORDS_PER_SECOND = 5;
 
 /**
+ * Ceiling on the cursor's absolute position, in words per second of played
+ * audio (~200 words/min, an upper bound on real TTS cadence). While a
+ * response streams, the scheduled audio covers only a synthesized prefix of
+ * the displayed words, so the played fraction maps onto too many words and
+ * runs ahead of speech; `playedSeconds` × this rate bounds the cursor to what
+ * real speech could have reached. Once the response has fully streamed the
+ * fraction mapping implies the voice's true (lower) rate and this ceiling
+ * stops binding. A voice faster than this rate trails slightly instead of
+ * leading — the lesser artifact.
+ */
+const MAX_SPEECH_WORDS_PER_SECOND = 3.3;
+
+/**
  * Index (into the caller's word segmentation) of the word the TTS playhead is
  * speaking, or `null` while the current response has produced no audio (the
  * caller keeps its default highlight). `wordCount` of 0 idles the loop
@@ -112,8 +129,17 @@ export function useSpokenWordCursor(wordCount: number): number | null {
         // fraction of 1.0 says nothing about displayed words with no
         // synthesized audio yet, so a null cursor stays null (default
         // highlight) and a numeric one holds its floor.
-        const mapped = Math.floor(
-          (progress.playedSeconds / progress.totalSeconds) * wordCount,
+        // The fraction mapping assumes the scheduled audio covers every
+        // displayed word — true once the response has fully streamed, but
+        // while text is still arriving the audio covers only a synthesized
+        // prefix and the fraction overshoots. The spoken ceiling bounds the
+        // cursor to the words real speech could have reached in the played
+        // seconds.
+        const mapped = Math.min(
+          Math.floor(
+            (progress.playedSeconds / progress.totalSeconds) * wordCount,
+          ),
+          Math.floor(progress.playedSeconds * MAX_SPEECH_WORDS_PER_SECOND),
         );
         const candidate =
           progress.playedSeconds < progress.totalSeconds &&


### PR DESCRIPTION
## Summary
Live-tryout fix: while a response streams, the scheduled audio covers only a synthesized prefix of the displayed words, so the played-fraction mapping overshoots and the highlight runs ahead of speech (the monotonic floor then latches it). Once the full response has streamed the mapping is trustworthy — which is why tracking looked correct only after streaming finished.

- The mapped candidate is now bounded by a spoken ceiling: playedSeconds × 3.3 words/sec (~200 wpm, an upper bound on real TTS cadence) — during streaming the cursor advances at the pace real speech can reach; at end-state the fraction term is smaller and behavior is unchanged
- Adoption jumps are bounded by the same ceiling, so a mid-response mount cannot sync into overshoot
- New test for the streaming case; rate-cap/adoption tests reworked onto values where the ceiling legitimately does not bind