### PR TITLE
feat(web): price and show a held legacy credit bundle in the custom-plan modal

### DIFF
--- a/clients/web/openapi-schemas/platform-source.json
+++ b/clients/web/openapi-schemas/platform-source.json
@@ -1,4 +1,4 @@
 {
   "sourceRepo": "vellum-ai/vellum-assistant-platform",
-  "sourceSha": "b5caad6120752c03a344a5086f4359cca9253da0"
+  "sourceSha": "32404bc0cb0898be4d4b5425cbea2d6262e9afb3"
 }

--- a/clients/web/openapi-schemas/platform.yaml
+++ b/clients/web/openapi-schemas/platform.yaml
@@ -6624,9 +6624,14 @@ components:
           minimum: 0
         lookup_key:
           type: string
+        legacy:
+          type: boolean
+          description: 'True only for a grandfathered tier: no longer offered, present
+            in the catalog solely because it is the org''s current tier.'
       required:
       - credits_usd
       - label
+      - legacy
       - lookup_key
       - price_cents
       - tier

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -226,6 +226,18 @@ function fullCatalog(): PlanListResponse {
             credits_usd: 50,
             price_cents: 5000,
             lookup_key: "credits_50",
+            legacy: false,
+          },
+          {
+            // A grandfathered bundle: no longer offered, present in the catalog
+            // only because a current Pro sub still holds it. Matches MIGHTY's
+            // credit tier so a sub on it seeds the modal to a held legacy pick.
+            tier: "credits_25",
+            label: "25 credits",
+            credits_usd: 25,
+            price_cents: 2500,
+            lookup_key: "credits_25",
+            legacy: true,
           },
         ],
         packages: [MIGHTY],
@@ -701,12 +713,12 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
   });
 });
 
-describe("CustomPlanModal — Pro plan the catalog can't fully represent", () => {
-  test("a deprecated credit bundle Pro sub's Configure opens the custom-plan modal", () => {
-    // The configurator only offers live credit tiers; the sub's `credits_25`
-    // bundle is absent from the catalog. Configure still opens the modal — the
-    // seed keeps the held credit, and an apply the backend can't honor surfaces
-    // as a toast instead of the takeover pre-empting the modal.
+describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bundle", () => {
+  // The catalog surfaces the held bundle as a `legacy: true` tier
+  // (`credits_25`) so the modal can price it. Configure opens seeded to the
+  // held credit; the recap totals it, and the dropdown shows it as the current
+  // (disabled) selection without offering it to a new configuration.
+  test("prices the held legacy bundle in the recap total and selection row", () => {
     const { getByRole, getByTestId, getByText } = renderPage(
       proMightySubscription({ selected_credit_tier: "credits_25" }),
     );
@@ -715,6 +727,68 @@ describe("CustomPlanModal — Pro plan the catalog can't fully represent", () =>
 
     getByText("Create a custom plan");
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
-    expect(machineTierCall).toBeNull();
+
+    // $20 base + $35 medium machine + $5 (10 GB) storage + $25 held credits.
+    getByText("$85/mo");
+
+    const dialog = document.querySelector('[role="dialog"]');
+    const rows = Array.from(dialog?.querySelectorAll("li") ?? []).map(
+      (li) => li.textContent?.trim() ?? "",
+    );
+    expect(rows).toEqual([
+      "Pro base plan — $20/mo",
+      "Medium machine (2.5 vCPU, 5 GiB)",
+      "10 GB storage",
+      "$25 of bundled credits",
+    ]);
+  });
+
+  test("shows the held bundle in the dropdown as the current, disabled choice", () => {
+    const { getByRole } = renderPage(
+      proMightySubscription({ selected_credit_tier: "credits_25" }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    openDropdown("Credit bundle");
+
+    // The held legacy bundle appears so the current selection is visible, but
+    // it's disabled — a new config can never pick it.
+    expect(findOption("25 credits").getAttribute("aria-disabled")).toBe("true");
+    // The live tier stays selectable.
+    expect(findOption("50 credits").getAttribute("aria-disabled")).toBe(
+      "false",
+    );
+  });
+
+  test("Continue preserves the held credit when another dimension changes", async () => {
+    const { getByRole, findByTestId } = renderPage(
+      proMightySubscription({ selected_credit_tier: "credits_25" }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    // Raise the machine but leave the held credit as seeded.
+    selectOption("Machine size", "Large machine (4 vCPU, 8 GiB)");
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(machineTierCall).not.toBeNull());
+    expect(machineTierCall!.body).toEqual({ machine_tier: "large" });
+    // The held credit is unchanged, so it's neither re-sent nor dropped.
+    expect(creditTierCall).toBeNull();
+    expect(storageTierCall).toBeNull();
+    const takeover = await findByTestId("resize-takeover");
+    expect(takeover.getAttribute("data-mode")).toBe("resize");
+  });
+
+  test("a config not holding the legacy bundle is never offered it", () => {
+    // A base subscriber configuring from scratch only sees the live tiers — the
+    // legacy `credits_25` bundle is filtered out of the selectable options.
+    const { getByRole } = renderPage(freeSubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    openDropdown("Credit bundle");
+
+    const labels = optionLabels();
+    expect(labels.some((l) => l.startsWith("50 credits"))).toBe(true);
+    expect(labels.some((l) => l.startsWith("25 credits"))).toBe(false);
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -132,7 +132,13 @@ export function CustomPlanModal({
     () => proPlan.storage_tiers.filter((t) => !t.legacy),
     [proPlan.storage_tiers],
   );
-  const creditTiers = proPlan.credit_tiers ?? [];
+  const allCreditTiers = proPlan.credit_tiers ?? [];
+  // Same legacy filter as storage for the selectable options; the full list is
+  // kept so a held legacy bundle can still be priced and shown (below).
+  const selectableCreditTiers = useMemo(
+    () => (proPlan.credit_tiers ?? []).filter((t) => !t.legacy),
+    [proPlan.credit_tiers],
+  );
 
   const machineOptions: DropdownOption<MachineTierEnum>[] = machineTiers.map(
     (t) => ({
@@ -154,28 +160,45 @@ export function CustomPlanModal({
         (currentStorageGib != null && t.storage_gib < currentStorageGib),
     }),
   );
+  // Price the current credit choice against the full catalog (legacy included)
+  // so a held bundle's price flows into the total and its recap row.
+  const selectedCredit =
+    creditChoice && creditChoice !== NO_EXTRA_CREDITS
+      ? (allCreditTiers.find((t) => t.tier === creditChoice) ?? null)
+      : null;
+  // A held legacy bundle isn't offered to a new config, but when it's the
+  // current selection it's appended disabled so the dropdown still shows it.
+  const heldLegacyCredit = selectedCredit?.legacy ? selectedCredit : null;
+
   const creditOptions: DropdownOption<CreditChoice>[] = [
     {
       value: NO_EXTRA_CREDITS,
       label: "No extra credits",
       icon: <Coins className="h-4 w-4" aria-hidden />,
     },
-    ...creditTiers.map((t) => ({
+    ...selectableCreditTiers.map((t) => ({
       value: t.tier as CreditTierEnum,
       label: t.label,
       icon: <Coins className="h-4 w-4" aria-hidden />,
       suffix: priceSuffix(t.price_cents),
     })),
+    ...(heldLegacyCredit
+      ? [
+          {
+            value: heldLegacyCredit.tier as CreditTierEnum,
+            label: heldLegacyCredit.label,
+            icon: <Coins className="h-4 w-4" aria-hidden />,
+            suffix: priceSuffix(heldLegacyCredit.price_cents),
+            disabled: true,
+          },
+        ]
+      : []),
   ];
 
   const selectedMachine =
     machineTiers.find((t) => t.tier === machineTier) ?? null;
   const selectedStorage =
     storageTiers.find((t) => t.tier === storageTier) ?? null;
-  const selectedCredit =
-    creditChoice && creditChoice !== NO_EXTRA_CREDITS
-      ? (creditTiers.find((t) => t.tier === creditChoice) ?? null)
-      : null;
 
   const complete =
     selectedMachine != null && selectedStorage != null && creditChoice !== "";

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -874,6 +874,7 @@ function customCatalog(): PlanListResponse {
             credits_usd: 50,
             price_cents: 5000,
             lookup_key: "credits_50",
+            legacy: false,
           },
         ],
         packages: [MIGHTY, SUPER, ULTRA],

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -163,6 +163,7 @@ function plansWithCredits(): PlanListResponse {
             credits_usd: 50,
             price_cents: 5000,
             lookup_key: "credits_50_key",
+            legacy: false,
           },
         ],
         packages: [],

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -109,6 +109,7 @@ function plansResponse(): PlanListResponse {
             credits_usd: 50,
             price_cents: 5000,
             lookup_key: "credits_50_key",
+            legacy: false,
           },
         ],
         packages: [

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
@@ -43,6 +43,7 @@ function plansResponse(): PlanListResponse {
             credits_usd: 50,
             price_cents: 5000,
             lookup_key: "credits_50_key",
+            legacy: false,
           },
         ],
         packages: [

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -95,6 +95,7 @@ const CREDIT_TIERS: CreditTier[] = [
     credits_usd: 25,
     price_cents: 2500,
     lookup_key: "credits_25_lk",
+    legacy: false,
   },
   {
     tier: "credits_50",
@@ -102,6 +103,7 @@ const CREDIT_TIERS: CreditTier[] = [
     credits_usd: 50,
     price_cents: 5000,
     lookup_key: "credits_50_lk",
+    legacy: false,
   },
 ];
 

--- a/clients/web/src/domains/settings/components/credit-bundle-picker.test.tsx
+++ b/clients/web/src/domains/settings/components/credit-bundle-picker.test.tsx
@@ -28,6 +28,7 @@ const TIERS: CreditTier[] = [
     credits_usd: 10,
     price_cents: 1000,
     lookup_key: "credits_10",
+    legacy: false,
   },
   {
     tier: "credits_25",
@@ -35,6 +36,7 @@ const TIERS: CreditTier[] = [
     credits_usd: 25,
     price_cents: 2500,
     lookup_key: "credits_25",
+    legacy: false,
   },
   {
     tier: "credits_50",
@@ -42,6 +44,7 @@ const TIERS: CreditTier[] = [
     credits_usd: 50,
     price_cents: 5000,
     lookup_key: "credits_50",
+    legacy: false,
   },
   {
     tier: "credits_100",
@@ -49,6 +52,7 @@ const TIERS: CreditTier[] = [
     credits_usd: 100,
     price_cents: 10000,
     lookup_key: "credits_100",
+    legacy: false,
   },
   {
     tier: "credits_200",
@@ -56,6 +60,7 @@ const TIERS: CreditTier[] = [
     credits_usd: 200,
     price_cents: 20000,
     lookup_key: "credits_200",
+    legacy: false,
   },
 ];
 


### PR DESCRIPTION
## Summary

The plans-takeover custom-plan modal understated the monthly total for a Pro sub holding a **deprecated (non-selectable) credit bundle**: the catalog omitted non-selectable credit tiers, so the modal couldn't find/price the held bundle — it dropped that price from the recap and the total while the change still preserved the bundle on save (the customer was quoted *less* than they're billed). Platform PR #9460 (merged) flags held/deprecated credit tiers with `legacy: true`; this PR consumes that flag to price and display the held bundle correctly.

## What changed

- **Schema sync** — `CreditTier.legacy` (from platform #9460) lands in `platform.yaml` + `platform-source.json`, and 6 test fixtures get `legacy: false`.
- **`custom-plan-modal.tsx`** — split `allCreditTiers` (full list, used for pricing/lookup) from `selectableCreditTiers = allCreditTiers.filter(t => !t.legacy)` (used for the picker). The price lookup now searches the full list, so a held bundle's `price_cents` flows into the recap total; the picker excludes legacy tiers and appends the currently-held one as a **disabled** option so it shows the current selection without ever offering it to a new config.
- **Tests** — held bundle is priced in the recap + total, shown disabled in the dropdown, never offered to new configs, and preserved on Continue; non-legacy subs are unaffected.

## Notes

- **Supersedes the automated sync PR #38735.** This PR carries the identical schema diff (same `sourceSha` `32404bc0cb08`) plus the fixture fixes the sync bot structurally can't add — which is why #38735's Type Check is red in isolation. Once this merges, #38735's diff is empty and it will be closed.
- Second half of the `held-credit-tier-pricing` plan (platform PR #9460 + this web PR).

## Verification

- CI green on the source branch: Type Check, Test, Lint, Build, Socket.
- Fresh-eyes self-review: **MINOR — ship as-is** (no blockers/majors); the one flagged comment was reworded to current-state framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
