### PR TITLE
refactor(web): reuse remoteGatewayPublicBaseUrl for the pairing handoff URL

### DIFF
--- a/clients/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.test.tsx
@@ -92,6 +92,15 @@ mock.module("@/lib/auth/remote-gateway-session", () => ({
       userCode: url.searchParams.get("userCode"),
     };
   },
+  remoteGatewayPublicBaseUrl: () => {
+    const { origin, pathname } = window.location;
+    const match = /\/assistant(?:\/|$)/.exec(pathname);
+    const prefix =
+      match && match.index > 0
+        ? pathname.slice(0, match.index).replace(/\/+$/, "")
+        : "";
+    return `${origin}${prefix}`;
+  },
   RemoteWebPairingError: MockRemoteWebPairingError,
 }));
 

--- a/clients/web/src/domains/remote-web/pairing-page.tsx
+++ b/clients/web/src/domains/remote-web/pairing-page.tsx
@@ -13,6 +13,7 @@ import {
   createRemoteWebPairingChallenge,
   exchangeRemoteWebPairingToken,
   parseRemoteWebPairingParams,
+  remoteGatewayPublicBaseUrl,
   RemoteWebPairingError,
 } from "@/lib/auth/remote-gateway-session";
 import { isRemoteGatewayMode } from "@/lib/local-mode";
@@ -124,24 +125,6 @@ function clearDeviceCodeFromUrl(): void {
 const VELLUM_APP_SCHEME = "vellum-assistant";
 
 /**
- * The server's public base URL: origin plus any path prefix the deployment is
- * served under, derived by stripping this page's own route from the pathname.
- * A prefix-served assistant (pair page at
- * `https://host/assistant-123/assistant/pair`) must hand the app
- * `https://host/assistant-123` — the connect handler appends the pair route
- * back onto whatever base it receives.
- */
-function publicBaseFromLocation(): string {
-  const { origin, pathname } = window.location;
-  const normalized = pathname.replace(/\/+$/, "");
-  const suffix = "/assistant/pair";
-  if (normalized.endsWith(suffix)) {
-    return `${origin}${normalized.slice(0, -suffix.length)}`;
-  }
-  return origin;
-}
-
-/**
  * Build the `vellum-assistant://connect?url=<base>&code=<device-code>` deep
  * link the iOS app consumes to persist this server and finish pairing inside
  * the app. `url` is the page's own public base (origin + served path prefix)
@@ -150,7 +133,7 @@ function publicBaseFromLocation(): string {
  */
 function buildAppHandoffUrl(deviceCode: string): string {
   const query = new URLSearchParams({
-    url: publicBaseFromLocation(),
+    url: remoteGatewayPublicBaseUrl(),
     code: deviceCode,
   });
   return `${VELLUM_APP_SCHEME}://connect?${query.toString()}`;

--- a/clients/web/src/lib/auth/remote-gateway-session.ts
+++ b/clients/web/src/lib/auth/remote-gateway-session.ts
@@ -124,7 +124,14 @@ export function remoteGatewayApiPath(
   return `${remoteGatewayPublicPathPrefix(location)}${path}`;
 }
 
-function remoteGatewayPublicBaseUrl(): string {
+/**
+ * The server's public base URL: origin plus any path prefix the deployment is
+ * served under (via {@link remoteGatewayPublicPathPrefix}). A prefix-served
+ * assistant (pair page at `https://host/assistant-123/assistant/pair`) resolves
+ * to `https://host/assistant-123`; consumers append their own route or API path
+ * onto this base, so it must carry the prefix to reach the right assistant.
+ */
+export function remoteGatewayPublicBaseUrl(): string {
   return `${window.location.origin}${remoteGatewayPublicPathPrefix()}`;
 }
 


### PR DESCRIPTION
## Summary

Addresses the Codex P1 on #38716: `pairing-page.tsx` locally re-derived the server's public base (origin + served path prefix) in `publicBaseFromLocation`, duplicating the derivation already owned by `remoteGatewayPublicBaseUrl()` in `remote-gateway-session.ts`. Two copies drift if public-prefix shapes change, and the iOS handoff URL could then disagree with the remote session's stored server URL — both now flow from the one helper.

- Export `remoteGatewayPublicBaseUrl` from `remote-gateway-session.ts` (origin+prefix rationale moved onto it, present tense) and consume it in `buildAppHandoffUrl`; delete `publicBaseFromLocation`.
- Verified equivalence for every pathname ending in `/assistant/pair` (unprefixed, hosted-prefix `/assistant-123`, trailing slashes): the prefix-regex and suffix-strip approaches return identical results, so the pinned handoff tests stay green.
- Added `remoteGatewayPublicBaseUrl` to the fully-mocked module in `pairing-page.test.tsx` (mirrors the real prefix derivation; the module mock replaces all exports, so the imported binding would otherwise be undefined).

Tests: pairing-page.test.tsx 14/14, remote-gateway-session.test.ts 13/13. No new tsc errors in touched files.

Addresses Codex review feedback on #38716.