### PR TITLE
fix(mcp): implement OAuth prepareTokenRequest for refresh-token rotation

### DIFF
--- a/assistant/src/mcp/mcp-oauth-provider.ts
+++ b/assistant/src/mcp/mcp-oauth-provider.ts
@@ -144,9 +144,29 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
+    // RFC 6749 §6 lets a token endpoint rotate the refresh_token, omit
+    // it, or leave it unchanged. Many MCP servers issue a fresh
+    // access_token without a new refresh_token on every refresh grant;
+    // overwriting storage verbatim would then drop the refresh_token
+    // we still need to send on the next silent refresh. Carry forward
+    // the previous refresh_token when the incoming response omits one.
+    let toPersist: OAuthTokens = tokens;
+    if (!tokens.refresh_token) {
+      const previous = await getSecureKeyAsync(tokensKey(this.serverId));
+      if (previous) {
+        try {
+          const parsed = JSON.parse(previous) as OAuthTokens;
+          if (parsed.refresh_token) {
+            toPersist = { ...tokens, refresh_token: parsed.refresh_token };
+          }
+        } catch {
+          // Existing payload is malformed; fall through and save as-is.
+        }
+      }
+    }
     const ok = await setSecureKeyAsync(
       tokensKey(this.serverId),
-      JSON.stringify(tokens),
+      JSON.stringify(toPersist),
     );
     if (!ok) {
       log.warn(
@@ -156,6 +176,38 @@ export class McpOAuthProvider implements OAuthClientProvider {
       return;
     }
     log.info({ serverId: this.serverId }, "OAuth tokens saved");
+  }
+
+  // --- Refresh-Token Grant ---
+
+  /**
+   * Build the URL-encoded body for a refresh-token grant request.
+   *
+   * The MCP SDK calls this method when it needs to obtain a fresh
+   * access token without an authorization code (typically after a 401
+   * on an existing MCP request). We return a `refresh_token` grant if
+   * the stored tokens include one; otherwise we return `undefined` so
+   * the SDK falls back to the full authorization-code flow.
+   *
+   * Per RFC 6749 §6, omitting `scope` on refresh means the server
+   * reuses the originally authorized scope — the default most MCP
+   * servers (including Nirvana) expect.
+   */
+  async prepareTokenRequest(
+    scope?: string,
+  ): Promise<URLSearchParams | undefined> {
+    const tokens = await this.tokens();
+    if (!tokens?.refresh_token) {
+      return undefined;
+    }
+    const params = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: tokens.refresh_token,
+    });
+    if (scope) {
+      params.set("scope", scope);
+    }
+    return params;
   }
 
   // --- Client Information ---


### PR DESCRIPTION
(Blurb and all coding by my Vellum assistant)
The MCP SDK calls provider.prepareTokenRequest() when it needs a fresh access token without an authorization code (typically after a 401). Returning undefined from that method — as our provider currently does — causes the SDK to fall through to the full authorization-code flow, which surfaces as "Either provider.prepareTokenRequest() or authorizationCode is required" and forces a manual browser re-auth every ~24-72h.

This implements prepareTokenRequest() to issue a refresh_token grant when the stored tokens include a refresh_token, and to return undefined otherwise (preserving the existing fallback to the auth-code flow).

OAuth servers that issue refresh tokens — including Nirvana (grant_types_supported: ["authorization_code", "refresh_token"], token_endpoint_auth_methods_supported: ["none"]) — will now silently rotate tokens instead of requiring a fresh browser handshake.

Mirrors the SDK reference impl in
@modelcontextprotocol/sdk/client/auth-extensions.js ClientCredentialsProvider.prepareTokenRequest.

Refs: SDK OAuthClientProvider interface (auth.d.ts prepareTokenRequest)
Refs: SDK fetchToken call site (auth.js:879)

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
