### PR TITLE
fix(web): tidy the takeover Custom-row current-plan summary

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -20,7 +20,7 @@ export interface PlanSpec {
  * The machine a package with no `machine_size` runs on — the small baseline
  * shared by Free and machine-less Pro packages (e.g. Mighty).
  */
-const STANDARD_MACHINE_LABEL = "Small";
+export const STANDARD_MACHINE_LABEL = "Small";
 
 /** Human machine-size label for a package (or the standard small machine). */
 export function machineLabel(pkg: ProPackage | null): string {

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
@@ -20,8 +20,8 @@ export interface CustomPlanRowProps {
    */
   isCurrent?: boolean;
   /**
-   * A short recap of the current custom tiers (e.g. "Medium machine · 30 GB ·
-   * $50 credits"). Shown as the row descriptor in place of the generic copy so
+   * A short recap of the current custom tiers (e.g. "Medium Machine · 30 GB ·
+   * 50 credits"). Shown as the row descriptor in place of the generic copy so
    * the user sees what their custom plan actually is.
    */
   currentSummary?: string;

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -881,16 +881,16 @@ describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
     expect(changePackageCall!.body).toEqual({ package: "mighty" });
   });
 
-  test("a Custom sub's Free card is a downgrade; the Custom row is current, no named card is", () => {
+  test("a Custom sub's Free card is a downgrade and no named card is current", () => {
     const html = renderStatic(proCustomizedMightySubscription(), fullCatalog());
     // Pro → Free is always a downgrade.
     expect(html).toContain("Downgrade to Free");
     expect(html).not.toContain("Start Free");
-    // A Custom sub has no catalog rank, so the Custom row carries the
-    // current-plan tag instead of any named column card.
-    expect(count(html, /Your Current Plan/g)).toBe(1);
-    // Every "Current Plan" match is that tag — no named column card is current.
-    expect(count(html, /Current Plan/g)).toBe(count(html, /Your Current Plan/g));
+    // A Custom sub has no catalog rank, so no named column card is its current
+    // plan. The Custom row's own current-plan tag is gated on the onboarding
+    // read, which a single-pass static render never resolves — the interactive
+    // "Custom row current-plan marker" suite covers that tag.
+    expect(html).not.toContain("Current Plan");
   });
 });
 
@@ -907,6 +907,16 @@ describe("PlansPage — Custom row current-plan marker", () => {
     };
   }
 
+  // A legacy/unpinned Pro sub carries no package at all, so it too is a Custom
+  // sub represented by the Custom row rather than any named card.
+  function proUnpinnedWithCredits(): SubscriptionResponse {
+    return {
+      ...proMightySubscription(),
+      package: null,
+      selected_credit_tier: "credits_50",
+    };
+  }
+
   test("a custom Pro sub sees the Custom row marked current with a tier summary", async () => {
     // onboarding() supplies medium machine / 10 GB; the sub carries credits_50.
     const { findByText } = renderInteractive(proCustomizedWithCredits(), {
@@ -914,7 +924,17 @@ describe("PlansPage — Custom row current-plan marker", () => {
     });
 
     await findByText("Your Current Plan");
-    await findByText("Medium machine · 10 GB · $50 credits");
+    await findByText("Medium Machine · 10 GB · 50 credits");
+  });
+
+  test("a legacy/unpinned Pro sub sees the Custom row marked current with a tier summary", async () => {
+    // No package pin — the same Custom-row current marker as the customized case.
+    const { findByText } = renderInteractive(proUnpinnedWithCredits(), {
+      plans: customCatalog(),
+    });
+
+    await findByText("Your Current Plan");
+    await findByText("Medium Machine · 10 GB · 50 credits");
   });
 
   test("a clean-pinned Pro sub sees no marker on the Custom row", async () => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -11,7 +11,10 @@ import {
   type SwitchRelation,
   tierRelation,
 } from "@/domains/settings/billing/package-types";
-import { machineLabel } from "@/domains/settings/billing/plan-spec";
+import {
+  machineLabel,
+  STANDARD_MACHINE_LABEL,
+} from "@/domains/settings/billing/plan-spec";
 import type { CurrentTiers } from "@/domains/settings/billing/use-change-tiers";
 import {
   FREE_CREDITS_USD,
@@ -31,6 +34,7 @@ import {
   getPlanTierCopy,
 } from "@/domains/settings/billing/plans/plans-copy";
 import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
+import { findCreditTier } from "@/domains/settings/billing/pro-onboarding/use-provisioning-credits";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
 import { useChangeTiers } from "@/domains/settings/billing/use-change-tiers";
 import { useCheckoutDismissRefresh } from "@/domains/settings/billing/use-checkout-dismiss-refresh";
@@ -111,24 +115,22 @@ function packageFeatures(pkg: ProPackage, extra: readonly string[]): string[] {
 
 /**
  * A one-line recap of a custom sub's current tiers for the Custom row, e.g.
- * "Medium machine · 30 GB · $50 credits". The machine reads from the tier
- * label map, storage from the resolved GiB, and credits from the live catalog;
- * a dimension with no value is dropped.
+ * "Medium Machine · 30 GB · 50 credits". The machine reads from the tier label
+ * map (or the standard-machine baseline), storage from the resolved GiB, and
+ * the credit label from the live catalog's `CreditTier.label`; a dimension with
+ * no value is dropped. The wording mirrors `packageSpecs` in `plan-spec.ts`.
  */
 function customCurrentSummary(current: CurrentTiers, proPlan: ProPlan): string {
   const machine = current.machineTier
     ? (MACHINE_TIER_LABEL[current.machineTier] ?? current.machineTier)
-    : "Small";
-  const parts = [`${machine} machine`];
+    : STANDARD_MACHINE_LABEL;
+  const parts = [`${machine} Machine`];
   if (current.storageGib != null) {
     parts.push(`${current.storageGib} GB`);
   }
-  const credits = current.creditTier
-    ? proPlan.credit_tiers?.find((t) => t.tier === current.creditTier)
-        ?.credits_usd
-    : null;
-  if (credits != null) {
-    parts.push(`$${credits} credits`);
+  const creditLabel = findCreditTier(proPlan, current.creditTier)?.label;
+  if (creditLabel != null) {
+    parts.push(creditLabel);
   }
   return parts.join(" · ");
 }
@@ -558,7 +560,7 @@ export function PlansPage() {
           className="mt-10"
           onConfigure={handleConfigure}
           configureDisabled={(isProUser && !currentReady) || billingActionPending}
-          isCurrent={isCustomCurrent}
+          isCurrent={isCustomCurrent && currentReady}
           currentSummary={currentSummary}
         />
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -2,12 +2,29 @@ import { useQuery } from "@tanstack/react-query";
 
 import { organizationsBillingPlansRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 import type {
+  CreditTier,
   CreditTierEnum,
   PlanCatalogEntry,
   ProPlan,
 } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
+
+/**
+ * Finds a Pro plan's `credit_tiers` entry for a tier — the single source of the
+ * credit-tier lookup shared by the label helpers here and the plans-page custom
+ * row summary. Returns undefined for a null/undefined tier or when the tier
+ * can't be resolved (no Pro plan, no matching tier).
+ */
+export function findCreditTier(
+  proPlan: ProPlan | undefined,
+  tier: string | null | undefined,
+): CreditTier | undefined {
+  if (tier == null) {
+    return undefined;
+  }
+  return proPlan?.credit_tiers?.find((t) => t.tier === tier);
+}
 
 /**
  * Resolves a credit tier's catalog label from the Pro plan's `credit_tiers`.
@@ -18,11 +35,8 @@ function creditTierLabel(
   plans: PlanCatalogEntry[] | undefined,
   tier: CreditTierEnum | null | undefined,
 ): string | null {
-  if (tier == null) {
-    return null;
-  }
   const proPlan = plans?.find((p): p is ProPlan => p.id === "pro");
-  return proPlan?.credit_tiers?.find((t) => t.tier === tier)?.label ?? null;
+  return findCreditTier(proPlan, tier)?.label ?? null;
 }
 
 /**
@@ -53,11 +67,10 @@ export function useProvisioningCredits(
   if (proPlan == null) {
     return null;
   }
-  const creditTiers = proPlan.credit_tiers ?? [];
 
   if (intent.kind === "package") {
     const pkg = proPlan.packages.find((p) => p.key === intent.packageKey);
-    const label = creditTiers.find((t) => t.tier === pkg?.credit_tier)?.label;
+    const label = findCreditTier(proPlan, pkg?.credit_tier)?.label;
     if (label != null) {
       return label;
     }


### PR DESCRIPTION
## Summary
- Gate the 'Your Current Plan' tag on onboarding readiness so it never shows next to generic copy on a cold deep-link.
- Reuse the shared credit-tier label helper and STANDARD_MACHINE_LABEL instead of re-hand-rolling the lookup and the 'Small' baseline.
- Add a plans-page test for the legacy/unpinned Custom-row current marker.

Fixes gaps from plan self-review for custom-subs-manage-takeover.md.