### PR TITLE
fix(web): bind Send-anyway bypass to blocked content and plumb the server-side override

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -19351,6 +19351,12 @@ paths:
                     - low
                     - medium
                     - high
+                bypassSecretCheck:
+                  description:
+                    When true, skip the secret-ingress scan for this message only. Set exclusively when the user explicitly
+                    confirms a client-side blocked send (the composer's "Send anyway" action); it is per-message and
+                    never persisted.
+                  type: boolean
                 hidden:
                   description:
                     "When true, persist the user message but suppress it from the UI transcript (it stays in LLM-side history

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -3007,6 +3007,12 @@ export const ROUTES: RouteDefinition[] = [
           "Plugin ids that scope this conversation to a subset of installed plugins (first-party defaults are always available). When present on a message, it sets/updates the conversation's plugin scope (the web client sends it only on the first message of a new chat). null clears the scope to default (all enabled plugins); omitting the field leaves the existing scope unchanged.",
         ),
       riskThreshold: z.enum(VALID_RISK_THRESHOLDS).optional(),
+      bypassSecretCheck: z
+        .boolean()
+        .optional()
+        .describe(
+          'When true, skip the secret-ingress scan for this message only. Set exclusively when the user explicitly confirms a client-side blocked send (the composer\'s "Send anyway" action); it is per-message and never persisted.',
+        ),
       hidden: z
         .boolean()
         .optional()

--- a/clients/web/src/domains/chat/api/messages.test.ts
+++ b/clients/web/src/domains/chat/api/messages.test.ts
@@ -176,6 +176,36 @@ describe("postChatMessage — enabledPlugins wire format", () => {
   });
 });
 
