### PR TITLE
feat(web): always open the custom-plan modal from the plans takeover Customize

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -849,6 +849,72 @@ function customCatalog(): PlanListResponse {
   };
 }
 
+/**
+ * A catalog whose only 10 GB storage tier is legacy. A Pro sub sitting on it
+ * can't be represented by the (legacy-filtered) modal storage picker, yet
+ * Configure must still open the modal rather than bounce to the manage surface.
+ */
+function legacyStorageCatalog(): PlanListResponse {
+  return {
+    plans: [
+      {
+        id: "base",
+        name: "Free",
+        price_cents: 0,
+        billing_interval: "month",
+        included_features: [],
+      },
+      {
+        id: "pro",
+        name: "Pro",
+        base_lookup_key: "pro_base",
+        base_price_cents: 2000,
+        billing_interval: "month",
+        included_features: [],
+        machine_tiers: [
+          {
+            tier: "medium",
+            label: "medium",
+            price_cents: 3500,
+            lookup_key: "machine_m",
+            cpu_limit: "2.5",
+            memory_gib: 5,
+            description: "Medium machine (2.5 vCPU, 5 GiB)",
+          },
+        ],
+        storage_tiers: [
+          {
+            tier: "xs",
+            label: "10 GB",
+            storage_gib: 10,
+            price_cents: 500,
+            lookup_key: "storage_10_legacy",
+            legacy: true,
+          },
+          {
+            tier: "s",
+            label: "30 GB",
+            storage_gib: 30,
+            price_cents: 1000,
+            lookup_key: "storage_30",
+            legacy: false,
+          },
+        ],
+        credit_tiers: [
+          {
+            tier: "credits_50",
+            label: "50 credits",
+            credits_usd: 50,
+            price_cents: 5000,
+            lookup_key: "credits_50",
+          },
+        ],
+        packages: [MIGHTY, SUPER, ULTRA],
+      },
+    ],
+  };
+}
+
 function openDropdown(ariaLabel: string): void {
   const trigger = document.querySelector<HTMLButtonElement>(
     `button[role="combobox"][aria-label="${ariaLabel}"]`,
@@ -922,20 +988,49 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
     expect(upgradeCall).toBeNull();
   });
 
