### PR TITLE
fix(contacts): refuse binding-strength demotions in the gateway ACL write path (LUM-2505)

### DIFF
--- a/assistant/src/runtime/introduction-policy.ts
+++ b/assistant/src/runtime/introduction-policy.ts
@@ -17,12 +17,20 @@
  *
  * This module is the single source of truth for:
  *   - the requester identity signals persisted on guardian access requests,
- *   - the binding-strength ladder derived from `verifiedVia` provenance,
  *   - the signal-driven action list every card surface renders.
  *
- * Binding strength is provenance/audit only — it never enters the capability
- * layer (`trusted_contact` ≡ `unverified_contact` on capabilities).
+ * The binding-strength ladder and `verified_via` constants are re-exported from
+ * `@vellumai/gateway-client` (their canonical home, shared with the gateway ACL
+ * write path that enforces demotion refusal — LUM-2505). Binding strength never
+ * enters the capability layer — `trusted_contact` ≡ `unverified_contact` on
+ * capabilities.
  */
+
+import type { BindingStrength } from "@vellumai/gateway-client";
+import {
+  VERIFIED_VIA_CHANNEL_CLAIM,
+  VERIFIED_VIA_MANUAL,
+} from "@vellumai/gateway-client";
 
 import type { ApprovalAction } from "./channel-approval-types.js";
 
@@ -110,59 +118,20 @@ export function parseRequesterSignals(
 }
 
 // ---------------------------------------------------------------------------
-// Binding strength ladder
+// Binding strength ladder (shared, gateway-owned)
 // ---------------------------------------------------------------------------
 
-/**
- * Binding-strength ladder: how strongly the contact's channel identity is
- * bound to the person/agent the guardian believes they are.
- *
- *   verified_handshake > internal_workspace_match > inbound_channel_claim
- *
- * - `verified_handshake` — the contact proved control of the channel by
- *   returning a verification code (`verifiedVia: "challenge"`).
- * - `internal_workspace_match` — the platform already authenticated the
- *   identity inside the guardian's own workspace (Slack member or workspace
- *   app); the guardian vouches directly (`verifiedVia: "manual"`).
- * - `inbound_channel_claim` — the guardian trusts an identity the platform is
- *   NOT vouching for (external / Slack-Connect / restricted guest / channels
- *   without workspace identity). Recorded as
- *   `verifiedVia: "manual_channel_claim"` so a trusted-anyway external never
- *   carries the same provenance as a code-verified contact.
- */
-export type BindingStrength =
-  | "verified_handshake"
-  | "internal_workspace_match"
-  | "inbound_channel_claim";
-
-/** verifiedVia written when the guardian direct-trusts a workspace-vouched identity. */
-export const VERIFIED_VIA_MANUAL = "manual";
-
-/** verifiedVia written when the guardian trusts an identity the platform is not vouching for. */
-export const VERIFIED_VIA_CHANNEL_CLAIM = "manual_channel_claim";
-
-/** verifiedVia written by the gateway when a verification code is redeemed. */
-export const VERIFIED_VIA_CHALLENGE = "challenge";
-
-/**
- * Derive the binding strength recorded by a `verifiedVia` provenance value.
- * Returns null for provenance outside the introduction ladder (e.g. "invite",
- * "bootstrap"), which predate it and keep their own audit meaning.
- */
-export function bindingStrengthForVerifiedVia(
-  verifiedVia: string | null | undefined,
-): BindingStrength | null {
-  switch (verifiedVia) {
-    case VERIFIED_VIA_CHALLENGE:
-      return "verified_handshake";
-    case VERIFIED_VIA_MANUAL:
-      return "internal_workspace_match";
-    case VERIFIED_VIA_CHANNEL_CLAIM:
-      return "inbound_channel_claim";
-    default:
-      return null;
-  }
-}
+// The binding-strength ladder and `verified_via` provenance constants are the
+// canonical vocabulary in `@vellumai/gateway-client`
+// (`binding-strength-contract.ts`); the gateway ACL write path enforces
+// demotion refusal on the same values (LUM-2505). Re-exported here so
+// introduction-card call sites keep importing them from this module.
+export {
+  bindingStrengthForVerifiedVia,
+  VERIFIED_VIA_CHALLENGE,
+} from "@vellumai/gateway-client";
+export { VERIFIED_VIA_CHANNEL_CLAIM, VERIFIED_VIA_MANUAL };
+export type { BindingStrength };
 
 /**
  * Whether the platform itself vouches for the requester's identity inside the

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -8,7 +8,15 @@
  * running daemon.
  */
 
-import { describe, test, expect, beforeAll, beforeEach, afterAll, mock } from "bun:test";
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  mock,
+} from "bun:test";
 
 import "./test-preload.js";
 
