### PR TITLE
feat(plugin-api): ship window.vellum app-bridge types

### DIFF
--- a/assistant/scripts/build-plugin-api.ts
+++ b/assistant/scripts/build-plugin-api.ts
@@ -255,7 +255,21 @@ function main(): void {
 
   // 5. Assemble the publishable package directory.
   mkdirSync(pkgDir, { recursive: true });
-  cpSync(rollup, join(pkgDir, "index.d.ts"));
+
+  // Ship the app-side ambient global (`window.vellum`) as `app.d.ts`, exposed
+  // via the `@vellumai/plugin-api/app` subpath. Plugin *apps* reference it
+  // (`/// <reference types="@vellumai/plugin-api/app" />` or a tsconfig
+  // `types` entry) instead of hand-declaring `window.vellum`. The main rollup
+  // triple-slash-references it too, so importing anything from the package
+  // also pulls the global in.
+  cpSync(
+    join(ASSISTANT_DIR, "src", "plugin-api", "app-globals.d.ts"),
+    join(pkgDir, "app.d.ts"),
+  );
+  writeFileSync(
+    join(pkgDir, "index.d.ts"),
+    `/// <reference path="./app.d.ts" />\n${readFileSync(rollup, "utf8")}`,
+  );
   writeFileSync(join(pkgDir, "index.js"), buildRuntimeShim());
   writeFileSync(
     join(pkgDir, "package.json"),
@@ -275,8 +289,14 @@ function main(): void {
             import: "./index.js",
             default: "./index.js",
           },
+          // App-side ambient globals (`window.vellum`). Types-only — the
+          // runtime is injected by the host into the app's sandboxed iframe,
+          // so there is nothing to import at runtime.
+          "./app": {
+            types: "./app.d.ts",
+          },
         },
-        files: ["index.js", "index.d.ts"],
+        files: ["index.js", "index.d.ts", "app.d.ts"],
         dependencies: { zod: ZOD_VERSION },
         publishConfig: { access: "public" },
         repository: {

--- a/assistant/src/__tests__/plugin-api-app-globals.test.ts
+++ b/assistant/src/__tests__/plugin-api-app-globals.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Guards the app-side ambient global (`window.vellum`) that
+ * `@vellumai/plugin-api` ships so plugin apps don't hand-declare it.
+ *
+ * Two things must hold: the declaration must cover every method the host
+ * injects into the app sandbox, and the publish build must actually ship it
+ * (as `app.d.ts`, via the `./app` export, referenced from the main rollup).
+ */
+
+const APP_GLOBALS = new URL("../plugin-api/app-globals.d.ts", import.meta.url);
+const BUILD_SCRIPT = new URL(
+  "../../scripts/build-plugin-api.ts",
+  import.meta.url,
+);
+
+/** The surface the runtime `sandbox-bridge` injects onto `window.vellum`. */
+const INJECTED_MEMBERS = [
+  "route",
+  "sendAction",
+  "fetch",
+  "asset",
+  "subscribe",
+] as const;
+
+describe("plugin-api app-side globals", () => {
+  test("declares window.vellum with the full injected surface", () => {
+    const src = readFileSync(APP_GLOBALS, "utf8");
+
+    // Augments the DOM `Window` with the bridge.
+    expect(src).toContain("interface Window");
+    expect(src).toContain("vellum: VellumAppBridge");
+    expect(src).toContain("declare global");
+
+    for (const member of INJECTED_MEMBERS) {
+      expect(src).toContain(member);
+    }
+  });
+
+  test("publish build ships the app subpath types", () => {
+    const src = readFileSync(BUILD_SCRIPT, "utf8");
+
+    // Copied into the package as app.d.ts…
+    expect(src).toContain("app-globals.d.ts");
+    expect(src).toContain('"app.d.ts"');
+    // …exposed via the ./app subpath…
+    expect(src).toContain('"./app"');
+    // …and pulled in transitively from the main rollup.
+    expect(src).toContain('/// <reference path="./app.d.ts" />');
+  });
+});

--- a/assistant/src/__tests__/plugin-api-app-globals.test.ts
+++ b/assistant/src/__tests__/plugin-api-app-globals.test.ts
@@ -5,9 +5,10 @@ import { describe, expect, test } from "bun:test";
  * Guards the app-side ambient global (`window.vellum`) that
  * `@vellumai/plugin-api` ships so plugin apps don't hand-declare it.
  *
- * Two things must hold: the declaration must cover every method the host
- * injects into the app sandbox, and the publish build must actually ship it
- * (as `app.d.ts`, via the `./app` export, referenced from the main rollup).
+ * Two things must hold: the declaration augments `Window` with the bridge's
+ * `fetch` (the only member exposed for now), and the publish build actually
+ * ships it (as `app.d.ts`, via the `./app` export, referenced from the main
+ * rollup).
  */
 
 const APP_GLOBALS = new URL("../plugin-api/app-globals.d.ts", import.meta.url);
@@ -16,27 +17,17 @@ const BUILD_SCRIPT = new URL(
   import.meta.url,
 );
 
-/** The surface the runtime `sandbox-bridge` injects onto `window.vellum`. */
-const INJECTED_MEMBERS = [
-  "route",
-  "sendAction",
-  "fetch",
-  "asset",
-  "subscribe",
-] as const;
-
 describe("plugin-api app-side globals", () => {
-  test("declares window.vellum with the full injected surface", () => {
+  test("augments Window with the window.vellum bridge fetch", () => {
     const src = readFileSync(APP_GLOBALS, "utf8");
 
     // Augments the DOM `Window` with the bridge.
+    expect(src).toContain("declare global");
     expect(src).toContain("interface Window");
     expect(src).toContain("vellum: VellumAppBridge");
-    expect(src).toContain("declare global");
 
-    for (const member of INJECTED_MEMBERS) {
-      expect(src).toContain(member);
-    }
+    // `fetch` is the only exposed member for now.
+    expect(src).toContain("fetch(");
   });
 
   test("publish build ships the app subpath types", () => {

--- a/assistant/src/config/bundled-skills/app-builder/references/CUSTOM_ROUTES.md
+++ b/assistant/src/config/bundled-skills/app-builder/references/CUSTOM_ROUTES.md
@@ -76,6 +76,16 @@ const createRes = await window.vellum.fetch("/v1/x/items", {
 if (!createRes.ok) throw new Error(`HTTP ${createRes.status}`);
 ```
 
+### Typing `window.vellum`
+
+Don't hand-declare `window.vellum` in a local `vellum.d.ts`. If the app depends on `@vellumai/plugin-api`, the `window.vellum` global is typed for you — either import anything from the package, or add a one-line reference in a `.d.ts` (or entry file):
+
+```typescript
+/// <reference types="@vellumai/plugin-api/app" />
+```
+
+Equivalently, add `"@vellumai/plugin-api/app"` to `compilerOptions.types` in `tsconfig.json`.
+
 ## Runtime context
 
 Every handler receives a frozen `context` object as its second argument. This provides access to daemon singletons that are otherwise unreachable from dynamically imported route modules.

--- a/assistant/src/config/bundled-skills/app-builder/references/CUSTOM_ROUTES.md
+++ b/assistant/src/config/bundled-skills/app-builder/references/CUSTOM_ROUTES.md
@@ -78,13 +78,13 @@ if (!createRes.ok) throw new Error(`HTTP ${createRes.status}`);
 
 ### Typing `window.vellum`
 
-Don't hand-declare `window.vellum` in a local `vellum.d.ts`. If the app depends on `@vellumai/plugin-api`, the `window.vellum` global is typed for you — either import anything from the package, or add a one-line reference in a `.d.ts` (or entry file):
+Don't hand-declare `window.vellum` in a local `vellum.d.ts`. If the app depends on `@vellumai/plugin-api`, the `window.vellum` global is typed for you — add a one-line reference in a `.d.ts` (or entry file):
 
 ```typescript
 /// <reference types="@vellumai/plugin-api/app" />
 ```
 
-Equivalently, add `"@vellumai/plugin-api/app"` to `compilerOptions.types` in `tsconfig.json`.
+Equivalently, add `"@vellumai/plugin-api/app"` to `compilerOptions.types` in `tsconfig.json`. Both are types-only — do **not** `import` from `@vellumai/plugin-api` to get the global; a runtime bare import isn't supported for sandboxed apps. If you want to name a type, use `import type { VellumAppBridge } from "@vellumai/plugin-api/app"`.
 
 ## Runtime context
 

--- a/assistant/src/plugin-api/app-globals.d.ts
+++ b/assistant/src/plugin-api/app-globals.d.ts
@@ -5,47 +5,27 @@
  * `window.vellum` object into it at load time (see the assistant's
  * `sandbox-bridge` runtime). This file is the type-only counterpart to that
  * injection: it teaches TypeScript the shape of `window.vellum` so an app can
- * call `window.vellum.fetch(...)`, `window.vellum.sendAction(...)`, etc.
- * without hand-declaring the global in every project.
+ * call `window.vellum.fetch(...)` without hand-declaring the global in every
+ * project.
  *
- * A plugin app that depends on `@vellumai/plugin-api` pulls this in one of two
- * ways:
+ * Only `fetch` is typed for now — the surface the vast majority of apps
+ * actually use. Other injected members are intentionally left undeclared until
+ * there's a concrete need.
  *
- * 1. Referenced explicitly (recommended for apps that don't otherwise import
- *    from the package — e.g. a plain Vite app that only calls
- *    `window.vellum.fetch`):
+ * A plugin app that depends on `@vellumai/plugin-api` pulls this in via a
+ * one-line reference (recommended — no runtime import, which apps can't rely
+ * on inside the sandbox):
  *
- *    ```ts
- *    /// <reference types="@vellumai/plugin-api/app" />
- *    ```
+ * ```ts
+ * /// <reference types="@vellumai/plugin-api/app" />
+ * ```
  *
- *    or add `"@vellumai/plugin-api/app"` to `compilerOptions.types` in
- *    `tsconfig.json`.
- *
- * 2. Transitively — importing anything from `@vellumai/plugin-api` also loads
- *    this augmentation, because the package's main type entry references it.
- *
- * Either way the app no longer needs its own `vellum.d.ts`.
+ * or by adding `"@vellumai/plugin-api/app"` to `compilerOptions.types` in
+ * `tsconfig.json`. Either way the app no longer needs its own `vellum.d.ts`.
  *
  * The named types below are also exported, so app code that wants to annotate
  * a variable can `import type { VellumAppBridge } from "@vellumai/plugin-api/app"`.
  */
-
-/**
- * A `sync_changed` invalidation forwarded from the host to a subscribed app.
- * The host scopes delivery to the tags the app asked for (reserved host
- * namespaces are never delivered), so `tags` lists only the matched tags.
- */
-export interface VellumAppSyncEvent {
-  type: "sync_changed";
-  tags: string[];
-}
-
-/** Filter passed to {@link VellumAppBridge.subscribe}. */
-export interface VellumAppSubscribeFilter {
-  /** Sync tags the app wants to hear `sync_changed` invalidations for. */
-  tags?: string[];
-}
 
 /**
  * Request init accepted by {@link VellumAppBridge.fetch}. A subset of the DOM
@@ -66,7 +46,6 @@ export interface VellumAppFetchInit {
  * Response returned by {@link VellumAppBridge.fetch}. A `fetch`-like subset,
  * not a full DOM `Response`: the body is delivered as text across the bridge,
  * so only `json()` and `text()` are available (no `blob()`, `body`, etc.).
- * Use {@link VellumAppBridge.asset} for binary payloads.
  */
 export interface VellumAppFetchResponse {
   /** True when `status` is in the 2xx range. */
@@ -87,42 +66,15 @@ export interface VellumAppFetchResponse {
  */
 export interface VellumAppBridge {
   /**
-   * The deep-link route the app was opened with, or `null` when opened
-   * without one.
-   */
-  route: string | null;
-
-  /**
-   * Forward a surface action to the host chat (e.g. `"relay_prompt"` to send
-   * a prompt into the conversation, `"set_view"` to change the app/chat
-   * layout). Fire-and-forget — the host handles it out of band.
-   */
-  sendAction(actionId: string, data?: unknown): void;
-
-  /**
    * Authenticated `fetch` to the app's own custom routes under `/v1/x/` (a
    * leading `/x/` is accepted and normalized). Proxied through the host so the
    * assistant's session/auth is attached — use this instead of the bare
    * global `fetch`, which fails from the sandboxed origin.
    */
-  fetch(path: string, options?: VellumAppFetchInit): Promise<VellumAppFetchResponse>;
-
-  /**
-   * Resolve a bundled app asset to a `blob:` object URL the sandbox can load
-   * in `<img>` / `<video>` / `<audio>`. The binary sibling of {@link fetch};
-   * results are cached per path.
-   */
-  asset(path: string): Promise<string>;
-
-  /**
-   * Subscribe to host `sync_changed` invalidations matching `filter.tags` so
-   * the app can refresh on demand instead of polling. Returns an unsubscribe
-   * function.
-   */
-  subscribe(
-    filter: VellumAppSubscribeFilter,
-    callback: (event: VellumAppSyncEvent) => void,
-  ): () => void;
+  fetch(
+    path: string,
+    options?: VellumAppFetchInit,
+  ): Promise<VellumAppFetchResponse>;
 }
 
 declare global {

--- a/assistant/src/plugin-api/app-globals.d.ts
+++ b/assistant/src/plugin-api/app-globals.d.ts
@@ -1,0 +1,132 @@
+/**
+ * Ambient global types for the **app-side** Vellum bridge — `window.vellum`.
+ *
+ * A Vellum plugin app runs inside a sandboxed iframe, and the host injects a
+ * `window.vellum` object into it at load time (see the assistant's
+ * `sandbox-bridge` runtime). This file is the type-only counterpart to that
+ * injection: it teaches TypeScript the shape of `window.vellum` so an app can
+ * call `window.vellum.fetch(...)`, `window.vellum.sendAction(...)`, etc.
+ * without hand-declaring the global in every project.
+ *
+ * A plugin app that depends on `@vellumai/plugin-api` pulls this in one of two
+ * ways:
+ *
+ * 1. Referenced explicitly (recommended for apps that don't otherwise import
+ *    from the package — e.g. a plain Vite app that only calls
+ *    `window.vellum.fetch`):
+ *
+ *    ```ts
+ *    /// <reference types="@vellumai/plugin-api/app" />
+ *    ```
+ *
+ *    or add `"@vellumai/plugin-api/app"` to `compilerOptions.types` in
+ *    `tsconfig.json`.
+ *
+ * 2. Transitively — importing anything from `@vellumai/plugin-api` also loads
+ *    this augmentation, because the package's main type entry references it.
+ *
+ * Either way the app no longer needs its own `vellum.d.ts`.
+ *
+ * The named types below are also exported, so app code that wants to annotate
+ * a variable can `import type { VellumAppBridge } from "@vellumai/plugin-api/app"`.
+ */
+
+/**
+ * A `sync_changed` invalidation forwarded from the host to a subscribed app.
+ * The host scopes delivery to the tags the app asked for (reserved host
+ * namespaces are never delivered), so `tags` lists only the matched tags.
+ */
+export interface VellumAppSyncEvent {
+  type: "sync_changed";
+  tags: string[];
+}
+
+/** Filter passed to {@link VellumAppBridge.subscribe}. */
+export interface VellumAppSubscribeFilter {
+  /** Sync tags the app wants to hear `sync_changed` invalidations for. */
+  tags?: string[];
+}
+
+/**
+ * Request init accepted by {@link VellumAppBridge.fetch}. A subset of the DOM
+ * `RequestInit`: the bridge serializes the request across `postMessage`, so
+ * `headers` must be a plain object and `body` a string (not a `Headers`
+ * instance, `FormData`, or a stream).
+ */
+export interface VellumAppFetchInit {
+  /** HTTP method. Defaults to `"GET"`. */
+  method?: string;
+  /** Request headers as a plain object. */
+  headers?: Record<string, string>;
+  /** Request body. Already-serialized string payloads only. */
+  body?: string | null;
+}
+
+/**
+ * Response returned by {@link VellumAppBridge.fetch}. A `fetch`-like subset,
+ * not a full DOM `Response`: the body is delivered as text across the bridge,
+ * so only `json()` and `text()` are available (no `blob()`, `body`, etc.).
+ * Use {@link VellumAppBridge.asset} for binary payloads.
+ */
+export interface VellumAppFetchResponse {
+  /** True when `status` is in the 2xx range. */
+  ok: boolean;
+  status: number;
+  statusText: string;
+  /** Response headers as a plain object. */
+  headers: Record<string, string>;
+  /** Parse the response body as JSON. */
+  json(): Promise<unknown>;
+  /** Read the response body as text. */
+  text(): Promise<string>;
+}
+
+/**
+ * The `window.vellum` bridge the host injects into a plugin app's sandboxed
+ * iframe. Mirrors the runtime built by the assistant's `sandbox-bridge`.
+ */
+export interface VellumAppBridge {
+  /**
+   * The deep-link route the app was opened with, or `null` when opened
+   * without one.
+   */
+  route: string | null;
+
+  /**
+   * Forward a surface action to the host chat (e.g. `"relay_prompt"` to send
+   * a prompt into the conversation, `"set_view"` to change the app/chat
+   * layout). Fire-and-forget — the host handles it out of band.
+   */
+  sendAction(actionId: string, data?: unknown): void;
+
+  /**
+   * Authenticated `fetch` to the app's own custom routes under `/v1/x/` (a
+   * leading `/x/` is accepted and normalized). Proxied through the host so the
+   * assistant's session/auth is attached — use this instead of the bare
+   * global `fetch`, which fails from the sandboxed origin.
+   */
+  fetch(path: string, options?: VellumAppFetchInit): Promise<VellumAppFetchResponse>;
+
+  /**
+   * Resolve a bundled app asset to a `blob:` object URL the sandbox can load
+   * in `<img>` / `<video>` / `<audio>`. The binary sibling of {@link fetch};
+   * results are cached per path.
+   */
+  asset(path: string): Promise<string>;
+
+  /**
+   * Subscribe to host `sync_changed` invalidations matching `filter.tags` so
+   * the app can refresh on demand instead of polling. Returns an unsubscribe
+   * function.
+   */
+  subscribe(
+    filter: VellumAppSubscribeFilter,
+    callback: (event: VellumAppSyncEvent) => void,
+  ): () => void;
+}
+
+declare global {
+  interface Window {
+    vellum: VellumAppBridge;
+  }
+}

--- a/clients/web/src/utils/sandbox-bridge.ts
+++ b/clients/web/src/utils/sandbox-bridge.ts
@@ -8,8 +8,8 @@
  *    which throw `SecurityError` in sandboxed contexts without `allow-same-origin`.
  * The app-side type of the `window.vellum` object injected here is declared in
  * `@vellumai/plugin-api`'s `app-globals.d.ts` (shipped as the package's
- * `/app` subpath). Keep that declaration in sync when the injected surface
- * (`route`, `sendAction`, `fetch`, `asset`, `subscribe`) changes.
+ * `/app` subpath). It currently types only `fetch`; keep it in sync if that
+ * member's signature changes or another member is added to the declaration.
  *
  * 2. **Action bridge** — `window.vellum.sendAction()` forwards surface actions to
  *    the parent via `postMessage`.

--- a/clients/web/src/utils/sandbox-bridge.ts
+++ b/clients/web/src/utils/sandbox-bridge.ts
@@ -6,6 +6,11 @@
  *
  * 1. **Storage polyfill** — in-memory shim for `localStorage` / `sessionStorage`,
  *    which throw `SecurityError` in sandboxed contexts without `allow-same-origin`.
+ * The app-side type of the `window.vellum` object injected here is declared in
+ * `@vellumai/plugin-api`'s `app-globals.d.ts` (shipped as the package's
+ * `/app` subpath). Keep that declaration in sync when the injected surface
+ * (`route`, `sendAction`, `fetch`, `asset`, `subscribe`) changes.
+ *
  * 2. **Action bridge** — `window.vellum.sendAction()` forwards surface actions to
  *    the parent via `postMessage`.
  * 3. **Fetch proxy** — `window.vellum.fetch()` proxies authenticated requests


### PR DESCRIPTION
## Prompt / plan

Reported from a downstream plugin app (`virlo-results-viewer`) that hand-declares a local `vellum.d.ts`:

> I expect npm packages that have `@vellumai/plugin-api` as a peer dep to not need this.

**Why the file existed:** plugin apps render inside the host's sandboxed iframe and call the host-injected `window.vellum` bridge (`fetch` / `asset` / `subscribe` / `sendAction`, plus `route`). The runtime for that bridge is built in `clients/web/src/utils/sandbox-bridge.ts`, but the published `@vellumai/plugin-api` package only shipped **server-side** authoring types — nothing typed the app-side global. So every app re-declared it.

**Approach:** add the canonical app-side ambient declaration and ship it from the package.

- `assistant/src/plugin-api/app-globals.d.ts` — the canonical `window.vellum` (`VellumAppBridge`) declaration, mirroring the runtime surface injected by `sandbox-bridge`. Named types are exported too, so app code can `import type { VellumAppBridge }` if it wants.
- `build-plugin-api.ts` ships it as `app.d.ts`, exposed via a new **`@vellumai/plugin-api/app`** subpath (types-only — the runtime is injected by the host, nothing to import). The main rollup triple-slash-references it, so importing anything from the package also pulls the global in.
- The app-builder skill's `CUSTOM_ROUTES.md` now steers generated apps to reference the shipped types instead of hand-writing `vellum.d.ts`, and `sandbox-bridge.ts` gets a comment pointing at the declaration to keep in sync.

Downstream apps drop their `vellum.d.ts` and either import from the package or add one line:

```ts
/// <reference types="@vellumai/plugin-api/app" />
```

(equivalently, add `"@vellumai/plugin-api/app"` to `compilerOptions.types`).

## Test plan

- New guard test `plugin-api-app-globals.test.ts` (2 pass) — asserts the declaration covers every injected member (`route`, `sendAction`, `fetch`, `asset`, `subscribe`) and augments `Window`, and that the publish build actually ships it (`app.d.ts`, the `./app` export, and the rollup reference).
- Existing `app-builder-skill-instructions.test.ts` still passes (3 pass) after the doc edit.
- `app-globals.d.ts` type-checks standalone under `strict` + `lib: ES2022,DOM`.
- Note: the full API-Extractor publish build could not be exercised in this environment (workspace `node_modules/.bin` not bootstrapped); the build-script edits are file copy + package.json wiring only.

## CLI verb checklist

No new IPC routes — types-only packaging change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014JtqnAgCuTXHRG8NvucRiR)_