-  test("an ineligible (cancelling) Pro sub's Configure routes to manage", async () => {
-    const { findByRole, getByTestId, queryByText } = renderInteractive(
+  // Configure always opens the in-place custom modal for a Pro sub, whatever the
+  // sub's eligibility or tier legacy status. An ineligible or legacy-tier sub
+  // that then tries to apply a change surfaces the backend's 4xx as a toast (the
+  // modal stays open) instead of being pre-emptively bounced to the manage
+  // surface.
+  test("an ineligible (cancelling) Pro sub's Configure opens the modal, not adjust_plan", async () => {
+    const { findByRole, getByTestId, getByText } = renderInteractive(
       { ...proMightySubscription(), cancel_at_period_end: true },
       { plans: customCatalog() },
     );
 
     fireEvent.click(await findByRole("button", { name: "Configure" }));
 
-    await waitFor(() =>
-      expect(getByTestId("loc").textContent).toBe(
-        "/assistant/settings/usage?tab=billing&adjust_plan",
-      ),
+    getByText("Create a custom plan");
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
+    expect(machineTierCall).toBeNull();
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("a base user's Configure opens the custom modal (checkout path), not adjust_plan", async () => {
+    const { findByRole, getByTestId, getByText } = renderInteractive(
+      freeSubscription(),
+      { plans: customCatalog() },
     );
-    expect(queryByText("Create a custom plan")).toBeNull();
+
+    fireEvent.click(await findByRole("button", { name: "Configure" }));
+
+    getByText("Create a custom plan");
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
+    // Checkout only fires once the modal's Continue is pressed.
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("a Pro sub on a legacy storage tier's Configure opens the modal, not adjust_plan", async () => {
+    const { findByRole, getByTestId, getByText } = renderInteractive(
+      proMightySubscription(),
+      { plans: legacyStorageCatalog() },
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Configure" }));
+
+    getByText("Create a custom plan");
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(machineTierCall).toBeNull();
     expect(upgradeCall).toBeNull();
   });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -135,7 +135,6 @@ export function PlansPage() {
     changeTiers,
     isPending: changeTiersPending,
     current,
-    eligible,
     currentReady,
   } = useChangeTiers({ enabled: platformReady });
   // Native iOS keeps Checkout inside an in-app sheet, so the page holds
@@ -176,35 +175,6 @@ export function PlansPage() {
       creditTier: current.creditTier,
     };
   }, [isProUser, current.machineTier, current.storageTier, current.creditTier]);
-
-  // The in-place custom editor can only faithfully represent a Pro sub whose
-  // current tiers are all live catalog options. A legacy storage tier or a
-  // deprecated credit bundle can't be shown or re-selected here — routing such
-  // a sub through the modal would force it to drop that tier — so those fall
-  // back to the adjust-plan surface (which preserves them) instead.
-  const customReconfigurable = useMemo(() => {
-    if (!isProUser || !proPlan) {
-      return false;
-    }
-    // A null baseline machine (a package with no paid machine tier) is a valid
-    // current state — represent it rather than excluding the sub from the modal.
-    const machineOk =
-      current.machineTier == null ||
-      proPlan.machine_tiers.some((t) => t.tier === current.machineTier);
-    const storageOk = proPlan.storage_tiers.some(
-      (t) => !t.legacy && t.tier === current.storageTier,
-    );
-    const creditOk =
-      current.creditTier == null ||
-      (proPlan.credit_tiers ?? []).some((t) => t.tier === current.creditTier);
-    return machineOk && storageOk && creditOk;
-  }, [
-    isProUser,
-    proPlan,
-    current.machineTier,
-    current.storageTier,
-    current.creditTier,
-  ]);
 
   // The takeover only makes sense against a platform-hosted assistant with a
   // live package catalog. Anything else — self-hosted or no platform session,
@@ -395,24 +365,10 @@ export function PlansPage() {
     };
 
     const handleConfigure = () => {
-      if (isProUser) {
-        // The current tiers that decide representability load after the page
-        // renders. While that first load is in flight, don't fall through to
-        // the manage surface — the Configure CTA is held disabled until they
-        // land (see `configureDisabled`), so this is a defensive guard.
-        if (eligible && !currentReady) {
-          return;
-        }
-        // An eligible Pro sub whose current tiers are all representable here
-        // reconfigures in the white modal. Anything else — cancelling /
-        // non-entitlement status, or a legacy/deprecated tier the modal can't
-        // show — routes to the billing manage/cancel surface, the same fallback
-        // the package CTAs use.
-        if (eligible && customReconfigurable) {
-          setCustomPlanOpen(true);
-          return;
-        }
-        navigate(`${routes.settings.usage}?tab=billing&adjust_plan`);
+      // A Pro sub's current tiers load after the page renders; the modal seeds
+      // from them, so hold the click until that first load settles (the CTA is
+      // also held disabled meanwhile — see `configureDisabled`).
+      if (isProUser && !currentReady) {
         return;
       }
       setCustomPlanOpen(true);
@@ -504,7 +460,7 @@ export function PlansPage() {
         <CustomPlanRow
           className="mt-10"
           onConfigure={handleConfigure}
-          configureDisabled={isProUser && eligible && !currentReady}
+          configureDisabled={isProUser && !currentReady}
         />
 
         <CustomPlanModal


### PR DESCRIPTION
## Summary
- The plans-takeover Customize/Configure row now always opens the new CustomPlanModal instead of falling back to the legacy adjust-plan surface for ineligible or legacy-tier Pro subs.
- Ineligible/cancelling subs still degrade gracefully (backend 409/403 surfaces as a toast, modal stays open).
- The upgrade path (selectTier / isPackageSwitchEligible) is unchanged.

Part of plan: plans-takeover-inplace-provisioning.md (PR 1)