### PR TITLE
feat(web): remove the bookmarks feature flag (GA)

### DIFF
--- a/assistant/src/persistence/schema/bookmarks.ts
+++ b/assistant/src/persistence/schema/bookmarks.ts
@@ -10,8 +10,7 @@ import { conversations, messages } from "./conversations.js";
 
 /**
  * User-saved bookmarks for individual messages. Surfaced in the macOS app
- * Settings → Bookmarks tab and on the message hover overflow menu, behind the
- * `bookmarks` client feature flag.
+ * Settings → Bookmarks tab and on the message hover overflow menu.
  *
  * Both foreign keys CASCADE so bookmarks disappear automatically when their
  * parent message or conversation is deleted. A unique index on `message_id`

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -1,15 +1,5 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-
-// Drive flag values via a module stub (never setState — SSR renders read
-// the store through `use.*` selector hooks).
-mock.module("@/stores/client-feature-flag-store", () => {
-  const store = () => null;
-  store.use = {
-    bookmarks: () => false,
-  };
-  return { useClientFeatureFlagStore: store };
-});
 
 import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions";
 import type { DisplayMessage } from "@/domains/chat/types/types";

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -5,7 +5,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
 import {
-  useBookmarksEnabled,
   useBookmarkToggle,
   useIsBookmarked,
 } from "@/hooks/use-bookmarks";
@@ -103,14 +102,12 @@ export function MessageHoverActions({
 }: MessageHoverActionsProps) {
   const { role } = message;
 
-  // Bookmarks are feature-flag gated, and only persisted messages qualify —
-  // optimistic/streaming rows carry a client-generated id the daemon can't
-  // resolve. The toggle's data hooks live in `MessageBookmarkButton` so they
-  // only mount (and only touch TanStack Query) for bookmarkable rows; that
-  // keeps the flag-off and no-conversation paths free of any query client.
-  const bookmarksEnabled = useBookmarksEnabled();
+  // Only persisted messages qualify for bookmarking — optimistic/streaming
+  // rows carry a client-generated id the daemon can't resolve. The toggle's
+  // data hooks live in `MessageBookmarkButton` so they only mount (and only
+  // touch TanStack Query) for bookmarkable rows; that keeps the
+  // no-conversation path free of any query client.
   const canBookmark =
-    bookmarksEnabled &&
     Boolean(conversationId) &&
     Boolean(message.id) &&
     !message.isOptimistic;

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-long-press-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-long-press-actions.tsx
@@ -13,7 +13,6 @@ import { useCallback, useMemo, useState } from "react";
 import type { MessageHoverActionsProps } from "@/domains/chat/components/message-hover-actions/message-hover-actions";
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
 import {
-  useBookmarksEnabled,
   useBookmarkToggle,
   useIsBookmarked,
 } from "@/hooks/use-bookmarks";
@@ -45,9 +44,7 @@ export function MessageLongPressActions({
   open,
   onOpenChange,
 }: MessageLongPressActionsProps) {
-  const bookmarksEnabled = useBookmarksEnabled();
   const canBookmark =
-    bookmarksEnabled &&
     Boolean(conversationId) &&
     Boolean(message.id) &&
     !message.isOptimistic;

--- a/clients/web/src/domains/settings/settings-layout.test.tsx
+++ b/clients/web/src/domains/settings/settings-layout.test.tsx
@@ -22,7 +22,6 @@ mock.module("@/stores/client-feature-flag-store", () => {
   const store = () => null;
   store.use = {
     platformNotifications: () => clientFlags.platformNotifications ?? false,
-    bookmarks: () => clientFlags.bookmarks ?? false,
     accountMfa: () => clientFlags.accountMfa ?? false,
   };
   return { useClientFeatureFlagStore: store };

--- a/clients/web/src/domains/settings/settings-layout.tsx
+++ b/clients/web/src/domains/settings/settings-layout.tsx
@@ -23,7 +23,6 @@ export function SettingsLayout() {
   const settingsDeveloperNav = useAssistantFeatureFlagStore.use.settingsDeveloperNav();
   const credentialsSettingsEnabled = useAssistantFeatureFlagStore.use.credentialsSettings();
   const platformNotifications = useClientFeatureFlagStore.use.platformNotifications();
-  const bookmarksEnabled = useClientFeatureFlagStore.use.bookmarks();
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   // The Usage item is never hidden: the Usage tab reads from the local daemon
   // and works for every assistant. Its label only gains "Billing &" when the
@@ -47,9 +46,6 @@ export function SettingsLayout() {
         ) {
           return false;
         }
-        if (item.id === "bookmarks" && !bookmarksEnabled) {
-          return false;
-        }
         if (item.id === "credentials" && !credentialsSettingsEnabled) {
           return false;
         }
@@ -63,7 +59,6 @@ export function SettingsLayout() {
     [
       platformNotifications,
       platformGate,
-      bookmarksEnabled,
       credentialsSettingsEnabled,
       billingLabel,
     ],

--- a/clients/web/src/hooks/use-bookmarks.ts
+++ b/clients/web/src/hooks/use-bookmarks.ts
@@ -6,8 +6,7 @@
  * (the per-message hover toggle and the Settings → Bookmarks tab). TanStack is
  * the single source of truth — there is no separate store mirroring the list.
  *
- * The query only runs when the `bookmarks` client feature flag is on AND an
- * assistant is resolved, so flag-off installs never hit the endpoint.
+ * The query only runs once an assistant is resolved.
  *
  * Cross-client invalidation (a bookmark made in another tab/window) is handled
  * by `use-bookmarks-sync.ts`, which listens for the daemon's
@@ -27,7 +26,6 @@ import {
 } from "@/generated/daemon/sdk.gen";
 import type { BookmarksGetResponse } from "@/generated/daemon/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { toast } from "@vellumai/design-library";
 
@@ -36,15 +34,10 @@ export type Bookmark = NonNullable<BookmarksGetResponse>["bookmarks"][number];
 
 const EMPTY_BOOKMARKS: Bookmark[] = [];
 
-/** Whether the `bookmarks` client feature flag is enabled. */
-export function useBookmarksEnabled(): boolean {
-  return useClientFeatureFlagStore.use.bookmarks();
-}
-
 /** Active assistant id + whether the shared bookmark query should run. */
 function useBookmarkQueryGate(): { assistantId: string | null; enabled: boolean } {
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const enabled = useBookmarksEnabled() && Boolean(assistantId);
+  const enabled = Boolean(assistantId);
   return { assistantId, enabled };
 }
 

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -148,14 +148,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "bookmarks",
-      "scope": "client",
-      "key": "bookmarks",
-      "label": "Message Bookmarks",
-      "description": "Show the bookmark icon on messages and enable the Bookmarks tab in Settings",
-      "defaultEnabled": false
-    },
-    {
       "id": "fork-from-message",
       "scope": "client",
       "key": "fork-from-message",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -148,14 +148,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "bookmarks",
-      "scope": "client",
-      "key": "bookmarks",
-      "label": "Message Bookmarks",
-      "description": "Show the bookmark icon on messages and enable the Bookmarks tab in Settings",
-      "defaultEnabled": false
-    },
-    {
       "id": "fork-from-message",
       "scope": "client",
       "key": "fork-from-message",


### PR DESCRIPTION
## Summary
- Delete the `bookmarks` client feature flag from `meta/feature-flags/feature-flag-registry.json` and re-run `meta/sync-bundled-copies.ts` (only the tracked `clients/web` copy shows in the diff; the assistant/gateway copies are gitignored build artifacts).
- Unwind the four flag gates in `clients/web` — `useBookmarksEnabled()` in `use-bookmarks.ts`, the Settings sidebar filter, and the hover/long-press `canBookmark` guards — so bookmarks are always on; the feature implementation is untouched.
- Drop the now-dead flag-store test mocks and a stale doc comment on the `message_bookmarks` schema.

No `vellum-assistant-platform` companion PR: the flag was never provisioned in the LaunchDarkly Terraform (verified by grep), so removal is entirely in this repo.

## Original prompt
The bookmarks feature is ready to GA, so the feature flag should be ripped out entirely rather than default-flipped — the feature becomes unconditionally available. Planned in plan mode first: exploration confirmed the flag is checked only in clients/web (4 call sites, 2 test mocks) and has no platform-side provisioning to clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)