### PR TITLE
fix(access-request): render a leave-unverified park as neutral, not "Denied"

### DIFF
--- a/assistant/docs/trusted-contact-access.md
+++ b/assistant/docs/trusted-contact-access.md
@@ -119,6 +119,8 @@ The two outcomes differ on re-contact. Suppression of re-prompting keys off the 
 - `leave_unverified` → `unverified` contact: a neutral park, **not** kept out. If the contact later does something that needs trust — e.g. DMs on a `trusted_contacts` channel — the deny-path flow **re-fires** (self-verify challenge + a fresh guardian card), so the guardian decides afresh. The guardian's way to stop the prompts is to `block`.
 - `block` → `revoked` contact: a durable keep-out. Re-contact is suppressed (no challenge, no guardian notification) on every floor.
 
+The resolved approval card mirrors this distinction on every surface (in-app, Slack): a `leave_unverified` park reads as a neutral **"Left unverified"**, while `block` reads as **"Denied"**. Both share the `denied` request status, so the card presentation is keyed off the decided action, not the status (see `PARK_ACTION_SET` / `isParkAction` in `runtime/channel-approval-types.ts`).
+
 Separately, the admitted-mode introduction **nudge** (for a contact who cleared the floor unclassified) is quieted once the guardian has decided the contact, so a classified contact is not re-nudged across conversations. That is distinct from the deny-path re-fire above.
 
 ### Stage: `expired`

--- a/assistant/src/__tests__/guardian-card-withdrawal.test.ts
+++ b/assistant/src/__tests__/guardian-card-withdrawal.test.ts
@@ -228,6 +228,63 @@ describe("withdrawGuardianRequestCards", () => {
       "Approved",
     );
   });
