### PR TITLE
fix(providers): default OpenRouter DeepSeek routing order for prefix-cache affinity

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4882,6 +4882,13 @@ paths:
                       items:
                         type: string
                         minLength: 1
+                    order:
+                      type: array
+                      items:
+                        type: string
+                        minLength: 1
+                    allowFallbacks:
+                      type: boolean
                 logitBias:
                   type: string
                   enum:
@@ -32360,6 +32367,13 @@ components:
                               items:
                                 type: string
                                 minLength: 1
+                            order:
+                              type: array
+                              items:
+                                type: string
+                                minLength: 1
+                            allowFallbacks:
+                              type: boolean
                         - type: "null"
                     logitBias:
                       anyOf:
@@ -32607,6 +32621,13 @@ components:
                   items:
                     type: string
                     minLength: 1
+                order:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                allowFallbacks:
+                  type: boolean
             - type: "null"
         logitBias:
           anyOf:
@@ -32803,6 +32824,13 @@ components:
                   items:
                     type: string
                     minLength: 1
+                order:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                allowFallbacks:
+                  type: boolean
             - type: "null"
         logitBias:
           anyOf:
@@ -33049,6 +33077,13 @@ components:
                       items:
                         type: string
                         minLength: 1
+                    order:
+                      type: array
+                      items:
+                        type: string
+                        minLength: 1
+                    allowFallbacks:
+                      type: boolean
                   additionalProperties: false
                 logitBias:
                   type: string
@@ -33211,6 +33246,13 @@ components:
                             items:
                               type: string
                               minLength: 1
+                          order:
+                            type: array
+                            items:
+                              type: string
+                              minLength: 1
+                          allowFallbacks:
+                            type: boolean
                         additionalProperties: false
                       logitBias:
                         type: string
@@ -33380,6 +33422,13 @@ components:
               items:
                 type: string
                 minLength: 1
+            order:
+              type: array
+              items:
+                type: string
+                minLength: 1
+            allowFallbacks:
+              type: boolean
           additionalProperties: false
         logitBias:
           type: string

--- a/assistant/src/__tests__/llm-schema.test.ts
+++ b/assistant/src/__tests__/llm-schema.test.ts
@@ -111,7 +111,7 @@ describe("LLMSchema", () => {
           nonInteractiveLatestTurnCompression: "truncate",
         },
       },
-      openrouter: { only: [] },
+      openrouter: { only: [], order: [] },
     });
   });
 
