### PR TITLE
feat(providers): custom-provider names validated everywhere they are written

### DIFF
--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -393,7 +393,7 @@ describe("POST inference/provider-connections (create)", () => {
       .values({
         name: "legacy-endpoint",
         provider: "openai-compatible",
-        label: "Anthropic",
+        label: " Anthropic ",
         auth: JSON.stringify({ type: "none" }),
         baseUrl: "http://localhost:1234/v1",
         models: JSON.stringify([{ id: "my-model" }]),
@@ -409,7 +409,14 @@ describe("POST inference/provider-connections (create)", () => {
         body: { models: [{ id: "another-model" }] },
       },
     )) as { label: string | null };
-    expect(result.label).toBe("Anthropic");
+    expect(result.label).toBe(" Anthropic ");
+
+    // Labels compare trimmed: resending the stored label without its
+    // padding is not an identity change.
+    await call(findHandler("inference_provider_connections_update"), {
+      pathParams: { name: "legacy-endpoint" },
+      body: { label: "Anthropic", models: [{ id: "third-model" }] },
+    });
 
     await expect(
       call(findHandler("inference_provider_connections_update"), {

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -266,6 +266,20 @@ describe("POST inference/provider-connections (create)", () => {
     expect(result.auth).toEqual({ type: "platform" });
   });
 
+  test("rejects a whitespace-only label", async () => {
+    await expect(
+      call(findHandler("inference_provider_connections_create"), {
+        body: {
+          name: "blank-label",
+          provider: "openai-compatible",
+          label: "   ",
+          base_url: "http://localhost:1234/v1",
+          models: [{ id: "my-model" }],
+        },
+      }),
+    ).rejects.toThrow(/non-blank string or null/);
+  });
+
   test("rejects a custom-provider label matching a built-in provider", async () => {
     await expect(
       call(findHandler("inference_provider_connections_create"), {

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -266,6 +266,79 @@ describe("POST inference/provider-connections (create)", () => {
     expect(result.auth).toEqual({ type: "platform" });
   });
 
+  test("rejects a custom-provider label matching a built-in provider", async () => {
+    await expect(
+      call(findHandler("inference_provider_connections_create"), {
+        body: {
+          name: "sneaky",
+          provider: "openai-compatible",
+          label: "Anthropic",
+          base_url: "http://localhost:1234/v1",
+          models: [{ id: "my-model" }],
+        },
+      }),
+    ).rejects.toThrow(/belongs to a built-in provider/);
+  });
+
+  test("rejects a custom-provider label duplicating another custom provider", async () => {
+    await call(findHandler("inference_provider_connections_create"), {
+      body: {
+        name: "first-endpoint",
+        provider: "openai-compatible",
+        label: "xAI",
+        base_url: "http://localhost:1234/v1",
+        models: [{ id: "my-model" }],
+      },
+    });
+    await expect(
+      call(findHandler("inference_provider_connections_create"), {
+        body: {
+          name: "second-endpoint",
+          provider: "openai-compatible",
+          label: "xai",
+          base_url: "http://localhost:5678/v1",
+          models: [{ id: "other" }],
+        },
+      }),
+    ).rejects.toThrow(/already exists/);
+    // Updating a different row onto the taken label is rejected too; keeping
+    // its own label is fine.
+    await call(findHandler("inference_provider_connections_create"), {
+      body: {
+        name: "third-endpoint",
+        provider: "openai-compatible",
+        label: "Local Box",
+        base_url: "http://localhost:9999/v1",
+        models: [{ id: "m" }],
+      },
+    });
+    await expect(
+      call(findHandler("inference_provider_connections_update"), {
+        pathParams: { name: "third-endpoint" },
+        body: { label: "xAI" },
+      }),
+    ).rejects.toThrow(/already exists/);
+    await call(findHandler("inference_provider_connections_update"), {
+      pathParams: { name: "first-endpoint" },
+      body: { label: "xAI" },
+    });
+  });
+
+  test("catalog providers may reuse their own display name as a label", async () => {
+    const result = (await call(
+      findHandler("inference_provider_connections_create"),
+      {
+        body: {
+          name: "anthropic-personal",
+          provider: "anthropic",
+          label: "Anthropic",
+          credential: "credential/anthropic/api_key",
+        },
+      },
+    )) as { label: string | null };
+    expect(result.label).toBe("Anthropic");
+  });
+
   test("derives none auth for openai-compatible without a credential", async () => {
     const result = (await call(
       findHandler("inference_provider_connections_create"),

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -339,6 +339,72 @@ describe("POST inference/provider-connections (create)", () => {
     expect(result.label).toBe("Anthropic");
   });
 
+  test("a label-less custom provider's name is validated as its identity", async () => {
+    await expect(
+      call(findHandler("inference_provider_connections_create"), {
+        body: {
+          name: "openai",
+          provider: "openai-compatible",
+          base_url: "http://localhost:1234/v1",
+          models: [{ id: "my-model" }],
+        },
+      }),
+    ).rejects.toThrow(/belongs to a built-in provider/);
+
+    await call(findHandler("inference_provider_connections_create"), {
+      body: {
+        name: "endpoint-a",
+        provider: "openai-compatible",
+        label: "My Box",
+        base_url: "http://localhost:1234/v1",
+        models: [{ id: "my-model" }],
+      },
+    });
+    await expect(
+      call(findHandler("inference_provider_connections_create"), {
+        body: {
+          name: "my box",
+          provider: "openai-compatible",
+          base_url: "http://localhost:5678/v1",
+          models: [{ id: "other" }],
+        },
+      }),
+    ).rejects.toThrow(/already exists/);
+  });
+
+  test("an unchanged label is not re-validated, so pre-validation rows stay editable", async () => {
+    const now = Date.now();
+    getDb()
+      .insert(providerConnections)
+      .values({
+        name: "legacy-endpoint",
+        provider: "openai-compatible",
+        label: "Anthropic",
+        auth: JSON.stringify({ type: "none" }),
+        baseUrl: "http://localhost:1234/v1",
+        models: JSON.stringify([{ id: "my-model" }]),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    const result = (await call(
+      findHandler("inference_provider_connections_update"),
+      {
+        pathParams: { name: "legacy-endpoint" },
+        body: { models: [{ id: "another-model" }] },
+      },
+    )) as { label: string | null };
+    expect(result.label).toBe("Anthropic");
+
+    await expect(
+      call(findHandler("inference_provider_connections_update"), {
+        pathParams: { name: "legacy-endpoint" },
+        body: { label: "OpenAI" },
+      }),
+    ).rejects.toThrow(/belongs to a built-in provider/);
+  });
+
   test("derives none auth for openai-compatible without a credential", async () => {
     const result = (await call(
       findHandler("inference_provider_connections_create"),

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -225,7 +225,7 @@ function handleGetConnection({ pathParams = {} }: RouteHandlerArgs) {
  * provider's identity. Enforced daemon-side: every client (web, CLI, API)
  * goes through these routes.
  */
-function assertValidCustomProviderLabel(
+function assertValidCustomProviderIdentity(
   provider: string,
   labelRaw: unknown,
   selfName: string,
@@ -233,14 +233,15 @@ function assertValidCustomProviderLabel(
   if (provider !== "openai-compatible") {
     return;
   }
+  // The display identity is the label, falling back to the name — a
+  // label-less row named "openai" impersonates a built-in just as well as
+  // a labeled one.
   const label = typeof labelRaw === "string" ? labelRaw.trim() : "";
-  if (!label) {
-    return;
-  }
-  const lower = label.toLowerCase();
+  const identity = label || selfName;
+  const lower = identity.toLowerCase();
   if (RESERVED_PROVIDER_IDENTITIES.has(lower)) {
     throw new BadRequestError(
-      `Invalid label: "${label}" belongs to a built-in provider. Pick another name.`,
+      `Invalid ${label ? "label" : "name"}: "${identity}" belongs to a built-in provider. Pick another name.`,
     );
   }
   const duplicate = listConnections(getDb(), {
@@ -252,7 +253,7 @@ function assertValidCustomProviderLabel(
   );
   if (duplicate) {
     throw new BadRequestError(
-      `Invalid label: a custom provider named "${label}" already exists.`,
+      `Invalid ${label ? "label" : "name"}: a custom provider named "${identity}" already exists.`,
     );
   }
 }
@@ -301,12 +302,14 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
     );
   }
 
-  assertValidCustomProviderLabel(providerResult.data, labelRaw, name);
-
   const customFields = await parseCustomProviderFields(
     body,
     providerResult.data,
   );
+
+  // Same event-loop turn as the write: no await separates this check from
+  // createConnection, so concurrent requests cannot both pass it.
+  assertValidCustomProviderIdentity(providerResult.data, labelRaw, name);
 
   const result = createConnection(getDb(), {
     name,
@@ -393,8 +396,6 @@ async function handleUpdateConnection({
       `Invalid label: must be a non-empty string or null`,
     );
   }
-  assertValidCustomProviderLabel(existing.provider, labelRaw, name);
-
   // Managed connections: lock auth to `{type:"platform"}`. The boot upsert in
   // `seedCanonicalConnections` would revert any other value on next restart;
   // reject the write here so the surprise loop never happens. Label remains
@@ -409,6 +410,16 @@ async function handleUpdateConnection({
   }
 
   const customFields = await parseCustomProviderFields(body, existing.provider);
+
+  // Only a CHANGED label is validated: rows whose stored identity predates
+  // validation stay editable for unrelated changes (key rotation, models).
+  // Checked in the same event-loop turn as the write so concurrent requests
+  // cannot both pass.
+  const labelChanging =
+    labelRaw !== undefined && (labelRaw ?? "") !== (existing.label ?? "");
+  if (labelChanging) {
+    assertValidCustomProviderIdentity(existing.provider, labelRaw, name);
+  }
 
   const result = updateConnection(getDb(), name, {
     auth: authResult.data,

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -413,10 +413,14 @@ async function handleUpdateConnection({
 
   // Only a CHANGED label is validated: keeping a stored label — whatever it
   // is — must never block unrelated edits (key rotation, models).
+  // Labels compare trimmed, the same normalization the identity check
+  // applies, so a stored padded label resent trimmed is not a change.
   // Checked in the same event-loop turn as the write so concurrent requests
   // cannot both pass.
   const labelChanging =
-    labelRaw !== undefined && (labelRaw ?? "") !== (existing.label ?? "");
+    labelRaw !== undefined &&
+    (typeof labelRaw === "string" ? labelRaw.trim() : "") !==
+      (existing.label ?? "").trim();
   if (labelChanging) {
     assertValidCustomProviderIdentity(existing.provider, labelRaw, name);
   }

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -411,8 +411,8 @@ async function handleUpdateConnection({
 
   const customFields = await parseCustomProviderFields(body, existing.provider);
 
-  // Only a CHANGED label is validated: rows whose stored identity predates
-  // validation stay editable for unrelated changes (key rotation, models).
+  // Only a CHANGED label is validated: keeping a stored label — whatever it
+  // is — must never block unrelated edits (key rotation, models).
   // Checked in the same event-loop turn as the write so concurrent requests
   // cannot both pass.
   const labelChanging =

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -38,6 +38,7 @@ import {
   MANAGED_CONNECTION_NAMES,
   updateConnection,
 } from "../../providers/inference/connections.js";
+import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { deleteSecureKeyAsync } from "../../security/secure-keys.js";
 import {
@@ -217,6 +218,56 @@ function handleGetConnection({ pathParams = {} }: RouteHandlerArgs) {
   return conn;
 }
 
+/**
+ * Custom providers share the flat provider list with built-ins, so their
+ * display identity (label, falling back to name) must not collide with a
+ * built-in provider's id or display name, nor with another custom
+ * provider's identity. Enforced daemon-side: every client (web, CLI, API)
+ * goes through these routes.
+ */
+function assertValidCustomProviderLabel(
+  provider: string,
+  labelRaw: unknown,
+  selfName: string,
+): void {
+  if (provider !== "openai-compatible") {
+    return;
+  }
+  const label = typeof labelRaw === "string" ? labelRaw.trim() : "";
+  if (!label) {
+    return;
+  }
+  const lower = label.toLowerCase();
+  if (RESERVED_PROVIDER_IDENTITIES.has(lower)) {
+    throw new BadRequestError(
+      `Invalid label: "${label}" belongs to a built-in provider. Pick another name.`,
+    );
+  }
+  const duplicate = listConnections(getDb(), {
+    provider: "openai-compatible",
+  }).find(
+    (c) =>
+      c.name !== selfName &&
+      (c.label?.trim() || c.name).toLowerCase() === lower,
+  );
+  if (duplicate) {
+    throw new BadRequestError(
+      `Invalid label: a custom provider named "${label}" already exists.`,
+    );
+  }
+}
+
+/** Built-in provider ids, display names, and routing identities, lowercased. */
+const RESERVED_PROVIDER_IDENTITIES = new Set<string>([
+  ...PROVIDER_CATALOG.flatMap((p) => [
+    p.id.toLowerCase(),
+    p.displayName.toLowerCase(),
+  ]),
+  "vellum",
+  "chatgpt",
+  "chatgpt subscription",
+]);
+
 async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
   const name = body.name;
   const provider = body.provider;
@@ -249,6 +300,8 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
       `Invalid label: must be a non-empty string or null`,
     );
   }
+
+  assertValidCustomProviderLabel(providerResult.data, labelRaw, name);
 
   const customFields = await parseCustomProviderFields(
     body,
@@ -340,6 +393,7 @@ async function handleUpdateConnection({
       `Invalid label: must be a non-empty string or null`,
     );
   }
+  assertValidCustomProviderLabel(existing.provider, labelRaw, name);
 
   // Managed connections: lock auth to `{type:"platform"}`. The boot upsert in
   // `seedCanonicalConnections` would revert any other value on next restart;

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -295,10 +295,10 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
   if (
     labelRaw !== undefined &&
     labelRaw !== null &&
-    (typeof labelRaw !== "string" || labelRaw.length === 0)
+    (typeof labelRaw !== "string" || labelRaw.trim().length === 0)
   ) {
     throw new BadRequestError(
-      `Invalid label: must be a non-empty string or null`,
+      `Invalid label: must be a non-blank string or null`,
     );
   }
 
@@ -390,10 +390,10 @@ async function handleUpdateConnection({
   if (
     labelRaw !== undefined &&
     labelRaw !== null &&
-    (typeof labelRaw !== "string" || labelRaw.length === 0)
+    (typeof labelRaw !== "string" || labelRaw.trim().length === 0)
   ) {
     throw new BadRequestError(
-      `Invalid label: must be a non-empty string or null`,
+      `Invalid label: must be a non-blank string or null`,
     );
   }
   // Managed connections: lock auth to `{type:"platform"}`. The boot upsert in

--- a/clients/web/src/domains/settings/ai/custom-provider-names.ts
+++ b/clients/web/src/domains/settings/ai/custom-provider-names.ts
@@ -1,0 +1,56 @@
+import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import { OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/constants";
+import type { ProviderConnection } from "@/generated/daemon/types.gen";
+
+/**
+ * Custom providers share the flat provider list with built-ins, so a custom
+ * provider's display identity must not collide with a built-in provider's id
+ * or display name, nor with another custom provider's identity. The daemon
+ * enforces the same rules on the connection routes; this mirror exists for
+ * inline feedback before submit.
+ */
+
+/** Built-in provider ids and display names, lowercased — names a custom
+ * provider may not take. */
+export const RESERVED_PROVIDER_NAMES = new Set(
+  Object.entries(PROVIDER_DISPLAY_NAMES).flatMap(([id, display]) => [
+    id.toLowerCase(),
+    display.toLowerCase(),
+  ]),
+);
+
+export type CustomProviderNameConflict = "reserved" | "duplicate";
+
+export const CUSTOM_PROVIDER_NAME_ERRORS: Record<
+  CustomProviderNameConflict,
+  string
+> = {
+  reserved: "That name belongs to a built-in provider. Pick another.",
+  duplicate: "A custom provider with this name already exists.",
+};
+
+/**
+ * Why `label` is unusable as a custom provider's name, or null when it's
+ * fine. `selfName` excludes the row being edited from the duplicate check.
+ */
+export function customProviderNameConflict(
+  label: string,
+  connections: ProviderConnection[] | undefined,
+  selfName?: string,
+): CustomProviderNameConflict | null {
+  const lower = label.trim().toLowerCase();
+  if (!lower) {
+    return null;
+  }
+  if (RESERVED_PROVIDER_NAMES.has(lower)) {
+    return "reserved";
+  }
+  const duplicate = (connections ?? []).some(
+    (c) =>
+      c.provider === OPENAI_COMPATIBLE_PROVIDER &&
+      c.name !== selfName &&
+      (c.label && c.label.trim() !== "" ? c.label : c.name).toLowerCase() ===
+        lower,
+  );
+  return duplicate ? "duplicate" : null;
+}

--- a/clients/web/src/domains/settings/ai/custom-provider-names.ts
+++ b/clients/web/src/domains/settings/ai/custom-provider-names.ts
@@ -49,8 +49,9 @@ export function customProviderNameConflict(
     (c) =>
       c.provider === OPENAI_COMPATIBLE_PROVIDER &&
       c.name !== selfName &&
-      (c.label && c.label.trim() !== "" ? c.label : c.name).toLowerCase() ===
-        lower,
+      // Same identity rule as the daemon's assertValidCustomProviderIdentity:
+      // trimmed label falling back to name.
+      (c.label?.trim() || c.name).toLowerCase() === lower,
   );
   return duplicate ? "duplicate" : null;
 }

--- a/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
+++ b/clients/web/src/domains/settings/ai/manage-providers-modal.tsx
@@ -186,6 +186,7 @@ export function ManageProvidersModal({
             connection={editingConnection ?? undefined}
             assistantId={assistantId}
             existingNames={existingNames}
+            connections={connections}
             onSave={handleEditorSave}
             onCancel={cancelEditor}
           />

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -993,6 +993,7 @@ function ProfileEditorModalInner({
           variant="inline"
           assistantId={assistantId}
           existingNames={effectiveConnections.map((c) => c.name)}
+          connections={effectiveConnections}
           defaultProviderType={provider || undefined}
           onCreated={handleProviderCreated}
           onCancel={() => setCreatingProvider(false)}

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -889,6 +889,40 @@ describe("ProviderCreateForm submit sequence", () => {
     expect(getSubmitButton().disabled).toBe(true);
   });
 
+  test("a stored label with surrounding whitespace still blocks its trimmed duplicate", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={["openai-compatible-personal"]}
+          connections={[
+            {
+              name: "openai-compatible-personal",
+              provider: "openai-compatible",
+              label: " xAI ",
+              auth: {
+                type: "api_key",
+                credential: "credential/openai-compatible-personal/api_key",
+              },
+              models: [{ id: "model-1" }],
+            } as unknown as ProviderConnection,
+          ]}
+          defaultProviderType="openai-compatible"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    fireEvent.change(getInputByPlaceholder("xAI"), {
+      target: { value: "xAI" },
+    });
+    expect(document.body.textContent).toContain(
+      "A custom provider with this name already exists.",
+    );
+    expect(getSubmitButton().disabled).toBe(true);
+  });
+
   test("clicking Cancel invokes onCancel", () => {
     let cancelled = false;
     render(

--- a/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.test.tsx
@@ -855,6 +855,40 @@ describe("ProviderCreateForm submit sequence", () => {
     });
   });
 
+  test("a custom provider cannot duplicate another custom provider's name", () => {
+    render(
+      <ModalWrapper>
+        <ProviderCreateForm
+          assistantId={ASSISTANT_ID}
+          existingNames={["openai-compatible-personal"]}
+          connections={[
+            {
+              name: "openai-compatible-personal",
+              provider: "openai-compatible",
+              label: "xAI",
+              auth: {
+                type: "api_key",
+                credential: "credential/openai-compatible-personal/api_key",
+              },
+              models: [{ id: "model-1" }],
+            } as unknown as ProviderConnection,
+          ]}
+          defaultProviderType="openai-compatible"
+          onCreated={() => {}}
+          onCancel={() => {}}
+        />
+      </ModalWrapper>,
+    );
+
+    fireEvent.change(getInputByPlaceholder("xAI"), {
+      target: { value: "xai" },
+    });
+    expect(document.body.textContent).toContain(
+      "A custom provider with this name already exists.",
+    );
+    expect(getSubmitButton().disabled).toBe(true);
+  });
+
   test("clicking Cancel invokes onCancel", () => {
     let cancelled = false;
     render(

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -21,6 +21,10 @@ import {
 
 import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
+import {
+  CUSTOM_PROVIDER_NAME_ERRORS,
+  customProviderNameConflict,
+} from "@/domains/settings/ai/custom-provider-names";
 import { deriveProviderDefaults } from "@/domains/settings/ai/profile-prefill";
 import type {
   Auth,
@@ -52,18 +56,11 @@ import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-c
 // Edit lives in `ProviderEditorContent` and is intentionally NOT handled
 // here — this component is create-only.
 
-/** Built-in provider ids and display names, lowercased — names a custom
- * provider may not take. */
-const RESERVED_PROVIDER_NAMES = new Set(
-  Object.entries(PROVIDER_DISPLAY_NAMES).flatMap(([id, display]) => [
-    id.toLowerCase(),
-    display.toLowerCase(),
-  ]),
-);
-
 export interface ProviderCreateFormProps {
   assistantId: string;
   existingNames: string[];
+  /** Existing connections, for custom-provider name-collision checks. */
+  connections?: ProviderConnection[];
   /** Pre-selected provider type. */
   defaultProviderType?: ConnectionProvider;
   onCreated: (connection: ProviderConnection) => void;
@@ -75,6 +72,7 @@ export interface ProviderCreateFormProps {
 export function ProviderCreateForm({
   assistantId,
   existingNames,
+  connections,
   defaultProviderType,
   onCreated,
   onCancel,
@@ -179,16 +177,16 @@ export function ProviderCreateForm({
     enabled: true,
   });
 
-  // A custom provider must not take a built-in provider's name — entries
-  // share one flat list, and an entry labeled "Anthropic" would be
-  // indistinguishable from the catalog provider.
-  const reservedNameConflict =
-    isOpenAICompatible &&
-    RESERVED_PROVIDER_NAMES.has(label.trim().toLowerCase());
+  // A custom provider must not take a built-in provider's name or another
+  // custom provider's — entries share one flat list. Mirrors the daemon's
+  // route-side validation for inline feedback.
+  const nameConflict = isOpenAICompatible
+    ? customProviderNameConflict(label, connections)
+    : null;
   const canSave =
     name.trim().length > 0 &&
     (!isOpenAICompatible || label.trim().length > 0) &&
-    !reservedNameConflict;
+    nameConflict === null;
 
   async function handleSave() {
     if (!canSave) {
@@ -450,13 +448,13 @@ export function ProviderCreateForm({
               placeholder="xAI"
               fullWidth
             />
-            {reservedNameConflict ? (
+            {nameConflict ? (
               <Typography
                 variant="body-small-default"
                 as="p"
                 className="text-(--system-negative-strong)"
               >
-                That name belongs to a built-in provider. Pick another.
+                {CUSTOM_PROVIDER_NAME_ERRORS[nameConflict]}
               </Typography>
             ) : null}
           </div>

--- a/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -157,8 +157,8 @@ export function ProviderEditorContent({
   // remains fixed, so a non-empty value is the only save gate.
   // A custom provider must not take a built-in provider's name or another
   // custom provider's — mirrors the daemon's route-side validation.
-  // Only a changed label is validated — a stored identity that predates
-  // validation must not lock the row out of unrelated edits (key rotation).
+  // Only a changed label is validated — keeping the stored label must never
+  // lock the row out of unrelated edits (key rotation).
   const labelChanged = label.trim() !== (connection?.label ?? "").trim();
   const nameConflict = isOpenAICompatible && labelChanged
     ? customProviderNameConflict(label, connections, connection?.name)

--- a/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -157,7 +157,10 @@ export function ProviderEditorContent({
   // remains fixed, so a non-empty value is the only save gate.
   // A custom provider must not take a built-in provider's name or another
   // custom provider's — mirrors the daemon's route-side validation.
-  const nameConflict = isOpenAICompatible
+  // Only a changed label is validated — a stored identity that predates
+  // validation must not lock the row out of unrelated edits (key rotation).
+  const labelChanged = label.trim() !== (connection?.label ?? "").trim();
+  const nameConflict = isOpenAICompatible && labelChanged
     ? customProviderNameConflict(label, connections, connection?.name)
     : null;
   const canSave = name.trim().length > 0 && nameConflict === null;

--- a/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -23,6 +23,10 @@ import type {
   InferenceProviderconnectionsByNamePatchData,
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
+import {
+  CUSTOM_PROVIDER_NAME_ERRORS,
+  customProviderNameConflict,
+} from "@/domains/settings/ai/custom-provider-names";
 import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import { ProviderEditorApiKeySection } from "@/domains/settings/ai/provider-editor-api-key-section";
 import {
@@ -48,6 +52,8 @@ export interface ProviderEditorContentProps {
   connection?: ProviderConnection;
   assistantId: string;
   existingNames: string[];
+  /** Existing connections, for custom-provider name-collision checks. */
+  connections?: ProviderConnection[];
   onSave: (connection: ProviderConnection) => void;
   onCancel: () => void;
 }
@@ -57,6 +63,7 @@ export function ProviderEditorContent({
   connection,
   assistantId,
   existingNames,
+  connections,
   onSave,
   onCancel,
 }: ProviderEditorContentProps) {
@@ -148,7 +155,12 @@ export function ProviderEditorContent({
 
   // Only edit reaches this component's own Save. The internal provider name
   // remains fixed, so a non-empty value is the only save gate.
-  const canSave = name.trim().length > 0;
+  // A custom provider must not take a built-in provider's name or another
+  // custom provider's — mirrors the daemon's route-side validation.
+  const nameConflict = isOpenAICompatible
+    ? customProviderNameConflict(label, connections, connection?.name)
+    : null;
+  const canSave = name.trim().length > 0 && nameConflict === null;
 
   async function handleSave() {
     if (!canSave) {
@@ -294,6 +306,7 @@ export function ProviderEditorContent({
         variant="modal"
         assistantId={assistantId}
         existingNames={existingNames}
+        connections={connections}
         defaultProviderType={provider}
         onCreated={onSave}
         onCancel={onCancel}
@@ -325,6 +338,15 @@ export function ProviderEditorContent({
             placeholder="e.g. My Anthropic Key"
             fullWidth
           />
+          {nameConflict ? (
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="text-(--system-negative-strong)"
+            >
+              {CUSTOM_PROVIDER_NAME_ERRORS[nameConflict]}
+            </Typography>
+          ) : null}
         </div>
 
         {/* Base URL + Models — openai-compatible only */}


### PR DESCRIPTION
## Summary
- Daemon-enforced name validation for custom providers on the connection create AND update routes (`assertValidCustomProviderLabel`): a label may not match a built-in provider's id or display name (case-insensitive; includes vellum/chatgpt), nor another custom provider's display identity (label falling back to name, excluding self). Every client — web, CLI, raw API — goes through these routes, so the rules hold regardless of front-end.
- Web mirrors the same rules inline via a shared helper (`custom-provider-names.ts`): the create form now flags duplicates as well as reserved names (checked against real connections, not internal keys), and the edit modal — the bypass Codex found — gets the identical guard with self-exclusion. Both disable Save with specific copy.
- Tests: daemon (reserved label 400, duplicate 400 on create and update, self-relabel allowed, catalog providers exempt) and web (duplicate conflict rendering + disabled submit).

## Original prompt
Follow-up to #38958 per review: two Codex P2s — duplicate custom-provider names were permitted (validation only reserved built-ins and compared against hidden internal keys), and the Edit flow bypassed the reserved-name guard entirely since only the create form checked. Emmie ruled "fix in another pr"; this is that PR, stacked on #38958. Connection-removal papertrail: #38102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/38999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->