### PR TITLE
fix(web): smooth the provisioning takeover's phase changes and ending

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -136,6 +136,13 @@ export function BillingOnboardingModal({
   const provisioningContentClass =
     "overflow-hidden inset-0 max-w-none w-screen h-screen max-h-none rounded-none border-0";
 
+  // The backdrop goes from a 50% scrim to solid black as the takeover opens.
+  // Easing that colour keeps the room darkening rather than blinking; padding
+  // isn't animatable and rides along with the geometry.
+  const overlayClass = `transition-[background-color] duration-300 ease-out${
+    isTakeover ? " bg-black p-0" : ""
+  }`;
+
   return (
     <Modal.Root open={open} onOpenChange={(o) => { if (!o) handleClose(); }}>
       <Modal.Content
@@ -145,7 +152,7 @@ export function BillingOnboardingModal({
         onEscapeKeyDown={lockTakeover ? (e) => e.preventDefault() : undefined}
         onInteractOutside={lockTakeover ? (e) => e.preventDefault() : undefined}
         data-theme={isTakeover ? "dark" : undefined}
-        overlayClassName={isTakeover ? "bg-black p-0" : undefined}
+        overlayClassName={overlayClass}
         className={isTakeover ? provisioningContentClass : "overflow-hidden"}
       >
         {/* Keyed on step so the fade replays as we swap takeover ⇄ card. */}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -71,13 +71,23 @@ export interface ProvisioningStateProps {
  * the avatar resolves or when none is configured. The idle breathe + reduced
  * -motion gating come from `AnimatedAvatar` inside `ChatAvatar`.
  */
-function TakeoverAvatar({ assistantId }: { assistantId?: string | null }) {
+function TakeoverAvatar({
+  assistantId,
+  resolved,
+}: {
+  assistantId?: string | null;
+  /** The work finished — play the one-shot settle. */
+  resolved: boolean;
+}) {
   const activeId = useResolvedAssistantsStore.use.activeAssistantId();
   const resolvedId = assistantId ?? activeId;
   const { components, traits, customImageUrl } = useAssistantAvatar(resolvedId);
   const fallbackComponents = useBundledAvatarComponents();
   return (
-    <div aria-hidden className="flex flex-col items-center">
+    <div
+      aria-hidden
+      className={`flex flex-col items-center ${resolved ? "provision-avatar-resolved" : ""}`}
+    >
       <ChatAvatar
         components={components ?? fallbackComponents}
         traits={traits}
@@ -358,8 +368,10 @@ export function ProvisioningState({
     onCelebrationEndRef.current = onCelebrationEnd;
   }, [onCelebrationEnd]);
 
-  const dwelling =
-    celebrating && (state === "DONE" || state === "NOT_APPLICABLE");
+  const resolved = state === "DONE" || state === "NOT_APPLICABLE";
+  const phaseKey = state === "RESIZING" ? "WAITING" : state;
+
+  const dwelling = celebrating && resolved;
   useEffect(() => {
     if (!dwelling) {
       return;
@@ -374,8 +386,16 @@ export function ProvisioningState({
       className="relative flex h-full min-h-[420px] w-full flex-col items-center justify-center gap-10 px-6 py-10 text-center"
       style={{ backgroundColor: TAKEOVER_BACKGROUND }}
     >
-      <TakeoverAvatar assistantId={assistantId} />
-      <div className="flex flex-col items-center gap-8 [animation:onboarding-step-in_350ms_ease-out] motion-reduce:[animation:none]">
+      <TakeoverAvatar assistantId={assistantId} resolved={resolved} />
+      {/* Keyed so each phase replays the entrance instead of swapping its copy
+          in place. WAITING and RESIZING render identical copy, so they share a
+          key and don't retrigger. The min-height anchors the block: phases
+          carry different chip counts, and without it the whole centred group
+          jumps as they swap. */}
+      <div
+        key={phaseKey}
+        className="flex min-h-[120px] w-full flex-col items-center gap-8 [animation:onboarding-step-in_420ms_ease-out] motion-reduce:[animation:none]"
+      >
         {renderPhase()}
       </div>
     </div>

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -282,6 +282,25 @@ body {
   to { opacity: 1; transform: translateY(0); }
 }
 
+/* Provisioning takeover — the avatar acknowledges completion with the same
+ * overshoot the hatching screen uses on resolve, held a touch longer so it
+ * reads as settling rather than bouncing. */
+@keyframes provision-resolve {
+  0% { transform: scale(1); }
+  55% { transform: scale(1.1); }
+  100% { transform: scale(1.06); }
+}
+
+.provision-avatar-resolved {
+  animation: provision-resolve 0.82s cubic-bezier(0.34, 1.4, 0.64, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .provision-avatar-resolved {
+    animation: none;
+  }
+}
+
 /* App shell sizing guards: keep routed pages from collapsing inside flex
  * main containers. */
 .app-shell {


### PR DESCRIPTION
## Summary

The Pro provisioning takeover cut between its own phases. `onboarding-step-in` sat on a **static wrapper that never re-keys** (`provisioning-state.tsx`), so it played once on mount and never again — when the state moved `CONFIRMING → WAITING → DONE`, the heading, caption and chips were replaced with no transition at all.

Three presentational changes:

- **Phase entrance.** The phase block is keyed so each one enters on the same rise the rest of onboarding uses, at 420ms. `WAITING` and `RESIZING` render identical copy and share a key, so they don't retrigger.
- **Anchored height.** Each phase carries a different chip set (`IntentChips` / `ResourceChangeChips` / `TargetChips`) at a different height, and in a `justify-center` column the whole group shifted vertically on every swap. A `min-h-[120px]` anchor holds it still.
- **An ending.** `TakeoverAvatar` idled on the same breathe from first paint through "All done!". It now plays a one-shot settle on resolve — `provision-resolve`, a 0.82s overshoot mirroring `.onboarding-avatar-awake` on the hatching screen, with a reduced-motion guard.

Plus the backdrop: it flipped `bg-black/50` → solid `bg-black` instantly. It now eases over 300ms so the room darkens rather than blinking. Padding isn't animatable and still rides along with the geometry.

## Deliberately not in this PR

- **The card → fullscreen geometry snap.** `Modal.Content` swaps to `inset-0 w-screen h-screen` in one frame. Fixing it means restructuring the modal into layers rather than morphing one container, which is a bigger change than this.
- **Carrying the avatar across the handoff.** Blocked by `key={step}` on the content wrapper, which forces a remount and makes a shared element impossible. That key exists only to replay the fade, so it has to be replaced first.
- **A minimum dwell for intermediate phases.** `PROVISION_MIN_DWELL_MS` (2,500ms) is documented as "minimum time a provisioning phase stays on screen so it doesn't flash" but is only wired to `celebrating && (DONE || NOT_APPLICABLE)` — the intermediate phases have no floor, so a fast upgrade flashes two phases in under a second. Fixing that changes timing behaviour and needs test changes, so it's separate.

Everything here is presentational — no render is delayed, so the existing `getByText` assertions are unaffected.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `provisioning-state.test.tsx` — 20 pass
- `billing-onboarding-modal.test.tsx` — 20 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)