### PR TITLE
feat(web): restyle the sidebar assistant cluster (New Chat + assistant nav item)

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -1,10 +1,12 @@
 /**
- * The sidebar's assistant cluster: a "New Chat" row — a plus glyph inside
- * a circular chip, label beside it — with the "Your Assistant" nav row
- * directly beneath, dressed up as the assistant: a standard-height row
- * painted solid in the avatar's color with the avatar's eyes sitting in
- * the leading icon slot, centered on the same axis as the New Chat chip
- * so the two rows' labels align.
+ * The sidebar's assistant cluster: a "New Chat" row — a plus glyph with a
+ * label beside it, on the same avatar-tinted wash the identity page's
+ * feature cards wear — with the "Your Assistant" nav row directly beneath,
+ * dressed up as the assistant: a standard-height row painted solid in the
+ * avatar's color with the avatar's eyes sitting in the leading icon slot,
+ * centered on the same axis as the New Chat plus so the two rows' labels
+ * align. On the collapsed rail both rows survive as icon-only tiles
+ * (Figma 7257:135811).
  *
  * Periodically the eyes go on patrol: they sink out through the row's
  * bottom fold, resurface grown on the right side (cut off by the edge),
@@ -23,6 +25,7 @@
 
 import { Brain, Plus } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties } from "react";
 import { motion, useAnimationControls, useReducedMotion } from "motion/react";
 
 import { cn } from "@vellumai/design-library";
@@ -38,10 +41,14 @@ import { pathBBox, unionBBox } from "@/utils/eye-bbox";
 const ROW_HEIGHT = 30;
 /** Mobile-overlay row height, matching `SideMenu.Item`'s mobile row. */
 const MOBILE_ROW_HEIGHT = 44;
+/** The New Chat row runs taller than a standard nav row (Figma 7257:135743). */
+const NEW_CHAT_ROW_HEIGHT = 38;
+/** Collapsed-rail assistant tile height (Figma 7257:135820). */
+const COLLAPSED_ASSISTANT_ROW_HEIGHT = 32;
 const ROW_PADDING_X = 6;
 /**
- * Diameter of the New Chat row's circular plus chip; the assistant row's
- * leading eye slot is the same width so the eyes center on the chip's axis
+ * Width of the New Chat row's leading plus slot; the assistant row's
+ * leading eye slot is the same width so the eyes center on the plus's axis
  * and both labels start at the same x.
  */
 const CHIP_SIZE = 20;
