### PR TITLE
fix(gateway): validate the Slack Socket Mode frame with parseSlackEnvelope

### DIFF
--- a/gateway/src/slack/envelope.test.ts
+++ b/gateway/src/slack/envelope.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "bun:test";
+
+import { parseSlackEnvelope } from "./envelope.js";
+
+describe("parseSlackEnvelope", () => {
+  it("parses a well-formed events_api envelope", () => {
+    const env = parseSlackEnvelope(
+      JSON.stringify({
+        envelope_id: "env-1",
+        type: "events_api",
+        payload: {
+          event_id: "Ev1",
+          event_time: 1700000000,
+          team_id: "T1",
+          event: { type: "app_mention", user: "U1", text: "hi", ts: "1.2" },
+        },
+      }),
+    );
+
+    expect(env).not.toBeNull();
+    expect(env!.envelope_id).toBe("env-1");
+    expect(env!.type).toBe("events_api");
+    expect(env!.payload?.event_id).toBe("Ev1");
+    expect(env!.payload?.team_id).toBe("T1");
+    expect(env!.payload?.event?.type).toBe("app_mention");
+  });
+
+  it("parses an interactive envelope, preserving the passthrough payload", () => {
+    const env = parseSlackEnvelope(
+      JSON.stringify({
+        envelope_id: "env-2",
+        type: "interactive",
+        payload: {
+          type: "block_actions",
+          trigger_id: "t1",
+          user: { id: "U1" },
+          actions: [{ action_id: "approve", type: "button" }],
+        },
+      }),
+    );
+
+    expect(env).not.toBeNull();
+    expect(env!.type).toBe("interactive");
+    // Interactive extras are preserved for normalizeSlackBlockActions.
+    expect(env!.payload?.type).toBe("block_actions");
+    expect(env!.payload?.trigger_id).toBe("t1");
+    expect((env!.payload as Record<string, unknown>).actions).toBeDefined();
+  });
+
+  it("parses a disconnect envelope", () => {
+    const env = parseSlackEnvelope(
+      JSON.stringify({ type: "disconnect", reason: "warning" }),
+    );
+
+    expect(env).not.toBeNull();
+    expect(env!.type).toBe("disconnect");
+    expect(env!.reason).toBe("warning");
+  });
+
+  it("returns null for non-JSON input", () => {
+    expect(parseSlackEnvelope("not json {")).toBeNull();
+    expect(parseSlackEnvelope("")).toBeNull();
+  });
+
+  it("returns null for a non-object JSON frame", () => {
+    expect(parseSlackEnvelope("42")).toBeNull();
+    expect(parseSlackEnvelope('"a string"')).toBeNull();
+    expect(parseSlackEnvelope("null")).toBeNull();
+    expect(parseSlackEnvelope("[1,2,3]")).toBeNull();
+  });
+
+  it("collapses malformed frame fields rather than rejecting the whole envelope", () => {
+    // envelope_id / type are non-strings, payload.event is a scalar. Tolerant:
+    // each bad field collapses to undefined, the envelope still parses, and the
+    // downstream handler drops it on the missing fields.
+    const env = parseSlackEnvelope(
+      JSON.stringify({
+        envelope_id: 123,
+        type: { nested: true },
+        payload: { event_id: "Ev1", event: "not-an-object" },
+      }),
+    );
+
+    expect(env).not.toBeNull();
+    expect(env!.envelope_id).toBeUndefined();
+    expect(env!.type).toBeUndefined();
+    expect(env!.payload?.event_id).toBe("Ev1");
+    expect(env!.payload?.event).toBeUndefined();
+  });
+
+  it("collapses a non-object payload to undefined", () => {
+    const env = parseSlackEnvelope(
+      JSON.stringify({ type: "events_api", payload: "bogus" }),
+    );
+
+    expect(env).not.toBeNull();
+    expect(env!.type).toBe("events_api");
+    expect(env!.payload).toBeUndefined();
+  });
+});

