### PR TITLE
refactor(slack): consolidate event types — SlackReactionEvent + route helpers through the classifier

### DIFF
--- a/gateway/src/__tests__/slack-reaction-normalize.test.ts
+++ b/gateway/src/__tests__/slack-reaction-normalize.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   normalizeSlackReactionAdded,
-  type SlackReactionAddedEvent,
+  type SlackReactionEvent,
 } from "../slack/normalize.js";
 import type { GatewayConfig } from "../config.js";
 
@@ -33,8 +33,8 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 }
 
 function makeReactionEvent(
-  overrides?: Partial<SlackReactionAddedEvent>,
-): SlackReactionAddedEvent {
+  overrides?: Partial<SlackReactionEvent>,
+): SlackReactionEvent {
   return {
     type: "reaction_added",
     user: "U001",

--- a/gateway/src/slack/classify-event.ts
+++ b/gateway/src/slack/classify-event.ts
@@ -3,8 +3,7 @@ import type {
   SlackChannelMessageEvent,
   SlackMessageChangedEvent,
   SlackMessageDeletedEvent,
-  SlackReactionAddedEvent,
-  SlackReactionRemovedEvent,
+  SlackReactionEvent,
 } from "./normalize.js";
 
 /**
@@ -26,8 +25,8 @@ export type ClassifiedSlackEvent =
   | { kind: "message"; event: SlackChannelMessageEvent }
   | { kind: "message_changed"; event: SlackMessageChangedEvent }
   | { kind: "message_deleted"; event: SlackMessageDeletedEvent }
-  | { kind: "reaction_added"; event: SlackReactionAddedEvent }
-  | { kind: "reaction_removed"; event: SlackReactionRemovedEvent };
+  | { kind: "reaction_added"; event: SlackReactionEvent }
+  | { kind: "reaction_removed"; event: SlackReactionEvent };
 
 /**
  * Classify a Slack inbound event by its `type` / `subtype` discriminators.
@@ -45,13 +44,10 @@ export function classifySlackEvent(
     return { kind: "app_mention", event: event as SlackChannelMessageEvent };
   }
   if (type === "reaction_added") {
-    return { kind: "reaction_added", event: event as SlackReactionAddedEvent };
+    return { kind: "reaction_added", event: event as SlackReactionEvent };
   }
   if (type === "reaction_removed") {
-    return {
-      kind: "reaction_removed",
-      event: event as SlackReactionRemovedEvent,
-    };
+    return { kind: "reaction_removed", event: event as SlackReactionEvent };
   }
   if (type === "message") {
     const subtype = (event as SlackMessageChangedEvent).subtype;

--- a/gateway/src/slack/envelope.ts
+++ b/gateway/src/slack/envelope.ts
@@ -6,8 +6,7 @@ import type {
   SlackDirectMessageEvent,
   SlackMessageChangedEvent,
   SlackMessageDeletedEvent,
-  SlackReactionAddedEvent,
-  SlackReactionRemovedEvent,
+  SlackReactionEvent,
 } from "./normalize.js";
 
 const optionalString = () => z.string().optional().catch(undefined);
@@ -24,8 +23,7 @@ export type SlackInboundEvent =
   | SlackChannelMessageEvent
   | SlackMessageChangedEvent
   | SlackMessageDeletedEvent
-  | SlackReactionAddedEvent
-  | SlackReactionRemovedEvent;
+  | SlackReactionEvent;
 
 /**
  * The `payload` object on a Socket Mode envelope. Serves two envelope kinds:

--- a/gateway/src/slack/event-ordering.test.ts
+++ b/gateway/src/slack/event-ordering.test.ts
@@ -5,8 +5,7 @@ import type {
   SlackAppMentionEvent,
   SlackMessageChangedEvent,
   SlackMessageDeletedEvent,
-  SlackReactionAddedEvent,
-  SlackReactionRemovedEvent,
+  SlackReactionEvent,
 } from "./normalize.js";
 
 const CHANNEL = "C0ABCDEF";
@@ -20,7 +19,7 @@ describe("slackEventOrderingKey — well-formed events", () => {
       user: "U1",
       reaction: "thumbsup",
       item: { type: "message", channel: CHANNEL, ts: TS },
-    } as SlackReactionAddedEvent;
+    } as SlackReactionEvent;
     expect(slackEventOrderingKey(event, EVENT_ID)).toBe(`${CHANNEL}:${TS}`);
   });
 
@@ -30,7 +29,7 @@ describe("slackEventOrderingKey — well-formed events", () => {
       user: "U1",
       reaction: "thumbsup",
       item: { type: "message", channel: CHANNEL, ts: TS },
-    } as SlackReactionRemovedEvent;
+    } as SlackReactionEvent;
     expect(slackEventOrderingKey(event, EVENT_ID)).toBe(`${CHANNEL}:${TS}`);
   });
 
@@ -76,7 +75,7 @@ describe("slackEventOrderingKey — malformed events do not crash the emit path"
       type: "reaction_added",
       user: "U1",
       reaction: "thumbsup",
-    } as unknown as SlackReactionAddedEvent;
+    } as unknown as SlackReactionEvent;
     expect(() => slackEventOrderingKey(event, EVENT_ID)).not.toThrow();
     expect(slackEventOrderingKey(event, EVENT_ID)).toBe(
       `${EVENT_ID}:${EVENT_ID}`,

--- a/gateway/src/slack/event-ordering.ts
+++ b/gateway/src/slack/event-ordering.ts
@@ -1,20 +1,5 @@
-import type {
-  SlackAppMentionEvent,
-  SlackChannelMessageEvent,
-  SlackDirectMessageEvent,
-  SlackMessageChangedEvent,
-  SlackMessageDeletedEvent,
-  SlackReactionEvent,
-} from "./normalize.js";
-
-/** The Slack event shapes that flow through ordered normalization. */
-export type SlackOrderableEvent =
-  | SlackAppMentionEvent
-  | SlackDirectMessageEvent
-  | SlackChannelMessageEvent
-  | SlackMessageChangedEvent
-  | SlackMessageDeletedEvent
-  | SlackReactionEvent;
+import type { SlackInboundEvent } from "./envelope.js";
+import { classifySlackEvent } from "./classify-event.js";
 
 /**
  * Ordering key that groups related Slack events onto a single sequential lane,
@@ -28,33 +13,29 @@ export type SlackOrderableEvent =
  * unique `eventId` so ordering never crashes.
  */
 export function slackEventOrderingKey(
-  event: SlackOrderableEvent,
+  event: SlackInboundEvent,
   eventId: string,
 ): string {
-  if (event.type === "reaction_added" || event.type === "reaction_removed") {
-    const reaction = event as SlackReactionEvent;
-    return `${reaction.item?.channel ?? eventId}:${reaction.item?.ts ?? eventId}`;
+  const classified = classifySlackEvent(event);
+  switch (classified?.kind) {
+    case "reaction_added":
+    case "reaction_removed": {
+      const { item } = classified.event;
+      return `${item?.channel ?? eventId}:${item?.ts ?? eventId}`;
+    }
+    case "message_changed": {
+      const changed = classified.event;
+      return `${changed.channel}:${changed.message?.thread_ts ?? changed.message?.ts ?? eventId}`;
+    }
+    case "message_deleted": {
+      const deleted = classified.event;
+      return `${deleted.channel}:${deleted.previous_message?.thread_ts ?? deleted.deleted_ts ?? eventId}`;
+    }
+    default: {
+      // app_mention / plain message (or an unclassifiable event): key on the
+      // message's own thread, falling back to its ts then the eventId.
+      const message = classified?.event;
+      return `${message?.channel}:${message?.thread_ts ?? message?.ts ?? eventId}`;
+    }
   }
-
-  if (
-    event.type === "message" &&
-    (event as SlackMessageChangedEvent).subtype === "message_changed"
-  ) {
-    const changed = event as SlackMessageChangedEvent;
-    return `${changed.channel}:${changed.message?.thread_ts ?? changed.message?.ts ?? eventId}`;
-  }
-
-  if (
-    event.type === "message" &&
-    (event as SlackMessageDeletedEvent).subtype === "message_deleted"
-  ) {
-    const deleted = event as SlackMessageDeletedEvent;
-    return `${deleted.channel}:${deleted.previous_message?.thread_ts ?? deleted.deleted_ts ?? eventId}`;
-  }
-
-  const message = event as
-    | SlackAppMentionEvent
-    | SlackDirectMessageEvent
-    | SlackChannelMessageEvent;
-  return `${message.channel}:${message.thread_ts ?? message.ts ?? eventId}`;
 }

--- a/gateway/src/slack/event-ordering.ts
+++ b/gateway/src/slack/event-ordering.ts
@@ -4,8 +4,7 @@ import type {
   SlackDirectMessageEvent,
   SlackMessageChangedEvent,
   SlackMessageDeletedEvent,
-  SlackReactionAddedEvent,
-  SlackReactionRemovedEvent,
+  SlackReactionEvent,
 } from "./normalize.js";
 
 /** The Slack event shapes that flow through ordered normalization. */
@@ -15,8 +14,7 @@ export type SlackOrderableEvent =
   | SlackChannelMessageEvent
   | SlackMessageChangedEvent
   | SlackMessageDeletedEvent
-  | SlackReactionAddedEvent
-  | SlackReactionRemovedEvent;
+  | SlackReactionEvent;
 
 /**
  * Ordering key that groups related Slack events onto a single sequential lane,
@@ -34,9 +32,7 @@ export function slackEventOrderingKey(
   eventId: string,
 ): string {
   if (event.type === "reaction_added" || event.type === "reaction_removed") {
-    const reaction = event as
-      | SlackReactionAddedEvent
-      | SlackReactionRemovedEvent;
+    const reaction = event as SlackReactionEvent;
     return `${reaction.item?.channel ?? eventId}:${reaction.item?.ts ?? eventId}`;
   }
 

--- a/gateway/src/slack/event-text.test.ts
+++ b/gateway/src/slack/event-text.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from "bun:test";
 
-import { slackEventText, type SlackTextBearingEvent } from "./event-text.js";
+import { slackEventText } from "./event-text.js";
+import type { SlackInboundEvent } from "./envelope.js";
 
 // The static types declare `text` as a string, but Socket Mode payloads are
 // untrusted — a non-string reaches this code at runtime. Cast through unknown
 // to model that in the tests.
-function asEvent(value: unknown): SlackTextBearingEvent {
-  return value as SlackTextBearingEvent;
+function asEvent(value: unknown): SlackInboundEvent {
+  return value as SlackInboundEvent;
 }
 
 describe("slackEventText", () => {

--- a/gateway/src/slack/event-text.ts
+++ b/gateway/src/slack/event-text.ts
@@ -4,8 +4,7 @@ import type {
   SlackDirectMessageEvent,
   SlackMessageChangedEvent,
   SlackMessageDeletedEvent,
-  SlackReactionAddedEvent,
-  SlackReactionRemovedEvent,
+  SlackReactionEvent,
 } from "./normalize.js";
 
 /** The Slack event shapes that flow through text extraction. */
@@ -15,8 +14,7 @@ export type SlackTextBearingEvent =
   | SlackChannelMessageEvent
   | SlackMessageChangedEvent
   | SlackMessageDeletedEvent
-  | SlackReactionAddedEvent
-  | SlackReactionRemovedEvent;
+  | SlackReactionEvent;
 
 /**
  * Extract the user-authored text from a Slack event for mention/channel label

--- a/gateway/src/slack/event-text.ts
+++ b/gateway/src/slack/event-text.ts
@@ -1,20 +1,5 @@
-import type {
-  SlackAppMentionEvent,
-  SlackChannelMessageEvent,
-  SlackDirectMessageEvent,
-  SlackMessageChangedEvent,
-  SlackMessageDeletedEvent,
-  SlackReactionEvent,
-} from "./normalize.js";
-
-/** The Slack event shapes that flow through text extraction. */
-export type SlackTextBearingEvent =
-  | SlackAppMentionEvent
-  | SlackDirectMessageEvent
-  | SlackChannelMessageEvent
-  | SlackMessageChangedEvent
-  | SlackMessageDeletedEvent
-  | SlackReactionEvent;
+import type { SlackInboundEvent } from "./envelope.js";
+import { classifySlackEvent } from "./classify-event.js";
 
 /**
  * Extract the user-authored text from a Slack event for mention/channel label
@@ -27,15 +12,21 @@ export type SlackTextBearingEvent =
  * path before the tolerant normalizer ever runs. Returning a string (or
  * undefined) keeps that path crash-safe.
  */
-export function slackEventText(
-  event: SlackTextBearingEvent,
-): string | undefined {
-  const raw =
-    event.type === "message" &&
-    (event as SlackMessageChangedEvent).subtype === "message_changed"
-      ? (event as SlackMessageChangedEvent).message?.text
-      : event.type === "app_mention" || event.type === "message"
-        ? (event as SlackAppMentionEvent | SlackDirectMessageEvent).text
-        : undefined;
+export function slackEventText(event: SlackInboundEvent): string | undefined {
+  const classified = classifySlackEvent(event);
+  let raw: unknown;
+  switch (classified?.kind) {
+    // The edited body lives on the inner `message`, not the top level.
+    case "message_changed":
+      raw = classified.event.message?.text;
+      break;
+    case "app_mention":
+    case "message":
+      raw = classified.event.text;
+      break;
+    // message_deleted / reactions carry no user-authored text to resolve.
+    default:
+      raw = undefined;
+  }
   return typeof raw === "string" ? raw : undefined;
 }

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -984,11 +984,12 @@ const slackReactionEventSchema = z.object({
   item_user: optionalString(),
   event_ts: optionalString(),
 });
-type SlackReactionEvent = z.infer<typeof slackReactionEventSchema>;
-
-/** Kept for `socket-mode.ts`'s narrowing casts; both are one payload shape. */
-export type SlackReactionAddedEvent = SlackReactionEvent;
-export type SlackReactionRemovedEvent = SlackReactionEvent;
+/**
+ * Slack `reaction_added` / `reaction_removed` share this one payload shape;
+ * the add-vs-remove distinction is the runtime `type` discriminator (and the
+ * explicit `op` the caller passes), not the type.
+ */
+export type SlackReactionEvent = z.infer<typeof slackReactionEventSchema>;
 
 // Compile-time cross-check against the official Slack event types, via the
 // shared `webhook-crosscheck` helpers. `@slack/types` is a types-only

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -41,7 +41,7 @@ import {
   type SlackChannelMessageEvent,
   type SlackMessageChangedEvent,
   type SlackMessageDeletedEvent,
-  type SlackReactionAddedEvent,
+  type SlackReactionEvent,
   type NormalizedSlackEvent,
   type SlackTextRenderContext,
 } from "./normalize.js";
@@ -526,7 +526,7 @@ export class SlackSocketModeClient {
    * reaction_removed share this filter; the daemon dispatches by callbackData
    * prefix.
    */
-  private admitReaction(event: SlackReactionAddedEvent): boolean {
+  private admitReaction(event: SlackReactionEvent): boolean {
     const targetChannel = event.item?.channel;
     return (
       !!event.item?.ts &&


### PR DESCRIPTION
## Prompt / plan

Two related type-cleanups following the classifier refactor (#39013), kept in one PR since they touch the same event-typing surface. Both remove redundant type machinery rather than paper over it — "use the types we have; don't redefine them."

### 1. Use `SlackReactionEvent` directly instead of add/remove aliases

The #39013 review flagged that `admitReaction` was typed `SlackReactionAddedEvent` while `reaction_removed` also flowed through it. Rather than widen it to `SlackReactionAddedEvent | SlackReactionRemovedEvent` — which is `SlackReactionEvent | SlackReactionEvent` — this fixes the root redundancy:

- `reaction_added` and `reaction_removed` carry an **identical** payload; the add-vs-remove distinction is the runtime `type` discriminator (and the explicit `op` the normalizer takes), not the type. Both aliases were literally `= SlackReactionEvent`.
- Export the real `SlackReactionEvent` (was private), drop the two aliases, and use it directly across the dispatch, classifier, envelope union, and the ordering/text event unions. The `@slack/types` cross-check already asserted against `SlackReactionEvent`, unchanged.

### 2. Route `event-ordering` / `event-text` through the classifier

`slackEventOrderingKey` and `slackEventText` each re-implemented the `type`/`subtype` narrowing with their **own** `event as Slack*Event` casts, duplicating what `classifySlackEvent` already does. Route both through the classifier and switch on `kind`, so the narrowing casts live only in the classifier (the single guarded seam) and these helpers carry none. Their redundant local `SlackOrderableEvent` / `SlackTextBearingEvent` unions (both just `SlackInboundEvent`) are dropped in favor of `SlackInboundEvent`.

The one remaining guarded cast inside `classifySlackEvent` is kept intentionally — it's the single narrowing seam (a shared-discriminator union → member always needs one assertion; even a type guard is a relocated cast), guarded by the `type`/`subtype` check and covered by tests.

### Why it's safe

Pure type-level / structural refactor. The reaction aliases were structurally identical, and the helper refactor is behavior-preserving — the ordering/text suites (including the malformed-event crash-safety cases) pass unchanged. No schema, routing, or output change.

## Test plan

- `bun test src/slack/ src/__tests__/slack-socket-mode-thread-tracking.test.ts src/__tests__/slack-socket-mode-catchup.test.ts src/__tests__/slack-reaction-normalize.test.ts` — **239 pass**.
- `tsc` (clean on touched files; remaining errors are pre-existing voice/websocket buffer-type issues on `main`), `eslint`, `prettier` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f