### PR TITLE
feat(billing): open the provisioning takeover after in-place plan changes on the plans page

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -116,11 +116,24 @@ mock.module("@/utils/use-bundled-avatar-components", () => ({
 }));
 
 // Stand in for the provisioning takeover so a Pro tier change can assert it was
-// revealed without driving its own resize queries.
-mock.module("@/domains/settings/components/tier-upgrade-resize-modal", () => ({
-  TierUpgradeResizeModal: ({ open }: { open: boolean }) =>
-    open ? <div data-testid="resize-takeover" /> : null,
-}));
+// revealed in resize mode without driving its own provisioning polls. The full
+// loading → "You're all set!" flow is owned by
+// billing-onboarding-modal.test.tsx's resize-mode suite (PR 1).
+mock.module(
+  "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal",
+  () => ({
+    BillingOnboardingModal: ({
+      open,
+      mode,
+    }: {
+      open: boolean;
+      mode?: string;
+    }) =>
+      open ? (
+        <div data-testid="resize-takeover" data-mode={mode ?? "checkout"} />
+      ) : null,
+  }),
+);
 
 const { PlansPage } = await import("./plans-page");
 
@@ -605,7 +618,8 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     expect(storageTierCall).toBeNull();
     expect(creditTierCall).toBeNull();
     // Baseline → medium is an upgrade, so the resize takeover opens.
