### PR TITLE
refactor(memory): dispatch clear-all through the conversations-cleared hook

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
@@ -96,7 +96,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "src/daemon/conversation-turn-finalize.ts",
     "src/daemon/conversation.ts",
     "src/daemon/embedding-reconcile.ts",
-    "src/daemon/handlers/conversations.ts",
     "src/daemon/handlers/skills.ts",
     "src/daemon/skill-memory-refresh.ts",
     "src/daemon/tool-side-effects.ts",

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -5,7 +5,6 @@ import {
   getConversation,
 } from "../../persistence/conversation-crud.js";
 import { resolveConversationId } from "../../persistence/conversation-key-store.js";
-import { clearAllConversationMemoryTables } from "../../plugins/defaults/memory/conversation-memory-purge.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
 import { resolveCapabilities } from "../../runtime/capabilities.js";
 import * as pendingInteractions from "../../runtime/pending-interactions.js";
@@ -64,12 +63,6 @@ export async function clearAllConversations(): Promise<number> {
   // Without this DB clear, that auto-created row survives, contradicting
   // the "clear all conversations" intent.
   await clearAll();
-  // Wipe the memory feature's relocated per-conversation tables too. clearAll
-  // (persistence) can't name them without importing the plugin, so the wipe
-  // lives here in the daemon, which already depends on memory. Unconditional —
-  // an explicit "delete everything" must not leave rows behind just because the
-  // memory plugin is disabled (its conversation-deleted hook wouldn't fire).
-  clearAllConversationMemoryTables();
   return cleared;
 }
 

