### PR TITLE
feat(routes): gate /x/* execution on the route host via `userRoutes.host.enabled`

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -58,6 +58,7 @@ import {
   TimeoutConfigSchema,
 } from "./schemas/timeouts.js";
 import { ToolsConfigSchema } from "./schemas/tools.js";
+import { UserRoutesConfigSchema } from "./schemas/user-routes.js";
 import { WorkflowsConfigSchema } from "./schemas/workflows.js";
 import { WorkspaceGitConfigSchema } from "./schemas/workspace-git.js";
 
@@ -66,6 +67,7 @@ export const AssistantConfigSchema = z.object({
   memory: MemoryConfigSchema.default(MemoryConfigSchema.parse({})),
   monitoring: MonitoringConfigSchema.default(MonitoringConfigSchema.parse({})),
   migrations: MigrationsConfigSchema.default(MigrationsConfigSchema.parse({})),
+  userRoutes: UserRoutesConfigSchema.default(UserRoutesConfigSchema.parse({})),
   dataDir: z
     .string({ error: "dataDir must be a string" })
     .default(getDataDir())

--- a/assistant/src/config/schemas/__tests__/user-routes.test.ts
+++ b/assistant/src/config/schemas/__tests__/user-routes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { UserRoutesConfigSchema } from "../user-routes.js";
+
+describe("UserRoutesConfigSchema", () => {
+  test("defaults host.enabled to false", () => {
+    expect(UserRoutesConfigSchema.parse({})).toEqual({
+      host: { enabled: false },
+    });
+  });
+
+  test("accepts host.enabled: true", () => {
+    expect(UserRoutesConfigSchema.parse({ host: { enabled: true } })).toEqual({
+      host: { enabled: true },
+    });
+  });
+
+  test("rejects a non-boolean enabled", () => {
+    expect(() =>
+      UserRoutesConfigSchema.parse({ host: { enabled: "yes" } }),
+    ).toThrow();
+  });
+});

--- a/assistant/src/config/schemas/user-routes.ts
+++ b/assistant/src/config/schemas/user-routes.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+/**
+ * User-defined route (`/x/*`) execution configuration.
+ *
+ * By default, route handlers run inline on the daemon's event loop. Enabling the
+ * route host runs each handler in a dedicated subprocess instead, so a handler
+ * that blocks synchronously pins only the host process (the daemon stays
+ * responsive) and a wedged handler can be reclaimed with a hard kill.
+ */
+export const UserRoutesConfigSchema = z
+  .object({
+    host: z
+      .object({
+        enabled: z
+          .boolean()
+          .default(false)
+          .describe(
+            "Run user-defined /x/* route handlers in a dedicated subprocess (the route host) instead of inline on the daemon's event loop. When on, a handler that blocks synchronously pins only the host process and a wedged handler is reclaimed with a hard kill; the next request respawns the host. Default false (in-band execution).",
+          ),
+      })
+      .default({ enabled: false })
+      .describe("Route host subprocess configuration."),
+  })
+  .describe("User-defined route (/x/*) execution configuration.");
+
+export type UserRoutesConfig = z.infer<typeof UserRoutesConfigSchema>;

--- a/assistant/src/routes/control.ts
+++ b/assistant/src/routes/control.ts
@@ -15,7 +15,7 @@
  * respawns the host.
  */
 
