### PR TITLE
fix(design-library): stop modal/bottom-sheet titles clipping descenders

### DIFF
--- a/packages/design-library/src/components/bottom-sheet.tsx
+++ b/packages/design-library/src/components/bottom-sheet.tsx
@@ -130,7 +130,11 @@ function Title({
           <Icon className="h-5 w-5 text-[var(--primary-base)]" />
         </span>
       ) : null}
-      <span className="min-w-0 truncate">{children}</span>
+      {/* `text-title-*` set line-height: 1, so `truncate`'s `overflow: hidden`
+          shears glyph descenders (the tail of a g/p/y). `leading-snug` grows
+          the line box to contain them; single-line ellipsis still works.
+          Mirrors the same fix in `modal.tsx`. */}
+      <span className="min-w-0 truncate leading-snug">{children}</span>
     </Dialog.Title>
   );
 }

--- a/packages/design-library/src/components/bottom-sheet.tsx
+++ b/packages/design-library/src/components/bottom-sheet.tsx
@@ -132,8 +132,7 @@ function Title({
       ) : null}
       {/* `text-title-*` set line-height: 1, so `truncate`'s `overflow: hidden`
           shears glyph descenders (the tail of a g/p/y). `leading-snug` grows
-          the line box to contain them; single-line ellipsis still works.
-          Mirrors the same fix in `modal.tsx`. */}
+          the line box to contain them; single-line ellipsis still works. */}
       <span className="min-w-0 truncate leading-snug">{children}</span>
     </Dialog.Title>
   );

--- a/packages/design-library/src/components/modal.tsx
+++ b/packages/design-library/src/components/modal.tsx
@@ -160,7 +160,11 @@ function Title({
           <Icon className="h-5 w-5 text-[var(--primary-base)]" />
         </span>
       ) : null}
-      <span className="min-w-0 truncate">{children}</span>
+      {/* `text-title-*` set line-height: 1, leaving no room under the baseline,
+          so `truncate`'s `overflow: hidden` shears glyph descenders (the tail
+          of a g/p/y in a title like "Upgrade to Super?"). `leading-snug` grows
+          the line box to contain them; single-line ellipsis still works. */}
+      <span className="min-w-0 truncate leading-snug">{children}</span>
     </Dialog.Title>
   );
 }


### PR DESCRIPTION
## Summary
Modal/bottom-sheet titles were clipping glyph **descenders** — the tail of a `g`/`p`/`y` in a title like "U**p**grade to Su**p**er?" was sheared off. Reported on both the View Plans takeover and the Billing settings tab, which both render `PackageSwitchConfirmModal` through the shared `Modal` primitive.

## Root cause
The title tokens `--text-title-medium-line-height` / `--text-title-large-line-height` are `1`. A `line-height: 1` alone paints descenders fine, but `Modal.Title` wraps its text in `<span class="min-w-0 truncate">`, and `truncate`'s `overflow: hidden` clips anything below the 1em line box — so descenders get cut off. (The note text uses `body-medium-default` with `line-height: 18px` and no overflow clip, so it was never affected.)

## Fix
Add `leading-snug` to the truncated title span so the line box has room for descenders, while single-line ellipsis still works:

```diff
- <span className="min-w-0 truncate">{children}</span>
+ <span className="min-w-0 truncate leading-snug">{children}</span>
```

Applied in the primitive (not the one modal) so **every** modal/sheet title benefits — the same latent clip affected all of them. `bottom-sheet.tsx` (the mobile counterpart) had the identical bug and is fixed the same way.

## Verification
- `tsc` clean; web suites that render this modal (`plan-card.test`, `plans-page.test`) pass 2/2; no snapshot references the title className.
- Minimal diff: 2 files, +10/−2 (title span + explanatory comment only).

## Note
Sized by font metrics (`leading-snug` = 1.375 → ~3–4px descender room at the 20px title) since I couldn't render it. If a `g` still grazes on-device, bumping to `leading-normal` is the follow-up.