### PR TITLE
feat(routes): add `assistant routes worker [start|stop|status]` commands

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24318,6 +24318,79 @@ paths:
                   - runs
                   - nextCursor
                 additionalProperties: false
+  /v1/routes/worker/start:
+    post:
+      operationId: routes_worker_start_post
+      summary: Start the route host
+      description: Spawns (or reuses) the route host process as a child of the daemon.
+      tags:
+        - system
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pid:
+                    type: number
+                  alreadyRunning:
+                    type: boolean
+                  pidPath:
+                    type: string
+                required:
+                  - pid
+                  - alreadyRunning
+                  - pidPath
+                additionalProperties: false
+  /v1/routes/worker/status:
+    get:
+      operationId: routes_worker_status_get
+      summary: Route host status
+      description: Reports the route host process liveness.
+      tags:
+        - system
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - running
+                      - not_running
+                  pid:
+                    type: number
+                required:
+                  - status
+                additionalProperties: false
+  /v1/routes/worker/stop:
+    post:
+      operationId: routes_worker_stop_post
+      summary: Stop the route host
+      description: SIGTERMs the route host process if it is running; the next request respawns it.
+      tags:
+        - system
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  workerWasRunning:
+                    type: boolean
+                  pid:
+                    type: number
+                required:
+                  - workerWasRunning
+                additionalProperties: false
   /v1/sanity/connect:
     post:
       operationId: sanity_connect_post

--- a/assistant/src/cli/commands/routes-worker.ts
+++ b/assistant/src/cli/commands/routes-worker.ts
@@ -1,0 +1,102 @@
+/**
+ * `assistant routes worker` CLI subgroup.
+ *
+ * The route host runs user-defined `/x/*` handlers as its own OS process — a
+ * child of the assistant, spawned on demand — so a handler that blocks does not
+ * stall the assistant's main event loop and can be reclaimed with a hard kill.
+ *
+ * Subcommands (thin IPC wrappers; the assistant owns the process so it is
+ * spawned as a child of the assistant and appears in `assistant ps`):
+ *
+ *   - `start`  — spawn the route host process if it is not already running.
+ *   - `stop`   — SIGTERM the route host process (the next request respawns it).
+ *   - `status` — report the route host process state.
+ */
+
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { subcommand } from "../lib/cli-command-help.js";
+import { log } from "../logger.js";
+import { shouldOutputJson, writeOutput } from "../output.js";
+
+interface StartResponse {
+  pid: number;
+  alreadyRunning: boolean;
+  pidPath: string;
+}
+
+interface StopResponse {
+  workerWasRunning: boolean;
+  pid?: number;
+}
+
+interface StatusResponse {
+  status: "running" | "not_running";
+  pid?: number;
+}
+
+export function registerRoutesWorkerCommand(routes: Command): void {
+  const worker = subcommand(routes, "worker");
+
+  subcommand(worker, "start").action(
+    async (_opts: { json?: boolean }, cmd: Command) => {
+      const r = await cliIpcCall<StartResponse>("routes_worker_start");
+      if (!r.ok) {
+        return exitFromIpcResult(r);
+      }
+      const res = r.result!;
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, res);
+        return;
+      }
+      log.info(
+        res.alreadyRunning
+          ? `Route host is already running (PID ${res.pid})`
+          : `Route host started (PID ${res.pid})`,
+      );
+    },
+  );
+
+  subcommand(worker, "stop").action(
+    async (_opts: { json?: boolean }, cmd: Command) => {
+      const r = await cliIpcCall<StopResponse>("routes_worker_stop");
+      if (!r.ok) {
+        return exitFromIpcResult(r);
+      }
+      const res = r.result!;
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, res);
+        return;
+      }
+      if (res.workerWasRunning) {
+        log.info(`Route host stop signal sent (PID ${res.pid})`);
+      } else {
+        log.info("Route host process was not running");
+      }
+      log.info("The route host respawns on the next request");
+    },
+  );
+
+  subcommand(worker, "status").action(
+    async (_opts: { json?: boolean }, cmd: Command) => {
+      const r = await cliIpcCall<StatusResponse>("routes_worker_status");
+      if (!r.ok) {
+        return exitFromIpcResult(r);
+      }
+      const res = r.result!;
+
+      if (shouldOutputJson(cmd)) {
+        writeOutput(cmd, res);
+        return;
+      }
+      if (res.status === "running") {
+        log.info(`Route host process is running (PID ${res.pid})`);
+      } else {
+        log.info("Route host process is not running");
+      }
+    },
+  );
+}

