### PR TITLE
refactor(slack): classify inbound events via a discriminated union

### DIFF
--- a/gateway/src/slack/classify-event.test.ts
+++ b/gateway/src/slack/classify-event.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import { classifySlackEvent } from "./classify-event.js";
+import type { SlackInboundEvent } from "./envelope.js";
+
+// The classifier receives tolerantly-parsed events (fields already collapsed to
+// their declared types); it discriminates purely on `type` / `subtype`.
+const as = (o: Record<string, unknown>): SlackInboundEvent =>
+  o as unknown as SlackInboundEvent;
+
+describe("classifySlackEvent", () => {
+  test("classifies an app_mention", () => {
+    const c = classifySlackEvent(as({ type: "app_mention", user: "U1" }));
+    expect(c?.kind).toBe("app_mention");
+  });
+
+  test("classifies a plain message (no subtype) as message", () => {
+    const c = classifySlackEvent(as({ type: "message", user: "U1" }));
+    expect(c?.kind).toBe("message");
+  });
+
+  test("classifies a message_changed by subtype", () => {
+    const c = classifySlackEvent(
+      as({ type: "message", subtype: "message_changed", message: { ts: "1" } }),
+    );
+    expect(c?.kind).toBe("message_changed");
+  });
+
+  test("classifies a message_deleted by subtype", () => {
+    const c = classifySlackEvent(
+      as({ type: "message", subtype: "message_deleted", deleted_ts: "1" }),
+    );
+    expect(c?.kind).toBe("message_deleted");
+  });
+
+  test("classifies reaction_added and reaction_removed", () => {
+    expect(
+      classifySlackEvent(as({ type: "reaction_added", reaction: "eyes" }))
+        ?.kind,
+    ).toBe("reaction_added");
+    expect(
+      classifySlackEvent(as({ type: "reaction_removed", reaction: "eyes" }))
+        ?.kind,
+    ).toBe("reaction_removed");
+  });
+
+  test("subtype takes precedence over the plain-message fallback", () => {
+    // A `message` with an edit/delete subtype must not classify as a plain
+    // message — the admit logic and normalizer differ per subtype.
+    expect(
+      classifySlackEvent(as({ type: "message", subtype: "message_changed" }))
+        ?.kind,
+    ).not.toBe("message");
+  });
+
+  test("an unmodeled message subtype still classifies as a plain message", () => {
+    // Only message_changed / message_deleted branch; any other subtype (e.g. a
+    // bot_message) falls through to the plain-message kind, matching the
+    // dispatch that treats it as a message and lets the normalizer decide.
+    const c = classifySlackEvent(
+      as({ type: "message", subtype: "bot_message", user: "U1" }),
+    );
+    expect(c?.kind).toBe("message");
+  });
+
+  test("returns null for an event type the dispatch does not handle", () => {
+    expect(classifySlackEvent(as({ type: "channel_join" }))).toBeNull();
+    expect(classifySlackEvent(as({ type: undefined }))).toBeNull();
+    expect(classifySlackEvent(as({}))).toBeNull();
+  });
+
+  test("exposes the event on the classified result for typed access", () => {
+    const c = classifySlackEvent(
+      as({
+        type: "message",
+        subtype: "message_changed",
+        message: { user: "U9" },
+      }),
+    );
+    expect(c?.kind).toBe("message_changed");
+    if (c?.kind === "message_changed") {
+      expect(c.event.message?.user).toBe("U9");
+    }
+  });
+});

