### PR TITLE
security: runtime registry for plugin-declared credential key patterns

### DIFF
--- a/assistant/src/__tests__/plugin-secret-patterns.test.ts
+++ b/assistant/src/__tests__/plugin-secret-patterns.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Plugin secret-pattern registry: restricted-grammar validation, per-plugin
+ * replace/unregister semantics, version counter, and union memoization.
+ *
+ * Also guards the module's import-light invariant — hot-path consumers
+ * (`util/log-redact.ts`, used inside log serializers) import the registry, so
+ * it must import nothing beyond `secret-patterns` types and `re2js`.
+ */
+
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getPluginSecretPatterns,
+  getPluginSecretPatternsVersion,
+  registerPluginSecretPatterns,
+  resetPluginSecretPatternsForTests,
+  unregisterPluginSecretPatterns,
+} from "../security/plugin-secret-patterns.js";
+
+const VALID_PATTERN = "virlo_tkn_[A-Za-z0-9_-]{20,}";
+
+describe("plugin secret-pattern registry", () => {
+  beforeEach(() => {
+    resetPluginSecretPatternsForTests();
+  });
+
+  afterEach(() => {
+    resetPluginSecretPatternsForTests();
+  });
+
+  test("a well-formed anchored prefix pattern registers and is exposed with a namespaced label", () => {
+    const result = registerPluginSecretPatterns("virlo", [
+      { label: "Virlo API Key", pattern: VALID_PATTERN },
+    ]);
+    expect(result.accepted).toBe(1);
+    expect(result.rejected).toEqual([]);
+
+    const union = getPluginSecretPatterns();
+    expect(union.length).toBe(1);
+    expect(union[0]!.label).toBe("Virlo API Key (plugin:virlo)");
+    expect(union[0]!.regex).toBeInstanceOf(RegExp);
+    expect(union[0]!.regex.flags).toBe("");
+    expect(union[0]!.regex.test(`virlo_tkn_${"a".repeat(24)}`)).toBe(true);
+    expect(union[0]!.regex.test("unrelated text")).toBe(false);
+  });
+
+  describe("restricted grammar rejections", () => {
+    const cases: Array<{ name: string; pattern: string }> = [
+      { name: "over-broad .*", pattern: ".*" },
+      { name: "ReDoS-shaped (a+)+b", pattern: "(a+)+b" },
+      { name: "prefix-less \\w{10,}", pattern: "\\w{10,}" },
+      {
+        name: "oversized 300-char source",
+        pattern: `virlo_tkn_${"a".repeat(290)}`,
+      },
+      {
+        name: "capture group",
+        pattern: "virlo_tkn_([A-Za-z0-9_-]{20,})",
+      },
+      { name: "lookahead", pattern: "virlo_tkn_(?=[A-Za-z0-9]{20,})" },
+    ];
+
+    for (const { name, pattern } of cases) {
+      test(`rejects ${name} with a reason and leaves the registry unchanged`, () => {
+        const result = registerPluginSecretPatterns("virlo", [
+          { label: "Bad Pattern", pattern },
+        ]);
+        expect(result.accepted).toBe(0);
+        expect(result.rejected.length).toBe(1);
+        expect(result.rejected[0]!.pattern).toBe(pattern);
+        expect(result.rejected[0]!.reason.length).toBeGreaterThan(0);
+        expect(getPluginSecretPatterns()).toEqual([]);
+      });
+    }
+
+    test("rejects a label longer than 40 chars", () => {
+      const result = registerPluginSecretPatterns("virlo", [
+        { label: "x".repeat(41), pattern: VALID_PATTERN },
+      ]);
+      expect(result.accepted).toBe(0);
+      expect(result.rejected[0]!.reason).toMatch(/label/);
+    });
+
+    test("a 6-pattern batch accepts 5 and rejects the excess", () => {
+      const batch = Array.from({ length: 6 }, (_, i) => ({
+        label: `Key ${i}`,
+        pattern: `virlo_tkn_${i}_[A-Za-z0-9]{20,}`,
+      }));
+      const result = registerPluginSecretPatterns("virlo", batch);
+      expect(result.accepted).toBe(5);
+      expect(result.rejected.length).toBe(1);
+      expect(result.rejected[0]!.reason).toMatch(/limit/);
+      expect(getPluginSecretPatterns().length).toBe(5);
+    });
+
+    test("a mixed batch accepts valid entries and rejects invalid ones independently", () => {
+      const result = registerPluginSecretPatterns("virlo", [
+        { label: "Good", pattern: VALID_PATTERN },
+        { label: "Bad", pattern: ".*" },
+      ]);
+      expect(result.accepted).toBe(1);
+      expect(result.rejected.length).toBe(1);
+      expect(getPluginSecretPatterns().map((p) => p.label)).toEqual([
+        "Good (plugin:virlo)",
+      ]);
+    });
+  });
+
+  describe("registry lifecycle", () => {
+    test("re-registering the same plugin replaces its prior set, not appends", () => {
+      registerPluginSecretPatterns("virlo", [
+        { label: "Old Key", pattern: VALID_PATTERN },
+      ]);
+      registerPluginSecretPatterns("virlo", [
+        { label: "New Key", pattern: "virlo_sec_[A-Za-z0-9]{20,}" },
+      ]);
+      const union = getPluginSecretPatterns();
+      expect(union.length).toBe(1);
+      expect(union[0]!.label).toBe("New Key (plugin:virlo)");
+    });
+
+    test("unregister removes the plugin's patterns", () => {
+      registerPluginSecretPatterns("virlo", [
+        { label: "Virlo API Key", pattern: VALID_PATTERN },
+      ]);
+      registerPluginSecretPatterns("other", [
+        { label: "Other Key", pattern: "othr_key_[A-Za-z0-9]{20,}" },
+      ]);
+      unregisterPluginSecretPatterns("virlo");
+      expect(getPluginSecretPatterns().map((p) => p.label)).toEqual([
+        "Other Key (plugin:other)",
+      ]);
+    });
+
+    test("version bumps on every mutation and not on reads", () => {
+      const v0 = getPluginSecretPatternsVersion();
+      registerPluginSecretPatterns("virlo", [
+        { label: "Virlo API Key", pattern: VALID_PATTERN },
+      ]);
+      const v1 = getPluginSecretPatternsVersion();
+      expect(v1).toBeGreaterThan(v0);
+
+      getPluginSecretPatterns();
+      expect(getPluginSecretPatternsVersion()).toBe(v1);
+
+      registerPluginSecretPatterns("virlo", [
+        { label: "Virlo API Key", pattern: VALID_PATTERN },
+      ]);
+      const v2 = getPluginSecretPatternsVersion();
+      expect(v2).toBeGreaterThan(v1);
+
+      unregisterPluginSecretPatterns("virlo");
+      const v3 = getPluginSecretPatternsVersion();
+      expect(v3).toBeGreaterThan(v2);
+
+      // Unregistering a plugin that never registered is not a mutation.
+      unregisterPluginSecretPatterns("never-registered");
+      expect(getPluginSecretPatternsVersion()).toBe(v3);
+    });
+
+    test("the union is referentially stable between mutations", () => {
+      registerPluginSecretPatterns("virlo", [
+        { label: "Virlo API Key", pattern: VALID_PATTERN },
+      ]);
+      const first = getPluginSecretPatterns();
+      expect(getPluginSecretPatterns()).toBe(first);
+
+      registerPluginSecretPatterns("other", [
+        { label: "Other Key", pattern: "othr_key_[A-Za-z0-9]{20,}" },
+      ]);
+      const second = getPluginSecretPatterns();
+      expect(second).not.toBe(first);
+      expect(getPluginSecretPatterns()).toBe(second);
+    });
+  });
+
+  test("import-light invariant: only re2js and secret-patterns types are imported", () => {
+    const source = readFileSync(
+      new URL("../security/plugin-secret-patterns.ts", import.meta.url),
+      "utf-8",
+    );
+    const imports = [...source.matchAll(/^import .*$/gm)].map((m) => m[0]);
+    expect(imports).toEqual([
+      'import { RE2JS } from "re2js";',
+      'import type { SecretPrefixPattern } from "./secret-patterns.js";',
+    ]);
+  });
+});

