### PR TITLE
feat(web): funnel event for first-run scope option clicks

### DIFF
--- a/clients/web/.cross-domain-allowlist.json
+++ b/clients/web/.cross-domain-allowlist.json
@@ -14,6 +14,12 @@
   "src/domains/chat/in-chat-onboarding/tour-telemetry.ts": [
     "onboarding"
   ],
+  "src/domains/chat/surface-actions.test.ts": [
+    "onboarding"
+  ],
+  "src/domains/chat/surface-actions.ts": [
+    "onboarding"
+  ],
   "src/domains/home/home-page.tsx": [
     "settings"
   ],

--- a/clients/web/src/domains/chat/surface-actions.test.ts
+++ b/clients/web/src/domains/chat/surface-actions.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Funnel telemetry for first-run scope option clicks.
+ *
+ * The "Let's chat" kickoff greeting renders a choice surface whose options
+ * carry `data: { firstRunScope: ... }` (see `first-run-scope.ts`). Clicking
+ * one must emit exactly one funnel event with the chosen scope — and only
+ * then: other surface actions emit nothing, failed submits emit nothing, and
+ * a throwing emitter must never break the surface-action path (telemetry is
+ * strictly fire-and-forget).
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import type { SurfaceActionResult } from "@/domains/chat/api/surfaces";
+
+let submitResult: SurfaceActionResult = { ok: true };
+let submitThrows = false;
+const submitCalls: Array<Record<string, unknown> | undefined> = [];
+
+mock.module("@/domains/chat/api/surfaces", () => ({
+  submitSurfaceAction: async (
+    _assistantId: string,
+    _surfaceId: string,
+    _actionId: string,
+    data?: Record<string, unknown>,
+  ): Promise<SurfaceActionResult> => {
+    submitCalls.push(data);
+    if (submitThrows) throw new Error("network down");
+    return submitResult;
+  },
+}));
+
+const emittedScopes: string[] = [];
+let emitThrows = false;
+
+mock.module("@/domains/onboarding/funnel-events", () => ({
+  emitFirstMessageScopeSelected: (scope: string): void => {
+    emittedScopes.push(scope);
+    if (emitThrows) throw new Error("telemetry down");
+  },
+}));
+
+const { handleSurfaceAction } = await import("@/domains/chat/surface-actions");
+const { FIRST_RUN_SCOPE_DATA_KEY } = await import(
+  "@/domains/onboarding/first-run-scope"
+);
+const { useChatSessionStore } = await import(
+  "@/domains/chat/chat-session-store"
+);
+const { useStreamStore } = await import("@/domains/chat/stream-store");
+const { useTurnStore } = await import("@/domains/chat/turn-store");
+
+beforeEach(() => {
+  submitResult = { ok: true };
+  submitThrows = false;
+  submitCalls.length = 0;
+  emittedScopes.length = 0;
+  emitThrows = false;
+  useStreamStore.getState().setStreamContext({
+    assistantId: "ast-1",
+    conversationId: "conv-1",
+  });
+  useChatSessionStore.getState().setError(null);
+  useTurnStore.getState().resetTurn();
+});
+
+describe("handleSurfaceAction — first-run scope funnel event", () => {
+  it("emits exactly one event with the chosen scope", async () => {
+    await handleSurfaceAction("srf-1", "scope_work", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "work",
+    });
+
+    expect(emittedScopes).toEqual(["work"]);
+    expect(useChatSessionStore.getState().error).toBeNull();
+  });
+
+  it("emits nothing for surface actions without the scope marker", async () => {
+    await handleSurfaceAction("srf-1", "confirm", { choice: "blue" });
+    await handleSurfaceAction("srf-1", "confirm");
+
+    expect(submitCalls).toHaveLength(2);
+    expect(emittedScopes).toEqual([]);
+  });
+
+  it("emits nothing when the marker value is not a known scope", async () => {
+    await handleSurfaceAction("srf-1", "scope_other", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "everything",
+    });
+
+    expect(emittedScopes).toEqual([]);
+  });
+
+  it("emits nothing when the submit fails", async () => {
+    submitResult = { ok: false };
+
+    await handleSurfaceAction("srf-1", "scope_personal", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "personal",
+    });
+
+    expect(emittedScopes).toEqual([]);
+    expect(useChatSessionStore.getState().error?.message).toBe(
+      "Failed to submit. Please try again.",
+    );
+  });
+
+  it("emits nothing when the submit throws", async () => {
+    submitThrows = true;
+
+    await handleSurfaceAction("srf-1", "scope_personal", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "personal",
+    });
+
+    expect(emittedScopes).toEqual([]);
+  });
+
+  it("emits nothing for guardian decision actions", async () => {
+    submitResult = { ok: true, applied: false, reason: "expired" };
+
+    await handleSurfaceAction("srf-1", "apr:allow", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "both",
+    });
+
+    expect(emittedScopes).toEqual([]);
+  });
+
+  it("a throwing emitter does not break the action path", async () => {
+    emitThrows = true;
+
+    await handleSurfaceAction("srf-1", "scope_both", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "both",
+    });
+
+    // The emitter was invoked (and threw)…
+    expect(emittedScopes).toEqual(["both"]);
+    // …but the action path completed: no error banner, and the turn store
+    // was signaled to expect a reply.
+    expect(useChatSessionStore.getState().error).toBeNull();
+    expect(useTurnStore.getState().phase).toBe("thinking");
+  });
+});

