### PR TITLE
fix(assistant): sanitize untrusted slugs/errors in consolidation prompt

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/substrate/__tests__/prompts-consolidation.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/substrate/__tests__/prompts-consolidation.test.ts
@@ -232,6 +232,53 @@ describe("resolveConsolidationPrompt — parse-failures repair section", () => {
     expect(result).toContain("frontmatter fields are ignored");
   });
 
+  test("sanitizes injection-shaped slugs and errors — newlines, backticks, oversize", () => {
+    // A concept-page filename and a YAML parser message (which quotes the
+    // file's own content) are attacker-influenced. Raw, they could break out
+    // of the list item or the inline-code span in this guardian-trust prompt.
+    const injected = {
+      slug: "evil\n\n## Injected heading\n- `nested`",
+      error: "boom`code`\nsecond line\n## also injected",
+      dropped: true,
+    };
+    const oversize = {
+      slug: "s".repeat(500),
+      error: "e".repeat(500),
+      dropped: false,
+    };
+    const section = renderParseFailuresSection([injected, oversize]);
+
+    // Each failure stays exactly one Markdown list item — no injected newline
+    // splits a page across lines.
+    const listBody = section
+      .split("could not be fully parsed:\n\n")[1]
+      .split("\n\nRepair each file")[0];
+    const listLines = listBody.split("\n");
+    expect(listLines).toHaveLength(2);
+    for (const line of listLines) {
+      expect(line.startsWith("- `memory/concepts/")).toBe(true);
+      // Only the template's own two backticks survive; injected ones are gone.
+      expect((line.match(/`/g) ?? []).length).toBe(2);
+    }
+
+    // Injected newlines create no new heading line — only the section's own
+    // `## 0.` header starts with `## `.
+    const headingLines = section
+      .split("\n")
+      .filter((line) => line.startsWith("## "));
+    expect(headingLines).toHaveLength(1);
+
+    // The page stays identifiable from its sanitized slug.
+    expect(section).toContain("memory/concepts/evil ");
+
+    // Lengths are capped (total, including the ellipsis) so a pathological
+    // value can't flood the prompt.
+    expect(section).toContain(`${"s".repeat(199)}…`);
+    expect(section).toContain(`${"e".repeat(299)}…`);
+    expect(section).not.toContain("s".repeat(200));
+    expect(section).not.toContain("e".repeat(300));
+  });
+
   test("override containing the placeholder → substituted in place", () => {
     const path = join(tmpWorkspace, "custom-prompt.md");
     writeFileSync(path, "Top\n{{PARSE_FAILURES_SECTION}}Bottom\n");

--- a/assistant/src/plugins/defaults/memory/v3/substrate/prompts/consolidation.ts
+++ b/assistant/src/plugins/defaults/memory/v3/substrate/prompts/consolidation.ts
@@ -18,6 +18,7 @@
  * the convention established for the sweep prompt.
  */
 
+import { truncate } from "../../../host-utils.js";
 import { getLogger } from "../../../logging.js";
 import { getWorkspaceDir } from "../../../paths.js";
 import { loadPromptOverride } from "../../../prompt-override.js";
@@ -39,6 +40,27 @@ export const CUTOFF_PLACEHOLDER = "{{CUTOFF}}";
  */
 export const PARSE_FAILURES_PLACEHOLDER = "{{PARSE_FAILURES_SECTION}}";
 
+/** Length cap for a rendered slug — long enough to stay identifiable. */
+const MAX_SLUG_CHARS = 200;
+/** Length cap for a rendered parser-error string. */
+const MAX_ERROR_CHARS = 300;
+
+/**
+ * Neutralize an untrusted page slug or parser-error string before it lands in
+ * the consolidation prompt. The consolidation run executes with unrestricted
+ * workspace file-write tools, and both values are attacker-influenced: a slug
+ * is a concept-page filename, and a YAML parser message embeds excerpts of the
+ * file's own content. Left raw they could break out of the Markdown list item
+ * or the inline-code span and inject instructions. Collapse every newline run
+ * to a single space so each failure stays one list item, replace backticks so
+ * an inline-code span cannot be opened or closed early, and cap the length so a
+ * pathological value cannot flood the prompt. The result stays identifiable.
+ */
+function sanitizeParseFailureText(value: string, maxChars: number): string {
+  const collapsed = value.replace(/[\r\n]+/g, " ").replaceAll("`", "'");
+  return truncate(collapsed, maxChars, "…");
+}
+
 /**
  * Render the repair step for pages the index build could not fully parse.
  * Empty input renders the empty string — with the section's trailing blank
@@ -53,11 +75,14 @@ export function renderParseFailuresSection(
   }
   const lines = failures.map(
     (f) =>
-      `- \`memory/concepts/${f.slug}.md\` — ${
+      `- \`memory/concepts/${sanitizeParseFailureText(
+        f.slug,
+        MAX_SLUG_CHARS,
+      )}.md\` — ${
         f.dropped
           ? "INVISIBLE to retrieval until repaired"
           : "indexed, but its frontmatter fields are ignored"
-      } — ${f.error}`,
+      } — ${sanitizeParseFailureText(f.error, MAX_ERROR_CHARS)}`,
   );
   return `## 0. FIRST — repair unreadable pages
 


### PR DESCRIPTION
## Summary

Follow-up to #38819 (Codex review, P2). `renderParseFailuresSection` interpolated the concept-page slug and the parser-error string into the guardian-trust consolidation prompt **raw**. Both are attacker-influenced — a slug is a page filename, and a YAML parser message embeds excerpts of the file's own content — so a crafted page could break out of its Markdown list item (via newlines) or its inline-code span (via backticks) and inject instructions into a consolidation run that holds unrestricted workspace file-write/edit tools.

## Fix

New `sanitizeParseFailureText(value, maxChars)` helper, applied to **both** the slug and the error before rendering:

- Collapses every `\r`/`\n` run to a single space, so each failure stays one Markdown list item.
- Replaces backticks with `'`, so the inline-code span can't be opened or closed early.
- Caps length (slug 200, error 300 — total including the ellipsis) via the shared surrogate-safe `truncate` from the memory plugin's `host-utils` waist (the sanctioned util channel; matches `pool-select` / `agent-protocol` usage).

The section's shape, byte-stability trick (empty input → empty string), and repair instructions are unchanged; a page stays identifiable from its sanitized slug.

## Scope

`renderParseFailuresSection` is the only site that interpolates `PageParseFailure` values into an LLM prompt. The other two consumers are non-prompt surfaces and need no change: `memory-v2-routes.ts` builds a JSON diagnostic (its own separate `ParseFailure` type) and the `memory-v2` CLI prints to the terminal.

## Tests

Extended `prompts-consolidation.test.ts` with an injection-shaped case (newline + backtick + 500-char oversize) asserting single-list-item containment, backtick neutralization, no injected heading line, slug identifiability, and length caps. 24/24 pass; `typecheck:fast` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)