### PR TITLE
fix(cli): bundle @vellumai/service-contracts in the published tarball

### DIFF
--- a/cli/knip.json
+++ b/cli/knip.json
@@ -11,6 +11,7 @@
   "ignoreDependencies": [
     "@vellumai/environments",
     "@vellumai/local-mode",
+    "@vellumai/service-contracts",
     "@vellumai/web"
   ]
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -40,7 +40,8 @@
   },
   "bundledDependencies": [
     "@vellumai/environments",
-    "@vellumai/local-mode"
+    "@vellumai/local-mode",
+    "@vellumai/service-contracts"
   ],
   "devDependencies": {
     "@types/bun": "1.3.11",


### PR DESCRIPTION
## Prompt / plan

Resolve the failing **Dev Release** run on `main`: https://github.com/vellum-ai/vellum-assistant/actions/runs/29930024805/job/88959229191

The `build-npm-dev (cli)` job failed at the **Strip bundled deps from the manifest** step:

```
"@vellumai/service-contracts" (workspace:*) is not in bundledDependencies — the published package would be unresolvable.
##[error]Process completed with exit code 1.
```

**Why:** `@vellumai/service-contracts` was added to `cli/package.json` `dependencies` as a `workspace:*` dep but never listed in `bundledDependencies`. `scripts/strip-bundled-deps.mjs` enforces that every workspace/file dependency ships inside the tarball (workspace deps are never published to npm, so an unbundled one would be unresolvable at install time). The fix adds it alongside the other two bundled workspace packages (`@vellumai/environments`, `@vellumai/local-mode`).

## Test plan

- Ran `bun scripts/strip-bundled-deps.mjs` against the updated manifest (via a scratch copy so the working file wasn't mutated) — now exits `0` and reports all three workspace deps stripped, where it previously exited `1`.
- CI Dev Release will re-validate the pack on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01225buFxta9xFQeV5zHn731

---
_Generated by [Claude Code](https://claude.ai/code/session_01225buFxta9xFQeV5zHn731)_