### PR TITLE
Author + single-source bookmark events from api/events

### DIFF
--- a/assistant/src/api/events/bookmark-created.ts
+++ b/assistant/src/api/events/bookmark-created.ts
@@ -1,0 +1,37 @@
+/**
+ * `bookmark.created` SSE event.
+ *
+ * Server → client broadcast emitted after a bookmark is created, so a
+ * `BookmarkStore` in any other connected client refreshes in lock-step.
+ * Carries the full `BookmarkSummary` for the new bookmark.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+/** Summary row for a saved message, as surfaced to clients. */
+export const BookmarkSummarySchema = z.object({
+  id: z.string(),
+  messageId: z.string(),
+  conversationId: z.string(),
+  conversationTitle: z.string().nullable(),
+  messagePreview: z.string(),
+  /** "user" | "assistant" — kept free-form so it round-trips raw. */
+  messageRole: z.string(),
+  /** Unix milliseconds. */
+  messageCreatedAt: z.number(),
+  /** Unix milliseconds. */
+  createdAt: z.number(),
+});
+
+export type BookmarkSummary = z.infer<typeof BookmarkSummarySchema>;
+
+export const BookmarkCreatedEventSchema = z.object({
+  type: z.literal("bookmark.created"),
+  bookmark: BookmarkSummarySchema,
+});
+
+export type BookmarkCreatedEvent = z.infer<typeof BookmarkCreatedEventSchema>;

