### PR TITLE
Credits paywall UI redesign (two-CTA wall + restyled Add Credits modal)

### DIFF
--- a/clients/web/src/components/add-credits-modal.test.tsx
+++ b/clients/web/src/components/add-credits-modal.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import { routes } from "@/utils/routes";
+
+mock.module("@/runtime/browser", () => ({
+  openUrl: () => Promise.resolve(),
+  openUrlFinishedListener: () => () => {},
+}));
+
+const { AddCreditsModal } = await import("@/components/add-credits-modal");
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderModal() {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <AddCreditsModal open onOpenChange={() => {}} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AddCreditsModal", () => {
+  test("renders the updated copy and labels", () => {
+    renderModal();
+
+    expect(screen.getByText("Add Credits")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "You'll be redirected to Stripe to complete the payment.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Continue" })).toBeTruthy();
+  });
+
+  test("links the automatic top-ups control to the billing route", () => {
+    renderModal();
+
+    const link = screen.getByRole("link", {
+      name: /Configure Automatic Top-Ups/,
+    });
+    expect(link.getAttribute("href")).toBe(routes.settings.usageBilling);
+  });
+});

--- a/clients/web/src/components/add-credits-modal.tsx
+++ b/clients/web/src/components/add-credits-modal.tsx
@@ -1,5 +1,5 @@
 
-import { AlertCircle, CreditCard, Loader2 } from "lucide-react";
+import { AlertCircle, ChevronRight, Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link, useLocation, useSearchParams } from "react-router";
 
@@ -118,10 +118,9 @@ export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
     <Modal.Root open={open} onOpenChange={onOpenChange}>
       <Modal.Content size="sm">
         <Modal.Header>
-          <Modal.Title icon={CreditCard}>Add Credits</Modal.Title>
+          <Modal.Title>Add Credits</Modal.Title>
           <Modal.Description>
-            Purchase credits to continue using the assistant. You&apos;ll be
-            redirected to Stripe to complete the payment.
+            You&apos;ll be redirected to Stripe to complete the payment.
           </Modal.Description>
         </Modal.Header>
 
@@ -160,11 +159,14 @@ export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
 
             <Link
               to={routes.settings.usageBilling}
-              className="text-body-small-default text-[var(--content-tertiary)] underline hover:text-[var(--content-secondary)]"
+              className="flex items-center gap-1 text-body-small-default text-[var(--content-tertiary)] hover:text-[var(--content-secondary)]"
               onClick={() => onOpenChange(false)}
             >
-              Configure Automatic Top-Ups →
+              Configure Automatic Top-Ups
+              <ChevronRight className="size-4" />
             </Link>
+
+            <div className="h-px w-full bg-[var(--border-subtle)]" />
           </div>
         </Modal.Body>
 
@@ -182,7 +184,7 @@ export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
             onClick={handleAddFunds}
             disabled={checkoutMutation.isPending || isLoading || !summary}
           >
