### PR TITLE
Author + single-source the small remaining event domains from api/events

### DIFF
--- a/assistant/src/api/events/notification-conversation-created.ts
+++ b/assistant/src/api/events/notification-conversation-created.ts
@@ -1,0 +1,51 @@
+/**
+ * `notification_conversation_created` SSE event.
+ *
+ * Server → client broadcast emitted when an incoming notification
+ * creates a new vellum conversation. Clients use it to place the
+ * conversation in the sidebar (`groupId`, `source`) and decide whether
+ * to raise a fallback OS banner (`silent`). `targetGuardianPrincipalId`
+ * scopes guardian-sensitive conversations to a bound identity.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const NotificationConversationCreatedEventSchema = z.object({
+  type: z.literal("notification_conversation_created"),
+  conversationId: z.string(),
+  title: z.string(),
+  sourceEventName: z.string(),
+  /**
+   * When set, this conversation was created for a guardian-sensitive
+   * notification and should only be surfaced by clients bound to this
+   * guardian identity.
+   */
+  targetGuardianPrincipalId: z.string().optional(),
+  /**
+   * Conversation group identifier propagated from the signal producer.
+   * Clients use this to place the conversation in the correct sidebar
+   * folder (e.g. "system:scheduled" for schedule completion threads).
+   */
+  groupId: z.string().optional(),
+  /**
+   * Semantic source of the conversation (e.g. "schedule", "reminder").
+   * Allows clients to override the default "notification" source so the
+   * conversation is attributed correctly.
+   */
+  source: z.string().optional(),
+  /**
+   * Mirrors `NotificationIntent.silent`. When true the client must not
+   * post a fallback OS banner for this conversation — the sidebar entry
+   * still appears, but the always-on inbox is the only surfaced channel.
+   * Derived from the originating signal's `attentionHints.urgency`.
+   */
+  silent: z.boolean().optional(),
+});
+
+export type NotificationConversationCreatedEvent = z.infer<
+  typeof NotificationConversationCreatedEventSchema
+>;

--- a/assistant/src/api/events/recording.ts
+++ b/assistant/src/api/events/recording.ts
@@ -1,0 +1,68 @@
+/**
+ * Recording lifecycle SSE events (`recording_start` / `_stop` / `_pause` /
+ * `_resume`).
+ *
+ * Server → client instructions that drive a screen recording on the
+ * client: the daemon assigns `recordingId` on `recording_start` and the
+ * subsequent stop/pause/resume events reference it. `recording_start`
+ * also carries capture `options` and an `operationToken` that guards
+ * against stale restart completions.
+ *
+ * Canonical wire-contract source. Daemon code imports the types
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+/** Recording options shared across standalone and CU recording flows. */
+export const RecordingOptionsSchema = z.object({
+  captureScope: z.enum(["display", "window"]).optional(),
+  /** CGDirectDisplayID as string. */
+  displayId: z.string().optional(),
+  /** CGWindowID. */
+  windowId: z.number().optional(),
+  includeAudio: z.boolean().optional(),
+  includeMicrophone: z.boolean().optional(),
+  /** Show source picker. */
+  promptForSource: z.boolean().optional(),
+});
+
+export type RecordingOptions = z.infer<typeof RecordingOptionsSchema>;
+
+export const RecordingStartEventSchema = z.object({
+  type: z.literal("recording_start"),
+  /** Daemon-assigned UUID. */
+  recordingId: z.string(),
+  attachToConversationId: z.string().optional(),
+  options: RecordingOptionsSchema.optional(),
+  /**
+   * Operation token for restart race hardening — stale completions with
+   * mismatched tokens are rejected.
+   */
+  operationToken: z.string().optional(),
+});
+
+export type RecordingStartEvent = z.infer<typeof RecordingStartEventSchema>;
+
+export const RecordingStopEventSchema = z.object({
+  type: z.literal("recording_stop"),
+  /** Matches `recording_start`'s recordingId. */
+  recordingId: z.string(),
+});
+
+export type RecordingStopEvent = z.infer<typeof RecordingStopEventSchema>;
+
+export const RecordingPauseEventSchema = z.object({
+  type: z.literal("recording_pause"),
+  recordingId: z.string(),
+});
+
+export type RecordingPauseEvent = z.infer<typeof RecordingPauseEventSchema>;
+
+export const RecordingResumeEventSchema = z.object({
+  type: z.literal("recording_resume"),
+  recordingId: z.string(),
+});
+
+export type RecordingResumeEvent = z.infer<typeof RecordingResumeEventSchema>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -43,11 +43,18 @@ import { MessageQueuedEventSchema } from "./events/message-queued.js";
 import { MessageQueuedDeletedEventSchema } from "./events/message-queued-deleted.js";
 import { MessageRequestCompleteEventSchema } from "./events/message-request-complete.js";
 import { NavigateSettingsEventSchema } from "./events/navigate-settings.js";
+import { NotificationConversationCreatedEventSchema } from "./events/notification-conversation-created.js";
 import { NotificationIntentEventSchema } from "./events/notification-intent.js";
 import { OpenConversationEventSchema } from "./events/open-conversation.js";
 import { OpenPanelEventSchema } from "./events/open-panel.js";
 import { OpenUrlEventSchema } from "./events/open-url.js";
 import { QuestionRequestEventSchema } from "./events/question-request.js";
+import {
+  RecordingPauseEventSchema,
+  RecordingResumeEventSchema,
+  RecordingStartEventSchema,
+  RecordingStopEventSchema,
+} from "./events/recording.js";
 import { RelationshipStateUpdatedEventSchema } from "./events/relationship-state-updated.js";
 import { SecretRequestEventSchema } from "./events/secret-request.js";
 import { ServiceGroupUpdateCompleteEventSchema } from "./events/service-group-update-complete.js";
@@ -302,6 +309,10 @@ export {
   NavigateSettingsEventSchema,
 } from "./events/navigate-settings.js";
 export {
+  type NotificationConversationCreatedEvent,
+  NotificationConversationCreatedEventSchema,
+} from "./events/notification-conversation-created.js";
+export {
   type NotificationIntentEvent,
   NotificationIntentEventSchema,
 } from "./events/notification-intent.js";
@@ -322,6 +333,18 @@ export {
   type QuestionRequestEvent,
   QuestionRequestEventSchema,
 } from "./events/question-request.js";
