### PR TITLE
fix(persistence): stop SQLITE_BUSY in persisted-seq write from crashing the daemon

### DIFF
--- a/assistant/src/__tests__/record-persisted-seq-lock-resilience.test.ts
+++ b/assistant/src/__tests__/record-persisted-seq-lock-resilience.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression: `recordConversationPersistedSeq` must not throw on transient
+ * SQLite write contention.
+ *
+ * The persisted-seq anchor is written from the agent loop as fire-and-forget
+ * bookkeeping (`flushAccumulatedContent`, `handleMessageComplete`, tool
+ * events). Before this resilience layer the write went through a bare
+ * `rawRun`, so a `SQLITE_BUSY` ("database is locked") threw raw: on the
+ * debounced partial-flush path it surfaced as an unhandled promise rejection,
+ * and on the `message_complete` path it hit `dispatchAgentEvent`'s re-throw
+ * allowlist — either one tripped the daemon's fail-fast shutdown and crashed
+ * the process.
+ *
+ * These tests pin the two guarantees:
+ *  1. A retryable `SQLITE_BUSY` is swallowed (the anchor simply does not
+ *     advance) and self-heals on the next successful record.
+ *  2. A non-retryable error (a genuine bug) still propagates.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Wrap the real raw-query module so the persisted-seq UPDATE can be made to
+// throw on demand while every other DB call (createConversation, the read-back
+// via `rawGet`) keeps hitting the real database.
+//
+// Destructure the real exports into stable locals BEFORE registering the mock:
+// `mock.module` mutates the live module namespace in place, so reading
+// `actualRawQuery.rawRun` from inside the factory would re-resolve to the mock
+// and recurse forever. The captured `realRawRun` const is immune to that swap.
+const actualRawQuery = await import("../persistence/raw-query.js");
+const realRawRun = actualRawQuery.rawRun;
+
+let injectedRecordError: Error | null = null;
+
+mock.module("../persistence/raw-query.js", () => ({
+  ...actualRawQuery,
+  rawRun: (label: string, sql: string, ...params: unknown[]): number => {
+    if (label === "conversation:recordPersistedSeq" && injectedRecordError) {
+      throw injectedRecordError;
+    }
+    return (realRawRun as (...a: unknown[]) => number)(label, sql, ...params);
+  },
+}));
+
+import {
+  createConversation,
+  getConversationPersistedSeq,
+  recordConversationPersistedSeq,
+} from "../persistence/conversation-crud.js";
+import { initializeDb } from "../persistence/db-init.js";
+
+await initializeDb();
+
+function sqliteError(code: string): Error {
+  return Object.assign(new Error("database is locked"), { code });
+}
+
+describe("recordConversationPersistedSeq write-contention resilience", () => {
+  beforeEach(() => {
+    injectedRecordError = null;
+  });
+
+  test("swallows a transient SQLITE_BUSY and self-heals on the next record", () => {
+    // GIVEN a conversation with a recorded baseline anchor
+    const conv = createConversation();
+    recordConversationPersistedSeq(conv.id, 10);
+    expect(getConversationPersistedSeq(conv.id)).toBe(10);
+
+    // WHEN the anchor-advancing write loses the write-lock race
+    injectedRecordError = sqliteError("SQLITE_BUSY");
+    expect(() => recordConversationPersistedSeq(conv.id, 20)).not.toThrow();
+
+    // THEN the anchor is simply left un-advanced (no crash, no regression) ...
+    expect(getConversationPersistedSeq(conv.id)).toBe(10);
+
+    // ... and the next contention-free record advances it (self-healing).
+    injectedRecordError = null;
+    recordConversationPersistedSeq(conv.id, 20);
+    expect(getConversationPersistedSeq(conv.id)).toBe(20);
+  });
+
+  test("swallows the extended-result-code SQLITE_BUSY_SNAPSHOT too", () => {
+    const conv = createConversation();
+    injectedRecordError = sqliteError("SQLITE_BUSY_SNAPSHOT");
+    expect(() => recordConversationPersistedSeq(conv.id, 5)).not.toThrow();
+    expect(getConversationPersistedSeq(conv.id)).toBeNull();
+  });
+
+  test("rethrows a non-retryable SQLite error (a genuine bug)", () => {
+    const conv = createConversation();
+    injectedRecordError = sqliteError("SQLITE_ERROR");
+    expect(() => recordConversationPersistedSeq(conv.id, 5)).toThrow(
+      "database is locked",
+    );
+  });
+});

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -45,7 +45,10 @@ import { getLogger } from "../util/logger.js";
 import { getLogsDbPath } from "../util/logs-db-path.js";
 import { getConversationsDir } from "../util/platform.js";
 import { createRowMapper, parseJsonNullable } from "../util/row-mapper.js";
