### PR TITLE
feat(web): make the in-chat tour desktop-only, cohorts included

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
@@ -23,6 +23,8 @@
 import { type MutableRefObject, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
 import { type PreChatOnboardingContext } from "@/domains/onboarding/prechat";
@@ -53,6 +55,8 @@ export interface UseOnboardingOrchestratorResult {
 export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const isMobile = useIsMobile();
+  const isNative = useIsNativePlatform();
 
   const pendingOnboardingContextRef = useRef<PreChatOnboardingContext | null>(null);
   const onboardingDraftConversationIdRef = useRef<string | null>(null);
@@ -74,19 +78,27 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
     onboardingDraftConversationIdRef.current = draftId;
     setOnboardingConversationId(draftId);
     useConversationStore.getState().setActiveConversationId(draftId);
-    // The in-chat-onboarding-tour experiment: an exposure event fires for
-    // BOTH arms at the hand-off (control emits nothing else, and the
-    // funnel needs its rows for comparison), then the `tour` arm plays
-    // the eyes-led tour over the workspace the user just landed in. The
-    // arm is read at consumption time — flags hydrated long ago during
-    // the onboarding flow itself, and the signal is one-shot.
-    emitInChatTourExposed();
-    if (isInChatTourOn(readInChatTourVariant())) {
-      useInChatOnboardingStore.getState().startPrototype();
-      emitInChatTourStarted("auto");
+    // The in-chat-onboarding-tour experiment — DESKTOP ONLY: phone-width
+    // viewports and the native shell get neither the tour (its takeover
+    // is built around the desktop sidebar/composer layout) nor ANY of its
+    // telemetry. Skipping the exposure event too is deliberate: mobile
+    // sessions must stay out of both cohorts, or arm comparisons would be
+    // diluted by users who could never see the tour. On desktop, an
+    // exposure event fires for BOTH arms at the hand-off (control emits
+    // nothing else, and the funnel needs its rows for comparison), then
+    // the `tour` arm plays the eyes-led tour over the workspace the user
+    // just landed in. The arm is read at consumption time — flags
+    // hydrated long ago during the onboarding flow itself, and the
+    // signal is one-shot.
+    if (!isMobile && !isNative) {
+      emitInChatTourExposed();
+      if (isInChatTourOn(readInChatTourVariant())) {
+        useInChatOnboardingStore.getState().startPrototype();
+        emitInChatTourStarted("auto");
+      }
     }
     void navigate(routes.conversation(draftId), { replace: true });
-  }, [searchParams, navigate]);
+  }, [searchParams, navigate, isMobile, isNative]);
 
   // Derive onboardingTasksEmpty from the pending context in sessionStorage.
   // Runs once on mount — if initial message key is present, this is an

--- a/clients/web/src/domains/chat/in-chat-onboarding/in-chat-onboarding-launch-button.tsx
+++ b/clients/web/src/domains/chat/in-chat-onboarding/in-chat-onboarding-launch-button.tsx
@@ -2,6 +2,8 @@ import { Sparkles } from "lucide-react";
 
 import { Button } from "@vellumai/design-library";
 
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
 
 import { isInChatTourOn, useInChatTourVariant } from "./in-chat-tour-flag";
@@ -15,13 +17,18 @@ import { emitInChatTourStarted } from "./tour-telemetry";
  * afterwards replays from the top.
  *
  * Gated on the `in-chat-onboarding-tour` experiment's `tour` arm
