### PR TITLE
docs(elevenlabs-voice): align provider guidance with deepgram-voice

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -155,7 +155,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-23T16:13:37.000Z"
+      "updatedAt": "2026-07-23T16:24:31.000Z"
     },
     {
       "id": "deploy-fullstack-vercel",
@@ -214,7 +214,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-23T00:08:19.000Z"
+      "updatedAt": "2026-07-23T16:26:29.000Z"
     },
     {
       "id": "email-setup",
@@ -1268,7 +1268,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-23T15:33:37.000Z"
+      "updatedAt": "2026-07-23T16:26:29.000Z"
     },
     {
       "id": "watch-together",

--- a/skills/elevenlabs-voice/SKILL.md
+++ b/skills/elevenlabs-voice/SKILL.md
@@ -20,7 +20,18 @@ voice_config_update setting="tts_voice_id" value="<voice-id>"
 
 > **The voice lives under the _active_ provider, not always ElevenLabs.** The config key depends on `services.tts.provider`: `elevenlabs` → `services.tts.providers.elevenlabs.voiceId`, `vellum` (managed) → `services.tts.providers.vellum.model`, `deepgram` → `services.tts.providers.deepgram.model`. The `voice_config_update` tool (and the `assistant tts voice <id>` CLI command) handle this routing for you. **Do NOT `assistant config set services.tts.providers.elevenlabs.voiceId ...` blindly** — on a managed (`vellum`) assistant that field is ignored, so the write "succeeds" but the voice never changes. See [Setting the voice](#setting-the-voice) for the CLI fallback.
 >
-> **The tables below apply when the active provider is `elevenlabs` (BYO key) or managed `vellum`.** On managed assistants they are the _only_ ElevenLabs voices — the platform bills per rate-carded model and rejects anything else at synthesis (the write succeeds but the voice fails on the next turn), so don't offer library or cloned voices unless the assistant has its own ElevenLabs API key. With a BYO key ([setup below](#elevenlabs-api-key-setup)), any voice id works. Other TTS providers (`deepgram`, `xai`, `fish-audio`, …) use their own voice/model identifiers — never write an ElevenLabs voice id to them; pick from that provider's own catalog instead.
+> **The tables below apply when the active provider is `elevenlabs` (BYO key) or managed `vellum`.** On managed assistants they are the _only_ ElevenLabs voices — the platform bills per rate-carded model and rejects anything else at synthesis (the write succeeds but the voice fails on the next turn), so don't offer library or cloned voices unless the `elevenlabs` provider is active with its own API key. With a BYO key ([setup below](#elevenlabs-api-key-setup)) and `elevenlabs` active, any voice id works. Other BYO TTS providers (`deepgram`, `xai`, `fish-audio`, …) use their own voice/model identifiers — never write an ElevenLabs voice id to them; see [Getting to an ElevenLabs voice from another provider](#getting-to-an-elevenlabs-voice-from-another-provider).
+
+## Getting to an ElevenLabs voice from another provider
+
+Check the active provider first: `assistant config get services.tts.provider`.
+
+- **Already on managed `vellum`?** No provider change needed. The managed platform supports **both ElevenLabs and Deepgram voices** — `services.tts.providers.vellum.model` accepts either an ElevenLabs voice id or an Aura model id, so switching between them is just another `voice_config_update` call.
+- **On a BYO provider (e.g. `deepgram`) and the user wants an ElevenLabs voice?** Two options — ask which they prefer. Switch with the `voice_config_update` tool, not raw `assistant config set` — the tool validates the switch (e.g. rejects `vellum` when no platform connection exists, which a raw config write would leave silently broken):
+  1. **Switch to managed `vellum`** (`voice_config_update setting="tts_provider" value="vellum"`) — no ElevenLabs key needed; requires a platform connection and bills managed credits. Bonus: they keep access to both the ElevenLabs and Deepgram catalogs.
+  2. **Switch to BYO `elevenlabs`** (`voice_config_update setting="tts_provider" value="elevenlabs"`) — requires an ElevenLabs API key ([setup below](#elevenlabs-api-key-setup)); usage bills their ElevenLabs account directly.
+
+After either switch, set the voice with `voice_config_update` as usual.
 
 ## Choose a Voice
 
@@ -86,7 +97,7 @@ assistant credentials prompt --service elevenlabs --field api_key --label "Eleve
 
 ## Advanced Voice Selection (with API key)
 
-Users with an ElevenLabs API key can go beyond the curated list above.
+Users with an ElevenLabs API key can go beyond the curated list above — **only when the active provider is `elevenlabs` (BYO key)**. On managed `vellum`, stay with the curated voices: the platform only accepts its rate-carded subset, and an unoffered id is persisted successfully but fails on the next spoken turn.
 
 ### Check for an existing key
 

--- a/skills/voice-setup/SKILL.md
+++ b/skills/voice-setup/SKILL.md
@@ -20,7 +20,7 @@ You are helping the user set up and troubleshoot voice features (push-to-talk, t
 
 ## Available Tools
 
-- `voice_config_update` - Change any voice setting (PTT key, conversation timeout, TTS voice ID)
+- `voice_config_update` - Change any voice setting (PTT key, conversation timeout, TTS provider, TTS voice ID)
 - `open_system_settings` - Open macOS System Settings to a specific privacy pane
 - `navigate_settings_tab` - Open the Vellum settings panel to the Voice tab
 - `assistant credentials prompt` - Collect API keys securely (for ElevenLabs/Deepgram TTS)


### PR DESCRIPTION
## Summary
Follow-up audit to #38852, applying the same provider-accuracy rules to the ElevenLabs skill:

- **BYO key scoping**: library/cloned voices require the `elevenlabs` provider to be *active*, not just a stored key — on managed `vellum` the platform rejects non-rate-carded ids at synthesis regardless of the key
- **New cross-provider section**: managed `vellum` accepts both ElevenLabs and Deepgram voice ids with no provider switch; from a BYO provider, switch via `voice_config_update setting="tts_provider"` (validated) to either managed `vellum` or BYO `elevenlabs` + API key
- **Advanced Voice Selection** scoped to BYO `elevenlabs` (mirror of the Codex P2 fixed on the Deepgram skill in #38852)
- `voice-setup` tools list now mentions `voice_config_update` also switches the TTS provider

## Test plan
- `node scripts/skills/lint-skill-spec.mjs elevenlabs-voice voice-setup` passes
- `node scripts/skills/check-catalog.mjs` reports catalog up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPAoQvBBMoDc6AuVFoYrES
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->