### PR TITLE
fix(streaming): recover stale SSE frontiers below the abandoned ceiling via seq-generation tags

### DIFF
--- a/clients/web/src/assistant/sse-service.test.ts
+++ b/clients/web/src/assistant/sse-service.test.ts
@@ -56,6 +56,8 @@ mock.module("@/lib/streaming/reconnect-cursor", () => ({
   getReconnectCursor: () => null,
   getAbandonedGenerationCeiling: () => null,
   recordAbandonedGeneration: () => {},
+  getSeqGeneration: () => 0,
+  advanceSeqGeneration: () => {},
   advanceReconnectCursor: () => {},
   replaceReconnectCursor: () => {},
   resetReconnectCursor: resetReconnectCursorMock,

--- a/clients/web/src/domains/chat/api/history.ts
+++ b/clients/web/src/domains/chat/api/history.ts
@@ -17,6 +17,7 @@ import {
   extractErrorMessage,
 } from "@/utils/api-errors";
 import { recordDiagnostic } from "@/lib/diagnostics";
+import { getSeqGeneration } from "@/lib/streaming/reconnect-cursor";
 import { summarizeDisplayMessages } from "@/domains/chat/utils/diagnostics";
 
 import { mapRuntimeToDisplayMessage } from "@/domains/chat/utils/map-runtime-message";
@@ -90,6 +91,12 @@ async function fetchPaginatedHistory(
   assistantId: string,
   query: HistoryQuery,
 ): Promise<PaginatedHistoryResult> {
+  // Capture the seq generation at request-ISSUE time: if the daemon's counter
+  // resets while this fetch is in flight, the watermark it returns belongs to
+  // the abandoned generation. Stamping the page with the issue-time generation
+  // lets the snapshot-anchor frontier be tagged accordingly (see
+  // `use-conversation-history`), so the stale-frontier guard can clear it.
+  const seqGeneration = getSeqGeneration();
   const { data, error, response } = await messagesGet({
     path: { assistant_id: assistantId },
     query,
@@ -111,7 +118,10 @@ async function fetchPaginatedHistory(
     throw new ApiError(response.status, message);
   }
 
-  const result = parsePaginatedResponse(data);
+  const result: PaginatedHistoryResult = {
+    ...parsePaginatedResponse(data),
+    seqGeneration,
+  };
   recordDiagnostic("history_page_fetch", {
     assistantId,
     query,

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -35,6 +35,7 @@ import { mapMessageSurfaces } from "@/domains/chat/utils/map-message-surfaces";
 import { recordDiagnostic } from "@/lib/diagnostics";
 import { recordServerSeq } from "@/lib/streaming/server-seq";
 import { recordLocalSeq } from "@/lib/streaming/local-seq";
+import { getSeqGeneration } from "@/lib/streaming/reconnect-cursor";
 import { anchorColdStartReplay } from "@/lib/streaming/cold-anchor";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
@@ -172,10 +173,16 @@ export function useConversationHistory({
       return;
     }
 
-    // Seq baseline (replay idempotency) + cold-start ring-replay anchor.
+    // Seq baseline (replay idempotency) + cold-start ring-replay anchor. Tag
+    // the frontier with the generation the page's `/messages` request was
+    // issued in (falling back to the current generation for pages that predate
+    // the stamp) so a page that raced a generation reset is recognised as a
+    // stale anchor by the stale-frontier guard rather than starving the stream.
     const latestPageSeq = pagination.latestPage?.seq ?? null;
+    const latestPageGeneration =
+      pagination.latestPage?.seqGeneration ?? getSeqGeneration();
     recordServerSeq(activeConversationId, latestPageSeq);
-    recordLocalSeq(activeConversationId, latestPageSeq);
+    recordLocalSeq(activeConversationId, latestPageSeq, latestPageGeneration);
     anchorColdStartReplay(latestPageSeq);
 
     // Seed (or reseed) the materialized snapshot from the committed history,

--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -10,6 +10,7 @@ import { bucketMessagesAdded, recordDiagnostic, resolvePlatformTag } from "@/lib
 import { summarizeRuntimeMessages } from "@/domains/chat/utils/diagnostics";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { recordLocalSeq } from "@/lib/streaming/local-seq";
+import { getSeqGeneration } from "@/lib/streaming/reconnect-cursor";
 import { mapRuntimeToDisplayMessage } from "@/domains/chat/utils/map-runtime-message";
 import { selectTranscriptMessages } from "@/domains/chat/transcript/select-transcript-messages";
 import { conversationHistoryQueryKey } from "@/domains/chat/transcript/use-history-pagination";
@@ -104,6 +105,12 @@ export function useMessageReconciliation({
       serverSeq: number | null,
       serverProcessing: boolean | undefined,
       authoritative = false,
+      // The seq generation this snapshot's `/messages` request was ISSUED in.
+      // A request that raced a generation reset returns a dead-generation
+      // watermark; tagging the frontier with the issue-time generation lets the
+      // stale-frontier guard recognise and clear it. Defaults to the current
+      // generation for callers that fetched synchronously with no reset window.
+      issuedGeneration: number = getSeqGeneration(),
     ): {
       changed: boolean;
       assistantProgress: boolean;
@@ -115,7 +122,7 @@ export function useMessageReconciliation({
       }
 
       // Advance the local seq frontier — we've observed this server snapshot.
-      recordLocalSeq(conversationId, serverSeq);
+      recordLocalSeq(conversationId, serverSeq, issuedGeneration);
 
       const localView = currentLocalView();
       const serverView = serverMessages.map(mapRuntimeToDisplayMessage);
@@ -225,6 +232,7 @@ export function useMessageReconciliation({
       serverSeq: number | null,
       serverProcessing: boolean | undefined,
       authoritative = false,
+      issuedGeneration: number = getSeqGeneration(),
     ): ReconcileActiveConversationResult => {
       const { changed, assistantProgress, messagesAdded } =
         reconcileFromServerDetailed(
@@ -233,6 +241,7 @@ export function useMessageReconciliation({
           serverSeq,
           serverProcessing,
           authoritative,
+          issuedGeneration,
         );
 
       // Reconcile turn state: only fire the silent-stall rescue when ALL
@@ -327,6 +336,11 @@ export function useMessageReconciliation({
       // in the store prevents stale reconciliation from idling it.
       const snapshotTurnId = useTurnStore.getState().activeTurnId;
       const snapshotEpoch = streamState.streamEpoch;
+      // Capture the seq generation at request-ISSUE time: if the daemon's
+      // counter resets while this fetch is in flight, the watermark it returns
+      // belongs to the abandoned generation, and tagging the frontier with the
+      // issue-time generation is what lets the stale-frontier guard clear it.
+      const issuedGeneration = getSeqGeneration();
 
       try {
         const snapshot = await fetchConversationMessages(
@@ -368,6 +382,7 @@ export function useMessageReconciliation({
           serverSeq,
           serverProcessing,
           authoritative,
+          issuedGeneration,
         );
       } catch (err) {
         // Re-throw so callers that await the result (e.g. the
@@ -426,6 +441,9 @@ export function useMessageReconciliation({
           return;
         }
         const snapshotTurnId = useTurnStore.getState().activeTurnId;
+        // Issue-time generation (see `reconcileActiveConversation`): a reset
+        // mid-fetch makes this snapshot's watermark a dead-generation anchor.
+        const issuedGeneration = getSeqGeneration();
 
         fetchConversationMessages(ctx.assistantId, ctx.conversationId, {
           latestPageLimit: RECONCILE_LATEST_PAGE_LIMIT,
@@ -450,6 +468,9 @@ export function useMessageReconciliation({
               ctx.conversationId,
               serverSeq,
               serverProcessing,
+              // Poll-loop reconciles are never authoritative.
+              false,
+              issuedGeneration,
             );
 
             if (changed) {

--- a/clients/web/src/domains/chat/streaming/sse-event-consumer.test.ts
+++ b/clients/web/src/domains/chat/streaming/sse-event-consumer.test.ts
@@ -20,9 +20,13 @@ let globalCursor: number | null = null;
 // The abandoned-generation ceiling, recorded on a seq generation reset and
 // read by the stale-frontier guard. Mirrors reconnect-cursor.ts semantics.
 let abandonedGenerationCeiling: number | null = null;
+// The current seq generation, advanced on each observed reset and read by the
+// stale-frontier guard to date each conversation's frontier.
+let seqGeneration = 0;
 mock.module("@/lib/streaming/reconnect-cursor", () => ({
   getReconnectCursor: () => globalCursor,
   getAbandonedGenerationCeiling: () => abandonedGenerationCeiling,
+  getSeqGeneration: () => seqGeneration,
   // Monotonic — matches the real implementation (won't lower the cursor).
   advanceReconnectCursor: (seq: number) => {
     if (globalCursor === null || seq > globalCursor) {
@@ -35,6 +39,9 @@ mock.module("@/lib/streaming/reconnect-cursor", () => ({
       abandonedGenerationCeiling = seq;
     }
   },
+  advanceSeqGeneration: () => {
+    seqGeneration += 1;
+  },
   // Unconditional — used for generation resets and gap resolves.
   replaceReconnectCursor: (seq: number) => {
     globalCursor = seq;
@@ -42,6 +49,7 @@ mock.module("@/lib/streaming/reconnect-cursor", () => ({
   resetReconnectCursor: () => {
     globalCursor = null;
     abandonedGenerationCeiling = null;
+    seqGeneration = 0;
   },
 }));
 
@@ -93,6 +101,7 @@ beforeEach(() => {
   mockStreamEpoch = 7;
   globalCursor = null;
   abandonedGenerationCeiling = null;
+  seqGeneration = 0;
   __resetLocalSeqForTesting();
   recordDiagnosticMock.mockClear();
 });
@@ -719,8 +728,9 @@ describe("sse-event-consumer — stale seq-generation recovery", () => {
      * live event is classified as an already-applied replay.
      */
     // GIVEN a cursor and a conversation frontier from the old seq space
+    // (generation 0 — no reset observed yet)
     globalCursor = 907779;
-    recordLocalSeq("conv-1", 907779);
+    recordLocalSeq("conv-1", 907779, 0);
     const { deps, handleStreamEvent, reconcileActive } = makeDeps({
       activeConversationId: "conv-1",
     });
@@ -747,14 +757,17 @@ describe("sse-event-consumer — stale seq-generation recovery", () => {
     );
   });
 
-  test("a stale /messages anchor re-poisoning the frontier after an observed reset is dropped as stale generation", () => {
+  test("a stale /messages anchor at the abandoned ceiling re-poisoning the frontier after an observed reset is dropped as stale generation", () => {
     /**
      * After the client observes the generation reset and clears its
      * frontiers, a `/messages` request that raced the reset can still land
-     * the dead generation's anchor back on the frontier. The next live
-     * event trails that poisoned frontier by more than the ring; because a
-     * reset abandoned a ceiling the live cursor has not re-climbed to, the
-     * frontier is proven stale, dropped, and re-seeded from the live event.
+     * the dead generation's anchor back on the frontier. Here the
+     * conversation's watermark IS the abandoned ceiling (a single-conversation
+     * daemon), and the racing anchor is tagged with the pre-reset generation.
+     * The next live event trails that poisoned frontier; because the frontier
+     * is dated to an older generation than the live stream (and additionally
+     * sits at the abandoned ceiling), it is proven stale, dropped, and
+     * re-seeded from the live event.
      */
     // GIVEN a warm cursor from the pre-restart generation
     globalCursor = 907779;
@@ -764,8 +777,8 @@ describe("sse-event-consumer — stale seq-generation recovery", () => {
     const consumer = createSseEventConsumer(deps);
 
     // WHEN the first event of the new (lower) seq space arrives, the client
-    // observes the generation reset — cursor replaced, frontiers cleared,
-    // and the abandoned ceiling (907779) recorded
+    // observes the generation reset — cursor replaced, frontiers cleared, the
+    // abandoned ceiling (907779) recorded, and the seq generation advanced
     consumer.handleSseEvent(
       makeEnvelope({
         conversationId: "conv-1",
@@ -774,10 +787,11 @@ describe("sse-event-consumer — stale seq-generation recovery", () => {
       }),
     );
     expect(abandonedGenerationCeiling).toBe(907779);
+    expect(seqGeneration).toBe(1);
 
-    // AND a `/messages` request that raced the reset re-poisons the frontier
-    // with the dead generation's anchor
-    recordLocalSeq("conv-1", 907779);
+    // AND a `/messages` request that raced the reset (issued in the pre-reset
+    // generation 0) re-poisons the frontier with the dead generation's anchor
+    recordLocalSeq("conv-1", 907779, 0);
 
     // AND the next live event arrives contiguously, trailing the poisoned
     // frontier by far more than the ring
@@ -797,6 +811,111 @@ describe("sse-event-consumer — stale seq-generation recovery", () => {
     expect(recordDiagnosticMock).toHaveBeenCalledWith(
       "sse_local_seq_stale_generation",
       expect.objectContaining({ eventSeq: 905854, localSeq: 907779 }),
+    );
+  });
+
+  test("a stale /messages anchor BELOW the abandoned ceiling (multi-conversation) is recovered by the generation tag", () => {
+    /**
+     * The gap Codex flagged on #38589. `/messages` returns the conversation's
+     * own persisted watermark (`conversations.seq`), which sits BELOW the
+     * global abandoned ceiling whenever another conversation emitted the later
+     * pre-reset seqs. The old ceiling-only guard (`localSeq >= ceiling`) never
+     * fired for such an anchor, so every live event through the anchor was
+     * dropped as a replay and the transcript wedged until the counter
+     * re-climbed past it. The generation tag closes this: the racing anchor
+     * carries the pre-reset generation, so it is dead by construction even
+     * though its value is under the ceiling.
+     */
+    // GIVEN the client had reached global seq 1000 (another conversation held
+    // the later seqs; conv-1's own watermark is 900)
+    globalCursor = 1000;
+    const { deps, handleStreamEvent } = makeDeps({
+      activeConversationId: "conv-1",
+    });
+    const consumer = createSseEventConsumer(deps);
+
+    // WHEN the counter resets to 10 — reset observed, ceiling 1000 recorded,
+    // generation advanced to 1, frontiers cleared, reset event applied
+    consumer.handleSseEvent(
+      makeEnvelope({
+        conversationId: "conv-1",
+        seq: 10,
+        message: { type: "assistant_text_delta", text: "a" },
+      }),
+    );
+    expect(abandonedGenerationCeiling).toBe(1000);
+    expect(seqGeneration).toBe(1);
+
+    // AND a `/messages` request that raced the reset (issued in generation 0)
+    // re-applies conv-1's old persisted anchor 900 — BELOW the ceiling
+    recordLocalSeq("conv-1", 900, 0);
+    expect(getLocalSeq("conv-1")).toBe(900);
+
+    // AND the next live event arrives contiguously at seq 11, trailing the
+    // poisoned frontier (900) though the ceiling check would never fire
+    // (900 < 1000)
+    consumer.handleSseEvent(
+      makeEnvelope({
+        conversationId: "conv-1",
+        seq: 11,
+        message: { type: "assistant_text_delta", text: "b" },
+      }),
+    );
+
+    // THEN the stale frontier is cleared by the generation tag and the live
+    // event applies — the stream is not wedged behind the below-ceiling anchor
+    expect(handleStreamEvent).toHaveBeenCalledTimes(2);
+    expect(getLocalSeq("conv-1")).toBe(11);
+    expect(recordDiagnosticMock).toHaveBeenCalledWith(
+      "sse_local_seq_stale_generation",
+      expect.objectContaining({ eventSeq: 11, localSeq: 900 }),
+    );
+  });
+
+  test("a post-reset anchor at the ceiling (current-generation tag) is still recovered by the ceiling check", () => {
+    /**
+     * A snapshot fetched AFTER the reset carries the current generation, so
+     * the generation tag can't date it as stale — yet `conversations.seq` is
+     * monotonic, so it can still return the pre-reset watermark until the new
+     * generation re-climbs past it. When that watermark IS the abandoned
+     * ceiling (single-conversation daemon), the retained ceiling check clears
+     * it; this is the case (a) cannot see, and why the ceiling signal stays.
+     */
+    // GIVEN the client reaches global seq 1000, then observes the reset to 10
+    globalCursor = 1000;
+    const { deps, handleStreamEvent } = makeDeps({
+      activeConversationId: "conv-1",
+    });
+    const consumer = createSseEventConsumer(deps);
+    consumer.handleSseEvent(
+      makeEnvelope({
+        conversationId: "conv-1",
+        seq: 10,
+        message: { type: "assistant_text_delta", text: "a" },
+      }),
+    );
+    expect(seqGeneration).toBe(1);
+
+    // AND a post-reset reconcile (issued in the CURRENT generation 1) re-applies
+    // the monotonic watermark still stuck at the ceiling 1000
+    recordLocalSeq("conv-1", 1000, 1);
+
+    // WHEN the next live event trails that frontier
+    consumer.handleSseEvent(
+      makeEnvelope({
+        conversationId: "conv-1",
+        seq: 11,
+        message: { type: "assistant_text_delta", text: "b" },
+      }),
+    );
+
+    // THEN the generation tag can't help (same generation), but the ceiling
+    // check clears it — the live event applies
+    expect(handleStreamEvent).toHaveBeenCalledTimes(2);
+    expect(getLocalSeq("conv-1")).toBe(11);
+    expect(recordDiagnosticMock).toHaveBeenCalledWith(
+      "sse_local_seq_stale_generation",
+      expect.objectContaining({ eventSeq: 11, localSeq: 1000 }),
     );
   });
 
@@ -826,11 +945,12 @@ describe("sse-event-consumer — stale seq-generation recovery", () => {
     );
 
     // AND a bursty-turn snapshot that jumps the frontier far ahead of the
-    // live cursor (no generation reset — the abandoned ceiling stays null).
-    // Only the seed has dispatched so far.
+    // live cursor (no generation reset — the abandoned ceiling stays null and
+    // the anchor carries the current generation 0). Only the seed dispatched.
     const frontier = base + SSE_REPLAY_RING_COUNT_LIMIT + 50;
-    recordLocalSeq("conv-1", frontier);
+    recordLocalSeq("conv-1", frontier, 0);
     expect(abandonedGenerationCeiling).toBeNull();
+    expect(seqGeneration).toBe(0);
     expect(handleStreamEvent).toHaveBeenCalledTimes(1);
 
     // WHEN a queued live frame, contiguous with the cursor, trails the
@@ -877,12 +997,15 @@ describe("sse-event-consumer — stale seq-generation recovery", () => {
      * overlap. A reset earlier in a long session must not permanently arm
      * the stale-generation clear.
      */
-    // GIVEN a past reset whose ceiling the live cursor has since climbed past
+    // GIVEN a past reset (generation now 1) whose ceiling the live cursor has
+    // since climbed past
     abandonedGenerationCeiling = 1000;
     globalCursor = 1600;
-    // AND a snapshot that advanced the frontier ahead of the live cursor
+    seqGeneration = 1;
+    // AND a current-generation snapshot that advanced the frontier ahead of
+    // the live cursor
     const frontier = 1600 + SSE_REPLAY_RING_COUNT_LIMIT + 50;
-    recordLocalSeq("conv-1", frontier);
+    recordLocalSeq("conv-1", frontier, 1);
     const { deps, handleStreamEvent } = makeDeps({
       activeConversationId: "conv-1",
     });

--- a/clients/web/src/domains/chat/streaming/sse-event-consumer.ts
+++ b/clients/web/src/domains/chat/streaming/sse-event-consumer.ts
@@ -82,11 +82,12 @@
  *   advances the frontier far past the live cursor (a bursty turn or a
  *   main-thread stall), so a large under-frontier gap is an ordinary
  *   idempotent replay — dropped, frontier held. The exception is a
- *   stale-generation anchor (a snapshot of a pre-reset seq space recorded
- *   onto the frontier by a `/messages` request that raced a counter
- *   reset): provable only inside the re-climb window of an observed
- *   generation reset, where the frontier is dropped and re-seeded from the
- *   live event rather than allowed to swallow the stream.
+ *   stale-generation anchor (a `/messages` watermark from a pre-reset seq
+ *   space): each frontier is tagged with the seq generation its value
+ *   belongs to, so a frontier from an older generation is dead by
+ *   construction — dropped and re-seeded from the live event rather than
+ *   allowed to swallow the stream. See the stale-frontier guard for the two
+ *   provable dead-anchor shapes it recognises.
  *
  * Reconnect handling:
  *   On reconnect the transport sends the cursor as `lastSeenSeq` and
@@ -108,13 +109,16 @@ import { recordDiagnostic } from "@/lib/diagnostics";
 import {
   clearLocalSeq,
   getLocalSeq,
+  getLocalSeqGeneration,
   recordLocalSeq,
   resetLocalSeqs,
 } from "@/lib/streaming/local-seq";
 import {
   advanceReconnectCursor,
+  advanceSeqGeneration,
   getAbandonedGenerationCeiling,
   getReconnectCursor,
+  getSeqGeneration,
   recordAbandonedGeneration,
   replaceReconnectCursor,
 } from "@/lib/streaming/reconnect-cursor";
@@ -206,11 +210,15 @@ export function createSseEventConsumer(
             observed: eventSeq,
           });
           replaceReconnectCursor(eventSeq);
-          // Remember the abandoned generation's ceiling so the stale-frontier
-          // guard below can tell a dead-generation anchor (recorded from a
-          // `/messages` snapshot that raced this reset) from an ordinary
-          // large snapshot overlap.
+          // Remember the abandoned generation's ceiling and advance the seq
+          // generation so the stale-frontier guard below can tell a
+          // dead-generation anchor (recorded from a `/messages` snapshot that
+          // raced this reset) from an ordinary large snapshot overlap. The
+          // generation tag catches a stale anchor whose value sits BELOW the
+          // ceiling (a multi-conversation daemon's per-conversation watermark);
+          // the ceiling still catches one AT it (see the guard).
           recordAbandonedGeneration(stored);
+          advanceSeqGeneration();
           resetLocalSeqs();
           gapDeferred = true;
           // Fire-and-forget: cursor is already replaced above (the old
@@ -332,9 +340,10 @@ export function createSseEventConsumer(
           // Advance the per-conversation frontier once the event is
           // applied so the snapshot/stream merge knows how far the
           // stream has carried this conversation, and so a later replay
-          // of this seq is recognised as a no-op above.
+          // of this seq is recognised as a no-op above. A live event's seq
+          // is always in the current generation, so tag the frontier with it.
           // `recordLocalSeq` ignores a null/undefined seq itself.
-          recordLocalSeq(eventConversationId, eventSeq);
+          recordLocalSeq(eventConversationId, eventSeq, getSeqGeneration());
         };
         if (
           eventSeq != null &&
@@ -358,21 +367,38 @@ export function createSseEventConsumer(
           // delta/completion handlers and duplicate or roll back chat state.
           // Gap SIZE is therefore not the signal.
           //
-          // The frontier is genuinely new content — a stale-generation
-          // anchor recorded by a `/messages` request that raced the daemon's
-          // counter reset — only inside the re-climb window of an OBSERVED
-          // generation reset: the reset abandoned a seq ceiling the live
-          // cursor has not yet climbed back to, and the frontier sits at or
-          // above it. There, a replay drop would silently swallow every live
-          // event until the counter re-passes the stale anchor, so clear the
-          // frontier and apply the live event as the new frontier instead.
+          // The frontier is genuinely a dead-generation anchor — a `/messages`
+          // watermark recorded against a pre-reset seq space — in two provable
+          // shapes, both scoped to an OBSERVED generation reset:
+          //   (a) the frontier was recorded under an older seq generation than
+          //       the live stream now runs in. `conversations.seq` is a
+          //       per-conversation watermark, so a request that raced the reset
+          //       lands a value BELOW the global abandoned ceiling in a
+          //       multi-conversation daemon; the generation tag catches it
+          //       where a ceiling comparison cannot.
+          //   (b) the frontier sits at or above the abandoned ceiling the live
+          //       cursor has not yet re-climbed to — a stale watermark a
+          //       post-reset snapshot re-applied at the ceiling (the
+          //       conversation whose watermark IS the global ceiling, e.g. a
+          //       single-conversation daemon), which (a) cannot see because the
+          //       post-reset request was issued in the current generation.
+          // In both, a replay drop would silently swallow every live event
+          // until the counter re-passes the stale anchor, so clear the frontier
+          // and apply the live event as the new frontier instead. A benign
+          // same-generation overlap satisfies neither (its generation is
+          // current and, during any re-climb, its value stays below the
+          // ceiling), so it still drops as a replay.
+          const frontierGeneration = getLocalSeqGeneration(eventConversationId);
+          const currentGeneration = getSeqGeneration();
           const abandonedCeiling = getAbandonedGenerationCeiling();
           const liveCursor = getReconnectCursor();
           const frontierFromDeadGeneration =
-            abandonedCeiling != null &&
-            liveCursor != null &&
-            liveCursor < abandonedCeiling &&
-            localSeq >= abandonedCeiling;
+            (frontierGeneration != null &&
+              frontierGeneration < currentGeneration) ||
+            (abandonedCeiling != null &&
+              liveCursor != null &&
+              liveCursor < abandonedCeiling &&
+              localSeq >= abandonedCeiling);
           if (frontierFromDeadGeneration) {
             recordDiagnostic("sse_local_seq_stale_generation", seqDiagnostic);
             clearLocalSeq(eventConversationId);

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -128,6 +128,13 @@ export interface PaginatedHistoryResult
    *  completion); it is optional so other constructors (snapshot spreads, tests)
    *  need not restate it. */
   backgroundToolCompletions?: BackgroundTaskEntry[];
+  /** Client-stamped seq generation captured when this page's `/messages`
+   *  request was ISSUED (see `reconnect-cursor.ts`). Lets the snapshot-anchor
+   *  frontier be tagged with the generation its watermark belongs to, so a
+   *  page that raced a generation reset is recognised as stale. Undefined for
+   *  constructors that don't stamp it (snapshot spreads, tests) — the caller
+   *  falls back to the current generation. */
+  seqGeneration?: number;
 }
 
 /** Snapshot of the transcript pagination state held by the scroll

--- a/clients/web/src/lib/streaming/cold-anchor.test.ts
+++ b/clients/web/src/lib/streaming/cold-anchor.test.ts
@@ -8,6 +8,8 @@ mock.module("@/lib/streaming/reconnect-cursor", () => ({
   getReconnectCursor: () => globalCursor,
   getAbandonedGenerationCeiling: () => null,
   recordAbandonedGeneration: () => {},
+  getSeqGeneration: () => 0,
+  advanceSeqGeneration: () => {},
   // Monotonic — matches the real implementation (won't lower the cursor).
   advanceReconnectCursor: (seq: number) => {
     if (globalCursor === null || seq > globalCursor) {

--- a/clients/web/src/lib/streaming/local-seq.test.ts
+++ b/clients/web/src/lib/streaming/local-seq.test.ts
@@ -3,8 +3,13 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import {
   __resetLocalSeqForTesting,
   getLocalSeq,
+  getLocalSeqGeneration,
   recordLocalSeq,
 } from "@/lib/streaming/local-seq";
+
+// Frontiers recorded by these tests belong to seq generation 0 unless a case
+// exercises the generation tag explicitly.
+const GEN_0 = 0;
 
 beforeEach(() => {
   __resetLocalSeqForTesting();
@@ -30,8 +35,8 @@ describe("local-seq", () => {
      * conversation's stream progress must not leak into another's.
      */
     // GIVEN two conversations have applied different events
-    recordLocalSeq("conv-1", 10);
-    recordLocalSeq("conv-2", 25);
+    recordLocalSeq("conv-1", 10, GEN_0);
+    recordLocalSeq("conv-2", 25, GEN_0);
 
     // WHEN each frontier is read
     // THEN each conversation keeps its own value
@@ -44,10 +49,10 @@ describe("local-seq", () => {
      * A later event carries the conversation further forward.
      */
     // GIVEN a conversation already advanced to seq 10
-    recordLocalSeq("conv-1", 10);
+    recordLocalSeq("conv-1", 10, GEN_0);
 
     // WHEN a higher seq is applied
-    recordLocalSeq("conv-1", 15);
+    recordLocalSeq("conv-1", 15, GEN_0);
 
     // THEN the frontier moves forward
     expect(getLocalSeq("conv-1")).toBe(15);
@@ -60,10 +65,10 @@ describe("local-seq", () => {
      * mistaken for new progress.
      */
     // GIVEN a conversation advanced to seq 20
-    recordLocalSeq("conv-1", 20);
+    recordLocalSeq("conv-1", 20, GEN_0);
 
     // WHEN a lower (replayed) seq is applied
-    recordLocalSeq("conv-1", 5);
+    recordLocalSeq("conv-1", 5, GEN_0);
 
     // THEN the frontier holds at the higher value
     expect(getLocalSeq("conv-1")).toBe(20);
@@ -74,10 +79,10 @@ describe("local-seq", () => {
      * Re-delivering the exact frontier event (reconnect overlap) is a no-op.
      */
     // GIVEN a conversation at seq 12
-    recordLocalSeq("conv-1", 12);
+    recordLocalSeq("conv-1", 12, GEN_0);
 
     // WHEN the same seq is applied again
-    recordLocalSeq("conv-1", 12);
+    recordLocalSeq("conv-1", 12, GEN_0);
 
     // THEN the frontier is unchanged
     expect(getLocalSeq("conv-1")).toBe(12);
@@ -96,13 +101,59 @@ describe("local-seq", () => {
        * disturb the existing frontier.
        */
       // GIVEN a conversation with a frontier
-      recordLocalSeq("conv-1", 10);
+      recordLocalSeq("conv-1", 10, GEN_0);
 
       // WHEN a non-honest value is applied
-      recordLocalSeq("conv-1", value);
+      recordLocalSeq("conv-1", value, GEN_0);
 
       // THEN the frontier is preserved
       expect(getLocalSeq("conv-1")).toBe(10);
     },
   );
+});
+
+describe("local-seq — generation tag", () => {
+  test("has no generation before the stream has advanced a conversation", () => {
+    // GIVEN no event has been applied
+    // THEN there is no generation to read
+    expect(getLocalSeqGeneration("conv-1")).toBeNull();
+  });
+
+  test("tags the frontier with the generation its value belongs to", () => {
+    // GIVEN a frontier recorded under generation 2
+    recordLocalSeq("conv-1", 10, 2);
+
+    // THEN both the value and its generation are readable
+    expect(getLocalSeq("conv-1")).toBe(10);
+    expect(getLocalSeqGeneration("conv-1")).toBe(2);
+  });
+
+  test("adopts the new value's generation when the frontier advances", () => {
+    /**
+     * A `/messages` anchor from a pre-reset generation can land a higher value
+     * on a live frontier; the tag must follow that value so the stale-frontier
+     * guard sees the anchor's (older) generation, not the live one it replaced.
+     */
+    // GIVEN a frontier at seq 10 in the current generation 1
+    recordLocalSeq("conv-1", 10, 1);
+
+    // WHEN a higher value from an older generation 0 is recorded
+    recordLocalSeq("conv-1", 900, 0);
+
+    // THEN the frontier advances and adopts the older generation tag
+    expect(getLocalSeq("conv-1")).toBe(900);
+    expect(getLocalSeqGeneration("conv-1")).toBe(0);
+  });
+
+  test("holds the generation tag when a lower value does not advance", () => {
+    // GIVEN a frontier at seq 900 in generation 0
+    recordLocalSeq("conv-1", 900, 0);
+
+    // WHEN a lower value from a newer generation is recorded (a no-op advance)
+    recordLocalSeq("conv-1", 50, 1);
+
+    // THEN the frontier and its generation are both unchanged
+    expect(getLocalSeq("conv-1")).toBe(900);
+    expect(getLocalSeqGeneration("conv-1")).toBe(0);
+  });
 });

--- a/clients/web/src/lib/streaming/local-seq.ts
+++ b/clients/web/src/lib/streaming/local-seq.ts
@@ -30,7 +30,21 @@
  * visited within a page session (bounded by navigation, not stream volume).
  */
 
-const localSeqByConversation = new Map<string, number>();
+interface LocalSeqEntry {
+  /** Highest global seq applied for the conversation. */
+  value: number;
+  /**
+   * The seq generation the `value` belongs to (see `reconnect-cursor.ts`): the
+   * current generation for a live-stream apply, or the generation the
+   * `/messages` request was ISSUED in for a snapshot anchor. The stale-frontier
+   * guard in `sse-event-consumer` treats a frontier tagged with a generation
+   * older than the current one as a dead-generation anchor regardless of its
+   * value, which recovers a stale anchor sitting below the abandoned ceiling.
+   */
+  generation: number;
+}
+
+const localSeqByConversation = new Map<string, LocalSeqEntry>();
 
 /**
  * Advance the local seq for a conversation to `seq` when it is higher than
@@ -38,19 +52,25 @@ const localSeqByConversation = new Map<string, number>();
  * the conversation, and after a snapshot is applied (with the snapshot's
  * seq) so the local seq reflects both apply paths.
  *
+ * `generation` is the seq generation `seq` belongs to — pass the current
+ * generation for a live-stream apply, or the request's issue-time generation
+ * for a `/messages` snapshot anchor. When the frontier advances it adopts the
+ * new value's generation, so the tag always tracks the value in force.
+ *
  * A `null`/`undefined`/non-finite `seq` is ignored — there is nothing to
  * advance to.
  */
 export function recordLocalSeq(
   conversationId: string,
   seq: number | null | undefined,
+  generation: number,
 ): void {
   if (typeof seq !== "number" || !Number.isFinite(seq)) {
     return;
   }
   const current = localSeqByConversation.get(conversationId);
-  if (current === undefined || seq > current) {
-    localSeqByConversation.set(conversationId, seq);
+  if (current === undefined || seq > current.value) {
+    localSeqByConversation.set(conversationId, { value: seq, generation });
   }
 }
 
@@ -59,7 +79,16 @@ export function recordLocalSeq(
  * known (never streamed to within this page session).
  */
 export function getLocalSeq(conversationId: string): number | null {
-  return localSeqByConversation.get(conversationId) ?? null;
+  return localSeqByConversation.get(conversationId)?.value ?? null;
+}
+
+/**
+ * The seq generation the conversation's current frontier value belongs to, or
+ * `null` when no frontier is recorded. Read by the stale-frontier guard to
+ * recognise a dead-generation anchor by construction (older generation).
+ */
+export function getLocalSeqGeneration(conversationId: string): number | null {
+  return localSeqByConversation.get(conversationId)?.generation ?? null;
 }
 
 /**

--- a/clients/web/src/lib/streaming/reconnect-cursor.test.ts
+++ b/clients/web/src/lib/streaming/reconnect-cursor.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
   advanceReconnectCursor,
+  advanceSeqGeneration,
   getAbandonedGenerationCeiling,
   getReconnectCursor,
+  getSeqGeneration,
   recordAbandonedGeneration,
   replaceReconnectCursor,
   resetReconnectCursor,
@@ -104,5 +106,33 @@ describe("reconnect-cursor — abandoned generation ceiling", () => {
 
     // THEN the ceiling clears too — the old seq space is gone
     expect(getAbandonedGenerationCeiling()).toBeNull();
+  });
+});
+
+describe("reconnect-cursor — seq generation", () => {
+  test("starts at 0 before any reset is observed", () => {
+    expect(getSeqGeneration()).toBe(0);
+  });
+
+  test("advances by one per observed reset", () => {
+    // WHEN two generation resets are observed
+    advanceSeqGeneration();
+    expect(getSeqGeneration()).toBe(1);
+    advanceSeqGeneration();
+
+    // THEN the counter tracks the number of resets
+    expect(getSeqGeneration()).toBe(2);
+  });
+
+  test("reset returns the generation to 0 (a new seq space)", () => {
+    // GIVEN a generation advanced by a reset
+    advanceSeqGeneration();
+    expect(getSeqGeneration()).toBe(1);
+
+    // WHEN the connection resets for a new assistant
+    resetReconnectCursor();
+
+    // THEN the generation clears too — the old seq space is gone
+    expect(getSeqGeneration()).toBe(0);
   });
 });

--- a/clients/web/src/lib/streaming/reconnect-cursor.ts
+++ b/clients/web/src/lib/streaming/reconnect-cursor.ts
@@ -49,6 +49,26 @@ let reconnectCursor: number | null = null;
 let abandonedGenerationCeiling: number | null = null;
 
 /**
+ * Monotonic count of seq-generation resets observed on this connection's seq
+ * space, starting at 0 and advanced (never lowered) each time a backwards seq
+ * jump proves the daemon's counter restarted.
+ *
+ * Every recorded per-conversation frontier is tagged with the generation its
+ * value belongs to (see `local-seq.ts`): a live event's value is the current
+ * generation, and a `/messages` snapshot anchor's value is the generation the
+ * request was ISSUED in. A frontier tagged with a generation older than the
+ * current one is a dead-generation anchor by construction — regardless of
+ * whether its value sits above or below the abandoned ceiling — so the
+ * stale-frontier guard in `sse-event-consumer` clears it. This is what recovers
+ * a stale `/messages` anchor in a multi-conversation daemon, where the
+ * conversation's persisted watermark is below the global abandoned ceiling.
+ *
+ * Cleared to 0 with the cursor on an assistant switch, which is a fresh seq
+ * space; a transport reconnect within one assistant preserves it.
+ */
+let seqGeneration = 0;
+
+/**
  * The highest global seq applied so far, or `null` if no event with a
  * seq has been seen yet.
  */
@@ -77,6 +97,23 @@ export function recordAbandonedGeneration(abandonedCeiling: number): void {
  */
 export function getAbandonedGenerationCeiling(): number | null {
   return abandonedGenerationCeiling;
+}
+
+/**
+ * The current seq generation, starting at 0. Frontiers tagged with an older
+ * generation are dead-generation anchors (see `local-seq.ts`).
+ */
+export function getSeqGeneration(): number {
+  return seqGeneration;
+}
+
+/**
+ * Advance the seq generation by one. Called when a generation reset is observed
+ * (a backwards seq jump), alongside `recordAbandonedGeneration`, so frontiers
+ * recorded under the abandoned generation can be told apart from live ones.
+ */
+export function advanceSeqGeneration(): void {
+  seqGeneration += 1;
 }
 
 /**
@@ -110,4 +147,5 @@ export function replaceReconnectCursor(seq: number): void {
 export function resetReconnectCursor(): void {
   reconnectCursor = null;
   abandonedGenerationCeiling = null;
+  seqGeneration = 0;
 }

--- a/clients/web/src/lib/streaming/stream-transport.test.ts
+++ b/clients/web/src/lib/streaming/stream-transport.test.ts
@@ -28,6 +28,8 @@ mock.module("@/lib/streaming/reconnect-cursor", () => ({
   getReconnectCursor: () => mockReconnectCursor,
   getAbandonedGenerationCeiling: () => null,
   recordAbandonedGeneration: () => {},
+  getSeqGeneration: () => 0,
+  advanceSeqGeneration: () => {},
 }));
 
 import { getLifecycleDiagnosticsEvents } from "@/lib/diagnostics";


### PR DESCRIPTION
Addresses Codex review feedback (P2) on #38589.

## Problem

#38589's stale-frontier guard only clears a dead-generation anchor when it sits **at or above** the abandoned ceiling (`localSeq >= abandonedCeiling`). But `/messages` returns the conversation's **own** persisted watermark (`conversations.seq`, per-conversation and monotonic), which sits **below** the global pre-reset cursor whenever another conversation emitted the later seqs.

Example (multi-conversation daemon): the client reaches global seq 1000; a `/messages` response that raced a reset re-applies conv-1's old anchor **900**; the counter resets to **10**. Because `900 >= 1000` is false, every live event for conv-1 through seq 900 is dropped as a replay — the transcript wedges until the counter re-climbs past 900. In multi-conversation daemons the anchor almost never equals the ceiling, so the recovery #38589 preserved rarely fired.

Value-based discrimination is fundamentally unsound here: a benign same-generation snapshot can also lead a lagging live cursor (bursty turn / main-thread stall), so it's numerically indistinguishable from a stale anchor. The only sound signal is **provenance** — which seq generation the frontier's value belongs to.

## Fix — seq-generation tags

- **`reconnect-cursor.ts`**: a monotonic `seqGeneration` counter (starts 0), advanced on each observed reset alongside `recordAbandonedGeneration`, cleared with the cursor on assistant switch.
- **`local-seq.ts`**: each per-conversation frontier now stores `{ value, generation }`. The generation follows the value on advance, so the tag always tracks the value in force. New `getLocalSeqGeneration()`.
- **`/messages` anchor paths capture the generation at request-ISSUE time** (the crux — a request that races a reset returns a dead-generation watermark, but is *applied* after the reset): `use-message-reconciliation` (reconcile + poll loop) and the history query (`history.ts` stamps the page; `use-conversation-history` reads it). Live-stream applies tag with the current generation.
- **Guard predicate** (`sse-event-consumer`) clears the frontier when it is a dead-generation anchor in either provable shape:
  - **(a)** the frontier's generation is older than the current one — dead by construction, regardless of value. This recovers the below-ceiling multi-conversation case Codex flagged.
  - **(b)** the frontier sits at/above the abandoned ceiling the live cursor hasn't re-climbed to — retained for the single-conversation case where the conversation's watermark *is* the ceiling and the poisoning request was issued *after* the reset (so (a) can't date it).

A benign same-generation overlap satisfies neither — its generation is current and, during any re-climb, its value stays below the ceiling — so it still drops as an idempotent replay with the frontier held. This preserves #38589's core invariant (clearing there would re-run old delta/completion handlers and duplicate or roll back chat state).

The two signals together **strictly dominate** #38589: everything it recovered still recovers, plus the multi-conversation below-ceiling case. The only residual (a multi-conversation *post*-reset reconcile returning a stale below-ceiling watermark) is the same self-heals-on-next-reconcile degradation #38589 already had, and is eliminated at the source by #38483's daemon-side counter floor.

## Tests

`sse-event-consumer.test.ts`:
- **NEW** multi-conversation scenario (anchor 900, ceiling 1000, reset to 10): the below-ceiling stale anchor is recovered by the generation tag — the exact case Codex flagged.
- **NEW** post-reset anchor at the ceiling tagged with the *current* generation: recovered by the retained ceiling check (documents why (a) alone is insufficient and (b) stays).
- Existing stale-anchor / benign-overlap / re-climb tests updated to thread generations; all still green.

`local-seq.test.ts` (generation tag: stored, follows the value, held on no-op advance) and `reconnect-cursor.test.ts` (generation counter: advances per reset, cleared on reset). Shared reconnect-cursor mock surfaces completed in `cold-anchor` / `sse-service` / `stream-transport` tests (mock.module-leakage hygiene).

All touched web test files pass locally (generated client materialized in-worktree to run them). Changed source files typecheck clean.

## Note

`reconcileFromServer` (an unused public method of `useMessageReconciliation`) is left in place: it is pre-existing dead code unrelated to this fix, and its existence as a generation-less entry point is what justifies the defensive `issuedGeneration` default on `reconcileFromServerDetailed`. Flagging for a possible separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)