### PR TITLE
fix(web): give Library the shared identity-section chrome

### DIFF
--- a/clients/web/src/domains/intelligence/components/identity-sections.ts
+++ b/clients/web/src/domains/intelligence/components/identity-sections.ts
@@ -57,8 +57,9 @@ export function buildIdentitySections({
     });
   }
   sections.push(
-    // Library moved off the nav sidebar and onto the overview strip; it
-    // keeps its own top-level page (no About Assistant chrome).
+    // Library moved off the nav sidebar and onto the overview strip; the
+    // list page wears the shared section chrome like its peers, while the
+    // app viewer (/assistant/library/:appId) stays full-bleed.
     {
       key: "library",
       label: "Library",

--- a/clients/web/src/domains/intelligence/components/identity-sections.ts
+++ b/clients/web/src/domains/intelligence/components/identity-sections.ts
@@ -60,9 +60,8 @@ export function buildIdentitySections({
     sections.push(section("memory", "What I remember"));
   }
   sections.push(
-    // Library moved off the nav sidebar and onto the overview strip; the
-    // list page wears the shared section chrome like its peers, while the
-    // app viewer (/assistant/library/:appId) stays full-bleed.
+    // Library's list page wears the shared section chrome like its peers;
+    // the app viewer (/assistant/library/:appId) renders full-bleed.
     section("library", "My apps & docs"),
     section("workspace", "My files"),
     section("contacts", "People I know"),

--- a/clients/web/src/domains/intelligence/components/identity-sections.ts
+++ b/clients/web/src/domains/intelligence/components/identity-sections.ts
@@ -1,11 +1,18 @@
 /**
  * The drill-down sections reachable from the assistant overview page —
- * the replacement for the old About Assistant tab bar. Pure so the
- * capability gating (channels feature flag, memory flag) is
- * unit-testable without rendering the overview.
+ * the replacement for the old About Assistant tab bar. Labels and paths
+ * come from the shared `ABOUT_ASSISTANT_SECTIONS` registry in
+ * `utils/routes.ts`; this module owns only what is overview-specific:
+ * ordering, descriptions, and capability gating. Pure so the gating
+ * (channels feature flag, memory flag) is unit-testable without
+ * rendering the overview.
  */
 
-import { routes } from "@/utils/routes";
+import {
+  aboutAssistantSection,
+  type AboutAssistantSectionKey,
+  routes,
+} from "@/utils/routes";
 
 export interface IdentitySection {
   key: string;
@@ -22,70 +29,46 @@ export interface IdentitySectionGates {
   showMemory: boolean;
 }
 
+/** Registry section + the overview's own description line. */
+function section(
+  key: AboutAssistantSectionKey,
+  description: string,
+): IdentitySection {
+  const { label, to } = aboutAssistantSection(key);
+  return { key, label, description, to };
+}
+
 export function buildIdentitySections({
   showChannels,
   showMemory,
 }: IdentitySectionGates): IdentitySection[] {
   const sections: IdentitySection[] = [
+    // Personality renders bare (full-bleed stage chrome), so it is not a
+    // registry section — the overview links it directly.
     {
       key: "personality",
       label: "Personality",
       description: "Tune how I talk",
       to: routes.personality,
     },
-    {
-      key: "schedules",
-      label: "Schedules",
-      description: "My routines",
-      to: routes.schedules.root,
-    },
+    section("schedules", "My routines"),
     // Skills and plugins combined into one list; on assistants without the
     // plugin surface the page itself degrades to skills-only.
-    {
-      key: "superpowers",
-      label: "My Superpowers",
-      description: "What I can do",
-      to: routes.superpowers,
-    },
+    section("superpowers", "What I can do"),
   ];
   if (showMemory) {
-    sections.push({
-      key: "memory",
-      label: "Memory",
-      description: "What I remember",
-      to: routes.memory,
-    });
+    sections.push(section("memory", "What I remember"));
   }
   sections.push(
     // Library moved off the nav sidebar and onto the overview strip; the
     // list page wears the shared section chrome like its peers, while the
     // app viewer (/assistant/library/:appId) stays full-bleed.
-    {
-      key: "library",
-      label: "Library",
-      description: "My apps & docs",
-      to: routes.library.root,
-    },
-    {
-      key: "workspace",
-      label: "Workspace",
-      description: "My files",
-      to: routes.workspace,
-    },
-    {
-      key: "contacts",
-      label: "Contacts",
-      description: "People I know",
-      to: routes.contacts.root,
-    },
+    section("library", "My apps & docs"),
+    section("workspace", "My files"),
+    section("contacts", "People I know"),
   );
   if (showChannels) {
-    sections.push({
-      key: "channels",
-      label: "Channels",
-      description: "Where I listen",
-      to: routes.channels,
-    });
+    sections.push(section("channels", "Where I listen"));
   }
   return sections;
 }

--- a/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
@@ -91,6 +91,14 @@ describe("IntelligenceLayout — section pages", () => {
     );
   });
 
+  test("the library page renders as a section with the back chevron", () => {
+    const { container } = renderLayoutAt("/assistant/library");
+    expect(container.querySelector("h1")?.textContent).toBe("Library");
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      "/assistant/identity",
+    );
+  });
+
   test("the memory page renders as a section with the back chevron", () => {
     const { container } = renderLayoutAt("/assistant/memory");
     expect(container.querySelector("h1")?.textContent).toBe("Memory");

--- a/clients/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.tsx
@@ -8,41 +8,7 @@ import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-s
 import { PageShell } from "@/components/page-shell";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
-import { routes } from "@/utils/routes";
-
-interface IntelligenceSection {
-  readonly label: string;
-  readonly to: string;
-}
-
-/**
- * The drill-down section pages that get the shared back-button chrome.
- * Sub-paths (e.g. `/assistant/skills/:skillId`) count as inside a section.
- * The legacy skills/plugins paths still carry the per-item detail routes,
- * so they wear the My Superpowers chrome.
- */
-const CHROME_SECTIONS: readonly IntelligenceSection[] = [
-  { label: "Schedules", to: routes.schedules.root },
-  { label: "My Superpowers", to: routes.superpowers },
-  { label: "My Superpowers", to: routes.plugins },
-  { label: "My Superpowers", to: routes.skills.root },
-  { label: "Memory", to: routes.memory },
-  { label: "Workspace", to: routes.workspace },
-  { label: "Contacts", to: routes.contacts.root },
-  { label: "Channels", to: routes.channels },
-  // Only the list page — /assistant/library/:appId (the full-bleed app
-  // viewer) is routed outside this layout, so the prefix match never
-  // reaches it.
-  { label: "Library", to: routes.library.root },
-];
-
-function sectionForPath(pathname: string): IntelligenceSection | null {
-  return (
-    CHROME_SECTIONS.find(
-      ({ to }) => pathname === to || pathname.startsWith(to + "/"),
-    ) ?? null
-  );
-}
+import { aboutAssistantSectionForPath, routes } from "@/utils/routes";
 
 /**
  * Shared layout for the "About Assistant" pages. The overview
@@ -50,7 +16,9 @@ function sectionForPath(pathname: string): IntelligenceSection | null {
  * they own their avatar-tinted stage chrome — while every other section
  * (Schedules, My Superpowers, Memory, Workspace, Contacts, Channels,
  * Library) renders inside the standard page shell with a back button to the
- * overview where the old tab bar used to be.
+ * overview where the old tab bar used to be. The section registry lives in
+ * `utils/routes.ts` (`ABOUT_ASSISTANT_SECTIONS`) — shared with the
+ * sidebar's active-section highlight and the overview strip.
  *
  * Mounted as a pathless layout route in `routes.tsx` so the child routes
  * keep their existing URL paths (`/assistant/identity`, etc.) while
@@ -64,7 +32,7 @@ export function IntelligenceLayout() {
   const isMobile = useIsMobile();
   const setTopBarCenter = useChatLayoutSlotsStore.use.setTopBarCenter();
 
-  const section = sectionForPath(pathname);
+  const section = aboutAssistantSectionForPath(pathname);
   const mobileTitle = section?.label ?? null;
 
   // On mobile the section title moves out of the page body and into the

--- a/clients/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.tsx
@@ -30,6 +30,10 @@ const CHROME_SECTIONS: readonly IntelligenceSection[] = [
   { label: "Workspace", to: routes.workspace },
   { label: "Contacts", to: routes.contacts.root },
   { label: "Channels", to: routes.channels },
+  // Only the list page — /assistant/library/:appId (the full-bleed app
+  // viewer) is routed outside this layout, so the prefix match never
+  // reaches it.
+  { label: "Library", to: routes.library.root },
 ];
 
 function sectionForPath(pathname: string): IntelligenceSection | null {
@@ -44,8 +48,8 @@ function sectionForPath(pathname: string): IntelligenceSection | null {
  * Shared layout for the "About Assistant" pages. The overview
  * (`/assistant/identity`) and the personality page render full-bleed —
  * they own their avatar-tinted stage chrome — while every other section
- * (Schedules, My Superpowers, Memory, Workspace, Contacts, Channels)
- * renders inside the standard page shell with a back button to the
+ * (Schedules, My Superpowers, Memory, Workspace, Contacts, Channels,
+ * Library) renders inside the standard page shell with a back button to the
  * overview where the old tab bar used to be.
  *
  * Mounted as a pathless layout route in `routes.tsx` so the child routes

--- a/clients/web/src/domains/library/library-page.tsx
+++ b/clients/web/src/domains/library/library-page.tsx
@@ -2,7 +2,6 @@ import { useCallback } from "react";
 import { useNavigate } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
-import { PageShell } from "@/components/page-shell";
 import { LibraryView } from "@/domains/library/library-view";
 import { navigateToNewConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
@@ -34,15 +33,14 @@ export function LibraryPage() {
     [navigate],
   );
 
+  // Page shell, heading, and back chrome come from IntelligenceLayout —
+  // this route mounts as one of its sections in routes.tsx.
   return (
-    <PageShell>
-      <LibraryView
-        assistantId={assistantId}
-        title="Library"
-        onNewConversation={handleNewConversation}
-        onOpenDocument={handleOpenDocument}
-        onOpenApp={handleOpenApp}
-      />
-    </PageShell>
+    <LibraryView
+      assistantId={assistantId}
+      onNewConversation={handleNewConversation}
+      onOpenDocument={handleOpenDocument}
+      onOpenApp={handleOpenApp}
+    />
   );
 }

--- a/clients/web/src/domains/library/library-view.tsx
+++ b/clients/web/src/domains/library/library-view.tsx
@@ -30,7 +30,6 @@ import { Button, Input, toast } from "@vellumai/design-library";
 export interface LibraryViewProps {
   assistantId: string;
   assistantName?: string;
-  title?: string;
   onNewConversation?: (initialMessage?: string) => void;
   onOpenDocument?: (documentSurfaceId: string) => void;
   onOpenApp: (appId: string) => void;
@@ -39,7 +38,6 @@ export interface LibraryViewProps {
 export function LibraryView({
   assistantId,
   assistantName,
-  title,
   onNewConversation,
   onOpenDocument,
   onOpenApp,
@@ -172,14 +170,7 @@ export function LibraryView({
   // --- Render: main library grid ---
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <div className="mb-4 flex shrink-0 items-center justify-between gap-4">
-        {title ? (
-          <h1 className="text-title-large text-[var(--content-default)]">
-            {title}
-          </h1>
-        ) : (
-          <span />
-        )}
+      <div className="mb-4 flex shrink-0 items-center justify-end gap-4">
         <div className="flex items-center gap-2">
           <input
             ref={fileInputRef}

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -387,9 +387,11 @@ export const routeTree = [
                     { path: "workspace", lazy: { Component: () => import("@/domains/workspace/workspace-page").then((m) => m.WorkspacePage) } },
                     { path: "contacts", lazy: { Component: () => import("@/contacts-page-route").then((m) => m.ContactsPageRoute) } },
                     { path: "channels", lazy: { Component: () => import("@/channels-page-route").then((m) => m.ChannelsPageRoute) } },
+                    { path: "library", lazy: { Component: () => import("@/domains/library/library-page").then((m) => m.LibraryPage) } },
                   ],
                 },
-                { path: "library", lazy: { Component: () => import("@/domains/library/library-page").then((m) => m.LibraryPage) } },
+                // The app viewer stays outside IntelligenceLayout: it renders
+                // full-bleed and must not inherit the section chrome.
                 { path: "library/:appId", lazy: { Component: () => import("@/domains/library/library-detail-page").then((m) => m.LibraryDetailPage) } },
                 { path: "connect", lazy: { Component: () => import("@/domains/contacts/connect-page").then((m) => m.ConnectPage) } },
                 {

--- a/clients/web/src/utils/routes.test.ts
+++ b/clients/web/src/utils/routes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  ABOUT_ASSISTANT_SECTIONS,
   isAboutAssistantPath,
   isConversationChatPath,
   isConversationPath,
@@ -54,6 +55,14 @@ describe("isAboutAssistantPath", () => {
   test("matches the Library section, including the app viewer sub-path", () => {
     expect(isAboutAssistantPath(routes.library.root)).toBe(true);
     expect(isAboutAssistantPath(routes.library.app("app-1"))).toBe(true);
+  });
+
+  test("every registry section counts as an About Assistant path", () => {
+    // Chrome and sidebar highlight derive from the same registry — this
+    // guards the wiring, so a new section can't get one without the other.
+    for (const { to } of ABOUT_ASSISTANT_SECTIONS) {
+      expect(isAboutAssistantPath(to)).toBe(true);
+    }
   });
 
   test("rejects the Activity page and conversations", () => {

--- a/clients/web/src/utils/routes.test.ts
+++ b/clients/web/src/utils/routes.test.ts
@@ -51,6 +51,11 @@ describe("isAboutAssistantPath", () => {
     expect(isAboutAssistantPath(routes.schedules.detail("sch_123"))).toBe(true);
   });
 
+  test("matches the Library section, including the app viewer sub-path", () => {
+    expect(isAboutAssistantPath(routes.library.root)).toBe(true);
+    expect(isAboutAssistantPath(routes.library.app("app-1"))).toBe(true);
+  });
+
   test("rejects the Activity page and conversations", () => {
     expect(isAboutAssistantPath(routes.home)).toBe(false);
     expect(isAboutAssistantPath(routes.conversation("conv-1"))).toBe(false);

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -235,32 +235,77 @@ export const routes = {
   },
 } as const;
 
+export interface AboutAssistantSection {
+  readonly key: string;
+  readonly label: string;
+  readonly to: string;
+}
+
 /**
- * Path prefixes of the "About Assistant" section — the routes mounted under
- * `IntelligenceLayout`'s tab bar. Sub-paths (e.g. `/assistant/plugins/:name`)
- * count as inside the section.
+ * Single source of truth for the About Assistant drill-down sections —
+ * the pages that wear `IntelligenceLayout`'s shared back-button chrome.
+ * Drives the layout chrome (label lookup via
+ * {@link aboutAssistantSectionForPath}), the sidebar's active-section
+ * highlight ({@link isAboutAssistantPath}), and the overview strip's
+ * labels/links (`buildIdentitySections`), so a section added here gets
+ * all three behaviors at once.
+ *
+ * Sub-paths count as inside a section: the legacy plugins/skills paths
+ * still carry the per-item detail routes (so they wear the My
+ * Superpowers chrome), and `/assistant/library/:appId` — the app viewer,
+ * which renders full-bleed *outside* `IntelligenceLayout` — still counts
+ * as Library territory for the sidebar highlight.
  */
-const ABOUT_ASSISTANT_PATHS: readonly string[] = [
+export const ABOUT_ASSISTANT_SECTIONS = [
+  { key: "schedules", label: "Schedules", to: routes.schedules.root },
+  { key: "superpowers", label: "My Superpowers", to: routes.superpowers },
+  { key: "plugins", label: "My Superpowers", to: routes.plugins },
+  { key: "skills", label: "My Superpowers", to: routes.skills.root },
+  { key: "memory", label: "Memory", to: routes.memory },
+  { key: "library", label: "Library", to: routes.library.root },
+  { key: "workspace", label: "Workspace", to: routes.workspace },
+  { key: "contacts", label: "Contacts", to: routes.contacts.root },
+  { key: "channels", label: "Channels", to: routes.channels },
+] as const satisfies readonly AboutAssistantSection[];
+
+export type AboutAssistantSectionKey =
+  (typeof ABOUT_ASSISTANT_SECTIONS)[number]["key"];
+
+/**
+ * About Assistant pages that render bare — the overview and personality
+ * own their full-bleed stage chrome, so they are not chrome sections.
+ */
+const BARE_ABOUT_ASSISTANT_PATHS: readonly string[] = [
   routes.identity,
   routes.personality,
-  routes.schedules.root,
-  routes.memory,
-  routes.superpowers,
-  routes.plugins,
-  routes.skills.root,
-  routes.workspace,
-  routes.contacts.root,
-  routes.channels,
-  // The prefix match also covers /assistant/library/:appId — the app
-  // viewer renders full-bleed outside IntelligenceLayout, but it is
-  // still Library territory for the sidebar highlight.
-  routes.library.root,
 ];
+
+const isPathWithin = (pathname: string, path: string): boolean =>
+  pathname === path || pathname.startsWith(`${path}/`);
+
+/** The chrome section `pathname` falls inside, if any. */
+export function aboutAssistantSectionForPath(
+  pathname: string,
+): AboutAssistantSection | null {
+  return (
+    ABOUT_ASSISTANT_SECTIONS.find(({ to }) => isPathWithin(pathname, to)) ??
+    null
+  );
+}
+
+/** The registry entry for `key` — label/path lookups for the overview strip. */
+export function aboutAssistantSection(
+  key: AboutAssistantSectionKey,
+): AboutAssistantSection {
+  // The key type is proven against the registry, so find() cannot miss.
+  return ABOUT_ASSISTANT_SECTIONS.find((section) => section.key === key)!;
+}
 
 /** Whether `pathname` falls inside the About Assistant section. */
 export function isAboutAssistantPath(pathname: string): boolean {
-  return ABOUT_ASSISTANT_PATHS.some(
-    (path) => pathname === path || pathname.startsWith(`${path}/`),
+  return (
+    BARE_ABOUT_ASSISTANT_PATHS.some((path) => isPathWithin(pathname, path)) ||
+    aboutAssistantSectionForPath(pathname) !== null
   );
 }
 

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -251,6 +251,10 @@ const ABOUT_ASSISTANT_PATHS: readonly string[] = [
   routes.workspace,
   routes.contacts.root,
   routes.channels,
+  // The prefix match also covers /assistant/library/:appId — the app
+  // viewer renders full-bleed outside IntelligenceLayout, but it is
+  // still Library territory for the sidebar highlight.
+  routes.library.root,
 ];
 
 /** Whether `pathname` falls inside the About Assistant section. */


### PR DESCRIPTION
## Prompt / plan

The Library page was the one identity subpage not using the shared section layout: it rendered as a plain page with its own `<h1>` and no back button, relying on browser history to get back. Plan:

1. Move the `/assistant/library` list route under `IntelligenceLayout` in `routes.tsx`, alongside Schedules / My Superpowers / Memory / Workspace / Contacts / Channels.
2. Add `{ label: "Library", to: routes.library.root }` to `CHROME_SECTIONS` so Library gets the shared back-chevron + header chrome (and the mobile top-bar title for free).
3. Drop `LibraryPage`'s own `PageShell` wrapper and `title` prop — the layout owns that chrome now.
4. Remove the now-unused `title` prop and `<h1>` branch from `LibraryView`; the Import button moves to its own right-aligned row below the shared header, matching how other sections keep actions in the page body.

The app viewer route (`/assistant/library/:appId`) deliberately stays outside the layout so it keeps its full-bleed presentation.

## Test plan

- Added a test to `intelligence-layout.test.tsx` asserting `/assistant/library` renders the "Library" heading with the back chevron to `/assistant/identity` (12/12 pass).
- `bunx tsc --noEmit` clean; `eslint` clean on touched files (0 errors).
- Full `bun run test:ci` pass in progress; six chat-domain test files that failed under a memory-constrained (`--smol`) run all pass when re-run normally (139/139).

## CLI verb checklist

No new IPC routes — section removed per template instructions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7yDF2bqxhYDwETtiM3gtA)_