### PR TITLE
fix(assistant): stop persisting ephemeral btw conversations to the sidebar

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -463,10 +463,18 @@ describe("POST /v1/btw", () => {
     await readStream(result as ReadableStream<Uint8Array>);
 
     expect(mockGetConversationByKey).toHaveBeenCalledWith("greeting-abc123");
-    expect(mockGetOrCreateConversation).toHaveBeenCalledWith("greeting-abc123");
+    // An unmapped key has no real conversation, so the side-chain runs against
+    // an ephemeral in-memory conversation with no persisted (sidebar-visible)
+    // row.
+    expect(mockGetOrCreateConversation).toHaveBeenCalledWith(
+      "greeting-abc123",
+      {
+        ephemeral: true,
+      },
+    );
   });
 
-  test("known conversationKey resolves to existing conversation ID", async () => {
+  test("known conversationKey resolves to existing conversation ID without the ephemeral flag", async () => {
     mockGetConversationByKey.mockReturnValueOnce({
       conversationId: "existing-conv-id",
     });
@@ -479,8 +487,11 @@ describe("POST /v1/btw", () => {
     });
     await readStream(result as ReadableStream<Uint8Array>);
 
+    // A mapped key targets a real conversation, so its persisted row is reused
+    // — no ephemeral options.
     expect(mockGetOrCreateConversation).toHaveBeenCalledWith(
       "existing-conv-id",
+      undefined,
     );
   });
 });

