### PR TITLE
feat(web): one-click package upgrade from the plan card

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -223,7 +223,9 @@ function BillingTab() {
             {showPlanManagement && (
                 <FinishProSetupNotice onFinishSetup={openProOnboarding} />
             )}
-            {showPlanManagement && <PlanCard onManage={openPlanModal} />}
+            {showPlanManagement && (
+                <PlanCard onManage={openPlanModal} onTierUpgraded={onTierUpgraded} />
+            )}
             {showPlanManagement && (
                 <AdjustPlanModal open={planModalOpen} onClose={closePlanModal} onTierUpgraded={onTierUpgraded} />
             )}

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -630,6 +630,37 @@ describe("PlanCard recommended upgrade — change-package", () => {
     expect(openedUrl).toBeNull();
   });
 
+  test("a non-entitlement-status Pro sub's recommended upgrade stays on the manage path", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // A packaged, non-customized, non-cancelling Pro sub in a non-entitlement
+    // status (`unpaid`) can't change package — the endpoint 4xxs. The banner CTA
+    // must gate on TIER_CHANGE_ELIGIBLE_STATUSES and fall back to the manage path
+    // instead of confirming a mutation that can only fail.
+    const subscription: SubscriptionResponse = {
+      ...proMightySubscription(),
+      status: "unpaid",
+    };
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    fireEvent.click(await findByTestId("recommended-upgrade-button"));
+
+    await waitFor(() => {
+      expect(onManage).toHaveBeenCalledTimes(1);
+    });
+    // No confirm dialog, no change-package mutation, no navigation.
+    expect(document.querySelector("[data-confirm-dialog-confirm]")).toBeNull();
+    expect(changePackageBody).toBeNull();
+    expect(onTierUpgraded).not.toHaveBeenCalled();
+    expect(navigateArgs).toEqual([]);
+    expect(openedUrl).toBeNull();
+  });
+
   test("a base user's recommended upgrade routes to Stripe checkout", async () => {
     const onTierUpgraded = mock(() => {});
     const { findByTestId } = renderCardInteractive(

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -539,6 +539,35 @@ describe("PlanCard recommended upgrade — change-package", () => {
     });
   });
 
+  test("a package-less Pro sub's recommended upgrade stays on the manage path", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // A legacy/custom Pro sub has no pinned package, so change-package (which
+    // operates only on named packages) can't switch it. The banner CTA must
+    // fall back to the manage path instead of confirming a change to Mighty.
+    const subscription = { ...proMightySubscription(), package: undefined };
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    fireEvent.click(await findByTestId("recommended-upgrade-button"));
+
+    await waitFor(() => {
+      expect(onManage).toHaveBeenCalledTimes(1);
+    });
+    // No confirm dialog, no change-package mutation, no navigation.
+    expect(
+      document.querySelector("[data-confirm-dialog-confirm]"),
+    ).toBeNull();
+    expect(changePackageBody).toBeNull();
+    expect(onTierUpgraded).not.toHaveBeenCalled();
+    expect(navigateArgs).toEqual([]);
+    expect(openedUrl).toBeNull();
+  });
+
   test("a base user's recommended upgrade routes to Stripe checkout", async () => {
     const onTierUpgraded = mock(() => {});
     const { findByTestId } = renderCardInteractive(

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -15,18 +15,27 @@
 import * as reactRouter from "react-router";
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import * as sdkGen from "@/generated/api/sdk.gen";
 import {
   organizationsBillingPlansRetrieveQueryKey,
   organizationsBillingSubscriptionRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type {
+  PackageChangeResponse,
   PlanListResponse,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
+import * as runtimeBrowser from "@/runtime/browser";
 import { routes } from "@/utils/routes";
 
 // Capture navigate() targets so the action-button wiring can be asserted
@@ -43,6 +52,55 @@ mock.module("react-router", () => ({
 mock.module("@/utils/use-bundled-avatar-components", () => ({
   preloadBundledAvatarComponents: () => {},
   useBundledAvatarComponents: () => null,
+}));
+
+// Drive the billing mutations from the SDK boundary (mirrors adjust-plan-modal's
+// harness): capture the request bodies and control each resolution. The retrieve
+// functions back the post-change invalidation refetch so the run stays hermetic.
+type Captured = { body?: unknown };
+let upgradeCall: Captured | null = null;
+let upgradeResponse: Record<string, unknown> = {
+  status: "redirect",
+  checkout_url: "https://checkout.example.com/session",
+};
+let changePackageBody: { package: string } | null = null;
+let changePackageImpl: () => Promise<{
+  data: PackageChangeResponse;
+  response: { ok: boolean };
+}> = async () => ({
+  data: { status: "ok" } as PackageChangeResponse,
+  response: { ok: true },
+});
+let currentSub: SubscriptionResponse = baseSubscription();
+let currentPlans: PlanListResponse = basePlansResponse();
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingSubscriptionUpgradeCreate: (opts: Captured) => {
+    upgradeCall = opts;
+    return Promise.resolve({ data: upgradeResponse, response: { ok: true } });
+  },
+  organizationsBillingSubscriptionChangePackageCreate: (opts: Captured) => {
+    changePackageBody = opts.body as { package: string };
+    return changePackageImpl();
+  },
+  organizationsBillingSubscriptionRetrieve: () =>
+    Promise.resolve({ data: currentSub, response: { ok: true } }),
+  organizationsBillingPlansRetrieve: () =>
+    Promise.resolve({ data: currentPlans, response: { ok: true } }),
+  organizationsBillingSubscriptionOnboardingRetrieve: () =>
+    Promise.resolve({ data: {}, response: { ok: true } }),
+}));
+
+// Capture the Stripe checkout redirect instead of opening a browser.
+let openedUrl: string | null = null;
+mock.module("@/runtime/browser", () => ({
+  ...runtimeBrowser,
+  openUrl: (url: string) => {
+    openedUrl = url;
+    return Promise.resolve();
+  },
+  openUrlFinishedListener: () => () => {},
 }));
 
 const { PlanCard } = await import("./plan-card");
@@ -198,18 +256,44 @@ function renderCardInteractive(
   subscription: SubscriptionResponse,
   plans: PlanListResponse,
   onManage: () => void,
+  onTierUpgraded?: () => void,
 ) {
+  // Back the post-change invalidation refetch with the same fixtures.
+  currentSub = subscription;
+  currentPlans = plans;
   const client = makeClient(subscription, plans);
   // useNavigate is mocked, so no Router wrapper is needed here.
   return render(
     <QueryClientProvider client={client}>
-      <PlanCard onManage={onManage} />
+      <PlanCard onManage={onManage} onTierUpgraded={onTierUpgraded} />
     </QueryClientProvider>,
   );
 }
 
+/** Waits for the ConfirmDialog (portaled to document.body) to open. */
+async function findConfirmDialogButton(): Promise<HTMLButtonElement> {
+  return await waitFor(() => {
+    const btn = document.querySelector<HTMLButtonElement>(
+      "[data-confirm-dialog-confirm]",
+    );
+    if (!btn) throw new Error("confirm dialog not open");
+    return btn;
+  });
+}
+
 beforeEach(() => {
   navigateArgs = [];
+  upgradeCall = null;
+  upgradeResponse = {
+    status: "redirect",
+    checkout_url: "https://checkout.example.com/session",
+  };
+  changePackageBody = null;
+  changePackageImpl = async () => ({
+    data: { status: "ok" } as PackageChangeResponse,
+    response: { ok: true },
+  });
+  openedUrl = null;
 });
 
 afterEach(() => {
@@ -372,6 +456,113 @@ describe("PlanCard action button", () => {
     await waitFor(() => {
       expect(onManage).toHaveBeenCalledTimes(1);
     });
+    expect(navigateArgs).toEqual([]);
+  });
+});
+
+describe("PlanCard recommended upgrade — change-package", () => {
+  test("a Pro user confirms then upgrades in place via change-package", async () => {
+    const onTierUpgraded = mock(() => {});
+    const { findByTestId, findByText } = renderCardInteractive(
+      proMightySubscription(),
+      plansWithSuper(),
+      () => {},
+      onTierUpgraded,
+    );
+
+    // The banner CTA opens a confirm dialog (no immediate mutation).
+    fireEvent.click(await findByTestId("recommended-upgrade-button"));
+    await findByText("You'll be charged the prorated difference now.");
+    expect(changePackageBody).toBeNull();
+
+    // Confirming posts the recommended package key to change-package.
+    fireEvent.click(await findConfirmDialogButton());
+
+    await waitFor(() => {
+      if (!changePackageBody) throw new Error("change-package not called");
+    });
+    expect(changePackageBody).toEqual({ package: "super" });
+
+    // On success the provisioning takeover is triggered — never the plans page.
+    await waitFor(() => {
+      expect(onTierUpgraded).toHaveBeenCalledTimes(1);
+    });
+    expect(navigateArgs).toEqual([]);
+    expect(openedUrl).toBeNull();
+  });
+
+  test("the CTA and confirm button are disabled while change-package is pending", async () => {
+    let release!: (value: {
+      data: PackageChangeResponse;
+      response: { ok: boolean };
+    }) => void;
+    changePackageImpl = () =>
+      new Promise((resolve) => {
+        release = resolve;
+      });
+    const onTierUpgraded = mock(() => {});
+    const { findByTestId } = renderCardInteractive(
+      proMightySubscription(),
+      plansWithSuper(),
+      () => {},
+      onTierUpgraded,
+    );
+
+    fireEvent.click(await findByTestId("recommended-upgrade-button"));
+    fireEvent.click(await findConfirmDialogButton());
+
+    // In-flight: the confirm button and the banner CTA both disable.
+    await waitFor(() => {
+      const confirm = document.querySelector<HTMLButtonElement>(
+        "[data-confirm-dialog-confirm]",
+      );
+      if (!confirm?.disabled) throw new Error("confirm not disabled yet");
+    });
+    const banner = (await findByTestId(
+      "recommended-upgrade-button",
+    )) as HTMLButtonElement;
+    expect(banner.disabled).toBe(true);
+
+    // Resolving completes the flow and raises the takeover.
+    await act(async () => {
+      release({
+        data: {
+          status: "ok",
+          package: { key: "super", name: "Super", version: 1, customized: false },
+        } as PackageChangeResponse,
+        response: { ok: true },
+      });
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(onTierUpgraded).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("a base user's recommended upgrade routes to Stripe checkout", async () => {
+    const onTierUpgraded = mock(() => {});
+    const { findByTestId } = renderCardInteractive(
+      baseSubscription(),
+      basePlansResponse(),
+      () => {},
+      onTierUpgraded,
+    );
+
+    // No confirm dialog for base users — the CTA starts checkout directly.
+    fireEvent.click(await findByTestId("recommended-upgrade-button"));
+
+    await waitFor(() => {
+      if (!openedUrl) throw new Error("checkout not opened");
+    });
+    expect(openedUrl).toBe("https://checkout.example.com/session");
+    expect(upgradeCall?.body).toMatchObject({
+      target_plan_id: "pro",
+      package: "mighty",
+      confirm: true,
+    });
+    // Base users never call change-package or the takeover.
+    expect(changePackageBody).toBeNull();
+    expect(onTierUpgraded).not.toHaveBeenCalled();
     expect(navigateArgs).toEqual([]);
   });
 });

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -568,6 +568,68 @@ describe("PlanCard recommended upgrade — change-package", () => {
     expect(openedUrl).toBeNull();
   });
 
+  test("a customized Pro sub's recommended upgrade stays on the manage path", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // A customized sub's tiers no longer match the stock package, so posting the
+    // next stock package key would use wrong deltas / drop custom line items. The
+    // banner CTA must fall back to the manage path instead of confirming a change.
+    const subscription = proMightySubscription();
+    subscription.package = {
+      key: "mighty",
+      name: "Mighty",
+      version: 1,
+      customized: true,
+    };
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    fireEvent.click(await findByTestId("recommended-upgrade-button"));
+
+    await waitFor(() => {
+      expect(onManage).toHaveBeenCalledTimes(1);
+    });
+    // No confirm dialog, no change-package mutation, no navigation.
+    expect(document.querySelector("[data-confirm-dialog-confirm]")).toBeNull();
+    expect(changePackageBody).toBeNull();
+    expect(onTierUpgraded).not.toHaveBeenCalled();
+    expect(navigateArgs).toEqual([]);
+    expect(openedUrl).toBeNull();
+  });
+
+  test("a cancelling Pro sub's recommended upgrade stays on the manage path", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // A sub pending cancellation 409s on change-package, so the confirm can only
+    // fail. The banner CTA must fall back to the manage path.
+    const subscription = {
+      ...proMightySubscription(),
+      cancel_at_period_end: true,
+    };
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    fireEvent.click(await findByTestId("recommended-upgrade-button"));
+
+    await waitFor(() => {
+      expect(onManage).toHaveBeenCalledTimes(1);
+    });
+    // No confirm dialog, no change-package mutation, no navigation.
+    expect(document.querySelector("[data-confirm-dialog-confirm]")).toBeNull();
+    expect(changePackageBody).toBeNull();
+    expect(onTierUpgraded).not.toHaveBeenCalled();
+    expect(navigateArgs).toEqual([]);
+    expect(openedUrl).toBeNull();
+  });
+
   test("a base user's recommended upgrade routes to Stripe checkout", async () => {
     const onTierUpgraded = mock(() => {});
     const { findByTestId } = renderCardInteractive(

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -10,6 +10,7 @@ import {
     nextPackageUp,
     type ProPackage,
 } from "@/domains/settings/billing/package-types";
+import { useChangePackage } from "@/domains/settings/billing/use-change-package";
 import {
     FREE_STORAGE_GIB,
     PlanTierAvatar,
@@ -34,6 +35,7 @@ import { routes } from "@/utils/routes";
 import type { ButtonProps } from "@vellumai/design-library/components/button";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -67,6 +69,12 @@ const DEFAULT_DISPLAY: PlanDisplay = PLAN_DISPLAY.base;
 
 export interface PlanCardProps {
     onManage: () => void;
+    /**
+     * Raised after a Pro user's in-place package upgrade succeeds — opens the
+     * provisioning takeover (resize modal), the same signal `AdjustPlanModal`
+     * emits after a tier change.
+     */
+    onTierUpgraded?: () => void;
 }
 
 function PlanHeading() {
@@ -155,24 +163,38 @@ interface RecommendedUpgradeProps {
     packages: ProPackage[];
     currentKey: string | null;
     /**
-     * Delegate for subscribers who are already on Pro — the upgrade endpoint
-     * no-ops for active Pro orgs, so package step-ups route to the plan-aware
-     * plans takeover instead. When absent (base plan), the CTA starts the
-     * Stripe package checkout directly.
+     * Whether the org already has a Pro subscription. Pro users change their
+     * package in place (prorated) via the change-package endpoint; base users
+     * go through Stripe checkout.
+     */
+    isProUser: boolean;
+    /**
+     * Base-user delegate. When absent (the base-plan default), the CTA starts
+     * the Stripe package checkout directly. Ignored for Pro users, who confirm
+     * and call change-package in place.
      */
     onUpgrade?: () => void;
+    /**
+     * Opens the provisioning takeover (resize modal) after a Pro user's in-place
+     * package change succeeds — the same signal the tier-change flow raises.
+     */
+    onTierUpgraded?: () => void;
 }
 
 function RecommendedUpgrade({
     packages,
     currentKey,
+    isProUser,
     onUpgrade,
+    onTierUpgraded,
 }: RecommendedUpgradeProps) {
     const queryClient = useQueryClient();
     const upgradeMutation = useMutation(
         organizationsBillingSubscriptionUpgradeCreateMutation(),
     );
+    const { changePackage, isPending: changePending } = useChangePackage();
     const [pending, setPending] = useState(false);
+    const [confirmOpen, setConfirmOpen] = useState(false);
 
     const recommended = nextPackageUp(packages, currentKey);
     if (!recommended) return null;
@@ -187,9 +209,26 @@ function RecommendedUpgrade({
     const upgradeLabel = `Upgrade for ${formatMonthly(deltaCents)} more`;
     const accent = TIER_ACCENT[recommended.key] ?? TIER_ACCENT.free;
     const tint = `color-mix(in srgb, ${accent} 10%, transparent)`;
-    const isPending = pending || upgradeMutation.isPending;
+    const isPending = pending || upgradeMutation.isPending || changePending;
+
+    // Pro users change their package in place: confirm the prorated charge, then
+    // call change-package and hand off to the resize takeover on success. Base
+    // users keep the delegate / Stripe-checkout path.
+    const handleConfirmChange = async () => {
+        const result = await changePackage(recommended.key);
+        if (result) {
+            setConfirmOpen(false);
+            onTierUpgraded?.();
+        }
+        // On a null result the hook already toasted; leave the dialog open so
+        // the user can retry.
+    };
 
     const handleUpgrade = async () => {
+        if (isProUser) {
+            setConfirmOpen(true);
+            return;
+        }
         if (onUpgrade) {
             onUpgrade();
             return;
@@ -306,11 +345,20 @@ function RecommendedUpgrade({
             >
                 {upgradeLabel}
             </Button>
+            <ConfirmDialog
+                open={confirmOpen}
+                title={`Upgrade to ${recommended.name}?`}
+                message="You'll be charged the prorated difference now."
+                confirmLabel="Upgrade"
+                isPending={isPending}
+                onConfirm={handleConfirmChange}
+                onCancel={() => setConfirmOpen(false)}
+            />
         </div>
     );
 }
 
-export function PlanCard({ onManage }: PlanCardProps) {
+export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
     const navigate = useNavigate();
     const subscriptionQuery = useQuery(
         organizationsBillingSubscriptionRetrieveOptions(),
@@ -442,13 +490,8 @@ export function PlanCard({ onManage }: PlanCardProps) {
                     <RecommendedUpgrade
                         packages={packages}
                         currentKey={currentKey}
-                        onUpgrade={
-                            currentPlan.id === "base"
-                                ? undefined
-                                : canOpenPlansTakeover
-                                  ? () => navigate(routes.plans)
-                                  : onManage
-                        }
+                        isProUser={currentPlan.id !== "base"}
+                        onTierUpgraded={onTierUpgraded}
                     />
                 </div>
             </div>

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -175,6 +175,12 @@ interface RecommendedUpgradeProps {
      */
     onUpgrade?: () => void;
     /**
+     * Manage-path delegate (AdjustPlanModal). Used to keep a legacy/custom Pro
+     * sub with no pinned package off the change-package flow, which operates
+     * only on named packages.
+     */
+    onManage: () => void;
+    /**
      * Opens the provisioning takeover (resize modal) after a Pro user's in-place
      * package change succeeds — the same signal the tier-change flow raises.
      */
@@ -186,6 +192,7 @@ function RecommendedUpgrade({
     currentKey,
     isProUser,
     onUpgrade,
+    onManage,
     onTierUpgraded,
 }: RecommendedUpgradeProps) {
     const queryClient = useQueryClient();
@@ -225,6 +232,12 @@ function RecommendedUpgrade({
     };
 
     const handleUpgrade = async () => {
+        // A legacy/custom Pro sub with no package pin can't be package-switched
+        // (change-package operates on named packages); keep it on the manage path.
+        if (isProUser && currentKey === null) {
+            onManage();
+            return;
+        }
         if (isProUser) {
             setConfirmOpen(true);
             return;
@@ -491,6 +504,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
                         packages={packages}
                         currentKey={currentKey}
                         isProUser={currentPlan.id !== "base"}
+                        onManage={onManage}
                         onTierUpgraded={onTierUpgraded}
                     />
                 </div>

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -40,7 +40,10 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
-import { extractMutationError } from "./adjust-plan-utils";
+import {
+    extractMutationError,
+    TIER_CHANGE_ELIGIBLE_STATUSES,
+} from "./adjust-plan-utils";
 import { formatMonthly } from "./tier-pricing";
 
 interface PlanDisplay {
@@ -452,6 +455,9 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
     // sub. A customized sub's tiers no longer match the stock package (posting
     // the next stock key would use wrong deltas / drop custom line items), and a
     // cancelling sub 409s on change-package — both fall back to the manage path.
+    // A sub in a non-entitlement status (`canceled`, `unpaid`, `incomplete`,
+    // `paused`, etc.) can't change package either — gate on the same status set
+    // the tier-change flow uses so the CTA never confirms a mutation that 4xxs.
     const isCancellingSub =
         subscription.cancel_at_period_end === true ||
         Boolean(subscription.cancel_at);
@@ -459,7 +465,9 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
         currentPlan.id !== "base" &&
         subscription.package != null &&
         !subscription.package.customized &&
-        !isCancellingSub;
+        !isCancellingSub &&
+        subscription.status != null &&
+        TIER_CHANGE_ELIGIBLE_STATUSES.has(subscription.status);
 
     return (
         <Card padding="md">

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -169,6 +169,13 @@ interface RecommendedUpgradeProps {
      */
     isProUser: boolean;
     /**
+     * Whether this Pro sub is eligible for a one-click, in-place package switch:
+     * true only for a clean packaged Pro sub (has a package pin, not customized,
+     * not cancelling). Every other Pro state falls back to the manage path.
+     * Meaningless for base users, whose CTA always routes to Stripe checkout.
+     */
+    canChangePackage: boolean;
+    /**
      * Base-user delegate. When absent (the base-plan default), the CTA starts
      * the Stripe package checkout directly. Ignored for Pro users, who confirm
      * and call change-package in place.
@@ -191,6 +198,7 @@ function RecommendedUpgrade({
     packages,
     currentKey,
     isProUser,
+    canChangePackage,
     onUpgrade,
     onManage,
     onTierUpgraded,
@@ -232,9 +240,10 @@ function RecommendedUpgrade({
     };
 
     const handleUpgrade = async () => {
-        // A legacy/custom Pro sub with no package pin can't be package-switched
-        // (change-package operates on named packages); keep it on the manage path.
-        if (isProUser && currentKey === null) {
+        // Only a clean packaged Pro sub (has a package pin, not customized, not
+        // cancelling) can be one-click package-switched; every other Pro state
+        // (package-less/legacy, customized, or cancelling) stays on the manage path.
+        if (isProUser && !canChangePackage) {
             onManage();
             return;
         }
@@ -439,6 +448,18 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
     const canOpenPlansTakeover =
         packages.length > 0 &&
         (currentPlan.id === "base" || subscription.package != null);
+    // A one-click, in-place package switch is safe only for a clean packaged Pro
+    // sub. A customized sub's tiers no longer match the stock package (posting
+    // the next stock key would use wrong deltas / drop custom line items), and a
+    // cancelling sub 409s on change-package — both fall back to the manage path.
+    const isCancellingSub =
+        subscription.cancel_at_period_end === true ||
+        Boolean(subscription.cancel_at);
+    const canChangePackage =
+        currentPlan.id !== "base" &&
+        subscription.package != null &&
+        !subscription.package.customized &&
+        !isCancellingSub;
 
     return (
         <Card padding="md">
@@ -504,6 +525,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
                         packages={packages}
                         currentKey={currentKey}
                         isProUser={currentPlan.id !== "base"}
+                        canChangePackage={canChangePackage}
                         onManage={onManage}
                         onTierUpgraded={onTierUpgraded}
                     />


### PR DESCRIPTION
## Summary
- Pro users' "Upgrade for $X/mo more" now confirms then calls the change-package endpoint directly (prorated charge now), instead of opening the plans takeover.
- Base users keep the direct Stripe checkout; pending/spinner covers the new mutation.

Part of plan: change-package-web-wiring.md (PR 3 of 4)