### PR TITLE
refactor(surfaces): single-source the simple lifecycle events, nuke dead surface client protocol

### DIFF
--- a/assistant/src/api/events/ui-surface-undo-result.ts
+++ b/assistant/src/api/events/ui-surface-undo-result.ts
@@ -1,0 +1,27 @@
+/**
+ * `ui_surface_undo_result` SSE event.
+ *
+ * Server → client result of an undo applied to a surface's submitted
+ * action (requested over the `surfaces/:id/undo` HTTP route). Reports
+ * whether the undo succeeded and how many undo entries remain, keyed by
+ * `surfaceId`.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const UISurfaceUndoResultEventSchema = z.object({
+  type: z.literal("ui_surface_undo_result"),
+  conversationId: z.string(),
+  surfaceId: z.string(),
+  success: z.boolean(),
+  /** Number of remaining undo entries after this undo. */
+  remainingUndos: z.number(),
+});
+
+export type UISurfaceUndoResultEvent = z.infer<
+  typeof UISurfaceUndoResultEventSchema
+>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -119,6 +119,7 @@ import { ToolUseStartEventSchema } from "./events/tool-use-start.js";
 import { UISurfaceCompleteEventSchema } from "./events/ui-surface-complete.js";
 import { UISurfaceDismissEventSchema } from "./events/ui-surface-dismiss.js";
 import { UISurfaceShowEventSchema } from "./events/ui-surface-show.js";
+import { UISurfaceUndoResultEventSchema } from "./events/ui-surface-undo-result.js";
 import { UISurfaceUpdateEventSchema } from "./events/ui-surface-update.js";
 import { UsageProgressEventSchema } from "./events/usage-progress.js";
 import { UsageUpdateEventSchema } from "./events/usage-update.js";
@@ -608,6 +609,10 @@ export {
   UISurfaceShowEventSchema,
 } from "./events/ui-surface-show.js";
 export {
+  type UISurfaceUndoResultEvent,
+  UISurfaceUndoResultEventSchema,
+} from "./events/ui-surface-undo-result.js";
+export {
   type UISurfaceUpdateEvent,
   UISurfaceUpdateEventSchema,
 } from "./events/ui-surface-update.js";
@@ -963,6 +968,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   UISurfaceCompleteEventSchema,
   UISurfaceDismissEventSchema,
   UISurfaceShowEventSchema,
+  UISurfaceUndoResultEventSchema,
   UISurfaceUpdateEventSchema,
   UsageProgressEventSchema,
   UsageUpdateEventSchema,

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -96,10 +96,7 @@ import type {
   _SubagentsClientMessages,
   _SubagentsServerMessages,
 } from "./message-types/subagents.js";
-import type {
-  _SurfacesClientMessages,
-  _SurfacesServerMessages,
-} from "./message-types/surfaces.js";
+import type { _SurfacesServerMessages } from "./message-types/surfaces.js";
 import type { _SyncInvalidationServerMessages } from "./message-types/sync.js";
 import type { _UpgradesServerMessages } from "./message-types/upgrades.js";
 import type { _WorkflowsServerMessages } from "./message-types/workflows.js";
