### PR TITLE
feat(web): allow a custom voice ID for vellum-managed voice (JARVIS-1339)

### DIFF
--- a/clients/web/src/components/speech/tts-provider-form.tsx
+++ b/clients/web/src/components/speech/tts-provider-form.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { List, Pencil } from "lucide-react";
+
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import {
   configGetOptions,
@@ -424,14 +426,38 @@ export function TtsProviderForm({
   const managedVoiceSupported =
     isManaged && selectedProvider.supportsVoiceSelection;
 
+  // The catalog/custom toggle sits on the "Voice" label row (right-aligned) and
+  // reads as a link at rest — icon plus a standing underline — so it's an
+  // obvious action tied to the field, not a caption for the control below it.
   const enterCustomVoiceLink = (
     <Button
       variant="link"
       size="compact"
-      className="h-auto px-0"
+      className="h-auto gap-1 px-0 underline"
       onClick={() => setCustomModeOverride(true)}
     >
+      <Pencil className="h-3.5 w-3.5" aria-hidden />
       Enter a custom voice ID
+    </Button>
+  );
+  const chooseFromCatalogLink = (
+    <Button
+      variant="link"
+      size="compact"
+      className="h-auto gap-1 px-0 underline"
+      onClick={() => {
+        setCustomModeOverride(false);
+        // Snap a non-catalog draft back to a real catalog voice so the picker's
+        // trigger label matches the selection.
+        if (!managedVoices.some((v) => v.model === draftManagedVoice)) {
+          setDraftManagedVoice(
+            defaultManagedVoice || managedVoices[0]?.model || "",
+          );
+        }
+      }}
+    >
+      <List className="h-3.5 w-3.5" aria-hidden />
+      Choose from catalog
     </Button>
   );
 
@@ -469,61 +495,43 @@ export function TtsProviderForm({
 
       {managedVoiceSupported && (
         <div className="space-y-1">
-          <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            Voice
-          </label>
+          <div className="flex items-center justify-between gap-2">
+            <label className="text-body-small-default text-[var(--content-tertiary)]">
+              Voice
+            </label>
+            {/* The toggle only appears once the catalog has resolved: from the
+                catalog it offers custom entry; from custom it offers a way back,
+                but only when there's actually a catalog to return to. */}
+            {customManagedVoice
+              ? managedVoices.length > 0 && chooseFromCatalogLink
+              : fetched && enterCustomVoiceLink}
+          </div>
           {customManagedVoice ? (
-            <>
-              {/* Free-text entry for a managed voice id outside the catalog
-                  (power users, or an id the platform serves but doesn't list). */}
-              <Input
-                type="text"
-                value={draftManagedVoice}
-                onChange={(e) => setDraftManagedVoice(e.target.value)}
-                placeholder="Enter a voice ID"
-                aria-label="Custom voice ID"
-                fullWidth
-              />
-              <Button
-                variant="link"
-                size="compact"
-                className="h-auto px-0"
-                onClick={() => {
-                  setCustomModeOverride(false);
-                  // Snap a non-catalog draft back to a real catalog voice so the
-                  // picker's trigger label matches the selection.
-                  if (!managedVoices.some((v) => v.model === draftManagedVoice)) {
-                    setDraftManagedVoice(
-                      defaultManagedVoice || managedVoices[0]?.model || "",
-                    );
-                  }
-                }}
-              >
-                Choose from catalog
-              </Button>
-            </>
+            /* Free-text entry for a managed voice id outside the catalog
+               (power users, or an id the platform serves but doesn't list). */
+            <Input
+              type="text"
+              value={draftManagedVoice}
+              onChange={(e) => setDraftManagedVoice(e.target.value)}
+              placeholder="Enter a voice ID"
+              aria-label="Custom voice ID"
+              fullWidth
+            />
           ) : selectedManagedVoice ? (
-            <>
-              {/* Collapsed select-style field that opens the shared voice list
-                  (grouped, per-row preview, provider badge). Controlled so the
-                  pick stays a draft until Save, matching the rest of this form. */}
-              <VoicePickerField
-                assistantId={assistantId}
-                value={draftManagedVoice}
-                onChange={setDraftManagedVoice}
-              />
-              {enterCustomVoiceLink}
-            </>
+            /* Collapsed select-style field that opens the shared voice list
+               (grouped, per-row preview, provider badge). Controlled so the
+               pick stays a draft until Save, matching the rest of this form. */
+            <VoicePickerField
+              assistantId={assistantId}
+              value={draftManagedVoice}
+              onChange={setDraftManagedVoice}
+            />
           ) : (
-            // Gated on `fetched` so the note never flashes while loading. Custom
-            // entry stays offered so an empty catalog isn't a dead end.
+            // Gated on `fetched` so the note never flashes while loading.
             fetched && (
-              <>
-                <p className="text-body-small-default text-[var(--content-tertiary)]">
-                  No managed voices are currently available.
-                </p>
-                {enterCustomVoiceLink}
-              </>
+              <p className="text-body-small-default text-[var(--content-tertiary)]">
+                No managed voices are currently available.
+              </p>
             )
           )}
         </div>

--- a/clients/web/src/components/speech/tts-provider-form.tsx
+++ b/clients/web/src/components/speech/tts-provider-form.tsx
@@ -426,14 +426,15 @@ export function TtsProviderForm({
   const managedVoiceSupported =
     isManaged && selectedProvider.supportsVoiceSelection;
 
-  // The catalog/custom toggle sits on the "Voice" label row (right-aligned) and
-  // reads as a link at rest — icon plus a standing underline — so it's an
-  // obvious action tied to the field, not a caption for the control below it.
+  // The catalog/custom toggle reads as a link at rest — icon plus a standing
+  // underline — and sits on the action row beside Save. `inline-flex` overrides
+  // the link variant's `inline` display so the icon centers with the label
+  // instead of riding the line above it.
   const enterCustomVoiceLink = (
     <Button
       variant="link"
       size="compact"
-      className="h-auto gap-1 px-0 underline"
+      className="inline-flex h-auto items-center gap-1 px-0 underline"
       onClick={() => setCustomModeOverride(true)}
     >
       <Pencil className="h-3.5 w-3.5" aria-hidden />
@@ -444,7 +445,7 @@ export function TtsProviderForm({
     <Button
       variant="link"
       size="compact"
-      className="h-auto gap-1 px-0 underline"
+      className="inline-flex h-auto items-center gap-1 px-0 underline"
       onClick={() => {
         setCustomModeOverride(false);
         // Snap a non-catalog draft back to a real catalog voice so the picker's
@@ -460,6 +461,18 @@ export function TtsProviderForm({
       Choose from catalog
     </Button>
   );
+  // From the catalog the toggle offers custom entry; from custom it offers a way
+  // back, but only when there's actually a catalog to return to. Null until the
+  // catalog resolves so it never flashes.
+  const managedVoiceToggle = !managedVoiceSupported
+    ? null
+    : customManagedVoice
+      ? managedVoices.length > 0
+        ? chooseFromCatalogLink
+        : null
+      : fetched
+        ? enterCustomVoiceLink
+        : null;
 
   return (
     <div className="space-y-4">
@@ -495,17 +508,9 @@ export function TtsProviderForm({
 
       {managedVoiceSupported && (
         <div className="space-y-1">
-          <div className="flex items-center justify-between gap-2">
-            <label className="text-body-small-default text-[var(--content-tertiary)]">
-              Voice
-            </label>
-            {/* The toggle only appears once the catalog has resolved: from the
-                catalog it offers custom entry; from custom it offers a way back,
-                but only when there's actually a catalog to return to. */}
-            {customManagedVoice
-              ? managedVoices.length > 0 && chooseFromCatalogLink
-              : fetched && enterCustomVoiceLink}
-          </div>
+          <label className="block text-body-small-default text-[var(--content-tertiary)]">
+            Voice
+          </label>
           {customManagedVoice ? (
             /* Free-text entry for a managed voice id outside the catalog
                (power users, or an id the platform serves but doesn't list). */
@@ -566,7 +571,8 @@ export function TtsProviderForm({
             {testing ? "Testing…" : "Test"}
           </Button>
         )}
-        <div className="ml-auto flex items-center gap-2">
+        <div className="ml-auto flex items-center gap-3">
+          {managedVoiceToggle}
           {!hideSaveButton && (
             <SaveButton onClick={handleSave} disabled={!hasChanges || saving} />
           )}

--- a/clients/web/src/components/speech/tts-provider-form.tsx
+++ b/clients/web/src/components/speech/tts-provider-form.tsx
@@ -172,16 +172,34 @@ export function TtsProviderForm({
     managedVoices.find((v) => v.model === draftManagedVoice) ??
     managedVoices[0];
 
+  // Custom-voice entry: a free-text field for a managed voice id outside the
+  // curated catalog. Null override means "not yet toggled by the user" — the
+  // mode then derives from the saved config, opening custom automatically when
+  // the saved voice isn't a catalog voice so an already-custom id shows in the
+  // field instead of the picker misrepresenting it as the first catalog voice.
+  const [customModeOverride, setCustomModeOverride] = useState<boolean | null>(
+    null,
+  );
+  const serverVoiceInCatalog = managedVoices.some(
+    (v) => v.model === serverManagedVoice,
+  );
+  const customManagedVoice =
+    customModeOverride ??
+    (fetched && serverManagedVoice !== "" && !serverVoiceInCatalog);
+
   const selectedProvider = useMemo(() => {
     return providers.find((p) => p.id === draftProvider) ?? providers[0]!;
   }, [draftProvider, providers]);
 
   // Written to config only when true: never writing on an untouched default
   // keeps "unset = platform default" configs unset, and daemons that predate
-  // managed voice selection never receive a field they would silently drop.
+  // managed voice selection never receive a field they would silently drop. The
+  // non-empty guard keeps a cleared custom-voice field from PATCHing an empty
+  // model (which the daemon would treat as an unknown voice).
   const managedVoiceChanged =
     draftProvider === "vellum" &&
     selectedProvider.supportsVoiceSelection &&
+    draftManagedVoice.trim() !== "" &&
     draftManagedVoice !== serverManagedVoice;
 
   const loadProviderState = useCallback((providerId: string) => {
@@ -285,7 +303,7 @@ export function TtsProviderForm({
             }
           : {}),
         ...(managedVoiceChanged
-          ? { providers: { vellum: { model: draftManagedVoice } } }
+          ? { providers: { vellum: { model: draftManagedVoice.trim() } } }
           : {}),
       };
       if (Object.keys(ttsBody).length > 0) {
@@ -406,6 +424,16 @@ export function TtsProviderForm({
   const managedVoiceSupported =
     isManaged && selectedProvider.supportsVoiceSelection;
 
+  const enterCustomVoiceLink = (
+    <button
+      type="button"
+      className="text-body-small-default text-[var(--content-tertiary)] underline-offset-2 hover:underline"
+      onClick={() => setCustomModeOverride(true)}
+    >
+      Enter a custom voice ID
+    </button>
+  );
+
   return (
     <div className="space-y-4">
       <div className="space-y-1">
@@ -438,26 +466,65 @@ export function TtsProviderForm({
         </div>
       )}
 
-      {managedVoiceSupported && selectedManagedVoice && (
+      {managedVoiceSupported && (
         <div className="space-y-1">
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
             Voice
           </label>
-          {/* Collapsed select-style field that opens the shared voice list
-              (grouped, per-row preview, provider badge). Controlled so the pick
-              stays a draft until Save, matching the rest of this form. */}
-          <VoicePickerField
-            assistantId={assistantId}
-            value={draftManagedVoice}
-            onChange={setDraftManagedVoice}
-          />
+          {customManagedVoice ? (
+            <>
+              {/* Free-text entry for a managed voice id outside the catalog
+                  (power users, or an id the platform serves but doesn't list). */}
+              <Input
+                type="text"
+                value={draftManagedVoice}
+                onChange={(e) => setDraftManagedVoice(e.target.value)}
+                placeholder="Enter a voice ID"
+                aria-label="Custom voice ID"
+                fullWidth
+              />
+              <button
+                type="button"
+                className="text-body-small-default text-[var(--content-tertiary)] underline-offset-2 hover:underline"
+                onClick={() => {
+                  setCustomModeOverride(false);
+                  // Snap a non-catalog draft back to a real catalog voice so the
+                  // picker's trigger label matches the selection.
+                  if (!managedVoices.some((v) => v.model === draftManagedVoice)) {
+                    setDraftManagedVoice(
+                      defaultManagedVoice || managedVoices[0]?.model || "",
+                    );
+                  }
+                }}
+              >
+                Choose from catalog
+              </button>
+            </>
+          ) : selectedManagedVoice ? (
+            <>
+              {/* Collapsed select-style field that opens the shared voice list
+                  (grouped, per-row preview, provider badge). Controlled so the
+                  pick stays a draft until Save, matching the rest of this form. */}
+              <VoicePickerField
+                assistantId={assistantId}
+                value={draftManagedVoice}
+                onChange={setDraftManagedVoice}
+              />
+              {enterCustomVoiceLink}
+            </>
+          ) : (
+            // Gated on `fetched` so the note never flashes while loading. Custom
+            // entry stays offered so an empty catalog isn't a dead end.
+            fetched && (
+              <>
+                <p className="text-body-small-default text-[var(--content-tertiary)]">
+                  No managed voices are currently available.
+                </p>
+                {enterCustomVoiceLink}
+              </>
+            )
+          )}
         </div>
-      )}
-      {/* Gated on `fetched` so the note never flashes while loading. */}
-      {managedVoiceSupported && fetched && !selectedManagedVoice && (
-        <p className="text-body-small-default text-[var(--content-tertiary)]">
-          No managed voices are currently available.
-        </p>
       )}
 
       {selectedProvider.supportsVoiceSelection && !isManaged && (

--- a/clients/web/src/components/speech/tts-provider-form.tsx
+++ b/clients/web/src/components/speech/tts-provider-form.tsx
@@ -200,7 +200,7 @@ export function TtsProviderForm({
     draftProvider === "vellum" &&
     selectedProvider.supportsVoiceSelection &&
     draftManagedVoice.trim() !== "" &&
-    draftManagedVoice !== serverManagedVoice;
+    draftManagedVoice.trim() !== serverManagedVoice;
 
   const loadProviderState = useCallback((providerId: string) => {
     const storedKey = getLocalSetting(LS_TTS_API_KEY_PREFIX + providerId, "");
@@ -425,13 +425,14 @@ export function TtsProviderForm({
     isManaged && selectedProvider.supportsVoiceSelection;
 
   const enterCustomVoiceLink = (
-    <button
-      type="button"
-      className="text-body-small-default text-[var(--content-tertiary)] underline-offset-2 hover:underline"
+    <Button
+      variant="link"
+      size="compact"
+      className="h-auto px-0"
       onClick={() => setCustomModeOverride(true)}
     >
       Enter a custom voice ID
-    </button>
+    </Button>
   );
 
   return (
@@ -483,9 +484,10 @@ export function TtsProviderForm({
                 aria-label="Custom voice ID"
                 fullWidth
               />
-              <button
-                type="button"
-                className="text-body-small-default text-[var(--content-tertiary)] underline-offset-2 hover:underline"
+              <Button
+                variant="link"
+                size="compact"
+                className="h-auto px-0"
                 onClick={() => {
                   setCustomModeOverride(false);
                   // Snap a non-catalog draft back to a real catalog voice so the
@@ -498,7 +500,7 @@ export function TtsProviderForm({
                 }}
               >
                 Choose from catalog
-              </button>
+              </Button>
             </>
           ) : selectedManagedVoice ? (
             <>

--- a/clients/web/src/components/speech/tts-provider-form.tsx
+++ b/clients/web/src/components/speech/tts-provider-form.tsx
@@ -426,15 +426,16 @@ export function TtsProviderForm({
   const managedVoiceSupported =
     isManaged && selectedProvider.supportsVoiceSelection;
 
-  // The catalog/custom toggle reads as a link at rest — icon plus a standing
-  // underline — and sits on the action row beside Save. `inline-flex` overrides
-  // the link variant's `inline` display so the icon centers with the label
-  // instead of riding the line above it.
+  // The catalog/custom toggle sits on the action row beside Save. It's a muted
+  // secondary action — the icon plus a standing underline carry the affordance
+  // while the tertiary tone keeps Save the dominant control. `inline-flex`
+  // overrides the link variant's `inline` display so the icon centers with the
+  // label instead of riding the line above it.
   const enterCustomVoiceLink = (
     <Button
       variant="link"
       size="compact"
-      className="inline-flex h-auto items-center gap-1 px-0 underline"
+      className="inline-flex h-auto items-center gap-1 px-0 underline [--vbtn-fg:var(--content-tertiary)]"
       onClick={() => setCustomModeOverride(true)}
     >
       <Pencil className="h-3.5 w-3.5" aria-hidden />
@@ -445,7 +446,7 @@ export function TtsProviderForm({
     <Button
       variant="link"
       size="compact"
-      className="inline-flex h-auto items-center gap-1 px-0 underline"
+      className="inline-flex h-auto items-center gap-1 px-0 underline [--vbtn-fg:var(--content-tertiary)]"
       onClick={() => {
         setCustomModeOverride(false);
         // Snap a non-catalog draft back to a real catalog voice so the picker's

--- a/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
+++ b/clients/web/src/domains/settings/ai/text-to-speech-card.tsx
@@ -10,6 +10,7 @@ import { TtsProviderForm } from "@/components/speech/tts-provider-form";
 export function TextToSpeechCard() {
   return (
     <ByoServiceCard
+      id="text-to-speech"
       title="Text-to-Speech"
       subtitle="Configure how your assistant speaks"
     >

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -148,7 +148,7 @@ function SpeechServicesBanner() {
         Want to use your own API key for STT or TTS, or set a custom voice?
       </span>
       <Link
-        to={routes.settings.ai}
+        to={`${routes.settings.ai}#text-to-speech`}
         className="inline-flex items-center gap-1 text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 hover:text-[var(--content-default)]"
       >
         Set it up in Models &amp; Services

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -133,10 +133,11 @@ export function VoiceSections() {
 }
 
 /**
- * Pointer to the BYO speech providers, which live with every other provider on
- * Models & Services rather than on this page. Restores the cross-link the Voice
- * page carried before speech briefly moved into a Services tab — most people
- * want the managed voice above, but the ones bringing their own key need a way
+ * Pointer to Models & Services, which carries the BYO speech providers (they
+ * live with every other provider there, not on this page) and the managed
+ * custom-voice-ID entry. Restores the cross-link the Voice page carried before
+ * speech briefly moved into a Services tab — most people want the managed voice
+ * above, but those bringing their own key or a specific voice ID need a way
  * across.
  */
 function SpeechServicesBanner() {
@@ -144,7 +145,7 @@ function SpeechServicesBanner() {
     <div className="flex flex-wrap items-center gap-1.5 px-1 text-body-small-default text-[var(--content-tertiary)]">
       <Info className="h-3.5 w-3.5 shrink-0 text-[var(--content-quiet)]" />
       <span>
-        Want to use your own API key for speech-to-text or text-to-speech?
+        Want to use your own API key for STT or TTS, or set a custom voice?
       </span>
       <Link
         to={routes.settings.ai}


### PR DESCRIPTION
## Summary
- **Custom voice ID for managed voice.** On **Models & Services → Text-to-Speech**, a muted `Enter a custom voice ID` action on the form's button row (beside Save) swaps the catalog picker for a free-text field (with `Choose from catalog` to switch back), so power users can enter an arbitrary voice id the curated catalog doesn't include. It writes to the same `services.tts.providers.vellum.model` config a catalog pick uses; custom mode auto-opens when the saved voice isn't a catalog voice, and the empty-catalog case still offers custom entry. The save is hardened to never PATCH an empty/whitespace model (compared trimmed).
- **Voice-page discoverability.** The Settings → Voice speech banner now reads "Want to use your own API key for STT or TTS, or set a custom voice?" and deep-links to the TTS card (`#text-to-speech`, which sits below the fold on Models & Services) so managed users know where custom voices live — without duplicating the input onto the Voice page.
- **Caveat (JARVIS-1310):** a hand-entered *ElevenLabs* managed voice id will still fail in live-voice streaming (Deepgram-only relay); it works for batch/read-aloud. Deepgram Aura ids stream fine.

## Original prompt
Last of the voice-selector polish items for the M&S voice settings: most of the original wishlist (provider/model badge, per-row preview, BYO voice-id entry) already shipped, so the remaining gap was that a **vellum-managed** assistant could only pick from the platform catalog — there was no way to type a specific voice id. This adds that custom-entry path on the Text-to-Speech form, plus a Voice-page pointer so managed users can find it. Tracked as JARVIS-1339.