### PR TITLE
fix(chat): record wake interactivity from resolved client state

### DIFF
--- a/assistant/src/__tests__/conversation-retry-route.test.ts
+++ b/assistant/src/__tests__/conversation-retry-route.test.ts
@@ -346,10 +346,10 @@ describe("POST /v1/conversations/:id/retry", () => {
   });
 
   test("background-event anchor recorded interactive re-runs hidden but interactive", async () => {
-    // A scheduled/backgrounded-tool/remote wake ran interactive and stamped
-    // `backgroundEventInteractive: true`; the retry reproduces that mode so it
-    // keeps the approval prompts the original turn had (rather than the legacy
-    // assumption that every background event ran headless).
+    // A scheduled/backgrounded-tool/remote wake that ran with a client attached
+    // stamped `backgroundEventInteractive: true`; the retry reproduces that mode
+    // so it keeps the approval prompts the original turn had (rather than the
+    // legacy assumption that every background event ran headless).
     discardResult = {
       anchor: anchorRow({
         metadata: JSON.stringify({
@@ -379,8 +379,10 @@ describe("POST /v1/conversations/:id/retry", () => {
   });
 
   test("background-event anchor recorded non-interactive re-runs hidden AND non-interactive", async () => {
-    // A clientless/headless wake (interrupted-turn recovery, local IPC wake)
-    // stamped `backgroundEventInteractive: false`; the retry reproduces the
+    // A wake that ran non-interactive — a clientless/headless wake
+    // (interrupted-turn recovery, local IPC wake), or a scheduled wake on a
+    // cold-hydrated conversation with no client attached — stamped
+    // `backgroundEventInteractive: false`; the retry reproduces the
     // non-interactive mode so side-effecting tools resolve against trust rules
     // instead of blocking on an absent client.
     discardResult = {

--- a/assistant/src/daemon/__tests__/wake-conversation-ops-completion.test.ts
+++ b/assistant/src/daemon/__tests__/wake-conversation-ops-completion.test.ts
@@ -23,10 +23,15 @@ import { persistWakeTriggerMessage } from "../wake-conversation-ops.js";
 await initializeDb();
 
 /** Minimal Conversation stub exercising only the fields the function reads. */
-function makeConversationStub(conversationId: string): Conversation {
+function makeConversationStub(
+  conversationId: string,
+  clientState: { hasNoClient?: boolean; headlessLock?: boolean } = {},
+): Conversation {
   return {
     conversationId,
     trustContext: undefined,
+    hasNoClient: clientState.hasNoClient ?? false,
+    headlessLock: clientState.headlessLock ?? false,
     getTurnChannelContext: () => null,
     getTurnInterfaceContext: () => null,
   } as unknown as Conversation;
@@ -76,7 +81,7 @@ describe("persistWakeTriggerMessage backgroundToolCompletion", () => {
       makeConversationStub(conversationId),
       triggerMessage(),
       "background-tool",
-      true,
+      false,
       completion,
     );
 
@@ -86,22 +91,41 @@ describe("persistWakeTriggerMessage backgroundToolCompletion", () => {
     expect(metadata.kind).toBe("background-event");
     expect(metadata.backgroundEventSource).toBe("background-tool");
     expect(metadata.automated).toBe(true);
-    // The interactivity mode the wake ran under is recorded for later retries.
+    // A non-clientless wake on a client-connected conversation runs interactive,
+    // and that mode is recorded for later retries.
     expect(metadata.backgroundEventInteractive).toBe(true);
   });
 
-  test("omits the key entirely when no completion is passed", async () => {
+  test("omits the completion key and records non-interactive for a clientless wake", async () => {
     await persistWakeTriggerMessage(
       makeConversationStub(conversationId),
       triggerMessage(),
       "background-tool",
-      false,
+      true,
     );
 
     const metadata = readMetadata(conversationId);
     expect("backgroundToolCompletion" in metadata).toBe(false);
     expect(metadata.kind).toBe("background-event");
-    // A clientless/headless wake records the non-interactive mode.
+    // A clientless wake (interrupted-turn recovery, local IPC wake) pins
+    // `hasNoClient` for its dispatch, so it records the non-interactive mode.
+    expect(metadata.backgroundEventInteractive).toBe(false);
+  });
+
+  test("records non-interactive for a cold-hydrated wake without clientless", async () => {
+    // A conversation cold-hydrated after a restart carries `hasNoClient = true`
+    // (no client attached). A scheduled wake omits `clientless`, yet the loop
+    // still resolves the turn non-interactive from `hasNoClient`, so the
+    // recorded mode is false rather than the requested `!clientless`.
+    await persistWakeTriggerMessage(
+      makeConversationStub(conversationId, { hasNoClient: true }),
+      triggerMessage(),
+      "schedule",
+      false,
+    );
+
+    const metadata = readMetadata(conversationId);
+    expect(metadata.backgroundEventSource).toBe("schedule");
     expect(metadata.backgroundEventInteractive).toBe(false);
   });
 });

--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -274,20 +274,28 @@ export async function persistWakeTailMessage(
  * output). The `backgroundEventSource` stamp lets clients hide this row from the
  * rendered transcript — the user-facing wake card carries the status instead.
  *
- * `interactive` records the permission mode the woken turn ran under (derived
- * from the wake's `clientless` option): most background events (scheduled
- * runs, backgrounded-tool completions, remote wakes) run interactive, while
- * clientless/headless wakes (interrupted-turn recovery, local IPC wakes) run
- * non-interactive. Retrying the anchor reuses this so the re-run reproduces the
+ * `backgroundEventInteractive` records the permission mode the woken turn runs
+ * under, matching how the agent loop resolves an unset `isInteractive`
+ * (`!hasNoClient && !headlessLock`; see `runAgentLoopImpl`). A `clientless` wake
+ * pins `hasNoClient = true` for its dispatch, and that pin is applied after this
+ * row is persisted, so `clientless` is taken as a flag here rather than read
+ * back from the conversation post-pin. Most background events run interactive
+ * (scheduled runs, backgrounded-tool completions, and remote wakes on a
+ * client-connected conversation); clientless wakes (interrupted-turn recovery,
+ * local IPC wakes) and wakes on a client-less conversation — e.g. a schedule
+ * firing after a restart with no client attached — run non-interactive.
+ * Retrying the anchor reuses the recorded mode so the re-run reproduces the
  * original turn's approval semantics.
  */
 export async function persistWakeTriggerMessage(
   conversation: Conversation,
   message: Message,
   source: string,
-  interactive: boolean,
+  clientless: boolean,
   completion?: CompletedBackgroundTool,
 ): Promise<void> {
+  const backgroundEventInteractive =
+    !clientless && !conversation.hasNoClient && !conversation.headlessLock;
   const turnChannelCtx = conversation.getTurnChannelContext();
   const turnInterfaceCtx = conversation.getTurnInterfaceContext();
   const metadata: Record<string, unknown> = {
@@ -300,7 +308,7 @@ export async function persistWakeTriggerMessage(
       turnInterfaceCtx?.assistantMessageInterface ?? "web",
     kind: "background-event",
     backgroundEventSource: source,
-    backgroundEventInteractive: interactive,
+    backgroundEventInteractive,
     automated: true,
     ...(completion ? { backgroundToolCompletion: completion } : {}),
   };

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -860,11 +860,12 @@ export async function wakeAgentForOpportunity(
           conversation,
           triggerMessage,
           source,
-          // Record the permission mode this wake runs under so a later retry
-          // reproduces it. `clientless` pins `hasNoClient` → `isInteractive:
-          // false`; its absence leaves the turn interactive (see the option's
-          // doc and the `hasNoClient` pin below).
-          !opts.clientless,
+          // Forward this wake's `clientless` option; `persistWakeTriggerMessage`
+          // derives the recorded interactivity from it plus the conversation's
+          // client state, matching the mode the loop resolves for the dispatch
+          // below (`clientless` pins `hasNoClient` → non-interactive; see the
+          // `hasNoClient` pin before `agentLoop.run`). A later retry replays it.
+          opts.clientless ?? false,
           opts.backgroundToolCompletion,
         );
       } catch (err) {


### PR DESCRIPTION
## Summary

Follow-up to #38879, addressing Codex P1 review feedback.

#38879 stamped `backgroundEventInteractive: !opts.clientless` into the
wake-trigger anchor — the **requested** mode, not the **resolved** one. The
agent loop resolves an unset `isInteractive` as `!hasNoClient && !headlessLock`,
and a `clientless` wake pins `hasNoClient = true`. Scheduled and background-tool
wakes generally omit `clientless`, so on a **cold-hydrated** conversation
(`getOrCreateConversation()` initializes hydrated conversations with
`hasNoClient = true` — e.g. a schedule firing after a daemon restart with no
client attached) the original turn runs **non-interactive** while the anchor was
stamped `true`. A later retry then forced `isInteractive: true`, changing
approval/tool behavior and potentially blocking on prompts the original turn
auto-resolved against trust rules.

## Change

- `persistWakeTriggerMessage` derives `backgroundEventInteractive` from the
  conversation's live client state plus the wake's `clientless` flag
  (`!clientless && !hasNoClient && !headlessLock`) — the same expression the
  loop resolves at dispatch. The `clientless` pin is applied *after* this row is
  persisted, so the flag is passed in rather than read back post-pin. The 4th
  parameter changes from `interactive` to `clientless`; the caller forwards its
  option and the derivation lives in one place.
- The recorded value now matches the loop's resolution in all three wake paths:
  clientless wakes → `false`, live-client wakes → `true`, and cold-hydrated
  wakes with no client attached → `false`.

## Tests

- `wake-conversation-ops-completion.test.ts`: a non-clientless client-connected
  wake records `true`; a clientless wake records `false`; a **cold-hydrated
  (`hasNoClient`) wake without `clientless` records `false`**.
- `conversation-retry-route.test.ts`: recorded-mode comments updated to document
  the cold-hydrated scheduled-wake scenario.

The retry read path is unchanged — it already consumes
`backgroundEventInteractive` with a legacy `!isBackgroundEventMetadata` fallback.

Addresses Codex review feedback on #38879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)