+export {
+  type RecordingOptions,
+  RecordingOptionsSchema,
+  type RecordingPauseEvent,
+  RecordingPauseEventSchema,
+  type RecordingResumeEvent,
+  RecordingResumeEventSchema,
+  type RecordingStartEvent,
+  RecordingStartEventSchema,
+  type RecordingStopEvent,
+  RecordingStopEventSchema,
+} from "./events/recording.js";
 export {
   type RelationshipStateUpdatedEvent,
   RelationshipStateUpdatedEventSchema,
@@ -699,11 +722,16 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   MessageQueuedDeletedEventSchema,
   MessageRequestCompleteEventSchema,
   NavigateSettingsEventSchema,
+  NotificationConversationCreatedEventSchema,
   NotificationIntentEventSchema,
   OpenConversationEventSchema,
   OpenPanelEventSchema,
   OpenUrlEventSchema,
   QuestionRequestEventSchema,
+  RecordingPauseEventSchema,
+  RecordingResumeEventSchema,
+  RecordingStartEventSchema,
+  RecordingStopEventSchema,
   RelationshipStateUpdatedEventSchema,
   SecretRequestEventSchema,
   ServiceGroupUpdateCompleteEventSchema,

--- a/assistant/src/daemon/message-types/computer-use.ts
+++ b/assistant/src/daemon/message-types/computer-use.ts
@@ -1,6 +1,18 @@
 // Computer use and recording types.
+//
+// The recording lifecycle server→client events (start/stop/pause/resume) are
+// single-sourced from their canonical `api/events` wire schemas; the shared
+// `RecordingOptions` shape is re-exported from there for barrel consumers.
 
+import type {
+  RecordingPauseEvent,
+  RecordingResumeEvent,
+  RecordingStartEvent,
+  RecordingStopEvent,
+} from "../../api/events/recording.js";
 import type { CommandIntent, UserMessageAttachment } from "./shared.js";
+
+export type { RecordingOptions } from "../../api/events/recording.js";
 
 // === Client → Server ===
 
@@ -15,22 +27,10 @@ export interface TaskSubmit {
   commandIntent?: CommandIntent;
 }
 
-// === Recording ===
-
-/** Recording options shared across standalone and CU recording flows. */
-export interface RecordingOptions {
-  captureScope?: "display" | "window";
-  displayId?: string; // CGDirectDisplayID as string
-  windowId?: number; // CGWindowID
-  includeAudio?: boolean;
-  includeMicrophone?: boolean;
-  promptForSource?: boolean; // show source picker
-}
-
 /** Client → Server: recording lifecycle status update. */
 export interface RecordingStatus {
   type: "recording_status";
-  conversationId: string; // matches recordingId from RecordingStart
+  conversationId: string; // matches recordingId from RecordingStartEvent
   status:
     | "started"
     | "stopped"
@@ -42,38 +42,8 @@ export interface RecordingStatus {
   durationMs?: number; // on stop
   error?: string; // on failure
   attachToConversationId?: string;
-  /** Operation token for restart race hardening — matches the token from RecordingStart. */
+  /** Operation token for restart race hardening — matches the token from RecordingStartEvent. */
   operationToken?: string;
-}
-
-// === Server → Client ===
-
-/** Server → Client: start a recording. */
-export interface RecordingStart {
-  type: "recording_start";
-  recordingId: string; // daemon-assigned UUID
-  attachToConversationId?: string;
-  options?: RecordingOptions;
-  /** Operation token for restart race hardening — stale completions with mismatched tokens are rejected. */
-  operationToken?: string;
-}
-
-/** Server → Client: stop a recording. */
-export interface RecordingStop {
-  type: "recording_stop";
-  recordingId: string; // matches RecordingStart.recordingId
-}
-
-/** Server → Client: pause the active recording. */
-export interface RecordingPause {
-  type: "recording_pause";
-  recordingId: string;
-}
-
-/** Server → Client: resume a paused recording. */
-export interface RecordingResume {
-  type: "recording_resume";
-  recordingId: string;
 }
 
 // --- Domain-level union aliases (consumed by the barrel file) ---
@@ -81,7 +51,7 @@ export interface RecordingResume {
 export type _ComputerUseClientMessages = TaskSubmit | RecordingStatus;
 
 export type _ComputerUseServerMessages =
-  | RecordingStart
-  | RecordingStop
-  | RecordingPause
-  | RecordingResume;
+  | RecordingStartEvent
+  | RecordingStopEvent
+  | RecordingPauseEvent
+  | RecordingResumeEvent;

--- a/assistant/src/daemon/message-types/notifications.ts
+++ b/assistant/src/daemon/message-types/notifications.ts
@@ -1,36 +1,5 @@
+import type { NotificationConversationCreatedEvent } from "../../api/events/notification-conversation-created.js";
 import type { NotificationIntentEvent } from "../../api/events/notification-intent.js";
-
-/** Server push — broadcast when a notification creates a new vellum conversation. */
-export interface NotificationConversationCreated {
-  type: "notification_conversation_created";
-  conversationId: string;
-  title: string;
-  sourceEventName: string;
-  /**
-   * When set, this conversation was created for a guardian-sensitive notification
-   * and should only be surfaced by clients bound to this guardian identity.
-   */
-  targetGuardianPrincipalId?: string;
-  /**
-   * Conversation group identifier propagated from the signal producer.
-   * Clients use this to place the conversation in the correct sidebar folder
-   * (e.g. "system:scheduled" for schedule completion threads).
-   */
-  groupId?: string;
-  /**
-   * Semantic source of the conversation (e.g. "schedule", "reminder").
-   * Allows clients to override the default "notification" source so the
-   * conversation is attributed correctly.
-   */
-  source?: string;
-  /**
-   * Mirrors `NotificationIntent.silent`. When true the client must not
-   * post a fallback OS banner for this conversation — the sidebar entry
-   * still appears, but the always-on inbox is the only surfaced channel.
-   * Derived from the originating signal's `attentionHints.urgency`.
-   */
-  silent?: boolean;
-}
 
 /** Client ack sent after UNUserNotificationCenter.add() completes (or fails). */
 export interface NotificationIntentResult {
@@ -76,4 +45,4 @@ export type _NotificationsClientMessages =
 
 export type _NotificationsServerMessages =
   | NotificationIntentEvent
-  | NotificationConversationCreated;
+  | NotificationConversationCreatedEvent;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -480,6 +480,15 @@ export function useStreamEventHandler(
         case "memory_recalled":
         case "memory_status":
           break;
+        // Notification-created broadcasts and recording lifecycle
+        // instructions. The web chat handler is a no-op for these — they target
+        // the CLI/desktop clients or are handled elsewhere.
+        case "notification_conversation_created":
+        case "recording_start":
+        case "recording_stop":
+        case "recording_pause":
+        case "recording_resume":
+          break;
         case "unknown":
           break;
         default: {

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -96,6 +96,16 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   // gate them as global.
   "bookmark.created",
   "bookmark.deleted",
+  // Notification-created broadcasts and recording lifecycle instructions are not
+  // tied to the active conversation stream (they carry no top-level
+  // `conversationId`, or — for notification_conversation_created — announce a
+  // *different* conversation), so gate them as global rather than through the
+  // conversation-id filter.
+  "notification_conversation_created",
+  "recording_start",
+  "recording_stop",
+  "recording_pause",
+  "recording_resume",
 ] as const;
 
 const GLOBAL_STREAM_EVENT_TYPES: ReadonlySet<string> = new Set(


### PR DESCRIPTION
## Why

Continues the event-type unification effort — making `api/events/*.ts` the single source of truth for every server→client event. Following the one-domain-per-PR migrations (`upgrades` #38767, `memory` #38778, `bookmarks` #38784), this clears the **long tail of small server-event domains in one sweep**.

## What

Authored canonical `api/events` schemas and registered them in `AssistantEventSchema` for:

| Domain | Events |
| --- | --- |
| **diagnostics** | `env_vars_response`, `dictation_response` |
| **inbox** | `contacts_invite_response` (+ invite summary/detail payload shapes) |
| **notifications** | `notification_conversation_created` |
| **computer-use** | `recording_start` / `_stop` / `_pause` / `_resume` (+ shared `RecordingOptions`, re-exported from api for barrel consumers) |

Each domain's `_*ServerMessages` union now composes the api-inferred `*Event` types. All these events are built inline by their producers (validated by typecheck against the api-inferred union — no type-import renames), and none is bound to the active conversation stream, so they're added to the web's global stream-event set with no-op cases in the chat handler's exhaustive switch.

## Deliberately deferred

`contacts` and `guardian-actions` — the other "small" domains by event count — are held for a focused follow-up. Their events carry deeper shared payload graphs (`ContactPayload` / `ContactChannelPayload`, `GuardianDecisionPrompt` / `GuardianDecisionAction`) that are re-exported through the `message-protocol` barrel and used as canonical shapes across `contacts/*`, so relocating them cleanly deserves its own change rather than riding along here.

## Safety

No wire change — schemas transcribed 1:1 from the interfaces they replace; typecheck validates every construction site. `bun run typecheck:fast` + web `tsc` (fresh `openapi-ts`), eslint, prettier, `generate:openapi --check` (unchanged), and the api-events + SSE-parity + plugin-import-boundary suites all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_