### PR TITLE
fix: harden plugin secret-pattern validator (alternation, ReDoS, min match length)

### DIFF
--- a/assistant/src/__tests__/plugin-secret-patterns.test.ts
+++ b/assistant/src/__tests__/plugin-secret-patterns.test.ts
@@ -1,6 +1,7 @@
 /**
  * Plugin secret-pattern registry: restricted-grammar validation, per-plugin
- * replace/unregister semantics, version counter, and union memoization.
+ * replace/unregister semantics, and union memoization (identity-based —
+ * consumers invalidate via `memoizePluginPatternDerivation`).
  *
  * Also guards the module's import-light invariant — hot-path consumers
  * (`util/log-redact.ts`, used inside log serializers) import the registry, so
@@ -12,7 +13,6 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   getPluginSecretPatterns,
-  getPluginSecretPatternsVersion,
   registerPluginSecretPatterns,
   resetPluginSecretPatternsForTests,
   unregisterPluginSecretPatterns,
@@ -45,6 +45,17 @@ describe("plugin secret-pattern registry", () => {
     expect(union[0]!.regex.test("unrelated text")).toBe(false);
   });
 
+  test("a pattern guaranteeing exactly the minimum match length (4 literal + {12}) is accepted", () => {
+    const result = registerPluginSecretPatterns("acme", [
+      { label: "Acme Key", pattern: "abcd[0-9]{12}" },
+    ]);
+    expect(result.accepted).toBe(1);
+    expect(result.rejected).toEqual([]);
+    expect(getPluginSecretPatterns()[0]!.regex.test("abcd012345678901")).toBe(
+      true,
+    );
+  });
+
   describe("restricted grammar rejections", () => {
     const cases: Array<{ name: string; pattern: string }> = [
       { name: "over-broad .*", pattern: ".*" },
@@ -59,6 +70,19 @@ describe("plugin secret-pattern registry", () => {
         pattern: "virlo_tkn_([A-Za-z0-9_-]{20,})",
       },
       { name: "lookahead", pattern: "virlo_tkn_(?=[A-Za-z0-9]{20,})" },
+      // A literal prefix followed by an alternation branch that matches
+      // everything — the branch bypasses the prefix requirement.
+      { name: "alternation bypass virlo|.*", pattern: "virlo|.*" },
+      // Compiles under RE2 but backtracks catastrophically under the native
+      // engine the stored matcher runs on.
+      { name: "quantified group (?:a+)+", pattern: "virlo_(?:a+)+b" },
+      {
+        name: "nested (lazy) quantifier {4,}?",
+        pattern: "virlo_tkn_[A-Za-z0-9]{4,}?",
+      },
+      // Guaranteed match is only 4 chars — would flag every occurrence of
+      // "http" in ordinary text.
+      { name: "too-short guaranteed match", pattern: "http" },
     ];
 
     for (const { name, pattern } of cases) {
@@ -133,33 +157,7 @@ describe("plugin secret-pattern registry", () => {
       ]);
     });
 
-    test("version bumps on every mutation and not on reads", () => {
-      const v0 = getPluginSecretPatternsVersion();
-      registerPluginSecretPatterns("virlo", [
-        { label: "Virlo API Key", pattern: VALID_PATTERN },
-      ]);
-      const v1 = getPluginSecretPatternsVersion();
-      expect(v1).toBeGreaterThan(v0);
-
-      getPluginSecretPatterns();
-      expect(getPluginSecretPatternsVersion()).toBe(v1);
-
-      registerPluginSecretPatterns("virlo", [
-        { label: "Virlo API Key", pattern: VALID_PATTERN },
-      ]);
-      const v2 = getPluginSecretPatternsVersion();
-      expect(v2).toBeGreaterThan(v1);
-
-      unregisterPluginSecretPatterns("virlo");
-      const v3 = getPluginSecretPatternsVersion();
-      expect(v3).toBeGreaterThan(v2);
-
-      // Unregistering a plugin that never registered is not a mutation.
-      unregisterPluginSecretPatterns("never-registered");
-      expect(getPluginSecretPatternsVersion()).toBe(v3);
-    });
-
-    test("the union is referentially stable between mutations", () => {
+    test("the union is referentially stable between mutations and changes identity on each one", () => {
       registerPluginSecretPatterns("virlo", [
         { label: "Virlo API Key", pattern: VALID_PATTERN },
       ]);
@@ -172,6 +170,15 @@ describe("plugin secret-pattern registry", () => {
       const second = getPluginSecretPatterns();
       expect(second).not.toBe(first);
       expect(getPluginSecretPatterns()).toBe(second);
+
+      unregisterPluginSecretPatterns("other");
+      const third = getPluginSecretPatterns();
+      expect(third).not.toBe(second);
+
+      // Unregistering a plugin that never registered is not a mutation —
+      // downstream memoized derivations must not be invalidated.
+      unregisterPluginSecretPatterns("never-registered");
+      expect(getPluginSecretPatterns()).toBe(third);
     });
   });
 

--- a/assistant/src/plugins/external-plugin-loader.ts
+++ b/assistant/src/plugins/external-plugin-loader.ts
@@ -49,6 +49,7 @@ import semver from "semver";
 import { z } from "zod";
 
 import assistantPkg from "../../package.json" with { type: "json" };
+import { PLUGIN_SECRET_PATTERN_LIMITS } from "../security/plugin-secret-patterns.js";
 import { finalizeTool } from "../tools/tool-defaults.js";
 import type { Tool, ToolDefinition } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
@@ -101,16 +102,22 @@ type PluginPackageJson = z.infer<typeof PluginPackageJsonSchema>;
  * security grammar for what makes a *safe* pattern (anchored prefix, ReDoS
  * bounds) is owned by the secret-pattern registry that consumes the parsed
  * field — this schema only bounds sizes so a manifest cannot smuggle in
- * unbounded data.
+ * unbounded data. The bounds themselves come from
+ * {@link PLUGIN_SECRET_PATTERN_LIMITS} so the two layers cannot drift. A
+ * pattern can never be shorter than its required literal prefix, so
+ * `minLiteralPrefix` doubles as the shape-level length floor.
  */
 const CredentialKeyPatternsSchema = z
   .array(
     z.object({
-      label: z.string().min(1).max(40),
-      pattern: z.string().min(4).max(200),
+      label: z.string().min(1).max(PLUGIN_SECRET_PATTERN_LIMITS.maxLabelLength),
+      pattern: z
+        .string()
+        .min(PLUGIN_SECRET_PATTERN_LIMITS.minLiteralPrefix)
+        .max(PLUGIN_SECRET_PATTERN_LIMITS.maxSourceLength),
     }),
   )
