### PR TITLE
fix(gateway): Cache-Control: no-store on token-bearing pair responses

### DIFF
--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -24,8 +24,12 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 
 const { initGatewayDb, resetGatewayDb, getGatewayDb } =
   await import("../db/connection.js");
-const { actorTokenRecords, actorRefreshTokenRecords, contacts, contactChannels } =
-  await import("../db/schema.js");
+const {
+  actorTokenRecords,
+  actorRefreshTokenRecords,
+  contacts,
+  contactChannels,
+} = await import("../db/schema.js");
 const { handlePair, resetPairRateLimiterForTests } =
   await import("../http/routes/pair.js");
 const { hashToken } = await import("../auth/guardian-bootstrap.js");
@@ -114,6 +118,8 @@ describe("/v1/pair device-bound minting", () => {
       LOOPBACK_IP,
     );
     expect(res.status).toBe(200);
+    // Token-bearing responses must never be cached by intermediaries/browser.
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(typeof body.token).toBe("string");
@@ -200,6 +206,8 @@ describe("/v1/pair device-bound minting", () => {
   test("without a deviceId, returns the legacy stateless token and records nothing", async () => {
     const res = await handlePair(makePairRequest(), LOOPBACK_IP);
     expect(res.status).toBe(200);
+    // The stateless token response is also token-bearing → no-store.
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(typeof body.token).toBe("string");

--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -645,6 +645,7 @@ describe("remote web pairing token exchange", () => {
       );
 
       expect(res.status).toBe(503);
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
       expect(await res.json()).toEqual({
         error: {
           code: "GUARDIAN_REPAIR_REQUIRED",
@@ -694,6 +695,7 @@ describe("remote web pairing token exchange", () => {
     );
 
     expect(res.status).toBe(401);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
     expect(await res.json()).toEqual({
       error: {
         code: "INVALID_OR_EXPIRED_DEVICE_CODE",

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -302,12 +302,15 @@ export async function handlePair(
       "Client paired successfully via loopback",
     );
 
-    return Response.json({
-      token,
-      expiresAt: expiresAtIso,
-      guardianId: guardianPrincipalId,
-      assistantId: getExternalAssistantId(),
-    });
+    return Response.json(
+      {
+        token,
+        expiresAt: expiresAtIso,
+        guardianId: guardianPrincipalId,
+        assistantId: getExternalAssistantId(),
+      },
+      { headers: { "Cache-Control": "no-store" } },
+    );
   }
 
   // CLI pairing (e.g. `vellum pair`): a loopback-local caller mints a
@@ -390,13 +393,16 @@ function mintDeviceBoundPairResponse(opts: {
     "Client paired successfully via loopback (device-bound)",
   );
 
-  return Response.json({
-    token: pair.accessToken,
-    expiresAt: new Date(pair.accessTokenExpiresAt).toISOString(),
-    refreshToken: pair.refreshToken,
-    refreshTokenExpiresAt: new Date(pair.refreshTokenExpiresAt).toISOString(),
-    refreshAfter: new Date(pair.refreshAfter).toISOString(),
-    guardianId: opts.guardianPrincipalId,
-    assistantId: opts.assistantId,
-  });
+  return Response.json(
+    {
+      token: pair.accessToken,
+      expiresAt: new Date(pair.accessTokenExpiresAt).toISOString(),
+      refreshToken: pair.refreshToken,
+      refreshTokenExpiresAt: new Date(pair.refreshTokenExpiresAt).toISOString(),
+      refreshAfter: new Date(pair.refreshAfter).toISOString(),
+      guardianId: opts.guardianPrincipalId,
+      assistantId: opts.assistantId,
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
 }

--- a/gateway/src/http/routes/remote-web-pairing-token.ts
+++ b/gateway/src/http/routes/remote-web-pairing-token.ts
@@ -19,7 +19,10 @@ const MAX_TOKEN_BODY_BYTES = 512;
 const REMOTE_WEB_PLATFORM = "web";
 
 function jsonError(code: string, message: string, status: number): Response {
-  return Response.json({ error: { code, message } }, { status });
+  return Response.json(
+    { error: { code, message } },
+    { status, headers: { "Cache-Control": "no-store" } },
+  );
 }
 
 function invalidDeviceCodeResponse(): Response {


### PR DESCRIPTION
## Summary
- Pairing responses that carry bearer tokens (/v1/remote-web/pairing-token, /v1/pair) now set Cache-Control: no-store
- Carry-forward from #38687 (closed): its superseded pair-response helper included this header; the reused RFC 8628 flow should too

Part of plan: ios-self-hosted-connect.md (review-pass remediation)