### PR TITLE
feat(ios): shell honors self_hosted_server_url with scoped navigation and fallback alert

### DIFF
--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -354,17 +354,42 @@ extension MyViewController: WKScriptMessageHandler {
 // MARK: - Unreachable self-hosted origin alert
 
 extension MyViewController: WebViewNavigationFailureObserver {
-    /// Present a single native alert when the self-hosted origin's main document
-    /// fails to load. A no-op when no override is active (the baked Vellum Cloud
-    /// URL keeps its existing behavior) or when the failure is a programmatic
-    /// cancellation, e.g. a superseding navigation.
+    /// Present a single native alert when the configured self-hosted server's
+    /// main document fails to load. A no-op when no override is active (the baked
+    /// Vellum Cloud URL keeps its existing behavior), when the failure is a
+    /// programmatic cancellation (e.g. a superseding navigation), or when the
+    /// failed navigation targeted some other host.
+    ///
+    /// The host check matters because the shell loads other URLs into the same
+    /// web view — most notably Universal Links via `AppDelegate.navigateWebView`.
+    /// Without it, an unrelated failure would offer to clear a valid preference.
+    /// The configured server's own failures (boot load, foreground reload, the
+    /// deferred connect pair-page load — all to the configured host) still alert.
     func webViewNavigationDidFail(_ error: Error) {
         guard let configured = SelfHostedServer.configuredURL() else { return }
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
             return
         }
+        guard let failedHost = Self.failingURL(for: nsError)?.host?.lowercased(),
+              failedHost == configured.host?.lowercased()
+        else {
+            return
+        }
         presentUnreachableAlert(for: configured)
+    }
+
+    /// The URL whose load failed, read from the navigation error. Populated on
+    /// the `NSURLErrorDomain` failures the unreachable alert cares about
+    /// (unreachable host, TLS, timeout).
+    private static func failingURL(for error: NSError) -> URL? {
+        if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
+            return url
+        }
+        if let string = error.userInfo[NSURLErrorFailingURLStringErrorKey] as? String {
+            return URL(string: string)
+        }
+        return nil
     }
 
     private func presentUnreachableAlert(for origin: URL) {

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -48,6 +48,42 @@ class MyViewController: CAPBridgeViewController {
     private static let textSelectionHandlerName = "vellumTextSelection"
     private static let surfaceOverlayHandlerName = "vellumSurfaceOverlay"
 
+    // MARK: - Self-hosted server origin
+
+    /// The baked Vellum Cloud URL from `capacitor.config.json`, captured before
+    /// any self-hosted override is applied so a cleared preference and the "Use
+    /// Vellum Cloud" fallback can always return here.
+    private var bakedServerURL: URL?
+
+    /// Retains the navigation-delegate decorator. Capacitor stores its
+    /// `navigationDelegate` weakly, so the proxy must be owned here to stay
+    /// alive for the view controller's lifetime.
+    private var navigationDelegateProxy: NavigationDelegateProxy?
+
+    /// Point the shell at the user's self-hosted assistant when
+    /// `self_hosted_server_url` is set, otherwise keep the baked Vellum Cloud
+    /// URL untouched. The configured host is added to the navigation allowlist —
+    /// scoped to exactly the baked cloud host plus the configured origin, never a
+    /// wildcard — so its pages load as the main document instead of being handed
+    /// off to Safari.
+    override open func instanceDescriptor() -> InstanceDescriptor {
+        let descriptor = super.instanceDescriptor()
+        bakedServerURL = descriptor.serverURL.flatMap { URL(string: $0) }
+
+        guard let configured = SelfHostedServer.configuredURL() else {
+            return descriptor
+        }
+        descriptor.serverURL = configured.absoluteString
+
+        var allowed = descriptor.allowedNavigationHostnames
+        for host in [bakedServerURL?.host, configured.host].compactMap({ $0 }) where !allowed.contains(host) {
+            allowed.append(host)
+        }
+        descriptor.allowedNavigationHostnames = allowed
+
+        return descriptor
+    }
+
     /// Substitute the quote-and-reply-aware web view subclass. This is the
     /// Capacitor-supported hook for providing a custom `WKWebView` class.
     override open func webView(
@@ -87,16 +123,67 @@ class MyViewController: CAPBridgeViewController {
         if let surfaceOverlay {
             webView?.underPageBackgroundColor = surfaceOverlay
         }
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(reloadIfConfiguredOriginChanged),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
     }
 
     override open func capacitorDidLoad() {
         bridge?.registerPluginInstance(NativeAuthPlugin())
         bridge?.registerPluginInstance(NativeBiometricPlugin())
+        installNavigationDelegateProxy()
         installInputZoomPreventionUserScript()
         installViewportZoomLockUserScript()
         installTextSelectionHandler()
         installSurfaceOverlayThemeSync()
         installQuoteReplyCapabilityMarker()
+    }
+
+    // MARK: - Self-hosted origin navigation
+
+    /// Decorate Capacitor's navigation delegate so the shell can allow top-level
+    /// navigation to the user-configured self-hosted host and surface a native
+    /// alert when that origin can't be reached. Every other callback is
+    /// forwarded to Capacitor unchanged. A no-op when the cast fails, leaving the
+    /// stock Capacitor behavior in place.
+    private func installNavigationDelegateProxy() {
+        guard let capacitorDelegate = webView?.navigationDelegate as? WebViewDelegationHandler else {
+            return
+        }
+        let proxy = NavigationDelegateProxy(forwardingTo: capacitorDelegate, failureObserver: self)
+        navigationDelegateProxy = proxy
+        webView?.navigationDelegate = proxy
+    }
+
+    /// On return to the foreground, reload the web view if the effective origin
+    /// (self-hosted override or baked default) no longer matches what's loaded.
+    /// A full reload is sufficient — the assistant has no useful offline state.
+    @objc private func reloadIfConfiguredOriginChanged() {
+        let destination = SelfHostedServer.configuredURL() ?? bakedServerURL
+        guard let destination else { return }
+        guard Self.originKey(webView?.url) != Self.originKey(destination) else {
+            return
+        }
+        webView?.load(URLRequest(url: destination))
+    }
+
+    /// A scheme+host+port identity for an origin, used to tell whether the web
+    /// view already shows the desired origin (ignoring path/query/fragment).
+    private static func originKey(_ url: URL?) -> String? {
+        guard let url,
+              let scheme = url.scheme?.lowercased(),
+              let host = url.host?.lowercased()
+        else {
+            return nil
+        }
+        if let port = url.port {
+            return "\(scheme)://\(host):\(port)"
+        }
+        return "\(scheme)://\(host)"
     }
 
     // MARK: - Quote-and-reply edit menu
@@ -264,6 +351,123 @@ extension MyViewController: WKScriptMessageHandler {
               let canReply = body["canReply"] as? Bool
         else { return }
         (webView as? QuoteReplyWebView)?.canQuoteReply = canReply
+    }
+}
+
+// MARK: - Unreachable self-hosted origin alert
+
+extension MyViewController: WebViewNavigationFailureObserver {
+    /// Present a single native alert when the self-hosted origin's main document
+    /// fails to load. A no-op when no override is active (the baked Vellum Cloud
+    /// URL keeps its existing behavior) or when the failure is a programmatic
+    /// cancellation, e.g. a superseding navigation.
+    func webViewNavigationDidFail(_ error: Error) {
+        guard let configured = SelfHostedServer.configuredURL() else { return }
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+            return
+        }
+        presentUnreachableAlert(for: configured)
+    }
+
+    private func presentUnreachableAlert(for origin: URL) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  self.viewIfLoaded?.window != nil,
+                  self.presentedViewController == nil
+            else { return }
+
+            let host = origin.host ?? origin.absoluteString
+            let alert = UIAlertController(
+                title: nil,
+                message: "Can't reach \(host).",
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "Retry", style: .default) { [weak self] _ in
+                self?.webView?.load(URLRequest(url: origin))
+            })
+            alert.addAction(UIAlertAction(title: "Use Vellum Cloud", style: .default) { [weak self] _ in
+                SelfHostedServer.clear()
+                if let baked = self?.bakedServerURL {
+                    self?.webView?.load(URLRequest(url: baked))
+                }
+            })
+            self.present(alert, animated: true)
+        }
+    }
+}
+
+// MARK: - Navigation delegate decoration
+
+/// Receives main-document load failures observed by `NavigationDelegateProxy`.
+protocol WebViewNavigationFailureObserver: AnyObject {
+    func webViewNavigationDidFail(_ error: Error)
+}
+
+/// `WKNavigationDelegate` decorator installed over Capacitor's own delegate.
+///
+/// Capacitor's `WebViewDelegationHandler` drives SSE handling, cookie sync, and
+/// the allow-navigation policy, so it must keep receiving every callback. This
+/// proxy forwards everything to it through Objective-C message forwarding and
+/// only adds two behaviors:
+///
+///  1. Top-level navigation to the user-configured self-hosted host is allowed
+///     even though Capacitor freezes its navigation allowlist at launch. This is
+///     what lets a runtime origin switch (a Settings change or a connect deep
+///     link) load in-app instead of being handed to Safari. The scope is exactly
+///     the currently-configured host; everything else defers to Capacitor.
+///  2. Main-document load failures are reported to `failureObserver` so the
+///     shell can show a native "can't reach server" alert.
+final class NavigationDelegateProxy: NSObject, WKNavigationDelegate {
+    private weak var target: WebViewDelegationHandler?
+    private weak var failureObserver: WebViewNavigationFailureObserver?
+
+    init(forwardingTo target: WebViewDelegationHandler, failureObserver: WebViewNavigationFailureObserver) {
+        self.target = target
+        self.failureObserver = failureObserver
+    }
+
+    // Forward any selector this proxy doesn't implement to Capacitor's delegate
+    // so every callback it relies on still reaches it unchanged.
+    override func responds(to aSelector: Selector!) -> Bool {
+        return super.responds(to: aSelector) || (target?.responds(to: aSelector) ?? false)
+    }
+
+    override func forwardingTarget(for aSelector: Selector!) -> Any? {
+        if target?.responds(to: aSelector) == true {
+            return target
+        }
+        return super.forwardingTarget(for: aSelector)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        if let host = navigationAction.request.url?.host?.lowercased(),
+           host == SelfHostedServer.configuredURL()?.host?.lowercased(),
+           navigationAction.targetFrame?.isMainFrame ?? true {
+            decisionHandler(.allow)
+            return
+        }
+        guard let target else {
+            decisionHandler(.allow)
+            return
+        }
+        target.webView(webView, decidePolicyFor: navigationAction, decisionHandler: decisionHandler)
+    }
+
+    // The force unwrap is part of the WKNavigationDelegate declaration.
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        failureObserver?.webViewNavigationDidFail(error)
+        target?.webView(webView, didFailProvisionalNavigation: navigation, withError: error)
+    }
+
+    // The force unwrap is part of the WKNavigationDelegate declaration.
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        failureObserver?.webViewNavigationDidFail(error)
+        target?.webView(webView, didFail: navigation, withError: error)
     }
 }
 

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -60,6 +60,13 @@ class MyViewController: CAPBridgeViewController {
     /// alive for the view controller's lifetime.
     private var navigationDelegateProxy: NavigationDelegateProxy?
 
+    /// The full server URL the web view was last loaded against — the effective
+    /// self-hosted override or the baked default. Foreground change detection
+    /// compares the current preference against this to decide whether to reload,
+    /// so a change that keeps the same host but a different path (e.g.
+    /// `https://host/a` → `https://host/b`) is still caught.
+    private var appliedServerURL: URL?
+
     /// Point the shell at the user's self-hosted assistant when
     /// `self_hosted_server_url` is set, otherwise keep the baked Vellum Cloud
     /// URL untouched. The configured host is added to the navigation allowlist —
@@ -70,7 +77,9 @@ class MyViewController: CAPBridgeViewController {
         let descriptor = super.instanceDescriptor()
         bakedServerURL = descriptor.serverURL.flatMap { URL(string: $0) }
 
-        guard let configured = SelfHostedServer.configuredURL() else {
+        let configured = SelfHostedServer.configuredURL()
+        appliedServerURL = configured ?? bakedServerURL
+        guard let configured else {
             return descriptor
         }
         descriptor.serverURL = configured.absoluteString
@@ -159,31 +168,19 @@ class MyViewController: CAPBridgeViewController {
         webView?.navigationDelegate = proxy
     }
 
-    /// On return to the foreground, reload the web view if the effective origin
-    /// (self-hosted override or baked default) no longer matches what's loaded.
-    /// A full reload is sufficient — the assistant has no useful offline state.
+    /// On return to the foreground, reload the web view if the effective server
+    /// URL (self-hosted override or baked default) no longer matches what was
+    /// last applied. Comparing the full URL — not just the origin — catches a
+    /// same-host path change. A full reload is sufficient; the assistant has no
+    /// useful offline state.
     @objc private func reloadIfConfiguredOriginChanged() {
         let destination = SelfHostedServer.configuredURL() ?? bakedServerURL
         guard let destination else { return }
-        guard Self.originKey(webView?.url) != Self.originKey(destination) else {
+        guard destination.absoluteString != appliedServerURL?.absoluteString else {
             return
         }
+        appliedServerURL = destination
         webView?.load(URLRequest(url: destination))
-    }
-
-    /// A scheme+host+port identity for an origin, used to tell whether the web
-    /// view already shows the desired origin (ignoring path/query/fragment).
-    private static func originKey(_ url: URL?) -> String? {
-        guard let url,
-              let scheme = url.scheme?.lowercased(),
-              let host = url.host?.lowercased()
-        else {
-            return nil
-        }
-        if let port = url.port {
-            return "\(scheme)://\(host):\(port)"
-        }
-        return "\(scheme)://\(host)"
     }
 
     // MARK: - Quote-and-reply edit menu
@@ -384,11 +381,13 @@ extension MyViewController: WebViewNavigationFailureObserver {
                 preferredStyle: .alert
             )
             alert.addAction(UIAlertAction(title: "Retry", style: .default) { [weak self] _ in
+                self?.appliedServerURL = origin
                 self?.webView?.load(URLRequest(url: origin))
             })
             alert.addAction(UIAlertAction(title: "Use Vellum Cloud", style: .default) { [weak self] _ in
                 SelfHostedServer.clear()
                 if let baked = self?.bakedServerURL {
+                    self?.appliedServerURL = baked
                     self?.webView?.load(URLRequest(url: baked))
                 }
             })

--- a/clients/ios/App/App/SelfHostedServer.swift
+++ b/clients/ios/App/App/SelfHostedServer.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The self-hosted assistant origin the shell points its `WKWebView` at instead
+/// of the baked Vellum Cloud URL.
+///
+/// The value lives in `UserDefaults` under `self_hosted_server_url`, written
+/// either from the native Settings pane (`Settings.bundle`) or the
+/// `vellum-assistant://connect` deep link. An empty or absent value means the
+/// shell uses its baked default (Vellum Cloud), which is the unchanged default
+/// experience. This type is the single reader/validator shared by
+/// `MyViewController` (boot + foreground override) and `AppDelegate` (connect
+/// deep link) so the key and the validation rules live in exactly one place.
+enum SelfHostedServer {
+    /// `UserDefaults` key shared with the `Settings.bundle` pane. This exact
+    /// string is the read/write contract with the settings `Root.plist`.
+    static let defaultsKey = "self_hosted_server_url"
+
+    /// The validated self-hosted origin, or `nil` when the preference is unset
+    /// or invalid so callers fall back to the baked default.
+    static func configuredURL(defaults: UserDefaults = .standard) -> URL? {
+        return validate(defaults.string(forKey: defaultsKey))
+    }
+
+    /// Parse and validate a candidate server URL: trims whitespace and requires
+    /// a parseable `https:` URL carrying a host. Returns `nil` for anything else
+    /// so a malformed preference can never break the boot or steer the shell to
+    /// an unexpected origin. `https:` is mandatory because iOS App Transport
+    /// Security requires valid TLS and the shell keeps `server.cleartext` off.
+    static func validate(_ raw: String?) -> URL? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty,
+              let url = URL(string: trimmed),
+              url.scheme?.lowercased() == "https",
+              let host = url.host,
+              !host.isEmpty
+        else {
+            return nil
+        }
+        return url
+    }
+
+    /// Persist a validated origin under the shared defaults key.
+    static func store(_ url: URL, defaults: UserDefaults = .standard) {
+        defaults.set(url.absoluteString, forKey: defaultsKey)
+    }
+
+    /// Clear the preference, returning the shell to the baked Vellum Cloud URL.
+    static func clear(defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: defaultsKey)
+    }
+}


### PR DESCRIPTION
## Summary
- WKWebView boots to the NSUserDefaults self_hosted_server_url origin when set (https-only, validated; empty = baked Vellum Cloud URL, unchanged default)
- Navigation allowlist extended to exactly the configured host; ATS untouched
- Foreground change detection reloads; unreachable origin gets one native Retry / Use Vellum Cloud alert

Part of plan: ios-self-hosted-connect.md (M2 PR 6). Companion: Settings.bundle PR (same milestone). Untested on device until sideload validation.