### PR TITLE
fix(service-contracts): share ingress placeholder-context + repeated-tail suppression

### DIFF
--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -10,8 +10,8 @@
  */
 
 import {
-  KNOWN_PLACEHOLDERS,
-  PLACEHOLDER_PREFIXES,
+  isPlaceholderContext,
+  isPlaceholderValue,
   TOKEN_SHAPE,
 } from "@vellumai/service-contracts/secret-detection";
 
@@ -59,54 +59,6 @@ const getGlobalPatterns = memoizePluginPatternDerivation(
 );
 
 // ---------------------------------------------------------------------------
-// Placeholder detection — ingress-specific heuristics layered on the shared
-// placeholder constants (not imported from secret-scanner.ts)
-// ---------------------------------------------------------------------------
-
-/**
- * Check if the text immediately before a matched value indicates
- * a placeholder context (e.g. "fake_", "test_").
- */
-function isPlaceholderContext(preContext: string): boolean {
-  const lower = preContext.toLowerCase();
-  for (const prefix of PLACEHOLDER_PREFIXES) {
-    if (lower.endsWith(prefix)) return true;
-  }
-  return false;
-}
-
-/**
- * Check if a matched value is a placeholder/test value that should not
- * trigger blocking.
- */
-function isPlaceholder(value: string): boolean {
-  const lower = value.toLowerCase();
-
-  // Known placeholder values
-  if (KNOWN_PLACEHOLDERS.has(lower)) return true;
-
-  // Placeholder prefixes
-  for (const prefix of PLACEHOLDER_PREFIXES) {
-    if (lower.startsWith(prefix)) return true;
-  }
-
-  // Repeated characters in the variable portion (e.g. "AKIA" + "X" x 16)
-  // Strip known prefixes to isolate the variable part
-  const variablePart = value
-    .replace(
-      /^(?:AKIA|gh[pousr]_|github_pat_|glpat-|sk_live_|rk_live_|xoxb-|xoxp-|xapp-|sk-ant-|sk-proj-|sk-or-v1-|AIza|GOCSPX-|SK|SG\.|npm_|pypi-|key-|lin_api_|ntn_|fw_|pplx-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/,
-      "",
-    )
-    .replace(/[^A-Za-z0-9]/g, "");
-  if (variablePart.length >= 8) {
-    const firstChar = variablePart[0];
-    if (variablePart.split("").every((c) => c === firstChar)) return true;
-  }
-
-  return false;
-}
-
-// ---------------------------------------------------------------------------
 // Token-shape heuristic (whole-message only)
 // ---------------------------------------------------------------------------
 
@@ -136,7 +88,7 @@ function isBlockedTokenShapedMessage(content: string): boolean {
   // Check both the full value (test_/fake_ prefixes) and the tail after the
   // keyword infix (repeated-char fillers like "xxxxxxxxxxxxxxxx")
   const tail = match[1]!;
-  if (isPlaceholder(trimmed) || isPlaceholder(tail)) {
+  if (isPlaceholderValue(trimmed) || isPlaceholderValue(tail)) {
     return false;
   }
 
@@ -181,7 +133,9 @@ export function checkIngressForSecrets(content: string): IngressCheckResult {
       // a small window before it for placeholder prefixes like "fake_")
       const contextStart = Math.max(0, match.index - 10);
       const preContext = content.slice(contextStart, match.index);
-      if (isPlaceholder(value) || isPlaceholderContext(preContext)) continue;
+      if (isPlaceholderValue(value) || isPlaceholderContext(preContext)) {
+        continue;
+      }
 
       // Skip user-allowlisted values
       if (isAllowlisted(value)) continue;

--- a/packages/service-contracts/src/__tests__/secret-detection.test.ts
+++ b/packages/service-contracts/src/__tests__/secret-detection.test.ts
@@ -131,6 +131,37 @@ describe("detectSecretsInText — placeholder suppression", () => {
     // known placeholder.
     expect(detectSecretsInText("acme_key_replace_with_your_key")).toEqual([]);
   });
+
+  test("placeholder pre-context suppresses a prefix match (fake_ghp_...)", () => {
+    // The GitHub regex matches starting at `ghp_`, so the `fake_` marker
+    // sits in the pre-context window rather than the matched value.
+    expect(detectSecretsInText(`fake_${"ghp_" + filler(36)}`)).toEqual([]);
+    expect(
+      detectSecretsInText(`docs use example_ghp_${filler(36)} as a stand-in`),
+    ).toEqual([]);
+  });
+
+  test("repeated-character variable portion suppresses a prefix match", () => {
+    // AKIA followed by 16 repeated placeholder characters.
+    expect(detectSecretsInText("AKIAXXXXXXXXXXXXXXXX")).toEqual([]);
+    expect(detectSecretsInText(`set AWS_KEY=AKIA${"X".repeat(16)}`)).toEqual(
+      [],
+    );
+  });
+
+  test("the same tokens without placeholder context still match", () => {
+    const github = `ghp_${filler(36)}`;
+    expect(detectSecretsInText(github).map((m) => m.label)).toEqual([
+      "GitHub Token",
+    ]);
+    expect(
+      detectSecretsInText("AKIAABCDEFGHIJKLMNOP").map((m) => m.label),
+    ).toEqual(["AWS Access Key"]);
+  });
+
+  test("token-shaped message with a repeated-character tail is suppressed", () => {
+    expect(detectSecretsInText(`my_key_${"x".repeat(16)}`)).toEqual([]);
+  });
 });
 
 describe("detectSecretsInText — whole-message token shape", () => {

--- a/packages/service-contracts/src/secret-detection.ts
+++ b/packages/service-contracts/src/secret-detection.ts
@@ -207,11 +207,27 @@ export const PLACEHOLDER_PREFIXES = [
 ];
 
 /**
- * Check if a matched value is a placeholder/test value that should not be
- * reported: exact `KNOWN_PLACEHOLDERS` membership or a `PLACEHOLDER_PREFIXES`
- * prefix, case-insensitive.
+ * Check if the text immediately before a matched value indicates a
+ * placeholder context (e.g. "fake_", "test_"): true when the pre-context
+ * window ends with any `PLACEHOLDER_PREFIXES` entry, case-insensitive.
  */
-function isPlaceholderValue(value: string): boolean {
+export function isPlaceholderContext(preContext: string): boolean {
+  const lower = preContext.toLowerCase();
+  for (const prefix of PLACEHOLDER_PREFIXES) {
+    if (lower.endsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if a matched value is a placeholder/test value that should not be
+ * reported: exact `KNOWN_PLACEHOLDERS` membership, a `PLACEHOLDER_PREFIXES`
+ * prefix (both case-insensitive), or a variable portion that is one repeated
+ * character (e.g. `AKIA` + `X` x 16).
+ */
+export function isPlaceholderValue(value: string): boolean {
   const lower = value.toLowerCase();
   if (KNOWN_PLACEHOLDERS.has(lower)) {
     return true;
@@ -221,6 +237,22 @@ function isPlaceholderValue(value: string): boolean {
       return true;
     }
   }
+
+  // Repeated characters in the variable portion (e.g. "AKIA" + "X" x 16)
+  // Strip known prefixes to isolate the variable part
+  const variablePart = value
+    .replace(
+      /^(?:AKIA|gh[pousr]_|github_pat_|glpat-|sk_live_|rk_live_|xoxb-|xoxp-|xapp-|sk-ant-|sk-proj-|sk-or-v1-|AIza|GOCSPX-|SK|SG\.|npm_|pypi-|key-|lin_api_|ntn_|fw_|pplx-|-----BEGIN [A-Z ]*PRIVATE KEY-----)/,
+      "",
+    )
+    .replace(/[^A-Za-z0-9]/g, "");
+  if (variablePart.length >= 8) {
+    const firstChar = variablePart[0];
+    if (variablePart.split("").every((c) => c === firstChar)) {
+      return true;
+    }
+  }
+
   return false;
 }
 
@@ -260,7 +292,10 @@ const GLOBAL_PREFIX_PATTERNS: SecretPrefixPattern[] = PREFIX_PATTERNS.map(
  * Scan a draft message for high-confidence secrets.
  *
  * Runs every `PREFIX_PATTERNS` entry over the text, suppressing placeholder
- * values. When no prefix pattern matches, the trimmed whole message is
+ * values and matches immediately preceded by a placeholder context (e.g.
+ * `fake_` before a real-looking token) — the same suppression the daemon
+ * applies at ingress, so client and server accept the same placeholders.
+ * When no prefix pattern matches, the trimmed whole message is
  * tested against {@link TOKEN_SHAPE} — the same whole-message token-shape
  * heuristic the daemon blocks at ingress. Overlapping spans are deduped
  * (first pattern in list order wins); results are sorted by `start`.
@@ -275,7 +310,12 @@ export function detectSecretsInText(text: string): DetectedSecret[] {
 
     while ((match = regex.exec(text)) !== null) {
       const value = match[0];
-      if (isPlaceholderValue(value)) {
+
+      // Skip placeholders and test values (check both the match and
+      // a small window before it for placeholder prefixes like "fake_")
+      const contextStart = Math.max(0, match.index - 10);
+      const preContext = text.slice(contextStart, match.index);
+      if (isPlaceholderValue(value) || isPlaceholderContext(preContext)) {
         continue;
       }
       const start = match.index;


### PR DESCRIPTION
## Summary
- Moves the daemon ingress pre-context (fake_/example_-style) and repeated-tail placeholder heuristics into the shared secret-detection module as pure functions; detectSecretsInText now applies them
- secret-ingress.ts imports the shared helpers (definitions deleted, behavior byte-identical, suites green per-file)
- Closes the client/server placeholder-acceptance divergence flagged by Codex on #38948

Part of plan: composer-secret-guard.md (follow-up to PR 1)