### PR TITLE
plugins: parse `credentialKeyPatterns` from plugin package.json manifests

### DIFF
--- a/assistant/src/__tests__/external-plugin-loader.test.ts
+++ b/assistant/src/__tests__/external-plugin-loader.test.ts
@@ -14,7 +14,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
-import { loadExternalPlugin } from "../plugins/external-plugin-loader.js";
+import {
+  loadExternalPlugin,
+  parsePluginManifest,
+} from "../plugins/external-plugin-loader.js";
 import {
   getRegisteredPlugins,
   resetPluginRegistryForTests,
@@ -101,6 +104,96 @@ describe("loadExternalPlugin — manifest", () => {
     expect(registered).toBeDefined();
     expect(registered?.manifest.version).toBe("0.0.0");
   });
+});
+
+describe("credentialKeyPatterns manifest field", () => {
+  const validPatterns = [
+    { label: "Example API token", pattern: "^ex_tkn_[A-Za-z0-9]{24}$" },
+    { label: "Example legacy key", pattern: "^ex_key_[0-9a-f]{32}$" },
+  ];
+
+  test("a valid declaration round-trips through loadExternalPlugin", async () => {
+    const dir = freshPluginDir("cred-patterns-valid");
+    writePackageJson(dir, {
+      name: "cred-patterns-valid",
+      version: "0.1.0",
+      credentialKeyPatterns: validPatterns,
+    });
+
+    await loadExternalPlugin(dir);
+
+    const registered = getRegisteredPlugins().find(
+      (p) => p.manifest.name === "cred-patterns-valid",
+    );
+    expect(registered?.manifest.credentialKeyPatterns).toEqual(validPatterns);
+  });
+
+  test("a valid declaration round-trips through parsePluginManifest", async () => {
+    const dir = freshPluginDir("cred-patterns-parse");
+    writePackageJson(dir, {
+      name: "cred-patterns-parse",
+      version: "0.1.0",
+      credentialKeyPatterns: validPatterns,
+    });
+
+    const manifest = await parsePluginManifest(dir);
+
+    expect(manifest).toEqual({
+      name: "cred-patterns-parse",
+      version: "0.1.0",
+      credentialKeyPatterns: validPatterns,
+    });
+  });
+
+  test("absent field parses to undefined on both paths", async () => {
+    const dir = freshPluginDir("cred-patterns-absent");
+    writePackageJson(dir, { name: "cred-patterns-absent", version: "0.1.0" });
+
+    await loadExternalPlugin(dir);
+    const manifest = await parsePluginManifest(dir);
+
+    const registered = getRegisteredPlugins().find(
+      (p) => p.manifest.name === "cred-patterns-absent",
+    );
+    expect(registered).toBeDefined();
+    expect(registered?.manifest.credentialKeyPatterns).toBeUndefined();
+    expect(manifest?.credentialKeyPatterns).toBeUndefined();
+  });
+
+  test.each([
+    ["a string instead of an array", "not-an-array"],
+    [
+      "more than 5 entries",
+      Array.from({ length: 6 }, (_, i) => ({
+        label: `key-${i}`,
+        pattern: `^ex_tkn_${i}_[A-Za-z0-9]+$`,
+      })),
+    ],
+    ["an empty label", [{ label: "", pattern: "^ex_tkn_[A-Za-z0-9]+$" }]],
+  ])(
+    "malformed declaration (%s) degrades to undefined without blocking load",
+    async (_desc, malformed) => {
+      const dir = freshPluginDir("cred-patterns-malformed");
+      writePackageJson(dir, {
+        name: "cred-patterns-malformed",
+        version: "0.1.0",
+        credentialKeyPatterns: malformed,
+      });
+
+      await loadExternalPlugin(dir);
+      const manifest = await parsePluginManifest(dir);
+
+      const registered = getRegisteredPlugins().find(
+        (p) => p.manifest.name === "cred-patterns-malformed",
+      );
+      expect(registered).toBeDefined();
+      expect(registered?.manifest.credentialKeyPatterns).toBeUndefined();
+      expect(manifest).toEqual({
+        name: "cred-patterns-malformed",
+        version: "0.1.0",
+      });
+    },
+  );
 });
 
 describe("loadExternalPlugin — plugin-api peerDependency", () => {

--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -39,6 +39,9 @@ describe("plugin core types", () => {
       name: "sample-plugin",
       version: "0.1.0",
       config: { parse: (input: unknown) => input },
+      credentialKeyPatterns: [
+        { label: "Example API token", pattern: "^ex_tkn_[A-Za-z0-9]{24}$" },
+      ],
     };
 
     const sampleTool: Tool = {

--- a/assistant/src/plugins/external-plugin-loader.ts
+++ b/assistant/src/plugins/external-plugin-loader.ts
@@ -56,6 +56,7 @@ import { registerPlugin } from "./registry.js";
 import type {
   HookFunction,
   Plugin,
+  PluginCredentialKeyPattern,
   PluginHooks,
   PluginManifest,
 } from "./types.js";
@@ -76,6 +77,10 @@ const DEFAULT_IMPORT_TIMEOUT_MS = 10_000;
  *   against the running assistant version and rejects the plugin on
  *   mismatch. If absent, the plugin loads without a host-compat claim
  *   (with a warning).
+ * - `credentialKeyPatterns` is typed `unknown` here and shape-validated
+ *   separately ({@link parseCredentialKeyPatterns}) so a malformed
+ *   declaration degrades to `undefined` instead of failing the whole
+ *   `safeParse` and blocking plugin load.
  * - Unknown fields pass through (`passthrough`) so the loader does not
  *   destructively reshape the file when the rest of the npm ecosystem
  *   writes to it.
@@ -85,10 +90,49 @@ const PluginPackageJsonSchema = z
     name: z.string().min(1, "package.json `name` must be a non-empty string"),
     version: z.string().optional(),
     peerDependencies: z.record(z.string(), z.string()).optional(),
+    credentialKeyPatterns: z.unknown().optional(),
   })
   .passthrough();
 
 type PluginPackageJson = z.infer<typeof PluginPackageJsonSchema>;
+
+/**
+ * Shape-level caps for the `credentialKeyPatterns` manifest field. The
+ * security grammar for what makes a *safe* pattern (anchored prefix, ReDoS
+ * bounds) is owned by the secret-pattern registry that consumes the parsed
+ * field — this schema only bounds sizes so a manifest cannot smuggle in
+ * unbounded data.
+ */
+const CredentialKeyPatternsSchema = z
+  .array(
+    z.object({
+      label: z.string().min(1).max(40),
+      pattern: z.string().min(4).max(200),
+    }),
+  )
+  .max(5);
+
+/**
+ * Shape-validate a raw `credentialKeyPatterns` value from a plugin
+ * `package.json`. A malformed value degrades to `undefined` with a logged
+ * warning — it must never fail plugin load (daemon startup philosophy:
+ * subsystem failures never block).
+ */
+function parseCredentialKeyPatterns(
+  raw: unknown,
+  pluginDir: string,
+): PluginCredentialKeyPattern[] | undefined {
+  if (raw === undefined) return undefined;
+  const parsed = CredentialKeyPatternsSchema.safeParse(raw);
+  if (!parsed.success) {
+    log.warn(
+      { pluginDir, err: parsed.error },
+      `package.json at ${pluginDir} has a malformed credentialKeyPatterns field — ignoring it`,
+    );
+    return undefined;
+  }
+  return parsed.data;
+}
 
 export interface LoadExternalPluginOptions {
   /**
@@ -274,6 +318,13 @@ async function buildPluginFromDir(pluginDir: string): Promise<Plugin> {
   }
 
   const manifest: PluginManifest = { name, version };
+  const credentialKeyPatterns = parseCredentialKeyPatterns(
+    pkg.credentialKeyPatterns,
+    pluginDir,
+  );
+  if (credentialKeyPatterns !== undefined) {
+    manifest.credentialKeyPatterns = credentialKeyPatterns;
+  }
   const plugin: Plugin = { manifest };
 
   const hooks = await loadHooks(pluginDir, name);
@@ -380,8 +431,9 @@ export async function loadExternalPlugin(
 
 /**
  * Parse a plugin's `package.json` manifest from disk. Returns the plugin
- * identity (its install directory name) and version, or `undefined` when the
- * `package.json` is missing, unparseable, or fails schema validation.
+ * identity (its install directory name), version, and any declared
+ * `credentialKeyPatterns`, or `undefined` when the `package.json` is
+ * missing, unparseable, or fails schema validation.
  *
  * Exported so the mtime cache can discover plugin identity without going
  * through the full `buildExternalPlugin` path. The identity mirrors
@@ -389,7 +441,9 @@ export async function loadExternalPlugin(
  */
 export async function parsePluginManifest(
   pluginDir: string,
-): Promise<{ name: string; version: string } | undefined> {
+): Promise<
+  Pick<PluginManifest, "name" | "version" | "credentialKeyPatterns"> | undefined
+> {
   const pkgPath = join(pluginDir, "package.json");
   let rawPkg: unknown;
   try {
@@ -413,5 +467,12 @@ export async function parsePluginManifest(
   const pkg: PluginPackageJson = parsed.data;
   const name = basename(pluginDir);
   const version = pkg.version && pkg.version.length > 0 ? pkg.version : "0.0.0";
+  const credentialKeyPatterns = parseCredentialKeyPatterns(
+    pkg.credentialKeyPatterns,
+    pluginDir,
+  );
+  if (credentialKeyPatterns !== undefined) {
+    return { name, version, credentialKeyPatterns };
+  }
   return { name, version };
 }

--- a/assistant/src/plugins/external-plugin-loader.ts
+++ b/assistant/src/plugins/external-plugin-loader.ts
@@ -122,7 +122,9 @@ function parseCredentialKeyPatterns(
   raw: unknown,
   pluginDir: string,
 ): PluginCredentialKeyPattern[] | undefined {
-  if (raw === undefined) return undefined;
+  if (raw === undefined) {
+    return undefined;
+  }
   const parsed = CredentialKeyPatternsSchema.safeParse(raw);
   if (!parsed.success) {
     log.warn(

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -54,6 +54,27 @@ export interface PluginManifest {
    * validators land in M2/M3 PRs.
    */
   config?: unknown;
+  /**
+   * Declared API-key formats for the plugin's service, parsed from the
+   * plugin's `package.json` `credentialKeyPatterns` field. Each entry pairs
+   * a human-readable label with a regex source string matching the service's
+   * credential format. Security-validated and fed into secret ingress
+   * detection + redaction when the plugin activates; the loader only
+   * enforces shape (a malformed declaration degrades to `undefined` and
+   * never blocks plugin load).
+   */
+  credentialKeyPatterns?: PluginCredentialKeyPattern[];
+}
+
+/**
+ * One declared credential format for a plugin's service: a display `label`
+ * plus the regex source string (`pattern`) that matches keys of that format.
+ */
+export interface PluginCredentialKeyPattern {
+  /** Human-readable name for the key format (e.g. "Example API token"). */
+  label: string;
+  /** Regex source string matching the service's credential format. */
+  pattern: string;
 }
 
 // ─── Public plugin-API types ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add optional `credentialKeyPatterns` ({label, pattern}[], ≤5) to `PluginManifest` and `PluginPackageJsonSchema`
- Populated via both `buildPluginFromDir` and `parsePluginManifest` (the live user-plugin path); malformed declarations degrade to `undefined` with a warning and never block plugin load
- Security-grammar validation and registry/lifecycle wiring land in sibling PRs

Part of plan: jarvis-1313-cred-chat-leak.md (PR 6 of 9)