### PR TITLE
feat(web): restyle enabled Extra Usage — payment row, summary chips, remove card

### DIFF
--- a/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -198,6 +198,56 @@ describe("AutoTopUpCard remove card", () => {
       container.querySelector('[data-testid="auto-top-up-remove-error"]'),
     ).toBeNull();
   });
+
+  test("removing while in Adjust form mode exits the form and disables Extra Usage", async () => {
+    retrieveResponse = { ...ENABLED_WITH_CARD };
+    const { container, getByLabelText, getByTestId } = render(
+      <QueryClientProvider client={makeClient(ENABLED_WITH_CARD)}>
+        <AutoTopUpCard />
+      </QueryClientProvider>,
+    );
+
+    // Enter Adjust form mode: the inline form (Save) mounts.
+    fireEvent.click(getByTestId("auto-top-up-edit-button"));
+    expect(
+      container.querySelector('[data-testid="auto-top-up-save-button"]'),
+    ).not.toBeNull();
+
+    // Remove the saved card and confirm.
+    fireEvent.click(
+      container.querySelector('[data-testid="payment-method-remove"]')!,
+    );
+    const confirmButton = await waitFor(() => {
+      const btn = document.querySelector<HTMLButtonElement>(
+        "[data-confirm-dialog-confirm]",
+      );
+      if (!btn) {
+        throw new Error("confirm dialog not open");
+      }
+      return btn;
+    });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      if (removeCalls.length === 0) {
+        throw new Error("remove endpoint not called");
+      }
+    });
+
+    // Form mode exited (no Save) and the card is disabled / no card.
+    await waitFor(() => {
+      const toggle = getByLabelText("Enable Extra Usage");
+      if (toggle.getAttribute("aria-checked") !== "false") {
+        throw new Error("still enabled");
+      }
+      if (container.querySelector('[data-testid="auto-top-up-save-button"]')) {
+        throw new Error("form still mounted after removal");
+      }
+      if (container.querySelector('[data-testid="payment-method-row"]')) {
+        throw new Error("payment-method row still present");
+      }
+    });
+  });
 });
 
 describe("AutoTopUpCard repeated-decline cutoff notice", () => {

--- a/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -1,34 +1,70 @@
 /**
- * Tests for the AutoTopUpCard repeated-decline cutoff notice and its enable
- * gate:
+ * Tests for the AutoTopUpCard enabled-state layout and the repeated-decline
+ * cutoff notice:
+ *  - The enabled view renders the payment-method row above two summary chips
+ *    (spend rule + monthly-cap progress) and Adjust swaps the chips for the
+ *    inline form.
+ *  - Removing the saved card opens a destructive confirm; confirming calls the
+ *    remove endpoint and drives the config to disabled / no card.
  *  - When the backend reports `disabled_due_to_repeated_failures` on a disabled
- *    config, the card renders a tailored warning telling the user to add a new
- *    payment method; a normally-disabled config renders no such notice.
- *  - The cutoff notice is suppressed when the config is `enabled` (defensive
- *    guard against contradictory copy from a raced/stale response).
- *  - Toggling Enable on while the cutoff flag is set (even with a saved PM)
- *    does NOT open the form — the user can't re-enable with the cut-off card.
+ *    config, the card renders a tailored warning; a normally-disabled config
+ *    renders no such notice; the notice is suppressed when `enabled`.
+ *  - Toggling Enable on while cut off (even with a saved PM) does NOT open the
+ *    form.
  *
  * Strategy: the render-only cases pre-populate the React Query cache so the
  * card's `useQuery` resolves synchronously — `renderToStaticMarkup` is
- * single-pass, so a pending query would otherwise report `isLoading` and render
- * the spinner. The enable-gate case needs a real DOM to drive a click, so it
- * uses @testing-library/react (happy-dom is registered via the test preload).
+ * single-pass, so a pending query would otherwise report `isLoading`. The
+ * interaction cases use @testing-library/react (happy-dom via the test
+ * preload). The remove flow mocks the SDK boundary so the mutation and the
+ * follow-up GET are deterministic.
  */
 
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import * as sdkGen from "@/generated/api/sdk.gen";
 import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 
-import { AutoTopUpCard, DISABLED_CONFIG } from "./auto-top-up-card";
+let removeCalls: Array<Record<string, unknown>> = [];
+let retrieveResponse: AutoTopUpConfigResponse;
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingAutoTopUpRemovePaymentMethodCreate: (
+    opts: Record<string, unknown>,
+  ) => {
+    removeCalls.push(opts);
+    // The endpoint clears the PM and disables auto-reload server-side, so the
+    // next GET reflects that.
+    retrieveResponse = {
+      ...retrieveResponse,
+      enabled: false,
+      has_payment_method: false,
+      payment_method_brand: null,
+      payment_method_last4: null,
+    };
+    return Promise.resolve({
+      data: { enabled: false, stubbed: false, message: "Payment method removed" },
+      response: { ok: true },
+    });
+  },
+  organizationsBillingAutoTopUpRetrieve: () =>
+    Promise.resolve({ data: retrieveResponse, response: { ok: true } }),
+}));
+
+import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+
+const { AutoTopUpCard, DISABLED_CONFIG } = await import("./auto-top-up-card");
 
 function makeClient(config: AutoTopUpConfigResponse): QueryClient {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
   });
   client.setQueryData(organizationsBillingAutoTopUpRetrieveQueryKey(), config);
   return client;
