### PR TITLE
feat(web): make Vellum a web search provider instead of a mode

### DIFF
--- a/clients/web/src/assistant/generated/web-search-provider-catalog.gen.ts
+++ b/clients/web/src/assistant/generated/web-search-provider-catalog.gen.ts
@@ -3,6 +3,7 @@
 
 /** Ordered list of provider ids — drives the picker option order. */
 export const WEB_SEARCH_PROVIDER_IDS: readonly string[] = [
+  "vellum",
   "inference-provider-native",
   "perplexity",
   "brave",
@@ -14,6 +15,7 @@ export const WEB_SEARCH_PROVIDER_IDS: readonly string[] = [
 export const WEB_SEARCH_PROVIDER_DISPLAY_NAMES: Readonly<
   Record<string, string>
 > = {
+  vellum: "Vellum",
   "inference-provider-native": "Provider Native",
   perplexity: "Perplexity",
   brave: "Brave",

--- a/clients/web/src/domains/settings/ai/web-search-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/web-search-card.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * Tests for `WebSearchCard`'s provider-only configuration (the Managed /
+ * Your Own mode toggle is gone — Vellum is a provider like any other):
+ *
+ *   1. No mode segmented-control renders in the card header.
+ *   2. Vellum is selectable, needs no API key, and saves as a
+ *      provider+mode pair for old-daemon compatibility.
+ *   3. BYOK providers still gate Save on a credential.
+ *   4. Legacy managed-mode daemon configs render as Vellum — except
+ *      Provider Native, which stays itself (mirrors migration 132).
+ *
+ * The design-library Dropdown is real, driven via its combobox trigger like
+ * `speech-to-text-card.test.tsx`.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+const ASSISTANT_ID = "asst-test";
+mock.module("@/assistant/use-active-assistant-id", () => ({
+  useActiveAssistantId: () => ASSISTANT_ID,
+}));
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { success: () => {}, error: () => {} },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+// Controllable daemon config the config-get query resolves to; `initialData`
+// makes it available synchronously like a warm cache.
+let daemonConfigData: { services: Record<string, unknown> } = { services: {} };
+interface SdkCall {
+  path?: unknown;
+  body?: unknown;
+}
+const configPatchCalls: SdkCall[] = [];
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  configGetOptions: () => ({
+    queryKey: ["config-get-test"],
+    queryFn: () => Promise.resolve(daemonConfigData),
+    initialData: daemonConfigData,
+  }),
+  configGetSetQueryData: () => {},
+  useConfigPatchMutation: () => ({
+    mutateAsync: (opts: SdkCall) => {
+      configPatchCalls.push(opts);
+      return Promise.resolve(daemonConfigData);
+    },
+  }),
+}));
+
+const provisionedKeys: Array<{ provider: string; key: string }> = [];
+mock.module("@/domains/settings/ai/use-daemon-config", () => ({
+  useProvisionProviderKey: () => (provider: string, key: string) => {
+    provisionedKeys.push({ provider, key });
+    return Promise.resolve();
+  },
+}));
+
+let hasStoredCredential = false;
+mock.module("@/domains/settings/ai/use-stored-credential-presence", () => ({
+  useStoredCredentialPresence: () => ({ hasStoredCredential }),
+  credentialPresenceQueryKey: (...parts: unknown[]) => [
+    "credential-presence-test",
+    ...parts,
+  ],
+}));
+
+const { WebSearchCard } = await import(
+  "@/domains/settings/ai/web-search-card"
+);
+const { LS_WEB_SEARCH_PROVIDER } = await import(
+  "@/utils/local-settings-keys"
+);
+
+function renderCard() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <WebSearchCard />
+    </QueryClientProvider>,
+  );
+}
+
+function providerTrigger(): HTMLButtonElement {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    'button[role="combobox"][aria-label="Web search provider"]',
+  );
+  if (!trigger) {
+    throw new Error("expected the web search provider dropdown trigger");
+  }
+  return trigger;
+}
+
+function visibleOptions(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).map((o) => o.textContent?.trim() ?? "");
+}
+
+/** Click an option in the already-open listbox (the trigger toggles). */
+function selectOption(label: string): void {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim() === label);
+  if (!option) {
+    throw new Error(
+      `expected option "${label}" — saw: ${visibleOptions().join(", ")}`,
+    );
+  }
+  fireEvent.click(option);
+}
+
+describe("WebSearchCard — provider-only configuration", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    configPatchCalls.length = 0;
+    provisionedKeys.length = 0;
+    hasStoredCredential = false;
+    daemonConfigData = { services: {} };
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  test("no Managed / Your Own mode toggle renders", () => {
+    renderCard();
+
+    expect(screen.queryByText("Managed")).toBeNull();
+    expect(screen.queryByText("Your Own")).toBeNull();
+    // The provider dropdown renders unconditionally instead.
+    expect(providerTrigger()).toBeTruthy();
+  });
+
+  test("Vellum and Provider Native are offered alongside the BYOK providers", () => {
+    renderCard();
+
+    fireEvent.click(providerTrigger());
+    const options = visibleOptions();
+    expect(options).toEqual([
+      "Vellum",
+      "Provider Native",
+      "Perplexity",
+      "Brave",
+      "Tavily",
+      "Firecrawl",
+    ]);
+  });
+
+  test("selecting Vellum hides the API key field and saves the provider+mode pair", async () => {
+    renderCard();
+
+    fireEvent.click(providerTrigger());
+    selectOption("Vellum");
+
+    expect(screen.queryByText("API Key")).toBeNull();
+    expect(
+      screen.getByText(/Search runs through your Vellum account/),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    // Written as a pair so the save stays valid on daemons whose schema
+    // still couples provider "vellum" to mode "managed".
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: {
+        "web-search": { provider: "vellum", mode: "managed" },
+      },
+    });
+    expect(provisionedKeys).toHaveLength(0);
+    expect(localStorage.getItem(LS_WEB_SEARCH_PROVIDER)).toBe("vellum");
+  });
+
+  test("Provider Native needs no key and saves with mode your-own", async () => {
+    // Start from a non-default provider so Save enables on the change.
+    daemonConfigData = {
+      services: { "web-search": { provider: "brave", mode: "your-own" } },
+    };
+    renderCard();
+
+    fireEvent.click(providerTrigger());
+    selectOption("Provider Native");
+
+    expect(screen.queryByText("API Key")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: {
+        "web-search": {
+          provider: "inference-provider-native",
+          mode: "your-own",
+        },
+      },
+    });
+    expect(provisionedKeys).toHaveLength(0);
+  });
+
+  test("a BYOK provider gates Save on a key, then saves provider, mode and key", async () => {
+    renderCard();
+
+    fireEvent.click(providerTrigger());
+    selectOption("Firecrawl");
+
+    // No stored credential and no typed key: Save must stay disabled.
+    const saveButton = screen.getByRole("button", {
+      name: "Save",
+    }) as HTMLButtonElement;
+    expect(saveButton.disabled).toBe(true);
+
+    const keyInput = screen.getByPlaceholderText("fc-...");
+    fireEvent.change(keyInput, { target: { value: "fc-secret" } });
+    expect(saveButton.disabled).toBe(false);
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(provisionedKeys).toEqual([
+      { provider: "firecrawl", key: "fc-secret" },
+    ]);
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: {
+        "web-search": { provider: "firecrawl", mode: "your-own" },
+      },
+    });
+  });
+
+  // A config written by the legacy mode toggle marks managed via `mode`
+  // while `provider` holds the BYOK restore value.
+  test("a legacy managed-mode daemon renders as Vellum", () => {
+    daemonConfigData = {
+      services: { "web-search": { mode: "managed", provider: "brave" } },
+    };
+    renderCard();
+
+    expect(providerTrigger().textContent).toContain("Vellum");
+    expect(screen.queryByText("API Key")).toBeNull();
+  });
+
+  test("a legacy managed-mode Provider Native daemon stays Provider Native", () => {
+    // The platform default config: managed mode never meant "Vellum search"
+    // for Provider Native — migration 132 preserves it, so must the card.
+    daemonConfigData = {
+      services: {
+        "web-search": {
+          mode: "managed",
+          provider: "inference-provider-native",
+        },
+      },
+    };
+    renderCard();
+
+    expect(providerTrigger().textContent).toContain("Provider Native");
+    expect(providerTrigger().textContent).not.toContain("Vellum");
+  });
+
+  test("escaping a legacy managed-mode daemon resets mode alongside the provider", async () => {
+    // Without the mode reset, the stale `mode: "managed"` would win over the
+    // BYOK provider choice and the user would silently stay on Vellum.
+    daemonConfigData = {
+      services: { "web-search": { mode: "managed", provider: "brave" } },
+    };
+    hasStoredCredential = true;
+    renderCard();
+
+    fireEvent.click(providerTrigger());
+    selectOption("Brave");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: {
+        "web-search": { provider: "brave", mode: "your-own" },
+      },
+    });
+  });
+});

