### PR TITLE
Single-source the remaining messages events; nuke dead suggestion types

### DIFF
--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -10,8 +10,8 @@ import { Minimatch } from "minimatch";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent } from "../agent/loop.js";
+import type { ConfirmationStateChangedEvent } from "../api/events/confirmation-state-changed.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import type { ConfirmationStateChanged } from "../daemon/message-types/messages.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 import type { ConfirmationDetails } from "../runtime/pending-interactions.js";
 
@@ -282,8 +282,8 @@ describe("approval cascading", () => {
     const confirmMsgs = emitted.filter(
       (m) =>
         m.type === "confirmation_state_changed" &&
-        (m as unknown as ConfirmationStateChanged).state === "approved",
-    ) as unknown as ConfirmationStateChanged[];
+        (m as unknown as ConfirmationStateChangedEvent).state === "approved",
+    ) as unknown as ConfirmationStateChangedEvent[];
 
     // Only the primary should be resolved
     expect(confirmMsgs).toHaveLength(1);
@@ -316,8 +316,8 @@ describe("approval cascading", () => {
     const confirmMsgs = emitted.filter(
       (m) =>
         m.type === "confirmation_state_changed" &&
-        (m as unknown as ConfirmationStateChanged).state === "denied",
-    ) as unknown as ConfirmationStateChanged[];
+        (m as unknown as ConfirmationStateChangedEvent).state === "denied",
+    ) as unknown as ConfirmationStateChangedEvent[];
 
     // Only the primary should be denied
     expect(confirmMsgs).toHaveLength(1);
@@ -364,8 +364,8 @@ describe("approval cascading", () => {
     const confirmMsgs = emitted.filter(
       (m) =>
         m.type === "confirmation_state_changed" &&
-        (m as unknown as ConfirmationStateChanged).state === "approved",
-    ) as unknown as ConfirmationStateChanged[];
+        (m as unknown as ConfirmationStateChangedEvent).state === "approved",
+    ) as unknown as ConfirmationStateChangedEvent[];
 
     expect(confirmMsgs).toHaveLength(1);
     expect(confirmMsgs[0].requestId).toBe("req-primary");

--- a/assistant/src/api/events/confirmation-state-changed.ts
+++ b/assistant/src/api/events/confirmation-state-changed.ts
@@ -1,0 +1,37 @@
+/**
+ * `confirmation_state_changed` SSE event.
+ *
+ * Authoritative per-request confirmation state transition emitted by the
+ * daemon. Clients must use this event (not local phrase inference) to
+ * update confirmation-bubble state.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const ConfirmationStateChangedEventSchema = z.object({
+  type: z.literal("confirmation_state_changed"),
+  conversationId: z.string(),
+  requestId: z.string(),
+  state: z.enum([
+    "pending",
+    "approved",
+    "denied",
+    "timed_out",
+    "resolved_stale",
+  ]),
+  source: z.enum(["button", "inline_nl", "auto_deny", "timeout", "system"]),
+  /** requestId of the user message that triggered this transition. */
+  causedByRequestId: z.string().optional(),
+  /** Normalized user text for analytics/debug (e.g. "approve", "deny"). */
+  decisionText: z.string().optional(),
+  /** The tool_use block ID this confirmation applies to, for disambiguating parallel tool calls. */
+  toolUseId: z.string().optional(),
+});
+
+export type ConfirmationStateChangedEvent = z.infer<
+  typeof ConfirmationStateChangedEventSchema
+>;

--- a/assistant/src/api/events/conversation-inference-profile-updated.ts
+++ b/assistant/src/api/events/conversation-inference-profile-updated.ts
@@ -1,0 +1,26 @@
+/**
+ * `conversation_inference_profile_updated` SSE event.
+ *
+ * Broadcast to clients when a conversation's inference-profile override
+ * changes. `profile` is the profile name (a key in `llm.profiles`) or
+ * `null` when the override is cleared and the conversation falls back to
+ * the workspace `llm.activeProfile` resolution.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const ConversationInferenceProfileUpdatedEventSchema = z.object({
+  type: z.literal("conversation_inference_profile_updated"),
+  conversationId: z.string(),
+  profile: z.string().nullable(),
+  sessionId: z.string().nullable().optional(),
+  expiresAt: z.number().nullable().optional(),
+});
+
+export type ConversationInferenceProfileUpdatedEvent = z.infer<
+  typeof ConversationInferenceProfileUpdatedEventSchema
+>;

--- a/assistant/src/api/events/message-steered.ts
+++ b/assistant/src/api/events/message-steered.ts
@@ -1,0 +1,21 @@
+/**
+ * `message_steered` SSE event.
+ *
+ * Server → client notification that an in-flight generation was steered
+ * by a follow-up user message, so clients can reflect the mid-turn
+ * redirect. Scoped by `conversationId` and `requestId`.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const MessageSteeredEventSchema = z.object({
+  type: z.literal("message_steered"),
+  conversationId: z.string(),
+  requestId: z.string(),
+});
+
+export type MessageSteeredEvent = z.infer<typeof MessageSteeredEventSchema>;

--- a/assistant/src/api/events/tool-input-delta.ts
+++ b/assistant/src/api/events/tool-input-delta.ts
@@ -1,0 +1,30 @@
+/**
+ * `tool_input_delta` SSE event.
+ *
+ * Server → client streaming chunk of a tool call's input as it is
+ * generated, so clients can render tool arguments incrementally.
+ * `toolUseId` correlates the chunk to its tool-use block and
+ * `messageId` to the owning assistant message.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const ToolInputDeltaEventSchema = z.object({
+  type: z.literal("tool_input_delta"),
+  toolName: z.string(),
+  content: z.string(),
+  conversationId: z.string().optional(),
+  /** The tool_use block ID for client-side correlation. */
+  toolUseId: z.string().optional(),
+  /**
+   * Database ID of the assistant message that owns this tool_use block.
+   * Same semantics as `AssistantTextDeltaEvent.messageId`.
+   */
+  messageId: z.string().optional(),
+});
+
+export type ToolInputDeltaEvent = z.infer<typeof ToolInputDeltaEventSchema>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -19,9 +19,11 @@ import { CompactionCircuitClosedEventSchema } from "./events/compaction-circuit-
 import { CompactionCircuitOpenEventSchema } from "./events/compaction-circuit-open.js";
 import { ConfigChangedEventSchema } from "./events/config-changed.js";
 import { ConfirmationRequestEventSchema } from "./events/confirmation-request.js";
