### PR TITLE
feat(ios): support VELLUM_SERVER_URL override for the Capacitor shell server URL

### DIFF
--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -305,9 +305,26 @@ bun run ios:setup
 copy in `clients/ios/App/App/public/`) and then `xcodegen generate` to refresh
 `App.xcodeproj/`. All three of those output paths are gitignored.
 
-### Point at a local Next.js instead of `dev-assistant`
+### Point at a different server (self-hosted origin or local dev)
 
-Temporarily edit `capacitor.config.ts`:
+**HTTPS origin (self-hosted assistant, or any valid-TLS host):** set
+`VELLUM_SERVER_URL` when syncing. It overrides the environment-derived
+Vellum Cloud URL and is baked into `server.url` the same way:
+
+```bash
+cd clients/web
+VELLUM_SERVER_URL=https://your-host.ts.net bunx cap sync ios
+```
+
+Then rebuild in Xcode. The value must be a valid `https:` URL — `cap sync`
+fails loudly otherwise, because iOS App Transport Security requires valid
+TLS and `server.cleartext` stays `false`. Nothing to edit or revert: resync
+without the variable (e.g. `bun run ios:setup`) to return to the environment
+default.
+
+**Plain-HTTP local dev (e.g. a local Next.js on your LAN):** ATS blocks
+cleartext HTTP and `VELLUM_SERVER_URL` is https-only, so this path still
+requires temporarily editing `capacitor.config.ts`:
 
 ```ts
 server: {

--- a/clients/web/capacitor.config.ts
+++ b/clients/web/capacitor.config.ts
@@ -10,12 +10,43 @@ import type { CapacitorConfig } from "@capacitor/cli";
 // and bounces non-prod shells off their own host.
 const env = process.env.VELLUM_ENVIRONMENT ?? "dev";
 
-const SERVER_URL =
+const ENV_SERVER_URL =
   env === "production"
     ? "https://www.vellum.ai/assistant"
     : env === "staging"
       ? "https://staging-assistant.vellum.ai/assistant"
       : "https://dev-assistant.vellum.ai/assistant";
+
+// `VELLUM_SERVER_URL` points the shell at a self-hosted assistant's own HTTPS
+// origin, taking precedence over the environment-derived Vellum Cloud URL. It
+// must parse as an `https:` URL — iOS App Transport Security requires valid TLS
+// and `server.cleartext` stays false — so an invalid value fails `cap sync`
+// loudly instead of baking a broken URL into the archived build.
+function resolveServerUrl(): string {
+  const override = process.env.VELLUM_SERVER_URL?.trim();
+  if (!override) {
+    return ENV_SERVER_URL;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(override);
+  } catch {
+    throw new Error(
+      `VELLUM_SERVER_URL is not a valid URL: ${JSON.stringify(override)}`,
+    );
+  }
+
+  if (parsed.protocol !== "https:") {
+    throw new Error(
+      `VELLUM_SERVER_URL must use https: (got ${JSON.stringify(override)}); iOS App Transport Security requires valid TLS.`,
+    );
+  }
+
+  return override;
+}
+
+const SERVER_URL = resolveServerUrl();
 
 const SCHEME_NAMES: Record<string, string> = {
   production: "App",


### PR DESCRIPTION
## Summary
- VELLUM_SERVER_URL env var overrides the Capacitor server.url at cap sync (https-only, validated)
- Replaces the README edit-and-revert hack with the supported override

Part of plan: ios-self-hosted-connect.md (PR 4 of 4)