### PR TITLE
refactor(telegram): route /start replies through the shared replyOpts

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -368,7 +368,7 @@ export function createTelegramWebhookHandler(
           normalized.message.conversationExternalId,
           START_COMMAND_ACK_TEXT,
           undefined,
-          { credentials: caches?.credentials, ...threadOpts },
+          replyOpts,
         ).catch((err) => {
           tlog.error(
             { err, chatId: normalized.message.conversationExternalId },
@@ -488,7 +488,7 @@ export function createTelegramWebhookHandler(
           normalized.message.conversationExternalId,
           "Welcome! I'm having a brief setup hiccup. Please try again in a moment.",
           undefined,
-          { credentials: caches?.credentials, ...threadOpts },
+          replyOpts,
         ).catch((replyErr) => {
           tlog.error({ err: replyErr }, "Failed to send /start error fallback");
         });


### PR DESCRIPTION
## Prompt / plan

Small consistency follow-up to #38769 (JARVIS-1328). That PR introduced `replyOpts = { credentials, configFile, ...threadOpts }`, built once at the top of the Telegram webhook handler, with the contract *"every gateway direct reply targets the same topic (or main chat) as the inbound message — one decision, made once."* Every direct reply was migrated to it **except** the two `/start` paths (greeting ACK + error fallback), which still hand-built `{ credentials, ...threadOpts }` and omitted `configFile`. This routes those two through `replyOpts` too.

Behavior is unchanged for topic targeting; the only delta is the two `/start` system messages now also pass `configFile` (a pre-existing omission, not a regression). Flagged as non-blocking by the `vex-assistant-bot` review on #38769; landing separately to avoid churning that PR's review cycle.

## Behavior before/after (whole Telegram-topics change set: #38769 + this)

This PR changes no user-visible behavior on its own; the table below is the combined effect of the topic work for reviewer context.

| What you do | Before | After |
| --- | --- | --- |
| Chat in a normal Telegram DM (no topics) | one ongoing conversation | **identical — no change** |
| Turn on Threaded Mode, message inside a topic | every topic's messages collapsed into one conversation; the bot replied in the main "All Messages" view, not your topic | each topic is its own Vellum conversation with its own context; the bot replies **inside that topic** |
| Send an attachment / see the typing indicator in a topic | appeared in the main chat | appears in the topic |
| `/new` in your main DM while topics are open | would have detached the topic bindings too | resets **only** the main conversation; your topics keep working |
| `/new` in a Slack channel with active threads | detached those threads' bindings too | **preserves** them (cross-channel correctness fix) |
| Verification code (any mode) | delivered in the main chat | **identical — unchanged** |

**Behavior changes that are not "the new feature":** exactly one — the `/new` binding-preservation fix, which also affects Slack (a channel-root reset no longer wipes thread bindings). It's a correctness fix, surfaced in #38769's description and pinned by a Slack test. Everything else is either the intended new topic capability (active only when Threaded Mode is on) or byte-identical to before.

## Test plan

- `gateway`: `bun test src/__tests__/telegram-webhook-handler.test.ts src/http/routes/telegram-webhook.test.ts` (31 pass).
- `bunx tsc --noEmit` clean.
- CI note: the `Test` job flaked on an unrelated assistant approval-routing timeout (`channel-approval-routes.test.ts`, 5s timeout, not this gateway diff); needs a re-run.

## CLI verb checklist

No new routes. N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sVe1gqnYum2hVNPrBdjCP