-  .max(5);
+  .max(PLUGIN_SECRET_PATTERN_LIMITS.maxPatternsPerPlugin);
 
 /**
  * Shape-validate a raw `credentialKeyPatterns` value from a plugin

--- a/assistant/src/security/plugin-secret-patterns.ts
+++ b/assistant/src/security/plugin-secret-patterns.ts
@@ -7,9 +7,10 @@
  * list cannot know about. Registrations are keyed by plugin name and flow
  * through {@link registerPluginSecretPatterns} /
  * {@link unregisterPluginSecretPatterns}; consumers read the memoized union
- * via {@link getPluginSecretPatterns} and use
- * {@link getPluginSecretPatternsVersion} to invalidate their own derived
- * (compiled/flagged) arrays.
+ * via {@link getPluginSecretPatterns} and wrap their derived
+ * (compiled/flagged) arrays in {@link memoizePluginPatternDerivation}, which
+ * invalidates on the union's array identity — every mutation produces a new
+ * union array.
  *
  * **Import-light invariant**: this module may import only `secret-patterns.ts`
  * types and `re2js` — no logger, no config, no `plugins/` modules. Hot-path
@@ -21,11 +22,16 @@
  * Patterns are validated against a **restricted grammar** rather than trusted
  * as arbitrary regex: bounded length, an anchored literal prefix (so a plugin
  * cannot register an over-broad matcher that redacts everything), no capture
- * groups / backreferences / lookarounds, and a mandatory `RE2JS.compile`
- * check that structurally guarantees linear-time matching. Only after a
- * pattern passes is it compiled to the native `RegExp` (no flags) that the
- * `SecretPrefixPattern` contract expects — the restricted grammar is what
- * makes the native compile safe.
+ * groups / backreferences / lookarounds, no alternation (`|` would let a
+ * short prefix smuggle in an unrelated over-broad branch), no quantified
+ * groups or nested quantifiers (quantifiers may apply only to a single
+ * char/class/escape atom, which keeps the accepted grammar linear-time under
+ * the **native** engine, not just under RE2), and a minimum guaranteed match
+ * length (so a pattern cannot match short common substrings and mass-redact
+ * every message and log line). An additional mandatory `RE2JS.compile` check
+ * backstops the structural scan. Only after a pattern passes is it compiled
+ * to the native `RegExp` (no flags) that the `SecretPrefixPattern` contract
+ * expects — the restricted grammar is what makes the native compile safe.
  */
 
 import { RE2JS } from "re2js";
