### PR TITLE
feat(chat): credit-paywall CTA experiment — single Add Credits vs Upgrade (free users)

### DIFF
--- a/clients/web/src/domains/chat/components/billing-error-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.test.tsx
@@ -55,35 +55,6 @@ describe("BillingErrorBanner", () => {
     expect(queryByTestId("banner-icon")).toBeNull();
   });
 
-  test("renders a secondary CTA to the left of the primary and wires each action", () => {
-    const onAction = mock(() => {});
-    const onSecondaryAction = mock(() => {});
-
-    const { getByRole } = render(
-      <BillingErrorBanner
-        ariaLabel="Billing notice"
-        title="Title"
-        subtitle="Subtitle"
-        ctaLabel="Upgrade"
-        onAction={onAction}
-        secondaryCtaLabel="Add Credits"
-        onSecondaryAction={onSecondaryAction}
-      />,
-    );
-
-    const secondary = getByRole("button", { name: "Add Credits" });
-    const primary = getByRole("button", { name: "Upgrade" });
-    expect(secondary).toBeTruthy();
-    expect(primary).toBeTruthy();
-
-    fireEvent.click(secondary);
-    expect(onSecondaryAction).toHaveBeenCalledTimes(1);
-    expect(onAction).not.toHaveBeenCalled();
-
-    fireEvent.click(primary);
-    expect(onAction).toHaveBeenCalledTimes(1);
-  });
-
   test("exposes role=status with the provided aria-label", () => {
     const { getByRole } = render(
       <BillingErrorBanner

--- a/clients/web/src/domains/chat/components/billing-error-banner.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.tsx
@@ -10,8 +10,6 @@ interface BillingErrorBannerProps {
   subtitle: string;
   ctaLabel: string;
   onAction: () => void;
-  secondaryCtaLabel?: string;
-  onSecondaryAction?: () => void;
   /**
    * Render as a standalone, centered card ~24px narrower than the composer with
    * full rounding, instead of a full-width banner flush-mounted above the
@@ -27,8 +25,6 @@ export function BillingErrorBanner({
   subtitle,
   ctaLabel,
   onAction,
-  secondaryCtaLabel,
-  onSecondaryAction,
   detached = false,
 }: BillingErrorBannerProps) {
   return (
@@ -74,18 +70,7 @@ export function BillingErrorBanner({
           </p>
         </div>
 
-        <div className="flex items-center gap-2 shrink-0">
-          {secondaryCtaLabel && onSecondaryAction ? (
-            <Button
-              variant="outlined"
-              size="regular"
-              onClick={onSecondaryAction}
-              aria-label={secondaryCtaLabel}
-            >
-              {secondaryCtaLabel}
-            </Button>
-          ) : null}
-
+        <div className="flex items-center shrink-0">
           <Button
             variant="primary"
             size="regular"

--- a/clients/web/src/domains/chat/components/billing-error-banner.tsx
+++ b/clients/web/src/domains/chat/components/billing-error-banner.tsx
@@ -12,6 +12,12 @@ interface BillingErrorBannerProps {
   onAction: () => void;
   secondaryCtaLabel?: string;
   onSecondaryAction?: () => void;
+  /**
+   * Render as a standalone, centered card ~24px narrower than the composer with
+   * full rounding, instead of a full-width banner flush-mounted above the
+   * composer (which flattens its bottom corners into the composer top).
+   */
+  detached?: boolean;
 }
 
 export function BillingErrorBanner({
@@ -23,15 +29,22 @@ export function BillingErrorBanner({
   onAction,
   secondaryCtaLabel,
   onSecondaryAction,
+  detached = false,
 }: BillingErrorBannerProps) {
   return (
     <div
       className="flex overflow-hidden"
       style={{
         background: "var(--surface-active)",
-        borderRadius: "10px 10px 0 0",
         animation: "fadeInUp 0.25s ease-out both",
         width: "100%",
+        ...(detached
+          ? {
+              maxWidth: "calc(100% - 24px)",
+              marginInline: "auto",
+              borderRadius: "10px",
+            }
+          : { borderRadius: "10px 10px 0 0" }),
       }}
       role="status"
       aria-label={ariaLabel}

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -84,6 +84,12 @@ import {
   shouldShowGenericChatErrorNotice,
 } from "@/domains/chat/utils/error-classification";
 import { openUrlInPopupOrTab } from "@/domains/chat/utils/oauth-popup-links";
+import { resolveCreditPaywallCta } from "@/domains/chat/utils/credit-paywall-cta";
+import {
+  isBillingCtaUpgradeArm,
+  useBillingCtaExperimentArm,
+} from "@/hooks/use-billing-cta-experiment";
+import { useIsFreePlan } from "@/hooks/use-is-free-plan";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import type { DisplayAttachment, DisplayMessage } from "@/domains/chat/types/types";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -888,6 +894,15 @@ export function ChatMainPanel({
   const billingBannerDecision =
     errorBillingBannerDecision ?? noticeBillingBannerDecision;
 
+  // Credit-paywall CTA: single CTA gated by experiment arm + plan. Only fetch
+  // the subscription when the credit paywall is actually shown.
+  const billingCtaArm = useBillingCtaExperimentArm();
+  const isFreePlan = useIsFreePlan(billingBannerDecision === "managed_credits");
+  const creditPaywallMode = resolveCreditPaywallCta({
+    isUpgradeArm: isBillingCtaUpgradeArm(billingCtaArm),
+    isFreePlan,
+  });
+
   // -------------------------------------------------------------------------
   // JSX construction
   // -------------------------------------------------------------------------
@@ -959,7 +974,10 @@ export function ChatMainPanel({
       onCancelEdit={isEditing ? handleCancelEdit : undefined}
       textareaMaxHeightPx={isEmptyConversation ? 320 : undefined}
       suggestion={suggestion}
-      hasBillingBanner={billingBannerDecision !== null}
+      hasBillingBanner={
+        billingBannerDecision !== null &&
+        billingBannerDecision !== "managed_credits"
+      }
       thresholdPickerSlot={
         assistantId ? (
           <ComposerSettingsMenu
@@ -991,8 +1009,10 @@ export function ChatMainPanel({
               <DailyLimitBanner onAdjustLimit={pushToBillingSettings} />
             ) : billingBannerDecision === "managed_credits" ? (
               <CreditsExhaustedBanner
+                mode={creditPaywallMode}
                 onAddCredits={() => setShowAddCreditsModal(true)}
                 onUpgrade={pushToPlansTakeover}
+                detached
               />
             ) : billingBannerDecision === "provider_billing" ? (
               <ProviderBillingBanner onOpenSettings={pushToAiSettings} />

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -1012,7 +1012,6 @@ export function ChatMainPanel({
                 mode={creditPaywallMode}
                 onAddCredits={() => setShowAddCreditsModal(true)}
                 onUpgrade={pushToPlansTakeover}
-                detached
               />
             ) : billingBannerDecision === "provider_billing" ? (
               <ProviderBillingBanner onOpenSettings={pushToAiSettings} />

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
@@ -1,8 +1,8 @@
 /**
- * Tests for `CreditsExhaustedBanner` — the two-CTA credit wall.
+ * Tests for `CreditsExhaustedBanner` — the single-CTA credit wall gated by mode.
  *
  * Renders via `@testing-library/react` (happy-dom registered in test-setup.ts)
- * and drives the CTAs with `fireEvent`. No jest-dom matchers — we assert with
+ * and drives the CTA with `fireEvent`. No jest-dom matchers — we assert with
  * plain bun `expect` against query results. The title carries an inline emoji,
  * so it is matched with a regex that tolerates the prefix.
  */
@@ -16,45 +16,42 @@ afterEach(() => {
 });
 
 describe("CreditsExhaustedBanner", () => {
-  test("renders the title, subtitle, and both CTAs", () => {
-    const { getByText, getByRole } = render(
-      <CreditsExhaustedBanner onAddCredits={() => {}} onUpgrade={() => {}} />,
-    );
-
-    expect(getByText(/Your balance has run out/)).toBeTruthy();
-    expect(
-      getByText("Upgrade to a higher plan or add credits to continue."),
-    ).toBeTruthy();
-    expect(getByRole("button", { name: "Add Credits" })).toBeTruthy();
-    expect(getByRole("button", { name: "Upgrade" })).toBeTruthy();
-  });
-
-  test("clicking Add Credits fires onAddCredits only", () => {
+  test("add-credits mode renders exactly one Add Credits CTA and no Upgrade", () => {
     const onAddCredits = mock(() => {});
     const onUpgrade = mock(() => {});
 
-    const { getByRole } = render(
+    const { getAllByRole, getByRole, queryByRole, getByText } = render(
       <CreditsExhaustedBanner
+        mode="add-credits"
         onAddCredits={onAddCredits}
         onUpgrade={onUpgrade}
       />,
     );
+
+    expect(getByText(/Your balance has run out/)).toBeTruthy();
+    expect(getAllByRole("button").length).toBe(1);
+    expect(queryByRole("button", { name: "Upgrade" })).toBeNull();
 
     fireEvent.click(getByRole("button", { name: "Add Credits" }));
     expect(onAddCredits).toHaveBeenCalledTimes(1);
     expect(onUpgrade).not.toHaveBeenCalled();
   });
 
-  test("clicking Upgrade fires onUpgrade only", () => {
+  test("upgrade mode renders exactly one Upgrade CTA and no Add Credits", () => {
     const onAddCredits = mock(() => {});
     const onUpgrade = mock(() => {});
 
-    const { getByRole } = render(
+    const { getAllByRole, getByRole, queryByRole, getByText } = render(
       <CreditsExhaustedBanner
+        mode="upgrade"
         onAddCredits={onAddCredits}
         onUpgrade={onUpgrade}
       />,
     );
+
+    expect(getByText(/Your balance has run out/)).toBeTruthy();
+    expect(getAllByRole("button").length).toBe(1);
+    expect(queryByRole("button", { name: "Add Credits" })).toBeNull();
 
     fireEvent.click(getByRole("button", { name: "Upgrade" }));
     expect(onUpgrade).toHaveBeenCalledTimes(1);

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
@@ -6,14 +6,12 @@ interface CreditsExhaustedBannerProps {
   mode: CreditPaywallCtaMode;
   onAddCredits: () => void;
   onUpgrade: () => void;
-  detached?: boolean;
 }
 
 export function CreditsExhaustedBanner({
   mode,
   onAddCredits,
   onUpgrade,
-  detached,
 }: CreditsExhaustedBannerProps) {
   const isUpgrade = mode === "upgrade";
   return (
@@ -31,7 +29,7 @@ export function CreditsExhaustedBanner({
       }
       ctaLabel={isUpgrade ? "Upgrade" : "Add Credits"}
       onAction={isUpgrade ? onUpgrade : onAddCredits}
-      detached={detached}
+      detached={true}
     />
   );
 }

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
@@ -1,24 +1,37 @@
 
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
+import type { CreditPaywallCtaMode } from "@/domains/chat/utils/credit-paywall-cta";
 
 interface CreditsExhaustedBannerProps {
+  mode: CreditPaywallCtaMode;
   onAddCredits: () => void;
   onUpgrade: () => void;
+  detached?: boolean;
 }
 
 export function CreditsExhaustedBanner({
+  mode,
   onAddCredits,
   onUpgrade,
+  detached,
 }: CreditsExhaustedBannerProps) {
+  const isUpgrade = mode === "upgrade";
   return (
     <BillingErrorBanner
-      ariaLabel="Your balance has run out. Upgrade to a higher plan or add credits to continue."
+      ariaLabel={
+        isUpgrade
+          ? "Your balance has run out. Upgrade to a higher plan to continue."
+          : "Your balance has run out. Add credits to continue."
+      }
       title="💰  Your balance has run out"
-      subtitle="Upgrade to a higher plan or add credits to continue."
-      secondaryCtaLabel="Add Credits"
-      onSecondaryAction={onAddCredits}
-      ctaLabel="Upgrade"
-      onAction={onUpgrade}
+      subtitle={
+        isUpgrade
+          ? "Upgrade to a higher plan to continue."
+          : "Add credits to continue."
+      }
+      ctaLabel={isUpgrade ? "Upgrade" : "Add Credits"}
+      onAction={isUpgrade ? onUpgrade : onAddCredits}
+      detached={detached}
     />
   );
 }

--- a/clients/web/src/domains/chat/utils/credit-paywall-cta.test.ts
+++ b/clients/web/src/domains/chat/utils/credit-paywall-cta.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveCreditPaywallCta } from "./credit-paywall-cta";
+
+describe("resolveCreditPaywallCta", () => {
+  test("upgrade arm + free plan → upgrade", () => {
+    expect(
+      resolveCreditPaywallCta({ isUpgradeArm: true, isFreePlan: true }),
+    ).toBe("upgrade");
+  });
+
+  test("upgrade arm + paid plan → add-credits", () => {
+    expect(
+      resolveCreditPaywallCta({ isUpgradeArm: true, isFreePlan: false }),
+    ).toBe("add-credits");
+  });
+
+  test("upgrade arm + unresolved plan → add-credits", () => {
+    expect(
+      resolveCreditPaywallCta({ isUpgradeArm: true, isFreePlan: undefined }),
+    ).toBe("add-credits");
+  });
+
+  test("control arm + free plan → add-credits", () => {
+    expect(
+      resolveCreditPaywallCta({ isUpgradeArm: false, isFreePlan: true }),
+    ).toBe("add-credits");
+  });
+});

--- a/clients/web/src/domains/chat/utils/credit-paywall-cta.ts
+++ b/clients/web/src/domains/chat/utils/credit-paywall-cta.ts
@@ -1,0 +1,13 @@
+export type CreditPaywallCtaMode = "add-credits" | "upgrade";
+
+/**
+ * Upgrade CTA shows ONLY in the experiment upgrade arm AND for a free-plan
+ * org. Control arm, paid plan, or unknown/unresolved plan / unhydrated flags
+ * all fall back to Add Credits (today's default for everyone).
+ */
+export function resolveCreditPaywallCta(args: {
+  isUpgradeArm: boolean;
+  isFreePlan: boolean | undefined;
+}): CreditPaywallCtaMode {
+  return args.isUpgradeArm && args.isFreePlan === true ? "upgrade" : "add-credits";
+}

--- a/clients/web/src/hooks/use-billing-cta-experiment.test.ts
+++ b/clients/web/src/hooks/use-billing-cta-experiment.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for the `experiment-billing-cta-2026-07-23` read seam: the pure arm
+ * predicate and the store-backed hook that defaults to "control" until flags
+ * hydrate.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import {
+  isBillingCtaUpgradeArm,
+  useBillingCtaExperimentArm,
+} from "@/hooks/use-billing-cta-experiment";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+beforeEach(() => {
+  // Reset the arm to its "control" default before each test so a value set by
+  // an earlier test can't leak in.
+  useClientFeatureFlagStore
+    .getState()
+    .setStringFlags({ experimentBillingCta20260723: "control" });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("isBillingCtaUpgradeArm", () => {
+  test("is true only for the upgrade-cta arm", () => {
+    expect(isBillingCtaUpgradeArm("upgrade-cta")).toBe(true);
+  });
+
+  test("is false for control, empty, and unknown arms", () => {
+    expect(isBillingCtaUpgradeArm("control")).toBe(false);
+    expect(isBillingCtaUpgradeArm("")).toBe(false);
+    expect(isBillingCtaUpgradeArm("something-else")).toBe(false);
+  });
+});
+
+describe("useBillingCtaExperimentArm", () => {
+  test("defaults to control", () => {
+    const { result } = renderHook(() => useBillingCtaExperimentArm());
+    expect(result.current).toBe("control");
+  });
+
+  test("reflects the arm set on the store", () => {
+    useClientFeatureFlagStore
+      .getState()
+      .setStringFlags({ experimentBillingCta20260723: "upgrade-cta" });
+    const { result } = renderHook(() => useBillingCtaExperimentArm());
+    expect(result.current).toBe("upgrade-cta");
+  });
+});

--- a/clients/web/src/hooks/use-billing-cta-experiment.ts
+++ b/clients/web/src/hooks/use-billing-cta-experiment.ts
@@ -1,0 +1,20 @@
+/**
+ * Read seam for the `experiment-billing-cta-2026-07-23` string flag: the credit
+ * paywall gates on this arm to decide whether FREE users see a single Upgrade
+ * CTA (View Plans takeover) instead of the default Add Credits CTA.
+ */
+
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+/** Current `experiment-billing-cta-2026-07-23` arm; "control" until flags hydrate. */
+export function useBillingCtaExperimentArm(): string {
+  return (
+    useClientFeatureFlagStore.use.stringFlags().experimentBillingCta20260723 ??
+    "control"
+  );
+}
+
+/** Whether the arm enables the free-user Upgrade CTA on the credit paywall. */
+export function isBillingCtaUpgradeArm(arm: string): boolean {
+  return arm === "upgrade-cta";
+}

--- a/clients/web/src/hooks/use-is-free-plan.test.ts
+++ b/clients/web/src/hooks/use-is-free-plan.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for `useIsFreePlan`. The generated subscription retrieve query options
+ * are `mock.module`-replaced so the hook reads a seeded fixture and its fetches
+ * can be counted. The QueryClient uses `staleTime/gcTime: Infinity` +
+ * `retry: false` so a seeded cache resolves synchronously and an unseeded query
+ * stays unresolved (its `queryFn` is a hang) — modeling the loading state.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import type { SubscriptionResponse } from "@/generated/api/types.gen";
+
+// Sentinel query key shared by the mocked options and the seeded cache.
+const SUBSCRIPTION_KEY = ["subscription"];
+
+// The fixture the mocked retrieve options resolve; each test seeds it.
+let subscriptionFixture: SubscriptionResponse | null = null;
+// Counts subscription fetches so the `enabled: false` gate can be asserted.
+let subscriptionFetches = 0;
+// When true, the query never resolves — models the first load still in flight.
+let subscriptionHangs = false;
+// Drives the mocked `useIsOrgReady`; the hook folds it into its `enabled` gate.
+let orgReady = true;
+
+mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
+  organizationsBillingSubscriptionRetrieveOptions: () => ({
+    queryKey: SUBSCRIPTION_KEY,
+    queryFn: () => {
+      subscriptionFetches += 1;
+      return subscriptionHangs
+        ? new Promise(() => {})
+        : subscriptionFixture;
+    },
+  }),
+}));
+
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => orgReady,
+}));
+
+const { useIsFreePlan } = await import("./use-is-free-plan");
+
+function subscription(
+  overrides: Partial<SubscriptionResponse> = {},
+): SubscriptionResponse {
+  return {
+    plan_id: "pro",
+    status: "active",
+    renewal_date: null,
+    current_period_end: "2026-07-10T00:00:00Z",
+    cancel_at_period_end: false,
+    cancel_at: null,
+    selected_credit_tier: null,
+    package: { key: "super", name: "Super", version: 1, customized: false },
+    entitlements: { managed_email: false, phone_number: false },
+    ...overrides,
+  };
+}
+
+/**
+ * Render the hook against a fresh QueryClient. When `seed` is set the
+ * subscription cache is primed so the read resolves synchronously.
+ */
+function setup({
+  seed,
+  enabled = true,
+}: {
+  seed?: SubscriptionResponse;
+  enabled?: boolean;
+} = {}) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        gcTime: Infinity,
+      },
+    },
+  });
+  if (seed) {
+    client.setQueryData(SUBSCRIPTION_KEY, seed);
+  }
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+  return renderHook(() => useIsFreePlan(enabled), { wrapper });
+}
+
+describe("useIsFreePlan", () => {
+  beforeEach(() => {
+    subscriptionFetches = 0;
+    subscriptionHangs = false;
+    subscriptionFixture = subscription();
+    orgReady = true;
+  });
+
+  test("returns true for a base (free) plan", () => {
+    const { result } = setup({ seed: subscription({ plan_id: "base" }) });
+    expect(result.current).toBe(true);
+  });
+
+  test("returns false for a pro (paid) plan", () => {
+    const { result } = setup({ seed: subscription({ plan_id: "pro" }) });
+    expect(result.current).toBe(false);
+  });
+
+  test("returns undefined while the subscription is unresolved", () => {
+    // No seeded data + a hanging fetch keeps the query pending.
+    subscriptionHangs = true;
+    const { result } = setup();
+    expect(result.current).toBeUndefined();
+  });
+
+  test("does not fetch and returns undefined when disabled", () => {
+    // Unseeded + disabled: the read must not fire and the value stays unknown.
+    const { result } = setup({ enabled: false });
+    expect(subscriptionFetches).toBe(0);
+    expect(result.current).toBeUndefined();
+  });
+
+  test("does not fetch and returns undefined when the org is not ready", () => {
+    // Even with `enabled` true, a not-ready org must keep the query from firing
+    // — the request would omit `Vellum-Organization-Id` and be rejected.
+    orgReady = false;
+    const { result } = setup({ enabled: true });
+    expect(subscriptionFetches).toBe(0);
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/clients/web/src/hooks/use-is-free-plan.ts
+++ b/clients/web/src/hooks/use-is-free-plan.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { organizationsBillingSubscriptionRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+
+/**
+ * Whether the org is on the FREE plan (`plan_id === "base"`).
+ * `undefined` while loading/unresolved — callers treat unknown as "not free"
+ * so paid-only affordances never flash for a paying user. `enabled` gates the
+ * fetch so surfaces only fetch the subscription when the value is needed, and
+ * is folded together with `useIsOrgReady()` so the request never fires before
+ * the org store hydrates — the subscription endpoint requires the
+ * `Vellum-Organization-Id` header the interceptor only attaches once the active
+ * org id is known, so a headerless request on first load would be rejected.
+ */
+export function useIsFreePlan(enabled = true): boolean | undefined {
+  const orgReady = useIsOrgReady();
+  const { data } = useQuery({
+    ...organizationsBillingSubscriptionRetrieveOptions(),
+    enabled: enabled && orgReady,
+  });
+  if (data?.plan_id == null) {
+    return undefined;
+  }
+  return data.plan_id === "base";
+}

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -35,6 +35,16 @@ describe("feature flag catalog", () => {
     );
   });
 
+  test("exposes the billing CTA experiment as a client string flag", () => {
+    expect(CLIENT_STRING_FLAG_DEFAULTS.experimentBillingCta20260723).toBe(
+      "control",
+    );
+    expect("experimentBillingCta20260723" in CLIENT_FLAG_DEFAULTS).toBe(false);
+    expect("experimentBillingCta20260723" in ASSISTANT_FLAG_DEFAULTS).toBe(
+      false,
+    );
+  });
+
   test("exposes proactive tips as a client string flag defaulted off", () => {
     expect(CLIENT_STRING_FLAG_DEFAULTS.proactiveTips).toBe("off");
     expect("proactiveTips" in CLIENT_FLAG_DEFAULTS).toBe(false);

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -37,6 +37,15 @@
       "values": ["control", "variant-a", "personal-page"]
     },
     {
+      "id": "experiment-billing-cta-2026-07-23",
+      "scope": "client",
+      "key": "experiment-billing-cta-2026-07-23",
+      "label": "Experiment: Billing CTA 2026-07-23",
+      "description": "Credit paywall CTA experiment. control = single Add Credits CTA for everyone (opens Add Credits modal). upgrade-cta = FREE users (plan_id base) get a single Upgrade CTA (View Plans takeover) instead; PAID users still get Add Credits.",
+      "defaultEnabled": "control",
+      "values": ["control", "upgrade-cta"]
+    },
+    {
       "id": "local-docker-enabled",
       "scope": "client",
       "key": "local-docker-enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -37,6 +37,15 @@
       "values": ["control", "variant-a", "personal-page"]
     },
     {
+      "id": "experiment-billing-cta-2026-07-23",
+      "scope": "client",
+      "key": "experiment-billing-cta-2026-07-23",
+      "label": "Experiment: Billing CTA 2026-07-23",
+      "description": "Credit paywall CTA experiment. control = single Add Credits CTA for everyone (opens Add Credits modal). upgrade-cta = FREE users (plan_id base) get a single Upgrade CTA (View Plans takeover) instead; PAID users still get Add Credits.",
+      "defaultEnabled": "control",
+      "values": ["control", "upgrade-cta"]
+    },
+    {
       "id": "local-docker-enabled",
       "scope": "client",
       "key": "local-docker-enabled",


### PR DESCRIPTION
## Summary
Collapses the out-of-credits paywall to a **single** CTA, gated by the `experiment-billing-cta-2026-07-23` A/B experiment + plan state:

| Arm | Free user (`plan_id = base`) | Paid user (`plan_id = pro`) |
|---|---|---|
| **control** (default) | **Add Credits** → Add Credits modal | **Add Credits** → Add Credits modal |
| **upgrade-cta** (treatment) | **Upgrade** → `/assistant/plans` takeover | **Add Credits** → Add Credits modal |

Always exactly one CTA. Paid users never see the Upgrade CTA on the paywall (their upgrade path stays on the billing page). Control is the default, so merging this reverts the recent across-the-board "Upgrade" CTA back to Add-Credits-only until LD targeting turns on the treatment for free users. The paywall is also now a detached card ~24px narrower than the composer.

## Self-review result
PASS — 4 fresh-eyes passes (external, faithfulness, integration, slop). 2 cleanup items found & fixed in a remediation PR (removed the now-dead `BillingErrorBanner` secondary-CTA API and one-valued `detached` plumbing left by the 2→1 CTA migration); re-verified clean.

## PRs merged into this feature branch
- #38861 — register `experiment-billing-cta-2026-07-23` (canonical `meta/` + web registry) + `useBillingCtaExperimentArm()` hook
- #38860 — `useIsFreePlan()` hook (subscription `plan_id`, gated on org readiness)
- #38867 — single experiment-gated CTA + detached 24px-narrower card
- #38870 — cleanup: drop dead secondary-CTA API + one-valued `detached` prop

## Dependency / rollout (IMPORTANT)
- Paired **Terraform PR** in `vellum-assistant-platform` (`experiment-billing-cta-2026-07-23`, tag `client`) — **must be merged & applied FIRST**, then configure LD targeting. Until then everyone resolves to `control` (Add Credits), so this is safe to merge with the flag absent.
- Client-only; no API/migration changes here.

Part of plan: credit-wall-billing-cta.md