### PR TITLE
fix(web): store platform_user_id when injecting local assistant credentials

### DIFF
--- a/clients/web/src/lib/local-platform-identity.test.ts
+++ b/clients/web/src/lib/local-platform-identity.test.ts
@@ -4,6 +4,7 @@ const RUNTIME_ASSISTANT_ID = "qa-loopback-auth";
 const PLATFORM_ASSISTANT_ID = "019ed7d1-e995-71cc-9859-c54f422ace3c";
 const OTHER_PLATFORM_ASSISTANT_ID = "019ed7d1-e995-71cc-9859-c54f422ace3d";
 const ORGANIZATION_ID = "019ed7d1-e995-71cc-9859-c54f422ace3e";
+const PLATFORM_USER_ID = "019ed7d1-e995-71cc-9859-c54f422ace3f";
 const GATEWAY_URL = "http://localhost:5173/assistant/__gateway/20101";
 const HOST_INSTALLATION_ID = "host-installation-1";
 const STATUS_PLATFORM_BASE_URL = "https://registered-platform.example.com";
@@ -91,6 +92,18 @@ mock.module("@/stores/organization-store", () => ({
   },
 }));
 
+const fetchMeMock = mock(async () => ({
+  id: PLATFORM_USER_ID,
+  username: "example-user",
+  email: "user@example.com",
+  first_name: "",
+  last_name: "",
+}));
+
+mock.module("@/domains/account/profile", () => ({
+  fetchMe: fetchMeMock,
+}));
+
 const {
   bootstrapLocalAssistantPlatformIdentity,
   resetLocalPlatformIdentityCacheForTesting,
@@ -156,6 +169,14 @@ beforeEach(() => {
   primeLocalGatewayConnectionWithRepairMock.mockClear();
   fetchOrganizationsMock.mockClear();
   updateLockfileAssistantMock.mockClear();
+  fetchMeMock.mockClear();
+  fetchMeMock.mockImplementation(async () => ({
+    id: PLATFORM_USER_ID,
+    username: "example-user",
+    email: "user@example.com",
+    first_name: "",
+    last_name: "",
+  }));
   resetLocalPlatformIdentityCacheForTesting();
   // Single attempt by default — retry tests opt into a schedule.
   setBootstrapRetryDelaysForTesting([]);
@@ -218,13 +239,59 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
       await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
 
     expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
-    expect(requestNames()).toEqual(["status"]);
+    // The status probe reports no stored platform_user_id, so the flow
+    // backfills it via a single secrets write before returning.
+    expect(requestNames()).toEqual(["status", "secrets"]);
+    expect(storedSecrets).toEqual(["vellum:platform_user_id"]);
     expect(updateLockfileAssistantMock).toHaveBeenCalledWith({
       ...activeAssistant,
       platformAssistantId: PLATFORM_ASSISTANT_ID,
       platformBaseUrl: STATUS_PLATFORM_BASE_URL,
       platformOrganizationId: ORGANIZATION_ID,
     });
+  });
+
+  test("does not backfill the platform user id when status already reports one", async () => {
+    statusBody = {
+      ...(statusBody as Record<string, unknown>),
+      user_id: PLATFORM_USER_ID,
+    };
+
+    const platformAssistantId =
+      await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
+
+    expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
+    expect(requestNames()).toEqual(["status"]);
+    expect(fetchMeMock).not.toHaveBeenCalled();
+    expect(storedSecrets).toEqual([]);
+  });
+
+  test("backfills the signed-in platform user id when status omits it", async () => {
+    await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
+
+    expect(fetchMeMock).toHaveBeenCalledTimes(1);
+    const secretsWrite = requests.find((request) =>
+      request.pathname.endsWith("/v1/secrets"),
+    );
+    expect(secretsWrite?.body).toEqual({
+      type: "credential",
+      name: "vellum:platform_user_id",
+      value: PLATFORM_USER_ID,
+    });
+  });
+
+  test("skips the user-id backfill when the platform lookup fails", async () => {
+    fetchMeMock.mockImplementation(async () => {
+      throw new Error("platform unreachable");
+    });
+
+    const platformAssistantId =
+      await resolveLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
+
+    // A failed lookup must not block resolution or write a bad credential.
+    expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
+    expect(requestNames()).toEqual(["status"]);
+    expect(storedSecrets).toEqual([]);
   });
 
   test("falls back to the configured platform URL when status omits its base URL", async () => {
@@ -272,6 +339,7 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
       "secrets",
       "secrets",
       "secrets",
+      "secrets",
     ]);
     expect(
       requests.find((request) =>
@@ -310,6 +378,11 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
       name: "vellum:platform_base_url",
       value: STATUS_PLATFORM_BASE_URL,
     });
+    expect(injectedSecrets).toContainEqual({
+      type: "credential",
+      name: "vellum:platform_user_id",
+      value: PLATFORM_USER_ID,
+    });
     expect(updateLockfileAssistantMock).toHaveBeenCalledWith({
       ...activeAssistant,
       platformAssistantId: PLATFORM_ASSISTANT_ID,
@@ -333,7 +406,7 @@ describe("resolveLocalAssistantPlatformIdentity", () => {
 
     expect(platformAssistantId).toBe(PLATFORM_ASSISTANT_ID);
     expect(primeLocalGatewayConnectionWithRepairMock).toHaveBeenCalledTimes(1);
-    expect(requestNames()).toEqual(["status"]);
+    expect(requestNames()).toEqual(["status", "secrets"]);
   });
 
   test("skips raw platform calls when platform features are disabled", async () => {
@@ -352,7 +425,7 @@ describe("bootstrapLocalAssistantPlatformIdentity", () => {
     bootstrapLocalAssistantPlatformIdentity(RUNTIME_ASSISTANT_ID);
     await flushAsyncWork();
 
-    expect(requestNames()).toEqual(["status"]);
+    expect(requestNames()).toEqual(["status", "secrets"]);
   });
 
   test("does not repair gateway access during best-effort bootstrap", async () => {
@@ -372,7 +445,7 @@ describe("bootstrapLocalAssistantPlatformIdentity", () => {
     bootstrapLocalAssistantPlatformIdentity();
     await flushAsyncWork();
 
-    expect(requestNames()).toEqual(["status"]);
+    expect(requestNames()).toEqual(["status", "secrets"]);
   });
 
   test("does nothing when platform features are disabled", async () => {

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -1,3 +1,4 @@
+import { fetchMe } from "@/domains/account/profile";
 import { buildVellumMutatingHeaders } from "@/lib/auth/request-headers";
 import {
   getActiveAssistant,
@@ -35,6 +36,8 @@ type PlatformStatusBody = {
   base_url?: unknown;
   organizationId?: unknown;
   organization_id?: unknown;
+  userId?: unknown;
+  user_id?: unknown;
   hasAssistantApiKey?: unknown;
   has_assistant_api_key?: unknown;
   clientInstallationId?: unknown;
@@ -45,6 +48,7 @@ type LocalPlatformStatus = {
   assistantId: string | null;
   baseUrl: string | null;
   organizationId: string | null;
+  userId: string | null;
   hasAssistantApiKey: boolean | null;
   clientInstallationId: string | null;
 };
@@ -220,6 +224,14 @@ async function ensureLocalAssistantPlatformIdentity(
         organizationId: statusOrganizationId,
       });
     }
+    // Backfill the platform user id for an assistant registered before this
+    // credential was injected. Such an assistant is otherwise healthy
+    // (assistant id + API key present, so the flow early-returns here) yet the
+    // gateway's edge auth 403s every request because no platform_user_id is
+    // stored to match against the request's user identity.
+    if (!status?.userId) {
+      await backfillPlatformUserId(gateway);
+    }
     return statusPlatformAssistantId;
   }
 
@@ -269,11 +281,13 @@ async function ensureLocalAssistantPlatformIdentity(
   }
 
   const platformBaseUrl = status?.baseUrl ?? getPlatformRuntimeUrl();
+  const platformUserId = status?.userId ?? (await resolvePlatformUserId());
   await injectPlatformCredentials(gateway, {
     assistantApiKey,
     platformAssistantId,
     platformBaseUrl,
     organizationId,
+    userId: platformUserId,
     webhookSecret: stringValue(registration.webhook_secret),
   });
   await persistPlatformRegistrationMetadata(assistant, {
@@ -356,6 +370,7 @@ async function fetchPlatformStatus(
     assistantId: firstString(body?.assistantId, body?.assistant_id),
     baseUrl: firstString(body?.baseUrl, body?.base_url),
     organizationId: firstString(body?.organizationId, body?.organization_id),
+    userId: firstString(body?.userId, body?.user_id),
     hasAssistantApiKey: firstBoolean(
       body?.hasAssistantApiKey,
       body?.has_assistant_api_key,
@@ -490,6 +505,7 @@ async function injectPlatformCredentials(
     platformAssistantId: string;
     platformBaseUrl: string;
     organizationId: string;
+    userId: string | null;
     webhookSecret: string | null;
   },
 ): Promise<void> {
@@ -497,6 +513,7 @@ async function injectPlatformCredentials(
     ["vellum:platform_assistant_id", params.platformAssistantId],
     ["vellum:platform_base_url", params.platformBaseUrl],
     ["vellum:platform_organization_id", params.organizationId],
+    ["vellum:platform_user_id", params.userId],
     ["vellum:webhook_secret", params.webhookSecret],
   ];
 
@@ -517,6 +534,41 @@ async function injectPlatformCredentials(
       "vellum:assistant_api_key",
       params.assistantApiKey,
     );
+  }
+}
+
+/**
+ * Resolve the signed-in platform user's id (the WorkOS user UUID the gateway's
+ * edge auth matches requests against). Best-effort: returns `null` when the
+ * lookup fails so a transient platform hiccup never blocks identity resolution.
+ */
+async function resolvePlatformUserId(): Promise<string | null> {
+  try {
+    const me = await fetchMe();
+    return stringValue(me.id);
+  } catch (error) {
+    console.warn("local assistant platform user lookup failed", error);
+    return null;
+  }
+}
+
+/**
+ * Store `vellum:platform_user_id` on an already-registered assistant that is
+ * missing it. Best-effort: a lookup or injection failure is logged and
+ * swallowed so a healthy assistant's identity resolution still succeeds.
+ */
+async function backfillPlatformUserId(gateway: {
+  gatewayUrl: string;
+  actorToken: string;
+}): Promise<void> {
+  const userId = await resolvePlatformUserId();
+  if (!userId) {
+    return;
+  }
+  try {
+    await injectCredential(gateway, "vellum:platform_user_id", userId);
+  } catch (error) {
+    console.warn("local assistant platform_user_id backfill failed", error);
   }
 }
 


### PR DESCRIPTION
## Prompt / plan

Follow-up to #38857 (platform-reconnect heartbeat investigation). That PR fixed the wake-publisher silence in `assistant/src`; this one fixes the second symptom from the same report — **`platform_user_id` is never written to credentials and stays `null` after a reconnect** — whose root cause is client-side.

`clients/web/src/lib/local-platform-identity.ts` `injectPlatformCredentials` pushed every platform credential *except* `platform_user_id`:

```ts
const entries: Array<[string, string | null]> = [
  ["vellum:platform_assistant_id", params.platformAssistantId],
  ["vellum:platform_base_url", params.platformBaseUrl],
  ["vellum:platform_organization_id", params.organizationId],
  ["vellum:webhook_secret", params.webhookSecret],
];
```

So a self-hosted assistant paired through the web/Electron app never had `platform_user_id` stored (the CLI login path *does* store it, via `fetchCurrentUser().id`). The gateway's edge auth matches each request's user identity against the stored `platform_user_id` and **403s when none exists** (`gateway/src/http/middleware/auth.ts`), silently breaking an assistant that otherwise looks healthy.

Two paths had to be covered, because the common reconnect case never reaches the injection call:
- **Full registration/injection path** — `injectPlatformCredentials` now includes `vellum:platform_user_id`, sourced from the platform `status` probe or, when absent, the signed-in user via `fetchMe()` (`/v1/user/me/`.id — the same identity the CLI stores).
- **Early-return path** — when the assistant is already registered with an API key present, `ensureLocalAssistantPlatformIdentity` returns before injecting anything. It now **backfills** `platform_user_id` there when the daemon reports none stored, repairing assistants paired before this credential was injected. This is the path the reported reconnect actually hits.

Both are best-effort: a platform lookup or injection failure is logged and swallowed so identity resolution never blocks on it, and `platform_user_id` is skipped entirely when the daemon already has it (no redundant writes, no extra `/v1/user/me/` round-trip once stored).

**Source-of-truth note for reviewers:** `/v1/user/me/` doesn't match `ASSISTANT_PATH_RE`, so it isn't rewritten to the self-hosted gateway — it routes to the platform and returns the WorkOS user UUID, the same identity the gateway compares in edge auth. The auth-store `user.id` was deliberately *not* used: in local mode it can be the `gateway-local` sentinel rather than the platform user.

## Test plan

- Extended `local-platform-identity.test.ts`: new coverage for the early-return backfill (value asserted), the "already stored → skip / no `fetchMe`" case, the failed-lookup best-effort path, and `platform_user_id` in the full-injection path. Updated the existing request-sequence assertions to include the backfill write.
- `bun test src/lib/local-platform-identity.test.ts` → 16 pass, 0 fail.
- `bunx tsc --noEmit` (web) passes; the pre-commit lint + full type-check pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PJd6aWTkzRFaXLNp85XnyB)_