### PR TITLE
fix(web): version-gate bookmarks UI for pre-0.8.1 assistants

### DIFF
--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -6,6 +6,7 @@ import type { DisplayMessage } from "@/domains/chat/types/types";
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
 import {
   useBookmarkToggle,
+  useCanBookmark,
   useIsBookmarked,
 } from "@/hooks/use-bookmarks";
 
@@ -102,15 +103,10 @@ export function MessageHoverActions({
 }: MessageHoverActionsProps) {
   const { role } = message;
 
-  // Only persisted messages qualify for bookmarking — optimistic/streaming
-  // rows carry a client-generated id the daemon can't resolve. The toggle's
-  // data hooks live in `MessageBookmarkButton` so they only mount (and only
-  // touch TanStack Query) for bookmarkable rows; that keeps the
-  // no-conversation path free of any query client.
-  const canBookmark =
-    Boolean(conversationId) &&
-    Boolean(message.id) &&
-    !message.isOptimistic;
+  // The toggle's data hooks live in `MessageBookmarkButton` so they only mount
+  // (and only touch TanStack Query) for bookmarkable rows; that keeps the
+  // unsupported-assistant and no-conversation paths free of any query client.
+  const canBookmark = useCanBookmark(message, conversationId);
 
   // Flat plain-text body derived from the message's text blocks; this is the
   // copy payload and mirrors the daemon's `joinWithSpacing`.

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-long-press-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-long-press-actions.tsx
@@ -14,6 +14,7 @@ import type { MessageHoverActionsProps } from "@/domains/chat/components/message
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
 import {
   useBookmarkToggle,
+  useCanBookmark,
   useIsBookmarked,
 } from "@/hooks/use-bookmarks";
 import { BottomSheet, PanelItem } from "@vellumai/design-library";
@@ -44,10 +45,7 @@ export function MessageLongPressActions({
   open,
   onOpenChange,
 }: MessageLongPressActionsProps) {
-  const canBookmark =
-    Boolean(conversationId) &&
-    Boolean(message.id) &&
-    !message.isOptimistic;
+  const canBookmark = useCanBookmark(message, conversationId);
 
   const content = useMemo(() => messagePlainText(message), [message]);
 

--- a/clients/web/src/domains/settings/settings-layout.test.tsx
+++ b/clients/web/src/domains/settings/settings-layout.test.tsx
@@ -8,6 +8,7 @@ import type { SidebarItem } from "@/components/sidebar-tree";
 
 let assistantFlags: Record<string, boolean> = {};
 let clientFlags: Record<string, boolean> = {};
+let supportsBookmarks = false;
 
 mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
@@ -26,6 +27,10 @@ mock.module("@/stores/client-feature-flag-store", () => {
   };
   return { useClientFeatureFlagStore: store };
 });
+
+mock.module("@/lib/backwards-compat/use-supports-bookmarks", () => ({
+  useSupportsBookmarks: () => supportsBookmarks,
+}));
 
 mock.module("@/hooks/use-platform-gate", () => ({
   usePlatformGate: () => "full",
@@ -74,6 +79,7 @@ afterEach(() => {
   cleanup();
   assistantFlags = {};
   clientFlags = {};
+  supportsBookmarks = false;
 });
 
 describe("SettingsLayout", () => {
@@ -97,6 +103,24 @@ describe("SettingsLayout", () => {
     );
 
     expect(screen.queryByRole("link", { name: "Security" })).toBeNull();
+  });
+
+  test("renders Bookmarks only when the assistant supports the bookmark routes", () => {
+    render(
+      <MemoryRouter initialEntries={["/assistant/settings"]}>
+        <SettingsLayout />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole("link", { name: "Bookmarks" })).toBeNull();
+    cleanup();
+
+    supportsBookmarks = true;
+    render(
+      <MemoryRouter initialEntries={["/assistant/settings"]}>
+        <SettingsLayout />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("link", { name: "Bookmarks" })).not.toBeNull();
   });
 
   test("renders Credentials only when the credentials-settings flag is on", () => {

--- a/clients/web/src/domains/settings/settings-layout.tsx
+++ b/clients/web/src/domains/settings/settings-layout.tsx
@@ -5,6 +5,7 @@ import { Outlet, useLocation, useNavigate } from "react-router";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { handleLogout } from "@/lib/auth/handle-logout";
+import { useSupportsBookmarks } from "@/lib/backwards-compat/use-supports-bookmarks";
 import { useHasPlatformSession } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -23,6 +24,10 @@ export function SettingsLayout() {
   const settingsDeveloperNav = useAssistantFeatureFlagStore.use.settingsDeveloperNav();
   const credentialsSettingsEnabled = useAssistantFeatureFlagStore.use.credentialsSettings();
   const platformNotifications = useClientFeatureFlagStore.use.platformNotifications();
+  // The Bookmarks tab needs the assistant's bookmark routes (v0.8.1+); an
+  // older assistant 404s them, so hide the tab rather than render a dead
+  // "Failed to load bookmarks" page.
+  const supportsBookmarks = useSupportsBookmarks();
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   // The Usage item is never hidden: the Usage tab reads from the local daemon
   // and works for every assistant. Its label only gains "Billing &" when the
@@ -46,6 +51,9 @@ export function SettingsLayout() {
         ) {
           return false;
         }
+        if (item.id === "bookmarks" && !supportsBookmarks) {
+          return false;
+        }
         if (item.id === "credentials" && !credentialsSettingsEnabled) {
           return false;
         }
@@ -59,6 +67,7 @@ export function SettingsLayout() {
     [
       platformNotifications,
       platformGate,
+      supportsBookmarks,
       credentialsSettingsEnabled,
       billingLabel,
     ],

--- a/clients/web/src/hooks/use-bookmarks.ts
+++ b/clients/web/src/hooks/use-bookmarks.ts
@@ -6,7 +6,9 @@
  * (the per-message hover toggle and the Settings → Bookmarks tab). TanStack is
  * the single source of truth — there is no separate store mirroring the list.
  *
- * The query only runs once an assistant is resolved.
+ * The query only runs once an assistant is resolved AND that assistant is
+ * new enough to expose the bookmark routes (see `useSupportsBookmarks`), so
+ * a current bundle connected to a pre-0.8.1 assistant never 404s the list.
  *
  * Cross-client invalidation (a bookmark made in another tab/window) is handled
  * by `use-bookmarks-sync.ts`, which listens for the daemon's
@@ -25,6 +27,7 @@ import {
   bookmarksPost,
 } from "@/generated/daemon/sdk.gen";
 import type { BookmarksGetResponse } from "@/generated/daemon/types.gen";
+import { useSupportsBookmarks } from "@/lib/backwards-compat/use-supports-bookmarks";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { toast } from "@vellumai/design-library";
@@ -37,7 +40,8 @@ const EMPTY_BOOKMARKS: Bookmark[] = [];
 /** Active assistant id + whether the shared bookmark query should run. */
 function useBookmarkQueryGate(): { assistantId: string | null; enabled: boolean } {
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const enabled = Boolean(assistantId);
+  const supportsBookmarks = useSupportsBookmarks();
+  const enabled = supportsBookmarks && Boolean(assistantId);
   return { assistantId, enabled };
 }
 
@@ -77,6 +81,25 @@ export function useIsBookmarked(messageId: string | undefined): boolean {
       messageId ? res.bookmarks.some((b) => b.messageId === messageId) : false,
   });
   return query.data ?? false;
+}
+
+/**
+ * Whether `message` can be bookmarked. Requires an assistant new enough to
+ * expose the bookmark routes (see `useSupportsBookmarks`) and a persisted row
+ * the daemon can resolve — optimistic/streaming messages carry a
+ * client-generated id, and a bookmark keys on (messageId, conversationId).
+ */
+export function useCanBookmark(
+  message: { id?: string; isOptimistic?: boolean },
+  conversationId: string | null | undefined,
+): boolean {
+  const supportsBookmarks = useSupportsBookmarks();
+  return (
+    supportsBookmarks &&
+    Boolean(conversationId) &&
+    Boolean(message.id) &&
+    !message.isOptimistic
+  );
 }
 
 /**

--- a/clients/web/src/lib/backwards-compat/use-supports-bookmarks.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-bookmarks.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { renderHook } from "@testing-library/react";
+
+import { useSupportsBookmarks } from "@/lib/backwards-compat/use-supports-bookmarks";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+function setVersion(version: string | null) {
+  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+}
+
+beforeEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+// Exhaustive truth-table for the underlying semver gate lives in
+// `utils.test.ts`. Here we verify each side of the 0.8.1 boundary (the first
+// release carrying the `/v1/assistants/{id}/bookmarks` routes and
+// `bookmark.*` SSE events) plus the conservative-on-unknown policy. `false`
+// means every bookmark affordance is hidden and the list query stays idle.
+describe("useSupportsBookmarks", () => {
+  test("false when version is unknown", () => {
+    setVersion(null);
+    const { result } = renderHook(() => useSupportsBookmarks());
+    expect(result.current).toBe(false);
+  });
+
+  test("false for assistants on 0.8.0 and older", () => {
+    setVersion("0.8.0");
+    const { result } = renderHook(() => useSupportsBookmarks());
+    expect(result.current).toBe(false);
+  });
+
+  test("true for assistants on 0.8.1+", () => {
+    setVersion("0.8.1");
+    const { result } = renderHook(() => useSupportsBookmarks());
+    expect(result.current).toBe(true);
+  });
+
+  test("true for much newer assistants", () => {
+    setVersion("0.10.9");
+    const { result } = renderHook(() => useSupportsBookmarks());
+    expect(result.current).toBe(true);
+  });
+
+  test("true for RC builds of the cutover patch", () => {
+    setVersion("0.8.1-rc.1");
+    const { result } = renderHook(() => useSupportsBookmarks());
+    expect(result.current).toBe(true);
+  });
+});

--- a/clients/web/src/lib/backwards-compat/use-supports-bookmarks.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-bookmarks.ts
@@ -1,0 +1,36 @@
+/**
+ * Backwards-compat gate: message bookmarks.
+ *
+ * Vellum Assistant 0.8.1 added the bookmark routes
+ * (`GET/POST/DELETE /v1/assistants/{id}/bookmarks`) and the
+ * `bookmark.created` / `bookmark.deleted` SSE events (PR #30118). Older
+ * assistants 404 those routes, so the web app hides every bookmark
+ * affordance — the per-message hover / long-press toggle and the
+ * Settings → Bookmarks tab — and keeps the shared list query disabled.
+ * The transcript and Settings render exactly as they did before the
+ * feature, with no control to invoke and no error surfaced.
+ *
+ * Before GA the `bookmarks` client feature flag doubled as an accidental
+ * compatibility gate: an old assistant that lacked the routes also
+ * reported no flag, so the UI stayed hidden. Removing the flag on GA
+ * removed that gate — a current bundle against a pre-0.8.1 assistant would
+ * otherwise fire the list query into a 404 ("Failed to load bookmarks")
+ * and issue unsupported POST/DELETE writes that fail after an optimistic
+ * update. This version gate restores the compatibility behavior the flag
+ * used to provide. CDN-served bundles routinely connect to self-hosted
+ * assistants of arbitrary age (the iOS shell loads the deployed SPA against
+ * self-hosted gateways), so the gate is load-bearing.
+ *
+ * A render hook (not the `assistantSupports` snapshot) so the bookmark UI
+ * appears the moment the version hydrates.
+ *
+ * MIN_VERSION is 0.8.1: the bookmark routes first shipped there (PR #30118,
+ * merged 2026-05-09); v0.8.0 and older 404 them.
+ */
+import { useAssistantSupports } from "@/lib/backwards-compat/utils";
+
+const MIN_VERSION = "0.8.1";
+
+export function useSupportsBookmarks(): boolean {
+  return useAssistantSupports(MIN_VERSION);
+}


### PR DESCRIPTION
## Summary

Restore the per-assistant compatibility gate that the `bookmarks` client feature flag used to provide implicitly, following the `clients/web/src/lib/backwards-compat/` convention (a module-level `MIN_VERSION` + `useAssistantSupports`).

Before GA, the server-reported `bookmarks` flag doubled as an accidental compatibility gate: an assistant old enough to lack the bookmark routes also reported no flag, so the UI stayed hidden. Removing the flag on GA (#38768) removed that gate. A current web bundle connected to a pre-`0.8.1` assistant would then enable the list query anyway — the request 404s and Settings renders "Failed to load bookmarks", and newly-visible bookmark controls issue unsupported POST/DELETE requests that fail after an optimistic update. This matters because CDN-served bundles routinely connect to self-hosted assistants of arbitrary age (the iOS shell loads the deployed SPA against self-hosted gateways).

## Fix

- Add `useSupportsBookmarks()` in `lib/backwards-compat/use-supports-bookmarks.ts` with `MIN_VERSION = "0.8.1"` — the release the bookmark routes and `bookmark.created` / `bookmark.deleted` SSE events first shipped in (routes added 2026-05-09 in #30118; `v0.8.0` was tagged before that commit, `v0.8.1` is the first release tag containing it).
- Gate the shared list query (`useBookmarkQueryGate`), the per-message hover / long-press bookmark control, and the Settings → Bookmarks nav tab on the gate, so unsupported assistants simply don't show any bookmarks UI and fire no requests.
- Extract the duplicated "is this message bookmarkable" predicate into a shared `useCanBookmark(message, conversationId)` hook — single source of truth for the hover and long-press call sites (simplify pass).

## Tests

- New `use-supports-bookmarks.test.ts` — verifies both sides of the `0.8.1` boundary plus conservative-on-unknown.
- Extend `settings-layout.test.tsx` — Bookmarks tab hidden unless the assistant supports it.
- Existing `message-hover-actions.test.tsx` remains green.

Addresses Codex review feedback on #38768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)