### PR TITLE
feat(web): show the credit-bundle change in the in-place provisioning takeover

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -153,19 +153,29 @@ mock.module("@/utils/use-bundled-avatar-components", () => ({
 // revealed in resize mode without driving its own provisioning polls.
 // The full loading → "You're all set!" flow is owned by
 // billing-onboarding-modal.test.tsx's resize-mode suite.
+//
+// Captures the credit tier the page threads in so the credit-change confirmation
+// (and the switch path's deliberate omission of it) can be asserted directly.
+let takeoverResizeCredits: string | null | undefined;
 mock.module(
   "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal",
   () => ({
     BillingOnboardingModal: ({
       open,
       mode,
+      resizeCredits,
     }: {
       open: boolean;
       mode?: string;
-    }) =>
-      open ? (
+      resizeCredits?: string | null;
+    }) => {
+      if (open) {
+        takeoverResizeCredits = resizeCredits;
+      }
+      return open ? (
         <div data-testid="resize-takeover" data-mode={mode ?? "checkout"} />
-      ) : null,
+      ) : null;
+    },
   }),
 );
 
@@ -543,6 +553,7 @@ beforeEach(() => {
   plansFixture = null;
   onboardingFixture = null;
   toastSuccessCalls.length = 0;
+  takeoverResizeCredits = undefined;
 });
 
 afterEach(() => {
@@ -590,6 +601,9 @@ describe("PlansPage — Pro package switch (change-package)", () => {
 
     const takeover = await findByTestId("resize-takeover");
     expect(takeover.getAttribute("data-mode")).toBe("resize");
+    // The switch path sources no bundle, so it threads none — a stale value
+    // from a prior custom change must never surface on this takeover.
+    expect(takeoverResizeCredits).toBeUndefined();
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
   });
 
@@ -955,6 +969,8 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
     // (which no-ops for active Pro) is never touched.
     const takeover = await findByTestId("resize-takeover");
     expect(takeover.getAttribute("data-mode")).toBe("resize");
+    // The bundle changed alongside the machine, so it's threaded through too.
+    expect(takeoverResizeCredits).toBe("credits_50");
     expect(upgradeCall).toBeNull();
   });
 
@@ -981,6 +997,9 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
     // a readable confirmation moment.
     const takeover = await findByTestId("resize-takeover");
     expect(takeover.getAttribute("data-mode")).toBe("resize");
+    // The applied bundle is threaded through so the takeover can confirm it —
+    // the credit-only path never reaches the WAITING credits chip.
+    expect(takeoverResizeCredits).toBe("credits_50");
     expect(upgradeCall).toBeNull();
   });
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -41,6 +41,7 @@ import {
   organizationsBillingSubscriptionUpgradeCreateMutation,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type {
+  CreditTierEnum,
   MachineSizeEnum,
   ProPlan,
   SubscriptionUpgradeRequestRequest,
@@ -151,6 +152,17 @@ export function PlansPage() {
   // the grow-only resize the platform already fired server-side (no redundant
   // client-driven resize).
   const [resizeTakeoverOpen, setResizeTakeoverOpen] = useState(false);
+  // The credit bundle just applied by an in-place custom change, threaded to
+  // the takeover so its terminal phase can confirm a credit-only change (which
+  // owes no resize and so never reaches the WAITING credits chip). `undefined`
+  // when the change didn't touch credits. Deliberately NOT sourced from the
+  // checkout intent: the package-switch path also opens this takeover without
+  // seeding one, so reading the intent there could surface a stale prior
+  // checkout's credits — this in-memory value stays scoped to the change that
+  // set it.
+  const [resizeCreditTier, setResizeCreditTier] = useState<
+    CreditTierEnum | null | undefined
+  >(undefined);
 
   const subscription = subscriptionQuery.data;
   const proPlan = plansQuery.data?.plans.find(
@@ -323,6 +335,10 @@ export function PlansPage() {
       if (relation === "downgrade") {
         toast.success(`Downgraded to ${target.name}.`);
       } else {
+        // The switch path seeds no credit value — its bundle isn't sourced
+        // cleanly here, and a stale one from a prior custom change must not
+        // leak onto this takeover. Clear it so the terminal phase stays neutral.
+        setResizeCreditTier(undefined);
         setResizeTakeoverOpen(true);
       }
     };
@@ -359,7 +375,12 @@ export function PlansPage() {
       if (result.needsResize || result.creditChanged) {
         // A machine/storage change needs the assistant to provision the new
         // ceiling; a credit change owes no provisioning but still opens the same
-        // in-tab takeover for a readable confirmation moment.
+        // in-tab takeover for a readable confirmation moment. Thread the applied
+        // bundle only when it actually changed so the terminal phase can confirm
+        // it — a resize-only change leaves this undefined.
+        setResizeCreditTier(
+          result.creditChanged ? selection.creditTier : undefined,
+        );
         setResizeTakeoverOpen(true);
       } else {
         toast.success("Plan updated.");
@@ -495,6 +516,7 @@ export function PlansPage() {
           mode="resize"
           open={resizeTakeoverOpen}
           onClose={() => setResizeTakeoverOpen(false)}
+          resizeCredits={resizeCreditTier}
         />
 
         <p className="mt-10 text-center text-[12px] font-medium text-[var(--content-tertiary)]">

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -17,15 +17,18 @@ import { MemoryRouter } from "react-router";
 import {
   assistantsDomainsListOptions,
   assistantsDomainsListSetQueryData,
+  organizationsBillingPlansRetrieveQueryKey,
   organizationsBillingSubscriptionOnboardingRetrieveSetQueryData,
 } from "@/generated/api/@tanstack/react-query.gen";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import type {
   Assistant,
+  CreditTierEnum,
   EnsureProvisionedResponse,
   OnboardingStateResponse,
   OperationalStatus,
   PaginatedAssistantDomainList,
+  PlanListResponse,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
 import { readCheckoutIntent, saveCheckoutIntent } from "@/lib/billing/checkout-intent";
@@ -134,6 +137,34 @@ function makeEnsureResponse(
   };
 }
 
+/** A pro catalog with a `credits_50` tier the terminal credits chip resolves. */
+function plansWithCredits(): PlanListResponse {
+  return {
+    plans: [
+      {
+        id: "pro",
+        name: "Pro",
+        base_lookup_key: "pro_base",
+        base_price_cents: 2000,
+        billing_interval: "month",
+        included_features: [],
+        machine_tiers: [],
+        storage_tiers: [],
+        credit_tiers: [
+          {
+            tier: "credits_50",
+            label: "$50 credits/mo",
+            credits_usd: 50,
+            price_cents: 5000,
+            lookup_key: "credits_50_key",
+          },
+        ],
+        packages: [],
+      },
+    ],
+  };
+}
+
 function makeDomains(hasDomain: boolean): PaginatedAssistantDomainList {
   return {
     count: hasDomain ? 1 : 0,
@@ -232,10 +263,23 @@ const BACKGROUND_LINE =
  */
 const TEST_DWELL_MS = 250;
 
-function renderModal({ mode }: { mode?: "checkout" | "resize" } = {}) {
+function renderModal({
+  mode,
+  resizeCredits,
+  plans,
+}: {
+  mode?: "checkout" | "resize";
+  resizeCredits?: CreditTierEnum | null;
+  plans?: PlanListResponse;
+} = {}) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+  // Seed the plan catalog so the terminal credits chip resolves its label
+  // without a fetch (the credits hook reads this shared query).
+  if (plans) {
+    client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
+  }
   const onClose = mock(() => {});
   const view = render(
     <MemoryRouter>
@@ -246,6 +290,7 @@ function renderModal({ mode }: { mode?: "checkout" | "resize" } = {}) {
           dwellMs={TEST_DWELL_MS}
           phaseMinMs={0}
           mode={mode}
+          resizeCredits={resizeCredits}
         />
       </QueryClientProvider>
     </MemoryRouter>,
@@ -1008,6 +1053,29 @@ describe("BillingOnboardingModal — resize mode", () => {
       { timeout: 5000 },
     );
     expect(queryByText("Super package")).toBeNull();
+  });
+
+  test("confirms an applied credit bundle on the terminal phase", async () => {
+    subscriptionPlanId = "pro";
+    const { client, getByText } = renderModal({
+      mode: "resize",
+      resizeCredits: "credits_50",
+      plans: plansWithCredits(),
+    });
+
+    await waitFor(
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+
+    assistantResponse = makeAssistant("large", 50);
+    await client.invalidateQueries();
+    await waitFor(() => expect(getByText("All done!")).toBeTruthy(), {
+      timeout: 5000,
+    });
+    // The threaded bundle is confirmed on the terminal phase — a credit change
+    // never reaches the WAITING credits chip, so this is its only surface.
+    expect(getByText("$50 credits/mo")).toBeTruthy();
   });
 
   test(

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { assistantsDomainsListQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import type { CreditTierEnum } from "@/generated/api/types.gen";
 import {
   clearCheckoutIntent,
   readCheckoutIntent,
@@ -67,6 +68,13 @@ export interface BillingOnboardingModalProps {
    * step shows only when it is newly usable (entitled AND no domain yet).
    */
   mode?: "checkout" | "resize";
+  /**
+   * Resize mode only: the credit tier just applied by an in-place change, so
+   * the takeover's terminal phase can confirm a credit-bundle change the phase
+   * machine would otherwise show nothing for. `undefined` = no credit change.
+   * Ignored in checkout mode, where credits ride the stashed intent instead.
+   */
+  resizeCredits?: CreditTierEnum | null;
 }
 
 export function BillingOnboardingModal({
@@ -75,6 +83,7 @@ export function BillingOnboardingModal({
   dwellMs,
   phaseMinMs,
   mode = "checkout",
+  resizeCredits,
 }: BillingOnboardingModalProps) {
   const isResize = mode === "resize";
   const queryClient = useQueryClient();
@@ -379,6 +388,7 @@ export function BillingOnboardingModal({
           state={provisioning.state}
           softWaiting={provisioning.softWaiting}
           intent={intent}
+          resizeCredits={isResize ? resizeCredits : undefined}
           targets={targets ?? EMPTY_DIMENSIONS}
           fromSnapshot={provisioning.actualsSnapshot ?? EMPTY_DIMENSIONS}
           celebrating={routingSettled}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -365,6 +365,45 @@ describe("done / not_applicable", () => {
     expect(queryByTestId("provisioning-apply")).toBeNull();
     await waitFor(() => expect(onCelebrationEnd).toHaveBeenCalledTimes(1));
   });
+
+  test("not_applicable confirms an applied credit bundle with the catalog label", () => {
+    // A credit-only in-place change owes no resize, so it lands here — the only
+    // surface where its bundle can be confirmed (the WAITING credits chip never
+    // shows).
+    const { getByText } = renderState({
+      state: "NOT_APPLICABLE",
+      resizeCredits: "credits_50",
+    });
+
+    expect(getByText("Your plan is ready")).toBeTruthy();
+    expect(getByText("Credits")).toBeTruthy();
+    expect(getByText("$50 credits/mo")).toBeTruthy();
+  });
+
+  test("not_applicable falls back to plain copy when the bundle can't resolve", () => {
+    // "No extra credits" (null tier) still counts as a change, so it confirms
+    // without a catalog label rather than leaving the phase blank.
+    const { getByText, queryByText } = renderState({
+      state: "NOT_APPLICABLE",
+      resizeCredits: null,
+    });
+
+    expect(getByText("Credits updated")).toBeTruthy();
+    expect(queryByText(/credits\/mo/)).toBeNull();
+  });
+
+  test("done confirms an applied credit bundle alongside the target chips", () => {
+    const { getByText } = renderState({
+      state: "DONE",
+      targets: { machineSize: "large", storageGib: 100 },
+      fromSnapshot: { machineSize: "small", storageGib: 30 },
+      resizeCredits: "credits_50",
+    });
+
+    expect(getByText("All done!")).toBeTruthy();
+    expect(getByText("Large")).toBeTruthy();
+    expect(getByText("$50 credits/mo")).toBeTruthy();
+  });
 });
 
 describe("stalled", () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import type { CreditTierEnum } from "@/generated/api/types.gen";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
 import { MACHINE_TIER_LABEL, SIZE_LABEL } from "@/lib/billing/machine-sizes";
@@ -27,7 +28,10 @@ import {
   buildResourceChanges,
   type ResourceChangeKey,
 } from "./resource-changes";
-import { useProvisioningCredits } from "./use-provisioning-credits";
+import {
+  useCreditTierLabel,
+  useProvisioningCredits,
+} from "./use-provisioning-credits";
 import { useRotatingIndex } from "./use-rotating-index";
 import { useHeldPhase } from "./use-held-phase";
 import {
@@ -100,6 +104,16 @@ export interface ProvisioningStateProps {
   softWaiting: boolean;
   /** The checkout selection stashed before the Stripe redirect. */
   intent: CheckoutIntent | null;
+  /**
+   * The credit tier just applied by an in-place resize change, threaded from
+   * the plans page so the terminal phase can confirm a credit-bundle change —
+   * a credit-only change skips WAITING/RESIZING, where the checkout-driven
+   * credits chip lives, so this is its only surface. `undefined` = no credit
+   * change (omit the chip); a tier or explicit `null` ("No extra credits") =
+   * show the confirmation. Distinct from `intent` on purpose: resize mode never
+   * reads the checkout intent, so a stale one can't leak in here.
+   */
+  resizeCredits?: CreditTierEnum | null;
   targets: ProvisioningDimensions;
   /** Pre-resize actuals rendered as the "from" side of the resource chips. */
   fromSnapshot: ProvisioningDimensions;
@@ -494,6 +508,7 @@ export function ProvisioningState({
   state,
   softWaiting,
   intent,
+  resizeCredits,
   targets,
   fromSnapshot,
   celebrating,
@@ -507,6 +522,11 @@ export function ProvisioningState({
   dwellMs = PROVISION_MIN_DWELL_MS,
   phaseMinMs = PROVISION_PHASE_MIN_MS,
 }: ProvisioningStateProps) {
+  // `undefined` = no credit change; a tier or explicit null both surface the
+  // terminal confirmation (see the `resizeCredits` prop).
+  const showCreditConfirmation = resizeCredits !== undefined;
+  const creditConfirmationLabel = useCreditTierLabel(resizeCredits ?? null);
+
   const onCelebrationEndRef = useRef(onCelebrationEnd);
   useEffect(() => {
     onCelebrationEndRef.current = onCelebrationEnd;
@@ -579,6 +599,31 @@ export function ProvisioningState({
     );
   }
 
+  // Confirmation chip for a credit-only (or credit-inclusive) in-place change,
+  // shown on the terminal phase. Resolves to the catalog label ("$50
+  // credits/mo") when known, matching the WAITING credits chip; falls back to
+  // a plain "Credits updated" for the "No extra credits" choice or before the
+  // catalog resolves, so the terminal phase is never left blank.
+  function creditConfirmationChip() {
+    if (!showCreditConfirmation) {
+      return null;
+    }
+    return (
+      <ChipRow>
+        {creditConfirmationLabel != null ? (
+          <DimensionChip
+            icon={RESOURCE_CHIP_ICON.credits}
+            label="Credits"
+            to={creditConfirmationLabel}
+            done
+          />
+        ) : (
+          <TextChip label="Credits updated" />
+        )}
+      </ChipRow>
+    );
+  }
+
   function renderPhase() {
     if (heldState === "CONFIRMING") {
       return (
@@ -619,12 +664,18 @@ export function ProvisioningState({
         <>
           <Copy status="All done!" />
           <TargetChips targets={targets} fromSnapshot={fromSnapshot} done />
+          {creditConfirmationChip()}
         </>
       );
     }
 
     if (heldState === "NOT_APPLICABLE") {
-      return <Copy status="Your plan is ready" />;
+      return (
+        <>
+          <Copy status="Your plan is ready" />
+          {creditConfirmationChip()}
+        </>
+      );
     }
 
     if (heldState === "STALLED") {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
@@ -19,7 +19,9 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
 }));
 
-const { useProvisioningCredits } = await import("./use-provisioning-credits");
+const { useProvisioningCredits, useCreditTierLabel } = await import(
+  "./use-provisioning-credits"
+);
 
 /** A pro-plan catalog with a `credits_50` tier and a Mighty package on it. */
 function plansResponse(): PlanListResponse {
@@ -204,5 +206,61 @@ describe("useProvisioningCredits", () => {
         plansResponse(),
       ),
     ).toBeNull();
+  });
+});
+
+describe("useCreditTierLabel", () => {
+  beforeEach(() => {
+    orgReady = true;
+  });
+
+  function renderLabel(
+    creditTier: Parameters<typeof useCreditTierLabel>[0],
+    plans?: PlanListResponse,
+  ): { value: string | null; client: QueryClient } {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    if (plans) {
+      client.setQueryData(organizationsBillingPlansRetrieveQueryKey(), plans);
+    }
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children);
+    const value = renderHook(() => useCreditTierLabel(creditTier), { wrapper })
+      .result.current;
+    return { value, client };
+  }
+
+  test("resolves a credit tier's catalog label", () => {
+    expect(renderLabel("credits_50", plansResponse()).value).toBe(
+      "$50 credits/mo",
+    );
+  });
+
+  test("returns null while the catalog is unresolved", () => {
+    expect(renderLabel("credits_50").value).toBeNull();
+  });
+
+  test("returns null for a tier absent from the catalog", () => {
+    expect(renderLabel("credits_100", plansResponse()).value).toBeNull();
+  });
+
+  test("returns null — and holds the lookup — for a null tier", () => {
+    const { value, client } = renderLabel(null, plansResponse());
+    expect(value).toBeNull();
+    expect(
+      client.getQueryState(organizationsBillingPlansRetrieveQueryKey())
+        ?.fetchStatus ?? "idle",
+    ).toBe("idle");
+  });
+
+  test("holds the lookup until the org is ready", () => {
+    orgReady = false;
+    const { value, client } = renderLabel("credits_50");
+    expect(value).toBeNull();
+    expect(
+      client.getQueryState(organizationsBillingPlansRetrieveQueryKey())
+        ?.fetchStatus ?? "idle",
+    ).toBe("idle");
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { organizationsBillingPlansRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
-import type { ProPlan } from "@/generated/api/types.gen";
+import type { CreditTierEnum, ProPlan } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
 
@@ -49,4 +49,33 @@ export function useProvisioningCredits(
   }
 
   return null;
+}
+
+/**
+ * Resolves a single credit tier's human-readable label from the shared plan
+ * catalog, for the in-place resize takeover's terminal "credits updated" chip.
+ * Mirrors `useProvisioningCredits`'s custom-intent resolution but takes the tier
+ * directly — the resize path threads the just-applied tier, not a stashed
+ * checkout intent. Returns null while the catalog loads, when no tier is given
+ * (e.g. the "No extra credits" choice), or when the tier can't be resolved.
+ * Display-only.
+ */
+export function useCreditTierLabel(
+  creditTier: CreditTierEnum | null | undefined,
+): string | null {
+  const orgReady = useIsOrgReady();
+  // Gate the same way the sibling provisioning queries do: without a ready org
+  // the request carries no `Vellum-Organization-Id` and fails.
+  const { data } = useQuery({
+    ...organizationsBillingPlansRetrieveOptions(),
+    enabled: orgReady && creditTier != null,
+  });
+
+  if (creditTier == null) {
+    return null;
+  }
+  const proPlan = data?.plans.find((p): p is ProPlan => p.id === "pro");
+  return (
+    proPlan?.credit_tiers?.find((t) => t.tier === creditTier)?.label ?? null
+  );
 }


### PR DESCRIPTION
## Summary
- A credits-only in-place change now shows a 'credits updated' chip/copy on the takeover's terminal phase, driven by an explicit resize-credits value threaded from plans-page (not the sessionStorage checkout intent, to avoid a stale intent on the package-switch path).

Part of plan: credit-change-takeover.md (PR 2)