### PR TITLE
feat(web): blur a custom avatar image behind the provisioning takeover

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -29,13 +29,15 @@ let avatarLoading = false;
  *  fallback the phase/mode cases render against. */
 let avatarComponents: CharacterComponents | null = null;
 let avatarTraits: CharacterTraits | null = null;
+/** An uploaded avatar image, which the takeover also blurs behind its content. */
+let avatarCustomImageUrl: string | null = null;
 mock.module("@/hooks/use-assistant-avatar", () => ({
   useAssistantAvatar: (assistantId: string | null) => {
     avatarQueryId = assistantId;
     return {
       components: avatarComponents,
       traits: avatarTraits,
-      customImageUrl: null,
+      customImageUrl: avatarCustomImageUrl,
       isLoading: avatarLoading,
       invalidate: () => {},
     };
@@ -59,6 +61,7 @@ beforeEach(() => {
   avatarLoading = false;
   avatarComponents = null;
   avatarTraits = null;
+  avatarCustomImageUrl = null;
   reducedMotion = false;
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
 });
@@ -478,18 +481,17 @@ describe("takeover avatar", () => {
   });
 });
 
-describe("takeover surface", () => {
-  /** The takeover root, which publishes the tint and paints from it. */
-  function root(container: HTMLElement): HTMLElement {
-    const el = container.querySelector<HTMLElement>(
-      ".provision-surface-settle",
-    );
-    if (!el) {
-      throw new Error("takeover root not found");
-    }
-    return el;
+/** The takeover root, which publishes the tint, paints from it, and holds the
+ *  backdrop and the content layered over it. */
+function root(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>(".provision-surface-settle");
+  if (!el) {
+    throw new Error("takeover root not found");
   }
+  return el;
+}
 
+describe("takeover surface", () => {
   test("paints from the published variable rather than a literal colour", () => {
     const { container } = renderState({ assistantId: "primary-assistant" });
 
@@ -533,6 +535,60 @@ describe("takeover surface", () => {
         .style.getPropertyValue(TAKEOVER_SURFACE_VAR)
         .toLowerCase(),
     ).toBe("#1d281d");
+  });
+});
+
+describe("takeover backdrop", () => {
+  test("a custom-image avatar blurs that image behind the takeover", () => {
+    avatarCustomImageUrl = "blob:vellum/avatar-image";
+
+    const { getByTestId } = renderState({ assistantId: "primary-assistant" });
+
+    expect(
+      getByTestId("takeover-backdrop")
+        .querySelector("img")
+        ?.getAttribute("src"),
+    ).toBe("blob:vellum/avatar-image");
+  });
+
+  test("every layer beside the backdrop stacks above it", () => {
+    // The backdrop is absolutely positioned, so it paints over any sibling left
+    // in normal flow — the avatar and the phase block both have to be raised.
+    avatarCustomImageUrl = "blob:vellum/avatar-image";
+
+    const { container, getByTestId } = renderState({
+      state: "WAITING",
+      assistantId: "primary-assistant",
+    });
+    const backdrop = getByTestId("takeover-backdrop");
+    const content = Array.from(root(container).children).filter(
+      (el) => el !== backdrop,
+    );
+
+    expect(content.length).toBeGreaterThan(0);
+    for (const el of content) {
+      expect(el.className).toContain("z-10");
+    }
+  });
+
+  test("a character avatar gets the flat tint and no image layer", () => {
+    avatarComponents = BUNDLED_COMPONENTS;
+    avatarTraits = { bodyShape: "blob", eyeStyle: "curious", color: "purple" };
+
+    const { queryByTestId } = renderState({ assistantId: "primary-assistant" });
+
+    expect(queryByTestId("takeover-backdrop")).toBeNull();
+  });
+
+  test("withholds the backdrop until the avatar query settles", () => {
+    // A backdrop that appears and then disappears is worse than one that
+    // arrives late.
+    avatarLoading = true;
+    avatarCustomImageUrl = "blob:vellum/avatar-image";
+
+    const { queryByTestId } = renderState({ assistantId: "primary-assistant" });
+
+    expect(queryByTestId("takeover-backdrop")).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -26,6 +26,7 @@ import {
   buildResourceChanges,
   type ResourceChangeKey,
 } from "./resource-changes";
+import { TakeoverBackdrop } from "./takeover-backdrop";
 import { useProvisioningCredits } from "./use-provisioning-credits";
 import { useTakeoverSurface } from "./use-takeover-surface";
 import { useRotatingIndex } from "./use-rotating-index";
@@ -206,7 +207,7 @@ function TakeoverAvatar({
   return (
     <div
       aria-hidden
-      className={`provision-avatar-evolve flex flex-col items-center${AVATAR_MODE_CLASS[activeMode]}`}
+      className={`provision-avatar-evolve relative z-10 flex flex-col items-center${AVATAR_MODE_CLASS[activeMode]}`}
       style={
         {
           "--provision-avatar-size": `${size}px`,
@@ -524,7 +525,7 @@ export function ProvisioningState({
 
   // The surface commits to a hue only once the avatar query settles, and eases
   // there over `--provision-reveal` — the same beat the avatar fades in on.
-  const { tintHex } = useTakeoverSurface(assistantId);
+  const { tintHex, backdropImageUrl } = useTakeoverSurface(assistantId);
 
   const dwelling = celebrating && resolved;
   useEffect(() => {
@@ -546,6 +547,9 @@ export function ProvisioningState({
         } as CSSProperties
       }
     >
+      {/* An absolutely positioned layer paints over in-flow siblings, so the
+          content below carries `z-10` to sit on top of it. */}
+      {backdropImageUrl && <TakeoverBackdrop imageUrl={backdropImageUrl} />}
       <TakeoverAvatar
         assistantId={assistantId}
         mode={avatarModeFor(heldState, softWaiting)}
@@ -559,7 +563,7 @@ export function ProvisioningState({
           mid-animation. */}
       <div
         key={phaseKey}
-        className="flex min-h-[144px] w-full flex-col items-center gap-8 [animation:onboarding-step-in_420ms_ease-out] motion-reduce:[animation:none]"
+        className="relative z-10 flex min-h-[144px] w-full flex-col items-center gap-8 [animation:onboarding-step-in_420ms_ease-out] motion-reduce:[animation:none]"
       >
         {renderPhase()}
       </div>


### PR DESCRIPTION
## Summary
- Assistants with a custom avatar image get that image blurred and darkened behind the provisioning takeover, over the neutral ground that holds while it decodes.
- The backdrop mounts only once the avatar query resolves, so it never appears and then vanishes.

Part of plan: takeover-avatar-tinted-background.md (PR 5 of 5)