### PR TITLE
Single-source host-ui-snapshot proxy events from api/events

### DIFF
--- a/assistant/src/api/events/host-ui-snapshot.ts
+++ b/assistant/src/api/events/host-ui-snapshot.ts
@@ -1,0 +1,46 @@
+/**
+ * Host UI-snapshot proxy SSE events (`host_ui_snapshot_request` /
+ * `host_ui_snapshot_cancel`).
+ *
+ * Server → client instruction asking the desktop client to render a
+ * staged view of the app's own UI with the current workspace-theme
+ * tokens applied, capture it, and POST the PNG back to
+ * `/v1/host-ui-snapshot-result`. `host_ui_snapshot_cancel` withdraws an
+ * in-flight request. The stage contains only fixed generic content —
+ * never user data.
+ *
+ * Canonical wire-contract source. Daemon code imports the types
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+/** Staged compositions the web client can render for capture. */
+export const HostUiSnapshotViewSchema = z.enum(["sampler", "chat"]);
+
+export type HostUiSnapshotView = z.infer<typeof HostUiSnapshotViewSchema>;
+
+export const HostUiSnapshotRequestEventSchema = z.object({
+  type: z.literal("host_ui_snapshot_request"),
+  requestId: z.string(),
+  view: HostUiSnapshotViewSchema,
+  /**
+   * Validated workspace-theme tokens to apply on the stage. Absent when no
+   * valid theme exists — the stage renders the built-in base theme.
+   */
+  tokens: z.record(z.string(), z.string()).optional(),
+});
+
+export type HostUiSnapshotRequestEvent = z.infer<
+  typeof HostUiSnapshotRequestEventSchema
+>;
+
+export const HostUiSnapshotCancelEventSchema = z.object({
+  type: z.literal("host_ui_snapshot_cancel"),
+  requestId: z.string(),
+});
+
+export type HostUiSnapshotCancelEvent = z.infer<
+  typeof HostUiSnapshotCancelEventSchema
+>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -45,6 +45,10 @@ import {
   HostCuCancelEventSchema,
   HostCuRequestEventSchema,
 } from "./events/host-cu.js";
+import {
+  HostUiSnapshotCancelEventSchema,
+  HostUiSnapshotRequestEventSchema,
+} from "./events/host-ui-snapshot.js";
 import { IdentityChangedEventSchema } from "./events/identity-changed.js";
 import { InteractionResolvedEventSchema } from "./events/interaction-resolved.js";
 import { MemoryRecalledEventSchema } from "./events/memory-recalled.js";
@@ -304,6 +308,14 @@ export {
   type HostCuRequestEvent,
   HostCuRequestEventSchema,
 } from "./events/host-cu.js";
