### PR TITLE
fix(gateway): guard Slack event text before pre-normalization rendering

### DIFF
--- a/gateway/src/slack/event-text.test.ts
+++ b/gateway/src/slack/event-text.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "bun:test";
+
+import { slackEventText, type SlackTextBearingEvent } from "./event-text.js";
+
+// The static types declare `text` as a string, but Socket Mode payloads are
+// untrusted — a non-string reaches this code at runtime. Cast through unknown
+// to model that in the tests.
+function asEvent(value: unknown): SlackTextBearingEvent {
+  return value as SlackTextBearingEvent;
+}
+
+describe("slackEventText", () => {
+  it("returns the text of an app_mention", () => {
+    expect(
+      slackEventText(asEvent({ type: "app_mention", text: "hello <@U1>" })),
+    ).toBe("hello <@U1>");
+  });
+
+  it("returns the text of a top-level message", () => {
+    expect(slackEventText(asEvent({ type: "message", text: "hi there" }))).toBe(
+      "hi there",
+    );
+  });
+
+  it("returns the edited text of a message_changed event", () => {
+    expect(
+      slackEventText(
+        asEvent({
+          type: "message",
+          subtype: "message_changed",
+          message: { text: "edited" },
+        }),
+      ),
+    ).toBe("edited");
+  });
+
+  it("returns undefined for an event with no text-bearing shape", () => {
+    expect(
+      slackEventText(asEvent({ type: "reaction_added", reaction: "thumbsup" })),
+    ).toBeUndefined();
+  });
+
+  it("collapses a non-string message text to undefined instead of returning it", () => {
+    // The crash this guards: the renderer calls `text.matchAll`, so a truthy
+    // non-string must never leave this function.
+    expect(
+      slackEventText(asEvent({ type: "message", text: 12345 })),
+    ).toBeUndefined();
+    expect(
+      slackEventText(asEvent({ type: "message", text: { rich: "object" } })),
+    ).toBeUndefined();
+    expect(
+      slackEventText(
+        asEvent({
+          type: "message",
+          subtype: "message_changed",
+          message: { text: ["array"] },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("collapses a missing message body on message_changed to undefined", () => {
+    expect(
+      slackEventText(asEvent({ type: "message", subtype: "message_changed" })),
+    ).toBeUndefined();
+  });
+});

--- a/gateway/src/slack/event-text.ts
+++ b/gateway/src/slack/event-text.ts
@@ -1,0 +1,43 @@
+import type {
+  SlackAppMentionEvent,
+  SlackChannelMessageEvent,
+  SlackDirectMessageEvent,
+  SlackMessageChangedEvent,
+  SlackMessageDeletedEvent,
+  SlackReactionAddedEvent,
+  SlackReactionRemovedEvent,
+} from "./normalize.js";
+
+/** The Slack event shapes that flow through text extraction. */
+export type SlackTextBearingEvent =
+  | SlackAppMentionEvent
+  | SlackDirectMessageEvent
+  | SlackChannelMessageEvent
+  | SlackMessageChangedEvent
+  | SlackMessageDeletedEvent
+  | SlackReactionAddedEvent
+  | SlackReactionRemovedEvent;
+
+/**
+ * Extract the user-authored text from a Slack event for mention/channel label
+ * resolution and rendering.
+ *
+ * This runs on **untrusted** event data and **before** normalization: the
+ * static types declare `text` as a string, but a Socket Mode payload can carry
+ * any JSON value there. The downstream Slack text renderer calls
+ * `text.matchAll`, so a truthy non-string would throw and take down the emit
+ * path before the tolerant normalizer ever runs. Returning a string (or
+ * undefined) keeps that path crash-safe.
+ */
+export function slackEventText(
+  event: SlackTextBearingEvent,
+): string | undefined {
+  const raw =
+    event.type === "message" &&
+    (event as SlackMessageChangedEvent).subtype === "message_changed"
+      ? (event as SlackMessageChangedEvent).message?.text
+      : event.type === "app_mention" || event.type === "message"
+        ? (event as SlackAppMentionEvent | SlackDirectMessageEvent).text
+        : undefined;
+  return typeof raw === "string" ? raw : undefined;
+}

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -20,6 +20,7 @@ import {
 } from "./slack-web.js";
 import { isSlackDmChannel } from "./channel.js";
 import { slackEventOrderingKey } from "./event-ordering.js";
+import { slackEventText } from "./event-text.js";
 import { stampSlackEventTeam } from "./event-team.js";
 import {
   normalizeSlackAppMention,
@@ -1104,30 +1105,6 @@ export class SlackSocketModeClient {
     );
   }
 
-  private extractTextBearingContent(
-    event:
-      | SlackAppMentionEvent
-      | SlackDirectMessageEvent
-      | SlackChannelMessageEvent
-      | SlackMessageChangedEvent
-      | SlackMessageDeletedEvent
-      | SlackReactionAddedEvent
-      | SlackReactionRemovedEvent,
-  ): string | undefined {
-    if (
-      event.type === "message" &&
-      (event as SlackMessageChangedEvent).subtype === "message_changed"
-    ) {
-      return (event as SlackMessageChangedEvent).message?.text;
-    }
-
-    if (event.type === "app_mention" || event.type === "message") {
-      return (event as SlackAppMentionEvent | SlackDirectMessageEvent).text;
-    }
-
-    return undefined;
-  }
-
   private async resolveMentionLabelsForText(
     text: string,
   ): Promise<Record<string, string>> {
@@ -1240,7 +1217,7 @@ export class SlackSocketModeClient {
     isMessageDeleted: boolean,
     isDm: boolean,
   ): Promise<void> {
-    const text = this.extractTextBearingContent(event);
+    const text = slackEventText(event);
     const renderContext = text ? await this.resolveTextRenderContext(text) : {};
     const userLabels = renderContext.userLabels ?? {};
 


### PR DESCRIPTION
## Prompt / plan

Standalone pre-normalization crash fix surfaced by a Codex P2 review on #38983 — same class as the earlier Slack Socket Mode read-crash fixes (event-ordering #38963, event-team #38969), so it's split into its own extract-pure-and-test PR rather than folded into the edit/delete leaf.

### Scope (there are two independent non-string-`text` crash sites)

1. **Label-resolution read** — `normalizeAndEmit` resolves mention/channel labels from the raw event text **before** any normalizer runs. **This PR fixes this site.**
2. **Normalizer-internal render** — each message normalizer independently calls `renderSlackInboundText(event.text)`. That site is closed **per-normalizer** by the tolerant-Zod migration (the schema collapses a non-string to `undefined`): already done for the edit normalizer in #38983, and covered for `app_mention`/DM/channel by the queued message-normalizer leaf. It is deliberately **not** band-aided here.

### Why (site 1)

In `socket-mode.ts`, `normalizeAndEmit` resolves mention/channel labels from a text-bearing event's `text` (`app_mention` / DM / channel message) or `message.text` (`message_changed`) **before** the tolerant normalizer runs:

```ts
const text = this.extractTextBearingContent(event);
const renderContext = text ? await this.resolveTextRenderContext(text) : {};
```

The static types declare `text` as a `string`, but the event is unvalidated `JSON.parse` output. `resolveTextRenderContext` feeds `text` into `buildSlackUserLabelMap` / `buildSlackChannelLabelMap`, which call `text.matchAll` — so a truthy **non-string** `text` throws there and the whole event is dropped with a normalization error. This read is upstream of the normalizers and runs for **every** text-bearing event, so it needs its own guard regardless of how tolerant the normalizers become.

### What changed

- Extracted the text extraction into a pure, unit-tested `slackEventText` helper (matching `event-ordering.ts` / `event-team.ts`) that returns a **string only** — a non-string `text`/`message.text` collapses to `undefined`, so the label-resolution path is never handed a non-string.
- Replaced the private `extractTextBearingContent` method with a call to it.

### Why it's safe

- Behavior is unchanged for well-formed events (a real string flows through exactly as before). Only a non-string `text`, which previously threw in label resolution, now yields `undefined` → the label-resolution step is skipped and the event proceeds to the normalizer.
- Pure function, no I/O, no state.

## Test plan

- `bun test src/slack/event-text.test.ts` — 6 pass (string extraction for app_mention / message / message_changed; non-text event → undefined; non-string `text`/`message.text` collapse; missing `message_changed` body).
- **Negative control:** reverting the `typeof raw === "string"` guard turns the non-string test red. Restored.
- `bun test src/slack/ src/__tests__/slack-socket-mode-*.test.ts` — 178 pass. `tsc`, `eslint`, `prettier`, generic-examples — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f