### PR TITLE
fix(web): hold provisioning phases long enough to read, and ease the takeover in

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -187,6 +187,8 @@ const BACKGROUND_LINE =
 /**
  * Fast celebration dwell. Long enough for waitFor (50ms polls) to reliably
  * observe the transient DONE / NOT_APPLICABLE copy before it auto-advances.
+ * These tests cover the flow, not the pacing, so the per-phase hold is off —
+ * `use-held-phase.test.ts` and `provisioning-state.test.tsx` own that.
  */
 const TEST_DWELL_MS = 250;
 
@@ -198,7 +200,12 @@ function renderModal() {
   const view = render(
     <MemoryRouter>
       <QueryClientProvider client={client}>
-        <BillingOnboardingModal open onClose={onClose} dwellMs={TEST_DWELL_MS} />
+        <BillingOnboardingModal
+          open
+          onClose={onClose}
+          dwellMs={TEST_DWELL_MS}
+          phaseMinMs={0}
+        />
       </QueryClientProvider>
     </MemoryRouter>,
   );

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -27,12 +27,15 @@ export interface BillingOnboardingModalProps {
   onClose: () => void;
   /** Test hook — forwarded to the provisioning screen's celebration dwell. */
   dwellMs?: number;
+  /** Test hook — forwarded to the provisioning screen's per-phase minimum. */
+  phaseMinMs?: number;
 }
 
 export function BillingOnboardingModal({
   open,
   onClose,
   dwellMs,
+  phaseMinMs,
 }: BillingOnboardingModalProps) {
   const [step, setStep] = useState<WizardStep>("provisioning");
   const [finishedInBackground, setFinishedInBackground] = useState(false);
@@ -155,10 +158,17 @@ export function BillingOnboardingModal({
         overlayClassName={overlayClass}
         className={isTakeover ? provisioningContentClass : "overflow-hidden"}
       >
-        {/* Keyed on step so the fade replays as we swap takeover ⇄ card. */}
+        {/* Keyed on step so the fade replays as we swap takeover ⇄ card. The
+            takeover is the modal's opening step, so it mounts at full size
+            rather than growing into it — it gets a longer, softer entrance so
+            a full-bleed dark canvas doesn't just appear over the billing page. */}
         <div
           key={step}
-          className="flex min-h-0 flex-1 flex-col [animation:fadeIn_0.25s_ease-out_both] motion-reduce:[animation:none]"
+          className={`flex min-h-0 flex-1 flex-col motion-reduce:[animation:none] ${
+            isTakeover
+              ? "[animation:fadeIn_0.45s_ease-out_both]"
+              : "[animation:fadeIn_0.25s_ease-out_both]"
+          }`}
         >
           {renderStep()}
         </div>
@@ -191,6 +201,7 @@ export function BillingOnboardingModal({
             onGoToBilling: onClose,
           }}
           dwellMs={dwellMs}
+          phaseMinMs={phaseMinMs}
         />
       );
     }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
-    clearCheckoutIntent,
-    readCheckoutIntent,
-    type CheckoutIntent,
+  clearCheckoutIntent,
+  readCheckoutIntent,
+  type CheckoutIntent,
 } from "@/lib/billing/checkout-intent";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
@@ -11,7 +11,10 @@ import { toast } from "@vellumai/design-library/components/toast";
 import { CompleteState } from "./complete-state";
 import { DomainStep } from "./domain-step";
 import { FetchErrorState } from "./error-states";
-import type { ProvisioningDimensions } from "./provisioning-machine";
+import type {
+  ProvisioningDimensions,
+  ProvisioningStateKind,
+} from "./provisioning-machine";
 import { ProvisioningState, TAKEOVER_BACKGROUND } from "./provisioning-state";
 import { useProProvisioning } from "./use-pro-provisioning";
 
@@ -34,6 +37,11 @@ function prefersReducedMotion() {
     window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true
   );
 }