@@ -80,10 +88,7 @@ const mirrorIpcCalls: { method: string; body: unknown }[] = [];
 mock.module("../ipc/assistant-client.js", () => ({
   IpcHandlerError: class extends Error {},
   IpcTransportError: class extends Error {},
-  ipcCallAssistant: async (
-    method: string,
-    params?: { body?: unknown },
-  ) => {
+  ipcCallAssistant: async (method: string, params?: { body?: unknown }) => {
     mirrorIpcCalls.push({ method, body: params?.body });
     return { ok: true };
   },
@@ -164,7 +169,13 @@ function seedContact(id: string, role: "guardian" | "contact" = "guardian") {
     .run();
 }
 
-function seedChannel(opts: { id: string; contactId: string; status?: string }) {
+function seedChannel(opts: {
+  id: string;
+  contactId: string;
+  status?: string;
+  verifiedVia?: string | null;
+  verifiedAt?: number | null;
+}) {
   const now = Date.now();
   getGatewayDb()
     .insert(contactChannels)
@@ -176,6 +187,8 @@ function seedChannel(opts: { id: string; contactId: string; status?: string }) {
       isPrimary: false,
       status: opts.status ?? "unverified",
       policy: "allow",
+      verifiedAt: opts.verifiedAt ?? null,
+      verifiedVia: opts.verifiedVia ?? null,
       interactionCount: 0,
       createdAt: now,
       updatedAt: now,
@@ -457,7 +470,7 @@ describe("upsert_verified_channel IPC handler", () => {
     expect(row!.status).toBe("blocked");
   });
 
-  test("round-trips verifiedVia=\"invite\" (free string, not the restricted enum)", async () => {
+  test('round-trips verifiedVia="invite" (free string, not the restricted enum)', async () => {
     const res = (await upsertVerifiedChannelHandler({
       type: "vellum",
       address: "addr-invite",
@@ -475,5 +488,94 @@ describe("upsert_verified_channel IPC handler", () => {
       .where(eq(contactChannels.address, "addr-invite"))
       .get();
     expect(row!.verifiedVia).toBe("invite");
+  });
+});
+
+describe("upsert_verified_channel binding-strength guard (LUM-2505)", () => {
+  test("refuses to demote an active challenge binding to a manual_channel_claim", async () => {
+    seedContact("c1", "contact");
+    seedChannel({
+      id: "ch1",
+      contactId: "c1",
+      status: "active",
+      verifiedVia: "challenge",
+      verifiedAt: 500,
+    });
+
+    const res = (await upsertVerifiedChannelHandler({
+      type: "vellum",
+      address: "addr-ch1",
+      externalChatId: "chat-1",
+      verifiedVia: "manual_channel_claim",
+    })) as { ok: boolean; verified: boolean; channel: { verifiedVia: string } };
+
+    // The write still succeeds, but the stronger provenance is preserved.
+    expect(res.ok).toBe(true);
+    expect(res.verified).toBe(true);
+    expect(res.channel.verifiedVia).toBe("challenge");
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.verifiedVia).toBe("challenge");
+    expect(row!.verifiedAt).toBe(500);
+    expect(row!.status).toBe("active");
+  });
+
+  test("refuses to demote an active challenge binding to a manual attest", async () => {
+    seedContact("c1", "contact");
+    seedChannel({
+      id: "ch1",
+      contactId: "c1",
+      status: "active",
+      verifiedVia: "challenge",
+      verifiedAt: 500,
+    });
+
+    const res = (await upsertVerifiedChannelHandler({
+      type: "vellum",
+      address: "addr-ch1",
+      externalChatId: "chat-1",
+      verifiedVia: "manual",
+    })) as { ok: boolean; channel: { verifiedVia: string } };
+
+    expect(res.channel.verifiedVia).toBe("challenge");
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.verifiedVia).toBe("challenge");
+  });
+
+  test("still applies an upgrade (manual_channel_claim -> challenge)", async () => {
+    seedContact("c1", "contact");
+    seedChannel({
+      id: "ch1",
+      contactId: "c1",
+      status: "active",
+      verifiedVia: "manual_channel_claim",
+      verifiedAt: 500,
+    });
+
+    const res = (await upsertVerifiedChannelHandler({
+      type: "vellum",
+      address: "addr-ch1",
+      externalChatId: "chat-1",
+      verifiedVia: "challenge",
+    })) as { ok: boolean; verified: boolean; channel: { verifiedVia: string } };
+
+    expect(res.verified).toBe(true);
+    expect(res.channel.verifiedVia).toBe("challenge");
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.verifiedVia).toBe("challenge");
   });
 });

--- a/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
+++ b/gateway/src/__tests__/contact-store-mark-channel-verified.test.ts
@@ -270,7 +270,7 @@ describe("ContactStore.markChannelVerified", () => {
     expect(result!.channel.verifiedVia).toBe("manual");
   });
 
-  test("upgrades a previously challenge-verified channel to manual", async () => {
+  test("refuses to demote a challenge-verified channel to manual (LUM-2505)", async () => {
     seedContact("c1");
     seedChannel({
       id: "ch1",
@@ -280,12 +280,33 @@ describe("ContactStore.markChannelVerified", () => {
       verifiedVia: "challenge",
     });
 
-    const before = Date.now();
+    // A `manual` attest (e.g. a roster "Link account") must not lower the
+    // stronger `challenge` proof on an active binding — the existing binding
+    // stands as an idempotent no-op.
     const result = await new ContactStore().markChannelVerified("ch1");
     expect(result).not.toBeNull();
+    expect(result!.didWrite).toBe(false);
+    expect(result!.channel.verifiedVia).toBe("challenge");
+    expect(result!.channel.verifiedAt).toBe(500);
+  });
+
+  test("applies an upgrade: manual -> challenge on an active channel", async () => {
+    seedContact("c1");
+    seedChannel({
+      id: "ch1",
+      contactId: "c1",
+      status: "active",
+      verifiedAt: 500,
+      verifiedVia: "manual",
+    });
+
+    const result = await new ContactStore().markChannelVerified(
+      "ch1",
+      "challenge",
+    );
+    expect(result).not.toBeNull();
     expect(result!.didWrite).toBe(true);
-    expect(result!.channel.verifiedVia).toBe("manual");
-    expect(result!.channel.verifiedAt!).toBeGreaterThanOrEqual(before);
+    expect(result!.channel.verifiedVia).toBe("challenge");
   });
 
   test("re-activates a non-active channel that previously had verifiedAt", async () => {
@@ -511,9 +532,7 @@ describe("ContactStore.markChannelVerified", () => {
 
     // Exactly one gateway channel row: the existing gateway row is verified in
     // place, keyed by (type,address).
-    expect(
-      getGatewayDb().select().from(contactChannels).all().length,
-    ).toBe(1);
+    expect(getGatewayDb().select().from(contactChannels).all().length).toBe(1);
   });
 
   test("legacy cross-contact: resolves the gateway row by (type,address) even under a different contact", async () => {
@@ -545,6 +564,75 @@ describe("ContactStore.markChannelVerified", () => {
     expect(result!.channel.contactId).toBe("gw-contact");
     expect(result!.channel.status).toBe("active");
     expect(result!.channel.verifiedVia).toBe("challenge");
+  });
+});
+
+describe("ContactStore.upsertContact binding-strength guard (LUM-2505)", () => {
+  test("does not demote an active challenge channel via a weaker verifiedVia upsert", async () => {
+    seedContact("c1", "contact");
+    seedChannel({
+      id: "ch1",
+      contactId: "c1",
+      status: "active",
+      verifiedAt: 500,
+      verifiedVia: "challenge",
+      address: "addr-ch1",
+    });
+
+    await new ContactStore().upsertContact({
+      id: "c1",
+      channels: [
+        {
+          type: "vellum",
+          address: "addr-ch1",
+          status: "active",
+          verifiedVia: "manual_channel_claim",
+          verifiedAt: 999,
+        },
+      ],
+    });
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.verifiedVia).toBe("challenge");
+    expect(row!.verifiedAt).toBe(500);
+    expect(row!.status).toBe("active");
+  });
+
+  test("applies an upgrade via upsert (manual_channel_claim -> challenge)", async () => {
+    seedContact("c1", "contact");
+    seedChannel({
+      id: "ch1",
+      contactId: "c1",
+      status: "active",
+      verifiedAt: 500,
+      verifiedVia: "manual_channel_claim",
+      address: "addr-ch1",
+    });
+
+    await new ContactStore().upsertContact({
+      id: "c1",
+      channels: [
+        {
+          type: "vellum",
+          address: "addr-ch1",
+          status: "active",
+          verifiedVia: "challenge",
+          verifiedAt: 999,
+        },
+      ],
+    });
+
+    const row = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.id, "ch1"))
+      .get();
+    expect(row!.verifiedVia).toBe("challenge");
+    expect(row!.verifiedAt).toBe(999);
   });
 });
 
@@ -588,9 +676,7 @@ describe("ContactStore.markChannelRevoked", () => {
 
     // Exactly one gateway channel row: the existing gateway row is revoked in
     // place, keyed by (type,address).
-    expect(
-      getGatewayDb().select().from(contactChannels).all().length,
-    ).toBe(1);
+    expect(getGatewayDb().select().from(contactChannels).all().length).toBe(1);
   });
 });
 

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -2,6 +2,7 @@ import { type Database } from "bun:sqlite";
 
 import { and, desc, eq, gt, ne, sql } from "drizzle-orm";
 
+import { isBindingDemotion } from "@vellumai/gateway-client";
 import {
   type AssistantContactMetadata,
   type ContactRead,
@@ -722,6 +723,25 @@ export class ContactStore {
     const gwChannel = await this.resolveGatewayChannel(channelId);
     if (!gwChannel) return null;
     const gwChannelId = gwChannel.id;
+
+    // Binding-strength guard (LUM-2505): never demote an active binding's
+    // provenance. A lower-strength verifiedVia (e.g. a `manual` roster attest)
+    // over an already-active, higher-strength channel (e.g. `challenge`) is
+    // refused — the stronger existing binding stands, as an idempotent no-op.
+    if (
+      gwChannel.status === "active" &&
+      isBindingDemotion(gwChannel.verifiedVia, verifiedVia)
+    ) {
+      log.warn(
+        {
+          channelId: gwChannelId,
+          existingVerifiedVia: gwChannel.verifiedVia,
+          incomingVerifiedVia: verifiedVia,
+        },
+        "markChannelVerified: refusing binding-strength demotion; preserving stronger verified_via",
+      );
+      return { channel: gwChannel, didWrite: false };
+    }
 
     const now = Date.now();
     const raw = (this.db as unknown as { $client: Database }).$client;
@@ -1545,9 +1565,27 @@ export class ContactStore {
           if (ch.blockedReason !== undefined)
             updateSet.blockedReason = ch.blockedReason;
         }
-        if (ch.verifiedAt !== undefined) updateSet.verifiedAt = ch.verifiedAt;
-        if (ch.verifiedVia !== undefined)
-          updateSet.verifiedVia = ch.verifiedVia;
+        // Binding-strength guard (LUM-2505): a lower-strength verifiedVia must
+        // not demote an active binding. When it would, preserve the stronger
+        // existing verified_via/verified_at; benign field updates still apply.
+        if (
+          existing.status === "active" &&
+          ch.verifiedVia !== undefined &&
+          isBindingDemotion(existing.verifiedVia, ch.verifiedVia)
+        ) {
+          log.warn(
+            {
+              channelId: existing.id,
+              existingVerifiedVia: existing.verifiedVia,
+              incomingVerifiedVia: ch.verifiedVia,
+            },
+            "syncChannels: refusing binding-strength demotion; preserving stronger verified_via",
+          );
+        } else {
+          if (ch.verifiedAt !== undefined) updateSet.verifiedAt = ch.verifiedAt;
+          if (ch.verifiedVia !== undefined)
+            updateSet.verifiedVia = ch.verifiedVia;
+        }
         if (ch.inviteId !== undefined) updateSet.inviteId = ch.inviteId;
         this.db
           .update(contactChannels)

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -15,6 +15,8 @@ import { existsSync } from "node:fs";
 
 import { and, eq, sql } from "drizzle-orm";
 
+import { isBindingDemotion } from "@vellumai/gateway-client";
+
 import { getGatewayDb } from "../db/connection.js";
 import {
   contactChannels as gwContactChannels,
@@ -82,6 +84,10 @@ export async function findContactChannelByAddress(
  * legacy/unmirrored channel may carry a different gateway id than the
  * assistant id, and a blind id-keyed update would silently affect 0 rows.
  *
+ * `verifiedAt` defaults to `now`; the caller passes an explicit value to
+ * preserve an existing timestamp when the binding-strength guard keeps a
+ * stronger `verifiedVia` (see {@link applyVerifiedChannelGatewayWrites}).
+ *
  * Returns true if a gateway row was updated or inserted; false if the only
  * matching row is blocked/revoked (so nothing was written).
  */
@@ -93,6 +99,7 @@ function writeVerifiedGatewayChannel(params: {
   externalChatId: string;
   verifiedVia: string;
   now: number;
+  verifiedAt?: number;
   allowRevokedReactivation?: boolean;
 }): boolean {
   const {
@@ -103,6 +110,7 @@ function writeVerifiedGatewayChannel(params: {
     externalChatId,
     verifiedVia,
     now,
+    verifiedAt,
     allowRevokedReactivation,
   } = params;
   const gwDb = getGatewayDb();
@@ -111,7 +119,7 @@ function writeVerifiedGatewayChannel(params: {
     policy: "allow",
     address,
     externalChatId,
-    verifiedAt: now,
+    verifiedAt: verifiedAt ?? now,
     verifiedVia,
     revokedReason: null,
     blockedReason: null,
@@ -523,8 +531,11 @@ export function applyVerifiedChannelGatewayWrites(params: {
   // The gateway is the source of truth: a blocked/revoked gateway row rejects
   // the verification, gating BOTH the existing-channel update and the
   // new-insert path so no active mirror is created for a blocked actor. A
-  // missing gateway row is the legitimate happy path (legacy/unmirrored).
-  const gwStatus = gatewayChannelStatus(sourceChannel, address);
+  // missing gateway row is the legitimate happy path (legacy/unmirrored). The
+  // same authoritative read carries the existing binding provenance for the
+  // demotion guard below.
+  const gwRow = getGatewayChannelByKey(sourceChannel, address);
+  const gwStatus = gwRow?.status ?? null;
   if (
     gwStatus === "blocked" ||
     (gwStatus === "revoked" && !allowRevokedReactivation)
@@ -534,6 +545,33 @@ export function applyVerifiedChannelGatewayWrites(params: {
       "Skipping upsert: authoritative gateway channel is blocked or revoked",
     );
     return { verified: false };
+  }
+
+  // Binding-strength guard (LUM-2505): a lower-strength source must never
+  // demote the recorded provenance of an already-active binding. When the
+  // incoming write would weaken the ladder, preserve the stronger existing
+  // `verified_via` / `verified_at`; the write still refreshes identity/ACL
+  // fields, it just cannot lower the proof. Only active bindings are protected
+  // — reactivation from revoked is invite-gated (a proven, top-tier
+  // `verified_via`) and keeps the incoming provenance.
+  let effectiveVerifiedVia = verifiedVia;
+  let effectiveVerifiedAt: number | undefined;
+  if (
+    gwRow &&
+    gwRow.status === "active" &&
+    isBindingDemotion(gwRow.verifiedVia, verifiedVia)
+  ) {
+    effectiveVerifiedVia = gwRow.verifiedVia ?? verifiedVia;
+    effectiveVerifiedAt = gwRow.verifiedAt ?? undefined;
+    log.warn(
+      {
+        sourceChannel,
+        address,
+        existingVerifiedVia: gwRow.verifiedVia,
+        incomingVerifiedVia: verifiedVia,
+      },
+      "Refusing binding-strength demotion: preserving stronger existing verified_via",
+    );
   }
 
   if (existing) {
@@ -575,8 +613,9 @@ export function applyVerifiedChannelGatewayWrites(params: {
       type: sourceChannel,
       address,
       externalChatId,
-      verifiedVia,
+      verifiedVia: effectiveVerifiedVia,
       now,
+      verifiedAt: effectiveVerifiedAt,
       allowRevokedReactivation,
     });
     // The pre-check passed, so a write is expected. A false means a
@@ -651,8 +690,9 @@ export function applyVerifiedChannelGatewayWrites(params: {
     type: sourceChannel,
     address,
     externalChatId,
-    verifiedVia,
+    verifiedVia: effectiveVerifiedVia,
     now,
+    verifiedAt: effectiveVerifiedAt,
     allowRevokedReactivation,
   });
   // A blocked/revoked gateway row appeared after the pre-check — reject

--- a/packages/gateway-client/src/__tests__/binding-strength-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/binding-strength-contract.test.ts
@@ -34,6 +34,9 @@ describe("knownStrengthRank", () => {
     expect(knownStrengthRank("invite")).toBe(3);
     expect(knownStrengthRank("voice")).toBe(3);
     expect(knownStrengthRank("bootstrap")).toBe(3);
+    // Guardian auto-registration bindings (createGuardianBinding writers).
+    expect(knownStrengthRank("platform_auto_register")).toBe(3);
+    expect(knownStrengthRank("webhook_registration")).toBe(3);
   });
 
   test("unrecognized non-empty provenance is unknown (null)", () => {
@@ -79,6 +82,14 @@ describe("isBindingDemotion", () => {
     ).toBe(true);
     // A proven value demoted to null/unverified is a demotion too.
     expect(isBindingDemotion(VERIFIED_VIA_CHALLENGE, null)).toBe(true);
+    // Guardian auto-registration bindings are proven — a later manual attest
+    // or channel claim can never demote them.
+    expect(
+      isBindingDemotion("platform_auto_register", VERIFIED_VIA_MANUAL),
+    ).toBe(true);
+    expect(
+      isBindingDemotion("webhook_registration", VERIFIED_VIA_CHANNEL_CLAIM),
+    ).toBe(true);
   });
 
   test("equal-tier writes and lateral proven swaps are not demotions", () => {

--- a/packages/gateway-client/src/__tests__/binding-strength-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/binding-strength-contract.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the shared binding-strength vocabulary: the display ladder and the
+ * enforcement order (demotion guard — LUM-2505).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  bindingStrengthForVerifiedVia,
+  isBindingDemotion,
+  knownStrengthRank,
+  VERIFIED_VIA_CHALLENGE,
+  VERIFIED_VIA_CHANNEL_CLAIM,
+  VERIFIED_VIA_MANUAL,
+} from "../binding-strength-contract.js";
+
+describe("knownStrengthRank", () => {
+  test("unverified (null / undefined / empty) ranks 0", () => {
+    expect(knownStrengthRank(null)).toBe(0);
+    expect(knownStrengthRank(undefined)).toBe(0);
+    expect(knownStrengthRank("")).toBe(0);
+  });
+
+  test("inbound channel claim ranks 1", () => {
+    expect(knownStrengthRank(VERIFIED_VIA_CHANNEL_CLAIM)).toBe(1);
+  });
+
+  test("workspace-vouched (manual) ranks 2", () => {
+    expect(knownStrengthRank(VERIFIED_VIA_MANUAL)).toBe(2);
+  });
+
+  test("proven / possession values all rank 3", () => {
+    expect(knownStrengthRank(VERIFIED_VIA_CHALLENGE)).toBe(3);
+    expect(knownStrengthRank("invite")).toBe(3);
+    expect(knownStrengthRank("voice")).toBe(3);
+    expect(knownStrengthRank("bootstrap")).toBe(3);
+  });
+
+  test("unrecognized non-empty provenance is unknown (null)", () => {
+    expect(knownStrengthRank("guardian_approval")).toBeNull();
+    expect(knownStrengthRank("something_new")).toBeNull();
+  });
+});
+
+describe("bindingStrengthForVerifiedVia (display ladder)", () => {
+  test("maps the three introduction-card provenances", () => {
+    expect(bindingStrengthForVerifiedVia(VERIFIED_VIA_CHALLENGE)).toBe(
+      "verified_handshake",
+    );
+    expect(bindingStrengthForVerifiedVia(VERIFIED_VIA_MANUAL)).toBe(
+      "internal_workspace_match",
+    );
+    expect(bindingStrengthForVerifiedVia(VERIFIED_VIA_CHANNEL_CLAIM)).toBe(
+      "inbound_channel_claim",
+    );
+  });
+
+  test("returns null for provenance outside the ladder (card UI relies on this)", () => {
+    expect(bindingStrengthForVerifiedVia("invite")).toBeNull();
+    expect(bindingStrengthForVerifiedVia("bootstrap")).toBeNull();
+    expect(bindingStrengthForVerifiedVia("voice")).toBeNull();
+    expect(bindingStrengthForVerifiedVia(null)).toBeNull();
+    expect(bindingStrengthForVerifiedVia(undefined)).toBeNull();
+  });
+});
+
+describe("isBindingDemotion", () => {
+  test("a lower-strength source demoting a higher-strength binding is refused", () => {
+    // challenge (3) is the strongest — nothing weaker may overwrite it.
+    expect(isBindingDemotion(VERIFIED_VIA_CHALLENGE, VERIFIED_VIA_MANUAL)).toBe(
+      true,
+    );
+    expect(
+      isBindingDemotion(VERIFIED_VIA_CHALLENGE, VERIFIED_VIA_CHANNEL_CLAIM),
+    ).toBe(true);
+    // manual (2) may not be demoted to an inbound claim (1).
+    expect(
+      isBindingDemotion(VERIFIED_VIA_MANUAL, VERIFIED_VIA_CHANNEL_CLAIM),
+    ).toBe(true);
+    // A proven value demoted to null/unverified is a demotion too.
+    expect(isBindingDemotion(VERIFIED_VIA_CHALLENGE, null)).toBe(true);
+  });
+
+  test("equal-tier writes and lateral proven swaps are not demotions", () => {
+    expect(isBindingDemotion(VERIFIED_VIA_CHALLENGE, "invite")).toBe(false);
+    expect(isBindingDemotion("invite", VERIFIED_VIA_CHALLENGE)).toBe(false);
+    expect(isBindingDemotion(VERIFIED_VIA_MANUAL, VERIFIED_VIA_MANUAL)).toBe(
+      false,
+    );
+  });
+
+  test("upgrades are not demotions", () => {
+    expect(
+      isBindingDemotion(VERIFIED_VIA_CHANNEL_CLAIM, VERIFIED_VIA_CHALLENGE),
+    ).toBe(false);
+    expect(isBindingDemotion(null, VERIFIED_VIA_CHANNEL_CLAIM)).toBe(false);
+    expect(isBindingDemotion(VERIFIED_VIA_MANUAL, VERIFIED_VIA_CHALLENGE)).toBe(
+      false,
+    );
+  });
+
+  test("unknown provenance on either side is never a demotion (fail-open)", () => {
+    expect(isBindingDemotion(VERIFIED_VIA_CHALLENGE, "guardian_approval")).toBe(
+      false,
+    );
+    expect(
+      isBindingDemotion("guardian_approval", VERIFIED_VIA_CHANNEL_CLAIM),
+    ).toBe(false);
+    expect(isBindingDemotion("unknown_a", "unknown_b")).toBe(false);
+  });
+});

--- a/packages/gateway-client/src/binding-strength-contract.ts
+++ b/packages/gateway-client/src/binding-strength-contract.ts
@@ -89,15 +89,20 @@ export function bindingStrengthForVerifiedVia(
 
 /**
  * `verified_via` values where the actor demonstrably controls the channel (a
- * code/token/possession proof) or is the guardian. They share the top
- * enforcement rank: none of them may be silently demoted, and a lateral swap
- * between them is not a demotion.
+ * code/token/possession proof) or the binding is a guardian binding (bootstrap
+ * or platform/webhook auto-registration). They share the top enforcement rank:
+ * none may be silently demoted, and a lateral swap between them is not a
+ * demotion. Every real production writer of `verified_via` that outranks
+ * `manual` must appear here, or the demotion guard would treat it as unknown
+ * (incomparable) and let a `manual` re-attest quietly demote it.
  */
 const PROVEN_VERIFIED_VIA: ReadonlySet<string> = new Set([
   VERIFIED_VIA_CHALLENGE, // returned a verification code
   "invite", // redeemed an invite code / token
   "voice", // returned a voice (DTMF) code
   "bootstrap", // guardian binding (also protected by the guardian-downgrade guard)
+  "platform_auto_register", // guardian binding auto-registered by the platform
+  "webhook_registration", // guardian binding registered via a provider webhook
 ]);
 
 /**

--- a/packages/gateway-client/src/binding-strength-contract.ts
+++ b/packages/gateway-client/src/binding-strength-contract.ts
@@ -1,0 +1,150 @@
+/**
+ * Shared binding-strength vocabulary for the contact channel `verified_via`
+ * provenance column.
+ *
+ * Two distinct notions live here, both keyed on the free-text `verified_via`
+ * audit value:
+ *
+ *  1. The 3-tier *display* ladder (`BindingStrength` +
+ *     `bindingStrengthForVerifiedVia`) the introduction card renders from. It
+ *     covers only the three introduction-card provenances and returns `null`
+ *     for everything else — the card UI depends on that exact shape.
+ *
+ *  2. The *enforcement* order (`knownStrengthRank` + `isBindingDemotion`) the
+ *     gateway ACL write path uses to refuse demotions (LUM-2505): a total,
+ *     conservative ranking over every real `verified_via` value, so a
+ *     lower-strength source can never silently overwrite a higher-strength
+ *     active binding.
+ *
+ * This lives in the shared package — not `assistant/` — because the gateway
+ * owns the contact ACL and is where the demotion guard runs. The assistant
+ * re-exports the display helpers from `runtime/introduction-policy.ts`, so its
+ * card/provenance call sites are unchanged.
+ *
+ * No import from `assistant/` or `gateway/`: pure vocabulary.
+ */
+
+// ---------------------------------------------------------------------------
+// verified_via constants
+// ---------------------------------------------------------------------------
+
+/** `verified_via` written by the gateway when a verification code is redeemed. */
+export const VERIFIED_VIA_CHALLENGE = "challenge";
+
+/** `verified_via` written when the guardian direct-trusts a workspace-vouched identity. */
+export const VERIFIED_VIA_MANUAL = "manual";
+
+/** `verified_via` written when the guardian trusts an identity the platform is not vouching for. */
+export const VERIFIED_VIA_CHANNEL_CLAIM = "manual_channel_claim";
+
+// ---------------------------------------------------------------------------
+// Display ladder (introduction card)
+// ---------------------------------------------------------------------------
+
+/**
+ * Binding-strength ladder the introduction card renders:
+ *
+ *   verified_handshake > internal_workspace_match > inbound_channel_claim
+ *
+ * - `verified_handshake` — the contact proved control of the channel by
+ *   returning a verification code (`verified_via: "challenge"`).
+ * - `internal_workspace_match` — the platform authenticated the identity inside
+ *   the guardian's own workspace; the guardian vouches directly
+ *   (`verified_via: "manual"`).
+ * - `inbound_channel_claim` — the guardian trusts an identity the platform is
+ *   NOT vouching for (`verified_via: "manual_channel_claim"`).
+ */
+export type BindingStrength =
+  | "verified_handshake"
+  | "internal_workspace_match"
+  | "inbound_channel_claim";
+
+/**
+ * Derive the display binding strength for a `verified_via`. Returns `null` for
+ * provenance outside the introduction ladder (e.g. `invite`, `bootstrap`),
+ * which predate it and keep their own audit meaning — the introduction card UI
+ * relies on this exact shape.
+ *
+ * This is the DISPLAY ladder, not the enforcement order: use
+ * {@link knownStrengthRank} / {@link isBindingDemotion} for the demotion guard.
+ */
+export function bindingStrengthForVerifiedVia(
+  verifiedVia: string | null | undefined,
+): BindingStrength | null {
+  switch (verifiedVia) {
+    case VERIFIED_VIA_CHALLENGE:
+      return "verified_handshake";
+    case VERIFIED_VIA_MANUAL:
+      return "internal_workspace_match";
+    case VERIFIED_VIA_CHANNEL_CLAIM:
+      return "inbound_channel_claim";
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Enforcement order (demotion guard — LUM-2505)
+// ---------------------------------------------------------------------------
+
+/**
+ * `verified_via` values where the actor demonstrably controls the channel (a
+ * code/token/possession proof) or is the guardian. They share the top
+ * enforcement rank: none of them may be silently demoted, and a lateral swap
+ * between them is not a demotion.
+ */
+const PROVEN_VERIFIED_VIA: ReadonlySet<string> = new Set([
+  VERIFIED_VIA_CHALLENGE, // returned a verification code
+  "invite", // redeemed an invite code / token
+  "voice", // returned a voice (DTMF) code
+  "bootstrap", // guardian binding (also protected by the guardian-downgrade guard)
+]);
+
+/**
+ * Total, conservative strength rank for a `verified_via`, used by the gateway
+ * ACL write path to refuse demotions. Higher = stronger. Grouped into coarse
+ * tiers that hold under ANY intra-tier ordering the pending Slack-permissions
+ * PRD (D4) may land on:
+ *
+ *   3  proven / possession — {@link PROVEN_VERIFIED_VIA}.
+ *   2  workspace-vouched — the platform authenticated the identity but the
+ *      actor did not actively prove control here (`manual`).
+ *   1  inbound channel claim — nobody vouches; the guardian trusted an
+ *      unproven claim (`manual_channel_claim`).
+ *   0  unverified — no verification at all (`null` / empty).
+ *
+ * Returns `null` for an unrecognized non-empty provenance ("unknown"). The
+ * demotion guard treats unknown as incomparable and never refuses on it, so a
+ * forward-compatible new `verified_via` value is never mistaken for a demotion.
+ */
+export function knownStrengthRank(
+  verifiedVia: string | null | undefined,
+): number | null {
+  if (verifiedVia == null || verifiedVia === "") return 0;
+  if (PROVEN_VERIFIED_VIA.has(verifiedVia)) return 3;
+  if (verifiedVia === VERIFIED_VIA_MANUAL) return 2;
+  if (verifiedVia === VERIFIED_VIA_CHANNEL_CLAIM) return 1;
+  return null;
+}
+
+/**
+ * Whether writing `incomingVia` over an existing `existingVia` binding would
+ * LOWER its strength — the demotion the gateway ACL write path refuses
+ * (LUM-2505).
+ *
+ * True only when BOTH provenances are known and the incoming rank is strictly
+ * lower than the existing. Unknown provenance on either side is incomparable
+ * and never counts as a demotion (fail-open), so the guard blocks only provable
+ * downgrades and never breaks a new/unrecognized `verified_via`. Equal ranks
+ * (including lateral swaps within the proven tier) and upgrades are not
+ * demotions.
+ */
+export function isBindingDemotion(
+  existingVia: string | null | undefined,
+  incomingVia: string | null | undefined,
+): boolean {
+  const existing = knownStrengthRank(existingVia);
+  const incoming = knownStrengthRank(incomingVia);
+  if (existing == null || incoming == null) return false;
+  return incoming < existing;
+}

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -321,3 +321,17 @@ export type {
   ResolvedChannelPermission,
   RiskThreshold,
 } from "./channel-permission-contract.js";
+
+// Binding-strength vocabulary for the contact `verified_via` provenance —
+// display ladder (introduction card) + the enforcement order the gateway ACL
+// write path uses to refuse demotions (LUM-2505).
+export {
+  bindingStrengthForVerifiedVia,
+  isBindingDemotion,
+  knownStrengthRank,
+  VERIFIED_VIA_CHALLENGE,
+  VERIFIED_VIA_CHANNEL_CLAIM,
+  VERIFIED_VIA_MANUAL,
+} from "./binding-strength-contract.js";
+
+export type { BindingStrength } from "./binding-strength-contract.js";


### PR DESCRIPTION
## Prompt / plan

Investigating [LUM-2505](https://linear.app/vellum/issue/LUM-2505/contact-resolver-lets-lower-strength-inbound-claim-overwrite-a) — *"Contact resolver lets lower-strength inbound claim overwrite a verified contact slot."* Confirmed still an issue, then fixed it at the root.

**Root cause.** The gateway owns the contact ACL, and channels carry a `verified_via` provenance column, but no write path compared *binding strength* before overwriting it — the writes gated only on channel `status` (blocked/revoked). So a lower-strength source (a `manual` roster "Link account" attest, or a "Trust anyway" `manual_channel_claim` activation) could silently overwrite a stronger `challenge` (code-proven) binding on the same `(type, address)` row. The three-tier ladder the ticket references already existed — but only as *provenance/audit* in `assistant/src/runtime/introduction-policy.ts` (added by #36874 / LUM-2670, which explicitly noted "nothing branches on `verifiedVia`"), living on the wrong side (assistant, not the gateway that owns the ACL).

**Fix (substrate guard, gateway-owned).**
- **New** `packages/gateway-client/src/binding-strength-contract.ts` — the canonical, gateway-owned strength vocabulary. `knownStrengthRank` is a *total, conservative* rank over every real `verified_via` (proven = `challenge`/`invite`/`voice`/`bootstrap`, workspace-vouched = `manual`, inbound-claim = `manual_channel_claim`, unverified = `null`; any unrecognized value → `null` / no-op). `isBindingDemotion(existing, incoming)` is true only when *both* are known and incoming is strictly weaker — unknown provenance on either side never blocks (fail-open), so a forward-compatible new `verified_via` is never mistaken for a demotion. The display ladder (`bindingStrengthForVerifiedVia`) moves here unchanged.
- `assistant/src/runtime/introduction-policy.ts` re-exports the ladder from the shared package; all its importers are untouched.
- Enforcement in the three gateway write paths, **preserving the stronger active binding** (never a hard-refuse — a benign re-trust / re-link is an idempotent no-op, not an error): `applyVerifiedChannelGatewayWrites` (`contact-helpers.ts`), `ContactStore.syncChannels`, `ContactStore.markChannelVerified`.

**Scope.** Substrate guard only — the full three-tier precedence *policy* is pending the D4 Slack-permissions PRD, and any tier ordering it lands on is consistent with this guard. No schema change (`verified_via` stays free-text); capabilities unchanged (`trusted_contact` ≡ `unverified_contact`).

The one intentional behavior change: an active `challenge` binding is no longer demoted to `manual` by a re-attest. `markChannelVerified`'s old "upgrades a challenge-verified channel to manual" test is flipped to assert preservation — that "upgrade" was precisely the bug.

## Behavior: before vs after

Strength ladder for reference: **proven** (`challenge`/`invite`/`voice`/`bootstrap`) > **workspace-vouched** (`manual`) > **inbound-claim** (`manual_channel_claim`) > **unverified** (`null`).

| Scenario | Before | After |
| --- | --- | --- |
| Stranger / "Trust anyway" (`manual_channel_claim`) write lands on a channel already `challenge`-verified — **the LUM-2505 takeover** | `verified_via` overwritten to `manual_channel_claim`; the code-proven binding is silently lost | **Refused** — `challenge` + original `verified_at` preserved; identity/ACL fields (address, chat id) still refresh |
| Roster "Link account" `manual` attest on an active `challenge` channel (`markChannelVerified`) | Demoted to `manual`, `verified_at` bumped, `didWrite: true` | Stays `challenge` (original `verified_at`), `didWrite: false` — idempotent no-op |
| A weaker `verified_via` reaches `upsertContact` / `syncChannels` for an active stronger channel | `verified_via` / `verified_at` overwritten with the weaker value | Weaker provenance dropped from the update; stronger binding preserved (other fields still sync) |
| **Upgrade** — weaker → stronger (e.g. `manual_channel_claim` → `challenge`, `manual` → `challenge`) | Applied | Applied — **unchanged** (only demotions are refused) |
| Equal / lateral within the proven tier (e.g. `challenge` ↔ `invite`) | Overwrites | Allowed — not a demotion, **unchanged** |
| First verification of a new / `unverified` channel (no prior binding) | Writes the incoming `verified_via` | **Unchanged** |
| Unrecognized / future `verified_via` value | (no strength concept) overwrites | **Fail-open** — never treated as a demotion; the write proceeds |
| Blocked / revoked channel | Blocked never reactivated; revoked only via the invite path | **Unchanged** — the new guard only protects *active* bindings; the status guards are untouched |
| Where the ladder lives / whether it's enforced | Defined in the assistant (`introduction-policy.ts`) as provenance/audit only — never consulted by any write | Canonical in `@vellumai/gateway-client`; **enforced** at the gateway ACL write path (assistant re-exports it) |

## Test plan

- **New** `packages/gateway-client/src/__tests__/binding-strength-contract.test.ts` — full truth table for `knownStrengthRank` + `isBindingDemotion` (every real value, null, unknown fail-open, equal-tier, upgrades). ✅ 11/11
- **Gateway write paths** (real in-memory gateway DB): `contact-handlers.test.ts` — `upsert_verified_channel` refuses `manual` / `manual_channel_claim` over an active `challenge` and still applies upgrades (the `applyVerifiedChannelGatewayWrites` path); `contact-store-mark-channel-verified.test.ts` — demotion refused, upgrade applied, plus `syncChannels` via `upsertContact`. ✅ 17 + 23
- Regression suites green: `upsert-verified-contact-channel.test.ts` (45), `ipc-contact-routes.test.ts` (47), `introduction-policy.test.ts` (19), `introduction-card-resolver.test.ts` (10). *(Run per-file — these gateway suites share the repo's known cross-file `mock.module` bleed; each passes individually.)*
- `tsc --noEmit` clean in `packages/gateway-client`, `gateway`, `assistant`; eslint clean on changed files; `bun run generate:openapi` produced **no diff** (no schema change).

## CLI verb checklist

No new IPC/HTTP routes — the change is internal to existing gateway write paths plus the shared contract package, so no `assistant` CLI verb is needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_018sY9Q7dnqUYJLHExxMrjUp)_