### PR TITLE
feat(ios): Settings.bundle exposing the self-hosted server URL preference

### DIFF
--- a/clients/ios/App/App/Settings.bundle/Root.plist
+++ b/clients/ios/App/App/Settings.bundle/Root.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>Title</key>
+			<string>Self-Hosted Server</string>
+			<key>FooterText</key>
+			<string>Connect to your own assistant. Enter the HTTPS URL shown by `vellum pair --qr`, or leave empty for Vellum Cloud. The app reloads on next launch.</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>Key</key>
+			<string>self_hosted_server_url</string>
+			<key>DefaultValue</key>
+			<string></string>
+			<key>IsSecure</key>
+			<false/>
+			<key>KeyboardType</key>
+			<string>URL</string>
+			<key>AutocapitalizationType</key>
+			<string>None</string>
+			<key>AutocorrectionType</key>
+			<string>No</string>
+			<key>Placeholder</key>
+			<string>https://</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Settings.app → Vellum gains a Self-Hosted Server group: one URL text field bound to NSUserDefaults key self_hosted_server_url
- Empty/absent = Vellum Cloud (default unchanged); no in-app UI
- Companion PR (same milestone) implements the runtime read/override in the shell

Part of plan: ios-self-hosted-connect.md (M2 PR 5). Untested on device until the milestone's sideload validation.