### PR TITLE
fix(settings): gate pair-device card action on feature-flag hydration

### DIFF
--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -11,6 +11,7 @@ import {
 let gatewayPath: string | undefined = "/assistant/__gateway/20100";
 let supportsPairingRoutes = true;
 let webRemoteIngressOn = true;
+let flagsHydrated = true;
 
 mock.module("@/lib/local-mode", () => ({
   getLocalGatewayUrl: () => gatewayPath,
@@ -23,7 +24,10 @@ mock.module("@/lib/backwards-compat/remote-web-pairing-gate", () => ({
 
 mock.module("@/stores/assistant-feature-flag-store", () => ({
   useAssistantFeatureFlagStore: {
-    use: { webRemoteIngress: () => webRemoteIngressOn },
+    use: {
+      webRemoteIngress: () => webRemoteIngressOn,
+      hasHydrated: () => flagsHydrated,
+    },
   },
 }));
 
@@ -99,6 +103,7 @@ beforeEach(() => {
   gatewayPath = "/assistant/__gateway/20100";
   supportsPairingRoutes = true;
   webRemoteIngressOn = true;
+  flagsHydrated = true;
   requests = [];
   localStorage.clear();
 });
@@ -130,6 +135,33 @@ describe("PairDeviceCard", () => {
     const { container } = render(<PairDeviceCard />);
     expect(container.firstChild).toBeNull();
     expect(screen.queryByText("Pair a device")).toBeNull();
+  });
+
+  test("holds the action in a loading state until feature flags hydrate", () => {
+    // Before hydration the store still reports registry defaults
+    // (webRemoteIngress false), so the precheck must not run against it yet.
+    flagsHydrated = false;
+    webRemoteIngressOn = false;
+    const fetchMock = installFetch(() => jsonResponse(challengeBody()));
+    render(<PairDeviceCard />);
+    typeUrl(PUBLIC_URL);
+
+    const button = screen.getByRole("button", {
+      name: "Loading…",
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+
+    // Enter is a second mint path the disabled button doesn't cover, so it must
+    // also no-op until hydration — otherwise the default flag reaches the
+    // precheck and shows a spurious "disabled" error.
+    fireEvent.keyDown(screen.getByLabelText("Public URL"), { key: "Enter" });
+
+    expect(
+      screen.queryByText(
+        "Remote web access is disabled on this assistant, so a scanned code couldn't connect.",
+      ),
+    ).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(0);
   });
 
   test("reports the enable guidance without minting when web-remote-ingress is off", async () => {

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -27,6 +27,7 @@ import { usePairDevice } from "./use-pair-device";
 export function PairDeviceCard() {
   const base = resolvePairDeviceGatewayBase();
   const supported = useSupportsRemoteWebPairing();
+  const flagsHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
   const webRemoteIngressOn = useAssistantFeatureFlagStore.use.webRemoteIngress();
   const pair = usePairDevice(base, webRemoteIngressOn);
   const { copy, copied } = useCopyToClipboard();
@@ -38,11 +39,25 @@ export function PairDeviceCard() {
   const { phase } = pair;
   const isMinting = phase.kind === "minting";
   const isReady = phase.kind === "ready";
-  const buttonLabel = isMinting
-    ? "Generating…"
-    : isReady
-      ? "Generate new code"
-      : "Generate pairing QR";
+  // Until the feature-flag store hydrates, webRemoteIngressOn is the registry
+  // default (false), not this assistant's real value, so the mint precheck
+  // can't be trusted until hasHydrated is true.
+  const buttonLabel = !flagsHydrated
+    ? "Loading…"
+    : isMinting
+      ? "Generating…"
+      : isReady
+        ? "Generate new code"
+        : "Generate pairing QR";
+
+  // Both the button and the Enter key mint through here, so the flag precheck
+  // is never evaluated against the pre-hydration default.
+  const handleGenerate = () => {
+    if (!flagsHydrated) {
+      return;
+    }
+    pair.generate();
+  };
 
   return (
     <DetailCard
@@ -63,15 +78,17 @@ export function PairDeviceCard() {
             onKeyDown={(event) => {
               if (event.key === "Enter") {
                 event.preventDefault();
-                pair.generate();
+                handleGenerate();
               }
             }}
           />
           <Button
             variant="primary"
             className="self-start"
-            disabled={isMinting || pair.publicBaseUrl.trim() === ""}
-            onClick={pair.generate}
+            disabled={
+              !flagsHydrated || isMinting || pair.publicBaseUrl.trim() === ""
+            }
+            onClick={handleGenerate}
           >
             {buttonLabel}
           </Button>


### PR DESCRIPTION
## Summary
Addresses the Codex P2 finding on #38802: the pair-device settings card read `useAssistantFeatureFlagStore.use.webRemoteIngress()` immediately. Before the feature-flag store hydrates (initial load and right after an assistant switch), that flag sits at its registry default (`false`). For an assistant where `web-remote-ingress` IS enabled, clicking the already-rendered card during that window took the ingress-disabled error branch and made no pairing request.

## Fix
- Subscribe to `useAssistantFeatureFlagStore.use.hasHydrated()` in the card (the contract documented on the store: gating destructive/precheck UI on a flag must wait for `hasHydrated === true`).
- Both mint entry points — the Generate button and the Input's Enter key — route through a single `handleGenerate` guard that no-ops until hydration, so the flag precheck is never evaluated against the pre-hydration default. Pre-hydration the button is disabled and shows a `Loading…` label.
- Post-hydration behavior is exactly as before.

## Tests
- Added `holds the action in a loading state until feature flags hydrate` (button disabled + loading label, Enter is a no-op, no error Notice, zero fetches).
- Full suite green: `bun test src/domains/settings/pair-device/pair-device-card.test.tsx` → 8/8.

## Files
- `clients/web/src/domains/settings/pair-device/pair-device-card.tsx`
- `clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx`