### PR TITLE
feat(web): voice-room settings polish — captions icon, picker parity, BYO voice row (JARVIS-1345)

### DIFF
--- a/clients/web/src/components/speech/use-managed-voice-selection.ts
+++ b/clients/web/src/components/speech/use-managed-voice-selection.ts
@@ -40,6 +40,14 @@ import {
 export interface UseManagedVoiceSelection {
   /** True only when this assistant is managed and its daemon offers voice selection. */
   available: boolean;
+  /**
+   * The assistant speaks through a provider the user configured themselves —
+   * there is no catalog to pick from, and its voice is set on Settings → Models
+   * & Services. Distinct from `!available`, which is also false while config is
+   * still loading: this stays false until config says so, so a surface can show
+   * a "set it in Settings" state without flashing it during the fetch.
+   */
+  isByok: boolean;
   voices: readonly ManagedVoiceOption[];
   /** The currently-selected model (config value, else the platform default). */
   currentModel: string;
@@ -91,6 +99,9 @@ export function useManagedVoiceSelection(
 
   const available =
     enabled && isManaged && vellumSupportsVoiceSelection && voices.length > 0;
+  // Gated on config having actually arrived — an unfetched config reads as
+  // "not managed", which would flash the BYO state on every mount.
+  const isByok = enabled && !!daemonConfig && !isManaged;
 
   const currentModel = useMemo(() => {
     const configured = daemonTts?.providers?.vellum?.model;
@@ -135,6 +146,7 @@ export function useManagedVoiceSelection(
 
   return {
     available,
+    isByok,
     voices,
     currentModel,
     defaultModel: defaultModel ?? "",

--- a/clients/web/src/components/speech/use-managed-voice-selection.ts
+++ b/clients/web/src/components/speech/use-managed-voice-selection.ts
@@ -19,7 +19,7 @@
  * unavailable, `available` is false and the surfaces render no picker.
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -49,13 +49,19 @@ export interface UseManagedVoiceSelection {
    */
   isByok: boolean;
   voices: readonly ManagedVoiceOption[];
-  /** The currently-selected model (config value, else the platform default). */
+  /**
+   * The currently-selected model: the pick a write is still carrying, else the
+   * config value, else the platform default.
+   */
   currentModel: string;
   /** The platform default model, for a "(default)" marker. Empty if none. */
   defaultModel: string;
-  /** Persist a voice; hot-applies on the assistant's next spoken turn. */
+  /**
+   * Persist a voice; hot-applies on the assistant's next spoken turn. Safe to
+   * call again before the last one lands — writes are serialized in call order.
+   */
   selectModel: (model: string) => void;
-  /** A write is in flight. */
+  /** A write is in flight. Stays true until the newest one settles. */
   selecting: boolean;
 }
 
@@ -103,22 +109,38 @@ export function useManagedVoiceSelection(
   // "not managed", which would flash the BYO state on every mount.
   const isByok = enabled && !!daemonConfig && !isManaged;
 
+  const [selecting, setSelecting] = useState(false);
+  // The voice a pick is heading for, held until its write has landed in config.
+  // Auditioning voices in a row is the point of the picker, and a check mark
+  // that waits out a round trip reads as a dropped click.
+  const [pendingModel, setPendingModel] = useState<string | null>(null);
+
   const currentModel = useMemo(() => {
     const configured = daemonTts?.providers?.vellum?.model;
     return (
+      pendingModel ??
       configured ??
       defaultModel ??
       voices[0]?.model ??
       ""
     );
-  }, [daemonTts, defaultModel, voices]);
+  }, [pendingModel, daemonTts, defaultModel, voices]);
 
-  const [selecting, setSelecting] = useState(false);
+  // Writes run one at a time in click order, and only the newest one settles the
+  // UI. Concurrent PATCHes of the same config field can arrive out of order —
+  // config would then keep whichever landed last rather than what was clicked
+  // last, and the first response back would clear `selecting` while a later
+  // write was still in flight.
+  const writeChain = useRef<Promise<void>>(Promise.resolve());
+  const latestWrite = useRef(0);
+
   const selectModel = useCallback(
     (model: string) => {
       if (!assistantId || model === currentModel) return;
+      const seq = ++latestWrite.current;
+      setPendingModel(model);
       setSelecting(true);
-      void (async () => {
+      writeChain.current = writeChain.current.then(async () => {
         try {
           const { response } = await configPatch({
             path: { assistant_id: assistantId },
@@ -136,10 +158,18 @@ export function useManagedVoiceSelection(
               path: { assistant_id: assistantId },
             }),
           });
+        } catch {
+          toast.error("Couldn't change the voice just now — try again.");
         } finally {
-          setSelecting(false);
+          // Superseded writes leave the state alone: the pick they'd revert to
+          // is not the one the user is waiting on. Dropping the pending model
+          // here also reverts a failed write to whatever config actually holds.
+          if (seq === latestWrite.current) {
+            setPendingModel(null);
+            setSelecting(false);
+          }
         }
-      })();
+      });
     },
     [assistantId, currentModel, queryClient],
   );

--- a/clients/web/src/components/speech/voice-list.test.tsx
+++ b/clients/web/src/components/speech/voice-list.test.tsx
@@ -81,10 +81,14 @@ mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
 }));
 
 const configPatchCalls: { path?: unknown; body?: unknown }[] = [];
+// Held open, `patchGate` keeps every PATCH in flight so a second pick can be
+// made while the first is still going — the audition case.
+let patchGate: Promise<void> | null = null;
 mock.module("@/generated/daemon/sdk.gen", () => ({
-  configPatch: (opts: { path?: unknown; body?: unknown }) => {
+  configPatch: async (opts: { path?: unknown; body?: unknown }) => {
     configPatchCalls.push(opts);
-    return Promise.resolve({ response: { ok: true, status: 200 } });
+    if (patchGate) await patchGate;
+    return { response: { ok: true, status: 200 } };
   },
 }));
 
@@ -113,6 +117,7 @@ function renderList(assistantId: string | null = ASSISTANT_ID) {
 beforeEach(() => {
   orgReady = true;
   configPatchCalls.length = 0;
+  patchGate = null;
   daemonConfigData = { services: { tts: { provider: "vellum" } } };
   providersData = {
     providers: [
@@ -178,6 +183,56 @@ describe("VoiceList", () => {
     expect(configPatchCalls[0]!.body).toEqual({
       services: { tts: { providers: { vellum: { model: "aura-2-zeus-en" } } } },
     });
+  });
+
+  test("the pick is marked selected before its write lands", async () => {
+    let openGate = () => {};
+    patchGate = new Promise<void>((resolve) => {
+      openGate = resolve;
+    });
+    renderList();
+
+    const zeus = () =>
+      screen
+        .getAllByRole("option")
+        .find((o) => o.textContent?.includes("Deep, trustworthy"))!;
+    fireEvent.click(zeus());
+
+    // Still mid-write — the check has to follow the click, not the round trip.
+    await waitFor(() => expect(zeus().getAttribute("aria-selected")).toBe("true"));
+    expect(configPatchCalls.length).toBe(1);
+    openGate();
+  });
+
+  test("picks made during a write are serialized in click order", async () => {
+    let openGate = () => {};
+    patchGate = new Promise<void>((resolve) => {
+      openGate = resolve;
+    });
+    renderList();
+
+    const option = (text: string) =>
+      screen.getAllByRole("option").find((o) => o.textContent?.includes(text))!;
+    // Zeus, then straight back to Sarah while Zeus's write is still in flight.
+    fireEvent.click(option("Deep, trustworthy"));
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    fireEvent.click(option("Professional, reassuring"));
+
+    // The second write waits its turn rather than racing the first: config
+    // would otherwise settle on whichever landed last, not the last click.
+    expect(configPatchCalls.length).toBe(1);
+    openGate();
+    patchGate = null;
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(2));
+    expect(configPatchCalls.map((c) => c.body)).toEqual([
+      { services: { tts: { providers: { vellum: { model: "aura-2-zeus-en" } } } } },
+      {
+        services: {
+          tts: { providers: { vellum: { model: "EXAVITQu4vr4xnSDxMaL" } } },
+        },
+      },
+    ]);
   });
 
   test("each row previews its own voice via the hosted sample", async () => {

--- a/clients/web/src/components/speech/voice-picker-modal.tsx
+++ b/clients/web/src/components/speech/voice-picker-modal.tsx
@@ -1,61 +1,74 @@
 /**
- * The voice-picker modal ("Pick a voice for <assistant>"). Gives voice
- * selection the room a cramped trigger can't: every voice's full description on
- * its own line with a per-voice preview.
+ * The voice-picker modal: the full catalog with every voice's description on
+ * its own line and a per-voice preview — what a cramped trigger can't hold.
+ * Serves the callers with no dialog of their own to host the list: the
+ * voice-room settings popover and the Settings voice card.
  *
- * Selecting a voice persists it (hot-applies on the next reply) and closes the
- * modal. The list itself lives in {@link VoiceList}; the first-run card renders
- * that list inline as one of its own views, so this modal serves callers with
- * no dialog of their own to host the list — the voice-room settings popover and
- * the Voice settings page's picker card.
+ * Deliberately the same surface as the first-run card's "Voices" view (which
+ * renders {@link VoiceList} inline as one of its own views, so it can't share
+ * this dialog): same title, same managed-credits subtitle, the same
+ * provider-scoped list, and the same Models & Services fine print. Picking a
+ * voice is chosen the same way everywhere.
+ *
+ * Selection is held here rather than left to the list so a pick doesn't close
+ * the modal — auditioning several voices in a row is the whole point, and each
+ * one hot-applies on the assistant's next reply (there is nothing to save).
+ * Done is the only exit, and it waits out an in-flight write.
  */
 
 import { Modal } from "@vellumai/design-library/components/modal";
+import { Button } from "@vellumai/design-library/components/button";
 
+import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
 import { VoiceList } from "@/components/speech/voice-list";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { VoiceProvidersNote } from "@/components/speech/voice-providers-note";
+import { MANAGED_VOICE_CREDITS_NOTE } from "@/lib/tts/managed-voice-catalog";
 
 export interface VoicePickerModalProps {
   assistantId: string | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Show each voice's provider badge (settings surfaces). */
-  showSource?: boolean;
-  /**
-   * Browse by provider: a dropdown scopes the catalog to one source, and the
-   * modal widens to give the list room. On for the Voice-page picker; the
-   * in-call voice-room modal stays the compact single-list picker.
-   */
-  filterBySource?: boolean;
 }
 
 export function VoicePickerModal({
   assistantId,
   open,
   onOpenChange,
-  showSource = false,
-  filterBySource = false,
 }: VoicePickerModalProps) {
-  const assistantName = useResolvedAssistantsStore.use
-    .assistants()
-    .find((a) => a.id === assistantId)?.name;
+  const { available, currentModel, selectModel, selecting } =
+    useManagedVoiceSelection(assistantId);
 
   return (
     <Modal.Root open={open} onOpenChange={onOpenChange}>
-      <Modal.Content size={filterBySource ? "md" : "sm"}>
+      <Modal.Content size="md">
         <Modal.Header>
-          <Modal.Title>
-            Pick a voice for {assistantName ?? "your assistant"}
-          </Modal.Title>
+          <Modal.Title>Voices</Modal.Title>
+          {available && (
+            <Modal.Description>{MANAGED_VOICE_CREDITS_NOTE}</Modal.Description>
+          )}
         </Modal.Header>
         <Modal.Body>
+          {/* Provider-scoped, like the first-run view: a dropdown picks the
+              upstream source so accent grouping isn't split across providers.
+              It hides itself when the catalog has a single provider. */}
           <VoiceList
             assistantId={assistantId}
-            onSelect={() => onOpenChange(false)}
-            showSource={showSource}
-            filterBySource={filterBySource}
+            filterBySource
+            value={currentModel}
+            onChange={selectModel}
           />
         </Modal.Body>
+        <Modal.Footer className="items-center justify-between gap-3">
+          <VoiceProvidersNote />
+          <Button
+            variant="primary"
+            onClick={() => onOpenChange(false)}
+            disabled={selecting}
+            className="shrink-0"
+          >
+            Done
+          </Button>
+        </Modal.Footer>
       </Modal.Content>
     </Modal.Root>
   );

--- a/clients/web/src/components/speech/voice-picker-modal.tsx
+++ b/clients/web/src/components/speech/voice-picker-modal.tsx
@@ -35,41 +35,62 @@ export function VoicePickerModal({
   open,
   onOpenChange,
 }: VoicePickerModalProps) {
+  return (
+    <Modal.Root open={open} onOpenChange={onOpenChange}>
+      <Modal.Content size="md">
+        {/* The picker's own component, so its daemon queries run only while the
+            modal is open — hosts keep this mounted across a whole session (the
+            voice room parks it outside its popover), and a closed dialog has no
+            business holding a React Query subscription. */}
+        <VoicePickerContent
+          assistantId={assistantId}
+          onDone={() => onOpenChange(false)}
+        />
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
+function VoicePickerContent({
+  assistantId,
+  onDone,
+}: {
+  assistantId: string | null;
+  onDone: () => void;
+}) {
   const { available, currentModel, selectModel, selecting } =
     useManagedVoiceSelection(assistantId);
 
   return (
-    <Modal.Root open={open} onOpenChange={onOpenChange}>
-      <Modal.Content size="md">
-        <Modal.Header>
-          <Modal.Title>Voices</Modal.Title>
-          {available && (
-            <Modal.Description>{MANAGED_VOICE_CREDITS_NOTE}</Modal.Description>
-          )}
-        </Modal.Header>
-        <Modal.Body>
-          {/* Provider-scoped, like the first-run view: a dropdown picks the
-              upstream source so accent grouping isn't split across providers.
-              It hides itself when the catalog has a single provider. */}
-          <VoiceList
-            assistantId={assistantId}
-            filterBySource
-            value={currentModel}
-            onChange={selectModel}
-          />
-        </Modal.Body>
-        <Modal.Footer className="items-center justify-between gap-3">
-          <VoiceProvidersNote />
-          <Button
-            variant="primary"
-            onClick={() => onOpenChange(false)}
-            disabled={selecting}
-            className="shrink-0"
-          >
-            Done
-          </Button>
-        </Modal.Footer>
-      </Modal.Content>
-    </Modal.Root>
+    <>
+      <Modal.Header>
+        <Modal.Title>Voices</Modal.Title>
+        {available && (
+          <Modal.Description>{MANAGED_VOICE_CREDITS_NOTE}</Modal.Description>
+        )}
+      </Modal.Header>
+      <Modal.Body>
+        {/* Provider-scoped, like the first-run view: a dropdown picks the
+            upstream source so accent grouping isn't split across providers.
+            It hides itself when the catalog has a single provider. */}
+        <VoiceList
+          assistantId={assistantId}
+          filterBySource
+          value={currentModel}
+          onChange={selectModel}
+        />
+      </Modal.Body>
+      <Modal.Footer className="items-center justify-between gap-3">
+        <VoiceProvidersNote />
+        <Button
+          variant="primary"
+          onClick={onDone}
+          disabled={selecting}
+          className="shrink-0"
+        >
+          Done
+        </Button>
+      </Modal.Footer>
+    </>
   );
 }

--- a/clients/web/src/components/speech/voice-providers-note.tsx
+++ b/clients/web/src/components/speech/voice-providers-note.tsx
@@ -1,0 +1,37 @@
+/**
+ * The fine print under a voice picker: everything the picker deliberately
+ * doesn't offer — providers, transcription, API keys — lives on Models &
+ * Services. Shared so the first-run card's Voices view and
+ * {@link VoicePickerModal} carry the same sentence and the same link target
+ * rather than two drifting copies.
+ *
+ * Safe to click mid-call: leaving the chat route hides the voice room (see
+ * `useIsVoiceRoomVisible`) and hands the live session to the title-bar pill —
+ * the call keeps running while the user is in Settings.
+ */
+
+import { Link } from "react-router";
+
+import { cn } from "@vellumai/design-library";
+
+import { routes } from "@/utils/routes";
+
+export function VoiceProvidersNote({ className }: { className?: string }) {
+  return (
+    <p
+      className={cn(
+        "text-label-small-default text-[var(--content-tertiary)]",
+        className,
+      )}
+    >
+      Speech providers, transcription, and API keys live in{" "}
+      <Link
+        to={`${routes.settings.ai}#text-to-speech`}
+        className="text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 hover:text-[var(--content-default)]"
+      >
+        Models &amp; Services
+      </Link>
+      .
+    </p>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { Link } from "react-router";
 
 import { ArrowLeft, AudioLines, Captions, MicOff, Settings } from "lucide-react";
 
@@ -9,10 +8,10 @@ import { Modal } from "@vellumai/design-library/components/modal";
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
 import { VoiceList } from "@/components/speech/voice-list";
+import { VoiceProvidersNote } from "@/components/speech/voice-providers-note";
 import { MANAGED_VOICE_CREDITS_NOTE } from "@/lib/tts/managed-voice-catalog";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { routes } from "@/utils/routes";
 
 /**
  * One-time welcome card shown the first time a user enters voice mode, before
@@ -277,16 +276,7 @@ function VoiceSettingsView({
           change when a voice is chosen. Start waits out an in-flight voice write
           so the session can't open on the previous voice. */}
       <Modal.Footer className="items-center justify-between gap-3">
-        <p className="text-label-small-default text-[var(--content-tertiary)]">
-          Speech providers, transcription, and API keys live in{" "}
-          <Link
-            to={`${routes.settings.ai}#text-to-speech`}
-            className="text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 hover:text-[var(--content-default)]"
-          >
-            Models &amp; Services
-          </Link>
-          .
-        </p>
+        <VoiceProvidersNote />
         <Button
           variant="primary"
           onClick={onStart}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.test.tsx
@@ -1,23 +1,38 @@
+import { type ReactNode } from "react";
+
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 
 // The voice picker has its own tests; here it stays collapsed (unavailable) so
-// the menu renders without the daemon query graph / a QueryClient.
+// the menu renders without the daemon query graph / a QueryClient. Mutable so a
+// test can put the assistant on a bring-your-own provider.
+let voiceSelection = {
+  available: false,
+  isByok: false,
+  voices: [] as unknown[],
+  currentModel: "",
+  defaultModel: "",
+  selectModel: () => {},
+  selecting: false,
+};
 mock.module("@/components/speech/use-managed-voice-selection", () => ({
-  useManagedVoiceSelection: () => ({
-    available: false,
-    voices: [],
-    currentModel: "",
-    selectModel: () => {},
-    selecting: false,
-  }),
+  useManagedVoiceSelection: () => voiceSelection,
 }));
 
-import { VoiceRoomSettingsMenu } from "./voice-room-settings-menu";
+// The BYO row links to Models & Services; a plain anchor renders it without a
+// Router.
+mock.module("react-router", () => ({
+  Link: ({ to, children }: { to: string; children: ReactNode }) => (
+    <a href={typeof to === "string" ? to : "#"}>{children}</a>
+  ),
+}));
+
+const { VoiceRoomSettingsMenu } = await import("./voice-room-settings-menu");
 
 beforeEach(() => {
+  voiceSelection = { ...voiceSelection, available: false, isByok: false };
   useVoicePrefsStore.setState({
     showUserTranscript: false,
     showAssistantTranscript: false,
@@ -48,8 +63,34 @@ describe("VoiceRoomSettingsMenu", () => {
     expect(useVoicePrefsStore.getState().showAssistantTranscript).toBe(false);
   });
 
+  test("captions row keeps its label beside the icon", () => {
+    openMenu();
+    expect(screen.getByText("Captions")).toBeTruthy();
+    expect(screen.getByLabelText("Show captions")).toBeTruthy();
+  });
+
   test("no pause-before-reply control (removed with the two-tier model)", () => {
     openMenu();
     expect(screen.queryByLabelText("Pause before reply")).toBeNull();
+  });
+
+  test("a bring-your-own provider gets a disabled Voice row and a Settings link", () => {
+    voiceSelection = { ...voiceSelection, available: false, isByok: true };
+    openMenu();
+    // Disabled rather than hidden, so the option is visibly unavailable rather
+    // than missing, with the one place it can be changed right under it.
+    const row = screen.getByText("Your API key").closest("button");
+    expect(row?.hasAttribute("disabled")).toBe(true);
+    expect(
+      screen.getByRole("link", { name: "Change voice in Settings" }),
+    ).toBeTruthy();
+  });
+
+  test("collapses the Voice row entirely while availability is unknown", () => {
+    // Not managed AND not confirmed BYO (config still loading) — showing the
+    // BYO row here would flash a wrong state on every open.
+    openMenu();
+    expect(screen.queryByText("Voice")).toBeNull();
+    expect(screen.queryByRole("link")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-settings-menu.tsx
@@ -5,11 +5,14 @@
  *
  * - **Captions** — enable/disable the ambient transcript. Purely client-side
  *   (the two `voice-prefs` transcript flags, toggled together), so it applies
- *   instantly.
+ *   instantly. Led by the captions icon, which carries the room's iconographic
+ *   control language into the popover.
  * - **Voice** — a row showing the assistant's current TTS voice that opens the
  *   dedicated {@link VoicePickerModal} (the full catalog with per-voice preview
  *   doesn't fit the popover). Writes `services.tts.providers.vellum.model`,
- *   which hot-applies on the assistant's next reply. Managed assistants only.
+ *   which hot-applies on the assistant's next reply. Managed assistants only;
+ *   a bring-your-own provider gets the disabled row and its Settings link (see
+ *   {@link VoiceSettingRow}).
  *
  * Captions are bound to the same `voice-prefs` store the Settings page uses;
  * voice is bound to daemon config, the source of truth the Settings → Voice
@@ -18,7 +21,7 @@
 
 import { useState } from "react";
 
-import { Settings } from "lucide-react";
+import { Captions, Settings } from "lucide-react";
 
 import { cn } from "@vellumai/design-library";
 import { Popover } from "@vellumai/design-library/components/popover";
@@ -34,8 +37,6 @@ interface VoiceRoomSettingsMenuProps {
   /** Assistant to audition in the voice picker; `null` disables the sample. */
   assistantId: string | null;
 }
-
-const rowLabelClass = "text-body-medium-default text-[var(--content-default)]";
 
 export function VoiceRoomSettingsMenu({
   triggerClassName,
@@ -84,7 +85,18 @@ export function VoiceRoomSettingsMenu({
         >
           <div className="flex flex-col">
             <label className="flex items-center justify-between gap-3 py-1">
-              <span className={rowLabelClass}>Captions</span>
+              {/* Icon + label: the icon ties the row to the captions control
+                  the room already shows, the label keeps it level with the
+                  Voice row below (an icon alone reads as unlabelled). */}
+              <span className="flex items-center gap-2">
+                <Captions
+                  aria-hidden
+                  className="size-5 shrink-0 text-[var(--content-secondary)]"
+                />
+                <span className="text-body-medium-default text-[var(--content-default)]">
+                  Captions
+                </span>
+              </span>
               <Toggle
                 checked={captionsOn}
                 onChange={setCaptions}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -15,6 +15,8 @@
  * removed on unmount (no leaks).
  */
 
+import { type ReactNode } from "react";
+
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
@@ -51,6 +53,11 @@ let mockPathname = routes.conversation(OWNING_CONVERSATION_ID);
 let mockSearch = "";
 mock.module("react-router", () => ({
   useLocation: () => ({ pathname: mockPathname, search: mockSearch }),
+  // The settings popover's bring-your-own-provider row links to Settings; a
+  // plain anchor renders it without a Router.
+  Link: ({ to, children }: { to: string; children: ReactNode }) => (
+    <a href={typeof to === "string" ? to : "#"}>{children}</a>
+  ),
 }));
 
 let mockMainView: MainView = "chat";

--- a/clients/web/src/domains/chat/voice/voice-room/voice-setting-row.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-setting-row.tsx
@@ -8,17 +8,24 @@
  * popover (which unmounts this row) can't unmount the picker with it; the
  * first-run card swaps to its own voice view.
  *
- * Renders nothing unless managed voice selection is available (managed assistant
- * + a daemon that offers it); BYO providers choose their voice on Settings →
- * Models & Services.
+ * An assistant on a bring-your-own speech provider has no catalog to open, so
+ * the row goes disabled and points at Settings → Models & Services, where that
+ * provider's voice id lives with the rest of its config — a stopgap until BYO
+ * voices get a picker of their own. Following that link mid-call is safe: it
+ * leaves the chat route, which hides the room and hands the live session to the
+ * title-bar pill. Everything else that leaves voice selection unavailable
+ * (config still loading, an older daemon) renders nothing, so the popover never
+ * shows a dead row it can't explain.
  */
 
 import { ChevronRight } from "lucide-react";
+import { Link } from "react-router";
 
 import { cn } from "@vellumai/design-library";
 
 import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
 import { VoiceLabel } from "@/components/speech/voice-list";
+import { routes } from "@/utils/routes";
 
 export interface VoiceSettingRowProps {
   assistantId: string | null;
@@ -32,11 +39,13 @@ export function VoiceSettingRow({
   onOpen,
   className,
 }: VoiceSettingRowProps) {
-  const { available, voices, currentModel } =
+  const { available, isByok, voices, currentModel } =
     useManagedVoiceSelection(assistantId);
   const current = voices.find((v) => v.model === currentModel) ?? voices[0];
 
-  if (!available || !current) return null;
+  if (!available || !current) {
+    return isByok ? <ByokVoiceRow className={className} /> : null;
+  }
 
   return (
     // The divider is its own straight, full-width line — a top border on the
@@ -57,6 +66,37 @@ export function VoiceSettingRow({
         />
         <ChevronRight className="size-4 shrink-0 self-center text-[var(--content-tertiary)]" />
       </button>
+    </div>
+  );
+}
+
+/**
+ * The bring-your-own-provider state: the same row, disabled — it keeps the
+ * shape so the popover doesn't reflow between assistants — with the one thing
+ * the user can act on underneath it.
+ */
+function ByokVoiceRow({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex flex-col", className)}>
+      <div className="border-t border-[var(--border-subtle)]" />
+      <button
+        type="button"
+        disabled
+        className="mt-1 flex w-full cursor-not-allowed items-baseline gap-2 rounded-md px-1 py-2 text-left opacity-50"
+      >
+        <span className="shrink-0 text-body-medium-default text-[var(--content-default)]">
+          Voice
+        </span>
+        <span className="min-w-0 flex-1 truncate text-right text-label-small-default text-[var(--content-tertiary)]">
+          Your API key
+        </span>
+      </button>
+      <Link
+        to={`${routes.settings.ai}#text-to-speech`}
+        className="px-1 pb-1 text-label-small-default text-[var(--content-tertiary)] underline decoration-[var(--border-element)] underline-offset-2 transition-colors hover:text-[var(--content-default)]"
+      >
+        Change voice in Settings
+      </Link>
     </div>
   );
 }

--- a/clients/web/src/domains/settings/pages/voice-page.test.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.test.tsx
@@ -101,6 +101,17 @@ describe("VoiceSections turn-taking defaults", () => {
   });
 });
 
+describe("VoiceSections Models & Services pointer", () => {
+  test("stays hidden while the voice card carries the same pointer", () => {
+    // The mocked selection reports no managed catalog, so the card renders its
+    // own "set its voice on Models & Services" copy — the banner beneath it
+    // would just repeat that sentence.
+    renderPage();
+
+    expect(screen.queryByText(/own API key for STT or TTS/)).toBeNull();
+  });
+});
+
 describe("VoiceSections caption toggles", () => {
   test("both transcript toggles default to off on first render", () => {
     renderPage();

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -18,6 +18,9 @@ import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import { VoicePickerCard } from "@/domains/settings/pages/voice-picker-card";
 
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { useManagedVoiceSelection } from "@/components/speech/use-managed-voice-selection";
+
 import { DetailCard } from "@/components/detail-card";
 import {
   DEFAULT_INTERRUPT_SENSITIVITY,
@@ -135,12 +138,18 @@ export function VoiceSections() {
 /**
  * Pointer to Models & Services, which carries the BYO speech providers (they
  * live with every other provider there, not on this page) and the managed
- * custom-voice-ID entry. Restores the cross-link the Voice page carried before
- * speech briefly moved into a Services tab — most people want the managed voice
- * above, but those bringing their own key or a specific voice ID need a way
- * across.
+ * custom-voice-ID entry: most people want the managed voice above, but those
+ * bringing their own key or a specific voice ID need a way across.
+ *
+ * Shown only alongside the managed picker. An assistant already on its own
+ * provider gets that same pointer from the card itself, which has nothing else
+ * to offer — a second copy of the sentence directly beneath it just repeats.
  */
 function SpeechServicesBanner() {
+  const { available } = useManagedVoiceSelection(useActiveAssistantId());
+
+  if (!available) return null;
+
   return (
     <div className="flex flex-wrap items-center gap-1.5 px-1 text-body-small-default text-[var(--content-tertiary)]">
       <Info className="h-3.5 w-3.5 shrink-0 text-[var(--content-quiet)]" />

--- a/clients/web/src/domains/settings/pages/voice-picker-card.tsx
+++ b/clients/web/src/domains/settings/pages/voice-picker-card.tsx
@@ -79,7 +79,7 @@ export function VoicePickerCard() {
         Your assistant speaks through a provider you configured yourself. Set
         its voice on{" "}
         <Link
-          to={routes.settings.ai}
+          to={`${routes.settings.ai}#text-to-speech`}
           className="text-[var(--primary-base)] hover:underline"
         >
           Models &amp; Services

--- a/clients/web/src/domains/settings/pages/voice-picker-card.tsx
+++ b/clients/web/src/domains/settings/pages/voice-picker-card.tsx
@@ -68,7 +68,6 @@ export function VoicePickerCard() {
           assistantId={assistantId}
           open={pickerOpen}
           onOpenChange={setPickerOpen}
-          filterBySource
         />
       </DetailCard>
     );


### PR DESCRIPTION
Three polish changes to the voice room's in-session settings gear.

Closes JARVIS-1345 — https://linear.app/vellum/issue/JARVIS-1345

## Captions row leads with its icon

The row is the captions icon beside its label, carrying the room's iconographic control language into the popover. (First pass dropped the label entirely; it read as unlabelled next to the Voice row, so the label stayed.)

## Voice picker matches the first-run modal

`VoicePickerModal` becomes the same surface as the first-run card's "Voices" view: same title, managed-credits subtitle, provider-scoped list, and Models & Services fine print — the last extracted to `VoiceProvidersNote` so the two surfaces share one copy of that sentence instead of two that drift.

Two behavior changes fall out of the parity:

- **A pick no longer closes the modal.** Selection is held by the modal (as in first-run) so several voices can be auditioned in a row; each hot-applies on the assistant's next reply. **Done** is the only exit and waits out an in-flight write.
- **The Settings → Voice card hosts the same modal**, so its picker changes shape too (was "Pick a voice for X", close-on-select). `filterBySource` / `showSource` are gone — the modal is always provider-scoped now.

## Bring-your-own providers get a disabled row, not an absent one

A BYO assistant has no catalog to open, so the Voice row goes disabled ("Your API key") with "Change voice in Settings" under it, pointing at Models & Services where that provider's voice id lives. Deliberately a stopgap until BYO voices get a picker of their own.

This needed a new `isByok` off `useManagedVoiceSelection`: `available` alone conflates "bring-your-own" with "config still loading", which would flash the BYO state on every open. Loading and old-daemon cases still render nothing.

That link is usable mid-call — leaving the chat route flips `useIsVoiceRoomVisible` false, so the room hides and the title-bar pill keeps the live session running while the user is in Settings.

## Settings → Voice fallout

Reviewing the BYO copy on the Settings page turned up two things worth fixing while here:

- **The Output section said the same thing twice.** A BYO voice card already reads "Set its voice on Models & Services", and the `SpeechServicesBanner` directly beneath it repeated the pointer. The banner now shows only alongside the managed picker.
- **The card's link skipped the anchor.** Every other pointer to the speech providers deep-links to `#text-to-speech`; this one dropped the reader at the top of Models & Services to find the card themselves.

## Write ordering (from Codex review)

Keeping the modal open after a pick makes two picks overlap by design, which exposed the write path. `selectModel` had no in-flight guard, so concurrent PATCHes of the same config field could arrive out of order — config keeps whichever landed last, not what was clicked last — and the first response back cleared `selecting`, re-enabling Done early. Writes now run one at a time in click order, and only the newest settles the UI.

The check mark also waited out the write plus the config refetch, which reads as a dropped click under the new flow. `currentModel` reports the pending pick until its write lands, reverting to config if it fails.

## One mounting note for reviewers

`VoicePickerModal`'s body must not call `useManagedVoiceSelection` — hosts keep the modal mounted for a whole session (the voice room parks it outside its popover so closing the popover can't unmount it), so a hook there subscribes to daemon queries whether or not anyone opens the picker. The picker lives in its own component under `Modal.Content`, which Radix mounts only while open. Same split, same reason, as the first-run card's Voices view. The room's own test catches a regression here as "No QueryClient set".

## Testing

- `voice-room-settings-menu.test.tsx` extended: captions label present, BYO row disabled + linked, and the row collapsed entirely while availability is unknown.
- `voice-list.test.tsx` extended: two tests hold a PATCH open to overlap picks — the pick is marked selected before its write lands, and overlapping picks serialize in click order. Both fail against the pre-fix hook (verified by stashing it).
- `voice-page.test.tsx` extended: the banner stays hidden while the card carries the same pointer.
- Green: settings-menu, first-run card, voice-list, voice-page, text-to-speech-card. Typecheck + lint clean.
- Not driven in a live voice session (the room needs an active call). The captions row, the BYO row, and the Settings-page copy were checked against screenshots during review; the reshaped picker modal is covered by tests and reading only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
