### PR TITLE
fix(gateway): validate Slack message normalizers with tolerant Zod, DRY the shared spine

### DIFF
--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -1660,6 +1660,45 @@ describe("SlackSocketModeClient thread tracking", () => {
     },
   );
 
+  test("does not arm a thread for a malformed app mention missing its user", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    const threadTs = "1700000005.000100";
+
+    try {
+      // Channel "C-thread" IS routed (conversation_id), so routing succeeds on
+      // the channel alone even though `user` is missing. Without the identity
+      // guard the thread would arm here, then normalizeSlackAppMention drops the
+      // mention for missing identity — leaving a thread that admits later
+      // unmentioned replies.
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-malformed-mention",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-malformed-mention",
+            event: {
+              type: "app_mention",
+              text: "<@UBOT> hi",
+              ts: "1700000005.000200",
+              channel: "C-thread",
+              thread_ts: threadTs,
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
+      expect(store.hasThread(threadTs)).toBe(false);
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test("renders live app mention user IDs as display-name labels", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -1150,6 +1150,122 @@ function makeMessageChangedEvent(
   };
 }
 
+describe("message event tolerant validation", () => {
+  const config = makeConfig();
+
+  it("drops non-object message payloads instead of throwing", () => {
+    expect(normalizeSlackDirectMessage("nope", "evt-t1", config)).toBeNull();
+    expect(normalizeSlackDirectMessage(null, "evt-t2", config)).toBeNull();
+    expect(normalizeSlackChannelMessage(42, "evt-t3", config)).toBeNull();
+    expect(normalizeSlackAppMention(null, "evt-t4", config)).toBeNull();
+  });
+
+  it("renders empty content for a non-string DM text instead of crashing", () => {
+    // The live crash this closes: the normalizer calls renderSlackInboundText
+    // (which `matchAll`s the text). A non-string text collapses to undefined at
+    // the schema, and `?? ""` yields empty content rather than throwing.
+    const result = normalizeSlackDirectMessage(
+      {
+        type: "message",
+        channel_type: "im",
+        user: "U123",
+        channel: "D789",
+        ts: "1.2",
+        text: 12345,
+      },
+      "evt-t5",
+      config,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("");
+  });
+
+  it("renders empty content for a non-string app_mention text", () => {
+    const result = normalizeSlackAppMention(
+      {
+        type: "app_mention",
+        user: "U123",
+        channel: "C456",
+        ts: "1.2",
+        text: { rich: "obj" },
+      },
+      "evt-t6",
+      config,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("");
+  });
+
+  it("drops a channel message missing its user", () => {
+    const result = normalizeSlackChannelMessage(
+      {
+        type: "message",
+        channel_type: "channel",
+        channel: "C456",
+        ts: "1.2",
+        text: "hi",
+      },
+      "evt-t7",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("drops a message missing its channel", () => {
+    const result = normalizeSlackDirectMessage(
+      {
+        type: "message",
+        channel_type: "im",
+        user: "U123",
+        ts: "1.2",
+        text: "hi",
+      },
+      "evt-t8",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("collapses a malformed files array to no attachments rather than throwing", () => {
+    const result = normalizeSlackChannelMessage(
+      {
+        type: "message",
+        channel_type: "channel",
+        channel: "C456",
+        user: "U123",
+        ts: "1.2",
+        text: "hi",
+        files: "not-an-array",
+      },
+      "evt-t9",
+      config,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.attachments).toBeUndefined();
+  });
+
+  it("preserves unknown extra keys verbatim in raw", () => {
+    const payload = {
+      type: "message",
+      channel_type: "channel",
+      channel: "C456",
+      user: "U123",
+      ts: "1.2",
+      text: "hi",
+      unexpected_field: "surprise",
+    };
+    const result = normalizeSlackChannelMessage(payload, "evt-t10", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.raw).toEqual(payload);
+  });
+});
+
 describe("normalizeSlackMessageEdit", () => {
   it("normalizes an edit in a subscribed channel (not DM, not bot thread)", () => {
     // Bot is subscribed to the channel via a conversation_id routing entry —

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -1264,6 +1264,25 @@ describe("message event tolerant validation", () => {
     expect(result).not.toBeNull();
     expect(result!.event.raw).toEqual(payload);
   });
+
+  it("drops a message with no usable timestamp (dedup key)", () => {
+    // Neither ts nor client_msg_id → the externalMessageId would collapse to
+    // `channel:undefined` and collide across every such malformed message in
+    // the channel, so the message is dropped instead.
+    const result = normalizeSlackChannelMessage(
+      {
+        type: "message",
+        channel_type: "channel",
+        channel: "C456",
+        user: "U123",
+        text: "hi",
+      },
+      "evt-t11",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
 });
 
 describe("normalizeSlackMessageEdit", () => {

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -25,6 +25,8 @@ import type {
 // `undefined` so the existing null-checks drop an unprocessable event rather than
 // trusting garbage. The original payload is preserved verbatim as `raw`.
 const optionalString = () => z.string().optional().catch(undefined);
+/** A required id string: a missing/non-string value collapses to `""`. */
+const requiredString = () => z.string().catch("");
 
 /**
  * Resolved Slack user info for populating actor fields.
@@ -360,88 +362,28 @@ export function getChannelInfoCacheSize(): number {
 }
 
 /** Slack file object (subset relevant to attachment handling). */
-export interface SlackFile {
-  id: string;
-  name?: string;
-  mimetype?: string;
-  size?: number;
-  url_private_download?: string;
-  url_private?: string;
-}
+/** A Slack file attachment; only the fields the gateway forwards are modeled. */
+const slackFileSchema = z.object({
+  id: requiredString(),
+  name: optionalString(),
+  mimetype: optionalString(),
+  size: z.number().optional().catch(undefined),
+  url_private_download: optionalString(),
+  url_private: optionalString(),
+});
+export type SlackFile = z.infer<typeof slackFileSchema>;
 
 /**
  * Slack `bot_profile` object attached to bot-authored messages
  * (subset relevant to sender classification).
  */
-export interface SlackBotProfile {
-  id?: string;
-  name?: string;
-  app_id?: string;
-  team_id?: string;
-}
-
-/**
- * Slack `app_mention` event shape (subset relevant to normalization).
- */
-export interface SlackAppMentionEvent {
-  type: "app_mention";
-  user: string;
-  text: string;
-  ts: string;
-  channel: string;
-  thread_ts?: string;
-  client_msg_id?: string;
-  event_ts?: string;
-  files?: SlackFile[];
-  /** Team ID of the mentioning user's workspace. */
-  team?: string;
-  /** Present when the message was authored by a bot/app. */
-  bot_id?: string;
-  bot_profile?: SlackBotProfile;
-}
-
-/**
- * Slack `message` event shape for direct messages (IMs).
- */
-export interface SlackDirectMessageEvent {
-  type: "message";
-  subtype?: string;
-  user?: string;
-  text: string;
-  ts: string;
-  channel: string;
-  channel_type: "im";
-  thread_ts?: string;
-  client_msg_id?: string;
-  event_ts?: string;
-  files?: SlackFile[];
-  /** Present when the message was authored by a bot/app. */
-  bot_id?: string;
-  bot_profile?: SlackBotProfile;
-}
-
-/**
- * Slack `message` event shape for channel/group messages (non-DM).
- * Used to pick up thread replies in threads the bot is already participating in.
- */
-export interface SlackChannelMessageEvent {
-  type: "message";
-  subtype?: string;
-  user?: string;
-  text: string;
-  ts: string;
-  channel: string;
-  channel_type: "channel" | "group" | "mpim";
-  thread_ts?: string;
-  client_msg_id?: string;
-  event_ts?: string;
-  files?: SlackFile[];
-  /** Team ID of the sending user's workspace. */
-  team?: string;
-  /** Present when the message was authored by a bot/app. */
-  bot_id?: string;
-  bot_profile?: SlackBotProfile;
-}
+const slackBotProfileSchema = z.object({
+  id: optionalString(),
+  name: optionalString(),
+  app_id: optionalString(),
+  team_id: optionalString(),
+});
+export type SlackBotProfile = z.infer<typeof slackBotProfileSchema>;
 
 /** `message.edited` / `previous_message.edited` sub-object. */
 const slackEditedSchema = z
@@ -567,6 +509,45 @@ type _SlackMessageApiCrossChecks = [
   >,
 ];
 
+/**
+ * Tolerant schema for the plain-message family — `app_mention`, direct
+ * messages, and channel/group messages. The three differ only in discriminator
+ * values (`type` / `channel_type`) and which fields the normalizer keys on, so
+ * one tolerant shape backs all three; each normalizer applies its own guards.
+ */
+const slackMessageEventSchema = z.object({
+  type: optionalString(),
+  subtype: optionalString(),
+  user: optionalString(),
+  text: optionalString(),
+  ts: optionalString(),
+  channel: optionalString(),
+  channel_type: slackMessageChannelType(),
+  thread_ts: optionalString(),
+  client_msg_id: optionalString(),
+  event_ts: optionalString(),
+  files: z.array(slackFileSchema).optional().catch(undefined),
+  team: optionalString(),
+  bot_id: optionalString(),
+  bot_profile: slackBotProfileSchema.optional().catch(undefined),
+});
+type SlackMessageEvent = z.infer<typeof slackMessageEventSchema>;
+
+/** All three plain-message events share the one tolerant shape. */
+export type SlackAppMentionEvent = SlackMessageEvent;
+export type SlackDirectMessageEvent = SlackMessageEvent;
+export type SlackChannelMessageEvent = SlackMessageEvent;
+
+// Key-integrity cross-check against the official `GenericMessageEvent` (a
+// superset of the fields all three plain-message events carry). Value-checking
+// is skipped here because `@slack/types` models `files` as DOM `File[]`, which
+// our forwarded-file subset intentionally does not match.
+type _SlackMessageEventApiCrossCheck = [
+  Expect<
+    ModeledKeysAreOfficial<SlackMessageEvent, SlackApiGenericMessageEvent>
+  >,
+];
+
 export type SlackTextRenderContext = {
   userLabels?: Record<string, string>;
   channelLabels?: Record<string, string>;
@@ -614,7 +595,7 @@ function extractSlackAttachments(files: SlackFile[] | undefined): Array<{
 }> {
   if (!files || files.length === 0) return [];
   return files
-    .filter((f) => f.url_private_download || f.url_private)
+    .filter((f) => f.id && (f.url_private_download || f.url_private))
     .map((f) => ({
       type: f.mimetype?.startsWith("image/")
         ? ("image" as const)
@@ -631,7 +612,7 @@ function extractSlackFileMap(
 ): Map<string, SlackFile> | undefined {
   if (!files || files.length === 0) return undefined;
   const downloadableFiles = files.filter(
-    (f) => f.url_private_download || f.url_private,
+    (f) => f.id && (f.url_private_download || f.url_private),
   );
   return downloadableFiles.length
     ? new Map(downloadableFiles.map((f) => [f.id, f]))
@@ -742,213 +723,196 @@ export function enrichNormalizedActor(
  * Bot's own messages are dropped by `processEventPayload` before
  * normalization.
  */
+/** The per-event-type differences across the plain-message normalizers. */
+type SlackMessageShape = {
+  /** `source.chatType`; omitted for `app_mention`. */
+  chatType?: "im" | "channel";
+  /** Stamp the sender's workspace id onto the actor (channel + app_mention). */
+  stampTeam: boolean;
+  /** Reply in the message's own ts when it has no `thread_ts` (channel + app_mention). */
+  fallbackThreadToTs: boolean;
+};
+
+/**
+ * Shared construction for the plain-message family (`app_mention` / DM /
+ * channel). Each caller owns its own guards, routing, and identity extraction;
+ * this builds the canonical normalized event they all produce, so the three
+ * public normalizers stay thin variant wrappers.
+ */
+function buildNormalizedSlackMessage(
+  event: SlackMessageEvent,
+  rawEvent: Record<string, unknown>,
+  eventId: string,
+  routing: RouteResult,
+  channel: string,
+  actorId: string,
+  shape: SlackMessageShape,
+  botToken?: string,
+  renderContext?: SlackTextRenderContext,
+): NormalizedSlackEvent {
+  const externalMessageId =
+    event.client_msg_id ?? event.ts ?? `${channel}:${event.ts}`;
+  const attachments = extractSlackAttachments(event.files);
+  const slackFiles = extractSlackFileMap(event.files);
+
+  // Cache-only lookup to avoid blocking normalization on network calls; a
+  // background fetch warms the cache for subsequent messages from this user.
+  const userInfo = botToken
+    ? resolveSlackUserSync(actorId, botToken)
+    : undefined;
+  const botSender = slackBotSenderInfo(event, userInfo);
+  const content = renderSlackInboundText(event.text ?? "", renderContext);
+  const threadTs =
+    event.thread_ts ?? (shape.fallbackThreadToTs ? event.ts : undefined);
+
+  return {
+    event: {
+      version: "v1",
+      sourceChannel: "slack",
+      receivedAt: new Date().toISOString(),
+      message: {
+        content,
+        conversationExternalId: channel,
+        externalMessageId,
+        ...(attachments.length > 0 ? { attachments } : {}),
+      },
+      actor: {
+        actorExternalId: actorId,
+        ...(userInfo ? slackUserActorFields(userInfo) : {}),
+        ...(shape.stampTeam && event.team ? { teamId: event.team } : {}),
+        ...(botSender ? { isBot: true } : {}),
+      },
+      source: {
+        updateId: eventId,
+        messageId: event.ts,
+        ...(shape.chatType ? { chatType: shape.chatType } : {}),
+        ...(event.thread_ts ? { threadId: event.thread_ts } : {}),
+      },
+      raw: rawEvent,
+    },
+    routing,
+    ...(threadTs ? { threadTs } : {}),
+    channel,
+    ...(slackFiles ? { slackFiles } : {}),
+    ...(botSender ? { botSender } : {}),
+  };
+}
+
 export function normalizeSlackDirectMessage(
-  event: SlackDirectMessageEvent,
+  event: unknown,
   eventId: string,
   config: GatewayConfig,
   botToken?: string,
   renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
-  // Ignore message subtypes (edits, deletions, etc.) — only handle plain user messages.
-  // message_changed is handled separately by normalizeSlackMessageEdit.
-  // file_share is allowed so image/file uploads are delivered to the assistant.
-  if (event.subtype && event.subtype !== "file_share") return null;
-  // user is required for routing
-  if (!event.user) return null;
+  const parsed = slackMessageEventSchema.safeParse(event);
+  if (!parsed.success) return null;
+  const msg = parsed.data;
 
-  // DMs are always directed at the bot, so use the default assistant even
-  // when the DM channel ID (D...) isn't in the routing table. This ensures
-  // guardian verification replies aren't silently dropped.
-  let routing = resolveAssistant(config, event.channel, event.user);
+  // Only plain user messages; file_share carries uploads. Edits/deletes have
+  // their own normalizers.
+  if (msg.subtype && msg.subtype !== "file_share") return null;
+  if (!msg.user || !msg.channel) return null;
+
+  // DMs are always directed at the bot, so fall back to the default assistant
+  // even when the DM channel id isn't in the routing table — otherwise guardian
+  // verification replies would be silently dropped.
+  let routing = resolveAssistant(config, msg.channel, msg.user);
   if (isRejection(routing) && config.defaultAssistantId) {
     routing = {
       assistantId: config.defaultAssistantId,
       routeSource: "default" as const,
     };
   }
-  if (isRejection(routing)) {
-    return null;
-  }
+  if (isRejection(routing)) return null;
 
-  const externalMessageId =
-    event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
-
-  const attachments = extractSlackAttachments(event.files);
-  const slackFiles = extractSlackFileMap(event.files);
-
-  // Use cache-only lookup to avoid blocking normalization on network calls.
-  // A background fetch warms the cache for subsequent messages from this user.
-  const userInfo =
-    botToken && event.user
-      ? resolveSlackUserSync(event.user, botToken)
-      : undefined;
-  const botSender = slackBotSenderInfo(event, userInfo);
-  const content = renderSlackInboundText(event.text, renderContext);
-
-  return {
-    event: {
-      version: "v1",
-      sourceChannel: "slack",
-      receivedAt: new Date().toISOString(),
-      message: {
-        content,
-        conversationExternalId: event.channel,
-        externalMessageId,
-        ...(attachments.length > 0 ? { attachments } : {}),
-      },
-      actor: {
-        actorExternalId: event.user,
-        ...(userInfo ? slackUserActorFields(userInfo) : {}),
-        ...(botSender ? { isBot: true } : {}),
-      },
-      source: {
-        updateId: eventId,
-        messageId: event.ts,
-        chatType: "im",
-        ...(event.thread_ts ? { threadId: event.thread_ts } : {}),
-      },
-      raw: event as unknown as Record<string, unknown>,
-    },
+  return buildNormalizedSlackMessage(
+    msg,
+    event as Record<string, unknown>,
+    eventId,
     routing,
-    ...(event.thread_ts ? { threadTs: event.thread_ts } : {}),
-    channel: event.channel,
-    ...(slackFiles ? { slackFiles } : {}),
-    ...(botSender ? { botSender } : {}),
-  };
+    msg.channel,
+    msg.user,
+    { chatType: "im", stampTeam: false, fallbackThreadToTs: false },
+    botToken,
+    renderContext,
+  );
 }
 
 /**
  * Normalize a Slack channel `message` event (thread reply in an active bot
  * thread) into the gateway's canonical inbound event shape.
  *
- * Returns null if the event should be ignored (subtypes, missing user,
+ * Returns null if the event should be ignored (subtypes, missing user/channel,
  * or unroutable channels).
  *
  * Bot's own messages are dropped by `processEventPayload` before
  * normalization.
  */
 export function normalizeSlackChannelMessage(
-  event: SlackChannelMessageEvent,
+  event: unknown,
   eventId: string,
   config: GatewayConfig,
   botToken?: string,
   renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
-  // file_share is allowed so image/file uploads are delivered to the assistant.
-  if (event.subtype && event.subtype !== "file_share") return null;
-  if (!event.user) return null;
+  const parsed = slackMessageEventSchema.safeParse(event);
+  if (!parsed.success) return null;
+  const msg = parsed.data;
 
-  const routing = resolveAssistant(config, event.channel, event.user);
+  // file_share is allowed so image/file uploads are delivered to the assistant.
+  if (msg.subtype && msg.subtype !== "file_share") return null;
+  if (!msg.user || !msg.channel) return null;
+
+  const routing = resolveAssistant(config, msg.channel, msg.user);
   if (isRejection(routing)) return null;
 
-  const content = renderSlackInboundText(event.text, renderContext);
-  const externalMessageId =
-    event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
-
-  const attachments = extractSlackAttachments(event.files);
-  const slackFiles = extractSlackFileMap(event.files);
-
-  const userInfo =
-    botToken && event.user
-      ? resolveSlackUserSync(event.user, botToken)
-      : undefined;
-  const botSender = slackBotSenderInfo(event, userInfo);
-
-  return {
-    event: {
-      version: "v1",
-      sourceChannel: "slack",
-      receivedAt: new Date().toISOString(),
-      message: {
-        content,
-        conversationExternalId: event.channel,
-        externalMessageId,
-        ...(attachments.length > 0 ? { attachments } : {}),
-      },
-      actor: {
-        actorExternalId: event.user,
-        ...(userInfo ? slackUserActorFields(userInfo) : {}),
-        ...(event.team ? { teamId: event.team } : {}),
-        ...(botSender ? { isBot: true } : {}),
-      },
-      source: {
-        updateId: eventId,
-        messageId: event.ts,
-        chatType: "channel",
-        ...(event.thread_ts ? { threadId: event.thread_ts } : {}),
-      },
-      raw: event as unknown as Record<string, unknown>,
-    },
+  return buildNormalizedSlackMessage(
+    msg,
+    event as Record<string, unknown>,
+    eventId,
     routing,
-    threadTs: event.thread_ts ?? event.ts,
-    channel: event.channel,
-    ...(slackFiles ? { slackFiles } : {}),
-    ...(botSender ? { botSender } : {}),
-  };
+    msg.channel,
+    msg.user,
+    { chatType: "channel", stampTeam: true, fallbackThreadToTs: true },
+    botToken,
+    renderContext,
+  );
 }
 
 /**
- * Normalize a Slack `app_mention` event into the gateway's
- * canonical inbound event shape, matching the pattern used by
- * the Telegram normalizer.
+ * Normalize a Slack `app_mention` event into the gateway's canonical inbound
+ * event shape, matching the pattern used by the Telegram normalizer.
  *
- * Returns null if the event cannot be routed.
+ * Returns null if the event is missing identity fields or cannot be routed.
  */
 export function normalizeSlackAppMention(
-  event: SlackAppMentionEvent,
+  event: unknown,
   eventId: string,
   config: GatewayConfig,
   botToken?: string,
   renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
-  const routing = resolveAssistant(config, event.channel, event.user);
-  if (isRejection(routing)) {
-    return null;
-  }
+  const parsed = slackMessageEventSchema.safeParse(event);
+  if (!parsed.success) return null;
+  const msg = parsed.data;
 
-  const content = renderSlackInboundText(event.text, renderContext);
-  const externalMessageId =
-    event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
+  if (!msg.user || !msg.channel) return null;
 
-  const attachments = extractSlackAttachments(event.files);
-  const slackFiles = extractSlackFileMap(event.files);
+  const routing = resolveAssistant(config, msg.channel, msg.user);
+  if (isRejection(routing)) return null;
 
-  const userInfo =
-    botToken && event.user
-      ? resolveSlackUserSync(event.user, botToken)
-      : undefined;
-  const botSender = slackBotSenderInfo(event, userInfo);
-
-  return {
-    event: {
-      version: "v1",
-      sourceChannel: "slack",
-      receivedAt: new Date().toISOString(),
-      message: {
-        content,
-        conversationExternalId: event.channel,
-        externalMessageId,
-        ...(attachments.length > 0 ? { attachments } : {}),
-      },
-      actor: {
-        actorExternalId: event.user,
-        ...(userInfo ? slackUserActorFields(userInfo) : {}),
-        ...(event.team ? { teamId: event.team } : {}),
-        ...(botSender ? { isBot: true } : {}),
-      },
-      source: {
-        updateId: eventId,
-        messageId: event.ts,
-        ...(event.thread_ts ? { threadId: event.thread_ts } : {}),
-      },
-      raw: event as unknown as Record<string, unknown>,
-    },
+  return buildNormalizedSlackMessage(
+    msg,
+    event as Record<string, unknown>,
+    eventId,
     routing,
-    threadTs: event.thread_ts ?? event.ts,
-    channel: event.channel,
-    ...(slackFiles ? { slackFiles } : {}),
-    ...(botSender ? { botSender } : {}),
-  };
+    msg.channel,
+    msg.user,
+    { stampTeam: true, fallbackThreadToTs: true },
+    botToken,
+    renderContext,
+  );
 }
 
 /**

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -812,7 +812,7 @@ export function normalizeSlackDirectMessage(
   // Only plain user messages; file_share carries uploads. Edits/deletes have
   // their own normalizers.
   if (msg.subtype && msg.subtype !== "file_share") return null;
-  if (!msg.user || !msg.channel) return null;
+  if (!msg.user || !msg.channel || !msg.ts) return null;
 
   // DMs are always directed at the bot, so fall back to the default assistant
   // even when the DM channel id isn't in the routing table — otherwise guardian
@@ -862,7 +862,7 @@ export function normalizeSlackChannelMessage(
 
   // file_share is allowed so image/file uploads are delivered to the assistant.
   if (msg.subtype && msg.subtype !== "file_share") return null;
-  if (!msg.user || !msg.channel) return null;
+  if (!msg.user || !msg.channel || !msg.ts) return null;
 
   const routing = resolveAssistant(config, msg.channel, msg.user);
   if (isRejection(routing)) return null;
@@ -897,7 +897,7 @@ export function normalizeSlackAppMention(
   if (!parsed.success) return null;
   const msg = parsed.data;
 
-  if (!msg.user || !msg.channel) return null;
+  if (!msg.user || !msg.channel || !msg.ts) return null;
 
   const routing = resolveAssistant(config, msg.channel, msg.user);
   if (isRejection(routing)) return null;

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -409,7 +409,8 @@ export class SlackSocketModeClient {
   }
 
   private handleSlackMuteCommand(event: SlackAppMentionEvent): boolean {
-    if (!isSlackMuteCommand(event.text, this.config.botUserId)) {
+    const text = slackEventText(event);
+    if (!text || !isSlackMuteCommand(text, this.config.botUserId)) {
       return false;
     }
 
@@ -1075,8 +1076,8 @@ export class SlackSocketModeClient {
       const threadTs = appMentionEvent.thread_ts ?? appMentionEvent.ts;
       const routing = resolveAssistant(
         this.config.gatewayConfig,
-        appMentionEvent.channel,
-        appMentionEvent.user,
+        appMentionEvent.channel ?? "",
+        appMentionEvent.user ?? "",
       );
       if (
         this.config.threadMode === "mention_then_thread" &&

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1073,23 +1073,31 @@ export class SlackSocketModeClient {
 
     if (isAppMention) {
       const appMentionEvent = event as SlackAppMentionEvent;
+      const { channel, user } = appMentionEvent;
       const threadTs = appMentionEvent.thread_ts ?? appMentionEvent.ts;
-      const routing = resolveAssistant(
-        this.config.gatewayConfig,
-        appMentionEvent.channel ?? "",
-        appMentionEvent.user ?? "",
-      );
+      // Only arm the thread for a well-formed, routable mention — the same
+      // identity fields normalizeSlackAppMention requires. These are read from
+      // the raw, untrusted frame, so guard type as well as presence: a
+      // malformed mention (missing/non-string channel, user, or ts) must not
+      // arm a thread that would then admit later unmentioned replies, since the
+      // mention itself is dropped at normalization.
       if (
         this.config.threadMode === "mention_then_thread" &&
-        threadTs &&
-        !isRejection(routing) &&
-        appMentionEvent.channel
+        typeof channel === "string" &&
+        channel &&
+        typeof user === "string" &&
+        user &&
+        typeof threadTs === "string" &&
+        threadTs
       ) {
-        this.store.trackThread(
-          threadTs,
-          appMentionEvent.channel,
-          ACTIVE_THREAD_TTL_MS,
+        const routing = resolveAssistant(
+          this.config.gatewayConfig,
+          channel,
+          user,
         );
+        if (!isRejection(routing)) {
+          this.store.trackThread(threadTs, channel, ACTIVE_THREAD_TTL_MS);
+        }
       }
     }
 


### PR DESCRIPTION
## Prompt / plan

Next leaf in the Slack Socket Mode ingress-hardening arc. Closes the **normalizer-internal** non-string-`text` crash that the #38983 and #38990 reviews both flagged as follow-up, and — per the "DRY as you go / keep the reorg's seams in mind" direction — collapses the three ~90%-duplicated normalizers onto one tolerant schema + one shared builder so the coming reorg inherits already-deduplicated code.

### Why

`app_mention` / DM / channel `message` events are unvalidated `JSON.parse` output, but the three normalizers trusted a blanket cast to hand-written interfaces. A non-object payload threw, and — the live crash — a truthy non-string `text` flowed into `renderSlackInboundText`'s `matchAll` and took the event down **inside** the normalizer (normalize.ts:710/768/833). #38990 fixed the sibling label-resolution read; this closes the normalizer-internal site.

### What changed

**One tolerant schema for all three:**
- The three events differ only in discriminator values (`type`/`channel_type`) and which fields each keys on, so one `slackMessageEventSchema` (type via `z.infer`) backs all three. Every field `.optional().catch(undefined)`; `files`/`bot_profile` modeled tolerantly; `SlackFile` and `SlackBotProfile` are now schema-inferred (single source of truth). Wrappers take `unknown` and `safeParse` at the boundary.

**One shared builder (the DRY win):**
- `buildNormalizedSlackMessage` holds the shared construction (externalMessageId, attachment/file extraction, cache-only user lookup, bot-sender classification, text render, the whole canonical event). The three public normalizers become thin variant wrappers owning only their guards, routing (DM keeps its default-assistant fallback), and a small shape descriptor (`chatType` / team stamp / thread-ts fallback). Net: the three ~65-line bodies become one builder + three ~20-line wrappers.

**Crash-safety + identity:**
- A collapsed `text` renders empty content (`?? ""`) instead of crashing; each normalizer guards the identity fields it keys on (`channel` + `user`); `raw` stays verbatim.
- Key-integrity cross-check against `@slack/types` `GenericMessageEvent` (the superset of all three) via the shared `webhook-crosscheck` helpers. Value-checking is skipped because `@slack/types` models `files` as DOM `File[]`.

**socket-mode pre-normalization reads** of the now-optional fields are made safe: the mute-command check **reuses** the `slackEventText` string guard from #38990, and the app_mention thread-tracking pre-check collapses missing `channel`/`user` to a clean routing rejection.

### Why it's safe

- Behavior-preserving: all pre-existing message/attachment/threading/bot-sender tests pass unchanged (245 in the slack + socket-mode suites). Only malformed input — which previously threw or trusted garbage — now drops cleanly or renders empty.
- No change to routing, dedup keys, or the normalized output shape.

## Test plan

- `bun test src/slack/ src/__tests__/slack-*.test.ts src/slack/download.test.ts` — green (adds: non-object payload drop, non-string DM + app_mention text → empty content, missing channel/user drop, malformed `files` array → no attachments, raw preservation).
- **Negative control:** reverting the DM `safeParse` + the shared builder's `text ?? ""` turns 3 tests red — the non-object crash and the non-string-text crash for both DM and app_mention (confirming the shared builder guard protects all three). Restored.
- `tsc`, `eslint`, `prettier`, `knip`, generic-examples — clean.
- Note: `telegram/send.test.ts` shows a pre-existing Bun cross-file module-cache flake (`downloadAttachment` "not found") only in large multi-file runs; it passes 8/8 in isolation and is unrelated to these Slack changes.

### Follow-up (not in this PR)

The redundant `event as Slack*Event` narrowings at the `socket-mode.ts` normalize call sites fall out in the `parseSlackEnvelope` seam capstone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f)_