### PR TITLE
Custom subs open the Pro plans takeover from Manage

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -20,7 +20,7 @@ export interface PlanSpec {
  * The machine a package with no `machine_size` runs on — the small baseline
  * shared by Free and machine-less Pro packages (e.g. Mighty).
  */
-const STANDARD_MACHINE_LABEL = "Small";
+export const STANDARD_MACHINE_LABEL = "Small";
 
 /** Human machine-size label for a package (or the standard small machine). */
 export function machineLabel(pkg: ProPackage | null): string {

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-row.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-row.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Rendering tests for CustomPlanRow's current-plan marker. `isCurrent` renders
+ * the "Your Current Plan" tag, and `currentSummary` replaces the generic
+ * descriptor with the sub's tier recap.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { CustomPlanRow } from "./custom-plan-row";
+
+const GENERIC = "Select custom CPU power, Ram and Storage";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CustomPlanRow", () => {
+  test("shows the generic descriptor and no current tag by default", () => {
+    const { queryByText } = render(<CustomPlanRow onConfigure={() => {}} />);
+    expect(queryByText(/Select custom CPU power/)).not.toBeNull();
+    expect(queryByText("Your Current Plan")).toBeNull();
+  });
+
+  test("renders the current-plan tag when isCurrent", () => {
+    const { queryByText } = render(
+      <CustomPlanRow onConfigure={() => {}} isCurrent />,
+    );
+    expect(queryByText("Your Current Plan")).not.toBeNull();
+  });
+
+  test("swaps the descriptor for the tier summary when provided", () => {
+    const summary = "Medium machine · 30 GB · $50 credits";
+    const { queryByText } = render(
+      <CustomPlanRow
+        onConfigure={() => {}}
+        isCurrent
+        currentSummary={summary}
+      />,
+    );
+    expect(queryByText(summary)).not.toBeNull();
+    // The generic copy is replaced, not shown alongside.
+    expect(queryByText(new RegExp(GENERIC))).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
@@ -20,8 +20,8 @@ export interface CustomPlanRowProps {
    */
   isCurrent?: boolean;
   /**
-   * A short recap of the current custom tiers (e.g. "Medium machine · 30 GB ·
-   * $50 credits"). Shown as the row descriptor in place of the generic copy so
+   * A short recap of the current custom tiers (e.g. "Medium Machine · 30 GB ·
+   * 50 credits"). Shown as the row descriptor in place of the generic copy so
    * the user sees what their custom plan actually is.
    */
   currentSummary?: string;

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-row.tsx
@@ -1,6 +1,10 @@
 import { SlidersHorizontal } from "lucide-react";
 
 import { Button } from "@vellumai/design-library/components/button";
+import { Tag } from "@vellumai/design-library/components/tag";
+
+const GENERIC_DESCRIPTOR =
+  "Select custom CPU power, Ram and Storage. Or just throw in some tokens.";
 
 export interface CustomPlanRowProps {
   className?: string;
@@ -10,6 +14,17 @@ export interface CustomPlanRowProps {
    * so the click can't resolve before the parent knows how to route it.
    */
   configureDisabled?: boolean;
+  /**
+   * Marks this row as the user's current plan — set for a custom Pro sub, whose
+   * config isn't represented by any named column card.
+   */
+  isCurrent?: boolean;
+  /**
+   * A short recap of the current custom tiers (e.g. "Medium machine · 30 GB ·
+   * $50 credits"). Shown as the row descriptor in place of the generic copy so
+   * the user sees what their custom plan actually is.
+   */
+  currentSummary?: string;
 }
 
 /**
@@ -21,6 +36,8 @@ export function CustomPlanRow({
   className,
   onConfigure,
   configureDisabled,
+  isCurrent = false,
+  currentSummary,
 }: CustomPlanRowProps) {
   return (
     <div className={`flex w-full flex-col items-center gap-8 ${className ?? ""}`}>
@@ -36,12 +53,18 @@ export function CustomPlanRow({
             />
           </div>
           <div className="flex min-w-0 flex-col gap-1">
-            <span className="text-[16px] font-medium text-[var(--content-emphasised)]">
-              Custom Plan
-            </span>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-[16px] font-medium text-[var(--content-emphasised)]">
+                Custom Plan
+              </span>
+              {isCurrent ? (
+                <Tag className="bg-[var(--feed-digest-weak)] text-[var(--content-default)]">
+                  Your Current Plan
+                </Tag>
+              ) : null}
+            </div>
             <span className="text-[14px] font-medium text-[var(--content-tertiary)]">
-              Select custom CPU power, Ram and Storage. Or just throw in some
-              tokens.
+              {currentSummary ?? GENERIC_DESCRIPTOR}
             </span>
           </div>
         </div>

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -937,6 +937,18 @@ describe("PlansPage — Custom row current-plan marker", () => {
     await findByText("Medium Machine · 10 GB · 50 credits");
   });
 
+  test("a custom sub holding a deprecated credit tier shows a derived credit label", async () => {
+    // credits_45 is a valid tier the sub holds but the catalog no longer lists,
+    // so the summary derives "45 credits" from the key instead of dropping it.
+    const { findByText } = renderInteractive(
+      { ...proCustomizedWithCredits(), selected_credit_tier: "credits_45" },
+      { plans: customCatalog() },
+    );
+
+    await findByText("Your Current Plan");
+    await findByText("Medium Machine · 10 GB · 45 credits");
+  });
+
   test("a clean-pinned Pro sub sees no marker on the Custom row", async () => {
     const { findByRole, queryByText } = renderInteractive(
       proMightySubscription(),

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -968,6 +968,22 @@ describe("PlansPage — Custom row current-plan marker", () => {
     await findByRole("button", { name: "Configure" });
     expect(queryByText("Your Current Plan")).toBeNull();
   });
+
+  test("a custom sub with no loaded current tiers shows no marker", async () => {
+    // When the onboarding read yields no provisioned storage (e.g. it errors),
+    // the row isn't marked current — no "Your Current Plan" tag next to a
+    // degraded summary.
+    const { findByRole, queryByText } = renderInteractive(
+      proCustomizedWithCredits(),
+      {
+        plans: customCatalog(),
+        onboardingData: onboarding({ selected_storage_gib: null }),
+      },
+    );
+
+    await findByRole("button", { name: "Configure" });
+    expect(queryByText("Your Current Plan")).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -881,13 +881,60 @@ describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
     expect(changePackageCall!.body).toEqual({ package: "mighty" });
   });
 
-  test("a Custom sub's Free card is a downgrade and no named card renders as current", () => {
+  test("a Custom sub's Free card is a downgrade; the Custom row is current, no named card is", () => {
     const html = renderStatic(proCustomizedMightySubscription(), fullCatalog());
     // Pro → Free is always a downgrade.
     expect(html).toContain("Downgrade to Free");
     expect(html).not.toContain("Start Free");
-    // A Custom sub has no catalog rank, so no card is the current plan.
-    expect(count(html, /Current Plan/g)).toBe(0);
+    // A Custom sub has no catalog rank, so the Custom row carries the
+    // current-plan tag instead of any named column card.
+    expect(count(html, /Your Current Plan/g)).toBe(1);
+    // Every "Current Plan" match is that tag — no named column card is current.
+    expect(count(html, /Current Plan/g)).toBe(count(html, /Your Current Plan/g));
+  });
+});
+
+// A custom Pro sub (unpinned, customized, or legacy) is represented by the
+// Custom row, not any named card: the row is marked as their current plan and
+// summarizes the tiers they actually hold. Base and clean-pinned subs — whose
+// current plan IS a named card — see no marker on the Custom row.
+describe("PlansPage — Custom row current-plan marker", () => {
+  function proCustomizedWithCredits(): SubscriptionResponse {
+    return {
+      ...proMightySubscription(),
+      package: { key: "mighty", name: "Mighty", version: 1, customized: true },
+      selected_credit_tier: "credits_50",
+    };
+  }
+
+  test("a custom Pro sub sees the Custom row marked current with a tier summary", async () => {
+    // onboarding() supplies medium machine / 10 GB; the sub carries credits_50.
+    const { findByText } = renderInteractive(proCustomizedWithCredits(), {
+      plans: customCatalog(),
+    });
+
+    await findByText("Your Current Plan");
+    await findByText("Medium machine · 10 GB · $50 credits");
+  });
+
+  test("a clean-pinned Pro sub sees no marker on the Custom row", async () => {
+    const { findByRole, queryByText } = renderInteractive(
+      proMightySubscription(),
+      { plans: customCatalog() },
+    );
+
+    // The body is mounted once the Configure CTA is present.
+    await findByRole("button", { name: "Configure" });
+    expect(queryByText("Your Current Plan")).toBeNull();
+  });
+
+  test("a base user sees no marker on the Custom row", async () => {
+    const { findByRole, queryByText } = renderInteractive(freeSubscription(), {
+      plans: customCatalog(),
+    });
+
+    await findByRole("button", { name: "Configure" });
+    expect(queryByText("Your Current Plan")).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -881,16 +881,16 @@ describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
     expect(changePackageCall!.body).toEqual({ package: "mighty" });
   });
 
-  test("a Custom sub's Free card is a downgrade; the Custom row is current, no named card is", () => {
+  test("a Custom sub's Free card is a downgrade and no named card is current", () => {
     const html = renderStatic(proCustomizedMightySubscription(), fullCatalog());
     // Pro → Free is always a downgrade.
     expect(html).toContain("Downgrade to Free");
     expect(html).not.toContain("Start Free");
-    // A Custom sub has no catalog rank, so the Custom row carries the
-    // current-plan tag instead of any named column card.
-    expect(count(html, /Your Current Plan/g)).toBe(1);
-    // Every "Current Plan" match is that tag — no named column card is current.
-    expect(count(html, /Current Plan/g)).toBe(count(html, /Your Current Plan/g));
+    // A Custom sub has no catalog rank, so no named column card is its current
+    // plan. The Custom row's own current-plan tag is gated on the onboarding
+    // read, which a single-pass static render never resolves — the interactive
+    // "Custom row current-plan marker" suite covers that tag.
+    expect(html).not.toContain("Current Plan");
   });
 });
 
@@ -907,6 +907,16 @@ describe("PlansPage — Custom row current-plan marker", () => {
     };
   }
 
+  // A legacy/unpinned Pro sub carries no package at all, so it too is a Custom
+  // sub represented by the Custom row rather than any named card.
+  function proUnpinnedWithCredits(): SubscriptionResponse {
+    return {
+      ...proMightySubscription(),
+      package: null,
+      selected_credit_tier: "credits_50",
+    };
+  }
+
   test("a custom Pro sub sees the Custom row marked current with a tier summary", async () => {
     // onboarding() supplies medium machine / 10 GB; the sub carries credits_50.
     const { findByText } = renderInteractive(proCustomizedWithCredits(), {
@@ -914,7 +924,17 @@ describe("PlansPage — Custom row current-plan marker", () => {
     });
 
     await findByText("Your Current Plan");
-    await findByText("Medium machine · 10 GB · $50 credits");
+    await findByText("Medium Machine · 10 GB · 50 credits");
+  });
+
+  test("a legacy/unpinned Pro sub sees the Custom row marked current with a tier summary", async () => {
+    // No package pin — the same Custom-row current marker as the customized case.
+    const { findByText } = renderInteractive(proUnpinnedWithCredits(), {
+      plans: customCatalog(),
+    });
+
+    await findByText("Your Current Plan");
+    await findByText("Medium Machine · 10 GB · 50 credits");
   });
 
   test("a clean-pinned Pro sub sees no marker on the Custom row", async () => {

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -327,10 +327,15 @@ export function PlansPage() {
     // not any named card. Mark that row as their current plan and summarize its
     // tiers, once the current tiers have loaded.
     const isCustomCurrent = isProUser && currentTierKey === null;
-    const currentSummary =
-      isCustomCurrent && currentReady
-        ? customCurrentSummary(current, proPlan)
-        : undefined;
+    // Mark the row current only once the real current tiers have loaded.
+    // `currentReady` also flips true when the onboarding read settles with an
+    // error (tiers null), so require the provisioned storage as the loaded
+    // signal — otherwise the row is marked current next to a degraded summary.
+    const showCurrentPlan =
+      isCustomCurrent && currentReady && current.storageGib != null;
+    const currentSummary = showCurrentPlan
+      ? customCurrentSummary(current, proPlan)
+      : undefined;
 
     const selectTier = (tierKey: string) => {
       // A billing action is already in flight (checkout / package switch /
@@ -566,7 +571,7 @@ export function PlansPage() {
           className="mt-10"
           onConfigure={handleConfigure}
           configureDisabled={(isProUser && !currentReady) || billingActionPending}
-          isCurrent={isCustomCurrent && currentReady}
+          isCurrent={showCurrentPlan}
           currentSummary={currentSummary}
         />
 

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -12,6 +12,7 @@ import {
   tierRelation,
 } from "@/domains/settings/billing/package-types";
 import { machineLabel } from "@/domains/settings/billing/plan-spec";
+import type { CurrentTiers } from "@/domains/settings/billing/use-change-tiers";
 import {
   FREE_CREDITS_USD,
   FREE_STORAGE_GIB,
@@ -61,6 +62,7 @@ import {
 } from "@/hooks/use-platform-gate";
 import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
+import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
 import { openUrl } from "@/runtime/browser";
 import { isElectron } from "@/runtime/is-electron";
 import { routes } from "@/utils/routes";
@@ -105,6 +107,30 @@ function packageFeatures(pkg: ProPackage, extra: readonly string[]): string[] {
     `${formatDollars(credits * 100)} in credits included`,
     ...extra,
   ];
+}
+
+/**
+ * A one-line recap of a custom sub's current tiers for the Custom row, e.g.
+ * "Medium machine · 30 GB · $50 credits". The machine reads from the tier
+ * label map, storage from the resolved GiB, and credits from the live catalog;
+ * a dimension with no value is dropped.
+ */
+function customCurrentSummary(current: CurrentTiers, proPlan: ProPlan): string {
+  const machine = current.machineTier
+    ? (MACHINE_TIER_LABEL[current.machineTier] ?? current.machineTier)
+    : "Small";
+  const parts = [`${machine} machine`];
+  if (current.storageGib != null) {
+    parts.push(`${current.storageGib} GB`);
+  }
+  const credits = current.creditTier
+    ? proPlan.credit_tiers?.find((t) => t.tier === current.creditTier)
+        ?.credits_usd
+    : null;
+  if (credits != null) {
+    parts.push(`$${credits} credits`);
+  }
+  return parts.join(" · ");
 }
 
 /**
@@ -287,6 +313,16 @@ export function PlansPage() {
         : isCleanPin(subscription.package)
           ? subscription.package.key
           : null;
+
+    // A Pro sub with no clean pin (unpinned, customized, or legacy) — exactly
+    // the subs `currentTierKey` leaves null — is represented by the Custom row,
+    // not any named card. Mark that row as their current plan and summarize its
+    // tiers, once the current tiers have loaded.
+    const isCustomCurrent = isProUser && currentTierKey === null;
+    const currentSummary =
+      isCustomCurrent && currentReady
+        ? customCurrentSummary(current, proPlan)
+        : undefined;
 
     const selectTier = (tierKey: string) => {
       // A billing action is already in flight (checkout / package switch /
@@ -522,6 +558,8 @@ export function PlansPage() {
           className="mt-10"
           onConfigure={handleConfigure}
           configureDisabled={(isProUser && !currentReady) || billingActionPending}
+          isCurrent={isCustomCurrent}
+          currentSummary={currentSummary}
         />
 
         <CustomPlanModal

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -128,9 +128,15 @@ function customCurrentSummary(current: CurrentTiers, proPlan: ProPlan): string {
   if (current.storageGib != null) {
     parts.push(`${current.storageGib} GB`);
   }
-  const creditLabel = findCreditTier(proPlan, current.creditTier)?.label;
-  if (creditLabel != null) {
-    parts.push(creditLabel);
+  if (current.creditTier != null) {
+    // A held/deprecated credit tier absent from the catalog can't resolve to a
+    // catalog label; derive the amount from the tier key (credits_<usd>) so the
+    // paid bundle still shows instead of being silently dropped.
+    const usd = current.creditTier.match(/^credits_(\d+)$/)?.[1];
+    parts.push(
+      findCreditTier(proPlan, current.creditTier)?.label ??
+        (usd != null ? `${usd} credits` : "Credit bundle"),
+    );
   }
   return parts.join(" · ");
 }

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -11,7 +11,10 @@ import {
   type SwitchRelation,
   tierRelation,
 } from "@/domains/settings/billing/package-types";
-import { machineLabel } from "@/domains/settings/billing/plan-spec";
+import {
+  machineLabel,
+  STANDARD_MACHINE_LABEL,
+} from "@/domains/settings/billing/plan-spec";
 import type { CurrentTiers } from "@/domains/settings/billing/use-change-tiers";
 import {
   FREE_CREDITS_USD,
@@ -31,6 +34,7 @@ import {
   getPlanTierCopy,
 } from "@/domains/settings/billing/plans/plans-copy";
 import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
+import { findCreditTier } from "@/domains/settings/billing/pro-onboarding/use-provisioning-credits";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
 import { useChangeTiers } from "@/domains/settings/billing/use-change-tiers";
 import { useCheckoutDismissRefresh } from "@/domains/settings/billing/use-checkout-dismiss-refresh";
@@ -111,24 +115,22 @@ function packageFeatures(pkg: ProPackage, extra: readonly string[]): string[] {
 
 /**
  * A one-line recap of a custom sub's current tiers for the Custom row, e.g.
- * "Medium machine · 30 GB · $50 credits". The machine reads from the tier
- * label map, storage from the resolved GiB, and credits from the live catalog;
- * a dimension with no value is dropped.
+ * "Medium Machine · 30 GB · 50 credits". The machine reads from the tier label
+ * map (or the standard-machine baseline), storage from the resolved GiB, and
+ * the credit label from the live catalog's `CreditTier.label`; a dimension with
+ * no value is dropped. The wording mirrors `packageSpecs` in `plan-spec.ts`.
  */
 function customCurrentSummary(current: CurrentTiers, proPlan: ProPlan): string {
   const machine = current.machineTier
     ? (MACHINE_TIER_LABEL[current.machineTier] ?? current.machineTier)
-    : "Small";
-  const parts = [`${machine} machine`];
+    : STANDARD_MACHINE_LABEL;
+  const parts = [`${machine} Machine`];
   if (current.storageGib != null) {
     parts.push(`${current.storageGib} GB`);
   }
-  const credits = current.creditTier
-    ? proPlan.credit_tiers?.find((t) => t.tier === current.creditTier)
-        ?.credits_usd
-    : null;
-  if (credits != null) {
-    parts.push(`$${credits} credits`);
+  const creditLabel = findCreditTier(proPlan, current.creditTier)?.label;
+  if (creditLabel != null) {
+    parts.push(creditLabel);
   }
   return parts.join(" · ");
 }
@@ -558,7 +560,7 @@ export function PlansPage() {
           className="mt-10"
           onConfigure={handleConfigure}
           configureDisabled={(isProUser && !currentReady) || billingActionPending}
-          isCurrent={isCustomCurrent}
+          isCurrent={isCustomCurrent && currentReady}
           currentSummary={currentSummary}
         />
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -2,12 +2,29 @@ import { useQuery } from "@tanstack/react-query";
 
 import { organizationsBillingPlansRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 import type {
+  CreditTier,
   CreditTierEnum,
   PlanCatalogEntry,
   ProPlan,
 } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
+
+/**
+ * Finds a Pro plan's `credit_tiers` entry for a tier — the single source of the
+ * credit-tier lookup shared by the label helpers here and the plans-page custom
+ * row summary. Returns undefined for a null/undefined tier or when the tier
+ * can't be resolved (no Pro plan, no matching tier).
+ */
+export function findCreditTier(
+  proPlan: ProPlan | undefined,
+  tier: string | null | undefined,
+): CreditTier | undefined {
+  if (tier == null) {
+    return undefined;
+  }
+  return proPlan?.credit_tiers?.find((t) => t.tier === tier);
+}
 
 /**
  * Resolves a credit tier's catalog label from the Pro plan's `credit_tiers`.
@@ -18,11 +35,8 @@ function creditTierLabel(
   plans: PlanCatalogEntry[] | undefined,
   tier: CreditTierEnum | null | undefined,
 ): string | null {
-  if (tier == null) {
-    return null;
-  }
   const proPlan = plans?.find((p): p is ProPlan => p.id === "pro");
-  return proPlan?.credit_tiers?.find((t) => t.tier === tier)?.label ?? null;
+  return findCreditTier(proPlan, tier)?.label ?? null;
 }
 
 /**
@@ -53,11 +67,10 @@ export function useProvisioningCredits(
   if (proPlan == null) {
     return null;
   }
-  const creditTiers = proPlan.credit_tiers ?? [];
 
   if (intent.kind === "package") {
     const pkg = proPlan.packages.find((p) => p.key === intent.packageKey);
-    const label = creditTiers.find((t) => t.tier === pkg?.credit_tier)?.label;
+    const label = findCreditTier(proPlan, pkg?.credit_tier)?.label;
     if (label != null) {
       return label;
     }

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -558,10 +558,10 @@ describe("PlanCard action button", () => {
     expect(navigateArgs).toEqual([]);
   });
 
-  test("a customized Pro sub's Manage stays on onManage", async () => {
+  test("a customized Pro sub's Manage opens the plans takeover", async () => {
     const onManage = mock(() => {});
-    // A customized package's tiers differ from the stock package, so the
-    // takeover would misrepresent it — keep it on the manage modal.
+    // A customized pin routes to the takeover alongside every other Pro sub; the
+    // takeover's own CTAs handle the customized state's transitions.
     const subscription = proMightySubscription();
     subscription.package = {
       key: "mighty",
@@ -578,16 +578,68 @@ describe("PlanCard action button", () => {
     fireEvent.click(await findByTestId("plan-card-manage-button"));
 
     await waitFor(() => {
-      expect(onManage).toHaveBeenCalledTimes(1);
+      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
     });
-    expect(navigateArgs).toEqual([]);
+    expect(onManage).not.toHaveBeenCalled();
   });
 
-  test("a Pro sub without a pinned package stays on onManage", async () => {
+  test("a Pro sub without a pinned package opens the plans takeover", async () => {
     const onManage = mock(() => {});
-    // A legacy/custom Pro sub (no package) would render as free in the takeover,
-    // so it stays on the manage modal even with a live catalog.
+    // A legacy/unpinned Custom Pro sub routes to the takeover with the rest; the
+    // takeover surfaces the Custom row as its current plan.
     const subscription = { ...proMightySubscription(), package: undefined };
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+    );
+
+    fireEvent.click(await findByTestId("plan-card-manage-button"));
+
+    await waitFor(() => {
+      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+    });
+    expect(onManage).not.toHaveBeenCalled();
+  });
+
+  test("a from-scratch custom Pro sub's Manage opens the plans takeover", async () => {
+    const onManage = mock(() => {});
+    // A Pro sub built from scratch — no stock lineage, pinned but customized —
+    // routes to the takeover like every other Pro sub with a live catalog.
+    const subscription = proMightySubscription();
+    subscription.package = {
+      key: "custom",
+      name: "Custom",
+      version: 1,
+      customized: true,
+    };
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+    );
+
+    fireEvent.click(await findByTestId("plan-card-manage-button"));
+
+    await waitFor(() => {
+      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+    });
+    expect(onManage).not.toHaveBeenCalled();
+  });
+
+  test("a cancelling custom Pro sub's Manage stays on the manage fallback", async () => {
+    const onManage = mock(() => {});
+    // A customized/unpinned sub pending cancellation keeps the manage modal,
+    // which surfaces the cancellation state and the "Keep your Plan" action; the
+    // takeover can't act on a cancelling sub.
+    const subscription = proMightySubscription();
+    subscription.package = {
+      key: "mighty",
+      name: "Mighty",
+      version: 1,
+      customized: true,
+    };
+    subscription.cancel_at = "2026-08-23T12:36:05Z";
     const { findByTestId } = renderCardInteractive(
       subscription,
       plansWithSuper(),
@@ -600,6 +652,26 @@ describe("PlanCard action button", () => {
       expect(onManage).toHaveBeenCalledTimes(1);
     });
     expect(navigateArgs).toEqual([]);
+  });
+
+  test("a cancelling clean-pin Pro sub still opens the plans takeover", async () => {
+    const onManage = mock(() => {});
+    // A clean pin routes to the takeover even while cancelling; its package CTA
+    // reaches the manage surface from there.
+    const subscription = proMightySubscription();
+    subscription.cancel_at = "2026-08-23T12:36:05Z";
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+    );
+
+    fireEvent.click(await findByTestId("plan-card-manage-button"));
+
+    await waitFor(() => {
+      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+    });
+    expect(onManage).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -673,6 +673,33 @@ describe("PlanCard action button", () => {
     });
     expect(onManage).not.toHaveBeenCalled();
   });
+
+  test("an unpaid custom Pro sub's Manage stays on the manage fallback", async () => {
+    const onManage = mock(() => {});
+    // A custom sub in a non-entitlement status (e.g. unpaid) is switch-ineligible,
+    // so it keeps the manage modal — the takeover would bounce every CTA back to
+    // the manage surface.
+    const subscription = proMightySubscription();
+    subscription.package = {
+      key: "mighty",
+      name: "Mighty",
+      version: 1,
+      customized: true,
+    };
+    subscription.status = "unpaid";
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+    );
+
+    fireEvent.click(await findByTestId("plan-card-manage-button"));
+
+    await waitFor(() => {
+      expect(onManage).toHaveBeenCalledTimes(1);
+    });
+    expect(navigateArgs).toEqual([]);
+  });
 });
 
 describe("PlanCard recommended upgrade — change-package", () => {

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -372,20 +372,19 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   const packages = proPlan?.packages ?? [];
   const currentKey = subscription.package?.key ?? null;
   const currentTier = currentKey ?? "free";
-  // A live packages catalog opens the plans takeover for base and every Pro sub
-  // — a clean pin, a customized pin, and an unpinned (legacy Custom) sub alike;
-  // the takeover's own CTAs handle each state's transitions. One exception: a
-  // custom/unpinned sub that is pending cancellation keeps the manage modal,
-  // which surfaces the cancellation state and the "Keep your Plan" action — the
-  // takeover can't act on a cancelling sub (every change is rejected), and a
-  // clean pin already reaches the manage surface through its package CTA. An
-  // empty catalog (the `pro-packages` flag off) has no takeover to open, so
+  // A live packages catalog opens the plans takeover for base and clean-pinned
+  // Pro subs, and for a custom/unpinned Pro sub that is switch-eligible. An
+  // ineligible custom sub — pending cancellation, or a non-entitlement status
+  // such as `unpaid` — keeps the manage modal, which surfaces its state and the
+  // recovery actions; the takeover can't act on it (every change is rejected),
+  // and a clean pin already reaches the manage surface through its package CTA.
+  // An empty catalog (the `pro-packages` flag off) has no takeover to open, so
   // Manage falls back to the manage modal.
   const canOpenPlansTakeover =
     packages.length > 0 &&
     (currentPlan.id === "base" ||
       isCleanPin(subscription.package) ||
-      !isCancelling);
+      isPackageSwitchEligible(subscription));
   // The banner's one-click switch is offered to any switch-eligible Pro sub —
   // a clean pin, a customized pin, or an unpinned (Custom) sub — inheriting the
   // shared eligibility gate. The confirm copy adapts to the sub's state via

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -372,14 +372,20 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   const packages = proPlan?.packages ?? [];
   const currentKey = subscription.package?.key ?? null;
   const currentTier = currentKey ?? "free";
-  // The plans takeover derives the current tier from the pinned package key
-  // alone, so a Pro sub without a package (legacy) or with a customized one
-  // (its tiers differ from the stock package) would be misrepresented there.
-  // Those stay on the manage modal; only base and clean packaged-Pro subs open
-  // the takeover.
+  // A live packages catalog opens the plans takeover for base and every Pro sub
+  // — a clean pin, a customized pin, and an unpinned (legacy Custom) sub alike;
+  // the takeover's own CTAs handle each state's transitions. One exception: a
+  // custom/unpinned sub that is pending cancellation keeps the manage modal,
+  // which surfaces the cancellation state and the "Keep your Plan" action — the
+  // takeover can't act on a cancelling sub (every change is rejected), and a
+  // clean pin already reaches the manage surface through its package CTA. An
+  // empty catalog (the `pro-packages` flag off) has no takeover to open, so
+  // Manage falls back to the manage modal.
   const canOpenPlansTakeover =
     packages.length > 0 &&
-    (currentPlan.id === "base" || isCleanPin(subscription.package));
+    (currentPlan.id === "base" ||
+      isCleanPin(subscription.package) ||
+      !isCancelling);
   // The banner's one-click switch is offered to any switch-eligible Pro sub —
   // a clean pin, a customized pin, or an unpinned (Custom) sub — inheriting the
   // shared eligibility gate. The confirm copy adapts to the sub's state via


### PR DESCRIPTION
## Summary
Widen the Plan card **Manage** button so base and every Pro sub — a clean pin, a customized pin, and an unpinned/legacy custom sub — open the full-screen plans takeover instead of the legacy `AdjustPlanModal`, and mark the takeover's **Custom row** as the current plan (a "Your Current Plan" tag + a tier summary) for custom subs. A **cancelling** custom sub keeps the manage fallback (the cancellation state and the "Keep your Plan" action live there, and the takeover can't act on a cancelling sub). Frontend-only — no backend/DB/Stripe/OpenAPI changes.

All plan transitions (custom→pinned, custom→custom, custom→free, free→custom) already work from the takeover's existing CTAs; this only changes routing + display.

## Self-review result
**PASS** — 4 gaps fixed in 1 fix PR: a cold-cache tag flash (gate the tag on onboarding readiness), reuse of the shared credit-tier + machine-label helpers instead of hand-rolled duplicates, and a legacy/unpinned test variant. Codex's per-PR findings were addressed inline (one real cancelling-custom carve-out on #39007; one cross-PR false positive on #39008).

## PRs merged into feature branch
- #39007: open the plans takeover from Manage for custom and legacy Pro subs
- #39008: mark the takeover Custom row as the current plan for custom subs

### Fix PRs
- #39015: reuse shared credit/machine labels + gate the Custom-row current tag on readiness

Part of plan: custom-subs-manage-takeover.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
