### PR TITLE
fix(web): correct custom-plan recap for unrepresentable current tiers

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.test.ts
@@ -324,4 +324,55 @@ describe("computeCustomPlanDiff — seeded reconfigure", () => {
     expect(diff.previousTotalCents).toBeNull();
     expect(diff.deltaCents).toBeNull();
   });
+
+  test("an untouched deprecated credit bundle gets no row at all", () => {
+    // Reopening seeded to a bundle the catalog dropped: the choice is still the
+    // held `credits_100`, which resolves to nothing. Labelling that row "No
+    // extra credits" would be false for a subscriber paying for the bundle.
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: {
+        machineTier: "medium",
+        storageTier: "xs",
+        creditTier: "credits_100",
+      },
+      machineTier: "medium",
+      storageTier: "xs",
+      creditChoice: "credits_100",
+    });
+
+    expect(diff.rows.map((r) => r.key)).toEqual(["base", "machine", "storage"]);
+  });
+
+  test("a seed machine the catalog dropped suppresses the comparison", () => {
+    // `xl` is a valid machine tier absent from the fixture's machine_tiers.
+    // Pricing it at $0 would report this downgrade as a $35 increase.
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      seed: { machineTier: "xl", storageTier: "xs", creditTier: null },
+      machineTier: "medium",
+      storageTier: "xs",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    expect(diff.previousTotalCents).toBeNull();
+    expect(diff.deltaCents).toBeNull();
+    const machineRow = diff.rows.find((r) => r.key === "machine");
+    expect(machineRow?.changed).toBe(true);
+    expect(machineRow?.previousLabel).toBeUndefined();
+  });
+
+  test("a seed storage tier the catalog dropped suppresses the comparison", () => {
+    const diff = computeCustomPlanDiff({
+      proPlan: proPlan(),
+      // `xxl` is a valid storage tier absent from the fixture's storage_tiers.
+      seed: { machineTier: "medium", storageTier: "xxl", creditTier: null },
+      machineTier: "medium",
+      storageTier: "s",
+      creditChoice: NO_EXTRA_CREDITS,
+    });
+
+    expect(diff.previousTotalCents).toBeNull();
+    expect(diff.deltaCents).toBeNull();
+  });
 });

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -1,11 +1,7 @@
 /**
- * Pure diff/recap computation for the Custom Plan configurator.
- *
- * Owns the recap-row and signed-delta logic that the modal renders, kept free
- * of React/JSX/tokens so it can be unit-tested in isolation and reused across
- * the base-checkout and Pro-reconfigure paths. The modal supplies the live
- * dropdown selection plus the seed (current plan), and consumes the returned
- * rows and raw cents to render the recap and price delta.
+ * Pure diff/recap computation for the Custom Plan configurator — the recap rows
+ * and signed price delta the modal renders, kept free of React/JSX/tokens so it
+ * can be unit-tested in isolation.
  */
 
 import {
@@ -15,59 +11,60 @@ import {
 import type {
   CreditTier,
   CreditTierEnum,
-  MachineTier,
   MachineTierEnum,
   ProPlan,
   StorageTier,
   StorageTierEnum,
 } from "@/generated/api/types.gen";
 
-import type { CustomPlanSeed } from "./custom-plan-modal";
-
 /** Sentinel for the "No extra credits" dropdown entry (Dropdown is generic over string, cannot carry real null). */
 export const NO_EXTRA_CREDITS = "__none__";
 export type CreditChoice = CreditTierEnum | typeof NO_EXTRA_CREDITS;
 
-export interface CustomPlanDiffRow {
-  /** Stable React key. */
+const NO_CREDITS_LABEL = "No extra credits";
+
+export interface CustomPlanSelection {
+  machineTier: MachineTierEnum;
+  storageTier: StorageTierEnum;
+  /** `null` is the explicit "No extra credits" choice. */
+  creditTier: CreditTierEnum | null;
+}
+
+/**
+ * The current Pro tiers used to pre-fill the modal. Unlike a submitted
+ * selection, `machineTier` may be `null` — a package with no paid machine tier
+ * (baseline "Small" computer) has no `MachineTierEnum` to seed, so its machine
+ * dropdown starts empty and the user picks a paid tier to continue.
+ */
+export interface CustomPlanSeed {
+  machineTier: MachineTierEnum | null;
+  storageTier: StorageTierEnum;
+  creditTier: CreditTierEnum | null;
+}
+
+interface CustomPlanDiffRow {
   key: string;
-  /** Label for the current/new value. */
   label: string;
-  /** Present only when this dimension changed from the seed: previous value's label, shown struck-through above the new one. */
+  /** Present only when the dimension changed and the seed value is one the catalog can label. */
   previousLabel?: string;
-  /** True when the dimension changed from the seed — new value gets the green check. */
   changed: boolean;
 }
 
-export interface CustomPlanDiff {
-  /** Total for the current selection incl. base fee; always a number (base checkout included). The modal renders this as the "$X/mo" figure so the header total, delta, and rows share one full-catalog resolution. */
+interface CustomPlanDiff {
   totalCents: number;
-  /** Total for the seed (previous) config incl. base fee; null for base checkout (no seed) or a held credit bundle the catalog can no longer price. */
+  /** Null when there is no seed, or when a seed tier is absent from the catalog and so cannot be priced. */
   previousTotalCents: number | null;
-  /** newTotal - previousTotal; null for base checkout. */
   deltaCents: number | null;
   rows: CustomPlanDiffRow[];
 }
 
-/** `tier.description`, e.g. "Medium machine (2.5 vCPU, 5 GiB)". */
-function machineLabel(tier: MachineTier): string {
-  return tier.description;
-}
-
-/** e.g. "30 GB storage". */
 function storageLabel(tier: StorageTier): string {
   return `${tier.storage_gib} GB storage`;
 }
 
-/** "No extra credits" for null; else "$50 of bundled credits". */
-function creditLabel(tier: CreditTier | null): string {
-  return tier
-    ? `${formatDollars(tier.credits_usd * 100)} of bundled credits`
-    : "No extra credits";
+function creditLabel(tier: CreditTier): string {
+  return `${formatDollars(tier.credits_usd * 100)} of bundled credits`;
 }
-
-/** Single "none" token for the "No extra credits" choice/seed. */
-const NO_CREDIT_KEY = "none";
 
 export function computeCustomPlanDiff(input: {
   proPlan: ProPlan;
@@ -78,12 +75,10 @@ export function computeCustomPlanDiff(input: {
 }): CustomPlanDiff {
   const { proPlan, seed, machineTier, storageTier, creditChoice } = input;
 
+  // Resolve against the full catalog, legacy tiers included: a tier a
+  // subscriber still holds has to price and label even where the modal no
+  // longer offers it as a choice.
   const machineTiers = proPlan.machine_tiers;
-  // Resolve against the FULL catalog, legacy tiers included. This helper only
-  // resolves already-chosen values into prices/labels — it never offers dropdown
-  // options — so a known tier value (e.g. a legacy current/seed storage tier a
-  // subscriber still pays for) must resolve to its real price/label. The
-  // `!legacy` option-gating lives in the modal, not here.
   const storageTiers = proPlan.storage_tiers;
   const creditTiers = proPlan.credit_tiers ?? [];
 
@@ -121,11 +116,9 @@ export function computeCustomPlanDiff(input: {
     const changed = seed != null && seedMachine?.tier !== selectedMachine.tier;
     rows.push({
       key: "machine",
-      label: machineLabel(selectedMachine),
-      // A null baseline seed machine has no representable previous value → omit
-      // previousLabel, still changed: true.
+      label: selectedMachine.description,
       previousLabel:
-        changed && seedMachine != null ? machineLabel(seedMachine) : undefined,
+        changed && seedMachine != null ? seedMachine.description : undefined,
       changed,
     });
   }
@@ -141,27 +134,30 @@ export function computeCustomPlanDiff(input: {
     });
   }
 
-  if (creditChoice !== "") {
-    // Detect the change from the RAW seed key, not the resolved objects: a
-    // deprecated seed bundle (absent from proPlan.credit_tiers) resolves to
-    // null, which would otherwise read identically to "No extra credits" and
-    // hide the change.
-    const seedCreditKey =
-      seed != null ? (seed.creditTier ?? NO_CREDIT_KEY) : null;
-    const selectedCreditKey =
-      creditChoice === NO_EXTRA_CREDITS ? NO_CREDIT_KEY : creditChoice;
-    const changed = seed != null && seedCreditKey !== selectedCreditKey;
+  // A concrete bundle the catalog can no longer resolve gets no row at all —
+  // "No extra credits" would be affirmatively false for a sub paying for one.
+  const selectedCreditLabel =
+    creditChoice === NO_EXTRA_CREDITS
+      ? NO_CREDITS_LABEL
+      : selectedCredit != null
+        ? creditLabel(selectedCredit)
+        : null;
+
+  if (selectedCreditLabel != null) {
+    // Compare the raw keys: a delisted seed bundle resolves to null, which
+    // would otherwise read identically to "no credits" and hide the change.
+    const changed =
+      seed != null && (seed.creditTier ?? NO_EXTRA_CREDITS) !== creditChoice;
+    const previousCreditLabel =
+      seed?.creditTier == null
+        ? NO_CREDITS_LABEL
+        : seedCredit != null
+          ? creditLabel(seedCredit)
+          : undefined;
     rows.push({
       key: "credit",
-      label: creditLabel(selectedCredit),
-      // A deprecated seed bundle's price/label is absent from the catalog, so
-      // seedCredit is null and we omit previousLabel there (mirroring a
-      // null-baseline seed machine) rather than fabricate one. That same
-      // unresolvable case suppresses previousTotalCents/deltaCents below.
-      previousLabel:
-        changed && (seed.creditTier == null || seedCredit != null)
-          ? creditLabel(seedCredit)
-          : undefined,
+      label: selectedCreditLabel,
+      previousLabel: changed ? previousCreditLabel : undefined,
       changed,
     });
   }
@@ -172,26 +168,15 @@ export function computeCustomPlanDiff(input: {
     (selectedStorage?.price_cents ?? 0) +
     (selectedCredit?.price_cents ?? 0);
 
-  if (seed == null) {
-    return {
-      totalCents: newTotalCents,
-      previousTotalCents: null,
-      deltaCents: null,
-      rows,
-    };
-  }
+  // An unpriceable seed tier suppresses the comparison rather than implying $0.
+  // A null seed machine is the baseline "Small" and legitimately costs nothing.
+  const seedUnpriceable =
+    seed != null &&
+    ((seed.machineTier != null && seedMachine == null) ||
+      seedStorage == null ||
+      (seed.creditTier != null && seedCredit == null));
 
-  // A held credit tier that is a concrete enum value but absent from the catalog
-  // (a delisted/deprecated bundle) resolves to null, yet is NOT the
-  // NO_EXTRA_CREDITS sentinel — so we cannot faithfully price it. Rather than
-  // fabricate a $0 credit price (which would show a false-precise previous total
-  // and delta), suppress the whole comparison: null out previousTotalCents AND
-  // deltaCents so the modal hides the "compared to previous" line. The credit
-  // row itself is unaffected — its key-based `changed` detection and omitted
-  // previousLabel are already handled above. Defense-in-depth: such subs are
-  // routed to the manage/adjust-plan modal upstream and do not normally reach here.
-  const seedCreditUnresolved = seed.creditTier != null && seedCredit == null;
-  if (seedCreditUnresolved) {
+  if (seed == null || seedUnpriceable) {
     return {
       totalCents: newTotalCents,
       previousTotalCents: null,

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -326,14 +326,18 @@ function renderPage(
   );
 }
 
-function openDropdown(ariaLabel: string): void {
+function dropdownTrigger(ariaLabel: string): HTMLButtonElement {
   const trigger = document.querySelector<HTMLButtonElement>(
     `button[role="combobox"][aria-label="${ariaLabel}"]`,
   );
   if (!trigger) {
     throw new Error(`expected a "${ariaLabel}" dropdown trigger`);
   }
-  fireEvent.click(trigger);
+  return trigger;
+}
+
+function openDropdown(ariaLabel: string): void {
+  fireEvent.click(dropdownTrigger(ariaLabel));
 }
 
 function optionLabels(): string[] {
@@ -411,7 +415,8 @@ function deltaLine(): HTMLElement | null {
   );
 }
 
-/** The recap's `<li>` texts (each row's full concatenated text). */
+/** The recap's `<li>` texts (each row's full concatenated text). Only valid
+ * with the dropdown menus closed — their options render as `li` too. */
 function recapRows(): string[] {
   const dialog = document.querySelector('[role="dialog"]');
   return Array.from(dialog?.querySelectorAll("li") ?? []).map(
@@ -422,8 +427,17 @@ function recapRows(): string[] {
 /** Struck-through (previous-value) recap labels. */
 function strikethroughs(): string[] {
   const dialog = document.querySelector('[role="dialog"]');
-  return Array.from(dialog?.querySelectorAll(".line-through") ?? []).map(
+  return Array.from(dialog?.querySelectorAll("s.line-through") ?? []).map(
     (el) => el.textContent?.trim() ?? "",
+  );
+}
+
+/** Each recap row's check-icon classes, in row order. */
+function checkIconClasses(): string[] {
+  const dialog = document.querySelector('[role="dialog"]');
+  return Array.from(dialog?.querySelectorAll("li") ?? []).map(
+    (li) =>
+      li.querySelector("div:last-child > svg")?.getAttribute("class") ?? "",
   );
 }
 
@@ -480,14 +494,9 @@ describe("CustomPlanModal — base subscriber", () => {
     // $20 base + $60 machine + $10 storage + $50 credits.
     getByText("$140/mo");
 
-    // The recap check-list is the only <ul> in the dialog once the dropdown
-    // menus are closed. (The machine text also appears in its trigger, so a
-    // plain getByText would double-match.)
-    const dialog = document.querySelector('[role="dialog"]');
-    const rows = Array.from(dialog?.querySelectorAll("li") ?? []).map(
-      (li) => li.textContent?.trim() ?? "",
-    );
-    expect(rows).toEqual([
+    // Read the recap rows rather than getByText — the machine text also appears
+    // in its dropdown trigger and would double-match.
+    expect(recapRows()).toEqual([
       "Pro base plan — $20/mo",
       "Large machine (4 vCPU, 8 GiB)",
       "30 GB storage",
@@ -592,11 +601,7 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     expect(continueButton().disabled).toBe(false);
 
     // The recap reflects the seeded current tiers.
-    const dialog = document.querySelector('[role="dialog"]');
-    const rows = Array.from(dialog?.querySelectorAll("li") ?? []).map(
-      (li) => li.textContent?.trim() ?? "",
-    );
-    expect(rows).toEqual([
+    expect(recapRows()).toEqual([
       "Pro base plan — $20/mo",
       "Medium machine (2.5 vCPU, 5 GiB)",
       "10 GB storage",
@@ -629,11 +634,22 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     selectOption("Machine size", "Large machine (4 vCPU, 8 GiB)");
 
     // The changed machine row shows the previous value struck through above
-    // the new value.
-    expect(strikethroughs()).toContain("Medium machine (2.5 vCPU, 5 GiB)");
-    expect(
-      recapRows().some((r) => r.includes("Large machine (4 vCPU, 8 GiB)")),
-    ).toBe(true);
+    // the new value; every other row keeps its single seeded label.
+    expect(strikethroughs()).toEqual(["Medium machine (2.5 vCPU, 5 GiB)"]);
+    expect(recapRows()).toEqual([
+      "Pro base plan — $20/mo",
+      "Medium machine (2.5 vCPU, 5 GiB)Large machine (4 vCPU, 8 GiB)",
+      "10 GB storage",
+      "No extra credits",
+    ]);
+
+    // Only the changed row's check goes green; the rest stay grey.
+    const checks = checkIconClasses();
+    expect(checks).toHaveLength(4);
+    expect(checks[1]).toContain("text-[var(--system-positive-strong)]");
+    for (const unchanged of [checks[0], checks[2], checks[3]]) {
+      expect(unchanged).toContain("text-[var(--content-secondary)]");
+    }
 
     // previous = base 2000 + medium 3500 + xs 500 = 6000 ($60);
     // new = base 2000 + large 6000 + xs 500 = 8500 ($85); delta = +$25/mo.
@@ -691,11 +707,8 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     getByText("Create a custom plan");
     expect(continueButton().disabled).toBe(true);
 
-    const dialog = document.querySelector('[role="dialog"]');
-    const rows = Array.from(dialog?.querySelectorAll("li") ?? []).map(
-      (li) => li.textContent?.trim() ?? "",
-    );
     // Storage and credit are seeded even though the machine is unset.
+    const rows = recapRows();
     expect(rows).toContain("10 GB storage");
     expect(rows).toContain("No extra credits");
   });
@@ -814,5 +827,70 @@ describe("CustomPlanModal — Pro plan the catalog can't fully represent", () =>
     getByText("Create a custom plan");
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(machineTierCall).toBeNull();
+  });
+
+  test("an untouched deprecated credit bundle is not recapped as 'No extra credits'", () => {
+    const { getByRole } = renderPage(
+      proMightySubscription({ selected_credit_tier: "credits_25" }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    // The held bundle has no catalog entry to label, so the row is omitted
+    // rather than claiming the paying subscriber has no credits.
+    expect(recapRows()).toEqual([
+      "Pro base plan — $20/mo",
+      "Medium machine (2.5 vCPU, 5 GiB)",
+      "10 GB storage",
+    ]);
+  });
+
+  test("a legacy-storage Pro sub sees the held tier and can continue", () => {
+    // 250 GB (xl) is legacy: no longer offered, but still what this sub pays
+    // for. The picker shows it (disabled), the recap agrees with the total, and
+    // Continue is live so an unrelated edit isn't blocked.
+    const { getByRole, getByText } = renderPage(
+      proMightySubscription(),
+      onboarding({ selected_storage_tier: "xl", selected_storage_gib: 250 }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    expect(continueButton().disabled).toBe(false);
+    expect(dropdownTrigger("Storage").textContent).toContain("250 GB");
+    expect(recapRows()).toEqual([
+      "Pro base plan — $20/mo",
+      "Medium machine (2.5 vCPU, 5 GiB)",
+      "250 GB storage",
+      "No extra credits",
+    ]);
+    // base $20 + medium $35 + legacy 250 GB $60.
+    getByText("$115/mo");
+  });
+
+  test("the held legacy storage tier is offered but not selectable", () => {
+    const { getByRole } = renderPage(
+      proMightySubscription(),
+      onboarding({ selected_storage_tier: "xl", selected_storage_gib: 250 }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    openDropdown("Storage");
+
+    expect(findOption("250 GB").getAttribute("aria-disabled")).toBe("true");
+  });
+
+  test("a seed machine the catalog dropped hides the delta rather than inverting it", () => {
+    // `xl` is a valid machine tier the fixture catalog no longer lists. Pricing
+    // it at $0 would report this downgrade to Medium as a $35 increase.
+    const { getByRole } = renderPage(
+      proMightySubscription(),
+      onboarding({ max_machine_tier: "xl" }),
+    );
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    selectOption("Machine size", "Medium machine (2.5 vCPU, 5 GiB)");
+
+    expect(deltaLine()).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -29,28 +29,13 @@ import { Modal } from "@vellumai/design-library/components/modal";
 
 import {
   type CreditChoice,
+  type CustomPlanSeed,
+  type CustomPlanSelection,
   computeCustomPlanDiff,
   NO_EXTRA_CREDITS,
 } from "./custom-plan-diff";
 
-export interface CustomPlanSelection {
-  machineTier: MachineTierEnum;
-  storageTier: StorageTierEnum;
-  /** `null` is the explicit "No extra credits" choice. */
-  creditTier: CreditTierEnum | null;
-}
-
-/**
- * The current Pro tiers used to pre-fill the modal. Unlike a submitted
- * selection, `machineTier` may be `null` — a package with no paid machine tier
- * (baseline "Small" computer) has no `MachineTierEnum` to seed, so its machine
- * dropdown starts empty and the user picks a paid tier to continue.
- */
-export interface CustomPlanSeed {
-  machineTier: MachineTierEnum | null;
-  storageTier: StorageTierEnum;
-  creditTier: CreditTierEnum | null;
-}
+export type { CustomPlanSeed, CustomPlanSelection };
 
 export interface CustomPlanModalProps {
   open: boolean;
@@ -125,13 +110,15 @@ export function CustomPlanModal({
   }, [open, initialSelection]);
 
   const machineTiers = proPlan.machine_tiers;
-  // Legacy tiers stay in the catalog only for existing subscribers; a new
-  // custom configuration must not offer them.
-  const storageTiers = useMemo(
-    () => proPlan.storage_tiers.filter((t) => !t.legacy),
-    [proPlan.storage_tiers],
-  );
+  const storageTiers = proPlan.storage_tiers;
   const creditTiers = proPlan.credit_tiers ?? [];
+
+  // Legacy tiers stay in the catalog only for existing subscribers, so a new
+  // configuration must not offer them — but a subscriber seeded onto one still
+  // has to see the tier they hold, rendered disabled.
+  const offerableStorageTiers = storageTiers.filter(
+    (t) => !t.legacy || t.tier === initialSelection?.storageTier,
+  );
 
   const machineOptions: DropdownOption<MachineTierEnum>[] = machineTiers.map(
     (t) => ({
@@ -142,17 +129,17 @@ export function CustomPlanModal({
       disabled: isTierDisabled(t),
     }),
   );
-  const storageOptions: DropdownOption<StorageTierEnum>[] = storageTiers.map(
-    (t) => ({
+  const storageOptions: DropdownOption<StorageTierEnum>[] =
+    offerableStorageTiers.map((t) => ({
       value: t.tier as StorageTierEnum,
       label: t.label,
       icon: <HardDrive className="h-4 w-4" aria-hidden />,
       suffix: priceSuffix(t.price_cents),
       disabled:
         isTierDisabled(t) ||
+        t.legacy ||
         (currentStorageGib != null && t.storage_gib < currentStorageGib),
-    }),
-  );
+    }));
   const creditOptions: DropdownOption<CreditChoice>[] = [
     {
       value: NO_EXTRA_CREDITS,
@@ -175,10 +162,6 @@ export function CustomPlanModal({
   const complete =
     selectedMachine != null && selectedStorage != null && creditChoice !== "";
 
-  // The "$X/mo" total, the delta line, and the recap rows all derive from this
-  // single computeCustomPlanDiff resolution against the FULL catalog, so they
-  // can never disagree — in particular a legacy-seed storage price stays in the
-  // header total (the modal's own `!legacy`-filtered lists would drop it).
   const diff = useMemo(
     () =>
       computeCustomPlanDiff({
@@ -321,9 +304,9 @@ export function CustomPlanModal({
                             className="mt-0.5 h-4 w-4 shrink-0 text-[var(--content-disabled)]"
                             aria-hidden
                           />
-                          <span className="text-[14px] font-medium leading-[18px] text-[var(--content-disabled)] line-through">
+                          <s className="text-[14px] font-medium leading-[18px] text-[var(--content-disabled)] line-through">
                             {row.previousLabel}
-                          </span>
+                          </s>
                         </div>
                       )}
                       <div className="flex items-start gap-2">


### PR DESCRIPTION
## Summary
- Resolve the modal's machine/storage against the full catalog so a legacy-storage sub can still continue, and show the held tier as a disabled option instead of a blank picker
- Suppress the previous-total/delta whenever any seed tier is unpriceable, not just credits, so a delisted tier can't produce a sign-inverted delta
- Stop labelling a held-but-unpriceable credit bundle as "No extra credits"; cover the green/grey check mapping and the newly reachable cases with tests

Fixes gaps identified during plan review for custom-plan-diff-recap.md