@@ -214,6 +214,38 @@ describe("LLMSchema", () => {
   test("openrouter.only rejects empty string entries", () => {
     const result = LLMSchema.safeParse({
       profiles: { pinned: { openrouter: { only: [""] } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("openrouter.order and allowFallbacks parse in profile/callSite", () => {
+    const parsed = LLMSchema.parse({
+      profiles: {
+        pinned: {
+          openrouter: {
+            order: ["deepseek", "fireworks"],
+            allowFallbacks: false,
+          },
+        },
+      },
+      callSites: {
+        mainAgent: { openrouter: { order: ["together"] } },
+      },
+    });
+    expect(parsed.profiles["pinned"]?.openrouter?.order).toEqual([
+      "deepseek",
+      "fireworks",
+    ]);
+    expect(parsed.profiles["pinned"]?.openrouter?.allowFallbacks).toBe(false);
+    expect(parsed.callSites.mainAgent?.openrouter?.order).toEqual(["together"]);
+    expect(
+      parsed.callSites.mainAgent?.openrouter?.allowFallbacks,
+    ).toBeUndefined();
+  });
+
+  test("openrouter.order rejects empty string entries", () => {
+    const result = LLMSchema.safeParse({
+      profiles: { pinned: { openrouter: { order: [""] } } },
     });
     expect(result.success).toBe(false);
   });

--- a/assistant/src/__tests__/openrouter-provider-only.test.ts
+++ b/assistant/src/__tests__/openrouter-provider-only.test.ts
@@ -131,13 +131,36 @@ describe("OpenRouter provider.only plumbing", () => {
       ).toEqual({ only: ["DeepSeek"], order: ["deepseek"] });
     });
 
-    test("preserves a caller-set provider object", () => {
+    test("a caller-set provider.sort suppresses the catalog default order", () => {
+      // An explicit routing-priority strategy (`sort`) is the caller's stated
+      // intent; injecting the catalog default `order` alongside it would fight
+      // that choice.
       expect(
         buildOpenRouterProviderField(
           { provider: { sort: "throughput" } },
           "deepseek/deepseek-v4-flash",
         ),
-      ).toEqual({ sort: "throughput", order: ["deepseek"] });
+      ).toEqual({ sort: "throughput" });
+    });
+
+    test("a caller-set provider.order suppresses the catalog default order", () => {
+      expect(
+        buildOpenRouterProviderField(
+          { provider: { order: ["fireworks"] } },
+          "deepseek/deepseek-v4-flash",
+        ),
+      ).toEqual({ order: ["fireworks"] });
+    });
+
+    test("a bare caller-set provider.only does not suppress the catalog default order", () => {
+      // `only` is an allowlist, not a routing priority, so the catalog default
+      // still fills the preference among the allowed upstreams.
+      expect(
+        buildOpenRouterProviderField(
+          { provider: { only: ["deepseek"] } },
+          "deepseek/deepseek-v4-flash",
+        ),
+      ).toEqual({ only: ["deepseek"], order: ["deepseek"] });
     });
 
     test("does not mutate the shared catalog default array across calls", () => {

--- a/assistant/src/__tests__/openrouter-provider-only.test.ts
+++ b/assistant/src/__tests__/openrouter-provider-only.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildOpenRouterProviderField,
+  extractAllowFallbacks,
   extractOnlyList,
+  extractOrderList,
   OpenRouterProvider,
   withOpenRouterBodyExtras,
 } from "../providers/openrouter/client.js";
@@ -37,6 +40,115 @@ describe("OpenRouter provider.only plumbing", () => {
       expect(extractOnlyList({ openrouter: { only: "Anthropic" } })).toEqual(
         [],
       );
+    });
+  });
+
+  describe("extractOrderList", () => {
+    test("returns the list when present and well-formed", () => {
+      expect(
+        extractOrderList({ openrouter: { order: ["deepseek", "fireworks"] } }),
+      ).toEqual(["deepseek", "fireworks"]);
+    });
+
+    test("filters empty strings and non-strings", () => {
+      expect(
+        extractOrderList({
+          openrouter: { order: ["deepseek", "", 7, null, "together"] },
+        }),
+      ).toEqual(["deepseek", "together"]);
+    });
+
+    test("returns [] when openrouter/order is absent or malformed", () => {
+      expect(extractOrderList(undefined)).toEqual([]);
+      expect(extractOrderList({ openrouter: {} })).toEqual([]);
+      expect(extractOrderList({ openrouter: { order: "deepseek" } })).toEqual(
+        [],
+      );
+    });
+  });
+
+  describe("extractAllowFallbacks", () => {
+    test("returns the boolean when set", () => {
+      expect(
+        extractAllowFallbacks({ openrouter: { allowFallbacks: false } }),
+      ).toBe(false);
+      expect(
+        extractAllowFallbacks({ openrouter: { allowFallbacks: true } }),
+      ).toBe(true);
+    });
+
+    test("returns undefined when absent or non-boolean", () => {
+      expect(extractAllowFallbacks(undefined)).toBeUndefined();
+      expect(extractAllowFallbacks({ openrouter: {} })).toBeUndefined();
+      expect(
+        extractAllowFallbacks({ openrouter: { allowFallbacks: "false" } }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("buildOpenRouterProviderField", () => {
+    test("defaults order from the catalog for a deepseek model with no config order", () => {
+      expect(
+        buildOpenRouterProviderField({}, "deepseek/deepseek-v4-flash"),
+      ).toEqual({ order: ["deepseek"] });
+    });
+
+    test("config order overrides the catalog default", () => {
+      expect(
+        buildOpenRouterProviderField(
+          { openrouter: { order: ["fireworks"] } },
+          "deepseek/deepseek-v4-flash",
+        ),
+      ).toEqual({ order: ["fireworks"] });
+    });
+
+    test("no default order for a non-deepseek model", () => {
+      expect(
+        buildOpenRouterProviderField({}, "x-ai/grok-4.20"),
+      ).toBeUndefined();
+    });
+
+    test("serializes allow_fallbacks as snake_case only when set", () => {
+      expect(
+        buildOpenRouterProviderField(
+          { openrouter: { allowFallbacks: false } },
+          "deepseek/deepseek-v4-flash",
+        ),
+      ).toEqual({ order: ["deepseek"], allow_fallbacks: false });
+      const withoutFlag = buildOpenRouterProviderField(
+        {},
+        "deepseek/deepseek-v4-flash",
+      );
+      expect(withoutFlag).not.toHaveProperty("allow_fallbacks");
+    });
+
+    test("only composes with the catalog default order", () => {
+      expect(
+        buildOpenRouterProviderField(
+          { openrouter: { only: ["DeepSeek"] } },
+          "deepseek/deepseek-v4-flash",
+        ),
+      ).toEqual({ only: ["DeepSeek"], order: ["deepseek"] });
+    });
+
+    test("preserves a caller-set provider object", () => {
+      expect(
+        buildOpenRouterProviderField(
+          { provider: { sort: "throughput" } },
+          "deepseek/deepseek-v4-flash",
+        ),
+      ).toEqual({ sort: "throughput", order: ["deepseek"] });
+    });
+
+    test("does not mutate the shared catalog default array across calls", () => {
+      const first = buildOpenRouterProviderField(
+        {},
+        "deepseek/deepseek-v4-flash",
+      );
+      (first?.order as string[]).push("mutated");
+      expect(
+        buildOpenRouterProviderField({}, "deepseek/deepseek-v4-flash"),
+      ).toEqual({ order: ["deepseek"] });
     });
   });
 
@@ -229,6 +341,76 @@ describe("OpenRouter provider.only plumbing", () => {
       expect(extras).toEqual({
         reasoning: { enabled: true, summary: "detailed" },
       });
+    });
+
+    test("defaults provider.order from the catalog for a deepseek model", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "deepseek/deepseek-v4-flash",
+      );
+      const extras = provider.probeExtras({ config: {} });
+      expect(extras).toEqual({ provider: { order: ["deepseek"] } });
+    });
+
+    test("config order overrides the catalog default for a deepseek model", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "deepseek/deepseek-v4-flash",
+      );
+      const extras = provider.probeExtras({
+        config: { openrouter: { order: ["fireworks"] } },
+      });
+      expect(extras).toEqual({ provider: { order: ["fireworks"] } });
+    });
+
+    test("deepseek default order composes with only and reasoning", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "deepseek/deepseek-v4-pro",
+      );
+      const extras = provider.probeExtras({
+        config: {
+          thinking: { enabled: true },
+          openrouter: { only: ["DeepSeek"] },
+        },
+      });
+      expect(extras).toEqual({
+        reasoning: { enabled: true, summary: "detailed" },
+        provider: { only: ["DeepSeek"], order: ["deepseek"] },
+      });
+    });
+
+    test("serializes allow_fallbacks as snake_case for a deepseek model", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "deepseek/deepseek-v4-flash",
+      );
+      const extras = provider.probeExtras({
+        config: { openrouter: { allowFallbacks: false } },
+      });
+      expect(extras).toEqual({
+        provider: { order: ["deepseek"], allow_fallbacks: false },
+      });
+    });
+
+    test("no default order for a non-deepseek model", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "x-ai/grok-4.20",
+      );
+      const extras = provider.probeExtras({ config: {} });
+      expect(extras).toEqual({});
+    });
+
+    test("keys the catalog default order off a per-call model override", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "x-ai/grok-4.20",
+      );
+      const extras = provider.probeExtras({
+        config: { model: "deepseek/deepseek-v4-flash" },
+      });
+      expect(extras).toEqual({ provider: { order: ["deepseek"] } });
     });
   });
 

