### PR TITLE
Single-source live conversations broadcasts; nuke dead conversation responses

### DIFF
--- a/assistant/src/__tests__/assistant-events-sse-shed.test.ts
+++ b/assistant/src/__tests__/assistant-events-sse-shed.test.ts
@@ -86,7 +86,7 @@ describe("SSE route — backpressure shed observability", () => {
     // publishing `SSE_HIGH_WATER_MARK` events triggers the shed on the
     // final publish when desiredSize hits 0.
     for (let i = 0; i < SSE_HIGH_WATER_MARK; i += 1) {
-      await hub.publish(buildAssistantEvent({ type: "pong" }));
+      await hub.publish(buildAssistantEvent({ type: "message_complete" }));
     }
 
     expect(hub.subscriberCount()).toBe(0);
@@ -119,7 +119,7 @@ describe("SSE route — backpressure shed observability", () => {
     // Fill the queue up to its limit without sending the publish that
     // would shed via the callback path.
     for (let i = 0; i < SSE_HIGH_WATER_MARK - 1; i += 1) {
-      await hub.publish(buildAssistantEvent({ type: "pong" }));
+      await hub.publish(buildAssistantEvent({ type: "message_complete" }));
     }
     expect(reports.length).toBe(0);
 
@@ -149,7 +149,7 @@ describe("SSE route — backpressure shed observability", () => {
     void reader.read();
 
     for (let i = 0; i < 32; i += 1) {
-      await hub.publish(buildAssistantEvent({ type: "pong" }));
+      await hub.publish(buildAssistantEvent({ type: "message_complete" }));
       void reader.read();
     }
 
@@ -177,7 +177,7 @@ describe("SSE route — backpressure shed observability", () => {
     );
 
     for (let i = 0; i < SSE_HIGH_WATER_MARK; i += 1) {
-      await hub.publish(buildAssistantEvent({ type: "pong" }));
+      await hub.publish(buildAssistantEvent({ type: "message_complete" }));
     }
 
     expect(reports.length).toBe(1);

--- a/assistant/src/__tests__/daemon-assistant-events.test.ts
+++ b/assistant/src/__tests__/daemon-assistant-events.test.ts
@@ -36,14 +36,14 @@ describe("buildAssistantEvent", () => {
   });
 
   test("generates unique ids for each call", () => {
-    const msg: ServerMessage = { type: "pong" };
+    const msg: ServerMessage = { type: "message_complete" };
     const a = buildAssistantEvent(msg);
     const b = buildAssistantEvent(msg);
     expect(a.id).not.toBe(b.id);
   });
 
   test("conversationId is undefined when omitted", () => {
-    const msg: ServerMessage = { type: "pong" };
+    const msg: ServerMessage = { type: "message_complete" };
     const event = buildAssistantEvent(msg);
     expect(event.conversationId).toBeUndefined();
   });
@@ -87,7 +87,7 @@ describe("daemon send → one mirrored assistant event", () => {
       },
     });
 
-    const msg: ServerMessage = { type: "pong" }; // no conversationId field
+    const msg: ServerMessage = { type: "message_complete" }; // no conversationId field
     const event = buildAssistantEvent(msg, "sess_explicit");
 
     await hub.publish(event);

--- a/assistant/src/__tests__/runtime-events-sse-bilingual.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-bilingual.test.ts
@@ -55,7 +55,7 @@ describe("GET /v1/events — bilingual scope query params", () => {
 
     // Publish an event scoped to that conversation — should be delivered.
     await testHub.publish(
-      buildAssistantEvent({ type: "pong" }, conversationId),
+      buildAssistantEvent({ type: "message_complete" }, conversationId),
     );
 
     const { value, done } = await reader.read();
@@ -102,9 +102,13 @@ describe("GET /v1/events — bilingual scope query params", () => {
 
     // Publish on the "key" conversation — should NOT be delivered (filter
     // is locked to idConv because conversationId wins).
-    await testHub.publish(buildAssistantEvent({ type: "pong" }, keyConv));
+    await testHub.publish(
+      buildAssistantEvent({ type: "message_complete" }, keyConv),
+    );
     // Publish on the "id" conversation — should be delivered.
-    await testHub.publish(buildAssistantEvent({ type: "pong" }, idConv));
+    await testHub.publish(
+      buildAssistantEvent({ type: "message_complete" }, idConv),
+    );
 
     const { value } = await reader.read();
     ac.abort();

--- a/assistant/src/__tests__/runtime-events-sse-reconnect.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-reconnect.test.ts
@@ -52,9 +52,9 @@ describe("SSE reconnect replay (B7.2)", () => {
     // broadcast prior to the client's reconnect. Seqs start at 1, so
     // these get seqs 1, 2, 3.
     const events = [
-      buildAssistantEvent({ type: "pong" }, conversationId),
-      buildAssistantEvent({ type: "pong" }, conversationId),
-      buildAssistantEvent({ type: "pong" }, conversationId),
+      buildAssistantEvent({ type: "message_complete" }, conversationId),
+      buildAssistantEvent({ type: "message_complete" }, conversationId),
+      buildAssistantEvent({ type: "message_complete" }, conversationId),
     ];
     for (const event of events) stampAndBuffer(event);
 
@@ -96,10 +96,10 @@ describe("SSE reconnect replay (B7.2)", () => {
     const { conversationId: convA } = getOrCreateConversation("multi-conv-a");
     const { conversationId: convB } = getOrCreateConversation("multi-conv-b");
 
-    stampAndBuffer(buildAssistantEvent({ type: "pong" }, convA)); // seq 1
-    stampAndBuffer(buildAssistantEvent({ type: "pong" }, convB)); // seq 2
-    stampAndBuffer(buildAssistantEvent({ type: "pong" }, convA)); // seq 3
-    stampAndBuffer(buildAssistantEvent({ type: "pong" }, convB)); // seq 4
+    stampAndBuffer(buildAssistantEvent({ type: "message_complete" }, convA)); // seq 1
+    stampAndBuffer(buildAssistantEvent({ type: "message_complete" }, convB)); // seq 2
+    stampAndBuffer(buildAssistantEvent({ type: "message_complete" }, convA)); // seq 3
+    stampAndBuffer(buildAssistantEvent({ type: "message_complete" }, convB)); // seq 4
 
     const ac = new AbortController();
     const { handleSubscribeAssistantEvents } =
@@ -145,7 +145,9 @@ describe("SSE reconnect replay (B7.2)", () => {
     // count-based eviction (cap 200) drops seqs 1 and 2. A cursor of
     // 0 then falls outside what getReplayWindow can serve.
     for (let i = 0; i < 202; i++) {
-      stampAndBuffer(buildAssistantEvent({ type: "pong" }, conversationId));
+      stampAndBuffer(
+        buildAssistantEvent({ type: "message_complete" }, conversationId),
+      );
     }
     const { _peekStreamForTesting } =
       await import("../runtime/assistant-stream-state.js");
@@ -178,8 +180,12 @@ describe("SSE reconnect replay (B7.2)", () => {
     const { conversationId } = getOrCreateConversation("reconnect-noparam");
 
     // Pre-fill the ring -- without the cursor, these MUST NOT be replayed.
-    stampAndBuffer(buildAssistantEvent({ type: "pong" }, conversationId));
-    stampAndBuffer(buildAssistantEvent({ type: "pong" }, conversationId));
+    stampAndBuffer(
+      buildAssistantEvent({ type: "message_complete" }, conversationId),
+    );
+    stampAndBuffer(
+      buildAssistantEvent({ type: "message_complete" }, conversationId),
+    );
 
     const ac = new AbortController();
     const { handleSubscribeAssistantEvents } =
@@ -202,8 +208,14 @@ describe("SSE reconnect replay (B7.2)", () => {
     const { conversationId } = getOrCreateConversation("reconnect-dedup");
 
     // Stamp two events. Seqs start at 1, so eventA=1 and eventB=2.
-    const eventA = buildAssistantEvent({ type: "pong" }, conversationId);
-    const eventB = buildAssistantEvent({ type: "pong" }, conversationId);
+    const eventA = buildAssistantEvent(
+      { type: "message_complete" },
+      conversationId,
+    );
+    const eventB = buildAssistantEvent(
+      { type: "message_complete" },
+      conversationId,
+    );
     stampAndBuffer(eventA); // seq 1
     stampAndBuffer(eventB); // seq 2
 
@@ -240,7 +252,10 @@ describe("SSE reconnect replay (B7.2)", () => {
     // SHOULD be delivered.
     await testHub.publish(eventB);
 
-    const eventC = buildAssistantEvent({ type: "pong" }, conversationId);
+    const eventC = buildAssistantEvent(
+      { type: "message_complete" },
+      conversationId,
+    );
     stampAndBuffer(eventC); // seq 3
     await testHub.publish(eventC);
 
@@ -258,11 +273,18 @@ describe("SSE reconnect replay (B7.2)", () => {
     // seq 2. The subscriber receives seq 1 and 3.
     const { conversationId } = getOrCreateConversation("replay-targeting");
 
-    stampAndBuffer(buildAssistantEvent({ type: "pong" }, conversationId));
-    stampAndBuffer(buildAssistantEvent({ type: "pong" }, conversationId), {
-      targeting: { targetCapability: "host_bash" },
-    });
-    stampAndBuffer(buildAssistantEvent({ type: "pong" }, conversationId));
+    stampAndBuffer(
+      buildAssistantEvent({ type: "message_complete" }, conversationId),
+    );
+    stampAndBuffer(
+      buildAssistantEvent({ type: "message_complete" }, conversationId),
+      {
+        targeting: { targetCapability: "host_bash" },
+      },
+    );
+    stampAndBuffer(
+      buildAssistantEvent({ type: "message_complete" }, conversationId),
+    );
 
     const ac = new AbortController();
     const { handleSubscribeAssistantEvents } =
@@ -315,8 +337,14 @@ describe("SSE reconnect replay (B7.2)", () => {
     expect(heartbeat).toBe(": heartbeat\n\n");
 
     // Publish two live events with seq via stampAndBuffer.
-    const e1 = buildAssistantEvent({ type: "pong" }, conversationId);
-    const e2 = buildAssistantEvent({ type: "pong" }, conversationId);
+    const e1 = buildAssistantEvent(
+      { type: "message_complete" },
+      conversationId,
+    );
+    const e2 = buildAssistantEvent(
+      { type: "message_complete" },
+      conversationId,
+    );
     stampAndBuffer(e1);
     stampAndBuffer(e2);
     await testHub.publish(e1);

--- a/assistant/src/__tests__/runtime-events-sse.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse.test.ts
@@ -110,7 +110,10 @@ describe("SSE assistant-events endpoint", () => {
 
     // start() is called synchronously during ReadableStream construction, so the
     // hub subscription is already registered before we publish.
-    const event = buildAssistantEvent({ type: "pong" }, conversationId);
+    const event = buildAssistantEvent(
+      { type: "message_complete" },
+      conversationId,
+    );
     await assistantEventHub.publish(event);
 
     // Read the first frame directly from the stream.
@@ -129,7 +132,7 @@ describe("SSE assistant-events endpoint", () => {
     const frame = new TextDecoder().decode(value);
     expect(frame).toContain("event: assistant_event");
     expect(frame).toContain(`"conversationId":"${conversationId}"`);
-    expect(frame).toContain('"type":"pong"');
+    expect(frame).toContain('"type":"message_complete"');
   });
 
   // ── Unfiltered subscription ──────────────────────────────────────────────
@@ -157,8 +160,14 @@ describe("SSE assistant-events endpoint", () => {
     expect(new TextDecoder().decode(heartbeat.value)).toBe(": heartbeat\n\n");
 
     // Publish events with two different conversationIds.
-    const eventA = buildAssistantEvent({ type: "pong" }, "conversation-aaa");
-    const eventB = buildAssistantEvent({ type: "pong" }, "conversation-bbb");
+    const eventA = buildAssistantEvent(
+      { type: "message_complete" },
+      "conversation-aaa",
+    );
+    const eventB = buildAssistantEvent(
+      { type: "message_complete" },
+      "conversation-bbb",
+    );
     await testHub.publish(eventA);
     await testHub.publish(eventB);
 

--- a/assistant/src/api/events/assistant-status.ts
+++ b/assistant/src/api/events/assistant-status.ts
@@ -1,0 +1,20 @@
+/**
+ * `assistant_status` SSE event.
+ *
+ * Server → client status announcement carrying the daemon `version`
+ * and, when present, the assistant's key `keyFingerprint`.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const AssistantStatusEventSchema = z.object({
+  type: z.literal("assistant_status"),
+  version: z.string().optional(),
+  keyFingerprint: z.string().optional(),
+});
+
+export type AssistantStatusEvent = z.infer<typeof AssistantStatusEventSchema>;

--- a/assistant/src/api/events/context-compacted.ts
+++ b/assistant/src/api/events/context-compacted.ts
@@ -1,0 +1,38 @@
+/**
+ * `context_compacted` SSE event.
+ *
+ * Server → client notification that a conversation's context was
+ * compacted, carrying before/after token counts and the summary-LLM
+ * cost, plus optional quality signals about the produced summary.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const ContextCompactedEventSchema = z.object({
+  type: z.literal("context_compacted"),
+  conversationId: z.string(),
+  previousEstimatedInputTokens: z.number(),
+  estimatedInputTokens: z.number(),
+  maxInputTokens: z.number(),
+  thresholdTokens: z.number(),
+  compactedMessages: z.number(),
+  summaryCalls: z.number(),
+  summaryInputTokens: z.number(),
+  summaryOutputTokens: z.number(),
+  summaryModel: z.string(),
+  /**
+   * Quality signals for the generated summary. Emitted for every
+   * compaction (including truncation-only paths where the summary text
+   * is unchanged from the prior pass). Consumers can use these to detect
+   * regressions without needing to read the summary text itself.
+   */
+  summaryCharCount: z.number().optional(),
+  summaryHeaderCount: z.number().optional(),
+  summaryHadMemoryEcho: z.boolean().optional(),
+});
+
+export type ContextCompactedEvent = z.infer<typeof ContextCompactedEventSchema>;

--- a/assistant/src/api/events/model-info.ts
+++ b/assistant/src/api/events/model-info.ts
@@ -1,0 +1,39 @@
+/**
+ * `model_info` SSE event.
+ *
+ * Server → client snapshot of the active model/provider for a
+ * conversation, plus the catalog of configured and available providers
+ * and models the client can offer as options.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+const ModelOptionSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+});
+
+const ProviderCatalogEntrySchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  models: z.array(ModelOptionSchema),
+  defaultModel: z.string(),
+  apiKeyUrl: z.string().optional(),
+  apiKeyPlaceholder: z.string().optional(),
+});
+
+export const ModelInfoEventSchema = z.object({
+  type: z.literal("model_info"),
+  conversationId: z.string().optional(),
+  model: z.string(),
+  provider: z.string(),
+  configuredProviders: z.array(z.string()).optional(),
+  availableModels: z.array(ModelOptionSchema).optional(),
+  allProviders: z.array(ProviderCatalogEntrySchema).optional(),
+});
+
+export type ModelInfoEvent = z.infer<typeof ModelInfoEventSchema>;

--- a/assistant/src/api/events/schedule-conversation-created.ts
+++ b/assistant/src/api/events/schedule-conversation-created.ts
@@ -1,0 +1,24 @@
+/**
+ * `schedule_conversation_created` SSE event.
+ *
+ * Server → client broadcast emitted when a schedule creates a
+ * conversation, so clients can surface it. Carries the new
+ * `conversationId`, the originating `scheduleJobId`, and the `title`.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const ScheduleConversationCreatedEventSchema = z.object({
+  type: z.literal("schedule_conversation_created"),
+  conversationId: z.string(),
+  scheduleJobId: z.string(),
+  title: z.string(),
+});
+
+export type ScheduleConversationCreatedEvent = z.infer<
+  typeof ScheduleConversationCreatedEventSchema
+>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -6,6 +6,7 @@ import { AcpSessionSpawnedEventSchema } from "./events/acp-session-spawned.js";
 import { AcpSessionUpdateEventSchema } from "./events/acp-session-update.js";
 import { AcpSessionUsageEventSchema } from "./events/acp-session-usage.js";
 import { AssistantActivityStateEventSchema } from "./events/assistant-activity-state.js";
+import { AssistantStatusEventSchema } from "./events/assistant-status.js";
 import { AssistantTextDeltaEventSchema } from "./events/assistant-text-delta.js";
 import { AssistantThinkingDeltaEventSchema } from "./events/assistant-thinking-delta.js";
 import { AssistantTurnStartEventSchema } from "./events/assistant-turn-start.js";
@@ -22,6 +23,7 @@ import { ConfirmationRequestEventSchema } from "./events/confirmation-request.js
 import { ConfirmationStateChangedEventSchema } from "./events/confirmation-state-changed.js";
 import { ContactRequestEventSchema } from "./events/contact-request.js";
 import { ContactsChangedEventSchema } from "./events/contacts-changed.js";
+import { ContextCompactedEventSchema } from "./events/context-compacted.js";
 import { ConversationErrorEventSchema } from "./events/conversation-error.js";
 import { ConversationInferenceProfileUpdatedEventSchema } from "./events/conversation-inference-profile-updated.js";
 import { ConversationListInvalidatedEventSchema } from "./events/conversation-list-invalidated.js";
@@ -77,6 +79,7 @@ import { MessageQueuedEventSchema } from "./events/message-queued.js";
 import { MessageQueuedDeletedEventSchema } from "./events/message-queued-deleted.js";
 import { MessageRequestCompleteEventSchema } from "./events/message-request-complete.js";
 import { MessageSteeredEventSchema } from "./events/message-steered.js";
+import { ModelInfoEventSchema } from "./events/model-info.js";
 import { NavigateSettingsEventSchema } from "./events/navigate-settings.js";
 import { NotificationConversationCreatedEventSchema } from "./events/notification-conversation-created.js";
 import { NotificationIntentEventSchema } from "./events/notification-intent.js";
@@ -91,6 +94,7 @@ import {
   RecordingStopEventSchema,
 } from "./events/recording.js";
 import { RelationshipStateUpdatedEventSchema } from "./events/relationship-state-updated.js";
+import { ScheduleConversationCreatedEventSchema } from "./events/schedule-conversation-created.js";
 import { SecretRequestEventSchema } from "./events/secret-request.js";
 import { ServiceGroupUpdateCompleteEventSchema } from "./events/service-group-update-complete.js";
 import { ServiceGroupUpdateProgressEventSchema } from "./events/service-group-update-progress.js";
@@ -166,6 +170,10 @@ export {
   type AssistantOutboundAttachment,
   AssistantOutboundAttachmentSchema,
 } from "./events/assistant-outbound-attachment.js";
+export {
+  type AssistantStatusEvent,
+  AssistantStatusEventSchema,
+} from "./events/assistant-status.js";
 export {
   type AssistantTextDeltaEvent,
   AssistantTextDeltaEventSchema,
@@ -246,6 +254,10 @@ export {
   type ContactsChangedEvent,
   ContactsChangedEventSchema,
 } from "./events/contacts-changed.js";
+export {
+  type ContextCompactedEvent,
+  ContextCompactedEventSchema,
+} from "./events/context-compacted.js";
 export {
   type ConversationErrorCode,
   ConversationErrorCodeSchema,
@@ -419,6 +431,10 @@ export {
   MessageSteeredEventSchema,
 } from "./events/message-steered.js";
 export {
+  type ModelInfoEvent,
+  ModelInfoEventSchema,
+} from "./events/model-info.js";
+export {
   type NavigateSettingsEvent,
   NavigateSettingsEventSchema,
 } from "./events/navigate-settings.js";
@@ -463,6 +479,10 @@ export {
   type RelationshipStateUpdatedEvent,
   RelationshipStateUpdatedEventSchema,
 } from "./events/relationship-state-updated.js";
+export {
+  type ScheduleConversationCreatedEvent,
+  ScheduleConversationCreatedEventSchema,
+} from "./events/schedule-conversation-created.js";
 export {
   type SecretRequestEvent,
   SecretRequestEventSchema,
@@ -816,6 +836,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   AcpSessionUpdateEventSchema,
   AcpSessionUsageEventSchema,
   AssistantActivityStateEventSchema,
+  AssistantStatusEventSchema,
   AssistantTextDeltaEventSchema,
   AssistantThinkingDeltaEventSchema,
   AssistantTurnStartEventSchema,
@@ -832,6 +853,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   ConfirmationStateChangedEventSchema,
   ContactRequestEventSchema,
   ContactsChangedEventSchema,
+  ContextCompactedEventSchema,
   ConversationErrorEventSchema,
   ConversationInferenceProfileUpdatedEventSchema,
   ConversationListInvalidatedEventSchema,
@@ -873,6 +895,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   MessageQueuedDeletedEventSchema,
   MessageRequestCompleteEventSchema,
   MessageSteeredEventSchema,
+  ModelInfoEventSchema,
   NavigateSettingsEventSchema,
   NotificationConversationCreatedEventSchema,
   NotificationIntentEventSchema,
@@ -885,6 +908,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   RecordingStartEventSchema,
   RecordingStopEventSchema,
   RelationshipStateUpdatedEventSchema,
+  ScheduleConversationCreatedEventSchema,
   SecretRequestEventSchema,
   ServiceGroupUpdateCompleteEventSchema,
   ServiceGroupUpdateProgressEventSchema,

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -1,14 +1,18 @@
 // Conversation lifecycle, auth, model config, and history types.
 
+import type { AssistantStatusEvent } from "../../api/events/assistant-status.js";
 import type { CompactionCircuitClosedEvent } from "../../api/events/compaction-circuit-closed.js";
 import type { CompactionCircuitOpenEvent } from "../../api/events/compaction-circuit-open.js";
+import type { ContextCompactedEvent } from "../../api/events/context-compacted.js";
 import type { ConversationErrorEvent } from "../../api/events/conversation-error.js";
 import type { ConversationListInvalidatedEvent } from "../../api/events/conversation-list-invalidated.js";
 import type { ConversationNoticeEvent } from "../../api/events/conversation-notice.js";
 import type { ConversationTitleUpdatedEvent } from "../../api/events/conversation-title-updated.js";
 import type { GenerationCancelledEvent } from "../../api/events/generation-cancelled.js";
 import type { GenerationHandoffEvent } from "../../api/events/generation-handoff.js";
+import type { ModelInfoEvent } from "../../api/events/model-info.js";
 import type { OpenConversationEvent } from "../../api/events/open-conversation.js";
+import type { ScheduleConversationCreatedEvent } from "../../api/events/schedule-conversation-created.js";
 import type { UsageProgressEvent } from "../../api/events/usage-progress.js";
 import type { UsageUpdateEvent } from "../../api/events/usage-update.js";
 import type {
@@ -164,18 +168,6 @@ export interface ImageGenModelSetRequest {
   model: string;
 }
 
-export interface MessageContentResponse {
-  type: "message_content_response";
-  conversationId: string;
-  messageId: string;
-  text?: string;
-  toolCalls?: Array<{
-    name: string;
-    result?: string;
-    input?: Record<string, unknown>;
-  }>;
-}
-
 export interface UndoRequest {
   type: "undo";
   conversationId: string;
@@ -200,27 +192,6 @@ export interface ReorderConversationsRequest {
 }
 
 // === Server → Client ===
-
-interface ConversationSearchMatchingMessage {
-  messageId: string;
-  role: string;
-  /** Plain-text excerpt around the match, truncated to ~200 chars. */
-  excerpt: string;
-  createdAt: number;
-}
-
-interface ConversationSearchResultItem {
-  conversationId: string;
-  conversationTitle: string | null;
-  conversationUpdatedAt: number;
-  matchingMessages: ConversationSearchMatchingMessage[];
-}
-
-export interface ConversationSearchResponse {
-  type: "conversation_search_response";
-  query: string;
-  results: ConversationSearchResultItem[];
-}
 
 export interface ConversationInfo {
   type: "conversation_info";
@@ -301,44 +272,6 @@ export interface ConversationListResponse {
   }>;
   /** Whether more conversations exist beyond the returned page. */
   hasMore?: boolean;
-}
-
-export interface ConversationsClearResponse {
-  type: "conversations_clear_response";
-  cleared: number;
-}
-
-export interface AuthResult {
-  type: "auth_result";
-  success: boolean;
-  message?: string;
-}
-
-export interface PongMessage {
-  type: "pong";
-}
-
-export interface AssistantStatusMessage {
-  type: "assistant_status";
-  version?: string;
-  keyFingerprint?: string;
-}
-
-export interface ModelInfo {
-  type: "model_info";
-  conversationId?: string;
-  model: string;
-  provider: string;
-  configuredProviders?: string[];
-  availableModels?: Array<{ id: string; displayName: string }>;
-  allProviders?: Array<{
-    id: string;
-    displayName: string;
-    models: Array<{ id: string; displayName: string }>;
-    defaultModel: string;
-    apiKeyUrl?: string;
-    apiKeyPlaceholder?: string;
-  }>;
 }
 
 interface HistoryResponseToolCall {
@@ -449,43 +382,6 @@ export interface UsageResponse {
 }
 
 /**
- * Emitted after a compaction turn completes (both auto-compaction and
- * `/compact`). Carries the fresh `estimatedInputTokens` so clients can refresh
- * the context-window indicator without waiting for the next `usage_update`.
- *
- * Scoped per-conversation — see `CompactionCircuitOpenEvent` doc for why.
- */
-export interface ContextCompacted {
-  type: "context_compacted";
-  conversationId: string;
-  previousEstimatedInputTokens: number;
-  estimatedInputTokens: number;
-  maxInputTokens: number;
-  thresholdTokens: number;
-  compactedMessages: number;
-  summaryCalls: number;
-  summaryInputTokens: number;
-  summaryOutputTokens: number;
-  summaryModel: string;
-  /**
-   * Quality signals for the generated summary. Emitted for every
-   * compaction (including truncation-only paths where the summary text
-   * is unchanged from the prior pass). Consumers can use these to detect
-   * regressions without needing to read the summary text itself.
-   *
-   * - `summaryCharCount`: length of the produced summary text.
-   * - `summaryHeaderCount`: number of `## ` section headers in the summary.
-   * - `summaryHadMemoryEcho`: `true` if the summary contains any runtime
-   *   injection tag (e.g. `<memory`, `<turn_context>`, `<workspace>`). The
-   *   durable summary should be clean prose, so `true` flags an echoed or
-   *   invented tag worth investigating.
-   */
-  summaryCharCount?: number;
-  summaryHeaderCount?: number;
-  summaryHadMemoryEcho?: boolean;
-}
-
-/**
  * Emitted when the compaction circuit breaker trips. After three consecutive
  * summary-LLM failures (with local fallback covering each), auto-compaction is
  * suspended until `openUntil` to avoid repeatedly hammering a broken provider.
@@ -497,14 +393,6 @@ export interface ContextCompacted {
  * conversation would set the "auto-compaction paused" banner on every open
  * `ChatViewModel`.
  */
-
-/** Server push — broadcast when a schedule creates a conversation. */
-export interface ScheduleConversationCreated {
-  type: "schedule_conversation_created";
-  conversationId: string;
-  scheduleJobId: string;
-  title: string;
-}
 
 // `open_conversation` is a migrated event: its canonical wire contract lives
 // in `../../api/events/open-conversation.ts` (imported as
@@ -530,18 +418,16 @@ export type _ConversationsClientMessages =
   | ReorderConversationsRequest;
 
 export type _ConversationsServerMessages =
-  | AuthResult
-  | PongMessage
-  | AssistantStatusMessage
+  | AssistantStatusEvent
   | GenerationCancelledEvent
   | GenerationHandoffEvent
-  | ModelInfo
+  | ModelInfoEvent
   | HistoryResponse
   | UndoComplete
   | UsageUpdateEvent
   | UsageProgressEvent
   | UsageResponse
-  | ContextCompacted
+  | ContextCompactedEvent
   | CompactionCircuitOpenEvent
   | CompactionCircuitClosedEvent
   | ConversationErrorEvent
@@ -549,9 +435,6 @@ export type _ConversationsServerMessages =
   | ConversationInfo
   | ConversationTitleUpdatedEvent
   | ConversationListResponse
-  | ConversationsClearResponse
-  | ConversationSearchResponse
-  | MessageContentResponse
   | ConversationListInvalidatedEvent
-  | ScheduleConversationCreated
+  | ScheduleConversationCreatedEvent
   | OpenConversationEvent;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -478,6 +478,14 @@ export function useStreamEventHandler(
         case "confirmation_state_changed":
         case "conversation_inference_profile_updated":
           break;
+        // Daemon status / model-catalog / compaction / schedule-created signals.
+        // The web chat handler is a no-op — these are surfaced elsewhere or not
+        // rendered by the web today.
+        case "assistant_status":
+        case "model_info":
+        case "context_compacted":
+        case "schedule_conversation_created":
+          break;
         // Host-proxy instructions targeting the desktop client / chrome
         // extension. The web chat handler is a no-op — host-proxy frames are
         // delivered to their capability holder by the hub, not through the

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -109,6 +109,13 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   // host_browser_cancel carries no `conversationId` (only a requestId), so it
   // must be gated as global; the other host-proxy frames carry one.
   "host_browser_cancel",
+  // Daemon status, model catalog, and schedule-created broadcasts are not tied
+  // to the active conversation stream (assistant_status / model_info carry no or
+  // optional conversationId; schedule_conversation_created announces a *new*
+  // conversation), so gate them as global.
+  "assistant_status",
+  "model_info",
+  "schedule_conversation_created",
   // Settings/config broadcasts (client-setting push, config.json change, sounds
   // change) carry no `conversationId` — they're app-wide, not conversation-scoped.
   "client_settings_update",


### PR DESCRIPTION
## Why

Continues the event-type unification effort into the `conversations` domain — the messiest big domain, entangled with the legacy CLI socket protocol. This does the safe, clean slice: migrate the live broadcasts, delete the provably-dead types, and defer the CLI-protocol reconciliation.

## What

**Migrated (live) → new `api/events` schemas, registered in `AssistantEventSchema`:**
- `assistant_status` (from `daemon/status`)
- `model_info` (from `conversation-process`)
- `context_compacted` (from `conversation-agent-loop`)
- `schedule_conversation_created` (from `schedule/scheduler`)

**Removed (dead — no daemon producer anywhere):**
- `auth_result`, `pong`, `conversations_clear_response`, `conversation_search_response`, `message_content_response`, plus the now-orphaned `ConversationSearch*` helper shapes.

`pong` had no production emitter but was the throwaway minimal fixture across the SSE test suite; those fixtures now use `message_complete` (a real minimal event) so the dead type can go.

## Deliberately deferred

The remaining local response types — `history_response`, `undo_complete`, `usage_response`, `conversation_info`, `conversation_list_response` — stay for now. They have **vestigial `cli.ts` switch cases but no daemon producer**, so the daemon never sends them and the CLI cases are dead. Retiring them cleanly (removing the CLI cases and their paired client-request messages) is a focused CLI-socket-protocol cleanup, not part of this event migration.

## Web

The four migrated events aren't tied to the active conversation stream (`assistant_status`/`model_info` carry no/optional `conversationId`; `schedule_conversation_created` announces a *new* conversation), so those three join the global stream-event set, and all four get no-op cases in the chat handler's exhaustive switch.

## Safety

No wire change for the live events (schemas transcribed 1:1). Repo-wide grep confirms zero references to any removed type. SSE test fixtures migrated off `pong` and pass. Clean `typecheck:fast` + web `tsc` (fresh `openapi-ts`), eslint, prettier, `generate:openapi --check` (unchanged), api-events + SSE (parity/reconnect/bilingual/shed) suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_