### PR TITLE
feat(web): profile editor drops the connection field for catalog providers

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -611,6 +611,45 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     }
   });
 
+  test("an unbound openai-compatible profile keeps its provider label in edit mode", async () => {
+    render(
+      <Wrapper>
+        <ProfileEditorModal
+          isOpen
+          mode="edit"
+          profileName="my-local"
+          initialValues={
+            {
+              name: "my-local",
+              provider: "openai-compatible",
+              model: "my-model",
+            } as never
+          }
+          existingNames={["my-local"]}
+          connections={[
+            {
+              ...makeConnection("lm-studio", "openai-compatible"),
+              models: [{ id: "my-model" }],
+            },
+            {
+              ...makeConnection("vllm-box", "openai-compatible"),
+              models: [{ id: "other-model" }],
+            },
+          ]}
+          assistantId={ASSISTANT_ID}
+          onSave={() => Promise.resolve()}
+          onCancel={() => {}}
+        />
+      </Wrapper>,
+    );
+
+    // No endpoint entry matches the unbound state; the bare protocol value
+    // keeps the trigger labeled instead of falling to the placeholder.
+    await waitFor(() => {
+      expect(providerTrigger().textContent?.trim()).toBe("OpenAI-compatible");
+    });
+  });
+
   test("a legacy-shape managed profile presents as Vellum in edit mode", async () => {
     // Managed profiles store their real upstream (anthropic) bound to the
     // vellum connection; the editor must present them as "Vellum".

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -325,17 +325,15 @@ beforeEach(async () => {
   // Seed a hydrated pre-gate version: the save path awaits
   // whenAssistantVersionKnown(), and an unhydrated store would stall each
   // save until that helper's timeout. Gate-on tests override per-test.
-  const { useAssistantIdentityStore } = await import(
-    "@/stores/assistant-identity-store"
-  );
+  const { useAssistantIdentityStore } =
+    await import("@/stores/assistant-identity-store");
   useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.11");
 });
 
 afterEach(async () => {
   cleanup();
-  const { useAssistantIdentityStore } = await import(
-    "@/stores/assistant-identity-store"
-  );
+  const { useAssistantIdentityStore } =
+    await import("@/stores/assistant-identity-store");
   useAssistantIdentityStore.getState().clearIdentity();
 });
 
@@ -500,22 +498,58 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     expect(document.body.textContent).not.toContain("Endpoint");
   });
 
