### PR TITLE
feat(config): migrate web-search mode onto provider vellum + drop the platform mode injection

### DIFF
--- a/assistant/src/__tests__/config-loader-platform-defaults.test.ts
+++ b/assistant/src/__tests__/config-loader-platform-defaults.test.ts
@@ -75,8 +75,8 @@ function readConfig(): Record<string, unknown> {
 // When IS_PLATFORM=true, every managed-capable service defaults to "managed".
 // Without IS_PLATFORM, services split by Zod schema default: google/notion-oauth
 // resolve to "managed" (per JARVIS-966), the rest resolve to "your-own".
-// web-search is deliberately absent: provider is its only axis (migration
-// 132), so the platform context no longer injects a legacy managed mode.
+// web-search is deliberately absent: `provider` is its only axis, so the
+// platform context injects no mode for it.
 const MANAGED_SERVICES = [
   "image-generation",
   "google-oauth",
@@ -429,8 +429,7 @@ describe("GET /v1/config handler — context-default fill on raw response", () =
     >;
     const services = result["services"] as Record<string, { mode: string }>;
     expect(services["image-generation"]!.mode).toBe("your-own");
-    // web-search is no longer context-filled: migration 132 made provider
-    // its only axis, and a re-injected mode would override migrated BYOK
+    // web-search is not context-filled: a filled `mode` would override BYOK
     // configs on every load.
     expect(services["web-search"]).toBeUndefined();
     // inference.mode is a legacy backwards-compat wire field — synthesized

--- a/assistant/src/__tests__/config-loader-platform-defaults.test.ts
+++ b/assistant/src/__tests__/config-loader-platform-defaults.test.ts
@@ -75,9 +75,10 @@ function readConfig(): Record<string, unknown> {
 // When IS_PLATFORM=true, every managed-capable service defaults to "managed".
 // Without IS_PLATFORM, services split by Zod schema default: google/notion-oauth
 // resolve to "managed" (per JARVIS-966), the rest resolve to "your-own".
+// web-search is deliberately absent: provider is its only axis (migration
+// 132), so the platform context no longer injects a legacy managed mode.
 const MANAGED_SERVICES = [
   "image-generation",
-  "web-search",
   "google-oauth",
   "outlook-oauth",
   "linear-oauth",
@@ -428,8 +429,10 @@ describe("GET /v1/config handler — context-default fill on raw response", () =
     >;
     const services = result["services"] as Record<string, { mode: string }>;
     expect(services["image-generation"]!.mode).toBe("your-own");
-    // web-search was missing → fill.
-    expect(services["web-search"]!.mode).toBe("managed");
+    // web-search is no longer context-filled: migration 132 made provider
+    // its only axis, and a re-injected mode would override migrated BYOK
+    // configs on every load.
+    expect(services["web-search"]).toBeUndefined();
     // inference.mode is a legacy backwards-compat wire field — synthesized
     // here for old macOS clients (SettingsStore.swift) that still read it.
     expect(services["inference"]!.mode).toBe("managed");

--- a/assistant/src/__tests__/workspace-migration-132-web-search-mode-to-provider.test.ts
+++ b/assistant/src/__tests__/workspace-migration-132-web-search-mode-to-provider.test.ts
@@ -10,9 +10,18 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { AssistantConfigSchema } from "../config/schema.js";
-import { webSearchModeToProviderMigration } from "../workspace/migrations/132-web-search-mode-to-provider.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import { getLastWorkspaceMigrationId } from "../workspace/migrations/runner.js";
+
+// Migration files expose no API to other code (see migrations AGENTS.md);
+// the registry is the one sanctioned importer, so the test exercises the
+// registered entry rather than importing the module directly.
+const webSearchModeToProviderMigration = WORKSPACE_MIGRATIONS.find(
+  (m) => m.id === "132-web-search-mode-to-provider",
+);
+if (!webSearchModeToProviderMigration) {
+  throw new Error("migration 132 is not registered in WORKSPACE_MIGRATIONS");
+}
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/__tests__/workspace-migration-132-web-search-mode-to-provider.test.ts
+++ b/assistant/src/__tests__/workspace-migration-132-web-search-mode-to-provider.test.ts
@@ -1,0 +1,231 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { AssistantConfigSchema } from "../config/schema.js";
+import { webSearchModeToProviderMigration } from "../workspace/migrations/132-web-search-mode-to-provider.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { getLastWorkspaceMigrationId } from "../workspace/migrations/runner.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-132-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function webSearch(config: Record<string, unknown>): Record<string, any> {
+  return (config.services as Record<string, any>)["web-search"];
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("132-web-search-mode-to-provider", () => {
+  // getLastWorkspaceMigrationId() reports the final array entry as the
+  // registry ceiling to the identity and rollback routes, so 132 must be the
+  // highest id AND sit last in the registry.
+  test("the registry ceiling stays at the highest-numbered migration", () => {
+    const numericId = (id: string) => Number.parseInt(id, 10);
+    const highest = Math.max(
+      ...WORKSPACE_MIGRATIONS.map((m) => numericId(m.id)).filter(
+        Number.isFinite,
+      ),
+    );
+    const last = getLastWorkspaceMigrationId(WORKSPACE_MIGRATIONS);
+    expect(last).not.toBeNull();
+    expect(numericId(last!)).toBe(highest);
+    expect(numericId(last!)).toBe(132);
+  });
+
+  test("rewrites a managed service to provider vellum", () => {
+    writeConfig({
+      services: { "web-search": { mode: "managed", provider: "brave" } },
+    });
+
+    webSearchModeToProviderMigration.run(workspaceDir);
+
+    expect(webSearch(readConfig())).toEqual({ provider: "vellum" });
+  });
+
+  test("keeps the BYOK provider and drops mode for your-own", () => {
+    writeConfig({
+      services: { "web-search": { mode: "your-own", provider: "firecrawl" } },
+    });
+
+    webSearchModeToProviderMigration.run(workspaceDir);
+
+    expect(webSearch(readConfig())).toEqual({ provider: "firecrawl" });
+  });
+
+  // The platform default config. Provider Native is a distinct user-facing
+  // option (native hosted search with its own managed fallback), so it must
+  // survive managed mode verbatim rather than becoming vellum.
+  test("preserves inference-provider-native under managed mode", () => {
+    writeConfig({
+      services: {
+        "web-search": {
+          mode: "managed",
+          provider: "inference-provider-native",
+        },
+      },
+    });
+
+    webSearchModeToProviderMigration.run(workspaceDir);
+
+    expect(webSearch(readConfig())).toEqual({
+      provider: "inference-provider-native",
+    });
+  });
+
+  test("is idempotent", () => {
+    writeConfig({
+      services: { "web-search": { mode: "managed", provider: "brave" } },
+    });
+
+    webSearchModeToProviderMigration.run(workspaceDir);
+    const once = readConfig();
+    webSearchModeToProviderMigration.run(workspaceDir);
+
+    expect(readConfig()).toEqual(once);
+  });
+
+  test("leaves configs without a web-search mode alone", () => {
+    const original = {
+      services: {
+        "web-search": { provider: "perplexity" },
+        stt: { mode: "managed", provider: "deepgram" },
+      },
+    };
+    writeConfig(original);
+
+    webSearchModeToProviderMigration.run(workspaceDir);
+
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("survives a missing config and malformed JSON", () => {
+    expect(() =>
+      webSearchModeToProviderMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    writeFileSync(join(workspaceDir, "config.json"), "{ not json");
+    expect(() =>
+      webSearchModeToProviderMigration.run(workspaceDir),
+    ).not.toThrow();
+  });
+
+  // The migrated shape is what the daemon actually parses, so a managed user
+  // must land on vellum rather than falling back to a keyless BYOK provider.
+  test("migrated output parses to the vellum provider", () => {
+    writeConfig({
+      services: { "web-search": { mode: "managed", provider: "brave" } },
+    });
+
+    webSearchModeToProviderMigration.run(workspaceDir);
+    const parsed = AssistantConfigSchema.parse(readConfig());
+
+    expect(parsed.services["web-search"].provider).toBe("vellum");
+  });
+
+  describe("down", () => {
+    test("round-trip restores the managed pair", () => {
+      writeConfig({
+        services: { "web-search": { mode: "managed", provider: "brave" } },
+      });
+
+      webSearchModeToProviderMigration.run(workspaceDir);
+      webSearchModeToProviderMigration.down!(workspaceDir);
+
+      // The pre-migration BYOK provider (brave) is not recoverable — it was
+      // overwritten with vellum on the way up.
+      expect(webSearch(readConfig())).toEqual({
+        mode: "managed",
+        provider: "vellum",
+      });
+    });
+
+    test("restores your-own for a BYOK provider", () => {
+      writeConfig({
+        services: { "web-search": { provider: "firecrawl" } },
+      });
+
+      webSearchModeToProviderMigration.down!(workspaceDir);
+
+      expect(webSearch(readConfig())).toEqual({
+        mode: "your-own",
+        provider: "firecrawl",
+      });
+    });
+
+    // The managed pairing was erased on the way up, so Provider Native rolls
+    // back to your-own even if it had been paired with managed mode.
+    test("rolls inference-provider-native back to your-own", () => {
+      writeConfig({
+        services: {
+          "web-search": { provider: "inference-provider-native" },
+        },
+      });
+
+      webSearchModeToProviderMigration.down!(workspaceDir);
+
+      expect(webSearch(readConfig())).toEqual({
+        mode: "your-own",
+        provider: "inference-provider-native",
+      });
+    });
+
+    test("does not re-add mode when it is already present", () => {
+      writeConfig({
+        services: { "web-search": { mode: "your-own", provider: "brave" } },
+      });
+
+      webSearchModeToProviderMigration.down!(workspaceDir);
+
+      expect(webSearch(readConfig())).toEqual({
+        mode: "your-own",
+        provider: "brave",
+      });
+    });
+  });
+});

--- a/assistant/src/config/__tests__/deployment-context-defaults.test.ts
+++ b/assistant/src/config/__tests__/deployment-context-defaults.test.ts
@@ -153,11 +153,9 @@ describe("deployment-context embedding-provider default (via loadConfig)", () =>
     >;
     expect(embeddingsRaw.provider).toBeUndefined();
 
-    // Managed service modes ARE persisted on first launch (existing behavior),
-    // but web-search is no longer among them: provider is its only axis
-    // (migration 132), so the platform context must not re-inject a legacy
-    // `mode` that would override migrated BYOK configs on every load. Until
-    // the schema drops `mode` entirely, the persisted value is the schema
+    // Managed service modes ARE persisted on first launch, but web-search is
+    // exempt: `provider` is its only axis, and a context-filled `mode` would
+    // override BYOK configs on every load. The persisted value is the schema
     // default rather than an injected "managed".
     const servicesRaw = (raw.services ?? {}) as Record<string, unknown>;
     const webSearchRaw = (servicesRaw["web-search"] ?? {}) as Record<

--- a/assistant/src/config/__tests__/deployment-context-defaults.test.ts
+++ b/assistant/src/config/__tests__/deployment-context-defaults.test.ts
@@ -153,13 +153,18 @@ describe("deployment-context embedding-provider default (via loadConfig)", () =>
     >;
     expect(embeddingsRaw.provider).toBeUndefined();
 
-    // Managed service modes ARE persisted on first launch (existing behavior).
+    // Managed service modes ARE persisted on first launch (existing behavior),
+    // but web-search is no longer among them: provider is its only axis
+    // (migration 132), so the platform context must not re-inject a legacy
+    // `mode` that would override migrated BYOK configs on every load. Until
+    // the schema drops `mode` entirely, the persisted value is the schema
+    // default rather than an injected "managed".
     const servicesRaw = (raw.services ?? {}) as Record<string, unknown>;
     const webSearchRaw = (servicesRaw["web-search"] ?? {}) as Record<
       string,
       unknown
     >;
-    expect(webSearchRaw.mode).toBe("managed");
+    expect(webSearchRaw.mode).not.toBe("managed");
 
     // Regression guard: on the NEXT load (config.json now exists with the
     // provider leaf absent), the platform default re-applies in memory rather

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -139,12 +139,11 @@ export function getDeploymentContextDefaults(): Record<string, unknown> {
   if (process.env.IS_PLATFORM !== "true" && process.env.IS_PLATFORM !== "1") {
     return {};
   }
-  // Web-search carries no deployment default: migration 132 made `provider`
-  // the only axis, the schema default (`inference-provider-native`) prefers
-  // native hosted search, and the runtime falls back to the platform proxy
-  // when the model has no native search and no BYOK key is configured —
-  // which reproduces the old `mode: "managed"` platform behavior. Re-filling
-  // a legacy `mode` here would override migrated BYOK configs on every load.
+  // Web-search carries no deployment default: `provider` is its only axis,
+  // the schema default (`inference-provider-native`) prefers native hosted
+  // search, and app-executed search falls back to the platform proxy when no
+  // BYOK key is configured. Filling a `mode` here would override BYOK
+  // configs on every load.
   const managed = { mode: "managed" as const };
   return {
     // Express platform intent that hosted assistants embed via the managed

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -139,9 +139,12 @@ export function getDeploymentContextDefaults(): Record<string, unknown> {
   if (process.env.IS_PLATFORM !== "true" && process.env.IS_PLATFORM !== "1") {
     return {};
   }
-  // `web-search.mode = managed` enables platform-backed app-executed search
-  // for non-native inference providers while preserving provider-native hosted
-  // search for providers/models that support it.
+  // Web-search carries no deployment default: migration 132 made `provider`
+  // the only axis, the schema default (`inference-provider-native`) prefers
+  // native hosted search, and the runtime falls back to the platform proxy
+  // when the model has no native search and no BYOK key is configured —
+  // which reproduces the old `mode: "managed"` platform behavior. Re-filling
+  // a legacy `mode` here would override migrated BYOK configs on every load.
   const managed = { mode: "managed" as const };
   return {
     // Express platform intent that hosted assistants embed via the managed
@@ -155,7 +158,6 @@ export function getDeploymentContextDefaults(): Record<string, unknown> {
     memory: { embeddings: { provider: "gemini" } },
     services: {
       "image-generation": managed,
-      "web-search": managed,
       "google-oauth": managed,
       "outlook-oauth": managed,
       "linear-oauth": managed,

--- a/assistant/src/workspace/migrations/132-web-search-mode-to-provider.ts
+++ b/assistant/src/workspace/migrations/132-web-search-mode-to-provider.ts
@@ -1,0 +1,102 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Fold `services["web-search"].mode` into the provider field.
+ *
+ * Managed web search used to be a second axis: `mode: "managed"` routed to the
+ * Vellum platform search proxy while `provider` held the untouched BYOK
+ * choice. Provider is now the only axis, with `"vellum"` meaning managed, so a
+ * managed service must be rewritten to `provider: "vellum"` before the new
+ * schema reads it — otherwise the lingering BYOK provider would be taken at
+ * face value and a managed user would silently fall back to a provider they
+ * have no key for.
+ *
+ * `inference-provider-native` is the exception: it is a distinct user-facing
+ * option (the inference model runs its own hosted search), so a managed
+ * service on that provider keeps it verbatim rather than becoming `vellum`.
+ * Its managed fallback (platform proxy when the model has no native search
+ * and no user key exists) works without a `mode`.
+ *
+ * Idempotent: a config with no `mode` key is left untouched.
+ */
+export const webSearchModeToProviderMigration: WorkspaceMigration = {
+  id: "132-web-search-mode-to-provider",
+  description:
+    "Fold services.web-search mode into provider (managed -> provider: vellum)",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return; // Malformed JSON — skip
+    }
+
+    const services = readObj(config, "services");
+    if (!services) return;
+
+    const service = readObj(services, "web-search");
+    if (!service || !("mode" in service)) return;
+
+    if (
+      service.mode === "managed" &&
+      service.provider !== "inference-provider-native"
+    ) {
+      service.provider = "vellum";
+    }
+    delete service.mode;
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const services = readObj(config, "services");
+    if (!services) return;
+
+    const service = readObj(services, "web-search");
+    if (!service || "mode" in service) return;
+
+    // The pre-migration schema accepts provider "vellum" alongside mode
+    // "managed", so the managed pair round-trips exactly. What a managed
+    // service had chosen for BYOK before is not recoverable — it was
+    // overwritten on the way up. Likewise, `inference-provider-native` rolls
+    // back to `your-own` even if it was previously paired with `managed`: the
+    // pairing was erased when `mode` was dropped.
+    service.mode = service.provider === "vellum" ? "managed" : "your-own";
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers (self-contained per migration AGENTS.md)
+// ---------------------------------------------------------------------------
+
+function readObj(
+  parent: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = parent[key];
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/132-web-search-mode-to-provider.ts
+++ b/assistant/src/workspace/migrations/132-web-search-mode-to-provider.ts
@@ -6,13 +6,13 @@ import type { WorkspaceMigration } from "./types.js";
 /**
  * Fold `services["web-search"].mode` into the provider field.
  *
- * Managed web search used to be a second axis: `mode: "managed"` routed to the
- * Vellum platform search proxy while `provider` held the untouched BYOK
- * choice. Provider is now the only axis, with `"vellum"` meaning managed, so a
- * managed service must be rewritten to `provider: "vellum"` before the new
- * schema reads it — otherwise the lingering BYOK provider would be taken at
- * face value and a managed user would silently fall back to a provider they
- * have no key for.
+ * Configs written by older versions carry two axes: `mode: "managed"` routes
+ * search through the Vellum platform proxy while `provider` holds an
+ * untouched BYOK choice. The schema treats `provider` as the only axis, with
+ * `"vellum"` meaning managed, so this migration rewrites a managed service to
+ * `provider: "vellum"` — otherwise the lingering BYOK provider would be taken
+ * at face value and a managed user would silently land on a provider they
+ * hold no key for.
  *
  * `inference-provider-native` is the exception: it is a distinct user-facing
  * option (the inference model runs its own hosted search), so a managed
@@ -90,12 +90,11 @@ export const webSearchModeToProviderMigration: WorkspaceMigration = {
       return;
     }
 
-    // The pre-migration schema accepts provider "vellum" alongside mode
-    // "managed", so the managed pair round-trips exactly. What a managed
-    // service had chosen for BYOK before is not recoverable — it was
-    // overwritten on the way up. Likewise, `inference-provider-native` rolls
-    // back to `your-own` even if it was previously paired with `managed`: the
-    // pairing was erased when `mode` was dropped.
+    // Schemas that predate this migration accept provider "vellum" alongside
+    // mode "managed", so the managed pair round-trips exactly. The BYOK
+    // provider a managed service holds before `run()` is not recoverable —
+    // `run()` overwrites it. Likewise `inference-provider-native` rolls back
+    // to `your-own`: dropping `mode` erases any pairing with `managed`.
     service.mode = service.provider === "vellum" ? "managed" : "your-own";
 
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");

--- a/assistant/src/workspace/migrations/132-web-search-mode-to-provider.ts
+++ b/assistant/src/workspace/migrations/132-web-search-mode-to-provider.ts
@@ -28,22 +28,30 @@ export const webSearchModeToProviderMigration: WorkspaceMigration = {
     "Fold services.web-search mode into provider (managed -> provider: vellum)",
   run(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");
-    if (!existsSync(configPath)) return;
+    if (!existsSync(configPath)) {
+      return;
+    }
 
     let config: Record<string, unknown>;
     try {
       const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return;
+      }
       config = raw as Record<string, unknown>;
     } catch {
       return; // Malformed JSON — skip
     }
 
     const services = readObj(config, "services");
-    if (!services) return;
+    if (!services) {
+      return;
+    }
 
     const service = readObj(services, "web-search");
-    if (!service || !("mode" in service)) return;
+    if (!service || !("mode" in service)) {
+      return;
+    }
 
     if (
       service.mode === "managed" &&
@@ -57,22 +65,30 @@ export const webSearchModeToProviderMigration: WorkspaceMigration = {
   },
   down(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");
-    if (!existsSync(configPath)) return;
+    if (!existsSync(configPath)) {
+      return;
+    }
 
     let config: Record<string, unknown>;
     try {
       const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return;
+      }
       config = raw as Record<string, unknown>;
     } catch {
       return;
     }
 
     const services = readObj(config, "services");
-    if (!services) return;
+    if (!services) {
+      return;
+    }
 
     const service = readObj(services, "web-search");
-    if (!service || "mode" in service) return;
+    if (!service || "mode" in service) {
+      return;
+    }
 
     // The pre-migration schema accepts provider "vellum" alongside mode
     // "managed", so the managed pair round-trips exactly. What a managed

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -129,6 +129,7 @@ import { repairStaleOpenrouterGrokModelIdsMigration } from "./128-repair-stale-o
 import { removeAnalyzeConversationConfigMigration } from "./129-remove-analyze-conversation-config.js";
 import { speechModeToProviderMigration } from "./130-speech-mode-to-provider.js";
 import { dropWebFetchModeMigration } from "./131-drop-web-fetch-mode.js";
+import { webSearchModeToProviderMigration } from "./132-web-search-mode-to-provider.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -273,4 +274,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   // keys, so relative execution order is irrelevant.
   speechModeToProviderMigration,
   dropWebFetchModeMigration,
+  webSearchModeToProviderMigration,
 ];


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge #38688 (the Web Search card conversion) before this PR.** This migration writes `provider: "vellum"` into daemon configs; #38688 is the web-client counterpart that renders that value (vellum in the picker, legacy-mode read bridge, version-gated writes). Merging this first would leave a window where a migrated daemon meets the old card and shows a blank provider under Your Own.

## Summary

- Adds workspace migration 132 (`assistant/src/workspace/migrations/132-web-search-mode-to-provider.ts`): folds `services["web-search"].mode` into the provider axis. `mode: "managed"` rewrites `provider` to `"vellum"`; `mode` is deleted in all cases; a config with no `mode` is untouched (idempotent).
- Provider Native exemption: `mode: "managed"` + `provider: "inference-provider-native"` (the platform default config) keeps its provider verbatim — Provider Native is a distinct user-facing option, and its managed fallback works without a `mode` (PR 2, #38681).
- `down()` reconstructs `mode = provider === "vellum" ? "managed" : "your-own"`. The pre-migration BYOK provider stored under managed mode is not recoverable, and `inference-provider-native` rolls back to `your-own` even if previously paired with managed.
- Registered last in the registry: the ceiling reported by `getLastWorkspaceMigrationId()` is now 132.
- Note: this migration is the billing-flip moment. A config that was mode-managed with Provider Native and a stored search key switches from proxy billing to the user's own key by design — post-migration, `inference-provider-native` prefers native search, then the user's own keys, with the platform proxy only as a last resort (the billing rule from PR 2).

## Original prompt

PR 4 of the web-search vellum-provider plan attached to #38677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->