### PR TITLE
feat(plugins): reserve the vellum- plugin name prefix for first-party plugins

### DIFF
--- a/assistant/src/cli/lib/__tests__/install-from-github.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-github.test.ts
@@ -1395,14 +1395,18 @@ describe("sanitizePluginName", () => {
     expect(sanitizePluginName("a")).toBe("a");
   });
 
-  test.each(["default-advisor", "default-memory", "default-", "default-x"])(
-    "rejects reserved prefix name %p",
-    (reserved) => {
-      expect(() => sanitizePluginName(reserved)).toThrow(
-        InvalidPluginNameError,
-      );
-    },
-  );
+  test.each([
+    "default-advisor",
+    "default-memory",
+    "default-",
+    "default-x",
+    "vellum-db",
+    "vellum-memory",
+    "vellum-",
+    "vellum-x",
+  ])("rejects reserved prefix name %p", (reserved) => {
+    expect(() => sanitizePluginName(reserved)).toThrow(InvalidPluginNameError);
+  });
 });
 
 describe("resolveTreeRefPath", () => {

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -330,13 +330,17 @@ async function resolvePluginSource(
 }
 
 /**
- * Prefix reserved for first-party default plugins that ship in the assistant
- * source tree. User-installable plugins must not use it — the `.disabled`
- * sentinel and the plugin registry both key on manifest names, and a
- * user plugin with a `default-` name would shadow or collide with the
- * built-in.
+ * Prefixes reserved for first-party plugins that ship from the Vellum team.
+ * User-installable plugins must not use them — the `.disabled` sentinel and
+ * the plugin registry both key on manifest names, and a user plugin with a
+ * reserved name would shadow or collide with a first-party one.
+ *
+ * - `default-`: built-in default plugins that ship in the assistant source
+ *   tree.
+ * - `vellum-`: first-class plugins shipped from the Vellum team (e.g. curated
+ *   marketplace entries).
  */
-export const RESERVED_PLUGIN_PREFIX = "default-";
+export const RESERVED_PLUGIN_PREFIXES = ["default-", "vellum-"] as const;
 
 /**
  * Reject plugin names that could escape the canonical source path or the
@@ -344,8 +348,9 @@ export const RESERVED_PLUGIN_PREFIX = "default-";
  * `plugins/`, so a legitimate name is a single path segment
  * built from kebab-case alphanumerics.
  *
- * Names prefixed with {@link RESERVED_PLUGIN_PREFIX} (`default-`) are also
- * rejected — that prefix is reserved for first-party default plugins.
+ * Names carrying one of the {@link RESERVED_PLUGIN_PREFIXES} (`default-`,
+ * `vellum-`) are also rejected — those prefixes are reserved for first-party
+ * plugins.
  *
  * Exported so callers (e.g. the CLI input prompt) can validate up front
  * before invoking {@link installPlugin}.
@@ -355,10 +360,13 @@ export function sanitizePluginName(name: string): string {
   if (!/^[a-z0-9][a-z0-9_-]*$/.test(trimmed)) {
     throw new InvalidPluginNameError(name);
   }
-  if (trimmed.startsWith(RESERVED_PLUGIN_PREFIX)) {
+  const reservedPrefix = RESERVED_PLUGIN_PREFIXES.find((prefix) =>
+    trimmed.startsWith(prefix),
+  );
+  if (reservedPrefix) {
     throw new InvalidPluginNameError(
       name,
-      `The "${RESERVED_PLUGIN_PREFIX}" prefix is reserved for first-party default plugins.`,
+      `The "${reservedPrefix}" prefix is reserved for first-party plugins.`,
     );
   }
   return trimmed;


### PR DESCRIPTION
## Prompt / plan

Follow-up to review feedback on #38887 ([discussion](https://github.com/vellum-ai/vellum-assistant/pull/38887#discussion_r3641231808)):

> I think we're likely to reserve the `vellum-` prefix for any first class plugins shipped from the team.

This reserves `vellum-` alongside the existing `default-` prefix so user-installable plugins can't shadow or collide with curated first-party plugins shipped from the team.

### Approach

`sanitizePluginName()` in `assistant/src/cli/lib/install-from-github.ts` previously rejected only the single `default-` prefix via `RESERVED_PLUGIN_PREFIX`. That constant is generalized into a `RESERVED_PLUGIN_PREFIXES` list (`["default-", "vellum-"]`), and the name check now rejects any candidate carrying one of them, reporting whichever prefix matched in the error message. The old constant had no external importers, so the rename is contained to this module.

`toggle-plugin.ts` intentionally keeps allowing reserved prefixes (enable/disable must operate on first-party plugins) and is unchanged.

## Test plan

- Extended the `sanitizePluginName` reserved-prefix test cases to cover `vellum-db`, `vellum-memory`, `vellum-`, and `vellum-x` in addition to the existing `default-` cases.
- `bun test src/cli/lib/__tests__/install-from-github.test.ts -t sanitizePluginName` → 15 pass, 0 fail.
- Pre-commit hook: prettier, eslint, and type-check all pass.

<!-- No new routes added; CLI verb checklist not applicable. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeAYJCnZG2djAFw3zjfDMS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeAYJCnZG2djAFw3zjfDMS)_