--- a/gateway/src/slack/envelope.ts
+++ b/gateway/src/slack/envelope.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+import type {
+  SlackAppMentionEvent,
+  SlackBlockActionsPayload,
+  SlackChannelMessageEvent,
+  SlackDirectMessageEvent,
+  SlackMessageChangedEvent,
+  SlackMessageDeletedEvent,
+  SlackReactionAddedEvent,
+  SlackReactionRemovedEvent,
+} from "./normalize.js";
+
+const optionalString = () => z.string().optional().catch(undefined);
+
+/**
+ * The inner Slack event carried by an `events_api` envelope. This is a
+ * pass-through: the frame parser confirms it is an object, but each normalizer
+ * re-validates it with its own tolerant schema (per-leaf validation), so the
+ * frame parser never re-models the event's fields.
+ */
+export type SlackInboundEvent =
+  | SlackAppMentionEvent
+  | SlackDirectMessageEvent
+  | SlackChannelMessageEvent
+  | SlackMessageChangedEvent
+  | SlackMessageDeletedEvent
+  | SlackReactionAddedEvent
+  | SlackReactionRemovedEvent;
+
+/**
+ * The `payload` object on a Socket Mode envelope. Serves two envelope kinds:
+ * `events_api` (wraps `event` + delivery metadata) and `interactive` (the
+ * Block Kit interaction payload itself). Extra keys are preserved so the
+ * interactive path can hand the whole payload to `normalizeSlackBlockActions`,
+ * which safeParses it.
+ */
+export interface SlackEnvelopePayload {
+  event_id?: string;
+  event_time?: number;
+  team_id?: string;
+  event?: SlackInboundEvent;
+  type?: string;
+  trigger_id?: string;
+  user?: { id?: string; username?: string; name?: string };
+  channel?: { id?: string; name?: string };
+  message?: { ts?: string; thread_ts?: string; text?: string };
+  actions?: SlackBlockActionsPayload["actions"];
+  [key: string]: unknown;
+}
+
+/** A validated Slack Socket Mode envelope (frame). */
+export interface SlackEnvelope {
+  envelope_id?: string;
+  type?: string;
+  reason?: string;
+  payload?: SlackEnvelopePayload;
+}
+
+const slackEnvelopeSchema = z.object({
+  envelope_id: optionalString(),
+  type: optionalString(),
+  reason: optionalString(),
+  payload: z
+    .object({
+      event_id: optionalString(),
+      event_time: z.number().optional().catch(undefined),
+      team_id: optionalString(),
+      // The inner event / interaction payload stay opaque objects here — the
+      // normalizers own their validation. We only confirm it is an object.
+      event: z.record(z.string(), z.unknown()).optional().catch(undefined),
+    })
+    .passthrough()
+    .optional()
+    .catch(undefined),
+});
+
+/**
+ * Parse and tolerantly validate an untrusted Slack Socket Mode frame.
+ *
+ * This is the single seam where the raw WebSocket text frame is turned into a
+ * typed envelope: it owns the `JSON.parse`, drops non-JSON / non-object frames,
+ * and validates the envelope wrapper (envelope_id / type / payload metadata).
+ * The inner `event` and interaction payload remain pass-through objects that
+ * each normalizer re-validates, so this never re-models what the leaves own.
+ *
+ * Returns `null` for a frame that is not JSON or not an object.
+ */
+export function parseSlackEnvelope(raw: string): SlackEnvelope | null {
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const parsed = slackEnvelopeSchema.safeParse(json);
+  if (!parsed.success) return null;
+  // The schema validates the frame; `event` is confirmed to be an object and
+  // typed as the inbound union for the (already-guarded) dispatch, which each
+  // normalizer then re-validates.
+  return parsed.data as SlackEnvelope;
+}

--- a/gateway/src/slack/envelope.ts
+++ b/gateway/src/slack/envelope.ts
@@ -93,7 +93,9 @@ export function parseSlackEnvelope(raw: string): SlackEnvelope | null {
     return null;
   }
   const parsed = slackEnvelopeSchema.safeParse(json);
-  if (!parsed.success) return null;
+  if (!parsed.success) {
+    return null;
+  }
   // The schema validates the frame; `event` is confirmed to be an object and
   // typed as the inbound union for the (already-guarded) dispatch, which each
   // normalizer then re-validates.

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -19,6 +19,7 @@ import {
   type SlackHistoryMessage,
 } from "./slack-web.js";
 import { isSlackDmChannel } from "./channel.js";
+import { parseSlackEnvelope } from "./envelope.js";
 import { slackEventOrderingKey } from "./event-ordering.js";
 import { slackEventText } from "./event-text.js";
 import { stampSlackEventTeam } from "./event-team.js";
@@ -39,7 +40,6 @@ import {
   type SlackChannelMessageEvent,
   type SlackMessageChangedEvent,
   type SlackMessageDeletedEvent,
-  type SlackBlockActionsPayload,
   type SlackReactionAddedEvent,
   type SlackReactionRemovedEvent,
   type NormalizedSlackEvent,
@@ -655,7 +655,11 @@ export class SlackSocketModeClient {
       });
 
       ws.addEventListener("message", (messageEvent) => {
-        this.handleMessage(messageEvent.data as string, ws);
+        // Slack Socket Mode delivers text frames; ignore any non-string frame
+        // rather than casting untrusted WebSocket data to `string`.
+        const frame = messageEvent.data;
+        if (typeof frame !== "string") return;
+        this.handleMessage(frame, ws);
       });
 
       ws.addEventListener("close", (closeEvent) => {
@@ -717,36 +721,9 @@ export class SlackSocketModeClient {
   }
 
   private handleMessage(raw: string, originWs: WebSocket): void {
-    let envelope: {
-      envelope_id?: string;
-      type?: string;
-      payload?: {
-        event_id?: string;
-        event_time?: number;
-        team_id?: string;
-        event?:
-          | SlackAppMentionEvent
-          | SlackDirectMessageEvent
-          | SlackChannelMessageEvent
-          | SlackMessageChangedEvent
-          | SlackMessageDeletedEvent
-          | SlackReactionAddedEvent
-          | SlackReactionRemovedEvent;
-        // Interactive payloads are delivered directly as the payload
-        type?: string;
-        trigger_id?: string;
-        user?: { id: string; username?: string; name?: string };
-        channel?: { id: string; name?: string };
-        message?: { ts: string; thread_ts?: string; text?: string };
-        actions?: SlackBlockActionsPayload["actions"];
-      };
-      reason?: string;
-    };
-
-    try {
-      envelope = JSON.parse(raw);
-    } catch {
-      log.warn("Received non-JSON Socket Mode message");
+    const envelope = parseSlackEnvelope(raw);
+    if (!envelope) {
+      log.warn("Received non-JSON or malformed Socket Mode message");
       return;
     }
 

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -659,7 +659,9 @@ export class SlackSocketModeClient {
         // Slack Socket Mode delivers text frames; ignore any non-string frame
         // rather than casting untrusted WebSocket data to `string`.
         const frame = messageEvent.data;
-        if (typeof frame !== "string") return;
+        if (typeof frame !== "string") {
+          return;
+        }
         this.handleMessage(frame, ws);
       });
 
@@ -1556,8 +1558,8 @@ export class SlackSocketModeClient {
     if (payload.type !== "block_actions") return;
 
     // The envelope id lives on the envelope wrapper, not the interaction
-    // payload; thread it through as the update id so block_actions correlate
-    // with their frame instead of always falling back to "unknown".
+    // payload, so it is threaded in as the update id to correlate the
+    // block_actions event with its frame.
     const normalized = normalizeSlackBlockActions(
       payload,
       envelopeId ?? "unknown",

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -20,6 +20,7 @@ import {
 } from "./slack-web.js";
 import { isSlackDmChannel } from "./channel.js";
 import { parseSlackEnvelope } from "./envelope.js";
+import type { SlackEnvelopePayload } from "./envelope.js";
 import { slackEventOrderingKey } from "./event-ordering.js";
 import { slackEventText } from "./event-text.js";
 import { stampSlackEventTeam } from "./event-team.js";
@@ -757,7 +758,7 @@ export class SlackSocketModeClient {
 
     // Handle interactive payloads (block_actions from Block Kit buttons)
     if (envelope.type === "interactive") {
-      this.handleInteractive(envelope.payload);
+      this.handleInteractive(envelope.payload, envelope.envelope_id);
       return;
     }
 
@@ -1545,17 +1546,21 @@ export class SlackSocketModeClient {
     return true;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private handleInteractive(payload: Record<string, any> | undefined): void {
+  private handleInteractive(
+    payload: SlackEnvelopePayload | undefined,
+    envelopeId: string | undefined,
+  ): void {
     if (!payload) return;
 
     // Only handle block_actions (from Block Kit buttons)
     if (payload.type !== "block_actions") return;
 
-    // First try to normalize as a channel-scoped block_actions event
+    // The envelope id lives on the envelope wrapper, not the interaction
+    // payload; thread it through as the update id so block_actions correlate
+    // with their frame instead of always falling back to "unknown".
     const normalized = normalizeSlackBlockActions(
       payload,
-      payload.envelope_id ?? "unknown",
+      envelopeId ?? "unknown",
       this.config.gatewayConfig,
     );
     if (normalized) {


### PR DESCRIPTION
## Prompt / plan

Frame half of the `parseSlackEnvelope` seam (LUM-2816 item 3), plus the WS-frame guard from item 6. Closes the **last untrusted `JSON.parse`** in the Slack ingress path. The 5 leaf normalizers + crash fixes are already merged, so this is the envelope wrapper.

### Why

The Socket Mode frame was the one remaining unvalidated parse:
- `handleMessage` cast `JSON.parse(raw)` straight onto an inline envelope type.
- The WebSocket `message` handler cast `messageEvent.data as string`.

### What changed

- New pure, tested **`slack/envelope.ts` → `parseSlackEnvelope(raw)`**: owns the `JSON.parse`, drops non-JSON / non-object frames, and tolerantly validates the envelope wrapper (`envelope_id` / `type` / `payload` metadata: `event_id` / `event_time` / `team_id`).
- The inner `event` and the interactive payload stay **pass-through objects** — each normalizer re-validates them with its own tolerant schema (per-leaf validation), so the frame parser never re-models what the leaves own. `payload` uses `.passthrough()` so the interactive path can hand the whole payload to `normalizeSlackBlockActions`.
- `handleMessage` now calls `parseSlackEnvelope` (inline type + manual guards deleted); the WS handler ignores any non-string `messageEvent.data` instead of casting (LUM-2816 item 6, WS-frame half).

### Scope note

The inner-event **dispatch** still narrows with `event as Slack*Event` casts (extractEventUser, normalizeAndEmit dispatch). Those exist because the inner event is a union of structurally-different shapes with non-literal discriminators; removing them is the **discriminated-union classifier** (LUM-2499-shaped), tracked and landing as its own PR next — it's type-safety, not crash-safety (all crashes are already closed by the merged leaves).

## Test plan

- `bun test src/slack/envelope.test.ts` — 7 pass (events_api / interactive / disconnect parsing; non-JSON and non-object frames → null; malformed fields collapse; passthrough preserved).
- `bun test src/__tests__/slack-socket-mode-*.test.ts` — 46 pass (the live `handleMessage` path through both socket-mode integration suites, unchanged behavior).
- **Negative control:** reverting `parseSlackEnvelope` to a raw `JSON.parse` cast turns the non-object + malformed-field tests red. Restored.
- `tsc`, `eslint`, `prettier` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f)_