### PR TITLE
feat(web): first-run Voices view — provider dropdown, retitle, start-from-picker (JARVIS-1342)

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -42,6 +42,19 @@ mock.module("@/components/speech/voice-list", () => ({
   VoiceList: () => <div data-testid="voice-list" />,
 }));
 
+// The Voices view reads managed-voice availability (for the credits subtitle)
+// off the daemon config graph; stub it so the card renders without React Query.
+mock.module("@/components/speech/use-managed-voice-selection", () => ({
+  useManagedVoiceSelection: () => ({
+    available: true,
+    voices: [],
+    currentModel: "",
+    defaultModel: "",
+    selectModel: () => {},
+    selecting: false,
+  }),
+}));
+
 // The settings view links to Models & Services; give it a plain anchor so the
 // card renders without a Router.
 mock.module("react-router", () => ({
@@ -60,9 +73,9 @@ const { VoiceFirstRunCard } = await import(
 const SETTINGS_LINK = "Voice settings";
 
 /**
- * The dialog's current title. The settings view shares its copy with the footer
- * link, so assertions read the heading rather than matching text anywhere —
- * otherwise the link alone would satisfy them.
+ * The dialog's current title. Read the heading specifically rather than matching
+ * text anywhere — the intro's "Voice settings" link would otherwise satisfy a
+ * loose text match for the settings-view assertions.
  */
 function dialogTitle(): string {
   return document.querySelector('[data-slot="modal-title"]')?.textContent ?? "";
@@ -158,15 +171,16 @@ describe("VoiceFirstRunCard", () => {
 
       fireEvent.click(getByText(SETTINGS_LINK));
 
-      expect(dialogTitle()).toBe("Voice settings");
+      expect(dialogTitle()).toBe("Voices");
       // The view is just the voice picker plus a pointer to Models & Services,
       // where advanced/BYO provider and API-key config lives.
       expect(getByTestId("voice-list")).toBeTruthy();
       expect(getByText("Models & Services")).toBeTruthy();
-      // The voice hot-applies, so there's no Save; and this is a view swap, not
-      // an overlay — the intro's forward action is gone and there's one dialog.
+      // The voice hot-applies, so there's no Save. "Start talking" moves into
+      // this view so a pick flows straight in, and it's a view swap, not an
+      // overlay — one dialog.
       expect(queryByText("Save")).toBeNull();
-      expect(queryByText("Start talking")).toBeNull();
+      expect(getByText("Start talking")).toBeTruthy();
       expect(baseElement.querySelectorAll('[role="dialog"]').length).toBe(1);
     });
 
@@ -196,7 +210,7 @@ describe("VoiceFirstRunCard", () => {
       );
 
       fireEvent.click(getByText(SETTINGS_LINK));
-      expect(dialogTitle()).toBe("Voice settings");
+      expect(dialogTitle()).toBe("Voices");
       fireEvent.click(getByLabelText("Back"));
       expect(getByText("Start talking")).toBeTruthy();
     });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -239,9 +239,13 @@ function VoiceSettingsView({
   onStart: () => void;
   onBack: () => void;
 }) {
-  // Managed assistants get the credits subtitle; BYO ones see no catalog here
-  // (the footer note is their path), so the Vellum-credits line wouldn't apply.
-  const { available } = useManagedVoiceSelection(assistantId);
+  // Own the selection here (rather than let the list self-commit) so the write's
+  // in-flight state can gate Start: the picker reports a pick via `onChange`, and
+  // `selecting` stays true until the config patch and refetch settle. Managed
+  // assistants also get the credits subtitle; BYO ones see no catalog (the footer
+  // note is their path), so the Vellum-credits line wouldn't apply.
+  const { available, currentModel, selectModel, selecting } =
+    useManagedVoiceSelection(assistantId);
 
   return (
     <>
@@ -261,11 +265,17 @@ function VoiceSettingsView({
             it hot-applies on the next reply (no Save). A provider dropdown
             scopes the list; it hides itself for assistants on a bring-your-own
             provider, leaving the footer note as their path. */}
-        <VoiceList assistantId={assistantId} filterBySource />
+        <VoiceList
+          assistantId={assistantId}
+          filterBySource
+          value={currentModel}
+          onChange={selectModel}
+        />
       </Modal.Body>
       {/* Mirrors the intro footer (fine print left, primary right) and is always
           present, so the picker flows straight into the session without a size
-          change when a voice is chosen. */}
+          change when a voice is chosen. Start waits out an in-flight voice write
+          so the session can't open on the previous voice. */}
       <Modal.Footer className="items-center justify-between gap-3">
         <p className="text-label-small-default text-[var(--content-tertiary)]">
           Speech providers, transcription, and API keys live in{" "}
@@ -277,7 +287,12 @@ function VoiceSettingsView({
           </Link>
           .
         </p>
-        <Button variant="primary" onClick={onStart} className="shrink-0">
+        <Button
+          variant="primary"
+          onClick={onStart}
+          disabled={selecting}
+          className="shrink-0"
+        >
           Start talking
         </Button>
       </Modal.Footer>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -7,7 +7,9 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
 import { VoiceList } from "@/components/speech/voice-list";
+import { MANAGED_VOICE_CREDITS_NOTE } from "@/lib/tts/managed-voice-catalog";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
@@ -90,6 +92,10 @@ export function VoiceFirstRunCard({
   const assistantName = useResolvedAssistantsStore.use
     .assistants()
     .find((a) => a.id === assistantId)?.name;
+  // Managed assistants get the credits subtitle; BYO ones see no catalog here
+  // (the note below is their path), so the Vellum-credits line wouldn't apply.
+  const { available: managedVoiceAvailable } =
+    useManagedVoiceSelection(assistantId);
 
   const [view, setView] = useState<FirstRunView>("intro");
   const backToIntro = () => setView("intro");
@@ -215,15 +221,22 @@ export function VoiceFirstRunCard({
             <Modal.Header>
               <div className="flex items-center gap-2">
                 <BackButton onClick={backToIntro} />
-                <Modal.Title className="leading-tight">Voice settings</Modal.Title>
+                <div className="flex min-w-0 flex-col">
+                  <Modal.Title className="leading-tight">Voices</Modal.Title>
+                  {managedVoiceAvailable && (
+                    <Modal.Description>
+                      {MANAGED_VOICE_CREDITS_NOTE}
+                    </Modal.Description>
+                  )}
+                </div>
               </div>
             </Modal.Header>
             <Modal.Body className="space-y-4">
               {/* Just the voice — the one thing most people come here to change,
-                  and it hot-applies on the next reply (no Save). The list hides
-                  itself for assistants on a bring-your-own provider, leaving the
-                  note below as their path. */}
-              <VoiceList assistantId={assistantId} showSource />
+                  and it hot-applies on the next reply (no Save). A provider
+                  dropdown scopes the list; it hides itself for assistants on a
+                  bring-your-own provider, leaving the note below as their path. */}
+              <VoiceList assistantId={assistantId} filterBySource />
               <p className="text-label-small-default text-[var(--content-tertiary)]">
                 Speech providers, transcription, and API keys live in{" "}
                 <Link

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -117,7 +117,7 @@ export function VoiceFirstRunCard({
         size="sm"
         // Held constant across views: a sub-view that resized the dialog would
         // shift the back arrow and ✕ out from under the pointer.
-        className="max-w-[440px]"
+        className="max-w-[520px]"
         // iOS lock: strip the ✕, the backdrop-tap dismiss, and Escape so the
         // only way forward is "Start talking" → the mic alert.
         hideCloseButton={nonDismissible}
@@ -240,7 +240,7 @@ export function VoiceFirstRunCard({
               <p className="text-label-small-default text-[var(--content-tertiary)]">
                 Speech providers, transcription, and API keys live in{" "}
                 <Link
-                  to={routes.settings.ai}
+                  to={`${routes.settings.ai}#text-to-speech`}
                   className="text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 hover:text-[var(--content-default)]"
                 >
                   Models &amp; Services

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -92,10 +92,6 @@ export function VoiceFirstRunCard({
   const assistantName = useResolvedAssistantsStore.use
     .assistants()
     .find((a) => a.id === assistantId)?.name;
-  // Managed assistants get the credits subtitle; BYO ones see no catalog here
-  // (the note below is their path), so the Vellum-credits line wouldn't apply.
-  const { available: managedVoiceAvailable } =
-    useManagedVoiceSelection(assistantId);
 
   const [view, setView] = useState<FirstRunView>("intro");
   const backToIntro = () => setView("intro");
@@ -217,53 +213,75 @@ export function VoiceFirstRunCard({
         )}
 
         {view === "settings" && (
-          <>
-            <Modal.Header>
-              <div className="flex items-center gap-2">
-                <BackButton onClick={backToIntro} />
-                <div className="flex min-w-0 flex-col">
-                  <Modal.Title className="leading-tight">Voices</Modal.Title>
-                  {managedVoiceAvailable && (
-                    <Modal.Description>
-                      {MANAGED_VOICE_CREDITS_NOTE}
-                    </Modal.Description>
-                  )}
-                </div>
-              </div>
-            </Modal.Header>
-            <Modal.Body>
-              {/* Just the voice — the one thing most people come here to change,
-                  and it hot-applies on the next reply (no Save). A provider
-                  dropdown scopes the list; it hides itself for assistants on a
-                  bring-your-own provider, leaving the footer note as their path. */}
-              <VoiceList assistantId={assistantId} filterBySource />
-            </Modal.Body>
-            {/* Mirrors the intro footer (fine print left, primary right) and is
-                always present, so the picker can flow straight into the session
-                without a size change when a voice is chosen. */}
-            <Modal.Footer className="items-center justify-between gap-3">
-              <p className="text-label-small-default text-[var(--content-tertiary)]">
-                Speech providers, transcription, and API keys live in{" "}
-                <Link
-                  to={`${routes.settings.ai}#text-to-speech`}
-                  className="text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 hover:text-[var(--content-default)]"
-                >
-                  Models &amp; Services
-                </Link>
-                .
-              </p>
-              <Button
-                variant="primary"
-                onClick={onStart}
-                className="shrink-0"
-              >
-                Start talking
-              </Button>
-            </Modal.Footer>
-          </>
+          <VoiceSettingsView
+            assistantId={assistantId}
+            onStart={onStart}
+            onBack={backToIntro}
+          />
         )}
       </Modal.Content>
     </Modal.Root>
+  );
+}
+
+/**
+ * The "Voices" view reached from the intro's "Voice settings" link: pick the
+ * assistant's voice, then start. Split into its own component so the managed-
+ * voice query runs only when this view is open — not on the intro (which would
+ * pull the React Query graph into every first-run render).
+ */
+function VoiceSettingsView({
+  assistantId,
+  onStart,
+  onBack,
+}: {
+  assistantId: string | null;
+  onStart: () => void;
+  onBack: () => void;
+}) {
+  // Managed assistants get the credits subtitle; BYO ones see no catalog here
+  // (the footer note is their path), so the Vellum-credits line wouldn't apply.
+  const { available } = useManagedVoiceSelection(assistantId);
+
+  return (
+    <>
+      <Modal.Header>
+        <div className="flex items-center gap-2">
+          <BackButton onClick={onBack} />
+          <div className="flex min-w-0 flex-col">
+            <Modal.Title className="leading-tight">Voices</Modal.Title>
+            {available && (
+              <Modal.Description>{MANAGED_VOICE_CREDITS_NOTE}</Modal.Description>
+            )}
+          </div>
+        </div>
+      </Modal.Header>
+      <Modal.Body>
+        {/* Just the voice — the one thing most people come here to change, and
+            it hot-applies on the next reply (no Save). A provider dropdown
+            scopes the list; it hides itself for assistants on a bring-your-own
+            provider, leaving the footer note as their path. */}
+        <VoiceList assistantId={assistantId} filterBySource />
+      </Modal.Body>
+      {/* Mirrors the intro footer (fine print left, primary right) and is always
+          present, so the picker flows straight into the session without a size
+          change when a voice is chosen. */}
+      <Modal.Footer className="items-center justify-between gap-3">
+        <p className="text-label-small-default text-[var(--content-tertiary)]">
+          Speech providers, transcription, and API keys live in{" "}
+          <Link
+            to={`${routes.settings.ai}#text-to-speech`}
+            className="text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 hover:text-[var(--content-default)]"
+          >
+            Models &amp; Services
+          </Link>
+          .
+        </p>
+        <Button variant="primary" onClick={onStart} className="shrink-0">
+          Start talking
+        </Button>
+      </Modal.Footer>
+    </>
   );
 }
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -231,12 +231,17 @@ export function VoiceFirstRunCard({
                 </div>
               </div>
             </Modal.Header>
-            <Modal.Body className="space-y-4">
+            <Modal.Body>
               {/* Just the voice — the one thing most people come here to change,
                   and it hot-applies on the next reply (no Save). A provider
                   dropdown scopes the list; it hides itself for assistants on a
-                  bring-your-own provider, leaving the note below as their path. */}
+                  bring-your-own provider, leaving the footer note as their path. */}
               <VoiceList assistantId={assistantId} filterBySource />
+            </Modal.Body>
+            {/* Mirrors the intro footer (fine print left, primary right) and is
+                always present, so the picker can flow straight into the session
+                without a size change when a voice is chosen. */}
+            <Modal.Footer className="items-center justify-between gap-3">
               <p className="text-label-small-default text-[var(--content-tertiary)]">
                 Speech providers, transcription, and API keys live in{" "}
                 <Link
@@ -247,7 +252,14 @@ export function VoiceFirstRunCard({
                 </Link>
                 .
               </p>
-            </Modal.Body>
+              <Button
+                variant="primary"
+                onClick={onStart}
+                className="shrink-0"
+              >
+                Start talking
+              </Button>
+            </Modal.Footer>
           </>
         )}
       </Modal.Content>

--- a/clients/web/src/domains/settings/pages/voice-picker-card.tsx
+++ b/clients/web/src/domains/settings/pages/voice-picker-card.tsx
@@ -22,6 +22,7 @@ import { Button } from "@vellumai/design-library/components/button";
 import { DetailCard } from "@/components/detail-card";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
+import { MANAGED_VOICE_CREDITS_NOTE } from "@/lib/tts/managed-voice-catalog";
 import { VoiceLabel } from "@/components/speech/voice-list";
 import { VoicePickerModal } from "@/components/speech/voice-picker-modal";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
@@ -44,7 +45,7 @@ export function VoicePickerCard() {
     return (
       <DetailCard
         title={voiceTitle}
-        subtitle="Uses Vellum credits, through providers like ElevenLabs and Deepgram."
+        subtitle={MANAGED_VOICE_CREDITS_NOTE}
       >
         <div className="flex items-center gap-3">
           <VoiceLabel

--- a/clients/web/src/lib/tts/managed-voice-catalog.ts
+++ b/clients/web/src/lib/tts/managed-voice-catalog.ts
@@ -16,6 +16,14 @@ export const MANAGED_VOICE_SOURCE_LABELS: Record<string, string> = {
 };
 
 /**
+ * Subtitle for managed-voice pickers: managed TTS bills Vellum credits while
+ * being served by upstream providers. Shared so the Voice-page card and the
+ * live-voice first-run picker can't drift.
+ */
+export const MANAGED_VOICE_CREDITS_NOTE =
+  "Uses Vellum credits, through providers like ElevenLabs and Deepgram.";
+
+/**
  * Split a voice `description` ("American · calm, smooth, professional") into its
  * character traits and its accent. The traits are the distinguishing part, so
  * UIs lead with them and de-emphasize the accent; `traits` is also the natural


### PR DESCRIPTION
## Summary
- The voice-mode first-run modal's **"Voice settings"** sub-view is retitled **"Voices"** and now reuses the **provider dropdown** from the Voice-page picker (`VoiceList filterBySource`) instead of per-row provider badges.
- Adds the managed-voice credits subtitle under the title ("Uses Vellum credits, through providers like ElevenLabs and Deepgram"), gated to managed assistants. The copy is extracted to a shared `MANAGED_VOICE_CREDITS_NOTE` so the Voice-page card and this view can't drift.
- The **Models & Services** note now deep-links to `#text-to-speech` so it lands on the speech card (below the fold).
- Adds an always-present footer mirroring the intro (note left, primary **Start talking** right) so picking a voice flows straight into the session — no back-out, no size change.
- Widens the first-run card 440 → 520px so the Voices view isn't cramped.

## Original prompt
Follow-up to the voice-picker polish: bring the first-run modal's voice sub-view in line with the Voice-page picker (provider dropdown, "Voices" title, credits subtitle), deep-link its Models & Services pointer to the right card, and let the user start talking directly from the picker instead of backing out. Tracked as JARVIS-1342.