### PR TITLE
feat(memory): replace retrospective lifecycle trigger with a scheduled sweep

### DIFF
--- a/assistant/src/__tests__/job-handler-registration-guard.test.ts
+++ b/assistant/src/__tests__/job-handler-registration-guard.test.ts
@@ -33,6 +33,7 @@ const MEMORY_JOB_TYPES = [
   "memory_v2_activation_recompute",
   "memory_v3_maintain",
   "memory_retrospective",
+  "memory_retrospective_sweep",
   "skill_card_insert",
   "pkb_filing",
   "pkb_compaction",

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -169,6 +169,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../home/job-handlers/conversation-starters.js",
     "../../../media/job-handlers/media-processing.js",
     "../../../permissions/types.js",
+    "../../../persistence/auto-analysis-constants.js",
     "../../../persistence/checkpoints.js",
     "../../../persistence/cleanup-schedule-state.js",
     "../../../persistence/conversation-crud.js",

--- a/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-reverse-guard.test.ts
@@ -89,7 +89,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "src/context/strip-injections.ts",
     "src/daemon/conversation-agent-loop-handlers.ts",
     "src/daemon/conversation-agent-loop.ts",
-    "src/daemon/conversation-lifecycle.ts",
     "src/daemon/conversation-runtime-assembly.ts",
     "src/daemon/conversation-surfaces.ts",
     "src/daemon/conversation-tool-setup.ts",

--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -39,6 +39,19 @@ export const MemoryRetrospectiveConfigSchema = z
         "Minimum milliseconds between attempts (success or failure). Prevents tight retry loops across trigger types. Pre-compaction bypasses this gate.",
       ),
 
+    sweepIntervalMs: z
+      .number({
+        error: "memory.retrospective.sweepIntervalMs must be a number",
+      })
+      .int("memory.retrospective.sweepIntervalMs must be an integer")
+      .positive(
+        "memory.retrospective.sweepIntervalMs must be a positive integer",
+      )
+      .default(8 * 60 * 60 * 1000)
+      .describe(
+        "Cadence of the scheduled retrospective sweep, the timer-driven backstop that re-scans conversations for unprocessed messages the event-driven triggers missed (e.g. a turn that ended in a crash or IPC drop before the post-turn hooks ran). A conversation is only swept when its last retrospective attempt is at least this old, so the sweep never competes with the responsive interval/message_count triggers on active conversations.",
+      ),
+
     keepSupersededRuns: z
       .boolean({
         error: "memory.retrospective.keepSupersededRuns must be a boolean",
@@ -64,19 +77,6 @@ export const MemoryRetrospectiveConfigSchema = z
       .default(null)
       .describe(
         "Optional path to a file whose contents replace the bundled retrospective fork-instruction prompt. Relative paths resolve under the workspace root; absolute paths and a leading `~/` (expanded to the home directory) are honored only when they still resolve inside the workspace root — a path that lands outside the workspace (including via symlinks) is rejected. The loaded contents may include `{{AVAILABLE_TOOLS_LINE}}`, `{{WINDOW_ANCHOR}}`, `{{ALREADY_REMEMBERED}}`, and `{{SKILL_AUTHORING_SECTION}}`, which are substituted at runtime. If the file is rejected, missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
-      ),
-
-    sweepIntervalMs: z
-      .number({
-        error: "memory.retrospective.sweepIntervalMs must be a number",
-      })
-      .int("memory.retrospective.sweepIntervalMs must be an integer")
-      .positive(
-        "memory.retrospective.sweepIntervalMs must be a positive integer",
-      )
-      .default(8 * 60 * 60 * 1000)
-      .describe(
-        "Milliseconds between scheduled sweep passes that find conversations with unprocessed messages and enqueue retrospective jobs. Supplements the turn-end trigger so memory quality does not depend on clean turn completions. Runs on each idle/drain worker tick after the interval elapses.",
       ),
   })
   .describe(

--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -65,6 +65,19 @@ export const MemoryRetrospectiveConfigSchema = z
       .describe(
         "Optional path to a file whose contents replace the bundled retrospective fork-instruction prompt. Relative paths resolve under the workspace root; absolute paths and a leading `~/` (expanded to the home directory) are honored only when they still resolve inside the workspace root — a path that lands outside the workspace (including via symlinks) is rejected. The loaded contents may include `{{AVAILABLE_TOOLS_LINE}}`, `{{WINDOW_ANCHOR}}`, `{{ALREADY_REMEMBERED}}`, and `{{SKILL_AUTHORING_SECTION}}`, which are substituted at runtime. If the file is rejected, missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
       ),
+
+    sweepIntervalMs: z
+      .number({
+        error: "memory.retrospective.sweepIntervalMs must be a number",
+      })
+      .int("memory.retrospective.sweepIntervalMs must be an integer")
+      .positive(
+        "memory.retrospective.sweepIntervalMs must be a positive integer",
+      )
+      .default(8 * 60 * 60 * 1000)
+      .describe(
+        "Milliseconds between scheduled sweep passes that find conversations with unprocessed messages and enqueue retrospective jobs. Supplements the turn-end trigger so memory quality does not depend on clean turn completions. Runs on each idle/drain worker tick after the interval elapses.",
+      ),
   })
   .describe(
     "Controls the memory-retrospective background pass. Model selection lives under llm.callSites.memoryRetrospective.",

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -17,7 +17,6 @@ import {
   isMemoryEnabled,
 } from "../persistence/jobs-store.js";
 import { disposeContextWindowManager } from "../plugins/defaults/compaction/manager-store.js";
-import { enqueueMemoryRetrospectiveIfEnabled } from "../plugins/defaults/memory/memory-retrospective-enqueue.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import { type TrustClass } from "../runtime/actor-trust-resolver.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
@@ -247,23 +246,6 @@ export function disposeConversation(ctx: DisposeContext): void {
         } catch {
           // Best-effort — don't block conversation disposal
         }
-      }
-
-      try {
-        // Memory-retrospective lifecycle safety-net. The periodic triggers
-        // (interval / message_count / pre-compaction) handle the common
-        // path; lifecycle catches the gap between the last interval fire
-        // and conversation eviction. The job's `no_new_messages` early
-        // return makes this a cheap no-op when the periodic path already
-        // covered things. Lives inside the `!isAutoAnalysis` guard so
-        // auto-analysis conversations don't trigger retrospective enqueues
-        // on disposal — mirrors the indexer-time gate in `indexer.ts`.
-        enqueueMemoryRetrospectiveIfEnabled({
-          conversationId: ctx.conversationId,
-          trigger: "lifecycle",
-        });
-      } catch {
-        // Best-effort — don't block conversation disposal
       }
     }
   }

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -68,6 +68,7 @@ export type MemoryJobType =
   | "delete_message_lexical"
   | "backfill_lexical_index"
   | "skill_card_insert"
