### PR TITLE
fix(plugin-api): lazy-load the STT resolver in the transcription facade

### DIFF
--- a/assistant/src/plugin-api/transcription-session.ts
+++ b/assistant/src/plugin-api/transcription-session.ts
@@ -11,7 +11,6 @@
  * credentials.
  */
 
-import { resolveStreamingTranscriber } from "../providers/speech-to-text/resolve.js";
 import type { StreamingTranscriber } from "../stt/types.js";
 
 /**
@@ -22,7 +21,19 @@ import type { StreamingTranscriber } from "../stt/types.js";
  * `start` / `sendAudio` / `stop`, or `null` when no streaming session can be
  * opened — the provider is unknown, has no streaming adapter, or is missing
  * credentials.
+ *
+ * The STT resolver is imported lazily at call time, mirroring
+ * `runConversationTurn`: plugin-api facades must not statically pull deep
+ * daemon subsystems into the barrel's module graph. The static import here
+ * dragged ~75 provider/STT modules into `plugin-api/index.ts` evaluation,
+ * and in the compiled binary that surfaced as a TDZ `ReferenceError`
+ * ("Cannot access 'openTranscriptionSession' before initialization") when a
+ * plugin touched the binding through the workspace shim. With the lazy
+ * import this module has no static value imports at all, so the barrel
+ * binding initializes trivially and the daemon graph loads on first use.
  */
-export function openTranscriptionSession(): Promise<StreamingTranscriber | null> {
+export async function openTranscriptionSession(): Promise<StreamingTranscriber | null> {
+  const { resolveStreamingTranscriber } =
+    await import("../providers/speech-to-text/resolve.js");
   return resolveStreamingTranscriber();
 }


### PR DESCRIPTION
## Prompt / plan

Bug report from meeting-bot QA: `ReferenceError: Cannot access 'openTranscriptionSession' before initialization`, thrown from the plugin's `stt-api.ts` when it touches the binding through the workspace shim.

Investigation findings (static import-graph analysis over `assistant/src`):

- Nothing outside `plugin-api/` value-imports the barrel except `embedded/plugin-api.ts` (the intended `globalThis` registry installer) — the daemon internals correctly import concrete modules, so the hypothesized "daemon code imports the barrel" cycle does not exist at source level.
- There is **no static path from `transcription-session.ts` back into `plugin-api/`** either, and evaluating the barrel from source works (`typeof openTranscriptionSession === "function"`, and calling it resolves `null` without a configured provider). The failure is specific to the **compiled binary**.
- What the static import *did* do: drag ~75 provider/STT modules into `plugin-api/index.ts`'s evaluation graph — a graph that (via other exports) also contains a genuine import cycle (`providers/connection-resolution → inference/connections → registry → adapter-factory → retry → usage/attribution → connection-resolution`, the only cycle among the barrel's 288 transitive modules). Under the bundler's cyclic-module lowering, barrel bindings can be observed before their module wrapper has run — a TDZ `ReferenceError` naming exactly the newest tail export.
- The repo already has the right pattern for this: `runConversationTurn` keeps its facade at **1 module** by `await import`ing every daemon dependency inside the function body. `transcription-session.ts` broke that pattern.

Fix: import the STT resolver lazily at call time, mirroring `runConversationTurn`. The facade now has no static value imports at all (subtree: 75 modules → itself), the barrel binding initializes trivially, and the daemon STT graph loads on first use. The pre-existing provider cycle is left for a follow-up if desired — with the facade lazy, it can no longer destabilize the plugin-api surface through this export.

## Test plan

- `transcription-session.test.ts` passes unchanged (2/2) — the mock-driven resolver behavior is identical through the dynamic import.
- Behavior check from source: `import("./src/plugin-api/index.ts")` → `typeof openTranscriptionSession === "function"`; calling it resolves `null` in an unconfigured environment (the documented no-session contract).
- Import-graph check: the facade's transitive value-import subtree is now exactly one module.
- Pre-commit format/lint/typecheck hooks pass.

## CLI verb checklist

No new routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ)_