### PR TITLE
fix(gateway): validate Slack reaction payloads with tolerant Zod

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -275,7 +275,6 @@
       "name": "@vellumai/vellum-gateway",
       "version": "0.10.11",
       "dependencies": {
-        "@slack/types": "2.21.1",
         "@vellumai/assistant-client": "workspace:*",
         "@vellumai/ces-client": "workspace:*",
         "@vellumai/gateway-client": "workspace:*",
@@ -295,6 +294,7 @@
       },
       "devDependencies": {
         "@grammyjs/types": "4.0.0",
+        "@slack/types": "2.21.1",
         "@types/bun": "1.3.9",
         "eslint": "10.0.0",
         "fast-check": "4.7.0",

--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -2,7 +2,6 @@
   "entry": ["src/**/*.test.ts", "src/**/__tests__/**/*.ts"],
   "project": ["src/**/*.ts"],
   "ignoreDependencies": [
-    "@slack/types",
     "@vellumai/assistant-client",
     "@vellumai/ces-client",
     "@vellumai/gateway-client",

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -25,7 +25,6 @@
     "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && ([ -f meta/sync-bundled-copies.ts ] && bun run meta/sync-bundled-copies.ts 2>/dev/null || true)"
   },
   "dependencies": {
-    "@slack/types": "2.21.1",
     "@vellumai/assistant-client": "workspace:*",
     "@vellumai/ces-client": "workspace:*",
     "@vellumai/gateway-client": "workspace:*",
@@ -54,6 +53,7 @@
   ],
   "devDependencies": {
     "@grammyjs/types": "4.0.0",
+    "@slack/types": "2.21.1",
     "@types/bun": "1.3.9",
     "eslint": "10.0.0",
     "fast-check": "4.7.0",

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -594,6 +594,38 @@ describe("reaction event tolerant validation", () => {
     expect(result).toBeNull();
   });
 
+  it("drops a missing reaction rather than emitting reaction:undefined", () => {
+    // `reaction` forms the callbackData and part of the dedup externalMessageId.
+    // A missing reaction must be dropped, not stringified into a bogus
+    // `reaction:undefined` that the assistant parser treats as a real emoji.
+    const result = normalizeSlackReactionAdded(
+      {
+        type: "reaction_added",
+        user: "U123",
+        item: { type: "message", channel: "C456", ts: "1700000000.000100" },
+      },
+      "evt-x5a",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("collapses a non-string reaction to undefined and drops the event", () => {
+    const result = normalizeSlackReactionAdded(
+      {
+        type: "reaction_added",
+        user: "U123",
+        reaction: { name: "thumbsup" },
+        item: { type: "message", channel: "C456", ts: "1700000000.000100" },
+      },
+      "evt-x5b",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
+
   it("collapses a malformed item field but keeps the rest of the event routable", () => {
     // A single bad field (non-string `ts`) collapses to undefined without
     // taking down the sibling fields; the event is dropped only because the

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -11,8 +11,6 @@ import {
   enrichNormalizedActor,
   slackBotContactNote,
   type SlackBlockActionsPayload,
-  type SlackReactionAddedEvent,
-  type SlackReactionRemovedEvent,
   type SlackDirectMessageEvent,
   type SlackChannelMessageEvent,
   type SlackAppMentionEvent,
@@ -69,7 +67,7 @@ function makeReactionAddedEvent(
     channelId: string;
     messageTs: string;
   }>,
-): SlackReactionAddedEvent {
+) {
   return {
     type: "reaction_added",
     user: overrides?.user ?? "U123",
@@ -89,7 +87,7 @@ function makeReactionRemovedEvent(
     channelId: string;
     messageTs: string;
   }>,
-): SlackReactionRemovedEvent {
+) {
   return {
     type: "reaction_removed",
     user: overrides?.user ?? "U123",
@@ -547,6 +545,91 @@ describe("normalizeSlackReactionRemoved", () => {
     expect(addResult!.event.message.externalMessageId).not.toBe(
       removeResult!.event.message.externalMessageId,
     );
+  });
+});
+
+describe("reaction event tolerant validation", () => {
+  const config = makeConfig();
+
+  it("drops a non-object payload instead of throwing", () => {
+    // The socket frame is unvalidated JSON.parse output; a scalar where an
+    // object is expected must be dropped at the boundary, not crash the batch.
+    expect(
+      normalizeSlackReactionAdded("not-an-object", "evt-x1", config),
+    ).toBeNull();
+    expect(normalizeSlackReactionAdded(null, "evt-x2", config)).toBeNull();
+    expect(normalizeSlackReactionAdded(42, "evt-x3", config)).toBeNull();
+  });
+
+  it("collapses a non-object item to undefined and drops the event", () => {
+    // A malformed `item` (here a string) is caught to undefined by the schema
+    // rather than rejecting the whole payload; the downstream null-check on
+    // `item.channel` then drops the unroutable event.
+    const result = normalizeSlackReactionAdded(
+      {
+        type: "reaction_added",
+        user: "U123",
+        reaction: "thumbsup",
+        item: "bogus",
+      },
+      "evt-x4",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("collapses a non-string user to undefined and drops the event", () => {
+    const result = normalizeSlackReactionAdded(
+      {
+        type: "reaction_added",
+        user: { id: "U123" },
+        reaction: "thumbsup",
+        item: { type: "message", channel: "C456", ts: "1700000000.000100" },
+      },
+      "evt-x5",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("collapses a malformed item field but keeps the rest of the event routable", () => {
+    // A single bad field (non-string `ts`) collapses to undefined without
+    // taking down the sibling fields; the event is dropped only because the
+    // now-missing `ts` fails the identity null-check.
+    const result = normalizeSlackReactionAdded(
+      {
+        type: "reaction_added",
+        user: "U123",
+        reaction: "thumbsup",
+        item: { type: "message", channel: "C456", ts: { nested: true } },
+      },
+      "evt-x6",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("preserves unknown extra keys verbatim in raw", () => {
+    // `raw` carries the original untrusted payload, not the schema-stripped
+    // working copy, so downstream consumers and debugging see it as-sent.
+    const payload = {
+      type: "reaction_added",
+      user: "U123",
+      reaction: "thumbsup",
+      item: { type: "message", channel: "C456", ts: "1700000000.000100" },
+      unexpected_field: "surprise",
+      nested_extra: { a: 1 },
+    };
+    const result = normalizeSlackReactionAdded(payload, "evt-x7", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.raw).toEqual(payload);
+    expect(
+      (result!.event.raw as Record<string, unknown>).unexpected_field,
+    ).toBe("surprise");
   });
 });
 

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -1,4 +1,8 @@
 import { renderSlackTextForModel } from "@vellumai/slack-text";
+import type {
+  ReactionAddedEvent as SlackApiReactionAddedEvent,
+  ReactionRemovedEvent as SlackApiReactionRemovedEvent,
+} from "@slack/types";
 import { createHash } from "node:crypto";
 import { z } from "zod";
 import { isSlackDmChannel } from "./channel.js";
@@ -911,6 +915,42 @@ type SlackReactionEvent = z.infer<typeof slackReactionEventSchema>;
 export type SlackReactionAddedEvent = SlackReactionEvent;
 export type SlackReactionRemovedEvent = SlackReactionEvent;
 
+// Compile-time cross-check against the official Slack event types.
+//
+// `@slack/types` is a types-only dependency: the `import type` above is erased
+// from the build, so `slackReactionEventSchema` stays the sole runtime
+// validator. Its job is to make `tsc` prove our tolerant schema never
+// contradicts Slack's published shape, so a field rename or wrong primitive
+// fails the build instead of silently parsing a live event to `undefined`:
+//   1. every key we model is a real key on the official event; and
+//   2. a real official event still satisfies our (looser) schema.
+// One-directional on purpose — our schema is a narrower, all-optional view of
+// only the fields the normalizer reads, so the reverse is not required.
+type Expect<T extends true> = T;
+/** Every key we model is a real key on the official type. */
+type ModeledKeysAreOfficial<Ours, Official> = keyof Ours extends keyof Official
+  ? true
+  : false;
+/** A real official value is accepted by our tolerant schema. */
+type OfficialValueSatisfiesOurs<Ours, Official> = Official extends Ours
+  ? true
+  : false;
+
+type _SlackReactionApiCrossChecks = [
+  Expect<
+    ModeledKeysAreOfficial<SlackReactionEvent, SlackApiReactionAddedEvent>
+  >,
+  Expect<
+    OfficialValueSatisfiesOurs<SlackReactionEvent, SlackApiReactionAddedEvent>
+  >,
+  Expect<
+    ModeledKeysAreOfficial<SlackReactionEvent, SlackApiReactionRemovedEvent>
+  >,
+  Expect<
+    OfficialValueSatisfiesOurs<SlackReactionEvent, SlackApiReactionRemovedEvent>
+  >,
+];
+
 /**
  * Normalize a Slack `block_actions` interactive payload into the gateway's
  * canonical inbound event shape, matching Telegram's `callback_query` pattern.
@@ -1006,7 +1046,19 @@ function normalizeSlackReaction(
   config: GatewayConfig,
   op: "added" | "removed",
 ): NormalizedSlackEvent | null {
-  if (!event.user || !event.item?.channel || !event.item?.ts) return null;
+  // `reaction` is load-bearing: it forms the `callbackData` and part of the
+  // dedup `externalMessageId`. Without this guard a collapsed (missing /
+  // non-string) reaction would emit `reaction:undefined`, which the
+  // assistant-side parser treats as a real emoji named "undefined" rather
+  // than dropping it.
+  if (
+    !event.user ||
+    !event.reaction ||
+    !event.item?.channel ||
+    !event.item?.ts
+  ) {
+    return null;
+  }
 
   const channel = event.item.channel;
 

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -11,6 +11,11 @@ import { fetchImpl } from "../fetch.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 import type { RouteResult } from "../routing/types.js";
 import type { GatewayInboundEvent } from "../types.js";
+import type {
+  Expect,
+  ModeledKeysAreOfficial,
+  OfficialValueSatisfiesOurs,
+} from "../webhook-crosscheck.js";
 
 // Slack event payloads are untrusted external input (Socket Mode / Events API).
 // Fields are validated with tolerant Zod schemas: a malformed value collapses to
@@ -915,27 +920,13 @@ type SlackReactionEvent = z.infer<typeof slackReactionEventSchema>;
 export type SlackReactionAddedEvent = SlackReactionEvent;
 export type SlackReactionRemovedEvent = SlackReactionEvent;
 
-// Compile-time cross-check against the official Slack event types.
-//
-// `@slack/types` is a types-only dependency: the `import type` above is erased
-// from the build, so `slackReactionEventSchema` stays the sole runtime
-// validator. Its job is to make `tsc` prove our tolerant schema never
-// contradicts Slack's published shape, so a field rename or wrong primitive
-// fails the build instead of silently parsing a live event to `undefined`:
-//   1. every key we model is a real key on the official event; and
-//   2. a real official event still satisfies our (looser) schema.
-// One-directional on purpose — our schema is a narrower, all-optional view of
-// only the fields the normalizer reads, so the reverse is not required.
-type Expect<T extends true> = T;
-/** Every key we model is a real key on the official type. */
-type ModeledKeysAreOfficial<Ours, Official> = keyof Ours extends keyof Official
-  ? true
-  : false;
-/** A real official value is accepted by our tolerant schema. */
-type OfficialValueSatisfiesOurs<Ours, Official> = Official extends Ours
-  ? true
-  : false;
-
+// Compile-time cross-check against the official Slack event types, via the
+// shared `webhook-crosscheck` helpers. `@slack/types` is a types-only
+// dependency: the `import type` above is erased from the build, so
+// `slackReactionEventSchema` stays the sole runtime validator. `tsc` proves our
+// tolerant schema never contradicts Slack's published shape, so a field rename
+// or wrong primitive fails the build instead of silently parsing a live event
+// to `undefined`.
 type _SlackReactionApiCrossChecks = [
   Expect<
     ModeledKeysAreOfficial<SlackReactionEvent, SlackApiReactionAddedEvent>

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -1,11 +1,18 @@
 import { renderSlackTextForModel } from "@vellumai/slack-text";
 import { createHash } from "node:crypto";
+import { z } from "zod";
 import { isSlackDmChannel } from "./channel.js";
 import type { GatewayConfig } from "../config.js";
 import { fetchImpl } from "../fetch.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 import type { RouteResult } from "../routing/types.js";
 import type { GatewayInboundEvent } from "../types.js";
+
+// Slack event payloads are untrusted external input (Socket Mode / Events API).
+// Fields are validated with tolerant Zod schemas: a malformed value collapses to
+// `undefined` so the existing null-checks drop an unprocessable event rather than
+// trusting garbage. The original payload is preserved verbatim as `raw`.
+const optionalString = () => z.string().optional().catch(undefined);
 
 /**
  * Resolved Slack user info for populating actor fields.
@@ -879,37 +886,30 @@ export interface SlackBlockActionsPayload {
 }
 
 /**
- * Slack `reaction_added` event shape.
+ * Slack `reaction_added` / `reaction_removed` event. Both carry an identical
+ * payload, differentiated only by the `type` discriminator (the caller passes
+ * the add-vs-remove distinction as an explicit `op`).
  */
-export interface SlackReactionAddedEvent {
-  type: "reaction_added";
-  user: string;
-  reaction: string;
-  item: {
-    type: string;
-    channel: string;
-    ts: string;
-  };
-  item_user?: string;
-  event_ts?: string;
-}
+const slackReactionEventSchema = z.object({
+  type: optionalString(),
+  user: optionalString(),
+  reaction: optionalString(),
+  item: z
+    .object({
+      type: optionalString(),
+      channel: optionalString(),
+      ts: optionalString(),
+    })
+    .optional()
+    .catch(undefined),
+  item_user: optionalString(),
+  event_ts: optionalString(),
+});
+type SlackReactionEvent = z.infer<typeof slackReactionEventSchema>;
 
-/**
- * Slack `reaction_removed` event shape — same payload as `reaction_added`,
- * differentiated only by the `type` discriminator.
- */
-export interface SlackReactionRemovedEvent {
-  type: "reaction_removed";
-  user: string;
-  reaction: string;
-  item: {
-    type: string;
-    channel: string;
-    ts: string;
-  };
-  item_user?: string;
-  event_ts?: string;
-}
+/** Kept for `socket-mode.ts`'s narrowing casts; both are one payload shape. */
+export type SlackReactionAddedEvent = SlackReactionEvent;
+export type SlackReactionRemovedEvent = SlackReactionEvent;
 
 /**
  * Normalize a Slack `block_actions` interactive payload into the gateway's
@@ -1000,7 +1000,8 @@ export function normalizeSlackBlockActions(
  * downstream callback prefix and externalMessageId suffix.
  */
 function normalizeSlackReaction(
-  event: SlackReactionAddedEvent | SlackReactionRemovedEvent,
+  event: SlackReactionEvent,
+  rawEvent: Record<string, unknown>,
   eventId: string,
   config: GatewayConfig,
   op: "added" | "removed",
@@ -1055,7 +1056,7 @@ function normalizeSlackReaction(
         messageId: event.item.ts,
         threadId: event.item.ts,
       },
-      raw: event as unknown as Record<string, unknown>,
+      raw: rawEvent,
     },
     routing,
     threadTs: event.item.ts,
@@ -1072,11 +1073,19 @@ function normalizeSlackReaction(
  * Returns null if the event is missing required fields or cannot be routed.
  */
 export function normalizeSlackReactionAdded(
-  event: SlackReactionAddedEvent,
+  event: unknown,
   eventId: string,
   config: GatewayConfig,
 ): NormalizedSlackEvent | null {
-  return normalizeSlackReaction(event, eventId, config, "added");
+  const parsed = slackReactionEventSchema.safeParse(event);
+  if (!parsed.success) return null;
+  return normalizeSlackReaction(
+    parsed.data,
+    event as Record<string, unknown>,
+    eventId,
+    config,
+    "added",
+  );
 }
 
 /**
@@ -1088,11 +1097,19 @@ export function normalizeSlackReactionAdded(
  * Returns null if the event is missing required fields or cannot be routed.
  */
 export function normalizeSlackReactionRemoved(
-  event: SlackReactionRemovedEvent,
+  event: unknown,
   eventId: string,
   config: GatewayConfig,
 ): NormalizedSlackEvent | null {
-  return normalizeSlackReaction(event, eventId, config, "removed");
+  const parsed = slackReactionEventSchema.safeParse(event);
+  if (!parsed.success) return null;
+  return normalizeSlackReaction(
+    parsed.data,
+    event as Record<string, unknown>,
+    eventId,
+    config,
+    "removed",
+  );
 }
 
 /**

--- a/gateway/src/telegram/normalize.ts
+++ b/gateway/src/telegram/normalize.ts
@@ -13,6 +13,11 @@ import type {
 } from "@grammyjs/types";
 
 import type { GatewayInboundEvent } from "../types.js";
+import type {
+  Expect,
+  ModeledKeysAreOfficial,
+  OfficialValueSatisfiesOurs,
+} from "../webhook-crosscheck.js";
 
 // Telegram webhook payloads are untrusted external input (Telegram Bot API).
 // These schemas validate the *types* of the nested fields the normalizer reads
@@ -314,28 +319,11 @@ export function normalizeTelegramUpdate(
 // `@grammyjs/types` is a types-only dev dependency: it contributes nothing at
 // runtime (the `import type` above is erased from the build) and the schemas
 // above stay the sole runtime validators. Its only job is to make TypeScript
-// prove two things about those schemas, so a drift from the real Bot API shape
-// fails `tsc` instead of silently mis-parsing a live webhook:
-//   1. every field name we model is a real field on the official type — a typo
-//      like `messsage_thread_id`, which would otherwise always parse to
-//      `undefined`, fails the build; and
-//   2. a real official value satisfies our (tolerant) schema — modeling a field
-//      with the wrong primitive (e.g. `chat.id` as a string) fails the build.
-//
-// The check is one-directional on purpose: our schemas are intentionally a
-// *narrower and looser* view (only the fields the normalizer reads, each
-// optional and `.catch()`-guarded), so we do NOT require our type to satisfy
-// the official one — only that we never contradict it.
-type Expect<T extends true> = T;
-/** Every key we model is a real key on the official type. */
-type ModeledKeysAreOfficial<Ours, Official> = keyof Ours extends keyof Official
-  ? true
-  : false;
-/** A real official value is accepted by our tolerant schema. */
-type OfficialValueSatisfiesOurs<Ours, Official> = Official extends Ours
-  ? true
-  : false;
-
+// prove, via the shared `webhook-crosscheck` helpers, that a drift from the
+// real Bot API shape fails `tsc` instead of silently mis-parsing a live
+// webhook — e.g. a field-name typo like `messsage_thread_id` (which would
+// otherwise always parse to `undefined`) or a wrong primitive (`chat.id` as a
+// string).
 type TelegramFrom = NonNullable<z.infer<typeof TelegramFromSchema>>;
 type TelegramChat = NonNullable<TelegramMessage["chat"]>;
 

--- a/gateway/src/webhook-crosscheck.ts
+++ b/gateway/src/webhook-crosscheck.ts
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------------
+// Compile-time cross-check helpers for provider webhook schemas.
+//
+// Provider normalizers validate untrusted payloads at runtime with tolerant
+// Zod schemas, which stay the sole runtime validators. These type-only helpers
+// layer a compile-time check over such a schema against the provider's official
+// published types (e.g. `@grammyjs/types`, `@slack/types`) so a drift from the
+// real API shape fails `tsc` instead of silently mis-parsing a live event. The
+// official-types import at each call site is `import type` only and is erased
+// from the build.
+//
+// The check is one-directional on purpose: our schemas are intentionally a
+// *narrower and looser* view (only the fields the normalizer reads, each
+// optional and `.catch()`-guarded), so we do NOT require our type to satisfy
+// the official one — only that we never contradict it.
+//
+// Usage — collect the assertions in a throwaway tuple type so `tsc` evaluates
+// them; a violated assertion resolves to `false` and fails `Expect`:
+//
+//   type _Checks = [
+//     Expect<ModeledKeysAreOfficial<z.infer<typeof mySchema>, OfficialEvent>>,
+//     Expect<OfficialValueSatisfiesOurs<z.infer<typeof mySchema>, OfficialEvent>>,
+//   ];
+
+/** Asserts its argument type is exactly `true`; a `false` fails the build. */
+export type Expect<T extends true> = T;
+
+/**
+ * Every key we model is a real key on the official type — a typo like
+ * `messsage_thread_id`, which would otherwise always parse to `undefined`,
+ * fails the build.
+ */
+export type ModeledKeysAreOfficial<Ours, Official> =
+  keyof Ours extends keyof Official ? true : false;
+
+/**
+ * A real official value is accepted by our tolerant schema — modeling a field
+ * with the wrong primitive (e.g. an id as a string) fails the build.
+ */
+export type OfficialValueSatisfiesOurs<Ours, Official> = Official extends Ours
+  ? true
+  : false;


### PR DESCRIPTION
## Prompt / plan

Part of the ongoing initiative to harden the gateway's untrusted webhook/socket ingress by replacing blanket `as` / `as unknown as` casts on external provider payloads with tolerant Zod schemas, one provider — and, for Slack's Socket Mode, one event leaf — at a time. This is the **reactions leaf**, following the convention documented in `gateway/CLAUDE.md` → "Provider Webhook Payload Validation" and the merged reference implementations (Telegram, WhatsApp, Resend) plus the merged Slack pre-normalization crash fixes (event-ordering #38963, event-team #38969).

### Why

`reaction_added` / `reaction_removed` events arrive over Slack Socket Mode as **unvalidated `JSON.parse` output**, but `normalizeSlackReaction` trusted a blanket cast to the hand-written `SlackReactionAddedEvent` / `SlackReactionRemovedEvent` interfaces. A non-object payload, or a non-string identity field, would flow straight into the normalizer and throw — e.g. reading `.user` off a scalar — taking down that event's processing rather than being dropped cleanly.

### What changed

**Runtime validation (the leaf):**
- Replaced the two near-identical interfaces with a single tolerant `slackReactionEventSchema`; the type is derived via `z.infer` (single source of truth), co-located in `normalize.ts` per the convention (input schemas have one consumer and are **not** hoisted to `packages/gateway-client`).
- Every field is `.optional().catch(undefined)` (the `item` sub-object too), so a malformed value collapses instead of rejecting the whole payload; the identity null-check (`user` / `reaction` / `item.channel` / `item.ts`) then drops the unroutable event. `reaction` is in that guard because it forms both the `callbackData` and part of the dedup `externalMessageId` — without it, a collapsed reaction emitted `reaction:undefined`, which the assistant-side parser treats as a real emoji named "undefined" (Codex P2).
- The wrappers take `unknown` and `safeParse` at the boundary, dropping non-object input rather than crashing — so one bad message can't take down a batch.
- `raw` now carries the **original payload verbatim** rather than the schema-shaped working copy.

**Official-types cross-check:**
- Layered a compile-time cross-check over the tolerant schema using the official `@slack/types` `ReactionAddedEvent` / `ReactionRemovedEvent`, matching the Telegram reference: `tsc` proves every field we model is a real key on Slack's published event and that a real official event still satisfies our looser schema, so a field rename or wrong primitive fails the build. The tolerant Zod schema remains the **sole runtime validator** (the types-only import is erased from the build; casting a socket frame to an official type would just re-introduce the unchecked `as`).
- Moved `@slack/types` from `dependencies` → `devDependencies` (it is type-only, matching `@grammyjs/types`, and was declared-but-unused before this PR) and dropped its now-stale `knip.json` ignore entry.

**Shared helper module:**
- Extracted the cross-check type helpers (`Expect` / `ModeledKeysAreOfficial` / `OfficialValueSatisfiesOurs`), previously duplicated in `telegram/normalize.ts`, into `gateway/src/webhook-crosscheck.ts` and wired both providers to it, so the pattern has one canonical home.

### Why it's safe

- Tolerant-by-design: the schema never makes previously-valid input newly-invalid. Well-formed reactions normalize exactly as before; only malformed input, which previously threw or trusted garbage, now drops cleanly.
- The official-types layer and the shared helpers are type-only — erased from the build, zero runtime effect.
- Purely at the ingress boundary — no change to routing, dedup keys, or the normalized output shape.

## Test plan

- `bun test src/slack/normalize.test.ts` — adds tolerant-validation tests: non-object payload dropped, collapsed non-object `item`, collapsed non-string `user`, missing `reaction`, non-string `reaction`, malformed `item` field, and unknown extra keys preserved verbatim in `raw`.
- `bun test src/slack/ src/telegram/` — 125 pass across the touched suites (sibling Slack + Telegram suites unaffected by the shared-helper extraction).
- **Negative controls:** (1) reverting the reaction `safeParse`/guard turns the malformed tests red, including the original `TypeError: null is not an object (evaluating 'event.user')`; (2) introducing a modeled-field typo makes the relocated cross-check fail `tsc` (`Type 'false' does not satisfy the constraint 'true'`), confirming the drift guard still bites from the shared module.
- `bunx tsc --noEmit`, `eslint`, `prettier --check`, `knip` (deps/unlisted), and the generic-examples check — all clean.

### Follow-up (not in this PR)

`gateway/src/__tests__/slack-reaction-normalize.test.ts` is an older, largely-redundant copy of the co-located reaction tests. Consolidating the two belongs in its own DRY-cleanup change rather than widening this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f