### PR TITLE
feat(web): open the provisioning takeover for an in-place credit-bundle change

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -958,6 +958,32 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
     expect(upgradeCall).toBeNull();
   });
 
+  test("a credits-only Continue opens the takeover, not just a toast", async () => {
+    // Current config is medium machine / 10 GB (xs) storage / no credits; change
+    // only the credit bundle.
+    const { findByRole, findByTestId } = renderInteractive(
+      proMightySubscription(),
+      { plans: customCatalog() },
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Configure" }));
+
+    selectOption("Credit bundle", "50 credits");
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(creditTierCall).not.toBeNull());
+    expect(creditTierCall!.body).toEqual({ credit_tier: "credits_50" });
+    // Machine and storage are unchanged, so no resource-tier request fires.
+    expect(machineTierCall).toBeNull();
+    expect(storageTierCall).toBeNull();
+
+    // A credit-only change owes no provisioning but still opens the takeover for
+    // a readable confirmation moment.
+    const takeover = await findByTestId("resize-takeover");
+    expect(takeover.getAttribute("data-mode")).toBe("resize");
+    expect(upgradeCall).toBeNull();
+  });
+
   // Configure always opens the in-place custom modal for a Pro sub, whatever the
   // sub's eligibility or tier legacy status. An ineligible or legacy-tier sub
   // that then tries to apply a change surfaces the backend's 4xx as a toast (the

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -356,9 +356,10 @@ export function PlansPage() {
         return;
       }
       setCustomPlanOpen(false);
