### PR TITLE
fix(web): stop the takeover flashing a stranger's avatar while yours loads

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -20,6 +20,8 @@ import type { ProvisioningStateProps } from "./provisioning-state";
 /** The id handed to the avatar hook, captured so the target-selection wiring
  *  can be asserted without a network fetch. */
 let avatarQueryId: string | null | undefined;
+/** Flipped per-test to hold the avatar query in flight. */
+let avatarLoading = false;
 mock.module("@/hooks/use-assistant-avatar", () => ({
   useAssistantAvatar: (assistantId: string | null) => {
     avatarQueryId = assistantId;
@@ -27,7 +29,7 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
       components: null,
       traits: null,
       customImageUrl: null,
-      isLoading: false,
+      isLoading: avatarLoading,
       invalidate: () => {},
     };
   },
@@ -46,6 +48,7 @@ const { ProvisioningState } = await import("./provisioning-state");
 
 beforeEach(() => {
   avatarQueryId = undefined;
+  avatarLoading = false;
   reducedMotion = false;
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
 });
@@ -504,6 +507,25 @@ describe("takeover avatar mode", () => {
       }
     });
   }
+
+  test("withholds the avatar until its query settles", () => {
+    // `components ?? fallback` synthesizes traits from the first bundled entry
+    // of each list, so drawing during the fetch shows a green blob regardless
+    // of the assistant's real avatar.
+    avatarLoading = true;
+
+    const { container } = renderState({ state: "WAITING" });
+
+    expect(container.querySelector(".provision-avatar-reveal")).toBeNull();
+    // The stage still reserves its height, so nothing moves when it arrives.
+    expect(container.querySelector(".provision-avatar-stage")).toBeTruthy();
+  });
+
+  test("reveals the avatar once the query settles", () => {
+    const { container } = renderState({ state: "WAITING" });
+
+    expect(container.querySelector(".provision-avatar-reveal")).toBeTruthy();
+  });
 
   test("steps the creature down so a short viewport keeps the actions below it", () => {
     // The stage reserves the grown height, so a full-size creature needs about

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -540,14 +540,19 @@ describe("takeover avatar mode", () => {
   test("keeps waiting while the target assistant is still unknown", () => {
     // `useAssistantAvatar(null)` is a disabled query, and a disabled query
     // reports `isLoading: false` with no data — so the id has to gate the
-    // render too. On a cold Stripe return both the onboarding primary and the
-    // active-store id are null for a beat.
-    useResolvedAssistantsStore.setState({ activeAssistantId: null });
+    // render too. The active assistant is deliberately set here: an explicit
+    // null target must not fall back to it, or a multi-assistant org fades in
+    // the active assistant before the provisioning primary resolves.
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "active-assistant",
+    });
 
     const { container } = renderState({ state: "WAITING", assistantId: null });
 
     expect(container.querySelector(".provision-avatar-reveal")).toBeNull();
     expect(container.querySelector(".provision-avatar-stage")).toBeTruthy();
+    // Nor should it fetch the wrong assistant's avatar on the way.
+    expect(avatarQueryId).toBeNull();
   });
 
   test("holds the grow until there is an avatar to play it on", () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -514,17 +514,36 @@ describe("takeover avatar mode", () => {
     // of the assistant's real avatar.
     avatarLoading = true;
 
-    const { container } = renderState({ state: "WAITING" });
+    const { container } = renderState({
+      state: "WAITING",
+      assistantId: "primary-assistant",
+    });
 
     expect(container.querySelector(".provision-avatar-reveal")).toBeNull();
     // The stage still reserves its height, so nothing moves when it arrives.
     expect(container.querySelector(".provision-avatar-stage")).toBeTruthy();
   });
 
-  test("reveals the avatar once the query settles", () => {
-    const { container } = renderState({ state: "WAITING" });
+  test("reveals the avatar once the target and the query both settle", () => {
+    const { container } = renderState({
+      state: "WAITING",
+      assistantId: "primary-assistant",
+    });
 
     expect(container.querySelector(".provision-avatar-reveal")).toBeTruthy();
+  });
+
+  test("keeps waiting while the target assistant is still unknown", () => {
+    // `useAssistantAvatar(null)` is a disabled query, and a disabled query
+    // reports `isLoading: false` with no data — so the id has to gate the
+    // render too. On a cold Stripe return both the onboarding primary and the
+    // active-store id are null for a beat.
+    useResolvedAssistantsStore.setState({ activeAssistantId: null });
+
+    const { container } = renderState({ state: "WAITING", assistantId: null });
+
+    expect(container.querySelector(".provision-avatar-reveal")).toBeNull();
+    expect(container.querySelector(".provision-avatar-stage")).toBeTruthy();
   });
 
   test("steps the creature down so a short viewport keeps the actions below it", () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -490,7 +490,11 @@ describe("takeover avatar mode", () => {
   for (const [state, softWaiting, expected] of CASES) {
     const label = softWaiting ? `${state} past the grace window` : state;
     test(`${label} renders ${expected || "no mode class"}`, () => {
-      const { container } = renderState({ state, softWaiting });
+      const { container } = renderState({
+        state,
+        softWaiting,
+        assistantId: "primary-assistant",
+      });
       const classes = modeClasses(container);
 
       if (expected) {
@@ -546,6 +550,22 @@ describe("takeover avatar mode", () => {
     expect(container.querySelector(".provision-avatar-stage")).toBeTruthy();
   });
 
+  test("holds the grow until there is an avatar to play it on", () => {
+    // The phase can resolve before the avatar fetch does — the avatar is read
+    // off the machine being restarted — and a grow that runs on an empty
+    // wrapper leaves the creature to fade in already at its final scale.
+    avatarLoading = true;
+
+    const { container } = renderState({
+      state: "DONE",
+      assistantId: "primary-assistant",
+    });
+
+    expect(
+      container.querySelector(".provision-avatar-evolve")?.className,
+    ).not.toContain("is-evolved");
+  });
+
   test("steps the creature down so a short viewport keeps the actions below it", () => {
     // The stage reserves the grown height, so a full-size creature needs about
     // 650px before the phase block — which carries the escape hatch and the
@@ -586,7 +606,11 @@ describe("takeover avatar mode", () => {
   });
 
   test("the grace window never softens a state that isn't waiting", () => {
-    const { container } = renderState({ state: "STALLED", softWaiting: true });
+    const { container } = renderState({
+      state: "STALLED",
+      softWaiting: true,
+      assistantId: "primary-assistant",
+    });
 
     expect(modeClasses(container)).toContain("is-stalled");
   });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -165,7 +165,8 @@ function avatarModeFor(
  * body-morph and the reduced-motion gating all come from `AnimatedAvatar`
  * inside `ChatAvatar`.
  *
- * Nothing renders until the avatar query settles. `components ?? fallback`
+ * Nothing renders until the target assistant resolves and its avatar query
+ * settles. `components ?? fallback`
  * synthesizes traits from the first bundled entry of each list — a green blob —
  * so drawing during the fetch shows a different assistant's avatar for a beat,
  * and the takeover is the one surface that reliably mounts cold: the Stripe
@@ -192,6 +193,11 @@ function TakeoverAvatar({
   const fallbackComponents = useBundledAvatarComponents();
   const size = useTakeoverAvatarSize();
   const laboring = mode === "working" || mode === "settling";
+  // A null id means the target assistant has not resolved yet, not that it has
+  // no avatar — and `useAssistantAvatar(null)` is a disabled query, which
+  // reports `isLoading: false` with no data. Both have to clear before there is
+  // anything safe to draw.
+  const avatarReady = resolvedId != null && !isLoading;
   return (
     <div
       aria-hidden
@@ -207,7 +213,7 @@ function TakeoverAvatar({
         <div className="provision-avatar-layer">
           <div className="provision-avatar-current">
             <div className="provision-avatar-strain">
-              {!isLoading && (
+              {avatarReady && (
                 <div className="provision-avatar-reveal">
                   <ChatAvatar
                     components={components ?? fallbackComponents}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -187,7 +187,13 @@ function TakeoverAvatar({
   mode: AvatarMode;
 }) {
   const activeId = useResolvedAssistantsStore.use.activeAssistantId();
-  const resolvedId = assistantId ?? activeId;
+  // An explicit null is the provisioning hook saying it does not know the
+  // target yet — it withholds `primary_assistant_id` until onboarding is fresh
+  // precisely so a multi-assistant org does not aim at the active assistant
+  // when the two diverge. Only an omitted prop falls back to active; a null one
+  // stays unresolved, so the takeover never fades in a different assistant's
+  // avatar on the way to the right one.
+  const resolvedId = assistantId === undefined ? activeId : assistantId;
   const { components, traits, customImageUrl, isLoading } =
     useAssistantAvatar(resolvedId);
   const fallbackComponents = useBundledAvatarComponents();

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -165,6 +165,13 @@ function avatarModeFor(
  * body-morph and the reduced-motion gating all come from `AnimatedAvatar`
  * inside `ChatAvatar`.
  *
+ * Nothing renders until the avatar query settles. `components ?? fallback`
+ * synthesizes traits from the first bundled entry of each list — a green blob —
+ * so drawing during the fetch shows a different assistant's avatar for a beat,
+ * and the takeover is the one surface that reliably mounts cold: the Stripe
+ * return is a full page load, so the fetch always loses the race. Withholding
+ * costs no layout, because the stage reserves its height from first paint.
+ *
  * On resolve it grows to `AVATAR_GROWTH` against a bottom baseline, so the
  * creature stands taller off its shadow instead of drifting up the screen. The
  * stage reserves the grown height from first paint. The strain loop sits on its
@@ -180,7 +187,8 @@ function TakeoverAvatar({
 }) {
   const activeId = useResolvedAssistantsStore.use.activeAssistantId();
   const resolvedId = assistantId ?? activeId;
-  const { components, traits, customImageUrl } = useAssistantAvatar(resolvedId);
+  const { components, traits, customImageUrl, isLoading } =
+    useAssistantAvatar(resolvedId);
   const fallbackComponents = useBundledAvatarComponents();
   const size = useTakeoverAvatarSize();
   const laboring = mode === "working" || mode === "settling";
@@ -199,13 +207,17 @@ function TakeoverAvatar({
         <div className="provision-avatar-layer">
           <div className="provision-avatar-current">
             <div className="provision-avatar-strain">
-              <ChatAvatar
-                components={components ?? fallbackComponents}
-                traits={traits}
-                customImageUrl={customImageUrl}
-                size={size}
-                isAssistantBusy={laboring}
-              />
+              {!isLoading && (
+                <div className="provision-avatar-reveal">
+                  <ChatAvatar
+                    components={components ?? fallbackComponents}
+                    traits={traits}
+                    customImageUrl={customImageUrl}
+                    size={size}
+                    isAssistantBusy={laboring}
+                  />
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -198,10 +198,16 @@ function TakeoverAvatar({
   // reports `isLoading: false` with no data. Both have to clear before there is
   // anything safe to draw.
   const avatarReady = resolvedId != null && !isLoading;
+  // Every mode animates the wrapper or its child, so the class waits for
+  // something to animate. Otherwise a phase that resolves before the fetch does
+  // — likely here, since the avatar is read off the machine being restarted —
+  // runs the grow on an empty wrapper and leaves the creature to fade in at its
+  // final scale with the success beat already spent.
+  const activeMode: AvatarMode = avatarReady ? mode : "idle";
   return (
     <div
       aria-hidden
-      className={`provision-avatar-evolve flex flex-col items-center${AVATAR_MODE_CLASS[mode]}`}
+      className={`provision-avatar-evolve flex flex-col items-center${AVATAR_MODE_CLASS[activeMode]}`}
       style={
         {
           "--provision-avatar-size": `${size}px`,

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -348,6 +348,24 @@ body {
   animation: provision-grow-shadow 1.1s cubic-bezier(0.36, 0.02, 0.24, 1) both;
 }
 
+/* The avatar is withheld until its query settles, so it arrives rather than
+ * swapping in over a placeholder. The stage has already reserved its height,
+ * so this fades in place with nothing moving around it. */
+@keyframes provision-avatar-reveal {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.provision-avatar-reveal {
+  animation: provision-avatar-reveal 250ms ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .provision-avatar-reveal {
+    animation: none;
+  }
+}
+
 /* One gesture at three amplitudes. The strain loop sits on its own nesting
  * level so it multiplies with the growth on the parent rather than fighting it
  * for `transform`; the transition is what carries it back to rest from wherever


### PR DESCRIPTION
## Summary

The provisioning takeover shows a green creature for a beat before your actual avatar appears — the same green one for everyone, whatever their avatar is.

`TakeoverAvatar` passes `components ?? fallbackComponents` to `ChatAvatar`. While the avatar query is in flight that resolves to the bundled component set with `traits: null`, and `ChatAvatar` then synthesizes traits from the first entry of each list (`chat-avatar.tsx:96`):

```ts
const body = components.bodyShapes[0];   // "blob"
const eyes = components.eyeStyles[0];    // "grumpy"
const color = components.colors[0];      // "green" — #4C9B50
```

Every other avatar surface hides this, because the query is cached by the time it paints. **The takeover structurally cannot be:** the Stripe return is a full page load, so the modal opens straight off `?session_id=` against an empty React Query cache and the fetch always loses the race. It is also the one place the creature is the focal point, at up to 240px.

## The fix

The hook already reports `isLoading`, so the render site can tell **"we don't know yet"** apart from **"there is no avatar"** — the second being the case the bundled fallback actually exists for, and which stays intact.

- Hold the creature until the query settles, then fade it in over 250ms (`provision-avatar-reveal`, reduced-motion gated).
- No layout cost: the stage already reserves the grown height from first paint, so it fades in place with nothing moving around it.
- On a query error after its retry, `isLoading` goes false with null data, so the default creature still renders — the correct final answer rather than a placeholder.

The trade is a beat of empty focal point instead of a beat of the wrong avatar.

## Scope

Deliberately limited to the takeover. The synthesize-from-`components[0]` behaviour lives in `ChatAvatar` itself, so any surface mounting an avatar cold can flash green — it is just invisible elsewhere behind a warm cache. Fixing it centrally means changing `ChatAvatar`'s fallback contract, which touches chat and every avatar in the app; worth doing deliberately rather than as a rider here.

## Verification

- `bun run tsc --noEmit` — clean
- `bunx eslint` — clean
- `provisioning-state.test.tsx` — **38 pass** (2 new: nothing renders while loading but the stage still reserves its height; the avatar appears once settled)
- `billing-onboarding-modal.test.tsx` — 29 pass

Not yet watched in a browser — and this one is worth it, since the whole point is a timing window only visible on a cold load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