--- a/assistant/src/security/plugin-secret-patterns.ts
+++ b/assistant/src/security/plugin-secret-patterns.ts
@@ -1,0 +1,286 @@
+/**
+ * Runtime registry for plugin-declared credential key patterns.
+ *
+ * Third-party plugins declare the prefix shape of their API keys (e.g.
+ * `virlo_tkn_[A-Za-z0-9_-]{20,}`) so that ingress blocking, tool output
+ * scanning, and log redaction can detect keys the static `PREFIX_PATTERNS`
+ * list cannot know about. Registrations are keyed by plugin name and flow
+ * through {@link registerPluginSecretPatterns} /
+ * {@link unregisterPluginSecretPatterns}; consumers read the memoized union
+ * via {@link getPluginSecretPatterns} and use
+ * {@link getPluginSecretPatternsVersion} to invalidate their own derived
+ * (compiled/flagged) arrays.
+ *
+ * **Import-light invariant**: this module may import only `secret-patterns.ts`
+ * types and `re2js` — no logger, no config, no `plugins/` modules. Hot-path
+ * consumers (`util/log-redact.ts`, used inside log serializers) import it, so
+ * any heavier import risks cycles and import-time side effects on the logging
+ * path. Disabled-plugin filtering happens at the plugin-lifecycle layer
+ * (register on activate, unregister on deactivate), not at read time.
+ *
+ * Patterns are validated against a **restricted grammar** rather than trusted
+ * as arbitrary regex: bounded length, an anchored literal prefix (so a plugin
+ * cannot register an over-broad matcher that redacts everything), no capture
+ * groups / backreferences / lookarounds, and a mandatory `RE2JS.compile`
+ * check that structurally guarantees linear-time matching. Only after a
+ * pattern passes is it compiled to the native `RegExp` (no flags) that the
+ * `SecretPrefixPattern` contract expects — the restricted grammar is what
+ * makes the native compile safe.
+ */
+
+import { RE2JS } from "re2js";
+
+import type { SecretPrefixPattern } from "./secret-patterns.js";
+
+// ---------------------------------------------------------------------------
+// Validation limits
+// ---------------------------------------------------------------------------
+
+/** Maximum regex source length a plugin may register. */
+const MAX_SOURCE_LENGTH = 200;
+
+/** Minimum number of guaranteed literal prefix characters. */
+const MIN_LITERAL_PREFIX = 4;
+
+/** Maximum number of patterns a single plugin may register. */
+const MAX_PATTERNS_PER_PLUGIN = 5;
+
+const MAX_LABEL_LENGTH = 40;
+
+export interface PluginSecretPatternInput {
+  /** Human-readable label, e.g. "Virlo API Key". 1–40 chars. */
+  label: string;
+  /** Regex source string (no flags, no delimiters). */
+  pattern: string;
+}
+
+export interface PluginSecretPatternRejection {
+  pattern: string;
+  reason: string;
+}
+
+export interface RegisterPluginSecretPatternsResult {
+  accepted: number;
+  rejected: PluginSecretPatternRejection[];
+}
+
+// ---------------------------------------------------------------------------
+// Validator
+// ---------------------------------------------------------------------------
+
+const LITERAL_PREFIX_CHAR = /[A-Za-z0-9_-]/;
+
+/**
+ * Number of characters guaranteed to appear literally at the start of a match.
+ * Counts a leading run of `[A-Za-z0-9_-]` chars plus escaped dots (`\.`); a
+ * bare `.` is a wildcard and terminates the run. If the run is immediately
+ * followed by a quantifier (`*`, `?`, `{`), the last literal char may be
+ * optional (e.g. `abcd*` only guarantees `abc`), so it is not counted.
+ */
+function literalPrefixLength(source: string): number {
+  let count = 0;
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i]!;
+    if (LITERAL_PREFIX_CHAR.test(ch)) {
+      count++;
+      i++;
+      continue;
+    }
+    if (ch === "\\" && source[i + 1] === ".") {
+      count++;
+      i += 2;
+      continue;
+    }
+    break;
+  }
+  const next = source[i];
+  if (count > 0 && (next === "*" || next === "?" || next === "{")) {
+    count--;
+  }
+  return count;
+}
+
+/**
+ * Scan for constructs outside the restricted grammar: capture groups (`(` is
+ * allowed only as `(?:`), lookarounds/inline flags (any other `(?`), and
+ * backreferences (`\1`–`\9`). Escapes and character classes are tracked so
+ * `\(` and `[()]` are not misread as groups.
+ */
+function findStructuralIssue(source: string): string | null {
+  let inClass = false;
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i]!;
+    if (ch === "\\") {
+      const next = source[i + 1];
+      if (next !== undefined && next >= "1" && next <= "9") {
+        return "backreferences are not allowed";
+      }
+      i++;
+      continue;
+    }
+    if (inClass) {
+      if (ch === "]") {
+        inClass = false;
+      }
+      continue;
+    }
+    if (ch === "[") {
+      inClass = true;
+      continue;
+    }
+    if (ch === "(") {
+      if (source.startsWith("(?:", i)) {
+        continue;
+      }
+      if (source[i + 1] === "?") {
+        return "lookarounds and inline groups other than (?: are not allowed";
+      }
+      return "capture groups are not allowed; use (?:...) instead";
+    }
+  }
+  return null;
+}
+
+/**
+ * Validate one pattern against the restricted grammar. Returns the compiled
+ * native `RegExp` on success, or a rejection reason. Never throws.
+ */
+function validatePattern(
+  input: PluginSecretPatternInput,
+): { ok: true; regex: RegExp } | { ok: false; reason: string } {
+  const reject = (reason: string) => ({ ok: false as const, reason });
+  if (typeof input.label !== "string" || input.label.length < 1) {
+    return reject("label must be a non-empty string");
+  }
+  if (input.label.length > MAX_LABEL_LENGTH) {
+    return reject(`label exceeds ${MAX_LABEL_LENGTH} characters`);
+  }
+  const source = input.pattern;
+  if (typeof source !== "string" || source.length === 0) {
+    return reject("pattern must be a non-empty string");
+  }
+  if (source.length > MAX_SOURCE_LENGTH) {
+    return reject(`pattern exceeds ${MAX_SOURCE_LENGTH} characters`);
+  }
+  if (literalPrefixLength(source) < MIN_LITERAL_PREFIX) {
+    return reject(
+      `pattern must start with at least ${MIN_LITERAL_PREFIX} literal characters from [A-Za-z0-9_.-] (a distinctive key prefix)`,
+    );
+  }
+  const structuralIssue = findStructuralIssue(source);
+  if (structuralIssue !== null) {
+    return reject(structuralIssue);
+  }
+  // RE2 compile guarantees linear-time matching semantics and structurally
+  // rejects anything the scans above missed (it has no backtracking, no
+  // backreferences, no lookarounds).
+  try {
+    RE2JS.compile(source);
+  } catch (err) {
+    return reject(
+      `pattern is not a valid RE2 regex: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  try {
+    return { ok: true, regex: new RegExp(source) };
+  } catch (err) {
+    return reject(
+      `pattern is not a valid regex: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/** Accepted patterns keyed by plugin name, labels already namespaced. */
+const patternsByPlugin = new Map<string, SecretPrefixPattern[]>();
+
+/** Bumped on every mutation; consumers memoize derived arrays against it. */
+let version = 0;
+
+/** Memoized flattened union; invalidated on every mutation. */
+let cachedUnion: SecretPrefixPattern[] | null = null;
+
+/**
+ * Register the credential key patterns declared by `pluginName`, replacing any
+ * prior set for that plugin. Each pattern is validated independently; invalid
+ * ones are rejected with a reason (never thrown) and valid ones are stored
+ * with their label namespaced as `<label> (plugin:<name>)`. At most
+ * {@link MAX_PATTERNS_PER_PLUGIN} patterns are accepted per plugin — the
+ * excess is rejected.
+ */
+export function registerPluginSecretPatterns(
+  pluginName: string,
+  patterns: ReadonlyArray<PluginSecretPatternInput>,
+): RegisterPluginSecretPatternsResult {
+  const accepted: SecretPrefixPattern[] = [];
+  const rejected: PluginSecretPatternRejection[] = [];
+  for (const input of patterns) {
+    if (accepted.length >= MAX_PATTERNS_PER_PLUGIN) {
+      rejected.push({
+        pattern: String(input.pattern),
+        reason: `per-plugin limit of ${MAX_PATTERNS_PER_PLUGIN} patterns exceeded`,
+      });
+      continue;
+    }
+    const result = validatePattern(input);
+    if (!result.ok) {
+      rejected.push({ pattern: String(input.pattern), reason: result.reason });
+      continue;
+    }
+    accepted.push({
+      label: `${input.label} (plugin:${pluginName})`,
+      regex: result.regex,
+    });
+  }
+  patternsByPlugin.set(pluginName, accepted);
+  version++;
+  cachedUnion = null;
+  return { accepted: accepted.length, rejected };
+}
+
+/**
+ * Remove the patterns declared by `pluginName`. No-op (no version bump) when
+ * the plugin never registered, so it is safe to call on every teardown path.
+ */
+export function unregisterPluginSecretPatterns(pluginName: string): void {
+  if (patternsByPlugin.delete(pluginName)) {
+    version++;
+    cachedUnion = null;
+  }
+}
+
+/**
+ * The flattened union of every registered plugin's accepted patterns.
+ * Memoized: the same array reference is returned until a mutation bumps the
+ * version, so hot-path consumers can cheaply detect change by reference or
+ * via {@link getPluginSecretPatternsVersion}.
+ */
+export function getPluginSecretPatterns(): SecretPrefixPattern[] {
+  if (cachedUnion === null) {
+    const union: SecretPrefixPattern[] = [];
+    for (const patterns of patternsByPlugin.values()) {
+      union.push(...patterns);
+    }
+    cachedUnion = union;
+  }
+  return cachedUnion;
+}
+
+/**
+ * Monotonic mutation counter. Consumers that derive per-call-site compiled
+ * arrays from the union should rebuild only when this value changes.
+ */
+export function getPluginSecretPatternsVersion(): number {
+  return version;
+}
+
+/** Drop every registration and reset the version. Exposed for test isolation. */
+export function resetPluginSecretPatternsForTests(): void {
+  patternsByPlugin.clear();
+  version = 0;
+  cachedUnion = null;
+}


### PR DESCRIPTION
## Summary
- New import-light `security/plugin-secret-patterns.ts` registry: register/unregister per plugin, memoized union, version counter for consumer-side caching
- Restricted-grammar validator (anchored ≥4-char literal prefix, ≤200 chars, ≤5 patterns/plugin, no capture groups/backrefs/lookarounds) with RE2JS compile check for linear-time safety
- Consumers (ingress/scanner/log-redact) and plugin lifecycle wiring land in follow-up PRs

Part of plan: jarvis-1313-cred-chat-leak.md (PR 5 of 9)