-    await findByTestId("resize-takeover");
+    const takeover = await findByTestId("resize-takeover");
+    expect(takeover.getAttribute("data-mode")).toBe("resize");
   });
 
   test("Continue dispatches only the changed tiers and opens the resize takeover", async () => {
@@ -627,7 +641,8 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     expect(storageTierCall).toBeNull();
 
     // A machine change resizes the assistant, so the takeover opens.
-    await findByTestId("resize-takeover");
+    const takeover = await findByTestId("resize-takeover");
+    expect(takeover.getAttribute("data-mode")).toBe("resize");
     // The change-tier path never touches the checkout endpoint.
     expect(upgradeCall).toBeNull();
     expect(openedUrl).toBeNull();

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -118,7 +118,7 @@ mock.module("@/utils/use-bundled-avatar-components", () => ({
 // Stand in for the provisioning takeover so a Pro tier change can assert it was
 // revealed in resize mode without driving its own provisioning polls. The full
 // loading → "You're all set!" flow is owned by
-// billing-onboarding-modal.test.tsx's resize-mode suite (PR 1).
+// billing-onboarding-modal.test.tsx's resize-mode suite.
 mock.module(
   "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal",
   () => ({

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -151,7 +151,7 @@ mock.module("@/utils/use-bundled-avatar-components", () => ({
 // Stand in for the provisioning takeover so the test can assert it was
 // revealed in resize mode without driving its own provisioning polls.
 // The full loading → "You're all set!" flow is owned by
-// billing-onboarding-modal.test.tsx's resize-mode suite (PR 1).
+// billing-onboarding-modal.test.tsx's resize-mode suite.
 mock.module(
   "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal",
   () => ({

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -148,12 +148,25 @@ mock.module("@/utils/use-bundled-avatar-components", () => ({
   useBundledAvatarComponents: () => null,
 }));
 
-// Stand in for the provisioning takeover so the test can assert it was revealed
-// without driving its own resize queries.
-mock.module("@/domains/settings/components/tier-upgrade-resize-modal", () => ({
-  TierUpgradeResizeModal: ({ open }: { open: boolean }) =>
-    open ? <div data-testid="resize-takeover" /> : null,
-}));
+// Stand in for the provisioning takeover so the test can assert it was
+// revealed in resize mode without driving its own provisioning polls.
+// The full loading → "You're all set!" flow is owned by
+// billing-onboarding-modal.test.tsx's resize-mode suite (PR 1).
+mock.module(
+  "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal",
+  () => ({
+    BillingOnboardingModal: ({
+      open,
+      mode,
+    }: {
+      open: boolean;
+      mode?: string;
+    }) =>
+      open ? (
+        <div data-testid="resize-takeover" data-mode={mode ?? "checkout"} />
+      ) : null,
+  }),
+);
 
 // Capture success toasts so the downgrade path can assert its confirmation
 // message; keep the real module's other methods (error, etc.) intact.
@@ -556,7 +569,8 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     await waitFor(() => expect(changePackageCall).not.toBeNull());
     expect(changePackageCall!.body).toEqual({ package: "ultra" });
 
-    await findByTestId("resize-takeover");
+    const takeover = await findByTestId("resize-takeover");
+    expect(takeover.getAttribute("data-mode")).toBe("resize");
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
   });
 
@@ -730,7 +744,8 @@ describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
 
     await waitFor(() => expect(changePackageCall).not.toBeNull());
     expect(changePackageCall!.body).toEqual({ package: "mighty" });
-    await findByTestId("resize-takeover");
+    const takeover = await findByTestId("resize-takeover");
+    expect(takeover.getAttribute("data-mode")).toBe("resize");
     expect(upgradeCall).toBeNull();
   });
 
@@ -902,7 +917,8 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
 
     // A machine change resizes the assistant, so the takeover opens; checkout
     // (which no-ops for active Pro) is never touched.
-    await findByTestId("resize-takeover");
+    const takeover = await findByTestId("resize-takeover");
+    expect(takeover.getAttribute("data-mode")).toBe("resize");
     expect(upgradeCall).toBeNull();
   });
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -23,6 +23,7 @@ import {
   downgradeLabel,
   getPlanTierCopy,
 } from "@/domains/settings/billing/plans/plans-copy";
+import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
 import { useChangeTiers } from "@/domains/settings/billing/use-change-tiers";
 import { useCheckoutDismissRefresh } from "@/domains/settings/billing/use-checkout-dismiss-refresh";
@@ -30,7 +31,6 @@ import {
   extractMutationError,
   isPackageSwitchEligible,
 } from "@/domains/settings/components/adjust-plan-utils";
-import { TierUpgradeResizeModal } from "@/domains/settings/components/tier-upgrade-resize-modal";
 import { formatDollars } from "@/domains/settings/components/tier-pricing";
 import {
   organizationsBillingPlansRetrieveOptions,
@@ -146,9 +146,10 @@ export function PlansPage() {
   // The package a Pro user is switching to, awaiting reconfirm; null when the
   // dialog is closed.
   const [switchTarget, setSwitchTarget] = useState<ProPackage | null>(null);
-  // Reveals the in-tab provisioning takeover after a successful switch — the
-  // same `TierUpgradeResizeModal` surface the tier-change flow opens via
-  // `onTierUpgraded` (see billing-page.tsx), reused here.
+  // Reveals the in-tab provisioning takeover after a successful switch or
+  // customize — `BillingOnboardingModal` in resize mode, which only observes
+  // the grow-only resize the platform already fired server-side (no redundant
+  // client-driven resize).
   const [resizeTakeoverOpen, setResizeTakeoverOpen] = useState(false);
 
   const subscription = subscriptionQuery.data;
@@ -531,7 +532,8 @@ export function PlansPage() {
           onConfirm={() => void confirmSwitch()}
         />
 
-        <TierUpgradeResizeModal
+        <BillingOnboardingModal
+          mode="resize"
           open={resizeTakeoverOpen}
           onClose={() => setResizeTakeoverOpen(false)}
         />


### PR DESCRIPTION
## Summary
- Swap plans-page's post-switch/post-customize mount from TierUpgradeResizeModal to BillingOnboardingModal in resize mode (observe-only; no redundant client resize)
- Trigger/toast logic unchanged: upgrade/Custom-sub → takeover; downgrade/no_op/no-grow → toast-only
- Update plans-page + custom-plan-modal tests to assert data-mode=resize

Part of plan: resize-takeover-on-plan-change.md (PR 2 of 4)