### PR TITLE
security(daemon): retroactive transcript scrub engine for stored credential values

### DIFF
--- a/assistant/src/__tests__/credential-transcript-scrub.test.ts
+++ b/assistant/src/__tests__/credential-transcript-scrub.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Verifies the retroactive credential transcript scrub engine: stored
+ * credential values are removed from recent DB message rows (text blocks,
+ * tool_use inputs, tool_result content, legacy plain-string rows) and from
+ * resident in-memory conversation histories, with lexical reindex and
+ * disk-view rebuild side effects — and the function never throws.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ── Shared mock plumbing (must precede module-under-test imports) ──────────
+//
+// `mock.module` is process-global in Bun and leaks into sibling files run in
+// the same invocation, so every stub delegates to the real implementation
+// unless this file's tests are active (`scrubMocksActive`, toggled in
+// beforeAll/afterAll). The real exports are snapshotted into plain objects
+// NOW, before the stubs register — a module namespace is a live view, so
+// reading a real export after the stub installs would resolve to the stub.
+
+let scrubMocksActive = false;
+
+const realDbConnection = {
+  ...(await import("../persistence/db-connection.js")),
+};
+const realConversationCrud = {
+  ...(await import("../persistence/conversation-crud.js")),
+};
+const realDiskView = {
+  ...(await import("../persistence/conversation-disk-view.js")),
+};
+const realMessageLexical = {
+  ...(await import("../persistence/job-handlers/message-lexical.js")),
+};
+const realRegistry = {
+  ...(await import("../daemon/conversation-registry.js")),
+};
+const realReadiness = {
+  ...(await import("../daemon/daemon-readiness.js")),
+};
+
+interface FakeDbRow {
+  id: string;
+  conversationId: string;
+  content: string;
+}
+const dbRows: FakeDbRow[] = [];
+
+// The engine builds its WHERE clause with real drizzle expressions (ignored
+// here) and consumes `.select().from().where().all()`.
+const fakeDb = {
+  select: () => ({
+    from: () => ({
+      where: () => ({ all: () => dbRows.map((row) => ({ ...row })) }),
+    }),
+  }),
+};
+
+mock.module("../persistence/db-connection.js", () => ({
+  ...realDbConnection,
+  getDb: () => (scrubMocksActive ? fakeDb : realDbConnection.getDb()),
+}));
+
+const updateCalls: Array<{ messageId: string; content: string }> = [];
+const updateThrowsFor = new Set<string>();
+mock.module("../persistence/conversation-crud.js", () => ({
+  ...realConversationCrud,
+  updateMessageContent: (messageId: string, content: string) => {
+    if (!scrubMocksActive) {
+      return realConversationCrud.updateMessageContent(messageId, content);
+    }
+    if (updateThrowsFor.has(messageId)) {
+      throw new Error("simulated write failure");
+    }
+    updateCalls.push({ messageId, content });
+  },
+}));
+
+const rebuildCalls: string[] = [];
+mock.module("../persistence/conversation-disk-view.js", () => ({
+  ...realDiskView,
+  rebuildConversationDiskViewFromDbState: (conversationId: string) => {
+    if (!scrubMocksActive) {
+      return realDiskView.rebuildConversationDiskViewFromDbState(
+        conversationId,
+      );
+    }
+    rebuildCalls.push(conversationId);
+  },
+}));
+
+const lexicalCalls: string[] = [];
+mock.module("../persistence/job-handlers/message-lexical.js", () => ({
+  ...realMessageLexical,
+  enqueueLexicalIndexForMessage: (messageId: string) => {
+    if (!scrubMocksActive) {
+      return realMessageLexical.enqueueLexicalIndexForMessage(messageId);
+    }
+    lexicalCalls.push(messageId);
+  },
+}));
+
+interface FakeResidentMessage {
+  role: string;
+  content: Array<Record<string, unknown>>;
+}
+interface FakeResidentConversation {
+  conversationId: string;
+  messages: FakeResidentMessage[];
+}
+const residentConversations: FakeResidentConversation[] = [];
+const residentSubagentConversations: FakeResidentConversation[] = [];
+mock.module("../daemon/conversation-registry.js", () => ({
+  ...realRegistry,
+  allConversations: () =>
+    scrubMocksActive
+      ? residentConversations.values()
+      : realRegistry.allConversations(),
+  allSubagentConversations: () =>
+    scrubMocksActive
+      ? residentSubagentConversations.values()
+      : realRegistry.allSubagentConversations(),
+}));
+
+mock.module("../daemon/daemon-readiness.js", () => ({
+  ...realReadiness,
+  getDbMigrationReadiness: () =>
+    scrubMocksActive
+      ? { ready: true, state: "ready" }
+      : realReadiness.getDbMigrationReadiness(),
+}));
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────
+
+import { scrubStoredCredentialFromTranscripts } from "../daemon/credential-transcript-scrub.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const VALUE = "test-credential-value-1234567890";
+const MARKER = '<redacted type="Credential" />';
+
+function textRow(id: string, conversationId: string, text: string): FakeDbRow {
+  return {
+    id,
+    conversationId,
+    content: JSON.stringify([{ type: "text", text }]),
+  };
+}
+
+function updatedContentFor(messageId: string): string {
+  const call = updateCalls.find((c) => c.messageId === messageId);
+  if (!call) {
+    throw new Error(`No updateMessageContent call for ${messageId}`);
+  }
+  return call.content;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+beforeAll(() => {
+  scrubMocksActive = true;
+});
+afterAll(() => {
+  scrubMocksActive = false;
+});
+
+describe("scrubStoredCredentialFromTranscripts", () => {
+  beforeEach(() => {
+    dbRows.length = 0;
+    updateCalls.length = 0;
+    updateThrowsFor.clear();
+    rebuildCalls.length = 0;
+    lexicalCalls.length = 0;
+    residentConversations.length = 0;
+    residentSubagentConversations.length = 0;
+  });
+
+  test("scrubs a user text message and stamps _redactionVersion", async () => {
+    dbRows.push(textRow("msg-1", "conv-1", `here is my key: ${VALUE}`));
+
+    const result = await scrubStoredCredentialFromTranscripts(VALUE);
+
+    expect(result.dbMessagesScrubbed).toBe(1);
+    const blocks = JSON.parse(updatedContentFor("msg-1")) as Array<
+      Record<string, unknown>
+    >;
+    expect(blocks[0].text).toBe(`here is my key: ${MARKER}`);
+    expect(blocks[0]._redactionVersion).toBe(2);
+    expect(lexicalCalls).toEqual(["msg-1"]);
+    expect(rebuildCalls).toEqual(["conv-1"]);
+  });
+
+  test("scrubs the JSON-escaped form inside a tool_use command input", async () => {
+    const quotedValue = 'cred-"quoted"-value-1234';
+    const escapedForm = JSON.stringify(quotedValue).slice(1, -1);
+    dbRows.push({
+      id: "msg-2",
+      conversationId: "conv-2",
+      content: JSON.stringify([
+        {
+          type: "tool_use",
+          id: "tu-1",
+          name: "bash",
+          // The string leaf itself embeds JSON-encoded text, so it carries
+          // the escaped form, not the raw value.
+          input: { command: `curl -d '{"key":"${escapedForm}"}'` },
+        },
+      ]),
+    });
+
+    const result = await scrubStoredCredentialFromTranscripts(quotedValue);
+
+    expect(result.dbMessagesScrubbed).toBe(1);
+    const content = updatedContentFor("msg-2");
+    expect(content).not.toContain("quoted");
+    const blocks = JSON.parse(content) as Array<{
+      input: { command: string };
+    }>;
+    expect(blocks[0].input.command).toBe(`curl -d '{"key":"${MARKER}"}'`);
+  });
+
+  test("scrubs tool_result string content", async () => {
+    dbRows.push({
+      id: "msg-3",
+      conversationId: "conv-3",
+      content: JSON.stringify([
+        { type: "tool_result", tool_use_id: "tu-1", content: `out: ${VALUE}` },
+      ]),
+    });
+
+    const result = await scrubStoredCredentialFromTranscripts(VALUE);
+
+    expect(result.dbMessagesScrubbed).toBe(1);
+    const blocks = JSON.parse(updatedContentFor("msg-3")) as Array<{
+      content: string;
+    }>;
+    expect(blocks[0].content).toBe(`out: ${MARKER}`);
+  });
+
+  test("scrubs legacy plain-string content rows with a plain replace", async () => {
+    dbRows.push({
+      id: "msg-legacy",
+      conversationId: "conv-legacy",
+      content: `plain history line with ${VALUE} in it`,
+    });
+
+    const result = await scrubStoredCredentialFromTranscripts(VALUE);
+
+    expect(result.dbMessagesScrubbed).toBe(1);
+    expect(updatedContentFor("msg-legacy")).toBe(
+      `plain history line with ${MARKER} in it`,
+    );
+  });
+
+  test("one call scrubs text, tool_use input, and tool_result across DB and resident memory", async () => {
+    dbRows.push(
+      textRow("msg-a", "conv-x", `pasted: ${VALUE}`),
+      {
+        id: "msg-b",
+        conversationId: "conv-x",
+        content: JSON.stringify([
+          {
+            type: "tool_use",
+            id: "tu-2",
+            name: "bash",
+            input: { command: `assistant credentials set --value ${VALUE}` },
+          },
+        ]),
+      },
+      {
+        id: "msg-c",
+        conversationId: "conv-y",
+        content: JSON.stringify([
+          { type: "tool_result", tool_use_id: "tu-2", content: `ok ${VALUE}` },
+        ]),
+      },
+    );
+    residentConversations.push({
+      conversationId: "conv-x",
+      messages: [
+        { role: "user", content: [{ type: "text", text: `pasted: ${VALUE}` }] },
+      ],
+    });
+
+    const result = await scrubStoredCredentialFromTranscripts(VALUE);
+
+    expect(result.dbMessagesScrubbed).toBe(3);
+    expect(result.residentMessagesScrubbed).toBe(1);
+    // Inside serialized block JSON the marker's quotes are JSON-escaped.
+    const escapedMarker = JSON.stringify(MARKER).slice(1, -1);
+    for (const id of ["msg-a", "msg-b", "msg-c"]) {
+      expect(updatedContentFor(id)).not.toContain(VALUE);
+      expect(updatedContentFor(id)).toContain(escapedMarker);
+    }
+    expect(lexicalCalls.sort()).toEqual(["msg-a", "msg-b", "msg-c"]);
+    // One disk-view rebuild per touched conversation.
+    expect(rebuildCalls.sort()).toEqual(["conv-x", "conv-y"]);
+  });
+
+  test("scrubs resident in-memory conversation messages in place, including subagents", async () => {
+    const topLevel: FakeResidentConversation = {
+      conversationId: "conv-live",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: `my key is ${VALUE}` }],
+        },
+      ],
+    };
+    const subagent: FakeResidentConversation = {
+      conversationId: "conv-sub",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "tu-3",
+              name: "bash",
+              input: { command: `echo ${VALUE}` },
+            },
+          ],
+        },
+      ],
+    };
+    residentConversations.push(topLevel);
+    residentSubagentConversations.push(subagent);
+
+    const result = await scrubStoredCredentialFromTranscripts(VALUE);
+
+    expect(result.residentMessagesScrubbed).toBe(2);
+    expect(topLevel.messages[0].content[0].text).toBe(`my key is ${MARKER}`);
+    expect(topLevel.messages[0].content[0]._redactionVersion).toBe(2);
+    const input = subagent.messages[0].content[0].input as {
+      command: string;
+    };
+    expect(input.command).toBe(`echo ${MARKER}`);
+    // In-memory sweep has no persistence side effects.
+    expect(updateCalls).toEqual([]);
+  });
+
+  test("values shorter than 8 chars are a no-op", async () => {
+    const short = "short12"; // 7 chars
+    dbRows.push(textRow("msg-4", "conv-4", `key: ${short}`));
+    residentConversations.push({
+      conversationId: "conv-4",
+      messages: [
+        { role: "user", content: [{ type: "text", text: `key: ${short}` }] },
+      ],
+    });
+
+    const result = await scrubStoredCredentialFromTranscripts(short);
+
+    expect(result).toEqual({
+      dbMessagesScrubbed: 0,
+      residentMessagesScrubbed: 0,
+    });
+    expect(updateCalls).toEqual([]);
+    expect(lexicalCalls).toEqual([]);
+    expect(rebuildCalls).toEqual([]);
+  });
+
+  test("value absent from the transcript produces zero writes", async () => {
+    dbRows.push(textRow("msg-5", "conv-5", "nothing sensitive here"));
+    residentConversations.push({
+      conversationId: "conv-5",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "still nothing" }] },
+      ],
+    });
+
+    const result = await scrubStoredCredentialFromTranscripts(VALUE);
+
+    expect(result).toEqual({
+      dbMessagesScrubbed: 0,
+      residentMessagesScrubbed: 0,
+    });
+    expect(updateCalls).toEqual([]);
+    expect(lexicalCalls).toEqual([]);
+    expect(rebuildCalls).toEqual([]);
+  });
+
+  test("a message not containing the value is never rewritten", async () => {
+    dbRows.push(
+      textRow("msg-6", "conv-6", `secret: ${VALUE}`),
+      textRow("msg-7", "conv-6", "unrelated message"),
+    );
+
+    const result = await scrubStoredCredentialFromTranscripts(VALUE);
+
+    expect(result.dbMessagesScrubbed).toBe(1);
+    expect(updateCalls.map((c) => c.messageId)).toEqual(["msg-6"]);
+    expect(lexicalCalls).toEqual(["msg-6"]);
+  });
+
+  test("resolves with partial counts when updateMessageContent throws", async () => {
+    dbRows.push(
+      textRow("msg-8", "conv-8", `first: ${VALUE}`),
+      textRow("msg-9", "conv-9", `second: ${VALUE}`),
+    );
+    updateThrowsFor.add("msg-8");
+
+    const result = await scrubStoredCredentialFromTranscripts(VALUE);
+
+    expect(result.dbMessagesScrubbed).toBe(1);
+    expect(updateCalls.map((c) => c.messageId)).toEqual(["msg-9"]);
+    // Side effects only fire for rows that were actually rewritten.
+    expect(lexicalCalls).toEqual(["msg-9"]);
+    expect(rebuildCalls).toEqual(["conv-9"]);
+  });
+});

