### PR TITLE
Single-source subagent lifecycle events from api/events

### DIFF
--- a/assistant/src/daemon/message-types/subagents.ts
+++ b/assistant/src/daemon/message-types/subagents.ts
@@ -1,32 +1,14 @@
 // Subagent lifecycle and communication types.
+//
+// The `subagent_spawned` and `subagent_status_changed` server events are
+// single-sourced from their canonical `api/events` wire schemas; this file
+// composes them into the domain union consumed by `message-protocol.ts`.
 
-import type { SubagentStatus } from "../../subagent/types.js";
+import type { SubagentSpawnedEvent } from "../../api/events/subagent-spawned.js";
+import type { SubagentStatusChangedEvent } from "../../api/events/subagent-status-changed.js";
 import type { UsageStats } from "./shared.js";
 
 // === Server → Client ===
-
-export interface SubagentSpawned {
-  type: "subagent_spawned";
-  subagentId: string;
-  parentConversationId: string;
-  label: string;
-  objective: string;
-  isFork?: boolean;
-  /**
-   * Tool-use id of the `skill_execute` call that spawned this subagent. Lets
-   * the client anchor the inline subagent card to the exact spawn tool call,
-   * independent of the (reconcile-volatile) parent message id.
-   */
-  parentToolUseId?: string;
-}
-
-export interface SubagentStatusChanged {
-  type: "subagent_status_changed";
-  subagentId: string;
-  status: SubagentStatus;
-  error?: string;
-  usage?: UsageStats;
-}
 
 export interface SubagentDetailResponse {
   type: "subagent_detail_response";
@@ -76,6 +58,6 @@ export type _SubagentsClientMessages =
   | SubagentDetailRequest;
 
 export type _SubagentsServerMessages =
-  | SubagentSpawned
-  | SubagentStatusChanged
+  | SubagentSpawnedEvent
+  | SubagentStatusChangedEvent
   | SubagentDetailResponse;


### PR DESCRIPTION
## Why

Continues the event-type unification effort — making `api/events/*.ts` the single source of truth for every server→client event so the runtime `message-types/*` domains stop hand-maintaining a parallel copy of the wire shape. Prior PRs migrated `background-tool`/`workflow` (#38718) and `acp` (#38726); this does the two subagent lifecycle events.

## What

- **`daemon/message-types/subagents.ts`** — Drop the hand-written `SubagentSpawned` and `SubagentStatusChanged` interfaces. `_SubagentsServerMessages` now composes `SubagentSpawnedEvent` / `SubagentStatusChangedEvent` imported from `api/events/subagent-*.ts`. Verified field-for-field identical, including the shared `SubagentStatus` enum (`api/events/subagent-status-changed.ts` mirrors `subagent/types.ts`) and the `UsageStats` shape (`SubagentUsageStatsSchema`).

These two events had no external type consumers — they're constructed inline by shape in `subagent/manager.ts` and validated by typecheck against the api-inferred union.

## Deliberately out of scope

- **`SubagentDetailResponse`** stays local. Its canonical schema already lives in `api/responses/subagent-detail.ts`, but the two diverge: the response schema has no `type` discriminant and carries extra `status` / `toolUseId` / `input` fields. That's a real reconciliation, not a mechanical swap, so it belongs with the `SubagentEvent` reconciliation PR.
- **`SubagentEvent`** (the recursive `event: ServerMessage` wrapper in `message-protocol.ts`) — untouched; the wire-sensitive reconciliation is its own PR.

## Safety

No wire or type change. `bun run typecheck:fast`, eslint, prettier, and the subagent + SSE-parity suites all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_