### PR TITLE
refactor(providers): break the registry/attribution import cycle

### DIFF
--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -54,11 +54,6 @@ import {
   MANAGED_ROUTABLE_PROVIDERS,
 } from "./vellum-model-routing.js";
 
-// Re-exported for the many existing importers; the definitions moved to
-// `routing-identity.ts` so `usage/attribution.ts` can use them without
-// importing this module (this file sits on the registry/attribution import
-// cycle that the move broke — see routing-identity.ts). New code should
-// import them from there.
 export { ConnectionResolutionError, resolveRoutingIdentity };
 
 const log = getLogger("providers/connection-resolution");

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -33,109 +33,35 @@ import {
 } from "../config/llm-resolver.js";
 import { getDb } from "../persistence/db-connection.js";
 import { credentialKey } from "../security/credential-key.js";
-import { ConfigError, ProviderNotConfiguredError } from "../util/errors.js";
+import { ProviderNotConfiguredError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
   describeSubscriptionModelIncompatibility,
   isConnectionCompatibleWithModel,
 } from "./connection-model-compat.js";
-import { CHATGPT_SUBSCRIPTION_CONNECTION_NAME } from "./inference/auth.js";
 import { getConnection, listConnections } from "./inference/connections.js";
-import { isCodexSubscriptionModel } from "./openai/codex-models.js";
 import { resolveManagedProxyContext } from "./platform-proxy/context.js";
 import { checkCredentialPresence } from "./provider-availability.js";
 import type { ProvidersConfig } from "./registry.js";
 import { resolveProviderFromConnection } from "./registry.js";
+import {
+  ConnectionResolutionError,
+  resolveRoutingIdentity,
+} from "./routing-identity.js";
 import type { Provider } from "./types.js";
 import {
-  getManagedUpstream,
   isVellumManagedConnection,
   MANAGED_ROUTABLE_PROVIDERS,
-  VELLUM_MANAGED_CONNECTION_NAME,
 } from "./vellum-model-routing.js";
 
+// Re-exported for the many existing importers; the definitions moved to
+// `routing-identity.ts` so `usage/attribution.ts` can use them without
+// importing this module (this file sits on the registry/attribution import
+// cycle that the move broke — see routing-identity.ts). New code should
+// import them from there.
+export { ConnectionResolutionError, resolveRoutingIdentity };
+
 const log = getLogger("providers/connection-resolution");
