### PR TITLE
fix(surfaces): harden ui_update merge for unknown types and tolerant fields

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-state-update.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-state-update.test.ts
@@ -247,3 +247,107 @@ describe("cleanup on dismiss", () => {
     expect(ctx.accumulatedSurfaceState.get("surface-2")).toEqual({ y: 2 });
   });
 });
+
+describe("ui_update preserves client-owned keys the daemon schema omits", () => {
+  test("a valid patch keeps unmodeled keys on the merged, sent, and stored data", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext({ sent });
+    // A document_preview whose stored data carries `surfaceId` — an unmodeled
+    // key read by the client renderer, not by the daemon schema.
+    ctx.surfaceState.set("doc-1", {
+      surfaceType: "document_preview",
+      data: {
+        title: "Notes",
+        surfaceId: "doc-real",
+        content: "# Heading",
+        mimeType: "text/markdown",
+      } as SurfaceData,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "doc-1",
+      data: { title: "Notes (edited)" },
+    });
+    expect(result.isError).toBe(false);
+
+    // Stored state keeps the unmodeled key and applies the patch.
+    expect(ctx.surfaceState.get("doc-1")?.data).toMatchObject({
+      title: "Notes (edited)",
+      surfaceId: "doc-real",
+    });
+
+    // The update sent to the client also carries it.
+    const update = sent.find((m) => m.type === "ui_surface_update");
+    expect(update).toBeDefined();
+    expect((update as { data: Record<string, unknown> }).data).toMatchObject({
+      title: "Notes (edited)",
+      surfaceId: "doc-real",
+    });
+  });
+});
+
+describe("ui_update on a restored unknown surface type", () => {
+  test("forwards the merge opaquely instead of storing garbage", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext({ sent });
+    // Restore preserves an unknown-but-non-empty surfaceType verbatim (a
+    // newer/custom client-rendered surface). safeParseSurfaceData has no schema
+    // for it — the update must forward the merge, not the type string.
+    ctx.surfaceState.set("future-1", {
+      surfaceType: "future_widget" as SurfaceType,
+      data: { title: "Widget", customField: 42 } as SurfaceData,
+    });
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "future-1",
+      data: { title: "Widget (edited)" },
+    });
+    expect(result.isError).toBe(false);
+
+    const stored = ctx.surfaceState.get("future-1");
+    expect(stored?.surfaceType as string).toBe("future_widget");
+    expect(stored?.data as Record<string, unknown>).toEqual({
+      title: "Widget (edited)",
+      customField: 42,
+    });
+
+    const update = sent.find((m) => m.type === "ui_surface_update");
+    expect(update).toBeDefined();
+    expect((update as { data: Record<string, unknown> }).data).toEqual({
+      title: "Widget (edited)",
+      customField: 42,
+    });
+  });
+});
+
+describe("ui_update normalizes modeled fields for known surface types", () => {
+  test("a malformed dynamic_page html patch is stored as its schema-coerced string", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext({ sent });
+    ctx.surfaceState.set("page-1", {
+      surfaceType: "dynamic_page",
+      data: { html: "<p>original</p>" } as SurfaceData,
+    });
+
+    // A malformed patch: `html` as a non-string. The tolerant schema
+    // (`z.string().catch("")`) accepts it, so the update must not revert — but
+    // the stored/sent value must be the coerced string, never the raw object,
+    // or later `truncateHtml(...).slice()` on the stored html would crash.
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: "page-1",
+      data: { html: { unexpected: "object" } },
+    });
+    expect(result.isError).toBe(false);
+
+    const storedHtml = (
+      ctx.surfaceState.get("page-1")?.data as { html: unknown }
+    ).html;
+    expect(typeof storedHtml).toBe("string");
+
+    const update = sent.find((m) => m.type === "ui_surface_update");
+    expect(update).toBeDefined();
+    expect(typeof (update as { data: { html: unknown } }).data.html).toBe(
+      "string",
+    );
+  });
+});

--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -509,6 +509,20 @@ export const MODEL_INVOKABLE_SURFACE_TYPES = SURFACE_TYPES.filter(
   (type) => !isDaemonInternalSurfaceType(type),
 );
 
