### PR TITLE
feat(cli): tailscale provider for vellum tunnel

### DIFF
--- a/cli/src/__tests__/tailscale-tunnel.test.ts
+++ b/cli/src/__tests__/tailscale-tunnel.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  normalizeDnsName,
+  resolveServeHostname,
+  startTailscaleServe,
+  stopTailscaleServe,
+  type TailscaleCommandResult,
+  type TailscaleDeps,
+} from "../lib/tailscale-tunnel.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const tempDirs: string[] = [];
+
+function makeWorkspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), "vellum-tailscale-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+const RUNNING_STATUS = JSON.stringify({
+  BackendState: "Running",
+  Self: { DNSName: "my-host.tail-scale.ts.net.", Online: true },
+});
+
+const ok = (stdout = "", stderr = ""): TailscaleCommandResult => ({
+  status: 0,
+  stdout,
+  stderr,
+});
+
+/**
+ * Build a fake {@link TailscaleDeps}. `binary` defaults to a present binary;
+ * pass `null` to simulate a missing install. `responses` is keyed by the
+ * space-joined args; unmatched calls return an empty success result.
+ */
+function makeDeps(opts: {
+  binary?: string | null;
+  responses?: Record<string, TailscaleCommandResult>;
+}): { deps: TailscaleDeps; calls: string[][] } {
+  const calls: string[][] = [];
+  const binary = opts.binary === undefined ? "tailscale" : opts.binary;
+  const deps: TailscaleDeps = {
+    findBinary: () => binary,
+    run: (_bin, args) => {
+      calls.push(args);
+      return opts.responses?.[args.join(" ")] ?? ok();
+    },
+  };
+  return { deps, calls };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── normalizeDnsName ────────────────────────────────────────────────────────
+
+describe("normalizeDnsName", () => {
+  test("trims the trailing MagicDNS dot", () => {
+    expect(normalizeDnsName("host.tailnet.ts.net.")).toBe(
+      "host.tailnet.ts.net",
+    );
+  });
+
+  test("leaves a name without a trailing dot unchanged", () => {
+    expect(normalizeDnsName("host.tailnet.ts.net")).toBe("host.tailnet.ts.net");
+  });
+});
+
+// ── resolveServeHostname ──────────────────────────────────────────────────────
+
+describe("resolveServeHostname", () => {
+  test("returns the trimmed Self.DNSName for a running node", () => {
+    expect(resolveServeHostname(RUNNING_STATUS)).toBe(
+      "my-host.tail-scale.ts.net",
+    );
+  });
+
+  test("throws a login hint when logged out", () => {
+    const json = JSON.stringify({ BackendState: "NeedsLogin", Self: {} });
+    expect(() => resolveServeHostname(json)).toThrow("not logged in");
+  });
+
+  test("throws when the backend is not running", () => {
+    const json = JSON.stringify({
+      BackendState: "Stopped",
+      Self: { DNSName: "host.ts.net." },
+    });
+    expect(() => resolveServeHostname(json)).toThrow("not ready");
+  });
+
+  test("throws when the DNS name is missing", () => {
+    const json = JSON.stringify({ BackendState: "Running", Self: {} });
+    expect(() => resolveServeHostname(json)).toThrow("DNS name");
+  });
+
+  test("throws on unparseable JSON", () => {
+    expect(() => resolveServeHostname("not json")).toThrow("Could not parse");
+  });
+});
+
+// ── startTailscaleServe ───────────────────────────────────────────────────────
+
+describe("startTailscaleServe", () => {
+  test("throws install guidance when the binary is missing", async () => {
+    const { deps, calls } = makeDeps({ binary: null });
+    await expect(
+      startTailscaleServe({ port: 7840, workspaceDir: makeWorkspace() }, deps),
+    ).rejects.toThrow("Tailscale is not installed");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("throws a login hint when logged out and never calls serve", async () => {
+    const { deps, calls } = makeDeps({
+      responses: {
+        "status --json": ok(
+          JSON.stringify({ BackendState: "NeedsLogin", Self: {} }),
+        ),
+      },
+    });
+    await expect(
+      startTailscaleServe({ port: 7840, workspaceDir: makeWorkspace() }, deps),
+    ).rejects.toThrow("not logged in");
+    expect(calls).not.toContainEqual(["serve", "--bg", "7840"]);
+  });
+
+  test("throws when the status query fails (daemon down)", async () => {
+    const { deps } = makeDeps({
+      responses: {
+        "status --json": {
+          status: 1,
+          stdout: "",
+          stderr: "failed to connect to local tailscaled",
+        },
+      },
+    });
+    await expect(
+      startTailscaleServe({ port: 7840, workspaceDir: makeWorkspace() }, deps),
+    ).rejects.toThrow("Could not query Tailscale");
+  });
+
+  test("serves the target port and persists the ingress URL on success", async () => {
+    const workspaceDir = makeWorkspace();
+    const { deps, calls } = makeDeps({
+      responses: {
+        "status --json": ok(RUNNING_STATUS),
+        "serve --bg 7840": ok(),
+      },
+    });
+
+    const info = await startTailscaleServe({ port: 7840, workspaceDir }, deps);
+
+    expect(info.publicUrl).toBe("https://my-host.tail-scale.ts.net");
+    expect(info.port).toBe(7840);
+    expect(info.viaIngress).toBe(false);
+    expect(calls).toContainEqual(["serve", "--bg", "7840"]);
+
+    const config = JSON.parse(
+      readFileSync(join(workspaceDir, "config.json"), "utf-8"),
+    );
+    expect(config.ingress.publicBaseUrl).toBe(
+      "https://my-host.tail-scale.ts.net",
+    );
+    expect(config.ingress.enabled).toBe(true);
+  });
+
+  test("surfaces tailscale's enable-URL guidance when serve is not enabled", async () => {
+    const workspaceDir = makeWorkspace();
+    const enableUrl = "https://login.tailscale.com/f/serve?node=abc123";
+    const { deps } = makeDeps({
+      responses: {
+        "status --json": ok(RUNNING_STATUS),
+        "serve --bg 7840": {
+          status: 1,
+          stdout: "",
+          stderr: `error: Serve is not enabled on your tailnet.\n\nTo enable, visit:\n  ${enableUrl}`,
+        },
+      },
+    });
+
+    await expect(
+      startTailscaleServe({ port: 7840, workspaceDir }, deps),
+    ).rejects.toThrow(enableUrl);
+
+    // A failed serve must not persist an ingress URL.
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+});
+
+// ── stopTailscaleServe ────────────────────────────────────────────────────────
+
+describe("stopTailscaleServe", () => {
+  test("turns off the HTTPS:443 serve (narrow off form)", () => {
+    const { deps, calls } = makeDeps({
+      responses: { "serve --https=443 off": ok() },
+    });
+    const result = stopTailscaleServe("tailscale", deps);
+    expect(result.status).toBe(0);
+    expect(calls).toContainEqual(["serve", "--https=443", "off"]);
+  });
+});

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -8,6 +8,7 @@ import {
   WEB_REMOTE_INGRESS_FLAG,
 } from "../lib/feature-flags.js";
 import { runNgrokTunnel } from "../lib/ngrok";
+import { runTailscaleTunnel } from "../lib/tailscale-tunnel.js";
 
 const VALID_PROVIDERS = ["vellum", "ngrok", "cloudflare", "tailscale"] as const;
 type TunnelProvider = (typeof VALID_PROVIDERS)[number];
@@ -62,12 +63,18 @@ function parseArgs(): TunnelArgs {
       console.log(
         "               No Cloudflare account required for quick tunnels.",
       );
+      console.log(
+        "  tailscale    Tailscale serve — install: brew install tailscale, then `tailscale up`",
+      );
+      console.log(
+        "               Reachable only from your own tailnet (private; LetsEncrypt cert).",
+      );
       console.log("");
       console.log("Examples:");
       console.log("  $ vellum tunnel");
       console.log("  $ vellum tunnel --provider ngrok");
       console.log("  $ vellum tunnel --provider cloudflare");
-      console.log("  $ vellum tunnel my-assistant --provider cloudflare");
+      console.log("  $ vellum tunnel my-assistant --provider tailscale");
       process.exit(0);
     } else if (arg === "--provider") {
       const next = args[i + 1];
@@ -171,6 +178,17 @@ export async function tunnel(): Promise<void> {
 
   if (provider === "cloudflare") {
     await runCloudflareTunnel({
+      ...baseTunnelOpts,
+      preferNginxIngress: await shouldPreferNginxIngress(
+        entry.assistantId,
+        gatewayPort,
+      ),
+    });
+    return;
+  }
+
+  if (provider === "tailscale") {
+    await runTailscaleTunnel({
       ...baseTunnelOpts,
       preferNginxIngress: await shouldPreferNginxIngress(
         entry.assistantId,

--- a/cli/src/lib/cloudflare-tunnel.ts
+++ b/cli/src/lib/cloudflare-tunnel.ts
@@ -1,59 +1,12 @@
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
 
 import { GATEWAY_PORT } from "./constants.js";
+import {
+  clearIngressUrl,
+  getDefaultWorkspaceDir,
+  saveIngressUrl,
+} from "./ingress-config.js";
 import { resolveTunnelTargetPort } from "./nginx-ingress.js";
-
-// ── Workspace config helpers (mirrors the pattern in ngrok.ts) ───────────────
-
-function getDefaultWorkspaceDir(): string {
-  return (
-    process.env.VELLUM_WORKSPACE_DIR?.trim() ||
-    join(homedir(), ".vellum", "workspace")
-  );
-}
-
-function getConfigPath(workspaceDir: string): string {
-  return join(workspaceDir, "config.json");
-}
-
-function loadRawConfig(workspaceDir: string): Record<string, unknown> {
-  const configPath = getConfigPath(workspaceDir);
-  if (!existsSync(configPath)) return {};
-  return JSON.parse(readFileSync(configPath, "utf-8")) as Record<
-    string,
-    unknown
-  >;
-}
-
-function saveRawConfig(
-  workspaceDir: string,
-  config: Record<string, unknown>,
-): void {
-  const configPath = getConfigPath(workspaceDir);
-  const dir = dirname(configPath);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
-}
-
-function saveIngressUrl(workspaceDir: string, publicUrl: string): void {
-  const config = loadRawConfig(workspaceDir);
-  const ingress = (config.ingress ?? {}) as Record<string, unknown>;
-  ingress.publicBaseUrl = publicUrl;
-  ingress.enabled = true;
-  config.ingress = ingress;
-  saveRawConfig(workspaceDir, config);
-}
-
-function clearIngressUrl(workspaceDir: string): void {
-  const config = loadRawConfig(workspaceDir);
-  const ingress = (config.ingress ?? {}) as Record<string, unknown>;
-  delete ingress.publicBaseUrl;
-  config.ingress = ingress;
-  saveRawConfig(workspaceDir, config);
-}
 
 // ── Cloudflare Tunnel ─────────────────────────────────────────────────────────
 

--- a/cli/src/lib/ingress-config.ts
+++ b/cli/src/lib/ingress-config.ts
@@ -1,0 +1,61 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+/**
+ * Shared workspace-config helpers for tunnel providers (ngrok, cloudflare,
+ * tailscale) and the nginx ingress proxy. Each provider fronts the local edge
+ * and records the resulting public URL under `ingress.publicBaseUrl` so webhook
+ * integrations can reach the assistant.
+ */
+
+/** Default workspace dir: `$VELLUM_WORKSPACE_DIR` or `~/.vellum/workspace`. */
+export function getDefaultWorkspaceDir(): string {
+  return (
+    process.env.VELLUM_WORKSPACE_DIR?.trim() ||
+    join(homedir(), ".vellum", "workspace")
+  );
+}
+
+function getConfigPath(workspaceDir: string): string {
+  return join(workspaceDir, "config.json");
+}
+
+/** Read the workspace `config.json`, or an empty object when it is absent. */
+export function loadRawConfig(workspaceDir: string): Record<string, unknown> {
+  const configPath = getConfigPath(workspaceDir);
+  if (!existsSync(configPath)) return {};
+  return JSON.parse(readFileSync(configPath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+/** Write the workspace `config.json`, creating parent directories as needed. */
+export function saveRawConfig(
+  workspaceDir: string,
+  config: Record<string, unknown>,
+): void {
+  const configPath = getConfigPath(workspaceDir);
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+}
+
+/** Persist a public ingress URL to the workspace config and enable ingress. */
+export function saveIngressUrl(workspaceDir: string, publicUrl: string): void {
+  const config = loadRawConfig(workspaceDir);
+  const ingress = (config.ingress ?? {}) as Record<string, unknown>;
+  ingress.publicBaseUrl = publicUrl;
+  ingress.enabled = true;
+  config.ingress = ingress;
+  saveRawConfig(workspaceDir, config);
+}
+
+/** Clear the ingress public base URL from the workspace config. */
+export function clearIngressUrl(workspaceDir: string): void {
+  const config = loadRawConfig(workspaceDir);
+  const ingress = (config.ingress ?? {}) as Record<string, unknown>;
+  delete ingress.publicBaseUrl;
+  config.ingress = ingress;
+  saveRawConfig(workspaceDir, config);
+}

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -17,6 +17,7 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 
 import { GATEWAY_PORT } from "./constants.js";
+import { loadRawConfig, saveRawConfig } from "./ingress-config.js";
 
 /**
  * CLI-managed nginx reverse proxy that fronts the gateway for remote web
@@ -56,28 +57,6 @@ export function getIngressPaths(workspaceDir: string): IngressPaths {
     pidPath: join(dir, "nginx.pid"),
     logPath: join(workspaceDir, "data", "logs", "nginx-ingress.log"),
   };
-}
-
-function getConfigPath(workspaceDir: string): string {
-  return join(workspaceDir, "config.json");
-}
-
-function loadRawConfig(workspaceDir: string): Record<string, unknown> {
-  const configPath = getConfigPath(workspaceDir);
-  if (!existsSync(configPath)) return {};
-  return JSON.parse(readFileSync(configPath, "utf-8")) as Record<
-    string,
-    unknown
-  >;
-}
-
-function saveRawConfig(
-  workspaceDir: string,
-  config: Record<string, unknown>,
-): void {
-  const configPath = getConfigPath(workspaceDir);
-  mkdirSync(dirname(configPath), { recursive: true });
-  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
 }
 
 /**

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -1,48 +1,16 @@
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
-import {
-  closeSync,
-  existsSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
-import { homedir } from "node:os";
+import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { GATEWAY_PORT } from "./constants.js";
+import {
+  clearIngressUrl,
+  getDefaultWorkspaceDir,
+  loadRawConfig,
+  saveIngressUrl,
+} from "./ingress-config.js";
 import { loopbackSafeFetch } from "./loopback-fetch.js";
 import { resolveTunnelTargetPort } from "./nginx-ingress.js";
-
-function getDefaultWorkspaceDir(): string {
-  return (
-    process.env.VELLUM_WORKSPACE_DIR?.trim() ||
-    join(homedir(), ".vellum", "workspace")
-  );
-}
-
-function getConfigPath(workspaceDir: string): string {
-  return join(workspaceDir, "config.json");
-}
-
-function loadRawConfig(workspaceDir: string): Record<string, unknown> {
-  const configPath = getConfigPath(workspaceDir);
-  if (!existsSync(configPath)) return {};
-  return JSON.parse(readFileSync(configPath, "utf-8")) as Record<
-    string,
-    unknown
-  >;
-}
-
-function saveRawConfig(
-  workspaceDir: string,
-  config: Record<string, unknown>,
-): void {
-  const configPath = getConfigPath(workspaceDir);
-  const dir = dirname(configPath);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
-}
 
 const NGROK_API_URL = "http://127.0.0.1:4040/api/tunnels";
 const NGROK_POLL_INTERVAL_MS = 500;
@@ -188,29 +156,6 @@ export async function waitForNgrokUrl(
   throw new Error(
     `ngrok tunnel did not become available within ${timeoutMs / 1000}s. Check ngrok logs for errors.`,
   );
-}
-
-/**
- * Persist a public ingress URL to the workspace config and enable ingress.
- */
-function saveIngressUrl(workspaceDir: string, publicUrl: string): void {
-  const config = loadRawConfig(workspaceDir);
-  const ingress = (config.ingress ?? {}) as Record<string, unknown>;
-  ingress.publicBaseUrl = publicUrl;
-  ingress.enabled = true;
-  config.ingress = ingress;
-  saveRawConfig(workspaceDir, config);
-}
-
-/**
- * Clear the ingress public base URL from the workspace config.
- */
-function clearIngressUrl(workspaceDir: string): void {
-  const config = loadRawConfig(workspaceDir);
-  const ingress = (config.ingress ?? {}) as Record<string, unknown>;
-  delete ingress.publicBaseUrl;
-  config.ingress = ingress;
-  saveRawConfig(workspaceDir, config);
 }
 
 /**

--- a/cli/src/lib/tailscale-tunnel.ts
+++ b/cli/src/lib/tailscale-tunnel.ts
@@ -1,0 +1,299 @@
+import { spawnSync } from "node:child_process";
+
+import { GATEWAY_PORT } from "./constants.js";
+import {
+  clearIngressUrl,
+  getDefaultWorkspaceDir,
+  saveIngressUrl,
+} from "./ingress-config.js";
+import { resolveTunnelTargetPort } from "./nginx-ingress.js";
+
+// ── Tailscale CLI discovery + invocation ────────────────────────────────────
+
+/**
+ * Common macOS locations for the tailscale CLI when it is not on PATH: the
+ * Homebrew bin and the CLI bundled inside the Mac App Store / standalone app.
+ */
+const TAILSCALE_FALLBACK_PATHS = [
+  "/opt/homebrew/bin/tailscale",
+  "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+];
+
+const TAILSCALE_NOT_INSTALLED_MESSAGE = [
+  "Tailscale is not installed or could not be found.",
+  "",
+  "Install Tailscale:",
+  "  macOS:  brew install tailscale   (or install the Tailscale app)",
+  "  Linux:  https://tailscale.com/download/linux",
+  "",
+  "Then start it and sign in: `tailscale up`.",
+].join("\n");
+
+export interface TailscaleCommandResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Injectable seam for the tailscale binary. The real implementation shells out
+ * via spawnSync; tests provide a fake to exercise the success and error paths
+ * without a real tailscale install.
+ */
+export interface TailscaleDeps {
+  /** Locate the tailscale CLI; returns the invocable path, null if absent. */
+  findBinary(): string | null;
+  /** Run `<bin> <args>` synchronously (spawnSync semantics). */
+  run(bin: string, args: string[]): TailscaleCommandResult;
+}
+
+function realFindBinary(): string | null {
+  for (const candidate of ["tailscale", ...TAILSCALE_FALLBACK_PATHS]) {
+    const res = spawnSync(candidate, ["version"], {
+      encoding: "utf-8",
+      timeout: 5_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    if (!res.error && res.status === 0) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function realRun(bin: string, args: string[]): TailscaleCommandResult {
+  const res = spawnSync(bin, args, { encoding: "utf-8", timeout: 15_000 });
+  if (res.error) {
+    throw res.error;
+  }
+  return {
+    status: res.status,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
+}
+
+function realTailscaleDeps(): TailscaleDeps {
+  return { findBinary: realFindBinary, run: realRun };
+}
+
+// ── Status parsing ──────────────────────────────────────────────────────────
+
+interface TailscaleStatus {
+  BackendState?: string;
+  Self?: { DNSName?: string; Online?: boolean };
+}
+
+/** Trim the trailing dot tailscale appends to MagicDNS names. */
+export function normalizeDnsName(dnsName: string): string {
+  return dnsName.replace(/\.$/, "");
+}
+
+/**
+ * Validate `tailscale status --json` output and return the MagicDNS hostname
+ * (without trailing dot) this machine serves at. Throws a clear error when the
+ * daemon is logged out or otherwise not ready to serve.
+ */
+export function resolveServeHostname(statusJson: string): string {
+  let status: TailscaleStatus;
+  try {
+    status = JSON.parse(statusJson) as TailscaleStatus;
+  } catch {
+    throw new Error("Could not parse `tailscale status --json` output.");
+  }
+
+  const backendState = status.BackendState;
+  if (backendState === "NeedsLogin" || backendState === "NoState") {
+    throw new Error(
+      "Tailscale is not logged in. Run `tailscale up` and try again.",
+    );
+  }
+  if (backendState && backendState !== "Running") {
+    throw new Error(
+      `Tailscale is not ready (state: ${backendState}). ` +
+        "Start Tailscale and run `tailscale up`, then try again.",
+    );
+  }
+
+  const dnsName = status.Self?.DNSName;
+  if (!dnsName) {
+    throw new Error(
+      "Could not determine this machine's Tailscale DNS name from `tailscale status`. " +
+        "Ensure Tailscale is running and signed in (`tailscale up`).",
+    );
+  }
+  return normalizeDnsName(dnsName);
+}
+
+function joinOutput(result: TailscaleCommandResult): string {
+  return [result.stdout, result.stderr]
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Compose an error for a failed `tailscale serve`, surfacing tailscale's own
+ * guidance (it prints an enable URL when Serve/HTTPS certs are not enabled for
+ * the tailnet) rather than swallowing it.
+ */
+function serveFailureMessage(result: TailscaleCommandResult): string {
+  const detail = joinOutput(result);
+  const base =
+    "`tailscale serve` failed. This usually means HTTPS certificates or the " +
+    "Serve feature are not enabled for your tailnet — follow the link below to " +
+    "enable them, then retry.";
+  return detail ? `${base}\n\n${detail}` : base;
+}
+
+// ── Tailscale serve lifecycle ───────────────────────────────────────────────
+
+export interface RunTailscaleTunnelOptions {
+  /** Gateway port to serve. Defaults to the global GATEWAY_PORT. */
+  port?: number;
+  /** Workspace directory for config read/write. Defaults to ~/.vellum/workspace. */
+  workspaceDir?: string;
+  /** Prefer nginx ingress over the gateway port when it is running. */
+  preferNginxIngress?: boolean;
+}
+
+export interface TailscaleServeInfo {
+  publicUrl: string;
+  port: number;
+  viaIngress: boolean;
+  binary: string;
+  workspaceDir: string;
+}
+
+/**
+ * Preflight tailscale, front the local edge with `tailscale serve --bg`, and
+ * persist the resulting tailnet URL as the ingress base URL.
+ *
+ * `serve --bg` registers the mapping in tailscaled and returns immediately;
+ * there is no long-lived child process to supervise. Throws on any failure
+ * (binary missing, logged out, serve not enabled) with actionable guidance.
+ */
+export async function startTailscaleServe(
+  opts: RunTailscaleTunnelOptions = {},
+  deps: TailscaleDeps = realTailscaleDeps(),
+): Promise<TailscaleServeInfo> {
+  const binary = deps.findBinary();
+  if (!binary) {
+    throw new Error(TAILSCALE_NOT_INSTALLED_MESSAGE);
+  }
+
+  const statusResult = deps.run(binary, ["status", "--json"]);
+  if (statusResult.status !== 0 || !statusResult.stdout.trim()) {
+    const detail = joinOutput(statusResult);
+    throw new Error(
+      "Could not query Tailscale — is the Tailscale app running? " +
+        "Start Tailscale and run `tailscale up`, then try again." +
+        (detail ? `\n\n${detail}` : ""),
+    );
+  }
+
+  const hostname = resolveServeHostname(statusResult.stdout);
+  const publicUrl = `https://${hostname}`;
+
+  const workspaceDir = opts.workspaceDir ?? getDefaultWorkspaceDir();
+  const gatewayPort = opts.port ?? GATEWAY_PORT;
+  const { port, viaIngress } = resolveTunnelTargetPort(
+    workspaceDir,
+    gatewayPort,
+    { preferNginxIngress: opts.preferNginxIngress === true },
+  );
+
+  const serveResult = deps.run(binary, ["serve", "--bg", String(port)]);
+  if (serveResult.status !== 0) {
+    throw new Error(serveFailureMessage(serveResult));
+  }
+
+  saveIngressUrl(workspaceDir, publicUrl);
+
+  return { publicUrl, port, viaIngress, binary, workspaceDir };
+}
+
+/**
+ * Turn off the HTTPS serve on 443 (the narrow form — leaves any other serve
+ * config intact). Returns the command result so callers can report failures.
+ */
+export function stopTailscaleServe(
+  binary: string,
+  deps: TailscaleDeps = realTailscaleDeps(),
+): TailscaleCommandResult {
+  return deps.run(binary, ["serve", "--https=443", "off"]);
+}
+
+/**
+ * Run the tailscale tunnel workflow: preflight, serve the local edge over the
+ * tailnet, persist the URL, then hold until Ctrl+C to tear the serve down and
+ * clear the ingress URL.
+ *
+ * The tailnet URL carries a real LetsEncrypt certificate but is reachable only
+ * from devices signed in to the same tailnet — no public exposure.
+ */
+export async function runTailscaleTunnel(
+  opts: RunTailscaleTunnelOptions = {},
+): Promise<void> {
+  const deps = realTailscaleDeps();
+
+  console.log("Setting up tailscale serve...");
+  const { publicUrl, port, viaIngress, binary, workspaceDir } =
+    await startTailscaleServe(opts, deps);
+
+  if (viaIngress) {
+    console.log(`nginx ingress detected — serving it on 127.0.0.1:${port}.`);
+  }
+
+  console.log("");
+  console.log(`Tunnel established: ${publicUrl}`);
+  console.log(`Serving:            localhost:${port}`);
+  console.log("");
+  console.log("Ingress URL saved to config.");
+  console.log(
+    "This URL is reachable only from devices signed in to your tailnet.",
+  );
+  console.log("");
+  console.log(
+    "The serve runs in the background (tailscaled) and persists after this",
+  );
+  console.log(
+    "command exits. Press Ctrl+C to stop serving and clear the ingress URL,",
+  );
+  console.log("or stop it later with: tailscale serve --https=443 off");
+
+  const teardown = (): void => {
+    console.log("\nStopping tailscale serve and clearing the ingress URL...");
+    let result: TailscaleCommandResult | null = null;
+    try {
+      result = stopTailscaleServe(binary, deps);
+    } catch (err) {
+      console.error(
+        `Could not stop tailscale serve automatically (${
+          err instanceof Error ? err.message : String(err)
+        }). Run \`tailscale serve --https=443 off\` manually.`,
+      );
+    }
+    if (result && result.status !== 0) {
+      const detail = joinOutput(result);
+      console.error(
+        "Could not stop tailscale serve automatically. Run " +
+          "`tailscale serve --https=443 off` manually." +
+          (detail ? `\n${detail}` : ""),
+      );
+    }
+    clearIngressUrl(workspaceDir);
+  };
+
+  const shutdown = (): void => {
+    teardown();
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  // Hold the process open until a signal fires. The serve itself lives in
+  // tailscaled, so there is no child process to await — the registered signal
+  // listeners keep the event loop alive.
+  await new Promise<void>(() => {});
+}


### PR DESCRIPTION
## Summary
- vellum tunnel --provider tailscale fronts the web edge via tailscale serve (tailnet-only, LetsEncrypt cert) and persists ingress.publicBaseUrl
- Preflights binary presence + login state; surfaces tailscale's own enable-URL guidance for serve/HTTPS features
- Shared ingress-URL persistence extracted and reused across providers

Part of plan: ios-self-hosted-connect.md (M3). Validated shape: manual tailscale serve flow proven live on the pilot instance 2026-07-21.