### PR TITLE
feat(web): open Earn Free Credits in a modal from the Credit Balance header

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -141,9 +141,6 @@ mock.module("@/domains/settings/components/plan-card", () => ({
         <button data-testid="plan-card-tier-upgraded" onClick={onTierUpgraded} />
     ),
 }));
-mock.module("@/domains/settings/components/referral-panel", () => ({
-    ReferralPanel: () => null,
-}));
 
 const { BillingPage } = await import("./billing-page");
 

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -18,7 +18,6 @@ import { BillingUsagePanel } from "@/domains/settings/components/billing-usage/b
 import { GracePeriodBanner } from "@/domains/settings/components/grace-period-banner";
 import { InvoicesTable } from "@/domains/settings/components/invoices-table";
 import { PlanCard } from "@/domains/settings/components/plan-card";
-import { ReferralPanel } from "@/domains/settings/components/referral-panel";
 import { useAssistantDomains } from "@/domains/settings/billing/pro-onboarding/use-assistant-domains";
 import {
     organizationsBillingSubscriptionOnboardingRetrieveOptions,
@@ -238,7 +237,6 @@ function BillingTab() {
             <Suspense fallback={null}>
                 <BillingPanel />
             </Suspense>
-            <ReferralPanel />
             <Suspense fallback={null}>
                 <InvoicesTable />
             </Suspense>

--- a/clients/web/src/domains/settings/components/billing-panel.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel.tsx
@@ -18,6 +18,7 @@ import { Toggle } from "@vellumai/design-library/components/toggle";
 import { Typography } from "@vellumai/design-library/components/typography";
 import { DailyCreditLimitCard } from "./daily-credit-limit-card";
 import { LowBalanceAlertCard } from "./low-balance-alert-card";
+import { ReferralModal } from "./referral-modal";
 
 export const BOOTSTRAP_MAX_RETRIES = 3;
 export const BOOTSTRAP_RETRY_DELAY_MS = 2000;
@@ -48,6 +49,7 @@ export function BillingPanel() {
     const summary = data ?? null;
 
     const [addCreditsOpen, setAddCreditsOpen] = useState(false);
+    const [referralOpen, setReferralOpen] = useState(false);
     const [lowBalanceExpanded, setLowBalanceExpanded] = useState(false);
 
     const bootstrapAttemptsRef = useRef(0);
@@ -117,14 +119,24 @@ export function BillingPanel() {
                     Quick overview of your balances and other things
                 </Typography>
             </div>
-            <Button
-                variant="primary"
-                onClick={() => setAddCreditsOpen(true)}
-                disabled={isLoading || !summary}
-                data-testid="add-credits-button"
-            >
-                Add Credits
-            </Button>
+            <div className="flex items-center gap-2">
+                <Button
+                    variant="outlined"
+                    leftIcon={<Coins className="h-4 w-4" aria-hidden />}
+                    onClick={() => setReferralOpen(true)}
+                    data-testid="earn-credits-button"
+                >
+                    Earn Free Credits
+                </Button>
+                <Button
+                    variant="primary"
+                    onClick={() => setAddCreditsOpen(true)}
+                    disabled={isLoading || !summary}
+                    data-testid="add-credits-button"
+                >
+                    Add Credits
+                </Button>
+            </div>
         </div>
     );
 
@@ -210,6 +222,7 @@ export function BillingPanel() {
             </Card>
 
             <AddCreditsModal open={addCreditsOpen} onOpenChange={setAddCreditsOpen} />
+            <ReferralModal open={referralOpen} onOpenChange={setReferralOpen} />
         </>
     );
 }

--- a/clients/web/src/domains/settings/components/referral-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/referral-modal.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * ReferralModal wraps ReferralContent in a dialog opened from the Credit
+ * Balance header. The referral query cache is seeded so the content resolves
+ * synchronously; the GET SDK function is stubbed with a never-resolving promise
+ * so the background refetch stays inert.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+import type { MyReferralCodeResponse } from "@/generated/api/types.gen";
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  referralCodesMeRetrieve: () => new Promise(() => {}),
+}));
+
+const { referralCodesMeRetrieveQueryKey } = await import(
+  "@/generated/api/@tanstack/react-query.gen"
+);
+const { ReferralModal } = await import("./referral-modal");
+
+function referralData(): MyReferralCodeResponse {
+  return {
+    code: "ABC123",
+    referral_url: "https://vellum.ai/r/ABC123",
+    referred_count: 2,
+    total_earned_usd: "10.00",
+    earning_cap_usd: "50.00",
+    total_earned: "10.00",
+    earning_cap: "50.00",
+    credit_amount: "5.00",
+    referrer_credit_amount: "5.00",
+    is_eligible_for_credits: true,
+  };
+}
+
+function renderModal(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(referralCodesMeRetrieveQueryKey(), referralData());
+  return render(
+    <QueryClientProvider client={client}>
+      <ReferralModal open={props.open} onOpenChange={props.onOpenChange} />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ReferralModal", () => {
+  test("renders the referral content when open", () => {
+    const { getByTestId } = renderModal({
+      open: true,
+      onOpenChange: () => {},
+    });
+    expect(getByTestId("referral-modal")).toBeDefined();
+    expect(getByTestId("referral-copy-button")).toBeDefined();
+  });
+
+  test("renders nothing when closed", () => {
+    const { queryByTestId } = renderModal({
+      open: false,
+      onOpenChange: () => {},
+    });
+    expect(queryByTestId("referral-modal")).toBeNull();
+  });
+
+  test("calls onOpenChange(false) when the close button is clicked", () => {
+    const onOpenChange = mock(() => {});
+    const { getByLabelText } = renderModal({ open: true, onOpenChange });
+    fireEvent.click(getByLabelText("Close"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/clients/web/src/domains/settings/components/referral-modal.tsx
+++ b/clients/web/src/domains/settings/components/referral-modal.tsx
@@ -1,0 +1,23 @@
+import { Modal } from "@vellumai/design-library/components/modal";
+
+import { ReferralContent } from "./referral-content";
+
+interface ReferralModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ReferralModal({ open, onOpenChange }: ReferralModalProps) {
+  return (
+    <Modal.Root open={open} onOpenChange={onOpenChange}>
+      <Modal.Content data-testid="referral-modal">
+        <Modal.Header>
+          <Modal.Title>Earn Free Credits</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <ReferralContent />
+        </Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}


### PR DESCRIPTION
## Summary
- Add an Earn Free Credits header button that opens the referral content in a modal.
- Drop the standalone ReferralPanel card from the billing page.

Part of plan: credit-balance-redesign.md (PR 4 of 5)