### PR TITLE
feat(web): make Pinned and Chats sidebar sections collapsible

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -1,5 +1,6 @@
 import {
     Clock,
+    MessageSquare,
     Pin,
     Search,
     SquarePen,
@@ -22,10 +23,7 @@ import {
     ConversationListProvider,
     type ConversationListContextValue,
 } from "@/domains/chat/components/conversation-list-context";
-import {
-    ConversationNavSection,
-    ConversationRowList,
-} from "@/domains/chat/components/conversation-nav-section";
+import { ConversationNavSection } from "@/domains/chat/components/conversation-nav-section";
 import { CollapsedGroupFlyout } from "@/domains/chat/components/conversation-rail-flyout";
 import { GroupActionsMenu, renderGroupMenuItems } from "@/domains/chat/components/group-actions-menu";
 import { AssistantNavItem } from "@/domains/chat/components/assistant-nav-item";
@@ -458,87 +456,101 @@ export function AssistantSideMenu({
             </div>
           ) : (
             <>
-              {sidebar.pinned.length > 0 ? (
-                <SideMenu.Section title="Pinned" className="gap-1">
-                  <ConversationRowList items={sidebar.pinned} dragSection="pinned" />
-                </SideMenu.Section>
-              ) : null}
+              {/* Pinned + Chats are collapsible like the channel/group
+                  sections below, but default open (see `openPrimary` in
+                  use-sidebar-state). New Chat lives in the assistant cluster
+                  above, not as a section-header action. */}
+              <CollapsibleNavSection.Root
+                type="multiple"
+                className="gap-1"
+                value={sidebar.effectiveOpenPrimary}
+                onValueChange={sidebar.onOpenPrimaryChange}
+              >
+                {sidebar.pinned.length > 0 ? (
+                  <ConversationNavSection
+                    value="pinned"
+                    icon={Pin}
+                    label="Pinned"
+                    items={sidebar.pinned}
+                    dragSection="pinned"
+                  />
+                ) : null}
 
-              {/* New Chat lives in the assistant cluster above, not as a
-                  section-header action. */}
-              <SideMenu.Section title="Chats" className="gap-1">
-                <ConversationRowList
+                <ConversationNavSection
+                  value="recents"
+                  icon={MessageSquare}
+                  label="Chats"
                   items={sidebar.recents.items}
                   pagination={sidebar.recents}
                 />
+              </CollapsibleNavSection.Root>
 
-                <CollapsibleNavSection.Root
-                  type="multiple"
-                  className="gap-1"
-                  value={sidebar.effectiveOpenCategories}
-                  onValueChange={sidebar.onOpenCategoriesChange}
-                >
-                  {sidebar.channelSections.map((section) => {
-                    const label = getChannelLabel(section.channelId);
-                    return (
-                      <ConversationNavSection
-                        key={section.channelId}
-                        value={channelSectionKey(section.channelId)}
-                        icon={getChannelIcon(section.channelId)}
-                        label={label}
-                        contextMenuContent={buildGroupContextMenu(label, section.all)}
-                        items={section.items}
-                        pagination={section}
-                      />
-                    );
-                  })}
-                </CollapsibleNavSection.Root>
+              <CollapsibleNavSection.Root
+                type="multiple"
+                className="gap-1"
+                value={sidebar.effectiveOpenCategories}
+                onValueChange={sidebar.onOpenCategoriesChange}
+              >
+                {sidebar.channelSections.map((section) => {
+                  const label = getChannelLabel(section.channelId);
+                  return (
+                    <ConversationNavSection
+                      key={section.channelId}
+                      value={channelSectionKey(section.channelId)}
+                      icon={getChannelIcon(section.channelId)}
+                      label={label}
+                      contextMenuContent={buildGroupContextMenu(label, section.all)}
+                      items={section.items}
+                      pagination={section}
+                    />
+                  );
+                })}
+              </CollapsibleNavSection.Root>
 
-                {sidebar.customGroups.length > 0 ? (
-                  <>
-                    <SideMenu.Separator />
-                    <SideMenu.Section title="Your Groups">
-                      <CollapsibleNavSection.Root
-                        type="multiple"
-                        className="gap-1"
-                        value={sidebar.effectiveOpenCustomGroups}
-                        onValueChange={sidebar.onOpenCustomGroupsChange}
-                      >
-                        {sidebar.customGroups.map((group) => (
-                          <ConversationNavSection
-                            key={group.id}
-                            value={group.id}
-                            label={group.name}
-                            trailing={
-                              onRenameGroup || onDeleteGroup ? (
-                                <GroupActionsMenu
-                                  groupId={group.id}
-                                  onRename={onRenameGroup}
-                                  onDelete={onDeleteGroup}
-                                />
-                              ) : null
-                            }
-                            contextMenuContent={buildGroupContextMenu(
-                              group.name,
-                              group.conversations,
-                              {
-                                onRename: onRenameGroup
-                                  ? () => onRenameGroup(group.id)
-                                  : undefined,
-                                onDelete: onDeleteGroup
-                                  ? () => onDeleteGroup(group.id)
-                                  : undefined,
-                              },
-                            )}
-                            items={group.conversations}
-                            dragSection={`group:${group.id}`}
-                          />
-                        ))}
-                      </CollapsibleNavSection.Root>
-                    </SideMenu.Section>
-                  </>
-                ) : null}
-              </SideMenu.Section>
+              {sidebar.customGroups.length > 0 ? (
+                <>
+                  <SideMenu.Separator />
+                  <SideMenu.Section title="Your Groups">
+                    <CollapsibleNavSection.Root
+                      type="multiple"
+                      className="gap-1"
+                      value={sidebar.effectiveOpenCustomGroups}
+                      onValueChange={sidebar.onOpenCustomGroupsChange}
+                    >
+                      {sidebar.customGroups.map((group) => (
+                        <ConversationNavSection
+                          key={group.id}
+                          value={group.id}
+                          label={group.name}
+                          trailing={
+                            onRenameGroup || onDeleteGroup ? (
+                              <GroupActionsMenu
+                                groupId={group.id}
+                                onRename={onRenameGroup}
+                                onDelete={onDeleteGroup}
+                              />
+                            ) : null
+                          }
+                          contextMenuContent={buildGroupContextMenu(
+                            group.name,
+                            group.conversations,
+                            {
+                              onRename: onRenameGroup
+                                ? () => onRenameGroup(group.id)
+                                : undefined,
+                              onDelete: onDeleteGroup
+                                ? () => onDeleteGroup(group.id)
+                                : undefined,
+                            },
+                          )}
+                          items={group.conversations}
+                          dragSection={`group:${group.id}`}
+                        />
+                      ))}
+                    </CollapsibleNavSection.Root>
+                  </SideMenu.Section>
+                </>
+              ) : null}
             </>
           )}
         </SideMenu.Body>

--- a/clients/web/src/domains/chat/sidebar-collapse-store.test.ts
+++ b/clients/web/src/domains/chat/sidebar-collapse-store.test.ts
@@ -8,6 +8,7 @@ function resetStore() {
     assistantId: null,
     openCategories: [],
     openCustomGroups: [],
+    openPrimary: ["pinned", "recents"],
     backgroundActivated: false,
     scheduledActivated: false,
   });
@@ -123,6 +124,33 @@ describe("SidebarCollapseStore", () => {
       "scheduled",
     ]);
     expect(localStorage.length).toBe(0);
+  });
+
+  test("openPrimary defaults to Pinned + Chats open when nothing is stored", () => {
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+    expect(useSidebarCollapseStore.getState().openPrimary).toEqual([
+      "pinned",
+      "recents",
+    ]);
+  });
+
+  test("setOpenPrimary persists to localStorage", () => {
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+    useSidebarCollapseStore.getState().setOpenPrimary(["pinned"]);
+
+    const raw = localStorage.getItem("vellum:sidebar-open-primary:asst-1");
+    expect(JSON.parse(raw!)).toEqual(["pinned"]);
+    expect(useSidebarCollapseStore.getState().openPrimary).toEqual(["pinned"]);
+  });
+
+  test("setAssistantId hydrates a collapsed primary section from storage", () => {
+    // Stored empty array = user collapsed both; must not fall back to open.
+    localStorage.setItem(
+      "vellum:sidebar-open-primary:asst-1",
+      JSON.stringify([]),
+    );
+    useSidebarCollapseStore.getState().setAssistantId("asst-1");
+    expect(useSidebarCollapseStore.getState().openPrimary).toEqual([]);
   });
 });
 

--- a/clients/web/src/domains/chat/sidebar-collapse-store.ts
+++ b/clients/web/src/domains/chat/sidebar-collapse-store.ts
@@ -24,8 +24,11 @@ import { createSelectors } from "@/utils/create-selectors";
 import {
   loadOpenCategories,
   loadOpenCustomGroups,
+  loadOpenPrimary,
+  PRIMARY_SECTION_KEYS,
   saveOpenCategories,
   saveOpenCustomGroups,
+  saveOpenPrimary,
 } from "@/domains/chat/utils/sidebar-group-collapse-storage";
 
 // ---------------------------------------------------------------------------
@@ -36,6 +39,11 @@ export interface SidebarCollapseState {
   assistantId: string | null;
   openCategories: string[];
   openCustomGroups: string[];
+  /**
+   * Open state of the always-present primary sections (Pinned, Chats).
+   * Defaults to both open (see {@link loadOpenPrimary}).
+   */
+  openPrimary: string[];
   /**
    * Whether the user has revealed the Background section this session —
    * either by expanding it in the full sidebar or opening its rail flyout.
@@ -57,6 +65,7 @@ export interface SidebarCollapseActions {
   setAssistantId: (assistantId: string) => void;
   setOpenCategories: (next: string[]) => void;
   setOpenCustomGroups: (next: string[]) => void;
+  setOpenPrimary: (next: string[]) => void;
   activateBackground: () => void;
   activateScheduled: () => void;
 }
@@ -72,6 +81,9 @@ const INITIAL_STATE: SidebarCollapseState = {
   assistantId: null,
   openCategories: [],
   openCustomGroups: [],
+  // Pinned + Chats start open; the real per-assistant value loads on
+  // setAssistantId.
+  openPrimary: [...PRIMARY_SECTION_KEYS],
   backgroundActivated: false,
   scheduledActivated: false,
 };
@@ -85,12 +97,13 @@ const useSidebarCollapseStoreBase = create<SidebarCollapseStore>()(
     ...INITIAL_STATE,
 
     setAssistantId: (assistantId: string) => {
-      if (get().assistantId === assistantId) return;
+      if (get().assistantId === assistantId) {return;}
       const openCategories = loadOpenCategories(assistantId);
       set({
         assistantId,
         openCategories,
         openCustomGroups: loadOpenCustomGroups(assistantId),
+        openPrimary: loadOpenPrimary(assistantId),
         // A persisted expanded section counts as a reveal, so each lazy
         // fetch resumes for assistants the user already had that section
         // open on — tracked per section so they stay independent.
@@ -108,13 +121,19 @@ const useSidebarCollapseStoreBase = create<SidebarCollapseStore>()(
           prev.scheduledActivated || next.includes("scheduled"),
       }));
       const { assistantId } = get();
-      if (assistantId) saveOpenCategories(assistantId, next);
+      if (assistantId) {saveOpenCategories(assistantId, next);}
     },
 
     setOpenCustomGroups: (next: string[]) => {
       set({ openCustomGroups: next });
       const { assistantId } = get();
-      if (assistantId) saveOpenCustomGroups(assistantId, next);
+      if (assistantId) {saveOpenCustomGroups(assistantId, next);}
+    },
+
+    setOpenPrimary: (next: string[]) => {
+      set({ openPrimary: next });
+      const { assistantId } = get();
+      if (assistantId) {saveOpenPrimary(assistantId, next);}
     },
 
     activateBackground: () => {

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -115,8 +115,10 @@ export interface SidebarState {
 
   effectiveOpenCategories: string[];
   effectiveOpenCustomGroups: string[];
+  effectiveOpenPrimary: string[];
   onOpenCategoriesChange: (next: string[]) => void;
   onOpenCustomGroupsChange: (next: string[]) => void;
+  onOpenPrimaryChange: (next: string[]) => void;
 
   /**
    * Reveal the Background section, enabling its lazy fetch. Wired to the
@@ -169,8 +171,10 @@ export function useSidebarState({
 
   const openCategories = useSidebarCollapseStore.use.openCategories();
   const openCustomGroups = useSidebarCollapseStore.use.openCustomGroups();
+  const openPrimary = useSidebarCollapseStore.use.openPrimary();
   const setOpenCategories = useSidebarCollapseStore.use.setOpenCategories();
   const setOpenCustomGroups = useSidebarCollapseStore.use.setOpenCustomGroups();
+  const setOpenPrimary = useSidebarCollapseStore.use.setOpenPrimary();
   const activateBackground = useSidebarCollapseStore.use.activateBackground();
   const activateScheduled = useSidebarCollapseStore.use.activateScheduled();
   const backgroundActivated = useSidebarCollapseStore.use.backgroundActivated();
@@ -336,6 +340,21 @@ export function useSidebarState({
     return [...new Set([...openCustomGroups, ...extra])];
   }, [openCustomGroups, attentionConversationIds, grouped.customGroups]);
 
+  // Pinned and Chats default open; force-open still applies if the user
+  // collapsed one and a conversation in it needs attention.
+  const effectiveOpenPrimary = useMemo(() => {
+    if (!attentionConversationIds || attentionConversationIds.size === 0)
+      return openPrimary;
+    const extra: string[] = [];
+    if (grouped.pinned.length > 0 && hasAttentionIn(grouped.pinned))
+      extra.push("pinned");
+    if (grouped.recents.length > 0 && hasAttentionIn(grouped.recents))
+      extra.push("recents");
+    if (extra.length === 0) return openPrimary;
+    if (extra.every((k) => openPrimary.includes(k))) return openPrimary;
+    return [...new Set([...openPrimary, ...extra])];
+  }, [openPrimary, attentionConversationIds, grouped.pinned, grouped.recents, hasAttentionIn]);
+
   return {
     pinned: grouped.pinned,
     scheduled: grouped.scheduled,
@@ -347,8 +366,10 @@ export function useSidebarState({
     customGroups: grouped.customGroups,
     effectiveOpenCategories,
     effectiveOpenCustomGroups,
+    effectiveOpenPrimary,
     onOpenCategoriesChange: setOpenCategories,
     onOpenCustomGroupsChange: setOpenCustomGroups,
+    onOpenPrimaryChange: setOpenPrimary,
     activateBackground,
     backgroundLoading,
     activateScheduled,

--- a/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.test.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.test.ts
@@ -3,12 +3,15 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } fr
 import {
   channelSectionKey,
   loadOpenCategories,
+  loadOpenPrimary,
   saveOpenCategories,
+  saveOpenPrimary,
 } from "@/domains/chat/utils/sidebar-group-collapse-storage";
 import { installMemoryStorage } from "@/utils/memory-storage.test-helper";
 
 const ASSISTANT_ID = "asst_123";
 const STORAGE_KEY = `vellum:sidebar-open-categories:${ASSISTANT_ID}`;
+const PRIMARY_STORAGE_KEY = `vellum:sidebar-open-primary:${ASSISTANT_ID}`;
 
 const memoryStorage = installMemoryStorage({ beforeAll, afterAll, beforeEach, afterEach });
 
@@ -102,5 +105,46 @@ describe("saveOpenCategories", () => {
     saveOpenCategories("other_assistant", ["scheduled"]);
     expect(loadOpenCategories(ASSISTANT_ID)).toEqual(["background"]);
     expect(loadOpenCategories("other_assistant")).toEqual(["scheduled"]);
+  });
+});
+
+describe("loadOpenPrimary", () => {
+  test("defaults to both Pinned and Chats open when nothing is stored", () => {
+    expect(loadOpenPrimary(ASSISTANT_ID)).toEqual(["pinned", "recents"]);
+  });
+
+  test("returns an empty array when the user has collapsed both", () => {
+    // A stored empty array is distinct from an absent key — it means the user
+    // explicitly collapsed both sections, so we must NOT fall back to open.
+    memoryStorage.setItem(PRIMARY_STORAGE_KEY, JSON.stringify([]));
+    expect(loadOpenPrimary(ASSISTANT_ID)).toEqual([]);
+  });
+
+  test("returns the stored subset when only one is open", () => {
+    memoryStorage.setItem(PRIMARY_STORAGE_KEY, JSON.stringify(["pinned"]));
+    expect(loadOpenPrimary(ASSISTANT_ID)).toEqual(["pinned"]);
+  });
+
+  test("filters unknown keys", () => {
+    memoryStorage.setItem(
+      PRIMARY_STORAGE_KEY,
+      JSON.stringify(["pinned", "recents", "scheduled", "bogus"]),
+    );
+    expect(loadOpenPrimary(ASSISTANT_ID)).toEqual(["pinned", "recents"]);
+  });
+});
+
+describe("saveOpenPrimary", () => {
+  test("writes under the assistant-scoped primary storage key", () => {
+    saveOpenPrimary(ASSISTANT_ID, ["recents"]);
+    expect(memoryStorage.getItem(PRIMARY_STORAGE_KEY)).toBe(
+      JSON.stringify(["recents"]),
+    );
+    expect(loadOpenPrimary(ASSISTANT_ID)).toEqual(["recents"]);
+  });
+
+  test("persists the collapsed-both state across a reload", () => {
+    saveOpenPrimary(ASSISTANT_ID, []);
+    expect(loadOpenPrimary(ASSISTANT_ID)).toEqual([]);
   });
 });

--- a/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-group-collapse-storage.ts
@@ -16,6 +16,16 @@ const OPEN_CATEGORY_KEYS = new Set([
   "background",
 ]);
 
+/**
+ * The always-present primary sections (Pinned, Chats). Unlike the built-in
+ * categories and custom groups, these default to OPEN.
+ */
+export const PRIMARY_SECTION_KEYS = ["pinned", "recents"] as const;
+
+function isKnownPrimaryKey(key: string): boolean {
+  return (PRIMARY_SECTION_KEYS as readonly string[]).includes(key);
+}
+
 /** Prefix marking a collapsible category as a per-channel origin section. */
 const CHANNEL_SECTION_PREFIX = "channel:";
 
@@ -52,6 +62,18 @@ const customGroupsStorage = createKeyedStorageAccessor<string[]>({
   fallback: [],
 });
 
+// Primary sections default to OPEN: the fallback returns both keys, so a
+// first-time user (no stored key) sees Pinned + Chats expanded. A stored empty
+// array is distinct — it means the user explicitly collapsed both — because
+// createKeyedStorageAccessor only falls back when the key is absent.
+const primaryStorage = createKeyedStorageAccessor<string[]>({
+  keyFn: (assistantId) => `vellum:sidebar-open-primary:${assistantId}`,
+  scope: "user",
+  parse: parseStringArray,
+  serialize: JSON.stringify,
+  fallback: [...PRIMARY_SECTION_KEYS],
+});
+
 /** Load open built-in sidebar category keys, filtering stale values. */
 export function loadOpenCategories(assistantId: string): string[] {
   return categoriesStorage.load(assistantId).filter(isKnownCategoryKey);
@@ -73,4 +95,16 @@ export function saveOpenCustomGroups(
   openGroups: string[],
 ): void {
   customGroupsStorage.save(assistantId, openGroups);
+}
+
+/** Load the open primary sections (Pinned, Chats). Defaults to both open. */
+export function loadOpenPrimary(assistantId: string): string[] {
+  return primaryStorage.load(assistantId).filter(isKnownPrimaryKey);
+}
+
+export function saveOpenPrimary(
+  assistantId: string,
+  openPrimary: string[],
+): void {
+  primaryStorage.save(assistantId, openPrimary);
 }


### PR DESCRIPTION
## Prompt / plan

Part of splitting the "restore custom conversation groups + make the sidebar consistently collapsible" work into small, focused PRs. Plan: `/root/.claude/plans/generic-giggling-rainbow.md` (Part B). The "Move to group / New group" restore this series began with landed separately in #38997 (**merged**), so this PR is now based directly on `main`. The collapsed-section activity indicator is a follow-up in #39002 (stacked on this branch).

**What & why:** Channels and custom groups were already collapsible via the shared `CollapsibleNavSection` primitive, but Pinned and Chats were not — they rendered as plain, always-open lists. This PR moves Pinned and Chats onto that same primitive so every sidebar section behaves the same way.

- Both sections **default to open**, and their open/closed state **persists per assistant**.
- The persisted state distinguishes "never touched" (default open) from "user collapsed both" by storing the *open* set with a default of the full section list — reusing the same keyed-storage accessor pattern as `openCategories` / `openCustomGroups`.
- A section with unread activity is **forced open** so attention is never hidden behind a collapsed header — via a new `effectiveOpenPrimary` memo that mirrors the existing `effectiveOpenCategories` / `effectiveOpenCustomGroups` ones.
- The collapsed-rail branch is untouched.

**Intentionally kept minimal:** the three `effectiveOpen*` memos now share the same shape and could be pulled behind one shared helper, but that consolidation touches working, tested code unrelated to this feature. It's deliberately left as a possible focused follow-up refactor rather than bundled into this feature PR.

## Test plan

- `bunx tsc --noEmit` — clean (also run by the pre-commit hook).
- `bun run lint` — clean (0 errors).
- `bun test` — 61 passing across `sidebar-collapse-store.test.ts`, `sidebar-group-collapse-storage.test.ts`, `use-sidebar-state.test.tsx`, `assistant-side-menu.test.tsx`. Covers the default-open primary sections and the absent-vs-empty persistence seam.
- Manual: collapse/expand Pinned + Chats, reload, confirm persistence and default-open; confirm a section with unread activity force-opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw7an5eWS7sgUBvdoqw5QK