@@ -111,7 +118,7 @@ export function AssistantNavItem({
   const eyesWidth = eye ? eyeStyleBaseWidth(eye.id) : 0;
   const eyesHeight = eye ? eyesWidth * (eye.bbox.h / eye.bbox.w) : 0;
 
-  const showNewConversation = Boolean(onNewConversation) && !collapsed;
+  const showNewConversation = Boolean(onNewConversation);
 
   useEffect(() => {
     if (navTourActive) {
@@ -214,6 +221,12 @@ export function AssistantNavItem({
       components.colors.find((c) => c.id === traits.color)?.hex) ||
     null;
 
+  // The row wears the identity page's feature-card wash — 28% of the
+  // avatar color mixed into the lifted surface, the Personality card's
+  // recipe (see `identity-overview.tsx` `--card-feature-bg`) — falling
+  // back to the plain hover treatment when there's no character avatar.
+  // While the tour owns the nav the wash drains away like the assistant
+  // row's color.
   const newConversationRow = showNewConversation ? (
     <button
       type="button"
@@ -223,31 +236,40 @@ export function AssistantNavItem({
       className={cn(
         "group relative flex w-full cursor-pointer items-center gap-[6px] overflow-hidden rounded-[8px] select-none",
         "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
-        "transition-colors duration-150 hover:bg-[var(--surface-hover)] active:scale-[0.98]",
+        "transition-colors duration-150 active:scale-[0.98]",
+        hex && !navTourActive
+          ? "bg-[color-mix(in_srgb,var(--assistant-tint)_28%,var(--surface-lift))] hover:bg-[color-mix(in_srgb,var(--assistant-tint)_36%,var(--surface-lift))]"
+          : "hover:bg-[var(--surface-hover)]",
+        collapsed && "justify-center",
       )}
-      style={{
-        height: rowHeight,
-        paddingLeft: ROW_PADDING_X,
-        paddingRight: ROW_PADDING_X,
-      }}
+      style={
+        {
+          height: isMobile ? MOBILE_ROW_HEIGHT : NEW_CHAT_ROW_HEIGHT,
+          paddingLeft: collapsed ? 0 : ROW_PADDING_X,
+          paddingRight: collapsed ? 0 : ROW_PADDING_X,
+          ...(hex ? { "--assistant-tint": hex } : null),
+        } as CSSProperties
+      }
     >
       <span
         aria-hidden="true"
-        className="flex shrink-0 items-center justify-center rounded-full bg-[var(--surface-active)]"
+        className="flex shrink-0 items-center justify-center"
         style={{ width: CHIP_SIZE, height: CHIP_SIZE }}
       >
         <Plus
           className="h-3.5 w-3.5"
-          style={{ color: "var(--content-emphasised)" }}
+          style={{ color: "var(--content-secondary)" }}
         />
       </span>
-      <span
-        className={`min-w-0 flex-1 truncate text-left text-[color:var(--content-secondary)] ${
-          isMobile ? "text-body-large-default" : "text-body-medium-lighter"
-        }`}
-      >
-        New Chat
-      </span>
+      {!collapsed && (
+        <span
+          className={`min-w-0 flex-1 truncate text-left text-[color:var(--content-default)] ${
+            isMobile ? "text-body-large-default" : "text-body-medium-lighter"
+          }`}
+        >
+          New Chat
+        </span>
+      )}
     </button>
   ) : null;
 
@@ -257,7 +279,7 @@ export function AssistantNavItem({
     // the same CHIP_SIZE slot the plus chip and the eyes use, so both
     // rows' labels stay on one axis.
     return (
-      <div className="flex flex-col gap-[4px]">
+      <div className="flex flex-col gap-[8px]">
         {newConversationRow}
         <button
           type="button"
@@ -266,7 +288,8 @@ export function AssistantNavItem({
           data-tour-id="assistant-page"
           aria-current={active ? "page" : undefined}
           className={cn(
-            "group relative flex w-full cursor-pointer items-center gap-[6px] overflow-hidden rounded-[8px] select-none",
+            "group relative flex w-full cursor-pointer items-center gap-[6px] overflow-hidden select-none",
+            collapsed ? "rounded-[8px]" : "rounded-[6px]",
             "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
             "transition-colors duration-150 active:scale-[0.98]",
             active
@@ -275,7 +298,7 @@ export function AssistantNavItem({
             collapsed && "justify-center",
           )}
           style={{
-            height: rowHeight,
+            height: collapsed ? COLLAPSED_ASSISTANT_ROW_HEIGHT : rowHeight,
             paddingLeft: collapsed ? 0 : ROW_PADDING_X,
             paddingRight: collapsed ? 0 : ROW_PADDING_X,
           }}
@@ -347,7 +370,8 @@ export function AssistantNavItem({
       data-tour-id="assistant-page"
       aria-current={active ? "page" : undefined}
       className={cn(
-        "group relative flex w-full cursor-pointer items-center gap-[6px] overflow-hidden rounded-[8px] select-none",
+        "group relative flex w-full cursor-pointer items-center gap-[6px] overflow-hidden select-none",
+        collapsed ? "rounded-[8px]" : "rounded-[6px]",
         "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
         "transition-[filter,transform,background-color,color] duration-300 active:scale-[0.98]",
         navTourActive
@@ -356,7 +380,7 @@ export function AssistantNavItem({
         collapsed && "justify-center",
       )}
       style={{
-        height: rowHeight,
+        height: collapsed ? COLLAPSED_ASSISTANT_ROW_HEIGHT : rowHeight,
         // While the tour owns the nav, the color leaves this row — it
         // drains to a plain nav item so the tour's flood is the only color
         // treatment on screen.
@@ -435,7 +459,7 @@ export function AssistantNavItem({
   );
 
   return (
-    <div className="flex flex-col gap-[4px]">
+    <div className="flex flex-col gap-[8px]">
       {newConversationRow}
       {assistantRow}
     </div>

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -309,11 +309,14 @@ export function AssistantSideMenu({
       ) : null}
       {/* The assistant cluster: the New Chat row (avatar-tinted, plus +
           label; icon-only tile on the collapsed rail) with the
-          avatar-gradient assistant row beneath it. No divider when
-          expanded; breathing room below instead. The overlay drawer skips
-          the New Chat row — its floating New Chat pill already owns that
-          action in the thumb zone. */}
-      <div className="mb-4">
+          avatar-colored assistant row beneath it. No divider when
+          expanded; breathing room below instead. On the collapsed rail
+          the separator provides the section break, so the margin drops
+          and the header's own gap (8px) plus the separator's margin keeps
+          the divider ~12px off the cluster (Figma 7257:135812). The
+          overlay drawer skips the New Chat row — its floating New Chat
+          pill already owns that action in the thumb zone. */}
+      <div className={isCollapsedRail ? undefined : "mb-4"}>
         <AssistantNavItem
           assistantId={assistantId ?? null}
           label={assistantName || "Your Assistant"}
@@ -370,7 +373,12 @@ export function AssistantSideMenu({
               /* pb-24 is a coarse floating-column reserve until the measured
                  inline padding below is applied. */
               ? "gap-4 pt-3 pb-24 max-md:pt-4"
-              : "gap-4 pt-3 max-md:pt-4"
+              /* The collapsed rail tucks the group icons up under the
+                 cluster separator (~12px to the first icon tile) so they
+                 read as the next section, not a distant island. */
+              : isCollapsedRail
+                ? "gap-4 pt-2"
+                : "gap-4 pt-3 max-md:pt-4"
           }
           style={
             variant === "overlay" && overlayBottomColumnHeight > 0

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -283,25 +283,6 @@ export function AssistantSideMenu({
     canReorder: !!onReorderConversations,
   };
 
-  // --- Header actions ---
-  // A plain icon button that starts a new conversation on click.
-
-  const headerActions = onStartNewConversation ? (
-    <Button
-      variant="ghost"
-      size="compact"
-      iconOnly={<SquarePen />}
-      aria-label="New Chat"
-      tooltip="New Chat"
-      tooltipSide="right"
-      className="text-[var(--content-tertiary)]"
-      onClick={() => {
-        onStartNewConversation();
-        onClose?.();
-      }}
-    />
-  ) : null;
-
   // --- Built-in navigation ---
   // Pinned apps above the built-in nav, separated by a divider. On the rail
   // this block lives in the non-scrolling header; on the overlay it renders
@@ -326,11 +307,12 @@ export function AssistantSideMenu({
           <SideMenu.Separator />
         </>
       ) : null}
-      {/* The assistant cluster: the New Chat row (plus chip + label) with
-          the avatar-colored assistant row beneath it. No divider; breathing
-          room below instead. The overlay drawer skips the New Chat row —
-          its floating New Chat pill already owns that action in the thumb
-          zone. */}
+      {/* The assistant cluster: the New Chat row (avatar-tinted, plus +
+          label; icon-only tile on the collapsed rail) with the
+          avatar-gradient assistant row beneath it. No divider when
+          expanded; breathing room below instead. The overlay drawer skips
+          the New Chat row — its floating New Chat pill already owns that
+          action in the thumb zone. */}
       <div className="mb-4">
         <AssistantNavItem
           assistantId={assistantId ?? null}
@@ -345,6 +327,9 @@ export function AssistantSideMenu({
           }
         />
       </div>
+      {/* The collapsed rail separates the cluster from the group icons
+          below it (Figma 7257:135826). */}
+      {isCollapsedRail ? <SideMenu.Separator /> : null}
     </>
   );
 
@@ -403,7 +388,6 @@ export function AssistantSideMenu({
           {variant === "overlay" ? builtInNav : null}
           {isCollapsedRail ? (
             <div className="flex flex-col items-center gap-2">
-              {headerActions}
               {sidebar.pinned.length > 0 ? (
                 <CollapsedGroupIcon
                   icon={Pin}


### PR DESCRIPTION
## Summary

Restyles the sidebar's assistant cluster to the new Figma look ([expanded 7257:135740](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=7257-135740), [collapsed 7257:135811](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=7257-135811)).

- **New Chat row**: now sits on the identity page's feature-card wash — `color-mix(in srgb, avatarHex 28%, var(--surface-lift))`, the same recipe the Personality card uses (`identity-overview.tsx` `--card-feature-bg`) — with a 36% mix on hover. Runs taller (38px vs the standard 30px row), drops the circular plus chip for a bare glyph in `--content-secondary`, label bumped to `--content-default`. Falls back to the plain hover-only treatment when there's no character avatar.
- **Assistant row**: stays solid avatar color; radius follows Figma (6px expanded, matching standard `SideMenu.Item` rows; 8px collapsed at a 32px tile).
- **Collapsed rail**: the New Chat tile now renders above the eyes tile inside the cluster (replacing the SquarePen icon button that used to sit in the collapsed column), with a separator between the cluster and the group icons.
- Cluster gap 4px → 8px per Figma.

The eyes animation — patrol loop, blink timing, collapsed pulse, and its alignment axis with the plus slot — is untouched; only container background/radius/height styles changed. The in-chat tour's drain-to-plain behavior extends to the New Chat wash so the tour's flood stays the only color treatment on screen.

Since the tint mixes the avatar color into theme tokens (not hardcoded Figma hexes), it tracks any avatar color and works across light/dark/velvet.

## Testing

- `bunx tsc --noEmit`, `bun run lint` on touched files — clean
- `bun test src/domains/chat/components/assistant-side-menu.test.tsx` — 22 pass
- `bun run build` — passes
- Visually QA'd in dev (expanded + collapsed rail, light mode with orange avatar, dark mode with green avatar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)