### PR TITLE
fix(web): keep the provisioning takeover escapable when routing hangs

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -417,6 +417,50 @@ describe("BillingOnboardingModal", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  test(
+    "a busy takeover past the escape grace with routing hung is dismissable via the backdrop",
+    async () => {
+      // The purest dead-end: an active WAITING/RESIZING takeover whose
+      // post-confirm onboarding refetch is held open, so routing never settles
+      // and the in-content escape button (gated on routing) never appears.
+      // Once the watch runs past the escape grace, the fallback background
+      // dismiss must unlock — otherwise the removed X strands the user.
+      onboardingHold = new Promise(() => {});
+      subscriptionPlanId = "pro";
+      const { getByText, onClose } = renderModal();
+
+      await waitFor(
+        () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+
+      // Past the escape grace (60s) but before the stall threshold (90s):
+      // escapeEligible latches while the state stays busy, not STALLED.
+      dateNowOffsetMs = 70_000;
+
+      // The X stays hidden throughout — the fallback exit is the backdrop.
+      expect(document.body.querySelector('[aria-label="Close"]')).toBeNull();
+
+      // The 1s clock tick re-derives escapeEligible; once it lands the backdrop
+      // unlocks, so re-click until the dismiss flows through to onClose.
+      await waitFor(
+        () => {
+          const overlay = document.body.querySelector(
+            '[data-slot="modal-overlay"]',
+          );
+          expect(overlay).not.toBeNull();
+          fireEvent.click(overlay as Element);
+          expect(onClose).toHaveBeenCalled();
+        },
+        { timeout: 5000 },
+      );
+
+      // Still the busy takeover, not the stalled path (which has its own Apply).
+      expect(getByText("Upgrading your assistant…")).toBeTruthy();
+    },
+    20_000,
+  );
+
   test("stall surfaces Apply & Restart; a successful apply resumes resizing through DONE", async () => {
     subscriptionPlanId = "pro";
     const { client, getByText, getByTestId } = renderModal();

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -122,10 +122,15 @@ export function BillingOnboardingModal({
   // actions) live inside the step content.
   const isTakeover = step === "provisioning" && !provisioningError;
 
-  // Lock Esc/backdrop only while provisioning is active — the terminal ready
-  // states unlock dismissal, so a hung routing refetch that blocks the
-  // auto-advance is never a dead-end.
-  const lockTakeover = isTakeover && !provisioningSettled;
+  // Lock Esc/backdrop while provisioning is active, with two escape valves so a
+  // hung routing refetch never strands the user behind the removed X: terminal
+  // ready states unlock, and a busy state stuck past the escape grace with
+  // routing still hung unlocks to a plain background-dismiss (the in-content
+  // escape hatch needs routing to have settled).
+  const stuckAwaitingRouting =
+    machineBusy && provisioning.escapeEligible && !routingSettled;
+  const lockTakeover =
+    isTakeover && !provisioningSettled && !stuckAwaitingRouting;
 
   // Full-bleed dark content that fills the viewport for the takeover.
   const provisioningContentClass =


### PR DESCRIPTION
## Summary
- The provisioning takeover removed its X; a hung post-confirm routing refetch left WAITING/RESIZING/STALLED with no exit (backdrop/Esc locked, in-content escape button gated on routing).
- Unlock a plain background-dismiss once the machine is busy past the escape grace with routing still hung, so the takeover is never a dead-end.
- Adds a regression test for the busy + escape-grace + routing-hung case.

Part of plan: pro-manage-downgrade-loading.md (self-review remediation)