### PR TITLE
feat(web): mark Mighty as Recommended and hide the badge on the current plan

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
@@ -65,3 +65,20 @@ describe("PlanColumnCard CTA", () => {
     expect(button.className).toContain("bg-[var(--primary-base)]");
   });
 });
+
+describe("PlanColumnCard Recommended badge", () => {
+  test("renders the badge on a tier the user is not on", async () => {
+    const { findByText } = render(
+      <PlanColumnCard {...baseProps} recommended isCurrent={false} />,
+    );
+    expect(await findByText("Recommended")).toBeTruthy();
+  });
+
+  test("hides the badge on the current plan", async () => {
+    const { queryByText, findByRole } = render(
+      <PlanColumnCard {...baseProps} recommended isCurrent intent="current" />,
+    );
+    expect(await findByRole("button", { name: "Current Plan" })).toBeTruthy();
+    expect(queryByText("Recommended")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
@@ -16,7 +16,8 @@ export interface PlanColumnCardProps {
   /** CTA label for a selectable tier; ignored when `isCurrent`. */
   ctaLabel: string;
   features: readonly string[];
-  mostPopular?: boolean;
+  /** Renders the "Recommended" chip — suppressed on the user's current plan. */
+  recommended?: boolean;
   /**
    * The featured tier renders as the white/light card; the rest stay dark. The
    * value drives a nested `data-theme` scope so the design tokens inside the
@@ -47,7 +48,7 @@ export function PlanColumnCard({
   priceCaption,
   ctaLabel,
   features,
-  mostPopular = false,
+  recommended = false,
   tone = "dark",
   isCurrent,
   intent = "upgrade",
@@ -67,9 +68,9 @@ export function PlanColumnCard({
           <span className="text-[20px] font-medium text-[var(--content-emphasised)]">
             {name}
           </span>
-          {mostPopular ? (
+          {recommended && !isCurrent ? (
             <Tag className="bg-[var(--feed-digest-weak)] text-[12px] font-semibold uppercase text-[var(--credits-accent)]">
-              Most Popular
+              Recommended
             </Tag>
           ) : null}
         </div>

--- a/clients/web/src/domains/settings/billing/plans/plans-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/plans-copy.ts
@@ -17,8 +17,8 @@ export interface PlanTierCopy {
   cta: string;
   /** Small caption rendered under the price. */
   priceCaption: string;
-  /** Marks the "MOST POPULAR" tier — also renders as the light/white card. */
-  mostPopular?: boolean;
+  /** Marks the "RECOMMENDED" tier — also renders as the light/white card. */
+  recommended?: boolean;
   /** Feature rows appended after the catalog-derived rows. */
   extraFeatures?: readonly string[];
 }
@@ -33,12 +33,12 @@ export const PLAN_TIER_COPY: Record<PlanTierKey, PlanTierCopy> = {
     tagline: "Empower your assistant to level you up.",
     cta: "Power Up",
     priceCaption: "Billed monthly",
+    recommended: true,
   },
   super: {
     tagline: "Give your assistant real muscle to help you grow",
     cta: "Go Super",
     priceCaption: "Billed monthly",
-    mostPopular: true,
     extraFeatures: ["Assistant email and subdomain"],
   },
   ultra: {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -339,11 +339,12 @@ describe("PlansPage — full catalog render", () => {
     expect(html).toContain("$200/month");
   });
 
-  test("shows the Most Popular badge exactly once", () => {
+  test("shows the Recommended badge exactly once", () => {
     const html = renderStatic(freeSubscription(), fullCatalog());
-    // The badge text is "Most Popular"; the all-caps look is CSS `uppercase`,
+    // The badge text is "Recommended"; the all-caps look is CSS `uppercase`,
     // which renderToStaticMarkup does not apply.
-    expect(count(html, /Most Popular/g)).toBe(1);
+    expect(count(html, /Recommended/g)).toBe(1);
+    expect(html).not.toContain("Most Popular");
   });
 
   test("derives feature rows from the fixture (storage, credits, machine)", () => {
@@ -412,6 +413,13 @@ describe("PlansPage — current-plan state", () => {
     // which a static first-paint render (no effects) never loads.
     expect(count(html, /disabled=""/g)).toBe(2);
   });
+
+  test("pro subscriber on Mighty: no Recommended badge, but Mighty keeps the light card", () => {
+    const html = renderStatic(proMightySubscription(), fullCatalog());
+    expect(html).not.toContain("Recommended");
+    expect(count(html, /data-theme="light"/g)).toBe(1);
+    expect(html).toContain("Current Plan");
+  });
 });
 
 describe("PlansPage — empty catalog (pro-packages flag off)", () => {
@@ -428,9 +436,10 @@ describe("PlansPage — empty catalog (pro-packages flag off)", () => {
 });
 
 describe("getPlanTierCopy", () => {
-  test("returns tier copy including the most-popular flag and CTA", () => {
+  test("returns tier copy including the recommended flag and CTA", () => {
     expect(getPlanTierCopy("mighty")?.cta).toBe("Power Up");
-    expect(getPlanTierCopy("super")?.mostPopular).toBe(true);
+    expect(getPlanTierCopy("mighty")?.recommended).toBe(true);
+    expect(getPlanTierCopy("super")?.recommended).toBeFalsy();
     expect(getPlanTierCopy("ultra")?.cta).toBe("Unleash Ultra");
   });
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -490,8 +490,8 @@ export function PlansPage() {
                     : (copy?.cta ?? pkg.name)
                 }
                 features={packageFeatures(pkg, copy?.extraFeatures ?? [])}
-                mostPopular={copy?.mostPopular}
-                tone={copy?.mostPopular ? "light" : "dark"}
+                recommended={copy?.recommended}
+                tone={copy?.recommended ? "light" : "dark"}
                 isCurrent={currentTierKey === pkg.key}
                 intent={relation}
                 pending={pending || changePackagePending}

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -102,8 +102,8 @@ function packageFeatures(pkg: ProPackage, extra: readonly string[]): string[] {
 
 /**
  * Full-screen "View Plans" pricing takeover at `/assistant/plans`. Always dark
- * regardless of the app theme; the "Super" column flips back to light within
- * its own theme scope. Renders from the live plan catalog — with the
+ * regardless of the app theme; the recommended column flips back to light
+ * within its own theme scope. Renders from the live plan catalog — with the
  * `pro-packages` flag off the catalog is empty and the route bounces back to
  * the billing page.
  */


### PR DESCRIPTION
## Summary

- Renames the plans-takeover featured flag `mostPopular` → `recommended` and moves it from Super to Mighty; the chip now reads "Recommended".
- Hides the chip on the viewer's own plan (chip only — the featured tier keeps `tone="light"`, so a Mighty subscriber still sees Mighty as the light/white card with a disabled "Current Plan" CTA).
- Adds coverage: badge shown/hidden on `PlanColumnCard`, single-chip and Mighty-subscriber cases on `PlansPage`, and the updated `getPlanTierCopy` flag assertions.

Part of plan: recommended-plan-badge.md (PR 2 of 2)