### PR TITLE
fix: allowed-tools replace semantics in browser-fill message; non-printing PEM decode docs; broker reason helper

### DIFF
--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -2220,13 +2220,13 @@ export async function executeBrowserFillCredential(
         reason.includes("no stored value")
       ) {
         return {
-          content: `No credential stored for ${service}/${field}. Collect it via \`assistant credentials prompt --service ${service} --field ${field} --label <label>\` first.`,
+          content: `No credential stored for ${service}/${field}. Collect it via \`assistant credentials prompt --service ${service} --field ${field} --label <label> --allowed-tools ${BROWSER_FILL_CAPABILITY}\` first (\`--allowed-tools\` sets the credential's full allowed-tools list).`,
           isError: true,
         };
       }
       if (reason.includes("not allowed to use credential")) {
         return {
-          content: `Policy denied: ${reason} If this tool should have access, run \`assistant credentials prompt --service ${service} --field ${field} --label <label> --allowed-tools ${BROWSER_FILL_CAPABILITY}\` (re-collects the value securely and sets allowed_tools).`,
+          content: `Policy denied: ${reason} If this tool should have access, run \`assistant credentials prompt --service ${service} --field ${field} --label <label> --allowed-tools <tools>\` (re-collects the value securely). Note: \`--allowed-tools\` REPLACES the credential's stored list, so pass every tool that should keep access — all currently allowed tools plus ${BROWSER_FILL_CAPABILITY}. See the current list with \`assistant credentials list --search ${service}\`.`,
           isError: true,
         };
       }

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -33,6 +33,22 @@ const TOKEN_TTL_MS = 5 * 60 * 1000;
 const NO_TOOLS_ALLOWED_REMEDIATION =
   "No tools are currently allowed - grant access via `assistant credentials prompt --service <service> --field <field> --label <label> --allowed-tools <tools>` (re-collects the value securely and sets allowed_tools).";
 