- * (default `control`), same seam as the post-onboarding auto-play.
+ * (default `control`), same seam as the post-onboarding auto-play — and
+ * desktop-only, like the tour itself: hidden on phone-width viewports and
+ * in the native shell, where the takeover's sidebar/composer choreography
+ * doesn't apply.
  */
 export function InChatOnboardingLaunchButton() {
   const startPrototype = useInChatOnboardingStore.use.startPrototype();
   const variant = useInChatTourVariant();
+  const isMobile = useIsMobile();
+  const isNative = useIsNativePlatform();
 
-  if (!isInChatTourOn(variant)) {
+  if (isMobile || isNative || !isInChatTourOn(variant)) {
     return null;
   }
 

--- a/clients/web/src/domains/chat/in-chat-onboarding/tour-telemetry.ts
+++ b/clients/web/src/domains/chat/in-chat-onboarding/tour-telemetry.ts
@@ -6,6 +6,12 @@
  * `in-chat-onboarding-tour` arm as `ab_variant`, so BigQuery can compare
  * the 70% `tour` arm against `control`.
  *
+ * DESKTOP-ONLY: the tour doesn't run on phone-width viewports or in the
+ * native shell, and neither do these events — both call sites gate on
+ * mobile/native BEFORE emitting anything (including `tour_exposed`), so
+ * the experiment's cohorts contain only sessions that could actually see
+ * the tour.
+ *
  * Events:
  * - `tour_exposed`   — the post-onboarding hand-off, fired for BOTH arms;
  *                      the control cohort emits nothing else, and the

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -6,7 +6,7 @@
       "scope": "client",
       "key": "in-chat-onboarding-tour",
       "label": "In-Chat Onboarding Tour",
-      "description": "Multivariate experiment for the eyes-led in-chat onboarding tour. control = straight to chat after research onboarding (current behavior); tour = the extended tour auto-plays on first workspace entry, and the header replay button shows. Targeted via LaunchDarkly (planned 70% tour / 30% control).",
+      "description": "Multivariate experiment for the eyes-led in-chat onboarding tour. control = straight to chat after research onboarding (current behavior); tour = the extended tour auto-plays on first workspace entry, and the header replay button shows. Desktop-only: phone-width viewports and the native shell get neither the tour nor its telemetry (not even the exposure event), so the funnel measures desktop sessions exclusively. Targeted via LaunchDarkly (planned 70% tour / 30% control).",
       "defaultEnabled": "control",
       "values": ["control", "tour"]
     },

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -6,7 +6,7 @@
       "scope": "client",
       "key": "in-chat-onboarding-tour",
       "label": "In-Chat Onboarding Tour",
-      "description": "Multivariate experiment for the eyes-led in-chat onboarding tour. control = straight to chat after research onboarding (current behavior); tour = the extended tour auto-plays on first workspace entry, and the header replay button shows. Targeted via LaunchDarkly (planned 70% tour / 30% control).",
+      "description": "Multivariate experiment for the eyes-led in-chat onboarding tour. control = straight to chat after research onboarding (current behavior); tour = the extended tour auto-plays on first workspace entry, and the header replay button shows. Desktop-only: phone-width viewports and the native shell get neither the tour nor its telemetry (not even the exposure event), so the funnel measures desktop sessions exclusively. Targeted via LaunchDarkly (planned 70% tour / 30% control).",
       "defaultEnabled": "control",
       "values": ["control", "tour"]
     },


### PR DESCRIPTION
Follow-up to #38627 / #38785 — removes the in-chat onboarding tour from mobile entirely, and keeps the experiment's tracking clean while doing it.

## Why

The tour's takeover choreography is built around the desktop layout (sidebar reveal, nav-row floods, composer finale) and isn't necessary for mobile users. The experiment should measure the tour's success on the surface it actually runs on: desktop.

## What

- **Hand-off gate** (`use-onboarding-orchestrator`): on phone-width viewports (`useIsMobile`, <768px) or in the native Capacitor shell (`useIsNativePlatform`), the `?onboarding=1` consumption skips the entire experiment block — no tour, and crucially **no `tour_exposed` event either**.
- **Replay button**: hidden on mobile/native, same gate.
- **Flag registry**: description updated to record the desktop-only scope (bundled copies synced).

## The tracking point

Skipping the exposure event on mobile is deliberate, not incidental. `tour_exposed` defines both cohorts; if mobile users kept emitting it while being unable to see the tour, the `tour` arm would be diluted by exposed-but-untoured sessions and control would include users outside the experiment's addressable surface. With this gate, both cohorts contain only sessions that could actually receive the treatment — the funnel (admin `/admin/onboarding` card, vellum-ai/vellum-assistant-platform#9424) needs no changes and reads desktop-only by construction.

Edge case, accepted: the gate is evaluated once at the hand-off moment, so a desktop user who later narrows their window mid-tour keeps the running tour (measurements re-run on resize). Real mobile users never reach the tour at all.

## Checks

`tsc` clean, eslint clean, cross-domain audit passes, 687/687 web tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)