-import { withSqliteRetry } from "../util/sqlite-retry.js";
+import {
+  isRetryableSqliteError,
+  withSqliteRetry,
+} from "../util/sqlite-retry.js";
 import {
   deleteOrphanAttachments,
   linkAttachmentToMessage,
@@ -2744,18 +2747,43 @@ export function getConversationPersistedSeq(id: string): number | null {
  * Monotonic: the `WHERE seq IS NULL OR seq < ?` guard makes the update raise
  * the high-water mark only, so out-of-order async commits never regress it.
  * Non-positive or non-finite `seq` values are ignored.
+ *
+ * Transient SQLite write contention (`SQLITE_BUSY`/`SQLITE_IOERR`) is swallowed
+ * rather than thrown. This is a single, idempotent, monotonic UPDATE of a
+ * snapshot↔stream anchor that every subsequent flush re-records with an
+ * equal-or-higher seq, so a dropped write self-heals on the next flush — the
+ * same self-healing property that lets the paired content write
+ * (`persistLoopMessageContent`) swallow its final failure. `busy_timeout`
+ * already made the statement wait for the lock before surfacing `SQLITE_BUSY`,
+ * so this synchronous path cannot usefully back off and retry; it just must not
+ * throw. Several callers are fire-and-forget bookkeeping in the agent loop
+ * (`flushAccumulatedContent`, `handleMessageComplete`, tool events) where a
+ * raw throw is fatal: the debounced partial flush becomes an unhandled
+ * rejection, and `message_complete` is on `dispatchAgentEvent`'s re-throw
+ * allowlist — either one takes down the daemon on lock contention. A
+ * non-contention error (a genuine bug: bad SQL, missing column) still throws.
  */
 export function recordConversationPersistedSeq(id: string, seq: number): void {
   if (!Number.isFinite(seq) || seq <= 0) {
     return;
   }
-  rawRun(
-    "conversation:recordPersistedSeq",
-    "UPDATE conversations SET seq = ? WHERE id = ? AND (seq IS NULL OR seq < ?)",
-    seq,
-    id,
-    seq,
-  );
+  try {
+    rawRun(
+      "conversation:recordPersistedSeq",
+      "UPDATE conversations SET seq = ? WHERE id = ? AND (seq IS NULL OR seq < ?)",
+      seq,
+      id,
+      seq,
+    );
+  } catch (err) {
+    if (!isRetryableSqliteError(err)) {
+      throw err;
+    }
+    log.warn(
+      { err, conversationId: id, seq },
+      "recordConversationPersistedSeq: transient SQLite contention; dropping this anchor advance (self-heals on the next flush)",
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Prompt / plan

Investigated a recurring daemon crash diagnosis: an unhandled `SQLITE_BUSY: database is locked` tripped the fail-fast shutdown (force-exit code 1, container restart, `restartCount` climbing every few hours), all crashes byte-identical in cause. Traced it to the one agent-loop write path that bypasses the `withSqliteRetry` guard.

**Root cause.** `recordConversationPersistedSeq` writes the `conversations.seq` snapshot↔stream anchor from the agent loop as fire-and-forget bookkeeping (`flushAccumulatedContent`, `handleMessageComplete`, `tool_use_start`, tool-result persist), but through a bare `rawRun` UPDATE with no retry or guard. Under write-lock contention that UPDATE throws `SQLITE_BUSY` raw, and unlike the *content* write it follows — which already degrades gracefully via `withSqliteRetry` / `persistLoopMessageContent` — nothing catches it:

- **Debounced partial flush:** `schedulePartialFlush` stores the flush promise with `.finally()` and **no `.catch()`**, so the throw surfaces as an unhandled promise rejection → fail-fast.
- **`message_complete`:** on `dispatchAgentEvent`'s re-throw allowlist, so the throw aborts the turn and propagates.

**Fix.** Swallow the retryable `SQLITE_BUSY` / `SQLITE_IOERR` family in `recordConversationPersistedSeq` (logged at warn) instead of throwing. The write is a single, idempotent, monotonic UPDATE that every subsequent flush re-records with an equal-or-higher seq, so a dropped advance self-heals on the next flush — the same self-healing property the content write relies on. `busy_timeout` already provides the wait-for-lock behavior, so this synchronous path cannot usefully back off and retry; keeping the signature synchronous also covers the sync tool-event callsite without rippling `async` through all ~11 callers. A genuine (non-contention) SQLite error still propagates.

This closes the crash. The underlying memory-retrospective write-lock pressure that is the common root of both these crashes and the earlier "sleeping" freezes is a separate, follow-up concern and is intentionally out of scope here.

## Test plan

- New regression test `assistant/src/__tests__/record-persisted-seq-lock-resilience.test.ts` (real DB, wraps `rawRun` to inject contention on the `conversation:recordPersistedSeq` label):
  - swallows a transient `SQLITE_BUSY` (anchor left un-advanced, no throw) and self-heals on the next contention-free record;
  - swallows the extended result code `SQLITE_BUSY_SNAPSHOT`;
  - rethrows a non-retryable `SQLITE_ERROR`.
- Existing `conversation-loop-db-lock-resilience.test.ts` and `list-messages-page-latest.test.ts` pass unchanged (each in isolation).
- `bunx tsc --noEmit`, prettier, and eslint clean (pre-commit hooks green).


---
_Generated by [Claude Code](https://claude.ai/code/session_0192kxjYpmUyKGkjWSGXBkck)_