--- a/clients/web/src/domains/settings/ai/web-search-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/web-search-card.test.tsx
@@ -72,12 +72,26 @@ mock.module("@/domains/settings/ai/use-stored-credential-presence", () => ({
   ],
 }));
 
-const { WebSearchCard } = await import(
-  "@/domains/settings/ai/web-search-card"
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => false,
+}));
+
+// Version gate for `provider: "vellum"` — supported by default; the
+// old-daemon test flips it off.
+let daemonSupportsVellumProvider = true;
+mock.module(
+  "@/lib/backwards-compat/use-supports-web-search-vellum-provider",
+  () => ({
+    MIN_VERSION: "0.10.12",
+    supportsWebSearchVellumProvider: () => daemonSupportsVellumProvider,
+  }),
 );
-const { LS_WEB_SEARCH_PROVIDER } = await import(
-  "@/utils/local-settings-keys"
-);
+mock.module("@/lib/backwards-compat/utils", () => ({
+  whenAssistantVersionKnown: () => Promise.resolve(),
+}));
+
+const { WebSearchCard } = await import("@/domains/settings/ai/web-search-card");
+const { LS_WEB_SEARCH_PROVIDER } = await import("@/utils/local-settings-keys");
 
 function renderCard() {
   const queryClient = new QueryClient({
@@ -125,6 +139,7 @@ describe("WebSearchCard — provider-only configuration", () => {
     configPatchCalls.length = 0;
     provisionedKeys.length = 0;
     hasStoredCredential = false;
+    daemonSupportsVellumProvider = true;
     daemonConfigData = { services: {} };
   });
 
@@ -235,6 +250,25 @@ describe("WebSearchCard — provider-only configuration", () => {
         "web-search": { provider: "firecrawl", mode: "your-own" },
       },
     });
+  });
+
+  test("a daemon predating the vellum provider gets the legacy managed write", async () => {
+    // Old daemon schemas reject provider "vellum" outright; the Vellum
+    // selection must degrade to the legacy Managed representation — mode
+    // only, letting the deep-merge keep the stored provider so the read
+    // bridge renders the pair as Vellum again.
+    daemonSupportsVellumProvider = false;
+    renderCard();
+
+    fireEvent.click(providerTrigger());
+    selectOption("Vellum");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    const body = configPatchCalls[0]!.body as {
+      services: { "web-search": Record<string, unknown> };
+    };
+    expect(body.services["web-search"]).toEqual({ mode: "managed" });
   });
 
   // A config written by the legacy mode toggle marks managed via `mode`

