### PR TITLE
refactor(slack): consolidate permalink construction and ts shape-check into shared Slack modules

### DIFF
--- a/assistant/src/messaging/channel-binding-schema.ts
+++ b/assistant/src/messaging/channel-binding-schema.ts
@@ -1,11 +1,15 @@
 import { z } from "zod";
 
 /** Channel-neutral deep-link pair into an external client: a native app URL
- *  (e.g. `slack://…`) and/or a browser URL. */
-const externalSourceLinkSchema = z.object({
+ *  (e.g. `slack://…`) and/or a browser URL. Exported as the single source of
+ *  truth for this shape — consumers (binding metadata, approval source
+ *  references) reuse it rather than re-declaring the pair. */
+export const externalSourceLinkSchema = z.object({
   appUrl: z.string().optional(),
   webUrl: z.string().optional(),
 });
+
+export type ExternalSourceLink = z.infer<typeof externalSourceLinkSchema>;
 
 const slackThreadSchema = z.object({
   channelId: z.string(),

--- a/assistant/src/messaging/providers/slack/deep-link.ts
+++ b/assistant/src/messaging/providers/slack/deep-link.ts
@@ -36,6 +36,24 @@ function normalizeSlackTeamUrl(teamUrl?: string | null): string | undefined {
   }
 }
 
+function buildArchivesMessageUrl(
+  teamUrl: string,
+  channelId: string,
+  messageTs: string,
+  threadTs?: string,
+): string {
+  const baseUrl = `${teamUrl}/archives/${encodeURIComponent(
+    channelId,
+  )}/p${formatSlackPermalinkTimestamp(messageTs)}`;
+  if (!threadTs) return baseUrl;
+
+  const search = new URLSearchParams({
+    thread_ts: threadTs,
+    cid: channelId,
+  });
+  return `${baseUrl}?${search.toString()}`;
+}
+
 export function buildSlackWebMessageUrl(params: {
   teamUrl?: string | null;
   channelId: string;
@@ -45,16 +63,35 @@ export function buildSlackWebMessageUrl(params: {
   const teamUrl = normalizeSlackTeamUrl(params.teamUrl);
   if (!teamUrl) return undefined;
 
-  const baseUrl = `${teamUrl}/archives/${encodeURIComponent(
+  return buildArchivesMessageUrl(
+    teamUrl,
     params.channelId,
-  )}/p${formatSlackPermalinkTimestamp(params.messageTs)}`;
-  if (!params.threadTs) return baseUrl;
+    params.messageTs,
+    params.threadTs,
+  );
+}
 
-  const search = new URLSearchParams({
-    thread_ts: params.threadTs,
-    cid: params.channelId,
-  });
-  return `${baseUrl}?${search.toString()}`;
+/**
+ * Workspace-agnostic message permalink: `https://slack.com/archives/…`
+ * resolves for any authenticated Slack viewer, so no per-workspace team URL
+ * is needed. When `threadTs` marks an enclosing thread (and the message is
+ * not itself the thread root), `thread_ts`/`cid` params make Slack open the
+ * message inside its thread view instead of failing to locate a threaded
+ * reply at the channel root.
+ */
+export function buildSlackPermalink(params: {
+  channelId: string;
+  messageTs: string;
+  threadTs?: string;
+}): string {
+  const threadTs =
+    params.threadTs !== params.messageTs ? params.threadTs : undefined;
+  return buildArchivesMessageUrl(
+    "https://slack.com",
+    params.channelId,
+    params.messageTs,
+    threadTs,
+  );
 }
 
 export function buildSlackWebChannelUrl(params: {

--- a/assistant/src/messaging/providers/slack/message-metadata.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.ts
@@ -19,6 +19,22 @@ import { z } from "zod";
 
 export type SlackEventKind = "message" | "reaction";
 
+/**
+ * Shape-check for a Slack `ts` value. Slack IDs messages by `<seconds>.<micros>`
+ * strings (e.g. `"1700000000.000100"`). The daemon also stores identifiers in
+ * other formats (gateway dedupe keys, UUIDs), so any path that treats a stored
+ * id as a ts — Slack API history bounds, permalink construction — must
+ * shape-check first; Slack rejects non-ts arguments with `invalid_arguments`.
+ */
+export function isSlackTs(value: string | null | undefined): value is string {
+  return typeof value === "string" && /^\d+\.\d+$/.test(value);
+}
+
+/** Slack DM conversation IDs start with `D` followed by alphanumeric chars. */
+export function isSlackDmConversation(conversationExternalId: string): boolean {
+  return /^D[A-Z0-9]+$/i.test(conversationExternalId);
+}
+
 const slackReactionMetadataSchema = z.object({
   emoji: z.string(),
   actorDisplayName: z.string().optional(),

--- a/assistant/src/notifications/access-request-copy.ts
+++ b/assistant/src/notifications/access-request-copy.ts
@@ -7,6 +7,8 @@
 
 import { z } from "zod";
 
+import { buildSlackPermalink } from "../messaging/providers/slack/deep-link.js";
+import { isSlackDmConversation } from "../messaging/providers/slack/message-metadata.js";
 import {
   buildIntroductionActions,
   coerceSignalBoolean,
@@ -145,25 +147,6 @@ export function isHandshakeOfferedForPayload(
     isStranger: p.isStranger,
     isRestricted: p.isRestricted,
   });
-}
-
-// ── Slack conversation helpers ───────────────────────────────────────────────
-
-/** Slack DM conversation IDs start with `D` followed by alphanumeric chars. */
-export function isSlackDmConversation(conversationExternalId: string): boolean {
-  return /^D[A-Z0-9]+$/i.test(conversationExternalId);
-}
-
-/**
- * Build a Slack message permalink from a channel ID and message timestamp.
- * Format: https://slack.com/archives/{channelId}/p{ts_without_dot}
- * Workspace-agnostic — resolves for any authenticated Slack viewer.
- */
-export function buildSlackMessagePermalink(
-  conversationExternalId: string,
-  messageTs: string,
-): string {
-  return `https://slack.com/archives/${conversationExternalId}/p${messageTs.replace(".", "")}`;
 }
 
 /** Internal typed implementation — avoids re-parsing when called from
@@ -375,7 +358,10 @@ export function buildAccessRequestContractText(
   // Conversation context: source channel + permalink when available.
   if (p.sourceChannel === "slack" && p.conversationExternalId) {
     const permalink = p.messageTs
-      ? buildSlackMessagePermalink(p.conversationExternalId, p.messageTs)
+      ? buildSlackPermalink({
+          channelId: p.conversationExternalId,
+          messageTs: p.messageTs,
+        })
       : undefined;
     const isDm = isSlackDmConversation(p.conversationExternalId);
     const channelLabel = isDm ? "Direct message" : p.conversationExternalId;
@@ -476,7 +462,10 @@ export function buildAccessRequestCardView(
 
   const messagePermalink =
     sourceChannel === "slack" && conversationExternalId && messageTs
-      ? buildSlackMessagePermalink(conversationExternalId, messageTs)
+      ? buildSlackPermalink({
+          channelId: conversationExternalId,
+          messageTs,
+        })
       : undefined;
 
   const rawPreview = nonEmpty(p.messagePreview);

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -55,6 +55,7 @@ import { downloadSlackFile } from "../../messaging/providers/slack/download.js";
 import {
   buildSlackTimezoneMetadata,
   formatSlackTimezoneLabel,
+  isSlackTs,
   mergeSlackMetadata,
   readSlackMetadataFromMessageMetadata,
   type SlackFileMetadata,
@@ -1458,19 +1459,6 @@ export async function handleChannelInbound({
  * message history yet.
  */
 const SLACK_DM_BACKFILL_WARM_THRESHOLD = 3;
-
-/**
- * Shape-check for a Slack `ts` value. Slack IDs messages by `<seconds>.<micros>`
- * strings (e.g. `"1700000000.000100"`). The daemon also stores an
- * `externalMessageId` derived from the gateway's dedupe key which follows a
- * different format, so any path that feeds a ts to Slack's API
- * (`conversations.history`'s `latest`, etc.) must shape-check first — Slack
- * rejects non-ts arguments with `invalid_arguments`, and passing a malformed
- * bound silently disables the intended history window.
- */
-function isSlackTs(value: string | null | undefined): value is string {
-  return typeof value === "string" && /^\d+\.\d+$/.test(value);
-}
 
 /**
  * Batch size used when pulling candidate rows from SQL. A bare


### PR DESCRIPTION
Part of [LUM-2703](https://linear.app/vellum/issue/LUM-2703/tool-approval-cards-dont-include-a-link-to-the-originating-slack) — pure-refactor prerequisite split out of #38758 so the feature PR is feature-only. **No behavior change.**

## Prompt / plan

Two pieces of Slack-format knowledge were duplicated, and the approval-card source-link work (#38758) would have added a third consumer of each. Consolidate first:

- **Permalink construction** existed in `deep-link.ts` (`buildSlackWebMessageUrl`, workspace-URL based) *and* as a parallel builder in `access-request-copy.ts` (workspace-agnostic `https://slack.com/archives/…` form) — already drifted on URL-encoding. `deep-link.ts` now owns a single internal archives-URL builder with two entry points: `buildSlackWebMessageUrl` (behavior unchanged) and `buildSlackPermalink` (workspace-agnostic, thread-root-aware `thread_ts`/`cid` params). Access-request copy delegates to it; output is byte-identical for existing cards.
- **The Slack `ts` shape-check** was a private helper in `inbound-message-handler.ts`. It's now exported from `message-metadata.ts` (the module that owns Slack metadata parsing) so all Slack-format consumers share one definition.

## Test plan

- `bunx tsc --noEmit` clean.
- Existing suites pin byte-identical output: `access-request-card-view`, `slack-notification-approval-card`, `non-member-access-request`, `binding-metadata`, `message-metadata` — 86 tests, all green.

## CLI verb checklist

No new routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsXZQbxfANvB6usw4mmWyy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsXZQbxfANvB6usw4mmWyy)_