### PR TITLE
feat(billing): add absolute per-plan spec helper for plan cards

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -1,0 +1,67 @@
+import { Coins, Computer, HardDrive } from "lucide-react";
+import { describe, expect, test } from "bun:test";
+
+import type { ProPackage } from "@/domains/settings/billing/package-types";
+
+import { machineLabel, packageSpecs } from "./plan-spec";
+
+describe("packageSpecs", () => {
+  test("uses the free/base baseline for a null package", () => {
+    const specs = packageSpecs(null);
+    expect(specs.map((s) => s.label)).toEqual([
+      "Small Machine",
+      "$0 credits",
+      "4 GB",
+    ]);
+    expect(specs.map((s) => s.icon)).toEqual([Computer, Coins, HardDrive]);
+  });
+
+  test("reads a machine-less Pro package (Mighty) at the small baseline", () => {
+    const specs = packageSpecs({
+      key: "mighty",
+      name: "Mighty",
+      machine_size: null,
+      credits_usd: 25,
+      storage_gib: 10,
+    } as ProPackage);
+    expect(specs.map((s) => s.label)).toEqual([
+      "Small Machine",
+      "$25 credits",
+      "10 GB",
+    ]);
+  });
+
+  test("reads a package with an explicit machine size", () => {
+    const specs = packageSpecs({
+      machine_size: "medium",
+      credits_usd: 45,
+      storage_gib: 30,
+    } as ProPackage);
+    expect(specs.map((s) => s.label)).toEqual([
+      "Medium Machine",
+      "$45 credits",
+      "30 GB",
+    ]);
+  });
+
+  test("falls back to $0 credits when credits_usd is null", () => {
+    const specs = packageSpecs({
+      machine_size: "small",
+      credits_usd: null,
+      storage_gib: 8,
+    } as ProPackage);
+    expect(specs[1].label).toBe("$0 credits");
+  });
+});
+
+describe("machineLabel", () => {
+  test("returns Small for a null package", () => {
+    expect(machineLabel(null)).toBe("Small");
+  });
+
+  test("returns the human label for an explicit size", () => {
+    expect(machineLabel({ machine_size: "extra_large" } as ProPackage)).toBe(
+      "Extra Large",
+    );
+  });
+});

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -1,0 +1,44 @@
+import { Coins, Computer, HardDrive, type LucideIcon } from "lucide-react";
+
+import {
+  FREE_CREDITS_USD,
+  FREE_STORAGE_GIB,
+} from "@/domains/settings/billing/plan-tier-meta";
+import type { ProPackage } from "@/domains/settings/billing/package-types";
+import type { MachineSizeEnum } from "@/generated/api/types.gen";
+import { SIZE_LABEL } from "@/lib/billing/machine-sizes";
+
+/** A single spec chip: an icon and its label. */
+export interface PlanSpec {
+  icon: LucideIcon;
+  label: string;
+}
+
+/**
+ * The machine a package with no `machine_size` runs on — the small baseline
+ * shared by Free and machine-less Pro packages (e.g. Mighty).
+ */
+export const STANDARD_MACHINE_LABEL = "Small";
+
+/** Human machine-size label for a package (or the standard small machine). */
+export function machineLabel(pkg: ProPackage | null): string {
+  if (!pkg?.machine_size) {
+    return STANDARD_MACHINE_LABEL;
+  }
+  const size = pkg.machine_size as MachineSizeEnum;
+  return SIZE_LABEL[size] ?? pkg.machine_size;
+}
+
+/**
+ * The three absolute spec chips for a package, in mock order:
+ * machine → credits → storage. A `null` package uses the free/base baseline.
+ */
+export function packageSpecs(pkg: ProPackage | null): PlanSpec[] {
+  const credits = pkg?.credits_usd ?? FREE_CREDITS_USD;
+  const storage = pkg?.storage_gib ?? FREE_STORAGE_GIB;
+  return [
+    { icon: Computer, label: `${machineLabel(pkg)} Machine` },
+    { icon: Coins, label: `$${credits} credits` },
+    { icon: HardDrive, label: `${storage} GB` },
+  ];
+}

--- a/clients/web/src/domains/settings/billing/plan-tier-meta.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tier-meta.tsx
@@ -31,6 +31,14 @@ export const TIER_TRAITS: Record<
 export const FREE_STORAGE_GIB = 4;
 
 /**
+ * Monthly included credits ($USD) for the free/base plan. The plan catalog's
+ * BasePlan entry carries no credits field, so this is the baseline the plan
+ * card shows on the current-plan chip for a free user.
+ * TODO(confirm): verify the product-correct free credit grant (may be $0).
+ */
+export const FREE_CREDITS_USD = 0;
+
+/**
  * Vellum creature avatar for a plan tier. The ~48 kB bundled component payload
  * loads lazily; a same-size placeholder holds the layout until it resolves.
  */


### PR DESCRIPTION
## Summary
- Add packageSpecs() returning absolute machine/credits/storage chips
- Add FREE_CREDITS_USD baseline constant

Part of plan: billing-plan-section-cards.md (PR 1 of 4)