### PR TITLE
feat(web): one-click package switch (up/down) from the plans page

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
@@ -1,0 +1,85 @@
+import { AlertTriangle } from "lucide-react";
+
+import type { TierRelation } from "@/domains/settings/billing/package-types";
+import { downgradeLabel } from "@/domains/settings/billing/plans/plans-copy";
+import { Button } from "@vellumai/design-library/components/button";
+import { Modal } from "@vellumai/design-library/components/modal";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+export interface PackageSwitchConfirmModalProps {
+  open: boolean;
+  /** How the target relates to the current tier — drives copy and chrome. */
+  relation: Exclude<TierRelation, "current">;
+  /** Target package display name, e.g. "Mighty". */
+  packageName: string;
+  /** A change-package call is in flight — disable the actions. */
+  pending: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+// Package switches apply immediately (no period-end deferral): an upgrade
+// charges the prorated difference now; a downgrade resizes the machine now and
+// nets a prorated credit against the next invoice — storage stays, no cash
+// refund. The copy must not imply the higher tier is kept until month end.
+const DOWNGRADE_NOTE =
+  "Your machine downsizes now and your storage stays. No refund — a prorated credit applies to your next invoice.";
+const UPGRADE_NOTE = "You'll be charged the prorated difference now.";
+
+/**
+ * Reconfirm dialog for a one-click Pro package switch from the plans takeover.
+ * A downgrade gets the AlertTriangle + danger confirm; an upgrade gets a
+ * lighter primary confirm. Layout-only — the parent owns the mutation.
+ */
+export function PackageSwitchConfirmModal({
+  open,
+  relation,
+  packageName,
+  pending,
+  onCancel,
+  onConfirm,
+}: PackageSwitchConfirmModalProps) {
+  const isDowngrade = relation === "downgrade";
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !pending) {
+          onCancel();
+        }
+      }}
+    >
+      <Modal.Content size="md" hideCloseButton>
+        <Modal.Header>
+          <Modal.Title icon={isDowngrade ? AlertTriangle : undefined}>
+            {isDowngrade
+              ? `Downgrade to ${packageName}?`
+              : `Upgrade to ${packageName}?`}
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Typography
+            as="p"
+            variant="body-medium-default"
+            className="text-(--content-secondary)"
+          >
+            {isDowngrade ? DOWNGRADE_NOTE : UPGRADE_NOTE}
+          </Typography>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outlined" onClick={onCancel} disabled={pending}>
+            Cancel
+          </Button>
+          <Button
+            variant={isDowngrade ? "danger" : "primary"}
+            onClick={onConfirm}
+            disabled={pending}
+            data-testid="confirm-package-switch-button"
+          >
+            {isDowngrade ? downgradeLabel(packageName) : `Switch to ${packageName}`}
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -235,20 +235,20 @@ describe("PlansPage checkout — base subscriber", () => {
 });
 
 describe("PlansPage checkout — Pro subscriber", () => {
-  // Below Mighty, Free reads "Downgrade to Free". For a Pro subscriber the
-  // tier CTA routes to the manage-plan flow via `?adjust_plan` and fires no
-  // checkout.
-  test("routes a downgrade CTA to the manage modal instead of a checkout", async () => {
+  // Below Mighty, Free reads "Downgrade to Free". Downgrading a Pro org to the
+  // Free plan is a subscription cancellation, not a package switch — the
+  // change-package endpoint can't express it — so the plans page leaves it a
+  // no-op (cancellation is reached from billing "manage plan"). It must not
+  // navigate to `?adjust_plan` or fire a Stripe checkout. Pro package↔package
+  // switches go through change-package, covered in `plans-page.test.tsx`.
+  test("a Free downgrade CTA is a no-op (no checkout, no navigation)", async () => {
     const { getByRole, getByTestId } = renderPage(proMightySubscription());
 
     fireEvent.click(getByRole("button", { name: "Downgrade to Free" }));
 
-    await waitFor(() => {
-      expect(getByTestId("loc").textContent).toBe(
-        "/assistant/settings/usage?tab=billing&adjust_plan",
-      );
-    });
-    // The upgrade endpoint no-ops for an active Pro org, so no checkout fires.
+    // Give any async effect a chance to run, then assert nothing happened.
+    await Promise.resolve();
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(upgradeCall).toBeNull();
     expect(openedUrl).toBeNull();
     expect(readCheckoutIntent()).toBeNull();

--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -237,18 +237,21 @@ describe("PlansPage checkout — base subscriber", () => {
 describe("PlansPage checkout — Pro subscriber", () => {
   // Below Mighty, Free reads "Downgrade to Free". Downgrading a Pro org to the
   // Free plan is a subscription cancellation, not a package switch — the
-  // change-package endpoint can't express it — so the plans page leaves it a
-  // no-op (cancellation is reached from billing "manage plan"). It must not
-  // navigate to `?adjust_plan` or fire a Stripe checkout. Pro package↔package
-  // switches go through change-package, covered in `plans-page.test.tsx`.
-  test("a Free downgrade CTA is a no-op (no checkout, no navigation)", async () => {
-    const { getByRole, getByTestId } = renderPage(proMightySubscription());
+  // change-package endpoint can't express it — so the plans page routes to the
+  // billing manage/cancel surface (`?adjust_plan`) instead. It must not fire a
+  // Stripe checkout. Pro package↔package switches go through change-package,
+  // covered in `plans-page.test.tsx`.
+  test("a Free downgrade CTA routes to the billing manage/cancel flow (no checkout)", async () => {
+    const { getByRole, findByTestId } = renderPage(proMightySubscription());
 
     fireEvent.click(getByRole("button", { name: "Downgrade to Free" }));
 
-    // Give any async effect a chance to run, then assert nothing happened.
-    await Promise.resolve();
-    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
+    const loc = await findByTestId("loc");
+    await waitFor(() =>
+      expect(loc.textContent).toBe(
+        "/assistant/settings/usage?tab=billing&adjust_plan",
+      ),
+    );
     expect(upgradeCall).toBeNull();
     expect(openedUrl).toBeNull();
     expect(readCheckoutIntent()).toBeNull();

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -461,6 +461,25 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
   });
 
+  test("Pro → Free downgrade routes to the manage/cancel flow, not change-package", async () => {
+    const { findByRole, findByTestId } = renderInteractive(
+      proSuperSubscription(),
+    );
+
+    // Below Super, Free reads "Downgrade to Free". Cancellation can't go through
+    // the package-only change-package endpoint, so it routes to `?adjust_plan`.
+    fireEvent.click(await findByRole("button", { name: "Downgrade to Free" }));
+
+    const loc = await findByTestId("loc");
+    await waitFor(() =>
+      expect(loc.textContent).toBe(
+        "/assistant/settings/usage?tab=billing&adjust_plan",
+      ),
+    );
+    expect(changePackageCall).toBeNull();
+    expect(upgradeCall).toBeNull();
+  });
+
   test("base user CTA starts Stripe checkout, not change-package", async () => {
     const { findByRole } = renderInteractive(freeSubscription());
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -1,25 +1,40 @@
 /**
- * Tests for the PlansPage takeover: verifies the full catalog render (headline,
- * four tier columns, catalog-derived prices/features, CTA labels, custom-plan
- * row, docs footer), the current-plan disabling, and the empty-catalog
- * (`pro-packages` flag off) fallback.
+ * Tests for the PlansPage takeover.
  *
- * Strategy mirrors `plan-card.test.tsx`: seed the React Query cache so the
- * page's `useQuery` calls resolve synchronously — `renderToStaticMarkup` is
- * single-pass, so a pending query would report `isLoading` and render the
- * spinner instead. The page uses no Zustand store (React Query + react-router
- * + local `useState` only), so static markup is a faithful first paint. The
- * avatar compositor loads lazily via `useEffect`, which doesn't fire under
- * `renderToStaticMarkup`, so avatars render as same-size placeholders. The
- * empty-catalog redirect also lives in a `useEffect`, so the pre-redirect
- * markup asserted here is the loading spinner, never the pricing grid.
+ * Two harnesses share this file:
+ *
+ * 1. Static render (`renderStatic`) mirrors `plan-card.test.tsx`: it seeds the
+ *    React Query cache so the page's `useQuery` calls resolve synchronously —
+ *    `renderToStaticMarkup` is single-pass, so a pending query would report
+ *    `isLoading` and render the spinner. Used for the catalog/label/price/
+ *    current-plan/empty-catalog assertions. Avatars and the redirect both live
+ *    in effects (not run by `renderToStaticMarkup`), so the pre-redirect markup
+ *    is faithful.
+ *
+ * 2. Interaction (`renderInteractive`) mirrors `plans-page-checkout.test.tsx`:
+ *    the generated SDK, browser runtime, platform gate, avatar compositor, and
+ *    the provisioning-takeover modal are `mock.module()`'d, and `PlansPage` is
+ *    dynamically imported after the mocks register. Used for the Pro
+ *    change-package switch flow (confirm dialog → change-package → takeover)
+ *    and the base-user Stripe checkout path.
  */
 
-import { describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderToStaticMarkup } from "react-dom/server";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 
+import * as sdkGen from "@/generated/api/sdk.gen";
+import * as browserRuntime from "@/runtime/browser";
+import * as platformGateMod from "@/hooks/use-platform-gate";
 import {
   organizationsBillingPlansRetrieveQueryKey,
   organizationsBillingSubscriptionRetrieveQueryKey,
@@ -30,8 +45,80 @@ import type {
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
 
-import { getPlanTierCopy } from "./plans-copy";
-import { PlansPage } from "./plans-page";
+const CHECKOUT_URL = "https://stripe.test/checkout/session";
+
+type Captured = { body?: unknown };
+let changePackageCall: Captured | null = null;
+let upgradeCall: Captured | null = null;
+let openedUrl: string | null = null;
+// When false, the change-package promise never settles — used to observe the
+// in-flight (pending) disabled state.
+let changePackageAutoResolve = true;
+// Fixtures returned by the mocked read SDK so post-mutation invalidation
+// refetches resolve deterministically instead of hitting the network.
+let subscriptionFixture: SubscriptionResponse | null = null;
+let plansFixture: PlanListResponse | null = null;
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingSubscriptionChangePackageCreate: (opts: Captured) => {
+    changePackageCall = opts;
+    if (!changePackageAutoResolve) {
+      return new Promise(() => {});
+    }
+    return Promise.resolve({
+      data: {
+        status: "ok",
+        package: { key: "mighty", name: "Mighty", version: 1, customized: false },
+      },
+      response: { ok: true },
+    });
+  },
+  organizationsBillingSubscriptionUpgradeCreate: (opts: Captured) => {
+    upgradeCall = opts;
+    return Promise.resolve({
+      data: { status: "redirect", checkout_url: CHECKOUT_URL },
+      response: { ok: true },
+    });
+  },
+  organizationsBillingSubscriptionRetrieve: () =>
+    Promise.resolve({ data: subscriptionFixture, response: { ok: true } }),
+  organizationsBillingPlansRetrieve: () =>
+    Promise.resolve({ data: plansFixture, response: { ok: true } }),
+}));
+
+mock.module("@/runtime/browser", () => ({
+  ...browserRuntime,
+  openUrl: (url: string) => {
+    openedUrl = url;
+    return Promise.resolve();
+  },
+}));
+
+// Force the platform-hosted gate open so the page mounts its pricing body
+// instead of firing the self-hosted / not-ready redirect effect.
+mock.module("@/hooks/use-platform-gate", () => ({
+  ...platformGateMod,
+  usePlatformGate: () => "full",
+  useActiveAssistantIsPlatformHosted: () => true,
+  useActiveAssistantLifecycleIsLoading: () => false,
+}));
+
+// Render avatar placeholders; skip the lazy compositor bundle in the DOM test.
+mock.module("@/utils/use-bundled-avatar-components", () => ({
+  preloadBundledAvatarComponents: () => {},
+  useBundledAvatarComponents: () => null,
+}));
+
+// Stand in for the provisioning takeover so the test can assert it was revealed
+// without driving its own resize queries.
+mock.module("@/domains/settings/components/tier-upgrade-resize-modal", () => ({
+  TierUpgradeResizeModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="resize-takeover" /> : null,
+}));
+
+const { PlansPage } = await import("./plans-page");
+const { getPlanTierCopy } = await import("./plans-copy");
 
 /** A fully-typed Pro package with Mighty defaults; override per tier. */
 function makePackage(overrides: Partial<ProPackage>): ProPackage {
@@ -128,7 +215,24 @@ function proMightySubscription(): SubscriptionResponse {
   };
 }
 
-function renderPage(
+function proSuperSubscription(): SubscriptionResponse {
+  return {
+    plan_id: "pro",
+    status: "active",
+    renewal_date: null,
+    current_period_end: "2026-07-10T00:00:00Z",
+    cancel_at_period_end: false,
+    cancel_at: null,
+    package: { key: "super", name: "Super", version: 1, customized: false },
+    entitlements: { managed_email: false, phone_number: false },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Static-render harness
+// ---------------------------------------------------------------------------
+
+function renderStatic(
   subscription: SubscriptionResponse,
   plans: PlanListResponse,
 ): string {
@@ -156,7 +260,7 @@ function count(html: string, needle: RegExp): number {
 
 describe("PlansPage — full catalog render", () => {
   test("renders the headline and all four tier names", () => {
-    const html = renderPage(freeSubscription(), fullCatalog());
+    const html = renderStatic(freeSubscription(), fullCatalog());
     expect(html).toContain("Plans designed to empower you");
     expect(html).toContain("Free");
     expect(html).toContain("Mighty");
@@ -165,7 +269,7 @@ describe("PlansPage — full catalog render", () => {
   });
 
   test("formats prices from the catalog totals (and $0 for free)", () => {
-    const html = renderPage(freeSubscription(), fullCatalog());
+    const html = renderStatic(freeSubscription(), fullCatalog());
     expect(html).toContain("$0/month");
     expect(html).toContain("$30/month");
     expect(html).toContain("$100/month");
@@ -173,14 +277,14 @@ describe("PlansPage — full catalog render", () => {
   });
 
   test("shows the Most Popular badge exactly once", () => {
-    const html = renderPage(freeSubscription(), fullCatalog());
+    const html = renderStatic(freeSubscription(), fullCatalog());
     // The badge text is "Most Popular"; the all-caps look is CSS `uppercase`,
     // which renderToStaticMarkup does not apply.
     expect(count(html, /Most Popular/g)).toBe(1);
   });
 
   test("derives feature rows from the fixture (storage, credits, machine)", () => {
-    const html = renderPage(freeSubscription(), fullCatalog());
+    const html = renderStatic(freeSubscription(), fullCatalog());
     // Storage rows.
     expect(html).toContain("10 GiB Storage");
     expect(html).toContain("25 GiB Storage");
@@ -198,20 +302,20 @@ describe("PlansPage — full catalog render", () => {
   });
 
   test("uses the correct 'Includes:' label (not the Figma typo)", () => {
-    const html = renderPage(freeSubscription(), fullCatalog());
+    const html = renderStatic(freeSubscription(), fullCatalog());
     expect(html).toContain("Includes:");
     expect(html).not.toContain("Inlcudes:");
   });
 
   test("renders the per-tier CTA labels", () => {
-    const html = renderPage(freeSubscription(), fullCatalog());
+    const html = renderStatic(freeSubscription(), fullCatalog());
     expect(html).toContain("Power Up");
     expect(html).toContain("Go Super");
     expect(html).toContain("Unleash Ultra");
   });
 
   test("renders the custom-plan row and docs footer", () => {
-    const html = renderPage(freeSubscription(), fullCatalog());
+    const html = renderStatic(freeSubscription(), fullCatalog());
     expect(html).toContain("Custom Plan");
     expect(html).toContain("Configure");
     expect(html).toContain("Billed monthly");
@@ -221,7 +325,7 @@ describe("PlansPage — full catalog render", () => {
 
 describe("PlansPage — current-plan state", () => {
   test("free subscriber: Free is the current (disabled) plan, no Start Free", () => {
-    const html = renderPage(freeSubscription(), fullCatalog());
+    const html = renderStatic(freeSubscription(), fullCatalog());
     expect(html).toContain("Current Plan");
     // The Free card swaps its "Start Free" CTA for the current-plan label.
     expect(html).not.toContain("Start Free");
@@ -231,7 +335,7 @@ describe("PlansPage — current-plan state", () => {
   });
 
   test("pro subscriber on Mighty: Mighty is current, lower tiers downgrade, higher tiers upgrade", () => {
-    const html = renderPage(proMightySubscription(), fullCatalog());
+    const html = renderStatic(proMightySubscription(), fullCatalog());
     // Only the Mighty column is the current plan.
     expect(count(html, /Current Plan/g)).toBe(1);
     // Free sits below Mighty, so its CTA becomes a downgrade.
@@ -248,7 +352,7 @@ describe("PlansPage — empty catalog (pro-packages flag off)", () => {
   test("renders the loading fallback, not the pricing grid", () => {
     // The redirect fires in a useEffect (not run by renderToStaticMarkup), so
     // the pre-redirect markup is the loading spinner.
-    const html = renderPage(freeSubscription(), plansWith([]));
+    const html = renderStatic(freeSubscription(), plansWith([]));
     expect(html).toContain("Loading plans");
     expect(html).not.toContain("Plans designed to empower you");
     expect(html).not.toContain("Mighty");
@@ -266,5 +370,123 @@ describe("getPlanTierCopy", () => {
 
   test("returns undefined for an unknown tier key", () => {
     expect(getPlanTierCopy("nonexistent")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Interaction harness — Pro change-package switch + base-user checkout
+// ---------------------------------------------------------------------------
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="loc">{location.pathname + location.search}</div>;
+}
+
+function renderInteractive(subscription: SubscriptionResponse) {
+  subscriptionFixture = subscription;
+  plansFixture = fullCatalog();
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: Infinity,
+        retry: false,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        gcTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(
+    organizationsBillingSubscriptionRetrieveQueryKey(),
+    subscription,
+  );
+  client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), fullCatalog());
+  return render(
+    <MemoryRouter initialEntries={["/assistant/plans"]}>
+      <QueryClientProvider client={client}>
+        <PlansPage />
+      </QueryClientProvider>
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  changePackageCall = null;
+  upgradeCall = null;
+  openedUrl = null;
+  changePackageAutoResolve = true;
+  subscriptionFixture = null;
+  plansFixture = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PlansPage — Pro package switch (change-package)", () => {
+  test("Super → Mighty downgrade confirms, then calls change-package and reveals the takeover", async () => {
+    const { findByRole, findByTestId, getByTestId } = renderInteractive(
+      proSuperSubscription(),
+    );
+
+    // Click the Mighty column's downgrade CTA (below Super).
+    fireEvent.click(await findByRole("button", { name: "Downgrade to Mighty" }));
+
+    // The reconfirm dialog appears; confirm it.
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+
+    await waitFor(() => expect(changePackageCall).not.toBeNull());
+    expect(changePackageCall!.body).toEqual({ package: "mighty" });
+
+    // The provisioning takeover is revealed in-tab; no `?adjust_plan` navigation.
+    await findByTestId("resize-takeover");
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("Super → Ultra upgrade confirms, then calls change-package with the ultra key", async () => {
+    const { findByRole, findByTestId, getByTestId } = renderInteractive(
+      proSuperSubscription(),
+    );
+
+    // The Ultra column keeps its upgrade CTA copy ("Unleash Ultra").
+    fireEvent.click(await findByRole("button", { name: "Unleash Ultra" }));
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+
+    await waitFor(() => expect(changePackageCall).not.toBeNull());
+    expect(changePackageCall!.body).toEqual({ package: "ultra" });
+
+    await findByTestId("resize-takeover");
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
+  });
+
+  test("base user CTA starts Stripe checkout, not change-package", async () => {
+    const { findByRole } = renderInteractive(freeSubscription());
+
+    fireEvent.click(await findByRole("button", { name: "Go Super" }));
+
+    await waitFor(() => expect(upgradeCall).not.toBeNull());
+    expect(upgradeCall!.body).toMatchObject({
+      target_plan_id: "pro",
+      package: "super",
+      confirm: true,
+    });
+    await waitFor(() => expect(openedUrl).toBe(CHECKOUT_URL));
+    expect(changePackageCall).toBeNull();
+  });
+
+  test("the confirm CTA is disabled while a switch is pending", async () => {
+    changePackageAutoResolve = false;
+    const { findByRole, findByTestId } = renderInteractive(proSuperSubscription());
+
+    fireEvent.click(await findByRole("button", { name: "Downgrade to Mighty" }));
+    const confirm = (await findByTestId(
+      "confirm-package-switch-button",
+    )) as HTMLButtonElement;
+    fireEvent.click(confirm);
+
+    await waitFor(() => expect(confirm.disabled).toBe(true));
+    expect(changePackageCall).not.toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -214,10 +214,16 @@ export function PlansPage() {
 
     const selectTier = (tierKey: string) => {
       if (isProUser) {
+        if (tierKey === "free") {
+          // Pro → Free is a subscription cancellation, not a package switch;
+          // route to the billing manage/cancel surface rather than the
+          // (package-only) change-package endpoint, which 400s on non-package
+          // keys.
+          navigate(`${routes.settings.usage}?tab=billing&adjust_plan`);
+          return;
+        }
         // Active Pro orgs switch packages in place via the change-package
-        // endpoint (up or down). Only the named Pro packages route here; the
-        // Free column is a subscription cancellation, not a package switch, so
-        // it stays a no-op (reachable from billing "manage plan").
+        // endpoint (up or down). Only the named Pro packages route here.
         const pkg = packages.find((p) => p.key === tierKey);
         if (!pkg) {
           return;

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -15,12 +15,15 @@ import {
   type CustomPlanSelection,
 } from "@/domains/settings/billing/plans/custom-plan-modal";
 import { CustomPlanRow } from "@/domains/settings/billing/plans/custom-plan-row";
+import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import { PlanColumnCard } from "@/domains/settings/billing/plans/plan-column-card";
 import {
   downgradeLabel,
   getPlanTierCopy,
 } from "@/domains/settings/billing/plans/plans-copy";
+import { useChangePackage } from "@/domains/settings/billing/use-change-package";
 import { extractMutationError } from "@/domains/settings/components/adjust-plan-utils";
+import { TierUpgradeResizeModal } from "@/domains/settings/components/tier-upgrade-resize-modal";
 import { formatDollars } from "@/domains/settings/components/tier-pricing";
 import {
   organizationsBillingPlansRetrieveOptions,
@@ -120,8 +123,16 @@ export function PlansPage() {
   const upgradeMutation = useMutation(
     organizationsBillingSubscriptionUpgradeCreateMutation(),
   );
+  const { changePackage, isPending: changePackagePending } = useChangePackage();
   const [pending, setPending] = useState(false);
   const [customPlanOpen, setCustomPlanOpen] = useState(false);
+  // The package a Pro user is switching to, awaiting reconfirm; null when the
+  // dialog is closed.
+  const [switchTarget, setSwitchTarget] = useState<ProPackage | null>(null);
+  // Reveals the in-tab provisioning takeover after a successful switch — the
+  // same `TierUpgradeResizeModal` surface the tier-change flow opens via
+  // `onTierUpgraded` (see billing-page.tsx), reused here rather than reinvented.
+  const [resizeTakeoverOpen, setResizeTakeoverOpen] = useState(false);
 
   const subscription = subscriptionQuery.data;
   const proPlan = plansQuery.data?.plans.find(
@@ -203,10 +214,18 @@ export function PlansPage() {
 
     const selectTier = (tierKey: string) => {
       if (isProUser) {
-        // The upgrade endpoint no-ops for an active Pro org, so plan changes
-        // for existing subscribers go through the billing "manage plan" modal,
-        // which auto-opens on the `adjust_plan` param.
-        navigate(`${routes.settings.usage}?tab=billing&adjust_plan`);
+        // Active Pro orgs switch packages in place via the change-package
+        // endpoint (up or down). Only the named Pro packages route here; the
+        // Free column is a subscription cancellation, not a package switch, so
+        // it stays a no-op (reachable from billing "manage plan").
+        const pkg = packages.find((p) => p.key === tierKey);
+        if (!pkg) {
+          return;
+        }
+        if (tierRelation(currentTierKey, pkg.key) === "current") {
+          return;
+        }
+        setSwitchTarget(pkg);
         return;
       }
       if (tierKey === "free") {
@@ -220,6 +239,24 @@ export function PlansPage() {
         confirm: true,
       });
     };
+
+    const confirmSwitch = async () => {
+      if (!switchTarget) {
+        return;
+      }
+      const result = await changePackage(switchTarget.key);
+      setSwitchTarget(null);
+      // A non-null result means the switch applied; reveal the provisioning
+      // takeover so the user can resize into the new tier. On null the hook
+      // already toasted the error, so do nothing.
+      if (result) {
+        setResizeTakeoverOpen(true);
+      }
+    };
+
+    const switchRelation = switchTarget
+      ? tierRelation(currentTierKey, switchTarget.key)
+      : "upgrade";
 
     const startCustomCheckout = (selection: CustomPlanSelection) =>
       startCheckout({
@@ -287,7 +324,7 @@ export function PlansPage() {
             tone="dark"
             isCurrent={currentTierKey === "free"}
             intent={freeRelation}
-            pending={pending}
+            pending={pending || changePackagePending}
             onCta={() => selectTier("free")}
           />
           {orderedPackages.map((pkg) => {
@@ -311,7 +348,7 @@ export function PlansPage() {
                 tone={copy?.mostPopular ? "light" : "dark"}
                 isCurrent={currentTierKey === pkg.key}
                 intent={relation}
-                pending={pending}
+                pending={pending || changePackagePending}
                 onCta={() => selectTier(pkg.key)}
               />
             );
@@ -326,6 +363,20 @@ export function PlansPage() {
           pending={pending}
           onClose={() => setCustomPlanOpen(false)}
           onContinue={(selection) => void startCustomCheckout(selection)}
+        />
+
+        <PackageSwitchConfirmModal
+          open={switchTarget !== null}
+          relation={switchRelation === "downgrade" ? "downgrade" : "upgrade"}
+          packageName={switchTarget?.name ?? ""}
+          pending={changePackagePending}
+          onCancel={() => setSwitchTarget(null)}
+          onConfirm={() => void confirmSwitch()}
+        />
+
+        <TierUpgradeResizeModal
+          open={resizeTakeoverOpen}
+          onClose={() => setResizeTakeoverOpen(false)}
         />
 
         <p className="mt-10 text-center text-[12px] font-medium text-[var(--content-tertiary)]">


### PR DESCRIPTION
## Summary
- Pro users' "Downgrade to _" and cross-package upgrade CTAs on the plans page now confirm then call the change-package endpoint directly, instead of routing to `?adjust_plan`.
- Immediate application, no cash refund (prorated credit next invoice); downgrades stay visible; base users keep Stripe checkout.

Part of plan: change-package-web-wiring.md (PR 4 of 4)