### PR TITLE
Raise default user-route handler timeout to 2 minutes

### DIFF
--- a/assistant/src/runtime/routes/__tests__/user-route-dispatcher-host.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-route-dispatcher-host.test.ts
@@ -22,6 +22,7 @@ interface InvokeCall {
 let hostEnabled = false;
 let invokeImpl: (call: InvokeCall) => Promise<RouteInvokeResponse>;
 const invokeCalls: InvokeCall[] = [];
+const ctorOptions: ({ invokeTimeoutMs?: number } | undefined)[] = [];
 
 class FakeTimeoutError extends Error {
   constructor(public readonly timeoutMs: number) {
@@ -35,6 +36,9 @@ mock.module("../../../routes/control.js", () => ({
 }));
 mock.module("../../../routes/route-host-client.js", () => ({
   RouteHostClient: class {
+    constructor(options?: { invokeTimeoutMs?: number }) {
+      ctorOptions.push(options);
+    }
     async invoke(params: RouteInvokeParams, body: Uint8Array | null) {
       const call = { params, body };
       invokeCalls.push(call);
@@ -75,6 +79,7 @@ beforeEach(() => {
   hostEnabled = false;
   invokeImpl = async () => jsonResponse(200, { via: "host" });
   invokeCalls.length = 0;
+  ctorOptions.length = 0;
 });
 
 afterEach(() => {
@@ -178,6 +183,17 @@ describe("UserRouteDispatcher — route host delegation", () => {
       new Request("http://localhost/v1/x/down", { method: "GET" }),
     );
     expect(res.status).toBe(503);
+  });
+
+  test("drives the host client's timeout from the dispatcher's handler timeout", async () => {
+    // The in-process and route-host paths must share one per-request deadline,
+    // so the host client's hard-kill timeout is the dispatcher's, not the
+    // client's own default.
+    new UserRouteDispatcher({ context: context() });
+    expect(ctorOptions.at(-1)?.invokeTimeoutMs).toBe(120_000);
+
+    new UserRouteDispatcher({ context: context(), handlerTimeoutMs: 5_000 });
+    expect(ctorOptions.at(-1)?.invokeTimeoutMs).toBe(5_000);
   });
 
   test("unknown route 404s without touching the host", async () => {

--- a/assistant/src/runtime/routes/user-route-dispatcher.ts
+++ b/assistant/src/runtime/routes/user-route-dispatcher.ts
@@ -130,8 +130,8 @@ interface CachedModule {
   mtimeMs: number;
 }
 
-/** Default per-request timeout for user-defined route handlers (30 seconds). */
-const DEFAULT_HANDLER_TIMEOUT_MS = 30_000;
+/** Default per-request timeout for user-defined route handlers (2 minutes). */
+const DEFAULT_HANDLER_TIMEOUT_MS = 120_000;
 
 export class UserRouteDispatcher {
   private moduleCache = new Map<string, CachedModule>();
@@ -151,7 +151,13 @@ export class UserRouteDispatcher {
     this.handlerTimeoutMs =
       options.handlerTimeoutMs ?? DEFAULT_HANDLER_TIMEOUT_MS;
     this.context = Object.freeze({ ...options.context });
-    this.routeHostClient = new RouteHostClient();
+    // Both execution paths — in-process ({@link executeHandler}) and the route
+    // host subprocess — must honor the same per-request timeout, so the host
+    // client's hard-kill deadline is driven by the dispatcher's timeout rather
+    // than its own independent default.
+    this.routeHostClient = new RouteHostClient({
+      invokeTimeoutMs: this.handlerTimeoutMs,
+    });
   }
 
   /**


### PR DESCRIPTION
## Why

The `default-platform-hosted/reengage` route (used by the platform's "Send Reengagement Email" admin action) runs a background LLM turn to draft the email. That turn regularly takes longer than 30 seconds, but the user-route dispatcher's per-request handler timeout was **30s** — so the handler was being aborted before it could return a draft, surfacing as a failure in the admin UI.

Testing the end-to-end flow confirmed 30s is too aggressive for LLM-backed route handlers.

## What

- Bump `DEFAULT_HANDLER_TIMEOUT_MS` from `30_000` → `120_000` (2 minutes) in `user-route-dispatcher.ts`. This is the default per-request timeout for all user-defined `/x/*` route handlers; the constructor still accepts a per-instance `handlerTimeoutMs` override.
- **Unify both execution paths under one deadline.** Since the original reengage work, main added a route-host *subprocess* dispatch path (`dispatchViaHost`) whose hard-kill timeout came from `RouteHostClient`'s own independent `DEFAULT_INVOKE_TIMEOUT_MS = 30_000`. The dispatcher now constructs the host client with `invokeTimeoutMs: this.handlerTimeoutMs`, so the in-process handler timeout and the host subprocess's hard-kill timeout are driven by the same knob. Without this, flipping the (currently-disabled-by-default) `userRoutes.host.enabled` flag on would silently reintroduce the 30s cap.

## Tests

- Added a test asserting the dispatcher passes its `handlerTimeoutMs` through to the route host client (default `120_000`, and a custom override).
- Existing dispatcher + host-delegation suites pass (35 tests). The handler-timeout test injects its own short timeout, so it does not depend on the default constant.

## Rollout

Server-side daemon change only; no infra or client changes. The route host path remains disabled by default, so in-process is the live path today — this change keeps the 2-minute timeout from regressing if/when the host is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjoP9o4shUNs7uwNAaiLqN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjoP9o4shUNs7uwNAaiLqN)_