--- a/clients/web/src/domains/chat/surface-actions.ts
+++ b/clients/web/src/domains/chat/surface-actions.ts
@@ -8,6 +8,12 @@
 
 import { captureError } from "@/lib/sentry/capture-error";
 
+import {
+  FIRST_RUN_SCOPE_DATA_KEY,
+  FIRST_RUN_SCOPES,
+  type FirstRunScope,
+} from "@/domains/onboarding/first-run-scope";
+import { emitFirstMessageScopeSelected } from "@/domains/onboarding/funnel-events";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
 import { useStreamStore } from "@/domains/chat/stream-store";
@@ -27,6 +33,24 @@ const DECISION_REASON_LABELS: Record<string, string> = {
 function formatDecisionReason(reason?: string): string {
   if (!reason) return "Not applied";
   return DECISION_REASON_LABELS[reason] ?? "Not applied";
+}
+
+/**
+ * Funnel telemetry for the first-run greeting's scope options. The
+ * `firstRunScope` marker only ever appears on choice-option payloads authored
+ * by the "Let's chat" kickoff prompt (the choice surface spreads each option's
+ * `data` into its click payload), so matching on it here needs no
+ * first-message heuristics. Strictly fire-and-forget — telemetry must never
+ * block or fail the surface-action path.
+ */
+function emitFirstRunScopeTelemetry(data?: Record<string, unknown>): void {
+  const scope = data?.[FIRST_RUN_SCOPE_DATA_KEY];
+  if (!(FIRST_RUN_SCOPES as readonly unknown[]).includes(scope)) return;
+  try {
+    emitFirstMessageScopeSelected(scope as FirstRunScope);
+  } catch (err) {
+    captureError(err, { context: "first_run_scope_telemetry" });
+  }
 }
 
 /**
@@ -74,6 +98,7 @@ export async function handleSurfaceAction(
   const isGuardianDecision = typeof result.applied === "boolean";
   if (!isGuardianDecision) {
     useTurnStore.getState().requestSend();
+    emitFirstRunScopeTelemetry(data);
   }
 
   const completionText =

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -1,5 +1,6 @@
 import { isAnalyticsEnabled } from "@/domains/onboarding/prefs";
 import { postTelemetryEvents } from "@/lib/telemetry/ingest";
+import type { FirstRunScope } from "@/domains/onboarding/first-run-scope";
 import type { ResearchStep } from "@/domains/onboarding/research-onboarding-persistence";
 
 export const ONBOARDING_FUNNEL_VERSION = "onboarding_v3_2026_05";
@@ -94,6 +95,20 @@ export const RESEARCH_CHECKIN_CALENDAR_ATTRIBUTION = "research_checkin";
 export const RESEARCH_ONBOARDING_CHECKIN_STEP = {
   stepName: "research_checkin_open",
   stepIndex: 11,
+} as const satisfies OnboardingFunnelStepDescriptor;
+
+/**
+ * The first-run scope option click. Like the check-in event above, it rides
+ * RESEARCH_ONBOARDING_FUNNEL_VERSION but fires after the flow ends — from the
+ * chat surface-action path when the user clicks one of the work / personal /
+ * both options the "Let's chat" greeting renders (see `first-run-scope.ts`) —
+ * so it lives outside RESEARCH_ONBOARDING_FUNNEL_STEPS and takes the next free
+ * index. The chosen scope rides `screen`, the same dimension-in-`screen`
+ * pattern the tips and tour funnels use.
+ */
+export const FIRST_MESSAGE_SCOPE_STEP = {
+  stepName: "first_message_scope_selected",
+  stepIndex: 13,
 } as const satisfies OnboardingFunnelStepDescriptor;
 
 /**
@@ -231,6 +246,20 @@ export function emitResearchOnboardingCheckinCalendarOpened(
   emitOnboardingFunnelStepCompleted(RESEARCH_ONBOARDING_CHECKIN_STEP, {
     userId: options.userId,
     funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
+    outcome: "completed",
+  });
+}
+
+/**
+ * Emit the first-run scope option click, with the chosen scope in `screen`.
+ * Stamped with the research funnel version and `control` variant like the
+ * in-flow steps, so click-through rate is derivable against their completion
+ * rows in the same funnel.
+ */
+export function emitFirstMessageScopeSelected(scope: FirstRunScope): void {
+  emitOnboardingFunnelStepCompleted(FIRST_MESSAGE_SCOPE_STEP, {
+    funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
+    screen: scope,
     outcome: "completed",
   });
 }


### PR DESCRIPTION
## Summary
- Emits an onboarding funnel event when a first-run greeting scope option (work / personal / both) is clicked, keyed off the firstRunScope marker on choice-option payloads
- Fire-and-forget: telemetry can never block or fail the surface-action path

Note: browser onboarding funnel events are currently zeroed in BQ by the consent-gate outage — this event will only produce data once that is fixed. Shown volume ≈ existing research-onboarding completion events, so CTR is derivable.

Part of plan: first-message-scope-options.md (PR 2 of 2)