### PR TITLE
feat(feature-flags): register experiment-billing-cta-2026-07-23 string flag + read hook

### DIFF
--- a/clients/web/src/hooks/use-billing-cta-experiment.test.ts
+++ b/clients/web/src/hooks/use-billing-cta-experiment.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for the `experiment-billing-cta-2026-07-23` read seam: the pure arm
+ * predicate and the store-backed hook that defaults to "control" until flags
+ * hydrate.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import {
+  isBillingCtaUpgradeArm,
+  useBillingCtaExperimentArm,
+} from "@/hooks/use-billing-cta-experiment";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+beforeEach(() => {
+  // Reset the arm to its "control" default before each test so a value set by
+  // an earlier test can't leak in.
+  useClientFeatureFlagStore
+    .getState()
+    .setStringFlags({ experimentBillingCta20260723: "control" });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("isBillingCtaUpgradeArm", () => {
+  test("is true only for the upgrade-cta arm", () => {
+    expect(isBillingCtaUpgradeArm("upgrade-cta")).toBe(true);
+  });
+
+  test("is false for control, empty, and unknown arms", () => {
+    expect(isBillingCtaUpgradeArm("control")).toBe(false);
+    expect(isBillingCtaUpgradeArm("")).toBe(false);
+    expect(isBillingCtaUpgradeArm("something-else")).toBe(false);
+  });
+});
+
+describe("useBillingCtaExperimentArm", () => {
+  test("defaults to control", () => {
+    const { result } = renderHook(() => useBillingCtaExperimentArm());
+    expect(result.current).toBe("control");
+  });
+
+  test("reflects the arm set on the store", () => {
+    useClientFeatureFlagStore
+      .getState()
+      .setStringFlags({ experimentBillingCta20260723: "upgrade-cta" });
+    const { result } = renderHook(() => useBillingCtaExperimentArm());
+    expect(result.current).toBe("upgrade-cta");
+  });
+});

--- a/clients/web/src/hooks/use-billing-cta-experiment.ts
+++ b/clients/web/src/hooks/use-billing-cta-experiment.ts
@@ -1,0 +1,20 @@
+/**
+ * Read seam for the `experiment-billing-cta-2026-07-23` string flag: the credit
+ * paywall gates on this arm to decide whether FREE users see a single Upgrade
+ * CTA (View Plans takeover) instead of the default Add Credits CTA.
+ */
+
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+/** Current `experiment-billing-cta-2026-07-23` arm; "control" until flags hydrate. */
+export function useBillingCtaExperimentArm(): string {
+  return (
+    useClientFeatureFlagStore.use.stringFlags().experimentBillingCta20260723 ??
+    "control"
+  );
+}
+
+/** Whether the arm enables the free-user Upgrade CTA on the credit paywall. */
+export function isBillingCtaUpgradeArm(arm: string): boolean {
+  return arm === "upgrade-cta";
+}

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -35,6 +35,16 @@ describe("feature flag catalog", () => {
     );
   });
 
+  test("exposes the billing CTA experiment as a client string flag", () => {
+    expect(CLIENT_STRING_FLAG_DEFAULTS.experimentBillingCta20260723).toBe(
+      "control",
+    );
+    expect("experimentBillingCta20260723" in CLIENT_FLAG_DEFAULTS).toBe(false);
+    expect("experimentBillingCta20260723" in ASSISTANT_FLAG_DEFAULTS).toBe(
+      false,
+    );
+  });
+
   test("exposes proactive tips as a client string flag defaulted off", () => {
     expect(CLIENT_STRING_FLAG_DEFAULTS.proactiveTips).toBe("off");
     expect("proactiveTips" in CLIENT_FLAG_DEFAULTS).toBe(false);

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -37,6 +37,15 @@
       "values": ["control", "variant-a", "personal-page"]
     },
     {
+      "id": "experiment-billing-cta-2026-07-23",
+      "scope": "client",
+      "key": "experiment-billing-cta-2026-07-23",
+      "label": "Experiment: Billing CTA 2026-07-23",
+      "description": "Credit paywall CTA experiment. control = single Add Credits CTA for everyone (opens Add Credits modal). upgrade-cta = FREE users (plan_id base) get a single Upgrade CTA (View Plans takeover) instead; PAID users still get Add Credits.",
+      "defaultEnabled": "control",
+      "values": ["control", "upgrade-cta"]
+    },
+    {
       "id": "local-docker-enabled",
       "scope": "client",
       "key": "local-docker-enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -37,6 +37,15 @@
       "values": ["control", "variant-a", "personal-page"]
     },
     {
+      "id": "experiment-billing-cta-2026-07-23",
+      "scope": "client",
+      "key": "experiment-billing-cta-2026-07-23",
+      "label": "Experiment: Billing CTA 2026-07-23",
+      "description": "Credit paywall CTA experiment. control = single Add Credits CTA for everyone (opens Add Credits modal). upgrade-cta = FREE users (plan_id base) get a single Upgrade CTA (View Plans takeover) instead; PAID users still get Add Credits.",
+      "defaultEnabled": "control",
+      "values": ["control", "upgrade-cta"]
+    },
+    {
       "id": "local-docker-enabled",
       "scope": "client",
       "key": "local-docker-enabled",


### PR DESCRIPTION
## Summary
- Register experiment-billing-cta-2026-07-23 as a client-scope string flag (control, upgrade-cta)
- Add useBillingCtaExperimentArm()/isBillingCtaUpgradeArm() read hook (mirrors useProactiveTipsVariant)

Part of plan: credit-wall-billing-cta.md (PR 1 of 3)