--- a/assistant/src/__tests__/retry-openrouter-only-normalization.test.ts
+++ b/assistant/src/__tests__/retry-openrouter-only-normalization.test.ts
@@ -1,8 +1,9 @@
 /**
- * Verifies that `RetryProvider.normalizeSendMessageOptions` plumbs
- * `openrouter.only` only to the `openrouter` provider and strips it for every
- * other provider — so strict-schema clients (Anthropic, OpenAI, …) never see
- * the unknown field on the wire.
+ * Verifies that `RetryProvider.normalizeSendMessageOptions` plumbs the
+ * `openrouter` routing knobs (`only`, `order`, `allowFallbacks`) only to the
+ * `openrouter` provider and strips them for every other provider — so
+ * strict-schema clients (Anthropic, OpenAI, …) never see the unknown field on
+ * the wire.
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
@@ -102,6 +103,45 @@ describe("retry normalization for openrouter.only", () => {
     const { provider, lastConfig } = makePipeline("openai");
     await provider.sendMessage([userMessage], {
       config: { openrouter: { only: ["Anthropic"] } },
+    });
+    expect(lastConfig()?.openrouter).toBe(undefined);
+  });
+
+  test("forwards openrouter.order and allowFallbacks for openrouter", async () => {
+    setLlmConfig({
+      callSites: {
+        mainAgent: {
+          provider: "openrouter",
+          model: "deepseek/deepseek-v4-flash",
+          openrouter: { order: ["fireworks"], allowFallbacks: false },
+        },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("openrouter");
+    await provider.sendMessage([userMessage], {
+      config: { callSite: "mainAgent" },
+    });
+    expect(lastConfig()?.openrouter).toEqual({
+      order: ["fireworks"],
+      allowFallbacks: false,
+    });
+  });
+
+  test("omits openrouter when the config sets no explicit routing knobs", async () => {
+    // The client applies the per-model catalog default order; retry only
+    // forwards config-set knobs, so an unconfigured deepseek call carries no
+    // openrouter field out of normalization.
+    setLlmConfig({
+      callSites: {
+        mainAgent: {
+          provider: "openrouter",
+          model: "deepseek/deepseek-v4-flash",
+        },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("openrouter");
+    await provider.sendMessage([userMessage], {
+      config: { callSite: "mainAgent" },
     });
     expect(lastConfig()?.openrouter).toBe(undefined);
   });

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -364,21 +364,29 @@ const ContextWindowDeepPartialSchema = z
 // OpenRouter provider-routing preferences
 //
 // OpenRouter's `/v1/chat/completions` and `/v1/messages` endpoints both accept
-// a `provider: { only: [...] }` body field that restricts which upstream
-// providers (Anthropic, Google, etc.) may fulfill a request. Exposed here so
-// users can pin routing via config without touching the wire-format knobs
-// directly. Nested shape keeps room for sibling OpenRouter knobs (`order`,
-// `allow_fallbacks`, …) to be added later without another schema reshape.
+// a `provider` body object of routing knobs. `only` restricts which upstream
+// providers (Anthropic, Google, etc.) may fulfill a request. `order` lists
+// upstream slugs to try first, in order, before OpenRouter's default load
+// balancing; pinning the order restores prefix-cache affinity for models whose
+// upstreams each keep an independent cache. `allowFallbacks` toggles whether
+// OpenRouter may fall back to upstreams outside the preferred set (default: it
+// may). Exposed here so users can pin routing via config without touching the
+// wire-format knobs directly. `allowFallbacks` is camelCase in config and
+// serialized as OpenRouter's snake_case `allow_fallbacks` on the wire.
 // ---------------------------------------------------------------------------
 
-const OpenRouterOnlyItemSchema = z.string().min(1);
+const OpenRouterProviderItemSchema = z.string().min(1);
 
 const OpenRouterSchema = z.object({
-  only: z.array(OpenRouterOnlyItemSchema).default([]),
+  only: z.array(OpenRouterProviderItemSchema).default([]),
+  order: z.array(OpenRouterProviderItemSchema).default([]),
+  allowFallbacks: z.boolean().optional(),
 });
 
 const OpenRouterDeepPartialSchema = z.object({
-  only: z.array(OpenRouterOnlyItemSchema).optional(),
+  only: z.array(OpenRouterProviderItemSchema).optional(),
+  order: z.array(OpenRouterProviderItemSchema).optional(),
+  allowFallbacks: z.boolean().optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -69,6 +69,16 @@ export interface CatalogModel {
    * Not projected into the client catalog (see scripts/sync-llm-catalog.ts).
    */
   supportsPromptCacheBreakpoints?: boolean;
