### PR TITLE
feat(web): first-run greeting offers three clickable scope options via ui_show choice

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -159,6 +159,7 @@ export function ActiveChatView() {
   const {
     didOnboarding,
     onboardingTasksEmpty,
+    onboardingKickoffHidden,
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,
@@ -555,6 +556,7 @@ export function ActiveChatView() {
 
     // Onboarding
     onboardingTasksEmpty,
+    onboardingKickoffHidden,
     didOnboarding,
     onboardingConversationId,
   };

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -164,6 +164,7 @@ export interface ChatMainPanelProps {
 
   // Onboarding (local state in ActiveChatView)
   onboardingTasksEmpty: boolean;
+  onboardingKickoffHidden: boolean;
   didOnboarding: boolean;
   onboardingConversationId: string | null;
 }
@@ -235,6 +236,7 @@ export function ChatMainPanel({
   transcriptRef,
   uiContextRef,
   onboardingTasksEmpty,
+  onboardingKickoffHidden,
   didOnboarding,
   onboardingConversationId,
 }: ChatMainPanelProps) {
@@ -466,6 +468,7 @@ export function ChatMainPanel({
     didOnboarding,
     messages,
     onboardingTasksEmpty,
+    onboardingKickoffHidden,
     activeConversationId,
     onboardingConversationId,
     sendMessage,

--- a/clients/web/src/domains/chat/hooks/use-onboarding-choice.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-choice.test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+import { useOnboardingChoice } from "./use-onboarding-choice";
+
+afterEach(() => {
+  cleanup();
+});
+
+const CONVERSATION_ID = "conv-1";
+
+const greeting: DisplayMessage[] = [{ id: "m1", role: "assistant" }];
+
+/** All conditions satisfied for the card to show; tests override per-case. */
+function baseOptions() {
+  return {
+    isNative: true,
+    didOnboarding: true,
+    messages: greeting,
+    onboardingTasksEmpty: true,
+    onboardingKickoffHidden: false,
+    activeConversationId: CONVERSATION_ID,
+    onboardingConversationId: CONVERSATION_ID,
+    sendMessage: mock(() => {}),
+  };
+}
+
+describe("useOnboardingChoice", () => {
+  test("shows the card when all conditions are met", () => {
+    const { result } = renderHook(() => useOnboardingChoice(baseOptions()));
+    expect(result.current.showOnboardingChoice).toBe(true);
+  });
+
+  test("suppresses the card for hidden-kickoff handoffs (research onboarding)", () => {
+    // The research-onboarding "Let's chat" handoff auto-sends a hidden kickoff
+    // whose scripted greeting carries its own choice surface; the legacy card
+    // must not stack a second chooser on top of it.
+    const { result } = renderHook(() =>
+      useOnboardingChoice({ ...baseOptions(), onboardingKickoffHidden: true }),
+    );
+    expect(result.current.showOnboardingChoice).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-onboarding-choice.ts
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-choice.ts
@@ -3,8 +3,9 @@
  *
  * Phase transitions: `pending` → `visible` → `dismissed`.
  * The card becomes visible when all conditions are met (native, did onboarding,
- * greeting arrived, no tasks selected during prechat). Once dismissed it never
- * reappears.
+ * greeting arrived, no tasks selected during prechat, and the handoff did not
+ * auto-send a hidden kickoff that scripts its own first-reply UI). Once
+ * dismissed it never reappears.
  */
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
@@ -17,6 +18,13 @@ interface UseOnboardingChoiceOptions {
   didOnboarding: boolean;
   messages: DisplayMessage[];
   onboardingTasksEmpty: boolean;
+  /**
+   * True when the onboarding handoff auto-sent a hidden kickoff message
+   * (`initialMessageHidden` on the pre-chat context). Those flows (research
+   * onboarding's "Let's chat") script the assistant's first reply — including
+   * its own choice surface — so the legacy card must never stack on top.
+   */
+  onboardingKickoffHidden: boolean;
   activeConversationId: string | null;
   onboardingConversationId: string | null;
   sendMessage: (content: string) => void;
@@ -34,6 +42,7 @@ export function useOnboardingChoice({
   didOnboarding,
   messages,
   onboardingTasksEmpty,
+  onboardingKickoffHidden,
   activeConversationId,
   onboardingConversationId,
   sendMessage,
@@ -70,6 +79,7 @@ export function useOnboardingChoice({
       phase === "pending" &&
       isNative &&
       didOnboarding &&
+      !onboardingKickoffHidden &&
       greetingSeenRef.current &&
       onboardingTasksEmpty &&
       activeConversationId === onboardingConversationId
@@ -79,7 +89,7 @@ export function useOnboardingChoice({
     }
     // `messages` is not read in the body; listed so this effect re-fires
     // when a new message arrives and greetingSeenRef may have just latched.
-  }, [phase, isNative, didOnboarding, messages, onboardingTasksEmpty, activeConversationId, onboardingConversationId]);
+  }, [phase, isNative, didOnboarding, messages, onboardingTasksEmpty, onboardingKickoffHidden, activeConversationId, onboardingConversationId]);
 
   // Dismiss if the user switches to a different conversation.
   useEffect(() => {

--- a/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
@@ -44,6 +44,13 @@ export interface UseOnboardingOrchestratorResult {
   didOnboarding: boolean;
   /** Whether the user skipped task selection during prechat. */
   onboardingTasksEmpty: boolean;
+  /**
+   * Whether the onboarding handoff auto-sends a hidden kickoff message
+   * (`initialMessageHidden` on the pre-chat context). Hidden-kickoff flows
+   * (research onboarding's "Let's chat") script their own first-reply UI, so
+   * the in-chat onboarding choice card must not stack on top of it.
+   */
+  onboardingKickoffHidden: boolean;
   /** The draft conversation created for the onboarding flow. */
   onboardingConversationId: string | null;
   /** Shared with `useSendMessage` — pre-chat context for the first send. */
@@ -62,6 +69,7 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
   const onboardingDraftConversationIdRef = useRef<string | null>(null);
   const [didOnboarding, setDidOnboarding] = useState(false);
   const [onboardingTasksEmpty, setOnboardingTasksEmpty] = useState(false);
+  const [onboardingKickoffHidden, setOnboardingKickoffHidden] = useState(false);
   const [onboardingConversationId, setOnboardingConversationId] = useState<string | null>(null);
 
   // Consume the `?onboarding=1` signal left by `/onboarding/hatching` when
@@ -107,9 +115,15 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
     try {
       const raw = globalThis.sessionStorage?.getItem("onboarding.prechat.pendingContext");
       if (!raw) return;
-      const ctx = JSON.parse(raw) as { tasks?: string[] };
+      const ctx = JSON.parse(raw) as {
+        tasks?: string[];
+        initialMessageHidden?: boolean;
+      };
       if (Array.isArray(ctx.tasks) && ctx.tasks.length === 0) {
         setOnboardingTasksEmpty(true);
+      }
+      if (ctx.initialMessageHidden === true) {
+        setOnboardingKickoffHidden(true);
       }
     } catch {
       // Storage or parse failure — ignore.
@@ -119,6 +133,7 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
   return {
     didOnboarding,
     onboardingTasksEmpty,
+    onboardingKickoffHidden,
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,

--- a/clients/web/src/domains/onboarding/first-run-scope.ts
+++ b/clients/web/src/domains/onboarding/first-run-scope.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared contract for the first-run scope options offered by the "Let's chat"
+ * kickoff greeting (see `lets-chat-kickoff.ts`).
+ *
+ * These are wire values: they ride `ui_show` choice-option `data` payloads
+ * through the daemon and come back on click as the surface action's data.
+ * Downstream consumers (e.g. click telemetry in the chat domain) match on
+ * them, so they must stay stable — do not rename or reorder.
+ *
+ * Chat-domain code may import this module; the import direction mirrors
+ * `PreChatOnboardingContext` in `prechat.ts` — onboarding exports, other
+ * domains import.
+ */
+export const FIRST_RUN_SCOPE_DATA_KEY = "firstRunScope";
+export const FIRST_RUN_SCOPES = ["work", "personal", "both"] as const;
+export type FirstRunScope = (typeof FIRST_RUN_SCOPES)[number];
+export const FIRST_RUN_SCOPE_OPTION_IDS: Record<FirstRunScope, string> = {
+  work: "scope_work",
+  personal: "scope_personal",
+  both: "scope_both",
+};

--- a/clients/web/src/domains/onboarding/lets-chat-kickoff.test.ts
+++ b/clients/web/src/domains/onboarding/lets-chat-kickoff.test.ts
@@ -7,6 +7,10 @@
 
 import { describe, expect, test } from "bun:test";
 
+import {
+  FIRST_RUN_SCOPE_DATA_KEY,
+  FIRST_RUN_SCOPE_OPTION_IDS,
+} from "./first-run-scope";
 import { buildLetsChatKickoffMessage } from "./lets-chat-kickoff";
 
 describe("buildLetsChatKickoffMessage", () => {
@@ -14,16 +18,35 @@ describe("buildLetsChatKickoffMessage", () => {
     const msg = buildLetsChatKickoffMessage("Quill");
     expect(msg).toContain("Your name is Quill — introduce yourself as Quill.");
     expect(msg).toContain("You're about to begin your first conversation.");
-    expect(msg).toContain("don't use `recall` or read any files");
   });
 
-  test("instructs a closing question that is specific and answerable", () => {
+  test("keeps the greeting short and forbids tools beyond the one ui_show", () => {
     const msg = buildLetsChatKickoffMessage("Quill");
-    expect(msg).toContain(
-      "exactly one short question about something specific you already know",
-    );
-    expect(msg).toContain("five words or less");
-    expect(msg).toContain("Never ask what they want to do");
+    expect(msg).toContain("Keep it short!");
+    expect(msg).toContain("don't use `recall`, don't read any files");
+    expect(msg).toContain("no tool calls other than that single `ui_show`");
+  });
+
+  test("instructs one ui_show choice call with the three scope options", () => {
+    const msg = buildLetsChatKickoffMessage("Quill");
+    expect(msg).toContain("`ui_show` tool exactly once");
+    expect(msg).toContain('"choice"');
+    for (const id of Object.values(FIRST_RUN_SCOPE_OPTION_IDS)) {
+      expect(msg).toContain(id);
+    }
+    expect(msg).toContain(FIRST_RUN_SCOPE_DATA_KEY);
+  });
+
+  test("frames the options as starters, not a menu", () => {
+    const msg = buildLetsChatKickoffMessage("Quill");
+    expect(msg).toContain("conversation starters, not a menu");
+    expect(msg).toContain("invite free-form answers");
+  });
+
+  test("drops the old closed-question instruction", () => {
+    const msg = buildLetsChatKickoffMessage("Quill");
+    expect(msg).not.toContain("five words or less");
+    expect(msg).not.toContain("Never ask what they want to do");
   });
 
   test("omits the name line when no name was picked", () => {

--- a/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
+++ b/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
@@ -1,3 +1,14 @@
+import {
+  FIRST_RUN_SCOPE_DATA_KEY,
+  FIRST_RUN_SCOPE_OPTION_IDS,
+  type FirstRunScope,
+} from "./first-run-scope";
+
+/** Renders one choice option's wire fields (id + data payload) for the prompt. */
+function optionWire(scope: FirstRunScope): string {
+  return `id \`${FIRST_RUN_SCOPE_OPTION_IDS[scope]}\`, \`data: {"${FIRST_RUN_SCOPE_DATA_KEY}": "${scope}"}\``;
+}
+
 /**
  * Hidden kickoff sent on the user's behalf when they hit "Let's chat" at the
  * end of the research-onboarding flow. It drives the assistant's first
@@ -10,6 +21,11 @@
  * out or IDENTITY.md's name is still a placeholder when the turn's system
  * prompt is built, the model would otherwise invent a name for its very first
  * words to the user.
+ *
+ * The greeting ends with a scope question backed by a single `ui_show` choice
+ * surface offering three clickable options (work / personal / both). The
+ * option ids and `data` payloads come from `first-run-scope.ts` — they're the
+ * wire contract a click-telemetry consumer matches on.
  */
 export function buildLetsChatKickoffMessage(assistantName?: string): string {
   const name = assistantName?.trim();
@@ -18,6 +34,13 @@ export function buildLetsChatKickoffMessage(assistantName?: string): string {
     : "";
   return `You're about to begin your first conversation.${nameLine}
 Respond with a warm and engaging greeting. Be interesting, be real. This is your chance to get to know and impress the user.
-End with exactly one short question about something specific you already know about them (see your Onboarding Context) — a question they can answer in five words or less. If you know almost nothing about them yet, ask one specific, concrete question anyway (still five-word-answerable). Never ask what they want to do, what you're getting into, or anything else open-ended: an open question hands a stranger a blank page.
-Keep it short! For this opening greeting only, don't use \`recall\` or read any files — just say hello. (This applies to the greeting alone; use your tools normally for everything the user asks afterward.)`;
+End the greeting text with one short question asking where they'd like to start, phrased so nothing feels off the table (e.g. "…or is there anything else on your mind entirely?").
+Then call the \`ui_show\` tool exactly once: \`surface_type: "choice"\`, \`data.selectionMode: "single"\`, no \`title\` (or a very short one), and exactly three options in this order:
+1. ${optionWire("work")} — a concrete offer grounded in their work or role from your Onboarding Context (occupation, daily tools, work-related research findings).
+2. ${optionWire("personal")} — a concrete offer grounded in their hobbies, interests, or personal research findings.
+3. ${optionWire("both")} — an "all of the above" invitation.
+An option's title becomes the user's visible reply bubble when they tap it, so every title must read naturally in the user's voice — imperative or neutral, ten words or fewer (e.g. "Help me plan my next ride", never "I can plan your next ride"). Put richer color in your own voice in each option's one-sentence \`description\` instead.
+These options are conversation starters, not a menu: never imply the user is limited to them, and your closing question itself must invite free-form answers.
+After the \`ui_show\` result comes back, stop — output no further text. If \`ui_show\` errors or is unavailable, just end with the text question alone; the user will type. Do not set \`await_action\` or \`persistent\`.
+Keep it short! For this opening greeting only, don't use \`recall\`, don't read any files, and make no tool calls other than that single \`ui_show\`. (This applies to the greeting alone; use your tools normally for everything the user asks afterward.)`;
 }


### PR DESCRIPTION
## Summary
- Rewrites the Let's-chat kickoff prompt: greeting now ends with a scope question plus one ui_show choice surface offering three personalized options (work / personal / both)
- Adds shared first-run-scope constants (option ids + data marker) for the upcoming click-telemetry consumer
- No daemon changes: choice clicks already render, echo a visible user bubble, and deliver the scope payload to the model

Part of plan: first-message-scope-options.md (PR 1 of 2)