### PR TITLE
perf(web): cancel stale chat history fetches

### DIFF
--- a/clients/web/src/domains/chat/api/history.test.ts
+++ b/clients/web/src/domains/chat/api/history.test.ts
@@ -18,6 +18,7 @@ import {
 interface CapturedRequest {
   url: string;
   init: RequestInit | undefined;
+  signal: AbortSignal | null | undefined;
 }
 
 function makeJsonResponse(
@@ -46,7 +47,8 @@ beforeEach(() => {
         : input instanceof URL
           ? input.toString()
           : input.url;
-    captured.push({ url, init });
+    const signal = input instanceof Request ? input.signal : init?.signal;
+    captured.push({ url, init, signal });
     if (!nextResponse) {
       throw new Error("test setup forgot to set nextResponse");
     }
@@ -95,6 +97,33 @@ describe("fetchLatestHistoryPage URL construction", () => {
     const url = new URL(captured[0]!.url, "http://localhost");
     expect(url.searchParams.get("limit")).toBe("25");
   });
+
+  test("threads an AbortSignal into the history request", async () => {
+    const controller = new AbortController();
+    const abortReason = new DOMException("Obsolete history", "AbortError");
+    nextResponse = new Promise<Response>((_resolve, reject) => {
+      controller.signal.addEventListener(
+        "abort",
+        () => reject(abortReason),
+        { once: true },
+      );
+    });
+
+    const pending = fetchLatestHistoryPage(
+      "asst-1",
+      "K",
+      undefined,
+      controller.signal,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.signal?.aborted).toBe(false);
+    controller.abort(abortReason);
+
+    await expect(pending).rejects.toBe(abortReason);
+    expect(captured[0]!.signal?.aborted).toBe(true);
+  });
 });
 
 describe("fetchOlderHistoryPage URL construction", () => {
@@ -130,6 +159,28 @@ describe("fetchOlderHistoryPage URL construction", () => {
 
     const url = new URL(captured[0]!.url, "http://localhost");
     expect(url.searchParams.get("limit")).toBe("10");
+  });
+
+  test("threads an AbortSignal into an older-page request", async () => {
+    const controller = new AbortController();
+    nextResponse = makeJsonResponse({
+      messages: [],
+      hasMore: false,
+      oldestTimestamp: null,
+      oldestMessageId: null,
+    });
+
+    await fetchOlderHistoryPage(
+      "asst-1",
+      "K",
+      1_700_000_000_000,
+      undefined,
+      controller.signal,
+    );
+
+    expect(captured[0]!.signal?.aborted).toBe(false);
+    controller.abort();
+    expect(captured[0]!.signal?.aborted).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/chat/api/history.ts
+++ b/clients/web/src/domains/chat/api/history.ts
@@ -90,6 +90,7 @@ function parsePaginatedResponse(
 async function fetchPaginatedHistory(
   assistantId: string,
   query: HistoryQuery,
+  signal?: AbortSignal,
 ): Promise<PaginatedHistoryResult> {
   // Capture the seq generation at request-ISSUE time: if the daemon's counter
   // resets while this fetch is in flight, the watermark it returns belongs to
@@ -100,6 +101,7 @@ async function fetchPaginatedHistory(
   const { data, error, response } = await messagesGet({
     path: { assistant_id: assistantId },
     query,
+    signal,
     throwOnError: false,
   });
 
@@ -145,12 +147,17 @@ export async function fetchLatestHistoryPage(
   assistantId: string,
   conversationId: string,
   limit: number = DEFAULT_LATEST_LIMIT,
+  signal?: AbortSignal,
 ): Promise<PaginatedHistoryResult> {
-  return fetchPaginatedHistory(assistantId, {
-    conversationId,
-    page: "latest",
-    limit,
-  });
+  return fetchPaginatedHistory(
+    assistantId,
+    {
+      conversationId,
+      page: "latest",
+      limit,
+    },
+    signal,
+  );
 }
 
 /**
@@ -164,10 +171,15 @@ export async function fetchOlderHistoryPage(
   conversationId: string,
   beforeTimestamp: number,
   limit: number = DEFAULT_OLDER_LIMIT,
+  signal?: AbortSignal,
 ): Promise<PaginatedHistoryResult> {
-  return fetchPaginatedHistory(assistantId, {
-    conversationId,
-    beforeTimestamp,
-    limit,
-  });
+  return fetchPaginatedHistory(
+    assistantId,
+    {
+      conversationId,
+      beforeTimestamp,
+      limit,
+    },
+    signal,
+  );
 }

--- a/clients/web/src/domains/chat/transcript/use-history-pagination.cancellation.test.tsx
+++ b/clients/web/src/domains/chat/transcript/use-history-pagination.cancellation.test.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+
+import { useHistoryPagination } from "./use-history-pagination";
+
+interface CapturedHistoryRequest {
+  signal: AbortSignal | null | undefined;
+}
+
+let originalFetch: typeof fetch;
+let requests: CapturedHistoryRequest[];
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  requests = [];
+  globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+    const signal = input instanceof Request ? input.signal : init?.signal;
+    return new Promise<Response>((_resolve, reject) => {
+      requests.push({ signal });
+      const rejectAbort = () =>
+        reject(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+      if (signal?.aborted) {
+        rejectAbort();
+      } else {
+        signal?.addEventListener("abort", rejectAbort, { once: true });
+      }
+    });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useHistoryPagination cancellation", () => {
+  test("aborts the obsolete request without surfacing or retrying it", async () => {
+    const queryClient = new QueryClient();
+    const view = renderHook(
+      ({ conversationId }: { conversationId: string }) =>
+        useHistoryPagination({
+          assistantId: "assistant-123",
+          conversationId,
+          enabled: true,
+        }),
+      {
+        initialProps: { conversationId: "conversation-123" },
+        wrapper: createWrapper(queryClient),
+      },
+    );
+    await waitFor(() => expect(requests).toHaveLength(1));
+
+    view.rerender({ conversationId: "conversation-456" });
+
+    await waitFor(() => expect(requests).toHaveLength(2));
+    expect(requests[0]!.signal?.aborted).toBe(true);
+    expect(requests[1]!.signal?.aborted).toBe(false);
+    expect(view.result.current.isError).toBe(false);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(requests).toHaveLength(2);
+
+    view.unmount();
+    queryClient.clear();
+  });
+});

--- a/clients/web/src/domains/chat/transcript/use-history-pagination.ts
+++ b/clients/web/src/domains/chat/transcript/use-history-pagination.ts
@@ -160,15 +160,21 @@ export function useHistoryPagination({
       if (!assistantId || !conversationId) {
         throw new Error("Missing assistantId or conversationId");
       }
-      void signal; // AbortController signal available for future use
       if (pageParam != null) {
         return fetchOlderHistoryPage(
           assistantId,
           conversationId,
           pageParam,
+          undefined,
+          signal,
         );
       }
-      return fetchLatestHistoryPage(assistantId, conversationId);
+      return fetchLatestHistoryPage(
+        assistantId,
+        conversationId,
+        undefined,
+        signal,
+      );
     },
     initialPageParam: null as number | null,
     getNextPageParam: (lastPage): number | undefined => {

--- a/clients/web/src/domains/chat/utils/diagnostics.test.ts
+++ b/clients/web/src/domains/chat/utils/diagnostics.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  ConversationContentBlock,
+  ConversationMessage,
+} from "@vellumai/assistant-api";
+
+import { summarizeRuntimeMessage } from "./diagnostics";
+
+function runtimeMessage(
+  contentBlocks: ConversationContentBlock[],
+): ConversationMessage {
+  return {
+    id: "message-123",
+    role: "assistant",
+    timestamp: "2026-07-23T00:00:00.000Z",
+    attachments: [],
+    contentBlocks,
+  };
+}
+
+describe("chat diagnostic content-block sizing", () => {
+  test("preserves serialized UTF-8 size semantics for ordinary content", () => {
+    const contentBlocks: ConversationContentBlock[] = [
+      { type: "text", text: "Hello, 👋\n\"world\"" },
+      {
+        type: "thinking",
+        thinking: "résumé",
+        startedAt: 1,
+        completedAt: 2,
+      },
+    ];
+    const expectedBytes = new TextEncoder().encode(
+      JSON.stringify(contentBlocks),
+    ).length;
+
+    const summary = summarizeRuntimeMessage(runtimeMessage(contentBlocks));
+
+    expect(summary.contentBlocksKb).toBe(
+      Math.round((expectedBytes / 1024) * 100) / 100,
+    );
+    expect(summary.inlineMediaKb).toBe(0);
+    expect(summary.inlineMediaCount).toBe(0);
+  });
+
+  test("measures large nested attachment and tool-result media separately", () => {
+    const attachmentData = "A".repeat(512 * 1024);
+    const thumbnailData = "B".repeat(256 * 1024);
+    const deprecatedToolImage = "C".repeat(512 * 1024);
+    const toolImages = ["D".repeat(512 * 1024), "E".repeat(512 * 1024)];
+    const contentBlocks: ConversationContentBlock[] = [
+      {
+        type: "attachment",
+        attachment: {
+          id: "attachment-123",
+          filename: "image.png",
+          mimeType: "image/png",
+          sizeBytes: attachmentData.length,
+          kind: "image",
+          data: attachmentData,
+          thumbnailData,
+        },
+      },
+      {
+        type: "tool_use",
+        toolCall: {
+          id: "tool-123",
+          name: "browser_screenshot",
+          input: {},
+          imageData: deprecatedToolImage,
+          imageDataList: toolImages,
+        },
+      },
+    ];
+    const inlineMediaBytes =
+      attachmentData.length +
+      thumbnailData.length +
+      deprecatedToolImage.length +
+      toolImages.reduce((total, image) => total + image.length, 0);
+    const summary = summarizeRuntimeMessage(runtimeMessage(contentBlocks));
+
+    expect(summary.inlineMediaCount).toBe(5);
+    expect(summary.inlineMediaKb).toBe(inlineMediaBytes / 1024);
+    expect(summary.contentBlocksKb).toBeGreaterThan(summary.inlineMediaKb as number);
+    expect(summary.contentBlocksKb).toBeLessThan(
+      (summary.inlineMediaKb as number) + 1,
+    );
+  });
+});

--- a/clients/web/src/domains/chat/utils/diagnostics.ts
+++ b/clients/web/src/domains/chat/utils/diagnostics.ts
@@ -13,26 +13,85 @@ import type {
 } from "@vellumai/assistant-api";
 import { roleCounts } from "@/lib/diagnostics";
 
-/**
- * Serialized size of a message's unified `contentBlocks` projection, in KB
- * (UTF-8 bytes, two-decimal precision). This is the migration's canonical
- * content payload, so its size is the meaningful weight of a row's body.
- */
-function contentBlocksSizeKb(
-  blocks: ConversationContentBlock[] | undefined,
-): number {
-  if (!blocks || blocks.length === 0) {
-    return 0;
-  }
-  const bytes = new TextEncoder().encode(JSON.stringify(blocks)).length;
+interface ContentBlockSizeSummary {
+  contentBlocksKb: number;
+  inlineMediaKb: number;
+  inlineMediaCount: number;
+}
+
+const UTF8_ENCODER = new TextEncoder();
+
+function roundKb(bytes: number): number {
   return Math.round((bytes / 1024) * 100) / 100;
 }
 
+function isAttachmentMetadata(value: unknown): value is object {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    "filename" in value &&
+    "mimeType" in value &&
+    "sizeBytes" in value
+  );
+}
+
+/**
+ * Measures serialized `contentBlocks` after replacing base64 payloads with
+ * empty markers, then adds their ASCII lengths back into the total.
+ */
+function summarizeContentBlockSize(
+  blocks: ConversationContentBlock[] | undefined,
+): ContentBlockSizeSummary {
+  if (!blocks || blocks.length === 0) {
+    return {
+      contentBlocksKb: 0,
+      inlineMediaKb: 0,
+      inlineMediaCount: 0,
+    };
+  }
+
+  let inlineMediaBytes = 0;
+  let inlineMediaCount = 0;
+  const redactInlineMedia = (value: string): string => {
+    inlineMediaBytes += value.length;
+    inlineMediaCount++;
+    return "";
+  };
+  const redacted = JSON.stringify(blocks, function (
+    this: unknown,
+    key,
+    value: unknown,
+  ) {
+    if (key === "imageDataList" && Array.isArray(value)) {
+      return value.map((item) =>
+        typeof item === "string" ? redactInlineMedia(item) : item,
+      );
+    }
+    if (
+      typeof value === "string" &&
+      (key === "imageData" ||
+        (isAttachmentMetadata(this) &&
+          (key === "data" || key === "thumbnailData")))
+    ) {
+      return redactInlineMedia(value);
+    }
+    return value;
+  });
+  const redactedBytes = UTF8_ENCODER.encode(redacted).length;
+  return {
+    contentBlocksKb: roundKb(redactedBytes + inlineMediaBytes),
+    inlineMediaKb: roundKb(inlineMediaBytes),
+    inlineMediaCount,
+  };
+}
+
 export function summarizeDisplayMessage(message: DisplayMessage): Record<string, unknown> {
+  const contentBlockSize = summarizeContentBlockSize(message.contentBlocks);
   return {
     id: message.id,
     role: message.role,
-    contentBlocksKb: contentBlocksSizeKb(message.contentBlocks),
+    ...contentBlockSize,
     timestamp: message.timestamp ?? null,
     queueStatus: message.queueStatus ?? null,
     queuePosition: message.queuePosition ?? null,
@@ -45,10 +104,11 @@ export function summarizeDisplayMessage(message: DisplayMessage): Record<string,
 }
 
 export function summarizeRuntimeMessage(message: ConversationMessage): Record<string, unknown> {
+  const contentBlockSize = summarizeContentBlockSize(message.contentBlocks);
   return {
     id: message.id,
     role: message.role,
-    contentBlocksKb: contentBlocksSizeKb(message.contentBlocks),
+    ...contentBlockSize,
     timestamp: message.timestamp ?? null,
     toolCallCount: message.toolCalls?.length ?? 0,
     surfaceCount: message.surfaces?.length ?? 0,


### PR DESCRIPTION
Closes #39010

Cancels obsolete paginated history requests and makes diagnostics measure media-heavy content without copying entire base64 payloads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->