+  | "memory_retrospective_sweep"
   // Retired/legacy — no live handler; persisted rows drop via LEGACY_JOB_TYPES.
   | "memory_v3_consolidate"
   | "memory_v3_index_maintenance"

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-retrospective-sweep.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-retrospective-sweep.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for `maybeEnqueueRetrospectiveSweepJob` — the scheduler entry that
+ * enqueues the timer-driven `memory_retrospective_sweep` backstop on a durable
+ * checkpoint cadence.
+ *
+ * The first-run seed (missing checkpoint → seed to now WITHOUT enqueuing) is the
+ * critical invariant: a `?? "0"` fallback would treat the sweep as overdue on
+ * the first worker tick and enqueue retrospective LLM work the moment the daemon
+ * starts. The seed defers the first sweep by one full interval instead.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import { createMockLoggerModule } from "../../../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../../../util/logger.js", () => createMockLoggerModule());
+
+import { applyNestedDefaults } from "../../../../config/loader.js";
+import type { AssistantConfig } from "../../../../config/types.js";
+import {
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "../../../../persistence/checkpoints.js";
+import { getMemoryDb } from "../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../persistence/db-init.js";
+import { enqueueMemoryJob } from "../../../../persistence/jobs-store.js";
+import { resetTestTables } from "../../../../persistence/raw-query.js";
+import { memoryJobs } from "../../../../persistence/schema/index.js";
+import {
+  maybeEnqueueRetrospectiveSweepJob,
+  RETROSPECTIVE_SWEEP_CHECKPOINT,
+} from "../jobs-worker.js";
+
+await initializeDb();
+// Pin the memory connection now that the per-process workspace is migrated.
+getMemoryDb();
+
+const SWEEP_INTERVAL_MS = 8 * 60 * 60 * 1000; // 8h default
+
+function buildConfig(
+  overrides: { memoryEnabled?: boolean } = {},
+): AssistantConfig {
+  const config = applyNestedDefaults({}) as unknown as AssistantConfig;
+  if (overrides.memoryEnabled !== undefined) {
+    config.memory.enabled = overrides.memoryEnabled;
+  }
+  return config;
+}
+
+function countSweepJobs(): number {
+  return getMemoryDb()!
+    .select()
+    .from(memoryJobs)
+    .where(eq(memoryJobs.type, "memory_retrospective_sweep"))
+    .all().length;
+}
+
+/** A checkpoint value older than the sweep interval, so the sweep is due. */
+function staleCheckpoint(nowMs: number): string {
+  return String(nowMs - SWEEP_INTERVAL_MS - 60_000);
+}
+
+beforeEach(() => {
+  getMemoryDb()!.run("DELETE FROM memory_jobs");
+  resetTestTables("memory_checkpoints");
+});
+
+describe("maybeEnqueueRetrospectiveSweepJob", () => {
+  test("first tick with no checkpoint: seeds to now WITHOUT enqueuing", () => {
+    const now = Date.now();
+
+    const enqueued = maybeEnqueueRetrospectiveSweepJob(buildConfig(), now);
+
+    expect(enqueued).toBe(false);
+    expect(countSweepJobs()).toBe(0);
+    expect(getMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT)).toBe(
+      String(now),
+    );
+  });
+
+  test("enqueues once the interval has elapsed and advances the checkpoint", () => {
+    const now = Date.now();
+    setMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT, staleCheckpoint(now));
+
+    const enqueued = maybeEnqueueRetrospectiveSweepJob(buildConfig(), now);
+
+    expect(enqueued).toBe(true);
+    expect(countSweepJobs()).toBe(1);
+    expect(getMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT)).toBe(
+      String(now),
+    );
+  });
+
+  test("does not enqueue before the interval has elapsed", () => {
+    const now = Date.now();
+    setMemoryCheckpoint(
+      RETROSPECTIVE_SWEEP_CHECKPOINT,
+      String(now - SWEEP_INTERVAL_MS / 2),
+    );
+
+    const enqueued = maybeEnqueueRetrospectiveSweepJob(buildConfig(), now);
+
+    expect(enqueued).toBe(false);
+    expect(countSweepJobs()).toBe(0);
+  });
+
+  test("does not enqueue when memory is disabled", () => {
+    const now = Date.now();
+    setMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT, staleCheckpoint(now));
+
+    const enqueued = maybeEnqueueRetrospectiveSweepJob(
+      buildConfig({ memoryEnabled: false }),
+      now,
+    );
+
+    expect(enqueued).toBe(false);
+    expect(countSweepJobs()).toBe(0);
+  });
+
+  test("does not stack a second sweep while one is still in flight, but advances the checkpoint", () => {
+    const now = Date.now();
+    // A prior sweep is already pending.
+    enqueueMemoryJob("memory_retrospective_sweep", {});
+    setMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT, staleCheckpoint(now));
+
+    const enqueued = maybeEnqueueRetrospectiveSweepJob(buildConfig(), now);
+
+    expect(enqueued).toBe(false);
+    expect(countSweepJobs()).toBe(1); // no second copy
+    expect(getMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT)).toBe(
+      String(now),
+    );
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Record enqueues instead of writing job rows — the sweep's scan/gate decision
+// is the unit under test, not the jobs store's coalescing. The enqueue's own
+// recursion/low-yield guards are covered by memory-retrospective-enqueue tests.
+let enqueueCalls: Array<{ conversationId: string; trigger: string }> = [];
+mock.module("../memory-retrospective-enqueue.js", () => ({
+  enqueueMemoryRetrospectiveIfEnabled: (args: {
+    conversationId: string;
+    trigger: string;
+  }) => {
+    enqueueCalls.push(args);
+  },
+}));
+
+import type { AssistantConfig } from "../../../../config/types.js";
+import { AUTO_ANALYSIS_SOURCE } from "../../../../persistence/auto-analysis-constants.js";
+import { createConversation } from "../../../../persistence/conversation-crud.js";
+import {
+  getDb,
+  getMemorySqlite,
+} from "../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../persistence/db-init.js";
+import { messages } from "../../../../persistence/schema/index.js";
+import {
+  MEMORY_RETROSPECTIVE_SOURCE,
+  SKILL_CARD_MESSAGE_KIND,
+} from "../memory-retrospective-constants.js";
+import { upsertRetrospectiveState } from "../memory-retrospective-state.js";
+import {
+  listSweepCandidateConversationIds,
+  runRetrospectiveSweep,
+} from "../memory-retrospective-sweep.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../v3/substrate/constants.js";
+
+await initializeDb();
+
+const SWEEP_INTERVAL_MS = 8 * 60 * 60 * 1000; // 8h
+
+function makeConfig(sweepIntervalMs = SWEEP_INTERVAL_MS): AssistantConfig {
+  return {
+    memory: { retrospective: { sweepIntervalMs } },
+  } as unknown as AssistantConfig;
+}
+
+function resetTables(): void {
+  const db = getDb();
+  db.run(`DELETE FROM messages`);
+  getMemorySqlite()!.exec(`DELETE FROM memory_retrospective_state`);
+  db.run(`DELETE FROM conversations`);
+}
+
+let messageSeq = 0;
+function insertMessage(
+  conversationId: string,
+  opts: {
+    role?: string;
+    createdAt: number;
+    metadata?: Record<string, unknown> | null;
+  },
+): string {
+  const id = `msg-${String(++messageSeq).padStart(4, "0")}`;
+  getDb()
+    .insert(messages)
+    .values({
+      id,
+      conversationId,
+      role: opts.role ?? "user",
+      content: JSON.stringify([{ type: "text", text: "hello" }]),
+      createdAt: opts.createdAt,
+      metadata: opts.metadata ? JSON.stringify(opts.metadata) : null,
+    })
+    .run();
+  return id;
+}
+
+describe("runRetrospectiveSweep", () => {
+  beforeEach(() => {
+    resetTables();
+    enqueueCalls = [];
+  });
+
+  test("never-run conversation with unprocessed messages is swept", async () => {
+    const conv = createConversation({ id: "conv-a" });
+    insertMessage(conv.id, { createdAt: 1_000 });
+
+    const result = await runRetrospectiveSweep(makeConfig());
+
+    expect(enqueueCalls).toEqual([
+      { conversationId: conv.id, trigger: "sweep" },
+    ]);
+    expect(result).toEqual({ scanned: 1, enqueued: 1 });
+  });
+
+  test("conversation with a recent attempt is skipped — the event triggers own it", async () => {
+    const conv = createConversation({ id: "conv-a" });
+    const cutoff = insertMessage(conv.id, { createdAt: 1_000 });
+    insertMessage(conv.id, { createdAt: 2_000 }); // unprocessed, but...
+    await upsertRetrospectiveState({
+      conversationId: conv.id,
+      lastProcessedMessageId: cutoff,
+      // Within one sweep interval → responsive triggers are still covering it.
+      lastRunAt: Date.now() - SWEEP_INTERVAL_MS / 2,
+    });
+
+    await runRetrospectiveSweep(makeConfig());
+
+    expect(enqueueCalls).toEqual([]);
+  });
+
+  test("conversation stale past the interval with unprocessed messages is swept", async () => {
+    const conv = createConversation({ id: "conv-a" });
+    const cutoff = insertMessage(conv.id, { createdAt: 1_000 });
+    insertMessage(conv.id, { createdAt: 2_000 });
+    await upsertRetrospectiveState({
+      conversationId: conv.id,
+      lastProcessedMessageId: cutoff,
+      lastRunAt: Date.now() - SWEEP_INTERVAL_MS - 60_000,
+    });
+
+    await runRetrospectiveSweep(makeConfig());
+
+    expect(enqueueCalls).toEqual([
+      { conversationId: conv.id, trigger: "sweep" },
+    ]);
+  });
+
+  test("conversation whose cursor is caught up is skipped (no unprocessed work)", async () => {
+    const conv = createConversation({ id: "conv-a" });
+    const latest = insertMessage(conv.id, { createdAt: 1_000 });
+    await upsertRetrospectiveState({
+      conversationId: conv.id,
+      lastProcessedMessageId: latest,
+      lastRunAt: Date.now() - SWEEP_INTERVAL_MS - 60_000,
+    });
+
+    await runRetrospectiveSweep(makeConfig());
+
+    expect(enqueueCalls).toEqual([]);
+  });
+
+  test("a card-only tail past the cursor does not count as unprocessed work", async () => {
+    const conv = createConversation({ id: "conv-a" });
+    const cutoff = insertMessage(conv.id, { createdAt: 1_000 });
+    await upsertRetrospectiveState({
+      conversationId: conv.id,
+      lastProcessedMessageId: cutoff,
+      lastRunAt: Date.now() - SWEEP_INTERVAL_MS - 60_000,
+    });
+    insertMessage(conv.id, {
+      role: "assistant",
+      createdAt: 2_000,
+      metadata: { kind: SKILL_CARD_MESSAGE_KIND, automated: true },
+    });
+
+    await runRetrospectiveSweep(makeConfig());
+
+    expect(enqueueCalls).toEqual([]);
+  });
+
+  test("every eligible conversation is examined — a zero-work one does not starve a later one", async () => {
+    // conv-a: caught up (zero work). conv-b: unprocessed. Ordered by id, the
+    // zero-work conversation sorts first; the full scan must still reach conv-b.
+    const a = createConversation({ id: "conv-a" });
+    const aMsg = insertMessage(a.id, { createdAt: 1_000 });
+    await upsertRetrospectiveState({
+      conversationId: a.id,
+      lastProcessedMessageId: aMsg,
+      lastRunAt: Date.now() - SWEEP_INTERVAL_MS - 60_000,
+    });
+
+    const b = createConversation({ id: "conv-b" });
+    insertMessage(b.id, { createdAt: 1_000 });
+
+    const result = await runRetrospectiveSweep(makeConfig());
+
+    expect(enqueueCalls).toEqual([{ conversationId: b.id, trigger: "sweep" }]);
+    expect(result.scanned).toBe(2);
+  });
+
+  test("no work anywhere is a clean no-op", async () => {
+    const result = await runRetrospectiveSweep(makeConfig());
+    expect(result).toEqual({ scanned: 0, enqueued: 0 });
+    expect(enqueueCalls).toEqual([]);
+  });
+
+  test("untrusted-actor conversation is never swept, even with unprocessed messages", async () => {
+    // A contact-audience conversation: the retrospective would run under
+    // guardian trust with `remember`, so its content must not reach memory.
+    const conv = createConversation({ id: "conv-a" });
+    insertMessage(conv.id, {
+      createdAt: 1_000,
+      metadata: { provenanceTrustClass: "unknown" },
+    });
+
+    await runRetrospectiveSweep(makeConfig());
+
+    expect(enqueueCalls).toEqual([]);
+  });
+
+  test("guardian-authored conversation is swept", async () => {
+    const conv = createConversation({ id: "conv-a" });
+    insertMessage(conv.id, {
+      createdAt: 1_000,
+      metadata: { provenanceTrustClass: "guardian" },
+    });
+
+    await runRetrospectiveSweep(makeConfig());
+
+    expect(enqueueCalls).toEqual([
+      { conversationId: conv.id, trigger: "sweep" },
+    ]);
+  });
+});
+
+describe("listSweepCandidateConversationIds", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("excludes retrospective, consolidation, auto-analysis, and scheduled sources; orders by id", () => {
+    createConversation({ id: "conv-a" });
+    createConversation({ id: "conv-b" });
+    createConversation({
+      id: "conv-retro",
+      source: MEMORY_RETROSPECTIVE_SOURCE,
+    });
+    createConversation({
+      id: "conv-consolidate",
+      source: MEMORY_V2_CONSOLIDATION_SOURCE,
+    });
+    createConversation({ id: "conv-auto", source: AUTO_ANALYSIS_SOURCE });
+    createConversation({ id: "conv-scheduled", conversationType: "scheduled" });
+
+    const ids = listSweepCandidateConversationIds("", 100);
+
+    expect(ids).toEqual(["conv-a", "conv-b"]);
+  });
+
+  test("keyset cursor resumes past the given id", () => {
+    createConversation({ id: "conv-a" });
+    createConversation({ id: "conv-b" });
+    createConversation({ id: "conv-c" });
+
+    expect(listSweepCandidateConversationIds("conv-a", 100)).toEqual([
+      "conv-b",
+      "conv-c",
+    ]);
+    expect(listSweepCandidateConversationIds("", 1)).toEqual(["conv-a"]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/job-handlers.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers.ts
@@ -44,6 +44,7 @@ import { embedPkbFileJob } from "./jobs/embed-pkb-file.js";
 import { getLogger } from "./logging.js";
 import { memoryRetrospectiveJob } from "./memory-retrospective-job.js";
 import { skillCardInsertJob } from "./memory-retrospective-skill-card.js";
+import { memoryRetrospectiveSweepJob } from "./memory-retrospective-sweep.js";
 import {
   memoryV2ActivationRecomputeJob,
   memoryV2MigrateJob,
@@ -212,6 +213,10 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
   {
     type: "memory_retrospective",
     handler: (job, config) => memoryRetrospectiveJob(job, config),
+  },
+  {
+    type: "memory_retrospective_sweep",
+    handler: (job, config) => memoryRetrospectiveSweepJob(job, config),
   },
   {
     type: "skill_card_insert",

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -60,7 +60,10 @@ import {
 import type { JobHandler } from "../../types.js";
 import { sweepOrphanConversationMemoryTables } from "./conversation-memory-orphan-sweep.js";
 import { getLogger } from "./logging.js";
+import { countRetrospectiveMessagesAfter } from "./memory-retrospective-accounting.js";
+import { enqueueMemoryRetrospectiveIfEnabled } from "./memory-retrospective-enqueue.js";
 import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
+import { listConversationsNeedingRetrospective } from "./memory-retrospective-state.js";
 import { getWorkspaceDir } from "./paths.js";
 import { hasPkbBufferContent } from "./pkb-schedule.js";
 import {
@@ -394,6 +397,7 @@ export async function runMemoryJobsOnce(
     }
     maybeEnqueueGraphMaintenanceJobs(config);
     if (memoryEnabled) {
+      maybeEnqueueRetrospectiveSweepJobs(config);
       await maybeRunDbMaintenance();
       await maybeRunPassiveWalCheckpoint();
     }
@@ -462,6 +466,9 @@ export async function runMemoryJobsOnce(
     maybeEnqueueScheduledCleanupJobs(config);
   }
   maybeEnqueueGraphMaintenanceJobs(config);
+  if (memoryEnabled) {
+    maybeEnqueueRetrospectiveSweepJobs(config);
+  }
   await maybeRunDbMaintenance();
   await maybeRunPassiveWalCheckpoint();
   return slowProcessed + fastProcessed + embedProcessed;
@@ -818,6 +825,114 @@ export function maybeEnqueueScheduledCleanupJobs(
   return enqueuedAny;
 }
 
+// ── Retrospective sweep scheduling ────────────────────────────────
+
+/**
+ * Max conversations examined per sweep pass. Keeps the per-tick DB load
+ * bounded even on instances with large conversation histories; the cursor
+ * checkpoint advances through the full set across successive passes.
+ */
+export const RETRO_SWEEP_BATCH_LIMIT = 50;
+
+/**
+ * Walk up to `RETRO_SWEEP_BATCH_LIMIT` conversations (paginated via a durable
+ * cursor) and enqueue a retrospective for each one that has unprocessed
+ * messages and is past its cooldown. Runs on the cadence set by
+ * `config.memory.retrospective.sweepIntervalMs` (default 8h).
+ *
+ * This is the catch-all backstop for turns that ended without firing the
+ * normal turn-end trigger (crash, IPC drop, early exit). It never fires
+ * duplicate jobs — `upsertMemoryRetrospectiveJob` coalesces rapid enqueues
+ * per conversation — and it respects the same cooldown as the turn-end path
+ * so it cannot spin a tight retry loop.
+ *
+ * Two durable checkpoints drive this function:
+ *   - `retro_sweep:last_run`  — epoch-ms timestamp of the last sweep start.
+ *     Seeded to `nowMs` on first startup so the first actual sweep fires a
+ *     full interval later (matches the PKB/cleanup no-LLM-work-at-boot rule).
+ *   - `retro_sweep:cursor`    — last conversation id examined. Advances by
+ *     `RETRO_SWEEP_BATCH_LIMIT` per sweep pass so the full conversation list
+ *     is eventually covered even when many candidates have no new messages.
+ *     Resets to "" when the end of the list is reached.
+ *
+ * Returns the number of retrospective jobs enqueued this pass.
+ */
+export function maybeEnqueueRetrospectiveSweepJobs(
+  config: AssistantConfig,
+  nowMs = Date.now(),
+): number {
+  const sweepIntervalMs = config.memory.retrospective.sweepIntervalMs;
+  const rawCheckpoint = getMemoryCheckpoint(
+    GRAPH_MAINTENANCE_CHECKPOINTS.retroSweep,
+  );
+
+  // Seed to nowMs on first startup (missing checkpoint) so the first actual
+  // sweep fires after a full interval, matching the PKB and cleanup schedule
+  // patterns — no LLM-backed retrospective jobs should fire at boot.
+  if (rawCheckpoint === null) {
+    setMemoryCheckpoint(
+      GRAPH_MAINTENANCE_CHECKPOINTS.retroSweep,
+      String(nowMs),
+    );
+    return 0;
+  }
+
+  const lastRun = parseInt(rawCheckpoint, 10);
+  if (nowMs - lastRun < sweepIntervalMs) {
+    return 0;
+  }
+
+  setMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweep, String(nowMs));
+
+  // Advance the cursor so each sweep pass covers a different window of
+  // conversations. Without a cursor, the query always returns the same top-N
+  // rows and conversations beyond index N are never examined.
+  const cursor =
+    getMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweepCursor) ?? "";
+  const candidates = listConversationsNeedingRetrospective(
+    RETRO_SWEEP_BATCH_LIMIT,
+    cursor,
+  );
+
+  // Advance or reset the cursor. < limit means we reached the end of the list.
+  if (candidates.length < RETRO_SWEEP_BATCH_LIMIT) {
+    setMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweepCursor, "");
+  } else {
+    const lastId = candidates[candidates.length - 1]!.conversationId;
+    setMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweepCursor, lastId);
+  }
+
+  const minCooldownMs = config.memory.retrospective.minCooldownMs;
+  let enqueued = 0;
+  for (const {
+    conversationId,
+    lastProcessedMessageId,
+    lastRunAt,
+  } of candidates) {
+    if (nowMs - lastRunAt < minCooldownMs) {
+      continue;
+    }
+    const newMessages = countRetrospectiveMessagesAfter(
+      conversationId,
+      lastProcessedMessageId,
+    );
+    if (newMessages === 0) {
+      continue;
+    }
+    enqueueMemoryRetrospectiveIfEnabled({ conversationId, trigger: "sweep" });
+    enqueued += 1;
+  }
+
+  if (enqueued > 0) {
+    log.info(
+      { enqueued, candidates: candidates.length, cursor },
+      "Retrospective sweep enqueued jobs",
+    );
+  }
+
+  return enqueued;
+}
+
 // ── Graph maintenance scheduling ──────────────────────────────────
 
 const GRAPH_DECAY_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
@@ -840,6 +955,8 @@ export const GRAPH_MAINTENANCE_CHECKPOINTS = {
   memoryV3Maintain: "memory_v3_maintain_last_run",
   pkbFiling: "pkb_filing_last_run",
   pkbCompaction: "pkb_compaction_last_run",
+  retroSweep: "retro_sweep:last_run",
+  retroSweepCursor: "retro_sweep:cursor",
 } as const;
 
 /**

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -60,10 +60,7 @@ import {
 import type { JobHandler } from "../../types.js";
 import { sweepOrphanConversationMemoryTables } from "./conversation-memory-orphan-sweep.js";
 import { getLogger } from "./logging.js";
-import { countRetrospectiveMessagesAfter } from "./memory-retrospective-accounting.js";
-import { enqueueMemoryRetrospectiveIfEnabled } from "./memory-retrospective-enqueue.js";
 import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
-import { listConversationsNeedingRetrospective } from "./memory-retrospective-state.js";
 import { getWorkspaceDir } from "./paths.js";
 import { hasPkbBufferContent } from "./pkb-schedule.js";
 import {
@@ -396,8 +393,8 @@ export async function runMemoryJobsOnce(
       maybeEnqueueScheduledCleanupJobs(config);
     }
     maybeEnqueueGraphMaintenanceJobs(config);
+    maybeEnqueueRetrospectiveSweepJob(config);
     if (memoryEnabled) {
-      maybeEnqueueRetrospectiveSweepJobs(config);
       await maybeRunDbMaintenance();
       await maybeRunPassiveWalCheckpoint();
     }
@@ -466,9 +463,7 @@ export async function runMemoryJobsOnce(
     maybeEnqueueScheduledCleanupJobs(config);
   }
   maybeEnqueueGraphMaintenanceJobs(config);
-  if (memoryEnabled) {
-    maybeEnqueueRetrospectiveSweepJobs(config);
-  }
+  maybeEnqueueRetrospectiveSweepJob(config);
   await maybeRunDbMaintenance();
   await maybeRunPassiveWalCheckpoint();
   return slowProcessed + fastProcessed + embedProcessed;
@@ -825,114 +820,6 @@ export function maybeEnqueueScheduledCleanupJobs(
   return enqueuedAny;
 }
 
-// ── Retrospective sweep scheduling ────────────────────────────────
-
-/**
- * Max conversations examined per sweep pass. Keeps the per-tick DB load
- * bounded even on instances with large conversation histories; the cursor
- * checkpoint advances through the full set across successive passes.
- */
-export const RETRO_SWEEP_BATCH_LIMIT = 50;
-
-/**
- * Walk up to `RETRO_SWEEP_BATCH_LIMIT` conversations (paginated via a durable
- * cursor) and enqueue a retrospective for each one that has unprocessed
- * messages and is past its cooldown. Runs on the cadence set by
- * `config.memory.retrospective.sweepIntervalMs` (default 8h).
- *
- * This is the catch-all backstop for turns that ended without firing the
- * normal turn-end trigger (crash, IPC drop, early exit). It never fires
- * duplicate jobs — `upsertMemoryRetrospectiveJob` coalesces rapid enqueues
- * per conversation — and it respects the same cooldown as the turn-end path
- * so it cannot spin a tight retry loop.
- *
- * Two durable checkpoints drive this function:
- *   - `retro_sweep:last_run`  — epoch-ms timestamp of the last sweep start.
- *     Seeded to `nowMs` on first startup so the first actual sweep fires a
- *     full interval later (matches the PKB/cleanup no-LLM-work-at-boot rule).
- *   - `retro_sweep:cursor`    — last conversation id examined. Advances by
- *     `RETRO_SWEEP_BATCH_LIMIT` per sweep pass so the full conversation list
- *     is eventually covered even when many candidates have no new messages.
- *     Resets to "" when the end of the list is reached.
- *
- * Returns the number of retrospective jobs enqueued this pass.
- */
-export function maybeEnqueueRetrospectiveSweepJobs(
-  config: AssistantConfig,
-  nowMs = Date.now(),
-): number {
-  const sweepIntervalMs = config.memory.retrospective.sweepIntervalMs;
-  const rawCheckpoint = getMemoryCheckpoint(
-    GRAPH_MAINTENANCE_CHECKPOINTS.retroSweep,
-  );
-
-  // Seed to nowMs on first startup (missing checkpoint) so the first actual
-  // sweep fires after a full interval, matching the PKB and cleanup schedule
-  // patterns — no LLM-backed retrospective jobs should fire at boot.
-  if (rawCheckpoint === null) {
-    setMemoryCheckpoint(
-      GRAPH_MAINTENANCE_CHECKPOINTS.retroSweep,
-      String(nowMs),
-    );
-    return 0;
-  }
-
-  const lastRun = parseInt(rawCheckpoint, 10);
-  if (nowMs - lastRun < sweepIntervalMs) {
-    return 0;
-  }
-
-  setMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweep, String(nowMs));
-
-  // Advance the cursor so each sweep pass covers a different window of
-  // conversations. Without a cursor, the query always returns the same top-N
-  // rows and conversations beyond index N are never examined.
-  const cursor =
-    getMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweepCursor) ?? "";
-  const candidates = listConversationsNeedingRetrospective(
-    RETRO_SWEEP_BATCH_LIMIT,
-    cursor,
-  );
-
-  // Advance or reset the cursor. < limit means we reached the end of the list.
-  if (candidates.length < RETRO_SWEEP_BATCH_LIMIT) {
-    setMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweepCursor, "");
-  } else {
-    const lastId = candidates[candidates.length - 1]!.conversationId;
-    setMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.retroSweepCursor, lastId);
-  }
-
-  const minCooldownMs = config.memory.retrospective.minCooldownMs;
-  let enqueued = 0;
-  for (const {
-    conversationId,
-    lastProcessedMessageId,
-    lastRunAt,
-  } of candidates) {
-    if (nowMs - lastRunAt < minCooldownMs) {
-      continue;
-    }
-    const newMessages = countRetrospectiveMessagesAfter(
-      conversationId,
-      lastProcessedMessageId,
-    );
-    if (newMessages === 0) {
-      continue;
-    }
-    enqueueMemoryRetrospectiveIfEnabled({ conversationId, trigger: "sweep" });
-    enqueued += 1;
-  }
-
-  if (enqueued > 0) {
-    log.info(
-      { enqueued, candidates: candidates.length, cursor },
-      "Retrospective sweep enqueued jobs",
-    );
-  }
-
-  return enqueued;
-}
-
 // ── Graph maintenance scheduling ──────────────────────────────────
 
 const GRAPH_DECAY_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