--- a/assistant/src/api/events/bookmark-deleted.ts
+++ b/assistant/src/api/events/bookmark-deleted.ts
@@ -1,0 +1,20 @@
+/**
+ * `bookmark.deleted` SSE event.
+ *
+ * Server → client broadcast emitted after a bookmark is removed, so a
+ * `BookmarkStore` in any other connected client drops it in lock-step.
+ * Identifies the bookmark by the `messageId` it was anchored to.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const BookmarkDeletedEventSchema = z.object({
+  type: z.literal("bookmark.deleted"),
+  messageId: z.string(),
+});
+
+export type BookmarkDeletedEvent = z.infer<typeof BookmarkDeletedEventSchema>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -12,6 +12,8 @@ import { AssistantTurnStartEventSchema } from "./events/assistant-turn-start.js"
 import { AvatarUpdatedEventSchema } from "./events/avatar-updated.js";
 import { BackgroundToolCompletedEventSchema } from "./events/background-tool-completed.js";
 import { BackgroundToolStartedEventSchema } from "./events/background-tool-started.js";
+import { BookmarkCreatedEventSchema } from "./events/bookmark-created.js";
+import { BookmarkDeletedEventSchema } from "./events/bookmark-deleted.js";
 import { CompactionCircuitClosedEventSchema } from "./events/compaction-circuit-closed.js";
 import { CompactionCircuitOpenEventSchema } from "./events/compaction-circuit-open.js";
 import { ConfirmationRequestEventSchema } from "./events/confirmation-request.js";
@@ -143,6 +145,16 @@ export {
   type BackgroundToolStartedEvent,
   BackgroundToolStartedEventSchema,
 } from "./events/background-tool-started.js";
+export {
+  type BookmarkCreatedEvent,
+  BookmarkCreatedEventSchema,
+  type BookmarkSummary,
+  BookmarkSummarySchema,
+} from "./events/bookmark-created.js";
+export {
+  type BookmarkDeletedEvent,
+  BookmarkDeletedEventSchema,
+} from "./events/bookmark-deleted.js";
 export {
   type CompactionCircuitClosedEvent,
   CompactionCircuitClosedEventSchema,
@@ -656,6 +668,8 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   AvatarUpdatedEventSchema,
   BackgroundToolCompletedEventSchema,
   BackgroundToolStartedEventSchema,
+  BookmarkCreatedEventSchema,
+  BookmarkDeletedEventSchema,
   CompactionCircuitClosedEventSchema,
   CompactionCircuitOpenEventSchema,
   ConfirmationRequestEventSchema,

--- a/assistant/src/daemon/message-types/bookmarks.ts
+++ b/assistant/src/daemon/message-types/bookmarks.ts
@@ -1,18 +1,13 @@
 // Bookmark events. Surfaced over SSE so a `BookmarkStore` instance in any
 // connected client can stay in sync when another window mutates the list.
+//
+// Server→client events are single-sourced from their canonical `api/events`
+// wire schemas; this file only composes them into the domain union consumed by
+// `message-protocol.ts`.
 
-import type { BookmarkSummary } from "../../persistence/bookmark-crud.js";
+import type { BookmarkCreatedEvent } from "../../api/events/bookmark-created.js";
+import type { BookmarkDeletedEvent } from "../../api/events/bookmark-deleted.js";
 
-export interface BookmarkCreated {
-  type: "bookmark.created";
-  bookmark: BookmarkSummary;
-}
-
-export interface BookmarkDeleted {
-  type: "bookmark.deleted";
-  messageId: string;
-}
-
-// --- Domain-level union aliases (consumed by the barrel file) ---
-
-export type _BookmarksServerMessages = BookmarkCreated | BookmarkDeleted;
+export type _BookmarksServerMessages =
+  | BookmarkCreatedEvent
+  | BookmarkDeletedEvent;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -439,9 +439,11 @@ export function useStreamEventHandler(
           break;
         // Cross-domain events handled by bus subscribers mounted in
         // RootLayout (useAssistantResourceSync, useConversationSync,
-        // useNotificationIntentSync, useDocumentEditorSync) or
-        // ChatPage-scoped hooks (useDiskPressureMonitor). The chat
+        // useNotificationIntentSync, useDocumentEditorSync, useBookmarksSync)
+        // or ChatPage-scoped hooks (useDiskPressureMonitor). The chat
         // handler is intentionally a no-op for these.
+        case "bookmark.created":
+        case "bookmark.deleted":
         case "sync_changed":
         case "home_feed_updated":
         case "relationship_state_updated":

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -91,6 +91,11 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   // global to avoid being dropped as "missing conversationId".
   "memory_recalled",
   "memory_status",
+  // Bookmark create/delete broadcasts sync the bookmark list across clients
+  // (handled by useBookmarksSync). They carry no top-level `conversationId`, so
+  // gate them as global.
+  "bookmark.created",
+  "bookmark.deleted",
 ] as const;
 
 const GLOBAL_STREAM_EVENT_TYPES: ReadonlySet<string> = new Set(

--- a/clients/web/src/hooks/use-bookmarks-sync.ts
+++ b/clients/web/src/hooks/use-bookmarks-sync.ts
@@ -6,9 +6,9 @@
  * lock-step. This hook listens on the event bus and invalidates the shared
  * bookmark query when one of those events lands.
  *
- * The discriminant is read as a plain string: the published
- * `@vellumai/assistant-api` event union does not model bookmark events, so a
- * typed `=== "bookmark.created"` comparison would not narrow.
+ * The discriminant is read as a plain string: the bus envelope's `message` is
+ * generically typed, so this consumer matches on the raw `type` field rather
+ * than narrowing the `@vellumai/assistant-api` event union.
  *
  * References:
  * - EVENT_BUS.md — bus subscription contract


### PR DESCRIPTION
## Why

Continues the event-type unification effort — making `api/events/*.ts` the single source of truth for every server→client event. Following `upgrades` (#38767) and `memory` (#38778), this authors the canonical schemas for the `bookmarks` domain.

## What

- **New `api/events/bookmark-created.ts`** — schema + type for `bookmark.created`, including the `BookmarkSummary` payload shape (transcribed 1:1 from `persistence/bookmark-crud.ts`, exported so it's a reusable wire type).
- **New `api/events/bookmark-deleted.ts`** — schema + type for `bookmark.deleted`.
- **`api/index.ts`** — register both at the three sites (import, re-export, `AssistantEventSchema` union).
- **`daemon/message-types/bookmarks.ts`** — `_BookmarksServerMessages` now composes the api-inferred `*Event` types.

The producer (`bookmark-routes.ts`) builds these events inline by shape, validated by typecheck against the api-inferred union — no type-import to rename.

## Web

`bookmark.created` / `bookmark.deleted` carry no `conversationId` and are consumed by the `useBookmarksSync` bus subscriber (cross-client list invalidation), so — like the other cross-domain broadcasts — they're added to the web's global stream-event set with a no-op case in the chat handler's exhaustive switch. Also refreshed a now-stale comment in `use-bookmarks-sync.ts` (the event union models bookmark events now; the consumer still matches on the raw bus-envelope `type`).

## Safety

No wire change — schemas transcribed 1:1; typecheck validates every construction site. `bun run typecheck:fast` + web `tsc` (fresh `openapi-ts`), eslint, prettier, `generate:openapi --check` (unchanged), and the api-events + SSE-parity + plugin-import-boundary suites all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_