### PR TITLE
fix(web): stop the exit-sheet backdrop double-animating

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -493,6 +493,9 @@ describe("BillingOnboardingModal", () => {
     expect(backdrop?.querySelector("img")?.getAttribute("src")).toBe(
       "blob:vellum/avatar-image",
     );
+    // The sheet's own fade drives the reveal here, so the backdrop must not
+    // re-fade over it.
+    expect(backdrop?.className).not.toContain("provision-avatar-reveal");
   });
 
   test(

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -385,8 +385,12 @@ export function BillingOnboardingModal({
           >
             {/* A custom-image takeover's colour lives in this blurred image, not
                 the ground fill, so the sheet reproduces it to match. The
-                `TAKEOVER_SURFACE` fill shows through while it decodes. */}
-            {backdropImageUrl && <TakeoverBackdrop imageUrl={backdropImageUrl} />}
+                `TAKEOVER_SURFACE` fill shows through while it decodes. The
+                sheet's own fade drives the reveal, so the backdrop doesn't
+                re-fade over it. */}
+            {backdropImageUrl && (
+              <TakeoverBackdrop imageUrl={backdropImageUrl} animateIn={false} />
+            )}
           </div>
         )}
       </Modal.Content>

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-backdrop.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-backdrop.test.tsx
@@ -38,4 +38,22 @@ describe("TakeoverBackdrop", () => {
     expect(image?.style.width.replace(/\s/g, "")).toBe("calc(100%+240px)");
     expect(image?.style.height.replace(/\s/g, "")).toBe("calc(100%+240px)");
   });
+
+  test("fades the layer in by default", () => {
+    const { getByTestId } = render(
+      <TakeoverBackdrop imageUrl="https://cdn.test/avatar.png" />,
+    );
+    expect(getByTestId("takeover-backdrop").className).toContain(
+      "provision-avatar-reveal",
+    );
+  });
+
+  test("omits the reveal when animateIn is false", () => {
+    const { getByTestId } = render(
+      <TakeoverBackdrop imageUrl="https://cdn.test/avatar.png" animateIn={false} />,
+    );
+    expect(getByTestId("takeover-backdrop").className).not.toContain(
+      "provision-avatar-reveal",
+    );
+  });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-backdrop.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-backdrop.tsx
@@ -6,13 +6,26 @@ const OVERSCAN_PX = BLUR_RADIUS_PX * 2; // 120px per side
 /**
  * Decorative backdrop for the provisioning takeover: the avatar image blurred
  * behind a scrim, so the takeover's ground picks up the avatar's color.
+ *
+ * `animateIn` fades the layer in over `--provision-reveal` as the image
+ * decodes — right where the backdrop mounts cold. Pass false where an ancestor
+ * already drives the fade (the takeover-exit sheet), so the two opacity ramps
+ * don't multiply.
  */
-export function TakeoverBackdrop({ imageUrl }: { imageUrl: string }) {
+export function TakeoverBackdrop({
+  imageUrl,
+  animateIn = true,
+}: {
+  imageUrl: string;
+  animateIn?: boolean;
+}) {
   return (
     <div
       aria-hidden
       data-testid="takeover-backdrop"
-      className="provision-avatar-reveal pointer-events-none absolute inset-0 overflow-hidden"
+      className={`pointer-events-none absolute inset-0 overflow-hidden${
+        animateIn ? " provision-avatar-reveal" : ""
+      }`}
     >
       {/* `blur()` samples transparent outside the element, so the layer
           over-scans the container by an absolute amount tied to the radius —


### PR DESCRIPTION
## Summary
- `TakeoverBackdrop` gains an `animateIn` flag; the takeover-exit sheet mounts it without the reveal so only the sheet's own fade drives it, while the live takeover keeps its async fade-in.

Addresses a self-review polish note for plan: takeover-avatar-tinted-background.md