### PR TITLE
fix(daemon): isolate Slack onStreamOpen breadcrumb failure from stream-start fallback

### DIFF
--- a/assistant/src/runtime/slack-reply-session.test.ts
+++ b/assistant/src/runtime/slack-reply-session.test.ts
@@ -370,6 +370,38 @@ describe("createSlackReplySession", () => {
     expect(reconciliation).toEqual({ mode: "fallback" });
   });
 
+  test("keeps streaming when the onStreamOpen breadcrumb write throws", async () => {
+    // The stream opened on Slack's side, so a throwing `onStreamOpen` (e.g. a
+    // transient breadcrumb write error) must not knock the session into
+    // fallback — that would repost the already-visible streamed reply.
+    const onStreamOpenCalls: string[] = [];
+    const session = createSlackReplySession({
+      sourceChannel: "slack",
+      chatType: "im",
+      replyCallbackUrl: CALLBACK_URL,
+      chatId: CHANNEL,
+      onStreamOpen: (streamTs) => {
+        onStreamOpenCalls.push(streamTs);
+        throw new Error("transient SQLite write error");
+      },
+    })!;
+    expect(session).toBeDefined();
+
+    session.observeEvent(textDelta("The complete answer."));
+    session.observeEvent(messageComplete("assistant-msg-1"));
+    const reconciliation = await session.finish();
+
+    // The callback fired with the opened stream's ts, and its throw left the
+    // session streaming: the stop still lands and finalize reconciles in place.
+    expect(onStreamOpenCalls).toEqual(["stream-ts-1"]);
+    expect(slackStreamOps().map((op) => op.action)).toEqual(["start", "stop"]);
+    expect(reconciliation).toEqual({
+      mode: "streamed",
+      messageTs: "stream-ts-1",
+      deliveredSegmentCount: 1,
+    });
+  });
+
   test("appends task-only progress that advances without new body text", async () => {
     // `chat.appendStream` accepts a chunks-only call, so a plan that advances
     // during tool work lands live instead of waiting for the final stop.

--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -234,7 +234,18 @@ export function createSlackReplySession(params: {
           confirmedLength = firstChunk.length;
           deliveredProgressKey = progressKey(title, tasks);
           state = "streaming";
-          params.onStreamOpen?.(result.ts);
+          // The stream is already open on Slack's side, so an `onStreamOpen`
+          // failure must not downgrade to fallback and repost the visible
+          // reply. Losing the breadcrumb only forfeits crash-window dedup —
+          // strictly better than a guaranteed duplicate post.
+          try {
+            params.onStreamOpen?.(result.ts);
+          } catch (err) {
+            log.warn(
+              { err, chatId },
+              "Slack onStreamOpen callback failed; keeping streamed state",
+            );
+          }
         } else {
           state = "fallback";
         }


### PR DESCRIPTION
Addresses Codex review feedback on #38585.

## Problem

In `createSlackReplySession`, `params.onStreamOpen?.(result.ts)` ran inside the same `try` block that catches `chat.startStream` failures. `onStreamOpen` is wired to `storeStreamedReplyTs`, which writes the stream-`ts` breadcrumb to SQLite. If that write throws a transient error (write/locking) **after** the stream already opened on Slack's side, the `catch` treated it as a stream-start failure and set `state = "fallback"`.

`finish()` then reports `fallback`, so durable delivery posts the **full reply** instead of reconciling against `result.ts` — duplicating the already-visible Slack stream. That is the exact duplicate-post bug class #38585 was fixing, re-introduced through a different path.

## Fix

Wrap the `onStreamOpen` callback in its own `try/catch` that logs a warning and **keeps** `state = "streaming"` (the stream genuinely opened). 

Trade-off accepted: if the breadcrumb write fails, a crash in that window can't dedup via the breadcrumb — that's the pre-existing recovery behavior and strictly better than a guaranteed duplicate post.

## Tests

New case in `slack-reply-session.test.ts`: `onStreamOpen` throws after a successful `startStream`; the session still stops the stream and reports `{ mode: "streamed" }` (no fallback duplicate). Verified the test fails against the pre-fix code (session flips to fallback, no `stop` op) and passes with the fix. Full file: 30 pass / 0 fail.