### PR TITLE
feat(web): add useChangePackage hook wrapping the change-package mutation

### DIFF
--- a/clients/web/src/domains/settings/billing/use-change-package.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-package.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for `useChangePackage`. The generated change-package mutation and the
+ * three billing query-key factories are `mock.module`-replaced so the hook runs
+ * against a controllable `mutationFn` and sentinel keys; `extractMutationError`
+ * (real) turns a `{ detail }` reject into the toasted message. The seeded
+ * QueryClient uses `staleTime/gcTime: Infinity` + `retry: false` so nothing
+ * refetches over the network during the test.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import type { PackageChangeResponse } from "@/generated/api/types.gen";
+
+// Sentinel query keys let the invalidation assertions match on identity.
+const SUBSCRIPTION_KEY = ["subscription"];
+const PLANS_KEY = ["plans"];
+const ONBOARDING_KEY = ["onboarding"];
+
+// Captures the body posted to `mutateAsync` and lets each test drive the
+// mutation's resolution (resolve a response, or reject to hit the error path).
+const mutationFnCalls: Array<{ body: { package: string } }> = [];
+let mutationImpl: (options: {
+  body: { package: string };
+}) => Promise<PackageChangeResponse>;
+
+mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
+  organizationsBillingSubscriptionChangePackageCreateMutation: () => ({
+    mutationFn: (options: { body: { package: string } }) => {
+      mutationFnCalls.push(options);
+      return mutationImpl(options);
+    },
+  }),
+  organizationsBillingSubscriptionRetrieveQueryKey: () => SUBSCRIPTION_KEY,
+  organizationsBillingPlansRetrieveQueryKey: () => PLANS_KEY,
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey: () =>
+    ONBOARDING_KEY,
+}));
+
+const toastErrorCalls: string[] = [];
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: {
+    error: (message: string) => {
+      toastErrorCalls.push(message);
+    },
+  },
+}));
+
+const { useChangePackage } = await import("./use-change-package");
+
+function okResponse(): PackageChangeResponse {
+  return {
+    status: "ok",
+    package: { key: "ultra", name: "Ultra", version: 1, customized: false },
+  };
+}
+
+/**
+ * Render the hook against a fresh QueryClient and record every key passed to
+ * `invalidateQueries` so the three-key billing invalidation can be asserted.
+ */
+function setup() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        gcTime: Infinity,
+      },
+    },
+  });
+  const invalidatedKeys: unknown[] = [];
+  type InvalidateFn = QueryClient["invalidateQueries"];
+  const originalInvalidate = client.invalidateQueries.bind(client);
+  client.invalidateQueries = ((...args: Parameters<InvalidateFn>) => {
+    invalidatedKeys.push(args[0]?.queryKey);
+    return originalInvalidate(...args);
+  }) as InvalidateFn;
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+  const { result } = renderHook(() => useChangePackage(), { wrapper });
+  return { result, invalidatedKeys };
+}
+
+describe("useChangePackage", () => {
+  beforeEach(() => {
+    mutationFnCalls.length = 0;
+    toastErrorCalls.length = 0;
+    mutationImpl = async () => okResponse();
+  });
+
+  test("posts the package and invalidates the three billing keys on success", async () => {
+    const response = okResponse();
+    mutationImpl = async () => response;
+    const { result, invalidatedKeys } = setup();
+
+    const captured: { value: PackageChangeResponse | null } = { value: null };
+    await act(async () => {
+      captured.value = await result.current.changePackage("ultra");
+    });
+
+    expect(captured.value).toEqual(response);
+    expect(mutationFnCalls).toEqual([{ body: { package: "ultra" } }]);
+    expect(invalidatedKeys).toEqual([SUBSCRIPTION_KEY, PLANS_KEY, ONBOARDING_KEY]);
+    expect(toastErrorCalls).toEqual([]);
+  });
+
+  test("toasts the extracted message and resolves null on error", async () => {
+    mutationImpl = async () => {
+      throw { detail: "Payment failed. Your card was declined." };
+    };
+    const { result, invalidatedKeys } = setup();
+
+    const captured: { value: PackageChangeResponse | null } = {
+      value: okResponse(),
+    };
+    await act(async () => {
+      captured.value = await result.current.changePackage("ultra");
+    });
+
+    expect(captured.value).toBeNull();
+    expect(toastErrorCalls).toEqual([
+      "Payment failed. Your card was declined.",
+    ]);
+    expect(invalidatedKeys).toEqual([]);
+  });
+
+  test("isPending reflects the underlying mutation pending flag", async () => {
+    let release!: (value: PackageChangeResponse) => void;
+    mutationImpl = () =>
+      new Promise<PackageChangeResponse>((resolve) => {
+        release = resolve;
+      });
+    const { result } = setup();
+
+    expect(result.current.isPending).toBe(false);
+
+    let pending: Promise<PackageChangeResponse | null>;
+    act(() => {
+      pending = result.current.changePackage("mighty");
+    });
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+
+    await act(async () => {
+      release(okResponse());
+      await pending;
+    });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+  });
+});

--- a/clients/web/src/domains/settings/billing/use-change-package.ts
+++ b/clients/web/src/domains/settings/billing/use-change-package.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "@vellumai/design-library/components/toast";
+
+import {
+  organizationsBillingPlansRetrieveQueryKey,
+  organizationsBillingSubscriptionChangePackageCreateMutation,
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
+  organizationsBillingSubscriptionRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type { PackageChangeResponse } from "@/generated/api/types.gen";
+
+import { extractMutationError } from "../components/adjust-plan-utils";
+
+/**
+ * Shared wiring for the change-package CTAs (plan-card banner, plans page).
+ * Posts `{ package }` to the change-package endpoint, invalidates the three
+ * billing queries on success (mirrors `adjust-plan-modal`'s
+ * `invalidateBillingQueries`), and surfaces the extracted error — including a
+ * 402 declined-card message — as a toast on failure.
+ */
+export function useChangePackage() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation(
+    organizationsBillingSubscriptionChangePackageCreateMutation(),
+  );
+
+  const changePackage = async (
+    packageKey: string,
+  ): Promise<PackageChangeResponse | null> => {
+    try {
+      const result = await mutation.mutateAsync({
+        body: { package: packageKey },
+      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: organizationsBillingPlansRetrieveQueryKey(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+        }),
+      ]);
+      return result;
+    } catch (error) {
+      toast.error(
+        extractMutationError(error, "Failed to change your plan. Please try again."),
+      );
+      return null;
+    }
+  };
+
+  return { changePackage, isPending: mutation.isPending };
+}


### PR DESCRIPTION
## Summary
- Shared `useChangePackage()` hook: posts `{ package }` to the change-package endpoint, invalidates the three billing query keys on success, and toasts the extracted error (incl. 402) on failure.
- Keeps the two consumer CTAs (plan-card banner, plans page) thin and identical.

Part of plan: change-package-web-wiring.md (PR 2 of 4)