### PR TITLE
fix(streaming): track a durable flush watermark for the worker persist anchor

### DIFF
--- a/assistant/src/__tests__/conversation-loop-db-lock-resilience.test.ts
+++ b/assistant/src/__tests__/conversation-loop-db-lock-resilience.test.ts
@@ -132,7 +132,7 @@ describe("agent loop SQLite write-contention resilience", () => {
     // A row was reserved at llm_call_started; message_complete finalizes it.
     state.lastAssistantMessageId = "assistant-row";
     state.assistantRowAwaitingFinalization = true;
-    state.lastPersistedContentSeq = 5;
+    state.lastStreamedContentSeq = 5;
     updateContentFailuresRemaining = 0;
     writtenContentById.clear();
     persistedSeqByConversation.clear();

--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -480,7 +480,7 @@ describe("tool preview lifecycle", () => {
         thinking: "Let me reason about this.",
       } as Extract<AgentEvent, { type: "thinking_delta" }>);
 
-      // THEN it is mirrored into the running view and the persisted seq field
+      // THEN it is mirrored into the running view and the streamed seq field
       // tracks the emitted delta
       const thinkingDelta = events.find(
         (e) => e.type === "assistant_thinking_delta",
@@ -493,7 +493,7 @@ describe("tool preview lifecycle", () => {
           signature: "",
         },
       ]);
-      expect(state.lastPersistedContentSeq).toBe(
+      expect(state.lastStreamedContentSeq).toBe(
         (thinkingDelta as unknown as AssistantEvent).seq ?? undefined,
       );
     });
@@ -589,11 +589,11 @@ describe("tool preview lifecycle", () => {
         },
       } as Extract<AgentEvent, { type: "message_complete" }>);
 
-      // THEN no thinking_delta was emitted and the persisted seq stays unset
+      // THEN no thinking_delta was emitted and the streamed seq stays unset
       expect(
         events.find((e) => e.type === "assistant_thinking_delta"),
       ).toBeUndefined();
