### PR TITLE
fix: keep plugin credential key patterns active through shutdown hooks

### DIFF
--- a/assistant/src/__tests__/plugin-secret-pattern-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-secret-pattern-contribution.test.ts
@@ -233,6 +233,41 @@ describe("user plugin credential key pattern lifecycle", () => {
     expect(getPluginSecretPatterns()).toHaveLength(0);
   });
 
+  test("patterns stay active through the shutdown hook on disable", async () => {
+    // Mirror of the init-ordering guarantee: shutdown-time logging must still
+    // be covered by the plugin's declared redaction patterns, so unregister
+    // happens only after the shutdown hook returns.
+    const g = globalThis as {
+      __patternProbe?: () => number;
+      __shutdownPatternCount?: number;
+    };
+    g.__patternProbe = () => getPluginSecretPatterns().length;
+    delete g.__shutdownPatternCount;
+    try {
+      const dir = writePluginDir("shutdown-order-plugin", [VIRLO_PATTERN]);
+      writeHook(
+        dir,
+        "shutdown",
+        `export default () => { const g = globalThis; g.__shutdownPatternCount = g.__patternProbe ? g.__patternProbe() : -1; };`,
+      );
+      await populateCacheAtBoot();
+      expect(
+        findRegistered("Virlo API Key", "shutdown-order-plugin"),
+      ).toBeDefined();
+
+      writeFileSync(join(dir, ".disabled"), "");
+      await publishAndDispatch();
+
+      const observed = (globalThis as { __shutdownPatternCount?: number })
+        .__shutdownPatternCount;
+      expect(observed).toBe(1);
+      expect(getPluginSecretPatterns()).toHaveLength(0);
+    } finally {
+      delete g.__patternProbe;
+      delete g.__shutdownPatternCount;
+    }
+  });
+
   test("an invalid declaration never blocks activation; the valid one still registers", async () => {
     const dir = writePluginDir("mixed-plugin", [
       VIRLO_PATTERN,

--- a/assistant/src/daemon/external-plugins-bootstrap.ts
+++ b/assistant/src/daemon/external-plugins-bootstrap.ts
@@ -375,7 +375,6 @@ async function teardownPlugin(
   }
 
   unregisterPluginInjectors(name);
-  unregisterPluginSecretPatterns(name);
 
   if (plugin.hooks?.[HOOKS.SHUTDOWN]) {
     try {
@@ -387,4 +386,9 @@ async function teardownPlugin(
       );
     }
   }
+
+  // Unregister AFTER the shutdown hook so shutdown-time logging is still
+  // covered by the plugin's declared redaction patterns (mirror of the
+  // register-before-init ordering in initializePlugin).
+  unregisterPluginSecretPatterns(name);
 }

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -1113,11 +1113,14 @@ async function deactivatePlugin(
   if (idx >= 0) {
     activatedPlugins.splice(idx, 1);
   }
-  unregisterPluginSecretPatterns(pluginName);
-
   if (reason !== "uninstall") {
     await runShutdownHook("plugin", pluginName, reason);
   }
+  // Unregister AFTER the shutdown hook: patterns must stay active while the
+  // hook runs so shutdown-time logging (including caught-error paths that
+  // echo a configured key) is still covered by log redaction — the mirror of
+  // the register-before-init ordering in activatePlugin.
+  unregisterPluginSecretPatterns(pluginName);
 }
 
 // ─── Boot population ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `deactivatePlugin` (user plugins) and `teardownPlugin` (default plugins) unregistered `credentialKeyPatterns` before the shutdown hook ran, so shutdown-time logging that echoes a configured key lost redaction coverage — the mirror of the register-before-init ordering shipped in #38761
- Unregister now happens after the hook returns; new lifecycle test proves patterns are visible during the disable-path shutdown hook and gone after

Addresses the post-merge Codex P2 on #38761 (mtime-cache.ts thread).

Part of plan: jarvis-1313-cred-chat-leak.md (post-merge follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)