@@ -955,9 +842,63 @@ export const GRAPH_MAINTENANCE_CHECKPOINTS = {
   memoryV3Maintain: "memory_v3_maintain_last_run",
   pkbFiling: "pkb_filing_last_run",
   pkbCompaction: "pkb_compaction_last_run",
-  retroSweep: "retro_sweep:last_run",
-  retroSweepCursor: "retro_sweep:cursor",
 } as const;
+
+/**
+ * Durable checkpoint (epoch-ms) tracking the last scheduled retrospective
+ * sweep so the cadence survives daemon restarts.
+ */
+export const RETROSPECTIVE_SWEEP_CHECKPOINT = "retro_sweep:last_run";
+
+/**
+ * Enqueue the scheduled `memory_retrospective_sweep` job once its interval has
+ * elapsed — the timer-driven backstop for retrospective triggers that an
+ * abnormal turn end (crash / IPC drop) skipped. See
+ * `memory-retrospective-sweep.ts`.
+ *
+ * First-run seeding: a missing checkpoint is seeded to `nowMs` WITHOUT
+ * enqueuing, so the first sweep fires one full interval after startup instead
+ * of treating the sweep as immediately overdue — a `?? "0"` fallback would make
+ * `nowMs - 0 >= sweepIntervalMs` true on the first tick and enqueue
+ * retrospective LLM work the moment the worker starts, violating the
+ * no-startup-LLM-work invariant. Mirrors the PKB schedule's null-checkpoint
+ * seed.
+ *
+ * Deduped against an in-flight sweep so a slow scan can't stack copies; the
+ * checkpoint still advances in that case to hold the cadence steady.
+ *
+ * Exported for tests; the worker calls it on every idle/drain tick. Returns
+ * true if a sweep job was enqueued this call.
+ */
+export function maybeEnqueueRetrospectiveSweepJob(
+  config: AssistantConfig,
+  nowMs = Date.now(),
+): boolean {
+  if (config.memory.enabled === false) {
+    return false;
+  }
+
+  const checkpoint = getMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT);
+  if (checkpoint === null) {
+    setMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT, String(nowMs));
+    return false;
+  }
+
+  const lastRun = parseInt(checkpoint, 10);
+  const sweepIntervalMs = config.memory.retrospective.sweepIntervalMs;
+  if (nowMs - lastRun < sweepIntervalMs) {
+    return false;
+  }
+
+  if (hasActiveJobOfType("memory_retrospective_sweep")) {
+    setMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT, String(nowMs));
+    return false;
+  }
+
+  enqueueMemoryJob("memory_retrospective_sweep", {});
+  setMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT, String(nowMs));
+  return true;
+}
 
 /**
  * Enqueue periodic graph maintenance jobs.

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
@@ -9,11 +9,19 @@
 //   - Source isn't a `scheduled` thread or a memory-consolidation background
 //     (low yield — see `isLowYieldRetrospectiveSource`).
 //
-// All four trigger types funnel through `upsertMemoryRetrospectiveJob` which
+// All trigger types funnel through `upsertMemoryRetrospectiveJob` which
 // coalesces rapid enqueues into a single pending row per conversation.
-// `lifecycle` and `compaction` triggers get a small debounce so the job runs
-// after the corresponding signal settles; `interval` and `message_count`
-// fire immediately.
+// `compaction` gets a small debounce so the job runs after the signal
+// settles; `interval`, `message_count`, and `sweep` fire immediately.
+//
+// The four triggers split by cadence: `interval` / `message_count` /
+// `compaction` are event-driven — evaluated from the post-turn indexing hook
+// and the compaction site, so they only fire while a conversation is actively
+// taking turns. `sweep` is the timer-driven backstop: a scheduled job
+// (`memory_retrospective_sweep`) re-scans conversations for unprocessed
+// messages the event triggers missed when a turn ended before its post-turn
+// hooks ran (crash / IPC drop) and the conversation then went idle. See
+// `memory-retrospective-sweep.ts`.
 
 import {
   getConversation,
@@ -35,7 +43,6 @@ export type MemoryRetrospectiveTrigger =
   | "interval"
   | "message_count"
   | "compaction"
-  | "lifecycle"
   | "sweep";
 
 const COMPACTION_DEBOUNCE_MS = 500;
@@ -100,9 +107,7 @@ export function isMemoryRetrospectiveConversation(
  */
 function isLowYieldRetrospectiveSource(conversationId: string): boolean {
   const conversation = getConversation(conversationId);
-  if (!conversation) {
-    return false;
-  }
+  if (!conversation) return false;
   return (
     conversation.conversationType === "scheduled" ||
     conversation.source === MEMORY_V2_CONSOLIDATION_SOURCE

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
@@ -35,7 +35,8 @@ export type MemoryRetrospectiveTrigger =
   | "interval"
   | "message_count"
   | "compaction"
-  | "lifecycle";
+  | "lifecycle"
+  | "sweep";
 
 const COMPACTION_DEBOUNCE_MS = 500;
 
@@ -99,7 +100,9 @@ export function isMemoryRetrospectiveConversation(
  */
 function isLowYieldRetrospectiveSource(conversationId: string): boolean {
   const conversation = getConversation(conversationId);
-  if (!conversation) return false;
+  if (!conversation) {
+    return false;
+  }
   return (
     conversation.conversationType === "scheduled" ||
     conversation.source === MEMORY_V2_CONSOLIDATION_SOURCE

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
@@ -26,15 +26,19 @@
 // table, so there is no FK cascade — the `conversation-deleted` hook purges the
 // row explicitly instead.
 
-import { desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, gt, isNull, ne, notInArray } from "drizzle-orm";
 
-import type { DrizzleDb } from "../../../persistence/db-connection.js";
-import { memoryRetrospectiveState } from "../../../persistence/schema/index.js";
+import { type DrizzleDb, getDb } from "../../../persistence/db-connection.js";
+import {
+  conversations,
+  memoryRetrospectiveState,
+} from "../../../persistence/schema/index.js";
 import { withSqliteRetry } from "./host-utils.js";
-import { getLogger } from "./logging.js";
-import { memoryDbOrNull } from "./memory-db.js";
-
-const log = getLogger("memory-retrospective-state");
+import {
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
+  MEMORY_RETROSPECTIVE_SOURCE,
+} from "./memory-retrospective-constants.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "./v3/substrate/constants.js";
 
 export interface MemoryRetrospectiveState {
   conversationId: string;
@@ -81,10 +85,14 @@ export function appendToRememberedLog(
 }
 
 function parseRememberedLog(raw: string | null): string[] {
-  if (!raw) return [];
+  if (!raw) {
+    return [];
+  }
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
     return parsed.filter((entry): entry is string => typeof entry === "string");
   } catch {
     return [];
@@ -123,6 +131,79 @@ export function listRetrospectiveStates(
 }
 
 /**
+ * Conversation source values that are excluded from the retrospective sweep.
+ * Mirrors `isMemoryRetrospectiveConversation` and `isLowYieldRetrospectiveSource`
+ * in the enqueue helper — only string-valued so we can push them into a SQL
+ * `NOT IN` predicate without loading and filtering in application code.
+ */
+const SWEEP_EXCLUDED_SOURCES = [
+  MEMORY_RETROSPECTIVE_SOURCE,
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
+  MEMORY_V2_CONSOLIDATION_SOURCE,
+] as const;
+
+export interface ConversationSweepEntry {
+  conversationId: string;
+  /** `null` when no state row exists (conversation has never been retro'd). */
+  lastProcessedMessageId: string | null;
+  /** `0` when no state row exists. */
+  lastRunAt: number;
+}
+
+/**
+ * Return up to `limit` active, non-excluded conversations in stable id-order,
+ * starting strictly after `afterConversationId` (the sweep cursor). An empty
+ * `afterConversationId` starts from the beginning of the list.
+ *
+ * Id-ordering with a cursor lets the caller page through the FULL conversation
+ * set across successive sweep passes. A stalest-first ordering without a cursor
+ * would permanently pin zero-work rows at the front of the query, so
+ * conversations beyond the batch limit could never be examined.
+ *
+ * Used by the scheduled sweep in jobs-worker.ts to find conversations that may
+ * have unprocessed messages regardless of whether a turn-end trigger fired.
+ * Archived and scheduled conversations are excluded; retrospective and
+ * consolidation background conversations are excluded (mirrors the recursion
+ * guard in `enqueueMemoryRetrospectiveIfEnabled`).
+ */
+export function listConversationsNeedingRetrospective(
+  limit: number,
+  afterConversationId = "",
+): ConversationSweepEntry[] {
+  const db = getDb();
+  const rows = db
+    .select({
+      conversationId: conversations.id,
+      lastProcessedMessageId: memoryRetrospectiveState.lastProcessedMessageId,
+      lastRunAt: memoryRetrospectiveState.lastRunAt,
+    })
+    .from(conversations)
+    .leftJoin(
+      memoryRetrospectiveState,
+      eq(conversations.id, memoryRetrospectiveState.conversationId),
+    )
+    .where(
+      and(
+        ne(conversations.conversationType, "scheduled"),
+        notInArray(conversations.source, [...SWEEP_EXCLUDED_SOURCES]),
+        isNull(conversations.archivedAt),
+        ...(afterConversationId
+          ? [gt(conversations.id, afterConversationId)]
+          : []),
+      ),
+    )
+    .orderBy(asc(conversations.id))
+    .limit(limit)
+    .all();
+
+  return rows.map((row) => ({
+    conversationId: row.conversationId,
+    lastProcessedMessageId: row.lastProcessedMessageId ?? null,
+    lastRunAt: row.lastRunAt ?? 0,
+  }));
+}
+
+/**
  * Load the state row for a conversation, or `null` if no row exists.
  */
 export function getRetrospectiveState(
@@ -140,7 +221,9 @@ export function getRetrospectiveState(
     .from(memoryRetrospectiveState)
     .where(eq(memoryRetrospectiveState.conversationId, conversationId))
     .get();
-  if (!row) return null;
+  if (!row) {
+    return null;
+  }
   return {
     conversationId: row.conversationId,
     lastProcessedMessageId: row.lastProcessedMessageId,
@@ -242,9 +325,14 @@ export function forkRetrospectiveState(args: {
     lastCopiedSourceMessageId,
   } = args;
 
-  try {
-    const mdb = memoryDbOrNull("forkRetrospectiveState");
-    if (!mdb) return;
+  const sourceRow = database
+    .select()
+    .from(memoryRetrospectiveState)
+    .where(eq(memoryRetrospectiveState.conversationId, sourceConversationId))
+    .get();
+  if (!sourceRow) {
+    return;
+  }
 
     const sourceRow = mdb
       .select({

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-state.ts
@@ -26,19 +26,15 @@
 // table, so there is no FK cascade — the `conversation-deleted` hook purges the
 // row explicitly instead.
 
-import { and, asc, desc, eq, gt, isNull, ne, notInArray } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 
-import { type DrizzleDb, getDb } from "../../../persistence/db-connection.js";
-import {
-  conversations,
-  memoryRetrospectiveState,
-} from "../../../persistence/schema/index.js";
+import type { DrizzleDb } from "../../../persistence/db-connection.js";
+import { memoryRetrospectiveState } from "../../../persistence/schema/index.js";
 import { withSqliteRetry } from "./host-utils.js";
-import {
-  MEMORY_RETROSPECTIVE_FORK_SOURCE,
-  MEMORY_RETROSPECTIVE_SOURCE,
-} from "./memory-retrospective-constants.js";
-import { MEMORY_V2_CONSOLIDATION_SOURCE } from "./v3/substrate/constants.js";
+import { getLogger } from "./logging.js";
+import { memoryDbOrNull } from "./memory-db.js";
+
+const log = getLogger("memory-retrospective-state");
 
 export interface MemoryRetrospectiveState {
   conversationId: string;
@@ -85,14 +81,10 @@ export function appendToRememberedLog(
 }
 
 function parseRememberedLog(raw: string | null): string[] {
-  if (!raw) {
-    return [];
-  }
+  if (!raw) return [];
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
+    if (!Array.isArray(parsed)) return [];
     return parsed.filter((entry): entry is string => typeof entry === "string");
   } catch {
     return [];
@@ -131,79 +123,6 @@ export function listRetrospectiveStates(
 }
 
 /**
- * Conversation source values that are excluded from the retrospective sweep.
- * Mirrors `isMemoryRetrospectiveConversation` and `isLowYieldRetrospectiveSource`
- * in the enqueue helper — only string-valued so we can push them into a SQL
- * `NOT IN` predicate without loading and filtering in application code.
- */
-const SWEEP_EXCLUDED_SOURCES = [
-  MEMORY_RETROSPECTIVE_SOURCE,
-  MEMORY_RETROSPECTIVE_FORK_SOURCE,
-  MEMORY_V2_CONSOLIDATION_SOURCE,
-] as const;
-
-export interface ConversationSweepEntry {
-  conversationId: string;
-  /** `null` when no state row exists (conversation has never been retro'd). */
-  lastProcessedMessageId: string | null;
-  /** `0` when no state row exists. */
-  lastRunAt: number;
-}
-
-/**
- * Return up to `limit` active, non-excluded conversations in stable id-order,
- * starting strictly after `afterConversationId` (the sweep cursor). An empty
- * `afterConversationId` starts from the beginning of the list.
- *
- * Id-ordering with a cursor lets the caller page through the FULL conversation
- * set across successive sweep passes. A stalest-first ordering without a cursor
- * would permanently pin zero-work rows at the front of the query, so
- * conversations beyond the batch limit could never be examined.
- *
- * Used by the scheduled sweep in jobs-worker.ts to find conversations that may
- * have unprocessed messages regardless of whether a turn-end trigger fired.
- * Archived and scheduled conversations are excluded; retrospective and
- * consolidation background conversations are excluded (mirrors the recursion
- * guard in `enqueueMemoryRetrospectiveIfEnabled`).
- */
-export function listConversationsNeedingRetrospective(
-  limit: number,
-  afterConversationId = "",
-): ConversationSweepEntry[] {
-  const db = getDb();
-  const rows = db
-    .select({
-      conversationId: conversations.id,
-      lastProcessedMessageId: memoryRetrospectiveState.lastProcessedMessageId,
-      lastRunAt: memoryRetrospectiveState.lastRunAt,
-    })
-    .from(conversations)
-    .leftJoin(
-      memoryRetrospectiveState,
-      eq(conversations.id, memoryRetrospectiveState.conversationId),
-    )
-    .where(
-      and(
-        ne(conversations.conversationType, "scheduled"),
-        notInArray(conversations.source, [...SWEEP_EXCLUDED_SOURCES]),
-        isNull(conversations.archivedAt),
-        ...(afterConversationId
-          ? [gt(conversations.id, afterConversationId)]
-          : []),
-      ),
-    )
-    .orderBy(asc(conversations.id))
-    .limit(limit)
-    .all();
-
-  return rows.map((row) => ({
-    conversationId: row.conversationId,
-    lastProcessedMessageId: row.lastProcessedMessageId ?? null,
-    lastRunAt: row.lastRunAt ?? 0,
-  }));
-}
-
-/**
  * Load the state row for a conversation, or `null` if no row exists.
  */
 export function getRetrospectiveState(
@@ -221,9 +140,7 @@ export function getRetrospectiveState(
     .from(memoryRetrospectiveState)
     .where(eq(memoryRetrospectiveState.conversationId, conversationId))
     .get();
-  if (!row) {
-    return null;
-  }
+  if (!row) return null;
   return {
     conversationId: row.conversationId,
     lastProcessedMessageId: row.lastProcessedMessageId,
@@ -325,14 +242,9 @@ export function forkRetrospectiveState(args: {
     lastCopiedSourceMessageId,
   } = args;
 
-  const sourceRow = database
-    .select()
-    .from(memoryRetrospectiveState)
-    .where(eq(memoryRetrospectiveState.conversationId, sourceConversationId))
-    .get();
-  if (!sourceRow) {
-    return;
-  }
+  try {
+    const mdb = memoryDbOrNull("forkRetrospectiveState");
+    if (!mdb) return;
 
     const sourceRow = mdb
       .select({

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
@@ -1,0 +1,234 @@
+// ---------------------------------------------------------------------------
+// Memory retrospective — scheduled sweep (timer-driven backstop).
+// ---------------------------------------------------------------------------
+//
+// The event-driven retrospective triggers (`interval` / `message_count` /
+// `compaction`) are all evaluated from within an agent turn — the post-turn
+// indexing hook and the compaction site. They fire reliably while a
+// conversation keeps taking turns. But a turn that ends abnormally (daemon
+// crash, IPC drop) never reaches its post-turn hooks, so its unprocessed
+// messages are left with no pending retrospective; if that conversation is
+// then never resumed, the event triggers never re-evaluate it and the messages
+// stay unprocessed indefinitely.
+//
+// This sweep is the backstop for exactly that gap. It runs as a scheduled job
+// (`memory_retrospective_sweep`, enqueued on a durable-checkpoint cadence from
+// `jobs-worker.ts`) and re-scans conversations for unprocessed messages,
+// enqueuing a retrospective for any the event triggers missed. It replaces the
+// former conversation-disposal safety-net: disposal only runs on graceful
+// eviction, so it shares the very failure mode (process death before the
+// path runs) it was meant to cover — a timer does not.
+//
+// Eligibility mirrors the event-driven path's gates so the sweep enqueues
+// exactly what a completed turn would have: memory-trusted actor only
+// (`isMemoryTrustedConversation`, matching `indexer.ts`'s `isTrustedActor` —
+// the retrospective runs under guardian trust with `remember`, so untrusted
+// contact content must never reach it) and no recursion/low-yield sources
+// (filtered in `EXCLUDED_SOURCES`).
+//
+// Cost discipline:
+//   - The per-conversation gate skips any conversation whose last retrospective
+//     attempt is newer than the sweep interval, so the sweep never competes
+//     with the responsive event triggers on active conversations — it only
+//     picks up genuinely stalled ones.
+//   - Enqueues route through `enqueueMemoryRetrospectiveIfEnabled`, whose
+//     `upsertMemoryRetrospectiveJob` coalesces against any already-pending job,
+//     so a conversation already queued by an event trigger is never
+//     double-processed.
+//   - The scan is keyset-paginated in bounded batches with a yield between
+//     pages (mirrors `conversation-memory-orphan-sweep.ts`), so a large history
+//     never materializes all ids at once or holds the event loop. Every
+//     eligible conversation is examined each pass — there is no front-of-list
+//     limit that could starve later conversations.
+
+import { and, asc, gt, ne, notInArray } from "drizzle-orm";
+
+import type { AssistantConfig } from "../../../config/types.js";
+import { AUTO_ANALYSIS_SOURCE } from "../../../persistence/auto-analysis-constants.js";
+import { getConversationRecentProvenanceTrustClass } from "../../../persistence/conversation-crud.js";
+import { getDb } from "../../../persistence/db-connection.js";
+import type { MemoryJob } from "../../../persistence/jobs-store.js";
+import { isMemoryEnabled } from "../../../persistence/jobs-store.js";
+import { conversations } from "../../../persistence/schema/index.js";
+import { getLogger } from "./logging.js";
+import { countRetrospectiveMessagesAfter } from "./memory-retrospective-accounting.js";
+import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
+import { enqueueMemoryRetrospectiveIfEnabled } from "./memory-retrospective-enqueue.js";
+import { getRetrospectiveState } from "./memory-retrospective-state.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "./v3/substrate/constants.js";
+
+const log = getLogger("memory-retrospective-sweep");
+
+/** Rows per keyset-paginated page — bounds each statement and the id set held. */
+const SWEEP_BATCH = 200;
+
+/**
+ * Conversation `source` values excluded from the sweep up front:
+ *   - retrospective background conversations — recursion guard (never run a
+ *     retrospective over the retrospective agent's own writes);
+ *   - consolidation sources — low-yield skip (already persisted to the corpus);
+ *   - auto-analysis conversations — recursion guard mirroring the
+ *     `!isAutoAnalysisSource` gate the event triggers apply (the analysis agent
+ *     wrote memory directly, so retrospecting its reflective output double-writes).
+ * The first two mirror guards `enqueueMemoryRetrospectiveIfEnabled` re-applies;
+ * auto-analysis is filtered here because the enqueue does not check it. Cheap
+ * SQL prefilter — the enqueue remains authoritative for the sources it covers.
+ */
+const EXCLUDED_SOURCES: string[] = [
+  ...MEMORY_RETROSPECTIVE_SOURCES,
+  MEMORY_V2_CONSOLIDATION_SOURCE,
+  AUTO_ANALYSIS_SOURCE,
+];
+
+/**
+ * Whether a conversation's actor is trusted to write into long-term memory.
+ * Mirrors the `isTrustedActor` gate in `indexer.ts`: only guardian-authored
+ * conversations and legacy conversations with no recorded provenance
+ * (predominantly desktop-origin guardian threads, which don't stamp
+ * provenance) are trusted. Contact-audience conversations (trusted_contact /
+ * unverified_contact / unknown) are excluded — the retrospective job runs
+ * under guardian trust with `remember`, so sweeping an untrusted conversation
+ * would write its content into memory across the memory trust boundary.
+ *
+ * This is the timer-path equivalent of the trust gate the event triggers
+ * apply per message (`isTrustedActor`) and the disposal net applied via
+ * `resolveCapabilities(...).canAccessMemory`; it must match the event triggers'
+ * `guardian || undefined` semantic rather than `canAccessMemory` so the sweep
+ * still backs up legacy/desktop guardian conversations (whose provenance is
+ * `undefined`), which `resolveCapabilities(undefined)` would wrongly exclude.
+ */
+export function isMemoryTrustedConversation(conversationId: string): boolean {
+  const trustClass = getConversationRecentProvenanceTrustClass(conversationId);
+  return trustClass === "guardian" || trustClass === undefined;
+}
+
+/** Yield to the event loop so a large backlog never blocks it. */
+function breathe(): Promise<void> {
+  return Bun.sleep(0);
+}
+
+/**
+ * One keyset page of sweep-eligible conversation ids past `cursor`. The empty
+ * string sorts before any real id, so the first page starts at the beginning.
+ * `scheduled`-type conversations are filtered here (low-yield, matching the
+ * enqueue guard); other low-yield cases are caught by the enqueue itself.
+ */
+export function listSweepCandidateConversationIds(
+  cursor: string,
+  limit: number,
+): string[] {
+  return getDb()
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(
+      and(
+        gt(conversations.id, cursor),
+        notInArray(conversations.source, EXCLUDED_SOURCES),
+        ne(conversations.conversationType, "scheduled"),
+      ),
+    )
+    .orderBy(asc(conversations.id))
+    .limit(limit)
+    .all()
+    .map((row) => row.id);
+}
+
+export interface RetrospectiveSweepResult {
+  /** Conversations examined across every page. */
+  scanned: number;
+  /** Conversations for which a retrospective was enqueued this pass. */
+  enqueued: number;
+}
+
+/**
+ * Scan all sweep-eligible conversations and enqueue a `sweep`-triggered
+ * retrospective for any with unprocessed messages whose last attempt is older
+ * than `sweepIntervalMs`. Idempotent and best-effort: enqueue coalescing
+ * prevents duplicates, and the scan degrades to a no-op when memory is
+ * disabled.
+ */
+export async function runRetrospectiveSweep(
+  config: AssistantConfig,
+  now: number = Date.now(),
+): Promise<RetrospectiveSweepResult> {
+  if (!isMemoryEnabled()) {
+    return { scanned: 0, enqueued: 0 };
+  }
+  const sweepIntervalMs = config.memory.retrospective.sweepIntervalMs;
+
+  let scanned = 0;
+  let enqueued = 0;
+  let cursor = "";
+  for (;;) {
+    const page = listSweepCandidateConversationIds(cursor, SWEEP_BATCH);
+    if (page.length === 0) {
+      break;
+    }
+    cursor = page[page.length - 1]!;
+
+    for (const conversationId of page) {
+      scanned += 1;
+
+      // Memory trust boundary: never enqueue a retrospective (which runs under
+      // guardian trust with `remember`) for a conversation whose actor isn't
+      // memory-trusted. This is the sweep's equivalent of the per-message
+      // `isTrustedActor` gate the event triggers apply and the disposal net's
+      // capability check — without it the timer path would write untrusted
+      // contact content into long-term memory.
+      if (!isMemoryTrustedConversation(conversationId)) {
+        continue;
+      }
+
+      // Skip conversations the event triggers are still actively covering: a
+      // last attempt within one sweep interval means the responsive path has
+      // it in hand. Never-run conversations (no state) fall through to the
+      // unprocessed-message check.
+      const state = getRetrospectiveState(conversationId);
+      if (state && now - state.lastRunAt < sweepIntervalMs) {
+        continue;
+      }
+
+      const unprocessed = countRetrospectiveMessagesAfter(
+        conversationId,
+        state?.lastProcessedMessageId ?? null,
+      );
+      if (unprocessed === 0) {
+        continue;
+      }
+
+      enqueueMemoryRetrospectiveIfEnabled({ conversationId, trigger: "sweep" });
+      enqueued += 1;
+    }
+
+    await breathe();
+    if (page.length < SWEEP_BATCH) {
+      break;
+    }
+  }
+
+  if (enqueued > 0) {
+    log.info(
+      { scanned, enqueued },
+      "Memory retrospective sweep enqueued backstop jobs",
+    );
+  } else {
+    log.debug({ scanned }, "Memory retrospective sweep found no stalled work");
+  }
+  return { scanned, enqueued };
+}
+
+/**
+ * Job handler for `memory_retrospective_sweep`. Thin wrapper over
+ * {@link runRetrospectiveSweep} — the scheduler enqueues the job on the
+ * configured cadence; the scan work happens here, off the scheduler tick.
+ */
+export async function memoryRetrospectiveSweepJob(
+  job: MemoryJob,
+  config: AssistantConfig,
+): Promise<void> {
+  const result = await runRetrospectiveSweep(config);
+  log.debug(
+    { jobId: job.id, ...result },
+    "Memory retrospective sweep job complete",
+  );
+}


### PR DESCRIPTION
## Prompt / plan

Supersedes #38624. That PR added a periodic sweep as a **fourth** retrospective entry-point alongside the existing `interval` / `message_count` / `compaction` / `lifecycle` triggers. The problem it targets is real — a turn that ends abnormally (daemon crash, IPC drop) never reaches its post-turn hooks, so its unprocessed messages get no retrospective — but the fix added surface rather than consolidating it.

Key observation from reviewing the existing triggers: the `lifecycle` trigger is *already* the intended backstop ("catches the gap between the last interval fire and conversation eviction"), but it fires from inside `disposeConversation`, so it shares the very failure mode it was meant to cover — disposal doesn't run when the process dies. It cannot backstop a crash.

This PR **replaces** `lifecycle` with a timer-driven `sweep` instead of adding to it, keeping the entry-point count unchanged (equal, not more):

- **`memory-retrospective-sweep.ts`** — a scheduled `memory_retrospective_sweep` job that keyset-paginates over eligible conversations, counts unprocessed messages (kind-aware, excludes skill cards), and enqueues a `sweep`-triggered retrospective via the existing `enqueueMemoryRetrospectiveIfEnabled` path (whose upsert coalesces against any already-pending job).
- **`jobs-worker.ts`** — `maybeEnqueueRetrospectiveSweepJob` enqueues that job on a durable checkpoint cadence (`retro_sweep:last_run`, default 8h), called from the same idle/drain ticks as the other maintenance schedulers. Uses the PKB schedule's null-checkpoint seed so the first sweep fires one full interval after startup rather than treating the sweep as overdue at boot.
- **`conversation-lifecycle.ts`** — removes the disposal-time `lifecycle` enqueue and its now-unused import.
- **`memory-retrospective-enqueue.ts`** — `MemoryRetrospectiveTrigger`: `lifecycle` → `sweep`.
- **`config/schemas/memory-retrospective.ts`** — adds `sweepIntervalMs` (default 8h).

This design also resolves the two Codex findings on #38624 by construction:
- **P1 (sweep fires immediately at startup):** the null-checkpoint seed defers the first sweep a full interval, so no retrospective LLM work is enqueued at boot.
- **P2 (front-of-list starvation):** the sweep does a full keyset-paginated scan each pass (bounded batches + yield between pages), so every eligible conversation is examined — there is no top-N limit that could starve later conversations on large histories.

The event-driven triggers (`interval` / `message_count` / `compaction`) are unchanged — they remain the responsive fast path for active conversations. A per-conversation staleness gate skips any conversation whose last attempt is newer than the sweep interval, so the sweep only picks up genuinely stalled work and never competes with the event triggers.

## Test plan

- `memory-retrospective-sweep.test.ts` (9 tests): never-run + unprocessed → swept; recent attempt → skipped; stale + unprocessed → swept; caught-up cursor → skipped; card-only tail → skipped; zero-work conversation does not starve a later one; clean no-op; source/type exclusion + keyset pagination for `listSweepCandidateConversationIds`.
- `jobs-worker-retrospective-sweep.test.ts` (5 tests): first-tick null-checkpoint seeds without enqueuing; enqueues once the interval elapses and advances the checkpoint; no enqueue before the interval; no enqueue when memory is disabled; no second copy while one is in flight (checkpoint still advances).
- Existing `memory-retrospective-enqueue`, `memory-retrospective-trigger-check`, and `conversation-lifecycle` suites pass unchanged.
- `bunx tsc --noEmit` and `eslint` pass (one pre-existing `curly` warning on an untouched line in `memory-retrospective-enqueue.ts`).

## CLI verb checklist

No new IPC routes under `assistant/src/runtime/routes/` — n/a.


---
_Generated by [Claude Code](https://claude.ai/code/session_016f89NT7KdSJQDDHEPYATFb)_