### PR TITLE
refactor(web): extract AddCredentialModal from credentials-page for reuse

### DIFF
--- a/clients/web/src/domains/settings/credentials/add-credential-modal.test.tsx
+++ b/clients/web/src/domains/settings/credentials/add-credential-modal.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Tests for `AddCredentialModal`:
+ *
+ *   1. The entered service / field / secret value / label reach the
+ *      credentials-set mutation — service and field trimmed, the secret
+ *      value verbatim — and a successful save fires `onSaved` + `onClose`.
+ *   2. An empty label is omitted from the payload rather than sent as "".
+ *   3. `initialValues` pre-populates every input (the prefill surface a
+ *      chat-domain consumer uses).
+ *   4. Cancel closes without saving.
+ *
+ * All credential values are synthetic fixtures.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useMutation,
+  type UseMutationOptions,
+} from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import type { AddCredentialModalProps } from "@/domains/settings/credentials/add-credential-modal";
+
+const ASSISTANT_ID = "asst-test";
+mock.module("@/assistant/use-active-assistant-id", () => ({
+  useActiveAssistantId: () => ASSISTANT_ID,
+}));
+
+const toasts: Array<{ kind: "success" | "error"; message: string }> = [];
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: {
+    success: (message: string) => {
+      toasts.push({ kind: "success", message });
+    },
+    error: (message: string) => {
+      toasts.push({ kind: "error", message });
+    },
+  },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+interface SetCall {
+  path: { assistant_id: string };
+  body: {
+    service: string;
+    field: string;
+    value: string;
+    label?: string;
+  };
+}
+const setCalls: SetCall[] = [];
+// The real generated hook wraps TanStack's `useMutation`; the mock keeps that
+// wiring (isPending, hook-level and per-call callbacks) and only swaps the
+// network layer for a recorder.
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  useCredentialsSetPostMutation: (
+    options: UseMutationOptions<unknown, Error, SetCall> = {},
+  ) =>
+    useMutation<unknown, Error, SetCall>({
+      mutationFn: (variables) => {
+        setCalls.push(variables);
+        return Promise.resolve({});
+      },
+      ...options,
+    }),
+}));
+
+const { AddCredentialModal } =
+  await import("@/domains/settings/credentials/add-credential-modal");
+
+function renderModal(props: Partial<AddCredentialModalProps> = {}) {
+  const queryClient = new QueryClient();
+  const onClose = mock<AddCredentialModalProps["onClose"]>(() => {});
+  const onSaved = mock<AddCredentialModalProps["onSaved"]>(() => {});
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AddCredentialModal open onClose={onClose} onSaved={onSaved} {...props} />
+    </QueryClientProvider>,
+  );
+  return { onClose, onSaved };
+}
+
+function input(label: string): HTMLInputElement {
+  return screen.getByLabelText(label) as HTMLInputElement;
+}
+
+function submitForm(): void {
+  const form = screen
+    .getByRole("button", { name: "Save" })
+    .closest("form") as HTMLFormElement;
+  fireEvent.submit(form);
+}
+
+describe("AddCredentialModal", () => {
+  beforeEach(() => {
+    setCalls.length = 0;
+    toasts.length = 0;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("saves the entered fields — service/field trimmed, value verbatim — then fires onSaved and onClose", async () => {
+    const { onClose, onSaved } = renderModal();
+
+    fireEvent.change(input("Service"), { target: { value: "  github  " } });
+    fireEvent.change(input("Field"), { target: { value: "api_token " } });
+    fireEvent.change(input("Value"), {
+      target: { value: " synthetic-secret-value " },
+    });
+    fireEvent.change(input("Label (optional)"), {
+      target: { value: "Synthetic test token" },
+    });
+    submitForm();
+
+    await waitFor(() => expect(setCalls.length).toBe(1));
+    expect(setCalls[0]).toEqual({
+      path: { assistant_id: ASSISTANT_ID },
+      body: {
+        service: "github",
+        field: "api_token",
+        value: " synthetic-secret-value ",
+        label: "Synthetic test token",
+      },
+    });
+
+    await waitFor(() => expect(onSaved.mock.calls.length).toBe(1));
+    expect(onSaved.mock.calls[0]).toEqual([
+      { service: "github", field: "api_token", label: "Synthetic test token" },
+    ]);
+    expect(onClose.mock.calls.length).toBe(1);
+    expect(toasts).toEqual([{ kind: "success", message: "Credential saved." }]);
+  });
+
+  test("omits an empty label from the payload and the onSaved meta", async () => {
+    const { onSaved } = renderModal();
+
+    fireEvent.change(input("Service"), { target: { value: "openai" } });
+    fireEvent.change(input("Field"), { target: { value: "api_key" } });
+    fireEvent.change(input("Value"), {
+      target: { value: "synthetic-key-123" },
+    });
+    submitForm();
+
+    await waitFor(() => expect(setCalls.length).toBe(1));
+    expect(setCalls[0]!.body.label).toBeUndefined();
+    await waitFor(() => expect(onSaved.mock.calls.length).toBe(1));
+    expect(onSaved.mock.calls[0]).toEqual([
+      { service: "openai", field: "api_key", label: undefined },
+    ]);
+  });
+
+  test("does not submit while a required field is empty", () => {
+    renderModal();
+
+    fireEvent.change(input("Service"), { target: { value: "github" } });
+    // Field and Value left empty.
+    submitForm();
+
+    expect(setCalls.length).toBe(0);
+    const saveButton = screen.getByRole("button", {
+      name: "Save",
+    }) as HTMLButtonElement;
+    expect(saveButton.disabled).toBe(true);
+  });
+
+  test("initialValues prefill every input", () => {
+    renderModal({
+      initialValues: {
+        service: "stripe",
+        field: "secret_key",
+        value: "synthetic-prefilled-value",
+        label: "Synthetic Stripe key",
+      },
+    });
+
+    expect(input("Service").value).toBe("stripe");
+    expect(input("Field").value).toBe("secret_key");
+    expect(input("Value").value).toBe("synthetic-prefilled-value");
+    expect(input("Label (optional)").value).toBe("Synthetic Stripe key");
+  });
+
+  test("Cancel closes without saving", () => {
+    const { onClose, onSaved } = renderModal();
+
+    fireEvent.change(input("Value"), {
+      target: { value: "synthetic-discarded" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose.mock.calls.length).toBe(1);
+    expect(onSaved.mock.calls.length).toBe(0);
+    expect(setCalls.length).toBe(0);
+  });
+});

--- a/clients/web/src/domains/settings/credentials/add-credential-modal.tsx
+++ b/clients/web/src/domains/settings/credentials/add-credential-modal.tsx
@@ -1,0 +1,218 @@
+import { KeyRound, Loader2 } from "lucide-react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
+
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { useCredentialsSetPostMutation } from "@/generated/daemon/@tanstack/react-query.gen";
+import { Button } from "@vellumai/design-library/components/button";
+import { Input } from "@vellumai/design-library/components/input";
+import { Modal } from "@vellumai/design-library/components/modal";
+import { toast } from "@vellumai/design-library/components/toast";
+
+/** Identity of a credential that was just saved to the vault. */
+export interface SavedCredentialMeta {
+  service: string;
+  field: string;
+  label?: string;
+}
+
+/** Optional values the form is seeded with each time the modal opens. */
+export interface AddCredentialInitialValues {
+  service?: string;
+  field?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface AddCredentialModalProps {
+  open: boolean;
+  /** Called when the modal closes — dismissal, Cancel, or a completed save. */
+  onClose: () => void;
+  /** Called after the credential is persisted to the vault. */
+  onSaved: (meta: SavedCredentialMeta) => void;
+  initialValues?: AddCredentialInitialValues;
+}
+
+/**
+ * Modal form that stores a credential (service / field / secret value /
+ * optional label) in the assistant's credential vault via the credentials-set
+ * endpoint. Owns validation, the save mutation, and success/error toasts so
+ * every call site shares identical behavior; callers handle what happens
+ * after a save (e.g. invalidating their credentials list) in `onSaved`.
+ */
+export function AddCredentialModal({
+  open,
+  onClose,
+  onSaved,
+  initialValues,
+}: AddCredentialModalProps) {
+  const assistantId = useActiveAssistantId();
+
+  const [service, setService] = useState(initialValues?.service ?? "");
+  const [field, setField] = useState(initialValues?.field ?? "");
+  const [value, setValue] = useState(initialValues?.value ?? "");
+  const [label, setLabel] = useState(initialValues?.label ?? "");
+
+  // Re-seed the form each time the modal opens so a prior open's draft never
+  // leaks into a new one and fresh initialValues take effect. The ref keeps
+  // the effect keyed on `open` alone — callers may pass a new initialValues
+  // object every render, and re-running on that would clobber user typing.
+  const initialValuesRef = useRef(initialValues);
+  useLayoutEffect(() => {
+    initialValuesRef.current = initialValues;
+  }, [initialValues]);
+  useEffect(() => {
+    if (open) {
+      const seed = initialValuesRef.current;
+      setService(seed?.service ?? "");
+      setField(seed?.field ?? "");
+      setValue(seed?.value ?? "");
+      setLabel(seed?.label ?? "");
+    }
+  }, [open]);
+
+  const setMutation = useCredentialsSetPostMutation({
+    onError: (err) => {
+      toast.error(err.message || "Failed to save credential");
+    },
+  });
+  const saving = setMutation.isPending;
+
+  // Clear the fields on close so the secret doesn't linger in state while
+  // the modal sits closed-but-mounted in the tree.
+  const resetAndClose = () => {
+    setService("");
+    setField("");
+    setValue("");
+    setLabel("");
+    onClose();
+  };
+
+  const handleSave = (e: FormEvent) => {
+    e.preventDefault();
+    const trimmedService = service.trim();
+    const trimmedField = field.trim();
+    // The secret value is stored verbatim — some secrets legitimately carry
+    // leading/trailing whitespace, and the CLI set path stores them unchanged.
+    // Trimming is used only to reject effectively-empty input.
+    if (!trimmedService || !trimmedField || !value.trim()) {
+      return;
+    }
+    const trimmedLabel = label.trim() || undefined;
+    setMutation.mutate(
+      {
+        path: { assistant_id: assistantId },
+        body: {
+          service: trimmedService,
+          field: trimmedField,
+          value,
+          label: trimmedLabel,
+        },
+      },
+      {
+        onSuccess: () => {
+          toast.success("Credential saved.");
+          onSaved({
+            service: trimmedService,
+            field: trimmedField,
+            label: trimmedLabel,
+          });
+          resetAndClose();
+        },
+      },
+    );
+  };
+
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        // Ignore dismissal (Escape / backdrop) while a save is in flight so a
+        // slow or failing mutation can't discard the entered secret, which
+        // the user may not be able to recover. The form clears only once the
+        // mutation settles (resetAndClose runs on success and on explicit
+        // Cancel, which is itself disabled while saving).
+        if (!nextOpen && !saving) {
+          resetAndClose();
+        }
+      }}
+    >
+      <Modal.Content size="sm">
+        <form onSubmit={handleSave}>
+          <Modal.Header>
+            <Modal.Title icon={KeyRound}>Add credential</Modal.Title>
+            <Modal.Description>
+              Add an API key or token to let tools and integrations use it.
+            </Modal.Description>
+          </Modal.Header>
+          <Modal.Body className="flex flex-col gap-3">
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Input
+                label="Service"
+                type="text"
+                value={service}
+                onChange={(e) => setService(e.target.value)}
+                placeholder="e.g. github"
+                autoFocus
+                fullWidth
+              />
+              <Input
+                label="Field"
+                type="text"
+                value={field}
+                onChange={(e) => setField(e.target.value)}
+                placeholder="e.g. api_token"
+                fullWidth
+              />
+            </div>
+            <Input
+              label="Value"
+              type="password"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder="Enter the secret value"
+              fullWidth
+            />
+            <Input
+              label="Label (optional)"
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="e.g. GitHub personal access token"
+              fullWidth
+            />
+          </Modal.Body>
+          <Modal.Footer>
+            <Button
+              type="button"
+              variant="outlined"
+              onClick={resetAndClose}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={
+                saving || !service.trim() || !field.trim() || !value.trim()
+              }
+              leftIcon={
+                saving ? (
+                  <Loader2 className="animate-spin" aria-hidden />
+                ) : undefined
+              }
+            >
+              Save
+            </Button>
+          </Modal.Footer>
+        </form>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/clients/web/src/domains/settings/credentials/credentials-page.tsx
+++ b/clients/web/src/domains/settings/credentials/credentials-page.tsx
@@ -1,14 +1,11 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Copy, KeyRound, Link2, Loader2, Plus, Search } from "lucide-react";
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { DetailCard } from "@/components/detail-card";
 import { NotFound } from "@/components/not-found";
-import {
-  useCredentialsDeletePostMutation,
-  useCredentialsSetPostMutation,
-} from "@/generated/daemon/@tanstack/react-query.gen";
+import { useCredentialsDeletePostMutation } from "@/generated/daemon/@tanstack/react-query.gen";
 import { credentialsListPost } from "@/generated/daemon/sdk.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
@@ -25,6 +22,7 @@ import {
 import { Tag } from "@vellumai/design-library/components/tag";
 import { toast } from "@vellumai/design-library/components/toast";
 
+import { AddCredentialModal } from "./add-credential-modal";
 import { CredentialRow, type StoredCredential } from "./credential-row";
 import {
   createCredentialRequest,
@@ -106,16 +104,6 @@ function CredentialsPageInner() {
     [listQuery.data],
   );
 
-  const setMutation = useCredentialsSetPostMutation({
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: listQueryKey });
-      toast.success("Credential saved.");
-    },
-    onError: (err) => {
-      toast.error(err.message || "Failed to save credential");
-    },
-  });
-
   const deleteMutation = useCredentialsDeletePostMutation({
     onError: (err) => {
       toast.error(err.message || "Failed to delete credential");
@@ -127,10 +115,6 @@ function CredentialsPageInner() {
   const [isShowingAddForm, setIsShowingAddForm] = useState(false);
   const [credentialView, setCredentialView] = useState<CredentialView>("own");
   const [searchText, setSearchText] = useState("");
-  const [service, setService] = useState("");
-  const [field, setField] = useState("");
-  const [value, setValue] = useState("");
-  const [label, setLabel] = useState("");
   const [pendingDeletion, setPendingDeletion] =
     useState<StoredCredential | null>(null);
   const [generatedLink, setGeneratedLink] = useState<GeneratedLink | null>(
@@ -140,7 +124,6 @@ function CredentialsPageInner() {
     null,
   );
 
-  const saving = setMutation.isPending;
   const deletingName = deleteMutation.isPending
     ? `${deleteMutation.variables?.body?.service}:${deleteMutation.variables?.body?.field}`
     : null;
@@ -183,38 +166,6 @@ function CredentialsPageInner() {
   }, [credentials.length, managedCredentials.length]);
 
   // --- Handlers ---
-
-  const resetAddForm = () => {
-    setIsShowingAddForm(false);
-    setService("");
-    setField("");
-    setValue("");
-    setLabel("");
-  };
-
-  const handleSave = (e?: FormEvent) => {
-    e?.preventDefault();
-    const trimmedService = service.trim();
-    const trimmedField = field.trim();
-    // The secret value is stored verbatim — some secrets legitimately carry
-    // leading/trailing whitespace, and the CLI set path stores them unchanged.
-    // Trimming is used only to reject effectively-empty input.
-    if (!trimmedService || !trimmedField || !value.trim()) {
-      return;
-    }
-    setMutation.mutate(
-      {
-        path: { assistant_id: assistantId },
-        body: {
-          service: trimmedService,
-          field: trimmedField,
-          value,
-          label: label.trim() || undefined,
-        },
-      },
-      { onSuccess: resetAddForm },
-    );
-  };
 
   const confirmDelete = () => {
     const credential = pendingDeletion;
@@ -447,91 +398,13 @@ function CredentialsPageInner() {
         onCancel={() => setPendingDeletion(null)}
       />
 
-      <Modal.Root
+      <AddCredentialModal
         open={isShowingAddForm}
-        onOpenChange={(open) => {
-          // Ignore dismissal (Escape / backdrop) while a save is in flight so a
-          // slow or failing mutation can't discard the entered secret, which
-          // the user may not be able to recover. The form clears only once the
-          // mutation settles (resetAddForm runs on success and on explicit
-          // Cancel, which is itself disabled while saving).
-          if (!open && !saving) {
-            resetAddForm();
-          }
+        onClose={() => setIsShowingAddForm(false)}
+        onSaved={() => {
+          void queryClient.invalidateQueries({ queryKey: listQueryKey });
         }}
-      >
-        <Modal.Content size="sm">
-          <form onSubmit={handleSave}>
-            <Modal.Header>
-              <Modal.Title icon={KeyRound}>Add credential</Modal.Title>
-              <Modal.Description>
-                Add an API key or token to let tools and integrations use it.
-              </Modal.Description>
-            </Modal.Header>
-            <Modal.Body className="flex flex-col gap-3">
-              <div className="flex flex-col gap-3 sm:flex-row">
-                <Input
-                  label="Service"
-                  type="text"
-                  value={service}
-                  onChange={(e) => setService(e.target.value)}
-                  placeholder="e.g. github"
-                  autoFocus
-                  fullWidth
-                />
-                <Input
-                  label="Field"
-                  type="text"
-                  value={field}
-                  onChange={(e) => setField(e.target.value)}
-                  placeholder="e.g. api_token"
-                  fullWidth
-                />
-              </div>
-              <Input
-                label="Value"
-                type="password"
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                placeholder="Enter the secret value"
-                fullWidth
-              />
-              <Input
-                label="Label (optional)"
-                type="text"
-                value={label}
-                onChange={(e) => setLabel(e.target.value)}
-                placeholder="e.g. GitHub personal access token"
-                fullWidth
-              />
-            </Modal.Body>
-            <Modal.Footer>
-              <Button
-                type="button"
-                variant="outlined"
-                onClick={resetAddForm}
-                disabled={saving}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                variant="primary"
-                disabled={
-                  saving || !service.trim() || !field.trim() || !value.trim()
-                }
-                leftIcon={
-                  saving ? (
-                    <Loader2 className="animate-spin" aria-hidden />
-                  ) : undefined
-                }
-              >
-                Save
-              </Button>
-            </Modal.Footer>
-          </form>
-        </Modal.Content>
-      </Modal.Root>
+      />
 
       <Modal.Root
         open={generatedLink !== null}


### PR DESCRIPTION
## Summary
- Pure refactor: the inline add-credential modal moves out of credentials-page.tsx into AddCredentialModal with an initialValues prefill prop
- Zero behavior change on the Settings → Credentials add flow
- New colocated component test (synthetic fixtures)

Part of plan: composer-secret-guard.md (PR 3 of 7)