@@ -123,7 +120,6 @@ export interface SubagentEvent {
 export type ClientMessage =
   | _ConversationsClientMessages
   | _MessagesClientMessages
-  | _SurfacesClientMessages
   | _IntegrationsClientMessages
   | _ComputerUseClientMessages
   | _HostBrowserClientMessages

--- a/assistant/src/daemon/message-types/surfaces.ts
+++ b/assistant/src/daemon/message-types/surfaces.ts
@@ -1,5 +1,8 @@
 // Surface types, UI surface lifecycle messages.
 
+import type { UISurfaceCompleteEvent } from "../../api/events/ui-surface-complete.js";
+import type { UISurfaceDismissEvent } from "../../api/events/ui-surface-dismiss.js";
+import type { UISurfaceUndoResultEvent } from "../../api/events/ui-surface-undo-result.js";
 import type {
   AnySurfaceData,
   CardSurfaceData,
@@ -96,21 +99,9 @@ export interface SurfaceAction {
   data?: Record<string, unknown>;
 }
 
-// === Client → Server ===
-
-export interface UiSurfaceAction {
-  type: "ui_surface_action";
-  conversationId: string;
-  surfaceId: string;
-  actionId: string;
-  data?: Record<string, unknown>;
-}
-
-export interface UiSurfaceUndoRequest {
-  type: "ui_surface_undo";
-  conversationId: string;
-  surfaceId: string;
-}
+// Surface actions (user clicks) and undo requests are served by the HTTP
+// surface-action routes (`surface-actions`, `surfaces/:id/undo`), not by client
+// messages.
 
 // === Server → Client ===
 
@@ -170,36 +161,16 @@ export interface UiSurfaceUpdate {
   data: Partial<AnySurfaceData>;
 }
 
-export interface UiSurfaceDismiss {
-  type: "ui_surface_dismiss";
-  conversationId: string;
-  surfaceId: string;
-}
-
-export interface UiSurfaceComplete {
-  type: "ui_surface_complete";
-  conversationId: string;
-  surfaceId: string;
-  summary: string;
-  submittedData?: Record<string, unknown>;
-}
-
-export interface UiSurfaceUndoResult {
-  type: "ui_surface_undo_result";
-  conversationId: string;
-  surfaceId: string;
-  success: boolean;
-  /** Number of remaining undo entries after this undo. */
-  remainingUndos: number;
-}
+// `ui_surface_dismiss`, `ui_surface_complete`, and `ui_surface_undo_result` are
+// single-sourced from their canonical `api/events` wire schemas. `ui_surface_show`
+// and `ui_surface_update` retain their strictly-correlated (`surfaceType` ↔ `data`)
+// daemon shapes here, which their producers/consumers depend on.
 
 // --- Domain-level union aliases (consumed by the barrel file) ---
-
-export type _SurfacesClientMessages = UiSurfaceAction | UiSurfaceUndoRequest;
 
 export type _SurfacesServerMessages =
   | UiSurfaceShow
   | UiSurfaceUpdate
-  | UiSurfaceDismiss
-  | UiSurfaceComplete
-  | UiSurfaceUndoResult;
+  | UISurfaceDismissEvent
+  | UISurfaceCompleteEvent
+  | UISurfaceUndoResultEvent;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -330,6 +330,11 @@ export function useStreamEventHandler(
         case "ui_surface_complete":
           handleUISurfaceComplete(event, ctx);
           break;
+        // Surface undo result. The chat handler is a no-op — the undo is driven
+        // through the `surfaces/:id/undo` HTTP route and its response; the web
+        // does not render the broadcast result.
+        case "ui_surface_undo_result":
+          break;
         case "tool_use_start":
           handleToolUseStart(event, ctx);
           break;


### PR DESCRIPTION
## Prompt / plan

Continuation of the event-type unification: make `assistant/src/api/events/*` the single source of truth for server→client hub events. Per the standing rule, each event is liveness-checked and dead types are deleted.

This PR covers the **safe subset** of the `surfaces` domain. Surface events were already partly migrated — `api/events/ui-surface-{show,update,dismiss,complete}.ts` exist and are registered in `AssistantEventSchema` and handled by the web — but `message-types/surfaces.ts` still carried parallel raw interfaces feeding `_SurfacesServerMessages`.

### Reconciled (dedup — api schema already existed, shapes byte-identical)
- `ui_surface_dismiss` → compose `UISurfaceDismissEvent`, drop the duplicate interface
- `ui_surface_complete` → compose `UISurfaceCompleteEvent`, drop the duplicate interface

### Migrated (was the one lifecycle event not yet in the api)
- `ui_surface_undo_result` → added `api/events/ui-surface-undo-result.ts`, registered in `AssistantEventSchema`, repointed the domain union. Carries a `conversationId` (conversation-scoped), so it gets a no-op web switch case (the web drives undo through the `surfaces/:id/undo` HTTP route + response and doesn't render the broadcast result).

### Nuked (dead — HTTP-route superseded)
- `ui_surface_action`, `ui_surface_undo` — surface action clicks and undo requests are served by `surface-action-routes.ts` (`surface-actions`, `surfaces/:id/undo`); no producer, dispatcher, or type consumer remains. `_SurfacesClientMessages` is now empty and removed (with its `ClientMessage` aggregate entry).

### Deliberately deferred to a dedicated follow-up
- `ui_surface_show` / `ui_surface_update` keep their **strictly-correlated** (`surfaceType` ↔ `data`) daemon shapes here. Their producers/consumers (`conversation-surfaces.ts`, `conversation-agent-loop-handlers.ts`) depend on that correlation, whereas the canonical api schemas are **intentionally opaque** (`surfaceType: string`, `data: record`) — documented in `ui-surface-show.ts` as necessary so the `type`-discriminated stream parser doesn't drop messy-but-renderable surfaces. Reconciling that strict→loose divergence needs its own careful per-consumer change, so it's out of scope here.

The surface `data` payload schemas remain single-sourced from `api/surfaces.ts` (unchanged).

## Test plan
- `bun run typecheck:fast` (tsgo) — clean
- `bun test src/api src/__tests__/runtime-events-sse-parity.test.ts src/__tests__/plugin-import-boundary-guard.test.ts` — 39 pass
- `bun test` on the surface suites (`conversation-surfaces-action-delivery`, `conversation-surfaces-task-progress`, `ui-choice-copy-surfaces`) — 73 pass
- `bun run generate:openapi -- --check` — spec unchanged
- web: `bun run openapi-ts` + `bunx tsc --noEmit` — clean (exhaustive stream-event switch satisfied)
- eslint + prettier on changed files

<!-- No new routes added; CLI verb checklist not applicable. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_