### PR TITLE
fix: align runtime credential guidance with agent-shell set guard; docs + PEM flow + catalog

### DIFF
--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -276,13 +276,17 @@ The `allowOneTimeSend` config gate (default: `false`) enables a secondary "Send 
 - The credentials prompt route output confirms delivery without including the secret value — the value is never returned to the model
 - The config gate must be explicitly enabled by the operator
 
+### Ingress Secret Detection
+
+User messages are scanned at ingress (`secret-ingress.ts`) against known credential prefix patterns plus any plugin-declared patterns: plugins can declare `credentialKeyPatterns` in their manifest, and those patterns feed ingress blocking, display-time secret scanning (`secret-scanner.ts`), and log redaction (`log-redact.ts`) while the plugin is active. In addition, when `secretDetection.blockTokenShapedMessages` is enabled (default: `true`), a whole-message heuristic blocks messages whose entire trimmed content is a single token-shaped value — an alphanumeric head, a secret-keyword infix (`token`, `key`, `secret`, …), and a long random tail — catching pasted credentials whose prefix is not a known format while keeping false positives near zero.
+
 ### Storage Layout
 
 | Component           | Location                                               | What it stores                                                                                                                                                   |
 | ------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Secret values       | CES credential store or encrypted file store           | Encrypted credential values keyed as `credential/{service}/{field}`. Stored via CES RPC (primary), CES HTTP (containerized), or encrypted file store (fallback). |
 | Credential metadata | `$VELLUM_WORKSPACE_DIR/data/credentials/metadata.json` | Service, field, label, policy (allowedTools, allowedDomains), timestamps                                                                                         |
-| Config              | `$VELLUM_WORKSPACE_DIR/config.*`                       | `secretDetection` settings: enabled, blockIngress, allowOneTimeSend                                                                                              |
+| Config              | `$VELLUM_WORKSPACE_DIR/config.*`                       | `secretDetection` settings: enabled, blockIngress, allowOneTimeSend, blockTokenShapedMessages (default `true` — whole-message token-shape heuristic)             |
 
 ### Key Files
 
@@ -296,7 +300,8 @@ The `allowOneTimeSend` config gate (default: `false`) enables a secondary "Send 
 | `assistant/src/tools/credentials/policy-validate.ts`             | Policy input validation (allowedTools, allowedDomains)                             |
 | `assistant/src/permissions/secret-prompter.ts`                   | HTTP secret_request/secret_response flow                                           |
 | `assistant/src/security/secret-scanner.ts`                       | Prefix + shape-based secret regex detection (used by display-time `redactSecrets`) |
-| `assistant/src/security/secret-ingress.ts`                       | Prefix-only ingress check on user messages                                         |
+| `assistant/src/security/secret-ingress.ts`                       | Ingress check on user messages: prefix + plugin patterns + token-shape heuristic   |
+| `assistant/src/security/plugin-secret-patterns.ts`               | Registry of plugin-declared `credentialKeyPatterns` feeding detection/redaction    |
 | `assistant/src/util/log-redact.ts`                               | Pino log serializers — prefix-based redaction for logs                             |
 | `clients/web/src/domains/chat/components/secret-prompt-card.tsx` | UI for secure credential entry                                                     |
 

--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -312,7 +312,7 @@ describe("executeBrowserFillCredential", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("No credential stored for slack/api_key");
-    expect(result.content).toContain("assistant credentials set");
+    expect(result.content).toContain("assistant credentials prompt");
     // The broker short-circuits before DOM.focus is dispatched.
     const methods = sendCalls.map((c) => c.method);
     expect(methods).not.toContain("DOM.focus");
@@ -328,7 +328,7 @@ describe("executeBrowserFillCredential", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("No credential stored for slack/api_key");
-    expect(result.content).toContain("assistant credentials set");
+    expect(result.content).toContain("assistant credentials prompt");
     const methods = sendCalls.map((c) => c.method);
     expect(methods).not.toContain("Input.insertText");
   });
@@ -458,7 +458,7 @@ describe("executeBrowserFillCredential", () => {
       expect(result.isError).toBe(true);
       expect(result.content).toContain("Policy denied");
       expect(result.content).toContain("not allowed to use credential");
-      expect(result.content).toContain("assistant credentials set");
+      expect(result.content).toContain("assistant credentials prompt");
       // The broker short-circuits before Input.insertText fires.
       const methods = sendCalls.map((c) => c.method);
       expect(methods).not.toContain("Input.insertText");

--- a/assistant/src/__tests__/credential-broker-browser-fill.test.ts
+++ b/assistant/src/__tests__/credential-broker-browser-fill.test.ts
@@ -452,7 +452,7 @@ describe("CredentialBroker.browserFill", () => {
       expect(result.reason).toContain("not allowed");
     });
 
-    test("denies with empty allowedTools and suggests assistant credentials set", async () => {
+    test("denies with empty allowedTools and suggests assistant credentials prompt", async () => {
       upsertCredentialMetadata("custom", "key", {
         allowedTools: [],
       });
@@ -469,7 +469,7 @@ describe("CredentialBroker.browserFill", () => {
 
       expect(result.success).toBe(false);
       expect(result.reason).toContain("No tools are currently allowed");
-      expect(result.reason).toContain("assistant credentials set");
+      expect(result.reason).toContain("assistant credentials prompt");
     });
   });
 

--- a/assistant/src/__tests__/credential-broker-server-use.test.ts
+++ b/assistant/src/__tests__/credential-broker-server-use.test.ts
@@ -296,7 +296,7 @@ describe("CredentialBroker.serverUse", () => {
 
       expect(result.success).toBe(false);
       expect(result.reason).toContain("No tools are currently allowed");
-      expect(result.reason).toContain("assistant credentials set");
+      expect(result.reason).toContain("assistant credentials prompt");
     });
 
     test("denies when credential has domain restrictions even if tool matches", async () => {
@@ -585,7 +585,7 @@ describe("CredentialBroker.serverUseById", () => {
     expect(result.success).toBe(false);
     if (result.success) throw new Error("expected denial");
     expect(result.reason).toContain("No tools are currently allowed");
-    expect(result.reason).toContain("assistant credentials set");
+    expect(result.reason).toContain("assistant credentials prompt");
   });
 
   test("denies when metadata exists but no stored secret value", async () => {

--- a/assistant/src/__tests__/credential-broker.test.ts
+++ b/assistant/src/__tests__/credential-broker.test.ts
@@ -95,7 +95,7 @@ describe("CredentialBroker", () => {
       if (!result.authorized) {
         expect(result.reason).toContain("not allowed");
         expect(result.reason).toContain("No tools are currently allowed");
-        expect(result.reason).toContain("assistant credentials set");
+        expect(result.reason).toContain("assistant credentials prompt");
       }
     });
 

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -227,8 +227,8 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     expect(message).toContain("Connect Claude Code");
     expect(message).toContain("Do NOT");
     expect(message).toContain("claude setup-token");
-    // Keeps the headless CLI fallback available.
-    expect(message).toContain("assistant credentials set");
+    // Keeps the headless CLI fallback available, via the secure prompt.
+    expect(message).toContain("assistant credentials prompt");
     // Corrects the earlier "nothing to paste" framing — the cloud (manual) flow
     // does paste a key, and the model is told not to claim otherwise.
     expect(message).toContain("does paste a key");

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -302,7 +302,7 @@ export class AcpAgentProcess {
           `ACP agent "${this.agentId}" requires authentication. ` +
             `Advertised methods: ${this.describeAuthMethods()}. ` +
             "Set the required env var under acp.agents.<id>.env in config.json, " +
-            "store it via 'assistant credentials set --service acp --field <field>', " +
+            "collect it securely via 'assistant credentials prompt --service acp --field <field> --label \"<label>\"', " +
             "or complete the agent's own login flow in the workspace.",
         );
       }

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -197,8 +197,8 @@ async function injectOptionalCredential(
  * (per-workspace, rotated, etc.) are never silently clobbered:
  *   1. `acp.agents.<id>.env.CLAUDE_CODE_OAUTH_TOKEN` in `config.json` —
  *      the user-supplied env override on the resolved agent config.
- *   2. Secure store via CLI: `assistant credentials set --service acp \
- *        --field claude_oauth_token <token>` — read through the
+ *   2. Secure store via CLI: `assistant credentials prompt --service acp \
+ *        --field claude_oauth_token --label ...` — read through the
  *      credential broker for policy enforcement and audit logging.
  * After resolution, this asserts the token is present (from either route)
  * before spawning. The "fail-fast" throw is symmetric with the existing
@@ -269,8 +269,10 @@ export async function prepareAgentEnv(
           "flow does paste a key). Do NOT tell them to run `claude setup-token`, " +
           "paste a token in chat, or run credential CLI commands, and do NOT " +
           "retry the spawn yourself — the card and auto-continue handle it. " +
-          "(Headless only, where no card can appear: `assistant credentials set " +
-          "--service acp --field claude_oauth_token <token>`.)",
+          "(Headless only, where no card can appear: `assistant credentials prompt " +
+          '--service acp --field claude_oauth_token --label "Claude Code OAuth ' +
+          'Token"` — it collects the token securely, falling back to a one-time ' +
+          "collection link to relay to the user.)",
         { code: ACP_CLAUDE_OAUTH_MISSING_CODE },
       );
     }

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -196,7 +196,7 @@ export async function resolveCallerIdentity(
     return {
       ok: false,
       error:
-        "user_number mode requires a user phone number. Set calls.callerIdentity.userNumber in config or store credential/twilio/user_phone_number via `assistant credentials set`.",
+        'user_number mode requires a user phone number. Set calls.callerIdentity.userNumber in config or store credential/twilio/user_phone_number via `assistant credentials prompt --service twilio --field user_phone_number --label "User Phone Number"`.',
     };
   }
 

--- a/assistant/src/calls/fish-audio-client.ts
+++ b/assistant/src/calls/fish-audio-client.ts
@@ -44,7 +44,7 @@ export async function synthesizeWithFishAudio(
   );
   if (!apiKey) {
     throw new Error(
-      "Fish Audio API key not configured. Store it via: assistant credentials set --service fish-audio --field api_key <key>",
+      'Fish Audio API key not configured. Collect it via: assistant credentials prompt --service fish-audio --field api_key --label "Fish Audio API Key"',
     );
   }
 

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -291,7 +291,7 @@ export function registerConnectCommand(oauth: Command): void {
             if (authorizeUrl === "urn:manual-token") {
               writeError(
                 `"${provider}" uses manual token configuration, not an OAuth browser flow. ` +
-                  `Set the token with: assistant credentials set <token_value> --service ${provider} --field <field_name>`,
+                  `Collect the token securely with: assistant credentials prompt --service ${provider} --field <field_name> --label "<label>"`,
               );
               return;
             }

--- a/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
+++ b/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
@@ -7,7 +7,7 @@ any generic account registry:
 
 - `assistant credentials list` for discovering stored credential handles
 - `assistant oauth status <provider>` for discovering OAuth connection handles
-- `assistant credentials set ...` for storing new credentials
+- `assistant credentials prompt ...` for collecting and storing user-supplied secrets (never pass a user-provided value inline to `assistant credentials set` — the CLI refuses it from an agent shell). `assistant credentials set ... --generated` is only for values the assistant machine-generated itself (e.g. `"$(uuidgen)"`, an API exchange result)
 - `assistant mcp auth <name>` when an MCP server needs browser login
 - `assistant platform status` for platform-linked deployment/auth context
 

--- a/assistant/src/runtime/routes/oauth-connect-routes.ts
+++ b/assistant/src/runtime/routes/oauth-connect-routes.ts
@@ -62,7 +62,7 @@ async function handleOAuthConnectStart({
   if (providerRow.authorizeUrl === "urn:manual-token") {
     throw new BadRequestError(
       `"${service}" uses manual token configuration, not an OAuth browser flow. ` +
-        `Set the token with: assistant credentials set <token_value> --service ${service} --field <field_name>`,
+        `Collect the token securely with: assistant credentials prompt --service ${service} --field <field_name> --label "<label>"`,
     );
   }
 

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -2220,13 +2220,13 @@ export async function executeBrowserFillCredential(
         reason.includes("no stored value")
       ) {
         return {
-          content: `No credential stored for ${service}/${field}. Use \`assistant credentials set\` to save it first.`,
+          content: `No credential stored for ${service}/${field}. Collect it via \`assistant credentials prompt --service ${service} --field ${field} --label <label>\` first.`,
           isError: true,
         };
       }
       if (reason.includes("not allowed to use credential")) {
         return {
-          content: `Policy denied: ${reason} Update the credential's allowed_tools via \`assistant credentials set\` if this tool should have access.`,
+          content: `Policy denied: ${reason} If this tool should have access, run \`assistant credentials prompt --service ${service} --field ${field} --label <label> --allowed-tools ${BROWSER_FILL_CAPABILITY}\` (re-collects the value securely and sets allowed_tools).`,
           isError: true,
         };
       }

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -26,6 +26,14 @@ const log = getLogger("credential-broker");
 const TOKEN_TTL_MS = 5 * 60 * 1000;
 
 /**
+ * Remediation for a credential whose allowed_tools list is empty. Points at
+ * `credentials prompt` (not inline `credentials set`, which agent shells
+ * refuse): the secure prompt re-collects the value and sets allowed_tools.
+ */
+const NO_TOOLS_ALLOWED_REMEDIATION =
+  "No tools are currently allowed - grant access via `assistant credentials prompt --service <service> --field <field> --label <label> --allowed-tools <tools>` (re-collects the value securely and sets allowed_tools).";
+
+/**
  * Credential broker that issues single-use tokens for policy-checked credential access.
  *
  * The broker never exposes plaintext secret values. Instead, it:
@@ -76,7 +84,7 @@ export class CredentialBroker {
         reason:
           `Tool "${request.toolName}" is not allowed to use credential ${request.service}/${request.field}. ` +
           (tools.length === 0
-            ? "No tools are currently allowed - update the credential's allowed_tools via `assistant credentials set`."
+            ? NO_TOOLS_ALLOWED_REMEDIATION
             : `Allowed tools: ${tools.join(", ")}.`),
       };
     }
@@ -186,7 +194,7 @@ export class CredentialBroker {
         reason:
           `Tool "${request.toolName}" is not allowed to use credential ${request.service}/${request.field}. ` +
           (tools.length === 0
-            ? "No tools are currently allowed - update the credential's allowed_tools via `assistant credentials set`."
+            ? NO_TOOLS_ALLOWED_REMEDIATION
             : `Allowed tools: ${tools.join(", ")}.`),
       };
     }
@@ -282,7 +290,7 @@ export class CredentialBroker {
         reason:
           `Tool "${request.toolName}" is not allowed to use credential ${request.service}/${request.field}. ` +
           (tools.length === 0
-            ? "No tools are currently allowed - update the credential's allowed_tools via `assistant credentials set`."
+            ? NO_TOOLS_ALLOWED_REMEDIATION
             : `Allowed tools: ${tools.join(", ")}.`),
       };
     }
@@ -365,7 +373,7 @@ export class CredentialBroker {
         reason:
           `Tool "${request.requestingTool}" is not allowed to use credential ${metadata.service}/${metadata.field}. ` +
           (tools.length === 0
-            ? "No tools are currently allowed - update the credential's allowed_tools via `assistant credentials set`."
+            ? NO_TOOLS_ALLOWED_REMEDIATION
             : `Allowed tools: ${tools.join(", ")}.`),
       };
     }

--- a/assistant/src/tts/providers/elevenlabs-provider.ts
+++ b/assistant/src/tts/providers/elevenlabs-provider.ts
@@ -230,7 +230,7 @@ async function performTtsRequest(
     throw new ElevenLabsTtsError(
       "ELEVENLABS_TTS_NO_API_KEY",
       "ElevenLabs API key not configured. " +
-        "Add it in Settings → Voice or via: assistant credentials set --service elevenlabs --field api_key <key>",
+        'Add it in Settings → Voice or via: assistant credentials prompt --service elevenlabs --field api_key --label "ElevenLabs API Key"',
     );
   }
 
@@ -396,7 +396,7 @@ export const elevenLabsTtsProviderDefinition: TtsProviderDefinition = {
       credentialStoreKey: "credential/elevenlabs/api_key",
       displayName: "ElevenLabs API Key",
       setCommand:
-        "assistant credentials set --service elevenlabs --field api_key <key>",
+        'assistant credentials prompt --service elevenlabs --field api_key --label "ElevenLabs API Key"',
     },
   ],
   adapter: createElevenLabsProvider(),

--- a/assistant/src/tts/providers/fish-audio-provider.ts
+++ b/assistant/src/tts/providers/fish-audio-provider.ts
@@ -194,7 +194,7 @@ export const fishAudioTtsProviderDefinition: TtsProviderDefinition = {
       credentialStoreKey: "credential/fish-audio/api_key",
       displayName: "Fish Audio API Key",
       setCommand:
-        "assistant credentials set --service fish-audio --field api_key <key>",
+        'assistant credentials prompt --service fish-audio --field api_key --label "Fish Audio API Key"',
     },
   ],
   adapter: createFishAudioProvider(),

--- a/assistant/src/tts/providers/xai-provider.ts
+++ b/assistant/src/tts/providers/xai-provider.ts
@@ -156,7 +156,7 @@ async function requireApiKey(): Promise<string> {
     throw new XaiTtsError(
       "XAI_TTS_NO_API_KEY",
       "xAI API key not configured. " +
-        "Add it via: assistant credentials set --service xai --field api_key <key>",
+        'Add it via: assistant credentials prompt --service xai --field api_key --label "xAI API Key"',
     );
   }
   return apiKey;
@@ -367,7 +367,7 @@ export const xaiTtsProviderDefinition: TtsProviderDefinition = {
       credentialStoreKey: "credential/xai/api_key",
       displayName: "xAI API Key",
       setCommand:
-        "assistant credentials set --service xai --field api_key <key>",
+        'assistant credentials prompt --service xai --field api_key --label "xAI API Key"',
     },
   ],
   adapter: createXaiProvider(),

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1026,7 +1026,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants. Requires Python 3, bun, and the assistant credentials CLI.",
-      "updatedAt": "2026-07-22T17:39:29.000Z"
+      "updatedAt": "2026-07-22T17:44:21.000Z"
     },
     {
       "id": "vellum-heartbeat",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -932,7 +932,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-22T16:44:13.000Z"
+      "updatedAt": "2026-07-22T17:39:29.000Z"
     },
     {
       "id": "twilio-setup",
@@ -1026,7 +1026,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants. Requires Python 3, bun, and the assistant credentials CLI.",
-      "updatedAt": "2026-07-22T17:01:41.000Z"
+      "updatedAt": "2026-07-22T17:39:29.000Z"
     },
     {
       "id": "vellum-heartbeat",
@@ -1106,7 +1106,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-22T17:01:41.000Z"
+      "updatedAt": "2026-07-22T17:12:50.000Z"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -23,7 +23,7 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 | -------------- | ---------- | ------------------------------------------- | ------- |
 | Bot Token      | Credential | `assistant credentials prompt`              | **Yes** |
 | Bot Username   | Config     | `assistant config set telegram.botUsername` | No      |
-| Webhook Secret | Credential | `assistant credentials set`                 | **Yes** |
+| Webhook Secret | Credential | `assistant credentials set … --generated`   | **Yes** |
 
 - **Bot Token** is a secret. Always collect via `assistant credentials prompt` - never accept it pasted in plaintext chat.
 - **Bot Username** is derived from the token via the Telegram API and stored as config.

--- a/skills/vellum-github-app-setup/SKILL.md
+++ b/skills/vellum-github-app-setup/SKILL.md
@@ -216,15 +216,15 @@ The default permission set covers the full range of actions the assistant may ne
 
 All credentials are stored under `service: github-app`:
 
-| Field             | Description                                     | When Set |
-| ----------------- | ----------------------------------------------- | -------- |
-| `app_id`          | Numeric GitHub App ID                           | Step 2   |
-| `app_slug`        | URL-friendly app name (e.g. `credence-the-bot`) | Step 2   |
-| `client_id`       | OAuth client ID                                 | Step 2   |
-| `client_secret`   | OAuth client secret                             | Step 2   |
-| `pem_b64`         | Base64-encoded (single-line) RSA private key for JWT signing — decode at use time with `assistant credentials reveal --service github-app --field pem_b64 \| base64 -d` | Step 2   |
-| `webhook_secret`  | Webhook verification secret                     | Step 2   |
-| `installation_id` | Numeric installation ID for the org             | Step 3   |
+| Field             | Description                                                               | When Set |
+| ----------------- | ------------------------------------------------------------------------- | -------- |
+| `app_id`          | Numeric GitHub App ID                                                     | Step 2   |
+| `app_slug`        | URL-friendly app name (e.g. `credence-the-bot`)                           | Step 2   |
+| `client_id`       | OAuth client ID                                                           | Step 2   |
+| `client_secret`   | OAuth client secret                                                       | Step 2   |
+| `pem_b64`         | Base64-encoded (single-line) RSA private key; decoded at JWT-signing time | Step 2   |
+| `webhook_secret`  | Webhook verification secret                                               | Step 2   |
+| `installation_id` | Numeric installation ID for the org                                       | Step 3   |
 
 ## Troubleshooting
 

--- a/skills/vellum-github-app-setup/SKILL.md
+++ b/skills/vellum-github-app-setup/SKILL.md
@@ -75,7 +75,7 @@ assistant credentials set --service github-app --field app_slug "APP_SLUG" --gen
 assistant credentials set --service github-app --field client_id "CLIENT_ID" --generated
 ```
 
-**Secret fields** (`client_secret`, `webhook_secret`, `pem`) — never read these into the conversation, ask for them in chat, or pass them inline to `assistant credentials set` (the CLI refuses inline user-supplied secrets). Collect each one with `assistant credentials prompt` — a secure input whose value never enters the chat transcript — and have the user copy the values out of the credentials JSON on their host:
+**Secret fields** (`client_secret`, `webhook_secret`, and the private key) — never read these into the conversation, ask for them in chat, or pass them inline to `assistant credentials set` (the CLI refuses inline user-supplied secrets). Collect each one with `assistant credentials prompt` — a secure input whose value never enters the chat transcript — and have the user copy the values out of the credentials JSON on their host:
 
 ```bash
 assistant credentials prompt --service github-app --field client_secret \
@@ -86,16 +86,16 @@ assistant credentials prompt --service github-app --field webhook_secret \
   --description "Copy the webhook_secret value from the credentials JSON"
 ```
 
-For the PEM (private key), the JSON stores it with `\n` escapes — the user must extract the real multi-line key first, then paste that into the secure prompt. Have them run this on their host to print the decoded key for copying:
+For the PEM (private key), the secure prompt input is single-line — pasting a multi-line key strips its newlines and the mangled key fails JWT signing. Have the user base64-encode the key to a single line on their host and paste **that** into the secure prompt. It is stored as field `pem_b64`; everything that signs JWTs decodes it at use time (`assistant credentials reveal --service github-app --field pem_b64 | base64 -d`). Print the single-line value for copying:
 
 ```bash
-jq -r .pem /tmp/github-app-credentials.json
+jq -r .pem /tmp/github-app-credentials.json | base64 | tr -d '\n'
 ```
 
 ```bash
-assistant credentials prompt --service github-app --field pem \
-  --label "GitHub App Private Key (PEM)" \
-  --description "Paste the full RSA private key (-----BEGIN ... END-----) printed by: jq -r .pem /tmp/github-app-credentials.json"
+assistant credentials prompt --service github-app --field pem_b64 \
+  --label "GitHub App Private Key (base64-encoded PEM)" \
+  --description "Paste the single-line output of: jq -r .pem /tmp/github-app-credentials.json | base64 | tr -d '\n'"
 ```
 
 > **Note:** The `installation_id` credential is stored in Step 3 after installing the app.
@@ -190,7 +190,7 @@ Test the full flow:
 
 Installation tokens expire after **1 hour**. The helper script `gh-app-token.mjs` generates a fresh one each time by:
 
-1. Reading `app_id` and `pem` from the vault
+1. Reading `app_id` and `pem_b64` from the vault (base64-decoding the key before signing)
 2. Signing a JWT with the private key
 3. Exchanging the JWT for an installation token via `POST /app/installations/{id}/access_tokens`
 
@@ -222,7 +222,7 @@ All credentials are stored under `service: github-app`:
 | `app_slug`        | URL-friendly app name (e.g. `credence-the-bot`) | Step 2   |
 | `client_id`       | OAuth client ID                                 | Step 2   |
 | `client_secret`   | OAuth client secret                             | Step 2   |
-| `pem`             | RSA private key for JWT signing                 | Step 2   |
+| `pem_b64`         | Base64-encoded (single-line) RSA private key for JWT signing — decode at use time with `assistant credentials reveal --service github-app --field pem_b64 \| base64 -d` | Step 2   |
 | `webhook_secret`  | Webhook verification secret                     | Step 2   |
 | `installation_id` | Numeric installation ID for the org             | Step 3   |
 
@@ -234,7 +234,7 @@ The manifest JSON must include `hook_attributes.url` — a nested URL inside the
 
 ### Token generation fails
 
-Check that all three required credentials are set: `app_id`, `pem`, `installation_id`. Use `assistant credentials list --search github-app` to verify.
+Check that all three required credentials are set: `app_id`, `pem_b64`, `installation_id`. Use `assistant credentials list --search github-app` to verify.
 
 ### Push rejected with 403
 
@@ -242,7 +242,7 @@ The installation token may have expired (1-hour lifetime). Regenerate with `bun 
 
 ### PEM won't store or fails JWT signing
 
-The PEM must be collected via `assistant credentials prompt` — inline `assistant credentials set` with a pasted key is refused from the agent shell. If the stored key fails JWT signing, the paste likely kept the JSON `\n` escapes; have the user re-copy the decoded multi-line key (`jq -r .pem /tmp/github-app-credentials.json`) and run the prompt again.
+The secure prompt input is single-line, so a raw multi-line PEM cannot be pasted into it — newlines are stripped and the mangled key fails JWT signing. Store the key base64-encoded as `pem_b64` instead: have the user re-run `jq -r .pem /tmp/github-app-credentials.json | base64 | tr -d '\n'` on their host, paste the single-line output into `assistant credentials prompt --service github-app --field pem_b64`, and decode at use time (`assistant credentials reveal --service github-app --field pem_b64 | base64 -d`). Never paste the PEM into chat, write it to a host file the agent reads, or pass it inline to `assistant credentials set` — those paths leak the key into the transcript.
 
 ### Port 29170 already in use
 

--- a/skills/vellum-github-app-setup/scripts/gh-app-token.mjs
+++ b/skills/vellum-github-app-setup/scripts/gh-app-token.mjs
@@ -20,12 +20,7 @@
 import crypto from "crypto";
 import { execSync } from "child_process";
 
-const ALLOWED_FIELDS = new Set([
-  "app_id",
-  "pem_b64",
-  "pem",
-  "installation_id",
-]);
+const ALLOWED_FIELDS = new Set(["app_id", "pem_b64", "pem", "installation_id"]);
 
 function getCredential(field, { optional = false } = {}) {
   if (!ALLOWED_FIELDS.has(field)) {

--- a/skills/vellum-github-app-setup/scripts/gh-app-token.mjs
+++ b/skills/vellum-github-app-setup/scripts/gh-app-token.mjs
@@ -13,15 +13,21 @@
  *
  * Requires these credentials in the vault (service: github-app):
  *   - app_id
- *   - pem
+ *   - pem_b64 (base64-encoded single-line PEM; a legacy multi-line
+ *     `pem` entry is also accepted)
  *   - installation_id
  */
 import crypto from "crypto";
 import { execSync } from "child_process";
 
-const ALLOWED_FIELDS = new Set(["app_id", "pem", "installation_id"]);
+const ALLOWED_FIELDS = new Set([
+  "app_id",
+  "pem_b64",
+  "pem",
+  "installation_id",
+]);
 
-function getCredential(field) {
+function getCredential(field, { optional = false } = {}) {
   if (!ALLOWED_FIELDS.has(field)) {
     throw new Error(`Invalid credential field: ${field}`);
   }
@@ -30,6 +36,7 @@ function getCredential(field) {
       `assistant credentials reveal --service github-app --field ${field}`,
       {
         timeout: 10_000,
+        stdio: ["ignore", "pipe", "pipe"],
       },
     )
       .toString()
@@ -39,6 +46,9 @@ function getCredential(field) {
     }
     return value;
   } catch (err) {
+    if (optional) {
+      return null;
+    }
     console.error(
       `Failed to read credential github-app:${field}. Is it stored in the vault?`,
     );
@@ -48,7 +58,13 @@ function getCredential(field) {
 }
 
 const appId = getCredential("app_id");
-const pem = getCredential("pem");
+// The private key is stored base64-encoded as `pem_b64` because the secure
+// credential prompt is a single-line input. Fall back to a legacy multi-line
+// `pem` entry when present.
+const pemB64 = getCredential("pem_b64", { optional: true });
+const pem = pemB64
+  ? Buffer.from(pemB64, "base64").toString("utf8")
+  : getCredential("pem");
 const installationId = getCredential("installation_id");
 
 // Generate JWT signed with the app's private key


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for jarvis-1313-cred-chat-leak.md:
- Broker/oauth/ACP/TTS/calls/browser messages and the bundled CLI-retrieval doc now point to `credentials prompt` (broker remediation was a dead end)
- telegram-setup table cell gets `--generated`; security.md documents `blockTokenShapedMessages` + plugin patterns
- github-app PEM flow reworked to single-line base64 via secure prompt with decode-at-use; skills catalog regenerated (repairs stale branch-tip entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)