### PR TITLE
fix(background-wake): time-bound platform wake requests so a hung fetch can't silence the publisher

### DIFF
--- a/assistant/src/background-wake/platform-client.test.ts
+++ b/assistant/src/background-wake/platform-client.test.ts
@@ -255,6 +255,26 @@ describe("background wake platform client", () => {
     );
   });
 
+  test("attaches an abort-timeout signal to every platform request", async () => {
+    // Guards the publisher's single-in-flight serialization: a wake request
+    // that hangs (half-open socket during a platform reconnect) would wedge the
+    // in-flight promise and silence every future refresh. Each request must
+    // carry a timeout so it rejects instead of hanging forever.
+    await publishBackgroundWakeIntent(intentFixture());
+    await clearBackgroundWakeIntent(intentFixture());
+    await renewBackgroundWakeLease("lease-123");
+    await completeBackgroundWakeLease({
+      leaseId: "lease-123",
+      status: "completed",
+    });
+
+    expect(mockClientFetch).toHaveBeenCalledTimes(4);
+    for (const call of mockClientFetch.mock.calls) {
+      const [, init] = call as [string, RequestInit];
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
   test("throws on non-OK platform responses", async () => {
     mockClientFetch = mock(
       async () => new Response("bad gateway", { status: 502 }),

--- a/assistant/src/background-wake/platform-client.ts
+++ b/assistant/src/background-wake/platform-client.ts
@@ -1,6 +1,19 @@
 import { VellumPlatformClient } from "../platform/client.js";
 import type { BackgroundWakeIntent } from "./next-wake.js";
 
+/**
+ * Upper bound for a single background-wake platform request.
+ *
+ * Every call here is a lightweight control-plane request (publish/clear the
+ * wake intent, renew/complete a lease), so it must settle quickly. The bound
+ * exists because the publisher serializes refreshes behind a single in-flight
+ * promise: a request that hangs (half-open socket during a platform reconnect)
+ * would wedge that promise and silence every future refresh. The timeout
+ * guarantees each request rejects instead of hanging, so the publisher always
+ * makes forward progress.
+ */
+const PLATFORM_REQUEST_TIMEOUT_MS = 15_000;
+
 export type BackgroundWakeIntentClientResult = {
   status: "published" | "cleared" | "skipped";
   httpStatus?: number;
@@ -38,6 +51,7 @@ export async function publishBackgroundWakeIntent(
       actual_next_due_at: toIsoString(intent.actualNextDueAt),
       source_payload: intent.sourcePayload,
     }),
+    signal: AbortSignal.timeout(PLATFORM_REQUEST_TIMEOUT_MS),
   });
 
   await throwIfNotOk(response, "publish background wake intent");
@@ -63,6 +77,7 @@ export async function clearBackgroundWakeIntent(
     method: "DELETE",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(PLATFORM_REQUEST_TIMEOUT_MS),
   });
 
   await throwIfNotOk(response, "clear background wake intent");
@@ -84,6 +99,7 @@ export async function renewBackgroundWakeLease(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
+      signal: AbortSignal.timeout(PLATFORM_REQUEST_TIMEOUT_MS),
     },
   );
 
@@ -126,6 +142,7 @@ export async function completeBackgroundWakeLease(args: {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(PLATFORM_REQUEST_TIMEOUT_MS),
     },
   );
 


### PR DESCRIPTION
## Prompt / plan

Investigating the "Platform reconnect doesn't restore heartbeat pipeline" bug: after a platform reconnect the `background-wake-publisher` goes silent (stops both erroring **and** succeeding) and managed heartbeat conversations stop firing. Log signals: a last 403 from the wake publisher, then silence; `disposed stale subscribers` events; a jump in content-block-drops.

**Root cause (this PR):** `assistant/src/background-wake/platform-client.ts` issued all four of its control-plane requests (publish/clear wake intent, renew/complete lease) with **no timeout**. The publisher (`publisher.ts`) serializes refreshes behind a single in-flight promise:

```ts
function schedulePendingRefresh(): void {
  if (refreshTimer || inFlightRefresh) return; // <- dropped while wedged
  ...
}
```

If a request hangs — e.g. a half-open socket left behind by a platform reconnect — `runRefresh` never settles, `inFlightRefresh` stays truthy forever, and **every** subsequent `refreshBackgroundWakeIntent()` is silently dropped at that early-return. That is exactly the reported "stops erroring AND stops succeeding": the last request that completed was the 403; the next one hung and wedged the loop. With no intent republished, the platform never re-issues wake leases and managed heartbeat/schedule wakes stop firing.

**Fix:** attach `AbortSignal.timeout(15_000)` to every platform request. A stalled call now rejects instead of hanging; the rejection surfaces through the publisher's existing `catch`, the in-flight promise settles, and pending refreshes reschedule — so the pipeline self-heals. This is the same timeout every other platform fetch in the codebase already carries (`sync-identity.ts`, `platform-routes.ts`, `credential-health-service.ts`); the background-wake client was the lone outlier with none.

**Scope note.** Per the report's scope (`assistant/src/`, wake publisher / heartbeat), this PR fixes the wake-publisher silence — the mechanism by which the pipeline fails to recover. The other reported symptoms were investigated and are **not** in `assistant/src/`:

- **`userId` never written to credentials** — root cause is client-side: `clients/web/src/lib/local-platform-identity.ts` `injectPlatformCredentials` omits `vellum:platform_user_id` from the pushed set entirely (the CLI login path does send it; the web/Electron reconnect path never has). The daemon write path (`secret-routes.ts` → `setPlatformUserId`) is correct but is never handed the value. Left for a follow-up in `clients/web/` since it's outside this PR's scope.
- **`disposed stale subscribers` / content-block-drops** — normal local-SSE reconnect churn (clients re-subscribing dispose their stale entries; slow/half-open old streams get shed under backpressure in `events-routes.ts`, discarding queued content-block frames). Correlated with the reconnect but not causal to the wake-publisher silence, and not routing any reconnect-completion signal.

## Test plan

- Added a regression test in `platform-client.test.ts` asserting every request (publish/clear/renew/complete) carries an `AbortSignal` timeout — the bug was the total absence of one.
- `bun test src/background-wake/platform-client.test.ts src/background-wake/wake-intent-hooks.test.ts` → 21 pass, 0 fail.
- `bun run typecheck:fast` and the pre-commit full `tsc` both pass.
- Existing publisher/hook tests unchanged and green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PJd6aWTkzRFaXLNp85XnyB)_