### PR TITLE
refactor(memory): use drizzle instead of raw SQL in the relocated memory stores

### DIFF
--- a/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -206,6 +206,7 @@ let testDbHandle: DrizzleDb | null = null;
 // memory-v3's everInjected record lives on the dedicated memory connection now;
 // each test db carries a matching in-memory memory connection.
 let memorySqliteHandle: Database | null = null;
+let memoryDbHandle: DrizzleDb | null = null;
 const realDbModule =
   await import("../../../../../persistence/db-connection.js");
 mock.module("../../../../../persistence/db-connection.js", () => ({
@@ -214,6 +215,7 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
     if (!testDbHandle) throw new Error("test db not initialized");
     return testDbHandle;
   },
+  getMemoryDb: () => memoryDbHandle,
   getMemorySqlite: () => memorySqliteHandle,
 }));
 
@@ -241,6 +243,7 @@ function createTestDb(): DrizzleDb {
   ensureActivationStateSchema(memorySqliteHandle);
   ensureConversationGraphMemoryStateSchema(memorySqliteHandle);
   ensureMemoryV3EverInjectedSchema(memorySqliteHandle);
+  memoryDbHandle = drizzle(memorySqliteHandle, { schema });
   return db;
 }
 

--- a/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -206,7 +206,6 @@ let testDbHandle: DrizzleDb | null = null;
 // memory-v3's everInjected record lives on the dedicated memory connection now;
 // each test db carries a matching in-memory memory connection.
 let memorySqliteHandle: Database | null = null;
-let memoryDbHandle: DrizzleDb | null = null;
 const realDbModule =
   await import("../../../../../persistence/db-connection.js");
 mock.module("../../../../../persistence/db-connection.js", () => ({
@@ -215,8 +214,9 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
     if (!testDbHandle) throw new Error("test db not initialized");
     return testDbHandle;
   },
-  getMemoryDb: () => memoryDbHandle,
   getMemorySqlite: () => memorySqliteHandle,
+  getMemoryDb: () =>
+    memorySqliteHandle ? drizzle(memorySqliteHandle, { schema }) : null,
 }));
 
 // ---------------------------------------------------------------------------
@@ -243,7 +243,6 @@ function createTestDb(): DrizzleDb {
   ensureActivationStateSchema(memorySqliteHandle);
   ensureConversationGraphMemoryStateSchema(memorySqliteHandle);
   ensureMemoryV3EverInjectedSchema(memorySqliteHandle);
-  memoryDbHandle = drizzle(memorySqliteHandle, { schema });
   return db;
 }
 

--- a/assistant/src/plugins/defaults/memory/graph/graph-memory-state-store.ts
+++ b/assistant/src/plugins/defaults/memory/graph/graph-memory-state-store.ts
@@ -1,4 +1,7 @@
-import { memorySqliteOrNull } from "../memory-db.js";
+import { eq } from "drizzle-orm";
+
+import { conversationGraphMemoryState } from "../../../../persistence/schema/conversations.js";
+import { memoryDbOrNull } from "../memory-db.js";
 
 /**
  * Persist graph memory state for a conversation (upsert). Writes the dedicated
@@ -8,19 +11,17 @@ export function saveGraphMemoryState(
   conversationId: string,
   stateJson: string,
 ): void {
-  const raw = memorySqliteOrNull("saveGraphMemoryState");
-  if (!raw) return;
+  const mdb = memoryDbOrNull("saveGraphMemoryState");
+  if (!mdb) return;
   const now = Date.now();
-  raw
-    .query(
-      /*sql*/ `INSERT INTO conversation_graph_memory_state
-         (conversation_id, state_json, created_at, updated_at)
-       VALUES (?, ?, ?, ?)
-       ON CONFLICT(conversation_id) DO UPDATE SET
-         state_json = excluded.state_json,
-         updated_at = excluded.updated_at`,
-    )
-    .run(conversationId, stateJson, now, now);
+  mdb
+    .insert(conversationGraphMemoryState)
+    .values({ conversationId, stateJson, createdAt: now, updatedAt: now })
+    .onConflictDoUpdate({
+      target: conversationGraphMemoryState.conversationId,
+      set: { stateJson, updatedAt: now },
+    })
+    .run();
 }
 
 /**
@@ -28,15 +29,14 @@ export function saveGraphMemoryState(
  * dedicated memory connection; an unavailable memory database reports none.
  */
 export function loadGraphMemoryState(conversationId: string): string | null {
-  const raw = memorySqliteOrNull("loadGraphMemoryState");
-  if (!raw) return null;
-  const row = raw
-    .query(
-      /*sql*/ `SELECT state_json FROM conversation_graph_memory_state
-         WHERE conversation_id = ?`,
-    )
-    .get(conversationId) as { state_json: string } | null;
-  return row?.state_json ?? null;
+  const mdb = memoryDbOrNull("loadGraphMemoryState");
+  if (!mdb) return null;
+  const row = mdb
+    .select({ stateJson: conversationGraphMemoryState.stateJson })
+    .from(conversationGraphMemoryState)
+    .where(eq(conversationGraphMemoryState.conversationId, conversationId))
+    .get();
+  return row?.stateJson ?? null;
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/memory-db.ts
+++ b/assistant/src/plugins/defaults/memory/memory-db.ts
@@ -1,4 +1,8 @@
-import { getMemorySqlite } from "../../../persistence/db-connection.js";
+import {
+  type DrizzleDb,
+  getMemoryDb,
+  getMemorySqlite,
+} from "../../../persistence/db-connection.js";
 import { getLogger } from "./logging.js";
 
 const log = getLogger("memory-db");
@@ -25,4 +29,17 @@ export function memorySqliteOrNull(context: string) {
     );
   }
   return sqlite;
