### PR TITLE
feat(voice): give the voice room one spatial model for its text

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-ambient-transcript.tsx
@@ -1,28 +1,39 @@
 /**
- * Live transcript for the voice room, styled as a right-side chat rail. A
- * bottom-anchored column pinned to the room's right edge, newest content at the
- * bottom, with a top fade mask so older lines dissolve as they scroll up. Two
- * independently pref-gated halves:
+ * Live transcript for the voice room, rendered into the room's two text zones
+ * (see `voice-room-layout.ts`): the user's speech above the eyes, the
+ * assistant's below. Two independently pref-gated halves:
  *
- * - USER speech as a right-aligned "raised surface" bubble —
+ * - USER speech as a soft pill in the upper zone —
  *   `partialTranscript || finalTranscript` from the live-voice store, shown only
- *   when `showUserTranscript` is on. The bubble uses the room's bubble tone vars
+ *   when `showUserTranscript` is on. The pill uses the room's bubble tone vars
  *   (white surface / dark text over dark avatars, inverted for the light one).
- * - ASSISTANT speech as left-aligned muted plain text (no bubble) —
- *   `assistantTranscript`, shown only when `showAssistantTranscript` is on AND
- *   the assistant isn't idle behind a new `listening` turn (the transcript
- *   lingers until the next response starts).
+ *   Set small and quiet: this is a receipt — "did it hear me right?" — not the
+ *   thing you're here for.
+ * - ASSISTANT speech as untreated text in the lower zone — `assistantTranscript`,
+ *   shown only when `showAssistantTranscript` is on AND the assistant isn't idle
+ *   behind a new `listening` turn (the transcript lingers until the next
+ *   response starts). Set at the room's largest size, with no container at all:
+ *   in a voice room this IS the content, so it gets the type presence and the
+ *   emphasis rather than the heavier treatment landing on the quieter half.
  *
- * Both prefs default OFF, so by default this renders nothing and the room stays
- * text-free. The rail is `pointer-events-none`, so it never blocks the room's
- * ✕/gear controls or the mic/stop cluster. Words reveal one at a time via
- * {@link VoiceTranscriptText}. The assistant half's bright leading-edge tone
- * tracks the TTS playhead — {@link useSpokenWordCursor} maps audio progress
- * onto the word list, so the highlight sits on the word being *spoken* rather
- * than the last-arrived one while the streamed text runs ahead of speech. A
- * `null` cursor (the response has produced no audio yet) falls back to the
- * default last-word reveal, so an audio-less response keeps a live leading
- * edge instead of a dead first-word highlight.
+ * Speaker identity is carried by *zone* alone. At most two items exist at once
+ * and they sit either side of the character, so position tells them apart
+ * without the alignment-and-bubble conventions a many-message thread needs.
+ *
+ * Both zones center a column of `VOICE_ROOM_TEXT_MEASURE` and left-align inside
+ * it, and each half grows from a fixed edge — the pill rightward from the
+ * column's left edge, the assistant text downward — so no arriving word ever
+ * shifts a word already on screen. Both prefs default OFF, so by default this
+ * renders nothing and the room stays text-free. The zones are
+ * `pointer-events-none`, so they never block the room's ✕/gear controls or the
+ * mic/stop cluster. Words reveal one at a time via {@link VoiceTranscriptText}.
+ * The assistant half's bright leading-edge tone tracks the TTS playhead —
+ * {@link useSpokenWordCursor} maps audio progress onto the word list, so the
+ * highlight sits on the word being *spoken* rather than the last-arrived one
+ * while the streamed text runs ahead of speech. A `null` cursor (the response
+ * has produced no audio yet) falls back to the default last-word reveal, so an
+ * audio-less response keeps a live leading edge instead of a dead first-word
+ * highlight.
  *
  * Subscriptions are deliberately narrow — the three transcript fields, the two
  * prefs, and the low-frequency `state`/`reconnecting` (per-turn, for the
@@ -35,7 +46,12 @@
  * current turn only.
  */
 
