### PR TITLE
fix(plugins): stop tool-registry init from activating plugins

### DIFF
--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -858,9 +858,11 @@ export function createResolveToolsCallback(
     void loadWorkspaceTools();
 
     // Same treatment for user-plugin tools: pull the plugin mtime-cache's
-    // active tool set into the registry (a no-op costs one sentinel stat +
-    // fingerprint compares), so a plugin installed/removed/edited at runtime
-    // is picked up without recreating the conversation.
+    // active tool set into the registry (a no-op costs a fingerprint compare
+    // per plugin). This pull is a pure cache read — the sentinel reconcile that
+    // activates plugins runs on the hook-dispatch path that precedes tool
+    // resolution each turn — so a plugin installed/removed/edited at runtime is
+    // still picked up here without recreating the conversation.
     void loadPluginTools();
 
     // Read every registered plugin tool each turn (so runtime installs/edits

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -712,20 +712,31 @@ export interface ActivePluginTools {
 }
 
 /**
- * Sync the plugin caches with the source-versions sentinel, then return the
- * tool contributions of every *active* (discovered, enabled, activated)
- * user plugin, keyed by plugin name in install-date order.
+ * Return the tool contributions of every *active* (discovered, enabled,
+ * activated) user plugin, keyed by plugin name in install-date order.
+ *
+ * This is a pure read of the already-reconciled caches — it never scans disk,
+ * activates a plugin, or runs an `init` hook. Reconciliation (which activates
+ * plugins and is the only thing that runs `init`) is owned exclusively by the
+ * three paths that legitimately change the plugin set: the boot scan
+ * ({@link populateCacheAtBoot}), the source-versions gate on the hook-dispatch
+ * path ({@link getUserHookEntriesFor} → {@link maybeReconcileFromSentinel}), and
+ * the imperative install/uninstall poke ({@link reconcilePluginSourcesNow}).
+ * Pulling tools must not be a fourth: the tool registry is populated from
+ * processes that never run plugin lifecycle (sidecar workers call
+ * `initializeTools()` for their own tool surface), so folding activation into
+ * this read would run `init` in a worker against daemon-owned plugin storage.
  *
  * This is the pull half of the tool-registry relationship: the registry's
  * `loadPluginTools()` reconcile calls this and diffs the result into its own
- * maps — this module never writes to the registry. Mirrors how hook reads
- * pull through {@link getUserHookEntriesFor}.
+ * maps — this module never writes to the registry. Because a runtime plugin
+ * change lands in the cache via the hook-dispatch reconcile that runs each turn
+ * (or the explicit install poke), the very next `loadPluginTools()` reads the
+ * updated set, so live install/remove/edit is still picked up without recreating
+ * the conversation. Mirrors how hook reads pull through
+ * {@link getUserHookEntriesFor}.
  */
-export async function getActiveUserPluginTools(): Promise<
-  Map<string, ActivePluginTools>
-> {
-  await maybeReconcileFromSentinel();
-
+export function getActiveUserPluginTools(): Map<string, ActivePluginTools> {
   const byPlugin = new Map<string, CachedTool[]>();
   for (const cached of toolCache.values()) {
     if (!activatedNames.has(cached.pluginName)) {

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -428,18 +428,25 @@ export function unregisterPluginTools(pluginName: string): void {
  * Pull the active user-plugin tool set from the plugin mtime-cache into the
  * registry. This is the pull half of the plugin-tool relationship — the
  * mtime-cache never writes to the registry; instead this reconcile reads
- * {@link import("../plugins/mtime-cache.js").getActiveUserPluginTools} (which
- * syncs against the source-versions sentinel first) and diffs the result into
- * the registry: plugins that vanished are unregistered, new plugins register,
- * and a plugin whose per-tool source mtimes moved is re-registered. Mirrors
- * how hooks resolve through `getUserHookEntriesFor`.
+ * {@link import("../plugins/mtime-cache.js").getActiveUserPluginTools} and diffs
+ * the result into the registry: plugins that vanished are unregistered, new
+ * plugins register, and a plugin whose per-tool source mtimes moved is
+ * re-registered. Mirrors how hooks resolve through `getUserHookEntriesFor`.
  *
- * Idempotent, cheap when nothing changed (one sentinel stat + fingerprint
- * compares), and concurrency-safe (concurrent callers coalesce onto one
- * in-flight reconcile). Runs as the final step of `initializeTools()` (at
- * daemon boot the plugin cache is already populated by then), and
- * fire-and-forget from the per-turn conversation tool resolver — the same
- * cadence `loadWorkspaceTools` runs on.
+ * This is a pure read of the plugin cache — it does NOT reconcile the cache
+ * against the source-versions sentinel, so it never activates a plugin or runs
+ * an `init` hook. Cache reconciliation is owned by the hook-dispatch gate and
+ * the boot/install paths (see `getActiveUserPluginTools`); this pull picks up
+ * whatever they last landed. That keeps tool registration decoupled from plugin
+ * lifecycle: sidecar workers call `initializeTools()` for their own tool
+ * surface and must never run a plugin's `init` as a side effect.
+ *
+ * Idempotent, cheap when nothing changed (a fingerprint compare per plugin),
+ * and concurrency-safe (concurrent callers coalesce onto one in-flight
+ * reconcile). Runs as the final step of `initializeTools()` (at daemon boot the
+ * plugin cache is already populated by then), and fire-and-forget from the
+ * per-turn conversation tool resolver — the same cadence `loadWorkspaceTools`
+ * runs on.
  */
 export function loadPluginTools(): Promise<void> {
   if (pluginToolsReconcileInFlight) {
@@ -462,7 +469,7 @@ async function reconcilePluginToolsFromCache(): Promise<void> {
   try {
     const { getActiveUserPluginTools } =
       await import("../plugins/mtime-cache.js");
-    active = await getActiveUserPluginTools();
+    active = getActiveUserPluginTools();
   } catch (err) {
     log.warn(
       { err },
@@ -1091,11 +1098,13 @@ async function runToolInitialization(): Promise<void> {
 
   // Pull the active user-plugin tool set last, so core and workspace
   // registrations already own their names when plugin conflicts resolve.
-  // At daemon boot the plugin mtime-cache is populated before this runs
-  // (`initializePlugins()` precedes `initializeTools()` in the lifecycle);
-  // in worker/standalone processes the cache is empty and this is a no-op.
-  // Runtime changes keep flowing through the same reconcile, re-fired by
-  // the per-turn conversation tool resolver.
+  // This is a pure cache read (it never activates a plugin or runs `init`):
+  // at daemon boot the plugin mtime-cache is already populated by
+  // `initializePlugins()`, which precedes `initializeTools()` in the lifecycle;
+  // in worker/standalone processes the cache is empty, so this registers no
+  // plugin tools and — critically — runs no plugin lifecycle. Runtime changes
+  // reach the cache via the hook-dispatch reconcile and are re-pulled by the
+  // per-turn conversation tool resolver.
   await loadPluginTools();
 }
 


### PR DESCRIPTION
## Prompt / plan

Reported bug: sidecar workers (schedule, monitoring, memory) were running plugin `init` hooks, producing cross-worker "init hook import failures" (e.g. `pid 85 = schedule-worker`, `pid 1161 = memory-worker` trying to load a user plugin).

**Root cause.** `initializeTools()` was activating plugins as a side effect of tool registration. The chain: `initializeTools()` → `loadPluginTools()` → `getActiveUserPluginTools()` → `maybeReconcileFromSentinel()` → `applySourceVersions()` → `bringUpPlugin()` → `activatePlugin()` → `runInitHook()`. Workers call `initializeTools()` only to populate their own tool surface, so they inherited plugin activation — and thus `init()`, which opens the plugin's storage, re-runs its schema step, and races the daemon on the same files.

**Fix.** Make `getActiveUserPluginTools()` a **pure read** of the already-reconciled caches — no disk scan, no activation, no `init` (it's now synchronous). Cache reconciliation — the only thing that activates plugins / runs `init` — stays owned by the three paths that legitimately change the plugin set:

- the boot scan (`populateCacheAtBoot`),
- the source-versions gate on the **hook-dispatch** path (`getUserHookEntriesFor` → `maybeReconcileFromSentinel`), and
- the imperative install/uninstall poke (`reconcilePluginSourcesNow`).

Tool registration is no longer a fourth activation path. `initializeTools()` in a worker now reads an empty cache, registers no plugin tools, and runs no plugin lifecycle. In the daemon, plugins are already activated by `initializePlugins()` (which precedes `initializeTools()`), so the boot pull just reads the populated cache. A runtime install/edit still lands in the cache via the per-turn hook-dispatch reconcile, so the next `loadPluginTools()` picks it up without recreating the conversation — the existing tests already drive exactly that order (`publishSourceChanges` → `getUserHooksFor` → `loadPluginTools`).

Files:
- `plugins/mtime-cache.ts` — `getActiveUserPluginTools()` no longer reconciles (now synchronous, pure cache read).
- `tools/registry.ts` — caller updated (no `await`); docstrings for `loadPluginTools` / `runToolInitialization` updated for pure-read semantics.
- `daemon/conversation-tool-setup.ts` — per-turn pull comment updated.

## Test plan

- Ran the affected suites — `mtime-cache`, `registry`, `plugin-bootstrap`, `plugin-tool-contribution`, `hook-live-reload`, `memory-worker-tool-registry-guard`, `worker-entrypoint-guards` (108 tests) — all green. These already exercise runtime install/remove/edit through the hook-dispatch reconcile followed by the tool pull, which is the behavior this change relies on.
- `bunx tsc --noEmit`, prettier, eslint clean (pre-commit hooks passed).

## CLI verb checklist

No new routes — not applicable.