+}
+
+/**
+ * The drizzle counterpart of {@link memorySqliteOrNull}: returns the memory
+ * connection's `DrizzleDb`, or `null` (with the same degraded-mode warning)
+ * when the connection is unavailable. Availability is gated on the underlying
+ * sqlite client so callers degrade in exactly the cases the raw path did — a
+ * stored connection whose `$client` is absent reports null here even though
+ * `getMemoryDb()` still returns the shell.
+ */
+export function memoryDbOrNull(context: string): DrizzleDb | null {
+  if (!memorySqliteOrNull(context)) return null;
+  return getMemoryDb();
 }

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
@@ -21,15 +21,18 @@
 //     than the last pass. Capped — see `appendToRememberedLog`.
 //
 // The row lives on the dedicated memory connection (`assistant-memory.db`),
-// resolved via `memorySqliteOrNull`; every read/write degrades to a no-op when
+// resolved via `memoryDbOrNull`; every read/write degrades to a no-op when
 // that connection is unavailable. The memory database has no `conversations`
 // table, so there is no FK cascade — the `conversation-deleted` hook purges the
 // row explicitly instead.
 
+import { desc, eq } from "drizzle-orm";
+
 import type { DrizzleDb } from "../../../persistence/db-connection.js";
+import { memoryRetrospectiveState } from "../../../persistence/schema/memory-core.js";
 import { withSqliteRetry } from "./host-utils.js";
 import { getLogger } from "./logging.js";
-import { memorySqliteOrNull } from "./memory-db.js";
+import { memoryDbOrNull } from "./memory-db.js";
 
 const log = getLogger("memory-retrospective-state");
 