-  test("openai-compatible providers keep the endpoint picker", async () => {
-    renderCreate([
-      makeConnection("lm-studio", "openai-compatible"),
-      makeConnection("vllm-box", "openai-compatible"),
+  test("each openai-compatible endpoint is its own provider entry", async () => {
+    const lmStudio = {
+      ...makeConnection("lm-studio", "openai-compatible"),
+      models: [{ id: "model-1", displayName: "Model 1" }],
+    } as unknown as ProviderConnection;
+    const vllmBox = {
+      ...makeConnection("vllm-box", "openai-compatible"),
+      models: [{ id: "model-2", displayName: "Model 2" }],
+    } as unknown as ProviderConnection;
+    const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
+    const onSave = (name: string, entry: unknown) => {
+      saveCalls.push({ name, entry: entry as Record<string, unknown> });
+      return Promise.resolve();
+    };
+    renderCreate([lmStudio, vllmBox], onSave);
+
+    // Both endpoints are individual entries; no generic collapsed entry and
+    // no second field.
+    fireEvent.click(providerTrigger());
+    const optionLabels = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((o) => o.textContent?.trim());
+    expect(optionLabels).toEqual([
+      "lm-studio",
+      "vllm-box",
+      "+ Create new provider",
     ]);
-    selectProvider("OpenAI-compatible");
-    await waitFor(() => {
-      expect(document.body.textContent).toContain("Endpoint");
-    });
+    fireEvent.click(
+      Array.from(
+        document.querySelectorAll<HTMLElement>('[role="option"]'),
+      ).find((o) => o.textContent?.trim() === "lm-studio")!,
+    );
+    expect(document.body.textContent).not.toContain("Endpoint");
     expect(document.body.textContent).not.toContain("Connection (optional)");
+
+    selectModel("Model 1");
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    // The endpoint entry implies the provider plus its binding on the wire.
+    expect(saveCalls[0].entry.provider).toBe("openai-compatible");
+    expect(saveCalls[0].entry.provider_connection).toBe("lm-studio");
+    expect(saveCalls[0].entry.model).toBe("model-1");
   });
 
   test("a new-enough assistant gets the identity payload: provider vellum, no binding", async () => {
-    const { useAssistantIdentityStore } = await import(
-      "@/stores/assistant-identity-store"
-    );
+    const { useAssistantIdentityStore } =
+      await import("@/stores/assistant-identity-store");
     useAssistantIdentityStore
       .getState()
       .setIdentity("test-asst", "0.10.12", ASSISTANT_ID);
@@ -547,9 +581,8 @@ describe("ProfileEditorModal create mode — provider-first", () => {
   });
 
   test("an older assistant keeps the legacy payload byte-identical", async () => {
-    const { useAssistantIdentityStore } = await import(
-      "@/stores/assistant-identity-store"
-    );
+    const { useAssistantIdentityStore } =
+      await import("@/stores/assistant-identity-store");
     useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.11");
     try {
       const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
@@ -689,8 +722,10 @@ describe("ProfileEditorModal create mode — provider-first", () => {
       </Wrapper>,
     );
 
+    // The trigger renders the ENDPOINT entry (labeled by the row name) —
+    // not Vellum picker mode; the wire payload proves the distinction.
     await waitFor(() => {
-      expect(providerTrigger().textContent?.trim()).toBe("OpenAI-compatible");
+      expect(providerTrigger().textContent?.trim()).toBe("vellum");
     });
 
     await waitFor(() => {

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -490,6 +490,28 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     expect(saveCalls[0].entry.provider_connection).toBe("vellum-managed");
   });
 
+  test("catalog providers show no connection field, even with multiple keys", async () => {
+    renderCreate([
+      makeConnection("anthropic-personal"),
+      makeConnection("anthropic-personal-2"),
+    ]);
+    selectProvider("Anthropic");
+    expect(document.body.textContent).not.toContain("Connection");
+    expect(document.body.textContent).not.toContain("Endpoint");
+  });
+
+  test("openai-compatible providers keep the endpoint picker", async () => {
+    renderCreate([
+      makeConnection("lm-studio", "openai-compatible"),
+      makeConnection("vllm-box", "openai-compatible"),
+    ]);
+    selectProvider("OpenAI-compatible");
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Endpoint");
+    });
+    expect(document.body.textContent).not.toContain("Connection (optional)");
+  });
+
   test("a new-enough assistant gets the identity payload: provider vellum, no binding", async () => {
     const { useAssistantIdentityStore } = await import(
       "@/stores/assistant-identity-store"

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -39,6 +39,7 @@ import {
 import { deriveProfileDefaults } from "@/domains/settings/ai/profile-prefill";
 import {
   MANAGED_ROUTABLE_PROVIDERS,
+  OPENAI_COMPATIBLE_PROVIDER,
   VELLUM_CONNECTION_PROVIDER,
 } from "@/domains/settings/ai/constants";
 import {
@@ -46,7 +47,12 @@ import {
   parseVellumRoutedModel,
 } from "@/assistant/llm-model-catalog";
 import { assistantSupportsVellumProviderProfiles } from "@/lib/backwards-compat/vellum-profile-provider";
-import { providersServedByConnections } from "@/domains/settings/ai/provider-availability";
+import {
+  endpointPickerValue,
+  expandEndpointEntries,
+  parseEndpointPickerValue,
+  providersServedByConnections,
+} from "@/domains/settings/ai/provider-availability";
 import type {
   ConnectionProvider,
   ProviderConnection,
@@ -71,7 +77,7 @@ function connectionServesProvider(
   connectionProvider: string,
   selectedProvider: string,
 ): boolean {
-  if (connectionProvider === selectedProvider) return true;
+  if (connectionProvider === selectedProvider) {return true;}
   // Legacy wire shape: a managed profile stores its real upstream (e.g.
   // "fireworks") while binding to the provider-agnostic vellum connection.
   return (
@@ -145,7 +151,7 @@ export function ProfileEditorModal({
     <Modal.Root
       open={isOpen}
       onOpenChange={(next) => {
-        if (!next) onCancel();
+        if (!next) {onCancel();}
       }}
     >
       {isOpen ? (
@@ -378,7 +384,7 @@ function ProfileEditorModalInner({
   // as valid before the parent refetch lands.
   const effectiveConnections = useMemo(() => {
     const base = connections ?? [];
-    if (locallyCreatedConnections.length === 0) return base;
+    if (locallyCreatedConnections.length === 0) {return base;}
     const known = new Set(base.map((c) => c.name));
     return [
       ...base,
@@ -427,7 +433,7 @@ function ProfileEditorModalInner({
     if (initialValues?.provider_connection !== VELLUM_CONNECTION_PROVIDER) {
       return;
     }
-    if (provider !== (initialValues?.provider ?? "")) return;
+    if (provider !== (initialValues?.provider ?? "")) {return;}
     const boundRow = connections?.find(
       (c) => c.name === initialValues.provider_connection,
     );
@@ -446,7 +452,7 @@ function ProfileEditorModalInner({
   }, [profileName, mode, resetDirty]);
 
   function handleProviderChange(newProvider: ConnectionProvider) {
-    if (newProvider === provider) return;
+    if (newProvider === provider) {return;}
     setProvider(newProvider);
     setModel("");
     // Auto-select connection: if exactly one connection exists for the new
@@ -486,13 +492,13 @@ function ProfileEditorModalInner({
             (c.models ?? []).map((m) => m.id),
           ),
         );
-        if (!allModelIds.has(model)) setModel("");
+        if (!allModelIds.has(model)) {setModel("");}
       } else {
         const conn = availableConnectionsForProvider.find(
           (c) => c.name === newConnection,
         );
         const connModelIds = new Set((conn?.models ?? []).map((m) => m.id));
-        if (!connModelIds.has(model)) setModel("");
+        if (!connModelIds.has(model)) {setModel("");}
       }
     }
   }
@@ -504,16 +510,16 @@ function ProfileEditorModalInner({
     const catalogMatch = getModelsForProvider(provider).find(
       (m) => m.id === modelId,
     );
-    if (catalogMatch) return catalogMatch.displayName;
+    if (catalogMatch) {return catalogMatch.displayName;}
     for (const conn of availableConnectionsForProvider) {
       const match = (conn.models ?? []).find((m) => m.id === modelId);
-      if (match) return match.displayName ?? match.id;
+      if (match) {return match.displayName ?? match.id;}
     }
     return modelId;
   }
 
   function handleModelChange(newModel: string) {
-    if (newModel === model) return;
+    if (newModel === model) {return;}
     setModel(newModel);
     // Reset token sliders when model changes
     setMaxTokens(null);
@@ -539,7 +545,7 @@ function ProfileEditorModalInner({
     // The create form can't produce a vellum connection; bail before touching
     // any state so the sub-form can't get stuck.
     const newProvider = connection.provider;
-    if (newProvider === "vellum") return;
+    if (newProvider === "vellum") {return;}
     // Optimistically register the new connection locally so the binding is
     // valid immediately (the parent `connections` refetch below is async).
     setLocallyCreatedConnections((prev) =>
@@ -586,14 +592,14 @@ function ProfileEditorModalInner({
         : null;
 
   async function handleSave() {
-    if (isInvalid && !isReadOnly) return;
+    if (isInvalid && !isReadOnly) {return;}
     // Read-only (managed) profiles reach Save only via the enable flip — the
     // daemon rejects every other mutation on them — so the body is exactly
     // `{status: "active"}`. `mode: "merge"` tells the parent to skip its
     // delete-then-recreate cycle and send a single deep-merge PATCH so the
     // seed-owned fields (provider, model, advanced params) stay intact.
     if (isReadOnly) {
-      if (!hasViewModeChanges) return;
+      if (!hasViewModeChanges) {return;}
       setSaving(true);
       setSaveError(null);
       try {
@@ -663,11 +669,11 @@ function ProfileEditorModalInner({
         entry.provider_connection = wireBinding || null;
       } else {
         // In create mode omit optional fields that are still empty.
-        if (label.trim()) entry.label = label.trim();
-        if (description.trim()) entry.description = description.trim();
-        if (wireProvider) entry.provider = wireProvider;
-        if (wireModel) entry.model = wireModel;
-        if (wireBinding) entry.provider_connection = wireBinding;
+        if (label.trim()) {entry.label = label.trim();}
+        if (description.trim()) {entry.description = description.trim();}
+        if (wireProvider) {entry.provider = wireProvider;}
+        if (wireModel) {entry.model = wireModel;}
+        if (wireBinding) {entry.provider_connection = wireBinding;}
       }
       // Advanced params
       if (visibility.maxTokens && maxTokens !== null) {
@@ -867,16 +873,14 @@ function ProfileEditorModalInner({
   // Providers with at least one connection, plus the always-present "+ Create
   // new provider" sentinel. First-run empty state shows ONLY the sentinel.
   const createModeProviderOptions = useMemo(() => {
-    const opts: {
-      value: ConnectionProvider | typeof CREATE_NEW_PROVIDER_SENTINEL;
-      label: string;
-    }[] = providersServedByConnections(
+    const opts: { value: string; label: string }[] = expandEndpointEntries(
+      providersServedByConnections(
+        effectiveConnections,
+        activeAssistantIsSelfHosted,
+      ),
       effectiveConnections,
-      activeAssistantIsSelfHosted,
-    ).map((p) => ({
-      value: p,
-      label: PROVIDER_DISPLAY_NAMES[p] ?? p,
-    }));
+      (p) => PROVIDER_DISPLAY_NAMES[p] ?? p,
+    );
     opts.push({
       value: CREATE_NEW_PROVIDER_SENTINEL,
       label: "+ Create new provider",
@@ -894,7 +898,13 @@ function ProfileEditorModalInner({
           Provider
         </label>
         <Dropdown
-          value={creatingProvider ? CREATE_NEW_PROVIDER_SENTINEL : provider}
+          value={
+            creatingProvider
+              ? CREATE_NEW_PROVIDER_SENTINEL
+              : provider === OPENAI_COMPATIBLE_PROVIDER && providerConnection
+                ? endpointPickerValue(providerConnection)
+                : provider
+          }
           onChange={(next) => {
             if (next === CREATE_NEW_PROVIDER_SENTINEL) {
               setCreatingProvider(true);
@@ -905,7 +915,19 @@ function ProfileEditorModalInner({
               return;
             }
             setCreatingProvider(false);
-            handleProviderChange(next);
+            const endpoint = parseEndpointPickerValue(next);
+            if (endpoint) {
+              // Each endpoint entry implies the openai-compatible provider
+              // plus its binding; switching endpoints re-picks the model.
+              if (provider !== OPENAI_COMPATIBLE_PROVIDER) {
+                handleProviderChange(OPENAI_COMPATIBLE_PROVIDER);
+              } else {
+                setModel("");
+              }
+              setProviderConnection(endpoint);
+              return;
+            }
+            handleProviderChange(next as ConnectionProvider);
           }}
           placeholder="Select a provider…"
           aria-labelledby="profile-editor-provider-label"

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -10,10 +10,7 @@ import {
   PROVIDER_DISPLAY_NAMES,
 } from "@/assistant/llm-model-catalog";
 
-import {
-  OPENAI_COMPATIBLE_PROVIDER,
-  VELLUM_CONNECTION_PROVIDER,
-} from "@/domains/settings/ai/constants";
+import { OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/constants";
 import {
   providersServedByConnections,
   useSelectableCatalogProviders,
@@ -212,13 +209,13 @@ export function ProfileEditorProviderSection({
   const providerOptionsSource =
     connections === undefined ? allProvidersForPicker : visibleProviders;
 
-  // Show the Connection field whenever there's something meaningful to show:
-  //  - matching connections to pick from, OR
-  //  - a non-empty saved binding (so the user can see + clear stale state).
-  // Provider must be selected; without it we can't filter or label.
+  // The endpoint picker is openai-compatible-only: each custom endpoint is
+  // its own named entry, and the binding selects which endpoint (and model
+  // list) the profile uses. Catalog providers resolve their credential from
+  // the provider value alone — profiles carry no user-facing binding, and a
+  // stored one passes through the save path untouched.
   const showConnectionField =
-    provider !== "" &&
-    provider !== VELLUM_CONNECTION_PROVIDER &&
+    provider === OPENAI_COMPATIBLE_PROVIDER &&
     (availableConnectionsForProvider.length > 0 || providerConnection !== "");
 
   // For openai-compatible providers the static catalog is empty — use models
@@ -372,12 +369,12 @@ export function ProfileEditorProviderSection({
         </div>
       )}
 
-      {/* Connection — visible when matching connections exist or a saved
-          binding exists (even if stale). */}
+      {/* Endpoint — openai-compatible only: picks which named endpoint the
+          profile uses. */}
       {showConnectionField && (
         <div className="space-y-1">
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            Connection{" "}
+            Endpoint{" "}
             <span className="text-[var(--content-disabled)]">(optional)</span>
           </label>
           <Dropdown
@@ -389,9 +386,7 @@ export function ProfileEditorProviderSection({
                 ? [
                     {
                       value: "",
-                      label: `Any ${
-                        PROVIDER_DISPLAY_NAMES[provider] ?? provider
-                      } connection`,
+                      label: "Any endpoint",
                     },
                   ]
                 : []),
@@ -418,7 +413,7 @@ export function ProfileEditorProviderSection({
               as="p"
               className="text-(--system-negative-strong)"
             >
-              Connection &ldquo;{providerConnection}&rdquo; not found. Will be
+              Endpoint &ldquo;{providerConnection}&rdquo; not found. Will be
               cleared on save unless you pick another.
             </Typography>
           ) : null}

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -376,6 +376,19 @@ export function ProfileEditorProviderSection({
                     },
                   ]
                 : []),
+              // An unbound openai-compatible profile has no endpoint entry to
+              // select; the bare protocol value keeps the trigger labeled.
+              // Picking an endpoint entry from this same list binds it.
+              ...(provider === OPENAI_COMPATIBLE_PROVIDER && !providerConnection
+                ? [
+                    {
+                      value: OPENAI_COMPATIBLE_PROVIDER,
+                      label:
+                        PROVIDER_DISPLAY_NAMES[OPENAI_COMPATIBLE_PROVIDER] ??
+                        OPENAI_COMPATIBLE_PROVIDER,
+                    },
+                  ]
+                : []),
             ]}
           />
           {providerOptionsSource.length === 0 && !isReadOnly ? (

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -12,6 +12,9 @@ import {
 
 import { OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/constants";
 import {
+  endpointPickerValue,
+  expandEndpointEntries,
+  parseEndpointPickerValue,
   providersServedByConnections,
   useSelectableCatalogProviders,
 } from "@/domains/settings/ai/provider-availability";
@@ -54,9 +57,7 @@ function restrictsToSubscriptionModels(
     return false;
   }
   const selectedConn = providerConnection
-    ? availableConnectionsForProvider.find(
-        (c) => c.name === providerConnection,
-      )
+    ? availableConnectionsForProvider.find((c) => c.name === providerConnection)
     : undefined;
   if (selectedConn?.auth.type === "oauth_subscription") {
     return true;
@@ -209,15 +210,6 @@ export function ProfileEditorProviderSection({
   const providerOptionsSource =
     connections === undefined ? allProvidersForPicker : visibleProviders;
 
-  // The endpoint picker is openai-compatible-only: each custom endpoint is
-  // its own named entry, and the binding selects which endpoint (and model
-  // list) the profile uses. Catalog providers resolve their credential from
-  // the provider value alone — profiles carry no user-facing binding, and a
-  // stored one passes through the save path untouched.
-  const showConnectionField =
-    provider === OPENAI_COMPATIBLE_PROVIDER &&
-    (availableConnectionsForProvider.length > 0 || providerConnection !== "");
-
   // For openai-compatible providers the static catalog is empty — use models
   // from the selected connection instead. When no specific connection is
   // selected, merge models from all available openai-compatible connections.
@@ -347,15 +339,44 @@ export function ProfileEditorProviderSection({
             Provider
           </label>
           <Dropdown
-            value={provider}
-            onChange={onProviderChange}
+            value={
+              provider === OPENAI_COMPATIBLE_PROVIDER && providerConnection
+                ? endpointPickerValue(providerConnection)
+                : provider
+            }
+            onChange={(next) => {
+              const endpoint = parseEndpointPickerValue(next);
+              if (endpoint) {
+                // Each endpoint entry implies the openai-compatible
+                // provider plus its binding.
+                onProviderChange(OPENAI_COMPATIBLE_PROVIDER);
+                onConnectionChange(endpoint);
+                return;
+              }
+              onProviderChange(next as ConnectionProvider);
+            }}
             disabled={isReadOnly}
             placeholder="Select a provider…"
             aria-labelledby="profile-editor-provider-label"
-            options={providerOptionsSource.map((p) => ({
-              value: p,
-              label: PROVIDER_DISPLAY_NAMES[p] ?? p,
-            }))}
+            options={[
+              ...expandEndpointEntries(
+                providerOptionsSource,
+                connections ?? [],
+                (p) => PROVIDER_DISPLAY_NAMES[p] ?? p,
+              ),
+              // A bound endpoint whose row was deleted still renders on the
+              // trigger; the warning below explains the state.
+              ...(connectionNotFound &&
+              provider === OPENAI_COMPATIBLE_PROVIDER &&
+              providerConnection
+                ? [
+                    {
+                      value: endpointPickerValue(providerConnection),
+                      label: `${providerConnection} (not found)`,
+                    },
+                  ]
+                : []),
+            ]}
           />
           {providerOptionsSource.length === 0 && !isReadOnly ? (
             <Typography
@@ -369,55 +390,20 @@ export function ProfileEditorProviderSection({
         </div>
       )}
 
-      {/* Endpoint — openai-compatible only: picks which named endpoint the
-          profile uses. */}
-      {showConnectionField && (
-        <div className="space-y-1">
-          <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            Endpoint{" "}
-            <span className="text-[var(--content-disabled)]">(optional)</span>
-          </label>
-          <Dropdown
-            value={providerConnection}
-            onChange={onConnectionChange}
-            disabled={isReadOnly}
-            options={[
-              ...(availableConnectionsForProvider.length > 1
-                ? [
-                    {
-                      value: "",
-                      label: "Any endpoint",
-                    },
-                  ]
-                : []),
-              ...availableConnectionsForProvider.map((c) => ({
-                value: c.name,
-                label: c.label && c.label.trim() !== "" ? c.label : c.name,
-              })),
-              // Include the stale binding as an explicit option so the trigger
-              // renders its name. The warning below explains the state; on save,
-              // stale bindings are auto-cleared regardless.
-              ...(connectionNotFound
-                ? [
-                    {
-                      value: providerConnection,
-                      label: `${providerConnection} (not found)`,
-                    },
-                  ]
-                : []),
-            ]}
-          />
-          {connectionNotFound && !isReadOnly ? (
-            <Typography
-              variant="body-small-default"
-              as="p"
-              className="text-(--system-negative-strong)"
-            >
-              Endpoint &ldquo;{providerConnection}&rdquo; not found. Will be
-              cleared on save unless you pick another.
-            </Typography>
-          ) : null}
-        </div>
+      {/* No binding UI: catalog providers resolve their credential from the
+          provider value, and openai-compatible endpoints are their own
+          provider-picker entries. A stored reference to a deleted
+          credential must still fail loudly: saving clears it and dispatch
+          falls back to the provider's available key. */}
+      {connectionNotFound && !isReadOnly && (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-(--system-negative-strong)"
+        >
+          This profile referenced a credential that no longer exists. Saving
+          resets it to use the provider&rsquo;s available key.
+        </Typography>
       )}
 
       {/* Model — required once a provider is selected. The dropdown offers the

--- a/clients/web/src/domains/settings/ai/provider-availability.ts
+++ b/clients/web/src/domains/settings/ai/provider-availability.ts
@@ -3,6 +3,7 @@ import { useActiveAssistantIsSelfHosted } from "@/hooks/use-platform-gate";
 
 import {
   INFERENCE_PROVIDERS,
+  OPENAI_COMPATIBLE_PROVIDER,
   VELLUM_CONNECTION_PROVIDER,
 } from "@/domains/settings/ai/constants";
 import { CONNECTION_PROVIDERS } from "@/domains/settings/ai/provider-editor-constants";
@@ -101,4 +102,56 @@ export function providersServedByConnections(
     ),
   );
   return ordered;
+}
+
+// ---------------------------------------------------------------------------
+// Per-endpoint picker entries
+// ---------------------------------------------------------------------------
+
+/**
+ * Picker-value encoding for one openai-compatible endpoint presented as its
+ * own provider-like entry. Each custom endpoint is a named entry; the
+ * profile pickers list them individually (labeled by the endpoint) instead
+ * of one generic "OpenAI-compatible" entry plus a second field. The `::`
+ * separator cannot collide with provider ids, which contain no colons.
+ */
+const ENDPOINT_PICKER_PREFIX = `${OPENAI_COMPATIBLE_PROVIDER}::`;
+
+export function endpointPickerValue(connectionName: string): string {
+  return `${ENDPOINT_PICKER_PREFIX}${connectionName}`;
+}
+
+/** The endpoint name inside a picker value, or null for plain provider ids. */
+export function parseEndpointPickerValue(value: string): string | null {
+  return value.startsWith(ENDPOINT_PICKER_PREFIX)
+    ? value.slice(ENDPOINT_PICKER_PREFIX.length)
+    : null;
+}
+
+/**
+ * Provider dropdown entries with openai-compatible expanded per endpoint:
+ * every other provider is one entry keyed by its id; each openai-compatible
+ * connection is its own entry keyed by `endpointPickerValue(name)` and
+ * labeled by the endpoint's label (falling back to its name).
+ */
+export function expandEndpointEntries(
+  providers: readonly ConnectionProvider[],
+  connections: ProviderConnection[],
+  labelFor: (provider: ConnectionProvider) => string,
+): { value: string; label: string }[] {
+  const entries: { value: string; label: string }[] = [];
+  for (const provider of providers) {
+    if (provider !== OPENAI_COMPATIBLE_PROVIDER) {
+      entries.push({ value: provider, label: labelFor(provider) });
+      continue;
+    }
+    for (const c of connections) {
+      if (c.provider !== OPENAI_COMPATIBLE_PROVIDER) {continue;}
+      entries.push({
+        value: endpointPickerValue(c.name),
+        label: c.label && c.label.trim() !== "" ? c.label : c.name,
+      });
+    }
+  }
+  return entries;
 }


### PR DESCRIPTION
## Summary
- The profile editor has no connection UI left, for any provider. Catalog providers (Anthropic, OpenAI, …) resolve from the provider value alone. Each **openai-compatible endpoint is now its own entry in the Provider dropdown**, labeled by the endpoint — selecting "x AI" implies `provider: "openai-compatible"` plus its binding on the wire, so the modal is Provider → Model → Description for every case.
- Save-path semantics are unchanged for catalog providers: existing stored bindings pass through edit-saves untouched, single-credential auto-stamping continues. A stored reference to a deleted credential warns loudly before a save clears it (previously the hidden field would have cleared it silently).
- Shared helpers (`endpointPickerValue` / `parseEndpointPickerValue` / `expandEndpointEntries` in `provider-availability.ts`) drive both the create-mode picker and the edit-mode section, so the encoding lives in one place.
- Tests: catalog provider with multiple keys shows no connection/endpoint UI; each endpoint appears as its own picker entry and round-trips the right wire payload; a user row literally named "vellum" still never enters Vellum mode.

## Original prompt
Follow-up to the connection-removal effort (papertrail on #38102): Emmie was surprised to find connection fields still in the New Profile modal — and asked why an openai-compatible endpoint isn't simply a provider entry itself, which is the design of record ("each endpoint = its own named entry, presented as its own provider-like card"). The one-credential-per-provider question stays parked; this PR removes the user-facing connection concept from the profile editor completely without foreclosing either branch of that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)