### PR TITLE
feat(gateway): host-minted one-time QR pairing codes with public exchange route

### DIFF
--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -134,6 +134,8 @@ describe("buildIngressNginxConfig", () => {
       "location = /v1/pair/ { return 404; }",
       "location = /v1/pair/web-init { return 404; }",
       "location = /v1/pair/web-init/ { return 404; }",
+      "location = /v1/pair/qr-code { return 404; }",
+      "location = /v1/pair/qr-code/ { return 404; }",
       "location = /v1/devices { return 404; }",
       "location = /v1/devices/ { return 404; }",
       "location = /v1/devices/revoke { return 404; }",
@@ -151,6 +153,15 @@ describe("buildIngressNginxConfig", () => {
         remoteConf.indexOf("location ^~ /v1/ {"),
       );
     }
+  });
+
+  test("allows the public QR pairing exchange to reach the gateway", () => {
+    // The exchange endpoint is deliberately internet-facing: it is NOT denied
+    // and falls through to the generic /v1/ proxy, unlike its loopback-only
+    // qr-code mint sibling which is 404'd above.
+    expect(remoteConf).not.toContain("/v1/pair/qr-exchange { return 404; }");
+    expect(remoteConf).not.toContain("/v1/pair/qr-exchange/ { return 404; }");
+    expect(remoteConf).toContain("location ^~ /v1/ {");
   });
 
   test("supports websockets and SSE streaming", () => {

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -255,6 +255,8 @@ function buildRemoteWebIngressLocations(opts: {
     location = /v1/pair/ { return 404; }
     location = /v1/pair/web-init { return 404; }
     location = /v1/pair/web-init/ { return 404; }
+    location = /v1/pair/qr-code { return 404; }
+    location = /v1/pair/qr-code/ { return 404; }
     location = /v1/devices { return 404; }
     location = /v1/devices/ { return 404; }
     location = /v1/devices/revoke { return 404; }

--- a/gateway/src/__tests__/pair-qr-code.test.ts
+++ b/gateway/src/__tests__/pair-qr-code.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for `POST /v1/pair/qr-code`: loopback-only mint of single-use QR pairing
+ * codes. The mint route touches no DB or signing key — it only writes to the
+ * in-memory code store — so the setup is limited to resetting that store.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { handleMintQrPairingCode } from "../http/routes/pair-qr-code.js";
+import {
+  getQrPairingCodeCountForTests,
+  resetQrPairingCodesForTests,
+} from "../remote-web/qr-pairing-code-store.js";
+
+const LOOPBACK_IP = "127.0.0.1";
+
+function makeMintRequest(
+  opts: { headers?: Record<string, string>; method?: string } = {},
+): Request {
+  return new Request("http://localhost:7830/v1/pair/qr-code", {
+    method: opts.method ?? "POST",
+    headers: { host: "localhost:7830", ...opts.headers },
+  });
+}
+
+beforeEach(() => {
+  resetQrPairingCodesForTests();
+});
+
+afterEach(() => {
+  resetQrPairingCodesForTests();
+});
+
+describe("POST /v1/pair/qr-code mint", () => {
+  test("mints a code for a loopback caller", async () => {
+    const res = await handleMintQrPairingCode(makeMintRequest(), LOOPBACK_IP);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(typeof body.code).toBe("string");
+    // 32 random bytes as base64url ⇒ 43 chars, well over 128 bits of entropy.
+    expect((body.code as string).length).toBeGreaterThanOrEqual(43);
+    expect(typeof body.expiresAt).toBe("string");
+    expect(body.expiresInSeconds).toBe(300);
+    expect(getQrPairingCodeCountForTests()).toBe(1);
+  });
+
+  test("mints a distinct code on each call", async () => {
+    const first = (await (
+      await handleMintQrPairingCode(makeMintRequest(), LOOPBACK_IP)
+    ).json()) as { code: string };
+    const second = (await (
+      await handleMintQrPairingCode(makeMintRequest(), LOOPBACK_IP)
+    ).json()) as { code: string };
+
+    expect(first.code).not.toBe(second.code);
+    expect(getQrPairingCodeCountForTests()).toBe(2);
+  });
+
+  test("rejects a non-loopback peer and mints nothing", async () => {
+    const res = await handleMintQrPairingCode(makeMintRequest(), "8.8.8.8");
+
+    expect(res.status).toBe(403);
+    expect(getQrPairingCodeCountForTests()).toBe(0);
+  });
+
+  test("rejects an edge-forwarded request from a loopback peer", async () => {
+    // The nginx edge sets the unspoofable marker; a loopback peer IP alone must
+    // not be treated as local when the request came over the tunnel.
+    const res = await handleMintQrPairingCode(
+      makeMintRequest({ headers: { "x-vellum-edge-forwarded": "1" } }),
+      LOOPBACK_IP,
+    );
+
+    expect(res.status).toBe(403);
+    expect(getQrPairingCodeCountForTests()).toBe(0);
+  });
+
+  test("rejects an X-Forwarded-For request", async () => {
+    const res = await handleMintQrPairingCode(
+      makeMintRequest({ headers: { "x-forwarded-for": "8.8.8.8" } }),
+      LOOPBACK_IP,
+    );
+
+    expect(res.status).toBe(403);
+    expect(getQrPairingCodeCountForTests()).toBe(0);
+  });
+
+  test("rejects a request carrying a browser Origin (WebView mint-and-readback)", async () => {
+    const res = await handleMintQrPairingCode(
+      makeMintRequest({ headers: { origin: "https://app.vellum.local" } }),
+      LOOPBACK_IP,
+    );
+
+    expect(res.status).toBe(403);
+    expect(getQrPairingCodeCountForTests()).toBe(0);
+  });
+
+  test("rejects a non-POST method with 405", async () => {
+    const res = await handleMintQrPairingCode(
+      makeMintRequest({ method: "GET" }),
+      LOOPBACK_IP,
+    );
+
+    expect(res.status).toBe(405);
+    expect(getQrPairingCodeCountForTests()).toBe(0);
+  });
+});

--- a/gateway/src/__tests__/pair-qr-exchange.test.ts
+++ b/gateway/src/__tests__/pair-qr-exchange.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for `POST /v1/pair/qr-exchange`: the public exchange of a host-minted QR
+ * pairing code for device-bound tokens. Covers flag gating, the happy path,
+ * atomic single-use burn (including concurrent exchange), expiry, uniform
+ * invalid-code failure, input validation, and per-IP rate limiting.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+
+import { initSigningKey } from "../auth/token-service.js";
+
+// Must init signing key before importing modules that mint tokens.
+initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
+
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: mock(),
+  assistantDbRun: mock(),
+  assistantDbExec: mock(),
+}));
+
+const { initGatewayDb, resetGatewayDb, getGatewayDb } =
+  await import("../db/connection.js");
+const {
+  actorTokenRecords,
+  actorRefreshTokenRecords,
+  contacts,
+  contactChannels,
+} = await import("../db/schema.js");
+const { handleQrPairingExchange } =
+  await import("../http/routes/pair-qr-exchange.js");
+const { hashToken } = await import("../auth/guardian-bootstrap.js");
+const {
+  createQrPairingCode,
+  getQrPairingCodeCountForTests,
+  resetQrPairingCodesForTests,
+  setQrPairingCodeNowForTests,
+} = await import("../remote-web/qr-pairing-code-store.js");
+const { resetQrPairingExchangeRateLimiterForTests } =
+  await import("../remote-web/qr-pairing-exchange-rate-limit-store.js");
+const { resetEnvOverridesCache } =
+  await import("../feature-flag-env-overrides.js");
+
+const GUARDIAN_ID = "guardian-001";
+const CLIENT_IP = "203.0.113.7";
+
+let testRoot: string;
+
+function makeExchangeRequest(
+  body?: unknown,
+  opts: { method?: string; raw?: string } = {},
+): Request {
+  return new Request("https://paired.example.com/v1/pair/qr-exchange", {
+    method: opts.method ?? "POST",
+    headers: { "content-type": "application/json" },
+    body:
+      opts.raw !== undefined
+        ? opts.raw
+        : body === undefined
+          ? undefined
+          : JSON.stringify(body),
+  });
+}
+
+function activeTokens() {
+  return getGatewayDb()
+    .select()
+    .from(actorTokenRecords)
+    .where(eq(actorTokenRecords.status, "active"))
+    .all();
+}
+
+function activeRefreshTokens() {
+  return getGatewayDb()
+    .select()
+    .from(actorRefreshTokenRecords)
+    .where(eq(actorRefreshTokenRecords.status, "active"))
+    .all();
+}
+
+function seedGatewayGuardian() {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: GUARDIAN_ID,
+      displayName: "Guardian",
+      role: "guardian",
+      principalId: GUARDIAN_ID,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id: `ch-${GUARDIAN_ID}`,
+      contactId: GUARDIAN_ID,
+      type: "vellum",
+      address: "guardian-vellum",
+      isPrimary: false,
+      status: "active",
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function enableFlag() {
+  process.env.VELLUM_FLAG_WEB_REMOTE_INGRESS = "true";
+  resetEnvOverridesCache();
+}
+
+function disableFlag() {
+  delete process.env.VELLUM_FLAG_WEB_REMOTE_INGRESS;
+  resetEnvOverridesCache();
+}
+
+beforeEach(async () => {
+  resetQrPairingCodesForTests();
+  resetQrPairingExchangeRateLimiterForTests();
+  testRoot = mkdtempSync(join(tmpdir(), "pair-qr-exchange-test-"));
+  const securityDir = join(testRoot, "protected");
+  mkdirSync(securityDir, { recursive: true });
+  process.env.GATEWAY_SECURITY_DIR = securityDir;
+  await initGatewayDb();
+  seedGatewayGuardian();
+  enableFlag();
+});
+
+afterEach(() => {
+  resetQrPairingCodesForTests();
+  resetQrPairingExchangeRateLimiterForTests();
+  disableFlag();
+  resetGatewayDb();
+  delete process.env.GATEWAY_SECURITY_DIR;
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("POST /v1/pair/qr-exchange", () => {
+  test("404s and mints nothing when web-remote-ingress is disabled", async () => {
+    disableFlag();
+    const { code } = createQrPairingCode();
+
+    const res = await handleQrPairingExchange(
+      makeExchangeRequest({ code, deviceId: "device-A" }),
+      CLIENT_IP,
+    );
+
+    expect(res.status).toBe(404);
+    // The code is untouched: minting is fully gated, so a later enabled attempt
+    // still works.
+    expect(getQrPairingCodeCountForTests()).toBe(1);
+    expect(activeTokens()).toHaveLength(0);
+  });
+
+  test("exchanges a valid code for a device-bound token pair", async () => {
+    const { code } = createQrPairingCode();
+
+    const res = await handleQrPairingExchange(
+      makeExchangeRequest({ code, deviceId: "device-A" }),
+      CLIENT_IP,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(typeof body.token).toBe("string");
+    expect(typeof body.refreshToken).toBe("string");
+    expect(typeof body.refreshTokenExpiresAt).toBe("string");
+    expect(typeof body.refreshAfter).toBe("string");
+    expect(body.guardianId).toBe(GUARDIAN_ID);
+
+    const tokens = activeTokens();
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].guardianPrincipalId).toBe(GUARDIAN_ID);
+    expect(tokens[0].hashedDeviceId).toBe(hashToken("device-A"));
+    expect(tokens[0].platform).toBe("qr");
+
+    const refresh = activeRefreshTokens();
+    expect(refresh).toHaveLength(1);
+    expect(refresh[0].tokenHash).toBe(hashToken(body.refreshToken as string));
+
+    // The code is burned: it is gone from the store.
+    expect(getQrPairingCodeCountForTests()).toBe(0);
+  });
+
+  test("is single-use: a second exchange of the same code fails", async () => {
+    const { code } = createQrPairingCode();
+
+    const first = await handleQrPairingExchange(
+      makeExchangeRequest({ code, deviceId: "device-A" }),
+      CLIENT_IP,
+    );
+    expect(first.status).toBe(200);
+
+    const second = await handleQrPairingExchange(
+      makeExchangeRequest({ code, deviceId: "device-B" }),
+      CLIENT_IP,
+    );
+    expect(second.status).toBe(401);
+    // No second token was minted.
+    expect(activeTokens()).toHaveLength(1);
+    expect(activeTokens()[0].hashedDeviceId).toBe(hashToken("device-A"));
+  });
+
+  test("a concurrent exchange of the same code lets exactly one win", async () => {
+    const { code } = createQrPairingCode();
+
+    const [a, b] = await Promise.all([
+      handleQrPairingExchange(
+        makeExchangeRequest({ code, deviceId: "device-A" }),
+        CLIENT_IP,
+      ),
+      handleQrPairingExchange(
+        makeExchangeRequest({ code, deviceId: "device-B" }),
+        CLIENT_IP,
+      ),
+    ]);
+
+    const statuses = [a.status, b.status].sort();
+    expect(statuses).toEqual([200, 401]);
+    expect(activeTokens()).toHaveLength(1);
+  });
+
+  test("rejects an expired code with 401", async () => {
+    setQrPairingCodeNowForTests(() => 1_000);
+    const { code } = createQrPairingCode();
+    // Advance past the 5-minute TTL.
+    setQrPairingCodeNowForTests(() => 1_000 + 6 * 60 * 1000);
+
+    const res = await handleQrPairingExchange(
+      makeExchangeRequest({ code, deviceId: "device-A" }),
+      CLIENT_IP,
+    );
+
+    expect(res.status).toBe(401);
+    expect(activeTokens()).toHaveLength(0);
+  });
+
+  test("returns the same 401 for an unknown code (no existence leak)", async () => {
+    const res = await handleQrPairingExchange(
+      makeExchangeRequest({ code: "not-a-real-code", deviceId: "device-A" }),
+      CLIENT_IP,
+    );
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "INVALID_OR_EXPIRED_QR_CODE",
+        message: "invalid or expired pairing code",
+      },
+    });
+    expect(activeTokens()).toHaveLength(0);
+  });
+
+  test("requires both code and deviceId", async () => {
+    const missingDevice = await handleQrPairingExchange(
+      makeExchangeRequest({ code: "abc" }),
+      CLIENT_IP,
+    );
+    expect(missingDevice.status).toBe(400);
+
+    const missingCode = await handleQrPairingExchange(
+      makeExchangeRequest({ deviceId: "device-A" }),
+      CLIENT_IP,
+    );
+    expect(missingCode.status).toBe(400);
+    expect(activeTokens()).toHaveLength(0);
+  });
+
+  test("rejects an invalid JSON body with 400", async () => {
+    const res = await handleQrPairingExchange(
+      makeExchangeRequest(undefined, { raw: "not json" }),
+      CLIENT_IP,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects a non-POST method with 405", async () => {
+    const res = await handleQrPairingExchange(
+      makeExchangeRequest(
+        { code: "abc", deviceId: "device-A" },
+        { method: "GET" },
+      ),
+      CLIENT_IP,
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("rate limits per IP after the request budget is spent", async () => {
+    // The limiter allows 10 requests/minute per IP; the 11th is 429.
+    for (let i = 0; i < 10; i++) {
+      const res = await handleQrPairingExchange(
+        makeExchangeRequest({ code: `miss-${i}`, deviceId: "device-A" }),
+        CLIENT_IP,
+      );
+      expect(res.status).toBe(401);
+    }
+
+    const limited = await handleQrPairingExchange(
+      makeExchangeRequest({ code: "miss-final", deviceId: "device-A" }),
+      CLIENT_IP,
+    );
+    expect(limited.status).toBe(429);
+    expect(typeof limited.headers.get("Retry-After")).toBe("string");
+
+    // A different IP is unaffected by another IP's budget.
+    const { code } = createQrPairingCode();
+    const other = await handleQrPairingExchange(
+      makeExchangeRequest({ code, deviceId: "device-A" }),
+      "198.51.100.9",
+    );
+    expect(other.status).toBe(200);
+  });
+});

--- a/gateway/src/__tests__/remote-web-ingress-denylist.test.ts
+++ b/gateway/src/__tests__/remote-web-ingress-denylist.test.ts
@@ -76,22 +76,28 @@ describe("remote web ingress denylist", () => {
       "/v1/guardian/init",
       "/v1/guardian/reset-bootstrap",
       "/v1/pair",
+      "/v1/pair/qr-code",
+      "/v1/pair/qr-exchange",
       "/v1/remote-web/pairing-challenge",
       "/v1/remote-web/pairing-token",
       "/v1/remote-web/pairing-verification",
     ]);
 
-    const publicRemoteWebRoutes = new Set([
+    // Routes that are meant to be reachable over the tunnel: the browser
+    // device-code pairing pair, plus the public QR pairing exchange. Everything
+    // else in the list is loopback-only and must be 404'd at the edge.
+    const publicIngressRoutes = new Set([
+      "/v1/pair/qr-exchange",
       "/v1/remote-web/pairing-challenge",
       "/v1/remote-web/pairing-token",
     ]);
 
     for (const path of unprotectedV1Routes) {
-      if (publicRemoteWebRoutes.has(path)) continue;
+      if (publicIngressRoutes.has(path)) continue;
       assertDeniedBeforeV1Proxy(path);
     }
 
-    for (const path of publicRemoteWebRoutes) {
+    for (const path of publicIngressRoutes) {
       assertNotExplicitlyDenied(path);
     }
   });

--- a/gateway/src/http/device-bound-pair-response.ts
+++ b/gateway/src/http/device-bound-pair-response.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared builder for device-bound pairing responses.
+ *
+ * Every pairing path that issues device-scoped credentials — loopback `/v1/pair`
+ * (chrome-extension and cli) and the public QR-code exchange — mints the same
+ * access + refresh token pair and returns the same body shape via this helper,
+ * so the credential contract can't drift between them.
+ */
+
+import { mintAndRecordDeviceBoundTokenPair } from "../auth/guardian-bootstrap.js";
+import { getLogger } from "../logger.js";
+
+const log = getLogger("device-bound-pair");
+
+/**
+ * Mint a device-bound, recorded, per-device-revocable credential and build the
+ * pair response.
+ *
+ * Issues the standard access + long-lived device-scoped refresh token pair, so
+ * a paired client renews via `/v1/guardian/refresh` instead of re-pairing.
+ * Both are revocable per device on the hot path (actor-token revocation is
+ * enforced on live requests), and the refresh endpoint rejects revoked/rotated
+ * tokens — so revocation, not a short TTL, bounds a leaked token's reach. The
+ * access TTL matches what `/v1/guardian/refresh` mints on rotation, so it stays
+ * consistent across the token's life (rather than 24h at mint then 30d after
+ * the first refresh).
+ *
+ * The response carries `Cache-Control: no-store` so the token pair is never
+ * cached by an intermediary on the internet-facing exchange path.
+ */
+export function mintDeviceBoundPairResponse(opts: {
+  guardianPrincipalId: string;
+  assistantId: string;
+  deviceId: string;
+  platform: string;
+  interfaceId: string;
+  clientId: string | null;
+}): Response {
+  const pair = mintAndRecordDeviceBoundTokenPair({
+    guardianPrincipalId: opts.guardianPrincipalId,
+    deviceId: opts.deviceId,
+    platform: opts.platform,
+  });
+
+  log.info(
+    {
+      interfaceId: opts.interfaceId,
+      clientId: opts.clientId,
+      guardianPrincipalId: opts.guardianPrincipalId,
+      platform: opts.platform,
+    },
+    "Client paired successfully (device-bound)",
+  );
+
+  return Response.json(
+    {
+      token: pair.accessToken,
+      expiresAt: new Date(pair.accessTokenExpiresAt).toISOString(),
+      refreshToken: pair.refreshToken,
+      refreshTokenExpiresAt: new Date(pair.refreshTokenExpiresAt).toISOString(),
+      refreshAfter: new Date(pair.refreshAfter).toISOString(),
+      guardianId: opts.guardianPrincipalId,
+      assistantId: opts.assistantId,
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/gateway/src/http/routes/pair-qr-code.ts
+++ b/gateway/src/http/routes/pair-qr-code.ts
@@ -1,0 +1,69 @@
+/**
+ * Route handler for `POST /v1/pair/qr-code`.
+ *
+ * Loopback-only mint of a single-use QR pairing code on the host machine. The
+ * CLI renders the returned code as a QR; a phone that scans it presents the
+ * code to the public `POST /v1/pair/qr-exchange` route for device-bound tokens.
+ *
+ * Possession of the code is the proof of physical presence at the host, so
+ * minting is restricted to loopback callers exactly like `/v1/pair` (peer IP,
+ * Host header, and the unspoofable edge-forwarded marker are all enforced by
+ * {@link enforceLoopbackOnly}). The self-hosted nginx edge additionally 404s
+ * this path so it is never reachable over the tunnel. A browser `Origin` is
+ * rejected too: a local WebView must not be able to mint a code and read it
+ * back through the gateway's WebView CORS allowance.
+ */
+
+import { getLogger } from "../../logger.js";
+import {
+  checkQrPairingCodeCapacity,
+  createQrPairingCode,
+} from "../../remote-web/qr-pairing-code-store.js";
+import { enforceLoopbackOnly, rejectBrowserOrigin } from "../loopback-guard.js";
+
+const log = getLogger("pair-qr-code");
+
+export async function handleMintQrPairingCode(
+  req: Request,
+  clientIp: string,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("method not allowed", {
+      status: 405,
+      headers: { Allow: "POST" },
+    });
+  }
+
+  const guardError = enforceLoopbackOnly(req, clientIp, "pair-qr-code");
+  if (guardError) return guardError;
+
+  const originError = rejectBrowserOrigin(req, clientIp, "pair-qr-code");
+  if (originError) return originError;
+
+  const capacityLimited = checkQrPairingCodeCapacity();
+  if (capacityLimited) {
+    return Response.json(
+      {
+        error: {
+          code: "QR_PAIRING_CODE_CAPACITY_EXCEEDED",
+          message: "too many active QR pairing codes",
+        },
+      },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(capacityLimited.retryAfterSeconds),
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
+  const created = createQrPairingCode();
+  log.info(
+    { expiresAt: created.expiresAt },
+    "Minted QR pairing code via loopback",
+  );
+
+  return Response.json(created, { headers: { "Cache-Control": "no-store" } });
+}

--- a/gateway/src/http/routes/pair-qr-exchange.ts
+++ b/gateway/src/http/routes/pair-qr-exchange.ts
@@ -1,0 +1,144 @@
+/**
+ * Route handler for `POST /v1/pair/qr-exchange`.
+ *
+ * Public exchange endpoint for QR pairing. A phone presents the single-use code
+ * minted by the host (`POST /v1/pair/qr-code`) together with its `deviceId` and
+ * receives device-bound access + refresh tokens — the same credential shape as
+ * the loopback device-bound pair flow. There is no prior auth: the code IS the
+ * credential, and possession proves the presenter physically saw the host's
+ * screen.
+ *
+ * Security posture (internet-facing):
+ *   - **Flag-gated**: gated behind `web-remote-ingress`; when disabled the route
+ *     404s so a host that has not opted into remote web ingress exposes no
+ *     pairing surface at all.
+ *   - **Atomic single-use burn**: the code is burned before tokens are minted,
+ *     so a concurrent second exchange of the same code fails.
+ *   - **Uniform failure**: every invalid / expired / already-burned code returns
+ *     the same error, so an attacker cannot probe which codes exist.
+ *   - **Rate limited**: strict per-IP request cap as flood defence-in-depth.
+ */
+
+import { getExternalAssistantId } from "../../auth/guardian-bootstrap.js";
+import { isFeatureFlagEnabled } from "../../feature-flag-resolver.js";
+import { getLogger } from "../../logger.js";
+import { claimQrPairingCode } from "../../remote-web/qr-pairing-code-store.js";
+import {
+  checkQrPairingExchangeRateLimit,
+  type QrPairingExchangeRateLimit,
+} from "../../remote-web/qr-pairing-exchange-rate-limit-store.js";
+import { mintDeviceBoundPairResponse } from "../device-bound-pair-response.js";
+import { readLimitedBody } from "../read-limited-body.js";
+import { resolveLocalGuardianPrincipalId } from "./pair.js";
+
+const WEB_REMOTE_INGRESS_FLAG = "web-remote-ingress";
+const MAX_EXCHANGE_BODY_BYTES = 512;
+const QR_PAIRING_INTERFACE = "qr";
+const log = getLogger("pair-qr-exchange");
+
+function jsonError(code: string, message: string, status: number): Response {
+  return Response.json(
+    { error: { code, message } },
+    { status, headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+function rateLimitedResponse(rateLimit: QrPairingExchangeRateLimit): Response {
+  return Response.json(
+    {
+      error: { code: "RATE_LIMITED", message: "too many QR pairing attempts" },
+    },
+    {
+      status: 429,
+      headers: {
+        "Retry-After": String(rateLimit.retryAfterSeconds),
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}
+
+/** Uniform failure for every invalid / expired / already-burned code. */
+function invalidCodeResponse(): Response {
+  return jsonError(
+    "INVALID_OR_EXPIRED_QR_CODE",
+    "invalid or expired pairing code",
+    401,
+  );
+}
+
+export async function handleQrPairingExchange(
+  req: Request,
+  clientIp: string,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("method not allowed", {
+      status: 405,
+      headers: { Allow: "POST" },
+    });
+  }
+
+  // Fail closed and invisible when remote web ingress is not enabled: the host
+  // has not opted into any browser/QR pairing surface.
+  if (!isFeatureFlagEnabled(WEB_REMOTE_INGRESS_FLAG)) {
+    return jsonError("NOT_FOUND", "not found", 404);
+  }
+
+  const rateLimited = checkQrPairingExchangeRateLimit(clientIp);
+  if (rateLimited) return rateLimitedResponse(rateLimited);
+
+  const rawBody = await readLimitedBody(req, MAX_EXCHANGE_BODY_BYTES);
+  if (rawBody.status === "too_large") {
+    return jsonError("PAYLOAD_TOO_LARGE", "request body too large", 413);
+  }
+  if (rawBody.status === "unreadable") {
+    return jsonError("BAD_REQUEST", "failed to read request body", 400);
+  }
+
+  let code: string | null = null;
+  let deviceId: string | null = null;
+  try {
+    const body = JSON.parse(rawBody.text) as {
+      code?: unknown;
+      deviceId?: unknown;
+    };
+    code =
+      typeof body.code === "string" && body.code.trim()
+        ? body.code.trim()
+        : null;
+    deviceId =
+      typeof body.deviceId === "string" && body.deviceId.trim()
+        ? body.deviceId.trim()
+        : null;
+  } catch {
+    return jsonError("BAD_REQUEST", "invalid JSON body", 400);
+  }
+
+  if (!code || !deviceId) {
+    return jsonError("BAD_REQUEST", "code and deviceId are required", 400);
+  }
+
+  // Atomic single-use burn happens before any token is minted, so a concurrent
+  // second exchange of the same code loses the race and fails here.
+  const claim = claimQrPairingCode(code);
+  if (claim.status !== "ok") {
+    return invalidCodeResponse();
+  }
+
+  const guardianPrincipalId = await resolveLocalGuardianPrincipalId();
+  const assistantId = getExternalAssistantId();
+
+  log.info(
+    { guardianPrincipalId },
+    "QR pairing code exchanged for device-bound tokens",
+  );
+
+  return mintDeviceBoundPairResponse({
+    guardianPrincipalId,
+    assistantId,
+    deviceId,
+    platform: QR_PAIRING_INTERFACE,
+    interfaceId: QR_PAIRING_INTERFACE,
+    clientId: null,
+  });
+}

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -29,7 +29,6 @@
 
 import { and, eq } from "drizzle-orm";
 
-import { mintAndRecordDeviceBoundTokenPair } from "../../auth/guardian-bootstrap.js";
 import { CURRENT_POLICY_EPOCH } from "../../auth/policy.js";
 import { mintToken } from "../../auth/token-service.js";
 import { KNOWN_EXTENSION_ORIGINS } from "../../chrome-extension-origins.js";
@@ -39,6 +38,7 @@ import {
   contactChannels as gwContactChannels,
 } from "../../db/schema.js";
 import { getLogger } from "../../logger.js";
+import { mintDeviceBoundPairResponse } from "../device-bound-pair-response.js";
 import { enforceLoopbackOnly, errorResponse } from "../loopback-guard.js";
 
 const log = getLogger("pair");
@@ -350,53 +350,4 @@ export async function handlePair(
     `unsupported interface: '${interfaceId}'`,
     400,
   );
-}
-
-/**
- * Mint a device-bound, recorded, per-device-revocable credential and build the
- * pair response. Shared by the chrome-extension (deviceId) and cli pairing
- * paths.
- *
- * Issues the standard access + long-lived device-scoped refresh token pair, so
- * a paired client renews via `/v1/guardian/refresh` instead of re-pairing.
- * Both are revocable per device on the hot path (actor-token revocation is
- * enforced on live requests), and the refresh endpoint rejects revoked/rotated
- * tokens — so revocation, not a short TTL, bounds a leaked token's reach. The
- * access TTL matches what `/v1/guardian/refresh` mints on rotation, so it stays
- * consistent across the token's life (rather than 24h at mint then 30d after
- * the first refresh).
- */
-function mintDeviceBoundPairResponse(opts: {
-  guardianPrincipalId: string;
-  assistantId: string;
-  deviceId: string;
-  platform: string;
-  interfaceId: string;
-  clientId: string | null;
-}): Response {
-  const pair = mintAndRecordDeviceBoundTokenPair({
-    guardianPrincipalId: opts.guardianPrincipalId,
-    deviceId: opts.deviceId,
-    platform: opts.platform,
-  });
-
-  log.info(
-    {
-      interfaceId: opts.interfaceId,
-      clientId: opts.clientId,
-      guardianPrincipalId: opts.guardianPrincipalId,
-      platform: opts.platform,
-    },
-    "Client paired successfully via loopback (device-bound)",
-  );
-
-  return Response.json({
-    token: pair.accessToken,
-    expiresAt: new Date(pair.accessTokenExpiresAt).toISOString(),
-    refreshToken: pair.refreshToken,
-    refreshTokenExpiresAt: new Date(pair.refreshTokenExpiresAt).toISOString(),
-    refreshAfter: new Date(pair.refreshAfter).toISOString(),
-    guardianId: opts.guardianPrincipalId,
-    assistantId: opts.assistantId,
-  });
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -91,6 +91,8 @@ import {
   handleRevokeDevice,
 } from "./http/routes/devices.js";
 import { handlePair } from "./http/routes/pair.js";
+import { handleMintQrPairingCode } from "./http/routes/pair-qr-code.js";
+import { handleQrPairingExchange } from "./http/routes/pair-qr-exchange.js";
 import { handleCredentialEntryPage } from "./http/routes/credential-entry-page.js";
 import {
   handleCredentialRequestPeek,
@@ -840,6 +842,25 @@ async function main() {
       method: "POST",
       auth: "none",
       handler: (req, _params, getClientIp) => handlePair(req, getClientIp()),
+    },
+    // Loopback-only mint of a single-use QR pairing code (self-guards loopback;
+    // the nginx edge also 404s this path).
+    {
+      path: "/v1/pair/qr-code",
+      method: "POST",
+      auth: "none",
+      handler: (req, _params, getClientIp) =>
+        handleMintQrPairingCode(req, getClientIp()),
+    },
+    // Public exchange of a QR pairing code for device-bound tokens. Reachable
+    // over the tunnel (flag-gated behind web-remote-ingress); the code is the
+    // credential.
+    {
+      path: "/v1/pair/qr-exchange",
+      method: "POST",
+      auth: "none",
+      handler: (req, _params, getClientIp) =>
+        handleQrPairingExchange(req, getClientIp()),
     },
     {
       path: "/v1/remote-web/pairing-challenge",

--- a/gateway/src/remote-web/qr-pairing-code-store.ts
+++ b/gateway/src/remote-web/qr-pairing-code-store.ts
@@ -1,0 +1,139 @@
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * In-memory store for host-minted QR pairing codes.
+ *
+ * The host machine mints a single-use, short-lived code (rendered as a QR by
+ * the CLI); a phone that scans it presents the code to the public exchange
+ * route for device-bound tokens. Possession of the code is the proof that the
+ * presenter physically saw the host's screen, so a code is:
+ *
+ *   - **High-entropy**: 256 random bits, URL-safe base64 (rides a `#code=` URL
+ *     fragment), so it cannot be guessed within its lifetime.
+ *   - **Short-lived**: ~5 minutes, bounding the window a leaked QR is usable.
+ *   - **Single-use**: burned atomically on the first successful exchange.
+ *
+ * Only the SHA-256 hash of a code is retained, so a memory dump never reveals a
+ * live code. Mirrors the remote-web pairing-challenge store's persistence
+ * choice (in-memory) and expiry handling.
+ */
+
+/** QR pairing codes are valid for 5 minutes. */
+const CODE_TTL_MS = 5 * 60 * 1000;
+
+/** Cap on concurrently-active codes, bounding memory from a runaway minter. */
+const MAX_ACTIVE_CODES = 200;
+
+/** 32 bytes = 256 bits of entropy. */
+const CODE_BYTES = 32;
+
+interface PendingQrPairingCode {
+  expiresAtMs: number;
+}
+
+export interface CreatedQrPairingCode {
+  code: string;
+  expiresAt: string;
+  expiresInSeconds: number;
+}
+
+export interface QrPairingCodeCapacityLimit {
+  retryAfterSeconds: number;
+}
+
+export type ClaimQrPairingCodeResult = { status: "ok" } | { status: "invalid" };
+
+const codesByHash = new Map<string, PendingQrPairingCode>();
+let nowForTests: (() => number) | null = null;
+
+function nowMs(): number {
+  return nowForTests?.() ?? Date.now();
+}
+
+function hashCode(code: string): string {
+  return createHash("sha256").update(code).digest("hex");
+}
+
+function cleanupExpiredCodes(now = nowMs()): void {
+  for (const [hash, code] of codesByHash) {
+    if (code.expiresAtMs <= now) {
+      codesByHash.delete(hash);
+    }
+  }
+}
+
+/**
+ * Capacity guard for the loopback mint route: returns a retry hint when the
+ * store is full (after evicting expired codes), or null when there is room.
+ */
+export function checkQrPairingCodeCapacity(): QrPairingCodeCapacityLimit | null {
+  const now = nowMs();
+  cleanupExpiredCodes(now);
+
+  if (codesByHash.size < MAX_ACTIVE_CODES) return null;
+
+  let earliestExpiresAtMs = Number.POSITIVE_INFINITY;
+  for (const code of codesByHash.values()) {
+    earliestExpiresAtMs = Math.min(earliestExpiresAtMs, code.expiresAtMs);
+  }
+
+  return {
+    retryAfterSeconds: Math.max(
+      1,
+      Math.ceil((earliestExpiresAtMs - now) / 1000),
+    ),
+  };
+}
+
+export function createQrPairingCode(): CreatedQrPairingCode {
+  cleanupExpiredCodes();
+
+  let code = randomBytes(CODE_BYTES).toString("base64url");
+  let codeHash = hashCode(code);
+  while (codesByHash.has(codeHash)) {
+    code = randomBytes(CODE_BYTES).toString("base64url");
+    codeHash = hashCode(code);
+  }
+
+  const expiresAtMs = nowMs() + CODE_TTL_MS;
+  codesByHash.set(codeHash, { expiresAtMs });
+
+  return {
+    code,
+    expiresAt: new Date(expiresAtMs).toISOString(),
+    expiresInSeconds: Math.ceil(CODE_TTL_MS / 1000),
+  };
+}
+
+/**
+ * Atomically burn a QR pairing code.
+ *
+ * A matched code is deleted before this returns, so a concurrent second claim
+ * of the same code finds nothing and fails — the exchange is single-use. Every
+ * non-`ok` case (missing, expired, already burned) reports the same "invalid"
+ * so the caller can return one uniform error and never reveal which codes exist.
+ */
+export function claimQrPairingCode(code: string): ClaimQrPairingCodeResult {
+  const codeHash = hashCode(code);
+  const pending = codesByHash.get(codeHash);
+  if (!pending) return { status: "invalid" };
+
+  // Burn on any terminal outcome: a matched code is spent even when expired.
+  codesByHash.delete(codeHash);
+
+  if (pending.expiresAtMs <= nowMs()) return { status: "invalid" };
+  return { status: "ok" };
+}
+
+export function resetQrPairingCodesForTests(): void {
+  codesByHash.clear();
+  nowForTests = null;
+}
+
+export function setQrPairingCodeNowForTests(now: () => number): void {
+  nowForTests = now;
+}
+
+export function getQrPairingCodeCountForTests(): number {
+  return codesByHash.size;
+}

--- a/gateway/src/remote-web/qr-pairing-exchange-rate-limit-store.ts
+++ b/gateway/src/remote-web/qr-pairing-exchange-rate-limit-store.ts
@@ -1,0 +1,60 @@
+/**
+ * Per-IP request rate limiter for the public QR pairing exchange route.
+ *
+ * The exchange endpoint is internet-facing, so it is capped per client IP as
+ * defence-in-depth against request floods. It counts every attempt (not only
+ * failures) so it never distinguishes a valid code from an invalid one via its
+ * rate-limit behaviour — the code's 256-bit entropy is what makes guessing
+ * infeasible; this bound just protects the endpoint from abuse.
+ *
+ * Note: the self-hosted nginx edge does not forward a client IP (it strips
+ * `X-Forwarded-For`, which the loopback guards reject), so edge-tunnelled
+ * callers share the loopback peer IP and this acts as a global bound for
+ * tunnelled traffic. That is acceptable for a single-user self-hosted assistant
+ * whose legitimate pairing volume is tiny.
+ */
+
+const RATE_LIMIT_MAX_REQUESTS = 10;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+interface RateLimitEntry {
+  timestamps: number[];
+}
+
+export interface QrPairingExchangeRateLimit {
+  retryAfterSeconds: number;
+}
+
+const requestsByIp = new Map<string, RateLimitEntry>();
+
+/**
+ * Record an exchange attempt for `clientIp` and return a retry hint when the
+ * per-IP window is already full, or null when the attempt is within budget.
+ */
+export function checkQrPairingExchangeRateLimit(
+  clientIp: string,
+): QrPairingExchangeRateLimit | null {
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+
+  let entry = requestsByIp.get(clientIp);
+  if (!entry) {
+    entry = { timestamps: [] };
+    requestsByIp.set(clientIp, entry);
+  }
+  entry.timestamps = entry.timestamps.filter((t) => t > windowStart);
+
+  if (entry.timestamps.length >= RATE_LIMIT_MAX_REQUESTS) {
+    const resetAtMs = entry.timestamps[0] + RATE_LIMIT_WINDOW_MS;
+    return {
+      retryAfterSeconds: Math.max(1, Math.ceil((resetAtMs - now) / 1000)),
+    };
+  }
+
+  entry.timestamps.push(now);
+  return null;
+}
+
+export function resetQrPairingExchangeRateLimiterForTests(): void {
+  requestsByIp.clear();
+}


### PR DESCRIPTION
## Summary
- Loopback-only mint of single-use ~5-min QR pairing codes (host-side); rendered as a QR by the CLI in a later PR
- Public flag-gated exchange route burning a code for device-bound access+refresh tokens (reuses existing mint machinery)
- nginx edge allowlists only the exchange route; all other pairing endpoints stay blocked

## How it works
The host mints a code at `POST /v1/pair/qr-code` (loopback-only). A phone presents `{code, deviceId}` to `POST /v1/pair/qr-exchange` (public, over the tunnel) and receives the same device-bound token pair as `/v1/pair`. Trust model: possession of the code proves physical presence at the host. This flips the direction of the existing remote-web device-code flow (where the browser shows a code and the host approves).

## Security (auth-boundary change — please focus review here)
- **Entropy**: codes are 256 random bits, URL-safe base64 (rides a `#code=` fragment) — infeasible to guess within the 5-min TTL.
- **Atomic single-use burn**: `claimQrPairingCode` deletes the code synchronously before any token is minted, so a concurrent second exchange loses the race and fails (covered by a concurrent-exchange test).
- **Flag gate**: the exchange route is gated behind the existing `web-remote-ingress` flag; disabled → 404 (invisible). No new Terraform flag required.
- **No existence leak**: every invalid / expired / already-burned code returns the same 401.
- **Rate limit**: strict per-IP request cap on the exchange route as flood defence-in-depth.
- **Edge behavior**: the mint route is loopback-only (`enforceLoopbackOnly` rejects edge-forwarded requests + browser Origin) AND 404-ed at the nginx edge; the exchange route is the ONLY new pairing path reachable over the tunnel (falls through to `^~ /v1/`). Guard tests updated: `remote-web-ingress-denylist.test.ts`, `nginx-ingress.test.ts`.

## Token machinery reuse
Extracts the device-bound pair response builder from `pair.ts` into `http/device-bound-pair-response.ts`, now shared by `/v1/pair` (chrome-extension + cli) and the QR exchange — no new token-minting logic.

## Tests
New `pair-qr-code.test.ts` (loopback enforcement incl. edge-forwarded + browser-Origin rejection) and `pair-qr-exchange.test.ts` (flag-off 404, happy-path token pair, single-use + concurrent burn, TTL expiry, uniform invalid, validation, per-IP rate limit). Updated edge guard tests. gateway + cli typecheck clean.

Part of plan: ios-self-hosted-connect.md (PR 1 of 4)