### PR TITLE
refactor: consolidate remote-web pairing wire contracts into a shared package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,6 +99,7 @@
       "dependencies": {
         "@vellumai/environments": "workspace:*",
         "@vellumai/local-mode": "workspace:*",
+        "@vellumai/service-contracts": "workspace:*",
         "chalk": "5.6.2",
         "ink": "6.8.0",
         "nanoid": "5.1.7",

--- a/cli/package.json
+++ b/cli/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@vellumai/environments": "workspace:*",
     "@vellumai/local-mode": "workspace:*",
+    "@vellumai/service-contracts": "workspace:*",
     "chalk": "5.6.2",
     "ink": "6.8.0",
     "nanoid": "5.1.7",

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -17,6 +17,13 @@ import { nanoid } from "nanoid";
 // error-correction level off `this`, so a destructured import renders nothing.
 import qrcodeTerminal from "qrcode-terminal";
 
+import type {
+  RemoteWebPairingChallengeRequest,
+  RemoteWebPairingChallengeResponse,
+  RemoteWebPairingVerificationRequest,
+  RemoteWebPairingVerificationResponse,
+} from "@vellumai/service-contracts/remote-web-pairing";
+
 import { extractFlag } from "../lib/arg-utils.js";
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import {
@@ -141,20 +148,6 @@ interface PairResponse {
   refreshAfter?: string;
 }
 
-interface RemoteWebPairingChallengeResponse {
-  deviceCode: string;
-  userCode: string;
-  verificationUri: string;
-  expiresAt: string;
-  expiresInSeconds: number;
-}
-
-interface RemoteWebPairingApprovalResponse {
-  status: "approved";
-  verificationUri: string;
-  expiresAt: string;
-}
-
 function normalizePublicBaseUrl(value: string): string {
   const url = new URL(value);
   url.search = "";
@@ -274,7 +267,7 @@ async function createRemoteWebPairingChallenge(
   const response = await gatewayPostOrExit(
     gatewayUrl,
     "/v1/remote-web/pairing-challenge",
-    { publicBaseUrl },
+    { publicBaseUrl } satisfies RemoteWebPairingChallengeRequest,
   );
   return (await response.json()) as RemoteWebPairingChallengeResponse;
 }
@@ -287,13 +280,13 @@ async function createRemoteWebPairingChallenge(
 async function approveRemoteWebPairing(
   gatewayUrl: string,
   userCode: string,
-): Promise<RemoteWebPairingApprovalResponse> {
+): Promise<RemoteWebPairingVerificationResponse> {
   const response = await gatewayPostOrExit(
     gatewayUrl,
     "/v1/remote-web/pairing-verification",
-    { userCode },
+    { userCode } satisfies RemoteWebPairingVerificationRequest,
   );
-  return (await response.json()) as RemoteWebPairingApprovalResponse;
+  return (await response.json()) as RemoteWebPairingVerificationResponse;
 }
 
 async function assertWebRemoteIngressEnabled(

--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -67,6 +67,8 @@ const APPROVED_RESULT: RemoteWebPairingTokenResult = {
   accessToken: "access-token",
   accessTokenExpiresAt: "2999-01-01T00:00:00.000Z",
   refreshAfter: "2999-01-01T00:00:00.000Z",
+  guardianId: "guardian-1",
+  assistantId: "assistant-1",
 };
 
 class MockRemoteWebPairingError extends Error {

--- a/clients/web/src/lib/auth/remote-gateway-session.test.ts
+++ b/clients/web/src/lib/auth/remote-gateway-session.test.ts
@@ -205,7 +205,6 @@ describe("remote gateway token exchange", () => {
     setLocation("/assistant-123/assistant/pair");
 
     activateRemoteGatewaySession({
-      status: "approved",
       accessToken: "access-token",
       accessTokenExpiresAt: "2999-01-01T00:00:00.000Z",
       refreshAfter: "2999-01-01T00:00:00.000Z",
@@ -227,7 +226,6 @@ describe("remote gateway token exchange", () => {
     ) as unknown as typeof fetch;
 
     activateRemoteGatewaySession({
-      status: "approved",
       accessToken: "access-token",
       accessTokenExpiresAt: "2999-01-01T00:00:00.000Z",
       refreshAfter: "2999-01-01T00:00:00.000Z",

--- a/clients/web/src/lib/auth/remote-gateway-session.ts
+++ b/clients/web/src/lib/auth/remote-gateway-session.ts
@@ -1,3 +1,11 @@
+import type {
+  RemoteWebPairingChallengeRequest,
+  RemoteWebPairingChallengeResponse,
+  RemoteWebPairingTokenApprovedResponse,
+  RemoteWebPairingTokenPendingResponse,
+  RemoteWebPairingTokenRequest,
+} from "@vellumai/service-contracts/remote-web-pairing";
+
 import {
   getGatewayToken,
   setRemoteGatewayToken,
@@ -32,33 +40,21 @@ export interface RemoteWebPairingParams {
   userCode: string | null;
 }
 
-export interface RemoteWebPairingChallenge {
-  deviceCode: string;
-  userCode: string;
-  verificationUri: string;
-  expiresAt: string;
-  expiresInSeconds: number;
-  intervalSeconds: number;
-}
-
-export interface RemoteWebPairingPending {
-  status: "pending";
-  expiresAt: string;
-  intervalSeconds: number;
-}
-
-export interface RemoteWebPairingApproved {
-  status: "approved";
+/**
+ * Credential fields {@link activateRemoteGatewaySession} consumes. Broader than
+ * the pairing-token approved response because the same activation path also
+ * handles the `/v1/guardian/refresh` rotation body, which serializes the two
+ * instants as epoch-millisecond numbers — hence both accept `string | number`.
+ */
+interface RemoteGatewaySessionCredentials {
   accessToken: string;
   accessTokenExpiresAt: string | number;
   refreshAfter: string | number;
-  guardianId?: string;
-  assistantId?: string;
 }
 
 export type RemoteWebPairingTokenResult =
-  | RemoteWebPairingPending
-  | RemoteWebPairingApproved;
+  | RemoteWebPairingTokenPendingResponse
+  | RemoteWebPairingTokenApprovedResponse;
 
 export class RemoteWebPairingError extends Error {
   readonly status: number;
@@ -146,8 +142,10 @@ function shouldRefreshRemoteGatewaySession(): boolean {
   return Date.now() >= remoteGatewayRefreshAfterMs - REFRESH_EARLY_MS;
 }
 
-function isApprovedPayload(value: unknown): value is RemoteWebPairingApproved {
-  const payload = value as Partial<RemoteWebPairingApproved>;
+function isApprovedPayload(
+  value: unknown,
+): value is RemoteWebPairingTokenApprovedResponse {
+  const payload = value as Partial<RemoteWebPairingTokenApprovedResponse>;
   return (
     payload?.status === "approved" &&
     typeof payload.accessToken === "string" &&
@@ -160,8 +158,8 @@ function isApprovedPayload(value: unknown): value is RemoteWebPairingApproved {
 
 function isChallengePayload(
   value: unknown,
-): value is RemoteWebPairingChallenge {
-  const payload = value as Partial<RemoteWebPairingChallenge>;
+): value is RemoteWebPairingChallengeResponse {
+  const payload = value as Partial<RemoteWebPairingChallengeResponse>;
   return (
     typeof payload?.deviceCode === "string" &&
     typeof payload.userCode === "string" &&
@@ -247,7 +245,7 @@ async function withRefreshLock<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 export function activateRemoteGatewaySession(
-  session: RemoteWebPairingApproved,
+  session: RemoteGatewaySessionCredentials,
 ): void {
   remoteGatewayRefreshAfterMs = toEpochMilliseconds(session.refreshAfter);
   setRemoteGatewayToken({
@@ -268,7 +266,7 @@ export async function exchangeRemoteWebPairingToken(
     method: "POST",
     credentials: "include",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ deviceCode }),
+    body: JSON.stringify({ deviceCode } satisfies RemoteWebPairingTokenRequest),
     signal,
   });
   // A non-JSON body (e.g. an HTML error page) resolves to null and falls
@@ -276,7 +274,8 @@ export async function exchangeRemoteWebPairingToken(
   const body = (await response.json().catch(() => null)) as unknown;
 
   if (response.status === 202) {
-    const pending = (body ?? {}) as Partial<RemoteWebPairingPending>;
+    const pending = (body ??
+      {}) as Partial<RemoteWebPairingTokenPendingResponse>;
     return {
       status: "pending",
       expiresAt: typeof pending.expiresAt === "string" ? pending.expiresAt : "",
@@ -308,12 +307,14 @@ export async function exchangeRemoteWebPairingToken(
 
 export async function createRemoteWebPairingChallenge(
   signal?: AbortSignal,
-): Promise<RemoteWebPairingChallenge> {
+): Promise<RemoteWebPairingChallengeResponse> {
   const response = await fetch(remoteGatewayApiPath(PAIRING_CHALLENGE_PATH), {
     method: "POST",
     credentials: "include",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ publicBaseUrl: remoteGatewayPublicBaseUrl() }),
+    body: JSON.stringify({
+      publicBaseUrl: remoteGatewayPublicBaseUrl(),
+    } satisfies RemoteWebPairingChallengeRequest),
     signal,
   });
   const body = (await response.json().catch(() => null)) as unknown;
@@ -351,9 +352,9 @@ async function refreshRemoteGatewaySessionOnce(): Promise<boolean> {
     return false;
   }
   activateRemoteGatewaySession({
-    ...(body as Omit<RemoteWebPairingApproved, "status">),
+    ...(body as Omit<RemoteWebPairingTokenApprovedResponse, "status">),
     status: "approved",
-  });
+  } as RemoteGatewaySessionCredentials);
   return true;
 }
 

--- a/gateway/src/http/routes/remote-web-pairing-token.ts
+++ b/gateway/src/http/routes/remote-web-pairing-token.ts
@@ -1,3 +1,8 @@
+import type {
+  RemoteWebPairingTokenApprovedResponse,
+  RemoteWebPairingTokenPendingResponse,
+} from "@vellumai/service-contracts/remote-web-pairing";
+
 import {
   ensureVellumGuardianBinding,
   getExternalAssistantId,
@@ -68,14 +73,15 @@ export async function handleRemoteWebPairingToken(
 
   const challenge = claimRemoteWebPairingChallengeExchange(deviceCode);
   if (challenge.status === "pending") {
-    return Response.json(
-      {
-        status: "pending",
-        expiresAt: challenge.expiresAt,
-        intervalSeconds: challenge.intervalSeconds,
-      },
-      { status: 202, headers: { "Cache-Control": "no-store" } },
-    );
+    const pending: RemoteWebPairingTokenPendingResponse = {
+      status: "pending",
+      expiresAt: challenge.expiresAt,
+      intervalSeconds: challenge.intervalSeconds,
+    };
+    return Response.json(pending, {
+      status: 202,
+      headers: { "Cache-Control": "no-store" },
+    });
   }
   if (
     challenge.status === "invalid" ||
@@ -127,15 +133,13 @@ export async function handleRemoteWebPairingToken(
     headers.append("Set-Cookie", cookie);
   }
 
-  return Response.json(
-    {
-      status: "approved",
-      accessToken: pair.accessToken,
-      accessTokenExpiresAt: new Date(pair.accessTokenExpiresAt).toISOString(),
-      refreshAfter: new Date(pair.refreshAfter).toISOString(),
-      guardianId: guardianPrincipalId,
-      assistantId: getExternalAssistantId(),
-    },
-    { headers },
-  );
+  const approved: RemoteWebPairingTokenApprovedResponse = {
+    status: "approved",
+    accessToken: pair.accessToken,
+    accessTokenExpiresAt: new Date(pair.accessTokenExpiresAt).toISOString(),
+    refreshAfter: new Date(pair.refreshAfter).toISOString(),
+    guardianId: guardianPrincipalId,
+    assistantId: getExternalAssistantId(),
+  };
+  return Response.json(approved, { headers });
 }

--- a/gateway/src/remote-web/pairing-challenge-store.ts
+++ b/gateway/src/remote-web/pairing-challenge-store.ts
@@ -1,5 +1,11 @@
 import { createHash, randomBytes, randomInt } from "node:crypto";
 
+import type {
+  RemoteWebPairingChallengeResponse,
+  RemoteWebPairingTokenPendingResponse,
+  RemoteWebPairingVerificationResponse,
+} from "@vellumai/service-contracts/remote-web-pairing";
+
 const CODE_TTL_MS = 10 * 60 * 1000;
 const MAX_ACTIVE_CHALLENGES = 200;
 const USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
@@ -19,25 +25,12 @@ export interface PendingRemoteWebPairingChallenge {
   consumedAtMs?: number;
 }
 
-export interface CreatedRemoteWebPairingChallenge {
-  deviceCode: string;
-  userCode: string;
-  verificationUri: string;
-  expiresAt: string;
-  expiresInSeconds: number;
-  intervalSeconds: number;
-}
-
 export interface RemoteWebPairingChallengeCapacityLimit {
   retryAfterSeconds: number;
 }
 
 export type ApproveRemoteWebPairingChallengeResult =
-  | {
-      status: "approved";
-      verificationUri: string;
-      expiresAt: string;
-    }
+  | RemoteWebPairingVerificationResponse
   | { status: "expired" }
   | { status: "invalid" };
 
@@ -48,11 +41,7 @@ export type ClaimRemoteWebPairingChallengeExchangeResult =
       verificationUri: string;
       expiresAt: string;
     }
-  | {
-      status: "pending";
-      expiresAt: string;
-      intervalSeconds: number;
-    }
+  | RemoteWebPairingTokenPendingResponse
   | { status: "expired" }
   | { status: "consumed" }
   | { status: "invalid" };
@@ -117,7 +106,7 @@ export function checkRemoteWebPairingChallengeCapacity(): RemoteWebPairingChalle
 
 export function createRemoteWebPairingChallenge(
   publicBaseUrl: string,
-): CreatedRemoteWebPairingChallenge {
+): RemoteWebPairingChallengeResponse {
   cleanupExpiredChallenges();
 
   const deviceCode = randomBytes(DEVICE_CODE_BYTES).toString("base64url");

--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -10,6 +10,7 @@
     "./client-metadata": "./src/client-metadata.ts",
     "./credential-rpc": "./src/credential-rpc.ts",
     "./ingress": "./src/ingress.ts",
+    "./remote-web-pairing": "./src/remote-web-pairing.ts",
     "./twilio-ingress": "./src/twilio-ingress.ts",
     "./trust-rules": "./src/trust-rules.ts",
     "./handles": "./src/handles.ts",

--- a/packages/service-contracts/src/index.ts
+++ b/packages/service-contracts/src/index.ts
@@ -26,4 +26,5 @@ export * from "./handles.js";
 export * from "./rpc.js";
 export * from "./trust-rules.js";
 export * from "./ingress.js";
+export * from "./remote-web-pairing.js";
 export * from "./twilio-ingress.js";

--- a/packages/service-contracts/src/remote-web-pairing.ts
+++ b/packages/service-contracts/src/remote-web-pairing.ts
@@ -1,0 +1,102 @@
+/**
+ * Wire contracts for the remote-web pairing flow — the RFC 8628-style
+ * device-code exchange that connects a browser (or the iOS app) to a
+ * self-hosted assistant over its public ingress URL.
+ *
+ * The gateway routes are the authoritative serving side:
+ *   - `POST /v1/remote-web/pairing-challenge`     mint a challenge
+ *       (`gateway/src/http/routes/remote-web-pairing-challenge.ts`,
+ *        `gateway/src/remote-web/pairing-challenge-store.ts`)
+ *   - `POST /v1/remote-web/pairing-verification`  approve by user code
+ *       (`gateway/src/http/routes/remote-web-pairing-verification.ts`)
+ *   - `POST /v1/remote-web/pairing-token`         poll + exchange device code
+ *       (`gateway/src/http/routes/remote-web-pairing-token.ts`)
+ *
+ * These shapes mirror those handlers' request/response bodies exactly so the
+ * gateway, the `vellum pair` CLI (`cli/src/commands/pair.ts`), and the web SPA
+ * (`clients/web/src/lib/auth/remote-gateway-session.ts`) share one definition
+ * and cannot silently drift.
+ *
+ * Timestamps are ISO-8601 strings — every gateway response serializes them via
+ * `Date#toISOString()`.
+ */
+
+/** `POST /v1/remote-web/pairing-challenge` request body. */
+export interface RemoteWebPairingChallengeRequest {
+  /** Public https base URL the scanning device can reach the assistant at. */
+  publicBaseUrl: string;
+}
+
+/** `POST /v1/remote-web/pairing-challenge` success response body (200). */
+export interface RemoteWebPairingChallengeResponse {
+  /** Opaque secret the paired device exchanges for a token. */
+  deviceCode: string;
+  /** Short human-readable code the host approves out of band. */
+  userCode: string;
+  /** URL the device opens to complete pairing. */
+  verificationUri: string;
+  /** ISO-8601 instant the challenge expires. */
+  expiresAt: string;
+  /** Seconds until the challenge expires. */
+  expiresInSeconds: number;
+  /** Recommended poll interval (seconds) for the token-exchange endpoint. */
+  intervalSeconds: number;
+}
+
+/** `POST /v1/remote-web/pairing-verification` request body. */
+export interface RemoteWebPairingVerificationRequest {
+  /** The `userCode` from the challenge, entered/scanned on the host. */
+  userCode: string;
+}
+
+/**
+ * `POST /v1/remote-web/pairing-verification` success response body (200).
+ *
+ * The gateway maps the `expired` / `invalid` outcomes to error responses, so
+ * the only success shape on the wire is the approved variant.
+ */
+export interface RemoteWebPairingVerificationResponse {
+  status: "approved";
+  verificationUri: string;
+  /** ISO-8601 instant the approved challenge expires. */
+  expiresAt: string;
+}
+
+/** `POST /v1/remote-web/pairing-token` request body. */
+export interface RemoteWebPairingTokenRequest {
+  /** The `deviceCode` from the challenge. */
+  deviceCode: string;
+}
+
+/**
+ * `POST /v1/remote-web/pairing-token` still-pending response body (202) — the
+ * challenge exists but has not been approved yet, so the client keeps polling.
+ */
+export interface RemoteWebPairingTokenPendingResponse {
+  status: "pending";
+  /** ISO-8601 instant the challenge expires. */
+  expiresAt: string;
+  /** Recommended poll interval (seconds) before the next exchange attempt. */
+  intervalSeconds: number;
+}
+
+/**
+ * `POST /v1/remote-web/pairing-token` approved response body (200) — carries
+ * the minted browser session credentials. The refresh token is delivered out
+ * of band as an `HttpOnly` cookie, not in this body.
+ */
+export interface RemoteWebPairingTokenApprovedResponse {
+  status: "approved";
+  accessToken: string;
+  /** ISO-8601 instant the access token expires. */
+  accessTokenExpiresAt: string;
+  /** ISO-8601 instant after which the client should refresh the session. */
+  refreshAfter: string;
+  guardianId: string;
+  assistantId: string;
+}
+
+/** Union of the two terminal `pairing-token` response bodies. */
+export type RemoteWebPairingTokenResponse =
+  | RemoteWebPairingTokenPendingResponse
+  | RemoteWebPairingTokenApprovedResponse;


### PR DESCRIPTION
## Summary
- The remote-web pairing challenge / approval / token wire shapes now live in one shared module — `@vellumai/service-contracts/remote-web-pairing` — which the gateway (authoritative serving side), the `vellum pair` CLI, and the web SPA all import.
- Types only — zero wire-behavior change; the local duplicates in all three places are deleted.
- Any drift found between the three copies is called out below and resolved toward the gateway's actual behavior (that drift is exactly what this PR exists to stop).

## Where the contracts landed, and why
`packages/service-contracts` — the existing lowest-layer, zero-runtime shared-contracts package that the gateway and clients/web already depend on. It already hosts cross-service wire vocab beyond CES (channel ids, ingress helpers, client-metadata, trust rules), so it is the right home; no new package was warranted. Added `cli` as a consumer (declared the workspace dep and the matching `bun.lock` edge). New subpath export: `@vellumai/service-contracts/remote-web-pairing`.

Kept plain TypeScript interfaces (matching the `client-metadata` / `ingress` convention) rather than zod schemas, because each side keeps its own hand-rolled runtime guards and this PR must not change validation behavior. The gateway's token-route response literals are now typed against the shared contract (typed consts, identical output) so the authoritative side is compile-checked against it.

## Drift found (resolved toward the gateway)
1. **CLI challenge response omitted `intervalSeconds`.** The gateway's challenge response always includes `intervalSeconds` (the device-code poll interval); the CLI's local `RemoteWebPairingChallengeResponse` left it out (the CLI approves locally and never polls). The shared type includes it — harmless for the CLI, which still ignores it.
2. **Web approved-token response was loosened.** The web's `RemoteWebPairingApproved` typed `accessTokenExpiresAt` / `refreshAfter` as `string | number` and marked `guardianId` / `assistantId` optional — because the same type was overloaded onto the `/v1/guardian/refresh` rotation response, which serializes those two instants as epoch-millisecond numbers and carries `guardianPrincipalId` (no `guardianId` / `assistantId` / `status`). The shared `RemoteWebPairingTokenApprovedResponse` matches the gateway's pairing-token response exactly (ISO-8601 strings, required `guardianId` / `assistantId`). To keep the guardian-refresh reuse correct without introducing a type lie, `activateRemoteGatewaySession` now takes a small local `RemoteGatewaySessionCredentials` type — the three credential fields it actually reads, still epoch-tolerant — which both the pairing-token and guardian-refresh paths satisfy.

The CLI's approval type and the web's challenge / pending types already matched the gateway exactly (renamed to the shared names, no shape change).

## Validation
- `bunx tsc --noEmit` (each package's typecheck script) passes in `cli`, `gateway`, and `clients/web`.
- Solo test runs, all green: cli `pair.test.ts` (`VELLUM_ENVIRONMENT=production`, 20), gateway `remote-web-pairing-challenge` / `-token` / `-verification` (11 / 13 / 5), web `pairing-page.test.tsx` (13) + `remote-gateway-session.test.ts` (13), service-contracts `package-boundary` (scans the new module — no forbidden imports) + `contracts` (4 / 30).

Part of plan: ios-self-hosted-connect.md (M3 backlog — recorded review observation).