### PR TITLE
fix(slack-text): decode Slack HTML entities so quote markers survive to markdown

### DIFF
--- a/packages/slack-text/src/index.test.ts
+++ b/packages/slack-text/src/index.test.ts
@@ -134,6 +134,43 @@ describe("renderSlackTextForModel", () => {
       }),
     ).toBe("@missing user #missing channel");
   });
+
+  test("decodes Slack HTML entities so quote markers survive to markdown", () => {
+    // Slack entity-encodes every literal &, <, > in message text. `&gt; ` at
+    // line start must decode back to `> ` — markdown resolves entities only
+    // after block parsing, so an encoded marker never forms a blockquote.
+    expect(renderSlackTextForModel("&gt; quoted line\nreply")).toBe(
+      "> quoted line\nreply",
+    );
+    expect(renderSlackTextForModel("1 &lt; 2 &amp;&amp; 3 &gt; 2")).toBe(
+      "1 < 2 && 3 > 2",
+    );
+  });
+
+  test("decodes entities inside link URLs after token rendering", () => {
+    expect(
+      renderSlackTextForModel("<https://example.com?a=1&amp;b=2|docs>"),
+    ).toBe("docs (https://example.com?a=1&b=2)");
+  });
+
+  test("a user-typed literal entity round-trips instead of over-decoding", () => {
+    // Someone typing the four characters `&gt;` in Slack arrives
+    // double-encoded as `&amp;gt;` — one decode pass must yield `&gt;`,
+    // not collapse it all the way to `>`.
+    expect(renderSlackTextForModel("escape it as &amp;gt; in HTML")).toBe(
+      "escape it as &gt; in HTML",
+    );
+  });
+
+  test("decoded angle brackets do not re-enter token parsing", () => {
+    // `&lt;@U123&gt;` is literal text about a mention, not a mention — after
+    // decoding it must render as the characters `<@U123>` untouched.
+    expect(
+      renderSlackTextForModel("say &lt;@U123&gt; to mention", {
+        userLabels: { U123: "Alice" },
+      }),
+    ).toBe("say <@U123> to mention");
+  });
 });
 
 describe("buildSlackUserLabelMap", () => {

--- a/packages/slack-text/src/index.test.ts
+++ b/packages/slack-text/src/index.test.ts
@@ -171,6 +171,40 @@ describe("renderSlackTextForModel", () => {
       }),
     ).toBe("say <@U123> to mention");
   });
