### PR TITLE
refactor(integrations): single-source live integration events, nuke dead wire protocol

### DIFF
--- a/assistant/src/api/events/oauth-connect-result.ts
+++ b/assistant/src/api/events/oauth-connect-result.ts
@@ -1,0 +1,26 @@
+/**
+ * `oauth_connect_result` SSE event.
+ *
+ * Emitted by the settings OAuth-connect route when a deferred OAuth flow
+ * completes, so connected clients can reflect the new connection state
+ * (or surface the failure) without re-fetching.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const OAuthConnectResultEventSchema = z.object({
+  type: z.literal("oauth_connect_result"),
+  success: z.boolean(),
+  service: z.string().optional(),
+  grantedScopes: z.array(z.string()).optional(),
+  accountInfo: z.string().optional(),
+  error: z.string().optional(),
+});
+
+export type OAuthConnectResultEvent = z.infer<
+  typeof OAuthConnectResultEventSchema
+>;

--- a/assistant/src/api/events/platform-disconnected.ts
+++ b/assistant/src/api/events/platform-disconnected.ts
@@ -1,0 +1,21 @@
+/**
+ * `platform_disconnected` SSE event.
+ *
+ * Emitted by the platform-disconnect route after stored platform
+ * credentials are deleted, notifying connected clients that the platform
+ * connection is gone.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const PlatformDisconnectedEventSchema = z.object({
+  type: z.literal("platform_disconnected"),
+});
+
+export type PlatformDisconnectedEvent = z.infer<
+  typeof PlatformDisconnectedEventSchema
+>;

--- a/assistant/src/api/events/show-platform-login.ts
+++ b/assistant/src/api/events/show-platform-login.ts
@@ -1,0 +1,20 @@
+/**
+ * `show_platform_login` SSE event.
+ *
+ * Emitted by the platform-connect route when no platform credentials are
+ * stored yet, signalling connected clients to surface the platform login UI.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const ShowPlatformLoginEventSchema = z.object({
+  type: z.literal("show_platform_login"),
+});
+
+export type ShowPlatformLoginEvent = z.infer<
+  typeof ShowPlatformLoginEventSchema
+>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -85,9 +85,11 @@ import { ModelInfoEventSchema } from "./events/model-info.js";
 import { NavigateSettingsEventSchema } from "./events/navigate-settings.js";
 import { NotificationConversationCreatedEventSchema } from "./events/notification-conversation-created.js";
 import { NotificationIntentEventSchema } from "./events/notification-intent.js";
+import { OAuthConnectResultEventSchema } from "./events/oauth-connect-result.js";
 import { OpenConversationEventSchema } from "./events/open-conversation.js";
 import { OpenPanelEventSchema } from "./events/open-panel.js";
 import { OpenUrlEventSchema } from "./events/open-url.js";
+import { PlatformDisconnectedEventSchema } from "./events/platform-disconnected.js";
 import { QuestionRequestEventSchema } from "./events/question-request.js";
 import {
   RecordingPauseEventSchema,
@@ -101,6 +103,7 @@ import { SecretRequestEventSchema } from "./events/secret-request.js";
 import { ServiceGroupUpdateCompleteEventSchema } from "./events/service-group-update-complete.js";
 import { ServiceGroupUpdateProgressEventSchema } from "./events/service-group-update-progress.js";
 import { ServiceGroupUpdateStartingEventSchema } from "./events/service-group-update-starting.js";
+import { ShowPlatformLoginEventSchema } from "./events/show-platform-login.js";
 import { SkillStateChangedEventSchema } from "./events/skill-state-changed.js";
 import { SoundsConfigUpdatedEventSchema } from "./events/sounds-config-updated.js";
 import { SubagentEventEventSchema } from "./events/subagent-event.js";
@@ -457,6 +460,10 @@ export {
   NotificationIntentEventSchema,
 } from "./events/notification-intent.js";
 export {
+  type OAuthConnectResultEvent,
+  OAuthConnectResultEventSchema,
+} from "./events/oauth-connect-result.js";
+export {
   type OpenConversationEvent,
   OpenConversationEventSchema,
 } from "./events/open-conversation.js";
@@ -465,6 +472,10 @@ export {
   OpenPanelEventSchema,
 } from "./events/open-panel.js";
 export { type OpenUrlEvent, OpenUrlEventSchema } from "./events/open-url.js";
+export {
+  type PlatformDisconnectedEvent,
+  PlatformDisconnectedEventSchema,
+} from "./events/platform-disconnected.js";
 export {
   type QuestionEntry,
   QuestionEntrySchema,
@@ -509,6 +520,10 @@ export {
   type ServiceGroupUpdateStartingEvent,
   ServiceGroupUpdateStartingEventSchema,
 } from "./events/service-group-update-starting.js";
+export {
+  type ShowPlatformLoginEvent,
+  ShowPlatformLoginEventSchema,
+} from "./events/show-platform-login.js";
 export {
   type SkillStateChangedEvent,
   SkillStateChangedEventSchema,
@@ -911,9 +926,11 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   NavigateSettingsEventSchema,
   NotificationConversationCreatedEventSchema,
   NotificationIntentEventSchema,
+  OAuthConnectResultEventSchema,
   OpenConversationEventSchema,
   OpenPanelEventSchema,
   OpenUrlEventSchema,
+  PlatformDisconnectedEventSchema,
   QuestionRequestEventSchema,
   RecordingPauseEventSchema,
   RecordingResumeEventSchema,
@@ -925,6 +942,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   ServiceGroupUpdateCompleteEventSchema,
   ServiceGroupUpdateProgressEventSchema,
   ServiceGroupUpdateStartingEventSchema,
+  ShowPlatformLoginEventSchema,
   SkillStateChangedEventSchema,
   SoundsConfigUpdatedEventSchema,
   SubagentEventEventSchema,

--- a/assistant/src/daemon/message-types/integrations.ts
+++ b/assistant/src/daemon/message-types/integrations.ts
@@ -1,43 +1,20 @@
-// External service integrations: Slack, Telegram, Vercel, ingress, guardian.
+// External service integrations: Slack, Telegram, Vercel, ingress, platform.
+//
+// Server→client events that are live hub broadcasts are single-sourced from
+// their canonical `api/events` wire schemas; this file only composes them into
+// the domain union consumed by `message-protocol.ts`. Config get/set flows
+// (Slack webhook, ingress, platform, Vercel, Telegram, integration listing and
+// connect) are served by the HTTP settings routes, not by client messages.
 
 import type { NavigateSettingsEvent } from "../../api/events/navigate-settings.js";
+import type { OAuthConnectResultEvent } from "../../api/events/oauth-connect-result.js";
 import type { OpenPanelEvent } from "../../api/events/open-panel.js";
 import type { OpenUrlEvent } from "../../api/events/open-url.js";
+import type { PlatformDisconnectedEvent } from "../../api/events/platform-disconnected.js";
+import type { ShowPlatformLoginEvent } from "../../api/events/show-platform-login.js";
 import type { ChannelId } from "../../channels/types.js";
 
 // === Client → Server ===
-
-export interface SlackWebhookConfigRequest {
-  type: "slack_webhook_config";
-  action: "get" | "set";
-  webhookUrl?: string;
-}
-
-export interface IngressConfigRequest {
-  type: "ingress_config";
-  action: "get" | "set";
-  publicBaseUrl?: string;
-  enabled?: boolean;
-}
-
-export interface PlatformConfigRequest {
-  type: "platform_config";
-  action: "get" | "set";
-  baseUrl?: string;
-}
-
-export interface VercelApiConfigRequest {
-  type: "vercel_api_config";
-  action: "get" | "set" | "delete";
-  apiToken?: string;
-}
-
-export interface TelegramConfigRequest {
-  type: "telegram_config";
-  action: "get" | "set" | "clear" | "set_commands" | "setup";
-  botToken?: string; // Only for action: 'set' or 'setup'
-  commands?: Array<{ command: string; description: string }>; // Only for action: 'set_commands' or 'setup'
-}
 
 export interface ChannelVerificationSessionRequest {
   type: "channel_verification_session";
@@ -60,86 +37,7 @@ export interface ChannelVerificationSessionRequest {
   contactChannelId?: string;
 }
 
-export interface IntegrationListRequest {
-  type: "integration_list";
-}
-
-export interface IntegrationConnectRequest {
-  type: "integration_connect";
-  integrationId: string;
-}
-
-export interface IntegrationDisconnectRequest {
-  type: "integration_disconnect";
-  integrationId: string;
-}
-
-export interface OAuthConnectStartRequest {
-  type: "oauth_connect_start";
-  service: string;
-  requestedScopes?: string[];
-}
-
-export interface LinkOpenRequest {
-  type: "link_open_request";
-  url: string;
-  metadata?: Record<string, unknown>;
-}
-
 // === Server → Client ===
-
-export interface SlackWebhookConfigResponse {
-  type: "slack_webhook_config_response";
-  webhookUrl?: string;
-  success: boolean;
-  error?: string;
-}
-
-export interface IngressConfigResponse {
-  type: "ingress_config_response";
-  enabled: boolean;
-  publicBaseUrl: string;
-  /** Read-only gateway target computed from GATEWAY_PORT env var (default 7830) + loopback host. */
-  localGatewayTarget: string;
-  /**
-   * When true, this assistant uses platform-managed callback routing.
-   * Webhook delivery is handled by the platform — no local tunnel or
-   * ngrok setup is needed. `publicBaseUrl` reflects the platform callback URL.
-   */
-  managedCallbacks?: boolean;
-  success: boolean;
-  error?: string;
-}
-
-export interface PlatformConfigResponse {
-  type: "platform_config_response";
-  baseUrl: string;
-  success: boolean;
-  error?: string;
-}
-
-export interface VercelApiConfigResponse {
-  type: "vercel_api_config_response";
-  hasToken: boolean;
-  success: boolean;
-  error?: string;
-}
-
-export interface TelegramConfigResponse {
-  type: "telegram_config_response";
-  success: boolean;
-  hasBotToken: boolean;
-  botId?: string;
-  botUsername?: string;
-  connected: boolean;
-  hasWebhookSecret: boolean;
-  lastError?: string;
-  error?: string;
-  /** Names of bot commands that were registered (present after set_commands or setup). */
-  commandsRegistered?: string[];
-  /** Non-fatal warning (e.g. commands registration failed during setup but token was configured). */
-  warning?: string;
-}
 
 export interface ChannelVerificationSessionResponse {
   type: "channel_verification_session_response";
@@ -178,72 +76,15 @@ export interface ChannelVerificationSessionResponse {
   pendingBootstrap?: boolean;
 }
 
-export interface IntegrationListResponse {
-  type: "integration_list_response";
-  integrations: Array<{
-    id: string;
-    connected: boolean;
-    accountInfo?: string | null;
-    connectedAt?: number | null;
-    lastUsed?: number | null;
-    error?: string | null;
-  }>;
-}
-
-export interface IntegrationConnectResult {
-  type: "integration_connect_result";
-  integrationId: string;
-  success: boolean;
-  accountInfo?: string | null;
-  error?: string | null;
-  setupRequired?: boolean;
-  setupHint?: string;
-}
-
-export interface OAuthConnectResultResponse {
-  type: "oauth_connect_result";
-  success: boolean;
-  service?: string;
-  grantedScopes?: string[];
-  accountInfo?: string;
-  error?: string;
-}
-
-export interface ShowPlatformLogin {
-  type: "show_platform_login";
-}
-
-export interface PlatformDisconnected {
-  type: "platform_disconnected";
-}
-
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
-export type _IntegrationsClientMessages =
-  | SlackWebhookConfigRequest
-  | IngressConfigRequest
-  | PlatformConfigRequest
-  | VercelApiConfigRequest
-  | TelegramConfigRequest
-  | ChannelVerificationSessionRequest
-  | IntegrationListRequest
-  | IntegrationConnectRequest
-  | IntegrationDisconnectRequest
-  | OAuthConnectStartRequest
-  | LinkOpenRequest;
+export type _IntegrationsClientMessages = ChannelVerificationSessionRequest;
 
 export type _IntegrationsServerMessages =
-  | SlackWebhookConfigResponse
-  | IngressConfigResponse
-  | PlatformConfigResponse
-  | VercelApiConfigResponse
-  | TelegramConfigResponse
   | ChannelVerificationSessionResponse
-  | IntegrationListResponse
-  | IntegrationConnectResult
-  | OAuthConnectResultResponse
+  | OAuthConnectResultEvent
   | OpenUrlEvent
   | OpenPanelEvent
   | NavigateSettingsEvent
-  | ShowPlatformLogin
-  | PlatformDisconnected;
+  | ShowPlatformLoginEvent
+  | PlatformDisconnectedEvent;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -532,6 +532,13 @@ export function useStreamEventHandler(
         case "config_changed":
         case "sounds_config_updated":
           break;
+        // Integration/platform lifecycle broadcasts. The web chat handler is a
+        // no-op — OAuth-connect completion and platform login/disconnect signals
+        // are consumed by the settings surfaces, not the conversation stream.
+        case "oauth_connect_result":
+        case "show_platform_login":
+        case "platform_disconnected":
+          break;
         // Notification-created broadcasts and recording lifecycle
         // instructions. The web chat handler is a no-op for these — they target
         // the CLI/desktop clients or are handled elsewhere.

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -125,6 +125,12 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   "client_settings_update",
   "config_changed",
   "sounds_config_updated",
+  // Integration/platform lifecycle broadcasts — OAuth-connect completion,
+  // platform login prompt, and platform disconnect notice — are app-wide and
+  // carry no `conversationId`, so gate them as global.
+  "oauth_connect_result",
+  "show_platform_login",
+  "platform_disconnected",
   // Notification-created broadcasts and recording lifecycle instructions are not
   // tied to the active conversation stream (they carry no top-level
   // `conversationId`, or — for notification_conversation_created — announce a


### PR DESCRIPTION
## Prompt / plan

Continuation of the event-type unification: make `assistant/src/api/events/*` the single source of truth for server→client hub events, migrating runtime `message-types` domains onto the api-inferred types (`z.infer<AssistantEventSchema>` becomes the full hub-published event set). Per the standing rule for this effort — every event being cut over is liveness-checked (must have a live producer AND consumer), and dead types are deleted rather than wrapped in schemas.

This PR covers the `integrations` domain.

### Migrated (live hub broadcasts → `api/events` + `AssistantEventSchema`)
- `oauth_connect_result` — settings-routes, deferred OAuth completion (`buildAssistantEvent` → `assistantEventHub.publish`)
- `show_platform_login` — platform-routes, no stored platform credentials
- `platform_disconnected` — platform-routes, after credential deletion

### Nuked (dead — no producer, dispatcher, or type consumer)
Slack webhook / ingress / platform / Vercel / Telegram config get-set, plus integration listing and connect, are served by the HTTP settings routes now. There is no runtime `ClientMessage` dispatcher at all; these were legacy wire messages.
- 7 server responses: `slack_webhook_config_response`, `ingress_config_response`, `platform_config_response`, `vercel_api_config_response`, `telegram_config_response`, `integration_list_response`, `integration_connect_result`
- 10 client requests: `slack_webhook_config`, `ingress_config`, `platform_config`, `vercel_api_config`, `telegram_config`, `integration_list`, `integration_connect`, `integration_disconnect`, `oauth_connect_start`, `link_open_request`

### Retained (not cut over)
`channel_verification_session` (request) is still consumed by `handleChannelVerificationSession` and its test suite; `channel_verification_session_response` is *not* a live hub event (the runtime path is the channel-verification HTTP route), so it stays a plain message-type rather than being migrated. `_IntegrationsClientMessages` keeps just the verification request; `_IntegrationsServerMessages` composes the api-inferred events plus the retained verification response. Deleting the legacy verification client-message shim is a separate, larger cleanup.

All three migrated events are app-wide broadcasts with no `conversationId`, so they join the web's global stream-event set with no-op chat-handler cases.

## Test plan
- `bun run typecheck:fast` (tsgo) — clean
- `bun test src/api src/__tests__/runtime-events-sse-parity.test.ts` — 34 pass
- `bun test src/__tests__/plugin-import-boundary-guard.test.ts` — 5 pass
- `bun run generate:openapi -- --check` — spec unchanged (SSE events don't affect the route-driven OpenAPI)
- web: `bun run openapi-ts` + `bunx tsc --noEmit` — clean (exhaustive stream-event switch satisfied)
- eslint + prettier on changed files

<!-- No new routes added; CLI verb checklist not applicable. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_