### PR TITLE
perf(memory): pin memoryV3SelectL2 to haiku so its 1h cache breakpoint engages

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -455,8 +455,14 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
   });
 
   test("strips ttl from a caller's block cache_control and omits the beta for Haiku", async () => {
-    // Haiku doesn't support the extended-cache-ttl beta, so a caller-stamped
-    // 1h ttl on a message block must be stripped before sending.
+    // The haiku family rejects the extended-cache-ttl beta and a custom cache
+    // `ttl` with a 400 (PR #25302), so a caller-stamped 1h ttl on a message
+    // block must be stripped and the beta omitted before sending. This is
+    // load-bearing for the memoryV3SelectL2 selector pin: the selector stamps a
+    // 1h breakpoint on its card-corpus prefix but runs a pinned haiku model
+    // (`claude-haiku-4-5-20251001`), so the breakpoint is served at the default
+    // 5m TTL rather than 1h. If a future change loosens the haiku gating, this
+    // assertion catches it here rather than as a 400 on the live pin.
     const haiku = new AnthropicProvider(
       "sk-ant-test",
       "claude-haiku-4-5-20251001",

--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -456,7 +456,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
 
   test("strips ttl from a caller's block cache_control and omits the beta for Haiku", async () => {
     // The haiku family rejects the extended-cache-ttl beta and a custom cache
-    // `ttl` with a 400 (PR #25302), so a caller-stamped 1h ttl on a message
+    // `ttl` with a 400, so a caller-stamped 1h ttl on a message
     // block must be stripped and the beta omitted before sending. This is
     // load-bearing for the memoryV3SelectL2 selector pin: the selector stamps a
     // 1h breakpoint on its card-corpus prefix but runs a pinned haiku model

--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { CALL_SITE_DEFAULTS } from "../config/call-site-defaults.js";
 import { CODE_DEFAULT_PROFILE_ENTRIES } from "../config/default-profile-catalog.js";
 import {
   type ResolutionFallbackReason,
@@ -528,5 +529,99 @@ describe("user shadows of default keys keep their intent", () => {
     });
     expect(pinned.model).toBe("gpt-5.4");
     expect(pinned.provider).toBe("openai");
+  });
+});
+
+describe("an overrideProfile winner suppresses a default-owned model pin", () => {
+  // `voiceFrontDecision` carries a shipped `model` pin (a best-effort latency
+  // optimization for its DEFAULT resolution). It is the vehicle here because it
+  // has a real shipped pin today; the image-fallback plugin's `vision` call
+  // site hits the identical resolver code the moment `vision` gets its own pin,
+  // and `vision` is the only production caller that passes `overrideProfile` to
+  // a pinned site. If this constant loses its pin, retarget to another pinned
+  // site (`voiceFrontDoor` / `memoryV3SelectL2`) — the assertions are generic.
+  const PINNED_SITE = "voiceFrontDecision" as const;
+  const pin = CALL_SITE_DEFAULTS[PINNED_SITE].model as string;
+
+  // An anthropic override profile: its provider SERVES the anthropic pin, so
+  // pre-fix the pin would stick (managed route / matching provider), which is
+  // exactly the silent-haiku bug. The override's own model must win instead.
+  const anthropicCustom = {
+    ...completeCustom,
+    provider: "anthropic" as const,
+    provider_connection: "anthropic-personal",
+    model: "claude-opus-4-6",
+  };
+
+  test("the shipped pin exists so these assertions are meaningful", () => {
+    expect(typeof pin).toBe("string");
+    expect(pin.length).toBeGreaterThan(0);
+  });
+
+  test("BYOK: the override profile's own model stands, not the pin", () => {
+    const llm = LLMSchema.parse({
+      profiles: { mine: anthropicCustom },
+      ...anthropicDp,
+    });
+    const { fallbacks, opts } = collect();
+    const resolved = resolveCallSiteConfig(PINNED_SITE, llm, {
+      overrideProfile: "mine",
+      forceOverrideProfile: true,
+      ...opts,
+    });
+    expect(resolved.model).toBe("claude-opus-4-6");
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.model).not.toBe(pin);
+    // Suppression is a deliberate semantic, not an `unroutable` drop — nothing
+    // is reported.
+    expect(fallbacks).toEqual([]);
+  });
+
+  test("managed: the override profile's own model stands, not the pin", () => {
+    const managedStubs = {
+      balanced: { source: "managed" as const },
+      "cost-optimized": { source: "managed" as const },
+    };
+    const llm = LLMSchema.parse({
+      profiles: managedStubs,
+      defaultProvider: { provider: "vellum" as const },
+    });
+    // The managed cost-optimized body through the vellum route.
+    const viaIntent = resolveCallSiteConfig("conversationSummarization", llm);
+    const { fallbacks, opts } = collect();
+    const resolved = resolveCallSiteConfig(PINNED_SITE, llm, {
+      overrideProfile: "cost-optimized",
+      forceOverrideProfile: true,
+      ...opts,
+    });
+    expect(resolved.model).toBe(viaIntent.model);
+    expect(resolved.model).not.toBe(pin);
+    expect(fallbacks).toEqual([]);
+  });
+
+  test("a user's explicit call-site model still beats the override profile", () => {
+    // Current semantics: an explicit `llm.callSites[id].model` is honored as
+    // written and wins over `overrideProfile`. Not default-owned, so the
+    // override-suppression rule leaves it untouched.
+    const llm = LLMSchema.parse({
+      profiles: { mine: anthropicCustom },
+      callSites: { [PINNED_SITE]: { model: "claude-sonnet-4-5-20250929" } },
+      ...anthropicDp,
+    });
+    const resolved = resolveCallSiteConfig(PINNED_SITE, llm, {
+      overrideProfile: "mine",
+      forceOverrideProfile: true,
+    });
+    expect(resolved.model).toBe("claude-sonnet-4-5-20250929");
+    expect(resolved.provider).toBe("anthropic");
+  });
+
+  test("no override: the pinned site still resolves to its shipped pin", () => {
+    const llm = LLMSchema.parse({
+      profiles: { mine: anthropicCustom },
+      ...anthropicDp,
+    });
+    const resolved = resolveCallSiteConfig(PINNED_SITE, llm);
+    expect(resolved.model).toBe(pin);
   });
 });

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -165,6 +165,32 @@ describe("resolver integration", () => {
     }
   });
 
