### PR TITLE
feat(web): add PaymentMethodRow for the billing payment-card display

### DIFF
--- a/clients/web/src/domains/settings/components/payment-method-row.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { PaymentMethodRow } from "./payment-method-row";
+
+afterEach(cleanup);
+
+describe("PaymentMethodRow", () => {
+  test("renders the brand and last4", () => {
+    const { getByTestId } = render(
+      <PaymentMethodRow
+        brand="Visa"
+        last4="4242"
+        onUpdateCard={() => {}}
+        onRemove={() => {}}
+      />,
+    );
+    const row = getByTestId("payment-method-row");
+    expect(row.textContent).toContain("Visa");
+    expect(row.textContent).toContain("Ending in 4242");
+  });
+
+  test("falls back to a generic label and omits the ending line when null", () => {
+    const { getByTestId } = render(
+      <PaymentMethodRow
+        brand={null}
+        last4={null}
+        onUpdateCard={() => {}}
+        onRemove={() => {}}
+      />,
+    );
+    const row = getByTestId("payment-method-row");
+    expect(row.textContent).toContain("Saved card");
+    expect(row.textContent).not.toContain("Ending in");
+    expect(row.textContent).not.toContain("null");
+  });
+
+  test("fires onUpdateCard when Update Card is clicked", () => {
+    const onUpdateCard = mock(() => {});
+    const { getByTestId } = render(
+      <PaymentMethodRow
+        brand="Visa"
+        last4="4242"
+        onUpdateCard={onUpdateCard}
+        onRemove={() => {}}
+      />,
+    );
+    fireEvent.click(getByTestId("payment-method-update"));
+    expect(onUpdateCard).toHaveBeenCalledTimes(1);
+  });
+
+  test("fires onRemove when Remove is clicked", () => {
+    const onRemove = mock(() => {});
+    const { getByTestId } = render(
+      <PaymentMethodRow
+        brand="Visa"
+        last4="4242"
+        onUpdateCard={() => {}}
+        onRemove={onRemove}
+      />,
+    );
+    fireEvent.click(getByTestId("payment-method-remove"));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  test("disables Remove and shows a pending label while removing", () => {
+    const { getByTestId } = render(
+      <PaymentMethodRow
+        brand="Visa"
+        last4="4242"
+        onUpdateCard={() => {}}
+        onRemove={() => {}}
+        removing
+      />,
+    );
+    const remove = getByTestId("payment-method-remove") as HTMLButtonElement;
+    expect(remove.disabled).toBe(true);
+    expect(remove.textContent).toContain("Removing…");
+  });
+});

--- a/clients/web/src/domains/settings/components/payment-method-row.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.tsx
@@ -1,0 +1,69 @@
+import { CreditCard } from "lucide-react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+export interface PaymentMethodRowProps {
+  brand: string | null;
+  last4: string | null;
+  onUpdateCard: () => void;
+  onRemove: () => void;
+  removing?: boolean;
+}
+
+export function PaymentMethodRow({
+  brand,
+  last4,
+  onUpdateCard,
+  onRemove,
+  removing = false,
+}: PaymentMethodRowProps) {
+  return (
+    <div
+      data-testid="payment-method-row"
+      className="flex items-center justify-between gap-2 rounded-lg bg-[var(--surface-base)] pl-3 pr-2 py-1.5"
+    >
+      <div className="flex items-center gap-2">
+        <CreditCard
+          aria-hidden
+          className="h-4 w-4 text-[var(--content-default)]"
+        />
+        <div>
+          <Typography
+            as="p"
+            variant="body-medium-default"
+            className="text-[var(--content-default)]"
+          >
+            {brand ?? "Saved card"}
+          </Typography>
+          {last4 != null && (
+            <Typography
+              as="p"
+              variant="body-small-default"
+              className="text-[var(--content-tertiary)]"
+            >
+              Ending in {last4}
+            </Typography>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outlined"
+          onClick={onUpdateCard}
+          data-testid="payment-method-update"
+        >
+          Update Card
+        </Button>
+        <Button
+          variant="dangerOutline"
+          onClick={onRemove}
+          disabled={removing}
+          data-testid="payment-method-remove"
+        >
+          {removing ? "Removing…" : "Remove"}
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a presentational PaymentMethodRow (brand/last4 + Update Card / Remove) for the Credit Balance section.

Part of plan: credit-balance-redesign.md (PR 1 of 5)