### PR TITLE
Simplify the voice-room first-run "Voice settings" view (JARVIS-1337)

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -159,8 +159,8 @@ describe("VoiceFirstRunCard", () => {
       fireEvent.click(getByText(SETTINGS_LINK));
 
       expect(dialogTitle()).toBe("Voice settings");
-      // Simplified to just the voice picker plus a pointer to Models & Services
-      // for the advanced/BYO config that used to crowd this view.
+      // The view is just the voice picker plus a pointer to Models & Services,
+      // where advanced/BYO provider and API-key config lives.
       expect(getByTestId("voice-list")).toBeTruthy();
       expect(getByText("Models & Services")).toBeTruthy();
       // The voice hot-applies, so there's no Save; and this is a view swap, not

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -2,9 +2,9 @@
  * Tests for `VoiceFirstRunCard`.
  *
  * The card is exercised in isolation: `onStart` is a spy, and the assistant
- * avatar / provider-form dependencies are stubbed so the card renders without
- * the React Query graph — they are chrome around the card's own behavior, and
- * each has its own tests.
+ * avatar / voice-list dependencies are stubbed so the card renders without the
+ * React Query graph — they are chrome around the card's own behavior, and each
+ * has its own tests.
  *
  * Load-bearing behavior:
  *   - the card renders on first run and does NOT start on its own,
@@ -16,11 +16,11 @@
  *   - the voice-settings detour is a VIEW of this one modal, not a modal
  *     stacked on it, and returns to the intro.
  */
-import { useEffect } from "react";
+import { type ReactNode } from "react";
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 
 // Stub the avatar hook so the card renders without the assistant-avatar React
 // Query graph — irrelevant to the card's preference behavior.
@@ -34,49 +34,20 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
   }),
 }));
 
