### PR TITLE
feat(routes): integrate the route host into the daemon lifecycle

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -32,6 +32,7 @@ import { syncWorkspaceIdentityToPlatform } from "../platform/sync-identity.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { runProviderConnectionsBackfill } from "../providers/inference/backfill.js";
 import { initializeProviders } from "../providers/registry.js";
+import { startRouteHost } from "../routes/control.js";
 import { floorSeqAbove } from "../runtime/assistant-stream-state.js";
 import {
   initAuthSigningKey,
@@ -702,6 +703,10 @@ export async function runDaemon(): Promise<void> {
   // Spawn the resource monitor as a child of the daemon when enabled, off the
   // main event loop.
   startMonitoring();
+
+  // Pre-warm the route host subprocess when `userRoutes.host.enabled` is set
+  // (no-op otherwise). Fire-and-forget — never blocks boot.
+  startRouteHost();
 
   // The runtime HTTP server is up; broadcast the fresh daemon status so
   // connected clients pick up the transition.

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -14,6 +14,7 @@ import { stopQdrantManager } from "../persistence/embeddings/qdrant-manager.js";
 import { stopConsentRefresh } from "../platform/consent-cache.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import { runHook } from "../plugins/pipeline.js";
+import { stopRouteHost } from "../routes/control.js";
 import { stopRuntimeHttpServer } from "../runtime/http-server.js";
 import { stopScheduler } from "../schedule/scheduler.js";
 import { getSubagentManager } from "../subagent/index.js";
@@ -169,6 +170,10 @@ async function shutdown(): Promise<void> {
 
   // Stop the resource monitor process if it's actually running.
   stopMonitoring();
+
+  // Stop the route host process if it's running (spawned at boot, via the CLI,
+  // or lazily on a request) so it isn't orphaned past daemon shutdown.
+  stopRouteHost();
 
   try {
     await stopMcpServerManager();

--- a/assistant/src/routes/__tests__/control.test.ts
+++ b/assistant/src/routes/__tests__/control.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the route host daemon-lifecycle entry points.
+ *
+ * `startRouteHost` is gated on `userRoutes.host.enabled` (opt-in pre-warm);
+ * `stopRouteHost` signals the host if running and never throws. The config,
+ * spawn, and stop dependencies are mocked so the tests assert the wrappers'
+ * gating and error-swallowing, not the underlying PID-file mechanics.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as realLoader from "../../config/loader.js";
+import * as realLogger from "../../util/logger.js";
+import * as realWorkerProcess from "../../util/worker-process.js";
+
+let enabled = false;
+let spawnArgs: Array<{ options?: { detached?: boolean } }> = [];
+let stopStatus: { status: "running" | "not_running"; pid?: number } = {
+  status: "not_running",
+};
+let stopCalls = 0;
+let stopThrows: Error | null = null;
+
+mock.module("../../config/loader.js", () => ({
+  ...realLoader,
+  getConfigReadOnly: () => ({ userRoutes: { host: { enabled } } }),
+}));
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+mock.module("../../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () => noopLogger,
+}));
+
+mock.module("../../util/worker-process.js", () => ({
+  ...realWorkerProcess,
+  spawnWorkerProcess: async (args: { options?: { detached?: boolean } }) => {
+    spawnArgs.push(args);
+    return { pid: 4242, alreadyRunning: false };
+  },
+  stopWorkerProcess: () => {
+    stopCalls++;
+    if (stopThrows) {
+      throw stopThrows;
+    }
+    return stopStatus;
+  },
+  probeWorkerPidFile: () => stopStatus,
+}));
+
+const { startRouteHost, stopRouteHost } = await import("../control.js");
+
+beforeEach(() => {
+  enabled = false;
+  spawnArgs = [];
+  stopStatus = { status: "not_running" };
+  stopCalls = 0;
+  stopThrows = null;
+});
+
+describe("startRouteHost", () => {
+  test("is a no-op when the route host is disabled", async () => {
+    enabled = false;
+    startRouteHost();
+    await Promise.resolve();
+    expect(spawnArgs).toHaveLength(0);
+  });
+
+  test("spawns the host as a daemon child when enabled", async () => {
+    enabled = true;
+    startRouteHost();
+    await Promise.resolve();
+    expect(spawnArgs).toHaveLength(1);
+    expect(spawnArgs[0].options?.detached).toBe(false);
+  });
+});
+
+describe("stopRouteHost", () => {
+  test("signals the host when it is running", () => {
+    stopStatus = { status: "running", pid: 555 };
+    stopRouteHost();
+    expect(stopCalls).toBe(1);
+  });
+
+  test("is a no-op (never throws) when the host is not running", () => {
+    stopStatus = { status: "not_running" };
+    expect(() => stopRouteHost()).not.toThrow();
+    expect(stopCalls).toBe(1);
+  });
+
+  test("swallows errors from the stop call", () => {
+    stopThrows = new Error("kill EPERM");
+    expect(() => stopRouteHost()).not.toThrow();
+  });
+});

--- a/assistant/src/routes/control.ts
+++ b/assistant/src/routes/control.ts
@@ -3,16 +3,17 @@
  * entry point is `worker.ts`, which runs user-defined `/x/*` route handlers off
  * the daemon.
  *
- * The `assistant routes worker` CLI (via the `routes_worker_*` routes) needs to
+ * The daemon lifecycle ({@link startRouteHost} / {@link stopRouteHost}) and the
+ * `assistant routes worker` CLI (via the `routes_worker_*` routes) both need to
  * probe, spawn, and stop this process. The generic PID-file mechanics live in
  * `util/worker-process.ts`; this module binds them to the route host's PID path
  * and entry point.
  *
- * Note the route host is spawned *on demand*, not at boot: {@link RouteHostClient}
- * also spawns it lazily on the first request. Both share the same PID file, so a
- * CLI-initiated `start` and a lazy spawn cooperate — whichever loses the race
- * sees `alreadyRunning`. Likewise `stop` is only a pause: the next request
- * respawns the host.
+ * The host may be brought up three ways, all sharing one PID file so they
+ * cooperate (whoever loses a race sees `alreadyRunning`): pre-warmed at boot
+ * when enabled ({@link startRouteHost}), started via the CLI, or lazily on the
+ * first request ({@link RouteHostClient}). A `stop` is only a pause — the next
+ * request respawns it.
  */
 
 import { getConfigReadOnly } from "../config/loader.js";
@@ -84,9 +85,43 @@ export async function spawnRouteHostWorkerProcess(
  * (e.g. EPERM) — a not-running host is a no-op.
  */
 export function stopRouteHostWorkerProcess(): WorkerProcessStatus {
-  const status = probeRouteHostWorker();
-  if (status.status === "running") {
-    log.info({ pid: status.pid }, "Sending SIGTERM to route host process");
-  }
   return stopWorkerProcess(routeHostPidPath());
+}
+
+/**
+ * Daemon-lifecycle entry point: pre-warm the route host at boot, as a child of
+ * the daemon (so it appears in `assistant ps` and is torn down on shutdown).
+ *
+ * Only when enabled — the host is opt-in, so a disabled config is a no-op here
+ * (a request lazily spawns it if the flag is flipped on at runtime). Runs
+ * fire-and-forget: a spawn failure must never block boot.
+ */
+export function startRouteHost(): void {
+  if (!isRouteHostEnabled()) {
+    return;
+  }
+  void spawnRouteHostWorkerProcess({ detached: false })
+    .then((r) =>
+      log.info(
+        { pid: r.pid, alreadyRunning: r.alreadyRunning },
+        "Route host started at boot",
+      ),
+    )
+    .catch((err) => log.warn({ err }, "Failed to start route host at boot"));
+}
+
+/**
+ * Daemon-lifecycle entry point: SIGTERM the route host if it is running. Keyed
+ * off live state, not config — the host may have been spawned at boot, via
+ * `assistant routes worker start`, or lazily on a request. Never throws.
+ */
+export function stopRouteHost(): void {
+  try {
+    const status = stopRouteHostWorkerProcess();
+    if (status.status === "running") {
+      log.info({ pid: status.pid }, "Sent SIGTERM to route host process");
+    }
+  } catch (err) {
+    log.warn({ err }, "Failed to stop route host process (non-fatal)");
+  }
 }


### PR DESCRIPTION
## Prompt / plan

The last item on your route-host roadmap. Item 3 was "integrate to lifecycle **and** the http router" — #38847 did the http-router half (config-gated dispatch); this is the **lifecycle** half. Until now the host was never referenced in the daemon lifecycle, so a lazily-spawned host was never torn down on daemon shutdown (orphan risk) and there was no boot pre-warm when enabled. This mirrors how the daemon already manages the resource monitor (`startMonitoring`/`stopMonitoring`).

- **`routes/control.ts`** — two lifecycle entry points:
  - `startRouteHost()` — pre-warm at boot as a daemon child (so it shows in `assistant ps`), **gated on `userRoutes.host.enabled`** (a no-op when disabled; a request lazily spawns it if the flag is flipped on later). Fire-and-forget, so a spawn failure never blocks boot.
  - `stopRouteHost()` — SIGTERM the host if running (keyed off live state, not config — covers boot-, CLI-, and lazily-spawned hosts). Never throws.
  - `stopRouteHostWorkerProcess()` simplified to a pure stop; the lifecycle wrapper owns the "sent SIGTERM" log.
- **`daemon/lifecycle.ts`** — `startRouteHost()` alongside `startMonitoring()` once the runtime HTTP server is up.
- **`daemon/shutdown-handlers.ts`** — `stopRouteHost()` alongside `stopMonitoring()`.

## Test plan

- `routes/__tests__/control.test.ts` (5) — mocks config + worker-process and asserts: `startRouteHost` is a no-op when disabled and spawns as a daemon child (`detached:false`) when enabled; `stopRouteHost` signals a running host and swallows errors.
- `route-host-worker-routes.test.ts` + `user-route-dispatcher-host.test.ts` still green (18 total in the batch).
- `bunx tsc --noEmit`, prettier, eslint clean; pre-commit hooks pass.

## Where this leaves the feature

The subprocess route host is now complete end-to-end: **mechanism** (#38789) → **CLI ops** (#38836) → **config-gated dispatch** (#38847) → **lifecycle** (this). Flip `userRoutes.host.enabled` and `/x/*` handlers execute off-daemon, spawned at boot and torn down on shutdown, so a stalling route can no longer freeze the daemon.

Optional future work (beyond the original roadmap): a host **pool** for route-from-route isolation, and the **plugin-api out-of-process surface** (`publishEvent` / `runConversationTurn`).

## CLI verb checklist

No new routes — wires existing route-host control into daemon startup/shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FosQeirkpt7G1K2SSbMx1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01FosQeirkpt7G1K2SSbMx1N)_