### PR TITLE
feat(providers): add Gemini 3.6 Flash and 3.5 Flash-Lite via Google

### DIFF
--- a/assistant/src/daemon/handlers/config-model.test.ts
+++ b/assistant/src/daemon/handlers/config-model.test.ts
@@ -65,7 +65,9 @@ describe("projectProviderForWire", () => {
     const wire = projectProviderForWire(gemini!);
     const modelIds = wire.models.map((model) => model.id);
     const expectedGemini3ModelIds = [
+      "gemini-3.6-flash",
       "gemini-3.5-flash",
+      "gemini-3.5-flash-lite",
       "gemini-3.1-pro-preview",
       "gemini-3.1-pro-preview-customtools",
       "gemini-3-flash-preview",

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -562,6 +562,21 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     },
     models: [
       {
+        id: "gemini-3.6-flash",
+        displayName: "Gemini 3.6 Flash",
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 65536,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 1.5,
+          outputPer1mTokens: 7.5,
+          cacheReadPer1mTokens: 0.15,
+        },
+      },
+      {
         id: "gemini-3.5-flash",
         displayName: "Gemini 3.5 Flash",
         contextWindowTokens: 1048576,
@@ -574,6 +589,21 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
           inputPer1mTokens: 1.5,
           outputPer1mTokens: 9.0,
           cacheReadPer1mTokens: 0.15,
+        },
+      },
+      {
+        id: "gemini-3.5-flash-lite",
+        displayName: "Gemini 3.5 Flash-Lite",
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 65536,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 0.3,
+          outputPer1mTokens: 2.5,
+          cacheReadPer1mTokens: 0.03,
         },
       },
       {

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -184,8 +184,24 @@ export const MODELS_BY_PROVIDER = {
   ],
   gemini: [
     {
+      id: "gemini-3.6-flash",
+      displayName: "Gemini 3.6 Flash",
+      contextWindowTokens: 1_048_576,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 65_536,
+      supportsThinking: true,
+    },
+    {
       id: "gemini-3.5-flash",
       displayName: "Gemini 3.5 Flash",
+      contextWindowTokens: 1_048_576,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 65_536,
+      supportsThinking: true,
+    },
+    {
+      id: "gemini-3.5-flash-lite",
+      displayName: "Gemini 3.5 Flash-Lite",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -434,6 +434,23 @@
       "defaultModel": "gemini-2.5-flash",
       "models": [
         {
+          "id": "gemini-3.6-flash",
+          "displayName": "Gemini 3.6 Flash",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 65536,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.5,
+            "outputPer1mTokens": 7.5,
+            "cacheReadPer1mTokens": 0.15
+          }
+        },
+        {
           "id": "gemini-3.5-flash",
           "displayName": "Gemini 3.5 Flash",
           "contextWindowTokens": 1048576,
@@ -448,6 +465,23 @@
             "inputPer1mTokens": 1.5,
             "outputPer1mTokens": 9,
             "cacheReadPer1mTokens": 0.15
+          }
+        },
+        {
+          "id": "gemini-3.5-flash-lite",
+          "displayName": "Gemini 3.5 Flash-Lite",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 65536,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.3,
+            "outputPer1mTokens": 2.5,
+            "cacheReadPer1mTokens": 0.03
           }
         },
         {


### PR DESCRIPTION
## Summary

Adds the two publicly-available Gemini models from [Google's 2026-07-21 announcement](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/) to the Google Gemini provider catalog:

- **`gemini-3.6-flash`** — 1M context, 64k output, thinking + caching + vision + tools. $1.50/$7.50 per 1M tokens, $0.15 cache read.
- **`gemini-3.5-flash-lite`** — same capability set. $0.30/$2.50 per 1M tokens, $0.03 cache read.

Model IDs, specs, and paid-tier pricing verified against ai.google.dev/gemini-api/docs (models, pricing, changelog) on 2026-07-21. Neither model has long-context pricing tiers.

**Excluded:** Gemini 3.5 Flash Cyber, the third model in the announcement — it is only available to governments and trusted partners via CodeMender, not the public Gemini API, so it can't be used with a user's Gemini API key.

## Notes

- Google's changelog deprecates `temperature`/`top_p`/`top_k` for these models (ignored now, hard 400 in future generations). Our Gemini client sends no sampling parameters, so no client change is needed.
- Provider defaults and model intents (`model-intents.ts`) are intentionally untouched — remapping e.g. `latency-optimized` → `gemini-3.5-flash-lite` changes behavior for existing intent-pinned call sites and can be a follow-up.

## Files

- `assistant/src/providers/model-catalog.ts` — source of truth
- `meta/llm-provider-catalog.json` — regenerated via `bun run sync:llm-catalog`
- `clients/web/src/assistant/llm-model-catalog.ts` — hand-maintained web mirror

## Testing

- `bun test llm-catalog-parity pricing model-intents` (assistant): 100 pass
- `bun test llm-model-catalog` (clients/web): 43 pass
- `typecheck:fast` (assistant) and `tsc --noEmit` (clients/web): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)