### PR TITLE
Single-source settings config events; nuke dead avatar/voice message types

### DIFF
--- a/assistant/src/api/events/client-settings-update.ts
+++ b/assistant/src/api/events/client-settings-update.ts
@@ -1,0 +1,25 @@
+/**
+ * `client_settings_update` SSE event.
+ *
+ * Server → client instruction to update a single client-side setting
+ * (e.g. the voice activation key). `key` names the setting and `value`
+ * is its new value, always sent as a string.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const ClientSettingsUpdateEventSchema = z.object({
+  type: z.literal("client_settings_update"),
+  /** The setting key to update (e.g. "activationKey"). */
+  key: z.string(),
+  /** The new value for the setting. */
+  value: z.string(),
+});
+
+export type ClientSettingsUpdateEvent = z.infer<
+  typeof ClientSettingsUpdateEventSchema
+>;

--- a/assistant/src/api/events/config-changed.ts
+++ b/assistant/src/api/events/config-changed.ts
@@ -1,0 +1,19 @@
+/**
+ * `config_changed` SSE event.
+ *
+ * Server → client invalidation signal emitted when the workspace
+ * `config.json` changes on disk. Carries no payload — clients refetch
+ * config-derived state on receipt.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const ConfigChangedEventSchema = z.object({
+  type: z.literal("config_changed"),
+});
+
+export type ConfigChangedEvent = z.infer<typeof ConfigChangedEventSchema>;

--- a/assistant/src/api/events/sounds-config-updated.ts
+++ b/assistant/src/api/events/sounds-config-updated.ts
@@ -1,0 +1,21 @@
+/**
+ * `sounds_config_updated` SSE event.
+ *
+ * Server → client invalidation signal emitted when the sounds config or
+ * the sound files change on disk. Carries no payload — clients refetch
+ * their sound set on receipt.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const SoundsConfigUpdatedEventSchema = z.object({
+  type: z.literal("sounds_config_updated"),
+});
+
+export type SoundsConfigUpdatedEvent = z.infer<
+  typeof SoundsConfigUpdatedEventSchema
+>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -14,8 +14,10 @@ import { BackgroundToolCompletedEventSchema } from "./events/background-tool-com
 import { BackgroundToolStartedEventSchema } from "./events/background-tool-started.js";
 import { BookmarkCreatedEventSchema } from "./events/bookmark-created.js";
 import { BookmarkDeletedEventSchema } from "./events/bookmark-deleted.js";
+import { ClientSettingsUpdateEventSchema } from "./events/client-settings-update.js";
 import { CompactionCircuitClosedEventSchema } from "./events/compaction-circuit-closed.js";
 import { CompactionCircuitOpenEventSchema } from "./events/compaction-circuit-open.js";
+import { ConfigChangedEventSchema } from "./events/config-changed.js";
 import { ConfirmationRequestEventSchema } from "./events/confirmation-request.js";
 import { ContactRequestEventSchema } from "./events/contact-request.js";
 import { ContactsChangedEventSchema } from "./events/contacts-changed.js";
@@ -61,6 +63,7 @@ import { SecretRequestEventSchema } from "./events/secret-request.js";
 import { ServiceGroupUpdateCompleteEventSchema } from "./events/service-group-update-complete.js";
 import { ServiceGroupUpdateProgressEventSchema } from "./events/service-group-update-progress.js";
 import { ServiceGroupUpdateStartingEventSchema } from "./events/service-group-update-starting.js";
+import { SoundsConfigUpdatedEventSchema } from "./events/sounds-config-updated.js";
 import { SubagentEventEventSchema } from "./events/subagent-event.js";
 import { SubagentSpawnedEventSchema } from "./events/subagent-spawned.js";
 import { SubagentStatusChangedEventSchema } from "./events/subagent-status-changed.js";
@@ -164,6 +167,10 @@ export {
   BookmarkDeletedEventSchema,
 } from "./events/bookmark-deleted.js";
 export {
+  type ClientSettingsUpdateEvent,
+  ClientSettingsUpdateEventSchema,
+} from "./events/client-settings-update.js";
+export {
   type CompactionCircuitClosedEvent,
   CompactionCircuitClosedEventSchema,
 } from "./events/compaction-circuit-closed.js";
@@ -171,6 +178,10 @@ export {
   type CompactionCircuitOpenEvent,
   CompactionCircuitOpenEventSchema,
 } from "./events/compaction-circuit-open.js";
+export {
+  type ConfigChangedEvent,
+  ConfigChangedEventSchema,
+} from "./events/config-changed.js";
 export {
   type ACPOption,
   type ACPOptionKind,
@@ -370,6 +381,10 @@ export {
   type ServiceGroupUpdateStartingEvent,
   ServiceGroupUpdateStartingEventSchema,
 } from "./events/service-group-update-starting.js";
+export {
+  type SoundsConfigUpdatedEvent,
+  SoundsConfigUpdatedEventSchema,
+} from "./events/sounds-config-updated.js";
 export {
   type SubagentEventEvent,
   SubagentEventEventSchema,
@@ -703,8 +718,10 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   BackgroundToolStartedEventSchema,
   BookmarkCreatedEventSchema,
   BookmarkDeletedEventSchema,
+  ClientSettingsUpdateEventSchema,
   CompactionCircuitClosedEventSchema,
   CompactionCircuitOpenEventSchema,
+  ConfigChangedEventSchema,
   ConfirmationRequestEventSchema,
   ContactRequestEventSchema,
   ContactsChangedEventSchema,
@@ -748,6 +765,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   ServiceGroupUpdateCompleteEventSchema,
   ServiceGroupUpdateProgressEventSchema,
   ServiceGroupUpdateStartingEventSchema,
+  SoundsConfigUpdatedEventSchema,
   SubagentEventEventSchema,
   SubagentSpawnedEventSchema,
   SubagentStatusChangedEventSchema,

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -99,10 +99,7 @@ import type {
   _SchedulesClientMessages,
   _SchedulesServerMessages,
 } from "./message-types/schedules.js";
-import type {
-  _SettingsClientMessages,
-  _SettingsServerMessages,
-} from "./message-types/settings.js";
+import type { _SettingsServerMessages } from "./message-types/settings.js";
 import type {
   _SkillsClientMessages,
   _SkillsServerMessages,
@@ -149,8 +146,7 @@ export type ClientMessage =
   | _WorkspaceClientMessages
   | _SchedulesClientMessages
   | _DiagnosticsClientMessages
-  | _NotificationsClientMessages
-  | _SettingsClientMessages;
+  | _NotificationsClientMessages;
 
 // === Server -> Client aggregate union ===
 

--- a/assistant/src/daemon/message-types/settings.ts
+++ b/assistant/src/daemon/message-types/settings.ts
@@ -1,61 +1,17 @@
 // Client settings: daemon-pushed configuration updates to connected clients.
+//
+// Server→client events are single-sourced from their canonical `api/events`
+// wire schemas; this file only composes them into the domain union consumed by
+// `message-protocol.ts`. Settings mutations (voice config, avatar generation)
+// are served by the HTTP settings/avatar routes, not by client messages.
 
 import type { AvatarUpdatedEvent } from "../../api/events/avatar-updated.js";
+import type { ClientSettingsUpdateEvent } from "../../api/events/client-settings-update.js";
+import type { ConfigChangedEvent } from "../../api/events/config-changed.js";
+import type { SoundsConfigUpdatedEvent } from "../../api/events/sounds-config-updated.js";
 
-// === Client → Server ===
-
-/** Request from a conversation or client to change the voice activation key. */
-export interface VoiceConfigUpdateRequest {
-  type: "voice_config_update";
-  /** The desired activation key (enum value or natural-language name). */
-  activationKey: string;
-}
-
-/** Request from the client to generate a custom avatar via Gemini. */
-export interface GenerateAvatarRequest {
-  type: "generate_avatar";
-  /** Text description of the desired avatar appearance. */
-  description: string;
-}
-
-// === Server → Client ===
-
-/** Sent by the daemon to update a client-side setting (e.g. activation key). */
-export interface ClientSettingsUpdate {
-  type: "client_settings_update";
-  /** The setting key to update (e.g. "activationKey"). */
-  key: string;
-  /** The new value for the setting. */
-  value: string;
-}
-
-/** Sent by the daemon when workspace config.json changes on disk. */
-export interface ConfigChanged {
-  type: "config_changed";
-}
-
-/** Sent by the daemon when sounds config or sound files change on disk. */
-export interface SoundsConfigUpdated {
-  type: "sounds_config_updated";
-}
-
-/** Response to a generate_avatar request indicating success or failure. */
-export interface GenerateAvatarResponse {
-  type: "generate_avatar_response";
-  /** Whether the avatar was generated successfully. */
-  success: boolean;
-  /** Error message when success is false. */
-  error?: string;
-}
-
-// --- Domain-level union aliases (consumed by the barrel file) ---
-
-export type _SettingsClientMessages =
-  | VoiceConfigUpdateRequest
-  | GenerateAvatarRequest;
 export type _SettingsServerMessages =
