### PR TITLE
feat(web): tint the provisioning takeover with the assistant's own color

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -29,6 +29,8 @@ import type {
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
 import { readCheckoutIntent, saveCheckoutIntent } from "@/lib/billing/checkout-intent";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 
 import * as proOnboardingUtils from "./utils";
 
@@ -52,11 +54,14 @@ mock.module("@/stores/organization-store", () => ({
 
 // Stub the takeover avatar hook so the provisioning target's avatar doesn't
 // fire (404-ing) fetches that each invalidateQueries() would await, slowing
-// the polls past the test budget.
+// the polls past the test budget. The payload is mutable so the surface tint
+// derived from it can be driven per-test.
+let avatarComponents: CharacterComponents | null = null;
+let avatarTraits: CharacterTraits | null = null;
 mock.module("@/hooks/use-assistant-avatar", () => ({
   useAssistantAvatar: () => ({
-    components: null,
-    traits: null,
+    components: avatarComponents,
+    traits: avatarTraits,
     customImageUrl: null,
     isLoading: false,
     invalidate: () => {},
@@ -220,6 +225,9 @@ mock.module("@/generated/api/sdk.gen", () => ({
 }));
 
 const { BillingOnboardingModal } = await import("./billing-onboarding-modal");
+const { TAKEOVER_SURFACE, TAKEOVER_SURFACE_VAR } = await import(
+  "./provisioning-state"
+);
 
 const BACKGROUND_LINE =
   "Assistant will go offline briefly while it resizes. Chat might not work during that time.";
@@ -254,6 +262,8 @@ function renderModal({ mode }: { mode?: "checkout" | "resize" } = {}) {
 }
 
 beforeEach(() => {
+  avatarComponents = null;
+  avatarTraits = null;
   subscriptionPlanId = "base";
   onboardingResponse = makeOnboarding();
   assistantResponse = makeAssistant("small", 10);
@@ -429,6 +439,33 @@ describe("BillingOnboardingModal", () => {
     const card = document.body.querySelector('[data-slot="modal-content"]');
     expect(card?.getAttribute("data-theme")).toBeNull();
     expect(card?.className).not.toContain("w-screen");
+  });
+
+  test("the takeover and its exit sheet both paint from the modal's surface variable", async () => {
+    // The sheet covers the takeover while the modal changes shape and theme
+    // underneath it, so a second colour there would show as a cross-fade.
+    avatarComponents = BUNDLED_COMPONENTS;
+    avatarTraits = { bodyShape: "blob", eyeStyle: "curious", color: "purple" };
+    subscriptionPlanId = "pro";
+    assistantResponse = makeAssistant("large", 50);
+    const { getByText, findByTestId } = renderModal();
+
+    await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
+      timeout: 5000,
+    });
+    const content = document.body.querySelector<HTMLElement>(
+      '[data-slot="modal-content"]',
+    );
+    expect(
+      content?.style.getPropertyValue(TAKEOVER_SURFACE_VAR).toLowerCase(),
+    ).toBe("#29202e");
+    const takeover = document.body.querySelector<HTMLElement>(
+      ".provision-surface-settle",
+    );
+    expect(takeover?.style.backgroundColor).toBe(TAKEOVER_SURFACE);
+
+    const sheet = await findByTestId("takeover-exit-sheet");
+    expect(sheet.style.backgroundColor).toBe(TAKEOVER_SURFACE);
   });
 
   test(

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -18,9 +24,14 @@ import type {
   ProvisioningDimensions,
   ProvisioningStateKind,
 } from "./provisioning-machine";
-import { ProvisioningState, TAKEOVER_BACKGROUND } from "./provisioning-state";
+import {
+  ProvisioningState,
+  TAKEOVER_SURFACE,
+  TAKEOVER_SURFACE_VAR,
+} from "./provisioning-state";
 import { useAssistantDomains } from "./use-assistant-domains";
 import { useProProvisioning } from "./use-pro-provisioning";
+import { useTakeoverSurface } from "./use-takeover-surface";
 
 type WizardStep = "provisioning" | "domain" | "complete";
 
@@ -146,6 +157,10 @@ export function BillingOnboardingModal({
 
   const { targets, assistantId, domainSetupAvailable, onboardingSettled } =
     provisioning;
+
+  // Published on the modal so the takeover and the sheet that covers it on the
+  // way out paint from one value — the handoff can't cross-fade two colours.
+  const { tintHex } = useTakeoverSurface(assistantId);
 
   // Resize-mode routing needs "is a domain already registered?", which
   // checkout mode never consults — DomainStep owns its own fetch there. The
@@ -337,6 +352,7 @@ export function BillingOnboardingModal({
         data-theme={isTakeover ? "dark" : undefined}
         overlayClassName={overlayClass}
         className={isTakeover ? provisioningContentClass : "overflow-hidden"}
+        style={{ [TAKEOVER_SURFACE_VAR]: tintHex } as CSSProperties}
       >
         {/* Keyed on step so the fade replays as we swap takeover ⇄ card. The
             takeover is the modal's opening step, so it mounts at full size
@@ -362,7 +378,7 @@ export function BillingOnboardingModal({
                   : "[animation:fadeIn_380ms_ease-out_both_reverse]"
               }`
             }
-            style={{ backgroundColor: TAKEOVER_BACKGROUND }}
+            style={{ backgroundColor: TAKEOVER_SURFACE }}
           />
         )}
       </Modal.Content>

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -14,6 +14,9 @@ import * as motionReact from "motion/react";
 import { organizationsBillingPlansRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import type { PlanListResponse } from "@/generated/api/types.gen";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { SURFACE_GROUND } from "@/utils/avatar-tone";
 
 import type { ProvisioningStateProps } from "./provisioning-state";
 
@@ -22,12 +25,16 @@ import type { ProvisioningStateProps } from "./provisioning-state";
 let avatarQueryId: string | null | undefined;
 /** Flipped per-test to hold the avatar query in flight. */
 let avatarLoading = false;
+/** The avatar the mocked query resolves to; null components keep the neutral
+ *  fallback the phase/mode cases render against. */
+let avatarComponents: CharacterComponents | null = null;
+let avatarTraits: CharacterTraits | null = null;
 mock.module("@/hooks/use-assistant-avatar", () => ({
   useAssistantAvatar: (assistantId: string | null) => {
     avatarQueryId = assistantId;
     return {
-      components: null,
-      traits: null,
+      components: avatarComponents,
+      traits: avatarTraits,
       customImageUrl: null,
       isLoading: avatarLoading,
       invalidate: () => {},
@@ -44,11 +51,14 @@ mock.module("motion/react", () => ({
   useReducedMotion: () => reducedMotion,
 }));
 
-const { ProvisioningState } = await import("./provisioning-state");
+const { ProvisioningState, TAKEOVER_SURFACE, TAKEOVER_SURFACE_VAR } =
+  await import("./provisioning-state");
 
 beforeEach(() => {
   avatarQueryId = undefined;
   avatarLoading = false;
+  avatarComponents = null;
+  avatarTraits = null;
   reducedMotion = false;
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
 });
@@ -465,6 +475,64 @@ describe("takeover avatar", () => {
     renderState();
 
     expect(avatarQueryId).toBe("active-assistant");
+  });
+});
+
+describe("takeover surface", () => {
+  /** The takeover root, which publishes the tint and paints from it. */
+  function root(container: HTMLElement): HTMLElement {
+    const el = container.querySelector<HTMLElement>(
+      ".provision-surface-settle",
+    );
+    if (!el) {
+      throw new Error("takeover root not found");
+    }
+    return el;
+  }
+
+  test("paints from the published variable rather than a literal colour", () => {
+    const { container } = renderState({ assistantId: "primary-assistant" });
+
+    expect(root(container).style.backgroundColor).toBe(TAKEOVER_SURFACE);
+  });
+
+  test("a purple character publishes its own deep tint", () => {
+    avatarComponents = BUNDLED_COMPONENTS;
+    avatarTraits = { bodyShape: "blob", eyeStyle: "curious", color: "purple" };
+
+    const { container } = renderState({ assistantId: "primary-assistant" });
+
+    expect(
+      root(container)
+        .style.getPropertyValue(TAKEOVER_SURFACE_VAR)
+        .toLowerCase(),
+    ).toBe("#29202e");
+  });
+
+  test("an unresolved avatar holds the neutral ground", () => {
+    // A hue committed before the query settles is the wrong assistant's, at
+    // full-viewport scale.
+    avatarLoading = true;
+    avatarComponents = BUNDLED_COMPONENTS;
+    avatarTraits = { bodyShape: "blob", eyeStyle: "curious", color: "purple" };
+
+    const { container } = renderState({ assistantId: "primary-assistant" });
+
+    expect(root(container).style.getPropertyValue(TAKEOVER_SURFACE_VAR)).toBe(
+      SURFACE_GROUND,
+    );
+  });
+
+  test("the default green creature keeps the takeover's established tint", () => {
+    avatarComponents = BUNDLED_COMPONENTS;
+
+    const { container } = renderState({ assistantId: "primary-assistant" });
+
+    expect(
+      root(container)
+        .style.getPropertyValue(TAKEOVER_SURFACE_VAR)
+        .toLowerCase(),
+    ).toBe("#1d281d");
   });
 });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -12,6 +12,7 @@ import {
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
 import { MACHINE_TIER_LABEL, SIZE_LABEL } from "@/lib/billing/machine-sizes";
+import { SURFACE_GROUND } from "@/utils/avatar-tone";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { Button } from "@vellumai/design-library/components/button";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -35,9 +36,13 @@ import {
   PROVISION_PHASE_MIN_MS,
 } from "./utils";
 
-// The mock's takeover tint, matched to the green Vellum creature. No token
-// holds this, so it follows the plans-page PAGE_BACKGROUND raw-hex precedent.
-export const TAKEOVER_BACKGROUND = "#1D271E";
+// The takeover's paint, published as a custom property on the modal so the
+// takeover and the sheet that covers it on the way out resolve one value. The
+// fallback is the hue-neutral ground the surface holds until the avatar
+// resolves. It carries no space after the comma — happy-dom's inline-style
+// parser drops the whole declaration otherwise, so the tests can't see it.
+export const TAKEOVER_SURFACE_VAR = "--takeover-surface";
+export const TAKEOVER_SURFACE = `var(${TAKEOVER_SURFACE_VAR},${SURFACE_GROUND})`;
 
 const CHIP_BACKGROUND =
   "color-mix(in srgb, var(--content-emphasised) 10%, transparent)";
@@ -517,6 +522,10 @@ export function ProvisioningState({
     onPhaseChangeRef.current?.(heldState);
   }, [heldState]);
 
+  // The surface commits to a hue only once the avatar query settles, and eases
+  // there over `--provision-reveal` — the same beat the avatar fades in on.
+  const { tintHex } = useTakeoverSurface(assistantId);
+
   const dwelling = celebrating && resolved;
   useEffect(() => {
     if (!dwelling) {
@@ -529,8 +538,13 @@ export function ProvisioningState({
   return (
     <div
       data-theme="dark"
-      className="relative flex h-full min-h-[420px] w-full flex-col items-center [justify-content:safe_center] gap-10 px-6 py-10 text-center"
-      style={{ backgroundColor: TAKEOVER_BACKGROUND }}
+      className="provision-surface-settle relative flex h-full min-h-[420px] w-full flex-col items-center [justify-content:safe_center] gap-10 px-6 py-10 text-center"
+      style={
+        {
+          [TAKEOVER_SURFACE_VAR]: tintHex,
+          backgroundColor: TAKEOVER_SURFACE,
+        } as CSSProperties
+      }
     >
       <TakeoverAvatar
         assistantId={assistantId}


### PR DESCRIPTION
## Summary
- The provisioning takeover and its exit sheet now paint a deep tint of the target assistant's avatar color, published as `--takeover-surface` on the modal so both resolve one value.
- The surface holds a hue-neutral ground until the avatar query settles, then settles on the same beat the avatar fades in.

Part of plan: takeover-avatar-tinted-background.md (PR 4 of 5)