### PR TITLE
feat(web): custom providers — "OpenAI-compatible" becomes configuration, not identity

### DIFF
--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -387,6 +387,16 @@ function ManageProvidersModalInner({
                             Default
                           </Tag>
                         )}
+                        {conn.provider === VELLUM_CONNECTION_PROVIDER
+                          ? null
+                          : conn.provider === "openai-compatible" && (
+                              <Tag
+                                tone="neutral"
+                                title="A provider you created — served by an OpenAI-compatible endpoint."
+                              >
+                                Custom
+                              </Tag>
+                            )}
                       </div>
                     </div>
 

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -57,6 +57,33 @@ interface ManageProvidersModalProps {
   onClose: () => void;
 }
 
+/**
+ * Card meta line for a custom provider: the endpoint host plus what it
+ * serves, e.g. "api.x.ai · 2 models" or "127.0.0.1:1234 · keyless".
+ */
+function customProviderMeta(conn: ProviderConnection): string {
+  let host = conn.baseUrl ?? "";
+  try {
+    if (conn.baseUrl) {
+      host = new URL(conn.baseUrl).host;
+    }
+  } catch {
+    // Keep the raw value when it isn't a parseable URL.
+  }
+  const parts: string[] = [];
+  if (host) {
+    parts.push(host);
+  }
+  const modelCount = conn.models?.length ?? 0;
+  if (modelCount > 0) {
+    parts.push(`${modelCount} ${modelCount === 1 ? "model" : "models"}`);
+  }
+  if (conn.auth.type === "none") {
+    parts.push("keyless");
+  }
+  return parts.join(" · ");
+}
+
 export function ManageProvidersModal({
   isOpen,
   assistantId,
@@ -398,6 +425,15 @@ function ManageProvidersModalInner({
                               </Tag>
                             )}
                       </div>
+                      {conn.provider === "openai-compatible" ? (
+                        <Typography
+                          variant="body-small-default"
+                          as="p"
+                          className="text-(--content-tertiary)"
+                        >
+                          {customProviderMeta(conn)}
+                        </Typography>
+                      ) : null}
                     </div>
 
                     {/* Actions */}

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -146,18 +146,27 @@ function dropdownTriggers(): HTMLButtonElement[] {
   );
 }
 
+/** An option row's label, excluding any right-aligned suffix meta. */
+function optionLabel(option: Element): string {
+  return (
+    option.querySelector(".truncate")?.textContent ??
+    option.textContent ??
+    ""
+  ).trim();
+}
+
 /** Open the dropdown trigger and click the option whose label matches. */
-function pickOption(trigger: HTMLButtonElement, optionLabel: string): void {
+function pickOption(trigger: HTMLButtonElement, wantedLabel: string): void {
   fireEvent.click(trigger);
   const option = Array.from(
     document.querySelectorAll<HTMLElement>('[role="option"]'),
-  ).find((o) => o.textContent?.trim() === optionLabel);
+  ).find((o) => optionLabel(o) === wantedLabel);
   if (!option) {
     throw new Error(
-      `expected option "${optionLabel}" — saw: ${Array.from(
+      `expected option "${wantedLabel}" — saw: ${Array.from(
         document.querySelectorAll('[role="option"]'),
       )
-        .map((o) => `"${o.textContent?.trim()}"`)
+        .map((o) => `"${optionLabel(o)}"`)
         .join(", ")}`,
     );
   }
@@ -189,7 +198,7 @@ function selectModel(label: string): void {
     fireEvent.click(trigger);
     const option = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
-    ).find((o) => o.textContent?.trim() === label);
+    ).find((o) => optionLabel(o) === label);
     if (option) {
       fireEvent.click(option);
       return;
@@ -424,7 +433,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     fireEvent.click(providerTrigger());
     const optionLabels = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
-    ).map((o) => o.textContent?.trim());
+    ).map((o) => optionLabel(o));
     expect(optionLabels).toEqual(["+ Create new provider"]);
   });
 
@@ -436,7 +445,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     fireEvent.click(providerTrigger());
     const optionLabels = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
-    ).map((o) => o.textContent?.trim());
+    ).map((o) => optionLabel(o));
     // A single Vellum entry — never the managed upstreams it routes to.
     expect(optionLabels).toEqual(["Vellum", "+ Create new provider"]);
   });
@@ -519,7 +528,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     fireEvent.click(providerTrigger());
     const optionLabels = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
-    ).map((o) => o.textContent?.trim());
+    ).map((o) => optionLabel(o));
     expect(optionLabels).toEqual([
       "lm-studio",
       "vllm-box",
@@ -528,7 +537,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     fireEvent.click(
       Array.from(
         document.querySelectorAll<HTMLElement>('[role="option"]'),
-      ).find((o) => o.textContent?.trim() === "lm-studio")!,
+      ).find((o) => optionLabel(o) === "lm-studio")!,
     );
     expect(document.body.textContent).not.toContain("Endpoint");
     expect(document.body.textContent).not.toContain("Connection (optional)");
@@ -677,7 +686,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     );
 
     await waitFor(() => {
-      expect(providerTrigger().textContent?.trim()).toBe("Vellum");
+      expect(optionLabel(providerTrigger())).toBe("Vellum");
     });
     expect(document.body.textContent).not.toContain("Connection (optional)");
   });
@@ -764,7 +773,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     // The trigger renders the ENDPOINT entry (labeled by the row name) —
     // not Vellum picker mode; the wire payload proves the distinction.
     await waitFor(() => {
-      expect(providerTrigger().textContent?.trim()).toBe("vellum");
+      expect(optionLabel(providerTrigger())).toBe("vellum");
     });
 
     await waitFor(() => {
@@ -873,7 +882,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     fireEvent.click(providerTrigger());
     const optionLabels = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
-    ).map((o) => o.textContent?.trim());
+    ).map((o) => optionLabel(o));
     expect(optionLabels).toEqual(["Anthropic", "+ Create new provider"]);
   });
 
@@ -930,7 +939,7 @@ describe("ProfileEditorModal create mode — provider-first", () => {
 
     const optionLabels = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
-    ).map((o) => o.textContent?.trim());
+    ).map((o) => optionLabel(o));
     expect(optionLabels).toEqual(["+ Create new provider"]);
   });
 
@@ -1207,7 +1216,7 @@ describe("ProfileEditorModal edit mode — catalog-absent bound model", () => {
       fireEvent.click(trigger);
       const labels = Array.from(
         document.querySelectorAll<HTMLElement>('[role="option"]'),
-      ).map((o) => o.textContent?.trim());
+      ).map((o) => optionLabel(o));
       fireEvent.click(trigger);
       return labels;
     });
@@ -1257,7 +1266,7 @@ describe("ProfileEditorModal edit mode — catalog-absent bound model", () => {
       fireEvent.click(trigger);
       const labels = Array.from(
         document.querySelectorAll<HTMLElement>('[role="option"]'),
-      ).map((o) => o.textContent?.trim());
+      ).map((o) => optionLabel(o));
       fireEvent.click(trigger);
       return labels;
     });
@@ -1363,7 +1372,7 @@ describe("ProfileEditorModal edit mode — catalog-absent bound model", () => {
       fireEvent.click(trigger);
       const labels = Array.from(
         document.querySelectorAll<HTMLElement>('[role="option"]'),
-      ).map((o) => o.textContent?.trim());
+      ).map((o) => optionLabel(o));
       fireEvent.click(trigger);
       return labels;
     });

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@vellumai/design-library/components/button";
@@ -30,7 +30,10 @@ import {
   ProfileAdvancedParams,
   THINKING_LEVEL_INHERIT,
 } from "@/domains/settings/ai/profile-advanced-params";
-import { ProfileEditorProviderSection } from "@/domains/settings/ai/profile-editor-provider-section";
+import {
+  PickerMeta,
+  ProfileEditorProviderSection,
+} from "@/domains/settings/ai/profile-editor-provider-section";
 import {
   type GeminiThinkingLevel,
   isGeminiThinkingLevel,
@@ -77,7 +80,9 @@ function connectionServesProvider(
   connectionProvider: string,
   selectedProvider: string,
 ): boolean {
-  if (connectionProvider === selectedProvider) {return true;}
+  if (connectionProvider === selectedProvider) {
+    return true;
+  }
   // Legacy wire shape: a managed profile stores its real upstream (e.g.
   // "fireworks") while binding to the provider-agnostic vellum connection.
   return (
@@ -151,7 +156,9 @@ export function ProfileEditorModal({
     <Modal.Root
       open={isOpen}
       onOpenChange={(next) => {
-        if (!next) {onCancel();}
+        if (!next) {
+          onCancel();
+        }
       }}
     >
       {isOpen ? (
@@ -384,7 +391,9 @@ function ProfileEditorModalInner({
   // as valid before the parent refetch lands.
   const effectiveConnections = useMemo(() => {
     const base = connections ?? [];
-    if (locallyCreatedConnections.length === 0) {return base;}
+    if (locallyCreatedConnections.length === 0) {
+      return base;
+    }
     const known = new Set(base.map((c) => c.name));
     return [
       ...base,
@@ -433,7 +442,9 @@ function ProfileEditorModalInner({
     if (initialValues?.provider_connection !== VELLUM_CONNECTION_PROVIDER) {
       return;
     }
-    if (provider !== (initialValues?.provider ?? "")) {return;}
+    if (provider !== (initialValues?.provider ?? "")) {
+      return;
+    }
     const boundRow = connections?.find(
       (c) => c.name === initialValues.provider_connection,
     );
@@ -452,7 +463,9 @@ function ProfileEditorModalInner({
   }, [profileName, mode, resetDirty]);
 
   function handleProviderChange(newProvider: ConnectionProvider) {
-    if (newProvider === provider) {return;}
+    if (newProvider === provider) {
+      return;
+    }
     setProvider(newProvider);
     setModel("");
     // Auto-select connection: if exactly one connection exists for the new
@@ -492,13 +505,17 @@ function ProfileEditorModalInner({
             (c.models ?? []).map((m) => m.id),
           ),
         );
-        if (!allModelIds.has(model)) {setModel("");}
+        if (!allModelIds.has(model)) {
+          setModel("");
+        }
       } else {
         const conn = availableConnectionsForProvider.find(
           (c) => c.name === newConnection,
         );
         const connModelIds = new Set((conn?.models ?? []).map((m) => m.id));
-        if (!connModelIds.has(model)) {setModel("");}
+        if (!connModelIds.has(model)) {
+          setModel("");
+        }
       }
     }
   }
@@ -510,16 +527,22 @@ function ProfileEditorModalInner({
     const catalogMatch = getModelsForProvider(provider).find(
       (m) => m.id === modelId,
     );
-    if (catalogMatch) {return catalogMatch.displayName;}
+    if (catalogMatch) {
+      return catalogMatch.displayName;
+    }
     for (const conn of availableConnectionsForProvider) {
       const match = (conn.models ?? []).find((m) => m.id === modelId);
-      if (match) {return match.displayName ?? match.id;}
+      if (match) {
+        return match.displayName ?? match.id;
+      }
     }
     return modelId;
   }
 
   function handleModelChange(newModel: string) {
-    if (newModel === model) {return;}
+    if (newModel === model) {
+      return;
+    }
     setModel(newModel);
     // Reset token sliders when model changes
     setMaxTokens(null);
@@ -545,7 +568,9 @@ function ProfileEditorModalInner({
     // The create form can't produce a vellum connection; bail before touching
     // any state so the sub-form can't get stuck.
     const newProvider = connection.provider;
-    if (newProvider === "vellum") {return;}
+    if (newProvider === "vellum") {
+      return;
+    }
     // Optimistically register the new connection locally so the binding is
     // valid immediately (the parent `connections` refetch below is async).
     setLocallyCreatedConnections((prev) =>
@@ -592,14 +617,18 @@ function ProfileEditorModalInner({
         : null;
 
   async function handleSave() {
-    if (isInvalid && !isReadOnly) {return;}
+    if (isInvalid && !isReadOnly) {
+      return;
+    }
     // Read-only (managed) profiles reach Save only via the enable flip — the
     // daemon rejects every other mutation on them — so the body is exactly
     // `{status: "active"}`. `mode: "merge"` tells the parent to skip its
     // delete-then-recreate cycle and send a single deep-merge PATCH so the
     // seed-owned fields (provider, model, advanced params) stay intact.
     if (isReadOnly) {
-      if (!hasViewModeChanges) {return;}
+      if (!hasViewModeChanges) {
+        return;
+      }
       setSaving(true);
       setSaveError(null);
       try {
@@ -669,11 +698,21 @@ function ProfileEditorModalInner({
         entry.provider_connection = wireBinding || null;
       } else {
         // In create mode omit optional fields that are still empty.
-        if (label.trim()) {entry.label = label.trim();}
-        if (description.trim()) {entry.description = description.trim();}
-        if (wireProvider) {entry.provider = wireProvider;}
-        if (wireModel) {entry.model = wireModel;}
-        if (wireBinding) {entry.provider_connection = wireBinding;}
+        if (label.trim()) {
+          entry.label = label.trim();
+        }
+        if (description.trim()) {
+          entry.description = description.trim();
+        }
+        if (wireProvider) {
+          entry.provider = wireProvider;
+        }
+        if (wireModel) {
+          entry.model = wireModel;
+        }
+        if (wireBinding) {
+          entry.provider_connection = wireBinding;
+        }
       }
       // Advanced params
       if (visibility.maxTokens && maxTokens !== null) {
@@ -873,14 +912,19 @@ function ProfileEditorModalInner({
   // Providers with at least one connection, plus the always-present "+ Create
   // new provider" sentinel. First-run empty state shows ONLY the sentinel.
   const createModeProviderOptions = useMemo(() => {
-    const opts: { value: string; label: string }[] = expandEndpointEntries(
-      providersServedByConnections(
+    const opts: { value: string; label: string; suffix?: ReactNode }[] =
+      expandEndpointEntries(
+        providersServedByConnections(
+          effectiveConnections,
+          activeAssistantIsSelfHosted,
+        ),
         effectiveConnections,
-        activeAssistantIsSelfHosted,
-      ),
-      effectiveConnections,
-      (p) => PROVIDER_DISPLAY_NAMES[p] ?? p,
-    );
+        (p) => PROVIDER_DISPLAY_NAMES[p] ?? p,
+      ).map(({ value, label, meta }) => ({
+        value,
+        label,
+        suffix: meta ? <PickerMeta text={meta} /> : undefined,
+      }));
     opts.push({
       value: CREATE_NEW_PROVIDER_SENTINEL,
       label: "+ Create new provider",

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -97,6 +97,18 @@ const MODEL_EMPTY_STATE_COPY = {
  */
 const CUSTOM_MODEL_OPTION_VALUE = "__custom-model-id__";
 
+/**
+ * Right-aligned muted annotation on a provider-picker row: the row answers
+ * "whose infrastructure" at the moment of choice (Managed / Custom).
+ */
+export function PickerMeta({ text }: { text: string }) {
+  return (
+    <span className="text-body-small-default text-[var(--content-tertiary)]">
+      {text}
+    </span>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
@@ -363,7 +375,11 @@ export function ProfileEditorProviderSection({
                 providerOptionsSource,
                 connections ?? [],
                 (p) => PROVIDER_DISPLAY_NAMES[p] ?? p,
-              ),
+              ).map(({ value, label, meta }) => ({
+                value,
+                label,
+                suffix: meta ? <PickerMeta text={meta} /> : undefined,
+              })),
               // A bound endpoint whose row was deleted still renders on the
               // trigger; the warning below explains the state.
               ...(connectionNotFound &&

--- a/clients/web/src/domains/settings/ai/provider-availability.ts
+++ b/clients/web/src/domains/settings/ai/provider-availability.ts
@@ -138,18 +138,29 @@ export function expandEndpointEntries(
   providers: readonly ConnectionProvider[],
   connections: ProviderConnection[],
   labelFor: (provider: ConnectionProvider) => string,
-): { value: string; label: string }[] {
-  const entries: { value: string; label: string }[] = [];
+): { value: string; label: string; meta?: string }[] {
+  const entries: { value: string; label: string; meta?: string }[] = [];
   for (const provider of providers) {
+    if (provider === VELLUM_CONNECTION_PROVIDER) {
+      entries.push({
+        value: provider,
+        label: labelFor(provider),
+        meta: "Managed",
+      });
+      continue;
+    }
     if (provider !== OPENAI_COMPATIBLE_PROVIDER) {
       entries.push({ value: provider, label: labelFor(provider) });
       continue;
     }
     for (const c of connections) {
-      if (c.provider !== OPENAI_COMPATIBLE_PROVIDER) {continue;}
+      if (c.provider !== OPENAI_COMPATIBLE_PROVIDER) {
+        continue;
+      }
       entries.push({
         value: endpointPickerValue(c.name),
         label: c.label && c.label.trim() !== "" ? c.label : c.name,
+        meta: "Custom",
       });
     }
   }

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -778,6 +778,35 @@ describe("ProviderCreateForm submit sequence", () => {
     );
   });
 
+  test("a custom provider cannot take a built-in provider's name", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={[]}
+          defaultProviderType="openai-compatible"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    fireEvent.change(getInputByPlaceholder("xAI"), {
+      target: { value: "Anthropic" },
+    });
+    expect(document.body.textContent).toContain(
+      "That name belongs to a built-in provider.",
+    );
+    expect(getSubmitButton().disabled).toBe(true);
+
+    fireEvent.change(getInputByPlaceholder("xAI"), {
+      target: { value: "xAI" },
+    });
+    expect(document.body.textContent).not.toContain(
+      "That name belongs to a built-in provider.",
+    );
+  });
+
   test("clicking Cancel invokes onCancel", () => {
     let cancelled = false;
     render(

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -323,6 +323,9 @@ describe("ProviderCreateForm submit sequence", () => {
       ),
     ).toBe(false);
 
+    fireEvent.change(getInputByPlaceholder("xAI"), {
+      target: { value: "Second Endpoint" },
+    });
     fireEvent.click(getSubmitButton());
 
     await waitFor(() => {
@@ -718,6 +721,9 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
+    fireEvent.change(getInputByPlaceholder("xAI"), {
+      target: { value: "LM Studio" },
+    });
     fireEvent.change(getInputByPlaceholder("https://api.x.ai/v1"), {
       target: { value: "http://localhost:1234/v1" },
     });

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -175,6 +175,17 @@ function getButton(label: string): HTMLButtonElement {
  * input mounts before a test reads or edits it. Idempotent — a no-op when the
  * section is already expanded.
  */
+/** The submit button — labeled "Add" or "Add <name>" for custom providers. */
+function getSubmitButton(): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((b) => b.textContent?.trim().startsWith("Add"));
+  if (!match) {
+    throw new Error("expected a submit button labeled Add…");
+  }
+  return match;
+}
+
 function openAdvancedFields(): void {
   const button = Array.from(
     document.querySelectorAll<HTMLButtonElement>("button"),
@@ -303,7 +314,6 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
-    openAdvancedFields();
     expect(document.body.textContent).not.toContain(
       "openai-compatible-personal",
     );
@@ -313,7 +323,7 @@ describe("ProviderCreateForm submit sequence", () => {
       ),
     ).toBe(false);
 
-    fireEvent.click(getButton("Add"));
+    fireEvent.click(getSubmitButton());
 
     await waitFor(() => {
       expect(createConnectionCalls.length).toBe(1);
@@ -681,7 +691,8 @@ describe("ProviderCreateForm submit sequence", () => {
     });
     selectDropdownOption("Provider", "Custom provider");
 
-    fireEvent.click(getButton("Add"));
+    // The custom form's submit binds to the edited name.
+    fireEvent.click(getButton("Add My Custom Name"));
 
     await waitFor(() => {
       expect(createConnectionCalls.length).toBe(1);
@@ -707,13 +718,13 @@ describe("ProviderCreateForm submit sequence", () => {
       </ModalWrapper>,
     );
 
-    fireEvent.change(getInputByPlaceholder("https://api.example.com/v1"), {
+    fireEvent.change(getInputByPlaceholder("https://api.x.ai/v1"), {
       target: { value: "http://localhost:1234/v1" },
     });
     fireEvent.change(getInputByPlaceholder("model-1, model-2"), {
       target: { value: "my-model" },
     });
-    fireEvent.click(getButton("Add"));
+    fireEvent.click(getSubmitButton());
 
     await waitFor(() => {
       expect(createConnectionCalls.length).toBe(1);
@@ -748,7 +759,13 @@ describe("ProviderCreateForm submit sequence", () => {
     expect(internalKeyInputMounted()).toBe(false);
 
     selectDropdownOption("Provider", "Custom provider");
-    openAdvancedFields();
+    // The custom form replaces the Advanced disclosure with a top-level
+    // Name field; the internal key still never renders.
+    expect(
+      Array.from(document.querySelectorAll("button")).some(
+        (b) => b.textContent?.trim() === "Advanced",
+      ),
+    ).toBe(false);
     expect(internalKeyInputMounted()).toBe(false);
     expect(document.body.textContent).not.toContain(
       "openai-compatible-personal",

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -679,7 +679,7 @@ describe("ProviderCreateForm submit sequence", () => {
     fireEvent.change(getInputByPlaceholder("e.g. My Anthropic Key"), {
       target: { value: "My Custom Name" },
     });
-    selectDropdownOption("Provider", "OpenAI-compatible");
+    selectDropdownOption("Provider", "Custom provider");
 
     fireEvent.click(getButton("Add"));
 
@@ -747,7 +747,7 @@ describe("ProviderCreateForm submit sequence", () => {
     openAdvancedFields();
     expect(internalKeyInputMounted()).toBe(false);
 
-    selectDropdownOption("Provider", "OpenAI-compatible");
+    selectDropdownOption("Provider", "Custom provider");
     openAdvancedFields();
     expect(internalKeyInputMounted()).toBe(false);
     expect(document.body.textContent).not.toContain(

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -371,11 +371,36 @@ export function ProviderCreateForm({
             // Credential ref changes above trigger a new TQ query key,
             // so the presence check auto-refetches for the new provider.
           }}
-          options={connectionProviderOptions.map((p) => ({
-            value: p,
-            label: PROVIDER_DISPLAY_NAMES[p],
-          }))}
+          options={[
+            // Catalog providers first; the custom-provider entry closes the
+            // list. "OpenAI-compatible" is the protocol a custom provider
+            // must speak, not the provider's identity.
+            ...connectionProviderOptions
+              .filter((p) => p !== "openai-compatible")
+              .map((p) => ({
+                value: p,
+                label: PROVIDER_DISPLAY_NAMES[p],
+              })),
+            ...(connectionProviderOptions.includes("openai-compatible")
+              ? [
+                  {
+                    value: "openai-compatible" as ConnectionProvider,
+                    label: "Custom provider",
+                  },
+                ]
+              : []),
+          ]}
         />
+        {isOpenAICompatible ? (
+          <Typography
+            variant="body-small-default"
+            as="p"
+            className="text-[var(--content-tertiary)]"
+          >
+            Custom providers connect to any endpoint that serves the
+            OpenAI-compatible API — xAI, Groq, LM Studio, vLLM, and similar.
+          </Typography>
+        ) : null}
       </div>
 
       {/* Base URL + Models — openai-compatible only */}

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -403,9 +403,21 @@ export function ProviderCreateForm({
         ) : null}
       </div>
 
-      {/* Base URL + Models — openai-compatible only */}
+      {/* Name + Base URL + Models — custom providers only. Name leads:
+          the user is adding "xAI", not configuring a URL. */}
       {isOpenAICompatible && (
         <>
+          <div className="space-y-1">
+            <label className="block text-body-small-default text-[var(--content-tertiary)]">
+              Name
+            </label>
+            <Input
+              value={label}
+              onChange={(e) => handleLabelChange(e.target.value)}
+              placeholder="xAI"
+              fullWidth
+            />
+          </div>
           <div className="space-y-1">
             <label className="block text-body-small-default text-[var(--content-tertiary)]">
               Base URL
@@ -413,7 +425,7 @@ export function ProviderCreateForm({
             <Input
               value={baseUrl}
               onChange={(e) => setBaseUrl(e.target.value)}
-              placeholder="https://api.example.com/v1"
+              placeholder="https://api.x.ai/v1"
               fullWidth
             />
           </div>
@@ -454,6 +466,16 @@ export function ProviderCreateForm({
         />
       )}
 
+      {isOpenAICompatible && authType === "api_key" ? (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-[var(--content-tertiary)]"
+        >
+          Leave the key empty for local endpoints — they connect keyless.
+        </Typography>
+      ) : null}
+
       {/* ChatGPT Subscription OAuth — shown when auth type is oauth_subscription */}
       {authType === "oauth_subscription" && (
         <ChatgptOAuthSection
@@ -462,7 +484,7 @@ export function ProviderCreateForm({
         />
       )}
 
-      {!isChatgpt && advancedDetailsSection}
+      {!isChatgpt && !isOpenAICompatible && advancedDetailsSection}
 
       {error && (
         <Typography
@@ -488,7 +510,11 @@ export function ProviderCreateForm({
           disabled={!canSave || saving || isSavingKey}
           onClick={() => void handleSave()}
         >
-          {saving ? "Saving…" : "Add"}
+          {saving
+            ? "Saving…"
+            : isOpenAICompatible && label.trim()
+              ? `Add ${label.trim()}`
+              : "Add"}
         </Button>
       )}
     </>

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -52,6 +52,15 @@ import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-c
 // Edit lives in `ProviderEditorContent` and is intentionally NOT handled
 // here — this component is create-only.
 
+/** Built-in provider ids and display names, lowercased — names a custom
+ * provider may not take. */
+const RESERVED_PROVIDER_NAMES = new Set(
+  Object.entries(PROVIDER_DISPLAY_NAMES).flatMap(([id, display]) => [
+    id.toLowerCase(),
+    display.toLowerCase(),
+  ]),
+);
+
 export interface ProviderCreateFormProps {
   assistantId: string;
   existingNames: string[];
@@ -163,8 +172,16 @@ export function ProviderCreateForm({
     enabled: true,
   });
 
+  // A custom provider must not take a built-in provider's name — entries
+  // share one flat list, and an entry labeled "Anthropic" would be
+  // indistinguishable from the catalog provider.
+  const reservedNameConflict =
+    isOpenAICompatible &&
+    RESERVED_PROVIDER_NAMES.has(label.trim().toLowerCase());
   const canSave =
-    name.trim().length > 0 && (!isOpenAICompatible || label.trim().length > 0);
+    name.trim().length > 0 &&
+    (!isOpenAICompatible || label.trim().length > 0) &&
+    !reservedNameConflict;
 
   async function handleSave() {
     if (!canSave) {
@@ -423,6 +440,15 @@ export function ProviderCreateForm({
               placeholder="xAI"
               fullWidth
             />
+            {reservedNameConflict ? (
+              <Typography
+                variant="body-small-default"
+                as="p"
+                className="text-(--system-negative-strong)"
+              >
+                That name belongs to a built-in provider. Pick another.
+              </Typography>
+            ) : null}
           </div>
           <div className="space-y-1">
             <label className="block text-body-small-default text-[var(--content-tertiary)]">

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -85,7 +85,9 @@ export function ProviderCreateForm({
     existingNames,
   );
 
-  const [label, setLabel] = useState(initialDefaults.name);
+  const [label, setLabel] = useState(
+    initialProvider === "openai-compatible" ? "" : initialDefaults.name,
+  );
   const [name, setName] = useState(initialDefaults.key);
   // The picker offers real connection providers plus "chatgpt", a
   // subscription-auth pseudo-provider: its connection is created by the OAuth
@@ -161,7 +163,8 @@ export function ProviderCreateForm({
     enabled: true,
   });
 
-  const canSave = name.trim().length > 0;
+  const canSave =
+    name.trim().length > 0 && (!isOpenAICompatible || label.trim().length > 0);
 
   async function handleSave() {
     if (!canSave) {
@@ -360,7 +363,10 @@ export function ProviderCreateForm({
               existingNames,
             );
             if (!isLabelDirty.current) {
-              setLabel(seedName);
+              // A custom provider's name is the user's identity for it —
+              // seeding the protocol's display name would produce
+              // "Add OpenAI-compatible".
+              setLabel(newSelected === "openai-compatible" ? "" : seedName);
             }
             setName(seedKey);
             setCredential(


### PR DESCRIPTION
## Summary
- The create-provider flow offers **Custom provider** (sorted last, protocol requirement stated once as a hint) instead of listing the wire protocol as a provider identity. The custom form leads with **Name** (never pre-seeded, always required, built-in provider names reserved), uses real-vernacular placeholders (`https://api.x.ai/v1`), notes the keyless local-endpoint path, and its submit button binds to the name — "Add xAI".
- Provider-picker rows carry a right-aligned meta through the Dropdown's existing `suffix` slot — `Vellum — Managed`, `xAI — Custom` — so each row answers "whose infrastructure" at the moment of choice. Zero design-library changes.
- Provider cards tag custom entries and show an endpoint meta line: `api.x.ai · 2 models`, `127.0.0.1:1234 · 1 model · keyless`.
- Wire semantics unchanged: custom providers still store `provider: "openai-compatible"` + the endpoint binding. The follow-on design (profiles referencing provider *entries* by a single name field, which is what finally deletes `provider_connection`) is the Milestone D / PR 13 work — proposal with mocks and the wire-model fork: https://claude.ai/code/artifact/6b0e1ca1-042c-4f03-baad-1494787cacdc

## Original prompt
Part of the connection-removal effort (papertrail #38102): Emmie's observation that "OpenAI-compatible" is a wire protocol posing as a provider — users add xAI or an LM Studio box, and the compatibility requirement belongs on the create form, not in the identity layer. Initially built as a team-buy-in prototype, promoted to a shippable polish PR: the flat provider-entry model is the direction of record, and this is its first user-visible step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)