### PR TITLE
refactor(routes): construct the route host client in the dispatcher constructor

### DIFF
--- a/assistant/src/runtime/routes/user-route-dispatcher.ts
+++ b/assistant/src/runtime/routes/user-route-dispatcher.ts
@@ -138,12 +138,11 @@ export class UserRouteDispatcher {
   private handlerTimeoutMs: number;
   private context: UserRouteContext;
   /**
-   * Lazily created on the first request that runs while the route host is
-   * enabled. Constructing it is inert (the subprocess spawns lazily on the
-   * client's first `invoke`), so a dispatcher whose host is never enabled never
-   * creates one.
+   * The route host client. Constructing it is inert — the subprocess spawns
+   * lazily on the client's first `invoke` — so a dispatcher whose host is never
+   * enabled never spawns one.
    */
-  private routeHostClient: RouteHostClient | undefined;
+  private readonly routeHostClient: RouteHostClient;
 
   constructor(options: {
     handlerTimeoutMs?: number;
@@ -152,10 +151,7 @@ export class UserRouteDispatcher {
     this.handlerTimeoutMs =
       options.handlerTimeoutMs ?? DEFAULT_HANDLER_TIMEOUT_MS;
     this.context = Object.freeze({ ...options.context });
-  }
-
-  private getRouteHostClient(): RouteHostClient {
-    return (this.routeHostClient ??= new RouteHostClient());
+    this.routeHostClient = new RouteHostClient();
   }
 
   /**
@@ -227,7 +223,7 @@ export class UserRouteDispatcher {
     }
 
     try {
-      const result = await this.getRouteHostClient().invoke(
+      const result = await this.routeHostClient.invoke(
         {
           filePath,
           mtimeMs,


### PR DESCRIPTION
## Prompt / plan

Follow-up to the merged #38847, per your review comment: initialize `routeHostClient` in the dispatcher's constructor (a `readonly` field, always defined) instead of the lazy `??=` getter, so it's never `undefined`.

Constructing the client stays inert — the subprocess only spawns on the client's first `invoke`, which only happens when `userRoutes.host.enabled` gates a request to the host — so a dispatcher whose host is never enabled still never spawns one. This just removes the `| undefined` + the `getRouteHostClient()` indirection.

## Test plan

- `user-route-dispatcher.test.ts`, `user-route-dispatcher-host.test.ts`, `default-plugin-routes.test.ts` → **45 pass** (every dispatcher construction now eagerly builds the inert client; the host-delegation path still delegates/maps 504/503/404 as before).
- `bunx tsc --noEmit`, prettier, eslint clean; pre-commit hooks pass.

## CLI verb checklist

No routes changed — internal dispatcher cleanup only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FosQeirkpt7G1K2SSbMx1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01FosQeirkpt7G1K2SSbMx1N)_