### PR TITLE
security: read plugin secret patterns at call time in ingress, scanner, and log redaction

### DIFF
--- a/assistant/src/__tests__/log-redact.test.ts
+++ b/assistant/src/__tests__/log-redact.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  registerPluginSecretPatterns,
+  resetPluginSecretPatternsForTests,
+  unregisterPluginSecretPatterns,
+} from "../security/plugin-secret-patterns.js";
+import { redactLogString } from "../util/log-redact.js";
+
+describe("redactLogString", () => {
+  test("redacts bearer tokens", () => {
+    expect(redactLogString("Authorization: Bearer abc.def-123")).toBe(
+      "Authorization: Bearer [REDACTED]",
+    );
+  });
+
+  test("redacts static prefix API keys", () => {
+    const key = `ghp_${"A".repeat(36)}`;
+    const result = redactLogString(`request with token ${key} failed`);
+    expect(result).not.toContain(key);
+    expect(result).toContain("[REDACTED]");
+  });
+
+  test("passes through strings without secrets", () => {
+    const input = "plain log line with no credentials";
+    expect(redactLogString(input)).toBe(input);
+  });
+
+  describe("plugin-declared patterns", () => {
+    // Synthetic token mirroring the incident's shape (never a real credential).
+    const pluginKey = "virlo_tkn_Qm7pW2xLbV9sKjR4tNcY8dZh3Fg";
+
+    const registerVirlo = () =>
+      registerPluginSecretPatterns("virlo", [
+        { label: "Virlo API Key", pattern: "virlo_tkn_[A-Za-z0-9_-]{20,}" },
+      ]);
+
+    beforeEach(() => {
+      resetPluginSecretPatternsForTests();
+    });
+
+    afterEach(() => {
+      resetPluginSecretPatternsForTests();
+    });
+
+    test("masks a registered plugin key", () => {
+      registerVirlo();
+      expect(redactLogString(`request failed for ${pluginKey}`)).toBe(
+        "request failed for [REDACTED]",
+      );
+    });
+
+    test("does not mask before registration and stops after unregister", () => {
+      const input = `request failed for ${pluginKey}`;
+      expect(redactLogString(input)).toBe(input);
+
+      registerVirlo();
+      expect(redactLogString(input)).not.toContain(pluginKey);
+
+      unregisterPluginSecretPatterns("virlo");
+      expect(redactLogString(input)).toBe(input);
+    });
+  });
+});

--- a/assistant/src/__tests__/secret-ingress.test.ts
+++ b/assistant/src/__tests__/secret-ingress.test.ts
@@ -23,6 +23,11 @@ mock.module("../util/logger.js", () => ({
   }),
 }));
 
+import {
+  registerPluginSecretPatterns,
+  resetPluginSecretPatternsForTests,
+  unregisterPluginSecretPatterns,
+} from "../security/plugin-secret-patterns.js";
 import { resetAllowlist } from "../security/secret-allowlist.js";
 import { checkIngressForSecrets } from "../security/secret-ingress.js";
 
@@ -328,6 +333,47 @@ describe("checkIngressForSecrets", () => {
     );
     expect(result.blocked).toBe(true);
     expect(result.detectedTypes).toEqual(["GitHub Token"]);
+  });
+
+  // ── Plugin-declared patterns ───────────────────────────────────────
+
+  describe("plugin-declared patterns", () => {
+    beforeEach(() => {
+      resetPluginSecretPatternsForTests();
+    });
+
+    afterEach(() => {
+      resetPluginSecretPatternsForTests();
+    });
+
+    const registerVirlo = () =>
+      registerPluginSecretPatterns("virlo", [
+        { label: "Virlo API Key", pattern: "virlo_tkn_[A-Za-z0-9_-]{20,}" },
+      ]);
+
+    test("blocks a registered plugin key under its namespaced label", () => {
+      registerVirlo();
+      const result = checkIngressForSecrets(incidentToken);
+      expect(result.blocked).toBe(true);
+      expect(result.detectedTypes).toEqual(["Virlo API Key (plugin:virlo)"]);
+    });
+
+    test("blocks a registered plugin key embedded in a sentence", () => {
+      registerVirlo();
+      const result = checkIngressForSecrets(
+        `Here is the value ${incidentToken} from the docs`,
+      );
+      expect(result.blocked).toBe(true);
+      expect(result.detectedTypes).toEqual(["Virlo API Key (plugin:virlo)"]);
+    });
+
+    test("falls back to the token-shape heuristic after unregister", () => {
+      registerVirlo();
+      unregisterPluginSecretPatterns("virlo");
+      const result = checkIngressForSecrets(incidentToken);
+      expect(result.blocked).toBe(true);
+      expect(result.detectedTypes).toEqual(["Token-shaped value"]);
+    });
   });
 
   // ── Multiple secrets ───────────────────────────────────────────────

