### PR TITLE
feat(billing): collapse plan-card label to Free / named package / Custom

### DIFF
--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -392,6 +392,19 @@ describe("PlanCard", () => {
     expect(html).toContain("Custom");
     expect(html).not.toContain("Mighty (Custom)");
   });
+
+  test("current-plan row labels an unpinned Pro sub as custom", () => {
+    // A legacy Pro sub with no pinned package reads "Custom", not the generic
+    // plan name "Pro".
+    const subscription: SubscriptionResponse = {
+      ...proMightySubscription(),
+      package: null,
+    };
+    const html = renderCard(subscription, plansWithSuper());
+    expect(html).toContain("plan-card-name");
+    expect(html).toContain("Custom");
+    expect(html).not.toContain("Pro");
+  });
 });
 
 describe("PlanCard action button", () => {

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -425,14 +425,16 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
     }
 
     const display = PLAN_DISPLAY[currentPlan.id] ?? DEFAULT_DISPLAY;
-    // Show the pinned package name (e.g. "Mighty"), or just "Custom" when the
-    // subscription is customized: its tiers differ from that stock package, so
-    // it isn't labeled as one.
-    const planName = subscription.package
-        ? subscription.package.customized
-            ? "Custom"
-            : subscription.package.name
-        : (currentPlan.name ?? currentPlan.id);
+    // A Pro sub shows the stock package name only for a clean (non-customized)
+    // pin (e.g. "Mighty"). Every other Pro state — an unpinned sub
+    // (`package == null`) or a customized pin whose tiers differ from the stock
+    // package — reads just "Custom". Non-Pro plans show their plan name.
+    const planName =
+        currentPlan.id === "pro"
+            ? subscription.package && !subscription.package.customized
+                ? subscription.package.name
+                : "Custom"
+            : (currentPlan.name ?? currentPlan.id);
 
     const isCancelling =
         display.showsRenewal &&


### PR DESCRIPTION
## Summary
- Unpinned (legacy `package: null`) Pro subs now render "Custom" instead of the generic plan name, completing the Free / named / Custom three-state collapse.
- Test coverage for the unpinned→Custom case.

Part of plan: custom-plan-classification.md (PR 1 of 3)