### PR TITLE
feat(telemetry): emit parent conversation linkage on llm_usage events

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -1922,6 +1922,28 @@ describe("queryUnreportedUsageEvents", () => {
     expect(events[0].parentTurnIndex).toBe(1);
   });
 
+  test("user-initiated forks (standard type) do not inherit fork parent attribution", () => {
+    const db = getDb();
+    // A user forks a conversation: the fork stamps
+    // fork_parent_conversation_id but is a first-class standard
+    // conversation — its usage must not fold into the source turn.
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('source-3', 'standard', 500, 500)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('s3', 'source-3', 'user', 'hello', 1000)`,
+    );
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, fork_parent_conversation_id, fork_parent_message_id) VALUES ('user-fork-1', 'standard', 2000, 2000, 'source-3', 's3')`,
+    );
+    insertEventAt(3000, { conversationId: "user-fork-1" });
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    expect(events[0].parentConversationId).toBeNull();
+    expect(events[0].parentTurnIndex).toBeNull();
+  });
+
   test("parent fields are null for parentless conversations and no-conversation events", () => {
     const db = getDb();
     const now = Date.now();

--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -1897,6 +1897,31 @@ describe("queryUnreportedUsageEvents", () => {
     expect(events[0].parentTurnIndex).toBe(1);
   });
 
+  test("fork parentTurnIndex anchors on the fork boundary message, not fork creation time", () => {
+    const db = getDb();
+    // Source conversation with turns at t=1000 and t=3000. The fork
+    // branches from the FIRST turn (boundary message s1) but is created
+    // at t=5000, after turn 2 exists — attribution must report turn 1.
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('source-2', 'standard', 500, 500)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('s2a', 'source-2', 'user', 'first', 1000)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('s2b', 'source-2', 'user', 'second', 3000)`,
+    );
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, fork_parent_conversation_id, fork_parent_message_id) VALUES ('retro-2', 'background', 5000, 5000, 'source-2', 's2a')`,
+    );
+    insertEventAt(6000, { conversationId: "retro-2" });
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    expect(events[0].parentConversationId).toBe("source-2");
+    expect(events[0].parentTurnIndex).toBe(1);
+  });
+
   test("parent fields are null for parentless conversations and no-conversation events", () => {
     const db = getDb();
     const now = Date.now();

--- a/assistant/src/persistence/llm-usage-store.ts
+++ b/assistant/src/persistence/llm-usage-store.ts
@@ -217,11 +217,12 @@ export interface UnreportedUsageEvent extends UsageEvent {
    */
   parentConversationId: string | null;
   /**
-   * 1-indexed position of the user turn that was in flight in the parent
-   * conversation when this LLM call's conversation was created — i.e. the
-   * parent turn that spawned it. Computed as the count of real user turns
-   * in the parent conversation with `created_at <=` the child
-   * conversation's `created_at` (same eligibility filter as `turnIndex`).
+   * 1-indexed position of the parent-conversation user turn this LLM
+   * call's conversation branched from. Computed as the count of real user
+   * turns in the parent conversation (same eligibility filter as
+   * `turnIndex`) up to the child conversation's creation for subagent
+   * spawns, or up to the fork boundary message for retrospective forks
+   * (which can fork from a turn much earlier than their creation time).
    * Null when there's no parent conversation.
    */
   parentTurnIndex: number | null;
@@ -241,6 +242,19 @@ export function queryUnreportedUsageEvents(
     ${conversations.parentConversationId},
     ${conversations.forkParentConversationId}
   )`;
+  // Cutoff for the parent-turn count. Subagent spawns attribute to the
+  // parent turn in flight at child creation. Retrospective forks can
+  // branch from a turn far earlier than the fork's creation time, so
+  // they anchor on the fork boundary message instead; child creation is
+  // the fallback when the boundary message is absent.
+  const parentTurnCutoffSql = sql<number>`CASE
+    WHEN ${conversations.parentConversationId} IS NOT NULL THEN ${conversations.createdAt}
+    ELSE COALESCE(
+      (SELECT mb.created_at FROM messages AS mb
+        WHERE mb.id = ${conversations.forkParentMessageId}),
+      ${conversations.createdAt}
+    )
+  END`;
   // JOIN to `conversations` to attach `conversationType`. LEFT JOIN
   // because `llm_usage_events.conversationId` is nullable — calls that
   // aren't tied to a conversation (memory consolidation, etc.) still
@@ -293,10 +307,11 @@ export function queryUnreportedUsageEvents(
         END
       )`.as("turn_index"),
       parentConversationId: parentIdSql.as("parent_conversation_id"),
-      // The parent turn in flight when the child conversation was created:
-      // count of the PARENT conversation's real user turns with
-      // `created_at <=` the CHILD conversation's `created_at`. Same
-      // eligibility filter as `turnIndex` above.
+      // The parent turn this child conversation branched from: count of
+      // the PARENT conversation's real user turns with `created_at <=`
+      // the cutoff (child creation for subagent spawns, fork boundary
+      // message for retrospective forks). Same eligibility filter as
+      // `turnIndex` above.
       parentTurnIndex: sql<number | null>`(
         CASE WHEN ${parentIdSql} IS NULL THEN NULL
         ELSE (
@@ -304,7 +319,7 @@ export function queryUnreportedUsageEvents(
           WHERE m3.conversation_id = ${parentIdSql}
             AND m3.role = 'user'
             AND ${realUserTurnContentFilter("m3")}
-            AND m3.created_at <= ${conversations.createdAt}
+            AND m3.created_at <= ${parentTurnCutoffSql}
         )
         END
       )`.as("parent_turn_index"),

--- a/assistant/src/persistence/llm-usage-store.ts
+++ b/assistant/src/persistence/llm-usage-store.ts
@@ -211,9 +211,11 @@ export interface UnreportedUsageEvent extends UsageEvent {
   /**
    * Id of the conversation that spawned this LLM call's conversation:
    * `parent_conversation_id` (subagent spawns), falling back to
-   * `fork_parent_conversation_id` (retrospective forks). Null when the
-   * conversation was not spawned by another conversation, or when the
-   * LLM call has no `conversationId` at all.
+   * `fork_parent_conversation_id` for background forks (retrospectives).
+   * User-initiated forks are excluded — they are standard conversations
+   * whose usage belongs to themselves. Null when the conversation was
+   * not spawned by another conversation, or when the LLM call has no
+   * `conversationId` at all.
    */
   parentConversationId: string | null;
   /**
@@ -236,11 +238,17 @@ export function queryUnreportedUsageEvents(
   const db = getTelemetryMainDb();
   // Spawn linkage: `parent_conversation_id` (subagent spawns) with a
   // fallback to `fork_parent_conversation_id` (retrospective forks — one
-  // hop up the fork chain is the intended attribution). Null when the
-  // LEFT JOIN below misses or the conversation has no parent.
+  // hop up the fork chain is the intended attribution). The fallback is
+  // gated to background conversations: user-initiated forks also stamp
+  // `fork_parent_conversation_id` but are first-class standard
+  // conversations whose usage belongs to themselves, not the source turn.
+  // Null when the LEFT JOIN below misses or the conversation has no
+  // parent.
   const parentIdSql = sql<string | null>`COALESCE(
     ${conversations.parentConversationId},
-    ${conversations.forkParentConversationId}
+    CASE WHEN ${conversations.conversationType} = 'background'
+      THEN ${conversations.forkParentConversationId}
+    END
   )`;
   // Cutoff for the parent-turn count. Subagent spawns attribute to the
   // parent turn in flight at child creation. Retrospective forks can

--- a/assistant/src/telemetry/__tests__/telemetry-event-fixtures.ts
+++ b/assistant/src/telemetry/__tests__/telemetry-event-fixtures.ts
@@ -39,6 +39,10 @@ const llmUsage: LlmUsageTelemetryEvent = {
   // Zero is legitimate here (wire bound is min(0)) — the wire schema must
   // not reject it.
   turn_index: 0,
+  parent_conversation_id: "conv-parent",
+  // Zero is legitimate (wire bound is min(0)): a subagent can be spawned
+  // before the parent's first real user turn.
+  parent_turn_index: 0,
   provider: "anthropic",
   model: "claude-fable-5",
   input_tokens: 1200,

--- a/assistant/src/telemetry/telemetry-event-sources.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.ts
@@ -279,6 +279,8 @@ const usageSource = simpleSource(
     conversation_id: e.conversationId,
     conversation_type: e.conversationType,
     turn_index: e.turnIndex,
+    parent_conversation_id: e.parentConversationId,
+    parent_turn_index: e.parentTurnIndex,
     provider: e.provider,
     model: e.model,
     input_tokens: e.inputTokens,

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -107,8 +107,9 @@ export interface LlmUsageTelemetryEvent extends TelemetryEventBase {
    */
   parent_conversation_id: string | null;
   /**
-   * 1-indexed count of real user turns in the *parent* conversation up to
-   * the child conversation's creation — the parent turn in flight at spawn
+   * 1-indexed parent-conversation user turn this event's conversation
+   * branched from: the turn in flight at child creation for subagent
+   * spawns, the fork boundary message's turn for retrospective forks
    * (same real-user-turn filter as `turn_index`). Null when there is no
    * parent conversation.
    */

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -98,6 +98,21 @@ export interface LlmUsageTelemetryEvent extends TelemetryEventBase {
    * tied to a conversation, or when no user turn has occurred yet.
    */
   turn_index: number | null;
+  /**
+   * Id of the conversation that spawned this event's conversation —
+   * `parent_conversation_id` stamped at subagent spawn, falling back to
+   * `fork_parent_conversation_id` for retrospective forks. Null when the
+   * conversation was not spawned by another conversation or the LLM call
+   * has no conversation.
+   */
+  parent_conversation_id: string | null;
+  /**
+   * 1-indexed count of real user turns in the *parent* conversation up to
+   * the child conversation's creation — the parent turn in flight at spawn
+   * (same real-user-turn filter as `turn_index`). Null when there is no
+   * parent conversation.
+   */
+  parent_turn_index: number | null;
   provider: string;
   model: string;
   input_tokens: number;

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1615,10 +1615,11 @@ describe("UsageTelemetryReporter", () => {
     expect("failure_code" in body.events[0]).toBe(false);
   });
 
-  test("llm_usage events carry conversation_id, conversation_type, and turn_index", async () => {
+  test("llm_usage events carry conversation_id, conversation_type, turn_index, and parent linkage", async () => {
     // Three LLM calls across the spectrum of the new fields:
     //  - tied to a conversation, mid-turn (typical foreground)
-    //  - tied to a background conversation, first turn
+    //  - tied to a background conversation spawned by a parent turn
+    //    (subagent: parent linkage populated)
     //  - untied (memory consolidation: no conversation, no turn)
     mockQueryUnreportedUsageEvents.mockReturnValue([
       makeUsageEvent({
@@ -1632,6 +1633,8 @@ describe("UsageTelemetryReporter", () => {
         conversationId: "conv-bg",
         conversationType: "background",
         turnIndex: 1,
+        parentConversationId: "conv-fg",
+        parentTurnIndex: 4,
       }),
       makeUsageEvent({
         id: "evt-untied-call",
@@ -1659,6 +1662,8 @@ describe("UsageTelemetryReporter", () => {
         conversation_id: string | null;
         conversation_type: string | null;
         turn_index: number | null;
+        parent_conversation_id: string | null;
+        parent_turn_index: number | null;
       }
     > = {};
     for (const e of body.events as Array<{
@@ -1667,6 +1672,8 @@ describe("UsageTelemetryReporter", () => {
       conversation_id: string | null;
       conversation_type: string | null;
       turn_index: number | null;
+      parent_conversation_id: string | null;
+      parent_turn_index: number | null;
     }>) {
       byId[e.daemon_event_id] = e;
     }
@@ -1676,15 +1683,19 @@ describe("UsageTelemetryReporter", () => {
       conversation_id: "conv-fg",
       conversation_type: "standard",
       turn_index: 4,
+      parent_conversation_id: null,
+      parent_turn_index: null,
     });
     expect(byId["evt-bg-call"]).toMatchObject({
       type: "llm_usage",
       conversation_id: "conv-bg",
       conversation_type: "background",
       turn_index: 1,
+      parent_conversation_id: "conv-fg",
+      parent_turn_index: 4,
     });
     // LLM calls without a parent conversation flush through with all
-    // three conversation-level fields null — the serializer accepts
+    // conversation-level fields null — the serializer accepts
     // allow_null and downstream SQL filters can `WHERE conversation_id
     // IS NOT NULL` to scope to foreground analytics.
     expect(byId["evt-untied-call"]).toMatchObject({
@@ -1692,6 +1703,8 @@ describe("UsageTelemetryReporter", () => {
       conversation_id: null,
       conversation_type: null,
       turn_index: null,
+      parent_conversation_id: null,
+      parent_turn_index: null,
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `parent_conversation_id` / `parent_turn_index` to the hand-written `LlmUsageTelemetryEvent` override in `types.ts` — the generated wire contract already carries both since sync PR #38719, so the `_llmUsageNarrows`/`_llmUsageKeysExist` drift guards stay green untouched.
- Emit both fields in `usageSource` from the flush-time values `queryUnreportedUsageEvents` has computed since Stage A (#38663): COALESCE of `conversations.parent_conversation_id` (stamped at subagent spawn) and `fork_parent_conversation_id` (retrospective forks), plus the spawn-time parent-turn correlated subquery.
- Extend the reporter mapping test (populated + null passthrough) and the typed wire-validation fixture. Empty-string safety for the wire's `.min(1)` bound holds by construction: `bootstrapConversation` only persists a parent id when truthy, and all sources are conversation uuids.

## Original prompt
Stage B of the cost-per-turn attribution arc: subagent LLM usage (~$717/week) records against the subagent's own background conversation, so the warehouse can't fold it into the spawning user turn. Stage A (#38663) persisted the parent linkage and resolved it at flush time; the platform serializer + wire sync (#38719) added the fields to the contract. This PR completes the daemon side by emitting the two fields on the `llm_usage` wire event, unblocking the `fct_llm_turn_full_attribution` warehouse mart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)