### PR TITLE
fix(gateway): reject no-identity events in resolveAssistant before the default policy

### DIFF
--- a/gateway/src/__tests__/resolve-assistant.test.ts
+++ b/gateway/src/__tests__/resolve-assistant.test.ts
@@ -118,4 +118,66 @@ describe("resolveAssistant", () => {
     const result = resolveAssistant(config, "99001", "55001");
     expect(isRejection(result)).toBe(true);
   });
+
+  test("rejects a no-identity event even under the default policy", () => {
+    // Fail-closed: an event with neither a conversation nor an actor id has
+    // nothing to route on, so it must reject rather than fall through to the
+    // default assistant.
+    const config = makeConfig({
+      unmappedPolicy: "default",
+      defaultAssistantId: "assistant-default",
+    });
+
+    for (const [conversationId, actorId] of [
+      ["", ""],
+      [undefined, undefined],
+      ["", undefined],
+      [undefined, ""],
+    ] as const) {
+      const result = resolveAssistant(config, conversationId, actorId);
+      expect(isRejection(result)).toBe(true);
+      if (isRejection(result)) {
+        expect(result.reason).toContain("No routable identity");
+      }
+    }
+  });
+
+  test("still resolves when only one identity is present and matches a route", () => {
+    const config = makeConfig({
+      routingEntries: [
+        { type: "conversation_id", key: "99001", assistantId: "assistant-a" },
+        { type: "actor_id", key: "55001", assistantId: "assistant-b" },
+      ],
+    });
+
+    // Missing actor, conversation matches.
+    const byConversation = resolveAssistant(config, "99001", undefined);
+    expect(isRejection(byConversation)).toBe(false);
+    if (!isRejection(byConversation)) {
+      expect(byConversation.assistantId).toBe("assistant-a");
+    }
+
+    // Missing conversation, actor matches.
+    const byActor = resolveAssistant(config, undefined, "55001");
+    expect(isRejection(byActor)).toBe(false);
+    if (!isRejection(byActor)) {
+      expect(byActor.assistantId).toBe("assistant-b");
+    }
+  });
+
+  test("applies the default policy when one identity is present but unrouted", () => {
+    // A valid-but-unrouted event (real identity, no explicit route) still gets
+    // the default — only the no-identity case is rejected.
+    const config = makeConfig({
+      unmappedPolicy: "default",
+      defaultAssistantId: "assistant-default",
+    });
+
+    const result = resolveAssistant(config, "C-unrouted", undefined);
+    expect(isRejection(result)).toBe(false);
+    if (!isRejection(result)) {
+      expect(result.assistantId).toBe("assistant-default");
+      expect(result.routeSource).toBe("default");
+    }
+  });
 });

--- a/gateway/src/http/routes/twilio-voice-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.test.ts
@@ -224,6 +224,48 @@ describe("twilio voice webhook handler", () => {
     expect(forwardCalled).toBe(true);
   });
 