@@ -98,28 +101,24 @@ function serializeRememberedLog(log: string[]): string | null {
 export function listRetrospectiveStates(
   limit: number,
 ): MemoryRetrospectiveState[] {
-  const raw = memorySqliteOrNull("listRetrospectiveStates");
-  if (!raw) return [];
-  const rows = raw
-    .query(
-      /*sql*/ `
-      SELECT conversation_id, last_processed_message_id, last_run_at, remembered_log
-      FROM memory_retrospective_state
-      ORDER BY last_run_at DESC
-      LIMIT ?
-    `,
-    )
-    .all(limit) as Array<{
-    conversation_id: string;
-    last_processed_message_id: string;
-    last_run_at: number;
-    remembered_log: string | null;
-  }>;
+  const mdb = memoryDbOrNull("listRetrospectiveStates");
+  if (!mdb) return [];
+  const rows = mdb
+    .select({
+      conversationId: memoryRetrospectiveState.conversationId,
+      lastProcessedMessageId: memoryRetrospectiveState.lastProcessedMessageId,
+      lastRunAt: memoryRetrospectiveState.lastRunAt,
+      rememberedLog: memoryRetrospectiveState.rememberedLog,
+    })
+    .from(memoryRetrospectiveState)
+    .orderBy(desc(memoryRetrospectiveState.lastRunAt))
+    .limit(limit)
+    .all();
   return rows.map((row) => ({
-    conversationId: row.conversation_id,
-    lastProcessedMessageId: row.last_processed_message_id,
-    lastRunAt: row.last_run_at,
-    rememberedLog: parseRememberedLog(row.remembered_log),
+    conversationId: row.conversationId,
+    lastProcessedMessageId: row.lastProcessedMessageId,
+    lastRunAt: row.lastRunAt,
+    rememberedLog: parseRememberedLog(row.rememberedLog),
   }));
 }
 
@@ -129,27 +128,24 @@ export function listRetrospectiveStates(
 export function getRetrospectiveState(
   conversationId: string,
 ): MemoryRetrospectiveState | null {
-  const raw = memorySqliteOrNull("getRetrospectiveState");
-  if (!raw) return null;
-  const row = raw
-    .query(
-      /*sql*/ `
-      SELECT conversation_id, last_processed_message_id, last_run_at, remembered_log
-      FROM memory_retrospective_state WHERE conversation_id = ?
-    `,
-    )
-    .get(conversationId) as {
-    conversation_id: string;
-    last_processed_message_id: string;
-    last_run_at: number;
-    remembered_log: string | null;
-  } | null;
+  const mdb = memoryDbOrNull("getRetrospectiveState");
+  if (!mdb) return null;
+  const row = mdb
+    .select({
+      conversationId: memoryRetrospectiveState.conversationId,
+      lastProcessedMessageId: memoryRetrospectiveState.lastProcessedMessageId,
+      lastRunAt: memoryRetrospectiveState.lastRunAt,
+      rememberedLog: memoryRetrospectiveState.rememberedLog,
+    })
+    .from(memoryRetrospectiveState)
+    .where(eq(memoryRetrospectiveState.conversationId, conversationId))
+    .get();
   if (!row) return null;
   return {
-    conversationId: row.conversation_id,
-    lastProcessedMessageId: row.last_processed_message_id,
-    lastRunAt: row.last_run_at,
-    rememberedLog: parseRememberedLog(row.remembered_log),
+    conversationId: row.conversationId,
+    lastProcessedMessageId: row.lastProcessedMessageId,
+    lastRunAt: row.lastRunAt,
+    rememberedLog: parseRememberedLog(row.rememberedLog),
   };
 }
 
@@ -166,8 +162,8 @@ export async function upsertRetrospectiveState(
     rememberedLog?: string[];
   },
 ): Promise<void> {
-  const raw = memorySqliteOrNull("upsertRetrospectiveState");
-  if (!raw) return;
+  const mdb = memoryDbOrNull("upsertRetrospectiveState");
+  if (!mdb) return;
   const serializedLog =
     args.rememberedLog === undefined
       ? undefined
@@ -175,29 +171,30 @@ export async function upsertRetrospectiveState(
   // Only overwrite the stored log when the caller supplied one, so an
   // omitted `rememberedLog` leaves the existing value untouched (seeded NULL
   // on first insert).
-  const logUpdate =
-    serializedLog !== undefined
-      ? ", remembered_log = excluded.remembered_log"
-      : "";
+  const set: {
+    lastProcessedMessageId: string;
+    lastRunAt: number;
+    rememberedLog?: string | null;
+  } = {
+    lastProcessedMessageId: args.lastProcessedMessageId,
+    lastRunAt: args.lastRunAt,
+  };
+  if (serializedLog !== undefined) set.rememberedLog = serializedLog;
   await withSqliteRetry(
     () =>
-      raw
-        .query(
-          /*sql*/ `
-          INSERT INTO memory_retrospective_state
-            (conversation_id, last_processed_message_id, last_run_at, remembered_log)
-          VALUES (?, ?, ?, ?)
-          ON CONFLICT (conversation_id) DO UPDATE SET
-            last_processed_message_id = excluded.last_processed_message_id,
-            last_run_at = excluded.last_run_at${logUpdate}
-        `,
-        )
-        .run(
-          args.conversationId,
-          args.lastProcessedMessageId,
-          args.lastRunAt,
-          serializedLog ?? null,
-        ),
+      mdb
+        .insert(memoryRetrospectiveState)
+        .values({
+          conversationId: args.conversationId,
+          lastProcessedMessageId: args.lastProcessedMessageId,
+          lastRunAt: args.lastRunAt,
+          rememberedLog: serializedLog ?? null,
+        })
+        .onConflictDoUpdate({
+          target: memoryRetrospectiveState.conversationId,
+          set,
+        })
+        .run(),
     {
       op: "upsertRetrospectiveState",
       context: { conversationId: args.conversationId },
@@ -246,26 +243,23 @@ export function forkRetrospectiveState(args: {
   } = args;
 
   try {
-    const raw = memorySqliteOrNull("forkRetrospectiveState");
-    if (!raw) return;
+    const mdb = memoryDbOrNull("forkRetrospectiveState");
+    if (!mdb) return;
 
-    const sourceRow = raw
-      .query(
-        /*sql*/ `
-      SELECT last_processed_message_id, last_run_at, remembered_log
-      FROM memory_retrospective_state WHERE conversation_id = ?
-    `,
-      )
-      .get(sourceConversationId) as {
-      last_processed_message_id: string;
-      last_run_at: number;
-      remembered_log: string | null;
-    } | null;
+    const sourceRow = mdb
+      .select({
+        lastProcessedMessageId: memoryRetrospectiveState.lastProcessedMessageId,
+        lastRunAt: memoryRetrospectiveState.lastRunAt,
+        rememberedLog: memoryRetrospectiveState.rememberedLog,
+      })
+      .from(memoryRetrospectiveState)
+      .where(eq(memoryRetrospectiveState.conversationId, sourceConversationId))
+      .get();
     if (!sourceRow) return;
 
     let forkedPointer = "";
-    if (sourceRow.last_processed_message_id !== "") {
-      const mapped = forkedMessageIds.get(sourceRow.last_processed_message_id);
+    if (sourceRow.lastProcessedMessageId !== "") {
+      const mapped = forkedMessageIds.get(sourceRow.lastProcessedMessageId);
       if (mapped !== undefined) {
         forkedPointer = mapped;
       } else if (lastCopiedSourceMessageId !== null) {
@@ -276,24 +270,23 @@ export function forkRetrospectiveState(args: {
       }
     }
 
-    raw
-      .query(
-        /*sql*/ `
-      INSERT INTO memory_retrospective_state
-        (conversation_id, last_processed_message_id, last_run_at, remembered_log)
-      VALUES (?, ?, ?, ?)
-      ON CONFLICT (conversation_id) DO UPDATE SET
-        last_processed_message_id = excluded.last_processed_message_id,
-        last_run_at = excluded.last_run_at,
-        remembered_log = excluded.remembered_log
-    `,
-      )
-      .run(
-        forkedConversationId,
-        forkedPointer,
-        sourceRow.last_run_at,
-        sourceRow.remembered_log,
-      );
+    mdb
+      .insert(memoryRetrospectiveState)
+      .values({
+        conversationId: forkedConversationId,
+        lastProcessedMessageId: forkedPointer,
+        lastRunAt: sourceRow.lastRunAt,
+        rememberedLog: sourceRow.rememberedLog,
+      })
+      .onConflictDoUpdate({
+        target: memoryRetrospectiveState.conversationId,
+        set: {
+          lastProcessedMessageId: forkedPointer,
+          lastRunAt: sourceRow.lastRunAt,
+          rememberedLog: sourceRow.rememberedLog,
+        },
+      })
+      .run();
   } catch (err) {
     log.warn({ err }, "failed to fork retrospective state; continuing");
   }
@@ -312,21 +305,22 @@ export async function bumpRetrospectiveLastRunAt(
   conversationId: string,
   lastRunAt: number,
 ): Promise<void> {
-  const raw = memorySqliteOrNull("bumpRetrospectiveLastRunAt");
-  if (!raw) return;
+  const mdb = memoryDbOrNull("bumpRetrospectiveLastRunAt");
+  if (!mdb) return;
   await withSqliteRetry(
     () =>
-      raw
-        .query(
-          /*sql*/ `
-          INSERT INTO memory_retrospective_state
-            (conversation_id, last_processed_message_id, last_run_at)
-          VALUES (?, '', ?)
-          ON CONFLICT (conversation_id) DO UPDATE SET
-            last_run_at = excluded.last_run_at
-        `,
-        )
-        .run(conversationId, lastRunAt),
+      mdb
+        .insert(memoryRetrospectiveState)
+        .values({
+          conversationId,
+          lastProcessedMessageId: "",
+          lastRunAt,
+        })
+        .onConflictDoUpdate({
+          target: memoryRetrospectiveState.conversationId,
+          set: { lastRunAt },
+        })
+        .run(),
     { op: "bumpRetrospectiveLastRunAt", context: { conversationId } },
   );
 }

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
@@ -29,7 +29,7 @@
 import { desc, eq } from "drizzle-orm";
 
 import type { DrizzleDb } from "../../../persistence/db-connection.js";
-import { memoryRetrospectiveState } from "../../../persistence/schema/memory-core.js";
+import { memoryRetrospectiveState } from "../../../persistence/schema/index.js";
 import { withSqliteRetry } from "./host-utils.js";
 import { getLogger } from "./logging.js";
 import { memoryDbOrNull } from "./memory-db.js";

--- a/assistant/src/plugins/defaults/memory/v2/activation-store.ts
+++ b/assistant/src/plugins/defaults/memory/v2/activation-store.ts
@@ -9,7 +9,7 @@
 
 import { eq } from "drizzle-orm";
 
-import { activationState } from "../../../../persistence/schema/memory-graph.js";
+import { activationState } from "../../../../persistence/schema/index.js";
 import { memoryDbOrNull } from "../memory-db.js";
 import {
   type ActivationState,

--- a/assistant/src/plugins/defaults/memory/v2/activation-store.ts
+++ b/assistant/src/plugins/defaults/memory/v2/activation-store.ts
@@ -7,31 +7,15 @@
 // conversation copies the parent row so the child starts with the same
 // activation/everInjected snapshot.
 
-import { memorySqliteOrNull } from "../memory-db.js";
+import { eq } from "drizzle-orm";
+
+import { activationState } from "../../../../persistence/schema/memory-graph.js";
+import { memoryDbOrNull } from "../memory-db.js";
 import {
   type ActivationState,
   ActivationStateSchema,
   type EverInjectedEntry,
 } from "../v3/substrate/types.js";
-
-const UPSERT_SQL = /*sql*/ `
-  INSERT INTO activation_state
-    (conversation_id, message_id, state_json, ever_injected_json, current_turn, updated_at)
-  VALUES (?, ?, ?, ?, ?, ?)
-  ON CONFLICT(conversation_id) DO UPDATE SET
-    message_id = excluded.message_id,
-    state_json = excluded.state_json,
-    ever_injected_json = excluded.ever_injected_json,
-    current_turn = excluded.current_turn,
-    updated_at = excluded.updated_at`;
-
-interface ActivationStateRow {
-  message_id: string;
-  state_json: string;
-  ever_injected_json: string;
-  current_turn: number;
-  updated_at: number;
-}
 
 /**
  * Load the activation state for a conversation, or `null` if no row exists.
@@ -41,22 +25,27 @@ interface ActivationStateRow {
 export async function hydrate(
   conversationId: string,
 ): Promise<ActivationState | null> {
-  const raw = memorySqliteOrNull("hydrateActivationState");
-  if (!raw) return null;
-  const row = raw
-    .query(
-      /*sql*/ `SELECT message_id, state_json, ever_injected_json, current_turn, updated_at
-         FROM activation_state WHERE conversation_id = ?`,
-    )
-    .get(conversationId) as ActivationStateRow | null;
+  const mdb = memoryDbOrNull("hydrateActivationState");
+  if (!mdb) return null;
+  const row = mdb
+    .select({
+      messageId: activationState.messageId,
+      stateJson: activationState.stateJson,
+      everInjectedJson: activationState.everInjectedJson,
+      currentTurn: activationState.currentTurn,
+      updatedAt: activationState.updatedAt,
+    })
+    .from(activationState)
+    .where(eq(activationState.conversationId, conversationId))
+    .get();
   if (!row) return null;
 
   return ActivationStateSchema.parse({
-    messageId: row.message_id,
-    state: JSON.parse(row.state_json),
-    everInjected: JSON.parse(row.ever_injected_json),
-    currentTurn: row.current_turn,
-    updatedAt: row.updated_at,
+    messageId: row.messageId,
+    state: JSON.parse(row.stateJson),
+    everInjected: JSON.parse(row.everInjectedJson),
+    currentTurn: row.currentTurn,
+    updatedAt: row.updatedAt,
   });
 }
 
@@ -69,18 +58,31 @@ export async function save(
   conversationId: string,
   state: ActivationState,
 ): Promise<void> {
-  const raw = memorySqliteOrNull("saveActivationState");
-  if (!raw) return;
-  raw
-    .query(UPSERT_SQL)
-    .run(
+  const mdb = memoryDbOrNull("saveActivationState");
+  if (!mdb) return;
+  const stateJson = JSON.stringify(state.state);
+  const everInjectedJson = JSON.stringify(state.everInjected);
+  mdb
+    .insert(activationState)
+    .values({
       conversationId,
-      state.messageId,
-      JSON.stringify(state.state),
-      JSON.stringify(state.everInjected),
-      state.currentTurn,
-      state.updatedAt,
-    );
+      messageId: state.messageId,
+      stateJson,
+      everInjectedJson,
+      currentTurn: state.currentTurn,
+      updatedAt: state.updatedAt,
+    })
+    .onConflictDoUpdate({
+      target: activationState.conversationId,
+      set: {
+        messageId: state.messageId,
+        stateJson,
+        everInjectedJson,
+        currentTurn: state.currentTurn,
+        updatedAt: state.updatedAt,
+      },
+    })
+    .run();
 }
 
 /**
@@ -100,26 +102,35 @@ export function forkActivationState(
   parentConversationId: string,
   newConversationId: string,
 ): void {
-  const raw = memorySqliteOrNull("forkActivationState");
-  if (!raw) return;
-  const row = raw
-    .query(
-      /*sql*/ `SELECT message_id, state_json, ever_injected_json, current_turn, updated_at
-         FROM activation_state WHERE conversation_id = ?`,
-    )
-    .get(parentConversationId) as ActivationStateRow | null;
+  const mdb = memoryDbOrNull("forkActivationState");
+  if (!mdb) return;
+  const row = mdb
+    .select({
+      messageId: activationState.messageId,
+      stateJson: activationState.stateJson,
+      everInjectedJson: activationState.everInjectedJson,
+      currentTurn: activationState.currentTurn,
+      updatedAt: activationState.updatedAt,
+    })
+    .from(activationState)
+    .where(eq(activationState.conversationId, parentConversationId))
+    .get();
   if (!row) return;
 
-  raw
-    .query(UPSERT_SQL)
-    .run(
-      newConversationId,
-      row.message_id,
-      row.state_json,
-      row.ever_injected_json,
-      row.current_turn,
-      row.updated_at,
-    );
+  mdb
+    .insert(activationState)
+    .values({ conversationId: newConversationId, ...row })
+    .onConflictDoUpdate({
+      target: activationState.conversationId,
+      set: {
+        messageId: row.messageId,
+        stateJson: row.stateJson,
+        everInjectedJson: row.everInjectedJson,
+        currentTurn: row.currentTurn,
+        updatedAt: row.updatedAt,
+      },
+    })
+    .run();
 }
 
 /**
@@ -156,26 +167,25 @@ export function seedForkActivationState(
   inheritedSlugs: string[],
 ): void {
   if (inheritedSlugs.length === 0) return;
-  const raw = memorySqliteOrNull("seedForkActivationState");
-  if (!raw) return;
+  const mdb = memoryDbOrNull("seedForkActivationState");
+  if (!mdb) return;
 
   const everInjected: EverInjectedEntry[] = inheritedSlugs.map((slug) => ({
     slug,
     turn: 0,
   }));
-  raw
-    .query(
-      /*sql*/ `INSERT INTO activation_state
-         (conversation_id, message_id, state_json, ever_injected_json, current_turn, updated_at)
-       VALUES (?, ?, '{}', ?, 0, ?)
-       ON CONFLICT(conversation_id) DO NOTHING`,
-    )
-    .run(
-      newConversationId,
-      `${newConversationId}:turn:0`,
-      JSON.stringify(everInjected),
-      Date.now(),
-    );
+  mdb
+    .insert(activationState)
+    .values({
+      conversationId: newConversationId,
+      messageId: `${newConversationId}:turn:0`,
+      stateJson: "{}",
+      everInjectedJson: JSON.stringify(everInjected),
+      currentTurn: 0,
+      updatedAt: Date.now(),
+    })
+    .onConflictDoNothing({ target: activationState.conversationId })
+    .run();
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
@@ -164,6 +164,10 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
         ),
   getMemorySqlite: () =>
     carryMockActive ? memorySqlite : realDbConnection.getMemorySqlite(),
+  getMemoryDb: () =>
+    carryMockActive
+      ? drizzle(memorySqlite, { schema })
+      : realDbConnection.getMemoryDb(),
 }));
 
 /** Mutable prune config: `null` until the script opens the valve window. */

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
@@ -126,6 +126,10 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
         ),
   getMemorySqlite: () =>
     injectionMockActive ? memorySqlite : realDbConnection.getMemorySqlite(),
