### PR TITLE
refactor(assistant): move memory-v3 lanes-version token to plugin-owned file

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -75,19 +75,22 @@ const realCliCommandStore = {
 };
 const realCoreSet = { ...(await import("../core-set.js")) };
 const realHotSet = { ...(await import("../hot-set.js")) };
-const realCheckpoints = {
-  ...(await import("../../../../../persistence/checkpoints.js")),
+const realLanesVersionStore = {
+  ...(await import("../lanes-version-store.js")),
 };
 
 let shadowMockActive = false;
 
 // ─── mutable test state, read by the mocks below ────────────────────────────
 
-// In-memory stand-in for the `memory_checkpoints` row backing the
-// lanes-version token, so tests control the cross-process signal without a
-// migrated main DB. `checkpointReadThrows` simulates an unavailable DB.
-const checkpointStore = new Map<string, string>();
-let checkpointReadThrows = false;
+// In-memory stand-in for the plugin-owned lanes-version token file, so tests
+// drive the cross-process signal without touching disk. `null` mirrors an
+// absent token; a fresh string mirrors another process's bump. Each mocked
+// bump writes a distinct value (via `bumpCounter`) like the real store's UUID.
+// `lanesVersionReadThrows` mirrors the store's "read failed → undefined" branch.
+let mockLanesVersion: string | null = null;
+let lanesVersionReadThrows = false;
+let bumpCounter = 0;
 
 let liveEnabled = false;
 let memoryEnabled = true;
@@ -458,19 +461,24 @@ mock.module("../orchestrate.js", () => ({
       : realOrchestrate.orchestrate(...args),
 }));
 
-mock.module("../../../../../persistence/checkpoints.js", () => ({
-  ...realCheckpoints,
-  getMemoryCheckpoint: (key: string) => {
-    if (!shadowMockActive) return realCheckpoints.getMemoryCheckpoint(key);
-    if (checkpointReadThrows) throw new Error("checkpoint store unavailable");
-    return checkpointStore.get(key) ?? null;
-  },
-  setMemoryCheckpoint: (key: string, value: string) => {
+mock.module("../lanes-version-store.js", () => ({
+  ...realLanesVersionStore,
+  readLanesVersion: (workspaceDir: string) => {
     if (!shadowMockActive) {
-      realCheckpoints.setMemoryCheckpoint(key, value);
-      return;
+      return realLanesVersionStore.readLanesVersion(workspaceDir);
     }
-    checkpointStore.set(key, value);
+    // The store swallows read errors and returns `undefined`; mirror that so
+    // `getLanes` exercises its "cannot judge staleness → serve memo" branch.
+    if (lanesVersionReadThrows) return undefined;
+    return mockLanesVersion;
+  },
+  bumpLanesVersion: (workspaceDir: string) => {
+    if (!shadowMockActive) {
+      return realLanesVersionStore.bumpLanesVersion(workspaceDir);
+    }
+    const token = `bump-${++bumpCounter}`;
+    mockLanesVersion = token;
+    return token;
   },
 }));
 
@@ -479,7 +487,6 @@ const {
   observeTurn: observeTurnImpl,
   resetShadowLanesForTests,
   invalidateLanes,
-  LANES_VERSION_CHECKPOINT_KEY,
   attributeSelections,
   writeSelections,
   backfillMemoryV3SelectionMessageId,
@@ -536,8 +543,9 @@ beforeEach(() => {
   hotSetResult = [];
   hotSetOpts = null;
   testDb = makeDb();
-  checkpointStore.clear();
-  checkpointReadThrows = false;
+  mockLanesVersion = null;
+  lanesVersionReadThrows = false;
+  bumpCounter = 0;
   resetShadowLanesForTests();
   // The injector memoizes one orchestration per (conversation, turn); clear it
   // so tests reusing the same ids observe fresh orchestrations.
@@ -945,11 +953,11 @@ describe("memory-v3 engine", () => {
 
   test("invalidateLanes writes a new, distinct lanes-version token each call", () => {
     invalidateLanes();
-    const first = checkpointStore.get(LANES_VERSION_CHECKPOINT_KEY);
+    const first = mockLanesVersion;
     invalidateLanes();
-    const second = checkpointStore.get(LANES_VERSION_CHECKPOINT_KEY);
-    expect(first).toBeDefined();
-    expect(second).toBeDefined();
+    const second = mockLanesVersion;
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
     expect(second).not.toBe(first);
   });
 
@@ -961,7 +969,7 @@ describe("memory-v3 engine", () => {
     // Simulate the memory worker's invalidateLanes(): its in-process memo
     // clear is invisible to this process — only the persisted token write
     // crosses the boundary.
-    checkpointStore.set(LANES_VERSION_CHECKPOINT_KEY, "worker-bump-1");
+    mockLanesVersion = "worker-bump-1";
 
     await observeTurn("conv-1", 2);
     expect(sectionBuilds).toBe(2);
@@ -977,7 +985,7 @@ describe("memory-v3 engine", () => {
     await observeTurn("conv-1", 0);
     expect(sectionBuilds).toBe(1);
 
-    checkpointReadThrows = true;
+    lanesVersionReadThrows = true;
     await observeTurn("conv-1", 1);
     expect(sectionBuilds).toBe(1);
   });

--- a/assistant/src/plugins/defaults/memory/v3/lanes-version-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/lanes-version-store.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for `lanes-version-store.ts` — the plugin-owned, cross-process
+ * lanes-version token.
+ *
+ * The store's whole job is to carry an invalidation signal between the daemon
+ * and the memory worker over the shared workspace volume, so the load-bearing
+ * assertion is the round-trip: a token written through one call is observed by a
+ * later read that resolves the same workspace dir (standing in for the other
+ * process). Uses a real temp workspace — no mocks — so the atomic file write and
+ * its absent/unreadable branches are exercised end-to-end.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { bumpLanesVersion, readLanesVersion } from "./lanes-version-store.js";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "lanes-version-store-"));
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("lanes-version-store", () => {
+  test("read returns null when no token has been written", () => {
+    // Absent file carries the same meaning an absent value did before: a
+    // legitimate stable state, not a read failure.
+    expect(readLanesVersion(workspaceDir)).toBeNull();
+  });
+
+  test("a bump is observed by a later read of the same workspace (cross-process round-trip)", () => {
+    // The writer (memory worker) bumps; a reader (daemon) resolving the same
+    // workspace dir sees the new token. `bumpLanesVersion` also creates the
+    // `memory/.v2-state/` state dir on demand.
+    const token = bumpLanesVersion(workspaceDir);
+    expect(token).toBeTruthy();
+    expect(readLanesVersion(workspaceDir)).toBe(token);
+  });
+
+  test("each bump writes a distinct token", () => {
+    const first = bumpLanesVersion(workspaceDir);
+    const second = bumpLanesVersion(workspaceDir);
+    expect(second).not.toBe(first);
+    expect(readLanesVersion(workspaceDir)).toBe(second);
+  });
+
+  test("read returns undefined when the token path is unreadable", () => {
+    // A directory at the token path makes the read throw EISDIR (not ENOENT):
+    // the "cannot judge staleness" signal, distinct from an absent token.
+    mkdirSync(join(workspaceDir, "memory", ".v2-state", "lanes-version"), {
+      recursive: true,
+    });
+    expect(readLanesVersion(workspaceDir)).toBeUndefined();
+  });
+});

--- a/assistant/src/plugins/defaults/memory/v3/lanes-version-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/lanes-version-store.ts
@@ -1,0 +1,91 @@
+/**
+ * Memory-v3 lanes-version token — the cross-process lane-invalidation signal.
+ *
+ * Memory jobs (the consolidation run's `memory_v3_maintain` follow-up) execute
+ * in the standalone memory worker process, so their in-process memo clear is
+ * invisible to the daemon — the process that owns the live lanes used by the
+ * live turn. A writer bumps this token whenever the underlying pages change;
+ * the reader (`getLanes` in `shadow-plugin.ts`) compares it per turn against
+ * the value captured at its last build and rebuilds on any change. The value
+ * is opaque — only inequality matters.
+ *
+ * The token is plugin-owned state: it lives in the memory plugin's workspace
+ * state directory (`<workspace>/memory/.v2-state/lanes-version`), beside the
+ * consolidation lock, NOT in the main database. Both processes reach it because
+ * they share the workspace volume — the same basis the consolidation lock relies
+ * on. Callers pass the workspace dir (resolved via `getWorkspaceDir()`), so the
+ * daemon and the worker address the same file.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * `<workspace>/memory/.v2-state/lanes-version` — the memory plugin's
+ * established cross-process state directory (the consolidation lock lives in
+ * the same folder).
+ */
+function lanesVersionPath(workspaceDir: string): string {
+  return join(workspaceDir, "memory", ".v2-state", "lanes-version");
+}
+
+/**
+ * Read the persisted lanes-version token:
+ *   - a non-empty string → the current token;
+ *   - `null` → no token has been written yet (the file is absent), a legitimate
+ *     stable state carrying the same meaning an absent value did before;
+ *   - `undefined` → the read itself failed (the path exists but is unreadable),
+ *     so the caller cannot judge staleness and keeps serving its memo —
+ *     degraded freshness beats a broken turn.
+ */
+export function readLanesVersion(
+  workspaceDir: string,
+): string | null | undefined {
+  try {
+    const token = readFileSync(lanesVersionPath(workspaceDir), "utf-8").trim();
+    return token.length > 0 ? token : null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    return undefined;
+  }
+}
+
+/**
+ * Bump the token to a fresh opaque value and return it. The write is atomic
+ * (temp file + rename), so a concurrent reader never observes a partial write —
+ * it sees either the prior token or the new one. The state directory is created
+ * on demand.
+ *
+ * Throws on an I/O failure; the sole caller (`invalidateLanes`) wraps this in
+ * its best-effort try/catch, so a failed bump only degrades cross-process
+ * freshness (the local invalidation still holds) and never breaks the turn.
+ */
+export function bumpLanesVersion(workspaceDir: string): string {
+  const token = randomUUID();
+  const path = lanesVersionPath(workspaceDir);
+  const tmpPath = `${path}.tmp.${process.pid}.${randomUUID()}`;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(tmpPath, token, "utf-8");
+    renameSync(tmpPath, path);
+  } catch (err) {
+    // Best-effort cleanup so a failed rename does not leak the temp file into
+    // the state directory.
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // ignore — the temp file may never have been created.
+    }
+    throw err;
+  }
+  return token;
+}

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -11,9 +11,9 @@
  *      dense lane config, link-graph edge graph, curated core set, frecency
  *      hot set), memoizing the init promise so concurrent first turns share a
  *      single build. The memo lives until the persisted lanes-version token
- *      changes ({@link LANES_VERSION_CHECKPOINT_KEY}) — writers in any
- *      process bump it via {@link invalidateLanes}, and {@link getLanes}
- *      observes the change and rebuilds.
+ *      changes (see `./lanes-version-store.js`) — writers in any process bump
+ *      it via {@link invalidateLanes}, and {@link getLanes} observes the change
+ *      and rebuilds.
  *   2. Build a {@link MemoryRoutingTurn} from the conversation's recent messages.
  *   3. Run {@link orchestrate} and record its selection set to
  *      `memory_v3_selections` with a best-effort lane attribution.
@@ -37,10 +37,6 @@ import {
   recordLatencySubSpan,
   timeLatencySubSpan,
 } from "../../../../daemon/turn-latency-sub-spans.js";
-import {
-  getMemoryCheckpoint,
-  setMemoryCheckpoint,
-} from "../../../../persistence/checkpoints.js";
 import { stripCommentLines } from "../host-utils.js";
 import { getLogger } from "../logging.js";
 import { memorySqliteOrNull } from "../memory-db.js";
@@ -59,6 +55,7 @@ import { getActiveSlugs } from "./ever-injected-store.js";
 import { computeFreshSet } from "./fresh-set.js";
 import { isMemoryV3InjectionGateEnabled } from "./gate-flag.js";
 import { computeHotSet } from "./hot-set.js";
+import { bumpLanesVersion, readLanesVersion } from "./lanes-version-store.js";
 import { computeLearnedEdgeGraph } from "./learned-edges.js";
 import type { OrchestrateResult } from "./orchestrate.js";
 import { orchestrate } from "./orchestrate.js";
@@ -148,36 +145,10 @@ const DAY_MS = 24 * 60 * 60 * 1000;
  */
 let lanesPromise: Promise<ShadowLanes> | null = null;
 
-/**
- * `memory_checkpoints` key carrying the lanes-version token — the
- * cross-process invalidation signal. Memory jobs (the consolidation run's
- * `memory_v3_maintain` follow-up) execute in the standalone memory worker
- * process, so their `invalidateLanes()` cannot touch the daemon's
- * `lanesPromise` directly; bumping the token in the shared workspace DB is
- * how an invalidation reaches the process that owns the live lanes. Writers
- * bump the token; {@link getLanes} compares it per call and rebuilds on any
- * change. The value is an opaque string — only inequality matters.
- */
-export const LANES_VERSION_CHECKPOINT_KEY = "memory_v3_lanes_version";
-
-/** The persisted lanes-version token captured when the memoized build
- *  started. {@link getLanes} rebuilds when the store's token differs. */
+/** The persisted lanes-version token captured when the memoized build started
+ *  ({@link readLanesVersion}). {@link getLanes} rebuilds when the store's token
+ *  differs. */
 let builtLanesVersion: string | null = null;
-
-/**
- * Current persisted lanes-version token: `null` when the store carries no
- * token (a legitimate stable state, compared as such), `undefined` when the
- * read itself failed (DB unavailable). Callers treat `undefined` as "cannot
- * judge staleness" and keep serving the memoized lanes — degraded freshness
- * beats a broken turn.
- */
-function readLanesVersion(): string | null | undefined {
-  try {
-    return getMemoryCheckpoint(LANES_VERSION_CHECKPOINT_KEY);
-  } catch {
-    return undefined;
-  }
-}
 
 /** Drop THIS process's lane caches: the memo and the page-index cache the
  *  rebuild reads through. Shared by the writer path ({@link invalidateLanes})
@@ -205,13 +176,13 @@ function dropLanesLocal(): void {
  *     and without the bump the daemon's lanes would never rebuild.
  *
  * The bump is best-effort: invalidation must never throw (it runs inside
- * jobs, the rebuild-index route, and tests), so a checkpoint-write failure
- * only logs — the local invalidation above still holds.
+ * jobs, the rebuild-index route, and tests), so a token-write failure only
+ * logs — the local invalidation above still holds.
  */
 export function invalidateLanes(): void {
   dropLanesLocal();
   try {
-    setMemoryCheckpoint(LANES_VERSION_CHECKPOINT_KEY, crypto.randomUUID());
+    bumpLanesVersion(getWorkspaceDir());
   } catch (err) {
     log.warn(
       { err },
@@ -447,7 +418,7 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
  */
 function getLanes(config: AssistantConfig): Promise<ShadowLanes> {
   if (lanesPromise) {
-    const current = readLanesVersion();
+    const current = readLanesVersion(getWorkspaceDir());
     if (current !== undefined && current !== builtLanesVersion) {
       // A writer bumped the persisted token since this build — the memory
       // worker's maintain job after a consolidation, or the rebuild-index
@@ -460,7 +431,7 @@ function getLanes(config: AssistantConfig): Promise<ShadowLanes> {
   if (!lanesPromise) {
     // Capture the token BEFORE building: a bump that lands mid-build is then
     // detected on the next call (one extra rebuild, never a missed one).
-    builtLanesVersion = readLanesVersion() ?? null;
+    builtLanesVersion = readLanesVersion(getWorkspaceDir()) ?? null;
     lanesPromise = initLanes(config).catch((err) => {
       // Reset on failure so a transient init error doesn't permanently wedge
       // the shadow lane — the next turn retries.


### PR DESCRIPTION
## Summary
Addresses the Codex P2 review on merged #38817 (`shadow-plugin.ts` `invalidateLanes()`). #38817 fixed a real incident (memory-v3 lanes freezing when the memory worker consolidates but the daemon never observes it) by bumping a persisted lanes-version token as the cross-process invalidation signal — but stored that token in the assistant-wide `memory_checkpoints` **main-DB** table. Per `assistant/src/plugins/AGENTS.md`, plugin state never belongs in the main database; the memory plugin's existing footprint is grandfathered, and this added *new* durable plugin state there.

This relocates the token into **plugin-owned, still cross-process-visible** storage. The cross-process invalidation behaves exactly as #38817 — only *where* the token lives changed.

## What changed
- **New `v3/lanes-version-store.ts`** — reads/writes the token at `<workspace>/memory/.v2-state/lanes-version`, the memory plugin's established cross-process state dir (the consolidation lock already lives there). Writes are atomic (temp file + rename), so a concurrent reader never sees a partial write. The daemon and the memory worker both resolve the same file because they share the workspace volume — the same basis #38817 relied on for the shared DB.
- **`shadow-plugin.ts`** — `invalidateLanes()` bumps via `bumpLanesVersion(getWorkspaceDir())`; `getLanes()` staleness compare reads via `readLanesVersion(getWorkspaceDir())`. Dropped the `memory_checkpoints` import and the `LANES_VERSION_CHECKPOINT_KEY` constant.
- **Semantics preserved exactly**: absent file → `null` (same meaning as an absent checkpoint row → no spurious rebuild); failed read → `undefined` (cannot judge staleness → serve the memo); write stays best-effort and never throws (the existing try/catch + warn is kept).

## Orphaned row (intentional)
On any install that already ran #38817, the old `memory_v3_lanes_version` row remains in `memory_checkpoints`. Per the task, **no main-DB migration is added** to clean it up — the code simply stops consulting it. It is inert (nothing reads or writes that key anymore).

## Tests
- `shadow-plugin.test.ts`: the three #38817 tests are ported to mock the new store instead of `checkpoints.js` (distinct token per bump, a cross-process bump forces exactly one rebuild with no churn, a read failure serves the memo). 33/33 pass.
- **New `lanes-version-store.test.ts`**: real-fs coverage — a write from one path is observed by a later read of the same workspace (the cross-process round-trip), distinct tokens per bump, absent file → null, unreadable path → undefined. 4/4 pass.
- `bunx tsc` (fast) clean; plugin-state-boundary guard unaffected (memory still imports frozen specifiers elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)