--- a/assistant/src/__tests__/secret-scanner.test.ts
+++ b/assistant/src/__tests__/secret-scanner.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import {
+  registerPluginSecretPatterns,
+  resetPluginSecretPatternsForTests,
+  unregisterPluginSecretPatterns,
+} from "../security/plugin-secret-patterns.js";
 import {
   _isPlaceholder,
   redactSecrets,
@@ -425,6 +430,66 @@ describe("redaction", () => {
     const result = redactSecrets(input);
     expect(result).toContain('<redacted type="AWS Access Key" />');
     expect(result).toContain('<redacted type="GitHub Token" />');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Plugin-declared patterns (runtime registry)
+// ---------------------------------------------------------------------------
+describe("plugin-declared patterns", () => {
+  // Synthetic token mirroring the incident's shape (never a real credential).
+  const pluginKey = "virlo_tkn_Qm7pW2xLbV9sKjR4tNcY8dZh3Fg";
+
+  const registerVirlo = () =>
+    registerPluginSecretPatterns("virlo", [
+      { label: "Virlo API Key", pattern: "virlo_tkn_[A-Za-z0-9_-]{20,}" },
+    ]);
+
+  beforeEach(() => {
+    resetPluginSecretPatternsForTests();
+  });
+
+  afterEach(() => {
+    resetPluginSecretPatternsForTests();
+  });
+
+  test("scanText detects a registered plugin key inside larger text", () => {
+    registerVirlo();
+    const input = `The setup doc pastes ${pluginKey} inline`;
+    const match = expectMatch(input, "Virlo API Key (plugin:virlo)");
+    expect(input.slice(match.startIndex, match.endIndex)).toBe(pluginKey);
+  });
+
+  test("scanText does not flag the key when the plugin is not registered", () => {
+    expectNoMatch(`The setup doc pastes ${pluginKey} inline`);
+  });
+
+  test("redactSecrets redacts a registered plugin key", () => {
+    registerVirlo();
+    const result = redactSecrets(`run with ${pluginKey} exported`);
+    expect(result).toBe(
+      'run with <redacted type="Virlo API Key (plugin:virlo)" /> exported',
+    );
+  });
+
+  test("a second registration mid-test is picked up without restart", () => {
+    registerVirlo();
+    expectMatch(`a ${pluginKey} b`, "Virlo API Key (plugin:virlo)");
+
+    const acmeKey = `acme_sec_${"Zx9".repeat(8)}`;
+    registerPluginSecretPatterns("acme", [
+      { label: "Acme Token", pattern: "acme_sec_[A-Za-z0-9]{16,}" },
+    ]);
+    expectMatch(`a ${acmeKey} b`, "Acme Token (plugin:acme)");
+    // The first plugin's pattern survives the rebuild
+    expectMatch(`a ${pluginKey} b`, "Virlo API Key (plugin:virlo)");
+  });
+
+  test("unregistering stops detection", () => {
+    registerVirlo();
+    expectMatch(`a ${pluginKey} b`, "Virlo API Key (plugin:virlo)");
+    unregisterPluginSecretPatterns("virlo");
+    expectNoMatch(`a ${pluginKey} b`);
   });
 });
 

--- a/assistant/src/security/plugin-secret-patterns.ts
+++ b/assistant/src/security/plugin-secret-patterns.ts
@@ -278,6 +278,26 @@ export function getPluginSecretPatternsVersion(): number {
   return version;
 }
 
+/**
+ * Memoize a consumer's derivation of the plugin-pattern union. `derive` runs
+ * only when the union's identity changes (any register/unregister/reset
+ * produces a new array), so the steady-state cost per call is one reference
+ * compare. Identity-based invalidation stays correct even when the test-only
+ * reset rewinds the version counter.
+ */
+export function memoizePluginPatternDerivation<T>(
+  derive: (patterns: SecretPrefixPattern[]) => T,
+): () => T {
+  let cached: { union: SecretPrefixPattern[]; value: T } | null = null;
+  return () => {
+    const union = getPluginSecretPatterns();
+    if (cached === null || cached.union !== union) {
+      cached = { union, value: derive(union) };
+    }
+    return cached.value;
+  };
+}
+
 /** Drop every registration and reset the version. Exposed for test isolation. */
 export function resetPluginSecretPatternsForTests(): void {
   patternsByPlugin.clear();

--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -2,12 +2,15 @@
  * Ingress secret detection for user messages.
  *
  * Consumes `PREFIX_PATTERNS` from `secret-patterns.ts` — the single source
- * of truth for prefix-based secret detection.  This module intentionally
+ * of truth for prefix-based secret detection — plus plugin-declared patterns
+ * from the runtime registry (`plugin-secret-patterns.ts`), read at call time
+ * so registrations apply without a daemon restart.  This module intentionally
  * does NOT import `scanText()` or any entropy/encoding logic to avoid
  * false positives on legitimate user input.
  */
 
 import { getConfig } from "../config/loader.js";
+import { getPluginSecretPatterns } from "./plugin-secret-patterns.js";
 import { isAllowlisted } from "./secret-allowlist.js";
 import { PREFIX_PATTERNS } from "./secret-patterns.js";
 
@@ -183,7 +186,10 @@ export function checkIngressForSecrets(content: string): IngressCheckResult {
 
   const detectedTypes: string[] = [];
 
-  for (const { label, regex } of PREFIX_PATTERNS) {
+  for (const { label, regex } of [
+    ...PREFIX_PATTERNS,
+    ...getPluginSecretPatterns(),
+  ]) {
     // Use a global version to find all matches
     const globalRegex = new RegExp(regex.source, "g");
     let match: RegExpExecArray | null;

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -9,8 +9,12 @@
  * own prefix-only path in `util/log-redact.ts`.
  */
 
+import { memoizePluginPatternDerivation } from "./plugin-secret-patterns.js";
 import { isAllowlisted } from "./secret-allowlist.js";
-import { PREFIX_PATTERNS } from "./secret-patterns.js";
+import {
+  PREFIX_PATTERNS,
+  type SecretPrefixPattern,
+} from "./secret-patterns.js";
 
 export interface SecretMatch {
   /** Human-readable type label, e.g. "AWS Access Key" */
@@ -40,9 +44,9 @@ const CUSTOM_BOUNDARY: Record<string, (src: string) => string> = {
   "Private Key": (src) => `(${src})`,
 };
 
-// Derive prefix-based patterns from the shared source of truth, adding
-// capture groups and the global flag that scanText() expects.
-const PREFIX_DERIVED: SecretPattern[] = PREFIX_PATTERNS.map((p) => {
+// Derive a scanner pattern from a shared prefix pattern, adding the capture
+// group and the global flag that scanText() expects.
+function deriveScannerPattern(p: SecretPrefixPattern): SecretPattern {
   const src = p.regex.source;
   const custom = CUSTOM_BOUNDARY[p.label];
   const pattern = custom ? custom(src) : `\\b(${src})\\b`;
@@ -50,7 +54,11 @@ const PREFIX_DERIVED: SecretPattern[] = PREFIX_PATTERNS.map((p) => {
     type: p.label,
     regex: new RegExp(pattern, "g"),
   };
-});
+}
+
+// Static patterns derived from the shared source of truth.
+const PREFIX_DERIVED: SecretPattern[] =
+  PREFIX_PATTERNS.map(deriveScannerPattern);
 
 // Scanner-only patterns that require surrounding context or are not
 // simple prefix matches — these stay defined here.
@@ -101,7 +109,15 @@ const SCANNER_ONLY_PATTERNS: SecretPattern[] = [
   },
 ];
 
-const PATTERNS: SecretPattern[] = [...PREFIX_DERIVED, ...SCANNER_ONLY_PATTERNS];
+// Full pattern list, rebuilt only when the plugin-pattern registry changes so
+// registrations apply to the next scan without a daemon restart.
+const getPatterns = memoizePluginPatternDerivation(
+  (pluginPatterns): SecretPattern[] => [
+    ...PREFIX_DERIVED,
+    ...pluginPatterns.map(deriveScannerPattern),
+    ...SCANNER_ONLY_PATTERNS,
+  ],
+);
 
 // ---------------------------------------------------------------------------
 // Known placeholder values that should NOT be flagged
@@ -227,7 +243,7 @@ export function scanText(text: string): SecretMatch[] {
   // De-duplicate overlapping ranges (a match can fire on multiple patterns)
   const seen = new Set<string>();
 
-  for (const pattern of PATTERNS) {
+  for (const pattern of getPatterns()) {
     // Reset lastIndex for global regexes
     pattern.regex.lastIndex = 0;
     let m: RegExpExecArray | null;

--- a/assistant/src/util/log-redact.ts
+++ b/assistant/src/util/log-redact.ts
@@ -4,10 +4,13 @@
  * so secrets never reach log files even when errors bubble up opaque objects.
  *
  * API-key patterns are imported from security/secret-patterns.ts — the shared
- * source of truth.  That module is data-only (no entropy, encoding, or config
- * logic) so it is safe for this hot-path serializer.
+ * source of truth — and unioned with plugin-declared patterns from
+ * security/plugin-secret-patterns.ts at call time.  Both modules are
+ * import-light by contract (no logger, no config, no entropy/encoding logic)
+ * so they are safe for this hot-path serializer.
  */
 
+import { memoizePluginPatternDerivation } from "../security/plugin-secret-patterns.js";
 import { PREFIX_PATTERNS } from "../security/secret-patterns.js";
 
 // ---------------------------------------------------------------------------
@@ -16,8 +19,17 @@ import { PREFIX_PATTERNS } from "../security/secret-patterns.js";
 
 const BEARER_RE = /Bearer [A-Za-z0-9._\-]+/g;
 
-const API_KEY_PATTERNS: RegExp[] = PREFIX_PATTERNS.map(
+const STATIC_API_KEY_PATTERNS: RegExp[] = PREFIX_PATTERNS.map(
   (p) => new RegExp(p.regex.source, "g"),
+);
+
+// Full pattern list, rebuilt only when the plugin-pattern registry changes so
+// registrations apply to the next serialized string without a daemon restart.
+const getApiKeyPatterns = memoizePluginPatternDerivation(
+  (pluginPatterns): RegExp[] => [
+    ...STATIC_API_KEY_PATTERNS,
+    ...pluginPatterns.map((p) => new RegExp(p.regex.source, "g")),
+  ],
 );
 
 // Header names whose values should always be fully redacted
@@ -41,7 +53,7 @@ export function redactLogString(value: string): string {
   result = result.replace(BEARER_RE, "Bearer [REDACTED]");
 
   // Redact API key patterns
-  for (const pattern of API_KEY_PATTERNS) {
+  for (const pattern of getApiKeyPatterns()) {
     pattern.lastIndex = 0;
     result = result.replace(pattern, "[REDACTED]");
   }


### PR DESCRIPTION
## Summary
- Ingress unions `getPluginSecretPatterns()` into its call-time loop; scanner and log-redact move module-load-frozen pattern arrays to memoized call-time getters
- Memoization is shared via a new `memoizePluginPatternDerivation()` helper in the registry (import-light invariant preserved): derived arrays rebuild only when the registry union's identity changes, so steady-state cost is one reference compare per call. Identity-based invalidation stays correct even when the test-only registry reset rewinds the version counter, which a plain version compare would not survive.
- Redaction marker contract unchanged; registry-driven detection/redaction covered in ingress, scanner, and log-redact tests

Part of plan: jarvis-1313-cred-chat-leak.md (PR 7 of 9)