-      if (result.needsResize) {
+      if (result.needsResize || result.creditChanged) {
         // A machine/storage change needs the assistant to provision the new
-        // ceiling — open the same in-tab resize takeover the tier-change flow uses.
+        // ceiling; a credit change owes no provisioning but still opens the same
+        // in-tab takeover for a readable confirmation moment.
         setResizeTakeoverOpen(true);
       } else {
         toast.success("Plan updated.");

--- a/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.test.ts
@@ -311,10 +311,14 @@ describe("useChangeTiers", () => {
     expect(creditCalls).toEqual([{ body: { credit_tier: "credits_50" } }]);
     // Storage is unchanged, so no storage-tier call fires.
     expect(storageCalls).toEqual([]);
-    expect(invalidatedKeys).toEqual([SUBSCRIPTION_KEY, ONBOARDING_KEY, PLANS_KEY]);
+    expect(invalidatedKeys).toEqual([
+      SUBSCRIPTION_KEY,
+      ONBOARDING_KEY,
+      PLANS_KEY,
+    ]);
     expect(toastErrorCalls).toEqual([]);
-    // A machine change resizes the assistant.
-    expect(captured.value).toEqual({ needsResize: true });
+    // A machine change resizes the assistant; the credit change persisted too.
+    expect(captured.value).toEqual({ needsResize: true, creditChanged: true });
   });
 
   test("a storage upgrade needs a resize", async () => {
@@ -331,7 +335,7 @@ describe("useChangeTiers", () => {
 
     expect(storageCalls).toEqual([{ body: { storage_tier: "s" } }]);
     expect(machineCalls).toEqual([]);
-    expect(captured.value).toEqual({ needsResize: true });
+    expect(captured.value).toEqual({ needsResize: true, creditChanged: false });
   });
 
   test("billing refetches are awaited before the result resolves", async () => {
@@ -373,10 +377,13 @@ describe("useChangeTiers", () => {
     });
 
     expect(machineCalls).toEqual([{ body: { machine_tier: "medium" } }]);
-    expect(captured.value).toEqual({ needsResize: false });
+    expect(captured.value).toEqual({
+      needsResize: false,
+      creditChanged: false,
+    });
   });
 
-  test("a credit-only change does not need a resize", async () => {
+  test("a credit-only change surfaces the takeover without a resize", async () => {
     const { result } = setup();
 
     const captured: { value: ChangeTiersResult | null } = { value: null };
@@ -391,7 +398,9 @@ describe("useChangeTiers", () => {
     expect(creditCalls).toEqual([{ body: { credit_tier: "credits_50" } }]);
     expect(machineCalls).toEqual([]);
     expect(storageCalls).toEqual([]);
-    expect(captured.value).toEqual({ needsResize: false });
+    // No compute/disk provisioning is owed, but the credit change persisted, so
+    // the caller still opens the takeover.
+    expect(captured.value).toEqual({ needsResize: false, creditChanged: true });
   });
 
   test("toasts the extracted error and returns null on failure", async () => {
@@ -401,7 +410,7 @@ describe("useChangeTiers", () => {
     const { result } = setup();
 
     const captured: { value: ChangeTiersResult | null } = {
-      value: { needsResize: true },
+      value: { needsResize: true, creditChanged: false },
     };
     await act(async () => {
       captured.value = await result.current.changeTiers({
@@ -440,20 +449,20 @@ describe("useChangeTiers", () => {
     expect(toastErrorCalls).toEqual([
       "Payment failed. Your card was declined.",
     ]);
-    expect(captured.value).toEqual({ needsResize: true });
+    // The storage upgrade landed (needs a resize); the credit change did not.
+    expect(captured.value).toEqual({ needsResize: true, creditChanged: false });
   });
 
-  test("returns null when only a non-resource dim landed and a resource failed", async () => {
+  test("surfaces the takeover when only the credit dim landed and a resource failed", async () => {
     // Machine (the sole resource change) fails; the credit change succeeds. No
-    // provisioning is owed, so hold the modal open for a retry.
+    // provisioning is owed, but the persisted credit change still opens the
+    // takeover.
     machineImpl = async () => {
       throw { detail: "Machine tier unavailable." };
     };
     const { result } = setup();
 
-    const captured: { value: ChangeTiersResult | null } = {
-      value: { needsResize: true },
-    };
+    const captured: { value: ChangeTiersResult | null } = { value: null };
     await act(async () => {
       captured.value = await result.current.changeTiers({
         machineTier: "large",
@@ -464,7 +473,7 @@ describe("useChangeTiers", () => {
 
     expect(creditCalls).toEqual([{ body: { credit_tier: "credits_50" } }]);
     expect(toastErrorCalls).toEqual(["Machine tier unavailable."]);
-    expect(captured.value).toBeNull();
+    expect(captured.value).toEqual({ needsResize: false, creditChanged: true });
   });
 
   test("posting no changes is a successful no-op with no dispatch", async () => {
@@ -483,6 +492,9 @@ describe("useChangeTiers", () => {
     expect(storageCalls).toEqual([]);
     expect(creditCalls).toEqual([]);
     expect(invalidatedKeys).toEqual([]);
-    expect(captured.value).toEqual({ needsResize: false });
+    expect(captured.value).toEqual({
+      needsResize: false,
+      creditChanged: false,
+    });
   });
 });

--- a/clients/web/src/domains/settings/billing/use-change-tiers.ts
+++ b/clients/web/src/domains/settings/billing/use-change-tiers.ts
@@ -50,9 +50,17 @@ export interface ChangeTiersResult {
    * A resource dimension grew and persisted — a storage upgrade or a machine
    * upgrade — so the assistant must provision the new compute/disk and the
    * caller opens the resize takeover. A machine downgrade, a credit-only
-   * change, or a no-op leaves this false.
+   * change, or a no-op leaves this false. Credits are kept out of it so
+   * downstream resize logic stays keyed on "the assistant must provision".
    */
   needsResize: boolean;
+  /**
+   * The credit bundle changed and persisted. Reported alongside `needsResize`
+   * so the caller can surface the takeover for a credit-only change (a readable
+   * confirmation moment) even though no compute/disk provisioning is owed.
+   * False for a machine/storage-only change or a no-op.
+   */
+  creditChanged: boolean;
 }
 
 export interface UseChangeTiersResult {
@@ -251,7 +259,7 @@ export function useChangeTiers({
     // Nothing diverged from the current config — treat as a successful no-op so
     // the caller closes the modal without opening the resize takeover.
     if (pending.length === 0) {
-      return { needsResize: false };
+      return { needsResize: false, creditChanged: false };
     }
 
     const results = await Promise.all(pending);
@@ -270,6 +278,11 @@ export function useChangeTiers({
       (r) => r.ok && r.dimension === "storage",
     );
     const needsResize = machineUpgradeSucceeded || storageSucceeded;
+    // A persisted credit-bundle change surfaces the takeover without owing any
+    // compute/disk provisioning, so it is tracked apart from `needsResize`.
+    const creditSucceeded = results.some(
+      (r) => r.ok && r.dimension === "credit",
+    );
 
     const failures = results.filter((r) => !r.ok);
     if (failures.length > 0) {
@@ -282,14 +295,16 @@ export function useChangeTiers({
         )
         .join(" ");
       toast.error(message);
-      // A resource dimension can persist server-side even when another one
-      // fails, so still surface the resize takeover to provision it; the caller
+      // A resource or credit dimension can persist server-side even when another
+      // one fails, so still surface the takeover for what landed; the caller
       // closes the modal. Only when nothing landed do we return null to hold the
       // modal open for a retry.
-      return needsResize ? { needsResize: true } : null;
+      return needsResize || creditSucceeded
+        ? { needsResize, creditChanged: creditSucceeded }
+        : null;
     }
 
-    return { needsResize };
+    return { needsResize, creditChanged: creditSucceeded };
   };
 
   return { changeTiers, isPending, current, eligible, currentReady };


### PR DESCRIPTION
## Summary
- Surface `creditChanged` from `changeTiers` and open the provisioning takeover on `needsResize || creditChanged`, so an in-place credits-only change shows the full-screen takeover (which already dwells for a readable moment) instead of only a toast.
- `needsResize` semantics unchanged; machine/storage/no-op behavior unchanged.

Part of plan: credit-change-takeover.md (PR 1)