### PR TITLE
fix(web): hide the Recommended chip on downgrade columns and consolidate the clean-pin check

### DIFF
--- a/clients/web/src/domains/settings/billing/package-types.test.ts
+++ b/clients/web/src/domains/settings/billing/package-types.test.ts
@@ -1,10 +1,29 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  isCleanPin,
   packageRank,
   proPackageDisplayName,
   tierRelation,
 } from "./package-types";
+
+describe("isCleanPin", () => {
+  test("true only for a non-customized pin", () => {
+    expect(
+      isCleanPin({
+        key: "super",
+        name: "Super",
+        version: 1,
+        customized: false,
+      }),
+    ).toBe(true);
+    expect(
+      isCleanPin({ key: "super", name: "Super", version: 1, customized: true }),
+    ).toBe(false);
+    expect(isCleanPin(null)).toBe(false);
+    expect(isCleanPin(undefined)).toBe(false);
+  });
+});
 
 describe("proPackageDisplayName", () => {
   test("names a clean pin", () => {

--- a/clients/web/src/domains/settings/billing/package-types.ts
+++ b/clients/web/src/domains/settings/billing/package-types.ts
@@ -12,15 +12,18 @@ import type {
 
 export type { ProPackage };
 
-/**
- * Display name for a Pro subscription's plan: the stock package name only for
- * a clean pin. An unpinned sub or a customized pin reads "Custom", since its
- * real tiers can diverge from any stock package.
- */
+/** A Pro sub pinned to a stock package whose tiers still match it (not customized). */
+export function isCleanPin(
+  pkg: SubscriptionPackage | null | undefined,
+): pkg is SubscriptionPackage {
+  return pkg != null && !pkg.customized;
+}
+
+/** A clean pin reads its stock name; anything else reads "Custom" (tiers can diverge). */
 export function proPackageDisplayName(
   pkg: SubscriptionPackage | null | undefined,
 ): string {
-  return pkg && !pkg.customized ? pkg.name : "Custom";
+  return isCleanPin(pkg) ? pkg.name : "Custom";
 }
 
 /**

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
@@ -1,8 +1,9 @@
 /**
- * Rendering tests for PlanColumnCard's CTA chrome. The `intent` prop selects
- * the button variant (outlined for downgrade) without changing the current /
- * upgrade rendering. The avatar compositor is mocked out — it's a lazy bundle
- * irrelevant to the CTA.
+ * Rendering tests for PlanColumnCard's CTA chrome and the Recommended chip. The
+ * `intent` prop selects the button variant (outlined for downgrade) without
+ * changing the current / upgrade rendering, and gates the chip alongside
+ * `isCurrent`. The avatar compositor is mocked out — it's a lazy bundle
+ * irrelevant to either.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -79,6 +80,22 @@ describe("PlanColumnCard Recommended badge", () => {
       <PlanColumnCard {...baseProps} recommended isCurrent intent="current" />,
     );
     expect(await findByRole("button", { name: "Current Plan" })).toBeTruthy();
+    expect(queryByText("Recommended")).toBeNull();
+  });
+
+  test("hides the badge on a downgrade column", async () => {
+    const { queryByText, findByRole } = render(
+      <PlanColumnCard
+        {...baseProps}
+        recommended
+        isCurrent={false}
+        intent="downgrade"
+        ctaLabel="Downgrade to Mighty"
+      />,
+    );
+    expect(
+      await findByRole("button", { name: "Downgrade to Mighty" }),
+    ).toBeTruthy();
     expect(queryByText("Recommended")).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
@@ -16,7 +16,7 @@ export interface PlanColumnCardProps {
   /** CTA label for a selectable tier; ignored when `isCurrent`. */
   ctaLabel: string;
   features: readonly string[];
-  /** Renders the "Recommended" chip — suppressed on the user's current plan. */
+  /** Renders the "Recommended" chip — only on a non-current, non-downgrade column. */
   recommended?: boolean;
   /**
    * The featured tier renders as the white/light card; the rest stay dark. The
@@ -68,7 +68,7 @@ export function PlanColumnCard({
           <span className="text-[20px] font-medium text-[var(--content-emphasised)]">
             {name}
           </span>
-          {recommended && !isCurrent ? (
+          {recommended && !isDowngrade && !isCurrent ? (
             <Tag className="bg-[var(--feed-digest-weak)] text-[12px] font-semibold uppercase text-[var(--credits-accent)]">
               Recommended
             </Tag>

--- a/clients/web/src/domains/settings/billing/plans/plans-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/plans-copy.ts
@@ -17,7 +17,7 @@ export interface PlanTierCopy {
   cta: string;
   /** Small caption rendered under the price. */
   priceCaption: string;
-  /** Marks the "RECOMMENDED" tier — also renders as the light/white card. */
+  /** Marks the recommended tier; plans-page keys the light/white card off this. */
   recommended?: boolean;
   /** Feature rows appended after the catalog-derived rows. */
   extraFeatures?: readonly string[];

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -420,6 +420,15 @@ describe("PlansPage — current-plan state", () => {
     expect(count(html, /data-theme="light"/g)).toBe(1);
     expect(html).toContain("Current Plan");
   });
+
+  test("pro subscriber on Super: Mighty is a downgrade, no Recommended badge, but keeps the light card", () => {
+    const html = renderStatic(proSuperSubscription(), fullCatalog());
+    // Mighty sits below Super, so its CTA is a downgrade and the chip is hidden.
+    expect(html).toContain("Downgrade to Mighty");
+    expect(html).not.toContain("Recommended");
+    // Mighty still renders as the light card for a Super subscriber.
+    expect(count(html, /data-theme="light"/g)).toBe(1);
+  });
 });
 
 describe("PlansPage — empty catalog (pro-packages flag off)", () => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
+  isCleanPin,
   PACKAGE_ORDER,
   type ProPackage,
   type SwitchRelation,
@@ -278,7 +279,7 @@ export function PlansPage() {
     const currentTierKey =
       subscription.plan_id === "base"
         ? "free"
-        : subscription.package && !subscription.package.customized
+        : isCleanPin(subscription.package)
           ? subscription.package.key
           : null;
 
@@ -452,8 +453,9 @@ export function PlansPage() {
         </header>
 
         {/* Shrinks the four columns to fit as the viewport narrows, reflowing
-            to two-up then one-up; `items-start` keeps each card at its content
-            height so the four-feature Super/Ultra cards stay taller. */}
+            to two-up then one-up; `items-start` keeps each card at its natural
+            content height, so the four-feature Super/Ultra columns are taller
+            than the featured Mighty column. */}
         <div className="mt-10 grid w-full max-w-[1312px] grid-cols-1 items-start gap-6 sm:grid-cols-2 lg:grid-cols-4">
           <PlanColumnCard
             tierKey="free"

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
+  isCleanPin,
   nextPackageUp,
   proPackageDisplayName,
   type ProPackage,
@@ -479,8 +480,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   // the takeover.
   const canOpenPlansTakeover =
     packages.length > 0 &&
-    (currentPlan.id === "base" ||
-      (subscription.package != null && !subscription.package.customized));
+    (currentPlan.id === "base" || isCleanPin(subscription.package));
   // The banner's one-click switch is offered to any switch-eligible Pro sub —
   // a clean pin, a customized pin, or an unpinned (Custom) sub — inheriting the
   // shared eligibility gate. The confirm copy adapts to the sub's state via
@@ -492,8 +492,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   // tiers can diverge from any stock package — gets the direction-neutral
   // switch, since a stock delta could misstate the change.
   const switchRelation: SwitchRelation =
-    currentPlan.id === "base" ||
-    (subscription.package && !subscription.package.customized)
+    currentPlan.id === "base" || isCleanPin(subscription.package)
       ? "upgrade"
       : "switch";
 


### PR DESCRIPTION
## Summary
- Suppress the Recommended chip on downgrade columns (Super/Ultra subscribers no longer see it on Mighty); Mighty keeps its light card for all viewers.
- Extract isCleanPin and reuse it in proPackageDisplayName, plan-card, and plans-page (one source of truth).
- Fix stale plans-page layout comment and plans-copy / test-header comment nits.

Addresses self-review findings for plan: recommended-plan-badge.md