### PR TITLE
feat(cli): pair --qr --app — connect-scheme QR variant for the iOS app

### DIFF
--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -15,7 +15,7 @@ import { join } from "node:path";
 const testDir = mkdtempSync(join(tmpdir(), "pair-command-test-"));
 process.env.VELLUM_LOCKFILE_DIR = testDir;
 
-import { pair } from "../commands/pair.js";
+import { buildAppConnectUrl, pair } from "../commands/pair.js";
 
 // Distinct loopback (mint) vs reachable (advertised) URLs to verify the split.
 const LOCAL_URL = "http://127.0.0.1:7830";
@@ -799,5 +799,136 @@ describe("pair command", () => {
     expect(calls[0][0]).toBe(
       `${LOCAL_URL}/v1/assistants/pair-test/feature-flags`,
     );
+  });
+
+  test("buildAppConnectUrl composes and encodes the connect link", () => {
+    expect(
+      buildAppConnectUrl(
+        "vellum-assistant",
+        "https://pair.example.ts.net",
+        "device-code",
+      ),
+    ).toBe(
+      "vellum-assistant://connect?url=https%3A%2F%2Fpair.example.ts.net&code=device-code",
+    );
+    // Path prefixes and fragment-hostile characters survive the encoding.
+    expect(
+      buildAppConnectUrl(
+        "vellum-assistant-dev",
+        "https://host.example.ts.net/assistant-123",
+        "a+b/c=",
+      ),
+    ).toBe(
+      "vellum-assistant-dev://connect?url=https%3A%2F%2Fhost.example.ts.net%2Fassistant-123&code=a%2Bb%2Fc%3D",
+    );
+  });
+
+  test("--qr --app emits an app connect URL alongside the browser URL", async () => {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) => {
+      if (url === `${LOCAL_URL}/v1/assistants/pair-test/feature-flags`) {
+        return new Response(
+          JSON.stringify({
+            flags: [{ key: "web-remote-ingress", enabled: true }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url === `${LOCAL_URL}/v1/remote-web/pairing-challenge`) {
+        return new Response(
+          JSON.stringify({
+            deviceCode: "device-code",
+            userCode: "ABCD-EFGH",
+            verificationUri: "https://pair.example.ts.net/assistant/pair",
+            expiresAt: "2026-06-04T00:10:00.000Z",
+            expiresInSeconds: 600,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url === `${LOCAL_URL}/v1/remote-web/pairing-verification`) {
+        return new Response(
+          JSON.stringify({
+            status: "approved",
+            verificationUri: "https://pair.example.ts.net/assistant/pair",
+            expiresAt: "2026-06-04T00:10:00.000Z",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation(
+      (...a: unknown[]) => {
+        logs.push(a.join(" "));
+      },
+    );
+
+    process.argv = [
+      "bun",
+      "vellum",
+      "pair",
+      "--qr",
+      "--app",
+      "--app-scheme",
+      "vellum-assistant-dev",
+      "--url",
+      "https://pair.example.ts.net",
+      "--json",
+    ];
+    try {
+      await pair();
+    } finally {
+      logSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    const out = JSON.parse(logs.join("\n"));
+    expect(out.appUrl).toBe(
+      "vellum-assistant-dev://connect?url=https%3A%2F%2Fpair.example.ts.net&code=device-code",
+    );
+    // The browser URL stays available as the no-app fallback.
+    expect(out.pairUrl).toBe(
+      "https://pair.example.ts.net/assistant/pair#device_code=device-code",
+    );
+    expect(out.deviceCode).toBe("device-code");
+  });
+
+  test("--app without --qr is refused", async () => {
+    let fetchCalled = false;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const errors: string[] = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...a: unknown[]) => {
+        errors.push(a.join(" "));
+      },
+    );
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    process.argv = ["bun", "vellum", "pair", "--app"];
+    let exited = false;
+    try {
+      await pair();
+    } catch (e) {
+      exited = (e as Error).message === "exit:1";
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    expect(exited).toBe(true);
+    expect(errors.join("\n")).toContain("--qr");
+    expect(fetchCalled).toBe(false);
   });
 });

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -61,8 +61,16 @@ OPTIONS:
                     scan alone completes pairing. Needs a public https URL
                     (--url, else the assistant's runtime URL); refuses
                     loopback or non-https URLs.
+    --app            With --qr: encode the QR as a vellum-assistant://connect
+                    link that opens the Vellum iOS app directly (the plain
+                    https pairing URL is printed as a fallback). Requires an
+                    app build with the connect handler installed on the phone.
+    --app-scheme <scheme>
+                    URL scheme for --app links (default: vellum-assistant;
+                    dev/staging app builds use vellum-assistant-dev /
+                    vellum-assistant-staging).
     --json           Output the result as JSON. With --qr: {pairUrl, deviceCode,
-                    expiresAt, expiresInSeconds}
+                    expiresAt, expiresInSeconds} (+ appUrl with --app)
 
 EXAMPLES:
     vellum pair
@@ -71,6 +79,7 @@ EXAMPLES:
     vellum pair --web --url https://abc123.ngrok.app
     vellum pair --web-approve ABCD-EFGH
     vellum pair --qr --url https://your-assistant.ts.net
+    vellum pair --qr --app --url https://your-assistant.ts.net
     vellum pair --qr --json
 `);
 }
@@ -122,6 +131,23 @@ function buildRemoteWebPairingUrl(
     device_code: challenge.deviceCode,
   }).toString();
   return url.toString();
+}
+
+/** Default URL scheme registered by production builds of the iOS app. */
+const DEFAULT_APP_CONNECT_SCHEME = "vellum-assistant";
+
+/**
+ * Compose the custom-scheme link the iOS app's connect handler accepts:
+ * `<scheme>://connect?url=<base>&code=<device code>`. The app persists the
+ * base as its self-hosted server and opens the pair page with the code.
+ */
+export function buildAppConnectUrl(
+  scheme: string,
+  baseUrl: string,
+  deviceCode: string,
+): string {
+  const params = new URLSearchParams({ url: baseUrl, code: deviceCode });
+  return `${scheme}://connect?${params.toString()}`;
 }
 
 type QrPublicBaseUrlFailureReason = "unparseable" | "loopback" | "non-https";
@@ -265,8 +291,9 @@ export async function pair(): Promise<void> {
   const webPairing = rawArgs.includes("--web");
   const webApproval = rawArgs.includes("--web-approve");
   const qrPairing = rawArgs.includes("--qr");
+  const appVariant = rawArgs.includes("--app");
   let args = rawArgs.filter(
-    (a) => a !== "--json" && a !== "--web" && a !== "--qr",
+    (a) => a !== "--json" && a !== "--web" && a !== "--qr" && a !== "--app",
   );
 
   const [label, afterLabel] = extractFlag(args, "--label");
@@ -275,7 +302,11 @@ export async function pair(): Promise<void> {
     "--web-approve",
   );
   const [urlOverride, afterUrl] = extractFlag(afterWebApprove, "--url");
-  args = afterUrl;
+  const [appSchemeOverride, afterAppScheme] = extractFlag(
+    afterUrl,
+    "--app-scheme",
+  );
+  args = afterAppScheme;
 
   if (webPairing && webApproveCode) {
     console.error("Error: use either --web or --web-approve, not both.");
@@ -287,6 +318,10 @@ export async function pair(): Promise<void> {
   }
   if (qrPairing && (webPairing || webApproveCode)) {
     console.error("Error: --qr can't be combined with --web or --web-approve.");
+    process.exit(1);
+  }
+  if ((appVariant || appSchemeOverride) && !qrPairing) {
+    console.error("Error: --app and --app-scheme only apply to --qr pairing.");
     process.exit(1);
   }
 
@@ -455,12 +490,20 @@ export async function pair(): Promise<void> {
     const challenge = await createRemoteWebPairingChallenge(mintUrl, qrBaseUrl);
     await approveRemoteWebPairing(mintUrl, challenge.userCode);
     const pairUrl = buildRemoteWebPairingUrl(challenge);
+    const appUrl = appVariant
+      ? buildAppConnectUrl(
+          appSchemeOverride ?? DEFAULT_APP_CONNECT_SCHEME,
+          qrBaseUrl,
+          challenge.deviceCode,
+        )
+      : null;
 
     if (jsonOutput) {
       console.log(
         JSON.stringify(
           {
             pairUrl,
+            ...(appUrl ? { appUrl } : {}),
             deviceCode: challenge.deviceCode,
             expiresAt: challenge.expiresAt,
             expiresInSeconds: challenge.expiresInSeconds,
@@ -475,11 +518,21 @@ export async function pair(): Promise<void> {
     const displayName = assistantDisplayName(entry);
     console.log(`Scan to pair a device with ${displayName}:`);
     console.log("");
-    qrcodeTerminal.generate(pairUrl, { small: true }, (qr) => {
+    qrcodeTerminal.generate(appUrl ?? pairUrl, { small: true }, (qr) => {
       console.log(qr);
     });
     console.log("");
-    console.log("Or open this URL on the device:");
+    if (appUrl) {
+      console.log("The QR opens the Vellum app. App link:");
+      console.log("");
+      console.log(`  ${appUrl}`);
+      console.log("");
+      console.log(
+        "No app on the device? Open this URL in its browser instead:",
+      );
+    } else {
+      console.log("Or open this URL on the device:");
+    }
     console.log("");
     console.log(`  ${pairUrl}`);
     console.log("");


### PR DESCRIPTION
## Summary
- `--app` (with `--qr`) encodes the QR as `<scheme>://connect?url=…&code=…` so the system camera opens the installed Vellum app straight into pairing; the plain https URL prints beneath as the no-app fallback
- `--app-scheme` overrides the scheme for dev/staging app builds; `--json` gains `appUrl`
- Opt-in by design: the default https QR keeps working for browser/PWA users until app builds with the connect handler (#38705) are widespread

Closes the loop on the Codex P1 on #38705 (the https QR never invoked the app handler). Part of plan: ios-self-hosted-connect.md (M2/M3 seam).