### PR TITLE
feat(marketplace): add markitdown-vellum plugin to registry.

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -254,6 +254,19 @@
       "icon": "📈"
     },
     {
+      "name": "markitdown-vellum",
+      "source": {
+        "source": "github",
+        "repo": "simensgreen/markitdown-vellum",
+        "ref": "5e5a4ecfd6c60d613778106442003a1ed302fc3c"
+      },
+      "description": "Convert workspace documents (PDF, DOCX, PPTX, XLSX, images, MSG, …) to markdown via @cognipeer/to-markdown, with Vellum vision OCR or Tesseract.",
+      "category": "productivity",
+      "homepage": "https://github.com/simensgreen/markitdown-vellum",
+      "license": "MIT",
+      "icon": "📄"
+    },
+    {
       "name": "model-router",
       "source": {
         "source": "github",


### PR DESCRIPTION
## Summary

Adds **markitdown-vellum** to the curated plugin catalog.

The plugin adds a `markitdown` tool that converts workspace documents to markdown using [@cognipeer/to-markdown](https://www.npmjs.com/package/@cognipeer/to-markdown). It covers office formats the model cannot read natively: PDF, DOCX, PPTX, XLSX, HTML, IPYNB, ZIP, Outlook `.msg`, images, and more.

Scanned PDFs and images can be OCR'd either via the workspace vision provider (`visionMode: "vellum"`) or bundled Tesseract.js (`visionMode: "tesseract"`).

- **Repo:** https://github.com/simensgreen/markitdown-vellum
- **Pinned commit:** `5e5a4ecfd6c60d613778106442003a1ed302fc3c`
- **License:** MIT

## Surfaces

| Surface | Name | Notes |
| --- | --- | --- |
| Tool | `markitdown` | Converts a workspace file path to markdown; optional `timeoutMs` per call |
| Hook | `init` | Merges `config.json` into plugin runtime config |

## Security / behavior notes

- Tool is read-only (`defaultRiskLevel: low`): reads workspace files, returns markdown in tool result
- Paths must stay inside the workspace; URLs rejected
- Extension allowlist derived from cognipeer `FileExtension`, excluding `.txt`, `.mp3`, `.wav`
- `visionMode: "vellum"` routes cognipeer `custom-vlm` OCR through a scoped `fetch` patch to `getConfiguredProvider("vision")` (sentinel URL only; restored after conversion)
- Runtime deps installed by host via `bun install --omit=dev` (`@cognipeer/to-markdown`, includes native `canvas` for PDF page rendering)

## Test plan

- [ ] `assistant plugins install markitdown-vellum` (after merge) or `assistant plugins install simensgreen/markitdown-vellum` (pre-merge)
- [ ] Plugin loads without import errors; tool appears in registry
- [ ] Convert a `.html` or `.docx` file in workspace → markdown returned
- [ ] With `visionMode: "tesseract"`, scanned PDF OCR works (or returns meaningful error if canvas unavailable)
- [ ] With `visionMode: "vellum"` and vision provider configured, image/scanned PDF OCR uses workspace vision