### PR TITLE
feat(plugin-api): expose streaming transcription session

### DIFF
--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -295,6 +295,32 @@ export {
 export type { SynthesizeTextOptions } from "../tts/synthesize-text.js";
 export { synthesizeText, TtsSynthesisError } from "../tts/synthesize-text.js";
 export type { TtsSynthesisResult } from "../tts/types.js";
+// Streaming speech-to-text — open a live transcription session against the
+// assistant's globally configured STT provider stack. The plugin feeds PCM
+// audio chunks via `sendAudio` and receives partial/final transcript events
+// through the `start(onEvent)` callback, closing with `stop`. Resolved from
+// process-local state only (workspace config + credential store), with no
+// in-daemon singletons, so a plugin can open a session from a spawned child
+// process (e.g. a meeting bot piping call audio), not just in-daemon.
+// `SttStreamServerEvent` and its variants type the events handed to `onEvent`;
+// `SttErrorCategory` classifies `error` events; `SttProviderId` names the
+// providers `listStreamingTranscriptionProviderIds` returns.
+export type {
+  StreamingTranscriber,
+  SttErrorCategory,
+  SttProviderId,
+  SttStreamServerClosedEvent,
+  SttStreamServerErrorEvent,
+  SttStreamServerEvent,
+  SttStreamServerFinalEvent,
+  SttStreamServerFinalizedEvent,
+  SttStreamServerPartialEvent,
+} from "../stt/types.js";
+export type { OpenTranscriptionSessionOptions } from "./transcription-session.js";
+export {
+  listStreamingTranscriptionProviderIds,
+  openTranscriptionSession,
+} from "./transcription-session.js";
 // Conversation agent-loop turn — run a full conversation turn (persist user
 // message, execute the agent loop with history/tools/compaction/injections,
 // return the assistant's full content-block response). Accepts ContentBlock[]

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -296,15 +296,12 @@ export type { SynthesizeTextOptions } from "../tts/synthesize-text.js";
 export { synthesizeText, TtsSynthesisError } from "../tts/synthesize-text.js";
 export type { TtsSynthesisResult } from "../tts/types.js";
 // Streaming speech-to-text — open a live transcription session against the
-// assistant's globally configured STT provider stack. The plugin feeds PCM
-// audio chunks via `sendAudio` and receives partial/final transcript events
-// through the `start(onEvent)` callback, closing with `stop`. Resolved from
-// process-local state only (workspace config + credential store), with no
-// in-daemon singletons, so a plugin can open a session from a spawned child
-// process (e.g. a meeting bot piping call audio), not just in-daemon.
-// `SttStreamServerEvent` and its variants type the events handed to `onEvent`;
-// `SttErrorCategory` classifies `error` events; `SttProviderId` names the
-// providers `listStreamingTranscriptionProviderIds` returns.
+// assistant's globally configured STT provider stack. The plugin feeds audio
+// chunks via `sendAudio` and receives partial/final transcript events through
+// the `start(onEvent)` callback, closing with `stop`. `SttStreamServerEvent`
+// and its variants type the events handed to `onEvent`; `SttErrorCategory`
+// classifies `error` events; `SttProviderId` names the resolved session's
+// provider.
 export type {
   StreamingTranscriber,
   SttErrorCategory,
@@ -316,11 +313,7 @@ export type {
   SttStreamServerFinalizedEvent,
   SttStreamServerPartialEvent,
 } from "../stt/types.js";
-export type { OpenTranscriptionSessionOptions } from "./transcription-session.js";
-export {
-  listStreamingTranscriptionProviderIds,
-  openTranscriptionSession,
-} from "./transcription-session.js";
+export { openTranscriptionSession } from "./transcription-session.js";
 // Conversation agent-loop turn — run a full conversation turn (persist user
 // message, execute the agent loop with history/tools/compaction/injections,
 // return the assistant's full content-block response). Accepts ContentBlock[]

--- a/assistant/src/plugin-api/transcription-session.test.ts
+++ b/assistant/src/plugin-api/transcription-session.test.ts
@@ -1,44 +1,23 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type {
-  StreamingTranscriber,
-  SttBoundaryId,
-  SttProviderId,
-} from "../stt/types.js";
+import type { StreamingTranscriber } from "../stt/types.js";
 
 // ---------------------------------------------------------------------------
-// Mocks — declared before the subject import so the facade's lazy
-// `await import()` calls resolve to these stand-ins.
+// Mocks — declared before the subject import so the facade's static import of
+// the resolver resolves to this stand-in.
 // ---------------------------------------------------------------------------
 
-let resolveCalls: unknown[] = [];
+let resolveCalls = 0;
 let resolveResult: StreamingTranscriber | null = null;
 
 mock.module("../providers/speech-to-text/resolve.js", () => ({
-  resolveStreamingTranscriber: (options: unknown) => {
-    resolveCalls.push(options);
+  resolveStreamingTranscriber: () => {
+    resolveCalls++;
     return Promise.resolve(resolveResult);
   },
 }));
 
-// A tiny catalog: two providers, only one of which streams.
-const STREAMING: SttBoundaryId = "daemon-streaming";
-const CATALOG: Record<SttProviderId, Set<SttBoundaryId>> = {
-  deepgram: new Set<SttBoundaryId>(["daemon-batch", "daemon-streaming"]),
-  "openai-whisper": new Set<SttBoundaryId>(["daemon-batch"]),
-  "google-gemini": new Set<SttBoundaryId>(["daemon-streaming"]),
-  xai: new Set<SttBoundaryId>(["daemon-streaming"]),
-  vellum: new Set<SttBoundaryId>(["daemon-streaming"]),
-};
-
-mock.module("../providers/speech-to-text/provider-catalog.js", () => ({
-  listProviderIds: () => Object.keys(CATALOG) as SttProviderId[],
-  supportsBoundary: (id: SttProviderId, boundary: SttBoundaryId) =>
-    CATALOG[id]?.has(boundary) ?? false,
-}));
-
-const { openTranscriptionSession, listStreamingTranscriptionProviderIds } =
-  await import("./transcription-session.js");
+const { openTranscriptionSession } = await import("./transcription-session.js");
 
 // A minimal session object standing in for a resolved transcriber.
 function fakeSession(): StreamingTranscriber {
@@ -52,60 +31,24 @@ function fakeSession(): StreamingTranscriber {
 }
 
 beforeEach(() => {
-  resolveCalls = [];
+  resolveCalls = 0;
   resolveResult = null;
 });
 
 describe("openTranscriptionSession", () => {
-  test("returns the resolved streaming session", async () => {
+  test("returns the session resolved for the configured provider", async () => {
     const session = fakeSession();
     resolveResult = session;
 
-    const result = await openTranscriptionSession({ sampleRate: 16_000 });
+    const result = await openTranscriptionSession();
 
     expect(result).toBe(session);
-  });
-
-  test("forwards supplied options to the resolver", async () => {
-    resolveResult = fakeSession();
-
-    await openTranscriptionSession({
-      sampleRate: 16_000,
-      diarize: "preferred",
-      providerId: "deepgram",
-    });
-
-    expect(resolveCalls).toEqual([
-      { sampleRate: 16_000, diarize: "preferred", providerId: "deepgram" },
-    ]);
-  });
-
-  test("omits unset options rather than forwarding undefined", async () => {
-    resolveResult = fakeSession();
-
-    await openTranscriptionSession();
-
-    expect(resolveCalls).toEqual([{}]);
+    expect(resolveCalls).toBe(1);
   });
 
   test("returns null when no streaming session can be opened", async () => {
     resolveResult = null;
 
-    const result = await openTranscriptionSession({ diarize: "required" });
-
-    expect(result).toBeNull();
-    // The unusable request still reached the resolver.
-    expect(resolveCalls).toEqual([{ diarize: "required" }]);
-  });
-});
-
-describe("listStreamingTranscriptionProviderIds", () => {
-  test("lists only providers supporting the daemon-streaming boundary", async () => {
-    const ids = await listStreamingTranscriptionProviderIds();
-
-    expect(ids).toEqual(["deepgram", "google-gemini", "xai", "vellum"]);
-    expect(ids).not.toContain("openai-whisper");
-    // Sanity: the boundary constant is the one the facade filters on.
-    expect(STREAMING).toBe("daemon-streaming");
+    expect(await openTranscriptionSession()).toBeNull();
   });
 });

--- a/assistant/src/plugin-api/transcription-session.test.ts
+++ b/assistant/src/plugin-api/transcription-session.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  StreamingTranscriber,
+  SttBoundaryId,
+  SttProviderId,
+} from "../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before the subject import so the facade's lazy
+// `await import()` calls resolve to these stand-ins.
+// ---------------------------------------------------------------------------
+
+let resolveCalls: unknown[] = [];
+let resolveResult: StreamingTranscriber | null = null;
+
+mock.module("../providers/speech-to-text/resolve.js", () => ({
+  resolveStreamingTranscriber: (options: unknown) => {
+    resolveCalls.push(options);
+    return Promise.resolve(resolveResult);
+  },
+}));
+
+// A tiny catalog: two providers, only one of which streams.
+const STREAMING: SttBoundaryId = "daemon-streaming";
+const CATALOG: Record<SttProviderId, Set<SttBoundaryId>> = {
+  deepgram: new Set<SttBoundaryId>(["daemon-batch", "daemon-streaming"]),
+  "openai-whisper": new Set<SttBoundaryId>(["daemon-batch"]),
+  "google-gemini": new Set<SttBoundaryId>(["daemon-streaming"]),
+  xai: new Set<SttBoundaryId>(["daemon-streaming"]),
+  vellum: new Set<SttBoundaryId>(["daemon-streaming"]),
+};
+
+mock.module("../providers/speech-to-text/provider-catalog.js", () => ({
+  listProviderIds: () => Object.keys(CATALOG) as SttProviderId[],
+  supportsBoundary: (id: SttProviderId, boundary: SttBoundaryId) =>
+    CATALOG[id]?.has(boundary) ?? false,
+}));
+
+const { openTranscriptionSession, listStreamingTranscriptionProviderIds } =
+  await import("./transcription-session.js");
+
+// A minimal session object standing in for a resolved transcriber.
+function fakeSession(): StreamingTranscriber {
+  return {
+    providerId: "deepgram",
+    boundaryId: "daemon-streaming",
+    start: () => Promise.resolve(),
+    sendAudio: () => {},
+    stop: () => {},
+  };
+}
+
+beforeEach(() => {
+  resolveCalls = [];
+  resolveResult = null;
+});
+
+describe("openTranscriptionSession", () => {
+  test("returns the resolved streaming session", async () => {
+    const session = fakeSession();
+    resolveResult = session;
+
+    const result = await openTranscriptionSession({ sampleRate: 16_000 });
+
+    expect(result).toBe(session);
+  });
+
+  test("forwards supplied options to the resolver", async () => {
+    resolveResult = fakeSession();
+
+    await openTranscriptionSession({
+      sampleRate: 16_000,
+      diarize: "preferred",
+      providerId: "deepgram",
+    });
+
+    expect(resolveCalls).toEqual([
+      { sampleRate: 16_000, diarize: "preferred", providerId: "deepgram" },
+    ]);
+  });
+
+  test("omits unset options rather than forwarding undefined", async () => {
+    resolveResult = fakeSession();
+
+    await openTranscriptionSession();
+
+    expect(resolveCalls).toEqual([{}]);
+  });
+
+  test("returns null when no streaming session can be opened", async () => {
+    resolveResult = null;
+
+    const result = await openTranscriptionSession({ diarize: "required" });
+
+    expect(result).toBeNull();
+    // The unusable request still reached the resolver.
+    expect(resolveCalls).toEqual([{ diarize: "required" }]);
+  });
+});
+
+describe("listStreamingTranscriptionProviderIds", () => {
+  test("lists only providers supporting the daemon-streaming boundary", async () => {
+    const ids = await listStreamingTranscriptionProviderIds();
+
+    expect(ids).toEqual(["deepgram", "google-gemini", "xai", "vellum"]);
+    expect(ids).not.toContain("openai-whisper");
+    // Sanity: the boundary constant is the one the facade filters on.
+    expect(STREAMING).toBe("daemon-streaming");
+  });
+});

--- a/assistant/src/plugin-api/transcription-session.ts
+++ b/assistant/src/plugin-api/transcription-session.ts
@@ -1,0 +1,116 @@
+/**
+ * Plugin-facing facade for opening a streaming speech-to-text session against
+ * the assistant's configured STT provider stack.
+ *
+ * A session is the streaming counterpart to the stateless `synthesizeText`
+ * (TTS) helper: the plugin feeds raw audio chunks in and receives partial and
+ * final transcript events back over a callback. The consumer drives it through
+ * a minimal three-method contract — {@link StreamingTranscriber.start},
+ * {@link StreamingTranscriber.sendAudio}, and {@link StreamingTranscriber.stop}
+ * — so a plugin (e.g. a meeting bot piping PCM frames captured from a call)
+ * needs no knowledge of the concrete provider (Deepgram, Whisper, Gemini, xAI,
+ * or Vellum-managed speech), its wire protocol, or its credentials.
+ *
+ * ## Child-process safety
+ *
+ * The session is deliberately singleton-free: it resolves the provider and its
+ * credentials from process-local state only — the workspace config on disk
+ * (`services.stt.provider`) and the credential store over the CES socket — and
+ * the returned session dials the provider directly. It does **not** touch any
+ * in-daemon singleton (the live-voice session manager, the WebSocket session
+ * registry, or the event hub). A plugin can therefore open a session from a
+ * spawned child process, not just from the daemon process, as long as that
+ * process inherits the workspace directory and can reach the credential store.
+ *
+ * Prefer this over reaching for the daemon's WebSocket STT session
+ * orchestrator: that path is bound to a client socket and the daemon-wide
+ * active-session registry, neither of which exists in a child process.
+ */
+
+import type {
+  StreamingTranscriber,
+  SttProviderId,
+} from "../stt/types.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface OpenTranscriptionSessionOptions {
+  /**
+   * Sample rate (Hz) of the PCM audio the plugin will feed. Passed through to
+   * the provider adapter so it decodes at the right rate. Supply this whenever
+   * the audio is raw PCM (e.g. `audio/pcm`) — a mismatch produces garbled
+   * transcripts. Ignored for container formats that carry their own rate.
+   */
+  sampleRate?: number;
+  /**
+   * Speaker diarization preference. Default: `"off"`.
+   *
+   * - `"off"` — never request speaker labels.
+   * - `"preferred"` — request diarization when the configured provider supports
+   *   it; proceed without it otherwise.
+   * - `"required"` — require diarization; resolve to `null` when the configured
+   *   provider cannot diarize, so the caller can surface a clear error.
+   */
+  diarize?: "off" | "preferred" | "required";
+  /**
+   * Provider to open a session for. Defaults to `services.stt.provider` from
+   * the workspace config. Supply this only when the plugin has independently
+   * determined the effective provider and wants the session to match it.
+   */
+  providerId?: SttProviderId;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Open a streaming transcription session against the configured STT provider.
+ *
+ * Resolves the provider from the workspace config (or `options.providerId`),
+ * verifies it supports daemon-streaming transcription, and looks up its
+ * credentials — then returns a live {@link StreamingTranscriber} the caller
+ * drives with `start` / `sendAudio` / `stop`.
+ *
+ * Returns `null` when no streaming session can be opened, i.e. the resolved
+ * provider is unknown, lacks a streaming adapter, has no credentials, or
+ * cannot satisfy a `diarize: "required"` request. Callers that want to explain
+ * the gap can list the eligible providers with
+ * {@link listStreamingTranscriptionProviderIds}.
+ */
+export async function openTranscriptionSession(
+  options: OpenTranscriptionSessionOptions = {},
+): Promise<StreamingTranscriber | null> {
+  const { resolveStreamingTranscriber } = await import(
+    "../providers/speech-to-text/resolve.js"
+  );
+  return resolveStreamingTranscriber({
+    ...(options.sampleRate !== undefined
+      ? { sampleRate: options.sampleRate }
+      : {}),
+    ...(options.diarize !== undefined ? { diarize: options.diarize } : {}),
+    ...(options.providerId !== undefined
+      ? { providerId: options.providerId }
+      : {}),
+  });
+}
+
+/**
+ * List the STT provider IDs that support daemon-streaming transcription, in
+ * catalog order. A session can only be opened for one of these (and only when
+ * its credentials are present), so callers use this to build a remediation
+ * message when {@link openTranscriptionSession} returns `null` — e.g. "set
+ * services.stt.provider to one of: …".
+ */
+export async function listStreamingTranscriptionProviderIds(): Promise<
+  SttProviderId[]
+> {
+  const { listProviderIds, supportsBoundary } = await import(
+    "../providers/speech-to-text/provider-catalog.js"
+  );
+  return listProviderIds().filter((id) =>
+    supportsBoundary(id, "daemon-streaming"),
+  );
+}

--- a/assistant/src/plugin-api/transcription-session.ts
+++ b/assistant/src/plugin-api/transcription-session.ts
@@ -3,114 +3,26 @@
  * the assistant's configured STT provider stack.
  *
  * A session is the streaming counterpart to the stateless `synthesizeText`
- * (TTS) helper: the plugin feeds raw audio chunks in and receives partial and
- * final transcript events back over a callback. The consumer drives it through
- * a minimal three-method contract — {@link StreamingTranscriber.start},
- * {@link StreamingTranscriber.sendAudio}, and {@link StreamingTranscriber.stop}
- * — so a plugin (e.g. a meeting bot piping PCM frames captured from a call)
- * needs no knowledge of the concrete provider (Deepgram, Whisper, Gemini, xAI,
- * or Vellum-managed speech), its wire protocol, or its credentials.
- *
- * ## Child-process safety
- *
- * The session is deliberately singleton-free: it resolves the provider and its
- * credentials from process-local state only — the workspace config on disk
- * (`services.stt.provider`) and the credential store over the CES socket — and
- * the returned session dials the provider directly. It does **not** touch any
- * in-daemon singleton (the live-voice session manager, the WebSocket session
- * registry, or the event hub). A plugin can therefore open a session from a
- * spawned child process, not just from the daemon process, as long as that
- * process inherits the workspace directory and can reach the credential store.
- *
- * Prefer this over reaching for the daemon's WebSocket STT session
- * orchestrator: that path is bound to a client socket and the daemon-wide
- * active-session registry, neither of which exists in a child process.
+ * (TTS) helper: the plugin feeds raw audio chunks in via `sendAudio` and
+ * receives partial and final transcript events back through the
+ * `start(onEvent)` callback, closing with `stop`. The consumer drives this
+ * three-method contract without knowing the concrete provider (Deepgram,
+ * Whisper, Gemini, xAI, or Vellum-managed speech), its wire protocol, or its
+ * credentials.
  */
 
-import type {
-  StreamingTranscriber,
-  SttProviderId,
-} from "../stt/types.js";
-
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
-export interface OpenTranscriptionSessionOptions {
-  /**
-   * Sample rate (Hz) of the PCM audio the plugin will feed. Passed through to
-   * the provider adapter so it decodes at the right rate. Supply this whenever
-   * the audio is raw PCM (e.g. `audio/pcm`) — a mismatch produces garbled
-   * transcripts. Ignored for container formats that carry their own rate.
-   */
-  sampleRate?: number;
-  /**
-   * Speaker diarization preference. Default: `"off"`.
-   *
-   * - `"off"` — never request speaker labels.
-   * - `"preferred"` — request diarization when the configured provider supports
-   *   it; proceed without it otherwise.
-   * - `"required"` — require diarization; resolve to `null` when the configured
-   *   provider cannot diarize, so the caller can surface a clear error.
-   */
-  diarize?: "off" | "preferred" | "required";
-  /**
-   * Provider to open a session for. Defaults to `services.stt.provider` from
-   * the workspace config. Supply this only when the plugin has independently
-   * determined the effective provider and wants the session to match it.
-   */
-  providerId?: SttProviderId;
-}
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
+import { resolveStreamingTranscriber } from "../providers/speech-to-text/resolve.js";
+import type { StreamingTranscriber } from "../stt/types.js";
 
 /**
- * Open a streaming transcription session against the configured STT provider.
+ * Open a streaming transcription session against the configured STT provider
+ * (`services.stt.provider`).
  *
- * Resolves the provider from the workspace config (or `options.providerId`),
- * verifies it supports daemon-streaming transcription, and looks up its
- * credentials — then returns a live {@link StreamingTranscriber} the caller
- * drives with `start` / `sendAudio` / `stop`.
- *
- * Returns `null` when no streaming session can be opened, i.e. the resolved
- * provider is unknown, lacks a streaming adapter, has no credentials, or
- * cannot satisfy a `diarize: "required"` request. Callers that want to explain
- * the gap can list the eligible providers with
- * {@link listStreamingTranscriptionProviderIds}.
+ * Returns a live {@link StreamingTranscriber} the caller drives with
+ * `start` / `sendAudio` / `stop`, or `null` when no streaming session can be
+ * opened — the provider is unknown, has no streaming adapter, or is missing
+ * credentials.
  */
-export async function openTranscriptionSession(
-  options: OpenTranscriptionSessionOptions = {},
-): Promise<StreamingTranscriber | null> {
-  const { resolveStreamingTranscriber } = await import(
-    "../providers/speech-to-text/resolve.js"
-  );
-  return resolveStreamingTranscriber({
-    ...(options.sampleRate !== undefined
-      ? { sampleRate: options.sampleRate }
-      : {}),
-    ...(options.diarize !== undefined ? { diarize: options.diarize } : {}),
-    ...(options.providerId !== undefined
-      ? { providerId: options.providerId }
-      : {}),
-  });
-}
-
-/**
- * List the STT provider IDs that support daemon-streaming transcription, in
- * catalog order. A session can only be opened for one of these (and only when
- * its credentials are present), so callers use this to build a remediation
- * message when {@link openTranscriptionSession} returns `null` — e.g. "set
- * services.stt.provider to one of: …".
- */
-export async function listStreamingTranscriptionProviderIds(): Promise<
-  SttProviderId[]
-> {
-  const { listProviderIds, supportsBoundary } = await import(
-    "../providers/speech-to-text/provider-catalog.js"
-  );
-  return listProviderIds().filter((id) =>
-    supportsBoundary(id, "daemon-streaming"),
-  );
+export function openTranscriptionSession(): Promise<StreamingTranscriber | null> {
+  return resolveStreamingTranscriber();
 }


### PR DESCRIPTION
## Prompt / plan

Extend `@vellumai/plugin-api` to expose the assistant's configured STT provider stack as a streaming transcription session a plugin can open — feed audio chunks in via `sendAudio`, receive partial/final transcript events back through `start(onEvent)`, and close with `stop`. This is the three-method contract the [meeting-bot audio-ingest](https://github.com/vellum-ai/meeting-bot/blob/be4848ff5a4cebcf4adc5bf54a0d4ea97a4e9a63/src/vellum/meet/daemon/audio-ingest.ts#L173-L177) consumes (currently stubbed).

## What changed

- **New facade `assistant/src/plugin-api/transcription-session.ts`:** `openTranscriptionSession()` returns a live `StreamingTranscriber` (the `start` / `sendAudio` / `stop` contract, plus optional `finalizeUtterance`) for the configured provider (`services.stt.provider`), or `null` when no streaming session can be opened (unknown provider, no streaming adapter, or missing credentials). A thin delegate over the existing `resolveStreamingTranscriber`.
- **`assistant/src/plugin-api/index.ts`:** re-export the STT domain types the session surface needs — `StreamingTranscriber`, `SttStreamServerEvent` and its variants (`…Partial`/`…Final`/`…Finalized`/`…Error`/`…Closed`), `SttErrorCategory`, `SttProviderId` — plus `openTranscriptionSession`.

## Why this shape

The facade mirrors the existing meeting-bot-oriented plugin-api siblings — `synthesizeText` (TTS, "globally configured provider") and `runConversationTurn`. It reuses the already-public-quality `StreamingTranscriber` / `SttStreamServerEvent` types rather than defining a parallel shape that would drift (per the Single Source of Truth convention); the meeting-bot's structural mirror already carries the same names.

## Test plan

- Unit test `assistant/src/plugin-api/transcription-session.test.ts` (passing): returns the session resolved for the configured provider; returns `null` when none can be opened.
- `bunx tsc --noEmit`: no new type errors (the sole `TS2688 'bun'` types-resolution error in this sandbox is present on baseline with the change stashed).
- Plugin-api runtime exports are enumerated dynamically (`PLUGIN_API_EXPORTS` via `Object.keys`), so the new export flows into the workspace shim automatically — no snapshot to update.
