### PR TITLE
feat(web): show a custom sub's current plan on the takeover Custom row

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-row.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-row.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Rendering tests for CustomPlanRow's current-plan marker. `isCurrent` renders
+ * the "Your Current Plan" tag, and `currentSummary` replaces the generic
+ * descriptor with the sub's tier recap.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { CustomPlanRow } from "./custom-plan-row";
+
+const GENERIC = "Select custom CPU power, Ram and Storage";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CustomPlanRow", () => {
+  test("shows the generic descriptor and no current tag by default", () => {
+    const { queryByText } = render(<CustomPlanRow onConfigure={() => {}} />);
+    expect(queryByText(/Select custom CPU power/)).not.toBeNull();
+    expect(queryByText("Your Current Plan")).toBeNull();
+  });
+
+  test("renders the current-plan tag when isCurrent", () => {
+    const { queryByText } = render(
+      <CustomPlanRow onConfigure={() => {}} isCurrent />,
+    );
+    expect(queryByText("Your Current Plan")).not.toBeNull();
+  });
+
+  test("swaps the descriptor for the tier summary when provided", () => {
+    const summary = "Medium machine · 30 GB · $50 credits";
+    const { queryByText } = render(
+      <CustomPlanRow
+        onConfigure={() => {}}
+        isCurrent
+        currentSummary={summary}
+      />,
+    );
+    expect(queryByText(summary)).not.toBeNull();
+    // The generic copy is replaced, not shown alongside.
+    expect(queryByText(new RegExp(GENERIC))).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
@@ -1,6 +1,10 @@
 import { SlidersHorizontal } from "lucide-react";
 
 import { Button } from "@vellumai/design-library/components/button";
+import { Tag } from "@vellumai/design-library/components/tag";
+
+const GENERIC_DESCRIPTOR =
+  "Select custom CPU power, Ram and Storage. Or just throw in some tokens.";
 
 export interface CustomPlanRowProps {
   className?: string;
@@ -10,6 +14,17 @@ export interface CustomPlanRowProps {
    * so the click can't resolve before the parent knows how to route it.
    */
   configureDisabled?: boolean;
+  /**
+   * Marks this row as the user's current plan — set for a custom Pro sub, whose
+   * config isn't represented by any named column card.
+   */
+  isCurrent?: boolean;
+  /**
+   * A short recap of the current custom tiers (e.g. "Medium machine · 30 GB ·
+   * $50 credits"). Shown as the row descriptor in place of the generic copy so
+   * the user sees what their custom plan actually is.
+   */
+  currentSummary?: string;
 }
 
 /**
@@ -21,6 +36,8 @@ export function CustomPlanRow({
   className,
   onConfigure,
   configureDisabled,
+  isCurrent = false,
+  currentSummary,
 }: CustomPlanRowProps) {
   return (
     <div className={`flex w-full flex-col items-center gap-8 ${className ?? ""}`}>
@@ -36,12 +53,18 @@ export function CustomPlanRow({
             />
           </div>
           <div className="flex min-w-0 flex-col gap-1">
-            <span className="text-[16px] font-medium text-[var(--content-emphasised)]">
-              Custom Plan
-            </span>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-[16px] font-medium text-[var(--content-emphasised)]">
+                Custom Plan
+              </span>
+              {isCurrent ? (
+                <Tag className="bg-[var(--feed-digest-weak)] text-[var(--content-default)]">
+                  Your Current Plan
+                </Tag>
+              ) : null}
+            </div>
             <span className="text-[14px] font-medium text-[var(--content-tertiary)]">
-              Select custom CPU power, Ram and Storage. Or just throw in some
-              tokens.
+              {currentSummary ?? GENERIC_DESCRIPTOR}
             </span>
           </div>
         </div>

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -881,13 +881,60 @@ describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
     expect(changePackageCall!.body).toEqual({ package: "mighty" });
   });
 
-  test("a Custom sub's Free card is a downgrade and no named card renders as current", () => {
+  test("a Custom sub's Free card is a downgrade; the Custom row is current, no named card is", () => {
     const html = renderStatic(proCustomizedMightySubscription(), fullCatalog());
     // Pro → Free is always a downgrade.
     expect(html).toContain("Downgrade to Free");
     expect(html).not.toContain("Start Free");
-    // A Custom sub has no catalog rank, so no card is the current plan.
-    expect(count(html, /Current Plan/g)).toBe(0);
+    // A Custom sub has no catalog rank, so the Custom row carries the
+    // current-plan tag instead of any named column card.
+    expect(count(html, /Your Current Plan/g)).toBe(1);
+    // Every "Current Plan" match is that tag — no named column card is current.
+    expect(count(html, /Current Plan/g)).toBe(count(html, /Your Current Plan/g));
+  });
+});
+
+// A custom Pro sub (unpinned, customized, or legacy) is represented by the
+// Custom row, not any named card: the row is marked as their current plan and
+// summarizes the tiers they actually hold. Base and clean-pinned subs — whose
+// current plan IS a named card — see no marker on the Custom row.
+describe("PlansPage — Custom row current-plan marker", () => {
+  function proCustomizedWithCredits(): SubscriptionResponse {
+    return {
+      ...proMightySubscription(),
+      package: { key: "mighty", name: "Mighty", version: 1, customized: true },
+      selected_credit_tier: "credits_50",
+    };
+  }
+
+  test("a custom Pro sub sees the Custom row marked current with a tier summary", async () => {
+    // onboarding() supplies medium machine / 10 GB; the sub carries credits_50.
+    const { findByText } = renderInteractive(proCustomizedWithCredits(), {
+      plans: customCatalog(),
+    });
+
+    await findByText("Your Current Plan");
+    await findByText("Medium machine · 10 GB · $50 credits");
+  });
+
+  test("a clean-pinned Pro sub sees no marker on the Custom row", async () => {
+    const { findByRole, queryByText } = renderInteractive(
+      proMightySubscription(),
+      { plans: customCatalog() },
+    );
+
+    // The body is mounted once the Configure CTA is present.
+    await findByRole("button", { name: "Configure" });
+    expect(queryByText("Your Current Plan")).toBeNull();
+  });
+
+  test("a base user sees no marker on the Custom row", async () => {
+    const { findByRole, queryByText } = renderInteractive(freeSubscription(), {
+      plans: customCatalog(),
+    });
+
+    await findByRole("button", { name: "Configure" });
+    expect(queryByText("Your Current Plan")).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -12,6 +12,7 @@ import {
   tierRelation,
 } from "@/domains/settings/billing/package-types";
 import { machineLabel } from "@/domains/settings/billing/plan-spec";
+import type { CurrentTiers } from "@/domains/settings/billing/use-change-tiers";
 import {
   FREE_CREDITS_USD,
   FREE_STORAGE_GIB,
@@ -61,6 +62,7 @@ import {
 } from "@/hooks/use-platform-gate";
 import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
+import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
 import { openUrl } from "@/runtime/browser";
 import { isElectron } from "@/runtime/is-electron";
 import { routes } from "@/utils/routes";
@@ -105,6 +107,30 @@ function packageFeatures(pkg: ProPackage, extra: readonly string[]): string[] {
     `${formatDollars(credits * 100)} in credits included`,
     ...extra,
   ];
+}
+
+/**
+ * A one-line recap of a custom sub's current tiers for the Custom row, e.g.
+ * "Medium machine · 30 GB · $50 credits". The machine reads from the tier
+ * label map, storage from the resolved GiB, and credits from the live catalog;
+ * a dimension with no value is dropped.
+ */
+function customCurrentSummary(current: CurrentTiers, proPlan: ProPlan): string {
+  const machine = current.machineTier
+    ? (MACHINE_TIER_LABEL[current.machineTier] ?? current.machineTier)
+    : "Small";
+  const parts = [`${machine} machine`];
+  if (current.storageGib != null) {
+    parts.push(`${current.storageGib} GB`);
+  }
+  const credits = current.creditTier
+    ? proPlan.credit_tiers?.find((t) => t.tier === current.creditTier)
+        ?.credits_usd
+    : null;
+  if (credits != null) {
+    parts.push(`$${credits} credits`);
+  }
+  return parts.join(" · ");
 }
 
 /**
@@ -287,6 +313,16 @@ export function PlansPage() {
         : isCleanPin(subscription.package)
           ? subscription.package.key
           : null;
+
+    // A Pro sub with no clean pin (unpinned, customized, or legacy) — exactly
+    // the subs `currentTierKey` leaves null — is represented by the Custom row,
+    // not any named card. Mark that row as their current plan and summarize its
+    // tiers, once the current tiers have loaded.
+    const isCustomCurrent = isProUser && currentTierKey === null;
+    const currentSummary =
+      isCustomCurrent && currentReady
+        ? customCurrentSummary(current, proPlan)
+        : undefined;
 
     const selectTier = (tierKey: string) => {
       // A billing action is already in flight (checkout / package switch /
@@ -522,6 +558,8 @@ export function PlansPage() {
           className="mt-10"
           onConfigure={handleConfigure}
           configureDisabled={(isProUser && !currentReady) || billingActionPending}
+          isCurrent={isCustomCurrent}
+          currentSummary={currentSummary}
         />
 
         <CustomPlanModal


### PR DESCRIPTION
## Summary
- Add isCurrent + currentSummary to CustomPlanRow so a custom/legacy/customized Pro sub sees the Custom row marked as their current plan with a tier summary on the plans takeover.
- Leave the four named plan cards un-marked for custom subs (they stay switch targets).

Part of plan: custom-subs-manage-takeover.md (PR 2 of 2)