### PR TITLE
plugins: register declared credential key patterns on activation, tear down on removal

### DIFF
--- a/assistant/src/__tests__/plugin-secret-pattern-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-secret-pattern-contribution.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for plugin-declared credential key pattern contributions.
+ *
+ * A plugin may declare `credentialKeyPatterns` in its `package.json` manifest;
+ * the plugin lifecycle registers the declared patterns into the secret-pattern
+ * registry when the plugin activates and removes them on every teardown path
+ * (disable, uninstall, eviction). Assertions read the registry via
+ * {@link getPluginSecretPatterns} — end-to-end detection through the ingress /
+ * scanner / redaction consumers is covered by those consumers' own suites.
+ *
+ * Two lifecycle layers are exercised, mirroring the injector-contribution
+ * suite (`plugin-injector-contribution.test.ts`) and the mtime-cache suite
+ * (`mtime-cache.test.ts`):
+ *
+ *  1. User plugins — synthetic plugin directories driven through boot
+ *     discovery and the source-versions reconcile (install, disable,
+ *     uninstall published exactly the way production publishes them).
+ *  2. Default/registered plugins — `bootstrapPlugins()` registering the
+ *     manifest declaration and rolling it back when `init()` fails.
+ *
+ * All token shapes in this file are synthetic; no real credential formats.
+ */
+
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { bootstrapPlugins } from "../daemon/external-plugins-bootstrap.js";
+import {
+  createSourceWatchState,
+  runSourceWatchPass,
+  type SourceWatchState,
+} from "../monitoring/plugin-source-watch.js";
+import {
+  getUserHooksFor,
+  populateCacheAtBoot,
+  resetPluginCacheForTests,
+} from "../plugins/mtime-cache.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import { getSourceVersionsPath } from "../plugins/source-versions.js";
+import type { PluginCredentialKeyPattern } from "../plugins/types.js";
+import { getPluginSecretPatterns } from "../security/plugin-secret-patterns.js";
+
+// ─── Test fixtures ───────────────────────────────────────────────────────────
+
+// realpath so the reconcile's symlink-resolving allowed-roots check matches
+// on platforms where the tempdir is itself behind a symlink (macOS /var).
+const ROOT = join(
+  realpathSync(tmpdir()),
+  `vellum-plugin-secret-pattern-contrib-test-${process.pid}-${Date.now()}`,
+);
+
+const PLUGINS_DIR = join(ROOT, "plugins");
+
+const VIRLO_PATTERN: PluginCredentialKeyPattern = {
+  label: "Virlo API Key",
+  pattern: "virlo_tkn_[A-Za-z0-9_-]{20,}",
+};
+
+/** Fails the registry's literal-prefix rule (leading `.` is a wildcard). */
+const INVALID_PATTERN: PluginCredentialKeyPattern = {
+  label: "Broad Matcher",
+  pattern: ".*secret",
+};
+
+function ensurePluginsDir(): void {
+  rmSync(PLUGINS_DIR, { recursive: true, force: true });
+  mkdirSync(PLUGINS_DIR, { recursive: true });
+}
+
+function writePluginDir(
+  name: string,
+  credentialKeyPatterns: PluginCredentialKeyPattern[],
+): string {
+  const dir = join(PLUGINS_DIR, name);
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify(
+      {
+        name,
+        version: "1.0.0",
+        peerDependencies: { "@vellumai/plugin-api": "*" },
+        credentialKeyPatterns,
+      },
+      null,
+      2,
+    ),
+  );
+  return dir;
+}
+
+function writeHook(dir: string, hookName: string, body: string): void {
+  const hooksDir = join(dir, "hooks");
+  mkdirSync(hooksDir, { recursive: true });
+  writeFileSync(join(hooksDir, `${hookName}.ts`), body);
+}
+
+/** Registered-pattern labels are namespaced as `<label> (plugin:<name>)`. */
+function findRegistered(label: string, pluginName: string) {
+  return getPluginSecretPatterns().find(
+    (p) => p.label === `${label} (plugin:${pluginName})`,
+  );
+}
+
+/**
+ * Watcher state shared by a test's publishes, reset per test so each test's
+ * first publish takes a fresh baseline.
+ */
+let watchState: SourceWatchState | null = null;
+
+/**
+ * Publish pending source changes the way production does — one watcher pass —
+ * then dispatch a hook read so the daemon-side sentinel gate applies the diff.
+ */
+async function publishAndDispatch(): Promise<void> {
+  if (watchState === null) {
+    watchState = createSourceWatchState();
+  }
+  runSourceWatchPass(watchState);
+  await getUserHooksFor("user-prompt-submit");
+}
+
+// ─── Setup / teardown ────────────────────────────────────────────────────────
+
+beforeAll(() => {
+  process.env.VELLUM_WORKSPACE_DIR = ROOT;
+});
+
+beforeEach(() => {
+  ensurePluginsDir();
+  rmSync(getSourceVersionsPath(), { force: true });
+  watchState = null;
+  // Also clears the secret-pattern registry via resetPluginSecretPatternsForTests.
+  resetPluginCacheForTests();
+  resetPluginRegistryForTests();
+});
+
+afterAll(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+});
+
+// ─── User plugins (mtime-cache lifecycle) ────────────────────────────────────
+
+describe("user plugin credential key pattern lifecycle", () => {
+  test("activation at boot registers declared patterns with plugin-attributed labels", async () => {
+    writePluginDir("virlo-plugin", [VIRLO_PATTERN]);
+
+    await populateCacheAtBoot();
+
+    const registered = findRegistered("Virlo API Key", "virlo-plugin");
+    expect(registered).toBeDefined();
+    expect(registered?.regex.source).toBe(VIRLO_PATTERN.pattern);
+  });
+
+  test("a runtime install makes patterns live without a restart", async () => {
+    await populateCacheAtBoot();
+    expect(getPluginSecretPatterns()).toHaveLength(0);
+
+    writePluginDir("late-plugin", [VIRLO_PATTERN]);
+    await publishAndDispatch();
+
+    expect(findRegistered("Virlo API Key", "late-plugin")).toBeDefined();
+  });
+
+  test("uninstalling a plugin removes its patterns", async () => {
+    const dir = writePluginDir("removable-plugin", [VIRLO_PATTERN]);
+    await populateCacheAtBoot();
+    expect(findRegistered("Virlo API Key", "removable-plugin")).toBeDefined();
+
+    rmSync(dir, { recursive: true, force: true });
+    await publishAndDispatch();
+
+    expect(getPluginSecretPatterns()).toHaveLength(0);
+  });
+
+  test("disabling a plugin removes its patterns", async () => {
+    const dir = writePluginDir("disableable-plugin", [VIRLO_PATTERN]);
+    await populateCacheAtBoot();
+    expect(findRegistered("Virlo API Key", "disableable-plugin")).toBeDefined();
+
+    writeFileSync(join(dir, ".disabled"), "");
+    await publishAndDispatch();
+
+    expect(getPluginSecretPatterns()).toHaveLength(0);
+  });
+
+  test("an invalid declaration never blocks activation; the valid one still registers", async () => {
+    const dir = writePluginDir("mixed-plugin", [
+      VIRLO_PATTERN,
+      INVALID_PATTERN,
+    ]);
+    writeHook(dir, "user-prompt-submit", `export default () => ({ ok: 1 });`);
+
+    await populateCacheAtBoot();
+
+    // Activation proceeded — the plugin's hook is live.
+    expect(await getUserHooksFor("user-prompt-submit")).toHaveLength(1);
+    // Only the valid pattern made it into the registry.
+    expect(getPluginSecretPatterns()).toHaveLength(1);
+    expect(findRegistered("Virlo API Key", "mixed-plugin")).toBeDefined();
+    expect(findRegistered("Broad Matcher", "mixed-plugin")).toBeUndefined();
+  });
+
+  test("resetPluginCacheForTests clears the registry", async () => {
+    writePluginDir("reset-plugin", [VIRLO_PATTERN]);
+    await populateCacheAtBoot();
+    expect(getPluginSecretPatterns()).toHaveLength(1);
+
+    resetPluginCacheForTests();
+
+    expect(getPluginSecretPatterns()).toHaveLength(0);
+  });
+});
+
+// ─── Default/registered plugins (bootstrap lifecycle) ────────────────────────
+
+describe("bootstrap credential key pattern lifecycle", () => {
+  test("bootstrapPlugins registers a plugin's declared patterns", async () => {
+    registerPlugin({
+      manifest: {
+        name: "fixture-secret-plugin",
+        version: "0.0.1",
+        credentialKeyPatterns: [VIRLO_PATTERN],
+      },
+      hooks: { init: async () => {} },
+    });
+
+    await bootstrapPlugins();
+
+    expect(
+      findRegistered("Virlo API Key", "fixture-secret-plugin"),
+    ).toBeDefined();
+  });
+
+  test("a failed init rolls the plugin's patterns back", async () => {
+    registerPlugin({
+      manifest: {
+        name: "failing-secret-plugin",
+        version: "0.0.1",
+        credentialKeyPatterns: [VIRLO_PATTERN],
+      },
+      hooks: {
+        init: async () => {
+          throw new Error("init boom");
+        },
+      },
+    });
+
+    await bootstrapPlugins();
+
+    expect(
+      findRegistered("Virlo API Key", "failing-secret-plugin"),
+    ).toBeUndefined();
+  });
+});

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -59,6 +59,7 @@ import {
   registerPluginInjectors,
   unregisterPluginInjectors,
 } from "../plugins/injector-registry.js";
