### PR TITLE
feat(web): land the takeover's avatar, color, and backdrop on one beat

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-backdrop.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-backdrop.test.tsx
@@ -34,7 +34,8 @@ describe("TakeoverBackdrop", () => {
     );
     const image = container.querySelector("img");
     expect(image?.style.filter).toBe("blur(60px)");
-    expect(image?.className).toContain("h-[130%]");
-    expect(image?.className).toContain("w-[130%]");
+    // Over-scan is 2x the 60px radius per side, so each axis grows by 240px.
+    expect(image?.style.width.replace(/\s/g, "")).toBe("calc(100%+240px)");
+    expect(image?.style.height.replace(/\s/g, "")).toBe("calc(100%+240px)");
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-backdrop.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-backdrop.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Tests for the presentational takeover backdrop. The visual contract is the
+ * blur radius and the over-scan, so those are asserted directly.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { TakeoverBackdrop } from "./takeover-backdrop";
+
+afterEach(cleanup);
+
+describe("TakeoverBackdrop", () => {
+  test("renders the passed image URL with an empty alt", () => {
+    const { container } = render(
+      <TakeoverBackdrop imageUrl="https://cdn.test/avatar.png" />,
+    );
+    const image = container.querySelector("img");
+    expect(image?.getAttribute("src")).toBe("https://cdn.test/avatar.png");
+    expect(image?.getAttribute("alt")).toBe("");
+  });
+
+  test("hides the decorative layer from the accessibility tree", () => {
+    const { getByTestId } = render(
+      <TakeoverBackdrop imageUrl="https://cdn.test/avatar.png" />,
+    );
+    expect(getByTestId("takeover-backdrop").getAttribute("aria-hidden")).toBe(
+      "true",
+    );
+  });
+
+  test("blurs and over-scans the image", () => {
+    const { container } = render(
+      <TakeoverBackdrop imageUrl="https://cdn.test/avatar.png" />,
+    );
+    const image = container.querySelector("img");
+    expect(image?.style.filter).toBe("blur(60px)");
+    expect(image?.className).toContain("h-[130%]");
+    expect(image?.className).toContain("w-[130%]");
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-backdrop.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-backdrop.tsx
@@ -1,3 +1,7 @@
+const BLUR_RADIUS_PX = 60;
+/** Over-scan per side is 2x the blur radius, so the layer grows by 4x on each axis. */
+const OVERSCAN_PX = BLUR_RADIUS_PX * 2;
+
 /**
  * Decorative backdrop for the provisioning takeover: the avatar image blurred
  * behind a scrim, so the takeover's ground picks up the avatar's color.
@@ -10,15 +14,19 @@ export function TakeoverBackdrop({ imageUrl }: { imageUrl: string }) {
       className="provision-backdrop-reveal pointer-events-none absolute inset-0 overflow-hidden"
     >
       {/* `blur()` samples transparent outside the element, so the layer
-          over-scans the container by more than the radius — otherwise the
-          edges fade to the ground color. */}
+          over-scans the container by an absolute amount tied to the radius —
+          otherwise the edges fade to the ground color on narrow surfaces. */}
       <img
         src={imageUrl}
         alt=""
         decoding="async"
         draggable={false}
-        className="absolute left-1/2 top-1/2 h-[130%] w-[130%] max-w-none -translate-x-1/2 -translate-y-1/2 object-cover object-center"
-        style={{ filter: "blur(60px)" }}
+        className="absolute left-1/2 top-1/2 max-w-none -translate-x-1/2 -translate-y-1/2 object-cover object-center"
+        style={{
+          filter: `blur(${BLUR_RADIUS_PX}px)`,
+          width: `calc(100% + ${OVERSCAN_PX * 2}px)`,
+          height: `calc(100% + ${OVERSCAN_PX * 2}px)`,
+        }}
       />
       <div className="absolute inset-0 bg-black/55" />
     </div>

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-backdrop.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-backdrop.tsx
@@ -1,0 +1,26 @@
+/**
+ * Decorative backdrop for the provisioning takeover: the avatar image blurred
+ * behind a scrim, so the takeover's ground picks up the avatar's color.
+ */
+export function TakeoverBackdrop({ imageUrl }: { imageUrl: string }) {
+  return (
+    <div
+      aria-hidden
+      data-testid="takeover-backdrop"
+      className="provision-backdrop-reveal pointer-events-none absolute inset-0 overflow-hidden"
+    >
+      {/* `blur()` samples transparent outside the element, so the layer
+          over-scans the container by more than the radius — otherwise the
+          edges fade to the ground color. */}
+      <img
+        src={imageUrl}
+        alt=""
+        decoding="async"
+        draggable={false}
+        className="absolute left-1/2 top-1/2 h-[130%] w-[130%] max-w-none -translate-x-1/2 -translate-y-1/2 object-cover object-center"
+        style={{ filter: "blur(60px)" }}
+      />
+      <div className="absolute inset-0 bg-black/55" />
+    </div>
+  );
+}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -356,13 +356,32 @@ body {
   to { opacity: 1; }
 }
 
+/* The takeover's arrival beat: the avatar, the surface color, and the blurred
+ * backdrop all resolve on this one duration. */
+:root {
+  --provision-reveal: 250ms;
+}
+
 .provision-avatar-reveal {
-  animation: provision-avatar-reveal 250ms ease-out both;
+  animation: provision-avatar-reveal var(--provision-reveal) ease-out both;
+}
+
+.provision-surface-settle {
+  transition: background-color var(--provision-reveal) ease-out;
+}
+
+.provision-backdrop-reveal {
+  animation: provision-avatar-reveal var(--provision-reveal) ease-out both;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .provision-avatar-reveal {
+  .provision-avatar-reveal,
+  .provision-backdrop-reveal {
     animation: none;
+  }
+
+  .provision-surface-settle {
+    transition: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- Hoists the takeover avatar reveal's 250ms into a shared `--provision-reveal` custom property, with matching surface-settle and backdrop-reveal classes so the entrance lands on one beat.
- Adds `TakeoverBackdrop`, a presentational blurred-and-scrimmed image layer for custom-avatar takeovers.

Part of plan: takeover-avatar-tinted-background.md (PR 2 of 5)