### PR TITLE
security(ingress): block whole-message token-shaped secrets at ingress

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -94,6 +94,7 @@ describe("AssistantConfigSchema", () => {
       enabled: true,
       blockIngress: true,
       allowOneTimeSend: false,
+      blockTokenShapedMessages: true,
     });
     expect(result.auditLog).toEqual({ retentionDays: 0 });
   });

--- a/assistant/src/__tests__/secret-ingress.test.ts
+++ b/assistant/src/__tests__/secret-ingress.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { setConfig } from "./helpers/set-config.js";
@@ -237,6 +239,95 @@ describe("checkIngressForSecrets", () => {
     // AKIA followed by 16 repeated X characters
     const result = checkIngressForSecrets("AKIAXXXXXXXXXXXXXXXX");
     expect(result.blocked).toBe(false);
+  });
+
+  // ── Token-shaped whole-message heuristic ───────────────────────────
+
+  // Synthetic token mirroring the incident's shape (never a real credential).
+  const incidentToken = "virlo_tkn_Qm7pW2xLbV9sKjR4tNcY8dZh3Fg";
+
+  test("blocks a whole-message token-shaped value with unknown prefix", () => {
+    const result = checkIngressForSecrets(incidentToken);
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("Token-shaped value");
+    expect(result.userNotice).toBeDefined();
+  });
+
+  test("blocks a whole-message token-shaped value with surrounding whitespace", () => {
+    const result = checkIngressForSecrets(`  ${incidentToken}\n`);
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toContain("Token-shaped value");
+  });
+
+  test("does not block the same token embedded in a sentence", () => {
+    const result = checkIngressForSecrets(
+      `Here is the value ${incidentToken} from the docs`,
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block a token-shaped value with a repeated-char tail", () => {
+    const result = checkIngressForSecrets("my_key_xxxxxxxxxxxxxxxx");
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block a test_-prefixed token-shaped value", () => {
+    const result = checkIngressForSecrets("test_token_abcdefghijklmnop");
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block a whole-message 40-char hex git SHA", () => {
+    const result = checkIngressForSecrets(
+      "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block a whole-message UUID", () => {
+    const result = checkIngressForSecrets(
+      "550e8400-e29b-41d4-a716-446655440000",
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block a normal long word", () => {
+    const result = checkIngressForSecrets("supercalifragilisticexpialidocious");
+    expect(result.blocked).toBe(false);
+  });
+
+  test("does not block an allowlisted token-shaped value", () => {
+    const dataDir = join(process.env.VELLUM_WORKSPACE_DIR!, "data");
+    mkdirSync(dataDir, { recursive: true });
+    try {
+      writeFileSync(
+        join(dataDir, "secret-allowlist.json"),
+        JSON.stringify({ values: [incidentToken] }),
+      );
+      resetAllowlist();
+      const result = checkIngressForSecrets(incidentToken);
+      expect(result.blocked).toBe(false);
+    } finally {
+      rmSync(join(dataDir, "secret-allowlist.json"), { force: true });
+      resetAllowlist();
+    }
+  });
+
+  test("does not block token-shaped values when blockTokenShapedMessages is false", () => {
+    setConfig("secretDetection", {
+      enabled: true,
+      blockIngress: true,
+      blockTokenShapedMessages: false,
+    });
+    const result = checkIngressForSecrets(incidentToken);
+    expect(result.blocked).toBe(false);
+  });
+
+  test("prefix-pattern detection takes precedence over the token-shape label", () => {
+    const result = checkIngressForSecrets(
+      "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.detectedTypes).toEqual(["GitHub Token"]);
   });
 
   // ── Multiple secrets ───────────────────────────────────────────────

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -18,6 +18,14 @@ export const SecretDetectionConfigSchema = z
       .describe(
         "Whether to allow sending a detected secret once (with user confirmation) before redacting future occurrences",
       ),
+    blockTokenShapedMessages: z
+      .boolean({
+        error: "secretDetection.blockTokenShapedMessages must be a boolean",
+      })
+      .default(true)
+      .describe(
+        "Block messages whose entire content is a single token-shaped value (e.g. `virlo_tkn_…`) even when the prefix is not a known credential format",
+      ),
   })
   .describe(
     "Prefix-based secret detection at user-message ingress, plus one-time-send override for the secure credential prompt",

--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -110,6 +110,54 @@ function isPlaceholder(value: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Token-shape heuristic (whole-message only)
+// ---------------------------------------------------------------------------
+
+/**
+ * A single token-shaped value: an alphanumeric head, a separator-delimited
+ * secret keyword infix, and a >=16-char tail (e.g. `virlo_tkn_JF…`). The
+ * capture group isolates the tail for placeholder checks. Applied only when
+ * the entire trimmed message is one such token — the whole-message and
+ * keyword-infix requirements keep false positives near zero without any
+ * entropy scoring.
+ */
+const TOKEN_SHAPE =
+  /^[A-Za-z0-9][A-Za-z0-9_-]*[_-](?:tkn|token|key|secret|api|pat|sk|auth)[_-]([A-Za-z0-9_-]{16,})$/i;
+
+const TOKEN_SHAPE_MIN_LENGTH = 20;
+const TOKEN_SHAPE_MAX_LENGTH = 512;
+
+/**
+ * Check whether the entire message content is a single token-shaped value
+ * that should be blocked (no whitespace, plausible length, keyword infix,
+ * not a placeholder, not allowlisted).
+ */
+function isBlockedTokenShapedMessage(content: string): boolean {
+  const trimmed = content.trim();
+  if (
+    trimmed.length < TOKEN_SHAPE_MIN_LENGTH ||
+    trimmed.length > TOKEN_SHAPE_MAX_LENGTH ||
+    /\s/.test(trimmed)
+  ) {
+    return false;
+  }
+
+  const match = TOKEN_SHAPE.exec(trimmed);
+  if (!match) {
+    return false;
+  }
+
+  // Check both the full value (test_/fake_ prefixes) and the tail after the
+  // keyword infix (repeated-char fillers like "xxxxxxxxxxxxxxxx")
+  const tail = match[1]!;
+  if (isPlaceholder(trimmed) || isPlaceholder(tail)) {
+    return false;
+  }
+
+  return !isAllowlisted(trimmed);
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -156,6 +204,14 @@ export function checkIngressForSecrets(content: string): IngressCheckResult {
         detectedTypes.push(label);
       }
     }
+  }
+
+  if (
+    detectedTypes.length === 0 &&
+    secretDetection.blockTokenShapedMessages &&
+    isBlockedTokenShapedMessage(content)
+  ) {
+    detectedTypes.push("Token-shaped value");
   }
 
   if (detectedTypes.length === 0) {


### PR DESCRIPTION
## Summary
- Add a config-gated (`secretDetection.blockTokenShapedMessages`, default on) ingress heuristic blocking messages whose entire content is a single token-shaped value with a secret-keyword infix (e.g. `virlo_tkn_…`)
- Deliberately no entropy scoring (retired in migration 074 for false positives); placeholder and allowlist rules respected
- Positive + negative coverage in secret-ingress tests

Part of plan: jarvis-1313-cred-chat-leak.md (PR 2 of 9)