### PR TITLE
fix: validated pre-chat context read + single onboarding-choice eligibility flag

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -158,8 +158,7 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   const {
     didOnboarding,
-    onboardingTasksEmpty,
-    onboardingKickoffHidden,
+    onboardingChoiceEligible,
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,
@@ -555,8 +554,7 @@ export function ActiveChatView() {
     uiContextRef,
 
     // Onboarding
-    onboardingTasksEmpty,
-    onboardingKickoffHidden,
+    onboardingChoiceEligible,
     didOnboarding,
     onboardingConversationId,
   };

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -163,8 +163,7 @@ export interface ChatMainPanelProps {
   uiContextRef: MutableRefObject<UIContext | null>;
 
   // Onboarding (local state in ActiveChatView)
-  onboardingTasksEmpty: boolean;
-  onboardingKickoffHidden: boolean;
+  onboardingChoiceEligible: boolean;
   didOnboarding: boolean;
   onboardingConversationId: string | null;
 }
@@ -235,8 +234,7 @@ export function ChatMainPanel({
   transcriptItemsRef,
   transcriptRef,
   uiContextRef,
-  onboardingTasksEmpty,
-  onboardingKickoffHidden,
+  onboardingChoiceEligible,
   didOnboarding,
   onboardingConversationId,
 }: ChatMainPanelProps) {
@@ -467,8 +465,7 @@ export function ChatMainPanel({
     isNative,
     didOnboarding,
     messages,
-    onboardingTasksEmpty,
-    onboardingKickoffHidden,
+    onboardingChoiceEligible,
     activeConversationId,
     onboardingConversationId,
     sendMessage,

--- a/clients/web/src/domains/chat/hooks/use-onboarding-choice.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-choice.test.tsx
@@ -19,8 +19,7 @@ function baseOptions() {
     isNative: true,
     didOnboarding: true,
     messages: greeting,
-    onboardingTasksEmpty: true,
-    onboardingKickoffHidden: false,
+    onboardingChoiceEligible: true,
     activeConversationId: CONVERSATION_ID,
     onboardingConversationId: CONVERSATION_ID,
     sendMessage: mock(() => {}),
@@ -33,12 +32,9 @@ describe("useOnboardingChoice", () => {
     expect(result.current.showOnboardingChoice).toBe(true);
   });
 
-  test("suppresses the card for hidden-kickoff handoffs (research onboarding)", () => {
-    // The research-onboarding "Let's chat" handoff auto-sends a hidden kickoff
-    // whose scripted greeting carries its own choice surface; the legacy card
-    // must not stack a second chooser on top of it.
+  test("suppresses the card for ineligible handoffs (tasks selected or hidden kickoff)", () => {
     const { result } = renderHook(() =>
-      useOnboardingChoice({ ...baseOptions(), onboardingKickoffHidden: true }),
+      useOnboardingChoice({ ...baseOptions(), onboardingChoiceEligible: false }),
     );
     expect(result.current.showOnboardingChoice).toBe(false);
   });

--- a/clients/web/src/domains/chat/hooks/use-onboarding-choice.ts
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-choice.ts
@@ -3,9 +3,8 @@
  *
  * Phase transitions: `pending` → `visible` → `dismissed`.
  * The card becomes visible when all conditions are met (native, did onboarding,
- * greeting arrived, no tasks selected during prechat, and the handoff did not
- * auto-send a hidden kickoff that scripts its own first-reply UI). Once
- * dismissed it never reappears.
+ * greeting arrived, and the handoff is choice-eligible — see
+ * `onboardingChoiceEligible` below). Once dismissed it never reappears.
  */
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
@@ -17,14 +16,17 @@ interface UseOnboardingChoiceOptions {
   isNative: boolean;
   didOnboarding: boolean;
   messages: DisplayMessage[];
-  onboardingTasksEmpty: boolean;
   /**
-   * True when the onboarding handoff auto-sent a hidden kickoff message
-   * (`initialMessageHidden` on the pre-chat context). Those flows (research
-   * onboarding's "Let's chat") script the assistant's first reply — including
-   * its own choice surface — so the legacy card must never stack on top.
+   * True when the pre-chat handoff qualifies for the choice card: the user
+   * selected no tasks during prechat (so the card's task chooser has work to
+   * do) AND the handoff did not auto-send a hidden kickoff message
+   * (`initialMessageHidden` on the pre-chat context). Hidden-kickoff flows
+   * (research onboarding's "Let's chat") script the assistant's first reply —
+   * including its own choice surface — so the legacy card must never stack on
+   * top. Derived from the validated pre-chat context by
+   * `useOnboardingOrchestrator`.
    */
-  onboardingKickoffHidden: boolean;
+  onboardingChoiceEligible: boolean;
   activeConversationId: string | null;
   onboardingConversationId: string | null;
   sendMessage: (content: string) => void;
@@ -41,8 +43,7 @@ export function useOnboardingChoice({
   isNative,
   didOnboarding,
   messages,
-  onboardingTasksEmpty,
-  onboardingKickoffHidden,
+  onboardingChoiceEligible,
   activeConversationId,
   onboardingConversationId,
   sendMessage,
@@ -79,9 +80,8 @@ export function useOnboardingChoice({
       phase === "pending" &&
       isNative &&
       didOnboarding &&
-      !onboardingKickoffHidden &&
+      onboardingChoiceEligible &&
       greetingSeenRef.current &&
-      onboardingTasksEmpty &&
       activeConversationId === onboardingConversationId
     ) {
       visibleConversationIdRef.current = activeConversationId;
@@ -89,7 +89,7 @@ export function useOnboardingChoice({
     }
     // `messages` is not read in the body; listed so this effect re-fires
     // when a new message arrives and greetingSeenRef may have just latched.
-  }, [phase, isNative, didOnboarding, messages, onboardingTasksEmpty, onboardingKickoffHidden, activeConversationId, onboardingConversationId]);
+  }, [phase, isNative, didOnboarding, messages, onboardingChoiceEligible, activeConversationId, onboardingConversationId]);
 
   // Dismiss if the user switches to a different conversation.
   useEffect(() => {

--- a/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
@@ -5,9 +5,9 @@
  * Owns:
  * - `pendingOnboardingContextRef` — pre-chat context for the first send
  * - `onboardingDraftConversationIdRef` — draft conversation created during onboarding
- * - `didOnboarding` / `onboardingConversationId` / `onboardingTasksEmpty` — lifecycle flags
+ * - `didOnboarding` / `onboardingConversationId` / `onboardingChoiceEligible` — lifecycle flags
  * - `?onboarding=1` search-param signal consumption effect
- * - `sessionStorage` tasks-empty derivation
+ * - choice-card eligibility derivation from the pending pre-chat context
  *
  * Does NOT own:
  * - Auto-send of the initial message (depends on `sendMessage` from `useSendMessage`,
@@ -27,7 +27,10 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
-import { type PreChatOnboardingContext } from "@/domains/onboarding/prechat";
+import {
+  peekPendingPreChatContext,
+  type PreChatOnboardingContext,
+} from "@/domains/onboarding/prechat";
 import {
   isInChatTourOn,
   readInChatTourVariant,
@@ -42,15 +45,12 @@ import { routes } from "@/utils/routes";
 export interface UseOnboardingOrchestratorResult {
   /** Whether the user arrived via the onboarding flow. */
   didOnboarding: boolean;
-  /** Whether the user skipped task selection during prechat. */
-  onboardingTasksEmpty: boolean;
   /**
-   * Whether the onboarding handoff auto-sends a hidden kickoff message
-   * (`initialMessageHidden` on the pre-chat context). Hidden-kickoff flows
-   * (research onboarding's "Let's chat") script their own first-reply UI, so
-   * the in-chat onboarding choice card must not stack on top of it.
+   * Whether this onboarding handoff is eligible for the in-chat onboarding
+   * choice card. See the option doc on `useOnboardingChoice` for the
+   * rationale behind each condition.
    */
-  onboardingKickoffHidden: boolean;
+  onboardingChoiceEligible: boolean;
   /** The draft conversation created for the onboarding flow. */
   onboardingConversationId: string | null;
   /** Shared with `useSendMessage` — pre-chat context for the first send. */
@@ -68,8 +68,7 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
   const pendingOnboardingContextRef = useRef<PreChatOnboardingContext | null>(null);
   const onboardingDraftConversationIdRef = useRef<string | null>(null);
   const [didOnboarding, setDidOnboarding] = useState(false);
-  const [onboardingTasksEmpty, setOnboardingTasksEmpty] = useState(false);
-  const [onboardingKickoffHidden, setOnboardingKickoffHidden] = useState(false);
+  const [onboardingChoiceEligible, setOnboardingChoiceEligible] = useState(false);
   const [onboardingConversationId, setOnboardingConversationId] = useState<string | null>(null);
 
   // Consume the `?onboarding=1` signal left by `/onboarding/hatching` when
@@ -108,32 +107,21 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
     void navigate(routes.conversation(draftId), { replace: true });
   }, [searchParams, navigate, isMobile, isNative]);
 
-  // Derive onboardingTasksEmpty from the pending context in sessionStorage.
-  // Runs once on mount — if initial message key is present, this is an
-  // onboarding mount, so peek at the context for the tasks-empty flag.
+  // Derive choice-card eligibility from the pending pre-chat context. Runs
+  // once on mount, before the first send consumes the context. Reads through
+  // the validated peek so this gate can never disagree with the auto-send
+  // path in ActiveChatView: a malformed/absent context yields `null` there
+  // too, which fails open to the legacy (card-less) behavior.
   useEffect(() => {
-    try {
-      const raw = globalThis.sessionStorage?.getItem("onboarding.prechat.pendingContext");
-      if (!raw) return;
-      const ctx = JSON.parse(raw) as {
-        tasks?: string[];
-        initialMessageHidden?: boolean;
-      };
-      if (Array.isArray(ctx.tasks) && ctx.tasks.length === 0) {
-        setOnboardingTasksEmpty(true);
-      }
-      if (ctx.initialMessageHidden === true) {
-        setOnboardingKickoffHidden(true);
-      }
-    } catch {
-      // Storage or parse failure — ignore.
+    const ctx = peekPendingPreChatContext();
+    if (ctx !== null && ctx.tasks.length === 0 && ctx.initialMessageHidden !== true) {
+      setOnboardingChoiceEligible(true);
     }
   }, []);
 
   return {
     didOnboarding,
-    onboardingTasksEmpty,
-    onboardingKickoffHidden,
+    onboardingChoiceEligible,
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for first-message-scope-options.md.

**Gap:** orchestrator raw-parsed the pre-chat sessionStorage context (could disagree with the validated peekPendingPreChatContext read in active-chat-view on malformed storage)
**Gap:** two booleans (onboardingTasksEmpty / onboardingKickoffHidden) drilled through four files for one conjunction; rationale comment duplicated 4x

- orchestrator now derives gating from peekPendingPreChatContext() (validated, single source of truth)
- single eligibility flag threads through ChatMainPanelProps; canonical rationale lives on the consuming hook option