### PR TITLE
feat(billing): add SpecChip presentational component

### DIFF
--- a/clients/web/src/domains/settings/billing/spec-chip.test.tsx
+++ b/clients/web/src/domains/settings/billing/spec-chip.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * Tests for SpecChip: verifies the compact label text renders and that the
+ * passed Lucide icon renders as an <svg>. Uses `renderToStaticMarkup` for a
+ * single-pass, DOM-free render.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Coins } from "lucide-react";
+
+import { SpecChip } from "./spec-chip";
+
+describe("SpecChip", () => {
+  test("renders the label text", () => {
+    const markup = renderToStaticMarkup(
+      <SpecChip icon={Coins} label="$25 credits" />,
+    );
+
+    expect(markup).toContain("$25 credits");
+  });
+
+  test("renders the passed icon as an svg", () => {
+    const markup = renderToStaticMarkup(
+      <SpecChip icon={Coins} label="$25 credits" />,
+    );
+
+    expect(markup).toContain("<svg");
+  });
+});

--- a/clients/web/src/domains/settings/billing/spec-chip.tsx
+++ b/clients/web/src/domains/settings/billing/spec-chip.tsx
@@ -1,0 +1,27 @@
+import type { LucideIcon } from "lucide-react";
+
+import { Typography } from "@vellumai/design-library/components/typography";
+
+export interface SpecChipProps {
+  icon: LucideIcon;
+  label: string;
+}
+
+/** A single plan-spec pill: an icon and a compact label (e.g. "$25 credits"). */
+export function SpecChip({ icon: Icon, label }: SpecChipProps) {
+  return (
+    <div className="flex h-8 items-center gap-1.5 rounded-lg bg-[var(--surface-overlay)] px-2 py-1.5">
+      <Icon
+        className="h-3.5 w-3.5 shrink-0 text-[var(--content-default)]"
+        aria-hidden
+      />
+      <Typography
+        as="span"
+        variant="body-medium-default"
+        className="whitespace-nowrap text-[var(--content-default)]"
+      >
+        {label}
+      </Typography>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add SpecChip icon+label pill for plan spec chips

Part of plan: billing-plan-section-cards.md (PR 2 of 4)