### PR TITLE
fix(gateway): guard Slack event-ordering key against missing item/message

### DIFF
--- a/gateway/src/slack/event-ordering.test.ts
+++ b/gateway/src/slack/event-ordering.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "bun:test";
+
+import { slackEventOrderingKey } from "./event-ordering.js";
+import type {
+  SlackAppMentionEvent,
+  SlackMessageChangedEvent,
+  SlackMessageDeletedEvent,
+  SlackReactionAddedEvent,
+  SlackReactionRemovedEvent,
+} from "./normalize.js";
+
+const CHANNEL = "C0ABCDEF";
+const TS = "1700000000.000100";
+const EVENT_ID = "Ev0MALFORMED";
+
+describe("slackEventOrderingKey — well-formed events", () => {
+  it("keys a reaction on its item channel + ts", () => {
+    const event = {
+      type: "reaction_added",
+      user: "U1",
+      reaction: "thumbsup",
+      item: { type: "message", channel: CHANNEL, ts: TS },
+    } as SlackReactionAddedEvent;
+    expect(slackEventOrderingKey(event, EVENT_ID)).toBe(`${CHANNEL}:${TS}`);
+  });
+
+  it("keys a reaction_removed the same as reaction_added (same lane)", () => {
+    const event = {
+      type: "reaction_removed",
+      user: "U1",
+      reaction: "thumbsup",
+      item: { type: "message", channel: CHANNEL, ts: TS },
+    } as SlackReactionRemovedEvent;
+    expect(slackEventOrderingKey(event, EVENT_ID)).toBe(`${CHANNEL}:${TS}`);
+  });
+
+  it("keys a message_changed on its channel + edited message thread_ts", () => {
+    const event = {
+      type: "message",
+      subtype: "message_changed",
+      channel: CHANNEL,
+      ts: TS,
+      message: { text: "edited", ts: "1700000000.000200", thread_ts: TS },
+    } as SlackMessageChangedEvent;
+    expect(slackEventOrderingKey(event, EVENT_ID)).toBe(`${CHANNEL}:${TS}`);
+  });
+
+  it("keys a message_delete on its channel + previous_message thread_ts", () => {
+    const event = {
+      type: "message",
+      subtype: "message_deleted",
+      channel: CHANNEL,
+      deleted_ts: TS,
+      previous_message: { text: "gone", ts: TS, thread_ts: TS },
+    } as SlackMessageDeletedEvent;
+    expect(slackEventOrderingKey(event, EVENT_ID)).toBe(`${CHANNEL}:${TS}`);
+  });
+
+  it("keys a plain message on channel + thread_ts (falling back to ts)", () => {
+    const event = {
+      type: "app_mention",
+      channel: CHANNEL,
+      user: "U1",
+      text: "hi",
+      ts: TS,
+    } as SlackAppMentionEvent;
+    expect(slackEventOrderingKey(event, EVENT_ID)).toBe(`${CHANNEL}:${TS}`);
+  });
+});
+
+describe("slackEventOrderingKey — malformed events do not crash the emit path", () => {
+  it("does not throw when a reaction is missing `item`, falling back to eventId", () => {
+    // `item` is untrusted and can be absent; dereferencing `item.channel` here
+    // (before normalization) would throw and take down the ordering lane.
+    const event = {
+      type: "reaction_added",
+      user: "U1",
+      reaction: "thumbsup",
+    } as unknown as SlackReactionAddedEvent;
+    expect(() => slackEventOrderingKey(event, EVENT_ID)).not.toThrow();
+    expect(slackEventOrderingKey(event, EVENT_ID)).toBe(
+      `${EVENT_ID}:${EVENT_ID}`,
+    );
+  });
+
+  it("does not throw when a message_changed is missing `message`, falling back to eventId", () => {
+    // A `message_changed` in a subscribed channel is admitted without requiring
+    // `message`, so `message.thread_ts` here would throw on the hot path.
+    const event = {
+      type: "message",
+      subtype: "message_changed",
+      channel: CHANNEL,
+      ts: TS,
+    } as unknown as SlackMessageChangedEvent;
+    expect(() => slackEventOrderingKey(event, EVENT_ID)).not.toThrow();
+    expect(slackEventOrderingKey(event, EVENT_ID)).toBe(
+      `${CHANNEL}:${EVENT_ID}`,
+    );
+  });
+});

