### PR TITLE
fix(cli): relative redirects in nginx ingress edge config

### DIFF
--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -59,6 +59,13 @@ describe("buildIngressNginxConfig", () => {
     }
   });
 
+  test("emits relative redirects so a fronting proxy keeps scheme and port", () => {
+    for (const config of [conf, remoteConf]) {
+      expect(config).toContain("absolute_redirect off;");
+      expect(config).toContain("port_in_redirect off;");
+    }
+  });
+
   test("proxies requests to the gateway", () => {
     expect(conf).toContain("location / {");
     expect(conf).toContain("proxy_pass http://127.0.0.1:7830;");

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -230,6 +230,13 @@ http {
     listen 127.0.0.1:${opts.listenPort};
     client_max_body_size 512m;
 
+    # This edge sits behind a TLS-terminating front (tunnel or tailscale serve),
+    # so redirects must be relative: emit "Location: /assistant/" and let the
+    # client resolve it against the origin it used, rather than an absolute URL
+    # built from nginx's own loopback scheme and port.
+    absolute_redirect off;
+    port_in_redirect off;
+
 ${serverLocations}
   }
 }


### PR DESCRIPTION
## Summary
- Adds absolute_redirect off / port_in_redirect off to the generated nginx edge config
- Fixes the root-path 302 pointing at http://<host>:7840/assistant/ when fronted by tailscale serve or a TLS tunnel

Found during live Phase-0 testing of plan: ios-self-hosted-connect.md