### PR TITLE
feat(web): redesign the credit-wall paywall with Add Credits + Upgrade CTAs

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -68,6 +68,12 @@ import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
+const AddCreditsModal = lazy(() =>
+  import("@/components/add-credits-modal").then((m) => ({
+    default: m.AddCreditsModal,
+  })),
+);
+
 const DeployDialogs = lazy(() =>
   import("@/components/deploy-dialogs").then((m) => ({
     default: m.DeployDialogs,
@@ -105,6 +111,7 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   const [refreshEpoch, setRefreshEpoch] = useState(0);
   const [assetsRefreshKey, setAssetsRefreshKey] = useState(0);
+  const [showAddCreditsModal, setShowAddCreditsModal] = useState(false);
 
   // -------------------------------------------------------------------------
   // Zustand store selectors
@@ -537,6 +544,7 @@ export function ActiveChatView() {
 
     // Upward signals
     setRefreshEpoch,
+    setShowAddCreditsModal,
 
     // Shared refs
     inputRef,
@@ -554,6 +562,15 @@ export function ActiveChatView() {
   return (
     <>
       <ChatContentLayout {...chatRouteProps} />
+
+      {showAddCreditsModal ? (
+        <LazyBoundary>
+          <AddCreditsModal
+            open={showAddCreditsModal}
+            onOpenChange={setShowAddCreditsModal}
+          />
+        </LazyBoundary>
+      ) : null}
 
       {assistantId && (isTokenDialogOpen || complexDeployApp) ? (
         <LazyBoundary>

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -147,6 +147,7 @@ export interface ChatMainPanelProps {
 
   // Upward signals to ActiveChatView local state
   setRefreshEpoch: Dispatch<SetStateAction<number>>;
+  setShowAddCreditsModal: Dispatch<SetStateAction<boolean>>;
 
   // Shared refs (owned by ActiveChatView for debug API / keydown handler)
   inputRef: RefObject<HTMLTextAreaElement | null>;
@@ -221,6 +222,7 @@ export function ChatMainPanel({
   historyPagination,
   diskPressure,
   setRefreshEpoch,
+  setShowAddCreditsModal,
   inputRef,
   sanitizedMessagesRef,
   transcriptItemsRef,
@@ -988,7 +990,10 @@ export function ChatMainPanel({
             billingBannerDecision === "daily_limit" ? (
               <DailyLimitBanner onAdjustLimit={pushToBillingSettings} />
             ) : billingBannerDecision === "managed_credits" ? (
-              <CreditsExhaustedBanner onUpgrade={pushToPlansTakeover} />
+              <CreditsExhaustedBanner
+                onAddCredits={() => setShowAddCreditsModal(true)}
+                onUpgrade={pushToPlansTakeover}
+              />
             ) : billingBannerDecision === "provider_billing" ? (
               <ProviderBillingBanner onOpenSettings={pushToAiSettings} />
             ) : null

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
@@ -1,9 +1,10 @@
 /**
- * Tests for the out-of-credits `CreditsExhaustedBanner`.
+ * Tests for `CreditsExhaustedBanner` — the two-CTA credit wall.
  *
  * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
- * and drives the CTA with `fireEvent`. No jest-dom matchers — we assert with
- * plain bun `expect` against query results.
+ * and drives the CTAs with `fireEvent`. No jest-dom matchers — we assert with
+ * plain bun `expect` against query results. The title carries an inline emoji,
+ * so it is matched with a regex that tolerates the prefix.
  */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
@@ -15,26 +16,48 @@ afterEach(() => {
 });
 
 describe("CreditsExhaustedBanner", () => {
-  test("renders the title, subtitle, and an Upgrade CTA", () => {
+  test("renders the title, subtitle, and both CTAs", () => {
     const { getByText, getByRole } = render(
-      <CreditsExhaustedBanner onUpgrade={() => {}} />,
+      <CreditsExhaustedBanner onAddCredits={() => {}} onUpgrade={() => {}} />,
     );
 
-    expect(getByText("Your credit balance has run out")).toBeTruthy();
+    expect(getByText(/Your balance has run out/)).toBeTruthy();
     expect(
-      getByText("Upgrade your plan for more credits every month."),
+      getByText("Upgrade to a higher plan or add credits to continue."),
     ).toBeTruthy();
-    expect(getByRole("button", { name: /upgrade/i })).toBeTruthy();
+    expect(getByRole("button", { name: "Add Credits" })).toBeTruthy();
+    expect(getByRole("button", { name: "Upgrade" })).toBeTruthy();
   });
 
-  test("fires onUpgrade once when the CTA is clicked", () => {
+  test("clicking Add Credits fires onAddCredits only", () => {
+    const onAddCredits = mock(() => {});
     const onUpgrade = mock(() => {});
 
     const { getByRole } = render(
-      <CreditsExhaustedBanner onUpgrade={onUpgrade} />,
+      <CreditsExhaustedBanner
+        onAddCredits={onAddCredits}
+        onUpgrade={onUpgrade}
+      />,
     );
 
-    fireEvent.click(getByRole("button", { name: /upgrade/i }));
+    fireEvent.click(getByRole("button", { name: "Add Credits" }));
+    expect(onAddCredits).toHaveBeenCalledTimes(1);
+    expect(onUpgrade).not.toHaveBeenCalled();
+  });
+
+  test("clicking Upgrade fires onUpgrade only", () => {
+    const onAddCredits = mock(() => {});
+    const onUpgrade = mock(() => {});
+
+    const { getByRole } = render(
+      <CreditsExhaustedBanner
+        onAddCredits={onAddCredits}
+        onUpgrade={onUpgrade}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Upgrade" }));
     expect(onUpgrade).toHaveBeenCalledTimes(1);
+    expect(onAddCredits).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
@@ -2,18 +2,21 @@
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
 
 interface CreditsExhaustedBannerProps {
+  onAddCredits: () => void;
   onUpgrade: () => void;
 }
 
 export function CreditsExhaustedBanner({
+  onAddCredits,
   onUpgrade,
 }: CreditsExhaustedBannerProps) {
   return (
     <BillingErrorBanner
-      ariaLabel="Your credit balance has run out. Upgrade your plan for more credits."
-      icon={<span style={{ fontSize: "1.25rem" }}>💰</span>}
-      title="Your credit balance has run out"
-      subtitle="Upgrade your plan for more credits every month."
+      ariaLabel="Your balance has run out. Upgrade to a higher plan or add credits to continue."
+      title="💰  Your balance has run out"
+      subtitle="Upgrade to a higher plan or add credits to continue."
+      secondaryCtaLabel="Add Credits"
+      onSecondaryAction={onAddCredits}
       ctaLabel="Upgrade"
       onAction={onUpgrade}
     />


### PR DESCRIPTION
## Summary
- Credit wall now shows two CTAs matching the mock: outlined "Add Credits" (opens the in-chat top-up modal) + primary "Upgrade" (opens the plans takeover); inline 💰 title, no icon column; refreshed copy.
- Restores the in-chat AddCreditsModal wiring in active-chat-view.tsx and the setShowAddCreditsModal prop in chat-route-content.tsx.
- Adds a test covering both CTAs.

Part of plan: credits-paywall-redesign.md (PR 2 of 3)