### PR TITLE
fix(chat): keep queued messages visible and cancellable

### DIFF
--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -98,6 +98,34 @@ const replaceProfileRoute = ROUTES.find(
   (r) => r.operationId === "config_llm_profiles_replace",
 )!;
 
+const deleteQueuedMessageRoute = ROUTES.find(
+  (r) => r.operationId === "messages_queued_delete",
+)!;
+
+const steerQueuedMessageRoute = ROUTES.find(
+  (r) => r.operationId === "messages_queued_steer",
+)!;
+
+describe("queued message conversation context", () => {
+  test("delete accepts the forwarded conversation header when the query is absent", () => {
+    expect(() =>
+      deleteQueuedMessageRoute.handler({
+        pathParams: { id: "request-1" },
+        headers: { "x-vellum-conversation-id": "missing-conversation" },
+      }),
+    ).toThrow("Conversation not found");
+  });
+
+  test("steer accepts the forwarded conversation header when the query is absent", () => {
+    expect(() =>
+      steerQueuedMessageRoute.handler({
+        pathParams: { id: "request-1" },
+        headers: { "x-vellum-conversation-id": "missing-conversation" },
+      }),
+    ).toThrow("Conversation not found");
+  });
+});
+
 function dispatchLlmContext(messageId: string) {
   return llmContextRoute.handler({ pathParams: { id: messageId } });
 }

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -2041,15 +2041,26 @@ async function handleGetLlmRequestLogContext({
   return normalizeLlmContextLog(log);
 }
 
-function handleDeleteQueuedMessage({
+function resolveQueuedMessageConversationId({
   queryParams = {},
-  pathParams = {},
-}: RouteHandlerArgs) {
-  const conversationId = queryParams.conversationId;
+  body,
+  headers = {},
+}: RouteHandlerArgs): string | undefined {
+  const bodyConversationId = body?.conversationId;
+  const conversationId =
+    queryParams.conversationId ??
+    (typeof bodyConversationId === "string" ? bodyConversationId : undefined) ??
+    headers["x-vellum-conversation-id"];
+  return typeof conversationId === "string" && conversationId.length > 0
+    ? conversationId
+    : undefined;
+}
+
+function handleDeleteQueuedMessage(args: RouteHandlerArgs) {
+  const { pathParams = {} } = args;
+  const conversationId = resolveQueuedMessageConversationId(args);
   if (!conversationId) {
-    throw new BadRequestError(
-      "Missing required query parameter: conversationId",
-    );
+    throw new BadRequestError("Missing required parameter: conversationId");
   }
   const result = deleteQueuedMessage(conversationId, pathParams.id ?? "");
   if (result.removed) {
@@ -2061,17 +2072,10 @@ function handleDeleteQueuedMessage({
   throw new NotFoundError("Queued message not found");
 }
 
-function handleSteerToMessage({
-  queryParams = {},
-  pathParams = {},
-  body,
-}: RouteHandlerArgs) {
-  const conversationId =
-    queryParams.conversationId ??
-    (body && typeof body === "object" && "conversationId" in body
-      ? (body as Record<string, unknown>).conversationId
-      : undefined);
-  if (!conversationId || typeof conversationId !== "string") {
+function handleSteerToMessage(args: RouteHandlerArgs) {
+  const { pathParams = {} } = args;
+  const conversationId = resolveQueuedMessageConversationId(args);
+  if (!conversationId) {
     throw new BadRequestError("Missing required parameter: conversationId");
   }
   const result = steerToMessage(conversationId, pathParams.id ?? "");

--- a/clients/web/src/domains/chat/api/messages.test.ts
+++ b/clients/web/src/domains/chat/api/messages.test.ts
@@ -208,12 +208,38 @@ describe("queued message request context", () => {
   test("sends conversation context in both the query and header when steering", async () => {
     expect(
       await steerToMessage("assistant-1", "conv-1", "request-1"),
-    ).toBe(true);
+    ).toBe("steered");
 
     expect(capturedPostOptions?.query).toEqual({ conversationId: "conv-1" });
     expect(capturedPostOptions?.headers).toEqual({
       "X-Vellum-Conversation-Id": "conv-1",
     });
+  });
+
+  test("classifies semantic steer rejections as not steerable", async () => {
+    for (const status of [400, 404]) {
+      nextPostResult = {
+        data: null,
+        error: { detail: "Cannot steer queued message" },
+        response: new Response(null, { status }),
+      };
+
+      expect(
+        await steerToMessage("assistant-1", "conv-1", "request-1"),
+      ).toBe("not_steerable");
+    }
+  });
+
+  test("classifies server steer failures as retryable request failures", async () => {
+    nextPostResult = {
+      data: null,
+      error: { detail: "Internal error" },
+      response: new Response(null, { status: 500 }),
+    };
+
+    expect(
+      await steerToMessage("assistant-1", "conv-1", "request-1"),
+    ).toBe("request_failed");
   });
 });
 

--- a/clients/web/src/domains/chat/api/messages.test.ts
+++ b/clients/web/src/domains/chat/api/messages.test.ts
@@ -216,18 +216,28 @@ describe("queued message request context", () => {
     });
   });
 
-  test("classifies semantic steer rejections as not steerable", async () => {
-    for (const status of [400, 404]) {
-      nextPostResult = {
-        data: null,
-        error: { detail: "Cannot steer queued message" },
-        response: new Response(null, { status }),
-      };
+  test("classifies a missing queued message as not steerable", async () => {
+    nextPostResult = {
+      data: null,
+      error: { detail: "Queued message not found" },
+      response: new Response(null, { status: 404 }),
+    };
 
-      expect(
-        await steerToMessage("assistant-1", "conv-1", "request-1"),
-      ).toBe("not_steerable");
-    }
+    expect(
+      await steerToMessage("assistant-1", "conv-1", "request-1"),
+    ).toBe("not_steerable");
+  });
+
+  test("restores queue state when the conversation stopped processing", async () => {
+    nextPostResult = {
+      data: null,
+      error: { detail: "Conversation is not currently processing" },
+      response: new Response(null, { status: 400 }),
+    };
+
+    expect(
+      await steerToMessage("assistant-1", "conv-1", "request-1"),
+    ).toBe("request_failed");
   });
 
   test("classifies server steer failures as retryable request failures", async () => {

--- a/clients/web/src/domains/chat/api/messages.test.ts
+++ b/clients/web/src/domains/chat/api/messages.test.ts
@@ -12,12 +12,14 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { client as daemonClient } from "@/generated/daemon/client.gen";
 import {
   fetchConversationMessages,
+  deleteQueuedMessage,
   getChatHistory,
   mapRuntimeToolCalls,
   normalizeContentBlocks,
   normalizeContentOrder,
   postChatMessage,
   RECONCILE_LATEST_PAGE_LIMIT,
+  steerToMessage,
 } from "@/domains/chat/api/messages";
 import { messageText } from "@/domains/chat/utils/message-test-helpers";
 import type {
@@ -43,12 +45,17 @@ function wireMessage(
 // ---------------------------------------------------------------------------
 
 let capturedBody: Record<string, unknown> | null = null;
+let capturedPostOptions: Record<string, unknown> | null = null;
+let capturedDeleteOptions: Record<string, unknown> | null = null;
 let nextPostResult: { data: unknown; error: unknown; response: Response };
 const originalPost = daemonClient.post;
 const originalGet = daemonClient.get;
+const originalDelete = daemonClient.delete;
 
 beforeEach(() => {
   capturedBody = null;
+  capturedPostOptions = null;
+  capturedDeleteOptions = null;
   nextPostResult = {
     data: { accepted: true, messageId: "msg-1" },
     error: null,
@@ -56,15 +63,25 @@ beforeEach(() => {
   };
   daemonClient.post = mock(
     async (options: { body?: Record<string, unknown> }) => {
+      capturedPostOptions = options;
       capturedBody = options.body ?? null;
       return nextPostResult;
     },
   ) as typeof daemonClient.post;
+  daemonClient.delete = mock(async (options: Record<string, unknown>) => {
+    capturedDeleteOptions = options;
+    return {
+      data: { ok: true },
+      error: null,
+      response: new Response(null, { status: 200 }),
+    };
+  }) as typeof daemonClient.delete;
 });
 
 afterEach(() => {
   daemonClient.post = originalPost;
   daemonClient.get = originalGet;
+  daemonClient.delete = originalDelete;
 });
 
 // ---------------------------------------------------------------------------
@@ -173,6 +190,30 @@ describe("postChatMessage — enabledPlugins wire format", () => {
     expect(
       (capturedBody as Record<string, unknown>).enabledPlugins,
     ).toBeUndefined();
+  });
+});
+
+describe("queued message request context", () => {
+  test("sends conversation context in both the query and header when deleting", async () => {
+    expect(
+      await deleteQueuedMessage("assistant-1", "conv-1", "request-1"),
+    ).toBe(true);
+
+    expect(capturedDeleteOptions?.query).toEqual({ conversationId: "conv-1" });
+    expect(capturedDeleteOptions?.headers).toEqual({
+      "X-Vellum-Conversation-Id": "conv-1",
+    });
+  });
+
+  test("sends conversation context in both the query and header when steering", async () => {
+    expect(
+      await steerToMessage("assistant-1", "conv-1", "request-1"),
+    ).toBe(true);
+
+    expect(capturedPostOptions?.query).toEqual({ conversationId: "conv-1" });
+    expect(capturedPostOptions?.headers).toEqual({
+      "X-Vellum-Conversation-Id": "conv-1",
+    });
   });
 });
 

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -739,7 +739,7 @@ export async function steerToMessage(
     if (response?.ok) {
       return "steered";
     }
-    if (response?.status === 400 || response?.status === 404) {
+    if (response?.status === 404) {
       return "not_steerable";
     }
     return "request_failed";

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -719,11 +719,16 @@ function queuedMessageHeaders(conversationId: string) {
  * Steer the assistant to a queued message by aborting the current
  * generation and promoting the message to the head of the queue.
  */
+export type SteerQueuedMessageResult =
+  | "steered"
+  | "not_steerable"
+  | "request_failed";
+
 export async function steerToMessage(
   assistantId: string,
   conversationId: string,
   requestId: string,
-): Promise<boolean> {
+): Promise<SteerQueuedMessageResult> {
   try {
     const { response } = await messagesQueuedByIdSteerPost({
       path: { assistant_id: assistantId, id: requestId },
@@ -731,9 +736,15 @@ export async function steerToMessage(
       headers: queuedMessageHeaders(conversationId),
       throwOnError: false,
     });
-    return response?.ok ?? false;
+    if (response?.ok) {
+      return "steered";
+    }
+    if (response?.status === 400 || response?.status === 404) {
+      return "not_steerable";
+    }
+    return "request_failed";
   } catch {
-    return false;
+    return "request_failed";
   }
 }
 

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -711,6 +711,10 @@ export async function postChatMessage(
   };
 }
 
+function queuedMessageHeaders(conversationId: string) {
+  return { "X-Vellum-Conversation-Id": conversationId };
+}
+
 /**
  * Steer the assistant to a queued message by aborting the current
  * generation and promoting the message to the head of the queue.
@@ -724,6 +728,7 @@ export async function steerToMessage(
     const { response } = await messagesQueuedByIdSteerPost({
       path: { assistant_id: assistantId, id: requestId },
       query: { conversationId },
+      headers: queuedMessageHeaders(conversationId),
       throwOnError: false,
     });
     return response?.ok ?? false;
@@ -746,6 +751,7 @@ export async function deleteQueuedMessage(
     const { response } = await messagesQueuedByIdDelete({
       path: { assistant_id: assistantId, id: requestId },
       query: { conversationId },
+      headers: queuedMessageHeaders(conversationId),
       throwOnError: false,
     });
     return response?.ok ?? false;

--- a/clients/web/src/domains/chat/hooks/use-message-queue.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-message-queue.test.tsx
@@ -40,7 +40,11 @@ import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useMessageQueue } from "@/domains/chat/hooks/use-message-queue";
 import { registerHistoryCachePatcher } from "@/domains/chat/transcript/patch-transcript-messages";
 
-function queuedMessage(id: string, clientMessageId: string): DisplayMessage {
+function queuedMessage(
+  id: string,
+  clientMessageId: string,
+  queuePosition = 1,
+): DisplayMessage {
   return {
     id,
     clientMessageId,
@@ -50,15 +54,15 @@ function queuedMessage(id: string, clientMessageId: string): DisplayMessage {
     contentBlocks: [{ type: "text", text: "Steer me" }],
     timestamp: 1,
     queueStatus: "queued",
-    queuePosition: 1,
+    queuePosition,
   };
 }
 
-function seedQueuedCopies(): void {
+function seedQueuedCopies(queuePosition = 1): void {
   useChatSessionStore.setState({
-    optimisticSends: [queuedMessage("client-1", "client-1")],
+    optimisticSends: [queuedMessage("client-1", "client-1", queuePosition)],
     snapshot: {
-      messages: [queuedMessage("request-1", "client-1")],
+      messages: [queuedMessage("request-1", "client-1", queuePosition)],
       hasMore: false,
       oldestTimestamp: null,
       oldestMessageId: null,
@@ -265,9 +269,9 @@ describe("useMessageQueue", () => {
     ]);
   });
 
-  test("failed steering restores both queued copies", async () => {
+  test("failed steering restores status and position on both queued copies", async () => {
     steerResult = false;
-    seedQueuedCopies();
+    seedQueuedCopies(2);
     const { result } = renderHook(() =>
       useMessageQueue({
         assistantId: "assistant-1",
@@ -284,7 +288,13 @@ describe("useMessageQueue", () => {
       useChatSessionStore.getState().optimisticSends[0]?.queueStatus,
     ).toBe("queued");
     expect(
+      useChatSessionStore.getState().optimisticSends[0]?.queuePosition,
+    ).toBe(2);
+    expect(
       useChatSessionStore.getState().snapshot?.messages[0]?.queueStatus,
     ).toBe("queued");
+    expect(
+      useChatSessionStore.getState().snapshot?.messages[0]?.queuePosition,
+    ).toBe(2);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-message-queue.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-message-queue.test.tsx
@@ -39,6 +39,7 @@ mock.module("@/domains/chat/api/messages", () => ({
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useMessageQueue } from "@/domains/chat/hooks/use-message-queue";
 import { registerHistoryCachePatcher } from "@/domains/chat/transcript/patch-transcript-messages";
+import { useTurnStore } from "@/domains/chat/turn-store";
 
 function queuedMessage(
   id: string,
@@ -80,9 +81,12 @@ beforeEach(() => {
     resolveDelete = resolve;
   });
   registerHistoryCachePatcher(null);
+  useTurnStore.getState().resetTurn();
   useChatSessionStore.setState({
     optimisticSends: [],
     snapshot: null,
+    previousAssistantId: "assistant-1",
+    previousConversationId: "conversation-1",
     pendingQueuedMessageIds: [],
     requestIdToMessageId: new Map(),
     pendingLocalDeletions: new Set(),
@@ -214,6 +218,43 @@ describe("useMessageQueue", () => {
     expect(useChatSessionStore.getState().optimisticSends).toHaveLength(1);
     expect(useChatSessionStore.getState().snapshot?.messages).toHaveLength(1);
     expect(useChatSessionStore.getState().requestIdToMessageId.size).toBe(1);
+  });
+
+  test("does not apply delayed deletion cleanup after navigation", async () => {
+    seedQueuedCopies();
+    useTurnStore.setState({ phase: "thinking", pendingQueuedCount: 1 });
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        assistantId: "assistant-1",
+        activeConversationId: "conversation-1",
+      }),
+    );
+
+    act(() => {
+      result.current.handleCancelQueuedMessage("client-1");
+      useChatSessionStore.getState().switchToConversation({
+        assistantId: "assistant-1",
+        activeConversationId: "conversation-2",
+      });
+      useChatSessionStore.setState({
+        optimisticSends: [queuedMessage("client-2", "client-2")],
+        requestIdToMessageId: new Map([["request-2", "client-2"]]),
+      });
+      useTurnStore.setState({ phase: "thinking", pendingQueuedCount: 1 });
+    });
+
+    await act(async () => {
+      resolveDelete(true);
+      await deletePromise;
+    });
+
+    expect(useChatSessionStore.getState().optimisticSends[0]?.id).toBe(
+      "client-2",
+    );
+    expect(useChatSessionStore.getState().requestIdToMessageId).toEqual(
+      new Map([["request-2", "client-2"]]),
+    );
+    expect(useTurnStore.getState().pendingQueuedCount).toBe(1);
   });
 
   test("keeps an early cancellation visible while its request id is pending", () => {

--- a/clients/web/src/domains/chat/hooks/use-message-queue.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-message-queue.test.tsx
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+const steerCalls: Array<{
+  assistantId: string;
+  conversationId: string;
+  requestId: string;
+}> = [];
+let steerResult = true;
+const deleteCalls: Array<{
+  assistantId: string;
+  conversationId: string;
+  requestId: string;
+}> = [];
+let deletePromise = Promise.resolve(true);
+let resolveDelete: (deleted: boolean) => void = () => {};
+
+mock.module("@/domains/chat/api/messages", () => ({
+  deleteQueuedMessage: (
+    assistantId: string,
+    conversationId: string,
+    requestId: string,
+  ) => {
+    deleteCalls.push({ assistantId, conversationId, requestId });
+    return deletePromise;
+  },
+  steerToMessage: async (
+    assistantId: string,
+    conversationId: string,
+    requestId: string,
+  ) => {
+    steerCalls.push({ assistantId, conversationId, requestId });
+    return steerResult;
+  },
+}));
+
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useMessageQueue } from "@/domains/chat/hooks/use-message-queue";
+import { registerHistoryCachePatcher } from "@/domains/chat/transcript/patch-transcript-messages";
+
+function queuedMessage(id: string, clientMessageId: string): DisplayMessage {
+  return {
+    id,
+    clientMessageId,
+    role: "user",
+    textSegments: ["Steer me"],
+    contentOrder: [{ type: "text", id: "0" }],
+    contentBlocks: [{ type: "text", text: "Steer me" }],
+    timestamp: 1,
+    queueStatus: "queued",
+    queuePosition: 1,
+  };
+}
+
+function seedQueuedCopies(): void {
+  useChatSessionStore.setState({
+    optimisticSends: [queuedMessage("client-1", "client-1")],
+    snapshot: {
+      messages: [queuedMessage("request-1", "client-1")],
+      hasMore: false,
+      oldestTimestamp: null,
+      oldestMessageId: null,
+      seq: 1,
+    },
+    requestIdToMessageId: new Map([["request-1", "client-1"]]),
+  });
+}
+
+beforeEach(() => {
+  steerCalls.length = 0;
+  steerResult = true;
+  deleteCalls.length = 0;
+  deletePromise = new Promise<boolean>((resolve) => {
+    resolveDelete = resolve;
+  });
+  registerHistoryCachePatcher(null);
+  useChatSessionStore.setState({
+    optimisticSends: [],
+    snapshot: null,
+    pendingQueuedMessageIds: [],
+    requestIdToMessageId: new Map(),
+    pendingLocalDeletions: new Set(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  registerHistoryCachePatcher(null);
+});
+
+describe("useMessageQueue", () => {
+  test("keeps a reconciled queued message visible and cancellable", async () => {
+    useChatSessionStore.setState({
+      optimisticSends: [queuedMessage("client-1", "client-1")],
+      requestIdToMessageId: new Map([["request-1", "client-1"]]),
+    });
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        assistantId: "assistant-1",
+        activeConversationId: "conversation-1",
+      }),
+    );
+
+    act(() => {
+      useChatSessionStore.getState().seedSnapshot("conversation-1", {
+        messages: [queuedMessage("request-1", "client-1")],
+        hasMore: false,
+        oldestTimestamp: null,
+        oldestMessageId: null,
+        seq: 1,
+      });
+    });
+
+    expect(useChatSessionStore.getState().optimisticSends).toHaveLength(0);
+    expect(result.current.queuedMessages.map((message) => message.id)).toEqual([
+      "request-1",
+    ]);
+
+    act(() => {
+      result.current.handleCancelQueuedMessage("request-1");
+    });
+    expect(deleteCalls[0]?.requestId).toBe("request-1");
+
+    await act(async () => {
+      resolveDelete(true);
+      await deletePromise;
+    });
+
+    expect(result.current.queuedMessages).toHaveLength(0);
+  });
+
+  test("steers a snapshot-backed queued message by its request id", () => {
+    useChatSessionStore.setState({
+      snapshot: {
+        messages: [queuedMessage("request-1", "client-1")],
+        hasMore: false,
+        oldestTimestamp: null,
+        oldestMessageId: null,
+        seq: 1,
+      },
+    });
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        assistantId: "assistant-1",
+        activeConversationId: "conversation-1",
+      }),
+    );
+
+    expect(result.current.queuedMessages).toHaveLength(1);
+    act(() => {
+      result.current.handleSteerMessage("request-1");
+    });
+
+    expect(steerCalls[0]?.requestId).toBe("request-1");
+    expect(result.current.queuedMessages).toHaveLength(0);
+  });
+
+  test("keeps a queued message visible until deletion is confirmed", async () => {
+    seedQueuedCopies();
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        assistantId: "assistant-1",
+        activeConversationId: "conversation-1",
+      }),
+    );
+
+    act(() => {
+      result.current.handleCancelQueuedMessage("client-1");
+    });
+
+    expect(useChatSessionStore.getState().optimisticSends).toHaveLength(1);
+    expect(useChatSessionStore.getState().snapshot?.messages).toHaveLength(1);
+    expect(deleteCalls).toEqual([
+      {
+        assistantId: "assistant-1",
+        conversationId: "conversation-1",
+        requestId: "request-1",
+      },
+    ]);
+
+    await act(async () => {
+      resolveDelete(true);
+      await deletePromise;
+    });
+
+    expect(useChatSessionStore.getState().optimisticSends).toHaveLength(0);
+    expect(useChatSessionStore.getState().snapshot?.messages).toHaveLength(0);
+    expect(useChatSessionStore.getState().requestIdToMessageId.size).toBe(0);
+  });
+
+  test("leaves a queued message visible when deletion fails", async () => {
+    seedQueuedCopies();
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        assistantId: "assistant-1",
+        activeConversationId: "conversation-1",
+      }),
+    );
+
+    act(() => {
+      result.current.handleCancelQueuedMessage("client-1");
+    });
+    await act(async () => {
+      resolveDelete(false);
+      await deletePromise;
+    });
+
+    expect(useChatSessionStore.getState().optimisticSends).toHaveLength(1);
+    expect(useChatSessionStore.getState().snapshot?.messages).toHaveLength(1);
+    expect(useChatSessionStore.getState().requestIdToMessageId.size).toBe(1);
+  });
+
+  test("keeps an early cancellation visible while its request id is pending", () => {
+    seedQueuedCopies();
+    useChatSessionStore.setState({
+      requestIdToMessageId: new Map(),
+      snapshot: null,
+    });
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        assistantId: "assistant-1",
+        activeConversationId: "conversation-1",
+      }),
+    );
+
+    act(() => {
+      result.current.handleCancelQueuedMessage("client-1");
+    });
+
+    expect(useChatSessionStore.getState().optimisticSends).toHaveLength(1);
+    expect(
+      useChatSessionStore.getState().pendingLocalDeletions.has("client-1"),
+    ).toBe(true);
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  test("steering promotes both optimistic and snapshot copies into the transcript", () => {
+    seedQueuedCopies();
+
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        assistantId: "assistant-1",
+        activeConversationId: "conversation-1",
+      }),
+    );
+
+    act(() => {
+      result.current.handleSteerMessage("client-1");
+    });
+
+    expect(
+      useChatSessionStore.getState().optimisticSends[0]?.queueStatus,
+    ).toBeUndefined();
+    expect(
+      useChatSessionStore.getState().snapshot?.messages[0]?.queueStatus,
+    ).toBeUndefined();
+    expect(steerCalls).toEqual([
+      {
+        assistantId: "assistant-1",
+        conversationId: "conversation-1",
+        requestId: "request-1",
+      },
+    ]);
+  });
+
+  test("failed steering restores both queued copies", async () => {
+    steerResult = false;
+    seedQueuedCopies();
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        assistantId: "assistant-1",
+        activeConversationId: "conversation-1",
+      }),
+    );
+
+    await act(async () => {
+      result.current.handleSteerMessage("client-1");
+      await Promise.resolve();
+    });
+
+    expect(
+      useChatSessionStore.getState().optimisticSends[0]?.queueStatus,
+    ).toBe("queued");
+    expect(
+      useChatSessionStore.getState().snapshot?.messages[0]?.queueStatus,
+    ).toBe("queued");
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-message-queue.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-message-queue.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
+import type { SteerQueuedMessageResult } from "@/domains/chat/api/messages";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 
 const steerCalls: Array<{
@@ -8,7 +9,7 @@ const steerCalls: Array<{
   conversationId: string;
   requestId: string;
 }> = [];
-let steerResult = true;
+let steerResult: SteerQueuedMessageResult = "steered";
 const deleteCalls: Array<{
   assistantId: string;
   conversationId: string;
@@ -40,6 +41,7 @@ import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useMessageQueue } from "@/domains/chat/hooks/use-message-queue";
 import { registerHistoryCachePatcher } from "@/domains/chat/transcript/patch-transcript-messages";
 import { useTurnStore } from "@/domains/chat/turn-store";
+import { useConversationStore } from "@/stores/conversation-store";
 
 function queuedMessage(
   id: string,
@@ -75,13 +77,14 @@ function seedQueuedCopies(queuePosition = 1): void {
 
 beforeEach(() => {
   steerCalls.length = 0;
-  steerResult = true;
+  steerResult = "steered";
   deleteCalls.length = 0;
   deletePromise = new Promise<boolean>((resolve) => {
     resolveDelete = resolve;
   });
   registerHistoryCachePatcher(null);
   useTurnStore.getState().resetTurn();
+  useConversationStore.setState({ activeConversationId: "conversation-1" });
   useChatSessionStore.setState({
     optimisticSends: [],
     snapshot: null,
@@ -236,6 +239,7 @@ describe("useMessageQueue", () => {
         assistantId: "assistant-1",
         activeConversationId: "conversation-2",
       });
+      useConversationStore.setState({ activeConversationId: "conversation-2" });
       useChatSessionStore.setState({
         optimisticSends: [queuedMessage("client-2", "client-2")],
         requestIdToMessageId: new Map([["request-2", "client-2"]]),
@@ -311,7 +315,7 @@ describe("useMessageQueue", () => {
   });
 
   test("failed steering restores status and position on both queued copies", async () => {
-    steerResult = false;
+    steerResult = "request_failed";
     seedQueuedCopies(2);
     const { result } = renderHook(() =>
       useMessageQueue({
@@ -337,5 +341,28 @@ describe("useMessageQueue", () => {
     expect(
       useChatSessionStore.getState().snapshot?.messages[0]?.queuePosition,
     ).toBe(2);
+  });
+
+  test("does not restore a message that is no longer steerable", async () => {
+    steerResult = "not_steerable";
+    seedQueuedCopies();
+    const { result } = renderHook(() =>
+      useMessageQueue({
+        assistantId: "assistant-1",
+        activeConversationId: "conversation-1",
+      }),
+    );
+
+    await act(async () => {
+      result.current.handleSteerMessage("client-1");
+      await Promise.resolve();
+    });
+
+    expect(
+      useChatSessionStore.getState().optimisticSends[0]?.queueStatus,
+    ).toBeUndefined();
+    expect(
+      useChatSessionStore.getState().snapshot?.messages[0]?.queueStatus,
+    ).toBeUndefined();
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-message-queue.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-queue.ts
@@ -27,7 +27,7 @@ import { useComposerStore } from "@/domains/chat/composer-store";
 import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
 import { confirmQueuedMessageDeletion } from "@/domains/chat/queue-cancellation";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
-import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import { messageMatchesKey } from "@/domains/chat/utils/message-identity";
 
 // ---------------------------------------------------------------------------
 // Params
@@ -48,7 +48,7 @@ function requestIdForQueuedMessage(messageId: string): string | undefined {
   return snapshot?.messages.find(
     (message) =>
       message.queueStatus === "queued" &&
-      messageMatchKeys(message).includes(messageId),
+      messageMatchesKey(message, messageId),
   )?.id;
 }
 
@@ -68,7 +68,9 @@ export function useMessageQueue({
       setOptimisticSends((prev) => prev.filter((m) => m.id !== messageId));
       const queueIds = useChatSessionStore.getState().pendingQueuedMessageIds;
       const idx = queueIds.indexOf(messageId);
-      if (idx !== -1) queueIds.splice(idx, 1);
+      if (idx !== -1) {
+        queueIds.splice(idx, 1);
+      }
     },
     [setOptimisticSends],
   );
@@ -119,6 +121,9 @@ export function useMessageQueue({
       }
       const targetRequestId = requestIdForQueuedMessage(messageId);
       if (targetRequestId) {
+        const queuePosition = queuedMessages.find((message) =>
+          messageMatchesKey(message, messageId),
+        )?.queuePosition;
         const patchMessageCopies = (
           updater: (prev: DisplayMessage[]) => DisplayMessage[],
         ) => {
@@ -132,14 +137,14 @@ export function useMessageQueue({
           (ok) => {
             if (!ok) {
               const restoreMessage = (prev: DisplayMessage[]) =>
-                markMessageQueued(prev, messageId);
+                markMessageQueued(prev, messageId, queuePosition);
               patchMessageCopies(restoreMessage);
             }
           },
         );
       }
     },
-    [assistantId, activeConversationId, setOptimisticSends],
+    [assistantId, activeConversationId, queuedMessages, setOptimisticSends],
   );
 
   const handleEditQueueTail = useCallback(() => {

--- a/clients/web/src/domains/chat/hooks/use-message-queue.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-queue.ts
@@ -15,11 +15,19 @@ import {
 } from "react";
 
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
+import type { DisplayMessage } from "@/domains/chat/types/types";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
-import { clearQueueStatus } from "@/domains/chat/utils/stream-updaters/shared";
+import {
+  clearQueueStatus,
+  markMessageQueued,
+} from "@/domains/chat/utils/stream-updaters/shared";
 import { useTurnStore } from "@/domains/chat/turn-store";
-import { deleteQueuedMessage, steerToMessage } from "@/domains/chat/api/messages";
+import { steerToMessage } from "@/domains/chat/api/messages";
 import { useComposerStore } from "@/domains/chat/composer-store";
+import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
+import { confirmQueuedMessageDeletion } from "@/domains/chat/queue-cancellation";
+import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
+import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
 
 // ---------------------------------------------------------------------------
 // Params
@@ -30,6 +38,20 @@ interface UseMessageQueueParams {
   activeConversationId: string | null;
 }
 
+function requestIdForQueuedMessage(messageId: string): string | undefined {
+  const { requestIdToMessageId, snapshot } = useChatSessionStore.getState();
+  for (const [requestId, mappedMessageId] of requestIdToMessageId.entries()) {
+    if (requestId === messageId || mappedMessageId === messageId) {
+      return requestId;
+    }
+  }
+  return snapshot?.messages.find(
+    (message) =>
+      message.queueStatus === "queued" &&
+      messageMatchKeys(message).includes(messageId),
+  )?.id;
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -38,7 +60,7 @@ export function useMessageQueue({
   assistantId,
   activeConversationId,
 }: UseMessageQueueParams) {
-  const optimisticSends = useChatSessionStore.use.optimisticSends();
+  const transcriptMessages = useTranscriptMessages();
   const setOptimisticSends = useChatSessionStore.use.setOptimisticSends();
   /** Remove an optimistically-added queued message and its tracking state. */
   const revertQueuedMessage = useCallback(
@@ -53,10 +75,10 @@ export function useMessageQueue({
 
   const queuedMessages = useMemo(
     () =>
-      optimisticSends
+      transcriptMessages
         .filter((m) => m.role === "user" && m.queueStatus === "queued")
         .sort((a, b) => (a.queuePosition ?? 0) - (b.queuePosition ?? 0)),
-    [optimisticSends],
+    [transcriptMessages],
   );
 
   const handleCancelQueuedMessage = useCallback(
@@ -64,19 +86,21 @@ export function useMessageQueue({
       if (!assistantId || !activeConversationId) {
         return;
       }
-      let targetRequestId: string | undefined;
-      for (const [reqId, mId] of useChatSessionStore.getState().requestIdToMessageId.entries()) {
-        if (mId === messageId) {
-          targetRequestId = reqId;
-          break;
-        }
-      }
-      setOptimisticSends((prev) => prev.filter((m) => m.id !== messageId));
+      const targetRequestId = requestIdForQueuedMessage(messageId);
       if (targetRequestId) {
-        void deleteQueuedMessage(assistantId, activeConversationId, targetRequestId);
+        void confirmQueuedMessageDeletion({
+          assistantId,
+          conversationId: activeConversationId,
+          requestId: targetRequestId,
+          messageId,
+          setOptimisticSends,
+          onDeleted: () => {
+            useChatSessionStore.getState().popRequestIdMapping(targetRequestId);
+            useTurnStore.getState().deleteQueuedMessage();
+          },
+        });
       } else {
         useChatSessionStore.getState().addPendingLocalDeletion(messageId);
-        useTurnStore.getState().deleteQueuedMessage();
       }
     },
     [assistantId, activeConversationId, setOptimisticSends],
@@ -93,25 +117,23 @@ export function useMessageQueue({
       if (!assistantId || !activeConversationId) {
         return;
       }
-      let targetRequestId: string | undefined;
-      for (const [reqId, mId] of useChatSessionStore.getState().requestIdToMessageId.entries()) {
-        if (mId === messageId) {
-          targetRequestId = reqId;
-          break;
-        }
-      }
+      const targetRequestId = requestIdForQueuedMessage(messageId);
       if (targetRequestId) {
-        setOptimisticSends((prev) => clearQueueStatus(prev, messageId));
+        const patchMessageCopies = (
+          updater: (prev: DisplayMessage[]) => DisplayMessage[],
+        ) => {
+          setOptimisticSends(updater);
+          patchTranscriptMessages(updater);
+        };
+        const promoteMessage = (prev: DisplayMessage[]) =>
+          clearQueueStatus(prev, messageId);
+        patchMessageCopies(promoteMessage);
         steerToMessage(assistantId, activeConversationId, targetRequestId).then(
           (ok) => {
             if (!ok) {
-              setOptimisticSends((prev) =>
-                prev.map((m) =>
-                  m.id === messageId
-                    ? { ...m, queueStatus: "queued" as const }
-                    : m,
-                ),
-              );
+              const restoreMessage = (prev: DisplayMessage[]) =>
+                markMessageQueued(prev, messageId);
+              patchMessageCopies(restoreMessage);
             }
           },
         );

--- a/clients/web/src/domains/chat/hooks/use-message-queue.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-queue.ts
@@ -134,8 +134,8 @@ export function useMessageQueue({
           clearQueueStatus(prev, messageId);
         patchMessageCopies(promoteMessage);
         steerToMessage(assistantId, activeConversationId, targetRequestId).then(
-          (ok) => {
-            if (!ok) {
+          (result) => {
+            if (result === "request_failed") {
               const restoreMessage = (prev: DisplayMessage[]) =>
                 markMessageQueued(prev, messageId, queuePosition);
               patchMessageCopies(restoreMessage);

--- a/clients/web/src/domains/chat/hooks/use-send-message-delivery.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-send-message-delivery.test.tsx
@@ -19,22 +19,27 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 import { createElement, type ReactNode } from "react";
 
+import type { PostMessageResult } from "@/domains/chat/api/messages";
+
 // ---------------------------------------------------------------------------
 // Module mocks — control the send seam and stub side-effect-only deps so the
 // test can drive the exact `hasMatchingActiveStream === false` fallback.
 // ---------------------------------------------------------------------------
 const realMessages = await import("@/domains/chat/api/messages");
 
-let postChatMessageMock = mock(async () => ({
+let postChatMessageMock = mock(async (): Promise<PostMessageResult> => ({
   ok: true as const,
   assistantId: "asst-1",
   conversationId: "conv-A",
   messageId: "user-msg-1",
 }));
+let deleteQueuedMessageMock = mock(async () => true);
 
 mock.module("@/domains/chat/api/messages", () => ({
   ...realMessages,
   postChatMessage: (...args: unknown[]) => postChatMessageMock(...(args as [])),
+  deleteQueuedMessage: (...args: unknown[]) =>
+    deleteQueuedMessageMock(...(args as [])),
 }));
 
 // Server-mint gating reads a backwards-compat store; force the legacy path so
@@ -105,17 +110,25 @@ function renderSend(startReconciliationLoop: () => void) {
 }
 
 beforeEach(() => {
-  postChatMessageMock = mock(async () => ({
+  postChatMessageMock = mock(async (): Promise<PostMessageResult> => ({
     ok: true as const,
     assistantId: "asst-1",
     conversationId: "conv-A",
     messageId: "user-msg-1",
   }));
+  deleteQueuedMessageMock = mock(async () => true);
   // Scope check: the send's assistant/conversation must be the active ones so
   // the fallback branch is reached (not short-circuited as inactive).
   useResolvedAssistantsStore.getState().setActiveAssistantId("asst-1");
   useConversationStore.getState().setActiveConversationId("conv-A");
-  useChatSessionStore.setState({ snapshot: null, optimisticSends: [], error: null });
+  useChatSessionStore.setState({
+    snapshot: null,
+    optimisticSends: [],
+    error: null,
+    pendingQueuedMessageIds: [],
+    requestIdToMessageId: new Map(),
+    pendingLocalDeletions: new Set(),
+  });
   // Reset turn phase to idle so a prior test's hidden send (which never calls
   // `endTurn`) can't leave the store "sending" and push the next send onto the
   // queue path instead of the active-send path under test.
@@ -157,5 +170,58 @@ describe("useSendMessage — SSE + reconciliation own delivery (no poll)", () =>
 
     expect(startReconciliationLoop).toHaveBeenCalledTimes(1);
     expect(useChatSessionStore.getState().error).toBeNull();
+  });
+
+  test("an early queue cancellation deletes after the POST supplies its request id", async () => {
+    let resolvePost: (result: PostMessageResult) => void = () => {};
+    postChatMessageMock = mock(
+      () =>
+        new Promise<PostMessageResult>((resolve) => {
+          resolvePost = resolve;
+        }),
+    );
+    useTurnStore.setState({
+      phase: "streaming",
+      activeTurnId: "turn-1",
+    });
+    const { result } = renderSend(() => {});
+    let sendPromise: Promise<void> = Promise.resolve();
+
+    await act(async () => {
+      sendPromise = result.current.sendMessage("cancel this queued message");
+      await Promise.resolve();
+    });
+    const messageId = useChatSessionStore.getState().optimisticSends[0]?.id;
+    if (!messageId) {
+      throw new Error("Expected an optimistic queued message");
+    }
+
+    act(() => {
+      result.current.handleCancelQueuedMessage(messageId);
+    });
+
+    expect(useChatSessionStore.getState().optimisticSends).toHaveLength(1);
+    expect(
+      useChatSessionStore.getState().pendingLocalDeletions.has(messageId),
+    ).toBe(true);
+
+    await act(async () => {
+      resolvePost({
+        ok: true,
+        queued: true,
+        assistantId: "asst-1",
+        conversationId: "conv-A",
+        requestId: "request-1",
+      });
+      await sendPromise;
+    });
+
+    expect(deleteQueuedMessageMock).toHaveBeenCalledWith(
+      "asst-1",
+      "conv-A",
+      "request-1",
+    );
+    expect(useChatSessionStore.getState().optimisticSends).toHaveLength(0);
+    expect(useChatSessionStore.getState().requestIdToMessageId.size).toBe(0);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -72,6 +72,7 @@ import type { UIContext } from "@/domains/chat/turn-selectors";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { getSoundManager } from "@/lib/sounds/sound-manager";
 import { useMessageQueue } from "@/domains/chat/hooks/use-message-queue";
+import { confirmQueuedMessageDeletion } from "@/domains/chat/queue-cancellation";
 import { conversationsByIdCancelPost } from "@/generated/daemon/sdk.gen";
 import type { Conversation } from "@/types/conversation-types";
 import { postChatMessage } from "@/domains/chat/api/messages";
@@ -707,8 +708,25 @@ export function useSendMessage({
             }
             return;
           }
-          if (postResult.requestId) {
-            useChatSessionStore.getState().setRequestIdMapping(postResult.requestId, userMessage.id);
+          const requestId = postResult.requestId;
+          if (requestId) {
+            const sessionStore = useChatSessionStore.getState();
+            sessionStore.setRequestIdMapping(requestId, userMessage.id);
+            if (sessionStore.consumePendingLocalDeletion(userMessage.id)) {
+              await confirmQueuedMessageDeletion({
+                assistantId,
+                conversationId: activeConversationId,
+                requestId,
+                messageId: userMessage.id,
+                setOptimisticSends,
+                onDeleted: () => {
+                  useChatSessionStore
+                    .getState()
+                    .popRequestIdMapping(requestId);
+                  useTurnStore.getState().deleteQueuedMessage();
+                },
+              });
+            }
           }
         } catch (err) {
           captureError(err, { context: "send_message_queue" });

--- a/clients/web/src/domains/chat/queue-cancellation.ts
+++ b/clients/web/src/domains/chat/queue-cancellation.ts
@@ -1,0 +1,40 @@
+import { deleteQueuedMessage } from "@/domains/chat/api/messages";
+import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import { removeQueuedMessage } from "@/domains/chat/utils/stream-updaters/shared";
+
+interface ConfirmQueuedMessageDeletionParams {
+  assistantId: string;
+  conversationId: string;
+  requestId: string;
+  messageId: string;
+  setOptimisticSends: (
+    updater: (prev: DisplayMessage[]) => DisplayMessage[],
+  ) => void;
+  onDeleted: () => void;
+}
+
+export async function confirmQueuedMessageDeletion({
+  assistantId,
+  conversationId,
+  requestId,
+  messageId,
+  setOptimisticSends,
+  onDeleted,
+}: ConfirmQueuedMessageDeletionParams): Promise<boolean> {
+  const deleted = await deleteQueuedMessage(
+    assistantId,
+    conversationId,
+    requestId,
+  );
+  if (!deleted) {
+    return false;
+  }
+
+  const removeMessage = (prev: DisplayMessage[]) =>
+    removeQueuedMessage(prev, messageId);
+  setOptimisticSends(removeMessage);
+  patchTranscriptMessages(removeMessage);
+  onDeleted();
+  return true;
+}

--- a/clients/web/src/domains/chat/queue-cancellation.ts
+++ b/clients/web/src/domains/chat/queue-cancellation.ts
@@ -1,4 +1,5 @@
 import { deleteQueuedMessage } from "@/domains/chat/api/messages";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { removeQueuedMessage } from "@/domains/chat/utils/stream-updaters/shared";
@@ -29,6 +30,12 @@ export async function confirmQueuedMessageDeletion({
   );
   if (!deleted) {
     return false;
+  }
+
+  if (
+    useChatSessionStore.getState().previousConversationId !== conversationId
+  ) {
+    return true;
   }
 
   const removeMessage = (prev: DisplayMessage[]) =>

--- a/clients/web/src/domains/chat/queue-cancellation.ts
+++ b/clients/web/src/domains/chat/queue-cancellation.ts
@@ -1,8 +1,8 @@
 import { deleteQueuedMessage } from "@/domains/chat/api/messages";
-import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { removeQueuedMessage } from "@/domains/chat/utils/stream-updaters/shared";
+import { useConversationStore } from "@/stores/conversation-store";
 
 interface ConfirmQueuedMessageDeletionParams {
   assistantId: string;
@@ -32,9 +32,7 @@ export async function confirmQueuedMessageDeletion({
     return false;
   }
 
-  if (
-    useChatSessionStore.getState().previousConversationId !== conversationId
-  ) {
+  if (useConversationStore.getState().activeConversationId !== conversationId) {
     return true;
   }
 

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
@@ -21,6 +21,19 @@ const SEED: PaginatedHistoryResult = {
   seq: 0,
 };
 
+const queuedSnapshot = (): PaginatedHistoryResult => ({
+  ...SEED,
+  messages: [
+    {
+      id: "req-1",
+      role: "user",
+      queueStatus: "queued",
+      queuePosition: 1,
+    },
+  ],
+  seq: 1,
+});
+
 // `emittedAt` is derived from `seq` so the deterministic creation stamp is
 // `1000 + seq` — the reducer parses it back to that epoch ms.
 function env(seq: number, message: AssistantEvent): AssistantEventEnvelope {
@@ -212,6 +225,31 @@ describe("rolling-snapshot reducer", () => {
       // A stale tail (<= snapshot.seq) folds to nothing.
       const resolved = resolveSnapshot(snapshot, [textDelta(4, "a1", " stale")]);
       expect(resolved.messages.find((m) => m.id === "a1")?.textSegments).toEqual(["x"]);
+    });
+
+    test("replays a dequeue transition onto a queued snapshot row", () => {
+      const resolved = resolveSnapshot(queuedSnapshot(), [
+        env(2, {
+          type: "message_dequeued",
+          conversationId: "conv-1",
+          requestId: "req-1",
+        } as AssistantEvent),
+      ]);
+
+      expect(resolved.messages[0]?.queueStatus).toBeUndefined();
+      expect(resolved.messages[0]?.queuePosition).toBeUndefined();
+    });
+
+    test("replays a queued deletion onto a queued snapshot row", () => {
+      const resolved = resolveSnapshot(queuedSnapshot(), [
+        env(2, {
+          type: "message_queued_deleted",
+          conversationId: "conv-1",
+          requestId: "req-1",
+        } as AssistantEvent),
+      ]);
+
+      expect(resolved.messages).toEqual([]);
     });
   });
 

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
@@ -227,13 +227,19 @@ describe("rolling-snapshot reducer", () => {
       expect(resolved.messages.find((m) => m.id === "a1")?.textSegments).toEqual(["x"]);
     });
 
-    test("removes a nonce-less queued placeholder when replaying a dequeue", () => {
+    test("removes a nonce-less placeholder after an optimistic steer", () => {
       const dequeued = env(2, {
         type: "message_dequeued",
         conversationId: "conv-1",
         requestId: "req-1",
       } as AssistantEvent);
-      const resolved = resolveSnapshot(queuedSnapshot(), [
+      const snapshot = queuedSnapshot();
+      snapshot.messages[0] = {
+        ...snapshot.messages[0]!,
+        queueStatus: undefined,
+        queuePosition: undefined,
+      };
+      const resolved = resolveSnapshot(snapshot, [
         dequeued,
         userEcho(3, "persisted-1", "queued message"),
       ]);

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
@@ -227,7 +227,7 @@ describe("rolling-snapshot reducer", () => {
       expect(resolved.messages.find((m) => m.id === "a1")?.textSegments).toEqual(["x"]);
     });
 
-    test("removes a nonce-less placeholder after an optimistic steer", () => {
+    test("reconciles a nonce-less placeholder after an optimistic steer", () => {
       const dequeued = env(2, {
         type: "message_dequeued",
         conversationId: "conv-1",
@@ -236,16 +236,36 @@ describe("rolling-snapshot reducer", () => {
       const snapshot = queuedSnapshot();
       snapshot.messages[0] = {
         ...snapshot.messages[0]!,
+        attachments: [
+          {
+            id: "attachment-1",
+            filename: "report.pdf",
+            mimeType: "application/pdf",
+            sizeBytes: 1,
+            previewUrl: null,
+          },
+        ],
         queueStatus: undefined,
         queuePosition: undefined,
       };
+      snapshot.messages.push({
+        id: "nonce-2",
+        clientMessageId: "nonce-2",
+        role: "user",
+        isOptimistic: true,
+        queueStatus: "queued",
+        queuePosition: 2,
+      });
       const resolved = resolveSnapshot(snapshot, [
         dequeued,
         userEcho(3, "persisted-1", "queued message"),
       ]);
 
-      expect(resolved.messages).toHaveLength(1);
+      expect(resolved.messages).toHaveLength(2);
       expect(resolved.messages[0]?.id).toBe("persisted-1");
+      expect(resolved.messages[0]?.isOptimistic).toBe(false);
+      expect(resolved.messages[0]?.attachments?.[0]?.id).toBe("attachment-1");
+      expect(resolved.messages[1]?.id).toBe("nonce-2");
     });
 
     test("retains a correlated queued row when replaying a dequeue", () => {

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
@@ -227,8 +227,25 @@ describe("rolling-snapshot reducer", () => {
       expect(resolved.messages.find((m) => m.id === "a1")?.textSegments).toEqual(["x"]);
     });
 
-    test("replays a dequeue transition onto a queued snapshot row", () => {
+    test("removes a nonce-less queued placeholder when replaying a dequeue", () => {
+      const dequeued = env(2, {
+        type: "message_dequeued",
+        conversationId: "conv-1",
+        requestId: "req-1",
+      } as AssistantEvent);
       const resolved = resolveSnapshot(queuedSnapshot(), [
+        dequeued,
+        userEcho(3, "persisted-1", "queued message"),
+      ]);
+
+      expect(resolved.messages).toHaveLength(1);
+      expect(resolved.messages[0]?.id).toBe("persisted-1");
+    });
+
+    test("retains a correlated queued row when replaying a dequeue", () => {
+      const snapshot = queuedSnapshot();
+      snapshot.messages[0]!.clientMessageId = "nonce-1";
+      const resolved = resolveSnapshot(snapshot, [
         env(2, {
           type: "message_dequeued",
           conversationId: "conv-1",

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.ts
@@ -37,7 +37,7 @@ import {
 import { attachConfirmationToToolCall } from "@/domains/chat/utils/chat";
 import { clearConfirmationByRequestId } from "@/domains/chat/utils/send-message-utils";
 import {
-  clearQueueStatus,
+  applyQueuedMessageDequeue,
   removeQueuedMessage,
 } from "@/domains/chat/utils/stream-updaters/shared";
 
@@ -84,7 +84,7 @@ export function appendEventToMessages(
         at,
       );
     case "message_dequeued":
-      return clearQueueStatus(messages, event.requestId);
+      return applyQueuedMessageDequeue(messages, event.requestId);
     case "message_queued_deleted":
       return removeQueuedMessage(messages, event.requestId);
     case "assistant_activity_state":

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.ts
@@ -36,6 +36,10 @@ import {
 } from "@/domains/chat/utils/stream-updaters/surface-updaters";
 import { attachConfirmationToToolCall } from "@/domains/chat/utils/chat";
 import { clearConfirmationByRequestId } from "@/domains/chat/utils/send-message-utils";
+import {
+  clearQueueStatus,
+  removeQueuedMessage,
+} from "@/domains/chat/utils/stream-updaters/shared";
 
 /** Parse the envelope's ISO `emittedAt` to epoch ms, the deterministic stamp
  *  for any row an event opens. Falls back to `seq` so a malformed/absent time
@@ -79,6 +83,10 @@ export function appendEventToMessages(
         },
         at,
       );
+    case "message_dequeued":
+      return clearQueueStatus(messages, event.requestId);
+    case "message_queued_deleted":
+      return removeQueuedMessage(messages, event.requestId);
     case "assistant_activity_state":
       // Only the terminal `idle` phase changes message content (it finalizes
       // running tool calls); other phases drive turn state, not history.
@@ -141,7 +149,9 @@ export function appendEventToMessages(
             : at,
       });
     case "tool_output_chunk":
-      if (!event.chunk) return messages;
+      if (!event.chunk) {
+        return messages;
+      }
       return appendToolOutputChunk(messages, {
         chunk: event.chunk,
         toolUseId: event.toolUseId,
@@ -190,7 +200,7 @@ export function appendEventToMessages(
         : messages;
     default:
       // Total: events that don't change message content (turn lifecycle,
-      // queue, subagent/workflow, sync, unknowns) leave the list untouched.
+      // subagent/workflow, sync, unknowns) leave the list untouched.
       return messages;
   }
 }
@@ -216,8 +226,12 @@ function nextProcessingState(
   event: AssistantEvent,
   seq: number | null | undefined,
 ): boolean | undefined {
-  if (current === undefined) return undefined;
-  if (typeof seq !== "number") return current;
+  if (current === undefined) {
+    return undefined;
+  }
+  if (typeof seq !== "number") {
+    return current;
+  }
   switch (event.type) {
     case "assistant_turn_start":
     case "assistant_text_delta":

--- a/clients/web/src/domains/chat/types/types.ts
+++ b/clients/web/src/domains/chat/types/types.ts
@@ -72,13 +72,13 @@ export interface DisplayMessage {
    */
   id: string;
   /**
-   * True when `id` is a client-generated placeholder rather than a
-   * server-assigned id. Set on optimistic user sends and on assistant
-   * rows born from SSE events that didn't carry `messageId`. Reconcile
-   * uses this as the signal that the row's id can't be matched against
-   * the server snapshot directly; optimistic user rows get a derived-text
-   * match + id swap, optimistic assistant rows are preserved as-is until
-   * a subsequent SSE event or history fetch resolves them.
+   * True when `id` is a transient placeholder rather than a persisted message
+   * id. Set on optimistic user sends, dequeued request-id rows awaiting their
+   * persisted echo, and assistant rows born from SSE events that didn't carry
+   * `messageId`. Reconcile uses this as the signal that the row's id can't be
+   * matched against the server snapshot directly; optimistic user rows get a
+   * derived-text match + id swap, optimistic assistant rows are preserved
+   * as-is until a subsequent SSE event or history fetch resolves them.
    */
   isOptimistic?: boolean;
   /**

--- a/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -97,6 +97,20 @@ describe("text-segment cleaning", () => {
 });
 
 describe("mapRuntimeToDisplayMessage", () => {
+  test("preserves queued-message state from history", () => {
+    const display = mapRuntimeToDisplayMessage(
+      makeMessage({
+        id: "request-1",
+        role: "user",
+        queueStatus: "queued",
+        queuePosition: 2,
+      }),
+    );
+
+    expect(display.queueStatus).toBe("queued");
+    expect(display.queuePosition).toBe(2);
+  });
+
   test("produces clean segments end-to-end for interleaved file attachments", () => {
     const m = makeMessage({
       id: "msg-2",

--- a/clients/web/src/domains/chat/utils/map-runtime-message.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.ts
@@ -165,6 +165,12 @@ export function mapRuntimeToDisplayMessage(
   if (m.slackMessage) msg.slackMessage = m.slackMessage;
   if (toolCalls) msg.toolCalls = toolCalls;
   if (timestamp != null) msg.timestamp = timestamp;
+  if (m.queueStatus) {
+    msg.queueStatus = m.queueStatus;
+  }
+  if (m.queuePosition != null) {
+    msg.queuePosition = m.queuePosition;
+  }
 
   const attachments = structuredAttachments ?? parsedAttachments;
   if (attachments) msg.attachments = attachments;

--- a/clients/web/src/domains/chat/utils/message-identity.ts
+++ b/clients/web/src/domains/chat/utils/message-identity.ts
@@ -40,6 +40,18 @@ export function messageMatchKeys(message: DisplayMessage): string[] {
   return keys;
 }
 
+/** Whether a message matches a server id, merged id, or client nonce. */
+export function messageMatchesKey(
+  message: DisplayMessage,
+  key: string,
+): boolean {
+  return (
+    message.id === key ||
+    message.clientMessageId === key ||
+    (message.mergedMessageIds?.includes(key) ?? false)
+  );
+}
+
 /** Register a message under each of its identity keys (first writer wins). */
 export function indexDisplayMessageByIdentity(
   indexById: Map<string, DisplayMessage>,

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
@@ -100,7 +100,7 @@ describe("handleMessageDequeued", () => {
     expect(ctx.setOptimisticSends).not.toHaveBeenCalled();
   });
 
-  it("removes an uncorrelatable server-backed transcript row", () => {
+  it("marks an uncorrelated transcript row optimistic until its echo", () => {
     useChatSessionStore.setState({
       snapshot: {
         messages: [
@@ -127,7 +127,10 @@ describe("handleMessageDequeued", () => {
       makeCtx(),
     );
 
-    expect(useChatSessionStore.getState().snapshot?.messages).toEqual([]);
+    const message = useChatSessionStore.getState().snapshot?.messages[0];
+    expect(message?.isOptimistic).toBe(true);
+    expect(message?.queueStatus).toBeUndefined();
+    expect(message?.queuePosition).toBeUndefined();
   });
 });
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
@@ -164,6 +164,36 @@ describe("handleMessageQueuedDeleted", () => {
     expect(ctx.turnActions.deleteQueuedMessage).toHaveBeenCalled();
     expect(ctx.setOptimisticSends).not.toHaveBeenCalled();
   });
+
+  it("removes a server-backed queued transcript row", () => {
+    useChatSessionStore.setState({
+      snapshot: {
+        messages: [
+          {
+            id: "req-1",
+            role: "user",
+            queueStatus: "queued",
+            queuePosition: 1,
+          },
+        ],
+        hasMore: false,
+        oldestTimestamp: null,
+        oldestMessageId: null,
+        seq: 1,
+      },
+    });
+
+    handleMessageQueuedDeleted(
+      {
+        type: "message_queued_deleted",
+        conversationId: "conv-1",
+        requestId: "req-1",
+      },
+      makeCtx(),
+    );
+
+    expect(useChatSessionStore.getState().snapshot?.messages).toEqual([]);
+  });
 });
 
 describe("handleMessageRequestComplete", () => {

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
@@ -100,7 +100,7 @@ describe("handleMessageDequeued", () => {
     expect(ctx.setOptimisticSends).not.toHaveBeenCalled();
   });
 
-  it("clears queue status from a server-backed transcript row", () => {
+  it("removes an uncorrelatable server-backed transcript row", () => {
     useChatSessionStore.setState({
       snapshot: {
         messages: [
@@ -127,9 +127,7 @@ describe("handleMessageDequeued", () => {
       makeCtx(),
     );
 
-    expect(
-      useChatSessionStore.getState().snapshot?.messages[0]?.queueStatus,
-    ).toBeUndefined();
+    expect(useChatSessionStore.getState().snapshot?.messages).toEqual([]);
   });
 });
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
 import {
   handleMessageQueued,
@@ -7,6 +8,10 @@ import {
   handleMessageQueuedDeleted,
   handleMessageRequestComplete,
 } from "@/domains/chat/utils/stream-handlers/queue-handlers";
+
+afterEach(() => {
+  useChatSessionStore.setState({ snapshot: null });
+});
 
 describe("handleMessageQueued", () => {
   it("maps requestId to messageId and sets queue position", () => {
@@ -93,6 +98,38 @@ describe("handleMessageDequeued", () => {
     );
     expect(ctx.turnActions.dequeueMessage).toHaveBeenCalled();
     expect(ctx.setOptimisticSends).not.toHaveBeenCalled();
+  });
+
+  it("clears queue status from a server-backed transcript row", () => {
+    useChatSessionStore.setState({
+      snapshot: {
+        messages: [
+          {
+            id: "req-1",
+            role: "user",
+            queueStatus: "queued",
+            queuePosition: 1,
+          },
+        ],
+        hasMore: false,
+        oldestTimestamp: null,
+        oldestMessageId: null,
+        seq: 1,
+      },
+    });
+
+    handleMessageDequeued(
+      {
+        type: "message_dequeued",
+        conversationId: "conv-1",
+        requestId: "req-1",
+      },
+      makeCtx(),
+    );
+
+    expect(
+      useChatSessionStore.getState().snapshot?.messages[0]?.queueStatus,
+    ).toBeUndefined();
   });
 });
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
@@ -21,7 +21,9 @@ export function handleMessageQueued(
   ctx.turnActions.enqueueMessage();
   const { requestId, position } = event;
   const messageId = ctx.shiftPendingQueuedMessageId();
-  if (!messageId) return;
+  if (!messageId) {
+    return;
+  }
 
   ctx.setRequestIdMapping(requestId, messageId);
 
@@ -69,6 +71,9 @@ export function handleMessageQueuedDeleted(
   if (deletedMessageId) {
     ctx.setOptimisticSends((prev) => removeQueuedMessage(prev, deletedMessageId));
   }
+  patchTranscriptMessages((prev) =>
+    removeQueuedMessage(prev, deletedMessageId ?? event.requestId),
+  );
 }
 
 export function handleMessageRequestComplete(

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
@@ -1,5 +1,5 @@
 import {
-  clearQueueStatus,
+  applyQueuedMessageDequeue,
   removeQueuedMessage,
   setQueuePosition,
 } from "@/domains/chat/utils/stream-updaters/shared";
@@ -55,10 +55,12 @@ export function handleMessageDequeued(
   ctx.turnActions.dequeueMessage();
   const dequeuedMessageId = ctx.popRequestIdMapping(event.requestId);
   if (dequeuedMessageId) {
-    ctx.setOptimisticSends((prev) => clearQueueStatus(prev, dequeuedMessageId));
+    ctx.setOptimisticSends((prev) =>
+      applyQueuedMessageDequeue(prev, dequeuedMessageId),
+    );
   }
   patchTranscriptMessages((prev) =>
-    clearQueueStatus(prev, dequeuedMessageId ?? event.requestId),
+    applyQueuedMessageDequeue(prev, dequeuedMessageId ?? event.requestId),
   );
 }
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts
@@ -10,8 +10,9 @@ import type {
   MessageQueuedEvent,
   MessageRequestCompleteEvent,
 } from "@vellumai/assistant-api";
-import { deleteQueuedMessage } from "@/domains/chat/api/messages";
 import { useConversationStore } from "@/stores/conversation-store";
+import { patchTranscriptMessages } from "@/domains/chat/transcript/patch-transcript-messages";
+import { confirmQueuedMessageDeletion } from "@/domains/chat/queue-cancellation";
 
 export function handleMessageQueued(
   event: MessageQueuedEvent,
@@ -28,11 +29,17 @@ export function handleMessageQueued(
     const conversationId =
       useConversationStore.getState().activeConversationId;
     if (ctx.assistantId && conversationId) {
-      void deleteQueuedMessage(
-        ctx.assistantId,
+      void confirmQueuedMessageDeletion({
+        assistantId: ctx.assistantId,
         conversationId,
         requestId,
-      );
+        messageId,
+        setOptimisticSends: ctx.setOptimisticSends,
+        onDeleted: () => {
+          ctx.popRequestIdMapping(requestId);
+          ctx.turnActions.deleteQueuedMessage();
+        },
+      });
     }
   } else {
     ctx.setOptimisticSends((prev) => setQueuePosition(prev, messageId, position + 1));
@@ -48,6 +55,9 @@ export function handleMessageDequeued(
   if (dequeuedMessageId) {
     ctx.setOptimisticSends((prev) => clearQueueStatus(prev, dequeuedMessageId));
   }
+  patchTranscriptMessages((prev) =>
+    clearQueueStatus(prev, dequeuedMessageId ?? event.requestId),
+  );
 }
 
 export function handleMessageQueuedDeleted(

--- a/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
@@ -401,8 +401,9 @@ export function finalizeMessageComplete(
  * send and an already-resolved row is short-circuited by id upstream, so the
  * nonce match needs no separate optimistic flag. When the event carries no
  * nonce — a daemon that predates the idempotency contract, or a synthetic
- * surface-action echo — fall back to the most recent still-optimistic user
- * row, which has no nonce to key on and so is identified by `isOptimistic`.
+ * surface-action echo — prefer the most recent still-optimistic user row that
+ * also lacks a nonce. Fall back to any optimistic user row for compatibility
+ * with daemons that accept a client nonce but do not echo it.
  */
 function findOptimisticUserEchoIdx(
   prev: DisplayMessage[],
@@ -414,13 +415,19 @@ function findOptimisticUserEchoIdx(
     );
   }
 
+  let nonceBearingFallbackIdx = -1;
   for (let i = prev.length - 1; i >= 0; i--) {
     const m = prev[i];
     if (m && m.role === "user" && m.isOptimistic === true) {
-      return i;
+      if (!m.clientMessageId) {
+        return i;
+      }
+      if (nonceBearingFallbackIdx === -1) {
+        nonceBearingFallbackIdx = i;
+      }
     }
   }
-  return -1;
+  return nonceBearingFallbackIdx;
 }
 
 /**

--- a/clients/web/src/domains/chat/utils/stream-updaters/shared.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/shared.ts
@@ -8,7 +8,7 @@
  */
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
-import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
+import { messageMatchesKey } from "@/domains/chat/utils/message-identity";
 import { isToolCallRunning } from "@/domains/chat/utils/tool-call-status";
 
 // ---------------------------------------------------------------------------
@@ -92,9 +92,13 @@ export function withMergedAlias(
   row: DisplayMessage,
   messageId: string | undefined,
 ): DisplayMessage {
-  if (!messageId || row.id === messageId) return row;
+  if (!messageId || row.id === messageId) {
+    return row;
+  }
   const existing = row.mergedMessageIds ?? [];
-  if (existing.includes(messageId)) return row;
+  if (existing.includes(messageId)) {
+    return row;
+  }
   return { ...row, mergedMessageIds: [...existing, messageId] };
 }
 
@@ -131,10 +135,6 @@ export function finalizeRunningToolCalls(
 // Queue updaters
 // ---------------------------------------------------------------------------
 
-function hasQueueMessageIdentity(message: DisplayMessage, id: string): boolean {
-  return messageMatchKeys(message).includes(id);
-}
-
 /** Set queue position on a message by id. */
 export function setQueuePosition(
   prev: DisplayMessage[],
@@ -150,7 +150,7 @@ export function clearQueueStatus(
   id: string,
 ): DisplayMessage[] {
   return prev.map((m) =>
-    hasQueueMessageIdentity(m, id)
+    messageMatchesKey(m, id)
       ? { ...m, queueStatus: undefined, queuePosition: undefined }
       : m,
   );
@@ -160,10 +160,11 @@ export function clearQueueStatus(
 export function markMessageQueued(
   prev: DisplayMessage[],
   id: string,
+  position: number | undefined,
 ): DisplayMessage[] {
   return prev.map((m) =>
-    hasQueueMessageIdentity(m, id)
-      ? { ...m, queueStatus: "queued" as const }
+    messageMatchesKey(m, id)
+      ? { ...m, queueStatus: "queued" as const, queuePosition: position }
       : m,
   );
 }
@@ -173,5 +174,5 @@ export function removeQueuedMessage(
   prev: DisplayMessage[],
   id: string,
 ): DisplayMessage[] {
-  return prev.filter((m) => !hasQueueMessageIdentity(m, id));
+  return prev.filter((m) => !messageMatchesKey(m, id));
 }

--- a/clients/web/src/domains/chat/utils/stream-updaters/shared.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/shared.ts
@@ -8,6 +8,7 @@
  */
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
+import { messageMatchKeys } from "@/domains/chat/utils/message-identity";
 import { isToolCallRunning } from "@/domains/chat/utils/tool-call-status";
 
 // ---------------------------------------------------------------------------
@@ -130,6 +131,10 @@ export function finalizeRunningToolCalls(
 // Queue updaters
 // ---------------------------------------------------------------------------
 
+function hasQueueMessageIdentity(message: DisplayMessage, id: string): boolean {
+  return messageMatchKeys(message).includes(id);
+}
+
 /** Set queue position on a message by id. */
 export function setQueuePosition(
   prev: DisplayMessage[],
@@ -139,22 +144,34 @@ export function setQueuePosition(
   return prev.map((m) => (m.id === id ? { ...m, queuePosition: position } : m));
 }
 
-/** Clear queue status on a message by id. */
+/** Clear queue status by server id or client correlation id. */
 export function clearQueueStatus(
   prev: DisplayMessage[],
   id: string,
 ): DisplayMessage[] {
   return prev.map((m) =>
-    m.id === id
+    hasQueueMessageIdentity(m, id)
       ? { ...m, queueStatus: undefined, queuePosition: undefined }
       : m,
   );
 }
 
-/** Remove a queued message by id. */
+/** Mark a message as queued by server id or client correlation id. */
+export function markMessageQueued(
+  prev: DisplayMessage[],
+  id: string,
+): DisplayMessage[] {
+  return prev.map((m) =>
+    hasQueueMessageIdentity(m, id)
+      ? { ...m, queueStatus: "queued" as const }
+      : m,
+  );
+}
+
+/** Remove a queued message by server id or client correlation id. */
 export function removeQueuedMessage(
   prev: DisplayMessage[],
   id: string,
 ): DisplayMessage[] {
-  return prev.filter((m) => m.id !== id);
+  return prev.filter((m) => !hasQueueMessageIdentity(m, id));
 }

--- a/clients/web/src/domains/chat/utils/stream-updaters/shared.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/shared.ts
@@ -156,6 +156,23 @@ export function clearQueueStatus(
   );
 }
 
+export function applyQueuedMessageDequeue(
+  prev: DisplayMessage[],
+  id: string,
+): DisplayMessage[] {
+  return prev.flatMap((message) => {
+    if (!messageMatchesKey(message, id)) {
+      return [message];
+    }
+    if (message.queueStatus === "queued" && !message.clientMessageId) {
+      return [];
+    }
+    return [
+      { ...message, queueStatus: undefined, queuePosition: undefined },
+    ];
+  });
+}
+
 /** Mark a message as queued by server id or client correlation id. */
 export function markMessageQueued(
   prev: DisplayMessage[],

--- a/clients/web/src/domains/chat/utils/stream-updaters/shared.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/shared.ts
@@ -164,7 +164,7 @@ export function applyQueuedMessageDequeue(
     if (!messageMatchesKey(message, id)) {
       return [message];
     }
-    if (message.queueStatus === "queued" && !message.clientMessageId) {
+    if (!message.clientMessageId) {
       return [];
     }
     return [

--- a/clients/web/src/domains/chat/utils/stream-updaters/shared.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/shared.ts
@@ -160,16 +160,16 @@ export function applyQueuedMessageDequeue(
   prev: DisplayMessage[],
   id: string,
 ): DisplayMessage[] {
-  return prev.flatMap((message) => {
+  return prev.map((message) => {
     if (!messageMatchesKey(message, id)) {
-      return [message];
+      return message;
     }
-    if (!message.clientMessageId) {
-      return [];
-    }
-    return [
-      { ...message, queueStatus: undefined, queuePosition: undefined },
-    ];
+    return {
+      ...message,
+      ...(!message.clientMessageId ? { isOptimistic: true } : {}),
+      queueStatus: undefined,
+      queuePosition: undefined,
+    };
   });
 }
 


### PR DESCRIPTION
## Prompt / plan

Fix the queue lifecycle issues found during live localhost QA: reconciled queued rows could disappear while still scheduled, cancellation could hide a row before the server confirmed deletion, early cancellation could race the request ID, and snapshot-backed rows could lose working cancel or steer controls.

The client now preserves queue metadata through history mapping, derives the drawer from the merged transcript, resolves both client and server identities, and patches optimistic plus snapshot copies consistently. Delete and steer requests also carry redundant conversation context for proxy compatibility.

## Test plan

- 34 message API tests
- 110 queue, reconciliation, delivery, mapper, and stream tests
- 65 assistant route and queued-history tests
- bun run typecheck in clients/web
- bunx tsgo --noEmit in assistant
- React Doctor changed-scope scan
- Manual localhost QA: queue remained visible past the reconciliation interval; cancellation prevented later delivery; steering promoted immediately; no new browser console errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->