### PR TITLE
feat(web): telemetry for the in-chat tour experiment

### DIFF
--- a/clients/web/.cross-domain-allowlist.json
+++ b/clients/web/.cross-domain-allowlist.json
@@ -8,10 +8,10 @@
   "src/domains/chat/hooks/use-onboarding-orchestrator.ts": [
     "onboarding"
   ],
-  "src/domains/chat/in-chat-onboarding/tour-telemetry.ts": [
+  "src/domains/chat/hooks/use-send-message.ts": [
     "onboarding"
   ],
-  "src/domains/chat/hooks/use-send-message.ts": [
+  "src/domains/chat/in-chat-onboarding/tour-telemetry.ts": [
     "onboarding"
   ],
   "src/domains/home/home-page.tsx": [

--- a/clients/web/.cross-domain-allowlist.json
+++ b/clients/web/.cross-domain-allowlist.json
@@ -8,6 +8,9 @@
   "src/domains/chat/hooks/use-onboarding-orchestrator.ts": [
     "onboarding"
   ],
+  "src/domains/chat/in-chat-onboarding/tour-telemetry.ts": [
+    "onboarding"
+  ],
   "src/domains/chat/hooks/use-send-message.ts": [
     "onboarding"
   ],

--- a/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
@@ -30,7 +30,10 @@ import {
   isInChatTourOn,
   readInChatTourVariant,
 } from "@/domains/chat/in-chat-onboarding/in-chat-tour-flag";
-import { emitInChatTourStarted } from "@/domains/chat/in-chat-onboarding/tour-telemetry";
+import {
+  emitInChatTourExposed,
+  emitInChatTourStarted,
+} from "@/domains/chat/in-chat-onboarding/tour-telemetry";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { routes } from "@/utils/routes";
 
@@ -71,10 +74,13 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
     onboardingDraftConversationIdRef.current = draftId;
     setOnboardingConversationId(draftId);
     useConversationStore.getState().setActiveConversationId(draftId);
-    // The in-chat-onboarding-tour experiment's `tour` arm: the eyes-led
-    // tour plays over the workspace the user just landed in. Read at
-    // consumption time — flags hydrated long ago during the onboarding
-    // flow itself, and the signal is one-shot.
+    // The in-chat-onboarding-tour experiment: an exposure event fires for
+    // BOTH arms at the hand-off (control emits nothing else, and the
+    // funnel needs its rows for comparison), then the `tour` arm plays
+    // the eyes-led tour over the workspace the user just landed in. The
+    // arm is read at consumption time — flags hydrated long ago during
+    // the onboarding flow itself, and the signal is one-shot.
+    emitInChatTourExposed();
     if (isInChatTourOn(readInChatTourVariant())) {
       useInChatOnboardingStore.getState().startPrototype();
       emitInChatTourStarted("auto");

--- a/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
@@ -30,6 +30,7 @@ import {
   isInChatTourOn,
   readInChatTourVariant,
 } from "@/domains/chat/in-chat-onboarding/in-chat-tour-flag";
+import { emitInChatTourStarted } from "@/domains/chat/in-chat-onboarding/tour-telemetry";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { routes } from "@/utils/routes";
 
@@ -76,6 +77,7 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
     // flow itself, and the signal is one-shot.
     if (isInChatTourOn(readInChatTourVariant())) {
       useInChatOnboardingStore.getState().startPrototype();
+      emitInChatTourStarted("auto");
     }
     void navigate(routes.conversation(draftId), { replace: true });
   }, [searchParams, navigate]);

--- a/clients/web/src/domains/chat/in-chat-onboarding/in-chat-onboarding-controller.tsx
+++ b/clients/web/src/domains/chat/in-chat-onboarding/in-chat-onboarding-controller.tsx
@@ -16,6 +16,10 @@ import {
 } from "./avatar-tour";
 import { TourOverlay } from "./tour-overlay";
 import { type TourStep } from "./tour-steps";
+import {
+  emitInChatTourCompleted,
+  emitInChatTourSkipped,
+} from "./tour-telemetry";
 
 /**
  * SPIKE — orchestrator for the in-chat onboarding UI prototype, mounted
@@ -40,6 +44,9 @@ export function InChatOnboardingController() {
   const { components, traits } = useAssistantAvatar(assistantId);
 
   const tourRef = useRef<AvatarTourHandle | null>(null);
+  /** True once Skip was pressed this run — tells the done handler to emit
+   *  `tour_skipped` (already sent at click time) instead of completed. */
+  const skippedRef = useRef(false);
   /** The stop the tour currently sits in; null while it's mid-transition. */
   const [narrationStep, setNarrationStep] = useState<TourStep | null>(null);
   /** Latches on first landing so the chat doesn't flash back between stops. */
@@ -60,6 +67,12 @@ export function InChatOnboardingController() {
   }, []);
 
   const handleTourDone = useCallback(() => {
+    // Skip's own event was emitted at click time; a natural end past the
+    // last beat is a completion.
+    if (!skippedRef.current) {
+      emitInChatTourCompleted();
+    }
+    skippedRef.current = false;
     setNarrationStep(null);
     setTakeover(false);
     setProgress(null);
@@ -73,6 +86,7 @@ export function InChatOnboardingController() {
       setNarrationStep(null);
       setTakeover(false);
       setProgress(null);
+      skippedRef.current = false;
     }
   }, [stage]);
 
@@ -87,7 +101,11 @@ export function InChatOnboardingController() {
   const skipButton = (
     <Button
       variant="ghost"
-      onClick={() => tourRef.current?.skip()}
+      onClick={() => {
+        skippedRef.current = true;
+        emitInChatTourSkipped(progress?.index ?? 0, progress?.count ?? 0);
+        tourRef.current?.skip();
+      }}
       // Contrast-toned over the intro's avatar-colored flood.
       style={{ color: introFg }}
     >

--- a/clients/web/src/domains/chat/in-chat-onboarding/in-chat-onboarding-launch-button.tsx
+++ b/clients/web/src/domains/chat/in-chat-onboarding/in-chat-onboarding-launch-button.tsx
@@ -5,6 +5,7 @@ import { Button } from "@vellumai/design-library";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
 
 import { isInChatTourOn, useInChatTourVariant } from "./in-chat-tour-flag";
+import { emitInChatTourStarted } from "./tour-telemetry";
 
 /**
  * Header entry point for the in-chat onboarding UI prototype — a stand-in
@@ -30,7 +31,10 @@ export function InChatOnboardingLaunchButton() {
       iconOnly={<Sparkles />}
       aria-label="In-chat onboarding (prototype)"
       tooltip="In-chat onboarding (prototype)"
-      onClick={startPrototype}
+      onClick={() => {
+        startPrototype();
+        emitInChatTourStarted("replay");
+      }}
     />
   );
 }

--- a/clients/web/src/domains/chat/in-chat-onboarding/tour-telemetry.ts
+++ b/clients/web/src/domains/chat/in-chat-onboarding/tour-telemetry.ts
@@ -7,6 +7,9 @@
  * the 70% `tour` arm against `control`.
  *
  * Events:
+ * - `tour_exposed`   — the post-onboarding hand-off, fired for BOTH arms;
+ *                      the control cohort emits nothing else, and the
+ *                      experiment needs its rows for comparison.
  * - `tour_started`   — the tour began; `screen` records the trigger
  *                      (`auto` = post-onboarding hand-off, `replay` = the
  *                      header button).
@@ -22,13 +25,24 @@ import { readInChatTourVariant } from "./in-chat-tour-flag";
 export const IN_CHAT_TOUR_FUNNEL_VERSION = "in_chat_tour_v1_2026_07";
 
 export const IN_CHAT_TOUR_FUNNEL_STEPS = {
-  started: { stepName: "tour_started", stepIndex: 0 },
-  completed: { stepName: "tour_completed", stepIndex: 1 },
-  skipped: { stepName: "tour_skipped", stepIndex: 2 },
+  exposed: { stepName: "tour_exposed", stepIndex: 0 },
+  started: { stepName: "tour_started", stepIndex: 1 },
+  completed: { stepName: "tour_completed", stepIndex: 2 },
+  skipped: { stepName: "tour_skipped", stepIndex: 3 },
 } as const;
 
 /** How the tour began: the post-onboarding hand-off or the header button. */
 export type InChatTourTrigger = "auto" | "replay";
+
+/** The arm-exposure moment — emitted for every user (both arms) at the
+ *  post-onboarding hand-off, stamped with their assigned arm. */
+export function emitInChatTourExposed(): void {
+  emitOnboardingFunnelStepCompleted(IN_CHAT_TOUR_FUNNEL_STEPS.exposed, {
+    funnelVersion: IN_CHAT_TOUR_FUNNEL_VERSION,
+    variant: readInChatTourVariant(),
+    outcome: "completed",
+  });
+}
 
 export function emitInChatTourStarted(trigger: InChatTourTrigger): void {
   emitOnboardingFunnelStepCompleted(IN_CHAT_TOUR_FUNNEL_STEPS.started, {

--- a/clients/web/src/domains/chat/in-chat-onboarding/tour-telemetry.ts
+++ b/clients/web/src/domains/chat/in-chat-onboarding/tour-telemetry.ts
@@ -1,0 +1,60 @@
+/**
+ * Telemetry for the in-chat onboarding tour experiment. Rides the
+ * onboarding funnel event shape and ingest path (`funnel-events.ts`) — the
+ * backend stores `step_name`/`funnel_version` as open strings, so these
+ * need no backend change — and stamps every event with the
+ * `in-chat-onboarding-tour` arm as `ab_variant`, so BigQuery can compare
+ * the 70% `tour` arm against `control`.
+ *
+ * Events:
+ * - `tour_started`   — the tour began; `screen` records the trigger
+ *                      (`auto` = post-onboarding hand-off, `replay` = the
+ *                      header button).
+ * - `tour_skipped`   — Skip pressed; `screen` records which beat it was
+ *                      pressed on (`beat_<index>_of_<count>`).
+ * - `tour_completed` — the user walked every beat to the end.
+ */
+
+import { emitOnboardingFunnelStepCompleted } from "@/domains/onboarding/funnel-events";
+
+import { readInChatTourVariant } from "./in-chat-tour-flag";
+
+export const IN_CHAT_TOUR_FUNNEL_VERSION = "in_chat_tour_v1_2026_07";
+
+export const IN_CHAT_TOUR_FUNNEL_STEPS = {
+  started: { stepName: "tour_started", stepIndex: 0 },
+  completed: { stepName: "tour_completed", stepIndex: 1 },
+  skipped: { stepName: "tour_skipped", stepIndex: 2 },
+} as const;
+
+/** How the tour began: the post-onboarding hand-off or the header button. */
+export type InChatTourTrigger = "auto" | "replay";
+
+export function emitInChatTourStarted(trigger: InChatTourTrigger): void {
+  emitOnboardingFunnelStepCompleted(IN_CHAT_TOUR_FUNNEL_STEPS.started, {
+    funnelVersion: IN_CHAT_TOUR_FUNNEL_VERSION,
+    variant: readInChatTourVariant(),
+    screen: trigger,
+    outcome: "completed",
+  });
+}
+
+export function emitInChatTourSkipped(
+  beatIndex: number,
+  beatCount: number,
+): void {
+  emitOnboardingFunnelStepCompleted(IN_CHAT_TOUR_FUNNEL_STEPS.skipped, {
+    funnelVersion: IN_CHAT_TOUR_FUNNEL_VERSION,
+    variant: readInChatTourVariant(),
+    screen: `beat_${beatIndex}_of_${beatCount}`,
+    outcome: "skipped",
+  });
+}
+
+export function emitInChatTourCompleted(): void {
+  emitOnboardingFunnelStepCompleted(IN_CHAT_TOUR_FUNNEL_STEPS.completed, {
+    funnelVersion: IN_CHAT_TOUR_FUNNEL_VERSION,
+    variant: readInChatTourVariant(),
+    outcome: "completed",
+  });
+}


### PR DESCRIPTION
Follow-up to #38627 — makes the 70/30 `in-chat-onboarding-tour` experiment measurable.

## Events

New `in_chat_tour_v1_2026_07` funnel riding the existing onboarding funnel event shape and `/v1/telemetry/ingest/` path — `step_name`/`funnel_version` are open strings server-side, so **no backend change**. Every event is stamped with the experiment arm as `ab_variant` for BigQuery comparison.

| Event | When | Extra context |
|---|---|---|
| `tour_started` | Tour begins | `screen` = trigger: `auto` (post-onboarding hand-off) or `replay` (header button) |
| `tour_skipped` | Skip pressed (intro-only affordance) | `screen` = `beat_<index>_of_<count>` |
| `tour_completed` | Walked every beat to the end | — |

Skip and completion are mutually exclusive per run (a per-run flag keeps a skip's `onDone` from double-emitting as a completion). Consent gating rides `emitOnboardingFunnelStepCompleted`'s existing `isAnalyticsEnabled()` check.

## Notes

- `tour-telemetry.ts` added to `.cross-domain-allowlist.json` (chat → onboarding) alongside the orchestrator's existing entry, since it composes the onboarding funnel helpers.
- Admin funnel-page charts for these events (incl. skip counts) land separately in `vellum-assistant-platform`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)