### PR TITLE
fix(web): voice-room close collapses into the avatar, no V flash (JARVIS-1344)

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -308,12 +308,19 @@ export function VoiceRoomColorLook({
       />
 
       {/* The avatar color fills in behind the body so coverage is end-to-end
-          even where the body shape has gaps/spikes. */}
+          even where the body shape has gaps/spikes. On close it clears early so
+          the shrinking body silhouette — not the full-screen rectangle — is what
+          collapses into the origin. */}
       <motion.div
         className="absolute inset-0"
         style={{ backgroundColor: look.bgHex }}
         initial={reduce ? false : { opacity: 0 }}
         animate={{ opacity: 1 }}
+        exit={
+          reduce
+            ? { opacity: 0 }
+            : { opacity: 0, transition: { duration: 0.2, ease: "easeIn" } }
+        }
         transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.35 }}
       />
 
@@ -340,6 +347,18 @@ export function VoiceRoomColorLook({
                 }
           }
           animate={{ scale: 1, x: 0, y: 0 }}
+          // Close reverses the grow: the body shrinks back to its "avatar on the
+          // screen" size at the entry origin.
+          exit={
+            reduce
+              ? { opacity: 0 }
+              : {
+                  scale: bodyGeometry.startScale,
+                  x: bodyGeometry.startX,
+                  y: bodyGeometry.startY,
+                  transition: { duration: 0.4, ease: "easeIn" },
+                }
+          }
           transition={
             reduce
               ? { duration: 0 }
@@ -908,6 +927,19 @@ export function VoiceRoomEyes({
               scale: [0.35, 1, 1],
             }
           : { x: 0, y: 0, scale: 1 }
+      }
+      // Close reverses the grow: the eyes shrink back to the entry origin
+      // alongside the body, so the whole avatar shape collapses to the point.
+      exit={
+        reduce
+          ? { opacity: 0 }
+          : {
+              x: geometry.startX,
+              y: geometry.startY,
+              scale: 0.35,
+              opacity: 0,
+              transition: { duration: 0.4, ease: "easeIn" },
+            }
       }
       transition={
         playEntrance && !entranceDone

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -39,7 +39,7 @@
  * is. The key handler attaches only while the room is mounted.
  */
 
-import { useEffect, type CSSProperties } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Mic, MicOff, Square, X } from "lucide-react";
 
@@ -125,7 +125,7 @@ function VoiceRoomOverlay() {
   // `speaking` stays set across a mid-turn tool run; gate `responding` on audio
   // actually flowing so the room reads `thinking` while the tool works.
   const assistantAudioActive = useLiveVoiceStore.use.assistantAudioActive();
-  const assistantId = useLiveVoiceStore.use.assistantId();
+  const liveAssistantId = useLiveVoiceStore.use.assistantId();
   const muted = useLiveVoiceStore.use.muted();
   // Turn-scoped ■ stop is hands-free-only (a manual session's interrupt ends
   // the whole session); room sessions are hands-free except on the
@@ -133,8 +133,17 @@ function VoiceRoomOverlay() {
   const handsFree = useLiveVoiceStore.use.handsFree();
   // Viewport point the entrance grows from (the tapped voice button); null →
   // the color look falls back to its screen-center origin.
-  const entryOrigin = useLiveVoiceStore.use.entryOrigin();
+  const liveEntryOrigin = useLiveVoiceStore.use.entryOrigin();
   const reduce = useReducedMotion();
+
+  // The room is one session, so freeze the avatar identity and the entry origin
+  // at mount. Ending the session calls the store `reset()` (assistantId /
+  // entryOrigin → null) while the room is still mounted for its exit animation;
+  // reading the live values there would flip the look to the "V" fallback
+  // mid-close and drop the shrink-to-origin target. The captured values hold for
+  // the room's whole lifetime (both are session-constant).
+  const [assistantId] = useState(liveAssistantId);
+  const [entryOrigin] = useState(liveEntryOrigin);
 
   const visual = toVoiceAvatarVisual(state, reconnecting, assistantAudioActive);
   // The label + sr-only announcement must follow the same audio-aware mapping as
@@ -219,6 +228,10 @@ function VoiceRoomOverlay() {
       }}
       initial={reduce ? false : { opacity: 0 }}
       animate={{ opacity: 1 }}
+      // On close the chrome and rectangular backgrounds fade, while the avatar
+      // shape itself shrinks back toward the entry origin — the color look's
+      // body + eyes and the void look's centered avatar each own that exit — so
+      // the room collapses into the avatar, not a shrinking rectangle.
       exit={{ opacity: 0 }}
       transition={{ duration: reduce ? 0 : 0.4 }}
     >
@@ -342,6 +355,18 @@ function VoiceRoomOverlay() {
           className="relative z-0"
           initial={reduce ? false : { scale: 0.8, y: 24, opacity: 0 }}
           animate={{ scale: 1, y: 0, opacity: 1 }}
+          // Exit is the inverse of the entry spring: the centered avatar settles
+          // back down and shrinks away rather than fading in place.
+          exit={
+            reduce
+              ? { opacity: 0 }
+              : {
+                  scale: 0.8,
+                  y: 24,
+                  opacity: 0,
+                  transition: { duration: 0.32, ease: "easeIn" },
+                }
+          }
           transition={reduce ? { duration: 0 } : AVATAR_ENTER_SPRING}
         >
           <VoiceAvatar


### PR DESCRIPTION
## Summary
- **No more "V" flash on close.** Ending a session calls the store `reset()` (`assistantId`/`entryOrigin` → null) while the room is still mounted for its exit; reading the live values there flipped the look to the void `VoiceAvatar(null)` fallback for the fade. The room is one session, so `assistantId` and `entryOrigin` are now frozen at mount — the teardown reset can't flip the look or drop the exit target.
- **Close is the inverse of the open.** Instead of a flat cross-fade, the color look's **body silhouette + eyes shrink back to the entry origin** (the tapped voice button) while the rectangular color fill clears early, so the room collapses into the avatar shape rather than a shrinking screen-rectangle. The void look's centered avatar reverses its entry spring. Reduced-motion keeps a plain fade.

## Original prompt
Closing voice mode briefly flashed a "V" logo and just faded out. Remove the flash and make the close animation basically the inverse of the open — which grows the avatar's body shape out of the tapped point — so it transforms back into the avatar shape. Tracked as JARVIS-1344.