### PR TITLE
feat(web): detect secrets in the chat draft and warn above the composer

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -26,6 +26,7 @@ import { useTranscriptData } from "@/domains/chat/hooks/use-transcript-data";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
 import { useChatEmptyState } from "@/domains/chat/hooks/use-chat-empty-state";
 import { useComposerSubmit } from "@/domains/chat/hooks/use-composer-submit";
+import { useDraftSecretDetection } from "@/domains/chat/hooks/use-draft-secret-detection";
 import { DiskPressureBannerSlot } from "@/domains/chat/components/disk-pressure-banner-slot";
 import { useRuleEditorBridge } from "@/domains/chat/hooks/use-rule-editor-bridge";
 import { useChatBannerSlots } from "@/domains/chat/hooks/use-chat-banner-slots";
@@ -54,6 +55,7 @@ import { ChatBody } from "@/domains/chat/components/chat-body";
 import { ChatComposer } from "@/domains/chat/components/chat-composer/chat-composer";
 import { ChatRuleEditorModal } from "@/domains/chat/components/chat-rule-editor-modal";
 import { ComposerNotices } from "@/domains/chat/components/composer-notices";
+import { ComposerSecretNotice } from "@/domains/chat/components/composer-secret-notice";
 import { ComposerSettingsMenu } from "@/domains/chat/components/composer-settings-menu";
 import { ContextWindowIndicator } from "@/domains/chat/components/context-window-indicator";
 import { CreditsExhaustedBanner } from "@/domains/chat/components/credits-exhausted-banner";
