### PR TITLE
feat(web): derive a deep surface tint from an avatar accent color

### DIFF
--- a/clients/web/src/utils/avatar-surface.test.ts
+++ b/clients/web/src/utils/avatar-surface.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for the avatar-tinted full-bleed surface helpers (`blendHex`,
+ * `avatarSurfaceHex`): the deep ground the takeover paints behind an avatar's
+ * accent color, which must stay dark enough for white UI to read on top.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { BUNDLED_COMPONENTS } from "./avatar-bundled-components";
+import { SURFACE_GROUND, avatarSurfaceHex, blendHex } from "./avatar-tone";
+
+/** WCAG relative luminance of a #rrggbb hex. */
+function luminance(hex: string): number {
+  const n = parseInt(hex.replace("#", ""), 16);
+  const ch = (shift: number) => {
+    const c = ((n >> shift) & 0xff) / 255;
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * ch(16) + 0.7152 * ch(8) + 0.0722 * ch(0);
+}
+
+function contrastRatio(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi! + 0.05) / (lo! + 0.05);
+}
+
+function channels(hex: string): [number, number, number] {
+  const n = parseInt(hex.replace("#", ""), 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
+
+describe("avatarSurfaceHex", () => {
+  test("green avatar reproduces the takeover's established surface", () => {
+    const derived = channels(avatarSurfaceHex("#4C9B50"));
+    const target = channels("#1D271E");
+    for (const [i, c] of derived.entries()) {
+      expect(Math.abs(c - target[i]!)).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test("every bundled palette color clears 7:1 against white", () => {
+    for (const { hex } of BUNDLED_COMPONENTS.colors) {
+      expect(contrastRatio(avatarSurfaceHex(hex), "#FFFFFF")).toBeGreaterThanOrEqual(7);
+    }
+  });
+
+  test("malformed accents degrade to the ground", () => {
+    for (const bad of ["rebeccapurple", "#GGG", ""]) {
+      expect(avatarSurfaceHex(bad)).toBe(SURFACE_GROUND);
+    }
+  });
+});
+
+describe("blendHex", () => {
+  test("alpha 0 is the base, alpha 1 is the overlay", () => {
+    expect(blendHex("#151515", "#4C9B50", 0).toLowerCase()).toBe("#151515");
+    expect(blendHex("#151515", "#4C9B50", 1).toLowerCase()).toBe("#4c9b50");
+  });
+
+  test("alpha is clamped and malformed inputs return the base", () => {
+    expect(blendHex("#151515", "#4C9B50", -1).toLowerCase()).toBe("#151515");
+    expect(blendHex("#151515", "#4C9B50", 2).toLowerCase()).toBe("#4c9b50");
+    expect(blendHex("#151515", "nope", 0.5)).toBe("#151515");
+  });
+});

--- a/clients/web/src/utils/avatar-tone.ts
+++ b/clients/web/src/utils/avatar-tone.ts
@@ -45,6 +45,9 @@ export interface AvatarTone {
 const FG_DARK = "#1A1A1A";
 const FG_LIGHT = "#FFFFFF";
 
+/** Near-black ground that avatar-tinted full-bleed surfaces blend over. */
+export const SURFACE_GROUND = "#151515";
+
 /** Perceived brightness (YIQ), 0–1. */
 function brightness(hex: string): number {
   const m = /^#?([0-9a-f]{6})$/i.exec(hex);
@@ -68,6 +71,34 @@ export function darkenHex(hex: string, factor: number): string {
   const ch = (shift: number) =>
     Math.max(0, Math.min(255, Math.round(((n >> shift) & 0xff) * factor)));
   return `#${((1 << 24) | (ch(16) << 16) | (ch(8) << 8) | ch(0)).toString(16).slice(1)}`;
+}
+
+/**
+ * Composite `overlay` at `alpha` over the solid `base`, returning the resulting
+ * opaque #rrggbb. Either hex may carry a leading `#`; a malformed input returns
+ * `base` unchanged, and `alpha` is clamped to 0–1.
+ */
+export function blendHex(base: string, overlay: string, alpha: number): string {
+  const b = /^#?([0-9a-f]{6})$/i.exec(base);
+  const o = /^#?([0-9a-f]{6})$/i.exec(overlay);
+  if (!b || !o) {
+    return base;
+  }
+  const a = Math.max(0, Math.min(1, alpha));
+  const bn = parseInt(b[1]!, 16);
+  const on = parseInt(o[1]!, 16);
+  const mix = (shift: number) =>
+    Math.round(((bn >> shift) & 0xff) * (1 - a) + ((on >> shift) & 0xff) * a);
+  return `#${((1 << 24) | (mix(16) << 16) | (mix(8) << 8) | mix(0)).toString(16).slice(1)}`;
+}
+
+/**
+ * Deep full-bleed surface for an avatar accent: the accent washed over
+ * {@link SURFACE_GROUND}. 0.14 is calibrated so the green character reproduces
+ * the takeover's established `#1D271E`.
+ */
+export function avatarSurfaceHex(accentHex: string): string {
+  return blendHex(SURFACE_GROUND, accentHex, 0.14);
 }
 
 /**

--- a/clients/web/src/utils/avatar-tone.ts
+++ b/clients/web/src/utils/avatar-tone.ts
@@ -108,15 +108,12 @@ export function avatarSurfaceHex(accentHex: string): string {
  * text is picked against this, not the raw avatar color, so contrast reflects
  * what the eye sees.
  */
-function compositeOverlay(base: string, overlay: 0 | 255, alpha: number): string {
-  const m = /^#?([0-9a-f]{6})$/i.exec(base);
-  if (!m) {
-    return base;
-  }
-  const n = parseInt(m[1]!, 16);
-  const mix = (shift: number) =>
-    Math.round(((n >> shift) & 0xff) * (1 - alpha) + overlay * alpha);
-  return `#${((1 << 24) | (mix(16) << 16) | (mix(8) << 8) | mix(0)).toString(16).slice(1)}`;
+function compositeOverlay(
+  base: string,
+  overlay: 0 | 255,
+  alpha: number,
+): string {
+  return blendHex(base, overlay === 255 ? "#ffffff" : "#000000", alpha);
 }
 
 /** WCAG relative luminance (sRGB-linearized), 0–1. */


### PR DESCRIPTION
## Summary
- Adds `blendHex` and `avatarSurfaceHex` to `avatar-tone.ts`, deriving a deep full-bleed surface tint from an avatar accent hex.
- The 0.14 blend over `#151515` is calibrated so the green character reproduces the takeover's established `#1D271E`.

Part of plan: takeover-avatar-tinted-background.md (PR 1 of 5)