### PR TITLE
fix(billing): recommended summary drops machine claim when machine is unchanged

### DIFF
--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -351,8 +351,10 @@ describe("PlanCard", () => {
     expect(html).not.toContain("4 GB");
     expect(html).not.toContain("Small Machine");
     // The recommended (Mighty) card shows the single summary chip, replacing the
-    // old absolute per-resource chips (machine · credits · storage).
-    expect(html).toContain("more credits, storage, and a stronger machine");
+    // old absolute per-resource chips (machine · credits · storage). Free→Mighty
+    // stays on the Small baseline, so the chip omits the machine claim.
+    expect(html).toContain("more credits and storage");
+    expect(html).not.toContain("stronger machine");
     expect(html).not.toContain("$25 credits");
     expect(html).not.toContain("10 GB");
     expect(html).not.toContain("vCPU");
@@ -399,9 +401,10 @@ describe("PlanCard", () => {
     expect(html).toContain("Switch to Mighty");
     // A neutral switch drops the "Recommended" tag and renders no chips on the
     // recommended card — not even the summary chip; the current "Custom" card
-    // also has no knowable chips.
+    // also has no knowable chips. Asserting on the "more credits" prefix covers
+    // both the full and machine-less summary labels.
     expect(html).not.toContain("Recommended");
-    expect(html).not.toContain("more credits, storage, and a stronger machine");
+    expect(html).not.toContain("more credits");
   });
 
   test("a customized Pro sub's banner drops the stock upgrade framing", () => {
@@ -418,8 +421,9 @@ describe("PlanCard", () => {
     expect(html).toContain("Switch plan");
     expect(html).toContain("Switch to Super");
     expect(html).not.toContain("Recommended");
-    // A neutral switch renders no summary chip either.
-    expect(html).not.toContain("more credits, storage, and a stronger machine");
+    // A neutral switch renders no summary chip either. The "more credits" prefix
+    // covers both the full and machine-less summary labels.
+    expect(html).not.toContain("more credits");
   });
 
   test("a base user's banner keeps the directional upgrade framing", () => {
@@ -492,8 +496,10 @@ describe("PlanCard", () => {
     expect(html).not.toContain("$0 credits");
     expect(html).not.toContain("4 GB");
     expect(html).not.toContain("Small Machine");
-    // The recommended (Mighty) card shows the single summary chip.
-    expect(html).toContain("more credits, storage, and a stronger machine");
+    // The recommended (Mighty) card shows the single summary chip. Free→Mighty
+    // keeps the Small baseline machine, so the chip claims only credits/storage.
+    expect(html).toContain("more credits and storage");
+    expect(html).not.toContain("stronger machine");
   });
 });
 

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -17,6 +17,7 @@ import { useChangePackage } from "@/domains/settings/billing/use-change-package"
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
 import {
+  machineLabel,
   packageSpecs,
   type PlanSpec,
 } from "@/domains/settings/billing/plan-spec";
@@ -74,15 +75,6 @@ const PLAN_DISPLAY: Record<string, PlanDisplay> = {
 };
 
 const DEFAULT_DISPLAY: PlanDisplay = PLAN_DISPLAY.base;
-
-/** The recommended card's single summary chip (replaces per-resource chips). */
-const RECOMMENDED_SUMMARY_SPECS: PlanSpec[] = [
-  {
-    icon: ArrowUp,
-    label: "more credits, storage, and a stronger machine",
-    multiline: true,
-  },
-];
 
 export interface PlanCardProps {
   onManage: () => void;
@@ -169,6 +161,20 @@ function RecommendedUpgrade({
   const currentPackage = currentKey
     ? (packages.find((p) => p.key === currentKey) ?? null)
     : null;
+  // "a stronger machine" only holds when the recommended tier's machine size
+  // actually steps up. Free→Mighty stays on the Small baseline (machine_size
+  // null), so only credits and storage increase there — drop the machine clause.
+  const machineUpgrades =
+    machineLabel(currentPackage) !== machineLabel(recommended);
+  const summarySpecs: PlanSpec[] = [
+    {
+      icon: ArrowUp,
+      label: machineUpgrades
+        ? "more credits, storage, and a stronger machine"
+        : "more credits and storage",
+      multiline: true,
+    },
+  ];
   const deltaCents =
     recommended.total_price_cents - (currentPackage?.total_price_cents ?? 0);
   // A Custom (customized or unpinned) sub's real tiers can diverge from any
@@ -291,7 +297,7 @@ function RecommendedUpgrade({
           </Tag>
         }
         tagline={recommendedCopy?.tagline}
-        specs={isNeutralSwitch ? null : RECOMMENDED_SUMMARY_SPECS}
+        specs={isNeutralSwitch ? null : summarySpecs}
         action={upgradeButton}
       />
       <PackageSwitchConfirmModal


### PR DESCRIPTION
## Summary
- Free→Mighty (same Small machine) recommended summary now reads 'more credits and storage'
- Mighty→Super and up keep 'more credits, storage, and a stronger machine' (machine actually steps up)
- Derived from machineLabel(current) vs machineLabel(recommended)

Part of the billing Plan section work (feature branch).