### PR TITLE
feat(web): first message offers three clickable scope options (work / personal / both) (JARVIS-1343)

### DIFF
--- a/clients/web/.cross-domain-allowlist.json
+++ b/clients/web/.cross-domain-allowlist.json
@@ -14,6 +14,12 @@
   "src/domains/chat/in-chat-onboarding/tour-telemetry.ts": [
     "onboarding"
   ],
+  "src/domains/chat/surface-actions.test.ts": [
+    "onboarding"
+  ],
+  "src/domains/chat/surface-actions.ts": [
+    "onboarding"
+  ],
   "src/domains/home/home-page.tsx": [
     "settings"
   ],

--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -158,8 +158,7 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   const {
     didOnboarding,
-    onboardingTasksEmpty,
-    onboardingKickoffHidden,
+    onboardingChoiceEligible,
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,
@@ -555,8 +554,7 @@ export function ActiveChatView() {
     uiContextRef,
 
     // Onboarding
-    onboardingTasksEmpty,
-    onboardingKickoffHidden,
+    onboardingChoiceEligible,
     didOnboarding,
     onboardingConversationId,
   };

--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -159,6 +159,7 @@ export function ActiveChatView() {
   const {
     didOnboarding,
     onboardingTasksEmpty,
+    onboardingKickoffHidden,
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,
@@ -555,6 +556,7 @@ export function ActiveChatView() {
 
     // Onboarding
     onboardingTasksEmpty,
+    onboardingKickoffHidden,
     didOnboarding,
     onboardingConversationId,
   };

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -164,6 +164,7 @@ export interface ChatMainPanelProps {
 
   // Onboarding (local state in ActiveChatView)
   onboardingTasksEmpty: boolean;
+  onboardingKickoffHidden: boolean;
   didOnboarding: boolean;
   onboardingConversationId: string | null;
 }
@@ -235,6 +236,7 @@ export function ChatMainPanel({
   transcriptRef,
   uiContextRef,
   onboardingTasksEmpty,
+  onboardingKickoffHidden,
   didOnboarding,
   onboardingConversationId,
 }: ChatMainPanelProps) {
@@ -466,6 +468,7 @@ export function ChatMainPanel({
     didOnboarding,
     messages,
     onboardingTasksEmpty,
+    onboardingKickoffHidden,
     activeConversationId,
     onboardingConversationId,
     sendMessage,

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -163,8 +163,7 @@ export interface ChatMainPanelProps {
   uiContextRef: MutableRefObject<UIContext | null>;
 
   // Onboarding (local state in ActiveChatView)
-  onboardingTasksEmpty: boolean;
-  onboardingKickoffHidden: boolean;
+  onboardingChoiceEligible: boolean;
   didOnboarding: boolean;
   onboardingConversationId: string | null;
 }
@@ -235,8 +234,7 @@ export function ChatMainPanel({
   transcriptItemsRef,
   transcriptRef,
   uiContextRef,
-  onboardingTasksEmpty,
-  onboardingKickoffHidden,
+  onboardingChoiceEligible,
   didOnboarding,
   onboardingConversationId,
 }: ChatMainPanelProps) {
@@ -467,8 +465,7 @@ export function ChatMainPanel({
     isNative,
     didOnboarding,
     messages,
-    onboardingTasksEmpty,
-    onboardingKickoffHidden,
+    onboardingChoiceEligible,
     activeConversationId,
     onboardingConversationId,
     sendMessage,

--- a/clients/web/src/domains/chat/hooks/use-onboarding-choice.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-choice.test.tsx
@@ -19,8 +19,7 @@ function baseOptions() {
     isNative: true,
     didOnboarding: true,
     messages: greeting,
-    onboardingTasksEmpty: true,
-    onboardingKickoffHidden: false,
+    onboardingChoiceEligible: true,
     activeConversationId: CONVERSATION_ID,
     onboardingConversationId: CONVERSATION_ID,
     sendMessage: mock(() => {}),
@@ -33,12 +32,9 @@ describe("useOnboardingChoice", () => {
     expect(result.current.showOnboardingChoice).toBe(true);
   });
 
-  test("suppresses the card for hidden-kickoff handoffs (research onboarding)", () => {
-    // The research-onboarding "Let's chat" handoff auto-sends a hidden kickoff
-    // whose scripted greeting carries its own choice surface; the legacy card
-    // must not stack a second chooser on top of it.
+  test("suppresses the card for ineligible handoffs (tasks selected or hidden kickoff)", () => {
     const { result } = renderHook(() =>
-      useOnboardingChoice({ ...baseOptions(), onboardingKickoffHidden: true }),
+      useOnboardingChoice({ ...baseOptions(), onboardingChoiceEligible: false }),
     );
     expect(result.current.showOnboardingChoice).toBe(false);
   });

--- a/clients/web/src/domains/chat/hooks/use-onboarding-choice.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-choice.test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+import { useOnboardingChoice } from "./use-onboarding-choice";
+
+afterEach(() => {
+  cleanup();
+});
+
+const CONVERSATION_ID = "conv-1";
+
+const greeting: DisplayMessage[] = [{ id: "m1", role: "assistant" }];
+
+/** All conditions satisfied for the card to show; tests override per-case. */
+function baseOptions() {
+  return {
+    isNative: true,
+    didOnboarding: true,
+    messages: greeting,
+    onboardingTasksEmpty: true,
+    onboardingKickoffHidden: false,
+    activeConversationId: CONVERSATION_ID,
+    onboardingConversationId: CONVERSATION_ID,
+    sendMessage: mock(() => {}),
+  };
+}
+
+describe("useOnboardingChoice", () => {
+  test("shows the card when all conditions are met", () => {
+    const { result } = renderHook(() => useOnboardingChoice(baseOptions()));
+    expect(result.current.showOnboardingChoice).toBe(true);
+  });
+
+  test("suppresses the card for hidden-kickoff handoffs (research onboarding)", () => {
+    // The research-onboarding "Let's chat" handoff auto-sends a hidden kickoff
+    // whose scripted greeting carries its own choice surface; the legacy card
+    // must not stack a second chooser on top of it.
+    const { result } = renderHook(() =>
+      useOnboardingChoice({ ...baseOptions(), onboardingKickoffHidden: true }),
+    );
+    expect(result.current.showOnboardingChoice).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-onboarding-choice.ts
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-choice.ts
@@ -3,8 +3,9 @@
  *
  * Phase transitions: `pending` → `visible` → `dismissed`.
  * The card becomes visible when all conditions are met (native, did onboarding,
- * greeting arrived, no tasks selected during prechat). Once dismissed it never
- * reappears.
+ * greeting arrived, no tasks selected during prechat, and the handoff did not
+ * auto-send a hidden kickoff that scripts its own first-reply UI). Once
+ * dismissed it never reappears.
  */
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
@@ -17,6 +18,13 @@ interface UseOnboardingChoiceOptions {
   didOnboarding: boolean;
   messages: DisplayMessage[];
   onboardingTasksEmpty: boolean;
+  /**
+   * True when the onboarding handoff auto-sent a hidden kickoff message
+   * (`initialMessageHidden` on the pre-chat context). Those flows (research
+   * onboarding's "Let's chat") script the assistant's first reply — including
+   * its own choice surface — so the legacy card must never stack on top.
+   */
+  onboardingKickoffHidden: boolean;
   activeConversationId: string | null;
   onboardingConversationId: string | null;
   sendMessage: (content: string) => void;
@@ -34,6 +42,7 @@ export function useOnboardingChoice({
   didOnboarding,
   messages,
   onboardingTasksEmpty,
+  onboardingKickoffHidden,
   activeConversationId,
   onboardingConversationId,
   sendMessage,
@@ -70,6 +79,7 @@ export function useOnboardingChoice({
       phase === "pending" &&
       isNative &&
       didOnboarding &&
+      !onboardingKickoffHidden &&
       greetingSeenRef.current &&
       onboardingTasksEmpty &&
       activeConversationId === onboardingConversationId
@@ -79,7 +89,7 @@ export function useOnboardingChoice({
     }
     // `messages` is not read in the body; listed so this effect re-fires
     // when a new message arrives and greetingSeenRef may have just latched.
-  }, [phase, isNative, didOnboarding, messages, onboardingTasksEmpty, activeConversationId, onboardingConversationId]);
+  }, [phase, isNative, didOnboarding, messages, onboardingTasksEmpty, onboardingKickoffHidden, activeConversationId, onboardingConversationId]);
 
   // Dismiss if the user switches to a different conversation.
   useEffect(() => {

--- a/clients/web/src/domains/chat/hooks/use-onboarding-choice.ts
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-choice.ts
@@ -3,9 +3,8 @@
  *
  * Phase transitions: `pending` → `visible` → `dismissed`.
  * The card becomes visible when all conditions are met (native, did onboarding,
- * greeting arrived, no tasks selected during prechat, and the handoff did not
- * auto-send a hidden kickoff that scripts its own first-reply UI). Once
- * dismissed it never reappears.
+ * greeting arrived, and the handoff is choice-eligible — see
+ * `onboardingChoiceEligible` below). Once dismissed it never reappears.
  */
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
@@ -17,14 +16,17 @@ interface UseOnboardingChoiceOptions {
   isNative: boolean;
   didOnboarding: boolean;
   messages: DisplayMessage[];
-  onboardingTasksEmpty: boolean;
   /**
-   * True when the onboarding handoff auto-sent a hidden kickoff message
-   * (`initialMessageHidden` on the pre-chat context). Those flows (research
-   * onboarding's "Let's chat") script the assistant's first reply — including
-   * its own choice surface — so the legacy card must never stack on top.
+   * True when the pre-chat handoff qualifies for the choice card: the user
+   * selected no tasks during prechat (so the card's task chooser has work to
+   * do) AND the handoff did not auto-send a hidden kickoff message
+   * (`initialMessageHidden` on the pre-chat context). Hidden-kickoff flows
+   * (research onboarding's "Let's chat") script the assistant's first reply —
+   * including its own choice surface — so the legacy card must never stack on
+   * top. Derived from the validated pre-chat context by
+   * `useOnboardingOrchestrator`.
    */
-  onboardingKickoffHidden: boolean;
+  onboardingChoiceEligible: boolean;
   activeConversationId: string | null;
   onboardingConversationId: string | null;
   sendMessage: (content: string) => void;
@@ -41,8 +43,7 @@ export function useOnboardingChoice({
   isNative,
   didOnboarding,
   messages,
-  onboardingTasksEmpty,
-  onboardingKickoffHidden,
+  onboardingChoiceEligible,
   activeConversationId,
   onboardingConversationId,
   sendMessage,
@@ -79,9 +80,8 @@ export function useOnboardingChoice({
       phase === "pending" &&
       isNative &&
       didOnboarding &&
-      !onboardingKickoffHidden &&
+      onboardingChoiceEligible &&
       greetingSeenRef.current &&
-      onboardingTasksEmpty &&
       activeConversationId === onboardingConversationId
     ) {
       visibleConversationIdRef.current = activeConversationId;
@@ -89,7 +89,7 @@ export function useOnboardingChoice({
     }
     // `messages` is not read in the body; listed so this effect re-fires
     // when a new message arrives and greetingSeenRef may have just latched.
-  }, [phase, isNative, didOnboarding, messages, onboardingTasksEmpty, onboardingKickoffHidden, activeConversationId, onboardingConversationId]);
+  }, [phase, isNative, didOnboarding, messages, onboardingChoiceEligible, activeConversationId, onboardingConversationId]);
 
   // Dismiss if the user switches to a different conversation.
   useEffect(() => {

--- a/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
@@ -44,6 +44,13 @@ export interface UseOnboardingOrchestratorResult {
   didOnboarding: boolean;
   /** Whether the user skipped task selection during prechat. */
   onboardingTasksEmpty: boolean;
+  /**
+   * Whether the onboarding handoff auto-sends a hidden kickoff message
+   * (`initialMessageHidden` on the pre-chat context). Hidden-kickoff flows
+   * (research onboarding's "Let's chat") script their own first-reply UI, so
+   * the in-chat onboarding choice card must not stack on top of it.
+   */
+  onboardingKickoffHidden: boolean;
   /** The draft conversation created for the onboarding flow. */
   onboardingConversationId: string | null;
   /** Shared with `useSendMessage` — pre-chat context for the first send. */
@@ -62,6 +69,7 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
   const onboardingDraftConversationIdRef = useRef<string | null>(null);
   const [didOnboarding, setDidOnboarding] = useState(false);
   const [onboardingTasksEmpty, setOnboardingTasksEmpty] = useState(false);
+  const [onboardingKickoffHidden, setOnboardingKickoffHidden] = useState(false);
   const [onboardingConversationId, setOnboardingConversationId] = useState<string | null>(null);
 
   // Consume the `?onboarding=1` signal left by `/onboarding/hatching` when
@@ -107,9 +115,15 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
     try {
       const raw = globalThis.sessionStorage?.getItem("onboarding.prechat.pendingContext");
       if (!raw) return;
-      const ctx = JSON.parse(raw) as { tasks?: string[] };
+      const ctx = JSON.parse(raw) as {
+        tasks?: string[];
+        initialMessageHidden?: boolean;
+      };
       if (Array.isArray(ctx.tasks) && ctx.tasks.length === 0) {
         setOnboardingTasksEmpty(true);
+      }
+      if (ctx.initialMessageHidden === true) {
+        setOnboardingKickoffHidden(true);
       }
     } catch {
       // Storage or parse failure — ignore.
@@ -119,6 +133,7 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
   return {
     didOnboarding,
     onboardingTasksEmpty,
+    onboardingKickoffHidden,
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,

--- a/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
+++ b/clients/web/src/domains/chat/hooks/use-onboarding-orchestrator.ts
@@ -5,9 +5,9 @@
  * Owns:
  * - `pendingOnboardingContextRef` — pre-chat context for the first send
  * - `onboardingDraftConversationIdRef` — draft conversation created during onboarding
- * - `didOnboarding` / `onboardingConversationId` / `onboardingTasksEmpty` — lifecycle flags
+ * - `didOnboarding` / `onboardingConversationId` / `onboardingChoiceEligible` — lifecycle flags
  * - `?onboarding=1` search-param signal consumption effect
- * - `sessionStorage` tasks-empty derivation
+ * - choice-card eligibility derivation from the pending pre-chat context
  *
  * Does NOT own:
  * - Auto-send of the initial message (depends on `sendMessage` from `useSendMessage`,
@@ -27,7 +27,10 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
-import { type PreChatOnboardingContext } from "@/domains/onboarding/prechat";
+import {
+  peekPendingPreChatContext,
+  type PreChatOnboardingContext,
+} from "@/domains/onboarding/prechat";
 import {
   isInChatTourOn,
   readInChatTourVariant,
@@ -42,15 +45,12 @@ import { routes } from "@/utils/routes";
 export interface UseOnboardingOrchestratorResult {
   /** Whether the user arrived via the onboarding flow. */
   didOnboarding: boolean;
-  /** Whether the user skipped task selection during prechat. */
-  onboardingTasksEmpty: boolean;
   /**
-   * Whether the onboarding handoff auto-sends a hidden kickoff message
-   * (`initialMessageHidden` on the pre-chat context). Hidden-kickoff flows
-   * (research onboarding's "Let's chat") script their own first-reply UI, so
-   * the in-chat onboarding choice card must not stack on top of it.
+   * Whether this onboarding handoff is eligible for the in-chat onboarding
+   * choice card. See the option doc on `useOnboardingChoice` for the
+   * rationale behind each condition.
    */
-  onboardingKickoffHidden: boolean;
+  onboardingChoiceEligible: boolean;
   /** The draft conversation created for the onboarding flow. */
   onboardingConversationId: string | null;
   /** Shared with `useSendMessage` — pre-chat context for the first send. */
@@ -68,8 +68,7 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
   const pendingOnboardingContextRef = useRef<PreChatOnboardingContext | null>(null);
   const onboardingDraftConversationIdRef = useRef<string | null>(null);
   const [didOnboarding, setDidOnboarding] = useState(false);
-  const [onboardingTasksEmpty, setOnboardingTasksEmpty] = useState(false);
-  const [onboardingKickoffHidden, setOnboardingKickoffHidden] = useState(false);
+  const [onboardingChoiceEligible, setOnboardingChoiceEligible] = useState(false);
   const [onboardingConversationId, setOnboardingConversationId] = useState<string | null>(null);
 
   // Consume the `?onboarding=1` signal left by `/onboarding/hatching` when
@@ -108,32 +107,21 @@ export function useOnboardingOrchestrator(): UseOnboardingOrchestratorResult {
     void navigate(routes.conversation(draftId), { replace: true });
   }, [searchParams, navigate, isMobile, isNative]);
 
-  // Derive onboardingTasksEmpty from the pending context in sessionStorage.
-  // Runs once on mount — if initial message key is present, this is an
-  // onboarding mount, so peek at the context for the tasks-empty flag.
+  // Derive choice-card eligibility from the pending pre-chat context. Runs
+  // once on mount, before the first send consumes the context. Reads through
+  // the validated peek so this gate can never disagree with the auto-send
+  // path in ActiveChatView: a malformed/absent context yields `null` there
+  // too, which fails open to the legacy (card-less) behavior.
   useEffect(() => {
-    try {
-      const raw = globalThis.sessionStorage?.getItem("onboarding.prechat.pendingContext");
-      if (!raw) return;
-      const ctx = JSON.parse(raw) as {
-        tasks?: string[];
-        initialMessageHidden?: boolean;
-      };
-      if (Array.isArray(ctx.tasks) && ctx.tasks.length === 0) {
-        setOnboardingTasksEmpty(true);
-      }
-      if (ctx.initialMessageHidden === true) {
-        setOnboardingKickoffHidden(true);
-      }
-    } catch {
-      // Storage or parse failure — ignore.
+    const ctx = peekPendingPreChatContext();
+    if (ctx !== null && ctx.tasks.length === 0 && ctx.initialMessageHidden !== true) {
+      setOnboardingChoiceEligible(true);
     }
   }, []);
 
   return {
     didOnboarding,
-    onboardingTasksEmpty,
-    onboardingKickoffHidden,
+    onboardingChoiceEligible,
     onboardingConversationId,
     pendingOnboardingContextRef,
     onboardingDraftConversationIdRef,

--- a/clients/web/src/domains/chat/surface-actions.test.ts
+++ b/clients/web/src/domains/chat/surface-actions.test.ts
@@ -31,11 +31,16 @@ mock.module("@/domains/chat/api/surfaces", () => ({
 }));
 
 const emittedScopes: string[] = [];
+const emittedUserIds: Array<string | null | undefined> = [];
 let emitThrows = false;
 
 mock.module("@/domains/onboarding/funnel-events", () => ({
-  emitFirstMessageScopeSelected: (scope: string): void => {
+  emitFirstMessageScopeSelected: (
+    scope: string,
+    options?: { userId?: string | null },
+  ): void => {
     emittedScopes.push(scope);
+    emittedUserIds.push(options?.userId);
     if (emitThrows) throw new Error("telemetry down");
   },
 }));
@@ -49,13 +54,16 @@ const { useChatSessionStore } = await import(
 );
 const { useStreamStore } = await import("@/domains/chat/stream-store");
 const { useTurnStore } = await import("@/domains/chat/turn-store");
+const { useAuthStore } = await import("@/stores/auth-store");
 
 beforeEach(() => {
   submitResult = { ok: true };
   submitThrows = false;
   submitCalls.length = 0;
   emittedScopes.length = 0;
+  emittedUserIds.length = 0;
   emitThrows = false;
+  useAuthStore.setState({ user: null });
   useStreamStore.getState().setStreamContext({
     assistantId: "ast-1",
     conversationId: "conv-1",
@@ -65,13 +73,35 @@ beforeEach(() => {
 });
 
 describe("handleSurfaceAction — first-run scope funnel event", () => {
-  it("emits exactly one event with the chosen scope", async () => {
+  it("emits exactly one event with the chosen scope and the auth user id", async () => {
+    useAuthStore.setState({
+      user: {
+        kind: "platform",
+        id: "user-42",
+        username: null,
+        email: null,
+        isStaff: false,
+        firstName: "",
+        lastName: "",
+      },
+    });
+
     await handleSurfaceAction("srf-1", "scope_work", {
       [FIRST_RUN_SCOPE_DATA_KEY]: "work",
     });
 
     expect(emittedScopes).toEqual(["work"]);
+    expect(emittedUserIds).toEqual(["user-42"]);
     expect(useChatSessionStore.getState().error).toBeNull();
+  });
+
+  it("still emits, with a null user id, when no user is signed in", async () => {
+    await handleSurfaceAction("srf-1", "scope_work", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "work",
+    });
+
+    expect(emittedScopes).toEqual(["work"]);
+    expect(emittedUserIds).toEqual([null]);
   });
 
   it("emits nothing for surface actions without the scope marker", async () => {

--- a/clients/web/src/domains/chat/surface-actions.test.ts
+++ b/clients/web/src/domains/chat/surface-actions.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Funnel telemetry for first-run scope option clicks.
+ *
+ * The "Let's chat" kickoff greeting renders a choice surface whose options
+ * carry `data: { firstRunScope: ... }` (see `first-run-scope.ts`). Clicking
+ * one must emit exactly one funnel event with the chosen scope — and only
+ * then: other surface actions emit nothing, failed submits emit nothing, and
+ * a throwing emitter must never break the surface-action path (telemetry is
+ * strictly fire-and-forget).
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import type { SurfaceActionResult } from "@/domains/chat/api/surfaces";
+
+let submitResult: SurfaceActionResult = { ok: true };
+let submitThrows = false;
+const submitCalls: Array<Record<string, unknown> | undefined> = [];
+
+mock.module("@/domains/chat/api/surfaces", () => ({
+  submitSurfaceAction: async (
+    _assistantId: string,
+    _surfaceId: string,
+    _actionId: string,
+    data?: Record<string, unknown>,
+  ): Promise<SurfaceActionResult> => {
+    submitCalls.push(data);
+    if (submitThrows) throw new Error("network down");
+    return submitResult;
+  },
+}));
+
+const emittedScopes: string[] = [];
+let emitThrows = false;
+
+mock.module("@/domains/onboarding/funnel-events", () => ({
+  emitFirstMessageScopeSelected: (scope: string): void => {
+    emittedScopes.push(scope);
+    if (emitThrows) throw new Error("telemetry down");
+  },
+}));
+
+const { handleSurfaceAction } = await import("@/domains/chat/surface-actions");
+const { FIRST_RUN_SCOPE_DATA_KEY } = await import(
+  "@/domains/onboarding/first-run-scope"
+);
+const { useChatSessionStore } = await import(
+  "@/domains/chat/chat-session-store"
+);
+const { useStreamStore } = await import("@/domains/chat/stream-store");
+const { useTurnStore } = await import("@/domains/chat/turn-store");
+
+beforeEach(() => {
+  submitResult = { ok: true };
+  submitThrows = false;
+  submitCalls.length = 0;
+  emittedScopes.length = 0;
+  emitThrows = false;
+  useStreamStore.getState().setStreamContext({
+    assistantId: "ast-1",
+    conversationId: "conv-1",
+  });
+  useChatSessionStore.getState().setError(null);
+  useTurnStore.getState().resetTurn();
+});
+
+describe("handleSurfaceAction — first-run scope funnel event", () => {
+  it("emits exactly one event with the chosen scope", async () => {
+    await handleSurfaceAction("srf-1", "scope_work", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "work",
+    });
+
+    expect(emittedScopes).toEqual(["work"]);
+    expect(useChatSessionStore.getState().error).toBeNull();
+  });
+
+  it("emits nothing for surface actions without the scope marker", async () => {
+    await handleSurfaceAction("srf-1", "confirm", { choice: "blue" });
+    await handleSurfaceAction("srf-1", "confirm");
+
+    expect(submitCalls).toHaveLength(2);
+    expect(emittedScopes).toEqual([]);
+  });
+
+  it("emits nothing when the marker value is not a known scope", async () => {
+    await handleSurfaceAction("srf-1", "scope_other", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "everything",
+    });
+
+    expect(emittedScopes).toEqual([]);
+  });
+
+  it("emits nothing when the submit fails", async () => {
+    submitResult = { ok: false };
+
+    await handleSurfaceAction("srf-1", "scope_personal", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "personal",
+    });
+
+    expect(emittedScopes).toEqual([]);
+    expect(useChatSessionStore.getState().error?.message).toBe(
+      "Failed to submit. Please try again.",
+    );
+  });
+
+  it("emits nothing when the submit throws", async () => {
+    submitThrows = true;
+
+    await handleSurfaceAction("srf-1", "scope_personal", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "personal",
+    });
+
+    expect(emittedScopes).toEqual([]);
+  });
+
+  it("emits nothing for guardian decision actions", async () => {
+    submitResult = { ok: true, applied: false, reason: "expired" };
+
+    await handleSurfaceAction("srf-1", "apr:allow", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "both",
+    });
+
+    expect(emittedScopes).toEqual([]);
+  });
+
+  it("a throwing emitter does not break the action path", async () => {
+    emitThrows = true;
+
+    await handleSurfaceAction("srf-1", "scope_both", {
+      [FIRST_RUN_SCOPE_DATA_KEY]: "both",
+    });
+
+    // The emitter was invoked (and threw)…
+    expect(emittedScopes).toEqual(["both"]);
+    // …but the action path completed: no error banner, and the turn store
+    // was signaled to expect a reply.
+    expect(useChatSessionStore.getState().error).toBeNull();
+    expect(useTurnStore.getState().phase).toBe("thinking");
+  });
+});

--- a/clients/web/src/domains/chat/surface-actions.ts
+++ b/clients/web/src/domains/chat/surface-actions.ts
@@ -8,6 +8,12 @@
 
 import { captureError } from "@/lib/sentry/capture-error";
 
+import {
+  FIRST_RUN_SCOPE_DATA_KEY,
+  FIRST_RUN_SCOPES,
+  type FirstRunScope,
+} from "@/domains/onboarding/first-run-scope";
+import { emitFirstMessageScopeSelected } from "@/domains/onboarding/funnel-events";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
 import { useStreamStore } from "@/domains/chat/stream-store";
@@ -27,6 +33,24 @@ const DECISION_REASON_LABELS: Record<string, string> = {
 function formatDecisionReason(reason?: string): string {
   if (!reason) return "Not applied";
   return DECISION_REASON_LABELS[reason] ?? "Not applied";
+}
+
+/**
+ * Funnel telemetry for the first-run greeting's scope options. The
+ * `firstRunScope` marker only ever appears on choice-option payloads authored
+ * by the "Let's chat" kickoff prompt (the choice surface spreads each option's
+ * `data` into its click payload), so matching on it here needs no
+ * first-message heuristics. Strictly fire-and-forget — telemetry must never
+ * block or fail the surface-action path.
+ */
+function emitFirstRunScopeTelemetry(data?: Record<string, unknown>): void {
+  const scope = data?.[FIRST_RUN_SCOPE_DATA_KEY];
+  if (!(FIRST_RUN_SCOPES as readonly unknown[]).includes(scope)) return;
+  try {
+    emitFirstMessageScopeSelected(scope as FirstRunScope);
+  } catch (err) {
+    captureError(err, { context: "first_run_scope_telemetry" });
+  }
 }
 
 /**
@@ -74,6 +98,7 @@ export async function handleSurfaceAction(
   const isGuardianDecision = typeof result.applied === "boolean";
   if (!isGuardianDecision) {
     useTurnStore.getState().requestSend();
+    emitFirstRunScopeTelemetry(data);
   }
 
   const completionText =

--- a/clients/web/src/domains/chat/surface-actions.ts
+++ b/clients/web/src/domains/chat/surface-actions.ts
@@ -10,10 +10,10 @@ import { captureError } from "@/lib/sentry/capture-error";
 
 import {
   FIRST_RUN_SCOPE_DATA_KEY,
-  FIRST_RUN_SCOPES,
-  type FirstRunScope,
+  isFirstRunScope,
 } from "@/domains/onboarding/first-run-scope";
 import { emitFirstMessageScopeSelected } from "@/domains/onboarding/funnel-events";
+import { useAuthStore } from "@/stores/auth-store";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
 import { useStreamStore } from "@/domains/chat/stream-store";
@@ -45,9 +45,12 @@ function formatDecisionReason(reason?: string): string {
  */
 function emitFirstRunScopeTelemetry(data?: Record<string, unknown>): void {
   const scope = data?.[FIRST_RUN_SCOPE_DATA_KEY];
-  if (!(FIRST_RUN_SCOPES as readonly unknown[]).includes(scope)) return;
+  if (!isFirstRunScope(scope)) return;
   try {
-    emitFirstMessageScopeSelected(scope as FirstRunScope);
+    // Same auth source `active-chat-view.tsx` derives `authUserId` from, read
+    // non-reactively; an absent user id emits as null rather than blocking.
+    const userId = useAuthStore.getState().user?.id ?? null;
+    emitFirstMessageScopeSelected(scope, { userId });
   } catch (err) {
     captureError(err, { context: "first_run_scope_telemetry" });
   }

--- a/clients/web/src/domains/onboarding/first-run-scope.ts
+++ b/clients/web/src/domains/onboarding/first-run-scope.ts
@@ -14,8 +14,8 @@
 export const FIRST_RUN_SCOPE_DATA_KEY = "firstRunScope";
 export const FIRST_RUN_SCOPES = ["work", "personal", "both"] as const;
 export type FirstRunScope = (typeof FIRST_RUN_SCOPES)[number];
-export const FIRST_RUN_SCOPE_OPTION_IDS: Record<FirstRunScope, string> = {
-  work: "scope_work",
-  personal: "scope_personal",
-  both: "scope_both",
-};
+
+/** Narrow an untrusted wire value (a click payload's `firstRunScope`) to a scope. */
+export function isFirstRunScope(value: unknown): value is FirstRunScope {
+  return (FIRST_RUN_SCOPES as readonly unknown[]).includes(value);
+}

--- a/clients/web/src/domains/onboarding/first-run-scope.ts
+++ b/clients/web/src/domains/onboarding/first-run-scope.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared contract for the first-run scope options offered by the "Let's chat"
+ * kickoff greeting (see `lets-chat-kickoff.ts`).
+ *
+ * These are wire values: they ride `ui_show` choice-option `data` payloads
+ * through the daemon and come back on click as the surface action's data.
+ * Downstream consumers (e.g. click telemetry in the chat domain) match on
+ * them, so they must stay stable — do not rename or reorder.
+ *
+ * Chat-domain code may import this module; the import direction mirrors
+ * `PreChatOnboardingContext` in `prechat.ts` — onboarding exports, other
+ * domains import.
+ */
+export const FIRST_RUN_SCOPE_DATA_KEY = "firstRunScope";
+export const FIRST_RUN_SCOPES = ["work", "personal", "both"] as const;
+export type FirstRunScope = (typeof FIRST_RUN_SCOPES)[number];
+export const FIRST_RUN_SCOPE_OPTION_IDS: Record<FirstRunScope, string> = {
+  work: "scope_work",
+  personal: "scope_personal",
+  both: "scope_both",
+};

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -251,13 +251,20 @@ export function emitResearchOnboardingCheckinCalendarOpened(
 }
 
 /**
- * Emit the first-run scope option click, with the chosen scope in `screen`.
+ * Emit the first-run scope option click. The chosen scope rides the event's
+ * `screen` field — the same dimension-in-`screen` pattern the tips and tour
+ * funnels use — so analysts read the scope from `screen`, not `step_name`.
  * Stamped with the research funnel version and `control` variant like the
  * in-flow steps, so click-through rate is derivable against their completion
- * rows in the same funnel.
+ * rows in the same funnel. `userId` keys the row to the clicking user; when
+ * unavailable the event still emits with `user_id: null`.
  */
-export function emitFirstMessageScopeSelected(scope: FirstRunScope): void {
+export function emitFirstMessageScopeSelected(
+  scope: FirstRunScope,
+  options: { userId?: string | null } = {},
+): void {
   emitOnboardingFunnelStepCompleted(FIRST_MESSAGE_SCOPE_STEP, {
+    userId: options.userId,
     funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
     screen: scope,
     outcome: "completed",

--- a/clients/web/src/domains/onboarding/funnel-events.ts
+++ b/clients/web/src/domains/onboarding/funnel-events.ts
@@ -1,5 +1,6 @@
 import { isAnalyticsEnabled } from "@/domains/onboarding/prefs";
 import { postTelemetryEvents } from "@/lib/telemetry/ingest";
+import type { FirstRunScope } from "@/domains/onboarding/first-run-scope";
 import type { ResearchStep } from "@/domains/onboarding/research-onboarding-persistence";
 
 export const ONBOARDING_FUNNEL_VERSION = "onboarding_v3_2026_05";
@@ -94,6 +95,20 @@ export const RESEARCH_CHECKIN_CALENDAR_ATTRIBUTION = "research_checkin";
 export const RESEARCH_ONBOARDING_CHECKIN_STEP = {
   stepName: "research_checkin_open",
   stepIndex: 11,
+} as const satisfies OnboardingFunnelStepDescriptor;
+
+/**
+ * The first-run scope option click. Like the check-in event above, it rides
+ * RESEARCH_ONBOARDING_FUNNEL_VERSION but fires after the flow ends — from the
+ * chat surface-action path when the user clicks one of the work / personal /
+ * both options the "Let's chat" greeting renders (see `first-run-scope.ts`) —
+ * so it lives outside RESEARCH_ONBOARDING_FUNNEL_STEPS and takes the next free
+ * index. The chosen scope rides `screen`, the same dimension-in-`screen`
+ * pattern the tips and tour funnels use.
+ */
+export const FIRST_MESSAGE_SCOPE_STEP = {
+  stepName: "first_message_scope_selected",
+  stepIndex: 13,
 } as const satisfies OnboardingFunnelStepDescriptor;
 
 /**
@@ -231,6 +246,20 @@ export function emitResearchOnboardingCheckinCalendarOpened(
   emitOnboardingFunnelStepCompleted(RESEARCH_ONBOARDING_CHECKIN_STEP, {
     userId: options.userId,
     funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
+    outcome: "completed",
+  });
+}
+
+/**
+ * Emit the first-run scope option click, with the chosen scope in `screen`.
+ * Stamped with the research funnel version and `control` variant like the
+ * in-flow steps, so click-through rate is derivable against their completion
+ * rows in the same funnel.
+ */
+export function emitFirstMessageScopeSelected(scope: FirstRunScope): void {
+  emitOnboardingFunnelStepCompleted(FIRST_MESSAGE_SCOPE_STEP, {
+    funnelVersion: RESEARCH_ONBOARDING_FUNNEL_VERSION,
+    screen: scope,
     outcome: "completed",
   });
 }

--- a/clients/web/src/domains/onboarding/lets-chat-kickoff.test.ts
+++ b/clients/web/src/domains/onboarding/lets-chat-kickoff.test.ts
@@ -7,6 +7,10 @@
 
 import { describe, expect, test } from "bun:test";
 
+import {
+  FIRST_RUN_SCOPE_DATA_KEY,
+  FIRST_RUN_SCOPE_OPTION_IDS,
+} from "./first-run-scope";
 import { buildLetsChatKickoffMessage } from "./lets-chat-kickoff";
 
 describe("buildLetsChatKickoffMessage", () => {
@@ -14,16 +18,35 @@ describe("buildLetsChatKickoffMessage", () => {
     const msg = buildLetsChatKickoffMessage("Quill");
     expect(msg).toContain("Your name is Quill — introduce yourself as Quill.");
     expect(msg).toContain("You're about to begin your first conversation.");
-    expect(msg).toContain("don't use `recall` or read any files");
   });
 
-  test("instructs a closing question that is specific and answerable", () => {
+  test("keeps the greeting short and forbids tools beyond the one ui_show", () => {
     const msg = buildLetsChatKickoffMessage("Quill");
-    expect(msg).toContain(
-      "exactly one short question about something specific you already know",
-    );
-    expect(msg).toContain("five words or less");
-    expect(msg).toContain("Never ask what they want to do");
+    expect(msg).toContain("Keep it short!");
+    expect(msg).toContain("don't use `recall`, don't read any files");
+    expect(msg).toContain("no tool calls other than that single `ui_show`");
+  });
+
+  test("instructs one ui_show choice call with the three scope options", () => {
+    const msg = buildLetsChatKickoffMessage("Quill");
+    expect(msg).toContain("`ui_show` tool exactly once");
+    expect(msg).toContain('"choice"');
+    for (const id of Object.values(FIRST_RUN_SCOPE_OPTION_IDS)) {
+      expect(msg).toContain(id);
+    }
+    expect(msg).toContain(FIRST_RUN_SCOPE_DATA_KEY);
+  });
+
+  test("frames the options as starters, not a menu", () => {
+    const msg = buildLetsChatKickoffMessage("Quill");
+    expect(msg).toContain("conversation starters, not a menu");
+    expect(msg).toContain("invite free-form answers");
+  });
+
+  test("drops the old closed-question instruction", () => {
+    const msg = buildLetsChatKickoffMessage("Quill");
+    expect(msg).not.toContain("five words or less");
+    expect(msg).not.toContain("Never ask what they want to do");
   });
 
   test("omits the name line when no name was picked", () => {

--- a/clients/web/src/domains/onboarding/lets-chat-kickoff.test.ts
+++ b/clients/web/src/domains/onboarding/lets-chat-kickoff.test.ts
@@ -7,10 +7,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import {
-  FIRST_RUN_SCOPE_DATA_KEY,
-  FIRST_RUN_SCOPE_OPTION_IDS,
-} from "./first-run-scope";
+import { FIRST_RUN_SCOPES } from "./first-run-scope";
 import { buildLetsChatKickoffMessage } from "./lets-chat-kickoff";
 
 describe("buildLetsChatKickoffMessage", () => {
@@ -31,10 +28,13 @@ describe("buildLetsChatKickoffMessage", () => {
     const msg = buildLetsChatKickoffMessage("Quill");
     expect(msg).toContain("`ui_show` tool exactly once");
     expect(msg).toContain('"choice"');
-    for (const id of Object.values(FIRST_RUN_SCOPE_OPTION_IDS)) {
-      expect(msg).toContain(id);
+    // Pin the exact option wire text: the data payloads are the contract the
+    // click-telemetry consumer matches on, so they must stay byte-identical.
+    for (const scope of FIRST_RUN_SCOPES) {
+      expect(msg).toContain(
+        `id \`scope_${scope}\`, \`data: {"firstRunScope": "${scope}"}\``,
+      );
     }
-    expect(msg).toContain(FIRST_RUN_SCOPE_DATA_KEY);
   });
 
   test("frames the options as starters, not a menu", () => {

--- a/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
+++ b/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
@@ -1,3 +1,14 @@
+import {
+  FIRST_RUN_SCOPE_DATA_KEY,
+  FIRST_RUN_SCOPE_OPTION_IDS,
+  type FirstRunScope,
+} from "./first-run-scope";
+
+/** Renders one choice option's wire fields (id + data payload) for the prompt. */
+function optionWire(scope: FirstRunScope): string {
+  return `id \`${FIRST_RUN_SCOPE_OPTION_IDS[scope]}\`, \`data: {"${FIRST_RUN_SCOPE_DATA_KEY}": "${scope}"}\``;
+}
+
 /**
  * Hidden kickoff sent on the user's behalf when they hit "Let's chat" at the
  * end of the research-onboarding flow. It drives the assistant's first
@@ -10,6 +21,11 @@
  * out or IDENTITY.md's name is still a placeholder when the turn's system
  * prompt is built, the model would otherwise invent a name for its very first
  * words to the user.
+ *
+ * The greeting ends with a scope question backed by a single `ui_show` choice
+ * surface offering three clickable options (work / personal / both). The
+ * option ids and `data` payloads come from `first-run-scope.ts` — they're the
+ * wire contract a click-telemetry consumer matches on.
  */
 export function buildLetsChatKickoffMessage(assistantName?: string): string {
   const name = assistantName?.trim();
@@ -18,6 +34,13 @@ export function buildLetsChatKickoffMessage(assistantName?: string): string {
     : "";
   return `You're about to begin your first conversation.${nameLine}
 Respond with a warm and engaging greeting. Be interesting, be real. This is your chance to get to know and impress the user.
-End with exactly one short question about something specific you already know about them (see your Onboarding Context) — a question they can answer in five words or less. If you know almost nothing about them yet, ask one specific, concrete question anyway (still five-word-answerable). Never ask what they want to do, what you're getting into, or anything else open-ended: an open question hands a stranger a blank page.
-Keep it short! For this opening greeting only, don't use \`recall\` or read any files — just say hello. (This applies to the greeting alone; use your tools normally for everything the user asks afterward.)`;
+End the greeting text with one short question asking where they'd like to start, phrased so nothing feels off the table (e.g. "…or is there anything else on your mind entirely?").
+Then call the \`ui_show\` tool exactly once: \`surface_type: "choice"\`, \`data.selectionMode: "single"\`, no \`title\` (or a very short one), and exactly three options in this order:
+1. ${optionWire("work")} — a concrete offer grounded in their work or role from your Onboarding Context (occupation, daily tools, work-related research findings).
+2. ${optionWire("personal")} — a concrete offer grounded in their hobbies, interests, or personal research findings.
+3. ${optionWire("both")} — an "all of the above" invitation.
+An option's title becomes the user's visible reply bubble when they tap it, so every title must read naturally in the user's voice — imperative or neutral, ten words or fewer (e.g. "Help me plan my next ride", never "I can plan your next ride"). Put richer color in your own voice in each option's one-sentence \`description\` instead.
+These options are conversation starters, not a menu: never imply the user is limited to them, and your closing question itself must invite free-form answers.
+After the \`ui_show\` result comes back, stop — output no further text. If \`ui_show\` errors or is unavailable, just end with the text question alone; the user will type. Do not set \`await_action\` or \`persistent\`.
+Keep it short! For this opening greeting only, don't use \`recall\`, don't read any files, and make no tool calls other than that single \`ui_show\`. (This applies to the greeting alone; use your tools normally for everything the user asks afterward.)`;
 }

--- a/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
+++ b/clients/web/src/domains/onboarding/lets-chat-kickoff.ts
@@ -1,12 +1,8 @@
-import {
-  FIRST_RUN_SCOPE_DATA_KEY,
-  FIRST_RUN_SCOPE_OPTION_IDS,
-  type FirstRunScope,
-} from "./first-run-scope";
+import { FIRST_RUN_SCOPE_DATA_KEY, type FirstRunScope } from "./first-run-scope";
 
 /** Renders one choice option's wire fields (id + data payload) for the prompt. */
 function optionWire(scope: FirstRunScope): string {
-  return `id \`${FIRST_RUN_SCOPE_OPTION_IDS[scope]}\`, \`data: {"${FIRST_RUN_SCOPE_DATA_KEY}": "${scope}"}\``;
+  return `id \`scope_${scope}\`, \`data: {"${FIRST_RUN_SCOPE_DATA_KEY}": "${scope}"}\``;
 }
 
 /**
@@ -24,8 +20,9 @@ function optionWire(scope: FirstRunScope): string {
  *
  * The greeting ends with a scope question backed by a single `ui_show` choice
  * surface offering three clickable options (work / personal / both). The
- * option ids and `data` payloads come from `first-run-scope.ts` — they're the
- * wire contract a click-telemetry consumer matches on.
+ * `data` payloads come from `first-run-scope.ts` — they're the wire contract a
+ * click-telemetry consumer matches on. The option ids are presentation-only
+ * (`scope_<scope>`), derived here.
  */
 export function buildLetsChatKickoffMessage(assistantName?: string): string {
   const name = assistantName?.trim();


### PR DESCRIPTION
## Summary
Replaces the post-onboarding first greeting's single ≤5-word question with a scope question backed by three clickable, personalized options — work, personal, or both — rendered via the existing `ui_show` choice surface. Option clicks produce a visible user bubble (existing daemon plumbing) and carry a `firstRunScope` payload the assistant sees; a funnel event records which scope users pick. No daemon changes; the greeting turn's zero-tool latency guarantee is preserved (text streams first, one small tool call after).

Fixes JARVIS-1343

## Self-review result
GAPS FOUND → fixed — 4 gaps (missing userId on the funnel event; unvalidated sessionStorage parse; over-wide shared contract + hand-rolled type guard; duplicated comments/prop drilling) fixed across 2 fix PRs. Round-2 re-review: PASS on all four passes.

## PRs merged into feature branch
- #38903: feat(web): first-run greeting offers three clickable scope options via ui_show choice (incl. suppression of the legacy native OnboardingChoiceCard for research-onboarding first chats, per Codex review)
- #38915: feat(web): funnel event for first-run scope option clicks

### Fix PRs
- #38928: fix: validated pre-chat context read + single onboarding-choice eligibility flag
- #38929: fix: thread userId into scope telemetry + slim first-run-scope contract

## Pre-ship checklist (manual)
- [ ] Live e2e on local `vel up`: research-onboarding → "Let's chat" → greeting streams, three options render after the text; clicking shows a user bubble with the option title and a scoped reply; typing instead of clicking dismisses the surface cleanly

## Notes for reviewers
- Scope-click telemetry rides the research-onboarding funnel; the chosen scope is in the event's `screen` field (the file's established dimension-in-`screen` pattern). Browser onboarding funnel rows are currently zeroed in BQ by the consent-gate outage, so data appears only once that's fixed.
- Two chat→onboarding cross-domain allowlist entries were added (same sanctioned pattern as `tour-telemetry.ts`).

Part of plan: first-message-scope-options.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)