### PR TITLE
fix(streaming): cap worker-persisted anchor at the in-flight turn's flushed seq

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -112,6 +112,10 @@ import { recordUsage } from "./conversation-usage.js";
 import { resolveTurnTimezoneContext } from "./date-context.js";
 import { getDiskPressureStatus } from "./disk-pressure-guard.js";
 import { classifyDiskPressureTurnPolicy } from "./disk-pressure-policy.js";
+import {
+  registerInflightTurn,
+  unregisterInflightTurn,
+} from "./inflight-turn-registry.js";
 import type { ServerMessage, UsageStats } from "./message-protocol.js";
 import type { TrustContext } from "./trust-context-types.js";
 import { resolveTurnCallSite } from "./turn-call-site.js";
@@ -596,6 +600,11 @@ export async function runAgentLoopImpl(
   startToolProfilingRequest(ctx.conversationId);
   let turnStarted = false;
   const state = createEventHandlerState();
+  // Publish this turn's flushed-content watermark so the worker → daemon
+  // persist hand-off can cap a snapshot anchor at flushed content rather than
+  // the live seq counter, which runs ahead while the turn streams. Cleared in
+  // the `finally`.
+  registerInflightTurn(ctx.conversationId, state);
   let persistedErrorAssistantMessage = false;
   let deletedReservedAssistantMessage = false;
   // Abnormal turn outcome for telemetry, stamped onto the user-message row in
@@ -1584,6 +1593,10 @@ export async function runAgentLoopImpl(
     }
     ctx.abortController = null;
     ctx.setProcessing(false);
+    // The turn's content is fully flushed by here (`settlePendingPartialFlush`
+    // ran inside the try), so daemon-side callers can safely fall back to the
+    // live seq counter once this registration is gone.
+    unregisterInflightTurn(ctx.conversationId, state);
 
     if (turnStarted) {
       ctx.turnCount++;

--- a/assistant/src/daemon/inflight-turn-registry.ts
+++ b/assistant/src/daemon/inflight-turn-registry.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-process index of in-flight agent-loop turns, keyed by conversation id,
+ * exposing each turn's flushed-content seq watermark.
+ *
+ * A turn registers here for the span it streams content into a conversation
+ * (see `conversation-agent-loop`), so a daemon-side caller that only knows a
+ * conversation id can tell whether a turn is streaming and, if so, how far its
+ * content has been flushed to durable rows. The worker → daemon persist
+ * hand-off (`ipc/routes/conversation-sync-ipc-routes`) reads it to cap the
+ * snapshot anchor it records: the daemon's live seq counter runs ahead of the
+ * content it has flushed, so anchoring at the counter while a turn streams
+ * would advertise in-flight content the durable rows do not yet hold.
+ *
+ * Leaf module: imports `EventHandlerState` as a type only, so it can be read
+ * from any layer without pulling in the agent-loop value graph.
+ */
+
+import type { EventHandlerState } from "./conversation-agent-loop-handlers.js";
+
+const inflightTurns = new Map<string, EventHandlerState>();
+
+/** Register a turn's live state for the span it streams into `conversationId`. */
+export function registerInflightTurn(
+  conversationId: string,
+  state: EventHandlerState,
+): void {
+  inflightTurns.set(conversationId, state);
+}
+
+/**
+ * Remove a turn's registration. Guards against clobbering a newer turn for the
+ * same conversation by only deleting when the stored entry is still this state.
+ */
+export function unregisterInflightTurn(
+  conversationId: string,
+  state: EventHandlerState,
+): void {
+  if (inflightTurns.get(conversationId) === state) {
+    inflightTurns.delete(conversationId);
+  }
+}
+
+/**
+ * The flushed-content seq ceiling for a conversation the daemon may be
+ * streaming, or `undefined` when no turn is in flight for it.
+ *
+ * While a turn streams, the value is the highest seq whose content has been
+ * flushed to durable rows (`EventHandlerState.lastPersistedContentSeq`), or `0`
+ * when the turn has flushed no content yet. A caller recording a snapshot
+ * anchor caps at this value so the anchor never claims content the live seq
+ * counter has served but no flush has written; the `0` case is a monotonic
+ * no-op in `recordConversationPersistedSeq`, leaving the existing anchor intact.
+ */
+export function getInflightFlushedContentSeq(
+  conversationId: string,
+): number | undefined {
+  const state = inflightTurns.get(conversationId);
+  if (state === undefined) {
+    return undefined;
+  }
+  return state.lastPersistedContentSeq ?? 0;
+}

--- a/assistant/src/ipc/routes/__tests__/conversation-sync-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/conversation-sync-ipc-routes.test.ts
@@ -6,8 +6,10 @@
  *
  * `recordConversationPersistedSeq` and `publishConversationMessagesChanged`
  * are stubbed to capture calls (their own behavior is covered in their own
- * suites); the seq authority (`assistant-stream-state`) is exercised for real
- * so the anchor value the handler records is the daemon's genuine `getCurrentSeq()`.
+ * suites); the seq authority (`assistant-stream-state`) and the in-flight-turn
+ * registry are exercised for real so the anchor the handler records is a
+ * genuine `getCurrentSeq()` — capped at a streaming turn's flushed-content
+ * watermark when one is in flight for the conversation.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -27,7 +29,12 @@ mock.module("../../../runtime/sync/resource-sync-events.js", () => ({
   },
 }));
 
+import type { EventHandlerState } from "../../../daemon/conversation-agent-loop-handlers.js";
 import { DB_MIGRATION_READINESS_EXEMPT_OPERATIONS } from "../../../daemon/daemon-readiness.js";
+import {
+  registerInflightTurn,
+  unregisterInflightTurn,
+} from "../../../daemon/inflight-turn-registry.js";
 import type { AssistantEvent } from "../../../runtime/assistant-event.js";
 import {
   _resetStreamStateForTesting,
@@ -53,7 +60,7 @@ describe("conversation-sync IPC route", () => {
     _resetStreamStateForTesting();
   });
 
-  test("records the anchor at the daemon's current seq and republishes the invalidation", () => {
+  test("records the anchor at the daemon's current seq when no turn is streaming the conversation", () => {
     // Advance the daemon's real seq counter so the recorded anchor is a
     // concrete, non-zero daemon-issued position — never above what it has served.
     stampEvent();
@@ -67,6 +74,53 @@ describe("conversation-sync IPC route", () => {
     expect(result).toEqual({ ok: true });
     expect(recordCalls).toEqual([["conv-1", 3]]);
     expect(publishCalls).toEqual(["conv-1"]);
+  });
+
+  test("caps the anchor at the streaming turn's flushed-content seq, below the live counter", () => {
+    stampEvent();
+    stampEvent();
+    stampEvent(); // getCurrentSeq() === 3
+
+    // A daemon turn is streaming into conv-1 but has flushed content only
+    // through seq 2 — the live counter (3) is ahead of the durable rows.
+    const state = {
+      lastPersistedContentSeq: 2,
+    } as unknown as EventHandlerState;
+    registerInflightTurn("conv-1", state);
+    try {
+      const result = handleNotifyConversationPersisted({
+        body: { conversationId: "conv-1" },
+      });
+
+      expect(result).toEqual({ ok: true });
+      // Anchored at the flushed watermark (2), NOT the live counter (3), so the
+      // snapshot never claims the in-flight delta at seq 3.
+      expect(recordCalls).toEqual([["conv-1", 2]]);
+      expect(publishCalls).toEqual(["conv-1"]);
+    } finally {
+      unregisterInflightTurn("conv-1", state);
+    }
+  });
+
+  test("records 0 (a raise-only no-op) when a streaming turn has flushed no content yet", () => {
+    stampEvent(); // getCurrentSeq() === 1
+
+    // A turn is streaming but has not flushed any content, so its watermark is
+    // undefined; the ceiling is 0, capping the anchor below the un-flushed seq.
+    const state = {
+      lastPersistedContentSeq: undefined,
+    } as unknown as EventHandlerState;
+    registerInflightTurn("conv-1", state);
+    try {
+      handleNotifyConversationPersisted({ body: { conversationId: "conv-1" } });
+
+      // The handler passes 0; `recordConversationPersistedSeq` ignores it and
+      // leaves the existing anchor intact (the live seq 1 is never advertised).
+      expect(recordCalls).toEqual([["conv-1", 0]]);
+      expect(publishCalls).toEqual(["conv-1"]);
+    } finally {
+      unregisterInflightTurn("conv-1", state);
+    }
   });
 
   test("rejects a payload without a conversationId", () => {

--- a/assistant/src/ipc/routes/conversation-sync-ipc-routes.ts
+++ b/assistant/src/ipc/routes/conversation-sync-ipc-routes.ts
@@ -11,9 +11,10 @@
  * switch/reload.
  *
  * This route runs the notification on the daemon instead: it records the
- * snapshot anchor at the daemon's own `getCurrentSeq()` and republishes the
+ * snapshot anchor from the daemon's own seq authority and republishes the
  * messages-changed invalidation on the daemon's hub, where real subscribers
- * observe it. (Why anchoring at the current seq is honest: see the handler.)
+ * observe it. (How the anchor is chosen so it never claims un-flushed content:
+ * see the handler.)
  *
  * IPC-only: registered directly on the assistant IPC server (see
  * `assistant-server.ts`), never in the shared `ROUTES` array. DB-migration
@@ -24,6 +25,7 @@
 
 import { z } from "zod";
 
+import { getInflightFlushedContentSeq } from "../../daemon/inflight-turn-registry.js";
 import { recordConversationPersistedSeq } from "../../persistence/conversation-crud.js";
 import { getCurrentSeq } from "../../runtime/assistant-stream-state.js";
 import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
@@ -43,12 +45,18 @@ export function handleNotifyConversationPersisted({
 }: RouteHandlerArgs) {
   const { conversationId } =
     NotifyConversationPersistedParamsSchema.parse(body);
-  // The daemon's live counter is at or above every seq it has served for this
-  // conversation, and the worker's freshly written rows carry no higher seq, so
-  // anchoring at the current seq is honest — never above the served frontier.
-  // `recordConversationPersistedSeq` is monotonic (raise-only) and ignores a
-  // non-positive seq, so a cold daemon (seq 0) simply leaves the anchor as-is.
-  recordConversationPersistedSeq(conversationId, getCurrentSeq());
+  // Anchor at the highest seq whose content the durable rows hold. While the
+  // daemon streams a turn into this conversation, its live seq counter runs
+  // ahead of flushed content, so a `getCurrentSeq()` anchor would advertise
+  // in-flight content the snapshot omits — clients drop those deltas as replays
+  // and the streamed text vanishes until the next flush. Cap at the streaming
+  // turn's flushed watermark; `undefined` means no turn is in flight, where the
+  // live counter is honest (the worker's fresh rows carry no higher seq).
+  // `recordConversationPersistedSeq` is raise-only and ignores a non-positive
+  // seq, so a cold daemon or an un-flushed turn leaves the anchor as-is.
+  const anchor =
+    getInflightFlushedContentSeq(conversationId) ?? getCurrentSeq();
+  recordConversationPersistedSeq(conversationId, anchor);
   publishConversationMessagesChanged(conversationId);
   return { ok: true };
 }


### PR DESCRIPTION
## Summary

Follow-up to #38591 addressing Codex review feedback (P1) on `handleNotifyConversationPersisted`.

The worker → daemon persist hand-off anchored the snapshot at `getCurrentSeq()` — the daemon's **global** live seq counter. When a worker persists rows for a conversation the daemon is **simultaneously** streaming (e.g. a reused schedule conversation written while the user is mid-turn in it), `getCurrentSeq()` includes daemon-served deltas whose content has **not** been flushed to the DB yet. Recording that seq as the anchor makes the subsequent `:messages` invalidation advertise a snapshot that omits the in-flight streamed content while claiming coverage of it — the client drops those live deltas as replays after refetching, and visible streamed text disappears until the daemon's own flush publishes the next invalidation.

## Fix

When the daemon has an active in-flight agent-loop stream for the conversation, cap the recorded anchor at that loop's `lastPersistedContentSeq` (the highest seq whose content is actually flushed) instead of `getCurrentSeq()`. This mirrors the daemon's own flush path, which records `lastPersistedContentSeq` only after the write commits (`conversation-agent-loop-handlers.ts`). When no stream is active for the conversation, `getCurrentSeq()` remains the anchor — nothing in flight can be omitted. `recordConversationPersistedSeq`'s monotonic raise-only semantics are preserved.

## Files

- **`daemon/inflight-turn-registry.ts`** (new) — per-process leaf registry mapping `conversationId` → the in-flight turn's `EventHandlerState` (imported as a type only, no value-graph coupling — same pattern as `conversation-registry.ts`). `getInflightFlushedContentSeq()` returns the streaming turn's flushed watermark, `0` when the turn has flushed nothing yet (a raise-only no-op in `recordConversationPersistedSeq`), and `undefined` when no turn is streaming.
- **`daemon/conversation-agent-loop.ts`** — register the turn at loop start, unregister in the `finally` (after `settlePendingPartialFlush` has flushed the tail), with a clobber guard against a newer turn.
- **`ipc/routes/conversation-sync-ipc-routes.ts`** — `anchor = getInflightFlushedContentSeq(id) ?? getCurrentSeq()`; the in-code comment restated as a present-tense invariant.

## Tests

`ipc/routes/__tests__/conversation-sync-ipc-routes.test.ts` — new cases: anchor capped at the streaming turn's flushed seq (below the live counter); an un-flushed streaming turn records `0` (raise-only no-op); the existing no-active-loop case still anchors at `getCurrentSeq()`. The stream-state seq authority and the registry are exercised for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)