### PR TITLE
feat(live-voice): unified voice front-door — endpointing merged into the triage leg (JARVIS-1320)

### DIFF
--- a/assistant/scripts/voice-ttft-spike.ts
+++ b/assistant/scripts/voice-ttft-spike.ts
@@ -1,0 +1,241 @@
+/**
+ * Voice front-door TTFT decomposition spike (JARVIS-1320).
+ *
+ * Measures time-to-first-token for the same chatty utterance across prompt
+ * sizes and profiles, to attribute where the live-voice front-door leg's
+ * multi-second first token goes (provider intrinsic vs prompt prefill vs
+ * agent-loop dispatch overhead — the last one is the gap between this
+ * script's `full` variants and the live session's `llmFirstDeltaMs`).
+ *
+ * Variants:
+ *   slim-haiku    voiceFrontDecision call site (Haiku pin), slim prompt
+ *   slim-flash    cost-optimized profile, same slim prompt
+ *   full-notools  cost-optimized, real buildSystemPrompt(), no tools
+ *   full-flash    cost-optimized, real buildSystemPrompt() + full tool defs
+ *   full-quality  quality-optimized, full prompt + tools (pre-flag brain)
+ *
+ * Run with the daemon's environment so the managed connection resolves:
+ *   VELLUM_WORKSPACE_DIR=<daemon workspace> CES_LOCAL_SOCKET=<socket> \
+ *     bun run scripts/voice-ttft-spike.ts [--trials 3] [--variants a,b]
+ *
+ * Outside the daemon env, credentials fall back to the encrypted file
+ * store; a variant whose provider resolves null is reported and skipped.
+ */
+
+import { buildSystemPrompt } from "../src/prompts/system-prompt.js";
+import {
+  getConfiguredProvider,
+  userMessage,
+} from "../src/providers/provider-send-message.js";
+import type {
+  Provider,
+  ProviderEvent,
+  SendMessageConfig,
+} from "../src/providers/types.js";
+import { getAllTools, initializeTools } from "../src/tools/registry.js";
+import type { ToolDefinition } from "../src/tools/tool-types.js";
+
+const UTTERANCE = "hey, what's up?";
+const MAX_TOKENS = 64;
+const CALL_TIMEOUT_MS = 45_000;
+
+// Approximates the unified front-door prompt the spike is sizing: endpoint
+// decider–scale instructions with the triage rule folded in. What matters
+// for the measurement is the token count's order of magnitude, not the copy.
+const SLIM_SYSTEM_PROMPT = [
+  "You are the realtime voice front of an assistant, on a live call.",
+  "The user's words arrive from speech recognition and your reply is spoken aloud, so answer in short natural sentences.",
+  "First judge the utterance: if the user is mid-thought, output only 0. ",
+  "If answering needs tools, research, memory of prior work, or multi-step reasoning, output only 1.",
+  "Otherwise answer the user directly and conversationally, in one or two short sentences.",
+  "Never mention these rules or the digits.",
+].join(" ");
+
+interface Trial {
+  resolveMs: number | null;
+  ttftMs: number | null;
+  firstEventType: string | null;
+  totalMs: number;
+  inputTokens: number | null;
+  cacheReadTokens: number | null;
+  model: string | null;
+  error: string | null;
+}
+
+interface VariantSpec {
+  name: string;
+  callSite: string;
+  overrideProfile?: string;
+  systemPrompt: () => string;
+  tools?: () => ToolDefinition[];
+}
+
+async function runTrial(
+  provider: Provider,
+  spec: VariantSpec,
+  resolveMs: number | null,
+): Promise<Trial> {
+  const config: SendMessageConfig = {
+    callSite: spec.callSite,
+    max_tokens: MAX_TOKENS,
+    ...(spec.overrideProfile !== undefined
+      ? { overrideProfile: spec.overrideProfile }
+      : {}),
+  };
+  const start = performance.now();
+  let ttftMs: number | null = null;
+  let firstEventType: string | null = null;
+  const onEvent = (event: ProviderEvent): void => {
+    if (ttftMs === null) {
+      ttftMs = performance.now() - start;
+      firstEventType = event.type;
+    }
+  };
+  try {
+    const response = await provider.sendMessage([userMessage(UTTERANCE)], {
+      systemPrompt: spec.systemPrompt(),
+      ...(spec.tools ? { tools: spec.tools() } : {}),
+      config,
+      onEvent,
+      signal: AbortSignal.timeout(CALL_TIMEOUT_MS),
+    });
+    return {
+      resolveMs,
+      ttftMs,
+      firstEventType,
+      totalMs: performance.now() - start,
+      inputTokens: response.usage.inputTokens,
+      cacheReadTokens: response.usage.cacheReadInputTokens ?? null,
+      model: response.model,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      resolveMs,
+      ttftMs,
+      firstEventType,
+      totalMs: performance.now() - start,
+      inputTokens: null,
+      cacheReadTokens: null,
+      model: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function fmt(value: number | null, suffix = ""): string {
+  return value === null ? "—" : `${Math.round(value)}${suffix}`;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const trials = Number(args[args.indexOf("--trials") + 1] || 0) || 3;
+  const variantFilter =
+    args.indexOf("--variants") !== -1
+      ? new Set(args[args.indexOf("--variants") + 1]?.split(",") ?? [])
+      : null;
+
+  // Tool init can wander into MCP/plugin registration; a failure there
+  // still leaves the core registry populated, which is all the size
+  // stand-in needs.
+  let toolInitError: string | null = null;
+  try {
+    await initializeTools();
+  } catch (error) {
+    toolInitError =
+      error instanceof Error ? error.message : String(error);
+  }
+  // Registry entries are definition-shaped objects (see tool-manifest.ts);
+  // getDefinition exists only on some registrations. Either way this
+  // payload is a size stand-in, not an executable tool set.
+  const toolDefs: ToolDefinition[] = getAllTools()
+    .map((tool) => {
+      const t = tool as unknown as ToolDefinition & {
+        getDefinition?: () => ToolDefinition;
+      };
+      return typeof t.getDefinition === "function"
+        ? t.getDefinition()
+        : { name: t.name, description: t.description, input_schema: t.input_schema };
+    })
+    .filter((def) => Boolean(def.name && def.input_schema));
+  const fullPrompt = buildSystemPrompt();
+  console.log(
+    `system prompt: ${fullPrompt.length} chars (~${Math.round(fullPrompt.length / 4)} tokens); ` +
+      `tools: ${toolDefs.length} defs, ${JSON.stringify(toolDefs).length} chars` +
+      (toolInitError ? ` (tool init degraded: ${toolInitError})` : ""),
+  );
+
+  const variants: VariantSpec[] = [
+    {
+      name: "slim-haiku",
+      callSite: "voiceFrontDecision",
+      systemPrompt: () => SLIM_SYSTEM_PROMPT,
+    },
+    {
+      name: "slim-flash",
+      callSite: "inference",
+      overrideProfile: "cost-optimized",
+      systemPrompt: () => SLIM_SYSTEM_PROMPT,
+    },
+    {
+      name: "full-notools",
+      callSite: "inference",
+      overrideProfile: "cost-optimized",
+      systemPrompt: () => fullPrompt,
+    },
+    {
+      name: "full-flash",
+      callSite: "inference",
+      overrideProfile: "cost-optimized",
+      systemPrompt: () => fullPrompt,
+      tools: () => toolDefs,
+    },
+    {
+      name: "full-quality",
+      callSite: "inference",
+      overrideProfile: "quality-optimized",
+      systemPrompt: () => fullPrompt,
+      tools: () => toolDefs,
+    },
+  ];
+
+  const results: Array<{ variant: string; trial: number } & Trial> = [];
+  for (const spec of variants) {
+    if (variantFilter && !variantFilter.has(spec.name)) {
+      continue;
+    }
+    const resolveStart = performance.now();
+    const provider = await getConfiguredProvider(spec.callSite, {
+      ...(spec.overrideProfile !== undefined
+        ? { overrideProfile: spec.overrideProfile }
+        : {}),
+    });
+    const resolveMs = performance.now() - resolveStart;
+    if (!provider) {
+      console.error(
+        `${spec.name}: no provider resolved (managed credentials missing? ` +
+          `run with the daemon's VELLUM_WORKSPACE_DIR + CES_LOCAL_SOCKET)`,
+      );
+      continue;
+    }
+    for (let i = 0; i < trials; i++) {
+      const trial = await runTrial(provider, spec, i === 0 ? resolveMs : null);
+      results.push({ variant: spec.name, trial: i + 1, ...trial });
+      const line =
+        `${spec.name.padEnd(14)} #${i + 1}  ` +
+        `ttft ${fmt(trial.ttftMs, "ms").padStart(8)}  ` +
+        `total ${fmt(trial.totalMs, "ms").padStart(8)}  ` +
+        `in ${fmt(trial.inputTokens, " tok").padStart(10)}  ` +
+        `cacheRead ${fmt(trial.cacheReadTokens).padStart(6)}  ` +
+        `${trial.model ?? ""}` +
+        (trial.error ? `  ERROR ${trial.error}` : "");
+      console.log(line);
+    }
+  }
+
+  console.log("\nJSON:");
+  console.log(JSON.stringify(results, null, 2));
+}
+
+await main();
+process.exit(0);

--- a/assistant/src/calls/__tests__/voice-control-protocol.test.ts
+++ b/assistant/src/calls/__tests__/voice-control-protocol.test.ts
@@ -2,43 +2,44 @@ import { describe, expect, test } from "bun:test";
 
 import {
   couldBeControlMarker,
-  ESCALATE_MARKER,
+  ESCALATE_VERDICT_TOKEN,
+  HOLD_VERDICT_TOKEN,
   stripInternalSpeechMarkers,
 } from "../voice-control-protocol.js";
 
-describe("[ESCALATE] control marker", () => {
-  test("marker constant is the expected token", () => {
-    expect(ESCALATE_MARKER).toBe("[ESCALATE]");
+describe("front-door verdict tokens", () => {
+  test("token constants are the expected bracketed forms", () => {
+    expect(HOLD_VERDICT_TOKEN).toBe("[0]");
+    expect(ESCALATE_VERDICT_TOKEN).toBe("[1]");
   });
 
-  test("stripInternalSpeechMarkers removes [ESCALATE] so it is never spoken", () => {
+  test("stripInternalSpeechMarkers removes both tokens so they are never spoken", () => {
     expect(
-      stripInternalSpeechMarkers("Let me think about that. [ESCALATE]").trim(),
+      stripInternalSpeechMarkers("[1] Let me think about that.").trim(),
     ).toBe("Let me think about that.");
+    expect(stripInternalSpeechMarkers("hey [0]").trim()).toBe("hey");
   });
 
-  test("stripping removes every [ESCALATE] occurrence", () => {
+  test("stripping removes every verdict-token occurrence", () => {
     expect(
-      stripInternalSpeechMarkers("[ESCALATE] one [ESCALATE] two").replace(
-        /\s+/g,
-        " ",
-      ),
-    ).toBe(" one two");
+      stripInternalSpeechMarkers("[1] one [1] two [0]").replace(/\s+/g, " "),
+    ).toBe(" one two ");
   });
 
-  test("couldBeControlMarker holds the complete marker (not flushed to TTS)", () => {
-    expect(couldBeControlMarker("[ESCALATE]")).toBe(true);
+  test("couldBeControlMarker holds the complete tokens (not flushed to TTS)", () => {
+    expect(couldBeControlMarker("[0]")).toBe(true);
+    expect(couldBeControlMarker("[1]")).toBe(true);
   });
 
-  test("couldBeControlMarker holds a partial marker still streaming", () => {
-    // Any prefix of the marker must be held so a streamed "[ESCA" does not
-    // leak to the TTS engine before the full marker arrives.
-    for (const partial of ["[", "[ES", "[ESCAL", "[ESCALATE"]) {
+  test("couldBeControlMarker holds a partial token still streaming", () => {
+    // Any prefix of a token must be held so a streamed "[1" does not leak
+    // to the TTS engine before the full token arrives.
+    for (const partial of ["[", "[0", "[1"]) {
       expect(couldBeControlMarker(partial)).toBe(true);
     }
   });
 
-  test("ordinary text is not mistaken for the marker", () => {
+  test("ordinary text is not mistaken for a token", () => {
     expect(couldBeControlMarker("Sure, one moment")).toBe(false);
     expect(stripInternalSpeechMarkers("Sure, one moment")).toBe(
       "Sure, one moment",

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -71,14 +71,14 @@ import { setConfig } from "../../__tests__/helpers/set-config.js";
 import { ABORT_WATCHDOG_MS } from "../../daemon/abort-watchdog.js";
 import { CALL_OPENING_MARKER } from "../voice-control-protocol.js";
 import {
-  cutFrontDoorContentAtMarker,
+  cutFrontDoorContentAtVerdict,
   startVoiceTurn,
   TOOL_RESULT_PREVIEW_MAX_CHARS,
 } from "../voice-session-bridge.js";
 import {
   escalatedContinuationRule,
   ESCALATION_CONTINUATION_CONTENT,
-  frontDoorTriageRule,
+  frontDoorDecisionRule,
 } from "../voice-triage-escalate.js";
 
 // `resolveProcessingWaitMs` reads `workspaceGit.turnCommitMaxWaitMs`; seed it
@@ -350,8 +350,8 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
 describe("startVoiceTurn triage-and-escalate control prompt", () => {
   // Live-voice supplies its own voiceControlPrompt, bypassing
   // buildVoiceCallControlPrompt where the routing-leg rule is normally injected.
-  // The rule must still be appended, or the front-door model is never told to
-  // emit [ESCALATE] and can't hand off.
+  // The rule must still be appended, or the front-door model never learns the
+  // verdict protocol and can't hold or hand off.
   const LIVE_VOICE_PROMPT = "You are speaking in a local live voice session.";
 
   // The turn installs its resolved control prompt, then cleanup resets it to
@@ -366,7 +366,7 @@ describe("startVoiceTurn triage-and-escalate control prompt", () => {
     return () => applied.find((p): p is string => typeof p === "string");
   }
 
-  test("appends the front-door triage rule to a caller-supplied prompt", async () => {
+  test("appends the front-door decision rule to a caller-supplied prompt", async () => {
     const installed = captureInstalledPrompt();
     await startVoiceTurn({
       ...makeTurnOptions(),
@@ -374,7 +374,18 @@ describe("startVoiceTurn triage-and-escalate control prompt", () => {
       routingLeg: "front-door",
     });
     expect(installed()).toContain(LIVE_VOICE_PROMPT);
-    expect(installed()).toContain(frontDoorTriageRule());
+    expect(installed()).toContain(frontDoorDecisionRule());
+  });
+
+  test("a speculative front-door leg's rule includes the hold branch", async () => {
+    const installed = captureInstalledPrompt();
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      voiceControlPrompt: LIVE_VOICE_PROMPT,
+      routingLeg: "front-door",
+      unifiedVerdict: true,
+    });
+    expect(installed()).toContain(frontDoorDecisionRule({ includeHold: true }));
   });
 
   test("appends the escalated continuation rule to a caller-supplied prompt", async () => {
@@ -1267,18 +1278,18 @@ describe("front-door leg tool suppression", () => {
   });
 });
 
-describe("cutFrontDoorContentAtMarker", () => {
-  test("null when no text block carries the marker (committed answer)", () => {
+describe("cutFrontDoorContentAtVerdict", () => {
+  test("null when the content carries no verdict token (committed answer)", () => {
     expect(
-      cutFrontDoorContentAtMarker([{ type: "text", text: "It is Tuesday." }]),
+      cutFrontDoorContentAtVerdict([{ type: "text", text: "It is Tuesday." }]),
     ).toBeNull();
   });
 
-  test("cuts at the marker, keeping only the spoken bridge", () => {
-    const cut = cutFrontDoorContentAtMarker([
+  test("an escalated leg reduces to its capped spoken bridge", () => {
+    const cut = cutFrontDoorContentAtVerdict([
       {
         type: "text",
-        text: "Let me check your calendar. [ESCALATE] weak answer",
+        text: "[1] Let me check your calendar. weak answer past the cap",
       },
     ]);
     expect(cut?.blocks).toEqual([
@@ -1287,22 +1298,30 @@ describe("cutFrontDoorContentAtMarker", () => {
     expect(cut?.spokenText).toBe("Let me check your calendar.");
   });
 
-  test("drops blocks after the marker block and keeps earlier ones", () => {
-    const cut = cutFrontDoorContentAtMarker([
-      { type: "text", text: "One moment. " },
-      { type: "text", text: "[ESCALATE]" },
+  test("a verdict split across blocks is still recognized from the joined text", () => {
+    const cut = cutFrontDoorContentAtVerdict([
+      { type: "text", text: "[1" },
+      { type: "text", text: "] One moment. " },
       { type: "text", text: "trailing weak text in its own block" },
     ]);
-    expect(cut?.blocks).toEqual([{ type: "text", text: "One moment. " }]);
+    expect(cut?.blocks).toEqual([{ type: "text", text: "One moment." }]);
     expect(cut?.spokenText).toBe("One moment.");
   });
 
-  test("a bare marker yields empty spoken text (delete-the-row signal)", () => {
-    const cut = cutFrontDoorContentAtMarker([
-      { type: "text", text: "[ESCALATE] discarded" },
-    ]);
+  test("a bare escalate verdict yields empty spoken text (delete-the-row signal)", () => {
+    const cut = cutFrontDoorContentAtVerdict([{ type: "text", text: "[1]" }]);
     expect(cut?.blocks).toEqual([]);
     expect(cut?.spokenText).toBe("");
+  });
+
+  test("stray verdict tokens inside an answer are stripped, not treated as escalation", () => {
+    const cut = cutFrontDoorContentAtVerdict([
+      { type: "text", text: "It is Tuesday [0] indeed." },
+    ]);
+    expect(cut?.blocks).toEqual([
+      { type: "text", text: "It is Tuesday  indeed." },
+    ]);
+    expect(cut?.spokenText).toBe("It is Tuesday  indeed.");
   });
 });
 
@@ -1352,7 +1371,7 @@ describe("front-door transcript hygiene (teardown pass)", () => {
   test("an escalated leg's row is cut to the spoken bridge and history reloads", async () => {
     const { events } = makeReservedRowConversation();
     getMessageByIdImpl = () =>
-      makeRow("Let me check your calendar. [ESCALATE] weak answer");
+      makeRow("[1] Let me check your calendar. weak answer past the cap");
 
     await startVoiceTurn({ ...makeTurnOptions(), routingLeg: "front-door" });
     await flushMicrotasks();
@@ -1371,9 +1390,9 @@ describe("front-door transcript hygiene (teardown pass)", () => {
     expect(events).toContain("loadFromDb");
   });
 
-  test("a bare-marker row (canned fallback was the audio) is deleted", async () => {
+  test("a bare-verdict row (canned fallback was the audio) is deleted", async () => {
     const { events } = makeReservedRowConversation();
-    getMessageByIdImpl = () => makeRow("[ESCALATE] discarded weak text");
+    getMessageByIdImpl = () => makeRow("[1]");
 
     await startVoiceTurn({ ...makeTurnOptions(), routingLeg: "front-door" });
     await flushMicrotasks();
@@ -1383,7 +1402,7 @@ describe("front-door transcript hygiene (teardown pass)", () => {
     expect(events).toContain("loadFromDb");
   });
 
-  test("a committed front-door answer (no marker) is left untouched", async () => {
+  test("a committed front-door answer (no verdict token) is left untouched", async () => {
     const { events } = makeReservedRowConversation();
     getMessageByIdImpl = () => makeRow("It is Tuesday.");
 
@@ -1398,7 +1417,7 @@ describe("front-door transcript hygiene (teardown pass)", () => {
 
   test("a non-routed leg never runs the hygiene pass", async () => {
     makeReservedRowConversation();
-    getMessageByIdImpl = () => makeRow("Anything [ESCALATE] at all");
+    getMessageByIdImpl = () => makeRow("[1] Anything at all");
 
     await startVoiceTurn(makeTurnOptions());
     await flushMicrotasks();

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -11,7 +11,14 @@
  * strings, so those are pinned here too. `waitForIdle`'s own semantics are
  * covered by `src/__tests__/conversation-wait-for-idle.test.ts`.
  */
-import { describe, expect, mock, setSystemTime, test } from "bun:test";
+import {
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mocks — declared before importing voice-session-bridge
@@ -24,10 +31,47 @@ mock.module("../../daemon/conversation-store.js", () => ({
   getOrCreateConversation: async () => fakeConversation,
 }));
 
+// Conversation-CRUD doubles for the teardown transcript-hygiene pass. The
+// real module is spread so every other export keeps its production behavior;
+// only the three functions the hygiene pass (and discard) touch are recorded.
+import * as realConversationCrud from "../../persistence/conversation-crud.js";
+
+let getMessageByIdImpl: (
+  messageId: string,
+  conversationId?: string,
+) => unknown = () => null;
+const crudLog: {
+  reads: string[];
+  updates: Array<{ messageId: string; content: string }>;
+  deletes: string[];
+} = { reads: [], updates: [], deletes: [] };
+function resetCrudLog(): void {
+  crudLog.reads.length = 0;
+  crudLog.updates.length = 0;
+  crudLog.deletes.length = 0;
+  getMessageByIdImpl = () => null;
+}
+
+mock.module("../../persistence/conversation-crud.js", () => ({
+  ...realConversationCrud,
+  getMessageById: (messageId: string, conversationId?: string) => {
+    crudLog.reads.push(messageId);
+    return getMessageByIdImpl(messageId, conversationId);
+  },
+  updateMessageContent: (messageId: string, content: string) => {
+    crudLog.updates.push({ messageId, content });
+  },
+  deleteMessageById: (messageId: string) => {
+    crudLog.deletes.push(messageId);
+    return { segmentIds: [], deletedSummaryIds: [] };
+  },
+}));
+
 import { setConfig } from "../../__tests__/helpers/set-config.js";
 import { ABORT_WATCHDOG_MS } from "../../daemon/abort-watchdog.js";
 import { CALL_OPENING_MARKER } from "../voice-control-protocol.js";
 import {
+  cutFrontDoorContentAtMarker,
   startVoiceTurn,
   TOOL_RESULT_PREVIEW_MAX_CHARS,
 } from "../voice-session-bridge.js";
@@ -73,6 +117,7 @@ interface FakeConversation {
   updateClient: (cb: unknown, reset?: boolean) => void;
   runAgentLoop: (...args: unknown[]) => Promise<void>;
   abort: (reason?: unknown) => void;
+  loadFromDb: () => Promise<void>;
   toolsDisabledDepth: number;
 }
 
@@ -129,6 +174,9 @@ function makeFakeConversation(opts: {
     },
     runAgentLoop: () => (opts.runAgentLoop ?? (async () => {}))(),
     abort: () => {},
+    loadFromDb: async () => {
+      opts.events?.push("loadFromDb");
+    },
     toolsDisabledDepth: 0,
   };
   return {
@@ -1216,5 +1264,172 @@ describe("front-door leg tool suppression", () => {
       expect(depthDuringLoop).toBe(0);
       expect(fake.conversation.toolsDisabledDepth).toBe(0);
     }
+  });
+});
+
+describe("cutFrontDoorContentAtMarker", () => {
+  test("null when no text block carries the marker (committed answer)", () => {
+    expect(
+      cutFrontDoorContentAtMarker([{ type: "text", text: "It is Tuesday." }]),
+    ).toBeNull();
+  });
+
+  test("cuts at the marker, keeping only the spoken bridge", () => {
+    const cut = cutFrontDoorContentAtMarker([
+      {
+        type: "text",
+        text: "Let me check your calendar. [ESCALATE] weak answer",
+      },
+    ]);
+    expect(cut?.blocks).toEqual([
+      { type: "text", text: "Let me check your calendar." },
+    ]);
+    expect(cut?.spokenText).toBe("Let me check your calendar.");
+  });
+
+  test("drops blocks after the marker block and keeps earlier ones", () => {
+    const cut = cutFrontDoorContentAtMarker([
+      { type: "text", text: "One moment. " },
+      { type: "text", text: "[ESCALATE]" },
+      { type: "text", text: "trailing weak text in its own block" },
+    ]);
+    expect(cut?.blocks).toEqual([{ type: "text", text: "One moment. " }]);
+    expect(cut?.spokenText).toBe("One moment.");
+  });
+
+  test("a bare marker yields empty spoken text (delete-the-row signal)", () => {
+    const cut = cutFrontDoorContentAtMarker([
+      { type: "text", text: "[ESCALATE] discarded" },
+    ]);
+    expect(cut?.blocks).toEqual([]);
+    expect(cut?.spokenText).toBe("");
+  });
+});
+
+describe("front-door transcript hygiene (teardown pass)", () => {
+  beforeEach(resetCrudLog);
+
+  function makeRow(text: string) {
+    return {
+      id: "assistant-row-1",
+      conversationId: "conv-voice-bridge-test",
+      role: "assistant",
+      content: [{ type: "text", text }],
+      createdAt: 0,
+      metadata: null,
+      clientMessageId: null,
+      finalized: 1,
+    };
+  }
+
+  /**
+   * Conversation whose scripted agent loop announces a reserved assistant
+   * row via `assistant_turn_start` — the id the teardown hygiene pass
+   * targets. With `holdLoopOpen` the loop stays in flight until released,
+   * so a discard can land mid-turn.
+   */
+  function makeReservedRowConversation(opts?: { holdLoopOpen?: boolean }) {
+    let release: () => void = () => {};
+    const events: string[] = [];
+    const fake = makeFakeConversation({ processing: false, events });
+    fake.conversation.runAgentLoop = async (...args: unknown[]) => {
+      const { onEvent } = args[2] as { onEvent: (msg: unknown) => void };
+      onEvent({
+        type: "assistant_turn_start",
+        messageId: "assistant-row-1",
+        conversationId: "conv-voice-bridge-test",
+      });
+      if (opts?.holdLoopOpen) {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      }
+    };
+    fakeConversation = fake.conversation;
+    return { events, releaseLoop: () => release() };
+  }
+
+  test("an escalated leg's row is cut to the spoken bridge and history reloads", async () => {
+    const { events } = makeReservedRowConversation();
+    getMessageByIdImpl = () =>
+      makeRow("Let me check your calendar. [ESCALATE] weak answer");
+
+    await startVoiceTurn({ ...makeTurnOptions(), routingLeg: "front-door" });
+    await flushMicrotasks();
+
+    expect(crudLog.updates).toEqual([
+      {
+        messageId: "assistant-row-1",
+        content: JSON.stringify([
+          { type: "text", text: "Let me check your calendar." },
+        ]),
+      },
+    ]);
+    expect(crudLog.deletes).toHaveLength(0);
+    // The escalated leg waits on this turn's teardown, so the reload below
+    // is what guarantees the quality model never sees the marker text.
+    expect(events).toContain("loadFromDb");
+  });
+
+  test("a bare-marker row (canned fallback was the audio) is deleted", async () => {
+    const { events } = makeReservedRowConversation();
+    getMessageByIdImpl = () => makeRow("[ESCALATE] discarded weak text");
+
+    await startVoiceTurn({ ...makeTurnOptions(), routingLeg: "front-door" });
+    await flushMicrotasks();
+
+    expect(crudLog.updates).toHaveLength(0);
+    expect(crudLog.deletes).toEqual(["assistant-row-1"]);
+    expect(events).toContain("loadFromDb");
+  });
+
+  test("a committed front-door answer (no marker) is left untouched", async () => {
+    const { events } = makeReservedRowConversation();
+    getMessageByIdImpl = () => makeRow("It is Tuesday.");
+
+    await startVoiceTurn({ ...makeTurnOptions(), routingLeg: "front-door" });
+    await flushMicrotasks();
+
+    expect(crudLog.reads).toEqual(["assistant-row-1"]);
+    expect(crudLog.updates).toHaveLength(0);
+    expect(crudLog.deletes).toHaveLength(0);
+    expect(events).not.toContain("loadFromDb");
+  });
+
+  test("a non-routed leg never runs the hygiene pass", async () => {
+    makeReservedRowConversation();
+    getMessageByIdImpl = () => makeRow("Anything [ESCALATE] at all");
+
+    await startVoiceTurn(makeTurnOptions());
+    await flushMicrotasks();
+
+    expect(crudLog.reads).toHaveLength(0);
+    expect(crudLog.updates).toHaveLength(0);
+    expect(crudLog.deletes).toHaveLength(0);
+  });
+
+  test("a discarded speculative leg deletes its reserved assistant row at teardown", async () => {
+    const { releaseLoop } = makeReservedRowConversation({
+      holdLoopOpen: true,
+    });
+
+    const handle = await startVoiceTurn({
+      ...makeTurnOptions(),
+      routingLeg: "front-door",
+      unifiedVerdict: true,
+    });
+    await flushMicrotasks();
+    await handle.discard?.();
+
+    // The discard rolls back the user row at once; the reserved assistant
+    // row is only safe to remove after the loop settles (the stranded fold
+    // would otherwise re-finalize it), so it goes at teardown.
+    expect(crudLog.deletes).toContain("msg-1");
+    expect(crudLog.deletes).not.toContain("assistant-row-1");
+
+    releaseLoop();
+    await flushMicrotasks();
+
+    expect(crudLog.deletes).toContain("assistant-row-1");
   });
 });

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -73,6 +73,7 @@ interface FakeConversation {
   updateClient: (cb: unknown, reset?: boolean) => void;
   runAgentLoop: (...args: unknown[]) => Promise<void>;
   abort: (reason?: unknown) => void;
+  toolsDisabledDepth: number;
 }
 
 function makeFakeConversation(opts: {
@@ -128,6 +129,7 @@ function makeFakeConversation(opts: {
     },
     runAgentLoop: () => (opts.runAgentLoop ?? (async () => {}))(),
     abort: () => {},
+    toolsDisabledDepth: 0,
   };
   return {
     conversation,
@@ -1169,5 +1171,50 @@ describe("startVoiceTurn tool-event forwarding", () => {
     await flushMicrotasks();
 
     expect(handle.turnId).toBeString();
+  });
+});
+
+describe("front-door leg tool suppression", () => {
+  test("tools are disabled for exactly the front-door loop's duration", async () => {
+    let depthDuringLoop = -1;
+    const fake = makeFakeConversation({
+      processing: false,
+      runAgentLoop: async () => {
+        depthDuringLoop = fake.conversation.toolsDisabledDepth;
+      },
+    });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(undefined, "conv-front-door-tools"),
+      routingLeg: "front-door",
+    });
+    await flushMicrotasks();
+
+    // Suppressed while the loop ran; the finally released it.
+    expect(depthDuringLoop).toBe(1);
+    expect(fake.conversation.toolsDisabledDepth).toBe(0);
+  });
+
+  test("non-routed and escalated legs leave tools enabled", async () => {
+    for (const routingLeg of [undefined, "escalated" as const]) {
+      let depthDuringLoop = -1;
+      const fake = makeFakeConversation({
+        processing: false,
+        runAgentLoop: async () => {
+          depthDuringLoop = fake.conversation.toolsDisabledDepth;
+        },
+      });
+      fakeConversation = fake.conversation;
+
+      await startVoiceTurn({
+        ...makeTurnOptions(undefined, "conv-tools-untouched"),
+        ...(routingLeg ? { routingLeg } : {}),
+      });
+      await flushMicrotasks();
+
+      expect(depthDuringLoop).toBe(0);
+      expect(fake.conversation.toolsDisabledDepth).toBe(0);
+    }
   });
 });

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -10,7 +10,6 @@ import {
   escalatedContinuationRule,
   ESCALATION_CONTINUATION_CONTENT,
   FALLBACK_ESCALATION_BRIDGE,
-  FRONT_DOOR_PROFILE,
   frontDoorCapabilityDigest,
   frontDoorDecisionRule,
   HOLD_VERDICT_TOKEN,
@@ -28,12 +27,6 @@ const CONFIG = {} as AssistantConfig;
 
 afterEach(() => {
   clearFeatureFlagOverridesCache();
-});
-
-describe("voice-triage-escalate profiles", () => {
-  test("front door is the fast Speed profile", () => {
-    expect(FRONT_DOOR_PROFILE).toBe("cost-optimized");
-  });
 });
 
 describe("frontDoorCapabilityDigest", () => {

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -7,8 +7,8 @@ import { ESCALATE_MARKER } from "../voice-control-protocol.js";
 import {
   escalatedContinuationRule,
   ESCALATION_CONTINUATION_CONTENT,
-  ESCALATION_PROFILE,
   FRONT_DOOR_PROFILE,
+  frontDoorCapabilityDigest,
   frontDoorTriageRule,
   isVoiceTriageEscalateEnabled,
   needsFallbackBridge,
@@ -24,9 +24,33 @@ afterEach(() => {
 });
 
 describe("voice-triage-escalate profiles", () => {
-  test("front door is the fast Speed profile, escalation is the Quality profile", () => {
+  test("front door is the fast Speed profile", () => {
     expect(FRONT_DOOR_PROFILE).toBe("cost-optimized");
-    expect(ESCALATION_PROFILE).toBe("quality-optimized");
+  });
+});
+
+describe("frontDoorCapabilityDigest", () => {
+  test("names the escalated leg's tools and demands escalation for them", () => {
+    const digest = frontDoorCapabilityDigest(["calendar_read", "web_search"]);
+    expect(digest).toContain("calendar_read, web_search");
+    expect(digest.toLowerCase()).toContain("escalate");
+    // The digest teaches routing, and the bridge phrase should name the
+    // action rather than the model refusing or guessing.
+    expect(digest.toLowerCase()).toContain("holding phrase");
+  });
+
+  test("is empty when no tool names are available (registry-less contexts)", () => {
+    expect(frontDoorCapabilityDigest([])).toBe("");
+  });
+
+  test("appends to the triage rule only when non-empty", () => {
+    const bare = frontDoorTriageRule();
+    expect(frontDoorTriageRule("")).toBe(bare);
+    const withDigest = frontDoorTriageRule(
+      frontDoorCapabilityDigest(["calendar_read"]),
+    );
+    expect(withDigest.startsWith(bare)).toBe(true);
+    expect(withDigest).toContain("calendar_read");
   });
 });
 

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -3,15 +3,20 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
 import { clearFeatureFlagOverridesCache } from "../../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../../config/schema.js";
-import { ESCALATE_MARKER } from "../voice-control-protocol.js";
 import {
+  capEscalationBridge,
+  classifyFrontDoorLeading,
+  ESCALATE_VERDICT_TOKEN,
   escalatedContinuationRule,
   ESCALATION_CONTINUATION_CONTENT,
   FALLBACK_ESCALATION_BRIDGE,
   FRONT_DOOR_PROFILE,
   frontDoorCapabilityDigest,
-  frontDoorTriageRule,
+  frontDoorDecisionRule,
+  HOLD_VERDICT_TOKEN,
+  isEscalationBridgeComplete,
   isVoiceTriageEscalateEnabled,
+  MAX_ESCALATION_BRIDGE_CHARS,
   needsFallbackBridge,
   spokenBridgeText,
   VOICE_TRIAGE_ESCALATE_FLAG,
@@ -45,12 +50,12 @@ describe("frontDoorCapabilityDigest", () => {
     expect(frontDoorCapabilityDigest([])).toBe("");
   });
 
-  test("appends to the triage rule only when non-empty", () => {
-    const bare = frontDoorTriageRule();
-    expect(frontDoorTriageRule("")).toBe(bare);
-    const withDigest = frontDoorTriageRule(
-      frontDoorCapabilityDigest(["calendar_read"]),
-    );
+  test("appends to the decision rule only when non-empty", () => {
+    const bare = frontDoorDecisionRule();
+    expect(frontDoorDecisionRule({ capabilityDigest: "" })).toBe(bare);
+    const withDigest = frontDoorDecisionRule({
+      capabilityDigest: frontDoorCapabilityDigest(["calendar_read"]),
+    });
     expect(withDigest.startsWith(bare)).toBe(true);
     expect(withDigest).toContain("calendar_read");
   });
@@ -73,25 +78,46 @@ describe("isVoiceTriageEscalateEnabled", () => {
   });
 });
 
-describe("front-door triage rule", () => {
-  const rule = frontDoorTriageRule();
+describe("front-door decision rule", () => {
+  const rule = frontDoorDecisionRule();
 
-  test("instructs the model to triage before answering and emit [ESCALATE]", () => {
-    expect(rule).toContain("TRIAGE FIRST");
-    expect(rule).toContain(ESCALATE_MARKER);
-    // Must decide up front — never answer, then bail (spoken audio is final).
-    expect(rule.toLowerCase()).toContain("before you begin answering");
+  test("demands a leading verdict and teaches the escalate token", () => {
+    expect(rule).toContain("DECIDE FIRST");
+    expect(rule).toContain(ESCALATE_VERDICT_TOKEN);
+    // The verdict must lead — never answer, then bail (spoken audio is final).
+    expect(rule.toLowerCase()).toContain("must begin with your verdict");
+    expect(rule.toLowerCase()).toContain("never start answering");
   });
 
-  test("lists tool uncertainty as an escalate trigger (no fabrication)", () => {
+  test("lists tool needs as an escalate trigger (no fabrication)", () => {
     expect(rule.toLowerCase()).toContain("tool");
   });
 
   test("demands a silent decision — no narrated reasoning in spoken output", () => {
     // Regression: a weak front-door model narrated its triage deliberation
     // aloud ("Context is complete — Alex paused...") before the bridge.
-    expect(rule.toLowerCase()).toContain("decide silently");
+    expect(rule.toLowerCase()).toContain("chosen silently");
     expect(rule.toLowerCase()).toContain("never narrate");
+  });
+
+  test("bans verdict tokens anywhere but the leading position", () => {
+    // Regression: a weak front-door model bled the bare hold digit into a
+    // real answer ("hey 0"). Tokens are leading-verdict-only.
+    expect(rule.toLowerCase()).toContain("never inside or after an answer");
+  });
+
+  test("includes the hold branch only when asked for", () => {
+    expect(rule).not.toContain(HOLD_VERDICT_TOKEN);
+    const withHold = frontDoorDecisionRule({ includeHold: true });
+    expect(withHold).toContain(HOLD_VERDICT_TOKEN);
+    // The tie-break asymmetry: when unsure whether the caller finished,
+    // hold — infra failures fail open to a released turn instead.
+    expect(withHold.toLowerCase()).toContain("when unsure");
+  });
+
+  test("demands a single-sentence holding phrase on escalation", () => {
+    expect(rule.toLowerCase()).toContain("one short natural holding phrase");
+    expect(rule.toLowerCase()).toContain("stop after that single sentence");
   });
 });
 
@@ -103,9 +129,9 @@ describe("escalated continuation rule", () => {
     expect(rule.toLowerCase()).toContain("do not greet again");
   });
 
-  test("forbids the quality model from emitting [ESCALATE] again", () => {
-    expect(rule).toContain(ESCALATE_MARKER);
-    expect(rule.toLowerCase()).toContain("never emit");
+  test("forbids the quality model from emitting verdict tokens", () => {
+    expect(rule).toContain(ESCALATE_VERDICT_TOKEN);
+    expect(rule.toLowerCase()).toContain("never output");
   });
 
   test("quotes the actual spoken bridge verbatim when provided", () => {
@@ -132,44 +158,109 @@ describe("escalated continuation rule", () => {
   });
 });
 
+describe("capEscalationBridge", () => {
+  test("cuts just after the first sentence terminator", () => {
+    expect(
+      capEscalationBridge(" Let me check your calendar. And also this junk"),
+    ).toBe("Let me check your calendar.");
+  });
+
+  test("hard-caps a rambling bridge with no terminator", () => {
+    const rambling = "a".repeat(MAX_ESCALATION_BRIDGE_CHARS + 50);
+    expect(capEscalationBridge(rambling)).toHaveLength(
+      MAX_ESCALATION_BRIDGE_CHARS,
+    );
+  });
+
+  test("strips internal markers before capping", () => {
+    expect(capEscalationBridge("[END_CALL] One moment.")).toBe("One moment.");
+  });
+});
+
+describe("isEscalationBridgeComplete", () => {
+  test("complete once a sentence terminator lands", () => {
+    expect(isEscalationBridgeComplete(" Let me check")).toBe(false);
+    expect(isEscalationBridgeComplete(" Let me check your calendar.")).toBe(
+      true,
+    );
+  });
+
+  test("complete at the hard cap even without a terminator", () => {
+    expect(
+      isEscalationBridgeComplete("a".repeat(MAX_ESCALATION_BRIDGE_CHARS)),
+    ).toBe(true);
+  });
+});
+
 describe("spokenBridgeText", () => {
-  test("returns the cleaned pre-marker phrase only", () => {
+  test("returns the capped bridge after a leading escalate verdict", () => {
     expect(
       spokenBridgeText(
-        "Let me check your calendar. [ESCALATE] weak answer that kept streaming",
+        `${ESCALATE_VERDICT_TOKEN} Let me check your calendar. junk past the cap`,
       ),
     ).toBe("Let me check your calendar.");
   });
 
-  test("is empty for a bare marker", () => {
-    expect(spokenBridgeText("[ESCALATE]")).toBe("");
+  test("is empty for a bare escalate verdict", () => {
+    expect(spokenBridgeText(ESCALATE_VERDICT_TOKEN)).toBe("");
   });
 
-  test("without a marker, returns the whole cleaned text", () => {
-    expect(spokenBridgeText("  Hello there. ")).toBe("Hello there.");
+  test("is empty when the output does not lead with the verdict (an answer)", () => {
+    // A stray token later in an answer is not an escalation under the
+    // verdict-first protocol.
+    expect(spokenBridgeText("It is Tuesday.")).toBe("");
+    expect(spokenBridgeText(`Half an answer ${ESCALATE_VERDICT_TOKEN}`)).toBe(
+      "",
+    );
   });
 });
 
 describe("needsFallbackBridge", () => {
-  test("false when the model spoke a real holding phrase before the marker", () => {
+  test("false when the model spoke a real holding phrase after the verdict", () => {
     expect(
-      needsFallbackBridge("Let me think about that for a second. [ESCALATE]"),
+      needsFallbackBridge(
+        `${ESCALATE_VERDICT_TOKEN} Let me think about that for a second.`,
+      ),
     ).toBe(false);
   });
 
-  test("true for a bare marker with no holding phrase", () => {
-    expect(needsFallbackBridge("[ESCALATE]")).toBe(true);
+  test("true for a bare escalate verdict with no holding phrase", () => {
+    expect(needsFallbackBridge(ESCALATE_VERDICT_TOKEN)).toBe(true);
+  });
+});
+
+describe("classifyFrontDoorLeading", () => {
+  test("pending while the stream could still become a verdict token", () => {
+    for (const leading of ["", "[", "[1"]) {
+      expect(classifyFrontDoorLeading(leading, false)).toBe("pending");
+    }
+    expect(classifyFrontDoorLeading("[0", true)).toBe("pending");
   });
 
-  test("true when only post-marker text exists — that text was never spoken", () => {
-    // Regression: the fallback decision must measure text BEFORE the marker.
-    // Post-marker text is suppressed from TTS, so counting it would skip the
-    // fallback and leave the caller in silence during the hand-off.
-    expect(
-      needsFallbackBridge(
-        "[ESCALATE] here is my weak answer the model kept going",
-      ),
-    ).toBe(true);
+  test("hold on the leading hold token, but only when hold is enabled", () => {
+    expect(classifyFrontDoorLeading("[0]", true)).toBe("hold");
+    expect(classifyFrontDoorLeading("[0] trailing", true)).toBe("hold");
+    // A leg whose prompt never taught the hold token must not have output
+    // swallowed by it.
+    expect(classifyFrontDoorLeading("[0]", false)).toBe("answer");
+    expect(classifyFrontDoorLeading("[0", false)).toBe("answer");
+  });
+
+  test("escalate on the leading escalate token", () => {
+    expect(classifyFrontDoorLeading("[1]", false)).toBe("escalate");
+    expect(classifyFrontDoorLeading("[1] Let me check.", true)).toBe(
+      "escalate",
+    );
+  });
+
+  test("answer on anything else, including disproved bracket prefixes", () => {
+    expect(classifyFrontDoorLeading("Sure, it's Tuesday.", true)).toBe(
+      "answer",
+    );
+    // "[A…" can still be an ASK_GUARDIAN marker — the answer path's own
+    // marker holdback owns that; classification only guards verdicts.
+    expect(classifyFrontDoorLeading("[ASK_GUARDIAN: x]", true)).toBe("answer");
+    expect(classifyFrontDoorLeading("[2]", true)).toBe("answer");
   });
 });
 
@@ -181,15 +272,16 @@ describe("escalation continuation content", () => {
 });
 
 // This module is the surface-agnostic escalation *policy* (profiles, prompt
-// rules, the fallback-bridge decision, the flag gate). The two-leg *routing*
-// runs on the in-app Voice Mode surface (LiveVoiceSession), gated behind both
-// the voice-mode and voice-triage-escalate flags — see
+// rules, the verdict classifier, the bridge cap/fallback decision, the flag
+// gate). The two-leg *routing* runs on the in-app Voice Mode surface
+// (LiveVoiceSession), gated behind both the voice-mode and
+// voice-triage-escalate flags — see
 // live-voice/__tests__/live-voice-triage-escalate.test.ts for the orchestration
-// coverage (flag gating, front-door → escalated hand-off, marker suppression,
-// fallback bridge, barge-in). What remains for the manual cli-testing flow is
-// true end-to-end audio: real TTS timing across the bridge, and the residual
-// broadcast/persist raw-marker leak (issue #37850, shared by both voice
-// surfaces) once that is addressed.
+// coverage (flag gating, verdict-first hand-off, token suppression, fallback
+// bridge, barge-in). What remains for the manual cli-testing flow is true
+// end-to-end audio: real TTS timing across the bridge, and the residual
+// broadcast raw-token leak (issue #37850, shared by both voice surfaces) once
+// that is addressed.
 describe("live-voice escalation orchestration (end-to-end — TODO)", () => {
   test.todo(
     "an unpunctuated fallback bridge is force-flushed so the caller hears audio during the escalated model's call, not silence",

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -84,6 +84,13 @@ describe("front-door triage rule", () => {
   test("lists tool uncertainty as an escalate trigger (no fabrication)", () => {
     expect(rule.toLowerCase()).toContain("tool");
   });
+
+  test("demands a silent decision — no narrated reasoning in spoken output", () => {
+    // Regression: a weak front-door model narrated its triage deliberation
+    // aloud ("Context is complete — Alex paused...") before the bridge.
+    expect(rule.toLowerCase()).toContain("decide silently");
+    expect(rule.toLowerCase()).toContain("never narrate");
+  });
 });
 
 describe("escalated continuation rule", () => {

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -7,11 +7,13 @@ import { ESCALATE_MARKER } from "../voice-control-protocol.js";
 import {
   escalatedContinuationRule,
   ESCALATION_CONTINUATION_CONTENT,
+  FALLBACK_ESCALATION_BRIDGE,
   FRONT_DOOR_PROFILE,
   frontDoorCapabilityDigest,
   frontDoorTriageRule,
   isVoiceTriageEscalateEnabled,
   needsFallbackBridge,
+  spokenBridgeText,
   VOICE_TRIAGE_ESCALATE_FLAG,
 } from "../voice-triage-escalate.js";
 
@@ -104,6 +106,47 @@ describe("escalated continuation rule", () => {
   test("forbids the quality model from emitting [ESCALATE] again", () => {
     expect(rule).toContain(ESCALATE_MARKER);
     expect(rule.toLowerCase()).toContain("never emit");
+  });
+
+  test("quotes the actual spoken bridge verbatim when provided", () => {
+    const withBridge = escalatedContinuationRule("Let me check your calendar.");
+    expect(withBridge).toContain('"Let me check your calendar."');
+    expect(withBridge).not.toContain(FALLBACK_ESCALATION_BRIDGE);
+  });
+
+  test("quotes the canned fallback when no bridge (or a blank one) is provided", () => {
+    expect(rule).toContain(`"${FALLBACK_ESCALATION_BRIDGE}"`);
+    expect(escalatedContinuationRule("   ")).toContain(
+      `"${FALLBACK_ESCALATION_BRIDGE}"`,
+    );
+  });
+
+  test("bans re-announcing the holding phrase (bridge-echo regression)", () => {
+    // Regression: after the bridge "Let me check your calendar", the quality
+    // model opened with "Let me check what calendar connections…" — a
+    // re-announcement echo. The rule must ban paraphrase/re-announce openers,
+    // not just literal repetition.
+    expect(rule.toLowerCase()).toContain("re-announce");
+    expect(rule.toLowerCase()).toContain("paraphrase");
+    expect(rule).toContain('"Let me check"');
+  });
+});
+
+describe("spokenBridgeText", () => {
+  test("returns the cleaned pre-marker phrase only", () => {
+    expect(
+      spokenBridgeText(
+        "Let me check your calendar. [ESCALATE] weak answer that kept streaming",
+      ),
+    ).toBe("Let me check your calendar.");
+  });
+
+  test("is empty for a bare marker", () => {
+    expect(spokenBridgeText("[ESCALATE]")).toBe("");
+  });
+
+  test("without a marker, returns the whole cleaned text", () => {
+    expect(spokenBridgeText("  Hello there. ")).toBe("Hello there.");
   });
 });
 

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -75,11 +75,36 @@ describe("front-door decision rule", () => {
   const rule = frontDoorDecisionRule();
 
   test("demands a leading verdict and teaches the escalate token", () => {
-    expect(rule).toContain("DECIDE FIRST");
+    expect(rule).toContain("DECIDE SILENTLY");
     expect(rule).toContain(ESCALATE_VERDICT_TOKEN);
-    // The verdict must lead — never answer, then bail (spoken audio is final).
-    expect(rule.toLowerCase()).toContain("must begin with your verdict");
-    expect(rule.toLowerCase()).toContain("never start answering");
+    // The escalate token is never a prefix on an answer the model gives
+    // itself — regression: Haiku emitted "[1]" and then just answered,
+    // turning a chatty turn into a pointless escalation.
+    expect(rule.toLowerCase()).toContain("never put it in front of an answer");
+    expect(rule.toLowerCase()).toContain("no token in front of it");
+  });
+
+  test("biases toward answering when unsure (over-escalation regression)", () => {
+    expect(rule.toLowerCase()).toContain(
+      "when unsure between answering and escalating, answer",
+    );
+  });
+
+  test("an open task in history is not an escalation trigger", () => {
+    // Regression: with an unresolved task in conversation history, the
+    // front-door escalated pure small talk ("It's going fine.") with a
+    // bridge naming the stale task.
+    expect(rule.toLowerCase()).toContain("not a reason to escalate");
+    expect(rule.toLowerCase()).toContain("judge only what this reply needs");
+  });
+
+  test("without the hold branch, completeness is declared settled", () => {
+    // Regression: replay legs (no hold branch) improvised an escape hatch
+    // through the escalate token when a turn looked incomplete.
+    expect(rule.toLowerCase()).toContain("has finished their turn");
+    expect(
+      frontDoorDecisionRule({ includeHold: true }).toLowerCase(),
+    ).not.toContain("has finished their turn");
   });
 
   test("lists tool needs as an escalate trigger (no fabrication)", () => {
@@ -89,14 +114,14 @@ describe("front-door decision rule", () => {
   test("demands a silent decision — no narrated reasoning in spoken output", () => {
     // Regression: a weak front-door model narrated its triage deliberation
     // aloud ("Context is complete — Alex paused...") before the bridge.
-    expect(rule.toLowerCase()).toContain("chosen silently");
+    expect(rule.toLowerCase()).toContain("decide silently");
     expect(rule.toLowerCase()).toContain("never narrate");
   });
 
   test("bans verdict tokens anywhere but the leading position", () => {
     // Regression: a weak front-door model bled the bare hold digit into a
     // real answer ("hey 0"). Tokens are leading-verdict-only.
-    expect(rule.toLowerCase()).toContain("never inside or after an answer");
+    expect(rule.toLowerCase()).toContain("inside or after an answer");
   });
 
   test("includes the hold branch only when asked for", () => {

--- a/assistant/src/calls/voice-control-protocol.ts
+++ b/assistant/src/calls/voice-control-protocol.ts
@@ -15,13 +15,18 @@ export const CALL_VERIFICATION_COMPLETE_MARKER = "[CALL_VERIFICATION_COMPLETE]";
 export const END_CALL_MARKER = "[END_CALL]";
 
 /**
- * Emitted by the fast "front-door" model (triage-and-escalate voice routing)
- * when a turn is too tricky for it to answer well. The front-door model speaks
- * a brief holding phrase, appends this marker, and stops; the call controller
- * then re-runs the turn on the stronger "quality" profile. Like the other
- * markers, it is swallowed before reaching TTS — never spoken aloud.
+ * Verdict tokens for the fast "front-door" model (triage-and-escalate voice
+ * routing — see voice-triage-escalate.ts). The protocol is verdict-first:
+ * the leg's output must BEGIN with its verdict on the turn —
+ * {@link HOLD_VERDICT_TOKEN} (the caller is mid-thought; unified front-door
+ * only), {@link ESCALATE_VERDICT_TOKEN} followed by one short spoken holding
+ * phrase (the turn is handed to the stronger model), or neither, in which
+ * case the output IS the answer. Bracketed like every other control marker
+ * so the shared partial-marker holdback and stripping apply; like the other
+ * markers they are swallowed before reaching TTS — never spoken aloud.
  */
-export const ESCALATE_MARKER = "[ESCALATE]";
+export const HOLD_VERDICT_TOKEN = "[0]";
+export const ESCALATE_VERDICT_TOKEN = "[1]";
 
 // ---------------------------------------------------------------------------
 // Regexes
@@ -40,7 +45,8 @@ const USER_INSTRUCTION_MARKER_REGEX = /\[USER_INSTRUCTION:\s*.+?\]/g;
 const CALL_OPENING_MARKER_REGEX = /\[CALL_OPENING\]/g;
 const CALL_OPENING_ACK_MARKER_REGEX = /\[CALL_OPENING_ACK\]/g;
 const END_CALL_MARKER_REGEX = /\[END_CALL\]/g;
-const ESCALATE_MARKER_REGEX = /\[ESCALATE\]/g;
+const HOLD_VERDICT_TOKEN_REGEX = /\[0\]/g;
+const ESCALATE_VERDICT_TOKEN_REGEX = /\[1\]/g;
 const GUARDIAN_TIMEOUT_MARKER_REGEX = /\[GUARDIAN_TIMEOUT\]/g;
 const GUARDIAN_UNAVAILABLE_MARKER_REGEX = /\[GUARDIAN_UNAVAILABLE\]/g;
 
@@ -155,7 +161,8 @@ export function stripInternalSpeechMarkers(text: string): string {
     .replace(CALL_OPENING_MARKER_REGEX, "")
     .replace(CALL_OPENING_ACK_MARKER_REGEX, "")
     .replace(END_CALL_MARKER_REGEX, "")
-    .replace(ESCALATE_MARKER_REGEX, "")
+    .replace(HOLD_VERDICT_TOKEN_REGEX, "")
+    .replace(ESCALATE_VERDICT_TOKEN_REGEX, "")
     .replace(GUARDIAN_TIMEOUT_MARKER_REGEX, "")
     .replace(GUARDIAN_UNAVAILABLE_MARKER_REGEX, "");
   return result;
@@ -178,7 +185,8 @@ const CONTROL_MARKER_STRINGS = [
   "[CALL_OPENING]",
   "[CALL_OPENING_ACK]",
   "[END_CALL]",
-  "[ESCALATE]",
+  "[0]",
+  "[1]",
   "[GUARDIAN_TIMEOUT]",
   "[GUARDIAN_UNAVAILABLE]",
 ];

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -22,7 +22,10 @@ import { resolveChannelCapabilities } from "../daemon/conversation-runtime-assem
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
-import { recordConversationPersistedSeq } from "../persistence/conversation-crud.js";
+import {
+  deleteMessageById,
+  recordConversationPersistedSeq,
+} from "../persistence/conversation-crud.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
@@ -40,6 +43,7 @@ import {
   escalatedContinuationRule,
   ESCALATION_CONTINUATION_CONTENT,
   frontDoorCapabilityDigest,
+  frontDoorHoldRule,
   frontDoorTriageRule,
   type VoiceRoutingLeg,
 } from "./voice-triage-escalate.js";
@@ -288,6 +292,14 @@ export interface VoiceTurnOptions {
    */
   routingLeg?: VoiceRoutingLeg;
   /**
+   * Unified front-door: this leg was dispatched speculatively at a silence
+   * boundary, so its control prompt carries the hold-verdict rule (first
+   * token `0` = the caller is mid-thought). Only ever set on front-door
+   * legs — a leg that doesn't know the token can't accidentally speak it,
+   * and a leg that does must be one whose first token is interpreted.
+   */
+  unifiedVerdict?: boolean;
+  /**
    * Session-side dispatch timestamp (`Date.now()` at turn launch). When set,
    * the bridge's dispatch-timing log reports latency relative to it, so the
    * pre-bridge half (thinking frame, trust resolution) is attributable too.
@@ -300,6 +312,16 @@ export interface VoiceTurnHandle {
   turnId: string;
   /** Abort the in-flight turn (e.g. for barge-in). */
   abort: () => void;
+  /**
+   * Abort the turn AND roll back its persisted user message, restoring the
+   * conversation to its pre-turn state (delete row + reload in-memory
+   * history, then notify sync consumers). Used by the unified front-door
+   * hold verdict: a mid-thought pause must leave no trace of the fragment
+   * in history. Idempotent; safe to call after abort. Optional so that
+   * test doubles and future non-bridge starters aren't forced to model
+   * rollback — a missing discard degrades to abort-without-rollback.
+   */
+  discard?: () => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -564,7 +586,10 @@ export async function startVoiceTurn(
     voiceCallControlPrompt = opts.voiceControlPrompt;
     const routingLegRule =
       opts.routingLeg === "front-door"
-        ? frontDoorRuleWithDigest()
+        ? [
+            ...(opts.unifiedVerdict === true ? [frontDoorHoldRule()] : []),
+            frontDoorRuleWithDigest(),
+          ].join(" ")
         : opts.routingLeg === "escalated"
           ? escalatedContinuationRule()
           : null;
@@ -1183,8 +1208,31 @@ export async function startVoiceTurn(
     }
   }
 
+  let discarded = false;
+  const discardFn = async () => {
+    if (discarded) {
+      return;
+    }
+    discarded = true;
+    abortFn();
+    try {
+      // Same rollback pattern as the pointer-turn runner: delete the row,
+      // then rebuild in-memory history from the clean DB (a plain pop is
+      // fragile against concurrent compaction reassigning the array).
+      deleteMessageById(messageId);
+      await conversation.loadFromDb();
+      publishConversationMessagesChanged(opts.conversationId);
+    } catch (err) {
+      log.warn(
+        { err, turnId, messageId },
+        "Voice turn discard could not roll back the persisted user message",
+      );
+    }
+  };
+
   return {
     turnId,
     abort: abortFn,
+    discard: discardFn,
   };
 }

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -1295,7 +1295,12 @@ export async function startVoiceTurn(
           // Note: tool_use_preview_start is intentionally not handled here.
           // Voice only reacts to the definitive tool_use_start event.
         },
-        callSite: "callAgent",
+        // Front-door legs resolve through their own call site, whose shipped
+        // default pins the latency-class verdict model (see
+        // call-site-defaults.ts `voiceFrontDoor`); every other leg keeps the
+        // ordinary call-agent resolution.
+        callSite:
+          opts.routingLeg === "front-door" ? "voiceFrontDoor" : "callAgent",
         // The escalation-continuation prompt is a transcript-suppressed machine
         // signal (persisted `hidden`), so flag the turn to match — keeps
         // prompt-as-user-speech consumers (e.g. title generation) from treating

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -24,8 +24,11 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import {
   deleteMessageById,
+  getMessageById,
   recordConversationPersistedSeq,
+  updateMessageContent,
 } from "../persistence/conversation-crud.js";
+import type { ContentBlock } from "../providers/types.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
@@ -38,6 +41,8 @@ import { truncate } from "../util/truncate.js";
 import {
   CALL_OPENING_MARKER,
   CALL_VERIFICATION_COMPLETE_MARKER,
+  ESCALATE_MARKER,
+  stripInternalSpeechMarkers,
 } from "./voice-control-protocol.js";
 import {
   escalatedContinuationRule,
@@ -292,6 +297,14 @@ export interface VoiceTurnOptions {
    */
   routingLeg?: VoiceRoutingLeg;
   /**
+   * The holding phrase the caller actually heard before this leg started
+   * (the front-door leg's own pre-marker text, or the canned fallback).
+   * Quoted verbatim in the escalated continuation rule so the quality model
+   * knows the exact words already spoken and does not re-announce them.
+   * Only meaningful with `routingLeg: "escalated"`.
+   */
+  spokenEscalationBridge?: string;
+  /**
    * Unified front-door: this leg was dispatched speculatively at a silence
    * boundary, so its control prompt carries the hold-verdict rule (first
    * token `0` = the caller is mid-thought). Only ever set on front-door
@@ -315,8 +328,10 @@ export interface VoiceTurnHandle {
   /**
    * Abort the turn AND roll back its persisted user message, restoring the
    * conversation to its pre-turn state (delete row + reload in-memory
-   * history, then notify sync consumers). Used by the unified front-door
-   * hold verdict: a mid-thought pause must leave no trace of the fragment
+   * history, then notify sync consumers). The leg's reserved assistant row
+   * is removed too, by the teardown transcript-hygiene pass once the agent
+   * loop settles. Used by the unified front-door hold verdict: a
+   * mid-thought pause must leave no trace of the fragment
    * in history. Idempotent; safe to call after abort. Optional so that
    * test doubles and future non-bridge starters aren't forced to model
    * rollback — a missing discard degrades to abort-without-rollback.
@@ -352,6 +367,7 @@ function buildVoiceCallControlPrompt(opts: {
   isCallerGuardian?: boolean;
   skipDisclosure?: boolean;
   routingLeg?: VoiceRoutingLeg;
+  spokenEscalationBridge?: string;
 }): string {
   const config = getConfig();
   const disclosureEnabled =
@@ -445,12 +461,64 @@ function buildVoiceCallControlPrompt(opts: {
   if (opts.routingLeg === "front-door") {
     lines.push(`13. ${frontDoorRuleWithDigest()}`);
   } else if (opts.routingLeg === "escalated") {
-    lines.push(`13. ${escalatedContinuationRule()}`);
+    lines.push(`13. ${escalatedContinuationRule(opts.spokenEscalationBridge)}`);
   }
 
   lines.push("</voice_call_control>");
 
   return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Front-door transcript hygiene
+// ---------------------------------------------------------------------------
+
+/**
+ * Cut a front-door leg's persisted content at the `[ESCALATE]` marker.
+ *
+ * Returns null when no text block carries the marker (a committed front-door
+ * answer — nothing to do). Otherwise returns the blocks that were actually
+ * spoken — text before the marker with internal markers stripped, the marker
+ * and every later block dropped — plus the remaining spoken text so the
+ * caller can decide between rewriting the row and deleting it outright.
+ * Empty spoken text means the caller heard only the canned fallback bridge,
+ * which is audio-only and never a transcript row.
+ */
+export function cutFrontDoorContentAtMarker(
+  blocks: ContentBlock[],
+): { blocks: ContentBlock[]; spokenText: string } | null {
+  const markerBlockIdx = blocks.findIndex(
+    (block) => block.type === "text" && block.text.includes(ESCALATE_MARKER),
+  );
+  if (markerBlockIdx === -1) {
+    return null;
+  }
+  const kept: ContentBlock[] = [];
+  for (const block of blocks.slice(0, markerBlockIdx)) {
+    if (block.type === "text") {
+      const cleaned = stripInternalSpeechMarkers(block.text);
+      if (cleaned.trim().length > 0) {
+        kept.push({ ...block, text: cleaned });
+      }
+    } else {
+      kept.push(block);
+    }
+  }
+  const markerBlock = blocks[markerBlockIdx] as Extract<
+    ContentBlock,
+    { type: "text" }
+  >;
+  const preMarker = stripInternalSpeechMarkers(
+    markerBlock.text.slice(0, markerBlock.text.indexOf(ESCALATE_MARKER)),
+  );
+  if (preMarker.trim().length > 0) {
+    kept.push({ ...markerBlock, text: preMarker.trimEnd() });
+  }
+  const spokenText = kept
+    .map((block) => (block.type === "text" ? block.text : ""))
+    .join("")
+    .trim();
+  return { blocks: kept, spokenText };
 }
 
 // ---------------------------------------------------------------------------
@@ -576,6 +644,7 @@ export async function startVoiceTurn(
       isCallerGuardian,
       skipDisclosure: opts.skipDisclosure,
       routingLeg: opts.routingLeg,
+      spokenEscalationBridge: opts.spokenEscalationBridge,
     });
   } else {
     // A caller-supplied prompt (e.g. live-voice) bypasses
@@ -591,7 +660,7 @@ export async function startVoiceTurn(
             frontDoorRuleWithDigest(),
           ].join(" ")
         : opts.routingLeg === "escalated"
-          ? escalatedContinuationRule()
+          ? escalatedContinuationRule(opts.spokenEscalationBridge)
           : null;
     if (voiceCallControlPrompt != null && routingLegRule) {
       voiceCallControlPrompt = `${voiceCallControlPrompt}\n\n${routingLegRule}`;
@@ -1076,6 +1145,73 @@ export async function startVoiceTurn(
   // decrement in the IIFE's finally, even when runAgentLoop throws.
   let frontDoorToolsSuppressed = false;
 
+  // The reserved assistant row of the leg's LLM call, captured from
+  // `assistant_turn_start`. Voice legs are single-call in practice (the
+  // front-door leg is toolless), so the last id observed is the leg's
+  // transcript row — the target of the teardown transcript-hygiene pass.
+  let reservedAssistantRowId: string | null = null;
+  // Set by the handle's discard(): the whole leg must leave no trace.
+  let discarded = false;
+
+  /**
+   * Teardown transcript hygiene. Runs after the agent loop has fully
+   * settled — including the stranded-content fold that finalizes an aborted
+   * leg's row with its raw partial output — and before `settleTurnTeardown`
+   * releases the next leg:
+   *
+   * - A discarded leg (unified front-door hold verdict) deletes its
+   *   reserved assistant row: `discard` already rolled back the user row,
+   *   and without this the fold leaves a stray row holding the leg's
+   *   unspoken partial output (typically the bare hold token).
+   * - A front-door leg that escalated is cut at `[ESCALATE]` so only the
+   *   spoken bridge persists — never the marker or the discarded weak
+   *   answer streamed after it (issue #37850). A row with no spoken bridge
+   *   (canned-fallback case — that bridge is audio-only) is deleted.
+   *
+   * After a rewrite, in-memory history is reloaded from the clean DB before
+   * the escalated leg — blocked on this turn's teardown — snapshots it, so
+   * the quality model never sees the marker text either. Best-effort: a
+   * hiccup here must not escalate into a turn-level failure.
+   */
+  const finalizeVoiceLegTranscript = async (): Promise<void> => {
+    if (reservedAssistantRowId == null) {
+      return;
+    }
+    if (!discarded && opts.routingLeg !== "front-door") {
+      return;
+    }
+    try {
+      let changed = false;
+      if (discarded) {
+        deleteMessageById(reservedAssistantRowId);
+        changed = true;
+      } else {
+        const row = getMessageById(reservedAssistantRowId, opts.conversationId);
+        const cut = row ? cutFrontDoorContentAtMarker(row.content) : null;
+        if (cut) {
+          if (cut.spokenText.length > 0) {
+            updateMessageContent(
+              reservedAssistantRowId,
+              JSON.stringify(cut.blocks),
+            );
+          } else {
+            deleteMessageById(reservedAssistantRowId);
+          }
+          changed = true;
+        }
+      }
+      if (changed) {
+        await conversation.loadFromDb();
+        publishConversationMessagesChanged(opts.conversationId);
+      }
+    } catch (err) {
+      log.warn(
+        { err, turnId, messageId: reservedAssistantRowId },
+        "Voice leg transcript hygiene failed",
+      );
+    }
+  };
+
   // Fire-and-forget the agent loop
   void (async () => {
     const loopEnterAt = Date.now();
@@ -1114,7 +1250,9 @@ export async function startVoiceTurn(
       }
       await conversation.runAgentLoop(persistedContent, messageId, {
         onEvent: (msg: ServerMessage) => {
-          if (msg.type === "error") {
+          if (msg.type === "assistant_turn_start") {
+            reservedAssistantRowId = msg.messageId;
+          } else if (msg.type === "error") {
             lastError = msg.message;
           } else if (msg.type === "conversation_error") {
             lastError = msg.userMessage;
@@ -1182,6 +1320,7 @@ export async function startVoiceTurn(
         conversation.toolsDisabledDepth--;
       }
       cleanup();
+      await finalizeVoiceLegTranscript();
       settleTurnTeardown();
     }
   })();
@@ -1208,7 +1347,6 @@ export async function startVoiceTurn(
     }
   }
 
-  let discarded = false;
   const discardFn = async () => {
     if (discarded) {
       return;

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -28,6 +28,7 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
+import { getAllTools } from "../tools/registry.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
@@ -38,11 +39,28 @@ import {
 import {
   escalatedContinuationRule,
   ESCALATION_CONTINUATION_CONTENT,
+  frontDoorCapabilityDigest,
   frontDoorTriageRule,
   type VoiceRoutingLeg,
 } from "./voice-triage-escalate.js";
 
 const log = getLogger("voice-session-bridge");
+
+/**
+ * Front-door triage rule with the registry-derived capability digest. The
+ * front-door leg runs toolless (see the `toolsDisabledDepth` bracket in
+ * `startVoiceTurn`), so the digest is its only knowledge of what the
+ * escalated leg can do. Registry unavailability degrades to the bare rule.
+ */
+function frontDoorRuleWithDigest(): string {
+  let toolNames: string[] = [];
+  try {
+    toolNames = getAllTools().map((tool) => tool.name);
+  } catch {
+    // Tool registry not initialized (e.g. unit tests): digest-less rule.
+  }
+  return frontDoorTriageRule(frontDoorCapabilityDigest(toolNames));
+}
 
 /**
  * Exact message thrown when `opts.signal` aborts while the turn is waiting
@@ -403,7 +421,7 @@ function buildVoiceCallControlPrompt(opts: {
   // front-door leg triages and may hand off; the escalated leg continues the
   // answer after a holding phrase was already spoken.
   if (opts.routingLeg === "front-door") {
-    lines.push(`13. ${frontDoorTriageRule()}`);
+    lines.push(`13. ${frontDoorRuleWithDigest()}`);
   } else if (opts.routingLeg === "escalated") {
     lines.push(`13. ${escalatedContinuationRule()}`);
   }
@@ -546,7 +564,7 @@ export async function startVoiceTurn(
     voiceCallControlPrompt = opts.voiceControlPrompt;
     const routingLegRule =
       opts.routingLeg === "front-door"
-        ? frontDoorTriageRule()
+        ? frontDoorRuleWithDigest()
         : opts.routingLeg === "escalated"
           ? escalatedContinuationRule()
           : null;
@@ -1029,6 +1047,10 @@ export async function startVoiceTurn(
     resolveTeardown();
   };
 
+  // Pairs the front-door leg's toolsDisabledDepth increment with its
+  // decrement in the IIFE's finally, even when runAgentLoop throws.
+  let frontDoorToolsSuppressed = false;
+
   // Fire-and-forget the agent loop
   void (async () => {
     const loopEnterAt = Date.now();
@@ -1057,6 +1079,14 @@ export async function startVoiceTurn(
       // try/finally so a failed setup before this point cannot leak the
       // flag into subsequent non-voice turns on the same conversation.
       conversation.forcePromptSideEffects = !isGuardian;
+      // The front-door leg runs toolless: no schemas on the wire and the
+      // executor gate closed (same depth-counter bracket the pointer-turn
+      // runner uses). Anything needing a tool must escalate — the capability
+      // digest in its control prompt tells it what the escalated leg can do.
+      if (opts.routingLeg === "front-door") {
+        conversation.toolsDisabledDepth++;
+        frontDoorToolsSuppressed = true;
+      }
       await conversation.runAgentLoop(persistedContent, messageId, {
         onEvent: (msg: ServerMessage) => {
           if (msg.type === "error") {
@@ -1123,6 +1153,9 @@ export async function startVoiceTurn(
       log.error({ err, turnId }, "Voice turn failed");
       eventSink.onError(message);
     } finally {
+      if (frontDoorToolsSuppressed) {
+        conversation.toolsDisabledDepth--;
+      }
       cleanup();
       settleTurnTeardown();
     }

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -1182,16 +1182,26 @@ export async function startVoiceTurn(
    */
   const finalizeVoiceLegTranscript = async (): Promise<void> => {
     if (reservedAssistantRowId == null) {
+      if (discarded || opts.routingLeg === "front-door") {
+        // A leg the pass should cover never announced a reserved row: either
+        // the leg died before its LLM call, or `assistant_turn_start` did not
+        // reach this bridge — the latter would leave raw verdict tokens in
+        // the transcript, so make the skip loud.
+        log.warn(
+          { turnId, routingLeg: opts.routingLeg ?? null, discarded },
+          "Voice leg transcript hygiene skipped: no reserved row observed",
+        );
+      }
       return;
     }
     if (!discarded && opts.routingLeg !== "front-door") {
       return;
     }
     try {
-      let changed = false;
+      let action = "none";
       if (discarded) {
         deleteMessageById(reservedAssistantRowId);
-        changed = true;
+        action = "delete_discarded";
       } else {
         const row = getMessageById(reservedAssistantRowId, opts.conversationId);
         const cut = row ? cutFrontDoorContentAtVerdict(row.content) : null;
@@ -1201,13 +1211,26 @@ export async function startVoiceTurn(
               reservedAssistantRowId,
               JSON.stringify(cut.blocks),
             );
+            action = "rewrite_spoken";
           } else {
             deleteMessageById(reservedAssistantRowId);
+            action = "delete_empty";
           }
-          changed = true;
+        } else if (!row) {
+          action = "row_missing";
         }
       }
-      if (changed) {
+      log.info(
+        {
+          turnId,
+          messageId: reservedAssistantRowId,
+          routingLeg: opts.routingLeg ?? null,
+          discarded,
+          action,
+        },
+        "Voice leg transcript hygiene",
+      );
+      if (action !== "none" && action !== "row_missing") {
         await conversation.loadFromDb();
         publishConversationMessagesChanged(opts.conversationId);
       }

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -269,6 +269,12 @@ export interface VoiceTurnOptions {
    * supplies its own `voiceControlPrompt`.
    */
   routingLeg?: VoiceRoutingLeg;
+  /**
+   * Session-side dispatch timestamp (`Date.now()` at turn launch). When set,
+   * the bridge's dispatch-timing log reports latency relative to it, so the
+   * pre-bridge half (thinking frame, trust resolution) is attributable too.
+   */
+  launchedAtMs?: number;
 }
 
 export interface VoiceTurnHandle {
@@ -425,6 +431,15 @@ function buildVoiceCallControlPrompt(opts: {
 export async function startVoiceTurn(
   opts: VoiceTurnOptions,
 ): Promise<VoiceTurnHandle> {
+  // Dispatch-latency stamps for the pre-loop half of a voice turn, logged
+  // once at agent-loop entry so live sessions expose where pre-model time
+  // goes (conversation resolve vs admission waits vs persist).
+  const dispatch = {
+    enteredAt: Date.now(),
+    conversationReadyAt: 0,
+    admissionClearAt: 0,
+    persistDoneAt: 0,
+  };
   const eventSink: VoiceRunEventSink = {
     onTextDelta: (msg) => {
       opts.onTextDelta?.(msg.text);
@@ -542,6 +557,7 @@ export async function startVoiceTurn(
 
   // Get or create the conversation
   const conversation = await getOrCreateConversation(opts.conversationId);
+  dispatch.conversationReadyAt = Date.now();
 
   const config = getConfig();
   const maxWaitMs = resolveProcessingWaitMs(
@@ -629,6 +645,7 @@ export async function startVoiceTurn(
     }
     break;
   }
+  dispatch.admissionClearAt = Date.now();
 
   // Releases the per-turn state of a voice turn that OWNED the conversation,
   // so `trustContext`, `callSessionId`, etc. don't leak into subsequent
@@ -851,6 +868,7 @@ export async function startVoiceTurn(
       throw retryErr;
     }
   }
+  dispatch.persistDoneAt = Date.now();
   try {
     opts.callbacks?.persisted_user_message_id?.(messageId);
   } catch (err) {
@@ -1013,6 +1031,23 @@ export async function startVoiceTurn(
 
   // Fire-and-forget the agent loop
   void (async () => {
+    const loopEnterAt = Date.now();
+    log.info(
+      {
+        turnId,
+        conversationId: opts.conversationId,
+        routingLeg: opts.routingLeg ?? null,
+        sinceLaunchMs:
+          opts.launchedAtMs != null ? loopEnterAt - opts.launchedAtMs : null,
+        bridgeMs: loopEnterAt - dispatch.enteredAt,
+        conversationMs: dispatch.conversationReadyAt - dispatch.enteredAt,
+        admissionWaitMs:
+          dispatch.admissionClearAt - dispatch.conversationReadyAt,
+        persistMs: dispatch.persistDoneAt - dispatch.admissionClearAt,
+        preLoopMs: loopEnterAt - dispatch.persistDoneAt,
+      },
+      "Voice turn dispatch timing",
+    );
     try {
       // Non-guardian voice callers force side-effect tools to prompt so the
       // auto-deny handler above reliably sees a confirmation_request. Without

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -41,34 +41,40 @@ import { truncate } from "../util/truncate.js";
 import {
   CALL_OPENING_MARKER,
   CALL_VERIFICATION_COMPLETE_MARKER,
-  ESCALATE_MARKER,
+  ESCALATE_VERDICT_TOKEN,
+  HOLD_VERDICT_TOKEN,
   stripInternalSpeechMarkers,
 } from "./voice-control-protocol.js";
 import {
   escalatedContinuationRule,
   ESCALATION_CONTINUATION_CONTENT,
   frontDoorCapabilityDigest,
-  frontDoorHoldRule,
-  frontDoorTriageRule,
+  frontDoorDecisionRule,
+  spokenBridgeText,
   type VoiceRoutingLeg,
 } from "./voice-triage-escalate.js";
 
 const log = getLogger("voice-session-bridge");
 
 /**
- * Front-door triage rule with the registry-derived capability digest. The
+ * Front-door decision rule with the registry-derived capability digest. The
  * front-door leg runs toolless (see the `toolsDisabledDepth` bracket in
  * `startVoiceTurn`), so the digest is its only knowledge of what the
  * escalated leg can do. Registry unavailability degrades to the bare rule.
+ * `includeHold` adds the mid-thought verdict branch (unified front-door
+ * speculative legs only).
  */
-function frontDoorRuleWithDigest(): string {
+function frontDoorRuleWithDigest(includeHold: boolean): string {
   let toolNames: string[] = [];
   try {
     toolNames = getAllTools().map((tool) => tool.name);
   } catch {
     // Tool registry not initialized (e.g. unit tests): digest-less rule.
   }
-  return frontDoorTriageRule(frontDoorCapabilityDigest(toolNames));
+  return frontDoorDecisionRule({
+    includeHold,
+    capabilityDigest: frontDoorCapabilityDigest(toolNames),
+  });
 }
 
 /**
@@ -306,10 +312,10 @@ export interface VoiceTurnOptions {
   spokenEscalationBridge?: string;
   /**
    * Unified front-door: this leg was dispatched speculatively at a silence
-   * boundary, so its control prompt carries the hold-verdict rule (first
-   * token `0` = the caller is mid-thought). Only ever set on front-door
-   * legs — a leg that doesn't know the token can't accidentally speak it,
-   * and a leg that does must be one whose first token is interpreted.
+   * boundary, so its decision rule includes the hold branch (leading token
+   * `[0]` = the caller is mid-thought). Only ever set on front-door legs —
+   * a leg that doesn't know the hold token can't accidentally emit it, and
+   * a leg that does must be one whose leading tokens are interpreted.
    */
   unifiedVerdict?: boolean;
   /**
@@ -368,6 +374,7 @@ function buildVoiceCallControlPrompt(opts: {
   skipDisclosure?: boolean;
   routingLeg?: VoiceRoutingLeg;
   spokenEscalationBridge?: string;
+  unifiedVerdict?: boolean;
 }): string {
   const config = getConfig();
   const disclosureEnabled =
@@ -456,10 +463,10 @@ function buildVoiceCallControlPrompt(opts: {
   );
 
   // Triage-and-escalate routing rules (voice-triage-escalate flag). The
-  // front-door leg triages and may hand off; the escalated leg continues the
+  // front-door leg decides and may hand off; the escalated leg continues the
   // answer after a holding phrase was already spoken.
   if (opts.routingLeg === "front-door") {
-    lines.push(`13. ${frontDoorRuleWithDigest()}`);
+    lines.push(`13. ${frontDoorRuleWithDigest(opts.unifiedVerdict === true)}`);
   } else if (opts.routingLeg === "escalated") {
     lines.push(`13. ${escalatedContinuationRule(opts.spokenEscalationBridge)}`);
   }
@@ -474,45 +481,47 @@ function buildVoiceCallControlPrompt(opts: {
 // ---------------------------------------------------------------------------
 
 /**
- * Cut a front-door leg's persisted content at the `[ESCALATE]` marker.
+ * Reduce a front-door leg's persisted content to what was actually spoken
+ * under the verdict-first protocol.
  *
- * Returns null when no text block carries the marker (a committed front-door
- * answer — nothing to do). Otherwise returns the blocks that were actually
- * spoken — text before the marker with internal markers stripped, the marker
- * and every later block dropped — plus the remaining spoken text so the
- * caller can decide between rewriting the row and deleting it outright.
- * Empty spoken text means the caller heard only the canned fallback bridge,
- * which is audio-only and never a transcript row.
+ * Returns null when the content carries no verdict token (a committed
+ * front-door answer — nothing to do). A leg that led with
+ * `ESCALATE_VERDICT_TOKEN` reduces to a single text block holding the
+ * capped bridge; empty spoken text means the caller heard only the canned
+ * fallback bridge, which is audio-only and never a transcript row, so the
+ * caller should delete the row. Stray verdict tokens elsewhere in an
+ * answer were never spoken (the live gate strips them) and are stripped
+ * from the persisted text to match.
  */
-export function cutFrontDoorContentAtMarker(
+export function cutFrontDoorContentAtVerdict(
   blocks: ContentBlock[],
 ): { blocks: ContentBlock[]; spokenText: string } | null {
-  const markerBlockIdx = blocks.findIndex(
-    (block) => block.type === "text" && block.text.includes(ESCALATE_MARKER),
-  );
-  if (markerBlockIdx === -1) {
+  const joinedText = blocks
+    .map((block) => (block.type === "text" ? block.text : ""))
+    .join("");
+  if (joinedText.trimStart().startsWith(ESCALATE_VERDICT_TOKEN)) {
+    const spokenText = spokenBridgeText(joinedText);
+    return {
+      blocks: spokenText.length > 0 ? [{ type: "text", text: spokenText }] : [],
+      spokenText,
+    };
+  }
+  if (
+    !joinedText.includes(ESCALATE_VERDICT_TOKEN) &&
+    !joinedText.includes(HOLD_VERDICT_TOKEN)
+  ) {
     return null;
   }
   const kept: ContentBlock[] = [];
-  for (const block of blocks.slice(0, markerBlockIdx)) {
-    if (block.type === "text") {
-      const cleaned = stripInternalSpeechMarkers(block.text);
-      if (cleaned.trim().length > 0) {
-        kept.push({ ...block, text: cleaned });
-      }
-    } else {
+  for (const block of blocks) {
+    if (block.type !== "text") {
       kept.push(block);
+      continue;
     }
-  }
-  const markerBlock = blocks[markerBlockIdx] as Extract<
-    ContentBlock,
-    { type: "text" }
-  >;
-  const preMarker = stripInternalSpeechMarkers(
-    markerBlock.text.slice(0, markerBlock.text.indexOf(ESCALATE_MARKER)),
-  );
-  if (preMarker.trim().length > 0) {
-    kept.push({ ...markerBlock, text: preMarker.trimEnd() });
+    const cleaned = stripInternalSpeechMarkers(block.text);
+    if (cleaned.trim().length > 0) {
+      kept.push({ ...block, text: cleaned });
+    }
   }
   const spokenText = kept
     .map((block) => (block.type === "text" ? block.text : ""))
@@ -645,20 +654,18 @@ export async function startVoiceTurn(
       skipDisclosure: opts.skipDisclosure,
       routingLeg: opts.routingLeg,
       spokenEscalationBridge: opts.spokenEscalationBridge,
+      unifiedVerdict: opts.unifiedVerdict,
     });
   } else {
     // A caller-supplied prompt (e.g. live-voice) bypasses
     // buildVoiceCallControlPrompt, which is where the triage-and-escalate rule
     // is normally injected from `routingLeg`. Append it here too — without it
-    // the front-door leg would run on the fast profile but never be told to
-    // emit [ESCALATE], so it could not hand off to the escalated leg.
+    // the front-door leg would run on the fast profile but never learn the
+    // verdict protocol, so it could not hold or hand off to the escalated leg.
     voiceCallControlPrompt = opts.voiceControlPrompt;
     const routingLegRule =
       opts.routingLeg === "front-door"
-        ? [
-            ...(opts.unifiedVerdict === true ? [frontDoorHoldRule()] : []),
-            frontDoorRuleWithDigest(),
-          ].join(" ")
+        ? frontDoorRuleWithDigest(opts.unifiedVerdict === true)
         : opts.routingLeg === "escalated"
           ? escalatedContinuationRule(opts.spokenEscalationBridge)
           : null;
@@ -1163,10 +1170,10 @@ export async function startVoiceTurn(
    *   reserved assistant row: `discard` already rolled back the user row,
    *   and without this the fold leaves a stray row holding the leg's
    *   unspoken partial output (typically the bare hold token).
-   * - A front-door leg that escalated is cut at `[ESCALATE]` so only the
-   *   spoken bridge persists — never the marker or the discarded weak
-   *   answer streamed after it (issue #37850). A row with no spoken bridge
-   *   (canned-fallback case — that bridge is audio-only) is deleted.
+   * - A front-door leg that escalated reduces to its capped spoken bridge —
+   *   never the verdict token or the text streamed past the cap (issue
+   *   #37850). A row with no spoken bridge (canned-fallback case — that
+   *   bridge is audio-only) is deleted.
    *
    * After a rewrite, in-memory history is reloaded from the clean DB before
    * the escalated leg — blocked on this turn's teardown — snapshots it, so
@@ -1187,7 +1194,7 @@ export async function startVoiceTurn(
         changed = true;
       } else {
         const row = getMessageById(reservedAssistantRowId, opts.conversationId);
-        const cut = row ? cutFrontDoorContentAtMarker(row.content) : null;
+        const cut = row ? cutFrontDoorContentAtVerdict(row.content) : null;
         if (cut) {
           if (cut.spokenText.length > 0) {
             updateMessageContent(

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -5,9 +5,10 @@
  * turns outright (low first-token latency -> the caller hears audio fast).
  * When a turn is too tricky, the front-door model speaks a brief natural
  * holding phrase, appends the `[ESCALATE]` marker, and stops. The call
- * controller then re-runs the same turn on the stronger "quality" model, whose
- * answer streams into the same TTS pipe. Because the holding phrase is spoken,
- * the caller never hears the quality model's think-time as silence.
+ * controller then re-runs the same turn on the call-site default profile —
+ * the model an un-routed voice turn would have used — whose answer streams
+ * into the same TTS pipe. Because the holding phrase is spoken, the caller
+ * never hears the stronger model's think-time as silence.
  *
  * This module owns the routing policy in one place: the feature gate, the two
  * profile keys, the leg-specific prompt fragments, and the fallback bridge.
@@ -34,8 +35,11 @@ export const VOICE_TRIAGE_ESCALATE_FLAG = "voice-triage-escalate";
 /** Fast/weak profile that fronts every turn when the flag is on. */
 export const FRONT_DOOR_PROFILE: DefaultProfileKey = "cost-optimized";
 
-/** Strong/quality profile a tricky turn escalates to. */
-export const ESCALATION_PROFILE: DefaultProfileKey = "quality-optimized";
+// The escalated leg deliberately carries NO profile override: it runs on the
+// call-site default, i.e. exactly the profile an un-routed voice turn would
+// use (balanced for a fresh workspace, or whatever the user pinned). That
+// guarantees an escalated answer is never weaker OR stronger than the
+// pre-routing behavior, and honors per-user profile choices.
 
 /**
  * Which leg of a triaged turn a `startVoiceTurn` call represents. Undefined
@@ -103,21 +107,43 @@ export function isVoiceTriageEscalateEnabled(
 }
 
 /**
+ * Compact, registry-derived digest of the tools the ESCALATED leg can use.
+ * The front-door leg runs toolless, so without this it has no way to know
+ * what the assistant can actually do — and its failure mode is refusing or
+ * fabricating instead of escalating. The digest teaches routing (and lets
+ * the holding phrase name the action) without carrying executable schemas.
+ * Empty input (registry unavailable) yields an empty digest; the triage
+ * rule still works, it just can't enumerate capabilities.
+ */
+export function frontDoorCapabilityDigest(toolNames: string[]): string {
+  if (toolNames.length === 0) {
+    return "";
+  }
+  return [
+    "You have no tools on this leg, but the stronger model you can escalate to has these:",
+    `${toolNames.join(", ")}.`,
+    "Any request that needs one of them must escalate — name the action in your holding phrase",
+    '(for example "Let me check your calendar") instead of refusing or guessing.',
+  ].join(" ");
+}
+
+/**
  * Extra CALL PROTOCOL RULE injected into the front-door leg's control prompt.
  * The decision must happen up front: the model triages BEFORE it starts
  * answering so it never speaks half an answer and then bails — spoken audio
  * cannot be un-said. Escalation triggers include anything needing careful
- * reasoning, research, or a tool it is unsure of, so the weak model never
- * fabricates an answer that actually required a tool.
+ * reasoning, research, or any tool at all (this leg carries no tool schemas),
+ * so the weak model never fabricates an answer that actually required a tool.
  */
-export function frontDoorTriageRule(): string {
-  return [
+export function frontDoorTriageRule(capabilityDigest = ""): string {
+  const rule = [
     "TRIAGE FIRST: Before you begin answering, judge whether this turn is within your reach.",
     "If it is simple, conversational, or clearly factual, just answer it normally.",
-    "If it needs careful reasoning, research, multi-step work, or a tool you are unsure how to use,",
+    "If it needs careful reasoning, research, multi-step work, or any tool,",
     `do NOT attempt the answer. Instead say one short, natural holding phrase out loud (for example "${FALLBACK_ESCALATION_BRIDGE}" or "Give me one second to look into that"), then append ${ESCALATE_MARKER} and stop.`,
     `Make this decision in your first words. Never start answering and then emit ${ESCALATE_MARKER}. Everything you say before ${ESCALATE_MARKER} is spoken to the caller; everything after it is discarded.`,
   ].join(" ");
+  return capabilityDigest ? `${rule} ${capabilityDigest}` : rule;
 }
 
 /**

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -1,23 +1,29 @@
 /**
- * Triage-and-escalate voice routing (weak -> strong model) — Phase 1.
+ * Triage-and-escalate voice routing (weak -> strong model).
  *
- * A fast "front-door" model fronts every phone-call turn. It answers simple
- * turns outright (low first-token latency -> the caller hears audio fast).
- * When a turn is too tricky, the front-door model speaks a brief natural
- * holding phrase, appends the `[ESCALATE]` marker, and stops. The call
- * controller then re-runs the same turn on the call-site default profile —
- * the model an un-routed voice turn would have used — whose answer streams
- * into the same TTS pipe. Because the holding phrase is spoken, the caller
- * never hears the stronger model's think-time as silence.
+ * A fast "front-door" model fronts every voice turn under a verdict-first
+ * protocol: its output must BEGIN with its verdict on the turn.
  *
- * This module owns the routing policy in one place: the feature gate, the two
- * profile keys, the leg-specific prompt fragments, and the fallback bridge.
+ *   - `[0]` ({@link HOLD_VERDICT_TOKEN}, unified front-door only): the
+ *     caller is mid-thought — the leg is discarded and listening continues.
+ *   - `[1]` ({@link ESCALATE_VERDICT_TOKEN}) followed by ONE short natural
+ *     holding phrase: the turn is too tricky — the phrase is spoken (capped
+ *     at a single sentence) while the turn re-runs on the call-site default
+ *     profile, the model an un-routed voice turn would have used. Because
+ *     the holding phrase is spoken, the caller never hears the stronger
+ *     model's think-time as silence.
+ *   - Anything else: the output IS the answer, streamed straight to TTS
+ *     (low first-token latency -> the caller hears audio fast).
  *
- * Phase 2/3 (not implemented here): fire the quality model the instant the
- * marker is detected so its prefill overlaps the spoken bridge; model-generated
- * (rather than canned) fallback bridges; a triage-threshold eval harness; and
- * extending the orchestration to in-app live voice (`live-voice/`), which drives
- * `startVoiceTurn` through its own session rather than the call controller.
+ * Leading with the verdict keeps the wire protocol aligned with the
+ * decision the prompt demands the model make in its first words, and bounds
+ * the escalation hand-off: the bridge is capped session-side instead of
+ * trusting the model to stop. Every infra failure fails open to a normal
+ * committed answer turn.
+ *
+ * This module owns the routing policy in one place: the feature gates, the
+ * profile key, the leg-specific prompt rules, the leading-token classifier,
+ * and the bridge cap/fallback policy.
  */
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
@@ -25,9 +31,12 @@ import type { DefaultProfileKey } from "../config/default-profile-names.js";
 import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
 import {
-  ESCALATE_MARKER,
+  ESCALATE_VERDICT_TOKEN,
+  HOLD_VERDICT_TOKEN,
   stripInternalSpeechMarkers,
 } from "./voice-control-protocol.js";
+
+export { ESCALATE_VERDICT_TOKEN, HOLD_VERDICT_TOKEN };
 
 /** Feature-flag key gating the whole behavior. Off by default. */
 export const VOICE_TRIAGE_ESCALATE_FLAG = "voice-triage-escalate";
@@ -35,21 +44,13 @@ export const VOICE_TRIAGE_ESCALATE_FLAG = "voice-triage-escalate";
 /**
  * Feature-flag key for the unified front-door (requires the triage flag
  * too): live-voice endpointing merges into the front-door leg. At each
- * pause the leg is dispatched speculatively and its first token carries the
- * verdict — {@link HOLD_VERDICT_TOKEN} (mid-thought, keep listening),
- * `[ESCALATE]` after a bridge, or the answer itself. Replaces the separate
- * endpoint-decider call on that path. Off by default.
+ * pause the leg is dispatched speculatively and its leading tokens carry
+ * the full verdict — {@link HOLD_VERDICT_TOKEN} (mid-thought, keep
+ * listening), {@link ESCALATE_VERDICT_TOKEN} plus a spoken bridge, or the
+ * answer itself. Replaces the separate endpoint-decider call on that path.
+ * Off by default.
  */
 export const VOICE_UNIFIED_FRONT_DOOR_FLAG = "voice-unified-front-door";
-
-/**
- * The hold verdict: the front-door leg outputs exactly this single
- * character when the caller is mid-thought. Mirrors the endpoint decider's
- * bare-token protocol ("0" = hold), so the tie-break asymmetry carries
- * over: the model is told to hold when unsure, while every infra failure
- * on the leg fails open to a normal released turn.
- */
-export const HOLD_VERDICT_TOKEN = "0";
 
 /**
  * Whether the unified front-door (endpointing merged into the front-door
@@ -59,22 +60,6 @@ export function isVoiceUnifiedFrontDoorEnabled(
   config: AssistantConfig = getConfig(),
 ): boolean {
   return isAssistantFeatureFlagEnabled(VOICE_UNIFIED_FRONT_DOOR_FLAG, config);
-}
-
-/**
- * Extra CALL PROTOCOL RULE for the unified front-door leg: the hold check
- * runs before triage. The digit must be the leg's entire output — anything
- * else is treated as a committed turn, so the rule also bans starting a
- * real answer with it.
- */
-export function frontDoorHoldRule(): string {
-  return [
-    "HOLD CHECK: Before anything else, silently judge whether the caller has finished their thought.",
-    "If the transcript ends mid-thought (a trailing conjunction, an unfinished clause, a list still being dictated),",
-    `output ONLY the single character ${HOLD_VERDICT_TOKEN} and stop — no punctuation, no other words.`,
-    `The digit ${HOLD_VERDICT_TOKEN} is a control token, never spoken text: when you DO answer, it must not appear anywhere in your output — not at the start, not appended at the end.`,
-    "If the caller is done, ignore this rule and proceed.",
-  ].join(" ");
 }
 
 /** Fast/weak profile that fronts every turn when the flag is on. */
@@ -93,45 +78,130 @@ export const FRONT_DOOR_PROFILE: DefaultProfileKey = "cost-optimized";
 export type VoiceRoutingLeg = "front-door" | "escalated";
 
 /**
- * Spoken when the front-door model emits `[ESCALATE]` without a meaningful
- * holding phrase of its own — guarantees the caller never hears dead air
- * across the hand-off. When the model does speak its own bridge, that natural
- * text is used instead and this is not injected.
+ * Spoken when the front-door model escalates without a meaningful holding
+ * phrase of its own — guarantees the caller never hears dead air across the
+ * hand-off. When the model does speak its own bridge, that natural text is
+ * used instead and this is not injected.
  */
 export const FALLBACK_ESCALATION_BRIDGE =
   "Let me think about that for a second.";
 
 /**
- * Minimum length (after marker stripping, trimmed) of the front-door leg's
- * spoken text for it to count as a real bridge. Below this, the fallback
- * bridge is injected before the quality leg runs.
+ * Minimum length (after capping, trimmed) of the front-door leg's spoken
+ * bridge for it to count as a real bridge. Below this, the fallback bridge
+ * is spoken before the quality leg runs.
  */
 export const MIN_SPOKEN_BRIDGE_CHARS = 3;
 
 /**
- * The holding phrase the caller actually heard from the front-door leg:
- * everything BEFORE `[ESCALATE]` with internal markers stripped, trimmed.
- * Post-marker text is suppressed from TTS, so it never counts. Empty when
- * the leg escalated bare — the canned {@link FALLBACK_ESCALATION_BRIDGE}
- * is spoken instead in that case.
+ * Hard cap on the spoken escalation bridge. The bridge is supposed to be a
+ * single short sentence; the cap bounds the hand-off delay (and the audio)
+ * when a model rambles instead of stopping.
+ */
+export const MAX_ESCALATION_BRIDGE_CHARS = 140;
+
+/** Sentence terminators that end an escalation bridge. */
+const BRIDGE_SENTENCE_END_REGEX = /[.!?…]/;
+
+/**
+ * Normalize a raw post-`[1]` stream into the bridge that is actually
+ * spoken: internal markers stripped, cut just after the first sentence
+ * terminator, hard-capped at {@link MAX_ESCALATION_BRIDGE_CHARS}, trimmed.
+ * The session speaks exactly this, the persisted front-door row keeps
+ * exactly this, and the escalated leg is told exactly this — one function
+ * so the three can never drift.
+ */
+export function capEscalationBridge(rawBridge: string): string {
+  const cleaned = stripInternalSpeechMarkers(rawBridge).trimStart();
+  const terminatorMatch = BRIDGE_SENTENCE_END_REGEX.exec(cleaned);
+  const end =
+    terminatorMatch !== null
+      ? Math.min(terminatorMatch.index + 1, MAX_ESCALATION_BRIDGE_CHARS)
+      : MAX_ESCALATION_BRIDGE_CHARS;
+  return cleaned.slice(0, end).trim();
+}
+
+/**
+ * Whether enough of the post-`[1]` stream has arrived to finalize the
+ * bridge and hand off: a sentence terminator landed, or the hard cap is
+ * reached. Until then the session keeps buffering (the bridge is spoken in
+ * one piece at hand-off, so what is spoken is exactly the capped bridge).
+ */
+export function isEscalationBridgeComplete(rawBridge: string): boolean {
+  const cleaned = stripInternalSpeechMarkers(rawBridge);
+  return (
+    BRIDGE_SENTENCE_END_REGEX.test(cleaned) ||
+    cleaned.trimStart().length >= MAX_ESCALATION_BRIDGE_CHARS
+  );
+}
+
+/**
+ * The spoken bridge of a front-door leg's FULL raw output: empty unless the
+ * output leads with {@link ESCALATE_VERDICT_TOKEN} (a stray token later in
+ * an answer is not an escalation under the verdict-first protocol), else
+ * the capped bridge that followed the token. Used by transcript hygiene to
+ * reconstruct what the caller heard from a persisted row.
  */
 export function spokenBridgeText(frontDoorText: string): string {
-  const markerIdx = frontDoorText.indexOf(ESCALATE_MARKER);
-  return stripInternalSpeechMarkers(
-    markerIdx === -1 ? frontDoorText : frontDoorText.slice(0, markerIdx),
-  ).trim();
+  const leading = frontDoorText.trimStart();
+  if (!leading.startsWith(ESCALATE_VERDICT_TOKEN)) {
+    return "";
+  }
+  return capEscalationBridge(leading.slice(ESCALATE_VERDICT_TOKEN.length));
 }
 
 /**
  * Whether a canned fallback bridge must be spoken before the escalated leg,
- * given the front-door leg's full response text.
- *
- * Decided on the spoken slice only (see {@link spokenBridgeText}): without
- * this, a bare `[ESCALATE]` followed by ignored weak text would skip the
- * fallback and leave the caller in silence while the quality leg spins up.
+ * given the front-door leg's full raw output. True when the model escalated
+ * with (nearly) no holding phrase of its own — without the fallback the
+ * caller would sit in silence while the quality leg spins up.
  */
 export function needsFallbackBridge(frontDoorText: string): boolean {
   return spokenBridgeText(frontDoorText).length < MIN_SPOKEN_BRIDGE_CHARS;
+}
+
+/**
+ * Classification of a front-door leg's accumulated leading output (already
+ * `trimStart()`ed). `pending` means the stream could still become a verdict
+ * token — keep buffering; everything else is final for the leg.
+ */
+export type FrontDoorLeadingVerdict =
+  | "pending"
+  | "hold"
+  | "escalate"
+  | "answer";
+
+/**
+ * Classify the leading output of a front-door leg under the verdict-first
+ * protocol. `holdEnabled` is true only for speculative (unified
+ * front-door) legs — a leg whose prompt never taught the hold token must
+ * not have output swallowed by it.
+ *
+ * A leading partial that could still become an enabled verdict token
+ * (e.g. `[`, `[1`) stays `pending`; a `[`-prefix that disproves both
+ * tokens (e.g. `[A` for an ASK_GUARDIAN marker) classifies as `answer` —
+ * the answer path's own marker holdback handles it from there.
+ */
+export function classifyFrontDoorLeading(
+  leading: string,
+  holdEnabled: boolean,
+): FrontDoorLeadingVerdict {
+  if (leading.length === 0) {
+    return "pending";
+  }
+  if (holdEnabled && leading.startsWith(HOLD_VERDICT_TOKEN)) {
+    return "hold";
+  }
+  if (leading.startsWith(ESCALATE_VERDICT_TOKEN)) {
+    return "escalate";
+  }
+  const candidates = holdEnabled
+    ? [HOLD_VERDICT_TOKEN, ESCALATE_VERDICT_TOKEN]
+    : [ESCALATE_VERDICT_TOKEN];
+  if (candidates.some((token) => token.startsWith(leading))) {
+    return "pending";
+  }
+  return "answer";
 }
 
 /**
@@ -141,9 +211,6 @@ export function needsFallbackBridge(frontDoorText: string): boolean {
  * prompt — the same pattern the opener/verification synthetic prompts use. The
  * quality model answers the caller's previous question, which sits in history
  * just above it.
- *
- * Phase 2 could collapse the two legs into a single persisted turn; Phase 1
- * keeps each leg a normal, independently-understood `startVoiceTurn`.
  */
 export const ESCALATION_CONTINUATION_CONTENT =
   "(You just told the caller you needed a moment to think. Now give them your full, careful answer to their previous question — do not repeat the holding phrase.)";
@@ -164,7 +231,7 @@ export function isVoiceTriageEscalateEnabled(
  * what the assistant can actually do — and its failure mode is refusing or
  * fabricating instead of escalating. The digest teaches routing (and lets
  * the holding phrase name the action) without carrying executable schemas.
- * Empty input (registry unavailable) yields an empty digest; the triage
+ * Empty input (registry unavailable) yields an empty digest; the decision
  * rule still works, it just can't enumerate capabilities.
  */
 export function frontDoorCapabilityDigest(toolNames: string[]): string {
@@ -180,23 +247,33 @@ export function frontDoorCapabilityDigest(toolNames: string[]): string {
 }
 
 /**
- * Extra CALL PROTOCOL RULE injected into the front-door leg's control prompt.
- * The decision must happen up front: the model triages BEFORE it starts
- * answering so it never speaks half an answer and then bails — spoken audio
- * cannot be un-said. Escalation triggers include anything needing careful
- * reasoning, research, or any tool at all (this leg carries no tool schemas),
- * so the weak model never fabricates an answer that actually required a tool.
+ * The front-door leg's single decision rule: one decision tree, decided
+ * silently, delivered as the leg's leading tokens. `includeHold` adds the
+ * mid-thought branch and is set only on speculative (unified front-door)
+ * legs — a leg that doesn't know the hold token can't accidentally emit
+ * it, and a leg that does must be one whose leading tokens are
+ * interpreted. The verdict must lead: spoken audio cannot be un-said, so
+ * the model must never start answering and then try to bail.
  */
-export function frontDoorTriageRule(capabilityDigest = ""): string {
+export function frontDoorDecisionRule(opts?: {
+  includeHold?: boolean;
+  capabilityDigest?: string;
+}): string {
+  const holdBranch =
+    opts?.includeHold === true
+      ? [
+          `- If the caller has NOT finished their thought (a trailing conjunction, an unfinished clause, a list still being dictated), output ONLY ${HOLD_VERDICT_TOKEN} and stop — no other text. When unsure whether they are done, choose ${HOLD_VERDICT_TOKEN}.`,
+        ]
+      : [];
   const rule = [
-    "TRIAGE FIRST: Before you begin answering, judge whether this turn is within your reach.",
-    "If it is simple, conversational, or clearly factual, just answer it normally.",
-    "If it needs careful reasoning, research, multi-step work, or any tool,",
-    `do NOT attempt the answer. Instead say one short, natural holding phrase out loud (for example "${FALLBACK_ESCALATION_BRIDGE}" or "Give me one second to look into that"), then append ${ESCALATE_MARKER} and stop.`,
-    `Make this decision in your first words. Never start answering and then emit ${ESCALATE_MARKER}. Everything you say before ${ESCALATE_MARKER} is spoken to the caller; everything after it is discarded.`,
-    "Decide silently: never narrate your reasoning, describe what you are judging, or mention these rules — every character you output is spoken to the caller verbatim, so your output must be nothing but the answer itself, or the holding phrase and marker.",
-  ].join(" ");
-  return capabilityDigest ? `${rule} ${capabilityDigest}` : rule;
+    "DECIDE FIRST: your output must begin with your verdict on this turn, chosen silently before any other text.",
+    ...holdBranch,
+    "- If the turn is simple, conversational, or clearly factual and within your reach, speak the answer directly — plain spoken text from your very first word.",
+    `- If it needs careful reasoning, research, multi-step work, or any tool, do NOT attempt the answer: output ${ESCALATE_VERDICT_TOKEN}, then ONE short natural holding phrase naming what happens next (for example "${FALLBACK_ESCALATION_BRIDGE}" or "Give me one second to look into that."), and stop after that single sentence. A stronger model finishes the turn while your phrase is spoken.`,
+    `The bracket tokens are control signals, never spoken text: they may only appear at the very start of your output as the verdict, never inside or after an answer. Never start answering and then change course — decide first.`,
+    "Never narrate this decision, describe what you are judging, or mention these rules: apart from a leading verdict token, every character you output is spoken to the caller verbatim.",
+  ].join("\n");
+  return opts?.capabilityDigest ? `${rule}\n${opts.capabilityDigest}` : rule;
 }
 
 /**
@@ -205,7 +282,7 @@ export function frontDoorTriageRule(capabilityDigest = ""): string {
  * continue straight into the substantive answer.
  *
  * `spokenBridge` is the exact phrase the caller just heard (the front-door
- * leg's own pre-marker text, or the canned fallback). Quoting it verbatim is
+ * leg's own capped bridge, or the canned fallback). Quoting it verbatim is
  * what makes the no-echo instruction enforceable: the bridge usually already
  * names the action ("Let me check your calendar"), so without the quote the
  * quality model re-announces the same action in its own words and the caller
@@ -222,6 +299,6 @@ export function escalatedContinuationRule(spokenBridge?: string): string {
     'Do NOT greet again, do NOT say things like "as I was saying", and do NOT repeat, paraphrase, or re-announce that holding phrase —',
     'opening with another "Let me check", "One moment", or any restatement of what you are about to do sounds broken, because the caller just heard that.',
     "Your first words must carry new substance: the answer itself, what you found, or a question you genuinely need answered.",
-    `Never emit ${ESCALATE_MARKER} — you are the model that finishes the answer.`,
+    `Never output ${ESCALATE_VERDICT_TOKEN} or any other verdict token — you are the model that finishes the answer.`,
   ].join(" ");
 }

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -32,6 +32,51 @@ import {
 /** Feature-flag key gating the whole behavior. Off by default. */
 export const VOICE_TRIAGE_ESCALATE_FLAG = "voice-triage-escalate";
 
+/**
+ * Feature-flag key for the unified front-door (requires the triage flag
+ * too): live-voice endpointing merges into the front-door leg. At each
+ * pause the leg is dispatched speculatively and its first token carries the
+ * verdict — {@link HOLD_VERDICT_TOKEN} (mid-thought, keep listening),
+ * `[ESCALATE]` after a bridge, or the answer itself. Replaces the separate
+ * endpoint-decider call on that path. Off by default.
+ */
+export const VOICE_UNIFIED_FRONT_DOOR_FLAG = "voice-unified-front-door";
+
+/**
+ * The hold verdict: the front-door leg outputs exactly this single
+ * character when the caller is mid-thought. Mirrors the endpoint decider's
+ * bare-token protocol ("0" = hold), so the tie-break asymmetry carries
+ * over: the model is told to hold when unsure, while every infra failure
+ * on the leg fails open to a normal released turn.
+ */
+export const HOLD_VERDICT_TOKEN = "0";
+
+/**
+ * Whether the unified front-door (endpointing merged into the front-door
+ * leg) is active. Only meaningful where triage-escalate is also on.
+ */
+export function isVoiceUnifiedFrontDoorEnabled(
+  config: AssistantConfig = getConfig(),
+): boolean {
+  return isAssistantFeatureFlagEnabled(VOICE_UNIFIED_FRONT_DOOR_FLAG, config);
+}
+
+/**
+ * Extra CALL PROTOCOL RULE for the unified front-door leg: the hold check
+ * runs before triage. The digit must be the leg's entire output — anything
+ * else is treated as a committed turn, so the rule also bans starting a
+ * real answer with it.
+ */
+export function frontDoorHoldRule(): string {
+  return [
+    "HOLD CHECK: Before anything else, judge whether the caller has finished their thought.",
+    "If the transcript ends mid-thought (a trailing conjunction, an unfinished clause, a list still being dictated),",
+    `output ONLY the single character ${HOLD_VERDICT_TOKEN} and stop — no punctuation, no other words.`,
+    `Never begin a real answer with the digit ${HOLD_VERDICT_TOKEN}.`,
+    "If the caller is done, ignore this rule and proceed.",
+  ].join(" ");
+}
+
 /** Fast/weak profile that fronts every turn when the flag is on. */
 export const FRONT_DOOR_PROFILE: DefaultProfileKey = "cost-optimized";
 

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -27,7 +27,6 @@
  */
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
-import type { DefaultProfileKey } from "../config/default-profile-names.js";
 import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
 import {
@@ -62,13 +61,12 @@ export function isVoiceUnifiedFrontDoorEnabled(
   return isAssistantFeatureFlagEnabled(VOICE_UNIFIED_FRONT_DOOR_FLAG, config);
 }
 
-/** Fast/weak profile that fronts every turn when the flag is on. */
-export const FRONT_DOOR_PROFILE: DefaultProfileKey = "cost-optimized";
-
-// The escalated leg deliberately carries NO profile override: it runs on the
-// call-site default, i.e. exactly the profile an un-routed voice turn would
-// use (balanced for a fresh workspace, or whatever the user pinned). That
-// guarantees an escalated answer is never weaker OR stronger than the
+// The fast model fronting every turn is pinned by the `voiceFrontDoor` call
+// site (see config/call-site-defaults.ts) — no per-turn profile override.
+// The escalated leg likewise carries NO override: it runs on the ordinary
+// call-agent resolution, i.e. exactly the profile an un-routed voice turn
+// would use (balanced for a fresh workspace, or whatever the user pinned).
+// That guarantees an escalated answer is never weaker OR stronger than the
 // pre-routing behavior, and honors per-user profile choices.
 
 /**

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -262,13 +262,19 @@ export function frontDoorDecisionRule(opts?: {
       ? [
           `- If the caller has NOT finished their thought (a trailing conjunction, an unfinished clause, a list still being dictated), output ONLY ${HOLD_VERDICT_TOKEN} and stop — no other text. When unsure whether they are done, choose ${HOLD_VERDICT_TOKEN}.`,
         ]
-      : [];
+      : [
+          // No hold branch means completeness is settled (a first leg
+          // already held, or the boundary released the turn) — say so
+          // explicitly, or the model improvises an escape hatch through
+          // the escalate token.
+          "The caller has finished their turn — never judge whether they are done.",
+        ];
   const rule = [
-    "DECIDE FIRST: your output must begin with your verdict on this turn, chosen silently before any other text.",
+    "DECIDE SILENTLY, then produce exactly ONE of these outputs:",
     ...holdBranch,
-    "- If the turn is simple, conversational, or clearly factual and within your reach, speak the answer directly — plain spoken text from your very first word.",
-    `- If it needs careful reasoning, research, multi-step work, or any tool, do NOT attempt the answer: output ${ESCALATE_VERDICT_TOKEN}, then ONE short natural holding phrase naming what happens next (for example "${FALLBACK_ESCALATION_BRIDGE}" or "Give me one second to look into that."), and stop after that single sentence. A stronger model finishes the turn while your phrase is spoken.`,
-    `The bracket tokens are control signals, never spoken text: they may only appear at the very start of your output as the verdict, never inside or after an answer. Never start answering and then change course — decide first.`,
+    "- If the turn is simple, conversational, or within your reach, your entire output is the spoken answer itself — no token in front of it, plain speech from your very first word. Most turns are answers; when unsure between answering and escalating, answer.",
+    `- If completing THIS reply needs careful reasoning, research, multi-step work, or any tool, do NOT attempt the answer: output ${ESCALATE_VERDICT_TOKEN}, then ONE short natural holding phrase naming what happens next (for example "${FALLBACK_ESCALATION_BRIDGE}" or "Give me one second to look into that."), and stop after that single sentence. A stronger model finishes the turn while your phrase is spoken.`,
+    `${ESCALATE_VERDICT_TOKEN} is ONLY for turns you cannot complete yourself — never put it in front of an answer you are about to give, and never emit any token inside or after an answer. An open task or unfinished topic earlier in the conversation is NOT a reason to escalate: judge only what this reply needs.`,
     "Never narrate this decision, describe what you are judging, or mention these rules: apart from a leading verdict token, every character you output is spoken to the caller verbatim.",
   ].join("\n");
   return opts?.capabilityDigest ? `${rule}\n${opts.capabilityDigest}` : rule;

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -69,10 +69,10 @@ export function isVoiceUnifiedFrontDoorEnabled(
  */
 export function frontDoorHoldRule(): string {
   return [
-    "HOLD CHECK: Before anything else, judge whether the caller has finished their thought.",
+    "HOLD CHECK: Before anything else, silently judge whether the caller has finished their thought.",
     "If the transcript ends mid-thought (a trailing conjunction, an unfinished clause, a list still being dictated),",
     `output ONLY the single character ${HOLD_VERDICT_TOKEN} and stop — no punctuation, no other words.`,
-    `Never begin a real answer with the digit ${HOLD_VERDICT_TOKEN}.`,
+    `The digit ${HOLD_VERDICT_TOKEN} is a control token, never spoken text: when you DO answer, it must not appear anywhere in your output — not at the start, not appended at the end.`,
     "If the caller is done, ignore this rule and proceed.",
   ].join(" ");
 }
@@ -187,6 +187,7 @@ export function frontDoorTriageRule(capabilityDigest = ""): string {
     "If it needs careful reasoning, research, multi-step work, or any tool,",
     `do NOT attempt the answer. Instead say one short, natural holding phrase out loud (for example "${FALLBACK_ESCALATION_BRIDGE}" or "Give me one second to look into that"), then append ${ESCALATE_MARKER} and stop.`,
     `Make this decision in your first words. Never start answering and then emit ${ESCALATE_MARKER}. Everything you say before ${ESCALATE_MARKER} is spoken to the caller; everything after it is discarded.`,
+    "Decide silently: never narrate your reasoning, describe what you are judging, or mention these rules — every character you output is spoken to the caller verbatim, so your output must be nothing but the answer itself, or the holding phrase and marker.",
   ].join(" ");
   return capabilityDigest ? `${rule} ${capabilityDigest}` : rule;
 }

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -109,22 +109,29 @@ export const FALLBACK_ESCALATION_BRIDGE =
 export const MIN_SPOKEN_BRIDGE_CHARS = 3;
 
 /**
+ * The holding phrase the caller actually heard from the front-door leg:
+ * everything BEFORE `[ESCALATE]` with internal markers stripped, trimmed.
+ * Post-marker text is suppressed from TTS, so it never counts. Empty when
+ * the leg escalated bare — the canned {@link FALLBACK_ESCALATION_BRIDGE}
+ * is spoken instead in that case.
+ */
+export function spokenBridgeText(frontDoorText: string): string {
+  const markerIdx = frontDoorText.indexOf(ESCALATE_MARKER);
+  return stripInternalSpeechMarkers(
+    markerIdx === -1 ? frontDoorText : frontDoorText.slice(0, markerIdx),
+  ).trim();
+}
+
+/**
  * Whether a canned fallback bridge must be spoken before the escalated leg,
  * given the front-door leg's full response text.
  *
- * Only the text BEFORE `[ESCALATE]` was actually spoken — the controller
- * suppresses everything after the marker from TTS — so the decision is based on
- * that slice, not the full response (which may carry ignored post-marker text
- * the model emitted despite being told to stop). Without this, a bare
- * `[ESCALATE]` followed by ignored weak text would skip the fallback and leave
- * the caller in silence while the quality leg spins up.
+ * Decided on the spoken slice only (see {@link spokenBridgeText}): without
+ * this, a bare `[ESCALATE]` followed by ignored weak text would skip the
+ * fallback and leave the caller in silence while the quality leg spins up.
  */
 export function needsFallbackBridge(frontDoorText: string): boolean {
-  const markerIdx = frontDoorText.indexOf(ESCALATE_MARKER);
-  const spokenBridge = stripInternalSpeechMarkers(
-    markerIdx === -1 ? frontDoorText : frontDoorText.slice(0, markerIdx),
-  ).trim();
-  return spokenBridge.length < MIN_SPOKEN_BRIDGE_CHARS;
+  return spokenBridgeText(frontDoorText).length < MIN_SPOKEN_BRIDGE_CHARS;
 }
 
 /**
@@ -196,13 +203,25 @@ export function frontDoorTriageRule(capabilityDigest = ""): string {
  * Extra CALL PROTOCOL RULE injected into the escalated (quality) leg's control
  * prompt. The holding phrase has already been spoken, so the model must
  * continue straight into the substantive answer.
+ *
+ * `spokenBridge` is the exact phrase the caller just heard (the front-door
+ * leg's own pre-marker text, or the canned fallback). Quoting it verbatim is
+ * what makes the no-echo instruction enforceable: the bridge usually already
+ * names the action ("Let me check your calendar"), so without the quote the
+ * quality model re-announces the same action in its own words and the caller
+ * hears two back-to-back "Let me check…" openers.
  */
-export function escalatedContinuationRule(): string {
+export function escalatedContinuationRule(spokenBridge?: string): string {
+  const bridge =
+    spokenBridge !== undefined && spokenBridge.trim().length > 0
+      ? spokenBridge.trim()
+      : FALLBACK_ESCALATION_BRIDGE;
   return [
-    "You have already spoken a brief holding phrase to the caller (something like",
-    `"${FALLBACK_ESCALATION_BRIDGE}").`,
+    `You have already spoken a brief holding phrase to the caller: "${bridge}".`,
     "Continue directly into your actual answer now.",
-    'Do NOT greet again, do NOT repeat the holding phrase, and do NOT say things like "as I was saying".',
+    'Do NOT greet again, do NOT say things like "as I was saying", and do NOT repeat, paraphrase, or re-announce that holding phrase —',
+    'opening with another "Let me check", "One moment", or any restatement of what you are about to do sounds broken, because the caller just heard that.',
+    "Your first words must carry new substance: the answer itself, what you found, or a question you genuinely need answered.",
     `Never emit ${ESCALATE_MARKER} — you are the model that finishes the answer.`,
   ].join(" ");
 }

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -133,6 +133,19 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     effort: "low",
     thinking: { enabled: false },
   },
+  voiceFrontDoor: {
+    profile: "cost-optimized",
+    // The front-door leg fronts EVERY unified live-voice turn and its
+    // leading tokens ARE the endpointing/triage verdict, so both TTFT
+    // variance and judgment quality gate the whole call. Pin the same
+    // latency-class model the endpoint decider uses: live drives showed the
+    // cost-optimized upstream with multi-second cross-session TTFT tails
+    // and over-escalation of small talk under open-task context pressure.
+    // Same model-pin caveat as voiceFrontDecision above.
+    model: "claude-haiku-4-5-20251001",
+    effort: "low",
+    thinking: { enabled: false },
+  },
   inviteInstructionGenerator: {
     profile: "cost-optimized",
     effort: "low",

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -296,6 +296,13 @@ const CATALOG_RECORD: CatalogRecord = {
       "Fast turn-taking and presence decisions during live voice (semantic endpointing, ack generation).",
     domain: "agentLoop",
   },
+  voiceFrontDoor: {
+    id: "voiceFrontDoor",
+    displayName: "Voice Front Door",
+    description:
+      "Fast front-door leg fronting live-voice turns under triage-and-escalate: leading-token verdict, holding phrase, or the direct answer.",
+    domain: "agentLoop",
+  },
   homeGreeting: {
     id: "homeGreeting",
     displayName: "Home Greeting",

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -144,6 +144,7 @@ export const LLMCallSiteEnum = z.enum([
   "inference",
   "vision",
   "voiceFrontDecision",
+  "voiceFrontDoor",
   "trustRuleSuggestion",
   "homeGreeting",
   "homeSuggestedPrompts",

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -1068,6 +1068,43 @@ async function flushAccumulatedContent(
   }
 }
 
+/**
+ * Settle the debounced partial flush at the turn-tail seam, BEFORE the
+ * stranded-content fold. A cancelled/aborted turn exits with the debounce
+ * timer still pending; left alone it fires up to a second later — after the
+ * fold has finalized the row (and cleared the in-flight writer, so the late
+ * flush lands as a direct row write), and after the voice bridge's
+ * transcript-hygiene pass has already read and settled the row. The
+ * accumulated tail is flushed NOW, in order, so nothing is lost (barge-in
+ * partials keep their final second of text) and nothing writes after the
+ * row is settled. No-op for completed turns — `handleMessageComplete`
+ * already cleared the timer and awaited the in-flight flush.
+ */
+export async function settlePendingPartialFlush(
+  state: EventHandlerState,
+  deps: EventHandlerDeps,
+): Promise<void> {
+  if (state.pendingPartialFlushTimer !== undefined) {
+    clearTimeout(state.pendingPartialFlushTimer);
+    state.pendingPartialFlushTimer = undefined;
+    try {
+      await flushAccumulatedContent(state, deps);
+    } catch (err) {
+      // Same tolerance as the debounced path: a failed partial flush must
+      // not escalate a finished turn into a turn-level throw.
+      deps.rlog.warn({ err }, "Turn-tail partial flush failed (non-fatal)");
+    }
+  }
+  if (state.pendingPartialFlushPromise !== undefined) {
+    try {
+      await state.pendingPartialFlushPromise;
+    } catch {
+      // The flush swallows its own errors; defensive against future changes.
+    }
+    state.pendingPartialFlushPromise = undefined;
+  }
+}
+
 /** Schedule a debounced partial flush. First-scheduled wins; no-op when timer pending. */
 function schedulePartialFlush(
   state: EventHandlerState,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -83,6 +83,7 @@ import {
   type EventHandlerDeps,
   finalizePendingToolResultRow,
   markHistoryStrippedBestEffort,
+  settlePendingPartialFlush,
 } from "./conversation-agent-loop-handlers.js";
 import {
   approveHostAttachmentRead,
@@ -1541,8 +1542,13 @@ export async function runAgentLoopImpl(
 
     // The terminal SSE for this turn has now been emitted (message_complete,
     // generation_handoff, or generation_cancelled), so the composer is already
-    // re-enabling. Drain the deferred bookkeeping now — after the SSE, before
-    // the `finally` commits and drains the queue for the next turn.
+    // re-enabling. Settle any pending debounced partial flush FIRST — a
+    // cancelled turn exits with the timer still pending, and a flush firing
+    // after the tail's stranded fold (or the voice bridge's transcript
+    // hygiene) would write raw content into an already-settled row. Then
+    // drain the deferred bookkeeping — after the SSE, before the `finally`
+    // commits and drains the queue for the next turn.
+    await settlePendingPartialFlush(state, deps);
     await runDeferredTurnTail({ ctx, state, rlog, generationCompletedAt });
   } catch (err) {
     clearConversationNotices(ctx.conversationId);

--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -323,9 +323,14 @@ describe("LiveVoiceSession archive and metrics events", () => {
       conversationId: "conversation-123",
       turnId: "live-turn-1",
       sttMs: 10,
-      llmFirstDeltaMs: 10,
+      // The assistant_dispatch mark adds one fake-clock tick between the
+      // final transcript and the first delta, so the transcript-anchored
+      // number inflates while the dispatch-anchored one stays at one tick.
+      llmFirstDeltaMs: 20,
+      dispatchToFirstDeltaMs: 10,
+      dispatchToFirstAudioMs: 20,
       ttsFirstAudioMs: 10,
-      totalMs: 60,
+      totalMs: 70,
       metrics: {
         summary: {
           completedTurnCount: 1,

--- a/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
@@ -123,6 +123,9 @@ describe("LiveVoiceMetricsCollector", () => {
     expect(getLiveVoiceMetricsAggregateFields(snapshot, "turn-vad")).toEqual({
       sttMs: 50,
       llmFirstDeltaMs: 25,
+      // No assistant-dispatch mark in this scripted turn.
+      dispatchToFirstDeltaMs: null,
+      dispatchToFirstAudioMs: null,
       ttsFirstAudioMs: 75,
       roundTripMs: 190,
       totalMs: 200,

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, mock, test } from "bun:test";
 
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
 import { sanitizeForTts } from "../../calls/tts-text-sanitizer.js";
 import type {
   VoiceTurnCallbacks,
   VoiceTurnOptions,
 } from "../../calls/voice-session-bridge.js";
+import { VOICE_TRIAGE_ESCALATE_FLAG } from "../../calls/voice-triage-escalate.js";
+import { clearFeatureFlagOverridesCache } from "../../config/assistant-feature-flags.js";
 import type {
   LiveVoiceFrontModelConfig,
   LiveVoiceProgressConfig,
@@ -251,6 +254,38 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
 }
 
 describe("LiveVoiceSession progress narration", () => {
+  test("the escalated leg re-arms idle narration into post-bridge dead air", async () => {
+    setOverridesForTesting({
+      "voice-mode": true,
+      [VOICE_TRIAGE_ESCALATE_FLAG]: true,
+    });
+    try {
+      const generateProgressText = mock(
+        async () => "Still working through your calendar.",
+      );
+      const { session, getCallbacks, ttsTexts } = createProgressHarness({
+        frontModelConfig: progressConfig({ idleIntervalMs: 40 }),
+        frontDecider: makeProgressDecider(generateProgressText),
+      });
+      await startReleasedTurn(session, getCallbacks);
+
+      // Bare escalate verdict: the canned bridge speaks and the escalated
+      // leg takes over. Its strong-model thinking + tool loops are the
+      // longest dead air in the system — narration must cover it once the
+      // bridge audio has drained, where it used to be suppressed for the
+      // rest of the turn.
+      emitTextDelta(getCallbacks, "[1]");
+      emitMessageComplete(getCallbacks);
+      await waitFor(() => ttsTexts.length === 1);
+
+      await waitFor(() => generateProgressText.mock.calls.length >= 1);
+      await waitFor(() => ttsTexts.length >= 2);
+      expect(ttsTexts[1]).toContain("Still working");
+    } finally {
+      clearFeatureFlagOverridesCache();
+    }
+  });
+
   test("ops threshold: three tool ops speak exactly one narration with the accumulated activity", async () => {
     const inputs: VoiceProgressTextInput[] = [];
     const generateProgressText = mock(async (input: VoiceProgressTextInput) => {

--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -4,7 +4,6 @@ import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helper
 import type { VoiceTurnOptions } from "../../calls/voice-session-bridge.js";
 import {
   ESCALATION_CONTINUATION_CONTENT,
-  ESCALATION_PROFILE,
   FRONT_DOOR_PROFILE,
   VOICE_TRIAGE_ESCALATE_FLAG,
 } from "../../calls/voice-triage-escalate.js";
@@ -218,7 +217,8 @@ describe("live-voice triage-and-escalate routing", () => {
     const escalated = starter.mock.calls[1]?.[0];
     expect(frontDoor?.overrideProfile).toBe(FRONT_DOOR_PROFILE);
     expect(frontDoor?.routingLeg).toBe("front-door");
-    expect(escalated?.overrideProfile).toBe(ESCALATION_PROFILE);
+    // The escalated leg runs on the call-site default profile: no override.
+    expect(escalated?.overrideProfile).toBeUndefined();
     expect(escalated?.routingLeg).toBe("escalated");
     expect(escalated?.content).toBe(ESCALATION_CONTINUATION_CONTENT);
   });

--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -4,6 +4,7 @@ import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helper
 import type { VoiceTurnOptions } from "../../calls/voice-session-bridge.js";
 import {
   ESCALATION_CONTINUATION_CONTENT,
+  FALLBACK_ESCALATION_BRIDGE,
   FRONT_DOOR_PROFILE,
   VOICE_TRIAGE_ESCALATE_FLAG,
 } from "../../calls/voice-triage-escalate.js";
@@ -264,6 +265,24 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(spoken).not.toContain("leftover");
   });
 
+  test("the escalated leg receives the front-door leg's actual spoken bridge", async () => {
+    enableBothFlags();
+    const { starter } = scriptedStartVoiceTurn({
+      frontDoor: ["Let me check your calendar. ", "[ESCALATE] ignored tail"],
+      escalated: ["You have three connections."],
+    });
+    const { session } = createHarness(starter);
+
+    await driveTurn(session);
+    await waitFor(() => starter.mock.calls.length >= 2);
+
+    // The exact phrase the caller heard — pre-marker, cleaned, trimmed — so
+    // the continuation rule can quote it and ban a re-announcing echo.
+    expect(starter.mock.calls[1]?.[0]?.spokenEscalationBridge).toBe(
+      "Let me check your calendar.",
+    );
+  });
+
   test("bare [ESCALATE] with no holding phrase still escalates (fallback bridge)", async () => {
     enableBothFlags();
     const { starter } = scriptedStartVoiceTurn({
@@ -279,6 +298,11 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(starter).toHaveBeenCalledTimes(2);
     expect(starter.mock.calls[1]?.[0]?.content).toBe(
       ESCALATION_CONTINUATION_CONTENT,
+    );
+    // The caller heard the canned fallback, so that is the bridge the
+    // escalated leg must be told about.
+    expect(starter.mock.calls[1]?.[0]?.spokenEscalationBridge).toBe(
+      FALLBACK_ESCALATION_BRIDGE,
     );
     // The marker itself is never shown; the fallback bridge is audio-only.
     expect(spokenText(frames)).not.toContain("[ESCALATE]");

--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -201,10 +201,10 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(spokenText(frames)).toBe("Sure, it's Tuesday.");
   });
 
-  test("both flags on, tricky turn: [ESCALATE] hands off to a second quality leg", async () => {
+  test("both flags on, tricky turn: the escalate verdict hands off to a second quality leg", async () => {
     enableBothFlags();
     const { starter } = scriptedStartVoiceTurn({
-      frontDoor: ["Let me think about that. ", "[ESCALATE]"],
+      frontDoor: ["[1] ", "Let me think about that."],
       escalated: ["The detailed answer is 42."],
     });
     const { frames, session } = createHarness(starter);
@@ -224,12 +224,12 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(escalated?.content).toBe(ESCALATION_CONTINUATION_CONTENT);
   });
 
-  test("the [ESCALATE] marker and any text after it never reach the transcript", async () => {
+  test("the verdict token and any text past the bridge cap never reach the transcript", async () => {
     enableBothFlags();
     const { starter } = scriptedStartVoiceTurn({
       frontDoor: [
-        "Let me think about that. ",
-        "[ESCALATE] this weak answer kept streaming",
+        "[1] Let me think about that.",
+        " this weak answer kept streaming",
       ],
       escalated: ["The careful answer."],
     });
@@ -241,15 +241,15 @@ describe("live-voice triage-and-escalate routing", () => {
 
     const spoken = spokenText(frames);
     expect(spoken).toContain("Let me think about that.");
-    expect(spoken).not.toContain("[ESCALATE]");
+    expect(spoken).not.toContain("[1]");
     expect(spoken).not.toContain("weak answer");
     expect(spoken).toContain("The careful answer.");
   });
 
-  test("a [ESCALATE] marker split across deltas is still detected and suppressed", async () => {
+  test("a verdict token split across deltas is still detected and suppressed", async () => {
     enableBothFlags();
     const { starter } = scriptedStartVoiceTurn({
-      frontDoor: ["One moment. ", "[ESC", "ALATE]", " leftover"],
+      frontDoor: ["[", "1]", " One moment.", " leftover past the cap"],
       escalated: ["Answer."],
     });
     const { frames, session } = createHarness(starter);
@@ -260,15 +260,33 @@ describe("live-voice triage-and-escalate routing", () => {
 
     const spoken = spokenText(frames);
     expect(spoken).toContain("One moment.");
-    expect(spoken).not.toContain("[ESC");
-    expect(spoken).not.toContain("ALATE");
+    expect(spoken).not.toContain("[1");
+    expect(spoken).not.toContain("1]");
     expect(spoken).not.toContain("leftover");
+  });
+
+  test("a bridge with no sentence terminator hands off at the leg's completion", async () => {
+    enableBothFlags();
+    const { starter } = scriptedStartVoiceTurn({
+      frontDoor: ["[1] Give me a moment"],
+      escalated: ["Answer."],
+    });
+    const { frames, session } = createHarness(starter);
+
+    await driveTurn(session);
+    await waitFor(() => starter.mock.calls.length >= 2);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(starter.mock.calls[1]?.[0]?.spokenEscalationBridge).toBe(
+      "Give me a moment",
+    );
+    expect(spokenText(frames)).toContain("Give me a moment");
   });
 
   test("the escalated leg receives the front-door leg's actual spoken bridge", async () => {
     enableBothFlags();
     const { starter } = scriptedStartVoiceTurn({
-      frontDoor: ["Let me check your calendar. ", "[ESCALATE] ignored tail"],
+      frontDoor: ["[1] Let me check your calendar.", " ignored tail"],
       escalated: ["You have three connections."],
     });
     const { session } = createHarness(starter);
@@ -283,10 +301,10 @@ describe("live-voice triage-and-escalate routing", () => {
     );
   });
 
-  test("bare [ESCALATE] with no holding phrase still escalates (fallback bridge)", async () => {
+  test("a bare escalate verdict with no holding phrase still escalates (fallback bridge)", async () => {
     enableBothFlags();
     const { starter } = scriptedStartVoiceTurn({
-      frontDoor: ["[ESCALATE]"],
+      frontDoor: ["[1]"],
       escalated: ["The thorough answer."],
     });
     const { frames, session } = createHarness(starter);
@@ -304,14 +322,15 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(starter.mock.calls[1]?.[0]?.spokenEscalationBridge).toBe(
       FALLBACK_ESCALATION_BRIDGE,
     );
-    // The marker itself is never shown; the fallback bridge is audio-only.
-    expect(spokenText(frames)).not.toContain("[ESCALATE]");
+    // The verdict itself is never shown; the fallback bridge is audio-only.
+    expect(spokenText(frames)).not.toContain("[1]");
+    expect(spokenText(frames)).not.toContain(FALLBACK_ESCALATION_BRIDGE);
   });
 
   test("gating requires BOTH flags: voice-triage-escalate alone does not escalate", async () => {
     setOverridesForTesting({ [VOICE_TRIAGE_ESCALATE_FLAG]: true });
     const { starter } = scriptedStartVoiceTurn({
-      frontDoor: ["Let me think. ", "[ESCALATE]"],
+      frontDoor: ["Let me think."],
     });
     const { frames, session } = createHarness(starter);
 
@@ -327,7 +346,7 @@ describe("live-voice triage-and-escalate routing", () => {
   test("gating requires BOTH flags: voice-mode alone does not escalate", async () => {
     setOverridesForTesting({ [VOICE_MODE_FLAG]: true });
     const { starter } = scriptedStartVoiceTurn({
-      frontDoor: ["Let me think. ", "[ESCALATE]"],
+      frontDoor: ["Let me think."],
     });
     const { frames, session } = createHarness(starter);
 
@@ -342,7 +361,7 @@ describe("live-voice triage-and-escalate routing", () => {
   test("barge-in during the escalated leg aborts it", async () => {
     enableBothFlags();
     const { starter, escalatedAbort } = scriptedStartVoiceTurn({
-      frontDoor: ["Let me think about that. ", "[ESCALATE]"],
+      frontDoor: ["[1] ", "Let me think about that."],
       holdEscalated: true,
     });
     const { session } = createHarness(starter);

--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -5,7 +5,6 @@ import type { VoiceTurnOptions } from "../../calls/voice-session-bridge.js";
 import {
   ESCALATION_CONTINUATION_CONTENT,
   FALLBACK_ESCALATION_BRIDGE,
-  FRONT_DOOR_PROFILE,
   VOICE_TRIAGE_ESCALATE_FLAG,
 } from "../../calls/voice-triage-escalate.js";
 import { clearFeatureFlagOverridesCache } from "../../config/assistant-feature-flags.js";
@@ -194,9 +193,9 @@ describe("live-voice triage-and-escalate routing", () => {
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
 
     expect(starter).toHaveBeenCalledTimes(1);
-    expect(starter.mock.calls[0]?.[0]?.overrideProfile).toBe(
-      FRONT_DOOR_PROFILE,
-    );
+    // The front-door model is pinned by the voiceFrontDoor call site, not a
+    // per-turn profile override.
+    expect(starter.mock.calls[0]?.[0]?.overrideProfile).toBeUndefined();
     expect(starter.mock.calls[0]?.[0]?.routingLeg).toBe("front-door");
     expect(spokenText(frames)).toBe("Sure, it's Tuesday.");
   });
@@ -216,9 +215,10 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(starter).toHaveBeenCalledTimes(2);
     const frontDoor = starter.mock.calls[0]?.[0];
     const escalated = starter.mock.calls[1]?.[0];
-    expect(frontDoor?.overrideProfile).toBe(FRONT_DOOR_PROFILE);
+    expect(frontDoor?.overrideProfile).toBeUndefined();
     expect(frontDoor?.routingLeg).toBe("front-door");
-    // The escalated leg runs on the call-site default profile: no override.
+    // The escalated leg runs on the ordinary call-agent resolution: no
+    // override either.
     expect(escalated?.overrideProfile).toBeUndefined();
     expect(escalated?.routingLeg).toBe("escalated");
     expect(escalated?.content).toBe(ESCALATION_CONTINUATION_CONTENT);

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -1124,7 +1124,8 @@ describe("LiveVoiceSession spoken ack", () => {
     // The front-door leg escalates with no holding phrase of its own, so the
     // canned bridge is enqueued — exactly the case where a late-resolving
     // generation would stack a second filler on top of it.
-    getCallbacks()?.assistant_text_delta?.(makeTextDelta("[ESCALATE]"));
+    getCallbacks()?.assistant_text_delta?.(makeTextDelta("[1]"));
+    getCallbacks()?.message_complete?.(makeMessageComplete());
     await waitFor(() => ttsTexts.length === 1);
     expect(ttsTexts).toEqual([EXPECTED_BRIDGE]);
 
@@ -1155,7 +1156,8 @@ describe("LiveVoiceSession spoken ack", () => {
 
     await startReleasedTurn(session);
     // A bare hand-off enqueues the canned bridge, which holds the floor.
-    getCallbacks()?.assistant_text_delta?.(makeTextDelta("[ESCALATE]"));
+    getCallbacks()?.assistant_text_delta?.(makeTextDelta("[1]"));
+    getCallbacks()?.message_complete?.(makeMessageComplete());
     await waitFor(() => ttsTexts.length === 1);
     expect(ttsTexts).toEqual([EXPECTED_BRIDGE]);
 
@@ -1187,7 +1189,8 @@ describe("LiveVoiceSession spoken ack", () => {
     });
 
     await startReleasedTurn(session);
-    getCallbacks()?.assistant_text_delta?.(makeTextDelta("[ESCALATE]"));
+    getCallbacks()?.assistant_text_delta?.(makeTextDelta("[1]"));
+    getCallbacks()?.message_complete?.(makeMessageComplete());
     await waitFor(() => ttsTexts.length === 1);
     expect(ttsTexts).toEqual([EXPECTED_BRIDGE]);
 

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -3294,4 +3294,130 @@ describe("LiveVoiceSession unified front-door endpointing", () => {
     expect(starter.calls[1]?.content).toBe("hello wor and more");
     expect(countType(frames, "utterance_end")).toBe(1);
   });
+
+  test("a discard that beats the bridge handle still rolls back the user row", async () => {
+    enableUnifiedFlags();
+    const discard = mock(async () => {});
+    const abort = mock();
+    let resolveHandle: (() => void) | null = null;
+    const calls: VoiceTurnOptions[] = [];
+    const startVoiceTurn: LiveVoiceTurnStarter = async (options) => {
+      calls.push(options);
+      if (calls.length === 1) {
+        // The speculative leg's handle resolution is delayed past the
+        // discard — models startVoiceTurn still inside its persist wait.
+        await new Promise<void>((resolve) => {
+          resolveHandle = resolve;
+        });
+        return { turnId: "bridge-slow", abort, discard };
+      }
+      return { turnId: `bridge-${calls.length}`, abort: mock() };
+    };
+    const { session, transcribers } = createHarness({
+      finals: ["hello there world"],
+      startVoiceTurn,
+      frontModelConfig: { endpointExtensionMs: 5_000 },
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.length === 1);
+
+    // Speech resumes while the handle is still unresolved: the discard
+    // finds handle === null and can only latch the request.
+    transcribers[0]?.emit({ type: "partial", text: "hello wor and more" });
+    await session.handleBinaryAudio(LOUD_CHUNK);
+
+    // The handle finally arrives: it must complete the rollback via
+    // discard(), not a plain abort that leaks the persisted user row.
+    await waitFor(() => resolveHandle !== null);
+    // Cast: TS narrows the closure-assigned resolver to null here.
+    (resolveHandle as (() => void) | null)?.();
+    await waitFor(() => discard.mock.calls.length === 1);
+    expect(abort).not.toHaveBeenCalled();
+  });
+
+  test("a manual release during the verdict window commits the leg instead of discarding it", async () => {
+    enableUnifiedFlags();
+    const discard = mock(async () => {});
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const calls: VoiceTurnOptions[] = [];
+    const startVoiceTurn: LiveVoiceTurnStarter = async (options) => {
+      calls.push(options);
+      callbacks = options.callbacks;
+      return { turnId: "bridge-manual", abort: mock(), discard };
+    };
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn,
+      frontModelConfig: { endpointExtensionMs: 5_000 },
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.length === 1);
+
+    // The caller hits release while the verdict is still in flight: the
+    // utterance releases immediately (utterance_end goes out now).
+    await session.handleClientFrame({ type: "ptt_release" });
+    expect(countType(frames, "utterance_end")).toBe(1);
+
+    // The verdict arrives as a normal answer — the caller explicitly asked
+    // to answer now, so it must commit into the released utterance.
+    callbacks?.assistant_text_delta?.(makeTextDelta("Hi there."));
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(discard).not.toHaveBeenCalled();
+    expect(calls).toHaveLength(1);
+    // No duplicate utterance_end from the commit; the thinking frame and
+    // the spoken answer still go out.
+    expect(countType(frames, "utterance_end")).toBe(1);
+    expect(countType(frames, "thinking")).toBe(1);
+    expect(spokenDeltaText(frames)).toContain("Hi there.");
+  });
+
+  test("a hold verdict after a manual release relaunches a fresh leg on the released utterance", async () => {
+    enableUnifiedFlags();
+    const discard = mock(async () => {});
+    let firstCallbacks: VoiceTurnCallbacks | undefined;
+    const calls: VoiceTurnOptions[] = [];
+    const startVoiceTurn: LiveVoiceTurnStarter = async (options) => {
+      calls.push(options);
+      if (calls.length === 1) {
+        firstCallbacks = options.callbacks;
+        return { turnId: "bridge-held", abort: mock(), discard };
+      }
+      // The relaunched leg answers normally.
+      setTimeout(() => {
+        options.callbacks?.assistant_text_delta?.(
+          makeTextDelta("Fresh answer."),
+        );
+        options.callbacks?.message_complete?.(makeMessageComplete());
+      }, 0);
+      return { turnId: `bridge-${calls.length}`, abort: mock() };
+    };
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn,
+      frontModelConfig: { endpointExtensionMs: 5_000 },
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => calls.length === 1);
+
+    await session.handleClientFrame({ type: "ptt_release" });
+
+    // The hold lands after the caller already said they were done: moot.
+    // The held leg rolls back and a fresh leg answers the released
+    // utterance instead of the turn dying with no response.
+    firstCallbacks?.assistant_text_delta?.(makeTextDelta("[0]"));
+    await waitFor(() => calls.length === 2);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(discard).toHaveBeenCalledTimes(1);
+    expect(spokenDeltaText(frames)).toContain("Fresh answer.");
+    expect(spokenDeltaText(frames)).not.toContain("[0]");
+  });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -3101,7 +3101,9 @@ describe("LiveVoiceSession unified front-door endpointing", () => {
     const startVoiceTurn: LiveVoiceTurnStarter = async (options) => {
       calls.push(options);
       const script = scripts[calls.length - 1];
-      if (script) {
+      // An empty script models a leg that stays in flight (no verdict, no
+      // completion) — a non-empty one streams its deltas then completes.
+      if (script && script.length > 0) {
         setTimeout(() => {
           for (const text of script) {
             options.callbacks?.assistant_text_delta?.(makeTextDelta(text));

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -3185,7 +3185,7 @@ describe("LiveVoiceSession unified front-door endpointing", () => {
 
   test("a hold verdict discards the leg silently and the extension replays the boundary", async () => {
     enableUnifiedFlags();
-    const starter = makeVerdictTurnStarter([["0"], ["Sure thing."]]);
+    const starter = makeVerdictTurnStarter([["[0]"], ["Sure thing."]]);
     const { frames, session, transcribers } = createHarness({
       finals: ["hello world"],
       startVoiceTurn: starter.startVoiceTurn,
@@ -3209,7 +3209,7 @@ describe("LiveVoiceSession unified front-door endpointing", () => {
     expect(countType(frames, "thinking")).toBe(1);
     expect(spokenDeltaText(frames)).toContain("Sure thing.");
     // The spoken stream never contains the verdict token.
-    expect(spokenDeltaText(frames)).not.toContain("0");
+    expect(spokenDeltaText(frames)).not.toContain("[0]");
   });
 
   test("speech resuming mid-verdict discards the leg and the utterance keeps accumulating", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -106,7 +106,9 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   }
 
   stop(): void {
-    if (this.stopped) return;
+    if (this.stopped) {
+      return;
+    }
     this.stopped = true;
     if (!this.holdStopEvents) {
       this.flushStopEvents();
@@ -299,7 +301,9 @@ async function waitFor(
   // message, not bun's, reports a failure.
   const deadline = Date.now() + 4_000;
   while (Date.now() < deadline) {
-    if (predicate()) return;
+    if (predicate()) {
+      return;
+    }
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   throw new Error(message);
@@ -3062,5 +3066,176 @@ describe("LiveVoiceSession semantic endpointing", () => {
     expect(calls).toHaveLength(1);
     expect(countType(frames, "utterance_end")).toBe(0);
     expect(frames.length).toBe(framesAtClose);
+  });
+});
+
+describe("LiveVoiceSession unified front-door endpointing", () => {
+  const enableUnifiedFlags = () =>
+    setCachedOverrides(
+      {
+        "voice-mode": true,
+        "voice-triage-escalate": true,
+        "voice-unified-front-door": true,
+      },
+      { fromGateway: true },
+    );
+
+  afterEach(() => clearCachedOverrides());
+
+  function spokenDeltaText(frames: LiveVoiceServerFrame[]): string {
+    return frames
+      .filter((frame) => frame.type === "assistant_text_delta")
+      .map((frame) => (frame as { text: string }).text)
+      .join("");
+  }
+
+  // A scriptable speculative starter: per-call delta scripts, with discard
+  // tracked so hold-verdict rollback is observable.
+  function makeVerdictTurnStarter(scripts: string[][]): {
+    startVoiceTurn: LiveVoiceTurnStarter;
+    calls: VoiceTurnOptions[];
+    discard: ReturnType<typeof mock>;
+  } {
+    const calls: VoiceTurnOptions[] = [];
+    const discard = mock(async () => {});
+    const startVoiceTurn: LiveVoiceTurnStarter = async (options) => {
+      calls.push(options);
+      const script = scripts[calls.length - 1];
+      if (script) {
+        setTimeout(() => {
+          for (const text of script) {
+            options.callbacks?.assistant_text_delta?.(makeTextDelta(text));
+          }
+          options.callbacks?.message_complete?.(makeMessageComplete());
+        }, 0);
+      }
+      return { turnId: `bridge-turn-${calls.length}`, abort: mock(), discard };
+    };
+    return { startVoiceTurn, calls, discard };
+  }
+
+  // A decider that must never be consulted once the unified flag owns
+  // endpointing.
+  function makeUntouchableDecider(): {
+    decider: VoiceFrontDecider;
+    endpointCalls: () => number;
+  } {
+    let count = 0;
+    return {
+      decider: {
+        decideEndpoint: async () => {
+          count += 1;
+          return { action: "release" as const };
+        },
+        generateAckText: async () => null,
+        generateProgressText: async () => null,
+      },
+      endpointCalls: () => count,
+    };
+  }
+
+  async function startWithPartial(
+    session: LiveVoiceSession,
+    transcribers: MockStreamingTranscriber[],
+    partialText = "hello wor",
+  ): Promise<void> {
+    await session.start();
+    await waitFor(() => transcribers.length === 1);
+    await flushAsyncCallbacks();
+    transcribers[0]?.emit({ type: "partial", text: partialText });
+  }
+
+  test("a chatty answer commits: verdict leg replaces the decider, frames follow commit order", async () => {
+    enableUnifiedFlags();
+    const { decider, endpointCalls } = makeUntouchableDecider();
+    const starter = makeVerdictTurnStarter([["Hey! Not much."]]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn: starter.startVoiceTurn,
+      frontDecider: decider,
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The leg IS the endpoint decision: the decider was never consulted.
+    expect(endpointCalls()).toBe(0);
+    expect(starter.calls).toHaveLength(1);
+    // Dispatched speculatively on the pre-finalize transcript, as the
+    // front-door leg with the verdict rule requested.
+    expect(starter.calls[0]).toMatchObject({
+      content: "hello wor",
+      routingLeg: "front-door",
+      unifiedVerdict: true,
+    });
+    // Deferred boundary work lands at commit, before the first spoken delta.
+    const types = frameTypes(frames);
+    expect(types.indexOf("utterance_end")).toBeGreaterThan(-1);
+    expect(types.indexOf("utterance_end")).toBeLessThan(
+      types.indexOf("thinking"),
+    );
+    expect(types.indexOf("thinking")).toBeLessThan(
+      types.indexOf("assistant_text_delta"),
+    );
+    expect(starter.discard).not.toHaveBeenCalled();
+  });
+
+  test("a hold verdict discards the leg silently and the extension replays the boundary", async () => {
+    enableUnifiedFlags();
+    const starter = makeVerdictTurnStarter([["0"], ["Sure thing."]]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn: starter.startVoiceTurn,
+      frontModelConfig: { endpointExtensionMs: 30 },
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+
+    // First leg returned the hold token: rollback, no user-visible frames.
+    await waitFor(() => starter.discard.mock.calls.length === 1);
+    expect(countType(frames, "utterance_end")).toBe(0);
+    expect(countType(frames, "thinking")).toBe(0);
+    expect(countType(frames, "assistant_text_delta")).toBe(0);
+
+    // The extension elapses in continued silence: the boundary replays, the
+    // second speculative leg answers, and the turn commits normally.
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(starter.calls).toHaveLength(2);
+    expect(countType(frames, "utterance_end")).toBe(1);
+    expect(countType(frames, "thinking")).toBe(1);
+    expect(spokenDeltaText(frames)).toContain("Sure thing.");
+    // The spoken stream never contains the verdict token.
+    expect(spokenDeltaText(frames)).not.toContain("0");
+  });
+
+  test("speech resuming mid-verdict discards the leg and the utterance keeps accumulating", async () => {
+    enableUnifiedFlags();
+    // First leg never produces a verdict (in flight); second answers.
+    const starter = makeVerdictTurnStarter([[], ["Got it all."]]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello there world"],
+      startVoiceTurn: starter.startVoiceTurn,
+      frontModelConfig: { endpointExtensionMs: 5_000 },
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => starter.calls.length === 1);
+
+    // The caller keeps talking while the verdict is in flight: silent
+    // discard, no frames for the abandoned leg.
+    transcribers[0]?.emit({ type: "partial", text: "hello wor and more" });
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => starter.discard.mock.calls.length === 1);
+    expect(countType(frames, "utterance_end")).toBe(0);
+    expect(countType(frames, "thinking")).toBe(0);
+
+    // The next silence re-speculates with the grown transcript and commits.
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(starter.calls).toHaveLength(2);
+    expect(starter.calls[1]?.content).toBe("hello wor and more");
+    expect(countType(frames, "utterance_end")).toBe(1);
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -3210,6 +3210,60 @@ describe("LiveVoiceSession unified front-door endpointing", () => {
     expect(spokenDeltaText(frames)).toContain("Sure thing.");
     // The spoken stream never contains the verdict token.
     expect(spokenDeltaText(frames)).not.toContain("[0]");
+    // One hold per utterance: the replay leg is not offered the hold verdict
+    // again — a second silence means the caller is done.
+    expect(starter.calls[0]?.unifiedVerdict).toBe(true);
+    expect(starter.calls[1]?.unifiedVerdict).toBeUndefined();
+  });
+
+  test("a verdict that misses the deadline commits the turn (fail-open)", async () => {
+    enableUnifiedFlags();
+    // The leg never produces a verdict — a provider TTFT tail. The deadline
+    // must commit the turn so the caller gets the thinking frame (and the
+    // ack timer arms) instead of unbounded structural silence.
+    const starter = makeVerdictTurnStarter([[]]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world"],
+      startVoiceTurn: starter.startVoiceTurn,
+      frontModelConfig: {
+        endpointDecisionTimeoutMs: 40,
+        endpointExtensionMs: 60_000,
+      },
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => starter.calls.length === 1);
+
+    await waitFor(() => countType(frames, "thinking") === 1);
+    expect(countType(frames, "utterance_end")).toBe(1);
+    // Fail-open commits; nothing was discarded or rolled back.
+    expect(starter.discard).not.toHaveBeenCalled();
+  });
+
+  test("a final that extends the held transcript replays the boundary immediately", async () => {
+    enableUnifiedFlags();
+    const starter = makeVerdictTurnStarter([["[0]"], ["Got it."]]);
+    const { frames, session, transcribers } = createHarness({
+      finals: ["hello world how are you"],
+      startVoiceTurn: starter.startVoiceTurn,
+      // Extension far beyond the test window: only the fresh-final path can
+      // re-dispatch in time.
+      frontModelConfig: { endpointExtensionMs: 60_000 },
+    });
+
+    await startWithPartial(session, transcribers);
+    await session.handleBinaryAudio(LOUD_CHUNK);
+    await waitFor(() => starter.discard.mock.calls.length === 1);
+
+    // The finalized transcript lands mid-extension and extends the partial
+    // the hold judged ("hello wor"): the hold was judged on stale text, so
+    // the boundary replays now instead of after the extension window.
+    transcribers[0]?.emit({ type: "final", text: "hello world how are you" });
+    await waitFor(() => starter.calls.length === 2);
+    expect(starter.calls[1]?.content).toBe("hello world how are you");
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(spokenDeltaText(frames)).toContain("Got it.");
   });
 
   test("speech resuming mid-verdict discards the leg and the utterance keeps accumulating", async () => {

--- a/assistant/src/live-voice/live-voice-metrics.ts
+++ b/assistant/src/live-voice/live-voice-metrics.ts
@@ -10,6 +10,7 @@ export type LiveVoiceMetricsEvent =
   | "session_ready"
   | "turn_started"
   | "first_audio"
+  | "assistant_dispatch"
   | "first_partial"
   | "vad_speech_start"
   | "ptt_release"
@@ -79,6 +80,11 @@ interface LiveVoiceTurnTimestamps {
   utteranceEndAtMs: number | null;
   bargeInAtMs: number | null;
   finalTranscriptAtMs: number | null;
+  // First assistant-leg dispatch of the turn (first-wins across hold
+  // replays): the moment the felt-latency clock starts, unlike
+  // finalTranscriptAtMs which can predate the boundary by the caller's
+  // whole multi-segment utterance.
+  assistantDispatchAtMs: number | null;
   firstAssistantDeltaAtMs: number | null;
   firstTtsAudioAtMs: number | null;
   completedAtMs: number | null;
@@ -90,6 +96,11 @@ interface LiveVoiceTurnDurations {
   pttReleaseToFinalTranscriptMs: number | null;
   utteranceEndToFinalTranscriptMs: number | null;
   finalTranscriptToFirstAssistantDeltaMs: number | null;
+  // Dispatch-anchored versions of the two numbers above: what the leg (and
+  // the caller's ear) actually waited, immune to final-transcript anchor
+  // inflation on multi-segment utterances.
+  dispatchToFirstAssistantDeltaMs: number | null;
+  dispatchToFirstTtsAudioMs: number | null;
   firstAssistantDeltaToFirstTtsAudioMs: number | null;
   // End-of-speech (utterance_end, or ptt_release in manual mode) to first
   // TTS audio: the server-side turn round trip.
@@ -143,6 +154,11 @@ interface LiveVoiceMetricsSnapshot {
 interface LiveVoiceMetricsAggregateFields {
   sttMs: number | null;
   llmFirstDeltaMs: number | null;
+  // Dispatch-anchored felt latency: leg dispatch to first delta / first TTS
+  // audio, immune to the final-transcript anchor inflation llmFirstDeltaMs
+  // suffers on multi-segment utterances.
+  dispatchToFirstDeltaMs: number | null;
+  dispatchToFirstAudioMs: number | null;
   ttsFirstAudioMs: number | null;
   roundTripMs: number | null;
   totalMs: number | null;
@@ -230,6 +246,7 @@ export class LiveVoiceMetricsCollector {
         utteranceEndAtMs: null,
         bargeInAtMs: null,
         finalTranscriptAtMs: null,
+        assistantDispatchAtMs: null,
         firstAssistantDeltaAtMs: null,
         firstTtsAudioAtMs: null,
         completedAtMs: null,
@@ -359,6 +376,14 @@ export class LiveVoiceMetricsCollector {
       turn.timestamps.finalTranscriptAtMs = this.timestamp();
     }
     return this.emit("final_transcript", turn.turnId);
+  }
+
+  markAssistantDispatch(turnId?: string): LiveVoiceMetricsFrame {
+    const turn = this.ensureActiveTurn(turnId);
+    if (turn.timestamps.assistantDispatchAtMs === null) {
+      turn.timestamps.assistantDispatchAtMs = this.timestamp();
+    }
+    return this.emit("assistant_dispatch", turn.turnId);
   }
 
   markFirstAssistantDelta(turnId?: string): LiveVoiceMetricsFrame {
@@ -516,6 +541,8 @@ export function getLiveVoiceMetricsAggregateFields(
     return {
       sttMs: null,
       llmFirstDeltaMs: null,
+      dispatchToFirstDeltaMs: null,
+      dispatchToFirstAudioMs: null,
       ttsFirstAudioMs: null,
       roundTripMs: null,
       totalMs: null,
@@ -535,6 +562,8 @@ function aggregateFieldsForTurn(
       turn.durations.pttReleaseToFinalTranscriptMs ??
       turn.durations.utteranceEndToFinalTranscriptMs,
     llmFirstDeltaMs: turn.durations.finalTranscriptToFirstAssistantDeltaMs,
+    dispatchToFirstDeltaMs: turn.durations.dispatchToFirstAssistantDeltaMs,
+    dispatchToFirstAudioMs: turn.durations.dispatchToFirstTtsAudioMs,
     ttsFirstAudioMs: turn.durations.firstAssistantDeltaToFirstTtsAudioMs,
     roundTripMs: turn.durations.roundTripMs,
     totalMs: turn.durations.totalTurnDurationMs,
@@ -636,6 +665,14 @@ function snapshotTurn(turn: MutableTurn): LiveVoiceTurnMetrics {
       finalTranscriptToFirstAssistantDeltaMs: duration(
         timestamps.finalTranscriptAtMs,
         timestamps.firstAssistantDeltaAtMs,
+      ),
+      dispatchToFirstAssistantDeltaMs: duration(
+        timestamps.assistantDispatchAtMs,
+        timestamps.firstAssistantDeltaAtMs,
+      ),
+      dispatchToFirstTtsAudioMs: duration(
+        timestamps.assistantDispatchAtMs,
+        timestamps.firstTtsAudioAtMs,
       ),
       firstAssistantDeltaToFirstTtsAudioMs: duration(
         timestamps.firstAssistantDeltaAtMs,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -25,7 +25,9 @@ import {
   ESCALATION_CONTINUATION_CONTENT,
   FALLBACK_ESCALATION_BRIDGE,
   FRONT_DOOR_PROFILE,
+  HOLD_VERDICT_TOKEN,
   isVoiceTriageEscalateEnabled,
+  isVoiceUnifiedFrontDoorEnabled,
   needsFallbackBridge,
   type VoiceRoutingLeg,
 } from "../calls/voice-triage-escalate.js";
@@ -425,6 +427,22 @@ interface ActiveAssistantTurn {
   // forwarded chunk so the firstTtsAudio metric is marked exactly once per turn.
   ttsAudioStarted: boolean;
   finalized: boolean;
+  // Unified front-door speculative dispatch: the leg is in flight but its
+  // first token's verdict (hold vs commit) has not arrived. The thinking
+  // frame, ack timer, and progress timer are deferred to commit; a hold
+  // verdict discards the leg and rolls back its persisted user message.
+  speculativePending: boolean;
+  // vadSpeechGeneration at dispatch — a mismatch at verdict time means
+  // speech resumed mid-flight, so the leg is discarded, never committed.
+  speculativeGeneration: number;
+  // The dispatched (pre-finalize) transcript, kept until the final
+  // transcript lands so divergence can be logged (see
+  // startAssistantTurnIfReady). Null once checked or for normal turns.
+  speculativeContent: string | null;
+  speculativeDispatchedAtMs: number;
+  // Accumulates leg deltas until the verdict resolves (whitespace-only
+  // prefixes carry no verdict).
+  speculativeBuffer: string;
   // When this turn started from a barge-in, the interrupted request's
   // transcript. Appended to the turn's control prompt (both legs) so the model
   // merges it with this turn's utterance instead of treating that utterance as
@@ -1274,6 +1292,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.vadSpeechGeneration += 1;
     this.clearEndpointExtensionTimer();
 
+    // Speech resumed while a speculative leg was awaiting its verdict: the
+    // pause was mid-thought after all. Discard silently (no frames were ever
+    // sent for it) and let the utterance keep accumulating — this is the
+    // hold outcome decided by the caller's own voice instead of the model.
+    const speculative = this.activeAssistantTurn;
+    if (speculative?.speculativePending) {
+      this.discardSpeculativeTurn(speculative, "speech_resumed");
+    }
+
     const turn = this.activeAssistantTurn;
     // Any in-flight, non-finalized turn is interruptible, whether it is still
     // "thinking" (pre-TTS) or audibly speaking, so a user can cut in before the
@@ -1578,9 +1605,21 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // event ordering — an extra await here would shift utterance release
       // across the persistent-transcriber flush attribution.
       if (reason === "silence" && !manualRelease) {
-        const holdDecision = this.maybeHoldUtteranceOpen(utterance);
-        if (holdDecision && (await holdDecision)) {
-          return;
+        if (this.unifiedFrontDoorActive()) {
+          // Unified front-door: the leg itself is the endpoint decision.
+          // When it launches, the boundary is deferred to the verdict —
+          // commit releases the utterance, hold replays the boundary via
+          // the extension timer. When speculation is inapplicable (no
+          // text, cap reached, a turn already active) fall through and
+          // release exactly as before.
+          if (await this.launchSpeculativeAssistantTurn(utterance)) {
+            return;
+          }
+        } else {
+          const holdDecision = this.maybeHoldUtteranceOpen(utterance);
+          if (holdDecision && (await holdDecision)) {
+            return;
+          }
         }
       }
       await this.sendFrame({ type: "utterance_end", reason });
@@ -1694,6 +1733,159 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
       this.handleVadUtteranceEnd("silence");
     }, this.frontModelConfig.endpointExtensionMs);
+  }
+
+  /**
+   * Whether unified front-door endpointing is active: the voice-mode
+   * surface, triage-escalate routing, and the unified flag all on. The
+   * decider-based hold path is skipped entirely when this holds.
+   */
+  private unifiedFrontDoorActive(): boolean {
+    const cfg = getConfig();
+    return (
+      isAssistantFeatureFlagEnabled("voice-mode", cfg) &&
+      isVoiceTriageEscalateEnabled(cfg) &&
+      isVoiceUnifiedFrontDoorEnabled(cfg)
+    );
+  }
+
+  /**
+   * Unified front-door: dispatch the assistant turn speculatively at the
+   * silence boundary, judging the transcript accumulated so far — the same
+   * text the endpoint decider judges today. In persistent-transcriber mode
+   * finals stream continuously (utteranceEnd→finalTranscript measures ~0ms),
+   * so this matches the eventual final transcript in practice; divergence is
+   * logged in startAssistantTurnIfReady. Returns false when speculation is
+   * inapplicable — the boundary then releases exactly as before.
+   */
+  private async launchSpeculativeAssistantTurn(
+    utterance: UtteranceCycle,
+  ): Promise<boolean> {
+    if (
+      utterance.endpointExtensionCount >=
+        this.frontModelConfig.endpointMaxExtensions ||
+      utterance.assistantTurnStarted ||
+      this.activeAssistantTurn !== null ||
+      !this.startVoiceTurn
+    ) {
+      return false;
+    }
+    const transcriptSoFar = utterance.finalTranscriptSegments.join(" ").trim();
+    const content = [transcriptSoFar, utterance.latestPartialText ?? ""]
+      .join(" ")
+      .trim();
+    if (content.length === 0) {
+      return false;
+    }
+    await this.launchAssistantTurn(utterance, content, { speculative: true });
+    return true;
+  }
+
+  /**
+   * Commit a speculative turn: the leg's first token was a real answer (or
+   * an escalation bridge), so the deferred boundary work happens now —
+   * utterance_end + thinking frames, utterance release (which finalizes the
+   * transcriber), and the floor-holding timers. Returns false when the
+   * world moved on mid-flight (speech resumed, utterance superseded): the
+   * leg is discarded and the caller must swallow the delta.
+   */
+  private commitSpeculativeTurn(turn: ActiveAssistantTurn): boolean {
+    if (!turn.speculativePending) {
+      return true;
+    }
+    const utterance = turn.utterance;
+    if (
+      turn.speculativeGeneration !== this.vadSpeechGeneration ||
+      this.isUtteranceStale(utterance) ||
+      utterance.released ||
+      utterance.completed
+    ) {
+      this.discardSpeculativeTurn(turn, "superseded");
+      return false;
+    }
+    turn.speculativePending = false;
+    void this.sendFrame({ type: "utterance_end", reason: "silence" });
+    void this.sendFrame({ type: "thinking", turnId: turn.turnId });
+    void this.releaseUtterance();
+    if (this.streamTtsAudio) {
+      this.armAckTimer(turn);
+    }
+    if (
+      this.frontModelConfig.progress.enabled &&
+      this.streamTtsAudio &&
+      this.frontDecider
+    ) {
+      this.armProgressIdleTimer(turn);
+    }
+    return true;
+  }
+
+  /**
+   * Hold verdict on a speculative turn: the model judged the pause
+   * mid-thought. Discard the leg (rolling back its persisted user message)
+   * and extend the listening window exactly as a decider hold does — the
+   * extension timer replays the silence boundary, which re-speculates.
+   */
+  private async holdSpeculativeTurn(turn: ActiveAssistantTurn): Promise<void> {
+    if (
+      this.activeAssistantTurn?.token !== turn.token ||
+      !turn.speculativePending
+    ) {
+      return;
+    }
+    const utterance = turn.utterance;
+    const decisionLatencyMs = Math.max(
+      0,
+      Date.now() - turn.speculativeDispatchedAtMs,
+    );
+    this.discardSpeculativeTurn(turn, "hold_verdict");
+    if (
+      this.isUtteranceStale(utterance) ||
+      utterance.released ||
+      utterance.completed ||
+      turn.speculativeGeneration !== this.vadSpeechGeneration
+    ) {
+      // Speech resumed or the utterance moved on during the verdict: the
+      // discard was the whole job; a fresh boundary owns the release.
+      return;
+    }
+    this.markEndpointDecision(utterance, "hold", decisionLatencyMs);
+    utterance.endpointExtensionCount += 1;
+    this.armEndpointExtensionTimer(utterance);
+  }
+
+  /**
+   * Abort a speculative leg and roll back everything it touched: the
+   * persisted user message (via the handle's discard), the active-turn
+   * slot, and the utterance's turn-started latch, so the utterance can be
+   * re-dispatched (hold replay) or keep accumulating (speech resumed).
+   * Nothing was ever user-visible — no frames were sent for this turn.
+   */
+  private discardSpeculativeTurn(
+    turn: ActiveAssistantTurn,
+    reason: string,
+  ): void {
+    turn.speculativePending = false;
+    if (this.activeAssistantTurn?.token === turn.token) {
+      this.activeAssistantTurn = null;
+    }
+    this.clearFillerTimers(turn);
+    turn.abortController.abort(
+      createAbortReason("voice_session_aborted", `live-voice-${reason}`),
+    );
+    const handle = turn.handle;
+    turn.handle = null;
+    void handle?.discard?.().catch((err: unknown) => {
+      log.warn(
+        { err, turnId: turn.turnId, reason },
+        "Speculative voice turn discard failed",
+      );
+    });
+    turn.utterance.assistantTurnStarted = false;
+    log.info(
+      { turnId: turn.turnId, reason },
+      "Speculative voice turn discarded",
+    );
   }
 
   private clearEndpointExtensionTimer(): void {
@@ -2179,6 +2371,33 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private async startAssistantTurnIfReady(): Promise<void> {
     const utterance = this.currentUtterance;
+    // A committed speculative turn answered the pre-finalize transcript;
+    // once the finalized transcript lands, log if they diverged (the finals
+    // stream continuously in persistent mode, so divergence should be rare
+    // — this measures whether that assumption holds in the field).
+    const committed = this.activeAssistantTurn;
+    if (
+      utterance?.assistantTurnStarted &&
+      committed?.speculativeContent != null &&
+      !committed.speculativePending &&
+      utterance.phase === "transcriber_closed"
+    ) {
+      const finalContent = utterance.finalTranscriptSegments.join(" ").trim();
+      if (
+        finalContent.length > 0 &&
+        finalContent !== committed.speculativeContent
+      ) {
+        log.warn(
+          {
+            turnId: committed.turnId,
+            speculative: committed.speculativeContent,
+            final: finalContent,
+          },
+          "Speculative voice turn content diverged from final transcript",
+        );
+      }
+      committed.speculativeContent = null;
+    }
     if (
       !utterance ||
       !utterance.released ||
@@ -2239,6 +2458,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // Set when a background continuation finished the interrupted reply: its
       // answer, appended to the turn's control prompt as context.
       continuationResult?: string | null;
+      // Unified front-door: dispatch without releasing the utterance. The
+      // thinking frame and floor-holding timers are deferred until the leg's
+      // first token commits the turn (see commitSpeculativeTurn); a hold
+      // verdict rolls everything back instead.
+      speculative?: boolean;
     },
   ): Promise<void> {
     utterance.assistantTurnStarted = true;
@@ -2266,6 +2490,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ttsDone: false,
       ttsAudioStarted: false,
       finalized: false,
+      speculativePending: opts?.speculative === true,
+      speculativeGeneration: this.vadSpeechGeneration,
+      speculativeContent: opts?.speculative === true ? content : null,
+      speculativeDispatchedAtMs: Date.now(),
+      speculativeBuffer: "",
       interruptedRequest: opts?.interruptedRequest ?? null,
       continuationResult: opts?.continuationResult ?? null,
       toolUseStarted: false,
@@ -2285,9 +2514,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     };
     this.activeAssistantTurn = activeTurn;
 
-    await this.sendFrame({ type: "thinking", turnId });
-    if (!this.isActiveAssistantTurn(token)) {
-      return;
+    // A speculative turn defers the thinking frame and both floor-holding
+    // timers to commitSpeculativeTurn: until the verdict arrives, the pause
+    // may still be mid-thought and nothing must be user-visible.
+    if (!opts?.speculative) {
+      await this.sendFrame({ type: "thinking", turnId });
+      if (!this.isActiveAssistantTurn(token)) {
+        return;
+      }
     }
 
     const cfg = getConfig();
@@ -2295,7 +2529,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Slow-first-delta spoken ack: if the model produces no delta within the
     // budget, a short static phrase holds the floor. Only meaningful on TTS
     // sessions — a text-only session has no audio gap to bridge.
-    if (this.streamTtsAudio) {
+    if (this.streamTtsAudio && !opts?.speculative) {
       this.armAckTimer(activeTurn);
     }
 
@@ -2306,7 +2540,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (
       this.frontModelConfig.progress.enabled &&
       this.streamTtsAudio &&
-      this.frontDecider
+      this.frontDecider &&
+      !opts?.speculative
     ) {
       this.armProgressIdleTimer(activeTurn);
     }
@@ -2436,10 +2671,36 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           ? { overrideProfile: leg.overrideProfile }
           : {}),
         ...(leg.routingLeg != null ? { routingLeg: leg.routingLeg } : {}),
+        // A speculative front-door leg carries the hold rule so its first
+        // token can be the hold verdict; non-speculative legs must never
+        // learn the token, or a spoken answer could start with it.
+        ...(activeTurn.speculativePending && leg.frontDoor
+          ? { unifiedVerdict: true }
+          : {}),
         callbacks: {
           assistant_text_delta: (msg) => {
             if (!this.isForwardingAssistantText(token)) {
               return;
+            }
+            // Unified front-door verdict: the first non-whitespace character
+            // of a speculative leg decides the turn's fate. The hold token
+            // discards it (mid-thought pause, keep listening); anything else
+            // commits — utterance release, thinking frame, and timers all
+            // happen inside commitSpeculativeTurn, then this delta falls
+            // through into the normal leg handling below.
+            if (activeTurn.speculativePending) {
+              activeTurn.speculativeBuffer += msg.text;
+              const leading = activeTurn.speculativeBuffer.trimStart();
+              if (leading.length === 0) {
+                return;
+              }
+              if (leg.frontDoor && leading.startsWith(HOLD_VERDICT_TOKEN)) {
+                void this.holdSpeculativeTurn(activeTurn);
+                return;
+              }
+              if (!this.commitSpeculativeTurn(activeTurn)) {
+                return;
+              }
             }
             if (leg.frontDoor) {
               rawText += msg.text;
@@ -2480,6 +2741,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               this.isClosed
             ) {
               return;
+            }
+            // A speculative leg that finished without a single delta (empty
+            // output, provider hiccup) carries no verdict — fail open to a
+            // committed turn so the utterance releases and finalizes like a
+            // normal empty completion instead of dangling un-released.
+            if (current.speculativePending) {
+              this.commitSpeculativeTurn(current);
             }
             // A front-door leg that handed off is finished; the escalated leg
             // drives completion. The front-door leg's own trailing completion

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -2431,6 +2431,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         voiceControlPrompt: buildVoiceControlPrompt(activeTurn),
         content: leg.content,
         isInbound: true,
+        launchedAtMs: activeTurn.launchedAtMs,
         signal: activeTurn.abortController.signal,
         ...(leg.overrideProfile != null
           ? { overrideProfile: leg.overrideProfile }
@@ -4023,10 +4024,21 @@ async function defaultStartVoiceTurn(
   // the turn resolved to the fail-closed `unknown` trust class and every
   // sensitive tool was denied. Resolution stays fail-closed: a gateway miss /
   // missing binding leaves the context unset (`unknown`), never a blind grant.
+  const trustStartedAt = performance.now();
   const trustContext = await resolveLocalLiveVoiceTrustContext(
     options.conversationId,
   );
+  const trustMs = Math.round(performance.now() - trustStartedAt);
   const { startVoiceTurn } = await import("../calls/voice-session-bridge.js");
+  log.info(
+    {
+      conversationId: options.conversationId,
+      trustMs,
+      sinceLaunchMs:
+        options.launchedAtMs != null ? Date.now() - options.launchedAtMs : null,
+    },
+    "Voice turn pre-bridge timing",
+  );
   return startVoiceTurn({
     ...options,
     ...(trustContext ? { trustContext } : {}),

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -26,7 +26,6 @@ import {
   ESCALATE_VERDICT_TOKEN,
   ESCALATION_CONTINUATION_CONTENT,
   FALLBACK_ESCALATION_BRIDGE,
-  FRONT_DOOR_PROFILE,
   isEscalationBridgeComplete,
   isVoiceTriageEscalateEnabled,
   isVoiceUnifiedFrontDoorEnabled,
@@ -2641,15 +2640,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       isAssistantFeatureFlagEnabled("voice-mode", cfg) &&
       isVoiceTriageEscalateEnabled(cfg);
 
-    // Front-door leg: with routing on, a fast profile fronts the turn and may
-    // hand off on the escalate verdict; with it off, a single leg runs on the
-    // call-site default — byte-for-byte the prior behavior.
+    // Front-door leg: with routing on, a fast model fronts the turn (the
+    // `voiceFrontDoor` call site pins it) and may hand off on the escalate
+    // verdict; with it off, a single leg runs on the call-site default —
+    // byte-for-byte the prior behavior.
     await this.startAssistantLeg(
       activeTurn,
       escalateEnabled
         ? {
             content,
-            overrideProfile: FRONT_DOOR_PROFILE,
             routingLeg: "front-door",
             frontDoor: true,
           }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -29,6 +29,7 @@ import {
   isVoiceTriageEscalateEnabled,
   isVoiceUnifiedFrontDoorEnabled,
   needsFallbackBridge,
+  spokenBridgeText,
   type VoiceRoutingLeg,
 } from "../calls/voice-triage-escalate.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
@@ -2580,8 +2581,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * (`frontDoor: true`) may emit [ESCALATE]; the marker and everything after it
    * are held back from the live-voice transcript and TTS here at the source,
    * and `escalateTurn` starts a second "escalated" leg that shares this same
-   * ActiveAssistantTurn. (The shared conversation-hub broadcast and persisted
-   * assistant message still carry the raw marker — see issue #37850.)
+   * ActiveAssistantTurn. The persisted assistant row is cut at the marker by
+   * the bridge's teardown transcript-hygiene pass; the shared conversation-hub
+   * broadcast still streams the raw marker deltas mid-turn until the
+   * turn-end resync (the remaining scope of issue #37850).
    */
   private async startAssistantLeg(
     activeTurn: ActiveAssistantTurn,
@@ -2590,6 +2593,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       overrideProfile?: string;
       routingLeg?: VoiceRoutingLeg;
       frontDoor?: boolean;
+      spokenEscalationBridge?: string;
     },
   ): Promise<void> {
     if (!this.startVoiceTurn) {
@@ -2671,6 +2675,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           ? { overrideProfile: leg.overrideProfile }
           : {}),
         ...(leg.routingLeg != null ? { routingLeg: leg.routingLeg } : {}),
+        ...(leg.spokenEscalationBridge != null
+          ? { spokenEscalationBridge: leg.spokenEscalationBridge }
+          : {}),
         // A speculative front-door leg carries the hold rule so its first
         // token can be the hold verdict; non-speculative legs must never
         // learn the token, or a spoken answer could start with it.
@@ -2929,7 +2936,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Speak a bridge so the strong-model call has no dead air. Fall back to a
     // canned phrase only when the front-door leg spoke too little before the
     // marker (measured pre-marker, so suppressed post-marker text can't count).
-    if (needsFallbackBridge(frontDoorText)) {
+    const usesFallbackBridge = needsFallbackBridge(frontDoorText);
+    if (usesFallbackBridge) {
       this.bufferAssistantTextForTts(
         activeTurn.token,
         `${FALLBACK_ESCALATION_BRIDGE} `,
@@ -2942,10 +2950,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     // No overrideProfile: the escalated leg runs on the call-site default —
     // the exact profile an un-routed voice turn would use (see
-    // voice-triage-escalate.ts).
+    // voice-triage-escalate.ts). The bridge phrase the caller just heard is
+    // handed along so the escalated continuation rule can quote it and ban
+    // a re-announcing echo ("Let me check…" twice in a row).
     void this.startAssistantLeg(activeTurn, {
       content: ESCALATION_CONTINUATION_CONTENT,
       routingLeg: "escalated",
+      spokenEscalationBridge: usesFallbackBridge
+        ? FALLBACK_ESCALATION_BRIDGE
+        : spokenBridgeText(frontDoorText),
     });
   }
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -23,7 +23,6 @@ import {
 } from "../calls/voice-session-bridge.js";
 import {
   ESCALATION_CONTINUATION_CONTENT,
-  ESCALATION_PROFILE,
   FALLBACK_ESCALATION_BRIDGE,
   FRONT_DOOR_PROFILE,
   isVoiceTriageEscalateEnabled,
@@ -2673,9 +2672,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // during the escalated model's call.
     this.flushTtsBuffer(activeTurn.token, true);
 
+    // No overrideProfile: the escalated leg runs on the call-site default —
+    // the exact profile an un-routed voice turn would use (see
+    // voice-triage-escalate.ts).
     void this.startAssistantLeg(activeTurn, {
       content: ESCALATION_CONTINUATION_CONTENT,
-      overrideProfile: ESCALATION_PROFILE,
       routingLeg: "escalated",
     });
   }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -311,6 +311,11 @@ interface UtteranceCycle {
   // Consecutive semantic-endpointing "hold" extensions this utterance has
   // consumed, bounded by `endpointMaxExtensions`.
   endpointExtensionCount: number;
+  // The transcript the most recent hold verdict judged (unified front-door).
+  // A final segment arriving during the extension window that extends this
+  // text replays the boundary immediately — the hold was judged on stale
+  // text, so waiting out the extension only adds silence.
+  heldSpeculativeContent: string | null;
   turnId: string | null;
   userMessageId: string | null;
   userAudioChunks: Buffer[];
@@ -442,6 +447,16 @@ interface ActiveAssistantTurn {
   // startAssistantTurnIfReady). Null once checked or for normal turns.
   speculativeContent: string | null;
   speculativeDispatchedAtMs: number;
+  // Whether this speculative leg may hold: true only on an utterance's FIRST
+  // dispatch. An extension replay already held once — a second silence means
+  // the caller is done, so the replay leg is not taught the hold token and
+  // its leading tokens can only escalate or answer.
+  speculativeHoldAllowed: boolean;
+  // Verdict-deadline fail-open: if a speculative leg produces no verdict
+  // within the endpoint budget, the turn commits anyway (thinking frame +
+  // ack timer arm) so a provider TTFT tail is bounded dead air instead of
+  // unbounded structural silence. Null once fired, cleared, or committed.
+  verdictDeadlineTimer: ReturnType<typeof setTimeout> | null;
   // Accumulates leg deltas until the verdict resolves (whitespace-only
   // prefixes carry no verdict).
   speculativeBuffer: string;
@@ -906,6 +921,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       finalTranscriptSegments: [],
       latestPartialText: null,
       endpointExtensionCount: 0,
+      heldSpeculativeContent: null,
       turnId: null,
       userMessageId: null,
       userAudioChunks: [],
@@ -1807,6 +1823,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return false;
     }
     turn.speculativePending = false;
+    if (turn.verdictDeadlineTimer !== null) {
+      clearTimeout(turn.verdictDeadlineTimer);
+      turn.verdictDeadlineTimer = null;
+    }
     void this.sendFrame({ type: "utterance_end", reason: "silence" });
     void this.sendFrame({ type: "thinking", turnId: turn.turnId });
     void this.releaseUtterance();
@@ -1854,6 +1874,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     this.markEndpointDecision(utterance, "hold", decisionLatencyMs);
     utterance.endpointExtensionCount += 1;
+    // Remember what the hold judged: a final segment arriving during the
+    // extension that extends this text replays the boundary immediately
+    // (see recordFinalTranscript) instead of waiting out the extension.
+    utterance.heldSpeculativeContent = turn.speculativeContent;
     this.armEndpointExtensionTimer(utterance);
   }
 
@@ -2299,6 +2323,36 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     utterance.latestPartialText = null;
     this.markFinalTranscript(utterance);
     await this.sendFrame({ type: "stt_final", text });
+    // Fresh-final fast replay (unified front-door): a hold judged on the
+    // pre-finalize partial is stale the moment the finalized transcript
+    // extends it — the caller already finished, so waiting out the extension
+    // window only adds silence. Replay the silence boundary now. Guards
+    // mirror the extension timer's own: still the current utterance, still
+    // unreleased, and the detector quiet (speech resuming owns the boundary).
+    if (
+      this.endpointExtensionTimer !== null &&
+      utterance.heldSpeculativeContent !== null &&
+      this.currentUtterance === utterance &&
+      !utterance.released &&
+      !utterance.completed &&
+      !this.turnDetector?.isActive
+    ) {
+      const contentNow = [
+        utterance.finalTranscriptSegments.join(" ").trim(),
+        utterance.latestPartialText ?? "",
+      ]
+        .join(" ")
+        .trim();
+      if (
+        contentNow.length > 0 &&
+        contentNow !== utterance.heldSpeculativeContent
+      ) {
+        this.clearEndpointExtensionTimer();
+        utterance.heldSpeculativeContent = null;
+        this.handleVadUtteranceEnd("silence");
+        return;
+      }
+    }
     await this.startAssistantTurnIfReady();
   }
 
@@ -2472,6 +2526,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const token = Symbol("live-voice-assistant-turn");
     const turnId = this.ensureTurnId(utterance);
     this.startMetricsTurnIfNeeded(utterance, turnId);
+    this.markAssistantDispatch(utterance, turnId);
     const abortController = new AbortController();
     const activeTurn: ActiveAssistantTurn = {
       token,
@@ -2497,6 +2552,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       speculativeGeneration: this.vadSpeechGeneration,
       speculativeContent: opts?.speculative === true ? content : null,
       speculativeDispatchedAtMs: Date.now(),
+      speculativeHoldAllowed:
+        opts?.speculative === true && utterance.endpointExtensionCount === 0,
+      verdictDeadlineTimer: null,
       speculativeBuffer: "",
       interruptedRequest: opts?.interruptedRequest ?? null,
       continuationResult: opts?.continuationResult ?? null,
@@ -2525,6 +2583,32 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       if (!this.isActiveAssistantTurn(token)) {
         return;
       }
+    } else {
+      // Verdict-deadline fail-open: the deferred-everything window is only
+      // safe while the verdict is fast. If the leg produces no verdict
+      // within the endpoint budget (provider TTFT tail), commit anyway so
+      // the thinking frame shows and the ack timer arms — bounded dead air
+      // instead of unbounded structural silence. A verdict that arrives
+      // after the commit still works: escalate hands off normally, and a
+      // late hold token is stripped like any stray token (the utterance is
+      // already released, so holding is no longer possible).
+      activeTurn.verdictDeadlineTimer = setTimeout(() => {
+        activeTurn.verdictDeadlineTimer = null;
+        if (
+          this.activeAssistantTurn?.token !== token ||
+          !activeTurn.speculativePending
+        ) {
+          return;
+        }
+        log.info(
+          {
+            turnId,
+            budgetMs: this.frontModelConfig.endpointDecisionTimeoutMs,
+          },
+          "Speculative verdict deadline elapsed; committing turn (fail-open)",
+        );
+        this.commitSpeculativeTurn(activeTurn);
+      }, this.frontModelConfig.endpointDecisionTimeoutMs);
     }
 
     const cfg = getConfig();
@@ -2689,10 +2773,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           ? { spokenEscalationBridge: leg.spokenEscalationBridge }
           : {}),
         // A speculative front-door leg's decision rule includes the hold
-        // branch so its leading tokens can be the hold verdict;
-        // non-speculative legs must never learn the token, or a spoken
-        // answer could start with it.
-        ...(activeTurn.speculativePending && leg.frontDoor
+        // branch so its leading tokens can be the hold verdict — but only
+        // on the utterance's FIRST dispatch. Extension replays (the
+        // utterance already held once) and non-speculative legs must never
+        // learn the token, or a spoken answer could start with it / a
+        // second hold could stack another silent extension.
+        ...(activeTurn.speculativePending &&
+        activeTurn.speculativeHoldAllowed &&
+        leg.frontDoor
           ? { unifiedVerdict: true }
           : {}),
         callbacks: {
@@ -2720,7 +2808,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               if (frontDoorStage === "deciding") {
                 const verdict = classifyFrontDoorLeading(
                   rawText.trimStart(),
-                  activeTurn.speculativePending,
+                  activeTurn.speculativePending &&
+                    activeTurn.speculativeHoldAllowed,
                 );
                 if (verdict === "pending") {
                   return;
@@ -3022,6 +3111,21 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       routingLeg: "escalated",
       spokenEscalationBridge: spokenBridge,
     });
+
+    // Escalated legs run the slowest work in the system (strong-model
+    // thinking + tool loops), and the bridge only covers the first couple of
+    // seconds of it — exactly the dead air progress narration exists for.
+    // Re-arm the idle narration timer (cleared above with the ack): its
+    // audible-silence gating means nothing speaks until the bridge audio has
+    // fully drained plus a whole idle interval. Acks stay suppressed
+    // post-handoff — the bridge already served that role.
+    if (
+      this.frontModelConfig.progress.enabled &&
+      this.streamTtsAudio &&
+      this.frontDecider
+    ) {
+      this.armProgressIdleTimer(activeTurn);
+    }
   }
 
   private async cancelAssistantTurn(reason: string): Promise<void> {
@@ -3195,14 +3299,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
   }
 
-  // Clears both filler timers (slow-first-delta ack + dead-air narration) for
-  // events that end the turn's filler lifecycle outright: escalation
-  // hand-off, barge-in, cancellation, tts-completion, finalize. Real output
-  // moots only the ack (markFirstDeltaForAck) — the narration timer keeps
-  // watching for mid-turn dead air.
+  // Clears the turn's filler timers (slow-first-delta ack, dead-air
+  // narration, verdict deadline) for events that end the current filler
+  // lifecycle: escalation hand-off (which then re-arms narration for the
+  // escalated leg), barge-in, cancellation, tts-completion, finalize. Real
+  // output moots only the ack (markFirstDeltaForAck) — the narration timer
+  // keeps watching for mid-turn dead air.
   private clearFillerTimers(turn: ActiveAssistantTurn): void {
     this.clearAckTimer(turn);
     this.clearProgressIdleTimer(turn);
+    if (turn.verdictDeadlineTimer !== null) {
+      clearTimeout(turn.verdictDeadlineTimer);
+      turn.verdictDeadlineTimer = null;
+    }
   }
 
   // A spoken ack may only speak into a live turn's pre-first-delta dead air.
@@ -3225,11 +3334,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // the dead air it exists to fill is almost always mid-turn, after the
   // model's opening words. It may speak whenever the live turn is audibly
   // silent right now — nothing streaming, queued, or still playing — and has
-  // not escalated (the bridge phrase holds the floor) or completed.
+  // not completed. Escalated turns qualify too: the bridge phrase holds the
+  // floor only while its audio plays (covered by the audible-idle check),
+  // and the strong leg's tool loops are the longest dead air in the system.
   private turnCanNarrateProgress(turn: ActiveAssistantTurn): boolean {
     return (
       this.isActiveAssistantTurn(turn.token) &&
-      !turn.escalationHandedOff &&
       !turn.assistantCompleted &&
       this.turnAudioIdle(turn)
     );
@@ -3852,6 +3962,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
     this.metrics.markFirstAssistantDelta(turnId);
+  }
+
+  // First-wins across an utterance's hold replays: the anchor stays at the
+  // FIRST dispatch, so the dispatch-anchored durations include the hold
+  // pipeline the caller actually sat through.
+  private markAssistantDispatch(
+    utterance: UtteranceCycle,
+    turnId: string,
+  ): void {
+    if (!this.startMetricsTurnIfNeeded(utterance, turnId)) {
+      return;
+    }
+    this.metrics.markAssistantDispatch(turnId);
   }
 
   private markEndpointDecision(

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -456,6 +456,11 @@ interface ActiveAssistantTurn {
   // ack timer arm) so a provider TTFT tail is bounded dead air instead of
   // unbounded structural silence. Null once fired, cleared, or committed.
   verdictDeadlineTimer: ReturnType<typeof setTimeout> | null;
+  // The turn was discarded before its bridge handle resolved (speech can
+  // resume while startVoiceTurn is still persisting). The handle's arrival
+  // must complete the rollback via discard(), not a plain abort — otherwise
+  // the discarded pause's user row leaks into history.
+  discardRequested: boolean;
   // Accumulates leg deltas until the verdict resolves (whitespace-only
   // prefixes carry no verdict).
   speculativeBuffer: string;
@@ -1815,20 +1820,30 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (
       turn.speculativeGeneration !== this.vadSpeechGeneration ||
       this.isUtteranceStale(utterance) ||
-      utterance.released ||
       utterance.completed
     ) {
       this.discardSpeculativeTurn(turn, "superseded");
       return false;
     }
+    // `released` alone is NOT superseded: a manual release during the
+    // verdict window (releaseFromClient) means the caller explicitly asked
+    // to answer now — the verdict commits into the already-released
+    // utterance instead of discarding the only in-flight turn. The manual
+    // path already sent utterance_end and released the utterance, so those
+    // are skipped; the thinking frame and timers still apply.
+    const alreadyReleased = utterance.released;
     turn.speculativePending = false;
     if (turn.verdictDeadlineTimer !== null) {
       clearTimeout(turn.verdictDeadlineTimer);
       turn.verdictDeadlineTimer = null;
     }
-    void this.sendFrame({ type: "utterance_end", reason: "silence" });
+    if (!alreadyReleased) {
+      void this.sendFrame({ type: "utterance_end", reason: "silence" });
+    }
     void this.sendFrame({ type: "thinking", turnId: turn.turnId });
-    void this.releaseUtterance();
+    if (!alreadyReleased) {
+      void this.releaseUtterance();
+    }
     if (this.streamTtsAudio) {
       this.armAckTimer(turn);
     }
@@ -1863,12 +1878,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.discardSpeculativeTurn(turn, "hold_verdict");
     if (
       this.isUtteranceStale(utterance) ||
-      utterance.released ||
       utterance.completed ||
       turn.speculativeGeneration !== this.vadSpeechGeneration
     ) {
       // Speech resumed or the utterance moved on during the verdict: the
       // discard was the whole job; a fresh boundary owns the release.
+      return;
+    }
+    if (utterance.released) {
+      // Manual release during the verdict window: the caller explicitly
+      // said they are done, so the hold is moot — but this leg's only
+      // output was the hold token, so committing it would answer with
+      // nothing. Discard it (done above; assistantTurnStarted is reset)
+      // and start a fresh leg on the released utterance instead.
+      void this.startAssistantTurnIfReady();
       return;
     }
     this.markEndpointDecision(utterance, "hold", decisionLatencyMs);
@@ -1892,6 +1915,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     reason: string,
   ): void {
     turn.speculativePending = false;
+    // Latched before the handle check: when the discard beats the bridge
+    // handle's resolution (startVoiceTurn still persisting), the handle's
+    // arrival in startAssistantLeg completes the rollback via discard().
+    turn.discardRequested = true;
     if (this.activeAssistantTurn?.token === turn.token) {
       this.activeAssistantTurn = null;
     }
@@ -2554,6 +2581,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       speculativeHoldAllowed:
         opts?.speculative === true && utterance.endpointExtensionCount === 0,
       verdictDeadlineTimer: null,
+      discardRequested: false,
       speculativeBuffer: "",
       interruptedRequest: opts?.interruptedRequest ?? null,
       continuationResult: opts?.continuationResult ?? null,
@@ -3020,7 +3048,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
       const current = this.activeAssistantTurn;
       if (current?.token !== token) {
-        handle.abort();
+        // A discard that beat this handle's resolution still owes the
+        // rollback: a plain abort would leave the discarded pause's user
+        // row in history.
+        if (activeTurn.discardRequested && handle.discard) {
+          void handle.discard().catch((err: unknown) => {
+            log.warn(
+              { err, turnId: activeTurn.turnId },
+              "Late speculative voice turn discard failed",
+            );
+          });
+        } else {
+          handle.abort();
+        }
         return;
       }
       if (current.finalized) {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -8,7 +8,6 @@ import {
 import { sanitizeForTts } from "../calls/tts-text-sanitizer.js";
 import {
   couldBeControlMarker,
-  ESCALATE_MARKER,
   stripInternalSpeechMarkers,
 } from "../calls/voice-control-protocol.js";
 import type {
@@ -22,14 +21,16 @@ import {
   waitForPriorTurnTeardown,
 } from "../calls/voice-session-bridge.js";
 import {
+  capEscalationBridge,
+  classifyFrontDoorLeading,
+  ESCALATE_VERDICT_TOKEN,
   ESCALATION_CONTINUATION_CONTENT,
   FALLBACK_ESCALATION_BRIDGE,
   FRONT_DOOR_PROFILE,
-  HOLD_VERDICT_TOKEN,
+  isEscalationBridgeComplete,
   isVoiceTriageEscalateEnabled,
   isVoiceUnifiedFrontDoorEnabled,
-  needsFallbackBridge,
-  spokenBridgeText,
+  MIN_SPOKEN_BRIDGE_CHARS,
   type VoiceRoutingLeg,
 } from "../calls/voice-triage-escalate.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
@@ -429,7 +430,7 @@ interface ActiveAssistantTurn {
   ttsAudioStarted: boolean;
   finalized: boolean;
   // Unified front-door speculative dispatch: the leg is in flight but its
-  // first token's verdict (hold vs commit) has not arrived. The thinking
+  // leading verdict (hold vs commit) has not arrived. The thinking
   // frame, ack timer, and progress timer are deferred to commit; a hold
   // verdict discards the leg and rolls back its persisted user message.
   speculativePending: boolean;
@@ -475,8 +476,9 @@ interface ActiveAssistantTurn {
   ackGenerationPending: boolean;
   // Pending slow-first-delta ack timer; null once cleared or fired.
   ackTimer: ReturnType<typeof setTimeout> | null;
-  // Triage-and-escalate (Voice Mode): the front-door leg emitted [ESCALATE]
-  // and the strong "escalated" leg has taken over this same turn. Guards the
+  // Triage-and-escalate (Voice Mode): the front-door leg gave the escalate
+  // verdict and the strong "escalated" leg has taken over this same turn.
+  // Guards the
   // front-door leg's trailing completion from finalizing the turn, and makes
   // the hand-off idempotent.
   escalationHandedOff: boolean;
@@ -1783,8 +1785,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   /**
-   * Commit a speculative turn: the leg's first token was a real answer (or
-   * an escalation bridge), so the deferred boundary work happens now —
+   * Commit a speculative turn: the leg's leading tokens were a real answer
+   * (or the escalate verdict), so the deferred boundary work happens now —
    * utterance_end + thinking frames, utterance release (which finalizes the
    * transcriber), and the floor-holding timers. Returns false when the
    * world moved on mid-flight (speech resumed, utterance superseded): the
@@ -2461,7 +2463,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       continuationResult?: string | null;
       // Unified front-door: dispatch without releasing the utterance. The
       // thinking frame and floor-holding timers are deferred until the leg's
-      // first token commits the turn (see commitSpeculativeTurn); a hold
+      // leading verdict commits the turn (see commitSpeculativeTurn); a hold
       // verdict rolls everything back instead.
       speculative?: boolean;
     },
@@ -2556,8 +2558,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       isVoiceTriageEscalateEnabled(cfg);
 
     // Front-door leg: with routing on, a fast profile fronts the turn and may
-    // hand off to the strong profile on [ESCALATE]; with it off, a single leg
-    // runs on the call-site default — byte-for-byte the prior behavior.
+    // hand off on the escalate verdict; with it off, a single leg runs on the
+    // call-site default — byte-for-byte the prior behavior.
     await this.startAssistantLeg(
       activeTurn,
       escalateEnabled
@@ -2578,13 +2580,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * callback-driven via message_complete, exactly as the single-leg path did.
    *
    * A turn runs one leg normally. Under triage-and-escalate the front-door leg
-   * (`frontDoor: true`) may emit [ESCALATE]; the marker and everything after it
-   * are held back from the live-voice transcript and TTS here at the source,
+   * (`frontDoor: true`) runs the verdict-first protocol: its leading tokens
+   * classify as hold / escalate / answer before anything is spoken. On the
+   * escalate verdict the post-verdict stream buffers into the capped bridge
    * and `escalateTurn` starts a second "escalated" leg that shares this same
-   * ActiveAssistantTurn. The persisted assistant row is cut at the marker by
-   * the bridge's teardown transcript-hygiene pass; the shared conversation-hub
-   * broadcast still streams the raw marker deltas mid-turn until the
-   * turn-end resync (the remaining scope of issue #37850).
+   * ActiveAssistantTurn. The persisted assistant row is reduced to the capped
+   * bridge by the bridge's teardown transcript-hygiene pass; the shared
+   * conversation-hub broadcast still streams the raw verdict deltas mid-turn
+   * until the turn-end resync (the remaining scope of issue #37850).
    */
   private async startAssistantLeg(
     activeTurn: ActiveAssistantTurn,
@@ -2601,12 +2604,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     const { token, utterance, turnId } = activeTurn;
 
-    // Front-door marker gate. `rawText` accumulates this leg's full stream (for
-    // marker detection and the fallback-bridge decision); `frontDoorEmitted`
-    // tracks how much of it has been forwarded, so a trailing partial marker
-    // held back on one delta is released once a later delta disproves it.
+    // Front-door verdict gate (verdict-first protocol — see
+    // voice-triage-escalate.ts). `rawText` accumulates this leg's full
+    // stream; the leg starts in `deciding` until its leading tokens
+    // classify as hold / escalate / answer. An answer flushes through
+    // `flushFrontDoor` (with `frontDoorEmitted` tracking what has been
+    // forwarded); an escalation buffers the post-verdict stream into
+    // `bridgeRaw` until the bridge is complete, then hands off.
     let rawText = "";
     let frontDoorEmitted = 0;
+    let frontDoorStage: "deciding" | "answer" | "bridging" | "handedOff" =
+      "deciding";
+    let bridgeRaw = "";
 
     const emitFrontDoor = (chunk: string): void => {
       if (chunk.length === 0) {
@@ -2625,26 +2634,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.bufferAssistantTextForTts(token, chunk);
     };
 
-    // Forward the marker-free, non-partial-marker prefix that has not been
-    // emitted yet. Returns true once the complete [ESCALATE] marker arrives.
-    const flushFrontDoor = (): boolean => {
-      const markerIdx = rawText.indexOf(ESCALATE_MARKER, frontDoorEmitted);
-      if (markerIdx !== -1) {
-        emitFrontDoor(
-          stripInternalSpeechMarkers(
-            rawText.slice(frontDoorEmitted, markerIdx),
-          ),
-        );
-        // Suppress the marker and anything the model streams after it.
-        frontDoorEmitted = rawText.length;
-        return true;
-      }
+    // Forward the stripped, non-partial-marker prefix that has not been
+    // emitted yet (answer stage only). A trailing "[…" that could still
+    // become a control marker is held back until a later delta disproves
+    // it; a real partial that never completes is simply never spoken.
+    const flushFrontDoor = (): void => {
       let safeEnd = rawText.length;
       const lastOpen = rawText.lastIndexOf("[");
       if (lastOpen >= frontDoorEmitted) {
         const tail = rawText.slice(lastOpen);
-        // Hold back a trailing "[…" that could still become a control marker;
-        // a real partial that never completes is simply never spoken.
         if (!tail.includes("]") && couldBeControlMarker(tail)) {
           safeEnd = lastOpen;
         }
@@ -2655,7 +2653,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         );
         frontDoorEmitted = safeEnd;
       }
-      return false;
+    };
+
+    // Hand off once enough of the post-verdict stream has arrived to cap
+    // the bridge (sentence terminator or hard cap). Until then nothing is
+    // spoken — the bridge goes out in one piece at hand-off, so the audio,
+    // the persisted row, and the phrase quoted to the escalated leg are all
+    // the same capped text.
+    const maybeHandOffBridge = (): void => {
+      if (!isEscalationBridgeComplete(bridgeRaw)) {
+        return;
+      }
+      frontDoorStage = "handedOff";
+      this.escalateTurn(activeTurn, capEscalationBridge(bridgeRaw));
     };
 
     try {
@@ -2678,9 +2688,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         ...(leg.spokenEscalationBridge != null
           ? { spokenEscalationBridge: leg.spokenEscalationBridge }
           : {}),
-        // A speculative front-door leg carries the hold rule so its first
-        // token can be the hold verdict; non-speculative legs must never
-        // learn the token, or a spoken answer could start with it.
+        // A speculative front-door leg's decision rule includes the hold
+        // branch so its leading tokens can be the hold verdict;
+        // non-speculative legs must never learn the token, or a spoken
+        // answer could start with it.
         ...(activeTurn.speculativePending && leg.frontDoor
           ? { unifiedVerdict: true }
           : {}),
@@ -2689,35 +2700,65 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             if (!this.isForwardingAssistantText(token)) {
               return;
             }
-            // Unified front-door verdict: the first non-whitespace character
-            // of a speculative leg decides the turn's fate. The hold token
-            // discards it (mid-thought pause, keep listening); anything else
-            // commits — utterance release, thinking frame, and timers all
-            // happen inside commitSpeculativeTurn, then this delta falls
-            // through into the normal leg handling below.
-            if (activeTurn.speculativePending) {
-              activeTurn.speculativeBuffer += msg.text;
-              const leading = activeTurn.speculativeBuffer.trimStart();
-              if (leading.length === 0) {
+            if (leg.frontDoor) {
+              rawText += msg.text;
+              if (frontDoorStage === "handedOff") {
                 return;
               }
-              if (leg.frontDoor && leading.startsWith(HOLD_VERDICT_TOKEN)) {
-                void this.holdSpeculativeTurn(activeTurn);
+              if (frontDoorStage === "bridging") {
+                bridgeRaw += msg.text;
+                maybeHandOffBridge();
+                return;
+              }
+              // Verdict-first: the leg's leading tokens decide the turn's
+              // fate. Hold discards a speculative turn (mid-thought pause,
+              // keep listening); escalate and answer both commit it —
+              // utterance release, thinking frame, and timers all happen
+              // inside commitSpeculativeTurn. The hold branch is only
+              // classifiable while the leg is speculative (its decision
+              // rule is the only one that teaches the hold token).
+              if (frontDoorStage === "deciding") {
+                const verdict = classifyFrontDoorLeading(
+                  rawText.trimStart(),
+                  activeTurn.speculativePending,
+                );
+                if (verdict === "pending") {
+                  return;
+                }
+                if (verdict === "hold") {
+                  void this.holdSpeculativeTurn(activeTurn);
+                  return;
+                }
+                if (
+                  activeTurn.speculativePending &&
+                  !this.commitSpeculativeTurn(activeTurn)
+                ) {
+                  return;
+                }
+                if (verdict === "escalate") {
+                  frontDoorStage = "bridging";
+                  bridgeRaw = rawText
+                    .trimStart()
+                    .slice(ESCALATE_VERDICT_TOKEN.length);
+                  maybeHandOffBridge();
+                  return;
+                }
+                frontDoorStage = "answer";
+              }
+              flushFrontDoor();
+              return;
+            }
+            // Defensive: speculative legs are always front-door today, but a
+            // non-front-door speculative leg must still fail open to a
+            // committed turn on its first delta rather than dangle.
+            if (activeTurn.speculativePending) {
+              activeTurn.speculativeBuffer += msg.text;
+              if (activeTurn.speculativeBuffer.trimStart().length === 0) {
                 return;
               }
               if (!this.commitSpeculativeTurn(activeTurn)) {
                 return;
               }
-            }
-            if (leg.frontDoor) {
-              rawText += msg.text;
-              if (activeTurn.escalationHandedOff) {
-                return;
-              }
-              if (flushFrontDoor()) {
-                this.escalateTurn(activeTurn, rawText);
-              }
-              return;
             }
             this.markFirstAssistantDelta(utterance, turnId);
             this.markFirstDeltaForAck(activeTurn);
@@ -2755,6 +2796,22 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             // normal empty completion instead of dangling un-released.
             if (current.speculativePending) {
               this.commitSpeculativeTurn(current);
+            }
+            // A front-door leg that stopped mid-bridge (a bare escalate
+            // verdict, or a holding phrase with no sentence terminator)
+            // hands off now with whatever arrived; the canned fallback
+            // covers an empty bridge. A cancellation mid-bridge falls
+            // through to normal cancelled finalization instead — a dead
+            // turn must not spawn an escalated leg.
+            if (
+              leg.frontDoor &&
+              frontDoorStage === "bridging" &&
+              msg.type === "message_complete" &&
+              !current.escalationHandedOff
+            ) {
+              frontDoorStage = "handedOff";
+              this.escalateTurn(current, capEscalationBridge(bridgeRaw));
+              return;
             }
             // A front-door leg that handed off is finished; the escalated leg
             // drives completion. The front-door leg's own trailing completion
@@ -2911,14 +2968,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   /**
    * Hand the turn from the front-door leg to the strong "escalated" leg after
-   * [ESCALATE]. Speaks a holding phrase (the front-door leg's own pre-marker
-   * text, or a canned fallback when that was too short) and force-flushes it so
-   * it plays during the strong-model call, then starts the escalated leg on the
-   * same ActiveAssistantTurn. Idempotent.
+   * the escalate verdict. Speaks the capped bridge (the leg's own post-verdict
+   * holding phrase, or the canned fallback when that was too short) in one
+   * piece and force-flushes it so it plays during the strong-model call, then
+   * starts the escalated leg on the same ActiveAssistantTurn. Idempotent.
    */
   private escalateTurn(
     activeTurn: ActiveAssistantTurn,
-    frontDoorText: string,
+    cappedBridge: string,
   ): void {
     if (activeTurn.escalationHandedOff || activeTurn.finalized) {
       return;
@@ -2928,21 +2985,28 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // slow-first-delta ack or progress narration would only stack a second
     // filler on top of it.
     this.clearFillerTimers(activeTurn);
-    // Abort the front-door leg so a model that keeps generating past the marker
-    // adds no latency before the escalated leg starts.
+    // Abort the front-door leg so a model that keeps generating past the
+    // bridge cap adds no latency before the escalated leg starts.
     activeTurn.handle?.abort();
     activeTurn.handle = null;
 
-    // Speak a bridge so the strong-model call has no dead air. Fall back to a
-    // canned phrase only when the front-door leg spoke too little before the
-    // marker (measured pre-marker, so suppressed post-marker text can't count).
-    const usesFallbackBridge = needsFallbackBridge(frontDoorText);
-    if (usesFallbackBridge) {
-      this.bufferAssistantTextForTts(
-        activeTurn.token,
-        `${FALLBACK_ESCALATION_BRIDGE} `,
+    // Speak the bridge so the strong-model call has no dead air. The model's
+    // own bridge is real assistant speech (captions + TTS); the canned
+    // fallback stays audio-only, matching the persisted-row hygiene (a
+    // deleted row for a bridge the model never produced).
+    const usesFallbackBridge = cappedBridge.length < MIN_SPOKEN_BRIDGE_CHARS;
+    const spokenBridge = usesFallbackBridge
+      ? FALLBACK_ESCALATION_BRIDGE
+      : cappedBridge;
+    if (!usesFallbackBridge) {
+      this.markFirstAssistantDelta(activeTurn.utterance, activeTurn.turnId);
+      this.markFirstDeltaForAck(activeTurn);
+      void this.sendFrame(
+        { type: "assistant_text_delta", text: spokenBridge },
+        () => !activeTurn.abortController.signal.aborted && !this.isClosed,
       );
     }
+    this.bufferAssistantTextForTts(activeTurn.token, `${spokenBridge} `);
     // Force-flush now: on the TTS path an unpunctuated bridge would otherwise
     // sit buffered until a sentence boundary and leave the caller in silence
     // during the escalated model's call.
@@ -2956,9 +3020,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     void this.startAssistantLeg(activeTurn, {
       content: ESCALATION_CONTINUATION_CONTENT,
       routingLeg: "escalated",
-      spokenEscalationBridge: usesFallbackBridge
-        ? FALLBACK_ESCALATION_BRIDGE
-        : spokenBridgeText(frontDoorText),
+      spokenEscalationBridge: spokenBridge,
     });
   }
 

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -108,6 +108,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "voice-unified-front-door",
+      "scope": "assistant",
+      "key": "voice-unified-front-door",
+      "label": "Voice Unified Front Door",
+      "description": "Merge live-voice endpointing into the triage front-door leg: one per-pause call whose first token decides hold / escalate / answer, replacing the separate endpoint-decider call",
+      "defaultEnabled": false
+    },
+    {
       "id": "voice-triage-escalate",
       "scope": "assistant",
       "key": "voice-triage-escalate",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -108,6 +108,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "voice-unified-front-door",
+      "scope": "assistant",
+      "key": "voice-unified-front-door",
+      "label": "Voice Unified Front Door",
+      "description": "Merge live-voice endpointing into the triage front-door leg: one per-pause call whose first token decides hold / escalate / answer, replacing the separate endpoint-decider call",
+      "defaultEnabled": false
+    },
+    {
       "id": "voice-triage-escalate",
       "scope": "assistant",
       "key": "voice-triage-escalate",


### PR DESCRIPTION
## What

Merges live-voice endpointing into the triage-and-escalate front-door leg: at each VAD silence boundary the front-door leg is dispatched speculatively and its **leading tokens are the verdict** — `[0]` (caller mid-thought; discard + keep listening), `[1]` + one short spoken holding phrase (escalate to the call-site default profile), or the answer itself streaming straight to TTS. This replaces the separate endpoint-decider call on that path (`decideEndpoint` is kept byte-identical for the flag-off path).

**Off by default.** Requires all three flags: `voice-mode` + `voice-triage-escalate` + `voice-unified-front-door` (registry entry included; gateway bakes its flag-registry copy at image build, so gateway must rebuild before the daemon sees the new key).

## Why

Live decomposition showed chatty turns paying 4.2–6.2s speech-end→first-token, of which ~0.6–1.2s was the decider stacking *before* dispatch and ~2.8s was provider TTFT on the full toolful prompt. With this branch, measured across four live sessions: direct answers hit **~0.8–1.7s dispatch→first-delta**, dispatch itself is 5–51ms, and escalations speak a bridge at ~1.1s while the strong model runs behind it.

## Design highlights

- **Front-door model**: pinned to `claude-haiku-4-5` via a new `voiceFrontDoor` LLM call site (same mechanism as `voiceFrontDecision`); overridable per-workspace via `llm.callSites.voiceFrontDoor` with no rebuild. The cost-optimized upstream showed multi-second cross-session TTFT tails and over-escalated under open-task context pressure.
- **Toolless front-door** (`toolsDisabledDepth` bracket) with a registry-derived capability digest so it routes instead of refusing/fabricating.
- **Decision rule** hardened against every live-drive failure mode observed: tokenless answer branch, answer-biased tiebreak, "caller has finished" on no-hold legs, open-task-in-history explicitly not an escalation trigger, silent decision, single-sentence bridge.
- **Bounded silent windows**: one hold per utterance (replay legs can't hold again); fresh-final fast replay (a finalized transcript that extends the held partial replays the boundary immediately); verdict-deadline fail-open (`endpointDecisionTimeoutMs`, default 1200ms → commit + thinking frame + ack timer).
- **Escalation hand-off**: bridge buffered and capped at one sentence, spoken in one piece — audio, persisted row, and the phrase quoted to the escalated leg are byte-identical; the escalated continuation rule quotes the exact bridge and bans re-announcement echo; progress-idle narration re-arms post-bridge for the strong leg's tool loops (acks stay suppressed).
- **Transcript hygiene** (issue #37850, escalation slice): a teardown pass in the bridge reduces an escalated front-door row to its spoken bridge, deletes discarded (hold) legs' rows, and reloads history before the escalated leg snapshots it. Per-leg action logging included.
- **Escalated leg runs the call-site default profile** — never weaker or stronger than an un-routed turn; honors user pins.

## Metrics note for dashboard consumers

`llmFirstDeltaMs` anchors to the final transcript, which on multi-segment utterances can predate the boundary by the whole utterance. New dispatch-anchored fields `dispatchToFirstDeltaMs` / `dispatchToFirstAudioMs` on the turn-latency frame are the honest felt-latency numbers.

## Known remaining (tracked in JARVIS-1320 thread)

- Hub broadcast still streams raw verdict-token deltas mid-turn until turn-end resync (remaining #37850 scope; live-voice frames and persistence are clean).
- Front-door model resolution via a real inference profile instead of the call-site model pin — deliberate follow-up; the team is deciding which profile shape to use.
- Offline verdict eval set (greetings / mid-thought / open-task chat / tool asks) is the agreed next step before rollout.
- Phone-path (call-controller) orchestration not wired; policy module is surface-agnostic.

## Testing

548+ voice tests green across `calls/` and `live-voice/` suites (single-file runs), including new coverage for the verdict classifier, bridge cap, hold-replay, verdict deadline, fresh-final replay, transcript hygiene, and escalated-leg narration. Validated across four live drive sessions with in-pod latency decomposition (`llm_request_logs.latency_breakdown`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
