### PR TITLE
fix: scrub ordering, JSON-string rows, sentinel neutralization in credential transcript scrub

### DIFF
--- a/assistant/src/__tests__/credential-routes.test.ts
+++ b/assistant/src/__tests__/credential-routes.test.ts
@@ -10,6 +10,7 @@ import type { CredentialMetadata } from "../tools/credentials/metadata-store.js"
 let secureStore: Map<string, string>;
 let metadataStore: Map<string, CredentialMetadata>;
 let syncedServices: string[];
+let syncRejects: boolean;
 let disconnectedProviders: string[];
 let credentialIdCounter: number;
 let scrubbedValues: string[];
@@ -102,6 +103,9 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 
 mock.module("../oauth/manual-token-connection.js", () => ({
   syncManualTokenConnection: mock(async (service: string) => {
+    if (syncRejects) {
+      throw new Error("simulated oauth-store failure");
+    }
     syncedServices.push(service);
   }),
 }));
@@ -178,6 +182,7 @@ describe("credentials routes", () => {
     secureStore = new Map();
     metadataStore = new Map();
     syncedServices = [];
+    syncRejects = false;
     disconnectedProviders = [];
     credentialIdCounter = 0;
     scrubbedValues = [];
@@ -548,6 +553,29 @@ describe("credentials routes", () => {
 
       // THEN the scrub never runs
       expect(scrubbedValues).toEqual([]);
+    });
+
+    test("the scrub still runs when the post-store connection sync throws", async () => {
+      /**
+       * `syncManualTokenConnection` performs oauth-store work that can
+       * throw. The secret is already in secure storage at that point, so
+       * the transcript scrub must have run BEFORE the failing side effect
+       * — a stored secret whose plaintext lingers in transcripts is the
+       * leak this seam exists to close.
+       */
+      // GIVEN a connection sync that throws after the store
+      syncRejects = true;
+
+      // WHEN the set is attempted
+      await expect(
+        setRoute!.handler({
+          body: { service: "vercel", field: "api_token", value: SECRET_VALUE },
+        }),
+      ).rejects.toThrow("simulated oauth-store failure");
+
+      // THEN the secret was stored and the scrub ran despite the failure
+      expect(secureStore.get("vercel:api_token")).toBe(SECRET_VALUE);
+      expect(scrubbedValues).toEqual([SECRET_VALUE]);
     });
 
     test("the set still succeeds when the transcript scrub rejects", async () => {

--- a/assistant/src/__tests__/credential-transcript-scrub.test.ts
+++ b/assistant/src/__tests__/credential-transcript-scrub.test.ts
@@ -243,6 +243,77 @@ describe("scrubStoredCredentialFromTranscripts", () => {
     expect(blocks[0].content).toBe(`out: ${MARKER}`);
   });
 
+  test("re-serializes JSON-string content rows so they stay valid JSON", async () => {
+    // `messages.content` can be a JSON-encoded bare string (the shape
+    // `resolveMessageContentBlocks` unwraps to one text block). The marker
+    // contains quotes, so a byte replace on the serialized form would
+    // corrupt the row — the scrub must replace within the parsed value and
+    // re-encode.
+    dbRows.push({
+      id: "msg-json-string",
+      conversationId: "conv-js",
+      content: JSON.stringify(`pasted: ${VALUE}`),
+    });
+
+    const result = await scrubStoredCredentialFromTranscripts(VALUE);
+
+    expect(result.dbMessagesScrubbed).toBe(1);
+    const updated = updatedContentFor("msg-json-string");
+    const parsed: unknown = JSON.parse(updated);
+    expect(parsed).toBe(`pasted: ${MARKER}`);
+  });
+
+  test("neutralizes forged sentinels when stamping an unmarked text block", async () => {
+    // A pre-feature block never had sentinel-shaped strings neutralized at
+    // write, and `renderHistoryContent` trusts `_redactionVersion`-stamped
+    // blocks verbatim — so stamping without neutralizing would promote a
+    // forged sentinel into a trusted, chip-renderable one.
+    const forged = "〔redacted:Credential:vercel:api_token〕";
+    dbRows.push(
+      textRow("msg-forged", "conv-forged", `${forged} and key ${VALUE}`),
+    );
+
+    const result = await scrubStoredCredentialFromTranscripts(VALUE);
+
+    expect(result.dbMessagesScrubbed).toBe(1);
+    const blocks = JSON.parse(updatedContentFor("msg-forged")) as Array<
+      Record<string, unknown>
+    >;
+    // Word joiner (U+2060) after the opening bracket defuses the forged
+    // sentinel; the credential is scrubbed and the stamp applied.
+    expect(blocks[0].text).toBe(
+      `\u3014\u2060redacted:Credential:vercel:api_token\u3015 and key ${MARKER}`,
+    );
+    expect(blocks[0]._redactionVersion).toBe(2);
+  });
+
+  test("preserves redactor-authored sentinels in an already-stamped block", async () => {
+    // A block the persist path stamped already had forgeries neutralized at
+    // write — its surviving sentinels are redactor-authored and must not be
+    // defused when the scrub touches the block.
+    const genuine = "〔redacted:Credential:vercel:api_token〕";
+    dbRows.push({
+      id: "msg-stamped",
+      conversationId: "conv-stamped",
+      content: JSON.stringify([
+        {
+          type: "text",
+          text: `${genuine} then ${VALUE}`,
+          _redactionVersion: 2,
+        },
+      ]),
+    });
+
+    const result = await scrubStoredCredentialFromTranscripts(VALUE);
+
+    expect(result.dbMessagesScrubbed).toBe(1);
+    const blocks = JSON.parse(updatedContentFor("msg-stamped")) as Array<
+      Record<string, unknown>
+    >;
+    expect(blocks[0].text).toBe(`${genuine} then ${MARKER}`);
+    expect(blocks[0]._redactionVersion).toBe(2);
+  });
+
   test("scrubs legacy plain-string content rows with a plain replace", async () => {
     dbRows.push({
       id: "msg-legacy",

--- a/assistant/src/daemon/chat-credential-redaction.ts
+++ b/assistant/src/daemon/chat-credential-redaction.ts
@@ -394,17 +394,32 @@ export function filterRefsByRevealProof(
 const MIN_CANDIDATE_VALUE_LENGTH = 6;
 
 /**
- * Append a candidate in EVERY stdout encoding of its plaintext, deduped on
- * identity+value. `credentials reveal --json` writes the value through
- * `JSON.stringify` (see the CLI's `writeOutput`), so a value containing
- * quotes, backslashes, or control characters — a PEM key's newlines —
- * appears in the tool's stdout ESCAPED: bytes a raw exact-match list can
- * never find, leaving the escaped body to the scanner (which only knows
- * the header). Registering the escaped encoding as its own candidate
- * covers that representation on every surface (persist byte-compare, live
- * guard, tool_result fallback, output chunks). `JSON.stringify` is
- * injective on the value, so an escaped-form match proves the same
- * identity the raw form does.
+ * Every textual encoding of a credential plaintext that can appear on a
+ * transcript surface: the raw value plus its JSON-escaped form
+ * (`JSON.stringify` minus the outer quotes). They differ when the value
+ * contains quotes, backslashes, or control characters — a PEM key's
+ * newlines — because tool stdout (`credentials reveal --json` writes
+ * through `JSON.stringify`) and persisted tool_use inputs carry the
+ * ESCAPED bytes, which a raw exact-match list can never find.
+ * `JSON.stringify` is injective on the value, so an escaped-form match
+ * proves the same identity the raw form does. Deduped: a value needing no
+ * escaping yields a single entry.
+ */
+export function credentialValueEncodings(value: string): string[] {
+  const encodings = [value];
+  const escaped = JSON.stringify(value).slice(1, -1);
+  if (escaped !== value) {
+    encodings.push(escaped);
+  }
+  return encodings;
+}
+
+/**
+ * Append a candidate in EVERY stdout encoding of its plaintext
+ * ({@link credentialValueEncodings}), deduped on identity+value.
+ * Registering the escaped encoding as its own candidate covers that
+ * representation on every surface (persist byte-compare, live guard,
+ * tool_result fallback, output chunks).
  */
 function appendCandidateEncodings(
   candidates: ResolvedRevealCandidate[],
@@ -413,7 +428,7 @@ function appendCandidateEncodings(
   field: string,
   value: string,
 ): void {
-  for (const encoded of [value, JSON.stringify(value).slice(1, -1)]) {
+  for (const encoded of credentialValueEncodings(value)) {
     if (encoded.length < MIN_CANDIDATE_VALUE_LENGTH) {
       continue;
     }
@@ -690,6 +705,14 @@ export interface LiveRevealGuardEntry {
  * classify on its own (context-sensitive patterns like `password=…`).
  */
 const FALLBACK_SENTINEL_TYPE = "Credential";
+
+/**
+ * The generic legacy redaction marker for a credential value — byte-identical
+ * everywhere a credential span is replaced without a proven identity
+ * (persist-time fallback protection, the retroactive transcript scrub), so
+ * downstream scanners and renderers treat every redacted span the same way.
+ */
+export const LEGACY_CREDENTIAL_REDACTION_MARKER = `<redacted type="${FALLBACK_SENTINEL_TYPE}" />`;
 
 /**
  * Precompute live-swap entries from resolved reveal candidates. Every
@@ -1327,7 +1350,7 @@ function protectCandidateValuesLegacy(
   return replaceRawSpans(
     text,
     values,
-    () => `<redacted type="${FALLBACK_SENTINEL_TYPE}" />`,
+    () => LEGACY_CREDENTIAL_REDACTION_MARKER,
     neutralizeRedactedSentinels,
     containedInLongerScannerMatch(text),
   );

--- a/assistant/src/daemon/credential-transcript-scrub.ts
+++ b/assistant/src/daemon/credential-transcript-scrub.ts
@@ -15,19 +15,37 @@
  * Best-effort by contract: the function never throws, logs only
  * lengths/counts (never secret material), and returns whatever it managed
  * to scrub.
+ *
+ * Accepted residual — crash during an in-flight turn: a streaming turn's
+ * unfinalized row is backed by an on-disk delta file that this sweep does
+ * not rewrite (the live turn is covered by the in-memory sweep, and the
+ * finalize seam re-runs persist-time redaction). If the daemon crashes
+ * after a scrub but before that turn finalizes, boot recovery
+ * (`monitoring/recovery/inflight-content.ts`) folds the delta file — which
+ * may still hold the plaintext — into a finalized row no future sweep
+ * revisits. The window is narrow (crash inside one turn, between a
+ * credential store and finalize) and the fold happens without an LLM in
+ * the loop; hardening the recovery fold to re-scrub is future work.
  */
 
-import { SENTINEL_REDACTION_VERSION } from "@vellumai/service-contracts/redacted-credential";
+import {
+  neutralizeRedactedSentinels,
+  SENTINEL_REDACTION_VERSION,
+} from "@vellumai/service-contracts/redacted-credential";
 import { and, eq, gte, or, sql } from "drizzle-orm";
 
 import { updateMessageContent } from "../persistence/conversation-crud.js";
 import { rebuildConversationDiskViewFromDbState } from "../persistence/conversation-disk-view.js";
 import { getDb } from "../persistence/db-connection.js";
 import { enqueueLexicalIndexForMessage } from "../persistence/job-handlers/message-lexical.js";
-import { resolveMessageContentBlocks } from "../persistence/message-content-file.js";
+import { resolveInlineBlockArray } from "../persistence/message-content-file.js";
 import { messages } from "../persistence/schema/conversations.js";
 import type { ContentBlock } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
+import {
+  credentialValueEncodings,
+  LEGACY_CREDENTIAL_REDACTION_MARKER,
+} from "./chat-credential-redaction.js";
 import {
   allConversations,
   allSubagentConversations,
@@ -37,16 +55,13 @@ import { getDbMigrationReadiness } from "./daemon-readiness.js";
 const log = getLogger("credential-transcript-scrub");
 
 /**
- * Same generic marker `protectCandidateValuesLegacy` persists
- * (chat-credential-redaction.ts) — byte-identical so downstream scanners and
- * renderers treat retroactively scrubbed spans like persist-time ones.
- */
-const REDACTION_MARKER = '<redacted type="Credential" />';
-
-/**
  * Floor below which a value is never scrubbed — short strings are too likely
- * to collide with innocent transcript text (mirrors the
- * `MIN_CANDIDATE_VALUE_LENGTH` rationale in chat-credential-redaction.ts).
+ * to collide with innocent transcript text. Deliberately stricter than the
+ * persist-time `MIN_CANDIDATE_VALUE_LENGTH` (6) in
+ * chat-credential-redaction.ts: this sweep rewrites finalized history
+ * across whole conversations, so a false-positive match destroys stored
+ * text rather than merely redacting a live stream — the higher bar buys
+ * collision safety at the cost of skipping very short secrets.
  */
 const MIN_SCRUB_VALUE_LENGTH = 8;
 
@@ -102,14 +117,13 @@ export async function scrubStoredCredentialFromTranscripts(
 }
 
 /**
- * The raw value plus its JSON-escaped form (`JSON.stringify` minus the outer
- * quotes). They differ when the value contains `"` or `\` — tool_use inputs
- * are stored as JSON, and string leaves can themselves embed JSON-encoded
- * text. Longest first so an escaped form is never half-eaten by its raw twin.
+ * Every transcript encoding of the value ({@link credentialValueEncodings}:
+ * raw plus JSON-escaped — tool_use inputs are stored as JSON, and string
+ * leaves can themselves embed JSON-encoded text). Longest first so an
+ * escaped form is never half-eaten by its raw twin.
  */
 function buildSearchTargets(value: string): string[] {
-  const targets = new Set<string>([value, JSON.stringify(value).slice(1, -1)]);
-  return [...targets].sort((a, b) => b.length - a.length);
+  return credentialValueEncodings(value).sort((a, b) => b.length - a.length);
 }
 
 function replaceTargets(
@@ -119,7 +133,7 @@ function replaceTargets(
   let out = text;
   for (const target of targets) {
     if (out.includes(target)) {
-      out = out.split(target).join(REDACTION_MARKER);
+      out = out.split(target).join(LEGACY_CREDENTIAL_REDACTION_MARKER);
     }
   }
   return { text: out, changed: out !== text };
@@ -200,8 +214,10 @@ function sweepDbMessages(targets: readonly string[]): number {
       );
     }
   }
+  // Debug level: the credentials_set route owns the single info-level
+  // summary of a scrub run.
   if (scrubbed > 0 || failures > 0) {
-    log.info(
+    log.debug(
       {
         matchedRows: rows.length,
         scrubbed,
@@ -215,12 +231,18 @@ function sweepDbMessages(targets: readonly string[]): number {
 }
 
 /**
- * Scrub a stored `messages.content` column value. Inline block arrays are
- * resolved through `resolveMessageContentBlocks` (which also repairs legacy
- * block shapes) and re-serialized; anything else — legacy plain-string rows,
- * JSON-string rows — gets a plain textual replace that preserves the stored
- * shape. `{ref}` rows never LIKE-match (the column holds only the pointer),
- * and the plain replace is a no-op for them.
+ * Scrub a stored `messages.content` column value, preserving each row's
+ * stored shape:
+ *   - Inline block arrays are repaired via `resolveInlineBlockArray`,
+ *     scrubbed per block, and re-serialized.
+ *   - JSON-string rows (the `typeof parsed === "string"` shape
+ *     `resolveMessageContentBlocks` unwraps) are scrubbed in the PARSED
+ *     value and re-encoded with `JSON.stringify` — a byte replace on the
+ *     serialized form would splice the marker's unescaped quotes into the
+ *     JSON and corrupt the row.
+ *   - Anything else — legacy plain-string rows, non-array JSON — gets a
+ *     plain textual replace. `{ref}` rows never LIKE-match (the column
+ *     holds only the pointer), and the plain replace is a no-op for them.
  */
 function scrubStoredContent(
   raw: string,
@@ -233,7 +255,7 @@ function scrubStoredContent(
     parsed = undefined;
   }
   if (Array.isArray(parsed)) {
-    const blocks = resolveMessageContentBlocks(raw);
+    const blocks = resolveInlineBlockArray(parsed);
     let changed = false;
     const scrubbedBlocks = blocks.map((block) => {
       const next = scrubBlock(block, targets);
@@ -244,6 +266,12 @@ function scrubStoredContent(
     });
     return changed
       ? { content: JSON.stringify(scrubbedBlocks), changed: true }
+      : { content: raw, changed: false };
+  }
+  if (typeof parsed === "string") {
+    const { text, changed } = replaceTargets(parsed, targets);
+    return changed
+      ? { content: JSON.stringify(text), changed: true }
       : { content: raw, changed: false };
   }
   const { text, changed } = replaceTargets(raw, targets);
@@ -262,12 +290,22 @@ function scrubBlock(
       if (!changed) {
         return { block, changed: false };
       }
-      // The rider marks the block as redaction-aware so
-      // `renderHistoryContent`'s neutralization boundary trusts its markers.
+      // The rider marks the block as redaction-aware, so
+      // `renderHistoryContent`'s neutralization boundary trusts the block's
+      // sentinels verbatim. Stamping therefore requires the same invariant
+      // the persist path establishes (conversation-agent-loop-handlers.ts):
+      // every surviving sentinel is redactor-authored. A block without a
+      // valid rider predates that guarantee — neutralize any sentinel-shaped
+      // strings it carries before stamping, or the stamp would promote a
+      // forged `〔redacted:…〕` into a trusted, chip-renderable one.
+      const rider = (block as { _redactionVersion?: unknown })
+        ._redactionVersion;
+      const alreadyNeutralized =
+        typeof rider === "number" && rider >= SENTINEL_REDACTION_VERSION;
       return {
         block: {
           ...block,
-          text,
+          text: alreadyNeutralized ? text : neutralizeRedactedSentinels(text),
           _redactionVersion: SENTINEL_REDACTION_VERSION,
         } as ContentBlock,
         changed: true,

--- a/assistant/src/persistence/message-content-file.ts
+++ b/assistant/src/persistence/message-content-file.ts
@@ -281,21 +281,31 @@ export function resolveMessageContentBlocks(raw: unknown): ContentBlock[] {
     return [{ type: "text", text: parsed }];
   }
   if (Array.isArray(parsed)) {
-    const result = z.array(contentBlockSchema).safeParse(parsed);
-    if (result.success) {
-      return result.data;
-    }
-    // Historical rows may carry malformed or retired block shapes. Repair
-    // per block — valid blocks stay untouched — so the returned array
-    // always satisfies the schema. Only the rare invalid row pays this.
-    log.warn(
-      { issueCount: result.error.issues.length },
-      "Inline content array has invalid block shapes; repairing per block",
-    );
-    return parsed.map((block) => {
-      const one = contentBlockSchema.safeParse(block);
-      return one.success ? one.data : coerceLegacyBlock(block);
-    });
+    return resolveInlineBlockArray(parsed);
   }
   return [{ type: "text", text: raw }];
+}
+
+/**
+ * Resolve an already-parsed inline content array to schema-valid blocks.
+ * Valid arrays pass through untouched; historical rows with malformed or
+ * retired block shapes are repaired per block ({@link coerceLegacyBlock}),
+ * so the returned array always satisfies the ContentBlock schema. Exported
+ * for callers that have already parsed the stored JSON and must not pay a
+ * second parse.
+ */
+export function resolveInlineBlockArray(parsed: unknown[]): ContentBlock[] {
+  const result = z.array(contentBlockSchema).safeParse(parsed);
+  if (result.success) {
+    return result.data;
+  }
+  // Only the rare invalid row pays the per-block repair.
+  log.warn(
+    { issueCount: result.error.issues.length },
+    "Inline content array has invalid block shapes; repairing per block",
+  );
+  return parsed.map((block) => {
+    const one = contentBlockSchema.safeParse(block);
+    return one.success ? one.data : coerceLegacyBlock(block);
+  });
 }

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -487,22 +487,16 @@ async function handleCredentialsSet({ body }: RouteHandlerArgs) {
     );
   }
 
-  const metadata = upsertCredentialMetadata(service, field, {
-    alias: label,
-    usageDescription: description,
-    allowedTools,
-    allowedDomains,
-    injectionTemplates,
-  });
-  await syncManualTokenConnection(service);
-
   // The stored plaintext may already sit in recent transcripts: the user
   // message that pasted it, the persisted tool_use input, the tool result
   // echoing the command. This route is the scrub seam — not
   // setSecureKeyAsync, which also fires on OAuth refresh rotations and MCP
-  // header writes whose values never transited a transcript. The credential
-  // IS stored at this point; the scrub is best-effort hygiene and must stay
-  // invisible to the caller.
+  // header writes whose values never transited a transcript. The scrub runs
+  // immediately after the secure-store write, BEFORE the metadata upsert and
+  // connection sync: those side effects can throw (oauth-store work), and a
+  // stored-but-unscrubbed secret must not depend on them succeeding. The
+  // credential IS stored at this point; the scrub is best-effort hygiene and
+  // must stay invisible to the caller.
   try {
     const scrubbed =
       await scrubStoredCredentialFromTranscripts(normalizedValue);
@@ -516,6 +510,15 @@ async function handleCredentialsSet({ body }: RouteHandlerArgs) {
       "Credential stored, but transcript scrub failed",
     );
   }
+
+  const metadata = upsertCredentialMetadata(service, field, {
+    alias: label,
+    usageDescription: description,
+    allowedTools,
+    allowedDomains,
+    injectionTemplates,
+  });
+  await syncManualTokenConnection(service);
 
   return {
     credentialId: metadata.credentialId,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for jarvis-1313-cred-chat-leak.md:
- Scrub runs immediately after the secure-store write, so metadata/sync failures can't skip it
- JSON-string content rows are re-serialized instead of byte-patched; forged sentinels neutralized before `_redactionVersion` stamping
- Marker + encoding logic single-sourced from chat-credential-redaction; accepted crash-recovery residual documented