### PR TITLE
feat(web): add custom-plan diff/recap computation helper

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for the pure custom-plan diff/recap computation.
+ *
+ * Mirrors the recap the modal renders: a base-checkout selection (no seed)
+ * produces null delta and all-unchanged rows; a seeded Pro reconfigure produces
+ * a signed cents delta and marks only the changed dimensions, carrying the
+ * previous value's label where it is representable.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { ProPlan } from "@/generated/api/types.gen";
+
+import { NO_EXTRA_CREDITS, computeCustomPlanDiff } from "./custom-plan-diff";
+
+function proPlan(): ProPlan {
+  return {
+    id: "pro",
+    name: "Pro",
+    base_price_cents: 2000,
+    base_lookup_key: "pro_base",
+    billing_interval: "month",
+    included_features: [],
+    machine_tiers: [
+      {
+        tier: "medium",
+        label: "medium",
+        price_cents: 3500,
+        lookup_key: "machine_m",
+        cpu_limit: "2.5",
+        memory_gib: 5,
+        description: "Medium machine (2.5 vCPU, 5 GiB)",
+      },
+      {
+        tier: "large",
+        label: "large",
+        price_cents: 6000,
+        lookup_key: "machine_l",
+        cpu_limit: "4",
+        memory_gib: 8,
+        description: "Large machine (4 vCPU, 8 GiB)",
+      },
+    ],
+    storage_tiers: [
+      {
+        tier: "xs",
+        label: "10 GB",
+        storage_gib: 10,
+        price_cents: 500,
+        lookup_key: "storage_10",
+        legacy: false,
+      },
+      {
+        tier: "s",
+        label: "30 GB",
+        storage_gib: 30,
+        price_cents: 1000,
+        lookup_key: "storage_30",
+        legacy: false,
+      },
+      {
+        tier: "xl",
+        label: "250 GB",
+        storage_gib: 250,
+        price_cents: 6000,
+        lookup_key: "storage_250",
+        legacy: true,
+      },
+    ],
+    credit_tiers: [
+      {
+        tier: "credits_50",
+        label: "50 credits",
+        credits_usd: 50,
+        price_cents: 5000,
+        lookup_key: "credits_50",
+      },
+    ],
+    packages: [],
+  };
+}
+
+describe("computeCustomPlanDiff — base checkout (no seed)", () => {
+  test("full selection has null delta and all rows unchanged", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: null,
+      machineTier: "large",
+      storageTier: "s",
+      creditChoice: "credits_50",
+    });
+
+    expect(diff.deltaCents).toBeNull();
+    expect(diff.previousTotalCents).toBeNull();
+    expect(diff.rows.map((r) => r.label)).toEqual([
+      "Pro base plan — $20/mo",
+      "Large machine (4 vCPU, 8 GiB)",
+      "30 GB storage",
+      "$50 of bundled credits",
+    ]);
+    expect(diff.rows.every((r) => !r.changed)).toBe(true);
+    expect(diff.rows.every((r) => r.previousLabel === undefined)).toBe(true);
+    expect(diff.rows[0].key).toBe("base");
+  });
+
+  test("'No extra credits' renders the none label", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: null,
+      machineTier: "medium",
+      storageTier: "xs",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    expect(diff.rows.map((r) => r.label)).toEqual([
+      "Pro base plan — $20/mo",
+      "Medium machine (2.5 vCPU, 5 GiB)",
+      "10 GB storage",
+      "No extra credits",
+    ]);
+  });
+
+  test("incomplete selection omits the unset dimensions", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: null,
+      machineTier: "",
+      storageTier: "s",
+      creditChoice: "",
+    });
+
+    expect(diff.rows.map((r) => r.key)).toEqual(["base", "storage"]);
+  });
+
+  test("the legacy xl storage tier is not resolvable", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: null,
+      machineTier: "medium",
+      storageTier: "xl",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    // xl is legacy → filtered out → no storage row, and its price is not added.
+    expect(diff.rows.map((r) => r.key)).toEqual(["base", "machine", "credit"]);
+  });
+
+  test("selecting a non-legacy tier still resolves normally", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: null,
+      machineTier: "medium",
+      storageTier: "s",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    const storageRow = diff.rows.find((r) => r.key === "storage");
+    expect(storageRow?.label).toBe("30 GB storage");
+  });
+});
+
+describe("computeCustomPlanDiff — seeded reconfigure", () => {
+  test("no-op selection has zero delta and no changed rows", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: { machineTier: "medium", storageTier: "xs", creditTier: null },
+      machineTier: "medium",
+      storageTier: "xs",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    expect(diff.deltaCents).toBe(0);
+    expect(diff.previousTotalCents).toBe(2000 + 3500 + 500);
+    expect(diff.rows.every((r) => !r.changed)).toBe(true);
+    expect(diff.rows.every((r) => r.previousLabel === undefined)).toBe(true);
+  });
+
+  test("a machine increase marks the machine row and carries the previous label", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: { machineTier: "medium", storageTier: "xs", creditTier: null },
+      machineTier: "large",
+      storageTier: "xs",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    expect(diff.deltaCents).toBe(2500);
+    const machineRow = diff.rows.find((r) => r.key === "machine");
+    expect(machineRow?.changed).toBe(true);
+    expect(machineRow?.previousLabel).toBe("Medium machine (2.5 vCPU, 5 GiB)");
+    expect(machineRow?.label).toBe("Large machine (4 vCPU, 8 GiB)");
+
+    // Every other row stayed unchanged.
+    for (const row of diff.rows) {
+      if (row.key !== "machine") {
+        expect(row.changed).toBe(false);
+      }
+    }
+  });
+
+  test("a machine decrease yields a negative delta", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: { machineTier: "large", storageTier: "xs", creditTier: null },
+      machineTier: "medium",
+      storageTier: "xs",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    expect(diff.deltaCents).toBe(-2500);
+    expect(diff.rows.find((r) => r.key === "machine")?.changed).toBe(true);
+  });
+
+  test("adding a credit bundle marks the credit row from the none baseline", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: { machineTier: "medium", storageTier: "xs", creditTier: null },
+      machineTier: "medium",
+      storageTier: "xs",
+      creditChoice: "credits_50",
+    });
+
+    expect(diff.deltaCents).toBe(5000);
+    const creditRow = diff.rows.find((r) => r.key === "credit");
+    expect(creditRow?.changed).toBe(true);
+    expect(creditRow?.previousLabel).toBe("No extra credits");
+    expect(creditRow?.label).toBe("$50 of bundled credits");
+  });
+
+  test("a null baseline seed machine changes without a previous label", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: { machineTier: null, storageTier: "xs", creditTier: null },
+      machineTier: "medium",
+      storageTier: "xs",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    expect(diff.deltaCents).toBe(3500);
+    const machineRow = diff.rows.find((r) => r.key === "machine");
+    expect(machineRow?.changed).toBe(true);
+    expect(machineRow?.previousLabel).toBeUndefined();
+    expect(machineRow?.label).toBe("Medium machine (2.5 vCPU, 5 GiB)");
+  });
+});

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
@@ -254,7 +254,11 @@ describe("computeCustomPlanDiff — seeded reconfigure", () => {
     const diff = computeCustomPlanDiff({
       proPlan: proPlan(),
       // credits_100 is not present in the fixture's credit_tiers (deprecated).
-      seed: { machineTier: "medium", storageTier: "xs", creditTier: "credits_100" },
+      seed: {
+        machineTier: "medium",
+        storageTier: "xs",
+        creditTier: "credits_100",
+      },
       machineTier: "medium",
       storageTier: "xs",
       creditChoice: NO_EXTRA_CREDITS,
@@ -270,7 +274,11 @@ describe("computeCustomPlanDiff — seeded reconfigure", () => {
   test("switching from a deprecated seed credit to a live bundle is a change with no previous label", () => {
     const diff = computeCustomPlanDiff({
       proPlan: proPlan(),
-      seed: { machineTier: "medium", storageTier: "xs", creditTier: "credits_100" },
+      seed: {
+        machineTier: "medium",
+        storageTier: "xs",
+        creditTier: "credits_100",
+      },
       machineTier: "medium",
       storageTier: "xs",
       creditChoice: "credits_50",

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
@@ -132,19 +132,6 @@ describe("computeCustomPlanDiff — base checkout (no seed)", () => {
     expect(diff.rows.map((r) => r.key)).toEqual(["base", "storage"]);
   });
 
-  test("the legacy xl storage tier is not resolvable", () => {
-    const diff = computeCustomPlanDiff({
-      proPlan: proPlan(),
-      seed: null,
-      machineTier: "medium",
-      storageTier: "xl",
-      creditChoice: NO_EXTRA_CREDITS,
-    });
-
-    // xl is legacy → filtered out → no storage row, and its price is not added.
-    expect(diff.rows.map((r) => r.key)).toEqual(["base", "machine", "credit"]);
-  });
-
   test("selecting a non-legacy tier still resolves normally", () => {
     const diff = computeCustomPlanDiff({
       proPlan: proPlan(),
@@ -241,5 +228,57 @@ describe("computeCustomPlanDiff — seeded reconfigure", () => {
     expect(machineRow?.changed).toBe(true);
     expect(machineRow?.previousLabel).toBeUndefined();
     expect(machineRow?.label).toBe("Medium machine (2.5 vCPU, 5 GiB)");
+  });
+
+  test("a legacy seed storage tier resolves and contributes its real price", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      // xl is a legacy tier ($60 / 250 GB) the subscriber still pays for.
+      seed: { machineTier: "medium", storageTier: "xl", creditTier: null },
+      machineTier: "medium",
+      storageTier: "s",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    // The legacy seed resolves against the full catalog, so its price is in the
+    // previous total and the delta reflects it (30 GB $10 − legacy 250 GB $60).
+    expect(diff.previousTotalCents).toBe(2000 + 3500 + 6000);
+    expect(diff.deltaCents).toBe(-5000);
+    const storageRow = diff.rows.find((r) => r.key === "storage");
+    expect(storageRow?.changed).toBe(true);
+    expect(storageRow?.previousLabel).toBe("250 GB storage");
+    expect(storageRow?.label).toBe("30 GB storage");
+  });
+
+  test("removing a deprecated seed credit bundle is detected as a change", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      // credits_100 is not present in the fixture's credit_tiers (deprecated).
+      seed: { machineTier: "medium", storageTier: "xs", creditTier: "credits_100" },
+      machineTier: "medium",
+      storageTier: "xs",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    const creditRow = diff.rows.find((r) => r.key === "credit");
+    expect(creditRow?.changed).toBe(true);
+    expect(creditRow?.label).toBe("No extra credits");
+    // The deprecated bundle's price/label is absent from the catalog → omitted.
+    expect(creditRow?.previousLabel).toBeUndefined();
+  });
+
+  test("switching from a deprecated seed credit to a live bundle is a change with no previous label", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: { machineTier: "medium", storageTier: "xs", creditTier: "credits_100" },
+      machineTier: "medium",
+      storageTier: "xs",
+      creditChoice: "credits_50",
+    });
+
+    const creditRow = diff.rows.find((r) => r.key === "credit");
+    expect(creditRow?.changed).toBe(true);
+    expect(creditRow?.label).toBe("$50 of bundled credits");
+    expect(creditRow?.previousLabel).toBeUndefined();
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
@@ -250,7 +250,7 @@ describe("computeCustomPlanDiff — seeded reconfigure", () => {
     expect(storageRow?.label).toBe("30 GB storage");
   });
 
-  test("removing a deprecated seed credit bundle is detected as a change", () => {
+  test("removing a deprecated seed credit bundle is detected as a change but suppresses the delta", () => {
     const diff = computeCustomPlanDiff({
       proPlan: proPlan(),
       // credits_100 is not present in the fixture's credit_tiers (deprecated).
@@ -269,9 +269,13 @@ describe("computeCustomPlanDiff — seeded reconfigure", () => {
     expect(creditRow?.label).toBe("No extra credits");
     // The deprecated bundle's price/label is absent from the catalog → omitted.
     expect(creditRow?.previousLabel).toBeUndefined();
+    // The held bundle can't be priced, so the comparison is suppressed rather
+    // than mispricing it at $0.
+    expect(diff.previousTotalCents).toBeNull();
+    expect(diff.deltaCents).toBeNull();
   });
 
-  test("switching from a deprecated seed credit to a live bundle is a change with no previous label", () => {
+  test("switching from a deprecated seed credit to a live bundle is a change with no delta or previous label", () => {
     const diff = computeCustomPlanDiff({
       proPlan: proPlan(),
       seed: {
@@ -288,5 +292,9 @@ describe("computeCustomPlanDiff — seeded reconfigure", () => {
     expect(creditRow?.changed).toBe(true);
     expect(creditRow?.label).toBe("$50 of bundled credits");
     expect(creditRow?.previousLabel).toBeUndefined();
+    // The delisted seed bundle can't be priced → no trustworthy previous total,
+    // so both the previous total and the delta are suppressed.
+    expect(diff.previousTotalCents).toBeNull();
+    expect(diff.deltaCents).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -64,10 +64,8 @@ function creditLabel(tier: CreditTier | null): string {
     : "No extra credits";
 }
 
-/** Normalized token so "no credits" == "no credits" reads as unchanged. */
-function creditKey(tier: CreditTier | null): string {
-  return tier ? tier.tier : "none";
-}
+/** Single "none" token for the "No extra credits" choice/seed. */
+const NO_CREDIT_KEY = "none";
 
 export function computeCustomPlanDiff(input: {
   proPlan: ProPlan;
@@ -79,9 +77,12 @@ export function computeCustomPlanDiff(input: {
   const { proPlan, seed, machineTier, storageTier, creditChoice } = input;
 
   const machineTiers = proPlan.machine_tiers;
-  // Legacy tiers stay in the catalog only for existing subscribers; a new
-  // custom configuration must not offer them as a current/new value.
-  const storageTiers = proPlan.storage_tiers.filter((t) => !t.legacy);
+  // Resolve against the FULL catalog, legacy tiers included. This helper only
+  // resolves already-chosen values into prices/labels — it never offers dropdown
+  // options — so a known tier value (e.g. a legacy current/seed storage tier a
+  // subscriber still pays for) must resolve to its real price/label. The
+  // `!legacy` option-gating lives in the modal, not here.
+  const storageTiers = proPlan.storage_tiers;
   const creditTiers = proPlan.credit_tiers ?? [];
 
   const selectedMachine =
@@ -139,12 +140,25 @@ export function computeCustomPlanDiff(input: {
   }
 
   if (creditChoice !== "") {
-    const changed =
-      seed != null && creditKey(seedCredit) !== creditKey(selectedCredit);
+    // Detect the change from the RAW seed key, not the resolved objects: a
+    // deprecated seed bundle (absent from proPlan.credit_tiers) resolves to
+    // null, which would otherwise read identically to "No extra credits" and
+    // hide the change.
+    const seedCreditKey = seed != null ? (seed.creditTier ?? NO_CREDIT_KEY) : null;
+    const selectedCreditKey =
+      creditChoice === NO_EXTRA_CREDITS ? NO_CREDIT_KEY : creditChoice;
+    const changed = seed != null && seedCreditKey !== selectedCreditKey;
     rows.push({
       key: "credit",
       label: creditLabel(selectedCredit),
-      previousLabel: changed ? creditLabel(seedCredit) : undefined,
+      // A deprecated seed bundle's price/label is absent from the catalog, so
+      // seedCredit is null and we omit previousLabel there (mirroring a
+      // null-baseline seed machine) rather than fabricate one — previousTotalCents
+      // is best-effort for that upstream-gated case.
+      previousLabel:
+        changed && (seed.creditTier == null || seedCredit != null)
+          ? creditLabel(seedCredit)
+          : undefined,
       changed,
     });
   }

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -154,8 +154,8 @@ export function computeCustomPlanDiff(input: {
       label: creditLabel(selectedCredit),
       // A deprecated seed bundle's price/label is absent from the catalog, so
       // seedCredit is null and we omit previousLabel there (mirroring a
-      // null-baseline seed machine) rather than fabricate one — previousTotalCents
-      // is best-effort for that upstream-gated case.
+      // null-baseline seed machine) rather than fabricate one. That same
+      // unresolvable case suppresses previousTotalCents/deltaCents below.
       previousLabel:
         changed && (seed.creditTier == null || seedCredit != null)
           ? creditLabel(seedCredit)
@@ -171,6 +171,20 @@ export function computeCustomPlanDiff(input: {
     (selectedCredit?.price_cents ?? 0);
 
   if (seed == null) {
+    return { previousTotalCents: null, deltaCents: null, rows };
+  }
+
+  // A held credit tier that is a concrete enum value but absent from the catalog
+  // (a delisted/deprecated bundle) resolves to null, yet is NOT the
+  // NO_EXTRA_CREDITS sentinel — so we cannot faithfully price it. Rather than
+  // fabricate a $0 credit price (which would show a false-precise previous total
+  // and delta), suppress the whole comparison: null out previousTotalCents AND
+  // deltaCents so the modal hides the "compared to previous" line. The credit
+  // row itself is unaffected — its key-based `changed` detection and omitted
+  // previousLabel are already handled above. Defense-in-depth: such subs are
+  // routed to the manage/adjust-plan modal upstream and do not normally reach here.
+  const seedCreditUnresolved = seed.creditTier != null && seedCredit == null;
+  if (seedCreditUnresolved) {
     return { previousTotalCents: null, deltaCents: null, rows };
   }
 

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -144,7 +144,8 @@ export function computeCustomPlanDiff(input: {
     // deprecated seed bundle (absent from proPlan.credit_tiers) resolves to
     // null, which would otherwise read identically to "No extra credits" and
     // hide the change.
-    const seedCreditKey = seed != null ? (seed.creditTier ?? NO_CREDIT_KEY) : null;
+    const seedCreditKey =
+      seed != null ? (seed.creditTier ?? NO_CREDIT_KEY) : null;
     const selectedCreditKey =
       creditChoice === NO_EXTRA_CREDITS ? NO_CREDIT_KEY : creditChoice;
     const changed = seed != null && seedCreditKey !== selectedCreditKey;

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -1,0 +1,173 @@
+/**
+ * Pure diff/recap computation for the Custom Plan configurator.
+ *
+ * Owns the recap-row and signed-delta logic that the modal renders, kept free
+ * of React/JSX/tokens so it can be unit-tested in isolation and reused across
+ * the base-checkout and Pro-reconfigure paths. The modal supplies the live
+ * dropdown selection plus the seed (current plan), and consumes the returned
+ * rows and raw cents to render the recap and price delta.
+ */
+
+import {
+  formatDollars,
+  formatMonthly,
+} from "@/domains/settings/components/tier-pricing";
+import type {
+  CreditTier,
+  CreditTierEnum,
+  MachineTier,
+  MachineTierEnum,
+  ProPlan,
+  StorageTier,
+  StorageTierEnum,
+} from "@/generated/api/types.gen";
+
+import type { CustomPlanSeed } from "./custom-plan-modal";
+
+/** Sentinel for the "No extra credits" dropdown entry (Dropdown is generic over string, cannot carry real null). */
+export const NO_EXTRA_CREDITS = "__none__";
+export type CreditChoice = CreditTierEnum | typeof NO_EXTRA_CREDITS;
+
+export interface CustomPlanDiffRow {
+  /** Stable React key. */
+  key: string;
+  /** Label for the current/new value. */
+  label: string;
+  /** Present only when this dimension changed from the seed: previous value's label, shown struck-through above the new one. */
+  previousLabel?: string;
+  /** True when the dimension changed from the seed — new value gets the green check. */
+  changed: boolean;
+}
+
+export interface CustomPlanDiff {
+  /** Total for the seed (previous) config incl. base fee; null for base checkout (no seed). */
+  previousTotalCents: number | null;
+  /** newTotal - previousTotal; null for base checkout. */
+  deltaCents: number | null;
+  rows: CustomPlanDiffRow[];
+}
+
+/** `tier.description`, e.g. "Medium machine (2.5 vCPU, 5 GiB)". */
+function machineLabel(tier: MachineTier): string {
+  return tier.description;
+}
+
+/** e.g. "30 GB storage". */
+function storageLabel(tier: StorageTier): string {
+  return `${tier.storage_gib} GB storage`;
+}
+
+/** "No extra credits" for null; else "$50 of bundled credits". */
+function creditLabel(tier: CreditTier | null): string {
+  return tier
+    ? `${formatDollars(tier.credits_usd * 100)} of bundled credits`
+    : "No extra credits";
+}
+
+/** Normalized token so "no credits" == "no credits" reads as unchanged. */
+function creditKey(tier: CreditTier | null): string {
+  return tier ? tier.tier : "none";
+}
+
+export function computeCustomPlanDiff(input: {
+  proPlan: ProPlan;
+  seed: CustomPlanSeed | null;
+  machineTier: MachineTierEnum | "";
+  storageTier: StorageTierEnum | "";
+  creditChoice: CreditChoice | "";
+}): CustomPlanDiff {
+  const { proPlan, seed, machineTier, storageTier, creditChoice } = input;
+
+  const machineTiers = proPlan.machine_tiers;
+  // Legacy tiers stay in the catalog only for existing subscribers; a new
+  // custom configuration must not offer them as a current/new value.
+  const storageTiers = proPlan.storage_tiers.filter((t) => !t.legacy);
+  const creditTiers = proPlan.credit_tiers ?? [];
+
+  const selectedMachine =
+    machineTiers.find((t) => t.tier === machineTier) ?? null;
+  const selectedStorage =
+    storageTiers.find((t) => t.tier === storageTier) ?? null;
+  const selectedCredit =
+    creditChoice && creditChoice !== NO_EXTRA_CREDITS
+      ? (creditTiers.find((t) => t.tier === creditChoice) ?? null)
+      : null;
+
+  const seedMachine =
+    seed != null
+      ? (machineTiers.find((t) => t.tier === seed.machineTier) ?? null)
+      : null;
+  const seedStorage =
+    seed != null
+      ? (storageTiers.find((t) => t.tier === seed.storageTier) ?? null)
+      : null;
+  const seedCredit =
+    seed != null && seed.creditTier != null
+      ? (creditTiers.find((t) => t.tier === seed.creditTier) ?? null)
+      : null;
+
+  const rows: CustomPlanDiffRow[] = [
+    {
+      key: "base",
+      label: `Pro base plan — ${formatMonthly(proPlan.base_price_cents)}`,
+      changed: false,
+    },
+  ];
+
+  if (selectedMachine != null) {
+    const changed = seed != null && seedMachine?.tier !== selectedMachine.tier;
+    rows.push({
+      key: "machine",
+      label: machineLabel(selectedMachine),
+      // A null baseline seed machine has no representable previous value → omit
+      // previousLabel, still changed: true.
+      previousLabel:
+        changed && seedMachine != null ? machineLabel(seedMachine) : undefined,
+      changed,
+    });
+  }
+
+  if (selectedStorage != null) {
+    const changed = seed != null && seedStorage?.tier !== selectedStorage.tier;
+    rows.push({
+      key: "storage",
+      label: storageLabel(selectedStorage),
+      previousLabel:
+        changed && seedStorage != null ? storageLabel(seedStorage) : undefined,
+      changed,
+    });
+  }
+
+  if (creditChoice !== "") {
+    const changed =
+      seed != null && creditKey(seedCredit) !== creditKey(selectedCredit);
+    rows.push({
+      key: "credit",
+      label: creditLabel(selectedCredit),
+      previousLabel: changed ? creditLabel(seedCredit) : undefined,
+      changed,
+    });
+  }
+
+  const newTotalCents =
+    proPlan.base_price_cents +
+    (selectedMachine?.price_cents ?? 0) +
+    (selectedStorage?.price_cents ?? 0) +
+    (selectedCredit?.price_cents ?? 0);
+
+  if (seed == null) {
+    return { previousTotalCents: null, deltaCents: null, rows };
+  }
+
+  const previousTotalCents =
+    proPlan.base_price_cents +
+    (seedMachine?.price_cents ?? 0) +
+    (seedStorage?.price_cents ?? 0) +
+    (seedCredit?.price_cents ?? 0);
+
+  return {
+    previousTotalCents,
+    deltaCents: newTotalCents - previousTotalCents,
+    rows,
+  };
+}


### PR DESCRIPTION
## Summary
- Add pure computeCustomPlanDiff helper (rows + signed delta vs current plan) with unit tests
- Purely additive; consumed by the modal recap in the next PR

Part of plan: custom-plan-diff-recap.md (PR 1 of 2)