### PR TITLE
feat(billing): add PlanSpecCard shared plan card

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-spec-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plan-spec-card.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests for PlanSpecCard: the shared, layout-only plan card used for both the
+ * light ("current") and dark ("recommended") columns in the billing Plan
+ * section. Verifies it renders the name, tagline, and spec chips; forwards
+ * `nameTestId`; forces the `data-theme` palette; and omits the divider + chip
+ * row when there are no specs.
+ *
+ * Rendered with `renderToStaticMarkup` (single-pass, no DOM) — so the lazy
+ * `PlanTierAvatar` compositor bundle is mocked to a placeholder, keeping the
+ * markup deterministic (mirrors plan-card.test.tsx).
+ */
+
+import { Coins, HardDrive } from "lucide-react";
+
+import { describe, expect, mock, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { PlanSpec } from "@/domains/settings/billing/plan-spec";
+
+// Render avatar placeholders; skip the lazy compositor bundle.
+mock.module("@/utils/use-bundled-avatar-components", () => ({
+  preloadBundledAvatarComponents: () => {},
+  useBundledAvatarComponents: () => null,
+}));
+
+const { PlanSpecCard } = await import("./plan-spec-card");
+
+const SPECS: PlanSpec[] = [
+  { icon: Coins, label: "$25 credits" },
+  { icon: HardDrive, label: "10 GB" },
+];
+
+describe("PlanSpecCard", () => {
+  test("renders name, tagline, spec labels, and the nameTestId", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard
+        tone="light"
+        tierKey="free"
+        name="Mighty"
+        nameTestId="plan-card-name"
+        tagline="A great starter plan"
+        specs={SPECS}
+      />,
+    );
+    expect(html).toContain("Mighty");
+    expect(html).toContain("A great starter plan");
+    expect(html).toContain("$25 credits");
+    expect(html).toContain("10 GB");
+    expect(html).toContain("plan-card-name");
+  });
+
+  test("omits the divider + chip row when specs is null", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard
+        tone="light"
+        tierKey="free"
+        name="Free"
+        specs={null}
+      />,
+    );
+    expect(html).toContain("Free");
+    expect(html).not.toContain("$25 credits");
+    expect(html).not.toContain("10 GB");
+  });
+
+  test("omits the divider + chip row when specs is empty", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard tone="light" tierKey="free" name="Free" specs={[]} />,
+    );
+    expect(html).toContain("Free");
+    expect(html).not.toContain("$25 credits");
+    expect(html).not.toContain("10 GB");
+  });
+
+  test("forces data-theme=\"dark\" when tone is dark", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard
+        tone="dark"
+        tierKey="free"
+        name="Recommended"
+        specs={SPECS}
+      />,
+    );
+    expect(html).toContain('data-theme="dark"');
+  });
+});

--- a/clients/web/src/domains/settings/billing/plan-spec-card.tsx
+++ b/clients/web/src/domains/settings/billing/plan-spec-card.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from "react";
+
+import { PlanTierAvatar } from "@/domains/settings/billing/plan-tier-meta";
+import type { PlanSpec } from "@/domains/settings/billing/plan-spec";
+import { SpecChip } from "@/domains/settings/billing/spec-chip";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+export interface PlanSpecCardProps {
+  /** Forces the card palette: "light" (current) or "dark" (recommended). */
+  tone: "light" | "dark";
+  /** Tier key ("free" or a `ProPackage.key`) — selects the creature avatar. */
+  tierKey: string;
+  name: string;
+  /** Test id applied to the plan-name node (e.g. "plan-card-name"). */
+  nameTestId?: string;
+  /** Rendered right of the name, e.g. a "Your Current Plan" / "Recommended" tag. */
+  tag?: ReactNode;
+  tagline?: string;
+  /** Absolute spec chips; when null/empty the divider + chip row are omitted. */
+  specs?: PlanSpec[] | null;
+  /** Header right-aligned action (e.g. the Upgrade button). */
+  action?: ReactNode;
+}
+
+/**
+ * One plan card in the billing "Plan" section. Layout-only: the parent owns
+ * the catalog data, the current-plan decision, and any CTA behavior. The
+ * forced `data-theme` scope resolves the semantic tokens to the mock's
+ * light (current) / dark (recommended) palettes.
+ */
+export function PlanSpecCard({
+  tone,
+  tierKey,
+  name,
+  nameTestId,
+  tag,
+  tagline,
+  specs,
+  action,
+}: PlanSpecCardProps) {
+  const hasSpecs = specs != null && specs.length > 0;
+  return (
+    <div
+      data-theme={tone}
+      className="flex flex-1 flex-col gap-4 rounded-xl bg-[var(--surface-base)] py-3 pl-3 pr-4"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <PlanTierAvatar tier={tierKey} />
+          <div className="flex min-w-0 flex-col gap-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <Typography
+                as="span"
+                variant="body-large-default"
+                className="text-[var(--content-default)]"
+                data-testid={nameTestId}
+              >
+                {name}
+              </Typography>
+              {tag}
+            </div>
+            {tagline ? (
+              <Typography
+                as="span"
+                variant="body-small-default"
+                className="text-[var(--content-tertiary)]"
+              >
+                {tagline}
+              </Typography>
+            ) : null}
+          </div>
+        </div>
+        {action}
+      </div>
+      {hasSpecs ? (
+        <>
+          <div className="h-px w-full bg-[var(--border-base)]" />
+          <div className="flex flex-wrap items-center gap-2">
+            {specs.map((spec) => (
+              <SpecChip key={spec.label} icon={spec.icon} label={spec.label} />
+            ))}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add PlanSpecCard: shared layout-only card (avatar, name, tag, tagline, chips) with forced data-theme palette

Part of plan: billing-plan-section-cards.md (PR 3 of 4)