-import { useMemo } from "react";
+import {
+  useMemo,
+  type ComponentProps,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
@@ -44,6 +60,14 @@ import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 import { useSpokenWordCursor } from "./use-spoken-word-cursor";
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
+import {
+  VOICE_ROOM_LOWER_ZONE_BOTTOM,
+  VOICE_ROOM_LOWER_ZONE_MAX_HEIGHT,
+  VOICE_ROOM_TEXT_MEASURE,
+  VOICE_ROOM_UPPER_ZONE_HEIGHT,
+  VOICE_ROOM_UPPER_ZONE_TOP,
+  VOICE_ROOM_ZONE_FADE,
+} from "./voice-room-layout";
 import {
   splitTranscriptWords,
   VoiceTranscriptText,
@@ -89,84 +113,108 @@ export function VoiceAmbientTranscript() {
   const showAssistantHalf =
     showAssistant && assistantTranscript.length > 0 && visual !== "listening";
 
-  // The rail shows whenever either half is present. An empty rail renders no DOM
-  // (the text-free room), and presence-managing the container through the outer
-  // AnimatePresence below lets the last remaining half fade out instead of
-  // popping when it clears.
-  const railVisible = showUserHalf || showAssistantHalf;
-
-  const fade = {
-    initial: reduce ? false : { opacity: 0 },
-    animate: { opacity: 1 },
-    exit: { opacity: 0 },
-    transition: { duration: reduce ? 0 : 0.3 },
-  } as const;
-
-  // A top-to-bottom fade so older lines dissolve as newer ones push up from the
-  // bottom-anchored column.
-  const fadeMask = "linear-gradient(to bottom, transparent, #000 12%)";
-
-  // Absolute children are positioned against the padding box, so the overlay's
-  // safe-area padding does not inset this rail — fold the right inset into the
-  // rail's own right padding (as the room's corner controls do) so transcript
-  // text clears the notch / rounded edge in landscape on notched shells.
-  const railRightPad =
-    "calc(1.5rem + var(--safe-area-inset-right, env(safe-area-inset-right, 0px)))";
+  // Each zone enters from its own side of the eyes — the user's from above, the
+  // assistant's from below — so the motion states the spatial model rather than
+  // just decorating the fade.
+  const enter = (from: number) =>
+    ({
+      initial: reduce ? false : { opacity: 0, y: from },
+      animate: { opacity: 1, y: 0 },
+      exit: reduce ? { opacity: 0 } : { opacity: 0, y: from },
+      transition: { duration: reduce ? 0 : 0.3 },
+    }) as const;
 
   return (
     <AnimatePresence>
-      {railVisible ? (
-        <motion.div
-          key="rail"
-          className="pointer-events-none absolute right-0 top-0 bottom-0 z-10 flex w-[min(30rem,42vw)] flex-col justify-end gap-3 overflow-hidden pl-4 pt-20 pb-28"
-          style={{
-            paddingRight: railRightPad,
-            maskImage: fadeMask,
-            WebkitMaskImage: fadeMask,
+      {showUserHalf ? (
+        <VoiceRoomTextZone
+          key="user"
+          placement={{
+            top: VOICE_ROOM_UPPER_ZONE_TOP,
+            height: VOICE_ROOM_UPPER_ZONE_HEIGHT,
           }}
-          {...fade}
+          {...enter(-10)}
         >
-          <AnimatePresence>
-            {showUserHalf ? (
-              <motion.div
-                key="user"
-                data-testid="voice-ambient-user"
-                aria-live="polite"
-                className="flex justify-end"
-                {...fade}
-              >
-                <div
-                  data-testid="voice-ambient-user-bubble"
-                  className="max-w-[85%] break-words rounded-lg border border-[var(--room-border)] px-4 py-2.5 text-[clamp(15px,2vmin,19px)] leading-snug"
-                  style={{ backgroundColor: "var(--room-bubble-bg)" }}
-                >
-                  <VoiceTranscriptText
-                    text={userText}
-                    color="var(--room-bubble-fg)"
-                  />
-                </div>
-              </motion.div>
-            ) : null}
+          <div
+            data-testid="voice-ambient-user"
+            aria-live="polite"
+            // The pill grows rightward from the column's left edge, so the
+            // words already revealed never shift as the partial extends.
+            className="flex justify-start"
+          >
+            <div
+              data-testid="voice-ambient-user-bubble"
+              className="max-w-full break-words rounded-2xl px-3.5 py-2 text-[clamp(13px,1.7vmin,16px)] leading-snug"
+              style={{ backgroundColor: "var(--room-bubble-bg)" }}
+            >
+              <VoiceTranscriptText
+                text={userText}
+                color="var(--room-bubble-fg)"
+              />
+            </div>
+          </div>
+        </VoiceRoomTextZone>
+      ) : null}
 
-            {showAssistantHalf ? (
-              <motion.div
-                key="assistant"
-                data-testid="voice-ambient-assistant"
-                aria-live="polite"
-                className="flex justify-start"
-                {...fade}
-              >
-                <div className="max-w-[95%] break-words text-[clamp(15px,2vmin,19px)] leading-relaxed">
-                  <VoiceTranscriptText
-                    text={assistantTranscript}
-                    highlightIndex={spokenIndex ?? undefined}
-                  />
-                </div>
-              </motion.div>
-            ) : null}
-          </AnimatePresence>
-        </motion.div>
+      {showAssistantHalf ? (
+        <VoiceRoomTextZone
+          key="assistant"
+          placement={{
+            bottom: VOICE_ROOM_LOWER_ZONE_BOTTOM,
+            maxHeight: VOICE_ROOM_LOWER_ZONE_MAX_HEIGHT,
+          }}
+          {...enter(10)}
+        >
+          <div
+            data-testid="voice-ambient-assistant"
+            aria-live="polite"
+            className="break-words text-[clamp(17px,2.5vmin,26px)] leading-relaxed"
+          >
+            <VoiceTranscriptText
+              text={assistantTranscript}
+              highlightIndex={spokenIndex ?? undefined}
+            />
+          </div>
+        </VoiceRoomTextZone>
       ) : null}
     </AnimatePresence>
+  );
+}
+
+/**
+ * One of the room's two text zones: a full-width band positioned by the caller
+ * (`top`/`height` above the eyes, `bottom`/`maxHeight` below), centering the
+ * shared text measure and anchoring its content to the band's bottom edge so
+ * overflow rides up into the fade instead of pushing the newest words out.
+ */
+function VoiceRoomTextZone({
+  placement,
+  children,
+  ...motionProps
+}: {
+  /** Where the band sits: `top`/`height` above the eyes, `bottom`/`maxHeight` below. */
+  placement: CSSProperties;
+  children: ReactNode;
+} & Pick<
+  ComponentProps<typeof motion.div>,
+  "initial" | "animate" | "exit" | "transition"
+>) {
+  return (
+    <motion.div
+      className="pointer-events-none absolute inset-x-0 z-10 flex flex-col justify-end overflow-hidden px-6"
+      style={{
+        ...placement,
+        maskImage: VOICE_ROOM_ZONE_FADE,
+        WebkitMaskImage: VOICE_ROOM_ZONE_FADE,
+      }}
+      {...motionProps}
+    >
+      <div
+        className="mx-auto w-full"
+        style={{ maxWidth: VOICE_ROOM_TEXT_MEASURE }}
+      >
+        {children}
+      </div>
+    </motion.div>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -196,12 +196,9 @@ function RoomScene({
           size={size}
         />
       </div>
-      {/* Shared caption below the centered avatar (half its size from center,
-          plus a gap), matching the app's void look. */}
-      <VoiceStateCaption
-        visual={visual}
-        top={`calc(50% + ${size / 2}px + 1.25rem)`}
-      />
+      {/* Shared caption in the room's lower text zone, matching the app's void
+          look — the same anchor the color look uses. */}
+      <VoiceStateCaption visual={visual} />
     </div>
   );
 }
@@ -444,7 +441,9 @@ export const States: Story = {
             visual={visual}
             eyePlacement="center"
             wavePlacement="top"
-            minHeight={280}
+            // Tall enough that the lower zone's caption clears the eyes in a
+            // grid cell — the zone anchors off the frame, not the centerpiece.
+            minHeight={320}
           />
         </div>
       ))}
@@ -551,7 +550,9 @@ export const VoidLookStates: VoidStory = {
       {VISUALS.map((visual) => (
         <div key={visual} className="flex flex-col gap-2">
           <span className="text-[13px] font-medium text-white/60">{visual}</span>
-          <RoomScene {...args} visual={visual} size={140} minHeight={260} />
+          {/* Tall enough that the lower zone's caption clears the avatar in a
+              grid cell — the zone anchors off the frame, not the centerpiece. */}
+          <RoomScene {...args} visual={visual} size={140} minHeight={360} />
         </div>
       ))}
     </div>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -25,8 +25,10 @@
  * just above them, then `responding` settles them to a medium size while the
  * assistant's voice radiates outward from behind them (see
  * {@link VoiceRespondingStyle}). A soft state caption ("Listening" / "Thinking"
- * / "Speaking") fades in below the eyes, filling the negative space and naming
- * the beat. `reconnecting` fades the eyes back — presence dimmed while away.
+ * / "Speaking") fades in down in the room's lower text zone (see
+ * `voice-room-layout.ts`), naming the beat from the same baseline the
+ * assistant's own speech would occupy. `reconnecting` fades the eyes back —
+ * presence dimmed while away.
  *
  * Geometry and timing mirror onboarding's `IntroductionScreen` +
  * `OnboardingPeekingEyes`. Traits default like `ChatAvatar` does (first
@@ -61,6 +63,10 @@ import {
 } from "./voice-listening-waves";
 import type { VoiceAvatarVisual } from "./voice-avatar-state";
 import { createAmplitudeSmoother } from "./voice-motion";
+import {
+  VOICE_ROOM_CAPTION_TEXT,
+  VOICE_ROOM_LOWER_ZONE_BOTTOM,
+} from "./voice-room-layout";
 
 /** Where the eyes come to rest: cut off at the bottom edge, or centered. */
 export type VoiceEyePlacement = "bottom" | "center";
@@ -74,9 +80,15 @@ const EYE_REST_CUTOFF = 0.25;
 const EYE_TARGET_HEIGHT = 0.22;
 const EYE_MAX_WIDTH = 0.6;
 const EYE_MAX_HEIGHT_PX = 240;
-/** Slight whole-eye cursor parallax. */
-const CURSOR_MAX_X = 14;
-const CURSOR_MAX_Y = 8;
+/**
+ * Slight whole-eye cursor parallax — a trace of life, not gaze tracking. Kept
+ * small, and smaller on X than on Y: the eyes are the room's vertical spine and
+ * every other centered element (the state caption, the thinking triad, both
+ * transcript zones) shares that axis, so horizontal drift reads as the eyes
+ * sitting *misaligned* with the text rather than as them following the cursor.
+ */
+const CURSOR_MAX_X = 4;
+const CURSOR_MAX_Y = 3;
 /**
  * Per-state eye size, as a scale of the rest geometry (which is authored at the
  * largest, `listening`, size). The eyes never move — they open wide when the
@@ -259,16 +271,14 @@ export function VoiceRoomColorLook({
   const sizeScale = EYE_STATE_SCALE[visual];
   const eyeH = eyeDisplayHeight(look.art, w, h);
   const centeredEyeTop = (h - eyeH) / 2;
-  // Spatial model: above the eyes is the user's space (the user transcript),
-  // below is the assistant's (its speech + status). The thinking dots are
-  // assistant activity, so they hang just *below* the shrunken thinking eyes —
-  // clear of the user transcript above, and pairing with the state caption in
+  // Spatial model (shared with both text zones — see `voice-room-layout.ts`):
+  // above the eyes is the user's space (the user transcript), below is the
+  // assistant's (its speech + status). The thinking dots are assistant
+  // activity, so they hang just *below* the shrunken thinking eyes — clear of
+  // the user transcript above, and pairing with the state caption further down
   // the lower zone. (Centered scaling, so the small eyes' bottom sits above the
   // full-size bottom by half the size loss.)
   const thinkingEyeBottom = centeredEyeTop + eyeH - (eyeH * (1 - EYE_STATE_SCALE.thinking)) / 2;
-  // The state caption sits in the negative space below the eyes' full-size
-  // bottom edge — a stable anchor the per-state resize (centered) doesn't move.
-  const captionTop = centeredEyeTop + eyeH + Math.max(24, eyeH * 0.22);
 
   // Body grows to cover the screen end to end, from the small avatar size at
   // the entry origin — onboarding's Introduction grow, re-anchored to where the
@@ -418,33 +428,33 @@ export function VoiceRoomColorLook({
         dimmed={visual === "reconnecting"}
       />
 
-      {/* State caption in the negative space below the eyes (unless the live
-          captions are on — the transcript fills that space instead). */}
-      {showStateCaption ? (
-        <VoiceStateCaption visual={visual} top={captionTop} />
-      ) : null}
+      {/* State caption in the room's lower zone (unless the live captions are
+          on — the assistant transcript occupies that zone instead). */}
+      {showStateCaption ? <VoiceStateCaption visual={visual} /> : null}
     </>
   );
 }
 
 /**
- * Soft state caption ("Listening" / "Thinking" / "Speaking") centered in the
- * negative space below the eyes, in the room's foreground tone. Cross-fades on
- * state change and simply isn't there for states without a caption
+ * Soft state caption ("Listening" / "Thinking" / "Speaking") in the room's
+ * lower text zone, in the room's foreground tone. Cross-fades on state change
+ * and simply isn't there for states without a caption
  * ({@link EYE_STATE_CAPTION}) — idle and the connecting-side states, which the
- * room's own connect label already covers. `top` is a stable anchor from the
- * centerpiece's bottom edge — a px number off the eyes' full-size bottom (color
- * look; the per-state resize is centered, so it doesn't shift this), or a CSS
- * length off the fixed avatar size (the void look). Shared by both looks so the
- * caption reads in the same place regardless of avatar type.
+ * room's own connect label already covers.
+ *
+ * Anchored to {@link VOICE_ROOM_LOWER_ZONE_BOTTOM}, the assistant's zone, so
+ * the caption names the assistant's beat from the same baseline the
+ * assistant's own speech occupies — the two never coexist (the caption stands
+ * down when live captions are on), so one baseline serves both rather than
+ * splitting the room's text across two regions. Holding it clear of the
+ * centerpiece also keeps it from reading as a facial feature: a caption sat
+ * just under the eyes reads as a mouth, which suits "Speaking" and contradicts
+ * "Listening", where the *user* is the one talking.
+ *
+ * Both looks share this anchor, so the caption reads in the same place
+ * regardless of avatar type.
  */
-export function VoiceStateCaption({
-  visual,
-  top,
-}: {
-  visual: VoiceAvatarVisual;
-  top: number | string;
-}) {
+export function VoiceStateCaption({ visual }: { visual: VoiceAvatarVisual }) {
   const reduce = useReducedMotion();
   const label = EYE_STATE_CAPTION[visual];
   return (
@@ -454,8 +464,11 @@ export function VoiceStateCaption({
           key={label}
           data-testid="voice-state-caption"
           aria-hidden="true"
-          className="pointer-events-none absolute left-1/2 z-[1] -translate-x-1/2 text-center text-[clamp(15px,2.2vmin,22px)] font-medium tracking-wide text-[var(--room-fg-muted,rgba(255,255,255,0.7))]"
-          style={{ top }}
+          className="pointer-events-none absolute left-1/2 z-[1] -translate-x-1/2 text-center font-medium tracking-wide text-[var(--room-fg-muted,rgba(255,255,255,0.7))]"
+          style={{
+            bottom: VOICE_ROOM_LOWER_ZONE_BOTTOM,
+            fontSize: VOICE_ROOM_CAPTION_TEXT,
+          }}
           initial={reduce ? false : { opacity: 0, y: 6 }}
           animate={{ opacity: 1, y: 0 }}
           exit={reduce ? { opacity: 0 } : { opacity: 0, y: -6 }}
@@ -473,8 +486,9 @@ export function VoiceStateCaption({
  * centered eyes (the lower "assistant status" zone, clear of the user
  * transcript above), in the room's foreground tone so it reads on any avatar
  * color. `eyesBottom` is the bottom of the shrunken thinking eyes; the triad
- * hangs a short gap below it (both scaled against the room box) so it stays
- * clear of the eyes in any frame. A first-pass "the assistant is working" motif.
+ * hangs a short gap below it (scaled against the room box) so it stays clear of
+ * the eyes in any frame, while the dots themselves are scaled against the state
+ * caption's type size. A first-pass "the assistant is working" motif.
  */
 function VoiceThinkingIndicator({
   viewport,
@@ -485,25 +499,29 @@ function VoiceThinkingIndicator({
   eyesBottom: number;
 }) {
   const reduce = useReducedMotion();
-  // Size against the room box (not fixed px) so the dots keep the same
-  // proportion in a small Storybook frame and the full-window app.
-  const dot = Math.max(8, Math.round(0.04 * Math.min(viewport.w, viewport.h)));
-  // Hang the triad's center a short gap below the eyes' bottom edge, clamped so
-  // it never rides off the bottom of a short frame.
-  const top = Math.min(viewport.h - dot * 1.5, eyesBottom + dot * 1.6);
+  // Hang the triad's center a short gap below the eyes' bottom edge. The gap
+  // scales with the room box, NOT with the dot size, so the two stay
+  // independent. Clamped so it never rides off the bottom of a short frame.
+  const top = Math.min(
+    viewport.h - 24,
+    eyesBottom + 0.06 * Math.min(viewport.w, viewport.h),
+  );
   return (
     <div
       aria-hidden="true"
       className="pointer-events-none absolute left-1/2 z-[1] flex -translate-x-1/2 -translate-y-1/2 items-center"
-      style={{ top, gap: dot }}
+      // Dots are sized in `em` off the caption's own type size, so the triad
+      // reads as a peer of the "Thinking" caption below it and the two stay
+      // locked to each other at every viewport.
+      style={{ top, fontSize: VOICE_ROOM_CAPTION_TEXT, gap: "0.45em" }}
     >
       {[0, 1, 2].map((i) => (
         <motion.span
           key={i}
           className="block rounded-full"
           style={{
-            width: dot,
-            height: dot,
+            width: "0.5em",
+            height: "0.5em",
             backgroundColor: "var(--room-fg, #ffffff)",
           }}
           initial={reduce ? false : { opacity: 0.3, scale: 0.75 }}
@@ -929,7 +947,9 @@ export function VoiceRoomEyes({
             animate={wobble}
             onClick={reactToClick}
           >
-            {/* Slight parallax: the whole eyes drift smoothly toward the cursor. */}
+            {/* Slight parallax: the whole eyes drift smoothly toward the
+                cursor — a few px only, so they stay visually centered on the
+                room's spine (see CURSOR_MAX_X / CURSOR_MAX_Y). */}
             <div
               style={{
                 transform: `translate(${pointer.x * CURSOR_MAX_X}px, ${pointer.y * CURSOR_MAX_Y}px)`,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-layout.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-layout.ts
@@ -1,0 +1,77 @@
+/**
+ * Vertical layout zones for the voice room's text surfaces.
+ *
+ * The room reads top-to-bottom as the conversation itself: the user's
+ * transcribed speech in the upper zone, the character's eyes holding the
+ * center, and the assistant's speech — or, when live captions are off, the
+ * state caption naming the beat — in the lower zone.
+ *
+ * Every text surface in the room anchors to these constants, so the model holds
+ * across both looks: the transcript's two halves, the state caption, and the
+ * thinking triad all derive their vertical position from one place.
+ *
+ * Zones are inset past the room's corner controls — the gear/✕ cluster above,
+ * the mute/stop cluster below — so text never collides with them. The `rem`
+ * floor in each anchor is what guarantees that clearance (the controls are a
+ * fixed 3rem tall at a 1.25rem inset); the percentage takes over on taller
+ * viewports, where hugging a fixed offset off the edge would strand the text
+ * far below the eyes. Both are safe-area aware per docs/CAPACITOR.md — the
+ * `var()` is set by `capacitor-plugin-safe-area` on Capacitor iOS, `env()`
+ * covers standard browsers with `viewport-fit=cover`, and `0px` covers desktop
+ * / non-notch devices.
+ *
+ * Percentages (not `vh`) resolve against the room box, so the zones size
+ * correctly both in the app — where the room is a `fixed inset-0` overlay — and
+ * in the Storybook harnesses, which render the room inside a bounded frame.
+ */
+
+export const SAFE_AREA_TOP =
+  "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))";
+export const SAFE_AREA_BOTTOM =
+  "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))";
+export const SAFE_AREA_LEFT =
+  "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))";
+export const SAFE_AREA_RIGHT =
+  "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))";
+
+/** Top edge of the upper (user) zone — clears the top-right gear/✕ cluster. */
+export const VOICE_ROOM_UPPER_ZONE_TOP = `calc(max(4.5rem, 11%) + ${SAFE_AREA_TOP})`;
+/** Height of the upper zone. Content is bottom-anchored inside it, so a longer
+ *  utterance grows upward and its oldest lines dissolve into the fade. */
+export const VOICE_ROOM_UPPER_ZONE_HEIGHT = "18%";
+
+/**
+ * Bottom edge of the lower (assistant) zone — clears the mute/stop cluster.
+ * The state caption and the assistant transcript's last line share this
+ * baseline, so turning live captions on replaces the status word roughly in
+ * place rather than moving the room's text to a different region.
+ */
+export const VOICE_ROOM_LOWER_ZONE_BOTTOM = `calc(max(4.5rem, 14%) + ${SAFE_AREA_BOTTOM})`;
+/** Ceiling on the lower zone. Content is bottom-anchored, so a long response
+ *  keeps its newest words on the baseline and fades out the top. */
+export const VOICE_ROOM_LOWER_ZONE_MAX_HEIGHT = "28%";
+
+/**
+ * The room's single text measure. Both zones center a column of this width and
+ * left-align their text inside it, which is what keeps the word-by-word reveal
+ * stable: centered text re-centers its last line on every arriving word, so the
+ * words already on screen would shimmy sideways as speech streams in. One
+ * shared left edge also gives the two speakers a common spine — they're told
+ * apart by zone, type scale, and treatment, not by alignment.
+ */
+export const VOICE_ROOM_TEXT_MEASURE = "min(36rem, 82vw)";
+
+/**
+ * Top-to-bottom dissolve for both zones: with content bottom-anchored, the
+ * oldest lines fade out as newer ones push up past the zone's ceiling.
+ */
+export const VOICE_ROOM_ZONE_FADE =
+  "linear-gradient(to bottom, transparent, #000 15%)";
+
+/**
+ * Type size for the room's status voice — the state caption, and anything that
+ * should read as its peer. The thinking triad sizes its dots in `em` against
+ * this, so the dots stay a fixed fraction of the caption beside them at every
+ * viewport rather than drifting heavier or lighter than the words.
+ */
+export const VOICE_ROOM_CAPTION_TEXT = "clamp(15px, 2.2vmin, 22px)";

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -66,6 +66,13 @@ import { useActiveConnectSurface } from "./use-active-connect-surface";
 
 import { resolveWaveAccentHex } from "./wave-accent";
 
+import {
+  SAFE_AREA_BOTTOM,
+  SAFE_AREA_LEFT,
+  SAFE_AREA_RIGHT,
+  SAFE_AREA_TOP,
+} from "./voice-room-layout";
+
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
 import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
 import { VoiceRoomSettingsMenu } from "./voice-room-settings-menu";
@@ -82,29 +89,6 @@ import {
 import { useIsVoiceRoomVisible } from "./use-is-voice-room-visible";
 
 const AVATAR_SIZE = 220;
-/**
- * State caption anchor for the void look — just below the centered avatar's
- * bottom edge (half its size from center, plus a gap), the void-look counterpart
- * to the color look's caption below the eyes. Sits above the assistant
- * transcript's `50% + 15vmin + 2.5rem` clearance on any typical viewport, and it
- * only shows when that transcript is off (see below), so the two never collide.
- */
-const VOID_CAPTION_TOP = `calc(50% + ${AVATAR_SIZE / 2}px + 1.75rem)`;
-
-/**
- * Safe-area insets (see `docs/CAPACITOR.md`): the `var()` is set by
- * `capacitor-plugin-safe-area` on Capacitor iOS, `env()` covers standard
- * browsers with `viewport-fit=cover`, and `0px` covers desktop / non-notch
- * devices — so these are inert everywhere except a notched iOS shell.
- */
-const SAFE_AREA_TOP =
-  "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))";
-const SAFE_AREA_BOTTOM =
-  "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))";
-const SAFE_AREA_LEFT =
-  "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))";
-const SAFE_AREA_RIGHT =
-  "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))";
 
 /**
  * Shared treatment for the room's top icon controls, toned to the active look
@@ -252,10 +236,10 @@ function VoiceRoomOverlay() {
           visual={visual}
           getAmplitude={getLiveVoiceInputAmplitude}
           getResponseAmplitude={getLiveVoiceOutputAmplitude}
-          // While assistant captions are on, the right-side transcript rail
-          // already narrates the turn, so the centered state caption stands down
-          // to avoid doubling it. The user-only caption pref leaves the caption
-          // up (a user bubble alone doesn't name the assistant's state).
+          // While assistant captions are on, the transcript's lower zone already
+          // narrates the turn from the caption's own baseline, so the caption
+          // stands down rather than doubling it. The user-only caption pref
+          // leaves it up (a user pill alone doesn't name the assistant's state).
           showStateCaption={!showAssistantTranscript}
           entryOrigin={entryOrigin}
         />
@@ -280,18 +264,17 @@ function VoiceRoomOverlay() {
             <VoiceRespondingRings getAmplitude={getLiveVoiceOutputAmplitude} />
           ) : null}
           {/* Same state caption + gating as the color look (stands down while
-              the assistant transcript rail is on), anchored below the centered
-              avatar instead of the eyes. */}
-          {!showAssistantTranscript ? (
-            <VoiceStateCaption visual={visual} top={VOID_CAPTION_TOP} />
-          ) : null}
+              the assistant transcript is on), in the same shared lower zone —
+              both looks name the beat from one baseline. */}
+          {!showAssistantTranscript ? <VoiceStateCaption visual={visual} /> : null}
         </>
       )}
 
-      {/* Optional live transcript, rendered as a right-side chat rail (user
-          bubbles, assistant plain text). Pref-gated (the captions control
-          above) and absolutely positioned in the right margin, so it never
-          shifts the centered avatar and stays absent by default. */}
+      {/* Optional live transcript, rendered into the room's two text zones —
+          the user's speech above the eyes, the assistant's below. Pref-gated
+          (the captions control above) and absolutely positioned in the margins
+          the centerpiece leaves free, so it never shifts the centered avatar
+          and stays absent by default. */}
       <VoiceAmbientTranscript />
 
       {/* Backwards-compat fallback card for assistants that can still raise

--- a/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-transcript.stories.tsx
@@ -16,15 +16,19 @@ import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
 import { VoiceTranscriptText } from "./voice-transcript-text";
 
 /**
- * Iteration harness for the voice room's live captions — a right-side chat rail
- * that streams the current turn word-by-word: user speech as a right-aligned
- * bubble, assistant speech as left-aligned muted plain text.
+ * Iteration harness for the voice room's live captions — the room's two text
+ * zones streaming the current turn word-by-word: the user's speech as a small
+ * pill above the eyes, the assistant's as large untreated text below them.
  *
  * The scenes simulate a live session by streaming a canned utterance into the
  * real live-voice store one word at a time (no mic / STT / TTS), so the reveal,
  * leading-edge tone, and partial→final hand-off all behave exactly as in the
  * app. Scrub `wordMs` for the pace of speech and bump `replay` to run the
  * utterance again.
+ *
+ * The scene frame stands in for the room box: the zones anchor off *it*, not
+ * the window, so keep `minHeight` in the range of a real viewport or the two
+ * zones will crowd the centerpiece.
  */
 
 // A sample avatar color so the room tone (and the `--room-*` caption vars)
@@ -150,7 +154,8 @@ function AmbientTranscriptScene({
       className="relative flex items-center justify-center overflow-hidden rounded-lg"
       style={{ minHeight, backgroundColor: SAMPLE_HEX, ...toneVars }}
     >
-      {/* Stand-in for the centered avatar so the rail reads against the right edge. */}
+      {/* Stand-in for the centered eyes, so both zones read against the
+          centerpiece they're framing. */}
       <div
         className="size-40 rounded-full"
         style={{ backgroundColor: "var(--room-fg)", opacity: 0.12 }}
@@ -177,7 +182,7 @@ const meta: Meta<typeof AmbientTranscriptScene> = {
       options: ["user", "assistant", "both"] satisfies Role[],
       control: { type: "inline-radio" },
       description:
-        "Which half streams — user (right bubble), assistant (left plain text), or both.",
+        "Which half streams — user (pill, upper zone), assistant (large text, lower zone), or both.",
     },
     wordMs: {
       control: { type: "range", min: 80, max: 600, step: 20 },
@@ -196,8 +201,9 @@ type Story = StoryObj<typeof AmbientTranscriptScene>;
 /**
  * The ambient captions over a live-streamed turn: each word fades + rises +
  * de-blurs in and the newest word carries the brighter leading-edge tone. The
- * rail sits against the room's right edge — the user's speech as a right-aligned
- * bubble, the assistant's as left-aligned muted text. Scrub `role` and `wordMs`.
+ * two zones frame the centerpiece — your speech in a small pill above it, the
+ * assistant's at full size below — sharing one centered measure so neither
+ * pulls the room off its spine. Scrub `role` and `wordMs`.
  */
 export const Playground: Story = {};
 


### PR DESCRIPTION
## Prompt / plan

Started as "try flipping the eyes and the state caption so the eyes sit at the bottom" (per a reference mock). While scoping it we found the caption is mutually exclusive with the live transcript — `showStateCaption={!showAssistantTranscript}` — so designing the caption's placement in isolation was optimizing a surface that vanishes in the other mode. Pivoted to giving the room one spatial model that both surfaces share.

The model was already written down in `voice-room-eyes.tsx` — *"above the eyes is the user's space, below is the assistant's"* — and used to justify where the thinking dots go, but nothing else implemented it. This PR makes it real.

### What changed

`voice-room-layout.ts` (new) is the single source for the room's vertical zones, and every text surface anchors to it.

- **Transcript** moves from a right-edge rail into two centered zones — the user's speech above the eyes, the assistant's below. Speaker identity now comes from *zone*, so the chat-thread conventions the rail borrowed (left/right alignment, a bordered bubble opposite plain text) come out. Those pay off across many alternating messages; at most two items exist here at once, separated by the full height of the character.
- **Type scale follows importance.** The assistant's speech is the content in a voice room, so it gets the largest size and no container; the user's half drops to a small quiet pill — a "did it hear me right?" receipt. Both previously shared one size, with the heavier treatment on the quieter half.
- **State caption** anchors to the lower zone instead of the centerpiece, sharing a baseline with the assistant transcript (they never coexist). Sat close under the eyes it read as a mouth — fine for "Speaking", wrong for "Listening", where the *user* is talking. Both looks now share one anchor; the color look measured off the eyes and the void look off the avatar, putting the same caption in two different places.
- **Thinking dots** size in `em` off the caption's type size. Derived from the raw viewport they came out ~1.8× the caption beside them, and on a 900px-tall window the triad and caption stacked ~6px apart.
- **Cursor parallax** drops from ±14/±8 to ±4/±3, tighter on X than Y — every other centered element shares the eyes' axis, so horizontal drift read as the eyes sitting misaligned with the text rather than as following the cursor.

### Notes for review

- Both zones center a shared measure and **left-align** inside it rather than centering the text. Centered text re-centers its last line on every arriving word, which would make the word-by-word reveal shimmy sideways as speech streams in.
- Zone anchors are `calc(max(<rem>, <%>) + safe-area)`. The rem floor guarantees clearance over the corner control clusters; the percentage takes over on tall viewports so the text isn't stranded at the edge. Percentages (not `vh`) so the zones size correctly inside the bounded Storybook frames too.
- Both transcript prefs remain **default-off**, so this is invisible until captions are switched on in the room's gear menu — blast radius on current users is nil.
- Two Storybook `minHeight`s were bumped (260→360, 280→320): the zones anchor off the frame, so very short grid cells crowded the centerpiece.

No Linear ticket — scoped as small design work.

## Test plan

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- **146 tests pass** across all 9 `voice-room` suites (`voice-room`, `voice-ambient-transcript`, `voice-transcript-text`, `use-spoken-word-cursor`, `voice-avatar-state`, `voice-motion`, `voice-room-settings-menu`, `voice-list`, `voice-first-run-card`)
- Drove the Storybook harnesses through Playwright and inspected screenshots for `listening` / `thinking` / `responding` plus a live-streaming transcript. Measured in-browser rather than eyeballed:
  - dot-to-caption ratio **0.50** (was ~1.82)
  - parallax **±4px X / ±3px Y** at extreme cursor corners (was ±14/±8)
- Reviewed by the author in Storybook before commit.

### Known gap (pre-existing, not addressed)

With assistant captions **on** during `listening`, the caption stands down but the transcript half is also hidden, so the lower zone is empty and nothing names the beat. Now that both share a baseline this is a small fix, but it's a behavior change rather than a visual one — happy to take it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