+  test("anonymous inbound call (no From) still routes to the default assistant under default policy", async () => {
+    // Caller-ID-withheld call: no `From` to route on. resolveAssistant
+    // fail-closes on the missing identity, but a voice line is intentionally
+    // open, so the handler answers via the default assistant.
+    const configWithDefault: GatewayConfig = {
+      ...baseConfig,
+      unmappedPolicy: "default",
+      defaultAssistantId: "fallback-assistant",
+    };
+    const handler = createTwilioVoiceWebhookHandler(
+      configWithDefault,
+      makeCachesWithPhoneNumbers(),
+    );
+    const req = makeVoiceRequest({
+      CallSid: "CA_inbound_anon",
+      To: "+12015550199",
+    });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(forwardCalled).toBe(true);
+  });
+
+  test("anonymous inbound call (no From) is rejected under reject policy", async () => {
+    const handler = createTwilioVoiceWebhookHandler(
+      baseConfig, // unmappedPolicy: "reject"
+      makeCachesWithPhoneNumbers(),
+    );
+    const req = makeVoiceRequest({
+      CallSid: "CA_inbound_anon_reject",
+      To: "+12015550199",
+    });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("<Reject");
+    expect(forwardCalled).toBe(false);
+  });
+
   test("outbound call (callSessionId present) does not resolve assistant by phone", async () => {
     const handler = createTwilioVoiceWebhookHandler(
       baseConfig,

--- a/gateway/src/http/routes/twilio-voice-webhook.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.ts
@@ -90,34 +90,51 @@ export function createTwilioVoiceWebhookHandler(
         // silently forwarding with no assistant ID.
         const fallbackRouting = resolveAssistant(
           config,
-          params.From || "",
-          params.From || "",
+          params.From,
+          params.From,
         );
 
         if (isRejection(fallbackRouting)) {
-          log.warn(
+          // A caller-ID-withheld (anonymous) inbound call has no `From` to
+          // route or trust-classify on, so resolveAssistant fail-closes on the
+          // missing identity. Voice lines are intentionally open, though, so
+          // keep answering an anonymous caller on an unmapped line via the
+          // default assistant when the unmapped policy allows it.
+          if (
+            !params.From &&
+            config.unmappedPolicy === "default" &&
+            config.defaultAssistantId
+          ) {
+            assistantId = config.defaultAssistantId;
+            log.info(
+              { to: params.To },
+              "Anonymous inbound call routed to the default assistant",
+            );
+          } else {
+            log.warn(
+              {
+                from: params.From,
+                to: params.To,
+                reason: fallbackRouting.reason,
+              },
+              "Inbound voice call rejected by routing — no phone number match and unmapped policy rejects",
+            );
+            return new Response(REJECT_TWIML, {
+              status: 200,
+              headers: TWIML_HEADERS,
+            });
+          }
+        } else {
+          assistantId = fallbackRouting.assistantId;
+          log.info(
             {
+              assistantId,
+              routeSource: fallbackRouting.routeSource,
               from: params.From,
-              to: params.To,
-              reason: fallbackRouting.reason,
             },
-            "Inbound voice call rejected by routing — no phone number match and unmapped policy rejects",
+            "Resolved assistant via fallback routing for inbound call",
           );
-          return new Response(REJECT_TWIML, {
-            status: 200,
-            headers: TWIML_HEADERS,
-          });
         }
-
-        assistantId = fallbackRouting.assistantId;
-        log.info(
-          {
-            assistantId,
-            routeSource: fallbackRouting.routeSource,
-            from: params.From,
-          },
-          "Resolved assistant via fallback routing for inbound call",
-        );
       }
 
       // ── Gateway-owned voice verification ────────────────────────────

--- a/gateway/src/routing/resolve-assistant.ts
+++ b/gateway/src/routing/resolve-assistant.ts
@@ -7,9 +7,21 @@ const log = getLogger("routing");
 
 export function resolveAssistant(
   config: GatewayConfig,
-  conversationId: string,
-  actorId: string,
+  conversationId: string | undefined,
+  actorId: string | undefined,
 ): RoutingOutcome {
+  // Priority 0: no identity at all → nothing to route on. Reject before the
+  // unmapped default policy, so a malformed event with neither a conversation
+  // nor an actor can never fall through to the default assistant. Callers are
+  // expected to validate identity too; this is the fail-closed backstop.
+  if (!conversationId && !actorId) {
+    log.info(
+      { conversationId, actorId },
+      "No routable identity on event, rejecting",
+    );
+    return { rejected: true, reason: "No routable identity on this event" };
+  }
+
   // Priority 1: explicit conversation_id route
   for (const entry of config.routingEntries) {
     if (entry.type === "conversation_id" && entry.key === conversationId) {


### PR DESCRIPTION
## Prompt / plan

Small standalone routing-hardening PR, split out from the Slack message-normalizers work (#38991) because `resolveAssistant` is the shared route-matcher used by **all** channels (Telegram, WhatsApp, email, phone, Slack).

### Why

`resolveAssistant` is a pure route-matcher — match `conversation_id` → match `actor_id` → apply the unmapped default policy. But when **both** the conversation and actor id are empty/missing, Priorities 1–2 never match and it fell through to Priority 3, returning the **default assistant** under the default policy. So a malformed event with *no identity at all* silently routed to the default instead of being dropped. (This is the footgun behind the malformed-`app_mention` thread-arming issue fixed in #38991.)

### What changed

**Routing (`resolve-assistant.ts`):**
- **Priority 0, fail-closed:** if neither a conversation nor an actor id is present, reject *before* the default policy.
- An event with **one** identity present still resolves exactly as before (route match, or default for a valid-but-unrouted event) — only the no-identity case changes.
- Signature widened to `string | undefined` so callers pass optional identity without coercing to `""`.

**Anonymous voice preservation (`twilio-voice-webhook.ts`):**
- One caller relied on the old empty→default behavior: the twilio-voice fallback passed `params.From || ""` for both ids, so a **caller-ID-withheld (anonymous) call** on an unmapped line reached the default assistant. That's *intended* — voice lines are open.
- Rather than weaken the generic guard, the adapter-specific fallback now lives in the voice route: when fallback routing rejects for a missing `From` and the unmapped policy is `default`, route to the configured default assistant; otherwise reject as before (a `reject` policy still drops anonymous calls). This keeps `resolveAssistant` fail-closed and generic while preserving the voice behavior, matching the existing seam (generic default in `resolveAssistant`, adapter-specific fallbacks in adapters).

### Why it's safe

- Every caller already validates identity and passes non-empty strings, so **no existing path passes both-empty** — behavior is unchanged for all of them except the voice fallback, which is explicitly preserved above. `tsc` clean across every caller.

## Test plan

- `resolve-assistant.test.ts` — 9 pass. Adds: no-identity rejects even under the default policy (all four empty/undefined combos); single-identity still resolves via route match; single-identity-but-unrouted still gets the default. Negative control: removing the Priority 0 guard turns the no-identity test red.
- `twilio-voice-webhook.test.ts` — 22 pass. Adds: anonymous call (no `From`) still routes to the default under the default policy, and rejects under the reject policy. Negative control: removing the rescue makes the default-routing test red.
- Caller regression check: `telegram-webhook` + `whatsapp-webhook` + `email-webhook` suites green. `eslint` / `prettier` / generic-examples clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f