### PR TITLE
feat(billing): rebuild Plan section into two-card mock layout

### DIFF
--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -313,6 +313,7 @@ describe("PlanCard", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
     expect(html).toContain("plan-card-name");
     expect(html).toContain("Free");
+    expect(html).toContain("Your Current Plan");
     expect(html).toContain("plan-card-renews");
     expect(html).toContain("auto renew");
   });
@@ -320,7 +321,7 @@ describe("PlanCard", () => {
   test("shows the upgrade button for a base plan", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
     expect(html).toContain("plan-card-upgrade-button");
-    expect(html).toContain("View Plans");
+    expect(html).toContain("View All Plans");
   });
 
   test("does not render the invoices button (moved to inline table)", () => {
@@ -331,47 +332,45 @@ describe("PlanCard", () => {
   test("renders the recommended-upgrade banner (Mighty from Free)", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
     expect(html).toContain("recommended-upgrade-button");
-    expect(html).toContain("Recommended Upgrade");
+    expect(html).toContain("Recommended");
     expect(html).toContain("Mighty");
   });
 
   test("no upgrade banner when the package catalog is empty (flag off)", () => {
     const html = renderCard(baseSubscription(), emptyCatalogPlans());
+    // Only the current card renders; the recommended card (and its CTA) is gone.
     expect(html).not.toContain("recommended-upgrade-button");
-    expect(html).not.toContain("Recommended Upgrade");
   });
 
-  test("Free → Mighty chips: credits, storage, and the larger-machines unlock", () => {
+  test("Free → Mighty chips: both cards render absolute per-plan chips", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
-    // Mighty keeps the small baseline machine (machine_size null), so the third
-    // chip advertises the Pro larger-machines unlock rather than a no-op
-    // "Small Machine" row. The vCPU chip is gone entirely.
-    expect(html).toContain("Larger machines");
+    // Both peer cards render absolute chips (machine → credits → storage); the
+    // recommended (Mighty) card and the current (Free) card each show their own
+    // values, with no delta/arrow framing and no vCPU chip.
+    expect(html).toContain("$25 credits");
+    expect(html).toContain("10 GB");
+    expect(html).toContain("Small Machine");
+    // The current (Free) card shows the free baseline chips.
+    expect(html).toContain("$0 credits");
+    expect(html).toContain("4 GB");
     expect(html).not.toContain("vCPU");
-    expect(html).not.toContain("Small Machine");
-    expect(html).not.toContain("Standard");
-    // Credits step from Free's $0 to Mighty's $25 (arrow form, real change),
-    // labelled per-month.
-    expect(html).toContain("$0 → $25 credits/mo");
-    // Storage really changes (free's 4 GiB baseline → Mighty's 10 GB).
-    expect(html).toContain("4 → 10 GB");
-    expect(html).not.toContain("0 → 10 GB");
   });
 
-  test("Mighty → Super: recommends Super with a machine step-up chip", () => {
+  test("Mighty → Super: recommends Super with absolute chips on both cards", () => {
     const html = renderCard(proMightySubscription(), plansWithSuper());
     // On Mighty, the recommended upgrade is the next catalog package, Super.
     expect(html).toContain("recommended-upgrade-button");
-    expect(html).toContain("Recommended Upgrade");
+    expect(html).toContain("Recommended");
     expect(html).toContain("Super");
-    // The machine tier actually changes here, so the third chip is the machine
-    // arrow — NOT the larger-machines unlock (that's only the Free → Pro step).
-    expect(html).toContain("Small → Medium Machine");
-    expect(html).not.toContain("Larger machines");
-    // Credits and storage step up from Mighty's values.
-    expect(html).toContain("$25 → $45 credits/mo");
-    expect(html).toContain("10 → 30 GB");
-    // The current-plan row shows the actual package name "Mighty" (not the
+    // The recommended (Super) card shows Super's absolute chips.
+    expect(html).toContain("$45 credits");
+    expect(html).toContain("30 GB");
+    expect(html).toContain("Medium Machine");
+    // The current (Mighty) card shows Mighty's absolute chips.
+    expect(html).toContain("$25 credits");
+    expect(html).toContain("10 GB");
+    expect(html).toContain("Small Machine");
+    // The current-plan card shows the actual package name "Mighty" (not the
     // generic plan name "Pro").
     expect(html).toContain("plan-card-name");
     expect(html).toContain("Mighty");
@@ -391,9 +390,9 @@ describe("PlanCard", () => {
     expect(html).toContain("recommended-upgrade-button");
     expect(html).toContain("Switch plan");
     expect(html).toContain("Switch to Mighty");
-    expect(html).not.toContain("Recommended Upgrade");
-    expect(html).not.toContain("credits/mo");
-    expect(html).not.toContain("Larger machines");
+    // A neutral switch drops the "Recommended" tag and renders no stock chips on
+    // the recommended card; the current "Custom" card also has no knowable chips.
+    expect(html).not.toContain("Recommended");
   });
 
   test("a customized Pro sub's banner drops the stock upgrade framing", () => {
@@ -409,15 +408,14 @@ describe("PlanCard", () => {
     // neutral switch since the customized tiers can differ from stock Super.
     expect(html).toContain("Switch plan");
     expect(html).toContain("Switch to Super");
-    expect(html).not.toContain("Recommended Upgrade");
-    expect(html).not.toContain("credits/mo");
+    expect(html).not.toContain("Recommended");
   });
 
   test("a base user's banner keeps the directional upgrade framing", () => {
-    // Base → Pro is a genuine Stripe-checkout upgrade, so the banner keeps its
-    // "Recommended Upgrade" tag, the "Upgrade for … more" CTA, and stock deltas.
+    // Base → Pro is a genuine Stripe-checkout upgrade, so the recommended card
+    // keeps its "Recommended" tag and the "Upgrade for … more" CTA.
     const html = renderCard(baseSubscription(), basePlansResponse());
-    expect(html).toContain("Recommended Upgrade");
+    expect(html).toContain("Recommended");
     expect(html).toContain("Upgrade for");
     expect(html).not.toContain("Switch plan");
   });

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -447,6 +447,22 @@ describe("PlanCard", () => {
     expect(html).toContain("Custom");
     expect(html).not.toContain("Pro");
   });
+
+  test("a clean-pinned Pro sub whose package is absent from the catalog shows no chips", () => {
+    // A clean pin on Mighty, but the catalog has no packages (e.g. the
+    // `pro-packages` flag is off, or the pinned key isn't in this response). The
+    // package lookup misses, so the current card's specs are unknowable and it
+    // must render NO chips — crucially NOT the free baseline, which would
+    // mislabel this paid Pro sub as $0 credits / 4 GB / Small Machine.
+    const html = renderCard(proMightySubscription(), emptyCatalogPlans());
+    // The current card still names the pinned package ("Mighty"), not "Custom".
+    expect(html).toContain("plan-card-name");
+    expect(html).toContain("Mighty");
+    // No free-baseline chips leak onto the paid sub's current card.
+    expect(html).not.toContain("$0 credits");
+    expect(html).not.toContain("4 GB");
+    expect(html).not.toContain("Small Machine");
+  });
 });
 
 describe("PlanCard action button", () => {

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -36,6 +36,7 @@ import type {
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
 import * as runtimeBrowser from "@/runtime/browser";
+import { PLAN_TIER_COPY } from "@/domains/settings/billing/plans/plans-copy";
 import { routes } from "@/utils/routes";
 
 // Capture navigate() targets so the action-button wiring can be asserted
@@ -354,6 +355,9 @@ describe("PlanCard", () => {
     expect(html).toContain("$0 credits");
     expect(html).toContain("4 GB");
     expect(html).not.toContain("vCPU");
+    // A known-specs (free baseline) current card keeps its stock tagline — the
+    // tagline gate only suppresses the Custom/unknown case, not this one.
+    expect(html).toContain(PLAN_TIER_COPY.free.tagline);
   });
 
   test("Mighty → Super: recommends Super with absolute chips on both cards", () => {
@@ -433,6 +437,9 @@ describe("PlanCard", () => {
     // doesn't masquerade as a stock package.
     expect(html).toContain("Custom");
     expect(html).not.toContain("Mighty (Custom)");
+    // Its specs are unknowable (no chips), so the stock Mighty tagline must not
+    // render under the "Custom" name either — same gate as the chips.
+    expect(html).not.toContain(PLAN_TIER_COPY.mighty.tagline);
   });
 
   test("current-plan row labels an unpinned Pro sub as custom", () => {
@@ -446,6 +453,10 @@ describe("PlanCard", () => {
     expect(html).toContain("plan-card-name");
     expect(html).toContain("Custom");
     expect(html).not.toContain("Pro");
+    // `currentTier` falls back to "free" for an unpinned sub, but its specs are
+    // unknowable (no chips), so the stock free tagline must not leak in under
+    // the "Custom" name.
+    expect(html).not.toContain(PLAN_TIER_COPY.free.tagline);
   });
 
   test("a clean-pinned Pro sub whose package is absent from the catalog shows no chips", () => {

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -445,7 +445,13 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
                 Your Current Plan
               </Tag>
             }
-            tagline={currentCopy?.tagline}
+            // Gate the tagline on the same "known stock specs" condition as the
+            // chips: a Custom/unknown current plan (`currentSpecs === null`)
+            // renders as "Custom" with no chips, so showing stock marketing copy
+            // under it would reintroduce the misleading stock-plan labeling the
+            // chip guard avoids. Only the free/base baseline or a clean-pinned
+            // package (both have non-null specs) keeps its tagline.
+            tagline={currentSpecs ? currentCopy?.tagline : undefined}
             specs={currentSpecs}
           />
           <RecommendedUpgrade

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -1,11 +1,4 @@
-import {
-  Coins,
-  Computer,
-  HardDrive,
-  Loader2,
-  Rocket,
-  Sparkles,
-} from "lucide-react";
+import { Loader2, Sparkles } from "lucide-react";
 
 import { useState } from "react";
 
@@ -22,11 +15,9 @@ import {
 } from "@/domains/settings/billing/package-types";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
-import {
-  FREE_STORAGE_GIB,
-  PlanTierAvatar,
-  TIER_ACCENT,
-} from "@/domains/settings/billing/plan-tier-meta";
+import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
+import { packageSpecs } from "@/domains/settings/billing/plan-spec";
+import { PlanSpecCard } from "@/domains/settings/billing/plan-spec-card";
 import { useCheckoutDismissRefresh } from "@/domains/settings/billing/use-checkout-dismiss-refresh";
 import {
   formatGraceDate,
@@ -39,10 +30,9 @@ import {
   organizationsBillingSubscriptionRetrieveQueryKey,
   organizationsBillingSubscriptionUpgradeCreateMutation,
 } from "@/generated/api/@tanstack/react-query.gen";
-import type { MachineSizeEnum, ProPlan } from "@/generated/api/types.gen";
+import type { ProPlan } from "@/generated/api/types.gen";
 import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
-import { SIZE_LABEL } from "@/lib/billing/machine-sizes";
 import { openUrl } from "@/runtime/browser";
 import { routes } from "@/utils/routes";
 import type { ButtonProps } from "@vellumai/design-library/components/button";
@@ -73,7 +63,7 @@ const PLAN_DISPLAY: Record<string, PlanDisplay> = {
     showsRenewal: true,
   },
   base: {
-    actionLabel: "View Plans",
+    actionLabel: "View All Plans",
     actionVariant: "primary",
     actionTestId: "plan-card-upgrade-button",
     showsRenewal: true,
@@ -102,76 +92,6 @@ function PlanHeading() {
       Plan
     </Typography>
   );
-}
-
-/**
- * The "standard" machine a package with no `machine_size` runs on — the small
- * baseline that Free and machine-less Pro packages (e.g. Mighty) share.
- */
-const STANDARD_MACHINE_LABEL = "Small";
-
-/** Machine size label for a package (or the standard small machine). */
-function machineLabel(pkg: ProPackage | null): string {
-  if (!pkg?.machine_size) {
-    return STANDARD_MACHINE_LABEL;
-  }
-  const size = pkg.machine_size as MachineSizeEnum;
-  return SIZE_LABEL[size] ?? pkg.machine_size;
-}
-
-interface ResourceDelta {
-  icon: typeof Computer;
-  label: string;
-}
-
-/** "X → Y" only when the resource actually changes; the bare value otherwise. */
-function arrow(from: string, to: string): string {
-  return from === to ? to : `${from} → ${to}`;
-}
-
-/**
- * The (max three) chips shown on the recommended-upgrade card. Credits and
- * storage change at every step of the catalog, so they anchor the first two
- * slots. The third slot shows the machine `from → to` when the tier steps up;
- * on the Free → Pro step the machine stays on the small baseline, but Pro
- * unlocks the `LARGER_MACHINE` entitlement, so it advertises that scale-up
- * headroom instead of a no-op "Small Machine" chip. A step that changes neither
- * (not in the current catalog) simply shows the two anchor chips.
- */
-function buildDeltas(
-  recommended: ProPackage,
-  currentPackage: ProPackage | null,
-): ResourceDelta[] {
-  const fromCredits = currentPackage?.credits_usd ?? 0;
-  const toCredits = recommended.credits_usd ?? 0;
-  const fromStorage = currentPackage?.storage_gib ?? FREE_STORAGE_GIB;
-
-  const deltas: ResourceDelta[] = [
-    {
-      icon: Coins,
-      label: `${arrow(`$${fromCredits}`, `$${toCredits}`)} credits/mo`,
-    },
-    {
-      icon: HardDrive,
-      label: `${arrow(String(fromStorage), String(recommended.storage_gib))} GB`,
-    },
-  ];
-
-  const fromMachine = machineLabel(currentPackage);
-  const toMachine = machineLabel(recommended);
-  if (fromMachine !== toMachine) {
-    deltas.push({
-      icon: Computer,
-      label: `${fromMachine} → ${toMachine} Machine`,
-    });
-  } else if (currentPackage === null) {
-    // Free → Pro keeps the small baseline machine, but Pro unlocks the
-    // ability to scale to larger machines — surface that capability rather
-    // than a static "Small Machine" chip that reads as no upgrade.
-    deltas.push({ icon: Rocket, label: "Larger machines" });
-  }
-
-  return deltas;
 }
 
 interface RecommendedUpgradeProps {
@@ -230,25 +150,23 @@ function RecommendedUpgrade({
   useCheckoutDismissRefresh();
 
   const recommended = nextPackageUp(packages, currentKey);
-  if (!recommended) return null;
+  if (!recommended) {
+    return null;
+  }
 
   const currentPackage = currentKey
     ? (packages.find((p) => p.key === currentKey) ?? null)
     : null;
-  const currentPriceCents = currentPackage?.total_price_cents ?? 0;
-  const deltas = buildDeltas(recommended, currentPackage);
-  const priceLabel = `${formatMonthly(recommended.total_price_cents).replace("/mo", "")} / Monthly`;
-  const deltaCents = recommended.total_price_cents - currentPriceCents;
+  const deltaCents =
+    recommended.total_price_cents - (currentPackage?.total_price_cents ?? 0);
   // A Custom (customized or unpinned) sub's real tiers can diverge from any
-  // stock package, so the stock price delta and stock resource deltas would
+  // stock package, so the stock price delta and stock resource chips would
   // misstate the direction and size of the change. The neutral "switch"
   // relation drops the delta framing and offers the named plan by itself.
   const isNeutralSwitch = relation === "switch";
   const upgradeLabel = isNeutralSwitch
     ? `Switch to ${recommended.name}`
     : `Upgrade for ${formatMonthly(deltaCents)} more`;
-  const accent = TIER_ACCENT[recommended.key] ?? TIER_ACCENT.free;
-  const tint = `color-mix(in srgb, ${accent} 10%, transparent)`;
   const isPending = pending || upgradeMutation.isPending || changePending;
 
   // Pro users change their package in place: confirm the prorated charge, then
@@ -328,79 +246,41 @@ function RecommendedUpgrade({
     }
   };
 
-  return (
-    <div
-      className="flex flex-col gap-6 rounded-lg p-3"
-      style={{ backgroundColor: tint }}
+  const recommendedCopy = getPlanTierCopy(recommended.key);
+  const upgradeButton = (
+    <Button
+      variant="primary"
+      className="shrink-0"
+      onClick={handleUpgrade}
+      disabled={isPending}
+      leftIcon={
+        isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined
+      }
+      data-testid="recommended-upgrade-button"
     >
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <PlanTierAvatar tier={recommended.key} />
-          <div className="flex flex-col gap-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <Typography
-                as="span"
-                variant="body-large-default"
-                className="text-[var(--content-default)]"
-              >
-                {recommended.name}
-              </Typography>
-              <Tag
-                className="bg-[var(--feed-digest-weak)] text-[var(--credits-accent)]"
-                leftIcon={
-                  <Sparkles className="h-3 w-3 text-[var(--credits-accent)]" />
-                }
-              >
-                {isNeutralSwitch ? "Switch plan" : "Recommended Upgrade"}
-              </Tag>
-            </div>
-            <Typography
-              as="span"
-              variant="body-small-default"
-              className="text-[var(--content-tertiary)]"
-            >
-              {priceLabel}
-            </Typography>
-          </div>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          {!isNeutralSwitch &&
-            deltas.map((delta) => {
-              const Icon = delta.icon;
-              return (
-                <div
-                  key={delta.label}
-                  className="flex h-8 items-center gap-1.5 rounded-lg px-2 py-1.5"
-                  style={{ backgroundColor: tint }}
-                >
-                  <Icon
-                    className="h-3.5 w-3.5 shrink-0 text-[var(--content-default)]"
-                    aria-hidden
-                  />
-                  <Typography
-                    as="span"
-                    variant="body-medium-default"
-                    className="whitespace-nowrap text-[var(--content-default)]"
-                  >
-                    {delta.label}
-                  </Typography>
-                </div>
-              );
-            })}
-        </div>
-      </div>
-      <Button
-        variant="primary"
-        className="self-start"
-        onClick={handleUpgrade}
-        disabled={isPending}
-        leftIcon={
-          isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined
+      {upgradeLabel}
+    </Button>
+  );
+  return (
+    <>
+      <PlanSpecCard
+        tone="dark"
+        tierKey={recommended.key}
+        name={recommended.name}
+        tag={
+          <Tag
+            className="bg-[var(--feed-digest-weak)] text-[var(--credits-accent)]"
+            leftIcon={
+              <Sparkles className="h-3 w-3 text-[var(--credits-accent)]" />
+            }
+          >
+            {isNeutralSwitch ? "Switch plan" : "Recommended"}
+          </Tag>
         }
-        data-testid="recommended-upgrade-button"
-      >
-        {upgradeLabel}
-      </Button>
+        tagline={recommendedCopy?.tagline}
+        specs={isNeutralSwitch ? null : packageSpecs(recommended)}
+        action={upgradeButton}
+      />
       <PackageSwitchConfirmModal
         open={confirmOpen}
         relation={relation}
@@ -409,7 +289,7 @@ function RecommendedUpgrade({
         onConfirm={() => void handleConfirmChange()}
         onCancel={() => setConfirmOpen(false)}
       />
-    </div>
+    </>
   );
 }
 
@@ -487,7 +367,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   // `switchRelation`.
   const canChangePackage = isPackageSwitchEligible(subscription);
   // A base user (Stripe checkout) and a clean-pinned Pro sub both make a real
-  // upgrade, so the banner keeps its directional copy and stock deltas. Only a
+  // upgrade, so the banner keeps its directional copy and stock chips. Only a
   // Custom Pro sub — a customized pin or an unpinned legacy sub, whose real
   // tiers can diverge from any stock package — gets the direction-neutral
   // switch, since a stock delta could misstate the change.
@@ -496,11 +376,48 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
       ? "upgrade"
       : "switch";
 
+  const currentCopy = getPlanTierCopy(currentTier);
+  // The current card shows absolute chips only when its specs are knowable: the
+  // free/base baseline, or a clean-pinned stock package. A customized pin or an
+  // unpinned legacy Pro sub (both read "Custom") has tiers that can diverge from
+  // any stock package, so it renders no chips.
+  const currentStockPackage =
+    currentPlan.id === "base"
+      ? null
+      : isCleanPin(subscription.package)
+        ? (packages.find((p) => p.key === currentKey) ?? null)
+        : undefined; // undefined = unknown specs → no chips
+  const currentSpecs =
+    currentStockPackage === undefined ? null : packageSpecs(currentStockPackage);
+
   return (
     <Card padding="md">
       <div className="flex flex-col gap-4">
-        <div className="flex items-center justify-between gap-3">
-          <PlanHeading />
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 flex-col gap-1">
+            <PlanHeading />
+            {showRenewal && (
+              <Typography
+                variant="body-small-default"
+                as="div"
+                className="leading-snug text-[var(--content-tertiary)]"
+                data-testid="plan-card-renews"
+              >
+                Monthly Payment &bull; Your subscription will auto renew on{" "}
+                {formatGraceDate(subscription.current_period_end!)}.
+              </Typography>
+            )}
+            {showCancellation && (
+              <Typography
+                variant="body-small-default"
+                as="div"
+                className="leading-snug text-[var(--system-mid-strong)]"
+                data-testid="plan-card-cancels"
+              >
+                Your plan ends on {formatGraceDate(cancelDate!)}.
+              </Typography>
+            )}
+          </div>
           <Button
             variant={display.actionVariant}
             onClick={
@@ -512,43 +429,20 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
             {display.actionLabel}
           </Button>
         </div>
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center gap-3 rounded-lg bg-[var(--surface-base)] py-1.5 pl-3 pr-2">
-            <div className="flex min-w-0 items-center gap-3">
-              <PlanTierAvatar tier={currentTier} />
-              <div className="flex min-w-0 flex-col gap-1">
-                <Typography
-                  variant="body-large-default"
-                  as="div"
-                  className="text-[var(--content-default)]"
-                  data-testid="plan-card-name"
-                >
-                  {planName}
-                </Typography>
-                {showRenewal && (
-                  <Typography
-                    variant="body-small-default"
-                    as="div"
-                    className="leading-snug text-[var(--content-tertiary)]"
-                    data-testid="plan-card-renews"
-                  >
-                    Monthly Payment &bull; Your subscription will auto renew on{" "}
-                    {formatGraceDate(subscription.current_period_end!)}.
-                  </Typography>
-                )}
-                {showCancellation && (
-                  <Typography
-                    variant="body-small-default"
-                    as="div"
-                    className="leading-snug text-[var(--system-mid-strong)]"
-                    data-testid="plan-card-cancels"
-                  >
-                    Your plan ends on {formatGraceDate(cancelDate!)}.
-                  </Typography>
-                )}
-              </div>
-            </div>
-          </div>
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-stretch">
+          <PlanSpecCard
+            tone="light"
+            tierKey={currentTier}
+            name={planName}
+            nameTestId="plan-card-name"
+            tag={
+              <Tag className="bg-[var(--feed-digest-weak)] text-[var(--content-default)]">
+                Your Current Plan
+              </Tag>
+            }
+            tagline={currentCopy?.tagline}
+            specs={currentSpecs}
+          />
           <RecommendedUpgrade
             packages={packages}
             currentKey={currentKey}

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -378,14 +378,19 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
 
   const currentCopy = getPlanTierCopy(currentTier);
   // The current card shows absolute chips only when its specs are knowable: the
-  // free/base baseline, or a clean-pinned stock package. A customized pin or an
-  // unpinned legacy Pro sub (both read "Custom") has tiers that can diverge from
-  // any stock package, so it renders no chips.
+  // free/base baseline, or a clean-pinned stock package that's present in the
+  // catalog. A customized pin or an unpinned legacy Pro sub (both read "Custom")
+  // has tiers that can diverge from any stock package; and a clean pin whose key
+  // is absent from the catalog (e.g. the `pro-packages` flag left `packages`
+  // empty, or a newer key isn't in this response) has unknown specs — both
+  // render no chips. `.find()`'s natural `undefined` for a missing package must
+  // flow through untouched: coercing it to `null` would make `packageSpecs` emit
+  // the FREE baseline, mislabeling a paid Pro sub as $0/4 GB/Small.
   const currentStockPackage =
     currentPlan.id === "base"
       ? null
       : isCleanPin(subscription.package)
-        ? (packages.find((p) => p.key === currentKey) ?? null)
+        ? packages.find((p) => p.key === currentKey)
         : undefined; // undefined = unknown specs → no chips
   const currentSpecs =
     currentStockPackage === undefined ? null : packageSpecs(currentStockPackage);


### PR DESCRIPTION
## Summary
- Rebuild PlanCard into two side-by-side PlanSpecCards (light current + dark recommended) with absolute per-plan chips
- Move renewal subtitle into the header; relabel action to 'View All Plans'
- Preserve all upgrade/switch/eligibility behavior and testids; remove buildDeltas delta logic

Part of plan: billing-plan-section-cards.md (PR 4 of 4)