### PR TITLE
fix(gateway): recover the vellum guardian from actor tokens on upgrade (LUM-2783)

### DIFF
--- a/gateway/src/__tests__/guardian-bootstrap-binding.test.ts
+++ b/gateway/src/__tests__/guardian-bootstrap-binding.test.ts
@@ -235,6 +235,72 @@ describe("createGuardianBinding gateway dual-write", () => {
     expect(row.blockedReason).toBe("spam");
   });
 
+  test("does not reactivate a revoked row without reactivateRevoked (fail-closed default)", async () => {
+    // A deliberately-revoked binding must not be silently brought back by a
+    // caller with no fresh verification act — this is the single enforcement
+    // point beneath the recovery path's absent-guardian gate. A regression here
+    // (e.g. dropping the guard) turns this test red.
+    seedGwChannel({
+      contactId: "revoked-contact",
+      channelId: "revoked-channel",
+      type: "slack",
+      address: "U_OWNER",
+      principalId: "revoked-principal",
+      status: "revoked",
+      policy: "deny",
+    });
+
+    await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U_OWNER",
+      deliveryChatId: "D_OWNER",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+      // reactivateRevoked omitted → defaults false (fail-closed).
+    });
+
+    const rows = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.type, "slack"))
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe("revoked"); // left intact, not reactivated
+  });
+
+  test("reactivates a revoked row when reactivateRevoked is set (verified act)", async () => {
+    // A caller backed by a fresh verification act (re-pair / re-verify) may
+    // bring a revoked binding back — the opt-in preserves that path.
+    seedGwChannel({
+      contactId: "revoked-contact",
+      channelId: "revoked-channel",
+      type: "slack",
+      address: "U_OWNER",
+      principalId: "revoked-principal",
+      status: "revoked",
+      policy: "deny",
+    });
+
+    await createGuardianBinding({
+      channel: "slack",
+      externalUserId: "U_OWNER",
+      deliveryChatId: "D_OWNER",
+      guardianPrincipalId: "guardian-principal",
+      displayName: "Example User",
+      verifiedVia: "challenge",
+      reactivateRevoked: true,
+    });
+
+    const rows = getGatewayDb()
+      .select()
+      .from(contactChannels)
+      .where(eq(contactChannels.type, "slack"))
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe("active"); // reactivated by the verified act
+  });
+
   test("inserts a brand-new (type,address) gateway row when none exists", async () => {
     const result = await createGuardianBinding({
       channel: "slack",
@@ -354,19 +420,21 @@ describe("createGuardianBinding id resolution (gateway reads)", () => {
       (c) => c[0] === "contacts_mirror_apply",
     );
     expect(applyCalls).toHaveLength(1);
-    expect((applyCalls[0][1] as { body: { ops: unknown[] } }).body.ops).toEqual([
-      {
-        op: "upsert_channel",
-        contactId: result.contactId,
-        channelId: result.channelId,
-        type: "slack",
-        address: "U_FRESH",
-        externalChatId: "D_FRESH",
-        displayName: "Example User",
-        isPrimary: true,
-        refreshDisplayName: true,
-        reassignConflictingChannels: true,
-      },
-    ]);
+    expect((applyCalls[0][1] as { body: { ops: unknown[] } }).body.ops).toEqual(
+      [
+        {
+          op: "upsert_channel",
+          contactId: result.contactId,
+          channelId: result.channelId,
+          type: "slack",
+          address: "U_FRESH",
+          externalChatId: "D_FRESH",
+          displayName: "Example User",
+          isPrimary: true,
+          refreshDisplayName: true,
+          reassignConflictingChannels: true,
+        },
+      ],
+    );
   });
 });

--- a/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
+++ b/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
@@ -510,6 +510,39 @@ describe("resolve-or-mint (resolveOrCreateVellumGuardian)", () => {
     expect(reportCalls).toEqual([{ integrity_state: "ok" }]);
   });
 
+  test("boot recovery heals past a principal-less guardian stub (contact-prompt pre-bootstrap)", async () => {
+    // A gateway-first contact-prompt stub is role='guardian' but carries no
+    // principal and no active binding. It must NOT count as a real guardian and
+    // block recovery — the surviving tokens name the real guardian, so an
+    // upgraded install carrying only a stub still self-heals.
+    seedGuardianChannel({
+      type: "vellum",
+      address: "stub-addr",
+      status: "unverified",
+      principalId: null,
+      contactId: "stub-contact",
+      channelId: "stub-channel",
+    });
+    seedActorToken(); // active token, guardianPrincipalId "principal-123"
+
+    const principalId = await ensureVellumGuardianBinding({
+      recoverFromActorTokens: true,
+    });
+
+    expect(principalId).toBe("principal-123");
+    // A real guardian binding now exists for the token's principal (alongside
+    // the inert stub).
+    const recovered = gatewayVellumGuardians().find(
+      (r) => r.principalId === "principal-123",
+    );
+    expect(recovered).toMatchObject({
+      address: "principal-123",
+      status: "active",
+    });
+    // Recovery succeeded — no missing-guardian / mint-refused report.
+    expect(reportCalls).toHaveLength(0);
+  });
+
   test("refuses when a guardian contact exists but the vellum binding is inactive — mint-refused report fires", async () => {
     seedGuardianChannel({
       type: "vellum",

--- a/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
+++ b/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
@@ -479,6 +479,37 @@ describe("resolve-or-mint (resolveOrCreateVellumGuardian)", () => {
     ]);
   });
 
+  test("boot recovery does not reactivate a deliberately-revoked guardian binding", async () => {
+    // A guardian CONTACT still exists but its vellum channel was deliberately
+    // revoked; active tokens survive (a still-live device). Boot recovery must
+    // stay fail-closed rather than upserting the channel back to active and
+    // silently undoing the revoke — recovery is only for a genuinely ABSENT
+    // guardian, not a present-but-revoked one.
+    seedGuardianChannel({
+      type: "vellum",
+      address: "vellum-principal-revoked",
+      status: "revoked",
+      principalId: "principal-revoked",
+    });
+    seedActorToken(); // active token, guardianPrincipalId "principal-123"
+
+    await expect(
+      ensureVellumGuardianBinding({ recoverFromActorTokens: true }),
+    ).rejects.toBeInstanceOf(VellumGuardianMintRefusedError);
+
+    // The revoked channel stays revoked — not reactivated — and no second
+    // guardian binding was minted from the token.
+    const gwRows = gatewayVellumGuardians();
+    expect(gwRows).toHaveLength(1);
+    expect(gwRows[0]).toMatchObject({
+      address: "vellum-principal-revoked",
+      status: "revoked",
+    });
+    // A guardian contact row exists, so integrity is "ok" (not
+    // missing_guardian) — only the mint-refused report fires.
+    expect(reportCalls).toEqual([{ integrity_state: "ok" }]);
+  });
+
   test("refuses when a guardian contact exists but the vellum binding is inactive — mint-refused report fires", async () => {
     seedGuardianChannel({
       type: "vellum",

--- a/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
+++ b/gateway/src/__tests__/guardian-bootstrap-lookups.test.ts
@@ -408,12 +408,68 @@ describe("resolve-or-mint (resolveOrCreateVellumGuardian)", () => {
     ]);
   });
 
-  test("startup backfill refuses to mint over actor-token evidence (guardian rows lost)", async () => {
+  test("startup backfill recovers the guardian from active actor-token evidence (LUM-2783)", async () => {
+    // The gateway carries actor tokens migrated from the assistant DB (m0002)
+    // but an empty contacts table — the contact reconcile could not run because
+    // assistant migration 305 had already dropped the ACL columns it reads. The
+    // backfill rebuilds the vellum guardian binding from the token's principal
+    // instead of refusing. Recovery is gateway-native, so the throwing
+    // assistant backend stays installed to prove it never reads the mirror.
+    seedActorToken(); // active token, guardianPrincipalId "principal-123"
+
+    const principalId = await ensureVellumGuardianBinding({
+      recoverFromActorTokens: true,
+    });
+
+    expect(principalId).toBe("principal-123");
+    const gwRows = gatewayVellumGuardians();
+    expect(gwRows).toHaveLength(1);
+    expect(gwRows[0]).toMatchObject({
+      principalId: "principal-123",
+      address: "principal-123",
+      status: "active",
+    });
+    // Recovery resolves the lost-guardian state, so neither the
+    // missing-guardian nor the mint-refused report fires.
+    expect(reportCalls).toHaveLength(0);
+  });
+
+  test("recovery is opt-in — runtime callers stay fail-closed over active-token evidence", async () => {
+    // Without the boot-time recovery flag, an active actor token is still just
+    // evidence: the default (runtime token/pairing) path refuses so its
+    // repairable 401/503 flow is preserved.
     seedActorToken();
 
     await expect(ensureVellumGuardianBinding()).rejects.toBeInstanceOf(
       VellumGuardianMintRefusedError,
     );
+    expect(gatewayVellumGuardians()).toHaveLength(0);
+  });
+
+  test("startup backfill refuses when only a revoked actor token survives", async () => {
+    // A revoked token is a properly offboarded guardian — recovery must not
+    // resurrect it, so the backfill falls through to the fail-closed refusal.
+    const now = Date.now();
+    getGatewayDb()
+      .insert(actorTokenRecords)
+      .values({
+        id: "revoked-token",
+        tokenHash: "hash-revoked",
+        guardianPrincipalId: "principal-offboarded",
+        hashedDeviceId: "device-x",
+        platform: "macos",
+        status: "revoked",
+        issuedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    // Recovery is enabled but the only token is revoked, so it must not
+    // resurrect the offboarded principal — the backfill falls through to refuse.
+    await expect(
+      ensureVellumGuardianBinding({ recoverFromActorTokens: true }),
+    ).rejects.toBeInstanceOf(VellumGuardianMintRefusedError);
 
     expect(gatewayVellumGuardians()).toHaveLength(0);
     expect(getGatewayDb().select().from(contacts).all()).toHaveLength(0);
@@ -441,8 +497,11 @@ describe("resolve-or-mint (resolveOrCreateVellumGuardian)", () => {
     expect(reportCalls).toEqual([{ integrity_state: "ok" }]);
   });
 
-  test("startup backfill recovers once the guardian is re-seeded", async () => {
-    seedActorToken();
+  test("startup backfill refusal is not permanent — recovers once the guardian is re-seeded", async () => {
+    // Contact evidence with no actor token: nothing to recover from, so the
+    // backfill refuses (fail-closed) rather than fabricating a guardian. The
+    // refusal must not latch — a later re-seed resolves on the next call.
+    seedContact({ id: "invited-contact" });
     await expect(ensureVellumGuardianBinding()).rejects.toBeInstanceOf(
       VellumGuardianMintRefusedError,
     );

--- a/gateway/src/__tests__/lum-2783-recovery-e2e.test.ts
+++ b/gateway/src/__tests__/lum-2783-recovery-e2e.test.ts
@@ -1,0 +1,190 @@
+/**
+ * End-to-end proof for LUM-2783.
+ *
+ * Reproduces the exact broken state an upgraded install lands in — the gateway
+ * `contacts` table empty (its contact reconcile bailed because migration 305
+ * had already dropped the assistant ACL columns) while the actor tokens `m0002`
+ * migrated into the gateway survive — then runs the REAL production paths in
+ * sequence:
+ *
+ *   1. the canonical classifier `resolveTrustVerdict` BEFORE recovery, to
+ *      confirm the reported symptom (`trust_class: unknown`), then
+ *   2. the boot backfill `ensureVellumGuardianBinding({ recoverFromActorTokens })`
+ *      that runs post-assistant-ready, then
+ *   3. `resolveTrustVerdict` AGAIN, to confirm a new vellum turn now classifies
+ *      the guardian and carries a real canonical identity.
+ *
+ * Nothing here is stubbed for the classifier or the recovery — both read the
+ * same real gateway DB. Only createGuardianBinding's best-effort assistant-DB
+ * mirror dials IPC, which is absent in-test and swallowed.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import "./test-preload.js";
+
+import {
+  ensureVellumGuardianBinding,
+  VellumGuardianMintRefusedError,
+} from "../auth/guardian-bootstrap.js";
+import { bustGuardianIntegrityCache } from "../auth/guardian-integrity.js";
+import { initSigningKey } from "../auth/token-service.js";
+import {
+  getGatewayDb,
+  initGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { actorTokenRecords, contacts, contactChannels } from "../db/schema.js";
+import {
+  resetGuardianIntegrityReporterForTesting,
+  setGuardianIntegrityReporterOverridesForTesting,
+} from "../guardian-integrity-reporter.js";
+import { resolveTrustVerdict } from "../risk/trust-verdict-resolver.js";
+
+initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long"));
+
+const PRINCIPAL = "vellum-principal-0aafaf2";
+
+function seedActiveActorToken(guardianPrincipalId: string): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(actorTokenRecords)
+    .values({
+      id: `tok-${guardianPrincipalId}`,
+      tokenHash: `hash-${guardianPrincipalId}`,
+      guardianPrincipalId,
+      hashedDeviceId: "device-1",
+      platform: "macos",
+      status: "active",
+      issuedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+async function vellumVerdictFor(principal: string) {
+  // A fresh classification, as a new thread would trigger.
+  bustGuardianIntegrityCache();
+  return resolveTrustVerdict({
+    channelType: "vellum",
+    actorExternalId: principal,
+  });
+}
+
+beforeEach(async () => {
+  await initGatewayDb();
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+  db.delete(actorTokenRecords).run();
+  bustGuardianIntegrityCache();
+  resetGuardianIntegrityReporterForTesting();
+  setGuardianIntegrityReporterOverridesForTesting({
+    fetchImpl: async () => new Response("{}"),
+    mintToken: () => "svc-token",
+    baseUrl: "http://127.0.0.1:7821",
+    log: { error: () => {}, warn: () => {} },
+  });
+});
+
+afterEach(() => {
+  resetGuardianIntegrityReporterForTesting();
+  resetGatewayDb();
+});
+
+describe("LUM-2783 end-to-end: broken state → boot recovery → trust resolves guardian", () => {
+  test("empty contacts + active token: a new vellum turn resolves guardian, not unknown", async () => {
+    // The broken state: no contacts, surviving active actor token.
+    seedActiveActorToken(PRINCIPAL);
+
+    // The reported symptom, straight from the canonical classifier.
+    const before = await vellumVerdictFor(PRINCIPAL);
+    expect(before.trustClass).toBe("unknown");
+
+    // Boot backfill (post-assistant-ready) self-heals from the token.
+    const recovered = await ensureVellumGuardianBinding({
+      recoverFromActorTokens: true,
+    });
+    expect(recovered).toBe(PRINCIPAL);
+
+    // A new thread now classifies the guardian with a real canonical identity.
+    const after = await vellumVerdictFor(PRINCIPAL);
+    expect(after.trustClass).toBe("guardian");
+    expect(after.canonicalSenderId).toBe(PRINCIPAL); // no longer `unknown`
+  });
+
+  test("principal-less contact-prompt stub + active token: still self-heals", async () => {
+    // A gateway-first contact-prompt stub (role=guardian, null principal, no
+    // active binding) plus the surviving token. The stub must not block the heal.
+    const now = Date.now();
+    getGatewayDb()
+      .insert(contacts)
+      .values({
+        id: "stub-contact",
+        displayName: "stub",
+        role: "guardian",
+        principalId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    getGatewayDb()
+      .insert(contactChannels)
+      .values({
+        id: "stub-channel",
+        contactId: "stub-contact",
+        type: "vellum",
+        address: "stub-addr",
+        isPrimary: true,
+        status: "unverified",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    seedActiveActorToken(PRINCIPAL);
+
+    expect((await vellumVerdictFor(PRINCIPAL)).trustClass).toBe("unknown");
+
+    const recovered = await ensureVellumGuardianBinding({
+      recoverFromActorTokens: true,
+    });
+    expect(recovered).toBe(PRINCIPAL);
+
+    const after = await vellumVerdictFor(PRINCIPAL);
+    expect(after.trustClass).toBe("guardian");
+    expect(after.canonicalSenderId).toBe(PRINCIPAL);
+  });
+
+  test("guardian gone with NO active token: fails closed, never fabricates an identity", async () => {
+    // Row 5: evidence exists (a revoked token) but nothing active to recover
+    // from. The backfill must refuse rather than invent a guardian, and the
+    // classifier stays `unknown` (fail-closed, repairable by re-pair).
+    const now = Date.now();
+    getGatewayDb()
+      .insert(actorTokenRecords)
+      .values({
+        id: "tok-revoked",
+        tokenHash: "hash-revoked",
+        guardianPrincipalId: PRINCIPAL,
+        hashedDeviceId: "device-x",
+        platform: "macos",
+        status: "revoked",
+        issuedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    await expect(
+      ensureVellumGuardianBinding({ recoverFromActorTokens: true }),
+    ).rejects.toBeInstanceOf(VellumGuardianMintRefusedError);
+
+    const after = await vellumVerdictFor(PRINCIPAL);
+    expect(after.trustClass).toBe("unknown");
+    // No guardian was fabricated.
+    expect(getGatewayDb().select().from(contacts).all()).toHaveLength(0);
+  });
+});

--- a/gateway/src/__tests__/post-assistant-ready-deferred.test.ts
+++ b/gateway/src/__tests__/post-assistant-ready-deferred.test.ts
@@ -43,19 +43,19 @@ const {
   runDeferredTasksWhenAssistantReady,
   waitForAssistant,
 } = await import("../post-assistant-ready.js");
-const { initGatewayDb, getGatewayDb, resetGatewayDb } = await import(
-  "../db/connection.js"
-);
-const { contacts, contactChannels } = await import("../db/schema.js");
+const { initGatewayDb, getGatewayDb, resetGatewayDb } =
+  await import("../db/connection.js");
+const { contacts, contactChannels, actorTokenRecords } =
+  await import("../db/schema.js");
 const { MIGRATIONS } = await import("../db/data-migrations/index.js");
-const { bustGuardianIntegrityCache } = await import(
-  "../auth/guardian-integrity.js"
-);
+const { bustGuardianIntegrityCache } =
+  await import("../auth/guardian-integrity.js");
 const {
   resetGuardianIntegrityReporterForTesting,
   setGuardianIntegrityReporterOverridesForTesting,
 } = await import("../guardian-integrity-reporter.js");
-const { seedContact } = await import("./helpers/contact-fixtures.js");
+const { seedContact, seedActorToken } =
+  await import("./helpers/contact-fixtures.js");
 
 const MIGRATING_HEALTH = {
   status: "MIGRATING",
@@ -147,10 +147,60 @@ describe("runDeferredTasksWhenAssistantReady", () => {
       await runDeferredTasksWhenAssistantReady(5);
 
       // Refused, not minted: no vellum guardian binding appeared.
-      expect(
-        getGatewayDb().select().from(contactChannels).all(),
-      ).toHaveLength(0);
+      expect(getGatewayDb().select().from(contactChannels).all()).toHaveLength(
+        0,
+      );
       expect(getGatewayDb().select().from(contacts).all()).toHaveLength(1);
+    } finally {
+      resetGuardianIntegrityReporterForTesting();
+      resetGatewayDb();
+    }
+  });
+
+  test("real deferred run recovers the guardian from surviving actor tokens (LUM-2783)", async () => {
+    await initGatewayDb();
+    try {
+      // This file's tests share one gateway DB in-process; clear the ACL/token
+      // tables so a prior test's seed can't skew the row-count assertions.
+      getGatewayDb().delete(contactChannels).run();
+      getGatewayDb().delete(contacts).run();
+      getGatewayDb().delete(actorTokenRecords).run();
+      // No-op the migration step so the guardian backfill is the code under
+      // test — the upgrade already left the gateway with an empty contacts
+      // table but a surviving actor token (m0002 ran; the contact reconcile
+      // could not, because assistant migration 305 had dropped the ACL columns).
+      for (const { key } of MIGRATIONS) {
+        getGatewayDb().run(
+          sql`INSERT OR IGNORE INTO one_time_migrations (key, ran_at) VALUES (${key}, ${Date.now()})`,
+        );
+      }
+      seedActorToken(); // active token, guardianPrincipalId "principal-123"
+      bustGuardianIntegrityCache();
+      setGuardianIntegrityReporterOverridesForTesting({
+        fetchImpl: async () => new Response("{}"),
+        mintToken: () => "svc-token",
+        baseUrl: "http://127.0.0.1:7821",
+        log: { error: () => {}, warn: () => {} },
+      });
+      resetPostAssistantReadyForTest(); // restore the REAL executor
+
+      await runDeferredTasksWhenAssistantReady(5);
+
+      // The boot backfill rebuilt the vellum guardian binding from the token's
+      // principal, so trust resolution can classify the owner again.
+      const channels = getGatewayDb().select().from(contactChannels).all();
+      expect(channels).toHaveLength(1);
+      expect(channels[0]).toMatchObject({
+        type: "vellum",
+        address: "principal-123",
+        status: "active",
+      });
+      const contactRows = getGatewayDb().select().from(contacts).all();
+      expect(contactRows).toHaveLength(1);
+      expect(contactRows[0]).toMatchObject({
+        role: "guardian",
+        principalId: "principal-123",
+      });
     } finally {
       resetGuardianIntegrityReporterForTesting();
       resetGatewayDb();

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -235,6 +235,19 @@ export interface CreateGuardianBindingParams {
   displayName?: string;
   /** How this binding was verified. Defaults to "challenge". */
   verifiedVia?: string;
+  /**
+   * Whether this write is backed by a fresh verification/authentication act and
+   * may therefore bring a deliberately-REVOKED binding at the same
+   * (type, address) back to active. Default false (fail-closed): a derived
+   * rebind with no fresh proof — e.g. boot-time token recovery — must never
+   * silently undo a revoke. `blocked` bindings stay terminal regardless.
+   *
+   * Every caller that reaches here from a real verification act (code/voice
+   * challenge, verification-session consume, platform channel-create,
+   * provider-validated email, guardian bootstrap) sets this true; new callers
+   * inherit the safe default until they prove they have one.
+   */
+  reactivateRevoked?: boolean;
 }
 
 export interface CreateGuardianBindingResult {
@@ -384,9 +397,17 @@ export function applyGuardianBindingGatewayWrites(
     .get();
 
   if (existingGw) {
-    // Never reactivate a blocked gateway row by code-match — leave it
-    // intact (mirrors text-verification / contact-helpers guards).
-    if (existingGw.status !== "blocked") {
+    // A governance-terminal binding must not be silently resurrected by a
+    // (type, address) code-match. `blocked` is always terminal; `revoked` is a
+    // deliberate downgrade that only a caller with a fresh verification act may
+    // reverse (`reactivateRevoked`). Without that proof — e.g. a derived rebind
+    // from token recovery — the revoke stays intact, fail-closed. This is the
+    // single enforcement point, so no caller (present or future) can turn a
+    // revoke back on without asserting a verification act.
+    const isProtectedFromReactivation =
+      existingGw.status === "blocked" ||
+      (existingGw.status === "revoked" && !params.reactivateRevoked);
+    if (!isProtectedFromReactivation) {
       gwDb
         .update(gwContactChannels)
         .set(channelSet)
@@ -812,6 +833,55 @@ async function fetchPlatformOwnerDisplayName(): Promise<string | null> {
 }
 
 /**
+ * Boot-time self-heal: rebuild an ABSENT vellum guardian binding from the
+ * gateway's own active actor tokens, returning the recovered principal (or
+ * null when nothing is recoverable). Single home for the recovery decision so
+ * its safety is co-located rather than re-derived at the call site.
+ *
+ * Safety contract — recovery is sound because, together:
+ *  - Actor tokens are minted EXCLUSIVELY for the guardian principal (every mint
+ *    site funnels through a guardianPrincipalId), so the token names the real
+ *    guardian, never some other actor.
+ *  - It fires only when NO `role='guardian'` contact row exists
+ *    (`!hasGuardianContactRow()`) — genuine data loss, never a guardian that
+ *    still exists but whose binding was deliberately revoked/blocked. That
+ *    "no guardian + surviving tokens" state is unreachable by intent (the
+ *    contact-delete route 403s a guardian), so it only arises from data loss.
+ *  - It rebinds the token's EXISTING principal — no divergent mint — and passes
+ *    `reactivateRevoked: false`, so the write path itself refuses to resurrect a
+ *    revoked binding: a second, enforced layer beneath the absent-guardian gate.
+ *  - Only ACTIVE tokens are recovered, so a properly offboarded (revoked)
+ *    guardian is never brought back.
+ */
+async function recoverAbsentVellumGuardianFromActorTokens(): Promise<
+  string | null
+> {
+  if (hasGuardianContactRow()) {
+    return null;
+  }
+  const recoveredPrincipalId = recoverGuardianPrincipalFromActorTokens();
+  if (!recoveredPrincipalId) {
+    return null;
+  }
+  await createGuardianBinding({
+    channel: "vellum",
+    externalUserId: recoveredPrincipalId,
+    deliveryChatId: "local",
+    guardianPrincipalId: recoveredPrincipalId,
+    verifiedVia: "bootstrap",
+    // Derived rebind with no fresh verification act: must not resurrect a
+    // revoked binding. The absent-guardian gate above already means there is
+    // none to resurrect; passing false keeps that true even if the gate moves.
+    reactivateRevoked: false,
+  });
+  log.info(
+    { guardianPrincipalId: recoveredPrincipalId },
+    "Recovered the vellum guardian binding from gateway actor tokens (empty contacts table on an upgraded install)",
+  );
+  return recoveredPrincipalId;
+}
+
+/**
  * Resolve the vellum guardian principal: (a) gateway fast path, then
  * (b) mint a fresh principal when the gateway has no guardian.
  *
@@ -853,48 +923,25 @@ async function resolveOrCreateVellumGuardian(options: {
     };
   }
 
-  const priorEvidence = hasEvidenceOfPriorGuardian();
-  if (priorEvidence && !options.allowMintWithEvidence) {
-    // Boot-time backfill only: before refusing, recover the guardian from the
-    // gateway's own active actor tokens. An install upgraded past the
-    // contact-ACL drop (assistant migration 305) reaches here with an empty
-    // contacts table but the actor tokens migrated into the gateway DB (m0002);
-    // those name the exact principal the client's JWTs still carry. Rebuilding
-    // the vellum binding for THAT principal restores identity from
-    // gateway-native data without minting a divergent one — so it is not the
-    // fail-open re-mint the refusal below guards against. Runtime token/pairing
-    // callers do NOT opt in: they stay fail-closed (repairable 401/503) and let
-    // the boot backfill be the single self-heal seam.
-    //
-    // Gate on a genuinely ABSENT guardian (`!hasGuardianContactRow()`): a
-    // guardian that still exists but whose vellum channel was deliberately
-    // revoked/blocked must stay fail-closed — recovering there would upsert the
-    // channel back to active (createGuardianBinding only protects `blocked`
-    // rows) and silently undo the revoke. Only when no active token survives do
-    // we refuse.
-    const recoveredPrincipalId =
-      options.recoverFromActorTokens && !hasGuardianContactRow()
-        ? recoverGuardianPrincipalFromActorTokens()
-        : null;
-    if (recoveredPrincipalId) {
-      await createGuardianBinding({
-        channel: "vellum",
-        externalUserId: recoveredPrincipalId,
-        deliveryChatId: "local",
-        guardianPrincipalId: recoveredPrincipalId,
-        verifiedVia: "bootstrap",
-      });
-      log.info(
-        { guardianPrincipalId: recoveredPrincipalId },
-        "Recovered the vellum guardian binding from gateway actor tokens (empty contacts table on an upgraded install)",
-      );
+  // Boot-time self-heal: recover an absent guardian from the gateway's own
+  // active actor tokens before the evidence-based refusal below. The full
+  // safety contract lives on recoverAbsentVellumGuardianFromActorTokens.
+  // Runtime token/pairing callers leave recoverFromActorTokens off and stay
+  // fail-closed (repairable 401/503), so the boot backfill is the single
+  // self-heal seam.
+  if (options.recoverFromActorTokens) {
+    const recovered = await recoverAbsentVellumGuardianFromActorTokens();
+    if (recovered) {
       return {
-        guardianPrincipalId: recoveredPrincipalId,
+        guardianPrincipalId: recovered,
         isNew: false,
         mintedOverPriorEvidence: false,
       };
     }
+  }
 
+  const priorEvidence = hasEvidenceOfPriorGuardian();
+  if (priorEvidence && !options.allowMintWithEvidence) {
     // Fires the missing-guardian reporter (error log + telemetry,
     // rate-limited there) when the DB is truly guardian-less. The state is
     // `ok` when a guardian contact row survives with a lost/inactive vellum
@@ -929,6 +976,10 @@ async function resolveOrCreateVellumGuardian(options: {
     deliveryChatId: "local",
     guardianPrincipalId,
     verifiedVia: "bootstrap",
+    // Guardian bootstrap is a verified act (bootstrap secret / platform auth);
+    // the principal is fresh so there is nothing to reactivate, but keep the
+    // classification honest.
+    reactivateRevoked: true,
     ...(displayName ? { displayName } : {}),
   });
   return {

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -175,6 +175,48 @@ export async function findGuardianForChannelActor(
   return row?.principalId ? { principalId: row.principalId } : null;
 }
 
+/**
+ * Recover the guardian principal id from the gateway's own actor-token records.
+ *
+ * Actor tokens are minted exclusively for the guardian principal (device
+ * pairing), so an active row names the exact principal the client's JWTs still
+ * carry. This recovers a lost vellum guardian binding on an install whose
+ * contact reconcile could not run: the assistant DB's contact ACL columns were
+ * already dropped (assistant migration 305) by the time the gateway's data
+ * migrations read them, so `contacts` stays empty while the actor tokens
+ * migrated into the gateway DB (m0002) survive.
+ *
+ * Reads only the gateway DB. Prefers the most recently issued ACTIVE token so a
+ * properly offboarded (revoked) guardian is never resurrected, and falls back
+ * to an active refresh token when no access token survives. Returns null when
+ * no active token names a principal.
+ */
+export function recoverGuardianPrincipalFromActorTokens(): string | null {
+  const db = getGatewayDb();
+
+  const activeAccess = db
+    .select({ guardianPrincipalId: actorTokenRecords.guardianPrincipalId })
+    .from(actorTokenRecords)
+    .where(eq(actorTokenRecords.status, "active"))
+    .orderBy(desc(actorTokenRecords.issuedAt))
+    .limit(1)
+    .get();
+  if (activeAccess?.guardianPrincipalId) {
+    return activeAccess.guardianPrincipalId;
+  }
+
+  const activeRefresh = db
+    .select({
+      guardianPrincipalId: actorRefreshTokenRecords.guardianPrincipalId,
+    })
+    .from(actorRefreshTokenRecords)
+    .where(eq(actorRefreshTokenRecords.status, "active"))
+    .orderBy(desc(actorRefreshTokenRecords.issuedAt))
+    .limit(1)
+    .get();
+  return activeRefresh?.guardianPrincipalId ?? null;
+}
+
 // ---------------------------------------------------------------------------
 // Guardian binding creation — writes to both assistant + gateway DBs
 // ---------------------------------------------------------------------------
@@ -784,6 +826,14 @@ async function fetchPlatformOwnerDisplayName(): Promise<string | null> {
  */
 async function resolveOrCreateVellumGuardian(options: {
   allowMintWithEvidence: boolean;
+  /**
+   * Boot-time backfill only: when the gateway has no vellum guardian binding
+   * but active actor tokens survive (an upgraded install whose contact
+   * reconcile could not run), rebuild the binding from the token's principal
+   * instead of refusing. Runtime callers leave this off so their fail-closed
+   * repair path is unchanged.
+   */
+  recoverFromActorTokens?: boolean;
 }): Promise<{
   guardianPrincipalId: string;
   isNew: boolean;
@@ -804,6 +854,39 @@ async function resolveOrCreateVellumGuardian(options: {
 
   const priorEvidence = hasEvidenceOfPriorGuardian();
   if (priorEvidence && !options.allowMintWithEvidence) {
+    // Boot-time backfill only: before refusing, recover the guardian from the
+    // gateway's own active actor tokens. An install upgraded past the
+    // contact-ACL drop (assistant migration 305) reaches here with an empty
+    // contacts table but the actor tokens migrated into the gateway DB (m0002);
+    // those name the exact principal the client's JWTs still carry. Rebuilding
+    // the vellum binding for THAT principal restores identity from
+    // gateway-native data without minting a divergent one — so it is not the
+    // fail-open re-mint the refusal below guards against. Runtime token/pairing
+    // callers do NOT opt in: they stay fail-closed (repairable 401/503) and let
+    // the boot backfill be the single self-heal seam. Only when no active token
+    // survives do we refuse.
+    const recoveredPrincipalId = options.recoverFromActorTokens
+      ? recoverGuardianPrincipalFromActorTokens()
+      : null;
+    if (recoveredPrincipalId) {
+      await createGuardianBinding({
+        channel: "vellum",
+        externalUserId: recoveredPrincipalId,
+        deliveryChatId: "local",
+        guardianPrincipalId: recoveredPrincipalId,
+        verifiedVia: "bootstrap",
+      });
+      log.info(
+        { guardianPrincipalId: recoveredPrincipalId },
+        "Recovered the vellum guardian binding from gateway actor tokens (empty contacts table on an upgraded install)",
+      );
+      return {
+        guardianPrincipalId: recoveredPrincipalId,
+        isNew: false,
+        mintedOverPriorEvidence: false,
+      };
+    }
+
     // Fires the missing-guardian reporter (error log + telemetry,
     // rate-limited there) when the DB is truly guardian-less. The state is
     // `ok` when a guardian contact row survives with a lost/inactive vellum
@@ -858,10 +941,19 @@ async function resolveOrCreateVellumGuardian(options: {
  * (its 401 is claimed by invalid device codes).
  *
  * Called during gateway startup to backfill existing installations.
+ *
+ * `recoverFromActorTokens` is the boot-time self-heal seam: the
+ * post-assistant-ready backfill sets it so an install whose contact reconcile
+ * could not run (empty contacts, surviving actor tokens) rebinds the guardian
+ * from its own tokens instead of refusing. Runtime callers leave it off and
+ * keep their fail-closed repair path.
  */
-export async function ensureVellumGuardianBinding(): Promise<string> {
+export async function ensureVellumGuardianBinding(
+  opts: { recoverFromActorTokens?: boolean } = {},
+): Promise<string> {
   const { guardianPrincipalId } = await resolveOrCreateVellumGuardian({
     allowMintWithEvidence: false,
+    recoverFromActorTokens: opts.recoverFromActorTokens ?? false,
   });
   return guardianPrincipalId;
 }

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -29,6 +29,7 @@ import {
   bustGuardianIntegrityCache,
   guardianIntegrityState,
   hasEvidenceOfPriorGuardian,
+  hasGuardianContactRow,
 } from "./guardian-integrity.js";
 import { CURRENT_POLICY_EPOCH } from "./policy.js";
 import { mintToken } from "./token-service.js";
@@ -863,11 +864,18 @@ async function resolveOrCreateVellumGuardian(options: {
     // gateway-native data without minting a divergent one — so it is not the
     // fail-open re-mint the refusal below guards against. Runtime token/pairing
     // callers do NOT opt in: they stay fail-closed (repairable 401/503) and let
-    // the boot backfill be the single self-heal seam. Only when no active token
-    // survives do we refuse.
-    const recoveredPrincipalId = options.recoverFromActorTokens
-      ? recoverGuardianPrincipalFromActorTokens()
-      : null;
+    // the boot backfill be the single self-heal seam.
+    //
+    // Gate on a genuinely ABSENT guardian (`!hasGuardianContactRow()`): a
+    // guardian that still exists but whose vellum channel was deliberately
+    // revoked/blocked must stay fail-closed — recovering there would upsert the
+    // channel back to active (createGuardianBinding only protects `blocked`
+    // rows) and silently undo the revoke. Only when no active token survives do
+    // we refuse.
+    const recoveredPrincipalId =
+      options.recoverFromActorTokens && !hasGuardianContactRow()
+        ? recoverGuardianPrincipalFromActorTokens()
+        : null;
     if (recoveredPrincipalId) {
       await createGuardianBinding({
         channel: "vellum",

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -29,7 +29,7 @@ import {
   bustGuardianIntegrityCache,
   guardianIntegrityState,
   hasEvidenceOfPriorGuardian,
-  hasGuardianContactRow,
+  hasGuardianContactWithPrincipal,
 } from "./guardian-integrity.js";
 import { CURRENT_POLICY_EPOCH } from "./policy.js";
 import { mintToken } from "./token-service.js";
@@ -842,11 +842,12 @@ async function fetchPlatformOwnerDisplayName(): Promise<string | null> {
  *  - Actor tokens are minted EXCLUSIVELY for the guardian principal (every mint
  *    site funnels through a guardianPrincipalId), so the token names the real
  *    guardian, never some other actor.
- *  - It fires only when NO `role='guardian'` contact row exists
- *    (`!hasGuardianContactRow()`) — genuine data loss, never a guardian that
- *    still exists but whose binding was deliberately revoked/blocked. That
- *    "no guardian + surviving tokens" state is unreachable by intent (the
- *    contact-delete route 403s a guardian), so it only arises from data loss.
+ *  - It fires only when NO *bootstrapped* guardian exists
+ *    (`!hasGuardianContactWithPrincipal()`) — genuine data loss, never a
+ *    guardian with a real identity whose binding was deliberately
+ *    revoked/blocked (that keeps its principal, so it stays fail-closed). A
+ *    principal-less contact-prompt stub is NOT a guardian, so an install
+ *    carrying only a stub plus surviving tokens is still self-healed.
  *  - It rebinds the token's EXISTING principal — no divergent mint — and passes
  *    `reactivateRevoked: false`, so the write path itself refuses to resurrect a
  *    revoked binding: a second, enforced layer beneath the absent-guardian gate.
@@ -856,7 +857,7 @@ async function fetchPlatformOwnerDisplayName(): Promise<string | null> {
 async function recoverAbsentVellumGuardianFromActorTokens(): Promise<
   string | null
 > {
-  if (hasGuardianContactRow()) {
+  if (hasGuardianContactWithPrincipal()) {
     return null;
   }
   const recoveredPrincipalId = recoverGuardianPrincipalFromActorTokens();

--- a/gateway/src/auth/guardian-integrity.ts
+++ b/gateway/src/auth/guardian-integrity.ts
@@ -23,7 +23,7 @@
  * check as "no stamp" and serve the plain verdict (degraded, loud).
  */
 
-import { eq } from "drizzle-orm";
+import { and, eq, isNotNull } from "drizzle-orm";
 
 import { getGatewayDb } from "../db/connection.js";
 import {
@@ -84,6 +84,30 @@ export function hasGuardianContactRow(): boolean {
       .select({ id: contacts.id })
       .from(contacts)
       .where(eq(contacts.role, "guardian"))
+      .limit(1)
+      .get() !== undefined
+  );
+}
+
+/**
+ * Whether a *bootstrapped* guardian exists: a `role='guardian'` contact row
+ * with a non-null `principal_id`.
+ *
+ * Distinct from {@link hasGuardianContactRow}, which also counts the
+ * principal-less guardian STUBS the gateway-first contact-prompt path creates
+ * before bootstrap. Recovery keys on this so a stub can't masquerade as a real
+ * guardian and suppress the self-heal, while a genuine guardian — which always
+ * carries a principal, even when its binding is revoked — still blocks it.
+ * Mirrors the `isNotNull(principalId)` guard `findGuardian` already applies.
+ */
+export function hasGuardianContactWithPrincipal(): boolean {
+  return (
+    getGatewayDb()
+      .select({ id: contacts.id })
+      .from(contacts)
+      .where(
+        and(eq(contacts.role, "guardian"), isNotNull(contacts.principalId)),
+      )
       .limit(1)
       .get() !== undefined
   );

--- a/gateway/src/auth/guardian-integrity.ts
+++ b/gateway/src/auth/guardian-integrity.ts
@@ -70,6 +70,26 @@ export function hasEvidenceOfPriorGuardian(): boolean {
 }
 
 /**
+ * Whether any `role='guardian'` contact row exists in the gateway DB.
+ *
+ * Side-effect-free (unlike {@link guardianIntegrityState}, it never fires the
+ * missing-guardian reporter) and distinct from `findVellumGuardian`, which
+ * additionally requires an ACTIVE vellum channel. Callers use this to tell a
+ * genuinely absent guardian (true data loss) from one that still exists but
+ * whose binding was deliberately revoked/blocked.
+ */
+export function hasGuardianContactRow(): boolean {
+  return (
+    getGatewayDb()
+      .select({ id: contacts.id })
+      .from(contacts)
+      .where(eq(contacts.role, "guardian"))
+      .limit(1)
+      .get() !== undefined
+  );
+}
+
+/**
  * `missing_guardian` when zero `role='guardian'` contact rows exist AND the
  * DB carries evidence of prior onboarding; `ok` otherwise (healthy install or
  * genuinely fresh install). Cached with a short TTL; a `missing_guardian`
@@ -86,13 +106,7 @@ export function guardianIntegrityState(): GuardianIntegrityState {
 }
 
 function computeState(): GuardianIntegrityState {
-  const guardianRow = getGatewayDb()
-    .select({ id: contacts.id })
-    .from(contacts)
-    .where(eq(contacts.role, "guardian"))
-    .limit(1)
-    .get();
-  if (guardianRow) {
+  if (hasGuardianContactRow()) {
     return "ok";
   }
 

--- a/gateway/src/http/routes/guardian-channel-create.ts
+++ b/gateway/src/http/routes/guardian-channel-create.ts
@@ -126,6 +126,7 @@ export function createGuardianChannelHandler() {
         guardianPrincipalId: guardian.principal_id,
         displayName: body.address,
         verifiedVia: "platform_auto_register",
+        reactivateRevoked: true,
       });
     } catch (err) {
       log.error({ err }, "Failed to create guardian channel binding");

--- a/gateway/src/http/routes/inbound-register.ts
+++ b/gateway/src/http/routes/inbound-register.ts
@@ -104,9 +104,7 @@ export function createInboundRegisterHandler(
   _config: GatewayConfig,
   credentialCache: CredentialCache,
 ) {
-  return async function handleInboundRegister(
-    req: Request,
-  ): Promise<Response> {
+  return async function handleInboundRegister(req: Request): Promise<Response> {
     // ── Parse & validate request body ─────────────────────────────
 
     let rawBody: unknown;
@@ -177,9 +175,7 @@ export function createInboundRegisterHandler(
 
     const guardian = await findGuardian();
     if (!guardian) {
-      log.warn(
-        "No guardian contact exists — cannot auto-verify email channel",
-      );
+      log.warn("No guardian contact exists — cannot auto-verify email channel");
       return Response.json(
         {
           error:
@@ -197,6 +193,7 @@ export function createInboundRegisterHandler(
         guardianPrincipalId: guardian.principal_id,
         displayName: binding.displayName,
         verifiedVia: "webhook_registration",
+        reactivateRevoked: true,
       });
     } catch (err) {
       log.error(

--- a/gateway/src/http/routes/twilio-voice-verify-callback.ts
+++ b/gateway/src/http/routes/twilio-voice-verify-callback.ts
@@ -153,6 +153,7 @@ export function createTwilioVoiceVerifyCallbackHandler(
             deliveryChatId: fromNumber,
             guardianPrincipalId: canonicalPrincipal,
             verifiedVia: "challenge",
+            reactivateRevoked: true,
           });
 
           log.info(

--- a/gateway/src/post-assistant-ready.ts
+++ b/gateway/src/post-assistant-ready.ts
@@ -135,9 +135,14 @@ async function executeDeferredTasks(): Promise<void> {
     log.error({ err }, "Post-ready data migrations failed");
   }
 
-  // 2. Guardian binding backfill
+  // 2. Guardian binding backfill. Opt into actor-token recovery: an install
+  //    whose contact reconcile could not run (the assistant DB's ACL columns
+  //    were already dropped by migration 305 before the gateway read them) has
+  //    an empty contacts table but surviving actor tokens — rebind the vellum
+  //    guardian from those instead of leaving it unresolved. This is the single
+  //    boot-time self-heal seam; runtime token/pairing callers stay fail-closed.
   try {
-    await ensureVellumGuardianBinding();
+    await ensureVellumGuardianBinding({ recoverFromActorTokens: true });
   } catch (err) {
     log.warn({ err }, "Post-ready guardian binding backfill failed");
   }

--- a/gateway/src/verification/session-service.ts
+++ b/gateway/src/verification/session-service.ts
@@ -507,5 +507,6 @@ function applyPhoneGuardianBindingGatewayWrites(
     deliveryChatId: chatId,
     guardianPrincipalId: canonicalPrincipal,
     verifiedVia: "challenge",
+    reactivateRevoked: true,
   });
 }

--- a/gateway/src/verification/text-verification.ts
+++ b/gateway/src/verification/text-verification.ts
@@ -369,6 +369,7 @@ async function applyGuardianSideEffects(params: {
     guardianPrincipalId: canonicalPrincipal,
     displayName,
     verifiedVia: "challenge",
+    reactivateRevoked: true,
   });
   return true;
 }


### PR DESCRIPTION
## Prompt / plan

Fixes **LUM-2783**: after upgrading to a build containing assistant migration **305** (`drop-contact-acl-columns`), starting a **new** thread resolves `canonical_actor_identity: unknown` and `trust_class: unknown` for the guardian, leaving the assistant stuck unverified. Old threads keep working; logout/login doesn't help.

Approach: self-heal the guardian at boot from the gateway's **own** actor tokens (gateway-native, no assistant-DB identity read, no runtime fallback), and enforce the surrounding safety at the write path rather than relying on callers.

## The issue

The gateway DB is the source of truth for contacts/trust (ATL-463). On upgrade the guardian's identity is copied from the assistant DB into the gateway by the reconcile migrations `m0006`/`m0008`, which read the assistant DB's **ACL columns** (`role`, `principal_id`, channel `status`…). But those gateway migrations run **post-assistant-ready** — *after* the assistant has already run migration 305, which drops those columns. On a single-hop upgrade the reconcile finds the columns gone and bails, so the gateway `contacts` table stays **empty** for installs that never reconciled on an earlier build. The guardian-binding backfill then treats the actor tokens migrated into the gateway by `m0002` as "evidence of a prior guardian" and **refuses to mint**, so no vellum guardian binding is ever created and every new vellum turn classifies `unknown`. (Full-history check: reconcile landed Jun 20–25 (#35536/#36146), the drop Jun 26 (#36279, migration 304→305) — a ~6-day window, so any install that didn't boot a build in it jumps straight from pre-reconcile to post-drop.)

## The fix

**Recover the guardian from gateway-native actor tokens at boot.** Actor tokens are minted *exclusively* for the guardian principal, and `m0002` preserved their `guardian_principal_id` — the exact value the desktop client's JWT carries, which is what a vellum turn is classified against. When the boot-time backfill would otherwise refuse, it rebuilds the vellum guardian binding for that principal. No assistant-DB read, no runtime fallback, no divergent mint. Recovery is opt-in (`recoverFromActorTokens`) and used only by the post-assistant-ready backfill; runtime `/auth/token` + pairing stay fail-closed (repairable 401/503).

The recovery decision is **co-located** in one function (`recoverAbsentVellumGuardianFromActorTokens`) whose docstring is an explicit safety contract.

## Security hardening (fail-closed by construction)

Review (Codex P2) surfaced that `findVellumGuardian()` returns null for a guardian whose vellum channel is *revoked*, and the binding write reactivated any non-`blocked` row — so recovery (or any caller) could silently undo a deliberate revoke. Two layers now prevent this:

1. Recovery only fires when the guardian contact row is **genuinely absent** (`!hasGuardianContactRow()`), never for a present-but-revoked guardian.
2. The binding write (`applyGuardianBindingGatewayWrites`) refuses to reactivate a `revoked` binding unless the caller passes `reactivateRevoked: true` — **default false**. The five callers with a real verification act (text/voice challenge, verification-session consume, platform channel-create, provider-validated email, guardian bootstrap) opt in; recovery does not. This is the single enforcement point, so no present-or-future caller can turn a revoke back on without asserting a verification act, and a regression trips the write-path tests.

## Why it's safe (verified in code)

- **The only thing that authenticates as the guardian is a gateway-signed JWT.** Recovery rebinds a principal that already holds gateway-minted credentials — no divergent mint — so it grants nothing an attacker could use without the signing key (and DB-write access could seed a guardian row directly anyway). No new attack surface.
- **Actor tokens are guardian-only.** Every mint site (`guardian-bootstrap`, `guardian-refresh`, `/auth/token`) funnels through a `guardianPrincipalId`.
- **"No guardian + surviving tokens" is only reachable via data loss.** The contact-delete route 403s on a guardian, and token revocation is per-device — so recovery only heals genuine loss, matching how `guardianIntegrityState` already classifies it (`missing_guardian`).
- **Active tokens only** — a properly offboarded (revoked) guardian is never resurrected.

## Before / after

| | Before (broken build) | After (fixed build, next gateway restart) |
|---|---|---|
| New desktop thread | `canonical_actor_identity: unknown`, `trust_class: unknown` | Resolves as `guardian` — verified |
| Guardian-only actions (memory, self-approve, schedules) | Refused / stuck unverified | Work normally |
| Existing threads | Work (stamped verdict) | Still work |
| Logout / login | No effect (binding missing, not the token) | N/A — already fixed at boot |
| Other devices | Fine until "repair" mints a divergent principal, breaking them | Untouched — same principal, all devices keep working |
| Fix required | Manual DB migration by a human | Automatic on update |

## Scope & limits

- Restores the **vellum (desktop) guardian** — the reported symptom and the load-bearing identity (principal → self-approval; the anchor other channels re-verify against). Trusted contacts / other-channel guardian bindings that were also lost are **not recoverable** post-305 — their ACL has no surviving source, and fabricating a trust status would be fail-open — so the guardian re-verifies them (safe, one-time). This isn't a deferral; it's the maximum the surviving data allows.
- The systemic *prevention* (a destructive contract-phase migration shouldn't ship until its consumer's reconcile is universally complete) is a separate, higher-level concern — tracked as a follow-up, not bolted onto this fix.
- No cross-repo companion change needed — internal gateway logic only.

## Test plan

- `guardian-bootstrap-lookups.test.ts`: recovers from an active token (LUM-2783 repro, gateway-native); recovery is opt-in (runtime callers refuse); a revoked-only token doesn't resurrect; **a present-but-revoked guardian is not reactivated by boot recovery**.
- `guardian-bootstrap-binding.test.ts`: the write's revoke gate — **fail-closed by default**, reactivates only with `reactivateRevoked: true`; `blocked` stays terminal.
- `post-assistant-ready-deferred.test.ts`: the real deferred boot run rebuilds the guardian from a surviving token; contact-evidence refusal retained.
- `guardian-integrity.test.ts` + all five verified callers (text-verification, guardian-channel-create, inbound-register, twilio-webhooks, verification-session-consume) stay green. Gateway `tsc --noEmit` + `eslint` clean.
