### PR TITLE
fix(web): make library import work on mobile instead of failing silently

### DIFF
--- a/clients/web/src/domains/library/components/library-empty-state.test.tsx
+++ b/clients/web/src/domains/library/components/library-empty-state.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * Tests for LibraryEmptyState.
+ *
+ * Renders to static markup via `react-dom/server` and asserts on the emitted
+ * HTML. The focus is the file-picker `accept` filter: on desktop the picker is
+ * constrained to `.vellum`, while touch devices (where iOS ignores extension
+ * filters) get an unrestricted picker so the bundle is actually selectable.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { LibraryEmptyState } from "./library-empty-state";
+
+function render(opts: {
+  accept: string | undefined;
+  onNewConversation?: () => void;
+}) {
+  return renderToStaticMarkup(
+    createElement(LibraryEmptyState, {
+      accept: opts.accept,
+      fileInputRef: { current: null },
+      isImporting: false,
+      onImportBundle: () => {},
+      onNewConversation: opts.onNewConversation,
+    }),
+  );
+}
+
+describe("LibraryEmptyState", () => {
+  test("constrains the picker to .vellum when an accept filter is given", () => {
+    const html = render({ accept: ".vellum" });
+    expect(html).toContain('accept=".vellum"');
+  });
+
+  test("leaves the picker unrestricted when accept is undefined (touch)", () => {
+    const html = render({ accept: undefined });
+    expect(html).not.toContain("accept=");
+  });
+
+  test("always renders the import and new-conversation entry points", () => {
+    const html = render({ accept: ".vellum", onNewConversation: () => {} });
+    expect(html).toContain("Import .vellum File");
+    expect(html).toContain("New Conversation");
+  });
+});

--- a/clients/web/src/domains/library/components/library-empty-state.tsx
+++ b/clients/web/src/domains/library/components/library-empty-state.tsx
@@ -9,6 +9,12 @@ import { type ChangeEvent, type RefObject } from "react";
 import { Button } from "@vellumai/design-library";
 
 interface LibraryEmptyStateProps {
+  /**
+   * File-picker `accept` filter. `undefined` leaves the picker unrestricted
+   * (touch devices, where iOS ignores extension filters) — see
+   * `LibraryView` for the platform rationale.
+   */
+  accept: string | undefined;
   fileInputRef: RefObject<HTMLInputElement | null>;
   isImporting: boolean;
   onImportBundle: (e: ChangeEvent<HTMLInputElement>) => void;
@@ -16,6 +22,7 @@ interface LibraryEmptyStateProps {
 }
 
 export function LibraryEmptyState({
+  accept,
   fileInputRef,
   isImporting,
   onImportBundle,
@@ -26,7 +33,7 @@ export function LibraryEmptyState({
       <input
         ref={fileInputRef}
         type="file"
-        accept=".vellum"
+        accept={accept}
         className="hidden"
         onChange={onImportBundle}
       />

--- a/clients/web/src/domains/library/library-view.tsx
+++ b/clients/web/src/domains/library/library-view.tsx
@@ -25,6 +25,7 @@ import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import type { AppSummary } from "@/types/app-types";
 import { getCachedAppHtml } from "@/utils/app-html-cache";
 import { importBundle } from "@/utils/import-bundle";
+import { isPointerCoarse } from "@/utils/pointer";
 import { Button, Input, toast } from "@vellumai/design-library";
 
 export interface LibraryViewProps {
@@ -70,6 +71,15 @@ export function LibraryView({
   } = useAppDelete(assistantId);
 
   // --- Import state ---
+  // iOS Safari/WKWebView (including iOS Chrome) doesn't implement `accept`
+  // with filename extensions, so a `.vellum` filter makes the custom-extension
+  // bundle non-selectable in the file picker there. Constrain the picker to
+  // `.vellum` only on fine-pointer (desktop) devices; touch devices get an
+  // unrestricted picker and rely on the server's bundle validation.
+  // https://github.com/mdn/browser-compat-data/issues/26043
+  const [bundleAccept] = useState<string | undefined>(() =>
+    isPointerCoarse() ? undefined : ".vellum",
+  );
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isImporting, setIsImporting] = useState(false);
 
@@ -157,6 +167,7 @@ export function LibraryView({
   if (apps.length === 0 && documents.length === 0) {
     return (
       <LibraryEmptyState
+        accept={bundleAccept}
         fileInputRef={fileInputRef}
         isImporting={isImporting}
         onImportBundle={handleImportBundle}
@@ -175,7 +186,7 @@ export function LibraryView({
           <input
             ref={fileInputRef}
             type="file"
-            accept=".vellum"
+            accept={bundleAccept}
             className="hidden"
             onChange={handleImportBundle}
           />


### PR DESCRIPTION
## Prompt / plan

Fixes [LUM-2808](https://linear.app/vellum/issue/LUM-2808) — "Mobile: Import button fails to import PDF and image on Library page" (reported on iPhone 14 Pro Max / Chrome).

The source report suggested *hiding* the Import button on mobile as a mitigation. Rather than remove the capability, this addresses the root cause so import actually works on mobile.

**Root cause.** The Library import uses `<input type="file" accept=".vellum">`. Per [MDN browser-compat-data#26043](https://github.com/mdn/browser-compat-data/issues/26043) and the [WebKit radar](https://github.com/lionheart/openradar-mirror/issues/19227), **iOS Safari/WKWebView doesn't implement `accept` with filename extensions** — and iOS Chrome is WKWebView-backed too. `.vellum` is a custom extension with no iOS UTI, so the filter made valid bundles non-selectable and steered the picker toward Photos/other files. The reporter ended up selecting a PDF/image, which then failed the server-side import — exactly the reported symptom.

**Fix.** Apply the `.vellum` filter only on fine-pointer (desktop) devices, where it works, via the existing `isPointerCoarse()` capability check. Touch devices get an unrestricted picker so the `.vellum` bundle is actually selectable. The server already validates the bundle end-to-end (zip → `manifest.json` → `format_version: 2` → security scan), so it remains the correctness gate — `accept` was only ever a picker hint, never validation. This also fixes import inside the Capacitor iOS shell (WKWebView).

Changed files:
- `library-view.tsx`: compute `bundleAccept` (`.vellum` on desktop, `undefined` on touch) once; use it on the grid file input and pass it to the empty state.
- `components/library-empty-state.tsx`: take an `accept` prop and apply it to its file input.

**Trade-off / note for review:** the gate is capability-based (`isPointerCoarse()`), so Android — which *does* honor extension filters — also gets an unrestricted picker on touch. That's a deliberate simplification: it avoids UA-sniffing for iOS specifically, and an unrestricted picker is correct everywhere (validation is server-side). If we'd rather keep Android's filter, the alternative is an iOS-specific check.

## Test plan

- Added `components/library-empty-state.test.tsx` — asserts the picker is constrained to `.vellum` when a filter is given (desktop) and unrestricted when `accept` is `undefined` (touch), and that the entry points still render.
- `cd clients/web && bun test src/domains/library/components/library-empty-state.test.tsx` — 3 pass.
- `cd clients/web && bunx tsc --noEmit` — passes.
- `cd clients/web && bun run lint` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiSoahxDVXHxcLiuou7hNS