### PR TITLE
feat(web): restore Move to group / New group menu and collapsible Pinned + Chats

### DIFF
--- a/clients/web/src/components/collapsible-nav-section.tsx
+++ b/clients/web/src/components/collapsible-nav-section.tsx
@@ -64,6 +64,12 @@ export interface CollapsibleNavSectionSectionProps
   label: string;
   trailing?: ReactNode;
   contextMenuContent?: ReactNode;
+  /**
+   * Activity indicator rendered inline in the header, but only while the
+   * section is collapsed — when open, the child rows show their own
+   * indicators, so a header dot would be redundant.
+   */
+  collapsedIndicator?: ReactNode;
   children?: ReactNode;
   contentClassName?: string;
   ref?: Ref<HTMLDivElement>;
@@ -75,6 +81,7 @@ function CollapsibleNavSectionSection({
   label,
   trailing,
   contextMenuContent,
+  collapsedIndicator,
   children,
   className,
   contentClassName,
@@ -117,6 +124,11 @@ function CollapsibleNavSectionSection({
           />
         </span>
         <span className="min-w-0 flex-1 truncate">{label}</span>
+        {collapsedIndicator ? (
+          <span className="ml-1 flex shrink-0 items-center group-data-[state=open]:hidden">
+            {collapsedIndicator}
+          </span>
+        ) : null}
       </Collapsible.Trigger>
       {trailing ? (
         <span

--- a/clients/web/src/domains/chat/chat-conversation-header.tsx
+++ b/clients/web/src/domains/chat/chat-conversation-header.tsx
@@ -4,20 +4,28 @@ import { ChevronDown } from "lucide-react";
 import type { ChatHeaderSupplements } from "@/components/layout/chat-layout-slots-store";
 import { ConversationActionsMenu } from "@/domains/chat/components/conversation-actions-menu";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
+import {
+  buildMoveToGroupTargets,
+  isInCustomGroup,
+} from "@/domains/chat/utils/group-conversations";
 import { ChannelIcon, getOpenInChannelLabel } from "@/utils/channel-presentation";
-import type { Conversation } from "@/types/conversation-types";
+import type { Conversation, ConversationGroup } from "@/types/conversation-types";
 
 interface ChatConversationHeaderProps {
   assistantId: string | null;
   activeConversation: Conversation | null;
   headerSupplements: ChatHeaderSupplements | null;
   showLlmInspector: boolean;
+  conversationGroups?: ConversationGroup[];
   onArchive: (c: Conversation) => void;
   onUnarchive: (c: Conversation) => void;
   onMarkUnread: (c: Conversation) => void;
   onMarkRead: (c: Conversation) => void;
   onPinToggle: (c: Conversation) => void;
   onRename: (c: Conversation) => void;
+  onMoveToGroup: (c: Conversation, groupId: string) => void;
+  onCreateGroupInto: (c: Conversation) => void;
+  onRemoveFromGroup: (c: Conversation) => void;
 }
 
 export function ChatConversationHeader({
@@ -25,12 +33,16 @@ export function ChatConversationHeader({
   activeConversation,
   headerSupplements,
   showLlmInspector,
+  conversationGroups,
   onArchive,
   onUnarchive,
   onMarkUnread,
   onMarkRead,
   onPinToggle,
   onRename,
+  onMoveToGroup,
+  onCreateGroupInto,
+  onRemoveFromGroup,
 }: ChatConversationHeaderProps) {
   if (!activeConversation) {
     if (!assistantId) {return null;}
@@ -67,6 +79,14 @@ export function ChatConversationHeader({
       isReadonly={isReadonly}
       onPinToggle={() => onPinToggle(activeConversation)}
       onRename={() => onRename(activeConversation)}
+      moveToGroups={buildMoveToGroupTargets(activeConversation, conversationGroups)}
+      onMoveToGroup={(groupId) => onMoveToGroup(activeConversation, groupId)}
+      onCreateGroupInto={() => onCreateGroupInto(activeConversation)}
+      onRemoveFromGroup={
+        isInCustomGroup(activeConversation)
+          ? () => onRemoveFromGroup(activeConversation)
+          : undefined
+      }
       onArchive={() => onArchive(activeConversation)}
       onUnarchive={() => onUnarchive(activeConversation)}
       onForkConversation={

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -489,7 +489,9 @@ export function ChatLayout({
   const handleCreateGroupForConversation = useCallback(
     async (conversation: Conversation) => {
       const group = await handleCreateGroup();
-      if (group) handleMoveToGroup(conversation, group.id);
+      if (group) {
+        handleMoveToGroup(conversation, group.id);
+      }
     },
     [handleCreateGroup, handleMoveToGroup],
   );

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -215,10 +215,11 @@ export function ChatLayout({
   // create/rename/delete affordances are rendered here, not in ChatPage.
   // The hook is self-sufficient (cache invalidation handles rollback), so
   // it can live wherever the sidebar lives.
-  const { handleRenameGroup, handleDeleteGroup } = useConversationGroupActions({
-    assistantId,
-    conversationGroups,
-  });
+  const { handleCreateGroup, handleRenameGroup, handleDeleteGroup } =
+    useConversationGroupActions({
+      assistantId,
+      conversationGroups,
+    });
 
   // Mirror the unread count + signed-in flag into the Electron Dock
   // (no-op off Electron). Uses the conversation list this layout
@@ -466,6 +467,8 @@ export function ChatLayout({
     handleMarkConversationUnread,
     handleMarkConversationRead,
     handleTogglePinConversation,
+    handleMoveToGroup,
+    handleRemoveFromGroup,
     handleRenameConversation,
     handleReorderConversations,
     handleMarkAllReadInGroup,
@@ -478,6 +481,18 @@ export function ChatLayout({
     startNewConversation,
     prePinGroupIdsRef,
   });
+
+  // Create a new custom group (via the "New group…" menu item) and move the
+  // conversation into it. This is the only group-creation entry point — there
+  // is no standalone create button. `handleCreateGroup` prompts for a name and
+  // returns the created group (or null if cancelled/failed).
+  const handleCreateGroupForConversation = useCallback(
+    async (conversation: Conversation) => {
+      const group = await handleCreateGroup();
+      if (group) handleMoveToGroup(conversation, group.id);
+    },
+    [handleCreateGroup, handleMoveToGroup],
+  );
 
   // Resolve the active row from whichever list cache holds it (foreground,
   // background, or scheduled), fetching the single row when an open
@@ -501,12 +516,16 @@ export function ChatLayout({
         activeConversation={activeConversation}
         headerSupplements={headerSupplements}
         showLlmInspector={showLlmInspector}
+        conversationGroups={conversationGroups}
         onArchive={handleArchiveConversation}
         onUnarchive={handleUnarchiveConversation}
         onMarkUnread={handleMarkConversationUnread}
         onMarkRead={handleMarkConversationRead}
         onPinToggle={handleTogglePinConversation}
         onRename={handleRenameConversation}
+        onMoveToGroup={handleMoveToGroup}
+        onCreateGroupInto={handleCreateGroupForConversation}
+        onRemoveFromGroup={handleRemoveFromGroup}
       />
     ) : null);
 
@@ -742,6 +761,9 @@ export function ChatLayout({
       onArchiveAllInGroup={handleArchiveAllInGroup}
       onOpenInNewWindow={isNative ? undefined : handleOpenInNewWindow}
       onInspect={showLlmInspector ? handleInspectConversation : undefined}
+      onMoveToGroup={handleMoveToGroup}
+      onCreateGroupInto={handleCreateGroupForConversation}
+      onRemoveFromGroup={handleRemoveFromGroup}
       footerAction={
         <PreferencesMenu
           assistantId={assistantId}

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -18,7 +18,7 @@ import {
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
 
 import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
-import { CollapsedGroupIcon, getGroupIndicatorState } from "@/domains/chat/components/collapsed-group-icon";
+import { CollapsedGroupIcon, getGroupIndicatorState, GroupIndicatorDot } from "@/domains/chat/components/collapsed-group-icon";
 import {
     ConversationListProvider,
     type ConversationListContextValue,
@@ -271,6 +271,18 @@ export function AssistantSideMenu({
   // Shared context for every conversation row (Pinned, Recents, channel
   // sections, custom groups, rail flyout): the action callbacks,
   // active/processing/attention state, and drag controller the rows read.
+  // Activity dot for a collapsed section header — surfaces processing/unread
+  // conversations that live in a collapsed section (attention already
+  // force-opens the section via effectiveOpen*). Null when the section is idle.
+  const collapsedActivityDot = (conversations: Conversation[]): ReactNode => {
+    const state = getGroupIndicatorState(
+      conversations,
+      processingConversationIds,
+      attentionConversationIds,
+    );
+    return state ? <GroupIndicatorDot state={state} /> : null;
+  };
+
   const listContext: ConversationListContextValue = {
     activeConversationId,
     activeConversationProcessing,
@@ -473,6 +485,7 @@ export function AssistantSideMenu({
                     label="Pinned"
                     items={sidebar.pinned}
                     dragSection="pinned"
+                    collapsedIndicator={collapsedActivityDot(sidebar.pinned)}
                   />
                 ) : null}
 
@@ -482,6 +495,7 @@ export function AssistantSideMenu({
                   label="Chats"
                   items={sidebar.recents.items}
                   pagination={sidebar.recents}
+                  collapsedIndicator={collapsedActivityDot(sidebar.recents.all)}
                 />
               </CollapsibleNavSection.Root>
 
@@ -502,6 +516,7 @@ export function AssistantSideMenu({
                       contextMenuContent={buildGroupContextMenu(label, section.all)}
                       items={section.items}
                       pagination={section}
+                      collapsedIndicator={collapsedActivityDot(section.all)}
                     />
                   );
                 })}
@@ -545,6 +560,7 @@ export function AssistantSideMenu({
                           )}
                           items={group.conversations}
                           dragSection={`group:${group.id}`}
+                          collapsedIndicator={collapsedActivityDot(group.conversations)}
                         />
                       ))}
                     </CollapsibleNavSection.Root>

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -23,9 +23,7 @@ import {
     ConversationListProvider,
     type ConversationListContextValue,
 } from "@/domains/chat/components/conversation-list-context";
-import {
-    ConversationNavSection,
-} from "@/domains/chat/components/conversation-nav-section";
+import { ConversationNavSection } from "@/domains/chat/components/conversation-nav-section";
 import { CollapsedGroupFlyout } from "@/domains/chat/components/conversation-rail-flyout";
 import { GroupActionsMenu, renderGroupMenuItems } from "@/domains/chat/components/group-actions-menu";
 import { AssistantNavItem } from "@/domains/chat/components/assistant-nav-item";

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -1,5 +1,6 @@
 import {
     Clock,
+    MessageSquare,
     Pin,
     Search,
     SquarePen,
@@ -24,7 +25,6 @@ import {
 } from "@/domains/chat/components/conversation-list-context";
 import {
     ConversationNavSection,
-    ConversationRowList,
 } from "@/domains/chat/components/conversation-nav-section";
 import { CollapsedGroupFlyout } from "@/domains/chat/components/conversation-rail-flyout";
 import { GroupActionsMenu, renderGroupMenuItems } from "@/domains/chat/components/group-actions-menu";
@@ -88,6 +88,12 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   onOpenInNewWindow?: (conversation: Conversation) => void;
   onShareFeedback?: () => void;
   onInspect?: (conversation: Conversation) => void;
+  /** Move a conversation into an existing custom group. */
+  onMoveToGroup?: (conversation: Conversation, groupId: string) => void;
+  /** Create a new custom group ("New group…") and move the conversation into it. */
+  onCreateGroupInto?: (conversation: Conversation) => void;
+  /** Remove a conversation from its current custom group (back to Recents). */
+  onRemoveFromGroup?: (conversation: Conversation) => void;
 }
 
 function SearchButton() {
@@ -170,6 +176,9 @@ export function AssistantSideMenu({
   onOpenInNewWindow,
   onShareFeedback,
   onInspect,
+  onMoveToGroup,
+  onCreateGroupInto,
+  onRemoveFromGroup,
 }: AssistantSideMenuProps) {
   const sidebar = useSidebarState({
     assistantId,
@@ -279,6 +288,10 @@ export function AssistantSideMenu({
     onOpenInNewWindow,
     onShareFeedback,
     onInspect,
+    conversationGroups,
+    onMoveToGroup,
+    onCreateGroupInto,
+    onRemoveFromGroup,
     dragReorder,
     canReorder: !!onReorderConversations,
   };
@@ -445,87 +458,101 @@ export function AssistantSideMenu({
             </div>
           ) : (
             <>
-              {sidebar.pinned.length > 0 ? (
-                <SideMenu.Section title="Pinned" className="gap-1">
-                  <ConversationRowList items={sidebar.pinned} dragSection="pinned" />
-                </SideMenu.Section>
-              ) : null}
+              {/* Pinned + Chats are collapsible like the channel/group
+                  sections below, but default open (see `openPrimary` in
+                  use-sidebar-state). New Chat lives in the assistant cluster
+                  above, not as a section-header action. */}
+              <CollapsibleNavSection.Root
+                type="multiple"
+                className="gap-1"
+                value={sidebar.effectiveOpenPrimary}
+                onValueChange={sidebar.onOpenPrimaryChange}
+              >
+                {sidebar.pinned.length > 0 ? (
+                  <ConversationNavSection
+                    value="pinned"
+                    icon={Pin}
+                    label="Pinned"
+                    items={sidebar.pinned}
+                    dragSection="pinned"
+                  />
+                ) : null}
 
-              {/* New Chat lives in the assistant cluster above, not as a
-                  section-header action. */}
-              <SideMenu.Section title="Chats" className="gap-1">
-                <ConversationRowList
+                <ConversationNavSection
+                  value="recents"
+                  icon={MessageSquare}
+                  label="Chats"
                   items={sidebar.recents.items}
                   pagination={sidebar.recents}
                 />
+              </CollapsibleNavSection.Root>
 
-                <CollapsibleNavSection.Root
-                  type="multiple"
-                  className="gap-1"
-                  value={sidebar.effectiveOpenCategories}
-                  onValueChange={sidebar.onOpenCategoriesChange}
-                >
-                  {sidebar.channelSections.map((section) => {
-                    const label = getChannelLabel(section.channelId);
-                    return (
-                      <ConversationNavSection
-                        key={section.channelId}
-                        value={channelSectionKey(section.channelId)}
-                        icon={getChannelIcon(section.channelId)}
-                        label={label}
-                        contextMenuContent={buildGroupContextMenu(label, section.all)}
-                        items={section.items}
-                        pagination={section}
-                      />
-                    );
-                  })}
-                </CollapsibleNavSection.Root>
+              <CollapsibleNavSection.Root
+                type="multiple"
+                className="gap-1"
+                value={sidebar.effectiveOpenCategories}
+                onValueChange={sidebar.onOpenCategoriesChange}
+              >
+                {sidebar.channelSections.map((section) => {
+                  const label = getChannelLabel(section.channelId);
+                  return (
+                    <ConversationNavSection
+                      key={section.channelId}
+                      value={channelSectionKey(section.channelId)}
+                      icon={getChannelIcon(section.channelId)}
+                      label={label}
+                      contextMenuContent={buildGroupContextMenu(label, section.all)}
+                      items={section.items}
+                      pagination={section}
+                    />
+                  );
+                })}
+              </CollapsibleNavSection.Root>
 
-                {sidebar.customGroups.length > 0 ? (
-                  <>
-                    <SideMenu.Separator />
-                    <SideMenu.Section title="Your Groups">
-                      <CollapsibleNavSection.Root
-                        type="multiple"
-                        className="gap-1"
-                        value={sidebar.effectiveOpenCustomGroups}
-                        onValueChange={sidebar.onOpenCustomGroupsChange}
-                      >
-                        {sidebar.customGroups.map((group) => (
-                          <ConversationNavSection
-                            key={group.id}
-                            value={group.id}
-                            label={group.name}
-                            trailing={
-                              onRenameGroup || onDeleteGroup ? (
-                                <GroupActionsMenu
-                                  groupId={group.id}
-                                  onRename={onRenameGroup}
-                                  onDelete={onDeleteGroup}
-                                />
-                              ) : null
-                            }
-                            contextMenuContent={buildGroupContextMenu(
-                              group.name,
-                              group.conversations,
-                              {
-                                onRename: onRenameGroup
-                                  ? () => onRenameGroup(group.id)
-                                  : undefined,
-                                onDelete: onDeleteGroup
-                                  ? () => onDeleteGroup(group.id)
-                                  : undefined,
-                              },
-                            )}
-                            items={group.conversations}
-                            dragSection={`group:${group.id}`}
-                          />
-                        ))}
-                      </CollapsibleNavSection.Root>
-                    </SideMenu.Section>
-                  </>
-                ) : null}
-              </SideMenu.Section>
+              {sidebar.customGroups.length > 0 ? (
+                <>
+                  <SideMenu.Separator />
+                  <SideMenu.Section title="Your Groups">
+                    <CollapsibleNavSection.Root
+                      type="multiple"
+                      className="gap-1"
+                      value={sidebar.effectiveOpenCustomGroups}
+                      onValueChange={sidebar.onOpenCustomGroupsChange}
+                    >
+                      {sidebar.customGroups.map((group) => (
+                        <ConversationNavSection
+                          key={group.id}
+                          value={group.id}
+                          label={group.name}
+                          trailing={
+                            onRenameGroup || onDeleteGroup ? (
+                              <GroupActionsMenu
+                                groupId={group.id}
+                                onRename={onRenameGroup}
+                                onDelete={onDeleteGroup}
+                              />
+                            ) : null
+                          }
+                          contextMenuContent={buildGroupContextMenu(
+                            group.name,
+                            group.conversations,
+                            {
+                              onRename: onRenameGroup
+                                ? () => onRenameGroup(group.id)
+                                : undefined,
+                              onDelete: onDeleteGroup
+                                ? () => onDeleteGroup(group.id)
+                                : undefined,
+                            },
+                          )}
+                          items={group.conversations}
+                          dragSection={`group:${group.id}`}
+                        />
+                      ))}
+                    </CollapsibleNavSection.Root>
+                  </SideMenu.Section>
+                </>
+              ) : null}
             </>
           )}
         </SideMenu.Body>

--- a/clients/web/src/domains/chat/components/collapsed-group-icon.test.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-group-icon.test.tsx
@@ -38,7 +38,6 @@ mock.module("@vellumai/design-library", () => ({
 import {
     CollapsedGroupIcon,
     getGroupIndicatorState,
-    GroupIndicatorDot,
 } from "@/domains/chat/components/collapsed-group-icon";
 import type { Conversation } from "@/types/conversation-types";
 import { Pin } from "lucide-react";
@@ -233,33 +232,5 @@ describe("CollapsedGroupIcon disabled state", () => {
       <CollapsedGroupIcon icon={Pin} label="Pinned" indicatorState="attention" disabled />,
     );
     expect(html).not.toContain("rounded-full");
-  });
-});
-
-describe("GroupIndicatorDot", () => {
-  test("renders nothing when the group is idle (null state)", () => {
-    expect(renderToStaticMarkup(<GroupIndicatorDot state={null} />)).toBe("");
-  });
-
-  test("renders a pulsing dot for processing", () => {
-    const html = renderToStaticMarkup(<GroupIndicatorDot state="processing" />);
-    expect(html).toContain("rounded-full");
-    expect(html).toContain("animate-pulse");
-  });
-
-  test("renders a solid (non-pulsing) dot for attention and unread", () => {
-    for (const state of ["attention", "unread"] as const) {
-      const html = renderToStaticMarkup(<GroupIndicatorDot state={state} />);
-      expect(html).toContain("rounded-full");
-      expect(html).not.toContain("animate-pulse");
-    }
-  });
-
-  test("merges caller-provided positioning classes", () => {
-    const html = renderToStaticMarkup(
-      <GroupIndicatorDot state="attention" className="absolute right-0 top-0" />,
-    );
-    expect(html).toContain("absolute");
-    expect(html).toContain("right-0");
   });
 });

--- a/clients/web/src/domains/chat/components/collapsed-group-icon.test.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-group-icon.test.tsx
@@ -38,6 +38,7 @@ mock.module("@vellumai/design-library", () => ({
 import {
     CollapsedGroupIcon,
     getGroupIndicatorState,
+    GroupIndicatorDot,
 } from "@/domains/chat/components/collapsed-group-icon";
 import type { Conversation } from "@/types/conversation-types";
 import { Pin } from "lucide-react";
@@ -232,5 +233,33 @@ describe("CollapsedGroupIcon disabled state", () => {
       <CollapsedGroupIcon icon={Pin} label="Pinned" indicatorState="attention" disabled />,
     );
     expect(html).not.toContain("rounded-full");
+  });
+});
+
+describe("GroupIndicatorDot", () => {
+  test("renders nothing when the group is idle (null state)", () => {
+    expect(renderToStaticMarkup(<GroupIndicatorDot state={null} />)).toBe("");
+  });
+
+  test("renders a pulsing dot for processing", () => {
+    const html = renderToStaticMarkup(<GroupIndicatorDot state="processing" />);
+    expect(html).toContain("rounded-full");
+    expect(html).toContain("animate-pulse");
+  });
+
+  test("renders a solid (non-pulsing) dot for attention and unread", () => {
+    for (const state of ["attention", "unread"] as const) {
+      const html = renderToStaticMarkup(<GroupIndicatorDot state={state} />);
+      expect(html).toContain("rounded-full");
+      expect(html).not.toContain("animate-pulse");
+    }
+  });
+
+  test("merges caller-provided positioning classes", () => {
+    const html = renderToStaticMarkup(
+      <GroupIndicatorDot state="attention" className="absolute right-0 top-0" />,
+    );
+    expect(html).toContain("absolute");
+    expect(html).toContain("right-0");
   });
 });

--- a/clients/web/src/domains/chat/components/collapsed-group-icon.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-group-icon.tsx
@@ -4,6 +4,7 @@ import type { LucideIcon } from "lucide-react";
 
 import type { Conversation } from "@/types/conversation-types";
 import { Popover, Tooltip } from "@vellumai/design-library";
+import { cn } from "@vellumai/design-library/utils/cn";
 
 // ---------------------------------------------------------------------------
 // Indicator state
@@ -54,6 +55,33 @@ const INDICATOR_CLASS: Record<Exclude<GroupIndicatorState, null>, string> = {
   processing: "bg-[var(--primary-base)] animate-pulse",
   unread: "bg-[var(--system-mid-strong)]",
 };
+
+/**
+ * The colored activity dot for a group of conversations. Renders nothing when
+ * there's no activity. Callers position it — the collapsed rail overlays it on
+ * the icon corner; the expanded section header renders it inline.
+ */
+export function GroupIndicatorDot({
+  state,
+  className,
+}: {
+  state: GroupIndicatorState;
+  className?: string;
+}) {
+  if (state == null) {
+    return null;
+  }
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "h-2.5 w-2.5 rounded-full",
+        INDICATOR_CLASS[state],
+        className,
+      )}
+    />
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -126,12 +154,10 @@ export function CollapsedGroupIcon({
             className="relative flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-[6px] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-default)]"
           >
             <Icon size={14} />
-            {indicatorState != null ? (
-              <span
-                aria-hidden
-                className={`absolute right-0 top-0 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-overlay)] ${INDICATOR_CLASS[indicatorState]}`}
-              />
-            ) : null}
+            <GroupIndicatorDot
+              state={indicatorState}
+              className="absolute right-0 top-0 border-2 border-[var(--surface-overlay)]"
+            />
           </button>
         </Popover.Trigger>
       </Tooltip>

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -215,6 +215,91 @@ describe("renderConversationMenuItems", () => {
 });
 
 // ---------------------------------------------------------------------------
+// "Move to group" submenu
+// ---------------------------------------------------------------------------
+
+describe("renderConversationMenuItems — Move to group submenu", () => {
+  test("omitted entirely when move/create handlers are not wired", () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        onPinToggle: () => {},
+      })}</>,
+    );
+    expect(html).not.toContain("Move to group");
+  });
+
+  test("shows the submenu with New group… even when there are no groups", () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        moveToGroups: [],
+        onMoveToGroup: () => {},
+        onCreateGroupInto: () => {},
+      })}</>,
+    );
+    expect(html).toContain("Move to group");
+    expect(html).toContain("New group…");
+  });
+
+  test("lists existing custom groups as targets", () => {
+    const html = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        moveToGroups: [
+          { id: "g_research", name: "Research" },
+          { id: "g_ideas", name: "Ideas" },
+        ],
+        onMoveToGroup: () => {},
+        onCreateGroupInto: () => {},
+      })}</>,
+    );
+    expect(html).toContain("Research");
+    expect(html).toContain("Ideas");
+    expect(html).toContain("New group…");
+  });
+
+  test("appends Remove from group only when onRemoveFromGroup is provided", () => {
+    const withRemove = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        moveToGroups: [{ id: "g_research", name: "Research" }],
+        onMoveToGroup: () => {},
+        onCreateGroupInto: () => {},
+        onRemoveFromGroup: () => {},
+      })}</>,
+    );
+    expect(withRemove).toContain("Remove from group");
+
+    const withoutRemove = renderToStaticMarkup(
+      <>{renderConversationMenuItems({
+        Primitive: Menu as unknown as ConversationMenuPrimitive,
+        moveToGroups: [{ id: "g_research", name: "Research" }],
+        onMoveToGroup: () => {},
+        onCreateGroupInto: () => {},
+      })}</>,
+    );
+    expect(withoutRemove).not.toContain("Remove from group");
+  });
+
+  test("mobile bottom sheet renders the flattened Move to group block", () => {
+    const html = renderToStaticMarkup(
+      <>
+        {renderConversationMenuItemsAsPanelItems({
+          moveToGroups: [{ id: "g_research", name: "Research" }],
+          onMoveToGroup: () => {},
+          onCreateGroupInto: () => {},
+          onClose: () => {},
+        })}
+      </>,
+    );
+    expect(html).toContain("Move to group");
+    expect(html).toContain("Research");
+    expect(html).toContain("New group…");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // ConversationActionsMenu component
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -5,6 +5,7 @@ import {
   CircleCheck,
   Copy,
   ExternalLink,
+  FolderInput,
   GitBranch,
   MessageCircle,
   Microscope,
@@ -17,6 +18,7 @@ import {
 } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
+import type { MoveToGroupTarget } from "@/domains/chat/utils/group-conversations";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { openExternalUrl } from "@/runtime/browser";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -30,7 +32,7 @@ import {
 /**
  * Hover-revealed "more" menu for a conversation row. Renders an ellipsis
  * button; clicking it opens a dropdown menu with Pin / Rename / Archive /
- * Mark as unread actions.
+ * Mark as unread actions, plus an optional "Move to group" submenu.
  *
  * The same item set is also rendered by the row's right-click context menu
  * (`AssistantSideMenu`) via the shared `renderConversationMenuItems` helper
@@ -59,6 +61,9 @@ type MenuAlign = "start" | "center" | "end";
 export type ConversationMenuPrimitive = {
   Item: typeof Menu.Item | typeof ContextMenu.Item;
   Separator: typeof Menu.Separator | typeof ContextMenu.Separator;
+  Sub: typeof Menu.Sub | typeof ContextMenu.Sub;
+  SubTrigger: typeof Menu.SubTrigger | typeof ContextMenu.SubTrigger;
+  SubContent: typeof Menu.SubContent | typeof ContextMenu.SubContent;
 };
 
 export interface ConversationMenuItemsProps {
@@ -90,6 +95,28 @@ export interface ConversationMenuItemsProps {
    * whichever is appropriate for the current read state.
    */
   onMarkRead?: () => void;
+  /**
+   * Custom groups this conversation can be filed into, excluding the one it
+   * already belongs to. Rendered as items in the "Move to group" submenu.
+   */
+  moveToGroups?: MoveToGroupTarget[];
+  /** Move the conversation to an existing custom group. */
+  onMoveToGroup?: (groupId: string) => void;
+  /**
+   * Create a new custom group and move the conversation into it. When
+   * provided together with `onMoveToGroup`, a "Move to group" submenu is
+   * shown with a "New group…" item — the only entry point for creating a
+   * group (there is no standalone create button). Available even when
+   * `moveToGroups` is empty.
+   */
+  onCreateGroupInto?: () => void;
+  /**
+   * Remove the conversation from its current custom group, falling back to
+   * Recents. When provided, a "Remove from group" item appears at the end of
+   * the submenu. Callers pass this only for conversations that belong to a
+   * custom group.
+   */
+  onRemoveFromGroup?: () => void;
   /**
    * Hide write-affording menu items (Mark-as-read/unread) when
    * the conversation is read-only. Items are hidden entirely, not
@@ -151,6 +178,10 @@ export function renderConversationMenuItems({
   onMarkUnread,
   isMarkUnreadDisabled = false,
   onMarkRead,
+  moveToGroups,
+  onMoveToGroup,
+  onCreateGroupInto,
+  onRemoveFromGroup,
   isReadonly = false,
   onForkConversation,
   onOpenInNewWindow,
@@ -163,6 +194,11 @@ export function renderConversationMenuItems({
 }: ConversationMenuItemsProps & {
   Primitive: ConversationMenuPrimitive;
 }): ReactNode {
+  // The submenu shows whenever move + create are wired, even with zero
+  // existing groups — "New group…" is always a valid action and is the only
+  // way to create a group.
+  const showMoveToGroup = Boolean(onMoveToGroup && onCreateGroupInto);
+
   const pinItem = onPinToggle ? (
     <Primitive.Item
       leftIcon={isPinned ? <PinOff size={14} /> : <Pin size={14} />}
@@ -209,6 +245,36 @@ export function renderConversationMenuItems({
         Mark as unread
       </Primitive.Item>
     ) : null;
+
+  const moveToGroupItem = showMoveToGroup ? (
+    <Primitive.Sub>
+      <Primitive.SubTrigger leftIcon={<FolderInput size={14} />}>
+        Move to group
+      </Primitive.SubTrigger>
+      <Primitive.SubContent>
+        {(moveToGroups ?? []).map((group) => (
+          <Primitive.Item
+            key={group.id}
+            onSelect={() => onMoveToGroup?.(group.id)}
+          >
+            {group.name}
+          </Primitive.Item>
+        ))}
+        {moveToGroups && moveToGroups.length > 0 ? (
+          <Primitive.Separator />
+        ) : null}
+        <Primitive.Item onSelect={onCreateGroupInto}>New group…</Primitive.Item>
+        {onRemoveFromGroup ? (
+          <>
+            <Primitive.Separator />
+            <Primitive.Item onSelect={onRemoveFromGroup}>
+              Remove from group
+            </Primitive.Item>
+          </>
+        ) : null}
+      </Primitive.SubContent>
+    </Primitive.Sub>
+  ) : null;
 
   const openInNewWindowItem = onOpenInNewWindow ? (
     <Primitive.Item
@@ -269,6 +335,7 @@ export function renderConversationMenuItems({
 
         {pinItem}
         {renameItem}
+        {moveToGroupItem}
         {archiveItem}
         {inspectItem}
       </>
@@ -282,6 +349,7 @@ export function renderConversationMenuItems({
       {archiveItem}
 
       {markReadUnreadItem}
+      {moveToGroupItem}
       {channelSourceLinkItem}
       {openInNewWindowItem}
 
@@ -381,6 +449,10 @@ export function renderConversationMenuItemsAsPanelItems({
   onMarkUnread,
   isMarkUnreadDisabled = false,
   onMarkRead,
+  moveToGroups,
+  onMoveToGroup,
+  onCreateGroupInto,
+  onRemoveFromGroup,
   isReadonly = false,
   onForkConversation,
   onOpenInNewWindow,
@@ -396,6 +468,9 @@ export function renderConversationMenuItemsAsPanelItems({
   onClose: () => void;
   isNativePlatform?: boolean;
 }): ReactNode {
+  // BottomSheet is a single-level surface, so the "Move to group" submenu is
+  // flattened into an inline labeled block (mirrors the desktop submenu).
+  const showMoveToGroup = Boolean(onMoveToGroup && onCreateGroupInto);
   const pinItem = onPinToggle
     ? buildPanelItem({
         key: "pin",
@@ -454,6 +529,41 @@ export function renderConversationMenuItemsAsPanelItems({
             onClose,
           })
         : null;
+
+  const moveToGroupBlock = showMoveToGroup ? (
+    <>
+      <MobileMenuDivider />
+      <div className="flex items-center gap-2 px-2 pt-1 pb-1 text-body-small-default uppercase tracking-wide text-[var(--content-tertiary)]">
+        <FolderInput size={14} aria-hidden />
+        Move to group
+      </div>
+      {(moveToGroups ?? []).map((group) =>
+        buildPanelItem({
+          key: `move-to-${group.id}`,
+          label: group.name,
+          className: "pl-7",
+          run: () => onMoveToGroup?.(group.id),
+          onClose,
+        }),
+      )}
+      {buildPanelItem({
+        key: "move-to-new-group",
+        label: "New group…",
+        className: "pl-7",
+        run: () => onCreateGroupInto?.(),
+        onClose,
+      })}
+      {onRemoveFromGroup
+        ? buildPanelItem({
+            key: "remove-from-group",
+            label: "Remove from group",
+            className: "pl-7",
+            run: onRemoveFromGroup,
+            onClose,
+          })
+        : null}
+    </>
+  ) : null;
 
   const openInNewWindowItem =
     onOpenInNewWindow && !isNativePlatform
@@ -526,6 +636,7 @@ export function renderConversationMenuItemsAsPanelItems({
         {pinItem}
         {renameItem}
         {archiveItem}
+        {moveToGroupBlock}
         {inspectItem}
       </>
     );
@@ -537,6 +648,7 @@ export function renderConversationMenuItemsAsPanelItems({
       {renameItem}
       {archiveItem}
       {markReadUnreadItem}
+      {moveToGroupBlock}
       {channelSourceLinkItem}
       {openInNewWindowItem}
 

--- a/clients/web/src/domains/chat/components/conversation-list-context.tsx
+++ b/clients/web/src/domains/chat/components/conversation-list-context.tsx
@@ -12,7 +12,7 @@
 import { createContext, useContext } from "react";
 
 import type { UseDragReorderResult } from "@/domains/chat/hooks/use-drag-reorder";
-import type { Conversation } from "@/types/conversation-types";
+import type { Conversation, ConversationGroup } from "@/types/conversation-types";
 
 export interface ConversationListContextValue {
   activeConversationId?: string;
@@ -35,6 +35,15 @@ export interface ConversationListContextValue {
   onOpenInNewWindow?: (conversation: Conversation) => void;
   onShareFeedback?: () => void;
   onInspect?: (conversation: Conversation) => void;
+
+  /** Custom groups available as "Move to group" targets in each row's menu. */
+  conversationGroups?: ConversationGroup[];
+  /** Move a conversation into an existing custom group. */
+  onMoveToGroup?: (conversation: Conversation, groupId: string) => void;
+  /** Create a new custom group (via "New group…") and move the conversation in. */
+  onCreateGroupInto?: (conversation: Conversation) => void;
+  /** Remove a conversation from its current custom group (back to Recents). */
+  onRemoveFromGroup?: (conversation: Conversation) => void;
 
   /** Drag-reorder controller; rows derive their own drag props from it. */
   dragReorder: UseDragReorderResult<Conversation>;

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -84,6 +84,8 @@ export interface ConversationNavSectionProps extends ConversationRowListProps {
   icon?: LucideIcon;
   trailing?: ReactNode;
   contextMenuContent?: ReactNode;
+  /** Activity dot shown in the header only while the section is collapsed. */
+  collapsedIndicator?: ReactNode;
 }
 
 export function ConversationNavSection({
@@ -92,6 +94,7 @@ export function ConversationNavSection({
   icon,
   trailing,
   contextMenuContent,
+  collapsedIndicator,
   ...listProps
 }: ConversationNavSectionProps) {
   return (
@@ -101,6 +104,7 @@ export function ConversationNavSection({
       label={label}
       trailing={trailing}
       contextMenuContent={contextMenuContent}
+      collapsedIndicator={collapsedIndicator}
     >
       <ConversationRowList {...listProps} />
     </CollapsibleNavSection.Section>

--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -93,7 +93,11 @@ export function buildMenuProps(
         ? () => ctx.onMarkUnread?.(conversation)
         : undefined,
     isMarkUnreadDisabled: !canMarkUnread(conversation),
-    moveToGroups: buildMoveToGroupTargets(conversation, ctx.conversationGroups),
+    // Only compute targets when the move action is wired — the rail flyout and
+    // other unwired surfaces skip this per-row allocation.
+    moveToGroups: ctx.onMoveToGroup
+      ? buildMoveToGroupTargets(conversation, ctx.conversationGroups)
+      : undefined,
     onMoveToGroup: ctx.onMoveToGroup
       ? (groupId) => ctx.onMoveToGroup?.(conversation, groupId)
       : undefined,

--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -36,7 +36,11 @@ import {
 } from "@/domains/chat/components/thread-status-indicator";
 import type { DragReorderItemProps } from "@/domains/chat/hooks/use-drag-reorder";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
-import { isConversationPinned } from "@/domains/chat/utils/group-conversations";
+import {
+  buildMoveToGroupTargets,
+  isConversationPinned,
+  isInCustomGroup,
+} from "@/domains/chat/utils/group-conversations";
 import type { Conversation } from "@/types/conversation-types";
 import { canMarkRead, canMarkUnread } from "@/utils/conversation-predicates";
 import { isPointerCoarse } from "@/utils/pointer";
@@ -89,6 +93,17 @@ export function buildMenuProps(
         ? () => ctx.onMarkUnread?.(conversation)
         : undefined,
     isMarkUnreadDisabled: !canMarkUnread(conversation),
+    moveToGroups: buildMoveToGroupTargets(conversation, ctx.conversationGroups),
+    onMoveToGroup: ctx.onMoveToGroup
+      ? (groupId) => ctx.onMoveToGroup?.(conversation, groupId)
+      : undefined,
+    onCreateGroupInto: ctx.onCreateGroupInto
+      ? () => ctx.onCreateGroupInto?.(conversation)
+      : undefined,
+    onRemoveFromGroup:
+      ctx.onRemoveFromGroup && isInCustomGroup(conversation)
+        ? () => ctx.onRemoveFromGroup?.(conversation)
+        : undefined,
     onOpenInNewWindow:
       ctx.onOpenInNewWindow && hasId
         ? () => ctx.onOpenInNewWindow?.(conversation)

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -337,6 +337,17 @@ export function useConversationActions({
     [assistantId, prePinGroupIdsRef, moveToGroupMutation],
   );
 
+  /**
+   * Remove a conversation from its current custom group, returning it to
+   * Recents (`"system:all"`). Reuses the move-to-group optimistic path.
+   */
+  const handleRemoveFromGroup = useCallback(
+    (conversation: Conversation) => {
+      handleMoveToGroup(conversation, "system:all");
+    },
+    [handleMoveToGroup],
+  );
+
   const handleTogglePinConversation = useCallback(
     (conversation: Conversation) => {
       const currentlyPinned =
@@ -495,6 +506,8 @@ export function useConversationActions({
     handleMarkConversationUnread,
     handleMarkConversationRead,
     handleTogglePinConversation,
+    handleMoveToGroup,
+    handleRemoveFromGroup,
     handleRenameConversation,
     handleReorderConversations,
     handleMarkAllReadInGroup,

--- a/clients/web/src/domains/chat/hooks/use-conversation-group-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-group-actions.ts
@@ -76,15 +76,15 @@ export function useConversationGroupActions({
   });
 
   const handleCreateGroup = useCallback(async (): Promise<ConversationGroup | null> => {
-    if (!assistantId) return null;
+    if (!assistantId) {return null;}
     haptic.light();
     const name =
       typeof window === "undefined"
         ? null
         : window.prompt("New group name");
-    if (name == null) return null;
+    if (name == null) {return null;}
     const trimmed = name.trim();
-    if (!trimmed) return null;
+    if (!trimmed) {return null;}
 
     const groupsKey = groupsGetQueryKey({ path: { assistant_id: assistantId } });
     await queryClient.cancelQueries({ queryKey: groupsKey });

--- a/clients/web/src/domains/chat/hooks/use-conversation-group-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-group-actions.ts
@@ -75,16 +75,16 @@ export function useConversationGroupActions({
     },
   });
 
-  const handleCreateGroup = useCallback(async () => {
-    if (!assistantId) return;
+  const handleCreateGroup = useCallback(async (): Promise<ConversationGroup | null> => {
+    if (!assistantId) return null;
     haptic.light();
     const name =
       typeof window === "undefined"
         ? null
         : window.prompt("New group name");
-    if (name == null) return;
+    if (name == null) return null;
     const trimmed = name.trim();
-    if (!trimmed) return;
+    if (!trimmed) return null;
 
     const groupsKey = groupsGetQueryKey({ path: { assistant_id: assistantId } });
     await queryClient.cancelQueries({ queryKey: groupsKey });
@@ -98,8 +98,10 @@ export function useConversationGroupActions({
         body: { name: trimmed },
       } as Options<GroupsPostData>);
       replaceOptimisticGroup(queryClient, assistantId, optimisticId, created);
+      return created;
     } catch {
       removeGroup(queryClient, assistantId, optimisticId);
+      return null;
     } finally {
       void queryClient.invalidateQueries({ queryKey: groupsKey });
     }

--- a/clients/web/src/domains/chat/sidebar-collapse-store.test.ts
+++ b/clients/web/src/domains/chat/sidebar-collapse-store.test.ts
@@ -8,6 +8,7 @@ function resetStore() {
     assistantId: null,
     openCategories: [],
     openCustomGroups: [],
+    openPrimary: ["pinned", "recents"],
     backgroundActivated: false,
     scheduledActivated: false,
   });
@@ -123,6 +124,33 @@ describe("SidebarCollapseStore", () => {
       "scheduled",
     ]);
     expect(localStorage.length).toBe(0);
+  });
+
+  test("openPrimary defaults to Pinned + Chats open when nothing is stored", () => {
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+    expect(useSidebarCollapseStore.getState().openPrimary).toEqual([
+      "pinned",
+      "recents",
+    ]);
+  });
+
+  test("setOpenPrimary persists to localStorage", () => {
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+    useSidebarCollapseStore.getState().setOpenPrimary(["pinned"]);
+
+    const raw = localStorage.getItem("vellum:sidebar-open-primary:asst-1");
+    expect(JSON.parse(raw!)).toEqual(["pinned"]);
+    expect(useSidebarCollapseStore.getState().openPrimary).toEqual(["pinned"]);
+  });
+
+  test("setAssistantId hydrates a collapsed primary section from storage", () => {
+    // Stored empty array = user collapsed both; must not fall back to open.
+    localStorage.setItem(
+      "vellum:sidebar-open-primary:asst-1",
+      JSON.stringify([]),
+    );
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+    expect(useSidebarCollapseStore.getState().openPrimary).toEqual([]);
   });
 });
 

--- a/clients/web/src/domains/chat/sidebar-collapse-store.ts
+++ b/clients/web/src/domains/chat/sidebar-collapse-store.ts
@@ -121,19 +121,19 @@ const useSidebarCollapseStoreBase = create<SidebarCollapseStore>()(
           prev.scheduledActivated || next.includes("scheduled"),
       }));
       const { assistantId } = get();
-      if (assistantId) saveOpenCategories(assistantId, next);
+      if (assistantId) {saveOpenCategories(assistantId, next);}
     },
 
     setOpenCustomGroups: (next: string[]) => {
       set({ openCustomGroups: next });
       const { assistantId } = get();
-      if (assistantId) saveOpenCustomGroups(assistantId, next);
+      if (assistantId) {saveOpenCustomGroups(assistantId, next);}
     },
 
     setOpenPrimary: (next: string[]) => {
       set({ openPrimary: next });
       const { assistantId } = get();
-      if (assistantId) saveOpenPrimary(assistantId, next);
+      if (assistantId) {saveOpenPrimary(assistantId, next);}
     },
 
     activateBackground: () => {

--- a/clients/web/src/domains/chat/sidebar-collapse-store.ts
+++ b/clients/web/src/domains/chat/sidebar-collapse-store.ts
@@ -25,6 +25,7 @@ import {
   loadOpenCategories,
   loadOpenCustomGroups,
   loadOpenPrimary,
+  PRIMARY_SECTION_KEYS,
   saveOpenCategories,
   saveOpenCustomGroups,
   saveOpenPrimary,
@@ -82,7 +83,7 @@ const INITIAL_STATE: SidebarCollapseState = {
   openCustomGroups: [],
   // Pinned + Chats start open; the real per-assistant value loads on
   // setAssistantId.
-  openPrimary: ["pinned", "recents"],
+  openPrimary: [...PRIMARY_SECTION_KEYS],
   backgroundActivated: false,
   scheduledActivated: false,
 };

--- a/clients/web/src/domains/chat/sidebar-collapse-store.ts
+++ b/clients/web/src/domains/chat/sidebar-collapse-store.ts
@@ -24,8 +24,10 @@ import { createSelectors } from "@/utils/create-selectors";
 import {
   loadOpenCategories,
   loadOpenCustomGroups,
+  loadOpenPrimary,
   saveOpenCategories,
   saveOpenCustomGroups,
+  saveOpenPrimary,
 } from "@/domains/chat/utils/sidebar-group-collapse-storage";
 
 // ---------------------------------------------------------------------------
@@ -36,6 +38,11 @@ export interface SidebarCollapseState {
   assistantId: string | null;
   openCategories: string[];
   openCustomGroups: string[];
+  /**
+   * Open state of the always-present primary sections (Pinned, Chats).
+   * Defaults to both open (see {@link loadOpenPrimary}).
+   */
+  openPrimary: string[];
   /**
    * Whether the user has revealed the Background section this session —
    * either by expanding it in the full sidebar or opening its rail flyout.
@@ -57,6 +64,7 @@ export interface SidebarCollapseActions {
   setAssistantId: (assistantId: string) => void;
   setOpenCategories: (next: string[]) => void;
   setOpenCustomGroups: (next: string[]) => void;
+  setOpenPrimary: (next: string[]) => void;
   activateBackground: () => void;
   activateScheduled: () => void;
 }
@@ -72,6 +80,9 @@ const INITIAL_STATE: SidebarCollapseState = {
   assistantId: null,
   openCategories: [],
   openCustomGroups: [],
+  // Pinned + Chats start open; the real per-assistant value loads on
+  // setAssistantId.
+  openPrimary: ["pinned", "recents"],
   backgroundActivated: false,
   scheduledActivated: false,
 };
@@ -91,6 +102,7 @@ const useSidebarCollapseStoreBase = create<SidebarCollapseStore>()(
         assistantId,
         openCategories,
         openCustomGroups: loadOpenCustomGroups(assistantId),
+        openPrimary: loadOpenPrimary(assistantId),
         // A persisted expanded section counts as a reveal, so each lazy
         // fetch resumes for assistants the user already had that section
         // open on — tracked per section so they stay independent.
@@ -115,6 +127,12 @@ const useSidebarCollapseStoreBase = create<SidebarCollapseStore>()(
       set({ openCustomGroups: next });
       const { assistantId } = get();
       if (assistantId) saveOpenCustomGroups(assistantId, next);
+    },
+
+    setOpenPrimary: (next: string[]) => {
+      set({ openPrimary: next });
+      const { assistantId } = get();
+      if (assistantId) saveOpenPrimary(assistantId, next);
     },
 
     activateBackground: () => {

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -115,8 +115,10 @@ export interface SidebarState {
 
   effectiveOpenCategories: string[];
   effectiveOpenCustomGroups: string[];
+  effectiveOpenPrimary: string[];
   onOpenCategoriesChange: (next: string[]) => void;
   onOpenCustomGroupsChange: (next: string[]) => void;
+  onOpenPrimaryChange: (next: string[]) => void;
 
   /**
    * Reveal the Background section, enabling its lazy fetch. Wired to the
@@ -169,8 +171,10 @@ export function useSidebarState({
 
   const openCategories = useSidebarCollapseStore.use.openCategories();
   const openCustomGroups = useSidebarCollapseStore.use.openCustomGroups();
+  const openPrimary = useSidebarCollapseStore.use.openPrimary();
   const setOpenCategories = useSidebarCollapseStore.use.setOpenCategories();
   const setOpenCustomGroups = useSidebarCollapseStore.use.setOpenCustomGroups();
+  const setOpenPrimary = useSidebarCollapseStore.use.setOpenPrimary();
   const activateBackground = useSidebarCollapseStore.use.activateBackground();
   const activateScheduled = useSidebarCollapseStore.use.activateScheduled();
   const backgroundActivated = useSidebarCollapseStore.use.backgroundActivated();
@@ -336,6 +340,28 @@ export function useSidebarState({
     return [...new Set([...openCustomGroups, ...extra])];
   }, [openCustomGroups, attentionConversationIds, grouped.customGroups]);
 
+  // Pinned and Chats default open, but if the user has collapsed one and a
+  // conversation in it needs attention, force it open (without persisting) so
+  // the attention indicator is reachable — same treatment as the categories.
+  const effectiveOpenPrimary = useMemo(() => {
+    if (!attentionConversationIds || attentionConversationIds.size === 0)
+      return openPrimary;
+    const extra: string[] = [];
+    if (grouped.pinned.length > 0 && hasAttentionIn(grouped.pinned))
+      extra.push("pinned");
+    if (grouped.recents.length > 0 && hasAttentionIn(grouped.recents))
+      extra.push("recents");
+    if (extra.length === 0) return openPrimary;
+    if (extra.every((c) => openPrimary.includes(c))) return openPrimary;
+    return [...new Set([...openPrimary, ...extra])];
+  }, [
+    openPrimary,
+    attentionConversationIds,
+    grouped.pinned,
+    grouped.recents,
+    hasAttentionIn,
+  ]);
+
   return {
     pinned: grouped.pinned,
     scheduled: grouped.scheduled,
@@ -347,8 +373,10 @@ export function useSidebarState({
     customGroups: grouped.customGroups,
     effectiveOpenCategories,
     effectiveOpenCustomGroups,
+    effectiveOpenPrimary,
     onOpenCategoriesChange: setOpenCategories,
     onOpenCustomGroupsChange: setOpenCustomGroups,
+    onOpenPrimaryChange: setOpenPrimary,
     activateBackground,
     backgroundLoading,
     activateScheduled,

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -13,7 +13,7 @@
  * @see {@link https://react.dev/reference/react/useMemo}
  */
 
-import { useCallback, useEffect, useMemo, useState, startTransition } from "react";
+import { useEffect, useMemo, useState, startTransition } from "react";
 
 import type { Conversation, ConversationGroup } from "@/types/conversation-types";
 import { groupConversations, type CustomGroup } from "@/domains/chat/utils/group-conversations";
@@ -97,6 +97,40 @@ function buildPaginatedSection(
       ),
     onShowLess: () => setVisibleCount(() => SIDEBAR_CONVERSATION_LIMIT),
   };
+}
+
+interface AttentionSection {
+  /** The section's collapse key (matches its `CollapsibleNavSection.Section`). */
+  key: string;
+  conversations: Conversation[];
+}
+
+/**
+ * Merge a persisted open-set with any sections that currently hold an
+ * attention-flagged conversation, so their indicator stays reachable even when
+ * the user has collapsed them. The forced-open keys are not persisted. Returns
+ * the original `open` reference when nothing needs forcing so memoized
+ * consumers stay referentially stable.
+ */
+function withAttentionForcedOpen(
+  open: string[],
+  attentionConversationIds: Set<string> | undefined,
+  sections: AttentionSection[],
+): string[] {
+  if (!attentionConversationIds || attentionConversationIds.size === 0) {
+    return open;
+  }
+  const extra = sections
+    .filter((s) =>
+      s.conversations.some((c) =>
+        attentionConversationIds.has(c.conversationId),
+      ),
+    )
+    .map((s) => s.key);
+  if (extra.every((k) => open.includes(k))) {
+    return open;
+  }
+  return [...new Set([...open, ...extra])];
 }
 
 export interface SidebarState {
@@ -283,84 +317,53 @@ export function useSidebarState({
   );
 
   // --- Attention-forced expansion ---
+  //
+  // Each effective-open set force-opens (without persisting) any of its
+  // sections that hold an attention-flagged conversation, via the shared
+  // withAttentionForcedOpen helper. Only the section list differs.
 
-  const hasAttentionIn = useCallback(
-    (convs: Conversation[]) =>
-      attentionConversationIds
-        ? convs.some((c) =>
-            attentionConversationIds.has(c.conversationId),
-          )
-        : false,
-    [attentionConversationIds],
+  const effectiveOpenCategories = useMemo(
+    () =>
+      withAttentionForcedOpen(openCategories, attentionConversationIds, [
+        { key: "scheduled", conversations: grouped.scheduled },
+        { key: "background", conversations: grouped.background },
+        ...grouped.channelSections.map((s) => ({
+          key: channelSectionKey(s.channelId),
+          conversations: s.conversations,
+        })),
+      ]),
+    [
+      openCategories,
+      attentionConversationIds,
+      grouped.scheduled,
+      grouped.background,
+      grouped.channelSections,
+    ],
   );
 
-  const effectiveOpenCategories = useMemo(() => {
-    if (!attentionConversationIds || attentionConversationIds.size === 0)
-      return openCategories;
-    const extra: string[] = [];
-    if (grouped.scheduled.length > 0 && hasAttentionIn(grouped.scheduled))
-      extra.push("scheduled");
-    if (grouped.background.length > 0 && hasAttentionIn(grouped.background))
-      extra.push("background");
-    for (const section of grouped.channelSections) {
-      if (
-        section.conversations.length > 0 &&
-        hasAttentionIn(section.conversations)
-      )
-        extra.push(channelSectionKey(section.channelId));
-    }
-    if (extra.length === 0) return openCategories;
-    if (extra.every((c) => openCategories.includes(c))) return openCategories;
-    return [...new Set([...openCategories, ...extra])];
-  }, [
-    openCategories,
-    attentionConversationIds,
-    grouped.scheduled,
-    grouped.background,
-    grouped.channelSections,
-    hasAttentionIn,
-  ]);
+  const effectiveOpenCustomGroups = useMemo(
+    () =>
+      withAttentionForcedOpen(
+        openCustomGroups,
+        attentionConversationIds,
+        grouped.customGroups.map((g) => ({
+          key: g.id,
+          conversations: g.conversations,
+        })),
+      ),
+    [openCustomGroups, attentionConversationIds, grouped.customGroups],
+  );
 
-  const effectiveOpenCustomGroups = useMemo(() => {
-    if (!attentionConversationIds || attentionConversationIds.size === 0)
-      return openCustomGroups;
-    const extra: string[] = [];
-    for (const group of grouped.customGroups) {
-      if (
-        group.conversations.some((c) =>
-          attentionConversationIds.has(c.conversationId),
-        )
-      ) {
-        extra.push(group.id);
-      }
-    }
-    if (extra.length === 0) return openCustomGroups;
-    if (extra.every((g) => openCustomGroups.includes(g)))
-      return openCustomGroups;
-    return [...new Set([...openCustomGroups, ...extra])];
-  }, [openCustomGroups, attentionConversationIds, grouped.customGroups]);
-
-  // Pinned and Chats default open, but if the user has collapsed one and a
-  // conversation in it needs attention, force it open (without persisting) so
-  // the attention indicator is reachable — same treatment as the categories.
-  const effectiveOpenPrimary = useMemo(() => {
-    if (!attentionConversationIds || attentionConversationIds.size === 0)
-      return openPrimary;
-    const extra: string[] = [];
-    if (grouped.pinned.length > 0 && hasAttentionIn(grouped.pinned))
-      extra.push("pinned");
-    if (grouped.recents.length > 0 && hasAttentionIn(grouped.recents))
-      extra.push("recents");
-    if (extra.length === 0) return openPrimary;
-    if (extra.every((c) => openPrimary.includes(c))) return openPrimary;
-    return [...new Set([...openPrimary, ...extra])];
-  }, [
-    openPrimary,
-    attentionConversationIds,
-    grouped.pinned,
-    grouped.recents,
-    hasAttentionIn,
-  ]);
+  // Pinned and Chats default open; force-open still applies if the user has
+  // collapsed one and a conversation in it needs attention.
+  const effectiveOpenPrimary = useMemo(
+    () =>
+      withAttentionForcedOpen(openPrimary, attentionConversationIds, [
+        { key: "pinned", conversations: grouped.pinned },
+        { key: "recents", conversations: grouped.recents },
+      ]),
+    [openPrimary, attentionConversationIds, grouped.pinned, grouped.recents],
+  );
 
   return {
     pinned: grouped.pinned,

--- a/clients/web/src/domains/chat/utils/group-conversations.test.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.test.ts
@@ -5,7 +5,6 @@ import type { Conversation, ConversationGroup } from "@/types/conversation-types
 import {
   buildMoveToGroupTargets,
   groupConversations,
-  isInCustomGroup,
 } from "@/domains/chat/utils/group-conversations";
 
 function makeConversation(overrides: Partial<Conversation>): Conversation {
@@ -770,20 +769,6 @@ describe("groupConversations · surfaced promotion to recents", () => {
       "pinned-1",
     ]);
     expect(result.recents.map((c) => c.conversationId)).toEqual(["regular"]);
-  });
-});
-
-describe("isInCustomGroup", () => {
-  test("true only when the conversation belongs to a custom group", () => {
-    expect(isInCustomGroup(makeConversation({ groupId: "g_research" }))).toBe(
-      true,
-    );
-    expect(isInCustomGroup(makeConversation({ groupId: "system:pinned" }))).toBe(
-      false,
-    );
-    expect(isInCustomGroup(makeConversation({ groupId: undefined }))).toBe(
-      false,
-    );
   });
 });
 

--- a/clients/web/src/domains/chat/utils/group-conversations.test.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 
 import type { Conversation, ConversationGroup } from "@/types/conversation-types";
-import { groupConversations } from "@/domains/chat/utils/group-conversations";
+import {
+  buildMoveToGroupTargets,
+  groupConversations,
+  isInCustomGroup,
+} from "@/domains/chat/utils/group-conversations";
 
 function makeConversation(overrides: Partial<Conversation>): Conversation {
   return {
@@ -766,5 +770,65 @@ describe("groupConversations · surfaced promotion to recents", () => {
       "pinned-1",
     ]);
     expect(result.recents.map((c) => c.conversationId)).toEqual(["regular"]);
+  });
+});
+
+describe("isInCustomGroup", () => {
+  test("true only when the conversation belongs to a custom group", () => {
+    expect(isInCustomGroup(makeConversation({ groupId: "g_research" }))).toBe(
+      true,
+    );
+    expect(isInCustomGroup(makeConversation({ groupId: "system:pinned" }))).toBe(
+      false,
+    );
+    expect(isInCustomGroup(makeConversation({ groupId: undefined }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("buildMoveToGroupTargets", () => {
+  const research = makeGroup({ id: "g_research", name: "Research" });
+  const ideas = makeGroup({ id: "g_ideas", name: "Ideas" });
+  const systemAll = makeGroup({
+    id: "system:all",
+    name: "Recents",
+    isSystemGroup: true,
+  });
+
+  test("returns every custom group when the conversation is ungrouped", () => {
+    const targets = buildMoveToGroupTargets(
+      makeConversation({ conversationId: "c1" }),
+      [research, ideas],
+    );
+    expect(targets).toEqual([
+      { id: "g_research", name: "Research" },
+      { id: "g_ideas", name: "Ideas" },
+    ]);
+  });
+
+  test("excludes the conversation's current custom group", () => {
+    const targets = buildMoveToGroupTargets(
+      makeConversation({ conversationId: "c1", groupId: "g_research" }),
+      [research, ideas],
+    );
+    expect(targets).toEqual([{ id: "g_ideas", name: "Ideas" }]);
+  });
+
+  test("never includes system groups (only custom folders are targets)", () => {
+    const targets = buildMoveToGroupTargets(
+      makeConversation({ conversationId: "c1" }),
+      [systemAll, research],
+    );
+    expect(targets).toEqual([{ id: "g_research", name: "Research" }]);
+  });
+
+  test("returns an empty list when there are no custom groups", () => {
+    expect(
+      buildMoveToGroupTargets(makeConversation({ conversationId: "c1" }), []),
+    ).toEqual([]);
+    expect(
+      buildMoveToGroupTargets(makeConversation({ conversationId: "c1" })),
+    ).toEqual([]);
   });
 });

--- a/clients/web/src/domains/chat/utils/group-conversations.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.ts
@@ -136,8 +136,43 @@ function compareByDisplayOrder(a: Conversation, b: Conversation): number {
  * True when a `groupId` refers to a non-system (custom) group.
  * System groups use a `"system:"` prefix (e.g. `"system:pinned"`).
  */
-function isCustomGroupId(groupId: string | undefined): groupId is string {
+export function isCustomGroupId(groupId: string | undefined): groupId is string {
   return !!groupId && !groupId.startsWith("system:");
+}
+
+// ---------------------------------------------------------------------------
+// Move-to-group helpers
+// ---------------------------------------------------------------------------
+
+/** A custom group a conversation can be filed into via the "Move to group" menu. */
+export interface MoveToGroupTarget {
+  id: string;
+  name: string;
+}
+
+/** True when a conversation currently belongs to a custom (non-system) group. */
+export function isInCustomGroup(conversation: Conversation): boolean {
+  return isCustomGroupId(conversation.groupId);
+}
+
+/**
+ * Build the "Move to group" targets for a conversation: every custom
+ * (non-system) group except the one it already belongs to.
+ *
+ * System buckets (Pinned, Recents, channel sections) are intentionally
+ * excluded — Pinning has its own menu item, and the rest are derived sections,
+ * not folders an arbitrary conversation can be filed into. This is why the
+ * older `SYSTEM_MOVE_TARGETS` list (removed in #34458) is not restored: with
+ * only custom groups as targets there is nothing to duplicate.
+ */
+export function buildMoveToGroupTargets(
+  conversation: Conversation,
+  groups?: ConversationGroup[],
+): MoveToGroupTarget[] {
+  const currentGroupId = conversation.groupId;
+  return (groups ?? [])
+    .filter((g) => !g.isSystemGroup && g.id !== currentGroupId)
+    .map((g) => ({ id: g.id, name: g.name }));
 }
 
 export function groupConversations(

--- a/clients/web/src/domains/chat/utils/group-conversations.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.ts
@@ -145,10 +145,7 @@ export function isCustomGroupId(groupId: string | undefined): groupId is string 
 // ---------------------------------------------------------------------------
 
 /** A custom group a conversation can be filed into via the "Move to group" menu. */
-export interface MoveToGroupTarget {
-  id: string;
-  name: string;
-}
+export type MoveToGroupTarget = Pick<ConversationGroup, "id" | "name">;
 
 /** True when a conversation currently belongs to a custom (non-system) group. */
 export function isInCustomGroup(conversation: Conversation): boolean {
@@ -161,9 +158,7 @@ export function isInCustomGroup(conversation: Conversation): boolean {
  *
  * System buckets (Pinned, Recents, channel sections) are intentionally
  * excluded — Pinning has its own menu item, and the rest are derived sections,
- * not folders an arbitrary conversation can be filed into. This is why the
- * older `SYSTEM_MOVE_TARGETS` list (removed in #34458) is not restored: with
- * only custom groups as targets there is nothing to duplicate.
+ * not folders an arbitrary conversation can be filed into.
  */
 export function buildMoveToGroupTargets(
   conversation: Conversation,

--- a/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.test.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.test.ts
@@ -3,12 +3,15 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } fr
 import {
   channelSectionKey,
   loadOpenCategories,
+  loadOpenPrimary,
   saveOpenCategories,
+  saveOpenPrimary,
 } from "@/domains/chat/utils/sidebar-group-collapse-storage";
 import { installMemoryStorage } from "@/utils/memory-storage.test-helper";
 
 const ASSISTANT_ID = "asst_123";
 const STORAGE_KEY = `vellum:sidebar-open-categories:${ASSISTANT_ID}`;
+const PRIMARY_STORAGE_KEY = `vellum:sidebar-open-primary:${ASSISTANT_ID}`;
 
 const memoryStorage = installMemoryStorage({ beforeAll, afterAll, beforeEach, afterEach });
 
@@ -102,5 +105,46 @@ describe("saveOpenCategories", () => {
     saveOpenCategories("other_assistant", ["scheduled"]);
     expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["background"]);
     expect(loadOpenCategories("other_assistant")).toEqual(["scheduled"]);
+  });
+});
+
+describe("loadOpenPrimary", () => {
+  test("defaults to both Pinned and Chats open when nothing is stored", () => {
+    expect(loadOpenPrimary(ASSISTANT_ID)).toEqual(["pinned", "recents"]);
+  });
+
+  test("returns an empty array when the user has collapsed both", () => {
+    // A stored empty array is distinct from an absent key — it means the user
+    // explicitly collapsed both sections, so we must NOT fall back to open.
+    memoryStorage.setItem(PRIMARY_STORAGE_KEY, JSON.stringify([]));
+    expect(loadOpenPrimary(ASSISTANT_ID)).toEqual([]);
+  });
+
+  test("returns the stored subset when only one is open", () => {
+    memoryStorage.setItem(PRIMARY_STORAGE_KEY, JSON.stringify(["pinned"]));
+    expect(loadOpenPrimary(ASSISTANT_ID)).toEqual(["pinned"]);
+  });
+
+  test("filters unknown keys", () => {
+    memoryStorage.setItem(
+      PRIMARY_STORAGE_KEY,
+      JSON.stringify(["pinned", "recents", "scheduled", "bogus"]),
+    );
+    expect(loadOpenPrimary(ASSISTANT_ID)).toEqual(["pinned", "recents"]);
+  });
+});
+
+describe("saveOpenPrimary", () => {
+  test("writes under the assistant-scoped primary storage key", () => {
+    saveOpenPrimary(ASSISTANT_ID, ["recents"]);
+    expect(memoryStorage.getItem(PRIMARY_STORAGE_KEY)).toBe(
+      JSON.stringify(["recents"]),
+    );
+    expect(loadOpenPrimary(ASSISTANT_ID)).toEqual(["recents"]);
+  });
+
+  test("persists the collapsed-both state across a reload", () => {
+    saveOpenPrimary(ASSISTANT_ID, []);
+    expect(loadOpenPrimary(ASSISTANT_ID)).toEqual([]);
   });
 });

--- a/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.ts
@@ -16,6 +16,16 @@ const OPEN_CATEGORY_KEYS = new Set([
   "background",
 ]);
 
+/**
+ * The always-present primary sections (Pinned, Chats). Unlike the built-in
+ * categories and custom groups, these default to OPEN.
+ */
+const PRIMARY_SECTION_KEYS = ["pinned", "recents"] as const;
+
+function isKnownPrimaryKey(key: string): boolean {
+  return (PRIMARY_SECTION_KEYS as readonly string[]).includes(key);
+}
+
 /** Prefix marking a collapsible category as a per-channel origin section. */
 const CHANNEL_SECTION_PREFIX = "channel:";
 
@@ -52,6 +62,18 @@ const customGroupsStorage = createKeyedStorageAccessor<string[]>({
   fallback: [],
 });
 
+// Primary sections default to OPEN: the fallback returns both keys, so a
+// first-time user (no stored key) sees Pinned + Chats expanded. A stored empty
+// array is distinct — it means the user explicitly collapsed both — because
+// createKeyedStorageAccessor only falls back when the key is absent.
+const primaryStorage = createKeyedStorageAccessor<string[]>({
+  keyFn: (assistantId) => `vellum:sidebar-open-primary:${assistantId}`,
+  scope: "user",
+  parse: parseStringArray,
+  serialize: JSON.stringify,
+  fallback: [...PRIMARY_SECTION_KEYS],
+});
+
 /** Load open built-in sidebar category keys, filtering stale values. */
 export function loadOpenCategories(assistantId: string): string[] {
   return categoriesStorage.load(assistantId).filter(isKnownCategoryKey);
@@ -73,4 +95,16 @@ export function saveOpenCustomGroups(
   openGroups: string[],
 ): void {
   customGroupsStorage.save(assistantId, openGroups);
+}
+
+/** Load the open primary sections (Pinned, Chats). Defaults to both open. */
+export function loadOpenPrimary(assistantId: string): string[] {
+  return primaryStorage.load(assistantId).filter(isKnownPrimaryKey);
+}
+
+export function saveOpenPrimary(
+  assistantId: string,
+  openPrimary: string[],
+): void {
+  primaryStorage.save(assistantId, openPrimary);
 }

--- a/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.ts
@@ -20,7 +20,7 @@ const OPEN_CATEGORY_KEYS = new Set([
  * The always-present primary sections (Pinned, Chats). Unlike the built-in
  * categories and custom groups, these default to OPEN.
  */
-const PRIMARY_SECTION_KEYS = ["pinned", "recents"] as const;
+export const PRIMARY_SECTION_KEYS = ["pinned", "recents"] as const;
 
 function isKnownPrimaryKey(key: string): boolean {
   return (PRIMARY_SECTION_KEYS as readonly string[]).includes(key);


### PR DESCRIPTION
## Prompt / plan

Investigate why custom conversation groups ("folders") disappeared from the sidebar, then bring them back and make the sidebar sections collapse consistently.

**What happened (from full git history):** Custom groups are still in the code and have been **GA since #35194** — the `conversation-groups-ui` flag was *deleted*, not disabled, so there is nothing to toggle. The feature looks gone because both entry points that *populate* a group were removed independently and never restored:

1. The **"Create group" button** — dropped in #31679 ("port missed sidebar tweaks from platform").
2. The **"Move to group" submenu** — deliberately removed in #34458, on the reasoning that the only remaining *system* target was "Pinned" (a Pin duplicate); but it stripped the *custom-group* targets too.

GA (#35194) then made the display path always-on (`customGroups` renders when non-empty), but with no way to create or assign a group, that section is permanently empty. `handleMoveToGroup` and `handleCreateGroup` already exist and are backend-backed — they were just wired to nothing.

This PR restores/adapts the code #34458 removed (custom-group-scoped) rather than rebuilding. Three commits:

**1. Restore Move to group + collapsible Pinned/Chats (`feat`)**
- **Move to group submenu** on the conversation row (dropdown + right-click + mobile bottom sheet) and the chat header. Lists the custom groups a conversation can move into, plus an always-available **"New group…"** (the *only* create entry point — no standalone button, matching the requested UX) and **"Remove from group"** when it's already in a group.
- Wires the existing `handleMoveToGroup` / `handleCreateGroup` (now returns the created group so create-then-move works) through the list context, layout, and header; adds `handleRemoveFromGroup`.
- **Collapsible Pinned + Chats**, reusing the existing `ConversationNavSection` component so every sidebar section collapses consistently. Both **default to open** and persist per assistant.

**2. Audit cleanups (`refactor`)** — applied a `/simplify` review (reuse / simplification / efficiency / altitude): extract `withAttentionForcedOpen()` so the three `effectiveOpen*` memos share one path; `MoveToGroupTarget = Pick<ConversationGroup, …>`; skip the per-row targets allocation on unwired surfaces; drop a migration-history comment; declare the default-open key set once. Left the three-root collapse store/storage structure as-is (Radix requires a value array per root).

**3. Activity dot on collapsed section headers (`feat`)** — a collapsed section (Pinned, Chats, a channel, or a custom group) shows a small activity dot when it holds a processing/unread conversation. Reuses `getGroupIndicatorState` and the dot the collapsed rail already renders (extracted as `GroupIndicatorDot`), via a generic `collapsedIndicator` slot shown only while collapsed. Complements the existing attention-based auto-open.

**Suggested follow-up (not in this PR):** the "Show less" pagination affordance already exists but only appears once a section is fully expanded (`use-sidebar-state.ts`) — worth making more discoverable separately.

## Test plan

- `bunx tsc --noEmit` — clean.
- `bun run lint` on all changed files — 0 errors.
- `bun test` on the affected suites — **153 pass, 0 fail**, covering:
  - `buildMoveToGroupTargets` (custom-only, current group excluded, no system targets) and `isInCustomGroup`.
  - The submenu render incl. the zero-groups **"New group…"** case, listing existing groups, and conditional **"Remove from group"** (desktop + mobile builders).
  - Default-open primary sections + `loadOpenPrimary`/`saveOpenPrimary` (absent → open, stored `[]` → collapsed) and the collapse store's `setOpenPrimary` persistence/hydration.
  - `GroupIndicatorDot` (null → nothing, pulsing for processing, solid for attention/unread, className merge).
- Manual (recommended before merge): with zero groups, open a conversation's `…` menu → **Move to group → New group…**, name it → conversation moves in and "Your Groups" appears; move a second conversation into the group; use **Remove from group**; collapse/expand Pinned + Chats and reload to confirm persistence and default-open; leave an unread in a collapsed section and confirm the header dot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw7an5eWS7sgUBvdoqw5QK