### PR TITLE
Let users close the pro-onboarding modal from the final step

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -404,6 +404,33 @@ describe("BillingOnboardingModal", () => {
     expect(domainsCalls).toBe(0);
   });
 
+  test("the complete step exposes a close button that dismisses", async () => {
+    subscriptionPlanId = "pro";
+    onboardingResponse = makeOnboarding({ domain_setup_available: false });
+    const { client, getByText, onClose } = renderModal();
+
+    await waitFor(
+      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+    await waitFor(() => expect(getByText("10 GB")).toBeTruthy(), {
+      timeout: 5000,
+    });
+    // The takeover holds no close control on the way through.
+    expect(document.body.querySelector('[aria-label="Close"]')).toBeNull();
+
+    assistantResponse = makeAssistant("large", 50);
+    await client.invalidateQueries();
+    await waitFor(() => expect(getByText("You're all set!")).toBeTruthy(), {
+      timeout: 5000,
+    });
+
+    const close = document.body.querySelector('[aria-label="Close"]');
+    expect(close).not.toBeNull();
+    fireEvent.click(close as Element);
+    expect(onClose).toHaveBeenCalled();
+  });
+
   test("storage-only package provisions without a machine card", async () => {
     subscriptionPlanId = "pro";
     onboardingResponse = makeOnboarding({ max_machine_tier: null });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -356,7 +356,9 @@ export function BillingOnboardingModal({
     >
       <Modal.Content
         size="md"
-        hideCloseButton
+        // The final step is terminal — nothing is in flight to interrupt, so it
+        // gets the standard dismiss. Earlier steps keep their exits in-content.
+        hideCloseButton={step !== "complete"}
         dismissOnOverlayClick={!lockTakeover}
         onEscapeKeyDown={lockTakeover ? (e) => e.preventDefault() : undefined}
         onInteractOutside={lockTakeover ? (e) => e.preventDefault() : undefined}


### PR DESCRIPTION
## Summary

The "You're all set!" step had no X — the only way out was clicking the backdrop. This adds one.

`BillingOnboardingModal` passed `hideCloseButton` unconditionally. That is deliberate for the provisioning takeover, which is locked so an accidental Esc or backdrop click can't bail the user out mid-provisioning — but the flag applies to the whole wizard, so it also stripped the X from the terminal step, where nothing is in flight.

```diff
-        hideCloseButton
+        hideCloseButton={step !== "complete"}
```

No new component: `Modal.Content` already ships the top-right X (`aria-label="Close"`, wired through `Dialog.Close`), which routes into the modal's existing `handleClose` → `onClose`.

## Scope

Only the `complete` step gains the X. The takeover and domain steps are unchanged — the three existing assertions that the takeover renders no close control still hold and still pass.

## Checked, not assumed

- The close button renders after `{children}` in `Modal.Content`, so it paints above `CreatureCorners` on the complete step.
- `CreatureCorners` is `pointer-events-none`, so the decorative layer cannot swallow the click.
- `handleClose` only fires the "continues in the background" toast when `step === "provisioning"`, so the new exit is a plain dismiss with no spurious toast.

## Verification

All 33 tests in `billing-onboarding-modal.test.tsx` pass via `bun run test:ci` (one file per process). Added one test asserting the X is absent during the takeover, present on the complete step, and calls `onClose` when clicked.

eslint output is byte-identical to baseline (2 pre-existing `curly` warnings, none introduced). The added test introduces no prettier deviation.

Note: this file leans on 5s `waitFor` timeouts and is timing-sensitive under CPU load — if it flakes in CI, re-run before investigating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)