--- a/gateway/src/slack/event-ordering.ts
+++ b/gateway/src/slack/event-ordering.ts
@@ -1,0 +1,64 @@
+import type {
+  SlackAppMentionEvent,
+  SlackChannelMessageEvent,
+  SlackDirectMessageEvent,
+  SlackMessageChangedEvent,
+  SlackMessageDeletedEvent,
+  SlackReactionAddedEvent,
+  SlackReactionRemovedEvent,
+} from "./normalize.js";
+
+/** The Slack event shapes that flow through ordered normalization. */
+export type SlackOrderableEvent =
+  | SlackAppMentionEvent
+  | SlackDirectMessageEvent
+  | SlackChannelMessageEvent
+  | SlackMessageChangedEvent
+  | SlackMessageDeletedEvent
+  | SlackReactionAddedEvent
+  | SlackReactionRemovedEvent;
+
+/**
+ * Ordering key that groups related Slack events onto a single sequential lane,
+ * so an edit or reaction is processed after the message it concerns.
+ *
+ * This runs on **untrusted** event data and **before** normalization, so every
+ * nested field access is guarded: `reaction.item` and `message_changed.message`
+ * can be absent on a malformed event (a `message_changed` in a subscribed
+ * channel is admitted without requiring `message`), and dereferencing them here
+ * would throw and take down the emit path. A missing field falls back to the
+ * unique `eventId` so ordering never crashes.
+ */
+export function slackEventOrderingKey(
+  event: SlackOrderableEvent,
+  eventId: string,
+): string {
+  if (event.type === "reaction_added" || event.type === "reaction_removed") {
+    const reaction = event as
+      | SlackReactionAddedEvent
+      | SlackReactionRemovedEvent;
+    return `${reaction.item?.channel ?? eventId}:${reaction.item?.ts ?? eventId}`;
+  }
+
+  if (
+    event.type === "message" &&
+    (event as SlackMessageChangedEvent).subtype === "message_changed"
+  ) {
+    const changed = event as SlackMessageChangedEvent;
+    return `${changed.channel}:${changed.message?.thread_ts ?? changed.message?.ts ?? eventId}`;
+  }
+
+  if (
+    event.type === "message" &&
+    (event as SlackMessageDeletedEvent).subtype === "message_deleted"
+  ) {
+    const deleted = event as SlackMessageDeletedEvent;
+    return `${deleted.channel}:${deleted.previous_message?.thread_ts ?? deleted.deleted_ts ?? eventId}`;
+  }
+
+  const message = event as
+    | SlackAppMentionEvent
+    | SlackDirectMessageEvent
+    | SlackChannelMessageEvent;
+  return `${message.channel}:${message.thread_ts ?? message.ts ?? eventId}`;
+}

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -19,6 +19,7 @@ import {
   type SlackHistoryMessage,
 } from "./slack-web.js";
 import { isSlackDmChannel } from "./channel.js";
+import { slackEventOrderingKey } from "./event-ordering.js";
 import {
   normalizeSlackAppMention,
   normalizeSlackDirectMessage,
@@ -1192,7 +1193,7 @@ export class SlackSocketModeClient {
     isDm: boolean,
   ): void {
     const queues = (this.emitQueues ??= new Map());
-    const orderingKey = this.getEventOrderingKey(event, eventId);
+    const orderingKey = slackEventOrderingKey(event, eventId);
     const previous = queues.get(orderingKey) ?? Promise.resolve();
     const current = previous
       .catch(() => undefined)
@@ -1220,47 +1221,6 @@ export class SlackSocketModeClient {
           queues.delete(orderingKey);
         }
       });