+export {
+  type HostUiSnapshotCancelEvent,
+  HostUiSnapshotCancelEventSchema,
+  type HostUiSnapshotRequestEvent,
+  HostUiSnapshotRequestEventSchema,
+  type HostUiSnapshotView,
+  HostUiSnapshotViewSchema,
+} from "./events/host-ui-snapshot.js";
 export {
   type IdentityChangedEvent,
   IdentityChangedEventSchema,
@@ -775,6 +787,8 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   HostBashRequestEventSchema,
   HostCuCancelEventSchema,
   HostCuRequestEventSchema,
+  HostUiSnapshotCancelEventSchema,
+  HostUiSnapshotRequestEventSchema,
   IdentityChangedEventSchema,
   InteractionResolvedEventSchema,
   MemoryRecalledEventSchema,

--- a/assistant/src/daemon/message-types/host-ui-snapshot.ts
+++ b/assistant/src/daemon/message-types/host-ui-snapshot.ts
@@ -1,36 +1,18 @@
 // Host UI-snapshot proxy types.
-// Asks the desktop client to render a staged view of the app's own UI
-// (`/assistant/theme-stage/:view`) in a hidden window with the current
-// workspace-theme tokens applied, capture it, and post the PNG back. The
-// stage contains only fixed generic content — never user data — so the
-// assistant can check its theming work without a human screenshotting the
-// app. Distinct from host-app-control's `observe` (which captures OTHER
-// applications' windows via the native helper).
+//
+// The server→client events (`host_ui_snapshot_request` / `_cancel`) and the
+// `HostUiSnapshotView` enum are single-sourced from their canonical `api/events`
+// wire schema. `HostUiSnapshotResultPayload` is the HTTP body the client POSTs
+// to /v1/host-ui-snapshot-result — a route contract, not an event.
 
-/** Staged compositions the web client can render for capture. */
-export type HostUiSnapshotView = "sampler" | "chat";
+import type { HostUiSnapshotCancelEvent } from "../../api/events/host-ui-snapshot.js";
+import type { HostUiSnapshotRequestEvent } from "../../api/events/host-ui-snapshot.js";
 
-export interface HostUiSnapshotRequestMessage {
-  type: "host_ui_snapshot_request";
-  requestId: string;
-  view: HostUiSnapshotView;
-  /**
-   * Validated workspace-theme tokens to apply on the stage. The daemon reads
-   * them from ui/theme.json at request time so the capture reflects the
-   * current file even before connected clients refetch. Absent when no valid
-   * theme exists — the stage renders the built-in base theme.
-   */
-  tokens?: Record<string, string>;
-}
-
-export interface HostUiSnapshotCancelMessage {
-  type: "host_ui_snapshot_cancel";
-  requestId: string;
-}
+export type { HostUiSnapshotView } from "../../api/events/host-ui-snapshot.js";
 
 export type _HostUiSnapshotServerMessages =
-  | HostUiSnapshotRequestMessage
-  | HostUiSnapshotCancelMessage;
+  | HostUiSnapshotRequestEvent
+  | HostUiSnapshotCancelEvent;
 
 /** Body the desktop client POSTs to /v1/host-ui-snapshot-result. */
 export interface HostUiSnapshotResultPayload {

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -470,13 +470,15 @@ export function useStreamEventHandler(
         // (e.g. user-prompt-submit). No web UI renders them yet.
         case "hook_event":
           break;
-        // Host-proxy instructions (bash / computer-use) targeting the desktop
-        // client. The web chat handler is a no-op — the web is not a host-proxy
-        // capability holder, so the hub never delivers these to it.
+        // Host-proxy instructions (bash / computer-use / ui-snapshot) targeting
+        // the desktop client. The web chat handler is a no-op — the web is not a
+        // host-proxy capability holder, so the hub never delivers these to it.
         case "host_bash_request":
         case "host_bash_cancel":
         case "host_cu_request":
         case "host_cu_cancel":
+        case "host_ui_snapshot_request":
+        case "host_ui_snapshot_cancel":
           break;
         // Service-group upgrade lifecycle broadcasts announcing a daemon
         // restart. The chat handler is a no-op; no web UI renders them yet.

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -102,6 +102,10 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   // Skill install/enable state-change broadcast — carries no `conversationId`;
   // clients refetch their skill list on receipt.
   "skills_state_changed",
+  // Host UI-snapshot proxy instructions — carry no `conversationId`; they target
+  // the desktop client, not a conversation.
+  "host_ui_snapshot_request",
+  "host_ui_snapshot_cancel",
   // Settings/config broadcasts (client-setting push, config.json change, sounds
   // change) carry no `conversationId` — they're app-wide, not conversation-scoped.
   "client_settings_update",


### PR DESCRIPTION
## Why

Continues the event-type unification effort — second slice of the `host_*` proxy group (after host-bash/host-cu in #38850).

## What

Authored `api/events/host-ui-snapshot.ts` and registered it in `AssistantEventSchema`:
- `host_ui_snapshot_request` / `host_ui_snapshot_cancel`
- the `HostUiSnapshotView` enum (`"sampler" | "chat"`), moved into the api schema and re-exported from the message-types module so `ui-snapshot-routes.ts` keeps importing it from there.

These are live broadcasts from `ui-snapshot-routes.ts` asking the desktop client to render a staged view of the app's own UI, capture it, and POST the PNG back to `/v1/host-ui-snapshot-result`. Built inline by the route, validated by typecheck.

**Preserved:** `HostUiSnapshotResultPayload` stays in the message-types file — it's the HTTP result body the client POSTs back, a route contract, not an event.

## Web

The events carry no `conversationId`, so they join the global stream-event set with no-op cases in the chat handler's exhaustive switch (the web isn't a host-proxy capability holder).

## Scope note

Remaining `host_*` domains, each with a wrinkle I'll handle in focused PRs:
- **host-app-control** — a nested 9-variant tool-input union to transcribe.
- **host-file / host-transfer** — multiple request variants share one `type` literal. I confirmed zod v4's `discriminatedUnion` **rejects union members** (`Invalid discriminated union option`), so these need a single loosened object schema (operation/direction as an enum discriminator with per-variant fields optional) rather than a true sub-union. I'll do that deliberately in their PR.
- **host-browser** — carries client→server events and is wired into the chrome-extension registry.

## Safety

No wire change (schema transcribed 1:1). Clean `typecheck:fast` + web `tsc` (fresh `openapi-ts`), eslint, prettier, `generate:openapi --check` (unchanged), api-events + SSE-parity suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_