+import { registerDeclaredCredentialKeyPatterns } from "../plugins/mtime-cache.js";
 import { getRegisteredPlugins, unregisterPlugin } from "../plugins/registry.js";
 import {
   type Plugin,
@@ -66,6 +67,7 @@ import {
   type ShutdownContext,
 } from "../plugins/types.js";
 import { loadUserPlugins } from "../plugins/user-loader.js";
+import { unregisterPluginSecretPatterns } from "../security/plugin-secret-patterns.js";
 import {
   registerPluginTools,
   unregisterPluginTools,
@@ -305,6 +307,15 @@ async function initializePlugin(
       );
     }
 
+    // Disabled plugins never reach this function (the `.disabled` sentinel
+    // check in `bootstrapPlugins` skips them before init), so declared
+    // credential key patterns are only ever registered for enabled plugins.
+    registerDeclaredCredentialKeyPatterns(
+      name,
+      plugin.manifest.credentialKeyPatterns,
+      log,
+    );
+
     if (plugin.hooks?.[HOOKS.INIT]) {
       try {
         await plugin.hooks[HOOKS.INIT](initContext);
@@ -330,6 +341,7 @@ async function initializePlugin(
     } else {
       unregisterPluginTools(name);
       unregisterPluginInjectors(name);
+      unregisterPluginSecretPatterns(name);
     }
     throw err;
   }
@@ -363,6 +375,7 @@ async function teardownPlugin(
   }
 
   unregisterPluginInjectors(name);
+  unregisterPluginSecretPatterns(name);
 
   if (plugin.hooks?.[HOOKS.SHUTDOWN]) {
     try {

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -39,6 +39,8 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import type { Logger } from "pino";
+
 import {
   clearPluginHooks,
   collectUserHookEntries,
@@ -51,6 +53,11 @@ import {
   WORKSPACE_HOOKS_OWNER,
 } from "../hooks/hook-loader.js";
 import type { HookFunction, ShutdownReason } from "../plugin-api/types.js";
+import {
+  registerPluginSecretPatterns,
+  resetPluginSecretPatternsForTests,
+  unregisterPluginSecretPatterns,
+} from "../security/plugin-secret-patterns.js";
 import { finalizeTool } from "../tools/tool-defaults.js";
 import type { Tool, ToolDefinition } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
@@ -78,7 +85,7 @@ import {
   importWithTimeout,
   setSurfaceImportTimeout,
 } from "./surface-import.js";
-import type { HookEntry } from "./types.js";
+import type { HookEntry, PluginCredentialKeyPattern } from "./types.js";
 
 // Re-export for type compat — consumers that import HookFunction from
 // the mtime cache module still resolve.
@@ -486,7 +493,11 @@ async function applySourceVersions(
             membershipChanged = true;
           }
           await reconcilePluginTools(dir, manifest.name);
-          await activatePlugin(dir, manifest.name);
+          await activatePlugin(
+            dir,
+            manifest.name,
+            manifest.credentialKeyPatterns,
+          );
         }
       }
     }
@@ -523,7 +534,7 @@ async function bringUpPlugin(dir: string): Promise<boolean> {
   disabledPluginDirs.delete(dir);
   log.info({ plugin: manifest.name, dir }, "plugin discovered");
   await reconcilePluginTools(dir, manifest.name);
-  await activatePlugin(dir, manifest.name);
+  await activatePlugin(dir, manifest.name, manifest.credentialKeyPatterns);
   return true;
 }
 
@@ -790,6 +801,12 @@ async function scanPlugins(): Promise<void> {
   }
 
   const currentDirs = new Map<string, string>();
+  // Declared credential key patterns per directory, carried from the manifest
+  // parse below to the activation loop at the bottom of the scan.
+  const credentialPatternsByDir = new Map<
+    string,
+    PluginCredentialKeyPattern[] | undefined
+  >();
 
   for (const entry of entries) {
     const pluginDir = join(pluginsDir, entry);
@@ -832,6 +849,7 @@ async function scanPlugins(): Promise<void> {
     const { name: pluginName } = manifest;
 
     currentDirs.set(pluginDir, pluginName);
+    credentialPatternsByDir.set(pluginDir, manifest.credentialKeyPatterns);
     disabledPluginDirs.delete(pluginDir);
 
     if (!discoveredPluginDirs.has(pluginDir)) {
@@ -864,7 +882,7 @@ async function scanPlugins(): Promise<void> {
   // into `toolCache` by `reconcilePluginTools` above, so they are visible to
   // the registry's pull reconcile as soon as activation flips.
   for (const [dir, name] of discoveredPluginDirs) {
-    await activatePlugin(dir, name);
+    await activatePlugin(dir, name, credentialPatternsByDir.get(dir));
   }
 }
 
@@ -898,6 +916,10 @@ async function evictPlugin(
   // Evict tools.
   evictToolCacheEntries(pluginName);
 
+  // Belt to deactivatePlugin's suspenders — eviction can run for a plugin
+  // that never fully activated.
+  unregisterPluginSecretPatterns(pluginName);
+
   log.info(
     { plugin: pluginName, pluginDir },
     "plugin evicted (directory removed)",
@@ -924,6 +946,9 @@ function evictToolCacheEntries(pluginName: string): void {
  */
 async function evictAll(): Promise<void> {
   clearPluginHooks();
+  for (const pluginName of discoveredPluginDirs.values()) {
+    unregisterPluginSecretPatterns(pluginName);
+  }
   toolCache.clear();
   discoveredPluginDirs.clear();
   installDateCache.clear();
@@ -972,6 +997,7 @@ const activatedNames = new Set<string>();
 async function activatePlugin(
   pluginDir: string,
   pluginName: string,
+  credentialKeyPatterns?: PluginCredentialKeyPattern[],
 ): Promise<void> {
   if (activatedNames.has(pluginName)) {
     return;
@@ -984,7 +1010,45 @@ async function activatePlugin(
   // Run the `init` hook if present.
   await runInitHook(pluginName, pluginDir);
 
+  registerDeclaredCredentialKeyPatterns(pluginName, credentialKeyPatterns, log);
+
   activatedPlugins.push({ kind: "plugin", name: pluginName });
+}
+
+/**
+ * Register a plugin's declared credential key patterns (its manifest
+ * `credentialKeyPatterns`) into the secret-pattern registry, replacing any
+ * prior set for that plugin. Invalid declarations never fail activation: each
+ * rejection is logged with plugin attribution — the declared label plus the
+ * rejection reason, never the full pattern source. Shared by the user-plugin
+ * activation path here and the default-plugin bootstrap
+ * (`daemon/external-plugins-bootstrap.ts`); disabled plugins never reach
+ * either call site, which is what keeps disabled-state filtering at the
+ * lifecycle layer (the registry itself does no config reads).
+ */
+export function registerDeclaredCredentialKeyPatterns(
+  pluginName: string,
+  patterns: readonly PluginCredentialKeyPattern[] | undefined,
+  logger: Logger,
+): void {
+  if (patterns === undefined || patterns.length === 0) {
+    return;
+  }
+  const { rejected } = registerPluginSecretPatterns(pluginName, patterns);
+  if (rejected.length === 0) {
+    return;
+  }
+  const labelByPattern = new Map(patterns.map((p) => [p.pattern, p.label]));
+  logger.warn(
+    {
+      plugin: pluginName,
+      rejected: rejected.map((r) => ({
+        label: labelByPattern.get(r.pattern),
+        reason: r.reason,
+      })),
+    },
+    `plugin ${pluginName} declared ${rejected.length} invalid credential key pattern(s) — ignoring them`,
+  );
 }
 
 /**
@@ -1015,6 +1079,7 @@ async function deactivatePlugin(
   if (idx >= 0) {
     activatedPlugins.splice(idx, 1);
   }
+  unregisterPluginSecretPatterns(pluginName);
 
   if (reason !== "uninstall") {
     await runShutdownHook("plugin", pluginName, reason);
@@ -1084,6 +1149,7 @@ export function resetPluginCacheForTests(): void {
   }
   resetHookCacheForTests();
   clearSurfaceImportInflight();
+  resetPluginSecretPatternsForTests();
   toolCache.clear();
   discoveredPluginDirs.clear();
   installDateCache.clear();


### PR DESCRIPTION
## Summary
- User plugins: register `credentialKeyPatterns` in `activatePlugin`, unregister in deactivate/evict/evictAll/reset paths
- Default plugins: mirrored register/unregister in `external-plugins-bootstrap`; disabled plugins skipped at this lifecycle layer
- Invalid declarations log rejection reasons and never block activation; contribution test covers the full lifecycle

Part of plan: jarvis-1313-cred-chat-leak.md (PR 8 of 9)