### PR TITLE
fix(web): name the actual plan in the finish-setup notice

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -28,6 +28,7 @@ import type {
     Assistant,
     OnboardingStateResponse,
     PaginatedAssistantDomainList,
+    SubscriptionPackage,
     SubscriptionResponse,
 } from "@/generated/api/types.gen";
 import * as platformGate from "@/hooks/use-platform-gate";
@@ -146,7 +147,10 @@ mock.module("@/domains/settings/components/referral-panel", () => ({
 
 const { BillingPage } = await import("./billing-page");
 
-function makeSubscription(planId: "base" | "pro"): SubscriptionResponse {
+function makeSubscription(
+    planId: "base" | "pro",
+    pkg?: SubscriptionPackage,
+): SubscriptionResponse {
     return {
         plan_id: planId,
         status: "active",
@@ -154,6 +158,7 @@ function makeSubscription(planId: "base" | "pro"): SubscriptionResponse {
         current_period_end: "2026-08-01T00:00:00Z",
         cancel_at_period_end: false,
         cancel_at: null,
+        package: pkg ?? null,
         entitlements: { managed_email: false, phone_number: false },
     };
 }
@@ -307,6 +312,32 @@ describe("Finish Pro setup nudge", () => {
         // The transient param is consumed straight back out of the URL.
         expect(getByTestId("loc").textContent).toBe(
             "/assistant/settings/usage?tab=billing",
+        );
+    });
+
+    test("names the pinned package in the title", async () => {
+        subscriptionResponse = makeSubscription("pro", {
+            key: "super",
+            name: "Super",
+            version: 1,
+            customized: false,
+        });
+        const { getByTestId } = renderPage();
+
+        await waitFor(() =>
+            expect(
+                getByTestId("finish-pro-setup-notice").textContent,
+            ).toContain("Finish setting up your Super plan"),
+        );
+    });
+
+    test("falls back to Custom for an unpinned Pro sub", async () => {
+        const { getByTestId } = renderPage();
+
+        await waitFor(() =>
+            expect(
+                getByTestId("finish-pro-setup-notice").textContent,
+            ).toContain("Finish setting up your Custom plan"),
         );
     });
 

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -9,6 +9,7 @@ import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
 import { shouldShowBillingTab } from "@/domains/settings/billing/billing-tab-visibility";
+import { proPackageDisplayName } from "@/domains/settings/billing/package-types";
 import { UsageTab } from "@/domains/settings/billing/usage/usage-tab";
 import { AdjustPlanModal } from "@/domains/settings/components/adjust-plan-modal";
 import { BillingPanel } from "@/domains/settings/components/billing-panel";
@@ -107,7 +108,7 @@ function FinishProSetupNotice({ onFinishSetup }: { onFinishSetup: () => void }) 
     return (
         <Notice
             tone="info"
-            title="Finish setting up your Pro plan"
+            title={`Finish setting up your ${proPackageDisplayName(subscription?.package)} plan`}
             actions={
                 <Button
                     variant="outlined"

--- a/clients/web/src/domains/settings/billing/package-types.test.ts
+++ b/clients/web/src/domains/settings/billing/package-types.test.ts
@@ -1,6 +1,39 @@
 import { describe, expect, test } from "bun:test";
 
-import { packageRank, tierRelation } from "./package-types";
+import {
+  packageRank,
+  proPackageDisplayName,
+  tierRelation,
+} from "./package-types";
+
+describe("proPackageDisplayName", () => {
+  test("names a clean pin", () => {
+    expect(
+      proPackageDisplayName({
+        key: "super",
+        name: "Super",
+        version: 1,
+        customized: false,
+      }),
+    ).toBe("Super");
+  });
+
+  test("reads Custom for a customized pin", () => {
+    expect(
+      proPackageDisplayName({
+        key: "super",
+        name: "Super",
+        version: 1,
+        customized: true,
+      }),
+    ).toBe("Custom");
+  });
+
+  test("reads Custom for an unpinned sub", () => {
+    expect(proPackageDisplayName(null)).toBe("Custom");
+    expect(proPackageDisplayName(undefined)).toBe("Custom");
+  });
+});
 
 describe("packageRank", () => {
   test("ranks tiers in ascending order", () => {

--- a/clients/web/src/domains/settings/billing/package-types.ts
+++ b/clients/web/src/domains/settings/billing/package-types.ts
@@ -5,9 +5,23 @@
  * `pro-packages` LaunchDarkly flag is off; callers no-op on an empty array.
  */
 
-import type { ProPackage } from "@/generated/api/types.gen";
+import type {
+  ProPackage,
+  SubscriptionPackage,
+} from "@/generated/api/types.gen";
 
 export type { ProPackage };
+
+/**
+ * Display name for a Pro subscription's plan: the stock package name only for
+ * a clean pin. An unpinned sub or a customized pin reads "Custom", since its
+ * real tiers can diverge from any stock package.
+ */
+export function proPackageDisplayName(
+  pkg: SubscriptionPackage | null | undefined,
+): string {
+  return pkg && !pkg.customized ? pkg.name : "Custom";
+}
 
 /**
  * Catalog display order (mirrors `PRO_PACKAGES` insertion order from

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -15,6 +15,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
   nextPackageUp,
+  proPackageDisplayName,
   type ProPackage,
   type SwitchRelation,
 } from "@/domains/settings/billing/package-types";
@@ -447,15 +448,9 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   }
 
   const display = PLAN_DISPLAY[currentPlan.id] ?? DEFAULT_DISPLAY;
-  // A Pro sub shows the stock package name only for a clean (non-customized)
-  // pin (e.g. "Mighty"). Every other Pro state — an unpinned sub
-  // (`package == null`) or a customized pin whose tiers differ from the stock
-  // package — reads just "Custom". Non-Pro plans show their plan name.
   const planName =
     currentPlan.id === "pro"
-      ? subscription.package && !subscription.package.customized
-        ? subscription.package.name
-        : "Custom"
+      ? proPackageDisplayName(subscription.package)
       : (currentPlan.name ?? currentPlan.id);
 
   const isCancelling =


### PR DESCRIPTION
## Summary

- Extract `proPackageDisplayName` into `billing/package-types.ts` as the single source of a Pro sub's displayed plan name (stock package name for a clean pin, "Custom" for an unpinned sub or a customized pin).
- `FinishProSetupNotice` now titles itself from the subscription's package ("Finish setting up your Super plan") instead of hardcoding "Pro"; no new query, `subscription` was already in scope.
- `PlanCard` drops its inline nested ternary for the shared helper — behavior unchanged.

Part of plan: recommended-plan-badge.md (PR 1 of 2)