### PR TITLE
Single-source host-bash and host-cu proxy events from api/events

### DIFF
--- a/assistant/src/api/events/host-bash.ts
+++ b/assistant/src/api/events/host-bash.ts
@@ -1,0 +1,40 @@
+/**
+ * Host-bash proxy SSE events (`host_bash_request` / `host_bash_cancel`).
+ *
+ * Server → client instructions that proxy shell commands to the desktop
+ * client (host machine) when running as a managed assistant. The client
+ * executes and POSTs the result back to `/v1/host-bash-result`;
+ * `host_bash_cancel` withdraws an in-flight request. `targetClientId`
+ * pins delivery to a single connected client.
+ *
+ * Canonical wire-contract source. Daemon code imports the types
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const HostBashRequestEventSchema = z.object({
+  type: z.literal("host_bash_request"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  command: z.string(),
+  working_dir: z.string().optional(),
+  timeout_seconds: z.number().optional(),
+  /** Extra environment variables to inject into the subprocess (e.g. __CONVERSATION_ID). */
+  env: z.record(z.string(), z.string()).optional(),
+  /** When set, route this request only to the client with this ID. */
+  targetClientId: z.string().optional(),
+});
+
+export type HostBashRequestEvent = z.infer<typeof HostBashRequestEventSchema>;
+
+export const HostBashCancelEventSchema = z.object({
+  type: z.literal("host_bash_cancel"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  /** When set, route this cancel only to the client that owns the request. */
+  targetClientId: z.string().optional(),
+});
+
+export type HostBashCancelEvent = z.infer<typeof HostBashCancelEventSchema>;

--- a/assistant/src/api/events/host-cu.ts
+++ b/assistant/src/api/events/host-cu.ts
@@ -1,0 +1,37 @@
+/**
+ * Host computer-use proxy SSE events (`host_cu_request` / `host_cu_cancel`).
+ *
+ * Server → client instructions that proxy computer-use actions (click,
+ * type, screenshot, …) to the desktop client when running as a managed
+ * assistant. The client executes and POSTs the result back to
+ * `/v1/host-cu-result`; `host_cu_cancel` withdraws an in-flight request.
+ *
+ * Canonical wire-contract source. Daemon code imports the types
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const HostCuRequestEventSchema = z.object({
+  type: z.literal("host_cu_request"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  targetClientId: z.string().optional(),
+  /** Tool name — "computer_use_click", "computer_use_type_text", etc. */
+  toolName: z.string(),
+  input: z.record(z.string(), z.unknown()),
+  stepNumber: z.number(),
+  reasoning: z.string().optional(),
+});
+
+export type HostCuRequestEvent = z.infer<typeof HostCuRequestEventSchema>;
+
+export const HostCuCancelEventSchema = z.object({
+  type: z.literal("host_cu_cancel"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  targetClientId: z.string().optional(),
+});
+
+export type HostCuCancelEvent = z.infer<typeof HostCuCancelEventSchema>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -37,6 +37,14 @@ import { GenerationCancelledEventSchema } from "./events/generation-cancelled.js
 import { GenerationHandoffEventSchema } from "./events/generation-handoff.js";
 import { HomeFeedUpdatedEventSchema } from "./events/home-feed-updated.js";
 import { HookEventSchema } from "./events/hook-event.js";
+import {
+  HostBashCancelEventSchema,
+  HostBashRequestEventSchema,
+} from "./events/host-bash.js";
+import {
+  HostCuCancelEventSchema,
+  HostCuRequestEventSchema,
+} from "./events/host-cu.js";
 import { IdentityChangedEventSchema } from "./events/identity-changed.js";
 import { InteractionResolvedEventSchema } from "./events/interaction-resolved.js";
 import { MemoryRecalledEventSchema } from "./events/memory-recalled.js";
@@ -284,6 +292,18 @@ export {
   HookEventOwnerSchema,
   HookEventSchema,
 } from "./events/hook-event.js";
+export {
+  type HostBashCancelEvent,
+  HostBashCancelEventSchema,
+  type HostBashRequestEvent,
+  HostBashRequestEventSchema,
+} from "./events/host-bash.js";
+export {
+  type HostCuCancelEvent,
+  HostCuCancelEventSchema,
+  type HostCuRequestEvent,
+  HostCuRequestEventSchema,
+} from "./events/host-cu.js";
 export {
   type IdentityChangedEvent,
   IdentityChangedEventSchema,
@@ -751,6 +771,10 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   GenerationHandoffEventSchema,
   HomeFeedUpdatedEventSchema,
   HookEventSchema,
+  HostBashCancelEventSchema,
+  HostBashRequestEventSchema,
+  HostCuCancelEventSchema,
+  HostCuRequestEventSchema,
   IdentityChangedEventSchema,
   InteractionResolvedEventSchema,
   MemoryRecalledEventSchema,

--- a/assistant/src/daemon/message-types/host-bash.ts
+++ b/assistant/src/daemon/message-types/host-bash.ts
@@ -1,30 +1,12 @@
-// Host bash proxy types.
-// Enables proxying shell commands to the desktop client (host machine)
-// when running as a managed assistant.
+// Host bash proxy events.
+//
+// Server→client events are single-sourced from their canonical `api/events`
+// wire schemas; this file only composes them into the domain union consumed by
+// `message-protocol.ts`.
 
-// === Server → Client ===
+import type { HostBashCancelEvent } from "../../api/events/host-bash.js";
+import type { HostBashRequestEvent } from "../../api/events/host-bash.js";
 
-export interface HostBashRequest {
-  type: "host_bash_request";
-  requestId: string;
-  conversationId: string;
-  command: string;
-  working_dir?: string;
-  timeout_seconds?: number;
-  /** Extra environment variables to inject into the subprocess (e.g. __CONVERSATION_ID). */
-  env?: Record<string, string>;
-  /** When set, route this request only to the client with this ID. */
-  targetClientId?: string;
-}
-
-export interface HostBashCancelRequest {
-  type: "host_bash_cancel";
-  requestId: string;
-  conversationId: string;
-  /** When set, route this cancel only to the client that owns the request. */
-  targetClientId?: string;
-}
-
-// --- Domain-level union aliases (consumed by the barrel file) ---
-
-export type _HostBashServerMessages = HostBashRequest | HostBashCancelRequest;
+export type _HostBashServerMessages =
+  | HostBashRequestEvent
+  | HostBashCancelEvent;

--- a/assistant/src/daemon/message-types/host-cu.ts
+++ b/assistant/src/daemon/message-types/host-cu.ts
@@ -1,27 +1,10 @@
-// Host computer-use proxy types.
-// Enables proxying computer-use actions (click, type, screenshot, etc.)
-// to the desktop client when running as a managed assistant.
+// Host computer-use proxy events.
+//
+// Server→client events are single-sourced from their canonical `api/events`
+// wire schemas; this file only composes them into the domain union consumed by
+// `message-protocol.ts`.
 
-// === Server → Client ===
+import type { HostCuCancelEvent } from "../../api/events/host-cu.js";
+import type { HostCuRequestEvent } from "../../api/events/host-cu.js";
 
-export interface HostCuRequest {
-  type: "host_cu_request";
-  requestId: string;
-  conversationId: string;
-  targetClientId?: string;
-  toolName: string; // "computer_use_click", "computer_use_type_text", etc.
-  input: Record<string, unknown>;
-  stepNumber: number;
-  reasoning?: string;
-}
-
-export interface HostCuCancelRequest {
-  type: "host_cu_cancel";
-  requestId: string;
-  conversationId: string;
-  targetClientId?: string;
-}
-
-// --- Domain-level union aliases (consumed by the barrel file) ---
-
-export type _HostCuServerMessages = HostCuRequest | HostCuCancelRequest;
+export type _HostCuServerMessages = HostCuRequestEvent | HostCuCancelEvent;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -470,6 +470,14 @@ export function useStreamEventHandler(
         // (e.g. user-prompt-submit). No web UI renders them yet.
         case "hook_event":
           break;
+        // Host-proxy instructions (bash / computer-use) targeting the desktop
+        // client. The web chat handler is a no-op — the web is not a host-proxy
+        // capability holder, so the hub never delivers these to it.
+        case "host_bash_request":
+        case "host_bash_cancel":
+        case "host_cu_request":
+        case "host_cu_cancel":
+          break;
         // Service-group upgrade lifecycle broadcasts announcing a daemon
         // restart. The chat handler is a no-op; no web UI renders them yet.
         case "service_group_update_starting":


### PR DESCRIPTION
## Why

Continues the event-type unification effort. The `host_*` proxy events are all genuine live broadcasts (the daemon instructs the desktop client to run something on the host and POST the result back), so this is a pure migration — starting with the two structurally simplest domains.

## What

Authored canonical `api/events` schemas and registered them in `AssistantEventSchema`:

- **`api/events/host-bash.ts`** — `host_bash_request` / `host_bash_cancel`
- **`api/events/host-cu.ts`** — `host_cu_request` / `host_cu_cancel`

Each domain's `_Host*ServerMessages` union now composes the api-inferred `*Event` types. The proxies (`host-bash-proxy.ts`, `host-cu-proxy.ts`) build these events inline, validated by typecheck against the api-inferred union — no consumer renames.

## Web

The events carry a `conversationId` (conversation-scoped), so they get no-op cases in the chat handler's exhaustive switch. The web isn't a host-proxy capability holder, so the hub never delivers these to it — the cases exist purely for TS exhaustiveness.

## Scope note

This is the **first slice of the `host_*` proxy group**. I split it because the domains vary a lot in shape; the rest follow as focused PRs:
- **host-file / host-transfer** — multiple request variants sharing one `type` literal (`z.union` members, needs care in the discriminated union)
- **host-app-control** — a nested 9-variant tool-input union to transcribe
- **host-ui-snapshot** — carries an auxiliary HTTP result-payload type to preserve
- **host-browser** — carries client→server events and is wired into the chrome-extension registry (most sensitive)

## Safety

No wire change (schemas transcribed 1:1). Clean `typecheck:fast` + web `tsc` (fresh `openapi-ts`), eslint, prettier, `generate:openapi --check` (unchanged), api-events + SSE-parity suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_