### PR TITLE
feat(web): credit wall CTA upgrades to Pro instead of adding funds

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -68,11 +68,6 @@ import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
-const AddCreditsModal = lazy(() =>
-  import("@/components/add-credits-modal").then((m) => ({
-    default: m.AddCreditsModal,
-  })),
-);
 const DeployDialogs = lazy(() =>
   import("@/components/deploy-dialogs").then((m) => ({
     default: m.DeployDialogs,
@@ -108,8 +103,6 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   // Local state (not store-backed)
   // -------------------------------------------------------------------------
-  const [showAddCreditsModal, setShowAddCreditsModal] = useState(false);
-
   const [refreshEpoch, setRefreshEpoch] = useState(0);
   const [assetsRefreshKey, setAssetsRefreshKey] = useState(0);
 
@@ -543,7 +536,6 @@ export function ActiveChatView() {
     diskPressure,
 
     // Upward signals
-    setShowAddCreditsModal,
     setRefreshEpoch,
 
     // Shared refs
@@ -562,14 +554,6 @@ export function ActiveChatView() {
   return (
     <>
       <ChatContentLayout {...chatRouteProps} />
-      {showAddCreditsModal ? (
-        <LazyBoundary>
-          <AddCreditsModal
-            open={showAddCreditsModal}
-            onOpenChange={setShowAddCreditsModal}
-          />
-        </LazyBoundary>
-      ) : null}
 
       {assistantId && (isTokenDialogOpen || complexDeployApp) ? (
         <LazyBoundary>

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -146,7 +146,6 @@ export interface ChatMainPanelProps {
   diskPressure: UseDiskPressureMonitorResult;
 
   // Upward signals to ActiveChatView local state
-  setShowAddCreditsModal: Dispatch<SetStateAction<boolean>>;
   setRefreshEpoch: Dispatch<SetStateAction<number>>;
 
   // Shared refs (owned by ActiveChatView for debug API / keydown handler)
@@ -221,7 +220,6 @@ export function ChatMainPanel({
   handleInspectMessage,
   historyPagination,
   diskPressure,
-  setShowAddCreditsModal,
   setRefreshEpoch,
   inputRef,
   sanitizedMessagesRef,
@@ -375,6 +373,10 @@ export function ChatMainPanel({
 
   const pushToBillingSettings = useCallback(() => {
     void navigate(routes.settings.usageBilling);
+  }, [navigate]);
+
+  const pushToPlansTakeover = useCallback(() => {
+    void navigate(routes.plans);
   }, [navigate]);
 
   const checkAssistant = useCallback(() => lifecycleService.checkAssistant(), []);
@@ -986,9 +988,7 @@ export function ChatMainPanel({
             billingBannerDecision === "daily_limit" ? (
               <DailyLimitBanner onAdjustLimit={pushToBillingSettings} />
             ) : billingBannerDecision === "managed_credits" ? (
-              <CreditsExhaustedBanner
-                onAddFunds={() => setShowAddCreditsModal(true)}
-              />
+              <CreditsExhaustedBanner onUpgrade={pushToPlansTakeover} />
             ) : billingBannerDecision === "provider_billing" ? (
               <ProviderBillingBanner onOpenSettings={pushToAiSettings} />
             ) : null

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Tests for the out-of-credits `CreditsExhaustedBanner`.
+ *
+ * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
+ * and drives the CTA with `fireEvent`. No jest-dom matchers — we assert with
+ * plain bun `expect` against query results.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { CreditsExhaustedBanner } from "./credits-exhausted-banner";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CreditsExhaustedBanner", () => {
+  test("renders the title, Pro-oriented subtitle, and an Upgrade CTA", () => {
+    const { getByText, getByRole } = render(
+      <CreditsExhaustedBanner onUpgrade={() => {}} />,
+    );
+
+    expect(getByText("Your credit balance has run out")).toBeTruthy();
+    expect(
+      getByText("Upgrade to a Pro plan to get monthly credits."),
+    ).toBeTruthy();
+    expect(getByRole("button", { name: /upgrade/i })).toBeTruthy();
+  });
+
+  test("fires onUpgrade once when the CTA is clicked", () => {
+    const onUpgrade = mock(() => {});
+
+    const { getByRole } = render(
+      <CreditsExhaustedBanner onUpgrade={onUpgrade} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: /upgrade/i }));
+    expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
@@ -2,20 +2,20 @@
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
 
 interface CreditsExhaustedBannerProps {
-  onAddFunds: () => void;
+  onUpgrade: () => void;
 }
 
 export function CreditsExhaustedBanner({
-  onAddFunds,
+  onUpgrade,
 }: CreditsExhaustedBannerProps) {
   return (
     <BillingErrorBanner
-      ariaLabel="Your credit balance has run out"
+      ariaLabel="Your credit balance has run out. Upgrade to a Pro plan."
       icon={<span style={{ fontSize: "1.25rem" }}>💰</span>}
       title="Your credit balance has run out"
-      subtitle="Purchase additional credits to pick up where you left off."
-      ctaLabel="Add Funds"
-      onAction={onAddFunds}
+      subtitle="Upgrade to a Pro plan to get monthly credits."
+      ctaLabel="Upgrade"
+      onAction={onUpgrade}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Relabels the out-of-credits chat wall CTA from 'Add Funds' to 'Upgrade' and reworks the copy to steer users to a Pro plan.
- The Upgrade CTA now opens the Pro plans takeover (/assistant/plans) instead of the Add Credits top-up modal.
- Removes the now-orphaned in-chat Add Credits modal wiring; Settings → Billing top-up is unchanged.

Part of plan: credit-wall-upgrade-cta.md (PR 1 of 1)