+
+const isMachineBusy = (state: ProvisioningStateKind) =>
+  state === "WAITING" || state === "RESIZING" || state === "STALLED";
+const isSettled = (state: ProvisioningStateKind) =>
+  state === "DONE" || state === "NOT_APPLICABLE";
 
 const EMPTY_DIMENSIONS: ProvisioningDimensions = {
   machineSize: null,
@@ -60,6 +68,10 @@ export function BillingOnboardingModal({
   const [takeoverExit, setTakeoverExit] = useState<TakeoverExit>("idle");
   const exitTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
   const [intent, setIntent] = useState<CheckoutIntent | null>(null);
+  // The phase the takeover currently has on screen, which lags the live one by
+  // up to the per-phase hold. Null until the takeover first reports.
+  const [displayedPhase, setDisplayedPhase] =
+    useState<ProvisioningStateKind | null>(null);
 
   // The hook owns the on-open subscription/onboarding cache invalidation and
   // every provisioning poll; it keeps tracking across step changes so a
@@ -71,9 +83,14 @@ export function BillingOnboardingModal({
       setIntent(readCheckoutIntent());
       return;
     }
+    // Closing mid-exit must drop the queued step change with it, or it lands
+    // while the wizard is closed and a reopen starts on the wrong step.
+    exitTimers.current.forEach(clearTimeout);
+    exitTimers.current = [];
     setStep("provisioning");
     setFinishedInBackground(false);
     setTakeoverExit("idle");
+    setDisplayedPhase(null);
   }, [open]);
 
   useEffect(
@@ -93,12 +110,16 @@ export function BillingOnboardingModal({
   // right after checkout, so the domain step stays guarded (submit disabled)
   // while that resize is in flight — including a stall, where the machine may
   // still be mid-restart.
-  const machineBusy =
-    provisioning.state === "WAITING" ||
-    provisioning.state === "RESIZING" ||
-    provisioning.state === "STALLED";
-  const provisioningSettled =
-    provisioning.state === "DONE" || provisioning.state === "NOT_APPLICABLE";
+  const machineBusy = isMachineBusy(provisioning.state);
+  const provisioningSettled = isSettled(provisioning.state);
+
+  // The lock and the close toast describe the screen the user is looking at, so
+  // they read the takeover's held phase rather than the live one. The steps
+  // after it keep tracking live provisioning: a resize backgrounded via the
+  // escape hatch has to unblock the domain step when it actually finishes.
+  const onScreenPhase = displayedPhase ?? provisioning.state;
+  const onScreenBusy = isMachineBusy(onScreenPhase);
+  const onScreenSettled = isSettled(onScreenPhase);
 
   const { targets, assistantId, domainSetupAvailable, onboardingSettled } =
     provisioning;
@@ -156,7 +177,7 @@ export function BillingOnboardingModal({
     (provisioning.confirmError || provisioning.targetsError);
 
   const handleClose = () => {
-    if (step === "provisioning" && !provisioningError && machineBusy) {
+    if (step === "provisioning" && !provisioningError && onScreenBusy) {
       toast.info("Your upgrade continues in the background.");
     }
     onClose();
@@ -174,9 +195,8 @@ export function BillingOnboardingModal({
   // state stuck past the escape grace with routing still hung unlocks to a plain
   // background-dismiss (the in-content escape hatch needs routing to have settled).
   const stuckAwaitingRouting =
-    machineBusy && provisioning.escapeEligible && !routingSettled;
-  const lockTakeover =
-    isTakeover && !provisioningSettled && !stuckAwaitingRouting;
+    onScreenBusy && provisioning.escapeEligible && !routingSettled;
+  const lockTakeover = isTakeover && !onScreenSettled && !stuckAwaitingRouting;
 
   // Full-bleed dark content that fills the viewport for the takeover.
   const provisioningContentClass =
@@ -196,7 +216,12 @@ export function BillingOnboardingModal({
       : "[animation:fadeIn_0.25s_ease-out_both]";
 
   return (
-    <Modal.Root open={open} onOpenChange={(o) => { if (!o) handleClose(); }}>
+    <Modal.Root
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) handleClose();
+      }}
+    >
       <Modal.Content
         size="md"
         hideCloseButton
@@ -257,6 +282,7 @@ export function BillingOnboardingModal({
             machineBusy && routingSettled && provisioning.escapeEligible
           }
           onEscape={escapeProvisioning}
+          onPhaseChange={setDisplayedPhase}
           stalledAction={stalledAction}
           confirm={{
             onRetry: provisioning.retryConfirm,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
     clearCheckoutIntent,
@@ -12,10 +12,28 @@ import { CompleteState } from "./complete-state";
 import { DomainStep } from "./domain-step";
 import { FetchErrorState } from "./error-states";
 import type { ProvisioningDimensions } from "./provisioning-machine";
-import { ProvisioningState } from "./provisioning-state";
+import { ProvisioningState, TAKEOVER_BACKGROUND } from "./provisioning-state";
 import { useProProvisioning } from "./use-pro-provisioning";
 
 type WizardStep = "provisioning" | "domain" | "complete";
+
+/**
+ * Leaving the takeover changes the modal's shape and its theme in one frame,
+ * which neither transitions cheaply. So a sheet in the takeover's own colour
+ * covers it first: fading that in reads as the content dissolving (it matches
+ * what is already on screen), the swap happens out of sight, and the sheet
+ * then clears to reveal the card.
+ */
+type TakeoverExit = "idle" | "covering" | "revealing";
+const TAKEOVER_COVER_MS = 200;
+const TAKEOVER_REVEAL_MS = 380;
+
+function prefersReducedMotion() {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true
+  );
+}
 
 const EMPTY_DIMENSIONS: ProvisioningDimensions = {
   machineSize: null,
@@ -39,6 +57,8 @@ export function BillingOnboardingModal({
 }: BillingOnboardingModalProps) {
   const [step, setStep] = useState<WizardStep>("provisioning");
   const [finishedInBackground, setFinishedInBackground] = useState(false);
+  const [takeoverExit, setTakeoverExit] = useState<TakeoverExit>("idle");
+  const exitTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
   const [intent, setIntent] = useState<CheckoutIntent | null>(null);
 
   // The hook owns the on-open subscription/onboarding cache invalidation and
@@ -53,7 +73,15 @@ export function BillingOnboardingModal({
     }
     setStep("provisioning");
     setFinishedInBackground(false);
+    setTakeoverExit("idle");
   }, [open]);
+
+  useEffect(
+    () => () => {
+      exitTimers.current.forEach(clearTimeout);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (step === "complete") clearCheckoutIntent();
@@ -89,7 +117,22 @@ export function BillingOnboardingModal({
   }, [open, onboardingSettled]);
 
   const advanceFromProvisioning = useCallback(() => {
-    setStep(domainSetupAvailable === false ? "complete" : "domain");
+    const next = domainSetupAvailable === false ? "complete" : "domain";
+    if (prefersReducedMotion()) {
+      setStep(next);
+      return;
+    }
+    setTakeoverExit("covering");
+    exitTimers.current.push(
+      setTimeout(() => {
+        // Both the geometry and the theme change here, under the sheet.
+        setStep(next);
+        setTakeoverExit("revealing");
+        exitTimers.current.push(
+          setTimeout(() => setTakeoverExit("idle"), TAKEOVER_REVEAL_MS),
+        );
+      }, TAKEOVER_COVER_MS),
+    );
   }, [domainSetupAvailable]);
 
   const escapeProvisioning = useCallback(() => {
@@ -146,6 +189,12 @@ export function BillingOnboardingModal({
     isTakeover ? " bg-black p-0" : ""
   }`;
 
+  const stepEntrance = isTakeover
+    ? "[animation:fadeIn_0.45s_ease-out_both]"
+    : takeoverExit === "revealing"
+      ? "[animation:fadeInUp_0.42s_ease-out_0.12s_both]"
+      : "[animation:fadeIn_0.25s_ease-out_both]";
+
   return (
     <Modal.Root open={open} onOpenChange={(o) => { if (!o) handleClose(); }}>
       <Modal.Content
@@ -164,14 +213,27 @@ export function BillingOnboardingModal({
             a full-bleed dark canvas doesn't just appear over the billing page. */}
         <div
           key={step}
-          className={`flex min-h-0 flex-1 flex-col motion-reduce:[animation:none] ${
-            isTakeover
-              ? "[animation:fadeIn_0.45s_ease-out_both]"
-              : "[animation:fadeIn_0.25s_ease-out_both]"
-          }`}
+          className={`flex min-h-0 flex-1 flex-col motion-reduce:[animation:none] ${stepEntrance}`}
         >
           {renderStep()}
         </div>
+        {takeoverExit !== "idle" && (
+          <div
+            aria-hidden
+            data-testid="takeover-exit-sheet"
+            className={
+              // `fixed` escapes the card's box once the modal has shrunk back,
+              // so the sheet still covers the viewport while it clears. Reversed
+              // fadeIn is the fade-out; no second keyframe needed.
+              `pointer-events-none fixed inset-0 z-50 ${
+                takeoverExit === "covering"
+                  ? "[animation:fadeIn_200ms_ease-in_both]"
+                  : "[animation:fadeIn_380ms_ease-out_both_reverse]"
+              }`
+            }
+            style={{ backgroundColor: TAKEOVER_BACKGROUND }}
+          />
+        )}
       </Modal.Content>
     </Modal.Root>
   );

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -468,3 +468,63 @@ describe("takeover avatar", () => {
     expect(avatarQueryId).toBe("active-assistant");
   });
 });
+
+describe("ProvisioningState phase hold", () => {
+  test("keeps a phase on screen for its minimum before the next one shows", async () => {
+    const { rerender, getByText, queryByText } = renderState({
+      state: "CONFIRMING",
+      phaseMinMs: 150,
+    });
+    expect(getByText("Confirming your upgrade…")).toBeTruthy();
+
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <ProvisioningState {...baseProps({ state: "DONE", phaseMinMs: 150 })} />
+      </QueryClientProvider>,
+    );
+    // Still inside CONFIRMING's window, so DONE hasn't been allowed through.
+    expect(queryByText("All done!")).toBeNull();
+
+    await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
+      timeout: 1000,
+    });
+  });
+
+  test("skips a phase that would resolve before it could be read", async () => {
+    const { rerender, getByText, queryByText } = renderState({
+      state: "CONFIRMING",
+      phaseMinMs: 150,
+    });
+
+    const advance = (state: ProvisioningStateProps["state"]) =>
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <ProvisioningState {...baseProps({ state, phaseMinMs: 150 })} />
+        </QueryClientProvider>,
+      );
+
+    // WAITING and DONE both land inside CONFIRMING's window; WAITING is never
+    // readable, so it must never reach the screen.
+    advance("WAITING");
+    advance("DONE");
+    expect(queryByText("Upgrading your assistant…")).toBeNull();
+
+    await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
+      timeout: 1000,
+    });
+    expect(queryByText("Upgrading your assistant…")).toBeNull();
+  });
+
+  test("passes phases straight through when the hold is disabled", () => {
+    const { rerender, getByText } = renderState({
+      state: "CONFIRMING",
+      phaseMinMs: 0,
+    });
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <ProvisioningState {...baseProps({ state: "DONE", phaseMinMs: 0 })} />
+      </QueryClientProvider>,
+    );
+    expect(getByText("All done!")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -376,9 +376,7 @@ describe("stalled", () => {
 
     expect(getByText("We couldn't finish this automatically")).toBeTruthy();
     expect(
-      getByText(
-        "Apply the changes below to finish setting up your upgrade.",
-      ),
+      getByText("Apply the changes below to finish setting up your upgrade."),
     ).toBeTruthy();
     expect(getByText("Machine")).toBeTruthy();
     fireEvent.click(getByTestId("provisioning-apply"));
@@ -415,9 +413,7 @@ describe("confirm_timeout", () => {
 
     expect(getByText("Still confirming your upgrade")).toBeTruthy();
     expect(
-      getByText(
-        "Your payment went through safely — this can take a minute.",
-      ),
+      getByText("Your payment went through safely — this can take a minute."),
     ).toBeTruthy();
     fireEvent.click(getByTestId("onboarding-retry"));
     expect(onRetry).toHaveBeenCalledTimes(1);
@@ -526,5 +522,35 @@ describe("ProvisioningState phase hold", () => {
       </QueryClientProvider>,
     );
     expect(getByText("All done!")).toBeTruthy();
+  });
+
+  test("reports the phase on screen, not the live one", async () => {
+    // The wizard locks Esc/backdrop against this report, so it has to describe
+    // what the user is looking at — reporting DONE early unlocks the takeover
+    // while it still reads as busy.
+    const reported: string[] = [];
+    const onPhaseChange = (phase: ProvisioningStateProps["state"]) => {
+      reported.push(phase);
+    };
+    const { rerender, getByText } = renderState({
+      state: "WAITING",
+      phaseMinMs: 150,
+      onPhaseChange,
+    });
+    expect(reported).toEqual(["WAITING"]);
+
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <ProvisioningState
+          {...baseProps({ state: "DONE", phaseMinMs: 150, onPhaseChange })}
+        />
+      </QueryClientProvider>,
+    );
+    expect(reported).toEqual(["WAITING"]);
+
+    await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
+      timeout: 1000,
+    });
+    expect(reported).toEqual(["WAITING", "DONE"]);
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -32,7 +32,7 @@ import {
 
 // The mock's takeover tint, matched to the green Vellum creature. No token
 // holds this, so it follows the plans-page PAGE_BACKGROUND raw-hex precedent.
-const TAKEOVER_BACKGROUND = "#1D271E";
+export const TAKEOVER_BACKGROUND = "#1D271E";
 
 const CHIP_BACKGROUND =
   "color-mix(in srgb, var(--content-emphasised) 10%, transparent)";

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -13,8 +13,8 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 import type {
-    ProvisioningDimensions,
-    ProvisioningStateKind,
+  ProvisioningDimensions,
+  ProvisioningStateKind,
 } from "./provisioning-machine";
 import { SERIF_HEADING_STYLE, type StalledApplyAction } from "./primitives";
 import {
@@ -64,6 +64,8 @@ export interface ProvisioningStateProps {
   assistantId?: string | null;
   escapeAvailable: boolean;
   onEscape: () => void;
+  /** Reports the phase actually on screen, which lags `state` by the hold. */
+  onPhaseChange?: (phase: ProvisioningStateKind) => void;
   stalledAction: StalledApplyAction;
   confirm: { onRetry: () => void; onGoToBilling: () => void };
   /** Test hook — overrides the per-phase minimum; 0 disables the hold. */
@@ -116,7 +118,10 @@ function TakeoverAvatar({
 function Copy({ status, caption }: { status: string; caption?: string }) {
   return (
     <div className="flex flex-col items-center gap-1.5">
-      <h1 className="text-[var(--content-emphasised)]" style={SERIF_HEADING_STYLE}>
+      <h1
+        className="text-[var(--content-emphasised)]"
+        style={SERIF_HEADING_STYLE}
+      >
         {status}
       </h1>
       {caption && (
@@ -366,6 +371,7 @@ export function ProvisioningState({
   assistantId,
   escapeAvailable,
   onEscape,
+  onPhaseChange,
   stalledAction,
   confirm,
   dwellMs = PROVISION_MIN_DWELL_MS,
@@ -383,6 +389,15 @@ export function ProvisioningState({
   const heldState = useHeldPhase(state, phaseMinMs);
   const resolved = heldState === "DONE" || heldState === "NOT_APPLICABLE";
   const phaseKey = heldState === "RESIZING" ? "WAITING" : heldState;
+
+  // The wizard locks itself against the phase on screen, not the live one.
+  const onPhaseChangeRef = useRef(onPhaseChange);
+  useEffect(() => {
+    onPhaseChangeRef.current = onPhaseChange;
+  }, [onPhaseChange]);
+  useEffect(() => {
+    onPhaseChangeRef.current?.(heldState);
+  }, [heldState]);
 
   const dwelling = celebrating && resolved;
   useEffect(() => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -430,7 +430,7 @@ export function ProvisioningState({
   }
 
   function renderPhase() {
-    if (state === "CONFIRMING") {
+    if (heldState === "CONFIRMING") {
       return (
         <>
           <Copy
@@ -443,7 +443,7 @@ export function ProvisioningState({
       );
     }
 
-    if (state === "WAITING" || state === "RESIZING") {
+    if (heldState === "WAITING" || heldState === "RESIZING") {
       return (
         <>
           <Copy
@@ -464,7 +464,7 @@ export function ProvisioningState({
       );
     }
 
-    if (state === "DONE") {
+    if (heldState === "DONE") {
       return (
         <>
           <Copy status="All done!" />
@@ -473,11 +473,11 @@ export function ProvisioningState({
       );
     }
 
-    if (state === "NOT_APPLICABLE") {
+    if (heldState === "NOT_APPLICABLE") {
       return <Copy status="Your plan is ready" />;
     }
 
-    if (state === "STALLED") {
+    if (heldState === "STALLED") {
       return (
         <>
           <Copy
@@ -501,7 +501,7 @@ export function ProvisioningState({
       );
     }
 
-    if (state === "CONFIRM_TIMEOUT") {
+    if (heldState === "CONFIRM_TIMEOUT") {
       return (
         <>
           <Copy

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -23,7 +23,12 @@ import {
 } from "./resource-changes";
 import { useProvisioningCredits } from "./use-provisioning-credits";
 import { useRotatingIndex } from "./use-rotating-index";
-import { extractOnboardingErrorMessage, PROVISION_MIN_DWELL_MS } from "./utils";
+import { useHeldPhase } from "./use-held-phase";
+import {
+  extractOnboardingErrorMessage,
+  PROVISION_MIN_DWELL_MS,
+  PROVISION_PHASE_MIN_MS,
+} from "./utils";
 
 // The mock's takeover tint, matched to the green Vellum creature. No token
 // holds this, so it follows the plans-page PAGE_BACKGROUND raw-hex precedent.
@@ -61,6 +66,8 @@ export interface ProvisioningStateProps {
   onEscape: () => void;
   stalledAction: StalledApplyAction;
   confirm: { onRetry: () => void; onGoToBilling: () => void };
+  /** Test hook — overrides the per-phase minimum; 0 disables the hold. */
+  phaseMinMs?: number;
   /** Test hook — overrides the celebration min dwell. */
   dwellMs?: number;
 }
@@ -362,14 +369,20 @@ export function ProvisioningState({
   stalledAction,
   confirm,
   dwellMs = PROVISION_MIN_DWELL_MS,
+  phaseMinMs = PROVISION_PHASE_MIN_MS,
 }: ProvisioningStateProps) {
   const onCelebrationEndRef = useRef(onCelebrationEnd);
   useEffect(() => {
     onCelebrationEndRef.current = onCelebrationEnd;
   }, [onCelebrationEnd]);
 
-  const resolved = state === "DONE" || state === "NOT_APPLICABLE";
-  const phaseKey = state === "RESIZING" ? "WAITING" : state;
+  // Everything below renders from the held phase, not the live one, so a phase
+  // the user couldn't have read never reaches the screen. The celebration dwell
+  // keys off it too — otherwise the wizard could advance past "All done!"
+  // before it was shown.
+  const heldState = useHeldPhase(state, phaseMinMs);
+  const resolved = heldState === "DONE" || heldState === "NOT_APPLICABLE";
+  const phaseKey = heldState === "RESIZING" ? "WAITING" : heldState;
 
   const dwelling = celebrating && resolved;
   useEffect(() => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-held-phase.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-held-phase.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+
+import { act, renderHook } from "@testing-library/react";
+
+import { useHeldPhase } from "./use-held-phase";
+
+const tick = (ms: number) =>
+  act(() => new Promise((resolve) => setTimeout(resolve, ms)));
+
+describe("useHeldPhase", () => {
+  test("passes the value straight through when the hold is disabled", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useHeldPhase(value, 0),
+      { initialProps: { value: "a" } },
+    );
+    expect(result.current).toBe("a");
+    rerender({ value: "b" });
+    expect(result.current).toBe("b");
+  });
+
+  test("holds the current value until the minimum has elapsed", async () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useHeldPhase(value, 120),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "b" });
+    expect(result.current).toBe("a");
+
+    await tick(200);
+    expect(result.current).toBe("b");
+  });
+
+  test("skips a value that never survives its own hold", async () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useHeldPhase(value, 120),
+      { initialProps: { value: "a" } },
+    );
+
+    // Two changes land well inside the first window: "b" is never readable, so
+    // it should never be returned.
+    rerender({ value: "b" });
+    rerender({ value: "c" });
+    expect(result.current).toBe("a");
+
+    await tick(200);
+    expect(result.current).toBe("c");
+  });
+
+  test("gives each value its own window", async () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useHeldPhase(value, 120),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "b" });
+    await tick(200);
+    expect(result.current).toBe("b");
+
+    rerender({ value: "c" });
+    expect(result.current).toBe("b");
+
+    await tick(200);
+    expect(result.current).toBe("c");
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-held-phase.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-held-phase.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Holds a value on screen for at least `minMs` before letting the next one
+ * through. When several changes land inside one hold, the intermediate values
+ * are skipped entirely — a phase nobody could have read is never rendered.
+ *
+ * `minMs <= 0` disables the hold and passes the value straight through, which
+ * keeps tests synchronous.
+ */
+export function useHeldPhase<T>(value: T, minMs: number): T {
+  const [held, setHeld] = useState(value);
+  const shownAt = useRef(0);
+
+  // The first value is whatever mounted, so start its window at mount rather
+  // than at epoch zero — otherwise the opening phase is free to leave instantly.
+  useEffect(() => {
+    shownAt.current = performance.now();
+  }, []);
+
+  useEffect(() => {
+    if (minMs <= 0 || value === held) {
+      return;
+    }
+    const wait = minMs - (performance.now() - shownAt.current);
+    if (wait <= 0) {
+      shownAt.current = performance.now();
+      setHeld(value);
+      return;
+    }
+    const timer = setTimeout(() => {
+      shownAt.current = performance.now();
+      setHeld(value);
+    }, wait);
+    return () => clearTimeout(timer);
+  }, [value, held, minMs]);
+
+  return minMs <= 0 ? value : held;
+}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/utils.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/utils.ts
@@ -9,8 +9,14 @@ export const PROVISION_WAIT_GRACE_MS = 30_000;
 export const PROVISION_STALL_MS = 90_000;
 /** How long the watch must run before the background escape hatch is offered. */
 export const PROVISION_ESCAPE_MS = (PROVISION_STALL_MS * 2) / 3;
-/** Minimum time a provisioning phase stays on screen so it doesn't flash. */
+/** Minimum time the finished state stays on screen before the wizard advances. */
 export const PROVISION_MIN_DWELL_MS = 2_500;
+/**
+ * Minimum time any other provisioning phase stays on screen. Without a floor a
+ * fast upgrade renders CONFIRMING and WAITING for however long the API happened
+ * to take, which reads as a flash rather than a step.
+ */
+export const PROVISION_PHASE_MIN_MS = 900;
 /**
  * How long to wait before re-asking ensure-provisioned when it answered
  * `not_applicable` / `no_active_pro` — the subscription flipped to Pro but the


### PR DESCRIPTION
## Summary

`PROVISION_MIN_DWELL_MS` (2,500ms) is documented as *"minimum time a provisioning phase stays on screen so it doesn't flash"* — but it was only ever wired to `celebrating && (DONE || NOT_APPLICABLE)`. **The intermediate phases had no floor.** A fast upgrade rendered `CONFIRMING` and `WAITING` for however long the API happened to take, then held "All done!" for 2.5s.

#38783 made that *worse*, not better: giving the phases a 420ms entrance means a fast run now starts two dissolves and interrupts both. A nicer animation with no dwell reads worse than the hard cut it replaced.

- **`useHeldPhase`** holds a value for a minimum before letting the next through, and skips any value that arrives and leaves inside another's window — so a phase nobody could have read is never rendered. `minMs <= 0` passes straight through, which keeps tests synchronous.
- **The celebration dwell keys off the held phase**, so the wizard can't advance past a state before it has been shown.
- **`PROVISION_PHASE_MIN_MS = 900`**, with the older constant's comment corrected to describe what it actually guards.

## The takeover entrance

Worth recording, because it corrects an assumption: the modal's initial step is already `provisioning`, and both open paths are URL-driven — `?session_id=` (the Stripe redirect) or `?pro_onboarding=`. **There is no in-app card → takeover morph.** You return from Stripe and a full-bleed dark canvas mounts over the billing page with no transition at all.

So the takeover needed a *mount* entrance, not a geometry morph. It now fades in over 450ms; the card steps keep their 250ms.

Two follow-ons this rules out:
- The "560px → fullscreen geometry snap" only fires on the way **out** (takeover → domain card), not on entry.
- Carrying an avatar across the handoff is **not possible on either real path** — there's no plan card on screen to carry from.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `use-held-phase.test.ts` — 4 pass (new)
- `provisioning-state.test.tsx` — 20 pass
- `billing-onboarding-modal.test.tsx` — 20 pass

The modal tests cover flow rather than pacing, so they pass `phaseMinMs={0}`; the hold has its own unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)