### PR TITLE
feat(web): profile editor writes provider "vellum" behind a version gate

### DIFF
--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -212,9 +212,11 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
           void queryClient.invalidateQueries({
             queryKey: assistantIdentityDetailsQueryKey(assistantId),
           });
-          const { version, setIdentity } =
+          const { version, assistantId: hydratedAssistantId, setIdentity } =
             useAssistantIdentityStore.getState();
-          setIdentity(newName, version);
+          // Preserve the owner tag: a rename changes the name, not which
+          // assistant the hydrated identity belongs to.
+          setIdentity(newName, version, hydratedAssistantId);
           toast.success(`Say hi to ${newName}!`);
         } else {
           toast.error("The rename didn't go through. Please try again.");

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -479,6 +479,70 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     expect(saveCalls[0].entry.provider_connection).toBe("vellum-managed");
   });
 
+  test("a new-enough assistant gets the identity payload: provider vellum, no binding", async () => {
+    const { useAssistantIdentityStore } = await import(
+      "@/stores/assistant-identity-store"
+    );
+    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.12");
+    try {
+      const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
+      const onSave = (name: string, entry: unknown) => {
+        saveCalls.push({ name, entry: entry as Record<string, unknown> });
+        return Promise.resolve();
+      };
+      renderCreate([makeConnection("vellum-managed", "vellum")], onSave);
+
+      selectProvider("Vellum");
+      selectModel("Claude Opus 4.8");
+
+      await waitFor(() => {
+        expect(getSaveBtn().disabled).toBe(false);
+      });
+      fireEvent.click(getSaveBtn());
+
+      await waitFor(() => {
+        expect(saveCalls.length).toBe(1);
+      });
+      expect(saveCalls[0].entry.provider).toBe("vellum");
+      expect(saveCalls[0].entry.model).toBe("claude-opus-4-8");
+      expect(saveCalls[0].entry.provider_connection).toBeUndefined();
+    } finally {
+      useAssistantIdentityStore.getState().clearIdentity();
+    }
+  });
+
+  test("an older assistant keeps the legacy payload byte-identical", async () => {
+    const { useAssistantIdentityStore } = await import(
+      "@/stores/assistant-identity-store"
+    );
+    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.11");
+    try {
+      const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
+      const onSave = (name: string, entry: unknown) => {
+        saveCalls.push({ name, entry: entry as Record<string, unknown> });
+        return Promise.resolve();
+      };
+      renderCreate([makeConnection("vellum-managed", "vellum")], onSave);
+
+      selectProvider("Vellum");
+      selectModel("Claude Opus 4.8");
+
+      await waitFor(() => {
+        expect(getSaveBtn().disabled).toBe(false);
+      });
+      fireEvent.click(getSaveBtn());
+
+      await waitFor(() => {
+        expect(saveCalls.length).toBe(1);
+      });
+      expect(saveCalls[0].entry.provider).toBe("anthropic");
+      expect(saveCalls[0].entry.model).toBe("claude-opus-4-8");
+      expect(saveCalls[0].entry.provider_connection).toBe("vellum-managed");
+    } finally {
+      useAssistantIdentityStore.getState().clearIdentity();
+    }
+  });
+
   test("a legacy-shape managed profile presents as Vellum in edit mode", async () => {
     // Managed profiles store their real upstream (anthropic) bound to the
     // vellum connection; the editor must present them as "Vellum".

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -494,7 +494,9 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     const { useAssistantIdentityStore } = await import(
       "@/stores/assistant-identity-store"
     );
-    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.12");
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("test-asst", "0.10.12", ASSISTANT_ID);
     try {
       const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
       const onSave = (name: string, entry: unknown) => {

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -318,14 +318,25 @@ function fillCreateForm(): void {
   });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   createdConnection = makeConnection("anthropic-personal");
   toastSuccessCalls = [];
   useAssistantLifecycleStore.setState(initialLifecycleState, true);
+  // Seed a hydrated pre-gate version: the save path awaits
+  // whenAssistantVersionKnown(), and an unhydrated store would stall each
+  // save until that helper's timeout. Gate-on tests override per-test.
+  const { useAssistantIdentityStore } = await import(
+    "@/stores/assistant-identity-store"
+  );
+  useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.11");
 });
 
-afterEach(() => {
+afterEach(async () => {
   cleanup();
+  const { useAssistantIdentityStore } = await import(
+    "@/stores/assistant-identity-store"
+  );
+  useAssistantIdentityStore.getState().clearIdentity();
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -637,7 +637,7 @@ function ProfileEditorModalInner({
       //   and must be stripped to the upstream's native id.
       const writesIdentityPayload =
         provider === VELLUM_CONNECTION_PROVIDER &&
-        assistantSupportsVellumProviderProfiles();
+        (await assistantSupportsVellumProviderProfiles());
       const wireProvider =
         provider === VELLUM_CONNECTION_PROVIDER
           ? writesIdentityPayload

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -46,7 +46,6 @@ import {
   parseVellumRoutedModel,
 } from "@/assistant/llm-model-catalog";
 import { assistantSupportsVellumProviderProfiles } from "@/lib/backwards-compat/vellum-profile-provider";
-import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { providersServedByConnections } from "@/domains/settings/ai/provider-availability";
 import type {
   ConnectionProvider,
@@ -223,12 +222,6 @@ function ProfileEditorModalInner({
     initialValues?.description ?? "",
   );
   const [key, setKey] = useState(mode === "create" ? "" : (profileName ?? ""));
-  // The assistant this editor writes to, captured at mount: the save
-  // payload's version gate must never be judged against a different
-  // assistant hydrated after a mid-save switch.
-  const [ownerAssistantId] = useState<string | null>(
-    () => useAssistantIdentityStore.getState().assistantId,
-  );
   // "vellum" is a picker-level value: profiles bound to the Vellum-managed
   // connection present (and edit) as provider "Vellum"; the wire-shape
   // upstream is derived from the model at save time. The form opens on the
@@ -642,9 +635,11 @@ function ProfileEditorModalInner({
       //   preserve the stored upstream too instead of clearing it.
       // - A routed `<provider>/<model>` string names its upstream directly
       //   and must be stripped to the upstream's native id.
+      // The gate is judged against this modal's write target: the hydrated
+      // identity must belong to `assistantId` or the payload stays legacy.
       const writesIdentityPayload =
         provider === VELLUM_CONNECTION_PROVIDER &&
-        (await assistantSupportsVellumProviderProfiles(ownerAssistantId));
+        (await assistantSupportsVellumProviderProfiles(assistantId));
       const wireProvider =
         provider === VELLUM_CONNECTION_PROVIDER
           ? writesIdentityPayload

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -46,6 +46,7 @@ import {
   parseVellumRoutedModel,
 } from "@/assistant/llm-model-catalog";
 import { assistantSupportsVellumProviderProfiles } from "@/lib/backwards-compat/vellum-profile-provider";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { providersServedByConnections } from "@/domains/settings/ai/provider-availability";
 import type {
   ConnectionProvider,
@@ -222,6 +223,12 @@ function ProfileEditorModalInner({
     initialValues?.description ?? "",
   );
   const [key, setKey] = useState(mode === "create" ? "" : (profileName ?? ""));
+  // The assistant this editor writes to, captured at mount: the save
+  // payload's version gate must never be judged against a different
+  // assistant hydrated after a mid-save switch.
+  const [ownerAssistantId] = useState<string | null>(
+    () => useAssistantIdentityStore.getState().assistantId,
+  );
   // "vellum" is a picker-level value: profiles bound to the Vellum-managed
   // connection present (and edit) as provider "Vellum"; the wire-shape
   // upstream is derived from the model at save time. The form opens on the
@@ -637,7 +644,7 @@ function ProfileEditorModalInner({
       //   and must be stripped to the upstream's native id.
       const writesIdentityPayload =
         provider === VELLUM_CONNECTION_PROVIDER &&
-        (await assistantSupportsVellumProviderProfiles());
+        (await assistantSupportsVellumProviderProfiles(ownerAssistantId));
       const wireProvider =
         provider === VELLUM_CONNECTION_PROVIDER
           ? writesIdentityPayload

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -45,6 +45,7 @@ import {
   getManagedUpstreamForModel,
   parseVellumRoutedModel,
 } from "@/assistant/llm-model-catalog";
+import { assistantSupportsVellumProviderProfiles } from "@/lib/backwards-compat/vellum-profile-provider";
 import { providersServedByConnections } from "@/domains/settings/ai/provider-availability";
 import type {
   ConnectionProvider,
@@ -621,23 +622,35 @@ function ProfileEditorModalInner({
           ? availableConnectionsForProvider[0].name
           : providerConnection;
       const effectiveBinding = connectionNotFound ? "" : resolvedBinding;
-      // The Vellum picker entry writes the legacy wire shape: the model's
-      // managed upstream as `provider`, bound to the vellum connection. Old
-      // daemons accept this today; the payload flips to provider "vellum"
-      // in a later milestone with no UI change.
-      // Derivation can miss for a bound model this build doesn't list (a
-      // newer managed model); the editor preserves such models, so preserve
-      // the stored upstream too instead of clearing it.
-      // A routed `<provider>/<model>` string names its upstream directly and
-      // must be stripped to the upstream's native id in the legacy wire shape.
+      // The Vellum picker entry's wire shape is version-gated. Daemons at
+      // the gate's MIN_VERSION store the routing identity directly:
+      // `provider: "vellum"` + the native model, no connection binding
+      // (dispatch derives the upstream from the model). Older daemons
+      // reject that value at the write route, so they get the legacy
+      // shape: the model's managed upstream as `provider`, bound to the
+      // provider-agnostic vellum connection.
+      // Legacy-shape notes:
+      // - Derivation can miss for a bound model this build doesn't list (a
+      //   newer managed model); the editor preserves such models, so
+      //   preserve the stored upstream too instead of clearing it.
+      // - A routed `<provider>/<model>` string names its upstream directly
+      //   and must be stripped to the upstream's native id.
+      const writesIdentityPayload =
+        provider === VELLUM_CONNECTION_PROVIDER &&
+        assistantSupportsVellumProviderProfiles();
       const wireProvider =
         provider === VELLUM_CONNECTION_PROVIDER
-          ? (routedModel?.provider ??
-            getManagedUpstreamForModel(model) ??
-            initialValues?.provider ??
-            "")
+          ? writesIdentityPayload
+            ? VELLUM_CONNECTION_PROVIDER
+            : (routedModel?.provider ??
+              getManagedUpstreamForModel(model) ??
+              initialValues?.provider ??
+              "")
           : provider;
       const wireModel = nativeModel;
+      // Identity payloads carry no binding; sending null on edit clears a
+      // legacy-shape binding left on the stored profile.
+      const wireBinding = writesIdentityPayload ? "" : effectiveBinding;
       if (effectiveMode === "edit") {
         // In edit mode send null for cleared fields so the server deep-merges
         // them as cleared rather than silently preserving the old value.
@@ -645,14 +658,14 @@ function ProfileEditorModalInner({
         entry.description = description.trim() || null;
         entry.provider = wireProvider || null;
         entry.model = wireModel || null;
-        entry.provider_connection = effectiveBinding || null;
+        entry.provider_connection = wireBinding || null;
       } else {
         // In create mode omit optional fields that are still empty.
         if (label.trim()) entry.label = label.trim();
         if (description.trim()) entry.description = description.trim();
         if (wireProvider) entry.provider = wireProvider;
         if (wireModel) entry.model = wireModel;
-        if (effectiveBinding) entry.provider_connection = effectiveBinding;
+        if (wireBinding) entry.provider_connection = wireBinding;
       }
       // Advanced params
       if (visibility.maxTokens && maxTokens !== null) {

--- a/clients/web/src/lib/backwards-compat/vellum-profile-provider.test.ts
+++ b/clients/web/src/lib/backwards-compat/vellum-profile-provider.test.ts
@@ -53,7 +53,12 @@ describe("assistantSupportsVellumProviderProfiles", () => {
       .setIdentity("other-asst", "0.11.0", "asst-B");
     expect(await assistantSupportsVellumProviderProfiles("asst-A")).toBe(false);
     expect(await assistantSupportsVellumProviderProfiles("asst-B")).toBe(true);
-    // A surface opened before first hydration has no owner to hold against.
+    // A caller with no write-target id accepts any hydrated identity.
     expect(await assistantSupportsVellumProviderProfiles(null)).toBe(true);
+  });
+
+  test("an un-owned hydrated identity gates to legacy when an owner is required", async () => {
+    useAssistantIdentityStore.getState().setIdentity("some-asst", "0.11.0");
+    expect(await assistantSupportsVellumProviderProfiles("asst-A")).toBe(false);
   });
 });

--- a/clients/web/src/lib/backwards-compat/vellum-profile-provider.test.ts
+++ b/clients/web/src/lib/backwards-compat/vellum-profile-provider.test.ts
@@ -21,12 +21,12 @@ afterEach(() => {
 describe("assistantSupportsVellumProviderProfiles", () => {
   test("returns false when the version stays unknown past the wait", async () => {
     setVersion(null);
-    expect(await assistantSupportsVellumProviderProfiles(1)).toBe(false);
+    expect(await assistantSupportsVellumProviderProfiles(null, 1)).toBe(false);
   });
 
   test("waits for hydration before deciding", async () => {
     setVersion(null);
-    const decision = assistantSupportsVellumProviderProfiles(1_000);
+    const decision = assistantSupportsVellumProviderProfiles(null, 1_000);
     setVersion("0.10.12");
     expect(await decision).toBe(true);
   });
@@ -45,5 +45,15 @@ describe("assistantSupportsVellumProviderProfiles", () => {
     expect(await assistantSupportsVellumProviderProfiles()).toBe(true);
     setVersion("0.11.0");
     expect(await assistantSupportsVellumProviderProfiles()).toBe(true);
+  });
+
+  test("a hydrated identity for a different assistant gates to legacy", async () => {
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("other-asst", "0.11.0", "asst-B");
+    expect(await assistantSupportsVellumProviderProfiles("asst-A")).toBe(false);
+    expect(await assistantSupportsVellumProviderProfiles("asst-B")).toBe(true);
+    // A surface opened before first hydration has no owner to hold against.
+    expect(await assistantSupportsVellumProviderProfiles(null)).toBe(true);
   });
 });

--- a/clients/web/src/lib/backwards-compat/vellum-profile-provider.test.ts
+++ b/clients/web/src/lib/backwards-compat/vellum-profile-provider.test.ts
@@ -17,26 +17,33 @@ afterEach(() => {
 
 // Exhaustive truth-table for the underlying semver gate lives in
 // `utils.test.ts`. Here we verify the boundary on each side of 0.10.12
-// plus the conservative-on-unknown policy.
+// plus the conservative-on-unknown policy after the bounded version wait.
 describe("assistantSupportsVellumProviderProfiles", () => {
-  test("returns false when version is unknown", () => {
+  test("returns false when the version stays unknown past the wait", async () => {
     setVersion(null);
-    expect(assistantSupportsVellumProviderProfiles()).toBe(false);
+    expect(await assistantSupportsVellumProviderProfiles(1)).toBe(false);
   });
 
-  test("returns false for assistants on 0.10.11 and older", () => {
-    setVersion("0.10.11");
-    expect(assistantSupportsVellumProviderProfiles()).toBe(false);
-    setVersion("0.9.9");
-    expect(assistantSupportsVellumProviderProfiles()).toBe(false);
-  });
-
-  test("returns true from 0.10.12, including pre-releases", () => {
+  test("waits for hydration before deciding", async () => {
+    setVersion(null);
+    const decision = assistantSupportsVellumProviderProfiles(1_000);
     setVersion("0.10.12");
-    expect(assistantSupportsVellumProviderProfiles()).toBe(true);
+    expect(await decision).toBe(true);
+  });
+
+  test("returns false for assistants on 0.10.11 and older", async () => {
+    setVersion("0.10.11");
+    expect(await assistantSupportsVellumProviderProfiles()).toBe(false);
+    setVersion("0.9.9");
+    expect(await assistantSupportsVellumProviderProfiles()).toBe(false);
+  });
+
+  test("returns true from 0.10.12, including pre-releases", async () => {
+    setVersion("0.10.12");
+    expect(await assistantSupportsVellumProviderProfiles()).toBe(true);
     setVersion("0.10.12-staging.1");
-    expect(assistantSupportsVellumProviderProfiles()).toBe(true);
+    expect(await assistantSupportsVellumProviderProfiles()).toBe(true);
     setVersion("0.11.0");
-    expect(assistantSupportsVellumProviderProfiles()).toBe(true);
+    expect(await assistantSupportsVellumProviderProfiles()).toBe(true);
   });
 });

--- a/clients/web/src/lib/backwards-compat/vellum-profile-provider.test.ts
+++ b/clients/web/src/lib/backwards-compat/vellum-profile-provider.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { assistantSupportsVellumProviderProfiles } from "@/lib/backwards-compat/vellum-profile-provider";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+function setVersion(version: string | null) {
+  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+}
+
+beforeEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+// Exhaustive truth-table for the underlying semver gate lives in
+// `utils.test.ts`. Here we verify the boundary on each side of 0.10.12
+// plus the conservative-on-unknown policy.
+describe("assistantSupportsVellumProviderProfiles", () => {
+  test("returns false when version is unknown", () => {
+    setVersion(null);
+    expect(assistantSupportsVellumProviderProfiles()).toBe(false);
+  });
+
+  test("returns false for assistants on 0.10.11 and older", () => {
+    setVersion("0.10.11");
+    expect(assistantSupportsVellumProviderProfiles()).toBe(false);
+    setVersion("0.9.9");
+    expect(assistantSupportsVellumProviderProfiles()).toBe(false);
+  });
+
+  test("returns true from 0.10.12, including pre-releases", () => {
+    setVersion("0.10.12");
+    expect(assistantSupportsVellumProviderProfiles()).toBe(true);
+    setVersion("0.10.12-staging.1");
+    expect(assistantSupportsVellumProviderProfiles()).toBe(true);
+    setVersion("0.11.0");
+    expect(assistantSupportsVellumProviderProfiles()).toBe(true);
+  });
+});

--- a/clients/web/src/lib/backwards-compat/vellum-profile-provider.ts
+++ b/clients/web/src/lib/backwards-compat/vellum-profile-provider.ts
@@ -1,0 +1,22 @@
+/**
+ * Backwards-compat gate: the wire payload for Vellum-picker profiles.
+ *
+ * Daemons at `MIN_VERSION` and later store and dispatch
+ * `provider: "vellum"` profiles (the routing identity: the managed
+ * upstream derives from the model per-request, no connection binding).
+ * Older daemons reject the value at the profile write route, so the
+ * editor writes the legacy wire shape instead — the model's managed
+ * upstream as `provider`, bound to the provider-agnostic `vellum`
+ * connection. The UI is identical either way; only the payload differs.
+ *
+ * NOTE: snapshot-based (`assistantSupports`) — the editor's save handler
+ * runs outside render. Unknown/unparseable versions gate to the legacy
+ * payload, which every daemon accepts.
+ */
+import { assistantSupports } from "./utils";
+
+const MIN_VERSION = "0.10.12";
+
+export function assistantSupportsVellumProviderProfiles(): boolean {
+  return assistantSupports(MIN_VERSION);
+}

--- a/clients/web/src/lib/backwards-compat/vellum-profile-provider.ts
+++ b/clients/web/src/lib/backwards-compat/vellum-profile-provider.ts
@@ -13,16 +13,35 @@
  * shape newer daemons merely tolerate — so the check awaits
  * `whenAssistantVersionKnown()` rather than snapshotting the
  * conservative false-on-unknown default (see the write-path note on
- * that helper). After the bounded wait, a still-unknown version gates
- * to the legacy payload, which every daemon accepts.
+ * that helper).
+ *
+ * Owner-scoped: the wait can resolve after an assistant switch, in
+ * which case the store holds a different assistant's version than the
+ * one the save targets. When `ownerAssistantId` is known, a post-wait
+ * identity that belongs to any other assistant gates to the legacy
+ * payload — the only shape that is safe on every daemon. A null owner
+ * (surface opened before first hydration) accepts the first hydrated
+ * identity.
  */
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
 import { assistantSupports, whenAssistantVersionKnown } from "./utils";
 
 const MIN_VERSION = "0.10.12";
 
 export async function assistantSupportsVellumProviderProfiles(
+  ownerAssistantId?: string | null,
   versionWaitTimeoutMs?: number,
 ): Promise<boolean> {
   await whenAssistantVersionKnown(versionWaitTimeoutMs);
+  const hydratedAssistantId =
+    useAssistantIdentityStore.getState().assistantId;
+  if (
+    ownerAssistantId != null &&
+    hydratedAssistantId != null &&
+    hydratedAssistantId !== ownerAssistantId
+  ) {
+    return false;
+  }
   return assistantSupports(MIN_VERSION);
 }

--- a/clients/web/src/lib/backwards-compat/vellum-profile-provider.ts
+++ b/clients/web/src/lib/backwards-compat/vellum-profile-provider.ts
@@ -17,11 +17,11 @@
  *
  * Owner-scoped: the wait can resolve after an assistant switch, in
  * which case the store holds a different assistant's version than the
- * one the save targets. When `ownerAssistantId` is known, a post-wait
- * identity that belongs to any other assistant gates to the legacy
- * payload — the only shape that is safe on every daemon. A null owner
- * (surface opened before first hydration) accepts the first hydrated
- * identity.
+ * one the save targets. When `ownerAssistantId` is supplied, the
+ * hydrated identity must belong to exactly that assistant — an
+ * un-owned identity (a writer that omitted the owner tag) gates to the
+ * legacy payload, the only shape that is safe on every daemon. A null
+ * owner (caller has no write-target id) accepts any hydrated identity.
  */
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
@@ -36,11 +36,7 @@ export async function assistantSupportsVellumProviderProfiles(
   await whenAssistantVersionKnown(versionWaitTimeoutMs);
   const hydratedAssistantId =
     useAssistantIdentityStore.getState().assistantId;
-  if (
-    ownerAssistantId != null &&
-    hydratedAssistantId != null &&
-    hydratedAssistantId !== ownerAssistantId
-  ) {
+  if (ownerAssistantId != null && hydratedAssistantId !== ownerAssistantId) {
     return false;
   }
   return assistantSupports(MIN_VERSION);

--- a/clients/web/src/lib/backwards-compat/vellum-profile-provider.ts
+++ b/clients/web/src/lib/backwards-compat/vellum-profile-provider.ts
@@ -9,14 +9,20 @@
  * upstream as `provider`, bound to the provider-agnostic `vellum`
  * connection. The UI is identical either way; only the payload differs.
  *
- * NOTE: snapshot-based (`assistantSupports`) — the editor's save handler
- * runs outside render. Unknown/unparseable versions gate to the legacy
- * payload, which every daemon accepts.
+ * Async: this gates a WRITE path, and the legacy fallback persists a
+ * shape newer daemons merely tolerate — so the check awaits
+ * `whenAssistantVersionKnown()` rather than snapshotting the
+ * conservative false-on-unknown default (see the write-path note on
+ * that helper). After the bounded wait, a still-unknown version gates
+ * to the legacy payload, which every daemon accepts.
  */
-import { assistantSupports } from "./utils";
+import { assistantSupports, whenAssistantVersionKnown } from "./utils";
 
 const MIN_VERSION = "0.10.12";
 
-export function assistantSupportsVellumProviderProfiles(): boolean {
+export async function assistantSupportsVellumProviderProfiles(
+  versionWaitTimeoutMs?: number,
+): Promise<boolean> {
+  await whenAssistantVersionKnown(versionWaitTimeoutMs);
   return assistantSupports(MIN_VERSION);
 }


### PR DESCRIPTION
## Summary
- New backwards-compat gate `lib/backwards-compat/vellum-profile-provider.ts` (`MIN_VERSION = "0.10.12"`, snapshot-based since the save handler runs outside render): daemons carrying the Milestone B write-enablement accept `provider: "vellum"` directly.
- Gate on: the Vellum picker entry saves `{provider: "vellum", model: <native id>}` with no connection binding; an edit-save sends `provider_connection: null` so a stored legacy binding is cleared (a soft per-profile migration on touch). Gate off (or version unknown): the PR 14 legacy payload, byte-identical — derived upstream bound to the vellum connection. The UI is identical either way.
- Tests: gate truth-table at the 0.10.12 boundary (including pre-release suffixes), plus editor payload tests for both gate states asserting the exact wire entries.

## Original prompt
Milestone C PR 10 of the connection-removal plan (papertrail on #38102) — the last C PR. PRs 6 (catalog stamp flip) and 7 (migration 133) are merged, so stored config is identity-shaped; this stops the web picker from producing new legacy-shape profiles wherever the daemon is new enough, while old daemons keep receiving the payload they can store.

NOTE for release cut: `MIN_VERSION = "0.10.12"` assumes the next assistant release off main is 0.10.12 (first release carrying #38682). If the next version number differs, update the gate constant before shipping the web bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->