### PR TITLE
fix(plugins): run the outgoing version's shutdown before an upgrade's file swap

### DIFF
--- a/assistant/src/cli/lib/__tests__/upgrade-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/upgrade-plugin.test.ts
@@ -427,6 +427,113 @@ describe("upgradePlugin", () => {
     // AND the previously installed copy is left intact at its old pin
     expect(sidecarCommit(pluginsDir, "level-up")).toBe(SHA_A);
   });
+
+  test("invokes beforeSwap after staging and before the files are replaced", async () => {
+    // GIVEN an installed copy pinned to SHA_A and an advanced marketplace pin
+    installCopy(pluginsDir, "level-up", { commit: SHA_A });
+    const fetch = makeFetch({ manifest: manifestWith("level-up", SHA_B) });
+    const runGit = fakeGitRunner(SHA_B);
+    // AND a beforeSwap that records what was on disk when it ran
+    const commitsSeen: Array<string | null> = [];
+    const beforeSwap = async () => {
+      commitsSeen.push(sidecarCommit(pluginsDir, "level-up"));
+    };
+
+    // WHEN the plugin is upgraded
+    const result = await upgradePlugin(
+      { name: "level-up" },
+      { fetch, runGit, workspacePluginsDir: pluginsDir, beforeSwap },
+    );
+
+    // THEN beforeSwap ran exactly once, while the OLD install was still on
+    // disk (the outgoing version's shutdown sees its own files), and the swap
+    // completed afterwards
+    expect(result.outcome).toBe("upgraded");
+    expect(commitsSeen).toEqual([SHA_A]);
+    expect(sidecarCommit(pluginsDir, "level-up")).toBe(SHA_B);
+  });
+
+  test("a beforeSwap rejection never blocks the swap", async () => {
+    installCopy(pluginsDir, "level-up", { commit: SHA_A });
+    const fetch = makeFetch({ manifest: manifestWith("level-up", SHA_B) });
+    const runGit = fakeGitRunner(SHA_B);
+
+    const result = await upgradePlugin(
+      { name: "level-up" },
+      {
+        fetch,
+        runGit,
+        workspacePluginsDir: pluginsDir,
+        beforeSwap: async () => {
+          throw new Error("teardown exploded");
+        },
+      },
+    );
+
+    expect(result.outcome).toBe("upgraded");
+    expect(sidecarCommit(pluginsDir, "level-up")).toBe(SHA_B);
+  });
+
+  test("does not invoke beforeSwap for a dry run or a no-op upgrade", async () => {
+    installCopy(pluginsDir, "level-up", { commit: SHA_A });
+    let calls = 0;
+    const beforeSwap = async () => {
+      calls += 1;
+    };
+
+    // Dry run against an advanced pin: reports the move, never swaps.
+    const dry = await upgradePlugin(
+      { name: "level-up", dryRun: true },
+      {
+        fetch: makeFetch({ manifest: manifestWith("level-up", SHA_B) }),
+        runGit: fakeGitRunner(SHA_B),
+        workspacePluginsDir: pluginsDir,
+        beforeSwap,
+      },
+    );
+    expect(dry.outcome).toBe("would-upgrade");
+
+    // No-op: the install already sits at the pin.
+    const noop = await upgradePlugin(
+      { name: "level-up" },
+      {
+        fetch: makeFetch({ manifest: manifestWith("level-up", SHA_A) }),
+        runGit: fakeGitRunner(SHA_A),
+        workspacePluginsDir: pluginsDir,
+        beforeSwap,
+      },
+    );
+    expect(noop.outcome).toBe("already-up-to-date");
+
+    expect(calls).toBe(0);
+  });
+
+  test("does not invoke beforeSwap when staging fails", async () => {
+    // The running plugin must never be torn down for an upgrade that cannot
+    // complete: a clone failure aborts before the swap boundary.
+    installCopy(pluginsDir, "level-up", { commit: SHA_A });
+    const fetch = makeFetch({ manifest: manifestWith("level-up", SHA_B) });
+    const failingGit: GitRunner = async (args) => {
+      if (args[0] === "fetch") throw new Error("network down");
+      return { stdout: "" };
+    };
+    let calls = 0;
+
+    await expect(
+      upgradePlugin(
+        { name: "level-up" },
+        {
+          fetch,
+          runGit: failingGit,
+          workspacePluginsDir: pluginsDir,
+          beforeSwap: async () => {
+            calls += 1;
+          },
+        },
+      ),
+    ).rejects.toThrow("network down");
+    expect(calls).toBe(0);
+  });
 });
 
 describe("upgradePlugin — direct GitHub-URL installs", () => {

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -166,6 +166,8 @@ export interface InstallPluginDeps {
   readonly runPostinstall?: PostinstallRunner;
   /** Override the runner used to install a plugin's dependencies. Falls back to {@link defaultDependencyInstaller}. */
   readonly runInstallDeps?: DependencyInstaller;
+  /** Forwarded to {@link finalizeStagedInstall}; see {@link FinalizeStagedInstallParams.beforeSwap}. */
+  readonly beforeSwap?: () => Promise<void>;
 }
 
 /** Successful install result. */
@@ -501,6 +503,7 @@ export async function installPlugin(
     committedAt,
     pluginsDir,
     installDependencies: deps.runInstallDeps,
+    beforeSwap: deps.beforeSwap,
   });
 
   return { name, target, fileCount, ref, commit, committedAt };
@@ -522,6 +525,15 @@ export interface FinalizeStagedInstallParams {
   readonly pluginsDir: string;
   /** Override the runner used to install the plugin's dependencies. Falls back to {@link defaultDependencyInstaller}. */
   readonly installDependencies?: DependencyInstaller;
+  /**
+   * Invoked after the staged tree is fully populated (dependencies installed,
+   * fingerprint recorded) and immediately before it is swapped over the live
+   * install. The upgrade path uses this to run the outgoing version's
+   * `shutdown` while its files are still on disk — mirroring
+   * `uninstallPlugin`, which runs `shutdown` before `rmSync`. Best-effort: a
+   * rejection is swallowed so a failing teardown can never block the swap.
+   */
+  readonly beforeSwap?: () => Promise<void>;
 }
 
 /**
@@ -548,6 +560,7 @@ export async function finalizeStagedInstall(
     etag,
     pluginsDir,
     installDependencies,
+    beforeSwap,
   }: FinalizeStagedInstallParams,
 ): Promise<{ target: string; fingerprint: Fingerprint }> {
   // Install the plugin's own runtime dependencies into the staged tree before
@@ -591,6 +604,19 @@ export async function finalizeStagedInstall(
   // it, so the target's parent is no longer created as a side effect.
   const target = join(pluginsDir, name);
   mkdirSync(pluginsDir, { recursive: true });
+
+  // Give the outgoing version its shutdown before anything below reads or
+  // replaces the live install: everything fallible (fetch, merge, dependency
+  // install) has already succeeded, so a staging failure never tears a
+  // running plugin down, and the preserved-entries copy below still captures
+  // any final state the shutdown hook writes into data/.
+  if (beforeSwap) {
+    try {
+      await beforeSwap();
+    } catch {
+      // Best-effort teardown; the swap must proceed regardless.
+    }
+  }
 
   // Copy preserved entries (config.json, data/, .disabled) from the existing
   // install into the staging dir before the swap so user-owned state survives

--- a/assistant/src/cli/lib/upgrade-plugin.ts
+++ b/assistant/src/cli/lib/upgrade-plugin.ts
@@ -42,6 +42,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
+import { runShutdownHook } from "../../hooks/hook-loader.js";
 import { PRESERVED_ENTRIES } from "../../plugins/plugin-tree-walk.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
 import type { FetchLike } from "./fetch-like.js";
@@ -125,6 +126,18 @@ export interface UpgradePluginDeps {
   readonly runPostinstall?: PostinstallRunner;
   /** Override the dependency-install runner. Forwarded to {@link installPlugin} and {@link finalizeStagedInstall}. */
   readonly runInstallDeps?: DependencyInstaller;
+  /**
+   * Invoked after every fallible staging step succeeds and immediately before
+   * the staged tree is swapped over the live install, so the outgoing
+   * version's teardown runs while its files are still on disk (mirroring
+   * `uninstallPlugin`, which runs `shutdown` before `rmSync`). Defaults to
+   * running the plugin's `shutdown` hook (reason `reload`) in this process,
+   * skipped when the plugin is disabled; the daemon's upgrade route overrides
+   * it to deactivate the plugin in-process instead, so the post-swap
+   * reconcile only has the new version's `init` left to run. Never invoked
+   * for dry runs or no-op upgrades (they never reach the swap).
+   */
+  readonly beforeSwap?: () => Promise<void>;
 }
 
 /** Result of an upgrade attempt. */
