### PR TITLE
fix(gateway): validate WhatsApp webhook payloads with a Zod discriminated union

### DIFF
--- a/gateway/src/__tests__/whatsapp-normalize.test.ts
+++ b/gateway/src/__tests__/whatsapp-normalize.test.ts
@@ -347,9 +347,9 @@ describe("normalizeWhatsAppWebhook", () => {
   });
 
   describe("malformed input is dropped, not trusted", () => {
-    test("a missing timestamp drops the message instead of throwing (was a RangeError crash)", () => {
-      // Before validation, `new Date(Number(undefined) * 1000).toISOString()`
-      // threw `RangeError: Invalid time value`, taking down the whole batch.
+    test("a missing timestamp drops the message instead of feeding NaN to new Date", () => {
+      // A message with no timestamp must be dropped, not passed to
+      // `new Date(Number(undefined) * 1000)` (an Invalid Date that throws).
       const payload = makeWhatsAppPayload({
         id: "wamid.no-ts",
         from: WA_FROM,
@@ -368,6 +368,21 @@ describe("normalizeWhatsAppWebhook", () => {
         type: "text",
         text: { body: "hi" },
       });
+      expect(normalizeWhatsAppWebhook(payload)).toHaveLength(0);
+    });
+
+    test("an out-of-range digit timestamp is dropped rather than overflowing new Date", () => {
+      // Digits only, but too large for `Date` (> ±8.64e15 ms): the seconds
+      // value overflows `new Date(seconds * 1000)` into an Invalid Date, so the
+      // message must be dropped rather than crash the batch on `.toISOString()`.
+      const payload = makeWhatsAppPayload({
+        id: "wamid.huge-ts",
+        from: WA_FROM,
+        timestamp: "9999999999999",
+        type: "text",
+        text: { body: "hi" },
+      });
+      expect(() => normalizeWhatsAppWebhook(payload)).not.toThrow();
       expect(normalizeWhatsAppWebhook(payload)).toHaveLength(0);
     });
 
@@ -392,8 +407,9 @@ describe("normalizeWhatsAppWebhook", () => {
     });
 
     test("valid messages in a batch survive when one message is malformed", () => {
-      // The malformed message is first; before the fix its throw discarded
-      // every valid message in the batch. Now it is dropped and the rest live.
+      // The malformed message is first: a valid message after it in the same
+      // batch must still be normalized (one bad message does not discard the
+      // whole batch).
       const payload = {
         object: "whatsapp_business_account",
         entry: [

--- a/gateway/src/__tests__/whatsapp-normalize.test.ts
+++ b/gateway/src/__tests__/whatsapp-normalize.test.ts
@@ -31,6 +31,12 @@ function makeWhatsAppPayload(
   };
 }
 
+// Reserved-range fictional sender (AGENTS.md § Generic Examples, 555-01xx) and
+// a fixture unix-seconds timestamp, shared by the validation tests below.
+const WA_FROM = "12025550142";
+// generic-examples:ignore-next-line — reason: unix-seconds fixture timestamp, not a phone number
+const WA_TS = "1700000000";
+
 describe("normalizeWhatsAppWebhook", () => {
   describe("image messages", () => {
     test("image with caption preserves both content and attachment", () => {
@@ -306,6 +312,171 @@ describe("normalizeWhatsAppWebhook", () => {
       expect(attachment).not.toHaveProperty("fileName");
       expect(attachment).not.toHaveProperty("mimeType");
       expect(attachment).not.toHaveProperty("fileSize");
+    });
+  });
+
+  describe("interactive messages", () => {
+    test("button_reply becomes callbackData with the title as content", () => {
+      const payload = makeWhatsAppPayload({
+        id: "wamid.int1",
+        from: WA_FROM,
+        timestamp: WA_TS,
+        type: "interactive",
+        interactive: {
+          type: "button_reply",
+          button_reply: { id: "apr:run1:approve", title: "Approve" },
+        },
+      });
+
+      const results = normalizeWhatsAppWebhook(payload);
+      expect(results).toHaveLength(1);
+      expect(results[0].event.message.callbackData).toBe("apr:run1:approve");
+      expect(results[0].event.message.content).toBe("Approve");
+    });
+
+    test("a non-button_reply interactive message is skipped", () => {
+      const payload = makeWhatsAppPayload({
+        id: "wamid.int2",
+        from: WA_FROM,
+        timestamp: WA_TS,
+        type: "interactive",
+        interactive: { type: "list_reply", list_reply: { id: "x" } },
+      });
+      expect(normalizeWhatsAppWebhook(payload)).toHaveLength(0);
+    });
+  });
+
+  describe("malformed input is dropped, not trusted", () => {
+    test("a missing timestamp drops the message instead of throwing (was a RangeError crash)", () => {
+      // Before validation, `new Date(Number(undefined) * 1000).toISOString()`
+      // threw `RangeError: Invalid time value`, taking down the whole batch.
+      const payload = makeWhatsAppPayload({
+        id: "wamid.no-ts",
+        from: WA_FROM,
+        type: "text",
+        text: { body: "hi" },
+      });
+      expect(() => normalizeWhatsAppWebhook(payload)).not.toThrow();
+      expect(normalizeWhatsAppWebhook(payload)).toHaveLength(0);
+    });
+
+    test("a non-numeric timestamp is dropped rather than producing an Invalid Date", () => {
+      const payload = makeWhatsAppPayload({
+        id: "wamid.bad-ts",
+        from: WA_FROM,
+        timestamp: "not-a-number",
+        type: "text",
+        text: { body: "hi" },
+      });
+      expect(normalizeWhatsAppWebhook(payload)).toHaveLength(0);
+    });
+
+    test("a message with a missing id is dropped", () => {
+      const payload = makeWhatsAppPayload({
+        from: WA_FROM,
+        timestamp: WA_TS,
+        type: "text",
+        text: { body: "hi" },
+      });
+      expect(normalizeWhatsAppWebhook(payload)).toHaveLength(0);
+    });
+
+    test("a message with a missing sender is dropped", () => {
+      const payload = makeWhatsAppPayload({
+        id: "wamid.no-from",
+        timestamp: WA_TS,
+        type: "text",
+        text: { body: "hi" },
+      });
+      expect(normalizeWhatsAppWebhook(payload)).toHaveLength(0);
+    });
+
+    test("valid messages in a batch survive when one message is malformed", () => {
+      // The malformed message is first; before the fix its throw discarded
+      // every valid message in the batch. Now it is dropped and the rest live.
+      const payload = {
+        object: "whatsapp_business_account",
+        entry: [
+          {
+            id: "BIZ",
+            changes: [
+              {
+                field: "messages",
+                value: {
+                  messaging_product: "whatsapp",
+                  contacts: [{ wa_id: WA_FROM, profile: { name: "A" } }],
+                  messages: [
+                    // malformed: no timestamp
+                    {
+                      id: "wamid.bad",
+                      from: WA_FROM,
+                      type: "text",
+                      text: { body: "bad" },
+                    },
+                    {
+                      id: "wamid.good",
+                      from: WA_FROM,
+                      timestamp: WA_TS,
+                      type: "text",
+                      text: { body: "survivor" },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const results = normalizeWhatsAppWebhook(payload);
+      expect(results).toHaveLength(1);
+      expect(results[0].whatsappMessageId).toBe("wamid.good");
+      expect(results[0].event.message.content).toBe("survivor");
+    });
+
+    test("a valid but unsupported message type (e.g. location) is skipped without throwing", () => {
+      const payload = makeWhatsAppPayload({
+        id: "wamid.loc",
+        from: WA_FROM,
+        timestamp: WA_TS,
+        type: "location",
+        location: { latitude: 1, longitude: 2 },
+      });
+      expect(() => normalizeWhatsAppWebhook(payload)).not.toThrow();
+      expect(normalizeWhatsAppWebhook(payload)).toHaveLength(0);
+    });
+
+    test("a non-WhatsApp object returns []", () => {
+      expect(normalizeWhatsAppWebhook({ object: "page", entry: [] })).toEqual(
+        [],
+      );
+    });
+
+    test("a structurally invalid payload returns [] rather than throwing", () => {
+      expect(() =>
+        normalizeWhatsAppWebhook({ entry: "not-an-array" }),
+      ).not.toThrow();
+      expect(normalizeWhatsAppWebhook({ entry: "not-an-array" })).toEqual([]);
+    });
+  });
+
+  describe("serve boundary", () => {
+    test("preserves the original payload verbatim as raw, unknown keys included", () => {
+      const payload = makeWhatsAppPayload({
+        id: "wamid.raw",
+        from: WA_FROM,
+        timestamp: WA_TS,
+        type: "text",
+        text: { body: "hi" },
+      });
+      // A field the schema strips from its working copy; raw must keep it.
+      (payload as Record<string, unknown>).unknown_future_field = { any: 1 };
+
+      const results = normalizeWhatsAppWebhook(payload);
+      expect(results).toHaveLength(1);
+      expect(results[0].event.raw).toEqual(payload);
+      expect(
+        (results[0].event.raw as Record<string, unknown>).unknown_future_field,
+      ).toEqual({ any: 1 });
     });
   });
 });

--- a/gateway/src/__tests__/whatsapp-normalize.test.ts
+++ b/gateway/src/__tests__/whatsapp-normalize.test.ts
@@ -346,46 +346,51 @@ describe("normalizeWhatsAppWebhook", () => {
     });
   });
 
+  describe("provider timestamp is not consumed (receivedAt is the gateway's clock)", () => {
+    // `receivedAt` is the gateway's wall-clock receipt time, like every other
+    // channel — the sender-supplied `timestamp` never reaches a `Date`. So no
+    // timestamp value (missing, non-numeric, or out of Date's range) can throw
+    // or otherwise affect normalization; the message is processed normally.
+    test.each([
+      ["missing", undefined],
+      ["non-numeric", "not-a-number"],
+      ["out-of-range digits", "9999999999999"],
+    ])("a %s timestamp is processed normally, never throwing", (_label, ts) => {
+      const payload = makeWhatsAppPayload({
+        id: "wamid.ts",
+        from: WA_FROM,
+        ...(ts === undefined ? {} : { timestamp: ts }),
+        type: "text",
+        text: { body: "hi" },
+      });
+      let results!: ReturnType<typeof normalizeWhatsAppWebhook>;
+      expect(() => {
+        results = normalizeWhatsAppWebhook(payload);
+      }).not.toThrow();
+      expect(results).toHaveLength(1);
+      expect(results[0].event.message.content).toBe("hi");
+    });
+
+    test("receivedAt is a recent wall-clock time, not derived from the provider timestamp", () => {
+      const before = Date.now();
+      const payload = makeWhatsAppPayload({
+        id: "wamid.recv",
+        from: WA_FROM,
+        // A historical send-time; receivedAt must NOT reflect it.
+        timestamp: WA_TS,
+        type: "text",
+        text: { body: "hi" },
+      });
+      const results = normalizeWhatsAppWebhook(payload);
+      const after = Date.now();
+      expect(results).toHaveLength(1);
+      const receivedMs = new Date(results[0].event.receivedAt).getTime();
+      expect(receivedMs).toBeGreaterThanOrEqual(before);
+      expect(receivedMs).toBeLessThanOrEqual(after);
+    });
+  });
+
   describe("malformed input is dropped, not trusted", () => {
-    test("a missing timestamp drops the message instead of feeding NaN to new Date", () => {
-      // A message with no timestamp must be dropped, not passed to
-      // `new Date(Number(undefined) * 1000)` (an Invalid Date that throws).
-      const payload = makeWhatsAppPayload({
-        id: "wamid.no-ts",
-        from: WA_FROM,
-        type: "text",
-        text: { body: "hi" },
-      });
-      expect(() => normalizeWhatsAppWebhook(payload)).not.toThrow();
-      expect(normalizeWhatsAppWebhook(payload)).toHaveLength(0);
-    });
-
-    test("a non-numeric timestamp is dropped rather than producing an Invalid Date", () => {
-      const payload = makeWhatsAppPayload({
-        id: "wamid.bad-ts",
-        from: WA_FROM,
-        timestamp: "not-a-number",
-        type: "text",
-        text: { body: "hi" },
-      });
-      expect(normalizeWhatsAppWebhook(payload)).toHaveLength(0);
-    });
-
-    test("an out-of-range digit timestamp is dropped rather than overflowing new Date", () => {
-      // Digits only, but too large for `Date` (> ±8.64e15 ms): the seconds
-      // value overflows `new Date(seconds * 1000)` into an Invalid Date, so the
-      // message must be dropped rather than crash the batch on `.toISOString()`.
-      const payload = makeWhatsAppPayload({
-        id: "wamid.huge-ts",
-        from: WA_FROM,
-        timestamp: "9999999999999",
-        type: "text",
-        text: { body: "hi" },
-      });
-      expect(() => normalizeWhatsAppWebhook(payload)).not.toThrow();
-      expect(normalizeWhatsAppWebhook(payload)).toHaveLength(0);
-    });
-
     test("a message with a missing id is dropped", () => {
       const payload = makeWhatsAppPayload({
         from: WA_FROM,
@@ -422,10 +427,10 @@ describe("normalizeWhatsAppWebhook", () => {
                   messaging_product: "whatsapp",
                   contacts: [{ wa_id: WA_FROM, profile: { name: "A" } }],
                   messages: [
-                    // malformed: no timestamp
+                    // malformed: no sender identity
                     {
                       id: "wamid.bad",
-                      from: WA_FROM,
+                      timestamp: WA_TS,
                       type: "text",
                       text: { body: "bad" },
                     },

--- a/gateway/src/whatsapp/normalize.ts
+++ b/gateway/src/whatsapp/normalize.ts
@@ -1,84 +1,155 @@
+import { z } from "zod";
+
+import { getLogger } from "../logger.js";
 import type { GatewayInboundEvent } from "../types.js";
 
-// WhatsApp Cloud API webhook payload shapes
+// WhatsApp Cloud API webhook payloads are untrusted external input:
 // https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/payload-examples
+//
+// The envelope and each message are validated with Zod. The core routing fields
+// of a message (`id`, `from`, `timestamp`) are required — a message missing or
+// malforming any of them is dropped rather than processed, so one bad message in
+// a batch can never take down the rest. Content-bearing fields (text body,
+// button reply, media metadata) stay tolerant: a malformed value collapses to
+// `undefined` rather than rejecting the whole message. The original payload is
+// preserved verbatim as `raw`.
 
-interface WhatsAppContact {
-  profile?: { name?: string };
-  wa_id?: string;
-}
+const log = getLogger("whatsapp-normalize");
 
-interface WhatsAppTextMessage {
-  id: string;
-  from: string;
-  timestamp: string;
-  type: "text";
-  text: { body: string };
-}
+const optionalString = () => z.string().optional().catch(undefined);
+const optionalNumber = () => z.number().optional().catch(undefined);
 
-interface WhatsAppInteractiveMessage {
-  id: string;
-  from: string;
-  timestamp: string;
-  type: "interactive";
-  interactive: {
-    type: "button_reply";
-    button_reply: {
-      id: string;
-      title: string;
-    };
-  };
-}
+/**
+ * Core routing fields present on every WhatsApp message. Required and validated:
+ * `id` is the dedup key / external message id, `from` is the sender identity and
+ * conversation address, and `timestamp` is unix-epoch **seconds** as a digit
+ * string. Validating `timestamp` here is what prevents
+ * `new Date(Number(timestamp) * 1000)` from being fed `NaN` (an Invalid Date,
+ * which throws on `.toISOString()`).
+ */
+const messageCore = {
+  id: z.string().min(1),
+  from: z.string().min(1),
+  timestamp: z.string().regex(/^\d+$/),
+};
 
-interface WhatsAppMediaPayload {
-  caption?: string;
-  mime_type?: string;
-  id?: string;
-  file_size?: number;
-  filename?: string;
-}
+const mediaPayloadSchema = z.object({
+  caption: optionalString(),
+  mime_type: optionalString(),
+  id: optionalString(),
+  file_size: optionalNumber(),
+  filename: optionalString(),
+});
 
-interface WhatsAppMediaMessage {
-  id: string;
-  from: string;
-  timestamp: string;
-  type: "audio" | "video" | "image" | "document" | "sticker";
-  // image, video, and document messages can carry a caption
-  image?: WhatsAppMediaPayload;
-  video?: WhatsAppMediaPayload;
-  document?: WhatsAppMediaPayload;
-  audio?: WhatsAppMediaPayload;
-  sticker?: WhatsAppMediaPayload;
-}
+const textMessageSchema = z.object({
+  ...messageCore,
+  type: z.literal("text"),
+  text: z.object({ body: optionalString() }).optional().catch(undefined),
+});
 
-type WhatsAppMessage =
-  | WhatsAppTextMessage
-  | WhatsAppInteractiveMessage
-  | WhatsAppMediaMessage;
+const interactiveMessageSchema = z.object({
+  ...messageCore,
+  type: z.literal("interactive"),
+  interactive: z
+    .object({
+      type: optionalString(),
+      button_reply: z
+        .object({ id: optionalString(), title: optionalString() })
+        .optional()
+        .catch(undefined),
+    })
+    .optional()
+    .catch(undefined),
+});
 
-interface WhatsAppValue {
-  messaging_product: "whatsapp";
-  metadata?: { phone_number_id?: string; display_phone_number?: string };
-  contacts?: WhatsAppContact[];
-  messages?: WhatsAppMessage[];
-  // statuses are delivery/read receipts — we ignore them
-  statuses?: unknown[];
-}
+const imageMessageSchema = z.object({
+  ...messageCore,
+  type: z.literal("image"),
+  image: mediaPayloadSchema.optional().catch(undefined),
+});
 
-interface WhatsAppChange {
-  field: string;
-  value?: WhatsAppValue;
-}
+const videoMessageSchema = z.object({
+  ...messageCore,
+  type: z.literal("video"),
+  video: mediaPayloadSchema.optional().catch(undefined),
+});
 
-interface WhatsAppEntry {
-  id?: string;
-  changes?: WhatsAppChange[];
-}
+const audioMessageSchema = z.object({
+  ...messageCore,
+  type: z.literal("audio"),
+  audio: mediaPayloadSchema.optional().catch(undefined),
+});
 
-interface WhatsAppWebhookPayload {
-  object?: string;
-  entry?: WhatsAppEntry[];
-}
+const documentMessageSchema = z.object({
+  ...messageCore,
+  type: z.literal("document"),
+  document: mediaPayloadSchema.optional().catch(undefined),
+});
+
+const stickerMessageSchema = z.object({
+  ...messageCore,
+  type: z.literal("sticker"),
+  sticker: mediaPayloadSchema.optional().catch(undefined),
+});
+
+const whatsAppMessageSchema = z.discriminatedUnion("type", [
+  textMessageSchema,
+  interactiveMessageSchema,
+  imageMessageSchema,
+  videoMessageSchema,
+  audioMessageSchema,
+  documentMessageSchema,
+  stickerMessageSchema,
+]);
+type WhatsAppMessage = z.infer<typeof whatsAppMessageSchema>;
+
+/** The message types this normalizer produces events for. */
+const HANDLED_MESSAGE_TYPES = new Set([
+  "text",
+  "interactive",
+  "image",
+  "video",
+  "audio",
+  "document",
+  "sticker",
+]);
+
+const contactSchema = z.object({
+  profile: z.object({ name: optionalString() }).optional().catch(undefined),
+  wa_id: optionalString(),
+});
+
+const valueSchema = z.object({
+  messaging_product: optionalString(),
+  metadata: z
+    .object({
+      phone_number_id: optionalString(),
+      display_phone_number: optionalString(),
+    })
+    .optional()
+    .catch(undefined),
+  contacts: z.array(contactSchema).optional().catch(undefined),
+  // Individual messages are parsed per-item in the loop so one malformed
+  // message drops on its own rather than failing the whole array.
+  messages: z.array(z.unknown()).optional().catch(undefined),
+  // statuses are delivery/read receipts — parsed loosely and ignored.
+  statuses: z.array(z.unknown()).optional().catch(undefined),
+});
+
+const changeSchema = z.object({
+  field: optionalString(),
+  value: valueSchema.optional().catch(undefined),
+});
+
+const entrySchema = z.object({
+  id: optionalString(),
+  changes: z.array(changeSchema).optional().catch(undefined),
+});
+
+const whatsAppWebhookSchema = z.object({
+  object: optionalString(),
+  entry: z.array(entrySchema).optional().catch(undefined),
+});
 
 export interface NormalizedWhatsAppMessage {
   event: GatewayInboundEvent;
@@ -88,24 +159,59 @@ export interface NormalizedWhatsAppMessage {
   mediaType?: string;
 }
 
+type WhatsAppMediaMessage = Extract<
+  WhatsAppMessage,
+  { type: "image" | "video" | "audio" | "document" | "sticker" }
+>;
+
+/** The media payload carried under the key matching the message's type. */
+function mediaPayloadOf(msg: WhatsAppMediaMessage) {
+  switch (msg.type) {
+    case "image":
+      return msg.image;
+    case "video":
+      return msg.video;
+    case "audio":
+      return msg.audio;
+    case "document":
+      return msg.document;
+    case "sticker":
+      return msg.sticker;
+  }
+}
+
+/** The `type` of a raw message that failed validation, if it is a string. */
+function rawMessageType(rawMsg: unknown): string | undefined {
+  if (
+    rawMsg &&
+    typeof rawMsg === "object" &&
+    "type" in rawMsg &&
+    typeof (rawMsg as { type: unknown }).type === "string"
+  ) {
+    return (rawMsg as { type: string }).type;
+  }
+  return undefined;
+}
+
 /**
  * Normalize a WhatsApp Cloud API webhook payload into an array of GatewayInboundEvent events.
  *
- * Returns an empty array if:
- * - The payload is not a WhatsApp messages webhook
- * - Required fields are missing
+ * Returns an empty array if the payload is not a WhatsApp messages webhook.
  *
  * Media messages (image/video/audio/document/sticker) are normalized with any
  * accompanying caption as the message content. The `mediaType` field is set so
  * the caller can log that media content itself was not processed.
  *
- * Meta may batch multiple messages in a single webhook payload; we process all
- * of them rather than discarding messages beyond the first.
+ * Meta may batch multiple messages in a single webhook payload; every valid
+ * message is processed. A message that fails validation is dropped individually
+ * (and, when its type is one we handle, logged) so it cannot discard the batch.
  */
 export function normalizeWhatsAppWebhook(
   payload: Record<string, unknown>,
 ): NormalizedWhatsAppMessage[] {
-  const wh = payload as WhatsAppWebhookPayload;
+  const parsed = whatsAppWebhookSchema.safeParse(payload);
+  if (!parsed.success) return [];
+  const wh = parsed.data;
 
   if (wh.object !== "whatsapp_business_account") return [];
 
@@ -119,7 +225,23 @@ export function normalizeWhatsAppWebhook(
     const messages = value.messages;
     if (!messages || messages.length === 0) continue;
 
-    for (const msg of messages) {
+    for (const rawMsg of messages) {
+      const parsedMsg = whatsAppMessageSchema.safeParse(rawMsg);
+      if (!parsedMsg.success) {
+        const rawType = rawMessageType(rawMsg);
+        // A valid WhatsApp message of a type we don't produce events for
+        // (location, reaction, order, …) is skipped quietly. Only a message
+        // whose type we *do* handle but that failed validation — or one with no
+        // usable type at all — is malformed and worth a warning.
+        if (rawType && !HANDLED_MESSAGE_TYPES.has(rawType)) continue;
+        log.warn(
+          { messageType: rawType },
+          "Dropping malformed WhatsApp message",
+        );
+        continue;
+      }
+      const msg = parsedMsg.data;
+
       let body: string;
       let callbackData: string | undefined;
       let mediaType: string | undefined;
@@ -134,31 +256,18 @@ export function normalizeWhatsAppWebhook(
         | undefined;
 
       if (msg.type === "text") {
-        const textMsg = msg as WhatsAppTextMessage;
-        body = textMsg.text?.body?.trim() ?? "";
+        body = msg.text?.body?.trim() ?? "";
       } else if (msg.type === "interactive") {
         // Interactive button reply — extract the button ID as callback data
-        const interactiveMsg = msg as WhatsAppInteractiveMessage;
-        if (interactiveMsg.interactive?.type !== "button_reply") continue;
-        const buttonReply = interactiveMsg.interactive.button_reply;
+        if (msg.interactive?.type !== "button_reply") continue;
+        const buttonReply = msg.interactive.button_reply;
         if (!buttonReply?.id) continue;
         callbackData = buttonReply.id;
         body = buttonReply.title ?? "";
-      } else if (
-        msg.type === "image" ||
-        msg.type === "video" ||
-        msg.type === "audio" ||
-        msg.type === "document" ||
-        msg.type === "sticker"
-      ) {
-        const mediaMsg = msg as WhatsAppMediaMessage;
-        const mediaPayload = mediaMsg[msg.type];
+      } else {
+        const mediaPayload = mediaPayloadOf(msg);
         // image, video, and document can carry a caption; audio and sticker cannot
-        const caption =
-          mediaMsg.image?.caption ??
-          mediaMsg.video?.caption ??
-          mediaMsg.document?.caption;
-        body = caption?.trim() ?? "";
+        body = mediaPayload?.caption?.trim() ?? "";
         mediaType = msg.type;
 
         if (mediaPayload?.id) {
@@ -178,13 +287,10 @@ export function normalizeWhatsAppWebhook(
             },
           ];
         }
-      } else {
-        continue;
       }
 
       // from is the sender's WhatsApp phone number in E.164 format
       const from = msg.from;
-      if (!from) continue;
 
       // Resolve display name from contacts array when available
       const contact = value.contacts?.find((c) => c.wa_id === from);

--- a/gateway/src/whatsapp/normalize.ts
+++ b/gateway/src/whatsapp/normalize.ts
@@ -20,17 +20,29 @@ const optionalString = () => z.string().optional().catch(undefined);
 const optionalNumber = () => z.number().optional().catch(undefined);
 
 /**
+ * The largest unix-epoch **seconds** value `new Date(seconds * 1000)` can
+ * represent: JS `Date`'s range is ±8.64e15 ms, so 8.64e15 / 1000 seconds. A
+ * digit string above this still makes `new Date(Number(timestamp) * 1000)` an
+ * Invalid Date that throws on `.toISOString()`, so it is rejected.
+ */
+const MAX_TIMESTAMP_SECONDS = 8_640_000_000_000;
+
+/**
  * Core routing fields present on every WhatsApp message. Required and validated:
  * `id` is the dedup key / external message id, `from` is the sender identity and
  * conversation address, and `timestamp` is unix-epoch **seconds** as a digit
- * string. Validating `timestamp` here is what prevents
- * `new Date(Number(timestamp) * 1000)` from being fed `NaN` (an Invalid Date,
- * which throws on `.toISOString()`).
+ * string bounded to `Date`'s representable range. Validating `timestamp` here is
+ * what keeps `new Date(Number(timestamp) * 1000)` from being an Invalid Date
+ * (fed `NaN` by a missing/non-numeric value, or overflowed by an out-of-range
+ * one), which would throw on `.toISOString()`.
  */
 const messageCore = {
   id: z.string().min(1),
   from: z.string().min(1),
-  timestamp: z.string().regex(/^\d+$/),
+  timestamp: z
+    .string()
+    .regex(/^\d+$/)
+    .refine((s) => Number(s) <= MAX_TIMESTAMP_SECONDS),
 };
 
 const mediaPayloadSchema = z.object({

--- a/gateway/src/whatsapp/normalize.ts
+++ b/gateway/src/whatsapp/normalize.ts
@@ -6,13 +6,15 @@ import type { GatewayInboundEvent } from "../types.js";
 // WhatsApp Cloud API webhook payloads are untrusted external input:
 // https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/payload-examples
 //
-// The envelope and each message are validated with Zod. The core routing fields
-// of a message (`id`, `from`, `timestamp`) are required — a message missing or
-// malforming any of them is dropped rather than processed, so one bad message in
-// a batch can never take down the rest. Content-bearing fields (text body,
-// button reply, media metadata) stay tolerant: a malformed value collapses to
-// `undefined` rather than rejecting the whole message. The original payload is
-// preserved verbatim as `raw`.
+// The envelope and each message are validated with Zod. The routing fields a
+// message is keyed on (`id` for dedup/identity, `from` for sender/conversation)
+// are required — a message missing either is dropped rather than processed, so
+// one bad message in a batch can never take down the rest. Content-bearing
+// fields (text body, button reply, media metadata) stay tolerant: a malformed
+// value collapses to `undefined` rather than rejecting the whole message. Fields
+// the normalizer does not consume (e.g. the provider `timestamp`) are not
+// modeled; they are stripped from the parsed copy and survive only in `raw`,
+// which carries the original payload verbatim.
 
 const log = getLogger("whatsapp-normalize");
 
@@ -20,29 +22,15 @@ const optionalString = () => z.string().optional().catch(undefined);
 const optionalNumber = () => z.number().optional().catch(undefined);
 
 /**
- * The largest unix-epoch **seconds** value `new Date(seconds * 1000)` can
- * represent: JS `Date`'s range is ±8.64e15 ms, so 8.64e15 / 1000 seconds. A
- * digit string above this still makes `new Date(Number(timestamp) * 1000)` an
- * Invalid Date that throws on `.toISOString()`, so it is rejected.
- */
-const MAX_TIMESTAMP_SECONDS = 8_640_000_000_000;
-
-/**
- * Core routing fields present on every WhatsApp message. Required and validated:
- * `id` is the dedup key / external message id, `from` is the sender identity and
- * conversation address, and `timestamp` is unix-epoch **seconds** as a digit
- * string bounded to `Date`'s representable range. Validating `timestamp` here is
- * what keeps `new Date(Number(timestamp) * 1000)` from being an Invalid Date
- * (fed `NaN` by a missing/non-numeric value, or overflowed by an out-of-range
- * one), which would throw on `.toISOString()`.
+ * Routing fields present on every WhatsApp message. Required and validated:
+ * `id` is the dedup key / external message id, and `from` is the sender identity
+ * and conversation address. The provider `timestamp` is intentionally not
+ * modeled — the event's `receivedAt` is the gateway's own receipt time (as on
+ * every other channel), so the sender-supplied time is never consumed.
  */
 const messageCore = {
   id: z.string().min(1),
   from: z.string().min(1),
-  timestamp: z
-    .string()
-    .regex(/^\d+$/)
-    .refine((s) => Number(s) <= MAX_TIMESTAMP_SECONDS),
 };
 
 const mediaPayloadSchema = z.object({
@@ -227,6 +215,10 @@ export function normalizeWhatsAppWebhook(
 
   if (wh.object !== "whatsapp_business_account") return [];
 
+  // One receipt time for the whole webhook — the gateway's wall clock, like
+  // every other channel. The sender-supplied `timestamp` is not trusted for this.
+  const receivedAt = new Date().toISOString();
+
   const results: NormalizedWhatsAppMessage[] = [];
 
   for (const entry of wh.entry ?? []) {
@@ -314,7 +306,7 @@ export function normalizeWhatsAppWebhook(
         event: {
           version: "v1",
           sourceChannel: "whatsapp",
-          receivedAt: new Date(Number(msg.timestamp) * 1000).toISOString(),
+          receivedAt,
           message: {
             content: body,
             // Use sender phone number as the chat identifier for 1:1 conversations

--- a/gateway/src/whatsapp/normalize.ts
+++ b/gateway/src/whatsapp/normalize.ts
@@ -204,10 +204,14 @@ export function normalizeWhatsAppWebhook(
   payload: Record<string, unknown>,
 ): NormalizedWhatsAppMessage[] {
   const parsed = whatsAppWebhookSchema.safeParse(payload);
-  if (!parsed.success) return [];
+  if (!parsed.success) {
+    return [];
+  }
   const wh = parsed.data;
 
-  if (wh.object !== "whatsapp_business_account") return [];
+  if (wh.object !== "whatsapp_business_account") {
+    return [];
+  }
 
   // One receipt time for the whole webhook — the gateway's wall clock, like
   // every other channel. The sender-supplied `timestamp` is not trusted for this.
@@ -217,11 +221,15 @@ export function normalizeWhatsAppWebhook(
 
   for (const entry of wh.entry ?? []) {
     const change = entry.changes?.find((c) => c.field === "messages");
-    if (!change?.value) continue;
+    if (!change?.value) {
+      continue;
+    }
 
     const value = change.value;
     const messages = value.messages;
-    if (!messages || messages.length === 0) continue;
+    if (!messages || messages.length === 0) {
+      continue;
+    }
 
     for (const rawMsg of messages) {
       const parsedMsg = whatsAppMessageSchema.safeParse(rawMsg);
@@ -231,7 +239,9 @@ export function normalizeWhatsAppWebhook(
         // (location, reaction, order, …) is skipped quietly. Only a message
         // whose type we *do* handle but that failed validation — or one with no
         // usable type at all — is malformed and worth a warning.
-        if (rawType && !HANDLED_MESSAGE_TYPES.has(rawType)) continue;
+        if (rawType && !HANDLED_MESSAGE_TYPES.has(rawType)) {
+          continue;
+        }
         log.warn(
           { messageType: rawType },
           "Dropping malformed WhatsApp message",
@@ -257,9 +267,13 @@ export function normalizeWhatsAppWebhook(
         body = msg.text?.body?.trim() ?? "";
       } else if (msg.type === "interactive") {
         // Interactive button reply — extract the button ID as callback data
-        if (msg.interactive?.type !== "button_reply") continue;
+        if (msg.interactive?.type !== "button_reply") {
+          continue;
+        }
         const buttonReply = msg.interactive.button_reply;
-        if (!buttonReply?.id) continue;
+        if (!buttonReply?.id) {
+          continue;
+        }
         callbackData = buttonReply.id;
         body = buttonReply.title ?? "";
       } else {

--- a/gateway/src/whatsapp/normalize.ts
+++ b/gateway/src/whatsapp/normalize.ts
@@ -103,16 +103,10 @@ const whatsAppMessageSchema = z.discriminatedUnion("type", [
 ]);
 type WhatsAppMessage = z.infer<typeof whatsAppMessageSchema>;
 
-/** The message types this normalizer produces events for. */
-const HANDLED_MESSAGE_TYPES = new Set([
-  "text",
-  "interactive",
-  "image",
-  "video",
-  "audio",
-  "document",
-  "sticker",
-]);
+/** The message types this normalizer produces events for, from the union above. */
+const HANDLED_MESSAGE_TYPES: ReadonlySet<string> = new Set(
+  whatsAppMessageSchema.options.map((option) => option.shape.type.value),
+);
 
 const contactSchema = z.object({
   profile: z.object({ name: optionalString() }).optional().catch(undefined),


### PR DESCRIPTION
## Prompt / plan

**LUM-2794.** Second slice of the untrusted-webhook-ingress hardening (after the Telegram pilot #38856), applying the LUM-2579 "parse untrusted, discriminator-tagged payloads with Zod instead of `as` casts" pattern to the WhatsApp normalizer. This one carries a **confirmed production crash**, so it's the highest-value slice.

### Why we want to do this

WhatsApp Cloud API webhook JSON is **fully untrusted external input**, but `gateway/src/whatsapp/normalize.ts` trusted it via a blanket `payload as WhatsAppWebhookPayload` cast plus per-message `msg as WhatsAppTextMessage` / `as WhatsAppMediaMessage` narrowing. As with Telegram, the per-provider `normalize.ts` is the canonical producer of `GatewayInboundEvent` and everything downstream trusts its output without re-validating — so it's the last line of defense.

**Confirmed crash + its root cause.** A message with a missing/non-numeric `timestamp` reached `new Date(Number(msg.timestamp) * 1000).toISOString()`, where `Number(undefined)` → `NaN` → `new Date(NaN).toISOString()` throws `RangeError: Invalid time value` — and because the whole function throws, **the entire batch is discarded**. The root cause isn't just the missing guard: WhatsApp was the **only** channel deriving `receivedAt` from the sender-supplied timestamp at all. Telegram, Slack, and email all use the gateway's wall clock, and `receivedAt` has **no downstream reader** (it isn't even forwarded to the runtime by `handle-inbound.ts`), so nothing relies on it being the send time.

### What it changes

- **`receivedAt` = the gateway's own receipt time** (`new Date().toISOString()`, computed once per webhook), matching every other channel. The untrusted `timestamp` is therefore never fed to a `Date`, so the entire "malformed timestamp throws and aborts the batch" failure mode is **gone by construction** — no numeric/range guard required.
- **Replace the casts with a `z.discriminatedUnion("type", …)`** over the 7 handled message types (`text`, `interactive`, `image`, `video`, `audio`, `document`, `sticker`), parsed **per-message** with `safeParse`.
- **Validate what we read.** `id` (dedup key / external id) and `from` (sender/conversation identity) are required — a message missing either is dropped individually, so one bad message can't take down the batch. Content-bearing fields (text body, button reply, media metadata) stay tolerant (`.optional().catch(undefined)`). The provider `timestamp` is no longer consumed, so it is **not modeled** — it's stripped from the parsed copy and survives only in `raw`.
- A valid WhatsApp message of a type we don't produce events for (`location`, `reaction`, …) is still **skipped quietly**; only a *handled*-type message that fails validation is logged as malformed.
- **Serve boundary preserved:** `raw: payload` carries the original payload verbatim. **No route change** — the normalizer keeps its `Record<string, unknown>` signature.

### Why it's safe

- **Behavior-identical for real input**, except `receivedAt` is now the receipt time rather than the sender's send time — which no consumer reads, isn't forwarded to the runtime, and now matches Telegram/Slack/email. For real messages the two differ by seconds anyway.
- **Strictly-better failure mode.** A malformed message is dropped (and logged) individually instead of throwing and losing the whole batch. And because the timestamp is unused, a message with *any* timestamp (missing, non-numeric, out of range) is now processed normally rather than dropped — no data lost over a field we ignore.
- **No official-types cross-check** (unlike Telegram's `@grammyjs/types`): Meta publishes an API spec, not TypeScript types, and the community packages are full runtime clients rather than a clean types-only package.

### What value it adds

- Fixes a **real production crash at its root** (removes the untrusted value from `Date` construction entirely) and removes the blanket cast at the last-line-of-defense seam.
- Aligns WhatsApp's `receivedAt` semantics with every other channel.
- Adds coverage for the **interactive (button-reply) path**, which had none, plus malformed/batch-resilience/receivedAt/raw cases.

## Test plan

- `cd gateway && bunx tsc --noEmit` — clean. ESLint / Prettier / knip / generic-examples all clean.
- `src/__tests__/whatsapp-normalize.test.ts`: pre-existing happy-path variant tests (image/video/audio/document/sticker/text) pass **unchanged**, plus new tests: the interactive path; a message with a missing/non-numeric/out-of-range `timestamp` is **processed normally and never throws** (crash class gone by construction); `receivedAt` is a recent wall-clock time, not derived from the provider timestamp; missing `id`/`from` dropped; a malformed message in a batch **does not discard the surviving messages**; unsupported types skipped; `raw` preserved verbatim. **23 pass.**
- `src/http/routes/whatsapp-webhook.test.ts` (mocks the normalizer): **19 pass**, unaffected.
- Test-quality check: reverting `receivedAt` to the old sender-time derivation turns the timestamp/receivedAt tests **red**; restoring makes them green — so they assert the fix, not a snapshot of current behavior.

### Note on review history

An earlier revision fixed the crash defensively — validating the timestamp is a numeric, in-`Date`-range digit string (addressing Codex's out-of-range catch). This revision supersedes that with the root fix above (don't consume the sender time at all), which removes the crash class by construction and is consistent with the other channels, so the numeric/range validation is no longer present or needed.

## CLI verb checklist

No new routes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f