+describe("postChatMessage — bypassSecretCheck wire format", () => {
+  test("includes bypassSecretCheck: true for an explicit Send-anyway override", async () => {
+    await postChatMessage("assistant-1", "conv-key", "user-approved content", {
+      bypassSecretCheck: true,
+    });
+
+    expect(
+      (capturedBody as Record<string, unknown>).bypassSecretCheck,
+    ).toBe(true);
+  });
+
+  test("omits bypassSecretCheck on an ordinary send", async () => {
+    await postChatMessage("assistant-1", "conv-key", "Hello");
+
+    expect(
+      (capturedBody as Record<string, unknown>).bypassSecretCheck,
+    ).toBeUndefined();
+  });
+
+  test("omits bypassSecretCheck when explicitly false", async () => {
+    await postChatMessage("assistant-1", "conv-key", "Hello", {
+      bypassSecretCheck: false,
+    });
+
+    expect(
+      (capturedBody as Record<string, unknown>).bypassSecretCheck,
+    ).toBeUndefined();
+  });
+});
+
 describe("normalizeContentOrder", () => {
   test("converts string-format entries to objects", () => {
     const result = normalizeContentOrder(["text:0", "tool:1", "surface:2"]);

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -431,6 +431,7 @@ export type PostChatMessageOptions = Pick<
   | "inferenceProfile"
   | "enabledPlugins"
   | "hidden"
+  | "bypassSecretCheck"
 > & {
   /** PreChat onboarding context — see the `postChatMessage` docs. */
   onboarding?: PreChatOnboardingContext;
@@ -470,6 +471,7 @@ export async function postChatMessage(
     inferenceProfile,
     enabledPlugins,
     hidden,
+    bypassSecretCheck,
   } = options;
   // Wire-field selection picks exactly one of `conversationId` (0.8.6+
   // strict internal-id lookup) or `conversationKey` (legacy
@@ -543,6 +545,13 @@ export async function postChatMessage(
   // the channel-setup wizard close/hand-off notifications.
   if (hidden) {
     body.hidden = true;
+  }
+  // Single-use override for the daemon's `secret_blocked` ingress guard,
+  // set only when the user explicitly confirmed a client-side blocked send
+  // (the composer's "Send anyway" action). Applies to this message alone —
+  // never persisted, and omitted from every ordinary send.
+  if (bypassSecretCheck) {
+    body.bypassSecretCheck = true;
   }
   const normalizedOnboarding = onboarding
     ? normalizePreChatOnboardingContext(onboarding)

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -27,6 +27,7 @@ import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-
 import { useChatEmptyState } from "@/domains/chat/hooks/use-chat-empty-state";
 import { useComposerSubmit } from "@/domains/chat/hooks/use-composer-submit";
 import { useDraftSecretDetection } from "@/domains/chat/hooks/use-draft-secret-detection";
+import type { SendChatMessageOptions } from "@/domains/chat/hooks/use-send-message";
 import { DiskPressureBannerSlot } from "@/domains/chat/components/disk-pressure-banner-slot";
 import { useRuleEditorBridge } from "@/domains/chat/hooks/use-rule-editor-bridge";
 import { useChatBannerSlots } from "@/domains/chat/hooks/use-chat-banner-slots";
@@ -130,7 +131,11 @@ import { useConversationStore } from "@/stores/conversation-store";
 
 export interface ChatMainPanelProps {
   // Send message (orchestration owns the SSE / queue lifecycle)
-  sendMessage: (content: string, attachments?: DisplayAttachment[]) => Promise<void>;
+  sendMessage: (
+    content: string,
+    attachments?: DisplayAttachment[],
+    opts?: SendChatMessageOptions,
+  ) => Promise<void>;
   handleStopGenerating: () => Promise<void>;
   queuedMessages: DisplayMessage[];
   handleCancelQueuedMessage: (messageId: string) => void;
@@ -805,12 +810,17 @@ export function ChatMainPanel({
     beforeSend: draftSecretDetection.checkBeforeSend,
   });
 
-  // "Send anyway" on the blocked notice: arm the single-use bypass, then
-  // resubmit the exact content that was intercepted.
+  // "Send anyway" on the blocked notice: arm the single-use client bypass
+  // (bound to the exact intercepted content), then resubmit carrying the
+  // daemon-side `bypassSecretCheck` override so the explicit confirmation
+  // is honored end to end instead of resurfacing as a server
+  // `secret_blocked` error. The `beforeSend` gate still runs: if the draft
+  // changed since the block, the content-bound bypass misses, the send
+  // re-blocks, and the override never reaches the wire.
   const { allowOnce: allowSecretSendOnce } = draftSecretDetection;
   const handleSecretSendAnyway = useCallback(() => {
     allowSecretSendOnce();
-    void submitMessage();
+    void submitMessage(undefined, { bypassSecretCheck: true });
   }, [allowSecretSendOnce, submitMessage]);
 
   const handleSelectStarter = useCallback((starter: { prompt: string }) => {

--- a/clients/web/src/domains/chat/components/composer-secret-notice.tsx
+++ b/clients/web/src/domains/chat/components/composer-secret-notice.tsx
@@ -27,7 +27,8 @@ export interface ComposerSecretNoticeProps {
   /**
    * Blocked state only: the user explicitly chose to send despite the
    * warning. The orchestrator arms the detection hook's single-use
-   * `allowOnce()` bypass and re-invokes the composer submit handler.
+   * `allowOnce()` bypass and re-invokes the composer submit handler with
+   * the daemon's per-message `bypassSecretCheck` override.
    */
   onSendAnyway: () => void;
 }
@@ -47,10 +48,11 @@ export interface ComposerSecretNoticeProps {
  * vendor) stays internal and is never rendered. The detected value appears
  * masked only; the full plaintext never reaches the DOM.
  *
- * "Send anyway" is a client-side bypass only: messages that consist
- * entirely of a token are still rejected server-side by the daemon's
- * `secret_blocked` ingress guard and surface through the existing send
- * error path (`api/messages.ts`) — intentionally unchanged here.
+ * "Send anyway" is honored end to end: the orchestrator's handler arms the
+ * detection hook's content-bound single-use bypass and resubmits with the
+ * daemon's per-message `bypassSecretCheck` override, so the explicit
+ * confirmation clears both the client gate and the daemon's
+ * `secret_blocked` ingress guard.
  */
 export function ComposerSecretNotice({
   matches,

--- a/clients/web/src/domains/chat/hooks/use-composer-submit.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-composer-submit.test.tsx
@@ -38,7 +38,11 @@ const uploadedAttachment: UploadedAttachment = {
 
 function renderSubmit(overrides: Partial<UseComposerSubmitParams> = {}) {
   const sendMessage = mock(
-    async (_content: string, _attachments?: DisplayAttachment[]) => {},
+    async (
+      _content: string,
+      _attachments?: DisplayAttachment[],
+      _opts?: { bypassSecretCheck?: boolean },
+    ) => {},
   );
   const { result } = renderHook(() =>
     useComposerSubmit({
@@ -148,6 +152,56 @@ describe("useComposerSubmit beforeSend gate", () => {
     await submit(result);
 
     expect(beforeSend).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("useComposerSubmit bypassSecretCheck plumbing", () => {
+  test("Send-anyway submits forward bypassSecretCheck to sendMessage for that send only", async () => {
+    useComposerStore.getState().setInput(`approved ${SYNTHETIC_PROJECT_KEY}`);
+    // The gate passes (the detection hook consumed its content-bound
+    // allowOnce bypass); the explicit override must ride the send.
+    const beforeSend = mock((_content: string) => true);
+    const { result, sendMessage } = renderSubmit({ beforeSend });
+    await act(async () => {
+      await result.current.submitMessage(undefined, {
+        bypassSecretCheck: true,
+      });
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[2]).toEqual({ bypassSecretCheck: true });
+
+    // The very next ordinary submit carries no override.
+    useComposerStore.getState().setInput("plain follow-up message");
+    await submit(result);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage.mock.calls[1]?.[2]).toBeUndefined();
+  });
+
+  test("an ordinary submit never sets bypassSecretCheck", async () => {
+    useComposerStore.getState().setInput("no override here");
+    const { result, sendMessage } = renderSubmit();
+    await submit(result);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[2]).toBeUndefined();
+  });
+
+  test("a blocking gate keeps the override off the wire entirely", async () => {
+    useComposerStore.getState().setInput(`edited to ${SYNTHETIC_PROJECT_KEY}`);
+    // The draft changed since the block, so the content-bound bypass
+    // missed and the gate re-blocks — the stale Send-anyway click must not
+    // send anything, override or not.
+    const beforeSend = mock((_content: string) => false);
+    const { result, sendMessage } = renderSubmit({ beforeSend });
+    await act(async () => {
+      await result.current.submitMessage(undefined, {
+        bypassSecretCheck: true,
+      });
+    });
+
+    expect(beforeSend).toHaveBeenCalledTimes(1);
     expect(sendMessage).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-composer-submit.ts
+++ b/clients/web/src/domains/chat/hooks/use-composer-submit.ts
@@ -33,7 +33,11 @@ import type { DisplayAttachment } from "@/domains/chat/types/types";
 // ---------------------------------------------------------------------------
 
 export interface UseComposerSubmitParams {
-  sendMessage: (content: string, attachments?: DisplayAttachment[]) => Promise<void>;
+  sendMessage: (
+    content: string,
+    attachments?: DisplayAttachment[],
+    opts?: { bypassSecretCheck?: boolean },
+  ) => Promise<void>;
   inputRef: RefObject<HTMLTextAreaElement | null>;
   scrollToLatest: (opts?: { behavior?: "auto" | "smooth" }) => void;
   isEditing: boolean;
@@ -55,8 +59,21 @@ export interface UseComposerSubmitParams {
 }
 
 export interface ComposerSubmitResult {
-  /** Send a message without requiring a FormEvent. */
-  submitMessage: (inputOverride?: string) => Promise<void>;
+  /**
+   * Send a message without requiring a FormEvent.
+   *
+   * `opts.bypassSecretCheck` forwards the daemon's single-use
+   * secret-ingress override on this send's POST. It is reserved for the
+   * composer secret guard's "Send anyway" handler — the only path where
+   * the user has explicitly confirmed a blocked send — and must never be
+   * set by any other caller. The `beforeSend` gate still runs first, so a
+   * draft edited since the block is re-scanned and re-blocked before the
+   * override could reach the wire.
+   */
+  submitMessage: (
+    inputOverride?: string,
+    opts?: { bypassSecretCheck?: boolean },
+  ) => Promise<void>;
   /** FormEvent wrapper — calls `e.preventDefault()` then `submitMessage()`. */
   handleFormSubmit: (e: FormEvent) => void;
 }
@@ -90,7 +107,10 @@ export function useComposerSubmit({
   }, [typingDisabled, sendDisabled, inputRef]);
 
   // --- Submit logic -------------------------------------------------------
-  const submitMessage = useCallback(async (inputOverride?: string) => {
+  const submitMessage = useCallback(async (
+    inputOverride?: string,
+    opts?: { bypassSecretCheck?: boolean },
+  ) => {
     const input = useComposerStore.getState().input;
     const chatAttachments = useComposerStore.getState().attachments;
     const uploadingCount = selectUploadingCount(chatAttachments);
@@ -159,7 +179,13 @@ export function useComposerSubmit({
         // If undo fails, still send the message as a new one
       }
     }
-    await sendMessage(finalContent, attachmentsToSend);
+    // Forward the secret-check override only when this send explicitly
+    // carries it (the Send-anyway path); ordinary sends never set it.
+    await sendMessage(
+      finalContent,
+      attachmentsToSend,
+      opts?.bypassSecretCheck === true ? { bypassSecretCheck: true } : undefined,
+    );
   }, [sendDisabled, beforeSend, activeConversationId, inputRef, scrollToLatest, isEditing, editingMessageId, assistantId, cancelEditing, canUndoEdit, sendMessage]);
 
   const handleFormSubmit = useCallback((e: FormEvent) => {

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.test.tsx
@@ -249,9 +249,14 @@ describe("useDraftSecretDetection checkBeforeSend", () => {
     expect(result.current.matches).toHaveLength(1);
   });
 
-  test("allowOnce arms a single-use bypass", () => {
+  test("allowOnce arms a single-use bypass for the blocked content", () => {
     seedFlags({ composerSecretGuard: true, hasHydrated: true });
     const { result } = renderDetection();
+
+    act(() => {
+      result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
+    });
+    expect(result.current.sendBlocked).toBe(true);
 
     act(() => {
       result.current.allowOnce();
@@ -263,6 +268,7 @@ describe("useDraftSecretDetection checkBeforeSend", () => {
     expect(allowed).toBe(true);
     expect(result.current.sendBlocked).toBe(false);
 
+    // Single-use: the identical content blocks again without a fresh arm.
     act(() => {
       allowed = result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
     });
@@ -270,16 +276,67 @@ describe("useDraftSecretDetection checkBeforeSend", () => {
     expect(result.current.sendBlocked).toBe(true);
   });
 
-  test("a draft edit invalidates an armed allowOnce bypass", () => {
+  test("the bypass is content-bound: different content is scanned and re-blocked", () => {
     seedFlags({ composerSecretGuard: true, hasHydrated: true });
-    // Never-elapsing debounce: only the synchronous subscription runs, so a
-    // block below proves the edit itself disarmed the bypass.
-    const { result } = renderDetection("conv-1", NEVER_ELAPSES_MS);
+    const { result } = renderDetection();
+
+    // Block on key A, then approve via Send anyway.
+    act(() => {
+      result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
+    });
+    expect(result.current.sendBlocked).toBe(true);
     act(() => {
       result.current.allowOnce();
     });
 
+    // The outgoing content changed to carry key B — the armed bypass must
+    // NOT apply; the synchronous scan runs and blocks key B.
+    let allowed = true;
+    act(() => {
+      allowed = result.current.checkBeforeSend(
+        `send ${SYNTHETIC_GITHUB_TOKEN}`,
+      );
+    });
+    expect(allowed).toBe(false);
+    expect(result.current.sendBlocked).toBe(true);
+    expect(result.current.matches[0]?.value).toBe(SYNTHETIC_GITHUB_TOKEN);
+  });
+
+  test("allowOnce without a recorded block arms nothing", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    const { result } = renderDetection();
+
+    act(() => {
+      result.current.allowOnce();
+    });
+    let allowed = true;
+    act(() => {
+      allowed = result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
+    });
+    expect(allowed).toBe(false);
+    expect(result.current.sendBlocked).toBe(true);
+  });
+
+  test("a draft edit after a block clears sendBlocked and disarms the bypass", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    // Never-elapsing debounce: only the synchronous subscription runs, so
+    // the resets below prove the edit itself cleared the state.
+    const { result } = renderDetection("conv-1", NEVER_ELAPSES_MS);
+    act(() => {
+      result.current.checkBeforeSend(`send ${SYNTHETIC_PROJECT_KEY}`);
+    });
+    expect(result.current.sendBlocked).toBe(true);
+    act(() => {
+      result.current.allowOnce();
+    });
+
+    // The edit clears the blocked state immediately — the notice drops back
+    // to the passive warning — without waiting for the debounced re-scan.
     setDraft(`edited to ${SYNTHETIC_GITHUB_TOKEN}`);
+    expect(result.current.sendBlocked).toBe(false);
+
+    // And the edited content gets a fresh scan + fresh block, even when it
+    // is exactly what a stale bypass might have been armed for.
     let allowed = true;
     act(() => {
       allowed = result.current.checkBeforeSend(

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
@@ -110,16 +110,23 @@ export interface DraftSecretDetectionResult {
    * conversation changes.
    */
   dismiss: () => void;
-  /** True when the most recent {@link checkBeforeSend} blocked a send. */
+  /**
+   * True when the most recent {@link checkBeforeSend} blocked a send.
+   * Cleared as soon as the draft changes — an edited draft always earns a
+   * fresh scan and a fresh explicit confirmation.
+   */
   sendBlocked: boolean;
   /**
    * Pre-send gate: scans the outgoing text and returns whether the send may
    * proceed. Returns false (and sets {@link sendBlocked}) when secrets are
-   * detected and no {@link allowOnce} bypass is armed.
+   * detected. An armed {@link allowOnce} bypass is honored only when the
+   * outgoing text is strictly equal to the content the bypass was armed
+   * for; any other text is scanned as usual.
    */
   checkBeforeSend: (text: string) => boolean;
   /**
-   * Arm a single-use bypass so the next {@link checkBeforeSend} passes.
+   * Arm a single-use bypass bound to the exact content the last
+   * {@link checkBeforeSend} blocked. A no-op when nothing is blocked.
    * Invalidated by any subsequent draft edit, flag flip, or conversation
    * switch — the bypass approves the content as it stood when armed.
    */
@@ -139,7 +146,12 @@ export function useDraftSecretDetection({
   const [dismissedValues, setDismissedValues] =
     useState<ReadonlySet<string>>(EMPTY_VALUE_SET);
   const [sendBlocked, setSendBlocked] = useState(false);
-  const allowOnceRef = useRef(false);
+  // Exact content the last checkBeforeSend intercepted; what allowOnce()
+  // binds its bypass to.
+  const blockedContentRef = useRef<string | null>(null);
+  // Armed single-use bypass, holding the exact content it approves. A
+  // checkBeforeSend for any OTHER text ignores it and scans normally.
+  const allowOnceContentRef = useRef<string | null>(null);
   // Armed on a conversation switch: the next composer input change is the
   // incoming conversation's restored draft (applied by the session store's
   // post-render switch effect), not a keystroke, so it is scanned
@@ -151,7 +163,8 @@ export function useDraftSecretDetection({
   // under one flag state — any transition of either invalidates them.
   // Layout effect: the reset must land before the switched route paints.
   useLayoutEffect(() => {
-    allowOnceRef.current = false;
+    allowOnceContentRef.current = null;
+    blockedContentRef.current = null;
     setSendBlocked(false);
     setDismissedValues(EMPTY_VALUE_SET);
   }, [enabled, conversationId]);
@@ -186,6 +199,7 @@ export function useDraftSecretDetection({
         setDismissedValues((prev) =>
           prev.size === 0 ? prev : EMPTY_VALUE_SET,
         );
+        blockedContentRef.current = null;
         setSendBlocked(false);
       }
     };
@@ -200,11 +214,15 @@ export function useDraftSecretDetection({
       if (state.input === prevState.input) {
         return;
       }
-      // Any draft edit invalidates an armed send bypass — "Send anyway"
-      // approved the content as it stood, not whatever it becomes. The
-      // normal bypass flow consumes the ref synchronously before the send
-      // clears the input, so this only disarms genuinely stale bypasses.
-      allowOnceRef.current = false;
+      // Any draft edit invalidates an armed send bypass AND the blocked
+      // state — "Send anyway" approved the content as it stood, not
+      // whatever it becomes, and an edited draft must earn a fresh scan
+      // and a fresh explicit confirmation. The normal bypass flow consumes
+      // the ref synchronously before the send clears the input, so this
+      // only disarms genuinely stale state.
+      allowOnceContentRef.current = null;
+      blockedContentRef.current = null;
+      setSendBlocked(false);
       if (timer !== null) {
         clearTimeout(timer);
         timer = null;
@@ -233,12 +251,17 @@ export function useDraftSecretDetection({
   const dismiss = useCallback(() => {
     setDismissedValues(new Set(matches.map((m) => m.value)));
     // Dismissing the blocked-send notice acknowledges the interception;
-    // the block state is per-attempt and re-arms on the next send.
+    // the block state is per-attempt and re-arms on the next send. The
+    // recorded blocked content goes with it — a dismissed block can no
+    // longer be approved via allowOnce.
+    blockedContentRef.current = null;
     setSendBlocked(false);
   }, [matches]);
 
   const allowOnce = useCallback(() => {
-    allowOnceRef.current = true;
+    // Bind the bypass to the exact content that was intercepted. Without a
+    // recorded block there is nothing to approve, so nothing is armed.
+    allowOnceContentRef.current = blockedContentRef.current;
     setSendBlocked(false);
   }, []);
 
@@ -247,16 +270,22 @@ export function useDraftSecretDetection({
       if (!enabled) {
         return true;
       }
-      if (allowOnceRef.current) {
-        allowOnceRef.current = false;
+      // Single-use: consumed on this attempt whether or not it applies.
+      const approvedContent = allowOnceContentRef.current;
+      allowOnceContentRef.current = null;
+      if (approvedContent !== null && approvedContent === text) {
+        blockedContentRef.current = null;
         setSendBlocked(false);
         return true;
       }
+      // Anything other than the exact approved content is scanned as usual.
       const found = scanDraftForSecrets(text, true);
       if (found.length === 0) {
+        blockedContentRef.current = null;
         setSendBlocked(false);
         return true;
       }
+      blockedContentRef.current = text;
       setMatches((prev) => (sameMatches(prev, found) ? prev : found));
       setSendBlocked(true);
       return false;

--- a/clients/web/src/domains/chat/hooks/use-send-message.plugins.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-send-message.plugins.test.tsx
@@ -148,3 +148,45 @@ describe("useSendMessage — enabledPlugins send wiring", () => {
     ).toBe(false);
   });
 });
+
+describe("useSendMessage — bypassSecretCheck send wiring", () => {
+  test("forwards the explicit Send-anyway override on that send's POST only", async () => {
+    useAssistantIdentityStore.getState().setIdentity("Assistant", MIN_VERSION);
+    const props = baseProps();
+    const { result } = renderHook(() => useSendMessage(props), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("user-approved send", [], {
+        bypassSecretCheck: true,
+      });
+    });
+    expect((capturedBody as Record<string, unknown>).bypassSecretCheck).toBe(
+      true,
+    );
+
+    // The override is strictly per-send: the next message from the same
+    // hook instance goes out without it.
+    capturedBody = null;
+    await act(async () => {
+      await result.current.sendMessage("ordinary follow-up");
+    });
+    // Reassigning the capture to null above narrows its static type, so
+    // widen through unknown for the post-send assertion.
+    const followupBody = capturedBody as unknown as Record<
+      string,
+      unknown
+    > | null;
+    expect(followupBody).not.toBeNull();
+    expect(followupBody?.bypassSecretCheck).toBeUndefined();
+  });
+
+  test("an ordinary send never sets bypassSecretCheck", async () => {
+    await send(MIN_VERSION);
+
+    expect(
+      (capturedBody as Record<string, unknown>).bypassSecretCheck,
+    ).toBeUndefined();
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -113,6 +113,26 @@ type SendStreamResult =
   | { status: "failed"; error: ChatError };
 
 // ---------------------------------------------------------------------------
+// Send options
+// ---------------------------------------------------------------------------
+
+/** Per-send options for `sendMessage`. */
+export interface SendChatMessageOptions {
+  /**
+   * Persist the message but suppress it from the transcript (drives the
+   * turn LLM-side). Used for machine signals the user never typed.
+   */
+  hidden?: boolean;
+  /**
+   * Single-use override for the daemon's `secret_blocked` ingress guard.
+   * Set ONLY by the composer secret guard's "Send anyway" handler, after
+   * the user explicitly confirmed sending content the client-side scan
+   * blocked. Applies to this send alone and is never persisted.
+   */
+  bypassSecretCheck?: boolean;
+}
+
+// ---------------------------------------------------------------------------
 // Params
 // ---------------------------------------------------------------------------
 
@@ -258,7 +278,7 @@ export function useSendMessage({
   // sendMessageViaStream — low-level POST + polling fallback
   // -------------------------------------------------------------------------
   const sendMessageViaStream = useCallback(
-    async (content: string, epoch: number, turnId: string, attachmentIds: string[] = [], isDraft = false, clientMessageId?: string, isHidden = false): Promise<SendStreamResult> => {
+    async (content: string, epoch: number, turnId: string, attachmentIds: string[] = [], isDraft = false, clientMessageId?: string, isHidden = false, bypassSecretCheck = false): Promise<SendStreamResult> => {
       if (!activeConversationId || !assistantId) {
         return {
           status: "failed",
@@ -331,6 +351,7 @@ export function useSendMessage({
           inferenceProfile: inferenceProfileForSend,
           enabledPlugins: enabledPluginsForSend,
           hidden: isHidden,
+          bypassSecretCheck,
         },
       );
       if (
@@ -547,7 +568,7 @@ export function useSendMessage({
     async (
       content: string,
       attachments: DisplayAttachment[] = [],
-      opts: { hidden?: boolean } = {},
+      opts: SendChatMessageOptions = {},
     ) => {
       // A hidden send (e.g. the onboarding "Let's chat" kickoff) drives a turn
       // and the assistant's reply, but renders NO user bubble: skip the
@@ -555,6 +576,9 @@ export function useSendMessage({
       // always a fresh first message (conversation idle), so they never take the
       // queue path below.
       const isHidden = opts.hidden === true;
+      // Explicit user override from the composer secret guard's "Send
+      // anyway" confirmation — forwarded on this send's POST only.
+      const bypassSecretCheck = opts.bypassSecretCheck === true;
       if (!activeConversationId || !assistantId) {
         setError({ message: "No active conversation. Please try again." });
         return;
@@ -659,7 +683,7 @@ export function useSendMessage({
             assistantId,
             activeConversationId,
             content,
-            { attachmentIds, clientMessageId, hidden: isHidden },
+            { attachmentIds, clientMessageId, hidden: isHidden, bypassSecretCheck },
           );
           if (!postResult.ok) {
             revertQueuedMessage(userMessage.id);
@@ -753,6 +777,7 @@ export function useSendMessage({
           isDraft,
           clientMessageId,
           isHidden,
+          bypassSecretCheck,
         );
 
         if (result.status === "failed") {


### PR DESCRIPTION
## Summary
- allowOnce() is now bound to the exact blocked content — any draft edit clears the blocked state and forces a fresh scan + confirmation (Codex P2 on #38972)
- Send anyway plumbs a single-use bypassSecretCheck through submitMessage/sendMessage/postChatMessage so the explicit override is honored server-side instead of surfacing secret_blocked (Codex P2 on #38972)

Part of plan: composer-secret-guard.md (follow-up to PR 6)