--- a/clients/web/src/domains/settings/ai/web-search-card.tsx
+++ b/clients/web/src/domains/settings/ai/web-search-card.tsx
@@ -135,7 +135,10 @@ export function WebSearchCard() {
       // writes only the legacy managed mode and lets the deep-merge keep the
       // stored provider — the read bridge renders that pair as Vellum again.
       await whenAssistantVersionKnown();
-      const webSearchService: { provider?: string; mode: string } =
+      const webSearchService: {
+        provider?: string;
+        mode: "managed" | "your-own";
+      } =
         webSearchProvider === "vellum"
           ? supportsWebSearchVellumProvider()
             ? { provider: "vellum", mode: "managed" }

--- a/clients/web/src/domains/settings/ai/web-search-card.tsx
+++ b/clients/web/src/domains/settings/ai/web-search-card.tsx
@@ -2,51 +2,62 @@ import { Loader2 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
 import {
-    WEB_SEARCH_BYOK_PROVIDER_IDS,
-    WEB_SEARCH_PROVIDER_DISPLAY_NAMES,
-    WEB_SEARCH_PROVIDER_IDS,
-    WEB_SEARCH_PROVIDER_KEY_PLACEHOLDERS,
+  WEB_SEARCH_BYOK_PROVIDER_IDS,
+  WEB_SEARCH_PROVIDER_DISPLAY_NAMES,
+  WEB_SEARCH_PROVIDER_IDS,
+  WEB_SEARCH_PROVIDER_KEY_PLACEHOLDERS,
 } from "@/assistant/generated/web-search-provider-catalog.gen";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
 import { captureError } from "@/lib/sentry/capture-error";
 import {
-    getLocalSetting,
-    removeLocalSetting,
-    setLocalSetting,
+  getLocalSetting,
+  removeLocalSetting,
+  setLocalSetting,
 } from "@/utils/local-settings";
 import { useQueryClient } from "@tanstack/react-query";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
-import {
-  ByoServiceCard,
-} from "@/domains/settings/ai/shared-ui";
-import {
-  ResetButton,
-  SaveButton,
-} from "@/components/service-form-controls";
+import { ByoServiceCard } from "@/domains/settings/ai/shared-ui";
+import { ResetButton, SaveButton } from "@/components/service-form-controls";
 import { LS_WEB_SEARCH_PROVIDER } from "@/utils/local-settings-keys";
 import { getWebSearchProviderKeyStorage } from "@/domains/settings/ai/utils";
 import { useProvisionProviderKey } from "@/domains/settings/ai/use-daemon-config";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
-import { configGetOptions, configGetSetQueryData, useConfigPatchMutation } from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+  configGetOptions,
+  configGetSetQueryData,
+  useConfigPatchMutation,
+} from "@/generated/daemon/@tanstack/react-query.gen";
 import { useQuery } from "@tanstack/react-query";
 import { useDraftOverride } from "@/hooks/use-draft-override";
-import { credentialPresenceQueryKey, useStoredCredentialPresence } from "@/domains/settings/ai/use-stored-credential-presence";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import {
+  credentialPresenceQueryKey,
+  useStoredCredentialPresence,
+} from "@/domains/settings/ai/use-stored-credential-presence";
+import { supportsWebSearchVellumProvider } from "@/lib/backwards-compat/use-supports-web-search-vellum-provider";
+import { whenAssistantVersionKnown } from "@/lib/backwards-compat/utils";
 
 export function WebSearchCard() {
   const assistantId = useActiveAssistantId();
   const queryClient = useQueryClient();
+  const isOrgReady = useIsOrgReady();
 
   const { data: daemonConfig } = useQuery({
     ...configGetOptions({ path: { assistant_id: assistantId } }),
+    enabled: isOrgReady,
     staleTime: 30_000,
   });
 
   const configMutation = useConfigPatchMutation({
     onSuccess: (data) => {
-      configGetSetQueryData(queryClient, { path: { assistant_id: assistantId } }, data);
+      configGetSetQueryData(
+        queryClient,
+        { path: { assistant_id: assistantId } },
+        data,
+      );
     },
   });
   const provisionProviderKey = useProvisionProviderKey();
@@ -56,11 +67,13 @@ export function WebSearchCard() {
   // automatically.
   const serverWebSearchProvider = useMemo((): string => {
     if (!daemonConfig) {
-      return getLocalSetting(LS_WEB_SEARCH_PROVIDER, "inference-provider-native");
+      return getLocalSetting(
+        LS_WEB_SEARCH_PROVIDER,
+        "inference-provider-native",
+      );
     }
     const wsService = daemonConfig.services?.["web-search"] as
-      | { provider?: string; mode?: string }
-      | undefined;
+      { provider?: string; mode?: string } | undefined;
     // A config written by the legacy mode toggle marks managed via `mode`
     // while `provider` holds the BYOK restore value — the daemon routes it to
     // Vellum, so the card must render it as Vellum too. Provider Native is
@@ -70,15 +83,21 @@ export function WebSearchCard() {
       wsService?.provider !== "inference-provider-native"
         ? "vellum"
         : wsService?.provider;
-    return daemonProvider || getLocalSetting(LS_WEB_SEARCH_PROVIDER, "inference-provider-native");
+    return (
+      daemonProvider ||
+      getLocalSetting(LS_WEB_SEARCH_PROVIDER, "inference-provider-native")
+    );
   }, [daemonConfig]);
 
   const [saving, setSaving] = useState(false);
-  const [webSearchProvider, setDraftWebSearchProvider] = useDraftOverride(serverWebSearchProvider);
+  const [webSearchProvider, setDraftWebSearchProvider] = useDraftOverride(
+    serverWebSearchProvider,
+  );
 
   const [webSearchApiKey, setWebSearchApiKey] = useState("");
 
-  const requiresProviderCredential = WEB_SEARCH_BYOK_PROVIDER_IDS.has(webSearchProvider);
+  const requiresProviderCredential =
+    WEB_SEARCH_BYOK_PROVIDER_IDS.has(webSearchProvider);
   const { hasStoredCredential: webSearchHasStoredKey } =
     useStoredCredentialPresence({
       assistantId,
@@ -91,13 +110,12 @@ export function WebSearchCard() {
   const hasNewApiKey = webSearchApiKey.trim().length > 0;
   const configChanged = webSearchProvider !== serverWebSearchProvider;
   const needsKeyBeforeSave =
-    requiresProviderCredential &&
-    !webSearchHasStoredKey &&
-    !hasNewApiKey;
+    requiresProviderCredential && !webSearchHasStoredKey && !hasNewApiKey;
   const saveDisabled =
     saving || needsKeyBeforeSave || (!configChanged && !hasNewApiKey);
   const apiKeyPlaceholder = secretPlaceholder(
-    WEB_SEARCH_PROVIDER_KEY_PLACEHOLDERS[webSearchProvider] ?? "Enter your API key",
+    WEB_SEARCH_PROVIDER_KEY_PLACEHOLDERS[webSearchProvider] ??
+      "Enter your API key",
     webSearchHasStoredKey,
   );
 
@@ -110,25 +128,35 @@ export function WebSearchCard() {
       if (hasUserKey) {
         await provisionProviderKey(webSearchProvider, trimmed);
       }
-      await configMutation.mutateAsync({
-        path: { assistant_id: assistantId },
-        body: {
-          services: {
-            // The provider is written as a pair with `mode`: older daemon
-            // schemas reject provider "vellum" without mode "managed", and a
-            // stale `mode: "managed"` from the legacy toggle would win over a
-            // BYOK choice unless reset.
-            "web-search": {
-              provider: webSearchProvider,
-              mode: webSearchProvider === "vellum" ? "managed" : "your-own",
+      // The provider is written as a pair with `mode`: a stale
+      // `mode: "managed"` from the legacy toggle would win over a BYOK
+      // choice unless reset. Daemons older than the vellum catalog entry
+      // reject the provider value outright, so for them a Vellum selection
+      // writes only the legacy managed mode and lets the deep-merge keep the
+      // stored provider — the read bridge renders that pair as Vellum again.
+      await whenAssistantVersionKnown();
+      const webSearchService: { provider?: string; mode: string } =
+        webSearchProvider === "vellum"
+          ? supportsWebSearchVellumProvider()
+            ? { provider: "vellum", mode: "managed" }
+            : { mode: "managed" }
+          : { provider: webSearchProvider, mode: "your-own" };
+      await configMutation
+        .mutateAsync({
+          path: { assistant_id: assistantId },
+          body: {
+            services: {
+              "web-search": webSearchService,
             },
           },
-        },
-      }).catch((error) => {
-        toast.error("Failed to update assistant configuration. Please try again.");
-        captureError(error, { context: "patch_daemon_config" });
-        throw error;
-      });
+        })
+        .catch((error) => {
+          toast.error(
+            "Failed to update assistant configuration. Please try again.",
+          );
+          captureError(error, { context: "patch_daemon_config" });
+          throw error;
+        });
     } catch {
       setSaving(false);
       return;
@@ -216,7 +244,9 @@ export function WebSearchCard() {
 
         <div className="flex items-center gap-2">
           <SaveButton onClick={handleSave} disabled={saveDisabled} />
-          {saving && <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />}
+          {saving && (
+            <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />
+          )}
           {requiresProviderCredential && (
             <ResetButton onClick={handleReset} filled />
           )}

--- a/clients/web/src/domains/settings/ai/web-search-card.tsx
+++ b/clients/web/src/domains/settings/ai/web-search-card.tsx
@@ -20,15 +20,14 @@ import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import {
-  ServiceCard,
+  ByoServiceCard,
 } from "@/domains/settings/ai/shared-ui";
 import {
   ResetButton,
   SaveButton,
 } from "@/components/service-form-controls";
-import { LS_WEB_SEARCH_MODE, LS_WEB_SEARCH_PROVIDER } from "@/utils/local-settings-keys";
-import { getWebSearchProviderKeyStorage, parseServiceMode } from "@/domains/settings/ai/utils";
-import type { ServiceMode } from "@/generated/daemon/types.gen";
+import { LS_WEB_SEARCH_PROVIDER } from "@/utils/local-settings-keys";
+import { getWebSearchProviderKeyStorage } from "@/domains/settings/ai/utils";
 import { useProvisionProviderKey } from "@/domains/settings/ai/use-daemon-config";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { configGetOptions, configGetSetQueryData, useConfigPatchMutation } from "@/generated/daemon/@tanstack/react-query.gen";
@@ -52,31 +51,29 @@ export function WebSearchCard() {
   });
   const provisionProviderKey = useProvisionProviderKey();
 
-  // Server values derived from daemon config, falling back to localStorage.
-  // When the cache refreshes (after save + invalidation), these update
+  // Server value derived from daemon config, falling back to localStorage.
+  // When the cache refreshes (after save + invalidation), this updates
   // automatically.
-  const { serverWebSearchMode, serverWebSearchProvider } = useMemo((): {
-    serverWebSearchMode: ServiceMode;
-    serverWebSearchProvider: string;
-  } => {
+  const serverWebSearchProvider = useMemo((): string => {
     if (!daemonConfig) {
-      return {
-        serverWebSearchMode: parseServiceMode(getLocalSetting(LS_WEB_SEARCH_MODE, "your-own"), "your-own"),
-        serverWebSearchProvider: getLocalSetting(LS_WEB_SEARCH_PROVIDER, "inference-provider-native"),
-      };
+      return getLocalSetting(LS_WEB_SEARCH_PROVIDER, "inference-provider-native");
     }
-    const wsService = daemonConfig.services?.["web-search"];
-    return {
-      serverWebSearchMode: parseServiceMode(
-        wsService?.mode ?? getLocalSetting(LS_WEB_SEARCH_MODE, "your-own"),
-        "your-own",
-      ),
-      serverWebSearchProvider: wsService?.provider || getLocalSetting(LS_WEB_SEARCH_PROVIDER, "inference-provider-native"),
-    };
+    const wsService = daemonConfig.services?.["web-search"] as
+      | { provider?: string; mode?: string }
+      | undefined;
+    // A config written by the legacy mode toggle marks managed via `mode`
+    // while `provider` holds the BYOK restore value — the daemon routes it to
+    // Vellum, so the card must render it as Vellum too. Provider Native is
+    // exempt: it stays itself under managed mode (see migration 132).
+    const daemonProvider =
+      wsService?.mode === "managed" &&
+      wsService?.provider !== "inference-provider-native"
+        ? "vellum"
+        : wsService?.provider;
+    return daemonProvider || getLocalSetting(LS_WEB_SEARCH_PROVIDER, "inference-provider-native");
   }, [daemonConfig]);
 
   const [saving, setSaving] = useState(false);
-  const [webSearchMode, setDraftWebSearchMode] = useDraftOverride(serverWebSearchMode);
   const [webSearchProvider, setDraftWebSearchProvider] = useDraftOverride(serverWebSearchProvider);
 
   const [webSearchApiKey, setWebSearchApiKey] = useState("");
@@ -92,13 +89,8 @@ export function WebSearchCard() {
 
   // --- Derived state ---
   const hasNewApiKey = webSearchApiKey.trim().length > 0;
-  const effectiveProvider =
-    webSearchMode === "managed" ? "inference-provider-native" : webSearchProvider;
-  const configChanged =
-    webSearchMode !== serverWebSearchMode ||
-    effectiveProvider !== serverWebSearchProvider;
+  const configChanged = webSearchProvider !== serverWebSearchProvider;
   const needsKeyBeforeSave =
-    webSearchMode === "your-own" &&
     requiresProviderCredential &&
     !webSearchHasStoredKey &&
     !hasNewApiKey;
@@ -112,20 +104,24 @@ export function WebSearchCard() {
   const handleSave = useCallback(async () => {
     setSaving(true);
     const trimmed = webSearchApiKey.trim();
-    const providerToSave =
-      webSearchMode === "managed" ? "inference-provider-native" : webSearchProvider;
-    const storageKey = getWebSearchProviderKeyStorage(providerToSave);
-    const hasUserKey =
-      webSearchMode === "your-own" && requiresProviderCredential && trimmed.length > 0;
+    const storageKey = getWebSearchProviderKeyStorage(webSearchProvider);
+    const hasUserKey = requiresProviderCredential && trimmed.length > 0;
     try {
       if (hasUserKey) {
-        await provisionProviderKey(providerToSave, trimmed);
+        await provisionProviderKey(webSearchProvider, trimmed);
       }
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
         body: {
           services: {
-            "web-search": { mode: webSearchMode, provider: providerToSave },
+            // The provider is written as a pair with `mode`: older daemon
+            // schemas reject provider "vellum" without mode "managed", and a
+            // stale `mode: "managed"` from the legacy toggle would win over a
+            // BYOK choice unless reset.
+            "web-search": {
+              provider: webSearchProvider,
+              mode: webSearchProvider === "vellum" ? "managed" : "your-own",
+            },
           },
         },
       }).catch((error) => {
@@ -139,8 +135,7 @@ export function WebSearchCard() {
     }
     setSaving(false);
     try {
-      setLocalSetting(LS_WEB_SEARCH_MODE, webSearchMode);
-      setLocalSetting(LS_WEB_SEARCH_PROVIDER, providerToSave);
+      setLocalSetting(LS_WEB_SEARCH_PROVIDER, webSearchProvider);
       if (hasUserKey) {
         if (storageKey) {
           setLocalSetting(storageKey, trimmed);
@@ -168,7 +163,6 @@ export function WebSearchCard() {
     queryClient,
     assistantId,
     webSearchApiKey,
-    webSearchMode,
     webSearchProvider,
   ]);
 
@@ -183,58 +177,51 @@ export function WebSearchCard() {
   }, [webSearchProvider, setDraftWebSearchProvider]);
 
   return (
-    <ServiceCard
+    <ByoServiceCard
       title="Web Search"
       subtitle="Configure how your assistant should search the web"
-      mode={webSearchMode}
-      onModeChange={(m) => setDraftWebSearchMode(m)}
     >
-      {webSearchMode === "managed" ? (
-        <div className="space-y-3">
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <label className="block text-body-small-default text-[var(--content-tertiary)]">
+            Provider
+          </label>
+          <Dropdown
+            aria-label="Web search provider"
+            value={webSearchProvider}
+            onChange={setDraftWebSearchProvider}
+            options={WEB_SEARCH_PROVIDER_IDS.map((p) => ({
+              value: p,
+              label: WEB_SEARCH_PROVIDER_DISPLAY_NAMES[p] ?? p,
+            }))}
+          />
+        </div>
+
+        {webSearchProvider === "vellum" && (
           <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
-            Web search is included with managed inference.
+            Search runs through your Vellum account.
           </p>
-          <div className="flex items-center gap-2">
-            <SaveButton onClick={handleSave} disabled={saveDisabled} />
-            {saving && <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />}
-          </div>
-        </div>
-      ) : (
-        <div className="space-y-4">
-          <div className="space-y-1">
-            <label className="block text-body-small-default text-[var(--content-tertiary)]">
-              Provider
-            </label>
-            <Dropdown
-              value={webSearchProvider}
-              onChange={setDraftWebSearchProvider}
-              options={WEB_SEARCH_PROVIDER_IDS.map((p) => ({
-                value: p,
-                label: WEB_SEARCH_PROVIDER_DISPLAY_NAMES[p] ?? p,
-              }))}
-            />
-          </div>
+        )}
 
+        {requiresProviderCredential && (
+          <Input
+            label="API Key"
+            type="password"
+            value={webSearchApiKey}
+            onChange={(e) => setWebSearchApiKey(e.target.value)}
+            placeholder={apiKeyPlaceholder}
+            fullWidth
+          />
+        )}
+
+        <div className="flex items-center gap-2">
+          <SaveButton onClick={handleSave} disabled={saveDisabled} />
+          {saving && <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />}
           {requiresProviderCredential && (
-            <Input
-              label="API Key"
-              type="password"
-              value={webSearchApiKey}
-              onChange={(e) => setWebSearchApiKey(e.target.value)}
-              placeholder={apiKeyPlaceholder}
-              fullWidth
-            />
+            <ResetButton onClick={handleReset} filled />
           )}
-
-          <div className="flex items-center gap-2">
-            <SaveButton onClick={handleSave} disabled={saveDisabled} />
-            {saving && <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />}
-            {requiresProviderCredential && (
-              <ResetButton onClick={handleReset} filled />
-            )}
-          </div>
         </div>
-      )}
-    </ServiceCard>
+      </div>
+    </ByoServiceCard>
   );
 }

--- a/clients/web/src/lib/backwards-compat/use-supports-web-search-vellum-provider.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-web-search-vellum-provider.ts
@@ -1,0 +1,34 @@
+/**
+ * Backwards-compat gate: `vellum` as a web-search provider value.
+ *
+ * The web app always serves the latest bundle, but the assistant can be any
+ * locally-installed version. Daemons older than MIN_VERSION validate
+ * `services["web-search"].provider` against an enum that has no `vellum`
+ * member, so writing it can make the daemon's next config reload reject or
+ * reset the web-search section while the UI reports a successful save.
+ *
+ * On the `false` branch the card still offers Vellum but persists the
+ * selection the way the legacy Managed toggle did: `{ mode: "managed" }`
+ * with no provider, letting the daemon's deep-merge keep whatever provider
+ * is already stored. The legacy read bridge then renders that config as
+ * Vellum again, so the choice round-trips. (A fresh old daemon with no
+ * stored web-search provider fills its schema default,
+ * `inference-provider-native`, which renders as Provider Native — a
+ * cosmetic snap that only affects old daemons and disappears once they
+ * upgrade.)
+ *
+ * MIN_VERSION targets 0.10.12 — the first release whose search-provider
+ * catalog (and config-schema enum) includes `vellum` (#38677).
+ */
+import { assistantSupports } from "./utils";
+
+export const MIN_VERSION = "0.10.12";
+
+/**
+ * Snapshot gate for the save path: whether the active assistant accepts
+ * `provider: "vellum"` in the web-search config. Callers should
+ * `await whenAssistantVersionKnown()` before reading.
+ */
+export function supportsWebSearchVellumProvider(): boolean {
+  return assistantSupports(MIN_VERSION);
+}

--- a/clients/web/src/utils/local-settings-keys.ts
+++ b/clients/web/src/utils/local-settings-keys.ts
@@ -8,7 +8,6 @@
 
 export const LS_IMAGE_GEN_MODE = "vellum:ai:imageGenMode";
 export const LS_IMAGE_GEN_MODEL = "vellum:ai:imageGenModel";
-export const LS_WEB_SEARCH_MODE = "vellum:ai:webSearchMode";
 export const LS_WEB_SEARCH_PROVIDER = "vellum:ai:webSearchProvider";
 export const LS_WEB_FETCH_PROVIDER = "vellum:ai:webFetchProvider";
 export const LS_EMAIL_MODE = "vellum:ai:emailMode";


### PR DESCRIPTION
## Summary
- Swap `ServiceCard` → `ByoServiceCard` on the Web Search card: the Managed | Your Own segmented control is gone, the provider dropdown renders unconditionally (Vellum, Provider Native, Perplexity, Brave, Tavily, Firecrawl), and the API-key field/Save gating hangs off `WEB_SEARCH_BYOK_PROVIDER_IDS` alone
- Legacy bridges preserved: a `mode: "managed"` daemon config renders as Vellum (Provider Native exempt — it stays itself, mirroring migration 132's exemption), and saves always write the `provider`+`mode` pair because older daemon schemas reject provider "vellum" without mode "managed"
- Adds vellum to the web client's static provider catalog (deferred from #38677 per its review finding — it must land atomically with this card), drops `LS_WEB_SEARCH_MODE`, and adds a full `web-search-card.test.tsx` (8 cases, modeled on the STT card tests)

## Original prompt
PR 5 of the web-search vellum-provider plan (attached to #38677): convert the Web Search settings card to the provider-only model the STT/TTS cards already use — selecting Vellum uses managed search billed to the platform account, any other provider brings its own credentials. The catalog gen.ts edit was explicitly moved into this PR after #38677's review showed that landing it before the card conversion exposed an unroutable provider in the legacy picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->