### PR TITLE
fix(assistant): raise corrupt-DB repair test timeouts to 30s

### DIFF
--- a/assistant/src/cli/commands/db/__tests__/repair.test.ts
+++ b/assistant/src/cli/commands/db/__tests__/repair.test.ts
@@ -192,6 +192,9 @@ describe("assistant db repair — healthy DB", () => {
   });
 });
 
+// Integrity-checking the corrupt seed (including the malformed-image throw
+// path) plus the follow-on backfill step can exceed bun's 5s per-test
+// default on a loaded machine, so each gets a 30s ceiling.
 describe("assistant db repair — corrupt DB", () => {
   test("integrity check surfaces corruption and exits 1", async () => {
     seedCorruptDb();
@@ -212,7 +215,7 @@ describe("assistant db repair — corrupt DB", () => {
     // backfill itself runs against an empty conversations dir and reports
     // "nothing to backfill", so the summary is `1 ok, 1 failed`.
     expect(stdout).toMatch(/Done\. 2 steps ran: 1 ok, 1 failed/);
-  });
+  }, 30_000);
 
   test("--json carries the full error list from integrity-check", async () => {
     seedCorruptDb();
@@ -225,7 +228,7 @@ describe("assistant db repair — corrupt DB", () => {
     expect(Array.isArray(parsed.steps[0].result.data.errors)).toBe(true);
     expect(parsed.steps[0].result.data.errors.length).toBeGreaterThan(0);
     expect(parsed.errorCount).toBe(1);
-  });
+  }, 30_000);
 });
 
 describe("assistant db repair — DB missing", () => {


### PR DESCRIPTION
## Summary
- Give both `assistant db repair — corrupt DB` tests in `repair.test.ts` an explicit 30s per-test ceiling, matching the ceilings the conversation-backfill block in the same file already uses.
- Fixes the main-branch CI failure in [run 29979644464](https://github.com/vellum-ai/vellum-assistant/actions/runs/29979644464/job/89118612856): `integrity check surfaces corruption and exits 1` ran 5946ms on a loaded 16-worker CI machine and timed out at bun's 5s default. The triggering commit (c086ee7f5a) only touched `memory/v3/substrate`, so this was CI-load flake, not a regression; the sibling test passed at 3221ms, well within the same risk band.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/29979644464/job/89118612856