### PR TITLE
feat(billing): add useIsFreePlan hook exposing free-vs-paid outside settings

### DIFF
--- a/clients/web/src/hooks/use-is-free-plan.test.ts
+++ b/clients/web/src/hooks/use-is-free-plan.test.ts
@@ -21,6 +21,8 @@ let subscriptionFixture: SubscriptionResponse | null = null;
 let subscriptionFetches = 0;
 // When true, the query never resolves — models the first load still in flight.
 let subscriptionHangs = false;
+// Drives the mocked `useIsOrgReady`; the hook folds it into its `enabled` gate.
+let orgReady = true;
 
 mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
   organizationsBillingSubscriptionRetrieveOptions: () => ({
@@ -32,6 +34,10 @@ mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
         : subscriptionFixture;
     },
   }),
+}));
+
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => orgReady,
 }));
 
 const { useIsFreePlan } = await import("./use-is-free-plan");
@@ -88,6 +94,7 @@ describe("useIsFreePlan", () => {
     subscriptionFetches = 0;
     subscriptionHangs = false;
     subscriptionFixture = subscription();
+    orgReady = true;
   });
 
   test("returns true for a base (free) plan", () => {
@@ -110,6 +117,15 @@ describe("useIsFreePlan", () => {
   test("does not fetch and returns undefined when disabled", () => {
     // Unseeded + disabled: the read must not fire and the value stays unknown.
     const { result } = setup({ enabled: false });
+    expect(subscriptionFetches).toBe(0);
+    expect(result.current).toBeUndefined();
+  });
+
+  test("does not fetch and returns undefined when the org is not ready", () => {
+    // Even with `enabled` true, a not-ready org must keep the query from firing
+    // — the request would omit `Vellum-Organization-Id` and be rejected.
+    orgReady = false;
+    const { result } = setup({ enabled: true });
     expect(subscriptionFetches).toBe(0);
     expect(result.current).toBeUndefined();
   });

--- a/clients/web/src/hooks/use-is-free-plan.test.ts
+++ b/clients/web/src/hooks/use-is-free-plan.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for `useIsFreePlan`. The generated subscription retrieve query options
+ * are `mock.module`-replaced so the hook reads a seeded fixture and its fetches
+ * can be counted. The QueryClient uses `staleTime/gcTime: Infinity` +
+ * `retry: false` so a seeded cache resolves synchronously and an unseeded query
+ * stays unresolved (its `queryFn` is a hang) — modeling the loading state.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import type { SubscriptionResponse } from "@/generated/api/types.gen";
+
+// Sentinel query key shared by the mocked options and the seeded cache.
+const SUBSCRIPTION_KEY = ["subscription"];
+
+// The fixture the mocked retrieve options resolve; each test seeds it.
+let subscriptionFixture: SubscriptionResponse | null = null;
+// Counts subscription fetches so the `enabled: false` gate can be asserted.
+let subscriptionFetches = 0;
+// When true, the query never resolves — models the first load still in flight.
+let subscriptionHangs = false;
+
+mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
+  organizationsBillingSubscriptionRetrieveOptions: () => ({
+    queryKey: SUBSCRIPTION_KEY,
+    queryFn: () => {
+      subscriptionFetches += 1;
+      return subscriptionHangs
+        ? new Promise(() => {})
+        : subscriptionFixture;
+    },
+  }),
+}));
+
+const { useIsFreePlan } = await import("./use-is-free-plan");
+
+function subscription(
+  overrides: Partial<SubscriptionResponse> = {},
+): SubscriptionResponse {
+  return {
+    plan_id: "pro",
+    status: "active",
+    renewal_date: null,
+    current_period_end: "2026-07-10T00:00:00Z",
+    cancel_at_period_end: false,
+    cancel_at: null,
+    selected_credit_tier: null,
+    package: { key: "super", name: "Super", version: 1, customized: false },
+    entitlements: { managed_email: false, phone_number: false },
+    ...overrides,
+  };
+}
+
+/**
+ * Render the hook against a fresh QueryClient. When `seed` is set the
+ * subscription cache is primed so the read resolves synchronously.
+ */
+function setup({
+  seed,
+  enabled = true,
+}: {
+  seed?: SubscriptionResponse;
+  enabled?: boolean;
+} = {}) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        gcTime: Infinity,
+      },
+    },
+  });
+  if (seed) {
+    client.setQueryData(SUBSCRIPTION_KEY, seed);
+  }
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+  return renderHook(() => useIsFreePlan(enabled), { wrapper });
+}
+
+describe("useIsFreePlan", () => {
+  beforeEach(() => {
+    subscriptionFetches = 0;
+    subscriptionHangs = false;
+    subscriptionFixture = subscription();
+  });
+
+  test("returns true for a base (free) plan", () => {
+    const { result } = setup({ seed: subscription({ plan_id: "base" }) });
+    expect(result.current).toBe(true);
+  });
+
+  test("returns false for a pro (paid) plan", () => {
+    const { result } = setup({ seed: subscription({ plan_id: "pro" }) });
+    expect(result.current).toBe(false);
+  });
+
+  test("returns undefined while the subscription is unresolved", () => {
+    // No seeded data + a hanging fetch keeps the query pending.
+    subscriptionHangs = true;
+    const { result } = setup();
+    expect(result.current).toBeUndefined();
+  });
+
+  test("does not fetch and returns undefined when disabled", () => {
+    // Unseeded + disabled: the read must not fire and the value stays unknown.
+    const { result } = setup({ enabled: false });
+    expect(subscriptionFetches).toBe(0);
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/clients/web/src/hooks/use-is-free-plan.ts
+++ b/clients/web/src/hooks/use-is-free-plan.ts
@@ -1,18 +1,26 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { organizationsBillingSubscriptionRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 
 /**
  * Whether the org is on the FREE plan (`plan_id === "base"`).
  * `undefined` while loading/unresolved — callers treat unknown as "not free"
  * so paid-only affordances never flash for a paying user. `enabled` gates the
- * fetch so surfaces only fetch the subscription when the value is needed.
+ * fetch so surfaces only fetch the subscription when the value is needed, and
+ * is folded together with `useIsOrgReady()` so the request never fires before
+ * the org store hydrates — the subscription endpoint requires the
+ * `Vellum-Organization-Id` header the interceptor only attaches once the active
+ * org id is known, so a headerless request on first load would be rejected.
  */
 export function useIsFreePlan(enabled = true): boolean | undefined {
+  const orgReady = useIsOrgReady();
   const { data } = useQuery({
     ...organizationsBillingSubscriptionRetrieveOptions(),
-    enabled,
+    enabled: enabled && orgReady,
   });
-  if (data?.plan_id == null) return undefined;
+  if (data?.plan_id == null) {
+    return undefined;
+  }
   return data.plan_id === "base";
 }

--- a/clients/web/src/hooks/use-is-free-plan.ts
+++ b/clients/web/src/hooks/use-is-free-plan.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { organizationsBillingSubscriptionRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+
+/**
+ * Whether the org is on the FREE plan (`plan_id === "base"`).
+ * `undefined` while loading/unresolved — callers treat unknown as "not free"
+ * so paid-only affordances never flash for a paying user. `enabled` gates the
+ * fetch so surfaces only fetch the subscription when the value is needed.
+ */
+export function useIsFreePlan(enabled = true): boolean | undefined {
+  const { data } = useQuery({
+    ...organizationsBillingSubscriptionRetrieveOptions(),
+    enabled,
+  });
+  if (data?.plan_id == null) return undefined;
+  return data.plan_id === "base";
+}


### PR DESCRIPTION
## Summary
- Add useIsFreePlan(enabled) hook reading subscription.plan_id (base=free, pro=paid); undefined while unresolved
- Lets non-settings surfaces (the chat credit paywall) gate on free-vs-paid

Part of plan: credit-wall-billing-cta.md (PR 2 of 3)