### PR TITLE
feat(web): Pro custom-plan config via the plans modal (change-tier dispatch)

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -54,6 +54,9 @@ let machineTierError: unknown = null;
 let subscriptionFixture: SubscriptionResponse | null = null;
 let plansFixture: PlanListResponse | null = null;
 let onboardingFixture: OnboardingStateResponse | null = null;
+// When true, the onboarding fetch never resolves — models the first load still
+// in flight so the Configure CTA's loading gate can be exercised.
+let onboardingHangs = false;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -84,7 +87,9 @@ mock.module("@/generated/api/sdk.gen", () => ({
   organizationsBillingPlansRetrieve: () =>
     Promise.resolve({ data: plansFixture, response: { ok: true } }),
   organizationsBillingSubscriptionOnboardingRetrieve: () =>
-    Promise.resolve({ data: onboardingFixture, response: { ok: true } }),
+    onboardingHangs
+      ? new Promise(() => {})
+      : Promise.resolve({ data: onboardingFixture, response: { ok: true } }),
 }));
 
 mock.module("@/runtime/browser", () => ({
@@ -268,6 +273,7 @@ function LocationProbe() {
 function renderPage(
   subscription: SubscriptionResponse,
   onboardingData: OnboardingStateResponse = onboarding(),
+  { seedOnboarding = true }: { seedOnboarding?: boolean } = {},
 ) {
   subscriptionFixture = subscription;
   plansFixture = fullCatalog();
@@ -291,10 +297,12 @@ function renderPage(
     organizationsBillingPlansRetrieveQueryKey(),
     fullCatalog(),
   );
-  client.setQueryData(
-    organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
-    onboardingData,
-  );
+  if (seedOnboarding) {
+    client.setQueryData(
+      organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+      onboardingData,
+    );
+  }
   return render(
     <MemoryRouter initialEntries={["/assistant/plans"]}>
       <QueryClientProvider client={client}>
@@ -359,6 +367,7 @@ beforeEach(() => {
   creditTierCall = null;
   openedUrl = null;
   machineTierError = null;
+  onboardingHangs = false;
   subscriptionFixture = null;
   plansFixture = null;
   onboardingFixture = null;
@@ -494,6 +503,26 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     // The manage/cancel fallback route was not taken.
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(upgradeCall).toBeNull();
+  });
+
+  test("holds Configure disabled while the current tiers load, without misrouting", () => {
+    // The onboarding query (which supplies the current tiers) is still in
+    // flight. Representability is unknown, so the CTA is disabled rather than
+    // falling through to the manage surface and stranding an eligible sub.
+    onboardingHangs = true;
+    const { getByRole, getByTestId, queryByText } = renderPage(
+      proMightySubscription(),
+      onboarding(),
+      { seedOnboarding: false },
+    );
+
+    const configure = getByRole("button", { name: "Configure" });
+    expect((configure as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(configure);
+    expect(queryByText("Create a custom plan")).toBeNull();
+    // The manage/cancel fallback route was not taken.
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
   });
 
   test("opens seeded to the current plan so Continue needs no re-pick", () => {

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -567,6 +567,47 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     expect(queryByTestId("resize-takeover")).toBeNull();
   });
 
+  test("a baseline (null machine) Pro sub can still open and reconfigure", () => {
+    // A package with no paid machine tier reports max_machine_tier: null. That
+    // sub must still reach the modal (not route to manage); storage/credit seed
+    // and the machine picker starts empty, so Continue waits for a machine pick.
+    const { getByRole, getByText } = renderPage(
+      proMightySubscription(),
+      onboarding({ max_machine_tier: null }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    getByText("Create a custom plan");
+    expect(continueButton().disabled).toBe(true);
+
+    const dialog = document.querySelector('[role="dialog"]');
+    const rows = Array.from(dialog?.querySelectorAll("li") ?? []).map(
+      (li) => li.textContent?.trim() ?? "",
+    );
+    // Storage and credit are seeded even though the machine is unset.
+    expect(rows).toContain("10 GB storage");
+    expect(rows).toContain("No extra credits");
+  });
+
+  test("a baseline Pro sub picking a machine dispatches the upgrade", async () => {
+    const { getByRole, findByTestId } = renderPage(
+      proMightySubscription(),
+      onboarding({ max_machine_tier: null }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    selectOption("Machine size", "Medium machine (2.5 vCPU, 5 GiB)");
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(machineTierCall).not.toBeNull());
+    expect(machineTierCall!.body).toEqual({ machine_tier: "medium" });
+    // Storage and credit stayed at their seeded values, so neither dispatches.
+    expect(storageTierCall).toBeNull();
+    expect(creditTierCall).toBeNull();
+    // Baseline → medium is an upgrade, so the resize takeover opens.
+    await findByTestId("resize-takeover");
+  });
+
   test("Continue dispatches only the changed tiers and opens the resize takeover", async () => {
     // Current config is medium machine / 10 GB (xs) storage / no credits.
     const { getByRole, findByTestId } = renderPage(proMightySubscription());

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -4,11 +4,13 @@
  * A base subscriber clicking Configure gets the "Create a custom plan" modal;
  * Continue stays disabled until all three dropdowns (machine size, storage,
  * credits) have an explicit choice, then fires the Stripe upgrade with the
- * selected tiers. A Pro subscriber's Configure routes to the billing manage
- * modal instead, mirroring the plan-card CTAs.
+ * selected tiers. An eligible Pro subscriber reaches the same modal, but
+ * Continue dispatches the change-machine/storage/credit-tier endpoints (not
+ * checkout, which no-ops for an active Pro sub) and opens the resize takeover;
+ * an ineligible Pro sub (cancelling / bad status) routes to the manage modal.
  *
  * Strategy mirrors plans-page-checkout.test.tsx: mock the generated SDK to
- * capture the upgrade body and return a redirect, mock `openUrl` to capture
+ * capture the request bodies and return fixtures, mock `openUrl` to capture
  * the redirect target, and force the platform-hosted gate open. The
  * design-library Dropdown is a custom combobox — driven by clicking the
  * trigger, then the option whose visible label matches.
@@ -24,9 +26,11 @@ import * as browserRuntime from "@/runtime/browser";
 import * as platformGate from "@/hooks/use-platform-gate";
 import {
   organizationsBillingPlansRetrieveQueryKey,
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
   organizationsBillingSubscriptionRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type {
+  OnboardingStateResponse,
   PlanListResponse,
   ProPackage,
   SubscriptionResponse,
@@ -36,7 +40,18 @@ const CHECKOUT_URL = "https://stripe.test/checkout/session";
 
 type Captured = { body?: unknown };
 let upgradeCall: Captured | null = null;
+let machineTierCall: Captured | null = null;
+let storageTierCall: Captured | null = null;
+let creditTierCall: Captured | null = null;
 let openedUrl: string | null = null;
+// When non-null, the change-machine-tier call rejects with this — drives the
+// error path (the hook toasts and the caller keeps the modal open).
+let machineTierError: unknown = null;
+// Read fixtures returned by the mocked SDK so post-mutation invalidation
+// refetches resolve deterministically instead of hitting the network.
+let subscriptionFixture: SubscriptionResponse | null = null;
+let plansFixture: PlanListResponse | null = null;
+let onboardingFixture: OnboardingStateResponse | null = null;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -47,6 +62,27 @@ mock.module("@/generated/api/sdk.gen", () => ({
       response: { ok: true },
     });
   },
+  organizationsBillingSubscriptionChangeMachineTierCreate: (opts: Captured) => {
+    machineTierCall = opts;
+    if (machineTierError !== null) {
+      return Promise.reject(machineTierError);
+    }
+    return Promise.resolve({ data: {}, response: { ok: true } });
+  },
+  organizationsBillingSubscriptionChangeStorageTierCreate: (opts: Captured) => {
+    storageTierCall = opts;
+    return Promise.resolve({ data: {}, response: { ok: true } });
+  },
+  organizationsBillingSubscriptionChangeCreditTierCreate: (opts: Captured) => {
+    creditTierCall = opts;
+    return Promise.resolve({ data: {}, response: { ok: true } });
+  },
+  organizationsBillingSubscriptionRetrieve: () =>
+    Promise.resolve({ data: subscriptionFixture, response: { ok: true } }),
+  organizationsBillingPlansRetrieve: () =>
+    Promise.resolve({ data: plansFixture, response: { ok: true } }),
+  organizationsBillingSubscriptionOnboardingRetrieve: () =>
+    Promise.resolve({ data: onboardingFixture, response: { ok: true } }),
 }));
 
 mock.module("@/runtime/browser", () => ({
@@ -70,6 +106,13 @@ mock.module("@/hooks/use-platform-gate", () => ({
 mock.module("@/utils/use-bundled-avatar-components", () => ({
   preloadBundledAvatarComponents: () => {},
   useBundledAvatarComponents: () => null,
+}));
+
+// Stand in for the provisioning takeover so a Pro tier change can assert it was
+// revealed without driving its own resize queries.
+mock.module("@/domains/settings/components/tier-upgrade-resize-modal", () => ({
+  TierUpgradeResizeModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="resize-takeover" /> : null,
 }));
 
 const { PlansPage } = await import("./plans-page");
@@ -183,7 +226,9 @@ function freeSubscription(): SubscriptionResponse {
   };
 }
 
-function proMightySubscription(): SubscriptionResponse {
+function proMightySubscription(
+  overrides: Partial<SubscriptionResponse> = {},
+): SubscriptionResponse {
   return {
     plan_id: "pro",
     status: "active",
@@ -191,8 +236,25 @@ function proMightySubscription(): SubscriptionResponse {
     current_period_end: "2026-07-10T00:00:00Z",
     cancel_at_period_end: false,
     cancel_at: null,
+    selected_credit_tier: null,
     package: { key: "mighty", name: "Mighty", version: 1, customized: false },
     entitlements: { managed_email: false, phone_number: false },
+    ...overrides,
+  };
+}
+
+/** Onboarding state carrying the Pro sub's current machine/storage tiers. */
+function onboarding(
+  overrides: Partial<OnboardingStateResponse> = {},
+): OnboardingStateResponse {
+  return {
+    max_machine_tier: "medium",
+    selected_storage_tier: "xs",
+    selected_storage_gib: 10,
+    pvc_ready: true,
+    domain_setup_available: false,
+    primary_assistant_id: null,
+    ...overrides,
   };
 }
 
@@ -201,9 +263,23 @@ function LocationProbe() {
   return <div data-testid="loc">{location.pathname + location.search}</div>;
 }
 
-function renderPage(subscription: SubscriptionResponse) {
+function renderPage(
+  subscription: SubscriptionResponse,
+  onboardingData: OnboardingStateResponse = onboarding(),
+) {
+  subscriptionFixture = subscription;
+  plansFixture = fullCatalog();
+  onboardingFixture = onboardingData;
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        gcTime: Infinity,
+      },
+    },
   });
   client.setQueryData(
     organizationsBillingSubscriptionRetrieveQueryKey(),
@@ -212,6 +288,10 @@ function renderPage(subscription: SubscriptionResponse) {
   client.setQueryData(
     organizationsBillingPlansRetrieveQueryKey(),
     fullCatalog(),
+  );
+  client.setQueryData(
+    organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+    onboardingData,
   );
   return render(
     <MemoryRouter initialEntries={["/assistant/plans"]}>
@@ -272,12 +352,30 @@ function continueButton(): HTMLButtonElement {
 
 beforeEach(() => {
   upgradeCall = null;
+  machineTierCall = null;
+  storageTierCall = null;
+  creditTierCall = null;
   openedUrl = null;
+  machineTierError = null;
+  subscriptionFixture = null;
+  plansFixture = null;
+  onboardingFixture = null;
 });
 
 afterEach(() => {
   cleanup();
 });
+
+/** Finds an open-menu option element whose text starts with `label`. */
+function findOption(label: string): HTMLElement {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => (o.textContent?.trim() ?? "").startsWith(label));
+  if (!option) {
+    throw new Error(`expected option "${label}"`);
+  }
+  return option;
+}
 
 describe("CustomPlanModal — base subscriber", () => {
   test("Continue stays disabled until every dropdown has a choice", () => {
@@ -382,10 +480,83 @@ describe("CustomPlanModal — base subscriber", () => {
   });
 });
 
-describe("CustomPlanModal — Pro subscriber", () => {
-  test("Configure routes to the manage modal instead of the configurator", async () => {
-    const { getByRole, getByTestId, queryByText } = renderPage(
+describe("CustomPlanModal — eligible Pro subscriber", () => {
+  test("Configure opens the white configurator, not the manage modal", () => {
+    const { getByRole, getByTestId, getByText } = renderPage(
       proMightySubscription(),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    getByText("Create a custom plan");
+    // The manage/cancel fallback route was not taken.
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("Continue dispatches only the changed tiers and opens the resize takeover", async () => {
+    // Current config is medium machine / 10 GB (xs) storage / no credits.
+    const { getByRole, findByTestId } = renderPage(proMightySubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    // Raise the machine, keep storage at its current size, add a credit bundle.
+    selectOption("Machine size", "Large machine (4 vCPU, 8 GiB)");
+    selectOption("Storage", "10 GB");
+    selectOption("Credit bundle", "50 credits");
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(machineTierCall).not.toBeNull());
+    expect(machineTierCall!.body).toEqual({ machine_tier: "large" });
+    expect(creditTierCall!.body).toEqual({ credit_tier: "credits_50" });
+    // Storage is unchanged, so no storage-tier request fires.
+    expect(storageTierCall).toBeNull();
+
+    // A machine change resizes the assistant, so the takeover opens.
+    await findByTestId("resize-takeover");
+    // The change-tier path never touches the checkout endpoint.
+    expect(upgradeCall).toBeNull();
+    expect(openedUrl).toBeNull();
+  });
+
+  test("storage tiers below the current size are disabled", () => {
+    // Current storage is 30 GB (s), so the 10 GB tier can't be selected.
+    const { getByRole } = renderPage(
+      proMightySubscription(),
+      onboarding({ selected_storage_tier: "s", selected_storage_gib: 30 }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    openDropdown("Storage");
+
+    expect(findOption("10 GB").getAttribute("aria-disabled")).toBe("true");
+    expect(findOption("30 GB").getAttribute("aria-disabled")).toBe("false");
+  });
+
+  test("a failed dispatch keeps the modal open and skips the takeover", async () => {
+    machineTierError = { detail: "Payment failed. Your card was declined." };
+    const { getByRole, getByText, queryByTestId } = renderPage(
+      proMightySubscription(),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    selectOption("Machine size", "Large machine (4 vCPU, 8 GiB)");
+    selectOption("Storage", "10 GB");
+    selectOption("Credit bundle", "No extra credits");
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(machineTierCall).not.toBeNull());
+    // The hook toasted; the configurator stays open and the takeover is absent.
+    getByText("Create a custom plan");
+    expect(queryByTestId("resize-takeover")).toBeNull();
+  });
+});
+
+describe("CustomPlanModal — ineligible Pro subscriber", () => {
+  test("a cancelling Pro sub's Configure routes to the manage modal", async () => {
+    const { getByRole, getByTestId, queryByText } = renderPage(
+      proMightySubscription({ cancel_at_period_end: true }),
     );
 
     fireEvent.click(getByRole("button", { name: "Configure" }));
@@ -396,6 +567,7 @@ describe("CustomPlanModal — Pro subscriber", () => {
       );
     });
     expect(queryByText("Create a custom plan")).toBeNull();
+    expect(machineTierCall).toBeNull();
     expect(upgradeCall).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -4,10 +4,12 @@
  * A base subscriber clicking Configure gets the "Create a custom plan" modal;
  * Continue stays disabled until all three dropdowns (machine size, storage,
  * credits) have an explicit choice, then fires the Stripe upgrade with the
- * selected tiers. An eligible Pro subscriber reaches the same modal, but
- * Continue dispatches the change-machine/storage/credit-tier endpoints (not
- * checkout, which no-ops for an active Pro sub) and opens the resize takeover;
- * an ineligible Pro sub (cancelling / bad status) routes to the manage modal.
+ * selected tiers. An eligible Pro subscriber reaches the same modal seeded to
+ * its current tiers, and Continue dispatches the change-machine/storage/
+ * credit-tier endpoints (not checkout, which no-ops for an active Pro sub) and
+ * opens the resize takeover. A Pro sub the modal can't faithfully represent — a
+ * legacy storage tier or a deprecated credit bundle — or an ineligible one
+ * (cancelling / bad status) routes to the manage modal instead.
  *
  * Strategy mirrors plans-page-checkout.test.tsx: mock the generated SDK to
  * capture the request bodies and return fixtures, mock `openUrl` to capture
@@ -494,6 +496,48 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     expect(upgradeCall).toBeNull();
   });
 
+  test("opens seeded to the current plan so Continue needs no re-pick", () => {
+    // Current config: medium machine / 10 GB (xs) storage / no credits. The
+    // configurator opens with all three pre-filled, so an unrelated edit can't
+    // strand the user into re-picking — and dropping — a tier they still hold.
+    const { getByRole, getByText } = renderPage(proMightySubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    getByText("Create a custom plan");
+    // Seeded, so Continue is enabled with no interaction.
+    expect(continueButton().disabled).toBe(false);
+
+    // The recap reflects the seeded current tiers.
+    const dialog = document.querySelector('[role="dialog"]');
+    const rows = Array.from(dialog?.querySelectorAll("li") ?? []).map(
+      (li) => li.textContent?.trim() ?? "",
+    );
+    expect(rows).toEqual([
+      "Pro base plan — $20/mo",
+      "Medium machine (2.5 vCPU, 5 GiB)",
+      "10 GB storage",
+      "No extra credits",
+    ]);
+  });
+
+  test("continuing with the seeded config is a no-op with no dispatch", async () => {
+    const { getByRole, queryByText, queryByTestId } = renderPage(
+      proMightySubscription(),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    fireEvent.click(continueButton());
+
+    // Nothing diverged from the current plan, so no change-tier request fires
+    // and the resize takeover stays closed.
+    await waitFor(() => expect(queryByText("Create a custom plan")).toBeNull());
+    expect(machineTierCall).toBeNull();
+    expect(storageTierCall).toBeNull();
+    expect(creditTierCall).toBeNull();
+    expect(queryByTestId("resize-takeover")).toBeNull();
+  });
+
   test("Continue dispatches only the changed tiers and opens the resize takeover", async () => {
     // Current config is medium machine / 10 GB (xs) storage / no credits.
     const { getByRole, findByTestId } = renderPage(proMightySubscription());
@@ -569,5 +613,46 @@ describe("CustomPlanModal — ineligible Pro subscriber", () => {
     expect(queryByText("Create a custom plan")).toBeNull();
     expect(machineTierCall).toBeNull();
     expect(upgradeCall).toBeNull();
+  });
+});
+
+describe("CustomPlanModal — non-representable Pro plan", () => {
+  test("a legacy storage tier routes to the manage modal", async () => {
+    // The configurator filters legacy storage tiers, so a sub holding one can't
+    // be shown or re-selected here — route to adjust-plan, which preserves it,
+    // rather than force the user to upgrade off it.
+    const { getByRole, getByTestId, queryByText } = renderPage(
+      proMightySubscription(),
+      onboarding({ selected_storage_tier: "xl", selected_storage_gib: 250 }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    await waitFor(() => {
+      expect(getByTestId("loc").textContent).toBe(
+        "/assistant/settings/usage?tab=billing&adjust_plan",
+      );
+    });
+    expect(queryByText("Create a custom plan")).toBeNull();
+    expect(machineTierCall).toBeNull();
+  });
+
+  test("a deprecated credit bundle routes to the manage modal", async () => {
+    // The configurator only offers live credit tiers; the sub's `credits_25`
+    // bundle is absent from the catalog, so routing it here would drop the paid
+    // credits — fall back to adjust-plan instead.
+    const { getByRole, getByTestId, queryByText } = renderPage(
+      proMightySubscription({ selected_credit_tier: "credits_25" }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    await waitFor(() => {
+      expect(getByTestId("loc").textContent).toBe(
+        "/assistant/settings/usage?tab=billing&adjust_plan",
+      );
+    });
+    expect(queryByText("Create a custom plan")).toBeNull();
+    expect(machineTierCall).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -592,6 +592,25 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     expect(openedUrl).toBeNull();
   });
 
+  test("a machine downgrade dispatches but skips the resize takeover", async () => {
+    // Current machine is large; lowering to medium is a downgrade, capped
+    // server-side, so it must not open the Apply & Restart takeover.
+    const { getByRole, queryByText, queryByTestId } = renderPage(
+      proMightySubscription(),
+      onboarding({ max_machine_tier: "large" }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    selectOption("Machine size", "Medium machine (2.5 vCPU, 5 GiB)");
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(machineTierCall).not.toBeNull());
+    expect(machineTierCall!.body).toEqual({ machine_tier: "medium" });
+    // The modal closes and the takeover never opens for a downgrade.
+    await waitFor(() => expect(queryByText("Create a custom plan")).toBeNull());
+    expect(queryByTestId("resize-takeover")).toBeNull();
+  });
+
   test("storage tiers below the current size are disabled", () => {
     // Current storage is 30 GB (s), so the 10 GB tier can't be selected.
     const { getByRole } = renderPage(

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -45,8 +45,15 @@ export interface CustomPlanModalProps {
   open: boolean;
   /** Pro catalog supplying the machine/storage/credit tiers and base price. */
   proPlan: ProPlan;
-  /** A checkout is in flight — hold Continue disabled until it resolves. */
+  /** A checkout or tier change is in flight — hold Continue disabled. */
   pending: boolean;
+  /**
+   * The Pro subscriber's current storage size, when reconfiguring an existing
+   * Pro plan. Storage is upgrade-only for Pro (the change-storage-tier endpoint
+   * rejects downgrades), so tiers below this size render disabled. Leave
+   * null/undefined for the base checkout path, where every tier is selectable.
+   */
+  currentStorageGib?: number | null;
   onClose: () => void;
   onContinue: (selection: CustomPlanSelection) => void;
 }
@@ -70,6 +77,7 @@ export function CustomPlanModal({
   open,
   proPlan,
   pending,
+  currentStorageGib,
   onClose,
   onContinue,
 }: CustomPlanModalProps) {
@@ -109,7 +117,9 @@ export function CustomPlanModal({
       label: t.label,
       icon: <HardDrive className="h-4 w-4" aria-hidden />,
       suffix: priceSuffix(t.price_cents),
-      disabled: isTierDisabled(t),
+      disabled:
+        isTierDisabled(t) ||
+        (currentStorageGib != null && t.storage_gib < currentStorageGib),
     }),
   );
   const creditOptions: DropdownOption<CreditChoice>[] = [

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -41,6 +41,18 @@ export interface CustomPlanSelection {
   creditTier: CreditTierEnum | null;
 }
 
+/**
+ * The current Pro tiers used to pre-fill the modal. Unlike a submitted
+ * selection, `machineTier` may be `null` — a package with no paid machine tier
+ * (baseline "Small" computer) has no `MachineTierEnum` to seed, so its machine
+ * dropdown starts empty and the user picks a paid tier to continue.
+ */
+export interface CustomPlanSeed {
+  machineTier: MachineTierEnum | null;
+  storageTier: StorageTierEnum;
+  creditTier: CreditTierEnum | null;
+}
+
 export interface CustomPlanModalProps {
   open: boolean;
   /** Pro catalog supplying the machine/storage/credit tiers and base price. */
@@ -58,9 +70,11 @@ export interface CustomPlanModalProps {
    * The Pro subscriber's current tiers, when reconfiguring an existing Pro
    * plan. Pre-fills every dimension so the default is a no-op and an unrelated
    * edit can't force re-picking — and dropping — a tier the user still holds.
-   * Leave null/undefined for the base checkout path, which starts empty.
+   * A null `machineTier` (baseline "Small") seeds storage/credit and leaves the
+   * machine picker empty. Leave null/undefined for base checkout, which starts
+   * every dimension empty.
    */
-  initialSelection?: CustomPlanSelection | null;
+  initialSelection?: CustomPlanSeed | null;
   onClose: () => void;
   onContinue: (selection: CustomPlanSelection) => void;
 }
@@ -102,9 +116,10 @@ export function CustomPlanModal({
       return;
     }
     // Reopening for a Pro reconfigure seeds the current tiers so the default is
-    // a no-op; base checkout passes none and leaves every dimension empty.
+    // a no-op; base checkout passes none and leaves every dimension empty. A
+    // baseline machine (null) has no tier to seed, so its picker starts empty.
     if (initialSelection) {
-      setMachineTier(initialSelection.machineTier);
+      setMachineTier(initialSelection.machineTier ?? "");
       setStorageTier(initialSelection.storageTier);
       setCreditChoice(initialSelection.creditTier ?? NO_EXTRA_CREDITS);
     }

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -54,6 +54,13 @@ export interface CustomPlanModalProps {
    * null/undefined for the base checkout path, where every tier is selectable.
    */
   currentStorageGib?: number | null;
+  /**
+   * The Pro subscriber's current tiers, when reconfiguring an existing Pro
+   * plan. Pre-fills every dimension so the default is a no-op and an unrelated
+   * edit can't force re-picking — and dropping — a tier the user still holds.
+   * Leave null/undefined for the base checkout path, which starts empty.
+   */
+  initialSelection?: CustomPlanSelection | null;
   onClose: () => void;
   onContinue: (selection: CustomPlanSelection) => void;
 }
@@ -70,14 +77,16 @@ function priceSuffix(cents: number) {
  * "Create a custom plan" configurator opened from the Custom Plan row of the
  * View Plans takeover. Always light regardless of the app theme, matching the
  * white dialog over the dark takeover in the pricing mocks. The three pickers
- * render as dropdowns and start unselected; Continue stays disabled until
- * every dimension has an explicit choice ("No extra credits" counts).
+ * render as dropdowns and start unselected for base checkout (or seeded from
+ * the current plan for a Pro reconfigure); Continue stays disabled until every
+ * dimension has an explicit choice ("No extra credits" counts).
  */
 export function CustomPlanModal({
   open,
   proPlan,
   pending,
   currentStorageGib,
+  initialSelection,
   onClose,
   onContinue,
 }: CustomPlanModalProps) {
@@ -90,8 +99,16 @@ export function CustomPlanModal({
       setMachineTier("");
       setStorageTier("");
       setCreditChoice("");
+      return;
     }
-  }, [open]);
+    // Reopening for a Pro reconfigure seeds the current tiers so the default is
+    // a no-op; base checkout passes none and leaves every dimension empty.
+    if (initialSelection) {
+      setMachineTier(initialSelection.machineTier);
+      setStorageTier(initialSelection.storageTier);
+      setCreditChoice(initialSelection.creditTier ?? NO_EXTRA_CREDITS);
+    }
+  }, [open, initialSelection]);
 
   const machineTiers = proPlan.machine_tiers;
   // Legacy tiers stay in the catalog only for existing subscribers; a new

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
@@ -5,6 +5,11 @@ import { Button } from "@vellumai/design-library/components/button";
 export interface CustomPlanRowProps {
   className?: string;
   onConfigure: () => void;
+  /**
+   * Holds Configure disabled while a Pro sub's current tiers are still loading,
+   * so the click can't resolve before the parent knows how to route it.
+   */
+  configureDisabled?: boolean;
 }
 
 /**
@@ -12,7 +17,11 @@ export interface CustomPlanRowProps {
  * Configure does (opening the custom plan modal, or routing Pro subscribers
  * to the manage-plan modal).
  */
-export function CustomPlanRow({ className, onConfigure }: CustomPlanRowProps) {
+export function CustomPlanRow({
+  className,
+  onConfigure,
+  configureDisabled,
+}: CustomPlanRowProps) {
   return (
     <div className={`flex w-full flex-col items-center gap-8 ${className ?? ""}`}>
       <p className="text-center text-[20px] font-medium text-[var(--content-tertiary)]">
@@ -40,7 +49,11 @@ export function CustomPlanRow({ className, onConfigure }: CustomPlanRowProps) {
           <span className="text-[11px] font-medium text-[var(--content-tertiary)]">
             Billed monthly
           </span>
-          <Button variant="outlined" onClick={onConfigure}>
+          <Button
+            variant="outlined"
+            onClick={onConfigure}
+            disabled={configureDisabled}
+          >
             Configure
           </Button>
         </div>

--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -52,6 +52,17 @@ mock.module("@/generated/api/sdk.gen", () => ({
       response: { ok: true },
     });
   },
+  // PlansPage mounts `useChangeTiers`, which reads onboarding for a Pro sub;
+  // resolve it from a fixture so the checkout tests stay hermetic.
+  organizationsBillingSubscriptionOnboardingRetrieve: () =>
+    Promise.resolve({
+      data: {
+        max_machine_tier: "medium",
+        selected_storage_tier: "xs",
+        selected_storage_gib: 10,
+      },
+      response: { ok: true },
+    }),
 }));
 
 mock.module("@/runtime/browser", () => ({

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -38,9 +38,11 @@ import * as platformGateMod from "@/hooks/use-platform-gate";
 import * as toastMod from "@vellumai/design-library/components/toast";
 import {
   organizationsBillingPlansRetrieveQueryKey,
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
   organizationsBillingSubscriptionRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type {
+  OnboardingStateResponse,
   PackageChangeResponse,
   PlanListResponse,
   ProPackage,
@@ -52,7 +54,12 @@ const CHECKOUT_URL = "https://stripe.test/checkout/session";
 type Captured = { body?: unknown };
 let changePackageCall: Captured | null = null;
 let upgradeCall: Captured | null = null;
+let machineTierCall: Captured | null = null;
+let storageTierCall: Captured | null = null;
+let creditTierCall: Captured | null = null;
 let openedUrl: string | null = null;
+// When non-null, the change-machine-tier call rejects — drives the failure path.
+let machineTierError: unknown = null;
 // Success-toast messages captured from the mocked toast module — lets the
 // downgrade path assert its confirmation toast without rendering the Toaster.
 const toastSuccessCalls: string[] = [];
@@ -72,6 +79,7 @@ let changePackageError: unknown = null;
 // refetches resolve deterministically instead of hitting the network.
 let subscriptionFixture: SubscriptionResponse | null = null;
 let plansFixture: PlanListResponse | null = null;
+let onboardingFixture: OnboardingStateResponse | null = null;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -95,10 +103,27 @@ mock.module("@/generated/api/sdk.gen", () => ({
       response: { ok: true },
     });
   },
+  organizationsBillingSubscriptionChangeMachineTierCreate: (opts: Captured) => {
+    machineTierCall = opts;
+    if (machineTierError !== null) {
+      return Promise.reject(machineTierError);
+    }
+    return Promise.resolve({ data: {}, response: { ok: true } });
+  },
+  organizationsBillingSubscriptionChangeStorageTierCreate: (opts: Captured) => {
+    storageTierCall = opts;
+    return Promise.resolve({ data: {}, response: { ok: true } });
+  },
+  organizationsBillingSubscriptionChangeCreditTierCreate: (opts: Captured) => {
+    creditTierCall = opts;
+    return Promise.resolve({ data: {}, response: { ok: true } });
+  },
   organizationsBillingSubscriptionRetrieve: () =>
     Promise.resolve({ data: subscriptionFixture, response: { ok: true } }),
   organizationsBillingPlansRetrieve: () =>
     Promise.resolve({ data: plansFixture, response: { ok: true } }),
+  organizationsBillingSubscriptionOnboardingRetrieve: () =>
+    Promise.resolve({ data: onboardingFixture, response: { ok: true } }),
 }));
 
 mock.module("@/runtime/browser", () => ({
@@ -408,9 +433,31 @@ function LocationProbe() {
   return <div data-testid="loc">{location.pathname + location.search}</div>;
 }
 
-function renderInteractive(subscription: SubscriptionResponse) {
+/** Onboarding state carrying a Pro sub's current machine/storage tiers. */
+function onboarding(
+  overrides: Partial<OnboardingStateResponse> = {},
+): OnboardingStateResponse {
+  return {
+    max_machine_tier: "medium",
+    selected_storage_tier: "xs",
+    selected_storage_gib: 10,
+    pvc_ready: true,
+    domain_setup_available: false,
+    primary_assistant_id: null,
+    ...overrides,
+  };
+}
+
+function renderInteractive(
+  subscription: SubscriptionResponse,
+  {
+    plans = fullCatalog(),
+    onboardingData = onboarding(),
+  }: { plans?: PlanListResponse; onboardingData?: OnboardingStateResponse } = {},
+) {
   subscriptionFixture = subscription;
-  plansFixture = fullCatalog();
+  plansFixture = plans;
+  onboardingFixture = onboardingData;
   const client = new QueryClient({
     defaultOptions: {
       queries: {
@@ -426,7 +473,11 @@ function renderInteractive(subscription: SubscriptionResponse) {
     organizationsBillingSubscriptionRetrieveQueryKey(),
     subscription,
   );
-  client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), fullCatalog());
+  client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
+  client.setQueryData(
+    organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+    onboardingData,
+  );
   return render(
     <MemoryRouter initialEntries={["/assistant/plans"]}>
       <QueryClientProvider client={client}>
@@ -440,7 +491,11 @@ function renderInteractive(subscription: SubscriptionResponse) {
 beforeEach(() => {
   changePackageCall = null;
   upgradeCall = null;
+  machineTierCall = null;
+  storageTierCall = null;
+  creditTierCall = null;
   openedUrl = null;
+  machineTierError = null;
   changePackageAutoResolve = true;
   changePackageData = {
     status: "ok",
@@ -449,6 +504,7 @@ beforeEach(() => {
   changePackageError = null;
   subscriptionFixture = null;
   plansFixture = null;
+  onboardingFixture = null;
   toastSuccessCalls.length = 0;
 });
 
@@ -621,4 +677,170 @@ describe("PlansPage — ineligible Pro subs route to manage", () => {
       expect(upgradeCall).toBeNull();
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// Pro custom plan — change-tier dispatch via the Configure modal
+// ---------------------------------------------------------------------------
+
+/** A full catalog whose Pro plan carries the tier lists the custom modal needs. */
+function customCatalog(): PlanListResponse {
+  return {
+    plans: [
+      {
+        id: "base",
+        name: "Free",
+        price_cents: 0,
+        billing_interval: "month",
+        included_features: [],
+      },
+      {
+        id: "pro",
+        name: "Pro",
+        base_lookup_key: "pro_base",
+        base_price_cents: 2000,
+        billing_interval: "month",
+        included_features: [],
+        machine_tiers: [
+          {
+            tier: "medium",
+            label: "medium",
+            price_cents: 3500,
+            lookup_key: "machine_m",
+            cpu_limit: "2.5",
+            memory_gib: 5,
+            description: "Medium machine (2.5 vCPU, 5 GiB)",
+          },
+          {
+            tier: "large",
+            label: "large",
+            price_cents: 6000,
+            lookup_key: "machine_l",
+            cpu_limit: "4",
+            memory_gib: 8,
+            description: "Large machine (4 vCPU, 8 GiB)",
+          },
+        ],
+        storage_tiers: [
+          {
+            tier: "xs",
+            label: "10 GB",
+            storage_gib: 10,
+            price_cents: 500,
+            lookup_key: "storage_10",
+            legacy: false,
+          },
+          {
+            tier: "s",
+            label: "30 GB",
+            storage_gib: 30,
+            price_cents: 1000,
+            lookup_key: "storage_30",
+            legacy: false,
+          },
+        ],
+        credit_tiers: [
+          {
+            tier: "credits_50",
+            label: "50 credits",
+            credits_usd: 50,
+            price_cents: 5000,
+            lookup_key: "credits_50",
+          },
+        ],
+        packages: [MIGHTY, SUPER, ULTRA],
+      },
+    ],
+  };
+}
+
+function openDropdown(ariaLabel: string): void {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    `button[role="combobox"][aria-label="${ariaLabel}"]`,
+  );
+  if (!trigger) {
+    throw new Error(`expected a "${ariaLabel}" dropdown trigger`);
+  }
+  fireEvent.click(trigger);
+}
+
+/** Clicks the open-menu option whose text starts with `label`. */
+function selectOption(dropdownLabel: string, optionLabel: string): void {
+  openDropdown(dropdownLabel);
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => (o.textContent?.trim() ?? "").startsWith(optionLabel));
+  if (!option) {
+    throw new Error(`expected option "${optionLabel}"`);
+  }
+  fireEvent.click(option);
+}
+
+function continueButton(): HTMLButtonElement {
+  const button = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((b) => b.textContent?.trim() === "Continue");
+  if (!button) {
+    throw new Error("expected a Continue button");
+  }
+  return button;
+}
+
+describe("PlansPage — Pro custom plan (change-tier)", () => {
+  test("an eligible Pro sub's Configure opens the white modal, not adjust_plan", async () => {
+    const { findByRole, getByTestId, getByText } = renderInteractive(
+      proMightySubscription(),
+      { plans: customCatalog() },
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Configure" }));
+
+    getByText("Create a custom plan");
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("Continue dispatches change-tier for the changed dims and opens the resize takeover", async () => {
+    // Current config is medium machine / 10 GB (xs) storage / no credits.
+    const { findByRole, findByTestId } = renderInteractive(
+      proMightySubscription(),
+      { plans: customCatalog() },
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Configure" }));
+
+    selectOption("Machine size", "Large machine (4 vCPU, 8 GiB)");
+    selectOption("Storage", "10 GB");
+    selectOption("Credit bundle", "50 credits");
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(machineTierCall).not.toBeNull());
+    expect(machineTierCall!.body).toEqual({ machine_tier: "large" });
+    expect(creditTierCall!.body).toEqual({ credit_tier: "credits_50" });
+    // Storage is unchanged, so no storage-tier request fires.
+    expect(storageTierCall).toBeNull();
+
+    // A machine change resizes the assistant, so the takeover opens; checkout
+    // (which no-ops for active Pro) is never touched.
+    await findByTestId("resize-takeover");
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("an ineligible (cancelling) Pro sub's Configure routes to manage", async () => {
+    const { findByRole, getByTestId, queryByText } = renderInteractive(
+      { ...proMightySubscription(), cancel_at_period_end: true },
+      { plans: customCatalog() },
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Configure" }));
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe(
+        "/assistant/settings/usage?tab=billing&adjust_plan",
+      ),
+    );
+    expect(queryByText("Create a custom plan")).toBeNull();
+    expect(machineTierCall).toBeNull();
+    expect(upgradeCall).toBeNull();
+  });
 });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -395,7 +395,10 @@ describe("PlansPage — current-plan state", () => {
     // Super and Ultra sit above Mighty, so they keep their upgrade CTAs.
     expect(html).toContain("Go Super");
     expect(html).toContain("Unleash Ultra");
-    expect(count(html, /disabled=""/g)).toBe(1);
+    // Two disabled buttons: the current-plan (Mighty) CTA, and Configure —
+    // held disabled until the onboarding query supplies the current tiers,
+    // which a static first-paint render (no effects) never loads.
+    expect(count(html, /disabled=""/g)).toBe(2);
   });
 });
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -12,6 +12,7 @@ import {
 import { FREE_STORAGE_GIB } from "@/domains/settings/billing/plan-tier-meta";
 import {
   CustomPlanModal,
+  type CustomPlanSeed,
   type CustomPlanSelection,
 } from "@/domains/settings/billing/plans/custom-plan-modal";
 import { CustomPlanRow } from "@/domains/settings/billing/plans/custom-plan-row";
@@ -157,14 +158,12 @@ export function PlansPage() {
   // edit (e.g. only the machine) doesn't force re-picking — and dropping — the
   // storage or credit the user still holds. Null for base checkout, which
   // starts every dimension empty.
-  const customInitialSelection = useMemo<CustomPlanSelection | null>(() => {
-    if (
-      !isProUser ||
-      current.machineTier == null ||
-      current.storageTier == null
-    ) {
+  const customInitialSelection = useMemo<CustomPlanSeed | null>(() => {
+    if (!isProUser || current.storageTier == null) {
       return null;
     }
+    // `machineTier` may be null for a baseline (Small) package — the modal
+    // seeds storage/credit and leaves the machine picker empty in that case.
     return {
       machineTier: current.machineTier,
       storageTier: current.storageTier,
@@ -181,9 +180,11 @@ export function PlansPage() {
     if (!isProUser || !proPlan) {
       return false;
     }
-    const machineOk = proPlan.machine_tiers.some(
-      (t) => t.tier === current.machineTier,
-    );
+    // A null baseline machine (a package with no paid machine tier) is a valid
+    // current state — represent it rather than excluding the sub from the modal.
+    const machineOk =
+      current.machineTier == null ||
+      proPlan.machine_tiers.some((t) => t.tier === current.machineTier);
     const storageOk = proPlan.storage_tiers.some(
       (t) => !t.legacy && t.tier === current.storageTier,
     );

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -133,6 +133,7 @@ export function PlansPage() {
     isPending: changeTiersPending,
     current,
     eligible,
+    currentReady,
   } = useChangeTiers();
   const [pending, setPending] = useState(false);
   const [customPlanOpen, setCustomPlanOpen] = useState(false);
@@ -371,6 +372,13 @@ export function PlansPage() {
 
     const handleConfigure = () => {
       if (isProUser) {
+        // The current tiers that decide representability load after the page
+        // renders. While that first load is in flight, don't fall through to
+        // the manage surface — the Configure CTA is held disabled until they
+        // land (see `configureDisabled`), so this is a defensive guard.
+        if (eligible && !currentReady) {
+          return;
+        }
         // An eligible Pro sub whose current tiers are all representable here
         // reconfigures in the white modal. Anything else — cancelling /
         // non-entitlement status, or a legacy/deprecated tier the modal can't
@@ -464,7 +472,11 @@ export function PlansPage() {
           })}
         </div>
 
-        <CustomPlanRow className="mt-10" onConfigure={handleConfigure} />
+        <CustomPlanRow
+          className="mt-10"
+          onConfigure={handleConfigure}
+          configureDisabled={isProUser && eligible && !currentReady}
+        />
 
         <CustomPlanModal
           open={customPlanOpen}

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -22,6 +22,7 @@ import {
   getPlanTierCopy,
 } from "@/domains/settings/billing/plans/plans-copy";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
+import { useChangeTiers } from "@/domains/settings/billing/use-change-tiers";
 import {
   extractMutationError,
   isPackageSwitchEligible,
@@ -127,6 +128,12 @@ export function PlansPage() {
     organizationsBillingSubscriptionUpgradeCreateMutation(),
   );
   const { changePackage, isPending: changePackagePending } = useChangePackage();
+  const {
+    changeTiers,
+    isPending: changeTiersPending,
+    current,
+    eligible,
+  } = useChangeTiers();
   const [pending, setPending] = useState(false);
   const [customPlanOpen, setCustomPlanOpen] = useState(false);
   // The package a Pro user is switching to, awaiting reconfirm; null when the
@@ -298,10 +305,34 @@ export function PlansPage() {
         credit_tier: selection.creditTier,
       });
 
+    // Active Pro orgs edit their tiers in place via the change-tier endpoints;
+    // the upgrade/checkout endpoint no-ops for an active Pro sub.
+    const applyCustomTierChange = async (selection: CustomPlanSelection) => {
+      const result = await changeTiers(selection);
+      if (!result) {
+        // The hook toasted; keep the modal open so the user can retry.
+        return;
+      }
+      setCustomPlanOpen(false);
+      if (result.needsResize) {
+        // A machine/storage change needs the assistant to provision the new
+        // ceiling — open the same in-tab resize takeover the tier-change flow uses.
+        setResizeTakeoverOpen(true);
+      } else {
+        toast.success("Plan updated.");
+      }
+    };
+
     const handleConfigure = () => {
       if (isProUser) {
-        // Same rule as the plan-card CTAs: the upgrade endpoint no-ops for an
-        // active Pro org, so plan changes go through the manage-plan modal.
+        // An eligible Pro sub reconfigures its tiers in the white modal; an
+        // ineligible one (cancelling / non-entitlement status) can't change
+        // tiers in place, so route it to the billing manage/cancel surface —
+        // the same fallback the package CTAs use.
+        if (eligible) {
+          setCustomPlanOpen(true);
+          return;
+        }
         navigate(`${routes.settings.usage}?tab=billing&adjust_plan`);
         return;
       }
@@ -391,9 +422,16 @@ export function PlansPage() {
         <CustomPlanModal
           open={customPlanOpen}
           proPlan={proPlan}
-          pending={pending}
+          pending={pending || changeTiersPending}
+          currentStorageGib={isProUser ? current.storageGib : null}
           onClose={() => setCustomPlanOpen(false)}
-          onContinue={(selection) => void startCustomCheckout(selection)}
+          onContinue={(selection) => {
+            if (isProUser) {
+              void applyCustomTierChange(selection);
+            } else {
+              void startCustomCheckout(selection);
+            }
+          }}
         />
 
         <PackageSwitchConfirmModal

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, Loader2 } from "lucide-react";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -150,6 +150,53 @@ export function PlansPage() {
   );
   const packages = proPlan?.packages ?? [];
   const hasPackages = packages.length > 0;
+  const isProUser = subscription?.plan_id === "pro";
+
+  // Seed the custom-plan modal with the Pro sub's current tiers so an unrelated
+  // edit (e.g. only the machine) doesn't force re-picking — and dropping — the
+  // storage or credit the user still holds. Null for base checkout, which
+  // starts every dimension empty.
+  const customInitialSelection = useMemo<CustomPlanSelection | null>(() => {
+    if (
+      !isProUser ||
+      current.machineTier == null ||
+      current.storageTier == null
+    ) {
+      return null;
+    }
+    return {
+      machineTier: current.machineTier,
+      storageTier: current.storageTier,
+      creditTier: current.creditTier,
+    };
+  }, [isProUser, current.machineTier, current.storageTier, current.creditTier]);
+
+  // The in-place custom editor can only faithfully represent a Pro sub whose
+  // current tiers are all live catalog options. A legacy storage tier or a
+  // deprecated credit bundle can't be shown or re-selected here — routing such
+  // a sub through the modal would force it to drop that tier — so those fall
+  // back to the adjust-plan surface (which preserves them) instead.
+  const customReconfigurable = useMemo(() => {
+    if (!isProUser || !proPlan) {
+      return false;
+    }
+    const machineOk = proPlan.machine_tiers.some(
+      (t) => t.tier === current.machineTier,
+    );
+    const storageOk = proPlan.storage_tiers.some(
+      (t) => !t.legacy && t.tier === current.storageTier,
+    );
+    const creditOk =
+      current.creditTier == null ||
+      (proPlan.credit_tiers ?? []).some((t) => t.tier === current.creditTier);
+    return machineOk && storageOk && creditOk;
+  }, [
+    isProUser,
+    proPlan,
+    current.machineTier,
+    current.storageTier,
+    current.creditTier,
+  ]);
 
   // The takeover only makes sense against a platform-hosted assistant with a
   // live package catalog. Anything else — self-hosted or no platform session,
@@ -216,7 +263,6 @@ export function PlansPage() {
 
   let body: ReactNode;
   if (subscription && proPlan && hasPackages) {
-    const isProUser = subscription.plan_id === "pro";
     const currentTierKey =
       subscription.plan_id === "base"
         ? "free"
@@ -325,11 +371,12 @@ export function PlansPage() {
 
     const handleConfigure = () => {
       if (isProUser) {
-        // An eligible Pro sub reconfigures its tiers in the white modal; an
-        // ineligible one (cancelling / non-entitlement status) can't change
-        // tiers in place, so route it to the billing manage/cancel surface —
-        // the same fallback the package CTAs use.
-        if (eligible) {
+        // An eligible Pro sub whose current tiers are all representable here
+        // reconfigures in the white modal. Anything else — cancelling /
+        // non-entitlement status, or a legacy/deprecated tier the modal can't
+        // show — routes to the billing manage/cancel surface, the same fallback
+        // the package CTAs use.
+        if (eligible && customReconfigurable) {
           setCustomPlanOpen(true);
           return;
         }
@@ -424,6 +471,7 @@ export function PlansPage() {
           proPlan={proPlan}
           pending={pending || changeTiersPending}
           currentStorageGib={isProUser ? current.storageGib : null}
+          initialSelection={customInitialSelection}
           onClose={() => setCustomPlanOpen(false)}
           onContinue={(selection) => {
             if (isProUser) {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -135,7 +135,7 @@ export function PlansPage() {
     current,
     eligible,
     currentReady,
-  } = useChangeTiers();
+  } = useChangeTiers({ enabled: platformReady });
   const [pending, setPending] = useState(false);
   const [customPlanOpen, setCustomPlanOpen] = useState(false);
   // The package a Pro user is switching to, awaiting reconfirm; null when the

--- a/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
@@ -27,6 +27,8 @@ const PLANS_KEY = ["plans"];
 // The fixtures the mocked retrieve options resolve; each test seeds them.
 let subscriptionFixture: SubscriptionResponse | null = null;
 let onboardingFixture: OnboardingStateResponse | null = null;
+// When true, the onboarding query stays pending (its first load never lands).
+let onboardingHangs = false;
 
 // Per-dimension captured bodies + resolution controls.
 type Body = { body: Record<string, unknown> };
@@ -45,7 +47,10 @@ mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
   organizationsBillingSubscriptionRetrieveQueryKey: () => SUBSCRIPTION_KEY,
   organizationsBillingSubscriptionOnboardingRetrieveOptions: () => ({
     queryKey: ONBOARDING_KEY,
-    queryFn: () => onboardingFixture,
+    // When `onboardingHangs`, never resolves — models the first onboarding load
+    // still in flight so `currentReady` can be exercised.
+    queryFn: () =>
+      onboardingHangs ? new Promise(() => {}) : onboardingFixture,
   }),
   organizationsBillingSubscriptionOnboardingRetrieveQueryKey: () =>
     ONBOARDING_KEY,
@@ -116,7 +121,7 @@ function onboarding(
  * Render the hook against a fresh QueryClient seeded with the current fixtures,
  * recording every key passed to `invalidateQueries`.
  */
-function setup() {
+function setup({ seedOnboarding = true }: { seedOnboarding?: boolean } = {}) {
   const client = new QueryClient({
     defaultOptions: {
       queries: {
@@ -129,7 +134,9 @@ function setup() {
     },
   });
   client.setQueryData(SUBSCRIPTION_KEY, subscriptionFixture);
-  client.setQueryData(ONBOARDING_KEY, onboardingFixture);
+  if (seedOnboarding) {
+    client.setQueryData(ONBOARDING_KEY, onboardingFixture);
+  }
   const invalidatedKeys: unknown[] = [];
   type InvalidateFn = QueryClient["invalidateQueries"];
   const originalInvalidate = client.invalidateQueries.bind(client);
@@ -152,6 +159,7 @@ describe("useChangeTiers", () => {
     machineImpl = async () => ({});
     storageImpl = async () => ({});
     creditImpl = async () => ({});
+    onboardingHangs = false;
     subscriptionFixture = proSubscription();
     onboardingFixture = onboarding();
   });
@@ -183,6 +191,28 @@ describe("useChangeTiers", () => {
     subscriptionFixture = proSubscription({ plan_id: "base" });
     const { result } = setup();
     expect(result.current.eligible).toBe(false);
+  });
+
+  test("currentReady is false while the onboarding query is still loading", () => {
+    // No seeded onboarding data + a hanging fetch keeps the query pending.
+    onboardingHangs = true;
+    const { result } = setup({ seedOnboarding: false });
+    expect(result.current.currentReady).toBe(false);
+    // The current tiers aren't known yet, so they read as null.
+    expect(result.current.current.machineTier).toBeNull();
+    expect(result.current.current.storageTier).toBeNull();
+  });
+
+  test("currentReady is true once the onboarding data is present", () => {
+    const { result } = setup();
+    expect(result.current.currentReady).toBe(true);
+  });
+
+  test("currentReady is true for a base sub (no onboarding to await)", () => {
+    subscriptionFixture = proSubscription({ plan_id: "base" });
+    onboardingHangs = true;
+    const { result } = setup({ seedOnboarding: false });
+    expect(result.current.currentReady).toBe(true);
   });
 
   test("fires only the changed dimensions and invalidates on success", async () => {

--- a/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for `useChangeTiers`. The three generated change-tier mutations, the
+ * subscription/onboarding retrieve query options, and the billing query-key
+ * factories are `mock.module`-replaced so the hook reads seeded fixtures and
+ * dispatches against controllable `mutationFn`s. `extractMutationError` (real)
+ * turns a `{ detail }` reject into the toasted message. The seeded QueryClient
+ * uses `staleTime/gcTime: Infinity` + `retry: false` so the queries resolve
+ * synchronously from the cache and never hit the network.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import type {
+  OnboardingStateResponse,
+  SubscriptionResponse,
+} from "@/generated/api/types.gen";
+
+import type { ChangeTiersResult } from "./use-change-tiers";
+
+// Sentinel query keys let the invalidation assertions match on identity.
+const SUBSCRIPTION_KEY = ["subscription"];
+const ONBOARDING_KEY = ["onboarding"];
+const PLANS_KEY = ["plans"];
+
+// The fixtures the mocked retrieve options resolve; each test seeds them.
+let subscriptionFixture: SubscriptionResponse | null = null;
+let onboardingFixture: OnboardingStateResponse | null = null;
+
+// Per-dimension captured bodies + resolution controls.
+type Body = { body: Record<string, unknown> };
+const machineCalls: Body[] = [];
+const storageCalls: Body[] = [];
+const creditCalls: Body[] = [];
+let machineImpl: (opts: Body) => Promise<unknown>;
+let storageImpl: (opts: Body) => Promise<unknown>;
+let creditImpl: (opts: Body) => Promise<unknown>;
+
+mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
+  organizationsBillingSubscriptionRetrieveOptions: () => ({
+    queryKey: SUBSCRIPTION_KEY,
+    queryFn: () => subscriptionFixture,
+  }),
+  organizationsBillingSubscriptionRetrieveQueryKey: () => SUBSCRIPTION_KEY,
+  organizationsBillingSubscriptionOnboardingRetrieveOptions: () => ({
+    queryKey: ONBOARDING_KEY,
+    queryFn: () => onboardingFixture,
+  }),
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey: () =>
+    ONBOARDING_KEY,
+  organizationsBillingPlansRetrieveQueryKey: () => PLANS_KEY,
+  organizationsBillingSubscriptionChangeMachineTierCreateMutation: () => ({
+    mutationFn: (opts: Body) => {
+      machineCalls.push(opts);
+      return machineImpl(opts);
+    },
+  }),
+  organizationsBillingSubscriptionChangeStorageTierCreateMutation: () => ({
+    mutationFn: (opts: Body) => {
+      storageCalls.push(opts);
+      return storageImpl(opts);
+    },
+  }),
+  organizationsBillingSubscriptionChangeCreditTierCreateMutation: () => ({
+    mutationFn: (opts: Body) => {
+      creditCalls.push(opts);
+      return creditImpl(opts);
+    },
+  }),
+}));
+
+const toastErrorCalls: string[] = [];
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: {
+    error: (message: string) => {
+      toastErrorCalls.push(message);
+    },
+  },
+}));
+
+const { useChangeTiers } = await import("./use-change-tiers");
+
+function proSubscription(
+  overrides: Partial<SubscriptionResponse> = {},
+): SubscriptionResponse {
+  return {
+    plan_id: "pro",
+    status: "active",
+    renewal_date: null,
+    current_period_end: "2026-07-10T00:00:00Z",
+    cancel_at_period_end: false,
+    cancel_at: null,
+    selected_credit_tier: null,
+    package: { key: "super", name: "Super", version: 1, customized: false },
+    entitlements: { managed_email: false, phone_number: false },
+    ...overrides,
+  };
+}
+
+function onboarding(
+  overrides: Partial<OnboardingStateResponse> = {},
+): OnboardingStateResponse {
+  return {
+    max_machine_tier: "medium",
+    selected_storage_tier: "xs",
+    selected_storage_gib: 10,
+    pvc_ready: true,
+    domain_setup_available: false,
+    primary_assistant_id: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Render the hook against a fresh QueryClient seeded with the current fixtures,
+ * recording every key passed to `invalidateQueries`.
+ */
+function setup() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        gcTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(SUBSCRIPTION_KEY, subscriptionFixture);
+  client.setQueryData(ONBOARDING_KEY, onboardingFixture);
+  const invalidatedKeys: unknown[] = [];
+  type InvalidateFn = QueryClient["invalidateQueries"];
+  const originalInvalidate = client.invalidateQueries.bind(client);
+  client.invalidateQueries = ((...args: Parameters<InvalidateFn>) => {
+    invalidatedKeys.push(args[0]?.queryKey);
+    return originalInvalidate(...args);
+  }) as InvalidateFn;
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+  const { result } = renderHook(() => useChangeTiers(), { wrapper });
+  return { result, invalidatedKeys };
+}
+
+describe("useChangeTiers", () => {
+  beforeEach(() => {
+    machineCalls.length = 0;
+    storageCalls.length = 0;
+    creditCalls.length = 0;
+    toastErrorCalls.length = 0;
+    machineImpl = async () => ({});
+    storageImpl = async () => ({});
+    creditImpl = async () => ({});
+    subscriptionFixture = proSubscription();
+    onboardingFixture = onboarding();
+  });
+
+  test("derives current tiers and eligibility for an active Pro sub", () => {
+    const { result } = setup();
+    expect(result.current.current).toEqual({
+      machineTier: "medium",
+      storageTier: "xs",
+      storageGib: 10,
+      creditTier: null,
+    });
+    expect(result.current.eligible).toBe(true);
+  });
+
+  test("is ineligible when the sub is cancelling", () => {
+    subscriptionFixture = proSubscription({ cancel_at_period_end: true });
+    const { result } = setup();
+    expect(result.current.eligible).toBe(false);
+  });
+
+  test("is ineligible in a non-entitlement status", () => {
+    subscriptionFixture = proSubscription({ status: "unpaid" });
+    const { result } = setup();
+    expect(result.current.eligible).toBe(false);
+  });
+
+  test("is ineligible for a base sub", () => {
+    subscriptionFixture = proSubscription({ plan_id: "base" });
+    const { result } = setup();
+    expect(result.current.eligible).toBe(false);
+  });
+
+  test("fires only the changed dimensions and invalidates on success", async () => {
+    // Current is medium/xs/null; change machine + credit, keep storage.
+    const { result, invalidatedKeys } = setup();
+
+    const captured: { value: ChangeTiersResult | null } = { value: null };
+    await act(async () => {
+      captured.value = await result.current.changeTiers({
+        machineTier: "large",
+        storageTier: "xs",
+        creditTier: "credits_50",
+      });
+    });
+
+    expect(machineCalls).toEqual([{ body: { machine_tier: "large" } }]);
+    expect(creditCalls).toEqual([{ body: { credit_tier: "credits_50" } }]);
+    // Storage is unchanged, so no storage-tier call fires.
+    expect(storageCalls).toEqual([]);
+    expect(invalidatedKeys).toEqual([SUBSCRIPTION_KEY, ONBOARDING_KEY, PLANS_KEY]);
+    expect(toastErrorCalls).toEqual([]);
+    // A machine change resizes the assistant.
+    expect(captured.value).toEqual({ needsResize: true });
+  });
+
+  test("a storage upgrade needs a resize", async () => {
+    const { result } = setup();
+
+    const captured: { value: ChangeTiersResult | null } = { value: null };
+    await act(async () => {
+      captured.value = await result.current.changeTiers({
+        machineTier: "medium",
+        storageTier: "s",
+        creditTier: null,
+      });
+    });
+
+    expect(storageCalls).toEqual([{ body: { storage_tier: "s" } }]);
+    expect(machineCalls).toEqual([]);
+    expect(captured.value).toEqual({ needsResize: true });
+  });
+
+  test("a credit-only change does not need a resize", async () => {
+    const { result } = setup();
+
+    const captured: { value: ChangeTiersResult | null } = { value: null };
+    await act(async () => {
+      captured.value = await result.current.changeTiers({
+        machineTier: "medium",
+        storageTier: "xs",
+        creditTier: "credits_50",
+      });
+    });
+
+    expect(creditCalls).toEqual([{ body: { credit_tier: "credits_50" } }]);
+    expect(machineCalls).toEqual([]);
+    expect(storageCalls).toEqual([]);
+    expect(captured.value).toEqual({ needsResize: false });
+  });
+
+  test("toasts the extracted error and returns null on failure", async () => {
+    machineImpl = async () => {
+      throw { detail: "Payment failed. Your card was declined." };
+    };
+    const { result } = setup();
+
+    const captured: { value: ChangeTiersResult | null } = {
+      value: { needsResize: true },
+    };
+    await act(async () => {
+      captured.value = await result.current.changeTiers({
+        machineTier: "large",
+        storageTier: "xs",
+        creditTier: null,
+      });
+    });
+
+    expect(captured.value).toBeNull();
+    expect(toastErrorCalls).toEqual([
+      "Payment failed. Your card was declined.",
+    ]);
+  });
+
+  test("posting no changes is a successful no-op with no dispatch", async () => {
+    const { result, invalidatedKeys } = setup();
+
+    const captured: { value: ChangeTiersResult | null } = { value: null };
+    await act(async () => {
+      captured.value = await result.current.changeTiers({
+        machineTier: "medium",
+        storageTier: "xs",
+        creditTier: null,
+      });
+    });
+
+    expect(machineCalls).toEqual([]);
+    expect(storageCalls).toEqual([]);
+    expect(creditCalls).toEqual([]);
+    expect(invalidatedKeys).toEqual([]);
+    expect(captured.value).toEqual({ needsResize: false });
+  });
+});

--- a/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
@@ -14,6 +14,7 @@ import { createElement, type ReactNode } from "react";
 
 import type {
   OnboardingStateResponse,
+  PlanListResponse,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
 
@@ -27,8 +28,48 @@ const PLANS_KEY = ["plans"];
 // The fixtures the mocked retrieve options resolve; each test seeds them.
 let subscriptionFixture: SubscriptionResponse | null = null;
 let onboardingFixture: OnboardingStateResponse | null = null;
+let plansFixture: PlanListResponse | null = null;
 // When true, the onboarding query stays pending (its first load never lands).
 let onboardingHangs = false;
+
+/** Pro catalog whose machine tiers carry the prices used to rank up/downgrades. */
+function proPlans(): PlanListResponse {
+  return {
+    plans: [
+      {
+        id: "pro",
+        name: "Pro",
+        base_lookup_key: "pro_base",
+        base_price_cents: 2000,
+        billing_interval: "month",
+        included_features: [],
+        machine_tiers: [
+          {
+            tier: "medium",
+            label: "medium",
+            price_cents: 3500,
+            lookup_key: "machine_m",
+            cpu_limit: "2.5",
+            memory_gib: 5,
+            description: "Medium",
+          },
+          {
+            tier: "large",
+            label: "large",
+            price_cents: 6000,
+            lookup_key: "machine_l",
+            cpu_limit: "4",
+            memory_gib: 8,
+            description: "Large",
+          },
+        ],
+        storage_tiers: [],
+        credit_tiers: [],
+        packages: [],
+      },
+    ],
+  };
+}
 
 // Per-dimension captured bodies + resolution controls.
 type Body = { body: Record<string, unknown> };
@@ -54,6 +95,10 @@ mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
   }),
   organizationsBillingSubscriptionOnboardingRetrieveQueryKey: () =>
     ONBOARDING_KEY,
+  organizationsBillingPlansRetrieveOptions: () => ({
+    queryKey: PLANS_KEY,
+    queryFn: () => plansFixture,
+  }),
   organizationsBillingPlansRetrieveQueryKey: () => PLANS_KEY,
   organizationsBillingSubscriptionChangeMachineTierCreateMutation: () => ({
     mutationFn: (opts: Body) => {
@@ -134,6 +179,7 @@ function setup({ seedOnboarding = true }: { seedOnboarding?: boolean } = {}) {
     },
   });
   client.setQueryData(SUBSCRIPTION_KEY, subscriptionFixture);
+  client.setQueryData(PLANS_KEY, plansFixture);
   if (seedOnboarding) {
     client.setQueryData(ONBOARDING_KEY, onboardingFixture);
   }
@@ -162,6 +208,7 @@ describe("useChangeTiers", () => {
     onboardingHangs = false;
     subscriptionFixture = proSubscription();
     onboardingFixture = onboarding();
+    plansFixture = proPlans();
   });
 
   test("derives current tiers and eligibility for an active Pro sub", () => {
@@ -253,6 +300,25 @@ describe("useChangeTiers", () => {
     expect(storageCalls).toEqual([{ body: { storage_tier: "s" } }]);
     expect(machineCalls).toEqual([]);
     expect(captured.value).toEqual({ needsResize: true });
+  });
+
+  test("a machine downgrade does not need a resize", async () => {
+    // Current machine is large; lowering to medium is a downgrade (cheaper),
+    // which is capped server-side and must not open the resize takeover.
+    onboardingFixture = onboarding({ max_machine_tier: "large" });
+    const { result } = setup();
+
+    const captured: { value: ChangeTiersResult | null } = { value: null };
+    await act(async () => {
+      captured.value = await result.current.changeTiers({
+        machineTier: "medium",
+        storageTier: "xs",
+        creditTier: null,
+      });
+    });
+
+    expect(machineCalls).toEqual([{ body: { machine_tier: "medium" } }]);
+    expect(captured.value).toEqual({ needsResize: false });
   });
 
   test("a credit-only change does not need a resize", async () => {

--- a/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
@@ -266,6 +266,56 @@ describe("useChangeTiers", () => {
     ]);
   });
 
+  test("opens the resize takeover when a resource dim lands but credit fails", async () => {
+    // Storage upgrade succeeds server-side; the credit change fails. The
+    // entitlement already moved, so the caller must still open resize.
+    creditImpl = async () => {
+      throw { detail: "Payment failed. Your card was declined." };
+    };
+    subscriptionFixture = proSubscription({ selected_credit_tier: null });
+    const { result } = setup();
+
+    const captured: { value: ChangeTiersResult | null } = { value: null };
+    await act(async () => {
+      captured.value = await result.current.changeTiers({
+        machineTier: "medium",
+        storageTier: "s",
+        creditTier: "credits_50",
+      });
+    });
+
+    expect(storageCalls).toEqual([{ body: { storage_tier: "s" } }]);
+    expect(creditCalls).toEqual([{ body: { credit_tier: "credits_50" } }]);
+    expect(toastErrorCalls).toEqual([
+      "Payment failed. Your card was declined.",
+    ]);
+    expect(captured.value).toEqual({ needsResize: true });
+  });
+
+  test("returns null when only a non-resource dim landed and a resource failed", async () => {
+    // Machine (the sole resource change) fails; the credit change succeeds. No
+    // provisioning is owed, so hold the modal open for a retry.
+    machineImpl = async () => {
+      throw { detail: "Machine tier unavailable." };
+    };
+    const { result } = setup();
+
+    const captured: { value: ChangeTiersResult | null } = {
+      value: { needsResize: true },
+    };
+    await act(async () => {
+      captured.value = await result.current.changeTiers({
+        machineTier: "large",
+        storageTier: "xs",
+        creditTier: "credits_50",
+      });
+    });
+
+    expect(creditCalls).toEqual([{ body: { credit_tier: "credits_50" } }]);
+    expect(toastErrorCalls).toEqual(["Machine tier unavailable."]);
+    expect(captured.value).toBeNull();
+  });
+
   test("posting no changes is a successful no-op with no dispatch", async () => {
     const { result, invalidatedKeys } = setup();
 

--- a/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
@@ -79,11 +79,16 @@ const creditCalls: Body[] = [];
 let machineImpl: (opts: Body) => Promise<unknown>;
 let storageImpl: (opts: Body) => Promise<unknown>;
 let creditImpl: (opts: Body) => Promise<unknown>;
+// Counts subscription fetches so the readiness gate can be asserted.
+let subscriptionFetches = 0;
 
 mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
   organizationsBillingSubscriptionRetrieveOptions: () => ({
     queryKey: SUBSCRIPTION_KEY,
-    queryFn: () => subscriptionFixture,
+    queryFn: () => {
+      subscriptionFetches += 1;
+      return subscriptionFixture;
+    },
   }),
   organizationsBillingSubscriptionRetrieveQueryKey: () => SUBSCRIPTION_KEY,
   organizationsBillingSubscriptionOnboardingRetrieveOptions: () => ({
@@ -166,7 +171,15 @@ function onboarding(
  * Render the hook against a fresh QueryClient seeded with the current fixtures,
  * recording every key passed to `invalidateQueries`.
  */
-function setup({ seedOnboarding = true }: { seedOnboarding?: boolean } = {}) {
+function setup({
+  seedOnboarding = true,
+  seedSubscription = true,
+  enabled = true,
+}: {
+  seedOnboarding?: boolean;
+  seedSubscription?: boolean;
+  enabled?: boolean;
+} = {}) {
   const client = new QueryClient({
     defaultOptions: {
       queries: {
@@ -178,7 +191,9 @@ function setup({ seedOnboarding = true }: { seedOnboarding?: boolean } = {}) {
       },
     },
   });
-  client.setQueryData(SUBSCRIPTION_KEY, subscriptionFixture);
+  if (seedSubscription) {
+    client.setQueryData(SUBSCRIPTION_KEY, subscriptionFixture);
+  }
   client.setQueryData(PLANS_KEY, plansFixture);
   if (seedOnboarding) {
     client.setQueryData(ONBOARDING_KEY, onboardingFixture);
@@ -197,7 +212,7 @@ function setup({ seedOnboarding = true }: { seedOnboarding?: boolean } = {}) {
   }) as InvalidateFn;
   const wrapper = ({ children }: { children: ReactNode }) =>
     createElement(QueryClientProvider, { client }, children);
-  const { result } = renderHook(() => useChangeTiers(), { wrapper });
+  const { result } = renderHook(() => useChangeTiers({ enabled }), { wrapper });
   return { result, invalidatedKeys, events };
 }
 
@@ -211,9 +226,21 @@ describe("useChangeTiers", () => {
     storageImpl = async () => ({});
     creditImpl = async () => ({});
     onboardingHangs = false;
+    subscriptionFetches = 0;
     subscriptionFixture = proSubscription();
     onboardingFixture = onboarding();
     plansFixture = proPlans();
+  });
+
+  test("holds the org-scoped subscription read until enabled", async () => {
+    // Disabled (the caller's platform gate is not open yet) and unseeded, so
+    // the org-scoped read must not fire without the org header.
+    const { result } = setup({ enabled: false, seedSubscription: false });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(subscriptionFetches).toBe(0);
+    expect(result.current.eligible).toBe(false);
   });
 
   test("derives current tiers and eligibility for an active Pro sub", () => {

--- a/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
@@ -184,16 +184,21 @@ function setup({ seedOnboarding = true }: { seedOnboarding?: boolean } = {}) {
     client.setQueryData(ONBOARDING_KEY, onboardingFixture);
   }
   const invalidatedKeys: unknown[] = [];
+  // Ordered log of when each invalidation settled, so a test can prove
+  // `changeTiers` resolves only after they have.
+  const events: string[] = [];
   type InvalidateFn = QueryClient["invalidateQueries"];
   const originalInvalidate = client.invalidateQueries.bind(client);
   client.invalidateQueries = ((...args: Parameters<InvalidateFn>) => {
     invalidatedKeys.push(args[0]?.queryKey);
-    return originalInvalidate(...args);
+    return originalInvalidate(...args).then(() => {
+      events.push("invalidated");
+    });
   }) as InvalidateFn;
   const wrapper = ({ children }: { children: ReactNode }) =>
     createElement(QueryClientProvider, { client }, children);
   const { result } = renderHook(() => useChangeTiers(), { wrapper });
-  return { result, invalidatedKeys };
+  return { result, invalidatedKeys, events };
 }
 
 describe("useChangeTiers", () => {
@@ -300,6 +305,29 @@ describe("useChangeTiers", () => {
     expect(storageCalls).toEqual([{ body: { storage_tier: "s" } }]);
     expect(machineCalls).toEqual([]);
     expect(captured.value).toEqual({ needsResize: true });
+  });
+
+  test("billing refetches are awaited before the result resolves", async () => {
+    // The resize takeover reads the onboarding query and treats cached data as
+    // loaded, so every invalidation must settle before the caller opens it —
+    // otherwise a machine upgrade applies against the pre-change ceiling.
+    const { result, events } = setup();
+
+    await act(async () => {
+      await result.current.changeTiers({
+        machineTier: "large",
+        storageTier: "xs",
+        creditTier: null,
+      });
+      events.push("resolved");
+    });
+
+    expect(events).toEqual([
+      "invalidated",
+      "invalidated",
+      "invalidated",
+      "resolved",
+    ]);
   });
 
   test("a machine downgrade does not need a resize", async () => {

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -199,6 +199,13 @@ export function useChangeTiers(): UseChangeTiersResult {
     const results = await Promise.all(pending);
     invalidateBillingQueries();
 
+    // Storage here is always an upgrade (the modal disables downgrades) and any
+    // machine change resizes the assistant, so a succeeded resource dimension
+    // means the assistant must provision the new ceiling.
+    const needsResize = results.some(
+      (r) => r.ok && (r.dimension === "machine" || r.dimension === "storage"),
+    );
+
     const failures = results.filter((r) => !r.ok);
     if (failures.length > 0) {
       const message = failures
@@ -207,12 +214,14 @@ export function useChangeTiers(): UseChangeTiersResult {
         )
         .join(" ");
       toast.error(message);
-      return null;
+      // A resource dimension can persist server-side even when another one
+      // fails, so still surface the resize takeover to provision it; the caller
+      // closes the modal. Only when nothing landed do we return null to hold the
+      // modal open for a retry.
+      return needsResize ? { needsResize: true } : null;
     }
 
-    // Storage here is always an upgrade (the modal disables downgrades) and any
-    // machine change resizes the assistant, so either one needs provisioning.
-    return { needsResize: machineChanged || storageChanged };
+    return { needsResize };
   };
 
   return { changeTiers, isPending, current, eligible };

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -6,6 +6,7 @@ import {
   extractMutationError,
 } from "@/domains/settings/components/adjust-plan-utils";
 import {
+  organizationsBillingPlansRetrieveOptions,
   organizationsBillingPlansRetrieveQueryKey,
   organizationsBillingSubscriptionChangeCreditTierCreateMutation,
   organizationsBillingSubscriptionChangeMachineTierCreateMutation,
@@ -18,6 +19,7 @@ import {
 import type {
   CreditTierEnum,
   MachineTierEnum,
+  ProPlan,
   StorageTierEnum,
 } from "@/generated/api/types.gen";
 
@@ -44,9 +46,10 @@ export interface ChangeTiersSelection {
 /** Outcome of a successful `changeTiers` dispatch. */
 export interface ChangeTiersResult {
   /**
-   * A machine or storage dimension changed and persisted, so the assistant
-   * must provision the new compute/disk — the caller opens the resize
-   * takeover. A credit-only change (or a no-op) leaves this false.
+   * A resource dimension grew and persisted — a storage upgrade or a machine
+   * upgrade — so the assistant must provision the new compute/disk and the
+   * caller opens the resize takeover. A machine downgrade, a credit-only
+   * change, or a no-op leaves this false.
    */
   needsResize: boolean;
 }
@@ -91,6 +94,18 @@ export function useChangeTiers(): UseChangeTiersResult {
     ...organizationsBillingSubscriptionOnboardingRetrieveOptions(),
     enabled: onPro,
   });
+  // Supplies the machine-tier prices used to tell an upgrade from a downgrade,
+  // the same way `adjust-plan-modal` reads them. Already cached by the plans
+  // page, so this is a deduped read.
+  const plansQuery = useQuery({
+    ...organizationsBillingPlansRetrieveOptions(),
+    enabled: onPro,
+  });
+  const machineTiers =
+    plansQuery.data?.plans.find((p): p is ProPlan => p.id === "pro")
+      ?.machine_tiers ?? [];
+  const machinePriceCents = (tier: MachineTierEnum | null): number | null =>
+    machineTiers.find((t) => t.tier === tier)?.price_cents ?? null;
 
   const changeMachineTierMutation = useMutation(
     organizationsBillingSubscriptionChangeMachineTierCreateMutation(),
@@ -132,17 +147,21 @@ export function useChangeTiers(): UseChangeTiersResult {
     changeStorageTierMutation.isPending ||
     changeCreditTierMutation.isPending;
 
-  const invalidateBillingQueries = () => {
-    void queryClient.invalidateQueries({
-      queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
-    });
-    void queryClient.invalidateQueries({
-      queryKey: organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
-    });
-    void queryClient.invalidateQueries({
-      queryKey: organizationsBillingPlansRetrieveQueryKey(),
-    });
-  };
+  // Awaited before a resize-needed result resolves so the takeover reads the
+  // refetched onboarding ceiling, not the stale cache (mirrors the
+  // package-switch path).
+  const invalidateBillingQueries = () =>
+    Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: organizationsBillingPlansRetrieveQueryKey(),
+      }),
+    ]);
 
   const changeTiers = async (
     selection: ChangeTiersSelection,
@@ -150,6 +169,17 @@ export function useChangeTiers(): UseChangeTiersResult {
     const machineChanged = selection.machineTier !== current.machineTier;
     const storageChanged = selection.storageTier !== current.storageTier;
     const creditChanged = selection.creditTier !== current.creditTier;
+
+    // A machine change that lowers the price is a downgrade — capped down
+    // server-side with no provisioning step — so it must not open the resize
+    // takeover (mirrors `adjust-plan-modal`'s price-based check).
+    const nextMachinePrice = machinePriceCents(selection.machineTier);
+    const currentMachinePrice = machinePriceCents(current.machineTier);
+    const machineIsDowngrade =
+      machineChanged &&
+      nextMachinePrice != null &&
+      currentMachinePrice != null &&
+      nextMachinePrice < currentMachinePrice;
 
     type DimensionResult = {
       dimension: "machine" | "storage" | "credit";
@@ -210,14 +240,21 @@ export function useChangeTiers(): UseChangeTiersResult {
     }
 
     const results = await Promise.all(pending);
-    invalidateBillingQueries();
+    // Await the refetches so a resize-needed result resolves only once the
+    // takeover can read the new ceiling instead of the stale cache.
+    await invalidateBillingQueries();
 
-    // Storage here is always an upgrade (the modal disables downgrades) and any
-    // machine change resizes the assistant, so a succeeded resource dimension
-    // means the assistant must provision the new ceiling.
-    const needsResize = results.some(
-      (r) => r.ok && (r.dimension === "machine" || r.dimension === "storage"),
+    // Storage is always an upgrade (the modal disables downgrades). A machine
+    // change needs a resize only when it grows the ceiling — a downgrade is
+    // capped server-side with no provisioning step. Either succeeded resource
+    // grow means the assistant must provision.
+    const machineUpgradeSucceeded =
+      results.some((r) => r.ok && r.dimension === "machine") &&
+      !machineIsDowngrade;
+    const storageSucceeded = results.some(
+      (r) => r.ok && r.dimension === "storage",
     );
+    const needsResize = machineUpgradeSucceeded || storageSucceeded;
 
     const failures = results.filter((r) => !r.ok);
     if (failures.length > 0) {

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -58,6 +58,13 @@ export interface UseChangeTiersResult {
   isPending: boolean;
   current: CurrentTiers;
   eligible: boolean;
+  /**
+   * False while the onboarding query behind `current` is still loading its
+   * first result for a Pro sub. `current.machineTier`/`storageTier` are null in
+   * that window, so callers must wait for this before treating a config as
+   * "not representable" — a false negative would misroute an eligible sub.
+   */
+  currentReady: boolean;
 }
 
 /**
@@ -113,6 +120,12 @@ export function useChangeTiers(): UseChangeTiersResult {
     TIER_CHANGE_ELIGIBLE_STATUSES.has(subscription.status) &&
     subscription.cancel_at_period_end !== true &&
     !subscription.cancel_at;
+
+  // For a Pro sub the current tiers come from the onboarding query, which
+  // resolves after the page has already rendered. Treat them as known only once
+  // that first load settles (success or error) — an error leaves the tiers null,
+  // which the caller safely reads as "not representable" and routes to manage.
+  const currentReady = !onPro || !onboardingQuery.isPending;
 
   const isPending =
     changeMachineTierMutation.isPending ||
@@ -224,5 +237,5 @@ export function useChangeTiers(): UseChangeTiersResult {
     return { needsResize };
   };
 
-  return { changeTiers, isPending, current, eligible };
+  return { changeTiers, isPending, current, eligible, currentReady };
 }

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -22,6 +22,7 @@ import type {
   ProPlan,
   StorageTierEnum,
 } from "@/generated/api/types.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 
 /**
  * The Pro subscription's current tier configuration, read the same way
@@ -81,25 +82,36 @@ export interface UseChangeTiersResult {
  * entitlement-bearing status — the change-tier endpoints 4xx otherwise. Unlike
  * `isPackageSwitchEligible`, a customized sub is allowed: a custom tier config
  * is exactly what this flow edits.
+ *
+ * Pass `enabled` (the caller's platform-hosted gate) to hold the org-scoped
+ * reads until the page is ready; they are also gated on org-header readiness.
  */
-export function useChangeTiers(): UseChangeTiersResult {
+export function useChangeTiers({
+  enabled = true,
+}: { enabled?: boolean } = {}): UseChangeTiersResult {
   const queryClient = useQueryClient();
-  const subscriptionQuery = useQuery(
-    organizationsBillingSubscriptionRetrieveOptions(),
-  );
+  // These are org-scoped reads, so hold them until the caller is ready (its own
+  // platform-hosted gate) and the org header source has hydrated — otherwise a
+  // request can fire without `Vellum-Organization-Id` and 4xx.
+  const orgReady = useIsOrgReady();
+  const ready = enabled && orgReady;
+  const subscriptionQuery = useQuery({
+    ...organizationsBillingSubscriptionRetrieveOptions(),
+    enabled: ready,
+  });
   const subscription = subscriptionQuery.data;
   const onPro = subscription != null && subscription.plan_id !== "base";
 
   const onboardingQuery = useQuery({
     ...organizationsBillingSubscriptionOnboardingRetrieveOptions(),
-    enabled: onPro,
+    enabled: ready && onPro,
   });
   // Supplies the machine-tier prices used to tell an upgrade from a downgrade,
   // the same way `adjust-plan-modal` reads them. Already cached by the plans
   // page, so this is a deduped read.
   const plansQuery = useQuery({
     ...organizationsBillingPlansRetrieveOptions(),
-    enabled: onPro,
+    enabled: ready && onPro,
   });
   const machineTiers =
     plansQuery.data?.plans.find((p): p is ProPlan => p.id === "pro")

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -1,0 +1,219 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "@vellumai/design-library/components/toast";
+
+import {
+  TIER_CHANGE_ELIGIBLE_STATUSES,
+  extractMutationError,
+} from "@/domains/settings/components/adjust-plan-utils";
+import {
+  organizationsBillingPlansRetrieveQueryKey,
+  organizationsBillingSubscriptionChangeCreditTierCreateMutation,
+  organizationsBillingSubscriptionChangeMachineTierCreateMutation,
+  organizationsBillingSubscriptionChangeStorageTierCreateMutation,
+  organizationsBillingSubscriptionOnboardingRetrieveOptions,
+  organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
+  organizationsBillingSubscriptionRetrieveOptions,
+  organizationsBillingSubscriptionRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type {
+  CreditTierEnum,
+  MachineTierEnum,
+  StorageTierEnum,
+} from "@/generated/api/types.gen";
+
+/**
+ * The Pro subscription's current tier configuration, read the same way
+ * `adjust-plan-modal` reads it: machine/storage from the onboarding retrieve
+ * query, the credit bundle from the subscription retrieve query.
+ */
+export interface CurrentTiers {
+  machineTier: MachineTierEnum | null;
+  storageTier: StorageTierEnum | null;
+  storageGib: number | null;
+  creditTier: CreditTierEnum | null;
+}
+
+/** A three-dimension custom selection to apply (mirrors `CustomPlanSelection`). */
+export interface ChangeTiersSelection {
+  machineTier: MachineTierEnum;
+  storageTier: StorageTierEnum;
+  /** `null` is the explicit "No extra credits" choice. */
+  creditTier: CreditTierEnum | null;
+}
+
+/** Outcome of a successful `changeTiers` dispatch. */
+export interface ChangeTiersResult {
+  /**
+   * A machine or storage dimension changed and persisted, so the assistant
+   * must provision the new compute/disk — the caller opens the resize
+   * takeover. A credit-only change (or a no-op) leaves this false.
+   */
+  needsResize: boolean;
+}
+
+export interface UseChangeTiersResult {
+  changeTiers: (
+    selection: ChangeTiersSelection,
+  ) => Promise<ChangeTiersResult | null>;
+  isPending: boolean;
+  current: CurrentTiers;
+  eligible: boolean;
+}
+
+/**
+ * Shared wiring for applying a custom tier configuration to an active Pro
+ * subscription. Posts ONLY the changed dimensions to the three change-tier
+ * endpoints in parallel (mirrors `adjust-plan-modal`'s `submitTierChanges`),
+ * awaits them as one batch, invalidates the three billing queries, and surfaces
+ * any error as a toast.
+ *
+ * `eligible` is true only for an active, non-cancelling Pro sub in an
+ * entitlement-bearing status — the change-tier endpoints 4xx otherwise. Unlike
+ * `isPackageSwitchEligible`, a customized sub is allowed: a custom tier config
+ * is exactly what this flow edits.
+ */
+export function useChangeTiers(): UseChangeTiersResult {
+  const queryClient = useQueryClient();
+  const subscriptionQuery = useQuery(
+    organizationsBillingSubscriptionRetrieveOptions(),
+  );
+  const subscription = subscriptionQuery.data;
+  const onPro = subscription != null && subscription.plan_id !== "base";
+
+  const onboardingQuery = useQuery({
+    ...organizationsBillingSubscriptionOnboardingRetrieveOptions(),
+    enabled: onPro,
+  });
+
+  const changeMachineTierMutation = useMutation(
+    organizationsBillingSubscriptionChangeMachineTierCreateMutation(),
+  );
+  const changeStorageTierMutation = useMutation(
+    organizationsBillingSubscriptionChangeStorageTierCreateMutation(),
+  );
+  const changeCreditTierMutation = useMutation(
+    organizationsBillingSubscriptionChangeCreditTierCreateMutation(),
+  );
+
+  const current: CurrentTiers = {
+    machineTier:
+      (onboardingQuery.data?.max_machine_tier as MachineTierEnum | null) ?? null,
+    storageTier:
+      (onboardingQuery.data?.selected_storage_tier as StorageTierEnum | null) ??
+      null,
+    storageGib: onboardingQuery.data?.selected_storage_gib ?? null,
+    creditTier:
+      (subscription?.selected_credit_tier as CreditTierEnum | null) ?? null,
+  };
+
+  const eligible =
+    subscription != null &&
+    subscription.plan_id !== "base" &&
+    subscription.status != null &&
+    TIER_CHANGE_ELIGIBLE_STATUSES.has(subscription.status) &&
+    subscription.cancel_at_period_end !== true &&
+    !subscription.cancel_at;
+
+  const isPending =
+    changeMachineTierMutation.isPending ||
+    changeStorageTierMutation.isPending ||
+    changeCreditTierMutation.isPending;
+
+  const invalidateBillingQueries = () => {
+    void queryClient.invalidateQueries({
+      queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: organizationsBillingSubscriptionOnboardingRetrieveQueryKey(),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: organizationsBillingPlansRetrieveQueryKey(),
+    });
+  };
+
+  const changeTiers = async (
+    selection: ChangeTiersSelection,
+  ): Promise<ChangeTiersResult | null> => {
+    const machineChanged = selection.machineTier !== current.machineTier;
+    const storageChanged = selection.storageTier !== current.storageTier;
+    const creditChanged = selection.creditTier !== current.creditTier;
+
+    type DimensionResult = {
+      dimension: "machine" | "storage" | "credit";
+      ok: boolean;
+      error?: unknown;
+    };
+    const pending: Promise<DimensionResult>[] = [];
+
+    if (machineChanged) {
+      pending.push(
+        new Promise<DimensionResult>((resolve) => {
+          changeMachineTierMutation.mutate(
+            { body: { machine_tier: selection.machineTier } },
+            {
+              onSuccess: () => resolve({ dimension: "machine", ok: true }),
+              onError: (error) =>
+                resolve({ dimension: "machine", ok: false, error }),
+            },
+          );
+        }),
+      );
+    }
+
+    if (storageChanged) {
+      pending.push(
+        new Promise<DimensionResult>((resolve) => {
+          changeStorageTierMutation.mutate(
+            { body: { storage_tier: selection.storageTier } },
+            {
+              onSuccess: () => resolve({ dimension: "storage", ok: true }),
+              onError: (error) =>
+                resolve({ dimension: "storage", ok: false, error }),
+            },
+          );
+        }),
+      );
+    }
+
+    if (creditChanged) {
+      pending.push(
+        new Promise<DimensionResult>((resolve) => {
+          changeCreditTierMutation.mutate(
+            { body: { credit_tier: selection.creditTier } },
+            {
+              onSuccess: () => resolve({ dimension: "credit", ok: true }),
+              onError: (error) =>
+                resolve({ dimension: "credit", ok: false, error }),
+            },
+          );
+        }),
+      );
+    }
+
+    // Nothing diverged from the current config — treat as a successful no-op so
+    // the caller closes the modal without opening the resize takeover.
+    if (pending.length === 0) {
+      return { needsResize: false };
+    }
+
+    const results = await Promise.all(pending);
+    invalidateBillingQueries();
+
+    const failures = results.filter((r) => !r.ok);
+    if (failures.length > 0) {
+      const message = failures
+        .map((f) =>
+          extractMutationError(f.error, `Failed to update ${f.dimension} tier.`),
+        )
+        .join(" ");
+      toast.error(message);
+      return null;
+    }
+
+    // Storage here is always an upgrade (the modal disables downgrades) and any
+    // machine change resizes the assistant, so either one needs provisioning.
+    return { needsResize: machineChanged || storageChanged };
+  };
+
+  return { changeTiers, isPending, current, eligible };
+}


### PR DESCRIPTION
## Summary
- Eligible Pro users now reach the white Custom Plan modal on the plans takeover; Continue dispatches the change-machine/storage/credit-tier endpoints (not checkout, which no-ops for active Pro) and opens the resize takeover on success.
- New shared `useChangeTiers` hook; storage-downgrade options disabled (endpoint rejects them); ineligible Pro (cancelling / bad status) still routes to the manage/cancel flow.
- v1 scope notes: AdjustPlanModal left untouched (deliberate); no machine-downgrade reconfirm yet.

Part of the change-package/plans work.