### PR TITLE
feat(surfaces): validate ui_show payloads with canonical per-type Zod schemas

### DIFF
--- a/assistant/src/__tests__/ui-choice-copy-surfaces.test.ts
+++ b/assistant/src/__tests__/ui-choice-copy-surfaces.test.ts
@@ -17,6 +17,7 @@ import type {
 } from "../daemon/message-protocol.js";
 import { INTERACTIVE_SURFACE_TYPES } from "../daemon/message-protocol.js";
 import { uiShowTool } from "../tools/ui-surface/definitions.js";
+import { uiShowTeachingError } from "../tools/ui-surface/surface-shape-docs.js";
 
 function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext {
   return {
@@ -109,7 +110,9 @@ describe("choice and copy_block surface proxying", () => {
       (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
     );
     expect(showMessage).toBeDefined();
-    if (!showMessage || showMessage.surfaceType !== "choice") return;
+    if (!showMessage || showMessage.surfaceType !== "choice") {
+      return;
+    }
 
     const data = showMessage.data as ChoiceSurfaceData;
     expect(data.options.map((option) => option.id)).toEqual([
@@ -172,7 +175,9 @@ describe("choice and copy_block surface proxying", () => {
       (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
     );
     expect(showMessage).toBeDefined();
-    if (!showMessage || showMessage.surfaceType !== "copy_block") return;
+    if (!showMessage || showMessage.surfaceType !== "copy_block") {
+      return;
+    }
 
     expect(showMessage.data as CopyBlockSurfaceData).toEqual({
       text: "Paste this prompt into another assistant.",
@@ -205,7 +210,9 @@ describe("choice and copy_block surface proxying", () => {
       (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
     );
     expect(showMessage).toBeDefined();
-    if (!showMessage || showMessage.surfaceType !== "oauth_connect") return;
+    if (!showMessage || showMessage.surfaceType !== "oauth_connect") {
+      return;
+    }
 
     expect(showMessage.data as OAuthConnectSurfaceData).toEqual({
       providerKey: "google",
@@ -229,6 +236,87 @@ describe("choice and copy_block surface proxying", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("data.providerKey");
     expect(sent).toHaveLength(0);
+  });
+
+  test("ui_show recovers copy_block data sent as a JSON-encoded string", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "copy_block",
+      data: JSON.stringify({ text: "bunx vellum doctor", label: "Command" }),
+    });
+
+    expect(result.isError).toBe(false);
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "copy_block") {
+      return;
+    }
+    expect(showMessage.data).toEqual({
+      text: "bunx vellum doctor",
+      label: "Command",
+    });
+  });
+
+  test("ui_show recovers copy_block fields placed at the top level of the input", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "copy_block",
+      text: "ssh user@example.com",
+      label: "SSH",
+      data: {},
+    });
+
+    expect(result.isError).toBe(false);
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "copy_block") {
+      return;
+    }
+    expect(showMessage.data).toEqual({
+      text: "ssh user@example.com",
+      label: "SSH",
+    });
+  });
+
+  test("ui_show rejects an unknown surface_type with the valid values", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "copyblock",
+      data: { text: "hello" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('"copyblock" is not a valid surface_type');
+    expect(result.content).toContain("copy_block");
+    expect(sent).toHaveLength(0);
+  });
+
+  test("ui_show teaching guard accepts JSON-string copy_block data with text", () => {
+    const teachingError = uiShowTeachingError({
+      surface_type: "copy_block",
+      data: JSON.stringify({ text: "populated" }),
+    });
+    expect(teachingError).toBeNull();
+  });
+
+  test("ui_show teaching guard still flags copy_block without text", () => {
+    const teachingError = uiShowTeachingError({
+      surface_type: "copy_block",
+      data: { label: "Command" },
+    });
+    expect(teachingError).toContain("`data.text` must be a non-empty string");
   });
 
   test("choice completion summary names multi-select choices", () => {

--- a/assistant/src/__tests__/ui-choice-copy-surfaces.test.ts
+++ b/assistant/src/__tests__/ui-choice-copy-surfaces.test.ts
@@ -303,6 +303,59 @@ describe("choice and copy_block surface proxying", () => {
     expect(sent).toHaveLength(0);
   });
 
+  test("ui_show teaching guard accepts copy_block text at the top level of the input", () => {
+    const teachingError = uiShowTeachingError({
+      surface_type: "copy_block",
+      text: "bunx vellum doctor",
+      data: {},
+    });
+    expect(teachingError).toBeNull();
+  });
+
+  test("uiShowTool.execute renders a copy_block whose text is at the top level", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+    const result = await uiShowTool.execute(
+      { surface_type: "copy_block", text: "bunx vellum doctor", data: {} },
+      {
+        proxyToolResolver: (toolName: string, input: Record<string, unknown>) =>
+          surfaceProxyResolver(ctx, toolName, input),
+      } as unknown as Parameters<typeof uiShowTool.execute>[1],
+    );
+
+    expect(result.isError).toBe(false);
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "copy_block") {
+      return;
+    }
+    expect(showMessage.data).toEqual({ text: "bunx vellum doctor" });
+  });
+
+  test("uiShowTool.execute renders a dynamic_page whose html is at the top level", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+    const result = await uiShowTool.execute(
+      { surface_type: "dynamic_page", html: "<p>hello</p>", data: {} },
+      {
+        proxyToolResolver: (toolName: string, input: Record<string, unknown>) =>
+          surfaceProxyResolver(ctx, toolName, input),
+      } as unknown as Parameters<typeof uiShowTool.execute>[1],
+    );
+
+    expect(result.isError).toBe(false);
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "dynamic_page") {
+      return;
+    }
+    expect(showMessage.data.html).toBe("<p>hello</p>");
+  });
+
   test("ui_show teaching guard accepts JSON-string copy_block data with text", () => {
     const teachingError = uiShowTeachingError({
       surface_type: "copy_block",

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -565,6 +565,7 @@ export {
   ListItemSchema,
   type ListSurfaceData,
   ListSurfaceDataSchema,
+  normalizeCopyBlockShowData,
   type OAuthConnectSurfaceData,
   OAuthConnectSurfaceDataSchema,
   safeParseSurfaceData,

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -567,7 +567,7 @@ export {
   ListSurfaceDataSchema,
   type OAuthConnectSurfaceData,
   OAuthConnectSurfaceDataSchema,
-  SURFACE_DATA_SCHEMAS,
+  safeParseSurfaceData,
   SURFACE_TYPES,
   type SurfaceData,
   type SurfaceType,

--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -132,6 +132,25 @@ export const CopyBlockSurfaceDataSchema = z.object({
 });
 export type CopyBlockSurfaceData = z.infer<typeof CopyBlockSurfaceDataSchema>;
 
+/**
+ * Normalize a copy_block `ui_show` payload: recover fields the model placed
+ * at the top level of the tool input instead of nesting inside `data`, then
+ * parse through the canonical schema. Shared by the tool's teaching guard and
+ * the daemon resolver so both layers accept exactly the same payloads.
+ */
+export function normalizeCopyBlockShowData(
+  input: Record<string, unknown>,
+  data: Record<string, unknown>,
+): CopyBlockSurfaceData {
+  const normalized: Record<string, unknown> = { ...data };
+  for (const key of ["text", "label", "language"] as const) {
+    if (typeof normalized[key] !== "string" && typeof input[key] === "string") {
+      normalized[key] = input[key];
+    }
+  }
+  return CopyBlockSurfaceDataSchema.parse(normalized);
+}
+
 export const ChoiceOptionSchema = z.object({
   id: z.string(),
   title: z.string(),

--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -13,8 +13,8 @@
  *
  * Every surface type has a canonical schema here; the daemon's
  * `daemon/message-types/surfaces.ts` re-exports the inferred types under
- * their canonical names, and `SURFACE_DATA_SCHEMAS` maps each
- * `surface_type` to its schema so entry points (`surfaceProxyResolver`)
+ * their canonical names, and `safeParseSurfaceData` dispatches a payload
+ * to its `surface_type`'s schema so entry points (`surfaceProxyResolver`)
  * can parse instead of casting.
  */
 
@@ -472,23 +472,60 @@ export type SurfaceData =
   | WorkResultSurfaceData;
 
 /**
- * Canonical `data` schema per surface type. `channel_setup` (a side-effect
- * command whose payload is forwarded opaquely to the setup panel) and
- * `task_preferences` (a fixed grid that reads no data) stay opaque records.
+ * Parse a surface `data` payload through its type's canonical schema,
+ * returning `undefined` when the payload does not parse.
+ *
+ * The dispatch is an exhaustive switch rather than a schema registry so the
+ * compiler verifies that every surface type's schema output is a member of
+ * the `SurfaceData` union — a registry keyed by `SurfaceType` erases the
+ * per-type output types and forces casts at every call site.
+ *
+ * Only `card` can actually fail on an object input (its fields validate
+ * without `catch` fallbacks); every other schema is total over plain
+ * objects, and a non-object payload fails them all.
  */
-export const SURFACE_DATA_SCHEMAS: Record<SurfaceType, z.ZodType> = {
-  card: CardSurfaceDataSchema,
-  channel_setup: z.record(z.string(), z.unknown()),
-  choice: ChoiceSurfaceDataSchema,
-  copy_block: CopyBlockSurfaceDataSchema,
-  oauth_connect: OAuthConnectSurfaceDataSchema,
-  form: FormSurfaceDataSchema,
-  list: ListSurfaceDataSchema,
-  table: TableSurfaceDataSchema,
-  confirmation: ConfirmationSurfaceDataSchema,
-  dynamic_page: DynamicPageSurfaceDataSchema,
-  file_upload: FileUploadSurfaceDataSchema,
-  document_preview: DocumentPreviewSurfaceDataSchema,
-  task_preferences: z.record(z.string(), z.unknown()),
-  work_result: WorkResultSurfaceDataSchema,
-};
+export function safeParseSurfaceData(
+  surfaceType: SurfaceType,
+  data: unknown,
+): SurfaceData | undefined {
+  const parse = <T>(schema: z.ZodType<T>): T | undefined => {
+    const result = schema.safeParse(data);
+    return result.success ? result.data : undefined;
+  };
+  switch (surfaceType) {
+    case "card":
+      return parse(CardSurfaceDataSchema);
+    case "choice":
+      return parse(ChoiceSurfaceDataSchema);
+    case "copy_block":
+      return parse(CopyBlockSurfaceDataSchema);
+    case "oauth_connect":
+      return parse(OAuthConnectSurfaceDataSchema);
+    case "form":
+      return parse(FormSurfaceDataSchema);
+    case "list":
+      return parse(ListSurfaceDataSchema);
+    case "table":
+      return parse(TableSurfaceDataSchema);
+    case "confirmation":
+      return parse(ConfirmationSurfaceDataSchema);
+    case "dynamic_page":
+      return parse(DynamicPageSurfaceDataSchema);
+    case "file_upload":
+      return parse(FileUploadSurfaceDataSchema);
+    case "document_preview":
+      return parse(DocumentPreviewSurfaceDataSchema);
+    case "work_result":
+      return parse(WorkResultSurfaceDataSchema);
+    case "channel_setup":
+    case "task_preferences":
+      // Opaque payloads: channel_setup is a side-effect command whose data
+      // is forwarded verbatim to the setup panel, and task_preferences
+      // renders a fixed grid that reads no data. There is no canonical
+      // shape to parse into, so this is the one deliberate cast in the
+      // surface-data parse path.
+      return coerceSurfaceDataRecord(data) as SurfaceData;
+    default:
+      return surfaceType satisfies never;
+  }
+}

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -4,7 +4,12 @@ import { z } from "zod";
 import { SurfaceActionSchema } from "../api/events/ui-surface-show.js";
 import {
   CardSurfaceDataSchema,
-  FileUploadSurfaceDataSchema,
+  coerceSurfaceDataRecord,
+  CopyBlockSurfaceDataSchema,
+  DynamicPageSurfaceDataSchema,
+  SURFACE_DATA_SCHEMAS,
+  SURFACE_TYPES,
+  SurfaceTypeSchema,
 } from "../api/surfaces.js";
 import {
   addAppConversationId,
@@ -57,10 +62,8 @@ import type {
   ConfirmationSurfaceData,
   CopyBlockSurfaceData,
   DynamicPageSurfaceData,
-  FileUploadSurfaceData,
   FormSurfaceData,
   ListSurfaceData,
-  OAuthConnectSurfaceData,
   ServerMessage,
   SurfaceData,
   SurfaceType,
@@ -475,7 +478,7 @@ function normalizeDynamicPageShowData(
     normalized.preview = input.preview;
   }
 
-  return normalized as unknown as DynamicPageSurfaceData;
+  return DynamicPageSurfaceDataSchema.parse(normalized);
 }
 
 /** First entry that is a non-empty (trimmed) string, else undefined. */
@@ -714,103 +717,41 @@ function normalizeTaskProgressCardPatch(
   return normalizedPatch;
 }
 
-function normalizeChoiceShowData(
-  rawData: Record<string, unknown>,
-): ChoiceSurfaceData {
-  const options = Array.isArray(rawData.options)
-    ? rawData.options
-        .filter((option): option is Record<string, unknown> =>
-          isPlainObject(option),
-        )
-        .map((option) => {
-          const id = typeof option.id === "string" ? option.id.trim() : "";
-          const title =
-            typeof option.title === "string"
-              ? option.title.trim()
-              : typeof option.label === "string"
-                ? option.label.trim()
-                : "";
-          if (!id || !title) {
-            return null;
-          }
-          return {
-            id,
-            title,
-            ...(typeof option.description === "string"
-              ? { description: option.description }
-              : {}),
-            ...(option.recommended === true ? { recommended: true } : {}),
-            ...(isPlainObject(option.data)
-              ? { data: option.data as Record<string, unknown> }
-              : {}),
-          };
-        })
-        .filter(
-          (option): option is NonNullable<typeof option> => option !== null,
-        )
-    : [];
-
-  return {
-    ...(typeof rawData.description === "string"
-      ? { description: rawData.description }
-      : {}),
-    options,
-    selectionMode: rawData.selectionMode === "multiple" ? "multiple" : "single",
-    ...(typeof rawData.submitLabel === "string"
-      ? { submitLabel: rawData.submitLabel }
-      : {}),
-    ...(typeof rawData.commitOnSelect === "boolean"
-      ? { commitOnSelect: rawData.commitOnSelect }
-      : {}),
-  };
-}
-
 function normalizeCopyBlockShowData(
+  input: Record<string, unknown>,
   rawData: Record<string, unknown>,
 ): CopyBlockSurfaceData {
-  return {
-    text: typeof rawData.text === "string" ? rawData.text : "",
-    ...(typeof rawData.label === "string" ? { label: rawData.label } : {}),
-    ...(typeof rawData.language === "string"
-      ? { language: rawData.language }
-      : {}),
-  };
+  const normalized: Record<string, unknown> = { ...rawData };
+  // The model sometimes places copy_block fields at the top level of the tool
+  // input instead of nesting them inside `data`; recover them so a populated
+  // payload isn't rejected as textless.
+  for (const key of ["text", "label", "language"] as const) {
+    if (typeof normalized[key] !== "string" && typeof input[key] === "string") {
+      normalized[key] = input[key];
+    }
+  }
+  return CopyBlockSurfaceDataSchema.parse(normalized);
 }
 
-function normalizeOAuthConnectShowData(
+/**
+ * Parse a `ui_show` payload through its surface type's canonical schema.
+ * The schemas are tolerant (malformed fields are dropped or defaulted, never
+ * rejected), so a record input parses; if one somehow does not, log loudly
+ * and pass the raw payload through rather than silently dropping the surface.
+ */
+function parseSurfaceShowData(
+  surfaceType: SurfaceType,
   rawData: Record<string, unknown>,
-): OAuthConnectSurfaceData {
-  return {
-    providerKey:
-      typeof rawData.providerKey === "string" ? rawData.providerKey.trim() : "",
-    ...(typeof rawData.displayName === "string"
-      ? { displayName: rawData.displayName }
-      : {}),
-    ...(typeof rawData.description === "string"
-      ? { description: rawData.description }
-      : {}),
-    ...(typeof rawData.logoUrl === "string" || rawData.logoUrl === null
-      ? { logoUrl: rawData.logoUrl }
-      : {}),
-  };
-}
-
-function normalizeFileUploadShowData(
-  rawData: Record<string, unknown>,
-): FileUploadSurfaceData {
-  // Parse against the canonical schema so the surface carries the shape the
-  // renderer expects. The schema is tolerant (every field optional and coerced)
-  // and recovers the common malformed `acceptedTypes` shapes — a comma-joined or
-  // bare string — into the `string[]` the renderer requires.
-  const parsed = FileUploadSurfaceDataSchema.safeParse(rawData);
+): SurfaceData {
+  const parsed = SURFACE_DATA_SCHEMAS[surfaceType].safeParse(rawData);
   if (parsed.success) {
-    return parsed.data;
+    return parsed.data as SurfaceData;
   }
   log.warn(
-    { issues: parsed.error.issues },
-    "ui_show file_upload data failed FileUploadSurfaceDataSchema; rendering an empty file_upload surface",
+    { surfaceType, issues: parsed.error.issues },
+    "ui_show data failed its canonical surface schema; passing raw data through",
   );
-  return {};
+  return rawData as SurfaceData;
 }
 
 function buildChoiceActions(data: ChoiceSurfaceData): Array<{
@@ -848,12 +789,13 @@ function isSlackTaskProgressUiException(
     return false;
   }
   if (toolName === "ui_show") {
-    const surfaceType = input.surface_type as SurfaceType;
-    if (surfaceType !== "card") {
+    if (input.surface_type !== "card") {
       return false;
     }
-    const rawData = isPlainObject(input.data) ? input.data : {};
-    const data = normalizeCardShowData(input, rawData);
+    const data = normalizeCardShowData(
+      input,
+      coerceSurfaceDataRecord(input.data),
+    );
     return isTaskProgressCardData(data);
   }
   if (toolName === "ui_update") {
@@ -1123,7 +1065,7 @@ export function showStandaloneSurface(
   const timeoutMs = request.timeoutMs ?? DEFAULT_STANDALONE_TIMEOUT_MS;
 
   // Build surface data from the request payload.
-  const surfaceType = request.surfaceType as SurfaceType;
+  const surfaceType: SurfaceType = request.surfaceType;
   const data = buildStandaloneSurfaceData(request);
   const actions = request.actions?.map((a) => ({
     id: a.id,
@@ -1249,8 +1191,15 @@ function buildStandaloneSurfaceData(
     } as FormSurfaceData;
   }
 
-  // Fallback: pass through opaque data
-  return request.data as unknown as SurfaceData;
+  // Any other surface type: parse through its canonical schema when the type
+  // is known; otherwise pass the payload through opaquely.
+  const parsedType = SurfaceTypeSchema.safeParse(request.surfaceType);
+  const parsed = parsedType.success
+    ? SURFACE_DATA_SCHEMAS[parsedType.data].safeParse(request.data)
+    : undefined;
+  return parsed?.success
+    ? (parsed.data as SurfaceData)
+    : (request.data as unknown as SurfaceData);
 }
 
 /**
@@ -3028,9 +2977,24 @@ export async function surfaceProxyResolver(
 
   if (toolName === "ui_show") {
     const surfaceId = uuid();
-    const surfaceType = input.surface_type as SurfaceType;
+    // Parse, don't cast: an unrecognized surface_type used to be asserted
+    // into the union and fall through to an opaque passthrough the client
+    // silently dropped. Reject it with the valid values instead.
+    const parsedSurfaceType = SurfaceTypeSchema.safeParse(input.surface_type);
+    if (!parsedSurfaceType.success) {
+      const got =
+        typeof input.surface_type === "string" &&
+        input.surface_type.trim().length > 0
+          ? `"${input.surface_type}" is not a valid surface_type`
+          : "`surface_type` is missing";
+      return {
+        content: `Error: ui_show was not displayed — ${got}. Valid surface_type values: ${SURFACE_TYPES.join(", ")}. Resend ui_show with one of these values.`,
+        isError: true,
+      };
+    }
+    const surfaceType = parsedSurfaceType.data;
     const title = typeof input.title === "string" ? input.title : undefined;
-    const rawData = isPlainObject(input.data) ? input.data : {};
+    const rawData = coerceSurfaceDataRecord(input.data);
 
     // channel_setup is a side-effect-only command: it opens the channel setup
     // drawer on the client. Emitted as `open_panel` (not `ui_surface_show`)
@@ -3081,10 +3045,10 @@ export async function surfaceProxyResolver(
       };
     }
 
-    // Each surface type that has a canonical Zod schema gets parsed through it;
-    // the rest pass through raw until migrated (LUM-2134 scope). The per-type
-    // normalizers validate+recover; the union cast at the end is only for the
-    // unmigrated branches that still return hand-written interfaces.
+    // Every surface type parses through its canonical schema. Card,
+    // copy_block, and dynamic_page first run bespoke normalizers that
+    // recover fields the model placed at the top level of the tool input;
+    // the rest go straight through `parseSurfaceShowData`.
     const cardData =
       surfaceType === "card"
         ? normalizeCardShowData(input, rawData)
@@ -3092,17 +3056,11 @@ export async function surfaceProxyResolver(
     const data: SurfaceData =
       cardData !== undefined
         ? cardData
-        : surfaceType === "choice"
-          ? normalizeChoiceShowData(rawData)
-          : surfaceType === "copy_block"
-            ? normalizeCopyBlockShowData(rawData)
-            : surfaceType === "oauth_connect"
-              ? normalizeOAuthConnectShowData(rawData)
-              : surfaceType === "dynamic_page"
-                ? normalizeDynamicPageShowData(input, rawData)
-                : surfaceType === "file_upload"
-                  ? normalizeFileUploadShowData(rawData)
-                  : (rawData as SurfaceData);
+        : surfaceType === "copy_block"
+          ? normalizeCopyBlockShowData(input, rawData)
+          : surfaceType === "dynamic_page"
+            ? normalizeDynamicPageShowData(input, rawData)
+            : parseSurfaceShowData(surfaceType, rawData);
     // Parse actions through the schema instead of typecasting raw model output.
     // The model may place actions inside `data` instead of the top-level
     // `actions` param — recover them so they aren't silently dropped.
@@ -3309,10 +3267,7 @@ export async function surfaceProxyResolver(
 
   if (toolName === "ui_update") {
     const surfaceId = input.surface_id as string;
-    let patch = (isPlainObject(input.data) ? input.data : {}) as Record<
-      string,
-      unknown
-    >;
+    let patch = coerceSurfaceDataRecord(input.data);
 
     // Merge the partial patch into the stored full surface data
     const stored = ctx.surfaceState.get(surfaceId);
@@ -3330,24 +3285,25 @@ export async function surfaceProxyResolver(
         pushUndoState(ctx.surfaceUndoStacks, surfaceId, currentHtml);
       }
       const rawMerged = { ...stored.data, ...patch };
-      if (stored.surfaceType === "card") {
-        // Validate the merged card data through the canonical schema so
-        // malformed patches (e.g. metadata as a string) are caught here
-        // instead of crashing the client's safeParse.
-        const parsed = CardSurfaceDataSchema.safeParse(rawMerged);
-        mergedData = parsed.success
-          ? parsed.data
-          : (CardSurfaceDataSchema.safeParse(stored.data).data ?? {});
-        if (!parsed.success) {
-          log.warn(
-            { surfaceId, issues: parsed.error.issues },
-            "ui_update card patch produced invalid merged data; reverting to stored data",
-          );
-        }
+      // Validate the merged data through the surface type's canonical schema
+      // so malformed patches (e.g. metadata as a string) are caught here
+      // instead of crashing the client's safeParse.
+      const schema = SURFACE_DATA_SCHEMAS[stored.surfaceType];
+      const parsed = schema.safeParse(rawMerged);
+      if (parsed.success) {
+        mergedData = parsed.data as SurfaceData;
       } else {
-        // Other surface types lack canonical Zod schemas (LUM-2134 scope).
-        // The raw merge is the best we can do until they're migrated.
-        mergedData = rawMerged as SurfaceData;
+        log.warn(
+          {
+            surfaceId,
+            surfaceType: stored.surfaceType,
+            issues: parsed.error.issues,
+          },
+          "ui_update patch produced invalid merged data; reverting to stored data",
+        );
+        mergedData =
+          (schema.safeParse(stored.data).data as SurfaceData | undefined) ??
+          stored.data;
       }
       stored.data = mergedData;
     } else {

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -4,10 +4,12 @@ import { z } from "zod";
 import { SurfaceActionSchema } from "../api/events/ui-surface-show.js";
 import {
   CardSurfaceDataSchema,
+  ChoiceSurfaceDataSchema,
   coerceSurfaceDataRecord,
   CopyBlockSurfaceDataSchema,
   DynamicPageSurfaceDataSchema,
-  SURFACE_DATA_SCHEMAS,
+  OAuthConnectSurfaceDataSchema,
+  safeParseSurfaceData,
   SURFACE_TYPES,
   SurfaceTypeSchema,
 } from "../api/surfaces.js";
@@ -733,27 +735,6 @@ function normalizeCopyBlockShowData(
   return CopyBlockSurfaceDataSchema.parse(normalized);
 }
 
-/**
- * Parse a `ui_show` payload through its surface type's canonical schema.
- * The schemas are tolerant (malformed fields are dropped or defaulted, never
- * rejected), so a record input parses; if one somehow does not, log loudly
- * and pass the raw payload through rather than silently dropping the surface.
- */
-function parseSurfaceShowData(
-  surfaceType: SurfaceType,
-  rawData: Record<string, unknown>,
-): SurfaceData {
-  const parsed = SURFACE_DATA_SCHEMAS[surfaceType].safeParse(rawData);
-  if (parsed.success) {
-    return parsed.data as SurfaceData;
-  }
-  log.warn(
-    { surfaceType, issues: parsed.error.issues },
-    "ui_show data failed its canonical surface schema; passing raw data through",
-  );
-  return rawData as SurfaceData;
-}
-
 function buildChoiceActions(data: ChoiceSurfaceData): Array<{
   id: string;
   label: string;
@@ -810,13 +791,12 @@ function isSlackTaskProgressUiException(
     if (!isTaskProgressCardData(stored.data)) {
       return false;
     }
-    const rawPatch = isPlainObject(input.data) ? input.data : {};
+    const rawPatch = coerceSurfaceDataRecord(input.data);
     const patch = normalizeTaskProgressCardPatch(
       stored.data as CardSurfaceData,
       rawPatch,
     );
-    const mergedData = { ...stored.data, ...patch } as SurfaceData;
-    return isTaskProgressCardData(mergedData);
+    return isTaskProgressCardData({ ...stored.data, ...patch });
   }
   return false;
 }
@@ -1191,15 +1171,8 @@ function buildStandaloneSurfaceData(
     } as FormSurfaceData;
   }
 
-  // Any other surface type: parse through its canonical schema when the type
-  // is known; otherwise pass the payload through opaquely.
-  const parsedType = SurfaceTypeSchema.safeParse(request.surfaceType);
-  const parsed = parsedType.success
-    ? SURFACE_DATA_SCHEMAS[parsedType.data].safeParse(request.data)
-    : undefined;
-  return parsed?.success
-    ? (parsed.data as SurfaceData)
-    : (request.data as unknown as SurfaceData);
+  // Any other surface type: parse through its canonical schema.
+  return safeParseSurfaceData(request.surfaceType, request.data) ?? {};
 }
 
 /**
@@ -1343,7 +1316,7 @@ export function openChannelSetupPanel(
     // conversationId. Cleared by cleanupStandaloneSurface on all outcomes.
     ctx.surfaceState.set(surfaceId, {
       surfaceType: "channel_setup",
-      data: data as SurfaceData,
+      data: safeParseSurfaceData("channel_setup", data) ?? {},
     });
 
     ctx.sendToClient({
@@ -3048,19 +3021,30 @@ export async function surfaceProxyResolver(
     // Every surface type parses through its canonical schema. Card,
     // copy_block, and dynamic_page first run bespoke normalizers that
     // recover fields the model placed at the top level of the tool input;
-    // the rest go straight through `parseSurfaceShowData`.
+    // the rest go straight through `safeParseSurfaceData`. Choice and
+    // oauth_connect parse into named bindings so their content guards below
+    // read typed data instead of re-narrowing the union.
     const cardData =
       surfaceType === "card"
         ? normalizeCardShowData(input, rawData)
         : undefined;
+    const choiceData =
+      surfaceType === "choice"
+        ? ChoiceSurfaceDataSchema.parse(rawData)
+        : undefined;
+    const oauthData =
+      surfaceType === "oauth_connect"
+        ? OAuthConnectSurfaceDataSchema.parse(rawData)
+        : undefined;
     const data: SurfaceData =
-      cardData !== undefined
-        ? cardData
-        : surfaceType === "copy_block"
-          ? normalizeCopyBlockShowData(input, rawData)
-          : surfaceType === "dynamic_page"
-            ? normalizeDynamicPageShowData(input, rawData)
-            : parseSurfaceShowData(surfaceType, rawData);
+      cardData ??
+      choiceData ??
+      oauthData ??
+      (surfaceType === "copy_block"
+        ? normalizeCopyBlockShowData(input, rawData)
+        : surfaceType === "dynamic_page"
+          ? normalizeDynamicPageShowData(input, rawData)
+          : (safeParseSurfaceData(surfaceType, rawData) ?? {}));
     // Parse actions through the schema instead of typecasting raw model output.
     // The model may place actions inside `data` instead of the top-level
     // `actions` param — recover them so they aren't silently dropped.
@@ -3081,9 +3065,7 @@ export async function surfaceProxyResolver(
       inputActions = valid.length > 0 ? valid : undefined;
     }
     const actions =
-      surfaceType === "choice"
-        ? buildChoiceActions(data as ChoiceSurfaceData)
-        : inputActions;
+      choiceData !== undefined ? buildChoiceActions(choiceData) : inputActions;
     const hasActions = Array.isArray(actions) && actions.length > 0;
     if (surfaceType === "choice" && !hasActions) {
       return {
@@ -3120,15 +3102,7 @@ export async function surfaceProxyResolver(
         };
       }
     }
-    const oauthProviderKey =
-      surfaceType === "oauth_connect"
-        ? (data as unknown as Record<string, unknown>).providerKey
-        : undefined;
-    if (
-      surfaceType === "oauth_connect" &&
-      (typeof oauthProviderKey !== "string" ||
-        oauthProviderKey.trim().length === 0)
-    ) {
+    if (oauthData !== undefined && oauthData.providerKey.length === 0) {
       return {
         content: "oauth_connect surfaces require data.providerKey.",
         isError: true,
@@ -3288,26 +3262,23 @@ export async function surfaceProxyResolver(
       // Validate the merged data through the surface type's canonical schema
       // so malformed patches (e.g. metadata as a string) are caught here
       // instead of crashing the client's safeParse.
-      const schema = SURFACE_DATA_SCHEMAS[stored.surfaceType];
-      const parsed = schema.safeParse(rawMerged);
-      if (parsed.success) {
-        mergedData = parsed.data as SurfaceData;
+      const parsed = safeParseSurfaceData(stored.surfaceType, rawMerged);
+      if (parsed !== undefined) {
+        mergedData = parsed;
       } else {
         log.warn(
-          {
-            surfaceId,
-            surfaceType: stored.surfaceType,
-            issues: parsed.error.issues,
-          },
+          { surfaceId, surfaceType: stored.surfaceType },
           "ui_update patch produced invalid merged data; reverting to stored data",
         );
         mergedData =
-          (schema.safeParse(stored.data).data as SurfaceData | undefined) ??
-          stored.data;
+          safeParseSurfaceData(stored.surfaceType, stored.data) ?? stored.data;
       }
       stored.data = mergedData;
     } else {
-      mergedData = patch as unknown as SurfaceData;
+      // No stored state for this surfaceId, so its surface type — and
+      // therefore its canonical schema — is unknown; forward the patch
+      // opaquely rather than dropping the update.
+      mergedData = patch as SurfaceData;
     }
 
     ctx.sendToClient({

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -6,8 +6,8 @@ import {
   CardSurfaceDataSchema,
   ChoiceSurfaceDataSchema,
   coerceSurfaceDataRecord,
-  CopyBlockSurfaceDataSchema,
   DynamicPageSurfaceDataSchema,
+  normalizeCopyBlockShowData,
   OAuthConnectSurfaceDataSchema,
   safeParseSurfaceData,
   SURFACE_TYPES,
@@ -62,7 +62,6 @@ import type {
   CardSurfaceData,
   ChoiceSurfaceData,
   ConfirmationSurfaceData,
-  CopyBlockSurfaceData,
   DynamicPageSurfaceData,
   FormSurfaceData,
   ListSurfaceData,
@@ -717,22 +716,6 @@ function normalizeTaskProgressCardPatch(
   }
 
   return normalizedPatch;
-}
-
-function normalizeCopyBlockShowData(
-  input: Record<string, unknown>,
-  rawData: Record<string, unknown>,
-): CopyBlockSurfaceData {
-  const normalized: Record<string, unknown> = { ...rawData };
-  // The model sometimes places copy_block fields at the top level of the tool
-  // input instead of nesting them inside `data`; recover them so a populated
-  // payload isn't rejected as textless.
-  for (const key of ["text", "label", "language"] as const) {
-    if (typeof normalized[key] !== "string" && typeof input[key] === "string") {
-      normalized[key] = input[key];
-    }
-  }
-  return CopyBlockSurfaceDataSchema.parse(normalized);
 }
 
 function buildChoiceActions(data: ChoiceSurfaceData): Array<{

--- a/assistant/src/daemon/message-types/surfaces.ts
+++ b/assistant/src/daemon/message-types/surfaces.ts
@@ -38,7 +38,7 @@ export {
   type ListItem,
   ListSurfaceDataSchema,
   OAuthConnectSurfaceDataSchema,
-  SURFACE_DATA_SCHEMAS,
+  safeParseSurfaceData,
   SURFACE_TYPES,
   SurfaceTypeSchema,
   type TableCellValue,

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -147,11 +147,21 @@ function isEmptyUpdate(input: Record<string, unknown>): boolean {
   return !hasContent(coerceSurfaceDataRecord(input.data));
 }
 
+/**
+ * The dynamic_page markup, honoring the same top-level recovery as the
+ * daemon's `normalizeDynamicPageShowData`: `data.html` wins, a top-level
+ * `html` fills in when the model put it outside `data`.
+ */
+function dynamicPageHtml(input: Record<string, unknown>): unknown {
+  const html = coerceSurfaceDataRecord(input.data).html;
+  return typeof html === "string" ? html : input.html;
+}
+
 function isEmptyDynamicPage(input: Record<string, unknown>): boolean {
   if (input.surface_type !== "dynamic_page") {
     return false;
   }
-  const html = coerceSurfaceDataRecord(input.data).html;
+  const html = dynamicPageHtml(input);
   return typeof html !== "string" || html.trim().length === 0;
 }
 
@@ -180,7 +190,7 @@ const INTERACTIVE_HTML_RE =
   /<script\b|on[a-z]+\s*=|addEventListener|new Chart\b|window\.vellum\b/i;
 
 function isSubstantialInteractiveHtml(input: Record<string, unknown>): boolean {
-  const html = coerceSurfaceDataRecord(input.data).html;
+  const html = dynamicPageHtml(input);
   if (typeof html !== "string") {
     return false;
   }

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -7,6 +7,7 @@
  * handled locally by the daemon.
  */
 
+import { coerceSurfaceDataRecord } from "../../api/surfaces.js";
 import { RiskLevel } from "../../permissions/types.js";
 import { isWeakOpenModel } from "../../providers/weak-open-model.js";
 import type {
@@ -130,8 +131,7 @@ function isTaskProgressCardShow(input: Record<string, unknown>): boolean {
   if (input.template === "task_progress") {
     return true;
   }
-  const data = asRecord(input.data);
-  return data?.template === "task_progress";
+  return coerceSurfaceDataRecord(input.data).template === "task_progress";
 }
 
 /**
@@ -144,16 +144,14 @@ function isTaskProgressCardShow(input: Record<string, unknown>): boolean {
  * as content.
  */
 function isEmptyUpdate(input: Record<string, unknown>): boolean {
-  const data = asRecord(input.data);
-  return data === null || !hasContent(data);
+  return !hasContent(coerceSurfaceDataRecord(input.data));
 }
 
 function isEmptyDynamicPage(input: Record<string, unknown>): boolean {
   if (input.surface_type !== "dynamic_page") {
     return false;
   }
-  const data = asRecord(input.data);
-  const html = data?.html;
+  const html = coerceSurfaceDataRecord(input.data).html;
   return typeof html !== "string" || html.trim().length === 0;
 }
 
@@ -182,8 +180,7 @@ const INTERACTIVE_HTML_RE =
   /<script\b|on[a-z]+\s*=|addEventListener|new Chart\b|window\.vellum\b/i;
 
 function isSubstantialInteractiveHtml(input: Record<string, unknown>): boolean {
-  const data = asRecord(input.data);
-  const html = data?.html;
+  const html = coerceSurfaceDataRecord(input.data).html;
   if (typeof html !== "string") {
     return false;
   }
@@ -195,14 +192,11 @@ function collectRoutingText(input: Record<string, unknown>): string[] {
   addString(values, input.title);
   addString(values, input.activity);
 
-  const data = asRecord(input.data);
-  if (data) {
-    const preview = asRecord(data.preview);
-    if (preview) {
-      addString(values, preview.title);
-      addString(values, preview.subtitle);
-      addString(values, preview.description);
-    }
+  const preview = asRecord(coerceSurfaceDataRecord(input.data).preview);
+  if (preview) {
+    addString(values, preview.title);
+    addString(values, preview.subtitle);
+    addString(values, preview.description);
   }
 
   return values;

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -16,7 +16,10 @@
  * stay accepted, so card has no guard here.
  */
 
-import { FileUploadSurfaceDataSchema } from "../../api/surfaces.js";
+import {
+  coerceSurfaceDataRecord,
+  FileUploadSurfaceDataSchema,
+} from "../../api/surfaces.js";
 
 export function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object"
@@ -258,7 +261,9 @@ export function uiShowTeachingError(
   if (!doc.missingContent) {
     return null;
   }
-  const missing = doc.missingContent(asRecord(input.data) ?? {});
+  // Coerce rather than asRecord: a JSON-string-encoded `data` payload carries
+  // real content, and rejecting it here reports a populated surface as empty.
+  const missing = doc.missingContent(coerceSurfaceDataRecord(input.data));
   if (missing === null) {
     return null;
   }

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -19,6 +19,7 @@
 import {
   coerceSurfaceDataRecord,
   FileUploadSurfaceDataSchema,
+  normalizeCopyBlockShowData,
 } from "../../api/surfaces.js";
 
 export function asRecord(value: unknown): Record<string, unknown> | null {
@@ -65,9 +66,15 @@ interface SurfaceShapeDoc {
    * Returns a description of what keeps the payload from rendering as intended
    * — missing load-bearing content, or keys that would be silently dropped —
    * or null when the payload is fine. Absent for types the daemon normalizes
-   * leniently (card) or that have bespoke handling (dynamic_page).
+   * leniently (card) or that have bespoke handling (dynamic_page). Guards for
+   * types whose daemon normalizer recovers top-level input fields also receive
+   * the full tool `input`, so the guard accepts exactly what the normalizer
+   * accepts.
    */
-  missingContent?: (data: Record<string, unknown>) => string | null;
+  missingContent?: (
+    data: Record<string, unknown>,
+    input: Record<string, unknown>,
+  ) => string | null;
 }
 
 /** templateData shape of a task_progress card (shared with channel variants). */
@@ -88,8 +95,8 @@ export const SURFACE_SHAPE_DOCS: Record<string, SurfaceShapeDoc> = {
     purpose: "copyable text with a visible copy button",
     shape:
       "{ text, label?, language? } — shows copyable text with a visible copy button; use for prompts, commands, paths, or snippets the user should copy",
-    missingContent: (data) =>
-      isNonEmptyString(data.text)
+    missingContent: (data, input) =>
+      isNonEmptyString(normalizeCopyBlockShowData(input, data).text)
         ? null
         : "`data.text` must be a non-empty string",
   },
@@ -263,7 +270,10 @@ export function uiShowTeachingError(
   }
   // Coerce rather than asRecord: a JSON-string-encoded `data` payload carries
   // real content, and rejecting it here reports a populated surface as empty.
-  const missing = doc.missingContent(coerceSurfaceDataRecord(input.data));
+  const missing = doc.missingContent(
+    coerceSurfaceDataRecord(input.data),
+    input,
+  );
   if (missing === null) {
     return null;
   }


### PR DESCRIPTION
## Prompt / plan

Fixes LUM-2579 — `ui_show` surface payload validation missing: `copy_block` (and other surfaces) silently reject valid payloads. Related: LUM-2134, LUM-2565 (superseded), LUM-2788.

**PR 2 of 2 — stacks on #38772** (canonical schemas + type migration + web component cutover, merged). This PR is the behavior half — it wires the canonical schemas into the `ui_show`/`ui_update` entry points, replacing assertion with validation:

1. **Real parse at `surfaceProxyResolver`**: the `input.surface_type as SurfaceType` cast is replaced by a Zod parse. An unknown `surface_type` now returns a descriptive error listing the valid values (previously it fell through to an opaque payload the client silently dropped).
2. **The live copy_block bug**: a `data` payload the model double-encodes as a JSON string (`"data": "{\"text\": ...}"`) used to collapse to `{}` at the teaching-error guard, so a populated `copy_block` was rejected as textless while the user saw nothing. `coerceSurfaceDataRecord()` now recovers JSON-string payloads at both the tool guard (`uiShowTeachingError`, `isEmptyDynamicPage`, `isEmptyUpdate`) and the resolver.
3. **Top-level field recovery, honored at both layers**: copy_block `text`/`label`/`language` and dynamic_page `html` sent outside `data` are recovered — and the tool-level teaching guards apply the same recovery (the copy_block normalizer lives in `@vellumai/assistant-api`, shared by guard and resolver, so the layers can't drift). Covered by end-to-end `uiShowTool.execute` tests.
4. **Every surface type parses through its canonical schema** via `safeParseSurfaceData` — an exhaustive, compiler-checked switch in `api/surfaces.ts` (replacing #38772's erased `Record<SurfaceType, z.ZodType>` registry, which is deleted here) so each schema's output is verified per-type to be a `SurfaceData` member and call sites consume typed results without casts. The hand-rolled choice/oauth_connect/copy_block/file_upload normalizers collapse into schema parses. Behavioral consequence for reviewers: unmodelled `data` keys are now **stripped** before reaching clients for every previously-raw type — `list`, `table`, `confirmation`, `work_result`, `form`, and `document_preview` (`task_preferences` and `channel_setup` stay opaque passthrough). No in-repo client reads keys outside the canonical shapes, but other consumers deserve a second look.
5. **`ui_update` merges validated for every surface type**, not just `card`.

**Cast inventory in the parse path after this PR**: one deliberate, documented cast — the `channel_setup`/`task_preferences` branch inside `safeParseSurfaceData` (opaque payloads no client renders, so there is no canonical shape), plus the pre-existing opaque passthrough for a `ui_update` whose surface has no stored state (surface type unknowable). Remaining `as` narrows elsewhere in `conversation-surfaces.ts` (`stored.data as DynamicPageSurfaceData` after a `surfaceType` check, the `as unknown as UiSurfaceShow` sends) predate this work and need a discriminated-union `surfaceState` refactor to remove — proposed as a follow-up, not smuggled into this diff.

## Test plan

- New regression tests in `assistant/src/__tests__/ui-choice-copy-surfaces.test.ts`: copy_block with JSON-string `data` renders with its text; top-level `text` is recovered — including end-to-end through `uiShowTool.execute` (guard + resolver together) for both copy_block and dynamic_page; unknown `surface_type` returns the descriptive error; the teaching guard accepts JSON-string data and still flags a genuinely textless copy_block.
- `cd assistant && bunx tsc --noEmit` clean; `clients/web` unchanged by this PR.
- Assistant surface suites pass (`ui-*`, `conversation-surfaces-*`, `dynamic-page-surface`, channel variants; 169 tests). Five failures in `conversation-surfaces-launch.test.ts` when run in a multi-file batch reproduce identically on a clean checkout (pre-existing cross-file pollution; the file passes in isolation).
- ESLint + Prettier clean on all touched files (verified by the pre-commit hook).

## CLI verb checklist

No new routes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f