### PR TITLE
fix(chat): retry background turns in their recorded interactivity mode

### DIFF
--- a/assistant/src/__tests__/conversation-retry-route.test.ts
+++ b/assistant/src/__tests__/conversation-retry-route.test.ts
@@ -316,7 +316,10 @@ describe("POST /v1/conversations/:id/retry", () => {
     expect(typeof (options as { onEvent?: unknown }).onEvent).toBe("function");
   });
 
-  test("background-event anchor re-runs hidden AND non-interactive", async () => {
+  test("legacy background-event anchor (no recorded mode) re-runs hidden AND non-interactive", async () => {
+    // Anchors persisted before `backgroundEventInteractive` existed carry only
+    // `backgroundEventSource`. Fall back to non-interactive so a retried
+    // scheduled turn doesn't stall on approvals the original never asked for.
     discardResult = {
       anchor: anchorRow({
         metadata: JSON.stringify({ backgroundEventSource: "schedule" }),
@@ -335,8 +338,72 @@ describe("POST /v1/conversations/:id/retry", () => {
     expect(res.status).toBe(202);
     await settle();
 
-    // A scheduled/wake anchor was dispatched non-interactively, so the retry
-    // reproduces that background permission mode instead of a foreground chat.
+    const [, , options] = ctx.runAgentLoop.mock.calls[0];
+    expect(options).toMatchObject({
+      isHiddenPrompt: true,
+      isInteractive: false,
+    });
+  });
+
+  test("background-event anchor recorded interactive re-runs hidden but interactive", async () => {
+    // A scheduled/backgrounded-tool/remote wake ran interactive and stamped
+    // `backgroundEventInteractive: true`; the retry reproduces that mode so it
+    // keeps the approval prompts the original turn had (rather than the legacy
+    // assumption that every background event ran headless).
+    discardResult = {
+      anchor: anchorRow({
+        metadata: JSON.stringify({
+          backgroundEventSource: "schedule",
+          backgroundEventInteractive: true,
+        }),
+      }),
+      deletedMessageIds: ["assistant-msg-1"],
+    };
+    const ctx = makeConversation();
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      retryHandler,
+      makeRequest(),
+      { id: "conv-retry-test" },
+      202,
+    );
+    expect(res.status).toBe(202);
+    await settle();
+
+    const [, , options] = ctx.runAgentLoop.mock.calls[0];
+    expect(options).toMatchObject({
+      isHiddenPrompt: true,
+      isInteractive: true,
+    });
+  });
+
+  test("background-event anchor recorded non-interactive re-runs hidden AND non-interactive", async () => {
+    // A clientless/headless wake (interrupted-turn recovery, local IPC wake)
+    // stamped `backgroundEventInteractive: false`; the retry reproduces the
+    // non-interactive mode so side-effecting tools resolve against trust rules
+    // instead of blocking on an absent client.
+    discardResult = {
+      anchor: anchorRow({
+        metadata: JSON.stringify({
+          backgroundEventSource: "interrupted-turn",
+          backgroundEventInteractive: false,
+        }),
+      }),
+      deletedMessageIds: ["assistant-msg-1"],
+    };
+    const ctx = makeConversation();
+    activeConversation = ctx.conversation;
+
+    const res = await callHandler(
+      retryHandler,
+      makeRequest(),
+      { id: "conv-retry-test" },
+      202,
+    );
+    expect(res.status).toBe(202);
+    await settle();
+
     const [, , options] = ctx.runAgentLoop.mock.calls[0];
     expect(options).toMatchObject({
       isHiddenPrompt: true,

--- a/assistant/src/daemon/__tests__/wake-conversation-ops-completion.test.ts
+++ b/assistant/src/daemon/__tests__/wake-conversation-ops-completion.test.ts
@@ -76,6 +76,7 @@ describe("persistWakeTriggerMessage backgroundToolCompletion", () => {
       makeConversationStub(conversationId),
       triggerMessage(),
       "background-tool",
+      true,
       completion,
     );
 
@@ -85,6 +86,8 @@ describe("persistWakeTriggerMessage backgroundToolCompletion", () => {
     expect(metadata.kind).toBe("background-event");
     expect(metadata.backgroundEventSource).toBe("background-tool");
     expect(metadata.automated).toBe(true);
+    // The interactivity mode the wake ran under is recorded for later retries.
+    expect(metadata.backgroundEventInteractive).toBe(true);
   });
 
   test("omits the key entirely when no completion is passed", async () => {
@@ -92,10 +95,13 @@ describe("persistWakeTriggerMessage backgroundToolCompletion", () => {
       makeConversationStub(conversationId),
       triggerMessage(),
       "background-tool",
+      false,
     );
 
     const metadata = readMetadata(conversationId);
     expect("backgroundToolCompletion" in metadata).toBe(false);
     expect(metadata.kind).toBe("background-event");
+    // A clientless/headless wake records the non-interactive mode.
+    expect(metadata.backgroundEventInteractive).toBe(false);
   });
 });

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -96,8 +96,10 @@ export function isEchoSuppressedUserMessage(
 /**
  * True when the row is a persisted `<background_event source="...">` trigger —
  * every wake, scheduled run, and backgrounded-tool completion stamps one (see
- * {@link persistWakeTriggerMessage}). Such turns are dispatched
- * non-interactively (clientless/headless).
+ * {@link persistWakeTriggerMessage}). The permission mode such a turn ran under
+ * varies (most run interactive; clientless/headless wakes do not) and is
+ * recorded separately in `backgroundEventInteractive`; this predicate only
+ * identifies the row as a background event.
  */
 export function isBackgroundEventMetadata(
   metadata: Record<string, unknown> | undefined,

--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -273,11 +273,19 @@ export async function persistWakeTailMessage(
  * for identification and skips indexing (the body may carry untrusted command
  * output). The `backgroundEventSource` stamp lets clients hide this row from the
  * rendered transcript — the user-facing wake card carries the status instead.
+ *
+ * `interactive` records the permission mode the woken turn ran under (derived
+ * from the wake's `clientless` option): most background events (scheduled
+ * runs, backgrounded-tool completions, remote wakes) run interactive, while
+ * clientless/headless wakes (interrupted-turn recovery, local IPC wakes) run
+ * non-interactive. Retrying the anchor reuses this so the re-run reproduces the
+ * original turn's approval semantics.
  */
 export async function persistWakeTriggerMessage(
   conversation: Conversation,
   message: Message,
   source: string,
+  interactive: boolean,
   completion?: CompletedBackgroundTool,
 ): Promise<void> {
   const turnChannelCtx = conversation.getTurnChannelContext();
@@ -292,6 +300,7 @@ export async function persistWakeTriggerMessage(
       turnInterfaceCtx?.assistantMessageInterface ?? "web",
     kind: "background-event",
     backgroundEventSource: source,
+    backgroundEventInteractive: interactive,
     automated: true,
     ...(completion ? { backgroundToolCompletion: completion } : {}),
   };

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -860,6 +860,11 @@ export async function wakeAgentForOpportunity(
           conversation,
           triggerMessage,
           source,
+          // Record the permission mode this wake runs under so a later retry
+          // reproduces it. `clientless` pins `hasNoClient` → `isInteractive:
+          // false`; its absence leaves the turn interactive (see the option's
+          // doc and the `hasNoClient` pin below).
+          !opts.clientless,
           opts.backgroundToolCompletion,
         );
       } catch (err) {

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -716,11 +716,17 @@ async function handleRetryLastAssistantTurn({
   // send) re-runs as a hidden turn so it stays out of the titler, mirroring
   // how the original turn ran.
   const isHiddenPrompt = isEchoSuppressedUserMessage(anchorMetadata);
-  // Reproduce the anchor's original permission mode: a background-event turn
-  // ran non-interactively (trust-rule auto-resolution, not blocking prompts),
-  // so forcing interactive would stall a retried scheduled turn on approvals
-  // the original never asked for.
-  const isInteractive = !isBackgroundEventMetadata(anchorMetadata);
+  // Reproduce the anchor's original permission mode so the re-run keeps the
+  // same approval semantics: a background-event wake records the interactivity
+  // it ran under (`backgroundEventInteractive`; see persistWakeTriggerMessage).
+  // Legacy anchors written before the field existed fall back to non-interactive
+  // — the conservative choice that keeps a retried scheduled turn from stalling
+  // on approvals the original never asked for.
+  const recordedInteractive = anchorMetadata?.backgroundEventInteractive;
+  const isInteractive =
+    typeof recordedInteractive === "boolean"
+      ? recordedInteractive
+      : !isBackgroundEventMetadata(anchorMetadata);
   const contentText = extractUserPromptText(anchor.content);
 
   // Fire-and-forget: return 202 immediately, stream the re-run over SSE. The


### PR DESCRIPTION
## Summary

Follow-up to #38583, addressing Codex review feedback.

#38583 made `POST /v1/conversations/:id/retry` re-run a background-event anchor non-interactively, inferring the mode from `!isBackgroundEventMetadata(anchorMetadata)`. But the `backgroundEventSource` marker only records that the trigger was persisted for transcript display — it does **not** imply the original wake ran clientless/non-interactive. In fact most background-event wakes run **interactive**:

- Scheduled wakes (`scheduler.ts`, `schedule-routes.ts`) pass `persistTriggerAsEvent: true` but **not** `clientless`.
- Backgrounded-tool completions (`shell.ts`, `host-shell.ts`) likewise run interactive.
- Remote persisted wakes (`wake-conversation-routes.ts`) stay interactive.

Only `interrupted-turn-reconciler` and local IPC wakes pass `clientless: true`. So the previous fix forced the majority of previously-interactive turns into non-interactive mode on retry — changing tool availability and converting approval prompts into automatic denial.

## Change

- Persist the original interactivity mode when the background-event trigger is written: `persistWakeTriggerMessage` now stamps `backgroundEventInteractive` into the row metadata, derived from the wake's `clientless` option (`!opts.clientless`) in `agent-wake.ts`. This is the single writer of `backgroundEventSource` metadata, and every `persistTriggerAsEvent` caller funnels through it, so all wake sources stamp the mode correctly.
- On retry, use the recorded field when present; fall back to the previous inference (`!isBackgroundEventMetadata`) for legacy anchors written before the field existed — preserving #38583's fix for pre-existing scheduled anchors.
- Corrected the now-inaccurate `isBackgroundEventMetadata` docstring that claimed these turns are always dispatched non-interactively.

## Backwards compatibility

`backgroundEventInteractive` is additive per-message JSON metadata — no migration needed. Legacy rows without it are handled by the fallback branch.

## Tests

- `conversation-retry-route.test.ts`: recorded-interactive anchor -> retry interactive; recorded-non-interactive anchor -> retry non-interactive; legacy anchor (no field) -> retry non-interactive (fallback).
- `wake-conversation-ops-completion.test.ts`: asserts `backgroundEventInteractive` round-trips both boolean values.

Addresses Codex review feedback on #38583.