@@ -451,6 +453,14 @@ export function ChatMainPanel({
   // Feature flags
   // -------------------------------------------------------------------------
   const queueSteering = useAssistantFeatureFlagStore.use.queueSteering();
+
+  // -------------------------------------------------------------------------
+  // Draft secret detection (flag-gated) — owns the composer warning's
+  // matches/dismissal plus the pre-send gate state.
+  // -------------------------------------------------------------------------
+  const draftSecretDetection = useDraftSecretDetection({
+    conversationId: activeConversationId,
+  });
 
   // -------------------------------------------------------------------------
   // Onboarding choice card
@@ -998,41 +1008,50 @@ export function ChatMainPanel({
         />
       }
       noticesAboveFormSlot={
-        <ComposerNotices
-          voiceError={voiceError}
-          onClearVoiceError={clearVoiceError}
-          onRetryMicPermission={handleRetryMicPermission}
-          onOpenMicSettings={handleOpenMicSettings}
-          onOpenTextInsertionSettings={handleOpenTextInsertionSettings}
-          billingBannerSlot={
-            billingBannerDecision === "daily_limit" ? (
-              <DailyLimitBanner onAdjustLimit={pushToBillingSettings} />
-            ) : billingBannerDecision === "managed_credits" ? (
-              <CreditsExhaustedBanner
-                mode={creditPaywallMode}
-                onAddCredits={() => setShowAddCreditsModal(true)}
-                onUpgrade={pushToPlansTakeover}
+        <>
+          {draftSecretDetection.matches.length > 0 &&
+            !draftSecretDetection.dismissed && (
+              <ComposerSecretNotice
+                matches={draftSecretDetection.matches}
+                onDismiss={draftSecretDetection.dismiss}
               />
-            ) : billingBannerDecision === "provider_billing" ? (
-              <ProviderBillingBanner onOpenSettings={pushToAiSettings} />
-            ) : null
-          }
-          diskPressureBanner={diskPressureBannerSlot}
-          showMissingApiKeyBanner={
-            error?.code === "PROVIDER_NOT_CONFIGURED"
-          }
-          onOpenAiSettings={pushToAiSettings}
-          onDismissApiKeyError={handleDismissApiKeyError}
-          compactionCircuitOpenUntil={compactionCircuitOpenUntil}
-          onCompactionCircuitExpired={handleCompactionCircuitExpired}
-          showMaintenanceBanner={
-            assistantState.kind === "active" &&
-            assistantState.maintenanceMode?.enabled === true
-          }
-          showMaintenanceExitAction={!statusBannerVisible}
-          assistantId={assistantId}
-          onMaintenanceExited={handleMaintenanceExited}
-        />
+            )}
+          <ComposerNotices
+            voiceError={voiceError}
+            onClearVoiceError={clearVoiceError}
+            onRetryMicPermission={handleRetryMicPermission}
+            onOpenMicSettings={handleOpenMicSettings}
+            onOpenTextInsertionSettings={handleOpenTextInsertionSettings}
+            billingBannerSlot={
+              billingBannerDecision === "daily_limit" ? (
+                <DailyLimitBanner onAdjustLimit={pushToBillingSettings} />
+              ) : billingBannerDecision === "managed_credits" ? (
+                <CreditsExhaustedBanner
+                  mode={creditPaywallMode}
+                  onAddCredits={() => setShowAddCreditsModal(true)}
+                  onUpgrade={pushToPlansTakeover}
+                />
+              ) : billingBannerDecision === "provider_billing" ? (
+                <ProviderBillingBanner onOpenSettings={pushToAiSettings} />
+              ) : null
+            }
+            diskPressureBanner={diskPressureBannerSlot}
+            showMissingApiKeyBanner={
+              error?.code === "PROVIDER_NOT_CONFIGURED"
+            }
+            onOpenAiSettings={pushToAiSettings}
+            onDismissApiKeyError={handleDismissApiKeyError}
+            compactionCircuitOpenUntil={compactionCircuitOpenUntil}
+            onCompactionCircuitExpired={handleCompactionCircuitExpired}
+            showMaintenanceBanner={
+              assistantState.kind === "active" &&
+              assistantState.maintenanceMode?.enabled === true
+            }
+            showMaintenanceExitAction={!statusBannerVisible}
+            assistantId={assistantId}
+            onMaintenanceExited={handleMaintenanceExited}
+          />
+        </>
       }
     />
   );

--- a/clients/web/src/domains/chat/components/composer-secret-notice.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-secret-notice.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tests for `ComposerSecretNotice` — masked display, generic copy, and
+ * dismissal. The token is a synthetic value invented for these tests.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { DetectedSecret } from "@vellumai/service-contracts/secret-detection";
+
+import {
+  ComposerSecretNotice,
+  maskSecretValue,
+} from "./composer-secret-notice";
+
+const SYNTHETIC_PROJECT_KEY =
+  "sk-proj-Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv1Wx2Yz3A";
+
+const match: DetectedSecret = {
+  label: "OpenAI Project Key",
+  value: SYNTHETIC_PROJECT_KEY,
+  start: 0,
+  end: SYNTHETIC_PROJECT_KEY.length,
+  wholeMessage: false,
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("maskSecretValue", () => {
+  test("keeps a short head and masks the rest", () => {
+    const masked = maskSecretValue(SYNTHETIC_PROJECT_KEY);
+    expect(masked).toBe("sk-pro••••••••");
+    expect(masked).not.toContain(SYNTHETIC_PROJECT_KEY);
+  });
+});
+
+describe("ComposerSecretNotice", () => {
+  test("renders the masked value — the full plaintext never reaches the DOM", () => {
+    const { container } = render(
+      <ComposerSecretNotice matches={[match]} onDismiss={() => {}} />,
+    );
+    expect(container.textContent).toContain("This looks like an API key");
+    expect(container.textContent).toContain(
+      maskSecretValue(SYNTHETIC_PROJECT_KEY),
+    );
+    expect(container.textContent).toContain(
+      "Credentials sent in chat are visible in the transcript — store it securely instead.",
+    );
+    expect(container.innerHTML).not.toContain(SYNTHETIC_PROJECT_KEY);
+    // The detection label (vendor) stays internal.
+    expect(container.textContent).not.toContain("OpenAI");
+  });
+
+  test("dismiss control invokes onDismiss", () => {
+    const onDismiss = mock(() => {});
+    render(<ComposerSecretNotice matches={[match]} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByLabelText("Dismiss"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders nothing without matches", () => {
+    const { container } = render(
+      <ComposerSecretNotice matches={[]} onDismiss={() => {}} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/clients/web/src/domains/chat/components/composer-secret-notice.tsx
+++ b/clients/web/src/domains/chat/components/composer-secret-notice.tsx
@@ -1,0 +1,53 @@
+import { Notice } from "@vellumai/design-library";
+import type { DetectedSecret } from "@vellumai/service-contracts/secret-detection";
+
+/** Leading characters of the detected value kept visible in the masked preview. */
+const MASK_VISIBLE_CHARS = 6;
+const MASK_BULLETS = "•".repeat(8);
+
+/**
+ * Masked preview of a detected secret: a short recognizable head plus a
+ * fixed bullet tail — never the full value.
+ */
+export function maskSecretValue(value: string): string {
+  return `${value.slice(0, MASK_VISIBLE_CHARS)}${MASK_BULLETS}`;
+}
+
+export interface ComposerSecretNoticeProps {
+  /** Detected secrets ordered by draft position; the first is previewed. */
+  matches: DetectedSecret[];
+  /** Invoked when the user dismisses the warning. */
+  onDismiss: () => void;
+}
+
+/**
+ * Passive warning above the composer when the draft contains what looks
+ * like an API key. The copy is deliberately generic — the detection label
+ * (which names the vendor) stays internal and is never rendered. The
+ * detected value appears masked only; the full plaintext never reaches the
+ * DOM.
+ */
+export function ComposerSecretNotice({
+  matches,
+  onDismiss,
+}: ComposerSecretNoticeProps) {
+  const first = matches[0];
+  if (!first) {
+    return null;
+  }
+  return (
+    <div className="mb-2">
+      <Notice
+        tone="warning"
+        title="This looks like an API key"
+        onDismiss={onDismiss}
+      >
+        <span className="font-mono">{maskSecretValue(first.value)}</span>
+        <p>
+          Credentials sent in chat are visible in the transcript — store it
+          securely instead.
+        </p>
+      </Notice>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.test.tsx
@@ -37,16 +37,25 @@ function setDraft(text: string) {
   });
 }
 
-function renderDetection(conversationId: string | null = "conv-1") {
+function renderDetection(
+  conversationId: string | null = "conv-1",
+  debounceMs = 0,
+) {
   return renderHook(
     (props: { conversationId: string | null }) =>
       useDraftSecretDetection({
         conversationId: props.conversationId,
-        debounceMs: 0,
+        debounceMs,
       }),
     { initialProps: { conversationId } },
   );
 }
+
+/**
+ * A debounce that never elapses within a test — assertions passing under it
+ * prove the scan ran synchronously rather than through the debounce timer.
+ */
+const NEVER_ELAPSES_MS = 60_000;
 
 beforeEach(() => {
   seedFlags({ composerSecretGuard: false, hasHydrated: false });
@@ -159,6 +168,53 @@ describe("useDraftSecretDetection detection", () => {
 
     rerender({ conversationId: "conv-2" });
     expect(result.current.dismissed).toBe(false);
+  });
+
+  test("conversation switch clears stale matches synchronously — even dismissed ones", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    setDraft(`here is ${SYNTHETIC_PROJECT_KEY}`);
+    const { result, rerender } = renderDetection("conv-1", NEVER_ELAPSES_MS);
+    expect(result.current.matches).toHaveLength(1);
+    act(() => {
+      result.current.dismiss();
+    });
+    act(() => {
+      result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
+    });
+    expect(result.current.sendBlocked).toBe(true);
+
+    // The draft swap lands via a post-render store effect, so at switch time
+    // the composer still holds conversation A's draft. The stale match (and
+    // its masked preview, un-hidden by the dismissal reset) must already be
+    // gone — no debounce-window flash over conversation B's composer.
+    rerender({ conversationId: "conv-2" });
+    expect(result.current.matches).toEqual([]);
+    expect(result.current.dismissed).toBe(false);
+    expect(result.current.sendBlocked).toBe(false);
+  });
+
+  test("a restored draft with a secret warns immediately after a switch", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    setDraft(`conversation A: ${SYNTHETIC_PROJECT_KEY}`);
+    const { result, rerender } = renderDetection("conv-1", NEVER_ELAPSES_MS);
+    expect(result.current.matches).toHaveLength(1);
+
+    rerender({ conversationId: "conv-2" });
+    expect(result.current.matches).toEqual([]);
+
+    // The session store restores conversation B's saved draft after the
+    // switch commit; its secret surfaces without waiting out the debounce.
+    setDraft(`restored draft: ${SYNTHETIC_GITHUB_TOKEN}`);
+    expect(result.current.matches).toHaveLength(1);
+    expect(result.current.matches[0]?.value).toBe(SYNTHETIC_GITHUB_TOKEN);
+    expect(result.current.dismissed).toBe(false);
+
+    // The immediate scan is single-use — the next input change is a
+    // keystroke again and waits out the (never-elapsing) debounce.
+    setDraft(
+      `restored draft: ${SYNTHETIC_GITHUB_TOKEN} plus ${SYNTHETIC_PROJECT_KEY}`,
+    );
+    expect(result.current.matches).toHaveLength(1);
   });
 
   test("scanning waits out the debounce between keystrokes", async () => {

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * Tests for the draft secret-detection hook and its pure scan policy.
+ *
+ * Uses the real composer and assistant-feature-flag stores (reset between
+ * tests) so the hook's store subscription, flag gating, and dismissal
+ * lifecycle are exercised end to end. All tokens are synthetic values
+ * invented for these tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+
+import { useComposerStore } from "@/domains/chat/composer-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+
+import {
+  SECRET_SCAN_MIN_DRAFT_LENGTH,
+  scanDraftForSecrets,
+  useDraftSecretDetection,
+} from "./use-draft-secret-detection";
+
+// Synthetic lookalike tokens — random strings matching detector shapes.
+const SYNTHETIC_PROJECT_KEY =
+  "sk-proj-Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv1Wx2Yz3A";
+const SYNTHETIC_GITHUB_TOKEN = "ghp_Zx9Wv8Ut7Sr6Qp5On4Ml3Kj2Ih1Gf0EdCbA9";
+
+function seedFlags(flags: {
+  composerSecretGuard: boolean;
+  hasHydrated: boolean;
+}) {
+  useAssistantFeatureFlagStore.setState(flags);
+}
+
+function setDraft(text: string) {
+  act(() => {
+    useComposerStore.getState().setInput(text);
+  });
+}
+
+function renderDetection(conversationId: string | null = "conv-1") {
+  return renderHook(
+    (props: { conversationId: string | null }) =>
+      useDraftSecretDetection({
+        conversationId: props.conversationId,
+        debounceMs: 0,
+      }),
+    { initialProps: { conversationId } },
+  );
+}
+
+beforeEach(() => {
+  seedFlags({ composerSecretGuard: false, hasHydrated: false });
+  useComposerStore.getState().setInput("");
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Pure scan policy
+// ---------------------------------------------------------------------------
+
+describe("scanDraftForSecrets", () => {
+  test("returns nothing when disabled, regardless of content", () => {
+    expect(
+      scanDraftForSecrets(`deploy with ${SYNTHETIC_PROJECT_KEY}`, false),
+    ).toEqual([]);
+  });
+
+  test("skips drafts shorter than the minimum scan length", () => {
+    const short = "a".repeat(SECRET_SCAN_MIN_DRAFT_LENGTH - 1);
+    expect(scanDraftForSecrets(short, true)).toEqual([]);
+  });
+
+  test("detects a token in a long-enough enabled draft", () => {
+    const matches = scanDraftForSecrets(
+      `here is ${SYNTHETIC_PROJECT_KEY} for you`,
+      true,
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.value).toBe(SYNTHETIC_PROJECT_KEY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook — flag gating
+// ---------------------------------------------------------------------------
+
+describe("useDraftSecretDetection flag gating", () => {
+  test("flag off: no matches even with a key in the draft", () => {
+    seedFlags({ composerSecretGuard: false, hasHydrated: true });
+    setDraft(`deploy with ${SYNTHETIC_PROJECT_KEY}`);
+    const { result } = renderDetection();
+    expect(result.current.matches).toEqual([]);
+    expect(result.current.dismissed).toBe(false);
+    expect(result.current.sendBlocked).toBe(false);
+  });
+
+  test("flag on but store not hydrated: inert", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: false });
+    setDraft(`deploy with ${SYNTHETIC_PROJECT_KEY}`);
+    const { result } = renderDetection();
+    expect(result.current.matches).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook — detection + dismissal lifecycle
+// ---------------------------------------------------------------------------
+
+describe("useDraftSecretDetection detection", () => {
+  test("flag on: match surfaces, dismiss hides, deletion resets", async () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    setDraft(`here is ${SYNTHETIC_PROJECT_KEY}`);
+    const { result } = renderDetection();
+
+    expect(result.current.matches).toHaveLength(1);
+    expect(result.current.matches[0]?.value).toBe(SYNTHETIC_PROJECT_KEY);
+    expect(result.current.dismissed).toBe(false);
+
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.dismissed).toBe(true);
+
+    // Deleting the key removes the match and resets dismissal.
+    setDraft("no secrets here anymore");
+    await waitFor(() => {
+      expect(result.current.matches).toEqual([]);
+    });
+    expect(result.current.dismissed).toBe(false);
+  });
+
+  test("a newly flagged value re-surfaces a dismissed notice", async () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    setDraft(`first ${SYNTHETIC_PROJECT_KEY}`);
+    const { result } = renderDetection();
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.dismissed).toBe(true);
+
+    setDraft(`first ${SYNTHETIC_PROJECT_KEY} then ${SYNTHETIC_GITHUB_TOKEN}`);
+    await waitFor(() => {
+      expect(result.current.matches).toHaveLength(2);
+    });
+    expect(result.current.dismissed).toBe(false);
+  });
+
+  test("dismissal resets when the conversation changes", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    setDraft(`here is ${SYNTHETIC_PROJECT_KEY}`);
+    const { result, rerender } = renderDetection("conv-1");
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.dismissed).toBe(true);
+
+    rerender({ conversationId: "conv-2" });
+    expect(result.current.dismissed).toBe(false);
+  });
+
+  test("scanning waits out the debounce between keystrokes", async () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    const { result } = renderDetection();
+    expect(result.current.matches).toEqual([]);
+
+    setDraft(`typed later: ${SYNTHETIC_PROJECT_KEY}`);
+    // Debounced: not scanned synchronously on the keystroke.
+    expect(result.current.matches).toEqual([]);
+    await waitFor(() => {
+      expect(result.current.matches).toHaveLength(1);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook — pre-send gate state (nothing in the submit path calls this yet)
+// ---------------------------------------------------------------------------
+
+describe("useDraftSecretDetection checkBeforeSend", () => {
+  test("blocks a send containing a secret and sets sendBlocked", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    const { result } = renderDetection();
+
+    let allowed = true;
+    act(() => {
+      allowed = result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
+    });
+    expect(allowed).toBe(false);
+    expect(result.current.sendBlocked).toBe(true);
+    expect(result.current.matches).toHaveLength(1);
+  });
+
+  test("allowOnce arms a single-use bypass", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    const { result } = renderDetection();
+
+    act(() => {
+      result.current.allowOnce();
+    });
+    let allowed = false;
+    act(() => {
+      allowed = result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
+    });
+    expect(allowed).toBe(true);
+    expect(result.current.sendBlocked).toBe(false);
+
+    act(() => {
+      allowed = result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
+    });
+    expect(allowed).toBe(false);
+    expect(result.current.sendBlocked).toBe(true);
+  });
+
+  test("passes clean text and clears sendBlocked", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    const { result } = renderDetection();
+    act(() => {
+      result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
+    });
+    expect(result.current.sendBlocked).toBe(true);
+
+    let allowed = false;
+    act(() => {
+      allowed = result.current.checkBeforeSend("all clear now");
+    });
+    expect(allowed).toBe(true);
+    expect(result.current.sendBlocked).toBe(false);
+  });
+
+  test("passes everything while the flag is off", () => {
+    seedFlags({ composerSecretGuard: false, hasHydrated: true });
+    const { result } = renderDetection();
+    let allowed = false;
+    act(() => {
+      allowed = result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
+    });
+    expect(allowed).toBe(true);
+    expect(result.current.sendBlocked).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
@@ -1,0 +1,221 @@
+/**
+ * Detects high-confidence secrets (API keys, tokens) in the chat draft and
+ * owns the notice/dismissal + pre-send gate state for the composer secret
+ * guard.
+ *
+ * Gated on the `composer-secret-guard` assistant flag: while the flag is off
+ * (or the flag store has not hydrated yet) the hook is inert — no store
+ * subscription, no scanning work, `matches` is always empty.
+ *
+ * Draft scanning subscribes to the composer store directly (debounced,
+ * non-reactive) instead of taking the draft as a reactive prop: the
+ * orchestrator that mounts this hook deliberately does not subscribe to
+ * composer input, so typing must never re-render it. React state only
+ * changes when the detected set changes.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  detectSecretsInText,
+  type DetectedSecret,
+} from "@vellumai/service-contracts/secret-detection";
+
+import { useComposerStore } from "@/domains/chat/composer-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+
+// ---------------------------------------------------------------------------
+// Pure scan policy (DOM-free, exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Drafts shorter than this are skipped without invoking the detector — no
+ * detectable token pattern fits in fewer characters.
+ */
+export const SECRET_SCAN_MIN_DRAFT_LENGTH = 16;
+
+/** Debounce between a draft keystroke and the scan it triggers. */
+export const SECRET_SCAN_DEBOUNCE_MS = 250;
+
+/**
+ * Scan decision + prefilter: returns the secrets to surface for a draft, or
+ * an empty list when scanning is disabled or the draft is too short to
+ * contain a detectable token.
+ */
+export function scanDraftForSecrets(
+  text: string,
+  enabled: boolean,
+): DetectedSecret[] {
+  if (!enabled || text.length < SECRET_SCAN_MIN_DRAFT_LENGTH) {
+    return [];
+  }
+  return detectSecretsInText(text);
+}
+
+function sameMatches(a: DetectedSecret[], b: DetectedSecret[]): boolean {
+  return (
+    a.length === b.length &&
+    a.every((m, i) => {
+      const other = b[i];
+      return (
+        other !== undefined &&
+        m.label === other.label &&
+        m.value === other.value &&
+        m.start === other.start &&
+        m.end === other.end
+      );
+    })
+  );
+}
+
+const EMPTY_VALUE_SET: ReadonlySet<string> = new Set();
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseDraftSecretDetectionParams {
+  /**
+   * Routing-truth conversation id. Switching conversations swaps the draft,
+   * so dismissal and send-block state reset when it changes.
+   */
+  conversationId: string | null;
+  /** Scan debounce override for tests. */
+  debounceMs?: number;
+}
+
+export interface DraftSecretDetectionResult {
+  /**
+   * Secrets currently detected in the draft, ordered by position. Empty
+   * while the flag is off or the flag store has not hydrated.
+   */
+  matches: DetectedSecret[];
+  /** True when the user dismissed the notice for every flagged value. */
+  dismissed: boolean;
+  /**
+   * Suppress the notice for the currently flagged values. Auto-resets when
+   * the flagged values leave the draft, a new value is flagged, or the
+   * conversation changes.
+   */
+  dismiss: () => void;
+  /** True when the most recent {@link checkBeforeSend} blocked a send. */
+  sendBlocked: boolean;
+  /**
+   * Pre-send gate: scans the outgoing text and returns whether the send may
+   * proceed. Returns false (and sets {@link sendBlocked}) when secrets are
+   * detected and no {@link allowOnce} bypass is armed.
+   */
+  checkBeforeSend: (text: string) => boolean;
+  /** Arm a single-use bypass so the next {@link checkBeforeSend} passes. */
+  allowOnce: () => void;
+}
+
+export function useDraftSecretDetection({
+  conversationId,
+  debounceMs = SECRET_SCAN_DEBOUNCE_MS,
+}: UseDraftSecretDetectionParams): DraftSecretDetectionResult {
+  const composerSecretGuard =
+    useAssistantFeatureFlagStore.use.composerSecretGuard();
+  const hasHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
+  const enabled = hasHydrated && composerSecretGuard;
+
+  const [matches, setMatches] = useState<DetectedSecret[]>([]);
+  const [dismissedValues, setDismissedValues] =
+    useState<ReadonlySet<string>>(EMPTY_VALUE_SET);
+  const [sendBlocked, setSendBlocked] = useState(false);
+  const allowOnceRef = useRef(false);
+
+  // Dismissal and send-block state are scoped to one conversation's draft
+  // under one flag state — any transition of either invalidates them.
+  useEffect(() => {
+    allowOnceRef.current = false;
+    setSendBlocked(false);
+    setDismissedValues(EMPTY_VALUE_SET);
+  }, [enabled, conversationId]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setMatches([]);
+      return;
+    }
+
+    const applyScan = (text: string) => {
+      const next = scanDraftForSecrets(text, true);
+      setMatches((prev) => (sameMatches(prev, next) ? prev : next));
+      if (next.length === 0) {
+        // The flagged values left the draft: reset dismissal and any block.
+        setDismissedValues((prev) =>
+          prev.size === 0 ? prev : EMPTY_VALUE_SET,
+        );
+        setSendBlocked(false);
+      }
+    };
+
+    // Scan the current draft immediately (restored drafts, prefills);
+    // conversation switches re-enter here through the input subscription.
+    applyScan(useComposerStore.getState().input);
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const unsubscribe = useComposerStore.subscribe((state, prevState) => {
+      if (state.input === prevState.input) {
+        return;
+      }
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => {
+        timer = null;
+        applyScan(useComposerStore.getState().input);
+      }, debounceMs);
+    });
+
+    return () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+      unsubscribe();
+    };
+  }, [enabled, debounceMs]);
+
+  const dismiss = useCallback(() => {
+    setDismissedValues(new Set(matches.map((m) => m.value)));
+  }, [matches]);
+
+  const allowOnce = useCallback(() => {
+    allowOnceRef.current = true;
+    setSendBlocked(false);
+  }, []);
+
+  const checkBeforeSend = useCallback(
+    (text: string): boolean => {
+      if (!enabled) {
+        return true;
+      }
+      if (allowOnceRef.current) {
+        allowOnceRef.current = false;
+        setSendBlocked(false);
+        return true;
+      }
+      const found = scanDraftForSecrets(text, true);
+      if (found.length === 0) {
+        setSendBlocked(false);
+        return true;
+      }
+      setMatches((prev) => (sameMatches(prev, found) ? prev : found));
+      setSendBlocked(true);
+      return false;
+    },
+    [enabled],
+  );
+
+  const dismissed =
+    matches.length > 0 && matches.every((m) => dismissedValues.has(m.value));
+
+  return {
+    matches,
+    dismissed,
+    dismiss,
+    sendBlocked,
+    checkBeforeSend,
+    allowOnce,
+  };
+}

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
@@ -12,6 +12,12 @@
  * orchestrator that mounts this hook deliberately does not subscribe to
  * composer input, so typing must never re-render it. React state only
  * changes when the detected set changes.
+ *
+ * Conversation switches are the one non-debounced path: stale matches are
+ * cleared in the switch commit and the incoming conversation's restored
+ * draft is scanned as soon as the session store swaps it in, so a stale
+ * notice never flashes over the new composer and a restored secret warns
+ * without waiting out the debounce.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -76,7 +82,8 @@ const EMPTY_VALUE_SET: ReadonlySet<string> = new Set();
 export interface UseDraftSecretDetectionParams {
   /**
    * Routing-truth conversation id. Switching conversations swaps the draft,
-   * so dismissal and send-block state reset when it changes.
+   * so matches, dismissal, and send-block state reset when it changes and
+   * the incoming draft is re-scanned immediately.
    */
   conversationId: string | null;
   /** Scan debounce override for tests. */
@@ -123,6 +130,12 @@ export function useDraftSecretDetection({
     useState<ReadonlySet<string>>(EMPTY_VALUE_SET);
   const [sendBlocked, setSendBlocked] = useState(false);
   const allowOnceRef = useRef(false);
+  // Armed on a conversation switch: the next composer input change is the
+  // incoming conversation's restored draft (applied by the session store's
+  // post-render switch effect), not a keystroke, so it is scanned
+  // immediately instead of debounced.
+  const scanNextInputImmediatelyRef = useRef(false);
+  const prevConversationIdRef = useRef(conversationId);
 
   // Dismissal and send-block state are scoped to one conversation's draft
   // under one flag state — any transition of either invalidates them.
@@ -131,6 +144,21 @@ export function useDraftSecretDetection({
     setSendBlocked(false);
     setDismissedValues(EMPTY_VALUE_SET);
   }, [enabled, conversationId]);
+
+  // Conversation switches swap the draft in a parent post-render effect,
+  // after this effect runs — the composer store still holds the outgoing
+  // conversation's draft here, so scanning it would resurrect the old
+  // matches. Instead: drop the stale matches in this commit (the previous
+  // conversation's notice must never carry over the new composer) and arm
+  // the immediate scan of the incoming draft when the swap lands.
+  useEffect(() => {
+    if (prevConversationIdRef.current === conversationId) {
+      return;
+    }
+    prevConversationIdRef.current = conversationId;
+    setMatches((prev) => (prev.length === 0 ? prev : []));
+    scanNextInputImmediatelyRef.current = true;
+  }, [conversationId]);
 
   useEffect(() => {
     if (!enabled) {
@@ -152,6 +180,7 @@ export function useDraftSecretDetection({
 
     // Scan the current draft immediately (restored drafts, prefills);
     // conversation switches re-enter here through the input subscription.
+    scanNextInputImmediatelyRef.current = false;
     applyScan(useComposerStore.getState().input);
 
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -161,6 +190,14 @@ export function useDraftSecretDetection({
       }
       if (timer !== null) {
         clearTimeout(timer);
+        timer = null;
+      }
+      if (scanNextInputImmediatelyRef.current) {
+        // Conversation-switch draft swap: surface the incoming draft's
+        // secrets without waiting out the keystroke debounce.
+        scanNextInputImmediatelyRef.current = false;
+        applyScan(state.input);
+        return;
       }
       timer = setTimeout(() => {
         timer = null;

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
@@ -20,7 +20,13 @@
  * without waiting out the debounce.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   detectSecretsInText,
   type DetectedSecret,
@@ -139,7 +145,8 @@ export function useDraftSecretDetection({
 
   // Dismissal and send-block state are scoped to one conversation's draft
   // under one flag state — any transition of either invalidates them.
-  useEffect(() => {
+  // Layout effect: the reset must land before the switched route paints.
+  useLayoutEffect(() => {
     allowOnceRef.current = false;
     setSendBlocked(false);
     setDismissedValues(EMPTY_VALUE_SET);
@@ -148,10 +155,11 @@ export function useDraftSecretDetection({
   // Conversation switches swap the draft in a parent post-render effect,
   // after this effect runs — the composer store still holds the outgoing
   // conversation's draft here, so scanning it would resurrect the old
-  // matches. Instead: drop the stale matches in this commit (the previous
-  // conversation's notice must never carry over the new composer) and arm
-  // the immediate scan of the incoming draft when the swap lands.
-  useEffect(() => {
+  // matches. Instead: drop the stale matches before the new route paints
+  // (layout effect — the previous conversation's notice must never be
+  // visible over the new composer, even for one frame) and arm the
+  // immediate scan of the incoming draft when the swap lands.
+  useLayoutEffect(() => {
     if (prevConversationIdRef.current === conversationId) {
       return;
     }


### PR DESCRIPTION
## Summary
- New use-draft-secret-detection hook (debounced, flag-gated on composer-secret-guard, powered by the shared secret-detection module)
- ComposerSecretNotice warning above the composer with masked value and generic no-vendor copy; Dismiss only (Store securely arrives in PR 7)
- Pure-helper + hook + render tests, synthetic fixtures

Part of plan: composer-secret-guard.md (PR 5 of 7)