+const SURFACE_TYPE_SET = new Set<string>(SURFACE_TYPES);
+
+/**
+ * Whether `type` is a surface type this daemon models (has a canonical schema
+ * for). Restore preserves an unknown-but-non-empty persisted `surfaceType`
+ * verbatim (a newer/custom client-rendered surface), so a runtime string can
+ * reach code that dispatches on the type; callers must gate on this before
+ * handing the type to `safeParseSurfaceData`, which has no schema for unknown
+ * types.
+ */
+export function isKnownSurfaceType(type: string): type is SurfaceType {
+  return SURFACE_TYPE_SET.has(type);
+}
+
 export type SurfaceData =
   | CardSurfaceData
   | ChoiceSurfaceData

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -8,6 +8,7 @@ import {
   coerceSurfaceDataRecord,
   DynamicPageSurfaceDataSchema,
   isDaemonInternalSurfaceType,
+  isKnownSurfaceType,
   MODEL_INVOKABLE_SURFACE_TYPES,
   normalizeCopyBlockShowData,
   OAuthConnectSurfaceDataSchema,
@@ -3250,19 +3251,38 @@ export async function surfaceProxyResolver(
         pushUndoState(ctx.surfaceUndoStacks, surfaceId, currentHtml);
       }
       const rawMerged = { ...stored.data, ...patch };
-      // Validate the merged data through the surface type's canonical schema
-      // so malformed patches (e.g. metadata as a string) are caught here
-      // instead of crashing the client's safeParse.
-      const parsed = safeParseSurfaceData(stored.surfaceType, rawMerged);
-      if (parsed !== undefined) {
-        mergedData = parsed;
+      if (!isKnownSurfaceType(stored.surfaceType)) {
+        // Restore preserves an unknown-but-non-empty persisted surfaceType
+        // verbatim (a newer/custom client-rendered surface). safeParseSurfaceData
+        // has no schema for it — it falls through to returning the type string
+        // rather than a data object — so forward the merge opaquely rather than
+        // storing that garbage, mirroring restore's verbatim handling.
+        mergedData = rawMerged as SurfaceData;
       } else {
-        log.warn(
-          { surfaceId, surfaceType: stored.surfaceType },
-          "ui_update patch produced invalid merged data; reverting to stored data",
-        );
-        mergedData =
-          safeParseSurfaceData(stored.surfaceType, stored.data) ?? stored.data;
+        // Validate the merged data through the surface type's canonical schema
+        // so malformed patches (e.g. metadata as a string) are caught here
+        // instead of crashing the client's safeParse. Keep unmodeled
+        // client-owned keys from the raw merge, but take the schema-NORMALIZED
+        // value for every modeled field: a tolerant field (dynamic_page `html`
+        // is `z.string().catch("")`, file_upload `acceptedTypes` coerces to
+        // `string[]`) accepts a malformed input and coerces it, and later daemon
+        // code (active-workspace injection's `truncateHtml`, undo-stack pushes)
+        // assumes the canonical shape — so storing the raw value would poison
+        // surfaceState. The parsed object holds only modeled keys, so spreading
+        // it over the raw merge normalizes those while preserving the
+        // client-owned ones. Only a failed parse reverts to the stored data.
+        const parsed = safeParseSurfaceData(stored.surfaceType, rawMerged);
+        if (parsed !== undefined) {
+          mergedData = { ...rawMerged, ...parsed } as SurfaceData;
+        } else {
+          log.warn(
+            { surfaceId, surfaceType: stored.surfaceType },
+            "ui_update patch produced invalid merged data; reverting to stored data",
+          );
+          mergedData =
+            safeParseSurfaceData(stored.surfaceType, stored.data) ??
+            stored.data;
+        }
       }
       stored.data = mergedData;
     } else {


### PR DESCRIPTION
## Prompt / plan

Two latent defects in the `ui_update` merge path, surfaced while reviewing the surface-cast refactor (#38786) but **pre-existing on `main`** — so they ship as their own fix first, and #38786 narrows back to a pure type refactor once this lands.

`ui_update` builds `rawMerged = { ...stored.data, ...patch }`, parses it through the stored surface type's canonical schema, then stores/sends the **parsed** output. That has two problems:

1. **Unknown surface type → stored garbage.** Restore preserves an unknown-but-non-empty persisted `surfaceType` verbatim (a newer/custom client-rendered surface — `(b.surfaceType ?? "dynamic_page") as SurfaceType`). `safeParseSurfaceData` has no schema for such a type and its `switch` falls through to returning the *type string*, which was then stored and sent as the surface `data`. (Under the #38786 refactor's mapped-registry `safeParseSurfaceData`, the same call instead throws — so this is also the root of that PR's reported crash.)

2. **Client-owned keys dropped on update.** The parsed output strips unmodeled keys — keys the client renderer reads but the daemon does not model (e.g. a surface's `surfaceId`, or legacy fields). So an update silently dropped them from the stored/served data, regressing display on the next read. This is the same class as the restore-stripping fix in #38800, but on the update path.

## User impact

| Scenario | Before (on `main`) | After (this PR) |
| --- | --- | --- |
| The assistant calls `ui_update` on a **custom / forward-compatible surface** whose type this daemon build doesn't model (e.g. a newer surface persisted before a downgrade, or a client-only surface kind) | The surface's `data` is overwritten with a meaningless internal string, so the card renders **blank or broken** after the update | The update is applied and the surface keeps rendering its real content |
| The assistant calls `ui_update` on a surface that carries **client-only fields** — data the app's renderer reads but the daemon doesn't model | Those fields are **silently dropped** by the update, so the surface **loses that content** on the next render / refresh / restart | The client-only fields survive the update; the surface's content stays intact |

Both cases are silent today — no error, just a surface that quietly loses content or renders wrong after an otherwise-normal update.

## Fix

- Add `isKnownSurfaceType(type): type is SurfaceType` to `@vellumai/assistant-api`.
- In the `ui_update` merge:
  - **Unknown type** → forward the merge opaquely (`mergedData = rawMerged`), mirroring restore's verbatim handling, instead of dispatching to a schema that doesn't exist.
  - **Known type** → store/send `{ ...rawMerged, ...parsed }`: keep unmodeled client-owned keys from the raw merge, but take the schema-**normalized** value for every modeled field. This preserves client-owned keys *and* keeps tolerant modeled fields canonical — `dynamic_page.html` (`z.string().catch("")`) and `file_upload.acceptedTypes` (coerced to `string[]`) can accept malformed input and coerce it, and later daemon code (active-workspace injection's `truncateHtml`, undo-stack pushes) assumes the canonical shape, so storing the raw value would poison `surfaceState`.

## Test plan

- `cd assistant && bunx tsc --noEmit` — clean.
- New regression tests in `conversation-surfaces-state-update.test.ts` (all pass in isolation):
  - `ui_update` preserves an unmodeled client-owned key on the merged/sent/stored data.
  - `ui_update` on a restored unknown surface type forwards the merge (not the type string).
  - `ui_update` normalizes a malformed `dynamic_page.html` patch to its schema-coerced string.
- ESLint + Prettier clean (pre-commit hook ran lint + typecheck on push).

## CLI verb checklist

No new routes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f