+import { ConfirmationStateChangedEventSchema } from "./events/confirmation-state-changed.js";
 import { ContactRequestEventSchema } from "./events/contact-request.js";
 import { ContactsChangedEventSchema } from "./events/contacts-changed.js";
 import { ConversationErrorEventSchema } from "./events/conversation-error.js";
+import { ConversationInferenceProfileUpdatedEventSchema } from "./events/conversation-inference-profile-updated.js";
 import { ConversationListInvalidatedEventSchema } from "./events/conversation-list-invalidated.js";
 import { ConversationNoticeEventSchema } from "./events/conversation-notice.js";
 import { ConversationTitleUpdatedEventSchema } from "./events/conversation-title-updated.js";
@@ -74,6 +76,7 @@ import { MessageDequeuedEventSchema } from "./events/message-dequeued.js";
 import { MessageQueuedEventSchema } from "./events/message-queued.js";
 import { MessageQueuedDeletedEventSchema } from "./events/message-queued-deleted.js";
 import { MessageRequestCompleteEventSchema } from "./events/message-request-complete.js";
+import { MessageSteeredEventSchema } from "./events/message-steered.js";
 import { NavigateSettingsEventSchema } from "./events/navigate-settings.js";
 import { NotificationConversationCreatedEventSchema } from "./events/notification-conversation-created.js";
 import { NotificationIntentEventSchema } from "./events/notification-intent.js";
@@ -98,6 +101,7 @@ import { SubagentEventEventSchema } from "./events/subagent-event.js";
 import { SubagentSpawnedEventSchema } from "./events/subagent-spawned.js";
 import { SubagentStatusChangedEventSchema } from "./events/subagent-status-changed.js";
 import { SyncChangedEventSchema } from "./events/sync-changed.js";
