### PR TITLE
feat(ios): connect deep link — QR scan writes the server preference and opens the pair page

### DIFF
--- a/clients/ios/App/App/AppDelegate.swift
+++ b/clients/ios/App/App/AppDelegate.swift
@@ -7,6 +7,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // A QR scan that launches the terminated app delivers the connect URL
+        // here, not through `application(_:open:)` (which only covers warm
+        // opens). Persist the origin now so the bridge boots to it.
+        if let url = launchOptions?[.url] as? URL {
+            _ = handleConnectDeepLink(url)
+        }
         return true
     }
 
@@ -17,6 +23,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {}
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        if handleConnectDeepLink(url) {
+            return true
+        }
         return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
     }
 
@@ -52,25 +61,115 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       )
     }
 
-    // MARK: - Universal Link Navigation
+    // MARK: - Self-hosted connect deep link
 
-    /// Find the Capacitor bridge's WKWebView and navigate it to the given URL.
-    private func navigateWebView(to url: URL) {
-        guard let rootVC = window?.rootViewController else { return }
-        // The Capacitor bridge VC is typically the root or embedded in a nav controller.
-        if let bridgeVC = rootVC as? CAPBridgeViewController {
-            bridgeVC.webView?.load(URLRequest(url: url))
-        } else if let nav = rootVC as? UINavigationController,
-                  let bridgeVC = nav.viewControllers.first as? CAPBridgeViewController {
-            bridgeVC.webView?.load(URLRequest(url: url))
-        } else {
-            // Fallback: walk the child hierarchy
-            for child in rootVC.children {
-                if let bridgeVC = child as? CAPBridgeViewController {
-                    bridgeVC.webView?.load(URLRequest(url: url))
-                    return
-                }
-            }
+    /// A pair-page navigation waiting for the bridge web view to come up. Set on
+    /// a cold launch (before the view controller exists) and consumed once it is
+    /// ready.
+    private var pendingConnectPairURL: URL?
+
+    /// Handle `<scheme>://connect?url=<https-base>&code=<device-code>` — the
+    /// custom-scheme QR path that pairs the shell to a self-hosted assistant. The
+    /// `url` parameter is the server base (host, optionally with a path prefix
+    /// like `/assistant-123` for Velay-style hosting); it is both persisted and
+    /// the value the pair-page URL is derived from, so there is one source of
+    /// truth.
+    ///
+    /// One handler serves both entry points: a warm open via
+    /// `application(_:open:)` and a cold launch via `launchOptions[.url]`. The
+    /// `connect` host distinguishes it from the OAuth-completion deep link (host
+    /// `oauth-complete`), which Capacitor's `appUrlOpen` routes.
+    ///
+    /// The base is persisted synchronously so that on a cold launch
+    /// `MyViewController.instanceDescriptor()` — which runs after this returns
+    /// but before the web view loads — boots straight to it. The pair-page
+    /// navigation is stashed and applied once the web view is live (immediately
+    /// for a warm open; from the freshly launched view controller's
+    /// `viewDidAppear` for a cold launch). Returns `true` for any `connect` link
+    /// (handled or ignored) so it isn't also routed to the OAuth handler;
+    /// `false` for everything else.
+    private func handleConnectDeepLink(_ url: URL) -> Bool {
+        guard url.host?.lowercased() == "connect" else {
+            return false
         }
+        guard let connect = AppDelegate.parseConnectDeepLink(url) else {
+            NSLog("[connect] Ignoring malformed connect deep link")
+            return true
+        }
+
+        SelfHostedServer.store(connect.base)
+        pendingConnectPairURL = connect.pairURL
+        deliverPendingConnectNavigation()
+        return true
+    }
+
+    /// Load a stashed connect pair page once the bridge web view exists. Safe to
+    /// call before the view controller is created (a cold launch defers to the
+    /// first `viewDidAppear`) and idempotent once the navigation is delivered.
+    func deliverPendingConnectNavigation() {
+        guard let pairURL = pendingConnectPairURL,
+              let bridgeVC = currentBridgeViewController(),
+              let webView = bridgeVC.webView
+        else {
+            return
+        }
+        pendingConnectPairURL = nil
+        (bridgeVC as? MyViewController)?.bindServerTrackingToConfiguredOrigin()
+        webView.load(URLRequest(url: pairURL))
+    }
+
+    /// Parse `<scheme>://connect?url=&code=` into the validated https server base
+    /// and the pair-page URL to load. Returns `nil` for a malformed or non-https
+    /// link.
+    private static func parseConnectDeepLink(_ url: URL) -> (base: URL, pairURL: URL)? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let serverParam = components.queryItems?.first(where: { $0.name == "url" })?.value,
+              let code = components.queryItems?.first(where: { $0.name == "code" })?.value,
+              !code.isEmpty,
+              let base = SelfHostedServer.validate(serverParam),
+              let pairURL = pairPageURL(forBase: base, deviceCode: code)
+        else {
+            return nil
+        }
+        return (base, pairURL)
+    }
+
+    /// Build the standalone SPA pairing route that completes the pre-approved
+    /// device-code exchange, `<base>/assistant/pair#device_code=<code>`.
+    ///
+    /// `/assistant/pair` is appended to the base's existing path so a hosting
+    /// prefix survives (base `https://host/assistant-123` →
+    /// `https://host/assistant-123/assistant/pair`); `appendingPathComponent`
+    /// also normalizes a trailing slash on the base.
+    private static func pairPageURL(forBase base: URL, deviceCode: String) -> URL? {
+        let pairBase = base.appendingPathComponent("assistant").appendingPathComponent("pair")
+        guard var components = URLComponents(url: pairBase, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        components.query = nil
+        let encodedCode = deviceCode.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed) ?? deviceCode
+        components.percentEncodedFragment = "device_code=\(encodedCode)"
+        return components.url
+    }
+
+    // MARK: - Web view navigation
+
+    /// The Capacitor bridge view controller — the window root, or embedded in a
+    /// navigation controller, or a direct child of the root.
+    private func currentBridgeViewController() -> CAPBridgeViewController? {
+        guard let rootVC = window?.rootViewController else { return nil }
+        if let bridgeVC = rootVC as? CAPBridgeViewController {
+            return bridgeVC
+        }
+        if let nav = rootVC as? UINavigationController,
+           let bridgeVC = nav.viewControllers.first as? CAPBridgeViewController {
+            return bridgeVC
+        }
+        return rootVC.children.compactMap { $0 as? CAPBridgeViewController }.first
+    }
+
+    /// Navigate the bridge's WKWebView to the given URL.
+    private func navigateWebView(to url: URL) {
+        currentBridgeViewController()?.webView?.load(URLRequest(url: url))
     }
 }

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -183,6 +183,21 @@ class MyViewController: CAPBridgeViewController {
         webView?.load(URLRequest(url: destination))
     }
 
