### PR TITLE
feat(web): support an optional secondary CTA on BillingErrorBanner

### DIFF
--- a/clients/web/src/domains/chat/components/billing-error-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for the shared `BillingErrorBanner` primitive.
+ *
+ * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
+ * and drives the CTAs with `fireEvent`. No jest-dom matchers — we assert with
+ * plain bun `expect` against query results.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { BillingErrorBanner } from "./billing-error-banner";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BillingErrorBanner", () => {
+  test("renders a single primary CTA and its icon", () => {
+    const onAction = mock(() => {});
+
+    const { getAllByRole, getByText, getByTestId } = render(
+      <BillingErrorBanner
+        ariaLabel="Billing notice"
+        icon={<span data-testid="banner-icon">!</span>}
+        title="Title"
+        subtitle="Subtitle"
+        ctaLabel="Upgrade"
+        onAction={onAction}
+      />,
+    );
+
+    expect(getByText("Title")).toBeTruthy();
+    expect(getByText("Subtitle")).toBeTruthy();
+    expect(getByTestId("banner-icon")).toBeTruthy();
+
+    const buttons = getAllByRole("button");
+    expect(buttons.length).toBe(1);
+
+    fireEvent.click(buttons[0]!);
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  test("omits the icon column when no icon is provided", () => {
+    const { getByText, queryByTestId } = render(
+      <BillingErrorBanner
+        ariaLabel="Billing notice"
+        title="Title"
+        subtitle="Subtitle"
+        ctaLabel="Upgrade"
+        onAction={() => {}}
+      />,
+    );
+
+    expect(getByText("Title")).toBeTruthy();
+    expect(queryByTestId("banner-icon")).toBeNull();
+  });
+
+  test("renders a secondary CTA to the left of the primary and wires each action", () => {
+    const onAction = mock(() => {});
+    const onSecondaryAction = mock(() => {});
+
+    const { getByRole } = render(
+      <BillingErrorBanner
+        ariaLabel="Billing notice"
+        title="Title"
+        subtitle="Subtitle"
+        ctaLabel="Upgrade"
+        onAction={onAction}
+        secondaryCtaLabel="Add Credits"
+        onSecondaryAction={onSecondaryAction}
+      />,
+    );
+
+    const secondary = getByRole("button", { name: "Add Credits" });
+    const primary = getByRole("button", { name: "Upgrade" });
+    expect(secondary).toBeTruthy();
+    expect(primary).toBeTruthy();
+
+    fireEvent.click(secondary);
+    expect(onSecondaryAction).toHaveBeenCalledTimes(1);
+    expect(onAction).not.toHaveBeenCalled();
+
+    fireEvent.click(primary);
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  test("exposes role=status with the provided aria-label", () => {
+    const { getByRole } = render(
+      <BillingErrorBanner
+        ariaLabel="Billing notice"
+        title="Title"
+        subtitle="Subtitle"
+        ctaLabel="Upgrade"
+        onAction={() => {}}
+      />,
+    );
+
+    expect(getByRole("status", { name: "Billing notice" })).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/components/billing-error-banner.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.tsx
@@ -5,11 +5,13 @@ import { Button } from "@vellumai/design-library";
 
 interface BillingErrorBannerProps {
   ariaLabel: string;
-  icon: ReactNode;
+  icon?: ReactNode;
   title: string;
   subtitle: string;
   ctaLabel: string;
   onAction: () => void;
+  secondaryCtaLabel?: string;
+  onSecondaryAction?: () => void;
 }
 
 export function BillingErrorBanner({
@@ -19,6 +21,8 @@ export function BillingErrorBanner({
   subtitle,
   ctaLabel,
   onAction,
+  secondaryCtaLabel,
+  onSecondaryAction,
 }: BillingErrorBannerProps) {
   return (
     <div
@@ -33,12 +37,14 @@ export function BillingErrorBanner({
       aria-label={ariaLabel}
     >
       <div className="flex flex-1 items-center gap-3 px-4 py-3">
-        <span
-          className="flex size-8 shrink-0 items-center justify-center"
-          aria-hidden="true"
-        >
-          {icon}
-        </span>
+        {icon ? (
+          <span
+            className="flex size-8 shrink-0 items-center justify-center"
+            aria-hidden="true"
+          >
+            {icon}
+          </span>
+        ) : null}
 
         <div className="min-w-0 flex-1">
           <p
@@ -55,14 +61,27 @@ export function BillingErrorBanner({
           </p>
         </div>
 
-        <Button
-          variant="primary"
-          size="regular"
-          onClick={onAction}
-          aria-label={ctaLabel}
-        >
-          {ctaLabel}
-        </Button>
+        <div className="flex items-center gap-2 shrink-0">
+          {secondaryCtaLabel && onSecondaryAction ? (
+            <Button
+              variant="outlined"
+              size="regular"
+              onClick={onSecondaryAction}
+              aria-label={secondaryCtaLabel}
+            >
+              {secondaryCtaLabel}
+            </Button>
+          ) : null}
+
+          <Button
+            variant="primary"
+            size="regular"
+            onClick={onAction}
+            aria-label={ctaLabel}
+          >
+            {ctaLabel}
+          </Button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Make BillingErrorBanner's `icon` optional (icon column renders only when provided) and add optional `secondaryCtaLabel` + `onSecondaryAction` for a secondary outlined CTA left of the primary.
- Additive/backward-compatible: DailyLimitBanner and ProviderBillingBanner are unaffected.
- Adds a test covering primary-only, no-icon, and secondary-CTA cases.

Part of plan: credits-paywall-redesign.md (PR 1 of 3)