### PR TITLE
fix(web): app handoff URL keeps the served path prefix

### DIFF
--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -338,6 +338,35 @@ describe("RemoteWebPairingPage", () => {
     ).not.toBeNull();
   });
 
+  test("the app handoff url keeps a served path prefix", async () => {
+    remoteGatewayMode = true;
+    setUserAgent(IPHONE_USER_AGENT);
+    // The real window location carries the served path in production; the
+    // in-memory router below only controls the route, not window.location.
+    window.history.pushState(null, "", "/assistant-123/assistant/pair");
+
+    try {
+      render(
+        <MemoryRouter
+          initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
+        >
+          <RemoteWebPairingPage />
+        </MemoryRouter>,
+      );
+
+      const link = await screen.findByRole("link", {
+        name: "Open in the Vellum app",
+      });
+      const href = link.getAttribute("href") ?? "";
+      const query = new URLSearchParams(href.slice(href.indexOf("?") + 1));
+      expect(query.get("url")).toBe(
+        `${window.location.origin}/assistant-123`,
+      );
+    } finally {
+      window.history.pushState(null, "", "/");
+    }
+  });
+
   test("exchanges immediately for a device code in a non-iOS browser", async () => {
     remoteGatewayMode = true;
     // The default happy-dom user agent is a non-iOS browser.

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -124,14 +124,33 @@ function clearDeviceCodeFromUrl(): void {
 const VELLUM_APP_SCHEME = "vellum-assistant";
 
 /**
- * Build the `vellum-assistant://connect?url=<origin>&code=<device-code>` deep
+ * The server's public base URL: origin plus any path prefix the deployment is
+ * served under, derived by stripping this page's own route from the pathname.
+ * A prefix-served assistant (pair page at
+ * `https://host/assistant-123/assistant/pair`) must hand the app
+ * `https://host/assistant-123` — the connect handler appends the pair route
+ * back onto whatever base it receives.
+ */
+function publicBaseFromLocation(): string {
+  const { origin, pathname } = window.location;
+  const normalized = pathname.replace(/\/+$/, "");
+  const suffix = "/assistant/pair";
+  if (normalized.endsWith(suffix)) {
+    return `${origin}${normalized.slice(0, -suffix.length)}`;
+  }
+  return origin;
+}
+
+/**
+ * Build the `vellum-assistant://connect?url=<base>&code=<device-code>` deep
  * link the iOS app consumes to persist this server and finish pairing inside
- * the app. `url` is the page's own origin so the app reconnects to the same
- * self-hosted assistant this browser is already on.
+ * the app. `url` is the page's own public base (origin + served path prefix)
+ * so the app reconnects to the same self-hosted assistant this browser is
+ * already on.
  */
 function buildAppHandoffUrl(deviceCode: string): string {
   const query = new URLSearchParams({
-    url: window.location.origin,
+    url: publicBaseFromLocation(),
     code: deviceCode,
   });
   return `${VELLUM_APP_SCHEME}://connect?${query.toString()}`;


### PR DESCRIPTION
## Summary
- The Open-in-app link's url param now carries origin + any served path prefix (derived by stripping the page's own /assistant/pair route from the pathname), matching the iOS connect handler's prefix-preserving pair-URL derivation
- Prefixed and unprefixed shapes test-pinned; validation note: fresh-worktree tsc baseline (missing generated API clients) is identical with and without this change — zero new errors — and the page's test file passes 14/14

Fixes the Codex P1 on #38710.