### PR TITLE
feat(billing): free centered card + single recommended summary chip

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-spec-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plan-spec-card.test.tsx
@@ -83,4 +83,54 @@ describe("PlanSpecCard", () => {
     );
     expect(html).toContain('data-theme="dark"');
   });
+
+  test("centers the card content when centered is set", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard
+        tone="light"
+        tierKey="free"
+        name="Free"
+        tagline="A great starter plan"
+        centered
+        specs={null}
+      />,
+    );
+    // The centering utilities land on both the root and the header row.
+    expect(html).toContain("justify-center");
+    expect(html).toContain("items-center");
+  });
+
+  test("renders a wrapping pill for a multiline spec", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard
+        tone="dark"
+        tierKey="mighty"
+        name="Mighty"
+        specs={[
+          {
+            icon: Coins,
+            label: "more credits, storage, and a stronger machine",
+            multiline: true,
+          },
+        ]}
+      />,
+    );
+    expect(html).toContain("more credits, storage, and a stronger machine");
+    // A multiline chip wraps (whitespace-normal) and grows vertically (min-h-8).
+    expect(html).toContain("whitespace-normal");
+    expect(html).toContain("min-h-8");
+  });
+
+  test("applies the passed className to the root", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard
+        tone="light"
+        tierKey="free"
+        name="Free"
+        className="lg:flex-[3]"
+        specs={null}
+      />,
+    );
+    expect(html).toContain("lg:flex-[3]");
+  });
 });

--- a/clients/web/src/domains/settings/billing/plan-spec-card.tsx
+++ b/clients/web/src/domains/settings/billing/plan-spec-card.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { PlanTierAvatar } from "@/domains/settings/billing/plan-tier-meta";
 import type { PlanSpec } from "@/domains/settings/billing/plan-spec";
 import { SpecChip } from "@/domains/settings/billing/spec-chip";
+import { cn } from "@/utils/misc";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 export interface PlanSpecCardProps {
@@ -20,6 +21,10 @@ export interface PlanSpecCardProps {
   specs?: PlanSpec[] | null;
   /** Header right-aligned action (e.g. the Upgrade button). */
   action?: ReactNode;
+  /** Centers the card content on both axes (the minimal free current card). */
+  centered?: boolean;
+  /** Extra root classes (e.g. a responsive width override); applied last. */
+  className?: string;
 }
 
 /**
@@ -37,14 +42,27 @@ export function PlanSpecCard({
   tagline,
   specs,
   action,
+  centered = false,
+  className,
 }: PlanSpecCardProps) {
   const hasSpecs = specs != null && specs.length > 0;
   return (
     <div
       data-theme={tone}
-      className="flex flex-1 flex-col gap-4 rounded-xl bg-[var(--surface-base)] py-3 pl-3 pr-4"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col gap-4 rounded-xl bg-[var(--surface-base)] py-3 pl-3 pr-4",
+        centered && "items-center justify-center",
+        className,
+      )}
     >
-      <div className="flex flex-wrap items-start justify-between gap-3">
+      <div
+        className={cn(
+          "flex flex-wrap gap-3",
+          centered
+            ? "items-center justify-center"
+            : "items-start justify-between",
+        )}
+      >
         <div className="flex items-center gap-3">
           <PlanTierAvatar tier={tierKey} />
           <div className="flex min-w-0 flex-col gap-1">
@@ -77,7 +95,12 @@ export function PlanSpecCard({
           <div className="h-px w-full bg-[var(--border-base)]" />
           <div className="flex flex-wrap items-center gap-2">
             {specs.map((spec) => (
-              <SpecChip key={spec.label} icon={spec.icon} label={spec.label} />
+              <SpecChip
+                key={spec.label}
+                icon={spec.icon}
+                label={spec.label}
+                multiline={spec.multiline}
+              />
             ))}
           </div>
         </>

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -12,6 +12,8 @@ import { SIZE_LABEL } from "@/lib/billing/machine-sizes";
 export interface PlanSpec {
   icon: LucideIcon;
   label: string;
+  /** Render the chip as a wrap-capable pill for long summary labels. */
+  multiline?: boolean;
 }
 
 /**

--- a/clients/web/src/domains/settings/billing/spec-chip.tsx
+++ b/clients/web/src/domains/settings/billing/spec-chip.tsx
@@ -2,15 +2,28 @@ import type { LucideIcon } from "lucide-react";
 
 import { Typography } from "@vellumai/design-library/components/typography";
 
+import { cn } from "@/utils/misc";
+
 export interface SpecChipProps {
   icon: LucideIcon;
   label: string;
+  /** Render as a wrap-capable pill instead of forcing a single line. */
+  multiline?: boolean;
 }
 
 /** A single plan-spec pill: an icon and a compact label (e.g. "$25 credits"). */