-// The provider forms own the daemon config/credential graph and are covered by
-// the settings-page tests. Here they stand in as save handles: each publishes a
-// dirty flag and a `save` the card's single footer button has to drive, which
-// is what's under test.
-type StubFormProps = {
-  hideSaveButton?: boolean;
-  onSaveStateChange?: (handle: {
-    hasChanges: boolean;
-    saving: boolean;
-    save: () => Promise<boolean>;
-  }) => void;
-};
-
-/** Per-service stub behavior, set by each test before render. */
-const formState = {
-  stt: { dirty: false, saveOk: true },
-  tts: { dirty: false, saveOk: true },
-};
-const saveCalls: string[] = [];
-
-function makeStubForm(kind: "stt" | "tts") {
-  return function StubForm({ onSaveStateChange }: StubFormProps) {
-    const { dirty, saveOk } = formState[kind];
-    // Mirrors the real form: republish whenever the state it reports changes.
-    useEffect(() => {
-      onSaveStateChange?.({
-        hasChanges: dirty,
-        saving: false,
-        save: async () => {
-          saveCalls.push(kind);
-          return saveOk;
-        },
-      });
-    }, [onSaveStateChange, dirty, saveOk]);
-    return <div data-testid={`${kind}-form`} />;
-  };
-}
-
-mock.module("@/components/speech/stt-provider-form", () => ({
-  SttProviderForm: makeStubForm("stt"),
+// The voice list owns the daemon config graph and is covered by its own tests.
+// Here it stands in as a marker so the settings view renders without the React
+// Query graph — the card's own behavior (view swap, back, lock) is what's under
+// test, not the picker.
+mock.module("@/components/speech/voice-list", () => ({
+  VoiceList: () => <div data-testid="voice-list" />,
 }));
-mock.module("@/components/speech/tts-provider-form", () => ({
-  TtsProviderForm: makeStubForm("tts"),
+
+// The settings view links to Models & Services; give it a plain anchor so the
+// card renders without a Router.
+mock.module("react-router", () => ({
+  Link: ({ to, children }: { to: string; children: ReactNode }) => (
+    <a href={typeof to === "string" ? to : "#"}>{children}</a>
+  ),
 }));
 
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
@@ -105,9 +76,6 @@ beforeEach(() => {
     showAssistantTranscript: false,
     firstRunSeen: false,
   });
-  formState.stt = { dirty: false, saveOk: true };
-  formState.tts = { dirty: false, saveOk: true };
-  saveCalls.length = 0;
 });
 
 describe("VoiceFirstRunCard", () => {
@@ -184,22 +152,20 @@ describe("VoiceFirstRunCard", () => {
 
   describe("voice settings view", () => {
     test("the link opens the settings view in place — one dialog, no stack", () => {
-      const { getByText, queryByText, baseElement } = render(
+      const { getByText, getByTestId, queryByText, baseElement } = render(
         <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
       );
 
       fireEvent.click(getByText(SETTINGS_LINK));
 
       expect(dialogTitle()).toBe("Voice settings");
-      // Section copy matches Settings → Services so the two read as one.
-      expect(getByText("Text-to-Speech")).toBeTruthy();
-      expect(getByText("Configure how your assistant speaks")).toBeTruthy();
-      expect(getByText("Speech-to-Text")).toBeTruthy();
-      expect(
-        getByText("Configure how your assistant transcribes speech"),
-      ).toBeTruthy();
-      // The intro's forward action is gone — this is a view swap, not an
-      // overlay on top of the intro.
+      // Simplified to just the voice picker plus a pointer to Models & Services
+      // for the advanced/BYO config that used to crowd this view.
+      expect(getByTestId("voice-list")).toBeTruthy();
+      expect(getByText("Models & Services")).toBeTruthy();
+      // The voice hot-applies, so there's no Save; and this is a view swap, not
+      // an overlay — the intro's forward action is gone and there's one dialog.
+      expect(queryByText("Save")).toBeNull();
       expect(queryByText("Start talking")).toBeNull();
       expect(baseElement.querySelectorAll('[role="dialog"]').length).toBe(1);
     });
@@ -218,66 +184,9 @@ describe("VoiceFirstRunCard", () => {
       expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
     });
 
-    test("one Save commits both forms and lands back on Start talking", async () => {
-      formState.stt = { dirty: true, saveOk: true };
-      formState.tts = { dirty: true, saveOk: true };
-      const { getByText } = render(
-        <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
-      );
-
-      fireEvent.click(getByText(SETTINGS_LINK));
-      await act(async () => {
-        fireEvent.click(getByText("Save"));
-      });
-
-      expect(saveCalls.sort()).toEqual(["stt", "tts"]);
-      expect(getByText("Start talking")).toBeTruthy();
-    });
-
-    test("Save writes only the forms that changed", async () => {
-      formState.tts = { dirty: true, saveOk: true };
-      const { getByText } = render(
-        <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
-      );
-
-      fireEvent.click(getByText(SETTINGS_LINK));
-      await act(async () => {
-        fireEvent.click(getByText("Save"));
-      });
-
-      // Entering a TTS key must not re-write the untouched STT service.
-      expect(saveCalls).toEqual(["tts"]);
-    });
-
-    test("Save stays disabled until something changes", () => {
-      const { getByText } = render(
-        <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
-      );
-
-      fireEvent.click(getByText(SETTINGS_LINK));
-      expect((getByText("Save") as HTMLButtonElement).disabled).toBe(true);
-    });
-
-    test("a failed save keeps the user on the settings view", async () => {
-      // The typed key has to stay on screen with its failure toast, not
-      // vanish behind the intro.
-      formState.tts = { dirty: true, saveOk: false };
-      const { getByText, queryByText } = render(
-        <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
-      );
-
-      fireEvent.click(getByText(SETTINGS_LINK));
-      await act(async () => {
-        fireEvent.click(getByText("Save"));
-      });
-
-      expect(dialogTitle()).toBe("Voice settings");
-      expect(queryByText("Start talking")).toBeNull();
-    });
-
     test("the link is reachable under the iOS lock too", () => {
       // The lock removes cancels, not in-modal navigation — a locked card
-      // still has to let a BYOK user configure before the mic prompt.
+      // still has to let a user reach voice settings before the mic prompt.
       const { getByText, getByLabelText } = render(
         <VoiceFirstRunCard
           assistantId="asst_test"

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -1,17 +1,16 @@
-import { type ReactNode, useState } from "react";
+import { useState } from "react";
+import { Link } from "react-router";
 
 import { ArrowLeft, AudioLines, Captions, MicOff, Settings } from "lucide-react";
 
-import { cn } from "@vellumai/design-library";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
-import type { ProviderFormSaveHandle } from "@/components/service-form-controls";
-import { SttProviderForm } from "@/components/speech/stt-provider-form";
-import { TtsProviderForm } from "@/components/speech/tts-provider-form";
+import { VoiceList } from "@/components/speech/voice-list";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { routes } from "@/utils/routes";
 
 /**
  * One-time welcome card shown the first time a user enters voice mode, before
@@ -24,17 +23,19 @@ import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
  * before the user has ever experienced voice mode is the wrong moment. The card
  * just sets expectations and starts.
  *
- * The one exception is the voice settings behind the footer link: the speech
- * providers, the assistant's voice, and API keys for users running voice on
- * their own providers. It lives here because it gates whether voice works at
- * all. The label names a destination rather than an action — the defaults work
- * untouched, and a link reading like a task would imply setup is owed. Quiet by
- * design so it never competes with "Start talking".
+ * The one exception is the voice settings behind the footer link: the
+ * assistant's voice, the one thing most people come here to change. It hides
+ * itself for assistants on a bring-your-own provider, whose full config
+ * (providers, transcription, keys) lives in Settings → Models & Services — a
+ * quiet link points there. The label names a destination rather than an action:
+ * the defaults work untouched, and a link reading like a task would imply setup
+ * is owed. Quiet by design so it never competes with "Start talking".
  *
  * Those settings are a **view within this one modal**, not a modal stacked on
- * it: entering swaps the card's header, body, and footer, and a back arrow
- * returns to the intro. Width is held constant across views so navigating
- * doesn't resize the dialog under the cursor.
+ * it: entering swaps the card's header and body, and a back arrow returns to the
+ * intro. The voice hot-applies on the next reply, so there's no Save. Width is
+ * held constant across views so navigating doesn't resize the dialog under the
+ * cursor.
  *
  * The card does NOT persist `firstRunSeen` itself: dismissing it (Escape /
  * backdrop / ✕) is a plain cancel and must leave the first run un-consumed so
@@ -92,25 +93,6 @@ export function VoiceFirstRunCard({
 
   const [view, setView] = useState<FirstRunView>("intro");
   const backToIntro = () => setView("intro");
-
-  // One Save commits both provider forms. Each publishes its own state here;
-  // the footer button derives from the pair and only the dirty ones are
-  // written, so saving a key for one service doesn't touch the other.
-  const [sttSave, setSttSave] = useState<ProviderFormSaveHandle | null>(null);
-  const [ttsSave, setTtsSave] = useState<ProviderFormSaveHandle | null>(null);
-  const keysDirty = !!sttSave?.hasChanges || !!ttsSave?.hasChanges;
-  const keysSaving = !!sttSave?.saving || !!ttsSave?.saving;
-  const saveKeys = async () => {
-    const results = await Promise.all([
-      ttsSave?.hasChanges ? ttsSave.save() : Promise.resolve(true),
-      sttSave?.hasChanges ? sttSave.save() : Promise.resolve(true),
-    ]);
-    // Only leave on a clean save — a rejected key has to stay on screen with
-    // the failure toast, not vanish behind the intro.
-    if (results.every(Boolean)) {
-      backToIntro();
-    }
-  };
 
   return (
     <Modal.Root
@@ -236,90 +218,27 @@ export function VoiceFirstRunCard({
                 <Modal.Title className="leading-tight">Voice settings</Modal.Title>
               </div>
             </Modal.Header>
-            <Modal.Body className="space-y-6">
-              {/* The same forms Settings → AI renders, minus that page's card
-                  chrome and its per-card Save — the footer commits both. Copy
-                  matches Settings → Services so the two read as one surface. */}
-              <ProviderSection
-                title="Text-to-Speech"
-                subtitle="Configure how your assistant speaks"
-              >
-                <TtsProviderForm
-                  assistantId={assistantId ?? undefined}
-                  hideSaveButton
-                  hideCredentialsGuide
-                  onSaveStateChange={setTtsSave}
-                />
-              </ProviderSection>
-              <ProviderSection
-                title="Speech-to-Text"
-                subtitle="Configure how your assistant transcribes speech"
-                divided
-              >
-                <SttProviderForm
-                  assistantId={assistantId ?? undefined}
-                  hideSaveButton
-                  hideCredentialsGuide
-                  onSaveStateChange={setSttSave}
-                />
-              </ProviderSection>
+            <Modal.Body className="space-y-4">
+              {/* Just the voice — the one thing most people come here to change,
+                  and it hot-applies on the next reply (no Save). The list hides
+                  itself for assistants on a bring-your-own provider, leaving the
+                  note below as their path. */}
+              <VoiceList assistantId={assistantId} showSource />
+              <p className="text-label-small-default text-[var(--content-tertiary)]">
+                Speech providers, transcription, and API keys live in{" "}
+                <Link
+                  to={routes.settings.ai}
+                  className="text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 hover:text-[var(--content-default)]"
+                >
+                  Models &amp; Services
+                </Link>
+                .
+              </p>
             </Modal.Body>
-            <Modal.Footer>
-              <Button
-                variant="primary"
-                onClick={saveKeys}
-                disabled={!keysDirty || keysSaving}
-              >
-                {keysSaving ? "Saving…" : "Save"}
-              </Button>
-            </Modal.Footer>
           </>
         )}
       </Modal.Content>
     </Modal.Root>
-  );
-}
-
-/**
- * One titled provider block in the settings view — the modal-scale echo of a
- * Settings → Services card, sharing its title and subtitle copy so the two
- * surfaces read as one. The subtitle sits on the title's line behind a rule,
- * keeping each block one row tall so both services fit without scrolling.
- * `divided` rules off the block from the one above it.
- */
-function ProviderSection({
-  title,
-  subtitle,
-  divided = false,
-  children,
-}: {
-  title: string;
-  subtitle: string;
-  divided?: boolean;
-  children: ReactNode;
-}) {
-  return (
-    <section
-      className={cn(
-        "space-y-3",
-        divided && "border-t border-[var(--border-subtle)] pt-5",
-      )}
-    >
-      {/* Wraps rather than truncates: the subtitle dropping to its own line on
-          a narrow viewport is better than losing the end of the sentence. */}
-      <div className="flex flex-wrap items-baseline gap-x-2">
-        <h3 className="text-body-medium-default text-[var(--content-emphasised)]">
-          {title}
-        </h3>
-        <span aria-hidden className="text-[var(--content-quiet)]">
-          |
-        </span>
-        <p className="text-label-small-default text-[var(--content-tertiary)]">
-          {subtitle}
-        </p>
-      </div>
-      {children}
-    </section>
   );
 }
 


### PR DESCRIPTION
Builds on #38804 (Voice IA restructure + unified voice selector).

The first-run card's **Voice settings** sub-view embedded the full Text-to-Speech **and** Speech-to-Text provider forms — provider dropdowns, API keys, a Save. ~p95 users are on managed voice and only want to change the voice; the rest was noise before they'd even heard voice mode.

## Change
- Replace the two provider forms with the shared **voice list** (grouped by accent, per-row audio preview, instant hot-apply — no Save).
- The list hides itself for assistants on a bring-your-own provider; a quiet **Models & Services** link carries advanced/BYO users to the full provider, transcription, and API-key config that used to crowd this view.
- Removes the per-card Save machinery and the `ProviderSection` helper from the card.

## Testing
- `bun run typecheck` + `bun run lint` clean.
- Reworked `voice-first-run-card.test.tsx` for the simplified view (view swap, back, iOS-lock reachability); the picker itself is covered by its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)