--- a/assistant/src/daemon/conversation-registry.ts
+++ b/assistant/src/daemon/conversation-registry.ts
@@ -115,10 +115,22 @@ export function getConversationMap(): Map<string, Conversation> {
 // store, so they are deliberately absent from `conversations` above. This
 // point-lookup index lets the per-conversation injectors (workspace context,
 // disk-pressure warning) resolve a subagent's live `Conversation` by id and
-// read state off it. It is intentionally excluded from the iteration accessors
-// and the evictor map so subagent lifecycle stays solely with the manager.
+// read state off it. It is intentionally excluded from the top-level iteration
+// accessors above and the evictor map so subagent lifecycle stays solely with
+// the manager; {@link allSubagentConversations} exposes a read-only iterator
+// for whole-registry sweeps (credential transcript scrubbing) and must never
+// be used to manage lifecycle.
 
 const subagentConversations = new Map<string, Conversation>();
+
+/**
+ * Iterate over all live subagent conversations. Read-only view for sweeps
+ * that must cover every resident transcript; lifecycle (registration,
+ * removal, eviction) stays solely with the `SubagentManager`.
+ */
+export function allSubagentConversations(): IterableIterator<Conversation> {
+  return subagentConversations.values();
+}
 
 /** Register a subagent's live conversation for point lookups. */
 export function setSubagentConversation(

--- a/assistant/src/daemon/credential-transcript-scrub.ts
+++ b/assistant/src/daemon/credential-transcript-scrub.ts
@@ -1,0 +1,396 @@
+/**
+ * Retroactive transcript scrub for stored credential values (JARVIS-1313).
+ *
+ * When a credential is stored, its exact plaintext may already sit in recent
+ * transcripts: the user message that pasted it, the assistant `tool_use`
+ * input that ran `assistant credentials set` (tool inputs are persisted raw
+ * — persist-time redaction covers text blocks only), and the tool result
+ * echoing the command. This module is the self-healing layer: one call
+ * replaces every occurrence of the value with the legacy redaction marker
+ * across (a) recent finalized DB message rows, (b) the per-conversation
+ * disk-view `messages.jsonl` that feedback exports bundle, and (c) the
+ * resident in-memory `Conversation.messages` history the next LLM turn
+ * reads.
+ *
+ * Best-effort by contract: the function never throws, logs only
+ * lengths/counts (never secret material), and returns whatever it managed
+ * to scrub.
+ */
+
+import { SENTINEL_REDACTION_VERSION } from "@vellumai/service-contracts/redacted-credential";
+import { and, eq, gte, or, sql } from "drizzle-orm";
+
+import { updateMessageContent } from "../persistence/conversation-crud.js";
+import { rebuildConversationDiskViewFromDbState } from "../persistence/conversation-disk-view.js";
+import { getDb } from "../persistence/db-connection.js";
+import { enqueueLexicalIndexForMessage } from "../persistence/job-handlers/message-lexical.js";
+import { resolveMessageContentBlocks } from "../persistence/message-content-file.js";
+import { messages } from "../persistence/schema/conversations.js";
+import type { ContentBlock } from "../providers/types.js";
+import { getLogger } from "../util/logger.js";
+import {
+  allConversations,
+  allSubagentConversations,
+} from "./conversation-registry.js";
+import { getDbMigrationReadiness } from "./daemon-readiness.js";
+
+const log = getLogger("credential-transcript-scrub");
+
+/**
+ * Same generic marker `protectCandidateValuesLegacy` persists
+ * (chat-credential-redaction.ts) — byte-identical so downstream scanners and
+ * renderers treat retroactively scrubbed spans like persist-time ones.
+ */
+const REDACTION_MARKER = '<redacted type="Credential" />';
+
+/**
+ * Floor below which a value is never scrubbed — short strings are too likely
+ * to collide with innocent transcript text (mirrors the
+ * `MIN_CANDIDATE_VALUE_LENGTH` rationale in chat-credential-redaction.ts).
+ */
+const MIN_SCRUB_VALUE_LENGTH = 8;
+
+/** How far back the DB sweep looks. Bounds the LIKE scan on large tables. */
+const SCRUB_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface TranscriptScrubResult {
+  dbMessagesScrubbed: number;
+  residentMessagesScrubbed: number;
+}
+
+/**
+ * Scrub every occurrence of `value` from recent transcripts: finalized DB
+ * message rows from the last 7 days (with lexical reindex + disk-view
+ * rebuild for each touched conversation) and the resident in-memory history
+ * of every live conversation, subagents included.
+ *
+ * Unfinalized (streaming) rows are intentionally skipped: the in-flight turn
+ * is covered by the in-memory sweep plus persist-time redaction at the
+ * finalize seam.
+ *
+ * Never throws — partial failures are logged (counts only, never content)
+ * and reflected in the best-effort result.
+ */
+export async function scrubStoredCredentialFromTranscripts(
+  value: string,
+): Promise<TranscriptScrubResult> {
+  const result: TranscriptScrubResult = {
+    dbMessagesScrubbed: 0,
+    residentMessagesScrubbed: 0,
+  };
+  if (value.trim().length < MIN_SCRUB_VALUE_LENGTH) {
+    return result;
+  }
+  const targets = buildSearchTargets(value);
+  try {
+    result.dbMessagesScrubbed = sweepDbMessages(targets);
+  } catch (err) {
+    log.warn(
+      { err, valueLength: value.length },
+      "Credential transcript DB sweep failed; continuing with in-memory sweep",
+    );
+  }
+  try {
+    result.residentMessagesScrubbed = sweepResidentConversations(targets);
+  } catch (err) {
+    log.warn(
+      { err, valueLength: value.length },
+      "Credential transcript in-memory sweep failed",
+    );
+  }
+  return result;
+}
+
+/**
+ * The raw value plus its JSON-escaped form (`JSON.stringify` minus the outer
+ * quotes). They differ when the value contains `"` or `\` — tool_use inputs
+ * are stored as JSON, and string leaves can themselves embed JSON-encoded
+ * text. Longest first so an escaped form is never half-eaten by its raw twin.
+ */
+function buildSearchTargets(value: string): string[] {
+  const targets = new Set<string>([value, JSON.stringify(value).slice(1, -1)]);
+  return [...targets].sort((a, b) => b.length - a.length);
+}
+
+function replaceTargets(
+  text: string,
+  targets: readonly string[],
+): { text: string; changed: boolean } {
+  let out = text;
+  for (const target of targets) {
+    if (out.includes(target)) {
+      out = out.split(target).join(REDACTION_MARKER);
+    }
+  }
+  return { text: out, changed: out !== text };
+}
+
+// ── DB sweep ───────────────────────────────────────────────────────
+
+/** Escape `%`, `_`, and `\` so the value is matched literally under `ESCAPE '\'`. */
+function escapeLikeLiteral(literal: string): string {
+  return literal.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+function sweepDbMessages(targets: readonly string[]): number {
+  // Module contract: callers can invoke this at any point in the daemon
+  // lifecycle, so readiness is checked rather than assumed (see
+  // assistant/CLAUDE.md § DB migration readiness gating).
+  if (!getDbMigrationReadiness().ready) {
+    log.warn(
+      "DB migrations not ready; skipping credential transcript DB sweep",
+    );
+    return 0;
+  }
+  const cutoff = Date.now() - SCRUB_WINDOW_MS;
+  const rows = getDb()
+    .select({
+      id: messages.id,
+      conversationId: messages.conversationId,
+      content: messages.content,
+    })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.finalized, 1),
+        gte(messages.createdAt, cutoff),
+        or(
+          ...targets.map(
+            (target) =>
+              sql`${messages.content} LIKE ${`%${escapeLikeLiteral(target)}%`} ESCAPE '\\'`,
+          ),
+        ),
+      ),
+    )
+    .all();
+
+  let scrubbed = 0;
+  let failures = 0;
+  const touchedConversationIds = new Set<string>();
+  for (const row of rows) {
+    try {
+      const next = scrubStoredContent(row.content, targets);
+      if (!next.changed) {
+        continue;
+      }
+      updateMessageContent(row.id, next.content);
+      // `updateMessageContent` is a pure CRUD primitive: reindex the changed
+      // searchable text ourselves (mutate-then-reindex, as consolidation does).
+      enqueueLexicalIndexForMessage(row.id);
+      touchedConversationIds.add(row.conversationId);
+      scrubbed++;
+    } catch (err) {
+      failures++;
+      log.warn(
+        { err, messageId: row.id },
+        "Failed to scrub credential value from message row",
+      );
+    }
+  }
+  // `messages.jsonl` is append-only, so a per-message re-sync would stack a
+  // scrubbed line on top of the original. Rebuild each touched
+  // conversation's disk view from post-scrub DB state instead.
+  for (const conversationId of touchedConversationIds) {
+    try {
+      rebuildConversationDiskViewFromDbState(conversationId);
+    } catch (err) {
+      log.warn(
+        { err, conversationId },
+        "Failed to rebuild disk view after credential scrub",
+      );
+    }
+  }
+  if (scrubbed > 0 || failures > 0) {
+    log.info(
+      {
+        matchedRows: rows.length,
+        scrubbed,
+        failures,
+        conversations: touchedConversationIds.size,
+      },
+      "Credential transcript DB sweep complete",
+    );
+  }
+  return scrubbed;
+}
+
+/**
+ * Scrub a stored `messages.content` column value. Inline block arrays are
+ * resolved through `resolveMessageContentBlocks` (which also repairs legacy
+ * block shapes) and re-serialized; anything else — legacy plain-string rows,
+ * JSON-string rows — gets a plain textual replace that preserves the stored
+ * shape. `{ref}` rows never LIKE-match (the column holds only the pointer),
+ * and the plain replace is a no-op for them.
+ */
+function scrubStoredContent(
+  raw: string,
+  targets: readonly string[],
+): { content: string; changed: boolean } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = undefined;
+  }
+  if (Array.isArray(parsed)) {
+    const blocks = resolveMessageContentBlocks(raw);
+    let changed = false;
+    const scrubbedBlocks = blocks.map((block) => {
+      const next = scrubBlock(block, targets);
+      if (next.changed) {
+        changed = true;
+      }
+      return next.block;
+    });
+    return changed
+      ? { content: JSON.stringify(scrubbedBlocks), changed: true }
+      : { content: raw, changed: false };
+  }
+  const { text, changed } = replaceTargets(raw, targets);
+  return { content: text, changed };
+}
+
+// ── Block walk (shared by DB and in-memory sweeps) ─────────────────
+
+function scrubBlock(
+  block: ContentBlock,
+  targets: readonly string[],
+): { block: ContentBlock; changed: boolean } {
+  switch (block.type) {
+    case "text": {
+      const { text, changed } = replaceTargets(block.text, targets);
+      if (!changed) {
+        return { block, changed: false };
+      }
+      // The rider marks the block as redaction-aware so
+      // `renderHistoryContent`'s neutralization boundary trusts its markers.
+      return {
+        block: {
+          ...block,
+          text,
+          _redactionVersion: SENTINEL_REDACTION_VERSION,
+        } as ContentBlock,
+        changed: true,
+      };
+    }
+    case "tool_use":
+    case "server_tool_use": {
+      const [input, changed] = scrubJsonLeaves(block.input, targets);
+      return changed
+        ? {
+            block: { ...block, input: input as Record<string, unknown> },
+            changed: true,
+          }
+        : { block, changed: false };
+    }
+    case "tool_result": {
+      let changed = false;
+      let content: unknown = block.content;
+      if (typeof content === "string") {
+        const next = replaceTargets(content, targets);
+        content = next.text;
+        changed = next.changed;
+      } else if (content !== undefined) {
+        // Legacy rows can carry nested content arrays/objects.
+        [content, changed] = scrubJsonLeaves(content, targets);
+      }
+      let contentBlocks = block.contentBlocks;
+      if (contentBlocks) {
+        let nestedChanged = false;
+        const nextNested = contentBlocks.map((nested) => {
+          const next = scrubBlock(nested, targets);
+          if (next.changed) {
+            nestedChanged = true;
+          }
+          return next.block;
+        });
+        if (nestedChanged) {
+          contentBlocks = nextNested;
+          changed = true;
+        }
+      }
+      return changed
+        ? {
+            block: {
+              ...block,
+              content: content as string,
+              ...(contentBlocks ? { contentBlocks } : {}),
+            },
+            changed: true,
+          }
+        : { block, changed: false };
+    }
+    default:
+      return { block, changed: false };
+  }
+}
+
+/** Recursively replace targets in every string leaf of a JSON-shaped value. */
+function scrubJsonLeaves(
+  value: unknown,
+  targets: readonly string[],
+): [unknown, boolean] {
+  if (typeof value === "string") {
+    const { text, changed } = replaceTargets(value, targets);
+    return [text, changed];
+  }
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map((item) => {
+      const [scrubbedItem, itemChanged] = scrubJsonLeaves(item, targets);
+      if (itemChanged) {
+        changed = true;
+      }
+      return scrubbedItem;
+    });
+    return changed ? [next, true] : [value, false];
+  }
+  if (value !== null && typeof value === "object") {
+    let changed = false;
+    const next: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      const [scrubbedEntry, entryChanged] = scrubJsonLeaves(entry, targets);
+      if (entryChanged) {
+        changed = true;
+      }
+      next[key] = scrubbedEntry;
+    }
+    return changed ? [next, true] : [value, false];
+  }
+  return [value, false];
+}
+
+// ── In-memory sweep ────────────────────────────────────────────────
+
+/**
+ * Scrub the live `Conversation.messages` history of every resident
+ * conversation (top-level and subagent). The next LLM turn reads this
+ * in-memory history — hydrated once in `loadFromDb` — not the DB, so the DB
+ * sweep alone would leave the value in context until eviction. No
+ * persistence side effects: durable copies are the DB sweep's job.
+ */
+function sweepResidentConversations(targets: readonly string[]): number {
+  let scrubbed = 0;
+  for (const registry of [allConversations(), allSubagentConversations()]) {
+    for (const conversation of registry) {
+      for (const message of conversation.messages) {
+        if (!Array.isArray(message.content)) {
+          continue;
+        }
+        let changed = false;
+        const content = message.content.map((block) => {
+          const next = scrubBlock(block, targets);
+          if (next.changed) {
+            changed = true;
+          }
+          return next.block;
+        });
+        if (changed) {
+          message.content = content;
+          scrubbed++;
+        }
+      }
+    }
+  }
+  return scrubbed;
+}


### PR DESCRIPTION
## Summary
- New `scrubStoredCredentialFromTranscripts(value)` engine: bounded 7-day DB sweep (text, tool_use input leaves, tool_result content), in-memory resident-conversation sweep, disk-view re-sync, and lexical reindex enqueue
- Replaces occurrences with `<redacted type="Credential" />`, stamps `_redactionVersion: 2`, never throws, ≥8-char floor
- Wiring into the credential-store route lands in a follow-up PR

Part of plan: jarvis-1313-cred-chat-leak.md (PR 3 of 9)