### PR TITLE
fix(gateway): validate Telegram webhook payloads with tolerant Zod schemas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -294,6 +294,7 @@
         "zod-openapi": "5.4.6",
       },
       "devDependencies": {
+        "@grammyjs/types": "4.0.0",
         "@types/bun": "1.3.9",
         "eslint": "10.0.0",
         "fast-check": "4.7.0",
@@ -705,6 +706,8 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@google/genai": ["@google/genai@1.45.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-+sNRWhKiRibVgc4OKi7aBJJ0A7RcoVD8tGG+eFkqxAWRjASDW+ktS9lLwTDnAxZICzCVoeAdu8dYLJVTX60N9w=="],
+
+    "@grammyjs/types": ["@grammyjs/types@4.0.0", "", {}, "sha512-Z8lDLTvOlo12e5Vnly/vQh3JC9ppaitS1dGZ3w068gNitOd/y8tTSiib+Xm38aBGbtYGmUZwOc6afYrLs2CSTg=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.2", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.2" } }, "sha512-/DC0hluanNJDVPUu69cidD46sGwzt8MJATiGx7WgCScn+ZH48fJQ0fvTfMPXY82/ASXWxnNo8P4BdHyU/dI/EA=="],
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -53,6 +53,7 @@
     "@vellumai/twilio-client"
   ],
   "devDependencies": {
+    "@grammyjs/types": "4.0.0",
     "@types/bun": "1.3.9",
     "eslint": "10.0.0",
     "fast-check": "4.7.0",

--- a/gateway/src/telegram/normalize.test.ts
+++ b/gateway/src/telegram/normalize.test.ts
@@ -256,8 +256,8 @@ describe("normalizeTelegramUpdate — audio messages", () => {
 
 describe("normalizeTelegramUpdate — malformed input is validated, not trusted", () => {
   it("drops a message whose chat.id is not a number", () => {
-    // Before validation the blanket cast trusted this and forwarded
-    // `String({...})` = "[object Object]" as the conversation id.
+    // A non-number chat.id must be dropped, not coerced to
+    // `String({...})` = "[object Object]" and forwarded as the conversation id.
     const result = normalizeTelegramUpdate({
       update_id: 600,
       message: {
@@ -271,8 +271,8 @@ describe("normalizeTelegramUpdate — malformed input is validated, not trusted"
   });
 
   it("ignores a non-array photo instead of treating it like an array", () => {
-    // Before, `photo.length` on a non-array string produced a garbage
-    // single-character attachment with an undefined fileId.
+    // A non-array photo must be ignored: `.length` on a string would otherwise
+    // produce a garbage single-character attachment with an undefined fileId.
     const result = normalizeTelegramUpdate({
       update_id: 601,
       message: {

--- a/gateway/src/telegram/normalize.test.ts
+++ b/gateway/src/telegram/normalize.test.ts
@@ -253,3 +253,70 @@ describe("normalizeTelegramUpdate — audio messages", () => {
     expect(result).toBeNull();
   });
 });
+
+describe("normalizeTelegramUpdate — malformed input is validated, not trusted", () => {
+  it("drops a message whose chat.id is not a number", () => {
+    // Before validation the blanket cast trusted this and forwarded
+    // `String({...})` = "[object Object]" as the conversation id.
+    const result = normalizeTelegramUpdate({
+      update_id: 600,
+      message: {
+        message_id: 60,
+        text: "hi",
+        chat: { id: { nested: true }, type: "private" },
+        from: { id: 42, first_name: "Alice" },
+      },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("ignores a non-array photo instead of treating it like an array", () => {
+    // Before, `photo.length` on a non-array string produced a garbage
+    // single-character attachment with an undefined fileId.
+    const result = normalizeTelegramUpdate({
+      update_id: 601,
+      message: {
+        message_id: 61,
+        text: "caption text",
+        photo: "not-an-array",
+        chat: { id: 42, type: "private" },
+        from: { id: 42, first_name: "Alice" },
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.message.content).toBe("caption text");
+    expect(result!.message.attachments).toBeUndefined();
+  });
+
+  it("drops a non-numeric message_thread_id rather than stringifying it", () => {
+    const result = normalizeTelegramUpdate({
+      update_id: 602,
+      message: {
+        message_id: 62,
+        message_thread_id: { bad: true },
+        text: "hi",
+        chat: { id: 42, type: "private" },
+        from: { id: 42, first_name: "Alice" },
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.source.threadId).toBeUndefined();
+  });
+
+  it("preserves the original payload verbatim as `raw`, unknown keys included", () => {
+    const payload = {
+      update_id: 603,
+      message: {
+        message_id: 63,
+        text: "hi",
+        chat: { id: 42, type: "private" },
+        from: { id: 42, first_name: "Alice" },
+      },
+      // The schema strips this from the parsed working copy; `raw` must keep it.
+      unknown_future_field: { anything: 1 },
+    };
+    const result = normalizeTelegramUpdate(payload);
+    expect(result).not.toBeNull();
+    expect(result!.raw).toEqual(payload);
+  });
+});

--- a/gateway/src/telegram/normalize.ts
+++ b/gateway/src/telegram/normalize.ts
@@ -6,10 +6,9 @@ import type { GatewayInboundEvent } from "../types.js";
 // These schemas validate the *types* of the nested fields the normalizer reads
 // while staying tolerant: a malformed field collapses to `undefined` (or an
 // empty string for required ids) rather than rejecting the whole update, so the
-// existing downstream null-checks drop an unsupported message as before instead
-// of trusting garbage narrowed off a blanket cast. Unknown keys are stripped
-// from the parsed working copy; the original payload is still preserved verbatim
-// as `raw`.
+// downstream null-checks drop an unsupported message instead of forwarding a
+// malformed value. Unknown keys are stripped from the parsed working copy; the
+// original payload is preserved verbatim as `raw`.
 const optionalNumber = () => z.number().optional().catch(undefined);
 const optionalString = () => z.string().optional().catch(undefined);
 const optionalBoolean = () => z.boolean().optional().catch(undefined);

--- a/gateway/src/telegram/normalize.ts
+++ b/gateway/src/telegram/normalize.ts
@@ -1,5 +1,17 @@
 import { z } from "zod";
 
+import type {
+  Audio,
+  CallbackQuery,
+  Chat,
+  Document as TelegramApiDocument,
+  Message,
+  PhotoSize,
+  Update,
+  User,
+  Voice,
+} from "@grammyjs/types";
+
 import type { GatewayInboundEvent } from "../types.js";
 
 // Telegram webhook payloads are untrusted external input (Telegram Bot API).
@@ -295,3 +307,68 @@ export function normalizeTelegramUpdate(
     raw: payload,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Compile-time cross-check against the official Telegram Bot API types.
+//
+// `@grammyjs/types` is a types-only dev dependency: it contributes nothing at
+// runtime (the `import type` above is erased from the build) and the schemas
+// above stay the sole runtime validators. Its only job is to make TypeScript
+// prove two things about those schemas, so a drift from the real Bot API shape
+// fails `tsc` instead of silently mis-parsing a live webhook:
+//   1. every field name we model is a real field on the official type — a typo
+//      like `messsage_thread_id`, which would otherwise always parse to
+//      `undefined`, fails the build; and
+//   2. a real official value satisfies our (tolerant) schema — modeling a field
+//      with the wrong primitive (e.g. `chat.id` as a string) fails the build.
+//
+// The check is one-directional on purpose: our schemas are intentionally a
+// *narrower and looser* view (only the fields the normalizer reads, each
+// optional and `.catch()`-guarded), so we do NOT require our type to satisfy
+// the official one — only that we never contradict it.
+type Expect<T extends true> = T;
+/** Every key we model is a real key on the official type. */
+type ModeledKeysAreOfficial<Ours, Official> = keyof Ours extends keyof Official
+  ? true
+  : false;
+/** A real official value is accepted by our tolerant schema. */
+type OfficialValueSatisfiesOurs<Ours, Official> = Official extends Ours
+  ? true
+  : false;
+
+type TelegramFrom = NonNullable<z.infer<typeof TelegramFromSchema>>;
+type TelegramChat = NonNullable<TelegramMessage["chat"]>;
+
+type _TelegramApiCrossChecks = [
+  Expect<ModeledKeysAreOfficial<z.infer<typeof TelegramUpdateSchema>, Update>>,
+  Expect<
+    OfficialValueSatisfiesOurs<z.infer<typeof TelegramUpdateSchema>, Update>
+  >,
+  Expect<ModeledKeysAreOfficial<TelegramMessage, Message>>,
+  Expect<OfficialValueSatisfiesOurs<TelegramMessage, Message>>,
+  Expect<
+    ModeledKeysAreOfficial<
+      z.infer<typeof TelegramCallbackQuerySchema>,
+      CallbackQuery
+    >
+  >,
+  Expect<
+    OfficialValueSatisfiesOurs<
+      z.infer<typeof TelegramCallbackQuerySchema>,
+      CallbackQuery
+    >
+  >,
+  Expect<ModeledKeysAreOfficial<TelegramChat, Chat>>,
+  Expect<ModeledKeysAreOfficial<TelegramFrom, User>>,
+  Expect<
+    ModeledKeysAreOfficial<z.infer<typeof TelegramPhotoSizeSchema>, PhotoSize>
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      z.infer<typeof TelegramDocumentSchema>,
+      TelegramApiDocument
+    >
+  >,
+  Expect<ModeledKeysAreOfficial<z.infer<typeof TelegramVoiceSchema>, Voice>>,
+  Expect<ModeledKeysAreOfficial<z.infer<typeof TelegramAudioSchema>, Audio>>,
+];

--- a/gateway/src/telegram/normalize.ts
+++ b/gateway/src/telegram/normalize.ts
@@ -1,59 +1,84 @@
+import { z } from "zod";
+
 import type { GatewayInboundEvent } from "../types.js";
 
-interface TelegramPhotoSize {
-  file_id: string;
-  file_unique_id: string;
-  width: number;
-  height: number;
-  file_size?: number;
-}
+// Telegram webhook payloads are untrusted external input (Telegram Bot API).
+// These schemas validate the *types* of the nested fields the normalizer reads
+// while staying tolerant: a malformed field collapses to `undefined` (or an
+// empty string for required ids) rather than rejecting the whole update, so the
+// existing downstream null-checks drop an unsupported message as before instead
+// of trusting garbage narrowed off a blanket cast. Unknown keys are stripped
+// from the parsed working copy; the original payload is still preserved verbatim
+// as `raw`.
+const optionalNumber = () => z.number().optional().catch(undefined);
+const optionalString = () => z.string().optional().catch(undefined);
+const optionalBoolean = () => z.boolean().optional().catch(undefined);
+/** A required id string: a missing/non-string value collapses to `""`. */
+const idString = () => z.string().catch("");
 
-interface TelegramDocument {
-  file_id: string;
-  file_unique_id: string;
-  file_name?: string;
-  mime_type?: string;
-  file_size?: number;
-}
+const TelegramPhotoSizeSchema = z.object({
+  file_id: idString(),
+  file_unique_id: optionalString(),
+  width: optionalNumber(),
+  height: optionalNumber(),
+  file_size: optionalNumber(),
+});
 
-interface TelegramVoice {
-  file_id: string;
-  file_unique_id: string;
-  duration: number;
-  mime_type?: string;
-  file_size?: number;
-}
+const TelegramDocumentSchema = z.object({
+  file_id: idString(),
+  file_unique_id: optionalString(),
+  file_name: optionalString(),
+  mime_type: optionalString(),
+  file_size: optionalNumber(),
+});
 
-interface TelegramAudio {
-  file_id: string;
-  file_unique_id: string;
-  duration: number;
-  performer?: string;
-  title?: string;
-  file_name?: string;
-  mime_type?: string;
-  file_size?: number;
-}
+const TelegramVoiceSchema = z.object({
+  file_id: idString(),
+  file_unique_id: optionalString(),
+  duration: optionalNumber(),
+  mime_type: optionalString(),
+  file_size: optionalNumber(),
+});
 
-interface TelegramMessage {
-  message_id?: number;
-  message_thread_id?: number;
-  text?: string;
-  caption?: string;
-  chat?: { id?: number; type?: string };
-  from?: {
-    id?: number;
-    is_bot?: boolean;
-    username?: string;
-    first_name?: string;
-    last_name?: string;
-    language_code?: string;
-  };
-  photo?: TelegramPhotoSize[];
-  document?: TelegramDocument;
-  voice?: TelegramVoice;
-  audio?: TelegramAudio;
-}
+const TelegramAudioSchema = z.object({
+  file_id: idString(),
+  file_unique_id: optionalString(),
+  duration: optionalNumber(),
+  performer: optionalString(),
+  title: optionalString(),
+  file_name: optionalString(),
+  mime_type: optionalString(),
+  file_size: optionalNumber(),
+});
+
+const TelegramFromSchema = z
+  .object({
+    id: optionalNumber(),
+    is_bot: optionalBoolean(),
+    username: optionalString(),
+    first_name: optionalString(),
+    last_name: optionalString(),
+    language_code: optionalString(),
+  })
+  .optional()
+  .catch(undefined);
+
+const TelegramMessageSchema = z.object({
+  message_id: optionalNumber(),
+  message_thread_id: optionalNumber(),
+  text: optionalString(),
+  caption: optionalString(),
+  chat: z
+    .object({ id: optionalNumber(), type: optionalString() })
+    .optional()
+    .catch(undefined),
+  from: TelegramFromSchema,
+  photo: z.array(TelegramPhotoSizeSchema).optional().catch(undefined),
+  document: TelegramDocumentSchema.optional().catch(undefined),
+  voice: TelegramVoiceSchema.optional().catch(undefined),
+  audio: TelegramAudioSchema.optional().catch(undefined),
+});
+type TelegramMessage = z.infer<typeof TelegramMessageSchema>;
 
 /**
  * Topic thread id of a private-chat message, as a string, or undefined for
@@ -66,26 +91,19 @@ function threadIdFromMessage(message: TelegramMessage): string | undefined {
     : undefined;
 }
 
-interface TelegramCallbackQuery {
-  id: string;
-  from: {
-    id?: number;
-    is_bot?: boolean;
-    username?: string;
-    first_name?: string;
-    last_name?: string;
-    language_code?: string;
-  };
-  message?: TelegramMessage;
-  data?: string;
-}
+const TelegramCallbackQuerySchema = z.object({
+  id: idString(),
+  from: TelegramFromSchema,
+  message: TelegramMessageSchema.optional().catch(undefined),
+  data: optionalString(),
+});
 
-interface TelegramUpdate {
-  update_id?: number;
-  message?: TelegramMessage;
-  edited_message?: TelegramMessage;
-  callback_query?: TelegramCallbackQuery;
-}
+const TelegramUpdateSchema = z.object({
+  update_id: optionalNumber(),
+  message: TelegramMessageSchema.optional().catch(undefined),
+  edited_message: TelegramMessageSchema.optional().catch(undefined),
+  callback_query: TelegramCallbackQuerySchema.optional().catch(undefined),
+});
 
 /**
  * Normalize a Telegram webhook payload into a GatewayInboundEvent.
@@ -95,7 +113,11 @@ interface TelegramUpdate {
 export function normalizeTelegramUpdate(
   payload: Record<string, unknown>,
 ): GatewayInboundEvent | null {
-  const update = payload as TelegramUpdate;
+  const parsed = TelegramUpdateSchema.safeParse(payload);
+  if (!parsed.success) {
+    return null;
+  }
+  const update = parsed.data;
   const updateId = update.update_id;
 
   // Handle callback_query updates (inline button clicks)


### PR DESCRIPTION
## Summary

Validate untrusted Telegram Bot API webhook payloads with **tolerant Zod schemas** instead of a blanket `as` cast, and cross-check those schemas against the **official Bot API types** at compile time. First slice of **LUM-2795** (Zod-parse the remaining provider webhook ingress); sibling of **LUM-2794** (the WhatsApp crash).

## Why we want to do this

Provider webhook payloads are **fully untrusted external input**, and the gateway currently *trusts* them via casts. `normalize.ts` deserializes the JSON and narrows it with one blanket cast — `const update = payload as TelegramUpdate` — then reads every nested field (`chat.id`, `from.id`, `photo[]`, `message_thread_id`) as if the cast were a guarantee. It isn't: a cast is a compile-time assertion with **zero runtime checking**.

This matters because of where the seam sits. The per-provider `normalize.ts` is the canonical producer of the internal `GatewayInboundEvent`, and everything downstream — `handle-inbound.ts`, trust/admission, routing — **consumes that event as fully typed and never re-validates provider fields**. So `normalize.ts` is the *last line of defense*: whatever it lets through is trusted from there on. The gateway already uses Zod `safeParse` on its entire control plane; the provider-webhook ingress was the one untrusted boundary still on casts.

Three concrete latent bugs the cast let through:

- a non-number `chat.id` passes the truthy guard and forwards `String({...})` = `"[object Object]"` as the conversation id;
- a non-array `photo` hits `.length` and produces a garbage single-character attachment with an undefined `fileId`;
- a non-number `message_thread_id` stringifies to garbage as the topic thread id.

## What it changes

- Replace the hand-written interfaces with **tolerant** Zod schemas; the TS types are inferred from them (single source of truth). Each field validates its type but collapses a malformed value to `undefined` (or `""` for a required id) rather than rejecting the whole update — so the existing downstream null-checks drop an unsupported message exactly like today, instead of trusting garbage.
- `safeParse` the payload at entry; a non-object payload returns `null` (the function's existing "unsupported" signal).
- **Serve boundary preserved:** `raw: payload` still carries the original payload verbatim (unknown keys included); only the parsed working copy is schema-shaped.
- **No route / signature change** — the normalizer keeps its `Record<string, unknown>` signature, so `telegram-webhook.ts` and the webhook-verification path are untouched.
- **Compile-time cross-check against the official Bot API types.** Telegram publishes an API spec, not TS types, so the schemas are hand-written — which means a typo'd key silently parses to `undefined` forever. To catch that, this PR adds **`@grammyjs/types`** (the canonical community typings, maintained by the grammY project) as a **types-only dev dependency** and asserts at compile time that (1) every field name we model is a real key on the official type, and (2) a real official value satisfies our tolerant schema. Schema drift now fails `tsc`.

## Why it's safe

- **Behavior-identical for real input.** Real Telegram payloads (numeric ids, array photos) normalize to exactly the same `GatewayInboundEvent`. The only behavior that changes is for malformed/attacker input, where garbage is now dropped instead of forwarded — strictly better.
- **No new reject path.** Tolerance means a malformed field collapses rather than throwing; the update is dropped by the same downstream null-checks that already existed, so there's no new way for a valid message to be rejected.
- **Serve boundary untouched.** `raw` is preserved verbatim, so any consumer that reads the original payload is unaffected.
- **The dev dependency has zero runtime footprint.** `@grammyjs/types` ships only `.d.ts` files plus an empty `mod.js`, has zero transitive dependencies, and runs no install script on a registry install; the `import type` is erased from the build. Socket Security scored it Supply Chain / Vulnerability / Quality / License all 100.
- **Verified, not asserted.** The 16 existing tests still pass (behavior preserved); the 4 new tests each fail on the old cast-based behavior; and the compile-time cross-check was negative-controlled — typo'ing a modeled field name and mistyping `chat.id`'s primitive each produce the expected `tsc` failure, and reverting restores a clean check.

## What value it adds

- Removes the blanket cast at the seam that is the *last line of defense* for untrusted ingress, and fixes the three concrete bugs above.
- Establishes the **reference pattern** for the remaining provider webhooks (WhatsApp / Resend / Slack) — tolerant Zod inside `normalize.ts`, `raw` preserved, drop-not-throw.
- The official-types cross-check upgrades "the author remembered to model the shape correctly" into a **compile-time guarantee**, at zero runtime cost — specifically buying back the strictness that tolerance gives up (a silently-wrong key).

## Why the seam is right

Confirmed by an architecture review of the ingress path, not assumed: there is **no adapter layer** the code is moving toward — the gateway's "adapter" is a channel-permission cascade tier (a permission-scoping string), not an ingress abstraction. The per-provider `normalize.ts` is the canonical, unified producer of the `GatewayInboundEvent` discriminated union, and `handle-inbound.ts` trusts its output without re-validation. So validation belongs **inside `normalize.ts`**, exactly where this PR puts it. (Telegram / WhatsApp / email hand `Record<string,unknown>` straight to their normalizer; Slack and Resend cast upstream, so those two will additionally need the cast moved into the normalizer when they're picked up.)

## Test plan

- `cd gateway && bunx tsc --noEmit` — clean (includes the new cross-check assertions). ESLint / Prettier / knip clean.
- `gateway/src/telegram/normalize.test.ts`: **16 existing tests pass** (behavior preserved) + **4 new malformed-input tests** — non-number `chat.id` dropped, non-array `photo` ignored, non-number `message_thread_id` dropped, `raw` preserved verbatim. Each new test **fails on the old cast-based behavior** (asserts the corrected outcome, not a snapshot of current output).
- Negative-control verification of the type cross-check: typo'ing a modeled field name and mistyping `chat.id`'s primitive each produce the expected `tsc` failure; reverting restores a clean type-check.

## Follow-ups (tracked)

- **LUM-2794 — WhatsApp** (next, immediately after): same seam; also fixes a confirmed `RangeError` crash on missing `timestamp` and adds the currently-missing test file. Batch producer, so validation is per-message `safeParse` + skip-and-log rather than drop-the-whole-update.
- **LUM-2795 — Resend** (~1hr, removes an `as unknown as` double-cast) and **Slack** (large; its cast lives upstream in the envelope processor and will move into normalize).

## CLI verb checklist

No new routes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f)_