### PR TITLE
fix(web): keep the takeover surface honest on the exit sheet and error path

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -58,11 +58,12 @@ mock.module("@/stores/organization-store", () => ({
 // derived from it can be driven per-test.
 let avatarComponents: CharacterComponents | null = null;
 let avatarTraits: CharacterTraits | null = null;
+let avatarCustomImageUrl: string | null = null;
 mock.module("@/hooks/use-assistant-avatar", () => ({
   useAssistantAvatar: () => ({
     components: avatarComponents,
     traits: avatarTraits,
-    customImageUrl: null,
+    customImageUrl: avatarCustomImageUrl,
     isLoading: false,
     invalidate: () => {},
   }),
@@ -264,6 +265,7 @@ function renderModal({ mode }: { mode?: "checkout" | "resize" } = {}) {
 beforeEach(() => {
   avatarComponents = null;
   avatarTraits = null;
+  avatarCustomImageUrl = null;
   subscriptionPlanId = "base";
   onboardingResponse = makeOnboarding();
   assistantResponse = makeAssistant("small", 10);
@@ -466,6 +468,31 @@ describe("BillingOnboardingModal", () => {
 
     const sheet = await findByTestId("takeover-exit-sheet");
     expect(sheet.style.backgroundColor).toBe(TAKEOVER_SURFACE);
+  });
+
+  test("a custom-image takeover's exit sheet reproduces the blurred backdrop", async () => {
+    // A custom-image takeover paints its colour in a blurred backdrop, not the
+    // ground fill. The exit sheet must carry that same image, or the covering
+    // fade cross-fades the image to flat neutral — the handoff it exists to
+    // prevent.
+    avatarComponents = BUNDLED_COMPONENTS;
+    avatarCustomImageUrl = "blob:vellum/avatar-image";
+    subscriptionPlanId = "pro";
+    assistantResponse = makeAssistant("large", 50);
+    const { getByText, findByTestId } = renderModal();
+
+    await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
+      timeout: 5000,
+    });
+
+    const sheet = await findByTestId("takeover-exit-sheet");
+    const backdrop = sheet.querySelector<HTMLElement>(
+      '[data-testid="takeover-backdrop"]',
+    );
+    expect(backdrop).not.toBeNull();
+    expect(backdrop?.querySelector("img")?.getAttribute("src")).toBe(
+      "blob:vellum/avatar-image",
+    );
   });
 
   test(

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -29,6 +29,7 @@ import {
   TAKEOVER_SURFACE,
   TAKEOVER_SURFACE_VAR,
 } from "./provisioning-state";
+import { TakeoverBackdrop } from "./takeover-backdrop";
 import { useAssistantDomains } from "./use-assistant-domains";
 import { useProProvisioning } from "./use-pro-provisioning";
 import { useTakeoverSurface } from "./use-takeover-surface";
@@ -158,9 +159,11 @@ export function BillingOnboardingModal({
   const { targets, assistantId, domainSetupAvailable, onboardingSettled } =
     provisioning;
 
-  // Published on the modal so the takeover and the sheet that covers it on the
-  // way out paint from one value — the handoff can't cross-fade two colours.
-  const { tintHex } = useTakeoverSurface(assistantId);
+  // The takeover and the sheet that covers it on the way out paint from one
+  // surface: the tint published as a custom property, plus the same blurred
+  // backdrop a custom-image avatar shows — so the handoff can't cross-fade a
+  // colour or an image against a flat fill.
+  const { tintHex, backdropImageUrl } = useTakeoverSurface(assistantId);
 
   // Resize-mode routing needs "is a domain already registered?", which
   // checkout mode never consults — DomainStep owns its own fetch there. The
@@ -379,7 +382,12 @@ export function BillingOnboardingModal({
               }`
             }
             style={{ backgroundColor: TAKEOVER_SURFACE }}
-          />
+          >
+            {/* A custom-image takeover's colour lives in this blurred image, not
+                the ground fill, so the sheet reproduces it to match. The
+                `TAKEOVER_SURFACE` fill shows through while it decodes. */}
+            {backdropImageUrl && <TakeoverBackdrop imageUrl={backdropImageUrl} />}
+          </div>
         )}
       </Modal.Content>
     </Modal.Root>

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.test.tsx
@@ -155,4 +155,25 @@ describe("resolved surfaces", () => {
     expect(result.current.tintHex.toLowerCase()).toBe(GREEN_SURFACE);
     expect(result.current.backdropImageUrl).toBeNull();
   });
+
+  test("a settled query with no components still tints from the bundled creature", () => {
+    // The query settles (ready) with no data at all: components and traits null,
+    // no image. ChatAvatar draws the bundled green creature from its own
+    // fallback, so the surface tints green to match it rather than dropping to
+    // the neutral ground.
+    avatar = {
+      components: null,
+      traits: null,
+      customImageUrl: null,
+      isLoading: false,
+    };
+
+    const { result } = renderHook(() =>
+      useTakeoverSurface("primary-assistant"),
+    );
+
+    expect(result.current.ready).toBe(true);
+    expect(result.current.tintHex.toLowerCase()).toBe(GREEN_SURFACE);
+    expect(result.current.backdropImageUrl).toBeNull();
+  });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
@@ -2,6 +2,7 @@ import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { resolveAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { SURFACE_GROUND, avatarSurfaceHex } from "@/utils/avatar-tone";
 
 /**
@@ -58,9 +59,13 @@ export function useTakeoverSurface(
 
   const accent =
     resolveAvatarAccentHex(components, traits) ??
-    // With no traits and no image, ChatAvatar draws the first bundled color, so
-    // the surface matches that creature rather than falling through to neutral.
-    (customImageUrl ? null : (components?.colors[0]?.hex ?? null));
+    // ChatAvatar draws from `components ?? bundled`, so the surface tints from
+    // the same source it does — the first bundled color when the query settles
+    // with none — and matches whatever creature is on screen instead of falling
+    // through to neutral.
+    (customImageUrl
+      ? null
+      : ((components ?? BUNDLED_COMPONENTS).colors?.[0]?.hex ?? null));
 
   return {
     tintHex: ready && accent ? avatarSurfaceHex(accent) : SURFACE_GROUND,


### PR DESCRIPTION
## Summary
- The takeover-exit sheet now renders the same blurred backdrop a custom-image takeover shows, so the handoff no longer cross-fades the image to flat neutral.
- The surface accent falls back to the same bundled components ChatAvatar draws, so a failed avatar query paints the green creature's ground instead of neutral.

Addresses self-review gaps for plan: takeover-avatar-tinted-background.md