### PR TITLE
refactor(events): single-source background-tool + workflow events from api/events

### DIFF
--- a/assistant/src/daemon/message-types/background-tools.ts
+++ b/assistant/src/daemon/message-types/background-tools.ts
@@ -1,28 +1,14 @@
 // Background bash/host_bash command lifecycle types.
+//
+// Server→client events are single-sourced from their canonical `api/events`
+// wire schemas; this file only composes them into the domain union consumed by
+// `message-protocol.ts`.
 
-// === Server → Client (streamed via SSE) ===
-
-export interface BackgroundToolStarted {
-  type: "background_tool_started";
-  id: string;
-  toolName: string;
-  conversationId: string;
-  command: string;
-  startedAt: number;
-}
-
-export interface BackgroundToolCompleted {
-  type: "background_tool_completed";
-  id: string;
-  conversationId: string;
-  status: "completed" | "failed" | "cancelled";
-  exitCode?: number | null;
-  output?: string;
-  completedAt: number;
-}
+import type { BackgroundToolCompletedEvent } from "../../api/events/background-tool-completed.js";
+import type { BackgroundToolStartedEvent } from "../../api/events/background-tool-started.js";
 
 // --- Domain-level union alias (consumed by message-protocol.ts) ---
 
 export type _BackgroundToolsServerMessages =
-  | BackgroundToolStarted
-  | BackgroundToolCompleted;
+  | BackgroundToolStartedEvent
+  | BackgroundToolCompletedEvent;

--- a/assistant/src/daemon/message-types/workflows.ts
+++ b/assistant/src/daemon/message-types/workflows.ts
@@ -4,128 +4,22 @@
 // progresses and completes. These are server → client push events only — the
 // run is launched via the workflow tool / scheduler / routes (later PRs), not
 // via a client message in this union.
+//
+// The events are single-sourced from their canonical `api/events` wire
+// schemas; this file only composes them into the domain union consumed by
+// `message-protocol.ts`.
 
-import type { WorkflowRunStatus } from "../../workflows/journal-store.js";
-
-// === Server → Client ===
-
-/**
- * Progress push for an in-flight workflow run. Maps the engine's
- * `onProgress` (`phase`/`log`) callback plus the current usage snapshot into a
- * single wire event. `phase` carries the latest `phase(title)`; `message`
- * carries the latest `log(msg)`; only one is set per emission.
- */
-export interface WorkflowProgress {
-  type: "workflow_progress";
-  runId: string;
-  /**
-   * Originating conversation id, when launched from one; lets `broadcastMessage`
-   * auto-scope + seq-stamp the event to that conversation's SSE stream. Omitted
-   * for a conversationless run (e.g. a scheduled workflow), which broadcasts
-   * unscoped for raw SSE listeners and the DB record.
-   */
-  conversationId?: string;
-  /** Latest phase title, when this emission came from a `phase(...)` call. */
-  phase?: string;
-  /** Run label (the workflow's `meta.name`), for client display. */
-  label?: string;
-  /** Live agent count at emission time. */
-  agentsSpawned: number;
-  /** Latest log line, when this emission came from a `log(...)` call. */
-  message?: string;
-}
-
-/**
- * Terminal push for a workflow run. Carries the final status, counts, token
- * usage, and a human-readable result/error summary the originating
- * conversation also receives via an agent wake.
- */
-export interface WorkflowCompleted {
-  type: "workflow_completed";
-  runId: string;
-  /**
-   * Originating conversation id, when launched from one; lets `broadcastMessage`
-   * auto-scope + seq-stamp the event to that conversation's SSE stream. Omitted
-   * for a conversationless run (e.g. a scheduled workflow), which broadcasts
-   * unscoped for raw SSE listeners and the DB record.
-   */
-  conversationId?: string;
-  status: WorkflowRunStatus;
-  agentsSpawned: number;
-  inputTokens: number;
-  outputTokens: number;
-  /** Human-readable result-or-error summary. */
-  summary?: string;
-}
-
-/**
- * A workflow run has started. Emitted once at launch, before any leaf events.
- */
-export interface WorkflowStarted {
-  type: "workflow_started";
-  runId: string;
-  /**
-   * Originating conversation id; lets `broadcastMessage` auto-scope +
-   * seq-stamp the event to the conversation's SSE stream.
-   */
-  conversationId: string;
-  /**
-   * Tool-use id of the `skill_execute` block that launched this run, for
-   * anchoring the inline workflow card to the exact spawn tool call.
-   */
-  toolUseId?: string;
-  /** Run label (the workflow's `meta.name`), for client display. */
-  label?: string;
-}
-
-/**
- * A leaf agent within a workflow run has started. `seq` orders leaves within
- * the run for stable client-side tree placement.
- */
-export interface WorkflowLeafStarted {
-  type: "workflow_leaf_started";
-  runId: string;
-  /**
-   * Originating conversation id; lets `broadcastMessage` auto-scope +
-   * seq-stamp the event to the conversation's SSE stream.
-   */
-  conversationId: string;
-  seq: number;
-  /** Leaf label, for client display. */
-  label?: string;
-  /** Phase the leaf belongs to, when the workflow declares phases. */
-  phase?: string;
-  /** Short summary of the leaf's prompt, for client display. */
-  promptSummary?: string;
-}
-
-/**
- * A leaf agent within a workflow run has finished. `seq` matches the
- * corresponding `workflow_leaf_started` event.
- */
-export interface WorkflowLeafFinished {
-  type: "workflow_leaf_finished";
-  runId: string;
-  /**
-   * Originating conversation id; lets `broadcastMessage` auto-scope +
-   * seq-stamp the event to the conversation's SSE stream.
-   */
-  conversationId: string;
-  seq: number;
-  status: "completed" | "failed";
-  /** Leaf label, for client display. */
-  label?: string;
-  inputTokens?: number;
-  outputTokens?: number;
-  /** Short summary of the leaf's result, for client display. */
-  resultSummary?: string;
-}
+import type { WorkflowCompletedEvent } from "../../api/events/workflow-completed.js";
+import type { WorkflowLeafFinishedEvent } from "../../api/events/workflow-leaf-finished.js";
+import type { WorkflowLeafStartedEvent } from "../../api/events/workflow-leaf-started.js";
+import type { WorkflowProgressEvent } from "../../api/events/workflow-progress.js";
+import type { WorkflowStartedEvent } from "../../api/events/workflow-started.js";
 
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _WorkflowsServerMessages =
-  | WorkflowProgress
-  | WorkflowCompleted
-  | WorkflowStarted
-  | WorkflowLeafStarted
-  | WorkflowLeafFinished;
+  | WorkflowProgressEvent
+  | WorkflowCompletedEvent
+  | WorkflowStartedEvent
+  | WorkflowLeafStartedEvent
+  | WorkflowLeafFinishedEvent;

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -1,8 +1,8 @@
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 
+import type { BackgroundToolCompletedEvent } from "../../api/events/background-tool-completed.js";
 import { getConfig } from "../../config/loader.js";
