### PR TITLE
fix(assistant): propagate memory-v3 lane invalidation across processes

### DIFF
--- a/assistant/src/plugins/defaults/memory/src/memory-v3-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-v3-routes.ts
@@ -43,8 +43,9 @@ export type MemoryV3RebuildIndexResult = z.infer<
 
 /**
  * Invalidate the v3 shadow lanes so the next turn rebuilds the section index
- * from the current on-disk state. Runs in-daemon so it acts on the live
- * process's cached lanes (an in-CLI call would invalidate nothing).
+ * from the current on-disk state. Runs in-daemon so it drops the live
+ * process's cached lanes immediately; the bumped lanes-version token also
+ * reaches every other process's memo on its next `getLanes`.
  */
 export async function handleMemoryV3RebuildIndex(): Promise<MemoryV3RebuildIndexResult> {
   invalidateLanes();

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -75,10 +75,19 @@ const realCliCommandStore = {
 };
 const realCoreSet = { ...(await import("../core-set.js")) };
 const realHotSet = { ...(await import("../hot-set.js")) };
+const realCheckpoints = {
+  ...(await import("../../../../../persistence/checkpoints.js")),
+};
 
 let shadowMockActive = false;
 
 // ─── mutable test state, read by the mocks below ────────────────────────────
+
+// In-memory stand-in for the `memory_checkpoints` row backing the
+// lanes-version token, so tests control the cross-process signal without a
+// migrated main DB. `checkpointReadThrows` simulates an unavailable DB.
+const checkpointStore = new Map<string, string>();
+let checkpointReadThrows = false;
 
 let liveEnabled = false;
 let memoryEnabled = true;
@@ -449,11 +458,28 @@ mock.module("../orchestrate.js", () => ({
       : realOrchestrate.orchestrate(...args),
 }));
 
+mock.module("../../../../../persistence/checkpoints.js", () => ({
+  ...realCheckpoints,
+  getMemoryCheckpoint: (key: string) => {
+    if (!shadowMockActive) return realCheckpoints.getMemoryCheckpoint(key);
+    if (checkpointReadThrows) throw new Error("checkpoint store unavailable");
+    return checkpointStore.get(key) ?? null;
+  },
+  setMemoryCheckpoint: (key: string, value: string) => {
+    if (!shadowMockActive) {
+      realCheckpoints.setMemoryCheckpoint(key, value);
+      return;
+    }
+    checkpointStore.set(key, value);
+  },
+}));
+
 // Import AFTER mocks so the plugin binds to them.
 const {
   observeTurn: observeTurnImpl,
   resetShadowLanesForTests,
   invalidateLanes,
+  LANES_VERSION_CHECKPOINT_KEY,
   attributeSelections,
   writeSelections,
   backfillMemoryV3SelectionMessageId,
@@ -510,6 +536,8 @@ beforeEach(() => {
   hotSetResult = [];
   hotSetOpts = null;
   testDb = makeDb();
+  checkpointStore.clear();
+  checkpointReadThrows = false;
   resetShadowLanesForTests();
   // The injector memoizes one orchestration per (conversation, turn); clear it
   // so tests reusing the same ids observe fresh orchestrations.
@@ -913,6 +941,45 @@ describe("memory-v3 engine", () => {
     await Promise.all([observeTurn("conv-1", 1), observeTurn("conv-1", 2)]);
     expect(sectionBuilds).toBe(2);
     expect(needleBuilds).toBe(2);
+  });
+
+  test("invalidateLanes writes a new, distinct lanes-version token each call", () => {
+    invalidateLanes();
+    const first = checkpointStore.get(LANES_VERSION_CHECKPOINT_KEY);
+    invalidateLanes();
+    const second = checkpointStore.get(LANES_VERSION_CHECKPOINT_KEY);
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(second).not.toBe(first);
+  });
+
+  test("a lanes-version bump from another process forces a rebuild on the next turn", async () => {
+    await observeTurn("conv-1", 0);
+    await observeTurn("conv-1", 1);
+    expect(sectionBuilds).toBe(1);
+
+    // Simulate the memory worker's invalidateLanes(): its in-process memo
+    // clear is invisible to this process — only the persisted token write
+    // crosses the boundary.
+    checkpointStore.set(LANES_VERSION_CHECKPOINT_KEY, "worker-bump-1");
+
+    await observeTurn("conv-1", 2);
+    expect(sectionBuilds).toBe(2);
+    expect(needleBuilds).toBe(2);
+
+    // The rebuild captured the new token — the observer path never re-bumps,
+    // so later turns reuse the rebuilt memo instead of churning.
+    await observeTurn("conv-1", 3);
+    expect(sectionBuilds).toBe(2);
+  });
+
+  test("a lanes-version read failure serves the memoized lanes", async () => {
+    await observeTurn("conv-1", 0);
+    expect(sectionBuilds).toBe(1);
+
+    checkpointReadThrows = true;
+    await observeTurn("conv-1", 1);
+    expect(sectionBuilds).toBe(1);
   });
 
   test("no user message → no orchestrate, no writes", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -7,10 +7,13 @@
  * and returns it at v2's dynamic-memory placement (`after-memory-prefix`).
  *
  * On each live turn:
- *   1. Lazy-init the v3 lanes ONCE across the whole process (section index,
- *      section-grain BM25 needle, dense lane config, link-graph edge graph,
- *      curated core set, frecency hot set), memoizing the init promise so
- *      concurrent first turns share a single build.
+ *   1. Lazy-init the v3 lanes (section index, section-grain BM25 needle,
+ *      dense lane config, link-graph edge graph, curated core set, frecency
+ *      hot set), memoizing the init promise so concurrent first turns share a
+ *      single build. The memo lives until the persisted lanes-version token
+ *      changes ({@link LANES_VERSION_CHECKPOINT_KEY}) — writers in any
+ *      process bump it via {@link invalidateLanes}, and {@link getLanes}
+ *      observes the change and rebuilds.
  *   2. Build a {@link MemoryRoutingTurn} from the conversation's recent messages.
  *   3. Run {@link orchestrate} and record its selection set to
  *      `memory_v3_selections` with a best-effort lane attribution.
@@ -34,6 +37,10 @@ import {
   recordLatencySubSpan,
   timeLatencySubSpan,
 } from "../../../../daemon/turn-latency-sub-spans.js";
+import {
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "../../../../persistence/checkpoints.js";
 import { stripCommentLines } from "../host-utils.js";
 import { getLogger } from "../logging.js";
 import { memorySqliteOrNull } from "../memory-db.js";
@@ -63,7 +70,7 @@ import { ensureSectionCollection } from "./section-dense-store.js";
 import type { SectionNeedle } from "./section-needle.js";
 import { buildSectionNeedle } from "./section-needle.js";
 import { buildSectionIndex } from "./sections.js";
-import { getPageIndex } from "./substrate/page-index.js";
+import { getPageIndex, invalidatePageIndex } from "./substrate/page-index.js";
 import { readPage, renderPageContent } from "./substrate/page-store.js";
 import { resolveV3Tuning } from "./tuning-profile.js";
 import {
@@ -142,15 +149,75 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 let lanesPromise: Promise<ShadowLanes> | null = null;
 
 /**
+ * `memory_checkpoints` key carrying the lanes-version token — the
+ * cross-process invalidation signal. Memory jobs (the consolidation run's
+ * `memory_v3_maintain` follow-up) execute in the standalone memory worker
+ * process, so their `invalidateLanes()` cannot touch the daemon's
+ * `lanesPromise` directly; bumping the token in the shared workspace DB is
+ * how an invalidation reaches the process that owns the live lanes. Writers
+ * bump the token; {@link getLanes} compares it per call and rebuilds on any
+ * change. The value is an opaque string — only inequality matters.
+ */
+export const LANES_VERSION_CHECKPOINT_KEY = "memory_v3_lanes_version";
+
+/** The persisted lanes-version token captured when the memoized build
+ *  started. {@link getLanes} rebuilds when the store's token differs. */
+let builtLanesVersion: string | null = null;
+
+/**
+ * Current persisted lanes-version token: `null` when the store carries no
+ * token (a legitimate stable state, compared as such), `undefined` when the
+ * read itself failed (DB unavailable). Callers treat `undefined` as "cannot
+ * judge staleness" and keep serving the memoized lanes — degraded freshness
+ * beats a broken turn.
+ */
+function readLanesVersion(): string | null | undefined {
+  try {
+    return getMemoryCheckpoint(LANES_VERSION_CHECKPOINT_KEY);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Drop THIS process's lane caches: the memo and the page-index cache the
+ *  rebuild reads through. Shared by the writer path ({@link invalidateLanes})
+ *  and the observer path in {@link getLanes}. */
+function dropLanesLocal(): void {
+  lanesPromise = null;
+  invalidatePageIndex();
+}
+
+/**
  * Drop the memoized lanes so the NEXT `getLanes` rebuilds them from scratch
  * (fresh section index + fresh needle + fresh edge graph). The rebuild is lazy
- * — this only clears the cache, so the cost is paid by the next caller, and
+ * — this only clears the caches, so the cost is paid by the next caller, and
  * concurrent first-callers after the invalidation still share a single build via
  * the re-memoized promise. Call this whenever the underlying pages change on
  * disk.
+ *
+ * Three effects, and every caller needs all three:
+ *   - null the local memo, so this process rebuilds on its next turn;
+ *   - drop the page-index cache, so the rebuild re-scans the workspace even
+ *     when the pages changed without a daemon tool hook firing (direct disk
+ *     edits, another process's writes);
+ *   - bump the persisted lanes-version token, so OTHER processes observe the
+ *     invalidation — the memory worker is where the maintain job calls this,
+ *     and without the bump the daemon's lanes would never rebuild.
+ *
+ * The bump is best-effort: invalidation must never throw (it runs inside
+ * jobs, the rebuild-index route, and tests), so a checkpoint-write failure
+ * only logs — the local invalidation above still holds.
  */
 export function invalidateLanes(): void {
-  lanesPromise = null;
+  dropLanesLocal();
+  try {
+    setMemoryCheckpoint(LANES_VERSION_CHECKPOINT_KEY, crypto.randomUUID());
+  } catch (err) {
+    log.warn(
+      { err },
+      "lanes-version bump failed; other processes will not observe this invalidation",
+    );
+  }
 }
 
 /** Test-only alias for {@link invalidateLanes}. */
@@ -372,9 +439,28 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   };
 }
 
-/** Lazy, memoized accessor for the shadow lanes. */
+/**
+ * Lazy, memoized accessor for the shadow lanes. The memo is valid while the
+ * persisted lanes-version token matches the one captured at build start; a
+ * mismatch (another process — or this one — called {@link invalidateLanes})
+ * drops the memo and rebuilds. A failed token read serves the memo unchanged.
+ */
 function getLanes(config: AssistantConfig): Promise<ShadowLanes> {
+  if (lanesPromise) {
+    const current = readLanesVersion();
+    if (current !== undefined && current !== builtLanesVersion) {
+      // A writer bumped the persisted token since this build — the memory
+      // worker's maintain job after a consolidation, or the rebuild-index
+      // route. This observer path never re-bumps the token: writers bump,
+      // observers only compare — a re-bump here would make every rebuild
+      // trigger another one on the following turn.
+      dropLanesLocal();
+    }
+  }
   if (!lanesPromise) {
+    // Capture the token BEFORE building: a bump that lands mid-build is then
+    // detected on the next call (one extra rebuild, never a missed one).
+    builtLanesVersion = readLanesVersion() ?? null;
     lanesPromise = initLanes(config).catch((err) => {
       // Reset on failure so a transient init error doesn't permanently wedge
       // the shadow lane — the next turn retries.


### PR DESCRIPTION
## Summary
- `invalidateLanes()` now bumps a persisted lanes-version token (`memory_checkpoints` key `memory_v3_lanes_version`) and drops the page-index cache alongside the lanes memo, so an invalidation issued in one process reaches every process sharing the workspace DB.
- `getLanes` compares the persisted token against the one captured at build start on every call: mismatch → drop memo + page-index cache and rebuild; failed read → serve the memo (degraded freshness over a broken turn). The observer path never re-bumps, so rebuilds cannot cascade.
- Adds tests: distinct token per bump, cross-process bump forces exactly one rebuild, unchanged token reuses the memo, checkpoint-read failure serves the memo.

## Original prompt
Diagnosed a live incident where an assistant's memory retrieval silently ignored every concept page created after daemon boot for 4.5 days: since #37895 moved memory jobs into the standalone worker process, the maintain job's `invalidateLanes()` only cleared the worker's own module-level memo, and the daemon — which owns the live lanes used by `observeTurn`/`orchestrate` — never observed any invalidation (its `getLanes` was a pure process-lifetime memo; the only other caller was the manual rebuild-index route). Asked to put in the durable fix: a persisted lanes-version token as the cross-process invalidation signal, best-effort and never throwing, preserving the stable-prefix/KV-cache contract (lanes still change only at invalidation events).