### PR TITLE
feat(billing): classify Pro plans as Free / Named / Custom, with one-click switch for Custom subs

### DIFF
--- a/clients/web/src/domains/settings/billing/package-types.ts
+++ b/clients/web/src/domains/settings/billing/package-types.ts
@@ -30,6 +30,14 @@ export function packageRank(key: string): number {
 export type TierRelation = "current" | "downgrade" | "upgrade";
 
 /**
+ * The relation a package-switch confirm expresses: any `TierRelation` except
+ * "current" (you never confirm a switch to your own tier), plus "switch" — the
+ * direction-neutral variant for a Custom sub whose real tiers can diverge from
+ * any stock package, so the change has no knowable up/down direction.
+ */
+export type SwitchRelation = Exclude<TierRelation, "current"> | "switch";
+
+/**
  * Classify a target tier relative to the user's current tier. When the current
  * tier is unknown (null, or an unrecognized key), or the target tier is
  * unrecognized, the result defaults to "upgrade", preserving base-user

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
@@ -8,8 +8,12 @@ import { Typography } from "@vellumai/design-library/components/typography";
 
 export interface PackageSwitchConfirmModalProps {
   open: boolean;
-  /** How the target relates to the current tier — drives copy and chrome. */
-  relation: Exclude<TierRelation, "current">;
+  /**
+   * How the target relates to the current tier — drives copy and chrome.
+   * "switch" is the direction-neutral variant for a Custom sub, whose catalog
+   * rank is unknown, so up-vs-down cannot be labelled.
+   */
+  relation: Exclude<TierRelation, "current"> | "switch";
   /** Target package display name, e.g. "Mighty". */
   packageName: string;
   /** A change-package call is in flight — disable the actions. */
@@ -25,11 +29,16 @@ export interface PackageSwitchConfirmModalProps {
 const DOWNGRADE_NOTE =
   "Your machine downsizes now and your storage stays. No refund — a prorated credit applies to your next invoice.";
 const UPGRADE_NOTE = "You'll be charged the prorated difference now.";
+// A Custom sub's direction is unknown, so the copy stays neutral: the change is
+// immediate and the prorated difference settles either way.
+const SWITCH_NOTE =
+  "Your plan changes now. Any prorated difference is charged now or credited to your next invoice.";
 
 /**
  * Reconfirm dialog for a one-click Pro package switch from the plans takeover.
- * A downgrade gets the AlertTriangle + danger confirm; an upgrade gets a
- * lighter primary confirm. Layout-only — the parent owns the mutation.
+ * A downgrade gets the AlertTriangle + danger confirm; an upgrade and a
+ * direction-neutral switch get a lighter primary confirm. Layout-only — the
+ * parent owns the mutation.
  */
 export function PackageSwitchConfirmModal({
   open,
@@ -40,6 +49,17 @@ export function PackageSwitchConfirmModal({
   onConfirm,
 }: PackageSwitchConfirmModalProps) {
   const isDowngrade = relation === "downgrade";
+  const isSwitch = relation === "switch";
+  const title = isDowngrade
+    ? `Downgrade to ${packageName}?`
+    : isSwitch
+      ? `Switch to ${packageName}?`
+      : `Upgrade to ${packageName}?`;
+  const note = isDowngrade
+    ? DOWNGRADE_NOTE
+    : isSwitch
+      ? SWITCH_NOTE
+      : UPGRADE_NOTE;
   return (
     <Modal.Root
       open={open}
@@ -52,9 +72,7 @@ export function PackageSwitchConfirmModal({
       <Modal.Content size="md" hideCloseButton>
         <Modal.Header>
           <Modal.Title icon={isDowngrade ? AlertTriangle : undefined}>
-            {isDowngrade
-              ? `Downgrade to ${packageName}?`
-              : `Upgrade to ${packageName}?`}
+            {title}
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
@@ -63,7 +81,7 @@ export function PackageSwitchConfirmModal({
             variant="body-medium-default"
             className="text-(--content-secondary)"
           >
-            {isDowngrade ? DOWNGRADE_NOTE : UPGRADE_NOTE}
+            {note}
           </Typography>
         </Modal.Body>
         <Modal.Footer>

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
@@ -1,6 +1,6 @@
 import { AlertTriangle } from "lucide-react";
 
-import type { TierRelation } from "@/domains/settings/billing/package-types";
+import type { SwitchRelation } from "@/domains/settings/billing/package-types";
 import { downgradeLabel } from "@/domains/settings/billing/plans/plans-copy";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
@@ -13,7 +13,7 @@ export interface PackageSwitchConfirmModalProps {
    * "switch" is the direction-neutral variant for a Custom sub, whose catalog
    * rank is unknown, so up-vs-down cannot be labelled.
    */
-  relation: Exclude<TierRelation, "current"> | "switch";
+  relation: SwitchRelation;
   /** Target package display name, e.g. "Mighty". */
   packageName: string;
   /** A change-package call is in flight — disable the actions. */
@@ -94,7 +94,9 @@ export function PackageSwitchConfirmModal({
             disabled={pending}
             data-testid="confirm-package-switch-button"
           >
-            {isDowngrade ? downgradeLabel(packageName) : `Switch to ${packageName}`}
+            {isDowngrade
+              ? downgradeLabel(packageName)
+              : `Switch to ${packageName}`}
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -645,20 +645,12 @@ describe("PlansPage — Pro package switch (change-package)", () => {
   });
 });
 
-// A Pro sub that isn't cleanly packaged (customized, cancelling, or in a
-// non-entitlement status) can't switch in place — the change-package endpoint
-// would 4xx. Clicking a package CTA must route it to the billing manage/cancel
-// surface (`?adjust_plan`) instead of posting change-package, matching the
-// plan-card banner's fallback.
+// A cancelling or non-entitlement-status Pro sub can't switch in place — the
+// change-package endpoint would 4xx. Clicking a package CTA must route it to the
+// billing manage/cancel surface (`?adjust_plan`) instead of posting
+// change-package, matching the plan-card banner's fallback.
 describe("PlansPage — ineligible Pro subs route to manage", () => {
   const ineligible: Array<[string, SubscriptionResponse]> = [
-    [
-      "customized",
-      {
-        ...proMightySubscription(),
-        package: { key: "mighty", name: "Mighty", version: 1, customized: true },
-      },
-    ],
     ["cancelling", { ...proMightySubscription(), cancel_at_period_end: true }],
     ["non-entitlement status", { ...proMightySubscription(), status: "unpaid" }],
   ];
@@ -680,6 +672,84 @@ describe("PlansPage — ineligible Pro subs route to manage", () => {
       expect(upgradeCall).toBeNull();
     });
   }
+});
+
+// A Custom sub — one with no package pin, or a customized (diverged) pin — has
+// no catalog rank. Every named card is a switch target: the confirm dialog uses
+// direction-neutral copy, and a successful switch opens the provisioning
+// takeover. A customized sub can even re-pin its own key (revert to stock).
+describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
+  function proUnpinnedSubscription(): SubscriptionResponse {
+    return {
+      plan_id: "pro",
+      status: "active",
+      renewal_date: null,
+      current_period_end: "2026-07-10T00:00:00Z",
+      cancel_at_period_end: false,
+      cancel_at: null,
+      package: null,
+      entitlements: { managed_email: false, phone_number: false },
+    };
+  }
+
+  function proCustomizedMightySubscription(): SubscriptionResponse {
+    return {
+      ...proMightySubscription(),
+      package: { key: "mighty", name: "Mighty", version: 1, customized: true },
+    };
+  }
+
+  test("an unpinned Pro sub's card opens the neutral 'Switch to' confirm and posts change-package", async () => {
+    const { findByRole, findByText, findByTestId } = renderInteractive(
+      proUnpinnedSubscription(),
+    );
+
+    // With no pin the card carries its plain upgrade CTA ("Power Up" for Mighty).
+    fireEvent.click(await findByRole("button", { name: "Power Up" }));
+
+    // The direction-neutral switch confirm appears (not upgrade/downgrade copy).
+    await findByText("Switch to Mighty?");
+    await findByText(
+      "Your plan changes now. Any prorated difference is charged now or credited to your next invoice.",
+    );
+
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+
+    await waitFor(() => expect(changePackageCall).not.toBeNull());
+    expect(changePackageCall!.body).toEqual({ package: "mighty" });
+    await findByTestId("resize-takeover");
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("a customized-pinned sub can re-select its own package (revert to stock), no 'current' short-circuit", async () => {
+    const { findByRole, findByText, findByTestId } = renderInteractive(
+      proCustomizedMightySubscription(),
+    );
+
+    // The customized sub's own Mighty card is not "current" — its CTA is live.
+    fireEvent.click(await findByRole("button", { name: "Power Up" }));
+
+    await findByText("Switch to Mighty?");
+    fireEvent.click(await findByTestId("confirm-package-switch-button"));
+
+    await waitFor(() => expect(changePackageCall).not.toBeNull());
+    expect(changePackageCall!.body).toEqual({ package: "mighty" });
+  });
+
+  test("a Custom sub's Free card is a downgrade and no named card renders as current", () => {
+    const html = renderStatic(
+      {
+        ...proMightySubscription(),
+        package: { key: "mighty", name: "Mighty", version: 1, customized: true },
+      },
+      fullCatalog(),
+    );
+    // Pro → Free is always a downgrade.
+    expect(html).toContain("Downgrade to Free");
+    expect(html).not.toContain("Start Free");
+    // A Custom sub has no catalog rank, so no card is the current plan.
+    expect(count(html, /Current Plan/g)).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -19,15 +19,14 @@
  *    and the base-user Stripe checkout path.
  */
 
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
-import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter, useLocation } from "react-router";
@@ -456,7 +455,10 @@ function renderInteractive(
   {
     plans = fullCatalog(),
     onboardingData = onboarding(),
-  }: { plans?: PlanListResponse; onboardingData?: OnboardingStateResponse } = {},
+  }: {
+    plans?: PlanListResponse;
+    onboardingData?: OnboardingStateResponse;
+  } = {},
 ) {
   subscriptionFixture = subscription;
   plansFixture = plans;
@@ -521,7 +523,9 @@ describe("PlansPage — Pro package switch (change-package)", () => {
       renderInteractive(proSuperSubscription());
 
     // Click the Mighty column's downgrade CTA (below Super).
-    fireEvent.click(await findByRole("button", { name: "Downgrade to Mighty" }));
+    fireEvent.click(
+      await findByRole("button", { name: "Downgrade to Mighty" }),
+    );
 
     // The reconfirm dialog appears; confirm it.
     fireEvent.click(await findByTestId("confirm-package-switch-button"));
@@ -592,9 +596,13 @@ describe("PlansPage — Pro package switch (change-package)", () => {
 
   test("the confirm CTA is disabled while a switch is pending", async () => {
     changePackageAutoResolve = false;
-    const { findByRole, findByTestId } = renderInteractive(proSuperSubscription());
+    const { findByRole, findByTestId } = renderInteractive(
+      proSuperSubscription(),
+    );
 
-    fireEvent.click(await findByRole("button", { name: "Downgrade to Mighty" }));
+    fireEvent.click(
+      await findByRole("button", { name: "Downgrade to Mighty" }),
+    );
     const confirm = (await findByTestId(
       "confirm-package-switch-button",
     )) as HTMLButtonElement;
@@ -631,7 +639,9 @@ describe("PlansPage — Pro package switch (change-package)", () => {
       proSuperSubscription(),
     );
 
-    fireEvent.click(await findByRole("button", { name: "Downgrade to Mighty" }));
+    fireEvent.click(
+      await findByRole("button", { name: "Downgrade to Mighty" }),
+    );
     fireEvent.click(await findByTestId("confirm-package-switch-button"));
 
     await waitFor(() => expect(changePackageCall).not.toBeNull());
@@ -652,7 +662,10 @@ describe("PlansPage — Pro package switch (change-package)", () => {
 describe("PlansPage — ineligible Pro subs route to manage", () => {
   const ineligible: Array<[string, SubscriptionResponse]> = [
     ["cancelling", { ...proMightySubscription(), cancel_at_period_end: true }],
-    ["non-entitlement status", { ...proMightySubscription(), status: "unpaid" }],
+    [
+      "non-entitlement status",
+      { ...proMightySubscription(), status: "unpaid" },
+    ],
   ];
 
   for (const [label, subscription] of ineligible) {
@@ -737,13 +750,7 @@ describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
   });
 
   test("a Custom sub's Free card is a downgrade and no named card renders as current", () => {
-    const html = renderStatic(
-      {
-        ...proMightySubscription(),
-        package: { key: "mighty", name: "Mighty", version: 1, customized: true },
-      },
-      fullCatalog(),
-    );
+    const html = renderStatic(proCustomizedMightySubscription(), fullCatalog());
     // Pro → Free is always a downgrade.
     expect(html).toContain("Downgrade to Free");
     expect(html).not.toContain("Start Free");

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -7,6 +7,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   PACKAGE_ORDER,
   type ProPackage,
+  type TierRelation,
   tierRelation,
 } from "@/domains/settings/billing/package-types";
 import { FREE_STORAGE_GIB } from "@/domains/settings/billing/plan-tier-meta";
@@ -269,10 +270,16 @@ export function PlansPage() {
 
   let body: ReactNode;
   if (subscription && proPlan && hasPackages) {
+    // A Custom sub (unpinned or customized) has no meaningful catalog rank, so
+    // it has no current tier: every named card is offered as a switch target —
+    // including a customized sub's own pinned key, which is a real
+    // revert-to-stock operation.
     const currentTierKey =
       subscription.plan_id === "base"
         ? "free"
-        : (subscription.package?.key ?? null);
+        : subscription.package && !subscription.package.customized
+          ? subscription.package.key
+          : null;
 
     const selectTier = (tierKey: string) => {
       if (isProUser) {
@@ -293,10 +300,11 @@ export function PlansPage() {
         if (tierRelation(currentTierKey, pkg.key) === "current") {
           return;
         }
-        // Only a clean packaged Pro sub can switch in place. A customized,
-        // cancelling, or non-entitlement-status sub can't — route it to the
-        // billing manage/cancel surface instead of posting a change-package that
-        // can only fail (the same fallback the Pro → Free case uses).
+        // Any active Pro sub — pinned, unpinned, or customized — switches in
+        // place via change-package. Only a cancelling or non-entitlement-status
+        // sub can't; route it to the billing manage/cancel surface instead of
+        // posting a change-package that can only fail (the same fallback the
+        // Pro → Free case uses).
         if (!isPackageSwitchEligible(subscription)) {
           navigate(`${routes.settings.usage}?tab=billing&adjust_plan`);
           return;
@@ -337,6 +345,9 @@ export function PlansPage() {
       // status === "ok": only an upgrade grows the machine, so only it needs
       // the resize/provisioning takeover. A downgrade caps the machine down
       // immediately server-side with no apply/restart step, so just confirm it.
+      // A Custom-sub switch has unknown direction, so it lands here as "upgrade"
+      // and opens the takeover — the provisioning step is grow-only/idempotent
+      // server-side, so it is the safe default when direction is unknown.
       if (relation === "downgrade") {
         toast.success(`Downgraded to ${target.name}.`);
       } else {
@@ -344,9 +355,17 @@ export function PlansPage() {
       }
     };
 
-    const switchRelation = switchTarget
-      ? tierRelation(currentTierKey, switchTarget.key)
-      : "upgrade";
+    // A Custom sub (currentTierKey null) can't be ranked against the target, so
+    // the confirm copy stays direction-neutral ("switch"); a clean-pinned sub
+    // gets the directional up/down copy.
+    const switchRelation: Exclude<TierRelation, "current"> | "switch" =
+      switchTarget
+        ? currentTierKey === null
+          ? "switch"
+          : tierRelation(currentTierKey, switchTarget.key) === "downgrade"
+            ? "downgrade"
+            : "upgrade"
+        : "upgrade";
 
     const startCustomCheckout = (selection: CustomPlanSelection) =>
       startCheckout({
@@ -405,7 +424,12 @@ export function PlansPage() {
         PACKAGE_ORDER.indexOf(b.key as (typeof PACKAGE_ORDER)[number]),
     );
     const freeCopy = getPlanTierCopy("free");
-    const freeRelation = tierRelation(currentTierKey, "free");
+    // Pro → Free is always a downgrade (cancellation), even for a Custom sub
+    // whose currentTierKey is null; `selectTier("free")` cancel routing is
+    // unchanged.
+    const freeRelation = isProUser
+      ? "downgrade"
+      : tierRelation(currentTierKey, "free");
 
     body = (
       <div className="my-auto flex w-full flex-col items-center">
@@ -501,7 +525,7 @@ export function PlansPage() {
 
         <PackageSwitchConfirmModal
           open={switchTarget !== null}
-          relation={switchRelation === "downgrade" ? "downgrade" : "upgrade"}
+          relation={switchRelation}
           packageName={switchTarget?.name ?? ""}
           pending={changePackagePending}
           onCancel={() => setSwitchTarget(null)}

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -7,7 +7,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   PACKAGE_ORDER,
   type ProPackage,
-  type TierRelation,
+  type SwitchRelation,
   tierRelation,
 } from "@/domains/settings/billing/package-types";
 import { FREE_STORAGE_GIB } from "@/domains/settings/billing/plan-tier-meta";
@@ -358,14 +358,13 @@ export function PlansPage() {
     // A Custom sub (currentTierKey null) can't be ranked against the target, so
     // the confirm copy stays direction-neutral ("switch"); a clean-pinned sub
     // gets the directional up/down copy.
-    const switchRelation: Exclude<TierRelation, "current"> | "switch" =
-      switchTarget
-        ? currentTierKey === null
-          ? "switch"
-          : tierRelation(currentTierKey, switchTarget.key) === "downgrade"
-            ? "downgrade"
-            : "upgrade"
-        : "upgrade";
+    const switchRelation: SwitchRelation = switchTarget
+      ? currentTierKey === null
+        ? "switch"
+        : tierRelation(currentTierKey, switchTarget.key) === "downgrade"
+          ? "downgrade"
+          : "upgrade"
+      : "upgrade";
 
     const startCustomCheckout = (selection: CustomPlanSelection) =>
       startCheckout({

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -79,9 +79,11 @@ export interface UseChangeTiersResult {
  * any error as a toast.
  *
  * `eligible` is true only for an active, non-cancelling Pro sub in an
- * entitlement-bearing status — the change-tier endpoints 4xx otherwise. Unlike
- * `isPackageSwitchEligible`, a customized sub is allowed: a custom tier config
- * is exactly what this flow edits.
+ * entitlement-bearing status — the change-tier endpoints 4xx otherwise. A
+ * customized sub qualifies: editing a custom tier config is exactly what this
+ * flow does. This mirrors `isPackageSwitchEligible`, which also admits
+ * customized (and unpinned) Pro subs; the difference is that this flow edits
+ * individual tiers in place, while the package switch re-pins to a named plan.
  *
  * Pass `enabled` (the caller's platform-hosted gate) to hold the org-scoped
  * reads until the page is ready; they are also gated on org-header readiness.
@@ -131,7 +133,8 @@ export function useChangeTiers({
 
   const current: CurrentTiers = {
     machineTier:
-      (onboardingQuery.data?.max_machine_tier as MachineTierEnum | null) ?? null,
+      (onboardingQuery.data?.max_machine_tier as MachineTierEnum | null) ??
+      null,
     storageTier:
       (onboardingQuery.data?.selected_storage_tier as StorageTierEnum | null) ??
       null,
@@ -272,7 +275,10 @@ export function useChangeTiers({
     if (failures.length > 0) {
       const message = failures
         .map((f) =>
-          extractMutationError(f.error, `Failed to update ${f.dimension} tier.`),
+          extractMutationError(
+            f.error,
+            `Failed to update ${f.dimension} tier.`,
+          ),
         )
         .join(" ");
       toast.error(message);

--- a/clients/web/src/domains/settings/components/adjust-plan-utils.ts
+++ b/clients/web/src/domains/settings/components/adjust-plan-utils.ts
@@ -21,12 +21,17 @@ export const TIER_CHANGE_ELIGIBLE_STATUSES: ReadonlySet<SubscriptionStatusEnum> 
 
 /**
  * Whether a subscription is eligible for a one-click, in-place package switch
- * via the change-package endpoint. True only for a clean packaged Pro sub: it
- * has a package pin, is not customized (a customized sub's tiers can diverge
- * from the stock package, so posting the next stock key would use wrong deltas
- * / drop custom line items), is not cancelling (a cancelling sub 409s on
- * change-package), and sits in an entitlement-bearing status. Every other Pro
- * state — and every base sub — falls back to the manage path.
+ * via the change-package endpoint. True for any active Pro sub — pinned,
+ * unpinned, or customized. The platform's `change_package` action re-pins the
+ * sub to a named plan by 3-way-diffing the current Stripe line items per
+ * dimension, so posting a stock key from a diverged sub is safe: it is exactly
+ * the "override back to a named plan" flow. A true pre-catalog legacy sub (no
+ * tier metadata) returns a clean 409 whose `detail` surfaces as a toast via
+ * `useChangePackage` → `extractMutationError` (which reads the `detail` key).
+ *
+ * A cancelling sub (change-package 409s) and a non-entitlement status still gate
+ * out, as does every base sub. Every other Pro state falls back to the manage
+ * path.
  *
  * Shared by both change-package surfaces (plan-card banner, plans takeover) so
  * the eligibility gate stays symmetric across them.
@@ -36,8 +41,6 @@ export function isPackageSwitchEligible(
 ): boolean {
   return (
     subscription.plan_id !== "base" &&
-    subscription.package != null &&
-    !subscription.package.customized &&
     subscription.cancel_at_period_end !== true &&
     !subscription.cancel_at &&
     subscription.status != null &&

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -378,6 +378,50 @@ describe("PlanCard", () => {
     expect(html).not.toContain("Pro");
   });
 
+  test("an unpinned Custom sub's banner drops the stock upgrade framing", () => {
+    // A legacy unpinned Pro sub's real tiers can diverge from any stock
+    // package, so the banner offers the named plan neutrally: a "Switch plan"
+    // tag and a "Switch to Mighty" CTA, with no "Recommended Upgrade" claim and
+    // no stock price/resource deltas that could point the wrong way.
+    const subscription: SubscriptionResponse = {
+      ...proMightySubscription(),
+      package: null,
+    };
+    const html = renderCard(subscription, plansWithSuper());
+    expect(html).toContain("recommended-upgrade-button");
+    expect(html).toContain("Switch plan");
+    expect(html).toContain("Switch to Mighty");
+    expect(html).not.toContain("Recommended Upgrade");
+    expect(html).not.toContain("credits/mo");
+    expect(html).not.toContain("Larger machines");
+  });
+
+  test("a customized Pro sub's banner drops the stock upgrade framing", () => {
+    const subscription = proMightySubscription();
+    subscription.package = {
+      key: "mighty",
+      name: "Mighty",
+      version: 1,
+      customized: true,
+    };
+    const html = renderCard(subscription, plansWithSuper());
+    // Recommended package is Super (next after the Mighty pin), offered as a
+    // neutral switch since the customized tiers can differ from stock Super.
+    expect(html).toContain("Switch plan");
+    expect(html).toContain("Switch to Super");
+    expect(html).not.toContain("Recommended Upgrade");
+    expect(html).not.toContain("credits/mo");
+  });
+
+  test("a base user's banner keeps the directional upgrade framing", () => {
+    // Base → Pro is a genuine Stripe-checkout upgrade, so the banner keeps its
+    // "Recommended Upgrade" tag, the "Upgrade for … more" CTA, and stock deltas.
+    const html = renderCard(baseSubscription(), basePlansResponse());
+    expect(html).toContain("Recommended Upgrade");
+    expect(html).toContain("Upgrade for");
+    expect(html).not.toContain("Switch plan");
+  });
+
   test("current-plan row labels a customized package as custom", () => {
     const subscription = proMightySubscription();
     subscription.package = {
@@ -517,8 +561,10 @@ describe("PlanCard recommended upgrade — change-package", () => {
       onTierUpgraded,
     );
 
-    // The banner CTA opens a confirm dialog (no immediate mutation).
+    // The banner CTA opens a confirm dialog (no immediate mutation). A clean pin
+    // keeps the directional upgrade copy.
     fireEvent.click(await findByTestId("recommended-upgrade-button"));
+    await findByText("Upgrade to Super?");
     await findByText("You'll be charged the prorated difference now.");
     expect(changePackageBody).toBeNull();
 
@@ -579,7 +625,12 @@ describe("PlanCard recommended upgrade — change-package", () => {
       release({
         data: {
           status: "ok",
-          package: { key: "super", name: "Super", version: 1, customized: false },
+          package: {
+            key: "super",
+            name: "Super",
+            version: 1,
+            customized: false,
+          },
         } as PackageChangeResponse,
         response: { ok: true },
       });
@@ -624,41 +675,40 @@ describe("PlanCard recommended upgrade — change-package", () => {
     expect(onTierUpgraded).not.toHaveBeenCalled();
   });
 
-  test("a package-less Pro sub's recommended upgrade stays on the manage path", async () => {
+  test("an unpinned Pro sub's recommended upgrade opens the neutral switch confirm", async () => {
     const onManage = mock(() => {});
     const onTierUpgraded = mock(() => {});
-    // A legacy/custom Pro sub has no pinned package, so change-package (which
-    // operates only on named packages) can't switch it. The banner CTA must
-    // fall back to the manage path instead of confirming a change to Mighty.
-    const subscription = { ...proMightySubscription(), package: undefined };
-    const { findByTestId } = renderCardInteractive(
+    // An unpinned (Custom) Pro sub is switch-eligible, so the banner CTA reaches
+    // the change-package confirm rather than the manage fallback. Its catalog
+    // rank is unknown, so the confirm copy stays direction-neutral.
+    const subscription: SubscriptionResponse = {
+      ...proMightySubscription(),
+      package: null,
+    };
+    const { findByTestId, findByText } = renderCardInteractive(
       subscription,
       plansWithSuper(),
       onManage,
       onTierUpgraded,
     );
 
+    // The banner renders and its CTA opens the neutral switch confirm (currentKey
+    // is null, so the recommended package is Mighty).
     fireEvent.click(await findByTestId("recommended-upgrade-button"));
-
-    await waitFor(() => {
-      expect(onManage).toHaveBeenCalledTimes(1);
-    });
-    // No confirm dialog, no change-package mutation, no navigation.
-    expect(
-      document.querySelector("[data-testid='confirm-package-switch-button']"),
-    ).toBeNull();
-    expect(changePackageBody).toBeNull();
-    expect(onTierUpgraded).not.toHaveBeenCalled();
+    await findByText("Switch to Mighty?");
+    await findByText(
+      "Your plan changes now. Any prorated difference is charged now or credited to your next invoice.",
+    );
+    expect(onManage).not.toHaveBeenCalled();
     expect(navigateArgs).toEqual([]);
-    expect(openedUrl).toBeNull();
   });
 
-  test("a customized Pro sub's recommended upgrade stays on the manage path", async () => {
+  test("a customized Pro sub's recommended upgrade opens the neutral switch confirm", async () => {
     const onManage = mock(() => {});
     const onTierUpgraded = mock(() => {});
-    // A customized sub's tiers can diverge from the stock package, so posting the
-    // next stock package key would use wrong deltas / drop custom line items. The
-    // banner CTA must fall back to the manage path instead of confirming a change.
+    // A customized pin is switch-eligible; the change-package endpoint re-pins it
+    // to the named target. Its catalog rank is ambiguous, so the confirm copy
+    // stays direction-neutral instead of claiming an upgrade.
     const subscription = proMightySubscription();
     subscription.package = {
       key: "mighty",
@@ -666,24 +716,21 @@ describe("PlanCard recommended upgrade — change-package", () => {
       version: 1,
       customized: true,
     };
-    const { findByTestId } = renderCardInteractive(
+    const { findByTestId, findByText } = renderCardInteractive(
       subscription,
       plansWithSuper(),
       onManage,
       onTierUpgraded,
     );
 
+    // Recommended package is Super (next after the customized Mighty pin).
     fireEvent.click(await findByTestId("recommended-upgrade-button"));
-
-    await waitFor(() => {
-      expect(onManage).toHaveBeenCalledTimes(1);
-    });
-    // No confirm dialog, no change-package mutation, no navigation.
-    expect(document.querySelector("[data-testid='confirm-package-switch-button']")).toBeNull();
-    expect(changePackageBody).toBeNull();
-    expect(onTierUpgraded).not.toHaveBeenCalled();
+    await findByText("Switch to Super?");
+    await findByText(
+      "Your plan changes now. Any prorated difference is charged now or credited to your next invoice.",
+    );
+    expect(onManage).not.toHaveBeenCalled();
     expect(navigateArgs).toEqual([]);
-    expect(openedUrl).toBeNull();
   });
 
   test("a cancelling Pro sub's recommended upgrade stays on the manage path", async () => {
@@ -708,7 +755,9 @@ describe("PlanCard recommended upgrade — change-package", () => {
       expect(onManage).toHaveBeenCalledTimes(1);
     });
     // No confirm dialog, no change-package mutation, no navigation.
-    expect(document.querySelector("[data-testid='confirm-package-switch-button']")).toBeNull();
+    expect(
+      document.querySelector("[data-testid='confirm-package-switch-button']"),
+    ).toBeNull();
     expect(changePackageBody).toBeNull();
     expect(onTierUpgraded).not.toHaveBeenCalled();
     expect(navigateArgs).toEqual([]);
@@ -739,7 +788,9 @@ describe("PlanCard recommended upgrade — change-package", () => {
       expect(onManage).toHaveBeenCalledTimes(1);
     });
     // No confirm dialog, no change-package mutation, no navigation.
-    expect(document.querySelector("[data-testid='confirm-package-switch-button']")).toBeNull();
+    expect(
+      document.querySelector("[data-testid='confirm-package-switch-button']"),
+    ).toBeNull();
     expect(changePackageBody).toBeNull();
     expect(onTierUpgraded).not.toHaveBeenCalled();
     expect(navigateArgs).toEqual([]);

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -392,6 +392,19 @@ describe("PlanCard", () => {
     expect(html).toContain("Custom");
     expect(html).not.toContain("Mighty (Custom)");
   });
+
+  test("current-plan row labels an unpinned Pro sub as custom", () => {
+    // A legacy Pro sub with no pinned package reads "Custom", not the generic
+    // plan name "Pro".
+    const subscription: SubscriptionResponse = {
+      ...proMightySubscription(),
+      package: null,
+    };
+    const html = renderCard(subscription, plansWithSuper());
+    expect(html).toContain("plan-card-name");
+    expect(html).toContain("Custom");
+    expect(html).not.toContain("Pro");
+  });
 });
 
 describe("PlanCard action button", () => {

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -16,7 +16,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   nextPackageUp,
   type ProPackage,
-  type TierRelation,
+  type SwitchRelation,
 } from "@/domains/settings/billing/package-types";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
@@ -194,7 +194,7 @@ interface RecommendedUpgradeProps {
    * copy. A clean pin's next package is an "upgrade"; a customized or unpinned
    * (Custom) sub gets the direction-neutral "switch".
    */
-  relation: Exclude<TierRelation, "current"> | "switch";
+  relation: SwitchRelation;
   /**
    * Manage-path delegate (AdjustPlanModal). Handles a cancelling or
    * non-entitlement Pro sub that the change-package flow cannot switch, and the
@@ -496,7 +496,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   // Custom Pro sub — a customized pin or an unpinned legacy sub, whose real
   // tiers can diverge from any stock package — gets the direction-neutral
   // switch, since a stock delta could misstate the change.
-  const switchRelation: Exclude<TierRelation, "current"> | "switch" =
+  const switchRelation: SwitchRelation =
     currentPlan.id === "base" ||
     (subscription.package && !subscription.package.customized)
       ? "upgrade"

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -1,4 +1,11 @@
-import { Coins, Computer, HardDrive, Loader2, Rocket, Sparkles } from "lucide-react";
+import {
+  Coins,
+  Computer,
+  HardDrive,
+  Loader2,
+  Rocket,
+  Sparkles,
+} from "lucide-react";
 
 import { useState } from "react";
 
@@ -7,27 +14,28 @@ import { useNavigate } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
-    nextPackageUp,
-    type ProPackage,
+  nextPackageUp,
+  type ProPackage,
+  type TierRelation,
 } from "@/domains/settings/billing/package-types";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import {
-    FREE_STORAGE_GIB,
-    PlanTierAvatar,
-    TIER_ACCENT,
+  FREE_STORAGE_GIB,
+  PlanTierAvatar,
+  TIER_ACCENT,
 } from "@/domains/settings/billing/plan-tier-meta";
 import { useCheckoutDismissRefresh } from "@/domains/settings/billing/use-checkout-dismiss-refresh";
 import {
-    formatGraceDate,
-    getEffectiveCancelDate,
+  formatGraceDate,
+  getEffectiveCancelDate,
 } from "@/domains/settings/hooks/use-billing-portal-session";
 import {
-    organizationsBillingPlansRetrieveOptions,
-    organizationsBillingPlansRetrieveQueryKey,
-    organizationsBillingSubscriptionRetrieveOptions,
-    organizationsBillingSubscriptionRetrieveQueryKey,
-    organizationsBillingSubscriptionUpgradeCreateMutation,
+  organizationsBillingPlansRetrieveOptions,
+  organizationsBillingPlansRetrieveQueryKey,
+  organizationsBillingSubscriptionRetrieveOptions,
+  organizationsBillingSubscriptionRetrieveQueryKey,
+  organizationsBillingSubscriptionUpgradeCreateMutation,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { MachineSizeEnum, ProPlan } from "@/generated/api/types.gen";
 import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
@@ -43,55 +51,55 @@ import { Tag } from "@vellumai/design-library/components/tag";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 import {
-    extractMutationError,
-    isPackageSwitchEligible,
+  extractMutationError,
+  isPackageSwitchEligible,
 } from "./adjust-plan-utils";
 import { formatMonthly } from "./tier-pricing";
 
 interface PlanDisplay {
-    actionLabel: string;
-    actionVariant: ButtonProps["variant"];
-    actionTestId: string;
-    showsRenewal: boolean;
+  actionLabel: string;
+  actionVariant: ButtonProps["variant"];
+  actionTestId: string;
+  showsRenewal: boolean;
 }
 
 const PLAN_DISPLAY: Record<string, PlanDisplay> = {
-    pro: {
-        actionLabel: "Manage",
-        actionVariant: "outlined",
-        actionTestId: "plan-card-manage-button",
-        showsRenewal: true,
-    },
-    base: {
-        actionLabel: "View Plans",
-        actionVariant: "primary",
-        actionTestId: "plan-card-upgrade-button",
-        showsRenewal: true,
-    },
+  pro: {
+    actionLabel: "Manage",
+    actionVariant: "outlined",
+    actionTestId: "plan-card-manage-button",
+    showsRenewal: true,
+  },
+  base: {
+    actionLabel: "View Plans",
+    actionVariant: "primary",
+    actionTestId: "plan-card-upgrade-button",
+    showsRenewal: true,
+  },
 };
 
 const DEFAULT_DISPLAY: PlanDisplay = PLAN_DISPLAY.base;
 
 export interface PlanCardProps {
-    onManage: () => void;
-    /**
-     * Raised after a Pro user's in-place package upgrade succeeds — opens the
-     * provisioning takeover (resize modal), the same signal `AdjustPlanModal`
-     * emits after a tier change.
-     */
-    onTierUpgraded?: () => void;
+  onManage: () => void;
+  /**
+   * Raised after a Pro user's in-place package upgrade succeeds — opens the
+   * provisioning takeover (resize modal), the same signal `AdjustPlanModal`
+   * emits after a tier change.
+   */
+  onTierUpgraded?: () => void;
 }
 
 function PlanHeading() {
-    return (
-        <Typography
-            as="h2"
-            variant="title-medium"
-            className="text-[var(--content-emphasised)]"
-        >
-            Plan
-        </Typography>
-    );
+  return (
+    <Typography
+      as="h2"
+      variant="title-medium"
+      className="text-[var(--content-emphasised)]"
+    >
+      Plan
+    </Typography>
+  );
 }
 
 /**
@@ -102,21 +110,21 @@ const STANDARD_MACHINE_LABEL = "Small";
 
 /** Machine size label for a package (or the standard small machine). */
 function machineLabel(pkg: ProPackage | null): string {
-    if (!pkg?.machine_size) {
-        return STANDARD_MACHINE_LABEL;
-    }
-    const size = pkg.machine_size as MachineSizeEnum;
-    return SIZE_LABEL[size] ?? pkg.machine_size;
+  if (!pkg?.machine_size) {
+    return STANDARD_MACHINE_LABEL;
+  }
+  const size = pkg.machine_size as MachineSizeEnum;
+  return SIZE_LABEL[size] ?? pkg.machine_size;
 }
 
 interface ResourceDelta {
-    icon: typeof Computer;
-    label: string;
+  icon: typeof Computer;
+  label: string;
 }
 
 /** "X → Y" only when the resource actually changes; the bare value otherwise. */
 function arrow(from: string, to: string): string {
-    return from === to ? to : `${from} → ${to}`;
+  return from === to ? to : `${from} → ${to}`;
 }
 
 /**
@@ -129,420 +137,435 @@ function arrow(from: string, to: string): string {
  * (not in the current catalog) simply shows the two anchor chips.
  */
 function buildDeltas(
-    recommended: ProPackage,
-    currentPackage: ProPackage | null,
+  recommended: ProPackage,
+  currentPackage: ProPackage | null,
 ): ResourceDelta[] {
-    const fromCredits = currentPackage?.credits_usd ?? 0;
-    const toCredits = recommended.credits_usd ?? 0;
-    const fromStorage = currentPackage?.storage_gib ?? FREE_STORAGE_GIB;
+  const fromCredits = currentPackage?.credits_usd ?? 0;
+  const toCredits = recommended.credits_usd ?? 0;
+  const fromStorage = currentPackage?.storage_gib ?? FREE_STORAGE_GIB;
 
-    const deltas: ResourceDelta[] = [
-        {
-            icon: Coins,
-            label: `${arrow(`$${fromCredits}`, `$${toCredits}`)} credits/mo`,
-        },
-        {
-            icon: HardDrive,
-            label: `${arrow(String(fromStorage), String(recommended.storage_gib))} GB`,
-        },
-    ];
+  const deltas: ResourceDelta[] = [
+    {
+      icon: Coins,
+      label: `${arrow(`$${fromCredits}`, `$${toCredits}`)} credits/mo`,
+    },
+    {
+      icon: HardDrive,
+      label: `${arrow(String(fromStorage), String(recommended.storage_gib))} GB`,
+    },
+  ];
 
-    const fromMachine = machineLabel(currentPackage);
-    const toMachine = machineLabel(recommended);
-    if (fromMachine !== toMachine) {
-        deltas.push({
-            icon: Computer,
-            label: `${fromMachine} → ${toMachine} Machine`,
-        });
-    } else if (currentPackage === null) {
-        // Free → Pro keeps the small baseline machine, but Pro unlocks the
-        // ability to scale to larger machines — surface that capability rather
-        // than a static "Small Machine" chip that reads as no upgrade.
-        deltas.push({ icon: Rocket, label: "Larger machines" });
-    }
+  const fromMachine = machineLabel(currentPackage);
+  const toMachine = machineLabel(recommended);
+  if (fromMachine !== toMachine) {
+    deltas.push({
+      icon: Computer,
+      label: `${fromMachine} → ${toMachine} Machine`,
+    });
+  } else if (currentPackage === null) {
+    // Free → Pro keeps the small baseline machine, but Pro unlocks the
+    // ability to scale to larger machines — surface that capability rather
+    // than a static "Small Machine" chip that reads as no upgrade.
+    deltas.push({ icon: Rocket, label: "Larger machines" });
+  }
 
-    return deltas;
+  return deltas;
 }
 
 interface RecommendedUpgradeProps {
-    packages: ProPackage[];
-    currentKey: string | null;
-    /**
-     * Whether the org already has a Pro subscription. Pro users change their
-     * package in place (prorated) via the change-package endpoint; base users
-     * go through Stripe checkout.
-     */
-    isProUser: boolean;
-    /**
-     * Whether this Pro sub is eligible for a one-click, in-place package switch:
-     * true only for a clean packaged Pro sub (has a package pin, not customized,
-     * not cancelling). Every other Pro state falls back to the manage path.
-     * Meaningless for base users, whose CTA always routes to Stripe checkout.
-     */
-    canChangePackage: boolean;
-    /**
-     * Manage-path delegate (AdjustPlanModal). Used to keep a legacy/custom Pro
-     * sub with no pinned package off the change-package flow, which operates
-     * only on named packages.
-     */
-    onManage: () => void;
-    /**
-     * Opens the provisioning takeover (resize modal) after a Pro user's in-place
-     * package change succeeds — the same signal the tier-change flow raises.
-     */
-    onTierUpgraded?: () => void;
+  packages: ProPackage[];
+  currentKey: string | null;
+  /**
+   * Whether the org already has a Pro subscription. Pro users change their
+   * package in place (prorated) via the change-package endpoint; base users
+   * go through Stripe checkout.
+   */
+  isProUser: boolean;
+  /**
+   * Whether this Pro sub is eligible for a one-click, in-place package switch:
+   * true for any switch-eligible Pro sub — a clean pin, a customized pin, or an
+   * unpinned (Custom) sub. A cancelling or non-entitlement Pro sub falls back to
+   * the manage path. Meaningless for base users, whose CTA always routes to
+   * Stripe checkout.
+   */
+  canChangePackage: boolean;
+  /**
+   * How the target package relates to the current sub — drives the confirm
+   * copy. A clean pin's next package is an "upgrade"; a customized or unpinned
+   * (Custom) sub gets the direction-neutral "switch".
+   */
+  relation: Exclude<TierRelation, "current"> | "switch";
+  /**
+   * Manage-path delegate (AdjustPlanModal). Handles a cancelling or
+   * non-entitlement Pro sub that the change-package flow cannot switch, and the
+   * empty-catalog fallback.
+   */
+  onManage: () => void;
+  /**
+   * Opens the provisioning takeover (resize modal) after a Pro user's in-place
+   * package change succeeds — the same signal the tier-change flow raises.
+   */
+  onTierUpgraded?: () => void;
 }
 
 function RecommendedUpgrade({
-    packages,
-    currentKey,
-    isProUser,
-    canChangePackage,
-    onManage,
-    onTierUpgraded,
+  packages,
+  currentKey,
+  isProUser,
+  canChangePackage,
+  relation,
+  onManage,
+  onTierUpgraded,
 }: RecommendedUpgradeProps) {
-    const queryClient = useQueryClient();
-    const upgradeMutation = useMutation(
-        organizationsBillingSubscriptionUpgradeCreateMutation(),
-    );
-    const { changePackage, isPending: changePending } = useChangePackage();
-    const [pending, setPending] = useState(false);
-    const [confirmOpen, setConfirmOpen] = useState(false);
-    // Native iOS keeps Checkout inside an in-app sheet; refetch when it closes.
-    useCheckoutDismissRefresh();
+  const queryClient = useQueryClient();
+  const upgradeMutation = useMutation(
+    organizationsBillingSubscriptionUpgradeCreateMutation(),
+  );
+  const { changePackage, isPending: changePending } = useChangePackage();
+  const [pending, setPending] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  // Native iOS keeps Checkout inside an in-app sheet; refetch when it closes.
+  useCheckoutDismissRefresh();
 
-    const recommended = nextPackageUp(packages, currentKey);
-    if (!recommended) return null;
+  const recommended = nextPackageUp(packages, currentKey);
+  if (!recommended) return null;
 
-    const currentPackage = currentKey
-        ? (packages.find((p) => p.key === currentKey) ?? null)
-        : null;
-    const currentPriceCents = currentPackage?.total_price_cents ?? 0;
-    const deltas = buildDeltas(recommended, currentPackage);
-    const priceLabel = `${formatMonthly(recommended.total_price_cents).replace("/mo", "")} / Monthly`;
-    const deltaCents = recommended.total_price_cents - currentPriceCents;
-    const upgradeLabel = `Upgrade for ${formatMonthly(deltaCents)} more`;
-    const accent = TIER_ACCENT[recommended.key] ?? TIER_ACCENT.free;
-    const tint = `color-mix(in srgb, ${accent} 10%, transparent)`;
-    const isPending = pending || upgradeMutation.isPending || changePending;
+  const currentPackage = currentKey
+    ? (packages.find((p) => p.key === currentKey) ?? null)
+    : null;
+  const currentPriceCents = currentPackage?.total_price_cents ?? 0;
+  const deltas = buildDeltas(recommended, currentPackage);
+  const priceLabel = `${formatMonthly(recommended.total_price_cents).replace("/mo", "")} / Monthly`;
+  const deltaCents = recommended.total_price_cents - currentPriceCents;
+  // A Custom (customized or unpinned) sub's real tiers can diverge from any
+  // stock package, so the stock price delta and stock resource deltas would
+  // misstate the direction and size of the change. The neutral "switch"
+  // relation drops the delta framing and offers the named plan by itself.
+  const isNeutralSwitch = relation === "switch";
+  const upgradeLabel = isNeutralSwitch
+    ? `Switch to ${recommended.name}`
+    : `Upgrade for ${formatMonthly(deltaCents)} more`;
+  const accent = TIER_ACCENT[recommended.key] ?? TIER_ACCENT.free;
+  const tint = `color-mix(in srgb, ${accent} 10%, transparent)`;
+  const isPending = pending || upgradeMutation.isPending || changePending;
 
-    // Pro users change their package in place: confirm the prorated charge, then
-    // call change-package and hand off to the resize takeover on success. Base
-    // users go through the Stripe-checkout path instead.
-    const handleConfirmChange = async () => {
-        const result = await changePackage(recommended.key);
-        if (!result) {
-            // The hook already toasted; leave the dialog open so the user can
-            // retry.
-            return;
-        }
-        setConfirmOpen(false);
-        if (result.status === "ok") {
-            onTierUpgraded?.();
-        } else {
-            // no_op: the sub is already on this package, so there's nothing to
-            // provision — just dismiss the confirm.
-            toast.success("You're already on this plan.");
-        }
-    };
+  // Pro users change their package in place: confirm the prorated charge, then
+  // call change-package and hand off to the resize takeover on success. Base
+  // users go through the Stripe-checkout path instead.
+  const handleConfirmChange = async () => {
+    const result = await changePackage(recommended.key);
+    if (!result) {
+      // The hook already toasted; leave the dialog open so the user can
+      // retry.
+      return;
+    }
+    setConfirmOpen(false);
+    if (result.status === "ok") {
+      onTierUpgraded?.();
+    } else {
+      // no_op: the sub is already on this package, so there's nothing to
+      // provision — just dismiss the confirm.
+      toast.success("You're already on this plan.");
+    }
+  };
 
-    const handleUpgrade = async () => {
-        // Only a clean packaged Pro sub (has a package pin, not customized, not
-        // cancelling) can be one-click package-switched; every other Pro state
-        // (package-less/legacy, customized, or cancelling) stays on the manage path.
-        if (isProUser && !canChangePackage) {
-            onManage();
-            return;
-        }
-        if (isProUser) {
-            setConfirmOpen(true);
-            return;
-        }
-        setPending(true);
-        try {
-            // A package checkout resolves its own line items server-side;
-            // explicit tiers / include_platform_fee alongside `package` are
-            // rejected by the upgrade serializer.
-            const result = await upgradeMutation.mutateAsync({
-                body: {
-                    target_plan_id: "pro",
-                    package: recommended.key,
-                    confirm: true,
-                    return_target: checkoutReturnTarget(),
-                },
-            });
-            if (result.status === "redirect" && result.checkout_url) {
-                // Stash the purchased package so the provisioning screen can
-                // show it before the subscribe webhook lands — and so it can't
-                // read a stale intent left by an abandoned earlier checkout.
-                saveCheckoutIntent({
-                    kind: "package",
-                    packageKey: recommended.key,
-                });
-                // Stripe returns with a `session_id`, which opens the
-                // post-checkout Pro onboarding wizard — via the billing page on
-                // web, via the `billing/checkout-complete` deep link on macOS.
-                openUrl(result.checkout_url);
-            } else {
-                await queryClient.invalidateQueries({
-                    queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
-                });
-                await queryClient.invalidateQueries({
-                    queryKey: organizationsBillingPlansRetrieveQueryKey(),
-                });
-            }
-        } catch (error) {
-            toast.error(
-                extractMutationError(
-                    error,
-                    "Failed to start the upgrade checkout. Please try again.",
-                ),
-            );
-        } finally {
-            setPending(false);
-        }
-    };
+  const handleUpgrade = async () => {
+    // Any switch-eligible Pro sub (a clean pin, a customized pin, or an
+    // unpinned Custom sub) can be one-click package-switched; a cancelling or
+    // non-entitlement Pro sub stays on the manage path.
+    if (isProUser && !canChangePackage) {
+      onManage();
+      return;
+    }
+    if (isProUser) {
+      setConfirmOpen(true);
+      return;
+    }
+    setPending(true);
+    try {
+      // A package checkout resolves its own line items server-side;
+      // explicit tiers / include_platform_fee alongside `package` are
+      // rejected by the upgrade serializer.
+      const result = await upgradeMutation.mutateAsync({
+        body: {
+          target_plan_id: "pro",
+          package: recommended.key,
+          confirm: true,
+          return_target: checkoutReturnTarget(),
+        },
+      });
+      if (result.status === "redirect" && result.checkout_url) {
+        // Stash the purchased package so the provisioning screen can
+        // show it before the subscribe webhook lands — and so it can't
+        // read a stale intent left by an abandoned earlier checkout.
+        saveCheckoutIntent({
+          kind: "package",
+          packageKey: recommended.key,
+        });
+        // Stripe returns with a `session_id`, which opens the
+        // post-checkout Pro onboarding wizard — via the billing page on
+        // web, via the `billing/checkout-complete` deep link on macOS.
+        openUrl(result.checkout_url);
+      } else {
+        await queryClient.invalidateQueries({
+          queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
+        });
+        await queryClient.invalidateQueries({
+          queryKey: organizationsBillingPlansRetrieveQueryKey(),
+        });
+      }
+    } catch (error) {
+      toast.error(
+        extractMutationError(
+          error,
+          "Failed to start the upgrade checkout. Please try again.",
+        ),
+      );
+    } finally {
+      setPending(false);
+    }
+  };
 
-    return (
-        <div
-            className="flex flex-col gap-6 rounded-lg p-3"
-            style={{ backgroundColor: tint }}
-        >
-            <div className="flex flex-wrap items-center justify-between gap-3">
-                <div className="flex items-center gap-3">
-                    <PlanTierAvatar tier={recommended.key} />
-                    <div className="flex flex-col gap-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                            <Typography
-                                as="span"
-                                variant="body-large-default"
-                                className="text-[var(--content-default)]"
-                            >
-                                {recommended.name}
-                            </Typography>
-                            <Tag
-                                className="bg-[var(--feed-digest-weak)] text-[var(--credits-accent)]"
-                                leftIcon={
-                                    <Sparkles className="h-3 w-3 text-[var(--credits-accent)]" />
-                                }
-                            >
-                                Recommended Upgrade
-                            </Tag>
-                        </div>
-                        <Typography
-                            as="span"
-                            variant="body-small-default"
-                            className="text-[var(--content-tertiary)]"
-                        >
-                            {priceLabel}
-                        </Typography>
-                    </div>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                    {deltas.map((delta) => {
-                        const Icon = delta.icon;
-                        return (
-                            <div
-                                key={delta.label}
-                                className="flex h-8 items-center gap-1.5 rounded-lg px-2 py-1.5"
-                                style={{ backgroundColor: tint }}
-                            >
-                                <Icon
-                                    className="h-3.5 w-3.5 shrink-0 text-[var(--content-default)]"
-                                    aria-hidden
-                                />
-                                <Typography
-                                    as="span"
-                                    variant="body-medium-default"
-                                    className="whitespace-nowrap text-[var(--content-default)]"
-                                >
-                                    {delta.label}
-                                </Typography>
-                            </div>
-                        );
-                    })}
-                </div>
-            </div>
-            <Button
-                variant="primary"
-                className="self-start"
-                onClick={handleUpgrade}
-                disabled={isPending}
+  return (
+    <div
+      className="flex flex-col gap-6 rounded-lg p-3"
+      style={{ backgroundColor: tint }}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <PlanTierAvatar tier={recommended.key} />
+          <div className="flex flex-col gap-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <Typography
+                as="span"
+                variant="body-large-default"
+                className="text-[var(--content-default)]"
+              >
+                {recommended.name}
+              </Typography>
+              <Tag
+                className="bg-[var(--feed-digest-weak)] text-[var(--credits-accent)]"
                 leftIcon={
-                    isPending ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : undefined
+                  <Sparkles className="h-3 w-3 text-[var(--credits-accent)]" />
                 }
-                data-testid="recommended-upgrade-button"
+              >
+                {isNeutralSwitch ? "Switch plan" : "Recommended Upgrade"}
+              </Tag>
+            </div>
+            <Typography
+              as="span"
+              variant="body-small-default"
+              className="text-[var(--content-tertiary)]"
             >
-                {upgradeLabel}
-            </Button>
-            <PackageSwitchConfirmModal
-                open={confirmOpen}
-                relation="upgrade"
-                packageName={recommended.name}
-                pending={isPending}
-                onConfirm={() => void handleConfirmChange()}
-                onCancel={() => setConfirmOpen(false)}
-            />
+              {priceLabel}
+            </Typography>
+          </div>
         </div>
-    );
+        <div className="flex flex-wrap items-center gap-2">
+          {!isNeutralSwitch &&
+            deltas.map((delta) => {
+              const Icon = delta.icon;
+              return (
+                <div
+                  key={delta.label}
+                  className="flex h-8 items-center gap-1.5 rounded-lg px-2 py-1.5"
+                  style={{ backgroundColor: tint }}
+                >
+                  <Icon
+                    className="h-3.5 w-3.5 shrink-0 text-[var(--content-default)]"
+                    aria-hidden
+                  />
+                  <Typography
+                    as="span"
+                    variant="body-medium-default"
+                    className="whitespace-nowrap text-[var(--content-default)]"
+                  >
+                    {delta.label}
+                  </Typography>
+                </div>
+              );
+            })}
+        </div>
+      </div>
+      <Button
+        variant="primary"
+        className="self-start"
+        onClick={handleUpgrade}
+        disabled={isPending}
+        leftIcon={
+          isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined
+        }
+        data-testid="recommended-upgrade-button"
+      >
+        {upgradeLabel}
+      </Button>
+      <PackageSwitchConfirmModal
+        open={confirmOpen}
+        relation={relation}
+        packageName={recommended.name}
+        pending={isPending}
+        onConfirm={() => void handleConfirmChange()}
+        onCancel={() => setConfirmOpen(false)}
+      />
+    </div>
+  );
 }
 
 export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
-    const navigate = useNavigate();
-    const subscriptionQuery = useQuery(
-        organizationsBillingSubscriptionRetrieveOptions(),
-    );
-    const plansQuery = useQuery(organizationsBillingPlansRetrieveOptions());
+  const navigate = useNavigate();
+  const subscriptionQuery = useQuery(
+    organizationsBillingSubscriptionRetrieveOptions(),
+  );
+  const plansQuery = useQuery(organizationsBillingPlansRetrieveOptions());
 
-    if (subscriptionQuery.isLoading || plansQuery.isLoading) {
-        return (
-            <Card padding="md">
-                <PlanHeading />
-                <div className="mt-4 flex items-center gap-2 text-[var(--content-tertiary)]">
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    <Typography as="span" variant="body-small-default">
-                        Loading plan...
-                    </Typography>
-                </div>
-            </Card>
-        );
-    }
-
-    const subscription = subscriptionQuery.data;
-    const plans = plansQuery.data?.plans;
-    const currentPlan = plans?.find((p) => p.id === subscription?.plan_id);
-
-    if (
-        subscriptionQuery.isError ||
-        plansQuery.isError ||
-        !subscription ||
-        !plans ||
-        !currentPlan
-    ) {
-        return <Notice tone="error">Failed to load plan.</Notice>;
-    }
-
-    const display = PLAN_DISPLAY[currentPlan.id] ?? DEFAULT_DISPLAY;
-    // A Pro sub shows the stock package name only for a clean (non-customized)
-    // pin (e.g. "Mighty"). Every other Pro state — an unpinned sub
-    // (`package == null`) or a customized pin whose tiers differ from the stock
-    // package — reads just "Custom". Non-Pro plans show their plan name.
-    const planName =
-        currentPlan.id === "pro"
-            ? subscription.package && !subscription.package.customized
-                ? subscription.package.name
-                : "Custom"
-            : (currentPlan.name ?? currentPlan.id);
-
-    const isCancelling =
-        display.showsRenewal &&
-        (subscription.cancel_at_period_end === true ||
-            Boolean(subscription.cancel_at));
-    const isCanceled = subscription.status === "canceled";
-    const cancelDate = getEffectiveCancelDate(subscription);
-    const showRenewal =
-        display.showsRenewal &&
-        !isCancelling &&
-        !isCanceled &&
-        subscription.current_period_end;
-    const showCancellation =
-        display.showsRenewal && isCancelling && !isCanceled && cancelDate;
-
-    const proPlan = plans.find((p): p is ProPlan => p.id === "pro");
-    // Empty while the `pro-packages` flag is off — the upgrade banner no-ops.
-    const packages = proPlan?.packages ?? [];
-    const currentKey = subscription.package?.key ?? null;
-    const currentTier = currentKey ?? "free";
-    // The plans takeover derives the current tier from the pinned package key
-    // alone, so a Pro sub without a package (legacy) or with a customized one
-    // (its tiers differ from the stock package) would be misrepresented there.
-    // Those stay on the manage modal; only base and clean packaged-Pro subs open
-    // the takeover.
-    const canOpenPlansTakeover =
-        packages.length > 0 &&
-        (currentPlan.id === "base" ||
-            (subscription.package != null && !subscription.package.customized));
-    // The banner's one-click switch targets a clean packaged Pro sub. It layers
-    // the pinned-and-not-customized requirement on top of the shared eligibility
-    // gate, so a customized or unpinned Pro sub falls back to the manage path
-    // here even though the plans takeover offers it a direction-neutral switch.
-    const canChangePackage =
-        isPackageSwitchEligible(subscription) &&
-        subscription.package != null &&
-        !subscription.package.customized;
-
+  if (subscriptionQuery.isLoading || plansQuery.isLoading) {
     return (
-        <Card padding="md">
-            <div className="flex flex-col gap-4">
-                <div className="flex items-center justify-between gap-3">
-                    <PlanHeading />
-                    <Button
-                        variant={display.actionVariant}
-                        onClick={
-                            canOpenPlansTakeover
-                                ? () => navigate(routes.plans)
-                                : onManage
-                        }
-                        data-testid={display.actionTestId}
-                        className="shrink-0"
-                    >
-                        {display.actionLabel}
-                    </Button>
-                </div>
-                <div className="flex flex-col gap-2">
-                    <div className="flex items-center gap-3 rounded-lg bg-[var(--surface-base)] py-1.5 pl-3 pr-2">
-                        <div className="flex min-w-0 items-center gap-3">
-                            <PlanTierAvatar tier={currentTier} />
-                            <div className="flex min-w-0 flex-col gap-1">
-                                <Typography
-                                    variant="body-large-default"
-                                    as="div"
-                                    className="text-[var(--content-default)]"
-                                    data-testid="plan-card-name"
-                                >
-                                    {planName}
-                                </Typography>
-                                {showRenewal && (
-                                    <Typography
-                                        variant="body-small-default"
-                                        as="div"
-                                        className="leading-snug text-[var(--content-tertiary)]"
-                                        data-testid="plan-card-renews"
-                                    >
-                                        Monthly Payment &bull; Your subscription
-                                        will auto renew on{" "}
-                                        {formatGraceDate(
-                                            subscription.current_period_end!,
-                                        )}
-                                        .
-                                    </Typography>
-                                )}
-                                {showCancellation && (
-                                    <Typography
-                                        variant="body-small-default"
-                                        as="div"
-                                        className="leading-snug text-[var(--system-mid-strong)]"
-                                        data-testid="plan-card-cancels"
-                                    >
-                                        Your plan ends on{" "}
-                                        {formatGraceDate(cancelDate!)}.
-                                    </Typography>
-                                )}
-                            </div>
-                        </div>
-                    </div>
-                    <RecommendedUpgrade
-                        packages={packages}
-                        currentKey={currentKey}
-                        isProUser={currentPlan.id !== "base"}
-                        canChangePackage={canChangePackage}
-                        onManage={onManage}
-                        onTierUpgraded={onTierUpgraded}
-                    />
-                </div>
-            </div>
-        </Card>
+      <Card padding="md">
+        <PlanHeading />
+        <div className="mt-4 flex items-center gap-2 text-[var(--content-tertiary)]">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <Typography as="span" variant="body-small-default">
+            Loading plan...
+          </Typography>
+        </div>
+      </Card>
     );
+  }
+
+  const subscription = subscriptionQuery.data;
+  const plans = plansQuery.data?.plans;
+  const currentPlan = plans?.find((p) => p.id === subscription?.plan_id);
+
+  if (
+    subscriptionQuery.isError ||
+    plansQuery.isError ||
+    !subscription ||
+    !plans ||
+    !currentPlan
+  ) {
+    return <Notice tone="error">Failed to load plan.</Notice>;
+  }
+
+  const display = PLAN_DISPLAY[currentPlan.id] ?? DEFAULT_DISPLAY;
+  // A Pro sub shows the stock package name only for a clean (non-customized)
+  // pin (e.g. "Mighty"). Every other Pro state — an unpinned sub
+  // (`package == null`) or a customized pin whose tiers differ from the stock
+  // package — reads just "Custom". Non-Pro plans show their plan name.
+  const planName =
+    currentPlan.id === "pro"
+      ? subscription.package && !subscription.package.customized
+        ? subscription.package.name
+        : "Custom"
+      : (currentPlan.name ?? currentPlan.id);
+
+  const isCancelling =
+    display.showsRenewal &&
+    (subscription.cancel_at_period_end === true ||
+      Boolean(subscription.cancel_at));
+  const isCanceled = subscription.status === "canceled";
+  const cancelDate = getEffectiveCancelDate(subscription);
+  const showRenewal =
+    display.showsRenewal &&
+    !isCancelling &&
+    !isCanceled &&
+    subscription.current_period_end;
+  const showCancellation =
+    display.showsRenewal && isCancelling && !isCanceled && cancelDate;
+
+  const proPlan = plans.find((p): p is ProPlan => p.id === "pro");
+  // Empty while the `pro-packages` flag is off — the upgrade banner no-ops.
+  const packages = proPlan?.packages ?? [];
+  const currentKey = subscription.package?.key ?? null;
+  const currentTier = currentKey ?? "free";
+  // The plans takeover derives the current tier from the pinned package key
+  // alone, so a Pro sub without a package (legacy) or with a customized one
+  // (its tiers differ from the stock package) would be misrepresented there.
+  // Those stay on the manage modal; only base and clean packaged-Pro subs open
+  // the takeover.
+  const canOpenPlansTakeover =
+    packages.length > 0 &&
+    (currentPlan.id === "base" ||
+      (subscription.package != null && !subscription.package.customized));
+  // The banner's one-click switch is offered to any switch-eligible Pro sub —
+  // a clean pin, a customized pin, or an unpinned (Custom) sub — inheriting the
+  // shared eligibility gate. The confirm copy adapts to the sub's state via
+  // `switchRelation`.
+  const canChangePackage = isPackageSwitchEligible(subscription);
+  // A base user (Stripe checkout) and a clean-pinned Pro sub both make a real
+  // upgrade, so the banner keeps its directional copy and stock deltas. Only a
+  // Custom Pro sub — a customized pin or an unpinned legacy sub, whose real
+  // tiers can diverge from any stock package — gets the direction-neutral
+  // switch, since a stock delta could misstate the change.
+  const switchRelation: Exclude<TierRelation, "current"> | "switch" =
+    currentPlan.id === "base" ||
+    (subscription.package && !subscription.package.customized)
+      ? "upgrade"
+      : "switch";
+
+  return (
+    <Card padding="md">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-3">
+          <PlanHeading />
+          <Button
+            variant={display.actionVariant}
+            onClick={
+              canOpenPlansTakeover ? () => navigate(routes.plans) : onManage
+            }
+            data-testid={display.actionTestId}
+            className="shrink-0"
+          >
+            {display.actionLabel}
+          </Button>
+        </div>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3 rounded-lg bg-[var(--surface-base)] py-1.5 pl-3 pr-2">
+            <div className="flex min-w-0 items-center gap-3">
+              <PlanTierAvatar tier={currentTier} />
+              <div className="flex min-w-0 flex-col gap-1">
+                <Typography
+                  variant="body-large-default"
+                  as="div"
+                  className="text-[var(--content-default)]"
+                  data-testid="plan-card-name"
+                >
+                  {planName}
+                </Typography>
+                {showRenewal && (
+                  <Typography
+                    variant="body-small-default"
+                    as="div"
+                    className="leading-snug text-[var(--content-tertiary)]"
+                    data-testid="plan-card-renews"
+                  >
+                    Monthly Payment &bull; Your subscription will auto renew on{" "}
+                    {formatGraceDate(subscription.current_period_end!)}.
+                  </Typography>
+                )}
+                {showCancellation && (
+                  <Typography
+                    variant="body-small-default"
+                    as="div"
+                    className="leading-snug text-[var(--system-mid-strong)]"
+                    data-testid="plan-card-cancels"
+                  >
+                    Your plan ends on {formatGraceDate(cancelDate!)}.
+                  </Typography>
+                )}
+              </div>
+            </div>
+          </div>
+          <RecommendedUpgrade
+            packages={packages}
+            currentKey={currentKey}
+            isProUser={currentPlan.id !== "base"}
+            canChangePackage={canChangePackage}
+            relation={switchRelation}
+            onManage={onManage}
+            onTierUpgraded={onTierUpgraded}
+          />
+        </div>
+      </div>
+    </Card>
+  );
 }

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -464,10 +464,14 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
         packages.length > 0 &&
         (currentPlan.id === "base" ||
             (subscription.package != null && !subscription.package.customized));
-    // A one-click, in-place package switch is safe only for a clean packaged Pro
-    // sub; every other Pro state (customized, cancelling, or a non-entitlement
-    // status) and every base sub falls back to the manage path.
-    const canChangePackage = isPackageSwitchEligible(subscription);
+    // The banner's one-click switch targets a clean packaged Pro sub. It layers
+    // the pinned-and-not-customized requirement on top of the shared eligibility
+    // gate, so a customized or unpinned Pro sub falls back to the manage path
+    // here even though the plans takeover offers it a direction-neutral switch.
+    const canChangePackage =
+        isPackageSwitchEligible(subscription) &&
+        subscription.package != null &&
+        !subscription.package.customized;
 
     return (
         <Card padding="md">

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -425,14 +425,16 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
     }
 
     const display = PLAN_DISPLAY[currentPlan.id] ?? DEFAULT_DISPLAY;
-    // Show the pinned package name (e.g. "Mighty"), or just "Custom" when the
-    // subscription is customized: its tiers differ from that stock package, so
-    // it isn't labeled as one.
-    const planName = subscription.package
-        ? subscription.package.customized
-            ? "Custom"
-            : subscription.package.name
-        : (currentPlan.name ?? currentPlan.id);
+    // A Pro sub shows the stock package name only for a clean (non-customized)
+    // pin (e.g. "Mighty"). Every other Pro state — an unpinned sub
+    // (`package == null`) or a customized pin whose tiers differ from the stock
+    // package — reads just "Custom". Non-Pro plans show their plan name.
+    const planName =
+        currentPlan.id === "pro"
+            ? subscription.package && !subscription.package.customized
+                ? subscription.package.name
+                : "Custom"
+            : (currentPlan.name ?? currentPlan.id);
 
     const isCancelling =
         display.showsRenewal &&


### PR DESCRIPTION
## Summary
Collapses the web app's Pro plan labeling into three states — **Free** (base), **Named** (a clean Mighty/Super/Ultra pin), and **Custom** (legacy-unpinned `package = null` and pinned-but-`customized` subs) — and lets Custom-state Pro users override up/down to a named package through the one-click change-package flow, with direction-neutral confirm copy (their real tiers can diverge from any stock package, so up/down is unknowable). macOS ships the compiled web build and iOS loads the hosted web app, so this one implementation covers all clients; no backend work (the platform `change-package` endpoint already re-pins any active Pro sub).

## Self-review result
PASS. 4 fresh reviewers (external-feedback, plan-faithfulness, repo-integration, slop-audit); no functional gaps. 3 non-functional findings remediated in `3386d0a5aa` (shared `SwitchRelation` type, accurate `useChangeTiers` doc, test-fixture reuse). One P2 caught during PR review — the banner body showed stock deltas that could misstate direction for Custom subs — was fixed by neutralizing the banner body for the `switch` relation (and correcting `switchRelation` so base users keep directional copy).

## PRs merged into this feature branch
- #38755 — collapse plan-card label to Free / named package / Custom
- #38757 — one-click package switch for custom/unpinned Pro subs with neutral confirm copy
- #38763 — neutral switch confirm (modal **and** banner body) for Custom subs on the plan-card upgrade banner
- `3386d0a5aa` — self-review cleanup (shared type, doc accuracy, test reuse)

## Open follow-up (not in scope of this plan)
The plan-card **Manage** button still routes Custom subs to the AdjustPlanModal (not the full 4-card plans takeover), because `canOpenPlansTakeover` was intentionally left untouched (PR 1 do-not-touch). Custom subs' in-card one-click switch is the banner; the takeover's Custom support is reachable by direct URL. Widen `canOpenPlansTakeover` if Custom subs should use the full takeover — a product call.

Part of plan: custom-plan-classification.md