### PR TITLE
Add bounded restarts for local assistant services

### DIFF
--- a/cli/src/commands/supervise.ts
+++ b/cli/src/commands/supervise.ts
@@ -1,0 +1,88 @@
+import { spawn } from "child_process";
+
+const MAX_RESTARTS = 5;
+const BASE_RESTART_DELAY_MS = 1_000;
+
+interface SupervisedProcessConfig {
+  command: string;
+  args: string[];
+  cwd?: string;
+  label: string;
+}
+
+function readConfig(): SupervisedProcessConfig {
+  const raw = process.env.VELLUM_SUPERVISED_PROCESS;
+  if (!raw) {
+    throw new Error("Missing supervised process configuration");
+  }
+
+  const config = JSON.parse(raw) as Partial<SupervisedProcessConfig>;
+  if (
+    typeof config.command !== "string" ||
+    !Array.isArray(config.args) ||
+    !config.args.every((arg) => typeof arg === "string") ||
+    typeof config.label !== "string"
+  ) {
+    throw new Error("Invalid supervised process configuration");
+  }
+
+  return {
+    command: config.command,
+    args: config.args,
+    cwd: typeof config.cwd === "string" ? config.cwd : undefined,
+    label: config.label,
+  };
+}
+
+export async function supervise(): Promise<void> {
+  const config = readConfig();
+  const childEnv = { ...process.env };
+  delete childEnv.VELLUM_SUPERVISED_PROCESS;
+  let child: ReturnType<typeof spawn> | undefined;
+  let shuttingDown = false;
+
+  const forwardSignal = (signal: NodeJS.Signals): void => {
+    shuttingDown = true;
+    if (!child?.kill(signal)) {
+      return;
+    }
+    setTimeout(() => child?.kill("SIGKILL"), 1_500).unref();
+  };
+  process.once("SIGINT", () => forwardSignal("SIGINT"));
+  process.once("SIGTERM", () => forwardSignal("SIGTERM"));
+
+  for (let restartCount = 0; ; restartCount++) {
+    child = spawn(config.command, config.args, {
+      cwd: config.cwd,
+      env: childEnv,
+      stdio: "inherit",
+    });
+
+    const result = await new Promise<{
+      code: number | null;
+      signal: NodeJS.Signals | null;
+    }>((resolve, reject) => {
+      child!.once("error", reject);
+      child!.once("exit", (code, signal) => resolve({ code, signal }));
+    });
+
+    if (shuttingDown || result.code === 0) {
+      process.exitCode = result.code ?? 0;
+      return;
+    }
+
+    if (restartCount >= MAX_RESTARTS) {
+      console.error(
+        `${config.label} crashed ${MAX_RESTARTS + 1} times; automatic restarts are disabled until the next wake.`,
+      );
+      process.exitCode = result.code ?? 1;
+      return;
+    }
+
+    const delayMs = BASE_RESTART_DELAY_MS * 2 ** restartCount;
+    console.error(
+      `${config.label} crashed; restarting in ${delayMs / 1_000}s (${restartCount + 1}/${MAX_RESTARTS}).`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -32,6 +32,7 @@ import { rollback } from "./commands/rollback";
 import { setup } from "./commands/setup";
 import { sleep } from "./commands/sleep";
 import { ssh } from "./commands/ssh";
+import { supervise } from "./commands/supervise";
 import { teleport } from "./commands/teleport";
 import { terminal } from "./commands/terminal";
 import { tunnel } from "./commands/tunnel";
@@ -72,6 +73,7 @@ const commands = {
   setup,
   sleep,
   ssh,
+  __supervise: supervise,
   teleport,
   terminal,
   tunnel,

--- a/cli/src/lib/__tests__/local-ces.test.ts
+++ b/cli/src/lib/__tests__/local-ces.test.ts
@@ -118,11 +118,15 @@ describe("startCes", () => {
     expect(lastSpawnCall).not.toBeNull();
     expect(lastSpawnCall!.options.detached).toBe(true);
 
-    // Under plain bun (source tree / tests), CES must run via `bun run
-    // src/main.ts` — never an adjacent `credential-executor` binary, which in
-    // bun's own bin dir is an unrelated globally-installed package bin.
+    // Under plain bun, the supervisor must launch CES from source rather than
+    // an unrelated globally-installed credential-executor binary.
     expect(lastSpawnCall!.cmd[0]).toBe(process.execPath);
-    expect(lastSpawnCall!.cmd).toContain("src/main.ts");
+    expect(lastSpawnCall!.cmd).toContain("__supervise");
+    const supervisedProcess = JSON.parse(
+      lastSpawnCall!.options.env!.VELLUM_SUPERVISED_PROCESS!,
+    );
+    expect(supervisedProcess.command).toBe(process.execPath);
+    expect(supervisedProcess.args).toContain("src/main.ts");
 
     // Verify env vars
     const env = lastSpawnCall!.options.env!;

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -148,6 +148,39 @@ function envWithBunPath(
   };
 }
 
+interface SupervisedProcessOptions {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env: Record<string, string | undefined>;
+  label: string;
+}
+
+function spawnSupervisedProcess(options: SupervisedProcessOptions) {
+  const supervisorArgs = isCompiledCli()
+    ? ["__supervise"]
+    : ["run", join(import.meta.dir, "..", "index.ts"), "__supervise"];
+  const supervisorEnv = {
+    ...options.env,
+    VELLUM_SUPERVISED_PROCESS: JSON.stringify({
+      command: options.command,
+      args: options.args,
+      cwd: options.cwd,
+      label: options.label,
+    }),
+  };
+
+  return spawn(
+    isCompiledCli() ? process.execPath : resolveBunExecutable(),
+    supervisorArgs,
+    {
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: supervisorEnv,
+    },
+  );
+}
+
 function localRuntimeAssistantIndex(
   resources: LocalInstanceResources,
 ): string | undefined {
@@ -684,10 +717,11 @@ async function startDaemonFromSource(
       })
     : (() => {
         const daemonLogFd = openLogFile("hatch.log");
-        const c = spawn(bunPath, ["run", daemonMainPath], {
-          detached: true,
-          stdio: ["ignore", "pipe", "pipe"],
+        const c = spawnSupervisedProcess({
+          command: bunPath,
+          args: ["run", daemonMainPath],
           env: spawnEnv,
+          label: "Assistant",
         });
         pipeToLogFile(c, daemonLogFd, "daemon");
         c.unref();
@@ -751,10 +785,11 @@ async function startDaemonWatchFromSource(
   writeFileSync(pidFile, "starting", "utf-8");
 
   const daemonLogFd = openLogFile("hatch.log");
-  const child = spawn(resolveBunExecutable(), ["--watch", "run", mainPath], {
-    detached: true,
-    stdio: ["ignore", "pipe", "pipe"],
+  const child = spawnSupervisedProcess({
+    command: resolveBunExecutable(),
+    args: ["--watch", "run", mainPath],
     env: envWithBunPath(env),
+    label: "Assistant",
   });
   pipeToLogFile(child, daemonLogFd, "daemon");
   child.unref();
@@ -916,10 +951,11 @@ export async function startCes(
   if (!runtimeCesDir && isCompiledCli() && existsSync(cesBinary) && !watch) {
     // Compiled binary alongside the CLI (desktop app / compiled CLI).
     const cesLogFd = openLogFile("hatch.log");
-    ces = spawn(cesBinary, [], {
-      detached: true,
-      stdio: ["ignore", "pipe", "pipe"],
+    ces = spawnSupervisedProcess({
+      command: cesBinary,
+      args: [],
       env: cesEnv,
+      label: "Credential executor",
     });
     pipeToLogFile(ces, cesLogFd, "credential-executor");
   } else {
@@ -929,11 +965,12 @@ export async function startCes(
       ? ["--watch", "run", "src/main.ts"]
       : ["run", "src/main.ts"];
     const cesLogFd = openLogFile("hatch.log");
-    ces = spawn(resolveBunExecutable(), bunArgs, {
+    ces = spawnSupervisedProcess({
+      command: resolveBunExecutable(),
+      args: bunArgs,
       cwd: cesDir,
-      detached: true,
-      stdio: ["ignore", "pipe", "pipe"],
       env: envWithBunPath(cesEnv),
+      label: "Credential executor",
     });
     pipeToLogFile(ces, cesLogFd, "credential-executor");
     if (watch) {
@@ -1435,11 +1472,12 @@ export async function startLocalDaemon(
           })
         : (() => {
             const daemonLogFd = openLogFile("hatch.log");
-            const c = spawn(daemonBinary, [], {
+            const c = spawnSupervisedProcess({
+              command: daemonBinary,
+              args: [],
               cwd: dirname(daemonBinary),
-              detached: true,
-              stdio: ["ignore", "pipe", "pipe"],
               env: daemonEnv,
+              label: "Assistant",
             });
             pipeToLogFile(c, daemonLogFd, "daemon");
             c.unref();
@@ -1635,10 +1673,11 @@ export async function startGateway(
     // CLI invoked from the terminal). In watch mode, skip the bundled binary
     // and use source (bun --watch only works with source files).
     const gatewayLogFd = openLogFile("hatch.log");
-    gateway = spawn(gatewayBinary, [], {
-      detached: true,
-      stdio: ["ignore", "pipe", "pipe"],
+    gateway = spawnSupervisedProcess({
+      command: gatewayBinary,
+      args: [],
       env: gatewayEnv,
+      label: "Gateway",
     });
     pipeToLogFile(gateway, gatewayLogFd, "gateway");
   } else {
@@ -1648,11 +1687,12 @@ export async function startGateway(
       ? ["--watch", "run", "src/index.ts", "--vellum-gateway"]
       : ["run", "src/index.ts", "--vellum-gateway"];
     const gwLogFd = openLogFile("hatch.log");
-    gateway = spawn(resolveBunExecutable(), bunArgs, {
+    gateway = spawnSupervisedProcess({
+      command: resolveBunExecutable(),
+      args: bunArgs,
       cwd: gatewayDir,
-      detached: true,
-      stdio: ["ignore", "pipe", "pipe"],
       env: envWithBunPath(gatewayEnv),
+      label: "Gateway",
     });
     pipeToLogFile(gateway, gwLogFd, "gateway");
     if (watch) {

--- a/cli/src/lib/statefulset.ts
+++ b/cli/src/lib/statefulset.ts
@@ -378,7 +378,7 @@ export function buildServiceRunArgs(
     const svc = container.internalName;
 
     result[svc] = () => {
-      const args: string[] = ["run", "--init", "-d"];
+      const args: string[] = ["run", "--init", "--restart=on-failure:5", "-d"];
 
       // Container name
       const containerName =


### PR DESCRIPTION
## Summary

- supervise local assistant, gateway, and credential-executor processes with exponential backoff
- stop automatically restarting after five crash retries while preserving explicit wake recovery
- apply Docker's native on-failure:5 policy to all three service containers

## Original prompt

Add nodemon-like crash recovery to the assistant, gateway, and credential executor startup paths. Automatically restart crashed services up to five times, then leave them stopped until an explicit wake, and implement it in the repository that owns those process launches.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->