### PR TITLE
Plans takeover: Customize always opens the new modal + modal spacing to mock

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -7,9 +7,9 @@
  * selected tiers. An eligible Pro subscriber reaches the same modal seeded to
  * its current tiers, and Continue dispatches the change-machine/storage/
  * credit-tier endpoints (not checkout, which no-ops for an active Pro sub) and
- * opens the resize takeover. A Pro sub the modal can't faithfully represent — a
- * legacy storage tier or a deprecated credit bundle — or an ineligible one
- * (cancelling / bad status) routes to the manage modal instead.
+ * opens the resize takeover. Configure opens the modal for a Pro sub the
+ * catalog can't fully represent too — e.g. a deprecated credit bundle — with
+ * the seed holding the tier and any un-representable apply surfacing as a toast.
  *
  * Strategy mirrors plans-page-checkout.test.tsx: mock the generated SDK to
  * capture the request bodies and return fixtures, mock `openUrl` to capture
@@ -701,62 +701,20 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
   });
 });
 
-describe("CustomPlanModal — ineligible Pro subscriber", () => {
-  test("a cancelling Pro sub's Configure routes to the manage modal", async () => {
-    const { getByRole, getByTestId, queryByText } = renderPage(
-      proMightySubscription({ cancel_at_period_end: true }),
-    );
-
-    fireEvent.click(getByRole("button", { name: "Configure" }));
-
-    await waitFor(() => {
-      expect(getByTestId("loc").textContent).toBe(
-        "/assistant/settings/usage?tab=billing&adjust_plan",
-      );
-    });
-    expect(queryByText("Create a custom plan")).toBeNull();
-    expect(machineTierCall).toBeNull();
-    expect(upgradeCall).toBeNull();
-  });
-});
-
-describe("CustomPlanModal — non-representable Pro plan", () => {
-  test("a legacy storage tier routes to the manage modal", async () => {
-    // The configurator filters legacy storage tiers, so a sub holding one can't
-    // be shown or re-selected here — route to adjust-plan, which preserves it,
-    // rather than force the user to upgrade off it.
-    const { getByRole, getByTestId, queryByText } = renderPage(
-      proMightySubscription(),
-      onboarding({ selected_storage_tier: "xl", selected_storage_gib: 250 }),
-    );
-
-    fireEvent.click(getByRole("button", { name: "Configure" }));
-
-    await waitFor(() => {
-      expect(getByTestId("loc").textContent).toBe(
-        "/assistant/settings/usage?tab=billing&adjust_plan",
-      );
-    });
-    expect(queryByText("Create a custom plan")).toBeNull();
-    expect(machineTierCall).toBeNull();
-  });
-
-  test("a deprecated credit bundle routes to the manage modal", async () => {
+describe("CustomPlanModal — Pro plan the catalog can't fully represent", () => {
+  test("a deprecated credit bundle Pro sub's Configure opens the custom-plan modal", () => {
     // The configurator only offers live credit tiers; the sub's `credits_25`
-    // bundle is absent from the catalog, so routing it here would drop the paid
-    // credits — fall back to adjust-plan instead.
-    const { getByRole, getByTestId, queryByText } = renderPage(
+    // bundle is absent from the catalog. Configure still opens the modal — the
+    // seed keeps the held credit, and an apply the backend can't honor surfaces
+    // as a toast instead of the takeover pre-empting the modal.
+    const { getByRole, getByTestId, getByText } = renderPage(
       proMightySubscription({ selected_credit_tier: "credits_25" }),
     );
 
     fireEvent.click(getByRole("button", { name: "Configure" }));
 
-    await waitFor(() => {
-      expect(getByTestId("loc").textContent).toBe(
-        "/assistant/settings/usage?tab=billing&adjust_plan",
-      );
-    });
-    expect(queryByText("Create a custom plan")).toBeNull();
+    getByText("Create a custom plan");
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(machineTierCall).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -229,9 +229,9 @@ export function CustomPlanModal({
         overlayClassName="backdrop-blur-[2px]"
         className="max-w-[820px] md:min-h-[min(608px,calc(100vh-4rem))]"
       >
-        <Modal.Body className="p-6">
+        <Modal.Body className="p-4">
           <div className="flex flex-col gap-8 md:flex-row md:gap-12">
-            <div className="flex min-w-0 flex-col gap-8 md:w-[440px] md:shrink-0">
+            <div className="flex min-w-0 flex-col gap-6 md:flex-1">
               <div className="flex items-center gap-3">
                 <div className="flex shrink-0 items-center justify-center rounded-xl bg-[var(--surface-active)] p-[14px]">
                   <SlidersHorizontal
@@ -249,7 +249,7 @@ export function CustomPlanModal({
                 </div>
               </div>
 
-              <div className="flex flex-col gap-2">
+              <div className="flex flex-col gap-1">
                 <span className="text-[11px] font-medium text-[var(--content-secondary)]">
                   Select a machine size:
                 </span>
@@ -262,7 +262,7 @@ export function CustomPlanModal({
                 />
               </div>
 
-              <div className="flex flex-col gap-2">
+              <div className="flex flex-col gap-1">
                 <span className="text-[11px] font-medium text-[var(--content-secondary)]">
                   Select storage:
                 </span>
@@ -275,7 +275,7 @@ export function CustomPlanModal({
                 />
               </div>
 
-              <div className="flex flex-col gap-2">
+              <div className="flex flex-col gap-1">
                 <span className="text-[11px] font-medium text-[var(--content-secondary)]">
                   Bundle some credits:
                 </span>
@@ -289,56 +289,58 @@ export function CustomPlanModal({
               </div>
             </div>
 
-            <div className="flex min-w-0 flex-1 flex-col gap-5 md:pt-[3px]">
+            <div className="flex min-w-0 flex-1 flex-col gap-16 md:pt-[5px]">
               <span className="text-[16px] font-medium text-[var(--content-emphasised)]">
                 Recap
               </span>
 
-              <div className="flex flex-col gap-1">
-                <span className="text-[24px] font-medium text-[var(--content-default)]">
-                  {formatMonthly(totalCents)}
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-1">
+                  <span className="text-[24px] font-medium text-[var(--content-default)]">
+                    {formatMonthly(totalCents)}
+                  </span>
+                  <span className="text-[11px] font-medium text-[var(--content-tertiary)]">
+                    Total
+                  </span>
+                </div>
+
+                <div className="h-px w-full bg-[var(--border-hover)]" />
+
+                <span className="text-[12px] font-medium text-[var(--content-tertiary)]">
+                  Your selection:
                 </span>
-                <span className="text-[11px] font-medium text-[var(--content-tertiary)]">
-                  Total
-                </span>
+
+                <ul className="flex flex-col gap-2">
+                  {selectionRows.map((row) => (
+                    <li key={row} className="flex items-center gap-2">
+                      <CircleCheck
+                        className="h-4 w-4 shrink-0 text-[var(--content-secondary)]"
+                        aria-hidden
+                      />
+                      <span className="text-[14px] font-medium leading-[18px] text-[var(--content-secondary)]">
+                        {row}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+
+                <Button
+                  variant="primary"
+                  fullWidth
+                  disabled={!complete || pending}
+                  onClick={handleContinue}
+                >
+                  Continue
+                </Button>
+                <Button
+                  variant="ghost"
+                  fullWidth
+                  disabled={pending}
+                  onClick={onClose}
+                >
+                  Cancel
+                </Button>
               </div>
-
-              <div className="h-px w-full bg-[var(--border-hover)]" />
-
-              <span className="text-[12px] font-medium text-[var(--content-tertiary)]">
-                Your selection:
-              </span>
-
-              <ul className="flex flex-col gap-2">
-                {selectionRows.map((row) => (
-                  <li key={row} className="flex items-start gap-2">
-                    <CircleCheck
-                      className="mt-0.5 h-4 w-4 shrink-0 text-[var(--content-secondary)]"
-                      aria-hidden
-                    />
-                    <span className="text-[14px] font-medium leading-[18px] text-[var(--content-secondary)]">
-                      {row}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-
-              <Button
-                variant="primary"
-                fullWidth
-                disabled={!complete || pending}
-                onClick={handleContinue}
-              >
-                Continue
-              </Button>
-              <Button
-                variant="ghost"
-                fullWidth
-                disabled={pending}
-                onClick={onClose}
-              >
-                Cancel
-              </Button>
             </div>
           </div>
         </Modal.Body>

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -849,6 +849,72 @@ function customCatalog(): PlanListResponse {
   };
 }
 
+/**
+ * A catalog whose only 10 GB storage tier is legacy. A Pro sub sitting on it
+ * can't be represented by the (legacy-filtered) modal storage picker, yet
+ * Configure must still open the modal rather than bounce to the manage surface.
+ */
+function legacyStorageCatalog(): PlanListResponse {
+  return {
+    plans: [
+      {
+        id: "base",
+        name: "Free",
+        price_cents: 0,
+        billing_interval: "month",
+        included_features: [],
+      },
+      {
+        id: "pro",
+        name: "Pro",
+        base_lookup_key: "pro_base",
+        base_price_cents: 2000,
+        billing_interval: "month",
+        included_features: [],
+        machine_tiers: [
+          {
+            tier: "medium",
+            label: "medium",
+            price_cents: 3500,
+            lookup_key: "machine_m",
+            cpu_limit: "2.5",
+            memory_gib: 5,
+            description: "Medium machine (2.5 vCPU, 5 GiB)",
+          },
+        ],
+        storage_tiers: [
+          {
+            tier: "xs",
+            label: "10 GB",
+            storage_gib: 10,
+            price_cents: 500,
+            lookup_key: "storage_10_legacy",
+            legacy: true,
+          },
+          {
+            tier: "s",
+            label: "30 GB",
+            storage_gib: 30,
+            price_cents: 1000,
+            lookup_key: "storage_30",
+            legacy: false,
+          },
+        ],
+        credit_tiers: [
+          {
+            tier: "credits_50",
+            label: "50 credits",
+            credits_usd: 50,
+            price_cents: 5000,
+            lookup_key: "credits_50",
+          },
+        ],
+        packages: [MIGHTY, SUPER, ULTRA],
+      },
+    ],
+  };
+}
+
 function openDropdown(ariaLabel: string): void {
   const trigger = document.querySelector<HTMLButtonElement>(
     `button[role="combobox"][aria-label="${ariaLabel}"]`,
@@ -922,20 +988,49 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
     expect(upgradeCall).toBeNull();
   });
 
-  test("an ineligible (cancelling) Pro sub's Configure routes to manage", async () => {
-    const { findByRole, getByTestId, queryByText } = renderInteractive(
+  // Configure always opens the in-place custom modal for a Pro sub, whatever the
+  // sub's eligibility or tier legacy status. An ineligible or legacy-tier sub
+  // that then tries to apply a change surfaces the backend's 4xx as a toast (the
+  // modal stays open) instead of being pre-emptively bounced to the manage
+  // surface.
+  test("an ineligible (cancelling) Pro sub's Configure opens the modal, not adjust_plan", async () => {
+    const { findByRole, getByTestId, getByText } = renderInteractive(
       { ...proMightySubscription(), cancel_at_period_end: true },
       { plans: customCatalog() },
     );
 
     fireEvent.click(await findByRole("button", { name: "Configure" }));
 
-    await waitFor(() =>
-      expect(getByTestId("loc").textContent).toBe(
-        "/assistant/settings/usage?tab=billing&adjust_plan",
-      ),
+    getByText("Create a custom plan");
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
+    expect(machineTierCall).toBeNull();
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("a base user's Configure opens the custom modal (checkout path), not adjust_plan", async () => {
+    const { findByRole, getByTestId, getByText } = renderInteractive(
+      freeSubscription(),
+      { plans: customCatalog() },
     );
-    expect(queryByText("Create a custom plan")).toBeNull();
+
+    fireEvent.click(await findByRole("button", { name: "Configure" }));
+
+    getByText("Create a custom plan");
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
+    // Checkout only fires once the modal's Continue is pressed.
+    expect(upgradeCall).toBeNull();
+  });
+
+  test("a Pro sub on a legacy storage tier's Configure opens the modal, not adjust_plan", async () => {
+    const { findByRole, getByTestId, getByText } = renderInteractive(
+      proMightySubscription(),
+      { plans: legacyStorageCatalog() },
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Configure" }));
+
+    getByText("Create a custom plan");
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(machineTierCall).toBeNull();
     expect(upgradeCall).toBeNull();
   });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -45,6 +45,7 @@ import type {
   PackageChangeResponse,
   PlanListResponse,
   ProPackage,
+  ProPlan,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
 
@@ -855,64 +856,15 @@ function customCatalog(): PlanListResponse {
  * Configure must still open the modal rather than bounce to the manage surface.
  */
 function legacyStorageCatalog(): PlanListResponse {
-  return {
-    plans: [
-      {
-        id: "base",
-        name: "Free",
-        price_cents: 0,
-        billing_interval: "month",
-        included_features: [],
-      },
-      {
-        id: "pro",
-        name: "Pro",
-        base_lookup_key: "pro_base",
-        base_price_cents: 2000,
-        billing_interval: "month",
-        included_features: [],
-        machine_tiers: [
-          {
-            tier: "medium",
-            label: "medium",
-            price_cents: 3500,
-            lookup_key: "machine_m",
-            cpu_limit: "2.5",
-            memory_gib: 5,
-            description: "Medium machine (2.5 vCPU, 5 GiB)",
-          },
-        ],
-        storage_tiers: [
-          {
-            tier: "xs",
-            label: "10 GB",
-            storage_gib: 10,
-            price_cents: 500,
-            lookup_key: "storage_10_legacy",
-            legacy: true,
-          },
-          {
-            tier: "s",
-            label: "30 GB",
-            storage_gib: 30,
-            price_cents: 1000,
-            lookup_key: "storage_30",
-            legacy: false,
-          },
-        ],
-        credit_tiers: [
-          {
-            tier: "credits_50",
-            label: "50 credits",
-            credits_usd: 50,
-            price_cents: 5000,
-            lookup_key: "credits_50",
-          },
-        ],
-        packages: [MIGHTY, SUPER, ULTRA],
-      },
-    ],
+  const catalog = customCatalog();
+  const pro = catalog.plans.find((p) => p.id === "pro") as ProPlan;
+  // storage_tiers[0] is the 10 GB tier.
+  pro.storage_tiers[0] = {
+    ...pro.storage_tiers[0],
+    lookup_key: "storage_10_legacy",
+    legacy: true,
   };
+  return catalog;
 }
 
 function openDropdown(ariaLabel: string): void {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -135,7 +135,6 @@ export function PlansPage() {
     changeTiers,
     isPending: changeTiersPending,
     current,
-    eligible,
     currentReady,
   } = useChangeTiers({ enabled: platformReady });
   // Native iOS keeps Checkout inside an in-app sheet, so the page holds
@@ -176,35 +175,6 @@ export function PlansPage() {
       creditTier: current.creditTier,
     };
   }, [isProUser, current.machineTier, current.storageTier, current.creditTier]);
-
-  // The in-place custom editor can only faithfully represent a Pro sub whose
-  // current tiers are all live catalog options. A legacy storage tier or a
-  // deprecated credit bundle can't be shown or re-selected here — routing such
-  // a sub through the modal would force it to drop that tier — so those fall
-  // back to the adjust-plan surface (which preserves them) instead.
-  const customReconfigurable = useMemo(() => {
-    if (!isProUser || !proPlan) {
-      return false;
-    }
-    // A null baseline machine (a package with no paid machine tier) is a valid
-    // current state — represent it rather than excluding the sub from the modal.
-    const machineOk =
-      current.machineTier == null ||
-      proPlan.machine_tiers.some((t) => t.tier === current.machineTier);
-    const storageOk = proPlan.storage_tiers.some(
-      (t) => !t.legacy && t.tier === current.storageTier,
-    );
-    const creditOk =
-      current.creditTier == null ||
-      (proPlan.credit_tiers ?? []).some((t) => t.tier === current.creditTier);
-    return machineOk && storageOk && creditOk;
-  }, [
-    isProUser,
-    proPlan,
-    current.machineTier,
-    current.storageTier,
-    current.creditTier,
-  ]);
 
   // The takeover only makes sense against a platform-hosted assistant with a
   // live package catalog. Anything else — self-hosted or no platform session,
@@ -395,24 +365,10 @@ export function PlansPage() {
     };
 
     const handleConfigure = () => {
-      if (isProUser) {
-        // The current tiers that decide representability load after the page
-        // renders. While that first load is in flight, don't fall through to
-        // the manage surface — the Configure CTA is held disabled until they
-        // land (see `configureDisabled`), so this is a defensive guard.
-        if (eligible && !currentReady) {
-          return;
-        }
-        // An eligible Pro sub whose current tiers are all representable here
-        // reconfigures in the white modal. Anything else — cancelling /
-        // non-entitlement status, or a legacy/deprecated tier the modal can't
-        // show — routes to the billing manage/cancel surface, the same fallback
-        // the package CTAs use.
-        if (eligible && customReconfigurable) {
-          setCustomPlanOpen(true);
-          return;
-        }
-        navigate(`${routes.settings.usage}?tab=billing&adjust_plan`);
+      // A Pro sub's current tiers load after the page renders; the modal seeds
+      // from them, so hold the click until that first load settles (the CTA is
+      // also held disabled meanwhile — see `configureDisabled`).
+      if (isProUser && !currentReady) {
         return;
       }
       setCustomPlanOpen(true);
@@ -504,7 +460,7 @@ export function PlansPage() {
         <CustomPlanRow
           className="mt-10"
           onConfigure={handleConfigure}
-          configureDisabled={isProUser && eligible && !currentReady}
+          configureDisabled={isProUser && !currentReady}
         />
 
         <CustomPlanModal


### PR DESCRIPTION
## Summary
Two focused fixes to the Pro plans takeover (`clients/web`), gated as today behind the `pro-packages` flag:
- **Customize/Configure always opens the new `CustomPlanModal`.** `handleConfigure` no longer falls back to the legacy `?tab=billing&adjust_plan` surface for ineligible / legacy-tier Pro subs — every plan can now open the custom-plan modal. Ineligible/cancelling subs still degrade gracefully (the backend's 409/403 surfaces as a toast, modal stays open). The upgrade path (`selectTier` / `isPackageSwitchEligible`) is intentionally unchanged.
- **Custom-plan modal spacing aligned to the Figma mock** (`7228:79872`): body padding, column/label gaps, the Recap column's two-tier spacing, centered checklist icons, and equal-width columns. The platform-fee recap row (`Pro base plan — $X/mo`) is preserved.

## Scope note
This is a **partial execution** of the plan. **PR 2 + PR 3 (wiring the full-screen provisioning takeover to in-place upgrades) are deferred** — their original scoping was against a stale local takeover snapshot and overlaps the in-flight `takeover-avatar-tinted-background` branch (#38858, not yet on main). They'll be re-scoped against main's current takeover and coordinated with #38858 in a follow-up.

## Self-review result
PASS. Production code was clean on the first pass (upgrade path untouched, no orphaned symbols, spacing-only modal change). Two test-only gaps were found and fixed in a single fix PR: a sibling test file (`custom-plan-modal.test.tsx`) still asserted the deleted Configure→`adjust_plan` routing (CI-red), and a bloated test fixture was slimmed to the repo's derive-and-override idiom.

## PRs merged into this feature branch
- #38871: feat(web): always open the custom-plan modal from the plans takeover Customize
- #38872: fix(web): align the custom-plan modal spacing with the Figma mock
- #38875: test(web): align Configure tests with the always-open custom-plan modal (self-review fix)

Part of plan: plans-takeover-inplace-provisioning.md