### PR TITLE
feat(web): open the plans takeover from Manage for custom and legacy Pro subs

### DIFF
--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -626,6 +626,53 @@ describe("PlanCard action button", () => {
     });
     expect(onManage).not.toHaveBeenCalled();
   });
+
+  test("a cancelling custom Pro sub's Manage stays on the manage fallback", async () => {
+    const onManage = mock(() => {});
+    // A customized/unpinned sub pending cancellation keeps the manage modal,
+    // which surfaces the cancellation state and the "Keep your Plan" action; the
+    // takeover can't act on a cancelling sub.
+    const subscription = proMightySubscription();
+    subscription.package = {
+      key: "mighty",
+      name: "Mighty",
+      version: 1,
+      customized: true,
+    };
+    subscription.cancel_at = "2026-08-23T12:36:05Z";
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+    );
+
+    fireEvent.click(await findByTestId("plan-card-manage-button"));
+
+    await waitFor(() => {
+      expect(onManage).toHaveBeenCalledTimes(1);
+    });
+    expect(navigateArgs).toEqual([]);
+  });
+
+  test("a cancelling clean-pin Pro sub still opens the plans takeover", async () => {
+    const onManage = mock(() => {});
+    // A clean pin routes to the takeover even while cancelling; its package CTA
+    // reaches the manage surface from there.
+    const subscription = proMightySubscription();
+    subscription.cancel_at = "2026-08-23T12:36:05Z";
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+    );
+
+    fireEvent.click(await findByTestId("plan-card-manage-button"));
+
+    await waitFor(() => {
+      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+    });
+    expect(onManage).not.toHaveBeenCalled();
+  });
 });
 
 describe("PlanCard recommended upgrade — change-package", () => {

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -558,10 +558,10 @@ describe("PlanCard action button", () => {
     expect(navigateArgs).toEqual([]);
   });
 
-  test("a customized Pro sub's Manage stays on onManage", async () => {
+  test("a customized Pro sub's Manage opens the plans takeover", async () => {
     const onManage = mock(() => {});
-    // A customized package's tiers differ from the stock package, so the
-    // takeover would misrepresent it — keep it on the manage modal.
+    // A customized pin routes to the takeover alongside every other Pro sub; the
+    // takeover's own CTAs handle the customized state's transitions.
     const subscription = proMightySubscription();
     subscription.package = {
       key: "mighty",
@@ -578,15 +578,15 @@ describe("PlanCard action button", () => {
     fireEvent.click(await findByTestId("plan-card-manage-button"));
 
     await waitFor(() => {
-      expect(onManage).toHaveBeenCalledTimes(1);
+      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
     });
-    expect(navigateArgs).toEqual([]);
+    expect(onManage).not.toHaveBeenCalled();
   });
 
-  test("a Pro sub without a pinned package stays on onManage", async () => {
+  test("a Pro sub without a pinned package opens the plans takeover", async () => {
     const onManage = mock(() => {});
-    // A legacy/custom Pro sub (no package) would render as free in the takeover,
-    // so it stays on the manage modal even with a live catalog.
+    // A legacy/unpinned Custom Pro sub routes to the takeover with the rest; the
+    // takeover surfaces the Custom row as its current plan.
     const subscription = { ...proMightySubscription(), package: undefined };
     const { findByTestId } = renderCardInteractive(
       subscription,
@@ -597,9 +597,34 @@ describe("PlanCard action button", () => {
     fireEvent.click(await findByTestId("plan-card-manage-button"));
 
     await waitFor(() => {
-      expect(onManage).toHaveBeenCalledTimes(1);
+      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
     });
-    expect(navigateArgs).toEqual([]);
+    expect(onManage).not.toHaveBeenCalled();
+  });
+
+  test("a from-scratch custom Pro sub's Manage opens the plans takeover", async () => {
+    const onManage = mock(() => {});
+    // A Pro sub built from scratch — no stock lineage, pinned but customized —
+    // routes to the takeover like every other Pro sub with a live catalog.
+    const subscription = proMightySubscription();
+    subscription.package = {
+      key: "custom",
+      name: "Custom",
+      version: 1,
+      customized: true,
+    };
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+    );
+
+    fireEvent.click(await findByTestId("plan-card-manage-button"));
+
+    await waitFor(() => {
+      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+    });
+    expect(onManage).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -374,10 +374,18 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   const currentTier = currentKey ?? "free";
   // A live packages catalog opens the plans takeover for base and every Pro sub
   // — a clean pin, a customized pin, and an unpinned (legacy Custom) sub alike;
-  // the takeover's own CTAs handle each state's transitions. An empty catalog
-  // (the `pro-packages` flag off) has no takeover to open, so Manage falls back
-  // to the manage modal.
-  const canOpenPlansTakeover = packages.length > 0;
+  // the takeover's own CTAs handle each state's transitions. One exception: a
+  // custom/unpinned sub that is pending cancellation keeps the manage modal,
+  // which surfaces the cancellation state and the "Keep your Plan" action — the
+  // takeover can't act on a cancelling sub (every change is rejected), and a
+  // clean pin already reaches the manage surface through its package CTA. An
+  // empty catalog (the `pro-packages` flag off) has no takeover to open, so
+  // Manage falls back to the manage modal.
+  const canOpenPlansTakeover =
+    packages.length > 0 &&
+    (currentPlan.id === "base" ||
+      isCleanPin(subscription.package) ||
+      !isCancelling);
   // The banner's one-click switch is offered to any switch-eligible Pro sub —
   // a clean pin, a customized pin, or an unpinned (Custom) sub — inheriting the
   // shared eligibility gate. The confirm copy adapts to the sub's state via

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -372,14 +372,12 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   const packages = proPlan?.packages ?? [];
   const currentKey = subscription.package?.key ?? null;
   const currentTier = currentKey ?? "free";
-  // The plans takeover derives the current tier from the pinned package key
-  // alone, so a Pro sub without a package (legacy) or with a customized one
-  // (its tiers differ from the stock package) would be misrepresented there.
-  // Those stay on the manage modal; only base and clean packaged-Pro subs open
-  // the takeover.
-  const canOpenPlansTakeover =
-    packages.length > 0 &&
-    (currentPlan.id === "base" || isCleanPin(subscription.package));
+  // A live packages catalog opens the plans takeover for base and every Pro sub
+  // — a clean pin, a customized pin, and an unpinned (legacy Custom) sub alike;
+  // the takeover's own CTAs handle each state's transitions. An empty catalog
+  // (the `pro-packages` flag off) has no takeover to open, so Manage falls back
+  // to the manage modal.
+  const canOpenPlansTakeover = packages.length > 0;
   // The banner's one-click switch is offered to any switch-eligible Pro sub —
   // a clean pin, a customized pin, or an unpinned (Custom) sub — inheriting the
   // shared eligibility gate. The confirm copy adapts to the sub's state via


### PR DESCRIPTION
## Summary
- Widen the Plan card Manage gate to open the plans takeover for base and every Pro sub (clean pin, customized, and unpinned/legacy), not just clean pins.
- Update the plan-card gate tests to cover custom/legacy/customized routing.

Part of plan: custom-subs-manage-takeover.md (PR 1 of 2)