-
-/**
- * Error raised when a `provider_connection` reference cannot be resolved
- * because the configuration is broken (DB lookup throws, no such row, or
- * the connection's provider does not match the resolving profile's
- * declared provider). These are deterministic configuration bugs that
- * should fail loudly rather than silently rerouting.
- */
-export class ConnectionResolutionError extends ConfigError {
-  public readonly model?: string;
-  public readonly profileName?: string;
-
-  constructor(
-    public readonly connectionName: string,
-    public readonly reason:
-      | "lookup_failed"
-      | "not_found"
-      | "provider_mismatch"
-      | "missing_connection"
-      | "model_incompatible"
-      | "missing_credential"
-      | "platform_unauthenticated"
-      | "unroutable_managed_model",
-    message: string,
-    options?: { cause?: unknown; model?: string; profileName?: string },
-  ) {
-    super(message, { cause: options?.cause });
-    this.name = "ConnectionResolutionError";
-    this.model = options?.model;
-    this.profileName = options?.profileName;
-  }
-}
-
-/**
- * Translate a routing-identity provider into its dispatch target. "vellum"
- * derives the managed upstream from the model and routes through the
- * canonical vellum connection; "chatgpt" routes through the
- * chatgpt-subscription connection with an openai upstream. Returns null for
- * real providers. Throws `unroutable_managed_model` when a vellum model has
- * no managed upstream, and `model_incompatible` when a chatgpt model is
- * outside the Codex subscription set — loud and explainable, never a soft
- * fall-through to the (possibly platform-billed) default transport.
- */
-export function resolveRoutingIdentity(
-  provider: string | undefined,
-  model: string | undefined,
-): { connectionName: string; expectedProvider: string } | null {
-  if (provider === "vellum") {
-    const upstream = model ? getManagedUpstream(model) : null;
-    if (!upstream) {
-      throw new ConnectionResolutionError(
-        VELLUM_MANAGED_CONNECTION_NAME,
-        "unroutable_managed_model",
-        `provider "vellum" cannot route model "${model ?? "<unset>"}" — no managed upstream serves it. Pick a model from the Vellum catalog or set a concrete provider.`,
-        { model },
-      );
-    }
-    return {
-      connectionName: VELLUM_MANAGED_CONNECTION_NAME,
-      expectedProvider: upstream,
-    };
-  }
-  if (provider === "chatgpt") {
-    // The subscription endpoint rejects non-Codex models with HTTP 400;
-    // gate here so the misconfiguration surfaces as a config error instead
-    // of an upstream request failure.
-    if (model && !isCodexSubscriptionModel(model)) {
-      throw new ConnectionResolutionError(
-        CHATGPT_SUBSCRIPTION_CONNECTION_NAME,
-        "model_incompatible",
-        `provider "chatgpt" cannot route model "${model}" — the ChatGPT subscription serves Codex models only. Pick a Codex model or set a concrete provider.`,
-        { model },
-      );
-    }
-    return {
-      connectionName: CHATGPT_SUBSCRIPTION_CONNECTION_NAME,
-      expectedProvider: "openai",
-    };
-  }
-  return null;
-}
 
 /**
  * Resolve a Provider through a named `provider_connection`.

--- a/assistant/src/providers/routing-identity.ts
+++ b/assistant/src/providers/routing-identity.ts
@@ -1,0 +1,105 @@
+/**
+ * Routing-identity translation and the connection-resolution error type.
+ *
+ * This lives in its own leaf module — deliberately below both
+ * `connection-resolution.ts` and `usage/attribution.ts` — because it is
+ * what those two would otherwise have to share directly. Attribution
+ * importing `resolveRoutingIdentity` from `connection-resolution.ts`
+ * closed the module graph's only import cycle
+ * (connection-resolution → inference/connections → registry →
+ * inference/adapter-factory → retry → usage/attribution →
+ * connection-resolution), and the compiled binary's cyclic-module
+ * lowering destabilized unrelated bindings in graphs containing that
+ * cycle. Keep this module's imports to leaves (codecs, constants,
+ * error base classes); an import from anything that reaches the
+ * provider registry re-forms the cycle.
+ */
+
+import { ConfigError } from "../util/errors.js";
+import { CHATGPT_SUBSCRIPTION_CONNECTION_NAME } from "./inference/auth.js";
+import { isCodexSubscriptionModel } from "./openai/codex-models.js";
+import {
+  getManagedUpstream,
+  VELLUM_MANAGED_CONNECTION_NAME,
+} from "./vellum-model-routing.js";
+
+/**
+ * Error raised when a `provider_connection` reference cannot be resolved
+ * because the configuration is broken (DB lookup throws, no such row, or
+ * the connection's provider does not match the resolving profile's
+ * declared provider). These are deterministic configuration bugs that
+ * should fail loudly rather than silently rerouting.
+ */
+export class ConnectionResolutionError extends ConfigError {
+  public readonly model?: string;
+  public readonly profileName?: string;
+
+  constructor(
+    public readonly connectionName: string,
+    public readonly reason:
+      | "lookup_failed"
+      | "not_found"
+      | "provider_mismatch"
+      | "missing_connection"
+      | "model_incompatible"
+      | "missing_credential"
+      | "platform_unauthenticated"
+      | "unroutable_managed_model",
+    message: string,
+    options?: { cause?: unknown; model?: string; profileName?: string },
+  ) {
+    super(message, { cause: options?.cause });
+    this.name = "ConnectionResolutionError";
+    this.model = options?.model;
+    this.profileName = options?.profileName;
+  }
+}
+
+/**
+ * Translate a routing-identity provider into its dispatch target. "vellum"
+ * derives the managed upstream from the model and routes through the
+ * canonical vellum connection; "chatgpt" routes through the
+ * chatgpt-subscription connection with an openai upstream. Returns null for
+ * real providers. Throws `unroutable_managed_model` when a vellum model has
+ * no managed upstream, and `model_incompatible` when a chatgpt model is
+ * outside the Codex subscription set — loud and explainable, never a soft
+ * fall-through to the (possibly platform-billed) default transport.
+ */
+export function resolveRoutingIdentity(
+  provider: string | undefined,
+  model: string | undefined,
+): { connectionName: string; expectedProvider: string } | null {
+  if (provider === "vellum") {
+    const upstream = model ? getManagedUpstream(model) : null;
+    if (!upstream) {
+      throw new ConnectionResolutionError(
+        VELLUM_MANAGED_CONNECTION_NAME,
+        "unroutable_managed_model",
+        `provider "vellum" cannot route model "${model ?? "<unset>"}" — no managed upstream serves it. Pick a model from the Vellum catalog or set a concrete provider.`,
+        { model },
+      );
+    }
+    return {
+      connectionName: VELLUM_MANAGED_CONNECTION_NAME,
+      expectedProvider: upstream,
+    };
+  }
+  if (provider === "chatgpt") {
+    // The subscription endpoint rejects non-Codex models with HTTP 400;
+    // gate here so the misconfiguration surfaces as a config error instead
+    // of an upstream request failure.
+    if (model && !isCodexSubscriptionModel(model)) {
+      throw new ConnectionResolutionError(
+        CHATGPT_SUBSCRIPTION_CONNECTION_NAME,
+        "model_incompatible",
+        `provider "chatgpt" cannot route model "${model}" — the ChatGPT subscription serves Codex models only. Pick a Codex model or set a concrete provider.`,
+        { model },
+      );
+    }
+    return {
+      connectionName: CHATGPT_SUBSCRIPTION_CONNECTION_NAME,
+      expectedProvider: "openai",
+    };
+  }
+  return null;
+}