-  | ClientSettingsUpdate
+  | ClientSettingsUpdateEvent
   | AvatarUpdatedEvent
-  | ConfigChanged
-  | SoundsConfigUpdated
-  | GenerateAvatarResponse;
+  | ConfigChangedEvent
+  | SoundsConfigUpdatedEvent;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -484,6 +484,12 @@ export function useStreamEventHandler(
         // the contacts page refetches through its own query invalidation.
         case "contacts_changed":
           break;
+        // Settings/config broadcasts. The chat handler is a no-op — these target
+        // the desktop client or are handled by config-sync consumers.
+        case "client_settings_update":
+        case "config_changed":
+        case "sounds_config_updated":
+          break;
         // Notification-created broadcasts and recording lifecycle
         // instructions. The web chat handler is a no-op for these — they target
         // the CLI/desktop clients or are handled elsewhere.

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -99,6 +99,11 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   // Contacts-table invalidation broadcast — carries no `conversationId`; clients
   // refetch their contact list on receipt.
   "contacts_changed",
+  // Settings/config broadcasts (client-setting push, config.json change, sounds
+  // change) carry no `conversationId` — they're app-wide, not conversation-scoped.
+  "client_settings_update",
+  "config_changed",
+  "sounds_config_updated",
   // Notification-created broadcasts and recording lifecycle instructions are not
   // tied to the active conversation stream (they carry no top-level
   // `conversationId`, or — for notification_conversation_created — announce a


### PR DESCRIPTION
## Why

Continues the event-type unification effort, with the standing liveness check applied per type: migrate only types that actually have a producer and consumer; delete the rest. The `settings` domain was a mix.

## What

**Migrated (live broadcasts) → new `api/events` schemas, registered in `AssistantEventSchema`:**
- `client_settings_update` — pushed from the `voice_config_update` tool + `tool-side-effects.ts`
- `config_changed` — broadcast from `resource-sync-events.ts` on `config.json` change
- `sounds_config_updated` — broadcast from `resource-sync-events.ts` on sounds change

(`avatar_updated` was already migrated.) `_SettingsServerMessages` now composes the api-inferred types.

**Removed (dead — no producer or consumer):**
- `generate_avatar` / `generate_avatar_response` — avatar generation is served by the HTTP `avatar/generate` + `settings/avatar/generate` routes now; the message types are orphaned.
- `voice_config_update` (`VoiceConfigUpdateRequest`) — the live `voice_config_update` is a **tool hook**, not this wire message; the type has no dispatcher and zero references.

`_SettingsClientMessages` held only those two dead client messages, so it and its `ClientMessage` aggregate entry are removed.

## Web

The three migrated events carry no `conversationId` (app-wide, not conversation-scoped), so they join the web's global stream-event set with no-op cases in the chat handler's exhaustive switch — desktop-targeted / handled by config-sync consumers.

## Safety

No wire change for the live events (schemas transcribed 1:1); removing dead types changes no runtime behavior. Repo-wide grep (assistant + cli + web + gateway) shows zero references to any removed type/literal (one remaining mention is a comment about the *Swift* client's type). Clean `typecheck:fast` + web `tsc` (fresh `openapi-ts`), eslint, prettier, `generate:openapi --check` (unchanged), api-events + SSE-parity suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_