### PR TITLE
feat(web): block sends containing detected secrets until stored or explicitly overridden

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -799,7 +799,19 @@ export function ChatMainPanel({
     typingDisabled,
     assistantId,
     activeConversationId,
+    // Synchronous pre-send gate: re-scans the outgoing content so pastes
+    // sent inside the detection debounce window are still caught. Flag off
+    // or no secrets → returns true, fully inert.
+    beforeSend: draftSecretDetection.checkBeforeSend,
   });
+
+  // "Send anyway" on the blocked notice: arm the single-use bypass, then
+  // resubmit the exact content that was intercepted.
+  const { allowOnce: allowSecretSendOnce } = draftSecretDetection;
+  const handleSecretSendAnyway = useCallback(() => {
+    allowSecretSendOnce();
+    void submitMessage();
+  }, [allowSecretSendOnce, submitMessage]);
 
   const handleSelectStarter = useCallback((starter: { prompt: string }) => {
     useComposerStore.getState().setInput(starter.prompt);
@@ -1010,10 +1022,15 @@ export function ChatMainPanel({
       noticesAboveFormSlot={
         <>
           {draftSecretDetection.matches.length > 0 &&
-            !draftSecretDetection.dismissed && (
+            // A blocked send always surfaces the notice — even when the
+            // passive warning for these values was previously dismissed.
+            (!draftSecretDetection.dismissed ||
+              draftSecretDetection.sendBlocked) && (
               <ComposerSecretNotice
                 matches={draftSecretDetection.matches}
+                sendBlocked={draftSecretDetection.sendBlocked}
                 onDismiss={draftSecretDetection.dismiss}
+                onSendAnyway={handleSecretSendAnyway}
               />
             )}
           <ComposerNotices

--- a/clients/web/src/domains/chat/components/composer-secret-notice.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-secret-notice.test.tsx
@@ -1,6 +1,8 @@
 /**
  * Tests for `ComposerSecretNotice` — masked display, generic copy, and
- * dismissal. The token is a synthetic value invented for these tests.
+ * dismissal in the passive state, plus the blocked-send state's exact copy
+ * and "Send anyway" / "Dismiss" actions. The token is a synthetic value
+ * invented for these tests.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -11,6 +13,7 @@ import type { DetectedSecret } from "@vellumai/service-contracts/secret-detectio
 import {
   ComposerSecretNotice,
   maskSecretValue,
+  type ComposerSecretNoticeProps,
 } from "./composer-secret-notice";
 
 const SYNTHETIC_PROJECT_KEY =
@@ -24,6 +27,21 @@ const match: DetectedSecret = {
   wholeMessage: false,
 };
 
+const BLOCKED_TITLE =
+  "Message not sent — it looks like it contains an API key";
+
+function renderNotice(overrides: Partial<ComposerSecretNoticeProps> = {}) {
+  return render(
+    <ComposerSecretNotice
+      matches={[match]}
+      sendBlocked={false}
+      onDismiss={() => {}}
+      onSendAnyway={() => {}}
+      {...overrides}
+    />,
+  );
+}
+
 afterEach(() => {
   cleanup();
 });
@@ -36,11 +54,9 @@ describe("maskSecretValue", () => {
   });
 });
 
-describe("ComposerSecretNotice", () => {
+describe("ComposerSecretNotice (passive)", () => {
   test("renders the masked value — the full plaintext never reaches the DOM", () => {
-    const { container } = render(
-      <ComposerSecretNotice matches={[match]} onDismiss={() => {}} />,
-    );
+    const { container } = renderNotice();
     expect(container.textContent).toContain("This looks like an API key");
     expect(container.textContent).toContain(
       maskSecretValue(SYNTHETIC_PROJECT_KEY),
@@ -51,19 +67,53 @@ describe("ComposerSecretNotice", () => {
     expect(container.innerHTML).not.toContain(SYNTHETIC_PROJECT_KEY);
     // The detection label (vendor) stays internal.
     expect(container.textContent).not.toContain("OpenAI");
+    // Blocked-state affordances are absent while passive.
+    expect(container.textContent).not.toContain(BLOCKED_TITLE);
+    expect(screen.queryByRole("button", { name: "Send anyway" })).toBeNull();
   });
 
   test("dismiss control invokes onDismiss", () => {
     const onDismiss = mock(() => {});
-    render(<ComposerSecretNotice matches={[match]} onDismiss={onDismiss} />);
+    renderNotice({ onDismiss });
     fireEvent.click(screen.getByLabelText("Dismiss"));
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
   test("renders nothing without matches", () => {
-    const { container } = render(
-      <ComposerSecretNotice matches={[]} onDismiss={() => {}} />,
-    );
+    const { container } = renderNotice({ matches: [] });
     expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("ComposerSecretNotice (blocked send)", () => {
+  test("shows the exact blocked copy, the masked value, and both actions", () => {
+    const { container } = renderNotice({ sendBlocked: true });
+    expect(container.textContent).toContain(BLOCKED_TITLE);
+    expect(container.textContent).toContain(
+      maskSecretValue(SYNTHETIC_PROJECT_KEY),
+    );
+    expect(container.innerHTML).not.toContain(SYNTHETIC_PROJECT_KEY);
+    // Copy stays generic — never names the detected vendor.
+    expect(container.textContent).not.toContain("OpenAI");
+    expect(
+      screen.getByRole("button", { name: "Send anyway" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
+  });
+
+  test("Send anyway invokes the bypass-and-resubmit handler once", () => {
+    // The handler is the orchestrator's composition of allowOnce() +
+    // submitMessage(); the component just fires it.
+    const onSendAnyway = mock(() => {});
+    renderNotice({ sendBlocked: true, onSendAnyway });
+    fireEvent.click(screen.getByRole("button", { name: "Send anyway" }));
+    expect(onSendAnyway).toHaveBeenCalledTimes(1);
+  });
+
+  test("Dismiss action invokes onDismiss", () => {
+    const onDismiss = mock(() => {});
+    renderNotice({ sendBlocked: true, onDismiss });
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/domains/chat/components/composer-secret-notice.tsx
+++ b/clients/web/src/domains/chat/components/composer-secret-notice.tsx
@@ -1,4 +1,4 @@
-import { Notice } from "@vellumai/design-library";
+import { Button, Notice } from "@vellumai/design-library";
 import type { DetectedSecret } from "@vellumai/service-contracts/secret-detection";
 
 /** Leading characters of the detected value kept visible in the masked preview. */
@@ -16,20 +16,47 @@ export function maskSecretValue(value: string): string {
 export interface ComposerSecretNoticeProps {
   /** Detected secrets ordered by draft position; the first is previewed. */
   matches: DetectedSecret[];
+  /**
+   * True when the pre-send gate intercepted the last submit. Switches the
+   * notice from the passive warning to the blocked-send state with explicit
+   * actions.
+   */
+  sendBlocked: boolean;
   /** Invoked when the user dismisses the warning. */
   onDismiss: () => void;
+  /**
+   * Blocked state only: the user explicitly chose to send despite the
+   * warning. The orchestrator arms the detection hook's single-use
+   * `allowOnce()` bypass and re-invokes the composer submit handler.
+   */
+  onSendAnyway: () => void;
 }
 
 /**
- * Passive warning above the composer when the draft contains what looks
- * like an API key. The copy is deliberately generic — the detection label
- * (which names the vendor) stays internal and is never rendered. The
- * detected value appears masked only; the full plaintext never reaches the
- * DOM.
+ * Warning above the composer when the draft contains what looks like an API
+ * key. Two states:
+ *
+ * - Passive (`sendBlocked` false): informational warning with a dismiss
+ *   control, shown while typing.
+ * - Blocked (`sendBlocked` true): the pre-send gate intercepted a submit;
+ *   the draft is untouched and the user chooses "Send anyway" (single-use
+ *   bypass + resubmit) or "Dismiss". Follow-up actions (e.g. storing the
+ *   credential securely) slot in as additional buttons alongside these.
+ *
+ * The copy is deliberately generic — the detection label (which names the
+ * vendor) stays internal and is never rendered. The detected value appears
+ * masked only; the full plaintext never reaches the DOM.
+ *
+ * "Send anyway" is a client-side bypass only: messages that consist
+ * entirely of a token are still rejected server-side by the daemon's
+ * `secret_blocked` ingress guard and surface through the existing send
+ * error path (`api/messages.ts`) — intentionally unchanged here.
  */
 export function ComposerSecretNotice({
   matches,
+  sendBlocked,
   onDismiss,
+  onSendAnyway,
 }: ComposerSecretNoticeProps) {
   const first = matches[0];
   if (!first) {
@@ -39,8 +66,24 @@ export function ComposerSecretNotice({
     <div className="mb-2">
       <Notice
         tone="warning"
-        title="This looks like an API key"
-        onDismiss={onDismiss}
+        title={
+          sendBlocked
+            ? "Message not sent — it looks like it contains an API key"
+            : "This looks like an API key"
+        }
+        onDismiss={sendBlocked ? undefined : onDismiss}
+        actions={
+          sendBlocked ? (
+            <>
+              <Button variant="outlined" size="compact" onClick={onSendAnyway}>
+                Send anyway
+              </Button>
+              <Button variant="ghost" size="compact" onClick={onDismiss}>
+                Dismiss
+              </Button>
+            </>
+          ) : undefined
+        }
       >
         <span className="font-mono">{maskSecretValue(first.value)}</span>
         <p>

--- a/clients/web/src/domains/chat/hooks/use-composer-submit.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-composer-submit.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Tests for `useComposerSubmit`, focused on the optional `beforeSend` gate:
+ * a blocking gate must cancel the send losslessly (draft, attachments, and
+ * staged quotes untouched), while a passing or omitted gate leaves the
+ * submit path unchanged. Uses the real composer and quote-reply stores,
+ * reset between tests. The token below is a synthetic value invented for
+ * these tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import {
+  useComposerStore,
+  type UploadedAttachment,
+} from "@/domains/chat/composer-store";
+import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+import {
+  useComposerSubmit,
+  type UseComposerSubmitParams,
+} from "./use-composer-submit";
+
+const SYNTHETIC_PROJECT_KEY =
+  "sk-proj-Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv1Wx2Yz3A";
+
+const uploadedAttachment: UploadedAttachment = {
+  kind: "uploaded",
+  localId: "local-1",
+  id: "attachment-1",
+  filename: "notes.txt",
+  mimeType: "text/plain",
+  sizeBytes: 12,
+  previewUrl: null,
+  thumbnailUrl: null,
+};
+
+function renderSubmit(overrides: Partial<UseComposerSubmitParams> = {}) {
+  const sendMessage = mock(
+    async (_content: string, _attachments?: DisplayAttachment[]) => {},
+  );
+  const { result } = renderHook(() =>
+    useComposerSubmit({
+      sendMessage,
+      inputRef: { current: null },
+      scrollToLatest: () => {},
+      isEditing: false,
+      editingMessageId: null,
+      cancelEditing: () => {},
+      canUndoEdit: false,
+      sendDisabled: false,
+      typingDisabled: false,
+      assistantId: "assistant-1",
+      activeConversationId: "conv-1",
+      ...overrides,
+    }),
+  );
+  return { result, sendMessage };
+}
+
+async function submit(result: {
+  current: { submitMessage: (inputOverride?: string) => Promise<void> };
+}) {
+  await act(async () => {
+    await result.current.submitMessage();
+  });
+}
+
+beforeEach(() => {
+  useComposerStore.getState().setInput("");
+  useComposerStore.getState().resetAttachments();
+  useQuoteReplyStore.getState().clearStagedQuotes();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useComposerSubmit beforeSend gate", () => {
+  test("blocking gate cancels the send with draft, attachments, and quotes intact", async () => {
+    const draft = `deploy with ${SYNTHETIC_PROJECT_KEY}`;
+    useComposerStore.getState().setInput(draft);
+    useComposerStore.setState({ attachments: [uploadedAttachment] });
+    useQuoteReplyStore.getState().addStagedQuote({
+      quotedText: "which key?",
+      replyText: "this one",
+      sourceMessageId: "msg-1",
+    });
+
+    const beforeSend = mock((_content: string) => false);
+    const { result, sendMessage } = renderSubmit({ beforeSend });
+    await submit(result);
+
+    expect(beforeSend).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+    // Nothing was cleared by the interception.
+    expect(useComposerStore.getState().input).toBe(draft);
+    expect(useComposerStore.getState().attachments).toEqual([
+      uploadedAttachment,
+    ]);
+    expect(useQuoteReplyStore.getState().stagedQuotes).toHaveLength(1);
+  });
+
+  test("gate sees the assembled outgoing content, not just the raw draft", async () => {
+    useComposerStore.getState().setInput("freeform text");
+    useQuoteReplyStore.getState().addStagedQuote({
+      quotedText: `quoted ${SYNTHETIC_PROJECT_KEY}`,
+      replyText: "about this",
+      sourceMessageId: "msg-1",
+    });
+
+    const beforeSend = mock((_content: string) => false);
+    const { result } = renderSubmit({ beforeSend });
+    await submit(result);
+
+    const seen = beforeSend.mock.calls[0]?.[0];
+    expect(seen).toContain(`> quoted ${SYNTHETIC_PROJECT_KEY}`);
+    expect(seen).toContain("freeform text");
+  });
+
+  test("passing gate sends the same assembled content and clears the draft", async () => {
+    useComposerStore.getState().setInput("all clear");
+    const beforeSend = mock((_content: string) => true);
+    const { result, sendMessage } = renderSubmit({ beforeSend });
+    await submit(result);
+
+    expect(beforeSend).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[0]).toBe("all clear");
+    expect(beforeSend.mock.calls[0]?.[0]).toBe("all clear");
+    expect(useComposerStore.getState().input).toBe("");
+  });
+
+  test("omitted gate leaves the submit path unchanged", async () => {
+    useComposerStore.getState().setInput("no gate here");
+    const { result, sendMessage } = renderSubmit();
+    await submit(result);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[0]).toBe("no gate here");
+    expect(useComposerStore.getState().input).toBe("");
+  });
+
+  test("empty submits return before the gate is consulted", async () => {
+    const beforeSend = mock((_content: string) => false);
+    const { result, sendMessage } = renderSubmit({ beforeSend });
+    await submit(result);
+
+    expect(beforeSend).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-composer-submit.ts
+++ b/clients/web/src/domains/chat/hooks/use-composer-submit.ts
@@ -8,6 +8,10 @@
  *
  * Owns `shouldFocusInputRef` and the effect that focuses the input
  * after a successful send.
+ *
+ * Callers may pass an optional `beforeSend` gate that sees the assembled
+ * outgoing content before anything is cleared; returning `false` cancels
+ * the send losslessly (used by the composer secret guard).
  */
 
 import { type FormEvent, type RefObject, useCallback, useEffect, useRef } from "react";
@@ -41,6 +45,13 @@ export interface UseComposerSubmitParams {
   typingDisabled: boolean;
   assistantId: string | null;
   activeConversationId: string | null;
+  /**
+   * Pre-send gate, invoked with the fully assembled outgoing content
+   * (quotes and path references included) before any composer state is
+   * cleared. Return `false` to block the send — the draft, attachments,
+   * and staged quotes are left fully intact. Omitted = always proceed.
+   */
+  beforeSend?: (content: string) => boolean;
 }
 
 export interface ComposerSubmitResult {
@@ -66,6 +77,7 @@ export function useComposerSubmit({
   typingDisabled,
   assistantId,
   activeConversationId,
+  beforeSend,
 }: UseComposerSubmitParams): ComposerSubmitResult {
   const shouldFocusInputRef = useRef(false);
 
@@ -97,6 +109,14 @@ export function useComposerSubmit({
       return;
     }
     if (uploadingCount > 0) return;
+
+    // Assemble the outgoing content before touching any state so the gate
+    // below can veto the send with the draft/attachments/quotes intact.
+    const contentWithQuotes = buildContentWithQuotes(stagedQuotes, trimmed);
+    const finalContent = appendPathReferences(contentWithQuotes, pathReferences);
+    if (beforeSend && !beforeSend(finalContent)) {
+      return;
+    }
 
     const attachmentsToSend: DisplayAttachment[] = chatAttachments
       .filter(
@@ -139,10 +159,8 @@ export function useComposerSubmit({
         // If undo fails, still send the message as a new one
       }
     }
-    const contentWithQuotes = buildContentWithQuotes(stagedQuotes, trimmed);
-    const finalContent = appendPathReferences(contentWithQuotes, pathReferences);
     await sendMessage(finalContent, attachmentsToSend);
-  }, [sendDisabled, activeConversationId, inputRef, scrollToLatest, isEditing, editingMessageId, assistantId, cancelEditing, canUndoEdit, sendMessage]);
+  }, [sendDisabled, beforeSend, activeConversationId, inputRef, scrollToLatest, isEditing, editingMessageId, assistantId, cancelEditing, canUndoEdit, sendMessage]);
 
   const handleFormSubmit = useCallback((e: FormEvent) => {
     e.preventDefault();

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.test.tsx
@@ -232,7 +232,7 @@ describe("useDraftSecretDetection detection", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Hook — pre-send gate state (nothing in the submit path calls this yet)
+// Hook — pre-send gate state (invoked by useComposerSubmit's beforeSend)
 // ---------------------------------------------------------------------------
 
 describe("useDraftSecretDetection checkBeforeSend", () => {
@@ -265,6 +265,61 @@ describe("useDraftSecretDetection checkBeforeSend", () => {
 
     act(() => {
       allowed = result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
+    });
+    expect(allowed).toBe(false);
+    expect(result.current.sendBlocked).toBe(true);
+  });
+
+  test("a draft edit invalidates an armed allowOnce bypass", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    // Never-elapsing debounce: only the synchronous subscription runs, so a
+    // block below proves the edit itself disarmed the bypass.
+    const { result } = renderDetection("conv-1", NEVER_ELAPSES_MS);
+    act(() => {
+      result.current.allowOnce();
+    });
+
+    setDraft(`edited to ${SYNTHETIC_GITHUB_TOKEN}`);
+    let allowed = true;
+    act(() => {
+      allowed = result.current.checkBeforeSend(
+        `edited to ${SYNTHETIC_GITHUB_TOKEN}`,
+      );
+    });
+    expect(allowed).toBe(false);
+    expect(result.current.sendBlocked).toBe(true);
+  });
+
+  test("dismissing a blocked notice clears sendBlocked but keeps dismissal", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    setDraft(`here is ${SYNTHETIC_PROJECT_KEY}`);
+    const { result } = renderDetection();
+    act(() => {
+      result.current.checkBeforeSend(`here is ${SYNTHETIC_PROJECT_KEY}`);
+    });
+    expect(result.current.sendBlocked).toBe(true);
+
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.sendBlocked).toBe(false);
+    expect(result.current.dismissed).toBe(true);
+  });
+
+  test("a blocked send after dismissal re-blocks (dismissal never bypasses)", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    setDraft(`here is ${SYNTHETIC_PROJECT_KEY}`);
+    const { result } = renderDetection();
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.dismissed).toBe(true);
+
+    let allowed = true;
+    act(() => {
+      allowed = result.current.checkBeforeSend(
+        `here is ${SYNTHETIC_PROJECT_KEY}`,
+      );
     });
     expect(allowed).toBe(false);
     expect(result.current.sendBlocked).toBe(true);

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
@@ -118,7 +118,11 @@ export interface DraftSecretDetectionResult {
    * detected and no {@link allowOnce} bypass is armed.
    */
   checkBeforeSend: (text: string) => boolean;
-  /** Arm a single-use bypass so the next {@link checkBeforeSend} passes. */
+  /**
+   * Arm a single-use bypass so the next {@link checkBeforeSend} passes.
+   * Invalidated by any subsequent draft edit, flag flip, or conversation
+   * switch — the bypass approves the content as it stood when armed.
+   */
   allowOnce: () => void;
 }
 
@@ -196,6 +200,11 @@ export function useDraftSecretDetection({
       if (state.input === prevState.input) {
         return;
       }
+      // Any draft edit invalidates an armed send bypass — "Send anyway"
+      // approved the content as it stood, not whatever it becomes. The
+      // normal bypass flow consumes the ref synchronously before the send
+      // clears the input, so this only disarms genuinely stale bypasses.
+      allowOnceRef.current = false;
       if (timer !== null) {
         clearTimeout(timer);
         timer = null;
@@ -223,6 +232,9 @@ export function useDraftSecretDetection({
 
   const dismiss = useCallback(() => {
     setDismissedValues(new Set(matches.map((m) => m.value)));
+    // Dismissing the blocked-send notice acknowledges the interception;
+    // the block state is per-attempt and re-arms on the next send.
+    setSendBlocked(false);
   }, [matches]);
 
   const allowOnce = useCallback(() => {


### PR DESCRIPTION
## Summary
- submitMessage gains an optional beforeSend gate, wired to the secret-detection hook's synchronous checkBeforeSend — pastes sent inside the debounce window are now caught (closes the Codex P2 from #38959)
- Blocked-send notice state with generic copy and an explicit single-use Send anyway bypass (server secret_blocked backstop unchanged)
- Draft/attachments/quotes fully preserved on interception

Part of plan: composer-secret-guard.md (PR 6 of 7)