--- a/assistant/src/cli/commands/routes.help.ts
+++ b/assistant/src/cli/commands/routes.help.ts
@@ -68,5 +68,54 @@ Examples:
   $ assistant routes inspect plugins/my-plugin/status
   $ assistant routes inspect items --json`,
     },
+    {
+      name: "worker",
+      description: "Manage the route host process (start/stop/status)",
+      helpText: `
+The route host runs user-defined /x/* handlers in a separate OS process, so a
+handler that blocks does not stall the assistant's main event loop and can be
+reclaimed with a hard kill. The assistant spawns it on demand (on the first
+request); these commands manage that process directly.
+
+\`start\` spawns it as a child of the assistant (so it shows up in
+\`assistant ps\`); \`stop\` SIGTERMs it — the next request respawns it.
+
+Examples:
+  $ assistant routes worker start
+  $ assistant routes worker status
+  $ assistant routes worker stop`,
+      subcommands: [
+        {
+          name: "start",
+          description: "Spawn the route host process if it is not running",
+          options: [
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted summary",
+            },
+          ],
+        },
+        {
+          name: "stop",
+          description: "SIGTERM the route host process",
+          options: [
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted summary",
+            },
+          ],
+        },
+        {
+          name: "status",
+          description: "Report the route host process liveness",
+          options: [
+            {
+              flags: "--json",
+              description: "Emit raw JSON instead of a formatted summary",
+            },
+          ],
+        },
+      ],
+    },
   ],
 };

--- a/assistant/src/cli/commands/routes.ts
+++ b/assistant/src/cli/commands/routes.ts
@@ -11,6 +11,7 @@ import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { log } from "../logger.js";
 import { routesHelp } from "./routes.help.js";
+import { registerRoutesWorkerCommand } from "./routes-worker.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -54,11 +55,15 @@ export function registerRoutesCommand(program: Command): void {
     build: (routes) => {
       applyCommandHelp(routes, routesHelp);
 
+      registerRoutesWorkerCommand(routes);
+
       subcommand(routes, "list").action(async (opts: { json?: boolean }) => {
         const r = await cliIpcCall<{ routes: DiscoveredRoute[] }>(
           "user_routes_list",
         );
-        if (!r.ok) return exitFromIpcResult(r);
+        if (!r.ok) {
+          return exitFromIpcResult(r);
+        }
 
         const discovered = r.result!.routes;
 

--- a/assistant/src/routes/control.ts
+++ b/assistant/src/routes/control.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared control surface for the route host *process* — the subprocess whose
+ * entry point is `worker.ts`, which runs user-defined `/x/*` route handlers off
+ * the daemon.
+ *
+ * The `assistant routes worker` CLI (via the `routes_worker_*` routes) needs to
+ * probe, spawn, and stop this process. The generic PID-file mechanics live in
+ * `util/worker-process.ts`; this module binds them to the route host's PID path
+ * and entry point.
+ *
+ * Note the route host is spawned *on demand*, not at boot: {@link RouteHostClient}
+ * also spawns it lazily on the first request. Both share the same PID file, so a
+ * CLI-initiated `start` and a lazy spawn cooperate — whichever loses the race
+ * sees `alreadyRunning`. Likewise `stop` is only a pause: the next request
+ * respawns the host.
+ */
+
+import { getLogger } from "../util/logger.js";
+import { getProcPidPath } from "../util/platform.js";
+import {
+  probeWorkerPidFile,
+  spawnWorkerProcess,
+  type SpawnWorkerProcessOptions,
+  stopWorkerProcess,
+  WorkerProcessSpawnError,
+  type WorkerProcessStatus,
+} from "../util/worker-process.js";
+import { ROUTE_HOST_PROC_NAME } from "./route-host-protocol.js";
+
+const log = getLogger("route-host-control");
+
+function routeHostPidPath(): string {
+  return getProcPidPath(ROUTE_HOST_PROC_NAME);
+}
+
+/**
+ * Read the PID file and report liveness. A missing or malformed file reports
+ * not_running; a file pointing at a dead process is cleaned up and reported as
+ * not_running.
+ */
+export function probeRouteHostWorker(): WorkerProcessStatus {
+  return probeWorkerPidFile(routeHostPidPath());
+}
+
+export class RouteHostSpawnError extends WorkerProcessSpawnError {}
+
+/**
+ * Spawn the route host as a background process. If one is already running,
+ * returns its PID with `alreadyRunning: true` rather than spawning a second
+ * one. Throws {@link RouteHostSpawnError} if the child crashes during startup or
+ * never writes its PID file within the wait window.
+ */
+export async function spawnRouteHostWorkerProcess(
+  opts: SpawnWorkerProcessOptions = {},
+): Promise<{ pid: number; alreadyRunning: boolean }> {
+  try {
+    return await spawnWorkerProcess({
+      pidPath: routeHostPidPath(),
+      entry: new URL("./worker.ts", import.meta.url),
+      workerLabel: "Route host",
+      options: opts,
+    });
+  } catch (err) {
+    if (err instanceof WorkerProcessSpawnError) {
+      throw new RouteHostSpawnError(err.message);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Send SIGTERM to the route host process if it is actually running. Returns the
+ * status observed before signalling. Only throws if `process.kill` itself fails
+ * (e.g. EPERM) — a not-running host is a no-op.
+ */
+export function stopRouteHostWorkerProcess(): WorkerProcessStatus {
+  const status = probeRouteHostWorker();
+  if (status.status === "running") {
+    log.info({ pid: status.pid }, "Sending SIGTERM to route host process");
+  }
+  return stopWorkerProcess(routeHostPidPath());
+}

--- a/assistant/src/runtime/routes/__tests__/route-host-worker-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/route-host-worker-routes.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the route host worker control routes (start / stop / status).
+ *
+ * The handlers run inside the daemon and manage the route host process. We mock
+ * the route host control surface so the tests assert handler behaviour:
+ *   - start spawns as a daemon child (detached:false) and throws on failure.
+ *   - stop signals the host and reports its prior state.
+ *   - status reports the host process liveness.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { getProcPidPath } from "../../../util/platform.js";
+
+class FakeSpawnError extends Error {}
+
+let spawnImpl: () => Promise<{ pid: number; alreadyRunning: boolean }>;
+let spawnArgs: Array<{ detached?: boolean; terminateOnTimeout?: boolean }> = [];
+let stopImpl: () => { status: "running" | "not_running"; pid?: number };
+let workerProbe: { status: "running" | "not_running"; pid?: number } = {
+  status: "not_running",
+};
+
+mock.module("../../../routes/control.js", () => ({
+  RouteHostSpawnError: FakeSpawnError,
+  spawnRouteHostWorkerProcess: async (opts: {
+    detached?: boolean;
+    terminateOnTimeout?: boolean;
+  }) => {
+    spawnArgs.push(opts);
+    return spawnImpl();
+  },
+  stopRouteHostWorkerProcess: () => stopImpl(),
+  probeRouteHostWorker: () => workerProbe,
+}));
+
+const { ROUTES } = await import("../route-host-worker-routes.js");
+
+function handler(operationId: string) {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`route ${operationId} not registered`);
+  }
+  return route.handler as () => Promise<Record<string, unknown>>;
+}
+
+beforeEach(() => {
+  spawnArgs = [];
+  spawnImpl = async () => ({ pid: 4242, alreadyRunning: false });
+  stopImpl = () => ({ status: "not_running" });
+  workerProbe = { status: "not_running" };
+});
+
+describe("routes_worker_start", () => {
+  test("spawns as a daemon child and returns the PID", async () => {
+    spawnImpl = async () => ({ pid: 4242, alreadyRunning: false });
+
+    const res = await handler("routes_worker_start")();
+
+    expect(spawnArgs).toEqual([{ detached: false }]);
+    expect(res).toEqual({
+      pid: 4242,
+      alreadyRunning: false,
+      pidPath: getProcPidPath("routes"),
+    });
+  });
+
+  test("reports an already-running host without re-spawning", async () => {
+    spawnImpl = async () => ({ pid: 99, alreadyRunning: true });
+
+    const res = await handler("routes_worker_start")();
+
+    expect(res).toMatchObject({ pid: 99, alreadyRunning: true });
+  });
+
+  test("throws when the spawn fails", async () => {
+    spawnImpl = async () => {
+      throw new FakeSpawnError("host exited during startup");
+    };
+
+    await expect(handler("routes_worker_start")()).rejects.toThrow(
+      "host exited during startup",
+    );
+  });
+});
+
+describe("routes_worker_stop", () => {
+  test("reports the host was running and its PID", async () => {
+    stopImpl = () => ({ status: "running", pid: 555 });
+
+    const res = await handler("routes_worker_stop")();
+
+    expect(res).toEqual({ workerWasRunning: true, pid: 555 });
+  });
+
+  test("reports not-running when no host is up", async () => {
+    stopImpl = () => ({ status: "not_running" });
+
+    const res = await handler("routes_worker_stop")();
+
+    expect(res).toEqual({ workerWasRunning: false });
+  });
+});
+
+describe("routes_worker_status", () => {
+  test("reports a running host with its PID", async () => {
+    workerProbe = { status: "running", pid: 777 };
+
+    const res = await handler("routes_worker_status")();
+
+    expect(res).toEqual({ status: "running", pid: 777 });
+  });
+
+  test("reports not-running", async () => {
+    workerProbe = { status: "not_running" };
+
+    const res = await handler("routes_worker_status")();
+
+    expect(res).toEqual({ status: "not_running" });
+  });
+});

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -126,6 +126,7 @@ import { ROUTES as QUESTION_ROUTES } from "./question-routes.js";
 import { ROUTES as RECORDING_ROUTES } from "./recording-routes.js";
 import { ROUTES as RENAME_CONVERSATION_ROUTES } from "./rename-conversation-routes.js";
 import { ROUTES as RETROSPECTIVE_ROUTES } from "./retrospective-routes.js";
+import { ROUTES as ROUTE_HOST_WORKER_ROUTES } from "./route-host-worker-routes.js";
 import { ROUTES as SANITY_ROUTES } from "./sanity-routes.js";
 import { ROUTES as SCHEDULE_ROUTES } from "./schedule-routes.js";
 import { ROUTES as SCHEDULE_WORKER_ROUTES } from "./schedule-worker-routes.js";
@@ -271,6 +272,7 @@ export const ROUTES: RouteDefinition[] = [
   ...RETROSPECTIVE_ROUTES,
   ...SCHEDULE_ROUTES,
   ...SCHEDULE_WORKER_ROUTES,
+  ...ROUTE_HOST_WORKER_ROUTES,
   ...SANITY_ROUTES,
   ...SECRET_ROUTES,
   ...SETTINGS_ROUTES,

--- a/assistant/src/runtime/routes/route-host-worker-routes.ts
+++ b/assistant/src/runtime/routes/route-host-worker-routes.ts
@@ -1,0 +1,144 @@
+/**
+ * Route host worker control endpoints (start / stop / status).
+ *
+ * The route host runs user-defined `/x/*` handlers as a child process the
+ * daemon spawns on demand (so it shows up in `assistant ps` and is torn down on
+ * shutdown). These routes run inside the daemon so a worker spawned via them is
+ * a direct child of the daemon too. `start` / `stop` manage the process
+ * lifecycle directly (respawn or SIGTERM); `status` reports its liveness. The
+ * `assistant routes worker` CLI is a thin IPC client over these routes.
+ *
+ * Unlike the schedule/monitor workers, the route host is NOT spawned at boot and
+ * has no liveness watchdog — `RouteHostClient` respawns it lazily on the next
+ * request — so there is no administratively-stopped flag to manage here.
+ */
+
+import { z } from "zod";
+
+import {
+  probeRouteHostWorker,
+  RouteHostSpawnError,
+  spawnRouteHostWorkerProcess,
+  stopRouteHostWorkerProcess,
+} from "../../routes/control.js";
+import { ROUTE_HOST_PROC_NAME } from "../../routes/route-host-protocol.js";
+import { getLogger } from "../../util/logger.js";
+import { getProcPidPath } from "../../util/platform.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { InternalError } from "./errors.js";
+import type { RouteDefinition } from "./types.js";
+
+const log = getLogger("route-host-worker-routes");
+
+const startResponseSchema = z.object({
+  pid: z.number(),
+  alreadyRunning: z.boolean(),
+  pidPath: z.string(),
+});
+
+const stopResponseSchema = z.object({
+  workerWasRunning: z.boolean(),
+  pid: z.number().optional(),
+});
+
+const statusResponseSchema = z.object({
+  status: z.enum(["running", "not_running"]),
+  pid: z.number().optional(),
+});
+
+/** Spawn (or reuse) the route host process as a child of the daemon. */
+async function startRouteHostWorker() {
+  let result: { pid: number; alreadyRunning: boolean };
+  try {
+    result = await spawnRouteHostWorkerProcess({ detached: false });
+  } catch (err) {
+    const message =
+      err instanceof RouteHostSpawnError || err instanceof Error
+        ? err.message
+        : String(err);
+    log.warn({ err }, "Failed to start route host process");
+    throw new InternalError(message);
+  }
+
+  return {
+    pid: result.pid,
+    alreadyRunning: result.alreadyRunning,
+    pidPath: getProcPidPath(ROUTE_HOST_PROC_NAME),
+  };
+}
+
+/**
+ * SIGTERM the route host process if it is running. A host that is not running
+ * is not an error. The next `/x/*` request respawns it.
+ */
+function stopRouteHostWorker() {
+  let before: ReturnType<typeof stopRouteHostWorkerProcess>;
+  try {
+    before = stopRouteHostWorkerProcess();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn({ err }, "Failed to signal route host process");
+    throw new InternalError(message);
+  }
+
+  return {
+    workerWasRunning: before.status === "running",
+    ...(before.pid != null ? { pid: before.pid } : {}),
+  };
+}
+
+/** Report the route host process liveness from its PID file. */
+function routeHostWorkerStatus() {
+  const worker = probeRouteHostWorker();
+  return {
+    status: worker.status,
+    ...(worker.pid != null ? { pid: worker.pid } : {}),
+  };
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "routes_worker_start",
+    endpoint: "routes/worker/start",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    handler: startRouteHostWorker,
+    summary: "Start the route host",
+    description:
+      "Spawns (or reuses) the route host process as a child of the daemon.",
+    tags: ["system"],
+    responseBody: startResponseSchema,
+  },
+  {
+    operationId: "routes_worker_stop",
+    endpoint: "routes/worker/stop",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    handler: stopRouteHostWorker,
+    summary: "Stop the route host",
+    description:
+      "SIGTERMs the route host process if it is running; the next request respawns it.",
+    tags: ["system"],
+    responseBody: stopResponseSchema,
+  },
+  {
+    operationId: "routes_worker_status",
+    endpoint: "routes/worker/status",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    handler: routeHostWorkerStatus,
+    summary: "Route host status",
+    description: "Reports the route host process liveness.",
+    tags: ["system"],
+    responseBody: statusResponseSchema,
+  },
+];


### PR DESCRIPTION
## Prompt / plan

First follow-up to the merged route host (#38789), and item #1 of the roadmap you left on that PR: an operator surface to manage the route host subprocess directly. Mirrors `assistant schedules worker` and `assistant monitoring`.

- **`src/routes/control.ts`** — probe/spawn/stop control surface bound to the route host's PID path and `worker.ts` entry, reusing `util/worker-process.ts` (the same helper the monitor and schedule workers use). `RouteHostClient` still spawns the host lazily on the first `/x/*` request; both share the same PID file, so a CLI-initiated `start` and a lazy spawn cooperate (whoever loses the race sees `alreadyRunning`).
- **`runtime/routes/route-host-worker-routes.ts`** — shared `ROUTES` (`routes_worker_start | stop | status`) that run inside the daemon, so a CLI-triggered `start` spawns the host as a **daemon child** (`detached: false`) — appearing in `assistant ps` and torn down on shutdown. Registered in the routes aggregator.
- **`cli/commands/routes-worker.ts` + `routes.help.ts`** — the `routes worker` subcommand group as thin IPC wrappers (`transport: "ipc"`), wired into `registerRoutesCommand`.
- **`openapi.yaml`** — regenerated for the three new operations.

Unlike the schedule/monitor workers, the route host is **not** spawned at boot and has no liveness watchdog — so `stop` is a pause, not a disable: the next `/x/*` request respawns it. That also means there's no administratively-stopped flag to manage.

## Test plan

- `bun test src/runtime/routes/__tests__/route-host-worker-routes.test.ts` → **7 pass**. Mocks the control surface and asserts the handlers: `start` spawns as a daemon child (`detached: false`), reports an already-running host without re-spawning, and surfaces spawn failures; `stop`/`status` report the process state.
- `cli-command-help-coverage.test.ts` passes — the new `worker` subcommand + `start/stop/status` are consistent between the help declaration and the command tree (`subcommand()` throws otherwise).
- `route-host.test.ts` (the merged mechanism) still passes.
- `bunx tsc --noEmit`, prettier, eslint clean; OpenAPI spec regenerated; pre-commit hooks pass.

## Follow-ups (remaining roadmap)

- An `enabled` boolean in workspace config gating whether the host is used.
- Lifecycle + HTTP-router integration (dispatch delegation from `user-route-dispatcher.ts` behind that flag).
- A host pool to isolate route-from-route.

## CLI verb checklist

This PR **is** the CLI verb: `assistant routes worker [start|stop|status]`, backed by the `routes_worker_*` routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FosQeirkpt7G1K2SSbMx1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01FosQeirkpt7G1K2SSbMx1N)_