### PR TITLE
docs(migration-routes): correct stale platform_user_id provisioning note

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -106,15 +106,15 @@ const PLATFORM_CREDENTIAL_PREFIX = credentialKey("vellum", "");
 
 /**
  * Platform-identity fields that the managed runtime expects to see in CES.
- * Django's post-hatch provisioning populates the first four via
- * `POST /v1/secrets`; `platform_organization_id` and `platform_user_id` are
- * populated by the signed-in client after hatch (onboarding, teleport,
- * local→managed transfer) because Django has no signed-in user session to
- * resolve them. Either set of writes can race with the import — the CES
- * write survives (separate volume), but the metadata upsert may be
- * clobbered by the in-place clear / atomic swap. After every import we
- * reconcile metadata.json against CES so any field CES already holds a
- * value for gets a matching metadata entry.
+ * On a managed assistant the platform provisions these after hatch (most via
+ * `POST /v1/secrets`), including `platform_organization_id` and
+ * `platform_user_id`, which it resolves from the hatching user and
+ * organization. A signed-in client may additionally (re)assert some of them
+ * on teleport / local→managed transfer. Either set of writes can race with
+ * the import — the CES write survives (separate volume), but the metadata
+ * upsert may be clobbered by the in-place clear / atomic swap. After every
+ * import we reconcile metadata.json against CES so any field CES already holds
+ * a value for gets a matching metadata entry.
  */
 const VELLUM_PLATFORM_IDENTITY_FIELDS = [
   "platform_base_url",


### PR DESCRIPTION
## Prompt / plan

While investigating the platform-reconnect heartbeat bug (a managed assistant left with `platform_user_id` null), the comment above `VELLUM_PLATFORM_IDENTITY_FIELDS` in `migration-routes.ts` actively misled the investigation. It claimed:

> `platform_organization_id` and `platform_user_id` are populated by the signed-in client after hatch … because Django has no signed-in user session to resolve them.

That is **not** how it works. Verified directly in the platform repo (`vellum-assistant-platform`): the post-hatch provisioning job (`_run_post_hatch_runtime_provisioning` → `provision_platform_user_id` / `provision_platform_organization_id`) resolves both from the **hatching user and organization** and pushes them to the runtime via `POST /v1/secrets`, server-side. A signed-in client only *additionally* (re)asserts them on some teleport / local→managed flows.

This PR corrects the note to describe the real provisioning contract. No code change — the reconcile logic and its rationale are unchanged.

(Context: the actual `platform_user_id`-null defect is server-side in the platform repo — the post-hatch push is best-effort, ungated, and has no recovery path. That's tracked separately; this is just the misleading comment that sent the first pass down the wrong trail.)

## Test plan

- Comment-only change. `bun run typecheck` (pre-commit `tsc --noEmit`) passes; lint clean on the changed lines.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PJd6aWTkzRFaXLNp85XnyB)_