### PR TITLE
fix(slack): control-plane routes act as the bot, not the installer's user token

### DIFF
--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -12,9 +12,9 @@ import {
 //
 // This file covers the share HANDLER's contract: token-not-configured, input
 // validation, app lookup, and the success response shape. Which Slack identity
-// the post authenticates as (user-first, bot fallback) is proven end-to-end at
-// the wire level in the routes' token-routing.test.ts, so it is deliberately
-// not re-asserted here.
+// the post authenticates as (always the bot) is proven end-to-end at the wire
+// level in the routes' token-routing.test.ts, so it is deliberately not
+// re-asserted here.
 
 const secureKeyValues = new Map<string, string>();
 mock.module("../security/secure-keys.js", () => ({

--- a/assistant/src/messaging/providers/slack/__tests__/auth.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/auth.test.ts
@@ -27,13 +27,7 @@ mock.module("../../../../oauth/connection-resolver.js", () => ({
   },
 }));
 
-// Import the real SlackApiError so runAsUserWithBotFallback's `instanceof`
-// check and the test share the same class. Do NOT mock the whole client module
-// here — a mock.module("../client.js") leaks across test files and strips the
-// real listConversations/postMessage the adapter tests rely on.
-const { resolveSlackAuth, runAsUserWithBotFallback } =
-  await import("../auth.js");
-const { SlackApiError } = await import("../client.js");
+const { resolveSlackAuth } = await import("../auth.js");
 
 const BOT_KEY = "credential/slack_channel/bot_token";
 const USER_KEY = "credential/slack_channel/user_token";
@@ -76,84 +70,5 @@ describe("resolveSlackAuth", () => {
     expect(await resolveSlackAuth("user")).toBeUndefined();
     // Guarded by the connection-row check — never reaches resolveOAuthConnection.
     expect(resolveOAuthCalls).toEqual([]);
-  });
-});
-
-describe("runAsUserWithBotFallback", () => {
-  test("runs as the user (user token) when the call succeeds", async () => {
-    secureKeys.set(BOT_KEY, "xoxb-bot");
-    secureKeys.set(USER_KEY, "xoxp-user");
-    const seen: unknown[] = [];
-    const result = await runAsUserWithBotFallback("xoxb-bot", async (auth) => {
-      seen.push(auth);
-      return "ok";
-    });
-    expect(result).toBe("ok");
-    expect(seen).toEqual(["xoxp-user"]);
-  });
-
-  test("retries with the bot token when the user token is rejected (401)", async () => {
-    secureKeys.set(BOT_KEY, "xoxb-bot");
-    secureKeys.set(USER_KEY, "xoxp-user");
-    const seen: unknown[] = [];
-    const result = await runAsUserWithBotFallback("xoxb-bot", async (auth) => {
-      seen.push(auth);
-      if (auth === "xoxp-user") {
-        throw new SlackApiError(401, "invalid_auth", "bad token");
-      }
-      return "recovered";
-    });
-    expect(result).toBe("recovered");
-    expect(seen).toEqual(["xoxp-user", "xoxb-bot"]);
-  });
-
-  test("does not retry when the user auth is already the bot token", async () => {
-    secureKeys.set(BOT_KEY, "xoxb-bot"); // no user token → user === bot
-    let calls = 0;
-    await expect(
-      runAsUserWithBotFallback("xoxb-bot", async () => {
-        calls += 1;
-        throw new SlackApiError(401, "invalid_auth", "bad token");
-      }),
-    ).rejects.toThrow();
-    expect(calls).toBe(1);
-  });
-
-  test("does not retry non-401 errors by default", async () => {
-    secureKeys.set(BOT_KEY, "xoxb-bot");
-    secureKeys.set(USER_KEY, "xoxp-user");
-    let calls = 0;
-    await expect(
-      runAsUserWithBotFallback("xoxb-bot", async () => {
-        calls += 1;
-        throw new SlackApiError(500, "internal_error", "boom");
-      }),
-    ).rejects.toThrow();
-    expect(calls).toBe(1);
-  });
-
-  test("a custom shouldFallback widens the retry to non-401 errors (missing_scope)", async () => {
-    secureKeys.set(BOT_KEY, "xoxb-bot");
-    secureKeys.set(USER_KEY, "xoxp-user");
-    const seen: unknown[] = [];
-    // missing_scope maps to status 400, so the default predicate would NOT
-    // retry — this is the share-post path, where the user token can lack
-    // chat:write and the bot token can still post.
-    const result = await runAsUserWithBotFallback(
-      "xoxb-bot",
-      async (auth) => {
-        seen.push(auth);
-        if (auth === "xoxp-user") {
-          throw new SlackApiError(400, "missing_scope", "no chat:write");
-        }
-        return "posted-as-bot";
-      },
-      {
-        shouldFallback: (err) =>
-          err.status === 401 || err.slackError === "missing_scope",
-      },
-    );
-    expect(result).toBe("posted-as-bot");
-    expect(seen).toEqual(["xoxp-user", "xoxb-bot"]);
   });
 });

--- a/assistant/src/messaging/providers/slack/auth.ts
+++ b/assistant/src/messaging/providers/slack/auth.ts
@@ -10,18 +10,25 @@
  *
  * Which token a call uses is a question of WHO should act, not read-vs-write:
  *
- *   - "bot"  — act as the app. Used for the presence list ("which rooms is the
- *     bot in", whose `is_member` view is relative to the token's own
- *     identity), the workspace roster, and content the assistant posts as
- *     itself. Never the user token — that would answer "which rooms is the
- *     USER in", or post as the user.
+ *   - "bot"  — act as the app. Used by everything reachable from the
+ *     settings/control-plane surface: the presence list ("which rooms is the
+ *     bot in", whose `is_member` view is relative to the token's own identity),
+ *     the workspace roster, the share picker, and the share post. Those routes
+ *     are exposed at the gateway with generic edge auth and the daemon never
+ *     sees the calling actor's identity (the proxy swaps the caller's
+ *     Authorization for a service token), so they MUST act as the neutral app
+ *     identity — acting as the single stored installer `user_token` would let
+ *     any caller read the installer's channels or post as them. Also used for
+ *     content the assistant posts as itself.
  *
- *   - "user" — act as the human. Prefers the user token for its wider reach
- *     (channels the user is in but the bot isn't; `search.messages`, which
- *     only a user token can call) and for human-initiated actions (sharing).
- *     Falls back to the bot token when no user token is stored — the user
- *     token is optional, so "user" intent must always resolve to *something*
- *     when Slack is connected.
+ *   - "user" — act as the assistant's owner, using the optional user token for
+ *     its wider reach (channels the owner is in but the bot isn't; and
+ *     `search.messages`, which only a user token can call). Scoped to the
+ *     in-conversation messaging adapter, where the assistant is acting for its
+ *     own owner within a trust-classified conversation — NOT the edge-reachable
+ *     control-plane routes above. Falls back to the bot token when no user
+ *     token is stored, so "user" always resolves to *something* when Slack is
+ *     connected.
  *
  * For Socket Mode installs the resolved value is a raw token string; for legacy
  * OAuth installs it is a refreshing `OAuthConnection` (whose access_token is
@@ -35,7 +42,6 @@ import { resolveOAuthConnection } from "../../../oauth/connection-resolver.js";
 import { getConnectionByProvider } from "../../../oauth/oauth-store.js";
 import { credentialKey } from "../../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../../security/secure-keys.js";
-import { SlackApiError } from "./client.js";
 
 export type SlackAuth = OAuthConnection | string;
 
@@ -69,46 +75,4 @@ export async function resolveSlackAuth(
     return undefined;
   }
   return resolveOAuthConnection("slack", { account: opts.account });
-}
-
-/**
- * Run a Slack call as the user — using the user token when one is stored —
- * and fall back to the bot token when the user token can't do the job.
- *
- * Callers resolve the bot auth first (it is always present when Slack is
- * connected) and pass it as `botFallback`, so this never has to re-resolve
- * credentials or signal "not configured".
- *
- * The default fallback trigger is a 401 — the user token was revoked or
- * expired. Callers whose operation can also fail because the user token lacks
- * a required scope (e.g. a share post needs `chat:write`, which surfaces as a
- * non-401 `missing_scope`) pass a wider `shouldFallback`.
- *
- * `call` must be idempotent: on fallback it is re-run from the top with the
- * bot auth. Slack reads are safe to repeat, and a Slack write that threw
- * created nothing (the error is raised before the message is posted), so a
- * single retry cannot double-post.
- */
-export async function runAsUserWithBotFallback<T>(
-  botFallback: SlackAuth,
-  call: (auth: SlackAuth) => Promise<T>,
-  opts: {
-    account?: string;
-    shouldFallback?: (err: SlackApiError) => boolean;
-  } = {},
-): Promise<T> {
-  const userAuth = (await resolveSlackAuth("user", opts)) ?? botFallback;
-  const shouldFallback = opts.shouldFallback ?? ((err) => err.status === 401);
-  try {
-    return await call(userAuth);
-  } catch (err) {
-    if (
-      userAuth !== botFallback &&
-      err instanceof SlackApiError &&
-      shouldFallback(err)
-    ) {
-      return call(botFallback);
-    }
-    throw err;
-  }
 }

--- a/assistant/src/runtime/routes/integrations/slack/__tests__/token-routing.test.ts
+++ b/assistant/src/runtime/routes/integrations/slack/__tests__/token-routing.test.ts
@@ -5,14 +5,12 @@
  * each handler is actually wired to the identity slack/auth.ts resolves — a
  * class of bug the mocked-client handler tests can't catch.
  *
- * Verifies which Slack identity each route acts as (see slack/auth.ts):
- * - Channel enumeration (`channels.ts`, GET /v1/slack/channels) prefers the
- *   user_token when present so the picker surfaces channels the user is in but
- *   the bot isn't.
- * - Channel sharing (`share.ts`, POST /v1/slack/share) is a human-initiated
- *   action: it posts as the user (user_token) when one is present so the
- *   message reads as the person who shared, falling back to the bot_token when
- *   no user token is stored or it can't post (401, or missing chat:write).
+ * Both routes act as the BOT, and these tests are the regression guard for why:
+ * `GET /v1/slack/channels` and `POST /v1/slack/share` are exposed at the gateway
+ * with generic edge auth and the daemon never sees the calling actor, so acting
+ * as the single stored installer `user_token` would let any caller read the
+ * installer's channel list (picker) or post as them (share). So even when a
+ * user_token IS stored, neither route may put it on the wire.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -62,11 +60,6 @@ type CapturedRequest = {
 const captured: CapturedRequest[] = [];
 const originalFetch = globalThis.fetch;
 
-// When set, chat.postMessage requests carrying this exact Authorization header
-// respond with `missing_scope`, so a share as the user falls through to the
-// bot token on the wire.
-let failPostMessageForAuth: string | null = null;
-
 function installFetchStub() {
   globalThis.fetch = (async (
     input: RequestInfo | URL,
@@ -80,16 +73,9 @@ function installFetchStub() {
           : input.url;
     const method = (init?.method ?? "GET").toUpperCase();
     const headers = new Headers(init?.headers ?? {});
-    const authorization = headers.get("authorization");
-    captured.push({ url, method, authorization });
+    captured.push({ url, method, authorization: headers.get("authorization") });
 
-    const body =
-      url.includes("/chat.postMessage") &&
-      failPostMessageForAuth !== null &&
-      authorization === failPostMessageForAuth
-        ? { ok: false, error: "missing_scope" }
-        : fakeSlackResponse(url);
-    return new Response(JSON.stringify(body), {
+    return new Response(JSON.stringify(fakeSlackResponse(url)), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
@@ -111,10 +97,23 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
 const BOT_TOKEN = "xoxb-test-bot-token";
 const USER_TOKEN = "xoxp-test-user-token";
 
+/** Stores both tokens, so a test asserting the bot token proves the stored
+ *  user_token was deliberately NOT put on the wire. */
+function storeBothTokens() {
+  getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
+    if (key === credentialKey("slack_channel", "bot_token")) {
+      return BOT_TOKEN;
+    }
+    if (key === credentialKey("slack_channel", "user_token")) {
+      return USER_TOKEN;
+    }
+    return null;
+  });
+}
+
 describe("Slack route token routing (channels + share)", () => {
   beforeEach(() => {
     captured.length = 0;
-    failPostMessageForAuth = null;
     getSecureKeyAsyncMock.mockReset();
     installFetchStub();
   });
@@ -123,17 +122,12 @@ describe("Slack route token routing (channels + share)", () => {
     globalThis.fetch = originalFetch;
   });
 
-  test("GET /v1/slack/channels: bot-only install reads with bot token", async () => {
-    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
-      if (key === credentialKey("slack_channel", "bot_token")) {
-        return BOT_TOKEN;
-      }
-      return null;
-    });
+  test("GET /v1/slack/channels: bot-only install reads with the bot token", async () => {
+    getSecureKeyAsyncMock.mockImplementation(async (key: string) =>
+      key === credentialKey("slack_channel", "bot_token") ? BOT_TOKEN : null,
+    );
 
-    const result = (await handleListSlackChannels()) as {
-      channels: unknown[];
-    };
+    const result = (await handleListSlackChannels()) as { channels: unknown[] };
     expect(result).toHaveProperty("channels");
 
     const listCall = captured.find((c) =>
@@ -143,74 +137,33 @@ describe("Slack route token routing (channels + share)", () => {
     expect(listCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
   });
 
-  test("GET /v1/slack/channels: bot + user tokens prefer user_token for reads", async () => {
-    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
-      if (key === credentialKey("slack_channel", "bot_token")) {
-        return BOT_TOKEN;
-      }
-      if (key === credentialKey("slack_channel", "user_token")) {
-        return USER_TOKEN;
-      }
-      return null;
-    });
+  test("GET /v1/slack/channels: a stored user_token is NOT used — reads stay on the bot token", async () => {
+    storeBothTokens();
 
-    const result = (await handleListSlackChannels()) as {
-      channels: unknown[];
-    };
+    const result = (await handleListSlackChannels()) as { channels: unknown[] };
     expect(result).toHaveProperty("channels");
 
+    // Security guard: this edge-reachable route must not read as the installer.
     const listCall = captured.find((c) =>
       c.url.includes("/conversations.list"),
     );
     expect(listCall).toBeDefined();
-    expect(listCall!.authorization).toBe(`Bearer ${USER_TOKEN}`);
+    expect(listCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
   });
 
-  test("POST /v1/slack/share: bot + user tokens post as the user", async () => {
-    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
-      if (key === credentialKey("slack_channel", "bot_token")) {
-        return BOT_TOKEN;
-      }
-      if (key === credentialKey("slack_channel", "user_token")) {
-        return USER_TOKEN;
-      }
-      return null;
-    });
+  test("POST /v1/slack/share: posts with the bot token even when a user_token is stored", async () => {
+    storeBothTokens();
 
     const result = (await handleShareToSlackChannel({
       body: { appId: FAKE_APP.id, channelId: "C123" },
     })) as { ok: boolean };
     expect(result.ok).toBe(true);
 
-    // Sharing is a human action — it posts as the user, not the bot.
+    // Security guard: shares must come from the neutral app identity, never the
+    // installer's user_token — the daemon can't verify the caller is the owner.
     const postCall = captured.find((c) => c.url.includes("/chat.postMessage"));
     expect(postCall).toBeDefined();
-    expect(postCall!.authorization).toBe(`Bearer ${USER_TOKEN}`);
-  });
-
-  test("POST /v1/slack/share: falls back to the bot token when the user token can't post", async () => {
-    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
-      if (key === credentialKey("slack_channel", "bot_token")) {
-        return BOT_TOKEN;
-      }
-      if (key === credentialKey("slack_channel", "user_token")) {
-        return USER_TOKEN;
-      }
-      return null;
-    });
-    // The user token lacks chat:write; the bot token can post.
-    failPostMessageForAuth = `Bearer ${USER_TOKEN}`;
-
-    const result = (await handleShareToSlackChannel({
-      body: { appId: FAKE_APP.id, channelId: "C123" },
-    })) as { ok: boolean };
-    expect(result.ok).toBe(true);
-
-    // It tries the user token first, then retries on the wire as the bot.
-    const postAuths = captured
-      .filter((c) => c.url.includes("/chat.postMessage"))
-      .map((c) => c.authorization);
-    expect(postAuths).toEqual([`Bearer ${USER_TOKEN}`, `Bearer ${BOT_TOKEN}`]);
+    expect(postCall!.authorization).toBe(`Bearer ${BOT_TOKEN}`);
   });
 
   test("no tokens configured: both handlers throw ServiceUnavailableError", async () => {

--- a/assistant/src/runtime/routes/integrations/slack/channels.ts
+++ b/assistant/src/runtime/routes/integrations/slack/channels.ts
@@ -9,7 +9,6 @@ import { z } from "zod";
 
 import {
   resolveSlackAuth,
-  runAsUserWithBotFallback,
   type SlackAuth,
 } from "../../../../messaging/providers/slack/auth.js";
 import {
@@ -68,13 +67,14 @@ export async function handleListSlackChannels({
 }: RouteHandlerArgs = {}) {
   const memberOnly = queryParams?.memberOnly === "true";
 
-  // The presence list ("where the assistant is present") reflects the BOT's
-  // own membership — Slack's `is_member` is relative to the token's identity —
-  // so it always reads as the bot, never the optional user token. The share
-  // picker (memberOnly absent) reads as the user for broader reach (channels
-  // the user is in but the bot isn't), falling back to the bot token when no
-  // user token is stored or it has been revoked. Resolve the bot auth up front
-  // either way: it anchors the fallback and gives the "not configured" check.
+  // Both views read as the BOT. This route is exposed at the gateway with
+  // generic edge auth and the daemon never sees the calling actor's identity,
+  // so it must act as the neutral app identity, never the single stored
+  // installer user_token (which would leak the installer's channel list to any
+  // caller). The presence list needs the bot regardless — Slack's `is_member`
+  // is relative to the token's own identity, so only the bot token answers
+  // "which rooms is the bot in". The share picker uses it too so its results
+  // match where the (bot-identity) share can actually post.
   const botAuth = await resolveSlackAuth("bot");
   if (botAuth === undefined) {
     throw new ServiceUnavailableError("No Slack token configured");
@@ -175,11 +175,7 @@ export async function handleListSlackChannels({
     return channels;
   };
 
-  // Presence reads as the bot; the share picker reads as the user with a bot
-  // fallback when no user token is stored or it has been revoked.
-  const channels = memberOnly
-    ? await enumerate(botAuth)
-    : await runAsUserWithBotFallback(botAuth, enumerate);
+  const channels = await enumerate(botAuth);
 
   return { channels };
 }

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -8,10 +8,7 @@
 import { z } from "zod";
 
 import { getApp } from "../../../../apps/app-store.js";
-import {
-  resolveSlackAuth,
-  runAsUserWithBotFallback,
-} from "../../../../messaging/providers/slack/auth.js";
+import { resolveSlackAuth } from "../../../../messaging/providers/slack/auth.js";
 import { postMessage } from "../../../../messaging/providers/slack/client.js";
 import { getLogger } from "../../../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../../../auth/route-policy.js";
@@ -34,12 +31,16 @@ const SlackShareResultSchema = z.object({
 export async function handleShareToSlackChannel({
   body = {},
 }: RouteHandlerArgs) {
-  // Sharing is a human-initiated action, so post AS THE USER when a user token
-  // is stored — the message should read as the person who clicked Share, not
-  // as the bot. Resolve the bot auth up front to anchor the fallback and to
-  // give the "not configured" check; the actual post prefers the user token.
-  const botAuth = await resolveSlackAuth("bot");
-  if (botAuth === undefined) {
+  // Post AS THE BOT. This route is exposed at the gateway with generic edge
+  // auth and the daemon never sees the calling actor's identity (the proxy
+  // strips the caller's Authorization for a service token), so it cannot verify
+  // that the caller is the Slack user who installed the stored user_token.
+  // Posting as that single installer token would let any authenticated caller
+  // make a message appear as another person — so shares always come from the
+  // neutral app identity. (Attributing a share to the acting user would require
+  // plumbing and verifying caller-specific Slack auth through the gateway.)
+  const auth = await resolveSlackAuth("bot");
+  if (auth === undefined) {
     throw new ServiceUnavailableError("No Slack token configured");
   }
 
@@ -88,17 +89,7 @@ export async function handleShareToSlackChannel({
   }
 
   try {
-    // Fall back to the bot token when the user token is revoked (401) or lacks
-    // chat:write (missing_scope) — otherwise a share would fail for an install
-    // whose user token is under-scoped even though the bot could post fine.
-    const result = await runAsUserWithBotFallback(
-      botAuth,
-      (auth) => postMessage(auth, channelId, fallbackText, { blocks }),
-      {
-        shouldFallback: (err) =>
-          err.status === 401 || err.slackError === "missing_scope",
-      },
-    );
+    const result = await postMessage(auth, channelId, fallbackText, { blocks });
     return {
       ok: true,
       ts: result.ts,


### PR DESCRIPTION
## Prompt / plan

Follow-up to the Codex **P1** on the merged #38898. `POST /v1/slack/share` posted with the stored Slack `user_token` — but that's a single workspace-level credential, the **installer's**. Both `/v1/slack/share` and `/v1/slack/channels` are exposed at the gateway with generic `auth: "edge"` (`gateway/src/index.ts`), and the proxy strips the caller's `Authorization` and swaps in a service token (`packages/assistant-client` `prepareUpstreamHeaders`), so the daemon **cannot verify the caller is the installer**. In any multi-actor deployment, one user's share appears as another person (impersonation), and the picker leaks the installer's channel list to any caller.

**Fix — route both edge-reachable control-plane endpoints through the bot identity**, matching the presence list:

- `share.ts` → posts as the bot (no user token, no fallback).
- `channels.ts` → the share picker reads as the bot too. It has to: the picker feeds the now-bot-identity share, so a user-identity picker would surface channels the bot can't post to.
- `runAsUserWithBotFallback` had no remaining callers → removed.
- The messaging **adapter's** in-conversation reads (search/history) keep `resolveSlackAuth("user")` — a *different* trust context (the assistant acting for its own owner within a trust-classified conversation, not an endpoint arbitrary edge callers can reach).

Attributing a share to the *acting* user would require plumbing and verifying caller-specific Slack identity through the gateway (which strips it) — a separate feature, not this hotfix.

## Test plan

- `runtime/routes/integrations/slack/__tests__/token-routing.test.ts` — rewritten as the **regression guard**: with a `user_token` stored, both the picker read and the share post assert `Bearer <bot>` on the wire.
- `messaging/providers/slack/__tests__/auth.test.ts` — drops the removed helper's suite; keeps `resolveSlackAuth` bot/user resolution.
- `slack-share-routes.test.ts` — handler-contract note updated (identity now always the bot).
- Verified per-file in isolation: auth (5), token-routing (4), slack-share-routes (4), slack-channels-routes (8), adapter-token-routing (6), slack-messaging-token-resolution (18). `tsc --noEmit` clean; prettier + eslint clean.

## CLI verb checklist

No new routes — this modifies existing Slack route handlers (`share`, `channels`) and the `slack/auth.ts` resolver.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Wgp8RrNu1qTXeGPVaq9HD)_