### PR TITLE
fix(web): mobile Library "Edit" no longer re-opens app full-screen with a duplicate Edit button

### DIFF
--- a/clients/web/src/hooks/use-edit-app.test.tsx
+++ b/clients/web/src/hooks/use-edit-app.test.tsx
@@ -40,6 +40,7 @@ let selectionSnapshot: ReturnType<typeof useResolvedAssistantsStore.getState>;
 const openAppMock = mock((_appId: string) => undefined);
 const setLoadedAppMock = mock((_app: OpenedAppState) => undefined);
 const enterAppEditingMock = mock(() => undefined);
+const minimizeAppMock = mock(() => undefined);
 const setEditingConversationIdMock = mock((_id: string | null) => undefined);
 
 const APP: OpenedAppState = {
@@ -82,6 +83,7 @@ beforeEach(() => {
   openAppMock.mockReset();
   setLoadedAppMock.mockReset();
   enterAppEditingMock.mockReset();
+  minimizeAppMock.mockReset();
   setEditingConversationIdMock.mockReset();
   window.sessionStorage.clear();
 
@@ -95,6 +97,7 @@ beforeEach(() => {
     openApp: openAppMock,
     setLoadedApp: setLoadedAppMock,
     enterAppEditing: enterAppEditingMock,
+    minimizeApp: minimizeAppMock,
   });
   useConversationStore.setState({
     activeConversationId: null,
@@ -141,10 +144,12 @@ describe("useEditApp", () => {
     expect(setLoadedAppMock).toHaveBeenCalledWith(APP);
     expect(setEditingConversationIdMock).toHaveBeenCalledWith(CONV_ID);
     expect(enterAppEditingMock).toHaveBeenCalledTimes(1);
+    // Desktop uses the split view, not the mobile minimized strip.
+    expect(minimizeAppMock).not.toHaveBeenCalled();
     expect(currentPath()).toBe(routes.conversation(CONV_ID));
   });
 
-  test("on a mobile viewport, binds the edit conversation and navigates but stays full-screen (no split)", () => {
+  test("on a mobile viewport, binds the edit conversation, navigates, and minimizes the app to the chat strip (no split)", () => {
     // GIVEN a phone-sized viewport where the chat+app split doesn't fit
     mobileRef.current = true;
     const { result } = renderHook(() => useEditApp(), { wrapper });
@@ -155,7 +160,10 @@ describe("useEditApp", () => {
     // THEN the edit conversation is still bound and we navigate to it...
     expect(setEditingConversationIdMock).toHaveBeenCalledWith(CONV_ID);
     expect(currentPath()).toBe(routes.conversation(CONV_ID));
-    // ...but the viewer is not upgraded to the split edit view
+    // ...the app is minimized so the chat is the primary surface (the strip
+    // shows "Open app", not a duplicate "Edit" over a full-screen app)...
+    expect(minimizeAppMock).toHaveBeenCalledTimes(1);
+    // ...and the viewer is not upgraded to the split edit view
     expect(enterAppEditingMock).not.toHaveBeenCalled();
   });
 

--- a/clients/web/src/hooks/use-edit-app.ts
+++ b/clients/web/src/hooks/use-edit-app.ts
@@ -20,9 +20,13 @@ import { routes } from "@/utils/routes";
  * viewer if it isn't already there, and navigates to that conversation so
  * `ChatMainPanel` renders the `app-editing` split.
  *
- * On a mobile viewport the split layout doesn't fit, so the viewer stays
- * full-screen (`app`) while still binding the edit conversation — matching
- * `useOpenAppFromChat`.
+ * On a mobile viewport the split layout doesn't fit, so instead the app is
+ * minimized to its bottom strip and the edit conversation becomes the primary
+ * surface — the user edits by chatting, and the strip reads "Open app". Leaving
+ * the app full-screen would re-present the same "Edit" button over a full-screen
+ * app, which reads as a no-op (LUM-2809). This is the deliberate difference from
+ * `useOpenAppFromChat`, which keeps the app full-screen because it is a
+ * view (not edit) action.
  *
  * Shared by the in-chat app viewer (`ChatMainPanel`) and the standalone
  * Library app view (`LibraryDetailPage`).
@@ -47,7 +51,15 @@ export function useEditApp(): (app: OpenedAppState) => void {
         viewer.setLoadedApp(app);
       }
       useConversationStore.getState().setEditingConversationId(convId);
-      if (!isMobile) viewer.enterAppEditing();
+      if (isMobile) {
+        // No room for the chat+app split: land in the edit conversation with
+        // the app minimized to its bottom strip so the chat is the primary
+        // surface and the strip's affordance reads "Open app" — rather than a
+        // second "Edit" button stacked over a re-opened full-screen app.
+        viewer.minimizeApp();
+      } else {
+        viewer.enterAppEditing();
+      }
 
       // The split edit view only renders on the conversation route. Navigate
       // whenever we aren't already there — comparing the path rather than the

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -352,6 +352,7 @@ export interface ViewerActions {
   handleAppLoadFailed: () => void;
   closeApp: () => void;
   toggleAppMinimized: () => void;
+  minimizeApp: () => void;
   handleAppUnpinned: (appId: string) => boolean;
   enterAppEditing: () => void;
   exitAppEditing: () => void;
@@ -560,6 +561,10 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
 
   toggleAppMinimized: () => {
     set({ isAppMinimized: !get().isAppMinimized });
+  },
+
+  minimizeApp: () => {
+    set({ isAppMinimized: true });
   },
 
   handleAppUnpinned: (appId) => {


### PR DESCRIPTION
## Prompt / plan

Fixes [LUM-2809](https://linear.app/vellum/issue/LUM-2809) — "Mobile: Edit button on library app opens full screen with duplicate Edit button".

Reproduction (iPhone, Chrome):
1. Open an app from the Library.
2. Tap the **Edit** button.
3. The app re-opens full-screen and shows another **Edit** button.

**Root cause:** On mobile, tapping Edit in the Library app viewer (`LibraryDetailPage` → `useEditApp`) left the viewer in full-screen `app` mode (`isAppMinimized: false`) and navigated to the per-app edit conversation, because the desktop chat+app split doesn't fit on a phone. The `MobileAppOverlay` then re-rendered the same app full-screen with the pencil **Edit** button (`isEditing` follows `isAppMinimized`, which was `false`). So tapping "Edit" read as a confusing no-op: the app just re-appeared full-screen with another Edit button.

**Fix:** On mobile, `useEditApp` now **minimizes** the app to its bottom strip so the edit conversation becomes the primary surface — the user edits by chatting, and the overlay's affordance reads **"Open app"** (chevron-up) instead of a duplicate "Edit". This mirrors the desktop "enter editing" intent (chat + app side by side) in a mobile-appropriate way, and is the deliberate counterpart to `useOpenAppFromChat`, which stays full-screen because it is a *view* (not edit) action.

Changes:
- `stores/viewer-store.ts` — add a `minimizeApp()` action (explicit set-minimized transition, alongside the existing `toggleAppMinimized`).
- `hooks/use-edit-app.ts` — on mobile, call `viewer.minimizeApp()` instead of leaving the app full-screen; desktop still enters the `app-editing` split. Docstring updated.

## Test plan

- Updated `hooks/use-edit-app.test.tsx`:
  - Mobile: asserts the app is minimized (`minimizeApp` called once), the edit conversation is bound, navigation happens, and the split view is **not** entered.
  - Desktop: unchanged behavior (enters split view) plus an assertion that `minimizeApp` is **not** called.
- `cd clients/web && bun test src/hooks/use-edit-app.test.tsx src/stores/viewer-store.test.ts src/domains/chat/components/mobile-app-overlay.test.tsx` → 93 pass, 0 fail.
- `cd clients/web && bunx tsc --noEmit` → clean.
- `cd clients/web && bunx eslint` on the touched files → 0 errors (only pre-existing `curly` warnings on untouched lines).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTbZ5pCqRHqBPqJzsRxYWw)_