### PR TITLE
fix(providers): per-connection credential slots for custom endpoints

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -174,6 +174,8 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "messaging/providers/whatsapp/api.ts", // WhatsApp Cloud API client (bot token for direct sends)
       "messaging/providers/slack/adapter.ts", // Slack bot token lookup for Socket Mode connectivity check
       "credential-health/credential-health-service.ts", // proactive credential health monitoring
+      "providers/inference/credential-slot-repair.ts", // boot repair: copies the shared openai-compatible slot value into per-connection slots (get/set of provider API keys only; values never logged or returned)
+      "runtime/routes/inference-provider-connection-routes.ts", // connection delete removes its dedicated per-connection key slot (deleteSecureKeyAsync only; no reads)
       "daemon/handlers/config-slack-channel.ts", // Slack channel config credential management
       "providers/platform-proxy/context.ts", // managed proxy API key lookup for provider initialization
       "platform/client.ts", // platform client credential store fallback for standalone CLI auth

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -31,6 +31,7 @@ import { startConsentRefresh } from "../platform/consent-cache.js";
 import { syncWorkspaceIdentityToPlatform } from "../platform/sync-identity.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { runProviderConnectionsBackfill } from "../providers/inference/backfill.js";
+import { repairSharedCredentialSlots } from "../providers/inference/credential-slot-repair.js";
 import { initializeProviders } from "../providers/registry.js";
 import { startRouteHost } from "../routes/control.js";
 import { floorSeqAbove } from "../runtime/assistant-stream-state.js";
@@ -316,6 +317,13 @@ export async function runDaemon(): Promise<void> {
         "provider_connections backfill failed — continuing startup",
       );
     }
+
+    // Repoint openai-compatible connections sharing the legacy provider-keyed
+    // credential slot onto per-connection slots. Vault-dependent, so it runs
+    // fire-and-forget with per-row deferral rather than blocking startup.
+    void repairSharedCredentialSlots(getDb()).catch((err) => {
+      log.warn({ err }, "credential slot repair failed — continuing startup");
+    });
 
     // Profiler retention sweep — prune completed profiler runs to stay
     // within configured byte-count, run-count, and free-space budgets.

