### PR TITLE
fix: thread userId into scope telemetry + slim first-run-scope contract

### DIFF
--- a/clients/web/src/domains/chat/surface-actions.test.ts
+++ b/clients/web/src/domains/chat/surface-actions.test.ts
@@ -31,11 +31,16 @@ mock.module("@/domains/chat/api/surfaces", () => ({
 }));
 
 const emittedScopes: string[] = [];
+const emittedUserIds: Array<string | null | undefined> = [];
 let emitThrows = false;
 
 mock.module("@/domains/onboarding/funnel-events", () => ({
-  emitFirstMessageScopeSelected: (scope: string): void => {
+  emitFirstMessageScopeSelected: (
+    scope: string,
+    options?: { userId?: string | null },
+  ): void => {
     emittedScopes.push(scope);
+    emittedUserIds.push(options?.userId);
     if (emitThrows) throw new Error("telemetry down");
   },
 }));
@@ -49,13 +54,16 @@ const { useChatSessionStore } = await import(
 );
 const { useStreamStore } = await import("@/domains/chat/stream-store");
 const { useTurnStore } = await import("@/domains/chat/turn-store");
+const { useAuthStore } = await import("@/stores/auth-store");
 
 beforeEach(() => {
   submitResult = { ok: true };
   submitThrows = false;
   submitCalls.length = 0;
   emittedScopes.length = 0;
+  emittedUserIds.length = 0;
   emitThrows = false;
+  useAuthStore.setState({ user: null });
   useStreamStore.getState().setStreamContext({
     assistantId: "ast-1",
     conversationId: "conv-1",
@@ -65,13 +73,35 @@ beforeEach(() => {
 });
 
 describe("handleSurfaceAction — first-run scope funnel event", () => {
-  it("emits exactly one event with the chosen scope", async () => {
+  it("emits exactly one event with the chosen scope and the auth user id", async () => {
+    useAuthStore.setState({
+      user: {
+        kind: "platform",
+        id: "user-42",
+        username: null,
+        email: null,
+        isStaff: false,
+        firstName: "",
+        lastName: "",
+      },
+    });
+
     await handleSurfaceAction("srf-1", "scope_work", {
       [FIRST_RUN_SCOPE_DATA_KEY]: "work",
     });
 
     expect(emittedScopes).toEqual(["work"]);
+    expect(emittedUserIds).toEqual(["user-42"]);
     expect(useChatSessionStore.getState().error).toBeNull();
+  });
+
+  it("still emits, with a null user id, when no user is signed in", async () => {
+    await handleSurfaceAction("srf-1", "scope_work", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "work",
+    });
+
+    expect(emittedScopes).toEqual(["work"]);
+    expect(emittedUserIds).toEqual([null]);
   });
 
   it("emits nothing for surface actions without the scope marker", async () => {

--- a/clients/web/src/domains/chat/surface-actions.ts
+++ b/clients/web/src/domains/chat/surface-actions.ts
@@ -10,10 +10,10 @@ import { captureError } from "@/lib/sentry/capture-error";
 
 import {
   FIRST_RUN_SCOPE_DATA_KEY,
-  FIRST_RUN_SCOPES,
-  type FirstRunScope,
+  isFirstRunScope,
 } from "@/domains/onboarding/first-run-scope";
 import { emitFirstMessageScopeSelected } from "@/domains/onboarding/funnel-events";
+import { useAuthStore } from "@/stores/auth-store";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
 import { useStreamStore } from "@/domains/chat/stream-store";
@@ -45,9 +45,12 @@ function formatDecisionReason(reason?: string): string {
  */
 function emitFirstRunScopeTelemetry(data?: Record<string, unknown>): void {
   const scope = data?.[FIRST_RUN_SCOPE_DATA_KEY];
-  if (!(FIRST_RUN_SCOPES as readonly unknown[]).includes(scope)) return;
+  if (!isFirstRunScope(scope)) return;
   try {
-    emitFirstMessageScopeSelected(scope as FirstRunScope);
+    // Same auth source `active-chat-view.tsx` derives `authUserId` from, read
+    // non-reactively; an absent user id emits as null rather than blocking.
+    const userId = useAuthStore.getState().user?.id ?? null;
+    emitFirstMessageScopeSelected(scope, { userId });
   } catch (err) {
     captureError(err, { context: "first_run_scope_telemetry" });
   }

--- a/clients/web/src/domains/onboarding/first-run-scope.ts
+++ b/clients/web/src/domains/onboarding/first-run-scope.ts
@@ -14,8 +14,8 @@
 export const FIRST_RUN_SCOPE_DATA_KEY = "firstRunScope";
 export const FIRST_RUN_SCOPES = ["work", "personal", "both"] as const;
 export type FirstRunScope = (typeof FIRST_RUN_SCOPES)[number];
-export const FIRST_RUN_SCOPE_OPTION_IDS: Record<FirstRunScope, string> = {
-  work: "scope_work",
-  personal: "scope_personal",
-  both: "scope_both",
-};
+
+/** Narrow an untrusted wire value (a click payload's `firstRunScope`) to a scope. */
+export function isFirstRunScope(value: unknown): value is FirstRunScope {
+  return (FIRST_RUN_SCOPES as readonly unknown[]).includes(value);
+}

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -251,13 +251,20 @@ export function emitResearchOnboardingCheckinCalendarOpened(
 }
 
 /**
- * Emit the first-run scope option click, with the chosen scope in `screen`.
+ * Emit the first-run scope option click. The chosen scope rides the event's
+ * `screen` field — the same dimension-in-`screen` pattern the tips and tour
+ * funnels use — so analysts read the scope from `screen`, not `step_name`.
  * Stamped with the research funnel version and `control` variant like the
  * in-flow steps, so click-through rate is derivable against their completion
- * rows in the same funnel.
+ * rows in the same funnel. `userId` keys the row to the clicking user; when
+ * unavailable the event still emits with `user_id: null`.
  */
-export function emitFirstMessageScopeSelected(scope: FirstRunScope): void {
+export function emitFirstMessageScopeSelected(
+  scope: FirstRunScope,
+  options: { userId?: string | null } = {},
+): void {
   emitOnboardingFunnelStepCompleted(FIRST_MESSAGE_SCOPE_STEP, {
+    userId: options.userId,
     funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
     screen: scope,
     outcome: "completed",

--- a/clients/web/src/domains/onboarding/lets-chat-kickoff.test.ts
+++ b/clients/web/src/domains/onboarding/lets-chat-kickoff.test.ts
@@ -7,10 +7,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import {
-  FIRST_RUN_SCOPE_DATA_KEY,
-  FIRST_RUN_SCOPE_OPTION_IDS,
-} from "./first-run-scope";
+import { FIRST_RUN_SCOPES } from "./first-run-scope";
 import { buildLetsChatKickoffMessage } from "./lets-chat-kickoff";
 
 describe("buildLetsChatKickoffMessage", () => {
@@ -31,10 +28,13 @@ describe("buildLetsChatKickoffMessage", () => {
     const msg = buildLetsChatKickoffMessage("Quill");
     expect(msg).toContain("`ui_show` tool exactly once");
     expect(msg).toContain('"choice"');
-    for (const id of Object.values(FIRST_RUN_SCOPE_OPTION_IDS)) {
-      expect(msg).toContain(id);
+    // Pin the exact option wire text: the data payloads are the contract the
+    // click-telemetry consumer matches on, so they must stay byte-identical.
+    for (const scope of FIRST_RUN_SCOPES) {
+      expect(msg).toContain(
+        `id \`scope_${scope}\`, \`data: {"firstRunScope": "${scope}"}\``,
+      );
     }
-    expect(msg).toContain(FIRST_RUN_SCOPE_DATA_KEY);
   });
 
   test("frames the options as starters, not a menu", () => {

--- a/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
+++ b/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
@@ -1,12 +1,8 @@
-import {
-  FIRST_RUN_SCOPE_DATA_KEY,
-  FIRST_RUN_SCOPE_OPTION_IDS,
-  type FirstRunScope,
-} from "./first-run-scope";
+import { FIRST_RUN_SCOPE_DATA_KEY, type FirstRunScope } from "./first-run-scope";
 
 /** Renders one choice option's wire fields (id + data payload) for the prompt. */
 function optionWire(scope: FirstRunScope): string {
-  return `id \`${FIRST_RUN_SCOPE_OPTION_IDS[scope]}\`, \`data: {"${FIRST_RUN_SCOPE_DATA_KEY}": "${scope}"}\``;
+  return `id \`scope_${scope}\`, \`data: {"${FIRST_RUN_SCOPE_DATA_KEY}": "${scope}"}\``;
 }
 
 /**
@@ -24,8 +20,9 @@ function optionWire(scope: FirstRunScope): string {
  *
  * The greeting ends with a scope question backed by a single `ui_show` choice
  * surface offering three clickable options (work / personal / both). The
- * option ids and `data` payloads come from `first-run-scope.ts` — they're the
- * wire contract a click-telemetry consumer matches on.
+ * `data` payloads come from `first-run-scope.ts` — they're the wire contract a
+ * click-telemetry consumer matches on. The option ids are presentation-only
+ * (`scope_<scope>`), derived here.
  */
 export function buildLetsChatKickoffMessage(assistantName?: string): string {
   const name = assistantName?.trim();


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for first-message-scope-options.md.

**Gap:** scope-click funnel event emitted without userId (only research-funnel event with user_id: null; late clicks unjoinable)
**Gap:** first-run-scope contract exported an id map nothing shared, while the telemetry consumer hand-rolled the type narrowing

- emitFirstMessageScopeSelected now carries the auth user id (read non-reactively from the auth store, still fire-and-forget); doc notes scope rides the screen field
- contract slimmed to data key + scopes + type, plus an isFirstRunScope guard; kickoff derives scope_${scope} ids locally — rendered prompt unchanged