--- a/gateway/src/slack/classify-event.ts
+++ b/gateway/src/slack/classify-event.ts
@@ -1,0 +1,73 @@
+import type { SlackInboundEvent } from "./envelope.js";
+import type {
+  SlackChannelMessageEvent,
+  SlackMessageChangedEvent,
+  SlackMessageDeletedEvent,
+  SlackReactionAddedEvent,
+  SlackReactionRemovedEvent,
+} from "./normalize.js";
+
+/**
+ * A Slack inbound event narrowed to exactly one dispatch kind, with the event
+ * typed as the matching leaf shape.
+ *
+ * The leaf schemas carry non-literal `type` / `subtype` discriminators (both
+ * `string | undefined`), so TypeScript cannot narrow `SlackInboundEvent` on its
+ * own — every reader would otherwise cast. `classifySlackEvent` performs that
+ * narrowing once, at a single validated point, and every consumer switches on
+ * `kind` to get a typed `event` without a cast.
+ *
+ * The `app_mention` and plain `message` kinds share the one message shape; the
+ * plain-message kind is the direct-message / channel-message / active-thread
+ * family whose DM-vs-channel split the dispatch resolves from the channel.
+ */
+export type ClassifiedSlackEvent =
+  | { kind: "app_mention"; event: SlackChannelMessageEvent }
+  | { kind: "message"; event: SlackChannelMessageEvent }
+  | { kind: "message_changed"; event: SlackMessageChangedEvent }
+  | { kind: "message_deleted"; event: SlackMessageDeletedEvent }
+  | { kind: "reaction_added"; event: SlackReactionAddedEvent }
+  | { kind: "reaction_removed"; event: SlackReactionRemovedEvent };
+
+/**
+ * Classify a Slack inbound event by its `type` / `subtype` discriminators.
+ *
+ * Returns `null` for an event whose `type` is not one the dispatch handles
+ * (e.g. an unmodeled system subtype); the caller drops it. This is the single
+ * seam that turns the tolerantly-parsed event union into a discriminated kind,
+ * so the `type` / `subtype` narrowing casts live here and nowhere else.
+ */
+export function classifySlackEvent(
+  event: SlackInboundEvent,
+): ClassifiedSlackEvent | null {
+  const type = event.type;
+  if (type === "app_mention") {
+    return { kind: "app_mention", event: event as SlackChannelMessageEvent };
+  }
+  if (type === "reaction_added") {
+    return { kind: "reaction_added", event: event as SlackReactionAddedEvent };
+  }
+  if (type === "reaction_removed") {
+    return {
+      kind: "reaction_removed",
+      event: event as SlackReactionRemovedEvent,
+    };
+  }
+  if (type === "message") {
+    const subtype = (event as SlackMessageChangedEvent).subtype;
+    if (subtype === "message_changed") {
+      return {
+        kind: "message_changed",
+        event: event as SlackMessageChangedEvent,
+      };
+    }
+    if (subtype === "message_deleted") {
+      return {
+        kind: "message_deleted",
+        event: event as SlackMessageDeletedEvent,
+      };
+    }
+    return { kind: "message", event: event as SlackChannelMessageEvent };
+  }
+  return null;
+}

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -543,7 +543,9 @@ export class SlackSocketModeClient {
    */
   private extractEventUser(event: SlackInboundEvent): string | undefined {
     const classified = classifySlackEvent(event);
-    if (!classified) return undefined;
+    if (!classified) {
+      return undefined;
+    }
     switch (classified.kind) {
       // message_changed: the author is on the inner `message` object.
       case "message_changed":
@@ -564,16 +566,24 @@ export class SlackSocketModeClient {
    * filter.
    */
   private maybeTrackBotOwnThreadReply(event: SlackInboundEvent): void {
-    if (this.config.threadMode !== "mention_then_thread") return;
+    if (this.config.threadMode !== "mention_then_thread") {
+      return;
+    }
 
     // Only a plain thread reply arms tracking — app_mentions, edits, deletes,
     // and reactions do not.
     const classified = classifySlackEvent(event);
-    if (!classified || classified.kind !== "message") return;
+    if (!classified || classified.kind !== "message") {
+      return;
+    }
     const { channel, thread_ts: threadTs } = classified.event;
-    if (!threadTs || !channel) return;
+    if (!threadTs || !channel) {
+      return;
+    }
 
-    if (!this.shouldTrackBotOwnThreadReply(channel)) return;
+    if (!this.shouldTrackBotOwnThreadReply(channel)) {
+      return;
+    }
 
     if (this.store.isThreadDetached(threadTs)) {
       log.info(

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -20,7 +20,8 @@ import {
 } from "./slack-web.js";
 import { isSlackDmChannel } from "./channel.js";
 import { parseSlackEnvelope } from "./envelope.js";
-import type { SlackEnvelopePayload } from "./envelope.js";
+import type { SlackEnvelopePayload, SlackInboundEvent } from "./envelope.js";
+import { classifySlackEvent } from "./classify-event.js";
 import { slackEventOrderingKey } from "./event-ordering.js";
 import { slackEventText } from "./event-text.js";
 import { stampSlackEventTeam } from "./event-team.js";
@@ -37,12 +38,10 @@ import {
   resolveSlackChannel,
   resolveSlackUser,
   type SlackAppMentionEvent,
-  type SlackDirectMessageEvent,
   type SlackChannelMessageEvent,
   type SlackMessageChangedEvent,
   type SlackMessageDeletedEvent,
   type SlackReactionAddedEvent,
-  type SlackReactionRemovedEvent,
   type NormalizedSlackEvent,
   type SlackTextRenderContext,
 } from "./normalize.js";
@@ -487,35 +486,75 @@ export class SlackSocketModeClient {
   }
 
   /**
+   * Admit a `message_changed` edit in DMs, tracked bot threads, or any channel
+   * the bot is explicitly subscribed to via a conversation_id routing entry.
+   * The subscription check keeps Slack unfurl (link preview) events in random
+   * channels from triggering the bot, while still surfacing edits made to any
+   * message in a configured channel so the daemon can correlate them with prior
+   * context.
+   */
+  private admitMessageEdit(event: SlackMessageChangedEvent): boolean {
+    return (
+      isSlackDmChannel(event.channel, event.channel_type) ||
+      (!!event.message?.thread_ts &&
+        this.store.hasThread(event.message.thread_ts)) ||
+      (!!event.message?.ts && this.store.hasThread(event.message.ts)) ||
+      (!!event.channel && this.isChannelSubscribed(event.channel))
+    );
+  }
+
+  /**
+   * Admit a `message_deleted` in DMs, tracked bot threads, or any channel the
+   * bot is subscribed to, so the daemon can mark the stored row deleted. Mirrors
+   * `admitMessageEdit`'s scoping, keyed on the deleted message's `ts`.
+   */
+  private admitMessageDelete(event: SlackMessageDeletedEvent): boolean {
+    return (
+      !!event.deleted_ts &&
+      (isSlackDmChannel(event.channel, event.channel_type) ||
+        (!!event.previous_message?.thread_ts &&
+          this.store.hasThread(event.previous_message.thread_ts)) ||
+        this.store.hasThread(event.deleted_ts) ||
+        (!!event.channel && this.isChannelSubscribed(event.channel)))
+    );
+  }
+
+  /**
+   * Admit a reaction on a message in a tracked bot thread, a DM, or any channel
+   * the bot is subscribed to (a conversation_id routing entry, or any DM channel
+   * since DMs always route to the default assistant). Both reaction_added and
+   * reaction_removed share this filter; the daemon dispatches by callbackData
+   * prefix.
+   */
+  private admitReaction(event: SlackReactionAddedEvent): boolean {
+    const targetChannel = event.item?.channel;
+    return (
+      !!event.item?.ts &&
+      !!targetChannel &&
+      (isSlackDmChannel(targetChannel) ||
+        this.isChannelSubscribed(targetChannel) ||
+        this.store.hasThread(event.item.ts))
+    );
+  }
+
+  /**
    * Extract the Slack user ID from any event type. Returns undefined for
    * events that don't carry a user field (e.g. some system subtypes).
    */
-  private extractEventUser(
-    event:
-      | SlackAppMentionEvent
-      | SlackDirectMessageEvent
-      | SlackChannelMessageEvent
-      | SlackMessageChangedEvent
-      | SlackMessageDeletedEvent
-      | SlackReactionAddedEvent
-      | SlackReactionRemovedEvent,
-  ): string | undefined {
-    // message_changed: the author is on the inner `message` object.
-    if (
-      event.type === "message" &&
-      (event as SlackMessageChangedEvent).subtype === "message_changed"
-    ) {
-      return (event as SlackMessageChangedEvent).message?.user;
+  private extractEventUser(event: SlackInboundEvent): string | undefined {
+    const classified = classifySlackEvent(event);
+    if (!classified) return undefined;
+    switch (classified.kind) {
+      // message_changed: the author is on the inner `message` object.
+      case "message_changed":
+        return classified.event.message?.user;
+      // message_deleted: the author is on previous_message.
+      case "message_deleted":
+        return classified.event.previous_message?.user;
+      // app_mention / plain message / reactions carry `user` at the top level.
+      default:
+        return classified.event.user;
     }
-    // message_deleted: the author is on previous_message.
-    if (
-      event.type === "message" &&
-      (event as SlackMessageDeletedEvent).subtype === "message_deleted"
-    ) {
-      return (event as SlackMessageDeletedEvent).previous_message?.user;
-    }
-    // All other event types carry `user` at the top level.
-    return (event as { user?: string }).user;
   }
 
   /**
@@ -524,46 +563,29 @@ export class SlackSocketModeClient {
    * tracking is armed so follow-up human replies pass the active-thread
    * filter.
    */
-  private maybeTrackBotOwnThreadReply(
-    event:
-      | SlackAppMentionEvent
-      | SlackDirectMessageEvent
-      | SlackChannelMessageEvent
-      | SlackMessageChangedEvent
-      | SlackMessageDeletedEvent
-      | SlackReactionAddedEvent
-      | SlackReactionRemovedEvent,
-  ): void {
+  private maybeTrackBotOwnThreadReply(event: SlackInboundEvent): void {
     if (this.config.threadMode !== "mention_then_thread") return;
 
-    const channelEvent = event as SlackChannelMessageEvent;
-    const subtype = (event as SlackMessageChangedEvent).subtype;
-    if (
-      event.type !== "message" ||
-      subtype === "message_changed" ||
-      subtype === "message_deleted" ||
-      !channelEvent.thread_ts ||
-      !channelEvent.channel
-    ) {
-      return;
-    }
-    if (!this.shouldTrackBotOwnThreadReply(channelEvent.channel)) return;
+    // Only a plain thread reply arms tracking — app_mentions, edits, deletes,
+    // and reactions do not.
+    const classified = classifySlackEvent(event);
+    if (!classified || classified.kind !== "message") return;
+    const { channel, thread_ts: threadTs } = classified.event;
+    if (!threadTs || !channel) return;
 
-    if (this.store.isThreadDetached(channelEvent.thread_ts)) {
+    if (!this.shouldTrackBotOwnThreadReply(channel)) return;
+
+    if (this.store.isThreadDetached(threadTs)) {
       log.info(
-        { channel: channelEvent.channel, threadTs: channelEvent.thread_ts },
+        { channel, threadTs },
         "Skipped tracking bot's own reply in explicitly muted thread",
       );
       return;
     }
 
-    this.store.trackThread(
-      channelEvent.thread_ts,
-      channelEvent.channel,
-      ACTIVE_THREAD_TTL_MS,
-    );
+    this.store.trackThread(threadTs, channel, ACTIVE_THREAD_TTL_MS);
     log.info(
-      { channel: channelEvent.channel, threadTs: channelEvent.thread_ts },
+      { channel, threadTs },
       "Tracked thread after bot's own thread reply",
     );
   }
@@ -801,14 +823,7 @@ export class SlackSocketModeClient {
   private processEventPayload(eventPayload: {
     event_id: string;
     event_time?: number;
-    event:
-      | SlackAppMentionEvent
-      | SlackDirectMessageEvent
-      | SlackChannelMessageEvent
-      | SlackMessageChangedEvent
-      | SlackMessageDeletedEvent
-      | SlackReactionAddedEvent
-      | SlackReactionRemovedEvent;
+    event: SlackInboundEvent;
   }): void {
     const event = eventPayload.event;
     const botUserId = this.config.botUserId;
@@ -841,103 +856,55 @@ export class SlackSocketModeClient {
       return;
     }
 
-    const dmEvent = event as SlackDirectMessageEvent;
-    const channelEvent = event as SlackChannelMessageEvent;
-    const messageChangedEvent = event as SlackMessageChangedEvent;
-    const messageDeletedEvent = event as SlackMessageDeletedEvent;
+    // Classify the event once, then admit per kind. Each event has exactly one
+    // kind, so at most one filter matches — the admit conditions per kind carry
+    // the DM / tracked-thread / subscribed-channel scoping.
+    const classified = classifySlackEvent(event);
 
-    const isAppMention = event.type === "app_mention";
-    const isMessageChangedRaw =
-      event.type === "message" &&
-      messageChangedEvent.subtype === "message_changed";
-    // Accept message_changed in DMs, tracked bot threads, or any channel
-    // the bot is explicitly subscribed to via a conversation_id routing
-    // entry. The routing-entry check keeps Slack unfurl (link preview)
-    // events in random channels from triggering the bot, while still
-    // surfacing edits made to any message in a configured channel so the
-    // daemon can correlate them with prior context.
-    const isSubscribedChannel =
-      !!messageChangedEvent.channel &&
-      this.config.gatewayConfig.routingEntries.some(
-        (entry) =>
-          entry.type === "conversation_id" &&
-          entry.key === messageChangedEvent.channel,
-      );
-    const isMessageChanged =
-      isMessageChangedRaw &&
-      (isSlackDmChannel(
-        messageChangedEvent.channel,
-        messageChangedEvent.channel_type,
-      ) ||
-        (!!messageChangedEvent.message?.thread_ts &&
-          this.store.hasThread(messageChangedEvent.message.thread_ts)) ||
-        (!!messageChangedEvent.message?.ts &&
-          this.store.hasThread(messageChangedEvent.message.ts)) ||
-        isSubscribedChannel);
-    // Admit message_deleted in DMs, tracked bot threads, or any channel the
-    // bot is explicitly subscribed to via a conversation_id routing entry so
-    // the daemon can mark the corresponding stored row deleted. The
-    // routing-entry check mirrors message_changed's scoping above.
-    const isMessageDeleted =
-      event.type === "message" &&
-      messageDeletedEvent.subtype === "message_deleted" &&
-      !!messageDeletedEvent.deleted_ts &&
-      (isSlackDmChannel(
-        messageDeletedEvent.channel,
-        messageDeletedEvent.channel_type,
-      ) ||
-        (!!messageDeletedEvent.previous_message?.thread_ts &&
-          this.store.hasThread(
-            messageDeletedEvent.previous_message.thread_ts,
-          )) ||
-        (!!messageDeletedEvent.deleted_ts &&
-          this.store.hasThread(messageDeletedEvent.deleted_ts)) ||
-        (!!messageDeletedEvent.channel &&
-          this.config.gatewayConfig.routingEntries.some(
-            (entry) =>
-              entry.type === "conversation_id" &&
-              entry.key === messageDeletedEvent.channel,
-          )));
-    const isDm =
-      event.type === "message" &&
-      !isMessageChanged &&
-      !isMessageDeleted &&
-      isSlackDmChannel(dmEvent.channel, dmEvent.channel_type);
-    const mentionsBot = channelEvent.text?.includes(`<@${botUserId}>`);
-    const isActiveThreadReply =
-      event.type === "message" &&
-      !isMessageChanged &&
-      !isMessageDeleted &&
-      !isDm &&
-      !mentionsBot &&
-      !!channelEvent.thread_ts &&
-      this.store.hasThread(channelEvent.thread_ts);
+    let isAppMention = false;
+    let isDm = false;
+    let isMessageChanged = false;
+    let isMessageDeleted = false;
+    let isReactionAdded = false;
+    let isReactionRemoved = false;
+    let isActiveThreadReply = false;
 
-    // Forward reaction events on:
-    //   1. messages in tracked bot threads (preserves original behavior), or
-    //   2. messages in any channel the bot is subscribed to (a configured
-    //      conversation_id routing entry, or any DM channel since DMs always
-    //      route to the default assistant).
-    // Both reaction_added and reaction_removed are admitted under the same
-    // filter; the daemon dispatches by callbackData prefix.
-    const reactionEvent = event as
-      | SlackReactionAddedEvent
-      | SlackReactionRemovedEvent;
-    const reactionTargetChannel = reactionEvent.item?.channel;
-    const reactionAdmitChannel =
-      !!reactionTargetChannel &&
-      (isSlackDmChannel(reactionTargetChannel) ||
-        this.isChannelSubscribed(reactionTargetChannel) ||
-        (!!reactionEvent.item?.ts &&
-          this.store.hasThread(reactionEvent.item.ts)));
-    const isReactionAdded =
-      event.type === "reaction_added" &&
-      !!reactionEvent.item?.ts &&
-      reactionAdmitChannel;
-    const isReactionRemoved =
-      event.type === "reaction_removed" &&
-      !!reactionEvent.item?.ts &&
-      reactionAdmitChannel;
+    switch (classified?.kind) {
+      case "app_mention":
+        isAppMention = true;
+        break;
+      case "message_changed":
+        isMessageChanged = this.admitMessageEdit(classified.event);
+        break;
+      case "message_deleted":
+        isMessageDeleted = this.admitMessageDelete(classified.event);
+        break;
+      case "reaction_added":
+        isReactionAdded = this.admitReaction(classified.event);
+        break;
+      case "reaction_removed":
+        isReactionRemoved = this.admitReaction(classified.event);
+        break;
+      case "message": {
+        // A plain message is a DM, or — only in mention-then-thread mode — an
+        // unmentioned reply in an already-tracked bot thread. A mention of the
+        // bot is handled by the app_mention event, not here.
+        const msg = classified.event;
+        if (isSlackDmChannel(msg.channel, msg.channel_type)) {
+          isDm = true;
+        } else if (
+          this.config.threadMode === "mention_then_thread" &&
+          !msg.text?.includes(`<@${botUserId}>`) &&
+          !!msg.thread_ts &&
+          this.store.hasThread(msg.thread_ts)
+        ) {
+          isActiveThreadReply = true;
+        }
+        break;
+      }
+      default:
+        break;
+    }
 
     // Process app_mention events, DMs, message edits, message deletes, scoped reactions, and replies in active bot threads
     const matchedFilter = isAppMention
@@ -952,8 +919,7 @@ export class SlackSocketModeClient {
               ? "reaction_added"
               : isReactionRemoved
                 ? "reaction_removed"
-                : isActiveThreadReply &&
-                    this.config.threadMode === "mention_then_thread"
+                : isActiveThreadReply
                   ? "active_thread_reply"
                   : null;
 
@@ -968,7 +934,7 @@ export class SlackSocketModeClient {
           user: (event as { user?: string }).user,
           hasThreadTs: !!(event as { thread_ts?: string }).thread_ts,
           threadTs: (event as { thread_ts?: string }).thread_ts,
-          isMessageChangedRaw,
+          kind: classified?.kind,
           text: (event as { text?: string }).text?.slice(0, 80),
         },
         "Slack event dropped by filter",
@@ -1044,15 +1010,12 @@ export class SlackSocketModeClient {
       this.store.setLastSeenTsIfGreater(watermarkTs);
     }
 
-    if (
-      isAppMention &&
-      this.handleSlackMuteCommand(event as SlackAppMentionEvent)
-    ) {
-      return;
-    }
+    if (classified?.kind === "app_mention") {
+      const appMentionEvent = classified.event;
+      if (this.handleSlackMuteCommand(appMentionEvent)) {
+        return;
+      }
 
-    if (isAppMention) {
-      const appMentionEvent = event as SlackAppMentionEvent;
       const { channel, user } = appMentionEvent;
       const threadTs = appMentionEvent.thread_ts ?? appMentionEvent.ts;
       // Only arm the thread for a well-formed, routable mention — the same
@@ -1140,14 +1103,7 @@ export class SlackSocketModeClient {
   }
 
   private enqueueNormalizeAndEmit(
-    event:
-      | SlackAppMentionEvent
-      | SlackDirectMessageEvent
-      | SlackChannelMessageEvent
-      | SlackMessageChangedEvent
-      | SlackMessageDeletedEvent
-      | SlackReactionAddedEvent
-      | SlackReactionRemovedEvent,
+    event: SlackInboundEvent,
     eventId: string,
     isAppMention: boolean,
     isActiveThreadReply: boolean,
@@ -1189,14 +1145,7 @@ export class SlackSocketModeClient {
   }
 
   private async normalizeAndEmit(
-    event:
-      | SlackAppMentionEvent
-      | SlackDirectMessageEvent
-      | SlackChannelMessageEvent
-      | SlackMessageChangedEvent
-      | SlackMessageDeletedEvent
-      | SlackReactionAddedEvent
-      | SlackReactionRemovedEvent,
+    event: SlackInboundEvent,
     eventId: string,
     isAppMention: boolean,
     isActiveThreadReply: boolean,
@@ -1213,19 +1162,19 @@ export class SlackSocketModeClient {
     let normalized: NormalizedSlackEvent | null;
     if (isReactionAdded) {
       normalized = normalizeSlackReactionAdded(
-        event as SlackReactionAddedEvent,
+        event,
         eventId,
         this.config.gatewayConfig,
       );
     } else if (isReactionRemoved) {
       normalized = normalizeSlackReactionRemoved(
-        event as SlackReactionRemovedEvent,
+        event,
         eventId,
         this.config.gatewayConfig,
       );
     } else if (isAppMention) {
       normalized = normalizeSlackAppMention(
-        event as SlackAppMentionEvent,
+        event,
         eventId,
         this.config.gatewayConfig,
         this.config.botToken,
@@ -1233,20 +1182,20 @@ export class SlackSocketModeClient {
       );
     } else if (isMessageChanged) {
       normalized = normalizeSlackMessageEdit(
-        event as SlackMessageChangedEvent,
+        event,
         eventId,
         this.config.gatewayConfig,
         renderContext,
       );
     } else if (isMessageDeleted) {
       normalized = normalizeSlackMessageDelete(
-        event as SlackMessageDeletedEvent,
+        event,
         eventId,
         this.config.gatewayConfig,
       );
     } else if (isActiveThreadReply) {
       normalized = normalizeSlackChannelMessage(
-        event as SlackChannelMessageEvent,
+        event,
         eventId,
         this.config.gatewayConfig,
         this.config.botToken,
@@ -1254,7 +1203,7 @@ export class SlackSocketModeClient {
       );
     } else if (isDm) {
       normalized = normalizeSlackDirectMessage(
-        event as SlackDirectMessageEvent,
+        event,
         eventId,
         this.config.gatewayConfig,
         this.config.botToken,
@@ -1535,10 +1484,7 @@ export class SlackSocketModeClient {
       ...(msg.files ? { files: msg.files } : {}),
       ...(msg.attachments ? { attachments: msg.attachments } : {}),
       ...(msg.blocks ? { blocks: msg.blocks } : {}),
-    } as unknown as
-      | SlackAppMentionEvent
-      | SlackDirectMessageEvent
-      | SlackChannelMessageEvent;
+    } as unknown as SlackChannelMessageEvent;
 
     this.processEventPayload({
       event_id: `replay:${channel}:${msg.ts}`,


### PR DESCRIPTION
## Prompt / plan

Final piece of the Slack Socket Mode ingress-hardening arc (LUM-2816): the discriminated-union classifier that removes the scattered `event as Slack*Event` narrowing casts left behind by the leaf/normalizer PRs and the `parseSlackEnvelope` seam. Stacked on the merged seam (#39004) and under the merged characterization-test net (#39005). This is a readability/type-safety refactor, not a crash fix — the crash classes were already closed by the merged leaves + frame parse.

### Why

The Slack inbound event union carries **non-literal** `type` / `subtype` discriminators (both `string | undefined`), so TypeScript can't narrow it on its own. Every reader in the dispatch worked around that with an `event as Slack*Event` cast — ~10 of them across `extractEventUser`, `maybeTrackBotOwnThreadReply`, the admit filter, and the normalize call sites. The message-family aliases (`SlackAppMentionEvent` / `SlackDirectMessageEvent` / `SlackChannelMessageEvent`) and the reaction-family aliases are each a **single** shape, so several of those casts were also structurally meaningless (target type equalled source).

### What changed

- **New `classifySlackEvent` (`slack/classify-event.ts`)** — a pure function that narrows the tolerantly-parsed event to exactly one dispatch `kind` at a **single validated point**, returning a discriminated union `{ kind, event }` with a properly-typed `event`. The `type` / `subtype` narrowing casts now live here and nowhere else.
- **`extractEventUser` / `maybeTrackBotOwnThreadReply`** read typed fields off the classified event — no casts.
- **`processEventPayload`** classifies once, then a `switch (classified.kind)` computes the admit decision per kind. Since each event has exactly one kind, at most one filter matches (the old code recomputed all branches off five differently-typed views of the same event). The per-kind admit conditions move into `admitMessageEdit` / `admitMessageDelete` / `admitReaction` helpers, which **reuse `isChannelSubscribed`** and so drop the duplicated inline `conversation_id` lookups.
- **The normalize call sites pass `event` directly** — the normalizers already take `unknown` and `safeParse`, so their `as Slack*Event` casts were no-ops.
- Collapsed the verbose 7-member union spellings on the internal method signatures to `SlackInboundEvent`; dropped the now-unused leaf-type imports.

### Why it's safe

- **Behavior-preserving.** The merged characterization tests, thread-tracking, and catch-up suites (231 tests across the slack + socket-mode files) pass unchanged. No change to routing, dedup keys, admit outcomes, or the normalized output shape.
- Each event has exactly one kind, and the plain-message DM/active-thread split and app_mention mute/thread-arm paths are re-narrowed off the same discriminated `classified` value, so the one-boolean-at-most invariant is preserved.

## Test plan

- `bun test src/slack/ src/__tests__/slack-socket-mode-thread-tracking.test.ts src/__tests__/slack-socket-mode-catchup.test.ts` — **231 pass**.
- New `classify-event.test.ts` pins the classifier: each kind, subtype precedence, unmodeled subtype → plain message, and `null` for unhandled types (9 tests).
- **Negative control:** disabling the `message_deleted` branch in the classifier turns exactly the four delete tests red (DM delete, no-arm-on-delete, subscribed-channel delete, tracked-thread delete) and nothing else — confirming the seam is load-bearing. Restored.
- `tsc` (clean on the changed files; remaining errors are pre-existing voice/websocket buffer-type issues on `main`), `eslint`, `prettier`, generic-examples — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f)_