### PR TITLE
feat(web): restyle the Add Credits modal to match the new mock

### DIFF
--- a/clients/web/src/components/add-credits-modal.test.tsx
+++ b/clients/web/src/components/add-credits-modal.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import { routes } from "@/utils/routes";
+
+mock.module("@/runtime/browser", () => ({
+  openUrl: () => Promise.resolve(),
+  openUrlFinishedListener: () => () => {},
+}));
+
+const { AddCreditsModal } = await import("@/components/add-credits-modal");
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderModal() {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <AddCreditsModal open onOpenChange={() => {}} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AddCreditsModal", () => {
+  test("renders the updated copy and labels", () => {
+    renderModal();
+
+    expect(screen.getByText("Add Credits")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "You'll be redirected to Stripe to complete the payment.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Continue" })).toBeTruthy();
+  });
+
+  test("links the automatic top-ups control to the billing route", () => {
+    renderModal();
+
+    const link = screen.getByRole("link", {
+      name: /Configure Automatic Top-Ups/,
+    });
+    expect(link.getAttribute("href")).toBe(routes.settings.usageBilling);
+  });
+});

--- a/clients/web/src/components/add-credits-modal.tsx
+++ b/clients/web/src/components/add-credits-modal.tsx
@@ -1,5 +1,5 @@
 
-import { AlertCircle, CreditCard, Loader2 } from "lucide-react";
+import { AlertCircle, ChevronRight, Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link, useLocation, useSearchParams } from "react-router";
 
@@ -118,10 +118,9 @@ export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
     <Modal.Root open={open} onOpenChange={onOpenChange}>
       <Modal.Content size="sm">
         <Modal.Header>
-          <Modal.Title icon={CreditCard}>Add Credits</Modal.Title>
+          <Modal.Title>Add Credits</Modal.Title>
           <Modal.Description>
-            Purchase credits to continue using the assistant. You&apos;ll be
-            redirected to Stripe to complete the payment.
+            You&apos;ll be redirected to Stripe to complete the payment.
           </Modal.Description>
         </Modal.Header>
 
@@ -160,11 +159,14 @@ export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
 
             <Link
               to={routes.settings.usageBilling}
-              className="text-body-small-default text-[var(--content-tertiary)] underline hover:text-[var(--content-secondary)]"
+              className="flex items-center gap-1 text-body-small-default text-[var(--content-tertiary)] hover:text-[var(--content-secondary)]"
               onClick={() => onOpenChange(false)}
             >
-              Configure Automatic Top-Ups →
+              Configure Automatic Top-Ups
+              <ChevronRight className="size-4" />
             </Link>
+
+            <div className="h-px w-full bg-[var(--border-subtle)]" />
           </div>
         </Modal.Body>
 
@@ -182,7 +184,7 @@ export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
             onClick={handleAddFunds}
             disabled={checkoutMutation.isPending || isLoading || !summary}
           >
-            Add credits
+            Continue
           </Button>
         </Modal.Footer>
       </Modal.Content>


### PR DESCRIPTION
## Summary
- Restyle the Add Credits modal to the new mock: no title icon, description "You'll be redirected to Stripe to complete the payment.", primary CTA "Continue", and a "Configure Automatic Top-Ups" row with a chevron + divider.
- Shared modal — also reflected in Settings → Billing.
- Adds a rendering test for the updated copy/labels.

Part of plan: credits-paywall-redesign.md (PR 3 of 3)