### PR TITLE
Recommended plan badge + dynamic Pro-setup notice copy

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -28,6 +28,7 @@ import type {
     Assistant,
     OnboardingStateResponse,
     PaginatedAssistantDomainList,
+    SubscriptionPackage,
     SubscriptionResponse,
 } from "@/generated/api/types.gen";
 import * as platformGate from "@/hooks/use-platform-gate";
@@ -146,7 +147,10 @@ mock.module("@/domains/settings/components/referral-panel", () => ({
 
 const { BillingPage } = await import("./billing-page");
 
-function makeSubscription(planId: "base" | "pro"): SubscriptionResponse {
+function makeSubscription(
+    planId: "base" | "pro",
+    pkg?: SubscriptionPackage,
+): SubscriptionResponse {
     return {
         plan_id: planId,
         status: "active",
@@ -154,6 +158,7 @@ function makeSubscription(planId: "base" | "pro"): SubscriptionResponse {
         current_period_end: "2026-08-01T00:00:00Z",
         cancel_at_period_end: false,
         cancel_at: null,
+        package: pkg ?? null,
         entitlements: { managed_email: false, phone_number: false },
     };
 }
@@ -307,6 +312,32 @@ describe("Finish Pro setup nudge", () => {
         // The transient param is consumed straight back out of the URL.
         expect(getByTestId("loc").textContent).toBe(
             "/assistant/settings/usage?tab=billing",
+        );
+    });
+
+    test("names the pinned package in the title", async () => {
+        subscriptionResponse = makeSubscription("pro", {
+            key: "super",
+            name: "Super",
+            version: 1,
+            customized: false,
+        });
+        const { getByTestId } = renderPage();
+
+        await waitFor(() =>
+            expect(
+                getByTestId("finish-pro-setup-notice").textContent,
+            ).toContain("Finish setting up your Super plan"),
+        );
+    });
+
+    test("falls back to Custom for an unpinned Pro sub", async () => {
+        const { getByTestId } = renderPage();
+
+        await waitFor(() =>
+            expect(
+                getByTestId("finish-pro-setup-notice").textContent,
+            ).toContain("Finish setting up your Custom plan"),
         );
     });
 

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -9,6 +9,7 @@ import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
 import { shouldShowBillingTab } from "@/domains/settings/billing/billing-tab-visibility";
+import { proPackageDisplayName } from "@/domains/settings/billing/package-types";
 import { UsageTab } from "@/domains/settings/billing/usage/usage-tab";
 import { AdjustPlanModal } from "@/domains/settings/components/adjust-plan-modal";
 import { BillingPanel } from "@/domains/settings/components/billing-panel";
@@ -107,7 +108,7 @@ function FinishProSetupNotice({ onFinishSetup }: { onFinishSetup: () => void }) 
     return (
         <Notice
             tone="info"
-            title="Finish setting up your Pro plan"
+            title={`Finish setting up your ${proPackageDisplayName(subscription?.package)} plan`}
             actions={
                 <Button
                     variant="outlined"

--- a/clients/web/src/domains/settings/billing/package-types.test.ts
+++ b/clients/web/src/domains/settings/billing/package-types.test.ts
@@ -1,10 +1,29 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  isCleanPin,
   packageRank,
   proPackageDisplayName,
   tierRelation,
 } from "./package-types";
+
+describe("isCleanPin", () => {
+  test("true only for a non-customized pin", () => {
+    expect(
+      isCleanPin({
+        key: "super",
+        name: "Super",
+        version: 1,
+        customized: false,
+      }),
+    ).toBe(true);
+    expect(
+      isCleanPin({ key: "super", name: "Super", version: 1, customized: true }),
+    ).toBe(false);
+    expect(isCleanPin(null)).toBe(false);
+    expect(isCleanPin(undefined)).toBe(false);
+  });
+});
 
 describe("proPackageDisplayName", () => {
   test("names a clean pin", () => {

--- a/clients/web/src/domains/settings/billing/package-types.test.ts
+++ b/clients/web/src/domains/settings/billing/package-types.test.ts
@@ -1,6 +1,39 @@
 import { describe, expect, test } from "bun:test";
 
-import { packageRank, tierRelation } from "./package-types";
+import {
+  packageRank,
+  proPackageDisplayName,
+  tierRelation,
+} from "./package-types";
+
+describe("proPackageDisplayName", () => {
+  test("names a clean pin", () => {
+    expect(
+      proPackageDisplayName({
+        key: "super",
+        name: "Super",
+        version: 1,
+        customized: false,
+      }),
+    ).toBe("Super");
+  });
+
+  test("reads Custom for a customized pin", () => {
+    expect(
+      proPackageDisplayName({
+        key: "super",
+        name: "Super",
+        version: 1,
+        customized: true,
+      }),
+    ).toBe("Custom");
+  });
+
+  test("reads Custom for an unpinned sub", () => {
+    expect(proPackageDisplayName(null)).toBe("Custom");
+    expect(proPackageDisplayName(undefined)).toBe("Custom");
+  });
+});
 
 describe("packageRank", () => {
   test("ranks tiers in ascending order", () => {

--- a/clients/web/src/domains/settings/billing/package-types.ts
+++ b/clients/web/src/domains/settings/billing/package-types.ts
@@ -5,9 +5,23 @@
  * `pro-packages` LaunchDarkly flag is off; callers no-op on an empty array.
  */
 
-import type { ProPackage } from "@/generated/api/types.gen";
+import type {
+  ProPackage,
+  SubscriptionPackage,
+} from "@/generated/api/types.gen";
 
 export type { ProPackage };
+
+/**
+ * Display name for a Pro subscription's plan: the stock package name only for
+ * a clean pin. An unpinned sub or a customized pin reads "Custom", since its
+ * real tiers can diverge from any stock package.
+ */
+export function proPackageDisplayName(
+  pkg: SubscriptionPackage | null | undefined,
+): string {
+  return pkg && !pkg.customized ? pkg.name : "Custom";
+}
 
 /**
  * Catalog display order (mirrors `PRO_PACKAGES` insertion order from

--- a/clients/web/src/domains/settings/billing/package-types.ts
+++ b/clients/web/src/domains/settings/billing/package-types.ts
@@ -12,15 +12,18 @@ import type {
 
 export type { ProPackage };
 
-/**
- * Display name for a Pro subscription's plan: the stock package name only for
- * a clean pin. An unpinned sub or a customized pin reads "Custom", since its
- * real tiers can diverge from any stock package.
- */
+/** A Pro sub pinned to a stock package whose tiers still match it (not customized). */
+export function isCleanPin(
+  pkg: SubscriptionPackage | null | undefined,
+): pkg is SubscriptionPackage {
+  return pkg != null && !pkg.customized;
+}
+
+/** A clean pin reads its stock name; anything else reads "Custom" (tiers can diverge). */
 export function proPackageDisplayName(
   pkg: SubscriptionPackage | null | undefined,
 ): string {
-  return pkg && !pkg.customized ? pkg.name : "Custom";
+  return isCleanPin(pkg) ? pkg.name : "Custom";
 }
 
 /**

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
@@ -1,8 +1,9 @@
 /**
- * Rendering tests for PlanColumnCard's CTA chrome. The `intent` prop selects
- * the button variant (outlined for downgrade) without changing the current /
- * upgrade rendering. The avatar compositor is mocked out — it's a lazy bundle
- * irrelevant to the CTA.
+ * Rendering tests for PlanColumnCard's CTA chrome and the Recommended chip. The
+ * `intent` prop selects the button variant (outlined for downgrade) without
+ * changing the current / upgrade rendering, and gates the chip alongside
+ * `isCurrent`. The avatar compositor is mocked out — it's a lazy bundle
+ * irrelevant to either.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -79,6 +80,22 @@ describe("PlanColumnCard Recommended badge", () => {
       <PlanColumnCard {...baseProps} recommended isCurrent intent="current" />,
     );
     expect(await findByRole("button", { name: "Current Plan" })).toBeTruthy();
+    expect(queryByText("Recommended")).toBeNull();
+  });
+
+  test("hides the badge on a downgrade column", async () => {
+    const { queryByText, findByRole } = render(
+      <PlanColumnCard
+        {...baseProps}
+        recommended
+        isCurrent={false}
+        intent="downgrade"
+        ctaLabel="Downgrade to Mighty"
+      />,
+    );
+    expect(
+      await findByRole("button", { name: "Downgrade to Mighty" }),
+    ).toBeTruthy();
     expect(queryByText("Recommended")).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
@@ -65,3 +65,20 @@ describe("PlanColumnCard CTA", () => {
     expect(button.className).toContain("bg-[var(--primary-base)]");
   });
 });
+
+describe("PlanColumnCard Recommended badge", () => {
+  test("renders the badge on a tier the user is not on", async () => {
+    const { findByText } = render(
+      <PlanColumnCard {...baseProps} recommended isCurrent={false} />,
+    );
+    expect(await findByText("Recommended")).toBeTruthy();
+  });
+
+  test("hides the badge on the current plan", async () => {
+    const { queryByText, findByRole } = render(
+      <PlanColumnCard {...baseProps} recommended isCurrent intent="current" />,
+    );
+    expect(await findByRole("button", { name: "Current Plan" })).toBeTruthy();
+    expect(queryByText("Recommended")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
@@ -16,7 +16,8 @@ export interface PlanColumnCardProps {
   /** CTA label for a selectable tier; ignored when `isCurrent`. */
   ctaLabel: string;
   features: readonly string[];
-  mostPopular?: boolean;
+  /** Renders the "Recommended" chip — suppressed on the user's current plan. */
+  recommended?: boolean;
   /**
    * The featured tier renders as the white/light card; the rest stay dark. The
    * value drives a nested `data-theme` scope so the design tokens inside the
@@ -47,7 +48,7 @@ export function PlanColumnCard({
   priceCaption,
   ctaLabel,
   features,
-  mostPopular = false,
+  recommended = false,
   tone = "dark",
   isCurrent,
   intent = "upgrade",
@@ -67,9 +68,9 @@ export function PlanColumnCard({
           <span className="text-[20px] font-medium text-[var(--content-emphasised)]">
             {name}
           </span>
-          {mostPopular ? (
+          {recommended && !isCurrent ? (
             <Tag className="bg-[var(--feed-digest-weak)] text-[12px] font-semibold uppercase text-[var(--credits-accent)]">
-              Most Popular
+              Recommended
             </Tag>
           ) : null}
         </div>

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
@@ -16,7 +16,7 @@ export interface PlanColumnCardProps {
   /** CTA label for a selectable tier; ignored when `isCurrent`. */
   ctaLabel: string;
   features: readonly string[];
-  /** Renders the "Recommended" chip — suppressed on the user's current plan. */
+  /** Renders the "Recommended" chip — only on a non-current, non-downgrade column. */
   recommended?: boolean;
   /**
    * The featured tier renders as the white/light card; the rest stay dark. The
@@ -68,7 +68,7 @@ export function PlanColumnCard({
           <span className="text-[20px] font-medium text-[var(--content-emphasised)]">
             {name}
           </span>
-          {recommended && !isCurrent ? (
+          {recommended && !isDowngrade && !isCurrent ? (
             <Tag className="bg-[var(--feed-digest-weak)] text-[12px] font-semibold uppercase text-[var(--credits-accent)]">
               Recommended
             </Tag>

--- a/clients/web/src/domains/settings/billing/plans/plans-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/plans-copy.ts
@@ -17,7 +17,7 @@ export interface PlanTierCopy {
   cta: string;
   /** Small caption rendered under the price. */
   priceCaption: string;
-  /** Marks the "RECOMMENDED" tier — also renders as the light/white card. */
+  /** Marks the recommended tier; plans-page keys the light/white card off this. */
   recommended?: boolean;
   /** Feature rows appended after the catalog-derived rows. */
   extraFeatures?: readonly string[];

--- a/clients/web/src/domains/settings/billing/plans/plans-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/plans-copy.ts
@@ -17,8 +17,8 @@ export interface PlanTierCopy {
   cta: string;
   /** Small caption rendered under the price. */
   priceCaption: string;
-  /** Marks the "MOST POPULAR" tier — also renders as the light/white card. */
-  mostPopular?: boolean;
+  /** Marks the "RECOMMENDED" tier — also renders as the light/white card. */
+  recommended?: boolean;
   /** Feature rows appended after the catalog-derived rows. */
   extraFeatures?: readonly string[];
 }
@@ -33,12 +33,12 @@ export const PLAN_TIER_COPY: Record<PlanTierKey, PlanTierCopy> = {
     tagline: "Empower your assistant to level you up.",
     cta: "Power Up",
     priceCaption: "Billed monthly",
+    recommended: true,
   },
   super: {
     tagline: "Give your assistant real muscle to help you grow",
     cta: "Go Super",
     priceCaption: "Billed monthly",
-    mostPopular: true,
     extraFeatures: ["Assistant email and subdomain"],
   },
   ultra: {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -420,6 +420,15 @@ describe("PlansPage — current-plan state", () => {
     expect(count(html, /data-theme="light"/g)).toBe(1);
     expect(html).toContain("Current Plan");
   });
+
+  test("pro subscriber on Super: Mighty is a downgrade, no Recommended badge, but keeps the light card", () => {
+    const html = renderStatic(proSuperSubscription(), fullCatalog());
+    // Mighty sits below Super, so its CTA is a downgrade and the chip is hidden.
+    expect(html).toContain("Downgrade to Mighty");
+    expect(html).not.toContain("Recommended");
+    // Mighty still renders as the light card for a Super subscriber.
+    expect(count(html, /data-theme="light"/g)).toBe(1);
+  });
 });
 
 describe("PlansPage — empty catalog (pro-packages flag off)", () => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -339,11 +339,12 @@ describe("PlansPage — full catalog render", () => {
     expect(html).toContain("$200/month");
   });
 
-  test("shows the Most Popular badge exactly once", () => {
+  test("shows the Recommended badge exactly once", () => {
     const html = renderStatic(freeSubscription(), fullCatalog());
-    // The badge text is "Most Popular"; the all-caps look is CSS `uppercase`,
+    // The badge text is "Recommended"; the all-caps look is CSS `uppercase`,
     // which renderToStaticMarkup does not apply.
-    expect(count(html, /Most Popular/g)).toBe(1);
+    expect(count(html, /Recommended/g)).toBe(1);
+    expect(html).not.toContain("Most Popular");
   });
 
   test("derives feature rows from the fixture (storage, credits, machine)", () => {
@@ -412,6 +413,13 @@ describe("PlansPage — current-plan state", () => {
     // which a static first-paint render (no effects) never loads.
     expect(count(html, /disabled=""/g)).toBe(2);
   });
+
+  test("pro subscriber on Mighty: no Recommended badge, but Mighty keeps the light card", () => {
+    const html = renderStatic(proMightySubscription(), fullCatalog());
+    expect(html).not.toContain("Recommended");
+    expect(count(html, /data-theme="light"/g)).toBe(1);
+    expect(html).toContain("Current Plan");
+  });
 });
 
 describe("PlansPage — empty catalog (pro-packages flag off)", () => {
@@ -428,9 +436,10 @@ describe("PlansPage — empty catalog (pro-packages flag off)", () => {
 });
 
 describe("getPlanTierCopy", () => {
-  test("returns tier copy including the most-popular flag and CTA", () => {
+  test("returns tier copy including the recommended flag and CTA", () => {
     expect(getPlanTierCopy("mighty")?.cta).toBe("Power Up");
-    expect(getPlanTierCopy("super")?.mostPopular).toBe(true);
+    expect(getPlanTierCopy("mighty")?.recommended).toBe(true);
+    expect(getPlanTierCopy("super")?.recommended).toBeFalsy();
     expect(getPlanTierCopy("ultra")?.cta).toBe("Unleash Ultra");
   });
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -102,8 +102,8 @@ function packageFeatures(pkg: ProPackage, extra: readonly string[]): string[] {
 
 /**
  * Full-screen "View Plans" pricing takeover at `/assistant/plans`. Always dark
- * regardless of the app theme; the "Super" column flips back to light within
- * its own theme scope. Renders from the live plan catalog — with the
+ * regardless of the app theme; the recommended column flips back to light
+ * within its own theme scope. Renders from the live plan catalog — with the
  * `pro-packages` flag off the catalog is empty and the route bounces back to
  * the billing page.
  */
@@ -490,8 +490,8 @@ export function PlansPage() {
                     : (copy?.cta ?? pkg.name)
                 }
                 features={packageFeatures(pkg, copy?.extraFeatures ?? [])}
-                mostPopular={copy?.mostPopular}
-                tone={copy?.mostPopular ? "light" : "dark"}
+                recommended={copy?.recommended}
+                tone={copy?.recommended ? "light" : "dark"}
                 isCurrent={currentTierKey === pkg.key}
                 intent={relation}
                 pending={pending || changePackagePending}

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
+  isCleanPin,
   PACKAGE_ORDER,
   type ProPackage,
   type SwitchRelation,
@@ -278,7 +279,7 @@ export function PlansPage() {
     const currentTierKey =
       subscription.plan_id === "base"
         ? "free"
-        : subscription.package && !subscription.package.customized
+        : isCleanPin(subscription.package)
           ? subscription.package.key
           : null;
 
@@ -452,8 +453,9 @@ export function PlansPage() {
         </header>
 
         {/* Shrinks the four columns to fit as the viewport narrows, reflowing
-            to two-up then one-up; `items-start` keeps each card at its content
-            height so the four-feature Super/Ultra cards stay taller. */}
+            to two-up then one-up; `items-start` keeps each card at its natural
+            content height, so the four-feature Super/Ultra columns are taller
+            than the featured Mighty column. */}
         <div className="mt-10 grid w-full max-w-[1312px] grid-cols-1 items-start gap-6 sm:grid-cols-2 lg:grid-cols-4">
           <PlanColumnCard
             tierKey="free"

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
+  isCleanPin,
   nextPackageUp,
   proPackageDisplayName,
   type ProPackage,
@@ -479,8 +480,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   // the takeover.
   const canOpenPlansTakeover =
     packages.length > 0 &&
-    (currentPlan.id === "base" ||
-      (subscription.package != null && !subscription.package.customized));
+    (currentPlan.id === "base" || isCleanPin(subscription.package));
   // The banner's one-click switch is offered to any switch-eligible Pro sub —
   // a clean pin, a customized pin, or an unpinned (Custom) sub — inheriting the
   // shared eligibility gate. The confirm copy adapts to the sub's state via
@@ -492,8 +492,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   // tiers can diverge from any stock package — gets the direction-neutral
   // switch, since a stock delta could misstate the change.
   const switchRelation: SwitchRelation =
-    currentPlan.id === "base" ||
-    (subscription.package && !subscription.package.customized)
+    currentPlan.id === "base" || isCleanPin(subscription.package)
       ? "upgrade"
       : "switch";
 

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -15,6 +15,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
   nextPackageUp,
+  proPackageDisplayName,
   type ProPackage,
   type SwitchRelation,
 } from "@/domains/settings/billing/package-types";
@@ -447,15 +448,9 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   }
 
   const display = PLAN_DISPLAY[currentPlan.id] ?? DEFAULT_DISPLAY;
-  // A Pro sub shows the stock package name only for a clean (non-customized)
-  // pin (e.g. "Mighty"). Every other Pro state — an unpinned sub
-  // (`package == null`) or a customized pin whose tiers differ from the stock
-  // package — reads just "Custom". Non-Pro plans show their plan name.
   const planName =
     currentPlan.id === "pro"
-      ? subscription.package && !subscription.package.customized
-        ? subscription.package.name
-        : "Custom"
+      ? proPackageDisplayName(subscription.package)
       : (currentPlan.name ?? currentPlan.id);
 
   const isCancelling =


### PR DESCRIPTION
## Summary
- Billing page's finish-setup notice now names the actual plan — "Finish setting up your <plan> plan" — instead of a hardcoded "Pro".
- The View Plans takeover marks **Mighty** as the **Recommended** plan (renamed from "Most Popular", moved off Super). The badge is hidden when you're already on that plan, and also suppressed on downgrade columns so Super/Ultra subscribers never see "Recommended" over a "Downgrade to Mighty" button. Mighty keeps its featured light card in every case.

## Self-review result
PASS — 4 gaps found across the first review round and fixed in one remediation PR (#38888); round 2 review clean.

## PRs merged into feature branch
- #38869: fix(web): name the actual plan in the finish-setup notice
- #38868: feat(web): mark Mighty as Recommended and hide the badge on the current plan

### Fix PRs
- #38888: fix(web): hide the Recommended chip on downgrade columns and consolidate the clean-pin check

Part of plan: recommended-plan-badge.md