### PR TITLE
feat(chat): single experiment-gated credit-paywall CTA (Add Credits vs Upgrade) in a narrower card

### DIFF
--- a/clients/web/src/domains/chat/components/billing-error-banner.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.tsx
@@ -12,6 +12,12 @@ interface BillingErrorBannerProps {
   onAction: () => void;
   secondaryCtaLabel?: string;
   onSecondaryAction?: () => void;
+  /**
+   * Render as a standalone, centered card ~24px narrower than the composer with
+   * full rounding, instead of a full-width banner flush-mounted above the
+   * composer (which flattens its bottom corners into the composer top).
+   */
+  detached?: boolean;
 }
 
 export function BillingErrorBanner({
@@ -23,15 +29,22 @@ export function BillingErrorBanner({
   onAction,
   secondaryCtaLabel,
   onSecondaryAction,
+  detached = false,
 }: BillingErrorBannerProps) {
   return (
     <div
       className="flex overflow-hidden"
       style={{
         background: "var(--surface-active)",
-        borderRadius: "10px 10px 0 0",
         animation: "fadeInUp 0.25s ease-out both",
         width: "100%",
+        ...(detached
+          ? {
+              maxWidth: "calc(100% - 24px)",
+              marginInline: "auto",
+              borderRadius: "10px",
+            }
+          : { borderRadius: "10px 10px 0 0" }),
       }}
       role="status"
       aria-label={ariaLabel}

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -84,6 +84,12 @@ import {
   shouldShowGenericChatErrorNotice,
 } from "@/domains/chat/utils/error-classification";
 import { openUrlInPopupOrTab } from "@/domains/chat/utils/oauth-popup-links";
+import { resolveCreditPaywallCta } from "@/domains/chat/utils/credit-paywall-cta";
+import {
+  isBillingCtaUpgradeArm,
+  useBillingCtaExperimentArm,
+} from "@/hooks/use-billing-cta-experiment";
+import { useIsFreePlan } from "@/hooks/use-is-free-plan";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import type { DisplayAttachment, DisplayMessage } from "@/domains/chat/types/types";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -888,6 +894,15 @@ export function ChatMainPanel({
   const billingBannerDecision =
     errorBillingBannerDecision ?? noticeBillingBannerDecision;
 
+  // Credit-paywall CTA: single CTA gated by experiment arm + plan. Only fetch
+  // the subscription when the credit paywall is actually shown.
+  const billingCtaArm = useBillingCtaExperimentArm();
+  const isFreePlan = useIsFreePlan(billingBannerDecision === "managed_credits");
+  const creditPaywallMode = resolveCreditPaywallCta({
+    isUpgradeArm: isBillingCtaUpgradeArm(billingCtaArm),
+    isFreePlan,
+  });
+
   // -------------------------------------------------------------------------
   // JSX construction
   // -------------------------------------------------------------------------
@@ -959,7 +974,10 @@ export function ChatMainPanel({
       onCancelEdit={isEditing ? handleCancelEdit : undefined}
       textareaMaxHeightPx={isEmptyConversation ? 320 : undefined}
       suggestion={suggestion}
-      hasBillingBanner={billingBannerDecision !== null}
+      hasBillingBanner={
+        billingBannerDecision !== null &&
+        billingBannerDecision !== "managed_credits"
+      }
       thresholdPickerSlot={
         assistantId ? (
           <ComposerSettingsMenu
@@ -991,8 +1009,10 @@ export function ChatMainPanel({
               <DailyLimitBanner onAdjustLimit={pushToBillingSettings} />
             ) : billingBannerDecision === "managed_credits" ? (
               <CreditsExhaustedBanner
+                mode={creditPaywallMode}
                 onAddCredits={() => setShowAddCreditsModal(true)}
                 onUpgrade={pushToPlansTakeover}
+                detached
               />
             ) : billingBannerDecision === "provider_billing" ? (
               <ProviderBillingBanner onOpenSettings={pushToAiSettings} />

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
@@ -1,8 +1,8 @@
 /**
- * Tests for `CreditsExhaustedBanner` — the two-CTA credit wall.
+ * Tests for `CreditsExhaustedBanner` — the single-CTA credit wall gated by mode.
  *
  * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
- * and drives the CTAs with `fireEvent`. No jest-dom matchers — we assert with
+ * and drives the CTA with `fireEvent`. No jest-dom matchers — we assert with
  * plain bun `expect` against query results. The title carries an inline emoji,
  * so it is matched with a regex that tolerates the prefix.
  */
@@ -16,45 +16,42 @@ afterEach(() => {
 });
 
 describe("CreditsExhaustedBanner", () => {
-  test("renders the title, subtitle, and both CTAs", () => {
-    const { getByText, getByRole } = render(
-      <CreditsExhaustedBanner onAddCredits={() => {}} onUpgrade={() => {}} />,
-    );
-
-    expect(getByText(/Your balance has run out/)).toBeTruthy();
-    expect(
-      getByText("Upgrade to a higher plan or add credits to continue."),
-    ).toBeTruthy();
-    expect(getByRole("button", { name: "Add Credits" })).toBeTruthy();
-    expect(getByRole("button", { name: "Upgrade" })).toBeTruthy();
-  });
-
-  test("clicking Add Credits fires onAddCredits only", () => {
+  test("add-credits mode renders exactly one Add Credits CTA and no Upgrade", () => {
     const onAddCredits = mock(() => {});
     const onUpgrade = mock(() => {});
 
-    const { getByRole } = render(
+    const { getAllByRole, getByRole, queryByRole, getByText } = render(
       <CreditsExhaustedBanner
+        mode="add-credits"
         onAddCredits={onAddCredits}
         onUpgrade={onUpgrade}
       />,
     );
+
+    expect(getByText(/Your balance has run out/)).toBeTruthy();
+    expect(getAllByRole("button").length).toBe(1);
+    expect(queryByRole("button", { name: "Upgrade" })).toBeNull();
 
     fireEvent.click(getByRole("button", { name: "Add Credits" }));
     expect(onAddCredits).toHaveBeenCalledTimes(1);
     expect(onUpgrade).not.toHaveBeenCalled();
   });
 
-  test("clicking Upgrade fires onUpgrade only", () => {
+  test("upgrade mode renders exactly one Upgrade CTA and no Add Credits", () => {
     const onAddCredits = mock(() => {});
     const onUpgrade = mock(() => {});
 
-    const { getByRole } = render(
+    const { getAllByRole, getByRole, queryByRole, getByText } = render(
       <CreditsExhaustedBanner
+        mode="upgrade"
         onAddCredits={onAddCredits}
         onUpgrade={onUpgrade}
       />,
     );
+
+    expect(getByText(/Your balance has run out/)).toBeTruthy();
+    expect(getAllByRole("button").length).toBe(1);
+    expect(queryByRole("button", { name: "Add Credits" })).toBeNull();
 
     fireEvent.click(getByRole("button", { name: "Upgrade" }));
     expect(onUpgrade).toHaveBeenCalledTimes(1);

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
@@ -1,24 +1,37 @@
 
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
+import type { CreditPaywallCtaMode } from "@/domains/chat/utils/credit-paywall-cta";
 
 interface CreditsExhaustedBannerProps {
+  mode: CreditPaywallCtaMode;
   onAddCredits: () => void;
   onUpgrade: () => void;
+  detached?: boolean;
 }
 
 export function CreditsExhaustedBanner({
+  mode,
   onAddCredits,
   onUpgrade,
+  detached,
 }: CreditsExhaustedBannerProps) {
+  const isUpgrade = mode === "upgrade";
   return (
     <BillingErrorBanner
-      ariaLabel="Your balance has run out. Upgrade to a higher plan or add credits to continue."
+      ariaLabel={
+        isUpgrade
+          ? "Your balance has run out. Upgrade to a higher plan to continue."
+          : "Your balance has run out. Add credits to continue."
+      }
       title="💰  Your balance has run out"
-      subtitle="Upgrade to a higher plan or add credits to continue."
-      secondaryCtaLabel="Add Credits"
-      onSecondaryAction={onAddCredits}
-      ctaLabel="Upgrade"
-      onAction={onUpgrade}
+      subtitle={
+        isUpgrade
+          ? "Upgrade to a higher plan to continue."
+          : "Add credits to continue."
+      }
+      ctaLabel={isUpgrade ? "Upgrade" : "Add Credits"}
+      onAction={isUpgrade ? onUpgrade : onAddCredits}
+      detached={detached}
     />
   );
 }

--- a/clients/web/src/domains/chat/utils/credit-paywall-cta.test.ts
+++ b/clients/web/src/domains/chat/utils/credit-paywall-cta.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveCreditPaywallCta } from "./credit-paywall-cta";
+
+describe("resolveCreditPaywallCta", () => {
+  test("upgrade arm + free plan → upgrade", () => {
+    expect(
+      resolveCreditPaywallCta({ isUpgradeArm: true, isFreePlan: true }),
+    ).toBe("upgrade");
+  });
+
+  test("upgrade arm + paid plan → add-credits", () => {
+    expect(
+      resolveCreditPaywallCta({ isUpgradeArm: true, isFreePlan: false }),
+    ).toBe("add-credits");
+  });
+
+  test("upgrade arm + unresolved plan → add-credits", () => {
+    expect(
+      resolveCreditPaywallCta({ isUpgradeArm: true, isFreePlan: undefined }),
+    ).toBe("add-credits");
+  });
+
+  test("control arm + free plan → add-credits", () => {
+    expect(
+      resolveCreditPaywallCta({ isUpgradeArm: false, isFreePlan: true }),
+    ).toBe("add-credits");
+  });
+});

--- a/clients/web/src/domains/chat/utils/credit-paywall-cta.ts
+++ b/clients/web/src/domains/chat/utils/credit-paywall-cta.ts
@@ -1,0 +1,13 @@
+export type CreditPaywallCtaMode = "add-credits" | "upgrade";
+
+/**
+ * Upgrade CTA shows ONLY in the experiment upgrade arm AND for a free-plan
+ * org. Control arm, paid plan, or unknown/unresolved plan / unhydrated flags
+ * all fall back to Add Credits (today's default for everyone).
+ */
+export function resolveCreditPaywallCta(args: {
+  isUpgradeArm: boolean;
+  isFreePlan: boolean | undefined;
+}): CreditPaywallCtaMode {
+  return args.isUpgradeArm && args.isFreePlan === true ? "upgrade" : "add-credits";
+}


### PR DESCRIPTION
## Summary
- Collapse the credit paywall to a single CTA gated by experiment arm + plan: control/paid -> Add Credits (modal); treatment+free -> Upgrade (View Plans takeover)
- Drop the secondary CTA; paid users never see Upgrade on the paywall
- Render the paywall as a detached card ~24px narrower than the composer; stop flattening the composer top for it
- Pure resolveCreditPaywallCta helper + rewritten single-CTA tests

Part of plan: credit-wall-billing-cta.md (PR 3 of 3)