### PR TITLE
feat(web): keep the sidebar expanded while the in-chat tour runs

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -18,6 +18,7 @@ import {
   selectChatFocusActive,
   selectHeaderCenterHidden,
   selectHeaderControlsHidden,
+  selectTourActive,
   useInChatOnboardingStore,
 } from "@/stores/in-chat-onboarding-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -252,6 +253,7 @@ export function ChatLayout({
     selectHeaderCenterHidden,
   );
   const navTourActive = useInChatOnboardingStore.use.navTourActive();
+  const tourActive = useInChatOnboardingStore(selectTourActive);
 
   // --- Assistant identity from store (written by ChatPage) ---
   const assistantName = useAssistantIdentityStore.use.name();
@@ -297,6 +299,11 @@ export function ChatLayout({
   // --- Sidebar collapsed / drawer state ---
   const [collapsed, setCollapsed] = useState<boolean>(readPersistedCollapsed);
   const [sidebarWidth, setSidebarWidth] = useState<number>(readPersistedWidth);
+  // The tour walks the sidebar's rows, which a 48px collapsed rail doesn't
+  // show — so the tour's whole run forces the rail expanded. Derived (not
+  // written through setCollapsed) so the user's persisted preference is
+  // untouched and the rail collapses back on its own when the tour ends.
+  const effectiveCollapsed = collapsed && !tourActive;
 
   useEffect(() => {
     setLocalBool(SIDEBAR_COLLAPSED_STORAGE_KEY, collapsed);
@@ -359,6 +366,12 @@ export function ChatLayout({
   const drawerVisible = isMobile && drawerOpen;
 
   const toggleSidebar = useCallback(() => {
+    // The tour forces the rail expanded; a toggle would only flip the
+    // persisted preference invisibly (Ctrl+\ still fires under the tour's
+    // click-blocking overlay), so ignore it for the tour's duration.
+    if (selectTourActive(useInChatOnboardingStore.getState())) {
+      return;
+    }
     haptic.light();
     if (window.matchMedia(MOBILE_MEDIA_QUERY).matches) {
       setDrawerOpen((value) => {
@@ -764,7 +777,7 @@ export function ChatLayout({
         <ChatLayoutHeader
           isMobile={isMobile}
           drawerOpen={drawerOpen}
-          collapsed={collapsed}
+          collapsed={effectiveCollapsed}
           sidebarWidth={sidebarWidth}
           toggleSidebar={toggleSidebar}
           controlsHidden={headerControlsHidden}
@@ -887,7 +900,7 @@ export function ChatLayout({
             // Hiding eases smoothly; revealing uses a back-ease so the rail
             // lands with a slight bounce (the tour's takeover moment).
             style={{
-              width: chatFocusActive ? 0 : collapsed ? 48 : sidebarWidth,
+              width: chatFocusActive ? 0 : effectiveCollapsed ? 48 : sidebarWidth,
               opacity: chatFocusActive ? 0 : 1,
               marginRight: chatFocusActive ? -16 : 0,
               transition: chatFocusActive
@@ -896,7 +909,7 @@ export function ChatLayout({
             }}
           >
             {renderSideMenu({
-              collapsed,
+              collapsed: effectiveCollapsed,
               variant: "rail",
               width: sidebarWidth,
               onWidthChange: handleSidebarWidthChange,

--- a/clients/web/src/stores/in-chat-onboarding-store.ts
+++ b/clients/web/src/stores/in-chat-onboarding-store.ts
@@ -66,14 +66,15 @@ export const useInChatOnboardingStore = createSelectors(
   useInChatOnboardingStoreBase,
 );
 
+/** Whether the tour is running — every beat, intro through last stop. */
+export function selectTourActive(state: InChatOnboardingStore): boolean {
+  return state.prototypeActive && state.stage === "tour";
+}
+
 /** Whether the sidebar is hidden: the tour's opening beats, until the tour
  *  itself reveals it with a bounce. */
 export function selectChatFocusActive(state: InChatOnboardingStore): boolean {
-  return (
-    state.prototypeActive &&
-    state.stage === "tour" &&
-    !state.tourSidebarRevealed
-  );
+  return selectTourActive(state) && !state.tourSidebarRevealed;
 }
 
 /** Whether the header's center chat title is hidden — the ENTIRE tour: the
@@ -82,7 +83,7 @@ export function selectChatFocusActive(state: InChatOnboardingStore): boolean {
 export function selectHeaderCenterHidden(
   state: InChatOnboardingStore,
 ): boolean {
-  return state.prototypeActive && state.stage === "tour";
+  return selectTourActive(state);
 }
 
 /** Whether the header's controls are hidden — the tour's opening beats;
@@ -91,9 +92,5 @@ export function selectHeaderCenterHidden(
 export function selectHeaderControlsHidden(
   state: InChatOnboardingStore,
 ): boolean {
-  return (
-    state.prototypeActive &&
-    state.stage === "tour" &&
-    !state.tourSidebarRevealed
-  );
+  return selectTourActive(state) && !state.tourSidebarRevealed;
 }


### PR DESCRIPTION
## Summary
- Force the desktop sidebar rail expanded for the tour's entire run via a derived `effectiveCollapsed` in `ChatLayout`. The persisted collapse preference is never written, so the rail collapses back on its own when the tour ends — but only if it was collapsed before the tour started.
- Ignore sidebar toggles while the tour runs: Ctrl+\ still fires under the tour's click-blocking overlay, and a toggle would only flip the persisted preference with no visible change.
- Add a `selectTourActive` selector to the in-chat onboarding store and compose the existing tour selectors from it instead of repeating the same predicate.

## Original prompt
Put up a PR to make sure the side nav is expanded while the onboarding tour is happening; we can collapse it back after the tour is complete. Motivation: the avatar tour measures its sidebar stops via `data-tour-id` DOM targets, which a collapsed 48px rail doesn't render — a user who had collapsed the sidebar would get a tour with its sidebar beats missing.