### PR TITLE
fix(assistant): materialize historical inline message media

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { eq, like } from "drizzle-orm";
 
 import {
+  attachInlineAttachmentToMessage,
   getAttachmentsForMessage,
   linkAttachmentToMessage,
   uploadAttachment,
@@ -17,8 +18,10 @@ import {
 import {
   addMessage,
   createConversation,
+  deleteConversation,
   forkConversation,
   getMessages,
+  updateMessageContent,
 } from "../persistence/conversation-crud.js";
 import { getConversationDirPath } from "../persistence/conversation-disk-view.js";
 import {
@@ -60,6 +63,8 @@ import {
   MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
   recordInjected as recordV3Injected,
 } from "../plugins/defaults/memory/v3/ever-injected-store.js";
+import { resolveMediaReferences } from "../providers/media-resolve.js";
+import type { ContentBlock } from "../providers/types.js";
 
 await initializeDb();
 
@@ -735,6 +740,122 @@ describe("forkConversation", () => {
     expect(forkJsonl[1]?.attachments).toEqual(["wireframe.png"]);
     expect(getAttachmentsForMessage(sourceAssistant.id)[0]?.id).toBe(
       sourceAttachments[0]?.id,
+    );
+  });
+
+  test("remaps root and nested workspace references to fork-owned attachments", async () => {
+    const source = createConversation("Referenced attachment thread");
+    const sourceMessage = await addMessage(
+      source.id,
+      "assistant",
+      "attachments",
+      { skipIndexing: true },
+    );
+    const rootBytes = Buffer.from("root-image-bytes");
+    const nestedBytes = Buffer.from("nested-file-bytes");
+    const rootAttachment = attachInlineAttachmentToMessage(
+      sourceMessage.id,
+      0,
+      "root.png",
+      "image/png",
+      rootBytes.toString("base64"),
+    );
+    const nestedAttachment = attachInlineAttachmentToMessage(
+      sourceMessage.id,
+      1,
+      "nested.txt",
+      "text/plain",
+      nestedBytes.toString("base64"),
+    );
+    const sourceContent: ContentBlock[] = [
+      {
+        type: "image",
+        source: {
+          type: "workspace_ref",
+          media_type: "image/png",
+          attachmentId: rootAttachment.id,
+          sizeBytes: rootAttachment.sizeBytes,
+        },
+      },
+      {
+        type: "tool_result",
+        tool_use_id: "tool-1",
+        content: "generated file",
+        contentBlocks: [
+          {
+            type: "file",
+            source: {
+              type: "workspace_ref",
+              media_type: "text/plain",
+              attachmentId: nestedAttachment.id,
+              sizeBytes: nestedAttachment.sizeBytes,
+              filename: "nested.txt",
+            },
+          },
+        ],
+      },
+    ];
+    updateMessageContent(sourceMessage.id, JSON.stringify(sourceContent));
+    const sourceDir = getConversationDirPath(source.id, source.createdAt);
+
+    const fork = forkConversation({ conversationId: source.id });
+    const forkMessage = getMessages(fork.id)[0]!;
+    const forkAttachments = getAttachmentsForMessage(forkMessage.id);
+    expect(forkAttachments).toHaveLength(2);
+    const rootBlock = forkMessage.content[0] as Extract<
+      ContentBlock,
+      { type: "image" }
+    >;
+    const toolResult = forkMessage.content[1] as Extract<
+      ContentBlock,
+      { type: "tool_result" }
+    >;
+    const nestedBlock = toolResult.contentBlocks![0] as Extract<
+      ContentBlock,
+      { type: "file" }
+    >;
+    expect(rootBlock.source.type).toBe("workspace_ref");
+    expect(nestedBlock.source.type).toBe("workspace_ref");
+    if (
+      rootBlock.source.type !== "workspace_ref" ||
+      nestedBlock.source.type !== "workspace_ref"
+    ) {
+      throw new Error("expected forked workspace references");
+    }
+    expect(rootBlock.source.attachmentId).toBe(forkAttachments[0]!.id);
+    expect(nestedBlock.source.attachmentId).toBe(forkAttachments[1]!.id);
+    expect(rootBlock.source.attachmentId).not.toBe(rootAttachment.id);
+    expect(nestedBlock.source.attachmentId).not.toBe(nestedAttachment.id);
+
+    deleteConversation(source.id);
+    expect(existsSync(sourceDir)).toBe(false);
+
+    const resolved = resolveMediaReferences([
+      { role: "assistant", content: forkMessage.content },
+    ])[0]!.content;
+    const resolvedRoot = resolved[0] as Extract<
+      ContentBlock,
+      { type: "image" }
+    >;
+    const resolvedToolResult = resolved[1] as Extract<
+      ContentBlock,
+      { type: "tool_result" }
+    >;
+    const resolvedNested = resolvedToolResult.contentBlocks![0] as Extract<
+      ContentBlock,
+      { type: "file" }
+    >;
+    expect(resolvedRoot.source.type).toBe("base64");
+    expect(resolvedNested.source.type).toBe("base64");
+    if (
+      resolvedRoot.source.type !== "base64" ||
+      resolvedNested.source.type !== "base64"
+    ) {
+      throw new Error("expected resolved fork media");
+    }
+    expect(Buffer.from(resolvedRoot.source.data, "base64")).toEqual(rootBytes);
+    expect(Buffer.from(resolvedNested.source.data, "base64")).toEqual(
+      nestedBytes,
     );
   });
 

--- a/assistant/src/__tests__/conversation-fork-retrospective.test.ts
+++ b/assistant/src/__tests__/conversation-fork-retrospective.test.ts
@@ -5,9 +5,8 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { eq } from "drizzle-orm";
 
 import {
+  attachInlineAttachmentToMessage,
   getAttachmentsForMessage,
-  linkAttachmentToMessage,
-  uploadAttachment,
 } from "../persistence/attachments-store.js";
 import { appendCompactionEvent } from "../persistence/compaction-ledger-store.js";
 import {
@@ -16,6 +15,7 @@ import {
   forkConversation,
   forkConversationForRetrospective,
   getMessages,
+  updateMessageContent,
 } from "../persistence/conversation-crud.js";
 import { getConversationDirPath } from "../persistence/conversation-disk-view.js";
 import {
@@ -52,6 +52,7 @@ import {
   findForkBoundaryCreatedAt,
   loadRetrospectiveRunMessages,
 } from "../plugins/defaults/memory/memory-retrospective-fork-boundary.js";
+import type { ContentBlock } from "../providers/types.js";
 
 await initializeDb();
 
@@ -198,8 +199,27 @@ describe("forkConversationForRetrospective", () => {
     const assistant = await addMessage(source.id, "assistant", "see mockup", {
       skipIndexing: true,
     });
-    const uploaded = uploadAttachment("wireframe.png", "image/png", "iVBORw0K");
-    linkAttachmentToMessage(assistant.id, uploaded.id, 0);
+    const sourceAttachment = attachInlineAttachmentToMessage(
+      assistant.id,
+      0,
+      "wireframe.png",
+      "image/png",
+      "iVBORw0K",
+    );
+    updateMessageContent(
+      assistant.id,
+      JSON.stringify([
+        {
+          type: "image",
+          source: {
+            type: "workspace_ref",
+            media_type: "image/png",
+            attachmentId: sourceAttachment.id,
+            sizeBytes: sourceAttachment.sizeBytes,
+          },
+        },
+      ] satisfies ContentBlock[]),
+    );
 
     const asyncFork = await forkConversationForRetrospective({
       conversationId: source.id,
@@ -211,9 +231,16 @@ describe("forkConversationForRetrospective", () => {
     const forkAttachments = getAttachmentsForMessage(forkAssistant!.id);
     expect(forkAttachments).toHaveLength(1);
     // Scoped to the fork — a distinct attachment row from the source's.
-    expect(forkAttachments[0]?.id).not.toBe(
-      getAttachmentsForMessage(assistant.id)[0]?.id,
-    );
+    expect(forkAttachments[0]?.id).not.toBe(sourceAttachment.id);
+    const forkImage = forkAssistant!.content[0] as Extract<
+      ContentBlock,
+      { type: "image" }
+    >;
+    expect(forkImage.source.type).toBe("workspace_ref");
+    if (forkImage.source.type !== "workspace_ref") {
+      throw new Error("expected retrospective fork workspace reference");
+    }
+    expect(forkImage.source.attachmentId).toBe(forkAttachments[0]?.id);
   });
 
   test("carries the parent graph-memory state on a full fork", async () => {

--- a/assistant/src/__tests__/historical-inline-media-replay.test.ts
+++ b/assistant/src/__tests__/historical-inline-media-replay.test.ts
@@ -1,0 +1,130 @@
+import { deflateSync } from "node:zlib";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { optimizeImageForTransport } from "../agent/image-optimize.js";
+import {
+  createInlineAttachment,
+  linkAttachmentToMessage,
+} from "../persistence/attachments-store.js";
+import {
+  addMessage,
+  createConversation,
+  deleteConversation,
+  getConversation,
+  getMessages,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { migrateMaterializeHistoricalInlineMessageMedia } from "../persistence/migrations/351-materialize-historical-inline-message-media.js";
+import { resolveMediaReferences } from "../providers/media-resolve.js";
+import type { ContentBlock } from "../providers/types.js";
+
+await initializeDb();
+
+let conversationId: string | null = null;
+
+afterEach(() => {
+  if (conversationId && getConversation(conversationId)) {
+    deleteConversation(conversationId);
+  }
+  conversationId = null;
+});
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const typeBytes = Buffer.from(type, "ascii");
+  const payload = Buffer.concat([typeBytes, data]);
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length);
+  const checksum = Buffer.alloc(4);
+  checksum.writeUInt32BE(crc32(payload));
+  return Buffer.concat([length, payload, checksum]);
+}
+
+function sparsePng(width: number, height: number): Buffer {
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8;
+  header[9] = 2;
+  const scanlines = Buffer.alloc((width * 3 + 1) * height);
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk("IHDR", header),
+    pngChunk("IDAT", deflateSync(scanlines, { level: 9 })),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+describe.skipIf(process.platform !== "darwin")(
+  "historical inline optimized image replay",
+  () => {
+    test("keeps the workspace reference aligned with original attachment bytes", async () => {
+      const originalPng = sparsePng(2000, 100);
+      const historicalInline = optimizeImageForTransport(
+        originalPng.toString("base64"),
+        "image/png",
+      );
+      expect(historicalInline.mediaType).toBe("image/jpeg");
+
+      const conversation = createConversation("Historical media thread");
+      conversationId = conversation.id;
+      const attachment = createInlineAttachment(
+        conversation.id,
+        conversation.createdAt,
+        "original.png",
+        "image/png",
+        originalPng.toString("base64"),
+      );
+      const message = await addMessage(
+        conversation.id,
+        "user",
+        JSON.stringify([
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: historicalInline.mediaType,
+              data: historicalInline.data,
+            },
+          },
+        ] satisfies ContentBlock[]),
+        { skipIndexing: true },
+      );
+      linkAttachmentToMessage(message.id, attachment.id, 0);
+
+      await migrateMaterializeHistoricalInlineMessageMedia(getDb(), {
+        yieldToEventLoop: async () => {},
+      });
+
+      const migratedImage = getMessages(conversation.id)[0]!
+        .content[0] as Extract<ContentBlock, { type: "image" }>;
+      expect(migratedImage.source.type).toBe("workspace_ref");
+      if (migratedImage.source.type !== "workspace_ref") {
+        throw new Error("expected migrated workspace reference");
+      }
+      expect(migratedImage.source.media_type).toBe("image/png");
+      expect(migratedImage.source.sizeBytes).toBe(originalPng.length);
+
+      const replayedImage = resolveMediaReferences([
+        { role: "user", content: [migratedImage] },
+      ])[0]!.content[0] as Extract<ContentBlock, { type: "image" }>;
+      expect(replayedImage.source.type).toBe("base64");
+      if (replayedImage.source.type !== "base64") {
+        throw new Error("expected replayed base64 image");
+      }
+      expect(replayedImage.source.media_type).toBe(historicalInline.mediaType);
+      expect(replayedImage.source.data).toBe(historicalInline.data);
+    });
+  },
+);

--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -233,6 +233,77 @@ describe("handleListMessages attachments", () => {
       "output.png",
     );
   });
+
+  test("does not append a migrated nested tool image as a standalone attachment", async () => {
+    const conv = createConversation();
+    const stored = uploadAttachment("screenshot.png", "image/png", "AQIDBA==");
+    const toolUse = await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([
+        {
+          type: "tool_use",
+          id: "tool-1",
+          name: "browser_screenshot",
+          input: {},
+        },
+      ]),
+    );
+    const toolResult = await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([
+        {
+          type: "tool_result",
+          tool_use_id: "tool-1",
+          content: "captured",
+          contentBlocks: [
+            {
+              type: "image",
+              source: {
+                type: "workspace_ref",
+                media_type: "image/png",
+                attachmentId: stored.id,
+                sizeBytes: 4,
+              },
+            },
+          ],
+        },
+      ]),
+    );
+    linkAttachmentToMessage(toolResult.id, stored.id, 0);
+
+    const response = handleListMessages(createTestArgs(conv.id));
+    const body = response as {
+      messages: Array<{
+        id: string;
+        mergedMessageIds?: string[];
+        attachments: Array<{ id: string }>;
+        toolCalls?: Array<{ imageAttachmentIds?: string[] }>;
+        contentBlocks: Array<{
+          type: string;
+          toolCall?: { imageAttachmentIds?: string[] };
+        }>;
+      }>;
+    };
+
+    expect(body.messages).toHaveLength(1);
+    const message = body.messages[0];
+    expect(message.id).toBe(toolUse.id);
+    expect(message.mergedMessageIds).toEqual([toolResult.id]);
+    expect(message.attachments.map((attachment) => attachment.id)).toEqual([
+      stored.id,
+    ]);
+    expect(message.toolCalls?.[0]?.imageAttachmentIds).toEqual([stored.id]);
+    expect(
+      message.contentBlocks.filter((block) => block.type === "attachment"),
+    ).toEqual([]);
+    expect(
+      message.contentBlocks
+        .filter((block) => block.type === "tool_use")
+        .flatMap((block) => block.toolCall?.imageAttachmentIds ?? []),
+    ).toEqual([stored.id]);
+  });
 });
 
 describe("handleListMessages HEIC display normalization", () => {

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -330,6 +330,38 @@ describe("renderHistoryContent", () => {
     expect(output.toolCalls[0].imageData).toBeUndefined();
   });
 
+  test("finds workspace_ref images in recursively nested tool results", () => {
+    const stored = uploadAttachment("nested.png", "image/png", "aGVsbG8=");
+    const output = renderHistoryContent([
+      { type: "tool_use", id: "tu_1", name: "nested_tool", input: {} },
+      {
+        type: "tool_result",
+        tool_use_id: "tu_1",
+        content: "outer result",
+        contentBlocks: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu_nested",
+            content: "inner result",
+            contentBlocks: [
+              {
+                type: "image",
+                source: {
+                  type: "workspace_ref",
+                  media_type: "image/png",
+                  attachmentId: stored.id,
+                  sizeBytes: 5,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(output.toolCalls[0].imageAttachmentIds).toEqual([stored.id]);
+  });
+
   test("resolves an inline base64 tool-result image without an id", () => {
     const output = renderHistoryContent([
       { type: "tool_use", id: "tu_1", name: "browser_screenshot", input: {} },

--- a/assistant/src/__tests__/workspace-migration-134-rebuild-historical-inline-media-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-134-rebuild-historical-inline-media-disk-view.test.ts
@@ -1,0 +1,303 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { rebuildHistoricalInlineMediaDiskViewMigration } from "../workspace/migrations/134-rebuild-historical-inline-media-disk-view.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import {
+  loadCheckpoints,
+  runWorkspaceMigrations,
+} from "../workspace/migrations/runner.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
+
+let workspaceDir: string;
+let db: Database;
+
+function conversationDir(id: string, createdAt: number): string {
+  return join(
+    workspaceDir,
+    "conversations",
+    `${new Date(createdAt).toISOString().replace(/:/g, "-")}_${id}`,
+  );
+}
+
+function seedConversation(options?: {
+  conversationId?: string;
+  attachmentId?: string;
+  attachmentBytes?: Buffer | null;
+}): { attachmentPath: string; messagesPath: string } {
+  const conversationId = options?.conversationId ?? "conversation-134";
+  const attachmentId =
+    options?.attachmentId ?? "historical-inline-media-attachment-134";
+  const attachmentBytes =
+    options?.attachmentBytes === undefined
+      ? Buffer.from("historical attachment")
+      : options.attachmentBytes;
+  const createdAt = 1_700_000_000_000;
+  const dir = conversationDir(conversationId, createdAt);
+  const attachmentsDir = join(dir, "attachments");
+  const attachmentPath = join(attachmentsDir, attachmentId);
+  const messagesPath = join(dir, "messages.jsonl");
+  mkdirSync(attachmentsDir, { recursive: true });
+  if (attachmentBytes) {
+    writeFileSync(attachmentPath, attachmentBytes);
+  }
+  writeFileSync(messagesPath, '{"role":"user","content":"stale"}\n');
+
+  db.query(
+    `INSERT INTO conversations (
+       id, title, created_at, updated_at, conversation_type, origin_channel
+     ) VALUES (?, 'Example conversation', ?, ?, 'standard', 'desktop')`,
+  ).run(conversationId, createdAt, createdAt + 1);
+  db.query(
+    `INSERT INTO messages (
+       id, conversation_id, role, content, created_at, metadata, finalized
+     ) VALUES (?, ?, 'user', ?, ?, '{"source":"example"}', 1)`,
+  ).run(
+    `message-${conversationId}`,
+    conversationId,
+    JSON.stringify([
+      { type: "text", text: "Stored message" },
+      {
+        type: "file",
+        source: {
+          type: "workspace_ref",
+          attachmentId,
+          media_type: "text/plain",
+          sizeBytes: attachmentBytes?.length ?? 0,
+        },
+      },
+    ]),
+    createdAt + 2,
+  );
+  db.query(
+    `INSERT INTO attachments (
+       id, original_filename, data_base64, file_path
+     ) VALUES (?, 'example.txt', '', ?)`,
+  ).run(attachmentId, attachmentPath);
+  db.query(
+    `INSERT INTO message_attachments (
+       id, message_id, attachment_id, position
+     ) VALUES (?, ?, ?, 0)`,
+  ).run(`link-${conversationId}`, `message-${conversationId}`, attachmentId);
+
+  return { attachmentPath, messagesPath };
+}
+
+function markDbMigrationComplete(value = "1"): void {
+  db.query(
+    `INSERT OR REPLACE INTO memory_checkpoints (key, value, updated_at)
+     VALUES ('step:migrateMaterializeHistoricalInlineMessageMedia', ?, 1)`,
+  ).run(value);
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "workspace-migration-134-"));
+  const dbDir = join(workspaceDir, "data", "db");
+  mkdirSync(dbDir, { recursive: true });
+  db = new Database(join(dbDir, "assistant.db"));
+  db.exec(/*sql*/ `
+    CREATE TABLE memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      conversation_type TEXT NOT NULL,
+      origin_channel TEXT
+    );
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      metadata TEXT,
+      finalized INTEGER NOT NULL
+    );
+    CREATE TABLE attachments (
+      id TEXT PRIMARY KEY,
+      original_filename TEXT NOT NULL,
+      data_base64 TEXT NOT NULL,
+      file_path TEXT
+    );
+    CREATE TABLE message_attachments (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      attachment_id TEXT NOT NULL,
+      position INTEGER NOT NULL
+    );
+  `);
+});
+
+afterEach(() => {
+  db.close();
+  assertNotLiveDb(workspaceDir);
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("workspace migration 134: historical inline-media disk view", () => {
+  test("is registered last and retries failed checkpoints", () => {
+    expect(WORKSPACE_MIGRATIONS.at(-1)).toBe(
+      rebuildHistoricalInlineMediaDiskViewMigration,
+    );
+    expect(
+      rebuildHistoricalInlineMediaDiskViewMigration.retryFailedCheckpoint,
+    ).toBe(true);
+  });
+
+  test("defers until the database media migration is complete", () => {
+    expect(() =>
+      rebuildHistoricalInlineMediaDiskViewMigration.run(workspaceDir),
+    ).toThrow("has not completed");
+    markDbMigrationComplete("started");
+    expect(() =>
+      rebuildHistoricalInlineMediaDiskViewMigration.run(workspaceDir),
+    ).toThrow("has not completed");
+  });
+
+  test("rebuilds only affected disk views and is idempotent", () => {
+    markDbMigrationComplete();
+    const target = seedConversation();
+    const unaffected = seedConversation({
+      conversationId: "conversation-unaffected",
+      attachmentId: "existing-attachment",
+    });
+
+    rebuildHistoricalInlineMediaDiskViewMigration.run(workspaceDir);
+
+    const rebuilt = readFileSync(target.messagesPath, "utf8");
+    const record = JSON.parse(rebuilt.trim()) as Record<string, unknown>;
+    expect(record).toMatchObject({
+      role: "user",
+      content: "Stored message",
+      metadata: { source: "example" },
+      attachments: ["historical-inline-media-attachment-134"],
+    });
+    expect(readFileSync(unaffected.messagesPath, "utf8")).toBe(
+      '{"role":"user","content":"stale"}\n',
+    );
+
+    rebuildHistoricalInlineMediaDiskViewMigration.run(workspaceDir);
+
+    expect(readFileSync(target.messagesPath, "utf8")).toBe(rebuilt);
+    expect(existsSync(target.attachmentPath)).toBe(true);
+  });
+
+  test("folds file-backed message content while rebuilding the conversation", () => {
+    markDbMigrationComplete();
+    const target = seedConversation();
+    const contentDir = join(workspaceDir, "conversations", "content");
+    const contentPath = join(contentDir, "message.jsonl");
+    mkdirSync(contentDir, { recursive: true });
+    writeFileSync(
+      contentPath,
+      [
+        JSON.stringify({
+          i: 0,
+          seq: 1,
+          block: { type: "text", text: "Older text" },
+        }),
+        JSON.stringify({
+          i: 0,
+          seq: 2,
+          block: { type: "text", text: "File-backed text" },
+        }),
+      ].join("\n"),
+    );
+    db.query(
+      `INSERT INTO messages (
+         id, conversation_id, role, content, created_at, metadata, finalized
+       ) VALUES ('message-file-backed', 'conversation-134', 'assistant', ?, ?, NULL, 1)`,
+    ).run(
+      JSON.stringify({ ref: "conversations/content/message.jsonl" }),
+      1_700_000_000_010,
+    );
+
+    rebuildHistoricalInlineMediaDiskViewMigration.run(workspaceDir);
+
+    const records = readFileSync(target.messagesPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records).toHaveLength(2);
+    expect(records[1]).toMatchObject({
+      role: "assistant",
+      content: "File-backed text",
+    });
+  });
+
+  test("retries a failed projection after attachment storage recovers", async () => {
+    markDbMigrationComplete();
+    const target = seedConversation({ attachmentBytes: null });
+
+    const failed = await runWorkspaceMigrations(workspaceDir, [
+      rebuildHistoricalInlineMediaDiskViewMigration,
+    ]);
+
+    expect(failed).toEqual({ applied: 0, skipped: 0, failed: 1 });
+    expect(
+      loadCheckpoints(workspaceDir).applied[
+        rebuildHistoricalInlineMediaDiskViewMigration.id
+      ]?.status,
+    ).toBe("failed");
+
+    writeFileSync(target.attachmentPath, "recovered");
+    const retried = await runWorkspaceMigrations(workspaceDir, [
+      rebuildHistoricalInlineMediaDiskViewMigration,
+    ]);
+
+    expect(retried).toEqual({ applied: 1, skipped: 0, failed: 0 });
+    expect(
+      loadCheckpoints(workspaceDir).applied[
+        rebuildHistoricalInlineMediaDiskViewMigration.id
+      ]?.status,
+    ).toBe("completed");
+    expect(
+      JSON.parse(readFileSync(target.messagesPath, "utf8").trim()).attachments,
+    ).toEqual(["historical-inline-media-attachment-134"]);
+  });
+
+  test("re-runs an interrupted started checkpoint", async () => {
+    markDbMigrationComplete();
+    const target = seedConversation();
+    const checkpointPath = join(
+      workspaceDir,
+      "data",
+      ".workspace-migrations.json",
+    );
+    writeFileSync(
+      checkpointPath,
+      JSON.stringify({
+        applied: {
+          [rebuildHistoricalInlineMediaDiskViewMigration.id]: {
+            appliedAt: new Date(0).toISOString(),
+            status: "started",
+          },
+        },
+      }),
+    );
+
+    const result = await runWorkspaceMigrations(workspaceDir, [
+      rebuildHistoricalInlineMediaDiskViewMigration,
+    ]);
+
+    expect(result).toEqual({ applied: 1, skipped: 0, failed: 0 });
+    expect(
+      JSON.parse(readFileSync(target.messagesPath, "utf8").trim()).attachments,
+    ).toEqual(["historical-inline-media-attachment-134"]);
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-134-rebuild-historical-inline-media-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-134-rebuild-historical-inline-media-disk-view.test.ts
@@ -100,6 +100,25 @@ function markDbMigrationComplete(value = "1"): void {
   ).run(value);
 }
 
+function historicalRepairBlocks(source: string): unknown[] {
+  return [
+    { type: "text", text: 42 },
+    {
+      type: "tool_result",
+      tool_use_id: "tool-malformed",
+      content: { answer: 42 },
+    },
+    { payload: source },
+    "bare value",
+    { type: "text", text: "Valid text", marker: "preserved" },
+    {
+      type: "tool_result",
+      tool_use_id: "tool-valid",
+      content: "Valid result",
+    },
+  ];
+}
+
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "workspace-migration-134-"));
   const dbDir = join(workspaceDir, "data", "db");
@@ -211,11 +230,9 @@ describe("workspace migration 134: historical inline-media disk view", () => {
           seq: 1,
           block: { type: "text", text: "Older text" },
         }),
-        JSON.stringify({
-          i: 0,
-          seq: 2,
-          block: { type: "text", text: "File-backed text" },
-        }),
+        ...historicalRepairBlocks("file-backed").map((block, index) =>
+          JSON.stringify({ i: index, seq: index + 2, block }),
+        ),
       ].join("\n"),
     );
     db.query(
@@ -236,8 +253,64 @@ describe("workspace migration 134: historical inline-media disk view", () => {
     expect(records).toHaveLength(2);
     expect(records[1]).toMatchObject({
       role: "assistant",
-      content: "File-backed text",
+      content: '42\n{"payload":"file-backed"}\n"bare value"\nValid text',
+      toolResults: [{ content: '{"answer":42}' }, { content: "Valid result" }],
     });
+  });
+
+  test("repairs malformed inline blocks without erasing their payloads", () => {
+    markDbMigrationComplete();
+    const target = seedConversation();
+    db.query(
+      `INSERT INTO messages (
+         id, conversation_id, role, content, created_at, metadata, finalized
+       ) VALUES ('message-malformed-inline', 'conversation-134', 'assistant', ?, ?, NULL, 1)`,
+    ).run(JSON.stringify(historicalRepairBlocks("inline")), 1_700_000_000_010);
+
+    rebuildHistoricalInlineMediaDiskViewMigration.run(workspaceDir);
+
+    const records = readFileSync(target.messagesPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records).toHaveLength(2);
+    expect(records[1]).toMatchObject({
+      role: "assistant",
+      content: '42\n{"payload":"inline"}\n"bare value"\nValid text',
+      toolResults: [{ content: '{"answer":42}' }, { content: "Valid result" }],
+    });
+  });
+
+  test("preserves web search tool results while rebuilding the conversation", () => {
+    markDbMigrationComplete();
+    const target = seedConversation();
+    const webSearchContent = [
+      {
+        type: "web_search_result",
+        url: "https://example.com/result",
+        title: "Example result",
+        encrypted_content: "opaque-result",
+      },
+    ];
+    db.query(
+      `INSERT INTO messages (
+         id, conversation_id, role, content, created_at, metadata, finalized
+       ) VALUES ('message-web-search', 'conversation-134', 'user', ?, ?, NULL, 1)`,
+    ).run(
+      JSON.stringify([
+        { type: "web_search_tool_result", content: webSearchContent },
+      ]),
+      1_700_000_000_010,
+    );
+
+    rebuildHistoricalInlineMediaDiskViewMigration.run(workspaceDir);
+
+    const records = readFileSync(target.messagesPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records).toHaveLength(2);
+    expect(records[1]?.toolResults).toEqual([{ content: webSearchContent }]);
   });
 
   test("retries a failed projection after attachment storage recovers", async () => {

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -319,6 +319,41 @@ function renderFileBlockForHistory(
   )}`;
 }
 
+function collectToolResultImages(
+  blocks: unknown[],
+  imageDataList: string[],
+  imageAttachmentIds: string[],
+): void {
+  for (const block of blocks) {
+    if (!isRecord(block)) {
+      continue;
+    }
+    if (block.type === "image" && isRecord(block.source)) {
+      const source = block.source as unknown as MediaSource;
+      if (source.type === "workspace_ref" && source.attachmentId) {
+        imageAttachmentIds.push(source.attachmentId);
+        continue;
+      }
+      const resolved = resolveMediaSourceData(source);
+      if (resolved) {
+        imageDataList.push(resolved.data);
+      }
+      continue;
+    }
+    if (
+      (block.type === "tool_result" ||
+        block.type === "web_search_tool_result") &&
+      Array.isArray(block.contentBlocks)
+    ) {
+      collectToolResultImages(
+        block.contentBlocks,
+        imageDataList,
+        imageAttachmentIds,
+      );
+    }
+  }
+}
+
 export function renderHistoryContent(
   content: unknown,
   attachmentBlocks?: ReadonlyArray<
@@ -704,19 +739,11 @@ export function renderHistoryContent(
       const imageDataList: string[] = [];
       const imageAttachmentIds: string[] = [];
       if (Array.isArray(block.contentBlocks)) {
-        for (const cb of block.contentBlocks) {
-          if (isRecord(cb) && cb.type === "image" && isRecord(cb.source)) {
-            const source = cb.source as unknown as MediaSource;
-            if (source.type === "workspace_ref" && source.attachmentId) {
-              imageAttachmentIds.push(source.attachmentId);
-              continue;
-            }
-            const resolved = resolveMediaSourceData(source);
-            if (resolved) {
-              imageDataList.push(resolved.data);
-            }
-          }
-        }
+        collectToolResultImages(
+          block.contentBlocks,
+          imageDataList,
+          imageAttachmentIds,
+        );
       }
       const matched = toolUseId ? pendingToolUses.get(toolUseId) : null;
       if (matched) {

--- a/assistant/src/monitoring/recovery/__tests__/inflight-content.test.ts
+++ b/assistant/src/monitoring/recovery/__tests__/inflight-content.test.ts
@@ -24,11 +24,13 @@ import {
 import {
   createConversation,
   finalizeMessageContent,
+  forkConversationForRetrospective,
   getMessageById,
   reserveMessage,
 } from "../../../persistence/conversation-crud.js";
 import { getDb, getSqliteFrom } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
+import { migrateMaterializeHistoricalInlineMessageMedia } from "../../../persistence/migrations/351-materialize-historical-inline-message-media.js";
 import type { ContentBlock } from "../../../providers/types.js";
 import { recoverInflightContent } from "../inflight-content.js";
 
@@ -117,6 +119,64 @@ describe("recoverInflightContent — folding stranded rows", () => {
 
     expect(rawRow(messageId).finalized).toBe(1);
     expect(getMessageById(messageId, conversationId)?.content).toEqual([]);
+  });
+
+  test("detaches a finalized retrospective fork before recovering its shared pending ref", async () => {
+    const source = await reserveInflight();
+    const content = [textBlock("shared pending content")];
+    appendInflightSnapshot(source.writer, content, 1, rlog);
+    const sourceRefContent = rawRow(source.messageId).content;
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.conversationId,
+    });
+    const forkRow = db()
+      .query(
+        `SELECT id, content, finalized FROM messages
+         WHERE conversation_id = ?`,
+      )
+      .get(fork.id) as { id: string; content: string; finalized: number };
+    expect(forkRow.content).toBe(sourceRefContent);
+    expect(forkRow.finalized).toBe(1);
+    const preparedMessageIds: string[] = [];
+    const releasedMessageIds: string[] = [];
+
+    await migrateMaterializeHistoricalInlineMessageMedia(getDb(), {
+      prepareLexicalReindex: (messageId) => {
+        preparedMessageIds.push(messageId);
+        return {
+          jobId: `prepared-${messageId}`,
+          messageId,
+          fallbackRunAfter: Number.MAX_SAFE_INTEGER,
+        };
+      },
+      releaseLexicalReindex: (prepared) => {
+        releasedMessageIds.push(prepared.messageId);
+      },
+      yieldToEventLoop: async () => {},
+    });
+
+    expect(rawRow(source.messageId).finalized).toBe(0);
+    expect(rawRow(source.messageId).content).toBe(sourceRefContent);
+    expect(rawRow(forkRow.id)).toEqual({
+      content: JSON.stringify(content),
+      finalized: 1,
+    });
+    expect(preparedMessageIds).toContain(forkRow.id);
+    expect(preparedMessageIds).not.toContain(source.messageId);
+    expect(releasedMessageIds).toContain(forkRow.id);
+    expect(existsSync(source.writer.absPath)).toBe(true);
+    backdateDeltaFile(source.writer.absPath);
+
+    recoverInflightContent({ minAgeMs: 0 });
+
+    expect(rawRow(source.messageId)).toEqual({
+      content: JSON.stringify(content),
+      finalized: 1,
+    });
+    expect(existsSync(source.writer.absPath)).toBe(false);
+    expect(
+      getMessageById(source.messageId, source.conversationId)?.content,
+    ).toEqual(getMessageById(forkRow.id, fork.id)?.content);
   });
 });
 

--- a/assistant/src/monitoring/recovery/__tests__/inflight-content.test.ts
+++ b/assistant/src/monitoring/recovery/__tests__/inflight-content.test.ts
@@ -178,6 +178,46 @@ describe("recoverInflightContent — folding stranded rows", () => {
       getMessageById(source.messageId, source.conversationId)?.content,
     ).toEqual(getMessageById(forkRow.id, fork.id)?.content);
   });
+
+  test("retains a shared ref until its finalized retrospective fork detaches", async () => {
+    const source = await reserveInflight();
+    const content = [textBlock("shared recovery content")];
+    appendInflightSnapshot(source.writer, content, 1, rlog);
+    const sourceRefContent = rawRow(source.messageId).content;
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.conversationId,
+    });
+    const forkRow = db()
+      .query(
+        `SELECT id, content, finalized FROM messages
+         WHERE conversation_id = ?`,
+      )
+      .get(fork.id) as { id: string; content: string; finalized: number };
+    expect(forkRow.content).toBe(sourceRefContent);
+    expect(forkRow.finalized).toBe(1);
+    backdateDeltaFile(source.writer.absPath);
+
+    const firstResult = recoverInflightContent({ minAgeMs: 0 });
+
+    expect(firstResult.finalized).toBeGreaterThanOrEqual(1);
+    expect(rawRow(source.messageId)).toEqual({
+      content: JSON.stringify(content),
+      finalized: 1,
+    });
+    expect(rawRow(forkRow.id)).toEqual({
+      content: sourceRefContent,
+      finalized: 1,
+    });
+    expect(existsSync(source.writer.absPath)).toBe(true);
+    expect(getMessageById(forkRow.id, fork.id)?.content).toEqual(content);
+
+    finalizeMessageContent(forkRow.id, JSON.stringify(content));
+    const secondResult = recoverInflightContent({ minAgeMs: 0 });
+
+    expect(secondResult.filesDeleted).toBeGreaterThanOrEqual(1);
+    expect(existsSync(source.writer.absPath)).toBe(false);
+    expect(getMessageById(forkRow.id, fork.id)?.content).toEqual(content);
+  });
 });
 
 describe("recoverInflightContent — ownership guards", () => {

--- a/assistant/src/monitoring/recovery/inflight-content.ts
+++ b/assistant/src/monitoring/recovery/inflight-content.ts
@@ -28,10 +28,10 @@
  *
  * Two phases:
  *   1. Fold each eligible `finalized = 0` row's resolved content inline and set
- *      `finalized = 1`, deleting its delta file.
- *   2. GC orphan delta files no `finalized = 0` row references — e.g. a file
- *      whose finalize landed but whose unlink was interrupted, which phase 1
- *      never revisits and which would otherwise leak on disk.
+ *      `finalized = 1` without deleting its delta file.
+ *   2. GC delta files no message row references, regardless of finalization
+ *      state. A finalized retrospective fork can share the pending source's
+ *      ref, so the file remains until every row has detached from it.
  */
 
 import { readdirSync, rmSync, statSync } from "node:fs";
@@ -59,7 +59,7 @@ export const DEFAULT_INFLIGHT_MIN_AGE_MS = 60_000;
 export interface InflightRecoveryResult {
   /** `finalized = 0` rows folded inline and flipped to `finalized = 1`. */
   finalized: number;
-  /** Orphan delta files unlinked from disk. */
+  /** Delta files unreferenced by every message row and unlinked from disk. */
   filesDeleted: number;
   /** Rows left for a later run because their conversation is mid-turn. */
   skippedProcessing: number;
@@ -121,8 +121,8 @@ export function recoverInflightContent(
       .all() as UnfinalizedRow[];
 
     // `AND finalized = 0` makes the write a no-op if the daemon finalized the
-    // row between our read and this write; `changes` then reports 0 and we
-    // leave its file to the daemon.
+    // row between our read and this write; `changes` then reports 0. File
+    // deletion is deferred to the all-message reference sweep below.
     const finalizeStmt = db.query(
       `UPDATE messages SET content = ?, finalized = 1
         WHERE id = ? AND finalized = 0`,
@@ -150,9 +150,6 @@ export function recoverInflightContent(
         const info = finalizeStmt.run(JSON.stringify(blocks), row.id);
         if (info.changes > 0) {
           finalized++;
-          if (absPath != null) {
-            rmSync(absPath, { force: true });
-          }
         }
       } catch (err) {
         log.warn(
@@ -174,24 +171,27 @@ export function recoverInflightContent(
 }
 
 /**
- * Delete delta files no `finalized = 0` row references. Re-reads the
- * unfinalized set so a row whose fold we skipped (busy conversation, fresh
- * file) keeps its file, and honours the same age floor so a live writer's file
- * is never unlinked mid-stream.
+ * Delete delta files no message row references. Re-reads all rows after the
+ * fold so skipped pending rows and finalized rows sharing their refs retain
+ * the file, and honours the same age floor so a live writer's file is never
+ * unlinked mid-stream.
  */
 function sweepOrphanDeltaFiles(
   db: Database,
   minAgeMs: number,
   now: number,
 ): number {
-  const referenced = new Set<string>();
+  const retained = new Set<string>();
+  // parseContentRef rejects every value whose first character is not `{`.
+  // Apply that exact fast-path in SQL so large historical inline arrays do not
+  // cross into the monitor process merely to be rejected in JavaScript.
   const rows = db
-    .query(`SELECT content FROM messages WHERE finalized = 0`)
+    .query(`SELECT content FROM messages WHERE substr(content, 1, 1) = '{'`)
     .all() as Array<{ content: string }>;
   for (const row of rows) {
     const absPath = refAbsPath(row.content);
     if (absPath != null) {
-      referenced.add(absPath);
+      retained.add(absPath);
     }
   }
 
@@ -217,7 +217,7 @@ function sweepOrphanDeltaFiles(
         continue;
       }
       const absPath = resolve(inflightDir, file);
-      if (referenced.has(absPath)) {
+      if (retained.has(absPath)) {
         continue;
       }
       const mtime = fileMtimeMs(absPath);

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -94,6 +94,7 @@ import {
   enqueuePurgeConversationLexical,
 } from "./job-handlers/message-lexical.js";
 import { buildLifecycleTelemetryEvent } from "./lifecycle-events-store.js";
+import { remapWorkspaceRefAttachmentIds } from "./media-reference-content.js";
 import { resolveMessageContentBlocks } from "./message-content-file.js";
 import {
   rawAll,
@@ -1410,6 +1411,17 @@ function populateForkContentsInProcess(args: PopulateForkContentsArgs): void {
     if (stagingMessageId) {
       relinkAttachments([stagingMessageId], forkedMessageId);
       db.delete(messages).where(eq(messages.id, stagingMessageId)).run();
+    }
+
+    const remappedContent =
+      attachmentLinks.length === 0
+        ? message.content
+        : remapWorkspaceRefAttachmentIds(message.content, attachmentIdMap);
+    if (remappedContent !== message.content) {
+      db.update(messages)
+        .set({ content: JSON.stringify(remappedContent) })
+        .where(eq(messages.id, forkedMessageId))
+        .run();
     }
 
     diskSyncQueue?.push({

--- a/assistant/src/persistence/conversation-directories.ts
+++ b/assistant/src/persistence/conversation-directories.ts
@@ -23,6 +23,19 @@ export function getConversationDirName(
   return `${getConversationDirTimestamp(createdAtMs)}_${id}`;
 }
 
+export function isFilesystemSafeConversationId(
+  conversationId: string,
+): boolean {
+  return (
+    conversationId.length > 0 &&
+    conversationId !== "." &&
+    conversationId !== ".." &&
+    !conversationId.includes("/") &&
+    !conversationId.includes("\\") &&
+    !conversationId.includes("\0")
+  );
+}
+
 /**
  * Parse a canonical conversation directory name (`<ISO-with-dashes>_<id>`)
  * back into its components. Returns null for names that don't match the
@@ -41,22 +54,20 @@ export function parseConversationDirName(
   const match = name.match(
     /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2}\.\d{1,9}Z)_(.+)$/,
   );
-  if (!match) return null;
+  if (!match) {
+    return null;
+  }
   const [, datePart, hh, mm, ssAndMs, conversationId] = match;
   const iso = `${datePart}T${hh}:${mm}:${ssAndMs}`;
   const ms = Date.parse(iso);
-  if (Number.isNaN(ms)) return null;
-  if (!conversationId) return null;
+  if (Number.isNaN(ms)) {
+    return null;
+  }
   // Reject conversation IDs that are path-traversal-shaped or contain
   // path separators. These are never valid conversation IDs and would
   // be a defense-in-depth concern if parsed.conversationId is later used
   // to construct filesystem paths.
-  if (
-    conversationId === "." ||
-    conversationId === ".." ||
-    conversationId.includes("/") ||
-    conversationId.includes("\\")
-  ) {
+  if (!isFilesystemSafeConversationId(conversationId)) {
     return null;
   }
   return { conversationId, createdAtMs: ms };

--- a/assistant/src/persistence/job-handlers/__tests__/message-lexical-enqueue.test.ts
+++ b/assistant/src/persistence/job-handlers/__tests__/message-lexical-enqueue.test.ts
@@ -40,7 +40,7 @@ import {
   saveRawConfig,
 } from "../../../config/loader.js";
 import { getWorkspacePluginsDir } from "../../../util/platform.js";
-import { getMemoryDb } from "../../db-connection.js";
+import { getMemoryDb, getMemorySqlite } from "../../db-connection.js";
 import { initializeDb } from "../../db-init.js";
 import { memoryJobs } from "../../schema/index.js";
 const MEMORY_PLUGIN_NAME = "default-memory";
@@ -48,6 +48,9 @@ import {
   enqueueDeleteMessageLexical,
   enqueueLexicalIndexForMessage,
   enqueuePurgeConversationLexical,
+  PREPARED_LEXICAL_INDEX_FALLBACK_DELAY_MS,
+  prepareLexicalIndexForMessage,
+  releasePreparedLexicalIndexJob,
 } from "../message-lexical.js";
 
 await initializeDb();
@@ -84,6 +87,14 @@ function jobCount(type: string): number {
     .all().length;
 }
 
+function jobRows(type: string) {
+  return getMemoryDb()!
+    .select()
+    .from(memoryJobs)
+    .where(eq(memoryJobs.type, type))
+    .all();
+}
+
 // Let any stray fire-and-forget promise settle before asserting.
 const flush = () => new Promise((r) => setTimeout(r, 5));
 
@@ -107,6 +118,92 @@ describe("lexical enqueues with memory enabled", () => {
     expect(deleteByConversationCalls).toEqual([]);
     expect(deleteByMessageIdCalls).toEqual([]);
   });
+
+  test("prepares the normal payload with a durable fallback, then releases the exact job", () => {
+    const beforePrepare = Date.now();
+    const prepared = prepareLexicalIndexForMessage("msg-prepared");
+    const afterPrepare = Date.now();
+    const preparedRows = jobRows("index_message_lexical");
+
+    expect(prepared.messageId).toBe("msg-prepared");
+    expect(prepared.fallbackRunAfter).toBeGreaterThanOrEqual(
+      beforePrepare + PREPARED_LEXICAL_INDEX_FALLBACK_DELAY_MS,
+    );
+    expect(prepared.fallbackRunAfter).toBeLessThanOrEqual(
+      afterPrepare + PREPARED_LEXICAL_INDEX_FALLBACK_DELAY_MS,
+    );
+    expect(preparedRows).toHaveLength(1);
+    expect(preparedRows[0]).toMatchObject({
+      id: prepared.jobId,
+      status: "pending",
+      runAfter: prepared.fallbackRunAfter,
+    });
+    expect(JSON.parse(preparedRows[0]!.payload)).toEqual({
+      messageId: "msg-prepared",
+    });
+
+    releasePreparedLexicalIndexJob(prepared);
+
+    const releasedRows = jobRows("index_message_lexical");
+    expect(releasedRows).toHaveLength(1);
+    expect(releasedRows[0]!.id).toBe(prepared.jobId);
+    expect(releasedRows[0]!.status).toBe("pending");
+    expect(releasedRows[0]!.runAfter).toBeLessThanOrEqual(Date.now());
+  });
+
+  test("keeps the prepared fallback pending when release storage fails", () => {
+    const prepared = prepareLexicalIndexForMessage("msg-release-failure");
+    const sqlite = getMemorySqlite()!;
+    sqlite.exec(/*sql*/ `
+      CREATE TEMP TRIGGER reject_prepared_lexical_release
+      BEFORE UPDATE OF run_after ON memory_jobs
+      BEGIN
+        SELECT RAISE(ABORT, 'release unavailable');
+      END;
+    `);
+
+    try {
+      expect(() => releasePreparedLexicalIndexJob(prepared)).toThrow(
+        "release unavailable",
+      );
+    } finally {
+      sqlite.exec(`DROP TRIGGER reject_prepared_lexical_release`);
+    }
+
+    expect(jobRows("index_message_lexical")).toEqual([
+      expect.objectContaining({
+        id: prepared.jobId,
+        status: "pending",
+        runAfter: prepared.fallbackRunAfter,
+      }),
+    ]);
+  });
+
+  test.each(["running", "completed"] as const)(
+    "enqueues a fresh immediate job when the prepared job is unexpectedly %s",
+    (status) => {
+      const prepared = prepareLexicalIndexForMessage(`msg-${status}`);
+      getMemoryDb()!
+        .update(memoryJobs)
+        .set({ status })
+        .where(eq(memoryJobs.id, prepared.jobId))
+        .run();
+
+      releasePreparedLexicalIndexJob(prepared);
+
+      const rows = jobRows("index_message_lexical");
+      expect(rows).toHaveLength(2);
+      expect(rows.find((row) => row.id === prepared.jobId)?.status).toBe(
+        status,
+      );
+      const replacement = rows.find((row) => row.id !== prepared.jobId);
+      expect(replacement).toMatchObject({ status: "pending" });
+      expect(replacement!.runAfter).toBeLessThanOrEqual(Date.now());
+      expect(JSON.parse(replacement!.payload)).toEqual({
+        messageId: `msg-${status}`,
+      });
+    },
+  );
 });
 
 describe("lexical enqueues with memory DISABLED — unchanged", () => {

--- a/assistant/src/persistence/job-handlers/message-lexical.ts
+++ b/assistant/src/persistence/job-handlers/message-lexical.ts
@@ -13,7 +13,11 @@ import {
 import { withQdrantBreaker } from "../embeddings/qdrant-circuit-breaker.js";
 import { resolveQdrantUrl } from "../embeddings/qdrant-client.js";
 import { asString } from "../job-utils.js";
-import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
+import {
+  enqueueMemoryJob,
+  type MemoryJob,
+  releasePendingMemoryJob,
+} from "../jobs-store.js";
 import { messages } from "../schema/index.js";
 
 const log = getLogger("messages-lexical-enqueue");
@@ -181,6 +185,57 @@ export function enqueueLexicalIndexForMessage(messageId: string): void {
       "Failed to enqueue lexical index job for message (non-fatal)",
     );
   }
+}
+
+export const PREPARED_LEXICAL_INDEX_FALLBACK_DELAY_MS = 60 * 60 * 1000;
+
+export interface PreparedLexicalIndexJob {
+  jobId: string;
+  messageId: string;
+  fallbackRunAfter: number;
+}
+
+/**
+ * Durably prepare a lexical reindex without making it immediately claimable.
+ * The one-hour fallback is intentionally conservative relative to the
+ * caller's short local transaction, while ensuring the job becomes runnable
+ * if the process exits before explicitly releasing it. Unlike the best-effort
+ * enqueue helper, failures propagate so callers can avoid committing the
+ * content change without a job.
+ */
+export function prepareLexicalIndexForMessage(
+  messageId: string,
+): PreparedLexicalIndexJob {
+  if (!messageId) {
+    throw new Error("Cannot prepare a lexical index job without a message ID");
+  }
+  const fallbackRunAfter =
+    Date.now() + PREPARED_LEXICAL_INDEX_FALLBACK_DELAY_MS;
+  return {
+    jobId: enqueueMemoryJob(
+      "index_message_lexical",
+      { messageId },
+      fallbackRunAfter,
+    ),
+    messageId,
+    fallbackRunAfter,
+  };
+}
+
+/**
+ * Release an exact prepared job after its source content commits. If that row
+ * has already left the pending state, enqueue a fresh idempotent reindex so an
+ * early worker cannot leave the newly committed content stale.
+ */
+export function releasePreparedLexicalIndexJob(
+  prepared: PreparedLexicalIndexJob,
+): void {
+  if (releasePendingMemoryJob(prepared.jobId)) {
+    return;
+  }
+  enqueueMemoryJob("index_message_lexical", {
+    messageId: prepared.messageId,
+  });
 }
 
 /**

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -181,6 +181,20 @@ export function enqueueMemoryJob(
 }
 
 /**
+ * Make one prepared job runnable without changing a job that has already left
+ * the pending state. Returns whether the exact pending row was released.
+ */
+export function releasePendingMemoryJob(id: string): boolean {
+  const now = Date.now();
+  memoryDb()
+    .update(memoryJobs)
+    .set({ runAfter: now, updatedAt: now })
+    .where(and(eq(memoryJobs.id, id), eq(memoryJobs.status, "pending")))
+    .run();
+  return rawMemoryChanges() === 1;
+}
+
+/**
  * Upsert a debounced job: if a pending job of the same type and conversation
  * already exists, merge the new payload into the existing row and update
  * `runAfter` instead of creating a duplicate. This prevents rapid message

--- a/assistant/src/persistence/media-reference-content.test.ts
+++ b/assistant/src/persistence/media-reference-content.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ContentBlock } from "../providers/types.js";
+import { remapWorkspaceRefAttachmentIds } from "./media-reference-content.js";
+
+function referencedImage(attachmentId: string): ContentBlock {
+  return {
+    type: "image",
+    source: {
+      type: "workspace_ref",
+      media_type: "image/png",
+      attachmentId,
+      sizeBytes: 10,
+    },
+  };
+}
+
+describe("remapWorkspaceRefAttachmentIds", () => {
+  test("remaps root and nested references while preserving unknown fields", () => {
+    const root = {
+      ...referencedImage("source-root"),
+      customBlockField: true,
+    } as unknown as ContentBlock;
+    const nestedTool = {
+      type: "tool_result",
+      tool_use_id: "tool-1",
+      content: "generated image",
+      customToolField: "kept",
+      contentBlocks: [referencedImage("source-tool")],
+    } as unknown as ContentBlock;
+    const nestedWebSearch = {
+      type: "web_search_tool_result",
+      tool_use_id: "search-1",
+      content: [],
+      customSearchField: "kept",
+      contentBlocks: [referencedImage("source-search")],
+    } as unknown as ContentBlock;
+    const content = [root, nestedTool, nestedWebSearch];
+
+    const remapped = remapWorkspaceRefAttachmentIds(
+      content,
+      new Map([
+        ["source-root", "fork-root"],
+        ["source-tool", "fork-tool"],
+        ["source-search", "fork-search"],
+      ]),
+    );
+
+    expect(remapped).not.toBe(content);
+    expect(JSON.stringify(remapped)).not.toContain("source-");
+    expect(JSON.stringify(remapped)).toContain("fork-root");
+    expect(JSON.stringify(remapped)).toContain("fork-tool");
+    expect(JSON.stringify(remapped)).toContain("fork-search");
+    expect(
+      (remapped[0] as unknown as Record<string, unknown>).customBlockField,
+    ).toBe(true);
+    expect(
+      (remapped[1] as unknown as Record<string, unknown>).customToolField,
+    ).toBe("kept");
+    expect(
+      (remapped[2] as unknown as Record<string, unknown>).customSearchField,
+    ).toBe("kept");
+    expect(content[0]).toBe(root);
+    expect(JSON.stringify(content)).toContain("source-root");
+  });
+
+  test("preserves array and block identity when no reference changes", () => {
+    const content = [referencedImage("source-root")];
+
+    const remapped = remapWorkspaceRefAttachmentIds(
+      content,
+      new Map([["different-source", "fork-root"]]),
+    );
+
+    expect(remapped).toBe(content);
+    expect(remapped[0]).toBe(content[0]);
+  });
+});

--- a/assistant/src/persistence/media-reference-content.test.ts
+++ b/assistant/src/persistence/media-reference-content.test.ts
@@ -75,4 +75,38 @@ describe("remapWorkspaceRefAttachmentIds", () => {
     expect(remapped).toBe(content);
     expect(remapped[0]).toBe(content[0]);
   });
+
+  test("preserves malformed root and nested media blocks by identity", () => {
+    const malformedBlocks = [
+      { type: "image" },
+      { type: "file", source: null },
+      { type: "image", source: "workspace_ref" },
+      { type: "file", source: { type: "workspace_ref" } },
+      {
+        type: "image",
+        source: { type: "workspace_ref", attachmentId: 42 },
+      },
+    ] as unknown as ContentBlock[];
+    const nestedTool = {
+      type: "tool_result",
+      tool_use_id: "tool-malformed",
+      content: "historical media",
+      contentBlocks: malformedBlocks,
+    } as unknown as ContentBlock;
+    const content = [...malformedBlocks, nestedTool];
+
+    const remapped = remapWorkspaceRefAttachmentIds(
+      content,
+      new Map([["source-attachment", "fork-attachment"]]),
+    );
+
+    expect(remapped).toBe(content);
+    for (const [index, block] of remapped.entries()) {
+      expect(block).toBe(content[index]);
+    }
+    expect(
+      (remapped.at(-1) as unknown as { contentBlocks?: ContentBlock[] })
+        .contentBlocks,
+    ).toBe(malformedBlocks);
+  });
 });

--- a/assistant/src/persistence/media-reference-content.ts
+++ b/assistant/src/persistence/media-reference-content.ts
@@ -4,22 +4,31 @@ type NestedContentBlock = ContentBlock & {
   contentBlocks?: ContentBlock[];
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function remapWorkspaceRefAttachmentId(
   block: ContentBlock,
   attachmentIdMap: ReadonlyMap<string, string>,
 ): ContentBlock {
-  if (
-    (block.type === "image" || block.type === "file") &&
-    block.source.type === "workspace_ref"
-  ) {
-    const attachmentId = attachmentIdMap.get(block.source.attachmentId);
-    if (!attachmentId || attachmentId === block.source.attachmentId) {
+  if (block.type === "image" || block.type === "file") {
+    const source: unknown = block.source;
+    if (
+      !isRecord(source) ||
+      source.type !== "workspace_ref" ||
+      typeof source.attachmentId !== "string"
+    ) {
+      return block;
+    }
+    const attachmentId = attachmentIdMap.get(source.attachmentId);
+    if (!attachmentId || attachmentId === source.attachmentId) {
       return block;
     }
     return {
       ...block,
-      source: { ...block.source, attachmentId },
-    };
+      source: { ...source, attachmentId },
+    } as ContentBlock;
   }
 
   if (block.type !== "tool_result" && block.type !== "web_search_tool_result") {

--- a/assistant/src/persistence/media-reference-content.ts
+++ b/assistant/src/persistence/media-reference-content.ts
@@ -1,0 +1,57 @@
+import type { ContentBlock } from "../providers/types.js";
+
+type NestedContentBlock = ContentBlock & {
+  contentBlocks?: ContentBlock[];
+};
+
+function remapWorkspaceRefAttachmentId(
+  block: ContentBlock,
+  attachmentIdMap: ReadonlyMap<string, string>,
+): ContentBlock {
+  if (
+    (block.type === "image" || block.type === "file") &&
+    block.source.type === "workspace_ref"
+  ) {
+    const attachmentId = attachmentIdMap.get(block.source.attachmentId);
+    if (!attachmentId || attachmentId === block.source.attachmentId) {
+      return block;
+    }
+    return {
+      ...block,
+      source: { ...block.source, attachmentId },
+    };
+  }
+
+  if (block.type !== "tool_result" && block.type !== "web_search_tool_result") {
+    return block;
+  }
+  const nestedBlock = block as NestedContentBlock;
+  if (!Array.isArray(nestedBlock.contentBlocks)) {
+    return block;
+  }
+  const contentBlocks = remapWorkspaceRefAttachmentIds(
+    nestedBlock.contentBlocks,
+    attachmentIdMap,
+  );
+  return contentBlocks === nestedBlock.contentBlocks
+    ? block
+    : ({ ...block, contentBlocks } as ContentBlock);
+}
+
+export function remapWorkspaceRefAttachmentIds(
+  content: ContentBlock[],
+  attachmentIdMap: ReadonlyMap<string, string>,
+): ContentBlock[] {
+  if (attachmentIdMap.size === 0) {
+    return content;
+  }
+  let remapped: ContentBlock[] | null = null;
+  for (const [index, block] of content.entries()) {
+    const nextBlock = remapWorkspaceRefAttachmentId(block, attachmentIdMap);
+    if (!remapped && nextBlock !== block) {
+      remapped = content.slice(0, index);
+    }
+    remapped?.push(nextBlock);
+  }
+  return remapped ?? content;
+}

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
@@ -26,6 +26,17 @@ const tempDirs: string[] = [];
 const DEFAULT_CONVERSATION_ID = "conversation-test";
 const DEFAULT_CONVERSATION_CREATED_AT = 1000;
 
+function preparedLexicalJob(
+  messageId: string,
+  jobId = `prepared-${messageId}`,
+) {
+  return {
+    jobId,
+    messageId,
+    fallbackRunAfter: Number.MAX_SAFE_INTEGER,
+  };
+}
+
 function createTestDb() {
   const sqlite = new Database(":memory:");
   sqlite.exec(/*sql*/ `
@@ -89,7 +100,8 @@ function createTestDb() {
     attachmentsDirFor,
     options: {
       resolveAttachmentsDir: attachmentsDirFor,
-      scheduleLexicalReindex: () => {},
+      prepareLexicalReindex: preparedLexicalJob,
+      releaseLexicalReindex: () => {},
       yieldToEventLoop: async () => {},
     },
   };
@@ -205,7 +217,8 @@ describe("migration 351: materialize historical inline message media", () => {
 
   test("materializes root and nested image/file blocks with stable links and metadata", async () => {
     const { sqlite, db, options } = createTestDb();
-    const scheduledMessageIds: string[] = [];
+    const preparedMessageIds: string[] = [];
+    const releasedMessageIds: string[] = [];
     const imageOne = Buffer.from("image-one").toString("base64");
     const fileOne = Buffer.from("file-one").toString("base64");
     const imageTwo = Buffer.from("image-two").toString("base64");
@@ -276,8 +289,12 @@ describe("migration 351: materialize historical inline message media", () => {
 
     await migrateMaterializeHistoricalInlineMessageMedia(db, {
       ...options,
-      scheduleLexicalReindex: (messageId) => {
-        scheduledMessageIds.push(messageId);
+      prepareLexicalReindex: (messageId) => {
+        preparedMessageIds.push(messageId);
+        return preparedLexicalJob(messageId);
+      },
+      releaseLexicalReindex: (prepared) => {
+        releasedMessageIds.push(prepared.messageId);
       },
     });
 
@@ -307,7 +324,8 @@ describe("migration 351: materialize historical inline message media", () => {
     expect(content[3].contentBlocks[0].source.filename).toBe("result.txt");
     expect(count(sqlite, "attachments")).toBe(5);
     expect(count(sqlite, "message_attachments")).toBe(5);
-    expect(scheduledMessageIds).toEqual(["message-1"]);
+    expect(preparedMessageIds).toEqual(["message-1"]);
+    expect(releasedMessageIds).toEqual(["message-1"]);
     const positions = (
       sqlite
         .query(
@@ -421,7 +439,7 @@ describe("migration 351: materialize historical inline message media", () => {
     );
     linkAttachment(sqlite, "message-referenced", "attachment-existing", 0);
     const reads: string[] = [];
-    const scheduledMessageIds: string[] = [];
+    const preparedMessageIds: string[] = [];
 
     await migrateMaterializeHistoricalInlineMessageMedia(db, {
       ...options,
@@ -429,13 +447,14 @@ describe("migration 351: materialize historical inline message media", () => {
         reads.push(attachmentId);
         throw new Error("linked attachment must not be read");
       },
-      scheduleLexicalReindex: (messageId) => {
-        scheduledMessageIds.push(messageId);
+      prepareLexicalReindex: (messageId) => {
+        preparedMessageIds.push(messageId);
+        return preparedLexicalJob(messageId);
       },
     });
 
     expect(reads).toEqual([]);
-    expect(scheduledMessageIds).toEqual([]);
+    expect(preparedMessageIds).toEqual([]);
     expect(messageContent(sqlite, "message-referenced")).toEqual(content);
   });
 
@@ -472,15 +491,20 @@ describe("migration 351: materialize historical inline message media", () => {
       ["attachment-never-read", Buffer.from("unused")],
     ]);
     const reads: string[] = [];
-    const scheduledMessageIds: string[] = [];
+    const preparedMessageIds: string[] = [];
+    const releasedMessageIds: string[] = [];
     const migrationOptions = {
       ...options,
       readLinkedAttachmentBytes: (attachmentId: string): Buffer | null => {
         reads.push(attachmentId);
         return candidateBytes.get(attachmentId) ?? null;
       },
-      scheduleLexicalReindex: (messageId: string): void => {
-        scheduledMessageIds.push(messageId);
+      prepareLexicalReindex: (messageId: string) => {
+        preparedMessageIds.push(messageId);
+        return preparedLexicalJob(messageId);
+      },
+      releaseLexicalReindex: (prepared: { messageId: string }): void => {
+        releasedMessageIds.push(prepared.messageId);
       },
     };
 
@@ -495,12 +519,14 @@ describe("migration 351: materialize historical inline message media", () => {
     });
     expect(count(sqlite, "attachments")).toBe(3);
     expect(count(sqlite, "message_attachments")).toBe(3);
-    expect(scheduledMessageIds).toEqual(["message-lazy-match"]);
+    expect(preparedMessageIds).toEqual(["message-lazy-match"]);
+    expect(releasedMessageIds).toEqual(["message-lazy-match"]);
 
     await migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions);
 
     expect(reads).toEqual(["attachment-wrong", "attachment-match"]);
-    expect(scheduledMessageIds).toEqual(["message-lazy-match"]);
+    expect(preparedMessageIds).toEqual(["message-lazy-match"]);
+    expect(releasedMessageIds).toEqual(["message-lazy-match"]);
     expect(count(sqlite, "attachments")).toBe(3);
     expect(count(sqlite, "message_attachments")).toBe(3);
   });
@@ -815,7 +841,7 @@ describe("migration 351: materialize historical inline message media", () => {
 
   test("leaves malformed JSON, invalid base64, and unfinalized rows untouched", async () => {
     const { sqlite, db, options, attachmentsDir } = createTestDb();
-    const scheduledMessageIds: string[] = [];
+    const preparedMessageIds: string[] = [];
     insertMessage(sqlite, "malformed-json", "{not-json");
     insertMessage(sqlite, "invalid-base64", [
       {
@@ -858,8 +884,9 @@ describe("migration 351: materialize historical inline message media", () => {
 
     await migrateMaterializeHistoricalInlineMessageMedia(db, {
       ...options,
-      scheduleLexicalReindex: (messageId) => {
-        scheduledMessageIds.push(messageId);
+      prepareLexicalReindex: (messageId) => {
+        preparedMessageIds.push(messageId);
+        return preparedLexicalJob(messageId);
       },
     });
 
@@ -868,13 +895,99 @@ describe("migration 351: materialize historical inline message media", () => {
     ).toEqual(before);
     expect(count(sqlite, "attachments")).toBe(0);
     expect(count(sqlite, "message_attachments")).toBe(0);
-    expect(scheduledMessageIds).toEqual([]);
+    expect(preparedMessageIds).toEqual([]);
     expect(existsSync(attachmentsDir)).toBe(false);
   });
 
-  test("keeps a lexical scheduling failure non-fatal after committing rewritten content", async () => {
+  test("prepares before the rewrite and releases only after its commit", async () => {
     const { sqlite, db, options } = createTestDb();
-    let schedulingAttempts = 0;
+    const events: string[] = [];
+    insertMessage(sqlite, "message-lexical-order", [
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "text/plain",
+          data: Buffer.from("ordered").toString("base64"),
+          filename: "ordered.txt",
+        },
+      },
+    ]);
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, {
+      ...options,
+      prepareLexicalReindex: (messageId) => {
+        expect(
+          (messageContent(sqlite, messageId) as Array<any>)[0].source.type,
+        ).toBe("base64");
+        events.push("prepare-before-update");
+        return preparedLexicalJob(messageId);
+      },
+      releaseLexicalReindex: (prepared) => {
+        expect(
+          (messageContent(sqlite, prepared.messageId) as Array<any>)[0].source
+            .type,
+        ).toBe("workspace_ref");
+        expect(count(sqlite, "attachments")).toBe(1);
+        events.push("release-after-commit");
+      },
+    });
+
+    expect(events).toEqual(["prepare-before-update", "release-after-commit"]);
+  });
+
+  test("leaves the row and migration checkpoint unfinished when preparation fails", async () => {
+    const { sqlite, db, options } = createTestDb();
+    const content = [
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "text/plain",
+          data: Buffer.from("retryable").toString("base64"),
+          filename: "retryable.txt",
+        },
+      },
+    ];
+    insertMessage(sqlite, "message-lexical-prepare-failure", content);
+
+    const result = await runMigrationSteps(db, [
+      {
+        name: "migrateMaterializeHistoricalInlineMessageMedia",
+        run: (migrationDb) =>
+          migrateMaterializeHistoricalInlineMessageMedia(migrationDb, {
+            ...options,
+            prepareLexicalReindex: () => {
+              throw new Error("jobs database unavailable");
+            },
+          }),
+      },
+    ]);
+
+    expect(result.failed).toEqual([
+      "migrateMaterializeHistoricalInlineMessageMedia",
+    ]);
+    expect(
+      (
+        sqlite
+          .query(
+            `SELECT value FROM memory_checkpoints
+             WHERE key = 'step:migrateMaterializeHistoricalInlineMessageMedia'`,
+          )
+          .get() as { value: string }
+      ).value,
+    ).toBe("started");
+    expect(messageContent(sqlite, "message-lexical-prepare-failure")).toEqual(
+      content,
+    );
+    expect(count(sqlite, "attachments")).toBe(0);
+    expect(count(sqlite, "message_attachments")).toBe(0);
+  });
+
+  test("keeps the deferred fallback durable when post-commit release fails", async () => {
+    const { sqlite, db, options } = createTestDb();
+    const preparedJobs: Array<ReturnType<typeof preparedLexicalJob>> = [];
+    let releaseAttempts = 0;
     insertMessage(sqlite, "message-lexical-failure", [
       {
         type: "file",
@@ -889,8 +1002,13 @@ describe("migration 351: materialize historical inline message media", () => {
 
     await migrateMaterializeHistoricalInlineMessageMedia(db, {
       ...options,
-      scheduleLexicalReindex: () => {
-        schedulingAttempts += 1;
+      prepareLexicalReindex: (messageId) => {
+        const prepared = preparedLexicalJob(messageId, `durable-${messageId}`);
+        preparedJobs.push(prepared);
+        return prepared;
+      },
+      releaseLexicalReindex: () => {
+        releaseAttempts += 1;
         throw new Error("jobs database unavailable");
       },
     });
@@ -900,7 +1018,13 @@ describe("migration 351: materialize historical inline message media", () => {
       "message-lexical-failure",
     ) as Array<any>;
     expect(content[0].source.type).toBe("workspace_ref");
-    expect(schedulingAttempts).toBe(1);
+    expect(releaseAttempts).toBe(1);
+    expect(preparedJobs).toHaveLength(1);
+    expect(preparedJobs[0]).toMatchObject({
+      jobId: "durable-message-lexical-failure",
+      messageId: "message-lexical-failure",
+    });
+    expect(preparedJobs[0]!.fallbackRunAfter).toBeGreaterThan(Date.now());
     expect(count(sqlite, "attachments")).toBe(1);
     expect(count(sqlite, "message_attachments")).toBe(1);
   });
@@ -952,11 +1076,19 @@ describe("migration 351: materialize historical inline message media", () => {
 
   test("rolls back database writes and reuses the deterministic file after interruption", async () => {
     const { sqlite, db, options, attachmentsDir } = createTestDb();
-    const scheduledMessageIds: string[] = [];
+    const preparedMessageIds: string[] = [];
+    const releasedMessageIds: string[] = [];
     const migrationOptions = {
       ...options,
-      scheduleLexicalReindex: (messageId: string): void => {
-        scheduledMessageIds.push(messageId);
+      prepareLexicalReindex: (messageId: string) => {
+        preparedMessageIds.push(messageId);
+        return preparedLexicalJob(
+          messageId,
+          `prepared-${preparedMessageIds.length}-${messageId}`,
+        );
+      },
+      releaseLexicalReindex: (prepared: { messageId: string }): void => {
+        releasedMessageIds.push(prepared.messageId);
       },
     };
     insertMessage(sqlite, "message-5", [
@@ -983,7 +1115,8 @@ describe("migration 351: materialize historical inline message media", () => {
     ).rejects.toThrow("interrupted");
     expect(count(sqlite, "attachments")).toBe(0);
     expect(count(sqlite, "message_attachments")).toBe(0);
-    expect(scheduledMessageIds).toEqual([]);
+    expect(preparedMessageIds).toEqual(["message-5"]);
+    expect(releasedMessageIds).toEqual([]);
     expect(readdirSync(attachmentsDir)).toHaveLength(1);
 
     sqlite.exec(`DROP TRIGGER fail_message_rewrite`);
@@ -993,7 +1126,8 @@ describe("migration 351: materialize historical inline message media", () => {
     expect(content[0].source.type).toBe("workspace_ref");
     expect(count(sqlite, "attachments")).toBe(1);
     expect(count(sqlite, "message_attachments")).toBe(1);
-    expect(scheduledMessageIds).toEqual(["message-5"]);
+    expect(preparedMessageIds).toEqual(["message-5", "message-5"]);
+    expect(releasedMessageIds).toEqual(["message-5"]);
     expect(readdirSync(attachmentsDir)).toHaveLength(1);
   });
 });

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
@@ -1,0 +1,537 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrationSteps } from "../steps.js";
+import { migrateMaterializeHistoricalInlineMessageMedia } from "./351-materialize-historical-inline-message-media.js";
+import { runMigrationSteps } from "./run-migrations.js";
+
+const tempDirs: string[] = [];
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(/*sql*/ `
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      content TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      finalized INTEGER NOT NULL DEFAULT 1
+    );
+    CREATE TABLE attachments (
+      id TEXT PRIMARY KEY,
+      original_filename TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      size_bytes INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      data_base64 TEXT NOT NULL,
+      content_hash TEXT,
+      thumbnail_base64 TEXT,
+      file_path TEXT,
+      created_at INTEGER NOT NULL
+    );
+    CREATE UNIQUE INDEX idx_attachments_content_dedup
+      ON attachments(content_hash) WHERE content_hash IS NOT NULL;
+    CREATE TABLE message_attachments (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      attachment_id TEXT NOT NULL REFERENCES attachments(id) ON DELETE CASCADE,
+      position INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL
+    );
+  `);
+  const attachmentsDir = mkdtempSync(join(tmpdir(), "inline-media-"));
+  tempDirs.push(attachmentsDir);
+  return {
+    sqlite,
+    db: drizzle(sqlite, { schema }),
+    options: {
+      attachmentsDir,
+      yieldToEventLoop: async () => {},
+    },
+  };
+}
+
+function insertMessage(
+  sqlite: Database,
+  id: string,
+  content: unknown,
+  finalized = 1,
+): void {
+  sqlite
+    .query(
+      `INSERT INTO messages (id, content, created_at, finalized)
+       VALUES (?, ?, 1234, ?)`,
+    )
+    .run(
+      id,
+      typeof content === "string" ? content : JSON.stringify(content),
+      finalized,
+    );
+}
+
+function messageContent(sqlite: Database, id: string): unknown {
+  const row = sqlite
+    .query(`SELECT content FROM messages WHERE id = ?`)
+    .get(id) as { content: string };
+  return JSON.parse(row.content);
+}
+
+function count(sqlite: Database, table: string): number {
+  return (
+    sqlite.query(`SELECT COUNT(*) AS count FROM ${table}`).get() as {
+      count: number;
+    }
+  ).count;
+}
+
+function historicalAttachmentId(
+  messageId: string,
+  path: string,
+  bytes: Buffer,
+): string {
+  const contentHash = createHash("sha256").update(bytes).digest("hex");
+  const identityHash = createHash("sha256")
+    .update(`${messageId}\0${path}\0${contentHash}`)
+    .digest("hex");
+  return `historical-inline-media-${identityHash}`;
+}
+
+function insertAttachment(
+  sqlite: Database,
+  id: string,
+  dataBase64: string,
+  filePath: string | null = null,
+): void {
+  sqlite
+    .query(
+      `INSERT INTO attachments (
+         id, original_filename, mime_type, size_bytes, kind, data_base64,
+         content_hash, thumbnail_base64, file_path, created_at
+       ) VALUES (?, 'existing.bin', 'application/octet-stream', ?, 'document', ?, NULL, NULL, ?, 1000)`,
+    )
+    .run(id, Buffer.from(dataBase64, "base64").length, dataBase64, filePath);
+}
+
+function linkAttachment(
+  sqlite: Database,
+  messageId: string,
+  attachmentId: string,
+  position: number,
+): void {
+  sqlite
+    .query(
+      `INSERT INTO message_attachments (
+         id, message_id, attachment_id, position, created_at
+       ) VALUES (?, ?, ?, ?, 1000)`,
+    )
+    .run(
+      `link-${messageId}-${attachmentId}`,
+      messageId,
+      attachmentId,
+      position,
+    );
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("migration 351: materialize historical inline message media", () => {
+  test("is registered as its own checkpointed migration step", () => {
+    const step = migrationSteps.find(
+      (candidate) =>
+        typeof candidate !== "function" &&
+        candidate.name === "migrateMaterializeHistoricalInlineMessageMedia",
+    );
+    expect(step).toBeDefined();
+    expect(typeof step !== "function" ? step?.run : undefined).toBe(
+      migrateMaterializeHistoricalInlineMessageMedia,
+    );
+  });
+
+  test("materializes root and nested image/file blocks with stable links and metadata", async () => {
+    const { sqlite, db, options } = createTestDb();
+    const imageOne = Buffer.from("image-one").toString("base64");
+    const fileOne = Buffer.from("file-one").toString("base64");
+    const imageTwo = Buffer.from("image-two").toString("base64");
+    const fileTwo = Buffer.from("file-two").toString("base64");
+    insertMessage(sqlite, "message-1", [
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: imageOne,
+          custom: "preserved",
+        },
+        blockMetadata: true,
+      },
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "text/plain",
+          data: fileOne,
+          filename: "notes.txt",
+        },
+        extracted_text: "notes",
+      },
+      {
+        type: "tool_result",
+        tool_use_id: "tool-1",
+        content: "generated media",
+        contentBlocks: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/jpeg",
+              data: imageTwo,
+            },
+          },
+          {
+            type: "file",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: fileTwo,
+              filename: "report.pdf",
+            },
+          },
+        ],
+      },
+    ]);
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    const content = messageContent(sqlite, "message-1") as Array<any>;
+    const converted = [
+      content[0],
+      content[1],
+      content[2].contentBlocks[0],
+      content[2].contentBlocks[1],
+    ];
+    expect(converted.map((block) => block.source.type)).toEqual([
+      "workspace_ref",
+      "workspace_ref",
+      "workspace_ref",
+      "workspace_ref",
+    ]);
+    expect(converted.map((block) => block.source.sizeBytes)).toEqual([
+      9, 8, 9, 8,
+    ]);
+    expect(content[0].source.custom).toBe("preserved");
+    expect(content[0].blockMetadata).toBe(true);
+    expect(content[1].source.filename).toBe("notes.txt");
+    expect(content[1].extracted_text).toBe("notes");
+    expect(content[2].contentBlocks[1].source.filename).toBe("report.pdf");
+    expect(count(sqlite, "attachments")).toBe(4);
+    expect(count(sqlite, "message_attachments")).toBe(4);
+    const positions = (
+      sqlite
+        .query(
+          `SELECT position FROM message_attachments
+           WHERE message_id = 'message-1' ORDER BY position`,
+        )
+        .all() as Array<{ position: number }>
+    ).map((row) => row.position);
+    expect(positions).toEqual([0, 1, 2, 3]);
+    for (const block of converted) {
+      const row = sqlite
+        .query(
+          `SELECT file_path AS filePath, content_hash AS contentHash FROM attachments WHERE id = ?`,
+        )
+        .get(block.source.attachmentId) as {
+        filePath: string;
+        contentHash: string | null;
+      };
+      expect(existsSync(row.filePath)).toBe(true);
+      expect(row.contentHash).toBeNull();
+    }
+  });
+
+  test("reuses same-message references and exact linked media without inferring by position", async () => {
+    const { sqlite, db, options } = createTestDb();
+    const fileData = Buffer.from("known-file").toString("base64");
+    const imageData = Buffer.from("known-image").toString("base64");
+    const unrelatedData = Buffer.from("unrelated").toString("base64");
+    insertMessage(sqlite, "message-2", [
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "application/octet-stream",
+          data: fileData,
+          filename: "known.bin",
+        },
+        _attachmentId: "attachment-file",
+      },
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: imageData,
+        },
+      },
+      {
+        type: "image",
+        source: {
+          type: "workspace_ref",
+          media_type: "image/png",
+          attachmentId: "already-referenced",
+          sizeBytes: 10,
+        },
+      },
+    ]);
+    insertAttachment(sqlite, "attachment-unrelated", unrelatedData);
+    insertAttachment(sqlite, "attachment-file", fileData);
+    insertAttachment(sqlite, "attachment-image", imageData);
+    linkAttachment(sqlite, "message-2", "attachment-unrelated", 0);
+    linkAttachment(sqlite, "message-2", "attachment-file", 4);
+    linkAttachment(sqlite, "message-2", "attachment-image", 7);
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    const content = messageContent(sqlite, "message-2") as Array<any>;
+    expect(content[0].source.attachmentId).toBe("attachment-file");
+    expect(content[0]._attachmentId).toBeUndefined();
+    expect(content[1].source.attachmentId).toBe("attachment-image");
+    expect(content[2].source.attachmentId).toBe("already-referenced");
+    expect(count(sqlite, "attachments")).toBe(3);
+    expect(count(sqlite, "message_attachments")).toBe(3);
+  });
+
+  test("is idempotent across rows, links, and files", async () => {
+    const { sqlite, db, options } = createTestDb();
+    insertMessage(sqlite, "message-3", [
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: Buffer.from("same-image").toString("base64"),
+        },
+      },
+    ]);
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+    const firstContent = JSON.stringify(messageContent(sqlite, "message-3"));
+    const firstFiles = readdirSync(options.attachmentsDir).sort();
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    expect(JSON.stringify(messageContent(sqlite, "message-3"))).toBe(
+      firstContent,
+    );
+    expect(count(sqlite, "attachments")).toBe(1);
+    expect(count(sqlite, "message_attachments")).toBe(1);
+    expect(readdirSync(options.attachmentsDir).sort()).toEqual(firstFiles);
+  });
+
+  test("reuses a verified deterministic row left without its message link", async () => {
+    const { sqlite, db, options } = createTestDb();
+    const bytes = Buffer.from("pre-existing-media");
+    const data = bytes.toString("base64");
+    const attachmentId = historicalAttachmentId("message-recovery", "0", bytes);
+    const filePath = join(options.attachmentsDir, attachmentId);
+    writeFileSync(filePath, bytes);
+    insertMessage(sqlite, "message-recovery", [
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "text/plain",
+          data,
+          filename: "recovery.txt",
+        },
+      },
+    ]);
+    insertAttachment(sqlite, attachmentId, "", filePath);
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    const content = messageContent(sqlite, "message-recovery") as Array<any>;
+    expect(content[0].source.attachmentId).toBe(attachmentId);
+    expect(count(sqlite, "attachments")).toBe(1);
+    expect(count(sqlite, "message_attachments")).toBe(1);
+    expect(readdirSync(options.attachmentsDir)).toEqual([attachmentId]);
+  });
+
+  test("rejects a deterministic row whose stored path conflicts with its identity", async () => {
+    const { sqlite, db, options } = createTestDb();
+    const bytes = Buffer.from("conflicting-media");
+    const data = bytes.toString("base64");
+    const attachmentId = historicalAttachmentId("message-conflict", "0", bytes);
+    const alternatePath = join(options.attachmentsDir, "alternate-file");
+    writeFileSync(alternatePath, bytes);
+    insertMessage(sqlite, "message-conflict", [
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data,
+        },
+      },
+    ]);
+    insertAttachment(sqlite, attachmentId, "", alternatePath);
+
+    expect(
+      migrateMaterializeHistoricalInlineMessageMedia(db, options),
+    ).rejects.toThrow("conflicts with deterministic identity");
+    expect(
+      (messageContent(sqlite, "message-conflict") as Array<any>)[0].source.type,
+    ).toBe("base64");
+    expect(count(sqlite, "message_attachments")).toBe(0);
+  });
+
+  test("leaves malformed JSON, invalid base64, and unfinalized rows untouched", async () => {
+    const { sqlite, db, options } = createTestDb();
+    insertMessage(sqlite, "malformed-json", "{not-json");
+    insertMessage(sqlite, "invalid-base64", [
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "text/plain",
+          data: "not base64!",
+          filename: "bad.txt",
+        },
+      },
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "text/plain",
+          data: "abcd==",
+          filename: "bad-padding.txt",
+        },
+      },
+    ]);
+    insertMessage(
+      sqlite,
+      "unfinalized",
+      [
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: Buffer.from("pending").toString("base64"),
+          },
+        },
+      ],
+      0,
+    );
+    const before = sqlite
+      .query(`SELECT id, content FROM messages ORDER BY id`)
+      .all();
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    expect(
+      sqlite.query(`SELECT id, content FROM messages ORDER BY id`).all(),
+    ).toEqual(before);
+    expect(count(sqlite, "attachments")).toBe(0);
+    expect(count(sqlite, "message_attachments")).toBe(0);
+    expect(readdirSync(options.attachmentsDir)).toEqual([]);
+  });
+
+  test("leaves a valid media write failure uncheckpointed without changing database state", async () => {
+    const { sqlite, db, options } = createTestDb();
+    const content = [
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: Buffer.from("valid-image").toString("base64"),
+        },
+      },
+    ];
+    insertMessage(sqlite, "message-4", content);
+
+    const result = await runMigrationSteps(db, [
+      {
+        name: "migrateMaterializeHistoricalInlineMessageMedia",
+        run: (migrationDb) =>
+          migrateMaterializeHistoricalInlineMessageMedia(migrationDb, {
+            ...options,
+            writeFile: () => {
+              throw new Error("disk unavailable");
+            },
+          }),
+      },
+    ]);
+
+    expect(result.failed).toEqual([
+      "migrateMaterializeHistoricalInlineMessageMedia",
+    ]);
+    expect(
+      (
+        sqlite
+          .query(
+            `SELECT value FROM memory_checkpoints
+             WHERE key = 'step:migrateMaterializeHistoricalInlineMessageMedia'`,
+          )
+          .get() as { value: string }
+      ).value,
+    ).toBe("started");
+    expect(messageContent(sqlite, "message-4")).toEqual(content);
+    expect(count(sqlite, "attachments")).toBe(0);
+    expect(count(sqlite, "message_attachments")).toBe(0);
+  });
+
+  test("rolls back database writes and reuses the deterministic file after interruption", async () => {
+    const { sqlite, db, options } = createTestDb();
+    insertMessage(sqlite, "message-5", [
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "text/plain",
+          data: Buffer.from("recoverable").toString("base64"),
+          filename: "recover.txt",
+        },
+      },
+    ]);
+    sqlite.exec(/*sql*/ `
+      CREATE TRIGGER fail_message_rewrite
+      BEFORE UPDATE ON messages
+      BEGIN
+        SELECT RAISE(ABORT, 'interrupted');
+      END;
+    `);
+
+    expect(
+      migrateMaterializeHistoricalInlineMessageMedia(db, options),
+    ).rejects.toThrow("interrupted");
+    expect(count(sqlite, "attachments")).toBe(0);
+    expect(count(sqlite, "message_attachments")).toBe(0);
+    expect(readdirSync(options.attachmentsDir)).toHaveLength(1);
+
+    sqlite.exec(`DROP TRIGGER fail_message_rewrite`);
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    const content = messageContent(sqlite, "message-5") as Array<any>;
+    expect(content[0].source.type).toBe("workspace_ref");
+    expect(count(sqlite, "attachments")).toBe(1);
+    expect(count(sqlite, "message_attachments")).toBe(1);
+    expect(readdirSync(options.attachmentsDir)).toHaveLength(1);
+  });
+});

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
@@ -89,6 +89,7 @@ function createTestDb() {
     attachmentsDirFor,
     options: {
       resolveAttachmentsDir: attachmentsDirFor,
+      scheduleLexicalReindex: () => {},
       yieldToEventLoop: async () => {},
     },
   };
@@ -204,6 +205,7 @@ describe("migration 351: materialize historical inline message media", () => {
 
   test("materializes root and nested image/file blocks with stable links and metadata", async () => {
     const { sqlite, db, options } = createTestDb();
+    const scheduledMessageIds: string[] = [];
     const imageOne = Buffer.from("image-one").toString("base64");
     const fileOne = Buffer.from("file-one").toString("base64");
     const imageTwo = Buffer.from("image-two").toString("base64");
@@ -272,7 +274,12 @@ describe("migration 351: materialize historical inline message media", () => {
       },
     ]);
 
-    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+    await migrateMaterializeHistoricalInlineMessageMedia(db, {
+      ...options,
+      scheduleLexicalReindex: (messageId) => {
+        scheduledMessageIds.push(messageId);
+      },
+    });
 
     const content = messageContent(sqlite, "message-1") as Array<any>;
     const converted = [
@@ -300,6 +307,7 @@ describe("migration 351: materialize historical inline message media", () => {
     expect(content[3].contentBlocks[0].source.filename).toBe("result.txt");
     expect(count(sqlite, "attachments")).toBe(5);
     expect(count(sqlite, "message_attachments")).toBe(5);
+    expect(scheduledMessageIds).toEqual(["message-1"]);
     const positions = (
       sqlite
         .query(
@@ -413,6 +421,7 @@ describe("migration 351: materialize historical inline message media", () => {
     );
     linkAttachment(sqlite, "message-referenced", "attachment-existing", 0);
     const reads: string[] = [];
+    const scheduledMessageIds: string[] = [];
 
     await migrateMaterializeHistoricalInlineMessageMedia(db, {
       ...options,
@@ -420,9 +429,13 @@ describe("migration 351: materialize historical inline message media", () => {
         reads.push(attachmentId);
         throw new Error("linked attachment must not be read");
       },
+      scheduleLexicalReindex: (messageId) => {
+        scheduledMessageIds.push(messageId);
+      },
     });
 
     expect(reads).toEqual([]);
+    expect(scheduledMessageIds).toEqual([]);
     expect(messageContent(sqlite, "message-referenced")).toEqual(content);
   });
 
@@ -459,11 +472,15 @@ describe("migration 351: materialize historical inline message media", () => {
       ["attachment-never-read", Buffer.from("unused")],
     ]);
     const reads: string[] = [];
+    const scheduledMessageIds: string[] = [];
     const migrationOptions = {
       ...options,
       readLinkedAttachmentBytes: (attachmentId: string): Buffer | null => {
         reads.push(attachmentId);
         return candidateBytes.get(attachmentId) ?? null;
+      },
+      scheduleLexicalReindex: (messageId: string): void => {
+        scheduledMessageIds.push(messageId);
       },
     };
 
@@ -478,10 +495,12 @@ describe("migration 351: materialize historical inline message media", () => {
     });
     expect(count(sqlite, "attachments")).toBe(3);
     expect(count(sqlite, "message_attachments")).toBe(3);
+    expect(scheduledMessageIds).toEqual(["message-lazy-match"]);
 
     await migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions);
 
     expect(reads).toEqual(["attachment-wrong", "attachment-match"]);
+    expect(scheduledMessageIds).toEqual(["message-lazy-match"]);
     expect(count(sqlite, "attachments")).toBe(3);
     expect(count(sqlite, "message_attachments")).toBe(3);
   });
@@ -796,6 +815,7 @@ describe("migration 351: materialize historical inline message media", () => {
 
   test("leaves malformed JSON, invalid base64, and unfinalized rows untouched", async () => {
     const { sqlite, db, options, attachmentsDir } = createTestDb();
+    const scheduledMessageIds: string[] = [];
     insertMessage(sqlite, "malformed-json", "{not-json");
     insertMessage(sqlite, "invalid-base64", [
       {
@@ -836,14 +856,53 @@ describe("migration 351: materialize historical inline message media", () => {
       .query(`SELECT id, content FROM messages ORDER BY id`)
       .all();
 
-    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+    await migrateMaterializeHistoricalInlineMessageMedia(db, {
+      ...options,
+      scheduleLexicalReindex: (messageId) => {
+        scheduledMessageIds.push(messageId);
+      },
+    });
 
     expect(
       sqlite.query(`SELECT id, content FROM messages ORDER BY id`).all(),
     ).toEqual(before);
     expect(count(sqlite, "attachments")).toBe(0);
     expect(count(sqlite, "message_attachments")).toBe(0);
+    expect(scheduledMessageIds).toEqual([]);
     expect(existsSync(attachmentsDir)).toBe(false);
+  });
+
+  test("keeps a lexical scheduling failure non-fatal after committing rewritten content", async () => {
+    const { sqlite, db, options } = createTestDb();
+    let schedulingAttempts = 0;
+    insertMessage(sqlite, "message-lexical-failure", [
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "text/plain",
+          data: Buffer.from("searchable").toString("base64"),
+          filename: "searchable.txt",
+        },
+      },
+    ]);
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, {
+      ...options,
+      scheduleLexicalReindex: () => {
+        schedulingAttempts += 1;
+        throw new Error("jobs database unavailable");
+      },
+    });
+
+    const content = messageContent(
+      sqlite,
+      "message-lexical-failure",
+    ) as Array<any>;
+    expect(content[0].source.type).toBe("workspace_ref");
+    expect(schedulingAttempts).toBe(1);
+    expect(count(sqlite, "attachments")).toBe(1);
+    expect(count(sqlite, "message_attachments")).toBe(1);
   });
 
   test("leaves a valid media write failure uncheckpointed without changing database state", async () => {
@@ -893,6 +952,13 @@ describe("migration 351: materialize historical inline message media", () => {
 
   test("rolls back database writes and reuses the deterministic file after interruption", async () => {
     const { sqlite, db, options, attachmentsDir } = createTestDb();
+    const scheduledMessageIds: string[] = [];
+    const migrationOptions = {
+      ...options,
+      scheduleLexicalReindex: (messageId: string): void => {
+        scheduledMessageIds.push(messageId);
+      },
+    };
     insertMessage(sqlite, "message-5", [
       {
         type: "file",
@@ -913,19 +979,21 @@ describe("migration 351: materialize historical inline message media", () => {
     `);
 
     expect(
-      migrateMaterializeHistoricalInlineMessageMedia(db, options),
+      migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions),
     ).rejects.toThrow("interrupted");
     expect(count(sqlite, "attachments")).toBe(0);
     expect(count(sqlite, "message_attachments")).toBe(0);
+    expect(scheduledMessageIds).toEqual([]);
     expect(readdirSync(attachmentsDir)).toHaveLength(1);
 
     sqlite.exec(`DROP TRIGGER fail_message_rewrite`);
-    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+    await migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions);
 
     const content = messageContent(sqlite, "message-5") as Array<any>;
     expect(content[0].source.type).toBe("workspace_ref");
     expect(count(sqlite, "attachments")).toBe(1);
     expect(count(sqlite, "message_attachments")).toBe(1);
+    expect(scheduledMessageIds).toEqual(["message-5"]);
     expect(readdirSync(attachmentsDir)).toHaveLength(1);
   });
 });

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
@@ -15,6 +15,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
+import { assertNotLiveDb } from "../../__tests__/assert-not-live-db.js";
 import { resolveConversationDirectoryPaths } from "../conversation-directories.js";
 import * as schema from "../schema.js";
 import { migrationSteps } from "../steps.js";
@@ -183,6 +184,7 @@ function linkAttachment(
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
+    assertNotLiveDb(dir);
     rmSync(dir, { recursive: true, force: true });
   }
 });
@@ -487,6 +489,7 @@ describe("migration 351: materialize historical inline message media", () => {
       1000,
       workspaceDir,
     ).resolvedDirPath;
+    assertNotLiveDb(conversationDirA);
     rmSync(conversationDirA, {
       recursive: true,
       force: true,

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, sep } from "node:path";
+import { dirname, join, sep } from "node:path";
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 
@@ -100,6 +100,8 @@ function createTestDb() {
     attachmentsDirFor,
     options: {
       resolveAttachmentsDir: attachmentsDirFor,
+      resolveMessageContentPath: (ref: string): string =>
+        join(workspaceDir, ref),
       prepareLexicalReindex: preparedLexicalJob,
       releaseLexicalReindex: () => {},
       yieldToEventLoop: async () => {},
@@ -137,6 +139,25 @@ function messageContent(sqlite: Database, id: string): unknown {
     .query(`SELECT content FROM messages WHERE id = ?`)
     .get(id) as { content: string };
   return JSON.parse(row.content);
+}
+
+function messageFinalized(sqlite: Database, id: string): number {
+  return (
+    sqlite.query(`SELECT finalized FROM messages WHERE id = ?`).get(id) as {
+      finalized: number;
+    }
+  ).finalized;
+}
+
+function writeMessageContentFile(
+  workspaceDir: string,
+  ref: string,
+  lines: unknown[],
+): string {
+  const path = join(workspaceDir, ref);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, lines.map((line) => JSON.stringify(line)).join("\n"));
+  return path;
 }
 
 function count(sqlite: Database, table: string): number {
@@ -347,6 +368,286 @@ describe("migration 351: materialize historical inline message media", () => {
       expect(existsSync(row.filePath)).toBe(true);
       expect(row.contentHash).toBeNull();
     }
+  });
+
+  test("folds finalized content refs and rewrites media inline atomically", async () => {
+    const { sqlite, db, options, workspaceDir } = createTestDb();
+    const ref = "conversations/conversation-test/inflight/message-ref.jsonl";
+    const olderImage = Buffer.from("older-image").toString("base64");
+    const rootImage = Buffer.from("root-image").toString("base64");
+    const nestedFile = Buffer.from("nested-file").toString("base64");
+    const contentPath = writeMessageContentFile(workspaceDir, ref, [
+      {
+        i: 0,
+        seq: 1,
+        block: {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: olderImage,
+          },
+        },
+      },
+      {
+        i: 0,
+        seq: 3,
+        block: {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: rootImage,
+          },
+        },
+      },
+      {
+        i: 1,
+        seq: 2,
+        block: {
+          type: "tool_result",
+          tool_use_id: "tool-ref",
+          content: "nested media",
+          contentBlocks: [
+            {
+              type: "file",
+              source: {
+                type: "base64",
+                media_type: "text/plain",
+                data: nestedFile,
+                filename: "nested.txt",
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    insertMessage(sqlite, "message-ref", JSON.stringify({ ref }));
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    const content = messageContent(sqlite, "message-ref") as Array<any>;
+    expect(content[0].source).toMatchObject({
+      type: "workspace_ref",
+      sizeBytes: Buffer.from("root-image").length,
+    });
+    expect(content[1].contentBlocks[0].source).toMatchObject({
+      type: "workspace_ref",
+      sizeBytes: Buffer.from("nested-file").length,
+      filename: "nested.txt",
+    });
+    const migratedIds = [
+      content[0].source.attachmentId,
+      content[1].contentBlocks[0].source.attachmentId,
+    ] as string[];
+    expect(
+      migratedIds.every((id) => id.startsWith("historical-inline-media-")),
+    ).toBe(true);
+    expect(count(sqlite, "attachments")).toBe(2);
+    expect(count(sqlite, "message_attachments")).toBe(2);
+    expect(readFileSync(contentPath, "utf8")).toContain(olderImage);
+
+    const firstContent = JSON.stringify(content);
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    expect(JSON.stringify(messageContent(sqlite, "message-ref"))).toBe(
+      firstContent,
+    );
+    expect(count(sqlite, "attachments")).toBe(2);
+    expect(count(sqlite, "message_attachments")).toBe(2);
+  });
+
+  test("finalizes crashed and shared content refs after materializing nested media", async () => {
+    const { sqlite, db, options, workspaceDir } = createTestDb();
+    const ref = "conversations/conversation-test/inflight/shared-ref.jsonl";
+    const mediaBytes = Buffer.from("crash-recovered-image");
+    const contentPath = writeMessageContentFile(workspaceDir, ref, [
+      {
+        i: 0,
+        seq: 1,
+        block: {
+          type: "tool_result",
+          tool_use_id: "tool-crashed",
+          content: "pending tool result",
+          contentBlocks: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: mediaBytes.toString("base64"),
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    const storedRef = JSON.stringify({ ref });
+    insertMessage(sqlite, "message-ref-crashed", storedRef, 0);
+    insertMessage(sqlite, "message-ref-shared", storedRef, 1);
+    const preparedMessageIds: string[] = [];
+    const releasedMessageIds: string[] = [];
+    const migrationOptions = {
+      ...options,
+      prepareLexicalReindex: (messageId: string) => {
+        preparedMessageIds.push(messageId);
+        return preparedLexicalJob(messageId);
+      },
+      releaseLexicalReindex: (prepared: { messageId: string }): void => {
+        releasedMessageIds.push(prepared.messageId);
+      },
+    };
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions);
+
+    const crashed = messageContent(sqlite, "message-ref-crashed") as Array<any>;
+    const shared = messageContent(sqlite, "message-ref-shared") as Array<any>;
+    for (const content of [crashed, shared]) {
+      const source = content[0].contentBlocks[0].source;
+      expect(source.type).toBe("workspace_ref");
+      expect(source.attachmentId.startsWith("historical-inline-media-")).toBe(
+        true,
+      );
+      const row = sqlite
+        .query(`SELECT file_path AS filePath FROM attachments WHERE id = ?`)
+        .get(source.attachmentId) as { filePath: string };
+      expect(readFileSync(row.filePath)).toEqual(mediaBytes);
+    }
+    expect(messageFinalized(sqlite, "message-ref-crashed")).toBe(1);
+    expect(messageFinalized(sqlite, "message-ref-shared")).toBe(1);
+    expect(preparedMessageIds).toEqual([
+      "message-ref-crashed",
+      "message-ref-shared",
+    ]);
+    expect(releasedMessageIds).toEqual(preparedMessageIds);
+    expect(count(sqlite, "attachments")).toBe(2);
+    expect(count(sqlite, "message_attachments")).toBe(2);
+    expect(existsSync(contentPath)).toBe(true);
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions);
+
+    expect(preparedMessageIds).toEqual([
+      "message-ref-crashed",
+      "message-ref-shared",
+    ]);
+    expect(releasedMessageIds).toEqual(preparedMessageIds);
+    expect(count(sqlite, "attachments")).toBe(2);
+    expect(count(sqlite, "message_attachments")).toBe(2);
+    expect(existsSync(contentPath)).toBe(true);
+  });
+
+  test("finalizes pending inline content after materializing media", async () => {
+    const { sqlite, db, options } = createTestDb();
+    insertMessage(
+      sqlite,
+      "message-pending-inline",
+      [
+        {
+          type: "file",
+          source: {
+            type: "base64",
+            media_type: "text/plain",
+            data: Buffer.from("pending-inline").toString("base64"),
+          },
+        },
+      ],
+      0,
+    );
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    const content = messageContent(
+      sqlite,
+      "message-pending-inline",
+    ) as Array<any>;
+    expect(content[0].source.type).toBe("workspace_ref");
+    expect(messageFinalized(sqlite, "message-pending-inline")).toBe(1);
+    expect(count(sqlite, "attachments")).toBe(1);
+    expect(count(sqlite, "message_attachments")).toBe(1);
+  });
+
+  test("leaves media-free pending refs unchanged without reading attachments", async () => {
+    const { sqlite, db, options, workspaceDir } = createTestDb();
+    const ref = "conversations/conversation-test/inflight/message-ref.jsonl";
+    writeMessageContentFile(workspaceDir, ref, [
+      {
+        i: 0,
+        seq: 1,
+        block: { type: "text", text: "Already externalized" },
+      },
+      {
+        i: 1,
+        seq: 2,
+        block: {
+          type: "image",
+          source: {
+            type: "workspace_ref",
+            media_type: "image/png",
+            attachmentId: "attachment-existing",
+            sizeBytes: 10,
+          },
+        },
+      },
+    ]);
+    const storedRef = { ref };
+    insertMessage(
+      sqlite,
+      "message-ref-no-inline",
+      JSON.stringify(storedRef),
+      0,
+    );
+    insertAttachment(sqlite, "attachment-existing", "");
+    linkAttachment(sqlite, "message-ref-no-inline", "attachment-existing", 0);
+    const reads: string[] = [];
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, {
+      ...options,
+      readLinkedAttachmentBytes: (attachmentId) => {
+        reads.push(attachmentId);
+        throw new Error("media-free refs must not read linked attachments");
+      },
+    });
+
+    expect(reads).toEqual([]);
+    expect(messageContent(sqlite, "message-ref-no-inline")).toEqual(storedRef);
+    expect(messageFinalized(sqlite, "message-ref-no-inline")).toBe(0);
+    expect(count(sqlite, "attachments")).toBe(1);
+    expect(count(sqlite, "message_attachments")).toBe(1);
+  });
+
+  test("leaves missing and malformed content refs unchanged", async () => {
+    const { sqlite, db, options, workspaceDir } = createTestDb();
+    const missingRef =
+      "conversations/conversation-test/inflight/missing-ref.jsonl";
+    const malformedRef =
+      "conversations/conversation-test/inflight/malformed-ref.jsonl";
+    const malformedPath = join(workspaceDir, malformedRef);
+    mkdirSync(dirname(malformedPath), { recursive: true });
+    writeFileSync(malformedPath, 'not-json\n{"i":0');
+    insertMessage(
+      sqlite,
+      "message-ref-missing",
+      JSON.stringify({ ref: missingRef }),
+    );
+    insertMessage(
+      sqlite,
+      "message-ref-malformed",
+      JSON.stringify({ ref: malformedRef }),
+      0,
+    );
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    expect(messageContent(sqlite, "message-ref-missing")).toEqual({
+      ref: missingRef,
+    });
+    expect(messageContent(sqlite, "message-ref-malformed")).toEqual({
+      ref: malformedRef,
+    });
+    expect(messageFinalized(sqlite, "message-ref-missing")).toBe(1);
+    expect(messageFinalized(sqlite, "message-ref-malformed")).toBe(0);
+    expect(count(sqlite, "attachments")).toBe(0);
+    expect(count(sqlite, "message_attachments")).toBe(0);
   });
 
   test("reuses same-message references and exact linked media without inferring by position", async () => {
@@ -839,7 +1140,7 @@ describe("migration 351: materialize historical inline message media", () => {
     expect(count(sqlite, "message_attachments")).toBe(0);
   });
 
-  test("leaves malformed JSON, invalid base64, and unfinalized rows untouched", async () => {
+  test("leaves malformed JSON and invalid base64 untouched", async () => {
     const { sqlite, db, options, attachmentsDir } = createTestDb();
     const preparedMessageIds: string[] = [];
     insertMessage(sqlite, "malformed-json", "{not-json");
@@ -863,21 +1164,6 @@ describe("migration 351: materialize historical inline message media", () => {
         },
       },
     ]);
-    insertMessage(
-      sqlite,
-      "unfinalized",
-      [
-        {
-          type: "image",
-          source: {
-            type: "base64",
-            media_type: "image/png",
-            data: Buffer.from("pending").toString("base64"),
-          },
-        },
-      ],
-      0,
-    );
     const before = sqlite
       .query(`SELECT id, content FROM messages ORDER BY id`)
       .all();

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
@@ -376,6 +376,13 @@ describe("migration 351: materialize historical inline message media", () => {
     const olderImage = Buffer.from("older-image").toString("base64");
     const rootImage = Buffer.from("root-image").toString("base64");
     const nestedFile = Buffer.from("nested-file").toString("base64");
+    const malformedText = { type: "text", text: 42 };
+    const retiredBlock = {
+      type: "ui_surface",
+      surfaceType: "historical-panel",
+      data: { preserved: true },
+    };
+    const typelessBlock = { historicalPayload: "preserved" };
     const contentPath = writeMessageContentFile(workspaceDir, ref, [
       {
         i: 0,
@@ -421,7 +428,14 @@ describe("migration 351: materialize historical inline message media", () => {
           ],
         },
       },
+      { i: 2, seq: 1, block: malformedText },
+      { i: 3, seq: 1, block: retiredBlock },
+      { i: 4, seq: 1, block: typelessBlock },
     ]);
+    writeFileSync(
+      contentPath,
+      `${readFileSync(contentPath, "utf8")}\nnot-json\n{"i":5,"seq":1,"block":`,
+    );
     insertMessage(sqlite, "message-ref", JSON.stringify({ ref }));
 
     await migrateMaterializeHistoricalInlineMessageMedia(db, options);
@@ -436,6 +450,11 @@ describe("migration 351: materialize historical inline message media", () => {
       sizeBytes: Buffer.from("nested-file").length,
       filename: "nested.txt",
     });
+    expect(content.slice(2)).toEqual([
+      malformedText,
+      retiredBlock,
+      typelessBlock,
+    ]);
     const migratedIds = [
       content[0].source.attachmentId,
       content[1].contentBlocks[0].source.attachmentId,

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
@@ -486,6 +486,104 @@ describe("migration 351: materialize historical inline message media", () => {
     expect(count(sqlite, "message_attachments")).toBe(3);
   });
 
+  test("falls back from a missing legacy hint to the matching linked attachment", async () => {
+    const { sqlite, db, options } = createTestDb();
+    const inlineBytes = Buffer.from("fork-owned-media");
+    insertMessage(sqlite, "message-missing-hint", [
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "application/octet-stream",
+          data: inlineBytes.toString("base64"),
+          filename: "fork.bin",
+        },
+        _attachmentId: "source-attachment-missing",
+      },
+    ]);
+    for (const [position, attachmentId] of [
+      "fork-attachment-match",
+      "attachment-never-read",
+    ].entries()) {
+      insertAttachment(sqlite, attachmentId, "", `/candidate/${attachmentId}`);
+      linkAttachment(sqlite, "message-missing-hint", attachmentId, position);
+    }
+    const reads: string[] = [];
+    const migrationOptions = {
+      ...options,
+      readLinkedAttachmentBytes: (attachmentId: string): Buffer | null => {
+        reads.push(attachmentId);
+        return attachmentId === "fork-attachment-match"
+          ? inlineBytes
+          : Buffer.from("unused");
+      },
+    };
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions);
+
+    const content = messageContent(
+      sqlite,
+      "message-missing-hint",
+    ) as Array<any>;
+    expect(reads).toEqual(["fork-attachment-match"]);
+    expect(content[0]._attachmentId).toBeUndefined();
+    expect(content[0].source.attachmentId).toBe("fork-attachment-match");
+    expect(count(sqlite, "attachments")).toBe(2);
+    expect(count(sqlite, "message_attachments")).toBe(2);
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions);
+
+    expect(reads).toEqual(["fork-attachment-match"]);
+    expect(count(sqlite, "attachments")).toBe(2);
+    expect(count(sqlite, "message_attachments")).toBe(2);
+  });
+
+  test("falls back after a mismatched linked hint while preserving hint priority", async () => {
+    const { sqlite, db, options } = createTestDb();
+    const inlineBytes = Buffer.from("fork-owned-media");
+    insertMessage(sqlite, "message-mismatched-hint", [
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "application/octet-stream",
+          data: inlineBytes.toString("base64"),
+          filename: "fork.bin",
+        },
+        _attachmentId: "source-attachment-stale",
+      },
+    ]);
+    for (const [attachmentId, position] of [
+      ["fork-attachment-match", 0],
+      ["source-attachment-stale", 1],
+      ["attachment-never-read", 2],
+    ] as const) {
+      insertAttachment(sqlite, attachmentId, "", `/candidate/${attachmentId}`);
+      linkAttachment(sqlite, "message-mismatched-hint", attachmentId, position);
+    }
+    const reads: string[] = [];
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, {
+      ...options,
+      readLinkedAttachmentBytes: (attachmentId) => {
+        reads.push(attachmentId);
+        return attachmentId === "fork-attachment-match"
+          ? inlineBytes
+          : Buffer.from("not-the-inline-bytes");
+      },
+    });
+
+    const content = messageContent(
+      sqlite,
+      "message-mismatched-hint",
+    ) as Array<any>;
+    expect(reads).toEqual(["source-attachment-stale", "fork-attachment-match"]);
+    expect(content[0]._attachmentId).toBeUndefined();
+    expect(content[0].source.attachmentId).toBe("fork-attachment-match");
+    expect(count(sqlite, "attachments")).toBe(3);
+    expect(count(sqlite, "message_attachments")).toBe(3);
+  });
+
   test("materializes the inline bytes when a legacy attachment ID points at different media", async () => {
     const { sqlite, db, options } = createTestDb();
     const inlineBytes = Buffer.from("correct-media");

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
@@ -585,7 +585,7 @@ describe("migration 351: materialize historical inline message media", () => {
     expect(count(sqlite, "message_attachments")).toBe(1);
   });
 
-  test("leaves media-free pending refs unchanged without reading attachments", async () => {
+  test("detaches media-free finalized refs without touching pending shared refs", async () => {
     const { sqlite, db, options, workspaceDir } = createTestDb();
     const ref = "conversations/conversation-test/inflight/message-ref.jsonl";
     writeMessageContentFile(workspaceDir, ref, [
@@ -615,23 +615,75 @@ describe("migration 351: materialize historical inline message media", () => {
       JSON.stringify(storedRef),
       0,
     );
+    insertMessage(
+      sqlite,
+      "message-ref-no-inline-finalized",
+      JSON.stringify(storedRef),
+    );
     insertAttachment(sqlite, "attachment-existing", "");
     linkAttachment(sqlite, "message-ref-no-inline", "attachment-existing", 0);
     const reads: string[] = [];
-
-    await migrateMaterializeHistoricalInlineMessageMedia(db, {
+    const preparedMessageIds: string[] = [];
+    const releasedMessageIds: string[] = [];
+    const migrationOptions = {
       ...options,
-      readLinkedAttachmentBytes: (attachmentId) => {
+      resolveAttachmentsDir: (): never => {
+        throw new Error("media-free refs must not resolve attachment storage");
+      },
+      readLinkedAttachmentBytes: (attachmentId: string): never => {
         reads.push(attachmentId);
         throw new Error("media-free refs must not read linked attachments");
       },
-    });
+      prepareLexicalReindex: (messageId: string) => {
+        preparedMessageIds.push(messageId);
+        return preparedLexicalJob(messageId);
+      },
+      releaseLexicalReindex: (prepared: { messageId: string }): void => {
+        releasedMessageIds.push(prepared.messageId);
+      },
+    };
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions);
 
     expect(reads).toEqual([]);
     expect(messageContent(sqlite, "message-ref-no-inline")).toEqual(storedRef);
     expect(messageFinalized(sqlite, "message-ref-no-inline")).toBe(0);
+    expect(messageContent(sqlite, "message-ref-no-inline-finalized")).toEqual([
+      { type: "text", text: "Already externalized" },
+      {
+        type: "image",
+        source: {
+          type: "workspace_ref",
+          media_type: "image/png",
+          attachmentId: "attachment-existing",
+          sizeBytes: 10,
+        },
+      },
+    ]);
+    expect(messageFinalized(sqlite, "message-ref-no-inline-finalized")).toBe(1);
+    expect(preparedMessageIds).toEqual(["message-ref-no-inline-finalized"]);
+    expect(releasedMessageIds).toEqual(preparedMessageIds);
     expect(count(sqlite, "attachments")).toBe(1);
     expect(count(sqlite, "message_attachments")).toBe(1);
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions);
+
+    expect(preparedMessageIds).toEqual(["message-ref-no-inline-finalized"]);
+    expect(releasedMessageIds).toEqual(preparedMessageIds);
+  });
+
+  test("detaches a readable empty finalized ref", async () => {
+    const { sqlite, db, options, workspaceDir } = createTestDb();
+    const ref = "conversations/conversation-test/inflight/empty-ref.jsonl";
+    writeMessageContentFile(workspaceDir, ref, []);
+    insertMessage(sqlite, "message-ref-empty", JSON.stringify({ ref }));
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    expect(messageContent(sqlite, "message-ref-empty")).toEqual([]);
+    expect(messageFinalized(sqlite, "message-ref-empty")).toBe(1);
+    expect(count(sqlite, "attachments")).toBe(0);
+    expect(count(sqlite, "message_attachments")).toBe(0);
   });
 
   test("leaves missing and malformed content refs unchanged", async () => {

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
@@ -1,31 +1,41 @@
 import { createHash } from "node:crypto";
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readdirSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
+import { resolveConversationDirectoryPaths } from "../conversation-directories.js";
 import * as schema from "../schema.js";
 import { migrationSteps } from "../steps.js";
 import { migrateMaterializeHistoricalInlineMessageMedia } from "./351-materialize-historical-inline-message-media.js";
 import { runMigrationSteps } from "./run-migrations.js";
 
 const tempDirs: string[] = [];
+const DEFAULT_CONVERSATION_ID = "conversation-test";
+const DEFAULT_CONVERSATION_CREATED_AT = 1000;
 
 function createTestDb() {
   const sqlite = new Database(":memory:");
   sqlite.exec(/*sql*/ `
     PRAGMA foreign_keys = ON;
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL
+    );
     CREATE TABLE messages (
       id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
       content TEXT NOT NULL,
       created_at INTEGER NOT NULL,
       finalized INTEGER NOT NULL DEFAULT 1
@@ -52,13 +62,32 @@ function createTestDb() {
       created_at INTEGER NOT NULL
     );
   `);
-  const attachmentsDir = mkdtempSync(join(tmpdir(), "inline-media-"));
-  tempDirs.push(attachmentsDir);
+  const workspaceDir = mkdtempSync(join(tmpdir(), "inline-media-"));
+  tempDirs.push(workspaceDir);
+  const attachmentsDirFor = (
+    conversationId: string,
+    conversationCreatedAt: number,
+  ): string =>
+    join(
+      resolveConversationDirectoryPaths(
+        conversationId,
+        conversationCreatedAt,
+        workspaceDir,
+      ).resolvedDirPath,
+      "attachments",
+    );
+  const attachmentsDir = attachmentsDirFor(
+    DEFAULT_CONVERSATION_ID,
+    DEFAULT_CONVERSATION_CREATED_AT,
+  );
   return {
     sqlite,
     db: drizzle(sqlite, { schema }),
+    workspaceDir,
+    attachmentsDir,
+    attachmentsDirFor,
     options: {
-      attachmentsDir,
+      resolveAttachmentsDir: attachmentsDirFor,
       yieldToEventLoop: async () => {},
     },
   };
@@ -69,14 +98,21 @@ function insertMessage(
   id: string,
   content: unknown,
   finalized = 1,
+  conversationId = DEFAULT_CONVERSATION_ID,
+  conversationCreatedAt = DEFAULT_CONVERSATION_CREATED_AT,
 ): void {
   sqlite
+    .query(`INSERT OR IGNORE INTO conversations (id, created_at) VALUES (?, ?)`)
+    .run(conversationId, conversationCreatedAt);
+  sqlite
     .query(
-      `INSERT INTO messages (id, content, created_at, finalized)
-       VALUES (?, ?, 1234, ?)`,
+      `INSERT INTO messages (
+         id, conversation_id, content, created_at, finalized
+       ) VALUES (?, ?, ?, 1234, ?)`,
     )
     .run(
       id,
+      conversationId,
       typeof content === "string" ? content : JSON.stringify(content),
       finalized,
     );
@@ -170,6 +206,7 @@ describe("migration 351: materialize historical inline message media", () => {
     const fileOne = Buffer.from("file-one").toString("base64");
     const imageTwo = Buffer.from("image-two").toString("base64");
     const fileTwo = Buffer.from("file-two").toString("base64");
+    const webFile = Buffer.from("web-file").toString("base64");
     insertMessage(sqlite, "message-1", [
       {
         type: "image",
@@ -215,6 +252,22 @@ describe("migration 351: materialize historical inline message media", () => {
           },
         ],
       },
+      {
+        type: "web_search_tool_result",
+        tool_use_id: "search-1",
+        content: [],
+        contentBlocks: [
+          {
+            type: "file",
+            source: {
+              type: "base64",
+              media_type: "text/plain",
+              data: webFile,
+              filename: "result.txt",
+            },
+          },
+        ],
+      },
     ]);
 
     await migrateMaterializeHistoricalInlineMessageMedia(db, options);
@@ -225,23 +278,26 @@ describe("migration 351: materialize historical inline message media", () => {
       content[1],
       content[2].contentBlocks[0],
       content[2].contentBlocks[1],
+      content[3].contentBlocks[0],
     ];
     expect(converted.map((block) => block.source.type)).toEqual([
       "workspace_ref",
       "workspace_ref",
       "workspace_ref",
       "workspace_ref",
+      "workspace_ref",
     ]);
     expect(converted.map((block) => block.source.sizeBytes)).toEqual([
-      9, 8, 9, 8,
+      9, 8, 9, 8, 8,
     ]);
     expect(content[0].source.custom).toBe("preserved");
     expect(content[0].blockMetadata).toBe(true);
     expect(content[1].source.filename).toBe("notes.txt");
     expect(content[1].extracted_text).toBe("notes");
     expect(content[2].contentBlocks[1].source.filename).toBe("report.pdf");
-    expect(count(sqlite, "attachments")).toBe(4);
-    expect(count(sqlite, "message_attachments")).toBe(4);
+    expect(content[3].contentBlocks[0].source.filename).toBe("result.txt");
+    expect(count(sqlite, "attachments")).toBe(5);
+    expect(count(sqlite, "message_attachments")).toBe(5);
     const positions = (
       sqlite
         .query(
@@ -250,7 +306,7 @@ describe("migration 351: materialize historical inline message media", () => {
         )
         .all() as Array<{ position: number }>
     ).map((row) => row.position);
-    expect(positions).toEqual([0, 1, 2, 3]);
+    expect(positions).toEqual([0, 1, 2, 3, 4]);
     for (const block of converted) {
       const row = sqlite
         .query(
@@ -317,8 +373,45 @@ describe("migration 351: materialize historical inline message media", () => {
     expect(count(sqlite, "message_attachments")).toBe(3);
   });
 
-  test("is idempotent across rows, links, and files", async () => {
+  test("materializes the inline bytes when a legacy attachment ID points at different media", async () => {
     const { sqlite, db, options } = createTestDb();
+    const inlineBytes = Buffer.from("correct-media");
+    insertMessage(sqlite, "message-stale-link", [
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "application/octet-stream",
+          data: inlineBytes.toString("base64"),
+          filename: "correct.bin",
+        },
+        _attachmentId: "attachment-stale",
+      },
+    ]);
+    insertAttachment(
+      sqlite,
+      "attachment-stale",
+      Buffer.from("wrong-media").toString("base64"),
+    );
+    linkAttachment(sqlite, "message-stale-link", "attachment-stale", 0);
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    const content = messageContent(sqlite, "message-stale-link") as Array<any>;
+    const recoveredId = content[0].source.attachmentId as string;
+    expect(recoveredId.startsWith("historical-inline-media-")).toBe(true);
+    expect(recoveredId).not.toBe("attachment-stale");
+    expect(content[0]._attachmentId).toBeUndefined();
+    const recovered = sqlite
+      .query(`SELECT file_path AS filePath FROM attachments WHERE id = ?`)
+      .get(recoveredId) as { filePath: string };
+    expect(readFileSync(recovered.filePath)).toEqual(inlineBytes);
+    expect(count(sqlite, "attachments")).toBe(2);
+    expect(count(sqlite, "message_attachments")).toBe(2);
+  });
+
+  test("is idempotent across rows, links, and files", async () => {
+    const { sqlite, db, options, attachmentsDir } = createTestDb();
     insertMessage(sqlite, "message-3", [
       {
         type: "image",
@@ -332,7 +425,7 @@ describe("migration 351: materialize historical inline message media", () => {
 
     await migrateMaterializeHistoricalInlineMessageMedia(db, options);
     const firstContent = JSON.stringify(messageContent(sqlite, "message-3"));
-    const firstFiles = readdirSync(options.attachmentsDir).sort();
+    const firstFiles = readdirSync(attachmentsDir).sort();
     await migrateMaterializeHistoricalInlineMessageMedia(db, options);
 
     expect(JSON.stringify(messageContent(sqlite, "message-3"))).toBe(
@@ -340,15 +433,103 @@ describe("migration 351: materialize historical inline message media", () => {
     );
     expect(count(sqlite, "attachments")).toBe(1);
     expect(count(sqlite, "message_attachments")).toBe(1);
-    expect(readdirSync(options.attachmentsDir).sort()).toEqual(firstFiles);
+    expect(readdirSync(attachmentsDir).sort()).toEqual(firstFiles);
+  });
+
+  test("stores files under independently removable conversation directories", async () => {
+    const { sqlite, db, options, attachmentsDirFor, workspaceDir } =
+      createTestDb();
+    const insertInlineFile = (
+      messageId: string,
+      conversationId: string,
+      conversationCreatedAt: number,
+    ): void => {
+      insertMessage(
+        sqlite,
+        messageId,
+        [
+          {
+            type: "file",
+            source: {
+              type: "base64",
+              media_type: "text/plain",
+              data: Buffer.from(messageId).toString("base64"),
+              filename: `${messageId}.txt`,
+            },
+          },
+        ],
+        1,
+        conversationId,
+        conversationCreatedAt,
+      );
+    };
+    insertInlineFile("message-a", "conversation-a", 1000);
+    insertInlineFile("message-b", "conversation-b", 2000);
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, options);
+
+    const rows = sqlite
+      .query(
+        `SELECT m.conversation_id AS conversationId, a.file_path AS filePath
+         FROM message_attachments ma
+         JOIN messages m ON m.id = ma.message_id
+         JOIN attachments a ON a.id = ma.attachment_id
+         ORDER BY m.conversation_id`,
+      )
+      .all() as Array<{ conversationId: string; filePath: string }>;
+    const attachmentsDirA = attachmentsDirFor("conversation-a", 1000);
+    const attachmentsDirB = attachmentsDirFor("conversation-b", 2000);
+    expect(rows[0].filePath.startsWith(`${attachmentsDirA}${sep}`)).toBe(true);
+    expect(rows[1].filePath.startsWith(`${attachmentsDirB}${sep}`)).toBe(true);
+
+    const conversationDirA = resolveConversationDirectoryPaths(
+      "conversation-a",
+      1000,
+      workspaceDir,
+    ).resolvedDirPath;
+    rmSync(conversationDirA, {
+      recursive: true,
+      force: true,
+    });
+    expect(existsSync(rows[0].filePath)).toBe(false);
+    expect(existsSync(rows[1].filePath)).toBe(true);
+  });
+
+  test("rejects path-traversal-shaped conversation IDs before writing files", async () => {
+    const { sqlite, db, options, workspaceDir } = createTestDb();
+    insertMessage(
+      sqlite,
+      "message-unsafe-conversation",
+      [
+        {
+          type: "file",
+          source: {
+            type: "base64",
+            media_type: "text/plain",
+            data: Buffer.from("unsafe").toString("base64"),
+          },
+        },
+      ],
+      1,
+      "../outside",
+      1000,
+    );
+
+    expect(
+      migrateMaterializeHistoricalInlineMessageMedia(db, options),
+    ).rejects.toThrow("unsafe conversation ID");
+    expect(readdirSync(workspaceDir)).toEqual([]);
+    expect(count(sqlite, "attachments")).toBe(0);
+    expect(count(sqlite, "message_attachments")).toBe(0);
   });
 
   test("reuses a verified deterministic row left without its message link", async () => {
-    const { sqlite, db, options } = createTestDb();
+    const { sqlite, db, options, attachmentsDir } = createTestDb();
     const bytes = Buffer.from("pre-existing-media");
     const data = bytes.toString("base64");
     const attachmentId = historicalAttachmentId("message-recovery", "0", bytes);
-    const filePath = join(options.attachmentsDir, attachmentId);
+    const filePath = join(attachmentsDir, attachmentId);
+    mkdirSync(attachmentsDir, { recursive: true });
     writeFileSync(filePath, bytes);
     insertMessage(sqlite, "message-recovery", [
       {
@@ -369,15 +550,16 @@ describe("migration 351: materialize historical inline message media", () => {
     expect(content[0].source.attachmentId).toBe(attachmentId);
     expect(count(sqlite, "attachments")).toBe(1);
     expect(count(sqlite, "message_attachments")).toBe(1);
-    expect(readdirSync(options.attachmentsDir)).toEqual([attachmentId]);
+    expect(readdirSync(attachmentsDir)).toEqual([attachmentId]);
   });
 
   test("rejects a deterministic row whose stored path conflicts with its identity", async () => {
-    const { sqlite, db, options } = createTestDb();
+    const { sqlite, db, options, attachmentsDir } = createTestDb();
     const bytes = Buffer.from("conflicting-media");
     const data = bytes.toString("base64");
     const attachmentId = historicalAttachmentId("message-conflict", "0", bytes);
-    const alternatePath = join(options.attachmentsDir, "alternate-file");
+    const alternatePath = join(attachmentsDir, "alternate-file");
+    mkdirSync(attachmentsDir, { recursive: true });
     writeFileSync(alternatePath, bytes);
     insertMessage(sqlite, "message-conflict", [
       {
@@ -401,7 +583,7 @@ describe("migration 351: materialize historical inline message media", () => {
   });
 
   test("leaves malformed JSON, invalid base64, and unfinalized rows untouched", async () => {
-    const { sqlite, db, options } = createTestDb();
+    const { sqlite, db, options, attachmentsDir } = createTestDb();
     insertMessage(sqlite, "malformed-json", "{not-json");
     insertMessage(sqlite, "invalid-base64", [
       {
@@ -449,7 +631,7 @@ describe("migration 351: materialize historical inline message media", () => {
     ).toEqual(before);
     expect(count(sqlite, "attachments")).toBe(0);
     expect(count(sqlite, "message_attachments")).toBe(0);
-    expect(readdirSync(options.attachmentsDir)).toEqual([]);
+    expect(existsSync(attachmentsDir)).toBe(false);
   });
 
   test("leaves a valid media write failure uncheckpointed without changing database state", async () => {
@@ -498,7 +680,7 @@ describe("migration 351: materialize historical inline message media", () => {
   });
 
   test("rolls back database writes and reuses the deterministic file after interruption", async () => {
-    const { sqlite, db, options } = createTestDb();
+    const { sqlite, db, options, attachmentsDir } = createTestDb();
     insertMessage(sqlite, "message-5", [
       {
         type: "file",
@@ -523,7 +705,7 @@ describe("migration 351: materialize historical inline message media", () => {
     ).rejects.toThrow("interrupted");
     expect(count(sqlite, "attachments")).toBe(0);
     expect(count(sqlite, "message_attachments")).toBe(0);
-    expect(readdirSync(options.attachmentsDir)).toHaveLength(1);
+    expect(readdirSync(attachmentsDir)).toHaveLength(1);
 
     sqlite.exec(`DROP TRIGGER fail_message_rewrite`);
     await migrateMaterializeHistoricalInlineMessageMedia(db, options);
@@ -532,6 +714,6 @@ describe("migration 351: materialize historical inline message media", () => {
     expect(content[0].source.type).toBe("workspace_ref");
     expect(count(sqlite, "attachments")).toBe(1);
     expect(count(sqlite, "message_attachments")).toBe(1);
-    expect(readdirSync(options.attachmentsDir)).toHaveLength(1);
+    expect(readdirSync(attachmentsDir)).toHaveLength(1);
   });
 });

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
@@ -375,6 +375,117 @@ describe("migration 351: materialize historical inline message media", () => {
     expect(count(sqlite, "message_attachments")).toBe(3);
   });
 
+  test("skips linked attachment reads when recursive content has no inline media", async () => {
+    const { sqlite, db, options } = createTestDb();
+    const content = [
+      {
+        type: "image",
+        source: {
+          type: "workspace_ref",
+          media_type: "image/png",
+          attachmentId: "attachment-existing",
+          sizeBytes: 1_000_000_000,
+        },
+      },
+      {
+        type: "tool_result",
+        tool_use_id: "tool-1",
+        content: "existing",
+        contentBlocks: [
+          {
+            type: "file",
+            source: {
+              type: "workspace_ref",
+              media_type: "application/octet-stream",
+              attachmentId: "attachment-existing",
+              sizeBytes: 1_000_000_000,
+            },
+          },
+        ],
+      },
+    ];
+    insertMessage(sqlite, "message-referenced", content);
+    insertAttachment(
+      sqlite,
+      "attachment-existing",
+      "",
+      "/unreadable/large-attachment.bin",
+    );
+    linkAttachment(sqlite, "message-referenced", "attachment-existing", 0);
+    const reads: string[] = [];
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, {
+      ...options,
+      readLinkedAttachmentBytes: (attachmentId) => {
+        reads.push(attachmentId);
+        throw new Error("linked attachment must not be read");
+      },
+    });
+
+    expect(reads).toEqual([]);
+    expect(messageContent(sqlite, "message-referenced")).toEqual(content);
+  });
+
+  test("reads linked candidates lazily and skips all reads on an idempotent replay", async () => {
+    const { sqlite, db, options } = createTestDb();
+    const inlineBytes = Buffer.from("matching-inline-file");
+    insertMessage(sqlite, "message-lazy-match", [
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "application/octet-stream",
+          data: inlineBytes.toString("base64"),
+          filename: "match.bin",
+        },
+      },
+    ]);
+    for (const [position, attachmentId] of [
+      "attachment-wrong",
+      "attachment-match",
+      "attachment-never-read",
+    ].entries()) {
+      insertAttachment(
+        sqlite,
+        attachmentId,
+        "",
+        `/candidate/${attachmentId}.bin`,
+      );
+      linkAttachment(sqlite, "message-lazy-match", attachmentId, position);
+    }
+    const candidateBytes = new Map<string, Buffer>([
+      ["attachment-wrong", Buffer.from("wrong")],
+      ["attachment-match", inlineBytes],
+      ["attachment-never-read", Buffer.from("unused")],
+    ]);
+    const reads: string[] = [];
+    const migrationOptions = {
+      ...options,
+      readLinkedAttachmentBytes: (attachmentId: string): Buffer | null => {
+        reads.push(attachmentId);
+        return candidateBytes.get(attachmentId) ?? null;
+      },
+    };
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions);
+
+    const content = messageContent(sqlite, "message-lazy-match") as Array<any>;
+    expect(reads).toEqual(["attachment-wrong", "attachment-match"]);
+    expect(content[0].source).toMatchObject({
+      type: "workspace_ref",
+      attachmentId: "attachment-match",
+      sizeBytes: inlineBytes.length,
+    });
+    expect(count(sqlite, "attachments")).toBe(3);
+    expect(count(sqlite, "message_attachments")).toBe(3);
+
+    await migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions);
+
+    expect(reads).toEqual(["attachment-wrong", "attachment-match"]);
+    expect(count(sqlite, "attachments")).toBe(3);
+    expect(count(sqlite, "message_attachments")).toBe(3);
+  });
+
   test("materializes the inline bytes when a legacy attachment ID points at different media", async () => {
     const { sqlite, db, options } = createTestDb();
     const inlineBytes = Buffer.from("correct-media");

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.test.ts
@@ -1144,7 +1144,7 @@ describe("migration 351: materialize historical inline message media", () => {
       1000,
     );
 
-    expect(
+    await expect(
       migrateMaterializeHistoricalInlineMessageMedia(db, options),
     ).rejects.toThrow("unsafe conversation ID");
     expect(readdirSync(workspaceDir)).toEqual([]);
@@ -1202,7 +1202,7 @@ describe("migration 351: materialize historical inline message media", () => {
     ]);
     insertAttachment(sqlite, attachmentId, "", alternatePath);
 
-    expect(
+    await expect(
       migrateMaterializeHistoricalInlineMessageMedia(db, options),
     ).rejects.toThrow("conflicts with deterministic identity");
     expect(
@@ -1467,7 +1467,7 @@ describe("migration 351: materialize historical inline message media", () => {
       END;
     `);
 
-    expect(
+    await expect(
       migrateMaterializeHistoricalInlineMessageMedia(db, migrationOptions),
     ).rejects.toThrow("interrupted");
     expect(count(sqlite, "attachments")).toBe(0);

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
@@ -19,7 +19,6 @@ import {
   releasePreparedLexicalIndexJob,
 } from "../job-handlers/message-lexical.js";
 import {
-  foldContentFile,
   parseContentRef,
   resolveContentRefPath,
 } from "../message-content-file.js";
@@ -136,6 +135,43 @@ function readableAttachmentBytes(row: AttachmentRow): Buffer | null {
     }
   }
   return decodeBase64(row.dataBase64);
+}
+
+function foldContentFileLosslessly(path: string): unknown[] | null {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  const byIndex = new Map<number, { seq: number; block: unknown }>();
+  for (const line of text.split("\n")) {
+    if (!line) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (
+      !isRecord(parsed) ||
+      !Number.isInteger(parsed.i) ||
+      typeof parsed.seq !== "number" ||
+      !("block" in parsed)
+    ) {
+      continue;
+    }
+    const index = parsed.i as number;
+    const existing = byIndex.get(index);
+    if (!existing || parsed.seq > existing.seq) {
+      byIndex.set(index, { seq: parsed.seq, block: parsed.block });
+    }
+  }
+  return [...byIndex.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([, entry]) => entry.block);
 }
 
 function byteSignature(bytes: Buffer): ByteSignature {
@@ -332,7 +368,7 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         if (!contentPath) {
           continue;
         }
-        const folded = foldContentFile(contentPath);
+        const folded = foldContentFileLosslessly(contentPath);
         if (!folded) {
           continue;
         }

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
@@ -336,6 +336,27 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         linkedRows.reduce((max, item) => Math.max(max, item.position), -1) + 1;
       let changed = false;
 
+      function* attachmentCandidates(
+        hintedAttachmentId: unknown,
+      ): Generator<LinkedAttachmentRow> {
+        const hinted =
+          typeof hintedAttachmentId === "string"
+            ? linkedById.get(hintedAttachmentId)
+            : undefined;
+        if (hinted) {
+          yield hinted;
+        }
+        for (const linked of linkedRows) {
+          if (
+            linked.linkId === hinted?.linkId ||
+            consumedLinkIds.has(linked.linkId)
+          ) {
+            continue;
+          }
+          yield linked;
+        }
+      }
+
       const getAttachmentsDir = (): string => {
         if (attachmentsDir) {
           return attachmentsDir;
@@ -396,40 +417,19 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         const inlineSignature = byteSignature(inlineBytes);
 
         let selected: SelectedAttachment | undefined;
-        if (typeof block._attachmentId === "string") {
-          const linked = linkedById.get(block._attachmentId);
-          if (linked) {
-            const match = matchAttachmentToBlock(
-              linked,
-              readLinkedAttachmentBytes,
-              block.type as "image" | "file",
-              mediaType,
-              inlineSignature,
-              attachmentSignatureCache,
-              optimizedSignatureCache,
-            );
-            if (match) {
-              selected = { row: linked, match };
-            }
-          }
-        } else {
-          for (const linked of linkedRows) {
-            if (consumedLinkIds.has(linked.linkId)) {
-              continue;
-            }
-            const match = matchAttachmentToBlock(
-              linked,
-              readLinkedAttachmentBytes,
-              block.type as "image" | "file",
-              mediaType,
-              inlineSignature,
-              attachmentSignatureCache,
-              optimizedSignatureCache,
-            );
-            if (match) {
-              selected = { row: linked, match };
-              break;
-            }
+        for (const linked of attachmentCandidates(block._attachmentId)) {
+          const match = matchAttachmentToBlock(
+            linked,
+            readLinkedAttachmentBytes,
+            block.type as "image" | "file",
+            mediaType,
+            inlineSignature,
+            attachmentSignatureCache,
+            optimizedSignatureCache,
+          );
+          if (match) {
+            selected = { row: linked, match };
+            break;
           }
         }
 

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
@@ -4,6 +4,7 @@ import { join, resolve, sep } from "node:path";
 
 import { optimizeImageForTransport } from "../../agent/image-optimize.js";
 import { parseImageDimensions } from "../../context/image-dimensions.js";
+import { getLogger } from "../../util/logger.js";
 import { getConversationsDir } from "../../util/platform.js";
 import { classifyKind } from "../attachments-store.js";
 import {
@@ -12,6 +13,9 @@ import {
 } from "../conversation-directories.js";
 import type { DrizzleDb } from "../db-connection.js";
 import { getSqliteFrom } from "../db-connection.js";
+import { enqueueLexicalIndexForMessage } from "../job-handlers/message-lexical.js";
+
+const log = getLogger("migration-historical-inline-media");
 
 const BATCH_SIZE = 10;
 const ATTACHMENT_ID_PREFIX = "historical-inline-media-";
@@ -24,6 +28,7 @@ export interface HistoricalInlineMediaMigrationOptions {
   ) => string;
   writeFile?: (path: string, data: Buffer) => void;
   readLinkedAttachmentBytes?: (attachmentId: string) => Buffer | null;
+  scheduleLexicalReindex?: (messageId: string) => void;
   yieldToEventLoop?: () => Promise<void>;
 }
 
@@ -259,6 +264,8 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
     options.resolveAttachmentsDir ?? defaultResolveAttachmentsDir;
   const writeFile = options.writeFile ?? defaultWriteFile;
   const yieldToEventLoop = options.yieldToEventLoop ?? defaultYield;
+  const scheduleLexicalReindex =
+    options.scheduleLexicalReindex ?? enqueueLexicalIndexForMessage;
   const readLinkedAttachmentBytes =
     options.readLinkedAttachmentBytes ??
     ((attachmentId: string): Buffer | null => {
@@ -579,6 +586,18 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         if (result.changes !== 1) {
           throw new Error(
             `Historical inline media message changed during migration: ${row.id}`,
+          );
+        }
+        // The lexical queue lives in a separate database. Enqueue after the
+        // guarded update but before this transaction commits so a crash cannot
+        // leave committed content without a pending idempotent reindex job.
+        // A queue failure stays non-fatal, matching the canonical enqueue seam.
+        try {
+          scheduleLexicalReindex(row.id);
+        } catch (err) {
+          log.warn(
+            { err, messageId: row.id },
+            "Failed to schedule lexical reindex after inline-media migration",
           );
         }
       });

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
@@ -1,11 +1,15 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
 
 import { optimizeImageForTransport } from "../../agent/image-optimize.js";
 import { parseImageDimensions } from "../../context/image-dimensions.js";
-import { getWorkspaceDir } from "../../util/platform.js";
+import { getConversationsDir } from "../../util/platform.js";
 import { classifyKind } from "../attachments-store.js";
+import {
+  getConversationAttachmentsDirPath,
+  isFilesystemSafeConversationId,
+} from "../conversation-directories.js";
 import type { DrizzleDb } from "../db-connection.js";
 import { getSqliteFrom } from "../db-connection.js";
 
@@ -14,7 +18,10 @@ const ATTACHMENT_ID_PREFIX = "historical-inline-media-";
 const LINK_ID_PREFIX = "historical-inline-media-link-";
 
 export interface HistoricalInlineMediaMigrationOptions {
-  attachmentsDir?: string;
+  resolveAttachmentsDir?: (
+    conversationId: string,
+    conversationCreatedAt: number,
+  ) => string;
   writeFile?: (path: string, data: Buffer) => void;
   yieldToEventLoop?: () => Promise<void>;
 }
@@ -24,6 +31,8 @@ interface MessageRow {
   id: string;
   content: string;
   createdAt: number;
+  conversationId: string;
+  conversationCreatedAt: number;
 }
 
 interface AttachmentRow {
@@ -155,6 +164,22 @@ function defaultYield(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+function defaultResolveAttachmentsDir(
+  conversationId: string,
+  conversationCreatedAt: number,
+): string {
+  const conversationsDir = resolve(getConversationsDir());
+  const attachmentsDir = resolve(
+    getConversationAttachmentsDirPath(conversationId, conversationCreatedAt),
+  );
+  if (!attachmentsDir.startsWith(`${conversationsDir}${sep}`)) {
+    throw new Error(
+      `Historical inline media conversation ID escapes the conversations directory: ${conversationId}`,
+    );
+  }
+  return attachmentsDir;
+}
+
 /**
  * Materialize base64 media from finalized inline message content into stable
  * attachment references. Each message's attachment rows, links, and content
@@ -166,20 +191,26 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
   options: HistoricalInlineMediaMigrationOptions = {},
 ): Promise<void> {
   const raw = getSqliteFrom(database);
-  const attachmentsDir =
-    options.attachmentsDir ?? join(getWorkspaceDir(), "data", "attachments");
+  const resolveAttachmentsDir =
+    options.resolveAttachmentsDir ?? defaultResolveAttachmentsDir;
   const writeFile = options.writeFile ?? defaultWriteFile;
   const yieldToEventLoop = options.yieldToEventLoop ?? defaultYield;
-  mkdirSync(attachmentsDir, { recursive: true });
 
   let lastRowid = 0;
   for (;;) {
     const rows = raw
       .query(
-        `SELECT rowid, id, content, created_at AS createdAt
-         FROM messages
-         WHERE finalized = 1 AND rowid > ?
-         ORDER BY rowid
+        `SELECT
+           m.rowid AS rowid,
+           m.id,
+           m.content,
+           m.created_at AS createdAt,
+           m.conversation_id AS conversationId,
+           c.created_at AS conversationCreatedAt
+         FROM messages m
+         JOIN conversations c ON c.id = m.conversation_id
+         WHERE m.finalized = 1 AND m.rowid > ?
+         ORDER BY m.rowid
          LIMIT ?`,
       )
       .all(lastRowid, BATCH_SIZE) as MessageRow[];
@@ -222,9 +253,27 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
       const consumedLinkIds = new Set<string>();
       const pendingAttachments: PendingAttachment[] = [];
       const pendingLinks: PendingLink[] = [];
+      let attachmentsDir: string | null = null;
       let nextPosition =
         linkedRows.reduce((max, item) => Math.max(max, item.position), -1) + 1;
       let changed = false;
+
+      const getAttachmentsDir = (): string => {
+        if (attachmentsDir) {
+          return attachmentsDir;
+        }
+        if (!isFilesystemSafeConversationId(row.conversationId)) {
+          throw new Error(
+            `Historical inline media has an unsafe conversation ID: ${row.conversationId}`,
+          );
+        }
+        attachmentsDir = resolveAttachmentsDir(
+          row.conversationId,
+          row.conversationCreatedAt,
+        );
+        mkdirSync(attachmentsDir, { recursive: true });
+        return attachmentsDir;
+      };
 
       const convert = (
         block: unknown,
@@ -234,7 +283,8 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
           return block;
         }
         if (
-          block.type === "tool_result" &&
+          (block.type === "tool_result" ||
+            block.type === "web_search_tool_result") &&
           Array.isArray(block.contentBlocks)
         ) {
           const contentBlocks = block.contentBlocks;
@@ -269,11 +319,20 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         let selected: LinkedAttachmentRow | undefined;
         if (typeof block._attachmentId === "string") {
           const linked = linkedById.get(block._attachmentId);
-          if (linked && (linkedBytes.get(linked.linkId)?.length ?? 0) > 0) {
+          if (
+            linked &&
+            attachmentMatchesBlock(
+              linked,
+              linkedBytes.get(linked.linkId) ?? null,
+              block.type as "image" | "file",
+              mediaType,
+              inlineBytes,
+              optimizedBytesCache,
+            )
+          ) {
             selected = linked;
           }
-        }
-        if (!selected) {
+        } else {
           selected = linkedRows.find(
             (linked) =>
               !consumedLinkIds.has(linked.linkId) &&
@@ -298,7 +357,7 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
           attachmentId = `${ATTACHMENT_ID_PREFIX}${sha256(
             `${row.id}\0${jsonPath}\0${contentHash}`,
           )}`;
-          const filePath = join(attachmentsDir, attachmentId);
+          const filePath = join(getAttachmentsDir(), attachmentId);
           ensureDeterministicFile(filePath, inlineBytes, writeFile);
           const recovered = raw
             .query(

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
@@ -18,6 +18,11 @@ import {
   prepareLexicalIndexForMessage,
   releasePreparedLexicalIndexJob,
 } from "../job-handlers/message-lexical.js";
+import {
+  foldContentFile,
+  parseContentRef,
+  resolveContentRefPath,
+} from "../message-content-file.js";
 
 const log = getLogger("migration-historical-inline-media");
 
@@ -32,6 +37,7 @@ export interface HistoricalInlineMediaMigrationOptions {
   ) => string;
   writeFile?: (path: string, data: Buffer) => void;
   readLinkedAttachmentBytes?: (attachmentId: string) => Buffer | null;
+  resolveMessageContentPath?: (ref: string) => string | null;
   prepareLexicalReindex?: (messageId: string) => PreparedLexicalIndexJob;
   releaseLexicalReindex?: (prepared: PreparedLexicalIndexJob) => void;
   yieldToEventLoop?: () => Promise<void>;
@@ -44,6 +50,7 @@ interface MessageRow {
   createdAt: number;
   conversationId: string;
   conversationCreatedAt: number;
+  finalized: number;
 }
 
 interface AttachmentRow {
@@ -255,10 +262,12 @@ function defaultResolveAttachmentsDir(
 }
 
 /**
- * Materialize base64 media from finalized inline message content into stable
- * attachment references. Each message's attachment rows, links, and content
- * rewrite commit together; deterministic files are written and verified first
- * so an interrupted run can safely reuse them.
+ * Materialize base64 media from inline and file-backed message content into
+ * stable attachment references. Readable content refs are folded into the
+ * atomic database rewrite, and touched pending rows become finalized. Each
+ * message's attachment rows, links, and content rewrite commit together;
+ * deterministic files are written and verified first so an interrupted run
+ * can safely reuse them.
  */
 export async function migrateMaterializeHistoricalInlineMessageMedia(
   database: DrizzleDb,
@@ -288,6 +297,8 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         .get(attachmentId) as AttachmentRow | null;
       return attachment ? readableAttachmentBytes(attachment) : null;
     });
+  const resolveMessageContentPath =
+    options.resolveMessageContentPath ?? resolveContentRefPath;
 
   let lastRowid = 0;
   for (;;) {
@@ -299,10 +310,11 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
            m.content,
            m.created_at AS createdAt,
            m.conversation_id AS conversationId,
-           c.created_at AS conversationCreatedAt
+           c.created_at AS conversationCreatedAt,
+           m.finalized
          FROM messages m
          JOIN conversations c ON c.id = m.conversation_id
-         WHERE m.finalized = 1 AND m.rowid > ?
+         WHERE m.rowid > ?
          ORDER BY m.rowid
          LIMIT ?`,
       )
@@ -313,14 +325,29 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
 
     for (const row of rows) {
       lastRowid = row.rowid;
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(row.content);
-      } catch {
-        continue;
-      }
-      if (!Array.isArray(parsed)) {
-        continue;
+      let parsed: unknown[];
+      const contentRef = parseContentRef(row.content);
+      if (contentRef) {
+        const contentPath = resolveMessageContentPath(contentRef.ref);
+        if (!contentPath) {
+          continue;
+        }
+        const folded = foldContentFile(contentPath);
+        if (!folded) {
+          continue;
+        }
+        parsed = folded;
+      } else {
+        let inline: unknown;
+        try {
+          inline = JSON.parse(row.content);
+        } catch {
+          continue;
+        }
+        if (!Array.isArray(inline)) {
+          continue;
+        }
+        parsed = inline;
       }
       if (!parsed.some(hasInlineMediaToMaterialize)) {
         continue;
@@ -587,10 +614,10 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         }
         const result = raw
           .query(
-            `UPDATE messages SET content = ?
-             WHERE id = ? AND content = ? AND finalized = 1`,
+            `UPDATE messages SET content = ?, finalized = 1
+             WHERE id = ? AND content = ? AND finalized = ?`,
           )
-          .run(rewrittenContent, row.id, row.content);
+          .run(rewrittenContent, row.id, row.content, row.finalized);
         if (result.changes !== 1) {
           throw new Error(
             `Historical inline media message changed during migration: ${row.id}`,

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
@@ -47,6 +47,16 @@ interface LinkedAttachmentRow extends AttachmentRow {
   position: number;
 }
 
+interface AttachmentMatch {
+  kind: "exact" | "optimized";
+  storedBytes: Buffer;
+}
+
+interface SelectedAttachment {
+  row: LinkedAttachmentRow;
+  match: AttachmentMatch;
+}
+
 interface PendingAttachment {
   id: string;
   originalFilename: string;
@@ -103,22 +113,22 @@ function readableAttachmentBytes(row: AttachmentRow): Buffer | null {
   return decodeBase64(row.dataBase64);
 }
 
-function attachmentMatchesBlock(
+function matchAttachmentToBlock(
   row: AttachmentRow,
   storedBytes: Buffer | null,
   blockType: "image" | "file",
   mediaType: string,
   inlineBytes: Buffer,
   optimizedBytesCache: Map<string, Buffer | null>,
-): boolean {
+): AttachmentMatch | null {
   if (!storedBytes) {
-    return false;
+    return null;
   }
   if (storedBytes.equals(inlineBytes)) {
-    return true;
+    return { kind: "exact", storedBytes };
   }
   if (blockType !== "image") {
-    return false;
+    return null;
   }
   const cacheKey = `${row.id}\0${mediaType}`;
   if (!optimizedBytesCache.has(cacheKey)) {
@@ -131,7 +141,9 @@ function attachmentMatchesBlock(
       optimized.mediaType === mediaType ? decodeBase64(optimized.data) : null,
     );
   }
-  return optimizedBytesCache.get(cacheKey)?.equals(inlineBytes) === true;
+  return optimizedBytesCache.get(cacheKey)?.equals(inlineBytes) === true
+    ? { kind: "optimized", storedBytes }
+    : null;
 }
 
 function ensureDeterministicFile(
@@ -316,43 +328,48 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
           return block;
         }
 
-        let selected: LinkedAttachmentRow | undefined;
+        let selected: SelectedAttachment | undefined;
         if (typeof block._attachmentId === "string") {
           const linked = linkedById.get(block._attachmentId);
-          if (
-            linked &&
-            attachmentMatchesBlock(
+          if (linked) {
+            const match = matchAttachmentToBlock(
               linked,
               linkedBytes.get(linked.linkId) ?? null,
               block.type as "image" | "file",
               mediaType,
               inlineBytes,
               optimizedBytesCache,
-            )
-          ) {
-            selected = linked;
+            );
+            if (match) {
+              selected = { row: linked, match };
+            }
           }
         } else {
-          selected = linkedRows.find(
-            (linked) =>
-              !consumedLinkIds.has(linked.linkId) &&
-              attachmentMatchesBlock(
-                linked,
-                linkedBytes.get(linked.linkId) ?? null,
-                block.type as "image" | "file",
-                mediaType,
-                inlineBytes,
-                optimizedBytesCache,
-              ),
-          );
+          for (const linked of linkedRows) {
+            if (consumedLinkIds.has(linked.linkId)) {
+              continue;
+            }
+            const match = matchAttachmentToBlock(
+              linked,
+              linkedBytes.get(linked.linkId) ?? null,
+              block.type as "image" | "file",
+              mediaType,
+              inlineBytes,
+              optimizedBytesCache,
+            );
+            if (match) {
+              selected = { row: linked, match };
+              break;
+            }
+          }
         }
 
         const jsonPath = path.join("/");
         const contentHash = sha256(inlineBytes);
         let attachmentId: string;
         if (selected) {
-          attachmentId = selected.id;
-          consumedLinkIds.add(selected.linkId);
+          attachmentId = selected.row.id;
+          consumedLinkIds.add(selected.row.linkId);
         } else {
           attachmentId = `${ATTACHMENT_ID_PREFIX}${sha256(
             `${row.id}\0${jsonPath}\0${contentHash}`,
@@ -406,11 +423,20 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         }
 
         const { data: _data, ...sourceMetadata } = block.source;
+        const referenceMediaType =
+          selected?.match.kind === "optimized"
+            ? selected.row.mimeType
+            : mediaType;
+        const referenceSizeBytes =
+          selected?.match.kind === "optimized"
+            ? selected.match.storedBytes.length
+            : inlineBytes.length;
         const nextSource: Record<string, unknown> = {
           ...sourceMetadata,
           type: "workspace_ref",
+          media_type: referenceMediaType,
           attachmentId,
-          sizeBytes: inlineBytes.length,
+          sizeBytes: referenceSizeBytes,
         };
         if (block.type === "image") {
           const optimized = optimizeImageForTransport(data, mediaType);

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
@@ -1,0 +1,442 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { optimizeImageForTransport } from "../../agent/image-optimize.js";
+import { parseImageDimensions } from "../../context/image-dimensions.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { classifyKind } from "../attachments-store.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+const BATCH_SIZE = 10;
+const ATTACHMENT_ID_PREFIX = "historical-inline-media-";
+const LINK_ID_PREFIX = "historical-inline-media-link-";
+
+export interface HistoricalInlineMediaMigrationOptions {
+  attachmentsDir?: string;
+  writeFile?: (path: string, data: Buffer) => void;
+  yieldToEventLoop?: () => Promise<void>;
+}
+
+interface MessageRow {
+  rowid: number;
+  id: string;
+  content: string;
+  createdAt: number;
+}
+
+interface AttachmentRow {
+  id: string;
+  dataBase64: string;
+  filePath: string | null;
+  mimeType: string;
+}
+
+interface LinkedAttachmentRow extends AttachmentRow {
+  linkId: string;
+  position: number;
+}
+
+interface PendingAttachment {
+  id: string;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  kind: string;
+  filePath: string;
+  createdAt: number;
+}
+
+interface PendingLink {
+  id: string;
+  attachmentId: string;
+  position: number;
+  createdAt: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function decodeBase64(data: string): Buffer | null {
+  if (!data || !/^[A-Za-z0-9+/]*={0,2}$/.test(data)) {
+    return null;
+  }
+  const unpadded = data.replace(/=+$/, "");
+  if (unpadded.length % 4 === 1) {
+    return null;
+  }
+  const paddingLength = data.length - unpadded.length;
+  const canonicalPaddingLength = (4 - (unpadded.length % 4)) % 4;
+  if (paddingLength !== 0 && paddingLength !== canonicalPaddingLength) {
+    return null;
+  }
+  const decoded = Buffer.from(unpadded, "base64");
+  if (decoded.toString("base64").replace(/=+$/, "") !== unpadded) {
+    return null;
+  }
+  return decoded;
+}
+
+function readableAttachmentBytes(row: AttachmentRow): Buffer | null {
+  if (row.filePath) {
+    try {
+      return readFileSync(row.filePath);
+    } catch {
+      return null;
+    }
+  }
+  return decodeBase64(row.dataBase64);
+}
+
+function attachmentMatchesBlock(
+  row: AttachmentRow,
+  storedBytes: Buffer | null,
+  blockType: "image" | "file",
+  mediaType: string,
+  inlineBytes: Buffer,
+  optimizedBytesCache: Map<string, Buffer | null>,
+): boolean {
+  if (!storedBytes) {
+    return false;
+  }
+  if (storedBytes.equals(inlineBytes)) {
+    return true;
+  }
+  if (blockType !== "image") {
+    return false;
+  }
+  const cacheKey = `${row.id}\0${mediaType}`;
+  if (!optimizedBytesCache.has(cacheKey)) {
+    const optimized = optimizeImageForTransport(
+      storedBytes.toString("base64"),
+      row.mimeType,
+    );
+    optimizedBytesCache.set(
+      cacheKey,
+      optimized.mediaType === mediaType ? decodeBase64(optimized.data) : null,
+    );
+  }
+  return optimizedBytesCache.get(cacheKey)?.equals(inlineBytes) === true;
+}
+
+function ensureDeterministicFile(
+  filePath: string,
+  bytes: Buffer,
+  writeFile: (path: string, data: Buffer) => void,
+): void {
+  let existing: Buffer;
+  try {
+    existing = readFileSync(filePath);
+  } catch (error) {
+    if (!isRecord(error) || error.code !== "ENOENT") {
+      throw error;
+    }
+    writeFile(filePath, bytes);
+    return;
+  }
+  if (!existing.equals(bytes)) {
+    throw new Error(
+      `Historical inline media path contains different bytes: ${filePath}`,
+    );
+  }
+}
+
+function defaultWriteFile(path: string, data: Buffer): void {
+  writeFileSync(path, data, { flag: "wx" });
+}
+
+function defaultYield(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Materialize base64 media from finalized inline message content into stable
+ * attachment references. Each message's attachment rows, links, and content
+ * rewrite commit together; deterministic files are written and verified first
+ * so an interrupted run can safely reuse them.
+ */
+export async function migrateMaterializeHistoricalInlineMessageMedia(
+  database: DrizzleDb,
+  options: HistoricalInlineMediaMigrationOptions = {},
+): Promise<void> {
+  const raw = getSqliteFrom(database);
+  const attachmentsDir =
+    options.attachmentsDir ?? join(getWorkspaceDir(), "data", "attachments");
+  const writeFile = options.writeFile ?? defaultWriteFile;
+  const yieldToEventLoop = options.yieldToEventLoop ?? defaultYield;
+  mkdirSync(attachmentsDir, { recursive: true });
+
+  let lastRowid = 0;
+  for (;;) {
+    const rows = raw
+      .query(
+        `SELECT rowid, id, content, created_at AS createdAt
+         FROM messages
+         WHERE finalized = 1 AND rowid > ?
+         ORDER BY rowid
+         LIMIT ?`,
+      )
+      .all(lastRowid, BATCH_SIZE) as MessageRow[];
+    if (rows.length === 0) {
+      return;
+    }
+
+    for (const row of rows) {
+      lastRowid = row.rowid;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(row.content);
+      } catch {
+        continue;
+      }
+      if (!Array.isArray(parsed)) {
+        continue;
+      }
+
+      const linkedRows = raw
+        .query(
+          `SELECT
+             ma.id AS linkId,
+             ma.position,
+             a.id,
+             a.data_base64 AS dataBase64,
+             a.file_path AS filePath,
+             a.mime_type AS mimeType
+           FROM message_attachments ma
+           JOIN attachments a ON a.id = ma.attachment_id
+           WHERE ma.message_id = ?
+           ORDER BY ma.position, ma.rowid`,
+        )
+        .all(row.id) as LinkedAttachmentRow[];
+      const linkedById = new Map(linkedRows.map((item) => [item.id, item]));
+      const linkedBytes = new Map(
+        linkedRows.map((item) => [item.linkId, readableAttachmentBytes(item)]),
+      );
+      const optimizedBytesCache = new Map<string, Buffer | null>();
+      const consumedLinkIds = new Set<string>();
+      const pendingAttachments: PendingAttachment[] = [];
+      const pendingLinks: PendingLink[] = [];
+      let nextPosition =
+        linkedRows.reduce((max, item) => Math.max(max, item.position), -1) + 1;
+      let changed = false;
+
+      const convert = (
+        block: unknown,
+        path: readonly (string | number)[],
+      ): unknown => {
+        if (!isRecord(block)) {
+          return block;
+        }
+        if (
+          block.type === "tool_result" &&
+          Array.isArray(block.contentBlocks)
+        ) {
+          const contentBlocks = block.contentBlocks;
+          const nextContentBlocks = contentBlocks.map((child, index) =>
+            convert(child, [...path, "contentBlocks", index]),
+          );
+          if (
+            nextContentBlocks.some(
+              (child, index) => child !== contentBlocks[index],
+            )
+          ) {
+            return { ...block, contentBlocks: nextContentBlocks };
+          }
+          return block;
+        }
+        if (block.type !== "image" && block.type !== "file") {
+          return block;
+        }
+        if (!isRecord(block.source) || block.source.type !== "base64") {
+          return block;
+        }
+        const mediaType = block.source.media_type;
+        const data = block.source.data;
+        if (typeof mediaType !== "string" || typeof data !== "string") {
+          return block;
+        }
+        const inlineBytes = decodeBase64(data);
+        if (!inlineBytes) {
+          return block;
+        }
+
+        let selected: LinkedAttachmentRow | undefined;
+        if (typeof block._attachmentId === "string") {
+          const linked = linkedById.get(block._attachmentId);
+          if (linked && (linkedBytes.get(linked.linkId)?.length ?? 0) > 0) {
+            selected = linked;
+          }
+        }
+        if (!selected) {
+          selected = linkedRows.find(
+            (linked) =>
+              !consumedLinkIds.has(linked.linkId) &&
+              attachmentMatchesBlock(
+                linked,
+                linkedBytes.get(linked.linkId) ?? null,
+                block.type as "image" | "file",
+                mediaType,
+                inlineBytes,
+                optimizedBytesCache,
+              ),
+          );
+        }
+
+        const jsonPath = path.join("/");
+        const contentHash = sha256(inlineBytes);
+        let attachmentId: string;
+        if (selected) {
+          attachmentId = selected.id;
+          consumedLinkIds.add(selected.linkId);
+        } else {
+          attachmentId = `${ATTACHMENT_ID_PREFIX}${sha256(
+            `${row.id}\0${jsonPath}\0${contentHash}`,
+          )}`;
+          const filePath = join(attachmentsDir, attachmentId);
+          ensureDeterministicFile(filePath, inlineBytes, writeFile);
+          const recovered = raw
+            .query(
+              `SELECT
+                 id,
+                 data_base64 AS dataBase64,
+                 file_path AS filePath,
+                 mime_type AS mimeType
+               FROM attachments WHERE id = ?`,
+            )
+            .get(attachmentId) as AttachmentRow | null;
+          if (recovered) {
+            const recoveredBytes = readableAttachmentBytes(recovered);
+            if (
+              recovered.filePath !== filePath ||
+              !recoveredBytes?.equals(inlineBytes)
+            ) {
+              throw new Error(
+                `Historical inline media attachment conflicts with deterministic identity: ${attachmentId}`,
+              );
+            }
+          } else {
+            pendingAttachments.push({
+              id: attachmentId,
+              originalFilename:
+                typeof block.source.filename === "string"
+                  ? block.source.filename
+                  : block.type === "image"
+                    ? "image"
+                    : "attachment",
+              mimeType: mediaType,
+              sizeBytes: inlineBytes.length,
+              kind: classifyKind(mediaType),
+              filePath,
+              createdAt: row.createdAt,
+            });
+          }
+          pendingLinks.push({
+            id: `${LINK_ID_PREFIX}${sha256(
+              `${row.id}\0${jsonPath}\0${attachmentId}`,
+            )}`,
+            attachmentId,
+            position: nextPosition++,
+            createdAt: row.createdAt,
+          });
+        }
+
+        const { data: _data, ...sourceMetadata } = block.source;
+        const nextSource: Record<string, unknown> = {
+          ...sourceMetadata,
+          type: "workspace_ref",
+          attachmentId,
+          sizeBytes: inlineBytes.length,
+        };
+        if (block.type === "image") {
+          const optimized = optimizeImageForTransport(data, mediaType);
+          const dimensions = parseImageDimensions(
+            optimized.data,
+            optimized.mediaType,
+          );
+          if (dimensions) {
+            nextSource.width = dimensions.width;
+            nextSource.height = dimensions.height;
+          }
+        }
+        const { _attachmentId: _legacyAttachmentId, ...blockMetadata } = block;
+        changed = true;
+        return { ...blockMetadata, source: nextSource };
+      };
+
+      const rewritten = parsed.map((block, index) => convert(block, [index]));
+      if (!changed) {
+        continue;
+      }
+      const rewrittenContent = JSON.stringify(rewritten);
+
+      const applyMessage = raw.transaction(() => {
+        for (const attachment of pendingAttachments) {
+          raw
+            .query(
+              `INSERT INTO attachments (
+                 id, original_filename, mime_type, size_bytes, kind,
+                 data_base64, content_hash, thumbnail_base64, file_path, created_at
+               ) VALUES (?, ?, ?, ?, ?, '', NULL, NULL, ?, ?)`,
+            )
+            .run(
+              attachment.id,
+              attachment.originalFilename,
+              attachment.mimeType,
+              attachment.sizeBytes,
+              attachment.kind,
+              attachment.filePath,
+              attachment.createdAt,
+            );
+        }
+        for (const link of pendingLinks) {
+          raw
+            .query(
+              `INSERT INTO message_attachments (
+                 id, message_id, attachment_id, position, created_at
+               )
+               SELECT ?, ?, ?, ?, ?
+               WHERE NOT EXISTS (
+                 SELECT 1 FROM message_attachments
+                 WHERE message_id = ? AND attachment_id = ?
+               )`,
+            )
+            .run(
+              link.id,
+              row.id,
+              link.attachmentId,
+              link.position,
+              link.createdAt,
+              row.id,
+              link.attachmentId,
+            );
+        }
+        const result = raw
+          .query(
+            `UPDATE messages SET content = ?
+             WHERE id = ? AND content = ? AND finalized = 1`,
+          )
+          .run(rewrittenContent, row.id, row.content);
+        if (result.changes !== 1) {
+          throw new Error(
+            `Historical inline media message changed during migration: ${row.id}`,
+          );
+        }
+      });
+      applyMessage();
+    }
+
+    await yieldToEventLoop();
+  }
+}
+
+export function migrateMaterializeHistoricalInlineMessageMediaDown(
+  _database: DrizzleDb,
+): void {
+  // Materialized files and references remain valid across rollback.
+}

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
@@ -299,11 +299,12 @@ function defaultResolveAttachmentsDir(
 
 /**
  * Materialize base64 media from inline and file-backed message content into
- * stable attachment references. Readable content refs are folded into the
- * atomic database rewrite, and touched pending rows become finalized. Each
- * message's attachment rows, links, and content rewrite commit together;
- * deterministic files are written and verified first so an interrupted run
- * can safely reuse them.
+ * stable attachment references. Readable finalized refs are detached into an
+ * inline atomic rewrite even when they contain no media, while pending refs
+ * remain available to recovery unless their media is migrated. Each message's
+ * attachment rows, links, and content rewrite commit together; deterministic
+ * files are written and verified first so an interrupted run can safely reuse
+ * them.
  */
 export async function migrateMaterializeHistoricalInlineMessageMedia(
   database: DrizzleDb,
@@ -385,23 +386,28 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         }
         parsed = inline;
       }
-      if (!parsed.some(hasInlineMediaToMaterialize)) {
+      const hasInlineMedia = parsed.some(hasInlineMediaToMaterialize);
+      const shouldDetachFinalizedRef =
+        contentRef !== null && row.finalized === 1;
+      if (!hasInlineMedia && !shouldDetachFinalizedRef) {
         continue;
       }
 
-      const linkedRows = raw
-        .query(
-          `SELECT
-             ma.id AS linkId,
-             ma.position,
-             a.id,
-             a.mime_type AS mimeType
-           FROM message_attachments ma
-           JOIN attachments a ON a.id = ma.attachment_id
-           WHERE ma.message_id = ?
-           ORDER BY ma.position, ma.rowid`,
-        )
-        .all(row.id) as LinkedAttachmentRow[];
+      const linkedRows = hasInlineMedia
+        ? (raw
+            .query(
+              `SELECT
+                 ma.id AS linkId,
+                 ma.position,
+                 a.id,
+                 a.mime_type AS mimeType
+               FROM message_attachments ma
+               JOIN attachments a ON a.id = ma.attachment_id
+               WHERE ma.message_id = ?
+               ORDER BY ma.position, ma.rowid`,
+            )
+            .all(row.id) as LinkedAttachmentRow[])
+        : [];
       const linkedById = new Map(linkedRows.map((item) => [item.id, item]));
       const attachmentSignatureCache = new Map<string, ByteSignature | null>();
       const optimizedSignatureCache = new Map<string, ByteSignature | null>();
@@ -411,7 +417,7 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
       let attachmentsDir: string | null = null;
       let nextPosition =
         linkedRows.reduce((max, item) => Math.max(max, item.position), -1) + 1;
-      let changed = false;
+      let changed = shouldDetachFinalizedRef;
 
       function* attachmentCandidates(
         hintedAttachmentId: unknown,

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
@@ -23,6 +23,7 @@ export interface HistoricalInlineMediaMigrationOptions {
     conversationCreatedAt: number,
   ) => string;
   writeFile?: (path: string, data: Buffer) => void;
+  readLinkedAttachmentBytes?: (attachmentId: string) => Buffer | null;
   yieldToEventLoop?: () => Promise<void>;
 }
 
@@ -42,14 +43,21 @@ interface AttachmentRow {
   mimeType: string;
 }
 
-interface LinkedAttachmentRow extends AttachmentRow {
+interface LinkedAttachmentRow {
+  id: string;
+  mimeType: string;
   linkId: string;
   position: number;
 }
 
 interface AttachmentMatch {
   kind: "exact" | "optimized";
-  storedBytes: Buffer;
+  storedSizeBytes: number;
+}
+
+interface ByteSignature {
+  digest: string;
+  sizeBytes: number;
 }
 
 interface SelectedAttachment {
@@ -113,36 +121,80 @@ function readableAttachmentBytes(row: AttachmentRow): Buffer | null {
   return decodeBase64(row.dataBase64);
 }
 
+function byteSignature(bytes: Buffer): ByteSignature {
+  return { digest: sha256(bytes), sizeBytes: bytes.length };
+}
+
+function signaturesMatch(left: ByteSignature, right: ByteSignature): boolean {
+  return left.sizeBytes === right.sizeBytes && left.digest === right.digest;
+}
+
+function hasInlineMediaToMaterialize(block: unknown): boolean {
+  if (!isRecord(block)) {
+    return false;
+  }
+  if (block.type === "image" || block.type === "file") {
+    return (
+      isRecord(block.source) &&
+      block.source.type === "base64" &&
+      typeof block.source.media_type === "string" &&
+      typeof block.source.data === "string"
+    );
+  }
+  return (
+    (block.type === "tool_result" || block.type === "web_search_tool_result") &&
+    Array.isArray(block.contentBlocks) &&
+    block.contentBlocks.some(hasInlineMediaToMaterialize)
+  );
+}
+
 function matchAttachmentToBlock(
-  row: AttachmentRow,
-  storedBytes: Buffer | null,
+  row: LinkedAttachmentRow,
+  readAttachmentBytes: (attachmentId: string) => Buffer | null,
   blockType: "image" | "file",
   mediaType: string,
-  inlineBytes: Buffer,
-  optimizedBytesCache: Map<string, Buffer | null>,
+  inlineSignature: ByteSignature,
+  attachmentSignatureCache: Map<string, ByteSignature | null>,
+  optimizedSignatureCache: Map<string, ByteSignature | null>,
 ): AttachmentMatch | null {
-  if (!storedBytes) {
+  let storedBytes: Buffer | null = null;
+  let storedSignature = attachmentSignatureCache.get(row.id);
+  if (storedSignature === undefined) {
+    storedBytes = readAttachmentBytes(row.id);
+    storedSignature = storedBytes ? byteSignature(storedBytes) : null;
+    attachmentSignatureCache.set(row.id, storedSignature);
+  }
+  if (!storedSignature) {
     return null;
   }
-  if (storedBytes.equals(inlineBytes)) {
-    return { kind: "exact", storedBytes };
+  if (signaturesMatch(storedSignature, inlineSignature)) {
+    return { kind: "exact", storedSizeBytes: storedSignature.sizeBytes };
   }
   if (blockType !== "image") {
     return null;
   }
   const cacheKey = `${row.id}\0${mediaType}`;
-  if (!optimizedBytesCache.has(cacheKey)) {
+  if (!optimizedSignatureCache.has(cacheKey)) {
+    storedBytes ??= readAttachmentBytes(row.id);
+    if (!storedBytes) {
+      optimizedSignatureCache.set(cacheKey, null);
+      return null;
+    }
     const optimized = optimizeImageForTransport(
       storedBytes.toString("base64"),
       row.mimeType,
     );
-    optimizedBytesCache.set(
+    const optimizedBytes =
+      optimized.mediaType === mediaType ? decodeBase64(optimized.data) : null;
+    optimizedSignatureCache.set(
       cacheKey,
-      optimized.mediaType === mediaType ? decodeBase64(optimized.data) : null,
+      optimizedBytes ? byteSignature(optimizedBytes) : null,
     );
   }
-  return optimizedBytesCache.get(cacheKey)?.equals(inlineBytes) === true
-    ? { kind: "optimized", storedBytes }
+  const optimizedSignature = optimizedSignatureCache.get(cacheKey);
+  return optimizedSignature &&
+    signaturesMatch(optimizedSignature, inlineSignature)
+    ? { kind: "optimized", storedSizeBytes: storedSignature.sizeBytes }
     : null;
 }
 
@@ -207,6 +259,21 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
     options.resolveAttachmentsDir ?? defaultResolveAttachmentsDir;
   const writeFile = options.writeFile ?? defaultWriteFile;
   const yieldToEventLoop = options.yieldToEventLoop ?? defaultYield;
+  const readLinkedAttachmentBytes =
+    options.readLinkedAttachmentBytes ??
+    ((attachmentId: string): Buffer | null => {
+      const attachment = raw
+        .query(
+          `SELECT
+             id,
+             data_base64 AS dataBase64,
+             file_path AS filePath,
+             mime_type AS mimeType
+           FROM attachments WHERE id = ?`,
+        )
+        .get(attachmentId) as AttachmentRow | null;
+      return attachment ? readableAttachmentBytes(attachment) : null;
+    });
 
   let lastRowid = 0;
   for (;;) {
@@ -241,6 +308,9 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
       if (!Array.isArray(parsed)) {
         continue;
       }
+      if (!parsed.some(hasInlineMediaToMaterialize)) {
+        continue;
+      }
 
       const linkedRows = raw
         .query(
@@ -248,8 +318,6 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
              ma.id AS linkId,
              ma.position,
              a.id,
-             a.data_base64 AS dataBase64,
-             a.file_path AS filePath,
              a.mime_type AS mimeType
            FROM message_attachments ma
            JOIN attachments a ON a.id = ma.attachment_id
@@ -258,10 +326,8 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         )
         .all(row.id) as LinkedAttachmentRow[];
       const linkedById = new Map(linkedRows.map((item) => [item.id, item]));
-      const linkedBytes = new Map(
-        linkedRows.map((item) => [item.linkId, readableAttachmentBytes(item)]),
-      );
-      const optimizedBytesCache = new Map<string, Buffer | null>();
+      const attachmentSignatureCache = new Map<string, ByteSignature | null>();
+      const optimizedSignatureCache = new Map<string, ByteSignature | null>();
       const consumedLinkIds = new Set<string>();
       const pendingAttachments: PendingAttachment[] = [];
       const pendingLinks: PendingLink[] = [];
@@ -327,6 +393,7 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         if (!inlineBytes) {
           return block;
         }
+        const inlineSignature = byteSignature(inlineBytes);
 
         let selected: SelectedAttachment | undefined;
         if (typeof block._attachmentId === "string") {
@@ -334,11 +401,12 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
           if (linked) {
             const match = matchAttachmentToBlock(
               linked,
-              linkedBytes.get(linked.linkId) ?? null,
+              readLinkedAttachmentBytes,
               block.type as "image" | "file",
               mediaType,
-              inlineBytes,
-              optimizedBytesCache,
+              inlineSignature,
+              attachmentSignatureCache,
+              optimizedSignatureCache,
             );
             if (match) {
               selected = { row: linked, match };
@@ -351,11 +419,12 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
             }
             const match = matchAttachmentToBlock(
               linked,
-              linkedBytes.get(linked.linkId) ?? null,
+              readLinkedAttachmentBytes,
               block.type as "image" | "file",
               mediaType,
-              inlineBytes,
-              optimizedBytesCache,
+              inlineSignature,
+              attachmentSignatureCache,
+              optimizedSignatureCache,
             );
             if (match) {
               selected = { row: linked, match };
@@ -365,7 +434,7 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         }
 
         const jsonPath = path.join("/");
-        const contentHash = sha256(inlineBytes);
+        const contentHash = inlineSignature.digest;
         let attachmentId: string;
         if (selected) {
           attachmentId = selected.row.id;
@@ -429,7 +498,7 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
             : mediaType;
         const referenceSizeBytes =
           selected?.match.kind === "optimized"
-            ? selected.match.storedBytes.length
+            ? selected.match.storedSizeBytes
             : inlineBytes.length;
         const nextSource: Record<string, unknown> = {
           ...sourceMetadata,

--- a/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
+++ b/assistant/src/persistence/migrations/351-materialize-historical-inline-message-media.ts
@@ -13,7 +13,11 @@ import {
 } from "../conversation-directories.js";
 import type { DrizzleDb } from "../db-connection.js";
 import { getSqliteFrom } from "../db-connection.js";
-import { enqueueLexicalIndexForMessage } from "../job-handlers/message-lexical.js";
+import {
+  type PreparedLexicalIndexJob,
+  prepareLexicalIndexForMessage,
+  releasePreparedLexicalIndexJob,
+} from "../job-handlers/message-lexical.js";
 
 const log = getLogger("migration-historical-inline-media");
 
@@ -28,7 +32,8 @@ export interface HistoricalInlineMediaMigrationOptions {
   ) => string;
   writeFile?: (path: string, data: Buffer) => void;
   readLinkedAttachmentBytes?: (attachmentId: string) => Buffer | null;
-  scheduleLexicalReindex?: (messageId: string) => void;
+  prepareLexicalReindex?: (messageId: string) => PreparedLexicalIndexJob;
+  releaseLexicalReindex?: (prepared: PreparedLexicalIndexJob) => void;
   yieldToEventLoop?: () => Promise<void>;
 }
 
@@ -264,8 +269,10 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
     options.resolveAttachmentsDir ?? defaultResolveAttachmentsDir;
   const writeFile = options.writeFile ?? defaultWriteFile;
   const yieldToEventLoop = options.yieldToEventLoop ?? defaultYield;
-  const scheduleLexicalReindex =
-    options.scheduleLexicalReindex ?? enqueueLexicalIndexForMessage;
+  const prepareLexicalReindex =
+    options.prepareLexicalReindex ?? prepareLexicalIndexForMessage;
+  const releaseLexicalReindex =
+    options.releaseLexicalReindex ?? releasePreparedLexicalIndexJob;
   const readLinkedAttachmentBytes =
     options.readLinkedAttachmentBytes ??
     ((attachmentId: string): Buffer | null => {
@@ -535,6 +542,7 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
         continue;
       }
       const rewrittenContent = JSON.stringify(rewritten);
+      const preparedLexicalReindex = prepareLexicalReindex(row.id);
 
       const applyMessage = raw.transaction(() => {
         for (const attachment of pendingAttachments) {
@@ -588,20 +596,21 @@ export async function migrateMaterializeHistoricalInlineMessageMedia(
             `Historical inline media message changed during migration: ${row.id}`,
           );
         }
-        // The lexical queue lives in a separate database. Enqueue after the
-        // guarded update but before this transaction commits so a crash cannot
-        // leave committed content without a pending idempotent reindex job.
-        // A queue failure stays non-fatal, matching the canonical enqueue seam.
-        try {
-          scheduleLexicalReindex(row.id);
-        } catch (err) {
-          log.warn(
-            { err, messageId: row.id },
-            "Failed to schedule lexical reindex after inline-media migration",
-          );
-        }
       });
       applyMessage();
+      try {
+        releaseLexicalReindex(preparedLexicalReindex);
+      } catch (err) {
+        log.warn(
+          {
+            err,
+            jobId: preparedLexicalReindex.jobId,
+            messageId: row.id,
+            fallbackRunAfter: preparedLexicalReindex.fallbackRunAfter,
+          },
+          "Failed to release prepared lexical reindex after inline-media migration",
+        );
+      }
     }
 
     await yieldToEventLoop();

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -458,6 +458,10 @@ import { migrateDeleteStrayGreetingConversation } from "./migrations/347-delete-
 import { migrateMemorySummariesScopeUpdatedIndex } from "./migrations/348-memory-summaries-scope-updated-index.js";
 import { migrateMoveMemoryGraphTablesToMemoryDb } from "./migrations/349-move-memory-graph-tables-to-memory-db.js";
 import { migrateConversationsTotalInputTokensNullable } from "./migrations/350-conversations-total-input-tokens-nullable.js";
+import {
+  migrateMaterializeHistoricalInlineMessageMedia,
+  migrateMaterializeHistoricalInlineMessageMediaDown,
+} from "./migrations/351-materialize-historical-inline-message-media.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1473,4 +1477,16 @@ export const migrationSteps: MigrationStep[] = [
     ],
   },
   migrateConversationsTotalInputTokensNullable,
+  {
+    name: "migrateMaterializeHistoricalInlineMessageMedia",
+    run: migrateMaterializeHistoricalInlineMessageMedia,
+    rollback: [
+      {
+        version: 58,
+        description:
+          "Materialize historical inline message media as durable attachment references",
+        down: migrateMaterializeHistoricalInlineMessageMediaDown,
+      },
+    ],
+  },
 ];

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1098,23 +1098,23 @@ export function handleListMessages({
         .filter((block) => block.type !== "text" || block.text.length > 0);
     }
 
-    // Ensure every hydrated attachment has a corresponding content block.
-    // renderHistoryContent inlines attachment blocks only when it has
-    // file-block refs with matching DB rows; directives (assistant-authored
-    // <vellum-attachment/> tags) don't leave a file block after stripping,
-    // so their attachments end up in the flat `attachments` array but not in
-    // `contentBlocks`. Append any that are missing so the canonical
-    // projection is complete.
-    const existingAttachmentIds = new Set(
-      contentBlocks
-        .filter(
-          (b): b is Extract<ConversationContentBlock, { type: "attachment" }> =>
-            b.type === "attachment",
-        )
-        .map((b) => b.attachment.id),
-    );
+    // Ensure every hydrated attachment is represented in contentBlocks.
+    // File-block refs produce attachment blocks, while tool-result images
+    // carry their ids inside tool_use blocks. Directives (assistant-authored
+    // <vellum-attachment/> tags) leave neither representation after stripping,
+    // so append their linked rows as standalone attachment blocks.
+    const representedAttachmentIds = new Set<string>();
+    for (const block of contentBlocks) {
+      if (block.type === "attachment") {
+        representedAttachmentIds.add(block.attachment.id);
+      } else if (block.type === "tool_use") {
+        for (const attachmentId of block.toolCall.imageAttachmentIds ?? []) {
+          representedAttachmentIds.add(attachmentId);
+        }
+      }
+    }
     for (const att of msgAttachments) {
-      if (!existingAttachmentIds.has(att.id)) {
+      if (!representedAttachmentIds.has(att.id)) {
         contentBlocks.push({ type: "attachment", attachment: att });
       }
     }

--- a/assistant/src/workspace/migrations/134-rebuild-historical-inline-media-disk-view.ts
+++ b/assistant/src/workspace/migrations/134-rebuild-historical-inline-media-disk-view.ts
@@ -50,6 +50,9 @@ interface ContentBlock {
   name?: string;
   input?: unknown;
   content?: unknown;
+  tool_use_id?: string;
+  is_error?: boolean;
+  contentBlocks?: unknown[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -89,7 +92,67 @@ function conversationDir(
   return existsSync(legacy) ? legacy : canonical;
 }
 
-function foldContentFile(workspaceDir: string, ref: string): ContentBlock[] {
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return String(value);
+  }
+}
+
+function coerceLegacyBlock(block: unknown): ContentBlock {
+  if (isRecord(block)) {
+    if (block.type === "text") {
+      if (typeof block.text === "string") {
+        return block as unknown as ContentBlock;
+      }
+      return { type: "text", text: safeJson(block.text) };
+    }
+    if (
+      block.type === "tool_result" ||
+      block.type === "web_search_tool_result"
+    ) {
+      const toolUseId =
+        typeof block.tool_use_id === "string" ? block.tool_use_id : "";
+      if (block.type === "web_search_tool_result") {
+        if (typeof block.tool_use_id === "string") {
+          return block as unknown as ContentBlock;
+        }
+        return {
+          type: "web_search_tool_result",
+          tool_use_id: toolUseId,
+          content: block.content,
+        };
+      }
+      if (
+        typeof block.tool_use_id === "string" &&
+        typeof block.content === "string" &&
+        (block.is_error === undefined || typeof block.is_error === "boolean") &&
+        (block.contentBlocks === undefined ||
+          Array.isArray(block.contentBlocks))
+      ) {
+        return block as unknown as ContentBlock;
+      }
+      return {
+        type: "tool_result",
+        tool_use_id: toolUseId,
+        content:
+          typeof block.content === "string"
+            ? block.content
+            : safeJson(block.content),
+        ...(typeof block.is_error === "boolean"
+          ? { is_error: block.is_error }
+          : {}),
+      };
+    }
+    if (typeof block.type === "string") {
+      return block as unknown as ContentBlock;
+    }
+  }
+  return { type: "text", text: safeJson(block) };
+}
+
+function foldContentFile(workspaceDir: string, ref: string): unknown[] {
   if (!/^conversations\/.+\.jsonl$/.test(ref)) {
     return [];
   }
@@ -104,18 +167,18 @@ function foldContentFile(workspaceDir: string, ref: string): ContentBlock[] {
   } catch {
     return [];
   }
-  const byIndex = new Map<number, { seq: number; block: ContentBlock }>();
+  const byIndex = new Map<number, { seq: number; block: unknown }>();
   for (const line of text.split("\n")) {
     if (!line) {
       continue;
     }
     try {
-      const parsed = JSON.parse(line) as Record<string, unknown>;
+      const parsed: unknown = JSON.parse(line);
       if (
+        !isRecord(parsed) ||
         !Number.isInteger(parsed.i) ||
         typeof parsed.seq !== "number" ||
-        !isRecord(parsed.block) ||
-        typeof parsed.block.type !== "string"
+        !("block" in parsed)
       ) {
         continue;
       }
@@ -124,7 +187,7 @@ function foldContentFile(workspaceDir: string, ref: string): ContentBlock[] {
       if (!existing || parsed.seq > existing.seq) {
         byIndex.set(index, {
           seq: parsed.seq,
-          block: parsed.block as unknown as ContentBlock,
+          block: parsed.block,
         });
       }
     } catch {
@@ -147,13 +210,10 @@ function resolveContentBlocks(
     return [{ type: "text", text: rawContent }];
   }
   if (Array.isArray(parsed)) {
-    return parsed.filter(
-      (block): block is ContentBlock =>
-        isRecord(block) && typeof block.type === "string",
-    );
+    return parsed.map(coerceLegacyBlock);
   }
   if (isRecord(parsed) && typeof parsed.ref === "string") {
-    return foldContentFile(workspaceDir, parsed.ref);
+    return foldContentFile(workspaceDir, parsed.ref).map(coerceLegacyBlock);
   }
   if (typeof parsed === "string") {
     return [{ type: "text", text: parsed }];
@@ -174,7 +234,10 @@ function flattenContent(blocks: ContentBlock[]): {
       text.push(block.text);
     } else if (block.type === "tool_use" && typeof block.name === "string") {
       toolCalls.push({ name: block.name, input: block.input });
-    } else if (block.type === "tool_result") {
+    } else if (
+      block.type === "tool_result" ||
+      block.type === "web_search_tool_result"
+    ) {
       toolResults.push({ content: block.content });
     }
   }

--- a/assistant/src/workspace/migrations/134-rebuild-historical-inline-media-disk-view.ts
+++ b/assistant/src/workspace/migrations/134-rebuild-historical-inline-media-disk-view.ts
@@ -1,0 +1,413 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, extname, join, resolve, sep } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migrations");
+const DB_STEP_KEY = "step:migrateMaterializeHistoricalInlineMessageMedia";
+const HISTORICAL_ATTACHMENT_ID_PREFIX = "historical-inline-media-";
+const HISTORICAL_ATTACHMENT_GLOB = `${HISTORICAL_ATTACHMENT_ID_PREFIX}*`;
+
+interface ConversationRow {
+  id: string;
+  title: string | null;
+  createdAt: number;
+  updatedAt: number;
+  conversationType: string;
+  originChannel: string | null;
+}
+
+interface MessageRow {
+  id: string;
+  role: string;
+  content: string;
+  createdAt: number;
+  metadata: string | null;
+}
+
+interface AttachmentRow {
+  id: string;
+  messageId: string;
+  originalFilename: string;
+  dataBase64: string;
+  filePath: string | null;
+}
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+  name?: string;
+  input?: unknown;
+  content?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSafeConversationId(id: string): boolean {
+  return (
+    id.length > 0 &&
+    id !== "." &&
+    id !== ".." &&
+    !id.includes("/") &&
+    !id.includes("\\") &&
+    !id.includes("\0")
+  );
+}
+
+function conversationTimestamp(createdAt: number): string {
+  return new Date(createdAt).toISOString().replace(/:/g, "-");
+}
+
+function conversationDir(
+  workspaceDir: string,
+  id: string,
+  createdAt: number,
+): string {
+  if (!isSafeConversationId(id)) {
+    throw new Error(`Unsafe conversation ID in disk-view rebuild: ${id}`);
+  }
+  const conversationsDir = join(workspaceDir, "conversations");
+  const timestamp = conversationTimestamp(createdAt);
+  const canonical = join(conversationsDir, `${timestamp}_${id}`);
+  if (existsSync(canonical)) {
+    return canonical;
+  }
+  const legacy = join(conversationsDir, `${id}_${timestamp}`);
+  return existsSync(legacy) ? legacy : canonical;
+}
+
+function foldContentFile(workspaceDir: string, ref: string): ContentBlock[] {
+  if (!/^conversations\/.+\.jsonl$/.test(ref)) {
+    return [];
+  }
+  const root = resolve(workspaceDir);
+  const path = resolve(root, ref);
+  if (path !== root && !path.startsWith(root + sep)) {
+    return [];
+  }
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return [];
+  }
+  const byIndex = new Map<number, { seq: number; block: ContentBlock }>();
+  for (const line of text.split("\n")) {
+    if (!line) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+      if (
+        !Number.isInteger(parsed.i) ||
+        typeof parsed.seq !== "number" ||
+        !isRecord(parsed.block) ||
+        typeof parsed.block.type !== "string"
+      ) {
+        continue;
+      }
+      const index = parsed.i as number;
+      const existing = byIndex.get(index);
+      if (!existing || parsed.seq > existing.seq) {
+        byIndex.set(index, {
+          seq: parsed.seq,
+          block: parsed.block as unknown as ContentBlock,
+        });
+      }
+    } catch {
+      // A crash-truncated or legacy malformed delta line is ignored.
+    }
+  }
+  return [...byIndex.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([, entry]) => entry.block);
+}
+
+function resolveContentBlocks(
+  workspaceDir: string,
+  rawContent: string,
+): ContentBlock[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawContent);
+  } catch {
+    return [{ type: "text", text: rawContent }];
+  }
+  if (Array.isArray(parsed)) {
+    return parsed.filter(
+      (block): block is ContentBlock =>
+        isRecord(block) && typeof block.type === "string",
+    );
+  }
+  if (isRecord(parsed) && typeof parsed.ref === "string") {
+    return foldContentFile(workspaceDir, parsed.ref);
+  }
+  if (typeof parsed === "string") {
+    return [{ type: "text", text: parsed }];
+  }
+  return [{ type: "text", text: rawContent }];
+}
+
+function flattenContent(blocks: ContentBlock[]): {
+  content: string;
+  toolCalls: Array<{ name: string; input: unknown }>;
+  toolResults: Array<{ content: unknown }>;
+} {
+  const text: string[] = [];
+  const toolCalls: Array<{ name: string; input: unknown }> = [];
+  const toolResults: Array<{ content: unknown }> = [];
+  for (const block of blocks) {
+    if (block.type === "text" && typeof block.text === "string") {
+      text.push(block.text);
+    } else if (block.type === "tool_use" && typeof block.name === "string") {
+      toolCalls.push({ name: block.name, input: block.input });
+    } else if (block.type === "tool_result") {
+      toolResults.push({ content: block.content });
+    }
+  }
+  return { content: text.join("\n"), toolCalls, toolResults };
+}
+
+function attachmentBytes(row: AttachmentRow): Buffer | null {
+  if (row.filePath) {
+    try {
+      return readFileSync(row.filePath);
+    } catch {
+      return null;
+    }
+  }
+  return row.dataBase64 ? Buffer.from(row.dataBase64, "base64") : null;
+}
+
+function projectedAttachmentFilename(
+  attachmentsDir: string,
+  row: AttachmentRow,
+): string | null {
+  if (
+    row.filePath &&
+    existsSync(row.filePath) &&
+    dirname(row.filePath) === attachmentsDir &&
+    statSync(row.filePath).isFile()
+  ) {
+    return basename(row.filePath);
+  }
+  const bytes = attachmentBytes(row);
+  if (!bytes) {
+    if (row.id.startsWith(HISTORICAL_ATTACHMENT_ID_PREFIX)) {
+      throw new Error(`Historical attachment bytes are missing: ${row.id}`);
+    }
+    return null;
+  }
+  const basenameCandidate = basename(row.originalFilename);
+  const safeName =
+    basenameCandidate && basenameCandidate !== "." && basenameCandidate !== ".."
+      ? basenameCandidate
+      : "attachment";
+  const extension = extname(safeName);
+  const stem = basename(safeName, extension);
+  let suffix = 1;
+  for (;;) {
+    const filename = suffix === 1 ? safeName : `${stem}-${suffix}${extension}`;
+    const path = join(attachmentsDir, filename);
+    try {
+      if (readFileSync(path).equals(bytes)) {
+        return filename;
+      }
+      suffix++;
+    } catch (err) {
+      if (!isRecord(err) || err.code !== "ENOENT") {
+        throw err;
+      }
+      writeFileSync(path, bytes, { flag: "wx" });
+      return filename;
+    }
+  }
+}
+
+function attachmentRowsByMessage(
+  db: Database,
+  conversationId: string,
+): Map<string, AttachmentRow[]> {
+  const rows = db
+    .query(
+      `SELECT
+         a.id,
+         ma.message_id AS messageId,
+         a.original_filename AS originalFilename,
+         a.data_base64 AS dataBase64,
+         a.file_path AS filePath
+       FROM message_attachments ma
+       JOIN attachments a ON a.id = ma.attachment_id
+       JOIN messages m ON m.id = ma.message_id
+       WHERE m.conversation_id = ?
+       ORDER BY m.created_at, m.rowid, ma.position, ma.rowid`,
+    )
+    .all(conversationId) as AttachmentRow[];
+  const byMessage = new Map<string, AttachmentRow[]>();
+  for (const row of rows) {
+    const messageRows = byMessage.get(row.messageId) ?? [];
+    messageRows.push(row);
+    byMessage.set(row.messageId, messageRows);
+  }
+  return byMessage;
+}
+
+function rebuildConversation(
+  db: Database,
+  workspaceDir: string,
+  conversation: ConversationRow,
+): void {
+  const dir = conversationDir(
+    workspaceDir,
+    conversation.id,
+    conversation.createdAt,
+  );
+  const attachmentsDir = join(dir, "attachments");
+  const messagesPath = join(dir, "messages.jsonl");
+  const messagesTempPath = `${messagesPath}.migration-134.tmp`;
+  mkdirSync(attachmentsDir, { recursive: true });
+  writeFileSync(messagesTempPath, "");
+
+  try {
+    const attachmentsByMessage = attachmentRowsByMessage(db, conversation.id);
+    const messages = db
+      .query(
+        `SELECT
+           id, role, content, created_at AS createdAt, metadata
+         FROM messages
+         WHERE conversation_id = ?
+         ORDER BY created_at, rowid`,
+      )
+      .all(conversation.id) as MessageRow[];
+    for (const message of messages) {
+      const { content, toolCalls, toolResults } = flattenContent(
+        resolveContentBlocks(workspaceDir, message.content),
+      );
+      const attachments: string[] = [];
+      for (const attachment of attachmentsByMessage.get(message.id) ?? []) {
+        const filename = projectedAttachmentFilename(
+          attachmentsDir,
+          attachment,
+        );
+        if (filename) {
+          attachments.push(filename);
+        }
+      }
+      const record: Record<string, unknown> = {
+        role: message.role,
+        ts: new Date(message.createdAt).toISOString(),
+      };
+      if (content) {
+        record.content = content;
+      }
+      if (toolCalls.length > 0) {
+        record.toolCalls = toolCalls;
+      }
+      if (toolResults.length > 0) {
+        record.toolResults = toolResults;
+      }
+      if (attachments.length > 0) {
+        record.attachments = attachments;
+      }
+      if (message.metadata) {
+        try {
+          record.metadata = JSON.parse(message.metadata);
+        } catch {
+          // Invalid historical metadata is omitted from the derived view.
+        }
+      }
+      appendFileSync(messagesTempPath, `${JSON.stringify(record)}\n`);
+    }
+    renameSync(messagesTempPath, messagesPath);
+
+    const meta = {
+      id: conversation.id,
+      title: conversation.title,
+      type: conversation.conversationType,
+      channel: conversation.originChannel,
+      createdAt: new Date(conversation.createdAt).toISOString(),
+      updatedAt: new Date(conversation.updatedAt).toISOString(),
+    };
+    const metaPath = join(dir, "meta.json");
+    const metaTempPath = `${metaPath}.migration-134.tmp`;
+    writeFileSync(metaTempPath, `${JSON.stringify(meta, null, 2)}\n`);
+    renameSync(metaTempPath, metaPath);
+  } catch (err) {
+    rmSync(messagesTempPath, { force: true });
+    throw err;
+  }
+}
+
+export const rebuildHistoricalInlineMediaDiskViewMigration: WorkspaceMigration =
+  {
+    id: "134-rebuild-historical-inline-media-disk-view",
+    description:
+      "Rebuild disk views for conversations with materialized historical inline media",
+    retryFailedCheckpoint: true,
+
+    run(workspaceDir: string): void {
+      const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+      if (!existsSync(dbPath)) {
+        throw new Error("Assistant database is unavailable for migration 134");
+      }
+      const db = new Database(dbPath, { readonly: true });
+      try {
+        // Workspace migrations still run during degraded startup after a DB
+        // step fails. Keep this checkpoint retryable until its source rows and
+        // deterministic attachment links are known to be complete.
+        const checkpoint = db
+          .query(`SELECT value FROM memory_checkpoints WHERE key = ?`)
+          .get(DB_STEP_KEY) as { value: string } | null;
+        if (checkpoint?.value !== "1") {
+          throw new Error(
+            "Historical inline media DB migration has not completed",
+          );
+        }
+        const conversations = db
+          .query(
+            `SELECT DISTINCT
+               c.id,
+               c.title,
+               c.created_at AS createdAt,
+               c.updated_at AS updatedAt,
+               c.conversation_type AS conversationType,
+               c.origin_channel AS originChannel
+             FROM conversations c
+             JOIN messages m ON m.conversation_id = c.id
+             JOIN message_attachments ma ON ma.message_id = m.id
+             JOIN attachments a ON a.id = ma.attachment_id
+             WHERE a.id GLOB ?
+             ORDER BY c.created_at, c.id`,
+          )
+          .all(HISTORICAL_ATTACHMENT_GLOB) as ConversationRow[];
+        for (const conversation of conversations) {
+          rebuildConversation(db, workspaceDir, conversation);
+        }
+        if (conversations.length > 0) {
+          log.info(
+            { conversations: conversations.length },
+            "Rebuilt historical inline-media conversation disk views",
+          );
+        }
+      } finally {
+        db.close();
+      }
+    },
+
+    down(_workspaceDir: string): void {
+      // Derived disk-view files remain valid after rollback.
+    },
+  };

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -131,6 +131,7 @@ import { speechModeToProviderMigration } from "./130-speech-mode-to-provider.js"
 import { dropWebFetchModeMigration } from "./131-drop-web-fetch-mode.js";
 import { webSearchModeToProviderMigration } from "./132-web-search-mode-to-provider.js";
 import { collapseProviderConnectionsMigration } from "./133-collapse-provider-connections.js";
+import { rebuildHistoricalInlineMediaDiskViewMigration } from "./134-rebuild-historical-inline-media-disk-view.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -277,4 +278,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   dropWebFetchModeMigration,
   webSearchModeToProviderMigration,
   collapseProviderConnectionsMigration,
+  rebuildHistoricalInlineMediaDiskViewMigration,
 ];


### PR DESCRIPTION
Closes #39019

Backfills inline image and file blocks into deterministic attachment references so lightweight chat history remains lossless for existing conversations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->