--- a/assistant/src/hooks/types.ts
+++ b/assistant/src/hooks/types.ts
@@ -640,3 +640,15 @@ export interface ConversationDeletedInputContext {
  */
 export interface ConversationDeletedContext
   extends ConversationDeletedInputContext, BaseHookContext {}
+
+// ─── Conversations-cleared hook context ──────────────────────────────────────
+
+/**
+ * The full `conversations-cleared` context a hook receives. Fires once when the
+ * clear-all reset wipes every conversation, so unlike `conversation-deleted` it
+ * carries no `conversationId` — a hook keyed on it wipes its own
+ * per-conversation state wholesale. Only the pipeline-stamped
+ * {@link BaseHookContext} capabilities are present, so the context is exactly
+ * {@link BaseHookContext}.
+ */
+export type ConversationsClearedContext = BaseHookContext;

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -3074,11 +3074,6 @@ export async function clearAll(): Promise<{
   // connection; clear them directly on those connections rather than through
   // a sqlite3 subprocess.
   rawMemoryRun("conversation:clearAll:memoryJobs", "DELETE FROM memory_jobs");
-  // Conversation-keyed tables the memory feature relocated to its own
-  // connection lost their main-DB cascade. The memory plugin owns which tables
-  // those are, so signal the wipe through the hook rather than reaching into
-  // the feature from here.
-  await runHook(HOOKS.CONVERSATIONS_CLEARED, {});
   await runOrThrow("DELETE FROM memory_checkpoints");
   rawLogsRun(
     "conversation:clearAll:requestLogs",
@@ -3090,6 +3085,15 @@ export async function clearAll(): Promise<{
   await runOrThrow("DELETE FROM tool_invocations");
   await runOrThrow("DELETE FROM messages");
   await runOrThrow("DELETE FROM conversations");
+
+  // The memory feature's relocated conversation-keyed tables lost their main-DB
+  // cascade. Signal the wipe through the hook rather than reaching into the
+  // plugin from here — fired only after the main-DB deletes above succeed, so a
+  // failed clear-all never leaves memory wiped for conversations that still
+  // exist (and it honors the hook's "after the main tables are cleared"
+  // contract). When the plugin is disabled the hook is a no-op; the startup
+  // orphan sweep reclaims those rows on the next memory boot.
+  await runHook(HOOKS.CONVERSATIONS_CLEARED, {});
 
   // Record audit event into the telemetry_events outbox (consent-bypassing);
   // the trail persists platform-side once flushed. Best-effort: the

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -3075,10 +3075,10 @@ export async function clearAll(): Promise<{
   // a sqlite3 subprocess.
   rawMemoryRun("conversation:clearAll:memoryJobs", "DELETE FROM memory_jobs");
   // Conversation-keyed tables the memory feature relocated to its own
-  // connection lost their main-DB cascade. Persistence must not name memory's
-  // tables, so the daemon caller (`clearAllConversations`) wipes them via the
-  // memory plugin after this returns — unconditionally, so a disabled plugin
-  // can't leave rows behind on an explicit wipe.
+  // connection lost their main-DB cascade. The memory plugin owns which tables
+  // those are, so signal the wipe through the hook rather than reaching into
+  // the feature from here.
+  await runHook(HOOKS.CONVERSATIONS_CLEARED, {});
   await runOrThrow("DELETE FROM memory_checkpoints");
   rawLogsRun(
     "conversation:clearAll:requestLogs",

--- a/assistant/src/plugin-api/constants.ts
+++ b/assistant/src/plugin-api/constants.ts
@@ -32,6 +32,8 @@ export const HOOKS = {
   POST_COMPACT: "post-compact",
   /** Fires once per deleted conversation, after its rows are removed. Fire-and-forget cleanup signal — hooks run async with no ordering guarantee relative to the caller. */
   CONVERSATION_DELETED: "conversation-deleted",
+  /** Fires once when every conversation is wiped at once (the clear-all reset), after the main tables are cleared. Carries no `conversationId`; cleanup hooks wipe their own per-conversation state wholesale. */
+  CONVERSATIONS_CLEARED: "conversations-cleared",
 } as const;
 
 /** Union of every hook name declared in {@link HOOKS}. */

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -102,6 +102,7 @@ export type { LLMCallSite } from "../config/schemas/llm.js";
 export type {
   AgentLoopExitReason,
   ConversationDeletedContext,
+  ConversationsClearedContext,
   HookBroadcast,
   HookFunction,
   InitContext,

--- a/assistant/src/plugin-api/types.ts
+++ b/assistant/src/plugin-api/types.ts
@@ -14,6 +14,7 @@ export type {
   AgentLoopExitReason,
   BaseHookContext,
   ConversationDeletedContext,
+  ConversationsClearedContext,
   HookBroadcast,
   PluginLogger,
   PostCompactContext,
@@ -58,6 +59,7 @@ export type {
  *   - `stop` — {@link StopContext}
  *   - `post-model-call` — {@link PostModelCallContext}
  *   - `conversation-deleted` — {@link ConversationDeletedContext}
+ *   - `conversations-cleared` — {@link ConversationsClearedContext}
  */
 export type HookFunction<TCtx = unknown> = (
   ctx: TCtx,

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -68,6 +68,7 @@ import maxTokensContinuePostModelCall from "./max-tokens-continue/hooks/post-mod
 import maxTokensContinueStop from "./max-tokens-continue/hooks/stop.js";
 import maxTokensContinuePkg from "./max-tokens-continue/package.json" with { type: "json" };
 import memoryConversationDeleted from "./memory/hooks/conversation-deleted.js";
+import memoryConversationsCleared from "./memory/hooks/conversations-cleared.js";
 import memoryInit from "./memory/hooks/init.js";
 import memoryPostCompact from "./memory/hooks/post-compact.js";
 import memoryShutdown from "./memory/hooks/shutdown.js";
@@ -206,6 +207,7 @@ export const defaultMemoryPlugin: Plugin = {
     "user-prompt-submit": memoryUserPromptSubmit,
     "post-compact": memoryPostCompact,
     "conversation-deleted": memoryConversationDeleted,
+    "conversations-cleared": memoryConversationsCleared,
   },
   injectors: [...memoryInjectors, memoryV3Injector, memoryV3SpotlightInjector],
 };

--- a/assistant/src/plugins/defaults/memory/hooks/conversations-cleared.ts
+++ b/assistant/src/plugins/defaults/memory/hooks/conversations-cleared.ts
@@ -1,0 +1,25 @@
+/**
+ * Default `memory` conversations-cleared hook.
+ *
+ * The clear-all reset wipes every conversation in one bulk delete on the main
+ * connection. SQLite foreign keys cannot span database files, so that delete
+ * never reaches the per-conversation memory tables relocated to the dedicated
+ * memory connection. This hook replaces the lost cascade with a wholesale wipe
+ * of those tables. Best-effort, mirroring the `conversation-deleted` hook: an
+ * unavailable memory database or a single failing table never breaks the reset.
+ */
+
+import type {
+  ConversationsClearedContext,
+  HookFunction,
+} from "@vellumai/plugin-api";
+
+import { clearAllConversationMemoryTables } from "../conversation-memory-purge.js";
+
+const conversationsCleared: HookFunction<
+  ConversationsClearedContext
+> = async () => {
+  clearAllConversationMemoryTables();
+};
+
+export default conversationsCleared;


### PR DESCRIPTION
## Summary

Follow-up to Wave 2 (#38723). Clear-all wiped the relocated per-conversation memory tables via a direct `daemon/handlers/conversations.ts` → memory-plugin import, which needed a reverse plugin-boundary-guard baseline exception.

Route it through the `conversations-cleared` plugin hook instead: the host emits the signal via `runHook`, the memory plugin's registered handler wipes its own tables. No import crosses the host↔plugin boundary, and the guard-baseline entry is removed. The disabled-plugin case stays covered by the startup orphan sweep.

Based on the Wave 2 branch; retargets to `main` when #38723 merges.