--- a/assistant/src/providers/routing-identity.ts
+++ b/assistant/src/providers/routing-identity.ts
@@ -1,18 +1,12 @@
 /**
  * Routing-identity translation and the connection-resolution error type.
  *
- * This lives in its own leaf module — deliberately below both
- * `connection-resolution.ts` and `usage/attribution.ts` — because it is
- * what those two would otherwise have to share directly. Attribution
- * importing `resolveRoutingIdentity` from `connection-resolution.ts`
- * closed the module graph's only import cycle
- * (connection-resolution → inference/connections → registry →
- * inference/adapter-factory → retry → usage/attribution →
- * connection-resolution), and the compiled binary's cyclic-module
- * lowering destabilized unrelated bindings in graphs containing that
- * cycle. Keep this module's imports to leaves (codecs, constants,
- * error base classes); an import from anything that reaches the
- * provider registry re-forms the cycle.
+ * This is a leaf module shared by `connection-resolution.ts` and
+ * `usage/attribution.ts`. Keep its imports to leaves (codecs, constants,
+ * error base classes): an import from anything that reaches the provider
+ * registry creates an import cycle through retry/attribution, and the
+ * compiled binary's cyclic-module lowering destabilizes bindings in
+ * graphs containing a cycle.
  */
 
 import { ConfigError } from "../util/errors.js";

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -4,8 +4,11 @@ import {
 } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
-import { resolveRoutingIdentity } from "../providers/connection-resolution.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
+// Imported from the leaf module, NOT from connection-resolution.js: that
+// import was the back-edge of the module graph's only cycle (registry ->
+// retry -> attribution -> connection-resolution). See routing-identity.ts.
+import { resolveRoutingIdentity } from "../providers/routing-identity.js";
 import { safeStringSlice } from "../util/unicode.js";
 
 const MAX_METADATA_VALUE_LENGTH = 128;

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -5,9 +5,6 @@ import {
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
-// Imported from the leaf module, NOT from connection-resolution.js: that
-// import was the back-edge of the module graph's only cycle (registry ->
-// retry -> attribution -> connection-resolution). See routing-identity.ts.
 import { resolveRoutingIdentity } from "../providers/routing-identity.js";
 import { safeStringSlice } from "../util/unicode.js";
 


### PR DESCRIPTION
## Prompt / plan

Follow-up to #38835. That PR insulated the plugin-api barrel from the TDZ ReferenceError by lazy-loading the STT resolver, but the underlying import cycle it flagged remained. This PR removes the cycle itself.

The module graph's only cycle was:

```
providers/connection-resolution.ts
  -> providers/inference/connections.ts
  -> providers/registry.ts
  -> providers/inference/adapter-factory.ts
  -> providers/retry.ts
  -> usage/attribution.ts
  -> providers/connection-resolution.ts   (back-edge: attribution imported resolveRoutingIdentity)
```

The plan, verified with an import-graph BFS before writing any code:

- Extract `resolveRoutingIdentity` and `ConnectionResolutionError` (which it throws) into a new leaf module, `providers/routing-identity.ts`. Its transitive value-import closure is 6 leaf modules (`vellum-model-routing`, `inference/auth`, `openai/codex-models`, `util/errors`, `model-catalog`, `platform-proxy/constants`) — none reach the registry, so the extraction introduces no new edges into the loop.
- `connection-resolution.ts` imports and re-exports both symbols, so its 10+ existing importers (`provider-send-message`, `call-site-routing`, daemon generators, routes, subagent manager) are untouched.
- `usage/attribution.ts` is the one required import-path change: it must import from the new module directly, since going through the re-export would re-form the cycle. After the edit, attribution's 67-module closure no longer reaches `connection-resolution.ts` at all.

Result: the plugin-api barrel's transitive import graph (286 modules) contains **zero** cycles, so the compiled binary's cyclic-module lowering — the mechanism behind the original `Cannot access 'openTranscriptionSession' before initialization` — is no longer exercised on this graph at all.

No behavior change: the moved code is byte-identical logic; only module placement and import paths changed.

## Test plan

- `bunx tsc --noEmit` clean.
- `bun test` on every suite touching the moved symbols: `dispatch-connection-routing`, `satellite-connection-routing`, `vellum-mismatch-routing`, `preflight-resolved-config`, `retry-callsite`, `src/usage`, `call-site-routing-provider`, `conversation-error`, `default-profile-catalog`, `src/plugin-api` — 287 pass, 0 fail.
- Cycle detector (Tarjan over the barrel's value-import graph) re-run after the change: 286 modules scanned, 0 cycles (was exactly 1 before).
- Pre-commit hooks (prettier, eslint, typecheck) pass.

## CLI verb checklist

- [ ] No CLI verbs added, removed, or changed — this is a module-placement refactor with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ)_