### PR TITLE
fix(gateway): validate Slack team_id before stamping it onto the event

### DIFF
--- a/gateway/src/slack/event-team.test.ts
+++ b/gateway/src/slack/event-team.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "bun:test";
+
+import { stampSlackEventTeam } from "./event-team.js";
+
+describe("stampSlackEventTeam", () => {
+  it("stamps a string team_id onto an event with no team", () => {
+    const event: { team?: string } = {};
+    stampSlackEventTeam(event, "T0WORKSPACE");
+    expect(event.team).toBe("T0WORKSPACE");
+  });
+
+  it("leaves an existing event-level team untouched (it takes precedence)", () => {
+    const event: { team?: string } = { team: "T0EVENTLEVEL" };
+    stampSlackEventTeam(event, "T0PAYLOAD");
+    expect(event.team).toBe("T0EVENTLEVEL");
+  });
+
+  it("ignores a non-string team_id rather than writing garbage identity", () => {
+    // `team_id` comes from an unvalidated JSON.parse; a non-string value must
+    // not be stamped, or it would flow into `actor.teamId` as garbage.
+    const event: { team?: string } = {};
+    stampSlackEventTeam(event, { nested: "object" } as unknown);
+    expect(event.team).toBeUndefined();
+  });
+
+  it("ignores a missing team_id", () => {
+    const event: { team?: string } = {};
+    stampSlackEventTeam(event, undefined);
+    expect(event.team).toBeUndefined();
+  });
+
+  it("ignores an empty-string team_id", () => {
+    const event: { team?: string } = {};
+    stampSlackEventTeam(event, "");
+    expect(event.team).toBeUndefined();
+  });
+});

--- a/gateway/src/slack/event-team.ts
+++ b/gateway/src/slack/event-team.ts
@@ -1,0 +1,19 @@
+/**
+ * Stamp the workspace id (`team_id`) from the events_api envelope onto the inner
+ * Slack event when the event itself doesn't carry a `team`.
+ *
+ * Slack's inner events don't reliably include `team` (app_mention and channel
+ * messages commonly omit it), so the payload-level `team_id` is the fallback
+ * source for the actor's workspace. `teamId` comes from an **unvalidated**
+ * `JSON.parse` of the socket frame, so a non-string value is ignored rather than
+ * written as a garbage `actor.teamId`. An event-level `team` (e.g. a Slack
+ * Connect sender's home workspace) takes precedence and is left untouched.
+ */
+export function stampSlackEventTeam(
+  event: { team?: string },
+  teamId: unknown,
+): void {
+  if (typeof teamId === "string" && teamId && !event.team) {
+    event.team = teamId;
+  }
+}

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -20,6 +20,7 @@ import {
 } from "./slack-web.js";
 import { isSlackDmChannel } from "./channel.js";
 import { slackEventOrderingKey } from "./event-ordering.js";
+import { stampSlackEventTeam } from "./event-team.js";
 import {
   normalizeSlackAppMention,
   normalizeSlackDirectMessage,
@@ -794,9 +795,7 @@ export class SlackSocketModeClient {
     // event so normalization can capture the actor's team. An event-level
     // `team` (e.g. a Slack Connect sender's home workspace) takes precedence.
     const innerEvent = eventPayload.event as { team?: string };
-    if (eventPayload.team_id && !innerEvent.team) {
-      innerEvent.team = eventPayload.team_id;
-    }
+    stampSlackEventTeam(innerEvent, eventPayload.team_id);
 
     this.processEventPayload({
       event_id: eventPayload.event_id,


### PR DESCRIPTION
## Prompt / plan

Second standalone bug fix in the Slack ingress hardening (LUM-2818, under LUM-2816; after LUM-2817 / #38963 landed). Slack's untrusted `event` is read at several sites in `socket-mode.ts` before any normalizer runs; this is the `team_id` stamp — a garbage-identity bug, fixed on its own ahead of the ingress parse-seam refactor.

## The bug

In the `events_api` handler, Slack's inner events don't reliably carry `team` (app_mention / channel messages often omit it), so the handler stamps the payload-level `team_id` onto the event:

```ts
const innerEvent = eventPayload.event as { team?: string };
if (eventPayload.team_id && !innerEvent.team) {
  innerEvent.team = eventPayload.team_id;
}
```

`team_id` comes from an **unvalidated `JSON.parse`**, and the envelope's inline type only *claims* it's a `string`. A non-string `team_id` (object/number) is truthy, passes the guard, and is written straight to `innerEvent.team` — which flows downstream into `actor.teamId` (via `normalizeSlackChannelMessage` / `normalizeSlackAppMention`) as **garbage identity**. `tsc` can't catch it because the type lies about untrusted input.

## The fix

- Extract the stamp into a pure `stampSlackEventTeam(event, teamId: unknown)` helper (`slack/event-team.ts`) that **ignores a non-string `team_id`** (`typeof`-guarded), keeping the existing "event-level `team` takes precedence" semantics and the in-place stamp.
- The extraction makes it **unit-testable** — like the ordering-key fix (#38963), this logic lived in the untested private `handleMessage`.

## Scope

Just this one garbage-identity bug. The root-cause seam refactor (LUM-2819, `parseSlackEnvelope`) will make `team_id`'s type runtime-guaranteed so the stamp is safe by construction; this stops the bad write now.

## Test plan

- `cd gateway && bunx tsc --noEmit` — clean. ESLint / Prettier / generic-examples clean.
- New `slack/event-team.test.ts`: string `team_id` stamped; existing event-level `team` preserved; **non-string `team_id` ignored** (the fix); missing/empty ignored.
- The Slack suite (`normalize` + `event-ordering` + `event-team`) passes — **102 tests**.
- Negative control: reverting the `typeof` guard makes exactly the non-string test **fail** (the object gets stamped); restoring it passes — so the test asserts the fix, not current behavior.

## CLI verb checklist

No new routes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f)_