### PR TITLE
fix(cli): keep ingress URL when tailscale serve teardown fails

### DIFF
--- a/cli/src/__tests__/flags.test.ts
+++ b/cli/src/__tests__/flags.test.ts
@@ -188,14 +188,7 @@ describe("vellum flags --assistant routing", () => {
       ],
       "alice-1",
     );
-    process.argv = [
-      "bun",
-      "vellum",
-      "flags",
-      "set",
-      "voice-mode",
-      "true",
-    ];
+    process.argv = ["bun", "vellum", "flags", "set", "voice-mode", "true"];
 
     await flags();
 

--- a/cli/src/__tests__/input-history.test.ts
+++ b/cli/src/__tests__/input-history.test.ts
@@ -1,10 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 

--- a/cli/src/__tests__/login-loopback.test.ts
+++ b/cli/src/__tests__/login-loopback.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, test } from "bun:test";
 import { startLoopbackListener } from "../commands/login.js";
 
 /** Resolve "settled"/"pending" — proves whether `waitForCode` resolved. */
-async function settleState(p: Promise<unknown>): Promise<"settled" | "pending"> {
+async function settleState(
+  p: Promise<unknown>,
+): Promise<"settled" | "pending"> {
   return Promise.race([
     p.then(
       () => "settled" as const,
@@ -49,7 +51,9 @@ describe("startLoopbackListener", () => {
         () => null,
         (e: Error) => e,
       );
-      const res = await fetch(`${listener.redirectUri}?error=access_denied&state=st`);
+      const res = await fetch(
+        `${listener.redirectUri}?error=access_denied&state=st`,
+      );
       expect(res.status).toBe(400);
       const err = await settled;
       expect(err?.message).toMatch(/access_denied/);

--- a/cli/src/__tests__/platform-client.test.ts
+++ b/cli/src/__tests__/platform-client.test.ts
@@ -240,7 +240,11 @@ describe("fetchAssistantDetail / fetchUpgradeInProgress", () => {
       current_release_version: "0.7.0",
       release_channel: "preview",
     });
-    const detail = await fetchAssistantDetail(TOKEN, ASSISTANT_ID, PLATFORM_URL);
+    const detail = await fetchAssistantDetail(
+      TOKEN,
+      ASSISTANT_ID,
+      PLATFORM_URL,
+    );
     expect(detail).toEqual({
       currentReleaseVersion: "0.7.0",
       releaseChannel: "preview",
@@ -251,7 +255,11 @@ describe("fetchAssistantDetail / fetchUpgradeInProgress", () => {
 
   test("fetchAssistantDetail defaults missing fields", async () => {
     mockFetchJson({});
-    const detail = await fetchAssistantDetail(TOKEN, ASSISTANT_ID, PLATFORM_URL);
+    const detail = await fetchAssistantDetail(
+      TOKEN,
+      ASSISTANT_ID,
+      PLATFORM_URL,
+    );
     expect(detail).toEqual({
       currentReleaseVersion: null,
       releaseChannel: "stable",

--- a/cli/src/__tests__/statefulset.test.ts
+++ b/cli/src/__tests__/statefulset.test.ts
@@ -56,7 +56,9 @@ describe("getBuilderManagedEnvKeys", () => {
 
   test("gateway hostForwarded equals the three spec host entries", () => {
     const { hostForwarded } = getBuilderManagedEnvKeys("gateway");
-    const sorted = [...hostForwarded].sort((a, b) => a.name.localeCompare(b.name));
+    const sorted = [...hostForwarded].sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
     expect(sorted).toEqual([
       { name: "VELAY_BASE_URL", hostVar: "VELAY_BASE_URL" },
       { name: "VELLUM_ENVIRONMENT", hostVar: "VELLUM_ENVIRONMENT" },

--- a/cli/src/__tests__/tailscale-tunnel.test.ts
+++ b/cli/src/__tests__/tailscale-tunnel.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   normalizeDnsName,
   resolveServeHostname,
+  shouldClearIngressUrl,
   startTailscaleServe,
   stopTailscaleServe,
   type TailscaleCommandResult,
@@ -204,5 +205,25 @@ describe("stopTailscaleServe", () => {
     const result = stopTailscaleServe("tailscale", deps);
     expect(result.status).toBe(0);
     expect(calls).toContainEqual(["serve", "--https=443", "off"]);
+  });
+});
+
+// ── shouldClearIngressUrl ─────────────────────────────────────────────────────
+
+describe("shouldClearIngressUrl", () => {
+  test("clears only after a confirmed successful stop", () => {
+    expect(shouldClearIngressUrl({ status: 0, stdout: "", stderr: "" })).toBe(
+      true,
+    );
+  });
+
+  test("keeps the URL when the stop command fails", () => {
+    expect(
+      shouldClearIngressUrl({ status: 1, stdout: "", stderr: "boom" }),
+    ).toBe(false);
+  });
+
+  test("keeps the URL when the stop command threw before running", () => {
+    expect(shouldClearIngressUrl(null)).toBe(false);
   });
 });

--- a/cli/src/__tests__/wake.test.ts
+++ b/cli/src/__tests__/wake.test.ts
@@ -27,9 +27,8 @@ const realLocal = { ...local };
 const realNgrok = { ...ngrok };
 const realProcessLib = { ...processLib };
 
-const resolveTargetAssistantMock = mock<
-  typeof assistantConfig.resolveTargetAssistant
->();
+const resolveTargetAssistantMock =
+  mock<typeof assistantConfig.resolveTargetAssistant>();
 const saveAssistantEntryMock = mock<typeof assistantConfig.saveAssistantEntry>(
   () => {},
 );
@@ -61,9 +60,10 @@ const seedGuardianTokenFromSiblingEnvMock = mock<
 // Default: a token exists, so the re-provision recovery path is skipped. Tests
 // that exercise recovery override loadGuardianToken to return null.
 const loadGuardianTokenMock = mock<typeof guardianToken.loadGuardianToken>(
-  () => ({ accessToken: "existing" }) as ReturnType<
-    typeof guardianToken.loadGuardianToken
-  >,
+  () =>
+    ({ accessToken: "existing" }) as ReturnType<
+      typeof guardianToken.loadGuardianToken
+    >,
 );
 const resetGuardianBootstrapMock = mock<
   typeof guardianToken.resetGuardianBootstrap
@@ -111,7 +111,9 @@ const isAssistantWatchModeAvailableMock = mock<
 const isGatewayWatchModeAvailableMock = mock<
   typeof local.isGatewayWatchModeAvailable
 >(() => false);
-const startLocalDaemonMock = mock<typeof local.startLocalDaemon>(async () => {});
+const startLocalDaemonMock = mock<typeof local.startLocalDaemon>(
+  async () => {},
+);
 const startGatewayMock = mock<typeof local.startGateway>(
   async () => "http://127.0.0.1:7830",
 );
@@ -175,10 +177,12 @@ beforeEach(() => {
     join(resources!.instanceDir, ".vellum", "daemon.pid"),
   );
   resolveProcessStateMock.mockReset();
-  resolveProcessStateMock.mockImplementation(async (_pidFile, _port, label) => ({
-    status: "healthy",
-    pid: label === "Gateway" ? 456 : 123,
-  }));
+  resolveProcessStateMock.mockImplementation(
+    async (_pidFile, _port, label) => ({
+      status: "healthy",
+      pid: label === "Gateway" ? 456 : 123,
+    }),
+  );
   stopProcessByPidFileMock.mockReset();
   stopProcessByPidFileMock.mockResolvedValue(true);
   generateLocalSigningKeyMock.mockReset();
@@ -198,9 +202,9 @@ beforeEach(() => {
   seedGuardianTokenFromSiblingEnvMock.mockReset();
   seedGuardianTokenFromSiblingEnvMock.mockReturnValue(false);
   loadGuardianTokenMock.mockReset();
-  loadGuardianTokenMock.mockReturnValue({ accessToken: "existing" } as ReturnType<
-    typeof guardianToken.loadGuardianToken
-  >);
+  loadGuardianTokenMock.mockReturnValue({
+    accessToken: "existing",
+  } as ReturnType<typeof guardianToken.loadGuardianToken>);
   resetGuardianBootstrapMock.mockReset();
   resetGuardianBootstrapMock.mockResolvedValue(undefined);
   leaseGuardianTokenMock.mockReset();
@@ -252,7 +256,13 @@ describe("vellum wake", () => {
   });
 
   test("re-provisions the guardian token when missing and --repair-guardian is passed", async () => {
-    process.argv = ["bun", "vellum", "wake", "--repair-guardian", "local-assistant"];
+    process.argv = [
+      "bun",
+      "vellum",
+      "wake",
+      "--repair-guardian",
+      "local-assistant",
+    ];
     loadGuardianTokenMock.mockReturnValue(null);
 
     await wake();
@@ -288,7 +298,13 @@ describe("vellum wake", () => {
     // (revoked, mis-seeded, wrong principal). The user explicitly confirmed
     // the destructive repair, so the flag forces a re-lease instead of
     // guessing from local token state and recreating the no-op loop.
-    process.argv = ["bun", "vellum", "wake", "--repair-guardian", "local-assistant"];
+    process.argv = [
+      "bun",
+      "vellum",
+      "wake",
+      "--repair-guardian",
+      "local-assistant",
+    ];
     // loadGuardianToken returns a healthy-looking token by default.
     await wake();
 

--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -134,15 +134,18 @@ export async function backup(): Promise<void> {
   // Call the export endpoint
   let response: Response;
   try {
-    response = await loopbackSafeFetch(`${entry.runtimeUrl}/v1/migrations/export`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
+    response = await loopbackSafeFetch(
+      `${entry.runtimeUrl}/v1/migrations/export`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ description: "CLI backup" }),
+        signal: AbortSignal.timeout(exportTimeoutMs),
       },
-      body: JSON.stringify({ description: "CLI backup" }),
-      signal: AbortSignal.timeout(exportTimeoutMs),
-    });
+    );
 
     // Retry once with a fresh token on 401 — the cached token may be stale
     // after a container restart that generated a new gateway signing key.
@@ -160,15 +163,18 @@ export async function backup(): Promise<void> {
       }
       if (refreshedToken) {
         accessToken = refreshedToken;
-        response = await loopbackSafeFetch(`${entry.runtimeUrl}/v1/migrations/export`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "Content-Type": "application/json",
+        response = await loopbackSafeFetch(
+          `${entry.runtimeUrl}/v1/migrations/export`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ description: "CLI backup" }),
+            signal: AbortSignal.timeout(exportTimeoutMs),
           },
-          body: JSON.stringify({ description: "CLI backup" }),
-          signal: AbortSignal.timeout(exportTimeoutMs),
-        });
+        );
       }
     }
   } catch (err) {

--- a/cli/src/commands/exec.ts
+++ b/cli/src/commands/exec.ts
@@ -220,7 +220,11 @@ export async function exec(): Promise<void> {
 
     if (interactive) {
       // Interactive mode: shell-escape argv and delegate to full terminal
-      await interactiveSession(assistant, shellEscapeArgs(command), serviceParam);
+      await interactiveSession(
+        assistant,
+        shellEscapeArgs(command),
+        serviceParam,
+      );
       return;
     }
 

--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -326,7 +326,8 @@ export async function rollback(): Promise<void> {
     }
 
     // Recover the assistant host port from the entry, fall back to default.
-    const assistantPort = entry.containerInfo?.assistantPort ?? ASSISTANT_INTERNAL_PORT;
+    const assistantPort =
+      entry.containerInfo?.assistantPort ?? ASSISTANT_INTERNAL_PORT;
 
     // Notify connected clients that a rollback is about to begin (best-effort)
     console.log("📢 Notifying connected clients...");

--- a/cli/src/commands/ssh.ts
+++ b/cli/src/commands/ssh.ts
@@ -1,9 +1,6 @@
 import { spawn } from "child_process";
 
-import {
-  extractHostFromUrl,
-  resolveAssistant,
-} from "../lib/assistant-config";
+import { extractHostFromUrl, resolveAssistant } from "../lib/assistant-config";
 import { dockerResourceNames } from "../lib/docker";
 import { getPlatformUrl, readPlatformToken } from "../lib/platform-client";
 import { sshAppleContainer } from "../lib/ssh-apple-container";

--- a/cli/src/lib/__tests__/step-runner.test.ts
+++ b/cli/src/lib/__tests__/step-runner.test.ts
@@ -33,7 +33,12 @@ describe("buildExecErrorMessage", () => {
   });
 
   it("appends both streams joined by newline when both present", () => {
-    const msg = buildExecErrorMessage("docker", 1, "stderr-line", "stdout-line");
+    const msg = buildExecErrorMessage(
+      "docker",
+      1,
+      "stderr-line",
+      "stdout-line",
+    );
     expect(msg).toBe("docker exited with code 1\nstderr-line\nstdout-line");
   });
 

--- a/cli/src/lib/__tests__/terminal-session.test.ts
+++ b/cli/src/lib/__tests__/terminal-session.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  parseSentinelOutput,
-  stripAnsi,
-} from "../terminal-session.js";
+import { parseSentinelOutput, stripAnsi } from "../terminal-session.js";
 
 const START = "__VELLUM_EXEC_START_1234__";
 const END = "__VELLUM_EXEC_END_1234__";
@@ -132,7 +129,7 @@ describe("parseSentinelOutput", () => {
       START,
       "📤 Resend Email Setup [installed]",
       "  ID: resend-setup",
-      '  Set up and send emails via a user-provided Resend account (BYO email provider)',
+      "  Set up and send emails via a user-provided Resend account (BYO email provider)",
       "",
       "Community registry (1):",
       "",
@@ -151,18 +148,12 @@ describe("parseSentinelOutput", () => {
     const cleaned = "just some random output\nwith no sentinels\n";
     const result = parseSentinelOutput(cleaned, START, END);
     // Falls back to entire output (trimmed)
-    expect(result.output).toBe(
-      "just some random output\nwith no sentinels",
-    );
+    expect(result.output).toBe("just some random output\nwith no sentinels");
     expect(result.exitCode).toBe(0);
   });
 
   test("handles output with only start sentinel (no end)", () => {
-    const cleaned = [
-      START,
-      "partial output",
-      "more output",
-    ].join("\n");
+    const cleaned = [START, "partial output", "more output"].join("\n");
 
     const result = parseSentinelOutput(cleaned, START, END);
     expect(result.output).toBe("partial output\nmore output");
@@ -177,7 +168,7 @@ describe("parseSentinelOutput", () => {
         ` '${END}'; echo '__VELLUM_EXIT_'$__ec; exit $__ec`,
       START,
       "[13:06:38.851] INFO (761 on pod-0): [clawhub] Running clawhub command",
-      '    args: [',
+      "    args: [",
       '      "search",',
       '      "resend-setup",',
       '      "--limit",',

--- a/cli/src/lib/device-id.ts
+++ b/cli/src/lib/device-id.ts
@@ -23,9 +23,7 @@ let cached: string | undefined;
 function resolveDeviceIdPaths(): { dir: string; file: string } {
   const env = getCurrentEnvironment();
   const dir =
-    env.name === "production"
-      ? join(homedir(), ".vellum")
-      : getConfigDir(env);
+    env.name === "production" ? join(homedir(), ".vellum") : getConfigDir(env);
   return { dir, file: join(dir, "device.json") };
 }
 

--- a/cli/src/lib/flag-args.test.ts
+++ b/cli/src/lib/flag-args.test.ts
@@ -12,12 +12,7 @@ describe("parseFeatureFlagArgs", () => {
   });
 
   test("multiple flags produce multiple env vars", () => {
-    const result = parseFeatureFlagArgs([
-      "--flag",
-      "a=1",
-      "--flag",
-      "b=0",
-    ]);
+    const result = parseFeatureFlagArgs(["--flag", "a=1", "--flag", "b=0"]);
     expect(result).toEqual({
       envVars: { VELLUM_FLAG_A: "1", VELLUM_FLAG_B: "0" },
       remaining: [],

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -17,10 +17,7 @@ import { platform } from "os";
 import { dirname, join } from "path";
 
 import { SEEDS } from "@vellumai/environments";
-import {
-  guardianTokenPath,
-  resolveConfigDir,
-} from "@vellumai/local-mode";
+import { guardianTokenPath, resolveConfigDir } from "@vellumai/local-mode";
 
 import { getConfigDir } from "./environments/paths.js";
 import { getCurrentEnvironment } from "./environments/resolve.js";
@@ -347,21 +344,24 @@ export async function refreshGuardianToken(
 
     const tokenData = current ?? before;
 
-    const response = await loopbackSafeFetch(`${gatewayUrl}/v1/guardian/refresh`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${tokenData.accessToken}`,
+    const response = await loopbackSafeFetch(
+      `${gatewayUrl}/v1/guardian/refresh`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${tokenData.accessToken}`,
+        },
+        body: JSON.stringify({
+          refreshToken: tokenData.refreshToken,
+          // The refresh token is device-bound; send the device id used at init
+          // (falling back to a fresh computation for tokens persisted before the
+          // field was stored) so the gateway can verify the binding.
+          deviceId: tokenData.deviceId || computeDeviceId(),
+        }),
+        signal: AbortSignal.timeout(REFRESH_FETCH_TIMEOUT_MS),
       },
-      body: JSON.stringify({
-        refreshToken: tokenData.refreshToken,
-        // The refresh token is device-bound; send the device id used at init
-        // (falling back to a fresh computation for tokens persisted before the
-        // field was stored) so the gateway can verify the binding.
-        deviceId: tokenData.deviceId || computeDeviceId(),
-      }),
-      signal: AbortSignal.timeout(REFRESH_FETCH_TIMEOUT_MS),
-    });
+    );
     if (!response.ok) return null;
 
     const json = (await response.json()) as Record<string, unknown>;

--- a/cli/src/lib/retire-apple-container.ts
+++ b/cli/src/lib/retire-apple-container.ts
@@ -13,7 +13,9 @@ export async function retireAppleContainer(
   name: string,
   entry: AssistantEntry,
 ): Promise<void> {
-  console.log(`\u{1F5D1}\ufe0f  Retiring Apple Container assistant '${name}'...\n`);
+  console.log(
+    `\u{1F5D1}\ufe0f  Retiring Apple Container assistant '${name}'...\n`,
+  );
 
   const mgmtSocket = entry.mgmtSocket as string | undefined;
   if (!mgmtSocket) {
@@ -46,7 +48,9 @@ export async function retireAppleContainer(
 
     socket.setTimeout(TIMEOUT_MS);
     socket.on("timeout", () => {
-      console.error("Timed out waiting for retire response from the macOS app.");
+      console.error(
+        "Timed out waiting for retire response from the macOS app.",
+      );
       socket.destroy();
       process.exit(1);
     });
@@ -77,9 +81,7 @@ export async function retireAppleContainer(
         resolve();
       } else {
         reject(
-          new Error(
-            `Retire failed: ${response.message || "unknown error"}`,
-          ),
+          new Error(`Retire failed: ${response.message || "unknown error"}`),
         );
       }
     });

--- a/cli/src/lib/tailscale-tunnel.ts
+++ b/cli/src/lib/tailscale-tunnel.ts
@@ -146,6 +146,18 @@ function serveFailureMessage(result: TailscaleCommandResult): string {
   return detail ? `${base}\n\n${detail}` : base;
 }
 
+/**
+ * The ingress URL may only be cleared once the serve mapping is confirmed
+ * stopped. tailscaled maintains the mapping independently of this process, so
+ * a failed or errored stop leaves the URL live — clearing the config then
+ * would strand webhook configuration while the endpoint still answers.
+ */
+export function shouldClearIngressUrl(
+  result: TailscaleCommandResult | null,
+): boolean {
+  return result !== null && result.status === 0;
+}
+
 // ── Tailscale serve lifecycle ───────────────────────────────────────────────
 
 export interface RunTailscaleTunnelOptions {
@@ -282,7 +294,15 @@ export async function runTailscaleTunnel(
           (detail ? `\n${detail}` : ""),
       );
     }
-    clearIngressUrl(workspaceDir);
+    if (shouldClearIngressUrl(result)) {
+      clearIngressUrl(workspaceDir);
+    } else {
+      console.error(
+        "Keeping the saved ingress URL since serve may still be active. " +
+          "After stopping serve manually, clear it with another Ctrl+C run " +
+          "or by re-running the tunnel command.",
+      );
+    }
   };
 
   const shutdown = (): void => {

--- a/cli/src/lib/upgrade-preflight.ts
+++ b/cli/src/lib/upgrade-preflight.ts
@@ -56,16 +56,14 @@ export function resolveUpgradeTarget(args: {
         isDowngrade: false,
       };
     }
-    target =
-      (releases.find((r) => r.is_stable !== false) ?? releases[0]).version;
+    target = (releases.find((r) => r.is_stable !== false) ?? releases[0])
+      .version;
   }
 
   const comparison = currentVersion
     ? compareVersions(target, currentVersion)
     : null;
-  const isNoOp = currentVersion
-    ? versionsEqual(target, currentVersion)
-    : false;
+  const isNoOp = currentVersion ? versionsEqual(target, currentVersion) : false;
 
   return {
     kind: "ok",
@@ -99,8 +97,13 @@ export interface UpgradePollState {
 export function evaluateUpgradePoll(
   state: UpgradePollState,
 ): "pending" | "complete" {
-  const { targetVersion, initialVersion, observedVersion, inProgress, sawInProgress } =
-    state;
+  const {
+    targetVersion,
+    initialVersion,
+    observedVersion,
+    inProgress,
+    sawInProgress,
+  } = state;
 
   if (targetVersion) {
     return observedVersion && versionsEqual(observedVersion, targetVersion)


### PR DESCRIPTION
## Summary
- Teardown clears ingress.publicBaseUrl only after a confirmed successful stop — a failed/errored stop keeps the URL (the serve mapping lives in tailscaled and may still be answering) with guidance to finish manually
- Extracted the decision as shouldClearIngressUrl() with pinning tests

Addresses the Codex P2 on #38702. Part of plan: ios-self-hosted-connect.md (M3).