### PR TITLE
docs(streaming): rewrite SSE stale-frontier comments in present tense

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -175,9 +175,10 @@ export function useConversationHistory({
 
     // Seq baseline (replay idempotency) + cold-start ring-replay anchor. Tag
     // the frontier with the generation the page's `/messages` request was
-    // issued in (falling back to the current generation for pages that predate
-    // the stamp) so a page that raced a generation reset is recognised as a
-    // stale anchor by the stale-frontier guard rather than starving the stream.
+    // issued in (falling back to the current generation for pages that carry no
+    // stamped generation) so a page that raced a generation reset is recognised
+    // as a stale anchor by the stale-frontier guard rather than starving the
+    // stream.
     const latestPageSeq = pagination.latestPage?.seq ?? null;
     const latestPageGeneration =
       pagination.latestPage?.seqGeneration ?? getSeqGeneration();

--- a/clients/web/src/domains/chat/streaming/sse-event-consumer.test.ts
+++ b/clients/web/src/domains/chat/streaming/sse-event-consumer.test.ts
@@ -816,15 +816,16 @@ describe("sse-event-consumer — stale seq-generation recovery", () => {
 
   test("a stale /messages anchor BELOW the abandoned ceiling (multi-conversation) is recovered by the generation tag", () => {
     /**
-     * The gap Codex flagged on #38589. `/messages` returns the conversation's
-     * own persisted watermark (`conversations.seq`), which sits BELOW the
+     * In a multi-conversation daemon `/messages` returns the conversation's
+     * own persisted watermark (`conversations.seq`), which can sit BELOW the
      * global abandoned ceiling whenever another conversation emitted the later
-     * pre-reset seqs. The old ceiling-only guard (`localSeq >= ceiling`) never
-     * fired for such an anchor, so every live event through the anchor was
-     * dropped as a replay and the transcript wedged until the counter
-     * re-climbed past it. The generation tag closes this: the racing anchor
-     * carries the pre-reset generation, so it is dead by construction even
-     * though its value is under the ceiling.
+     * pre-reset seqs. A value-only ceiling comparison (`localSeq >= ceiling`)
+     * cannot identify such an anchor as dead, so a live event through the anchor
+     * would drop as a replay and wedge the transcript until the counter
+     * re-climbs past it. The generation tag is the signal that proves it stale:
+     * the racing anchor carries the pre-reset generation, so it is dead by
+     * construction even though its value is under the ceiling, and the frontier
+     * recovers.
      */
     // GIVEN the client had reached global seq 1000 (another conversation held
     // the later seqs; conv-1's own watermark is 900)
@@ -878,8 +879,9 @@ describe("sse-event-consumer — stale seq-generation recovery", () => {
      * the generation tag can't date it as stale — yet `conversations.seq` is
      * monotonic, so it can still return the pre-reset watermark until the new
      * generation re-climbs past it. When that watermark IS the abandoned
-     * ceiling (single-conversation daemon), the retained ceiling check clears
-     * it; this is the case (a) cannot see, and why the ceiling signal stays.
+     * ceiling (single-conversation daemon), the ceiling check clears it: this
+     * is the dead-anchor shape the generation tag cannot see, which is why the
+     * guard needs both signals.
      */
     // GIVEN the client reaches global seq 1000, then observes the reset to 10
     globalCursor = 1000;
@@ -921,7 +923,7 @@ describe("sse-event-consumer — stale seq-generation recovery", () => {
 
   test("a large snapshot overlap with no generation reset is an idempotent replay, not a stale generation", () => {
     /**
-     * The false-positive Codex flagged: a `/messages` reseed or reconcile
+     * The benign false-positive case: a `/messages` reseed or reconcile
      * advances the frontier far past the live cursor during a bursty turn
      * or a main-thread stall, so the queued live backlog trails it by more
      * than the ring — WITHOUT any daemon reset. Those events are contained


### PR DESCRIPTION
Addresses Codex review feedback on #38894.

The P1 flagged a newly-added test block comment that narrated review history
("The gap Codex flagged on #38589.", "The old ceiling-only guard ... never
fired", "The generation tag closes this"). Per AGENTS.md **Code Comments**
(present tense; history belongs in PRs), it is rewritten as a statement of the
multi-conversation invariant under test, and the rest of the PR's changed
comments are swept for the same class.

Changes (comment-only):

- `sse-event-consumer.test.ts`
  - "stale anchor BELOW the abandoned ceiling" block → present-tense invariant:
    `/messages` returns the conversation's own `conversations.seq`, which can
    sit below the global abandoned ceiling; a value-only ceiling comparison
    cannot identify such an anchor as dead, so the generation tag is the signal
    that proves it stale and recovers the frontier.
  - "post-reset anchor at the ceiling" block → dropped "the retained ceiling
    check" / "why the ceiling signal stays"; now states why the guard needs
    both signals.
  - "large snapshot overlap" block → "The false-positive Codex flagged:" →
    "The benign false-positive case:" (a pre-existing #38589 comment — the same
    Codex-reference violation in the same describe block, cleaned for
    consistency).
- `use-conversation-history.ts` → "pages that predate the stamp" → "pages that
  carry no stamped generation" (temporal narration → runtime condition).

Zero behavior/assertion/code changes — the non-comment diff is empty.
`sse-event-consumer.test.ts` passes 26/26. The three
`use-conversation-history.*.test.tsx` files fail only on a missing generated
client (`@/generated/daemon/sdk.gen`, not materialized in this worktree) —
pre-existing environmental noise unrelated to a comment edit.