--- a/assistant/src/__tests__/conversation-store-ephemeral.test.ts
+++ b/assistant/src/__tests__/conversation-store-ephemeral.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Regression: an ephemeral `getOrCreateConversation` call (the empty-state
+ * greeting side-chain via POST /v1/btw) must NOT persist a `conversations`
+ * row. A persisted row surfaces as an "Untitled" conversation with the literal
+ * id "greeting" in every client's sidebar. A normal (non-ephemeral) call still
+ * creates the row so real conversations remain sidebar-visible.
+ *
+ * The DB layer is mocked so the assertion targets exactly the row-creation
+ * decision inside `getOrCreateConversation` (`createConversation` /
+ * `ensureConversationExists`) rather than the surrounding provider wiring.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { Message } from "../providers/types.js";
+import { setConfig } from "./helpers/set-config.js";
+
+const mockProviderStub = { name: "mock-provider" };
+mock.module("../providers/registry.js", () => ({
+  getProvider: () => mockProviderStub,
+  initializeProviders: async () => {},
+  listProviders: () => ["anthropic", "openai", "gemini"],
+  resolveProviderFromConnection: async () => mockProviderStub,
+}));
+
+mock.module("../providers/inference/connections.js", () => ({
+  getConnection: (_db: unknown, name: string) => ({
+    id: 1,
+    name,
+    provider: "anthropic",
+    auth_strategy: "user_managed_credential",
+    credential_alias: null,
+    metadata_json: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }),
+}));
+
+setConfig("llm", {
+  callSites: {
+    mainAgent: {
+      provider: "anthropic",
+      provider_connection: "anthropic-conn",
+      model: "claude-opus-4-6",
+    },
+  },
+});
+setConfig("memory", { enabled: false, v2: { enabled: false } });
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => "system prompt",
+}));
+
+mock.module("../prompts/persona-resolver.js", () => ({
+  resolvePersonaContext: () => ({
+    userPersona: undefined,
+    channelPersona: undefined,
+    userSlug: undefined,
+  }),
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  clearCache: () => {},
+}));
+
+mock.module("../security/secret-allowlist.js", () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module("../workspace/turn-commit.js", () => ({
+  commitTurnChanges: async () => {},
+}));
+
+mock.module("../workspace/git-service.js", () => ({
+  getWorkspaceGitService: () => ({
+    ensureInitialized: async () => {},
+    commitIfDirty: async () => ({ committed: false }),
+  }),
+}));
+
+// The row-creation spies. `getConversation` returns null so the conversation
+// reads as brand-new — the branch that would create a row.
+const mockCreateConversation = mock((_opts?: unknown) => ({ id: "conv-x" }));
+const mockEnsureConversationExists = mock((_id: string) => true);
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  ADOPTABLE_CONVERSATION_ID_RE: /^[A-Za-z0-9_-]{1,128}$/,
+  createConversation: mockCreateConversation,
+  ensureConversationExists: mockEnsureConversationExists,
+  getConversation: () => null,
+  getMessages: () => [],
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+}));
+
+mock.module("../persistence/conversation-queries.js", () => ({
+  listConversations: () => [],
+}));
+
+mock.module("../memory/retriever.js", () => ({
+  buildMemoryRecall: async () => ({
+    enabled: false,
+    degraded: false,
+    injectedText: "",
+    semanticHits: 0,
+    injectedTokens: 0,
+    latencyMs: 0,
+  }),
+  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
+}));
+
+mock.module("../agent/loop.js", () => ({
+  AgentLoop: class {
+    constructor() {}
+    getToolTokenBudget() {
+      return 0;
+    }
+    getResolvedTools() {
+      return [];
+    }
+    async run(options: { messages: Message[] }): Promise<Message[]> {
+      return [
+        ...options.messages,
+        { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      ];
+    }
+  },
+}));
+
+mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
+  ContextWindowManager: class {
+    estimateInputTokens() {
+      return 0;
+    }
+    get tokenCountInputs() {
+      return { systemPrompt: "", tools: undefined };
+    }
+    constructor() {}
+    updateConfig() {}
+    shouldCompact() {
+      return { needed: false, estimatedTokens: 0 };
+    }
+    async maybeCompact() {
+      return { compacted: false };
+    }
+    resetOverflowRecovery() {}
+  },
+  createContextSummaryMessage: () => ({
+    role: "user",
+    content: [{ type: "text", text: "summary" }],
+  }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+import {
+  clearAllActiveConversations,
+  getOrCreateConversation,
+} from "../daemon/conversation-store.js";
+
+describe("getOrCreateConversation ephemeral flag", () => {
+  test("ephemeral call does not persist a conversations row", async () => {
+    clearAllActiveConversations();
+    mockCreateConversation.mockClear();
+    mockEnsureConversationExists.mockClear();
+
+    await getOrCreateConversation("greeting", { ephemeral: true });
+
+    expect(mockEnsureConversationExists).not.toHaveBeenCalled();
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+  });
+
+  test("non-ephemeral call persists a conversations row", async () => {
+    clearAllActiveConversations();
+    mockCreateConversation.mockClear();
+    mockEnsureConversationExists.mockClear();
+
+    await getOrCreateConversation("real-conversation-id");
+
+    expect(mockEnsureConversationExists).toHaveBeenCalledWith(
+      "real-conversation-id",
+    );
+  });
+});

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -101,7 +101,14 @@ export async function getOrCreateConversation(
   let conversation = findConversation(conversationId);
   const sendToClient = () => {};
 
-  const { taskRunId: _taskRunId, ...persistentOptions } = options ?? {};
+  // `taskRunId` and `ephemeral` are per-call scopes, not durable conversation
+  // metadata, so they are stripped before the remaining options are merged
+  // into the persisted `conversationOptions` map.
+  const {
+    taskRunId: _taskRunId,
+    ephemeral,
+    ...persistentOptions
+  } = options ?? {};
   if (Object.values(persistentOptions).some((v) => v !== undefined)) {
     mergeConversationOptions(conversationId, persistentOptions);
   }
@@ -176,7 +183,12 @@ export async function getOrCreateConversation(
       // pattern as `ensureConversationExists` to prevent path traversal.
       // Otherwise use `ensureConversationExists` directly, which validates
       // and creates a standard row.
-      if (!getConversation(conversationId)) {
+      //
+      // Ephemeral calls skip row creation entirely: their contract persists
+      // nothing, so the in-memory Conversation hydrates from whatever rows
+      // already exist without leaking a sidebar-visible row. `loadFromDb`
+      // tolerates a missing row.
+      if (!ephemeral && !getConversation(conversationId)) {
         if (storedOptions?.conversationType) {
           if (!ADOPTABLE_CONVERSATION_ID_RE.test(conversationId)) {
             throw new Error(

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -147,6 +147,14 @@ export interface ConversationCreateOptions {
    * task permissions do not leak into later turns on a reused conversation.
    */
   taskRunId?: string;
+  /**
+   * Skip persisting a `conversations` row for this call. The in-memory
+   * {@link Conversation} is still built and hydrated from whatever rows
+   * already exist, but no sidebar-visible row is created — used by ephemeral
+   * side-chains (e.g. the empty-state greeting) whose contract persists
+   * nothing. Per-call only: never merged into stored conversation metadata.
+   */
+  ephemeral?: boolean;
   /** Normalized auth context for the conversation. */
   authContext?: AuthContext;
   /** Whether this turn can block on interactive approval prompts. */
@@ -704,7 +712,9 @@ export function renderHistoryContent(
               continue;
             }
             const resolved = resolveMediaSourceData(source);
-            if (resolved) {imageDataList.push(resolved.data);}
+            if (resolved) {
+              imageDataList.push(resolved.data);
+            }
           }
         }
       }

--- a/assistant/src/persistence/migrations/347-delete-stray-greeting-conversation.ts
+++ b/assistant/src/persistence/migrations/347-delete-stray-greeting-conversation.ts
@@ -1,0 +1,46 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * The web empty-state greeting posts to `/v1/btw` with `conversationKey`
+ * "greeting". That side-chain is ephemeral and persists nothing, so its id is
+ * a literal string rather than a minted uuid.
+ */
+const STRAY_GREETING_CONVERSATION_ID = "greeting";
+
+/**
+ * Delete the stray `greeting` conversations row when it carries no messages.
+ *
+ * A message-less row with this id is an artifact of the ephemeral empty-state
+ * greeting side-chain and renders as an "Untitled" conversation in every
+ * client's sidebar. A row carrying messages means the user opened it and
+ * chatted, so it is user data and is left untouched.
+ *
+ * The ephemeral greeting path persists no messages, tool invocations, request
+ * logs, or telemetry, so the conversations row is the only artifact to remove.
+ * `tool_invocations` is cleared defensively — it is the sole conversation-
+ * scoped table a message-less conversation delete touches on the main
+ * database, and clearing it keeps the migration self-contained if some other
+ * path ever attached one.
+ *
+ * Idempotent: once the row is gone (or when the user has chatted in it) a
+ * re-run matches nothing and no-ops.
+ */
+export function migrateDeleteStrayGreetingConversation(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  const hasMessages = raw
+    .query(/*sql*/ `SELECT 1 FROM messages WHERE conversation_id = ? LIMIT 1`)
+    .get(STRAY_GREETING_CONVERSATION_ID);
+  if (hasMessages) {
+    return;
+  }
+
+  raw
+    .query(/*sql*/ `DELETE FROM tool_invocations WHERE conversation_id = ?`)
+    .run(STRAY_GREETING_CONVERSATION_ID);
+  raw
+    .query(/*sql*/ `DELETE FROM conversations WHERE id = ?`)
+    .run(STRAY_GREETING_CONVERSATION_ID);
+}

--- a/assistant/src/persistence/migrations/__tests__/347-delete-stray-greeting-conversation.test.ts
+++ b/assistant/src/persistence/migrations/__tests__/347-delete-stray-greeting-conversation.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for migration 347 — deleting the leaked ephemeral `greeting`
+ * conversations row from the sidebar.
+ *
+ * A message-less `greeting` row is an ephemeral empty-state greeting persisted
+ * by mistake and is removed; a `greeting` row carrying messages means the user
+ * chatted in it and is preserved as user data. Unrelated conversations are
+ * never touched, and the migration is idempotent.
+ */
+import { describe, expect, test } from "bun:test";
+
+const { getDb, getSqlite } = await import("../../db-connection.js");
+const { initializeDb } = await import("../../db-init.js");
+const { migrateDeleteStrayGreetingConversation } =
+  await import("../347-delete-stray-greeting-conversation.js");
+
+await initializeDb();
+
+function reset(): void {
+  const db = getSqlite();
+  db.query(`DELETE FROM messages`).run();
+  db.query(`DELETE FROM conversations`).run();
+}
+
+function insertConversation(id: string): void {
+  getSqlite()
+    .query(
+      `INSERT OR IGNORE INTO conversations (id, created_at, updated_at) VALUES (?, ?, ?)`,
+    )
+    .run(id, Date.now(), Date.now());
+}
+
+let seq = 0;
+function insertMessage(conversationId: string): void {
+  getSqlite()
+    .query(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(`m347-${seq++}`, conversationId, "user", "hello", Date.now());
+}
+
+function conversationExists(id: string): boolean {
+  return (
+    getSqlite()
+      .query(`SELECT 1 AS present FROM conversations WHERE id = ?`)
+      .get(id) != null
+  );
+}
+
+describe("migration 347 — delete stray greeting conversation", () => {
+  test("deletes an empty greeting row", () => {
+    reset();
+    insertConversation("greeting");
+
+    migrateDeleteStrayGreetingConversation(getDb());
+
+    expect(conversationExists("greeting")).toBe(false);
+  });
+
+  test("preserves a greeting row that carries messages", () => {
+    reset();
+    insertConversation("greeting");
+    insertMessage("greeting");
+
+    migrateDeleteStrayGreetingConversation(getDb());
+
+    expect(conversationExists("greeting")).toBe(true);
+  });
+
+  test("never touches unrelated conversations", () => {
+    reset();
+    insertConversation("greeting");
+    insertConversation("real-conversation");
+
+    migrateDeleteStrayGreetingConversation(getDb());
+
+    expect(conversationExists("greeting")).toBe(false);
+    expect(conversationExists("real-conversation")).toBe(true);
+  });
+
+  test("is idempotent across repeated runs", () => {
+    reset();
+    insertConversation("greeting");
+
+    migrateDeleteStrayGreetingConversation(getDb());
+    // A second run finds no matching row and must not throw.
+    migrateDeleteStrayGreetingConversation(getDb());
+
+    expect(conversationExists("greeting")).toBe(false);
+  });
+
+  test("no-ops cleanly when there is no greeting row at all", () => {
+    reset();
+    insertConversation("real-conversation");
+
+    migrateDeleteStrayGreetingConversation(getDb());
+
+    expect(conversationExists("real-conversation")).toBe(true);
+  });
+});

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -454,6 +454,7 @@ import { migrateMoveActivationStateToMemoryDb } from "./migrations/343-move-acti
 import { migrateMoveConversationGraphMemoryStateToMemoryDb } from "./migrations/344-move-conversation-graph-memory-state-to-memory-db.js";
 import { migrateMoveMemoryV3EverInjectedToMemoryDb } from "./migrations/345-move-memory-v3-ever-injected-to-memory-db.js";
 import { migrateMoveMemoryRetrospectiveStateToMemoryDb } from "./migrations/346-move-memory-retrospective-state-to-memory-db.js";
+import { migrateDeleteStrayGreetingConversation } from "./migrations/347-delete-stray-greeting-conversation.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1439,4 +1440,5 @@ export const migrationSteps: MigrationStep[] = [
       "migrateMemoryRetrospectiveRememberedLog",
     ],
   },
+  migrateDeleteStrayGreetingConversation,
 ];

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -119,13 +119,20 @@ async function handleBtw({
     }
   }
 
-  // Look up an existing conversation or create an ephemeral one.
+  // Look up an existing conversation or create an ephemeral one. An unmapped
+  // key (e.g. "greeting") does not correspond to a real conversation, so the
+  // side-chain runs against an ephemeral in-memory conversation with no
+  // persisted row — keeping the "no messages are persisted" contract and off
+  // the sidebar. A mapped key targets a real conversation and reuses its row.
   const mapping = getConversationByKey(conversationKey);
   const conversationId = mapping?.conversationId ?? conversationKey;
 
   let conversation;
   try {
-    conversation = await getOrCreateConversation(conversationId);
+    conversation = await getOrCreateConversation(
+      conversationId,
+      mapping ? undefined : { ephemeral: true },
+    );
   } catch {
     throw new ServiceUnavailableError("Message processing is not available");
   }


### PR DESCRIPTION
## Problem

An "Untitled" conversation with literal id `greeting` (`/assistant/conversations/greeting`) appears in every user's sidebar (reported by Vargas, reproduced by Aaron).

## Root cause

The empty-state greeting calls `POST /v1/btw` with `conversationKey: "greeting"`. When the key has no conversation mapping, `btw-routes.ts` uses the key itself as the conversation id and calls `getOrCreateConversation("greeting")`.

Since #38291 moved DB row creation into `getOrCreateConversation`, that call unconditionally persists a `standard` (sidebar-visible) `conversations` row — violating the btw side-chain's "no messages are persisted" contract and leaking the row into every sidebar the first time the greeting cache misses.

## Fix

- Add a per-call `ephemeral` option to `getOrCreateConversation` that skips row creation (stripped like `taskRunId` so it never merges into stored conversation options). `Conversation.loadFromDb()` already tolerates a missing row.
- `btw-routes.ts` passes `{ ephemeral: true }` only on the unmapped-key path; mapped keys keep reusing their real conversation row.
- DB migration `342-delete-stray-greeting-conversation` removes the leaked row for existing installs — only when it carries no messages. If a user opened the stray conversation and chatted in it, the row is user data and is left untouched.

Safety of the residual edge: a real send to a row-less conversation id can't corrupt state — the explicit-`conversationId` send path 404s when no row exists, and the keyed path creates its row via the conversation-key store before any message insert.

## Testing

- New `conversation-store-ephemeral.test.ts`: ephemeral calls create no row; non-ephemeral calls do.
- New migration test: stray empty row deleted; row with messages preserved; unrelated conversations untouched; idempotent.
- Updated `btw-routes.test.ts` call-signature assertions.
- `bunx tsc --noEmit` clean, eslint clean, migration-prefix-guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->