### PR TITLE
feat(web): streamline pre-approved QR arrival on the device-code pairing page

### DIFF
--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
+import type { RemoteWebPairingTokenResult } from "@/lib/auth/remote-gateway-session";
+
 let remoteGatewayMode = false;
 
 mock.module("@/lib/local-mode", () => ({
@@ -9,7 +11,10 @@ mock.module("@/lib/local-mode", () => ({
 }));
 
 const exchangeRemoteWebPairingTokenMock = mock(
-  async (_deviceCode: string, _signal?: AbortSignal) => ({
+  async (
+    _deviceCode: string,
+    _signal?: AbortSignal,
+  ): Promise<RemoteWebPairingTokenResult> => ({
     status: "pending",
     expiresAt: "2026-06-16T12:00:00.000Z",
     intervalSeconds: 5,
@@ -25,6 +30,14 @@ const createRemoteWebPairingChallengeMock = mock(
     intervalSeconds: 5,
   }),
 );
+const activateRemoteGatewaySessionMock = mock((_session: unknown) => {});
+
+const APPROVED_RESULT: RemoteWebPairingTokenResult = {
+  status: "approved",
+  accessToken: "access-token",
+  accessTokenExpiresAt: "2999-01-01T00:00:00.000Z",
+  refreshAfter: "2999-01-01T00:00:00.000Z",
+};
 
 class MockRemoteWebPairingError extends Error {
   readonly status: number;
@@ -37,7 +50,7 @@ class MockRemoteWebPairingError extends Error {
 }
 
 mock.module("@/lib/auth/remote-gateway-session", () => ({
-  activateRemoteGatewaySession: () => {},
+  activateRemoteGatewaySession: activateRemoteGatewaySessionMock,
   createRemoteWebPairingChallenge: createRemoteWebPairingChallengeMock,
   exchangeRemoteWebPairingToken: exchangeRemoteWebPairingTokenMock,
   parseRemoteWebPairingParams: (value: string) => {
@@ -58,6 +71,7 @@ afterEach(() => {
   remoteGatewayMode = false;
   exchangeRemoteWebPairingTokenMock.mockClear();
   createRemoteWebPairingChallengeMock.mockClear();
+  activateRemoteGatewaySessionMock.mockClear();
 });
 
 describe("RemoteWebPairingPage", () => {
@@ -182,5 +196,82 @@ describe("RemoteWebPairingPage", () => {
     expect(await screen.findByText("Pairing failed")).not.toBeNull();
     expect(screen.getByText(/Try starting a new pairing/)).not.toBeNull();
     expect(screen.queryByText(/trust database needs repair/)).toBeNull();
+  });
+
+  test("goes straight to paired for a pre-approved code, without flashing the approval code", async () => {
+    remoteGatewayMode = true;
+    exchangeRemoteWebPairingTokenMock.mockImplementationOnce(
+      async () => APPROVED_RESULT,
+    );
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/assistant/pair?deviceCode=fast-code&userCode=WXYZ-1234",
+        ]}
+      >
+        <RemoteWebPairingPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Connected")).not.toBeNull();
+    expect(activateRemoteGatewaySessionMock).toHaveBeenCalledTimes(1);
+    // The pre-approved arrival never shows the approval-code / waiting UI.
+    expect(screen.queryByText("Waiting for approval")).toBeNull();
+    expect(screen.queryByText("Pairing code")).toBeNull();
+    expect(screen.queryByText("WXYZ-1234")).toBeNull();
+  });
+
+  test("still shows the waiting state and code when the code is not yet approved", async () => {
+    remoteGatewayMode = true;
+    // Default mock returns pending — the not-pre-approved device-code path.
+
+    render(
+      <MemoryRouter
+        initialEntries={["/assistant/pair?deviceCode=slow-code&userCode=ABCD"]}
+      >
+        <RemoteWebPairingPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Waiting for approval")).not.toBeNull();
+    expect(screen.getByText("ABCD")).not.toBeNull();
+    expect(screen.getByText("Pairing code")).not.toBeNull();
+  });
+
+  test("clears the device-code fragment from the URL after a successful exchange", async () => {
+    remoteGatewayMode = true;
+    exchangeRemoteWebPairingTokenMock.mockImplementationOnce(
+      async () => APPROVED_RESULT,
+    );
+    const replaceStateSpy = mock(
+      (_data: unknown, _unused: string, _url?: string | URL | null) => {},
+    );
+    const originalReplaceState = window.history.replaceState;
+    Object.defineProperty(window.history, "replaceState", {
+      configurable: true,
+      value: replaceStateSpy,
+    });
+
+    try {
+      render(
+        <MemoryRouter initialEntries={["/assistant/pair?deviceCode=fast-code"]}>
+          <RemoteWebPairingPage />
+        </MemoryRouter>,
+      );
+
+      await screen.findByText("Connected");
+      expect(replaceStateSpy).toHaveBeenCalled();
+      // The replacement URL carries no fragment.
+      const clearedWithoutHash = replaceStateSpy.mock.calls.some(
+        (call) => !String(call?.[2] ?? "").includes("#"),
+      );
+      expect(clearedWithoutHash).toBe(true);
+    } finally {
+      Object.defineProperty(window.history, "replaceState", {
+        configurable: true,
+        value: originalReplaceState,
+      });
+    }
   });
 });

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -21,6 +21,7 @@ type PairingDetails = {
 
 type PairingState =
   | { kind: "starting" }
+  | { kind: "verifying" }
   | { kind: "polling"; expiresAt: string | null }
   | { kind: "approved" }
   | { kind: "expired" }
@@ -33,6 +34,11 @@ function statusCopy(state: PairingState): { title: string; body: string } {
         title: "Starting pairing",
         body: "Creating a code for this browser.",
       };
+    case "verifying":
+      return {
+        title: "Pairing",
+        body: "Connecting this device to your assistant.",
+      };
     case "approved":
       return {
         title: "Connected",
@@ -41,7 +47,7 @@ function statusCopy(state: PairingState): { title: string; body: string } {
     case "expired":
       return {
         title: "Pairing expired",
-        body: "Start a new web pairing from the local assistant.",
+        body: "This pairing code is invalid or expired. Run vellum pair --qr (or vellum pair --web) on the machine running your assistant to get a new one.",
       };
     case "error":
       return {
@@ -60,7 +66,11 @@ function StatusIcon({ state }: { state: PairingState }) {
   if (state.kind === "approved") {
     return <CheckCircle2 className="h-5 w-5 text-green-600" aria-hidden />;
   }
-  if (state.kind === "starting" || state.kind === "polling") {
+  if (
+    state.kind === "starting" ||
+    state.kind === "verifying" ||
+    state.kind === "polling"
+  ) {
     return (
       <LoaderCircle
         className="h-5 w-5 animate-spin text-blue-600"
@@ -69,6 +79,24 @@ function StatusIcon({ state }: { state: PairingState }) {
     );
   }
   return <AlertCircle className="h-5 w-5 text-red-600" aria-hidden />;
+}
+
+/**
+ * Strip the burned `#device_code=` fragment (and any query variants) from the
+ * address bar after a successful exchange, preserving `returnTo`, so the spent
+ * code does not linger in the location bar or get re-submitted on reload.
+ */
+function clearDeviceCodeFromUrl(): void {
+  try {
+    const url = new URL(window.location.href);
+    for (const key of ["deviceCode", "device_code", "userCode", "user_code"]) {
+      url.searchParams.delete(key);
+    }
+    url.hash = "";
+    window.history.replaceState(null, "", `${url.pathname}${url.search}`);
+  } catch {
+    // history.replaceState unavailable — the burned code is inert regardless.
+  }
 }
 
 export function RemoteWebPairingPage() {
@@ -95,7 +123,7 @@ export function RemoteWebPairingPage() {
       : null,
   );
   const [state, setState] = useState<PairingState>(
-    pairing ? { kind: "polling", expiresAt: null } : { kind: "starting" },
+    pairing ? { kind: "verifying" } : { kind: "starting" },
   );
 
   useEffect(() => {
@@ -156,6 +184,9 @@ export function RemoteWebPairingPage() {
         }
 
         activateRemoteGatewaySession(result);
+        // Drop the burned device code from the URL before navigating so it
+        // never lingers in the address bar or re-submits on reload.
+        clearDeviceCodeFromUrl();
         setState({ kind: "approved" });
         timeout = setTimeout(() => navigate(returnTo, { replace: true }), 250);
       } catch (err) {
@@ -207,7 +238,7 @@ export function RemoteWebPairingPage() {
           <h1 className="text-xl font-semibold">{copy.title}</h1>
         </div>
 
-        {pairing?.userCode ? (
+        {state.kind === "polling" && pairing?.userCode ? (
           <div className="mb-5 rounded-md border border-[var(--border-subtle)] bg-[var(--background-muted)] p-4 text-center">
             <div className="text-xs font-medium uppercase text-[var(--content-secondary)]">
               Pairing code


### PR DESCRIPTION
## Summary

Companion to the `vellum pair --qr` CLI PR; supersedes the PR-3 scope in the plan attached to #38685 — the QR flow reuses the existing RFC 8628 device-code challenge (pre-approved at mint, since running the CLI on the host is the authorization), so this PR is the pre-approved-arrival UX polish. No new gateway endpoints, no new session-storage mechanism.

- The device-code arrival now starts in a neutral **"Pairing"** state and only renders the approval code + "Waiting for approval" once the poll actually returns `pending`. A pre-approved challenge goes straight to **Connected** without flashing the approval-code / waiting UI; an unapproved `--web` code still shows the code so it can be approved on the host.
- The burned `#device_code=` fragment is stripped from the URL (`history.replaceState`) after a successful exchange, so it can't linger in the address bar or re-submit on reload.
- Invalid/expired codes now tell the user to mint a fresh one with `vellum pair --qr` (or `vellum pair --web`).

## Verification (no changes needed)

- **Refresh-cookie persistence survives restarts**: the existing device-code flow (`/v1/remote-web/pairing-token`) issues the HttpOnly `vellum_web_refresh` cookie; on restart `initSession` → `refreshRemoteGatewaySession` replays it, so the browser session is durable with zero wiring. (This is the key win of reusing the device-code flow — unlike the abandoned qr-exchange path, it sets the cookie.)
- **401 recovery routes to the pair page, not platform login**: the route guard `requireRemoteGatewayPairing` already redirects unauthenticated remote-gateway users to `/assistant/pair`, and `platformAuthRecoveryInterceptor` explicitly skips same-origin gateway 401s; a mid-session 401 self-heals on the next app-resume refresh via the cookie (else the guard routes to re-pair). No dead-end — no fix applied.

Pure client UX on an existing flow (only `domains/remote-web/pairing-page.tsx` + its test).
