### PR TITLE
Refresh plans takeover and credit-wall copy

### DIFF
--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.test.tsx
@@ -16,28 +16,53 @@ afterEach(() => {
 });
 
 describe("CreditsExhaustedBanner", () => {
-  test("add-credits mode renders exactly one Add Credits CTA and no Upgrade", () => {
+  test("add-credits-free mode renders exactly one Add credits CTA and no View plans", () => {
     const onAddCredits = mock(() => {});
     const onUpgrade = mock(() => {});
 
     const { getAllByRole, getByRole, queryByRole, getByText } = render(
       <CreditsExhaustedBanner
-        mode="add-credits"
+        mode="add-credits-free"
         onAddCredits={onAddCredits}
         onUpgrade={onUpgrade}
       />,
     );
 
-    expect(getByText(/Your balance has run out/)).toBeTruthy();
+    expect(getByText(/You’ve used all your credits/)).toBeTruthy();
+    expect(
+      getByText("Add credits to continue without changing your plan."),
+    ).toBeTruthy();
     expect(getAllByRole("button").length).toBe(1);
-    expect(queryByRole("button", { name: "Upgrade" })).toBeNull();
+    expect(queryByRole("button", { name: "View plans" })).toBeNull();
 
-    fireEvent.click(getByRole("button", { name: "Add Credits" }));
+    fireEvent.click(getByRole("button", { name: "Add credits" }));
     expect(onAddCredits).toHaveBeenCalledTimes(1);
     expect(onUpgrade).not.toHaveBeenCalled();
   });
 
-  test("upgrade mode renders exactly one Upgrade CTA and no Add Credits", () => {
+  test("add-credits-paid mode renders exactly one Add credits CTA and no View plans", () => {
+    const onAddCredits = mock(() => {});
+    const onUpgrade = mock(() => {});
+
+    const { getAllByRole, getByRole, queryByRole, getByText } = render(
+      <CreditsExhaustedBanner
+        mode="add-credits-paid"
+        onAddCredits={onAddCredits}
+        onUpgrade={onUpgrade}
+      />,
+    );
+
+    expect(getByText(/You’ve used all your credits/)).toBeTruthy();
+    expect(getByText("Add more credits to keep going.")).toBeTruthy();
+    expect(getAllByRole("button").length).toBe(1);
+    expect(queryByRole("button", { name: "View plans" })).toBeNull();
+
+    fireEvent.click(getByRole("button", { name: "Add credits" }));
+    expect(onAddCredits).toHaveBeenCalledTimes(1);
+    expect(onUpgrade).not.toHaveBeenCalled();
+  });
+
+  test("upgrade mode renders exactly one View plans CTA and no Add credits", () => {
     const onAddCredits = mock(() => {});
     const onUpgrade = mock(() => {});
 
@@ -49,11 +74,12 @@ describe("CreditsExhaustedBanner", () => {
       />,
     );
 
-    expect(getByText(/Your balance has run out/)).toBeTruthy();
+    expect(getByText(/You’ve used all your Free credits/)).toBeTruthy();
+    expect(getByText("Upgrade to a higher plan to continue.")).toBeTruthy();
     expect(getAllByRole("button").length).toBe(1);
-    expect(queryByRole("button", { name: "Add Credits" })).toBeNull();
+    expect(queryByRole("button", { name: "Add credits" })).toBeNull();
 
-    fireEvent.click(getByRole("button", { name: "Upgrade" }));
+    fireEvent.click(getByRole("button", { name: "View plans" }));
     expect(onUpgrade).toHaveBeenCalledTimes(1);
     expect(onAddCredits).not.toHaveBeenCalled();
   });

--- a/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
+++ b/clients/web/src/domains/chat/components/credits-exhausted-banner.tsx
@@ -2,6 +2,27 @@
 import { BillingErrorBanner } from "@/domains/chat/components/billing-error-banner";
 import type { CreditPaywallCtaMode } from "@/domains/chat/utils/credit-paywall-cta";
 
+const COPY: Record<
+  CreditPaywallCtaMode,
+  { title: string; subtitle: string; ctaLabel: string }
+> = {
+  upgrade: {
+    title: "You’ve used all your Free credits",
+    subtitle: "Upgrade to a higher plan to continue.",
+    ctaLabel: "View plans",
+  },
+  "add-credits-free": {
+    title: "You’ve used all your credits",
+    subtitle: "Add credits to continue without changing your plan.",
+    ctaLabel: "Add credits",
+  },
+  "add-credits-paid": {
+    title: "You’ve used all your credits",
+    subtitle: "Add more credits to keep going.",
+    ctaLabel: "Add credits",
+  },
+};
+
 interface CreditsExhaustedBannerProps {
   mode: CreditPaywallCtaMode;
   onAddCredits: () => void;
@@ -13,22 +34,14 @@ export function CreditsExhaustedBanner({
   onAddCredits,
   onUpgrade,
 }: CreditsExhaustedBannerProps) {
-  const isUpgrade = mode === "upgrade";
+  const copy = COPY[mode];
   return (
     <BillingErrorBanner
-      ariaLabel={
-        isUpgrade
-          ? "Your balance has run out. Upgrade to a higher plan to continue."
-          : "Your balance has run out. Add credits to continue."
-      }
-      title="💰  Your balance has run out"
-      subtitle={
-        isUpgrade
-          ? "Upgrade to a higher plan to continue."
-          : "Add credits to continue."
-      }
-      ctaLabel={isUpgrade ? "Upgrade" : "Add Credits"}
-      onAction={isUpgrade ? onUpgrade : onAddCredits}
+      ariaLabel={`${copy.title}. ${copy.subtitle}`}
+      title={`💰  ${copy.title}`}
+      subtitle={copy.subtitle}
+      ctaLabel={copy.ctaLabel}
+      onAction={mode === "upgrade" ? onUpgrade : onAddCredits}
       detached={true}
     />
   );

--- a/clients/web/src/domains/chat/utils/credit-paywall-cta.test.ts
+++ b/clients/web/src/domains/chat/utils/credit-paywall-cta.test.ts
@@ -9,21 +9,33 @@ describe("resolveCreditPaywallCta", () => {
     ).toBe("upgrade");
   });
 
-  test("upgrade arm + paid plan → add-credits", () => {
+  test("upgrade arm + paid plan → add-credits-paid", () => {
     expect(
       resolveCreditPaywallCta({ isUpgradeArm: true, isFreePlan: false }),
-    ).toBe("add-credits");
+    ).toBe("add-credits-paid");
   });
 
-  test("upgrade arm + unresolved plan → add-credits", () => {
+  test("upgrade arm + unresolved plan → add-credits-paid", () => {
     expect(
       resolveCreditPaywallCta({ isUpgradeArm: true, isFreePlan: undefined }),
-    ).toBe("add-credits");
+    ).toBe("add-credits-paid");
   });
 
-  test("control arm + free plan → add-credits", () => {
+  test("control arm + free plan → add-credits-free", () => {
     expect(
       resolveCreditPaywallCta({ isUpgradeArm: false, isFreePlan: true }),
-    ).toBe("add-credits");
+    ).toBe("add-credits-free");
+  });
+
+  test("control arm + paid plan → add-credits-paid", () => {
+    expect(
+      resolveCreditPaywallCta({ isUpgradeArm: false, isFreePlan: false }),
+    ).toBe("add-credits-paid");
+  });
+
+  test("control arm + unresolved plan → add-credits-paid", () => {
+    expect(
+      resolveCreditPaywallCta({ isUpgradeArm: false, isFreePlan: undefined }),
+    ).toBe("add-credits-paid");
   });
 });

--- a/clients/web/src/domains/chat/utils/credit-paywall-cta.ts
+++ b/clients/web/src/domains/chat/utils/credit-paywall-cta.ts
@@ -1,13 +1,17 @@
-export type CreditPaywallCtaMode = "add-credits" | "upgrade";
+export type CreditPaywallCtaMode =
+  "add-credits-free" | "add-credits-paid" | "upgrade";
 
 /**
  * Upgrade CTA shows ONLY in the experiment upgrade arm AND for a free-plan
- * org. Control arm, paid plan, or unknown/unresolved plan / unhydrated flags
- * all fall back to Add Credits (today's default for everyone).
+ * org. Everything else gets Add Credits, whose copy differs for free vs paid
+ * orgs; an unknown/unresolved plan / unhydrated flags count as paid.
  */
 export function resolveCreditPaywallCta(args: {
   isUpgradeArm: boolean;
   isFreePlan: boolean | undefined;
 }): CreditPaywallCtaMode {
-  return args.isUpgradeArm && args.isFreePlan === true ? "upgrade" : "add-credits";
+  if (args.isUpgradeArm && args.isFreePlan === true) {
+    return "upgrade";
+  }
+  return args.isFreePlan === true ? "add-credits-free" : "add-credits-paid";
 }

--- a/clients/web/src/domains/settings/billing/plans/plans-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/plans-copy.ts
@@ -25,25 +25,24 @@ export interface PlanTierCopy {
 
 export const PLAN_TIER_COPY: Record<PlanTierKey, PlanTierCopy> = {
   free: {
-    tagline: "Get to know your assistant",
+    tagline: "Get to know your assistant.",
     cta: "Start Free",
     priceCaption: "Forever",
   },
   mighty: {
-    tagline: "Empower your assistant to level you up.",
+    tagline: "More capacity for consistent user.",
     cta: "Power Up",
     priceCaption: "Billed monthly",
     recommended: true,
   },
   super: {
-    tagline: "Give your assistant real muscle to help you grow",
+    tagline: "Stronger performance for heavier workloads.",
     cta: "Go Super",
     priceCaption: "Billed monthly",
     extraFeatures: ["Assistant email and subdomain"],
   },
   ultra: {
-    tagline:
-      "Our most powerful assistant. There's nothing you can't tackle together",
+    tagline: "Our highest level of power and capacity.",
     cta: "Unleash Ultra",
     priceCaption: "Billed monthly",
     extraFeatures: ["Assistant email and subdomain"],

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -335,7 +335,7 @@ function count(html: string, needle: RegExp): number {
 describe("PlansPage — full catalog render", () => {
   test("renders the headline and all four tier names", () => {
     const html = renderStatic(freeSubscription(), fullCatalog());
-    expect(html).toContain("Plans designed to empower you");
+    expect(html).toContain("Give your assistant more power");
     expect(html).toContain("Free");
     expect(html).toContain("Mighty");
     expect(html).toContain("Super");
@@ -367,7 +367,7 @@ describe("PlansPage — full catalog render", () => {
     // Free plan's baseline storage (FREE_STORAGE_GIB).
     expect(html).toContain("4 GB Storage");
     // Credits row, formatted from credits_usd.
-    expect(html).toContain("$25 in credits per month");
+    expect(html).toContain("$25 in credits included");
     // Machine "Computer" labels; a null machine_size renders "Small".
     expect(html).toContain("Small Computer");
     expect(html).toContain("Medium Computer");
@@ -448,7 +448,7 @@ describe("PlansPage — empty catalog (pro-packages flag off)", () => {
     // the pre-redirect markup is the loading spinner.
     const html = renderStatic(freeSubscription(), plansWith([]));
     expect(html).toContain("Loading plans");
-    expect(html).not.toContain("Plans designed to empower you");
+    expect(html).not.toContain("Give your assistant more power");
     expect(html).not.toContain("Mighty");
     expect(html).not.toContain("Power Up");
     expect(html).not.toContain("Custom Plan");

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -97,7 +97,7 @@ function packageFeatures(pkg: ProPackage, extra: readonly string[]): string[] {
   return [
     machineComputerLabel(pkg),
     `${pkg.storage_gib} GB Storage`,
-    `${formatDollars(credits * 100)} in credits per month`,
+    `${formatDollars(credits * 100)} in credits included`,
     ...extra,
   ];
 }
@@ -412,10 +412,10 @@ export function PlansPage() {
               letterSpacing: "1.2px",
             }}
           >
-            Plans designed to empower you
+            Give your assistant more power
           </h1>
           <p className="text-[20px] font-medium text-[var(--content-tertiary)]">
-            Start free. Upgrade when you actually need more.
+            Choose the level that matches how much you want it to take on.
           </p>
         </header>
 


### PR DESCRIPTION
## Summary

Copy update across two surfaces.

**Pro plan takeover** (`/assistant/plans`)
- Title → `Give your assistant more power`
- Subtitle → `Choose the level that matches how much you want it to take on.`
- New taglines for Free / Mighty / Super / Ultra
- Card credits row: `$25 in credits per month` → `$25 in credits included`

**In-chat credit wall**
Three copy variants, per the spec. This needed one behavioural change: the add-credits case previously had a single copy, but the new copy differs for free vs paid orgs. `CreditPaywallCtaMode` widens from `"add-credits" | "upgrade"` to `"add-credits-free" | "add-credits-paid" | "upgrade"`.

| mode | title | subtitle | CTA |
|---|---|---|---|
| `upgrade` | You’ve used all your Free credits | Upgrade to a higher plan to continue. | View plans |
| `add-credits-free` | You’ve used all your credits | Add credits to continue without changing your plan. | Add credits |
| `add-credits-paid` | You’ve used all your credits | Add more credits to keep going. | Add credits |

No new data plumbing — `chat-route-content.tsx` already computed `useIsFreePlan` and passed it to the resolver. The `upgrade` guard is unchanged: it still requires the upgrade arm **and** a confirmed free plan, and an unresolved plan still counts as paid.

## Reviewer notes

- **The taglines also render on the Billing settings tab.** `PLAN_TIER_COPY` is shared with `plan-card.tsx:299` (recommended-upgrade card) and `:470` (current-plan card). Intentional — flagging in case the copy was meant to be takeover-only.
- **Brief copy flip while the plan resolves.** `add-credits-paid` is the fallback for an unresolved plan, so a free org in the control arm shows "Add more credits to keep going." momentarily before settling on the free variant. Same fail-safe direction as the pre-existing upgrade guard; fixing it would mean suppressing the wall until the plan resolves, which changes *when* the wall appears.
- `/month` price labels (`$0/month`, `$30/month`) are deliberately untouched — only the literal phrase "per month" was in scope.
- Paywall titles keep their existing `💰` prefix; only the words changed.
- "More capacity for consistent user." is verbatim from the copy spec, not a typo introduced here.

## Verification

All 7 affected test files pass in isolation via `bun run test:ci` (one file per process — multi-file runs leak `mock.module` and give false failures):

`credit-paywall-cta` · `credits-exhausted-banner` · `billing-error-banner` · `plans-page` · `plans-page-checkout` · `plan-column-card` · `plan-card`

eslint clean. `tsc --noEmit` error set is byte-identical to the pre-change baseline (45 pre-existing errors, all from dangling `@vellumai/service-contracts` worktree symlinks, none in the touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)