### PR TITLE
fix(gateway): validate Slack block_actions payloads with tolerant Zod

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -151,9 +151,9 @@ describe("normalizeSlackBlockActions", () => {
   it("generates unique externalMessageId per click via action_ts", () => {
     const config = makeConfig();
     const payload1 = makeBlockActionsPayload();
-    payload1.actions[0].action_ts = "1000000000.000001";
+    payload1.actions![0].action_ts = "1000000000.000001";
     const payload2 = makeBlockActionsPayload();
-    payload2.actions[0].action_ts = "1000000000.000002";
+    payload2.actions![0].action_ts = "1000000000.000002";
 
     const result1 = normalizeSlackBlockActions(payload1, "env-same", config);
     const result2 = normalizeSlackBlockActions(payload2, "env-same", config);
@@ -170,7 +170,7 @@ describe("normalizeSlackBlockActions", () => {
     const payload = makeBlockActionsPayload({
       actionValue: undefined as unknown as string,
     });
-    payload.actions[0].value = undefined;
+    payload.actions![0].value = undefined;
     const result = normalizeSlackBlockActions(payload, "env-2", config);
 
     expect(result).not.toBeNull();
@@ -279,6 +279,114 @@ describe("normalizeSlackBlockActions", () => {
     );
 
     expect(result).toBeNull();
+  });
+});
+
+describe("block_actions tolerant validation", () => {
+  const config = makeConfig();
+
+  it("drops a non-object payload instead of throwing", () => {
+    expect(normalizeSlackBlockActions("nope", "env-x1", config)).toBeNull();
+    expect(normalizeSlackBlockActions(null, "env-x2", config)).toBeNull();
+    expect(normalizeSlackBlockActions(42, "env-x3", config)).toBeNull();
+  });
+
+  it("collapses a non-array actions field and drops the payload", () => {
+    const result = normalizeSlackBlockActions(
+      {
+        type: "block_actions",
+        trigger_id: "t1",
+        user: { id: "U123" },
+        channel: { id: "C456" },
+        actions: "not-an-array",
+      },
+      "env-x4",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("drops an action carrying neither value nor action_id", () => {
+    const result = normalizeSlackBlockActions(
+      {
+        type: "block_actions",
+        trigger_id: "t1",
+        user: { id: "U123" },
+        channel: { id: "C456" },
+        actions: [{ type: "button" }],
+      },
+      "env-x5",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("drops a payload missing the user id", () => {
+    const result = normalizeSlackBlockActions(
+      {
+        type: "block_actions",
+        trigger_id: "t1",
+        channel: { id: "C456" },
+        actions: [{ action_id: "approve", type: "button" }],
+      },
+      "env-x6",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("drops a payload missing the channel id", () => {
+    const result = normalizeSlackBlockActions(
+      {
+        type: "block_actions",
+        trigger_id: "t1",
+        user: { id: "U123" },
+        actions: [{ action_id: "approve", type: "button" }],
+      },
+      "env-x7",
+      config,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("collapses a non-string action value, falling back to action_id", () => {
+    const result = normalizeSlackBlockActions(
+      {
+        type: "block_actions",
+        trigger_id: "t1",
+        user: { id: "U123" },
+        channel: { id: "C456" },
+        actions: [
+          { action_id: "approve_btn", value: { bad: true }, type: "button" },
+        ],
+      },
+      "env-x8",
+      config,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.callbackData).toBe("approve_btn");
+  });
+
+  it("preserves unknown extra keys verbatim in raw", () => {
+    const payload = {
+      type: "block_actions",
+      trigger_id: "t1",
+      user: { id: "U123" },
+      channel: { id: "C456" },
+      actions: [
+        { action_id: "approve", value: "apr:run1:approve", type: "button" },
+      ],
+      unexpected_field: "surprise",
+    };
+    const result = normalizeSlackBlockActions(payload, "env-x9", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.raw).toEqual(payload);
   });
 });
 

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -916,23 +916,53 @@ export function normalizeSlackAppMention(
 }
 
 /**
- * Slack `block_actions` interactive payload shape (subset relevant to normalization).
- * Sent when a user clicks a Block Kit interactive element (button, menu, etc.).
+ * Slack `block_actions` interactive payload (subset relevant to normalization),
+ * delivered when a user clicks a Block Kit element (button, menu, …).
+ *
+ * No `@slack/types` cross-check here: unlike the Events API events, the
+ * interaction payload has no published type in `@slack/types` (it models Block
+ * Kit *elements*, e.g. `Button`, not the interaction envelope — that lives in
+ * `@slack/bolt`). The tolerant schema is the sole validator.
  */
-export interface SlackBlockActionsPayload {
-  type: "block_actions";
-  trigger_id: string;
-  user: { id: string; username?: string; name?: string };
-  channel?: { id: string; name?: string };
-  message?: { ts: string; thread_ts?: string; text?: string };
-  actions: Array<{
-    action_id: string;
-    value?: string;
-    type: string;
-    block_id?: string;
-    action_ts?: string;
-  }>;
-}
+const slackBlockActionsPayloadSchema = z.object({
+  type: optionalString(),
+  trigger_id: optionalString(),
+  user: z
+    .object({
+      id: optionalString(),
+      username: optionalString(),
+      name: optionalString(),
+    })
+    .optional()
+    .catch(undefined),
+  channel: z
+    .object({ id: optionalString(), name: optionalString() })
+    .optional()
+    .catch(undefined),
+  message: z
+    .object({
+      ts: optionalString(),
+      thread_ts: optionalString(),
+      text: optionalString(),
+    })
+    .optional()
+    .catch(undefined),
+  actions: z
+    .array(
+      z.object({
+        action_id: optionalString(),
+        value: optionalString(),
+        type: optionalString(),
+        block_id: optionalString(),
+        action_ts: optionalString(),
+      }),
+    )
+    .optional()
+    .catch(undefined),
+});
+export type SlackBlockActionsPayload = z.infer<
+  typeof slackBlockActionsPayloadSchema
+>;
 
 /**
  * Slack `reaction_added` / `reaction_removed` event. Both carry an identical
@@ -993,17 +1023,26 @@ type _SlackReactionApiCrossChecks = [
  * Returns null if the payload is missing required fields or cannot be routed.
  */
 export function normalizeSlackBlockActions(
-  payload: SlackBlockActionsPayload,
+  payload: unknown,
   envelopeId: string,
   config: GatewayConfig,
 ): NormalizedSlackEvent | null {
-  const action = payload.actions?.[0];
+  const parsed = slackBlockActionsPayloadSchema.safeParse(payload);
+  if (!parsed.success) return null;
+  const data = parsed.data;
+
+  const action = data.actions?.[0];
   if (!action) return null;
 
-  const userId = payload.user?.id;
+  // The action's value / id is the callback content and dedup payload; an
+  // action carrying neither is unactionable, so drop it.
+  const callbackData = action.value ?? action.action_id;
+  if (!callbackData) return null;
+
+  const userId = data.user?.id;
   if (!userId) return null;
 
-  const channelId = payload.channel?.id;
+  const channelId = data.channel?.id;
   if (!channelId) return null;
 
   // DM channels (D...) fall back to the default assistant when the DM
@@ -1024,8 +1063,7 @@ export function normalizeSlackBlockActions(
   }
   if (isRejection(routing)) return null;
 
-  const callbackData = action.value ?? action.action_id;
-  const messageTs = payload.message?.ts;
+  const messageTs = data.message?.ts;
   // Use action_ts (unique per click) to prevent dedup collisions when
   // multiple buttons on the same message are clicked or the same button
   // is clicked again after a transient failure.
@@ -1040,27 +1078,27 @@ export function normalizeSlackBlockActions(
         content: callbackData,
         conversationExternalId: channelId,
         externalMessageId: `${channelId}:${messageTs ?? envelopeId}:${actionTs}`,
-        callbackQueryId: payload.trigger_id,
+        callbackQueryId: data.trigger_id,
         callbackData,
       },
       actor: {
         actorExternalId: userId,
-        username: payload.user.username,
-        displayName: payload.user.name,
+        username: data.user?.username,
+        displayName: data.user?.name,
       },
       source: {
         updateId: envelopeId,
         messageId: messageTs,
-        ...(payload.message?.thread_ts
-          ? { threadId: payload.message.thread_ts }
+        ...(data.message?.thread_ts
+          ? { threadId: data.message.thread_ts }
           : {}),
       },
-      raw: payload as unknown as Record<string, unknown>,
+      raw: payload as Record<string, unknown>,
     },
     routing,
     // Prefer the thread root so follow-up messages land in the original
     // conversation thread, not a reply's sub-thread.
-    threadTs: payload.message?.thread_ts ?? messageTs ?? envelopeId,
+    threadTs: data.message?.thread_ts ?? messageTs ?? envelopeId,
     channel: channelId,
   };
 }

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1577,7 +1577,7 @@ export class SlackSocketModeClient {
 
     // First try to normalize as a channel-scoped block_actions event
     const normalized = normalizeSlackBlockActions(
-      payload as unknown as SlackBlockActionsPayload,
+      payload,
       payload.envelope_id ?? "unknown",
       this.config.gatewayConfig,
     );


### PR DESCRIPTION
## Prompt / plan

Next leaf in the Slack Socket Mode ingress-hardening arc (LUM-2816 item 5). Removes the `payload as unknown as SlackBlockActionsPayload` double-cast on Block Kit interaction payloads. Follows the merged reactions / edit-delete / message-normalizer leaves; same convention as `gateway/CLAUDE.md` → "Provider Webhook Payload Validation".

### Why

Block Kit interaction payloads (button / menu clicks) arrive over Socket Mode as **unvalidated `JSON.parse` output**, but `normalizeSlackBlockActions` trusted a blanket `payload as unknown as SlackBlockActionsPayload` cast at the socket-mode call site plus a hand-written interface. A non-object payload would throw (e.g. reading `.actions` off a scalar).

### What changed

- Replaced the interface with a tolerant `slackBlockActionsPayloadSchema` (type via `z.infer`); every field `.optional().catch(undefined)`.
- The normalizer now takes `unknown` and `safeParse`s at the boundary, so the socket-mode call site **drops its `as unknown as` double-cast** (just passes `payload`).
- Guards the fields it keys on — the first action, a **usable callback** (`value ?? action_id`), `user.id`, and `channel.id` — dropping the event when any is absent. A collapsed action value now falls back to `action_id` rather than emitting `undefined` content.
- `raw` carries the payload verbatim.

### Why no `@slack/types` cross-check here

Unlike the Events API events (reactions, messages), the `block_actions` **interaction payload** has no published type in `@slack/types` — that package models Block Kit *elements* (`Button`, etc.), and the interaction envelope lives in `@slack/bolt`. So the tolerant schema is the sole validator, noted inline.

### Why it's safe

- Behavior-preserving: all existing block_actions tests (routing, DM fallback, thread-root, per-click dedup, action_id fallback) pass unchanged. Only malformed input — which previously threw or trusted garbage — now drops cleanly.
- No change to routing, dedup keys, or the normalized output shape.

## Test plan

- `bun test src/slack/ src/__tests__/slack-*.test.ts` — 261 pass. Adds tolerant-validation tests: non-object payload, non-array `actions`, action carrying no callback, missing `user`/`channel` id, non-string action value → `action_id` fallback, and raw preservation.
- **Negative control:** reverting the `safeParse` turns the non-object and non-string-value tests red (including the original crash). Restored.
- `tsc`, `eslint`, `prettier`, `knip`, generic-examples — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f)_