@@ -41,6 +77,128 @@ function renderCard(config: AutoTopUpConfigResponse): string {
     </QueryClientProvider>,
   );
 }
+
+const ENABLED_WITH_CARD: AutoTopUpConfigResponse = {
+  ...DISABLED_CONFIG,
+  enabled: true,
+  threshold_usd: "50.00",
+  amount_usd: "200.00",
+  monthly_cap_usd: "500.00",
+  current_month_credits_purchased_usd: "150.00",
+  has_payment_method: true,
+  payment_method_brand: "Visa",
+  payment_method_last4: "4242",
+};
+
+beforeEach(() => {
+  removeCalls = [];
+  retrieveResponse = { ...DISABLED_CONFIG };
+});
+
+afterEach(cleanup);
+
+describe("AutoTopUpCard enabled-state layout", () => {
+  test("renders both summary chips and Adjust swaps them for the form", () => {
+    retrieveResponse = { ...ENABLED_WITH_CARD };
+    const { container, getByTestId } = render(
+      <QueryClientProvider client={makeClient(ENABLED_WITH_CARD)}>
+        <AutoTopUpCard />
+      </QueryClientProvider>,
+    );
+
+    expect(getByTestId("auto-top-up-summary").textContent).toContain(
+      "Add $200 when balance falls under $50",
+    );
+    const cap = getByTestId("auto-top-up-cap-progress").textContent ?? "";
+    expect(cap).toContain("$150");
+    expect(cap).toContain("$500");
+    expect(cap).toContain("this month");
+
+    // Adjust enters form mode: the chips disappear, the form's Save appears.
+    fireEvent.click(getByTestId("auto-top-up-edit-button"));
+
+    expect(
+      container.querySelector('[data-testid="auto-top-up-save-button"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="auto-top-up-summary"]'),
+    ).toBeNull();
+  });
+
+  test("renders the payment-method row above the summary chips", () => {
+    const html = renderCard(ENABLED_WITH_CARD);
+
+    expect(html).toContain("payment-method-row");
+    expect(html).toContain("Visa");
+    expect(html).toContain("Ending in 4242");
+    // The row's Update/Remove controls belong to it.
+    expect(html).toContain("payment-method-update");
+    expect(html).toContain("payment-method-remove");
+
+    // The row is rendered before the summary chips.
+    expect(html.indexOf("payment-method-row")).toBeLessThan(
+      html.indexOf("auto-top-up-summary"),
+    );
+  });
+});
+
+describe("AutoTopUpCard remove card", () => {
+  test("confirming Remove calls the endpoint and disables Extra Usage", async () => {
+    retrieveResponse = { ...ENABLED_WITH_CARD };
+    const { container, getByLabelText } = render(
+      <QueryClientProvider client={makeClient(ENABLED_WITH_CARD)}>
+        <AutoTopUpCard />
+      </QueryClientProvider>,
+    );
+
+    // Precondition: the card is on file and Extra Usage is on.
+    expect(
+      container.querySelector('[data-testid="payment-method-row"]'),
+    ).not.toBeNull();
+
+    // Remove opens a destructive confirm that warns it turns off Extra Usage.
+    fireEvent.click(
+      container.querySelector('[data-testid="payment-method-remove"]')!,
+    );
+    const confirmButton = await waitFor(() => {
+      const btn = document.querySelector<HTMLButtonElement>(
+        "[data-confirm-dialog-confirm]",
+      );
+      if (!btn) {
+        throw new Error("confirm dialog not open");
+      }
+      return btn;
+    });
+    expect(document.body.textContent).toContain("Remove payment method?");
+    expect(document.body.textContent).toContain("turn off Extra Usage");
+    expect(removeCalls.length).toBe(0);
+
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      if (removeCalls.length === 0) {
+        throw new Error("remove endpoint not called");
+      }
+    });
+
+    // The card drops to the disabled / no-card state: toggle off, no PM row.
+    await waitFor(() => {
+      const toggle = getByLabelText("Enable Extra Usage");
+      if (toggle.getAttribute("aria-checked") !== "false") {
+        throw new Error("still enabled");
+      }
+      if (container.querySelector('[data-testid="payment-method-row"]')) {
+        throw new Error("payment-method row still present");
+      }
+    });
+    expect(
+      container.querySelector('[data-testid="auto-top-up-summary"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="auto-top-up-remove-error"]'),
+    ).toBeNull();
+  });
+});
 
 describe("AutoTopUpCard repeated-decline cutoff notice", () => {
   test("renders the cutoff notice when disabled after repeated declines", () => {
@@ -63,11 +221,10 @@ describe("AutoTopUpCard repeated-decline cutoff notice", () => {
   });
 
   test("suppresses the cutoff notice when the config is enabled", () => {
-    // Defensive guard (Finding 2): the backend treats the cutoff as terminal
-    // (cutoff ⇒ enabled=false), but if a raced/stale response carried both
-    // `enabled: true` and the flag, the enabled summary and the cutoff notice
-    // must stay mutually exclusive — show the summary, not the contradictory
-    // "we paused reloads" copy.
+    // Defensive guard: the backend treats the cutoff as terminal (cutoff ⇒
+    // enabled=false), but if a raced/stale response carried both `enabled: true`
+    // and the flag, the enabled summary and the cutoff notice must stay mutually
+    // exclusive — show the summary, not the contradictory "we paused reloads".
     const html = renderCard({
       ...DISABLED_CONFIG,
       enabled: true,
@@ -81,9 +238,9 @@ describe("AutoTopUpCard repeated-decline cutoff notice", () => {
   });
 
   test("renders the cutoff notice (not the enabled summary) when cut off with a saved PM", () => {
-    // Finding 1 state: the saved card is still on file (`has_payment_method:
-    // true`) but the backend cut auto-reload off after repeated declines. The
-    // cutoff notice is the single message; the enabled summary is absent.
+    // The saved card is still on file (`has_payment_method: true`) but the
+    // backend cut auto-reload off after repeated declines. The cutoff notice is
+    // the single message; the enabled summary is absent.
     const html = renderCard({
       ...DISABLED_CONFIG,
       enabled: false,
@@ -96,12 +253,10 @@ describe("AutoTopUpCard repeated-decline cutoff notice", () => {
 });
 
 describe("AutoTopUpCard enable gate", () => {
-  afterEach(cleanup);
-
   test("toggling Enable on while cut off (with a saved PM) does not open the form", () => {
-    // Finding 1: even though a PM is on file, the repeated-decline cutoff must
-    // block re-enabling with the same cut-off card. The toggle must not enter
-    // form mode (no AutoTopUpForm / Save button), and the cutoff notice stays.
+    // Even though a PM is on file, the repeated-decline cutoff must block
+    // re-enabling with the same cut-off card. The toggle must not enter form
+    // mode (no AutoTopUpForm / Save button), and the cutoff notice stays.
     const config: AutoTopUpConfigResponse = {
       ...DISABLED_CONFIG,
       enabled: false,

--- a/clients/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -350,6 +350,9 @@ export function AutoTopUpCard() {
             queryKey: organizationsBillingAutoTopUpRetrieveQueryKey(),
           });
           setConfirmingRemove(false);
+          // Removal disables auto-reload, so leave the Adjust form (if open)
+          // to keep the OFF toggle and a saveable form from coexisting.
+          exitFormMode();
         },
       },
     );

--- a/clients/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -1,10 +1,10 @@
-import { Info, X } from "lucide-react";
+import { Coins, Info, X } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
-import { brandLabel, formatBrandLast4 } from "@/domains/settings/utils/payment-method-brand";
 import {
     organizationsBillingAutoTopUpDisableCreateMutation,
+    organizationsBillingAutoTopUpRemovePaymentMethodCreateMutation,
     organizationsBillingAutoTopUpRetrieveOptions,
     organizationsBillingAutoTopUpRetrieveQueryKey,
     organizationsBillingAutoTopUpRetrieveSetQueryData,
@@ -12,6 +12,7 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 import { Button } from "@vellumai/design-library/components/button";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -22,6 +23,7 @@ import {
     type AutoTopUpFormValues,
 } from "@/domains/settings/components/auto-top-up-form";
 import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-top-up-payment-method-modal";
+import { PaymentMethodRow } from "@/domains/settings/components/payment-method-row";
 
 type Mode = "view" | "form";
 
@@ -97,26 +99,25 @@ export function extractAutoTopUpServerErrors(err: unknown): Record<string, strin
 }
 
 /**
- * Build the saved-PM display string for the enabled-state summary:
- * - "Charged to <brand> •••• <last4>" when both fields are present
- * - "Charged to <brand>" when only the brand is present
- * - null when neither is present (caller renders nothing)
- *
- * The "<brand> •••• <last4>" shape comes from `formatBrandLast4` in
- * `utils/payment-method-brand.ts`, which owns the brand-fallback (`"card"`)
- * and last4-fallback (`"????"`).
+ * Neutral pill shared by the enabled-state summary row — the "add $X under
+ * $Y" chip and the monthly-cap progress chip use identical chrome so they
+ * read as one control group.
  */
-export function formatSavedPaymentMethodLine(args: {
-  brand: string | null;
-  last4: string | null;
-}): string | null {
-  const { brand, last4 } = args;
-  if (!brand && !last4) return null;
-  // When last4 is missing we render "Charged to <brand>" (no bullets), so
-  // we don't route through formatBrandLast4 here — that helper always
-  // emits the "•••• <last4>" tail.
-  if (!last4) return `Charged to ${brandLabel(brand ?? "card")}`;
-  return `Charged to ${formatBrandLast4(brand, last4)}`;
+function SummaryChip({
+  testId,
+  children,
+}: {
+  testId: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      data-testid={testId}
+      className="flex h-8 min-w-0 flex-1 items-center gap-1.5 rounded-lg bg-[var(--surface-base)] px-2"
+    >
+      {children}
+    </div>
+  );
 }
 
 /**
@@ -142,10 +143,14 @@ export function AutoTopUpCard() {
   const disableMutation = useMutation(
     organizationsBillingAutoTopUpDisableCreateMutation(),
   );
+  const removeMutation = useMutation(
+    organizationsBillingAutoTopUpRemovePaymentMethodCreateMutation(),
+  );
 
   const [mode, setMode] = useState<Mode>("view");
   const [pendingEnable, setPendingEnable] = useState(false);
   const [confirmingDisable, setConfirmingDisable] = useState(false);
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
   const [showAddPm, setShowAddPm] = useState(false);
   const [bannerDismissed, setBannerDismissed] = useState(false);
   const [pmModalOpen, setPmModalOpen] = useState(false);
@@ -321,6 +326,36 @@ export function AutoTopUpCard() {
   };
 
   /**
+   * The remove endpoint clears the PM AND flips `enabled=False` server-side,
+   * so the optimistic write lands on the disabled/no-PM state — matching what
+   * the follow-up GET returns, with no separate disable call needed.
+   */
+  const handleConfirmRemove = () => {
+    removeMutation.mutate(
+      {},
+      {
+        onSuccess: () => {
+          organizationsBillingAutoTopUpRetrieveSetQueryData(
+            queryClient,
+            undefined,
+            {
+              ...config,
+              enabled: false,
+              has_payment_method: false,
+              payment_method_brand: null,
+              payment_method_last4: null,
+            },
+          );
+          void queryClient.invalidateQueries({
+            queryKey: organizationsBillingAutoTopUpRetrieveQueryKey(),
+          });
+          setConfirmingRemove(false);
+        },
+      },
+    );
+  };
+
+  /**
    * Click handler for the "Enable Extra Usage" toggle. The toggle itself is
    * never disabled — turning it on always flips visually to reflect intent
    * (`pendingEnable`), even when a payment method still needs to be added.
@@ -418,10 +453,6 @@ export function AutoTopUpCard() {
     updateMutation.isError && Object.keys(fieldErrors).length === 0;
 
   const toggleChecked = enabled || pendingEnable;
-  const savedPmLine = formatSavedPaymentMethodLine({
-    brand: config.payment_method_brand,
-    last4: config.payment_method_last4,
-  });
 
   return (
     <div data-testid="auto-top-up-card">
@@ -431,37 +462,60 @@ export function AutoTopUpCard() {
           onChange={handleToggleChange}
           label="Enable Extra Usage"
         />
-
-        {enabled && !isFormMode && (
-          <div className="flex items-center gap-3">
-            <div className="text-right">
-              <p
-                className="text-body-small-default text-[var(--content-tertiary)]"
-                data-testid="auto-top-up-summary"
-              >
-                Add {formatUsdShort(config.amount_usd)} when the balance falls
-                under {formatUsdShort(config.threshold_usd)}
-              </p>
-              {config.monthly_cap_usd != null && (
-                <p
-                  className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]"
-                  data-testid="auto-top-up-cap-progress"
-                >
-                  {formatUsdShort(config.current_month_credits_purchased_usd)} of{" "}
-                  {formatUsdShort(config.monthly_cap_usd)} this month
-                </p>
-              )}
-            </div>
-            <Button
-              variant="outlined"
-              onClick={enterFormMode}
-              data-testid="auto-top-up-edit-button"
-            >
-              Adjust
-            </Button>
-          </div>
-        )}
       </div>
+
+      {enabled && config.has_payment_method && (
+        <div className="mt-3">
+          <PaymentMethodRow
+            brand={config.payment_method_brand}
+            last4={config.payment_method_last4}
+            onUpdateCard={() => setPmModalOpen(true)}
+            onRemove={() => setConfirmingRemove(true)}
+            removing={removeMutation.isPending}
+          />
+        </div>
+      )}
+
+      {enabled && !isFormMode && (
+        <div className="mt-3 flex w-full items-center gap-2">
+          <SummaryChip testId="auto-top-up-summary">
+            <Coins
+              className="h-3.5 w-3.5 shrink-0 text-[var(--content-default)]"
+              aria-hidden="true"
+            />
+            <Typography
+              variant="body-medium-default"
+              className="truncate text-[var(--content-default)]"
+            >
+              Add {formatUsdShort(config.amount_usd)} when balance falls under{" "}
+              {formatUsdShort(config.threshold_usd)}
+            </Typography>
+          </SummaryChip>
+          {config.monthly_cap_usd != null && (
+            <SummaryChip testId="auto-top-up-cap-progress">
+              <Typography
+                variant="body-medium-default"
+                className="truncate text-[var(--content-default)]"
+              >
+                <span>
+                  {formatUsdShort(config.current_month_credits_purchased_usd)}{" "}
+                </span>
+                <span className="text-[var(--content-tertiary)]">
+                  / {formatUsdShort(config.monthly_cap_usd)} this month
+                </span>
+              </Typography>
+            </SummaryChip>
+          )}
+          <Button
+            variant="outlined"
+            onClick={enterFormMode}
+            data-testid="auto-top-up-edit-button"
+            className="shrink-0"
+          >
+            Adjust
+          </Button>
+        </div>
+      )}
 
       {disabledAfterDeclines && (
         <Notice
@@ -548,6 +602,16 @@ export function AutoTopUpCard() {
         </Notice>
       )}
 
+      {removeMutation.isError && (
+        <Notice
+          tone="error"
+          className="mt-4"
+          data-testid="auto-top-up-remove-error"
+        >
+          Failed to remove the payment method. Please try again.
+        </Notice>
+      )}
+
       {isFormMode && (
         <AutoTopUpForm
           initialValues={
@@ -566,15 +630,6 @@ export function AutoTopUpCard() {
         />
       )}
 
-      {enabled && config.has_payment_method && (
-        <p
-          className="mt-3 text-body-small-default text-[var(--content-tertiary)]"
-          data-testid="auto-top-up-saved-pm"
-        >
-          {savedPmLine ?? "Charged to a saved card"}
-        </p>
-      )}
-
       {(enabled || isFormMode) && (
         <Notice tone="info" className="mt-4">
           If you&apos;re too close to your monthly limit, the auto-reload will
@@ -587,6 +642,17 @@ export function AutoTopUpCard() {
         confirming={disableMutation.isPending}
         onCancel={dismissDisableConfirm}
         onConfirm={handleConfirmDisable}
+      />
+
+      <ConfirmDialog
+        open={confirmingRemove}
+        title="Remove payment method?"
+        message="Removing your card will turn off Extra Usage."
+        confirmLabel={removeMutation.isPending ? "Removing…" : "Remove"}
+        cancelLabel="Keep card"
+        destructive
+        onConfirm={handleConfirmRemove}
+        onCancel={() => setConfirmingRemove(false)}
       />
 
       <AutoTopUpPaymentMethodModal

--- a/clients/web/src/domains/settings/utils/payment-method-brand.ts
+++ b/clients/web/src/domains/settings/utils/payment-method-brand.ts
@@ -19,8 +19,6 @@ export function brandLabel(brand: string): string {
 
 /**
  * Render the canonical "<brand> •••• <last4>" shape with safe fallbacks.
- * Used by `AutoTopUpCard.formatSavedPaymentMethodLine` (with "Charged to"
- * prefix).
  *
  * Fallback chain when brand is null: passes the literal `"card"` to
  * `brandLabel`, which falls through to the default branch (lowercase


### PR DESCRIPTION
## Summary
- Restructure the enabled Extra Usage view: payment-method row (Update Card / Remove) above two summary chips + Adjust.
- Wire card removal via a destructive confirm that disables Extra Usage.

Backend verification: the remove-payment-method endpoint (`remove_payment_method` in `django/app/billing/auto_top_up_views.py`) sets `enabled=False` AND clears the PM server-side, so the optimistic write to enabled:false/has_payment_method:false matches the follow-up GET. No separate disable call is needed.

Part of plan: credit-balance-redesign.md (PR 5 of 5)