### PR TITLE
fix: change-package self-review gaps (eligibility symmetry, no_op, error handling, dedup)

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -27,7 +27,7 @@ import {
   mock,
   test,
 } from "bun:test";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter, useLocation } from "react-router";
@@ -40,6 +40,7 @@ import {
   organizationsBillingSubscriptionRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type {
+  PackageChangeResponse,
   PlanListResponse,
   ProPackage,
   SubscriptionResponse,
@@ -54,6 +55,15 @@ let openedUrl: string | null = null;
 // When false, the change-package promise never settles — used to observe the
 // in-flight (pending) disabled state.
 let changePackageAutoResolve = true;
+// The data the mocked change-package resolves with; a test flips `status` to
+// `no_op` to exercise the already-on-this-plan branch. Default is a clean switch.
+let changePackageData: PackageChangeResponse = {
+  status: "ok",
+  package: { key: "mighty", name: "Mighty", version: 1, customized: false },
+};
+// When non-null the change-package call rejects with this — drives the error
+// path (the hook toasts and resolves null, so the confirm dialog stays open).
+let changePackageError: unknown = null;
 // Fixtures returned by the mocked read SDK so post-mutation invalidation
 // refetches resolve deterministically instead of hitting the network.
 let subscriptionFixture: SubscriptionResponse | null = null;
@@ -66,11 +76,11 @@ mock.module("@/generated/api/sdk.gen", () => ({
     if (!changePackageAutoResolve) {
       return new Promise(() => {});
     }
+    if (changePackageError !== null) {
+      return Promise.reject(changePackageError);
+    }
     return Promise.resolve({
-      data: {
-        status: "ok",
-        package: { key: "mighty", name: "Mighty", version: 1, customized: false },
-      },
+      data: changePackageData,
       response: { ok: true },
     });
   },
@@ -416,6 +426,11 @@ beforeEach(() => {
   upgradeCall = null;
   openedUrl = null;
   changePackageAutoResolve = true;
+  changePackageData = {
+    status: "ok",
+    package: { key: "mighty", name: "Mighty", version: 1, customized: false },
+  };
+  changePackageError = null;
   subscriptionFixture = null;
   plansFixture = null;
 });
@@ -508,4 +523,81 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     await waitFor(() => expect(confirm.disabled).toBe(true));
     expect(changePackageCall).not.toBeNull();
   });
+
+  test("a no_op result closes the dialog without opening the takeover", async () => {
+    changePackageData = {
+      status: "no_op",
+      package: { key: "ultra", name: "Ultra", version: 1, customized: false },
+    };
+    const { findByRole, findByTestId, queryByTestId } = renderInteractive(
+      proSuperSubscription(),
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Unleash Ultra" }));
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+
+    await waitFor(() => expect(changePackageCall).not.toBeNull());
+    // no_op means the org is already on that package: the confirm dialog closes
+    // but the provisioning takeover never opens.
+    await waitFor(() =>
+      expect(queryByTestId("confirm-package-switch-button")).toBeNull(),
+    );
+    expect(queryByTestId("resize-takeover")).toBeNull();
+  });
+
+  test("a failed switch keeps the confirm dialog open for retry", async () => {
+    changePackageError = { detail: "Payment failed. Your card was declined." };
+    const { findByRole, findByTestId, queryByTestId } = renderInteractive(
+      proSuperSubscription(),
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Downgrade to Mighty" }));
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+
+    await waitFor(() => expect(changePackageCall).not.toBeNull());
+    // Flush the rejected mutation so any erroneous close would have committed.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // The dialog stays open (the hook already toasted); the takeover never opens.
+    expect(queryByTestId("confirm-package-switch-button")).not.toBeNull();
+    expect(queryByTestId("resize-takeover")).toBeNull();
+  });
+});
+
+// A Pro sub that isn't cleanly packaged (customized, cancelling, or in a
+// non-entitlement status) can't switch in place — the change-package endpoint
+// would 4xx. Clicking a package CTA must route it to the billing manage/cancel
+// surface (`?adjust_plan`) instead of posting change-package, matching the
+// plan-card banner's fallback.
+describe("PlansPage — ineligible Pro subs route to manage", () => {
+  const ineligible: Array<[string, SubscriptionResponse]> = [
+    [
+      "customized",
+      {
+        ...proMightySubscription(),
+        package: { key: "mighty", name: "Mighty", version: 1, customized: true },
+      },
+    ],
+    ["cancelling", { ...proMightySubscription(), cancel_at_period_end: true }],
+    ["non-entitlement status", { ...proMightySubscription(), status: "unpaid" }],
+  ];
+
+  for (const [label, subscription] of ineligible) {
+    test(`a ${label} Pro sub's package CTA routes to manage, not change-package`, async () => {
+      const { findByRole, findByTestId } = renderInteractive(subscription);
+
+      // From Mighty, "Go Super" is the Super column's upgrade CTA.
+      fireEvent.click(await findByRole("button", { name: "Go Super" }));
+
+      const loc = await findByTestId("loc");
+      await waitFor(() =>
+        expect(loc.textContent).toBe(
+          "/assistant/settings/usage?tab=billing&adjust_plan",
+        ),
+      );
+      expect(changePackageCall).toBeNull();
+      expect(upgradeCall).toBeNull();
+    });
+  }
 });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -22,7 +22,10 @@ import {
   getPlanTierCopy,
 } from "@/domains/settings/billing/plans/plans-copy";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
-import { extractMutationError } from "@/domains/settings/components/adjust-plan-utils";
+import {
+  extractMutationError,
+  isPackageSwitchEligible,
+} from "@/domains/settings/components/adjust-plan-utils";
 import { TierUpgradeResizeModal } from "@/domains/settings/components/tier-upgrade-resize-modal";
 import { formatDollars } from "@/domains/settings/components/tier-pricing";
 import {
@@ -231,6 +234,14 @@ export function PlansPage() {
         if (tierRelation(currentTierKey, pkg.key) === "current") {
           return;
         }
+        // Only a clean packaged Pro sub can switch in place. A customized,
+        // cancelling, or non-entitlement-status sub can't — route it to the
+        // billing manage/cancel surface instead of posting a change-package that
+        // can only fail (the same fallback the Pro → Free case uses).
+        if (!isPackageSwitchEligible(subscription)) {
+          navigate(`${routes.settings.usage}?tab=billing&adjust_plan`);
+          return;
+        }
         setSwitchTarget(pkg);
         return;
       }
@@ -251,12 +262,19 @@ export function PlansPage() {
         return;
       }
       const result = await changePackage(switchTarget.key);
+      if (!result) {
+        // The hook already toasted; keep the confirm dialog open so the user
+        // can retry.
+        return;
+      }
       setSwitchTarget(null);
-      // A non-null result means the switch applied; reveal the provisioning
-      // takeover so the user can resize into the new tier. On null the hook
-      // already toasted the error, so do nothing.
-      if (result) {
+      if (result.status === "ok") {
+        // The switch applied; reveal the provisioning takeover so the user can
+        // resize into the new tier.
         setResizeTakeoverOpen(true);
+      } else {
+        // no_op: already on this package — nothing to provision.
+        toast.success("You're already on this plan.");
       }
     };
 

--- a/clients/web/src/domains/settings/billing/use-change-package.ts
+++ b/clients/web/src/domains/settings/billing/use-change-package.ts
@@ -9,7 +9,7 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { PackageChangeResponse } from "@/generated/api/types.gen";
 
-import { extractMutationError } from "../components/adjust-plan-utils";
+import { extractMutationError } from "@/domains/settings/components/adjust-plan-utils";
 
 /**
  * Shared wiring for the change-package CTAs (plan-card banner, plans page).

--- a/clients/web/src/domains/settings/components/adjust-plan-utils.ts
+++ b/clients/web/src/domains/settings/components/adjust-plan-utils.ts
@@ -22,9 +22,9 @@ export const TIER_CHANGE_ELIGIBLE_STATUSES: ReadonlySet<SubscriptionStatusEnum> 
 /**
  * Whether a subscription is eligible for a one-click, in-place package switch
  * via the change-package endpoint. True only for a clean packaged Pro sub: it
- * has a package pin, is not customized (customized tiers no longer match the
- * stock package, so posting the next stock key would use wrong deltas / drop
- * custom line items), is not cancelling (a cancelling sub 409s on
+ * has a package pin, is not customized (a customized sub's tiers can diverge
+ * from the stock package, so posting the next stock key would use wrong deltas
+ * / drop custom line items), is not cancelling (a cancelling sub 409s on
  * change-package), and sits in an entitlement-bearing status. Every other Pro
  * state — and every base sub — falls back to the manage path.
  *

--- a/clients/web/src/domains/settings/components/adjust-plan-utils.ts
+++ b/clients/web/src/domains/settings/components/adjust-plan-utils.ts
@@ -3,6 +3,7 @@ import type {
     CreditTierEnum,
     MachineTier,
     StorageTier,
+    SubscriptionResponse,
     SubscriptionStatusEnum,
 } from "@/generated/api/types.gen";
 import { isTierDisabled } from "./tier-picker";
@@ -19,6 +20,32 @@ export const TIER_CHANGE_ELIGIBLE_STATUSES: ReadonlySet<SubscriptionStatusEnum> 
   new Set<SubscriptionStatusEnum>(["active", "trialing", "past_due"]);
 
 /**
+ * Whether a subscription is eligible for a one-click, in-place package switch
+ * via the change-package endpoint. True only for a clean packaged Pro sub: it
+ * has a package pin, is not customized (customized tiers no longer match the
+ * stock package, so posting the next stock key would use wrong deltas / drop
+ * custom line items), is not cancelling (a cancelling sub 409s on
+ * change-package), and sits in an entitlement-bearing status. Every other Pro
+ * state — and every base sub — falls back to the manage path.
+ *
+ * Shared by both change-package surfaces (plan-card banner, plans takeover) so
+ * the eligibility gate stays symmetric across them.
+ */
+export function isPackageSwitchEligible(
+  subscription: SubscriptionResponse,
+): boolean {
+  return (
+    subscription.plan_id !== "base" &&
+    subscription.package != null &&
+    !subscription.package.customized &&
+    subscription.cancel_at_period_end !== true &&
+    !subscription.cancel_at &&
+    subscription.status != null &&
+    TIER_CHANGE_ELIGIBLE_STATUSES.has(subscription.status)
+  );
+}
+
+/**
  * Extract a user-facing message from a subscription mutation error.
  *
  * DRF field errors arrive as `{ field_name: [message, ...] }`; we probe the
@@ -30,6 +57,7 @@ const DRF_FIELD_KEYS = [
   "machine_tier",
   "storage_tier",
   "credit_tier",
+  "package",
   "non_field_errors",
 ] as const;
 

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -279,7 +279,9 @@ async function findConfirmDialogButton(): Promise<HTMLButtonElement> {
     const btn = document.querySelector<HTMLButtonElement>(
       "[data-testid='confirm-package-switch-button']",
     );
-    if (!btn) throw new Error("confirm dialog not open");
+    if (!btn) {
+      throw new Error("confirm dialog not open");
+    }
     return btn;
   });
 }
@@ -485,7 +487,9 @@ describe("PlanCard recommended upgrade — change-package", () => {
     fireEvent.click(await findConfirmDialogButton());
 
     await waitFor(() => {
-      if (!changePackageBody) throw new Error("change-package not called");
+      if (!changePackageBody) {
+        throw new Error("change-package not called");
+      }
     });
     expect(changePackageBody).toEqual({ package: "super" });
 
@@ -522,7 +526,9 @@ describe("PlanCard recommended upgrade — change-package", () => {
       const confirm = document.querySelector<HTMLButtonElement>(
         "[data-testid='confirm-package-switch-button']",
       );
-      if (!confirm?.disabled) throw new Error("confirm not disabled yet");
+      if (!confirm?.disabled) {
+        throw new Error("confirm not disabled yet");
+      }
     });
     const banner = (await findByTestId(
       "recommended-upgrade-button",
@@ -565,7 +571,9 @@ describe("PlanCard recommended upgrade — change-package", () => {
     fireEvent.click(await findConfirmDialogButton());
 
     await waitFor(() => {
-      if (!changePackageBody) throw new Error("change-package not called");
+      if (!changePackageBody) {
+        throw new Error("change-package not called");
+      }
     });
     // no_op: the sub is already on this package, so the confirm dismisses and
     // the provisioning takeover is never raised.
@@ -712,7 +720,9 @@ describe("PlanCard recommended upgrade — change-package", () => {
     fireEvent.click(await findByTestId("recommended-upgrade-button"));
 
     await waitFor(() => {
-      if (!openedUrl) throw new Error("checkout not opened");
+      if (!openedUrl) {
+        throw new Error("checkout not opened");
+      }
     });
     expect(openedUrl).toBe("https://checkout.example.com/session");
     expect(upgradeCall?.body).toMatchObject({

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -68,7 +68,10 @@ let changePackageImpl: () => Promise<{
   data: PackageChangeResponse;
   response: { ok: boolean };
 }> = async () => ({
-  data: { status: "ok" } as PackageChangeResponse,
+  data: {
+    status: "ok",
+    package: { key: "super", name: "Super", version: 1, customized: false },
+  },
   response: { ok: true },
 });
 let currentSub: SubscriptionResponse = baseSubscription();
@@ -270,11 +273,11 @@ function renderCardInteractive(
   );
 }
 
-/** Waits for the ConfirmDialog (portaled to document.body) to open. */
+/** Waits for the PackageSwitchConfirmModal (portaled) to open. */
 async function findConfirmDialogButton(): Promise<HTMLButtonElement> {
   return await waitFor(() => {
     const btn = document.querySelector<HTMLButtonElement>(
-      "[data-confirm-dialog-confirm]",
+      "[data-testid='confirm-package-switch-button']",
     );
     if (!btn) throw new Error("confirm dialog not open");
     return btn;
@@ -290,7 +293,10 @@ beforeEach(() => {
   };
   changePackageBody = null;
   changePackageImpl = async () => ({
-    data: { status: "ok" } as PackageChangeResponse,
+    data: {
+      status: "ok",
+      package: { key: "super", name: "Super", version: 1, customized: false },
+    },
     response: { ok: true },
   });
   openedUrl = null;
@@ -514,7 +520,7 @@ describe("PlanCard recommended upgrade — change-package", () => {
     // In-flight: the confirm button and the banner CTA both disable.
     await waitFor(() => {
       const confirm = document.querySelector<HTMLButtonElement>(
-        "[data-confirm-dialog-confirm]",
+        "[data-testid='confirm-package-switch-button']",
       );
       if (!confirm?.disabled) throw new Error("confirm not disabled yet");
     });
@@ -539,6 +545,38 @@ describe("PlanCard recommended upgrade — change-package", () => {
     });
   });
 
+  test("a no_op change-package result dismisses the confirm without the takeover", async () => {
+    changePackageImpl = async () => ({
+      data: {
+        status: "no_op",
+        package: { key: "super", name: "Super", version: 1, customized: false },
+      },
+      response: { ok: true },
+    });
+    const onTierUpgraded = mock(() => {});
+    const { findByTestId } = renderCardInteractive(
+      proMightySubscription(),
+      plansWithSuper(),
+      () => {},
+      onTierUpgraded,
+    );
+
+    fireEvent.click(await findByTestId("recommended-upgrade-button"));
+    fireEvent.click(await findConfirmDialogButton());
+
+    await waitFor(() => {
+      if (!changePackageBody) throw new Error("change-package not called");
+    });
+    // no_op: the sub is already on this package, so the confirm dismisses and
+    // the provisioning takeover is never raised.
+    await waitFor(() => {
+      expect(
+        document.querySelector("[data-testid='confirm-package-switch-button']"),
+      ).toBeNull();
+    });
+    expect(onTierUpgraded).not.toHaveBeenCalled();
+  });
+
   test("a package-less Pro sub's recommended upgrade stays on the manage path", async () => {
     const onManage = mock(() => {});
     const onTierUpgraded = mock(() => {});
@@ -560,7 +598,7 @@ describe("PlanCard recommended upgrade — change-package", () => {
     });
     // No confirm dialog, no change-package mutation, no navigation.
     expect(
-      document.querySelector("[data-confirm-dialog-confirm]"),
+      document.querySelector("[data-testid='confirm-package-switch-button']"),
     ).toBeNull();
     expect(changePackageBody).toBeNull();
     expect(onTierUpgraded).not.toHaveBeenCalled();
@@ -594,7 +632,7 @@ describe("PlanCard recommended upgrade — change-package", () => {
       expect(onManage).toHaveBeenCalledTimes(1);
     });
     // No confirm dialog, no change-package mutation, no navigation.
-    expect(document.querySelector("[data-confirm-dialog-confirm]")).toBeNull();
+    expect(document.querySelector("[data-testid='confirm-package-switch-button']")).toBeNull();
     expect(changePackageBody).toBeNull();
     expect(onTierUpgraded).not.toHaveBeenCalled();
     expect(navigateArgs).toEqual([]);
@@ -623,7 +661,7 @@ describe("PlanCard recommended upgrade — change-package", () => {
       expect(onManage).toHaveBeenCalledTimes(1);
     });
     // No confirm dialog, no change-package mutation, no navigation.
-    expect(document.querySelector("[data-confirm-dialog-confirm]")).toBeNull();
+    expect(document.querySelector("[data-testid='confirm-package-switch-button']")).toBeNull();
     expect(changePackageBody).toBeNull();
     expect(onTierUpgraded).not.toHaveBeenCalled();
     expect(navigateArgs).toEqual([]);
@@ -654,7 +692,7 @@ describe("PlanCard recommended upgrade — change-package", () => {
       expect(onManage).toHaveBeenCalledTimes(1);
     });
     // No confirm dialog, no change-package mutation, no navigation.
-    expect(document.querySelector("[data-confirm-dialog-confirm]")).toBeNull();
+    expect(document.querySelector("[data-testid='confirm-package-switch-button']")).toBeNull();
     expect(changePackageBody).toBeNull();
     expect(onTierUpgraded).not.toHaveBeenCalled();
     expect(navigateArgs).toEqual([]);

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -11,6 +11,7 @@ import {
     type ProPackage,
 } from "@/domains/settings/billing/package-types";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
+import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import {
     FREE_STORAGE_GIB,
     PlanTierAvatar,
@@ -35,14 +36,13 @@ import { routes } from "@/utils/routes";
 import type { ButtonProps } from "@vellumai/design-library/components/button";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
-import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 import {
     extractMutationError,
-    TIER_CHANGE_ELIGIBLE_STATUSES,
+    isPackageSwitchEligible,
 } from "./adjust-plan-utils";
 import { formatMonthly } from "./tier-pricing";
 
@@ -179,12 +179,6 @@ interface RecommendedUpgradeProps {
      */
     canChangePackage: boolean;
     /**
-     * Base-user delegate. When absent (the base-plan default), the CTA starts
-     * the Stripe package checkout directly. Ignored for Pro users, who confirm
-     * and call change-package in place.
-     */
-    onUpgrade?: () => void;
-    /**
      * Manage-path delegate (AdjustPlanModal). Used to keep a legacy/custom Pro
      * sub with no pinned package off the change-package flow, which operates
      * only on named packages.
@@ -202,7 +196,6 @@ function RecommendedUpgrade({
     currentKey,
     isProUser,
     canChangePackage,
-    onUpgrade,
     onManage,
     onTierUpgraded,
 }: RecommendedUpgradeProps) {
@@ -231,15 +224,22 @@ function RecommendedUpgrade({
 
     // Pro users change their package in place: confirm the prorated charge, then
     // call change-package and hand off to the resize takeover on success. Base
-    // users keep the delegate / Stripe-checkout path.
+    // users go through the Stripe-checkout path instead.
     const handleConfirmChange = async () => {
         const result = await changePackage(recommended.key);
-        if (result) {
-            setConfirmOpen(false);
-            onTierUpgraded?.();
+        if (!result) {
+            // The hook already toasted; leave the dialog open so the user can
+            // retry.
+            return;
         }
-        // On a null result the hook already toasted; leave the dialog open so
-        // the user can retry.
+        setConfirmOpen(false);
+        if (result.status === "ok") {
+            onTierUpgraded?.();
+        } else {
+            // no_op: the sub is already on this package, so there's nothing to
+            // provision — just dismiss the confirm.
+            toast.success("You're already on this plan.");
+        }
     };
 
     const handleUpgrade = async () => {
@@ -252,10 +252,6 @@ function RecommendedUpgrade({
         }
         if (isProUser) {
             setConfirmOpen(true);
-            return;
-        }
-        if (onUpgrade) {
-            onUpgrade();
             return;
         }
         setPending(true);
@@ -370,13 +366,12 @@ function RecommendedUpgrade({
             >
                 {upgradeLabel}
             </Button>
-            <ConfirmDialog
+            <PackageSwitchConfirmModal
                 open={confirmOpen}
-                title={`Upgrade to ${recommended.name}?`}
-                message="You'll be charged the prorated difference now."
-                confirmLabel="Upgrade"
-                isPending={isPending}
-                onConfirm={handleConfirmChange}
+                relation="upgrade"
+                packageName={recommended.name}
+                pending={isPending}
+                onConfirm={() => void handleConfirmChange()}
                 onCancel={() => setConfirmOpen(false)}
             />
         </div>
@@ -452,22 +447,9 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
         packages.length > 0 &&
         (currentPlan.id === "base" || subscription.package != null);
     // A one-click, in-place package switch is safe only for a clean packaged Pro
-    // sub. A customized sub's tiers no longer match the stock package (posting
-    // the next stock key would use wrong deltas / drop custom line items), and a
-    // cancelling sub 409s on change-package — both fall back to the manage path.
-    // A sub in a non-entitlement status (`canceled`, `unpaid`, `incomplete`,
-    // `paused`, etc.) can't change package either — gate on the same status set
-    // the tier-change flow uses so the CTA never confirms a mutation that 4xxs.
-    const isCancellingSub =
-        subscription.cancel_at_period_end === true ||
-        Boolean(subscription.cancel_at);
-    const canChangePackage =
-        currentPlan.id !== "base" &&
-        subscription.package != null &&
-        !subscription.package.customized &&
-        !isCancellingSub &&
-        subscription.status != null &&
-        TIER_CHANGE_ELIGIBLE_STATUSES.has(subscription.status);
+    // sub; every other Pro state (customized, cancelling, or a non-entitlement
+    // status) and every base sub falls back to the manage path.
+    const canChangePackage = isPackageSwitchEligible(subscription);
 
     return (
         <Card padding="md">


### PR DESCRIPTION
## Summary
Remediates self-review findings on the change-package wiring:
- Extract shared `isPackageSwitchEligible` and gate the plans-page CTAs with it (was only guarded on the plan card) so customized/cancelling/ineligible Pro subs route to manage on both surfaces.
- extractMutationError surfaces the `package` field error; consumers branch on `no_op`; plans-page keeps the confirm dialog open on error; remove dead `onUpgrade`; share the upgrade confirm UX; import-alias + test-fixture cleanups.

Fixes gaps from plan-run self-review of change-package-web-wiring.md.