-import { getConfig } from "../config/loader.js";
+import { getConfigReadOnly } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
 import { getProcPidPath } from "../util/platform.js";
 import {
@@ -36,7 +36,7 @@ const log = getLogger("route-host-control");
  * edit (hot-reloaded by the config watcher) takes effect without a restart.
  */
 export function isRouteHostEnabled(): boolean {
-  return getConfig().userRoutes.host.enabled;
+  return getConfigReadOnly().userRoutes.host.enabled;
 }
 
 function routeHostPidPath(): string {

--- a/assistant/src/routes/control.ts
+++ b/assistant/src/routes/control.ts
@@ -15,6 +15,7 @@
  * respawns the host.
  */
 
+import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
 import { getProcPidPath } from "../util/platform.js";
 import {
@@ -28,6 +29,15 @@ import {
 import { ROUTE_HOST_PROC_NAME } from "./route-host-protocol.js";
 
 const log = getLogger("route-host-control");
+
+/**
+ * Whether `/x/*` handlers should execute in the route host subprocess rather
+ * than inline on the daemon's event loop. Read per-request so a `config.json`
+ * edit (hot-reloaded by the config watcher) takes effect without a restart.
+ */
+export function isRouteHostEnabled(): boolean {
+  return getConfig().userRoutes.host.enabled;
+}
 
 function routeHostPidPath(): string {
   return getProcPidPath(ROUTE_HOST_PROC_NAME);

--- a/assistant/src/routes/route-host-client.ts
+++ b/assistant/src/routes/route-host-client.ts
@@ -143,14 +143,25 @@ export class RouteHostClient {
   }
 
   private async spawnAndConnect(): Promise<Socket> {
-    const { pid } = await spawnWorkerProcess({
-      pidPath: this.pidPath,
-      entry: this.workerEntryUrl,
-      workerLabel: "Route host",
-      // Owned by the daemon (appears in its process tree, torn down with it);
-      // kill it if it hangs during startup so a failed spawn leaves nothing.
-      options: { detached: false, terminateOnTimeout: true },
-    });
+    let pid: number;
+    try {
+      ({ pid } = await spawnWorkerProcess({
+        pidPath: this.pidPath,
+        entry: this.workerEntryUrl,
+        workerLabel: "Route host",
+        // Owned by the daemon (appears in its process tree, torn down with it);
+        // kill it if it hangs during startup so a failed spawn leaves nothing.
+        options: { detached: false, terminateOnTimeout: true },
+      }));
+    } catch (err) {
+      // A failed bring-up (crash-on-startup, PID-file timeout) is a retryable
+      // availability failure, not a handler error — surface it as such so the
+      // dispatcher maps it to a 503 rather than a 500.
+      const message = err instanceof Error ? err.message : String(err);
+      throw new RouteHostUnavailableError(
+        `route host failed to start: ${message}`,
+      );
+    }
     this.pid = pid;
 
     const socket = await new Promise<Socket>((resolve, reject) => {

--- a/assistant/src/runtime/routes/__tests__/user-route-dispatcher-host.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-route-dispatcher-host.test.ts
@@ -1,0 +1,197 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type {
+  RouteHostClient,
+  RouteInvokeResponse,
+} from "../../../routes/route-host-client.js";
+import {
+  RouteHostTimeoutError,
+  RouteHostUnavailableError,
+} from "../../../routes/route-host-client.js";
+import type { RouteInvokeParams } from "../../../routes/route-host-protocol.js";
+import { getWorkspaceRoutesDir } from "../../../util/platform.js";
+import { AssistantEventHub } from "../../assistant-event-hub.js";
+import type {
+  RouteHostBinding,
+  UserRouteContext,
+} from "../user-route-dispatcher.js";
+import { UserRouteDispatcher } from "../user-route-dispatcher.js";
+
+function context(): UserRouteContext {
+  return {
+    assistantEventHub: new AssistantEventHub(),
+    conversations: { postMessage: async () => ({ messageId: "m" }) },
+  };
+}
+
+function writeHandler(name: string, content: string): void {
+  const full = join(getWorkspaceRoutesDir(), name);
+  mkdirSync(getWorkspaceRoutesDir(), { recursive: true });
+  writeFileSync(full, content);
+}
+
+afterEach(() => {
+  rmSync(getWorkspaceRoutesDir(), { recursive: true, force: true });
+});
+
+interface InvokeCall {
+  params: RouteInvokeParams;
+  body: Uint8Array | null;
+}
+
+/** A fake RouteHostClient recording invocations, with a scriptable reply. */
+function fakeHost(reply: (call: InvokeCall) => Promise<RouteInvokeResponse>): {
+  binding: (enabled: boolean) => RouteHostBinding;
+  calls: InvokeCall[];
+} {
+  const calls: InvokeCall[] = [];
+  const client = {
+    invoke: async (params: RouteInvokeParams, body: Uint8Array | null) => {
+      const call = { params, body };
+      calls.push(call);
+      return reply(call);
+    },
+  } as unknown as RouteHostClient;
+  return {
+    calls,
+    binding: (enabled: boolean) => ({ client, isEnabled: () => enabled }),
+  };
+}
+
+function jsonResponse(status: number, value: unknown): RouteInvokeResponse {
+  return {
+    status,
+    headers: [["content-type", "application/json"]],
+    body: new TextEncoder().encode(JSON.stringify(value)),
+  };
+}
+
+describe("UserRouteDispatcher — route host delegation", () => {
+  test("delegates to the host when enabled (in-band handler never runs)", async () => {
+    // If the in-band path ran, it would return {via:"in-band"}; the host reply
+    // returns {via:"host"}, so the response distinguishes which path executed.
+    writeHandler(
+      "foo.ts",
+      `export function GET() { return Response.json({ via: "in-band" }); }`,
+    );
+    const host = fakeHost(async () => jsonResponse(200, { via: "host" }));
+    const dispatcher = new UserRouteDispatcher({
+      context: context(),
+      routeHost: host.binding(true),
+    });
+
+    const res = await dispatcher.dispatch(
+      "foo",
+      new Request("http://localhost/v1/x/foo", { method: "GET" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ via: "host" });
+    expect(host.calls).toHaveLength(1);
+    expect(host.calls[0].params.method).toBe("GET");
+    expect(host.calls[0].params.filePath.endsWith("foo.ts")).toBe(true);
+    expect(host.calls[0].params.url).toContain("/v1/x/foo");
+  });
+
+  test("runs in-band when disabled (host never called)", async () => {
+    writeHandler(
+      "bar.ts",
+      `export function GET() { return Response.json({ via: "in-band" }); }`,
+    );
+    const host = fakeHost(async () => jsonResponse(200, { via: "host" }));
+    const dispatcher = new UserRouteDispatcher({
+      context: context(),
+      routeHost: host.binding(false),
+    });
+
+    const res = await dispatcher.dispatch(
+      "bar",
+      new Request("http://localhost/v1/x/bar", { method: "GET" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ via: "in-band" });
+    expect(host.calls).toHaveLength(0);
+  });
+
+  test("forwards a POST body to the host", async () => {
+    writeHandler(
+      "echo.ts",
+      `export function POST() { return new Response(); }`,
+    );
+    const host = fakeHost(async (call) =>
+      jsonResponse(201, {
+        received: new TextDecoder().decode(call.body ?? new Uint8Array()),
+      }),
+    );
+    const dispatcher = new UserRouteDispatcher({
+      context: context(),
+      routeHost: host.binding(true),
+    });
+
+    const res = await dispatcher.dispatch(
+      "echo",
+      new Request("http://localhost/v1/x/echo", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ hello: "world" }),
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({
+      received: JSON.stringify({ hello: "world" }),
+    });
+  });
+
+  test("maps a host timeout to 504", async () => {
+    writeHandler("slow.ts", `export function GET() { return new Response(); }`);
+    const host = fakeHost(async () => {
+      throw new RouteHostTimeoutError(1000);
+    });
+    const dispatcher = new UserRouteDispatcher({
+      context: context(),
+      routeHost: host.binding(true),
+    });
+
+    const res = await dispatcher.dispatch(
+      "slow",
+      new Request("http://localhost/v1/x/slow", { method: "GET" }),
+    );
+    expect(res.status).toBe(504);
+  });
+
+  test("maps host unavailable to 503", async () => {
+    writeHandler("down.ts", `export function GET() { return new Response(); }`);
+    const host = fakeHost(async () => {
+      throw new RouteHostUnavailableError("route host killed");
+    });
+    const dispatcher = new UserRouteDispatcher({
+      context: context(),
+      routeHost: host.binding(true),
+    });
+
+    const res = await dispatcher.dispatch(
+      "down",
+      new Request("http://localhost/v1/x/down", { method: "GET" }),
+    );
+    expect(res.status).toBe(503);
+  });
+
+  test("unknown route 404s without touching the host", async () => {
+    const host = fakeHost(async () => jsonResponse(200, {}));
+    const dispatcher = new UserRouteDispatcher({
+      context: context(),
+      routeHost: host.binding(true),
+    });
+
+    const res = await dispatcher.dispatch(
+      "does-not-exist",
+      new Request("http://localhost/v1/x/does-not-exist", { method: "GET" }),
+    );
+    expect(res.status).toBe(404);
+    expect(host.calls).toHaveLength(0);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/user-route-dispatcher-host.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-route-dispatcher-host.test.ts
@@ -1,23 +1,51 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type {
-  RouteHostClient,
-  RouteInvokeResponse,
-} from "../../../routes/route-host-client.js";
-import {
-  RouteHostTimeoutError,
-  RouteHostUnavailableError,
-} from "../../../routes/route-host-client.js";
 import type { RouteInvokeParams } from "../../../routes/route-host-protocol.js";
 import { getWorkspaceRoutesDir } from "../../../util/platform.js";
 import { AssistantEventHub } from "../../assistant-event-hub.js";
-import type {
-  RouteHostBinding,
-  UserRouteContext,
-} from "../user-route-dispatcher.js";
-import { UserRouteDispatcher } from "../user-route-dispatcher.js";
+import type { UserRouteContext } from "../user-route-dispatcher.js";
+
+// The dispatcher constructs the route host client inline and reads the enabled
+// flag from config, so both are mocked here (there is no injection seam).
+interface RouteInvokeResponse {
+  status: number;
+  headers: [string, string][];
+  body: Uint8Array | null;
+}
+interface InvokeCall {
+  params: RouteInvokeParams;
+  body: Uint8Array | null;
+}
+
+let hostEnabled = false;
+let invokeImpl: (call: InvokeCall) => Promise<RouteInvokeResponse>;
+const invokeCalls: InvokeCall[] = [];
+
+class FakeTimeoutError extends Error {
+  constructor(public readonly timeoutMs: number) {
+    super(`route handler timed out after ${timeoutMs}ms`);
+  }
+}
+class FakeUnavailableError extends Error {}
+
+mock.module("../../../routes/control.js", () => ({
+  isRouteHostEnabled: () => hostEnabled,
+}));
+mock.module("../../../routes/route-host-client.js", () => ({
+  RouteHostClient: class {
+    async invoke(params: RouteInvokeParams, body: Uint8Array | null) {
+      const call = { params, body };
+      invokeCalls.push(call);
+      return invokeImpl(call);
+    }
+  },
+  RouteHostTimeoutError: FakeTimeoutError,
+  RouteHostUnavailableError: FakeUnavailableError,
+}));
+
+const { UserRouteDispatcher } = await import("../user-route-dispatcher.js");
 
 function context(): UserRouteContext {
   return {
@@ -26,38 +54,13 @@ function context(): UserRouteContext {
   };
 }
 
+function makeDispatcher() {
+  return new UserRouteDispatcher({ context: context() });
+}
+
 function writeHandler(name: string, content: string): void {
-  const full = join(getWorkspaceRoutesDir(), name);
   mkdirSync(getWorkspaceRoutesDir(), { recursive: true });
-  writeFileSync(full, content);
-}
-
-afterEach(() => {
-  rmSync(getWorkspaceRoutesDir(), { recursive: true, force: true });
-});
-
-interface InvokeCall {
-  params: RouteInvokeParams;
-  body: Uint8Array | null;
-}
-
-/** A fake RouteHostClient recording invocations, with a scriptable reply. */
-function fakeHost(reply: (call: InvokeCall) => Promise<RouteInvokeResponse>): {
-  binding: (enabled: boolean) => RouteHostBinding;
-  calls: InvokeCall[];
-} {
-  const calls: InvokeCall[] = [];
-  const client = {
-    invoke: async (params: RouteInvokeParams, body: Uint8Array | null) => {
-      const call = { params, body };
-      calls.push(call);
-      return reply(call);
-    },
-  } as unknown as RouteHostClient;
-  return {
-    calls,
-    binding: (enabled: boolean) => ({ client, isEnabled: () => enabled }),
-  };
+  writeFileSync(join(getWorkspaceRoutesDir(), name), content);
 }
 
 function jsonResponse(status: number, value: unknown): RouteInvokeResponse {
@@ -68,19 +71,26 @@ function jsonResponse(status: number, value: unknown): RouteInvokeResponse {
   };
 }
 
+beforeEach(() => {
+  hostEnabled = false;
+  invokeImpl = async () => jsonResponse(200, { via: "host" });
+  invokeCalls.length = 0;
+});
+
+afterEach(() => {
+  rmSync(getWorkspaceRoutesDir(), { recursive: true, force: true });
+});
+
 describe("UserRouteDispatcher — route host delegation", () => {
   test("delegates to the host when enabled (in-band handler never runs)", async () => {
-    // If the in-band path ran, it would return {via:"in-band"}; the host reply
+    // If the in-band path ran it would return {via:"in-band"}; the host reply
     // returns {via:"host"}, so the response distinguishes which path executed.
     writeHandler(
       "foo.ts",
       `export function GET() { return Response.json({ via: "in-band" }); }`,
     );
-    const host = fakeHost(async () => jsonResponse(200, { via: "host" }));
-    const dispatcher = new UserRouteDispatcher({
-      context: context(),
-      routeHost: host.binding(true),
-    });
+    hostEnabled = true;
+    const dispatcher = makeDispatcher();
 
     const res = await dispatcher.dispatch(
       "foo",
@@ -89,10 +99,10 @@ describe("UserRouteDispatcher — route host delegation", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ via: "host" });
-    expect(host.calls).toHaveLength(1);
-    expect(host.calls[0].params.method).toBe("GET");
-    expect(host.calls[0].params.filePath.endsWith("foo.ts")).toBe(true);
-    expect(host.calls[0].params.url).toContain("/v1/x/foo");
+    expect(invokeCalls).toHaveLength(1);
+    expect(invokeCalls[0].params.method).toBe("GET");
+    expect(invokeCalls[0].params.filePath.endsWith("foo.ts")).toBe(true);
+    expect(invokeCalls[0].params.url).toContain("/v1/x/foo");
   });
 
   test("runs in-band when disabled (host never called)", async () => {
@@ -100,11 +110,8 @@ describe("UserRouteDispatcher — route host delegation", () => {
       "bar.ts",
       `export function GET() { return Response.json({ via: "in-band" }); }`,
     );
-    const host = fakeHost(async () => jsonResponse(200, { via: "host" }));
-    const dispatcher = new UserRouteDispatcher({
-      context: context(),
-      routeHost: host.binding(false),
-    });
+    hostEnabled = false;
+    const dispatcher = makeDispatcher();
 
     const res = await dispatcher.dispatch(
       "bar",
@@ -113,7 +120,7 @@ describe("UserRouteDispatcher — route host delegation", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ via: "in-band" });
-    expect(host.calls).toHaveLength(0);
+    expect(invokeCalls).toHaveLength(0);
   });
 
   test("forwards a POST body to the host", async () => {
@@ -121,15 +128,12 @@ describe("UserRouteDispatcher — route host delegation", () => {
       "echo.ts",
       `export function POST() { return new Response(); }`,
     );
-    const host = fakeHost(async (call) =>
+    hostEnabled = true;
+    invokeImpl = async (call) =>
       jsonResponse(201, {
         received: new TextDecoder().decode(call.body ?? new Uint8Array()),
-      }),
-    );
-    const dispatcher = new UserRouteDispatcher({
-      context: context(),
-      routeHost: host.binding(true),
-    });
+      });
+    const dispatcher = makeDispatcher();
 
     const res = await dispatcher.dispatch(
       "echo",
@@ -148,13 +152,11 @@ describe("UserRouteDispatcher — route host delegation", () => {
 
   test("maps a host timeout to 504", async () => {
     writeHandler("slow.ts", `export function GET() { return new Response(); }`);
-    const host = fakeHost(async () => {
-      throw new RouteHostTimeoutError(1000);
-    });
-    const dispatcher = new UserRouteDispatcher({
-      context: context(),
-      routeHost: host.binding(true),
-    });
+    hostEnabled = true;
+    invokeImpl = async () => {
+      throw new FakeTimeoutError(1000);
+    };
+    const dispatcher = makeDispatcher();
 
     const res = await dispatcher.dispatch(
       "slow",
@@ -163,15 +165,13 @@ describe("UserRouteDispatcher — route host delegation", () => {
     expect(res.status).toBe(504);
   });
 
-  test("maps host unavailable to 503", async () => {
+  test("maps host unavailable (incl. failed startup) to 503", async () => {
     writeHandler("down.ts", `export function GET() { return new Response(); }`);
-    const host = fakeHost(async () => {
-      throw new RouteHostUnavailableError("route host killed");
-    });
-    const dispatcher = new UserRouteDispatcher({
-      context: context(),
-      routeHost: host.binding(true),
-    });
+    hostEnabled = true;
+    invokeImpl = async () => {
+      throw new FakeUnavailableError("route host failed to start");
+    };
+    const dispatcher = makeDispatcher();
 
     const res = await dispatcher.dispatch(
       "down",
@@ -181,17 +181,14 @@ describe("UserRouteDispatcher — route host delegation", () => {
   });
 
   test("unknown route 404s without touching the host", async () => {
-    const host = fakeHost(async () => jsonResponse(200, {}));
-    const dispatcher = new UserRouteDispatcher({
-      context: context(),
-      routeHost: host.binding(true),
-    });
+    hostEnabled = true;
+    const dispatcher = makeDispatcher();
 
     const res = await dispatcher.dispatch(
       "does-not-exist",
       new Request("http://localhost/v1/x/does-not-exist", { method: "GET" }),
     );
     expect(res.status).toBe(404);
-    expect(host.calls).toHaveLength(0);
+    expect(invokeCalls).toHaveLength(0);
   });
 });

--- a/assistant/src/runtime/routes/user-route-dispatcher.ts
+++ b/assistant/src/runtime/routes/user-route-dispatcher.ts
@@ -29,8 +29,9 @@
 
 import { statSync } from "node:fs";
 
-import type { RouteHostClient } from "../../routes/route-host-client.js";
+import { isRouteHostEnabled } from "../../routes/control.js";
 import {
+  RouteHostClient,
   RouteHostTimeoutError,
   RouteHostUnavailableError,
 } from "../../routes/route-host-client.js";
@@ -132,36 +133,29 @@ interface CachedModule {
 /** Default per-request timeout for user-defined route handlers (30 seconds). */
 const DEFAULT_HANDLER_TIMEOUT_MS = 30_000;
 
-/**
- * Off-daemon execution binding: the route host client plus a per-request check
- * of whether the host is enabled in config. When enabled, handler execution is
- * delegated to the subprocess instead of running inline.
- */
-export interface RouteHostBinding {
-  readonly client: RouteHostClient;
-  readonly isEnabled: () => boolean;
-}
-
 export class UserRouteDispatcher {
   private moduleCache = new Map<string, CachedModule>();
   private handlerTimeoutMs: number;
   private context: UserRouteContext;
-  private routeHost?: RouteHostBinding;
+  /**
+   * Lazily created on the first request that runs while the route host is
+   * enabled. Constructing it is inert (the subprocess spawns lazily on the
+   * client's first `invoke`), so a dispatcher whose host is never enabled never
+   * creates one.
+   */
+  private routeHostClient: RouteHostClient | undefined;
 
   constructor(options: {
     handlerTimeoutMs?: number;
     context: UserRouteContext;
-    /**
-     * When present and `isEnabled()` returns true at dispatch time, handler
-     * execution is delegated to the route host subprocess. Resolution, path
-     * traversal, and 404s stay on the main thread. See {@link RouteHostClient}.
-     */
-    routeHost?: RouteHostBinding;
   }) {
     this.handlerTimeoutMs =
       options.handlerTimeoutMs ?? DEFAULT_HANDLER_TIMEOUT_MS;
     this.context = Object.freeze({ ...options.context });
-    this.routeHost = options.routeHost;
+  }
+
+  private getRouteHostClient(): RouteHostClient {
+    return (this.routeHostClient ??= new RouteHostClient());
   }
 
   /**
@@ -189,7 +183,7 @@ export class UserRouteDispatcher {
       );
     }
 
-    if (this.routeHost?.isEnabled()) {
+    if (isRouteHostEnabled()) {
       return this.dispatchViaHost(filePath, routePath, request);
     }
 
@@ -233,7 +227,7 @@ export class UserRouteDispatcher {
     }
 
     try {
-      const result = await this.routeHost!.client.invoke(
+      const result = await this.getRouteHostClient().invoke(
         {
           filePath,
           mtimeMs,

--- a/assistant/src/runtime/routes/user-route-dispatcher.ts
+++ b/assistant/src/runtime/routes/user-route-dispatcher.ts
@@ -29,6 +29,11 @@
 
 import { statSync } from "node:fs";
 
+import type { RouteHostClient } from "../../routes/route-host-client.js";
+import {
+  RouteHostTimeoutError,
+  RouteHostUnavailableError,
+} from "../../routes/route-host-client.js";
 import { getLogger } from "../../util/logger.js";
 import type { AssistantEventHub } from "../assistant-event-hub.js";
 import { httpError } from "../http-errors.js";
@@ -127,18 +132,36 @@ interface CachedModule {
 /** Default per-request timeout for user-defined route handlers (30 seconds). */
 const DEFAULT_HANDLER_TIMEOUT_MS = 30_000;
 
+/**
+ * Off-daemon execution binding: the route host client plus a per-request check
+ * of whether the host is enabled in config. When enabled, handler execution is
+ * delegated to the subprocess instead of running inline.
+ */
+export interface RouteHostBinding {
+  readonly client: RouteHostClient;
+  readonly isEnabled: () => boolean;
+}
+
 export class UserRouteDispatcher {
   private moduleCache = new Map<string, CachedModule>();
   private handlerTimeoutMs: number;
   private context: UserRouteContext;
+  private routeHost?: RouteHostBinding;
 
   constructor(options: {
     handlerTimeoutMs?: number;
     context: UserRouteContext;
+    /**
+     * When present and `isEnabled()` returns true at dispatch time, handler
+     * execution is delegated to the route host subprocess. Resolution, path
+     * traversal, and 404s stay on the main thread. See {@link RouteHostClient}.
+     */
+    routeHost?: RouteHostBinding;
   }) {
     this.handlerTimeoutMs =
       options.handlerTimeoutMs ?? DEFAULT_HANDLER_TIMEOUT_MS;
     this.context = Object.freeze({ ...options.context });
+    this.routeHost = options.routeHost;
   }
 
   /**
@@ -166,6 +189,10 @@ export class UserRouteDispatcher {
       );
     }
 
+    if (this.routeHost?.isEnabled()) {
+      return this.dispatchViaHost(filePath, routePath, request);
+    }
+
     const mod = await this.loadModule(filePath);
     const method = request.method as HttpMethod;
     const handler = mod.handlers[method];
@@ -179,6 +206,73 @@ export class UserRouteDispatcher {
     }
 
     return this.executeHandler(handler, request, routePath);
+  }
+
+  /**
+   * Delegate execution to the route host subprocess. The main thread has
+   * already resolved `filePath` (and 404'd if missing); here it marshals the
+   * request, hands it to the host, and rebuilds a `Response` from the reply.
+   * Maps the host's typed failures to HTTP: timeout → 504, host unavailable →
+   * 503, and a handler that threw → 500 (matching the in-thread contract).
+   */
+  private async dispatchViaHost(
+    filePath: string,
+    routePath: string,
+    request: Request,
+  ): Promise<Response> {
+    const mtimeMs = statSync(filePath).mtimeMs;
+
+    const headers: [string, string][] = [];
+    request.headers.forEach((value, name) => {
+      headers.push([name, value]);
+    });
+    let body: Uint8Array | null = null;
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      const buffer = new Uint8Array(await request.arrayBuffer());
+      body = buffer.byteLength > 0 ? buffer : null;
+    }
+
+    try {
+      const result = await this.routeHost!.client.invoke(
+        {
+          filePath,
+          mtimeMs,
+          method: request.method,
+          url: request.url,
+          headers,
+        },
+        body,
+      );
+      const responseHeaders = new Headers();
+      for (const [name, value] of result.headers) {
+        responseHeaders.append(name, value);
+      }
+      // `Uint8Array` is a valid body at runtime; the cast placates the DOM lib's
+      // `Uint8Array<ArrayBuffer>` vs `ArrayBufferLike` generic mismatch.
+      return new Response(result.body as BodyInit | null, {
+        status: result.status,
+        headers: responseHeaders,
+      });
+    } catch (err) {
+      if (err instanceof RouteHostTimeoutError) {
+        return httpError(
+          "SERVICE_UNAVAILABLE",
+          `Route handler for /x/${routePath} timed out after ${err.timeoutMs}ms`,
+          504,
+        );
+      }
+      if (err instanceof RouteHostUnavailableError) {
+        return httpError(
+          "SERVICE_UNAVAILABLE",
+          `Route host is unavailable; retry shortly`,
+          503,
+        );
+      }
+      log.error({ err, routePath }, "User route handler threw an error");
+      const message =
+        err instanceof Error ? err.message : "Internal server error";
+      return httpError("INTERNAL_ERROR", message, 500);
+    }
   }
 
   /**

--- a/assistant/src/runtime/routes/user-routes.ts
+++ b/assistant/src/runtime/routes/user-routes.ts
@@ -16,11 +16,17 @@
  */
 
 import { postRouteConversationMessage } from "../../daemon/route-conversation-post.js";
+import { isRouteHostEnabled } from "../../routes/control.js";
+import { RouteHostClient } from "../../routes/route-host-client.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 import { RouteResponse } from "./types.js";
 import { UserRouteDispatcher } from "./user-route-dispatcher.js";
+
+// Constructed eagerly but inert: the client spawns the route host lazily on the
+// first request, and only when `userRoutes.host.enabled` gates dispatch to it.
+const routeHostClient = new RouteHostClient();
 
 const dispatcher = new UserRouteDispatcher({
   context: {
@@ -29,6 +35,7 @@ const dispatcher = new UserRouteDispatcher({
       postMessage: postRouteConversationMessage,
     },
   },
+  routeHost: { client: routeHostClient, isEnabled: isRouteHostEnabled },
 });
 
 /**

--- a/assistant/src/runtime/routes/user-routes.ts
+++ b/assistant/src/runtime/routes/user-routes.ts
@@ -16,17 +16,11 @@
  */
 
 import { postRouteConversationMessage } from "../../daemon/route-conversation-post.js";
-import { isRouteHostEnabled } from "../../routes/control.js";
-import { RouteHostClient } from "../../routes/route-host-client.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 import { RouteResponse } from "./types.js";
 import { UserRouteDispatcher } from "./user-route-dispatcher.js";
-
-// Constructed eagerly but inert: the client spawns the route host lazily on the
-// first request, and only when `userRoutes.host.enabled` gates dispatch to it.
-const routeHostClient = new RouteHostClient();
 
 const dispatcher = new UserRouteDispatcher({
   context: {
@@ -35,7 +29,6 @@ const dispatcher = new UserRouteDispatcher({
       postMessage: postRouteConversationMessage,
     },
   },
-  routeHost: { client: routeHostClient, isEnabled: isRouteHostEnabled },
 });
 
 /**


### PR DESCRIPTION
## Prompt / plan

Next roadmap items after the route host (#38789) and its CLI (#38836): the **`enabled` config flag** and the **dispatch integration** that consumes it. I combined them into one PR because a flag with no reader is dead code — this way the PR delivers actual, testable behavior. **Default is in-band, so nothing changes until you turn it on.**

- **config** — new `userRoutes.host.enabled` boolean (default `false`) in `schemas/user-routes.ts`, composed into `AssistantConfigSchema`.
- **`routes/control.ts`** — `isRouteHostEnabled()` reads the flag from `getConfig()` **per request**, so a `config.json` edit (hot-reloaded by the config watcher) takes effect without a restart.
- **`user-route-dispatcher.ts`** — when the host is enabled, `dispatch` still resolves the handler file on the main thread (path-traversal check + 404 unchanged), then delegates execution to the `RouteHostClient`: marshal the request, rebuild a `Response` from the reply. Typed failures map to HTTP — timeout → **504**, host unavailable → **503**, handler throw → **500** — matching the in-band contract.
- **`user-routes.ts`** — constructs the `RouteHostClient` (inert until the flag is on and the first request arrives, when it lazily spawns the host) and passes the binding to the dispatcher.

## Test plan

- `user-route-dispatcher-host.test.ts` (6) — with a fake host client: **delegates when enabled** (asserts the in-band handler never runs), **runs in-band when disabled** (host never called), forwards a POST body, maps **timeout → 504** and **unavailable → 503**, and **404s an unknown route** without touching the host.
- `user-routes.test.ts` config schema (3) — default `false`, accepts `true`, rejects non-boolean.
- Existing `user-route-dispatcher.test.ts` (28) still green.
- `bunx tsc --noEmit`, prettier, eslint clean; pre-commit hooks pass. (The `src/config/__tests__` dir shows 3 unrelated failures **only** when run in one process — cross-file `mock.module` pollution; each passes in isolation, and CI runs per-file via `scripts/test.ts`.)

## Follow-ups

- A host **pool** to isolate route-from-route (a single host serializes on its one loop until a stall is killed; the daemon stays responsive regardless).
- The plugin-api surface for out-of-process daemon access (publish / runConversationTurn), gated on DB-backed readiness + one-process-per-conversation.

## CLI verb checklist

No new routes — this gates existing `/x/*` execution on a config flag. Toggle it with the existing `assistant config` surface; `assistant routes worker` (#38836) manages the process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FosQeirkpt7G1K2SSbMx1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01FosQeirkpt7G1K2SSbMx1N)_