### PR TITLE
refactor(plugins): remove plugin activation from the hook-dispatch path

### DIFF
--- a/assistant/src/__tests__/mtime-cache.test.ts
+++ b/assistant/src/__tests__/mtime-cache.test.ts
@@ -1,13 +1,13 @@
 /**
  * Tests for the plugin cache orchestrator: boot discovery plus the
- * source-versions reconcile that drives every steady-state change.
+ * imperative source-versions reconcile that drives every steady-state change.
  *
  * Each test materializes a synthetic plugin directory under a per-file
- * tempdir. Changes are published the way production publishes them — by
- * running the resource monitor's watcher pass over the same workspace — and
- * observed the way production observes them: a hook dispatch, whose
- * sentinel check applies the published diff. This makes the suite an
- * end-to-end exercise of detector → sentinel → reconcile → redeploy.
+ * tempdir. Changes are applied the way production applies them — the
+ * install/uninstall/enable/disable routes call `reconcilePluginSourcesNow()`
+ * after materializing files on disk. Dispatch-time hook and tool reads are
+ * pure cache reads and must never activate anything; that invariant has its
+ * own test below.
  */
 import {
   existsSync,
@@ -29,11 +29,6 @@ import {
 } from "bun:test";
 
 import { _inspectHookCacheForTests } from "../hooks/hook-loader.js";
-import {
-  createSourceWatchState,
-  runSourceWatchPass,
-  type SourceWatchState,
-} from "../monitoring/plugin-source-watch.js";
 import {
   _inspectToolCacheForTests,
   getCachedUserTools,
@@ -134,31 +129,16 @@ const SIMPLE_PKG = {
   peerDependencies: { "@vellumai/plugin-api": "*" },
 };
 
-/**
- * Watcher state shared by a test's publishes, reset per test so each test's
- * first publish takes a fresh baseline (adopting any sentinel on disk).
- */
-let watchState: SourceWatchState | null = null;
-
-/** Strictly increasing mtime offset for sentinel touches within one test. */
-let sentinelTouchSeq = 0;
+/** Strictly increasing mtime offset for source-file touches within one test. */
+let touchSeq = 0;
 
 /**
- * Publish pending source changes exactly the way production does: one pass
- * of the resource monitor's watcher over this workspace. When the pass
- * rewrites the sentinel, its mtime is bumped to a strictly increasing
- * timestamp so the daemon's one-stat gate observes every publish even when
- * two land inside the same filesystem-timestamp granule.
+ * Apply pending source changes exactly the way production does: the
+ * imperative reconcile the install/uninstall/enable/disable routes call
+ * after materializing a change on disk.
  */
-function publishSourceChanges(): boolean {
-  if (watchState === null) {
-    watchState = createSourceWatchState();
-  }
-  const wrote = runSourceWatchPass(watchState);
-  if (wrote) {
-    touchFile(getSourceVersionsPath(), (sentinelTouchSeq += 2));
-  }
-  return wrote;
+async function applySourceChangesNow(): Promise<void> {
+  await reconcilePluginSourcesNow();
 }
 
 // ─── Setup / teardown ────────────────────────────────────────────────────────
@@ -171,8 +151,7 @@ beforeEach(() => {
   ensurePluginsDir();
   ensureWorkspaceHooksDir();
   rmSync(getSourceVersionsPath(), { force: true });
-  watchState = null;
-  sentinelTouchSeq = 0;
+  touchSeq = 0;
   resetPluginCacheForTests();
   // The registry pulls plugin tools via loadPluginTools(); clear its side
   // (tools + pulled fingerprints) so registrations never leak across tests.
@@ -201,7 +180,7 @@ describe("plugin mtime cache (per-surface)", () => {
     expect(hooks).toHaveLength(1);
   });
 
-  test("dispatch serves the cache and ignores disk changes until published", async () => {
+  test("dispatch serves the cache and ignores disk changes until reconciled", async () => {
     const dir = freshPluginDir("cached-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "cached-plugin" });
     writeHook(dir, "user-prompt-submit", `export default () => "v1";`);
@@ -209,7 +188,7 @@ describe("plugin mtime cache (per-surface)", () => {
     await populateCacheAtBoot();
     const first = (await getUserHooksFor("user-prompt-submit"))[0];
 
-    // Edit lands on disk but the watcher hasn't published — dispatch keeps
+    // Edit lands on disk but no reconcile has run — dispatch keeps
     // serving the exact cached function, proving it never re-scans.
     const hookFile = join(dir, "hooks", "user-prompt-submit.ts");
     writeFileSync(hookFile, `export default () => "v2";`);
@@ -220,7 +199,7 @@ describe("plugin mtime cache (per-surface)", () => {
     expect((again as unknown as () => string)()).toBe("v1");
   });
 
-  test("an edited hook takes effect once the watcher publishes", async () => {
+  test("an edited hook takes effect once imperatively reconciled", async () => {
     const dir = freshPluginDir("rebuild-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "rebuild-plugin" });
     const hookFile = join(dir, "hooks", "user-prompt-submit.ts");
@@ -237,7 +216,7 @@ describe("plugin mtime cache (per-surface)", () => {
 
     writeFileSync(hookFile, `export default () => "v2";`);
     touchFile(hookFile);
-    expect(publishSourceChanges()).toBe(true);
+    await applySourceChangesNow();
 
     expect(
       (
@@ -248,7 +227,7 @@ describe("plugin mtime cache (per-surface)", () => {
     ).toBe("v2");
   });
 
-  test("plugin deletion: a published removal evicts cache entries", async () => {
+  test("plugin deletion: a reconciled removal evicts cache entries", async () => {
     const dir = freshPluginDir("deletable-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "deletable-plugin" });
     writeHook(
@@ -261,7 +240,7 @@ describe("plugin mtime cache (per-surface)", () => {
     expect(await getUserHooksFor("user-prompt-submit")).toHaveLength(1);
 
     rmSync(dir, { recursive: true, force: true });
-    publishSourceChanges();
+    await applySourceChangesNow();
 
     const hooks = await getUserHooksFor("user-prompt-submit");
     expect(hooks).toHaveLength(0);
@@ -306,7 +285,7 @@ describe("plugin mtime cache (per-surface)", () => {
     expect(hooks).toHaveLength(0);
   });
 
-  test("getUserHooksFor detects a newly added plugin once published", async () => {
+  test("getUserHooksFor detects a newly added plugin once reconciled", async () => {
     const dir1 = freshPluginDir("existing-plugin");
     writePackageJson(dir1, { ...SIMPLE_PKG, name: "existing-plugin" });
     writeHook(dir1, "user-prompt-submit", `export default () => ({ v: 1 });`);
@@ -314,11 +293,11 @@ describe("plugin mtime cache (per-surface)", () => {
     await populateCacheAtBoot();
     expect(await getUserHooksFor("user-prompt-submit")).toHaveLength(1);
 
-    // Add a new plugin directory after boot and publish it.
+    // Add a new plugin directory after boot and reconcile.
     const dir2 = freshPluginDir("new-plugin");
     writePackageJson(dir2, { ...SIMPLE_PKG, name: "new-plugin" });
     writeHook(dir2, "user-prompt-submit", `export default () => ({ v: 2 });`);
-    publishSourceChanges();
+    await applySourceChangesNow();
 
     const hooks = await getUserHooksFor("user-prompt-submit");
     expect(hooks).toHaveLength(2);
@@ -340,7 +319,7 @@ describe("plugin mtime cache (per-surface)", () => {
     expect(tools[0]?.name).toBe("my-tool");
   });
 
-  test("an edited tool serves its new definition once published", async () => {
+  test("an edited tool serves its new definition once reconciled", async () => {
     const dir = freshPluginDir("tool-edit-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "tool-edit-plugin" });
     // Unique tool name: the global tool registry is process-wide state that
@@ -361,8 +340,7 @@ describe("plugin mtime cache (per-surface)", () => {
       `export default { name: "edited-tool", description: "v2", parameters: { type: "object", properties: {} } };`,
     );
     touchFile(toolFile);
-    publishSourceChanges();
-    await getUserHooksFor("user-prompt-submit");
+    await applySourceChangesNow();
     await loadPluginTools();
 
     // Both the cache and the global registry serve the fresh definition —
@@ -548,7 +526,7 @@ describe("workspace hooks (<workspace>/hooks/)", () => {
     expect(results[1]!.tag).toBe("workspace");
   });
 
-  test("an edited workspace hook takes effect once published", async () => {
+  test("an edited workspace hook takes effect once reconciled", async () => {
     const hookFile = join(WORKSPACE_HOOKS_DIR, "post-model-call.ts");
     writeWorkspaceHook("post-model-call", `export default () => "ws-v1";`);
 
@@ -561,7 +539,7 @@ describe("workspace hooks (<workspace>/hooks/)", () => {
 
     writeFileSync(hookFile, `export default () => "ws-v2";`);
     touchFile(hookFile);
-    publishSourceChanges();
+    await applySourceChangesNow();
 
     expect(
       (
@@ -570,7 +548,7 @@ describe("workspace hooks (<workspace>/hooks/)", () => {
     ).toBe("ws-v2");
   });
 
-  test("deleting a workspace hook file evicts it once published", async () => {
+  test("deleting a workspace hook file evicts it once reconciled", async () => {
     const hookFile = join(WORKSPACE_HOOKS_DIR, "stop.ts");
     writeWorkspaceHook("stop", `export default () => ({ v: 1 });`);
 
@@ -578,18 +556,18 @@ describe("workspace hooks (<workspace>/hooks/)", () => {
     expect(await getUserHooksFor("stop")).toHaveLength(1);
 
     rmSync(hookFile, { force: true });
-    publishSourceChanges();
+    await applySourceChangesNow();
 
     const hooks = await getUserHooksFor("stop");
     expect(hooks).toHaveLength(0);
   });
 
-  test("a newly added workspace hook is picked up once published", async () => {
+  test("a newly added workspace hook is picked up once reconciled", async () => {
     await populateCacheAtBoot();
     expect(await getUserHooksFor("post-compact")).toHaveLength(0);
 
     writeWorkspaceHook("post-compact", `export default () => ({ v: 1 });`);
-    publishSourceChanges();
+    await applySourceChangesNow();
 
     expect(await getUserHooksFor("post-compact")).toHaveLength(1);
   });
@@ -636,21 +614,17 @@ const TOOL_SRC = (name: string) =>
   `export default { name: ${JSON.stringify(name)}, description: "test", parameters: { type: "object", properties: {} } };`;
 
 /**
- * Publish pending source changes through the watcher, then dispatch — the
- * production sequence: the monitor's pass rewrites the sentinel, and the
- * next hook dispatch's one-stat gate applies the diff. The hook name is
- * irrelevant — the reconcile runs regardless of whether a plugin defines
- * that hook. Finish with the registry pull the per-turn tool resolver
- * fires, so registry-facing assertions see the reconciled tool set.
+ * Apply pending source changes through the imperative reconcile, then run
+ * the registry pull the per-turn tool resolver fires, so registry-facing
+ * assertions see the reconciled tool set.
  */
-async function publishAndDispatch(): Promise<void> {
-  publishSourceChanges();
-  await getUserHooksFor("user-prompt-submit");
+async function reconcileAndPull(): Promise<void> {
+  await reconcilePluginSourcesNow();
   await loadPluginTools();
 }
 
 describe("plugin runtime activation", () => {
-  test("a plugin installed after boot becomes live once published", async () => {
+  test("a plugin installed after boot becomes live once reconciled", async () => {
     await populateCacheAtBoot(); // empty plugins dir
     expect(getAllToolDefinitions().some((t) => t.name === "late-tool")).toBe(
       false,
@@ -662,7 +636,7 @@ describe("plugin runtime activation", () => {
     const initMarker = join(ROOT, "late-init.log");
     writeMarkerHook(dir, "init", initMarker, "init");
 
-    await publishAndDispatch();
+    await reconcileAndPull();
 
     // Registered into the global registry as a plugin-owned tool, and exposed
     // to the per-turn resolver via getPluginToolDefinitions().
@@ -680,49 +654,37 @@ describe("plugin runtime activation", () => {
     expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
   });
 
-  test("a runtime install is reconciled even when the sentinel mtime never moves (coarse-mtime filesystems)", async () => {
+  test("hook dispatch and tool pull alone never activate a plugin installed after boot", async () => {
     await populateCacheAtBoot(); // empty plugins dir
 
-    // Pin every sentinel write back to the SAME timestamp, simulating a
-    // filesystem whose mtime granularity can't distinguish two rewrites (the
-    // virtiofs / 9p / network mounts the watcher polls precisely because their
-    // timestamps are unreliable). Only the sentinel's size + inode move — and
-    // the reconcile gate keys on those, not mtime alone.
-    const FIXED = new Date("2020-01-01T00:00:00.000Z");
-    const pinMtime = (): void =>
-      utimesSync(getSourceVersionsPath(), FIXED, FIXED);
+    const dir = freshPluginDir("inert-plugin");
+    writePackageJson(dir, { ...SIMPLE_PKG, name: "inert-plugin" });
+    writeTool(dir, "inert-tool", TOOL_SRC("inert-tool"));
+    const initMarker = join(ROOT, "inert-init.log");
+    writeMarkerHook(dir, "init", initMarker, "init");
 
-    // First install → publish → dispatch. Pin the mtime so the SECOND publish
-    // below shares it exactly.
-    const dirA = freshPluginDir("coarse-a");
-    writePackageJson(dirA, { ...SIMPLE_PKG, name: "coarse-a" });
-    writeTool(dirA, "coarse-a-tool", TOOL_SRC("coarse-a-tool"));
-    expect(publishSourceChanges()).toBe(true);
-    pinMtime();
+    // Dispatch hooks and pull tools repeatedly — the reads a sidecar worker
+    // running conversation turns performs. None of them may activate the
+    // plugin: activation belongs to the boot scan and the imperative poke,
+    // both main-daemon paths.
+    await getUserHooksFor("user-prompt-submit");
     await getUserHooksFor("user-prompt-submit");
     await loadPluginTools();
-    expect(
-      getAllToolDefinitions().some((t) => t.name === "coarse-a-tool"),
-    ).toBe(true);
 
-    // Second install → publish → pin the SAME mtime as the first. An mtime-only
-    // gate would see no change and never reconcile (the plugin would go live
-    // only at the next daemon restart); the composite signature still moves —
-    // the atomic rename swaps in a fresh inode and the sentinel grew — so the
-    // plugin goes live on the very next dispatch.
-    const dirB = freshPluginDir("coarse-b");
-    writePackageJson(dirB, { ...SIMPLE_PKG, name: "coarse-b" });
-    writeTool(dirB, "coarse-b-tool", TOOL_SRC("coarse-b-tool"));
-    expect(publishSourceChanges()).toBe(true);
-    pinMtime();
-    await getUserHooksFor("user-prompt-submit");
-    await loadPluginTools();
-    expect(
-      getAllToolDefinitions().some((t) => t.name === "coarse-b-tool"),
-    ).toBe(true);
+    expect(getAllToolDefinitions().some((t) => t.name === "inert-tool")).toBe(
+      false,
+    );
+    expect(existsSync(initMarker)).toBe(false);
+
+    // The imperative poke is what brings it up.
+    await reconcileAndPull();
+    expect(getAllToolDefinitions().some((t) => t.name === "inert-tool")).toBe(
+      true,
+    );
+    expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
   });
 
-  test("reconcilePluginSourcesNow brings a freshly installed plugin up immediately, without the sentinel", async () => {
+  test("reconcilePluginSourcesNow brings a freshly installed plugin up immediately", async () => {
     await populateCacheAtBoot(); // empty plugins dir
     expect(getAllToolDefinitions().some((t) => t.name === "eager-tool")).toBe(
       false,
@@ -734,9 +696,8 @@ describe("plugin runtime activation", () => {
     const initMarker = join(ROOT, "eager-init.log");
     writeMarkerHook(dir, "init", initMarker, "init");
 
-    // Deliberately do NOT publish through the watcher and do NOT dispatch a
-    // hook — this is the imperative install path: the plugin's files land on
-    // disk and the daemon is told to bring it up right now.
+    // This is the imperative install path: the plugin's files land on disk
+    // and the daemon is told to bring it up right now.
     await reconcilePluginSourcesNow();
     await loadPluginTools();
 
@@ -746,8 +707,8 @@ describe("plugin runtime activation", () => {
     // init ran exactly once, as part of the reconcile — not at a later turn.
     expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
 
-    // Calling it again (e.g. the monitor's later sentinel publish, or a
-    // redundant poke) is a no-op — the plugin is already up.
+    // Calling it again (a redundant poke) is a no-op — the plugin is
+    // already up.
     await reconcilePluginSourcesNow();
     expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
   });
@@ -782,7 +743,7 @@ describe("plugin runtime activation", () => {
     expect(existsSync(shutdownMarker)).toBe(false);
   });
 
-  test("activation is idempotent — republishing without changes does not re-run init", async () => {
+  test("activation is idempotent — reconciling without changes does not re-run init", async () => {
     const dir = freshPluginDir("idem-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "idem-plugin" });
     writeTool(dir, "idem-tool", TOOL_SRC("idem-tool"));
@@ -790,8 +751,8 @@ describe("plugin runtime activation", () => {
     writeMarkerHook(dir, "init", initMarker, "init");
 
     await populateCacheAtBoot();
-    await publishAndDispatch();
-    await publishAndDispatch();
+    await reconcileAndPull();
+    await reconcileAndPull();
 
     expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
     // Registered exactly once (no refcount inflation from re-registration).
@@ -817,7 +778,7 @@ describe("plugin runtime activation", () => {
     expect(getToolOwner("temp-tool")?.kind).toBe("plugin");
 
     rmSync(dir, { recursive: true, force: true });
-    await publishAndDispatch();
+    await reconcileAndPull();
 
     expect(getToolOwner("temp-tool")).toBeUndefined();
     expect(getPluginToolDefinitions().some((t) => t.name === "temp-tool")).toBe(
@@ -857,7 +818,7 @@ describe("plugin runtime activation", () => {
     expect(getToolOwner("disable-tool")?.kind).toBe("plugin");
 
     writeFileSync(join(dir, ".disabled"), "");
-    await publishAndDispatch();
+    await reconcileAndPull();
 
     expect(getToolOwner("disable-tool")).toBeUndefined();
     // Disable keeps the directory, so `shutdown` is resolved from disk and runs
@@ -866,7 +827,7 @@ describe("plugin runtime activation", () => {
   });
 });
 
-// ─── Live reload (sentinel-driven redeploy) ──────────────────────────────────
+// ─── Live reload (reconcile-driven redeploy) ─────────────────────────────────
 
 /** Write a helper module at `relPath` inside a plugin dir. */
 function writeLibFile(dir: string, relPath: string, body: string): string {
@@ -883,7 +844,7 @@ async function dispatchFirst(hookName: string): Promise<unknown> {
   return (hooks[0] as unknown as () => unknown)();
 }
 
-describe("live reload (sentinel-driven redeploy)", () => {
+describe("live reload (reconcile-driven redeploy)", () => {
   test("editing a helper imported by a hook redeploys the plugin, repeatably", async () => {
     const dir = freshPluginDir("helper-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "helper-plugin" });
@@ -909,8 +870,8 @@ describe("live reload (sentinel-driven redeploy)", () => {
         helperPath,
         `export const value = ${JSON.stringify(marker)};`,
       );
-      touchFile(helperPath, sentinelTouchSeq + 2);
-      publishSourceChanges();
+      touchFile(helperPath, (touchSeq += 2));
+      await applySourceChangesNow();
       expect(await dispatchFirst("helper-reload")).toBe(marker);
     }
   });
@@ -941,8 +902,8 @@ describe("live reload (sentinel-driven redeploy)", () => {
     // what keeps a re-imported hook from pairing with a's stale cached
     // binding to the old `b`.
     writeFileSync(bPath, `export const leaf = "b2";`);
-    touchFile(bPath, sentinelTouchSeq + 2);
-    publishSourceChanges();
+    touchFile(bPath, (touchSeq += 2));
+    await applySourceChangesNow();
     expect(await dispatchFirst("transitive-reload")).toBe("a:b2");
   });
 
@@ -973,8 +934,8 @@ describe("live reload (sentinel-driven redeploy)", () => {
     // shutdown from disk and runs it, then brings the new version up through
     // the same init path as boot.
     writeFileSync(helperPath, `export const value = 2;`);
-    touchFile(helperPath, sentinelTouchSeq + 2);
-    await publishAndDispatch();
+    touchFile(helperPath, (touchSeq += 2));
+    await reconcileAndPull();
 
     expect(readFileSync(shutdownMarker, "utf8").trim().split("\n")).toEqual([
       "reload",
@@ -982,7 +943,7 @@ describe("live reload (sentinel-driven redeploy)", () => {
     expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(2);
   });
 
-  test("boot adopts a pre-existing sentinel without spurious redeploys", async () => {
+  test("boot state is stable — dispatch and a redundant reconcile never redeploy", async () => {
     const dir = freshPluginDir("adopt-plugin");
     writePackageJson(dir, { ...SIMPLE_PKG, name: "adopt-plugin" });
     writeLibFile(dir, join("lib", "helper.ts"), `export const v = 1;`);
@@ -990,19 +951,17 @@ describe("live reload (sentinel-driven redeploy)", () => {
     rmSync(initMarker, { force: true });
     writeMarkerHook(dir, "init", initMarker, "init");
 
-    // The watcher published before the daemon booted.
-    publishSourceChanges();
-
     await populateCacheAtBoot();
     await getUserHooksFor("user-prompt-submit");
     await getUserHooksFor("user-prompt-submit");
+    await reconcilePluginSourcesNow();
 
-    // One init: the sentinel matching boot's own walk must not redeploy.
+    // One init: a reconcile matching boot's own walk must not redeploy.
     expect(readFileSync(initMarker, "utf8").trim().split("\n")).toHaveLength(1);
   });
 });
 
-describe("sentinel path validation (ATL-983)", () => {
+describe("plugin root validation (ATL-983)", () => {
   test("forged sentinel pointing outside plugins dir does not load arbitrary code", async () => {
     // Create a directory outside the plugins dir that looks like a plugin.
     const evilDir = join(ROOT, "evil-outside-plugins");
@@ -1014,6 +973,7 @@ describe("sentinel path validation (ATL-983)", () => {
 
     // Forge a sentinel that claims the evil directory is a plugin.
     const sentinelPath = getSourceVersionsPath();
+    mkdirSync(join(sentinelPath, ".."), { recursive: true });
     const { snapshotPluginSource } =
       await import("../plugins/source-fingerprint.js");
     const snapshot = snapshotPluginSource(evilDir);
@@ -1032,11 +992,14 @@ describe("sentinel path validation (ATL-983)", () => {
         },
       }),
     );
-    // Bump mtime so the sentinel check picks it up.
     const future = new Date(Date.now() + 5000);
     utimesSync(sentinelPath, future, future);
 
+    // Neither dispatch (a pure cache read that never touches the sentinel)
+    // nor the imperative reconcile (which walks only the plugin roots) may
+    // load code from outside the plugins directory.
     await getUserHooksFor("user-prompt-submit");
+    await reconcilePluginSourcesNow();
 
     // The evil plugin's init hook must NOT have run.
     expect(existsSync(evilMarker)).toBe(false);

--- a/assistant/src/__tests__/plugin-secret-pattern-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-secret-pattern-contribution.test.ts
@@ -13,8 +13,8 @@
  * (`mtime-cache.test.ts`):
  *
  *  1. User plugins — synthetic plugin directories driven through boot
- *     discovery and the source-versions reconcile (install, disable,
- *     uninstall published exactly the way production publishes them).
+ *     discovery and the imperative source-versions reconcile (install,
+ *     disable, uninstall applied exactly the way production applies them).
  *  2. Default/registered plugins — `bootstrapPlugins()` registering the
  *     manifest declaration and rolling it back when `init()` fails.
  *
@@ -35,13 +35,9 @@ import {
 
 import { bootstrapPlugins } from "../daemon/external-plugins-bootstrap.js";
 import {
-  createSourceWatchState,
-  runSourceWatchPass,
-  type SourceWatchState,
-} from "../monitoring/plugin-source-watch.js";
-import {
   getUserHooksFor,
   populateCacheAtBoot,
+  reconcilePluginSourcesNow,
   resetPluginCacheForTests,
 } from "../plugins/mtime-cache.js";
 import {
@@ -116,21 +112,11 @@ function findRegistered(label: string, pluginName: string) {
 }
 
 /**
- * Watcher state shared by a test's publishes, reset per test so each test's
- * first publish takes a fresh baseline.
- */
-let watchState: SourceWatchState | null = null;
-
-/**
- * Publish pending source changes the way production does — one watcher pass —
- * then dispatch a hook read so the daemon-side sentinel gate applies the diff.
+ * Apply pending source changes the way production does: the imperative
+ * reconcile the install/uninstall/enable/disable routes call.
  */
 async function publishAndDispatch(): Promise<void> {
-  if (watchState === null) {
-    watchState = createSourceWatchState();
-  }
-  runSourceWatchPass(watchState);
-  await getUserHooksFor("user-prompt-submit");
+  await reconcilePluginSourcesNow();
 }
 
 // ─── Setup / teardown ────────────────────────────────────────────────────────
@@ -142,7 +128,6 @@ beforeAll(() => {
 beforeEach(() => {
   ensurePluginsDir();
   rmSync(getSourceVersionsPath(), { force: true });
-  watchState = null;
   // Also clears the secret-pattern registry via resetPluginSecretPatternsForTests.
   resetPluginCacheForTests();
   resetPluginRegistryForTests();

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -871,10 +871,10 @@ export function createResolveToolsCallback(
 
     // Same treatment for user-plugin tools: pull the plugin mtime-cache's
     // active tool set into the registry (a no-op costs a fingerprint compare
-    // per plugin). This pull is a pure cache read — the sentinel reconcile that
-    // activates plugins runs on the hook-dispatch path that precedes tool
-    // resolution each turn — so a plugin installed/removed/edited at runtime is
-    // still picked up here without recreating the conversation.
+    // per plugin). This pull is a pure cache read — plugin activation happens
+    // only at boot and through the install/uninstall routes, both main-daemon
+    // paths — so a plugin installed or removed through the routes is still
+    // picked up here without recreating the conversation.
     void loadPluginTools();
 
     // Read every registered plugin tool each turn (so runtime installs/edits

--- a/assistant/src/hooks/registry.ts
+++ b/assistant/src/hooks/registry.ts
@@ -84,7 +84,7 @@ export function unregisterPluginHooks(pluginName: string): void {
  * In-process default plugin hooks are read from this registry (synchronous)
  * and filtered by the `.disabled` sentinel at read time via
  * {@link isPluginDisabled}. User-land hooks are pulled from the plugin cache
- * (async; applies any pending source-versions reconcile first). Default hooks are prepended so they compose
+ * (async, pure cache read). Default hooks are prepended so they compose
  * innermost, ahead of any user plugins.
  *
  * The `TCtx` generic mirrors {@link HookFunction}'s — callers parameterize
@@ -137,8 +137,8 @@ export async function getHookEntriesFor<TCtx = unknown>(
     });
   }
 
-  // User-land hooks from the plugin cache (async; applies any pending
-  // source-versions reconcile first). The per-chat
+  // User-land hooks from the plugin cache (async, pure cache read; dispatch
+  // never activates plugins). The per-chat
   // scope is threaded through so a deselected user plugin's hooks are excluded
   // too — standalone workspace hooks (not owned by a plugin) always run.
   const userEntries = await getUserHookEntriesFor<TCtx>(

--- a/assistant/src/plugins/mtime-cache.ts
+++ b/assistant/src/plugins/mtime-cache.ts
@@ -13,9 +13,10 @@
  *
  * - Boot does one full discovery scan; after that, every change (plugin
  *   installed, removed, disabled, or any source file inside a plugin edited
- *   — including helper modules hooks/tools import) arrives through the
- *   source-versions sentinel published by the resource monitor's watcher.
- *   The dispatch path stats that one file and otherwise runs on memory.
+ *   — including helper modules hooks/tools import) is applied by the
+ *   imperative reconcile the install/uninstall/enable/disable routes call
+ *   ({@link reconcilePluginSourcesNow}). The dispatch path is a pure cache
+ *   read — it never scans disk, activates a plugin, or runs `init`.
  * - A changed plugin is redeployed in place: its `shutdown` runs (resolved
  *   from disk), its hook/tool cache entries and module-registry entries are
  *   swept, and reactivation runs `init`; the next read of each hook re-resolves
@@ -74,13 +75,8 @@ import {
 import { snapshotPluginSource } from "./source-fingerprint.js";
 import type { PluginSourceVersion } from "./source-versions.js";
 import {
-  getSourceVersionsPath,
-  readSourceVersions,
-} from "./source-versions.js";
-import {
   clearSurfaceImportInflight,
   evictModule,
-  getFileSignature,
   getMtime,
   importWithTimeout,
   setSurfaceImportTimeout,
@@ -206,32 +202,28 @@ const disabledPluginDirs = new Set<string>();
 
 /**
  * The source-versions state this process last applied, keyed by directory
- * (see `./source-versions.ts`). Seeded at boot from the daemon's own walk —
- * the same fingerprint algorithm over the same disk yields the same stamps
- * as the watcher, so the first sentinel publication after boot diffs
- * correctly even against edits made while the daemon was down.
+ * (see `./source-versions.ts`). Seeded at boot from the daemon's own walk,
+ * so the first imperative reconcile after boot diffs correctly against the
+ * state boot just loaded.
  */
 let lastVersions: Record<string, PluginSourceVersion> = {};
 
-/**
- * Change signature (`mtimeMs:size:ino`) of the sentinel document as of the last
- * look; `""` = never seen. A composite signature rather than mtime alone so a
- * publish is detected even when the filesystem's mtime granularity can't move
- * the timestamp between two rewrites (see {@link getFileSignature}).
- */
-let lastSentinelSignature = "";
-
-/** In-flight reconcile — concurrent dispatches await it rather than racing. */
+/** In-flight reconcile — concurrent imperative pokes await it rather than racing. */
 let reconcileInFlight: Promise<void> | null = null;
 
 // ─── Hook reads ──────────────────────────────────────────────────────────────
 
 /**
  * Get all hooks for a given event name from user plugins and standalone
- * workspace hooks. Checks the source-versions sentinel first (one stat;
- * reconciles only when the watcher published a change), then delegates to
- * the hook loader's in-memory cache. Plugin hooks run in install-date
- * order, the workspace hook runs last.
+ * workspace hooks, from the hook loader's in-memory cache. Plugin hooks run
+ * in install-date order, the workspace hook runs last.
+ *
+ * This is a pure cache read: it never scans disk, activates a plugin, or
+ * runs `init`. Activation happens only at boot ({@link populateCacheAtBoot})
+ * and through the imperative install/uninstall poke
+ * ({@link reconcilePluginSourcesNow}) — both main-daemon paths — so a
+ * sidecar process that dispatches hooks (a worker running conversation
+ * turns) can never bring a plugin up in its own process.
  *
  * `effectiveEnabledPlugins` carries the per-chat plugin scope: when non-null,
  * user plugins outside the set are skipped (standalone workspace hooks always
@@ -241,7 +233,6 @@ export async function getUserHookEntriesFor<TCtx = unknown>(
   hookName: string,
   effectiveEnabledPlugins?: Set<string> | null,
 ): Promise<HookEntry<TCtx>[]> {
-  await maybeReconcileFromSentinel();
   return collectUserHookEntries<TCtx>(
     hookName,
     discoveredPluginDirs.values(),
@@ -267,80 +258,26 @@ export async function getUserHooksFor<TCtx = unknown>(
 // ─── Source-versions reconcile ───────────────────────────────────────────────
 
 /**
- * Dispatch-path gate: one stat of the source-versions sentinel. When its
- * change signature is unchanged since the last look (the overwhelmingly common
- * case) this returns immediately, and dispatch runs entirely on memory. When
- * the watcher published a change, the document is applied before the dispatch
- * proceeds, so the turn that follows an edit already runs the new code.
- *
- * The signature is `mtimeMs:size:ino`, not mtime alone: the sentinel is
- * published via temp-file + atomic rename, which swaps in a fresh inode on
- * every write, so a runtime install is picked up even on filesystems whose
- * mtime granularity is too coarse to move the timestamp between two publishes
- * (virtiofs / 9p / network mounts). With an mtime-only gate such a publish is
- * invisible until the next daemon restart re-walks the plugins directory.
- *
- * A missing or unreadable sentinel is degraded mode, not an error: the
- * boot-time state keeps serving, and live reload resumes when the monitor
- * publishes again.
- */
-async function maybeReconcileFromSentinel(): Promise<void> {
-  // Loop so a dispatch that waits out an in-flight reconcile re-checks the
-  // sentinel afterward: the monitor may have published a newer version while
-  // that reconcile ran, and this turn must run against the latest on disk —
-  // not whatever the reconcile it happened to await had already applied.
-  for (;;) {
-    if (reconcileInFlight !== null) {
-      await reconcileInFlight;
-      continue;
-    }
-    const signature = getFileSignature(getSourceVersionsPath());
-    if (signature === lastSentinelSignature) {
-      return;
-    }
-    // Claim the signature before any async work, so a concurrent dispatch
-    // either finds the in-flight promise above or skips on the updated value.
-    lastSentinelSignature = signature;
-    if (signature === "") {
-      return;
-    }
-    const doc = readSourceVersions();
-    if (doc === null) {
-      return;
-    }
-    reconcileInFlight = applySourceVersions(doc.plugins).finally(() => {
-      reconcileInFlight = null;
-    });
-    await reconcileInFlight;
-    return;
-  }
-}
-
-/**
  * Imperatively reconcile the plugin caches against the current on-disk state
- * *now* — without waiting for the resource monitor to republish the
- * source-versions sentinel or for the next hook dispatch to notice it.
+ * *now*.
  *
- * An install / uninstall / enable / disable materializes files on disk; the
- * steady-state path picks that up eventually — the monitor republishes the
- * sentinel and the dispatch-path gate applies the diff on the next turn. That
- * is eventually-correct but not immediate: nothing runs a newly installed
- * plugin's `init` until some later turn dispatches a hook. Callers that just
- * changed the plugin set on disk (the install / uninstall routes, and the
- * CLI's best-effort post-install poke) call this to bring the change up
+ * An install / uninstall / enable / disable materializes files on disk;
+ * nothing else applies that change to the caches. Callers that just changed
+ * the plugin set on disk (the install / uninstall routes, and the CLI's
+ * best-effort post-install poke) call this to bring the change up
  * deterministically, so a freshly installed plugin's `init` fires as part of
- * the install rather than at the next daemon boot.
+ * the install rather than at the next daemon boot. Together with the boot
+ * scan this is the only path that activates plugins — dispatch-time hook and
+ * tool reads are pure cache reads — so activation only ever happens in the
+ * main daemon, where these routes run.
  *
- * Reuses the same collector the monitor writes into the sentinel, so the map
- * applied here is identical to the monitor's next publish — which then diffs to
- * a no-op. Idempotent and safe to call redundantly: `applySourceVersions` only
- * redeploys directories whose fingerprint moved, and activation is guarded so a
- * plugin already up is never re-initialized. Never throws — a failure is
+ * Idempotent and safe to call redundantly: `applySourceVersions` only
+ * redeploys directories whose fingerprint moved, and activation is guarded so
+ * a plugin already up is never re-initialized. Never throws — a failure is
  * contained inside `applySourceVersions` and logged there.
  *
- * Coordinates with the sentinel gate through the shared `reconcileInFlight`
- * latch: it waits out any dispatch-driven reconcile already running, then
- * claims the latch for its own apply, so the two paths never overlap.
+ * Concurrent pokes serialize through the `reconcileInFlight` latch, so two
+ * applies never overlap.
  */
 export async function reconcilePluginSourcesNow(): Promise<void> {
   while (reconcileInFlight !== null) {
@@ -363,14 +300,11 @@ export async function reconcilePluginSourcesNow(): Promise<void> {
 }
 
 /**
- * Validate that a directory path from the sentinel is an allowed plugin
- * source: either under the workspace plugins directory or the standalone
- * workspace hooks directory. The sentinel file lives under
- * `<workspace>/data/monitoring/` which is not protected by the file-risk
- * classifier, so a forged sentinel could point at arbitrary directories
- * containing attacker-controlled TypeScript. This check ensures
- * `bringUpPlugin` never dynamically imports code from outside the
- * designated plugin roots, regardless of what the sentinel contains.
+ * Validate that a directory path from a collected source-versions map is an
+ * allowed plugin source: either under the workspace plugins directory or the
+ * standalone workspace hooks directory. This check ensures `bringUpPlugin`
+ * never dynamically imports code from outside the designated plugin roots,
+ * regardless of what the collector walked.
  *
  * Uses `realpathSync` to resolve symlinks before the prefix check, so a
  * symlinked path that looks like it's under the plugins dir but points
@@ -402,9 +336,9 @@ function isAllowedPluginDir(
 }
 
 /**
- * Apply a published source-versions map: diff it against the state last
+ * Apply a collected source-versions map: diff it against the state last
  * applied and redeploy exactly what changed. Never throws — a failed apply
- * is logged and the next publication retries from the sentinel's truth.
+ * is logged and the next imperative reconcile retries from disk.
  *
  * Per directory, the transitions are:
  * - present + enabled with a moved fingerprint → in-place redeploy:
@@ -433,14 +367,13 @@ async function applySourceVersions(
       if (dir === workspaceHooksDir) {
         continue;
       }
-      // Reject directories from the sentinel that are outside the allowed
-      // plugin roots. A forged sentinel could point at arbitrary paths;
-      // without this check, bringUpPlugin would dynamic-import attacker
-      // code from anywhere on the filesystem.
+      // Reject directories outside the allowed plugin roots; without this
+      // check, bringUpPlugin would dynamic-import code from anywhere on
+      // the filesystem.
       if (!isAllowedPluginDir(dir, pluginsDir, workspaceHooksDir)) {
         log.warn(
           { dir },
-          "sentinel references directory outside allowed plugin roots — skipping",
+          "source-versions map references directory outside allowed plugin roots — skipping",
         );
         continue;
       }
@@ -521,7 +454,7 @@ async function applySourceVersions(
 }
 
 /**
- * Bring up a directory the sentinel reports as present and enabled. Returns
+ * Bring up a directory the source-versions map reports as present and enabled. Returns
  * whether the plugin joined the discovered set (a malformed manifest is
  * logged by the parser and the directory is skipped until it changes again).
  */
@@ -587,13 +520,9 @@ async function reconcileWorkspaceHooks(
 }
 
 /**
- * Seed the reconcile baseline at boot from the daemon's own walk, and record
- * the sentinel's current mtime without applying its content. Both sides run
- * the same fingerprint algorithm over the same disk, so the seed matches
- * whatever a healthy watcher would publish for the state boot just loaded —
- * and the first publication that differs (including edits made while the
- * daemon was down, which the watcher detects against its own adopted state)
- * diffs correctly against it.
+ * Seed the reconcile baseline at boot from the daemon's own walk, so the
+ * first imperative reconcile after boot diffs against the state boot just
+ * loaded (an unchanged plugin costs a fingerprint compare, not a redeploy).
  */
 function seedVersionBaseline(): void {
   const seeded: Record<string, PluginSourceVersion> = {};
@@ -615,7 +544,6 @@ function seedVersionBaseline(): void {
     };
   }
   lastVersions = seeded;
-  lastSentinelSignature = getFileSignature(getSourceVersionsPath());
 }
 
 // ─── Tool cache ──────────────────────────────────────────────────────────────
@@ -729,23 +657,21 @@ export interface ActivePluginTools {
  * This is a pure read of the already-reconciled caches — it never scans disk,
  * activates a plugin, or runs an `init` hook. Reconciliation (which activates
  * plugins and is the only thing that runs `init`) is owned exclusively by the
- * three paths that legitimately change the plugin set: the boot scan
- * ({@link populateCacheAtBoot}), the source-versions gate on the hook-dispatch
- * path ({@link getUserHookEntriesFor} → {@link maybeReconcileFromSentinel}), and
- * the imperative install/uninstall poke ({@link reconcilePluginSourcesNow}).
- * Pulling tools must not be a fourth: the tool registry is populated from
- * processes that never run plugin lifecycle (sidecar workers call
- * `initializeTools()` for their own tool surface), so folding activation into
- * this read would run `init` in a worker against daemon-owned plugin storage.
+ * two paths that legitimately change the plugin set, both main-daemon only:
+ * the boot scan ({@link populateCacheAtBoot}) and the imperative
+ * install/uninstall poke ({@link reconcilePluginSourcesNow}). Pulling tools
+ * (or dispatching hooks) must not be a third: those reads run in processes
+ * that never run plugin lifecycle (sidecar workers call `initializeTools()`
+ * for their own tool surface and dispatch hooks for the conversations they
+ * wake), so folding activation into a read would run `init` in a worker
+ * against daemon-owned plugin storage.
  *
  * This is the pull half of the tool-registry relationship: the registry's
  * `loadPluginTools()` reconcile calls this and diffs the result into its own
  * maps — this module never writes to the registry. Because a runtime plugin
- * change lands in the cache via the hook-dispatch reconcile that runs each turn
- * (or the explicit install poke), the very next `loadPluginTools()` reads the
- * updated set, so live install/remove/edit is still picked up without recreating
- * the conversation. Mirrors how hook reads pull through
- * {@link getUserHookEntriesFor}.
+ * change lands in the cache via the install poke, the very next
+ * `loadPluginTools()` reads the updated set, so install/remove through the
+ * routes is still picked up without recreating the conversation.
  */
 export function getActiveUserPluginTools(): Map<string, ActivePluginTools> {
   const byPlugin = new Map<string, CachedTool[]>();
@@ -1137,10 +1063,10 @@ async function deactivatePlugin(
  * {@link getActiveUserPluginTools}.
  *
  * Called by `loadUserPlugins()` during daemon startup. After boot, the same
- * `activatePlugin`/`deactivatePlugin` reconciliation runs via the
- * source-versions sentinel on every hook dispatch and registry pull, so
- * plugins whose files appear or disappear at runtime are picked up without a
- * restart.
+ * `activatePlugin`/`deactivatePlugin` reconciliation runs only through the
+ * imperative poke ({@link reconcilePluginSourcesNow}) the install/uninstall/
+ * enable/disable routes call, so plugin lifecycle stays confined to the main
+ * daemon — dispatch-time hook and tool reads never activate anything.
  */
 export async function populateCacheAtBoot(
   opts: { importTimeoutMs?: number } = {},
@@ -1163,8 +1089,8 @@ export async function populateCacheAtBoot(
     activatedPlugins.push({ kind: "workspace", name: WORKSPACE_HOOKS_OWNER });
   }
 
-  // Boot is self-sufficient (the scan above never waits on the monitor);
-  // from here on, changes arrive via the sentinel diffed against this seed.
+  // From here on, changes arrive via the imperative reconcile diffed
+  // against this seed.
   seedVersionBaseline();
 }
 
@@ -1191,7 +1117,6 @@ export function resetPluginCacheForTests(): void {
   activatedNames.clear();
   disabledPluginDirs.clear();
   lastVersions = {};
-  lastSentinelSignature = "";
   reconcileInFlight = null;
 }
 


### PR DESCRIPTION
## Prompt / plan

QA found the meeting-bot plugin's entire runtime (vellum worker, STT bridge, join handling) living on the **memory-worker** (pid 1137) instead of daemon-main. Root cause: `maybeReconcileFromSentinel` — the source-versions gate on the hook-dispatch path — activated plugins in **whatever process dispatched hooks**. The memory jobs worker wakes real agent conversations (retrospective/consolidation passes); its first turn dispatched a hook, applied the sentinel document, and ran every user plugin's `init` in that process. Downstream chaos: plugin runtimes spawned from the wrong process, worker PID files reaped across processes, two runtimes contending one port.

Per direction: dispatch must never activate plugins — surfaces resolve enablement from cached state, and `init` runs only from the main daemon. This PR deletes `maybeReconcileFromSentinel` outright.

**After this change, activation is owned by exactly two paths, both main-daemon only:**
- the boot scan (`populateCacheAtBoot`), which still inits all installed plugins on container start, and
- the imperative reconcile (`reconcilePluginSourcesNow`) the install/uninstall/enable/disable/upgrade routes call.

`getUserHookEntriesFor` is now a pure cache read: no sentinel stat, no disk scan, no activation. A sidecar process dispatching hooks serves whatever is cached in that process (for a worker: nothing plugin-owned) and can never bring a plugin up.

**Behavioral consequences, stated explicitly:**
- Out-of-band source edits (files changed on disk without going through the routes) are no longer hot-reloaded on the next turn — they land at the next route-driven reconcile or daemon boot.
- The resource monitor's watcher still publishes the source-versions sentinel; nothing consumes it for activation anymore. Removing the publisher is left for a follow-up to keep this diff surgical.
- The forged-sentinel guard (ATL-983) is retained: `isAllowedPluginDir` still fences `applySourceVersions` input, and the test now also asserts a forged sentinel is inert against both dispatch and the imperative reconcile.

## Test plan

- Migrated the sentinel-driven suites (`mtime-cache.test.ts`, `plugin-secret-pattern-contribution.test.ts`) to drive changes through `reconcilePluginSourcesNow()` — the same lifecycle coverage (install/edit/delete/disable pickup, whole-plugin redeploy, shutdown-reason semantics, idempotency) under the new model.
- New invariant test: hook dispatch + tool pulls alone never activate a plugin installed after boot; the imperative poke does.
- Deleted only the coarse-mtime-filesystem test — it exercised the sentinel signature gate, which no longer exists.
- 64 tests pass across the five directly affected suites; `bunx tsc --noEmit` clean.
- Wider sweep (`src/hooks`, `src/plugins`, plugins-routes: 2031 tests): the failure set is **byte-identical** to the unmodified baseline in this sandbox (509 pre-existing environmental failures, verified by A/B diff of failing test names) — zero new failures.

## CLI verb checklist

- [ ] No CLI verbs added, removed, or changed. The CLI's post-install poke and the routes keep calling `reconcilePluginSourcesNow`, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUyRrxL9RGwDMjp7ReeatQ)_