### PR TITLE
docs(skills): align elevenlabs-voice with the platform managed allowlist

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -199,7 +199,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-21T14:49:44.000Z"
+      "updatedAt": "2026-07-22T23:58:36.000Z"
     },
     {
       "id": "email-setup",

--- a/skills/elevenlabs-voice/SKILL.md
+++ b/skills/elevenlabs-voice/SKILL.md
@@ -20,7 +20,7 @@ voice_config_update setting="tts_voice_id" value="<voice-id>"
 
 > **The voice lives under the _active_ provider, not always ElevenLabs.** The config key depends on `services.tts.provider`: `elevenlabs` → `services.tts.providers.elevenlabs.voiceId`, `vellum` (managed) → `services.tts.providers.vellum.model`, `deepgram` → `services.tts.providers.deepgram.model`. The `voice_config_update` tool (and the `assistant tts voice <id>` CLI command) handle this routing for you. **Do NOT `assistant config set services.tts.providers.elevenlabs.voiceId ...` blindly** — on a managed (`vellum`) assistant that field is ignored, so the write "succeeds" but the voice never changes. See [Setting the voice](#setting-the-voice) for the CLI fallback.
 >
-> **The tables below work on every provider.** On managed (`vellum`) assistants they are the *only* ElevenLabs voices — the platform bills per rate-carded model and rejects anything else at synthesis (the write succeeds but the voice fails on the next turn), so don't offer library or cloned voices unless the assistant has its own ElevenLabs API key. With a BYO key ([setup below](#elevenlabs-api-key-setup)), any voice id works.
+> **The tables below apply when the active provider is `elevenlabs` (BYO key) or managed `vellum`.** On managed assistants they are the _only_ ElevenLabs voices — the platform bills per rate-carded model and rejects anything else at synthesis (the write succeeds but the voice fails on the next turn), so don't offer library or cloned voices unless the assistant has its own ElevenLabs API key. With a BYO key ([setup below](#elevenlabs-api-key-setup)), any voice id works. Other TTS providers (`deepgram`, `xai`, `fish-audio`, …) use their own voice/model identifiers — never write an ElevenLabs voice id to them; pick from that provider's own catalog instead.
 
 ## Choose a Voice
 
@@ -46,7 +46,7 @@ Pick a voice that matches your identity and the user's preferences. Offer to sho
 | Charlie | Casual, Australian              | `IKne3meq5aSn9XLyUdCD` |
 | Liam    | Young, articulate               | `TX3LPaxmHKxFdv7VOQHJ` |
 
-> These are ElevenLabs' **current premade** voices. Do not use retired legacy ids (Antoni, Josh, Arnold, Rachel, Charlotte, Amelia, …): ElevenLabs silently remaps them to *different* voices — synthesis succeeds but speaks as the wrong voice.
+> These are ElevenLabs' **current premade** voices. Do not use retired legacy ids (Antoni, Josh, Arnold, Rachel, Charlotte, Amelia, …): ElevenLabs silently remaps them to _different_ voices — synthesis succeeds but speaks as the wrong voice.
 
 ### Setting the voice
 

--- a/skills/elevenlabs-voice/SKILL.md
+++ b/skills/elevenlabs-voice/SKILL.md
@@ -20,45 +20,33 @@ voice_config_update setting="tts_voice_id" value="<voice-id>"
 
 > **The voice lives under the _active_ provider, not always ElevenLabs.** The config key depends on `services.tts.provider`: `elevenlabs` → `services.tts.providers.elevenlabs.voiceId`, `vellum` (managed) → `services.tts.providers.vellum.model`, `deepgram` → `services.tts.providers.deepgram.model`. The `voice_config_update` tool (and the `assistant tts voice <id>` CLI command) handle this routing for you. **Do NOT `assistant config set services.tts.providers.elevenlabs.voiceId ...` blindly** — on a managed (`vellum`) assistant that field is ignored, so the write "succeeds" but the voice never changes. See [Setting the voice](#setting-the-voice) for the CLI fallback.
 >
-> **Managed (`vellum`) assistants can only use a curated subset of voices** — the platform bills per rate-carded model, and voices outside that list are rejected at synthesis (so the write succeeds but the voice fails on the next turn). That subset is a handful of ElevenLabs voices **plus** Deepgram Aura voices, all set through `vellum.model`. **If the active provider is `vellum`, pick from [Managed (Vellum) voices](#managed-vellum-voices), NOT the full ElevenLabs tables below** — most voices below (Bill, George, Amelia, …) are not offered on managed and will fail.
+> **The tables below work on every provider.** On managed (`vellum`) assistants they are the *only* ElevenLabs voices — the platform bills per rate-carded model and rejects anything else at synthesis (the write succeeds but the voice fails on the next turn), so don't offer library or cloned voices unless the assistant has its own ElevenLabs API key. With a BYO key ([setup below](#elevenlabs-api-key-setup)), any voice id works.
 
 ## Choose a Voice
-
-**First, check the active provider** — it decides which list to pick from:
-
-```bash
-assistant config get services.tts.provider
-```
-
-- `vellum` (managed) → choose from [Managed (Vellum) voices](#managed-vellum-voices). The ElevenLabs tables below do **not** all work on managed.
-- `elevenlabs` (BYO key) → choose from the tables below.
 
 Pick a voice that matches your identity and the user's preferences. Offer to show the full list if they want to choose themselves.
 
 ### Female voices
 
-| Voice     | Style                             | Voice ID               |
-| --------- | --------------------------------- | ---------------------- |
-| Amelia    | Expressive, enthusiastic, British | `ZF6FPAbjXT4488VcRRnw` |
-| Sarah     | Soft, young, approachable         | `EXAVITQu4vr4xnSDxMaL` |
-| Charlotte | Warm, Swedish-accented            | `XB0fDUnXU5powFXDhCwa` |
-| Alice     | Confident, British                | `Xb7hH8MSUJpSbSDYk0k2` |
-| Matilda   | Warm, friendly, young             | `XrExE9yKIg1WjnnlVkGX` |
-| Lily      | Warm, British                     | `pFZP5JQG7iQjIQuC4Bku` |
+| Voice   | Style                     | Voice ID               |
+| ------- | ------------------------- | ---------------------- |
+| Sarah   | Soft, young, approachable | `EXAVITQu4vr4xnSDxMaL` |
+| Alice   | Confident, British        | `Xb7hH8MSUJpSbSDYk0k2` |
+| Matilda | Warm, friendly, young     | `XrExE9yKIg1WjnnlVkGX` |
+| Lily    | Warm, British             | `pFZP5JQG7iQjIQuC4Bku` |
 
 ### Male voices
 
 | Voice   | Style                           | Voice ID               |
 | ------- | ------------------------------- | ---------------------- |
-| Antoni  | Warm, well-rounded              | `ErXwobaYiN019PkySvjV` |
-| Josh    | Deep, young, clear              | `TxGEqnHWrfWFTfGW9XjX` |
-| Arnold  | Crisp, narrative                | `VR6AewLTigWG4xSOukaG` |
 | Adam    | Deep, middle-aged, professional | `pNInz6obpgDQGcFmaJgB` |
 | Bill    | Trustworthy, American           | `pqHfZKP75CvOlQylNhV4` |
 | George  | Warm, British, distinguished    | `JBFqnCBsd6RMkjVDRZzb` |
 | Daniel  | Authoritative, British          | `onwK4e9ZLuTAKqWW03F9` |
 | Charlie | Casual, Australian              | `IKne3meq5aSn9XLyUdCD` |
 | Liam    | Young, articulate               | `TX3LPaxmHKxFdv7VOQHJ` |
+
+> These are ElevenLabs' **current premade** voices. Do not use retired legacy ids (Antoni, Josh, Arnold, Rachel, Charlotte, Amelia, …): ElevenLabs silently remaps them to *different* voices — synthesis succeeds but speaks as the wrong voice.
 
 ### Setting the voice
 
@@ -82,47 +70,9 @@ Verify it worked by reading back the key for the **active** provider, e.g. for a
 assistant config get services.tts.providers.vellum.model
 ```
 
+The change hot-applies to the next voice turn (live voice and phone read the config fresh each turn).
+
 Tell the user what voice you chose and why, but also offer to show all available voices so they can choose for themselves.
-
-## Managed (Vellum) voices
-
-When the active provider is **vellum** (managed speech, common for voice-mode assistants), pick a voice from the two tables below **and only these** — they are the rate-carded models the platform actually offers. Set the chosen `Model` id exactly as you would an ElevenLabs voice (the tool routes it to `vellum.model`):
-
-```
-voice_config_update setting="tts_voice_id" value="aura-2-zeus-en"
-```
-
-The change hot-applies to the next voice turn (live voice and phone read the config fresh each turn). This list mirrors the daemon `GET /v1/tts/managed-voices` route (which the web voice picker uses); if a requested voice isn't here, don't guess an id — offer the closest one below.
-
-### Managed ElevenLabs voices
-
-| Voice | Style                                    | Model                  |
-| ----- | ---------------------------------------- | ---------------------- |
-| Sarah | American · professional, reassuring      | `EXAVITQu4vr4xnSDxMaL` |
-| Roger | American · laid-back, casual, resonant   | `CwhRBWXzGAHq8TQ4Fs17` |
-| Alice | British · clear, engaging, professional  | `Xb7hH8MSUJpSbSDYk0k2` |
-| River | American · relaxed, neutral, informative | `SAz9YHcvj6GT2YYXdXww` |
-| Eric  | American · smooth, trustworthy, classy   | `cjVigY5qzO86Huf0OWal` |
-| Adam  | American · deep, dominant, firm          | `pNInz6obpgDQGcFmaJgB` |
-
-### Deepgram Aura voices
-
-| Voice     | Style                                  | Model                 |
-| --------- | -------------------------------------- | --------------------- |
-| Thalia    | American · clear, confident, energetic | `aura-2-thalia-en`    |
-| Andromeda | American · casual, expressive          | `aura-2-andromeda-en` |
-| Helena    | American · caring, natural, friendly   | `aura-2-helena-en`    |
-| Athena    | American · calm, smooth, professional  | `aura-2-athena-en`    |
-| Luna      | American · friendly, natural, engaging | `aura-2-luna-en`      |
-| Pandora   | British · smooth, calm, melodic        | `aura-2-pandora-en`   |
-| Theia     | Australian · expressive, polite        | `aura-2-theia-en`     |
-| Apollo    | American · confident, casual           | `aura-2-apollo-en`    |
-| Arcas     | American · natural, smooth, clear      | `aura-2-arcas-en`     |
-| Zeus      | American · deep, trustworthy, smooth   | `aura-2-zeus-en`      |
-| Draco     | British · warm, approachable, baritone | `aura-2-draco-en`     |
-| Hyperion  | Australian · caring, warm, empathetic  | `aura-2-hyperion-en`  |
-
-**"American male" on managed** → Eric, Adam, Roger (ElevenLabs) or Apollo, Arcas, Zeus (Aura). (Bill/George from the ElevenLabs tables above are **not** offered on managed.)
 
 ## ElevenLabs API Key Setup
 
@@ -176,7 +126,7 @@ voice_config_update setting="tts_voice_id" value="<selected-voice-id>"
 
 ## Voice Tuning
 
-Fine-tune how the selected voice sounds. These parameters apply to all ElevenLabs modes (in-app TTS and phone calls):
+Fine-tune how the selected voice sounds. These parameters apply to all ElevenLabs modes (in-app TTS and phone calls) **when the active provider is `elevenlabs`** — managed (`vellum`) synthesis does not read them:
 
 ```bash
 # Playback speed (0.7 = slower, 1.0 = normal, 1.2 = faster)


### PR DESCRIPTION
## What changed

Companion to vellum-ai/vellum-assistant-platform#9427, which aligned the platform's managed ElevenLabs allowlist with this skill's curated voice list. With the two now identical, the skill's managed-vs-BYO split collapses:

- **Retired legacy voices removed** (Amelia, Charlotte, Antoni, Josh, Arnold): authenticated `GET /v1/voices/{id}` shows ElevenLabs silently remaps these ids to *different* voices (Antoni's and Arnold's ids both resolve to Adam; Amelia's errors outright) — synthesis succeeds but speaks as the wrong voice, on any tier. A warning note under the tables documents this so they don't get re-added.
- **"Managed (Vellum) voices" section removed**, including the duplicate 6-voice ElevenLabs table and the Deepgram Aura table. Aura voices will move to their own `deepgram-voice` skill (follow-up); until then they remain discoverable via the fetch-based pickers (`GET /v1/tts/managed-voices`).
- **One universal curated list** (10 current premades). The managed restriction is a one-line note (managed can *only* use these; don't offer library/cloned voices without a BYO key), and Voice Tuning is marked BYO-only since managed synthesis doesn't read those params.

No frontmatter changes; `catalog.json` unaffected (verified with `check-catalog.mjs`, `lint-skill-spec.mjs` clean for this skill).

## Merge order

No hard dependency, but merging the platform PR first keeps this skill's claims accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHuRiWztF52CE7nzbcVKQx
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->