### PR TITLE
fix(assistant): don't crash the daemon on MCP OAuth gateway auth failure (ATL-1126)

### DIFF
--- a/assistant/src/mcp/__tests__/mcp-oauth-provider.test.ts
+++ b/assistant/src/mcp/__tests__/mcp-oauth-provider.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (must precede SUT import) ────────────────────────────────────
+// startGatewayCallback() dynamically imports these to resolve the public
+// callback URL. Stub them so the gateway flow runs without platform infra.
+
+mock.module("../../inbound/platform-callback-registration.js", () => ({
+  resolveCallbackUrl: async () =>
+    "https://platform.example/v1/gateway/callbacks/abc/webhooks/oauth/callback/",
+}));
+
+mock.module("../../inbound/public-ingress-urls.js", () => ({
+  getOAuthCallbackUrl: () =>
+    "https://platform.example/v1/gateway/callbacks/abc/webhooks/oauth/callback/",
+}));
+
+mock.module("../../config/loader.js", () => ({
+  loadConfig: () => ({}),
+}));
+
+// ── Import SUT after mocks ────────────────────────────────────────────────────
+
+const { McpOAuthProvider } = await import("../mcp-oauth-provider.js");
+
+function newGatewayProvider() {
+  return new McpOAuthProvider(
+    "comms",
+    "https://comms.example/mcp",
+    /* interactive */ false,
+    "gateway",
+  );
+}
+
+describe("McpOAuthProvider gateway callback", () => {
+  test("stopCallbackServer() before a consumer attaches does not emit an unhandled rejection", async () => {
+    // stopCallbackServer() rejects the deferred code promise. When no consumer
+    // is attached, that rejection must stay observed so it does not surface as
+    // an unhandled rejection, which the daemon treats as fatal.
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const provider = newGatewayProvider();
+
+      // Intentionally do NOT consume the returned codePromise — this mirrors the
+      // early-exit paths where connect() throws before the OAuth tail is wired up.
+      await provider.startCallbackServer();
+      provider.stopCallbackServer();
+
+      // Drain the queue so any unhandled rejection has a chance to fire.
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+      const cancelRejections = unhandled.filter(
+        (r) =>
+          r instanceof Error &&
+          r.message.includes("MCP OAuth gateway callback cancelled"),
+      );
+      expect(cancelRejections).toHaveLength(0);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
+  test("stopCallbackServer() still rejects a consumer that is awaiting the code", async () => {
+    const provider = newGatewayProvider();
+    await provider.startCallbackServer();
+
+    const codePromise = provider.waitForCode();
+    provider.stopCallbackServer();
+
+    await expect(codePromise).rejects.toThrow(
+      "MCP OAuth gateway callback cancelled",
+    );
+  });
+});

--- a/assistant/src/mcp/mcp-oauth-provider.ts
+++ b/assistant/src/mcp/mcp-oauth-provider.ts
@@ -416,6 +416,12 @@ export class McpOAuthProvider implements OAuthClientProvider {
     });
     this._codePromise = codePromise;
 
+    // stopCallbackServer() can reject this deferred before any consumer is
+    // attached. Without a handler that rejection is unhandled, which the daemon
+    // treats as fatal; the no-op catch keeps it observed while a real consumer
+    // awaits the same promise and still sees the rejection.
+    void codePromise.catch(() => {});
+
     log.info(
       { serverId: this.serverId, redirectUrl },
       "MCP OAuth gateway callback prepared (awaiting state from auth URL)",


### PR DESCRIPTION
`assistant mcp auth <server>` on a containerized/platform daemon could shut the whole daemon down. On the gateway callback transport the OAuth flow creates a deferred code promise; the orchestrator's early-exit paths reject it (via `stopCallbackServer()`) before any consumer is attached, and the resulting unhandled rejection trips the daemon's global fatal-error handler.

Fix: attach a no-op catch when the deferred is created so the rejection is always observed. A real consumer still awaits the same promise and sees the outcome. Includes a regression test that reproduces the crash and fails without the fix.

Loopback (bare-metal desktop) daemons are unaffected — only the gateway transport rejects the deferred.

ATL-1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