+  /**
+   * Daemon-only: preferred OpenRouter upstream provider slugs for this model,
+   * emitted as `provider: { order: [...] }` so OpenRouter tries them first
+   * before its default load balancing. Restores prefix-cache affinity for
+   * models (e.g. DeepSeek) whose upstream deployments each keep an independent
+   * prefix cache, so cross-request cache hits require sticking to one upstream.
+   * Fallbacks stay enabled, so availability is unchanged. Config-specified
+   * `openrouter.order` overrides this. Not projected into the client catalog.
+   */
+  openrouterPreferredUpstreams?: string[];
   /** When set, this model is only visible when the named feature flag is enabled. */
   featureFlag?: string;
 }
@@ -1378,6 +1388,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: false,
         supportsToolUse: true,
+        openrouterPreferredUpstreams: ["deepseek"],
         pricing: { inputPer1mTokens: 0.55, outputPer1mTokens: 2.19 },
       },
       {
@@ -1389,6 +1400,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: false,
         supportsToolUse: true,
+        openrouterPreferredUpstreams: ["deepseek"],
         pricing: { inputPer1mTokens: 0.27, outputPer1mTokens: 1.1 },
       },
       {
@@ -1400,6 +1412,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: false,
         supportsToolUse: true,
+        openrouterPreferredUpstreams: ["deepseek"],
         pricing: { inputPer1mTokens: 0.435, outputPer1mTokens: 0.87 },
       },
       {
@@ -1411,6 +1424,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: false,
         supportsToolUse: true,
+        openrouterPreferredUpstreams: ["deepseek"],
         pricing: { inputPer1mTokens: 0.14, outputPer1mTokens: 0.28 },
       },
       {
@@ -1422,6 +1436,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: false,
         supportsToolUse: false,
+        openrouterPreferredUpstreams: ["deepseek"],
         pricing: { inputPer1mTokens: 0.287, outputPer1mTokens: 0.431 },
       },
       // Qwen
