### PR TITLE
docs: steer self-hosted phone setup to the prebuilt web bundle

### DIFF
--- a/docs/self-hosted-phone.md
+++ b/docs/self-hosted-phone.md
@@ -7,12 +7,12 @@ device in a single scan.
 
 Connect from a mobile browser (add it to your home screen for a full-screen
 PWA) or, on a recent build, from the native **Vellum iOS app** pointed at your
-own server — see [Using the Vellum iOS app](#6-using-the-vellum-ios-app). Both
+own server (see [Using the Vellum iOS app](#6-using-the-vellum-ios-app)). Both
 reach the same assistant.
 
 This is a CLI-driven flow for people who already run their assistant locally
 (`vellum wake`). If you use the managed Vellum Cloud app, you don't need any
-of this — sign in and your phone is already connected.
+of this; sign in and your phone is already connected.
 
 ## How it works
 
@@ -41,7 +41,7 @@ terminates TLS and makes the edge reachable from your phone.
   - macOS: `brew install nginx`
   - Linux: `sudo apt install nginx`
 - **Tailscale** installed on both the host machine and your phone, both
-  signed into the same tailnet. (Only needed for the default private path —
+  signed into the same tailnet. (Only needed for the default private path;
   see [Step 4](#4-put-an-https-address-in-front) for public alternatives.)
 
 ## 1. Enable remote web ingress
@@ -55,12 +55,11 @@ vellum flags set web-remote-ingress true
 
 ## 2. The web app ships with the CLI
 
-There's nothing to build: the `vellum` CLI already includes a prebuilt bundle
-of the web app compiled for self-hosting (pointed at your own gateway, not
-Vellum Cloud). The nginx edge in the next step finds it automatically.
+The `vellum` CLI includes a prebuilt bundle of the web app, compiled for
+self-hosting (pointed at your own gateway, not Vellum Cloud). The nginx edge
+in the next step finds it automatically; there is nothing to build.
 
-To try the web UI on the host machine right now, serve that same bundle
-locally:
+To open the web UI on the host machine itself, serve the same bundle locally:
 
 ```bash
 vellum client --interface web
@@ -85,7 +84,7 @@ vellum nginx-ingress up
 ```
 
 This serves the web app on `http://127.0.0.1:7840` and proxies `/v1` to the
-gateway. Useful companions:
+gateway. Related commands:
 
 ```bash
 vellum nginx-ingress status   # is it running, and where
@@ -108,7 +107,8 @@ vellum tunnel --provider tailscale
 While the nginx edge is running, the tunnel automatically targets it and
 records the public URL in your workspace config (`ingress.publicBaseUrl`), so
 channel integrations (Telegram, Twilio, …) can reach the assistant too. Note
-the `https://…ts.net` address it prints — you'll pass it to the pairing step.
+the `https://…ts.net` address it prints; the pairing step reuses it
+automatically.
 
 <details>
 <summary>Manual Tailscale fallback (no <code>vellum tunnel</code> needed)</summary>
@@ -154,19 +154,19 @@ vellum pair --qr
 ```
 
 If you put the HTTPS front in place with `vellum tunnel` (Step 4),
-`vellum pair --qr` reuses that saved address automatically — it prints
-`Using saved ingress URL … (from vellum tunnel; override with --url)`, so you
-don't pass a URL at all. Add `--url` to advertise a different address (and for
-the manual `tailscale serve` fallback, which doesn't save one):
+`vellum pair --qr` reuses that saved address automatically and prints
+`Using saved ingress URL … (from vellum tunnel; override with --url)`. Pass
+`--url` to advertise a different address, or when using the manual
+`tailscale serve` fallback, which doesn't save one:
 
 ```bash
 vellum pair --qr --url https://your-assistant.ts.net
 ```
 
-Either way the command mints a pairing challenge and approves it locally —
-running it on the host _is_ the proof of presence — then renders a QR code (and
-the same URL as text) in your terminal. The advertised URL must be public
-HTTPS; the command refuses loopback or plain-HTTP addresses.
+The command mints a pairing challenge and approves it locally (running it on
+the host is the proof of presence), then renders a QR code and the same URL
+as text in your terminal. The advertised URL must be public HTTPS; the
+command refuses loopback and plain-HTTP addresses.
 
 On your phone:
 
@@ -174,7 +174,7 @@ On your phone:
    on any network (for a public tunnel).
 2. Open the **system camera** and point it at the QR code, then tap the
    notification to open the pairing page in Safari. On iOS the page first
-   offers **Open in the Vellum app** or **Continue in this browser** — tap
+   offers **Open in the Vellum app** or **Continue in this browser**; tap
    **Continue in this browser** to pair here (see
    [Using the Vellum iOS app](#6-using-the-vellum-ios-app) for the app path).
    The page then shows **Connected**; pairing is already approved, so there's
@@ -183,34 +183,33 @@ On your phone:
    an app icon.
 
 The pairing session survives assistant restarts via a refresh cookie, so you
-stay signed in. Pairing codes are **single-use and expire after 10 minutes** —
-to add another device (or if a code lapses), just run `vellum pair --qr`
-again.
+stay signed in. Pairing codes are **single-use and expire after 10 minutes**;
+run `vellum pair --qr` again to add another device or replace a lapsed code.
 
 ## 6. Using the Vellum iOS app
 
-The native **Vellum iOS app** can point at your self-hosted assistant instead of
-Vellum Cloud, giving you the full app shell — not just a home-screen web page —
-against your own server. Steps 1–4 are identical; only the way the phone
+The native **Vellum iOS app** can point at your self-hosted assistant instead
+of Vellum Cloud, giving you the full app shell against your own server rather
+than a home-screen web page. Steps 1–4 are identical; only the way the phone
 connects changes.
 
 > **Build requirement.** These app features ship in the next app release
 > (TestFlight, then the App Store). On an older build, use the browser / Add to
-> Home Screen path in [Step 5](#5-pair-your-phone) — it keeps working
+> Home Screen path in [Step 5](#5-pair-your-phone), which keeps working
 > unchanged. Building the shell from source
 > ([Step 7](#7-native-ios-shell-optional-for-developers)) also produces a build
 > that carries them today.
 
 All three connection methods below reach the same nginx edge you set up above.
 
-### Open the app from the default QR (works for everyone)
+### Open the app from the default QR
 
 The QR from `vellum pair --qr` (Step 5) already serves app users. On iOS its
 pairing page leads with **Open in the Vellum app** and offers **Continue in
 this browser** underneath. Tapping **Open in the Vellum app** hands the pairing
 to the app _before_ the single-use code is spent, so **Continue in this
-browser** still works if the app isn't installed. This one QR is the right
-choice when your phones are a mix of app and browser users.
+browser** still works if the app isn't installed. Use this QR when your phones
+are a mix of app and browser users.
 
 ### Scan straight into the app with `--app`
 
@@ -222,12 +221,12 @@ vellum pair --qr --app
 
 This encodes the pairing as a `vellum-assistant://connect` link; the plain
 https pairing URL is printed beneath it as a fallback. Point the **system
-camera** at the QR and the app opens — cold-launching if it was closed — saves
+camera** at the QR and the app opens (cold-launching if it was closed), saves
 your server, and completes pairing in a single scan. Like plain `--qr`, it
 reuses the `vellum tunnel` address automatically; pass `--url` to override.
 
 An `--app` QR only opens on a phone that already has the app installed, so
-reach for it when every target device has the app. Use `--app-scheme` to target
+use it when every target device has the app. Use `--app-scheme` to target
 a non-production build (`vellum-assistant-dev` for a dev build,
 `vellum-assistant-staging` for staging):
 
@@ -237,22 +236,20 @@ vellum pair --qr --app --app-scheme vellum-assistant-dev
 
 ### Enter the server by hand in Settings
 
-To point the app at your server without scanning, open the iOS **Settings** app,
-tap **Vellum**, and use the **Self-Hosted Server** section: enter your
-assistant's HTTPS URL (the field shows a `https://` placeholder) — the same
-`https://…ts.net` address `vellum pair --qr` prints. Leaving it empty keeps the
-app on Vellum Cloud. The app applies the change when you reopen it. You still
-pair the device once — by any method above, or a browser sign-in — for the app
-to have access.
+To point the app at your server without scanning, open the iOS **Settings**
+app, tap **Vellum**, and use the **Self-Hosted Server** section: enter your
+assistant's HTTPS URL, the same `https://…ts.net` address `vellum pair --qr`
+prints. Leaving the field empty keeps the app on Vellum Cloud. The app applies
+the change when you reopen it. You still pair the device once — by any method
+above, or a browser sign-in — for the app to have access.
 
-If the app can't reach the configured server, it shows an alert —
-**Can't reach `your-assistant.ts.net`.** — with **Retry** and **Use Vellum
+If the app can't reach the configured server, it shows an alert
+(**Can't reach `your-assistant.ts.net`.**) with **Retry** and **Use Vellum
 Cloud**. **Use Vellum Cloud** clears the field and returns the app to Vellum
 Cloud; clearing the field yourself does the same.
 
-The [Good to know](#good-to-know) notes below — laptop awake, no background
-push, single-use 10-minute codes — apply to the app just as they do to the
-browser path.
+The [Good to know](#good-to-know) notes below apply to the app just as they do
+to the browser path.
 
 ## 7. Native iOS shell (optional, for developers)
 
@@ -276,9 +273,9 @@ for prerequisites, signing, and the full build flow.
   it's asleep or offline, the phone can't reach it.
 - **No background push in this mode.** You get live streaming while the app is
   in the foreground, but no push notifications. For proactive pings, connect a
-  channel like Telegram — those deliver notifications independently.
+  channel like Telegram, which delivers notifications independently.
 - **Tailnet-private by default.** `tailscale serve` exposes the edge only to
-  your own devices, not the public internet. Reach for a public tunnel
-  (Step 4) only if you accept the privacy trade-off.
+  your own devices, not the public internet. Use a public tunnel (Step 4) only
+  if you accept the privacy trade-off.
 - **Pairing codes are single-use and expire in 10 minutes.** Re-run
   `vellum pair --qr` whenever you need a fresh one.

--- a/docs/self-hosted-phone.md
+++ b/docs/self-hosted-phone.md
@@ -53,18 +53,30 @@ assistant:
 vellum flags set web-remote-ingress true
 ```
 
-## 2. Build the web app in self-hosted mode
+## 2. The web app ships with the CLI
 
-The nginx edge serves a build of the web app compiled for self-hosting
-(pointed at your own gateway, not Vellum Cloud):
+There's nothing to build: the `vellum` CLI already includes a prebuilt bundle
+of the web app compiled for self-hosting (pointed at your own gateway, not
+Vellum Cloud). The nginx edge in the next step finds it automatically.
+
+To try the web UI on the host machine right now, serve that same bundle
+locally:
+
+```bash
+vellum client --interface web
+```
+
+<details>
+<summary>Running from a source checkout?</summary>
+
+A source checkout has no prebuilt bundle, so build the web app in self-hosted
+mode before starting the edge:
 
 ```bash
 cd clients/web && VITE_PLATFORM_MODE=false bun run build
 ```
 
-> Prefer a prebuilt bundle? Installing the `@vellumai/web` package makes its
-> packaged `dist/` available, and the nginx edge will find it automatically —
-> no local build required.
+</details>
 
 ## 3. Start the nginx edge
 


### PR DESCRIPTION
## Summary
- Rewrite step 2 of `docs/self-hosted-phone.md` to lead with the prebuilt web bundle that ships with the `vellum` CLI (via its `@vellumai/web` dependency) instead of treating a from-source build as the first-class path
- Show `vellum client --interface web` as the way to serve that bundle locally; the nginx edge picks it up automatically for the phone flow
- Demote the `VITE_PLATFORM_MODE=false bun run build` command to a collapsed source-checkout fallback (a checkout genuinely has no prebuilt dist)
- Second commit: a prose-tightening pass over the whole doc (fewer em dashes, less filler), no technical content changes

## Verification
- The published `vellum` package depends on `@vellumai/web` (`meta/package.json`), so a normal install already carries the bundle
- Both `vellum client --interface web` and `vellum nginx-ingress up` resolve the package's `dist/` first via `findWebDistDir()` (`cli/src/commands/client.ts`, `cli/src/lib/nginx-ingress.ts`)
- The release workflow builds the published package with `VITE_PLATFORM_MODE=false`, so it is the self-hosted build this doc needs
- No other file links to the renamed step-2 anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)