### PR TITLE
fix(cli): ingress-URL default flows through the lockfile — the CLI-owned contract

### DIFF
--- a/cli/src/__tests__/ingress-config.test.ts
+++ b/cli/src/__tests__/ingress-config.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Real assistant-config reads the lockfile from VELLUM_LOCKFILE_DIR.
+const testDir = mkdtempSync(join(tmpdir(), "ingress-config-test-"));
+process.env.VELLUM_LOCKFILE_DIR = testDir;
+
+import { clearIngressUrl, saveIngressUrl } from "../lib/ingress-config.js";
+
+function writeLockfile(entry: Record<string, unknown>): void {
+  writeFileSync(
+    join(testDir, ".vellum.lock.json"),
+    JSON.stringify({ assistants: [entry], activeAssistant: "ingress-test" }),
+  );
+}
+
+function readLockfileEntry(): Record<string, unknown> {
+  const data = JSON.parse(
+    readFileSync(join(testDir, ".vellum.lock.json"), "utf-8"),
+  ) as { assistants: Record<string, unknown>[] };
+  return data.assistants[0];
+}
+
+const tempDirs: string[] = [];
+
+function makeWorkspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ingress-config-ws-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("ingress lockfile mirroring", () => {
+  test("saveIngressUrl stamps the entry's ingressUrl when given an assistantId", () => {
+    writeLockfile({
+      assistantId: "ingress-test",
+      runtimeUrl: "http://192.168.1.50:7830",
+      cloud: "local",
+    });
+    const ws = makeWorkspace();
+
+    saveIngressUrl(ws, "https://tunnel.example.ts.net", "ingress-test");
+
+    // Both contracts are written: workspace config (gateway-facing)...
+    const config = JSON.parse(readFileSync(join(ws, "config.json"), "utf-8"));
+    expect(config.ingress.publicBaseUrl).toBe("https://tunnel.example.ts.net");
+    // ...and the lockfile entry (CLI-facing).
+    expect(readLockfileEntry().ingressUrl).toBe(
+      "https://tunnel.example.ts.net",
+    );
+  });
+
+  test("clearIngressUrl removes the entry's ingressUrl", () => {
+    writeLockfile({
+      assistantId: "ingress-test",
+      runtimeUrl: "http://192.168.1.50:7830",
+      cloud: "local",
+      ingressUrl: "https://tunnel.example.ts.net",
+    });
+    const ws = makeWorkspace();
+    saveIngressUrl(ws, "https://tunnel.example.ts.net");
+
+    clearIngressUrl(ws, "ingress-test");
+
+    const config = JSON.parse(readFileSync(join(ws, "config.json"), "utf-8"));
+    expect(config.ingress.publicBaseUrl).toBeUndefined();
+    expect(readLockfileEntry().ingressUrl).toBeUndefined();
+  });
+
+  test("without an assistantId the lockfile is untouched", () => {
+    writeLockfile({
+      assistantId: "ingress-test",
+      runtimeUrl: "http://192.168.1.50:7830",
+      cloud: "local",
+    });
+    const ws = makeWorkspace();
+
+    saveIngressUrl(ws, "https://tunnel.example.ts.net");
+
+    expect(readLockfileEntry().ingressUrl).toBeUndefined();
+  });
+
+  test("an unknown assistantId is a no-op, not an error", () => {
+    writeLockfile({
+      assistantId: "ingress-test",
+      runtimeUrl: "http://192.168.1.50:7830",
+      cloud: "local",
+    });
+    const ws = makeWorkspace();
+
+    expect(() => {
+      saveIngressUrl(ws, "https://tunnel.example.ts.net", "no-such-assistant");
+    }).not.toThrow();
+    expect(readLockfileEntry().ingressUrl).toBeUndefined();
+  });
+});

--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -932,22 +932,26 @@ describe("pair command", () => {
     expect(fetchCalled).toBe(false);
   });
 
