### PR TITLE
fix(web): drop "its" from the context-compaction caption

### DIFF
--- a/clients/web/src/domains/chat/components/context-window-indicator.tsx
+++ b/clients/web/src/domains/chat/components/context-window-indicator.tsx
@@ -182,7 +182,7 @@ function MobileSheetContent({
             )}
           </span>
           <span className="text-body-medium-lighter text-[var(--content-tertiary)]">
-            {assistantDisplayName} automatically compacts its context
+            {assistantDisplayName} automatically compacts context
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Reword the context-window indicator caption from "[Assistant Name] automatically compacts its context" to "[Assistant Name] automatically compacts context".
- The possessive "its" reads impersonal applied to a named assistant; dropping the pronoun keeps the caption neutral.

## Original prompt
Change the user-facing string "[Assistant Name] automatically compacts its context" to "[Assistant Name] automatically compacts context" in the web client, because "its" is an impersonal pronoun and reads wrong applied to a named assistant.