### PR TITLE
test(design-library): add story for prose mixed with inline code in a blockquote

### DIFF
--- a/packages/design-library/src/components/markdown-message.stories.tsx
+++ b/packages/design-library/src/components/markdown-message.stories.tsx
@@ -25,6 +25,22 @@ export const Default: Story = {
   },
 };
 
+/**
+ * Regression guard for LUM-2788: prose mixed with inline code chips inside a
+ * blockquote must keep real leading — with the single-line label token's
+ * line-height:1 the padded chips paint over the lines above and below.
+ */
+export const QuoteWithInlineCode: Story = {
+  args: {
+    content: [
+      "> Symptom: Settings shows `backup.enabled` as `false` in config, and",
+      "> `handleBackupCreate()` throws a `BadRequestError` saying creation",
+      "> moved to the gateway (`POST /v1/backups/create`). Three `.vbundle`",
+      "> files exist in `~/.vellum/backups/local/` — nothing newer.",
+    ].join("\n"),
+  },
+};
+
 /** A fenced block that overflows both axes. */
 export const LongCodeBlock: Story = {
   args: {

--- a/packages/design-library/src/components/markdown-message.stories.tsx
+++ b/packages/design-library/src/components/markdown-message.stories.tsx
@@ -27,8 +27,8 @@ export const Default: Story = {
 
 /**
  * Regression guard for LUM-2788: prose mixed with inline code chips inside a
- * blockquote must keep real leading — with the single-line label token's
- * line-height:1 the padded chips paint over the lines above and below.
+ * blockquote must keep real leading — a line-height:1 label token on the
+ * quote lets the chips' padded backgrounds paint over adjacent lines.
  */
 export const QuoteWithInlineCode: Story = {
   args: {


### PR DESCRIPTION
Part of [LUM-2788](https://linear.app/vellum/issue/LUM-2788/web-mixed-inline-code-prose-in-chat-messages-causes-line-height)

## Prompt / plan

Storybook has no story covering the pattern that triggers LUM-2788 (prose mixed with inline code chips inside a blockquote), which is why the line-height collapse never surfaced in visual review. This PR adds only the story, based on current `main`, so it renders the **existing broken behavior**: the blockquote's label-token `line-height: 1` gives quoted prose 12px line boxes while the padded inline-code chips paint ~18px tall and overlap the lines above and below.

The fix lands separately in #38754 — once both are merged, this story renders correctly and serves as the visual-QA target for the pattern going forward.

## Test plan

- Story renders in the design-library Storybook (`Components/MarkdownMessage/Quote With Inline Code`) and visibly reproduces the collapsed/overlapping rendering on this branch; side-by-side screenshots (before on this branch, after with #38754) are attached to the review thread.
- Design-library typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPEsEduoBTUyfbpLirzdAu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPEsEduoBTUyfbpLirzdAu)_