### PR TITLE
feat(web): show an activity dot on collapsed sidebar section headers

### DIFF
--- a/clients/web/src/components/collapsible-nav-section.tsx
+++ b/clients/web/src/components/collapsible-nav-section.tsx
@@ -64,6 +64,12 @@ export interface CollapsibleNavSectionSectionProps
   label: string;
   trailing?: ReactNode;
   contextMenuContent?: ReactNode;
+  /**
+   * Activity indicator rendered inline in the header, but only while the
+   * section is collapsed — when open, the child rows show their own
+   * indicators, so a header dot would be redundant.
+   */
+  collapsedIndicator?: ReactNode;
   children?: ReactNode;
   contentClassName?: string;
   ref?: Ref<HTMLDivElement>;
@@ -75,6 +81,7 @@ function CollapsibleNavSectionSection({
   label,
   trailing,
   contextMenuContent,
+  collapsedIndicator,
   children,
   className,
   contentClassName,
@@ -117,6 +124,11 @@ function CollapsibleNavSectionSection({
           />
         </span>
         <span className="min-w-0 flex-1 truncate">{label}</span>
+        {collapsedIndicator ? (
+          <span className="ml-1 flex shrink-0 items-center group-data-[state=open]:hidden">
+            {collapsedIndicator}
+          </span>
+        ) : null}
       </Collapsible.Trigger>
       {trailing ? (
         <span

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -18,7 +18,7 @@ import {
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
 
 import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
-import { CollapsedGroupIcon, getGroupIndicatorState } from "@/domains/chat/components/collapsed-group-icon";
+import { CollapsedGroupIcon, getGroupIndicatorState, GroupIndicatorDot } from "@/domains/chat/components/collapsed-group-icon";
 import {
     ConversationListProvider,
     type ConversationListContextValue,
@@ -271,6 +271,18 @@ export function AssistantSideMenu({
   // Shared context for every conversation row (Pinned, Recents, channel
   // sections, custom groups, rail flyout): the action callbacks,
   // active/processing/attention state, and drag controller the rows read.
+  // Activity dot for a collapsed section header — surfaces processing/unread
+  // conversations that live in a collapsed section (attention already
+  // force-opens the section via effectiveOpen*). Null when the section is idle.
+  const collapsedActivityDot = (conversations: Conversation[]): ReactNode => {
+    const state = getGroupIndicatorState(
+      conversations,
+      processingConversationIds,
+      attentionConversationIds,
+    );
+    return state ? <GroupIndicatorDot state={state} /> : null;
+  };
+
   const listContext: ConversationListContextValue = {
     activeConversationId,
     activeConversationProcessing,
@@ -473,6 +485,7 @@ export function AssistantSideMenu({
                     label="Pinned"
                     items={sidebar.pinned}
                     dragSection="pinned"
+                    collapsedIndicator={collapsedActivityDot(sidebar.pinned)}
                   />
                 ) : null}
 
@@ -482,6 +495,7 @@ export function AssistantSideMenu({
                   label="Chats"
                   items={sidebar.recents.items}
                   pagination={sidebar.recents}
+                  collapsedIndicator={collapsedActivityDot(sidebar.recents.all)}
                 />
               </CollapsibleNavSection.Root>
 
@@ -502,6 +516,7 @@ export function AssistantSideMenu({
                       contextMenuContent={buildGroupContextMenu(label, section.all)}
                       items={section.items}
                       pagination={section}
+                      collapsedIndicator={collapsedActivityDot(section.all)}
                     />
                   );
                 })}
@@ -545,6 +560,7 @@ export function AssistantSideMenu({
                           )}
                           items={group.conversations}
                           dragSection={`group:${group.id}`}
+                          collapsedIndicator={collapsedActivityDot(group.conversations)}
                         />
                       ))}
                     </CollapsibleNavSection.Root>

--- a/clients/web/src/domains/chat/components/collapsed-group-icon.tsx
+++ b/clients/web/src/domains/chat/components/collapsed-group-icon.tsx
@@ -4,6 +4,7 @@ import type { LucideIcon } from "lucide-react";
 
 import type { Conversation } from "@/types/conversation-types";
 import { Popover, Tooltip } from "@vellumai/design-library";
+import { cn } from "@vellumai/design-library/utils/cn";
 
 // ---------------------------------------------------------------------------
 // Indicator state
@@ -54,6 +55,33 @@ const INDICATOR_CLASS: Record<Exclude<GroupIndicatorState, null>, string> = {
   processing: "bg-[var(--primary-base)] animate-pulse",
   unread: "bg-[var(--system-mid-strong)]",
 };
+
+/**
+ * The colored activity dot for a group of conversations. Renders nothing when
+ * there's no activity. Callers position it — the collapsed rail overlays it on
+ * the icon corner; the expanded section header renders it inline.
+ */
+export function GroupIndicatorDot({
+  state,
+  className,
+}: {
+  state: GroupIndicatorState;
+  className?: string;
+}) {
+  if (state == null) {
+    return null;
+  }
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "h-2.5 w-2.5 rounded-full",
+        INDICATOR_CLASS[state],
+        className,
+      )}
+    />
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -126,12 +154,10 @@ export function CollapsedGroupIcon({
             className="relative flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-[6px] text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] aria-[expanded=true]:bg-[var(--surface-active)] aria-[expanded=true]:text-[var(--content-default)]"
           >
             <Icon size={14} />
-            {indicatorState != null ? (
-              <span
-                aria-hidden
-                className={`absolute right-0 top-0 h-2.5 w-2.5 rounded-full border-2 border-[var(--surface-overlay)] ${INDICATOR_CLASS[indicatorState]}`}
-              />
-            ) : null}
+            <GroupIndicatorDot
+              state={indicatorState}
+              className="absolute right-0 top-0 border-2 border-[var(--surface-overlay)]"
+            />
           </button>
         </Popover.Trigger>
       </Tooltip>

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -84,6 +84,8 @@ export interface ConversationNavSectionProps extends ConversationRowListProps {
   icon?: LucideIcon;
   trailing?: ReactNode;
   contextMenuContent?: ReactNode;
+  /** Activity dot shown in the header only while the section is collapsed. */
+  collapsedIndicator?: ReactNode;
 }
 
 export function ConversationNavSection({
@@ -92,6 +94,7 @@ export function ConversationNavSection({
   icon,
   trailing,
   contextMenuContent,
+  collapsedIndicator,
   ...listProps
 }: ConversationNavSectionProps) {
   return (
@@ -101,6 +104,7 @@ export function ConversationNavSection({
       label={label}
       trailing={trailing}
       contextMenuContent={contextMenuContent}
+      collapsedIndicator={collapsedIndicator}
     >
       <ConversationRowList {...listProps} />
     </CollapsibleNavSection.Section>


### PR DESCRIPTION
## Prompt / plan

Final part of splitting the "restore custom conversation groups + make the sidebar consistently collapsible" work into small, focused PRs. Plan: `/root/.claude/plans/generic-giggling-rainbow.md` (Part C — the collapsed-section activity indicator). The two PRs this built on are both **merged** — #38997 (Move to group / New group) and #39000 (collapsible Pinned/Chats) — so this is now on `main`.

**What & why:** Now that Pinned/Chats (and channels/custom groups) can be collapsed (#39000), a collapsed section can hide an active conversation. Only *attention* conversations force their section open — a merely *processing* or *unread* conversation does not — so while such a section is collapsed its per-row indicator disappears entirely. This surfaces that activity on the collapsed section header, reusing the same dot and the same `getGroupIndicatorState` precedence (**attention › processing › unread**) the collapsed rail already uses. Since attention force-opens, the collapsed-header dot in practice shows for *processing* or *unread* conversations (unread in the same color the rail uses — intentional and consistent).

- **Extract `GroupIndicatorDot`** from the collapsed-rail icon so the rail and the section header render one dot component instead of two copies of the markup.
- **`CollapsibleNavSection`** gains an optional `collapsedIndicator`, rendered inline in the header and hidden via `group-data-[state=open]:hidden` — open sections already show each row's own indicator, so a header dot would be redundant there.
- Reuses the existing **`getGroupIndicatorState`**, so the dot follows the same processing/unread precedence as the rail. Wired into all four section kinds (Pinned, Chats, channels, custom groups).

**Known limitation (pre-existing, not introduced here):** in an *open but paginated* section, a processing/unread conversation in rows hidden behind "Show more" has no indicator — the header dot is hidden while the section is open, and the row itself isn't rendered until expanded. The sidebar had this same gap before this change; it's best addressed alongside the separate "Show more / less" pagination follow-up rather than by expanding this PR.

Deliberately minimal: no new tests for the thin presentational `GroupIndicatorDot` split (covered indirectly by the existing `collapsed-group-icon` and `assistant-side-menu` suites) — matching the "only if easy / reuse existing" scope for this indicator.

## Test plan

- `bunx tsc --noEmit` — clean (also run by the pre-commit hook).
- `bun run lint` — clean.
- `bun test` — existing suites still pass: 39 across `collapsed-group-icon.test.tsx` + `assistant-side-menu.test.tsx`, and 8 in `collapsible-nav-section.test.tsx`. The rail's dot rendering is unchanged (same component, now shared).
- Manual: collapse a section holding a processing (or unread) conversation → dot appears on the header; expand → dot hides and the row's own indicator shows. An *attention* conversation force-opens its section, so it surfaces through the (open) rows rather than the header dot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw7an5eWS7sgUBvdoqw5QK