### PR TITLE
Single-source the remaining host_* proxy events from api/events

### DIFF
--- a/assistant/src/__tests__/host-transfer-pending-interactions.test.ts
+++ b/assistant/src/__tests__/host-transfer-pending-interactions.test.ts
@@ -3,19 +3,17 @@
  * registration.
  *
  * Verifies:
- * - HostTransferRequest and HostTransferCancelRequest are part of ServerMessage
+ * - HostTransferRequestEvent and HostTransferCancelEvent are part of ServerMessage
  * - "host_transfer" is a valid PendingInteraction kind
  * - host_transfer interactions survive removeByConversation (not auto-denied)
  */
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type {
-  HostTransferCancelRequest,
-  HostTransferRequest,
-  HostTransferToHostRequest,
-  HostTransferToSandboxRequest,
-  ServerMessage,
-} from "../daemon/message-protocol.js";
+  HostTransferCancelEvent,
+  HostTransferRequestEvent,
+} from "../api/events/host-transfer.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 
 // ---------------------------------------------------------------------------
@@ -23,8 +21,8 @@ import * as pendingInteractions from "../runtime/pending-interactions.js";
 // ---------------------------------------------------------------------------
 
 describe("HostTransfer message types", () => {
-  test("HostTransferToHostRequest is assignable to ServerMessage", () => {
-    const msg: HostTransferToHostRequest = {
+  test("host_transfer to_host request is assignable to ServerMessage", () => {
+    const msg: HostTransferRequestEvent = {
       type: "host_transfer_request",
       requestId: "req-1",
       conversationId: "conv-1",
@@ -39,8 +37,8 @@ describe("HostTransfer message types", () => {
     expect(_sm.type).toBe("host_transfer_request");
   });
 
-  test("HostTransferToSandboxRequest is assignable to ServerMessage", () => {
-    const msg: HostTransferToSandboxRequest = {
+  test("host_transfer to_sandbox request is assignable to ServerMessage", () => {
+    const msg: HostTransferRequestEvent = {
       type: "host_transfer_request",
       requestId: "req-2",
       conversationId: "conv-1",
@@ -52,8 +50,8 @@ describe("HostTransfer message types", () => {
     expect(_sm.type).toBe("host_transfer_request");
   });
 
-  test("HostTransferCancelRequest is assignable to ServerMessage", () => {
-    const msg: HostTransferCancelRequest = {
+  test("HostTransferCancelEvent is assignable to ServerMessage", () => {
+    const msg: HostTransferCancelEvent = {
       type: "host_transfer_cancel",
       requestId: "req-3",
       conversationId: "conv-1",
@@ -62,8 +60,8 @@ describe("HostTransfer message types", () => {
     expect(_sm.type).toBe("host_transfer_cancel");
   });
 
-  test("HostTransferRequest union covers both directions", () => {
-    const toHost: HostTransferRequest = {
+  test("HostTransferRequestEvent union covers both directions", () => {
+    const toHost: HostTransferRequestEvent = {
       type: "host_transfer_request",
       requestId: "req-4",
       conversationId: "conv-1",
@@ -74,7 +72,7 @@ describe("HostTransfer message types", () => {
       sha256: "def456",
       overwrite: true,
     };
-    const toSandbox: HostTransferRequest = {
+    const toSandbox: HostTransferRequestEvent = {
       type: "host_transfer_request",
       requestId: "req-5",
       conversationId: "conv-1",

--- a/assistant/src/api/events/host-app-control.ts
+++ b/assistant/src/api/events/host-app-control.ts
@@ -1,0 +1,146 @@
+/**
+ * Host app-control proxy SSE events (`host_app_control_request` /
+ * `host_app_control_cancel`).
+ *
+ * Server → client instructions that proxy app-control actions (start,
+ * observe, press, combo, sequence, type, click, drag, stop) to the desktop
+ * client, targeting a specific application by bundle ID or process name. The
+ * client executes the action and POSTs the result back to
+ * `/v1/host-app-control-result`. `host_app_control_cancel` withdraws an
+ * in-flight request.
+ *
+ * Canonical wire-contract source. Daemon code imports the types
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+const HostAppControlStartInputSchema = z.object({
+  tool: z.literal("start"),
+  /** Bundle ID (preferred) or process name. */
+  app: z.string(),
+  /** Optional command-line arguments to launch the app with. */
+  args: z.array(z.string()).optional(),
+});
+
+const HostAppControlObserveInputSchema = z.object({
+  tool: z.literal("observe"),
+  app: z.string(),
+  /** Milliseconds to wait before capturing the window (default ~200ms). */
+  settle_ms: z.number().optional(),
+});
+
+const HostAppControlPressInputSchema = z.object({
+  tool: z.literal("press"),
+  app: z.string(),
+  /** Single key identifier, e.g. "return", "a", "f12". */
+  key: z.string(),
+  /** Modifier list, e.g. ["cmd", "shift"]. */
+  modifiers: z.array(z.string()).optional(),
+  /** Hold duration in milliseconds. */
+  duration_ms: z.number().optional(),
+});
+
+const HostAppControlComboInputSchema = z.object({
+  tool: z.literal("combo"),
+  app: z.string(),
+  /** Sequence of keys pressed simultaneously, e.g. ["cmd", "shift", "4"]. */
+  keys: z.array(z.string()),
+  /** Hold duration in milliseconds. */
+  duration_ms: z.number().optional(),
+});
+
+/** A single step inside a sequence: one key press with optional modifiers, hold duration, and post-press gap. */
+export const HostAppControlSequenceStepSchema = z.object({
+  /** Single key identifier, e.g. "right", "a", "return". */
+  key: z.string(),
+  /** Modifier list, e.g. ["cmd", "shift"]. Omit for no modifiers. */
+  modifiers: z.array(z.string()).optional(),
+  /** Hold duration for this key in milliseconds. */
+  duration_ms: z.number().optional(),
+  /** Pause after this step before starting the next, in milliseconds. */
+  gap_ms: z.number().optional(),
+});
+
+export type HostAppControlSequenceStep = z.infer<
+  typeof HostAppControlSequenceStepSchema
+>;
+
+const HostAppControlSequenceInputSchema = z.object({
+  tool: z.literal("sequence"),
+  app: z.string(),
+  /** Ordered list of single-key presses to execute serially. */
+  steps: z.array(HostAppControlSequenceStepSchema),
+});
+
+const HostAppControlTypeInputSchema = z.object({
+  tool: z.literal("type"),
+  app: z.string(),
+  text: z.string(),
+});
+
+const HostAppControlClickInputSchema = z.object({
+  tool: z.literal("click"),
+  app: z.string(),
+  x: z.number(),
+  y: z.number(),
+  button: z.enum(["left", "right", "middle"]).optional(),
+  double: z.boolean().optional(),
+});
+
+const HostAppControlDragInputSchema = z.object({
+  tool: z.literal("drag"),
+  app: z.string(),
+  from_x: z.number(),
+  from_y: z.number(),
+  to_x: z.number(),
+  to_y: z.number(),
+  button: z.enum(["left", "right", "middle"]).optional(),
+});
+
+const HostAppControlStopInputSchema = z.object({
+  tool: z.literal("stop"),
+  /** Optional — when omitted the proxy stops whichever app currently holds the session. */
+  app: z.string().optional(),
+  /** Free-form reason, surfaced for logging. */
+  reason: z.string().optional(),
+});
+
+/** Inputs accepted by the nine app-control tool variants. */
+export const HostAppControlInputSchema = z.discriminatedUnion("tool", [
+  HostAppControlStartInputSchema,
+  HostAppControlObserveInputSchema,
+  HostAppControlPressInputSchema,
+  HostAppControlComboInputSchema,
+  HostAppControlSequenceInputSchema,
+  HostAppControlTypeInputSchema,
+  HostAppControlClickInputSchema,
+  HostAppControlDragInputSchema,
+  HostAppControlStopInputSchema,
+]);
+
+export type HostAppControlInput = z.infer<typeof HostAppControlInputSchema>;
+
+export const HostAppControlRequestEventSchema = z.object({
+  type: z.literal("host_app_control_request"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  /** "app_control_start", "app_control_observe", etc. */
+  toolName: z.string(),
+  input: HostAppControlInputSchema,
+});
+
+export type HostAppControlRequestEvent = z.infer<
+  typeof HostAppControlRequestEventSchema
+>;
+
+export const HostAppControlCancelEventSchema = z.object({
+  type: z.literal("host_app_control_cancel"),
+  requestId: z.string(),
+  conversationId: z.string(),
+});
+
+export type HostAppControlCancelEvent = z.infer<
+  typeof HostAppControlCancelEventSchema
+>;

--- a/assistant/src/api/events/host-browser.ts
+++ b/assistant/src/api/events/host-browser.ts
@@ -1,0 +1,43 @@
+/**
+ * Host-browser proxy SSE events (`host_browser_request` /
+ * `host_browser_cancel`).
+ *
+ * Server → client instructions that proxy CDP (Chrome DevTools Protocol)
+ * commands to a browser attached on the desktop host (or chrome extension).
+ * The client executes the command and POSTs the result back to
+ * `/v1/host-browser-result`. `host_browser_cancel` withdraws an in-flight
+ * request.
+ *
+ * Canonical wire-contract source. Daemon code imports the types
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const HostBrowserRequestEventSchema = z.object({
+  type: z.literal("host_browser_request"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  /** CDP method name, e.g. "Page.navigate", "Runtime.evaluate". */
+  cdpMethod: z.string(),
+  /** Opaque JSON params object forwarded verbatim to CDP. */
+  cdpParams: z.record(z.string(), z.unknown()).optional(),
+  /** Optional CDP target/session ID; omitted = "most-recently-active tab". */
+  cdpSessionId: z.string().optional(),
+  /** Client-side timeout hint; defaults to 30s in the proxy. */
+  timeout_seconds: z.number().optional(),
+});
+
+export type HostBrowserRequestEvent = z.infer<
+  typeof HostBrowserRequestEventSchema
+>;
+
+export const HostBrowserCancelEventSchema = z.object({
+  type: z.literal("host_browser_cancel"),
+  requestId: z.string(),
+});
+
+export type HostBrowserCancelEvent = z.infer<
+  typeof HostBrowserCancelEventSchema
+>;

--- a/assistant/src/api/events/host-file.ts
+++ b/assistant/src/api/events/host-file.ts
@@ -1,0 +1,65 @@
+/**
+ * Host-file proxy SSE events (`host_file_request` / `host_file_cancel`).
+ *
+ * Server → client instructions that proxy file operations (read / write /
+ * edit) to the desktop client when running as a managed assistant. The
+ * request is a discriminated union on `operation`; the client executes it
+ * and POSTs the result back to `/v1/host-file-result`. `host_file_cancel`
+ * withdraws an in-flight request.
+ *
+ * Canonical wire-contract source. Daemon code imports the types
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+const HostFileReadRequestSchema = z.object({
+  type: z.literal("host_file_request"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  targetClientId: z.string().optional(),
+  operation: z.literal("read"),
+  path: z.string(),
+  offset: z.number().optional(),
+  limit: z.number().optional(),
+});
+
+const HostFileWriteRequestSchema = z.object({
+  type: z.literal("host_file_request"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  targetClientId: z.string().optional(),
+  operation: z.literal("write"),
+  path: z.string(),
+  content: z.string(),
+});
+
+const HostFileEditRequestSchema = z.object({
+  type: z.literal("host_file_request"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  targetClientId: z.string().optional(),
+  operation: z.literal("edit"),
+  path: z.string(),
+  old_string: z.string(),
+  new_string: z.string(),
+  replace_all: z.boolean().optional(),
+});
+
+export const HostFileRequestEventSchema = z.discriminatedUnion("operation", [
+  HostFileReadRequestSchema,
+  HostFileWriteRequestSchema,
+  HostFileEditRequestSchema,
+]);
+
+export type HostFileRequestEvent = z.infer<typeof HostFileRequestEventSchema>;
+
+export const HostFileCancelEventSchema = z.object({
+  type: z.literal("host_file_cancel"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  targetClientId: z.string().optional(),
+});
+
+export type HostFileCancelEvent = z.infer<typeof HostFileCancelEventSchema>;

--- a/assistant/src/api/events/host-transfer.ts
+++ b/assistant/src/api/events/host-transfer.ts
@@ -1,0 +1,59 @@
+/**
+ * Host-transfer proxy SSE events (`host_transfer_request` /
+ * `host_transfer_cancel`).
+ *
+ * Server → client instructions that proxy bidirectional file transfer
+ * between the sandbox and the host machine. The request is a discriminated
+ * union on `direction` (`to_host` uploads to the host; `to_sandbox` pulls a
+ * host file into the sandbox). `host_transfer_cancel` withdraws an in-flight
+ * request.
+ *
+ * Canonical wire-contract source. Daemon code imports the types
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+const HostTransferToHostRequestSchema = z.object({
+  type: z.literal("host_transfer_request"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  targetClientId: z.string().optional(),
+  direction: z.literal("to_host"),
+  transferId: z.string(),
+  destPath: z.string(),
+  sizeBytes: z.number(),
+  sha256: z.string(),
+  overwrite: z.boolean(),
+});
+
+const HostTransferToSandboxRequestSchema = z.object({
+  type: z.literal("host_transfer_request"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  targetClientId: z.string().optional(),
+  direction: z.literal("to_sandbox"),
+  transferId: z.string(),
+  sourcePath: z.string(),
+});
+
+export const HostTransferRequestEventSchema = z.discriminatedUnion(
+  "direction",
+  [HostTransferToHostRequestSchema, HostTransferToSandboxRequestSchema],
+);
+
+export type HostTransferRequestEvent = z.infer<
+  typeof HostTransferRequestEventSchema
+>;
+
+export const HostTransferCancelEventSchema = z.object({
+  type: z.literal("host_transfer_cancel"),
+  requestId: z.string(),
+  conversationId: z.string(),
+  targetClientId: z.string().optional(),
+});
+
+export type HostTransferCancelEvent = z.infer<
+  typeof HostTransferCancelEventSchema
+>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -38,13 +38,29 @@ import { GenerationHandoffEventSchema } from "./events/generation-handoff.js";
 import { HomeFeedUpdatedEventSchema } from "./events/home-feed-updated.js";
 import { HookEventSchema } from "./events/hook-event.js";
 import {
+  HostAppControlCancelEventSchema,
+  HostAppControlRequestEventSchema,
+} from "./events/host-app-control.js";
+import {
   HostBashCancelEventSchema,
   HostBashRequestEventSchema,
 } from "./events/host-bash.js";
 import {
+  HostBrowserCancelEventSchema,
+  HostBrowserRequestEventSchema,
+} from "./events/host-browser.js";
+import {
   HostCuCancelEventSchema,
   HostCuRequestEventSchema,
 } from "./events/host-cu.js";
+import {
+  HostFileCancelEventSchema,
+  HostFileRequestEventSchema,
+} from "./events/host-file.js";
+import {
+  HostTransferCancelEventSchema,
+  HostTransferRequestEventSchema,
+} from "./events/host-transfer.js";
 import {
   HostUiSnapshotCancelEventSchema,
   HostUiSnapshotRequestEventSchema,
@@ -297,17 +313,45 @@ export {
   HookEventSchema,
 } from "./events/hook-event.js";
 export {
+  type HostAppControlCancelEvent,
+  HostAppControlCancelEventSchema,
+  type HostAppControlInput,
+  HostAppControlInputSchema,
+  type HostAppControlRequestEvent,
+  HostAppControlRequestEventSchema,
+  type HostAppControlSequenceStep,
+  HostAppControlSequenceStepSchema,
+} from "./events/host-app-control.js";
+export {
   type HostBashCancelEvent,
   HostBashCancelEventSchema,
   type HostBashRequestEvent,
   HostBashRequestEventSchema,
 } from "./events/host-bash.js";
 export {
+  type HostBrowserCancelEvent,
+  HostBrowserCancelEventSchema,
+  type HostBrowserRequestEvent,
+  HostBrowserRequestEventSchema,
+} from "./events/host-browser.js";
+export {
   type HostCuCancelEvent,
   HostCuCancelEventSchema,
   type HostCuRequestEvent,
   HostCuRequestEventSchema,
 } from "./events/host-cu.js";
+export {
+  type HostFileCancelEvent,
+  HostFileCancelEventSchema,
+  type HostFileRequestEvent,
+  HostFileRequestEventSchema,
+} from "./events/host-file.js";
+export {
+  type HostTransferCancelEvent,
+  HostTransferCancelEventSchema,
+  type HostTransferRequestEvent,
+  HostTransferRequestEventSchema,
+} from "./events/host-transfer.js";
 export {
   type HostUiSnapshotCancelEvent,
   HostUiSnapshotCancelEventSchema,
@@ -783,10 +827,18 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   GenerationHandoffEventSchema,
   HomeFeedUpdatedEventSchema,
   HookEventSchema,
+  HostAppControlCancelEventSchema,
+  HostAppControlRequestEventSchema,
   HostBashCancelEventSchema,
   HostBashRequestEventSchema,
+  HostBrowserCancelEventSchema,
+  HostBrowserRequestEventSchema,
   HostCuCancelEventSchema,
   HostCuRequestEventSchema,
+  HostFileCancelEventSchema,
+  HostFileRequestEventSchema,
+  HostTransferCancelEventSchema,
+  HostTransferRequestEventSchema,
   HostUiSnapshotCancelEventSchema,
   HostUiSnapshotRequestEventSchema,
   IdentityChangedEventSchema,

--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from "uuid";
 
+import type { HostBrowserRequestEvent } from "../api/events/host-browser.js";
 import {
   assistantEventHub,
   broadcastMessage,
@@ -10,7 +11,6 @@ import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { sleep } from "../util/retry.js";
-import type { HostBrowserRequest } from "./message-types/host-browser.js";
 
 /** Distributive omit that preserves union variant fields. */
 type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
@@ -19,7 +19,7 @@ type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
 
 /** Clean input type for callers — transport envelope fields are added by the proxy. */
 export type HostBrowserInput = DistributiveOmit<
-  HostBrowserRequest,
+  HostBrowserRequestEvent,
   "type" | "requestId" | "conversationId"
 >;
 
@@ -112,10 +112,10 @@ function hasClientForActor(
   clients: ReadonlyArray<{ actorPrincipalId?: string }>,
   sourceActorPrincipalId?: string,
 ): boolean {
-  if (sourceActorPrincipalId == null) return clients.length > 0;
-  return clients.some(
-    (c) => c.actorPrincipalId === sourceActorPrincipalId,
-  );
+  if (sourceActorPrincipalId == null) {
+    return clients.length > 0;
+  }
+  return clients.some((c) => c.actorPrincipalId === sourceActorPrincipalId);
 }
 
 function resolveTargetClient(
@@ -132,14 +132,15 @@ function resolveTargetClient(
   const extension = all.filter((c) => c.interfaceId === "chrome-extension");
   const candidates = isExtensionOnlyMethod(cdpMethod)
     ? extension
-    : [...extension, ...all.filter((c) => c.interfaceId !== "chrome-extension")];
+    : [
+        ...extension,
+        ...all.filter((c) => c.interfaceId !== "chrome-extension"),
+      ];
 
   if (sourceActorPrincipalId == null) {
     return candidates[0];
   }
-  return candidates.find(
-    (c) => c.actorPrincipalId === sourceActorPrincipalId,
-  );
+  return candidates.find((c) => c.actorPrincipalId === sourceActorPrincipalId);
 }
 
 export class HostBrowserProxy {
@@ -231,8 +232,12 @@ export class HostBrowserProxy {
         : this.hasExtensionClient(sourceActorPrincipalId);
     const deadline = Date.now() + timeoutMs;
     for (;;) {
-      if (connected()) return true;
-      if (Date.now() >= deadline) return false;
+      if (connected()) {
+        return true;
+      }
+      if (Date.now() >= deadline) {
+        return false;
+      }
       await sleep(EXTENSION_RECONNECT_POLL_MS);
     }
   }
@@ -294,7 +299,9 @@ export class HostBrowserProxy {
         targetClientId: preferredClient.clientId,
         op: "host_browser",
       });
-      if (rejection) return Promise.resolve(rejection);
+      if (rejection) {
+        return Promise.resolve(rejection);
+      }
     }
 
     // Pseudo-methods can only be served by the Chrome extension. Fail fast

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from "uuid";
 
+import type { HostFileRequestEvent } from "../api/events/host-file.js";
 import {
   assistantEventHub,
   broadcastMessage,
@@ -15,7 +16,6 @@ import { readImageBase64 } from "../tools/shared/filesystem/image-read.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
-import type { HostFileRequest } from "./message-types/host-file.js";
 
 /** Distributive omit that preserves union variant fields. */
 type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
@@ -24,7 +24,7 @@ type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
 
 /** Clean input type for callers — transport envelope fields are added by the proxy. */
 export type HostFileInput = DistributiveOmit<
-  HostFileRequest,
+  HostFileRequestEvent,
   "type" | "requestId" | "conversationId"
 >;
 
@@ -126,7 +126,9 @@ export class HostFileProxy {
         targetClientId: resolvedTargetClientId,
         op: "host_file",
       });
-      if (rejection) return Promise.resolve(rejection);
+      if (rejection) {
+        return Promise.resolve(rejection);
+      }
     }
 
     const requestId = uuid();

--- a/assistant/src/daemon/message-types/host-app-control.ts
+++ b/assistant/src/daemon/message-types/host-app-control.ts
@@ -1,131 +1,24 @@
 // Host app-control proxy types.
-// Enables proxying app-control actions (start, observe, press, combo, type,
-// click, drag, stop) to the desktop client (host machine) when running as a
-// managed assistant. Targets a specific application by bundle ID or process
-// name — distinct from the system-wide computer-use proxy in host-cu.ts.
+//
+// The server→client events (`host_app_control_request` / `_cancel`) and the
+// tool-input union (`HostAppControlInput`) are single-sourced from their
+// canonical `api/events` wire schema. `HostAppControlResultPayload` is the HTTP
+// body the client POSTs to /v1/host-app-control-result — a route contract, not
+// an event.
 
-// === Tool input discriminated union ===
+import type { HostAppControlCancelEvent } from "../../api/events/host-app-control.js";
+import type { HostAppControlRequestEvent } from "../../api/events/host-app-control.js";
 
-/** Inputs accepted by the nine app-control tool variants. */
-export type HostAppControlInput =
-  | HostAppControlStartInput
-  | HostAppControlObserveInput
-  | HostAppControlPressInput
-  | HostAppControlComboInput
-  | HostAppControlSequenceInput
-  | HostAppControlTypeInput
-  | HostAppControlClickInput
-  | HostAppControlDragInput
-  | HostAppControlStopInput;
+export type {
+  HostAppControlInput,
+  HostAppControlSequenceStep,
+} from "../../api/events/host-app-control.js";
 
-export interface HostAppControlStartInput {
-  tool: "start";
-  /** Bundle ID (preferred) or process name. */
-  app: string;
-  /** Optional command-line arguments to launch the app with. */
-  args?: string[];
-}
+// --- Domain-level union aliases (consumed by the barrel file) ---
 
-export interface HostAppControlObserveInput {
-  tool: "observe";
-  app: string;
-  /**
-   * Milliseconds to wait between receiving the request and capturing the
-   * window. Lets the target app process pending input and the WindowServer
-   * composite a fresh frame. When omitted, the client uses its default
-   * (~200ms, sized for emulator-class apps at 60fps). Pass `0` for static
-   * UIs to make `observe` snappier; raise it for slow-feedback apps.
-   */
-  settle_ms?: number;
-}
-
-export interface HostAppControlPressInput {
-  tool: "press";
-  app: string;
-  /** Single key identifier, e.g. "return", "a", "f12". */
-  key: string;
-  /** Modifier list, e.g. ["cmd", "shift"]. */
-  modifiers?: string[];
-  /** Hold duration in milliseconds. */
-  duration_ms?: number;
-}
-
-export interface HostAppControlComboInput {
-  tool: "combo";
-  app: string;
-  /** Sequence of keys pressed simultaneously, e.g. ["cmd", "shift", "4"]. */
-  keys: string[];
-  /** Hold duration in milliseconds. */
-  duration_ms?: number;
-}
-
-/** A single step inside a sequence: one key press with optional modifiers, hold duration, and post-press gap. */
-export interface HostAppControlSequenceStep {
-  /** Single key identifier, e.g. "right", "a", "return". */
-  key: string;
-  /** Modifier list, e.g. ["cmd", "shift"]. Omit for no modifiers. */
-  modifiers?: string[];
-  /** Hold duration for this key in milliseconds. */
-  duration_ms?: number;
-  /** Pause after this step before starting the next, in milliseconds. */
-  gap_ms?: number;
-}
-
-export interface HostAppControlSequenceInput {
-  tool: "sequence";
-  app: string;
-  /** Ordered list of single-key presses to execute serially. */
-  steps: HostAppControlSequenceStep[];
-}
-
-export interface HostAppControlTypeInput {
-  tool: "type";
-  app: string;
-  text: string;
-}
-
-export interface HostAppControlClickInput {
-  tool: "click";
-  app: string;
-  x: number;
-  y: number;
-  button?: "left" | "right" | "middle";
-  double?: boolean;
-}
-
-export interface HostAppControlDragInput {
-  tool: "drag";
-  app: string;
-  from_x: number;
-  from_y: number;
-  to_x: number;
-  to_y: number;
-  button?: "left" | "right" | "middle";
-}
-
-export interface HostAppControlStopInput {
-  tool: "stop";
-  /** Optional — when omitted the proxy stops whichever app currently holds the session. */
-  app?: string;
-  /** Free-form reason, surfaced for logging. */
-  reason?: string;
-}
-
-// === Server → Client ===
-
-export interface HostAppControlRequest {
-  type: "host_app_control_request";
-  requestId: string;
-  conversationId: string;
-  toolName: string; // "app_control_start", "app_control_observe", etc.
-  input: HostAppControlInput;
-}
-
-export interface HostAppControlCancel {
-  type: "host_app_control_cancel";
-  requestId: string;
-  conversationId: string;
-}
+export type _HostAppControlServerMessages =
+  | HostAppControlRequestEvent
+  | HostAppControlCancelEvent;
 
 // === Result payload (HTTP /v1/host-app-control-result body) ===
 
@@ -142,9 +35,3 @@ export interface HostAppControlResultPayload {
   executionResult?: string;
   executionError?: string;
 }
-
-// --- Domain-level union aliases (consumed by the barrel file) ---
-
-export type _HostAppControlServerMessages =
-  | HostAppControlRequest
-  | HostAppControlCancel;

--- a/assistant/src/daemon/message-types/host-browser.ts
+++ b/assistant/src/daemon/message-types/host-browser.ts
@@ -1,27 +1,12 @@
 // Host browser proxy types.
-// Enables proxying CDP commands to the desktop client (host machine)
-// when running as a managed assistant.
+//
+// The server→client CDP proxy events (`host_browser_request` /
+// `host_browser_cancel`) are single-sourced from their canonical `api/events`
+// wire schema. The client→server events below are unsolicited signals the
+// chrome extension pushes back to the runtime.
 
-// === Server → Client ===
-
-export interface HostBrowserRequest {
-  type: "host_browser_request";
-  requestId: string;
-  conversationId: string;
-  /** CDP method name, e.g. "Page.navigate", "Runtime.evaluate", "Accessibility.getFullAXTree". */
-  cdpMethod: string;
-  /** Opaque JSON params object forwarded verbatim to CDP. */
-  cdpParams?: Record<string, unknown>;
-  /** Optional CDP target/session ID; omitted = "most-recently-active tab". */
-  cdpSessionId?: string;
-  /** Client-side timeout hint; defaults to 30s in the proxy. */
-  timeout_seconds?: number;
-}
-
-export interface HostBrowserCancelRequest {
-  type: "host_browser_cancel";
-  requestId: string;
-}
+import type { HostBrowserCancelEvent } from "../../api/events/host-browser.js";
+import type { HostBrowserRequestEvent } from "../../api/events/host-browser.js";
 
 // === Client → Server ===
 
@@ -92,8 +77,8 @@ export interface HostBrowserSessionInvalidated {
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _HostBrowserServerMessages =
-  | HostBrowserRequest
-  | HostBrowserCancelRequest;
+  | HostBrowserRequestEvent
+  | HostBrowserCancelEvent;
 
 export type _HostBrowserClientMessages =
   | HostBrowserEvent

--- a/assistant/src/daemon/message-types/host-file.ts
+++ b/assistant/src/daemon/message-types/host-file.ts
@@ -1,54 +1,12 @@
-// Host file proxy types.
-// Enables proxying file operations to the desktop client (host machine)
-// when running as a managed assistant.
+// Host file proxy events.
+//
+// Server→client events are single-sourced from their canonical `api/events`
+// wire schemas; this file only composes them into the domain union consumed by
+// `message-protocol.ts`.
 
-// === Server → Client ===
+import type { HostFileCancelEvent } from "../../api/events/host-file.js";
+import type { HostFileRequestEvent } from "../../api/events/host-file.js";
 
-export interface HostFileReadRequest {
-  type: "host_file_request";
-  requestId: string;
-  conversationId: string;
-  targetClientId?: string;
-  operation: "read";
-  path: string;
-  offset?: number;
-  limit?: number;
-}
-
-export interface HostFileWriteRequest {
-  type: "host_file_request";
-  requestId: string;
-  conversationId: string;
-  targetClientId?: string;
-  operation: "write";
-  path: string;
-  content: string;
-}
-
-export interface HostFileEditRequest {
-  type: "host_file_request";
-  requestId: string;
-  conversationId: string;
-  targetClientId?: string;
-  operation: "edit";
-  path: string;
-  old_string: string;
-  new_string: string;
-  replace_all?: boolean;
-}
-
-export type HostFileRequest =
-  | HostFileReadRequest
-  | HostFileWriteRequest
-  | HostFileEditRequest;
-
-export interface HostFileCancelRequest {
-  type: "host_file_cancel";
-  requestId: string;
-  conversationId: string;
-  targetClientId?: string;
-}
-
-// --- Domain-level union aliases (consumed by the barrel file) ---
-
-export type _HostFileServerMessages = HostFileRequest | HostFileCancelRequest;
+export type _HostFileServerMessages =
+  | HostFileRequestEvent
+  | HostFileCancelEvent;

--- a/assistant/src/daemon/message-types/host-transfer.ts
+++ b/assistant/src/daemon/message-types/host-transfer.ts
@@ -1,45 +1,12 @@
-// Host transfer proxy types.
-// Enables bidirectional file transfer between sandbox and host machine
-// when running as a managed assistant.
+// Host transfer proxy events.
+//
+// Server→client events are single-sourced from their canonical `api/events`
+// wire schemas; this file only composes them into the domain union consumed by
+// `message-protocol.ts`.
 
-// === Server → Client ===
-
-export interface HostTransferToHostRequest {
-  type: "host_transfer_request";
-  requestId: string;
-  conversationId: string;
-  targetClientId?: string;
-  direction: "to_host";
-  transferId: string;
-  destPath: string;
-  sizeBytes: number;
-  sha256: string;
-  overwrite: boolean;
-}
-
-export interface HostTransferToSandboxRequest {
-  type: "host_transfer_request";
-  requestId: string;
-  conversationId: string;
-  targetClientId?: string;
-  direction: "to_sandbox";
-  transferId: string;
-  sourcePath: string;
-}
-
-export type HostTransferRequest =
-  | HostTransferToHostRequest
-  | HostTransferToSandboxRequest;
-
-export interface HostTransferCancelRequest {
-  type: "host_transfer_cancel";
-  requestId: string;
-  conversationId: string;
-  targetClientId?: string;
-}
-
-// --- Domain-level union aliases (consumed by the barrel file) ---
+import type { HostTransferCancelEvent } from "../../api/events/host-transfer.js";
+import type { HostTransferRequestEvent } from "../../api/events/host-transfer.js";
 
 export type _HostTransferServerMessages =
-  | HostTransferRequest
-  | HostTransferCancelRequest;
+  | HostTransferRequestEvent
+  | HostTransferCancelEvent;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -470,15 +470,24 @@ export function useStreamEventHandler(
         // (e.g. user-prompt-submit). No web UI renders them yet.
         case "hook_event":
           break;
-        // Host-proxy instructions (bash / computer-use / ui-snapshot) targeting
-        // the desktop client. The web chat handler is a no-op — the web is not a
-        // host-proxy capability holder, so the hub never delivers these to it.
+        // Host-proxy instructions targeting the desktop client / chrome
+        // extension. The web chat handler is a no-op — host-proxy frames are
+        // delivered to their capability holder by the hub, not through the
+        // conversation stream.
         case "host_bash_request":
         case "host_bash_cancel":
         case "host_cu_request":
         case "host_cu_cancel":
         case "host_ui_snapshot_request":
         case "host_ui_snapshot_cancel":
+        case "host_app_control_request":
+        case "host_app_control_cancel":
+        case "host_browser_request":
+        case "host_browser_cancel":
+        case "host_file_request":
+        case "host_file_cancel":
+        case "host_transfer_request":
+        case "host_transfer_cancel":
           break;
         // Service-group upgrade lifecycle broadcasts announcing a daemon
         // restart. The chat handler is a no-op; no web UI renders them yet.

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -106,6 +106,9 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   // the desktop client, not a conversation.
   "host_ui_snapshot_request",
   "host_ui_snapshot_cancel",
+  // host_browser_cancel carries no `conversationId` (only a requestId), so it
+  // must be gated as global; the other host-proxy frames carry one.
+  "host_browser_cancel",
   // Settings/config broadcasts (client-setting push, config.json change, sounds
   // change) carry no `conversationId` — they're app-wide, not conversation-scoped.
   "client_settings_update",


### PR DESCRIPTION
## Why

Completes the `host_*` proxy group (after host-bash/host-cu #38850 and host-ui-snapshot #38909) — migrating the last four domains in one PR.

## What

Authored `api/events` schemas and registered them in `AssistantEventSchema`:

| Domain | Events |
| --- | --- |
| **host-app-control** | `host_app_control_request` / `_cancel` |
| **host-file** | `host_file_request` / `_cancel` |
| **host-transfer** | `host_transfer_request` / `_cancel` |
| **host-browser** | `host_browser_request` / `_cancel` |

Each `_Host*ServerMessages` union now composes the api-inferred `*Event` types. The proxies build these inline; `host-file-proxy` and `host-browser-proxy` had their type imports repointed at the api `*Event` types.

### The discriminated-union wrinkle

`host_file_request` (read/write/edit) and `host_transfer_request` (to_host/to_sandbox) have **multiple variants sharing one `type` literal**. Zod v4's `discriminatedUnion` rejects a plain `z.union` member — but a **nested `discriminatedUnion`** (on `operation` / `direction`) *is* a valid member of the outer `discriminatedUnion("type")`. So the request schemas are nested discriminated unions: the variant shapes are preserved 1:1 (no field-loosening), and the proxies keep their `direction`/`operation` narrowing.

`host-app-control`'s request carries the full 9-variant `HostAppControlInput` tool-input union, transcribed as a nested `discriminatedUnion("tool")` and re-exported from message-types for the proxy.

### Preserved (not events)

- `HostAppControlState` + `HostAppControlResultPayload` — the HTTP `/v1/host-app-control-result` body, kept in message-types.
- `HostBrowserEvent` / `HostBrowserSessionInvalidated` — client→server signals the chrome extension pushes back; they stay as `_HostBrowserClientMessages`.

## Web

All events carry a `conversationId` except `host_browser_cancel`, so they get no-op cases in the chat handler's exhaustive switch (host-proxy frames reach their capability holder via the hub, not the conversation stream); `host_browser_cancel` also joins the global set.

## Safety

No wire change — schemas transcribed 1:1 (verified the nested-union round-trips). Updated one type-only test (`host-transfer-pending-interactions`) to the new `*Event` names. Clean `typecheck:fast` + web `tsc` (fresh `openapi-ts`), eslint, prettier, `generate:openapi --check` (unchanged), api-events + SSE-parity suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_