### PR TITLE
fix: pair-device card version gate + flag precheck; pairing URL helpers extracted to service-contracts

### DIFF
--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -15,11 +15,15 @@ import { nanoid } from "nanoid";
 // error-correction level off `this`, so a destructured import renders nothing.
 import qrcodeTerminal from "qrcode-terminal";
 
-import type {
-  RemoteWebPairingChallengeRequest,
-  RemoteWebPairingChallengeResponse,
-  RemoteWebPairingVerificationRequest,
-  RemoteWebPairingVerificationResponse,
+import {
+  buildRemoteWebPairingUrl,
+  normalizePublicBaseUrl,
+  resolvePublicBaseUrl,
+  type PublicBaseUrlRejection,
+  type RemoteWebPairingChallengeRequest,
+  type RemoteWebPairingChallengeResponse,
+  type RemoteWebPairingVerificationRequest,
+  type RemoteWebPairingVerificationResponse,
 } from "@vellumai/service-contracts/remote-web-pairing";
 
 import { extractFlag } from "../lib/arg-utils.js";
@@ -127,29 +131,6 @@ interface PairResponse {
   refreshAfter?: string;
 }
 
-function normalizePublicBaseUrl(value: string): string {
-  const url = new URL(value);
-  url.search = "";
-  url.hash = "";
-  const parts = url.pathname.split("/").filter(Boolean);
-  const assistantIndex = parts.indexOf("assistant");
-  if (assistantIndex >= 0) {
-    parts.splice(assistantIndex);
-  }
-  url.pathname = parts.length ? `/${parts.join("/")}` : "/";
-  return url.toString().replace(/\/+$/, "");
-}
-
-function buildRemoteWebPairingUrl(
-  challenge: RemoteWebPairingChallengeResponse,
-): string {
-  const url = new URL(challenge.verificationUri);
-  url.hash = new URLSearchParams({
-    device_code: challenge.deviceCode,
-  }).toString();
-  return url.toString();
-}
-
 /** Default URL scheme registered by production builds of the iOS app. */
 const DEFAULT_APP_CONNECT_SCHEME = "vellum-assistant";
 
@@ -165,35 +146,6 @@ export function buildAppConnectUrl(
 ): string {
   const params = new URLSearchParams({ url: baseUrl, code: deviceCode });
   return `${scheme}://connect?${params.toString()}`;
-}
-
-type QrPublicBaseUrlFailureReason = "unparseable" | "loopback" | "non-https";
-
-type QrPublicBaseUrlResult =
-  | { ok: true; url: string }
-  | { ok: false; reason: QrPublicBaseUrlFailureReason };
-
-/**
- * Normalize the advertised URL to the public https origin a scanning phone can
- * open, or report why it isn't internet-reachable. Stricter than the copy-paste
- * bundle path's loopback guard: a QR that encodes a loopback or plain-http link
- * is unusable from another device, so both are refused. The failure reason is
- * returned so the caller can emit an accurate message per case.
- */
-function resolveQrPublicBaseUrl(advertisedUrl: string): QrPublicBaseUrlResult {
-  let normalized: string;
-  try {
-    normalized = normalizePublicBaseUrl(advertisedUrl);
-  } catch {
-    return { ok: false, reason: "unparseable" };
-  }
-  if (isLoopbackUrl(normalized)) {
-    return { ok: false, reason: "loopback" };
-  }
-  if (new URL(normalized).protocol !== "https:") {
-    return { ok: false, reason: "non-https" };
-  }
-  return { ok: true, url: normalized };
 }
 
 /**
@@ -493,9 +445,9 @@ export async function pair(): Promise<void> {
   if (qrPairing) {
     // Validate the public URL before any network call — a QR that encodes a
     // loopback or plain-http link is unscannable from another device.
-    const qrResult = resolveQrPublicBaseUrl(advertisedUrl);
+    const qrResult = resolvePublicBaseUrl(advertisedUrl);
     if (!qrResult.ok) {
-      const detailByReason: Record<QrPublicBaseUrlFailureReason, string> = {
+      const detailByReason: Record<PublicBaseUrlRejection, string> = {
         unparseable: `${advertisedUrl} isn't a valid URL`,
         loopback: `${advertisedUrl} is a loopback address`,
         "non-https": `${advertisedUrl} is not https`,

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -9,10 +9,22 @@ import {
 } from "@testing-library/react";
 
 let gatewayPath: string | undefined = "/assistant/__gateway/20100";
+let supportsPairingRoutes = true;
+let webRemoteIngressOn = true;
 
 mock.module("@/lib/local-mode", () => ({
   getLocalGatewayUrl: () => gatewayPath,
   getSelectedAssistant: () => ({ assistantId: "self", cloud: "local" }),
+}));
+
+mock.module("@/lib/backwards-compat/remote-web-pairing-gate", () => ({
+  useSupportsRemoteWebPairing: () => supportsPairingRoutes,
+}));
+
+mock.module("@/stores/assistant-feature-flag-store", () => ({
+  useAssistantFeatureFlagStore: {
+    use: { webRemoteIngress: () => webRemoteIngressOn },
+  },
 }));
 
 mock.module("@/lib/sentry/capture-error", () => ({
@@ -85,6 +97,8 @@ function typeUrl(value: string) {
 
 beforeEach(() => {
   gatewayPath = "/assistant/__gateway/20100";
+  supportsPairingRoutes = true;
+  webRemoteIngressOn = true;
   requests = [];
   localStorage.clear();
 });
@@ -109,6 +123,34 @@ describe("PairDeviceCard", () => {
     expect(
       screen.getByRole("button", { name: "Generate pairing QR" }),
     ).toBeTruthy();
+  });
+
+  test("renders nothing against an assistant without the pairing routes", () => {
+    supportsPairingRoutes = false;
+    const { container } = render(<PairDeviceCard />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText("Pair a device")).toBeNull();
+  });
+
+  test("reports the enable guidance without minting when web-remote-ingress is off", async () => {
+    webRemoteIngressOn = false;
+    const fetchMock = installFetch(() => jsonResponse(challengeBody()));
+    render(<PairDeviceCard />);
+    typeUrl(PUBLIC_URL);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Generate pairing QR" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "Remote web access is disabled on this assistant, so a scanned code couldn't connect.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(screen.getByText(/web-remote-ingress/)).toBeTruthy();
+    // Mirrors the CLI: the flag is checked before minting, so no network call.
+    expect(fetchMock).toHaveBeenCalledTimes(0);
   });
 
   test("mints + approves, then shows the QR and pair URL", async () => {

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -4,6 +4,8 @@ import { Notice } from "@vellumai/design-library/components/notice";
 
 import { DetailCard } from "@/components/detail-card";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import { useSupportsRemoteWebPairing } from "@/lib/backwards-compat/remote-web-pairing-gate";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 import { resolvePairDeviceGatewayBase } from "./pair-device-client";
 import { PairDeviceReady } from "./pair-device-ready";
@@ -16,15 +18,20 @@ import { usePairDevice } from "./use-pair-device";
  * https pair URL as a QR with a copyable link and expiry countdown.
  *
  * Rendered only in desktop/local mode against an on-machine gateway (the gate
- * lives in {@link resolvePairDeviceGatewayBase}); a remote or platform session
- * sees nothing.
+ * lives in {@link resolvePairDeviceGatewayBase}) whose assistant version
+ * serves the pairing routes ({@link useSupportsRemoteWebPairing}); a remote or
+ * platform session, or an older assistant, sees nothing. Generating also
+ * requires the `web-remote-ingress` flag — checked before minting, like the
+ * CLI, so a rendered QR always represents a scannable pairing.
  */
 export function PairDeviceCard() {
   const base = resolvePairDeviceGatewayBase();
-  const pair = usePairDevice(base);
+  const supported = useSupportsRemoteWebPairing();
+  const webRemoteIngressOn = useAssistantFeatureFlagStore.use.webRemoteIngress();
+  const pair = usePairDevice(base, webRemoteIngressOn);
   const { copy, copied } = useCopyToClipboard();
 
-  if (!base) {
+  if (!base || !supported) {
     return null;
   }
 

--- a/clients/web/src/domains/settings/pair-device/pair-device-url.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-url.ts
@@ -1,80 +1,21 @@
-import type { RemoteWebPairingChallengeResponse } from "@vellumai/service-contracts/remote-web-pairing";
-
 /**
  * Public-URL validation and pair-link construction for the "Pair a device"
- * settings section. These mirror the semantics of the `vellum pair --qr` CLI
- * flow (`cli/src/commands/pair.ts`: `normalizePublicBaseUrl`,
- * `resolveQrPublicBaseUrl`, `buildRemoteWebPairingUrl`) so the browser mint and
- * the CLI mint accept the same URLs and produce the same pair links. They live
- * here rather than being imported because the CLI is a separate Node package the
- * browser bundle cannot depend on.
+ * settings section. The implementations live in
+ * `@vellumai/service-contracts/remote-web-pairing` and are shared with the
+ * `vellum pair --qr` CLI flow, so both mints accept the same URLs and produce
+ * the same pair links. This module re-exports them and adds the UI copy.
  */
 
-/** Why a pasted public URL can't be used to pair a phone. */
-export type PublicBaseUrlRejection = "unparseable" | "loopback" | "non-https";
+export {
+  buildRemoteWebPairingUrl,
+  isLoopbackPublicUrl as isLoopbackUrl,
+  normalizePublicBaseUrl,
+  resolvePublicBaseUrl,
+  type PublicBaseUrlRejection,
+  type PublicBaseUrlResult,
+} from "@vellumai/service-contracts/remote-web-pairing";
 
-export type PublicBaseUrlResult =
-  | { ok: true; url: string }
-  | { ok: false; reason: PublicBaseUrlRejection };
-
-/**
- * A loopback URL — `localhost`, `[::1]`, or `127.x.x.x`. A QR encoding a
- * loopback link is unscannable from another device, so it is refused.
- */
-export function isLoopbackUrl(url: string): boolean {
-  try {
-    // WHATWG URL canonicalizes hostnames, so IPv6 loopback is always "[::1]".
-    const hostname = new URL(url).hostname;
-    return (
-      hostname === "localhost" ||
-      hostname === "[::1]" ||
-      /^127(?:\.\d{1,3}){3}$/.test(hostname)
-    );
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Normalize a pasted address to the public origin a scanning phone opens:
- * query/hash stripped, the `assistant` path segment (and anything after it)
- * removed so a pasted pair-page URL collapses to its base, and trailing slashes
- * trimmed. Throws if the value is not a parseable URL.
- */
-export function normalizePublicBaseUrl(value: string): string {
-  const url = new URL(value);
-  url.search = "";
-  url.hash = "";
-  const parts = url.pathname.split("/").filter(Boolean);
-  const assistantIndex = parts.indexOf("assistant");
-  if (assistantIndex >= 0) {
-    parts.splice(assistantIndex);
-  }
-  url.pathname = parts.length ? `/${parts.join("/")}` : "/";
-  return url.toString().replace(/\/+$/, "");
-}
-
-/**
- * Resolve a pasted address to the public https base URL to advertise in the
- * pairing challenge, or report why it can't be used. Stricter than a plain
- * parse: a loopback or non-https link is unreachable from another device, so
- * both are refused with a specific reason the UI turns into an inline message.
- */
-export function resolvePublicBaseUrl(raw: string): PublicBaseUrlResult {
-  let normalized: string;
-  try {
-    normalized = normalizePublicBaseUrl(raw);
-  } catch {
-    return { ok: false, reason: "unparseable" };
-  }
-  if (isLoopbackUrl(normalized)) {
-    return { ok: false, reason: "loopback" };
-  }
-  if (new URL(normalized).protocol !== "https:") {
-    return { ok: false, reason: "non-https" };
-  }
-  return { ok: true, url: normalized };
-}
+import type { PublicBaseUrlRejection } from "@vellumai/service-contracts/remote-web-pairing";
 
 /** Inline validation message for each rejection reason. */
 export function publicBaseUrlRejectionMessage(
@@ -90,20 +31,3 @@ export function publicBaseUrlRejectionMessage(
   }
 }
 
-/**
- * The scannable pair URL: the challenge's verification URI with the device code
- * carried in the fragment (`#device_code=…`), matching what the pair page reads
- * on load.
- */
-export function buildRemoteWebPairingUrl(
-  challenge: Pick<
-    RemoteWebPairingChallengeResponse,
-    "verificationUri" | "deviceCode"
-  >,
-): string {
-  const url = new URL(challenge.verificationUri);
-  url.hash = new URLSearchParams({
-    device_code: challenge.deviceCode,
-  }).toString();
-  return url.toString();
-}

--- a/clients/web/src/domains/settings/pair-device/use-pair-device.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pair-device.ts
@@ -6,6 +6,7 @@ import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import {
   mintDevicePairing,
   PairDeviceError,
+  WEB_REMOTE_INGRESS_HINT,
   type DevicePairing,
 } from "./pair-device-client";
 import {
@@ -42,8 +43,15 @@ export interface PairDeviceController {
  * request against the host's loopback gateway, and a 1s expiry countdown while a
  * code is live. `base` is the resolved local-gateway base URL, or `null` when
  * pairing isn't available from here (the hook then no-ops).
+ * `webRemoteIngressEnabled` is the host's `web-remote-ingress` flag — when off,
+ * generating reports the enable guidance without minting (the loopback routes
+ * succeed regardless of the flag, but a scan can only connect through public
+ * ingress, so a minted QR would be unusable).
  */
-export function usePairDevice(base: string | null): PairDeviceController {
+export function usePairDevice(
+  base: string | null,
+  webRemoteIngressEnabled: boolean,
+): PairDeviceController {
   const [publicBaseUrl, setPublicBaseUrlState] = useState(() =>
     getLocalSetting(PUBLIC_BASE_URL_STORAGE_KEY, ""),
   );
@@ -84,6 +92,16 @@ export function usePairDevice(base: string | null): PairDeviceController {
     }
     setInputError(null);
 
+    if (!webRemoteIngressEnabled) {
+      setPhase({
+        kind: "error",
+        message:
+          "Remote web access is disabled on this assistant, so a scanned code couldn't connect.",
+        hint: WEB_REMOTE_INGRESS_HINT,
+      });
+      return;
+    }
+
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
@@ -121,7 +139,7 @@ export function usePairDevice(base: string | null): PairDeviceController {
         });
       }
     })();
-  }, [base, publicBaseUrl]);
+  }, [base, publicBaseUrl, webRemoteIngressEnabled]);
 
   const remainingMs =
     phase.kind === "ready" ? Math.max(0, phase.expiresAtMs - nowMs) : 0;

--- a/clients/web/src/lib/backwards-compat/remote-web-pairing-gate.ts
+++ b/clients/web/src/lib/backwards-compat/remote-web-pairing-gate.ts
@@ -1,0 +1,17 @@
+/**
+ * Backwards-compat gate: remote-web device pairing.
+ *
+ * Assistant `0.10.0` is the first version whose gateway serves the
+ * remote-web pairing routes (`/v1/remote-web/pairing-challenge`,
+ * `/v1/remote-web/pairing-verification`) that the settings "Pair a
+ * device" card mints through. Against an older assistant the card
+ * renders nothing rather than offering a button whose first POST fails.
+ */
+import { useAssistantSupports } from "@/lib/backwards-compat/utils";
+
+const MIN_VERSION = "0.10.0";
+
+/** `true` when the connected assistant serves the remote-web pairing routes. */
+export function useSupportsRemoteWebPairing(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}

--- a/packages/service-contracts/src/remote-web-pairing.ts
+++ b/packages/service-contracts/src/remote-web-pairing.ts
@@ -100,3 +100,93 @@ export interface RemoteWebPairingTokenApprovedResponse {
 export type RemoteWebPairingTokenResponse =
   | RemoteWebPairingTokenPendingResponse
   | RemoteWebPairingTokenApprovedResponse;
+
+// ── Shared pairing URL helpers ──────────────────────────────────────────────
+//
+// Every surface that mints a pairing (the `vellum pair --qr` CLI, the web
+// settings "Pair a device" card) must accept the same public URLs and build
+// the same scannable links. The helpers are environment-neutral (WHATWG URL
+// only) so both Node and browser callers share one implementation.
+
+/** Why a public base URL can't be advertised in a pairing challenge. */
+export type PublicBaseUrlRejection = "unparseable" | "loopback" | "non-https";
+
+export type PublicBaseUrlResult =
+  | { ok: true; url: string }
+  | { ok: false; reason: PublicBaseUrlRejection };
+
+/**
+ * A loopback URL — `localhost`, `[::1]`, or `127.x.x.x`. A pairing link that
+ * encodes a loopback address is unreachable from the scanning device.
+ */
+export function isLoopbackPublicUrl(url: string): boolean {
+  try {
+    // WHATWG URL canonicalizes hostnames, so IPv6 loopback is always "[::1]".
+    const hostname = new URL(url).hostname;
+    return (
+      hostname === "localhost" ||
+      hostname === "[::1]" ||
+      /^127(?:\.\d{1,3}){3}$/.test(hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Normalize an address to the public base a scanning device opens:
+ * query/hash stripped, the `assistant` path segment (and everything after it)
+ * removed so a pasted pair-page URL collapses to its base, and trailing
+ * slashes trimmed. Throws if the value is not a parseable URL.
+ */
+export function normalizePublicBaseUrl(value: string): string {
+  const url = new URL(value);
+  url.search = "";
+  url.hash = "";
+  const parts = url.pathname.split("/").filter(Boolean);
+  const assistantIndex = parts.indexOf("assistant");
+  if (assistantIndex >= 0) {
+    parts.splice(assistantIndex);
+  }
+  url.pathname = parts.length ? `/${parts.join("/")}` : "/";
+  return url.toString().replace(/\/+$/, "");
+}
+
+/**
+ * Resolve an address to the public https base URL to advertise in a pairing
+ * challenge, or report why it can't be used. Loopback and non-https links are
+ * refused with a specific reason callers turn into their own guidance.
+ */
+export function resolvePublicBaseUrl(raw: string): PublicBaseUrlResult {
+  let normalized: string;
+  try {
+    normalized = normalizePublicBaseUrl(raw);
+  } catch {
+    return { ok: false, reason: "unparseable" };
+  }
+  if (isLoopbackPublicUrl(normalized)) {
+    return { ok: false, reason: "loopback" };
+  }
+  if (new URL(normalized).protocol !== "https:") {
+    return { ok: false, reason: "non-https" };
+  }
+  return { ok: true, url: normalized };
+}
+
+/**
+ * The scannable pair URL: the challenge's verification URI with the device
+ * code carried in the fragment (`#device_code=…`), matching what the pair
+ * page reads on load. Fragments never reach the wire.
+ */
+export function buildRemoteWebPairingUrl(
+  challenge: Pick<
+    RemoteWebPairingChallengeResponse,
+    "verificationUri" | "deviceCode"
+  >,
+): string {
+  const url = new URL(challenge.verificationUri);
+  url.hash = new URLSearchParams({
+    device_code: challenge.deviceCode,
+  }).toString();
+  return url.toString();
+}


### PR DESCRIPTION
## Summary
- New backwards-compat gate (registry pattern, MIN_VERSION 0.10.0 — the release whose gateway first serves the pairing routes): the card renders nothing against older assistants instead of offering a button whose first POST fails
- web-remote-ingress precheck before minting, mirroring the CLI: flag off → enable guidance with zero network calls (the loopback routes succeed regardless of the flag, so an unchecked mint yields an unscannable QR)
- normalizePublicBaseUrl / resolvePublicBaseUrl / isLoopbackPublicUrl / buildRemoteWebPairingUrl extracted to @vellumai/service-contracts/remote-web-pairing; the CLI and the web card import one implementation (identical semantics verified before extraction), local duplicates deleted
- Tests: card suite grows to cover the version gate and flag-off path (18/18 web, 20/20 cli, cli tsc clean)

Addresses 3 of 4 Codex findings on #38801; the fourth (card tests failing in a standard run) did not reproduce — 5/5 pass in a fresh worktree, evidence on the thread.