### PR TITLE
fix(web): normalize payment-method brand casing in PaymentMethodRow

### DIFF
--- a/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -86,7 +86,7 @@ const ENABLED_WITH_CARD: AutoTopUpConfigResponse = {
   monthly_cap_usd: "500.00",
   current_month_credits_purchased_usd: "150.00",
   has_payment_method: true,
-  payment_method_brand: "Visa",
+  payment_method_brand: "visa",
   payment_method_last4: "4242",
 };
 

--- a/clients/web/src/domains/settings/components/payment-method-row.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.test.tsx
@@ -20,6 +20,20 @@ describe("PaymentMethodRow", () => {
     expect(row.textContent).toContain("Ending in 4242");
   });
 
+  test("normalizes a lowercase brand to its canonical label", () => {
+    const { getByTestId } = render(
+      <PaymentMethodRow
+        brand="visa"
+        last4="4242"
+        onUpdateCard={() => {}}
+        onRemove={() => {}}
+      />,
+    );
+    const row = getByTestId("payment-method-row");
+    expect(row.textContent).toContain("Visa");
+    expect(row.textContent).not.toContain("visa");
+  });
+
   test("falls back to a generic label and omits the ending line when null", () => {
     const { getByTestId } = render(
       <PaymentMethodRow

--- a/clients/web/src/domains/settings/components/payment-method-row.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.tsx
@@ -3,6 +3,8 @@ import { CreditCard } from "lucide-react";
 import { Button } from "@vellumai/design-library/components/button";
 import { Typography } from "@vellumai/design-library/components/typography";
 
+import { brandLabel } from "@/domains/settings/utils/payment-method-brand";
+
 export interface PaymentMethodRowProps {
   brand: string | null;
   last4: string | null;
@@ -34,7 +36,7 @@ export function PaymentMethodRow({
             variant="body-medium-default"
             className="text-[var(--content-default)]"
           >
-            {brand ?? "Saved card"}
+            {brand ? brandLabel(brand) : "Saved card"}
           </Typography>
           {last4 != null && (
             <Typography

--- a/clients/web/src/domains/settings/utils/payment-method-brand.ts
+++ b/clients/web/src/domains/settings/utils/payment-method-brand.ts
@@ -1,7 +1,6 @@
 /**
- * Canonical display labels for the Stripe payment-method brand strings.
- * Centralized here so every auto-top-up payment-method display in
- * `AutoTopUpCard` agrees on capitalization.
+ * Canonical display labels for the raw Stripe payment-method brand strings,
+ * so the payment-method display renders `"Visa"` rather than `"visa"`.
  */
 const BRAND_LABELS: Record<string, string> = {
   visa: "Visa",
@@ -15,18 +14,4 @@ const BRAND_LABELS: Record<string, string> = {
 
 export function brandLabel(brand: string): string {
   return BRAND_LABELS[brand.toLowerCase()] ?? brand;
-}
-
-/**
- * Render the canonical "<brand> •••• <last4>" shape with safe fallbacks.
- *
- * Fallback chain when brand is null: passes the literal `"card"` to
- * `brandLabel`, which falls through to the default branch (lowercase
- * `"card"` is not in `BRAND_LABELS`) and returns `"card"` verbatim.
- */
-export function formatBrandLast4(
-  brand: string | null,
-  last4: string | null,
-): string {
-  return `${brandLabel(brand ?? "card")} •••• ${last4 ?? "????"}`;
 }


### PR DESCRIPTION
## Summary
Fixes a gap from plan review for credit-balance-redesign.md.
- PaymentMethodRow runs the raw Stripe brand through brandLabel so it renders 'Visa' not 'visa'.
- Removes the now-unused formatBrandLast4; brandLabel is reconnected to the render path.
- Tests seed lowercase brands to lock the normalization.