-export function SpecChip({ icon: Icon, label }: SpecChipProps) {
+export function SpecChip({
+  icon: Icon,
+  label,
+  multiline = false,
+}: SpecChipProps) {
   return (
-    <div className="flex h-8 items-center gap-1.5 rounded-lg bg-[var(--surface-overlay)] px-2 py-1.5">
+    <div
+      className={cn(
+        "flex items-center gap-1.5 rounded-lg bg-[var(--surface-overlay)] px-2 py-1.5",
+        multiline ? "min-h-8 min-w-0" : "h-8",
+      )}
+    >
       <Icon
         className="h-3.5 w-3.5 shrink-0 text-[var(--content-default)]"
         aria-hidden
@@ -18,7 +31,10 @@ export function SpecChip({ icon: Icon, label }: SpecChipProps) {
       <Typography
         as="span"
         variant="body-medium-default"
-        className="whitespace-nowrap text-[var(--content-default)]"
+        className={cn(
+          "text-[var(--content-default)]",
+          multiline ? "whitespace-normal" : "whitespace-nowrap",
+        )}
       >
         {label}
       </Typography>

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -343,34 +343,37 @@ describe("PlanCard", () => {
     expect(html).not.toContain("recommended-upgrade-button");
   });
 
-  test("Free → Mighty chips: both cards render absolute per-plan chips", () => {
+  test("Free current card is chip-less; recommended shows the summary chip", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
-    // Both peer cards render absolute chips (machine → credits → storage); the
-    // recommended (Mighty) card and the current (Free) card each show their own
-    // values, with no delta/arrow framing and no vCPU chip.
-    expect(html).toContain("$25 credits");
-    expect(html).toContain("10 GB");
-    expect(html).toContain("Small Machine");
-    // The current (Free) card shows the free baseline chips.
-    expect(html).toContain("$0 credits");
-    expect(html).toContain("4 GB");
+    // The current (Free) card is now a minimal centered card with NO spec chips:
+    // none of the free-baseline chip labels appear.
+    expect(html).not.toContain("$0 credits");
+    expect(html).not.toContain("4 GB");
+    expect(html).not.toContain("Small Machine");
+    // The recommended (Mighty) card shows the single summary chip, replacing the
+    // old absolute per-resource chips (machine · credits · storage).
+    expect(html).toContain("more credits, storage, and a stronger machine");
+    expect(html).not.toContain("$25 credits");
+    expect(html).not.toContain("10 GB");
     expect(html).not.toContain("vCPU");
-    // A known-specs (free baseline) current card keeps its stock tagline — the
-    // tagline gate only suppresses the Custom/unknown case, not this one.
+    // The centered free card still shows its "Your Current Plan" tag and its real
+    // tagline — the tagline follows "known plan", not "has chips".
+    expect(html).toContain("Your Current Plan");
     expect(html).toContain(PLAN_TIER_COPY.free.tagline);
   });
 
-  test("Mighty → Super: recommends Super with absolute chips on both cards", () => {
+  test("Mighty → Super: current keeps its chips, recommended shows the summary chip", () => {
     const html = renderCard(proMightySubscription(), plansWithSuper());
     // On Mighty, the recommended upgrade is the next catalog package, Super.
     expect(html).toContain("recommended-upgrade-button");
     expect(html).toContain("Recommended");
     expect(html).toContain("Super");
-    // The recommended (Super) card shows Super's absolute chips.
-    expect(html).toContain("$45 credits");
-    expect(html).toContain("30 GB");
-    expect(html).toContain("Medium Machine");
-    // The current (Mighty) card shows Mighty's absolute chips.
+    // The recommended (Super) card shows the single summary chip, not Super's
+    // absolute per-resource chips.
+    expect(html).toContain("more credits, storage, and a stronger machine");
+    expect(html).not.toContain("$45 credits");
+    expect(html).not.toContain("30 GB");
+    // The current (Mighty) card keeps its absolute chips.
     expect(html).toContain("$25 credits");
     expect(html).toContain("10 GB");
     expect(html).toContain("Small Machine");
@@ -394,9 +397,11 @@ describe("PlanCard", () => {
     expect(html).toContain("recommended-upgrade-button");
     expect(html).toContain("Switch plan");
     expect(html).toContain("Switch to Mighty");
-    // A neutral switch drops the "Recommended" tag and renders no stock chips on
-    // the recommended card; the current "Custom" card also has no knowable chips.
+    // A neutral switch drops the "Recommended" tag and renders no chips on the
+    // recommended card — not even the summary chip; the current "Custom" card
+    // also has no knowable chips.
     expect(html).not.toContain("Recommended");
+    expect(html).not.toContain("more credits, storage, and a stronger machine");
   });
 
   test("a customized Pro sub's banner drops the stock upgrade framing", () => {
@@ -413,6 +418,8 @@ describe("PlanCard", () => {
     expect(html).toContain("Switch plan");
     expect(html).toContain("Switch to Super");
     expect(html).not.toContain("Recommended");
+    // A neutral switch renders no summary chip either.
+    expect(html).not.toContain("more credits, storage, and a stronger machine");
   });
 
   test("a base user's banner keeps the directional upgrade framing", () => {
@@ -473,6 +480,20 @@ describe("PlanCard", () => {
     expect(html).not.toContain("$0 credits");
     expect(html).not.toContain("4 GB");
     expect(html).not.toContain("Small Machine");
+  });
+
+  test("a free user's current card is centered, chip-less, and keeps its tagline", () => {
+    const html = renderCard(baseSubscription(), basePlansResponse());
+    // The free current card is a minimal centered card: centering classes on the
+    // card, its "Your Current Plan" tag, and the real free tagline, but NO chips.
+    expect(html).toContain("justify-center");
+    expect(html).toContain("Your Current Plan");
+    expect(html).toContain(PLAN_TIER_COPY.free.tagline);
+    expect(html).not.toContain("$0 credits");
+    expect(html).not.toContain("4 GB");
+    expect(html).not.toContain("Small Machine");
+    // The recommended (Mighty) card shows the single summary chip.
+    expect(html).toContain("more credits, storage, and a stronger machine");
   });
 });
 

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Sparkles } from "lucide-react";
+import { ArrowUp, Loader2, Sparkles } from "lucide-react";
 
 import { useState } from "react";
 
@@ -16,7 +16,10 @@ import {
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
-import { packageSpecs } from "@/domains/settings/billing/plan-spec";
+import {
+  packageSpecs,
+  type PlanSpec,
+} from "@/domains/settings/billing/plan-spec";
 import { PlanSpecCard } from "@/domains/settings/billing/plan-spec-card";
 import { useCheckoutDismissRefresh } from "@/domains/settings/billing/use-checkout-dismiss-refresh";
 import {
@@ -71,6 +74,15 @@ const PLAN_DISPLAY: Record<string, PlanDisplay> = {
 };
 
 const DEFAULT_DISPLAY: PlanDisplay = PLAN_DISPLAY.base;
+
+/** The recommended card's single summary chip (replaces per-resource chips). */
+const RECOMMENDED_SUMMARY_SPECS: PlanSpec[] = [
+  {
+    icon: ArrowUp,
+    label: "more credits, storage, and a stronger machine",
+    multiline: true,
+  },
+];
 
 export interface PlanCardProps {
   onManage: () => void;
@@ -267,6 +279,7 @@ function RecommendedUpgrade({
         tone="dark"
         tierKey={recommended.key}
         name={recommended.name}
+        className="lg:flex-[2]"
         tag={
           <Tag
             className="bg-[var(--feed-digest-weak)] text-[var(--credits-accent)]"
@@ -278,7 +291,7 @@ function RecommendedUpgrade({
           </Tag>
         }
         tagline={recommendedCopy?.tagline}
-        specs={isNeutralSwitch ? null : packageSpecs(recommended)}
+        specs={isNeutralSwitch ? null : RECOMMENDED_SUMMARY_SPECS}
         action={upgradeButton}
       />
       <PackageSwitchConfirmModal
@@ -377,23 +390,20 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
       : "switch";
 
   const currentCopy = getPlanTierCopy(currentTier);
-  // The current card shows absolute chips only when its specs are knowable: the
-  // free/base baseline, or a clean-pinned stock package that's present in the
-  // catalog. A customized pin or an unpinned legacy Pro sub (both read "Custom")
-  // has tiers that can diverge from any stock package; and a clean pin whose key
-  // is absent from the catalog (e.g. the `pro-packages` flag left `packages`
-  // empty, or a newer key isn't in this response) has unknown specs — both
-  // render no chips. `.find()`'s natural `undefined` for a missing package must
-  // flow through untouched: coercing it to `null` would make `packageSpecs` emit
-  // the FREE baseline, mislabeling a paid Pro sub as $0/4 GB/Small.
-  const currentStockPackage =
-    currentPlan.id === "base"
-      ? null
-      : isCleanPin(subscription.package)
-        ? packages.find((p) => p.key === currentKey)
-        : undefined; // undefined = unknown specs → no chips
-  const currentSpecs =
-    currentStockPackage === undefined ? null : packageSpecs(currentStockPackage);
+  const isFreePlan = currentPlan.id === "base";
+  // Chips render only for a paid plan whose stock package specs are known.
+  // Free shows a minimal centered card (no chips); a clean pin absent from the
+  // catalog and a customized/unpinned "Custom" sub show no chips either (never
+  // fall back to the free baseline, which would mislabel a paid sub).
+  const currentPackage =
+    !isFreePlan && isCleanPin(subscription.package)
+      ? (packages.find((p) => p.key === currentKey) ?? null)
+      : null;
+  const currentSpecs = currentPackage ? packageSpecs(currentPackage) : null;
+  // Tagline shows for a KNOWN plan (free, or a clean stock pin); hidden for a
+  // Custom/unknown sub whose real plan can't be named. (Note: this is gated on
+  // "known plan", NOT on having chips — free has no chips but a real tagline.)
+  const isKnownCurrentPlan = isFreePlan || isCleanPin(subscription.package);
 
   return (
     <Card padding="md">
@@ -440,18 +450,18 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
             tierKey={currentTier}
             name={planName}
             nameTestId="plan-card-name"
+            className="lg:flex-[3]"
+            centered={isFreePlan}
             tag={
               <Tag className="bg-[var(--feed-digest-weak)] text-[var(--content-default)]">
                 Your Current Plan
               </Tag>
             }
-            // Gate the tagline on the same "known stock specs" condition as the
-            // chips: a Custom/unknown current plan (`currentSpecs === null`)
-            // renders as "Custom" with no chips, so showing stock marketing copy
-            // under it would reintroduce the misleading stock-plan labeling the
-            // chip guard avoids. Only the free/base baseline or a clean-pinned
-            // package (both have non-null specs) keeps its tagline.
-            tagline={currentSpecs ? currentCopy?.tagline : undefined}
+            // The tagline follows "known plan" (free, or a clean stock pin), not
+            // "has chips": free is centered with no chips but still shows its
+            // real tagline, while a Custom/unknown sub — whose real plan can't be
+            // named — hides it to avoid mislabeling a paid sub with stock copy.
+            tagline={isKnownCurrentPlan ? currentCopy?.tagline : undefined}
             specs={currentSpecs}
           />
           <RecommendedUpgrade


### PR DESCRIPTION
## Summary
- Free current-plan card: minimal centered card, no spec chips (mock 7330-149443)
- Pro current-plan card: keeps machine/credits/storage chips (mock 7330-149398)
- Recommended card: single summary chip (ArrowUp + 'more credits, storage, and a stronger machine')
- Current card wider than recommended; tagline gated on known-plan not on chips
- SpecChip gains multiline; PlanSpecCard gains centered + className

Part of the billing Plan section work (feature branch).