### PR TITLE
feat(web): resolve the takeover surface from the target assistant's avatar

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -10,10 +10,8 @@ import {
 } from "react";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
-import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
 import { MACHINE_TIER_LABEL, SIZE_LABEL } from "@/lib/billing/machine-sizes";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { Button } from "@vellumai/design-library/components/button";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -28,6 +26,7 @@ import {
   type ResourceChangeKey,
 } from "./resource-changes";
 import { useProvisioningCredits } from "./use-provisioning-credits";
+import { useTakeoverSurface } from "./use-takeover-surface";
 import { useRotatingIndex } from "./use-rotating-index";
 import { useHeldPhase } from "./use-held-phase";
 import {
@@ -186,24 +185,13 @@ function TakeoverAvatar({
   assistantId?: string | null;
   mode: AvatarMode;
 }) {
-  const activeId = useResolvedAssistantsStore.use.activeAssistantId();
-  // An explicit null is the provisioning hook saying it does not know the
-  // target yet — it withholds `primary_assistant_id` until onboarding is fresh
-  // precisely so a multi-assistant org does not aim at the active assistant
-  // when the two diverge. Only an omitted prop falls back to active; a null one
-  // stays unresolved, so the takeover never fades in a different assistant's
-  // avatar on the way to the right one.
-  const resolvedId = assistantId === undefined ? activeId : assistantId;
-  const { components, traits, customImageUrl, isLoading } =
-    useAssistantAvatar(resolvedId);
+  // `useTakeoverSurface` owns which assistant the takeover draws and when its
+  // avatar is safe to draw, so the creature and the paint around it can never
+  // disagree about either.
+  const { avatar, ready: avatarReady } = useTakeoverSurface(assistantId);
   const fallbackComponents = useBundledAvatarComponents();
   const size = useTakeoverAvatarSize();
   const laboring = mode === "working" || mode === "settling";
-  // A null id means the target assistant has not resolved yet, not that it has
-  // no avatar — and `useAssistantAvatar(null)` is a disabled query, which
-  // reports `isLoading: false` with no data. Both have to clear before there is
-  // anything safe to draw.
-  const avatarReady = resolvedId != null && !isLoading;
   // Every mode animates the wrapper or its child, so the class waits for
   // something to animate. Otherwise a phase that resolves before the fetch does
   // — likely here, since the avatar is read off the machine being restarted —
@@ -228,9 +216,9 @@ function TakeoverAvatar({
               {avatarReady && (
                 <div className="provision-avatar-reveal">
                   <ChatAvatar
-                    components={components ?? fallbackComponents}
-                    traits={traits}
-                    customImageUrl={customImageUrl}
+                    components={avatar.components ?? fallbackComponents}
+                    traits={avatar.traits}
+                    customImageUrl={avatar.customImageUrl}
                     size={size}
                     isAssistantBusy={laboring}
                   />

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Tests for `useTakeoverSurface`. The avatar hook is mocked to serve a
+ * per-test payload and to record the id it is queried with, so the
+ * target-selection rule and the flash guard can both be asserted without a
+ * fetch. The resolved-assistants store is driven through `setState`, as in
+ * `provisioning-state.test.tsx`.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { renderHook } from "@testing-library/react";
+
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { SURFACE_GROUND } from "@/utils/avatar-tone";
+
+/** The id handed to the avatar hook, captured to assert the target rule. */
+let avatarQueryId: string | null | undefined;
+/** The payload the mocked avatar query resolves to, set per test. */
+let avatar: {
+  components: CharacterComponents | null;
+  traits: CharacterTraits | null;
+  customImageUrl: string | null;
+  isLoading: boolean;
+};
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: (assistantId: string | null) => {
+    avatarQueryId = assistantId;
+    return { ...avatar, invalidate: () => {} };
+  },
+}));
+
+const { useTakeoverSurface } = await import("./use-takeover-surface");
+
+const GREEN_SURFACE = "#1d281d";
+const PURPLE_SURFACE = "#29202e";
+
+function traits(color: string): CharacterTraits {
+  return { bodyShape: "blob", eyeStyle: "default", color };
+}
+
+beforeEach(() => {
+  avatarQueryId = undefined;
+  avatar = {
+    components: null,
+    traits: null,
+    customImageUrl: null,
+    isLoading: false,
+  };
+  useResolvedAssistantsStore.setState({ activeAssistantId: null });
+});
+
+describe("target selection", () => {
+  test("falls back to the active assistant when no id is passed", () => {
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "active-assistant",
+    });
+    avatar.components = BUNDLED_COMPONENTS;
+
+    const { result } = renderHook(() => useTakeoverSurface());
+
+    expect(avatarQueryId).toBe("active-assistant");
+    expect(result.current.ready).toBe(true);
+  });
+
+  test("an explicit null does not fall back to the active assistant", () => {
+    // The active assistant is deliberately non-null: with the store's default
+    // null, an unresolved surface would pass for the wrong reason.
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: "active-assistant",
+    });
+    avatar.components = BUNDLED_COMPONENTS;
+    avatar.traits = traits("purple");
+
+    const { result } = renderHook(() => useTakeoverSurface(null));
+
+    expect(avatarQueryId).toBeNull();
+    expect(result.current.ready).toBe(false);
+    expect(result.current.tintHex).toBe(SURFACE_GROUND);
+    expect(result.current.backdropImageUrl).toBeNull();
+  });
+});
+
+describe("flash guard", () => {
+  test("holds the neutral ground while the avatar query is in flight", () => {
+    avatar = {
+      components: BUNDLED_COMPONENTS,
+      traits: traits("purple"),
+      customImageUrl: "blob:avatar",
+      isLoading: true,
+    };
+
+    const { result } = renderHook(() =>
+      useTakeoverSurface("primary-assistant"),
+    );
+
+    expect(result.current.ready).toBe(false);
+    expect(result.current.tintHex).toBe(SURFACE_GROUND);
+    expect(result.current.backdropImageUrl).toBeNull();
+  });
+});
+
+describe("resolved surfaces", () => {
+  test("a character's trait color becomes the tint", () => {
+    avatar.components = BUNDLED_COMPONENTS;
+    avatar.traits = traits("purple");
+
+    const { result } = renderHook(() =>
+      useTakeoverSurface("primary-assistant"),
+    );
+
+    expect(result.current.tintHex.toLowerCase()).toBe(PURPLE_SURFACE);
+    expect(result.current.backdropImageUrl).toBeNull();
+    expect(result.current.ready).toBe(true);
+  });
+
+  test("a custom image becomes the backdrop and leaves the ground neutral", () => {
+    avatar.components = BUNDLED_COMPONENTS;
+    avatar.customImageUrl = "blob:custom-avatar";
+
+    const { result } = renderHook(() =>
+      useTakeoverSurface("primary-assistant"),
+    );
+
+    expect(result.current.backdropImageUrl).toBe("blob:custom-avatar");
+    expect(result.current.tintHex).toBe(SURFACE_GROUND);
+  });
+
+  test("no traits and no image tints from the first bundled color", () => {
+    // ChatAvatar draws that creature, so the surface has to match it.
+    avatar.components = BUNDLED_COMPONENTS;
+
+    const { result } = renderHook(() =>
+      useTakeoverSurface("primary-assistant"),
+    );
+
+    expect(result.current.tintHex.toLowerCase()).toBe(GREEN_SURFACE);
+    expect(result.current.backdropImageUrl).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
@@ -99,6 +99,25 @@ describe("flash guard", () => {
   });
 });
 
+describe("avatar render inputs", () => {
+  test("passes the query payload through for the ready branch to draw", () => {
+    avatar.components = BUNDLED_COMPONENTS;
+    avatar.traits = traits("purple");
+    avatar.customImageUrl = "blob:custom-avatar";
+
+    const { result } = renderHook(() =>
+      useTakeoverSurface("primary-assistant"),
+    );
+
+    expect(result.current.ready).toBe(true);
+    expect(result.current.avatar).toEqual({
+      components: BUNDLED_COMPONENTS,
+      traits: traits("purple"),
+      customImageUrl: "blob:custom-avatar",
+    });
+  });
+});
+
 describe("resolved surfaces", () => {
   test("a character's trait color becomes the tint", () => {
     avatar.components = BUNDLED_COMPONENTS;

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
@@ -1,26 +1,45 @@
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { resolveAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { SURFACE_GROUND, avatarSurfaceHex } from "@/utils/avatar-tone";
+
+/**
+ * The target assistant's raw avatar payload, for drawing the creature itself.
+ * Ungated: every field carries whatever the query holds right now, so a
+ * consumer must render it only inside a {@link TakeoverSurface.ready} branch.
+ */
+export interface TakeoverAvatarInputs {
+  components: CharacterComponents | null;
+  traits: CharacterTraits | null;
+  /** The assistant's uploaded image, drawn as the avatar in place of an SVG. */
+  customImageUrl: string | null;
+}
 
 export interface TakeoverSurface {
   /** Opaque #rrggbb to paint the takeover and its exit sheet. */
   tintHex: string;
-  /** Custom avatar image to blur behind the content, when there is one. */
+  /**
+   * Ready-gated custom avatar image to blur behind the content, when there is
+   * one — the background wash, not the avatar. The avatar's own image is
+   * {@link TakeoverAvatarInputs.customImageUrl}.
+   */
   backdropImageUrl: string | null;
-  /** The avatar query has settled — safe to commit to a hue. */
+  /** The target resolved and its avatar query settled — safe to draw. */
   ready: boolean;
+  /** Render inputs for the avatar, valid only once `ready`. */
+  avatar: TakeoverAvatarInputs;
 }
 
 /**
- * The paint for the provisioning takeover, derived from the target assistant's
- * avatar: a deep tint of the character accent, or the custom image to blur
- * behind the content.
+ * The single resolution of the provisioning takeover's avatar: which assistant
+ * it draws, that avatar's render inputs, and the paint derived from it — a deep
+ * tint of the character accent, or the custom image to blur behind the content.
  *
- * The surface stays on the hue-neutral {@link SURFACE_GROUND} until the avatar
- * query settles. `ChatAvatar` synthesizes fallback traits from the first
- * bundled color, so a surface derived before the fetch resolves would paint
- * green and then jump to the assistant's real color at full-viewport scale.
+ * The surface stays on the hue-neutral {@link SURFACE_GROUND} and withholds the
+ * avatar until the query settles. `ChatAvatar` synthesizes fallback traits from
+ * the first bundled color, so drawing before the fetch resolves paints green
+ * and then jumps to the assistant's real color at full-viewport scale.
  */
 export function useTakeoverSurface(
   assistantId?: string | null,
@@ -47,5 +66,6 @@ export function useTakeoverSurface(
     tintHex: ready && accent ? avatarSurfaceHex(accent) : SURFACE_GROUND,
     backdropImageUrl: ready ? customImageUrl : null,
     ready,
+    avatar: { components, traits, customImageUrl },
   };
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
@@ -1,0 +1,51 @@
+import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { resolveAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { SURFACE_GROUND, avatarSurfaceHex } from "@/utils/avatar-tone";
+
+export interface TakeoverSurface {
+  /** Opaque #rrggbb to paint the takeover and its exit sheet. */
+  tintHex: string;
+  /** Custom avatar image to blur behind the content, when there is one. */
+  backdropImageUrl: string | null;
+  /** The avatar query has settled — safe to commit to a hue. */
+  ready: boolean;
+}
+
+/**
+ * The paint for the provisioning takeover, derived from the target assistant's
+ * avatar: a deep tint of the character accent, or the custom image to blur
+ * behind the content.
+ *
+ * The surface stays on the hue-neutral {@link SURFACE_GROUND} until the avatar
+ * query settles. `ChatAvatar` synthesizes fallback traits from the first
+ * bundled color, so a surface derived before the fetch resolves would paint
+ * green and then jump to the assistant's real color at full-viewport scale.
+ */
+export function useTakeoverSurface(
+  assistantId?: string | null,
+): TakeoverSurface {
+  const activeId = useResolvedAssistantsStore.use.activeAssistantId();
+  // An explicit null is the provisioning hook saying it does not know the
+  // target yet — it withholds `primary_assistant_id` until onboarding is fresh,
+  // so a multi-assistant org must not aim at the active assistant. Only an
+  // omitted prop falls back to active.
+  const resolvedId = assistantId === undefined ? activeId : assistantId;
+  const { components, traits, customImageUrl, isLoading } =
+    useAssistantAvatar(resolvedId);
+  // `useAssistantAvatar(null)` is a disabled query, which reports
+  // `isLoading: false` with no data, so the id has to gate readiness too.
+  const ready = resolvedId != null && !isLoading;
+
+  const accent =
+    resolveAvatarAccentHex(components, traits) ??
+    // With no traits and no image, ChatAvatar draws the first bundled color, so
+    // the surface matches that creature rather than falling through to neutral.
+    (customImageUrl ? null : (components?.colors[0]?.hex ?? null));
+
+  return {
+    tintHex: ready && accent ? avatarSurfaceHex(accent) : SURFACE_GROUND,
+    backdropImageUrl: ready ? customImageUrl : null,
+    ready,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `useTakeoverSurface`, which resolves the provisioning takeover's paint from the target assistant's avatar: a deep tint of the character accent, or the custom image to blur behind the content.
- Holds a hue-neutral ground until the avatar query settles, so the takeover never commits to another assistant's color.

Part of plan: takeover-avatar-tinted-background.md (PR 3 of 5)