### PR TITLE
feat(billing): one-click package switch for custom/unpinned Pro subs with neutral confirm copy

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
@@ -8,8 +8,12 @@ import { Typography } from "@vellumai/design-library/components/typography";
 
 export interface PackageSwitchConfirmModalProps {
   open: boolean;
-  /** How the target relates to the current tier — drives copy and chrome. */
-  relation: Exclude<TierRelation, "current">;
+  /**
+   * How the target relates to the current tier — drives copy and chrome.
+   * "switch" is the direction-neutral variant for a Custom sub, whose catalog
+   * rank is unknown, so up-vs-down cannot be labelled.
+   */
+  relation: Exclude<TierRelation, "current"> | "switch";
   /** Target package display name, e.g. "Mighty". */
   packageName: string;
   /** A change-package call is in flight — disable the actions. */
@@ -25,11 +29,16 @@ export interface PackageSwitchConfirmModalProps {
 const DOWNGRADE_NOTE =
   "Your machine downsizes now and your storage stays. No refund — a prorated credit applies to your next invoice.";
 const UPGRADE_NOTE = "You'll be charged the prorated difference now.";
+// A Custom sub's direction is unknown, so the copy stays neutral: the change is
+// immediate and the prorated difference settles either way.
+const SWITCH_NOTE =
+  "Your plan changes now. Any prorated difference is charged now or credited to your next invoice.";
 
 /**
  * Reconfirm dialog for a one-click Pro package switch from the plans takeover.
- * A downgrade gets the AlertTriangle + danger confirm; an upgrade gets a
- * lighter primary confirm. Layout-only — the parent owns the mutation.
+ * A downgrade gets the AlertTriangle + danger confirm; an upgrade and a
+ * direction-neutral switch get a lighter primary confirm. Layout-only — the
+ * parent owns the mutation.
  */
 export function PackageSwitchConfirmModal({
   open,
@@ -40,6 +49,17 @@ export function PackageSwitchConfirmModal({
   onConfirm,
 }: PackageSwitchConfirmModalProps) {
   const isDowngrade = relation === "downgrade";
+  const isSwitch = relation === "switch";
+  const title = isDowngrade
+    ? `Downgrade to ${packageName}?`
+    : isSwitch
+      ? `Switch to ${packageName}?`
+      : `Upgrade to ${packageName}?`;
+  const note = isDowngrade
+    ? DOWNGRADE_NOTE
+    : isSwitch
+      ? SWITCH_NOTE
+      : UPGRADE_NOTE;
   return (
     <Modal.Root
       open={open}
@@ -52,9 +72,7 @@ export function PackageSwitchConfirmModal({
       <Modal.Content size="md" hideCloseButton>
         <Modal.Header>
           <Modal.Title icon={isDowngrade ? AlertTriangle : undefined}>
-            {isDowngrade
-              ? `Downgrade to ${packageName}?`
-              : `Upgrade to ${packageName}?`}
+            {title}
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
@@ -63,7 +81,7 @@ export function PackageSwitchConfirmModal({
             variant="body-medium-default"
             className="text-(--content-secondary)"
           >
-            {isDowngrade ? DOWNGRADE_NOTE : UPGRADE_NOTE}
+            {note}
           </Typography>
         </Modal.Body>
         <Modal.Footer>

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -645,20 +645,12 @@ describe("PlansPage — Pro package switch (change-package)", () => {
   });
 });
 
-// A Pro sub that isn't cleanly packaged (customized, cancelling, or in a
-// non-entitlement status) can't switch in place — the change-package endpoint
-// would 4xx. Clicking a package CTA must route it to the billing manage/cancel
-// surface (`?adjust_plan`) instead of posting change-package, matching the
-// plan-card banner's fallback.
+// A cancelling or non-entitlement-status Pro sub can't switch in place — the
+// change-package endpoint would 4xx. Clicking a package CTA must route it to the
+// billing manage/cancel surface (`?adjust_plan`) instead of posting
+// change-package, matching the plan-card banner's fallback.
 describe("PlansPage — ineligible Pro subs route to manage", () => {
   const ineligible: Array<[string, SubscriptionResponse]> = [
-    [
-      "customized",
-      {
-        ...proMightySubscription(),
-        package: { key: "mighty", name: "Mighty", version: 1, customized: true },
-      },
-    ],
     ["cancelling", { ...proMightySubscription(), cancel_at_period_end: true }],
     ["non-entitlement status", { ...proMightySubscription(), status: "unpaid" }],
   ];
@@ -680,6 +672,84 @@ describe("PlansPage — ineligible Pro subs route to manage", () => {
       expect(upgradeCall).toBeNull();
     });
   }
+});
+
+// A Custom sub — one with no package pin, or a customized (diverged) pin — has
+// no catalog rank. Every named card is a switch target: the confirm dialog uses
+// direction-neutral copy, and a successful switch opens the provisioning
+// takeover. A customized sub can even re-pin its own key (revert to stock).
+describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
+  function proUnpinnedSubscription(): SubscriptionResponse {
+    return {
+      plan_id: "pro",
+      status: "active",
+      renewal_date: null,
+      current_period_end: "2026-07-10T00:00:00Z",
+      cancel_at_period_end: false,
+      cancel_at: null,
+      package: null,
+      entitlements: { managed_email: false, phone_number: false },
+    };
+  }
+
+  function proCustomizedMightySubscription(): SubscriptionResponse {
+    return {
+      ...proMightySubscription(),
+      package: { key: "mighty", name: "Mighty", version: 1, customized: true },
+    };
+  }
+
+  test("an unpinned Pro sub's card opens the neutral 'Switch to' confirm and posts change-package", async () => {
+    const { findByRole, findByText, findByTestId } = renderInteractive(
+      proUnpinnedSubscription(),
+    );
+
+    // With no pin the card carries its plain upgrade CTA ("Power Up" for Mighty).
+    fireEvent.click(await findByRole("button", { name: "Power Up" }));
+
+    // The direction-neutral switch confirm appears (not upgrade/downgrade copy).
+    await findByText("Switch to Mighty?");
+    await findByText(
+      "Your plan changes now. Any prorated difference is charged now or credited to your next invoice.",
+    );
+
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+
+    await waitFor(() => expect(changePackageCall).not.toBeNull());
+    expect(changePackageCall!.body).toEqual({ package: "mighty" });
+    await findByTestId("resize-takeover");
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("a customized-pinned sub can re-select its own package (revert to stock), no 'current' short-circuit", async () => {
+    const { findByRole, findByText, findByTestId } = renderInteractive(
+      proCustomizedMightySubscription(),
+    );
+
+    // The customized sub's own Mighty card is not "current" — its CTA is live.
+    fireEvent.click(await findByRole("button", { name: "Power Up" }));
+
+    await findByText("Switch to Mighty?");
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+
+    await waitFor(() => expect(changePackageCall).not.toBeNull());
+    expect(changePackageCall!.body).toEqual({ package: "mighty" });
+  });
+
+  test("a Custom sub's Free card is a downgrade and no named card renders as current", () => {
+    const html = renderStatic(
+      {
+        ...proMightySubscription(),
+        package: { key: "mighty", name: "Mighty", version: 1, customized: true },
+      },
+      fullCatalog(),
+    );
+    // Pro → Free is always a downgrade.
+    expect(html).toContain("Downgrade to Free");
+    expect(html).not.toContain("Start Free");
+    // A Custom sub has no catalog rank, so no card is the current plan.
+    expect(count(html, /Current Plan/g)).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -7,6 +7,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   PACKAGE_ORDER,
   type ProPackage,
+  type TierRelation,
   tierRelation,
 } from "@/domains/settings/billing/package-types";
 import { FREE_STORAGE_GIB } from "@/domains/settings/billing/plan-tier-meta";
@@ -269,10 +270,16 @@ export function PlansPage() {
 
   let body: ReactNode;
   if (subscription && proPlan && hasPackages) {
+    // A Custom sub (unpinned or customized) has no meaningful catalog rank, so
+    // it has no current tier: every named card is offered as a switch target —
+    // including a customized sub's own pinned key, which is a real
+    // revert-to-stock operation.
     const currentTierKey =
       subscription.plan_id === "base"
         ? "free"
-        : (subscription.package?.key ?? null);
+        : subscription.package && !subscription.package.customized
+          ? subscription.package.key
+          : null;
 
     const selectTier = (tierKey: string) => {
       if (isProUser) {
@@ -293,10 +300,11 @@ export function PlansPage() {
         if (tierRelation(currentTierKey, pkg.key) === "current") {
           return;
         }
-        // Only a clean packaged Pro sub can switch in place. A customized,
-        // cancelling, or non-entitlement-status sub can't — route it to the
-        // billing manage/cancel surface instead of posting a change-package that
-        // can only fail (the same fallback the Pro → Free case uses).
+        // Any active Pro sub — pinned, unpinned, or customized — switches in
+        // place via change-package. Only a cancelling or non-entitlement-status
+        // sub can't; route it to the billing manage/cancel surface instead of
+        // posting a change-package that can only fail (the same fallback the
+        // Pro → Free case uses).
         if (!isPackageSwitchEligible(subscription)) {
           navigate(`${routes.settings.usage}?tab=billing&adjust_plan`);
           return;
@@ -337,6 +345,9 @@ export function PlansPage() {
       // status === "ok": only an upgrade grows the machine, so only it needs
       // the resize/provisioning takeover. A downgrade caps the machine down
       // immediately server-side with no apply/restart step, so just confirm it.
+      // A Custom-sub switch has unknown direction, so it lands here as "upgrade"
+      // and opens the takeover — the provisioning step is grow-only/idempotent
+      // server-side, so it is the safe default when direction is unknown.
       if (relation === "downgrade") {
         toast.success(`Downgraded to ${target.name}.`);
       } else {
@@ -344,9 +355,17 @@ export function PlansPage() {
       }
     };
 
-    const switchRelation = switchTarget
-      ? tierRelation(currentTierKey, switchTarget.key)
-      : "upgrade";
+    // A Custom sub (currentTierKey null) can't be ranked against the target, so
+    // the confirm copy stays direction-neutral ("switch"); a clean-pinned sub
+    // gets the directional up/down copy.
+    const switchRelation: Exclude<TierRelation, "current"> | "switch" =
+      switchTarget
+        ? currentTierKey === null
+          ? "switch"
+          : tierRelation(currentTierKey, switchTarget.key) === "downgrade"
+            ? "downgrade"
+            : "upgrade"
+        : "upgrade";
 
     const startCustomCheckout = (selection: CustomPlanSelection) =>
       startCheckout({
@@ -405,7 +424,12 @@ export function PlansPage() {
         PACKAGE_ORDER.indexOf(b.key as (typeof PACKAGE_ORDER)[number]),
     );
     const freeCopy = getPlanTierCopy("free");
-    const freeRelation = tierRelation(currentTierKey, "free");
+    // Pro → Free is always a downgrade (cancellation), even for a Custom sub
+    // whose currentTierKey is null; `selectTier("free")` cancel routing is
+    // unchanged.
+    const freeRelation = isProUser
+      ? "downgrade"
+      : tierRelation(currentTierKey, "free");
 
     body = (
       <div className="my-auto flex w-full flex-col items-center">
@@ -501,7 +525,7 @@ export function PlansPage() {
 
         <PackageSwitchConfirmModal
           open={switchTarget !== null}
-          relation={switchRelation === "downgrade" ? "downgrade" : "upgrade"}
+          relation={switchRelation}
           packageName={switchTarget?.name ?? ""}
           pending={changePackagePending}
           onCancel={() => setSwitchTarget(null)}

--- a/clients/web/src/domains/settings/components/adjust-plan-utils.ts
+++ b/clients/web/src/domains/settings/components/adjust-plan-utils.ts
@@ -21,12 +21,17 @@ export const TIER_CHANGE_ELIGIBLE_STATUSES: ReadonlySet<SubscriptionStatusEnum> 
 
 /**
  * Whether a subscription is eligible for a one-click, in-place package switch
- * via the change-package endpoint. True only for a clean packaged Pro sub: it
- * has a package pin, is not customized (a customized sub's tiers can diverge
- * from the stock package, so posting the next stock key would use wrong deltas
- * / drop custom line items), is not cancelling (a cancelling sub 409s on
- * change-package), and sits in an entitlement-bearing status. Every other Pro
- * state — and every base sub — falls back to the manage path.
+ * via the change-package endpoint. True for any active Pro sub — pinned,
+ * unpinned, or customized. The platform's `change_package` action re-pins the
+ * sub to a named plan by 3-way-diffing the current Stripe line items per
+ * dimension, so posting a stock key from a diverged sub is safe: it is exactly
+ * the "override back to a named plan" flow. A true pre-catalog legacy sub (no
+ * tier metadata) returns a clean 409 whose `detail` surfaces as a toast via
+ * `useChangePackage` → `extractMutationError` (which reads the `detail` key).
+ *
+ * A cancelling sub (change-package 409s) and a non-entitlement status still gate
+ * out, as does every base sub. Every other Pro state falls back to the manage
+ * path.
  *
  * Shared by both change-package surfaces (plan-card banner, plans takeover) so
  * the eligibility gate stays symmetric across them.
@@ -36,8 +41,6 @@ export function isPackageSwitchEligible(
 ): boolean {
   return (
     subscription.plan_id !== "base" &&
-    subscription.package != null &&
-    !subscription.package.customized &&
     subscription.cancel_at_period_end !== true &&
     !subscription.cancel_at &&
     subscription.status != null &&

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -462,10 +462,14 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
         packages.length > 0 &&
         (currentPlan.id === "base" ||
             (subscription.package != null && !subscription.package.customized));
-    // A one-click, in-place package switch is safe only for a clean packaged Pro
-    // sub; every other Pro state (customized, cancelling, or a non-entitlement
-    // status) and every base sub falls back to the manage path.
-    const canChangePackage = isPackageSwitchEligible(subscription);
+    // The banner's one-click switch targets a clean packaged Pro sub. It layers
+    // the pinned-and-not-customized requirement on top of the shared eligibility
+    // gate, so a customized or unpinned Pro sub falls back to the manage path
+    // here even though the plans takeover offers it a direction-neutral switch.
+    const canChangePackage =
+        isPackageSwitchEligible(subscription) &&
+        subscription.package != null &&
+        !subscription.package.customized;
 
     return (
         <Card padding="md">


### PR DESCRIPTION
## Summary
- Loosen `isPackageSwitchEligible` so unpinned/customized active Pro subs can use the one-click change-package flow.
- Add a direction-neutral "switch" confirm variant and treat Custom subs as having no current tier so every named card is an actionable switch target.

Part of plan: custom-plan-classification.md (PR 2 of 3)