### PR TITLE
fix(surfaces): make safeParseSurfaceData total; drop its unused public export

### DIFF
--- a/assistant/src/__tests__/safe-parse-surface-data.test.ts
+++ b/assistant/src/__tests__/safe-parse-surface-data.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { safeParseSurfaceData, type SurfaceType } from "../api/surfaces.js";
+
+describe("safeParseSurfaceData", () => {
+  test("parses a known surface type through its canonical schema", () => {
+    expect(safeParseSurfaceData("copy_block", { text: "hello" })).toEqual({
+      text: "hello",
+    });
+  });
+
+  test("returns undefined (never throws) for an out-of-enum surface type", () => {
+    // The `<K extends SurfaceType>` signature keeps typed callers honest, but a
+    // JS caller — or a runtime string widened past the type system — can still
+    // reach this helper with a type that has no entry in `SURFACE_DATA_SCHEMAS`.
+    // Indexing it then yields `undefined`, and the helper must return `undefined`
+    // (its "couldn't produce a typed payload" signal) rather than throwing on
+    // `undefined.safeParse`.
+    const unknownType = "future_widget" as SurfaceType;
+    expect(() =>
+      safeParseSurfaceData(unknownType, { any: "data" }),
+    ).not.toThrow();
+    expect(safeParseSurfaceData(unknownType, { any: "data" })).toBeUndefined();
+  });
+});

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -613,7 +613,6 @@ export {
   normalizeCopyBlockShowData,
   type OAuthConnectSurfaceData,
   OAuthConnectSurfaceDataSchema,
-  safeParseSurfaceData,
   SURFACE_DATA_SCHEMAS,
   SURFACE_TYPES,
   type SurfaceData,

--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -614,6 +614,18 @@ export function safeParseSurfaceData<K extends SurfaceType>(
   surfaceType: K,
   data: unknown,
 ): SurfaceDataByType[K] | undefined {
-  const result = SURFACE_DATA_SCHEMAS[surfaceType].safeParse(data);
+  // `surfaceType` is typed as a known type, but nothing stops a JS caller — or a
+  // runtime string that only survived under a widened type — from passing one
+  // that isn't in the registry, where `SURFACE_DATA_SCHEMAS[surfaceType]` is
+  // `undefined` and `.safeParse` would throw. Return `undefined` (the same
+  // "couldn't produce a typed payload" signal a parse miss gives) so this stays
+  // total, as its name promises.
+  const schema = SURFACE_DATA_SCHEMAS[surfaceType] as
+    | z.ZodType<SurfaceDataByType[K]>
+    | undefined;
+  if (!schema) {
+    return undefined;
+  }
+  const result = schema.safeParse(data);
   return result.success ? result.data : undefined;
 }


### PR DESCRIPTION
## Prompt / plan

Follow-up hardening surfaced by a Devin review on #38786 (the discriminated-union `surfaceState` refactor, now merged).

In that refactor `safeParseSurfaceData` went from an exhaustive `switch` (whose `default` returned the raw type string at runtime) to `SURFACE_DATA_SCHEMAS[surfaceType].safeParse(data)`. For a runtime `surfaceType` **not** in the registry, the indexed schema is `undefined` and `.safeParse` throws a `TypeError` — i.e. a function named `safeParse` can throw.

This is **not a live bug**: every in-repo caller is guarded (`ui_update` gates on `isKnownSurfaceType`; `buildSurfaceShowPair` / `parseSurfaceShowPair` only get enum-validated or `K extends SurfaceType` types; the other calls pass string literals), and no external consumer calls it at all. But it's a real footgun on a public API export, so two small hardening changes:

## Changes

1. **Make `safeParseSurfaceData` total.** Guard the registry lookup and return `undefined` for an unknown type — the same "couldn't produce a typed payload" signal a parse miss already gives — instead of throwing on `undefined.safeParse`. The `<K extends SurfaceType>` generic (and its precise `SurfaceDataByType[K]` return) is unchanged; the guard only covers the runtime/JS case the type system can't. This also makes `buildSurfaceShowPair` and `parseSurfaceShowPair` total, since they delegate to it.

2. **Drop the unused public export.** Remove `safeParseSurfaceData` from the `@vellumai/assistant-api` barrel (`api/index.ts`). Nothing outside `assistant` imports it, and internal callers import it directly from `api/surfaces.js`, so nothing breaks — this removes the external-caller surface Devin flagged and trims the public API.

## Why it's safe

- The guard is additive: known types behave exactly as before (dispatch to their schema); only the previously-throwing unknown-type path changes, to return `undefined`.
- Removing the barrel export is a no-op for every current importer (verified: no reference to it in `clients/web`, `gateway`, `packages`, or via the barrel anywhere).
- `bunx tsc --noEmit` clean; ESLint/Prettier clean.

## Test plan

- New `safe-parse-surface-data.test.ts`: a known type parses through its schema, and an **out-of-enum** type returns `undefined` instead of throwing (the test fails if the guard is reverted — it asserts the corrected contract, not the old behavior).
- `cd assistant && bunx tsc --noEmit` — clean.

## CLI verb checklist

No new routes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f)_