### PR TITLE
chore(chat): remove dead BillingErrorBanner secondary CTA + one-valued detached prop

### DIFF
--- a/clients/web/src/domains/chat/components/billing-error-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.test.tsx
@@ -55,35 +55,6 @@ describe("BillingErrorBanner", () => {
     expect(queryByTestId("banner-icon")).toBeNull();
   });
 
-  test("renders a secondary CTA to the left of the primary and wires each action", () => {
-    const onAction = mock(() => {});
-    const onSecondaryAction = mock(() => {});
-
-    const { getByRole } = render(
-      <BillingErrorBanner
-        ariaLabel="Billing notice"
-        title="Title"
-        subtitle="Subtitle"
-        ctaLabel="Upgrade"
-        onAction={onAction}
-        secondaryCtaLabel="Add Credits"
-        onSecondaryAction={onSecondaryAction}
-      />,
-    );
-
-    const secondary = getByRole("button", { name: "Add Credits" });
-    const primary = getByRole("button", { name: "Upgrade" });
-    expect(secondary).toBeTruthy();
-    expect(primary).toBeTruthy();
-
-    fireEvent.click(secondary);
-    expect(onSecondaryAction).toHaveBeenCalledTimes(1);
-    expect(onAction).not.toHaveBeenCalled();
-
-    fireEvent.click(primary);
-    expect(onAction).toHaveBeenCalledTimes(1);
-  });
-
   test("exposes role=status with the provided aria-label", () => {
     const { getByRole } = render(
       <BillingErrorBanner

--- a/clients/web/src/domains/chat/components/billing-error-banner.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.tsx
@@ -10,8 +10,6 @@ interface BillingErrorBannerProps {
   subtitle: string;
   ctaLabel: string;
   onAction: () => void;
-  secondaryCtaLabel?: string;
-  onSecondaryAction?: () => void;
   /**
    * Render as a standalone, centered card ~24px narrower than the composer with
    * full rounding, instead of a full-width banner flush-mounted above the
@@ -27,8 +25,6 @@ export function BillingErrorBanner({
   subtitle,
   ctaLabel,
   onAction,
-  secondaryCtaLabel,
-  onSecondaryAction,
   detached = false,
 }: BillingErrorBannerProps) {
   return (
@@ -74,18 +70,7 @@ export function BillingErrorBanner({
           </p>
         </div>
 
-        <div className="flex items-center gap-2 shrink-0">
-          {secondaryCtaLabel && onSecondaryAction ? (
-            <Button
-              variant="outlined"
-              size="regular"
-              onClick={onSecondaryAction}
-              aria-label={secondaryCtaLabel}
-            >
-              {secondaryCtaLabel}
-            </Button>
-          ) : null}
-
+        <div className="flex items-center shrink-0">
           <Button
             variant="primary"
             size="regular"

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -1012,7 +1012,6 @@ export function ChatMainPanel({
                 mode={creditPaywallMode}
                 onAddCredits={() => setShowAddCreditsModal(true)}
                 onUpgrade={pushToPlansTakeover}
-                detached
               />
             ) : billingBannerDecision === "provider_billing" ? (
               <ProviderBillingBanner onOpenSettings={pushToAiSettings} />

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
@@ -6,14 +6,12 @@ interface CreditsExhaustedBannerProps {
   mode: CreditPaywallCtaMode;
   onAddCredits: () => void;
   onUpgrade: () => void;
-  detached?: boolean;
 }
 
 export function CreditsExhaustedBanner({
   mode,
   onAddCredits,
   onUpgrade,
-  detached,
 }: CreditsExhaustedBannerProps) {
   const isUpgrade = mode === "upgrade";
   return (
@@ -31,7 +29,7 @@ export function CreditsExhaustedBanner({
       }
       ctaLabel={isUpgrade ? "Upgrade" : "Add Credits"}
       onAction={isUpgrade ? onUpgrade : onAddCredits}
-      detached={detached}
+      detached={true}
     />
   );
 }


### PR DESCRIPTION
## Summary
Post-migration cleanup for the single-CTA credit paywall (plan review findings):
- Remove BillingErrorBanner's now-unused secondaryCtaLabel/onSecondaryAction API (+ its test); no production consumer remains after the credit paywall went single-CTA
- CreditsExhaustedBanner is always detached, so hardcode detached=true internally and drop the one-valued pass-through prop + call-site arg

Part of plan: credit-wall-billing-cta.md (review remediation)