### PR TITLE
refactor(config): drop mode from the web-search schema

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -32347,8 +32347,6 @@ components:
               anyOf:
                 - type: object
                   properties:
-                    mode:
-                      $ref: "#/components/schemas/ServiceMode"
                     provider:
                       type: string
                   additionalProperties: {}
@@ -33165,8 +33163,6 @@ components:
             web-search:
               type: object
               properties:
-                mode:
-                  $ref: "#/components/schemas/ServiceMode"
                 provider:
                   type: string
               additionalProperties: {}

--- a/assistant/src/__tests__/config-loader-platform-defaults.test.ts
+++ b/assistant/src/__tests__/config-loader-platform-defaults.test.ts
@@ -100,9 +100,9 @@ const SCHEMA_MANAGED_DEFAULT_SERVICES = [
   "notion-oauth",
 ] as const;
 
+// web-search is absent from both lists: it carries no mode at all.
 const SCHEMA_YOUR_OWN_DEFAULT_SERVICES = [
   "image-generation",
-  "web-search",
   "outlook-oauth",
   "linear-oauth",
   "github-oauth",

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -72,7 +72,7 @@ describe("AssistantConfigSchema", () => {
     expect(result.services["web-search"].provider).toBe(
       "inference-provider-native",
     );
-    expect(result.services["web-search"].mode).toBe("your-own");
+    expect(result.services["web-search"]).not.toHaveProperty("mode");
     expect(result.llm.profileSession).toEqual({
       defaultTtlSeconds: 1800,
       maxTtlSeconds: 43200,
@@ -106,7 +106,8 @@ describe("AssistantConfigSchema", () => {
     });
 
     expect(result.services["web-search"].provider).toBe("tavily");
-    expect(result.services["web-search"].mode).toBe("your-own");
+    // A mode key sent by an older client is stripped at parse.
+    expect(result.services["web-search"]).not.toHaveProperty("mode");
   });
 
   test("accepts Firecrawl as a web search provider", () => {
@@ -117,7 +118,7 @@ describe("AssistantConfigSchema", () => {
     });
 
     expect(result.services["web-search"].provider).toBe("firecrawl");
-    expect(result.services["web-search"].mode).toBe("your-own");
+    expect(result.services["web-search"]).not.toHaveProperty("mode");
   });
 
   test("defaults the web-fetch provider to the built-in fetcher", () => {

--- a/assistant/src/__tests__/config-set-platform-guard.test.ts
+++ b/assistant/src/__tests__/config-set-platform-guard.test.ts
@@ -43,17 +43,11 @@ mock.module("../platform/client.js", () => ({
 // ---------------------------------------------------------------------------
 
 mock.module("../ipc/cli-client.js", () => ({
-  cliIpcCall: async (
-    method: string,
-    params?: Record<string, unknown>,
-  ) => {
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
     mockIpcCalls.push({ method, params });
     return mockIpcResult;
   },
-  exitFromIpcResult: (r: {
-    error?: string;
-    statusCode?: number;
-  }) => {
+  exitFromIpcResult: (r: { error?: string; statusCode?: number }) => {
     process.stderr.write((r.error ?? "Unknown error") + "\n");
     if (r.statusCode === undefined) {
       process.exitCode = 10;
@@ -245,15 +239,15 @@ describe("config set - platform connection guard for service mode paths", () => 
     });
   });
 
-  test("config set services.web-search.mode managed - fails when not connected, no IPC write emitted", async () => {
+  test("config set services.web-search.provider vellum - fails when not connected, no IPC write emitted", async () => {
     const { exitCode, stdout } = await runCli([
       "node",
       "assistant",
       "--json",
       "config",
       "set",
-      "services.web-search.mode",
-      "managed",
+      "services.web-search.provider",
+      "vellum",
     ]);
 
     expect(exitCode).toBe(1);
@@ -262,8 +256,8 @@ describe("config set - platform connection guard for service mode paths", () => 
     expect(parsed.error).toContain("vellum platform connect");
     // The guard runs *before* the IPC call - no config_set should have been
     // emitted.
-    expect(
-      mockIpcCalls.filter((c) => c.method === "config_set"),
-    ).toHaveLength(0);
+    expect(mockIpcCalls.filter((c) => c.method === "config_set")).toHaveLength(
+      0,
+    );
   });
 });

--- a/assistant/src/__tests__/config-set-platform-guard.test.ts
+++ b/assistant/src/__tests__/config-set-platform-guard.test.ts
@@ -239,6 +239,28 @@ describe("config set - platform connection guard for service mode paths", () => 
     });
   });
 
+  test("config set services.web-search.mode - rejected with provider guidance, no IPC write emitted", async () => {
+    // The web-search schema has no mode field; a raw write would be stripped
+    // at parse while the CLI reported success.
+    const { exitCode, stdout } = await runCli([
+      "node",
+      "assistant",
+      "--json",
+      "config",
+      "set",
+      "services.web-search.mode",
+      "managed",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("services.web-search.provider vellum");
+    expect(mockIpcCalls.filter((c) => c.method === "config_set")).toHaveLength(
+      0,
+    );
+  });
+
   test("config set services.web-search.provider vellum - fails when not connected, no IPC write emitted", async () => {
     const { exitCode, stdout } = await runCli([
       "node",

--- a/assistant/src/__tests__/inference-no-mode-boot-e2e.test.ts
+++ b/assistant/src/__tests__/inference-no-mode-boot-e2e.test.ts
@@ -158,7 +158,6 @@ function makeConfig(overrides?: Record<string, unknown>) {
         model: "gemini-3.1-flash-image-preview",
       },
       "web-search": {
-        mode: "your-own" as const,
         provider: "inference-provider-native",
       },
     },

--- a/assistant/src/__tests__/provider-platform-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-platform-proxy-integration.test.ts
@@ -102,7 +102,6 @@ let mockPlatformAssistantId = "";
 let mockAssistantApiKey: string | null = null;
 let mockProviderKeys: Record<string, string> = {};
 const defaultWebSearchService: Services["web-search"] = {
-  mode: "your-own",
   provider: "inference-provider-native",
 };
 
@@ -177,7 +176,6 @@ const MANAGED_API_KEY = "ast-managed-key-123";
 const PLATFORM_ASSISTANT_ID = "assistant-abc123";
 
 const MANAGED_NATIVE_WEB_SEARCH: Services["web-search"] = {
-  mode: "managed",
   provider: "inference-provider-native",
 };
 

--- a/assistant/src/__tests__/provider-registry-ollama.test.ts
+++ b/assistant/src/__tests__/provider-registry-ollama.test.ts
@@ -17,10 +17,7 @@ import {
 
 const baseLlm = LLMSchema.parse({});
 
-function ollamaConfig(webSearch: {
-  mode: "managed" | "your-own";
-  provider: "inference-provider-native";
-}) {
+function ollamaConfig(webSearch: { provider: "inference-provider-native" }) {
   return {
     services: {
       inference: {},
@@ -49,7 +46,6 @@ describe("provider registry (ollama)", () => {
   test("registers ollama when selected provider has no API key", async () => {
     await initializeProviders(
       ollamaConfig({
-        mode: "your-own",
         provider: "inference-provider-native",
       }),
     );
@@ -62,7 +58,6 @@ describe("provider registry (ollama)", () => {
   test("managed native web search preference does not make ollama a managed web-search provider", async () => {
     await initializeProviders(
       ollamaConfig({
-        mode: "managed",
         provider: "inference-provider-native",
       }),
     );

--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -66,12 +66,19 @@ export function registerConfigCommand(program: Command): void {
             // keep as string
           }
 
-          // Require platform connection when setting a service mode to "managed"
-          if (SERVICE_MODE_PATH_RE.test(key) && parsed === "managed") {
+          // Managed services authenticate via the platform connection:
+          // mode "managed" for mode-based services, provider "vellum" for
+          // web search.
+          const requiresPlatform =
+            (SERVICE_MODE_PATH_RE.test(key) && parsed === "managed") ||
+            (key === "services.web-search.provider" && parsed === "vellum");
+          if (requiresPlatform) {
             const { requirePlatformConnection } =
               await import("./oauth/shared.js");
             const connected = await requirePlatformConnection(cmd);
-            if (!connected) return;
+            if (!connected) {
+              return;
+            }
           }
 
           // Direct-replacement set semantics (preserves null, replaces objects).

--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -66,6 +66,20 @@ export function registerConfigCommand(program: Command): void {
             // keep as string
           }
 
+          // Web-search has no mode field: the schema strips it, so a write
+          // here would print success while changing nothing. Reject it with
+          // the provider-based replacement instead.
+          if (key === "services.web-search.mode") {
+            const { writeOutput } = await import("../output.js");
+            writeOutput(cmd, {
+              ok: false,
+              error:
+                "services.web-search.mode does not exist; web search is configured by provider alone. For managed search run `config set services.web-search.provider vellum`.",
+            });
+            process.exitCode = 1;
+            return;
+          }
+
           // Managed services authenticate via the platform connection:
           // mode "managed" for mode-based services, provider "vellum" for
           // web search.

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -56,11 +56,15 @@ const ImageGenerationServiceSchema = BaseServiceSchema.extend({
   model: z.string().default(DEFAULT_IMAGE_MODEL),
 });
 
-const WebSearchServiceSchema = BaseServiceSchema.extend({
-  // Provider choice for app-executed search in Your Own mode, or the native
-  // hosted-search preference when set to `inference-provider-native`. In
-  // Managed mode, non-native inference providers can still use the platform
-  // managed search proxy through the app-executed `web_search` tool.
+/**
+ * Web-search carries no `mode`: `provider` is the only axis. `"vellum"`
+ * searches through the Vellum platform search proxy, billed to Vellum
+ * credits; `"inference-provider-native"` prefers the inference model's own
+ * hosted search, falling back to the user's keys and then the platform
+ * proxy; any other provider uses the user's own API key. A `mode` key sent
+ * by an older client is stripped at parse.
+ */
+const WebSearchServiceSchema = z.object({
   provider: z
     .enum(VALID_WEB_SEARCH_PROVIDERS)
     .default("inference-provider-native"),

--- a/assistant/src/providers/__tests__/registry-native-web-search.test.ts
+++ b/assistant/src/providers/__tests__/registry-native-web-search.test.ts
@@ -57,7 +57,6 @@ function makeConfig(): ProvidersConfig {
         model: "gemini-3.1-flash-image-preview",
       },
       "web-search": {
-        mode: "managed",
         provider: "inference-provider-native",
       },
     },

--- a/assistant/src/providers/__tests__/satellite-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/satellite-connection-routing.test.ts
@@ -159,7 +159,7 @@ const providersConfigStub = {
       provider: "openai",
       model: "gpt-image-1",
     },
-    "web-search": { mode: "managed" as const, provider: "brave" },
+    "web-search": { provider: "vellum" as const },
   },
 };
 

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -80,7 +80,6 @@ export interface ProvidersConfig {
       model: string;
     };
     "web-search": {
-      mode: "managed" | "your-own";
       provider: string;
     };
   };

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -692,7 +692,6 @@ const ConfigGetResponseSchema = z
       .object({
         "web-search": z
           .object({
-            mode: ServiceModeSchema.optional(),
             provider: z.string().optional(),
           })
           .passthrough()
@@ -795,7 +794,6 @@ const ConfigPatchRequestSchema = z
       .object({
         "web-search": z
           .object({
-            mode: ServiceModeSchema.optional(),
             provider: z.string().optional(),
           })
           .passthrough()

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -474,8 +474,8 @@ describe("web_search tool", () => {
 
   // ---- Managed Brave provider -------------------------------------------
 
-  test("managed mode uses Brave proxy without BYOK provider keys", async () => {
-    seedWebSearch("managed", "inference-provider-native");
+  test("provider vellum uses Brave proxy without BYOK provider keys", async () => {
+    seedWebSearch(undefined, "vellum");
     mockManagedSearchProxyResult = {
       ok: true,
       status: 200,
@@ -548,7 +548,7 @@ describe("web_search tool", () => {
 
     const directResult = await execute({ query: "same query" });
 
-    seedWebSearch("managed", "brave");
+    seedWebSearch(undefined, "vellum");
     mockBraveSecureKey = undefined;
     mockManagedSearchProxyResult = {
       ok: true,
@@ -566,8 +566,8 @@ describe("web_search tool", () => {
     );
   });
 
-  test("managed mode passes abort signal to the platform proxy", async () => {
-    seedWebSearch("managed", "perplexity");
+  test("provider vellum passes abort signal to the platform proxy", async () => {
+    seedWebSearch(undefined, "vellum");
     const controller = new AbortController();
 
     await execute({ query: "abortable query" }, { signal: controller.signal });
@@ -576,8 +576,8 @@ describe("web_search tool", () => {
     expect(mockManagedSearchProxyCalls[0].signal).toBe(controller.signal);
   });
 
-  test("managed mode maps insufficient balance to a managed usage error", async () => {
-    seedWebSearch("managed", "perplexity");
+  test("provider vellum maps insufficient balance to a managed usage error", async () => {
+    seedWebSearch(undefined, "vellum");
     mockManagedSearchProxyResult = {
       ok: false,
       kind: "platform-error",
@@ -595,8 +595,8 @@ describe("web_search tool", () => {
     expect(result.content).toContain("different web search provider");
   });
 
-  test("managed mode maps proxied provider errors to a tool error", async () => {
-    seedWebSearch("managed", "perplexity");
+  test("provider vellum maps proxied provider errors to a tool error", async () => {
+    seedWebSearch(undefined, "vellum");
     mockManagedSearchProxyResult = {
       ok: true,
       status: 400,
@@ -612,8 +612,8 @@ describe("web_search tool", () => {
     );
   });
 
-  test("managed mode returns a clear error when platform context is unavailable", async () => {
-    seedWebSearch("managed", "perplexity");
+  test("provider vellum returns a clear error when platform context is unavailable", async () => {
+    seedWebSearch(undefined, "vellum");
     mockManagedSearchProxyResult = {
       ok: false,
       kind: "unavailable",

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -37,7 +37,6 @@ const TAVILY_API_URL = "https://api.tavily.com/search";
 const FIRECRAWL_API_URL = "https://api.firecrawl.dev/v2/search";
 
 type WebSearchProvider = "perplexity" | "brave" | "tavily" | "firecrawl";
-type WebSearchMode = "managed" | "your-own";
 
 /**
  * Arguments passed to every {@link WebSearchAdapter}. The full superset is
@@ -143,20 +142,6 @@ function getWebSearchProvider(): WebSearchProvider {
     return "perplexity";
   }
   return configured as WebSearchProvider;
-}
-
-function getWebSearchMode(): WebSearchMode {
-  const services = getConfig().services["web-search"];
-  // ponytail: `mode` is the pre-migration-132 signal; delete this half once
-  // migration 132 has shipped everywhere. While it exists it preserves
-  // pre-migration routing VERBATIM — including proxy-billed searches for
-  // `mode: "managed"` + Provider Native configs that also hold a BYOK key.
-  // That is deliberate: this PR must not change legacy-config behavior.
-  // Migration 132 drops `mode` and thereby flips those configs to the
-  // keys-first fallback below.
-  return services.provider === "vellum" || services.mode === "managed"
-    ? "managed"
-    : "your-own";
 }
 
 async function getApiKey(
@@ -1190,7 +1175,10 @@ export const webSearchTool = {
     }
 
     const startedAt = Date.now();
-    const mode = getWebSearchMode();
+    // An explicit vellum choice is unconditionally managed: proxy errors
+    // (including 402) surface to the user and never fall back to BYOK keys.
+    const managedSearch =
+      getConfig().services["web-search"].provider === "vellum";
 
     const count =
       typeof input.count === "number"
@@ -1226,7 +1214,7 @@ export const webSearchTool = {
       }
     };
 
-    if (mode === "managed") {
+    if (managedSearch) {
       return executeManagedSearch();
     }
 


### PR DESCRIPTION
## Summary
- `WebSearchServiceSchema` is a plain `{ provider }` object: no `BaseServiceSchema`, no `mode` — a mode key sent by an older client is stripped at parse (`ServiceModeSchema`/`BaseServiceSchema`/`getServiceMode` stay for image-generation and the OAuth services)
- Daemon config GET/PATCH contracts expose `provider` only for web-search (matching web-fetch); `web_search` dispatch branches on `provider === "vellum"` directly — `getWebSearchMode()` and the `WebSearchMode` type are deleted; `ProvidersConfig` drops the field
- `config set services.web-search.provider vellum` requires a platform connection (same guard as mode-based managed services); test fixtures across 9 suites move to provider-only configs
- The web card's legacy `mode` write-pair bridge is deliberately untouched: old daemons still need it, and this daemon strips the key

## Original prompt
Final code PR of the web-search vellum-provider plan (attached to #38677): with routing (#38681), the card (#38688), and migration 132 + platform defaults (#38689) all merged, remove the `mode` field from the web-search schema and every contract that carries it, leaving provider as the only axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->