### PR TITLE
fix(storybook): repair broken stories and add markdown kitchen-sink coverage

### DIFF
--- a/clients/web/src/domains/chat/transcript/transcript.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.stories.tsx
@@ -147,6 +147,44 @@ export const Conversation: Story = {
   render: (args) => <TranscriptAtLatest {...args} />,
 };
 
+// Messages exercising the block-level markdown the transcript renders beyond
+// plain prose — blockquote with inline code chips, a table with wrapping code
+// cells, and a fenced block — so message-level rendering regressions in those
+// shapes are visible in a transcript context, not just in the design library's
+// isolated MarkdownMessage stories.
+const RICH_CONTENT: TranscriptItem[] = [
+  user("ru1", "What did the failing config look like?"),
+  assistant(
+    "ra1",
+    [
+      "The report quoted it directly:",
+      "",
+      "> Settings shows `backup.enabled` as `false` in config, and",
+      "> `handleBackupCreate()` throws a `BadRequestError` saying creation",
+      "> moved to the gateway (`POST /v1/backups/create`).",
+      "",
+      "The relevant keys:",
+      "",
+      "| Key | Value |",
+      "| --- | --- |",
+      "| `backup.enabled` | `false` |",
+      "| `backup.localDirectory` | `null` — falls back to the workspace-adjacent default |",
+      "",
+      "And the fix:",
+      "",
+      "```ts",
+      "await updateConfig({ backup: { enabled: true } });",
+      "```",
+    ].join("\n"),
+  ),
+];
+
+/** Quote + inline code, a table, and fenced code inside real transcript rows. */
+export const RichContent: Story = {
+  args: { items: RICH_CONTENT },
+  render: (args) => <TranscriptAtLatest {...args} />,
+};
+
 /** No messages yet — a fresh conversation renders an empty transcript. */
 export const Empty: Story = {
   args: { items: [] },

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
@@ -62,9 +62,18 @@ function useWordStream(
   useEffect(() => {
     onResetRef.current();
     let i = 0;
-    const id = setInterval(() => {
+    const step = () => {
       i += 1;
       onWordRef.current(words.slice(0, i).join(" "));
+    };
+    // Land the first word synchronously so the scene never renders an empty
+    // frame — screenshots and visual sweeps otherwise capture a blank panel
+    // during the first interval tick.
+    if (words.length > 0) {
+      step();
+    }
+    const id = setInterval(() => {
+      step();
       if (i >= words.length) {
         clearInterval(id);
       }

--- a/clients/web/src/domains/contacts/components/provenance-pill.stories.tsx
+++ b/clients/web/src/domains/contacts/components/provenance-pill.stories.tsx
@@ -1,24 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { MemoryRouter } from "react-router";
 
 import { ProvenancePill } from "./provenance-pill";
 
 /**
  * Cascade provenance pill for a contact channel's effective access — names
  * the layer the admission floor comes from. The channel-default state links
- * "Channels → Slack" to that channel's sub-tab on the Channels page, so the
- * stories mount inside a router.
+ * "Channels → Slack" to that channel's sub-tab on the Channels page; the
+ * router it needs comes from the global preview decorator, which wraps every
+ * story in a MemoryRouter (a story-level router would nest and crash).
  */
 const meta: Meta<typeof ProvenancePill> = {
   title: "Contacts/ProvenancePill",
   component: ProvenancePill,
-  decorators: [
-    (Story) => (
-      <MemoryRouter>
-        <Story />
-      </MemoryRouter>
-    ),
-  ],
 };
 
 export default meta;

--- a/clients/web/src/domains/intelligence/intelligence-layout.stories.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Navigate } from "react-router";
+import { Navigate, Route, Routes } from "react-router";
 
 import { IntelligenceLayout } from "./intelligence-layout";
 
@@ -38,5 +38,35 @@ export const SectionChrome: Story = {
   ],
 };
 
-/** At a non-section path the layout renders bare — an empty outlet here. */
-export const BareOverview: Story = {};
+/**
+ * At a non-section path the layout renders bare — no back link, no heading —
+ * and passes the outlet through untouched. A stub child route stands in for
+ * the overview stage so the story renders visible content (an empty outlet
+ * makes the story a blank page that can't distinguish working from broken).
+ */
+export const BareOverview: Story = {
+  render: () => (
+    <Routes>
+      <Route element={<IntelligenceLayout />}>
+        <Route
+          index
+          element={
+            <div
+              style={{
+                display: "grid",
+                placeItems: "center",
+                height: "100%",
+                width: "100%",
+                border: "1px dashed var(--border-default)",
+                borderRadius: 8,
+                color: "var(--content-tertiary)",
+              }}
+            >
+              overview stage (outlet content)
+            </div>
+          }
+        />
+      </Route>
+    </Routes>
+  ),
+};

--- a/packages/design-library/src/components/markdown-message.stories.tsx
+++ b/packages/design-library/src/components/markdown-message.stories.tsx
@@ -57,6 +57,60 @@ export const LongCodeBlock: Story = {
 };
 
 /**
+ * Every markdown feature the component styles, in one story — the visual-QA
+ * sweep target. Each block exercises a dedicated component override (heading
+ * levels, lists with pinned ordinals, quote with inline code, table with
+ * wrapping code, fenced code, hr, emphasis with emoji, image fallback), so a
+ * regression in any of them is visible here without hunting per-feature
+ * stories.
+ */
+export const KitchenSink: Story = {
+  args: {
+    content: [
+      "# Heading one",
+      "## Heading two",
+      "### Heading three",
+      "#### Heading four",
+      "##### Heading five",
+      "###### Heading six",
+      "",
+      "Prose with **bold**, _italic *🎉* emoji_, ~~strikethrough~~, a [link](https://example.com), and inline `code.chips` mixed into the sentence flow across `multiple` tokens.",
+      "",
+      "- bullet one",
+      "- bullet two",
+      "  - nested bullet",
+      "",
+      "1. first",
+      "2. second",
+      "4. fourth — typed ordinal is preserved",
+      "",
+      "- [ ] open task",
+      "- [x] done task",
+      "",
+      "> Quote mixing prose with `inline.code` chips across lines —",
+      "> `handleBackupCreate()` throws a `BadRequestError` here, and the",
+      "> accent bar spans the quote's full height.",
+      "",
+      "| Function | Usage |",
+      "| --- | --- |",
+      "| `useState` | `const [s, setS] = useState(initialValue)` |",
+      "| plain cell | prose that wraps onto a second line inside the cell |",
+      "",
+      "```ts",
+      "const answer: number = 42;",
+      "export function greet(name: string): string {",
+      '  return `hello ${name}`;',
+      "}",
+      "```",
+      "",
+      "---",
+      "",
+      "![missing image](https://example.com/blocked.png)",
+    ].join("\n"),
+  },
+};
+
+/**
  * Regression guard for JARVIS-1006: monetary values must render as plain text
  * rather than being greedily paired into italic LaTeX math by remark-math.
  */


### PR DESCRIPTION
Fixes [LUM-2791](https://linear.app/vellum/issue/LUM-2791/web-storybook-health-fix-broken-stories-add-markdown-kitchen-sink)

## Prompt / plan

A headless-Chromium screenshot sweep of both Storybooks (188 web + 116 design-library stories), run during the LUM-2788 investigation, found stories that render error screens or blank pages, plus the coverage gap that let LUM-2788's quote collapse and the cramped code-block leading go undetected for so long. This PR repairs the broken stories and closes the markdown coverage gap:

**Repairs**
- **ProvenancePill (3 stories)** crashed with "You cannot render a `<Router>` inside another `<Router>`" — the story added its own `MemoryRouter` while the global preview decorator already wraps every story in one. Dropped the story-level router; the doc comment now points future stories at the global one.
- **IntelligenceLayout / Bare Overview** rendered a fully blank page (bare layout + empty outlet). The story now mounts the layout with a stub index child route so it renders visible outlet content — a story that renders nothing can't distinguish working from broken.
- **Voice transcript Reveal harness** started from an empty frame and streamed its first word only after the first interval tick, so screenshots and visual sweeps captured a blank panel. The first word now lands synchronously.

**Coverage**
- **`MarkdownMessage` KitchenSink story** (design library): every feature the component styles in one story — h1–h6, bullet/nested/ordered lists with pinned ordinals, task lists, blockquote mixing prose with inline code, a table with wrapping code cells, fenced code, hr, emphasis with emoji, and the blocked-external-image fallback. This is the visual-QA sweep target going forward.
- **Transcript RichContent story** (web): quote + inline code, a table, and fenced code inside real transcript rows — the existing transcript stories only rendered plain prose, so message-level rendering regressions were invisible at the transcript level.

## Test plan

- Rebuilt both Storybooks and re-screenshotted the repaired + new stories in headless Chromium: all three ProvenancePill stories render pills (no error screen), BareOverview shows the stub stage inside the bare layout, the Reveal panel shows content on its first frame, and the KitchenSink / RichContent stories render all features correctly (screenshots in the review thread).
- `clients/web` `bunx tsc --noEmit` and design-library typecheck pass. Stories-only change plus one story-harness function — no component code touched.

## CLI verb checklist

No new routes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPEsEduoBTUyfbpLirzdAu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPEsEduoBTUyfbpLirzdAu)_