### PR TITLE
fix(cli): expect assistantId in tunnel ngrok opts test

### DIFF
--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -145,6 +145,7 @@ describe("tunnel nginx ingress feature flag", () => {
     expect(init?.method).toBe("GET");
     expect(runNgrokTunnelMock).toHaveBeenCalledWith({
       port: 7830,
+      assistantId: "assistant-1",
       workspaceDir: join(entry.resources!.instanceDir, ".vellum", "workspace"),
       preferNginxIngress: true,
     });


### PR DESCRIPTION
## Summary
- Add the `assistantId: "assistant-1"` field to the `runNgrokTunnel` call expectation in `cli/src/__tests__/tunnel.test.ts`, matching the tunnel command's `baseTunnelOpts` which now includes the entry's assistant id so the tunnel can record the ingress URL on the lockfile entry.
- Fixes the failing `CI Main CLI Checks` job on main ([run 29910434140](https://github.com/vellum-ai/vellum-assistant/actions/runs/29910434140/job/88891810578)) — verified locally with `VELLUM_ENVIRONMENT=production bun test src/__tests__/tunnel.test.ts` (3 pass).

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29910434140/job/88891810578