+
+  test("renders a leave-unverified park neutrally in-app and forwards the action to Slack", async () => {
+    const req = makeRequest({ decidedByExternalUserId: "U-guardian" });
+    bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-1",
+    });
+    bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "slack",
+      destinationChatId: "C1",
+      destinationMessageId: "1.0",
+    });
+
+    await withdrawGuardianRequestCards({
+      request: req,
+      status: "denied",
+      originChannel: "slack",
+      decidedAction: "leave_unverified",
+    });
+
+    // In-app card reads the neutral park label, not "Denied".
+    expect(completeSurfaceAndNotify).toHaveBeenCalledWith(
+      "conv-1",
+      `access-request-${req.id}`,
+      "Left unverified",
+    );
+    // The park action is forwarded so the Slack surface renders it neutrally too.
+    const [params] = withdrawSlackApprovalCard.mock.calls[0];
+    expect(params).toMatchObject({
+      status: "denied",
+      decidedAction: "leave_unverified",
+    });
+  });
+
+  test("a block deny still reads 'Denied' on the in-app card", async () => {
+    const req = makeRequest();
+    bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-1",
+    });
+
+    await withdrawGuardianRequestCards({
+      request: req,
+      status: "denied",
+      originChannel: "slack",
+      decidedAction: "block",
+    });
+
+    expect(completeSurfaceAndNotify).toHaveBeenCalledWith(
+      "conv-1",
+      `access-request-${req.id}`,
+      "Denied",
+    );
+  });
 });
 
 describe("recordApprovalCardDelivery", () => {

--- a/assistant/src/approvals/guardian-card-withdrawal.ts
+++ b/assistant/src/approvals/guardian-card-withdrawal.ts
@@ -30,6 +30,11 @@ import {
 import { completeSurfaceAndNotify } from "../daemon/conversation-surfaces.js";
 import { withdrawSlackApprovalCard } from "../messaging/providers/slack/withdraw.js";
 import { approvalCardSurfaceId } from "../notifications/approval-card-data.js";
+import {
+  type ApprovalAction,
+  isParkAction,
+  PARK_STATUS_LABEL,
+} from "../runtime/channel-approval-types.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("guardian-card-withdrawal");
@@ -41,6 +46,21 @@ const SURFACE_STATUS_LABELS: Partial<Record<GuardianRequestStatus, string>> = {
   expired: "Expired",
   cancelled: "Cancelled",
 };
+
+/**
+ * The completion-summary label for a resolved card. A `denied` status reached by
+ * a park action reads as the neutral {@link PARK_STATUS_LABEL} rather than
+ * "Denied" — a parked contact was neither trusted nor kept out.
+ */
+function resolveStatusLabel(
+  status: GuardianRequestStatus,
+  decidedAction: ApprovalAction | undefined,
+): string {
+  if (status === "denied" && isParkAction(decidedAction)) {
+    return PARK_STATUS_LABEL;
+  }
+  return SURFACE_STATUS_LABELS[status] ?? "Resolved";
+}
 
 /** The request fields withdrawal reads — structural subset of the wire row. */
 export interface WithdrawableGuardianRequest {
@@ -64,6 +84,14 @@ export interface WithdrawGuardianCardsParams {
    * sweep) to withdraw every surface.
    */
   originChannel?: string;
+  /**
+   * The action the guardian took, when the terminal status came from a decision
+   * (omitted for the expiry sweep). A `denied` status can mean either a neutral
+   * park (`leave_unverified`) or an active rejection (`block`/`reject`); the
+   * action disambiguates them so a park renders neutrally as
+   * {@link PARK_STATUS_LABEL} instead of "Denied".
+   */
+  decidedAction?: ApprovalAction;
 }
 
 /**
@@ -73,7 +101,7 @@ export interface WithdrawGuardianCardsParams {
 export async function withdrawGuardianRequestCards(
   params: WithdrawGuardianCardsParams,
 ): Promise<void> {
-  const { request, status, originChannel } = params;
+  const { request, status, originChannel, decidedAction } = params;
 
   let deliveries: GuardianRequestDeliveryWire[];
   try {
@@ -89,9 +117,15 @@ export async function withdrawGuardianRequestCards(
   for (const delivery of deliveries) {
     try {
       if (delivery.destinationChannel === "vellum") {
-        withdrawVellumCard(request, delivery, status, originChannel);
+        withdrawVellumCard(
+          request,
+          delivery,
+          status,
+          originChannel,
+          decidedAction,
+        );
       } else if (delivery.destinationChannel === "slack") {
-        await withdrawSlackCard(request, delivery, status);
+        await withdrawSlackCard(request, delivery, status, decidedAction);
       }
       // Telegram/WhatsApp direct delivery can't edit a message in place (it
       // would post a new one), so their stale clicks are left to the existing
@@ -119,15 +153,22 @@ function withdrawVellumCard(
   delivery: GuardianRequestDeliveryWire,
   status: GuardianRequestStatus,
   originChannel: string | undefined,
+  decidedAction: ApprovalAction | undefined,
 ): void {
-  if (originChannel === "vellum") return;
-  if (!delivery.destinationConversationId) return;
+  if (originChannel === "vellum") {
+    return;
+  }
+  if (!delivery.destinationConversationId) {
+    return;
+  }
   const surfaceId = approvalCardSurfaceId(request.kind, request.id);
-  if (!surfaceId) return;
+  if (!surfaceId) {
+    return;
+  }
   completeSurfaceAndNotify(
     delivery.destinationConversationId,
     surfaceId,
-    SURFACE_STATUS_LABELS[status] ?? "Resolved",
+    resolveStatusLabel(status, decidedAction),
   );
 }
 
@@ -140,12 +181,16 @@ async function withdrawSlackCard(
   request: WithdrawableGuardianRequest,
   delivery: GuardianRequestDeliveryWire,
   status: GuardianRequestStatus,
+  decidedAction: ApprovalAction | undefined,
 ): Promise<void> {
-  if (!delivery.destinationChatId || !delivery.destinationMessageId) return;
+  if (!delivery.destinationChatId || !delivery.destinationMessageId) {
+    return;
+  }
   await withdrawSlackApprovalCard({
     channel: delivery.destinationChatId,
     messageTs: delivery.destinationMessageId,
     status,
+    ...(decidedAction ? { decidedAction } : {}),
     decidedByExternalUserId: request.decidedByExternalUserId ?? undefined,
     decidedAtMs: request.updatedAt,
   });

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -450,7 +450,9 @@ export async function applyGuardianDecision(
       actor: actorContext,
       channelDeliveryContext,
       emissionContext,
-      ...(decided.mintedSession ? { mintedSession: decided.mintedSession } : {}),
+      ...(decided.mintedSession
+        ? { mintedSession: decided.mintedSession }
+        : {}),
     });
 
     if (!resolverResult.ok) {
@@ -510,6 +512,7 @@ export async function applyGuardianDecision(
     request: resolved,
     status: targetStatus,
     originChannel: actorContext.channel,
+    decidedAction: effectiveAction,
   }).catch((err) => {
     log.warn(
       { err, requestId },

--- a/assistant/src/messaging/providers/slack/withdraw.test.ts
+++ b/assistant/src/messaging/providers/slack/withdraw.test.ts
@@ -228,4 +228,38 @@ describe("withdrawSlackApprovalCard", () => {
       callSlackApi.mock.calls.some((c) => c[0] === "chat.postMessage"),
     ).toBe(false);
   });
+
+  test("renders a leave-unverified park neutrally as 'Left unverified', not a denial", async () => {
+    getSlackMessageBlocks.mockImplementationOnce(async () => null);
+
+    await withdrawSlackApprovalCard({
+      channel: "C1",
+      messageTs: "1.0",
+      status: "denied",
+      decidedAction: "leave_unverified",
+    });
+
+    const serialized = JSON.stringify(callSlackApi.mock.calls[0][1].blocks);
+    // A park is a neutral hold — the card must not read as a denial.
+    expect(serialized).toContain("Left unverified");
+    expect(serialized).not.toContain("Denied");
+    expect(serialized).not.toContain(":x:");
+    expect(serialized).toContain(":pause_button:");
+  });
+
+  test("a block deny still renders as 'Denied' with the denial glyph", async () => {
+    getSlackMessageBlocks.mockImplementationOnce(async () => null);
+
+    await withdrawSlackApprovalCard({
+      channel: "C1",
+      messageTs: "1.0",
+      status: "denied",
+      decidedAction: "block",
+    });
+
+    const serialized = JSON.stringify(callSlackApi.mock.calls[0][1].blocks);
+    expect(serialized).toContain("Denied");
+    expect(serialized).toContain(":x:");
+    expect(serialized).not.toContain("Left unverified");
+  });
 });

--- a/assistant/src/messaging/providers/slack/withdraw.ts
+++ b/assistant/src/messaging/providers/slack/withdraw.ts
@@ -15,6 +15,10 @@
  * back to editing the message down to a status-only block — still an edit.
  */
 
+import {
+  isParkAction,
+  PARK_STATUS_LABEL,
+} from "../../../runtime/channel-approval-types.js";
 import { getLogger } from "../../../util/logger.js";
 import { callSlackApi, getSlackMessageBlocks } from "./api.js";
 
@@ -49,6 +53,13 @@ const STATUS_WORD: Record<string, string> = {
   cancelled: "Cancelled",
 };
 
+/**
+ * Glyph for a parked (leave-unverified) decision. A neutral "on hold" mark
+ * rather than the `denied` red cross — the sender was neither trusted nor kept
+ * out, just left at `unverified`.
+ */
+const PARK_STATUS_GLYPH = ":pause_button:";
+
 export interface WithdrawSlackApprovalCardParams {
   /** Channel/DM id the approval message lives in. */
   channel: string;
@@ -56,6 +67,13 @@ export interface WithdrawSlackApprovalCardParams {
   messageTs: string;
   /** Terminal status of the request (e.g. "approved", "denied", "expired"). */
   status: string;
+  /**
+   * The action the guardian took, when known. A `denied` status reached by a
+   * park action (`leave_unverified`) reads as the neutral
+   * {@link PARK_STATUS_LABEL} rather than "Denied"; `block`/`reject` stay a
+   * denial. Omitted for status-only transitions (e.g. the expiry sweep).
+   */
+  decidedAction?: string;
   /** Slack user id of the decider, when the decision came from Slack. */
   decidedByExternalUserId?: string;
   /** Decision time (epoch ms) for the audit line. */
@@ -67,8 +85,11 @@ export interface WithdrawSlackApprovalCardParams {
  * Uses Slack's `<!date>` token so the time renders in each viewer's timezone.
  */
 function buildStatusText(params: WithdrawSlackApprovalCardParams): string {
-  const glyph = STATUS_GLYPH[params.status] ?? "";
-  const word = STATUS_WORD[params.status] ?? "Resolved";
+  const park = params.status === "denied" && isParkAction(params.decidedAction);
+  const glyph = park ? PARK_STATUS_GLYPH : (STATUS_GLYPH[params.status] ?? "");
+  const word = park
+    ? PARK_STATUS_LABEL
+    : (STATUS_WORD[params.status] ?? "Resolved");
   let line = glyph ? `${glyph} *${word}*` : `*${word}*`;
   if (params.decidedByExternalUserId) {
     line += ` by <@${params.decidedByExternalUserId}>`;

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -81,6 +81,28 @@ export const DENYING_ACTION_SET: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * The denying actions that *park* the sender at `unverified` — a neutral hold,
+ * not an active rejection. A parked contact is still admitted under the
+ * permissive admission floors (`any_contact`, `strangers`) and can be trusted
+ * or verified later; contrast `block` (→ revoked, a hard keep-out) and `reject`
+ * (an explicit decline). Both resolve the request to `denied`, so the terminal
+ * status alone can't tell a park from a rejection — surfaces that present the
+ * resolved card consult this to render a park neutrally (see
+ * {@link PARK_STATUS_LABEL}) instead of as a denial.
+ */
+export const PARK_ACTION_SET: ReadonlySet<string> = new Set([
+  "leave_unverified",
+]);
+
+/** Completed-card label shown for a parked (leave-unverified) decision. */
+export const PARK_STATUS_LABEL = "Left unverified";
+
+/** True when `action` parks the sender at `unverified` (a neutral hold). */
+export function isParkAction(action: string | undefined): boolean {
+  return action !== undefined && PARK_ACTION_SET.has(action);
+}
+
+/**
  * Map `GuardianDecisionAction[]` to `ApprovalActionOption[]` so channel
  * prompt payloads can be derived from the unified decision action set.
  * The `action` field from GuardianDecisionAction maps to the `id` field

--- a/clients/web/src/domains/chat/completion-tone.test.ts
+++ b/clients/web/src/domains/chat/completion-tone.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  guardianDecisionTone,
+  inferCompletionTone,
+} from "@/domains/chat/completion-tone";
+
+describe("guardianDecisionTone", () => {
+  it("marks a leave-unverified park as neutral, not a denial", () => {
+    // A park holds the contact at `unverified` — neither trusted nor kept out —
+    // so its completed card must not show the red rejection cross.
+    expect(
+      guardianDecisionTone("apr:req1:leave_unverified", { applied: true }),
+    ).toBe("neutral");
+  });
+
+  it("marks block and reject as danger", () => {
+    expect(guardianDecisionTone("apr:req1:block", { applied: true })).toBe(
+      "danger",
+    );
+    expect(guardianDecisionTone("apr:req1:reject", { applied: true })).toBe(
+      "danger",
+    );
+  });
+
+  it("marks approve and trust as success", () => {
+    expect(
+      guardianDecisionTone("apr:req1:approve_once", { applied: true }),
+    ).toBe("success");
+    expect(guardianDecisionTone("apr:req1:trust", { applied: true })).toBe(
+      "success",
+    );
+  });
+
+  it("marks a decision that didn't apply as neutral regardless of action", () => {
+    expect(guardianDecisionTone("apr:req1:block", { applied: false })).toBe(
+      "neutral",
+    );
+    expect(
+      guardianDecisionTone("apr:req1:approve_once", { applied: false }),
+    ).toBe("neutral");
+  });
+
+  it("reads the action from a bare id without the apr: prefix", () => {
+    expect(guardianDecisionTone("leave_unverified", { applied: true })).toBe(
+      "neutral",
+    );
+  });
+});
+
+describe("inferCompletionTone", () => {
+  it("reads the 'Left unverified' park label as neutral", () => {
+    expect(inferCompletionTone("Left unverified")).toBe("neutral");
+  });
+
+  it("reads the guardian park reply as neutral", () => {
+    expect(inferCompletionTone("Alice will stay unverified.")).toBe("neutral");
+  });
+
+  it("reads denial labels as danger", () => {
+    expect(inferCompletionTone("Denied")).toBe("danger");
+    expect(inferCompletionTone("Blocked")).toBe("danger");
+  });
+
+  it("reads voided terminal labels as neutral", () => {
+    expect(inferCompletionTone("Expired")).toBe("neutral");
+    expect(inferCompletionTone("Cancelled")).toBe("neutral");
+  });
+
+  it("keeps ordinary completed cards affirmative", () => {
+    expect(inferCompletionTone("Approved")).toBe("success");
+    expect(inferCompletionTone(undefined)).toBe("success");
+  });
+});

--- a/clients/web/src/domains/chat/completion-tone.ts
+++ b/clients/web/src/domains/chat/completion-tone.ts
@@ -1,0 +1,88 @@
+/**
+ * Completion tone for a resolved surface card — the icon + color shown once a
+ * card is done. One tone is derived two ways that must agree:
+ *
+ * - {@link guardianDecisionTone} from the action the guardian took (the
+ *   optimistic path, where the client knows the action it just submitted), and
+ * - {@link inferCompletionTone} from the completion summary string (the SSE
+ *   `ui_surface_complete` path and history-restored cards, which carry only the
+ *   label).
+ *
+ * Keeping both here makes their agreement explicit: a `leave_unverified` park
+ * and its "Left unverified" summary both resolve to `neutral`; a `block`/deny
+ * and its "Denied"/"Blocked" summary both resolve to `danger`.
+ */
+
+import type { SurfaceCompletionTone } from "@/domains/chat/types/types";
+
+/** Guardian-decision actions that resolve a request to a denied state. */
+const DENY_DECISION_ACTIONS: ReadonlySet<string> = new Set([
+  "reject",
+  "leave_unverified",
+  "block",
+]);
+
+/**
+ * Denying actions that *park* the contact at `unverified` — a neutral hold, not
+ * an active rejection. Mirrors the daemon's `PARK_ACTION_SET`: a parked contact
+ * is neither trusted nor kept out, so the card reads neutral. `block`/`reject`
+ * stay `danger`.
+ */
+const PARK_DECISION_ACTIONS: ReadonlySet<string> = new Set(["leave_unverified"]);
+
+/** Action segment of an `apr:<requestId>:<action>` guardian-decision id. */
+function guardianDecisionAction(actionId: string): string {
+  return actionId.startsWith("apr:")
+    ? actionId.split(":").slice(2).join(":")
+    : actionId;
+}
+
+/**
+ * Completion tone for a guardian decision (apr:*): a decision that didn't apply
+ * (already resolved, expired, …) is a neutral non-affirmative state; an applied
+ * park (leave-unverified) is also neutral (the contact is held, not rejected);
+ * an applied deny/block is a rejection (danger); an applied approve/trust is a
+ * success. This keeps the completed card's icon from showing an affirmative
+ * green check on a denial, or a red rejection cross on a neutral park.
+ */
+export function guardianDecisionTone(
+  actionId: string,
+  result: { applied?: boolean },
+): SurfaceCompletionTone {
+  if (result.applied === false) {
+    return "neutral";
+  }
+  const action = guardianDecisionAction(actionId);
+  if (PARK_DECISION_ACTIONS.has(action)) {
+    return "neutral";
+  }
+  return DENY_DECISION_ACTIONS.has(action) ? "danger" : "success";
+}
+
+/**
+ * Infer a completion tone from the summary text. Used when no explicit
+ * `completionTone` was set (the SSE `ui_surface_complete` path and
+ * history-restored surfaces carry only the summary string). Covers the daemon's
+ * terminal-status labels ("Denied", "Left unverified", "Expired", …) and the
+ * guardian-decision reason labels; anything unrecognized stays `success` so
+ * ordinary completed cards keep their affirmative check.
+ */
+export function inferCompletionTone(
+  summary: string | undefined,
+): SurfaceCompletionTone {
+  if (!summary) {
+    return "success";
+  }
+  const s = summary.toLowerCase();
+  if (/denied|declined|rejected|blocked/.test(s)) {
+    return "danger";
+  }
+  if (
+    /unverified|expired|cancel|timed out|resolved|not applied|not authorized|not found|failed/.test(
+      s,
+    )
+  ) {
+    return "neutral";
+  }
+  return "success";
+}

--- a/clients/web/src/domains/chat/components/surfaces/surface-container.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-container.tsx
@@ -2,6 +2,7 @@ import { CheckCircle, CircleSlash, Loader2, XCircle } from "lucide-react";
 import { type ComponentType, type ReactNode, useState } from "react";
 
 import { Button } from "@vellumai/design-library";
+import { inferCompletionTone } from "@/domains/chat/completion-tone";
 import type { Surface, SurfaceCompletionTone } from "@/domains/chat/types/types";
 import { cn } from "@/utils/misc";
 
@@ -18,7 +19,7 @@ interface SurfaceContainerProps {
  * Icon + color for each completion tone. `success` is the affirmative green
  * check; `danger` is a red rejection glyph (denied / blocked); `neutral` is a
  * muted "voided" glyph for terminal states that are not a success and not an
- * active rejection (expired / cancelled / timed out).
+ * active rejection (left unverified / expired / cancelled / timed out).
  */
 const COMPLETION_TONE_STYLE: Record<
   SurfaceCompletionTone,
@@ -37,24 +38,6 @@ const COMPLETION_TONE_STYLE: Record<
     colorClass: "text-[var(--content-quiet)]",
   },
 };
-
-/**
- * Infer a completion tone from the summary text. Used when no explicit
- * `completionTone` was set (the SSE `ui_surface_complete` path and
- * history-restored surfaces carry only the summary string). Covers the
- * daemon's terminal-status labels ("Denied", "Expired", "Cancelled", …) and
- * the guardian-decision reason labels; anything unrecognized stays `success`
- * so ordinary completed cards keep their affirmative check.
- */
-function inferCompletionTone(summary: string | undefined): SurfaceCompletionTone {
-  if (!summary) {return "success";}
-  const s = summary.toLowerCase();
-  if (/denied|declined|rejected|blocked/.test(s)) {return "danger";}
-  if (/expired|cancel|timed out|resolved|not applied|not authorized|not found|failed/.test(s)) {
-    return "neutral";
-  }
-  return "success";
-}
 
 export function SurfaceContainer({ surface, onAction, hideTitle, className, children }: SurfaceContainerProps) {
   const [submittingAction, setSubmittingAction] = useState<string | null>(null);

--- a/clients/web/src/domains/chat/surface-actions.ts
+++ b/clients/web/src/domains/chat/surface-actions.ts
@@ -20,10 +20,8 @@ import { useStreamStore } from "@/domains/chat/stream-store";
 import { useTurnStore } from "@/domains/chat/turn-store";
 import { completeSubmittedSurface } from "@/domains/chat/utils/send-message-utils";
 import { submitSurfaceAction } from "@/domains/chat/api/surfaces";
-import type {
-  DisplayMessage,
-  SurfaceCompletionTone,
-} from "@/domains/chat/types/types";
+import { guardianDecisionTone } from "@/domains/chat/completion-tone";
+import type { DisplayMessage } from "@/domains/chat/types/types";
 
 // Guardian-decision failure reasons (applied === false) → guardian-facing
 // label. Covers every reason `processGuardianDecision` can return; anything
@@ -45,37 +43,6 @@ function formatDecisionReason(reason?: string): string {
   return DECISION_REASON_LABELS[reason] ?? "Not applied";
 }
 
-/** Guardian-decision actions that resolve a request to a denied state. */
-const DENY_DECISION_ACTIONS: ReadonlySet<string> = new Set([
-  "reject",
-  "leave_unverified",
-  "block",
-]);
-
-/** Action segment of an `apr:<requestId>:<action>` guardian-decision id. */
-function guardianDecisionAction(actionId: string): string {
-  return actionId.startsWith("apr:")
-    ? actionId.split(":").slice(2).join(":")
-    : actionId;
-}
-
-/**
- * Completion tone for a guardian decision (apr:*): a decision that didn't apply
- * (already resolved, expired, …) is a neutral non-affirmative state; an applied
- * deny/block is a rejection (danger); an applied approve/trust is a success.
- * This keeps the completed card's icon from showing an affirmative green check
- * on a denial.
- */
-function guardianDecisionTone(
-  actionId: string,
-  result: { applied?: boolean },
-): SurfaceCompletionTone {
-  if (result.applied === false) {return "neutral";}
-  return DENY_DECISION_ACTIONS.has(guardianDecisionAction(actionId))
-    ? "danger"
-    : "success";
-}
-
 /**
  * Funnel telemetry for the first-run greeting's scope options. The
  * `firstRunScope` marker only ever appears on choice-option payloads authored
@@ -86,7 +53,7 @@ function guardianDecisionTone(
  */
 function emitFirstRunScopeTelemetry(data?: Record<string, unknown>): void {
   const scope = data?.[FIRST_RUN_SCOPE_DATA_KEY];
-  if (!isFirstRunScope(scope)) return;
+  if (!isFirstRunScope(scope)) {return;}
   try {
     // Same auth source `active-chat-view.tsx` derives `authUserId` from, read
     // non-reactively; an absent user id emits as null rather than blocking.

--- a/clients/web/src/domains/chat/utils/send-message-utils.test.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.test.ts
@@ -175,7 +175,7 @@ describe("completeSubmittedSurface", () => {
             actions: [
               {
                 id: "apr:req1:leave_unverified",
-                label: "Deny",
+                label: "Leave unverified",
                 style: "secondary",
               },
             ],
@@ -184,14 +184,13 @@ describe("completeSubmittedSurface", () => {
       }),
     ];
 
-    const replyText =
-      "Alice will stay unverified. They won't be able to message the assistant.";
+    const replyText = "Alice will stay unverified.";
     const result = completeSubmittedSurface(
       messages,
       "access-request-req1",
       "apr:req1:leave_unverified",
       replyText,
-      { isGuardianDecision: true, tone: "danger" },
+      { isGuardianDecision: true, tone: "neutral" },
     );
 
     const surface = result[0]!.surfaces![0]!;
@@ -199,7 +198,8 @@ describe("completeSubmittedSurface", () => {
     // The secondary-style button must NOT collapse to "Cancelled" for a
     // guardian decision — the resolver's reply text is preserved.
     expect(surface.completionSummary).toBe(replyText);
-    expect(surface.completionTone).toBe("danger");
+    // A leave-unverified park is a neutral hold, not a denial.
+    expect(surface.completionTone).toBe("neutral");
   });
 });
 


### PR DESCRIPTION
Follow-up to #38960 (LUM-2815), which explicitly deferred this: _"the completed card still labels a leave-unverified park 'Denied'. Fixing that cleanly means threading the decided action through the withdrawal path on every surface plus a neutral tone; kept out of this PR so the behavior change stays focused."_ This is that fix.

## Prompt / plan

#38960 established the model: `leave_unverified` is a neutral **park** at `unverified` (the contact is neither trusted nor kept out, and is still admitted under permissive floors), while `block` is the hard keep-out. But the *resolved card* still presented a park identically to a block — "Denied", red ✕, danger tone — on every surface. This PR makes the card presentation match the model.

The obstacle: a park and a block both resolve the guardian request to the same `denied` status, so the terminal status alone can't tell them apart. The fix threads the **decided action** through the card-withdrawal path and keys the presentation off it.

## Before → after (what the guardian sees)

| Surface | Guardian clicks "Leave unverified" — before | After |
| --- | --- | --- |
| In-app completed card | "Denied" with the red danger ✕ icon | "Left unverified" with the neutral (muted) icon |
| Slack card (edited in place) | `:x: *Denied*` | `:pause_button: *Left unverified*` |
| `block` / `reject`, any surface | "Denied", danger tone | **Unchanged** — still "Denied", danger |
| Expiry sweep / approve / trust | (as before) | **Unchanged** |

## Why it's safe

- **Presentation only.** No decision logic, ACL outcome, admission, or notification changes. A park still resolves the request to `denied` (the existing lifecycle); only how the *resolved card* reads changes.
- **Single source of truth.** `PARK_ACTION_SET` / `isParkAction` / `PARK_STATUS_LABEL` live in `channel-approval-types.ts` and are consumed by both withdrawal surfaces; the web mirrors them in one pure `completion-tone.ts` (web can't import daemon code). A park is `leave_unverified` only — `block` / `reject` stay a denial.
- **Optional threading.** `decidedAction` is optional throughout; the expiry sweep (no action) is untouched → still "Expired".
- **Both directions are pinned by tests** (a park reads neutral; a block/reject still reads as a denial).

## What changed (files)

- `runtime/channel-approval-types.ts` — `PARK_ACTION_SET` / `isParkAction` / `PARK_STATUS_LABEL`.
- `approvals/guardian-decision-primitive.ts` — pass `decidedAction` into card withdrawal.
- `approvals/guardian-card-withdrawal.ts` — in-app card reads "Left unverified" for a park; forwards the action to the Slack surface.
- `messaging/providers/slack/withdraw.ts` — Slack card word + glyph for a park.
- web `domains/chat/completion-tone.ts` (new) — unifies the two tone paths; a park action → neutral, and the "Left unverified" summary reads neutral on the SSE / history path. `surface-actions.ts` + `surface-container.tsx` rewired to it.
- `docs/trusted-contact-access.md` — one-line note that the card mirrors the park / keep-out distinction.

## Test plan

- New `clients/web/src/domains/chat/completion-tone.test.ts`: park → neutral; block / reject → danger; approve / trust → success; not-applied → neutral; the "Left unverified" and "will stay unverified" summaries → neutral; "Denied" / "Blocked" → danger.
- `messaging/providers/slack/withdraw.test.ts`: a park renders "Left unverified" (neutral glyph, no `:x:`); a `block` still renders "Denied" + `:x:`.
- `guardian-card-withdrawal.test.ts`: a park sets the in-app summary "Left unverified" and forwards `decidedAction` to Slack; a `block` still reads "Denied".
- Updated a stale `send-message-utils.test.ts` fixture — a `leave_unverified` decision had been asserting a `danger` tone plus the old inaccurate copy.
- `bunx tsc --noEmit` clean (assistant + web); eslint + prettier clean; pre-commit and pre-push hooks re-verified format + lint + typecheck (incl. the web openapi regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5AUkuGpZ7J15ZjXzgzST4

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5AUkuGpZ7J15ZjXzgzST4)_