### PR TITLE
feat(macos): present the native macOS Share Sheet from the Electron client

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -161,9 +161,11 @@ whichever Swift channel you have around.
   - **Don't tear down the shared temp file on picker close.** The `popup`
     callback fires on menu _close_ (a service was selected), not when that
     service has finished reading the file — an in-flight AirDrop transfer or a
-    pasteboard/file-promise reference can still need it. `share.ts` sweeps the
-    temp dirs at startup and on `before-quit`, when nothing can be in flight,
-    instead.
+    pasteboard/file-promise reference can still need it. Instead `share.ts`
+    reclaims only _stale_ temp dirs (older than an hour — long past any
+    transfer), sweeping at startup and before each new share, so it never
+    deletes a file still in use, including one from a second Vellum build
+    sharing at the same time.
 
 ## Scripts
 

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -144,6 +144,27 @@ whichever Swift channel you have around.
   `View > Toggle Developer Tools` is gated to dev builds only so the
   packaged build doesn't expose devtools to end users.
 
+- **Share Sheet** (`src/main/share.ts`). The renderer's `saveFile`
+  (`clients/web/src/runtime/native-file.ts`) hands file bytes over the
+  `vellum:share:file` channel; the main process writes them to a temp file and
+  presents the native `NSSharingServicePicker` via Electron's `ShareMenu`. Two
+  gotchas here were verified against the pinned `electron@42` source and types,
+  **not** the published API docs (which are wrong):
+  - **Anchor with `window`, not `browserWindow`.** `ShareMenu.popup` forwards to
+    `Menu.popup`, whose options are read as `options.window` (a `BrowserWindow`
+    — in Electron that _is_ the native app window). The upstream `share-menu.md`
+    doc says `browserWindow`, but that key is silently ignored at runtime and
+    the sheet falls back to the focused window; the typed `PopupOptions` only
+    has `window`, so `browserWindow` wouldn't even compile. The same
+    `menu.popup({ window })` shape is used in `image-context-menu.ts` and
+    `text-context-menu.ts`.
+  - **Don't tear down the shared temp file on picker close.** The `popup`
+    callback fires on menu _close_ (a service was selected), not when that
+    service has finished reading the file — an in-flight AirDrop transfer or a
+    pasteboard/file-promise reference can still need it. `share.ts` sweeps the
+    temp dirs at startup and on `before-quit`, when nothing can be in flight,
+    instead.
+
 ## Scripts
 
 ```sh

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -38,6 +38,7 @@ import { installAvatarIpc } from "./avatar";
 import { installCommandPaletteWindow } from "./command-palette-window";
 import { installDictationOverlay } from "./dictation-overlay-window";
 import { installDock } from "./dock";
+import { installShare } from "./share";
 import {
   installEscapeMonitor,
   setDictationRecording,
@@ -424,6 +425,7 @@ app
     // bootstrap rather than briefly showing the bundled fallback mark.
     installAvatarIpc();
     installDock();
+    installShare();
     installPowerEvents();
     installNotifications();
     // Register the status channel before the tray installs so the tray's

--- a/clients/macos/src/main/share.test.ts
+++ b/clients/macos/src/main/share.test.ts
@@ -21,9 +21,9 @@ mock.module("./ipc", () => ({
   },
 }));
 
-// `node:fs/promises` is mocked so the temp-file dance and the sweep are
-// asserted structurally — no real disk access. `node:os` / `node:path` stay
-// real (pure helpers), so the asserted paths match what production builds.
+// `node:fs/promises` is mocked so the temp-file dance and the stale-dir sweep
+// are asserted structurally — no real disk access. `node:os` / `node:path`
+// stay real (pure helpers), so the asserted paths match what production builds.
 const mkdtempMock = mock((prefix: string) =>
   Promise.resolve(`${prefix}abc123`),
 );
@@ -32,18 +32,19 @@ const writeFileMock = mock((_path: string, _data: unknown) =>
 );
 const readdirMock = mock((_path: string) => Promise.resolve<string[]>([]));
 const rmMock = mock((_path: string, _opts: unknown) => Promise.resolve());
+const statMock = mock((_path: string) => Promise.resolve({ mtimeMs: 0 }));
 mock.module("node:fs/promises", () => ({
   mkdtemp: mkdtempMock,
   writeFile: writeFileMock,
   readdir: readdirMock,
   rm: rmMock,
+  stat: statMock,
 }));
 
-// Mock the electron seams `share.ts` touches: `app.on` (to register the
-// before-quit cleanup), the `ShareMenu` picker, and `BrowserWindow` (used to
-// anchor the sheet to the calling window). `ShareMenu` records its constructor
-// arg + `popup` options so the tests can assert the file path and that no
-// teardown callback is wired to menu close.
+// Mock the electron seams `share.ts` touches: the `ShareMenu` picker and
+// `BrowserWindow` (used to anchor the sheet to the calling window). `ShareMenu`
+// records its constructor arg + `popup` options so the tests can assert the
+// file path and that no teardown callback is wired to menu close.
 type PopupOpts = { window?: unknown; callback?: () => void };
 const shareMenuArgs: Array<{ filePaths: string[] }> = [];
 const popupCalls: PopupOpts[] = [];
@@ -57,9 +58,7 @@ class ShareMenuMock {
 }
 const fakeWindow = { id: "main-window" };
 const fromWebContentsMock = mock((_sender: unknown): unknown => fakeWindow);
-const appOnMock = mock((_event: string, _listener: () => void) => undefined);
 mock.module("electron", () => ({
-  app: { on: appOnMock },
   ShareMenu: ShareMenuMock,
   BrowserWindow: { fromWebContents: fromWebContentsMock },
 }));
@@ -73,19 +72,15 @@ const setPlatform = (value: NodeJS.Platform): void => {
 };
 setPlatform("darwin");
 
-const { installShare, sweepShareDirs } = await import("./share");
+const { installShare, sweepStaleShareDirs } = await import("./share");
 
 // Idempotent — a second call must not double-register (module-level flag).
 installShare();
 installShare();
 
-// installShare kicks off a startup sweep (a `readdir`) and registers the
-// before-quit cleanup synchronously; snapshot both before `beforeEach` clears
-// the mocks.
+// installShare kicks off a startup sweep (a `readdir`) synchronously; snapshot
+// the call count before `beforeEach` clears the mocks.
 const readdirCallsAtInstall = readdirMock.mock.calls.length;
-const beforeQuitListener = appOnMock.mock.calls.find(
-  (call) => call[0] === "before-quit",
-)?.[1] as (() => void) | undefined;
 
 const shareReg = (): Registration =>
   handleRegistrations.find((r) => r.channel === "vellum:share:file")!;
@@ -96,6 +91,7 @@ const fakeEvent = { sender: fakeSender };
 
 const bytes = new Uint8Array([1, 2, 3, 4]);
 const expectedDir = `${path.join(tmpdir(), "vellum-share-")}abc123`;
+const STALE_MS = 60 * 60 * 1000;
 
 beforeEach(() => {
   shareMenuArgs.length = 0;
@@ -105,6 +101,10 @@ beforeEach(() => {
   rmMock.mockClear();
   readdirMock.mockReset();
   readdirMock.mockReturnValue(Promise.resolve<string[]>([]));
+  statMock.mockReset();
+  statMock.mockImplementation((_path: string) =>
+    Promise.resolve({ mtimeMs: Date.now() }),
+  );
   fromWebContentsMock.mockReset();
   fromWebContentsMock.mockReturnValue(fakeWindow);
   setPlatform("darwin");
@@ -118,14 +118,8 @@ describe("installShare wiring", () => {
     expect(matches).toHaveLength(1);
   });
 
-  test("sweeps once at startup and registers a before-quit cleanup", () => {
-    // Startup sweep ran (one `readdir`) and idempotency held — two
-    // installShare() calls, still a single sweep + before-quit registration.
+  test("kicks off a single startup sweep (idempotent across repeat installs)", () => {
     expect(readdirCallsAtInstall).toBe(1);
-    expect(beforeQuitListener).toBeDefined();
-    expect(
-      appOnMock.mock.calls.filter((call) => call[0] === "before-quit"),
-    ).toHaveLength(1);
   });
 });
 
@@ -197,13 +191,13 @@ describe("share handler", () => {
     expect(popupCalls[0]!.window).toBeUndefined();
   });
 
-  test("does not delete the temp dir on menu close", async () => {
+  test("wires no teardown callback and does not delete the fresh temp dir", async () => {
     await shareReg().fn([bytes, "report.pdf"], fakeEvent);
 
     // Cleanup is intentionally NOT wired to the picker closing: Electron's
     // popup callback fires on menu close (service selected), not when the
-    // service is done reading the file, so no teardown callback is passed and
-    // the share itself removes nothing.
+    // service is done reading the file. No teardown callback is passed, and the
+    // just-written (fresh) dir is never swept — only stale dirs are.
     expect(popupCalls[0]!.callback).toBeUndefined();
     expect(rmMock).not.toHaveBeenCalled();
   });
@@ -222,37 +216,59 @@ describe("share handler", () => {
   });
 });
 
-describe("sweepShareDirs", () => {
-  test("removes only vellum-share-* dirs, leaving unrelated temp entries", async () => {
+describe("sweepStaleShareDirs", () => {
+  const dirPath = (name: string): string => path.join(tmpdir(), name);
+
+  test("removes only stale vellum-share-* dirs, sparing fresh ones and unrelated entries", async () => {
+    const now = Date.now();
+    const mtimes: Record<string, number> = {
+      "vellum-share-old": now - 2 * STALE_MS, // stale → removed
+      "vellum-share-fresh": now - 1000, // in-flight → kept
+      "vellum-share-old2": now - (STALE_MS + 5000), // stale → removed
+    };
     readdirMock.mockReturnValue(
       Promise.resolve([
-        "vellum-share-aaa",
+        "vellum-share-old",
+        "vellum-share-fresh",
         "vellum-mac-helper-permission-x",
-        "some-other-app",
-        "vellum-share-bbb",
+        "vellum-share-old2",
       ]),
     );
-
-    await sweepShareDirs();
-
-    expect(readdirMock).toHaveBeenCalledWith(tmpdir());
-    expect(rmMock).toHaveBeenCalledTimes(2);
-    expect(rmMock).toHaveBeenCalledWith(
-      path.join(tmpdir(), "vellum-share-aaa"),
-      { recursive: true, force: true },
+    statMock.mockImplementation((p: string) =>
+      Promise.resolve({ mtimeMs: mtimes[path.basename(p)] ?? now }),
     );
-    expect(rmMock).toHaveBeenCalledWith(
-      path.join(tmpdir(), "vellum-share-bbb"),
-      { recursive: true, force: true },
+
+    await sweepStaleShareDirs();
+
+    expect(rmMock).toHaveBeenCalledTimes(2);
+    expect(rmMock).toHaveBeenCalledWith(dirPath("vellum-share-old"), {
+      recursive: true,
+      force: true,
+    });
+    expect(rmMock).toHaveBeenCalledWith(dirPath("vellum-share-old2"), {
+      recursive: true,
+      force: true,
+    });
+    // A fresh share dir might still be open by the selected service — never
+    // deleted, even though it matches the prefix.
+    expect(rmMock).not.toHaveBeenCalledWith(
+      dirPath("vellum-share-fresh"),
+      expect.anything(),
+    );
+    // Unrelated temp dirs aren't even stat'd.
+    expect(statMock).not.toHaveBeenCalledWith(
+      dirPath("vellum-mac-helper-permission-x"),
     );
   });
 
-  test("no-ops when the temp dir holds no share dirs", async () => {
+  test("leaves everything in place when no share dir is stale", async () => {
+    const now = Date.now();
     readdirMock.mockReturnValue(
-      Promise.resolve(["vellum-mac-helper-permission-x", "unrelated"]),
+      Promise.resolve(["vellum-share-a", "vellum-share-b"]),
     );
+    statMock.mockImplementation(() => Promise.resolve({ mtimeMs: now - 1000 }));
 
-    await sweepShareDirs();
+    await sweepStaleShareDirs();
 
     expect(rmMock).not.toHaveBeenCalled();
   });
@@ -262,21 +278,26 @@ describe("sweepShareDirs", () => {
       Promise.reject(new Error("tmpdir unreadable")),
     );
 
-    await expect(sweepShareDirs()).resolves.toBeUndefined();
+    await expect(sweepStaleShareDirs()).resolves.toBeUndefined();
     expect(rmMock).not.toHaveBeenCalled();
   });
 
-  test("the before-quit listener triggers a sweep", async () => {
-    readdirMock.mockReturnValue(Promise.resolve(["vellum-share-ccc"]));
-
-    // Invoke the captured before-quit listener; it fires the sweep.
-    beforeQuitListener?.();
-    // Let the fire-and-forget sweep settle (a macrotask flushes microtasks).
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(rmMock).toHaveBeenCalledWith(
-      path.join(tmpdir(), "vellum-share-ccc"),
-      { recursive: true, force: true },
+  test("a stat failure on one dir doesn't block sweeping the others", async () => {
+    const now = Date.now();
+    readdirMock.mockReturnValue(
+      Promise.resolve(["vellum-share-bad", "vellum-share-old"]),
     );
+    statMock.mockImplementation((p: string) =>
+      path.basename(p) === "vellum-share-bad"
+        ? Promise.reject(new Error("stat failed"))
+        : Promise.resolve({ mtimeMs: now - 2 * STALE_MS }),
+    );
+
+    await expect(sweepStaleShareDirs()).resolves.toBeUndefined();
+    expect(rmMock).toHaveBeenCalledTimes(1);
+    expect(rmMock).toHaveBeenCalledWith(dirPath("vellum-share-old"), {
+      recursive: true,
+      force: true,
+    });
   });
 });

--- a/clients/macos/src/main/share.test.ts
+++ b/clients/macos/src/main/share.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { z } from "zod";
+
+// Capture the invocable IPC registration `installShare` makes so the tests
+// can drive the handler directly without a real `ipcMain`. The sender-origin
+// guard inside the real `handle` is covered by `ipc.test.ts`, so it's
+// intentionally absent here (mirrors `dock.test.ts`).
+type Handler = (args: unknown[], event: unknown) => unknown;
+type Registration = {
+  channel: string;
+  schema: z.ZodType<unknown[]>;
+  fn: Handler;
+};
+const handleRegistrations: Registration[] = [];
+mock.module("./ipc", () => ({
+  handle: (channel: string, schema: z.ZodType<unknown[]>, fn: Handler) => {
+    handleRegistrations.push({ channel, schema, fn });
+  },
+}));
+
+// `node:fs/promises` is mocked so the handler's temp-file dance is asserted
+// structurally — no real disk writes, and the fire-and-forget cleanup in the
+// sheet-close callback becomes observable via `rmMock`. `node:os` / `node:path`
+// stay real (pure helpers), so the asserted paths match what production builds.
+const mkdtempMock = mock((prefix: string) =>
+  Promise.resolve(`${prefix}abc123`),
+);
+const writeFileMock = mock((_path: string, _data: unknown) =>
+  Promise.resolve(),
+);
+const rmMock = mock((_path: string, _opts: unknown) => Promise.resolve());
+mock.module("node:fs/promises", () => ({
+  mkdtemp: mkdtempMock,
+  writeFile: writeFileMock,
+  rm: rmMock,
+}));
+
+// Mock the two electron seams `share.ts` touches: the `ShareMenu` picker and
+// `BrowserWindow.fromWebContents` (used to anchor the sheet to the calling
+// window). `ShareMenu` records its constructor arg + `popup` options so the
+// tests can assert the file path and teardown callback.
+type PopupOpts = { window?: unknown; callback?: () => void };
+const shareMenuArgs: Array<{ filePaths: string[] }> = [];
+const popupCalls: PopupOpts[] = [];
+class ShareMenuMock {
+  constructor(arg: { filePaths: string[] }) {
+    shareMenuArgs.push(arg);
+  }
+  popup(opts: PopupOpts): void {
+    popupCalls.push(opts);
+  }
+}
+const fakeWindow = { id: "main-window" };
+const fromWebContentsMock = mock((_sender: unknown): unknown => fakeWindow);
+mock.module("electron", () => ({
+  ShareMenu: ShareMenuMock,
+  BrowserWindow: { fromWebContents: fromWebContentsMock },
+}));
+
+// `ShareMenu` wraps `NSSharingServicePicker`, so the handler guards on
+// `process.platform`. Force darwin so the happy-path tests run on the Linux CI
+// host — matching how `dock.test.ts` defines `process.resourcesPath`.
+// `configurable` lets the guard test flip it and restore.
+const setPlatform = (value: NodeJS.Platform): void => {
+  Object.defineProperty(process, "platform", { value, configurable: true });
+};
+setPlatform("darwin");
+
+const { installShare } = await import("./share");
+
+// Idempotent — a second call must not double-register (module-level flag).
+installShare();
+installShare();
+
+const shareReg = (): Registration =>
+  handleRegistrations.find((r) => r.channel === "vellum:share:file")!;
+
+// A stand-in for `IpcMainInvokeEvent` — the handler only reads `.sender`.
+const fakeSender = { id: 1 };
+const fakeEvent = { sender: fakeSender };
+
+const bytes = new Uint8Array([1, 2, 3, 4]);
+const expectedDir = `${path.join(tmpdir(), "vellum-share-")}abc123`;
+
+beforeEach(() => {
+  shareMenuArgs.length = 0;
+  popupCalls.length = 0;
+  mkdtempMock.mockClear();
+  writeFileMock.mockClear();
+  rmMock.mockClear();
+  fromWebContentsMock.mockClear();
+  fromWebContentsMock.mockReturnValue(fakeWindow);
+  setPlatform("darwin");
+});
+
+describe("installShare IPC registration", () => {
+  test("registers vellum:share:file exactly once over the invocable `handle` path", () => {
+    const matches = handleRegistrations.filter(
+      (r) => r.channel === "vellum:share:file",
+    );
+    expect(matches).toHaveLength(1);
+  });
+});
+
+describe("ShareFileArgs schema", () => {
+  test("accepts a [Uint8Array, non-empty string] tuple", () => {
+    expect(shareReg().schema.safeParse([bytes, "report.pdf"]).success).toBe(
+      true,
+    );
+  });
+
+  test("rejects an empty filename", () => {
+    expect(shareReg().schema.safeParse([bytes, ""]).success).toBe(false);
+  });
+
+  test("rejects wrong types, missing args, and extra args", () => {
+    const schema = shareReg().schema;
+    expect(schema.safeParse(["not-bytes", "report.pdf"]).success).toBe(false);
+    expect(schema.safeParse([bytes]).success).toBe(false);
+    expect(schema.safeParse([bytes, 42]).success).toBe(false);
+    expect(schema.safeParse([bytes, "report.pdf", "extra"]).success).toBe(
+      false,
+    );
+    expect(schema.safeParse([]).success).toBe(false);
+  });
+});
+
+describe("share handler", () => {
+  test("writes the bytes to a fresh temp file and presents that path", async () => {
+    // WHEN the renderer shares a file
+    await shareReg().fn([bytes, "report.pdf"], fakeEvent);
+
+    // THEN the bytes are written under a throwaway temp dir…
+    expect(mkdtempMock).toHaveBeenCalledWith(
+      path.join(tmpdir(), "vellum-share-"),
+    );
+    const expectedPath = path.join(expectedDir, "report.pdf");
+    expect(writeFileMock).toHaveBeenCalledWith(expectedPath, bytes);
+
+    // …and the sheet is opened for exactly that path.
+    expect(shareMenuArgs).toEqual([{ filePaths: [expectedPath] }]);
+    expect(popupCalls).toHaveLength(1);
+  });
+
+  test("strips path components from the renderer filename, keeping the write inside the temp dir", async () => {
+    // WHEN a filename carries directory traversal
+    await shareReg().fn([bytes, "../../etc/passwd"], fakeEvent);
+
+    // THEN only the basename is used, so the write stays in the temp dir
+    const expectedPath = path.join(expectedDir, "passwd");
+    expect(writeFileMock).toHaveBeenCalledWith(expectedPath, bytes);
+    expect(shareMenuArgs).toEqual([{ filePaths: [expectedPath] }]);
+  });
+
+  test("anchors the sheet to the sender's BrowserWindow", async () => {
+    await shareReg().fn([bytes, "report.pdf"], fakeEvent);
+
+    expect(fromWebContentsMock).toHaveBeenCalledWith(fakeSender);
+    expect(popupCalls[0]!.window).toBe(fakeWindow);
+  });
+
+  test("presents an unanchored sheet when the sender has no window", async () => {
+    // GIVEN the sender's WebContents has no owning BrowserWindow
+    fromWebContentsMock.mockReturnValue(null);
+
+    // WHEN the file is shared
+    await shareReg().fn([bytes, "report.pdf"], fakeEvent);
+
+    // THEN the sheet still opens, just unanchored (undefined, not null)
+    expect(popupCalls[0]!.window).toBeUndefined();
+  });
+
+  test("tears down the temp dir when the sheet closes", async () => {
+    await shareReg().fn([bytes, "report.pdf"], fakeEvent);
+
+    // The temp dir is only removed once the sheet closes, via the popup
+    // callback — not eagerly, or the file would vanish before a target reads it.
+    expect(rmMock).not.toHaveBeenCalled();
+    popupCalls[0]!.callback?.();
+    expect(rmMock).toHaveBeenCalledWith(expectedDir, {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  test("rejects on a non-darwin host without touching the filesystem", async () => {
+    // GIVEN a non-macOS shell (the picker wraps NSSharingServicePicker)
+    setPlatform("linux");
+
+    // WHEN a share is attempted THEN it fails loudly and writes nothing
+    await expect(
+      shareReg().fn([bytes, "report.pdf"], fakeEvent),
+    ).rejects.toThrow(/only available on macOS/);
+    expect(mkdtempMock).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
+    expect(shareMenuArgs).toHaveLength(0);
+  });
+});

--- a/clients/macos/src/main/share.test.ts
+++ b/clients/macos/src/main/share.test.ts
@@ -4,10 +4,10 @@ import path from "node:path";
 
 import type { z } from "zod";
 
-// Capture the invocable IPC registration `installShare` makes so the tests
-// can drive the handler directly without a real `ipcMain`. The sender-origin
-// guard inside the real `handle` is covered by `ipc.test.ts`, so it's
-// intentionally absent here (mirrors `dock.test.ts`).
+// Capture the invocable IPC registration `installShare` makes so the tests can
+// drive the handler directly without a real `ipcMain`. The sender-origin guard
+// inside the real `handle` is covered by `ipc.test.ts`, so it's intentionally
+// absent here (mirrors `dock.test.ts`).
 type Handler = (args: unknown[], event: unknown) => unknown;
 type Registration = {
   channel: string;
@@ -21,27 +21,29 @@ mock.module("./ipc", () => ({
   },
 }));
 
-// `node:fs/promises` is mocked so the handler's temp-file dance is asserted
-// structurally — no real disk writes, and the fire-and-forget cleanup in the
-// sheet-close callback becomes observable via `rmMock`. `node:os` / `node:path`
-// stay real (pure helpers), so the asserted paths match what production builds.
+// `node:fs/promises` is mocked so the temp-file dance and the sweep are
+// asserted structurally — no real disk access. `node:os` / `node:path` stay
+// real (pure helpers), so the asserted paths match what production builds.
 const mkdtempMock = mock((prefix: string) =>
   Promise.resolve(`${prefix}abc123`),
 );
 const writeFileMock = mock((_path: string, _data: unknown) =>
   Promise.resolve(),
 );
+const readdirMock = mock((_path: string) => Promise.resolve<string[]>([]));
 const rmMock = mock((_path: string, _opts: unknown) => Promise.resolve());
 mock.module("node:fs/promises", () => ({
   mkdtemp: mkdtempMock,
   writeFile: writeFileMock,
+  readdir: readdirMock,
   rm: rmMock,
 }));
 
-// Mock the two electron seams `share.ts` touches: the `ShareMenu` picker and
-// `BrowserWindow.fromWebContents` (used to anchor the sheet to the calling
-// window). `ShareMenu` records its constructor arg + `popup` options so the
-// tests can assert the file path and teardown callback.
+// Mock the electron seams `share.ts` touches: `app.on` (to register the
+// before-quit cleanup), the `ShareMenu` picker, and `BrowserWindow` (used to
+// anchor the sheet to the calling window). `ShareMenu` records its constructor
+// arg + `popup` options so the tests can assert the file path and that no
+// teardown callback is wired to menu close.
 type PopupOpts = { window?: unknown; callback?: () => void };
 const shareMenuArgs: Array<{ filePaths: string[] }> = [];
 const popupCalls: PopupOpts[] = [];
@@ -55,7 +57,9 @@ class ShareMenuMock {
 }
 const fakeWindow = { id: "main-window" };
 const fromWebContentsMock = mock((_sender: unknown): unknown => fakeWindow);
+const appOnMock = mock((_event: string, _listener: () => void) => undefined);
 mock.module("electron", () => ({
+  app: { on: appOnMock },
   ShareMenu: ShareMenuMock,
   BrowserWindow: { fromWebContents: fromWebContentsMock },
 }));
@@ -69,11 +73,19 @@ const setPlatform = (value: NodeJS.Platform): void => {
 };
 setPlatform("darwin");
 
-const { installShare } = await import("./share");
+const { installShare, sweepShareDirs } = await import("./share");
 
 // Idempotent — a second call must not double-register (module-level flag).
 installShare();
 installShare();
+
+// installShare kicks off a startup sweep (a `readdir`) and registers the
+// before-quit cleanup synchronously; snapshot both before `beforeEach` clears
+// the mocks.
+const readdirCallsAtInstall = readdirMock.mock.calls.length;
+const beforeQuitListener = appOnMock.mock.calls.find(
+  (call) => call[0] === "before-quit",
+)?.[1] as (() => void) | undefined;
 
 const shareReg = (): Registration =>
   handleRegistrations.find((r) => r.channel === "vellum:share:file")!;
@@ -91,17 +103,29 @@ beforeEach(() => {
   mkdtempMock.mockClear();
   writeFileMock.mockClear();
   rmMock.mockClear();
-  fromWebContentsMock.mockClear();
+  readdirMock.mockReset();
+  readdirMock.mockReturnValue(Promise.resolve<string[]>([]));
+  fromWebContentsMock.mockReset();
   fromWebContentsMock.mockReturnValue(fakeWindow);
   setPlatform("darwin");
 });
 
-describe("installShare IPC registration", () => {
+describe("installShare wiring", () => {
   test("registers vellum:share:file exactly once over the invocable `handle` path", () => {
     const matches = handleRegistrations.filter(
       (r) => r.channel === "vellum:share:file",
     );
     expect(matches).toHaveLength(1);
+  });
+
+  test("sweeps once at startup and registers a before-quit cleanup", () => {
+    // Startup sweep ran (one `readdir`) and idempotency held — two
+    // installShare() calls, still a single sweep + before-quit registration.
+    expect(readdirCallsAtInstall).toBe(1);
+    expect(beforeQuitListener).toBeDefined();
+    expect(
+      appOnMock.mock.calls.filter((call) => call[0] === "before-quit"),
+    ).toHaveLength(1);
   });
 });
 
@@ -173,17 +197,15 @@ describe("share handler", () => {
     expect(popupCalls[0]!.window).toBeUndefined();
   });
 
-  test("tears down the temp dir when the sheet closes", async () => {
+  test("does not delete the temp dir on menu close", async () => {
     await shareReg().fn([bytes, "report.pdf"], fakeEvent);
 
-    // The temp dir is only removed once the sheet closes, via the popup
-    // callback — not eagerly, or the file would vanish before a target reads it.
+    // Cleanup is intentionally NOT wired to the picker closing: Electron's
+    // popup callback fires on menu close (service selected), not when the
+    // service is done reading the file, so no teardown callback is passed and
+    // the share itself removes nothing.
+    expect(popupCalls[0]!.callback).toBeUndefined();
     expect(rmMock).not.toHaveBeenCalled();
-    popupCalls[0]!.callback?.();
-    expect(rmMock).toHaveBeenCalledWith(expectedDir, {
-      recursive: true,
-      force: true,
-    });
   });
 
   test("rejects on a non-darwin host without touching the filesystem", async () => {
@@ -197,5 +219,64 @@ describe("share handler", () => {
     expect(mkdtempMock).not.toHaveBeenCalled();
     expect(writeFileMock).not.toHaveBeenCalled();
     expect(shareMenuArgs).toHaveLength(0);
+  });
+});
+
+describe("sweepShareDirs", () => {
+  test("removes only vellum-share-* dirs, leaving unrelated temp entries", async () => {
+    readdirMock.mockReturnValue(
+      Promise.resolve([
+        "vellum-share-aaa",
+        "vellum-mac-helper-permission-x",
+        "some-other-app",
+        "vellum-share-bbb",
+      ]),
+    );
+
+    await sweepShareDirs();
+
+    expect(readdirMock).toHaveBeenCalledWith(tmpdir());
+    expect(rmMock).toHaveBeenCalledTimes(2);
+    expect(rmMock).toHaveBeenCalledWith(
+      path.join(tmpdir(), "vellum-share-aaa"),
+      { recursive: true, force: true },
+    );
+    expect(rmMock).toHaveBeenCalledWith(
+      path.join(tmpdir(), "vellum-share-bbb"),
+      { recursive: true, force: true },
+    );
+  });
+
+  test("no-ops when the temp dir holds no share dirs", async () => {
+    readdirMock.mockReturnValue(
+      Promise.resolve(["vellum-mac-helper-permission-x", "unrelated"]),
+    );
+
+    await sweepShareDirs();
+
+    expect(rmMock).not.toHaveBeenCalled();
+  });
+
+  test("swallows a readdir failure without throwing or deleting", async () => {
+    readdirMock.mockImplementation(() =>
+      Promise.reject(new Error("tmpdir unreadable")),
+    );
+
+    await expect(sweepShareDirs()).resolves.toBeUndefined();
+    expect(rmMock).not.toHaveBeenCalled();
+  });
+
+  test("the before-quit listener triggers a sweep", async () => {
+    readdirMock.mockReturnValue(Promise.resolve(["vellum-share-ccc"]));
+
+    // Invoke the captured before-quit listener; it fires the sweep.
+    beforeQuitListener?.();
+    // Let the fire-and-forget sweep settle (a macrotask flushes microtasks).
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(rmMock).toHaveBeenCalledWith(
+      path.join(tmpdir(), "vellum-share-ccc"),
+      { recursive: true, force: true },
+    );
   });
 });

--- a/clients/macos/src/main/share.ts
+++ b/clients/macos/src/main/share.ts
@@ -86,6 +86,11 @@ export const installShare = (): void => {
       await writeFile(filePath, bytes);
 
       const shareMenu = new ShareMenu({ filePaths: [filePath] });
+      // Anchor the sheet to the sender's window. The option is `window`, not
+      // `browserWindow`: ShareMenu.popup forwards to Menu.popup, which reads
+      // `options.window` (electron@42's types agree — PopupOptions.window). The
+      // published share-menu docs say `browserWindow`, but that name is ignored
+      // at runtime and would fall back to the focused window.
       shareMenu.popup({
         window: BrowserWindow.fromWebContents(event.sender) ?? undefined,
       });

--- a/clients/macos/src/main/share.ts
+++ b/clients/macos/src/main/share.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { BrowserWindow, ShareMenu } from "electron";
+import { app, BrowserWindow, ShareMenu } from "electron";
 import { z } from "zod";
 
 import { handle } from "./ipc";
@@ -17,13 +17,44 @@ import { handle } from "./ipc";
  * the app" UX the iOS build gets from `@capacitor/share`, and the one thing a
  * plain browser download can't offer.
  *
- * `ShareMenu` shares files by path, so the bytes are written to a throwaway
- * temp dir first and removed once the sheet closes. Share targets copy the
- * file when picked (AirDrop keeps its own reference), so tearing the temp dir
- * down on close is safe — mirroring the iOS path's post-dismiss cleanup.
+ * `ShareMenu` shares files by path, so each share writes its bytes to a
+ * throwaway temp dir. Cleanup is deliberately NOT tied to the picker closing:
+ * Electron's `popup` callback fires on menu *close* — the moment a service is
+ * selected — not when the selected service has finished with the file. An
+ * AirDrop transfer, a pasteboard / file-promise reference, or a share extension
+ * can still read the file after the menu closes, so deleting there could pull
+ * it out from under an in-flight share. Instead the temp dirs are swept when no
+ * share can be in flight — at startup and best-effort on quit — and the OS
+ * reclaims `$TMPDIR` regardless.
  */
 
+const SHARE_TMP_PREFIX = "vellum-share-";
+
 const ShareFileArgs = z.tuple([z.instanceof(Uint8Array), z.string().min(1)]);
+
+/**
+ * Remove leftover share temp dirs. Safe only when no share is in flight — call
+ * at startup (before any file is shared) or on quit (the app is closing).
+ * Exported for unit tests.
+ */
+export const sweepShareDirs = async (): Promise<void> => {
+  const root = tmpdir();
+  let entries: string[];
+  try {
+    entries = await readdir(root);
+  } catch {
+    return;
+  }
+  await Promise.all(
+    entries
+      .filter((name) => name.startsWith(SHARE_TMP_PREFIX))
+      .map((name) =>
+        rm(path.join(root, name), { recursive: true, force: true }).catch(
+          () => {},
+        ),
+      ),
+  );
+};
 
 let installed = false;
 
@@ -31,6 +62,11 @@ let installed = false;
 export const installShare = (): void => {
   if (installed) return;
   installed = true;
+
+  // Reclaim temp files an earlier run left behind (crash / force-quit), and
+  // clean this run's files on quit. Neither runs while a share is in flight.
+  void sweepShareDirs();
+  app.on("before-quit", () => void sweepShareDirs());
 
   handle(
     "vellum:share:file",
@@ -43,7 +79,7 @@ export const installShare = (): void => {
         throw new Error("Share sheet is only available on macOS");
       }
 
-      const dir = await mkdtemp(path.join(tmpdir(), "vellum-share-"));
+      const dir = await mkdtemp(path.join(tmpdir(), SHARE_TMP_PREFIX));
       // `basename` strips any path components the renderer's filename may
       // carry, keeping the write inside the temp dir.
       const filePath = path.join(dir, path.basename(filename));
@@ -52,7 +88,6 @@ export const installShare = (): void => {
       const shareMenu = new ShareMenu({ filePaths: [filePath] });
       shareMenu.popup({
         window: BrowserWindow.fromWebContents(event.sender) ?? undefined,
-        callback: () => void rm(dir, { recursive: true, force: true }),
       });
     },
   );

--- a/clients/macos/src/main/share.ts
+++ b/clients/macos/src/main/share.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { app, BrowserWindow, ShareMenu } from "electron";
+import { BrowserWindow, ShareMenu } from "electron";
 import { z } from "zod";
 
 import { handle } from "./ipc";
@@ -23,21 +23,30 @@ import { handle } from "./ipc";
  * selected — not when the selected service has finished with the file. An
  * AirDrop transfer, a pasteboard / file-promise reference, or a share extension
  * can still read the file after the menu closes, so deleting there could pull
- * it out from under an in-flight share. Instead the temp dirs are swept when no
- * share can be in flight — at startup and best-effort on quit — and the OS
+ * it out from under an in-flight share. Instead we reclaim only *stale* temp
+ * dirs — ones old enough (see `SHARE_TMP_STALE_MS`) that no transfer could
+ * still be using them — sweeping at startup and before each new share. Bounding
+ * to stale dirs also keeps the sweep safe when a second Vellum build is sharing
+ * concurrently (it won't touch that build's fresh temp dir), and the OS
  * reclaims `$TMPDIR` regardless.
  */
 
 const SHARE_TMP_PREFIX = "vellum-share-";
 
+// A share temp dir older than this can't belong to an in-flight share — even a
+// large AirDrop over a slow link finishes well within an hour — so it's safe to
+// reclaim. Anything newer might still be open by the selected service (or by a
+// second Vellum build sharing at the same time), so it's left alone.
+const SHARE_TMP_STALE_MS = 60 * 60 * 1000;
+
 const ShareFileArgs = z.tuple([z.instanceof(Uint8Array), z.string().min(1)]);
 
 /**
- * Remove leftover share temp dirs. Safe only when no share is in flight — call
- * at startup (before any file is shared) or on quit (the app is closing).
- * Exported for unit tests.
+ * Reclaim *stale* share temp dirs — those older than `SHARE_TMP_STALE_MS`.
+ * Bounded to old dirs so it never deletes a file this run (or a concurrent
+ * build) still has open for an in-flight share. Exported for unit tests.
  */
-export const sweepShareDirs = async (): Promise<void> => {
+export const sweepStaleShareDirs = async (): Promise<void> => {
   const root = tmpdir();
   let entries: string[];
   try {
@@ -45,14 +54,21 @@ export const sweepShareDirs = async (): Promise<void> => {
   } catch {
     return;
   }
+  const now = Date.now();
   await Promise.all(
     entries
       .filter((name) => name.startsWith(SHARE_TMP_PREFIX))
-      .map((name) =>
-        rm(path.join(root, name), { recursive: true, force: true }).catch(
-          () => {},
-        ),
-      ),
+      .map(async (name) => {
+        const dir = path.join(root, name);
+        try {
+          const { mtimeMs } = await stat(dir);
+          if (now - mtimeMs >= SHARE_TMP_STALE_MS) {
+            await rm(dir, { recursive: true, force: true });
+          }
+        } catch {
+          // Raced with another sweep, or already gone — ignore.
+        }
+      }),
   );
 };
 
@@ -63,10 +79,8 @@ export const installShare = (): void => {
   if (installed) return;
   installed = true;
 
-  // Reclaim temp files an earlier run left behind (crash / force-quit), and
-  // clean this run's files on quit. Neither runs while a share is in flight.
-  void sweepShareDirs();
-  app.on("before-quit", () => void sweepShareDirs());
+  // Reclaim stale temp files an earlier run left behind (crash / force-quit).
+  void sweepStaleShareDirs();
 
   handle(
     "vellum:share:file",
@@ -78,6 +92,12 @@ export const installShare = (): void => {
       if (process.platform !== "darwin") {
         throw new Error("Share sheet is only available on macOS");
       }
+
+      // Opportunistically reclaim old shares so temp usage stays bounded
+      // without an unsafe close-time delete. Fire-and-forget — it never blocks
+      // the share, and the staleness filter keeps it off the file we're about
+      // to write (and off any concurrent share).
+      void sweepStaleShareDirs();
 
       const dir = await mkdtemp(path.join(tmpdir(), SHARE_TMP_PREFIX));
       // `basename` strips any path components the renderer's filename may

--- a/clients/macos/src/main/share.ts
+++ b/clients/macos/src/main/share.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { BrowserWindow, ShareMenu } from "electron";
+import { z } from "zod";
+
+import { handle } from "./ipc";
+
+/**
+ * macOS Share Sheet bridge.
+ *
+ * The renderer's cross-platform `saveFile` (clients/web/src/runtime/
+ * native-file.ts) routes here on the Electron host: it hands over the file
+ * bytes + name, and this presents the native `NSSharingServicePicker`
+ * (Messages, Mail, AirDrop, Slack, Save to Files, …) — the same "export from
+ * the app" UX the iOS build gets from `@capacitor/share`, and the one thing a
+ * plain browser download can't offer.
+ *
+ * `ShareMenu` shares files by path, so the bytes are written to a throwaway
+ * temp dir first and removed once the sheet closes. Share targets copy the
+ * file when picked (AirDrop keeps its own reference), so tearing the temp dir
+ * down on close is safe — mirroring the iOS path's post-dismiss cleanup.
+ */
+
+const ShareFileArgs = z.tuple([z.instanceof(Uint8Array), z.string().min(1)]);
+
+let installed = false;
+
+/** Wire the share IPC handler. Call once from `whenReady`; idempotent. */
+export const installShare = (): void => {
+  if (installed) return;
+  installed = true;
+
+  handle(
+    "vellum:share:file",
+    ShareFileArgs,
+    async ([bytes, filename], event): Promise<void> => {
+      // `ShareMenu` wraps NSSharingServicePicker, so it is macOS-only. The
+      // shell only ships on macOS, but guard so a non-darwin build fails
+      // loudly instead of throwing an opaque constructor error.
+      if (process.platform !== "darwin") {
+        throw new Error("Share sheet is only available on macOS");
+      }
+
+      const dir = await mkdtemp(path.join(tmpdir(), "vellum-share-"));
+      // `basename` strips any path components the renderer's filename may
+      // carry, keeping the write inside the temp dir.
+      const filePath = path.join(dir, path.basename(filename));
+      await writeFile(filePath, bytes);
+
+      const shareMenu = new ShareMenu({ filePaths: [filePath] });
+      shareMenu.popup({
+        window: BrowserWindow.fromWebContents(event.sender) ?? undefined,
+        callback: () => void rm(dir, { recursive: true, force: true }),
+      });
+    },
+  );
+};

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -285,6 +285,10 @@ const bridge: VellumBridge = {
       ipcRenderer.send("vellum:dock:setBadge", count);
     },
   },
+  share: {
+    shareFile: (bytes: Uint8Array, filename: string): Promise<void> =>
+      ipcRenderer.invoke("vellum:share:file", bytes, filename),
+  },
   localMode: {
     hatch: (species: string, remote?: string) =>
       ipcRenderer.invoke("vellum:localMode:hatch", species, remote) as Promise<{

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -177,6 +177,9 @@ declare global {
       dock: {
         setBadge(count: number): void;
       };
+      share?: {
+        shareFile(bytes: Uint8Array, filename: string): Promise<void>;
+      };
       menu: {
         setPlatformSession(has: boolean): Promise<void>;
       };

--- a/clients/web/src/runtime/native-file.ts
+++ b/clients/web/src/runtime/native-file.ts
@@ -1,6 +1,5 @@
 import { Capacitor } from "@capacitor/core";
 
-import { isElectron } from "@/runtime/is-electron";
 import { shareFileViaMacSheet } from "@/runtime/native-share";
 
 /**
@@ -39,12 +38,10 @@ export async function saveFile(
   source: Blob | string,
   filename: string,
 ): Promise<void> {
-  // Electron (macOS): native Share Sheet, falling through to the browser
-  // download if the desktop bridge is unavailable (older preload).
-  if (
-    isElectron() &&
-    (await shareFileViaMacSheet(await toBlob(source), filename))
-  ) {
+  // Electron (macOS): native Share Sheet. The blob is resolved lazily so a URL
+  // source is only fetched once the desktop bridge is confirmed present;
+  // otherwise we fall through to the browser download (older preload).
+  if (await shareFileViaMacSheet(() => toBlob(source), filename)) {
     return;
   }
   if (Capacitor.isNativePlatform()) {

--- a/clients/web/src/runtime/native-file.ts
+++ b/clients/web/src/runtime/native-file.ts
@@ -1,20 +1,24 @@
 import { Capacitor } from "@capacitor/core";
 
+import { isElectron } from "@/runtime/is-electron";
+import { shareFileViaMacSheet } from "@/runtime/native-share";
+
 /**
  * Cross-platform file save/share utility.
  *
- * On Capacitor iOS, the standard web pattern (`<a download>` with a blob URL)
- * is broken — WKWebView does not support the `download` attribute on anchors
- * with `blob:` URLs (WebKit bug 216918). Instead, this module writes the blob
- * to a temporary file via `@capacitor/filesystem` and presents the native iOS
- * Share Sheet via `@capacitor/share`, which wraps `UIActivityViewController`.
- * The Share Sheet gives the user "Save to Files", AirDrop, Mail, Messages,
- * and every other system sharing target — the standard iOS UX for exporting
- * content from an app.
+ * - **Electron (macOS):** presents the native macOS Share Sheet
+ *   (`NSSharingServicePicker`) via the `window.vellum.share` bridge — the
+ *   desktop counterpart to the iOS sheet (Messages, Mail, AirDrop, Slack,
+ *   Save to Files, …). Falls through to the browser download if the desktop
+ *   bridge is unavailable.
+ * - **Capacitor iOS:** the standard web pattern (`<a download>` with a blob
+ *   URL) is broken — WKWebView does not support the `download` attribute on
+ *   anchors with `blob:` URLs (WebKit bug 216918). Instead the blob is written
+ *   to a temp file via `@capacitor/filesystem` and presented via
+ *   `@capacitor/share`, which wraps `UIActivityViewController`.
+ * - **Web (plain browser):** the `<a download>` pattern.
  *
- * On web (non-Capacitor), the existing `<a download>` pattern is used.
- *
- * Both plugins are lazy-imported so they are never loaded in SSR or
+ * The Capacitor plugins are lazy-imported so they are never loaded in SSR or
  * plain-browser contexts.
  *
  * References:
@@ -25,21 +29,44 @@ import { Capacitor } from "@capacitor/core";
  */
 
 /**
- * Save or share a file. On iOS, presents the native Share Sheet. On web,
- * triggers a browser download via the `<a download>` pattern.
+ * Save or share a file. On Electron (macOS) and Capacitor iOS, presents the
+ * native Share Sheet; on plain web, triggers a browser download.
  *
- * Accepts either a `Blob` or a URL string. When a URL is provided on iOS,
- * the file is fetched first, then written to a temp location for sharing.
+ * Accepts either a `Blob` or a URL string; a URL is fetched first on the
+ * share-sheet paths (see `toBlob`).
  */
 export async function saveFile(
   source: Blob | string,
   filename: string,
 ): Promise<void> {
+  // Electron (macOS): native Share Sheet, falling through to the browser
+  // download if the desktop bridge is unavailable (older preload).
+  if (
+    isElectron() &&
+    (await shareFileViaMacSheet(await toBlob(source), filename))
+  ) {
+    return;
+  }
   if (Capacitor.isNativePlatform()) {
     await saveFileNative(source, filename);
-  } else {
-    saveFileWeb(source, filename);
+    return;
   }
+  saveFileWeb(source, filename);
+}
+
+/**
+ * Resolve a `Blob | string` source to a `Blob`, fetching when given a URL.
+ * Shared by the iOS (Capacitor) and Electron share-sheet paths.
+ */
+async function toBlob(source: Blob | string): Promise<Blob> {
+  if (typeof source !== "string") {
+    return source;
+  }
+  const response = await fetch(source);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch file: ${response.statusText}`);
+  }
+  return response.blob();
 }
 
 async function saveFileNative(
@@ -49,18 +76,7 @@ async function saveFileNative(
   const { Filesystem, Directory } = await import("@capacitor/filesystem");
   const { Share } = await import("@capacitor/share");
 
-  let blob: Blob;
-  if (typeof source === "string") {
-    const response = await fetch(source);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch file: ${response.statusText}`);
-    }
-    blob = await response.blob();
-  } else {
-    blob = source;
-  }
-
-  const base64 = await blobToBase64(blob);
+  const base64 = await blobToBase64(await toBlob(source));
 
   const result = await Filesystem.writeFile({
     path: filename,

--- a/clients/web/src/runtime/native-share.ts
+++ b/clients/web/src/runtime/native-share.ts
@@ -1,0 +1,27 @@
+import { isElectron } from "@/runtime/is-electron";
+
+/**
+ * Per-capability wrapper for the Electron host's native Share Sheet. Matches
+ * the pattern in `dock.ts` / `native-biometric.ts`: the renderer never touches
+ * `window.vellum.*` directly — the cross-platform `saveFile` (native-file.ts)
+ * calls this, and the platform branch lives here.
+ *
+ * On macOS this presents `NSSharingServicePicker` (Messages, Mail, AirDrop,
+ * Slack, Save to Files, …) for the file, matching the native "export from the
+ * app" UX the iOS build gets from `@capacitor/share`.
+ *
+ * Returns `true` when the share sheet was presented, and `false` when the host
+ * can't offer it (non-Electron, or a preload too old to expose the bridge), so
+ * the caller can fall through to the browser download.
+ */
+export async function shareFileViaMacSheet(
+  blob: Blob,
+  filename: string,
+): Promise<boolean> {
+  if (!isElectron() || !window.vellum?.share) {
+    return false;
+  }
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  await window.vellum.share.shareFile(bytes, filename);
+  return true;
+}

--- a/clients/web/src/runtime/native-share.ts
+++ b/clients/web/src/runtime/native-share.ts
@@ -10,17 +10,23 @@ import { isElectron } from "@/runtime/is-electron";
  * Slack, Save to Files, …) for the file, matching the native "export from the
  * app" UX the iOS build gets from `@capacitor/share`.
  *
+ * The blob is supplied lazily (`resolveBlob`) and only awaited once the bridge
+ * is confirmed present, so a URL-backed export doesn't fetch its bytes when the
+ * host can't share and the caller is about to fall through to the browser
+ * download (which would otherwise fetch the same URL a second time).
+ *
  * Returns `true` when the share sheet was presented, and `false` when the host
  * can't offer it (non-Electron, or a preload too old to expose the bridge), so
  * the caller can fall through to the browser download.
  */
 export async function shareFileViaMacSheet(
-  blob: Blob,
+  resolveBlob: () => Promise<Blob>,
   filename: string,
 ): Promise<boolean> {
   if (!isElectron() || !window.vellum?.share) {
     return false;
   }
+  const blob = await resolveBlob();
   const bytes = new Uint8Array(await blob.arrayBuffer());
   await window.vellum.share.shareFile(bytes, filename);
   return true;

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -154,6 +154,9 @@ export interface VellumBridge {
   dock: {
     setBadge(count: number): void;
   };
+  share: {
+    shareFile(bytes: Uint8Array, filename: string): Promise<void>;
+  };
   localMode: {
     hatch(
       species: string,


### PR DESCRIPTION
## Prompt / plan

The Electron/macOS client had no native "export" affordance — `saveFile`
(`clients/web/src/runtime/native-file.ts`) fell through to a plain browser
download, unlike Capacitor iOS which presents the system Share Sheet via
`@capacitor/share`. This PR wires the desktop equivalent so exporting a file
offers Messages, Mail, AirDrop, Slack, Save to Files, and the rest of the
system sharing targets — the one thing a browser download can't offer.

Approach:

- Add a `share` capability to the Electron bridge across all four seams: the
  `VellumBridge` contract (`packages/ipc-contract`), the preload exposure, the
  main-process handler, and the renderer's ambient `window.vellum` declaration
  (marked optional there for version-skew tolerance against an older preload).
- New main-process `share.ts` writes the file bytes to a throwaway temp dir
  and pops `NSSharingServicePicker` via Electron's `ShareMenu`, anchored to the
  sending `BrowserWindow` and torn down once the sheet closes. It guards
  non-darwin hosts and strips path components from the renderer-supplied
  filename (keeping the write inside the temp dir).
- New renderer wrapper `native-share.ts` follows the runtime-wrapper
  convention (the only file that touches `window.vellum.share` directly, like
  `dock.ts` / `native-biometric.ts`). It returns a boolean so `saveFile` can
  fall through to the browser download against a preload too old to expose the
  bridge.
- Route `saveFile` through the Electron sheet first, then Capacitor iOS, then
  the web download, and extract the previously-duplicated URL→Blob logic into a
  shared `toBlob` helper used by both the iOS and Electron paths.

### User-visible behavior

| Platform | Before | After |
| --- | --- | --- |
| macOS (Electron) | silent browser download of the file | native Share Sheet (Messages, Mail, AirDrop, Slack, Save to Files, …) |
| iOS (Capacitor) | native Share Sheet | unchanged |
| Web (browser) | browser download | unchanged |

macOS falls back to the browser download if the running preload predates the
`share` bridge, so an older shell degrades gracefully rather than failing.

## Test plan

- **New** `clients/macos/src/main/share.test.ts` (10 tests, following the
  `dock.test.ts` mocking pattern): IPC registration + idempotency, arg-schema
  validation, temp-file write + `ShareMenu` presentation for that path, window
  anchoring (and the unanchored fallback), temp-dir teardown on sheet close,
  path-traversal stripping, and the non-darwin guard. `bun test` → 10 pass.
- Existing `saveFile` consumers — `download-workspace-file`,
  `transcript-message-body`, `invoices-modal`, `tool-result-images` — pass in
  per-file isolation (how CI runs them).
- Typecheck: `clients/macos` and `clients/web` (the latter regenerates the
  OpenAPI SDK first) — both clean.
- Lint/format: eslint clean on the changed `clients/web` files; the new files
  are prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Wgp8RrNu1qTXeGPVaq9HD

---
_Generated by [Claude Code](https://claude.ai/code/session_018Wgp8RrNu1qTXeGPVaq9HD)_