### PR TITLE
Single-source ACP session events from api/events

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -10,8 +10,8 @@
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import type { AcpSessionUpdateEvent } from "../../api/events/acp-session-update.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
-import type { AcpSessionUpdate } from "../../daemon/message-types/acp.js";
 import { getSqlite } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import { VellumAcpClientHandler } from "../client-handler.js";
@@ -44,7 +44,7 @@ function buildSessionWithFakeProcess(opts: {
     usage?: { inputTokens: number; outputTokens: number };
   }) => void;
   rejectPrompt: (e: Error) => void;
-  emitUpdate: (update: AcpSessionUpdate) => void;
+  emitUpdate: (update: AcpSessionUpdateEvent) => void;
 } {
   const manager = new AcpSessionManager(1);
   const sent: ServerMessage[] = [];
@@ -85,7 +85,7 @@ function buildSessionWithFakeProcess(opts: {
     if (msg.type === "acp_session_update") {
       (
         manager as unknown as {
-          appendToBuffer: (id: string, u: AcpSessionUpdate) => void;
+          appendToBuffer: (id: string, u: AcpSessionUpdateEvent) => void;
         }
       ).appendToBuffer(opts.id, msg);
     }
@@ -134,7 +134,7 @@ function buildSessionWithFakeProcess(opts: {
 
   // Helper that pushes an update through the wrapped sender — exactly
   // matching what VellumAcpClientHandler.sessionUpdate does.
-  const emitUpdate = (update: AcpSessionUpdate) => {
+  const emitUpdate = (update: AcpSessionUpdateEvent) => {
     wrappedSend(update);
   };
 
@@ -204,7 +204,7 @@ describe("AcpSessionManager — terminal persistence", () => {
     expect(row!.completed_at).not.toBeNull();
     expect(row!.error).toBeNull();
 
-    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdate[];
+    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdateEvent[];
     expect(log).toHaveLength(3);
     expect(log[0]).toMatchObject({
       type: "acp_session_update",
@@ -272,7 +272,7 @@ describe("AcpSessionManager — terminal persistence", () => {
 
     const row = readHistoryRow(id);
     expect(row).not.toBeNull();
-    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdate[];
+    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdateEvent[];
     expect(log).toHaveLength(2);
     expect(log[0]!.rawInput).toEqual(rawInput);
     expect(log[1]!.rawOutput).toBe(rawOutput);
@@ -304,7 +304,7 @@ describe("AcpSessionManager — terminal persistence", () => {
     expect(row!.error).toBe("agent died");
     expect(row!.stop_reason).toBeNull();
 
-    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdate[];
+    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdateEvent[];
     expect(log).toHaveLength(1);
     expect(log[0]).toMatchObject({
       updateType: "agent_message_chunk",
@@ -333,7 +333,7 @@ describe("AcpSessionManager — terminal persistence", () => {
     // Verify in-memory buffer is bounded before persistence.
     const eventBuffers = (
       handles.manager as unknown as {
-        eventBuffers: Map<string, { update: AcpSessionUpdate }[]>;
+        eventBuffers: Map<string, { update: AcpSessionUpdateEvent }[]>;
       }
     ).eventBuffers;
     expect(eventBuffers.get(id)?.length).toBe(200);
@@ -344,7 +344,7 @@ describe("AcpSessionManager — terminal persistence", () => {
 
     const row = readHistoryRow(id);
     expect(row).not.toBeNull();
-    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdate[];
+    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdateEvent[];
     expect(log).toHaveLength(200);
     // Oldest events were evicted — the persisted log contains the last 200.
     expect((log[0] as { content?: string }).content).toBe("chunk-100");
@@ -378,7 +378,7 @@ describe("AcpSessionManager — terminal persistence", () => {
 
     const row = readHistoryRow(id);
     expect(row).not.toBeNull();
-    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdate[];
+    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdateEvent[];
     expect(log.length).toBeLessThan(80);
     expect(log.length).toBeGreaterThan(0);
     // Persisted JSON must respect the 256 KB cap (allowing a small margin
@@ -610,7 +610,7 @@ describe("AcpSessionManager — terminal persistence", () => {
     expect(row!.status).toBe("completed");
     expect(row!.stop_reason).toBe("end_turn");
     expect(row!.cwd).toBe("/new/cwd");
-    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdate[];
+    const log = JSON.parse(row!.event_log_json) as AcpSessionUpdateEvent[];
     expect(log).toHaveLength(1);
     expect(log[0]).toMatchObject({ content: "from the resumed run" });
   });

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -81,7 +81,9 @@ class FakeAcpAgentProcess {
   }
 
   async resumeSession(sessionId: string, cwd: string): Promise<void> {
-    if (resumeSessionGate) await resumeSessionGate;
+    if (resumeSessionGate) {
+      await resumeSessionGate;
+    }
     this.resumeSessionCalls.push({ sessionId, cwd });
   }
 
@@ -154,7 +156,9 @@ mock.module("../prepare-agent-env.js", () => ({
     args: string[];
     env?: Record<string, string | undefined>;
   }) => {
-    if (prepareAgentEnvGate) await prepareAgentEnvGate;
+    if (prepareAgentEnvGate) {
+      await prepareAgentEnvGate;
+    }
     prepareAgentEnvCommands.push(agentConfig.command);
     return {
       ...agentConfig,
@@ -203,8 +207,8 @@ const BUN_BIN = "/usr/local/bin/bun";
 /** Key the exec stub uses for the global install. */
 const BUN_ADD_KEY = `${BUN_BIN} add`;
 
+import type { AcpSessionUpdateEvent } from "../../api/events/acp-session-update.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
-import type { AcpSessionUpdate } from "../../daemon/message-types/acp.js";
 import { getSqlite } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import type { AcpSessionState } from "../types.js";
@@ -236,7 +240,7 @@ function countHistoryRows(): number {
 
 type ManagerInternals = {
   sessions: Map<string, { clientHandler: FakeClient; command: string }>;
-  eventBuffers: Map<string, Array<{ update: AcpSessionUpdate }>>;
+  eventBuffers: Map<string, Array<{ update: AcpSessionUpdateEvent }>>;
   pendingResumes: Map<string, Promise<void>>;
 };
 
@@ -271,7 +275,7 @@ beforeEach(() => {
   which.setWhich({});
 });
 
-const PERSISTED_EVENT: AcpSessionUpdate = {
+const PERSISTED_EVENT: AcpSessionUpdateEvent = {
   type: "acp_session_update",
   acpSessionId: "resume-1",
   updateType: "agent_message_chunk",
@@ -341,7 +345,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
   test("live updates after resume continue seq past the persisted max", async () => {
     fakeCaps.resume = true;
     // Persisted log whose updates carry seq up to 4.
-    const persisted: AcpSessionUpdate[] = [
+    const persisted: AcpSessionUpdateEvent[] = [
       { ...PERSISTED_EVENT, seq: 2 },
       { ...PERSISTED_EVENT, seq: 4 },
     ];
@@ -360,7 +364,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     // The first live update continues at 5 (max persisted seq + 1), not 1, so
     // the web client's highWaterMark de-dupe doesn't drop it.
     const liveUpdates = sent.filter(
-      (m): m is AcpSessionUpdate => m.type === "acp_session_update",
+      (m): m is AcpSessionUpdateEvent => m.type === "acp_session_update",
     );
     expect(liveUpdates).toHaveLength(1);
     expect(liveUpdates[0]!.seq).toBe(5);

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -31,8 +31,8 @@ import type {
   WriteTextFileResponse,
 } from "@agentclientprotocol/sdk";
 
+import type { AcpSessionUpdateEvent } from "../api/events/acp-session-update.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import type { AcpSessionUpdate } from "../daemon/message-types/acp.js";
 import { redactJsonStringLeaves } from "../security/redact-json.js";
 import { redactSensitiveFields } from "../security/redaction.js";
 import { redactSecrets } from "../security/secret-scanner.js";
@@ -43,7 +43,9 @@ const log = getLogger("acp:client-handler");
 // Field-name redaction across object/array shapes (covers top-level arrays;
 // redactSensitiveFields handles the nested recursion within objects).
 function redactSensitivePayload(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(redactSensitivePayload);
+  if (Array.isArray(value)) {
+    return value.map(redactSensitivePayload);
+  }
   if (value !== null && typeof value === "object") {
     return redactSensitiveFields(value as Record<string, unknown>);
   }
@@ -53,7 +55,9 @@ function redactSensitivePayload(value: unknown): unknown {
 // The execute kind's title is the command line, which can carry a literal
 // credential — scrub shaped secrets before forwarding/persisting it.
 function redactTitle(title: string | null | undefined): string | undefined {
-  if (title == null) return undefined;
+  if (title == null) {
+    return undefined;
+  }
   return redactSecrets(title);
 }
 
@@ -103,7 +107,7 @@ export class VellumAcpClientHandler implements Client {
 
   /** Forwards an update to Vellum, stamping a contiguous per-session `seq`. */
   private forwardUpdate(
-    update: Omit<AcpSessionUpdate, "type" | "acpSessionId" | "seq">,
+    update: Omit<AcpSessionUpdateEvent, "type" | "acpSessionId" | "seq">,
   ): void {
     this.sendToVellum({
       type: "acp_session_update",
@@ -120,14 +124,18 @@ export class VellumAcpClientHandler implements Client {
    */
   private capRawPayload(value: unknown): unknown {
     const CAP_BYTES = 16 * 1024;
-    if (value === undefined) return undefined;
+    if (value === undefined) {
+      return undefined;
+    }
     let serialized: string;
     try {
       serialized = JSON.stringify(value) ?? "";
     } catch {
       return "[raw payload omitted: not serializable]";
     }
-    if (serialized.length <= CAP_BYTES) return value;
+    if (serialized.length <= CAP_BYTES) {
+      return value;
+    }
     return `[raw payload omitted: ${serialized.length} bytes exceeds ${CAP_BYTES}-byte cap]`;
   }
 
@@ -141,7 +149,9 @@ export class VellumAcpClientHandler implements Client {
    * straight through.
    */
   private prepareRawPayload(value: unknown): unknown {
-    if (value === undefined) return undefined;
+    if (value === undefined) {
+      return undefined;
+    }
     const redacted = redactJsonStringLeaves(
       redactSensitivePayload(value),
     ).value;
@@ -476,8 +486,12 @@ export class VellumAcpClientHandler implements Client {
 function mapLocations(
   locations: ToolCallLocation[] | null | undefined,
 ): Array<{ path: string; line?: number }> | undefined {
-  if (locations === undefined) return undefined;
-  if (locations === null) return [];
+  if (locations === undefined) {
+    return undefined;
+  }
+  if (locations === null) {
+    return [];
+  }
   return locations.map((l) => ({ path: l.path, line: l.line ?? undefined }));
 }
 

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -8,9 +8,9 @@ import { basename } from "node:path";
 
 import { eq, inArray } from "drizzle-orm";
 
+import type { AcpSessionUpdateEvent } from "../api/events/acp-session-update.js";
 import { findConversation } from "../daemon/conversation-registry.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import type { AcpSessionUpdate } from "../daemon/message-types/acp.js";
 import { getDb } from "../persistence/db-connection.js";
 import { acpSessionHistory } from "../persistence/schema/index.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
@@ -59,7 +59,7 @@ const MAX_BUFFER_BYTES = 256 * 1024;
 
 interface BufferedAcpUpdate {
   /** The wire-shaped update — exactly what was forwarded to clients. */
-  update: AcpSessionUpdate;
+  update: AcpSessionUpdateEvent;
   /** Cached UTF-8 byte length of `JSON.stringify(update)` for cap math. */
   byteSize: number;
 }
@@ -528,9 +528,11 @@ export class AcpSessionManager {
       const persisted = JSON.parse(row.eventLogJson) as unknown;
       if (Array.isArray(persisted)) {
         for (const update of persisted) {
-          this.appendToBuffer(acpSessionId, update as AcpSessionUpdate);
-          const seq = (update as AcpSessionUpdate)?.seq;
-          if (typeof seq === "number" && seq > maxSeq) maxSeq = seq;
+          this.appendToBuffer(acpSessionId, update as AcpSessionUpdateEvent);
+          const seq = (update as AcpSessionUpdateEvent)?.seq;
+          if (typeof seq === "number" && seq > maxSeq) {
+            maxSeq = seq;
+          }
         }
       }
     } catch (err) {
@@ -700,7 +702,9 @@ export class AcpSessionManager {
       // A missing history row keeps its not-found shape; everything else
       // (legacy row without cwd, resolver failure, capability missing)
       // is a resume failure with an actionable message.
-      if (err instanceof AcpSessionNotFoundError) throw err;
+      if (err instanceof AcpSessionNotFoundError) {
+        throw err;
+      }
       throw new AcpResumeError(err);
     }
 
@@ -873,13 +877,15 @@ export class AcpSessionManager {
 
   /**
    * Returns the live ring buffer for an active session as wire-shaped
-   * `AcpSessionUpdate[]` (each carrying `seq`), matching exactly what
+   * `AcpSessionUpdateEvent[]` (each carrying `seq`), matching exactly what
    * `persistTerminal` serializes to `eventLogJson` on terminal transition.
    * Empty array for unknown/already-torn-down ids.
    */
-  getBufferedUpdates(acpSessionId: string): AcpSessionUpdate[] {
+  getBufferedUpdates(acpSessionId: string): AcpSessionUpdateEvent[] {
     const buffer = this.eventBuffers.get(acpSessionId);
-    if (!buffer) return [];
+    if (!buffer) {
+      return [];
+    }
     return buffer.map((b) => b.update);
   }
 
@@ -890,20 +896,29 @@ export class AcpSessionManager {
    * target (off by at most `buffer.length` for delimiters in the eventual
    * `JSON.stringify(buffer)` output).
    */
-  private appendToBuffer(acpSessionId: string, update: AcpSessionUpdate): void {
+  private appendToBuffer(
+    acpSessionId: string,
+    update: AcpSessionUpdateEvent,
+  ): void {
     const buffer = this.eventBuffers.get(acpSessionId);
-    if (!buffer) return; // Session already torn down.
+    if (!buffer) {
+      return;
+    } // Session already torn down.
     const byteSize = Buffer.byteLength(JSON.stringify(update), "utf8");
     buffer.push({ update, byteSize });
     let totalBytes = 0;
-    for (const entry of buffer) totalBytes += entry.byteSize;
+    for (const entry of buffer) {
+      totalBytes += entry.byteSize;
+    }
 
     while (
       buffer.length > 0 &&
       (buffer.length > MAX_BUFFER_EVENTS || totalBytes > MAX_BUFFER_BYTES)
     ) {
       const dropped = buffer.shift();
-      if (dropped !== undefined) totalBytes -= dropped.byteSize;
+      if (dropped !== undefined) {
+        totalBytes -= dropped.byteSize;
+      }
     }
   }
 
@@ -1147,7 +1162,9 @@ export class AcpSessionManager {
       content: message,
       metadata: { acpNotification },
     });
-    if (enqueueResult.queued || enqueueResult.rejected) return;
+    if (enqueueResult.queued || enqueueResult.rejected) {
+      return;
+    }
     parentConversation
       .persistUserMessage({ content: message, metadata: { acpNotification } })
       .then(({ id: messageId }) =>

--- a/assistant/src/daemon/message-types/acp.ts
+++ b/assistant/src/daemon/message-types/acp.ts
@@ -1,78 +1,20 @@
 // ACP (Agent Client Protocol) session lifecycle and communication types.
+//
+// Server→client events are single-sourced from their canonical `api/events`
+// wire schemas; this file only composes them into the domain union consumed by
+// `message-protocol.ts`.
 
-// === Server → Client (streamed via SSE) ===
-
-export interface AcpSessionSpawned {
-  type: "acp_session_spawned";
-  acpSessionId: string;
-  agent: string;
-  parentConversationId: string;
-  /** Tool-use id of the `acp_spawn` call that spawned this session. */
-  parentToolUseId?: string;
-  /** Objective text for the spawned session. */
-  task?: string;
-}
-
-export interface AcpSessionUpdate {
-  type: "acp_session_update";
-  acpSessionId: string;
-  updateType:
-    | "agent_message_chunk"
-    | "agent_thought_chunk"
-    | "user_message_chunk"
-    | "tool_call"
-    | "tool_call_update"
-    | "plan";
-  content?: string;
-  toolCallId?: string;
-  toolTitle?: string;
-  toolKind?: string;
-  toolStatus?: string;
-  /** Optional raw input parameters sent to the tool (ACP `rawInput`); shape is tool-specific. */
-  rawInput?: unknown;
-  /** Optional raw output returned by the tool (ACP `rawOutput`); shape is tool-specific. */
-  rawOutput?: unknown;
-  /** Files touched by this tool call (for the file-diff affordance). */
-  locations?: { path: string; line?: number }[];
-  /** Stable id for the message this chunk belongs to. */
-  messageId?: string;
-  /** Monotonic ordering hint within the session. */
-  seq?: number;
-}
-
-export interface AcpSessionCompleted {
-  type: "acp_session_completed";
-  acpSessionId: string;
-  stopReason:
-    | "end_turn"
-    | "max_tokens"
-    | "max_turn_requests"
-    | "refusal"
-    | "cancelled";
-}
-
-export interface AcpSessionError {
-  type: "acp_session_error";
-  acpSessionId: string;
-  error: string;
-}
-
-export interface AcpSessionUsage {
-  type: "acp_session_usage";
-  acpSessionId: string;
-  usedTokens: number;
-  contextSize: number;
-  costAmount?: number;
-  costCurrency?: string;
-  inputTokens?: number;
-  outputTokens?: number;
-}
+import type { AcpSessionCompletedEvent } from "../../api/events/acp-session-completed.js";
+import type { AcpSessionErrorEvent } from "../../api/events/acp-session-error.js";
+import type { AcpSessionSpawnedEvent } from "../../api/events/acp-session-spawned.js";
+import type { AcpSessionUpdateEvent } from "../../api/events/acp-session-update.js";
+import type { AcpSessionUsageEvent } from "../../api/events/acp-session-usage.js";
 
 // --- Domain-level union alias (consumed by message-protocol.ts) ---
 
 export type _AcpServerMessages =
-  | AcpSessionSpawned
-  | AcpSessionUpdate
-  | AcpSessionCompleted
-  | AcpSessionError
-  | AcpSessionUsage;
+  | AcpSessionSpawnedEvent
+  | AcpSessionUpdateEvent
+  | AcpSessionCompletedEvent
+  | AcpSessionErrorEvent
+  | AcpSessionUsageEvent;

--- a/assistant/src/runtime/routes/acp-routes-event-log.test.ts
+++ b/assistant/src/runtime/routes/acp-routes-event-log.test.ts
@@ -8,17 +8,21 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { AcpSessionState } from "../../acp/index.js";
-import type { AcpSessionUpdate } from "../../daemon/message-types/acp.js";
+import type { AcpSessionUpdateEvent } from "../../api/events/acp-session-update.js";
 
 const inMemoryStates = new Map<string, AcpSessionState>();
-const bufferedUpdates = new Map<string, AcpSessionUpdate[]>();
+const bufferedUpdates = new Map<string, AcpSessionUpdateEvent[]>();
 
 mock.module("../../acp/index.js", () => ({
   getAcpSessionManager: () => ({
     getStatus: (id?: string) => {
-      if (id === undefined) return Array.from(inMemoryStates.values());
+      if (id === undefined) {
+        return Array.from(inMemoryStates.values());
+      }
       const state = inMemoryStates.get(id);
-      if (!state) throw new Error(`ACP session "${id}" not found`);
+      if (!state) {
+        throw new Error(`ACP session "${id}" not found`);
+      }
       return state;
     },
     getBufferedUpdates: (id: string) => bufferedUpdates.get(id) ?? [],
@@ -45,7 +49,9 @@ function getListHandler() {
     (r: { endpoint: string; method: string }) =>
       r.endpoint === "acp/sessions" && r.method === "GET",
   );
-  if (!route) throw new Error("GET acp/sessions route not registered");
+  if (!route) {
+    throw new Error("GET acp/sessions route not registered");
+  }
   return route.handler;
 }
 
@@ -65,7 +71,7 @@ function makeInMemoryState(
   };
 }
 
-function makeUpdate(seq: number, content: string): AcpSessionUpdate {
+function makeUpdate(seq: number, content: string): AcpSessionUpdateEvent {
   return {
     type: "acp_session_update",
     acpSessionId: "active",
@@ -102,7 +108,7 @@ describe("GET /v1/acp/sessions — eventLog", () => {
 
     const session = result.sessions.find((s) => s.id === "active");
     expect(session).toBeDefined();
-    const eventLog = session?.eventLog as AcpSessionUpdate[];
+    const eventLog = session?.eventLog as AcpSessionUpdateEvent[];
     expect(eventLog).toHaveLength(2);
     expect(eventLog.map((u) => u.seq)).toEqual([1, 2]);
     expect(eventLog[0]?.content).toBe("hello");
@@ -149,7 +155,7 @@ describe("GET /v1/acp/sessions — eventLog", () => {
 
     const session = result.sessions.find((s) => s.id === "terminal");
     expect(session).toBeDefined();
-    const eventLog = session?.eventLog as AcpSessionUpdate[];
+    const eventLog = session?.eventLog as AcpSessionUpdateEvent[];
     expect(eventLog).toHaveLength(1);
     expect(eventLog[0]?.seq).toBe(7);
     expect(eventLog[0]?.content).toBe("persisted");
@@ -159,7 +165,7 @@ describe("GET /v1/acp/sessions — eventLog", () => {
     const rawInput = { command: "grep -rn foo", pattern: "foo" };
     const rawOutput = "src/a.ts:1: foo\nsrc/b.ts:9: foo";
 
-    const activeToolCall: AcpSessionUpdate = {
+    const activeToolCall: AcpSessionUpdateEvent = {
       type: "acp_session_update",
       acpSessionId: "active",
       updateType: "tool_call",
@@ -187,7 +193,7 @@ describe("GET /v1/acp/sessions — eventLog", () => {
           rawInput,
           rawOutput,
           seq: 1,
-        } satisfies AcpSessionUpdate,
+        } satisfies AcpSessionUpdateEvent,
       ]),
     });
 
@@ -199,7 +205,7 @@ describe("GET /v1/acp/sessions — eventLog", () => {
     for (const id of ["active", "terminal"]) {
       const session = result.sessions.find((s) => s.id === id);
       expect(session).toBeDefined();
-      const eventLog = session?.eventLog as AcpSessionUpdate[];
+      const eventLog = session?.eventLog as AcpSessionUpdateEvent[];
       expect(eventLog).toHaveLength(1);
       expect(eventLog[0]?.rawInput).toEqual(rawInput);
       expect(eventLog[0]?.rawOutput).toBe(rawOutput);


### PR DESCRIPTION
## Why

Continues the event-type unification effort: making `api/events/*.ts` the single source of truth for every server→client event, so the runtime `message-types/*` domains stop hand-maintaining a parallel copy of the wire shape. Prior PRs migrated the `background-tool` and `workflow` domains (#38718); this one does the same for the ACP domain.

## What

- **`daemon/message-types/acp.ts`** — Drop the five hand-written `acp_session_*` interfaces (`AcpSessionSpawned`, `AcpSessionUpdate`, `AcpSessionCompleted`, `AcpSessionError`, `AcpSessionUsage`). The domain union `_AcpServerMessages` now composes the api-inferred `*Event` types imported from `api/events/acp-session-*.ts`, which are already field-for-field identical.
- **Consumers of `AcpSessionUpdate`** (`acp/session-manager.ts`, `acp/client-handler.ts`, and three acp tests) — renamed to `AcpSessionUpdateEvent` and pointed at `api/events/acp-session-update.js` directly, matching the api naming.

The other four events had no external consumers.

## Safety

No wire or type change — the api schemas are 1:1 with the interfaces they replace, and a clean typecheck at every `broadcastMessage` construction site proves it. `bun run typecheck:fast`, eslint, prettier, and the ACP event-log / SSE-parity / session-manager tests all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_