@@ -236,6 +249,21 @@ export async function upgradePlugin(
   const name = sanitizePluginName(opts.name);
   const dryRun = opts.dryRun ?? false;
   const strategy = opts.strategy ?? DEFAULT_PLUGIN_UPGRADE_STRATEGY;
+
+  // Old-version teardown at the swap boundary. The default runs the
+  // `shutdown` hook in whatever process performs the upgrade (CLI or
+  // daemon), exactly like `uninstallPlugin`; a disabled plugin is skipped
+  // for the same reason uninstall skips it — it was never init'd, so
+  // running its shutdown would be the first-ever execution of its code.
+  const beforeSwap =
+    deps.beforeSwap ??
+    (async () => {
+      if (existsSync(join(pluginTarget(name, deps), ".disabled"))) {
+        return;
+      }
+      await runShutdownHook("plugin", name, "reload");
+    });
+  deps = { ...deps, beforeSwap };
 
   let inspection: PluginInspection;
   try {
@@ -372,6 +400,7 @@ export async function upgradePlugin(
       runGit: deps.runGit,
       runPostinstall: deps.runPostinstall,
       runInstallDeps: deps.runInstallDeps,
+      beforeSwap: deps.beforeSwap,
     },
   );
 
@@ -561,6 +590,7 @@ async function directUpgrade(
       runGit: deps.runGit,
       runPostinstall: deps.runPostinstall,
       runInstallDeps: deps.runInstallDeps,
+      beforeSwap: deps.beforeSwap,
     },
   );
 