@@ -2092,6 +2107,25 @@ export function modelEffortCeilings(
   return new Map(
     PROVIDER_CATALOG.find((p) => p.id === providerId)?.models.flatMap((m) =>
       m.maxEffort ? ([[m.id, m.maxEffort]] as const) : [],
+    ) ?? [],
+  );
+}
+
+/**
+ * Per-model preferred OpenRouter upstream provider slugs for a provider, keyed
+ * by model ID and derived from each model's `openrouterPreferredUpstreams`. The
+ * OpenRouter client consults this to default `provider: { order: [...] }` when a
+ * per-call config sets no explicit order. Models without the hint are absent.
+ */
+export function modelOpenrouterPreferredUpstreams(
+  providerId: string,
+): ReadonlyMap<string, readonly string[]> {
+  return new Map(
+    PROVIDER_CATALOG.find((p) => p.id === providerId)?.models.flatMap((m) =>
+      m.openrouterPreferredUpstreams &&
+      m.openrouterPreferredUpstreams.length > 0
+        ? ([[m.id, m.openrouterPreferredUpstreams]] as const)
+        : [],
     ) ?? [],
   );
 }

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -6,6 +6,7 @@ import {
 } from "../anthropic-gateway-shared.js";
 import {
   modelEffortCeilings,
+  modelOpenrouterPreferredUpstreams,
   PROMPT_CACHE_BREAKPOINT_MODEL_IDS,
 } from "../model-catalog.js";
 import {
@@ -13,7 +14,10 @@ import {
   EFFORT_TO_REASONING_EFFORT,
   OpenAIChatCompletionsProvider,
 } from "../openai/chat-completions-provider.js";
-import { OpenAIResponsesProvider } from "../openai/responses-provider.js";
+import {
+  OpenAIResponsesProvider,
+  type OpenAIResponsesProviderOptions,
+} from "../openai/responses-provider.js";
 import { isThinkingConfigEnabled } from "../thinking-config.js";
 import type {
   Message,
@@ -35,6 +39,17 @@ const OPENROUTER_APP_ATTRIBUTION_HEADERS = {
 };
 
 const OPENROUTER_MODEL_EFFORT_CEILINGS = modelEffortCeilings("openrouter");
+const OPENROUTER_MODEL_PREFERRED_UPSTREAMS =
+  modelOpenrouterPreferredUpstreams("openrouter");
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (x): x is string => typeof x === "string" && x.length > 0,
+  );
+}
 
 /**
  * Extract the normalized `openrouter.only` list from a per-call config. Returns
@@ -44,9 +59,84 @@ const OPENROUTER_MODEL_EFFORT_CEILINGS = modelEffortCeilings("openrouter");
  */
 export function extractOnlyList(config: unknown): string[] {
   const cfg = config as { openrouter?: { only?: unknown } } | undefined;
-  const only = cfg?.openrouter?.only;
-  if (!Array.isArray(only)) return [];
-  return only.filter((x): x is string => typeof x === "string" && x.length > 0);
+  return normalizeStringList(cfg?.openrouter?.only);
+}
+
+/**
+ * Extract the normalized `openrouter.order` list — the upstream providers to
+ * try first — from a per-call config. Empty when absent or malformed. Exported
+ * for tests.
+ */
+export function extractOrderList(config: unknown): string[] {
+  const cfg = config as { openrouter?: { order?: unknown } } | undefined;
+  return normalizeStringList(cfg?.openrouter?.order);
+}
+
+/**
+ * Extract the `openrouter.allowFallbacks` toggle from a per-call config, or
+ * `undefined` when unset. Serialized as OpenRouter's snake_case
+ * `allow_fallbacks` on the wire. Exported for tests.
+ */
+export function extractAllowFallbacks(config: unknown): boolean | undefined {
+  const cfg = config as
+    | { openrouter?: { allowFallbacks?: unknown } }
+    | undefined;
+  const allow = cfg?.openrouter?.allowFallbacks;
+  return typeof allow === "boolean" ? allow : undefined;
+}
+
+/** Resolve the effective model for a call, honoring a per-call `model` override. */
+export function resolveOpenRouterEffectiveModel(
+  config: unknown,
+  fallbackModel: string,
+): string {
+  const cfg = config as { model?: unknown } | undefined;
+  const override =
+    typeof cfg?.model === "string" && cfg.model.trim().length > 0
+      ? cfg.model.trim()
+      : undefined;
+  return override ?? fallbackModel;
+}
+
+/**
+ * Build OpenRouter's `provider` routing body object from a per-call config and
+ * the effective model. Composes any caller-set `provider` fields with
+ * `openrouter.only` (upstream allowlist), `openrouter.order` (upstream
+ * preference — defaulting from the model catalog's `openrouterPreferredUpstreams`
+ * when the config sets none), and `openrouter.allowFallbacks` (serialized as
+ * OpenRouter's snake_case `allow_fallbacks`). Config-set values always win over
+ * catalog defaults. Returns `undefined` when nothing applies so callers can omit
+ * the field entirely. Exported for tests.
+ */
+export function buildOpenRouterProviderField(
+  config: unknown,
+  effectiveModel: string,
+): Record<string, unknown> | undefined {
+  const only = extractOnlyList(config);
+  const configOrder = extractOrderList(config);
+  const allowFallbacks = extractAllowFallbacks(config);
+  const order =
+    configOrder.length > 0
+      ? configOrder
+      : [...(OPENROUTER_MODEL_PREFERRED_UPSTREAMS.get(effectiveModel) ?? [])];
+
+  const existingProvider = ((config as Record<string, unknown> | undefined)
+    ?.provider ?? {}) as Record<string, unknown>;
+  const provider: Record<string, unknown> = { ...existingProvider };
+  let hasField = Object.keys(existingProvider).length > 0;
+  if (only.length > 0) {
+    provider.only = only;
+    hasField = true;
+  }
+  if (order.length > 0) {
+    provider.order = order;
+    hasField = true;
+  }
+  if (allowFallbacks !== undefined) {
+    provider.allow_fallbacks = allowFallbacks;
+    hasField = true;
+  }
+  return hasField ? provider : undefined;
 }
 
 // OpenRouter's `reasoning.summary` field controls whether reasoning models emit
