### PR TITLE
fix(skills-watcher): react only to SKILL.md and TOOLS.json changes

### DIFF
--- a/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
+++ b/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
@@ -162,204 +162,198 @@ describe("ConfigWatcher skills watcher reseeding", () => {
     rmSync(WORKSPACE_DIR, { recursive: true, force: true });
   });
 
-  test("watched skill file changes evict conversations and refresh skill memories", async () => {
-    watcher.start();
+  describe("recursive watcher", () => {
+    beforeEach(() => {
+      recursiveWatchAvailable = true;
+    });
 
-    const skillsWatcher = findWatcher(SKILLS_DIR);
-    expect(skillsWatcher).toBeDefined();
-    skillsWatcher!.callback("change", "example-skill/SKILL.md");
+    test("reloads on SKILL.md changes", async () => {
+      watcher.start();
 
-    await new Promise((resolve) => setTimeout(resolve, 300));
+      const skillsWatcher = findWatcher(SKILLS_DIR);
+      expect(skillsWatcher).toBeDefined();
+      skillsWatcher!.callback("change", "example-skill/SKILL.md");
 
-    expect(evictCalls).toBe(1);
-    expect(skillsChangedCalls).toBe(1);
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      expect(evictCalls).toBe(1);
+      expect(skillsChangedCalls).toBe(1);
+    });
+
+    test("reloads on TOOLS.json changes", async () => {
+      watcher.start();
+
+      const skillsWatcher = findWatcher(SKILLS_DIR);
+      skillsWatcher!.callback("change", "example-skill/TOOLS.json");
+
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      expect(evictCalls).toBe(1);
+      expect(skillsChangedCalls).toBe(1);
+    });
+
+    test("ignores non-catalog files (scripts, references, build output)", async () => {
+      watcher.start();
+
+      const skillsWatcher = findWatcher(SKILLS_DIR);
+      skillsWatcher!.callback("change", "example-skill/references/foo.md");
+      skillsWatcher!.callback("change", "example-skill/dist/index.js");
+      skillsWatcher!.callback("change", "example-skill/package.json");
+      skillsWatcher!.callback("change", "example-skill/scripts/run.py");
+
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      expect(evictCalls).toBe(0);
+      expect(skillsChangedCalls).toBe(0);
+    });
+
+    test("ignores catalog files under skipped dependency and staging paths", async () => {
+      watcher.start();
+
+      const skillsWatcher = findWatcher(SKILLS_DIR);
+      skillsWatcher!.callback(
+        "change",
+        "example-skill/node_modules/pkg/SKILL.md",
+      );
+      skillsWatcher!.callback(
+        "change",
+        ".install-staging/example-skill/SKILL.md",
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      expect(evictCalls).toBe(0);
+      expect(skillsChangedCalls).toBe(0);
+    });
+
+    test("coalesces multiple catalog changes into one reload", async () => {
+      watcher.start();
+
+      const skillsWatcher = findWatcher(SKILLS_DIR);
+      skillsWatcher!.callback("change", "example-skill/SKILL.md");
+      skillsWatcher!.callback("change", "example-skill/package.json");
+      skillsWatcher!.callback("change", "example-skill/TOOLS.json");
+      skillsWatcher!.callback("change", "other-skill/SKILL.md");
+
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      expect(evictCalls).toBe(1);
+      expect(skillsChangedCalls).toBe(1);
+    });
   });
 
-  test("recursive watcher ignores skipped dependency and staging paths", async () => {
-    recursiveWatchAvailable = true;
+  describe("per-skill-directory fallback", () => {
+    test("watches the root and each immediate skill directory, not nested subdirectories", () => {
+      const skillDir = join(SKILLS_DIR, "example-skill");
+      mkdirSync(join(skillDir, "references"), { recursive: true });
+      mkdirSync(join(skillDir, "dist"), { recursive: true });
 
-    watcher.start();
+      watcher.start();
 
-    const skillsWatcher = findWatcher(SKILLS_DIR);
-    expect(skillsWatcher).toBeDefined();
-    skillsWatcher!.callback(
-      "change",
-      "example-skill/node_modules/pkg/index.js",
-    );
-    skillsWatcher!.callback(
-      "change",
-      ".install-staging/example-skill/SKILL.md",
-    );
+      expect(findWatcher(SKILLS_DIR)).toBeDefined();
+      expect(findWatcher(skillDir)).toBeDefined();
+      expect(findWatcher(join(skillDir, "references"))).toBeUndefined();
+      expect(findWatcher(join(skillDir, "dist"))).toBeUndefined();
+    });
 
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    test("does not watch dependency or staging directories", () => {
+      const skillDir = join(SKILLS_DIR, "example-skill");
+      mkdirSync(join(skillDir, "node_modules", "pkg"), { recursive: true });
+      mkdirSync(join(SKILLS_DIR, ".install-staging", "staged"), {
+        recursive: true,
+      });
 
-    expect(evictCalls).toBe(0);
-    expect(skillsChangedCalls).toBe(0);
+      watcher.start();
 
-    skillsWatcher!.callback("change", "example-skill/references/foo.md");
+      expect(findWatcher(join(skillDir, "node_modules"))).toBeUndefined();
+      expect(findWatcher(join(SKILLS_DIR, ".install-staging"))).toBeUndefined();
+      expect(findWatcher(skillDir)).toBeDefined();
+    });
 
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    test("reloads on SKILL.md / TOOLS.json edits within a skill directory", async () => {
+      const skillDir = join(SKILLS_DIR, "example-skill");
+      mkdirSync(skillDir, { recursive: true });
 
-    expect(evictCalls).toBe(1);
-    expect(skillsChangedCalls).toBe(1);
-  });
+      watcher.start();
+      const skillWatcher = findWatcher(skillDir);
+      expect(skillWatcher).toBeDefined();
 
-  test("recursive watcher reloads skill memories for build output changes", async () => {
-    recursiveWatchAvailable = true;
+      skillWatcher!.callback("change", "SKILL.md");
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(evictCalls).toBe(1);
+      expect(skillsChangedCalls).toBe(1);
 
-    watcher.start();
+      skillWatcher!.callback("change", "TOOLS.json");
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(evictCalls).toBe(2);
+      expect(skillsChangedCalls).toBe(2);
+    });
 
-    const skillsWatcher = findWatcher(SKILLS_DIR);
-    expect(skillsWatcher).toBeDefined();
-    skillsWatcher!.callback("change", "example-skill/dist/index.js");
+    test("ignores non-catalog file edits within a skill directory", async () => {
+      const skillDir = join(SKILLS_DIR, "example-skill");
+      mkdirSync(skillDir, { recursive: true });
 
-    await new Promise((resolve) => setTimeout(resolve, 300));
+      watcher.start();
+      const skillWatcher = findWatcher(skillDir);
 
-    expect(evictCalls).toBe(1);
-    expect(skillsChangedCalls).toBe(1);
-  });
+      skillWatcher!.callback("change", "README.md");
+      skillWatcher!.callback("change", "package.json");
+      await new Promise((resolve) => setTimeout(resolve, 300));
 
-  test("coalesces multiple skill file changes into one catalog refresh", async () => {
-    watcher.start();
+      expect(evictCalls).toBe(0);
+      expect(skillsChangedCalls).toBe(0);
+    });
 
-    const skillsWatcher = findWatcher(SKILLS_DIR);
-    expect(skillsWatcher).toBeDefined();
-    skillsWatcher!.callback("change", "example-skill/SKILL.md");
-    skillsWatcher!.callback("change", "example-skill/package.json");
-    skillsWatcher!.callback("change", "other-skill/SKILL.md");
+    test("watches and reloads when a skill is installed", async () => {
+      watcher.start();
+      const rootWatcher = findWatcher(SKILLS_DIR);
+      expect(rootWatcher).toBeDefined();
 
-    await new Promise((resolve) => setTimeout(resolve, 300));
+      const newSkillDir = join(SKILLS_DIR, "new-skill");
+      mkdirSync(newSkillDir, { recursive: true });
+      rootWatcher!.callback("rename", "new-skill");
 
-    expect(evictCalls).toBe(1);
-    expect(skillsChangedCalls).toBe(1);
-  });
+      await new Promise((resolve) => setTimeout(resolve, 300));
 
-  test("fallback watches existing nested skill directories", async () => {
-    const referencesDir = join(SKILLS_DIR, "example-skill", "references");
-    mkdirSync(referencesDir, { recursive: true });
+      expect(findWatcher(newSkillDir)).toBeDefined();
+      expect(evictCalls).toBe(1);
+      expect(skillsChangedCalls).toBe(1);
+    });
 
-    watcher.start();
+    test("closes the watcher and reloads when a skill is removed", async () => {
+      const skillDir = join(SKILLS_DIR, "example-skill");
+      mkdirSync(skillDir, { recursive: true });
 
-    const referencesWatcher = findWatcher(referencesDir);
-    expect(referencesWatcher).toBeDefined();
-    referencesWatcher!.callback("change", "notes.md");
+      watcher.start();
+      expect(findWatcher(skillDir)).toBeDefined();
 
-    await new Promise((resolve) => setTimeout(resolve, 300));
+      rmSync(skillDir, { recursive: true, force: true });
+      const rootWatcher = findWatcher(SKILLS_DIR);
+      rootWatcher!.callback("rename", "example-skill");
 
-    expect(evictCalls).toBe(1);
-    expect(skillsChangedCalls).toBe(1);
-  });
+      await new Promise((resolve) => setTimeout(resolve, 300));
 
-  test("fallback skips dependency and staging directories", async () => {
-    const skillDir = join(SKILLS_DIR, "example-skill");
-    const nodeModulesDir = join(skillDir, "node_modules");
-    const dependencyDir = join(nodeModulesDir, "pkg");
-    const stagingDir = join(SKILLS_DIR, ".install-staging");
-    const stagedSkillDir = join(stagingDir, "example-skill");
-    const referencesDir = join(skillDir, "references");
-    mkdirSync(dependencyDir, { recursive: true });
-    mkdirSync(stagedSkillDir, { recursive: true });
-    mkdirSync(referencesDir, { recursive: true });
+      expect(findWatcher(skillDir)).toBeUndefined();
+      expect(findCapturedWatcher(skillDir)?.closed).toBe(true);
+      expect(evictCalls).toBe(1);
+      expect(skillsChangedCalls).toBe(1);
+    });
 
-    watcher.start();
+    test("does not duplicate a watcher or reload when the root changes but the skill set does not", async () => {
+      const skillDir = join(SKILLS_DIR, "example-skill");
+      mkdirSync(skillDir, { recursive: true });
 
-    expect(findWatcher(nodeModulesDir)).toBeUndefined();
-    expect(findWatcher(dependencyDir)).toBeUndefined();
-    expect(findWatcher(stagingDir)).toBeUndefined();
-    expect(findWatcher(stagedSkillDir)).toBeUndefined();
+      watcher.start();
+      expect(capturedWatcherCount(skillDir)).toBe(1);
 
-    const skillsWatcher = findWatcher(SKILLS_DIR);
-    const skillWatcher = findWatcher(skillDir);
-    expect(skillsWatcher).toBeDefined();
-    expect(skillWatcher).toBeDefined();
+      // A stray file event at the root: no skill directory added or removed.
+      const rootWatcher = findWatcher(SKILLS_DIR);
+      rootWatcher!.callback("change", "README.md");
+      await new Promise((resolve) => setTimeout(resolve, 300));
 
-    skillsWatcher!.callback("rename", ".install-staging");
-    skillWatcher!.callback("rename", "node_modules");
-    skillWatcher!.callback("change", "node_modules/pkg/index.js");
-
-    await new Promise((resolve) => setTimeout(resolve, 300));
-
-    expect(evictCalls).toBe(0);
-    expect(skillsChangedCalls).toBe(0);
-
-    const referencesWatcher = findWatcher(referencesDir);
-    expect(referencesWatcher).toBeDefined();
-    referencesWatcher!.callback("change", "foo.md");
-
-    await new Promise((resolve) => setTimeout(resolve, 300));
-
-    expect(evictCalls).toBe(1);
-    expect(skillsChangedCalls).toBe(1);
-  });
-
-  test("fallback watches skill build output directories", async () => {
-    const distDir = join(SKILLS_DIR, "example-skill", "dist");
-    const buildDir = join(SKILLS_DIR, "example-skill", "build");
-    mkdirSync(distDir, { recursive: true });
-    mkdirSync(buildDir, { recursive: true });
-
-    watcher.start();
-
-    const distWatcher = findWatcher(distDir);
-    const buildWatcher = findWatcher(buildDir);
-    expect(distWatcher).toBeDefined();
-    expect(buildWatcher).toBeDefined();
-
-    distWatcher!.callback("change", "index.js");
-
-    await new Promise((resolve) => setTimeout(resolve, 300));
-
-    expect(evictCalls).toBe(1);
-    expect(skillsChangedCalls).toBe(1);
-
-    buildWatcher!.callback("change", "tool.js");
-
-    await new Promise((resolve) => setTimeout(resolve, 300));
-
-    expect(evictCalls).toBe(2);
-    expect(skillsChangedCalls).toBe(2);
-  });
-
-  test("fallback adds watchers for new nested skill directories without duplicates", () => {
-    const skillDir = join(SKILLS_DIR, "example-skill");
-    const toolsDir = join(skillDir, "tools");
-    const generatedDir = join(toolsDir, "generated");
-    mkdirSync(skillDir, { recursive: true });
-
-    watcher.start();
-
-    const skillWatcher = findWatcher(skillDir);
-    expect(skillWatcher).toBeDefined();
-
-    mkdirSync(generatedDir, { recursive: true });
-    skillWatcher!.callback("rename", "tools");
-    skillWatcher!.callback("rename", "tools");
-
-    expect(findWatcher(toolsDir)).toBeDefined();
-    expect(findWatcher(generatedDir)).toBeDefined();
-    expect(capturedWatcherCount(toolsDir)).toBe(1);
-    expect(capturedWatcherCount(generatedDir)).toBe(1);
-  });
-
-  test("fallback closes stale nested watchers when directories are removed", () => {
-    const skillDir = join(SKILLS_DIR, "example-skill");
-    const referencesDir = join(skillDir, "references");
-    const deepDir = join(referencesDir, "deep");
-    mkdirSync(deepDir, { recursive: true });
-
-    watcher.start();
-
-    expect(findWatcher(referencesDir)).toBeDefined();
-    expect(findWatcher(deepDir)).toBeDefined();
-
-    rmSync(referencesDir, { recursive: true, force: true });
-    const skillWatcher = findWatcher(skillDir);
-    expect(skillWatcher).toBeDefined();
-    skillWatcher!.callback("rename", "references");
-
-    expect(findWatcher(referencesDir)).toBeUndefined();
-    expect(findWatcher(deepDir)).toBeUndefined();
-    expect(findCapturedWatcher(referencesDir)?.closed).toBe(true);
-    expect(findCapturedWatcher(deepDir)?.closed).toBe(true);
+      expect(capturedWatcherCount(skillDir)).toBe(1);
+      expect(evictCalls).toBe(0);
+      expect(skillsChangedCalls).toBe(0);
+    });
   });
 });

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -4,7 +4,6 @@
  * for changes.
  */
 import {
-  type Dirent,
   existsSync,
   type FSWatcher,
   mkdirSync,
@@ -14,7 +13,7 @@ import {
   watch,
   watchFile,
 } from "node:fs";
-import { join, relative } from "node:path";
+import { basename, join } from "node:path";
 
 import { getConfig, invalidateConfigCache } from "../config/loader.js";
 import type { MemoryCleanupConfig } from "../config/schemas/memory-lifecycle.js";
@@ -72,6 +71,20 @@ function isSkippedSkillWatchPath(relativePath: string): boolean {
 
   const segments = relativePath.split(/[\\/]+/).filter(Boolean);
   return segments.some((segment) => SKILL_WATCH_SKIPPED_DIRS.has(segment));
+}
+
+/**
+ * Files whose contents feed the skill catalog: `SKILL.md` carries a skill's
+ * metadata and body, `TOOLS.json` its tool manifest. Both live at the top
+ * level of a skill directory. Every other file (scripts, reference docs, build
+ * output) is read fresh on demand or irrelevant to the catalog, so changes to
+ * them do not require a catalog reload.
+ */
+const SKILL_CATALOG_FILENAMES = new Set(["SKILL.md", "TOOLS.json"]);
+
+/** True when a changed path's basename is a skill-catalog file. */
+function isSkillCatalogFile(filename: string): boolean {
+  return SKILL_CATALOG_FILENAMES.has(basename(filename));
 }
 
 /**
@@ -484,46 +497,58 @@ export class ConfigWatcher {
       }
 
       this.debounceTimers.schedule("skills:catalog", () => {
-        log.info({ file }, "Skill file changed, reloading");
+        log.info({ file }, "Skill catalog changed, reloading");
         evictConversationsForReload();
         refreshSkillCapabilityMemories(getConfig());
       });
     };
 
+    // Only SKILL.md and TOOLS.json feed the skill catalog, and both live at the
+    // top level of a skill directory. Changes to any other file (scripts,
+    // reference docs, build output) never alter the catalog, so the watchers
+    // react only to those two files — plus skill directories appearing or
+    // disappearing, which is an install or removal.
     try {
       const recursiveWatcher = watch(
         skillsDir,
         { recursive: true },
         (_eventType, filename) => {
-          scheduleSkillsReload(filename ? String(filename) : "(unknown)");
+          if (!filename || isSkillCatalogFile(String(filename))) {
+            scheduleSkillsReload(filename ? String(filename) : "(unknown)");
+          }
         },
       );
       attachWatcherErrorHandler(recursiveWatcher, skillsDir);
       this.watchers.push(recursiveWatcher);
-      log.info({ dir: skillsDir }, "Watching skills directory recursively");
+      log.info({ dir: skillsDir }, "Watching skills catalog recursively");
       return;
     } catch (err) {
       log.info(
         { err, dir: skillsDir },
-        "Recursive skills watch unavailable; using per-directory watchers",
+        "Recursive skills watch unavailable; using per-skill-directory watchers",
       );
     }
 
-    const childWatchers = new Map<string, FSWatcher>();
+    // Fallback when recursive watches are unavailable: watch the skills root
+    // (to detect a skill being installed or removed) plus each immediate skill
+    // directory (to detect SKILL.md / TOOLS.json edits). Nested subdirectories
+    // are deliberately not watched, bounding the descriptor count to one per
+    // skill rather than one per subdirectory.
+    const skillDirWatchers = new Map<string, FSWatcher>();
 
     const watchDir = (
       dirPath: string,
-      onChange: (filename: string) => void,
+      onChange: (filename: string | null) => void,
     ): FSWatcher | null => {
       try {
         const watcher = watch(dirPath, (_eventType, filename) => {
-          onChange(filename ? String(filename) : "(unknown)");
+          onChange(filename ? String(filename) : null);
         });
         attachWatcherErrorHandler(watcher, dirPath);
         this.watchers.push(watcher);
         return watcher;
       } catch (err) {
-        log.warn({ err, dirPath }, "Failed to watch skills directory");
+        log.warn({ err, dirPath }, "Failed to watch skill directory");
         return null;
       }
     };
@@ -535,103 +560,72 @@ export class ConfigWatcher {
       }
     };
 
-    const formatSkillChangeLabel = (
-      dirPath: string,
-      filename: string,
-    ): string => {
-      if (filename === "(unknown)") {
-        const relativeDir = relative(skillsDir, dirPath);
-        return relativeDir || "(unknown)";
-      }
-      const relativeFile = relative(skillsDir, join(dirPath, filename));
-      return relativeFile || filename;
-    };
-
-    const enumerateSkillSubdirectories = (
-      dirPath: string,
-      acc: Set<string>,
-    ): boolean => {
-      let entries: Dirent[];
+    const listSkillDirs = (): string[] => {
       try {
-        entries = readdirSync(dirPath, { withFileTypes: true });
+        return readdirSync(skillsDir, { withFileTypes: true })
+          .filter(
+            (entry) =>
+              entry.isDirectory() && !SKILL_WATCH_SKIPPED_DIRS.has(entry.name),
+          )
+          .map((entry) => join(skillsDir, entry.name));
       } catch (err) {
-        log.warn({ err, dirPath }, "Failed to enumerate skill directories");
-        return dirPath !== skillsDir;
+        log.warn({ err, skillsDir }, "Failed to enumerate skill directories");
+        return [];
       }
-
-      for (const entry of entries) {
-        if (!entry.isDirectory()) {
-          continue;
-        }
-        if (SKILL_WATCH_SKIPPED_DIRS.has(entry.name)) {
-          continue;
-        }
-        const childDir = join(dirPath, entry.name);
-        acc.add(childDir);
-        enumerateSkillSubdirectories(childDir, acc);
-      }
-      return true;
     };
 
-    const closeChildWatcher = (dirPath: string, watcher: FSWatcher): void => {
-      watcher.close();
-      childWatchers.delete(dirPath);
-      removeWatcher(watcher);
-    };
+    // Reconcile the per-skill-directory watchers against what is on disk.
+    // Returns true when the set of watched directories changed — i.e. a skill
+    // was installed or removed — so the caller can reload the catalog.
+    const refreshSkillDirWatchers = (): boolean => {
+      const nextDirs = new Set(listSkillDirs());
+      let changed = false;
 
-    const refreshChildWatchers = (): void => {
-      const nextChildDirs = new Set<string>();
-      if (!enumerateSkillSubdirectories(skillsDir, nextChildDirs)) {
-        for (const [childDir, watcher] of childWatchers.entries()) {
-          closeChildWatcher(childDir, watcher);
-        }
-        return;
-      }
-
-      for (const [childDir, watcher] of childWatchers.entries()) {
-        if (nextChildDirs.has(childDir)) {
+      for (const [dirPath, watcher] of skillDirWatchers.entries()) {
+        if (nextDirs.has(dirPath)) {
           continue;
         }
-        closeChildWatcher(childDir, watcher);
+        watcher.close();
+        skillDirWatchers.delete(dirPath);
+        removeWatcher(watcher);
+        changed = true;
       }
 
-      for (const childDir of nextChildDirs) {
-        if (childWatchers.has(childDir)) {
+      for (const dirPath of nextDirs) {
+        if (skillDirWatchers.has(dirPath)) {
           continue;
         }
-
-        const watcher = watchDir(childDir, (filename) => {
-          const file = formatSkillChangeLabel(childDir, filename);
-          if (isSkippedSkillWatchPath(file)) {
-            return;
+        const watcher = watchDir(dirPath, (filename) => {
+          if (!filename || isSkillCatalogFile(filename)) {
+            scheduleSkillsReload(filename ?? "(unknown)");
           }
-
-          scheduleSkillsReload(file);
-          refreshChildWatchers();
         });
         if (watcher) {
-          childWatchers.set(childDir, watcher);
+          skillDirWatchers.set(dirPath, watcher);
+          changed = true;
         }
       }
+
+      return changed;
     };
 
-    const rootWatcher = watchDir(skillsDir, (filename) => {
-      if (isSkippedSkillWatchPath(filename)) {
-        return;
+    const rootWatcher = watchDir(skillsDir, () => {
+      // A change directly under the skills root means a skill directory was
+      // added, removed, or renamed. Re-sync the per-skill watchers and reload
+      // the catalog when the set actually changed.
+      if (refreshSkillDirWatchers()) {
+        scheduleSkillsReload("(skill installed or removed)");
       }
-
-      scheduleSkillsReload(filename);
-      refreshChildWatchers();
     });
 
     if (!rootWatcher) {
       return;
     }
 
-    refreshChildWatchers();
+    refreshSkillDirWatchers();
     log.info(
       { dir: skillsDir },
-      "Watching skills directory with non-recursive fallback",
+      "Watching skills catalog with per-skill-directory fallback",
     );
   }
 }


### PR DESCRIPTION
## Prompt / plan

Follow-up to the outbound-proxy fd fix, narrowing the workspace skills watcher. The watcher previously fired a full catalog reload (`evictConversationsForReload` + `refreshSkillCapabilityMemories`) on **any** file change anywhere under the skills tree, and in its per-directory fallback created one `fs.watch` per subdirectory (nested scripts, `references/`, `dist/`, `build/` included).

Only two files actually feed the skill catalog, both at the top level of a skill directory:

- **`SKILL.md`** — metadata frontmatter + body (`config/skills.ts` `readSkillFromDirectory`)
- **`TOOLS.json`** — tool manifest (`detectToolManifest`)

Everything else is irrelevant to the catalog: skill scripts are executed fresh on each invocation (`sandbox-runner` does `bun run …`), and a skill's `includes` are child **skill IDs** whose own `SKILL.md` files are already watched — so there's no staleness gap from narrowing the watch.

## Changes

- **Recursive watch:** only `SKILL.md` / `TOOLS.json` changes (matched by basename) trigger a reload; other file changes are ignored. Skipped dependency/staging paths (`node_modules`, `.install-staging`, etc.) stay filtered.
- **Per-directory fallback:** watch the skills **root** (to detect a skill being installed or removed) plus **each immediate skill directory** (to catch `SKILL.md` / `TOOLS.json` edits). Nested subdirectories are no longer watched, bounding the descriptor count to **one watcher per skill** instead of one per subdirectory. Install/removal is detected by reconciling the immediate-skill-dir set on root events, reloading only when that set actually changes.

Net effect: no more redundant catalog reloads on irrelevant edits (a script tweak, a reference-doc edit), and — in fallback mode — a sharply smaller inotify/descriptor footprint for skills that carry deep directory trees.

## Test plan

`config-watcher-skill-reseed.test.ts` rewritten to the new semantics:

- **recursive:** reloads on `SKILL.md` and `TOOLS.json`; ignores `references/`, `dist/`, `package.json`, `scripts/`; ignores catalog files under skipped dependency/staging paths; coalesces multiple catalog changes into one reload.
- **fallback:** watches only the root + immediate skill dirs (not `references/`/`dist/`, not `node_modules`/`.install-staging`); reloads on in-dir `SKILL.md`/`TOOLS.json` edits; ignores non-catalog edits; watches + reloads on install; closes the watcher + reloads on removal; no duplicate watcher or reload when a root event doesn't change the skill set.

`12 pass, 0 fail`. Pre-commit hook green (Prettier, ESLint, full `assistant/` type-check all pass).

Note: the standalone combined run of the three `config-watcher-*` test files trips a pre-existing cross-file `VELLUM_WORKSPACE_DIR` env-pollution issue (the reseed module sets it at module scope and `rmSync`s it in `afterAll`); each file passes in isolation, which is how the suite is meant to be run per `AGENTS.md`.

## CLI verb checklist

No new routes — this only changes daemon-internal file-watching behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFdTA4wopPbcTsQaAiK4as

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFdTA4wopPbcTsQaAiK4as)_