### PR TITLE
feat(web): settings Pair a device — QR pairing without shell commands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -197,6 +197,7 @@
         "lucide-react": "1.16.0",
         "motion": "12.39.0",
         "pdfjs-dist": "5.7.284",
+        "qrcode.react": "4.2.0",
         "react": "19.2.6",
         "react-dom": "19.2.6",
         "react-markdown": "10.1.0",
@@ -2834,6 +2835,8 @@
     "pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "qrcode-terminal": ["qrcode-terminal@0.12.0", "", { "bin": { "qrcode-terminal": "./bin/qrcode-terminal.js" } }, "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="],
+
+    "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
 
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -77,6 +77,7 @@
     "lucide-react": "1.16.0",
     "motion": "12.39.0",
     "pdfjs-dist": "5.7.284",
+    "qrcode.react": "4.2.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-markdown": "10.1.0",

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -20,6 +20,7 @@ import {
 import { DeleteAccountSection } from "@/domains/settings/components/delete-account-section";
 import { DevModeVersionUnlock } from "@/domains/settings/components/dev-mode-version-unlock";
 import { IOSAppCard } from "@/domains/settings/components/ios-app-card";
+import { PairDeviceCard } from "@/domains/settings/pair-device/pair-device-card";
 import { PreferencesModal } from "@/domains/settings/components/preferences-modal";
 import { PreviewReleaseChannel } from "@/domains/settings/components/preview-release-channel";
 import { ResizeCard } from "@/domains/settings/components/resize-card";
@@ -306,6 +307,8 @@ export function GeneralPage() {
       {teleportEnabled && isElectron() && <TeleportCard />}
 
       <IOSAppCard />
+
+      <PairDeviceCard />
 
       {infraGate === "full" && platformAssistant && settingsSleepPolicy && (
         <DetailCard

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+let gatewayPath: string | undefined = "/assistant/__gateway/20100";
+
+mock.module("@/lib/local-mode", () => ({
+  getLocalGatewayUrl: () => gatewayPath,
+  getSelectedAssistant: () => ({ assistantId: "self", cloud: "local" }),
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: () => {},
+}));
+
+const { PairDeviceCard } = await import("./pair-device-card");
+
+const PUBLIC_URL = "https://foo.ts.net";
+const PAIR_URL = "https://foo.ts.net/assistant/pair#device_code=DEV-123";
+
+const originalFetch = globalThis.fetch;
+let requests: Array<{ url: string; body: unknown }> = [];
+
+function futureIso(): string {
+  return new Date(Date.now() + 10 * 60_000).toISOString();
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function challengeBody() {
+  return {
+    deviceCode: "DEV-123",
+    userCode: "WXYZ-1234",
+    verificationUri: "https://foo.ts.net/assistant/pair",
+    expiresAt: futureIso(),
+    expiresInSeconds: 600,
+    intervalSeconds: 5,
+  };
+}
+
+/** Install a fetch mock that records requests and answers per route. */
+function installFetch(
+  onChallenge: () => Response,
+  onVerification: () => Response = () =>
+    jsonResponse({
+      status: "approved",
+      verificationUri: "https://foo.ts.net/assistant/pair",
+      expiresAt: futureIso(),
+    }),
+) {
+  const fetchMock = mock(async (input: string | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    requests.push({
+      url,
+      body: typeof init?.body === "string" ? JSON.parse(init.body) : null,
+    });
+    if (url.endsWith("/v1/remote-web/pairing-challenge")) {
+      return onChallenge();
+    }
+    if (url.endsWith("/v1/remote-web/pairing-verification")) {
+      return onVerification();
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function typeUrl(value: string) {
+  fireEvent.change(screen.getByLabelText("Public URL"), {
+    target: { value },
+  });
+}
+
+beforeEach(() => {
+  gatewayPath = "/assistant/__gateway/20100";
+  requests = [];
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+describe("PairDeviceCard", () => {
+  test("renders nothing when there is no local gateway (remote/platform mode)", () => {
+    gatewayPath = undefined;
+    const { container } = render(<PairDeviceCard />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText("Pair a device")).toBeNull();
+  });
+
+  test("renders the section in local mode", () => {
+    render(<PairDeviceCard />);
+    expect(screen.getByText("Pair a device")).toBeTruthy();
+    expect(screen.getByLabelText("Public URL")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Generate pairing QR" }),
+    ).toBeTruthy();
+  });
+
+  test("mints + approves, then shows the QR and pair URL", async () => {
+    const fetchMock = installFetch(() => jsonResponse(challengeBody()));
+    render(<PairDeviceCard />);
+    typeUrl(PUBLIC_URL);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Generate pairing QR" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTitle("Device pairing QR code")).toBeTruthy(),
+    );
+    expect(screen.getByTestId("pair-device-url").textContent).toBe(PAIR_URL);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(requests[0]?.url).toContain(
+      "/assistant/__gateway/20100/v1/remote-web/pairing-challenge",
+    );
+    expect(requests[0]?.body).toEqual({ publicBaseUrl: PUBLIC_URL });
+    expect(requests[1]?.url).toContain(
+      "/assistant/__gateway/20100/v1/remote-web/pairing-verification",
+    );
+    expect(requests[1]?.body).toEqual({ userCode: "WXYZ-1234" });
+  });
+
+  test("surfaces the server's rejection message with a flag hint", async () => {
+    installFetch(() =>
+      jsonResponse(
+        { error: { code: "LOOPBACK_REQUIRED", message: "loopback required" } },
+        403,
+      ),
+    );
+    render(<PairDeviceCard />);
+    typeUrl(PUBLIC_URL);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Generate pairing QR" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("loopback required")).toBeTruthy(),
+    );
+    expect(screen.getByText(/web-remote-ingress/)).toBeTruthy();
+  });
+
+  test("blocks a loopback URL client-side without a network call", () => {
+    const fetchMock = installFetch(() => jsonResponse(challengeBody()));
+    render(<PairDeviceCard />);
+    typeUrl("http://localhost:3000");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Generate pairing QR" }),
+    );
+
+    expect(
+      screen.getByText(
+        "This is a loopback address your phone can't reach. Enter the assistant's public https URL.",
+      ),
+    ).toBeTruthy();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -1,0 +1,91 @@
+import { Button } from "@vellumai/design-library/components/button";
+import { Input } from "@vellumai/design-library/components/input";
+import { Notice } from "@vellumai/design-library/components/notice";
+
+import { DetailCard } from "@/components/detail-card";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+
+import { resolvePairDeviceGatewayBase } from "./pair-device-client";
+import { PairDeviceReady } from "./pair-device-ready";
+import { usePairDevice } from "./use-pair-device";
+
+/**
+ * Settings card that pairs a phone to this assistant without shell commands —
+ * the UI equivalent of `vellum pair --qr`. It mints and auto-approves a
+ * device-code challenge against the host's loopback gateway and renders the
+ * https pair URL as a QR with a copyable link and expiry countdown.
+ *
+ * Rendered only in desktop/local mode against an on-machine gateway (the gate
+ * lives in {@link resolvePairDeviceGatewayBase}); a remote or platform session
+ * sees nothing.
+ */
+export function PairDeviceCard() {
+  const base = resolvePairDeviceGatewayBase();
+  const pair = usePairDevice(base);
+  const { copy, copied } = useCopyToClipboard();
+
+  if (!base) {
+    return null;
+  }
+
+  const { phase } = pair;
+  const isMinting = phase.kind === "minting";
+  const isReady = phase.kind === "ready";
+  const buttonLabel = isMinting
+    ? "Generating…"
+    : isReady
+      ? "Generate new code"
+      : "Generate pairing QR";
+
+  return (
+    <DetailCard
+      title="Pair a device"
+      subtitle="Scan from your phone's camera to open this assistant on it."
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3">
+          <Input
+            label="Public URL"
+            fullWidth
+            placeholder="https://your-assistant.ts.net"
+            helperText="The https address your phone can reach this assistant at (e.g. your Tailscale or tunnel URL)."
+            value={pair.publicBaseUrl}
+            errorText={pair.inputError ?? undefined}
+            disabled={isMinting}
+            onChange={(event) => pair.setPublicBaseUrl(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                pair.generate();
+              }
+            }}
+          />
+          <Button
+            variant="primary"
+            className="self-start"
+            disabled={isMinting || pair.publicBaseUrl.trim() === ""}
+            onClick={pair.generate}
+          >
+            {buttonLabel}
+          </Button>
+        </div>
+
+        {phase.kind === "error" && (
+          <Notice tone="error" title={phase.message}>
+            {phase.hint}
+          </Notice>
+        )}
+
+        {isReady && (
+          <PairDeviceReady
+            pairUrl={phase.pairUrl}
+            remainingMs={pair.remainingMs}
+            expired={pair.expired}
+            copied={copied}
+            onCopy={copy}
+          />
+        )}
+      </div>
+    </DetailCard>
+  );
+}

--- a/clients/web/src/domains/settings/pair-device/pair-device-client.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-client.ts
@@ -1,0 +1,154 @@
+/**
+ * Browser side of the `vellum pair --qr` flow. In desktop/local mode the SPA
+ * reaches the same-machine gateway over its loopback proxy
+ * (`/assistant/__gateway/<port>`) and drives the two loopback-only routes the
+ * CLI uses:
+ *   1. `POST /v1/remote-web/pairing-challenge` — mint a device-code challenge.
+ *   2. `POST /v1/remote-web/pairing-verification` — approve it with the user
+ *      code. Running on the host IS the authorization, so the scan alone
+ *      completes pairing.
+ *
+ * Both routes are loopback-gated and unauthenticated (they refuse any
+ * non-loopback origin server-side), so no token is attached — the loopback
+ * proxy is the trust boundary. Minting is possible only from the host; a remote
+ * paired session can never reach these routes, which is why the UI is hidden
+ * outside local mode rather than relying on a client-side check.
+ */
+
+import type {
+  RemoteWebPairingChallengeRequest,
+  RemoteWebPairingChallengeResponse,
+  RemoteWebPairingVerificationRequest,
+} from "@vellumai/service-contracts/remote-web-pairing";
+
+import { getLocalGatewayUrl, getSelectedAssistant } from "@/lib/local-mode";
+
+import { buildRemoteWebPairingUrl } from "./pair-device-url";
+
+const PAIRING_CHALLENGE_PATH = "/v1/remote-web/pairing-challenge";
+const PAIRING_VERIFICATION_PATH = "/v1/remote-web/pairing-verification";
+
+/**
+ * Guidance appended when the host rejects the mint. The routes themselves only
+ * require loopback, but a scan can only complete against the public URL when
+ * remote web ingress is enabled on the host — the usual reason pairing doesn't
+ * work end to end.
+ */
+export const WEB_REMOTE_INGRESS_HINT =
+  "If a scan can't connect, enable remote web access on the host with `vellum flags set web-remote-ingress true`, then generate a new code.";
+
+/** A pairing mint that failed, carrying an optional actionable hint. */
+export class PairDeviceError extends Error {
+  readonly hint?: string;
+
+  constructor(message: string, hint?: string) {
+    super(message);
+    this.name = "PairDeviceError";
+    this.hint = hint;
+  }
+}
+
+export interface DevicePairing {
+  /** The scannable https pair URL (verification URI + `#device_code=…`). */
+  pairUrl: string;
+  /** ISO-8601 instant the pairing expires (single-use). */
+  expiresAt: string;
+}
+
+/**
+ * The absolute local-gateway base URL to mint against, or `null` when device
+ * pairing isn't available from here. `getLocalGatewayUrl` already resolves only
+ * in desktop/local mode (never remote-gateway or platform mode) and only for an
+ * on-machine assistant with a recorded loopback gateway — exactly the cases
+ * where a host-presence mint is possible — so this doubles as the section's
+ * visibility gate.
+ */
+export function resolvePairDeviceGatewayBase(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  const path = getLocalGatewayUrl(getSelectedAssistant());
+  if (!path) {
+    return null;
+  }
+  return `${window.location.origin}${path}`;
+}
+
+function serverErrorMessage(payload: unknown): string | null {
+  const message = (payload as { error?: { message?: unknown } } | null)?.error
+    ?.message;
+  return typeof message === "string" && message.trim() ? message : null;
+}
+
+async function postPairingRoute<T>(
+  url: string,
+  body: unknown,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal,
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw err;
+    }
+    throw new PairDeviceError(
+      "Couldn't reach the assistant. Make sure it's running and try again.",
+    );
+  }
+
+  // A non-JSON body (e.g. an HTML error page) resolves to null and falls
+  // through to the status / shape checks below.
+  const payload = (await response.json().catch(() => null)) as unknown;
+
+  if (!response.ok) {
+    throw new PairDeviceError(
+      serverErrorMessage(payload) ??
+        `Pairing failed (HTTP ${response.status}).`,
+      WEB_REMOTE_INGRESS_HINT,
+    );
+  }
+
+  if (payload === null || typeof payload !== "object") {
+    throw new PairDeviceError("The assistant returned an unexpected response.");
+  }
+  return payload as T;
+}
+
+/**
+ * Mint and auto-approve a device pairing against the host's loopback gateway,
+ * returning the scannable pair URL and its expiry. Throws {@link PairDeviceError}
+ * on rejection or an unreachable gateway; rethrows an `AbortError` when the
+ * caller cancels.
+ */
+export async function mintDevicePairing(args: {
+  base: string;
+  publicBaseUrl: string;
+  signal?: AbortSignal;
+}): Promise<DevicePairing> {
+  const { base, publicBaseUrl, signal } = args;
+
+  const challenge = await postPairingRoute<RemoteWebPairingChallengeResponse>(
+    `${base}${PAIRING_CHALLENGE_PATH}`,
+    { publicBaseUrl } satisfies RemoteWebPairingChallengeRequest,
+    signal,
+  );
+
+  await postPairingRoute(
+    `${base}${PAIRING_VERIFICATION_PATH}`,
+    {
+      userCode: challenge.userCode,
+    } satisfies RemoteWebPairingVerificationRequest,
+    signal,
+  );
+
+  return {
+    pairUrl: buildRemoteWebPairingUrl(challenge),
+    expiresAt: challenge.expiresAt,
+  };
+}

--- a/clients/web/src/domains/settings/pair-device/pair-device-ready.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-ready.tsx
@@ -1,0 +1,80 @@
+import { Check, Copy } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { Notice } from "@vellumai/design-library/components/notice";
+
+interface PairDeviceReadyProps {
+  pairUrl: string;
+  remainingMs: number;
+  expired: boolean;
+  copied: boolean;
+  onCopy: (text: string) => void;
+}
+
+/** "Expires in m:ss · single-use.", or a bare "Single-use." once time is up. */
+function formatExpiry(remainingMs: number): string {
+  if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
+    return "Single-use.";
+  }
+  const totalSeconds = Math.ceil(remainingMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `Expires in ${minutes}:${seconds
+    .toString()
+    .padStart(2, "0")} · single-use.`;
+}
+
+/**
+ * The live-code view: the scannable QR, the pair URL as copyable text, and the
+ * expiry countdown — or an expired notice once the single-use code lapses.
+ */
+export function PairDeviceReady({
+  pairUrl,
+  remainingMs,
+  expired,
+  copied,
+  onCopy,
+}: PairDeviceReadyProps) {
+  if (expired) {
+    return (
+      <Notice tone="warning" title="This pairing code expired.">
+        Generate a new code to pair a device.
+      </Notice>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* A white backdrop keeps the QR high-contrast and scannable in every
+          theme — the code itself must not vary with the app surface. */}
+      <div className="w-fit rounded-lg bg-white p-3">
+        <QRCodeSVG
+          value={pairUrl}
+          size={192}
+          level="M"
+          title="Device pairing QR code"
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <code
+          data-testid="pair-device-url"
+          className="min-w-0 flex-1 truncate rounded-md bg-[var(--surface-active)] px-2.5 py-1.5 text-body-small-default text-[var(--content-secondary)]"
+        >
+          {pairUrl}
+        </code>
+        <Button
+          variant="outlined"
+          size="compact"
+          leftIcon={copied ? <Check /> : <Copy />}
+          onClick={() => onCopy(pairUrl)}
+        >
+          {copied ? "Copied" : "Copy"}
+        </Button>
+      </div>
+      <p className="text-body-small-default text-[var(--content-tertiary)]">
+        {formatExpiry(remainingMs)}
+      </p>
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/pair-device/pair-device-url.test.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-url.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildRemoteWebPairingUrl,
+  isLoopbackUrl,
+  normalizePublicBaseUrl,
+  resolvePublicBaseUrl,
+} from "./pair-device-url";
+
+describe("normalizePublicBaseUrl", () => {
+  test("strips query, hash, and the assistant path segment", () => {
+    expect(
+      normalizePublicBaseUrl(
+        "https://foo.ts.net/assistant/pair?x=1#device_code=abc",
+      ),
+    ).toBe("https://foo.ts.net");
+  });
+
+  test("preserves a deployment path prefix before /assistant", () => {
+    expect(
+      normalizePublicBaseUrl("https://foo.example.com/vellum/assistant/"),
+    ).toBe("https://foo.example.com/vellum");
+  });
+
+  test("trims trailing slashes", () => {
+    expect(normalizePublicBaseUrl("https://foo.ts.net///")).toBe(
+      "https://foo.ts.net",
+    );
+  });
+
+  test("throws on an unparseable value", () => {
+    expect(() => normalizePublicBaseUrl("not a url")).toThrow();
+  });
+});
+
+describe("isLoopbackUrl", () => {
+  test("flags localhost, 127.x, and ::1", () => {
+    expect(isLoopbackUrl("https://localhost")).toBe(true);
+    expect(isLoopbackUrl("http://127.0.0.1:7830")).toBe(true);
+    expect(isLoopbackUrl("http://[::1]:7830")).toBe(true);
+  });
+
+  test("passes a public host", () => {
+    expect(isLoopbackUrl("https://foo.ts.net")).toBe(false);
+  });
+});
+
+describe("resolvePublicBaseUrl", () => {
+  test("accepts a public https URL and returns the normalized origin", () => {
+    expect(resolvePublicBaseUrl("https://foo.ts.net/assistant#x")).toEqual({
+      ok: true,
+      url: "https://foo.ts.net",
+    });
+  });
+
+  test("rejects a loopback address", () => {
+    expect(resolvePublicBaseUrl("https://localhost:7830")).toEqual({
+      ok: false,
+      reason: "loopback",
+    });
+  });
+
+  test("rejects a non-https URL", () => {
+    expect(resolvePublicBaseUrl("http://foo.ts.net")).toEqual({
+      ok: false,
+      reason: "non-https",
+    });
+  });
+
+  test("rejects an unparseable value", () => {
+    expect(resolvePublicBaseUrl("nope")).toEqual({
+      ok: false,
+      reason: "unparseable",
+    });
+  });
+});
+
+describe("buildRemoteWebPairingUrl", () => {
+  test("carries the device code in the fragment", () => {
+    expect(
+      buildRemoteWebPairingUrl({
+        verificationUri: "https://foo.ts.net/assistant/pair",
+        deviceCode: "DEV-123",
+      }),
+    ).toBe("https://foo.ts.net/assistant/pair#device_code=DEV-123");
+  });
+});

--- a/clients/web/src/domains/settings/pair-device/pair-device-url.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-url.ts
@@ -1,0 +1,109 @@
+import type { RemoteWebPairingChallengeResponse } from "@vellumai/service-contracts/remote-web-pairing";
+
+/**
+ * Public-URL validation and pair-link construction for the "Pair a device"
+ * settings section. These mirror the semantics of the `vellum pair --qr` CLI
+ * flow (`cli/src/commands/pair.ts`: `normalizePublicBaseUrl`,
+ * `resolveQrPublicBaseUrl`, `buildRemoteWebPairingUrl`) so the browser mint and
+ * the CLI mint accept the same URLs and produce the same pair links. They live
+ * here rather than being imported because the CLI is a separate Node package the
+ * browser bundle cannot depend on.
+ */
+
+/** Why a pasted public URL can't be used to pair a phone. */
+export type PublicBaseUrlRejection = "unparseable" | "loopback" | "non-https";
+
+export type PublicBaseUrlResult =
+  | { ok: true; url: string }
+  | { ok: false; reason: PublicBaseUrlRejection };
+
+/**
+ * A loopback URL — `localhost`, `[::1]`, or `127.x.x.x`. A QR encoding a
+ * loopback link is unscannable from another device, so it is refused.
+ */
+export function isLoopbackUrl(url: string): boolean {
+  try {
+    // WHATWG URL canonicalizes hostnames, so IPv6 loopback is always "[::1]".
+    const hostname = new URL(url).hostname;
+    return (
+      hostname === "localhost" ||
+      hostname === "[::1]" ||
+      /^127(?:\.\d{1,3}){3}$/.test(hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Normalize a pasted address to the public origin a scanning phone opens:
+ * query/hash stripped, the `assistant` path segment (and anything after it)
+ * removed so a pasted pair-page URL collapses to its base, and trailing slashes
+ * trimmed. Throws if the value is not a parseable URL.
+ */
+export function normalizePublicBaseUrl(value: string): string {
+  const url = new URL(value);
+  url.search = "";
+  url.hash = "";
+  const parts = url.pathname.split("/").filter(Boolean);
+  const assistantIndex = parts.indexOf("assistant");
+  if (assistantIndex >= 0) {
+    parts.splice(assistantIndex);
+  }
+  url.pathname = parts.length ? `/${parts.join("/")}` : "/";
+  return url.toString().replace(/\/+$/, "");
+}
+
+/**
+ * Resolve a pasted address to the public https base URL to advertise in the
+ * pairing challenge, or report why it can't be used. Stricter than a plain
+ * parse: a loopback or non-https link is unreachable from another device, so
+ * both are refused with a specific reason the UI turns into an inline message.
+ */
+export function resolvePublicBaseUrl(raw: string): PublicBaseUrlResult {
+  let normalized: string;
+  try {
+    normalized = normalizePublicBaseUrl(raw);
+  } catch {
+    return { ok: false, reason: "unparseable" };
+  }
+  if (isLoopbackUrl(normalized)) {
+    return { ok: false, reason: "loopback" };
+  }
+  if (new URL(normalized).protocol !== "https:") {
+    return { ok: false, reason: "non-https" };
+  }
+  return { ok: true, url: normalized };
+}
+
+/** Inline validation message for each rejection reason. */
+export function publicBaseUrlRejectionMessage(
+  reason: PublicBaseUrlRejection,
+): string {
+  switch (reason) {
+    case "unparseable":
+      return "Enter a valid URL, e.g. https://your-assistant.ts.net.";
+    case "loopback":
+      return "This is a loopback address your phone can't reach. Enter the assistant's public https URL.";
+    case "non-https":
+      return "The URL must use https so your phone can connect securely.";
+  }
+}
+
+/**
+ * The scannable pair URL: the challenge's verification URI with the device code
+ * carried in the fragment (`#device_code=…`), matching what the pair page reads
+ * on load.
+ */
+export function buildRemoteWebPairingUrl(
+  challenge: Pick<
+    RemoteWebPairingChallengeResponse,
+    "verificationUri" | "deviceCode"
+  >,
+): string {
+  const url = new URL(challenge.verificationUri);
+  url.hash = new URLSearchParams({
+    device_code: challenge.deviceCode,
+  }).toString();
+  return url.toString();
+}

--- a/clients/web/src/domains/settings/pair-device/use-pair-device.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pair-device.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { captureError } from "@/lib/sentry/capture-error";
+import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
+
+import {
+  mintDevicePairing,
+  PairDeviceError,
+  type DevicePairing,
+} from "./pair-device-client";
+import {
+  publicBaseUrlRejectionMessage,
+  resolvePublicBaseUrl,
+} from "./pair-device-url";
+
+/** localStorage key for the last public URL that successfully minted a code. */
+const PUBLIC_BASE_URL_STORAGE_KEY = "vellum:pair-device:public-base-url";
+
+export type PairDevicePhase =
+  | { kind: "idle" }
+  | { kind: "minting" }
+  | { kind: "ready"; pairUrl: string; expiresAtMs: number }
+  | { kind: "error"; message: string; hint?: string };
+
+export interface PairDeviceController {
+  /** The public URL to advertise, editable and prefilled from the last success. */
+  publicBaseUrl: string;
+  setPublicBaseUrl: (value: string) => void;
+  /** Client-side validation message for the URL field, or `null`. */
+  inputError: string | null;
+  phase: PairDevicePhase;
+  /** Milliseconds until the live code expires (0 outside the `ready` phase). */
+  remainingMs: number;
+  /** Whether a live code has passed its expiry. */
+  expired: boolean;
+  /** Validate the URL and mint a code (also used to regenerate). */
+  generate: () => void;
+}
+
+/**
+ * Drives the "Pair a device" flow: URL validation + prefill, the mint/approve
+ * request against the host's loopback gateway, and a 1s expiry countdown while a
+ * code is live. `base` is the resolved local-gateway base URL, or `null` when
+ * pairing isn't available from here (the hook then no-ops).
+ */
+export function usePairDevice(base: string | null): PairDeviceController {
+  const [publicBaseUrl, setPublicBaseUrlState] = useState(() =>
+    getLocalSetting(PUBLIC_BASE_URL_STORAGE_KEY, ""),
+  );
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [phase, setPhase] = useState<PairDevicePhase>({ kind: "idle" });
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
+
+  // Run a 1s clock only while a code is live so the countdown advances and the
+  // UI flips to "expired" on its own — no background timer the rest of the time.
+  useEffect(() => {
+    if (phase.kind !== "ready") {
+      return;
+    }
+    setNowMs(Date.now());
+    const id = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [phase]);
+
+  const setPublicBaseUrl = useCallback((value: string) => {
+    setPublicBaseUrlState(value);
+    setInputError(null);
+  }, []);
+
+  const generate = useCallback(() => {
+    if (!base) {
+      return;
+    }
+    const resolved = resolvePublicBaseUrl(publicBaseUrl.trim());
+    if (!resolved.ok) {
+      setInputError(publicBaseUrlRejectionMessage(resolved.reason));
+      return;
+    }
+    setInputError(null);
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setPhase({ kind: "minting" });
+    void (async () => {
+      try {
+        const pairing: DevicePairing = await mintDevicePairing({
+          base,
+          publicBaseUrl: resolved.url,
+          signal: controller.signal,
+        });
+        if (controller.signal.aborted) {
+          return;
+        }
+        // Remember the URL that worked so the next open prefills it.
+        setLocalSetting(PUBLIC_BASE_URL_STORAGE_KEY, resolved.url);
+        setPhase({
+          kind: "ready",
+          pairUrl: pairing.pairUrl,
+          expiresAtMs: Date.parse(pairing.expiresAt),
+        });
+      } catch (err) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        if (err instanceof PairDeviceError) {
+          setPhase({ kind: "error", message: err.message, hint: err.hint });
+          return;
+        }
+        captureError(err, { context: "pair-device-mint" });
+        setPhase({
+          kind: "error",
+          message: "Something went wrong while generating the code.",
+        });
+      }
+    })();
+  }, [base, publicBaseUrl]);
+
+  const remainingMs =
+    phase.kind === "ready" ? Math.max(0, phase.expiresAtMs - nowMs) : 0;
+  const expired = phase.kind === "ready" && remainingMs <= 0;
+
+  return {
+    publicBaseUrl,
+    setPublicBaseUrl,
+    inputError,
+    phase,
+    remainingMs,
+    expired,
+    generate,
+  };
+}


### PR DESCRIPTION
## Summary
- Local-mode settings gains Pair a device: mints + auto-approves via the existing loopback-only remote-web routes (same flow as vellum pair --qr) and renders the https pair URL as a QR with copyable link and expiry countdown
- Hidden entirely outside same-machine mode — local presence remains the pairing authorization, enforced server-side by the loopback-only mint; remote sessions minting pairings is an explicit non-goal
- One QR serves both audiences (the pair page's Open-in-app handoff covers app users); wire types from @vellumai/service-contracts/remote-web-pairing

Part of plan: ios-self-hosted-connect.md (settings pairing UI).