-  }
-
-  private getEventOrderingKey(
-    event:
-      | SlackAppMentionEvent
-      | SlackDirectMessageEvent
-      | SlackChannelMessageEvent
-      | SlackMessageChangedEvent
-      | SlackMessageDeletedEvent
-      | SlackReactionAddedEvent
-      | SlackReactionRemovedEvent,
-    eventId: string,
-  ): string {
-    if (event.type === "reaction_added" || event.type === "reaction_removed") {
-      const reaction = event as
-        | SlackReactionAddedEvent
-        | SlackReactionRemovedEvent;
-      return `${reaction.item.channel}:${reaction.item.ts}`;
-    }
-
-    if (
-      event.type === "message" &&
-      (event as SlackMessageChangedEvent).subtype === "message_changed"
-    ) {
-      const changed = event as SlackMessageChangedEvent;
-      return `${changed.channel}:${changed.message.thread_ts ?? changed.message.ts ?? eventId}`;
-    }
-
-    if (
-      event.type === "message" &&
-      (event as SlackMessageDeletedEvent).subtype === "message_deleted"
-    ) {
-      const deleted = event as SlackMessageDeletedEvent;
-      return `${deleted.channel}:${deleted.previous_message?.thread_ts ?? deleted.deleted_ts ?? eventId}`;
-    }
-
-    const message = event as
-      | SlackAppMentionEvent
-      | SlackDirectMessageEvent
-      | SlackChannelMessageEvent;
-    return `${message.channel}:${message.thread_ts ?? message.ts ?? eventId}`;
   }
 
   private async normalizeAndEmit(


### PR DESCRIPTION
## Prompt / plan

First standalone bug fix in the Slack ingress hardening (LUM-2795, Slack slice). Slack is being migrated to the same untrusted-payload-validation pattern as Telegram/WhatsApp/Resend, but its untrusted `event` object is read at several sites in `socket-mode.ts` **before** any normalizer runs — so those sites have latent crashes independent of the Zod work. This PR fixes the first, on its own, ahead of the larger envelope-parse-seam refactor.

## The bug (a real crash)

`SlackSocketModeClient.getEventOrderingKey` computes a key that groups related events onto one sequential lane. It runs on untrusted event data, **before** normalization, and dereferenced two fields with no guard:

- `reaction.item.channel` / `reaction.item.ts` — `item` can be absent on a malformed reaction.
- `message_changed.message.thread_ts` / `.ts` — `message` can be absent: a `message_changed` in a **subscribed channel** is admitted (`isSubscribedChannel` branch) **without requiring `message`**.

The event interfaces mark `item`/`message` as required, so `tsc` never caught it — the types were lying about untrusted input. At runtime, such an event throws a `TypeError` and takes down the ordering/emit path.

## The fix

- **Extract** the key computation into a pure `slackEventOrderingKey()` module (`slack/event-ordering.ts`). It used no instance state, so pulling it out of the untested `SlackSocketModeClient` class makes it unit-testable — which is *why* this went unnoticed (the class has zero tests today).
- **Guard** the untrusted accesses: `reaction.item?.channel`, `changed.message?.thread_ts`, etc., each falling back to the unique `eventId` so ordering never crashes on a malformed event (which is dropped downstream at normalization anyway).

No behavior change for well-formed events — the key is identical.

## Scope

Deliberately just this one crash. The broader fix — validating the Slack envelope once at ingress so these accesses are typed-safe by construction, plus the other pre-normalization read sites (the `team_id` stamp) — follows in separate PRs. This one is independently mergeable and stops a live crash now.

## Test plan

- `cd gateway && bunx tsc --noEmit` — clean. ESLint / Prettier / generic-examples clean.
- New `slack/event-ordering.test.ts` (first coverage for this logic): 5 well-formed cases (reaction add/remove, message_changed, message_deleted, plain message) + 2 malformed cases (reaction missing `item`, `message_changed` missing `message`) asserting **no throw** and the eventId fallback.
- The 90 existing `slack/normalize.test.ts` tests pass unchanged.
- Negative control: reverting the two guards makes exactly the two malformed tests **throw**; restoring them passes — so they assert the fix, not current behavior.

## CLI verb checklist

No new routes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f)_