### PR TITLE
feat(billing): open the provisioning takeover after tier upgrades on the billing page

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -94,9 +94,19 @@ mock.module("@/hooks/use-is-org-ready", () => ({
 mock.module(
     "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal",
     () => ({
-        BillingOnboardingModal: ({ open }: { open: boolean }) => (
+        BillingOnboardingModal: ({
+            open,
+            mode,
+        }: {
+            open: boolean;
+            mode?: "checkout" | "resize";
+        }) => (
             <div
-                data-testid="onboarding-modal"
+                data-testid={
+                    mode === "resize"
+                        ? "resize-onboarding-modal"
+                        : "onboarding-modal"
+                }
                 data-open={open ? "true" : "false"}
             />
         ),
@@ -126,13 +136,12 @@ mock.module("@/domains/settings/components/invoices-table", () => ({
     InvoicesTable: () => null,
 }));
 mock.module("@/domains/settings/components/plan-card", () => ({
-    PlanCard: () => null,
+    PlanCard: ({ onTierUpgraded }: { onTierUpgraded?: () => void }) => (
+        <button data-testid="plan-card-tier-upgraded" onClick={onTierUpgraded} />
+    ),
 }));
 mock.module("@/domains/settings/components/referral-panel", () => ({
     ReferralPanel: () => null,
-}));
-mock.module("@/domains/settings/components/tier-upgrade-resize-modal", () => ({
-    TierUpgradeResizeModal: () => null,
 }));
 
 const { BillingPage } = await import("./billing-page");
@@ -223,6 +232,39 @@ describe("BillingTab ?pro_onboarding param", () => {
             expect(
                 getByTestId("onboarding-modal").getAttribute("data-open"),
             ).toBe("true"),
+        );
+        // The checkout instance opens; the dedicated resize instance stays inert.
+        expect(
+            getByTestId("resize-onboarding-modal").getAttribute("data-open"),
+        ).toBe("false");
+        expect(getByTestId("loc").textContent).toBe(
+            "/assistant/settings/usage?tab=billing",
+        );
+    });
+});
+
+describe("BillingTab tier-upgrade resize takeover", () => {
+    test("opens the resize instance on tier upgrade without touching the URL or the checkout instance", async () => {
+        const { getByTestId } = renderPage();
+
+        await waitFor(() =>
+            expect(getByTestId("resize-onboarding-modal")).toBeTruthy(),
+        );
+        expect(
+            getByTestId("resize-onboarding-modal").getAttribute("data-open"),
+        ).toBe("false");
+
+        fireEvent.click(getByTestId("plan-card-tier-upgraded"));
+
+        await waitFor(() =>
+            expect(
+                getByTestId("resize-onboarding-modal").getAttribute("data-open"),
+            ).toBe("true"),
+        );
+        // The checkout instance is untouched and the resize flow leaves the URL
+        // params exactly as they were.
+        expect(getByTestId("onboarding-modal").getAttribute("data-open")).toBe(
+            "false",
         );
         expect(getByTestId("loc").textContent).toBe(
             "/assistant/settings/usage?tab=billing",

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -18,7 +18,6 @@ import { GracePeriodBanner } from "@/domains/settings/components/grace-period-ba
 import { InvoicesTable } from "@/domains/settings/components/invoices-table";
 import { PlanCard } from "@/domains/settings/components/plan-card";
 import { ReferralPanel } from "@/domains/settings/components/referral-panel";
-import { TierUpgradeResizeModal } from "@/domains/settings/components/tier-upgrade-resize-modal";
 import { useAssistantDomains } from "@/domains/settings/billing/pro-onboarding/use-assistant-domains";
 import {
     organizationsBillingSubscriptionOnboardingRetrieveOptions,
@@ -249,7 +248,8 @@ function BillingTab() {
                 />
             )}
             {showPlanManagement && (
-                <TierUpgradeResizeModal
+                <BillingOnboardingModal
+                    mode="resize"
                     open={resizeModalOpen}
                     onClose={() => setResizeModalOpen(false)}
                 />


### PR DESCRIPTION
## Summary
- Replace billing-page's TierUpgradeResizeModal mount with a dedicated second BillingOnboardingModal instance in resize mode (observe-only)
- Closing the resize takeover never touches URL params; the checkout instance and its session_id-stripping are unchanged
- Update billing-page tests: mode-keyed modal stub, PlanCard callback, tier-upgrade + checkout regression coverage

Part of plan: resize-takeover-on-plan-change.md (PR 3 of 4)