@@ -70,7 +160,7 @@ function extractReasoningSummaryOverride(config: unknown): string | undefined {
 
 /**
  * Rewrite `options.config` for the Anthropic-compat path so OpenRouter's
- * `provider: { only: [...] }` body field travels through `AnthropicProvider`'s
+ * `provider` routing body field travels through `AnthropicProvider`'s
  * `...restConfig` spread into `Anthropic.MessageStreamParams`. The `openrouter`
  * key itself is removed because Anthropic's JSON parser doesn't know about it
  * — only the translated `provider` field should reach the wire. Safe to inject
@@ -80,39 +170,51 @@ function extractReasoningSummaryOverride(config: unknown): string | undefined {
 export function withOpenRouterBodyExtras(
   options?: SendMessageOptions,
 ): SendMessageOptions | undefined {
-  if (!options?.config) return options;
-  const only = extractOnlyList(options.config);
-  if (only.length === 0) return options;
+  if (!options?.config) {
+    return options;
+  }
+  const effectiveModel = resolveOpenRouterEffectiveModel(options.config, "");
+  const provider = buildOpenRouterProviderField(options.config, effectiveModel);
+  if (provider === undefined) {
+    return options;
+  }
   const { openrouter: _openrouter, ...rest } = options.config as Record<
     string,
     unknown
   >;
-  const existingProvider = (rest.provider ?? {}) as Record<string, unknown>;
   return {
     ...options,
-    config: { ...rest, provider: { ...existingProvider, only } },
+    config: { ...rest, provider },
   };
 }
 
 /**
  * Responses-API delegate for OpenRouter `openai/*` models with explicit
  * prompt caching. Extends the OpenAI Responses transport with OpenRouter's
- * `provider: { only: [...] }` body field — the same translation the
- * chat-completions path performs in `OpenRouterProvider.buildExtraCreateParams`.
- * Exported for tests.
+ * `provider` routing body field — the same translation the chat-completions
+ * path performs in `OpenRouterProvider.buildExtraCreateParams`. Exported for
+ * tests.
  */
 export class OpenRouterResponsesProvider extends OpenAIResponsesProvider {
+  private readonly routingModel: string;
+
+  constructor(
+    apiKey: string,
+    model: string,
+    options: OpenAIResponsesProviderOptions = {},
+  ) {
+    super(apiKey, model, options);
+    this.routingModel = model;
+  }
+
   protected override buildExtraCreateParams(
     options?: SendMessageOptions,
   ): Record<string, unknown> {
-    const only = extractOnlyList(options?.config);
-    if (only.length === 0) {
-      return {};
-    }
-    const existingProvider = ((
-      options?.config as Record<string, unknown> | undefined
-    )?.provider ?? {}) as Record<string, unknown>;
-    return { provider: { ...existingProvider, only } };
+    const provider = buildOpenRouterProviderField(
+      options?.config,
+      resolveOpenRouterEffectiveModel(options?.config, this.routingModel),
+    );
+    return provider === undefined ? {} : { provider };
   }
 }
 
@@ -224,13 +326,12 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
       reasoning.summary = summaryOverride ?? "detailed";
       extras.reasoning = reasoning;
     }
