### PR TITLE
refactor(billing): consolidate shared plan baselines + remove dead code

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -18,7 +18,7 @@ export interface PlanSpec {
  * The machine a package with no `machine_size` runs on — the small baseline
  * shared by Free and machine-less Pro packages (e.g. Mighty).
  */
-export const STANDARD_MACHINE_LABEL = "Small";
+const STANDARD_MACHINE_LABEL = "Small";
 
 /** Human machine-size label for a package (or the standard small machine). */
 export function machineLabel(pkg: ProPackage | null): string {

--- a/clients/web/src/domains/settings/billing/plan-tier-meta.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tier-meta.tsx
@@ -4,14 +4,6 @@ import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-component
 /** Pro package tier keys, keyed by `ProPackage.key` ("free" is the base plan). */
 export type PlanTierKey = "free" | "mighty" | "super" | "ultra";
 
-/** Accent color per Pro package tier, keyed by `ProPackage.key` ("free" for the base plan). */
-export const TIER_ACCENT: Record<string, string> = {
-    free: "#E9C91A",
-    mighty: "#4C9B50",
-    super: "#0E9B8B",
-    ultra: "#EF4300",
-};
-
 /** Vellum creature traits per plan tier, matching the pricing-page creatures. */
 export const TIER_TRAITS: Record<
     string,

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -11,7 +11,11 @@ import {
   type SwitchRelation,
   tierRelation,
 } from "@/domains/settings/billing/package-types";
-import { FREE_STORAGE_GIB } from "@/domains/settings/billing/plan-tier-meta";
+import { machineLabel } from "@/domains/settings/billing/plan-spec";
+import {
+  FREE_CREDITS_USD,
+  FREE_STORAGE_GIB,
+} from "@/domains/settings/billing/plan-tier-meta";
 import {
   CustomPlanModal,
   type CustomPlanSeed,
@@ -41,7 +45,6 @@ import {
   organizationsBillingSubscriptionUpgradeCreateMutation,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type {
-  MachineSizeEnum,
   ProPlan,
   SubscriptionUpgradeRequestRequest,
 } from "@/generated/api/types.gen";
@@ -52,7 +55,6 @@ import {
 } from "@/hooks/use-platform-gate";
 import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
-import { SIZE_LABEL } from "@/lib/billing/machine-sizes";
 import { openUrl } from "@/runtime/browser";
 import { isElectron } from "@/runtime/is-electron";
 import { routes } from "@/utils/routes";
@@ -85,14 +87,12 @@ function priceLabelFromCents(cents: number): string {
 
 /** Machine label for a package's feature row, e.g. "Medium Computer". */
 function machineComputerLabel(pkg: ProPackage): string {
-  const size = pkg.machine_size;
-  const label = size ? (SIZE_LABEL[size as MachineSizeEnum] ?? size) : "Small";
-  return `${label} Computer`;
+  return `${machineLabel(pkg)} Computer`;
 }
 
 /** Catalog-derived feature rows, plus any static extras from the copy. */
 function packageFeatures(pkg: ProPackage, extra: readonly string[]): string[] {
-  const credits = pkg.credits_usd ?? 0;
+  const credits = pkg.credits_usd ?? FREE_CREDITS_USD;
   return [
     machineComputerLabel(pkg),
     `${pkg.storage_gib} GB Storage`,


### PR DESCRIPTION
## Summary
- Delegate plans-page machineComputerLabel to the shared machineLabel (no output change)
- Use FREE_CREDITS_USD for the plans-page free-credits baseline
- Demote STANDARD_MACHINE_LABEL to module-local
- Remove orphaned TIER_ACCENT export

Self-review remediation for plan: billing-plan-section-cards.md