### PR TITLE
refactor(config): vellum catalog column stamps provider "vellum"; drop connectionName from templates

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -599,8 +599,8 @@ describe("loadConfig startup behavior", () => {
     // Default content resolves from the code catalog via the effective view.
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
     expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
-    expect(effectiveBalanced?.provider).toBe("fireworks");
-    expect(effectiveBalanced?.provider_connection).toBe("vellum");
+    expect(effectiveBalanced?.provider).toBe("vellum");
+    expect(effectiveBalanced?.provider_connection).toBeUndefined();
   });
 
   test("on-platform hatch writes no profile entries; defaults resolve from the catalog", () => {
@@ -635,8 +635,8 @@ describe("loadConfig startup behavior", () => {
     // Default content resolves from the code catalog via the effective view.
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
     expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
-    expect(effectiveBalanced?.provider).toBe("fireworks");
-    expect(effectiveBalanced?.provider_connection).toBe("vellum");
+    expect(effectiveBalanced?.provider).toBe("vellum");
+    expect(effectiveBalanced?.provider_connection).toBeUndefined();
   });
 
   test("re-hatch from openai to anthropic creates user anthropic profiles off-platform", () => {
@@ -679,8 +679,8 @@ describe("loadConfig startup behavior", () => {
     // code-owned and resolves from the catalog.
     expect(raw.llm.profiles.balanced).toEqual(managedStub("Balanced"));
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
-    expect(effectiveBalanced?.provider).toBe("fireworks");
-    expect(effectiveBalanced?.provider_connection).toBe("vellum");
+    expect(effectiveBalanced?.provider).toBe("vellum");
+    expect(effectiveBalanced?.provider_connection).toBeUndefined();
   });
 
   test("on-platform re-hatch resets active profile to balanced", () => {
@@ -716,8 +716,8 @@ describe("loadConfig startup behavior", () => {
     // No managed entry is materialized; content resolves from the catalog.
     expect(raw.llm.profiles.balanced).toBeUndefined();
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
-    expect(effectiveBalanced?.provider).toBe("fireworks");
-    expect(effectiveBalanced?.provider_connection).toBe("vellum");
+    expect(effectiveBalanced?.provider).toBe("vellum");
+    expect(effectiveBalanced?.provider_connection).toBeUndefined();
     // The old custom-balanced is preserved on disk but no longer active.
     expect(raw.llm.profiles["custom-balanced"].provider).toBe("openai");
   });
@@ -850,16 +850,17 @@ describe("loadConfig startup behavior", () => {
     // Default content resolves from the code catalog via the effective view.
     // Balanced serves GLM 5.2 on Fireworks.
     const effective = getEffectiveProfiles(raw.llm.profiles);
-    expect(effective.balanced?.provider).toBe("fireworks");
-    expect(effective.balanced?.provider_connection).toBe("vellum");
+    expect(effective.balanced?.provider).toBe("vellum");
+    expect(effective.balanced?.provider_connection).toBeUndefined();
     expect(effective.balanced?.model).toBe("accounts/fireworks/models/glm-5p2");
     expect(effective.balanced?.effort).toBe("high");
     expect(effective.balanced?.source).toBe("managed");
-    // Quality serves Anthropic Fable, the most capable managed profile.
-    expect(effective["quality-optimized"]?.provider).toBe("anthropic");
+    // Quality pins Anthropic Fable, the most capable managed model.
+    expect(effective["quality-optimized"]?.provider).toBe("vellum");
+    expect(effective["quality-optimized"]?.model).toBe("claude-fable-5");
     expect(effective["quality-optimized"]?.model).toBe("claude-fable-5");
     // Speed is served by DeepSeek V4 Flash on Fireworks.
-    expect(effective["cost-optimized"]?.provider).toBe("fireworks");
+    expect(effective["cost-optimized"]?.provider).toBe("vellum");
     expect(effective["cost-optimized"]?.model).toBe(
       "accounts/fireworks/models/deepseek-v4-flash",
     );
@@ -892,7 +893,7 @@ describe("loadConfig startup behavior", () => {
     // only label/status/topP, everything else comes from the catalog.
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
     expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
-    expect(effectiveBalanced?.provider_connection).toBe("vellum");
+    expect(effectiveBalanced?.provider_connection).toBeUndefined();
   });
 
   test("boot leaves a source-less legacy canonical profile as a user-owned shadow", () => {
@@ -973,7 +974,7 @@ describe("loadConfig startup behavior", () => {
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
     expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
     expect(effectiveBalanced?.maxTokens).toBe(32000);
-    expect(effectiveBalanced?.provider_connection).toBe("vellum");
+    expect(effectiveBalanced?.provider_connection).toBeUndefined();
     // The catalog body carries no topP and the entry has none, so the
     // effective profile has no topP override.
     expect("topP" in (effectiveBalanced ?? {})).toBe(false);
@@ -1207,7 +1208,7 @@ describe("loadConfig startup behavior", () => {
     // overlay's provider/model never reach the resolver — even on the
     // overlay boot. The overlay-set label is what shows through the
     // effective view.
-    expect(mainAgentConfig.provider).toBe("fireworks");
+    expect(mainAgentConfig.provider).toBe("vellum");
     expect(mainAgentConfig.model).toBe("accounts/fireworks/models/glm-5p2");
 
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
@@ -1237,8 +1238,8 @@ describe("loadConfig startup behavior", () => {
       afterRestart.llm.profiles,
       "balanced",
     );
-    expect(effectiveBalanced?.provider).toBe("fireworks");
-    expect(effectiveBalanced?.provider_connection).toBe("vellum");
+    expect(effectiveBalanced?.provider).toBe("vellum");
+    expect(effectiveBalanced?.provider_connection).toBeUndefined();
     expect(effectiveBalanced?.model).toBe("accounts/fireworks/models/glm-5p2");
     expect(effectiveBalanced?.maxTokens).toBe(32000);
     expect(effectiveBalanced?.thinking).toEqual({
@@ -1583,7 +1584,7 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     expect(raw.llm.advisorProfile).toBe("quality-optimized");
     expect(raw.llm.profiles.balanced).toBeUndefined();
     const effectiveBalanced = getEffectiveProfile(raw.llm.profiles, "balanced");
-    expect(effectiveBalanced?.provider_connection).toBe("vellum");
+    expect(effectiveBalanced?.provider_connection).toBeUndefined();
     expect("status" in (effectiveBalanced ?? {})).toBe(false);
   });
 

--- a/assistant/src/__tests__/llm-context-resolution.test.ts
+++ b/assistant/src/__tests__/llm-context-resolution.test.ts
@@ -113,6 +113,24 @@ describe("resolveEffectiveContextWindow", () => {
     expect(resolved.maxInputTokens).toBe(175000);
   });
 
+  test("a routing-identity profile resolves the model's own context limits", () => {
+    const llm = LLMSchema.parse({
+      profiles: {
+        managed: { provider: "vellum", model: "gpt-5.5" },
+      },
+      activeProfile: "managed",
+    });
+
+    const resolved = resolveEffectiveContextWindow({
+      llm,
+      callSite: "mainAgent",
+    });
+
+    // The catalog owner (openai) carries gpt-5.5's limits; a raw "vellum"
+    // lookup would miss and misreport the model max as the 200k default.
+    expect(resolved.modelMaxInputTokens).toBe(1050000);
+  });
+
   test("unknown catalog model falls back safely to the default 200k cap", () => {
     const llm = LLMSchema.parse({
       callSites: {

--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -250,7 +250,7 @@ describe("composition", () => {
     expect(resolved.provider_connection).toBeUndefined();
   });
 
-  test("a model-only tweak keeps the provider-agnostic vellum connection for managed-routable implied providers", () => {
+  test("a model-only tweak on the vellum default keeps the identity provider", () => {
     const llm = LLMSchema.parse({
       callSites: {
         conversationSummarization: { model: "claude-haiku-4-5-20251001" },
@@ -258,10 +258,10 @@ describe("composition", () => {
       defaultProvider: { provider: "vellum" },
     });
     const resolved = resolveCallSiteConfig("conversationSummarization", llm);
-    expect(resolved.provider).toBe("anthropic");
-    // The vellum connection routes anthropic via expectedProvider; dropping
-    // it would leave platform installs with no resolvable connection.
-    expect(resolved.provider_connection).toBe("vellum");
+    // provider "vellum" + the tweaked model is the complete dispatch shape:
+    // the upstream derives from the model, no connection stamp needed.
+    expect(resolved.provider).toBe("vellum");
+    expect(resolved.provider_connection).toBeUndefined();
   });
 
   test("profileless call sites anchor on balanced intent through the default provider plus their tweaks", () => {

--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -250,6 +250,24 @@ describe("composition", () => {
     expect(resolved.provider_connection).toBeUndefined();
   });
 
+  test("a provider-pinning tweak over the vellum default keeps the managed routing", () => {
+    const llm = LLMSchema.parse({
+      callSites: {
+        conversationSummarization: {
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
+      },
+      defaultProvider: { provider: "vellum" },
+    });
+    const resolved = resolveCallSiteConfig("conversationSummarization", llm);
+    // The tweak wins the fields it sets; the identity winner contributes its
+    // routing through the provider-agnostic managed connection.
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.model).toBe("claude-opus-4-6");
+    expect(resolved.provider_connection).toBe("vellum");
+  });
+
   test("a model-only tweak on the vellum default keeps the identity provider", () => {
     const llm = LLMSchema.parse({
       callSites: {

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -1068,7 +1068,8 @@ describe("code-owned default profiles — wire view and write normalization", ()
     const response = (await getRoute.handler({})) as Record<string, any>;
     const wireBalanced = response.llm.profiles.balanced;
     expect(wireBalanced.model).toBe("accounts/fireworks/models/glm-5p2");
-    expect(wireBalanced.provider_connection).toBe("vellum");
+    expect(wireBalanced.provider).toBe("vellum");
+    expect(wireBalanced.provider_connection).toBeUndefined();
     expect(wireBalanced.status).toBe("disabled");
     expect(wireBalanced.invariant).toBe(true);
     // Absent defaults are materialized too — the catalog owns their content.

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { resolveRoutingIdentity } from "../../providers/connection-resolution.js";
 import { resolveModelIntent } from "../../providers/model-intents.js";
 import { CALL_SITE_DEFAULTS } from "../call-site-defaults.js";
 import {
@@ -37,9 +38,18 @@ describe("getEffectiveProfiles", () => {
       const body = CODE_DEFAULT_PROFILE_ENTRIES[key];
       expect(body).toBeDefined();
       expect(typeof body.model).toBe("string");
-      expect(body.provider).toBeDefined();
-      expect(body.provider_connection).toBe("vellum");
+      expect(body.provider).toBe("vellum");
+      expect(body.provider_connection).toBeUndefined();
       expect(body.source).toBe("managed");
+    }
+  });
+
+  test("every vellum-column body translates to a managed dispatch target", () => {
+    for (const key of [...DEFAULT_PROFILE_KEYS, OS_BETA_PROFILE_KEY]) {
+      const body = CODE_DEFAULT_PROFILE_ENTRIES[key];
+      const identity = resolveRoutingIdentity(body.provider, body.model);
+      expect(identity?.connectionName).toBe("vellum");
+      expect(typeof identity?.expectedProvider).toBe("string");
     }
   });
 
@@ -137,10 +147,8 @@ describe("resolver integration", () => {
     expect(resolved.model).toBe(
       CODE_DEFAULT_PROFILE_ENTRIES.balanced.model as string,
     );
-    expect(String(resolved.provider)).toBe(
-      String(CODE_DEFAULT_PROFILE_ENTRIES.balanced.provider),
-    );
-    expect(resolved.provider_connection).toBe("vellum");
+    expect(String(resolved.provider)).toBe("vellum");
+    expect(resolved.provider_connection).toBeUndefined();
   });
 
   test("an empty workspace resolves every call-site default from the catalog", () => {
@@ -246,7 +254,12 @@ describe("resolveDefaultProfileForProvider", () => {
         expect(entry).toBeDefined();
         expect(typeof entry?.model).toBe("string");
         expect(entry?.provider).toBeDefined();
-        expect(entry?.provider_connection).toBeDefined();
+        // Identity columns stamp no connection; BYOK columns always do.
+        if (entry?.provider === "vellum") {
+          expect(entry?.provider_connection).toBeUndefined();
+        } else {
+          expect(entry?.provider_connection).toBeDefined();
+        }
         expect(entry?.source).toBe("managed");
       }
     }

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -95,8 +95,8 @@ describe("reconcileFlagGatedProfiles", () => {
     // Through the effective view the stub resolves to the catalog body.
     const effective = getEffectiveProfile(raw.llm.profiles, "os-beta")!;
     expect(effective.model).toBe("MiniMaxAI/MiniMax-M3");
-    expect(effective.provider_connection).toBe("vellum");
-    expect(effective.provider).toBe("together");
+    expect(effective.provider_connection).toBeUndefined();
+    expect(effective.provider).toBe("vellum");
     expect(effective.source).toBe("managed");
     expect(effective.label).toBe("OS Beta");
     expect(effective.effort).toBe("low");
@@ -157,7 +157,7 @@ describe("reconcileFlagGatedProfiles", () => {
     expect(effective.label).toBe("My OS Beta");
     expect(effective.topP).toBe(0.8);
     expect(effective.model).toBe("MiniMaxAI/MiniMax-M3");
-    expect(effective.provider_connection).toBe("vellum");
+    expect(effective.provider_connection).toBeUndefined();
     expect(effective.effort).toBe("low");
   });
 

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -1,7 +1,8 @@
+import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
 import { isModelInCatalog } from "../providers/model-catalog.js";
 import { resolveModelIntent } from "../providers/model-intents.js";
 import type { ModelIntent } from "../providers/types.js";
-import { VELLUM_MANAGED_CONNECTION_NAME } from "../providers/vellum-model-routing.js";
+import { getManagedUpstream } from "../providers/vellum-model-routing.js";
 import {
   DEFAULT_PROFILE_KEYS,
   DEFAULT_PROFILE_PROVIDERS,
@@ -49,20 +50,21 @@ export type DefaultProfileTemplate = Omit<
   intent?: ModelIntent;
   model?: string;
   provider: NonNullable<ProfileEntry["provider"]>;
-  connectionName: string;
 };
 
 /**
- * The `vellum` column: platform-managed implementations. Overwritten in
- * workspace config on every daemon boot so Vellum can push model/config
- * updates to customers in new releases.
+ * The `vellum` column: platform-managed implementations, stamped
+ * `provider: "vellum"` — dispatch derives the upstream from the model.
+ * Models are pinned (never intents): the intent tables are keyed by
+ * concrete dispatch providers, and the model is what selects the upstream.
+ * Overwritten in workspace config on every daemon boot so Vellum can push
+ * model/config updates to customers in new releases.
  */
 const VELLUM_PROFILE_IMPLS: Record<DefaultProfileKey, DefaultProfileTemplate> =
   {
     balanced: {
       model: "accounts/fireworks/models/glm-5p2",
-      provider: "fireworks",
-      connectionName: VELLUM_MANAGED_CONNECTION_NAME,
+      provider: "vellum",
       source: "managed",
       label: "Balanced",
       description: "Good balance of quality, cost, and speed",
@@ -74,9 +76,8 @@ const VELLUM_PROFILE_IMPLS: Record<DefaultProfileKey, DefaultProfileTemplate> =
       },
     },
     "quality-optimized": {
-      intent: "quality-optimized",
-      provider: "anthropic",
-      connectionName: VELLUM_MANAGED_CONNECTION_NAME,
+      model: "claude-fable-5",
+      provider: "vellum",
       source: "managed",
       label: "Quality",
       description: "High-quality results with the most capable model",
@@ -89,8 +90,7 @@ const VELLUM_PROFILE_IMPLS: Record<DefaultProfileKey, DefaultProfileTemplate> =
     },
     "cost-optimized": {
       model: "accounts/fireworks/models/deepseek-v4-flash",
-      provider: "fireworks",
-      connectionName: VELLUM_MANAGED_CONNECTION_NAME,
+      provider: "vellum",
       source: "managed",
       label: "Speed",
       description: "Fastest responses at lower cost (DeepSeek V4 Flash)",
@@ -111,12 +111,12 @@ const VELLUM_PROFILE_IMPLS: Record<DefaultProfileKey, DefaultProfileTemplate> =
  * The BYOK implementation of each default profile intent, shared by every
  * non-vellum provider column. The concrete model resolves per provider from
  * the `intent` via `resolveModelIntent` at materialization time. `provider`
- * and `connectionName` are stamped per column (and overridden at hatch time
- * with the user's chosen provider and personal connection).
+ * is stamped per column (and overridden at hatch time with the user's
+ * chosen provider).
  */
 const BYOK_PROFILE_IMPLS: Record<
   DefaultProfileKey,
-  Omit<DefaultProfileTemplate, "provider" | "connectionName">
+  Omit<DefaultProfileTemplate, "provider">
 > = {
   balanced: {
     intent: "balanced",
@@ -165,7 +165,7 @@ export const PROFILE_IMPLS: Record<
         provider,
         provider === "vellum"
           ? VELLUM_PROFILE_IMPLS[key]
-          : { ...BYOK_PROFILE_IMPLS[key], provider, connectionName: "" },
+          : { ...BYOK_PROFILE_IMPLS[key], provider },
       ]),
     ) as Record<DefaultProfileProvider, DefaultProfileTemplate>,
   ]),
@@ -186,9 +186,9 @@ export const MANAGED_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
 
 /**
  * User profile templates, materialized as `custom-*` at hatch time for
- * off-platform installations. The `provider` and `connectionName` fields are
- * placeholders — they are overridden at hatch time with the user's chosen
- * provider and personal connection name.
+ * off-platform installations. The `provider` field is a placeholder — it is
+ * overridden at hatch time with the user's chosen provider and personal
+ * connection name.
  */
 export const USER_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
   Object.fromEntries(
@@ -205,9 +205,8 @@ export const USER_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
  * Balanced defaults, with lower reasoning effort while the profile is in beta.
  */
 export const OS_BETA_PROFILE_TEMPLATE: DefaultProfileTemplate = {
-  intent: "balanced",
-  provider: "together",
-  connectionName: VELLUM_MANAGED_CONNECTION_NAME,
+  model: "MiniMaxAI/MiniMax-M3",
+  provider: "vellum",
   source: "managed",
   label: "OS Beta",
   description: "Good balance of quality, cost, and speed, in beta",
@@ -243,22 +242,26 @@ export const MANAGED_PROFILE_NAMES = new Set<string>([
 /**
  * Materialize a template into a concrete `ProfileEntry`: resolve `intent` to
  * a model id for the given provider and stamp the provider connection.
+ * Routing-identity providers ("vellum") never receive a connection stamp —
+ * dispatch resolves their row per-request from the provider value.
  */
 export function materializeProfile(
   template: DefaultProfileTemplate,
   provider: NonNullable<ProfileEntry["provider"]>,
-  connectionName: string,
+  connectionName?: string,
 ): ProfileEntry {
-  const { intent, model, provider: _p, connectionName: _c, ...rest } = template;
+  const { intent, model, provider: _p, ...rest } = template;
   const resolvedModel =
     model ?? (intent ? resolveModelIntent(provider, intent) : undefined);
   if (!resolvedModel) {
     throw new Error("DefaultProfileTemplate requires `intent` or `model`");
   }
+  const stampConnection =
+    connectionName && !ROUTING_IDENTITY_PROVIDERS.has(provider);
   return {
     ...rest,
     provider,
-    provider_connection: connectionName,
+    ...(stampConnection ? { provider_connection: connectionName } : {}),
     model: resolvedModel,
   };
 }
@@ -276,12 +279,24 @@ for (const key of DEFAULT_PROFILE_KEYS) {
         `PROFILE_IMPLS[${key}][${provider}] must set exactly one of \`intent\` or \`model\`.`,
       );
     }
-    if (impl.model != null && !isModelInCatalog(impl.provider, impl.model)) {
+    if (impl.provider === "vellum" && impl.model == null) {
       throw new Error(
-        `PROFILE_IMPLS[${key}][${provider}] references model "${impl.model}" ` +
-          `which is not in PROVIDER_CATALOG for provider "${impl.provider}". ` +
-          `Update model-catalog.ts or default-profile-catalog.ts.`,
+        `PROFILE_IMPLS[${key}][${provider}] must pin a \`model\`: the vellum ` +
+          `column has no intent table, and the model selects the upstream.`,
       );
+    }
+    if (impl.model != null) {
+      const routable =
+        impl.provider === "vellum"
+          ? getManagedUpstream(impl.model) !== null
+          : isModelInCatalog(impl.provider, impl.model);
+      if (!routable) {
+        throw new Error(
+          `PROFILE_IMPLS[${key}][${provider}] references model "${impl.model}" ` +
+            `which is not ${impl.provider === "vellum" ? "served by any managed upstream" : `in PROVIDER_CATALOG for provider "${impl.provider}"`}. ` +
+            `Update model-catalog.ts or default-profile-catalog.ts.`,
+        );
+      }
     }
   }
 }
@@ -290,12 +305,11 @@ function buildDefaultProfileEntries(): Record<string, ProfileEntry> {
   const entries: Record<string, ProfileEntry> = {};
   for (const key of DEFAULT_PROFILE_KEYS) {
     const impl = PROFILE_IMPLS[key].vellum;
-    entries[key] = materializeProfile(impl, impl.provider, impl.connectionName);
+    entries[key] = materializeProfile(impl, impl.provider);
   }
   entries[OS_BETA_PROFILE_KEY] = materializeProfile(
     OS_BETA_PROFILE_TEMPLATE,
     OS_BETA_PROFILE_TEMPLATE.provider,
-    OS_BETA_PROFILE_TEMPLATE.connectionName,
   );
   return entries;
 }
@@ -386,9 +400,8 @@ function resolveAgainstBody(
  *
  * Non-obvious rules:
  *
- * - For the `vellum` column the stamped provider stays the column's
- *   underlying provider (e.g. `fireworks` for `balanced`) — `vellum` is a
- *   routing identity, not a dispatch provider.
+ * - The `vellum` column stamps `provider: "vellum"` with no connection —
+ *   dispatch derives the upstream from the model per-request.
  * - The resolved body carries `source: "managed"` regardless of column:
  *   default profile content is code-owned whichever provider implements it.
  *   The BYOK templates' `source: "user"` is hatch-time state for

--- a/assistant/src/config/llm-context-resolution.ts
+++ b/assistant/src/config/llm-context-resolution.ts
@@ -1,4 +1,8 @@
-import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
+import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
+import {
+  getCatalogProviderForModel,
+  PROVIDER_CATALOG,
+} from "../providers/model-catalog.js";
 import { resolveCallSiteConfig } from "./llm-resolver.js";
 import {
   type ContextWindow,
@@ -50,8 +54,13 @@ export function resolveEffectiveContextWindow({
     forceOverrideProfile,
     selectionSeed,
   });
+  // Routing identities are not catalog providers; the model's catalog owner
+  // carries its context-window limits.
+  const catalogProviderId = ROUTING_IDENTITY_PROVIDERS.has(resolved.provider)
+    ? getCatalogProviderForModel(resolved.model)
+    : resolved.provider;
   const catalogModel = PROVIDER_CATALOG.find(
-    (provider) => provider.id === resolved.provider,
+    (provider) => provider.id === catalogProviderId,
   )?.models.find((model) => model.id === resolved.model);
 
   const modelMaxInputTokens =

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -410,9 +410,28 @@ function resolveOverrideOrDefault(
     }
   }
 
-  return finalize(
-    deepMerge(CODE_DEFAULT_BASE as unknown as Mergeable, winnerFragment, tweak),
+  const merged = deepMerge(
+    CODE_DEFAULT_BASE as unknown as Mergeable,
+    winnerFragment,
+    tweak,
   );
+  // A vellum winner's managed routing survives a concrete-provider tweak:
+  // call-site fragments carry no connection, so a tweak pinning e.g.
+  // anthropic over a managed default would otherwise resolve to a
+  // connection-less concrete provider — stranded on platform installs with
+  // no BYOK row. The tweak keeps every field it sets; the winner contributes
+  // its routing via the provider-agnostic managed connection, which serves
+  // any managed-routable upstream.
+  if (
+    winnerFragment.provider === "vellum" &&
+    typeof merged.provider === "string" &&
+    merged.provider !== "vellum" &&
+    merged.provider_connection == null &&
+    MANAGED_ROUTABLE_PROVIDERS.has(merged.provider)
+  ) {
+    merged.provider_connection = VELLUM_MANAGED_CONNECTION_NAME;
+  }
+  return finalize(merged);
 }
 
 /** The winner's config fields: metadata stripped, sampling and logitBias

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
 import {
   getCatalogProviderForModel,
   isModelInCatalog,
@@ -19,6 +20,7 @@ import {
   LLMConfigBase,
   type LLMSchema,
   type ProfileEntry,
+  routingIdentityModelIssue,
 } from "./schemas/llm.js";
 
 /**
@@ -378,10 +380,16 @@ function resolveOverrideOrDefault(
   const applicableProvider =
     (winnerFragment.provider as string | undefined) ??
     CODE_DEFAULT_BASE.provider;
+  // A routing-identity winner serves any model its route can dispatch —
+  // identity + model is the complete shape, so no provider implication.
+  const winnerServesModel = (model: string): boolean =>
+    ROUTING_IDENTITY_PROVIDERS.has(applicableProvider)
+      ? routingIdentityModelIssue(applicableProvider, model) === null
+      : isModelInCatalog(applicableProvider, model);
   if (
     typeof tweak.model === "string" &&
     tweak.provider === undefined &&
-    !isModelInCatalog(applicableProvider, tweak.model)
+    !winnerServesModel(tweak.model)
   ) {
     const implied = getCatalogProviderForModel(tweak.model);
     if (implied !== undefined) {

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -7,7 +7,11 @@ import {
   MANAGED_ROUTABLE_PROVIDERS,
   VELLUM_MANAGED_CONNECTION_NAME,
 } from "../providers/vellum-model-routing.js";
-import type { LLMConfigBase, ProfileEntry } from "./schemas/llm.js";
+import {
+  type LLMConfigBase,
+  type ProfileEntry,
+  routingIdentityModelIssue,
+} from "./schemas/llm.js";
 
 /**
  * Materializes a partial custom profile into a complete, standalone
@@ -76,10 +80,16 @@ export function completeCustomProfile(
     profile.openrouter,
   );
 
+  // A routing-identity fill base serves any model its route can dispatch —
+  // identity + model is the complete shape, so no provider implication.
+  const fillBaseServesModel = (model: string): boolean =>
+    ROUTING_IDENTITY_PROVIDERS.has(dflt.provider)
+      ? routingIdentityModelIssue(dflt.provider, model) === null
+      : isModelInCatalog(dflt.provider, model);
   if (
     profile.model !== undefined &&
     profile.provider === undefined &&
-    !isModelInCatalog(dflt.provider, profile.model)
+    !fillBaseServesModel(profile.model)
   ) {
     const implied = getCatalogProviderForModel(profile.model);
     if (implied !== undefined) {

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -6,6 +6,7 @@ import {
   MANAGED_CONNECTION_NAMES,
 } from "../providers/inference/connections.js";
 import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
+import { VELLUM_MANAGED_CONNECTION_NAME } from "../providers/vellum-model-routing.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -448,10 +449,11 @@ function getHatchSelectedManagedConnection(
       : undefined;
   }
 
-  const templateConnection =
-    MANAGED_PROFILE_TEMPLATES[activeProfile]?.connectionName;
-  return templateConnection && MANAGED_CONNECTION_NAMES.has(templateConnection)
-    ? templateConnection
+  // A default-profile name with no explicit connection selects the managed
+  // route: the vellum column IS the managed column, and its profiles route
+  // through the canonical vellum row.
+  return MANAGED_PROFILE_TEMPLATES[activeProfile]
+    ? VELLUM_MANAGED_CONNECTION_NAME
     : undefined;
 }
 

--- a/assistant/src/plugin-api/vision-support.test.ts
+++ b/assistant/src/plugin-api/vision-support.test.ts
@@ -90,6 +90,18 @@ describe("doesSupportVision", () => {
     expect(doesSupportVision(profile("model-only"))).toBe(true);
   });
 
+  test("resolves a routing-identity profile through the model's catalog owner", () => {
+    setMockConfig({
+      managed: { provider: "vellum", model: "claude-fable-5" },
+      "managed-text": {
+        provider: "vellum",
+        model: "accounts/fireworks/models/deepseek-v4-flash",
+      },
+    });
+    expect(doesSupportVision(profile("managed"))).toBe(true);
+    expect(doesSupportVision(profile("managed-text"))).toBe(false);
+  });
+
   test("fails safe to false for a profile without a model", () => {
     // A model-less entry is not a usable resolution target, so vision
     // resolution treats it as "can't show images" (caption instead).

--- a/assistant/src/plugin-api/vision-support.ts
+++ b/assistant/src/plugin-api/vision-support.ts
@@ -18,6 +18,7 @@
 
 import { getEffectiveProfile } from "../config/default-profile-catalog.js";
 import { getConfig } from "../config/loader.js";
+import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
 import {
   getCatalogProviderForModel,
   PROVIDER_CATALOG,
@@ -102,7 +103,12 @@ function resolveEntryVision(entry: {
   provider?: string;
   model?: string;
 }): boolean | undefined {
-  const provider = entry.provider;
+  // Routing identities ("vellum"/"chatgpt") are not catalog providers; the
+  // model's catalog owner is the capability source for them.
+  const provider =
+    entry.provider != null && ROUTING_IDENTITY_PROVIDERS.has(entry.provider)
+      ? undefined
+      : entry.provider;
   const model = entry.model;
 
   // Infer provider from model when missing (mirrors the resolver's catalog


### PR DESCRIPTION
## Summary
- The default-profile catalog's vellum column now stamps `provider: "vellum"` with no connection — the first PR of Milestone C ("the flip"): managed default profiles (`balanced`, `quality-optimized`, `cost-optimized`, `os-beta`) resolve as identity profiles, and dispatch derives the upstream from the model per-request (#38629/#38630/#38682 machinery).
- Vellum-column models are pinned rather than intent-resolved (`quality-optimized` → `claude-fable-5`, `os-beta` → `MiniMaxAI/MiniMax-M3`, both their previous intent resolutions): the intent tables key concrete dispatch providers, and the model is what selects the upstream. The module-load consistency check validates the column via `getManagedUpstream`.
- `DefaultProfileTemplate` loses `connectionName`; `materializeProfile` stamps `provider_connection` only for non-identity providers. BYOK columns are unchanged.
- Resolver fix the flipped tests surfaced: a call-site model-only tweak over a vellum winner now keeps the identity provider when the route serves the tweaked model, instead of implying the catalog owner — the implied shape (concrete provider, no connection) would strand managed installs.

## Original prompt
Milestone C PR 6 of the connection-removal plan (papertrail on #38102). Milestone B (dispatch, preflight/availability, write enablement) is fully merged, so `provider: "vellum"` is now a dispatchable, storable value; this PR makes the code-owned default profiles use it, replacing the concrete-upstream + `connectionName: "vellum"` template shape. Migration 130 (PR 7) rewrites existing workspace configs next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->