### PR TITLE
fix(web): scope bookmarks version gate to the owning assistant

### DIFF
--- a/clients/web/src/domains/settings/settings-layout.test.tsx
+++ b/clients/web/src/domains/settings/settings-layout.test.tsx
@@ -32,6 +32,14 @@ mock.module("@/lib/backwards-compat/use-supports-bookmarks", () => ({
   useSupportsBookmarks: () => supportsBookmarks,
 }));
 
+mock.module("@/stores/resolved-assistants-store", () => {
+  const store = () => null;
+  store.use = {
+    activeAssistantId: () => "asst-active",
+  };
+  return { useResolvedAssistantsStore: store };
+});
+
 mock.module("@/hooks/use-platform-gate", () => ({
   usePlatformGate: () => "full",
 }));

--- a/clients/web/src/domains/settings/settings-layout.tsx
+++ b/clients/web/src/domains/settings/settings-layout.tsx
@@ -9,6 +9,7 @@ import { useSupportsBookmarks } from "@/lib/backwards-compat/use-supports-bookma
 import { useHasPlatformSession } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
 import { SETTINGS_SIDEBAR } from "@/utils/settings-navigation";
 import { SidebarShell } from "@/components/sidebar-shell";
@@ -24,10 +25,12 @@ export function SettingsLayout() {
   const settingsDeveloperNav = useAssistantFeatureFlagStore.use.settingsDeveloperNav();
   const credentialsSettingsEnabled = useAssistantFeatureFlagStore.use.credentialsSettings();
   const platformNotifications = useClientFeatureFlagStore.use.platformNotifications();
-  // The Bookmarks tab needs the assistant's bookmark routes (v0.8.1+); an
-  // older assistant 404s them, so hide the tab rather than render a dead
-  // "Failed to load bookmarks" page.
-  const supportsBookmarks = useSupportsBookmarks();
+  const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  // The Bookmarks tab needs the active assistant's bookmark routes (v0.8.1+);
+  // an older assistant 404s them, so hide the tab rather than render a dead
+  // "Failed to load bookmarks" page. Scoped to the active assistant so a
+  // stale cross-store version can't light the tab mid-switch.
+  const supportsBookmarks = useSupportsBookmarks(activeAssistantId);
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   // The Usage item is never hidden: the Usage tab reads from the local daemon
   // and works for every assistant. Its label only gains "Billing &" when the

--- a/clients/web/src/hooks/use-bookmarks.ts
+++ b/clients/web/src/hooks/use-bookmarks.ts
@@ -40,7 +40,7 @@ const EMPTY_BOOKMARKS: Bookmark[] = [];
 /** Active assistant id + whether the shared bookmark query should run. */
 function useBookmarkQueryGate(): { assistantId: string | null; enabled: boolean } {
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const supportsBookmarks = useSupportsBookmarks();
+  const supportsBookmarks = useSupportsBookmarks(assistantId);
   const enabled = supportsBookmarks && Boolean(assistantId);
   return { assistantId, enabled };
 }
@@ -84,16 +84,18 @@ export function useIsBookmarked(messageId: string | undefined): boolean {
 }
 
 /**
- * Whether `message` can be bookmarked. Requires an assistant new enough to
- * expose the bookmark routes (see `useSupportsBookmarks`) and a persisted row
- * the daemon can resolve — optimistic/streaming messages carry a
- * client-generated id, and a bookmark keys on (messageId, conversationId).
+ * Whether `message` can be bookmarked. Requires the active assistant to be new
+ * enough to expose the bookmark routes (see `useSupportsBookmarks`, scoped to
+ * that assistant) and a persisted row the daemon can resolve —
+ * optimistic/streaming messages carry a client-generated id, and a bookmark
+ * keys on (messageId, conversationId).
  */
 export function useCanBookmark(
   message: { id?: string; isOptimistic?: boolean },
   conversationId: string | null | undefined,
 ): boolean {
-  const supportsBookmarks = useSupportsBookmarks();
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const supportsBookmarks = useSupportsBookmarks(assistantId);
   return (
     supportsBookmarks &&
     Boolean(conversationId) &&

--- a/clients/web/src/lib/backwards-compat/use-supports-bookmarks.test.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-bookmarks.test.ts
@@ -1,12 +1,21 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-
-import { renderHook } from "@testing-library/react";
+import { cleanup, renderHook } from "@testing-library/react";
 
 import { useSupportsBookmarks } from "@/lib/backwards-compat/use-supports-bookmarks";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
-function setVersion(version: string | null) {
-  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+const OWNER_ASSISTANT_ID = "asst-owner";
+
+/** Read the gate synchronously through the exported hook, scoped to OWNER_ASSISTANT_ID. */
+function readGate(
+  version: string | null,
+  identityAssistantId: string | null = OWNER_ASSISTANT_ID,
+): boolean {
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity("test-asst", version, identityAssistantId);
+  return renderHook(() => useSupportsBookmarks(OWNER_ASSISTANT_ID)).result
+    .current;
 }
 
 beforeEach(() => {
@@ -14,42 +23,49 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  cleanup();
   useAssistantIdentityStore.getState().clearIdentity();
 });
 
-// Exhaustive truth-table for the underlying semver gate lives in
-// `utils.test.ts`. Here we verify each side of the 0.8.1 boundary (the first
-// release carrying the `/v1/assistants/{id}/bookmarks` routes and
-// `bookmark.*` SSE events) plus the conservative-on-unknown policy. `false`
-// means every bookmark affordance is hidden and the list query stays idle.
+// Exhaustive semver + owner-scoping truth-table lives in `utils.test.ts`
+// (`useAssistantSupports` / `useAssistantScopedSupports`). Here we verify each
+// side of the 0.8.1 boundary (the first release carrying the
+// `/v1/assistants/{id}/bookmarks` routes and `bookmark.*` SSE events), the
+// conservative-on-unknown policy, and that a version fetched for a DIFFERENT
+// assistant cannot authorize this one. `false` means every bookmark affordance
+// is hidden and the list query stays idle.
 describe("useSupportsBookmarks", () => {
   test("false when version is unknown", () => {
-    setVersion(null);
-    const { result } = renderHook(() => useSupportsBookmarks());
-    expect(result.current).toBe(false);
+    expect(readGate(null)).toBe(false);
   });
 
   test("false for assistants on 0.8.0 and older", () => {
-    setVersion("0.8.0");
-    const { result } = renderHook(() => useSupportsBookmarks());
-    expect(result.current).toBe(false);
+    expect(readGate("0.8.0")).toBe(false);
   });
 
   test("true for assistants on 0.8.1+", () => {
-    setVersion("0.8.1");
-    const { result } = renderHook(() => useSupportsBookmarks());
-    expect(result.current).toBe(true);
-  });
-
-  test("true for much newer assistants", () => {
-    setVersion("0.10.9");
-    const { result } = renderHook(() => useSupportsBookmarks());
-    expect(result.current).toBe(true);
+    expect(readGate("0.8.1")).toBe(true);
+    expect(readGate("0.10.9")).toBe(true);
   });
 
   test("true for RC builds of the cutover patch", () => {
-    setVersion("0.8.1-rc.1");
-    const { result } = renderHook(() => useSupportsBookmarks());
-    expect(result.current).toBe(true);
+    expect(readGate("0.8.1-rc.1")).toBe(true);
+  });
+
+  test("true when the identity version was fetched for this assistant", () => {
+    expect(readGate("0.8.1", OWNER_ASSISTANT_ID)).toBe(true);
+  });
+
+  test("false when the identity version belongs to a different assistant", () => {
+    expect(readGate("0.8.1", "asst-other")).toBe(false);
+  });
+
+  test("false when no owner is provided even on a supported version", () => {
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("test-asst", "0.8.1", OWNER_ASSISTANT_ID);
+    expect(
+      renderHook(() => useSupportsBookmarks(null)).result.current,
+    ).toBe(false);
   });
 });

--- a/clients/web/src/lib/backwards-compat/use-supports-bookmarks.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-bookmarks.ts
@@ -1,36 +1,42 @@
 /**
  * Backwards-compat gate: message bookmarks.
  *
- * Vellum Assistant 0.8.1 added the bookmark routes
- * (`GET/POST/DELETE /v1/assistants/{id}/bookmarks`) and the
- * `bookmark.created` / `bookmark.deleted` SSE events (PR #30118). Older
- * assistants 404 those routes, so the web app hides every bookmark
- * affordance — the per-message hover / long-press toggle and the
- * Settings → Bookmarks tab — and keeps the shared list query disabled.
- * The transcript and Settings render exactly as they did before the
- * feature, with no control to invoke and no error surfaced.
+ * The bookmark routes (`GET/POST/DELETE /v1/assistants/{id}/bookmarks`) and
+ * the `bookmark.created` / `bookmark.deleted` SSE events first ship in
+ * assistant 0.8.1 (PR #30118, merged 2026-05-09), so MIN_VERSION is 0.8.1.
+ * Assistants older than that 404 the routes, so the web app hides every
+ * bookmark affordance — the per-message hover / long-press toggle and the
+ * Settings → Bookmarks tab — and keeps the shared list query disabled. The
+ * transcript and Settings render with no bookmark control to invoke and no
+ * error surfaced.
  *
- * Before GA the `bookmarks` client feature flag doubled as an accidental
- * compatibility gate: an old assistant that lacked the routes also
- * reported no flag, so the UI stayed hidden. Removing the flag on GA
- * removed that gate — a current bundle against a pre-0.8.1 assistant would
- * otherwise fire the list query into a 404 ("Failed to load bookmarks")
- * and issue unsupported POST/DELETE writes that fail after an optimistic
- * update. This version gate restores the compatibility behavior the flag
- * used to provide. CDN-served bundles routinely connect to self-hosted
+ * The gate is load-bearing because one CDN-served bundle serves self-hosted
  * assistants of arbitrary age (the iOS shell loads the deployed SPA against
- * self-hosted gateways), so the gate is load-bearing.
+ * self-hosted gateways). Absent the gate, a current bundle pointed at a
+ * pre-0.8.1 assistant fires the list query into a 404 ("Failed to load
+ * bookmarks") and issues POST/DELETE writes that fail after an optimistic
+ * update.
  *
- * A render hook (not the `assistantSupports` snapshot) so the bookmark UI
- * appears the moment the version hydrates.
- *
- * MIN_VERSION is 0.8.1: the bookmark routes first shipped there (PR #30118,
- * merged 2026-05-09); v0.8.0 and older 404 them.
+ * Scoped to the owning assistant via `useAssistantScopedSupports` — see its
+ * JSDoc in `./utils.ts` for the atomic version+owner snapshot and
+ * conservative unknown/mismatch semantics — so a version fetched for one
+ * assistant never authorizes another's routes mid-switch. A render hook (not
+ * the `assistantSupports` snapshot) so the bookmark UI appears the moment the
+ * version hydrates.
  */
-import { useAssistantSupports } from "@/lib/backwards-compat/utils";
+import { useAssistantScopedSupports } from "@/lib/backwards-compat/utils";
 
 const MIN_VERSION = "0.8.1";
 
-export function useSupportsBookmarks(): boolean {
-  return useAssistantSupports(MIN_VERSION);
+/**
+ * Returns `true` when the assistant that owns the bookmark surface
+ * (`ownerAssistantId` — the active assistant whose transcript or Settings are
+ * rendered) is new enough to serve the bookmark routes. Conservative
+ * (`false`) until the scoped version hydrates and on any owner mismatch, so
+ * every bookmark affordance stays hidden and the list query idle.
+ */
+export function useSupportsBookmarks(
+  ownerAssistantId: string | null | undefined,
+): boolean {
+  return useAssistantScopedSupports(MIN_VERSION, ownerAssistantId);
 }


### PR DESCRIPTION
Addresses Codex review feedback on #38884.

**P2 (cross-store race).** `useSupportsBookmarks` paired `activeAssistantId` (resolved-assistants store) with the unscoped identity-store version. On an assistant switch the two stores update at different times, so a 0.8.1+ version could briefly authorize the query/toggle against a pre-0.8.1 assistant, recreating the 404s the gate prevents. `useSupportsBookmarks(ownerAssistantId)` now delegates to `useAssistantScopedSupports`, comparing the version against the owner the identity store records atomically alongside it. Threaded through `useBookmarkQueryGate`, `useCanBookmark`, and the Settings → Bookmarks tab, all scoped to the active assistant; conservative on null/mismatched owner.

**P1 (comment history).** Rewrote the `use-supports-bookmarks.ts` module docstring to state only the present contract — what the gate does, why MIN_VERSION is 0.8.1 (the release carrying the bookmark routes and `bookmark.*` SSE events), and the CDN-served-bundle vs self-hosted-assistant deployment reality. Dropped the before-GA / removed-flag / restores narrative per the present-tense comment rule.

**Tests.** `use-supports-bookmarks.test.ts` gains matching-owner and mismatched-owner cases; `settings-layout.test.tsx` stubs the resolved-assistants store now that the layout reads `activeAssistantId`.