-      expect(state.lastPersistedContentSeq).toBeUndefined();
+      expect(state.lastStreamedContentSeq).toBeUndefined();
       expect(getConversationPersistedSeq(conversationId)).toBeNull();
     });
   });

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -357,15 +357,24 @@ export interface EventHandlerState {
   currentThinkingTimestamps: { startedAt: number; completedAt: number }[];
   /**
    * `seq` of the most recent streamed content delta mirrored into
-   * `currentMessageContent`. Recorded as the conversation's persisted `seq`
-   * after each flush commits (the debounced partial flushes and the
-   * `message_complete` finalize), so the snapshot's advertised `seq` tracks
-   * exactly the streamed content the durable row holds. `undefined` until the
-   * first content delta of the in-flight message. Because every streamed
-   * content type rides the same mirror-and-flush path, this single field
-   * never claims content a flush has not yet written.
+   * `currentMessageContent`, stamped synchronously as the delta is emitted —
+   * before any flush writes it, so this runs ahead of the durable rows. Each
+   * flush snapshots it to learn how far the live stream has advanced; the
+   * committed watermark lives in `flushedContentSeq`. `undefined` until the
+   * first content delta of the in-flight message.
    */
-  lastPersistedContentSeq: number | undefined;
+  lastStreamedContentSeq: number | undefined;
+  /**
+   * Highest `seq` whose streamed content a flush has committed to durable rows
+   * for the in-flight turn. Raised (monotonic max) only after a partial flush
+   * or the `message_complete` finalize write commits — never at emit time —
+   * and never reset mid-turn, so it is a turn-level high-water mark that trails
+   * `lastStreamedContentSeq` by exactly the content not yet written. A caller
+   * anchoring a snapshot at this value (`inflight-turn-registry`) never
+   * advertises content the durable rows do not hold. `undefined` until the
+   * first flush of the turn commits.
+   */
+  flushedContentSeq: number | undefined;
   /**
    * Pre-compaction history buffered from `context_compacting` start events,
    * keyed by `compactionId`. The paired `compaction_completed` event no
@@ -583,7 +592,8 @@ export function createEventHandlerState(): EventHandlerState {
     pendingPartialFlushPromise: undefined,
     currentMessageContent: [],
     currentThinkingTimestamps: [],
-    lastPersistedContentSeq: undefined,
+    lastStreamedContentSeq: undefined,
+    flushedContentSeq: undefined,
     compactionStartMessages: new Map(),
     latencyCursor: 0,
     deferredFinalizeEffects: [],
@@ -937,7 +947,7 @@ function resetPartialPersistAccumulator(state: EventHandlerState): void {
   }
   state.currentMessageContent = [];
   state.currentThinkingTimestamps = [];
-  state.lastPersistedContentSeq = undefined;
+  state.lastStreamedContentSeq = undefined;
   state.pendingPartialFlushPromise = undefined;
   // If a previous LLM call (e.g. a retried/replaced stream) held back
   // sentinel-guarded text via `drainSentinelGuardedText`, the stale
@@ -1021,6 +1031,23 @@ async function persistLoopMessageContent(
   }
 }
 
+/**
+ * Raise the in-flight turn's flushed-content watermark once a flush or finalize
+ * write has committed `committedSeq`'s content to durable rows. Monotonic max: a
+ * slower flush can resolve after a newer delta already advanced the watermark,
+ * so it must never regress. Feeds `getInflightFlushedContentSeq`, which caps the
+ * worker → daemon persist hand-off's snapshot anchor at flushed content.
+ */
+function raiseFlushedContentWatermark(
+  state: EventHandlerState,
+  committedSeq: number,
+): void {
+  state.flushedContentSeq = Math.max(
+    state.flushedContentSeq ?? 0,
+    committedSeq,
+  );
+}
+
 /** Flush `state.currentMessageContent` to the persisted assistant row. */
 async function flushAccumulatedContent(
   state: EventHandlerState,
@@ -1044,9 +1071,9 @@ async function flushAccumulatedContent(
     persistRemintAuthorities(state, deps, revealCandidates),
   );
   // Pair the seq with the exact content snapshot taken above: deltas that
-  // arrive while the write is in flight bump `lastPersistedContentSeq`
+  // arrive while the write is in flight bump `lastStreamedContentSeq`
   // again, but they are not part of this write.
-  const flushedSeq = state.lastPersistedContentSeq;
+  const flushedSeq = state.lastStreamedContentSeq;
 
   // Partial flushes append to the in-flight delta file — a pure file
   // write; the row has held the `{ ref }` since it was reserved. Delta
@@ -1061,10 +1088,11 @@ async function flushAccumulatedContent(
         "partial_flush_assistant_content",
         deps.rlog,
       );
-  // Record only after the write commits, so the snapshot seq never
-  // claims content that is not yet durable.
+  // Record only after the write commits, so the snapshot seq never claims
+  // content that is not yet durable.
   if (persisted && flushedSeq != null) {
     recordConversationPersistedSeq(deps.ctx.conversationId, flushedSeq);
+    raiseFlushedContentWatermark(state, flushedSeq);
   }
 }
 
@@ -1410,7 +1438,7 @@ function handleTextDelta(
       // `getCurrentSeq()` here is that delta's seq -- the position the
       // mirrored content now reflects. A partial flush snapshots this to
       // record how far the durable rows track the live stream.
-      state.lastPersistedContentSeq = getCurrentSeq();
+      state.lastStreamedContentSeq = getCurrentSeq();
       schedulePartialFlush(state, deps);
     }
     if (deps.shouldGenerateTitle) {
@@ -1458,7 +1486,7 @@ function handleThinkingDelta(
   appendThinkingToCurrentMessage(state, event.thinking);
   // The hub stamps `seq` synchronously on the delta emitted above, so
   // `getCurrentSeq()` is that delta's position in the mirrored content.
-  state.lastPersistedContentSeq = getCurrentSeq();
+  state.lastStreamedContentSeq = getCurrentSeq();
   schedulePartialFlush(state, deps);
 }
 
@@ -2696,14 +2724,14 @@ export async function handleMessageComplete(
       messageId: state.lastAssistantMessageId,
     });
     // The hub stamps `seq` synchronously on the delta emitted above, so
-    // `getCurrentSeq()` is that delta's position — advance the persisted-seq
+    // `getCurrentSeq()` is that delta's position — advance the streamed-seq
     // mirror exactly like the normal text-delta path. The finalize below
     // records this value; without the advance it would record the PREVIOUS
     // emitted chunk's seq, so a `/messages` snapshot could contain this tail
     // while advertising a seq before the delta that carried it — and a
     // reconnecting client applying `seq > snapshot.seq` would append the
     // tail a second time.
-    state.lastPersistedContentSeq = getCurrentSeq();
+    state.lastStreamedContentSeq = getCurrentSeq();
     if (deps.shouldGenerateTitle) {
       state.firstAssistantText += state.pendingDirectiveDisplayBuffer;
     }
@@ -2803,7 +2831,7 @@ export async function handleMessageComplete(
   state.assistantRowAwaitingFinalization = false;
   // The assistant row now holds the authoritative content (text + thinking +
   // tool_use blocks from `event.message`), and any drained tool-result rows
-  // are durable. `lastPersistedContentSeq` is the last streamed text/thinking
+  // are durable. `lastStreamedContentSeq` is the last streamed text/thinking
   // delta's seq -- the highest stamped content event this row reflects -- so
   // recording it is honest. A drained tool result was stamped earlier in the
   // turn, so this seq already covers it; a call that streams no content (a
@@ -2811,17 +2839,19 @@ export async function handleMessageComplete(
   // `recordConversationPersistedSeq` clamps monotonically, so a lower value
   // here never regresses the seq. Gate on `persisted` so a swallowed finalize
   // write never advances the seq past content that is not durable.
-  if (persisted && state.lastPersistedContentSeq != null) {
+  if (persisted && state.lastStreamedContentSeq != null) {
     recordConversationPersistedSeq(
       deps.ctx.conversationId,
-      state.lastPersistedContentSeq,
+      state.lastStreamedContentSeq,
     );
+    raiseFlushedContentWatermark(state, state.lastStreamedContentSeq);
   }
   // Reset the partial-persist mirror so subsequent calls in this turn
-  // start with an empty running view.
+  // start with an empty running view. `flushedContentSeq` is a turn-level
+  // watermark and intentionally survives the reset.
   state.currentMessageContent = [];
   state.currentThinkingTimestamps = [];
-  state.lastPersistedContentSeq = undefined;
+  state.lastStreamedContentSeq = undefined;
 
   // ── Indexing + attention projection (deferred off the critical path) ──
   // `reserveMessage` + `updateMessageContent` are CRUD-only — unlike

--- a/assistant/src/daemon/inflight-turn-registry.ts
+++ b/assistant/src/daemon/inflight-turn-registry.ts
@@ -44,12 +44,15 @@ export function unregisterInflightTurn(
  * The flushed-content seq ceiling for a conversation the daemon may be
  * streaming, or `undefined` when no turn is in flight for it.
  *
- * While a turn streams, the value is the highest seq whose content has been
- * flushed to durable rows (`EventHandlerState.lastPersistedContentSeq`), or `0`
- * when the turn has flushed no content yet. A caller recording a snapshot
- * anchor caps at this value so the anchor never claims content the live seq
- * counter has served but no flush has written; the `0` case is a monotonic
- * no-op in `recordConversationPersistedSeq`, leaving the existing anchor intact.
+ * While a turn streams, the value is the highest seq whose content a flush has
+ * committed to durable rows (`EventHandlerState.flushedContentSeq`), or `0`
+ * when the turn has flushed no content yet. It trails the turn's live emit
+ * position (`lastStreamedContentSeq`): a delta stamps the live seq the instant
+ * it is emitted, but the watermark rises only once that delta's flush commits,
+ * so an anchor capped here never claims a delta whose content the durable rows
+ * do not yet hold. A caller recording a snapshot anchor caps at this value; the
+ * `0` case is a monotonic no-op in `recordConversationPersistedSeq`, leaving the
+ * existing anchor intact.
  */
 export function getInflightFlushedContentSeq(
   conversationId: string,
@@ -58,5 +61,5 @@ export function getInflightFlushedContentSeq(
   if (state === undefined) {
     return undefined;
   }
-  return state.lastPersistedContentSeq ?? 0;
+  return state.flushedContentSeq ?? 0;
 }

--- a/assistant/src/ipc/routes/__tests__/conversation-sync-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/conversation-sync-ipc-routes.test.ts
@@ -81,10 +81,10 @@ describe("conversation-sync IPC route", () => {
     stampEvent();
     stampEvent(); // getCurrentSeq() === 3
 
-    // A daemon turn is streaming into conv-1 but has flushed content only
+    // A daemon turn is streaming into conv-1 but has committed a flush only
     // through seq 2 — the live counter (3) is ahead of the durable rows.
     const state = {
-      lastPersistedContentSeq: 2,
+      flushedContentSeq: 2,
     } as unknown as EventHandlerState;
     registerInflightTurn("conv-1", state);
     try {
@@ -102,13 +102,41 @@ describe("conversation-sync IPC route", () => {
     }
   });
 
+  test("holds the anchor at the committed flush watermark when the live streamed seq has raced ahead", () => {
+    stampEvent();
+    stampEvent();
+    stampEvent();
+    stampEvent(); // getCurrentSeq() === 4
+
+    // The exact P1 window: the turn emitted a delta at seq 4 (stamped onto the
+    // live streamed position the instant it was emitted) but that delta's flush
+    // has not committed — the durable rows hold only through seq 2. The persist
+    // notification must anchor at the committed watermark, never the live emit
+    // position, or the client discards the seq-4 delta as an already-covered
+    // replay and the streamed text vanishes.
+    const state = {
+      lastStreamedContentSeq: 4,
+      flushedContentSeq: 2,
+    } as unknown as EventHandlerState;
+    registerInflightTurn("conv-1", state);
+    try {
+      handleNotifyConversationPersisted({ body: { conversationId: "conv-1" } });
+
+      // Anchored at the durable watermark (2), NOT the un-flushed live seq (4).
+      expect(recordCalls).toEqual([["conv-1", 2]]);
+      expect(publishCalls).toEqual(["conv-1"]);
+    } finally {
+      unregisterInflightTurn("conv-1", state);
+    }
+  });
+
   test("records 0 (a raise-only no-op) when a streaming turn has flushed no content yet", () => {
     stampEvent(); // getCurrentSeq() === 1
 
-    // A turn is streaming but has not flushed any content, so its watermark is
+    // A turn is streaming but has committed no flush, so its watermark is
     // undefined; the ceiling is 0, capping the anchor below the un-flushed seq.
     const state = {
-      lastPersistedContentSeq: undefined,
+      flushedContentSeq: undefined,
     } as unknown as EventHandlerState;
     registerInflightTurn("conv-1", state);
     try {


### PR DESCRIPTION
## Summary

Follow-up to #38883 addressing Codex P1 review feedback.

#38883 exposed `getInflightFlushedContentSeq()` from the in-flight-turn registry so the worker → daemon persist hand-off could cap its snapshot anchor at flushed content. But the registry read `EventHandlerState.lastPersistedContentSeq`, which is **not** a flushed watermark: it is assigned `getCurrentSeq()` synchronously at delta-emit time (text/thinking deltas), before the debounced partial flush starts or its write commits. When a worker persist notification arrives after a new delta is emitted but before its flush commits, the registry returned that un-flushed delta's seq, so the recorded anchor claimed content the durable rows do not hold — clients drop the corresponding live delta as a replay and the streamed text vanishes. This is the same disappearing-streamed-text failure #38883 exists to prevent, in a narrower window.

## Fix

Track a separate durable watermark, `EventHandlerState.flushedContentSeq`, raised (monotonic max) only after a partial flush or the `message_complete` finalize write commits — never at emit time, and never reset mid-turn, so it is a turn-level high-water mark. `getInflightFlushedContentSeq()` now reads this field, so the anchor never advertises content a flush has not written. The monotonic max guards against a slower flush resolving after a newer delta already advanced the watermark. Both commit sites share a `raiseFlushedContentWatermark()` helper.

The misleadingly-named live field `lastPersistedContentSeq` (assigned at emit, before persistence) is renamed to `lastStreamedContentSeq` to make the live-vs-durable distinction explicit and prevent the confusion that produced this bug. Docstrings in `inflight-turn-registry.ts` that described the exposed value as "flushed" are now accurate because the code reads the genuinely-flushed field.

## Tests

`conversation-sync-ipc-routes.test.ts` — switched the state fixtures to `flushedContentSeq` and added a case proving the gap is closed: the live streamed seq (4) has raced ahead of the committed flush (2), and the anchor holds at 2, never the un-flushed 4. `conversation-loop-db-lock-resilience.test.ts` and `tool-preview-lifecycle.test.ts` updated for the field rename.

Addresses Codex review feedback on #38883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)