@@ -36,16 +42,28 @@ import type { SecretPrefixPattern } from "./secret-patterns.js";
 // Validation limits
 // ---------------------------------------------------------------------------
 
-/** Maximum regex source length a plugin may register. */
-const MAX_SOURCE_LENGTH = 200;
-
-/** Minimum number of guaranteed literal prefix characters. */
-const MIN_LITERAL_PREFIX = 4;
-
-/** Maximum number of patterns a single plugin may register. */
-const MAX_PATTERNS_PER_PLUGIN = 5;
-
-const MAX_LABEL_LENGTH = 40;
+/**
+ * Size and count limits for plugin-declared patterns. Exported as the single
+ * source of truth: the manifest shape schema in
+ * `plugins/external-plugin-loader.ts` references these same values so the
+ * loader's caps cannot drift from the registry's.
+ */
+export const PLUGIN_SECRET_PATTERN_LIMITS = {
+  /** Maximum regex source length a plugin may register. */
+  maxSourceLength: 200,
+  /** Minimum number of guaranteed literal prefix characters. */
+  minLiteralPrefix: 4,
+  /** Maximum number of patterns a single plugin may register. */
+  maxPatternsPerPlugin: 5,
+  /** Maximum label length. */
+  maxLabelLength: 40,
+  /**
+   * Minimum number of characters a pattern is guaranteed to match. Keeps a
+   * short pattern (e.g. `http`) from matching common substrings and blocking
+   * every chat message / rewriting every log line.
+   */
+  minGuaranteedMatchLength: 16,
+} as const;
 
 export interface PluginSecretPatternInput {
   /** Human-readable label, e.g. "Virlo API Key". 1–40 chars. */
@@ -101,14 +119,36 @@ function literalPrefixLength(source: string): number {
   return count;
 }
 
+const QUANTIFIER_CHARS = new Set(["?", "*", "+", "{"]);
+
+/** Matches a `{n}` / `{n,}` / `{n,m}` quantifier at the given offset. */
+function parseBraceQuantifier(
+  source: string,
+  start: number,
+): { end: number; min: number } | null {
+  const match = /^\{(\d+)(?:,\d*)?\}/.exec(source.slice(start));
+  if (match === null) {
+    return null;
+  }
+  return { end: start + match[0].length, min: Number(match[1]) };
+}
+
 /**
  * Scan for constructs outside the restricted grammar: capture groups (`(` is
- * allowed only as `(?:`), lookarounds/inline flags (any other `(?`), and
- * backreferences (`\1`–`\9`). Escapes and character classes are tracked so
- * `\(` and `[()]` are not misread as groups.
+ * allowed only as `(?:`), lookarounds/inline flags (any other `(?`),
+ * backreferences (`\1`–`\9`), alternation (an unescaped `|` outside a
+ * character class — a branch could bypass the literal-prefix requirement,
+ * e.g. `virlo|.*`), quantified groups (`)` followed by `?`/`*`/`+`/`{`), and
+ * nested quantifiers (a quantifier directly following another, including lazy
+ * `+?` forms). Banning quantifiers on anything but a single char/class/escape
+ * atom is what makes the accepted grammar linear-time under the native
+ * `RegExp` engine — RE2 accepting a pattern says nothing about how the native
+ * matcher backtracks on it. Escapes and character classes are tracked so
+ * `\(`, `\|`, and `[()|]` are not misread.
  */
 function findStructuralIssue(source: string): string | null {
   let inClass = false;
+  let prevWasQuantifier = false;
   for (let i = 0; i < source.length; i++) {
     const ch = source[i]!;
     if (ch === "\\") {
@@ -117,6 +157,7 @@ function findStructuralIssue(source: string): string | null {
         return "backreferences are not allowed";
       }
       i++;
+      prevWasQuantifier = false;
       continue;
     }
     if (inClass) {
@@ -127,19 +168,129 @@ function findStructuralIssue(source: string): string | null {
     }
     if (ch === "[") {
       inClass = true;
+      prevWasQuantifier = false;
+      continue;
+    }
+    if (ch === "|") {
+      return "alternation (|) is not allowed";
+    }
+    if (ch === "(") {
+      if (source[i + 1] !== "?") {
+        return "capture groups are not allowed; use (?:...) instead";
+      }
+      if (!source.startsWith("(?:", i)) {
+        return "lookarounds and inline groups other than (?: are not allowed";
+      }
+      // Consume the whole `(?:` opener so its `?` is not read as a quantifier.
+      i += 2;
+      prevWasQuantifier = false;
+      continue;
+    }
+    if (ch === ")") {
+      const next = source[i + 1];
+      if (next !== undefined && QUANTIFIER_CHARS.has(next)) {
+        return "quantifiers on groups are not allowed; quantify single characters or character classes instead";
+      }
+      prevWasQuantifier = false;
+      continue;
+    }
+    if (ch === "?" || ch === "*" || ch === "+") {
+      if (prevWasQuantifier) {
+        return "nested quantifiers are not allowed";
+      }
+      prevWasQuantifier = true;
+      continue;
+    }
+    if (ch === "{") {
+      const quantifier = parseBraceQuantifier(source, i);
+      if (quantifier !== null) {
+        if (prevWasQuantifier) {
+          return "nested quantifiers are not allowed";
+        }
+        prevWasQuantifier = true;
+        i = quantifier.end - 1;
+        continue;
+      }
+    }
+    prevWasQuantifier = false;
+  }
+  return null;
+}
+
+/**
+ * Conservative lower bound on the number of characters any match of `source`
+ * must span. Assumes the source already passed {@link findStructuralIssue},
+ * so there is no alternation and every quantifier applies to exactly one
+ * single-character atom (literal, `.`, escape, or character class): each atom
+ * counts 1, `?`/`*` zero out their atom, `+` keeps it at 1, and `{n,...}`
+ * multiplies it by `n`. Groups and zero-width assertions count 0.
+ */
+function minGuaranteedMatchLength(source: string): number {
+  let total = 0;
+  let lastAtom = 0;
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i]!;
+    if (ch === "\\") {
+      const next = source[i + 1];
+      lastAtom = next === "b" || next === "B" ? 0 : 1;
+      total += lastAtom;
+      i += 2;
+      continue;
+    }
+    if (ch === "[") {
+      i++;
+      if (source[i] === "^") {
+        i++;
+      }
+      if (source[i] === "]") {
+        i++;
+      }
+      while (i < source.length && source[i] !== "]") {
+        i += source[i] === "\\" ? 2 : 1;
+      }
+      i++;
+      lastAtom = 1;
+      total += 1;
       continue;
     }
     if (ch === "(") {
-      if (source.startsWith("(?:", i)) {
+      // Structural scan guarantees this is `(?:`.
+      i += 3;
+      lastAtom = 0;
+      continue;
+    }
+    if (ch === ")" || ch === "^" || ch === "$") {
+      i++;
+      lastAtom = 0;
+      continue;
+    }
+    if (ch === "?" || ch === "*") {
+      total -= lastAtom;
+      lastAtom = 0;
+      i++;
+      continue;
+    }
+    if (ch === "+") {
+      lastAtom = 0;
+      i++;
+      continue;
+    }
+    if (ch === "{") {
+      const quantifier = parseBraceQuantifier(source, i);
+      if (quantifier !== null) {
+        total += lastAtom * (quantifier.min - 1);
+        lastAtom = 0;
+        i = quantifier.end;
         continue;
       }
-      if (source[i + 1] === "?") {
-        return "lookarounds and inline groups other than (?: are not allowed";
-      }
-      return "capture groups are not allowed; use (?:...) instead";
     }
+    // Literal char or `.` wildcard — both span exactly one character.
+    lastAtom = 1;
+    total += 1;
+    i++;
   }
-  return null;
+  return total;
 }
 
 /**
@@ -149,28 +300,34 @@ function findStructuralIssue(source: string): string | null {
 function validatePattern(
   input: PluginSecretPatternInput,
 ): { ok: true; regex: RegExp } | { ok: false; reason: string } {
+  const limits = PLUGIN_SECRET_PATTERN_LIMITS;
   const reject = (reason: string) => ({ ok: false as const, reason });
   if (typeof input.label !== "string" || input.label.length < 1) {
     return reject("label must be a non-empty string");
   }
-  if (input.label.length > MAX_LABEL_LENGTH) {
-    return reject(`label exceeds ${MAX_LABEL_LENGTH} characters`);
+  if (input.label.length > limits.maxLabelLength) {
+    return reject(`label exceeds ${limits.maxLabelLength} characters`);
   }
   const source = input.pattern;
   if (typeof source !== "string" || source.length === 0) {
     return reject("pattern must be a non-empty string");
   }
-  if (source.length > MAX_SOURCE_LENGTH) {
-    return reject(`pattern exceeds ${MAX_SOURCE_LENGTH} characters`);
+  if (source.length > limits.maxSourceLength) {
+    return reject(`pattern exceeds ${limits.maxSourceLength} characters`);
   }
-  if (literalPrefixLength(source) < MIN_LITERAL_PREFIX) {
+  if (literalPrefixLength(source) < limits.minLiteralPrefix) {
     return reject(
-      `pattern must start with at least ${MIN_LITERAL_PREFIX} literal characters from [A-Za-z0-9_.-] (a distinctive key prefix)`,
+      `pattern must start with at least ${limits.minLiteralPrefix} literal characters from [A-Za-z0-9_.-] (a distinctive key prefix)`,
     );
   }
   const structuralIssue = findStructuralIssue(source);
   if (structuralIssue !== null) {
     return reject(structuralIssue);
+  }
+  if (minGuaranteedMatchLength(source) < limits.minGuaranteedMatchLength) {
+    return reject(
+      `pattern must be guaranteed to match at least ${limits.minGuaranteedMatchLength} characters (short patterns over-match ordinary text)`,
+    );
   }
   // RE2 compile guarantees linear-time matching semantics and structurally
   // rejects anything the scans above missed (it has no backtracking, no
@@ -198,10 +355,12 @@ function validatePattern(
 /** Accepted patterns keyed by plugin name, labels already namespaced. */
 const patternsByPlugin = new Map<string, SecretPrefixPattern[]>();
 
-/** Bumped on every mutation; consumers memoize derived arrays against it. */
-let version = 0;
-
-/** Memoized flattened union; invalidated on every mutation. */
+/**
+ * Memoized flattened union; invalidated (set to null) on every mutation so
+ * the next read builds a new array. The union's array identity is the
+ * registry's change signal — {@link memoizePluginPatternDerivation} keys off
+ * it.
+ */
 let cachedUnion: SecretPrefixPattern[] | null = null;
 
 /**
@@ -209,8 +368,8 @@ let cachedUnion: SecretPrefixPattern[] | null = null;
  * prior set for that plugin. Each pattern is validated independently; invalid
  * ones are rejected with a reason (never thrown) and valid ones are stored
  * with their label namespaced as `<label> (plugin:<name>)`. At most
- * {@link MAX_PATTERNS_PER_PLUGIN} patterns are accepted per plugin — the
- * excess is rejected.
+ * {@link PLUGIN_SECRET_PATTERN_LIMITS.maxPatternsPerPlugin} patterns are
+ * accepted per plugin — the excess is rejected.
  */
 export function registerPluginSecretPatterns(
   pluginName: string,
@@ -219,10 +378,10 @@ export function registerPluginSecretPatterns(
   const accepted: SecretPrefixPattern[] = [];
   const rejected: PluginSecretPatternRejection[] = [];
   for (const input of patterns) {
-    if (accepted.length >= MAX_PATTERNS_PER_PLUGIN) {
+    if (accepted.length >= PLUGIN_SECRET_PATTERN_LIMITS.maxPatternsPerPlugin) {
       rejected.push({
         pattern: String(input.pattern),
-        reason: `per-plugin limit of ${MAX_PATTERNS_PER_PLUGIN} patterns exceeded`,
+        reason: `per-plugin limit of ${PLUGIN_SECRET_PATTERN_LIMITS.maxPatternsPerPlugin} patterns exceeded`,
       });
       continue;
     }
@@ -237,27 +396,26 @@ export function registerPluginSecretPatterns(
     });
   }
   patternsByPlugin.set(pluginName, accepted);
-  version++;
   cachedUnion = null;
   return { accepted: accepted.length, rejected };
 }
 
 /**
- * Remove the patterns declared by `pluginName`. No-op (no version bump) when
- * the plugin never registered, so it is safe to call on every teardown path.
+ * Remove the patterns declared by `pluginName`. No-op (the memoized union
+ * keeps its identity) when the plugin never registered, so it is safe to call
+ * on every teardown path.
  */
 export function unregisterPluginSecretPatterns(pluginName: string): void {
   if (patternsByPlugin.delete(pluginName)) {
-    version++;
     cachedUnion = null;
   }
 }
 
 /**
  * The flattened union of every registered plugin's accepted patterns.
- * Memoized: the same array reference is returned until a mutation bumps the
- * version, so hot-path consumers can cheaply detect change by reference or
- * via {@link getPluginSecretPatternsVersion}.
+ * Memoized: the same array reference is returned until a mutation invalidates
+ * it, so hot-path consumers can cheaply detect change by reference (see
+ * {@link memoizePluginPatternDerivation}).
  */
 export function getPluginSecretPatterns(): SecretPrefixPattern[] {
   if (cachedUnion === null) {
@@ -271,19 +429,10 @@ export function getPluginSecretPatterns(): SecretPrefixPattern[] {
 }
 
 /**
- * Monotonic mutation counter. Consumers that derive per-call-site compiled
- * arrays from the union should rebuild only when this value changes.
- */
-export function getPluginSecretPatternsVersion(): number {
-  return version;
-}
-
-/**
  * Memoize a consumer's derivation of the plugin-pattern union. `derive` runs
  * only when the union's identity changes (any register/unregister/reset
  * produces a new array), so the steady-state cost per call is one reference
- * compare. Identity-based invalidation stays correct even when the test-only
- * reset rewinds the version counter.
+ * compare.
  */
 export function memoizePluginPatternDerivation<T>(
   derive: (patterns: SecretPrefixPattern[]) => T,
@@ -298,9 +447,8 @@ export function memoizePluginPatternDerivation<T>(
   };
 }
 
-/** Drop every registration and reset the version. Exposed for test isolation. */
+/** Drop every registration. Exposed for test isolation. */
 export function resetPluginSecretPatternsForTests(): void {
   patternsByPlugin.clear();
-  version = 0;
   cachedUnion = null;
 }

--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -10,9 +10,12 @@
  */
 
 import { getConfig } from "../config/loader.js";
-import { getPluginSecretPatterns } from "./plugin-secret-patterns.js";
+import { memoizePluginPatternDerivation } from "./plugin-secret-patterns.js";
 import { isAllowlisted } from "./secret-allowlist.js";
-import { PREFIX_PATTERNS } from "./secret-patterns.js";
+import {
+  PREFIX_PATTERNS,
+  type SecretPrefixPattern,
+} from "./secret-patterns.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -23,6 +26,31 @@ export interface IngressCheckResult {
   detectedTypes: string[];
   userNotice?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Compiled patterns — global variants of the shared prefix patterns
+// ---------------------------------------------------------------------------
+
+interface GlobalPattern {
+  label: string;
+  regex: RegExp;
+}
+
+function toGlobalPattern(p: SecretPrefixPattern): GlobalPattern {
+  return { label: p.label, regex: new RegExp(p.regex.source, "g") };
+}
+
+const STATIC_GLOBAL_PATTERNS: GlobalPattern[] =
+  PREFIX_PATTERNS.map(toGlobalPattern);
+
+// Full pattern list, rebuilt only when the plugin-pattern registry changes so
+// registrations apply to the next message without a daemon restart.
+const getGlobalPatterns = memoizePluginPatternDerivation(
+  (pluginPatterns): GlobalPattern[] => [
+    ...STATIC_GLOBAL_PATTERNS,
+    ...pluginPatterns.map(toGlobalPattern),
+  ],
+);
 
 // ---------------------------------------------------------------------------
 // Placeholder detection (inline — not imported from secret-scanner.ts)
@@ -186,15 +214,12 @@ export function checkIngressForSecrets(content: string): IngressCheckResult {
 
   const detectedTypes: string[] = [];
 
-  for (const { label, regex } of [
-    ...PREFIX_PATTERNS,
-    ...getPluginSecretPatterns(),
-  ]) {
-    // Use a global version to find all matches
-    const globalRegex = new RegExp(regex.source, "g");
+  for (const { label, regex } of getGlobalPatterns()) {
+    // Reset lastIndex — the compiled global regexes are shared across calls
+    regex.lastIndex = 0;
     let match: RegExpExecArray | null;
 
-    while ((match = globalRegex.exec(content)) !== null) {
+    while ((match = regex.exec(content)) !== null) {
       const value = match[0];
 
       // Skip placeholders and test values (check both the match and

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -39,7 +39,7 @@
     }
     ```
 
-  - Patterns are validated at registration against a restricted grammar; invalid entries are rejected with a logged reason and never block plugin load. Constraints: at most 5 patterns per plugin; `label` is 1–40 chars; `pattern` is 4–200 chars and must start with at least 4 literal characters from `[A-Za-z0-9_.-]` (a distinctive key prefix — over-broad matchers are rejected); no capture groups (use `(?:...)`), backreferences, or lookarounds; and the pattern must compile as a linear-time RE2 regex.
+  - Patterns are validated at registration against a restricted grammar; invalid entries are rejected with a logged reason and never block plugin load. Constraints: at most 5 patterns per plugin; `label` is 1–40 chars; `pattern` is 4–200 chars and must start with at least 4 literal characters from `[A-Za-z0-9_.-]` (a distinctive key prefix — over-broad matchers are rejected); no capture groups (use `(?:...)`), backreferences, lookarounds, or alternation (`|`); quantifiers may apply only to a single character, escape, or character class (no quantified groups or nested quantifiers); the pattern must be guaranteed to match at least 16 characters (short patterns like `http` over-match ordinary text); and the pattern must compile as a linear-time RE2 regex.
   - **Security analysis note**: Skills that demonstrate `curl`, `wget`, or other network tool usage against specific API endpoints do not introduce new capabilities — the assistant already has outbound network access via `bash`. These are instructions for using an existing tool, not a new attack surface. See [`assistant/docs/architecture/security.md#skill-threat-model`](../assistant/docs/architecture/security.md) for the full threat model.
 
 - **Write portable instructions**

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1026,7 +1026,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants. Requires Python 3, bun, and the assistant credentials CLI.",
-      "updatedAt": "2026-07-22T17:01:41.000Z"
+      "updatedAt": "2026-07-22T17:12:50.000Z"
     },
     {
       "id": "vellum-heartbeat",
@@ -1106,7 +1106,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-22T17:01:41.000Z"
+      "updatedAt": "2026-07-22T17:12:50.000Z"
     },
     {
       "id": "vellum-self-knowledge",


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for jarvis-1313-cred-chat-leak.md:
- Reject unescaped alternation, quantified groups/nested quantifiers (native-engine linear-time guarantee), and patterns with min guaranteed match < 16 chars
- Remove dead `getPluginSecretPatternsVersion` export; loader zod schema now references exported limit constants
- Ingress precompiles static patterns and memoizes plugin-derived ones like its sibling consumers