### PR TITLE
refactor(assistant): move memory-v3 lanes-version token into the memory plugin storage dir

### DIFF
--- a/assistant/src/plugins/defaults/memory/v3/lanes-version-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/lanes-version-store.test.ts
@@ -37,7 +37,7 @@ describe("lanes-version-store", () => {
   test("a bump is observed by a later read of the same workspace (cross-process round-trip)", () => {
     // The writer (memory worker) bumps; a reader (daemon) resolving the same
     // workspace dir sees the new token. `bumpLanesVersion` also creates the
-    // `memory/.v2-state/` state dir on demand.
+    // `plugins-data/default-memory/` storage dir on demand.
     const token = bumpLanesVersion(workspaceDir);
     expect(token).toBeTruthy();
     expect(readLanesVersion(workspaceDir)).toBe(token);
@@ -53,9 +53,10 @@ describe("lanes-version-store", () => {
   test("read returns undefined when the token path is unreadable", () => {
     // A directory at the token path makes the read throw EISDIR (not ENOENT):
     // the "cannot judge staleness" signal, distinct from an absent token.
-    mkdirSync(join(workspaceDir, "memory", ".v2-state", "lanes-version"), {
-      recursive: true,
-    });
+    mkdirSync(
+      join(workspaceDir, "plugins-data", "default-memory", "lanes-version"),
+      { recursive: true },
+    );
     expect(readLanesVersion(workspaceDir)).toBeUndefined();
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/lanes-version-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/lanes-version-store.ts
@@ -9,12 +9,12 @@
  * the value captured at its last build and rebuilds on any change. The value
  * is opaque — only inequality matters.
  *
- * The token is plugin-owned state: it lives in the memory plugin's workspace
- * state directory (`<workspace>/memory/.v2-state/lanes-version`), beside the
- * consolidation lock, NOT in the main database. Both processes reach it because
- * they share the workspace volume — the same basis the consolidation lock relies
- * on. Callers pass the workspace dir (resolved via `getWorkspaceDir()`), so the
- * daemon and the worker address the same file.
+ * The token is plugin-owned state: it lives in the memory plugin's own storage
+ * directory (`<workspace>/plugins-data/default-memory/lanes-version`, the
+ * default-plugin `pluginStorageDir`), NOT in the main database. Both processes
+ * reach it because they share the workspace volume. Callers pass the workspace
+ * dir (resolved via `getWorkspaceDir()`), so the daemon and the worker address
+ * the same file.
  */
 
 import { randomUUID } from "node:crypto";
@@ -28,12 +28,12 @@ import {
 import { dirname, join } from "node:path";
 
 /**
- * `<workspace>/memory/.v2-state/lanes-version` — the memory plugin's
- * established cross-process state directory (the consolidation lock lives in
- * the same folder).
+ * `<workspace>/plugins-data/default-memory/lanes-version` — inside the memory
+ * plugin's own storage directory (`<workspaceDir>/plugins-data/<manifest-name>/`,
+ * the `pluginStorageDir` bootstrap derives for default plugins).
  */
 function lanesVersionPath(workspaceDir: string): string {
-  return join(workspaceDir, "memory", ".v2-state", "lanes-version");
+  return join(workspaceDir, "plugins-data", "default-memory", "lanes-version");
 }
 
 /**


### PR DESCRIPTION
## Summary
Codex flagged a P2 on merged #38885: the memory-v3 lanes-version token was moved out of the main DB (correct) but landed at `<workspace>/memory/.v2-state/lanes-version`, which is **not** the plugin's storage dir. Per `assistant/src/plugins/AGENTS.md`, durable default-plugin state must live under `InitContext.pluginStorageDir` (`<workspaceDir>/plugins-data/<name>/`); the memory plugin's grandfathered exception covers only its **main-DB tables**, not new workspace files.

This relocates the token into the memory plugin's own storage directory. Cross-process behavior is unchanged — the daemon and the memory worker both resolve the path from `getWorkspaceDir()` and share the workspace volume, exactly as before.

## What changed
- `v3/lanes-version-store.ts` — `lanesVersionPath()` resolves `<workspace>/plugins-data/default-memory/lanes-version` (was `<workspace>/memory/.v2-state/lanes-version`). Read/bump semantics are byte-for-byte identical: non-empty → token; ENOENT/empty → `null`; other read error → `undefined`; bump = fresh `randomUUID`, atomic temp-file + rename, `mkdirSync(recursive)` on demand, temp cleanup + rethrow on failure.
- `v3/lanes-version-store.test.ts` — path expectations updated (incl. the EISDIR unreadable-path case).
- Docstrings name the present location only.

## Path name — `default-memory`, not `memory`
The review brief named the target `plugins-data/memory/`, but the memory plugin's `manifest.name` is **`default-memory`** (`defaults/memory/package.json`), so `ensurePluginStorageDir` (`daemon/external-plugins-bootstrap.ts`) derives its storage dir as `<workspace>/plugins-data/default-memory/`. Using `plugins-data/memory/` would relocate the token to *another* non-owned workspace path — the same class of violation Codex raised — and would split from the real `pluginStorageDir` if this plugin ever adopts an `init`-hook store. The token therefore lives at `plugins-data/default-memory/lanes-version`, the genuine plugin-owned dir. Flag if the literal `plugins-data/memory/` is preferred.

## No migration / orphaned file (intentional)
On upgrade the new path is absent → `readLanesVersion` returns `null` → identical meaning to "no token yet"; worst case is one extra lane rebuild. The old file at `<workspace>/memory/.v2-state/lanes-version` becomes inert; per the task no cleanup code is added (mirroring #38885's "orphaned row (intentional)" precedent). The pre-existing consolidation lock under `memory/.v2-state/` is out of scope and untouched.

## Tests
- `lanes-version-store.test.ts`: 4/4 pass.
- `bun run typecheck:fast`: clean.

Addresses Codex review feedback on #38885.