### PR TITLE
refactor(web): share the credit-tier label resolver and trim resize-credits comments

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -152,14 +152,8 @@ export function PlansPage() {
   // the grow-only resize the platform already fired server-side (no redundant
   // client-driven resize).
   const [resizeTakeoverOpen, setResizeTakeoverOpen] = useState(false);
-  // The credit bundle just applied by an in-place custom change, threaded to
-  // the takeover so its terminal phase can confirm a credit-only change (which
-  // owes no resize and so never reaches the WAITING credits chip). `undefined`
-  // when the change didn't touch credits. Deliberately NOT sourced from the
-  // checkout intent: the package-switch path also opens this takeover without
-  // seeding one, so reading the intent there could surface a stale prior
-  // checkout's credits — this in-memory value stays scoped to the change that
-  // set it.
+  // The credit tier applied by an in-place change, threaded to the takeover's
+  // terminal confirmation. See `ProvisioningStateProps.resizeCredits`.
   const [resizeCreditTier, setResizeCreditTier] = useState<
     CreditTierEnum | null | undefined
   >(undefined);
@@ -335,9 +329,7 @@ export function PlansPage() {
       if (relation === "downgrade") {
         toast.success(`Downgraded to ${target.name}.`);
       } else {
-        // The switch path seeds no credit value — its bundle isn't sourced
-        // cleanly here, and a stale one from a prior custom change must not
-        // leak onto this takeover. Clear it so the terminal phase stays neutral.
+        // The switch path owes no credit confirmation; clear any prior tier.
         setResizeCreditTier(undefined);
         setResizeTakeoverOpen(true);
       }
@@ -373,11 +365,8 @@ export function PlansPage() {
       }
       setCustomPlanOpen(false);
       if (result.needsResize || result.creditChanged) {
-        // A machine/storage change needs the assistant to provision the new
-        // ceiling; a credit change owes no provisioning but still opens the same
-        // in-tab takeover for a readable confirmation moment. Thread the applied
-        // bundle only when it actually changed so the terminal phase can confirm
-        // it — a resize-only change leaves this undefined.
+        // Both a resize and a credit-only change open the takeover; thread the
+        // applied tier only when credits actually changed.
         setResizeCreditTier(
           result.creditChanged ? selection.creditTier : undefined,
         );
@@ -515,7 +504,12 @@ export function PlansPage() {
         <BillingOnboardingModal
           mode="resize"
           open={resizeTakeoverOpen}
-          onClose={() => setResizeTakeoverOpen(false)}
+          onClose={() => {
+            setResizeTakeoverOpen(false);
+            // Fail-safe: clear the tier so a stale credit chip can't resurface
+            // if an open path forgot to set it.
+            setResizeCreditTier(undefined);
+          }}
           resizeCredits={resizeCreditTier}
         />
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -69,10 +69,9 @@ export interface BillingOnboardingModalProps {
    */
   mode?: "checkout" | "resize";
   /**
-   * Resize mode only: the credit tier just applied by an in-place change, so
-   * the takeover's terminal phase can confirm a credit-bundle change the phase
-   * machine would otherwise show nothing for. `undefined` = no credit change.
-   * Ignored in checkout mode, where credits ride the stashed intent instead.
+   * Resize mode only: the credit tier applied by an in-place change, forwarded
+   * to the takeover. Ignored in checkout mode, where credits ride the stashed
+   * intent instead. See `ProvisioningStateProps.resizeCredits`.
    */
   resizeCredits?: CreditTierEnum | null;
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -1,9 +1,29 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { organizationsBillingPlansRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
-import type { CreditTierEnum, ProPlan } from "@/generated/api/types.gen";
+import type {
+  CreditTierEnum,
+  PlanCatalogEntry,
+  ProPlan,
+} from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
+
+/**
+ * Resolves a credit tier's catalog label from the Pro plan's `credit_tiers`.
+ * Returns null for a null/undefined tier or when the tier can't be resolved
+ * (catalog still loading, no Pro plan, no matching tier).
+ */
+function creditTierLabel(
+  plans: PlanCatalogEntry[] | undefined,
+  tier: CreditTierEnum | null | undefined,
+): string | null {
+  if (tier == null) {
+    return null;
+  }
+  const proPlan = plans?.find((p): p is ProPlan => p.id === "pro");
+  return proPlan?.credit_tiers?.find((t) => t.tier === tier)?.label ?? null;
+}
 
 /**
  * Resolves the human-readable monthly-credit label for the purchased plan from
@@ -44,11 +64,7 @@ export function useProvisioningCredits(
     return pkg?.credits_usd != null ? `${pkg.credits_usd} credits` : null;
   }
 
-  if (intent.creditTier != null) {
-    return creditTiers.find((t) => t.tier === intent.creditTier)?.label ?? null;
-  }
-
-  return null;
+  return creditTierLabel(data?.plans, intent.creditTier);
 }
 
 /**
@@ -71,11 +87,5 @@ export function useCreditTierLabel(
     enabled: orgReady && creditTier != null,
   });
 
-  if (creditTier == null) {
-    return null;
-  }
-  const proPlan = data?.plans.find((p): p is ProPlan => p.id === "pro");
-  return (
-    proPlan?.credit_tiers?.find((t) => t.tier === creditTier)?.label ?? null
-  );
+  return creditTierLabel(data?.plans, creditTier);
 }


### PR DESCRIPTION
## Summary
- Extract a shared `creditTierLabel` helper so useProvisioningCredits and useCreditTierLabel don't duplicate the catalog resolution.
- Trim the copy-pasted resizeCredits rationale to one canonical prop doc.
- Reset resizeCreditTier on the takeover onClose as a fail-safe against a stale credit chip.

Fixes review cleanups for plan: credit-change-takeover.md