+
+  test("caller-resolved labels are never entity-decoded", () => {
+    // Labels come from the caller (resolved display names), not from Slack's
+    // entity-encoded message text — literal entity text in them must pass
+    // through verbatim.
+    expect(
+      renderSlackTextForModel("<@U123>", {
+        userLabels: { U123: "A &gt; B" },
+      }),
+    ).toBe("@A &gt; B");
+  });
+
+  test("an encoded bracket in a display name cannot bypass label sanitization", () => {
+    // sanitizeLabel strips raw brackets from labels; an entity-encoded
+    // bracket must not decode into `<`/`>` after that stripping has run.
+    expect(
+      renderSlackTextForModel("hi <@U123>", {
+        userLabels: { U123: "&lt;fake-token&gt;" },
+      }),
+    ).toBe("hi @&lt;fake-token&gt;");
+  });
+
+  test("token-embedded labels are Slack-sourced and decode before sanitization", () => {
+    expect(renderSlackTextForModel("<#C123|a&amp;b>")).toBe("#a&b");
+    expect(renderSlackTextForModel("<!subteam^S123|eng &amp; data>")).toBe(
+      "@eng & data",
+    );
+  });
+
+  test("unrecognized tokens stay byte-for-byte verbatim", () => {
+    expect(renderSlackTextForModel("<mailbox:a&amp;b>")).toBe(
+      "<mailbox:a&amp;b>",
+    );
+  });
 });
 
 describe("buildSlackUserLabelMap", () => {

--- a/packages/slack-text/src/index.ts
+++ b/packages/slack-text/src/index.ts
@@ -42,32 +42,50 @@ export function renderSlackTextForModel(
   text: string,
   options: RenderSlackTextOptions = {},
 ): string {
-  const rendered = text.replace(/<([^<>\s][^<>]*)>/g, (token, content: string) => {
-    if (content.startsWith("@")) {
-      return renderUserMention(content, options);
-    }
+  // Decode entities per Slack-sourced segment, never on the combined output:
+  // caller-resolved labels (display names, channel names) must pass through
+  // verbatim, so a label containing literal entity text is preserved and an
+  // encoded bracket in a display name cannot decode into `<`/`>` after
+  // sanitizeLabel() has already stripped raw brackets.
+  let result = "";
+  let cursor = 0;
+  for (const match of text.matchAll(/<([^<>\s][^<>]*)>/g)) {
+    result += decodeSlackHtmlEntities(text.slice(cursor, match.index));
+    result += renderSlackToken(match[0], match[1] as string, options);
+    cursor = match.index + match[0].length;
+  }
+  result += decodeSlackHtmlEntities(text.slice(cursor));
+  return result;
+}
 
-    if (content.startsWith("#")) {
-      return renderChannelReference(content, options);
-    }
+function renderSlackToken(
+  token: string,
+  content: string,
+  options: RenderSlackTextOptions,
+): string {
+  if (content.startsWith("@")) {
+    return renderUserMention(content, options);
+  }
 
-    if (content.startsWith("!")) {
-      return renderSpecialReference(content);
-    }
+  if (content.startsWith("#")) {
+    return renderChannelReference(content, options);
+  }
 
-    if (looksLikeUrl(content)) {
-      return renderLink(content);
-    }
+  if (content.startsWith("!")) {
+    return renderSpecialReference(content);
+  }
 
-    return token;
-  });
-  return decodeSlackHtmlEntities(rendered);
+  if (looksLikeUrl(content)) {
+    return renderLink(content);
+  }
+
+  return token;
 }
 
 /**
  * Slack entity-encodes every literal `&`, `<`, and `>` in message text so its
- * own `<...>` control tokens stay unambiguous. Decode them back once the
- * tokens have been rendered — leaving them encoded breaks downstream markdown
+ * own `<...>` control tokens stay unambiguous. Decode them back on the
+ * Slack-sourced segments — leaving them encoded breaks downstream markdown
  * (`&gt; quote` at line start never forms a blockquote, since entities resolve
  * only after block parsing) and shows raw entities to the model. `&lt;`/`&gt;`
  * are decoded before `&amp;` so a user-typed literal `&gt;` (double-encoded by
@@ -180,7 +198,11 @@ function renderChannelReference(
     options.channelFallbackLabel,
     "unknown-channel",
   );
-  const embeddedLabel = sanitizeOptionalLabel(label);
+  // The embedded label is Slack-sourced (part of the token), so entities
+  // decode before sanitization; the caller-resolved label below is not.
+  const embeddedLabel = sanitizeOptionalLabel(
+    label === undefined ? undefined : decodeSlackHtmlEntities(label),
+  );
   if (embeddedLabel && embeddedLabel !== channelId) {
     return `#${embeddedLabel}`;
   }
@@ -206,19 +228,27 @@ function renderSpecialReference(content: string): string {
 
   const subteam = /^!subteam\^[^|>]+(?:\|(.+))?$/.exec(content);
   if (subteam) {
-    return `@${sanitizeLabel(subteam[1], "usergroup")}`;
+    const embedded = subteam[1];
+    return `@${sanitizeLabel(
+      embedded === undefined ? undefined : decodeSlackHtmlEntities(embedded),
+      "usergroup",
+    )}`;
   }
 
   return `<${content}>`;
 }
 
 function renderLink(content: string): string {
-  const [url, label] = splitSlackLabel(content);
-  if (!label) {
+  // Both halves of a link token are Slack-sourced, so entities decode here
+  // (e.g. `&amp;` in URL query strings); sanitizeLabel runs after the decode
+  // so it strips any bracket the decode reintroduced.
+  const [rawUrl, rawLabel] = splitSlackLabel(content);
+  const url = decodeSlackHtmlEntities(rawUrl);
+  if (!rawLabel) {
     return url;
   }
 
-  return `${sanitizeLabel(label, url)} (${url})`;
+  return `${sanitizeLabel(decodeSlackHtmlEntities(rawLabel), url)} (${url})`;
 }
 
 function splitSlackLabel(content: string): [string, string | undefined] {

--- a/packages/slack-text/src/index.ts
+++ b/packages/slack-text/src/index.ts
@@ -42,7 +42,7 @@ export function renderSlackTextForModel(
   text: string,
   options: RenderSlackTextOptions = {},
 ): string {
-  return text.replace(/<([^<>\s][^<>]*)>/g, (token, content: string) => {
+  const rendered = text.replace(/<([^<>\s][^<>]*)>/g, (token, content: string) => {
     if (content.startsWith("@")) {
       return renderUserMention(content, options);
     }
@@ -61,6 +61,23 @@ export function renderSlackTextForModel(
 
     return token;
   });
+  return decodeSlackHtmlEntities(rendered);
+}
+
+/**
+ * Slack entity-encodes every literal `&`, `<`, and `>` in message text so its
+ * own `<...>` control tokens stay unambiguous. Decode them back once the
+ * tokens have been rendered — leaving them encoded breaks downstream markdown
+ * (`&gt; quote` at line start never forms a blockquote, since entities resolve
+ * only after block parsing) and shows raw entities to the model. `&lt;`/`&gt;`
+ * are decoded before `&amp;` so a user-typed literal `&gt;` (double-encoded by
+ * Slack as `&amp;gt;`) round-trips to `&gt;`, not `>`.
+ */
+function decodeSlackHtmlEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
 }
 
 export async function buildSlackUserLabelMap(


### PR DESCRIPTION
## Prompt / plan

Reported symptom: chat messages sometimes render literal `>` carets at line starts instead of turning into a styled blockquote. Traced it to Slack ingress: Slack's API entity-encodes every literal `&`, `<`, `>` in message text (so its own `<...>` control tokens stay unambiguous), but `renderSlackTextForModel` in `packages/slack-text` only unwrapped the tokens (mentions, channels, links) and left the entities encoded. A Slack message quoting with `> text` therefore reached the daemon and web transcript as `&gt; text` — and CommonMark resolves entities only *after* block parsing, so the blockquote never forms and the caret renders as literal text. Link URLs likewise carried raw `&amp;` in query strings. Non-Slack messages are unaffected, which is why the symptom was intermittent.

Fix: decode `&lt;` / `&gt;` / `&amp;` after the token-rendering pass, in `renderSlackTextForModel` so both callers (gateway inbound normalization and the assistant's Slack adapter history/search rendering) are covered. Two ordering invariants, both pinned by tests:

- decode runs **after** token rendering, so decoded angle brackets (`&lt;@U123&gt;` → literal `<@U123>`) can never re-enter token parsing and manufacture a mention;
- `&lt;`/`&gt;` decode **before** `&amp;`, so a user-typed literal `&gt;` (double-encoded by Slack as `&amp;gt;`) round-trips to `&gt;` instead of over-decoding to `>`.

## Test plan

- New tests: quote marker at line start decodes (`&gt; quoted` → `> quoted`), mixed comparison text, entities inside link URLs, double-encoded round-trip, and decoded brackets not re-entering token parsing. `packages/slack-text`: 25 pass.
- Gateway Slack normalize suites: 129 pass. Assistant Slack provider suite runs with the same 19 pre-existing environment failures as pristine `main` (verified by running both states) — no new failures.
- `packages/slack-text` typecheck passes.

## CLI verb checklist

No new routes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPEsEduoBTUyfbpLirzdAu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPEsEduoBTUyfbpLirzdAu)_