### PR TITLE
feat(service-contracts): browser-safe secret-detection module (patterns + token-shape + draft scanner)

### DIFF
--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -17,6 +17,7 @@
     "./rpc": "./src/rpc.ts",
     "./attachment-naming": "./src/attachment-naming.ts",
     "./redacted-credential": "./src/redacted-credential.ts",
+    "./secret-detection": "./src/secret-detection.ts",
     "./error": "./src/error.ts"
   },
   "scripts": {

--- a/packages/service-contracts/src/__tests__/secret-detection.test.ts
+++ b/packages/service-contracts/src/__tests__/secret-detection.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+
+// Self-referencing package import — proves the `./secret-detection` subpath
+// export resolves for consumers.
+import * as subpathExport from "@vellumai/service-contracts/secret-detection";
+
+import {
+  detectSecretsInText,
+  PREFIX_PATTERNS,
+  TOKEN_SHAPE,
+} from "../secret-detection.js";
+
+// All fixtures below are synthetic lookalike tokens — never real key material.
+
+function matchingLabels(text: string): string[] {
+  return PREFIX_PATTERNS.filter((p) => p.regex.test(text)).map((p) => p.label);
+}
+
+const ALNUM = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+/** Lowercase-alphanumeric filler of the given length (no separators, so it
+ * can never form another pattern's prefix like `npm_` or `key-`). */
+function filler(length: number): string {
+  return ALNUM.repeat(Math.ceil(length / ALNUM.length)).slice(0, length);
+}
+
+/** One synthetic fixture per provider family, keyed by pattern label. */
+const FIXTURES: Record<string, string> = {
+  "AWS Access Key": "AKIAABCDEFGHIJKLMNOP",
+  "GitHub Token": `ghp_${filler(36)}`,
+  "GitHub Fine-Grained PAT": `github_pat_${filler(22)}`,
+  "GitLab Token": `glpat-${filler(20)}`,
+  "Stripe Secret Key": `sk_live_${filler(24)}`,
+  "Stripe Restricted Key": `rk_live_${filler(24)}`,
+  "Slack Bot Token": `xoxb-1234567890-1234567890-${filler(24)}`,
+  "Slack User Token": `xoxp-1234567890-1234567890-1234567890-${"0123456789abcdef".repeat(2)}`,
+  "Slack App Token": "xapp-1-abc123-4567-defghij890",
+  "Telegram Bot Token": `123456789:${filler(35)}`,
+  "Anthropic API Key": `sk-ant-${filler(80)}`,
+  "OpenAI API Key": `sk-${filler(20)}T3BlbkFJ${filler(20)}`,
+  "OpenAI Project Key": `sk-proj-${filler(40)}`,
+  "Google API Key": `AIza${filler(35)}`,
+  "Google OAuth Client Secret": `GOCSPX-${filler(28)}`,
+  "Twilio API Key": `SK${"0123456789abcdef".repeat(2)}`,
+  "SendGrid API Key": `SG.${filler(22)}.${filler(43)}`,
+  "Mailgun API Key": `key-${filler(32)}`,
+  "npm Token": `npm_${filler(36)}`,
+  "PyPI API Token": `pypi-${filler(50)}`,
+  "Private Key": "-----BEGIN OPENSSH PRIVATE KEY-----",
+  "Linear API Key": `lin_api_${filler(32)}`,
+  "Notion Integration Token": `ntn_${filler(40)}`,
+  "OpenRouter API Key": `sk-or-v1-${filler(40)}`,
+  "Vercel AI Gateway API Key": `vck_${filler(24)}`,
+  "Fireworks API Key": `fw_${filler(32)}`,
+  "Perplexity API Key": `pplx-${filler(40)}`,
+  "Tavily API Key": `tvly-${filler(20)}`,
+  "Firecrawl API Key": `fc-${filler(20)}`,
+};
+
+describe("subpath export", () => {
+  test("@vellumai/service-contracts/secret-detection resolves to this module", () => {
+    expect(subpathExport.PREFIX_PATTERNS).toBe(PREFIX_PATTERNS);
+    expect(subpathExport.detectSecretsInText).toBe(detectSecretsInText);
+  });
+});
+
+describe("PREFIX_PATTERNS", () => {
+  test("every pattern has a fixture", () => {
+    expect(Object.keys(FIXTURES).sort()).toEqual(
+      PREFIX_PATTERNS.map((p) => p.label).sort(),
+    );
+  });
+
+  test("pattern labels are unique", () => {
+    const labels = PREFIX_PATTERNS.map((p) => p.label);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  // Label-uniqueness invariant: each fixture matches exactly one pattern, so
+  // a detected value always maps to an unambiguous label.
+  for (const [label, fixture] of Object.entries(FIXTURES)) {
+    test(`${label} fixture matches exactly that pattern`, () => {
+      expect(matchingLabels(fixture)).toEqual([label]);
+    });
+  }
+
+  test("does not match a short vck_ string", () => {
+    expect(matchingLabels("vck_abc")).toEqual([]);
+  });
+});
+
+describe("detectSecretsInText — prefix patterns", () => {
+  for (const [label, fixture] of Object.entries(FIXTURES)) {
+    test(`detects a ${label} with the right label and span`, () => {
+      const text = `my key is ${fixture} thanks`;
+      const start = text.indexOf(fixture);
+      expect(detectSecretsInText(text)).toEqual([
+        {
+          label,
+          value: fixture,
+          start,
+          end: start + fixture.length,
+          wholeMessage: false,
+        },
+      ]);
+    });
+  }
+
+  test("does not mutate the shared pattern objects' lastIndex", () => {
+    detectSecretsInText(`ghp_${filler(36)}`);
+    for (const p of PREFIX_PATTERNS) {
+      expect(p.regex.lastIndex).toBe(0);
+    }
+  });
+});
+
+describe("detectSecretsInText — placeholder suppression", () => {
+  test("known placeholder text returns no matches", () => {
+    expect(detectSecretsInText("your-api-key-here")).toEqual([]);
+    expect(detectSecretsInText("sk-xxxxxxxxxxxxxxxxxxxxxxxx")).toEqual([]);
+  });
+
+  test("placeholder-prefixed token-shaped message is suppressed", () => {
+    expect(detectSecretsInText(`fake_key_${filler(20)}`)).toEqual([]);
+    expect(detectSecretsInText(`test_api_${filler(16)}`)).toEqual([]);
+    expect(detectSecretsInText(`dummy-token-${filler(16)}`)).toEqual([]);
+  });
+
+  test("token-shaped message with a placeholder tail is suppressed", () => {
+    // TOKEN_SHAPE matches with tail "replace_with_your_key", which is a
+    // known placeholder.
+    expect(detectSecretsInText("acme_key_replace_with_your_key")).toEqual([]);
+  });
+});
+
+describe("detectSecretsInText — whole-message token shape", () => {
+  test("a whole-message token-shaped value is detected", () => {
+    const token = `virlo_tkn_${filler(20)}`;
+    expect(TOKEN_SHAPE.test(token)).toBe(true);
+    expect(detectSecretsInText(token)).toEqual([
+      {
+        label: "Token-shaped message",
+        value: token,
+        start: 0,
+        end: token.length,
+        wholeMessage: true,
+      },
+    ]);
+  });
+
+  test("surrounding whitespace is trimmed and the span covers the token", () => {
+    const token = `acme_secret_${filler(18)}`;
+    expect(detectSecretsInText(`  ${token} \n`)).toEqual([
+      {
+        label: "Token-shaped message",
+        value: token,
+        start: 2,
+        end: 2 + token.length,
+        wholeMessage: true,
+      },
+    ]);
+  });
+
+  test("a normal sentence returns no matches", () => {
+    expect(
+      detectSecretsInText("can you review my pull request today?"),
+    ).toEqual([]);
+    expect(detectSecretsInText("")).toEqual([]);
+  });
+
+  test("token shape is not applied when a prefix pattern already matched", () => {
+    const key = `glpat-${filler(20)}`;
+    const results = detectSecretsInText(key);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.label).toBe("GitLab Token");
+  });
+});
+
+describe("detectSecretsInText — multiple and overlapping matches", () => {
+  test("multiple secrets yield sorted, non-overlapping matches", () => {
+    const aws = "AKIAABCDEFGHIJKLMNOP";
+    const github = `ghp_${filler(36)}`;
+    // GitHub appears before AWS in the text but after it in pattern order.
+    const text = `first ${github} then ${aws} done`;
+    const results = detectSecretsInText(text);
+    expect(results.map((r) => r.label)).toEqual([
+      "GitHub Token",
+      "AWS Access Key",
+    ]);
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i]!.start).toBeGreaterThanOrEqual(results[i - 1]!.end);
+    }
+  });
+
+  test("overlapping spans keep the first pattern in list order", () => {
+    // The GitHub token's tail embeds an `npm_…` run; GitHub Token precedes
+    // npm Token in PREFIX_PATTERNS, so only the GitHub match survives.
+    const value = `ghp_npm_${filler(36)}`;
+    const results = detectSecretsInText(value);
+    expect(results.map((r) => r.label)).toEqual(["GitHub Token"]);
+  });
+});

--- a/packages/service-contracts/src/secret-detection.ts
+++ b/packages/service-contracts/src/secret-detection.ts
@@ -1,0 +1,311 @@
+/**
+ * Shared prefix-based secret patterns — the single source of truth.
+ *
+ * Ingress blocking, tool output scanning, log redaction, and client-side
+ * composer detection all consume this list.  When adding a new integration,
+ * add its API key pattern here.
+ *
+ * This module is intentionally data-only: no imports, no entropy logic,
+ * no config — safe for hot-path consumers like log serializers, and
+ * browser-safe so web clients can bundle it directly.  The pattern values
+ * are shared verbatim by the daemon and web clients so client and server
+ * detection can never disagree.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SecretPrefixPattern {
+  /** Human-readable label shown in block notices and redaction tags. */
+  label: string;
+  /**
+   * Regex that matches the token value.  Must NOT include the `g` flag or
+   * capture groups — consumers add those as needed.
+   */
+  regex: RegExp;
+}
+
+// ---------------------------------------------------------------------------
+// Prefix patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * High-confidence, prefix-based secret patterns.
+ *
+ * Each entry matches a known API key / token format by its distinctive
+ * prefix.  Patterns that require surrounding context (entropy analysis,
+ * keyword proximity, URL structure) do NOT belong here — they stay in
+ * `secret-scanner.ts` as scanner-only patterns.
+ *
+ * **When adding a new third-party integration, add its API key pattern
+ * here.**  If the service uses only opaque OAuth access tokens (no fixed
+ * prefix), no pattern is needed.
+ */
+export const PREFIX_PATTERNS: SecretPrefixPattern[] = [
+  // -- AWS --
+  { label: "AWS Access Key", regex: /AKIA[0-9A-Z]{16}/ },
+
+  // -- GitHub --
+  { label: "GitHub Token", regex: /gh[pousr]_[A-Za-z0-9_]{36,}/ },
+  { label: "GitHub Fine-Grained PAT", regex: /github_pat_[A-Za-z0-9_]{22,}/ },
+
+  // -- GitLab --
+  { label: "GitLab Token", regex: /glpat-[A-Za-z0-9\-_]{20,}/ },
+
+  // -- Stripe --
+  { label: "Stripe Secret Key", regex: /sk_live_[A-Za-z0-9]{24,}/ },
+  { label: "Stripe Restricted Key", regex: /rk_live_[A-Za-z0-9]{24,}/ },
+
+  // -- Slack --
+  {
+    label: "Slack Bot Token",
+    regex: /xoxb-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{24,}/,
+  },
+  {
+    label: "Slack User Token",
+    regex: /xoxp-[0-9]{10,}-[0-9]{10,}-[0-9]{10,}-[a-f0-9]{32}/,
+  },
+  {
+    label: "Slack App Token",
+    regex: /xapp-[0-9]+-[A-Za-z0-9]+-[0-9]+-[A-Za-z0-9]+/,
+  },
+
+  // -- Telegram --
+  {
+    label: "Telegram Bot Token",
+    // Format: <bot_id>:<secret> where bot_id is 8–10 digits, secret is 35 chars
+    regex: /[0-9]{8,10}:[A-Za-z0-9_-]{35}/,
+  },
+
+  // -- Anthropic --
+  { label: "Anthropic API Key", regex: /sk-ant-[A-Za-z0-9\-_]{80,}/ },
+
+  // -- OpenAI --
+  {
+    label: "OpenAI API Key",
+    regex: /sk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}/,
+  },
+  { label: "OpenAI Project Key", regex: /sk-proj-[A-Za-z0-9\-_]{40,}/ },
+
+  // -- Google --
+  { label: "Google API Key", regex: /AIza[A-Za-z0-9\-_]{35}/ },
+  {
+    label: "Google OAuth Client Secret",
+    regex: /GOCSPX-[A-Za-z0-9\-_]{28}/,
+  },
+
+  // -- Twilio --
+  { label: "Twilio API Key", regex: /SK[0-9a-f]{32}/ },
+
+  // -- SendGrid --
+  {
+    label: "SendGrid API Key",
+    regex: /SG\.[A-Za-z0-9\-_]{22}\.[A-Za-z0-9\-_]{43}/,
+  },
+
+  // -- Mailgun --
+  { label: "Mailgun API Key", regex: /key-[A-Za-z0-9]{32}/ },
+
+  // -- npm --
+  { label: "npm Token", regex: /npm_[A-Za-z0-9]{36}/ },
+
+  // -- PyPI --
+  { label: "PyPI API Token", regex: /pypi-[A-Za-z0-9\-_]{50,}/ },
+
+  // -- Private keys --
+  {
+    label: "Private Key",
+    regex:
+      /-----BEGIN (?:RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY(?:\s+BLOCK)?-----/,
+  },
+
+  // -- Linear --
+  { label: "Linear API Key", regex: /lin_api_[A-Za-z0-9]{32,}/ },
+
+  // -- Notion --
+  { label: "Notion Integration Token", regex: /ntn_[A-Za-z0-9]{40,}/ },
+
+  // -- OpenRouter --
+  { label: "OpenRouter API Key", regex: /sk-or-v1-[A-Za-z0-9\-_]{40,}/ },
+
+  // -- Vercel AI Gateway --
+  { label: "Vercel AI Gateway API Key", regex: /vck_[A-Za-z0-9\-_]{24,}/ },
+
+  // -- Fireworks --
+  { label: "Fireworks API Key", regex: /fw_[A-Za-z0-9]{32,}/ },
+
+  // -- Perplexity --
+  { label: "Perplexity API Key", regex: /pplx-[A-Za-z0-9]{40,}/ },
+
+  // -- Tavily --
+  { label: "Tavily API Key", regex: /tvly-[A-Za-z0-9]{20,}/ },
+
+  // -- Firecrawl --
+  { label: "Firecrawl API Key", regex: /fc-[A-Za-z0-9]{20,}/ },
+];
+
+// ---------------------------------------------------------------------------
+// Token-shape heuristic (whole-message only)
+// ---------------------------------------------------------------------------
+
+/**
+ * A single token-shaped value: an alphanumeric head, a separator-delimited
+ * secret keyword infix, and a >=16-char tail (e.g. `virlo_tkn_JF…`). The
+ * capture group isolates the tail for placeholder checks. Applied only when
+ * the entire trimmed message is one such token — the whole-message and
+ * keyword-infix requirements keep false positives near zero without any
+ * entropy scoring.
+ */
+export const TOKEN_SHAPE =
+  /^[A-Za-z0-9][A-Za-z0-9_-]*[_-](?:tkn|token|key|secret|api|pat|sk|auth)[_-]([A-Za-z0-9_-]{16,})$/i;
+
+// ---------------------------------------------------------------------------
+// Placeholder suppression (ingress semantics: user-typed input, near-zero
+// false positives)
+// ---------------------------------------------------------------------------
+
+export const KNOWN_PLACEHOLDERS = new Set([
+  "your-api-key-here",
+  "your_api_key_here",
+  "insert-your-key-here",
+  "insert_your_key_here",
+  "replace-with-your-key",
+  "replace_with_your_key",
+  "xxx",
+  "xxxxxxxx",
+  "test",
+  "example",
+  "sample",
+  "demo",
+  "placeholder",
+  "changeme",
+  "CHANGEME",
+  "TODO",
+  "FIXME",
+  "your-token-here",
+  "your_token_here",
+  "my-api-key",
+  "my_api_key",
+]);
+
+export const PLACEHOLDER_PREFIXES = [
+  "sk-test-",
+  "sk_test_",
+  "fake_",
+  "fake-",
+  "dummy_",
+  "dummy-",
+  "test_",
+  "test-",
+  "example_",
+  "example-",
+  "sample_",
+  "sample-",
+  "mock_",
+  "mock-",
+];
+
+/**
+ * Check if a matched value is a placeholder/test value that should not be
+ * reported: exact `KNOWN_PLACEHOLDERS` membership or a `PLACEHOLDER_PREFIXES`
+ * prefix, case-insensitive.
+ */
+function isPlaceholderValue(value: string): boolean {
+  const lower = value.toLowerCase();
+  if (KNOWN_PLACEHOLDERS.has(lower)) {
+    return true;
+  }
+  for (const prefix of PLACEHOLDER_PREFIXES) {
+    if (lower.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Draft scanner
+// ---------------------------------------------------------------------------
+
+export interface DetectedSecret {
+  /** Human-readable secret type label, e.g. "Anthropic API Key". */
+  label: string;
+  /** The matched secret text. */
+  value: string;
+  /** Start offset of the match in the scanned text (inclusive). */
+  start: number;
+  /** End offset of the match in the scanned text (exclusive). */
+  end: number;
+  /** True when the entire trimmed text is one token-shaped value. */
+  wholeMessage: boolean;
+}
+
+/**
+ * Global clones of {@link PREFIX_PATTERNS}, compiled once so the draft
+ * scanner never mutates the shared pattern objects' `lastIndex` and never
+ * recompiles on the hot path (the composer scans on every draft change).
+ */
+const GLOBAL_PREFIX_PATTERNS: SecretPrefixPattern[] = PREFIX_PATTERNS.map(
+  ({ label, regex }) => ({
+    label,
+    regex: new RegExp(
+      regex.source,
+      regex.flags.includes("g") ? regex.flags : regex.flags + "g",
+    ),
+  }),
+);
+
+/**
+ * Scan a draft message for high-confidence secrets.
+ *
+ * Runs every `PREFIX_PATTERNS` entry over the text, suppressing placeholder
+ * values. When no prefix pattern matches, the trimmed whole message is
+ * tested against {@link TOKEN_SHAPE} — the same whole-message token-shape
+ * heuristic the daemon blocks at ingress. Overlapping spans are deduped
+ * (first pattern in list order wins); results are sorted by `start`.
+ */
+export function detectSecretsInText(text: string): DetectedSecret[] {
+  const matches: DetectedSecret[] = [];
+
+  for (const { label, regex } of GLOBAL_PREFIX_PATTERNS) {
+    // Reset lastIndex — the compiled global regexes are shared across calls.
+    regex.lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(text)) !== null) {
+      const value = match[0];
+      if (isPlaceholderValue(value)) {
+        continue;
+      }
+      const start = match.index;
+      const end = start + value.length;
+      // Overlap dedupe: the first pattern in list order wins.
+      if (matches.some((m) => start < m.end && end > m.start)) {
+        continue;
+      }
+      matches.push({ label, value, start, end, wholeMessage: false });
+    }
+  }
+
+  if (matches.length === 0) {
+    const trimmed = text.trim();
+    const shapeMatch = TOKEN_SHAPE.exec(trimmed);
+    if (
+      shapeMatch !== null &&
+      !isPlaceholderValue(trimmed) &&
+      !isPlaceholderValue(shapeMatch[1]!)
+    ) {
+      const start = text.length - text.trimStart().length;
+      matches.push({
+        label: "Token-shaped message",
+        value: trimmed,
+        start,
+        end: start + trimmed.length,
+        wholeMessage: true,
+      });
+    }
+  }
+
+  return matches.sort((a, b) => a.start - b.start);
+}


### PR DESCRIPTION
## Summary
- New dependency-free subpath export `@vellumai/service-contracts/secret-detection`: PREFIX_PATTERNS, TOKEN_SHAPE, placeholder suppression, and a pure detectSecretsInText() draft scanner
- Values copied verbatim from assistant/src/security so client and server detection can never drift
- Synthetic-fixture tests incl. the label-uniqueness invariant

Part of plan: composer-secret-guard.md (PR 1 of 7)