+/** Denial reason for a tool that is not in a credential's allowed_tools list. */
+function toolNotAllowedReason(
+  toolName: string,
+  service: string,
+  field: string,
+  allowedTools: string[] | undefined,
+): string {
+  const tools = allowedTools ?? [];
+  return (
+    `Tool "${toolName}" is not allowed to use credential ${service}/${field}. ` +
+    (tools.length === 0
+      ? NO_TOOLS_ALLOWED_REMEDIATION
+      : `Allowed tools: ${tools.join(", ")}.`)
+  );
+}
+
 /**
  * Credential broker that issues single-use tokens for policy-checked credential access.
  *
@@ -78,14 +94,14 @@ export class CredentialBroker {
 
     // Tool policy enforcement - deny if tool is not in the credential's allowed list
     if (!isToolAllowed(request.toolName, metadata.allowedTools)) {
-      const tools = metadata.allowedTools ?? [];
       return {
         authorized: false,
-        reason:
-          `Tool "${request.toolName}" is not allowed to use credential ${request.service}/${request.field}. ` +
-          (tools.length === 0
-            ? NO_TOOLS_ALLOWED_REMEDIATION
-            : `Allowed tools: ${tools.join(", ")}.`),
+        reason: toolNotAllowedReason(
+          request.toolName,
+          request.service,
+          request.field,
+          metadata.allowedTools,
+        ),
       };
     }
 
@@ -188,14 +204,14 @@ export class CredentialBroker {
 
     // Tool policy enforcement - deny if tool is not in the credential's allowed list
     if (!isToolAllowed(request.toolName, metadata.allowedTools)) {
-      const tools = metadata.allowedTools ?? [];
       return {
         success: false,
-        reason:
-          `Tool "${request.toolName}" is not allowed to use credential ${request.service}/${request.field}. ` +
-          (tools.length === 0
-            ? NO_TOOLS_ALLOWED_REMEDIATION
-            : `Allowed tools: ${tools.join(", ")}.`),
+        reason: toolNotAllowedReason(
+          request.toolName,
+          request.service,
+          request.field,
+          metadata.allowedTools,
+        ),
       };
     }
 
@@ -284,14 +300,14 @@ export class CredentialBroker {
     }
 
     if (!isToolAllowed(request.toolName, metadata.allowedTools)) {
-      const tools = metadata.allowedTools ?? [];
       return {
         success: false,
-        reason:
-          `Tool "${request.toolName}" is not allowed to use credential ${request.service}/${request.field}. ` +
-          (tools.length === 0
-            ? NO_TOOLS_ALLOWED_REMEDIATION
-            : `Allowed tools: ${tools.join(", ")}.`),
+        reason: toolNotAllowedReason(
+          request.toolName,
+          request.service,
+          request.field,
+          metadata.allowedTools,
+        ),
       };
     }
 
@@ -367,14 +383,14 @@ export class CredentialBroker {
 
     // Tool policy enforcement
     if (!isToolAllowed(request.requestingTool, metadata.allowedTools)) {
-      const tools = metadata.allowedTools ?? [];
       return {
         success: false,
-        reason:
-          `Tool "${request.requestingTool}" is not allowed to use credential ${metadata.service}/${metadata.field}. ` +
-          (tools.length === 0
-            ? NO_TOOLS_ALLOWED_REMEDIATION
-            : `Allowed tools: ${tools.join(", ")}.`),
+        reason: toolNotAllowedReason(
+          request.requestingTool,
+          metadata.service,
+          metadata.field,
+          metadata.allowedTools,
+        ),
       };
     }
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1026,7 +1026,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants. Requires Python 3, bun, and the assistant credentials CLI.",
-      "updatedAt": "2026-07-22T17:55:24.000Z"
+      "updatedAt": "2026-07-22T18:11:44.000Z"
     },
     {
       "id": "vellum-heartbeat",

--- a/skills/vellum-github-app-setup/SKILL.md
+++ b/skills/vellum-github-app-setup/SKILL.md
@@ -86,7 +86,7 @@ assistant credentials prompt --service github-app --field webhook_secret \
   --description "Copy the webhook_secret value from the credentials JSON"
 ```
 
-For the PEM (private key), the secure prompt input is single-line — pasting a multi-line key strips its newlines and the mangled key fails JWT signing. Have the user base64-encode the key to a single line on their host and paste **that** into the secure prompt. It is stored as field `pem_b64`; everything that signs JWTs decodes it at use time (`assistant credentials reveal --service github-app --field pem_b64 | base64 -d`). Print the single-line value for copying:
+For the PEM (private key), the secure prompt input is single-line — pasting a multi-line key strips its newlines and the mangled key fails JWT signing. Have the user base64-encode the key to a single line on their host and paste **that** into the secure prompt. It is stored as field `pem_b64`; `scripts/gh-app-token.mjs` (copied into the workspace in Step 4) is the sole decode site — it reveals and base64-decodes the key internally at JWT-signing time, so the plaintext PEM never appears anywhere. If a step genuinely needs the decoded key in a shell, capture it in a variable — `PEM="$(assistant credentials reveal --service github-app --field pem_b64 | base64 -d)"` — and **never run the reveal|decode pipeline bare: it prints the private key into the transcript**, evading every redaction layer. Print the single-line value for copying:
 
 ```bash
 jq -r .pem /tmp/github-app-credentials.json | base64 | tr -d '\n'
@@ -242,7 +242,7 @@ The installation token may have expired (1-hour lifetime). Regenerate with `bun 
 
 ### PEM won't store or fails JWT signing
 
-The secure prompt input is single-line, so a raw multi-line PEM cannot be pasted into it — newlines are stripped and the mangled key fails JWT signing. Store the key base64-encoded as `pem_b64` instead: have the user re-run `jq -r .pem /tmp/github-app-credentials.json | base64 | tr -d '\n'` on their host, paste the single-line output into `assistant credentials prompt --service github-app --field pem_b64`, and decode at use time (`assistant credentials reveal --service github-app --field pem_b64 | base64 -d`). Never paste the PEM into chat, write it to a host file the agent reads, or pass it inline to `assistant credentials set` — those paths leak the key into the transcript.
+The secure prompt input is single-line, so a raw multi-line PEM cannot be pasted into it — newlines are stripped and the mangled key fails JWT signing. Re-store the key base64-encoded as `pem_b64` using the procedure in Step 2. Never paste the PEM into chat, write it to a host file the agent reads, pass it inline to `assistant credentials set`, or run the reveal|decode pipeline bare — those paths leak the key into the transcript.
 
 ### Port 29170 already in use
 


### PR DESCRIPTION
## Summary
Round-2 review fixes for jarvis-1313-cred-chat-leak.md:
- Browser-fill denial message now states `--allowed-tools` replaces the list and must include existing grants
- github-app PEM decode documented only in non-printing forms with an explicit warning; Step 2/troubleshooting duplication collapsed; catalog regenerated
- Broker denial-reason construction extracted to a shared helper