-import type { BackgroundToolCompleted } from "../../daemon/message-types/background-tools.js";
 import { RiskLevel } from "../../permissions/types.js";
 import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
@@ -340,7 +340,9 @@ export const shellTool = {
       let completed = false;
 
       child.on("close", (code, signal) => {
-        if (completed) {return;}
+        if (completed) {
+          return;
+        }
         completed = true;
         clearTimeout(timer);
         removeBackgroundTool(bgId);
@@ -367,7 +369,7 @@ export const shellTool = {
           timeoutSec,
         );
 
-        const status: BackgroundToolCompleted["status"] = aborted
+        const status: BackgroundToolCompletedEvent["status"] = aborted
           ? "cancelled"
           : timedOut
             ? "failed"
@@ -430,7 +432,9 @@ export const shellTool = {
       });
 
       child.on("error", (err) => {
-        if (completed) {return;}
+        if (completed) {
+          return;
+        }
         completed = true;
         clearTimeout(timer);
         removeBackgroundTool(bgId);


### PR DESCRIPTION
## Prompt / plan

First step of the event-type unification: collapse the duplicate server→client event definitions onto the canonical `api/events` wire schemas (the single source of truth), so runtime `message-types` domains **compose the api-inferred types** instead of re-declaring them. This is groundwork toward making `api/events` the sole event definition and eventually retiring `ServerMessage` — which unblocks validating/publishing events cleanly across process boundaries (the `/events/publish` transport and multi-process turns).

Deliberately small and low-risk to establish and prove the migration pattern (and the parity guards) before batching more domains.

## Changes

- `message-types/background-tools.ts` and `message-types/workflows.ts` now `import type` their event types from the matching `api/events/*` schemas and only compose the domain union; the hand-written local interfaces are deleted.
- `tools/terminal/shell.ts` — the one external consumer — uses `BackgroundToolCompletedEvent` from `api/events` directly.

## Why this is a no-op on the wire

Both domains were verified **field-for-field identical** to their api schemas. The safety net is the compiler: because every `broadcastMessage(...)` construction site must now satisfy the api-inferred type, a clean `typecheck` proves the api type is compatible with what's actually built and sent. No wire or type change.

## Test plan

- `bun run typecheck:fast` clean (all construction sites satisfy the api types).
- Schema tests for the migrated events pass (`background-tool-*`, `workflow-*`).
- SSE parity guard `runtime-events-sse-parity.test.ts` green (14 pass).
- Lint + format green via the pre-commit hook.

<!-- CLI verb checklist: no routes added. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_