-            Add credits
+            Continue
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -68,6 +68,12 @@ import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
+const AddCreditsModal = lazy(() =>
+  import("@/components/add-credits-modal").then((m) => ({
+    default: m.AddCreditsModal,
+  })),
+);
+
 const DeployDialogs = lazy(() =>
   import("@/components/deploy-dialogs").then((m) => ({
     default: m.DeployDialogs,
@@ -105,6 +111,7 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   const [refreshEpoch, setRefreshEpoch] = useState(0);
   const [assetsRefreshKey, setAssetsRefreshKey] = useState(0);
+  const [showAddCreditsModal, setShowAddCreditsModal] = useState(false);
 
   // -------------------------------------------------------------------------
   // Zustand store selectors
@@ -537,6 +544,7 @@ export function ActiveChatView() {
 
     // Upward signals
     setRefreshEpoch,
+    setShowAddCreditsModal,
 
     // Shared refs
     inputRef,
@@ -554,6 +562,15 @@ export function ActiveChatView() {
   return (
     <>
       <ChatContentLayout {...chatRouteProps} />
+
+      {showAddCreditsModal ? (
+        <LazyBoundary>
+          <AddCreditsModal
+            open={showAddCreditsModal}
+            onOpenChange={setShowAddCreditsModal}
+          />
+        </LazyBoundary>
+      ) : null}
 
       {assistantId && (isTokenDialogOpen || complexDeployApp) ? (
         <LazyBoundary>

--- a/clients/web/src/domains/chat/components/billing-error-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for the shared `BillingErrorBanner` primitive.
+ *
+ * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
+ * and drives the CTAs with `fireEvent`. No jest-dom matchers — we assert with
+ * plain bun `expect` against query results.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { BillingErrorBanner } from "./billing-error-banner";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BillingErrorBanner", () => {
+  test("renders a single primary CTA and its icon", () => {
+    const onAction = mock(() => {});
+
+    const { getAllByRole, getByText, getByTestId } = render(
+      <BillingErrorBanner
+        ariaLabel="Billing notice"
+        icon={<span data-testid="banner-icon">!</span>}
+        title="Title"
+        subtitle="Subtitle"
+        ctaLabel="Upgrade"
+        onAction={onAction}
+      />,
+    );
+
+    expect(getByText("Title")).toBeTruthy();
+    expect(getByText("Subtitle")).toBeTruthy();
+    expect(getByTestId("banner-icon")).toBeTruthy();
+
+    const buttons = getAllByRole("button");
+    expect(buttons.length).toBe(1);
+
+    fireEvent.click(buttons[0]!);
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  test("omits the icon column when no icon is provided", () => {
+    const { getByText, queryByTestId } = render(
+      <BillingErrorBanner
+        ariaLabel="Billing notice"
+        title="Title"
+        subtitle="Subtitle"
+        ctaLabel="Upgrade"
+        onAction={() => {}}
+      />,
+    );
+
+    expect(getByText("Title")).toBeTruthy();
+    expect(queryByTestId("banner-icon")).toBeNull();
+  });
+
+  test("renders a secondary CTA to the left of the primary and wires each action", () => {
+    const onAction = mock(() => {});
+    const onSecondaryAction = mock(() => {});
+
+    const { getByRole } = render(
+      <BillingErrorBanner
+        ariaLabel="Billing notice"
+        title="Title"
+        subtitle="Subtitle"
+        ctaLabel="Upgrade"
+        onAction={onAction}
+        secondaryCtaLabel="Add Credits"
+        onSecondaryAction={onSecondaryAction}
+      />,
+    );
+
+    const secondary = getByRole("button", { name: "Add Credits" });
+    const primary = getByRole("button", { name: "Upgrade" });
+    expect(secondary).toBeTruthy();
+    expect(primary).toBeTruthy();
+
+    fireEvent.click(secondary);
+    expect(onSecondaryAction).toHaveBeenCalledTimes(1);
+    expect(onAction).not.toHaveBeenCalled();
+
+    fireEvent.click(primary);
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  test("exposes role=status with the provided aria-label", () => {
+    const { getByRole } = render(
+      <BillingErrorBanner
+        ariaLabel="Billing notice"
+        title="Title"
+        subtitle="Subtitle"
+        ctaLabel="Upgrade"
+        onAction={() => {}}
+      />,
+    );
+
+    expect(getByRole("status", { name: "Billing notice" })).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/components/billing-error-banner.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.tsx
@@ -5,11 +5,13 @@ import { Button } from "@vellumai/design-library";
 
 interface BillingErrorBannerProps {
   ariaLabel: string;
-  icon: ReactNode;
+  icon?: ReactNode;
   title: string;
   subtitle: string;
   ctaLabel: string;
   onAction: () => void;
+  secondaryCtaLabel?: string;
+  onSecondaryAction?: () => void;
 }
 
 export function BillingErrorBanner({
@@ -19,6 +21,8 @@ export function BillingErrorBanner({
   subtitle,
   ctaLabel,
   onAction,
+  secondaryCtaLabel,
+  onSecondaryAction,
 }: BillingErrorBannerProps) {
   return (
     <div
@@ -33,12 +37,14 @@ export function BillingErrorBanner({
       aria-label={ariaLabel}
     >
       <div className="flex flex-1 items-center gap-3 px-4 py-3">
-        <span
-          className="flex size-8 shrink-0 items-center justify-center"
-          aria-hidden="true"
-        >
-          {icon}
-        </span>
+        {icon ? (
+          <span
+            className="flex size-8 shrink-0 items-center justify-center"
+            aria-hidden="true"
+          >
+            {icon}
+          </span>
+        ) : null}
 
         <div className="min-w-0 flex-1">
           <p
@@ -55,14 +61,27 @@ export function BillingErrorBanner({
           </p>
         </div>
 
-        <Button
-          variant="primary"
-          size="regular"
-          onClick={onAction}
-          aria-label={ctaLabel}
-        >
-          {ctaLabel}
-        </Button>
+        <div className="flex items-center gap-2 shrink-0">
+          {secondaryCtaLabel && onSecondaryAction ? (
+            <Button
+              variant="outlined"
+              size="regular"
+              onClick={onSecondaryAction}
+              aria-label={secondaryCtaLabel}
+            >
+              {secondaryCtaLabel}
+            </Button>
+          ) : null}
+
+          <Button
+            variant="primary"
+            size="regular"
+            onClick={onAction}
+            aria-label={ctaLabel}
+          >
+            {ctaLabel}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -147,6 +147,7 @@ export interface ChatMainPanelProps {
 
   // Upward signals to ActiveChatView local state
   setRefreshEpoch: Dispatch<SetStateAction<number>>;
+  setShowAddCreditsModal: Dispatch<SetStateAction<boolean>>;
 
   // Shared refs (owned by ActiveChatView for debug API / keydown handler)
   inputRef: RefObject<HTMLTextAreaElement | null>;
@@ -221,6 +222,7 @@ export function ChatMainPanel({
   historyPagination,
   diskPressure,
   setRefreshEpoch,
+  setShowAddCreditsModal,
   inputRef,
   sanitizedMessagesRef,
   transcriptItemsRef,
@@ -988,7 +990,10 @@ export function ChatMainPanel({
             billingBannerDecision === "daily_limit" ? (
               <DailyLimitBanner onAdjustLimit={pushToBillingSettings} />
             ) : billingBannerDecision === "managed_credits" ? (
-              <CreditsExhaustedBanner onUpgrade={pushToPlansTakeover} />
+              <CreditsExhaustedBanner
+                onAddCredits={() => setShowAddCreditsModal(true)}
+                onUpgrade={pushToPlansTakeover}
+              />
             ) : billingBannerDecision === "provider_billing" ? (
               <ProviderBillingBanner onOpenSettings={pushToAiSettings} />
             ) : null

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
@@ -1,9 +1,10 @@
 /**
- * Tests for the out-of-credits `CreditsExhaustedBanner`.
+ * Tests for `CreditsExhaustedBanner` — the two-CTA credit wall.
  *
  * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
- * and drives the CTA with `fireEvent`. No jest-dom matchers — we assert with
- * plain bun `expect` against query results.
+ * and drives the CTAs with `fireEvent`. No jest-dom matchers — we assert with
+ * plain bun `expect` against query results. The title carries an inline emoji,
+ * so it is matched with a regex that tolerates the prefix.
  */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
@@ -15,26 +16,48 @@ afterEach(() => {
 });
 
 describe("CreditsExhaustedBanner", () => {
-  test("renders the title, subtitle, and an Upgrade CTA", () => {
+  test("renders the title, subtitle, and both CTAs", () => {
     const { getByText, getByRole } = render(
-      <CreditsExhaustedBanner onUpgrade={() => {}} />,
+      <CreditsExhaustedBanner onAddCredits={() => {}} onUpgrade={() => {}} />,
     );
 
-    expect(getByText("Your credit balance has run out")).toBeTruthy();
+    expect(getByText(/Your balance has run out/)).toBeTruthy();
     expect(
-      getByText("Upgrade your plan for more credits every month."),
+      getByText("Upgrade to a higher plan or add credits to continue."),
     ).toBeTruthy();
-    expect(getByRole("button", { name: /upgrade/i })).toBeTruthy();
+    expect(getByRole("button", { name: "Add Credits" })).toBeTruthy();
+    expect(getByRole("button", { name: "Upgrade" })).toBeTruthy();
   });
 
-  test("fires onUpgrade once when the CTA is clicked", () => {
+  test("clicking Add Credits fires onAddCredits only", () => {
+    const onAddCredits = mock(() => {});
     const onUpgrade = mock(() => {});
 
     const { getByRole } = render(
-      <CreditsExhaustedBanner onUpgrade={onUpgrade} />,
+      <CreditsExhaustedBanner
+        onAddCredits={onAddCredits}
+        onUpgrade={onUpgrade}
+      />,
     );
 
-    fireEvent.click(getByRole("button", { name: /upgrade/i }));
+    fireEvent.click(getByRole("button", { name: "Add Credits" }));
+    expect(onAddCredits).toHaveBeenCalledTimes(1);
+    expect(onUpgrade).not.toHaveBeenCalled();
+  });
+
+  test("clicking Upgrade fires onUpgrade only", () => {
+    const onAddCredits = mock(() => {});
+    const onUpgrade = mock(() => {});
+
+    const { getByRole } = render(
+      <CreditsExhaustedBanner
+        onAddCredits={onAddCredits}
+        onUpgrade={onUpgrade}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Upgrade" }));
     expect(onUpgrade).toHaveBeenCalledTimes(1);
+    expect(onAddCredits).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
@@ -2,18 +2,21 @@
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
 
 interface CreditsExhaustedBannerProps {
+  onAddCredits: () => void;
   onUpgrade: () => void;
 }
 
 export function CreditsExhaustedBanner({
+  onAddCredits,
   onUpgrade,
 }: CreditsExhaustedBannerProps) {
   return (
     <BillingErrorBanner
-      ariaLabel="Your credit balance has run out. Upgrade your plan for more credits."
-      icon={<span style={{ fontSize: "1.25rem" }}>💰</span>}
-      title="Your credit balance has run out"
-      subtitle="Upgrade your plan for more credits every month."
+      ariaLabel="Your balance has run out. Upgrade to a higher plan or add credits to continue."
+      title="💰  Your balance has run out"
+      subtitle="Upgrade to a higher plan or add credits to continue."
+      secondaryCtaLabel="Add Credits"
+      onSecondaryAction={onAddCredits}
       ctaLabel="Upgrade"
       onAction={onUpgrade}
     />


### PR DESCRIPTION
## Summary
Updates the out-of-credits paywall in the chat composer to match the new Figma mocks:
- The credit wall now shows **two CTAs** — outlined **"Add Credits"** (opens the in-chat top-up modal) + primary **"Upgrade"** (opens the plans takeover) — with refreshed copy and an inline 💰 title (no separate icon column).
- The **Add Credits modal** is restyled to its mock: no title icon, description "You'll be redirected to Stripe to complete the payment.", primary CTA **"Continue"**, and a "Configure Automatic Top-Ups" row with a chevron + divider.

This builds on #38818 (already on main): that change had replaced "Add Funds" with a single "Upgrade" CTA and removed the in-chat modal wiring. These mocks bring the top-up path **back alongside** the upgrade path, so this restores the in-chat `AddCreditsModal` wiring #38818 removed.

## Self-review result
PASS on 3/4 fresh-eyes passes (external feedback, plan faithfulness, integration). The slop/reuse pass raised 3 findings, all triaged as **non-actionable**:
1. Emoji-in-title + optional-icon is the deliberate "match the mock" design (no icon column); the title/aria-label split is an intentional a11y choice — not reverting.
2. `open={showAddCreditsModal}` inside its mount gate is a verbatim restoration of the pre-existing lazy-modal pattern (mirrors `DeployDialogs`).
3. The wrapper test locks exact copy + the callback-to-slot mapping — distinct value, not pure duplication.

## PRs merged into this feature branch
- #38825 — feat(web): support an optional secondary CTA on BillingErrorBanner
- #38826 — feat(web): restyle the Add Credits modal to match the new mock
- #38827 — feat(web): redesign the credit-wall paywall with Add Credits + Upgrade CTAs

## Things to be aware of
- **`pro-packages` LaunchDarkly flag (rollout):** the "Upgrade" CTA lands on the real plans takeover only where `pro-packages` is enabled (prod). In flag-off cohorts the takeover gracefully self-redirects to the billing usage tab — no dead-end.
- **Shared modal:** the restyled `AddCreditsModal` is also opened from Settings → Billing (`billing-panel.tsx`); the copy/label changes apply there too (intended, consistent).
- **Default top-up amount:** the mock shows "30 credits" illustratively; the default-amount logic is unchanged (still the first allowed amount).
- **Banner chrome:** the shared container's radius/padding are left at the primitive's current values (shared with the two sibling banners that have no mock); the deltas vs the mock are imperceptible. Happy to make all three banners pixel-exact as a follow-up.

Part of plan: credits-paywall-redesign.md