### PR TITLE
feat(billing): gate custom-plan Continue on a change; open Stripe portal for Pro→Free

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -5,9 +5,10 @@
  * Continue stays disabled until all three dropdowns (machine size, storage,
  * credits) have an explicit choice, then fires the Stripe upgrade with the
  * selected tiers. An eligible Pro subscriber reaches the same modal seeded to
- * its current tiers, and Continue dispatches the change-machine/storage/
- * credit-tier endpoints (not checkout, which no-ops for an active Pro sub) and
- * opens the resize takeover. Configure opens the modal for a Pro sub the
+ * its current tiers; Continue stays disabled until a dimension changes, then
+ * dispatches the change-machine/storage/credit-tier endpoints (not checkout,
+ * which no-ops for an active Pro sub) and opens the resize takeover. Configure
+ * opens the modal for a Pro sub the
  * catalog can't fully represent too — e.g. a deprecated credit bundle — with
  * the seed holding the tier and any un-representable apply surfacing as a toast.
  *
@@ -600,7 +601,7 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
   });
 
-  test("opens seeded to the current plan so Continue needs no re-pick", () => {
+  test("opens seeded to the current plan, Continue disabled until a change", () => {
     // Current config: medium machine / 10 GB (xs) storage / no credits. The
     // configurator opens with all three pre-filled, so an unrelated edit can't
     // strand the user into re-picking — and dropping — a tier they still hold.
@@ -609,8 +610,8 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     fireEvent.click(getByRole("button", { name: "Configure" }));
 
     getByText("Create a custom plan");
-    // Seeded, so Continue is enabled with no interaction.
-    expect(continueButton().disabled).toBe(false);
+    // Seeded to the current plan (a no-op), so Continue starts disabled.
+    expect(continueButton().disabled).toBe(true);
 
     // The recap reflects the seeded current tiers.
     expect(recapRows()).toEqual([
@@ -619,6 +620,10 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
       "10 GB storage",
       "No extra credits",
     ]);
+
+    // Changing any dimension diverges from the seed and enables Continue.
+    selectOption("Machine size", "Large machine (4 vCPU, 8 GiB)");
+    expect(continueButton().disabled).toBe(false);
   });
 
   test("a seeded no-op shows the plain grey-check recap with no delta line", () => {
@@ -689,17 +694,19 @@ describe("CustomPlanModal — eligible Pro subscriber", () => {
     expect(delta!.className).toContain("text-[var(--system-negative-strong)]");
   });
 
-  test("continuing with the seeded config is a no-op with no dispatch", async () => {
-    const { getByRole, queryByText, queryByTestId } = renderPage(
+  test("the untouched seeded config holds Continue disabled and dispatches nothing", () => {
+    const { getByRole, getByText, queryByTestId } = renderPage(
       proMightySubscription(),
     );
 
     fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    // Nothing diverged from the current plan, so Continue is disabled — a click
+    // can't submit a no-op change-tier request and the modal stays open.
+    expect(continueButton().disabled).toBe(true);
     fireEvent.click(continueButton());
 
-    // Nothing diverged from the current plan, so no change-tier request fires
-    // and the resize takeover stays closed.
-    await waitFor(() => expect(queryByText("Create a custom plan")).toBeNull());
+    getByText("Create a custom plan");
     expect(machineTierCall).toBeNull();
     expect(storageTierCall).toBeNull();
     expect(creditTierCall).toBeNull();
@@ -922,10 +929,10 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
     expect(deltaLine()).toBeNull();
   });
 
-  test("a legacy-storage Pro sub sees the held tier and can continue", () => {
+  test("a legacy-storage Pro sub sees the held tier and can reconfigure", () => {
     // 250 GB (xl) is legacy: no longer offered, but still what this sub pays
-    // for. The picker shows it, the recap agrees with the total, and Continue
-    // is live so an unrelated edit isn't blocked.
+    // for. The picker shows it and the recap agrees with the total; an unrelated
+    // edit isn't blocked by the held legacy tier.
     const { getByRole, getByText } = renderPage(
       proMightySubscription(),
       onboarding({ selected_storage_tier: "xl", selected_storage_gib: 250 }),
@@ -933,7 +940,8 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
 
     fireEvent.click(getByRole("button", { name: "Configure" }));
 
-    expect(continueButton().disabled).toBe(false);
+    // Seeded to the held tier (a no-op), so Continue starts disabled.
+    expect(continueButton().disabled).toBe(true);
     expect(dropdownTrigger("Storage").textContent).toContain("250 GB");
     expect(recapRows()).toEqual([
       "Pro base plan — $20/mo",
@@ -943,6 +951,10 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
     ]);
     // base $20 + medium $35 + legacy 250 GB $60.
     getByText("$115/mo");
+
+    // The held legacy storage doesn't block an unrelated edit.
+    selectOption("Machine size", "Large machine (4 vCPU, 8 GiB)");
+    expect(continueButton().disabled).toBe(false);
   });
 
   test("the held legacy storage tier stays re-selectable", () => {

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -59,11 +59,12 @@ export interface CustomPlanModalProps {
   currentStorageGib?: number | null;
   /**
    * The Pro subscriber's current tiers, when reconfiguring an existing Pro
-   * plan. Pre-fills every dimension so the default is a no-op and an unrelated
-   * edit can't force re-picking — and dropping — a tier the user still holds.
-   * A null `machineTier` (baseline "Small") seeds storage/credit and leaves the
-   * machine picker empty. Leave null/undefined for base checkout, which starts
-   * every dimension empty.
+   * plan. Pre-fills every dimension; the seeded default is a no-op, so Continue
+   * stays disabled until a dimension changes, and an unrelated edit can't force
+   * re-picking — and dropping — a tier the user still holds. A null
+   * `machineTier` (baseline "Small") seeds storage/credit and leaves the machine
+   * picker empty. Leave null/undefined for base checkout, which starts every
+   * dimension empty.
    */
   initialSelection?: CustomPlanSeed | null;
   onClose: () => void;
@@ -84,7 +85,8 @@ function priceSuffix(cents: number) {
  * white dialog over the dark takeover in the pricing mocks. The three pickers
  * render as dropdowns and start unselected for base checkout (or seeded from
  * the current plan for a Pro reconfigure); Continue stays disabled until every
- * dimension has an explicit choice ("No extra credits" counts).
+ * dimension has an explicit choice ("No extra credits" counts) and, for a Pro
+ * reconfigure, until at least one dimension differs from the seeded plan.
  */
 export function CustomPlanModal({
   open,
@@ -228,6 +230,18 @@ export function CustomPlanModal({
     submittableStorage != null &&
     submittableCredit != null;
 
+  // Reconfiguring an existing Pro plan opens seeded to the current tiers, so
+  // submitting them unchanged is a no-op — hold Continue disabled until at least
+  // one dimension differs from the seed. Base checkout has no seed, so a
+  // complete selection is always submittable. Compared against the raw seed
+  // values (not the priced diff) so a seed tier the catalog dropped still reads
+  // as changed once the user picks a live replacement.
+  const matchesSeed =
+    initialSelection != null &&
+    machineTier === (initialSelection.machineTier ?? "") &&
+    storageTier === initialSelection.storageTier &&
+    creditChoice === (initialSelection.creditTier ?? NO_EXTRA_CREDITS);
+
   const diff = useMemo(
     () =>
       computeCustomPlanDiff({
@@ -241,7 +255,7 @@ export function CustomPlanModal({
   );
 
   const handleContinue = () => {
-    if (!complete || pending) {
+    if (!complete || matchesSeed || pending) {
       return;
     }
     onContinue({
@@ -398,7 +412,7 @@ export function CustomPlanModal({
                 <Button
                   variant="primary"
                   fullWidth
-                  disabled={!complete || pending}
+                  disabled={!complete || matchesSeed || pending}
                   onClick={handleContinue}
                 >
                   Continue

--- a/clients/web/src/domains/settings/billing/plans/free-downgrade-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/free-downgrade-confirm-modal.tsx
@@ -1,0 +1,87 @@
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { Modal } from "@vellumai/design-library/components/modal";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+export interface FreeDowngradeConfirmModalProps {
+  open: boolean;
+  /**
+   * Pro features lost by downgrading to Free (the Pro plan's `included_features`
+   * minus the Free plan's). Empty when the catalog lists none — the list is then
+   * omitted and the dialog shows just the cancellation note.
+   */
+  lostFeatures: string[];
+  /** A billing-portal session is being created — disable the actions. */
+  pending: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * Reconfirm dialog for cancelling Pro ("Downgrade to Free") from the plans
+ * takeover. Mirrors the adjust-plan modal's "Downgrade to Base?" step: it lists
+ * the Pro features that will be lost before handing off to the Stripe billing
+ * portal, where the actual cancellation happens. Layout-only — the parent owns
+ * the portal mutation.
+ */
+export function FreeDowngradeConfirmModal({
+  open,
+  lostFeatures,
+  pending,
+  onCancel,
+  onConfirm,
+}: FreeDowngradeConfirmModalProps) {
+  const hasLostFeatures = lostFeatures.length > 0;
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !pending) {
+          onCancel();
+        }
+      }}
+    >
+      <Modal.Content size="md" hideCloseButton>
+        <Modal.Header>
+          <Modal.Title icon={AlertTriangle}>Downgrade to Free?</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Typography
+            as="p"
+            variant="body-medium-default"
+            className="text-(--content-secondary)"
+          >
+            {hasLostFeatures
+              ? "Downgrading removes the following Pro features. You'll be taken to Stripe to cancel your subscription."
+              : "You'll be taken to Stripe to cancel your subscription."}
+          </Typography>
+          {hasLostFeatures ? (
+            <ul className="mt-4 list-disc space-y-2 pl-5">
+              {lostFeatures.map((feature) => (
+                <li key={feature}>
+                  <Typography as="span" variant="body-medium-default">
+                    {feature}
+                  </Typography>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outlined" onClick={onCancel} disabled={pending}>
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            onClick={onConfirm}
+            disabled={pending}
+            data-testid="confirm-free-downgrade-button"
+          >
+            Downgrade to Free
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -38,12 +38,9 @@ import type {
 import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
 
 const CHECKOUT_URL = "https://stripe.test/checkout/session";
-const PORTAL_URL = "https://stripe.test/portal/session";
 
 type Captured = { body?: unknown };
 let upgradeCall: Captured | null = null;
-// Captures the billing-portal session create — the Pro → Free cancel path.
-let portalSessionCall: Captured | null = null;
 let openedUrl: string | null = null;
 
 mock.module("@/generated/api/sdk.gen", () => ({
@@ -52,13 +49,6 @@ mock.module("@/generated/api/sdk.gen", () => ({
     upgradeCall = opts;
     return Promise.resolve({
       data: { status: "redirect", checkout_url: CHECKOUT_URL },
-      response: { ok: true },
-    });
-  },
-  organizationsBillingPortalSessionCreate: (opts: Captured) => {
-    portalSessionCall = opts;
-    return Promise.resolve({
-      data: { portal_url: PORTAL_URL },
       response: { ok: true },
     });
   },
@@ -216,7 +206,6 @@ function renderPage(subscription: SubscriptionResponse) {
 
 beforeEach(() => {
   upgradeCall = null;
-  portalSessionCall = null;
   openedUrl = null;
   sessionStorage.clear();
 });
@@ -258,24 +247,17 @@ describe("PlansPage checkout — base subscriber", () => {
 
 describe("PlansPage checkout — Pro subscriber", () => {
   // Below Mighty, Free reads "Downgrade to Free". Downgrading a Pro org to the
-  // Free plan is a subscription cancellation, not a package switch — the
-  // change-package endpoint can't express it — so the plans page opens the
-  // Stripe billing portal (the same destination as the adjust-plan modal's
-  // "Downgrade to Base"), where the user can cancel. It must not fire a Stripe
-  // checkout. Pro package↔package switches go through change-package, covered in
-  // `plans-page.test.tsx`.
-  test("a Free downgrade CTA opens the Stripe billing portal (no checkout)", async () => {
-    // This harness intentionally doesn't mock the read endpoints (it seeds the
-    // cache), so asserting the location is unreliable — the loc assertion for
-    // "stays on the plans page" lives in `plans-page.test.tsx`. Here we assert
-    // the portal opens and no checkout fires.
+  // Free plan is a subscription cancellation, not a package switch — clicking it
+  // opens a confirm step (then the Stripe billing portal, the same destination
+  // as the adjust-plan modal's "Downgrade to Base"). The full confirm → portal
+  // flow is covered in `plans-page.test.tsx`; here we only guard that it never
+  // fires a Stripe checkout. This harness seeds the cache without mocking the
+  // read endpoints, so the confirm/portal/location aren't asserted.
+  test("a Free downgrade CTA never starts a Stripe checkout", () => {
     const { getByRole } = renderPage(proMightySubscription());
 
     fireEvent.click(getByRole("button", { name: "Downgrade to Free" }));
 
-    await waitFor(() => expect(openedUrl).toBe(PORTAL_URL));
-    expect(portalSessionCall).not.toBeNull();
-    // Never fires a Stripe checkout / upgrade.
     expect(upgradeCall).toBeNull();
     expect(readCheckoutIntent()).toBeNull();
   });

--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -38,9 +38,12 @@ import type {
 import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
 
 const CHECKOUT_URL = "https://stripe.test/checkout/session";
+const PORTAL_URL = "https://stripe.test/portal/session";
 
 type Captured = { body?: unknown };
 let upgradeCall: Captured | null = null;
+// Captures the billing-portal session create — the Pro → Free cancel path.
+let portalSessionCall: Captured | null = null;
 let openedUrl: string | null = null;
 
 mock.module("@/generated/api/sdk.gen", () => ({
@@ -49,6 +52,13 @@ mock.module("@/generated/api/sdk.gen", () => ({
     upgradeCall = opts;
     return Promise.resolve({
       data: { status: "redirect", checkout_url: CHECKOUT_URL },
+      response: { ok: true },
+    });
+  },
+  organizationsBillingPortalSessionCreate: (opts: Captured) => {
+    portalSessionCall = opts;
+    return Promise.resolve({
+      data: { portal_url: PORTAL_URL },
       response: { ok: true },
     });
   },
@@ -206,6 +216,7 @@ function renderPage(subscription: SubscriptionResponse) {
 
 beforeEach(() => {
   upgradeCall = null;
+  portalSessionCall = null;
   openedUrl = null;
   sessionStorage.clear();
 });
@@ -248,23 +259,24 @@ describe("PlansPage checkout — base subscriber", () => {
 describe("PlansPage checkout — Pro subscriber", () => {
   // Below Mighty, Free reads "Downgrade to Free". Downgrading a Pro org to the
   // Free plan is a subscription cancellation, not a package switch — the
-  // change-package endpoint can't express it — so the plans page routes to the
-  // billing manage/cancel surface (`?adjust_plan`) instead. It must not fire a
-  // Stripe checkout. Pro package↔package switches go through change-package,
-  // covered in `plans-page.test.tsx`.
-  test("a Free downgrade CTA routes to the billing manage/cancel flow (no checkout)", async () => {
-    const { getByRole, findByTestId } = renderPage(proMightySubscription());
+  // change-package endpoint can't express it — so the plans page opens the
+  // Stripe billing portal (the same destination as the adjust-plan modal's
+  // "Downgrade to Base"), where the user can cancel. It must not fire a Stripe
+  // checkout. Pro package↔package switches go through change-package, covered in
+  // `plans-page.test.tsx`.
+  test("a Free downgrade CTA opens the Stripe billing portal (no checkout)", async () => {
+    // This harness intentionally doesn't mock the read endpoints (it seeds the
+    // cache), so asserting the location is unreliable — the loc assertion for
+    // "stays on the plans page" lives in `plans-page.test.tsx`. Here we assert
+    // the portal opens and no checkout fires.
+    const { getByRole } = renderPage(proMightySubscription());
 
     fireEvent.click(getByRole("button", { name: "Downgrade to Free" }));
 
-    const loc = await findByTestId("loc");
-    await waitFor(() =>
-      expect(loc.textContent).toBe(
-        "/assistant/settings/usage?tab=billing&adjust_plan",
-      ),
-    );
+    await waitFor(() => expect(openedUrl).toBe(PORTAL_URL));
+    expect(portalSessionCall).not.toBeNull();
+    // Never fires a Stripe checkout / upgrade.
     expect(upgradeCall).toBeNull();
-    expect(openedUrl).toBeNull();
     expect(readCheckoutIntent()).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -50,10 +50,13 @@ import type {
 } from "@/generated/api/types.gen";
 
 const CHECKOUT_URL = "https://stripe.test/checkout/session";
+const PORTAL_URL = "https://stripe.test/portal/session";
 
 type Captured = { body?: unknown };
 let changePackageCall: Captured | null = null;
 let upgradeCall: Captured | null = null;
+// Captures the billing-portal session create — the Pro → Free cancel path.
+let portalSessionCall: Captured | null = null;
 let machineTierCall: Captured | null = null;
 let storageTierCall: Captured | null = null;
 let creditTierCall: Captured | null = null;
@@ -100,6 +103,13 @@ mock.module("@/generated/api/sdk.gen", () => ({
     upgradeCall = opts;
     return Promise.resolve({
       data: { status: "redirect", checkout_url: CHECKOUT_URL },
+      response: { ok: true },
+    });
+  },
+  organizationsBillingPortalSessionCreate: (opts: Captured) => {
+    portalSessionCall = opts;
+    return Promise.resolve({
+      data: { portal_url: PORTAL_URL },
       response: { ok: true },
     });
   },
@@ -538,6 +548,7 @@ function renderInteractive(
 beforeEach(() => {
   changePackageCall = null;
   upgradeCall = null;
+  portalSessionCall = null;
   machineTierCall = null;
   storageTierCall = null;
   creditTierCall = null;
@@ -607,21 +618,21 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
   });
 
-  test("Pro → Free downgrade routes to the manage/cancel flow, not change-package", async () => {
-    const { findByRole, findByTestId } = renderInteractive(
+  test("Pro → Free downgrade opens the Stripe billing portal, not change-package", async () => {
+    const { findByRole, getByTestId } = renderInteractive(
       proSuperSubscription(),
     );
 
     // Below Super, Free reads "Downgrade to Free". Cancellation can't go through
-    // the package-only change-package endpoint, so it routes to `?adjust_plan`.
+    // the package-only change-package endpoint, so it opens the Stripe billing
+    // portal (the same destination as the adjust-plan modal's Downgrade to Base).
     fireEvent.click(await findByRole("button", { name: "Downgrade to Free" }));
 
-    const loc = await findByTestId("loc");
-    await waitFor(() =>
-      expect(loc.textContent).toBe(
-        "/assistant/settings/usage?tab=billing&adjust_plan",
-      ),
-    );
+    await waitFor(() => expect(openedUrl).toBe(PORTAL_URL));
+    expect(portalSessionCall).not.toBeNull();
+    // Stays on the plans page (no navigation to the manage surface) and never
+    // touches the package/checkout endpoints.
+    expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(changePackageCall).toBeNull();
     expect(upgradeCall).toBeNull();
   });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -57,6 +57,9 @@ let changePackageCall: Captured | null = null;
 let upgradeCall: Captured | null = null;
 // Captures the billing-portal session create — the Pro → Free cancel path.
 let portalSessionCall: Captured | null = null;
+// When false, the portal-session promise never settles — used to observe the
+// in-flight (pending) state after confirming the Free downgrade.
+let portalSessionResolves = true;
 let machineTierCall: Captured | null = null;
 let storageTierCall: Captured | null = null;
 let creditTierCall: Captured | null = null;
@@ -108,6 +111,9 @@ mock.module("@/generated/api/sdk.gen", () => ({
   },
   organizationsBillingPortalSessionCreate: (opts: Captured) => {
     portalSessionCall = opts;
+    if (!portalSessionResolves) {
+      return new Promise(() => {});
+    }
     return Promise.resolve({
       data: { portal_url: PORTAL_URL },
       response: { ok: true },
@@ -549,6 +555,7 @@ beforeEach(() => {
   changePackageCall = null;
   upgradeCall = null;
   portalSessionCall = null;
+  portalSessionResolves = true;
   machineTierCall = null;
   storageTierCall = null;
   creditTierCall = null;
@@ -670,6 +677,37 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     await findByText("Downgrade to Free?");
     await findByText("Managed email");
     await findByText("Custom domain");
+  });
+
+  test("while the portal is opening, the other plan CTAs and Configure are disabled", async () => {
+    // Hold the portal-session request in flight so `portalMutation.isPending`
+    // stays true after the Free downgrade is confirmed.
+    portalSessionResolves = false;
+    const { findByRole, findByTestId } = renderInteractive(
+      proMightySubscription(),
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Downgrade to Free" }));
+    fireEvent.click(await findByTestId("confirm-free-downgrade-button"));
+
+    // The portal request is in flight and never settles: every other plan
+    // action is disabled so a second click can't start a competing billing
+    // operation before the redirect lands.
+    const goSuper = (await findByRole("button", {
+      name: "Go Super",
+    })) as HTMLButtonElement;
+    const configure = (await findByRole("button", {
+      name: "Configure",
+    })) as HTMLButtonElement;
+    await waitFor(() => {
+      expect(goSuper.disabled).toBe(true);
+      expect(configure.disabled).toBe(true);
+    });
+
+    // The portal was actually initiated, and no competing action started.
+    expect(portalSessionCall).not.toBeNull();
+    expect(changePackageCall).toBeNull();
+    expect(upgradeCall).toBeNull();
   });
 
   test("base user CTA starts Stripe checkout, not change-package", async () => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -618,16 +618,21 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
   });
 
-  test("Pro → Free downgrade opens the Stripe billing portal, not change-package", async () => {
-    const { findByRole, getByTestId } = renderInteractive(
-      proSuperSubscription(),
-    );
+  test("Pro → Free downgrade confirms first, then opens the Stripe billing portal", async () => {
+    const { findByRole, findByText, findByTestId, getByTestId } =
+      renderInteractive(proSuperSubscription());
 
-    // Below Super, Free reads "Downgrade to Free". Cancellation can't go through
-    // the package-only change-package endpoint, so it opens the Stripe billing
-    // portal (the same destination as the adjust-plan modal's Downgrade to Base).
+    // Below Super, Free reads "Downgrade to Free". Clicking it opens the confirm
+    // dialog — not an immediate portal redirect.
     fireEvent.click(await findByRole("button", { name: "Downgrade to Free" }));
+    await findByText("Downgrade to Free?");
+    expect(openedUrl).toBeNull();
+    expect(portalSessionCall).toBeNull();
 
+    // Confirming opens the Stripe billing portal (the same destination as the
+    // adjust-plan modal's Downgrade to Base). Cancellation can't go through the
+    // package-only change-package endpoint.
+    fireEvent.click(await findByTestId("confirm-free-downgrade-button"));
     await waitFor(() => expect(openedUrl).toBe(PORTAL_URL));
     expect(portalSessionCall).not.toBeNull();
     // Stays on the plans page (no navigation to the manage surface) and never
@@ -635,6 +640,36 @@ describe("PlansPage — Pro package switch (change-package)", () => {
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(changePackageCall).toBeNull();
     expect(upgradeCall).toBeNull();
+  });
+
+  test("dismissing the Free downgrade confirm doesn't open the portal", async () => {
+    const { findByRole, findByText, getByRole, queryByText } =
+      renderInteractive(proSuperSubscription());
+
+    fireEvent.click(await findByRole("button", { name: "Downgrade to Free" }));
+    await findByText("Downgrade to Free?");
+
+    // The confirm dialog's Cancel closes it without creating a portal session.
+    fireEvent.click(getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(queryByText("Downgrade to Free?")).toBeNull());
+    expect(portalSessionCall).toBeNull();
+    expect(openedUrl).toBeNull();
+  });
+
+  test("the Free downgrade confirm lists the Pro features being lost", async () => {
+    const plans = fullCatalog();
+    const pro = plans.plans.find((p) => p.id === "pro") as ProPlan;
+    // Base plan lists no features, so both Pro features are "lost".
+    pro.included_features = ["Managed email", "Custom domain"];
+    const { findByRole, findByText } = renderInteractive(
+      proSuperSubscription(),
+      { plans },
+    );
+
+    fireEvent.click(await findByRole("button", { name: "Downgrade to Free" }));
+    await findByText("Downgrade to Free?");
+    await findByText("Managed email");
+    await findByText("Custom domain");
   });
 
   test("base user CTA starts Stripe checkout, not change-package", async () => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -38,6 +38,10 @@ import {
 } from "@/domains/settings/components/adjust-plan-utils";
 import { formatDollars } from "@/domains/settings/components/tier-pricing";
 import {
+  buildPortalReturnSnapshot,
+  useBillingPortalSession,
+} from "@/domains/settings/hooks/use-billing-portal-session";
+import {
   organizationsBillingPlansRetrieveOptions,
   organizationsBillingPlansRetrieveQueryKey,
   organizationsBillingSubscriptionRetrieveOptions,
@@ -166,6 +170,13 @@ export function PlansPage() {
   const hasPackages = packages.length > 0;
   const isProUser = subscription?.plan_id === "pro";
 
+  // Pro → Free is a cancellation: it opens the Stripe billing portal (the same
+  // destination as the adjust-plan modal's "Downgrade to Base") so the user can
+  // cancel there. Snapshot the pre-redirect state for the post-return toast.
+  const portalMutation = useBillingPortalSession(
+    buildPortalReturnSnapshot(subscription),
+  );
+
   // Seed the custom-plan modal with the Pro sub's current tiers so an unrelated
   // edit (e.g. only the machine) doesn't force re-picking — and dropping — the
   // storage or credit the user still holds. Null for base checkout, which
@@ -262,11 +273,11 @@ export function PlansPage() {
     const selectTier = (tierKey: string) => {
       if (isProUser) {
         if (tierKey === "free") {
-          // Pro → Free is a subscription cancellation, not a package switch;
-          // route to the billing manage/cancel surface rather than the
-          // (package-only) change-package endpoint, which 400s on non-package
-          // keys.
-          navigate(`${routes.settings.usage}?tab=billing&adjust_plan`);
+          // Pro → Free is a subscription cancellation, not a package switch.
+          // Open the Stripe billing portal (the same destination as the
+          // adjust-plan modal's "Downgrade to Base"), where the user can cancel
+          // — the package-only change-package endpoint 400s on non-package keys.
+          portalMutation.mutate({});
           return;
         }
         // Active Pro orgs switch packages in place via the change-package
@@ -439,7 +450,7 @@ export function PlansPage() {
             tone="dark"
             isCurrent={currentTierKey === "free"}
             intent={freeRelation}
-            pending={pending || changePackagePending}
+            pending={pending || changePackagePending || portalMutation.isPending}
             onCta={() => selectTier("free")}
           />
           {orderedPackages.map((pkg) => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -22,6 +22,7 @@ import {
   type CustomPlanSelection,
 } from "@/domains/settings/billing/plans/custom-plan-modal";
 import { CustomPlanRow } from "@/domains/settings/billing/plans/custom-plan-row";
+import { FreeDowngradeConfirmModal } from "@/domains/settings/billing/plans/free-downgrade-confirm-modal";
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import { PlanColumnCard } from "@/domains/settings/billing/plans/plan-column-card";
 import {
@@ -148,6 +149,8 @@ export function PlansPage() {
   useCheckoutDismissRefresh();
   const [pending, setPending] = useState(false);
   const [customPlanOpen, setCustomPlanOpen] = useState(false);
+  // Whether the Pro → Free cancellation confirm dialog is open.
+  const [freeDowngradeOpen, setFreeDowngradeOpen] = useState(false);
   // The package a Pro user is switching to, awaiting reconfirm; null when the
   // dialog is closed.
   const [switchTarget, setSwitchTarget] = useState<ProPackage | null>(null);
@@ -170,11 +173,20 @@ export function PlansPage() {
   const hasPackages = packages.length > 0;
   const isProUser = subscription?.plan_id === "pro";
 
-  // Pro → Free is a cancellation: it opens the Stripe billing portal (the same
-  // destination as the adjust-plan modal's "Downgrade to Base") so the user can
-  // cancel there. Snapshot the pre-redirect state for the post-return toast.
+  // Pro → Free is a cancellation: after a confirm step it opens the Stripe
+  // billing portal (the same destination as the adjust-plan modal's "Downgrade
+  // to Base") so the user can cancel there. Snapshot the pre-redirect state for
+  // the post-return toast.
   const portalMutation = useBillingPortalSession(
     buildPortalReturnSnapshot(subscription),
+  );
+
+  // Pro features lost by downgrading to Free — the confirm dialog lists these.
+  const baseFeatureSet = new Set(
+    plansQuery.data?.plans.find((p) => p.id === "base")?.included_features ?? [],
+  );
+  const freeDowngradeLostFeatures = (proPlan?.included_features ?? []).filter(
+    (f) => !baseFeatureSet.has(f),
   );
 
   // Seed the custom-plan modal with the Pro sub's current tiers so an unrelated
@@ -274,10 +286,11 @@ export function PlansPage() {
       if (isProUser) {
         if (tierKey === "free") {
           // Pro → Free is a subscription cancellation, not a package switch.
-          // Open the Stripe billing portal (the same destination as the
-          // adjust-plan modal's "Downgrade to Base"), where the user can cancel
-          // — the package-only change-package endpoint 400s on non-package keys.
-          portalMutation.mutate({});
+          // Confirm first (which Pro features are lost), then open the Stripe
+          // billing portal — the same destination as the adjust-plan modal's
+          // "Downgrade to Base" — where the user actually cancels. The
+          // package-only change-package endpoint 400s on non-package keys.
+          setFreeDowngradeOpen(true);
           return;
         }
         // Active Pro orgs switch packages in place via the change-package
@@ -311,6 +324,13 @@ export function PlansPage() {
         package: tierKey,
         confirm: true,
       });
+    };
+
+    // Confirmed Pro → Free cancellation: close the confirm and hand off to the
+    // Stripe billing portal, where the actual cancellation happens.
+    const confirmFreeDowngrade = () => {
+      setFreeDowngradeOpen(false);
+      portalMutation.mutate({});
     };
 
     const confirmSwitch = async () => {
@@ -510,6 +530,14 @@ export function PlansPage() {
           pending={changePackagePending}
           onCancel={() => setSwitchTarget(null)}
           onConfirm={() => void confirmSwitch()}
+        />
+
+        <FreeDowngradeConfirmModal
+          open={freeDowngradeOpen}
+          lostFeatures={freeDowngradeLostFeatures}
+          pending={portalMutation.isPending}
+          onCancel={() => setFreeDowngradeOpen(false)}
+          onConfirm={confirmFreeDowngrade}
         />
 
         <BillingOnboardingModal

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -189,6 +189,12 @@ export function PlansPage() {
     (f) => !baseFeatureSet.has(f),
   );
 
+  // Any billing action in flight — a checkout, a package switch, or the Stripe
+  // portal opening — disables every plan CTA (and Configure) so a second click
+  // can't start a competing billing operation before the first resolves.
+  const billingActionPending =
+    pending || changePackagePending || portalMutation.isPending;
+
   // Seed the custom-plan modal with the Pro sub's current tiers so an unrelated
   // edit (e.g. only the machine) doesn't force re-picking — and dropping — the
   // storage or credit the user still holds. Null for base checkout, which
@@ -283,6 +289,12 @@ export function PlansPage() {
           : null;
 
     const selectTier = (tierKey: string) => {
+      // A billing action is already in flight (checkout / package switch /
+      // portal opening) — ignore the click. The CTAs are also disabled; this
+      // guards against a race between the click and the disabled re-render.
+      if (billingActionPending) {
+        return;
+      }
       if (isProUser) {
         if (tierKey === "free") {
           // Pro → Free is a subscription cancellation, not a package switch.
@@ -408,6 +420,11 @@ export function PlansPage() {
     };
 
     const handleConfigure = () => {
+      // Don't open the configurator while another billing action is in flight
+      // (the CTA is also disabled — see `configureDisabled`).
+      if (billingActionPending) {
+        return;
+      }
       // A Pro sub's current tiers load after the page renders; the modal seeds
       // from them, so hold the click until that first load settles (the CTA is
       // also held disabled meanwhile — see `configureDisabled`).
@@ -470,7 +487,7 @@ export function PlansPage() {
             tone="dark"
             isCurrent={currentTierKey === "free"}
             intent={freeRelation}
-            pending={pending || changePackagePending || portalMutation.isPending}
+            pending={billingActionPending}
             onCta={() => selectTier("free")}
           />
           {orderedPackages.map((pkg) => {
@@ -494,7 +511,7 @@ export function PlansPage() {
                 tone={copy?.recommended ? "light" : "dark"}
                 isCurrent={currentTierKey === pkg.key}
                 intent={relation}
-                pending={pending || changePackagePending}
+                pending={billingActionPending}
                 onCta={() => selectTier(pkg.key)}
               />
             );
@@ -504,7 +521,7 @@ export function PlansPage() {
         <CustomPlanRow
           className="mt-10"
           onConfigure={handleConfigure}
-          configureDisabled={isProUser && !currentReady}
+          configureDisabled={(isProUser && !currentReady) || billingActionPending}
         />
 
         <CustomPlanModal


### PR DESCRIPTION
## Summary

Two billing plan-modal refinements on the View Plans takeover (`clients/web`):

1. **Custom Plan modal — disable "Continue" when nothing changed.** When an existing Pro sub opens the configurator, it seeds to the current tiers. Previously "Continue" was enabled on open and submitting the unchanged plan silently no-oped. It's now disabled until at least one dimension (machine / storage / credits) differs from the seeded plan. Base checkout is unaffected (no seed → any complete selection is submittable).
   - Compared against the raw seed values, not the priced diff, so a seed tier the catalog has dropped still reads as "changed" once the user picks a live replacement.

2. **"Downgrade to Free" opens the Stripe billing portal.** For a Pro user, the Free card's "Downgrade to Free" now opens the Stripe Customer Portal via the existing `useBillingPortalSession` hook — the same destination as the adjust-plan modal's "Downgrade to Base" — where the user can cancel the subscription. It previously routed to the `?adjust_plan` manage modal (an extra hop to reach the same portal). The package-only change-package endpoint can't express a cancellation, so this is the correct path.

## Tests
- `custom-plan-modal.test.tsx`: seeded no-op now asserts Continue disabled, and enables after a change (incl. the held-legacy-storage case).
- `plans-page.test.tsx` / `plans-page-checkout.test.tsx`: Pro→Free now asserts the Stripe billing portal opens (not `?adjust_plan`), with no checkout/change-package.
- All three suites pass; touched files are type-clean and lint-clean.

## Notes
- Additive/no contract change; reuses the existing portal-session endpoint. No native-client compatibility impact.