### PR TITLE
Collapse voice-triage-escalate into voice-mode

### DIFF
--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -1,8 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
-import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
-import { clearFeatureFlagOverridesCache } from "../../config/assistant-feature-flags.js";
-import type { AssistantConfig } from "../../config/schema.js";
 import {
   capEscalationBridge,
   classifyFrontDoorLeading,
@@ -14,20 +11,10 @@ import {
   frontDoorDecisionRule,
   HOLD_VERDICT_TOKEN,
   isEscalationBridgeComplete,
-  isVoiceTriageEscalateEnabled,
   MAX_ESCALATION_BRIDGE_CHARS,
   needsFallbackBridge,
   spokenBridgeText,
-  VOICE_TRIAGE_ESCALATE_FLAG,
 } from "../voice-triage-escalate.js";
-
-// The gate ignores the config arg (flags resolve from the override cache +
-// bundled registry), so a bare cast is sufficient.
-const CONFIG = {} as AssistantConfig;
-
-afterEach(() => {
-  clearFeatureFlagOverridesCache();
-});
 
 describe("frontDoorCapabilityDigest", () => {
   test("names the escalated leg's tools and demands escalation for them", () => {
@@ -51,23 +38,6 @@ describe("frontDoorCapabilityDigest", () => {
     });
     expect(withDigest.startsWith(bare)).toBe(true);
     expect(withDigest).toContain("calendar_read");
-  });
-});
-
-describe("isVoiceTriageEscalateEnabled", () => {
-  test("is off by default (registry defaultEnabled: false)", () => {
-    clearFeatureFlagOverridesCache();
-    expect(isVoiceTriageEscalateEnabled(CONFIG)).toBe(false);
-  });
-
-  test("is on when the flag override is set", () => {
-    setOverridesForTesting({ [VOICE_TRIAGE_ESCALATE_FLAG]: true });
-    expect(isVoiceTriageEscalateEnabled(CONFIG)).toBe(true);
-  });
-
-  test("is off when the flag override is explicitly false", () => {
-    setOverridesForTesting({ [VOICE_TRIAGE_ESCALATE_FLAG]: false });
-    expect(isVoiceTriageEscalateEnabled(CONFIG)).toBe(false);
   });
 });
 
@@ -345,10 +315,9 @@ describe("escalation continuation content", () => {
 });
 
 // This module is the surface-agnostic escalation *policy* (profiles, prompt
-// rules, the verdict classifier, the bridge cap/fallback decision, the flag
-// gate). The two-leg *routing* runs on the in-app Voice Mode surface
-// (LiveVoiceSession), gated behind both the voice-mode and
-// voice-triage-escalate flags — see
+// rules, the verdict classifier, the bridge cap/fallback decision). The
+// two-leg *routing* runs on the in-app Voice Mode surface (LiveVoiceSession),
+// gated behind the single voice-mode flag — see
 // live-voice/__tests__/live-voice-triage-escalate.test.ts for the orchestration
 // coverage (flag gating, verdict-first hand-off, token suppression, fallback
 // bridge, barge-in). What remains for the manual cli-testing flow is true

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -466,7 +466,7 @@ function buildVoiceCallControlPrompt(opts: {
     `12. ${VOICE_NO_SETUP_FLOWS_RULE}`,
   );
 
-  // Triage-and-escalate routing rules (voice-triage-escalate flag). The
+  // Triage-and-escalate routing rules (gated by the voice-mode flag). The
   // front-door leg decides and may hand off; the escalated leg continues the
   // answer after a holding phrase was already spoken.
   if (opts.routingLeg === "front-door") {

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -21,14 +21,12 @@
  * trusting the model to stop. Every infra failure fails open to a normal
  * committed answer turn.
  *
- * This module owns the routing policy in one place: the feature gates, the
- * profile key, the leg-specific prompt rules, the leading-token classifier,
- * and the bridge cap/fallback policy.
+ * This module owns the routing policy in one place: the profile key, the
+ * leg-specific prompt rules, the leading-token classifier, and the bridge
+ * cap/fallback policy. The gate itself is the `voice-mode` flag, read by the
+ * LiveVoiceSession that drives the routing.
  */
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
-import { getConfig } from "../config/loader.js";
-import type { AssistantConfig } from "../config/schema.js";
 import {
   ESCALATE_VERDICT_TOKEN,
   HOLD_VERDICT_TOKEN,
@@ -36,17 +34,6 @@ import {
 } from "./voice-control-protocol.js";
 
 export { ESCALATE_VERDICT_TOKEN, HOLD_VERDICT_TOKEN };
-
-/**
- * Feature-flag key gating the whole behavior: a fast model fronts each
- * live-voice turn, and endpointing rides that same leg. At each pause the
- * leg is dispatched speculatively and its leading tokens carry the full
- * verdict — {@link HOLD_VERDICT_TOKEN} (mid-thought, keep listening),
- * {@link ESCALATE_VERDICT_TOKEN} plus a spoken bridge, or the answer
- * itself. Off by default; when off, live voice runs the single-leg path
- * with the separate endpoint decider.
- */
-export const VOICE_TRIAGE_ESCALATE_FLAG = "voice-triage-escalate";
 
 // The fast model fronting every turn is pinned by the `voiceFrontDoor` call
 // site (see config/call-site-defaults.ts) — no per-turn profile override.
@@ -199,16 +186,6 @@ export function classifyFrontDoorLeading(
  */
 export const ESCALATION_CONTINUATION_CONTENT =
   "(You just told the caller you needed a moment to think. Now give them your full, careful answer to their previous question — do not repeat the holding phrase.)";
-
-/**
- * Whether triage-and-escalate routing is active for this workspace.
- * When false, every voice turn behaves exactly as before.
- */
-export function isVoiceTriageEscalateEnabled(
-  config: AssistantConfig = getConfig(),
-): boolean {
-  return isAssistantFeatureFlagEnabled(VOICE_TRIAGE_ESCALATE_FLAG, config);
-}
 
 /**
  * Compact, registry-derived digest of the tools the ESCALATED leg can use.

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -6,7 +6,6 @@ import type {
   VoiceTurnCallbacks,
   VoiceTurnOptions,
 } from "../../calls/voice-session-bridge.js";
-import { VOICE_TRIAGE_ESCALATE_FLAG } from "../../calls/voice-triage-escalate.js";
 import { clearFeatureFlagOverridesCache } from "../../config/assistant-feature-flags.js";
 import type {
   LiveVoiceFrontModelConfig,
@@ -257,7 +256,6 @@ describe("LiveVoiceSession progress narration", () => {
   test("the escalated leg re-arms idle narration into post-bridge dead air", async () => {
     setOverridesForTesting({
       "voice-mode": true,
-      [VOICE_TRIAGE_ESCALATE_FLAG]: true,
     });
     try {
       const generateProgressText = mock(

--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -5,7 +5,6 @@ import type { VoiceTurnOptions } from "../../calls/voice-session-bridge.js";
 import {
   ESCALATION_CONTINUATION_CONTENT,
   FALLBACK_ESCALATION_BRIDGE,
-  VOICE_TRIAGE_ESCALATE_FLAG,
 } from "../../calls/voice-triage-escalate.js";
 import { clearFeatureFlagOverridesCache } from "../../config/assistant-feature-flags.js";
 import type {
@@ -154,10 +153,9 @@ function spokenText(frames: LiveVoiceServerFrame[]): string {
     .join("");
 }
 
-function enableBothFlags(): void {
+function enableVoiceMode(): void {
   setOverridesForTesting({
     [VOICE_MODE_FLAG]: true,
-    [VOICE_TRIAGE_ESCALATE_FLAG]: true,
   });
 }
 
@@ -182,8 +180,8 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(spokenText(frames)).toBe("A simple reply.");
   });
 
-  test("both flags on, simple turn: only the fast front-door leg runs", async () => {
-    enableBothFlags();
+  test("voice-mode on, simple turn: only the fast front-door leg runs", async () => {
+    enableVoiceMode();
     const { starter } = scriptedStartVoiceTurn({
       frontDoor: ["Sure, it's Tuesday."],
     });
@@ -200,8 +198,8 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(spokenText(frames)).toBe("Sure, it's Tuesday.");
   });
 
-  test("both flags on, tricky turn: the escalate verdict hands off to a second quality leg", async () => {
-    enableBothFlags();
+  test("voice-mode on, tricky turn: the escalate verdict hands off to a second quality leg", async () => {
+    enableVoiceMode();
     const { starter } = scriptedStartVoiceTurn({
       frontDoor: ["[1] ", "Let me think about that."],
       escalated: ["The detailed answer is 42."],
@@ -225,7 +223,7 @@ describe("live-voice triage-and-escalate routing", () => {
   });
 
   test("the verdict token and any text past the bridge cap never reach the transcript", async () => {
-    enableBothFlags();
+    enableVoiceMode();
     const { starter } = scriptedStartVoiceTurn({
       frontDoor: [
         "[1] Let me think about that.",
@@ -247,7 +245,7 @@ describe("live-voice triage-and-escalate routing", () => {
   });
 
   test("a verdict token split across deltas is still detected and suppressed", async () => {
-    enableBothFlags();
+    enableVoiceMode();
     const { starter } = scriptedStartVoiceTurn({
       frontDoor: ["[", "1]", " One moment.", " leftover past the cap"],
       escalated: ["Answer."],
@@ -266,7 +264,7 @@ describe("live-voice triage-and-escalate routing", () => {
   });
 
   test("a bridge with no sentence terminator hands off at the leg's completion", async () => {
-    enableBothFlags();
+    enableVoiceMode();
     const { starter } = scriptedStartVoiceTurn({
       frontDoor: ["[1] Give me a moment"],
       escalated: ["Answer."],
@@ -284,7 +282,7 @@ describe("live-voice triage-and-escalate routing", () => {
   });
 
   test("the escalated leg receives the front-door leg's actual spoken bridge", async () => {
-    enableBothFlags();
+    enableVoiceMode();
     const { starter } = scriptedStartVoiceTurn({
       frontDoor: ["[1] Let me check your calendar.", " ignored tail"],
       escalated: ["You have three connections."],
@@ -302,7 +300,7 @@ describe("live-voice triage-and-escalate routing", () => {
   });
 
   test("a bare escalate verdict with no holding phrase still escalates (fallback bridge)", async () => {
-    enableBothFlags();
+    enableVoiceMode();
     const { starter } = scriptedStartVoiceTurn({
       frontDoor: ["[1]"],
       escalated: ["The thorough answer."],
@@ -327,39 +325,26 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(spokenText(frames)).not.toContain(FALLBACK_ESCALATION_BRIDGE);
   });
 
-  test("gating requires BOTH flags: voice-triage-escalate alone does not escalate", async () => {
-    setOverridesForTesting({ [VOICE_TRIAGE_ESCALATE_FLAG]: true });
-    const { starter } = scriptedStartVoiceTurn({
-      frontDoor: ["Let me think."],
-    });
-    const { frames, session } = createHarness(starter);
-
-    await driveTurn(session);
-    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
-
-    // No front-door profile, no escalation — the single leg is the default path.
-    expect(starter).toHaveBeenCalledTimes(1);
-    expect(starter.mock.calls[0]?.[0]?.overrideProfile).toBeUndefined();
-    expect(starter.mock.calls[0]?.[0]?.routingLeg).toBeUndefined();
-  });
-
-  test("gating requires BOTH flags: voice-mode alone does not escalate", async () => {
+  test("single-flag gating: voice-mode alone routes through the front door", async () => {
     setOverridesForTesting({ [VOICE_MODE_FLAG]: true });
     const { starter } = scriptedStartVoiceTurn({
-      frontDoor: ["Let me think."],
+      frontDoor: ["[1] ", "Let me think about that."],
+      escalated: ["The detailed answer is 42."],
     });
     const { frames, session } = createHarness(starter);
 
     await driveTurn(session);
+    await waitFor(() => starter.mock.calls.length >= 2);
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
 
-    expect(starter).toHaveBeenCalledTimes(1);
-    expect(starter.mock.calls[0]?.[0]?.overrideProfile).toBeUndefined();
-    expect(starter.mock.calls[0]?.[0]?.routingLeg).toBeUndefined();
+    // voice-mode alone now activates the front door and its escalation hand-off.
+    expect(starter).toHaveBeenCalledTimes(2);
+    expect(starter.mock.calls[0]?.[0]?.routingLeg).toBe("front-door");
+    expect(starter.mock.calls[1]?.[0]?.routingLeg).toBe("escalated");
   });
 
   test("barge-in during the escalated leg aborts it", async () => {
-    enableBothFlags();
+    enableVoiceMode();
     const { starter, escalatedAbort } = scriptedStartVoiceTurn({
       frontDoor: ["[1] ", "Let me think about that."],
       holdEscalated: true,

--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -337,7 +337,7 @@ describe("live-voice triage-and-escalate routing", () => {
     await waitFor(() => starter.mock.calls.length >= 2);
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
 
-    // voice-mode alone now activates the front door and its escalation hand-off.
+    // voice-mode alone activates the front door and its escalation hand-off.
     expect(starter).toHaveBeenCalledTimes(2);
     expect(starter.mock.calls[0]?.[0]?.routingLeg).toBe("front-door");
     expect(starter.mock.calls[1]?.[0]?.routingLeg).toBe("escalated");

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -5,10 +5,7 @@ import type {
   VoiceTurnCallbacks,
   VoiceTurnOptions,
 } from "../../calls/voice-session-bridge.js";
-import {
-  FALLBACK_ESCALATION_BRIDGE,
-  VOICE_TRIAGE_ESCALATE_FLAG,
-} from "../../calls/voice-triage-escalate.js";
+import { FALLBACK_ESCALATION_BRIDGE } from "../../calls/voice-triage-escalate.js";
 import {
   clearCachedOverrides,
   setCachedOverrides,
@@ -778,7 +775,6 @@ describe("LiveVoiceSession spoken ack", () => {
     setCachedOverrides(
       {
         "voice-mode": true,
-        [VOICE_TRIAGE_ESCALATE_FLAG]: true,
       },
       { fromGateway: true },
     );

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -3074,7 +3074,6 @@ describe("LiveVoiceSession unified front-door endpointing", () => {
     setCachedOverrides(
       {
         "voice-mode": true,
-        "voice-triage-escalate": true,
       },
       { fromGateway: true },
     );

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -27,7 +27,6 @@ import {
   ESCALATION_CONTINUATION_CONTENT,
   FALLBACK_ESCALATION_BRIDGE,
   isEscalationBridgeComplete,
-  isVoiceTriageEscalateEnabled,
   MIN_SPOKEN_BRIDGE_CHARS,
   type VoiceRoutingLeg,
 } from "../calls/voice-triage-escalate.js";
@@ -1759,18 +1758,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   /**
-   * Whether front-door routing is active: the voice-mode surface flag and
-   * the triage-escalate routing flag both on. Governs both halves of the
-   * unified front door — the speculative leg that decides the endpoint, and
-   * the escalation hand-off — so the two can never disagree. The
-   * decider-based hold path runs only when this is false.
+   * Whether front-door routing is active: the single `voice-mode` flag.
+   * Governs both halves of the unified front door — the speculative leg that
+   * decides the endpoint, and the escalation hand-off — so the two can never
+   * disagree. The decider-based hold path (`decideEndpoint`) runs as the
+   * flag-off fallback, so endpointing stays model-decided either way.
    */
   private frontDoorRoutingActive(config?: AssistantConfig): boolean {
     const cfg = config ?? getConfig();
-    return (
-      isAssistantFeatureFlagEnabled("voice-mode", cfg) &&
-      isVoiceTriageEscalateEnabled(cfg)
-    );
+    return isAssistantFeatureFlagEnabled("voice-mode", cfg);
   }
 
   /**
@@ -2661,10 +2657,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.armProgressIdleTimer(activeTurn);
     }
 
-    // Triage-and-escalate (Voice Mode): active only when BOTH the voice-mode
-    // surface flag and the voice-triage-escalate routing flag are on. A
-    // live-voice session already implies voice-mode client-side; the explicit
-    // check keeps the "gated behind both flags" contract true server-side.
+    // Triage-and-escalate (Voice Mode): active whenever the `voice-mode` flag
+    // is on. A live-voice session already implies voice-mode client-side; the
+    // explicit server-side check keeps the gate honest when the daemon's flag
+    // copy lags (it falls back to the decider-based hold path until it lands).
     const escalateEnabled = this.frontDoorRoutingActive(cfg);
 
     // Front-door leg: with routing on, a fast model fronts the turn (the

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -117,14 +117,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "voice-triage-escalate",
-      "scope": "assistant",
-      "key": "voice-triage-escalate",
-      "label": "Voice Triage & Escalate",
-      "description": "Front each live-voice turn with a fast model that answers simple turns and escalates tricky ones to the quality model, cutting perceived latency. The same leg decides the endpoint: its first token holds a mid-thought pause, escalates, or begins the answer, replacing the separate endpoint-decider call",
-      "defaultEnabled": false
-    },
-    {
       "id": "voice-duplex-handoff",
       "scope": "assistant",
       "key": "voice-duplex-handoff",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -117,14 +117,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "voice-triage-escalate",
-      "scope": "assistant",
-      "key": "voice-triage-escalate",
-      "label": "Voice Triage & Escalate",
-      "description": "Front each live-voice turn with a fast model that answers simple turns and escalates tricky ones to the quality model, cutting perceived latency. The same leg decides the endpoint: its first token holds a mid-thought pause, escalates, or begins the answer, replacing the separate endpoint-decider call",
-      "defaultEnabled": false
-    },
-    {
       "id": "voice-duplex-handoff",
       "scope": "assistant",
       "key": "voice-duplex-handoff",


### PR DESCRIPTION
Step 2 of folding every voice feature flag into `voice-mode` so Friday's release is a single on/off switch. **Flag collapse only — no behavior deletion.**

Follows #38748 (deleted `voice-unified-front-door`) and #38760 (front-door decision-rule fix).

## What changed
- Delete the `voice-triage-escalate` flag key, the `isVoiceTriageEscalateEnabled` predicate, and its registry entry (re-ran `bun run meta/sync-bundled-copies.ts`).
- Reduce `frontDoorRoutingActive()` in `live-voice-session.ts` to a single `voice-mode` read — the daemon's one front-door gate.
- Update the affected tests to single-flag gating (`enableBothFlags` → `enableVoiceMode`; the two "requires BOTH flags" tests collapse into one "voice-mode alone routes through the front door").

## Deliberately kept
`decideEndpoint`, `maybeHoldUtteranceOpen`, `decideUtteranceHold`, and the `else` branch at `live-voice-session.ts:1641` stay as the **flags-off fallback**. `voice-mode` on → the front door decides the endpoint; `voice-mode` off (or a stale daemon flag copy) → the decider decides it. Endpointing stays model-decided in every state, which is the hard requirement. Removing `decideEndpoint` entirely is a deferred post-bake pass.

## Verification
- `bun run typecheck` clean.
- All six affected test files pass: `voice-triage-escalate` (35), `live-voice-triage-escalate` (10), `live-voice-progress` (16), `live-voice-tts-session` (27), `live-voice-vad` (75), `voice-session-bridge` (44).

## Follow-ups (not in this PR)
- Collapse `voice-duplex-handoff` into `voice-mode`.
- Cosmetic platform terraform: the `voice-triage-escalate` LD flag description still references the deleted unified flag / "phone-call turns."

🤖 Generated with [Claude Code](https://claude.com/claude-code)