### PR TITLE
refactor(voice): collapse voice-unified-front-door into voice-triage-escalate

### DIFF
--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -37,29 +37,16 @@ import {
 
 export { ESCALATE_VERDICT_TOKEN, HOLD_VERDICT_TOKEN };
 
-/** Feature-flag key gating the whole behavior. Off by default. */
+/**
+ * Feature-flag key gating the whole behavior: a fast model fronts each
+ * live-voice turn, and endpointing rides that same leg. At each pause the
+ * leg is dispatched speculatively and its leading tokens carry the full
+ * verdict — {@link HOLD_VERDICT_TOKEN} (mid-thought, keep listening),
+ * {@link ESCALATE_VERDICT_TOKEN} plus a spoken bridge, or the answer
+ * itself. Off by default; when off, live voice runs the single-leg path
+ * with the separate endpoint decider.
+ */
 export const VOICE_TRIAGE_ESCALATE_FLAG = "voice-triage-escalate";
-
-/**
- * Feature-flag key for the unified front-door (requires the triage flag
- * too): live-voice endpointing merges into the front-door leg. At each
- * pause the leg is dispatched speculatively and its leading tokens carry
- * the full verdict — {@link HOLD_VERDICT_TOKEN} (mid-thought, keep
- * listening), {@link ESCALATE_VERDICT_TOKEN} plus a spoken bridge, or the
- * answer itself. Replaces the separate endpoint-decider call on that path.
- * Off by default.
- */
-export const VOICE_UNIFIED_FRONT_DOOR_FLAG = "voice-unified-front-door";
-
-/**
- * Whether the unified front-door (endpointing merged into the front-door
- * leg) is active. Only meaningful where triage-escalate is also on.
- */
-export function isVoiceUnifiedFrontDoorEnabled(
-  config: AssistantConfig = getConfig(),
-): boolean {
-  return isAssistantFeatureFlagEnabled(VOICE_UNIFIED_FRONT_DOOR_FLAG, config);
-}
 
 // The fast model fronting every turn is pinned by the `voiceFrontDoor` call
 // site (see config/call-site-defaults.ts) — no per-turn profile override.

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -3075,7 +3075,6 @@ describe("LiveVoiceSession unified front-door endpointing", () => {
       {
         "voice-mode": true,
         "voice-triage-escalate": true,
-        "voice-unified-front-door": true,
       },
       { fromGateway: true },
     );

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -28,12 +28,12 @@ import {
   FALLBACK_ESCALATION_BRIDGE,
   isEscalationBridgeComplete,
   isVoiceTriageEscalateEnabled,
-  isVoiceUnifiedFrontDoorEnabled,
   MIN_SPOKEN_BRIDGE_CHARS,
   type VoiceRoutingLeg,
 } from "../calls/voice-triage-escalate.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
+import type { AssistantConfig } from "../config/schema.js";
 import {
   type LiveVoiceFrontModelConfig,
   LiveVoiceFrontModelConfigSchema,
@@ -1628,7 +1628,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // event ordering — an extra await here would shift utterance release
       // across the persistent-transcriber flush attribution.
       if (reason === "silence" && !manualRelease) {
-        if (this.unifiedFrontDoorActive()) {
+        if (this.frontDoorRoutingActive()) {
           // Unified front-door: the leg itself is the endpoint decision.
           // When it launches, the boundary is deferred to the verdict —
           // commit releases the utterance, hold replays the boundary via
@@ -1759,16 +1759,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   /**
-   * Whether unified front-door endpointing is active: the voice-mode
-   * surface, triage-escalate routing, and the unified flag all on. The
-   * decider-based hold path is skipped entirely when this holds.
+   * Whether front-door routing is active: the voice-mode surface flag and
+   * the triage-escalate routing flag both on. Governs both halves of the
+   * unified front door — the speculative leg that decides the endpoint, and
+   * the escalation hand-off — so the two can never disagree. The
+   * decider-based hold path runs only when this is false.
    */
-  private unifiedFrontDoorActive(): boolean {
-    const cfg = getConfig();
+  private frontDoorRoutingActive(config?: AssistantConfig): boolean {
+    const cfg = config ?? getConfig();
     return (
       isAssistantFeatureFlagEnabled("voice-mode", cfg) &&
-      isVoiceTriageEscalateEnabled(cfg) &&
-      isVoiceUnifiedFrontDoorEnabled(cfg)
+      isVoiceTriageEscalateEnabled(cfg)
     );
   }
 
@@ -2664,9 +2665,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // surface flag and the voice-triage-escalate routing flag are on. A
     // live-voice session already implies voice-mode client-side; the explicit
     // check keeps the "gated behind both flags" contract true server-side.
-    const escalateEnabled =
-      isAssistantFeatureFlagEnabled("voice-mode", cfg) &&
-      isVoiceTriageEscalateEnabled(cfg);
+    const escalateEnabled = this.frontDoorRoutingActive(cfg);
 
     // Front-door leg: with routing on, a fast model fronts the turn (the
     // `voiceFrontDoor` call site pins it) and may hand off on the escalate

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -108,19 +108,11 @@
       "defaultEnabled": false
     },
     {
-      "id": "voice-unified-front-door",
-      "scope": "assistant",
-      "key": "voice-unified-front-door",
-      "label": "Voice Unified Front Door",
-      "description": "Merge live-voice endpointing into the triage front-door leg: one per-pause call whose first token decides hold / escalate / answer, replacing the separate endpoint-decider call",
-      "defaultEnabled": false
-    },
-    {
       "id": "voice-triage-escalate",
       "scope": "assistant",
       "key": "voice-triage-escalate",
       "label": "Voice Triage & Escalate",
-      "description": "Front phone-call turns with a fast model that answers simple turns and escalates tricky ones to the quality model, cutting perceived latency",
+      "description": "Front each live-voice turn with a fast model that answers simple turns and escalates tricky ones to the quality model, cutting perceived latency. The same leg decides the endpoint: its first token holds a mid-thought pause, escalates, or begins the answer, replacing the separate endpoint-decider call",
       "defaultEnabled": false
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -108,19 +108,11 @@
       "defaultEnabled": false
     },
     {
-      "id": "voice-unified-front-door",
-      "scope": "assistant",
-      "key": "voice-unified-front-door",
-      "label": "Voice Unified Front Door",
-      "description": "Merge live-voice endpointing into the triage front-door leg: one per-pause call whose first token decides hold / escalate / answer, replacing the separate endpoint-decider call",
-      "defaultEnabled": false
-    },
-    {
       "id": "voice-triage-escalate",
       "scope": "assistant",
       "key": "voice-triage-escalate",
       "label": "Voice Triage & Escalate",
-      "description": "Front phone-call turns with a fast model that answers simple turns and escalates tricky ones to the quality model, cutting perceived latency",
+      "description": "Front each live-voice turn with a fast model that answers simple turns and escalates tricky ones to the quality model, cutting perceived latency. The same leg decides the endpoint: its first token holds a mid-thought pause, escalates, or begins the answer, replacing the separate endpoint-decider call",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
Step one of folding the voice flags down to a single control.

## Why

`voice-unified-front-door` was never independently reachable — it required `voice-mode` **and** `voice-triage-escalate` to also be on. The only extra combination it created was "triage on, unified off," which is a spike artifact describing no config we'd ship. It also has no LaunchDarkly definition in the platform terraform (only `voice-triage-escalate` is there), so as written it was undeployable in prod. The choice was to write a new LD flag definition or delete one; this deletes it.

Same shape as `5e12dfe159`, which removed `voice-front-model` once that layer stopped needing its own switch.

## What changed

- `voice-unified-front-door` removed: the flag key, `isVoiceUnifiedFrontDoorEnabled`, and the registry entry (plus synced bundled copies).
- `unifiedFrontDoorActive()` → `frontDoorRoutingActive()`, now shared with the escalation call site. Both halves of the unified front door — the speculative leg that decides the endpoint and the escalation hand-off — read one predicate, so they can never disagree about whether routing is on.
- Registry description corrected: it claimed the flag fronts *phone-call* turns, but the Twilio path never sets `routingLeg` (`call-controller.ts:902`), so this has always been live-voice-only. The description now also covers endpointing.

## Behavior

Unchanged in both directions. With `voice-mode` + `voice-triage-escalate` on, turns run the unified front door exactly as they did with all three on — that is the combination that shipped in #38730 and was demo-validated. With either off, live voice runs the single-leg path with the separate endpoint decider, untouched.

`voice-triage-escalate` keeps its role as the kill switch, which is what its own LaunchDarkly description already says it is.

## Follow-ups

- `decideEndpoint` stays alive as the flag-off path. It is live production endpointing today — `frontDecider` is constructed unconditionally (`live-voice-session.ts:4416`) — so deleting it changes what "flag off" degrades to (pure-VAD endpointing rather than today's behavior). That is a deliberate call to make separately, and it is where the ~275-line cleanup actually lives.
- The platform terraform description for `voice-triage-escalate` still carries the old "phone-call turns" wording and the now-stale "Requires voice-mode to also be on" note about the unified flag; worth a cosmetic platform PR.

## Test

`bunx tsc --noEmit` clean. Full affected suites pass locally: live-voice-vad (75), calls/voice-triage-escalate (35), front-decision (43), live-voice-tts-session (27), live-voice-progress (16), live-voice-triage-escalate (11), live-voice-events (4), plus both feature-flag-registry suites confirming the bundled copies are in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)