### PR TITLE
Single-source document_editor_show; nuke dead document save/load/list types

### DIFF
--- a/assistant/src/api/events/document-editor-show.ts
+++ b/assistant/src/api/events/document-editor-show.ts
@@ -1,0 +1,26 @@
+/**
+ * `document_editor_show` SSE event.
+ *
+ * Server → client instruction to open the document editor for a
+ * surface, emitted by the document tool. Carries the owning
+ * `conversationId`, the `surfaceId` to bind the editor to, the
+ * `title`, and the `initialContent` to seed it with.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const DocumentEditorShowEventSchema = z.object({
+  type: z.literal("document_editor_show"),
+  conversationId: z.string(),
+  surfaceId: z.string(),
+  title: z.string(),
+  initialContent: z.string(),
+});
+
+export type DocumentEditorShowEvent = z.infer<
+  typeof DocumentEditorShowEventSchema
+>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -30,6 +30,7 @@ import { DocumentCommentCreatedEventSchema } from "./events/document-comment-cre
 import { DocumentCommentDeletedEventSchema } from "./events/document-comment-deleted.js";
 import { DocumentCommentReopenedEventSchema } from "./events/document-comment-reopened.js";
 import { DocumentCommentResolvedEventSchema } from "./events/document-comment-resolved.js";
+import { DocumentEditorShowEventSchema } from "./events/document-editor-show.js";
 import { DocumentEditorUpdateEventSchema } from "./events/document-editor-update.js";
 import { ErrorEventSchema } from "./events/error.js";
 import { GenerationCancelledEventSchema } from "./events/generation-cancelled.js";
@@ -255,6 +256,10 @@ export {
   type DocumentCommentResolvedEvent,
   DocumentCommentResolvedEventSchema,
 } from "./events/document-comment-resolved.js";
+export {
+  type DocumentEditorShowEvent,
+  DocumentEditorShowEventSchema,
+} from "./events/document-editor-show.js";
 export {
   type DocumentEditorUpdateEvent,
   DocumentEditorUpdateEventSchema,
@@ -734,6 +739,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   DocumentCommentDeletedEventSchema,
   DocumentCommentReopenedEventSchema,
   DocumentCommentResolvedEventSchema,
+  DocumentEditorShowEventSchema,
   DocumentEditorUpdateEventSchema,
   ErrorEventSchema,
   GenerationCancelledEventSchema,

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -67,10 +67,7 @@ import type {
 } from "./message-types/conversations.js";
 import type { _DiagnosticsClientMessages } from "./message-types/diagnostics.js";
 import type { _DocumentCommentsServerMessages } from "./message-types/document-comments.js";
-import type {
-  _DocumentsClientMessages,
-  _DocumentsServerMessages,
-} from "./message-types/documents.js";
+import type { _DocumentsServerMessages } from "./message-types/documents.js";
 import type { _HomeServerMessages } from "./message-types/home.js";
 import type { _HostAppControlServerMessages } from "./message-types/host-app-control.js";
 import type { _HostBashServerMessages } from "./message-types/host-bash.js";
@@ -142,7 +139,6 @@ export type ClientMessage =
   | _ComputerUseClientMessages
   | _HostBrowserClientMessages
   | _SubagentsClientMessages
-  | _DocumentsClientMessages
   | _WorkspaceClientMessages
   | _SchedulesClientMessages
   | _DiagnosticsClientMessages

--- a/assistant/src/daemon/message-types/documents.ts
+++ b/assistant/src/daemon/message-types/documents.ts
@@ -1,82 +1,13 @@
-// Document editor and document persistence types.
+// Document editor events.
+//
+// Server→client events are single-sourced from their canonical `api/events`
+// wire schemas; this file only composes them into the domain union consumed by
+// `message-protocol.ts`. Document save/load/list are served by the document
+// tools and HTTP document routes, not by client messages.
 
+import type { DocumentEditorShowEvent } from "../../api/events/document-editor-show.js";
 import type { DocumentEditorUpdateEvent } from "../../api/events/document-editor-update.js";
 
-// === Server → Client ===
-
-export interface DocumentEditorShow {
-  type: "document_editor_show";
-  conversationId: string;
-  surfaceId: string;
-  title: string;
-  initialContent: string;
-}
-
-// === Client → Server ===
-
-export interface DocumentSaveRequest {
-  type: "document_save";
-  surfaceId: string;
-  conversationId: string;
-  title: string;
-  content: string;
-  wordCount: number;
-}
-
-export interface DocumentLoadRequest {
-  type: "document_load";
-  surfaceId: string;
-}
-
-export interface DocumentListRequest {
-  type: "document_list";
-  conversationId?: string;
-}
-
-// === Server → Client ===
-
-export interface DocumentSaveResponse {
-  type: "document_save_response";
-  surfaceId: string;
-  success: boolean;
-  error?: string;
-}
-
-export interface DocumentLoadResponse {
-  type: "document_load_response";
-  surfaceId: string;
-  conversationId: string;
-  title: string;
-  content: string;
-  wordCount: number;
-  createdAt: number;
-  updatedAt: number;
-  success: boolean;
-  error?: string;
-}
-
-export interface DocumentListResponse {
-  type: "document_list_response";
-  documents: Array<{
-    surfaceId: string;
-    conversationId: string;
-    title: string;
-    wordCount: number;
-    createdAt: number;
-    updatedAt: number;
-  }>;
-}
-
-// --- Domain-level union aliases (consumed by the barrel file) ---
-
-export type _DocumentsClientMessages =
-  | DocumentSaveRequest
-  | DocumentLoadRequest
-  | DocumentListRequest;
-
 export type _DocumentsServerMessages =
-  | DocumentEditorShow
-  | DocumentEditorUpdateEvent
-  | DocumentSaveResponse
-  | DocumentLoadResponse
-  | DocumentListResponse;
+  | DocumentEditorShowEvent
+  | DocumentEditorUpdateEvent;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -451,6 +451,7 @@ export function useStreamEventHandler(
         case "avatar_updated":
         case "disk_pressure_status_changed":
         case "notification_intent":
+        case "document_editor_show":
         case "document_editor_update":
         case "conversation_title_updated":
         case "document_comment_created":


### PR DESCRIPTION
## Why

Continues the event-type unification effort, liveness-check first. The `documents` domain was mostly dead — one live event, six orphaned types.

## What

**Migrated (live) → new `api/events/document-editor-show.ts`, registered in `AssistantEventSchema`:**
- `document_editor_show` — broadcast by the document tool (`document-tool.ts`) to open the editor for a surface.

(`document_editor_update` was already migrated.) `_DocumentsServerMessages` now composes the two api-inferred types.

**Removed (dead — no producer or consumer):**
- `document_save` / `document_load` / `document_list` client requests and their `document_save_response` / `document_load_response` / `document_list_response` events. Document persistence runs through the document tools + HTTP document routes now; these wire types have no emitter or dispatcher anywhere (the live `document_list` is a *tool name* in `TOOLS.json`, not this message).

`_DocumentsClientMessages` held only those three dead client messages, so it and its `ClientMessage` aggregate entry are removed.

## Web

`document_editor_show` carries a `conversationId` (conversation-scoped, like `document_editor_update`), so it joins `document_editor_update` as a no-op case in the chat handler's exhaustive switch — the editor is driven by the `useDocumentEditorSync` bus consumer, not the chat handler.

## Safety

No wire change for the live event (schema transcribed 1:1); removing dead types changes no runtime behavior. Repo-wide grep (assistant + cli + web + gateway) shows zero references to any removed type/literal. Clean `typecheck:fast` + web `tsc` (fresh `openapi-ts`), eslint, prettier, `generate:openapi --check` (unchanged), api-events + SSE-parity suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_