+  test("memoryV3SelectL2 pins the haiku model over a managed route so its 1h cache breakpoint engages", () => {
+    // The selector's ~30k-token card-corpus prefix carries a 1h `cache_control`
+    // breakpoint that only an Anthropic-protocol model honors. The call-site
+    // default pins `claude-haiku-4-5-20251001` as a bare model pin: on a
+    // managed install the balanced winner is the `vellum` routing identity, and
+    // the managed route serves the anthropic-catalog model, so the pin keeps
+    // the provider-agnostic managed connection and just swaps the model.
+    const llm = LLMSchema.parse({
+      activeProfile: "balanced",
+      profiles: managedStubs(),
+    });
+    const resolved = resolveCallSiteConfig("memoryV3SelectL2", llm);
+    expect(String(resolved.provider)).toBe("vellum");
+    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
+    expect(resolved.provider_connection).toBeUndefined();
+    // Sampling/thinking tweaks from the call-site default survive the pin.
+    expect(resolved.temperature).toBe(0);
+    expect(resolved.thinking.enabled).toBe(false);
+    expect(resolved.thinking.streamThinking).toBe(false);
+    // The managed route dispatches the pinned model to its Anthropic upstream —
+    // this is what makes the Anthropic `cache_control` breakpoint effective.
+    const identity = resolveRoutingIdentity(resolved.provider, resolved.model);
+    expect(identity?.connectionName).toBe("vellum");
+    expect(identity?.expectedProvider).toBe("anthropic");
+  });
+
   test("thin managed stubs and fully seeded bodies resolve identically at every call site", () => {
     const seededProfiles = Object.fromEntries(
       Object.entries(CODE_DEFAULT_PROFILE_ENTRIES).filter(

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -165,13 +165,15 @@ describe("resolver integration", () => {
     }
   });
 
-  test("memoryV3SelectL2 pins the haiku model over a managed route so its 1h cache breakpoint engages", () => {
-    // The selector's ~30k-token card-corpus prefix carries a 1h `cache_control`
-    // breakpoint that only an Anthropic-protocol model honors. The call-site
-    // default pins `claude-haiku-4-5-20251001` as a bare model pin: on a
-    // managed install the balanced winner is the `vellum` routing identity, and
-    // the managed route serves the anthropic-catalog model, so the pin keeps
-    // the provider-agnostic managed connection and just swaps the model.
+  test("memoryV3SelectL2 pins the haiku model over a managed route so its cache breakpoint engages", () => {
+    // The selector's ~30k-token card-corpus prefix carries a `cache_control`
+    // breakpoint that only an Anthropic-protocol model honors (the caller
+    // stamps a 1h TTL, but the provider serves it at the default 5m TTL on the
+    // haiku family). The call-site default pins `claude-haiku-4-5-20251001` as
+    // a bare model pin: on a managed install the balanced winner is the
+    // `vellum` routing identity, and the managed route serves the
+    // anthropic-catalog model, so the pin keeps the provider-agnostic managed
+    // connection and just swaps the model.
     const llm = LLMSchema.parse({
       activeProfile: "balanced",
       profiles: managedStubs(),
@@ -302,6 +304,78 @@ describe("resolver integration", () => {
     expect(resolved.model).toBe("claude-haiku-4-5-20251001");
     expect(resolved.provider).toBe("anthropic");
     expect(resolved.provider_connection).toBeUndefined();
+  });
+
+  test("a tuning-only override keeps the shipped haiku pin on a managed install", () => {
+    // A workspace override that sets neither `profile` nor its own `model`
+    // (here just `temperature`) replaces the shipped call-site default
+    // wholesale. The resolver re-applies the shipped model as a default-owned
+    // pin, so on a managed install the pin still resolves to the haiku model
+    // over the provider-agnostic managed route — the override tunes sampling
+    // without silently disabling the pin.
+    const llm = LLMSchema.parse({
+      activeProfile: "balanced",
+      profiles: managedStubs(),
+      callSites: { memoryV3SelectL2: { temperature: 0.2 } },
+    });
+    const resolved = resolveCallSiteConfig("memoryV3SelectL2", llm);
+    expect(String(resolved.provider)).toBe("vellum");
+    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
+    expect(resolved.provider_connection).toBeUndefined();
+    // The override's own tuning wins.
+    expect(resolved.temperature).toBe(0.2);
+  });
+
+  test("a tuning-only override drops the unreachable haiku pin on a BYOK install", () => {
+    // Same tuning-only override on a BYOK-openai install with no Anthropic
+    // connection. The inherited haiku pin is default-owned, so it gets the
+    // graceful `unroutable` drop: resolution falls back to the balanced profile
+    // through openai, stays dispatchable, and reports the drop — no error, and
+    // the override's own tuning still applies.
+    const llm = LLMSchema.parse({
+      profiles: managedStubs(),
+      defaultProvider: { provider: "openai" },
+      callSites: { memoryV3SelectL2: { temperature: 0.2 } },
+    });
+    const fallbacks: { requested: string; reason: string }[] = [];
+    const resolved = resolveCallSiteConfig("memoryV3SelectL2", llm, {
+      onResolutionFallback: ({ requested, reason }) =>
+        fallbacks.push({ requested, reason }),
+    });
+    const balancedOnOpenai = resolveDefaultProfileForProvider(
+      undefined,
+      "balanced",
+      { provider: "openai" },
+    );
+    expect(resolved.provider).toBe("openai");
+    expect(resolved.model).toBe(balancedOnOpenai?.model as string);
+    expect(resolved.model).not.toBe("claude-haiku-4-5-20251001");
+    expect(resolved.provider_connection).toBe(
+      balancedOnOpenai?.provider_connection,
+    );
+    expect(resolved.provider_connection).toBeDefined();
+    expect(resolved.temperature).toBe(0.2);
+    expect(fallbacks).toContainEqual({
+      requested: "claude-haiku-4-5-20251001",
+      reason: "unroutable",
+    });
+  });
+
+  test("a profile override outranks the shipped pin on a managed install too", () => {
+    // The shipped pin is selection, not tuning: pointing the call site at a
+    // profile means the winner supplies the model and the shipped haiku pin
+    // never enters resolution — on a managed install as well as the BYOK case
+    // above. Neither `profile` nor `model` is inherited from the shipped
+    // default when the user names a profile.
+    const llm = LLMSchema.parse({
+      profiles: managedStubs(),
+      callSites: { memoryV3SelectL2: { profile: "cost-optimized" } },
+    });
+    const resolved = resolveCallSiteConfig("memoryV3SelectL2", llm);
+    expect(resolved.model).toBe(
+      CODE_DEFAULT_PROFILE_ENTRIES["cost-optimized"].model as string,
+    );
+    expect(resolved.model).not.toBe("claude-haiku-4-5-20251001");
   });
 
   test("thin managed stubs and fully seeded bodies resolve identically at every call site", () => {

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -191,6 +191,119 @@ describe("resolver integration", () => {
     expect(identity?.expectedProvider).toBe("anthropic");
   });
 
+  test("memoryV3SelectL2 drops the unreachable haiku pin on a BYOK install and runs the balanced-profile model", () => {
+    // BYOK install: openai is the default provider and there is no Anthropic
+    // connection. The haiku pin's catalog provider (anthropic) is reachable
+    // through neither managed routing nor a matching connection, so the pin is
+    // dropped and the call site's balanced profile — resolved through the
+    // openai default provider — supplies the model. Without this, the resolved
+    // config would name `provider: anthropic` with no connection and fail every
+    // dispatch.
+    const llm = LLMSchema.parse({
+      profiles: managedStubs(),
+      defaultProvider: { provider: "openai" },
+    });
+    const fallbacks: { requested: string; reason: string }[] = [];
+    const resolved = resolveCallSiteConfig("memoryV3SelectL2", llm, {
+      onResolutionFallback: ({ requested, reason }) =>
+        fallbacks.push({ requested, reason }),
+    });
+    const balancedOnOpenai = resolveDefaultProfileForProvider(
+      undefined,
+      "balanced",
+      {
+        provider: "openai",
+      },
+    );
+    expect(resolved.provider).toBe("openai");
+    expect(resolved.model).toBe(balancedOnOpenai?.model as string);
+    expect(resolved.model).not.toBe("claude-haiku-4-5-20251001");
+    // The winner's own connection survives — resolution stays dispatchable.
+    expect(resolved.provider_connection).toBe(
+      balancedOnOpenai?.provider_connection,
+    );
+    expect(resolved.provider_connection).toBeDefined();
+    // Sampling/thinking tweaks from the call-site default are provider-agnostic
+    // and still apply.
+    expect(resolved.temperature).toBe(0);
+    expect(resolved.thinking.enabled).toBe(false);
+    // The drop is reported so user-facing paths can log it.
+    expect(fallbacks).toContainEqual({
+      requested: "claude-haiku-4-5-20251001",
+      reason: "unroutable",
+    });
+  });
+
+  test("voiceFront call sites drop the unreachable haiku pin on a BYOK install", () => {
+    const llm = LLMSchema.parse({
+      profiles: managedStubs(),
+      defaultProvider: { provider: "openai" },
+    });
+    const costOptimizedOnOpenai = resolveDefaultProfileForProvider(
+      undefined,
+      "cost-optimized",
+      { provider: "openai" },
+    );
+    for (const callSite of ["voiceFrontDecision", "voiceFrontDoor"] as const) {
+      const resolved = resolveCallSiteConfig(callSite, llm);
+      expect(resolved.provider).toBe("openai");
+      expect(resolved.model).toBe(costOptimizedOnOpenai?.model as string);
+      expect(resolved.model).not.toBe("claude-haiku-4-5-20251001");
+      expect(resolved.provider_connection).toBeDefined();
+    }
+  });
+
+  test("a BYOK install whose default provider IS anthropic keeps the haiku pin", () => {
+    // The winner (balanced through anthropic) already serves the anthropic
+    // catalog model, so the pin is honored on its own connection — no drop.
+    const llm = LLMSchema.parse({
+      profiles: managedStubs(),
+      defaultProvider: { provider: "anthropic" },
+    });
+    const resolved = resolveCallSiteConfig("memoryV3SelectL2", llm);
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
+    expect(resolved.provider_connection).toBe("anthropic-personal");
+  });
+
+  test("an explicit user profile pin outranks the call-site default and its model pin", () => {
+    // On the same BYOK-openai install, a user who points the call site at their
+    // own profile gets that profile verbatim — the shipped haiku pin never
+    // enters resolution.
+    const llm = LLMSchema.parse({
+      profiles: {
+        ...managedStubs(),
+        "my-openai": {
+          source: "user",
+          provider: "openai",
+          provider_connection: "openai-personal",
+          model: "gpt-5.5",
+        },
+      },
+      defaultProvider: { provider: "openai" },
+      callSites: { memoryV3SelectL2: { profile: "my-openai" } },
+    });
+    const resolved = resolveCallSiteConfig("memoryV3SelectL2", llm);
+    expect(resolved.provider).toBe("openai");
+    expect(resolved.model).toBe("gpt-5.5");
+  });
+
+  test("an explicit user model pin is honored as written even when unreachable", () => {
+    // The graceful drop is scoped to shipped call-site DEFAULT pins. A
+    // deliberate user model override still stamps the catalog provider (and
+    // drops the winner's connection), preserving the existing contract — a
+    // user's explicit choice is never silently swapped.
+    const llm = LLMSchema.parse({
+      profiles: managedStubs(),
+      defaultProvider: { provider: "openai" },
+      callSites: { memoryV3SelectL2: { model: "claude-haiku-4-5-20251001" } },
+    });
+    const resolved = resolveCallSiteConfig("memoryV3SelectL2", llm);
+    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.provider_connection).toBeUndefined();
+  });
+
   test("thin managed stubs and fully seeded bodies resolve identically at every call site", () => {
     const seededProfiles = Object.fromEntries(
       Object.entries(CODE_DEFAULT_PROFILE_ENTRIES).filter(

--- a/assistant/src/config/__tests__/loader-callsite-strip-fallback.test.ts
+++ b/assistant/src/config/__tests__/loader-callsite-strip-fallback.test.ts
@@ -21,7 +21,9 @@ function ensureTestDir(): void {
     join(WORKSPACE_DIR, "data", "logs"),
   ];
   for (const dir of dirs) {
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
   }
 }
 
@@ -37,10 +39,12 @@ function writeConfig(obj: unknown): void {
 }
 
 /**
- * Base config where the active profile resolves to a DIFFERENT model than the
- * `balanced` profile that the shipped `memoryV3SelectL2` call-site default
- * points at. This lets each test distinguish the two failure modes:
- *   - call-site default applied (fixed)  -> model "balanced-model"
+ * Base config whose active profile ("speedy") resolves to a DIFFERENT model
+ * than the shipped `memoryV3SelectL2` call-site default produces. That default
+ * anchors on the `balanced` profile and pins the `claude-haiku-4-5-20251001`
+ * model, so applying it yields the pinned model. This lets each test
+ * distinguish the two failure modes:
+ *   - call-site default applied (fixed)  -> pinned model "claude-haiku-4-5-20251001"
  *   - silently downgraded to active      -> model "active-model"
  */
 function baseLlm(callSites: Record<string, unknown>): unknown {
@@ -60,14 +64,18 @@ function baseLlm(callSites: Record<string, unknown>): unknown {
 describe("config recovery prunes call-site overrides emptied by a strip", () => {
   beforeEach(() => {
     ensureTestDir();
-    if (existsSync(CONFIG_PATH)) rmSync(CONFIG_PATH, { force: true });
+    if (existsSync(CONFIG_PATH)) {
+      rmSync(CONFIG_PATH, { force: true });
+    }
     delete process.env.IS_PLATFORM;
     invalidateConfigCache();
   });
 
   afterEach(() => {
     delete process.env.IS_PLATFORM;
-    if (existsSync(CONFIG_PATH)) rmSync(CONFIG_PATH, { force: true });
+    if (existsSync(CONFIG_PATH)) {
+      rmSync(CONFIG_PATH, { force: true });
+    }
     invalidateConfigCache();
   });
 
@@ -83,10 +91,11 @@ describe("config recovery prunes call-site overrides emptied by a strip", () => 
     // The emptied call-site entry must be pruned entirely, not left as `{}`.
     expect(config.llm.callSites?.memoryV3SelectL2).toBeUndefined();
 
-    // Resolution now lands on the shipped call-site default (balanced), not the
-    // active profile ("active-model"), which is what the bug produced.
+    // Resolution now lands on the shipped call-site default (which pins the
+    // haiku model), not the active profile ("active-model"), which is what the
+    // bug produced.
     const resolved = resolveCallSiteConfig("memoryV3SelectL2", config.llm);
-    expect(resolved.model).toBe("balanced-model");
+    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
   });
 
   test("a valid sibling call-site override survives while the invalid one is pruned", () => {

--- a/assistant/src/config/__tests__/loader-callsite-strip-fallback.test.ts
+++ b/assistant/src/config/__tests__/loader-callsite-strip-fallback.test.ts
@@ -91,9 +91,8 @@ describe("config recovery prunes call-site overrides emptied by a strip", () => 
     // The emptied call-site entry must be pruned entirely, not left as `{}`.
     expect(config.llm.callSites?.memoryV3SelectL2).toBeUndefined();
 
-    // Resolution now lands on the shipped call-site default (which pins the
-    // haiku model), not the active profile ("active-model"), which is what the
-    // bug produced.
+    // With the invalid entry pruned, resolution uses the shipped call-site
+    // default (which pins the haiku model) rather than the active profile.
     const resolved = resolveCallSiteConfig("memoryV3SelectL2", config.llm);
     expect(resolved.model).toBe("claude-haiku-4-5-20251001");
   });

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -10,10 +10,13 @@ type CallSiteDefaultConfig = {
   profile?: string;
   /**
    * Direct model pin overriding the resolved profile's model. The resolver
-   * treats a bare model pin as catalog-implied: it stamps the model's
-   * catalog provider and keeps the provider-agnostic Vellum managed
-   * connection (see `resolveOverrideOrDefault`). Reserve for call sites
-   * whose latency envelope the profile's model cannot meet.
+   * treats a bare model pin as catalog-implied: it stamps the model's catalog
+   * provider and keeps the provider-agnostic Vellum managed connection (see
+   * `resolveOverrideOrDefault`). On an install that can reach the implied
+   * provider through neither managed routing nor a matching connection, the
+   * pin is dropped and the call site's profile/intent model stands, so the pin
+   * is a best-effort optimization rather than a hard requirement. Reserve for
+   * call sites whose latency envelope the profile's model cannot meet.
    */
   model?: string;
   maxTokens?: number;
@@ -57,9 +60,9 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     // provider-agnostic managed connection (the managed route dispatches the
     // model to its Anthropic upstream). Production shows ~81% of selector
     // calls land within the 1h TTL, so the pin converts the recurring prefix
-    // from full-price input into cache reads. Same managed-credential caveat
-    // as the voice pins below — replace only with a model whose managed
-    // credentials are provisioned in every environment.
+    // from full-price input into cache reads. On a BYOK install that cannot
+    // reach Anthropic, the resolver drops the pin and the balanced profile's
+    // own model runs — the cache optimization is forgone, not an error.
     model: "claude-haiku-4-5-20251001",
     temperature: 0,
     thinking: { enabled: false, streamThinking: false },
@@ -141,8 +144,9 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     // profile's upstream cannot fit any usable decision budget (~1s+ per
     // forced tool call). Pin a latency-optimized model instead — the bare
     // model pin lets the catalog imply the provider, which preserves the
-    // provider-agnostic managed connection. Replace only with a model whose
-    // managed credentials are provisioned in every environment.
+    // provider-agnostic managed connection. On a BYOK install that cannot
+    // reach the implied provider, the resolver drops the pin and the
+    // cost-optimized profile's own model runs.
     model: "claude-haiku-4-5-20251001",
     effort: "low",
     thinking: { enabled: false },
@@ -155,7 +159,8 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     // latency-class model the endpoint decider uses: live drives showed the
     // cost-optimized upstream with multi-second cross-session TTFT tails
     // and over-escalation of small talk under open-task context pressure.
-    // Same model-pin caveat as voiceFrontDecision above.
+    // Falls back the same way as voiceFrontDecision above when the implied
+    // provider is unreachable.
     model: "claude-haiku-4-5-20251001",
     effort: "low",
     thinking: { enabled: false },

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -51,18 +51,25 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
   memoryV3SelectL2: {
     profile: "balanced",
     // The selector's ~30k-token card-corpus prefix is emitted as its own
-    // content block carrying a 1h `cache_control` breakpoint, which only an
+    // content block carrying a `cache_control` breakpoint, which only an
     // Anthropic-protocol model honors — the balanced profile's managed model
     // is Fireworks-served, where the Anthropic breakpoint is inert and the
     // implicit cache misses because calls are spaced one per user turn. Pin a
     // latency-class Anthropic model so the breakpoint engages; the bare model
     // pin lets the catalog imply the provider, which preserves the
     // provider-agnostic managed connection (the managed route dispatches the
-    // model to its Anthropic upstream). Production shows ~81% of selector
-    // calls land within the 1h TTL, so the pin converts the recurring prefix
-    // from full-price input into cache reads. On a BYOK install that cannot
-    // reach Anthropic, the resolver drops the pin and the balanced profile's
-    // own model runs — the cache optimization is forgone, not an error.
+    // model to its Anthropic upstream).
+    //
+    // On the haiku family the breakpoint runs at the DEFAULT 5m TTL, not the
+    // 1h TTL the caller stamps: extended cache TTL is gated off for haiku
+    // (the Anthropic client strips `ttl` from cache_control blocks and omits
+    // the extended-cache-ttl beta, which the haiku family rejects). Production
+    // shows ~44% of selector calls land within 5m of the previous, converting
+    // that share of the recurring prefix into cache reads (~0.1x input); the
+    // remainder is re-billed as 5m cache writes at 1.25x. The pin also cuts
+    // latency. On a BYOK install that cannot reach Anthropic, the resolver
+    // drops the pin and the balanced profile's own model runs — the cache
+    // optimization is forgone, not an error.
     model: "claude-haiku-4-5-20251001",
     temperature: 0,
     thinking: { enabled: false, streamThinking: false },

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -47,6 +47,20 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
   },
   memoryV3SelectL2: {
     profile: "balanced",
+    // The selector's ~30k-token card-corpus prefix is emitted as its own
+    // content block carrying a 1h `cache_control` breakpoint, which only an
+    // Anthropic-protocol model honors — the balanced profile's managed model
+    // is Fireworks-served, where the Anthropic breakpoint is inert and the
+    // implicit cache misses because calls are spaced one per user turn. Pin a
+    // latency-class Anthropic model so the breakpoint engages; the bare model
+    // pin lets the catalog imply the provider, which preserves the
+    // provider-agnostic managed connection (the managed route dispatches the
+    // model to its Anthropic upstream). Production shows ~81% of selector
+    // calls land within the 1h TTL, so the pin converts the recurring prefix
+    // from full-price input into cache reads. Same managed-credential caveat
+    // as the voice pins below — replace only with a model whose managed
+    // credentials are provisioned in every environment.
+    model: "claude-haiku-4-5-20251001",
     temperature: 0,
     thinking: { enabled: false, streamThinking: false },
   },

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -100,7 +100,9 @@ export interface ResolveCallSiteOpts {
   onMixSelected?: (info: { mixProfile: string; chosenProfile: string }) => void;
   /**
    * Invoked once per chain rung that named a profile the resolver could not
-   * use, before resolution continues to the next rung. Fallback is silent to
+   * use (before resolution continues to the next rung), and once when a
+   * call-site default's model pin resolves to a provider this install cannot
+   * reach so the pin is dropped (`reason: "unroutable"`). Fallback is silent to
    * the call but must be visible in logs — callers on user-facing paths should
    * log at warn.
    */
@@ -111,7 +113,11 @@ export interface ResolveCallSiteOpts {
   }) => void;
 }
 
-export type ResolutionFallbackReason = "missing" | "disabled" | "incomplete";
+export type ResolutionFallbackReason =
+  | "missing"
+  | "disabled"
+  | "incomplete"
+  | "unroutable";
 
 export function resolveCallSiteConfig(
   callSite: LLMCallSite,
@@ -365,18 +371,34 @@ function resolveOverrideOrDefault(
 
   // The call site's own tweak fragment: the workspace override replaces the
   // code default wholesale. `profile` is the selection discriminator and
-  // `logitBias` is winner-owned, so neither enters the merge.
-  const site = llm.callSites?.[callSite] ?? CALL_SITE_DEFAULTS[callSite];
+  // `logitBias` is winner-owned, so neither enters the merge. `userSite`
+  // distinguishes an explicit workspace override from the shipped call-site
+  // default so a bare model pin is treated differently in each case (below).
+  const userSite = llm.callSites?.[callSite];
+  const site = userSite ?? CALL_SITE_DEFAULTS[callSite];
   const {
     profile: _siteProfile,
     logitBias: _siteBias,
     ...tweak
   } = (site ?? {}) as Record<string, unknown>;
 
-  // Direct call-site model overrides are fragments by design: when the tweak
-  // pins a model the winner's provider does not serve, stamp the catalog
-  // owner and drop the winner's connection (it belongs to the replaced
-  // provider; dispatch auto-resolves an absent connection by provider).
+  // A bare model tweak (a model with no sibling provider) is catalog-implied:
+  // the winner's provider does not serve it, so the model's catalog owner is
+  // the real dispatch provider. What happens next depends on whether that
+  // provider is reachable on this install:
+  //  - reachable — stamp the implied provider and drop the winner's connection
+  //    (it belongs to the replaced provider; dispatch auto-resolves an absent
+  //    connection by provider), unless it is the provider-agnostic Vellum
+  //    managed connection, which routes any managed-routable upstream and must
+  //    survive or platform installs lose their only connection.
+  //  - unreachable AND the pin is this call site's shipped default — drop the
+  //    pin and let the winner (the call site's profile/intent resolved through
+  //    `llm.defaultProvider`) stand. This is the same graceful fall-through an
+  //    unusable profile rung gets: a default pin is a best-effort optimization,
+  //    not a hard requirement, so on a BYOK install with no connection for the
+  //    implied provider it degrades to the profile's own model instead of
+  //    failing every dispatch. An explicit user model override is honored as
+  //    written, never silently swapped.
   const applicableProvider =
     (winnerFragment.provider as string | undefined) ??
     CODE_DEFAULT_BASE.provider;
@@ -391,21 +413,28 @@ function resolveOverrideOrDefault(
     tweak.provider === undefined &&
     !winnerServesModel(tweak.model)
   ) {
-    const implied = getCatalogProviderForModel(tweak.model);
+    const pinnedModel = tweak.model;
+    const implied = getCatalogProviderForModel(pinnedModel);
+    // The provider-agnostic Vellum managed connection reaches any
+    // managed-routable upstream, so a managed winner serves the implied
+    // provider even though its own `provider` field differs.
+    const managedRouteServesImplied =
+      implied !== undefined &&
+      winnerFragment.provider_connection === VELLUM_MANAGED_CONNECTION_NAME &&
+      MANAGED_ROUTABLE_PROVIDERS.has(implied);
     if (implied !== undefined) {
-      tweak.provider = implied;
-      // A provider-specific connection must not pin a mismatch onto the
-      // implied provider — but the provider-agnostic Vellum managed
-      // connection routes any managed-routable upstream and must survive,
-      // or platform installs lose their only connection.
-      if (
-        !(
-          winnerFragment.provider_connection ===
-            VELLUM_MANAGED_CONNECTION_NAME &&
-          MANAGED_ROUTABLE_PROVIDERS.has(implied)
-        )
-      ) {
-        delete winnerFragment.provider_connection;
+      if (userSite == null && !managedRouteServesImplied) {
+        delete tweak.model;
+        opts.onResolutionFallback?.({
+          callSite,
+          requested: pinnedModel,
+          reason: "unroutable",
+        });
+      } else {
+        tweak.provider = implied;
+        if (!managedRouteServesImplied) {
+          delete winnerFragment.provider_connection;
+        }
       }
     }
   }

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -53,6 +53,12 @@ import {
  * tweak); `logitBias` only ever from the winner. These are provider-coupled, so
  * a shadowed profile can never leak its sampling onto a different provider.
  *
+ * A default-owned call-site `model` pin (from the shipped call-site default, or
+ * a tuning-only workspace override inheriting it) is a best-effort optimization
+ * for the call site's DEFAULT resolution — it does NOT apply when an explicit
+ * `opts.overrideProfile` wins, so the override profile's own model stands. An
+ * explicit user call-site `model` is honored as written regardless.
+ *
  * `opts.forceOverrideProfile` is a no-op here: the override profile already
  * sits at the top of the chain for every call site.
  *
@@ -153,6 +159,10 @@ export function resolveCallSiteConfig(
 // tweaks (`thinking.enabled`) combine leaf-wise instead of wiping siblings.
 // `temperature`/`topP` come from the winner (or an explicit tweak);
 // `logitBias` only ever from the winner.
+// A default-owned `model` pin (shipped call-site default, or a tuning-only
+// override inheriting it) is suppressed when the winner is an explicit
+// `overrideProfile`, so the override profile's own model stands; an explicit
+// user call-site `model` still applies.
 // `forceOverrideProfile` is a no-op here (the override is already first).
 
 export interface ProfileWinnerSelection {
@@ -410,6 +420,19 @@ function resolveOverrideOrDefault(
   // (no user entry) or from a tuning-only override that inherited it above. A
   // model the user set explicitly is honored as written, never dropped.
   const modelPinIsDefaultOwned = userSite == null || tuningOnlyUserOverride;
+
+  // An explicit `overrideProfile` winner is a per-turn model selection that
+  // supersedes a default-owned pin: the caller (e.g. the image-fallback
+  // plugin's vision profile candidate) is choosing the profile precisely to
+  // run ITS model. A shipped default's `model` pin — a best-effort latency
+  // optimization for the call site's DEFAULT resolution — must not silently
+  // override that choice (which would run haiku for every candidate on managed
+  // installs, or force an unroutable concrete combination on BYOK). Drop the
+  // default-owned pin so the override profile's own model stands. An explicit
+  // user call-site `model` (not default-owned) is honored as written.
+  if (selection.source === "override" && modelPinIsDefaultOwned) {
+    delete tweak.model;
+  }
 
   // A bare model tweak (a model with no sibling provider) is catalog-implied:
   // the winner's provider does not serve it, so the model's catalog owner is

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -101,10 +101,13 @@ export interface ResolveCallSiteOpts {
   /**
    * Invoked once per chain rung that named a profile the resolver could not
    * use (before resolution continues to the next rung), and once when a
-   * call-site default's model pin resolves to a provider this install cannot
-   * reach so the pin is dropped (`reason: "unroutable"`). Fallback is silent to
-   * the call but must be visible in logs — callers on user-facing paths should
-   * log at warn.
+   * default-owned call-site model pin resolves to a provider this install
+   * cannot reach so the pin is dropped (`reason: "unroutable"`). The pin is
+   * default-owned when it comes from the shipped call-site default or from a
+   * tuning-only workspace override that inherits it (an override setting
+   * neither `profile` nor its own `model`); an explicit user model pin is never
+   * dropped. Fallback is silent to the call but must be visible in logs —
+   * callers on user-facing paths should log at warn.
    */
   onResolutionFallback?: (info: {
     callSite: LLMCallSite;
@@ -375,12 +378,38 @@ function resolveOverrideOrDefault(
   // distinguishes an explicit workspace override from the shipped call-site
   // default so a bare model pin is treated differently in each case (below).
   const userSite = llm.callSites?.[callSite];
-  const site = userSite ?? CALL_SITE_DEFAULTS[callSite];
+  const shipped = CALL_SITE_DEFAULTS[callSite];
+  const site = userSite ?? shipped;
   const {
     profile: _siteProfile,
     logitBias: _siteBias,
     ...tweak
   } = (site ?? {}) as Record<string, unknown>;
+
+  // A tuning-only workspace override — a `llm.callSites[id]` entry that sets
+  // neither `profile` nor its own `model` (e.g. `{ temperature: 0.2 }`) —
+  // replaces the shipped call-site default wholesale, dropping the shipped
+  // model pin. Resolution would then fall back to the winning profile's model,
+  // silently disabling a shipped pin (e.g. memoryV3SelectL2's haiku
+  // cache-latency pin). Re-apply the shipped default's model as a
+  // default-owned pin so it keeps the SAME `unroutable` fall-through the
+  // shipped default gets (the `userSite == null` case below): it applies where
+  // the implied provider is reachable and is dropped, not fatal, where it is
+  // not. A user entry that sets its own `profile` or `model` is an explicit
+  // selection, so the shipped pin does not apply.
+  const userSiteRecord = userSite as Record<string, unknown> | null | undefined;
+  const tuningOnlyUserOverride =
+    userSiteRecord != null &&
+    userSiteRecord.profile === undefined &&
+    userSiteRecord.model === undefined;
+  if (tuningOnlyUserOverride && typeof shipped?.model === "string") {
+    tweak.model = shipped.model;
+  }
+  // A model pin is default-owned — and thus eligible for the graceful
+  // `unroutable` drop below — when it comes from the shipped call-site default
+  // (no user entry) or from a tuning-only override that inherited it above. A
+  // model the user set explicitly is honored as written, never dropped.
+  const modelPinIsDefaultOwned = userSite == null || tuningOnlyUserOverride;
 
   // A bare model tweak (a model with no sibling provider) is catalog-implied:
   // the winner's provider does not serve it, so the model's catalog owner is
@@ -391,8 +420,9 @@ function resolveOverrideOrDefault(
   //    connection by provider), unless it is the provider-agnostic Vellum
   //    managed connection, which routes any managed-routable upstream and must
   //    survive or platform installs lose their only connection.
-  //  - unreachable AND the pin is this call site's shipped default — drop the
-  //    pin and let the winner (the call site's profile/intent resolved through
+  //  - unreachable AND the pin is default-owned (the shipped call-site default,
+  //    or a tuning-only override that inherited it above) — drop the pin and let
+  //    the winner (the call site's profile/intent resolved through
   //    `llm.defaultProvider`) stand. This is the same graceful fall-through an
   //    unusable profile rung gets: a default pin is a best-effort optimization,
   //    not a hard requirement, so on a BYOK install with no connection for the
@@ -423,7 +453,7 @@ function resolveOverrideOrDefault(
       winnerFragment.provider_connection === VELLUM_MANAGED_CONNECTION_NAME &&
       MANAGED_ROUTABLE_PROVIDERS.has(implied);
     if (implied !== undefined) {
-      if (userSite == null && !managedRouteServesImplied) {
+      if (modelPinIsDefaultOwned && !managedRouteServesImplied) {
         delete tweak.model;
         opts.onResolutionFallback?.({
           callSite,

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1479,6 +1479,57 @@ describe("call-site override tuning backfill", () => {
     });
     expect(savedCallSites().recall).toBeUndefined();
   });
+
+  test("profile-only memoryV3SelectL2 entry backfills tuning but never the shipped model pin", async () => {
+    await configPatchRoute.handler({
+      body: { llm: { callSites: { memoryV3SelectL2: { profile: "mine" } } } },
+    });
+    const saved = savedCallSites().memoryV3SelectL2!;
+    expect(saved.profile).toBe("mine");
+    // Tuning survives so the user's profile switch keeps the shipped knobs.
+    expect(saved.temperature).toBe(0);
+    expect(saved.thinking).toEqual({ enabled: false, streamThinking: false });
+    // The shipped haiku pin is selection, not tuning: the user's profile must
+    // control model selection, so no model key is stamped. Backfilling it would
+    // make the resolver treat it as an explicit user override and route a BYOK
+    // profile to Anthropic with no connection.
+    expect("model" in saved).toBe(false);
+  });
+
+  test("profile-only voiceFront entries backfill tuning but never the shipped model pin", async () => {
+    await configPatchRoute.handler({
+      body: {
+        llm: {
+          callSites: {
+            voiceFrontDecision: { profile: "mine" },
+            voiceFrontDoor: { profile: "mine" },
+          },
+        },
+      },
+    });
+    for (const site of ["voiceFrontDecision", "voiceFrontDoor"] as const) {
+      const saved = savedCallSites()[site]!;
+      expect(saved.profile).toBe("mine");
+      expect(saved.effort).toBe("low");
+      expect(saved.thinking).toEqual({ enabled: false });
+      expect("model" in saved).toBe(false);
+    }
+  });
+
+  test("an explicit model in the patch is persisted as written", async () => {
+    await configPatchRoute.handler({
+      body: {
+        llm: {
+          callSites: {
+            memoryV3SelectL2: { profile: "mine", model: "gpt-4o-mini" },
+          },
+        },
+      },
+    });
+    const saved = savedCallSites().memoryV3SelectL2!;
+    expect(saved.profile).toBe("mine");
+    expect(saved.model).toBe("gpt-4o-mini");
+  });
 });
 
 describe("config invariant flag enrichment", () => {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -905,10 +905,19 @@ function stripWireOnlyProfileKeys(patch: unknown): void {
  * effort bounds. Enforce the same invariant here: when a patch creates an
  * entry, copy in any shipped tuning key the patch doesn't set itself.
  *
- * `profile` is never backfilled — it is the selection discriminator, and
- * stamping it onto a custom provider/model entry would change winner
- * selection. Existing on-disk entries are never touched: deep-merge already
- * preserves their keys, and their values may be deliberate customization.
+ * Neither `profile` nor `model` is backfilled — both are selection, not
+ * tuning. `profile` is the winner discriminator; a shipped `model` pin (e.g.
+ * `memoryV3SelectL2`/`voiceFront*`' haiku cache-latency pin) is a best-effort
+ * optimization the resolver honors only for the shipped default, dropping it
+ * when the implied provider is unroutable. Stamping either onto a user's
+ * profile-based override would let the shipped model override the user's chosen
+ * one — and because the resolver treats a model pin on a user entry
+ * (`userSite != null`) as an explicit override honored as written, it would
+ * route a BYOK user's profile to that model's provider with no connection. A
+ * `model` the user sets in the patch itself is preserved untouched (it is
+ * already `in entry`). Existing on-disk entries are never touched: deep-merge
+ * already preserves their keys, and their values may be deliberate
+ * customization.
  */
 function backfillNewCallSiteEntries(
   raw: Record<string, unknown>,
@@ -931,7 +940,7 @@ function backfillNewCallSiteEntries(
       continue;
     }
     for (const [key, shippedValue] of Object.entries(shipped)) {
-      if (key === "profile" || key in entry) {
+      if (key === "profile" || key === "model" || key in entry) {
         continue;
       }
       entry[key] = structuredClone(shippedValue);


### PR DESCRIPTION
## Why

The memory-v3 L2 pool selector (`memoryV3SelectL2`, one call per user turn on established users) is already cache-optimal in shape — a ~30k-token stable card-corpus prefix with a `cache_control` breakpoint, dynamic tail last. But its default profile (`balanced`) resolves to a Fireworks-served model where the Anthropic breakpoint is **inert**, and Fireworks' own short-TTL implicit cache misses because calls are spaced per user turn.

Production (Jul 8–22): **12,524 events, avg 31.2k uncached input each, ~0 cache reads, $458/15d** — the prefix re-bills at full price on every single call.

## What

Bare `model: "claude-haiku-4-5-20251001"` pin on the call site (catalog-implied provider preserves the provider-agnostic managed connection), following the `voiceFrontDecision`/`voiceFrontDoor` precedent, keeping `temperature: 0` / thinking off.

**TTL reality (corrected after review):** the Anthropic provider gates extended 1h TTL OFF for the haiku family — a real, observed API 400 (PR #25302) — so the breakpoint runs at the default **5m TTL**. Measured clustering: 43.5% of selector calls arrive within 5m of the previous call (80.8% within 1h, which haiku cannot use). Blended per-event estimate at 5m: ~$0.037 → ~$0.025 (**~30% site cost cut**, ~$220/mo at current volume) plus a meaningful latency win. An existing provider test is now an explicit tripwire on the haiku TTL gating; if Anthropic lifts the haiku restriction upstream, un-gating restores the full 1h economics (~50%+) — noted as a follow-up.

Also hardened during review:
- Resolver drops a shipped call-site default's model pin when the install can't route it (new `unroutable` fallback reason) — BYOK installs without Anthropic fall through to the profile model instead of failing every turn; covers the pre-existing voiceFront pins too. Explicit user pins are always honored as written.
- Tuning-only call-site overrides (e.g. `{ temperature: 0.2 }`) re-apply the shipped default-owned pin (with the same fallback protection); profile-selecting overrides suppress it. The route backfill no longer copies shipped `model` pins into user override entries.
- `maxTokens` deliberately untouched: forced `select_pages` tool call with variable-length arrays; a cap risks truncating tool JSON → memory-recall degradation.

## Risk

Model swap (GLM → Haiku 4.5) on a bounded forced-tool relevance pick with a recall-safe fallback; low risk but worth watching selection quality in telemetry.

## Verification

- 231+ tests across resolver/catalog/loader/route/provider suites; `typecheck:fast` + lint clean. Managed-install resolution verified to dispatch to the Anthropic upstream (same path as voiceFrontDecision).
- Post-deploy: `memoryV3SelectL2` in `telemetry.llm_usage_raw` should show cache_read ≈ 40%+ of input volume and cost/event down ~30%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)