@@ -727,6 +757,7 @@ async function mergeUpgrade(
       committedAt: toTimestamp,
       pluginsDir,
       installDependencies: deps.runInstallDeps,
+      beforeSwap: deps.beforeSwap,
     });
 
     return {

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -1001,6 +1001,24 @@ async function activatePlugin(
  * *before* removing the directory (see `cli/lib/uninstall-plugin.ts`), and an
  * out-of-band `rm` leaves nothing to resolve.
  */
+/**
+ * Deactivate a plugin ahead of an in-place upgrade's file swap: run the
+ * outgoing version's `shutdown` while its files are still on disk and drop
+ * its cached hook/tool resolutions. The upgrade route passes this as the
+ * upgrade's `beforeSwap` so teardown precedes the new files landing; the
+ * post-swap reconcile's redeploy branch then finds the plugin already
+ * deactivated (the `activatedNames` guard makes its own deactivate a no-op,
+ * so `shutdown` never double-runs) and proceeds straight to re-import and
+ * the new version's `init`. Safe no-op when the plugin is not active.
+ */
+export async function deactivatePluginForUpdate(
+  pluginName: string,
+): Promise<void> {
+  await deactivatePlugin(pluginName, "reload");
+  evictHooksForOwner("plugin", pluginName);
+  evictToolCacheEntries(pluginName);
+}
+
 async function deactivatePlugin(
   pluginName: string,
   reason: ShutdownReason,

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -91,7 +91,10 @@ import {
 import { getPlatformBaseUrl } from "../../config/env.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { ensurePluginApiShim } from "../../plugins/ensure-plugin-api-shim.js";
-import { reconcilePluginSourcesNow } from "../../plugins/mtime-cache.js";
+import {
+  deactivatePluginForUpdate,
+  reconcilePluginSourcesNow,
+} from "../../plugins/mtime-cache.js";
 import { getLocalCategorySlugs } from "../../skills/categories-cache.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
@@ -1413,24 +1416,44 @@ async function handleUpgradePlugin({
   // (resolved inside `upgradePlugin` via `inspectPlugin`), never a
   // caller-supplied ref — a `settings.write` principal cannot redirect the
   // upgrade at an unreviewed revision.
+  //
+  // Ensure the workspace `@vellumai/plugin-api` shim before the upgrade (as
+  // the uninstall route does before `uninstallPlugin`): the old version's
+  // `shutdown` runs mid-upgrade at the swap boundary, and a hook that imports
+  // the package must resolve even inside the daemon boot window.
+  await ensurePluginApiShim().catch(() => {});
+  // Set when the upgrade reached the swap boundary and this route deactivated
+  // the old version; from that point the plugin is down until a reconcile
+  // brings the on-disk version up, so the reconcile below must run even when
+  // the swap itself failed (re-initializing the untouched old install).
+  let deactivated = false;
   try {
+    const name = sanitizePluginName(rawName);
     const result = await upgradePlugin(
-      { name: rawName, dryRun, strategy },
-      { fetch: globalThis.fetch.bind(globalThis) },
+      { name, dryRun, strategy },
+      {
+        fetch: globalThis.fetch.bind(globalThis),
+        // Tear the old version down BEFORE the staged tree replaces its
+        // files, mirroring uninstall (shutdown runs while the files it was
+        // initialized from are still on disk). Deactivating in-process also
+        // marks the plugin inactive, so the post-swap reconcile's redeploy
+        // branch skips its own deactivate (no double shutdown) and only the
+        // new version's `init` remains to run.
+        beforeSwap: async () => {
+          deactivated = true;
+          await deactivatePluginForUpdate(name);
+        },
+      },
     );
-    // An upgrade that actually moved files (outcome `upgraded`) rewrites the
-    // plugin's on-disk source; bring the change up in-process right now — run
-    // the old version's `shutdown` and the new version's `init` via the
-    // reconcile — instead of waiting for the resource monitor to republish the
-    // sentinel and a later turn to apply it. This is what makes the lifecycle
-    // fire as part of the upgrade rather than at the next daemon boot,
-    // symmetric to the install and uninstall routes. A no-op or dry run leaves
-    // the tree unchanged, so there is nothing to reconcile. Ensure the
-    // workspace `@vellumai/plugin-api` shim first (as uninstall does) so a hook
-    // that imports the package resolves even inside the daemon boot window.
-    // Never throws; a failure is contained and logged.
+    // Bring the change up in-process right now — the new version's `init`
+    // via the reconcile — instead of waiting for the resource monitor to
+    // republish the sentinel and a later turn to apply it. This is what
+    // makes the lifecycle fire as part of the upgrade rather than at the
+    // next daemon boot, symmetric to the install and uninstall routes. A
+    // no-op or dry run leaves the tree unchanged (and never reaches the
+    // swap boundary), so there is nothing to reconcile. Never throws; a
+    // failure is contained and logged.
     if (result.outcome === "upgraded") {
-      await ensurePluginApiShim().catch(() => {});
       await reconcilePluginSourcesNow();
     }
     publishPluginsChanged(getOriginClientId(headers));
@@ -1480,6 +1503,18 @@ async function handleUpgradePlugin({
     throw new InternalError(
       err instanceof Error ? err.message : "plugin upgrade failed",
     );
+  } finally {
+    // Once `beforeSwap` deactivated the old version, the plugin is down until
+    // a reconcile brings the on-disk tree up — the new revision on success,
+    // or the untouched old install when the swap itself failed. Run it here
+    // rather than only on the success path so a failed swap never strands
+    // the plugin deactivated until the next sentinel-driven reconcile.
+    // (On success this is the same reconcile the try block already awaited;
+    // `reconcilePluginSourcesNow` coalesces, and a second pass with nothing
+    // changed is a cheap no-op.)
+    if (deactivated) {
+      await reconcilePluginSourcesNow();
+    }
   }
 }
 


### PR DESCRIPTION
## Prompt / plan

Follow-up from meeting-bot QA (vellum-ai/meeting-bot#33 context): `plugins upgrade` replaced the plugin's files first and ran the lifecycle afterwards, so the old version's `shutdown` hook executed with the new revision already on disk — asymmetric with uninstall, which runs `shutdown` while the files it initialized from are still present (`uninstallPlugin` before `rmSync`). Plan: hook the teardown into the existing single swap boundary rather than reordering the flows.

- `finalizeStagedInstall` (the one rm+rename choke point shared by installs and both upgrade paths) gains an optional `beforeSwap` callback, invoked after every fallible staging step succeeds (fetch, merge, dependency install) and immediately before the preserved-entries copy + swap — so a staging failure still never touches the running plugin, and any final state the shutdown writes into `data/` rides the preserved-entries copy.
- `upgradePlugin` threads it through both the overwrite (`installPlugin` delegation) and merge paths, defaulting to `runShutdownHook("plugin", name, "reload")` in whatever process performs the upgrade (skipped for disabled plugins, mirroring `uninstallPlugin`'s rationale). Dry runs and no-op upgrades never reach the swap boundary, so the hook never fires for them. A rejecting `beforeSwap` is swallowed — teardown can never block the swap.
- The daemon's upgrade route overrides the default with a new `deactivatePluginForUpdate` export from mtime-cache (deactivate + hook/tool cache eviction), so the plugin is marked inactive in-process before the swap: the post-swap reconcile's redeploy branch no-ops its own deactivate via the existing `activatedNames` guard (no double shutdown) and only the new version's `init` remains to run. The route now reconciles in a `finally` whenever the swap boundary was reached, so a swap that fails after teardown re-initializes the untouched old install instead of stranding the plugin deactivated until the next sentinel-driven reconcile.

## Test plan

- 4 new tests in `upgrade-plugin.test.ts`: `beforeSwap` runs exactly once with the OLD install still on disk and the swap completes after; a rejecting `beforeSwap` doesn't block the swap; dry-run and already-up-to-date never invoke it; a staging (clone) failure never invokes it.
- Existing suites pass: `upgrade-plugin.test.ts` 29/29, `plugins-routes.test.ts` 111/111, `src/plugins/__tests__` 8/8. (`install-from-github` / `install-from-platform` / `uninstall-plugin` suites have 29 failures in my sandbox that reproduce identically on the unmodified baseline — environment, not this change.)
- `bunx tsc --noEmit` clean (modulo the baseline `TS2688 'bun'` types-resolution noise); pre-commit format/lint/typecheck hooks pass.

## CLI verb checklist

No new routes — the existing `plugins_upgrade` route changes behavior only. The CLI's local-fallback path (`assistant plugins upgrade` with the daemon unreachable) picks up the default `beforeSwap`, so it now runs the old shutdown pre-swap too, mirroring how `plugins uninstall` behaves in both processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ)_