+  getMemoryDb: () =>
+    injectionMockActive
+      ? drizzle(memorySqlite, { schema })
+      : realDbConnection.getMemoryDb(),
 }));
 
 // The injector reads `memory.enabled` / `memory.v3.live` / `memory.v3.spotlight`

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
@@ -110,6 +110,10 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
         ),
   getMemorySqlite: () =>
     denseMockActive ? memorySqlite : realDbConnection.getMemorySqlite(),
+  getMemoryDb: () =>
+    denseMockActive
+      ? drizzle(memorySqlite, { schema })
+      : realDbConnection.getMemoryDb(),
 }));
 
 const { orchestrate } = await import("../orchestrate.js");

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -279,6 +279,8 @@ mock.module("../../../../../persistence/db-connection.js", () => ({
   getDb: () => testDb,
   getSqliteFrom: () => testSqlite,
   getMemorySqlite: () => (memoryDbAvailable ? memorySqlite : null),
+  getMemoryDb: () =>
+    memoryDbAvailable ? drizzle(memorySqlite, { schema }) : null,
 }));
 
 mock.module("../substrate/page-index.js", () => ({

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.test.ts
@@ -39,30 +39,28 @@ let memoryDbAvailable = true;
 // stand-in to pass positionally so the call sites read the same as production.
 let testSqlite: Database;
 let memorySqlite: Database;
-let memoryDb: ReturnType<typeof drizzle<typeof schema>>;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   memorySqlite = new Database(":memory:");
   ensureMemoryV3EverInjectedSchema(memorySqlite);
-  memoryDb = drizzle(memorySqlite, { schema });
   return drizzle(testSqlite, { schema });
 }
 
 mock.module("../../../../persistence/db-connection.js", () => ({
   ...realDb,
-  getMemoryDb: () =>
-    storeMockActive
-      ? memoryDbAvailable
-        ? memoryDb
-        : null
-      : realDb.getMemoryDb(),
   getMemorySqlite: () =>
     storeMockActive
       ? memoryDbAvailable
         ? memorySqlite
         : null
       : realDb.getMemorySqlite(),
+  getMemoryDb: () =>
+    storeMockActive
+      ? memoryDbAvailable
+        ? drizzle(memorySqlite, { schema })
+        : null
+      : realDb.getMemoryDb(),
 }));
 
 const {

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.test.ts
@@ -39,16 +39,24 @@ let memoryDbAvailable = true;
 // stand-in to pass positionally so the call sites read the same as production.
 let testSqlite: Database;
 let memorySqlite: Database;
+let memoryDb: ReturnType<typeof drizzle<typeof schema>>;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   memorySqlite = new Database(":memory:");
   ensureMemoryV3EverInjectedSchema(memorySqlite);
+  memoryDb = drizzle(memorySqlite, { schema });
   return drizzle(testSqlite, { schema });
 }
 
 mock.module("../../../../persistence/db-connection.js", () => ({
   ...realDb,
+  getMemoryDb: () =>
+    storeMockActive
+      ? memoryDbAvailable
+        ? memoryDb
+        : null
+      : realDb.getMemoryDb(),
   getMemorySqlite: () =>
     storeMockActive
       ? memoryDbAvailable

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
@@ -3,7 +3,7 @@
  *
  * Backed by `memory_v3_ever_injected`, which lives on the dedicated memory
  * connection (`assistant-memory.db`) — every read/write resolves it via
- * `memorySqliteOrNull` and degrades to a no-op when that connection is
+ * `memoryDbOrNull` and degrades to a no-op when that connection is
  * unavailable. One row per (conversation, page-slug) the v3 injector ever
  * attached as a card. The
  * active (non-pruned) slug set is the injection dedup record — a slug present
@@ -27,9 +27,12 @@
  *     not contain, suppressing their re-injection forever.
  */
 
+import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
+
 import type { DrizzleDb } from "../../../../persistence/db-connection.js";
+import { memoryV3EverInjected } from "../../../../persistence/schema/memory-injection.js";
 import { getLogger } from "../logging.js";
-import { memorySqliteOrNull } from "../memory-db.js";
+import { memoryDbOrNull } from "../memory-db.js";
 
 const log = getLogger("memory-v3-ever-injected-store");
 
@@ -56,20 +59,17 @@ export interface EverInjectedEntry {
 export function getInjected(
   conversationId: string,
 ): Map<string, EverInjectedEntry> {
-  const raw = memorySqliteOrNull("getInjected");
-  if (!raw) return new Map();
-  const rows = raw
-    .query(
-      /*sql*/ `
-      SELECT slug, bytes, pruned_at AS prunedAt FROM memory_v3_ever_injected
-      WHERE conversation_id = ?
-    `,
-    )
-    .all(conversationId) as Array<{
-    slug: string;
-    bytes: number;
-    prunedAt: number | null;
-  }>;
+  const mdb = memoryDbOrNull("getInjected");
+  if (!mdb) return new Map();
+  const rows = mdb
+    .select({
+      slug: memoryV3EverInjected.slug,
+      bytes: memoryV3EverInjected.bytes,
+      prunedAt: memoryV3EverInjected.prunedAt,
+    })
+    .from(memoryV3EverInjected)
+    .where(eq(memoryV3EverInjected.conversationId, conversationId))
+    .all();
 
   return new Map(
     rows.map((row) => [row.slug, { bytes: row.bytes, prunedAt: row.prunedAt }]),
@@ -78,16 +78,18 @@ export function getInjected(
 
 /** The injection dedup set: slugs whose cards are currently resident. */
 export function getActiveSlugs(conversationId: string): Set<string> {
-  const raw = memorySqliteOrNull("getActiveSlugs");
-  if (!raw) return new Set();
-  const rows = raw
-    .query(
-      /*sql*/ `
-      SELECT slug FROM memory_v3_ever_injected
-      WHERE conversation_id = ? AND pruned_at IS NULL
-    `,
+  const mdb = memoryDbOrNull("getActiveSlugs");
+  if (!mdb) return new Set();
+  const rows = mdb
+    .select({ slug: memoryV3EverInjected.slug })
+    .from(memoryV3EverInjected)
+    .where(
+      and(
+        eq(memoryV3EverInjected.conversationId, conversationId),
+        isNull(memoryV3EverInjected.prunedAt),
+      ),
     )
-    .all(conversationId) as Array<{ slug: string }>;
+    .all();
   return new Set(rows.map((row) => row.slug));
 }
 
@@ -107,16 +109,22 @@ export interface ActiveInjectedEntry {
 export function getActiveEntries(
   conversationId: string,
 ): ActiveInjectedEntry[] {
-  const raw = memorySqliteOrNull("getActiveEntries");
-  if (!raw) return [];
-  return raw
-    .query(
-      /*sql*/ `
-      SELECT slug, bytes, injected_at AS injectedAt FROM memory_v3_ever_injected
-      WHERE conversation_id = ? AND pruned_at IS NULL
-    `,
+  const mdb = memoryDbOrNull("getActiveEntries");
+  if (!mdb) return [];
+  return mdb
+    .select({
+      slug: memoryV3EverInjected.slug,
+      bytes: memoryV3EverInjected.bytes,
+      injectedAt: memoryV3EverInjected.injectedAt,
+    })
+    .from(memoryV3EverInjected)
+    .where(
+      and(
+        eq(memoryV3EverInjected.conversationId, conversationId),
+        isNull(memoryV3EverInjected.prunedAt),
+      ),
     )
-    .all(conversationId) as ActiveInjectedEntry[];
+    .all();
 }
 
 /**
@@ -125,16 +133,18 @@ export function getActiveEntries(
  * `prune.ts` / `daemon/conversation.ts`).
  */
 export function getPrunedSlugs(conversationId: string): Set<string> {
-  const raw = memorySqliteOrNull("getPrunedSlugs");
-  if (!raw) return new Set();
-  const rows = raw
-    .query(
-      /*sql*/ `
-      SELECT slug FROM memory_v3_ever_injected
-      WHERE conversation_id = ? AND pruned_at IS NOT NULL
-    `,
+  const mdb = memoryDbOrNull("getPrunedSlugs");
+  if (!mdb) return new Set();
+  const rows = mdb
+    .select({ slug: memoryV3EverInjected.slug })
+    .from(memoryV3EverInjected)
+    .where(
+      and(
+        eq(memoryV3EverInjected.conversationId, conversationId),
+        isNotNull(memoryV3EverInjected.prunedAt),
+      ),
     )
-    .all(conversationId) as Array<{ slug: string }>;
+    .all();
   return new Set(rows.map((row) => row.slug));
 }
 
@@ -153,18 +163,26 @@ export function recordInjected(
   // agent turn, so a degraded memory connection or a failed statement only
   // logs a warning.
   try {
-    const raw = memorySqliteOrNull("recordInjected");
-    if (!raw) return;
-    const stmt = raw.query(/*sql*/ `
-      INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
-      VALUES (?, ?, ?, ?, NULL)
-      ON CONFLICT (conversation_id, slug) DO UPDATE SET
-        injected_at = excluded.injected_at,
-        bytes = excluded.bytes,
-        pruned_at = NULL
-    `);
+    const mdb = memoryDbOrNull("recordInjected");
+    if (!mdb) return;
     for (const entry of entries) {
-      stmt.run(conversationId, entry.slug, at, entry.bytes);
+      mdb
+        .insert(memoryV3EverInjected)
+        .values({
+          conversationId,
+          slug: entry.slug,
+          injectedAt: at,
+          bytes: entry.bytes,
+          prunedAt: null,
+        })
+        .onConflictDoUpdate({
+          target: [
+            memoryV3EverInjected.conversationId,
+            memoryV3EverInjected.slug,
+          ],
+          set: { injectedAt: at, bytes: entry.bytes, prunedAt: null },
+        })
+        .run();
     }
   } catch (err) {
     log.warn({ err }, "failed to record ever-injected cards; continuing");
@@ -182,17 +200,18 @@ export function markPruned(
 ): void {
   if (slugs.length === 0) return;
   try {
-    const raw = memorySqliteOrNull("markPruned");
-    if (!raw) return;
-    const placeholders = slugs.map(() => "?").join(", ");
-    raw
-      .query(
-        /*sql*/ `
-      UPDATE memory_v3_ever_injected SET pruned_at = ?
-      WHERE conversation_id = ? AND slug IN (${placeholders})
-    `,
+    const mdb = memoryDbOrNull("markPruned");
+    if (!mdb) return;
+    mdb
+      .update(memoryV3EverInjected)
+      .set({ prunedAt: at })
+      .where(
+        and(
+          eq(memoryV3EverInjected.conversationId, conversationId),
+          inArray(memoryV3EverInjected.slug, slugs),
+        ),
       )
-      .run(at, conversationId, ...slugs);
+      .run();
   } catch (err) {
     log.warn({ err }, "failed to mark ever-injected cards pruned; continuing");
   }
@@ -204,15 +223,12 @@ export function markPruned(
  */
 export function clearConversation(conversationId: string): void {
   try {
-    const raw = memorySqliteOrNull("clearConversation");
-    if (!raw) return;
-    raw
-      .query(
-        /*sql*/ `
-      DELETE FROM memory_v3_ever_injected WHERE conversation_id = ?
-    `,
-      )
-      .run(conversationId);
+    const mdb = memoryDbOrNull("clearConversation");
+    if (!mdb) return;
+    mdb
+      .delete(memoryV3EverInjected)
+      .where(eq(memoryV3EverInjected.conversationId, conversationId))
+      .run();
   } catch (err) {
     log.warn(
       { err },
@@ -223,17 +239,21 @@ export function clearConversation(conversationId: string): void {
 
 /** Total bytes of resident (non-pruned) cards — the prune-valve input. */
 export function residentBytes(conversationId: string): number {
-  const raw = memorySqliteOrNull("residentBytes");
-  if (!raw) return 0;
-  const row = raw
-    .query(
-      /*sql*/ `
-      SELECT COALESCE(SUM(bytes), 0) AS total FROM memory_v3_ever_injected
-      WHERE conversation_id = ? AND pruned_at IS NULL
-    `,
+  const mdb = memoryDbOrNull("residentBytes");
+  if (!mdb) return 0;
+  const row = mdb
+    .select({
+      total: sql<number>`COALESCE(SUM(${memoryV3EverInjected.bytes}), 0)`,
+    })
+    .from(memoryV3EverInjected)
+    .where(
+      and(
+        eq(memoryV3EverInjected.conversationId, conversationId),
+        isNull(memoryV3EverInjected.prunedAt),
+      ),
     )
-    .get(conversationId) as { total: number };
-  return row.total;
+    .get();
+  return row?.total ?? 0;
 }
 
 /**
@@ -251,21 +271,35 @@ export function forkEverInjected(
   newConversationId: string,
 ): void {
   try {
-    const raw = memorySqliteOrNull("forkEverInjected");
-    if (!raw) return;
-    raw
-      .query(
-        /*sql*/ `
-      INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
-      SELECT ?, slug, injected_at, bytes, pruned_at FROM memory_v3_ever_injected
-      WHERE conversation_id = ?
-      ON CONFLICT (conversation_id, slug) DO UPDATE SET
-        injected_at = excluded.injected_at,
-        bytes = excluded.bytes,
-        pruned_at = excluded.pruned_at
-    `,
-      )
-      .run(newConversationId, parentConversationId);
+    const mdb = memoryDbOrNull("forkEverInjected");
+    if (!mdb) return;
+    const parentRows = mdb
+      .select({
+        slug: memoryV3EverInjected.slug,
+        injectedAt: memoryV3EverInjected.injectedAt,
+        bytes: memoryV3EverInjected.bytes,
+        prunedAt: memoryV3EverInjected.prunedAt,
+      })
+      .from(memoryV3EverInjected)
+      .where(eq(memoryV3EverInjected.conversationId, parentConversationId))
+      .all();
+    for (const row of parentRows) {
+      mdb
+        .insert(memoryV3EverInjected)
+        .values({ conversationId: newConversationId, ...row })
+        .onConflictDoUpdate({
+          target: [
+            memoryV3EverInjected.conversationId,
+            memoryV3EverInjected.slug,
+          ],
+          set: {
+            injectedAt: row.injectedAt,
+            bytes: row.bytes,
+            prunedAt: row.prunedAt,
+          },
+        })
+        .run();
+    }
   } catch (err) {
     log.warn({ err }, "failed to fork ever-injected record; continuing");
   }
@@ -306,24 +340,39 @@ export function seedEverInjectedFromSlugs(
 ): void {
   if (slugs.length === 0) return;
   try {
-    const raw = memorySqliteOrNull("seedEverInjectedFromSlugs");
-    if (!raw) return;
-    const prunedRows = raw
-      .query(
-        /*sql*/ `
-      SELECT slug, pruned_at AS prunedAt FROM memory_v3_ever_injected
-      WHERE conversation_id = ? AND pruned_at IS NOT NULL
-    `,
+    const mdb = memoryDbOrNull("seedEverInjectedFromSlugs");
+    if (!mdb) return;
+    const prunedRows = mdb
+      .select({
+        slug: memoryV3EverInjected.slug,
+        prunedAt: memoryV3EverInjected.prunedAt,
+      })
+      .from(memoryV3EverInjected)
+      .where(
+        and(
+          eq(memoryV3EverInjected.conversationId, parentConversationId),
+          isNotNull(memoryV3EverInjected.prunedAt),
+        ),
       )
-      .all(parentConversationId) as Array<{ slug: string; prunedAt: number }>;
+      .all();
     const parentPrunedAt = new Map(prunedRows.map((r) => [r.slug, r.prunedAt]));
-    const stmt = raw.query(/*sql*/ `
-    INSERT INTO memory_v3_ever_injected (conversation_id, slug, injected_at, bytes, pruned_at)
-    VALUES (?, ?, ?, 0, ?)
-    ON CONFLICT (conversation_id, slug) DO NOTHING
-  `);
     for (const slug of slugs) {
-      stmt.run(newConversationId, slug, at, parentPrunedAt.get(slug) ?? null);
+      mdb
+        .insert(memoryV3EverInjected)
+        .values({
+          conversationId: newConversationId,
+          slug,
+          injectedAt: at,
+          bytes: 0,
+          prunedAt: parentPrunedAt.get(slug) ?? null,
+        })
+        .onConflictDoNothing({
+          target: [
+            memoryV3EverInjected.conversationId,
+            memoryV3EverInjected.slug,
+          ],
+        })
+        .run();
     }
   } catch (err) {
     log.warn({ err }, "failed to seed forked ever-injected record; continuing");

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
@@ -30,7 +30,7 @@
 import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 
 import type { DrizzleDb } from "../../../../persistence/db-connection.js";
-import { memoryV3EverInjected } from "../../../../persistence/schema/memory-injection.js";
+import { memoryV3EverInjected } from "../../../../persistence/schema/index.js";
 import { getLogger } from "../logging.js";
 import { memoryDbOrNull } from "../memory-db.js";
 

--- a/assistant/src/plugins/defaults/memory/v3/prune.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.test.ts
@@ -83,6 +83,8 @@ mock.module("../../../../persistence/db-connection.js", () => ({
       : realDb.getSqliteFrom(db as Parameters<typeof realDb.getSqliteFrom>[0]),
   getMemorySqlite: () =>
     pruneMockActive ? memorySqlite : realDb.getMemorySqlite(),
+  getMemoryDb: () =>
+    pruneMockActive ? drizzle(memorySqlite, { schema }) : realDb.getMemoryDb(),
 }));
 
 // Memory code resolves its config through the plugin's own accessor


### PR DESCRIPTION
## Summary

Follow-up to Wave 2 (#38723). The four relocated per-conversation memory stores used raw, stringly-typed `bun:sqlite` SQL on the memory connection. Convert them to drizzle on `getMemoryDb()` using the existing schema objects — behavior-preserving, fail-soft unchanged.

Removes the duplicated column-name string literals and hand-written snake_case row interfaces; reads now return typed rows from the schema. Adds `memoryDbOrNull(context)` to preserve exact degraded-mode behavior (gates on the same sqlite-availability check the raw path used).

Wave-1 stores still use raw SQL and could follow for consistency — left out of scope here.

Based on the Wave 2 branch; retargets to `main` when #38723 merges.