+    /// Apply any connect deep link that arrived before the web view was ready.
+    /// A cold launch stashes the pair-page navigation in `AppDelegate` and it is
+    /// delivered here, once the bridge web view is live and on screen.
+    override open func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        (UIApplication.shared.delegate as? AppDelegate)?.deliverPendingConnectNavigation()
+    }
+
+    /// Bind foreground change detection to the currently-configured self-hosted
+    /// origin so a connect deep link that switched the server out-of-band isn't
+    /// re-detected as a change on the next foreground.
+    func bindServerTrackingToConfiguredOrigin() {
+        appliedServerURL = SelfHostedServer.configuredURL() ?? bakedServerURL
+    }
+
     // MARK: - Quote-and-reply edit menu
 
     /// Advertise to the web layer that this shell hosts the quote-and-reply


### PR DESCRIPTION
## Summary
- vellum-assistant://connect?url=…&code=… (system-camera QR path): validates, persists self_hosted_server_url, loads /assistant/pair#device_code=… for the pre-approved exchange
- Additive to the existing OAuth scheme handling; reuses PR 6's origin plumbing

Stacked on the PR-6 branch — merge order: Settings.bundle / PR 6 / this. Part of plan: ios-self-hosted-connect.md (M2 PR 7). Untested on device until sideload validation.