### PR TITLE
fix(providers): send prompt_cache_key for implicit-caching OpenAI models

### DIFF
--- a/assistant/src/__tests__/openai-responses-prompt-cache.test.ts
+++ b/assistant/src/__tests__/openai-responses-prompt-cache.test.ts
@@ -1,10 +1,12 @@
 /**
- * Explicit prompt-cache breakpoint placement for GPT-5.6+ on the OpenAI
- * Responses transport: request-wide `prompt_cache_options`/`prompt_cache_key`
- * emission, block-level `prompt_cache_breakpoint` anchor placement (turn-start
- * / previous-turn / advancing tail, mirroring the Anthropic client), the
- * `disableCache` explicit-mode-with-zero-markers opt-out, and the unflagged-
- * model regression guard.
+ * Prompt caching on the OpenAI Responses transport: request-wide
+ * `prompt_cache_key` emission for every direct-API model (routing affinity for
+ * implicit-mode models, opt-in explicit mode for breakpoint-capable ones),
+ * explicit `prompt_cache_options` and block-level `prompt_cache_breakpoint`
+ * anchor placement for GPT-5.6+ (turn-start / previous-turn / advancing tail,
+ * mirroring the Anthropic client), the `disableCache`
+ * explicit-mode-with-zero-markers opt-out, and the unflagged-model and Codex
+ * regression guards.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -339,15 +341,33 @@ describe("OpenAIResponsesProvider explicit prompt caching (GPT-5.6+)", () => {
     expect(breakpointedItemIndexes()).toEqual([0]);
   });
 
-  test("unflagged model sends no cache params at all", async () => {
+  test("unflagged model sends the cache key for routing affinity but no explicit mode or breakpoints", async () => {
     const provider = makeProvider("gpt-5.5");
     await provider.sendMessage(
       [userMsg("t1"), assistantMsg("r1"), userMsg("t2")],
       { config: { mutableLatestUserMessage: true, promptCacheKey: "conv-1" } },
     );
 
+    // Implicit-caching models still get a stable prompt_cache_key so OpenAI's
+    // cache router keeps a conversation on the same shard, but they never opt
+    // into explicit mode or carry block-level breakpoints.
+    expect(lastStreamParams?.prompt_cache_key).toBe("conv-1");
     expect(lastStreamParams?.prompt_cache_options).toBeUndefined();
+    expect(JSON.stringify(lastStreamParams?.input)).not.toContain(
+      "prompt_cache_breakpoint",
+    );
+  });
+
+  test("unflagged model with no key sends no cache params at all", async () => {
+    const provider = makeProvider("gpt-5.5");
+    await provider.sendMessage([
+      userMsg("t1"),
+      assistantMsg("r1"),
+      userMsg("t2"),
+    ]);
+
     expect(lastStreamParams?.prompt_cache_key).toBeUndefined();
+    expect(lastStreamParams?.prompt_cache_options).toBeUndefined();
     expect(JSON.stringify(lastStreamParams?.input)).not.toContain(
       "prompt_cache_breakpoint",
     );

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -254,6 +254,18 @@ export class OpenAIResponsesProvider implements Provider {
         );
       }
 
+      // A per-conversation prompt-cache key gives OpenAI's cache router a
+      // stable affinity key so a conversation's requests land on the same
+      // cache shard. Every model on the direct API receives it — both
+      // breakpoint-capable models (which additionally opt into explicit mode
+      // below) and implicit-mode models, which carry no explicit breakpoints
+      // yet still gain prefix-cache routing affinity from a stable key. The
+      // Codex subscription endpoint rejects extra params, so it is skipped
+      // there.
+      if (!this.codexSubscription && promptCacheKey) {
+        params.prompt_cache_key = promptCacheKey;
+      }
+
       // Explicit prompt-cache mode (GPT-5.6+ semantics, direct API only).
       // Explicit mode disables the implicit latest-message breakpoint — under
       // implicit mode a volatile latest user message (mutableLatestUserMessage)
@@ -264,15 +276,12 @@ export class OpenAIResponsesProvider implements Provider {
       // breakpoints neither uses the cache nor incurs cache-write charges,
       // which is exactly the opt-out `disableCache` wants (omitting the param
       // would re-enable implicit mode). The Codex subscription endpoint
-      // rejects extra params, so cache params are skipped entirely there.
+      // rejects extra params, so these params are skipped entirely there.
       if (
         !this.codexSubscription &&
         PROMPT_CACHE_BREAKPOINT_MODEL_IDS.has(effectiveModel)
       ) {
         params.prompt_cache_options = { mode: "explicit" };
-        if (promptCacheKey) {
-          params.prompt_cache_key = promptCacheKey;
-        }
         if (!disableCache) {
           this.applyPromptCacheBreakpoints(input, {
             mutableLatestUserMessage,


### PR DESCRIPTION
## Why

Production telemetry (Jul 8–22) shows OpenAI Responses-API models without explicit-breakpoint support suffering severe prefix-cache miss rates on agentic loops:

- **gpt-5.5 mainAgent turns average ~156k genuinely-uncached input tokens per turn** (vs ~35k fresh tokens/turn on healthy cached paths — Anthropic explicit caching and Fireworks implicit caching). gpt-5.4 shows ~74k.
- The gpt-5.x mainAgent slices cost ~$2.1k over that 15-day window; a large share of the uncached volume is preventable prefix-cache misses.

Mechanism: `prompt_cache_key` was only sent inside the `PROMPT_CACHE_BREAKPOINT_MODEL_IDS` gate, so implicit-caching models (gpt-5.5/5.4 and earlier) sent **no cache-affinity key at all**. OpenAI's implicit cache routes on a hash of the prompt prefix + key; without a stable per-conversation key, consecutive tool-loop iterations spread across cache shards and long prefixes re-bill at full price.

## What

`prompt_cache_key` (already derived per-conversation by the retry layer) is now sent for **all** direct-API Responses requests when available. Explicit cache mode and breakpoint stamping remain gated to breakpoint-capable models exactly as before. The Codex subscription endpoint (rejects extra params) is unchanged.

Non-goals: OpenRouter paths are untouched (non-breakpoint OpenRouter models use the chat-completions transport where no key is derived); other providers unchanged.

## Verification

- 106 tests pass across the 4 Responses-provider suites; new cases assert (1) implicit-mode model + key → `prompt_cache_key` present, no `prompt_cache_options`, no breakpoints; (2) no key → all absent; (3) codex subscription → neither.
- `bun run typecheck:fast`, `bun run lint` clean.
- Post-deploy check: `telemetry.llm_usage_raw` — expect gpt-5.5/5.4 mainAgent per-event `input_tokens` to drop and `cache_read_input_tokens` share to rise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->