-    const only = extractOnlyList(config);
-    if (only.length > 0) {
-      const existingProvider = (config?.provider ?? {}) as Record<
-        string,
-        unknown
-      >;
-      extras.provider = { ...existingProvider, only };
+    const provider = buildOpenRouterProviderField(
+      config,
+      this.resolveEffectiveModel(options),
+    );
+    if (provider !== undefined) {
+      extras.provider = provider;
     }
     return extras;
   }
@@ -248,12 +349,7 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
   }
 
   private resolveEffectiveModel(options?: SendMessageOptions): string {
-    const config = options?.config as Record<string, unknown> | undefined;
-    const override =
-      typeof config?.model === "string" && config.model.trim().length > 0
-        ? config.model.trim()
-        : undefined;
-    return override ?? this.defaultModel;
+    return resolveOpenRouterEffectiveModel(options?.config, this.defaultModel);
   }
 
   private getAnthropicInner(): AnthropicProvider {

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -98,15 +98,37 @@ export function resolveOpenRouterEffectiveModel(
   return override ?? fallbackModel;
 }
 
+// OpenRouter provider-preferences keys that themselves express a routing
+// priority (which upstream is tried first). When a caller supplies one of
+// these directly on `config.provider`, they have already stated an explicit
+// routing intent, so the catalog default `order` must not be injected on top —
+// doing so would override an explicit `provider.order` or fight an explicit
+// `provider.sort`. A bare `only` allowlist is NOT a priority key: it restricts
+// which upstreams are eligible but states no preference among them, so the
+// catalog default still applies. See OpenRouter's provider-routing docs
+// (https://openrouter.ai/docs/features/provider-routing).
+const PROVIDER_ROUTING_PRIORITY_KEYS = ["order", "sort"] as const;
+
+function providerHasRoutingPriority(
+  provider: Record<string, unknown>,
+): boolean {
+  return PROVIDER_ROUTING_PRIORITY_KEYS.some(
+    (key) => provider[key] !== undefined,
+  );
+}
+
 /**
  * Build OpenRouter's `provider` routing body object from a per-call config and
  * the effective model. Composes any caller-set `provider` fields with
  * `openrouter.only` (upstream allowlist), `openrouter.order` (upstream
  * preference — defaulting from the model catalog's `openrouterPreferredUpstreams`
- * when the config sets none), and `openrouter.allowFallbacks` (serialized as
- * OpenRouter's snake_case `allow_fallbacks`). Config-set values always win over
- * catalog defaults. Returns `undefined` when nothing applies so callers can omit
- * the field entirely. Exported for tests.
+ * when neither `openrouter.order` nor an explicit caller `provider` routing
+ * priority is present), and `openrouter.allowFallbacks` (serialized as
+ * OpenRouter's snake_case `allow_fallbacks`). Explicit caller routing always
+ * wins: a caller-supplied `provider.order` or `provider.sort` suppresses the
+ * catalog default order (a bare `provider.only` allowlist does not). Returns
+ * `undefined` when nothing applies so callers can omit the field entirely.
+ * Exported for tests.
  */
 export function buildOpenRouterProviderField(
   config: unknown,
@@ -115,13 +137,20 @@ export function buildOpenRouterProviderField(
   const only = extractOnlyList(config);
   const configOrder = extractOrderList(config);
   const allowFallbacks = extractAllowFallbacks(config);
-  const order =
-    configOrder.length > 0
-      ? configOrder
-      : [...(OPENROUTER_MODEL_PREFERRED_UPSTREAMS.get(effectiveModel) ?? [])];
 
   const existingProvider = ((config as Record<string, unknown> | undefined)
     ?.provider ?? {}) as Record<string, unknown>;
+
+  // The catalog default order is a fallback, applied only when the caller has
+  // stated no routing priority of their own — neither `openrouter.order` nor an
+  // explicit `provider.{order,sort}`.
+  const order =
+    configOrder.length > 0
+      ? configOrder
+      : providerHasRoutingPriority(existingProvider)
+        ? []
+        : [...(OPENROUTER_MODEL_PREFERRED_UPSTREAMS.get(effectiveModel) ?? [])];
+
   const provider: Record<string, unknown> = { ...existingProvider };
   let hasField = Object.keys(existingProvider).length > 0;
   if (only.length > 0) {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -449,16 +449,31 @@ function normalizeSendMessageOptions(
     ) {
       nextConfig.disableCache = resolved.disableCache;
     }
-    // Forward OpenRouter-only routing preferences so `OpenRouterProvider` can
-    // translate `openrouter.only` into the wire-format `provider: { only: [...] }`
-    // body field on both the OpenAI-compat and Anthropic-compat endpoints.
-    if (
-      providerName === "openrouter" &&
-      nextConfig.openrouter === undefined &&
-      Array.isArray(resolved.openrouter?.only) &&
-      resolved.openrouter.only.length > 0
-    ) {
-      nextConfig.openrouter = { only: resolved.openrouter.only };
+    // Forward OpenRouter routing preferences so `OpenRouterProvider` can
+    // translate `openrouter.{only,order,allowFallbacks}` into the wire-format
+    // `provider` body field on both the OpenAI-compat and Anthropic-compat
+    // endpoints. Only carry keys the config actually set; the client applies a
+    // per-model default `order` from the catalog when none is forwarded here.
+    if (providerName === "openrouter" && nextConfig.openrouter === undefined) {
+      const openrouter: Record<string, unknown> = {};
+      if (
+        Array.isArray(resolved.openrouter?.only) &&
+        resolved.openrouter.only.length > 0
+      ) {
+        openrouter.only = resolved.openrouter.only;
+      }
+      if (
+        Array.isArray(resolved.openrouter?.order) &&
+        resolved.openrouter.order.length > 0
+      ) {
+        openrouter.order = resolved.openrouter.order;
+      }
+      if (typeof resolved.openrouter?.allowFallbacks === "boolean") {
+        openrouter.allowFallbacks = resolved.openrouter.allowFallbacks;
+      }
+      if (Object.keys(openrouter).length > 0) {
+        nextConfig.openrouter = openrouter;
+      }
     }
     // Forward a profile's opted-in `logit_bias` preset only on the Fireworks
     // (OpenAI-compatible) path. `resolved.logitBias` is set by the resolver from

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -841,7 +841,7 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
         maxAttempts: 4,
       },
     });
-    expect(savedProfile.openrouter).toEqual({ only: ["anthropic"] });
+    expect(savedProfile.openrouter).toEqual({ only: ["anthropic"], order: [] });
   });
 
   test("writes only the replacement contextWindow maxInputTokens override", async () => {
@@ -876,7 +876,7 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
         maxAttempts: 4,
       },
     });
