### PR TITLE
feat(web): custom-plan recap shows the diff vs current plan with dynamic height

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
@@ -92,6 +92,8 @@ describe("computeCustomPlanDiff — base checkout (no seed)", () => {
 
     expect(diff.deltaCents).toBeNull();
     expect(diff.previousTotalCents).toBeNull();
+    // base $20 + large $60 + 30 GB $10 + $50 credits.
+    expect(diff.totalCents).toBe(2000 + 6000 + 1000 + 5000);
     expect(diff.rows.map((r) => r.label)).toEqual([
       "Pro base plan — $20/mo",
       "Large machine (4 vCPU, 8 GiB)",
@@ -172,6 +174,8 @@ describe("computeCustomPlanDiff — seeded reconfigure", () => {
     });
 
     expect(diff.deltaCents).toBe(2500);
+    // Current config total: base $20 + large $60 + xs $5.
+    expect(diff.totalCents).toBe(2000 + 6000 + 500);
     const machineRow = diff.rows.find((r) => r.key === "machine");
     expect(machineRow?.changed).toBe(true);
     expect(machineRow?.previousLabel).toBe("Medium machine (2.5 vCPU, 5 GiB)");
@@ -248,6 +252,29 @@ describe("computeCustomPlanDiff — seeded reconfigure", () => {
     expect(storageRow?.changed).toBe(true);
     expect(storageRow?.previousLabel).toBe("250 GB storage");
     expect(storageRow?.label).toBe("30 GB storage");
+  });
+
+  test("a held legacy storage tier is priced into totalCents so the total matches its row", () => {
+    // Reopening seeded to a legacy storage tier with no change: the selected
+    // storageTier is still the legacy `xl`. totalCents must resolve it against
+    // the full catalog and include its $60 price, so the header total agrees
+    // with the "250 GB storage" row the recap renders (the modal's own
+    // `!legacy`-filtered list would have dropped it and mispriced the total).
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: { machineTier: "medium", storageTier: "xl", creditTier: null },
+      machineTier: "medium",
+      storageTier: "xl",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    // base $20 + medium $35 + legacy 250 GB $60.
+    expect(diff.totalCents).toBe(2000 + 3500 + 6000);
+    // A no-op reopen, so it equals the seed's total and the delta is zero.
+    expect(diff.previousTotalCents).toBe(2000 + 3500 + 6000);
+    expect(diff.deltaCents).toBe(0);
+    const storageRow = diff.rows.find((r) => r.key === "storage");
+    expect(storageRow?.label).toBe("250 GB storage");
   });
 
   test("removing a deprecated seed credit bundle is detected as a change but suppresses the delta", () => {

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -40,7 +40,9 @@ export interface CustomPlanDiffRow {
 }
 
 export interface CustomPlanDiff {
-  /** Total for the seed (previous) config incl. base fee; null for base checkout (no seed). */
+  /** Total for the current selection incl. base fee; always a number (base checkout included). The modal renders this as the "$X/mo" figure so the header total, delta, and rows share one full-catalog resolution. */
+  totalCents: number;
+  /** Total for the seed (previous) config incl. base fee; null for base checkout (no seed) or a held credit bundle the catalog can no longer price. */
   previousTotalCents: number | null;
   /** newTotal - previousTotal; null for base checkout. */
   deltaCents: number | null;
@@ -171,7 +173,12 @@ export function computeCustomPlanDiff(input: {
     (selectedCredit?.price_cents ?? 0);
 
   if (seed == null) {
-    return { previousTotalCents: null, deltaCents: null, rows };
+    return {
+      totalCents: newTotalCents,
+      previousTotalCents: null,
+      deltaCents: null,
+      rows,
+    };
   }
 
   // A held credit tier that is a concrete enum value but absent from the catalog
@@ -185,7 +192,12 @@ export function computeCustomPlanDiff(input: {
   // routed to the manage/adjust-plan modal upstream and do not normally reach here.
   const seedCreditUnresolved = seed.creditTier != null && seedCredit == null;
   if (seedCreditUnresolved) {
-    return { previousTotalCents: null, deltaCents: null, rows };
+    return {
+      totalCents: newTotalCents,
+      previousTotalCents: null,
+      deltaCents: null,
+      rows,
+    };
   }
 
   const previousTotalCents =
@@ -195,6 +207,7 @@ export function computeCustomPlanDiff(input: {
     (seedCredit?.price_cents ?? 0);
 
   return {
+    totalCents: newTotalCents,
     previousTotalCents,
     deltaCents: newTotalCents - previousTotalCents,
     rows,

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -401,6 +401,32 @@ function findOption(label: string): HTMLElement {
   return option;
 }
 
+/** The recap's "…compared to previous (…)" delta span, or null when absent. */
+function deltaLine(): HTMLElement | null {
+  const dialog = document.querySelector('[role="dialog"]');
+  return (
+    Array.from(dialog?.querySelectorAll<HTMLElement>("span") ?? []).find((s) =>
+      (s.textContent ?? "").includes("compared to previous"),
+    ) ?? null
+  );
+}
+
+/** The recap's `<li>` texts (each row's full concatenated text). */
+function recapRows(): string[] {
+  const dialog = document.querySelector('[role="dialog"]');
+  return Array.from(dialog?.querySelectorAll("li") ?? []).map(
+    (li) => li.textContent?.trim() ?? "",
+  );
+}
+
+/** Struck-through (previous-value) recap labels. */
+function strikethroughs(): string[] {
+  const dialog = document.querySelector('[role="dialog"]');
+  return Array.from(dialog?.querySelectorAll(".line-through") ?? []).map(
+    (el) => el.textContent?.trim() ?? "",
+  );
+}
+
 describe("CustomPlanModal — base subscriber", () => {
   test("Continue stays disabled until every dropdown has a choice", () => {
     const { getByRole, getByText } = renderPage(freeSubscription());
@@ -467,6 +493,21 @@ describe("CustomPlanModal — base subscriber", () => {
       "30 GB storage",
       "$50 of bundled credits",
     ]);
+  });
+
+  test("base checkout shows no delta line and no strikethrough", () => {
+    // No seed (a base subscriber), so there is no previous plan to compare
+    // against — the recap stays the plain grey-check list.
+    const { getByRole } = renderPage(freeSubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    selectOption("Machine size", "Large machine (4 vCPU, 8 GiB)");
+    selectOption("Storage", "30 GB");
+    selectOption("Credit bundle", "50 credits");
+
+    expect(deltaLine()).toBeNull();
+    expect(strikethroughs()).toEqual([]);
   });
 
   test("Continue starts a Stripe checkout with the selected tiers", async () => {
@@ -561,6 +602,63 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
       "10 GB storage",
       "No extra credits",
     ]);
+  });
+
+  test("a seeded no-op shows the plain grey-check recap with no delta line", () => {
+    // Opening seeded to the current plan with no interaction: every dimension
+    // matches the seed, so no row is struck through and the delta line is hidden.
+    const { getByRole } = renderPage(proMightySubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    expect(recapRows()).toEqual([
+      "Pro base plan — $20/mo",
+      "Medium machine (2.5 vCPU, 5 GiB)",
+      "10 GB storage",
+      "No extra credits",
+    ]);
+    expect(deltaLine()).toBeNull();
+    expect(strikethroughs()).toEqual([]);
+  });
+
+  test("a machine upgrade struck-throughs the previous value with a green up delta", () => {
+    // Seed: medium machine / 10 GB (xs) storage / no credits.
+    const { getByRole } = renderPage(proMightySubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    selectOption("Machine size", "Large machine (4 vCPU, 8 GiB)");
+
+    // The changed machine row shows the previous value struck through above
+    // the new value.
+    expect(strikethroughs()).toContain("Medium machine (2.5 vCPU, 5 GiB)");
+    expect(
+      recapRows().some((r) => r.includes("Large machine (4 vCPU, 8 GiB)")),
+    ).toBe(true);
+
+    // previous = base 2000 + medium 3500 + xs 500 = 6000 ($60);
+    // new = base 2000 + large 6000 + xs 500 = 8500 ($85); delta = +$25/mo.
+    const delta = deltaLine();
+    expect(delta).not.toBeNull();
+    expect(delta!.textContent).toBe("+$25/mo compared to previous ($60)");
+    expect(delta!.className).toContain("text-[var(--system-positive-strong)]");
+  });
+
+  test("a cheaper reconfigure shows a red down delta with the U+2212 minus", () => {
+    // Seed machine to large; lowering to medium is cheaper.
+    const { getByRole } = renderPage(
+      proMightySubscription(),
+      onboarding({ max_machine_tier: "large" }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    selectOption("Machine size", "Medium machine (2.5 vCPU, 5 GiB)");
+
+    // previous = base 2000 + large 6000 + xs 500 = 8500 ($85);
+    // new = base 2000 + medium 3500 + xs 500 = 6000 ($60); delta = −$25/mo.
+    const delta = deltaLine();
+    expect(delta).not.toBeNull();
+    expect(delta!.textContent).toBe("−$25/mo compared to previous ($85)");
+    expect(delta!.className).toContain("text-[var(--system-negative-strong)]");
   });
 
   test("continuing with the seeded config is a no-op with no dispatch", async () => {

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -171,20 +171,14 @@ export function CustomPlanModal({
     machineTiers.find((t) => t.tier === machineTier) ?? null;
   const selectedStorage =
     storageTiers.find((t) => t.tier === storageTier) ?? null;
-  const selectedCredit =
-    creditChoice && creditChoice !== NO_EXTRA_CREDITS
-      ? (creditTiers.find((t) => t.tier === creditChoice) ?? null)
-      : null;
 
   const complete =
     selectedMachine != null && selectedStorage != null && creditChoice !== "";
-  const totalCents =
-    proPlan.base_price_cents +
-    (selectedMachine?.price_cents ?? 0) +
-    (selectedStorage?.price_cents ?? 0) +
-    (selectedCredit?.price_cents ?? 0);
 
-  // Recap rows + signed price delta vs. the current plan (seed).
+  // The "$X/mo" total, the delta line, and the recap rows all derive from this
+  // single computeCustomPlanDiff resolution against the FULL catalog, so they
+  // can never disagree — in particular a legacy-seed storage price stays in the
+  // header total (the modal's own `!legacy`-filtered lists would drop it).
   const diff = useMemo(
     () =>
       computeCustomPlanDiff({
@@ -295,7 +289,7 @@ export function CustomPlanModal({
               <div className="flex flex-col gap-4">
                 <div className="flex flex-col gap-1">
                   <span className="text-[24px] font-medium text-[var(--content-default)]">
-                    {formatMonthly(totalCents)}
+                    {formatMonthly(diff.totalCents)}
                   </span>
                   {diff.deltaCents != null &&
                     diff.deltaCents !== 0 &&

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -1,4 +1,5 @@
 import {
+  Circle,
   CircleCheck,
   Coins,
   Computer,
@@ -9,6 +10,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { isTierDisabled } from "@/domains/settings/components/tier-picker";
 import {
+  formatDelta,
   formatDollars,
   formatMonthly,
 } from "@/domains/settings/components/tier-pricing";
@@ -25,14 +27,11 @@ import {
 } from "@vellumai/design-library/components/dropdown";
 import { Modal } from "@vellumai/design-library/components/modal";
 
-/**
- * Sentinel option value for the "No extra credits" entry — the Dropdown is
- * generic over `T extends string`, so it cannot carry a real `null`. Mapped
- * to `null` at the `onContinue` boundary (mirrors `credit-bundle-picker`).
- */
-const NO_EXTRA_CREDITS = "__none__";
-
-type CreditChoice = CreditTierEnum | typeof NO_EXTRA_CREDITS;
+import {
+  type CreditChoice,
+  computeCustomPlanDiff,
+  NO_EXTRA_CREDITS,
+} from "./custom-plan-diff";
 
 export interface CustomPlanSelection {
   machineTier: MachineTierEnum;
@@ -185,19 +184,18 @@ export function CustomPlanModal({
     (selectedStorage?.price_cents ?? 0) +
     (selectedCredit?.price_cents ?? 0);
 
-  // The base platform fee is always charged, so it permanently leads the
-  // recap — the total above then reconciles with the visible rows even
-  // before anything is selected.
-  const selectionRows = [
-    `Pro base plan — ${formatMonthly(proPlan.base_price_cents)}`,
-    selectedMachine?.description,
-    selectedStorage ? `${selectedStorage.storage_gib} GB storage` : null,
-    creditChoice === NO_EXTRA_CREDITS
-      ? "No extra credits"
-      : selectedCredit
-        ? `${formatDollars(selectedCredit.credits_usd * 100)} of bundled credits`
-        : null,
-  ].filter((row): row is string => row != null);
+  // Recap rows + signed price delta vs. the current plan (seed).
+  const diff = useMemo(
+    () =>
+      computeCustomPlanDiff({
+        proPlan,
+        seed: initialSelection ?? null,
+        machineTier,
+        storageTier,
+        creditChoice,
+      }),
+    [proPlan, initialSelection, machineTier, storageTier, creditChoice],
+  );
 
   const handleContinue = () => {
     if (!selectedMachine || !selectedStorage || creditChoice === "" || pending) {
@@ -299,6 +297,16 @@ export function CustomPlanModal({
                   <span className="text-[24px] font-medium text-[var(--content-default)]">
                     {formatMonthly(totalCents)}
                   </span>
+                  {diff.deltaCents != null &&
+                    diff.deltaCents !== 0 &&
+                    diff.previousTotalCents != null && (
+                      <span
+                        className={`text-[12px] font-medium ${diff.deltaCents > 0 ? "text-[var(--system-positive-strong)]" : "text-[var(--system-negative-strong)]"}`}
+                      >
+                        {formatDelta(diff.deltaCents)} compared to previous (
+                        {formatDollars(diff.previousTotalCents)})
+                      </span>
+                    )}
                   <span className="text-[11px] font-medium text-[var(--content-tertiary)]">
                     Total
                   </span>
@@ -311,15 +319,28 @@ export function CustomPlanModal({
                 </span>
 
                 <ul className="flex flex-col gap-2">
-                  {selectionRows.map((row) => (
-                    <li key={row} className="flex items-center gap-2">
-                      <CircleCheck
-                        className="h-4 w-4 shrink-0 text-[var(--content-secondary)]"
-                        aria-hidden
-                      />
-                      <span className="text-[14px] font-medium leading-[18px] text-[var(--content-secondary)]">
-                        {row}
-                      </span>
+                  {diff.rows.map((row) => (
+                    <li key={row.key} className="flex flex-col gap-2">
+                      {row.previousLabel != null && (
+                        <div className="flex items-start gap-2">
+                          <Circle
+                            className="mt-0.5 h-4 w-4 shrink-0 text-[var(--content-disabled)]"
+                            aria-hidden
+                          />
+                          <span className="text-[14px] font-medium leading-[18px] text-[var(--content-disabled)] line-through">
+                            {row.previousLabel}
+                          </span>
+                        </div>
+                      )}
+                      <div className="flex items-start gap-2">
+                        <CircleCheck
+                          className={`mt-0.5 h-4 w-4 shrink-0 ${row.changed ? "text-[var(--system-positive-strong)]" : "text-[var(--content-secondary)]"}`}
+                          aria-hidden
+                        />
+                        <span className="text-[14px] font-medium leading-[18px] text-[var(--content-secondary)]">
+                          {row.label}
+                        </span>
+                      </div>
                     </li>
                   ))}
                 </ul>


### PR DESCRIPTION
## Summary
- Recap now shows a signed price-delta line (green up / red down) and per-dimension diff rows (previous struck-through + new green check) when a reconfigure differs from the current plan
- Consolidates the NO_EXTRA_CREDITS sentinel to the shared helper; content-driven modal height keeps Continue/Cancel spacing

Part of plan: custom-plan-diff-recap.md (PR 2 of 2)