### PR TITLE
Credit-wall CTA → Upgrade to Pro (opens plans takeover)

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -68,11 +68,6 @@ import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
-const AddCreditsModal = lazy(() =>
-  import("@/components/add-credits-modal").then((m) => ({
-    default: m.AddCreditsModal,
-  })),
-);
 const DeployDialogs = lazy(() =>
   import("@/components/deploy-dialogs").then((m) => ({
     default: m.DeployDialogs,
@@ -108,8 +103,6 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   // Local state (not store-backed)
   // -------------------------------------------------------------------------
-  const [showAddCreditsModal, setShowAddCreditsModal] = useState(false);
-
   const [refreshEpoch, setRefreshEpoch] = useState(0);
   const [assetsRefreshKey, setAssetsRefreshKey] = useState(0);
 
@@ -543,7 +536,6 @@ export function ActiveChatView() {
     diskPressure,
 
     // Upward signals
-    setShowAddCreditsModal,
     setRefreshEpoch,
 
     // Shared refs
@@ -562,14 +554,6 @@ export function ActiveChatView() {
   return (
     <>
       <ChatContentLayout {...chatRouteProps} />
-      {showAddCreditsModal ? (
-        <LazyBoundary>
-          <AddCreditsModal
-            open={showAddCreditsModal}
-            onOpenChange={setShowAddCreditsModal}
-          />
-        </LazyBoundary>
-      ) : null}
 
       {assistantId && (isTokenDialogOpen || complexDeployApp) ? (
         <LazyBoundary>

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -146,7 +146,6 @@ export interface ChatMainPanelProps {
   diskPressure: UseDiskPressureMonitorResult;
 
   // Upward signals to ActiveChatView local state
-  setShowAddCreditsModal: Dispatch<SetStateAction<boolean>>;
   setRefreshEpoch: Dispatch<SetStateAction<number>>;
 
   // Shared refs (owned by ActiveChatView for debug API / keydown handler)
@@ -221,7 +220,6 @@ export function ChatMainPanel({
   handleInspectMessage,
   historyPagination,
   diskPressure,
-  setShowAddCreditsModal,
   setRefreshEpoch,
   inputRef,
   sanitizedMessagesRef,
@@ -375,6 +373,10 @@ export function ChatMainPanel({
 
   const pushToBillingSettings = useCallback(() => {
     void navigate(routes.settings.usageBilling);
+  }, [navigate]);
+
+  const pushToPlansTakeover = useCallback(() => {
+    void navigate(routes.plans);
   }, [navigate]);
 
   const checkAssistant = useCallback(() => lifecycleService.checkAssistant(), []);
@@ -986,9 +988,7 @@ export function ChatMainPanel({
             billingBannerDecision === "daily_limit" ? (
               <DailyLimitBanner onAdjustLimit={pushToBillingSettings} />
             ) : billingBannerDecision === "managed_credits" ? (
-              <CreditsExhaustedBanner
-                onAddFunds={() => setShowAddCreditsModal(true)}
-              />
+              <CreditsExhaustedBanner onUpgrade={pushToPlansTakeover} />
             ) : billingBannerDecision === "provider_billing" ? (
               <ProviderBillingBanner onOpenSettings={pushToAiSettings} />
             ) : null

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
@@ -15,14 +15,14 @@ afterEach(() => {
 });
 
 describe("CreditsExhaustedBanner", () => {
-  test("renders the title, Pro-oriented subtitle, and an Upgrade CTA", () => {
+  test("renders the title, subtitle, and an Upgrade CTA", () => {
     const { getByText, getByRole } = render(
       <CreditsExhaustedBanner onUpgrade={() => {}} />,
     );
 
     expect(getByText("Your credit balance has run out")).toBeTruthy();
     expect(
-      getByText("Upgrade to a Pro plan to get monthly credits."),
+      getByText("Upgrade your plan for more credits every month."),
     ).toBeTruthy();
     expect(getByRole("button", { name: /upgrade/i })).toBeTruthy();
   });

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Tests for the out-of-credits `CreditsExhaustedBanner`.
+ *
+ * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
+ * and drives the CTA with `fireEvent`. No jest-dom matchers — we assert with
+ * plain bun `expect` against query results.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { CreditsExhaustedBanner } from "./credits-exhausted-banner";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CreditsExhaustedBanner", () => {
+  test("renders the title, Pro-oriented subtitle, and an Upgrade CTA", () => {
+    const { getByText, getByRole } = render(
+      <CreditsExhaustedBanner onUpgrade={() => {}} />,
+    );
+
+    expect(getByText("Your credit balance has run out")).toBeTruthy();
+    expect(
+      getByText("Upgrade to a Pro plan to get monthly credits."),
+    ).toBeTruthy();
+    expect(getByRole("button", { name: /upgrade/i })).toBeTruthy();
+  });
+
+  test("fires onUpgrade once when the CTA is clicked", () => {
+    const onUpgrade = mock(() => {});
+
+    const { getByRole } = render(
+      <CreditsExhaustedBanner onUpgrade={onUpgrade} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: /upgrade/i }));
+    expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
@@ -10,10 +10,10 @@ export function CreditsExhaustedBanner({
 }: CreditsExhaustedBannerProps) {
   return (
     <BillingErrorBanner
-      ariaLabel="Your credit balance has run out. Upgrade to a Pro plan."
+      ariaLabel="Your credit balance has run out. Upgrade your plan for more credits."
       icon={<span style={{ fontSize: "1.25rem" }}>💰</span>}
       title="Your credit balance has run out"
-      subtitle="Upgrade to a Pro plan to get monthly credits."
+      subtitle="Upgrade your plan for more credits every month."
       ctaLabel="Upgrade"
       onAction={onUpgrade}
     />

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
@@ -2,20 +2,20 @@
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
 
 interface CreditsExhaustedBannerProps {
-  onAddFunds: () => void;
+  onUpgrade: () => void;
 }
 
 export function CreditsExhaustedBanner({
-  onAddFunds,
+  onUpgrade,
 }: CreditsExhaustedBannerProps) {
   return (
     <BillingErrorBanner
-      ariaLabel="Your credit balance has run out"
+      ariaLabel="Your credit balance has run out. Upgrade to a Pro plan."
       icon={<span style={{ fontSize: "1.25rem" }}>💰</span>}
       title="Your credit balance has run out"
-      subtitle="Purchase additional credits to pick up where you left off."
-      ctaLabel="Add Funds"
-      onAction={onAddFunds}
+      subtitle="Upgrade to a Pro plan to get monthly credits."
+      ctaLabel="Upgrade"
+      onAction={onUpgrade}
     />
   );
 }


### PR DESCRIPTION
## Summary
When a user runs out of Vellum credits, the chat composer's out-of-credits wall now steers them toward a Pro plan instead of a one-off credit top-up:
- CTA relabeled **"Add Funds" → "Upgrade"**; subtitle → **"Upgrade to a Pro plan to get monthly credits."**; title kept ("Your credit balance has run out"); `aria-label` updated to match.
- The "Upgrade" CTA now opens the **Pro plans takeover** (`/assistant/plans`) instead of the Add Credits top-up modal.
- The now-orphaned in-chat `AddCreditsModal` wiring was removed. Settings → Billing top-up is unchanged (`billing-panel.tsx` still opens its own modal).

## Self-review result
PASS with 1 documented product consideration.
- Pass 1 (external feedback): PASS — Codex reviewed `ebfe098f79` clean.
- Pass 2 (plan faithfulness): PASS — all acceptance criteria met; test passes in isolation.
- Pass 3 (repo integration): 1 finding (below) — triaged as a product/rollout consideration, not a code defect.
- Pass 4 (slop/reuse): PASS — clean rewiring, zero dangling refs.

### ⚠️ Rollout consideration (`pro-packages` flag)
The plans takeover (`plans-page.tsx:209-221`) redirects to the billing usage tab when the assistant is self-hosted, the subscription can't be read, **or the package catalog is empty (`pro-packages` LaunchDarkly flag off)**. So the "Upgrade" CTA renders the takeover only where `pro-packages` is enabled; otherwise it lands on the billing usage tab (a graceful fallback with its own "Add Credits" + plan CTAs — no dead-end). This is the takeover's existing guard, which the plan-card "Manage/View Plans" buttons already depend on. **Confirm `pro-packages` is enabled in the target environment(s)** before relying on the takeover as the credit-wall destination.

## Open product decisions (from the plan, not blocking)
1. **Escape hatch:** this removes the only *in-chat* path to buy credits manually (top-up remains in Settings → Billing). If you'd rather keep a secondary "Add credits" link in the wall, that's a small follow-up.
2. **Pro-user copy:** an existing Pro user can also hit the out-of-credits wall, where "get a Pro plan" reads slightly off. Tier-aware copy is an optional follow-up.

## PRs merged into feature branch
- #38816: feat(web): credit wall CTA upgrades to Pro instead of adding funds

Part of plan: credit-wall-upgrade-cta.md