+import { ToolInputDeltaEventSchema } from "./events/tool-input-delta.js";
 import { ToolOutputChunkEventSchema } from "./events/tool-output-chunk.js";
 import { ToolResultEventSchema } from "./events/tool-result.js";
 import { ToolUsePreviewStartEventSchema } from "./events/tool-use-preview-start.js";
@@ -231,6 +235,10 @@ export {
   ScopeOptionSchema,
 } from "./events/confirmation-request.js";
 export {
+  type ConfirmationStateChangedEvent,
+  ConfirmationStateChangedEventSchema,
+} from "./events/confirmation-state-changed.js";
+export {
   type ContactRequestEvent,
   ContactRequestEventSchema,
 } from "./events/contact-request.js";
@@ -244,6 +252,10 @@ export {
   type ConversationErrorEvent,
   ConversationErrorEventSchema,
 } from "./events/conversation-error.js";
+export {
+  type ConversationInferenceProfileUpdatedEvent,
+  ConversationInferenceProfileUpdatedEventSchema,
+} from "./events/conversation-inference-profile-updated.js";
 export {
   type ConversationListInvalidatedEvent,
   ConversationListInvalidatedEventSchema,
@@ -403,6 +415,10 @@ export {
   MessageRequestCompleteEventSchema,
 } from "./events/message-request-complete.js";
 export {
+  type MessageSteeredEvent,
+  MessageSteeredEventSchema,
+} from "./events/message-steered.js";
+export {
   type NavigateSettingsEvent,
   NavigateSettingsEventSchema,
 } from "./events/navigate-settings.js";
@@ -493,6 +509,10 @@ export {
   type SyncChangedEvent,
   SyncChangedEventSchema,
 } from "./events/sync-changed.js";
+export {
+  type ToolInputDeltaEvent,
+  ToolInputDeltaEventSchema,
+} from "./events/tool-input-delta.js";
 export {
   type ToolOutputChunkEvent,
   ToolOutputChunkEventSchema,
@@ -809,9 +829,11 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   CompactionCircuitOpenEventSchema,
   ConfigChangedEventSchema,
   ConfirmationRequestEventSchema,
+  ConfirmationStateChangedEventSchema,
   ContactRequestEventSchema,
   ContactsChangedEventSchema,
   ConversationErrorEventSchema,
+  ConversationInferenceProfileUpdatedEventSchema,
   ConversationListInvalidatedEventSchema,
   ConversationNoticeEventSchema,
   ConversationTitleUpdatedEventSchema,
@@ -850,6 +872,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   MessageQueuedEventSchema,
   MessageQueuedDeletedEventSchema,
   MessageRequestCompleteEventSchema,
+  MessageSteeredEventSchema,
   NavigateSettingsEventSchema,
   NotificationConversationCreatedEventSchema,
   NotificationIntentEventSchema,
@@ -872,6 +895,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   SubagentSpawnedEventSchema,
   SubagentStatusChangedEventSchema,
   SyncChangedEventSchema,
+  ToolInputDeltaEventSchema,
   ToolOutputChunkEventSchema,
   ToolResultEventSchema,
   ToolUsePreviewStartEventSchema,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -18,6 +18,7 @@
 import type { AgentLoopConfig } from "../agent/loop.js";
 import { AgentLoop } from "../agent/loop.js";
 import type { AssistantActivityStateEvent } from "../api/events/assistant-activity-state.js";
+import type { ConfirmationStateChangedEvent } from "../api/events/confirmation-state-changed.js";
 import { decideGuardianRequest } from "../channels/gateway-guardian-requests.js";
 import type {
   ChannelId,
@@ -170,7 +171,6 @@ import type {
 import { filterMessagesForUntrustedActor } from "./message-provenance.js";
 import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 import { isHostProxyTransport } from "./message-types/conversations.js";
-import type { ConfirmationStateChanged } from "./message-types/messages.js";
 import { conversationMetadataSyncTag } from "./message-types/sync.js";
 import {
   resolveSummarizeBoundary,
@@ -1750,7 +1750,7 @@ export class Conversation {
       selectedScope?: string;
       decisionContext?: string;
       emissionContext?: {
-        source?: ConfirmationStateChanged["source"];
+        source?: ConfirmationStateChangedEvent["source"];
         causedByRequestId?: string;
         decisionText?: string;
       };
@@ -1864,7 +1864,7 @@ export class Conversation {
   // ── Server-authoritative state signals ─────────────────────────────
 
   emitConfirmationStateChanged(
-    params: Omit<ConfirmationStateChanged, "type">,
+    params: Omit<ConfirmationStateChangedEvent, "type">,
   ): void {
     const msg: ServerMessage = {
       type: "confirmation_state_changed",

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -5,6 +5,8 @@ import type { AssistantTextDeltaEvent } from "../../api/events/assistant-text-de
 import type { AssistantThinkingDeltaEvent } from "../../api/events/assistant-thinking-delta.js";
 import type { AssistantTurnStartEvent } from "../../api/events/assistant-turn-start.js";
 import type { ConfirmationRequestEvent } from "../../api/events/confirmation-request.js";
+import type { ConfirmationStateChangedEvent } from "../../api/events/confirmation-state-changed.js";
+import type { ConversationInferenceProfileUpdatedEvent } from "../../api/events/conversation-inference-profile-updated.js";
 import type { ErrorEvent } from "../../api/events/error.js";
 import type { InteractionResolvedEvent } from "../../api/events/interaction-resolved.js";
 import type { MessageCompleteEvent } from "../../api/events/message-complete.js";
@@ -12,8 +14,10 @@ import type { MessageDequeuedEvent } from "../../api/events/message-dequeued.js"
 import type { MessageQueuedEvent } from "../../api/events/message-queued.js";
 import type { MessageQueuedDeletedEvent } from "../../api/events/message-queued-deleted.js";
 import type { MessageRequestCompleteEvent } from "../../api/events/message-request-complete.js";
+import type { MessageSteeredEvent } from "../../api/events/message-steered.js";
 import type { QuestionRequestEvent } from "../../api/events/question-request.js";
 import type { SecretRequestEvent } from "../../api/events/secret-request.js";
+import type { ToolInputDeltaEvent } from "../../api/events/tool-input-delta.js";
 import type { ToolOutputChunkEvent } from "../../api/events/tool-output-chunk.js";
 import type { ToolResultEvent } from "../../api/events/tool-result.js";
 import type { ToolUsePreviewStartEvent } from "../../api/events/tool-use-preview-start.js";
@@ -64,80 +68,12 @@ export interface SecretResponse {
   delivery?: "store" | "transient_send";
 }
 
-export interface SuggestionRequest {
-  type: "suggestion_request";
-  conversationId: string;
-  requestId: string;
-}
-
-// === Server → Client ===
-
-export interface ToolInputDelta {
-  type: "tool_input_delta";
-  toolName: string;
-  content: string;
-  conversationId?: string;
-  /** The tool_use block ID for client-side correlation. */
-  toolUseId?: string;
-  /** Database ID of the assistant message that owns this tool_use block.
-   *  Same semantics as `AssistantTextDeltaEvent.messageId`. */
-  messageId?: string;
-}
-
-export interface MessageSteered {
-  type: "message_steered";
-  conversationId: string;
-  requestId: string;
-}
-
-export interface SuggestionResponse {
-  type: "suggestion_response";
-  requestId: string;
-  suggestion: string | null;
-  source: "llm" | "none";
-}
-
-/**
- * Authoritative per-request confirmation state transition emitted by the daemon.
- *
- * The client must use this event (not local phrase inference) to update
- * confirmation bubble state.
- */
-export interface ConfirmationStateChanged {
-  type: "confirmation_state_changed";
-  conversationId: string;
-  requestId: string;
-  state: "pending" | "approved" | "denied" | "timed_out" | "resolved_stale";
-  source: "button" | "inline_nl" | "auto_deny" | "timeout" | "system";
-  /** requestId of the user message that triggered this transition. */
-  causedByRequestId?: string;
-  /** Normalized user text for analytics/debug (e.g. "approve", "deny"). */
-  decisionText?: string;
-  /** The tool_use block ID this confirmation applies to, for disambiguating parallel tool calls. */
-  toolUseId?: string;
-}
-
-/**
- * Broadcast to clients when a conversation's inference-profile override
- * changes. `profile` is the profile name (a key in `llm.profiles`) or
- * `null` when the override is cleared and the conversation falls back to
- * the workspace `llm.activeProfile` resolution.
- */
-export interface ConversationInferenceProfileUpdated {
-  type: "conversation_inference_profile_updated";
-  conversationId: string;
-  profile: string | null;
-  sessionId?: string | null;
-  expiresAt?: number | null;
-}
-
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _MessagesClientMessages =
   | UserMessage
   | ConfirmationResponse
-  | SecretResponse
-  | SuggestionRequest;
+  | SecretResponse;
 
 export type _MessagesServerMessages =
   | UserMessageEchoEvent
@@ -147,7 +83,7 @@ export type _MessagesServerMessages =
   | ToolUseStartEvent
   | ToolUsePreviewStartEvent
   | ToolOutputChunkEvent
-  | ToolInputDelta
+  | ToolInputDeltaEvent
   | ToolResultEvent
   | ConfirmationRequestEvent
   | SecretRequestEvent
@@ -158,9 +94,8 @@ export type _MessagesServerMessages =
   | MessageDequeuedEvent
   | MessageRequestCompleteEvent
   | MessageQueuedDeletedEvent
-  | MessageSteered
-  | SuggestionResponse
-  | ConfirmationStateChanged
+  | MessageSteeredEvent
+  | ConfirmationStateChangedEvent
   | AssistantActivityStateEvent
-  | ConversationInferenceProfileUpdated
+  | ConversationInferenceProfileUpdatedEvent
   | InteractionResolvedEvent;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -470,6 +470,14 @@ export function useStreamEventHandler(
         // (e.g. user-prompt-submit). No web UI renders them yet.
         case "hook_event":
           break;
+        // Conversation-scoped signals the web chat view does not render:
+        // streaming tool-input deltas, steer acks, authoritative confirmation
+        // state transitions, and inference-profile override changes.
+        case "tool_input_delta":
+        case "message_steered":
+        case "confirmation_state_changed":
+        case "conversation_inference_profile_updated":
+          break;
         // Host-proxy instructions targeting the desktop client / chrome
         // extension. The web chat handler is a no-op — host-proxy frames are
         // delivered to their capability holder by the hub, not through the


### PR DESCRIPTION
## Why

Continues the event-type unification effort. The `messages` domain was the closest to done (19/24 server events already migrated) — this closes the gap.

## What

**Migrated (live) → new `api/events` schemas, registered in `AssistantEventSchema`:**
- `tool_input_delta` — streaming tool-call input chunks (from `conversation-agent-loop-handlers`)
- `message_steered` — mid-turn steer ack (from `handlers/conversations`)
- `confirmation_state_changed` — authoritative confirmation state transition (from `conversation.ts`)
- `conversation_inference_profile_updated` — inference-profile override broadcast (from `resource-sync-events`)

`_MessagesServerMessages` now composes only api-inferred `*Event` types. `ConfirmationStateChanged` → `ConfirmationStateChangedEvent` at its consumers (`conversation.ts`, one test).

**Removed (dead — no producer, consumer, or type reference):**
- `suggestion_request` (client) / `suggestion_response` (server) — the suggestion wire messages have no emitter or dispatcher anywhere. `suggestion_request` drops out of `_MessagesClientMessages`.

## Web

The four events are conversation-scoped (all carry `conversationId`, `tool_input_delta` optionally), so they get no-op cases in the chat handler's exhaustive switch — the web chat view doesn't render them today, so this preserves current behavior while keeping the switch exhaustive.

## Safety

No wire change for the live events (schemas transcribed 1:1). Repo-wide grep confirms zero references to the removed suggestion types. Clean `typecheck:fast` + web `tsc` (fresh `openapi-ts`), eslint, prettier, `generate:openapi --check` (unchanged), api-events + SSE-parity + approval-cascade + confirmation-signals suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_