### PR TITLE
Run the re-engagement email draft on the fast inference profile

### DIFF
--- a/assistant/src/plugins/defaults/platform-hosted/__tests__/reengage.test.ts
+++ b/assistant/src/plugins/defaults/platform-hosted/__tests__/reengage.test.ts
@@ -98,6 +98,11 @@ describe("platform-hosted /reengage POST", () => {
     expect(lastOptions?.conversationId).toBeUndefined();
   });
 
+  test("runs on the fast inference call site rather than the main-agent default", async () => {
+    await POST(postRequest());
+    expect(lastOptions?.callSite).toBe("inference");
+  });
+
   test("tolerates JSON wrapped in a code fence", async () => {
     fileContents =
       '```json\n{"subject": "A quick nudge", "body": "Let me know."}\n```';

--- a/assistant/src/plugins/defaults/platform-hosted/routes/reengage.ts
+++ b/assistant/src/plugins/defaults/platform-hosted/routes/reengage.ts
@@ -100,6 +100,12 @@ export const POST = async (request: Request): Promise<Response> => {
     await runConversationTurn({
       content: [{ type: "text", text: buildPrompt(outputPath) }],
       conversationType: "background",
+      // Drafting a short email is latency-bound, not depth-bound, so run it on
+      // the fast model rather than the balanced main-agent default. `inference`
+      // is the general-purpose call site plugins use for exactly this — it
+      // resolves to the Speed (cost-optimized) profile — so we reuse it instead
+      // of teaching the daemon about a reengagement-specific call site.
+      callSite: "inference",
       signal: request.signal,
     });
 


### PR DESCRIPTION
## Why

The platform's "Send Reengagement Email" admin action calls the `default-platform-hosted/reengage` route, which runs a background conversation turn to draft the email. That turn was running under the **balanced** main-agent default (GLM-5p2, `effort: high`, thinking on) — tuned for depth. Drafting a short re-engagement email is latency-bound, not depth-bound, and the draft was taking longer than expected. Running it on the fast model should meaningfully cut model latency.

## What

- Pass `callSite: "inference"` when the reengage route calls `runConversationTurn`.
- `inference` is the daemon's existing general-purpose call site — the one the plugin-api documents plugins using ("plugins typically pass `"inference"`") — and it resolves to the Speed (`cost-optimized`) profile.
- **No new call site.** An earlier revision added a dedicated `reengagementEmail` call site, but that pushes plugin-specific identifiers into the daemon's core call-site registry (enum + defaults + display catalog), inverting the dependency — the daemon shouldn't know a particular plugin exists. Reusing the generic `inference` call site keeps the registry plugin-agnostic. The whole change is now contained to the plugin route (plus its test).

## Tests

- Added an assertion that the reengage turn runs on the `inference` call site rather than the main-agent default.
- `tsc`, eslint, prettier all green.

## Trade-off worth noting

`inference` resolving to Speed is an implicit contract: if that call site is ever retuned to a different profile, this route follows silently. That's an accepted trade-off for keeping the daemon free of plugin-specific call sites. If we later want an explicit, self-documenting pin without a bespoke call site, the follow-up is to expose the existing generic `overrideProfile` knob on `runConversationTurn` (the plumbing already exists in `ProcessMessageOptions`) and pass `"cost-optimized"` directly.

## Note on latency

This reduces the *model's* latency. The handler still runs a full agent loop (history, memory injections) and composes by having the assistant call a file-writing tool and then re-reading that file, so agent-loop + tool-round-trip overhead remains. Flagging in case the end-to-end time turns out to be dominated by that structure rather than generation.

## Rollout

Daemon-only change. No config/schema changes; contained to the plugin route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjoP9o4shUNs7uwNAaiLqN