-  test("--qr with no --url uses the tunnel-saved ingress URL", async () => {
-    const workspaceDir = mkdtempSync(join(tmpdir(), "vellum-pair-ingress-"));
-    // Point the synthesized instance dir at an empty temp XDG root so the
-    // resolution deterministically falls through to VELLUM_WORKSPACE_DIR.
-    const xdgDir = mkdtempSync(join(tmpdir(), "vellum-pair-xdg-"));
-    process.env.XDG_DATA_HOME = xdgDir;
+  function writeLockfileWithIngress(ingressUrl: string): void {
     writeFileSync(
-      join(workspaceDir, "config.json"),
+      join(testDir, ".vellum.lock.json"),
       JSON.stringify({
-        ingress: {
-          publicBaseUrl: "https://saved.example.ts.net",
-          enabled: true,
-        },
+        assistants: [
+          {
+            assistantId: "pair-test",
+            runtimeUrl: RUNTIME_URL,
+            localUrl: LOCAL_URL,
+            cloud: "local",
+            ingressUrl,
+          },
+        ],
+        activeAssistant: "pair-test",
       }),
     );
-    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  }
+
+  test("--qr with no --url uses the entry's tunnel-recorded ingress URL", async () => {
+    writeLockfileWithIngress("https://saved.example.ts.net");
 
     const calls: string[] = [];
     const origFetch = globalThis.fetch;
@@ -962,7 +966,7 @@ describe("pair command", () => {
         );
       }
       if (url === `${LOCAL_URL}/v1/remote-web/pairing-challenge`) {
-        // The minted challenge must advertise the SAVED ingress URL.
+        // The minted challenge must advertise the entry's recorded URL.
         expect(JSON.parse(init?.body as string)).toEqual({
           publicBaseUrl: "https://saved.example.ts.net",
         });
@@ -1003,10 +1007,6 @@ describe("pair command", () => {
     } finally {
       logSpy.mockRestore();
       globalThis.fetch = origFetch;
-      delete process.env.VELLUM_WORKSPACE_DIR;
-      delete process.env.XDG_DATA_HOME;
-      rmSync(workspaceDir, { recursive: true, force: true });
-      rmSync(xdgDir, { recursive: true, force: true });
     }
 
     expect(calls).toContain(`${LOCAL_URL}/v1/remote-web/pairing-challenge`);
@@ -1019,22 +1019,8 @@ describe("pair command", () => {
     );
   });
 
-  test("--url beats the saved ingress URL", async () => {
-    const workspaceDir = mkdtempSync(join(tmpdir(), "vellum-pair-ingress-"));
-    // Point the synthesized instance dir at an empty temp XDG root so the
-    // resolution deterministically falls through to VELLUM_WORKSPACE_DIR.
-    const xdgDir = mkdtempSync(join(tmpdir(), "vellum-pair-xdg-"));
-    process.env.XDG_DATA_HOME = xdgDir;
-    writeFileSync(
-      join(workspaceDir, "config.json"),
-      JSON.stringify({
-        ingress: {
-          publicBaseUrl: "https://saved.example.ts.net",
-          enabled: true,
-        },
-      }),
-    );
-    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  test("--url beats the entry's recorded ingress URL", async () => {
+    writeLockfileWithIngress("https://saved.example.ts.net");
 
     const origFetch = globalThis.fetch;
     globalThis.fetch = (async (url: string, init?: RequestInit) => {
@@ -1094,31 +1080,13 @@ describe("pair command", () => {
     } finally {
       logSpy.mockRestore();
       globalThis.fetch = origFetch;
-      delete process.env.VELLUM_WORKSPACE_DIR;
-      delete process.env.XDG_DATA_HOME;
-      rmSync(workspaceDir, { recursive: true, force: true });
-      rmSync(xdgDir, { recursive: true, force: true });
     }
 
     expect(logs.join("\n")).not.toContain("Using saved ingress URL");
   });
 
-  test("a non-https saved ingress URL is ignored", async () => {
-    const workspaceDir = mkdtempSync(join(tmpdir(), "vellum-pair-ingress-"));
-    // Point the synthesized instance dir at an empty temp XDG root so the
-    // resolution deterministically falls through to VELLUM_WORKSPACE_DIR.
-    const xdgDir = mkdtempSync(join(tmpdir(), "vellum-pair-xdg-"));
-    process.env.XDG_DATA_HOME = xdgDir;
-    writeFileSync(
-      join(workspaceDir, "config.json"),
-      JSON.stringify({
-        ingress: {
-          publicBaseUrl: "http://insecure.example.com",
-          enabled: true,
-        },
-      }),
-    );
-    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  test("a non-https recorded ingress URL is ignored", async () => {
+    writeLockfileWithIngress("http://insecure.example.com");
 
     const origFetch = globalThis.fetch;
     let minted = false;
@@ -1157,35 +1125,17 @@ describe("pair command", () => {
       errSpy.mockRestore();
       exitSpy.mockRestore();
       globalThis.fetch = origFetch;
-      delete process.env.VELLUM_WORKSPACE_DIR;
-      delete process.env.XDG_DATA_HOME;
-      rmSync(workspaceDir, { recursive: true, force: true });
-      rmSync(xdgDir, { recursive: true, force: true });
     }
 
-    // The saved http URL is skipped, so --qr falls through to the (non-https)
-    // runtime URL and refuses — proving the saved value was not advertised.
+    // The recorded http URL is skipped, so --qr falls through to the
+    // (non-https) runtime URL and refuses — proving it was not advertised.
     expect(exited).toBe(true);
     expect(errors.join("\n")).toContain(RUNTIME_URL);
     expect(minted).toBe(false);
   });
 
-  test("a saved ingress URL with ingress disabled is ignored", async () => {
-    const workspaceDir = mkdtempSync(join(tmpdir(), "vellum-pair-ingress-"));
-    // Point the synthesized instance dir at an empty temp XDG root so the
-    // resolution deterministically falls through to VELLUM_WORKSPACE_DIR.
-    const xdgDir = mkdtempSync(join(tmpdir(), "vellum-pair-xdg-"));
-    process.env.XDG_DATA_HOME = xdgDir;
-    writeFileSync(
-      join(workspaceDir, "config.json"),
-      JSON.stringify({
-        ingress: {
-          publicBaseUrl: "https://saved.example.ts.net",
-          enabled: false,
-        },
-      }),
-    );
-    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  test("a loopback recorded ingress URL is ignored", async () => {
+    writeLockfileWithIngress("https://127.0.0.1:7840");
 
     const origFetch = globalThis.fetch;
     let minted = false;
@@ -1224,10 +1174,6 @@ describe("pair command", () => {
       errSpy.mockRestore();
       exitSpy.mockRestore();
       globalThis.fetch = origFetch;
-      delete process.env.VELLUM_WORKSPACE_DIR;
-      delete process.env.XDG_DATA_HOME;
-      rmSync(workspaceDir, { recursive: true, force: true });
-      rmSync(xdgDir, { recursive: true, force: true });
     }
 
     expect(exited).toBe(true);

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -10,8 +10,6 @@
  * independent, separately-revocable device (see `vellum unpair`, forthcoming).
  */
 
-import { join } from "node:path";
-
 import { nanoid } from "nanoid";
 // Call `qrcodeTerminal.generate` as a method — the library reads its default
 // error-correction level off `this`, so a destructured import renders nothing.
@@ -35,10 +33,6 @@ import {
   isAssistantFeatureFlagEnabled,
   WEB_REMOTE_INGRESS_FLAG,
 } from "../lib/feature-flags.js";
-import {
-  getDefaultWorkspaceDir,
-  loadIngressUrl,
-} from "../lib/ingress-config.js";
 import { getLocalLanIPv4 } from "../lib/local.js";
 import { isLoopbackUrl, loopbackSafeFetch } from "../lib/loopback-fetch.js";
 
@@ -47,42 +41,27 @@ function assistantDisplayName(entry: AssistantEntry): string {
 }
 
 /**
- * The tunnel-saved ingress URL, when usable as a remote-web advertised
- * default: https and non-loopback (the bar `--qr`/`--web` URLs must clear).
- * Checks the workspaces a tunnel provider may have written: the instance's
- * own workspace (managed/XDG layouts), then the default workspace (legacy
- * `~/.vellum/workspace` layouts, where the gateway reads its config).
+ * The tunnel-recorded ingress URL from this entry's own lockfile record, when
+ * usable as a remote-web advertised default: https and non-loopback (the bar
+ * `--qr`/`--web` URLs must clear). The lockfile is the CLI-owned contract —
+ * `vellum tunnel` providers mirror the URL onto the entry when they save it.
  */
-function loadUsableIngressUrl(entry: AssistantEntry): string | null {
-  const candidates = entry.resources
-    ? [
-        join(entry.resources.instanceDir, ".vellum", "workspace"),
-        getDefaultWorkspaceDir(),
-      ]
-    : [getDefaultWorkspaceDir()];
-  for (const workspaceDir of candidates) {
-    let saved: string | null = null;
-    try {
-      saved = loadIngressUrl(workspaceDir);
-    } catch {
-      continue;
-    }
-    if (!saved) {
-      continue;
-    }
-    try {
-      if (new URL(saved).protocol !== "https:") {
-        continue;
-      }
-    } catch {
-      continue;
-    }
-    if (isLoopbackUrl(saved)) {
-      continue;
-    }
-    return saved;
+function usableEntryIngressUrl(entry: AssistantEntry): string | null {
+  const saved = entry.ingressUrl?.trim();
+  if (!saved) {
+    return null;
   }
-  return null;
+  try {
+    if (new URL(saved).protocol !== "https:") {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+  if (isLoopbackUrl(saved)) {
+    return null;
+  }
+  return saved;
 }
 
 function printUsage(): void {
@@ -403,7 +382,7 @@ export async function pair(): Promise<void> {
   ).replace(/\/+$/, "");
   const savedIngressUrl =
     !urlOverride && (qrPairing || webPairing)
-      ? loadUsableIngressUrl(entry)
+      ? usableEntryIngressUrl(entry)
       : null;
   const advertisedUrl = (
     urlOverride ||

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -160,6 +160,7 @@ export async function tunnel(): Promise<void> {
   const gatewayPort = resolveEntryGatewayPort(entry);
   const baseTunnelOpts = {
     port: gatewayPort,
+    assistantId: entry.assistantId,
     ...(resources
       ? { workspaceDir: join(resources.instanceDir, ".vellum", "workspace") }
       : {}),

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -109,6 +109,9 @@ export type AssistantEntry = Omit<
   /** Loopback URL for same-machine health checks (e.g. `http://127.0.0.1:7831`).
    *  Avoids mDNS resolution issues when the machine checks its own gateway. */
   localUrl?: string;
+  /** Public https ingress URL recorded by `vellum tunnel` providers for this
+   *  instance. The advertised-URL default for remote-web pairing. */
+  ingressUrl?: string;
   bearerToken?: string;
   /** True when this entry was registered via `vellum connect import` (a remote
    *  pairing). Set alongside `cloud: "paired"`; also backs the re-import /

--- a/cli/src/lib/cloudflare-tunnel.ts
+++ b/cli/src/lib/cloudflare-tunnel.ts
@@ -131,6 +131,8 @@ export interface RunCloudflareTunnelOptions {
   workspaceDir?: string;
   /** Prefer nginx ingress over the gateway port when it is running. */
   preferNginxIngress?: boolean;
+  /** Lockfile entry to mirror the ingress URL onto (`ingressUrl`). */
+  assistantId?: string;
 }
 
 export async function runCloudflareTunnel(
@@ -177,7 +179,7 @@ export async function runCloudflareTunnel(
     if (!child.killed) child.kill("SIGTERM");
     if (publicUrl) {
       console.log("\nClearing ingress URL from config...");
-      clearIngressUrl(workspaceDir);
+      clearIngressUrl(workspaceDir, opts.assistantId);
     }
   };
 
@@ -199,7 +201,7 @@ export async function runCloudflareTunnel(
     // Always clear the saved ingress URL when the tunnel process ends so
     // webhook integrations don't keep hitting a dead endpoint.
     if (publicUrl !== undefined) {
-      clearIngressUrl(workspaceDir);
+      clearIngressUrl(workspaceDir, opts.assistantId);
     }
     if (code !== null && code !== 0) {
       console.error(`\ncloudflared exited with code ${code}.`);
@@ -230,7 +232,7 @@ export async function runCloudflareTunnel(
   console.log(`Forwarding to:     localhost:${port}`);
   console.log("");
 
-  saveIngressUrl(workspaceDir, publicUrl);
+  saveIngressUrl(workspaceDir, publicUrl, opts.assistantId);
   console.log("Ingress URL saved to config.");
   console.log("");
   console.log("Press Ctrl+C to stop the tunnel and clear the ingress URL.");

--- a/cli/src/lib/ingress-config.ts
+++ b/cli/src/lib/ingress-config.ts
@@ -2,11 +2,20 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+import {
+  lookupAssistantByIdentifier,
+  saveAssistantEntry,
+} from "./assistant-config.js";
+
 /**
  * Shared workspace-config helpers for tunnel providers (ngrok, cloudflare,
  * tailscale) and the nginx ingress proxy. Each provider fronts the local edge
  * and records the resulting public URL under `ingress.publicBaseUrl` so webhook
- * integrations can reach the assistant.
+ * integrations can reach the assistant. The workspace config is the
+ * gateway-facing contract; when an `assistantId` is supplied, the URL is also
+ * mirrored onto the lockfile entry (`ingressUrl`) — the CLI-owned contract
+ * that CLI features (e.g. remote-web pairing defaults) read, per the
+ * no-`.vellum/`-reads boundary in cli/AGENTS.md.
  */
 
 /** Default workspace dir: `$VELLUM_WORKSPACE_DIR` or `~/.vellum/workspace`. */
@@ -41,35 +50,52 @@ export function saveRawConfig(
   writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
 }
 
+/** Mirror the ingress URL onto the lockfile entry; null removes it. */
+function stampLockfileIngressUrl(
+  assistantId: string,
+  publicUrl: string | null,
+): void {
+  const result = lookupAssistantByIdentifier(assistantId);
+  if (result.status !== "found") {
+    return;
+  }
+  const entry = result.entry;
+  if (publicUrl) {
+    entry.ingressUrl = publicUrl;
+  } else {
+    delete entry.ingressUrl;
+  }
+  saveAssistantEntry(entry);
+}
+
 /** Persist a public ingress URL to the workspace config and enable ingress. */
-export function saveIngressUrl(workspaceDir: string, publicUrl: string): void {
+export function saveIngressUrl(
+  workspaceDir: string,
+  publicUrl: string,
+  assistantId?: string,
+): void {
   const config = loadRawConfig(workspaceDir);
   const ingress = (config.ingress ?? {}) as Record<string, unknown>;
   ingress.publicBaseUrl = publicUrl;
   ingress.enabled = true;
   config.ingress = ingress;
   saveRawConfig(workspaceDir, config);
-}
-
-/**
- * Read the saved public ingress URL, or null when ingress is unset or
- * explicitly disabled.
- */
-export function loadIngressUrl(workspaceDir: string): string | null {
-  const config = loadRawConfig(workspaceDir);
-  const ingress = config.ingress as Record<string, unknown> | undefined;
-  if (!ingress || ingress.enabled === false) {
-    return null;
+  if (assistantId) {
+    stampLockfileIngressUrl(assistantId, publicUrl);
   }
-  const url = ingress.publicBaseUrl;
-  return typeof url === "string" && url.trim() ? url.trim() : null;
 }
 
 /** Clear the ingress public base URL from the workspace config. */
-export function clearIngressUrl(workspaceDir: string): void {
+export function clearIngressUrl(
+  workspaceDir: string,
+  assistantId?: string,
+): void {
   const config = loadRawConfig(workspaceDir);
   const ingress = (config.ingress ?? {}) as Record<string, unknown>;
   delete ingress.publicBaseUrl;
   config.ingress = ingress;
   saveRawConfig(workspaceDir, config);
+  if (assistantId) {
+    stampLockfileIngressUrl(assistantId, null);
+  }
 }

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -257,6 +257,8 @@ export interface RunNgrokTunnelOptions {
   workspaceDir?: string;
   /** Prefer nginx ingress over the gateway port when it is running. */
   preferNginxIngress?: boolean;
+  /** Lockfile entry to mirror the ingress URL onto (`ingressUrl`). */
+  assistantId?: string;
 }
 
 /**
@@ -300,7 +302,7 @@ export async function runNgrokTunnel(
   const existingUrl = await findExistingTunnel(port);
   if (existingUrl) {
     console.log(`Found existing ngrok tunnel: ${existingUrl}`);
-    saveIngressUrl(workspaceDir, existingUrl);
+    saveIngressUrl(workspaceDir, existingUrl, opts.assistantId);
     console.log("Ingress URL saved to config.");
     console.log("");
     console.log(
@@ -327,7 +329,7 @@ export async function runNgrokTunnel(
     }
     if (publicUrl) {
       console.log("\nClearing ingress URL from config...");
-      clearIngressUrl(workspaceDir);
+      clearIngressUrl(workspaceDir, opts.assistantId);
     }
   };
 
@@ -376,7 +378,7 @@ export async function runNgrokTunnel(
   console.log(`Tunnel established: ${publicUrl}`);
   console.log(`Forwarding to:     localhost:${port}`);
 
-  saveIngressUrl(workspaceDir, publicUrl);
+  saveIngressUrl(workspaceDir, publicUrl, opts.assistantId);
   console.log("Ingress URL saved to config.");
   console.log("");
   console.log("Press Ctrl+C to stop the tunnel and clear the ingress URL.");

--- a/cli/src/lib/tailscale-tunnel.ts
+++ b/cli/src/lib/tailscale-tunnel.ts
@@ -167,6 +167,8 @@ export interface RunTailscaleTunnelOptions {
   workspaceDir?: string;
   /** Prefer nginx ingress over the gateway port when it is running. */
   preferNginxIngress?: boolean;
+  /** Lockfile entry to mirror the ingress URL onto (`ingressUrl`). */
+  assistantId?: string;
 }
 
 export interface TailscaleServeInfo {
@@ -220,7 +222,7 @@ export async function startTailscaleServe(
     throw new Error(serveFailureMessage(serveResult));
   }
 
-  saveIngressUrl(workspaceDir, publicUrl);
+  saveIngressUrl(workspaceDir, publicUrl, opts.assistantId);
 
   return { publicUrl, port, viaIngress, binary, workspaceDir };
 }
@@ -295,7 +297,7 @@ export async function runTailscaleTunnel(
       );
     }
     if (shouldClearIngressUrl(result)) {
-      clearIngressUrl(workspaceDir);
+      clearIngressUrl(workspaceDir, opts.assistantId);
     } else {
       console.error(
         "Keeping the saved ingress URL since serve may still be active. " +


### PR DESCRIPTION
## Summary
- Tunnel providers now mirror the saved ingress URL onto the lockfile entry (`ingressUrl`) via an optional assistantId on saveIngressUrl/clearIngressUrl; `vellum tunnel` passes the resolved entry's id
- `pair --qr`/`--web` read ONLY their own entry's `ingressUrl` — no workspace-config reads (cli/AGENTS.md no-`.vellum/`-reads boundary) and no cross-assistant fallback (a named assistant can never advertise another's URL)
- Workspace-config writes remain the gateway-facing contract, unchanged
- Tests: lockfile-based pair resolution (4), ingress lockfile mirroring (4 new), tailscale suite green

Addresses both Codex P1s on #38709. Note: URLs saved before this change (manual config writes) aren't in lockfiles — a fresh `vellum tunnel --provider <p> <assistant>` records the entry; until then `--url` behaves as always.