-    expect(savedProfile.openrouter).toEqual({ only: ["anthropic"] });
+    expect(savedProfile.openrouter).toEqual({ only: ["anthropic"], order: [] });
   });
 
   test("writes provider_connection when present in body", async () => {


### PR DESCRIPTION
## Why

DeepSeek models served via OpenRouter show catastrophic prefix-cache behavior in production (Jul 8–22): **~340–427k genuinely-uncached input tokens per mainAgent turn-event** (healthy cached paths run ~35k fresh tokens/turn), ~$500/15d and concentrated among top-spending users. Mechanism: without a `provider` routing directive, OpenRouter load-balances each request across multiple upstream deployments, each with its own independent prefix cache — consecutive agentic-loop calls land on different backends and DeepSeek's automatic context caching never engages.

## What

- `OpenRouterSchema` gains `order` (upstream preference list) and `allowFallbacks` (serialized as OpenRouter's snake_case `allow_fallbacks`, only when set) alongside the existing `only`.
- The model catalog's OpenRouter DeepSeek entries carry `openrouterPreferredUpstreams: ["deepseek"]` (daemon-only field, excluded from the client catalog projection). When config sets no `order`, the request defaults `provider.order` from the catalog — so DeepSeek requests consistently try the first-party upstream first and its automatic context cache engages.
- **Fallbacks stay enabled** (no `allow_fallbacks: false` default): availability is unchanged; OpenRouter simply tries the preferred upstream first. Config-set values always win over catalog defaults.
- Wired through all three body paths (chat-completions, Responses delegate, Anthropic-compat extras).

## Verification

- 70 targeted tests + 187 broader provider/schema tests + 36 routing tests pass; `typecheck:fast`, lint, and `sync:llm-catalog --check` clean.
- Post-deploy: `deepseek/*` mainAgent avg uncached tokens/event in `telemetry.llm_usage_raw` should fall from 340–427k toward the ~35k fresh band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->