### PR TITLE
perf(memory): index memory_summaries for recent-summaries fetch

### DIFF
--- a/assistant/src/persistence/migrations/348-memory-summaries-scope-updated-index.ts
+++ b/assistant/src/persistence/migrations/348-memory-summaries-scope-updated-index.ts
@@ -1,0 +1,25 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Add an index on `memory_summaries(scope, updated_at DESC)` to support the
+ * recent-summaries fetch on context load
+ * (`ConversationGraphMemory.fetchRecentSummaries`).
+ *
+ * That query filters `scope = 'conversation'` and orders by `updated_at DESC`
+ * with a small `LIMIT`, joining `conversations` only to read
+ * `conversation_type`. The existing summary indexes cover `(scope, scope_key)`
+ * and `(scope, end_at DESC)` but none provides `updated_at` order, so SQLite
+ * had to materialize and sort the entire `scope = 'conversation'` partition on
+ * every context load (observed ~2.2s for a 3-row result). This composite index
+ * lets the planner walk the partition newest-first and stop after the first few
+ * qualifying rows, eliminating the sort and enabling early termination.
+ *
+ * Idempotent: `CREATE INDEX IF NOT EXISTS`.
+ */
+export function migrateMemorySummariesScopeUpdatedIndex(
+  database: DrizzleDb,
+): void {
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_updated ON memory_summaries(scope, updated_at DESC)`,
+  );
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -455,6 +455,7 @@ import { migrateMoveConversationGraphMemoryStateToMemoryDb } from "./migrations/
 import { migrateMoveMemoryV3EverInjectedToMemoryDb } from "./migrations/345-move-memory-v3-ever-injected-to-memory-db.js";
 import { migrateMoveMemoryRetrospectiveStateToMemoryDb } from "./migrations/346-move-memory-retrospective-state-to-memory-db.js";
 import { migrateDeleteStrayGreetingConversation } from "./migrations/347-delete-stray-greeting-conversation.js";
+import { migrateMemorySummariesScopeUpdatedIndex } from "./migrations/348-memory-summaries-scope-updated-index.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1441,4 +1442,5 @@ export const migrationSteps: MigrationStep[] = [
     ],
   },
   migrateDeleteStrayGreetingConversation,
+  migrateMemorySummariesScopeUpdatedIndex,
 ];


### PR DESCRIPTION
## Prompt / plan

A slow-query log flagged `fetchRecentSummaries` (`conversation-graph-memory.ts`) taking **2177ms to return 3 rows** on context load. The question raised was whether the `INNER JOIN conversations` was the culprit.

**Finding:** the join is *not* the problem — it's a primary-key lookup and is functionally required, since `conversation_type` (used to prefer user conversations and cap background/scheduled ones) only exists on `conversations`. The real cost is the `ORDER BY memory_summaries.updated_at DESC LIMIT 3`. The existing `memory_summaries` indexes cover `(scope, scope_key)` and `(scope, end_at DESC)`, but **none provides `updated_at` order**, so SQLite materialized and sorted the entire `scope='conversation'` partition on every context load.

**Fix:** add `idx_memory_summaries_scope_updated ON memory_summaries(scope, updated_at DESC)` (migration `348`). The planner can now walk the partition newest-first and early-terminate at the `LIMIT`, eliminating the sort.

## Test plan

- `EXPLAIN QUERY PLAN` on the exact query, before vs. after the index:
  - **Before:** `SEARCH ms USING INDEX idx_ms_scope_time` → **`USE TEMP B-TREE FOR ORDER BY`**
  - **After:** `SEARCH ms USING INDEX idx_memory_summaries_scope_updated` — the temp-b-tree sort is gone; the `conversations` join stays a PK lookup.
- `bun test src/persistence/__tests__/db-init-migrations-ok.test.ts` — full migration chain applies cleanly (2 pass).
- `tsc --noEmit` and lint pass (pre-push hook green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbyP2Rs6bTvsnF6cHAnimL)_