### PR TITLE
fix(routes): serve default-plugin routes under their manifest name

### DIFF
--- a/assistant/src/plugins/defaults/main.ts
+++ b/assistant/src/plugins/defaults/main.ts
@@ -20,9 +20,16 @@ import { dirname, join, resolve } from "node:path";
 
 const DEFAULTS_DIR = import.meta.dir;
 
+/**
+ * Route-namespace prefix for default plugins. A default plugin's route
+ * namespace is `default-<directory-name>` by convention (matching its
+ * `package.json` name and its `.disabled` sentinel key), so route resolution
+ * derives the namespace from the directory name directly — no manifest read.
+ */
+const DEFAULT_PLUGIN_NAMESPACE_PREFIX = "default-";
+
 let cachedNames: readonly string[] | null = null;
 let cachedDirToManifest: ReadonlyMap<string, string> | null = null;
-let cachedManifestToDir: ReadonlyMap<string, string> | null = null;
 
 /**
  * Names of every first-party default plugin (their `package.json` names,
@@ -89,48 +96,25 @@ export function getDefaultPluginManifestName(dirName: string): string | null {
 }
 
 /**
- * Directory name (e.g. `platform-hosted`) for a default plugin's *manifest*
- * name (e.g. `default-platform-hosted`), or `null` when `<manifestName>` is not
- * a default plugin. The inverse of {@link getDefaultPluginManifestName}.
- */
-function getDefaultPluginDirName(manifestName: string): string | null {
-  if (cachedManifestToDir === null) {
-    const map = new Map<string, string>();
-    for (const entry of readdirSync(DEFAULTS_DIR, { withFileTypes: true })) {
-      if (!entry.isDirectory()) {
-        continue;
-      }
-      const manifest = getDefaultPluginManifestName(entry.name);
-      if (manifest !== null) {
-        map.set(manifest, entry.name);
-      }
-    }
-    cachedManifestToDir = map;
-  }
-  return cachedManifestToDir.get(manifestName) ?? null;
-}
-
-/**
  * Absolute path to a default plugin's `routes/` directory in the source tree,
- * or `null` when `<name>` is not a default plugin.
+ * or `null` when `<name>` is not a default plugin's route namespace.
  *
- * A default plugin's route namespace is its *manifest* name (e.g.
+ * A default plugin's route namespace is `default-<directory-name>` (e.g.
  * `default-platform-hosted`) — the same `default-…` name its `.disabled`
- * sentinel and per-chat scoping are keyed by. `<name>` is looked up against the
- * known manifest names and mapped back to the plugin's directory, so an
- * unknown name or a `..`/nested segment taken from a URL path can never escape
- * the defaults tree (it simply resolves to `null`). The path is derived from
- * this module's own location (`import.meta.dir`), so it resolves relative to
- * the app source, which the assistant always ships and runs un-bundled.
+ * sentinel and per-chat scoping are keyed by. `<name>` is the namespace: the
+ * `default-` prefix is stripped to recover the source directory, so a name
+ * without the prefix (e.g. the bare directory name) resolves to `null`. The
+ * containment guard rejects any `..`/nested segment taken from a URL path so it
+ * can never escape the defaults tree. The path is derived from this module's
+ * own location (`import.meta.dir`), so it resolves relative to the app source,
+ * which the assistant always ships and runs un-bundled.
  */
 export function getDefaultPluginRoutesDir(name: string): string | null {
-  const dirName = getDefaultPluginDirName(name);
-  if (dirName === null) {
+  if (!name.startsWith(DEFAULT_PLUGIN_NAMESPACE_PREFIX)) {
     return null;
   }
+  const dirName = name.slice(DEFAULT_PLUGIN_NAMESPACE_PREFIX.length);
   const pluginDir = resolve(join(DEFAULTS_DIR, dirName));
-  // `dirName` comes from the manifest map (a real immediate subdirectory), but
-  // keep the containment guard as a defense-in-depth backstop.
   if (dirname(pluginDir) !== resolve(DEFAULTS_DIR)) {
     return null;
   }
@@ -142,7 +126,7 @@ export function getDefaultPluginRoutesDir(name: string): string | null {
 
 /**
  * Enumerate default plugins that ship a `routes/` directory, keyed by their
- * *manifest* name (the route namespace, e.g. `default-platform-hosted`).
+ * route namespace (`default-<directory-name>`, e.g. `default-platform-hosted`).
  * Mirrors {@link getDefaultPluginRoutesDir} so route discovery and dispatch
  * agree on which default plugin routes exist and under which namespace.
  */
@@ -155,13 +139,12 @@ export function getDefaultPluginRouteRoots(): {
     if (!entry.isDirectory()) {
       continue;
     }
-    const manifestName = getDefaultPluginManifestName(entry.name);
-    if (manifestName === null) {
-      continue;
-    }
     const routesDir = join(DEFAULTS_DIR, entry.name, "routes");
     if (existsSync(routesDir) && statSync(routesDir).isDirectory()) {
-      roots.push({ pluginName: manifestName, routesDir });
+      roots.push({
+        pluginName: DEFAULT_PLUGIN_NAMESPACE_PREFIX + entry.name,
+        routesDir,
+      });
     }
   }
   return roots;

--- a/assistant/src/plugins/defaults/main.ts
+++ b/assistant/src/plugins/defaults/main.ts
@@ -22,6 +22,7 @@ const DEFAULTS_DIR = import.meta.dir;
 
 let cachedNames: readonly string[] | null = null;
 let cachedDirToManifest: ReadonlyMap<string, string> | null = null;
+let cachedManifestToDir: ReadonlyMap<string, string> | null = null;
 
 /**
  * Names of every first-party default plugin (their `package.json` names,
@@ -88,21 +89,48 @@ export function getDefaultPluginManifestName(dirName: string): string | null {
 }
 
 /**
+ * Directory name (e.g. `platform-hosted`) for a default plugin's *manifest*
+ * name (e.g. `default-platform-hosted`), or `null` when `<manifestName>` is not
+ * a default plugin. The inverse of {@link getDefaultPluginManifestName}.
+ */
+function getDefaultPluginDirName(manifestName: string): string | null {
+  if (cachedManifestToDir === null) {
+    const map = new Map<string, string>();
+    for (const entry of readdirSync(DEFAULTS_DIR, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const manifest = getDefaultPluginManifestName(entry.name);
+      if (manifest !== null) {
+        map.set(manifest, entry.name);
+      }
+    }
+    cachedManifestToDir = map;
+  }
+  return cachedManifestToDir.get(manifestName) ?? null;
+}
+
+/**
  * Absolute path to a default plugin's `routes/` directory in the source tree,
  * or `null` when `<name>` is not a default plugin.
  *
- * A default plugin's route namespace is its *directory* name (e.g.
- * `platform-hosted`), matching how a workspace plugin's namespace is its
- * directory name — not the `default-…` manifest name. The path is derived
- * from this module's own location (`import.meta.dir`), so it resolves relative
- * to the app source, which the assistant always ships and runs un-bundled.
- *
- * `name` is taken from a URL path segment, so the resolved directory is
- * required to sit directly under `plugins/defaults/` — a `..` or nested
- * segment that escapes the defaults tree returns `null`.
+ * A default plugin's route namespace is its *manifest* name (e.g.
+ * `default-platform-hosted`) — the same `default-…` name its `.disabled`
+ * sentinel and per-chat scoping are keyed by. `<name>` is looked up against the
+ * known manifest names and mapped back to the plugin's directory, so an
+ * unknown name or a `..`/nested segment taken from a URL path can never escape
+ * the defaults tree (it simply resolves to `null`). The path is derived from
+ * this module's own location (`import.meta.dir`), so it resolves relative to
+ * the app source, which the assistant always ships and runs un-bundled.
  */
 export function getDefaultPluginRoutesDir(name: string): string | null {
-  const pluginDir = resolve(join(DEFAULTS_DIR, name));
+  const dirName = getDefaultPluginDirName(name);
+  if (dirName === null) {
+    return null;
+  }
+  const pluginDir = resolve(join(DEFAULTS_DIR, dirName));
+  // `dirName` comes from the manifest map (a real immediate subdirectory), but
+  // keep the containment guard as a defense-in-depth backstop.
   if (dirname(pluginDir) !== resolve(DEFAULTS_DIR)) {
     return null;
   }
@@ -114,8 +142,9 @@ export function getDefaultPluginRoutesDir(name: string): string | null {
 
 /**
  * Enumerate default plugins that ship a `routes/` directory, keyed by their
- * directory name (the route namespace). Mirrors {@link getDefaultPluginRoutesDir}
- * so route discovery and dispatch agree on which default plugin routes exist.
+ * *manifest* name (the route namespace, e.g. `default-platform-hosted`).
+ * Mirrors {@link getDefaultPluginRoutesDir} so route discovery and dispatch
+ * agree on which default plugin routes exist and under which namespace.
  */
 export function getDefaultPluginRouteRoots(): {
   pluginName: string;
@@ -126,9 +155,13 @@ export function getDefaultPluginRouteRoots(): {
     if (!entry.isDirectory()) {
       continue;
     }
+    const manifestName = getDefaultPluginManifestName(entry.name);
+    if (manifestName === null) {
+      continue;
+    }
     const routesDir = join(DEFAULTS_DIR, entry.name, "routes");
     if (existsSync(routesDir) && statSync(routesDir).isDirectory()) {
-      roots.push({ pluginName: entry.name, routesDir });
+      roots.push({ pluginName: manifestName, routesDir });
     }
   }
   return roots;

--- a/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
@@ -1,12 +1,12 @@
 /**
  * Default-plugin route resolution: a first-party default plugin's routes are
  * served in the `/x/plugins/<name>/` namespace from the app source tree
- * (`plugins/defaults/<dir>/routes/`), where `<name>` is the plugin's
- * `default-…` MANIFEST name (e.g. `default-platform-hosted`) — the same name
- * its `.disabled` sentinel is keyed by — not its bare directory name. An
- * installed workspace plugin of the same name overrides the default.
+ * (`plugins/defaults/<dir>/routes/`), where `<name>` is `default-<dir>` (e.g.
+ * `default-platform-hosted`) — the same `default-…` name its `.disabled`
+ * sentinel is keyed by — not its bare directory name. An installed workspace
+ * plugin of the same name overrides the default.
  *
- * These tests exercise the real `platform-hosted` default plugin (manifest name
+ * These tests exercise the real `platform-hosted` default plugin (namespace
  * `default-platform-hosted`), which ships `routes/reengage.ts`, a POST-only
  * handler. A GET reaches the resolved source file and 405s — proving
  * resolution + source-tree module load without running the handler's heavy
@@ -24,7 +24,6 @@ import { dirname, join, relative } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
 import {
-  getDefaultPluginManifestName,
   getDefaultPluginRouteRoots,
   getDefaultPluginRoutesDir,
 } from "../../../plugins/defaults/main.js";
@@ -41,8 +40,8 @@ import {
 
 /** The default plugin's source directory name. */
 const DEFAULT_PLUGIN_DIR = "platform-hosted";
-/** Its route namespace = its `default-…` manifest name. */
-const DEFAULT_PLUGIN = getDefaultPluginManifestName(DEFAULT_PLUGIN_DIR)!;
+/** Its route namespace = `default-<dir>` by convention. */
+const DEFAULT_PLUGIN = `default-${DEFAULT_PLUGIN_DIR}`;
 
 function makeDispatcher(): UserRouteDispatcher {
   const context: UserRouteContext = {
@@ -88,11 +87,13 @@ describe("default plugin route source resolution", () => {
   });
 
   test("getDefaultPluginRoutesDir returns null for the bare directory name, unknown names, and path traversal", () => {
-    // The bare dir name is no longer a route namespace — only the manifest name.
+    // The bare dir name is no longer a route namespace — only `default-<dir>`.
     expect(getDefaultPluginRoutesDir(DEFAULT_PLUGIN_DIR)).toBeNull();
     expect(getDefaultPluginRoutesDir("definitely-not-a-plugin")).toBeNull();
     expect(getDefaultPluginRoutesDir("../util")).toBeNull();
     expect(getDefaultPluginRoutesDir("..")).toBeNull();
+    // The containment guard still rejects a traversal hidden behind the prefix.
+    expect(getDefaultPluginRoutesDir("default-../util")).toBeNull();
   });
 
   test("getDefaultPluginRouteRoots includes the platform-hosted plugin under its manifest name", () => {

--- a/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts
@@ -1,13 +1,16 @@
 /**
  * Default-plugin route resolution: a first-party default plugin's routes are
  * served in the `/x/plugins/<name>/` namespace from the app source tree
- * (`plugins/defaults/<name>/routes/`), not the workspace. An installed
- * workspace plugin of the same name overrides the default.
+ * (`plugins/defaults/<dir>/routes/`), where `<name>` is the plugin's
+ * `default-…` MANIFEST name (e.g. `default-platform-hosted`) — the same name
+ * its `.disabled` sentinel is keyed by — not its bare directory name. An
+ * installed workspace plugin of the same name overrides the default.
  *
- * These tests exercise the real `platform-hosted` default plugin (which ships
- * `routes/reengage.ts`, a POST-only handler). A GET reaches the resolved
- * source file and 405s — proving resolution + source-tree module load without
- * running the handler's heavy background-turn logic.
+ * These tests exercise the real `platform-hosted` default plugin (manifest name
+ * `default-platform-hosted`), which ships `routes/reengage.ts`, a POST-only
+ * handler. A GET reaches the resolved source file and 405s — proving
+ * resolution + source-tree module load without running the handler's heavy
+ * background-turn logic.
  */
 
 import {
@@ -36,8 +39,10 @@ import {
   resolveRouteLocation,
 } from "../user-route-resolution.js";
 
-const DEFAULT_PLUGIN = "platform-hosted";
-const DEFAULT_PLUGIN_MANIFEST = getDefaultPluginManifestName(DEFAULT_PLUGIN)!;
+/** The default plugin's source directory name. */
+const DEFAULT_PLUGIN_DIR = "platform-hosted";
+/** Its route namespace = its `default-…` manifest name. */
+const DEFAULT_PLUGIN = getDefaultPluginManifestName(DEFAULT_PLUGIN_DIR)!;
 
 function makeDispatcher(): UserRouteDispatcher {
   const context: UserRouteContext = {
@@ -64,7 +69,7 @@ function writeWorkspacePluginHandler(
 }
 
 afterEach(() => {
-  for (const name of [DEFAULT_PLUGIN, DEFAULT_PLUGIN_MANIFEST]) {
+  for (const name of [DEFAULT_PLUGIN, DEFAULT_PLUGIN_DIR]) {
     rmSync(join(getWorkspacePluginsDir(), name), {
       recursive: true,
       force: true,
@@ -73,22 +78,24 @@ afterEach(() => {
 });
 
 describe("default plugin route source resolution", () => {
-  test("getDefaultPluginRoutesDir returns the source routes dir for a default plugin", () => {
+  test("getDefaultPluginRoutesDir returns the source routes dir for a default plugin's manifest name", () => {
     const dir = getDefaultPluginRoutesDir(DEFAULT_PLUGIN);
     expect(dir).not.toBeNull();
     expect(
-      dir!.endsWith(join("plugins", "defaults", DEFAULT_PLUGIN, "routes")),
+      dir!.endsWith(join("plugins", "defaults", DEFAULT_PLUGIN_DIR, "routes")),
     ).toBe(true);
     expect(existsSync(dir!)).toBe(true);
   });
 
-  test("getDefaultPluginRoutesDir returns null for unknown names and path traversal", () => {
+  test("getDefaultPluginRoutesDir returns null for the bare directory name, unknown names, and path traversal", () => {
+    // The bare dir name is no longer a route namespace — only the manifest name.
+    expect(getDefaultPluginRoutesDir(DEFAULT_PLUGIN_DIR)).toBeNull();
     expect(getDefaultPluginRoutesDir("definitely-not-a-plugin")).toBeNull();
     expect(getDefaultPluginRoutesDir("../util")).toBeNull();
     expect(getDefaultPluginRoutesDir("..")).toBeNull();
   });
 
-  test("getDefaultPluginRouteRoots includes the platform-hosted plugin", () => {
+  test("getDefaultPluginRouteRoots includes the platform-hosted plugin under its manifest name", () => {
     const roots = getDefaultPluginRouteRoots();
     const entry = roots.find((r) => r.pluginName === DEFAULT_PLUGIN);
     expect(entry).toBeDefined();
@@ -108,23 +115,27 @@ describe("default plugin route source resolution", () => {
     expect(handlerFile!.endsWith(join("reengage.ts"))).toBe(true);
   });
 
-  test("listPluginRouteRoots includes default plugins", () => {
+  test("listPluginRouteRoots includes default plugins under their manifest name", () => {
     const roots = listPluginRouteRoots();
     expect(roots.some((r) => r.pluginName === DEFAULT_PLUGIN)).toBe(true);
   });
 
   test("does not advertise memory (its ROUTES modules live in src/, not routes/)", () => {
     // memory's shared-table `RouteDefinition` modules are internal (registered
-    // into the /v1 table), not userland `/x/plugins/memory/*` handlers, so the
-    // source-tree fallback must not surface them.
-    expect(getDefaultPluginRoutesDir("memory")).not.toBeNull();
-    expect(existsSync(getDefaultPluginRoutesDir("memory")!)).toBe(false);
-    expect(
-      getDefaultPluginRouteRoots().some((r) => r.pluginName === "memory"),
-    ).toBe(false);
-    expect(listPluginRouteRoots().some((r) => r.pluginName === "memory")).toBe(
+    // into the /v1 table), not userland `/x/plugins/default-memory/*` handlers,
+    // so the source-tree fallback must not surface them.
+    expect(getDefaultPluginRoutesDir("default-memory")).not.toBeNull();
+    expect(existsSync(getDefaultPluginRoutesDir("default-memory")!)).toBe(
       false,
     );
+    expect(
+      getDefaultPluginRouteRoots().some(
+        (r) => r.pluginName === "default-memory",
+      ),
+    ).toBe(false);
+    expect(
+      listPluginRouteRoots().some((r) => r.pluginName === "default-memory"),
+    ).toBe(false);
   });
 });
 
@@ -141,10 +152,11 @@ describe("default plugin route dispatch", () => {
     expect(response.headers.get("Allow")).toBe("POST");
   });
 
-  test("honors the manifest-name .disabled sentinel (how the CLI keys defaults)", async () => {
-    // The CLI/bootstrap key default-plugin sentinels by manifest name
-    // (`default-platform-hosted`), not the route namespace (`platform-hosted`).
-    const pluginDir = join(getWorkspacePluginsDir(), DEFAULT_PLUGIN_MANIFEST);
+  test("honors the manifest-name .disabled sentinel", async () => {
+    // A default plugin's namespace IS its manifest name, so the sentinel the
+    // CLI/bootstrap write (`<workspace>/plugins/<manifest-name>/.disabled`)
+    // gates it directly.
+    const pluginDir = join(getWorkspacePluginsDir(), DEFAULT_PLUGIN);
     mkdirSync(pluginDir, { recursive: true });
     writeFileSync(join(pluginDir, ".disabled"), "");
 
@@ -165,17 +177,7 @@ describe("default plugin route dispatch", () => {
     expect(response.status).toBe(404);
   });
 
-  test("a namespace-name .disabled sentinel also disables the default", async () => {
-    const pluginDir = join(getWorkspacePluginsDir(), DEFAULT_PLUGIN);
-    mkdirSync(pluginDir, { recursive: true });
-    writeFileSync(join(pluginDir, ".disabled"), "");
-
-    expect(
-      resolveRouteLocation(`plugins/${DEFAULT_PLUGIN}/reengage`),
-    ).toBeNull();
-  });
-
-  test("an installed workspace plugin overrides the default of the same name", async () => {
+  test("an installed workspace plugin overrides the default of the same namespace", async () => {
     writeWorkspacePluginHandler(
       DEFAULT_PLUGIN,
       "reengage.ts",
@@ -248,38 +250,5 @@ describe("default plugin route dispatch", () => {
       walk(routesDir, routesDir);
     }
     expect(offenders).toEqual([]);
-  });
-
-  test("disabling the default does not disable an installed override of the same namespace", async () => {
-    // Installed workspace plugin shadows the namespace...
-    writeWorkspacePluginHandler(
-      DEFAULT_PLUGIN,
-      "reengage.ts",
-      `export const GET = () => Response.json({ source: "workspace" });`,
-    );
-    // ...and the bundled default is separately disabled by its manifest name.
-    const disabledDir = join(getWorkspacePluginsDir(), DEFAULT_PLUGIN_MANIFEST);
-    mkdirSync(disabledDir, { recursive: true });
-    writeFileSync(join(disabledDir, ".disabled"), "");
-
-    // The manifest-name sentinel gates only the default fallback, so the
-    // installed override still resolves and serves.
-    const location = resolveRouteLocation(`plugins/${DEFAULT_PLUGIN}/reengage`);
-    expect(location!.routesDir).toBe(
-      join(getWorkspacePluginsDir(), DEFAULT_PLUGIN, "routes"),
-    );
-    expect(
-      listPluginRouteRoots().some((r) => r.pluginName === DEFAULT_PLUGIN),
-    ).toBe(true);
-
-    const dispatcher = makeDispatcher();
-    const response = await dispatcher.dispatch(
-      `plugins/${DEFAULT_PLUGIN}/reengage`,
-      new Request(`http://localhost/v1/x/plugins/${DEFAULT_PLUGIN}/reengage`, {
-        method: "GET",
-      }),
-    );
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ source: "workspace" });
   });
 });

--- a/assistant/src/runtime/routes/user-route-resolution.ts
+++ b/assistant/src/runtime/routes/user-route-resolution.ts
@@ -13,7 +13,9 @@
  *   `/x/plugins/<name>/<path>`.
  * - `plugins/defaults/<name>/routes/<path>` (the app source tree) — a
  *   first-party default plugin's routes, served in the same
- *   `/x/plugins/<name>/<path>` namespace. Default plugins live in the binary's
+ *   `/x/plugins/<name>/<path>` namespace, where `<name>` is the plugin's
+ *   `default-…` manifest name (e.g. `default-platform-hosted`) — the same name
+ *   its `.disabled` sentinel is keyed by. Default plugins live in the binary's
  *   source, not the workspace, so their routes resolve from the source tree.
  *   An installed plugin of the same name takes precedence (it can override a
  *   default).
@@ -23,7 +25,6 @@ import { existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative, resolve, sep } from "node:path";
 
 import {
-  getDefaultPluginManifestName,
   getDefaultPluginRouteRoots,
   getDefaultPluginRoutesDir,
 } from "../../plugins/defaults/main.js";
@@ -90,12 +91,14 @@ export function resolveRouteLocation(routePath: string): RouteLocation | null {
     if (!pluginName) {
       return null;
     }
-    const { routesDir, isDefault } = resolvePluginRoutesDir(pluginName);
-    if (isPluginRouteDirDisabled(pluginName, isDefault)) {
+    // A default plugin's namespace IS its `default-…` manifest name, so the
+    // single `.disabled` sentinel key (`<workspace>/plugins/<name>/.disabled`)
+    // covers installed and default plugins alike.
+    if (isPluginDisabled(pluginName)) {
       return null;
     }
     return {
-      routesDir,
+      routesDir: resolvePluginRoutesDir(pluginName),
       subPath: segments.slice(2).join("/"),
     };
   }
@@ -103,55 +106,27 @@ export function resolveRouteLocation(routePath: string): RouteLocation | null {
 }
 
 /**
- * Whether the `.disabled` sentinel disables the resolved route directory.
- *
- * The sentinel is keyed by the plugin's directory name for installed plugins
- * but by the `default-…` manifest name for default plugins (the CLI/bootstrap
- * write it as `<workspace>/plugins/<manifest-name>/.disabled`). The manifest
- * check therefore applies *only* when the resolved directory is a default
- * plugin's source routes — so disabling a bundled default never takes down an
- * installed workspace plugin that shadows the same namespace, and vice versa.
- */
-function isPluginRouteDirDisabled(
-  pluginName: string,
-  isDefault: boolean,
-): boolean {
-  if (isPluginDisabled(pluginName)) {
-    return true;
-  }
-  if (!isDefault) {
-    return false;
-  }
-  const manifestName = getDefaultPluginManifestName(pluginName);
-  return manifestName !== null && isPluginDisabled(manifestName);
-}
-
-/**
  * Resolve the `routes/` directory that backs a plugin's `/x/plugins/<name>/`
- * namespace, and whether that directory is a first-party default's source
- * tree. An installed plugin that ships a `routes/` directory takes precedence
- * (so it can override a same-named default); otherwise a default plugin's
- * source `routes/` directory is used. Falls back to the (missing) workspace
- * path when the name matches neither, so {@link resolveHandlerFile} reports a
- * 404.
+ * namespace. An installed plugin that ships a `routes/` directory takes
+ * precedence (so it can override a same-named default); otherwise a default
+ * plugin's source `routes/` directory is used (resolved by manifest name).
+ * Falls back to the (missing) workspace path when the name matches neither, so
+ * {@link resolveHandlerFile} reports a 404.
  */
-function resolvePluginRoutesDir(pluginName: string): {
-  routesDir: string;
-  isDefault: boolean;
-} {
+function resolvePluginRoutesDir(pluginName: string): string {
   const workspaceRoutesDir = join(
     getWorkspacePluginsDir(),
     pluginName,
     "routes",
   );
   if (existsSync(workspaceRoutesDir)) {
-    return { routesDir: workspaceRoutesDir, isDefault: false };
+    return workspaceRoutesDir;
   }
   const defaultRoutesDir = getDefaultPluginRoutesDir(pluginName);
   if (defaultRoutesDir && existsSync(defaultRoutesDir)) {
-    return { routesDir: defaultRoutesDir, isDefault: true };
+    return defaultRoutesDir;
   }
-  return { routesDir: workspaceRoutesDir, isDefault: false };
+  return workspaceRoutesDir;
 }
 
 /**
@@ -221,7 +196,7 @@ export function listPluginRouteRoots(): {
   const byName = new Map<string, string>();
 
   for (const { pluginName, routesDir } of getDefaultPluginRouteRoots()) {
-    if (!isPluginRouteDirDisabled(pluginName, true)) {
+    if (!isPluginDisabled(pluginName)) {
       byName.set(pluginName, routesDir);
     }
   }
@@ -229,7 +204,7 @@ export function listPluginRouteRoots(): {
   const pluginsDir = getWorkspacePluginsDir();
   if (existsSync(pluginsDir)) {
     for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
-      if (!entry.isDirectory() || isPluginRouteDirDisabled(entry.name, false)) {
+      if (!entry.isDirectory() || isPluginDisabled(entry.name)) {
         continue;
       }
       const routesDir = join(pluginsDir, entry.name, "routes");


### PR DESCRIPTION
## Prompt / plan

The platform's admin "Send Reengagement Email" feature calls the `default-platform-hosted` plugin's `/reengage` route at `POST /v1/x/plugins/default-platform-hosted/reengage` and got a **404**.

Root cause: default-plugin routes were exposed under the plugin's **directory** name (`platform-hosted`), while everything else that identifies a default plugin — its `.disabled` sentinel, per-chat scoping, the barrel's `manifest.name` — uses the `default-…` **manifest** name. So a caller addressing a default plugin by its (canonical) manifest name never resolved.

Fix: unify the route namespace on the **manifest name** (`default-<dir>`), so a default plugin's namespace, override key, and disable key are all the same `default-…` name.

- `getDefaultPluginRouteRoots()` keys entries by manifest name.
- `getDefaultPluginRoutesDir()` looks a namespace up against the known manifest names and maps it back to the plugin's directory (unknown names / `..` traversal still resolve to `null`).
- The route resolver's dir-name-vs-manifest-name `.disabled` bridge collapses to a single `isPluginDisabled(<namespace>)` check.

**Behavior change to flag for review:** the bare directory name is no longer a route namespace, and there is now a single `.disabled` key per default plugin (the previous dir-name-override / manifest-name-disable independence is removed). This intentionally simplifies the model — shout if that independence was load-bearing somewhere I didn't see.

Paired with `vellum-ai/vellum-assistant-platform` PR #9438, which keeps the platform sending `default-platform-hosted` and forwards daemon HTTP errors so a mismatch like this is diagnosable rather than masked as a 502.

## Test plan

- Updated `assistant/src/runtime/routes/__tests__/default-plugin-routes.test.ts` for the manifest-name namespace (resolution, dispatch → 405 on GET, `.disabled` sentinel → 404, workspace override, traversal/unknown-name/bare-dir-name null, test-file containment).
- `bun test src/runtime/routes/__tests__/default-plugin-routes.test.ts` → 11 pass; default-plugin-names guard + the `reengage` plugin test → 7 pass.
- `bunx tsc --noEmit` → 0 errors; `eslint` + `prettier` clean (verified by the pre-commit/pre-push hooks).

## CLI verb checklist

N/A — this PR changes how existing default-plugin routes are namespaced; it does not add a new IPC route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjoP9o4shUNs7uwNAaiLqN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjoP9o4shUNs7uwNAaiLqN)_