--- a/assistant/src/providers/inference/__tests__/credential-slot-repair.test.ts
+++ b/assistant/src/providers/inference/__tests__/credential-slot-repair.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Vault mock (must precede imports) ───────────────────────────────────────
+
+let vault: Record<string, string>;
+let vaultUnreachable: boolean;
+const setCalls: Array<{ account: string; value: string }> = [];
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getSecureKeyResultAsync: async (account: string) =>
+    vaultUnreachable
+      ? { value: undefined, unreachable: true }
+      : { value: vault[account], unreachable: false },
+  setSecureKeyAsync: async (account: string, value: string) => {
+    setCalls.push({ account, value });
+    vault[account] = value;
+  },
+  deleteSecureKeyAsync: async (account: string) => {
+    delete vault[account];
+  },
+}));
+
+// ── Real imports (after mocks) ──────────────────────────────────────────────
+
+import { getDb } from "../../../persistence/db-connection.js";
+import { initializeDb } from "../../../persistence/db-init.js";
+import { providerConnections } from "../../../persistence/schema/inference.js";
+import { getConnection } from "../connections.js";
+import { repairSharedCredentialSlots } from "../credential-slot-repair.js";
+
+await initializeDb();
+
+const LEGACY = "credential/openai-compatible/api_key";
+
+function seedRow(name: string, credential: string): void {
+  const now = Date.now();
+  getDb()
+    .insert(providerConnections)
+    .values({
+      name,
+      provider: "openai-compatible",
+      auth: JSON.stringify({ type: "api_key", credential }),
+      baseUrl: `https://${name}.example/v1`,
+      models: JSON.stringify([{ id: "model-1" }]),
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function refOf(name: string): string | undefined {
+  const row = getConnection(getDb(), name);
+  return row?.auth.type === "api_key" ? row.auth.credential : undefined;
+}
+
+beforeEach(() => {
+  getDb().delete(providerConnections).run();
+  vault = {};
+  vaultUnreachable = false;
+  setCalls.length = 0;
+});
+
+describe("repairSharedCredentialSlots", () => {
+  test("repoints sharing rows to per-connection slots and copies the shared value", async () => {
+    seedRow("openai-compatible-personal", LEGACY);
+    seedRow("openai-compatible-personal-2", LEGACY);
+    vault[LEGACY] = "sk-last-saved";
+
+    await repairSharedCredentialSlots(getDb());
+
+    expect(refOf("openai-compatible-personal")).toBe(
+      "credential/openai-compatible-personal/api_key",
+    );
+    expect(refOf("openai-compatible-personal-2")).toBe(
+      "credential/openai-compatible-personal-2/api_key",
+    );
+    // Behavior-preserving: each new slot holds the value the row resolved
+    // through the shared slot.
+    expect(vault["credential/openai-compatible-personal/api_key"]).toBe(
+      "sk-last-saved",
+    );
+    expect(vault["credential/openai-compatible-personal-2/api_key"]).toBe(
+      "sk-last-saved",
+    );
+  });
+
+  test("an empty shared slot still repoints the refs without writing secrets", async () => {
+    seedRow("openai-compatible-personal", LEGACY);
+
+    await repairSharedCredentialSlots(getDb());
+
+    expect(refOf("openai-compatible-personal")).toBe(
+      "credential/openai-compatible-personal/api_key",
+    );
+    expect(setCalls).toEqual([]);
+  });
+
+  test("defers everything when the vault is unreachable", async () => {
+    seedRow("openai-compatible-personal", LEGACY);
+    vaultUnreachable = true;
+
+    await repairSharedCredentialSlots(getDb());
+
+    expect(refOf("openai-compatible-personal")).toBe(LEGACY);
+  });
+
+  test("leaves per-connection and custom refs untouched; idempotent", async () => {
+    seedRow(
+      "openai-compatible-personal",
+      "credential/openai-compatible-personal/api_key",
+    );
+    seedRow("my-endpoint", "credential/shared-team-key/api_key");
+
+    await repairSharedCredentialSlots(getDb());
+    await repairSharedCredentialSlots(getDb());
+
+    expect(refOf("openai-compatible-personal")).toBe(
+      "credential/openai-compatible-personal/api_key",
+    );
+    expect(refOf("my-endpoint")).toBe("credential/shared-team-key/api_key");
+    expect(setCalls).toEqual([]);
+  });
+
+  test("does not overwrite a value already present in a per-connection slot", async () => {
+    seedRow("openai-compatible-personal", LEGACY);
+    vault[LEGACY] = "sk-shared";
+    vault["credential/openai-compatible-personal/api_key"] = "sk-already-mine";
+
+    await repairSharedCredentialSlots(getDb());
+
+    expect(vault["credential/openai-compatible-personal/api_key"]).toBe(
+      "sk-already-mine",
+    );
+    expect(refOf("openai-compatible-personal")).toBe(
+      "credential/openai-compatible-personal/api_key",
+    );
+  });
+});

--- a/assistant/src/providers/inference/credential-slot-repair.ts
+++ b/assistant/src/providers/inference/credential-slot-repair.ts
@@ -1,0 +1,90 @@
+import type { DrizzleDb } from "../../persistence/db-connection.js";
+import { credentialKey } from "../../security/credential-key.js";
+import {
+  getSecureKeyResultAsync,
+  setSecureKeyAsync,
+} from "../../security/secure-keys.js";
+import { getLogger } from "../../util/logger.js";
+import { listConnections, updateConnection } from "./connections.js";
+
+const log = getLogger("providers/credential-slot-repair");
+
+/**
+ * The provider-keyed vault ref that unrepaired openai-compatible connections
+ * share. One slot for N endpoints means saving any endpoint's key overwrites
+ * the key every sibling resolves — the repair repoints each row at its own
+ * per-connection slot (`credential/<connection-name>/api_key`).
+ */
+const LEGACY_SHARED_REF = credentialKey("openai-compatible", "api_key");
+
+/**
+ * Repoint openai-compatible connections still referencing the shared legacy
+ * credential slot onto per-connection slots.
+ *
+ * Per row: copy the shared slot's current value into the row's own slot
+ * (behavior-preserving — the shared value is what the row resolves; any
+ * key overwritten inside the shared slot is unrecoverable), then
+ * rewrite the row's ref. Rows are only rewritten after their slot is settled,
+ * so a vault outage mid-repair leaves the remaining rows on the legacy ref
+ * to be repaired on a later boot. Idempotent: a repaired row does not match
+ * the legacy ref.
+ */
+export async function repairSharedCredentialSlots(
+  db: DrizzleDb,
+): Promise<void> {
+  const rows = listConnections(db, { provider: "openai-compatible" });
+  const sharing = rows.filter(
+    (row) =>
+      row.auth.type === "api_key" && row.auth.credential === LEGACY_SHARED_REF,
+  );
+  if (sharing.length === 0) {
+    return;
+  }
+
+  const shared = await getSecureKeyResultAsync(LEGACY_SHARED_REF);
+  if (shared.unreachable) {
+    log.warn(
+      { connections: sharing.map((row) => row.name) },
+      "Credential vault unreachable — shared-slot repair deferred to a later boot",
+    );
+    return;
+  }
+
+  for (const row of sharing) {
+    const target = credentialKey(row.name, "api_key");
+    try {
+      if (shared.value != null) {
+        const existing = await getSecureKeyResultAsync(target);
+        if (existing.unreachable) {
+          log.warn(
+            { connection: row.name },
+            "Credential vault unreachable — leaving this connection on the shared slot",
+          );
+          continue;
+        }
+        if (existing.value == null) {
+          await setSecureKeyAsync(target, shared.value);
+        }
+      }
+      const updated = updateConnection(db, row.name, {
+        auth: { type: "api_key", credential: target },
+      });
+      if (updated.ok) {
+        log.info(
+          { connection: row.name, credential: target },
+          "Repointed shared credential slot to a per-connection slot",
+        );
+      } else {
+        log.warn(
+          { connection: row.name, error: updated.error },
+          "Failed to repoint shared credential slot",
+        );
+      }
+    } catch (err) {
+      log.warn(
+        { err, connection: row.name },
+        "Shared-slot repair failed for connection — deferred to a later boot",
+      );
+    }
+  }
+}

--- a/assistant/src/providers/inference/credential-slot-repair.ts
+++ b/assistant/src/providers/inference/credential-slot-repair.ts
@@ -5,7 +5,11 @@ import {
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
-import { listConnections, updateConnection } from "./connections.js";
+import {
+  getConnection,
+  listConnections,
+  updateConnection,
+} from "./connections.js";
 
 const log = getLogger("providers/credential-slot-repair");
 
@@ -65,6 +69,22 @@ export async function repairSharedCredentialSlots(
         if (existing.value == null) {
           await setSecureKeyAsync(target, shared.value);
         }
+      }
+      // Re-read synchronously after the vault awaits: the repair runs
+      // concurrently with client mutations, and a row rewritten (or
+      // deleted and recreated) mid-await must not have its fresh auth
+      // clobbered with the repair target. The check and the update share
+      // one event-loop turn, so no mutation can interleave.
+      const current = getConnection(db, row.name);
+      if (
+        current?.auth.type !== "api_key" ||
+        current.auth.credential !== LEGACY_SHARED_REF
+      ) {
+        log.info(
+          { connection: row.name },
+          "Connection changed during repair — leaving it as-is",
+        );
+        continue;
       }
       const updated = updateConnection(db, row.name, {
         auth: { type: "api_key", credential: target },

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -38,6 +38,8 @@ import {
   MANAGED_CONNECTION_NAMES,
   updateConnection,
 } from "../../providers/inference/connections.js";
+import { credentialKey } from "../../security/credential-key.js";
+import { deleteSecureKeyAsync } from "../../security/secure-keys.js";
 import {
   isPrivateOrLocalHost,
   resolveHostAddresses,
@@ -458,6 +460,17 @@ function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
       );
     }
     throw new BadRequestError("Delete failed.");
+  }
+
+  // A per-connection credential slot is owned by exactly this row, so the
+  // delete removes it too. Provider-keyed and custom refs stay: they can be
+  // shared across rows. Best-effort — a vault outage leaves an orphaned
+  // secret, never a failed delete.
+  if (
+    existing.auth.type === "api_key" &&
+    existing.auth.credential === credentialKey(name, "api_key")
+  ) {
+    void deleteSecureKeyAsync(existing.auth.credential).catch(() => {});
   }
 
   return { ok: true as const };

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -45,9 +45,12 @@ import {
   resolveHostAddresses,
   resolveRequestAddress,
 } from "../../tools/network/url-safety.js";
+import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, ConflictError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const log = getLogger("routes/inference-provider-connections");
 
 // ---------------------------------------------------------------------------
 // Shared Zod schema for the ProviderConnection response shape
@@ -379,7 +382,7 @@ async function handleUpdateConnection({
   return result.connection;
 }
 
-function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
+async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   const { name } = pathParams;
   if (!name) {
     throw new BadRequestError("name is required");
@@ -464,13 +467,23 @@ function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
 
   // A per-connection credential slot is owned by exactly this row, so the
   // delete removes it too. Provider-keyed and custom refs stay: they can be
-  // shared across rows. Best-effort — a vault outage leaves an orphaned
-  // secret, never a failed delete.
+  // shared across rows. Awaited so the response orders after the vault
+  // delete — a client that deletes, recreates the name, and saves a new key
+  // must never have that key erased by a still-in-flight deletion. Failures
+  // are logged, never surfaced: a vault outage leaves an orphaned secret,
+  // not a failed delete (the timeout on vault calls bounds the wait).
   if (
     existing.auth.type === "api_key" &&
     existing.auth.credential === credentialKey(name, "api_key")
   ) {
-    void deleteSecureKeyAsync(existing.auth.credential).catch(() => {});
+    try {
+      await deleteSecureKeyAsync(existing.auth.credential);
+    } catch (err) {
+      log.warn(
+        { err, connection: name, credential: existing.auth.credential },
+        "Failed to delete the connection's credential slot — secret orphaned in the vault",
+      );
+    }
   }
 
   return { ok: true as const };

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -807,6 +807,54 @@ describe("ProviderCreateForm submit sequence", () => {
     );
   });
 
+  test("custom endpoints get per-connection credential slots", async () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={["openai-compatible-personal"]}
+          defaultProviderType="openai-compatible"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    fireEvent.change(getInputByPlaceholder("xAI"), {
+      target: { value: "xAI Two" },
+    });
+    fireEvent.change(getInputByPlaceholder("https://api.x.ai/v1"), {
+      target: { value: "https://api.x.ai/v1" },
+    });
+    fireEvent.change(getInputByPlaceholder("model-1, model-2"), {
+      target: { value: "grok-4" },
+    });
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-oc-key" },
+    });
+    fireEvent.click(getSubmitButton());
+
+    await waitFor(() => {
+      expect(createConnectionCalls.length).toBe(1);
+    });
+    // The vault slot and the row's ref are keyed by the connection name —
+    // a provider-keyed slot would be shared by every custom endpoint, so
+    // saving one endpoint's key would overwrite the others'.
+    expect(secretsPostCalls.length).toBe(1);
+    expect(secretsPostCalls[0].body).toEqual({
+      type: "credential",
+      name: "openai-compatible-personal-2:api_key",
+      value: "sk-oc-key",
+    });
+    expect(createConnectionCalls[0].body).toMatchObject({
+      name: "openai-compatible-personal-2",
+      auth: {
+        type: "api_key",
+        credential: "credential/openai-compatible-personal-2/api_key",
+      },
+    });
+  });
+
   test("clicking Cancel invokes onCancel", () => {
     let cancelled = false;
     render(

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -113,8 +113,15 @@ export function ProviderCreateForm({
     : provider === "ollama"
       ? "none"
       : "api_key";
+  // Custom providers get per-connection credential slots: keying the ref by
+  // the provider type would share ONE vault slot across every custom
+  // endpoint, so saving any endpoint's key overwrites the others'.
   const [credential, setCredential] = useState(() =>
-    initialProvider === "ollama" ? "" : `credential/${initialProvider}/api_key`,
+    initialProvider === "ollama"
+      ? ""
+      : initialProvider === "openai-compatible"
+        ? `credential/${initialDefaults.key}/api_key`
+        : `credential/${initialProvider}/api_key`,
   );
   const [baseUrl, setBaseUrl] = useState("");
   const [connectionModels, setConnectionModels] = useState("");
@@ -194,7 +201,8 @@ export function ProviderCreateForm({
 
       if (authType === "api_key") {
         const effectiveCredential =
-          credential.trim() || `credential/${provider}/api_key`;
+          credential.trim() ||
+          `credential/${isOpenAICompatible ? name : provider}/api_key`;
         const trimmedKey = apiKeyValue.trim();
 
         if (trimmedKey) {
@@ -389,7 +397,9 @@ export function ProviderCreateForm({
             setCredential(
               newSelected === "ollama"
                 ? ""
-                : `credential/${newSelected}/api_key`,
+                : newSelected === "openai-compatible"
+                  ? `credential/${seedKey}/api_key`
+                  : `credential/${newSelected}/api_key`,
             );
             // Credential ref changes above trigger a new TQ query key,
             // so the presence check auto-refetches for the new provider.


### PR DESCRIPTION
## Summary
- Every openai-compatible connection derived the same vault reference — `credential/openai-compatible/api_key` — so saving any custom endpoint's API key silently overwrote the key every sibling endpoint resolves (observed live: three endpoints — OpenRouter, Fireworks, Anthropic-compat — all pointing at one slot holding whichever key was saved last).
- **Web**: the create form keys the ref by the connection name (`credential/<connection-name>/api_key`) for openai-compatible providers — initial state, provider-switch, and save-fallback derivations all updated. Catalog providers keep their provider-keyed slot: one entry per provider is intended there, and that slot name is a de-facto interface (CLI keys, credentials list).
- **Daemon boot repair** (`credential-slot-repair.ts`, invoked after the connections backfill, fire-and-forget): rows still on the shared ref are repointed to per-connection slots after copying the shared value — behavior-preserving, since overwritten keys are unrecoverable from the vault; re-keying one endpoint afterward can never break another. Rows are rewritten only after their slot is settled, so vault outages defer per-row to a later boot; idempotent.
- **Delete cleanup**: deleting a connection whose ref is its own per-name slot deletes the slot (best-effort) — impossible before because slots were shared.
- Compatibility: none needed — the daemon treats `auth.credential` as an opaque ref and the vault accepts arbitrary names, so new-style refs work against old daemons today; the repair simply waits for upgrade.

## Original prompt
Found while testing custom providers locally (connection-removal effort, papertrail #38102): configuring Anthropic as a custom provider clobbered the OpenRouter and Fireworks endpoint keys. Root cause is one interpolation choosing the provider type where it should use the connection name. Per-entry credential slots are also the prerequisite for the provider-entries model ("Anthropic — Work" as its own entry) recorded as the design direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->