### PR TITLE
feat(web): store a detected composer secret into the credential vault and rewrite the draft

### DIFF
--- a/clients/web/src/components/add-credential-modal.test.tsx
+++ b/clients/web/src/components/add-credential-modal.test.tsx
@@ -26,7 +26,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 
-import type { AddCredentialModalProps } from "@/domains/settings/credentials/add-credential-modal";
+import type { AddCredentialModalProps } from "@/components/add-credential-modal";
 
 const ASSISTANT_ID = "asst-test";
 mock.module("@/assistant/use-active-assistant-id", () => ({
@@ -73,19 +73,25 @@ mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
     }),
 }));
 
-const { AddCredentialModal } =
-  await import("@/domains/settings/credentials/add-credential-modal");
+const { AddCredentialModal, credentialsListQueryKey } =
+  await import("@/components/add-credential-modal");
 
 function renderModal(props: Partial<AddCredentialModalProps> = {}) {
   const queryClient = new QueryClient();
+  const invalidateQueries = mock(
+    queryClient.invalidateQueries.bind(queryClient),
+  );
+  queryClient.invalidateQueries = invalidateQueries;
   const onClose = mock<AddCredentialModalProps["onClose"]>(() => {});
-  const onSaved = mock<AddCredentialModalProps["onSaved"]>(() => {});
+  const onSaved = mock<NonNullable<AddCredentialModalProps["onSaved"]>>(
+    () => {},
+  );
   render(
     <QueryClientProvider client={queryClient}>
       <AddCredentialModal open onClose={onClose} onSaved={onSaved} {...props} />
     </QueryClientProvider>,
   );
-  return { onClose, onSaved };
+  return { onClose, onSaved, invalidateQueries };
 }
 
 function input(label: string): HTMLInputElement {
@@ -110,7 +116,7 @@ describe("AddCredentialModal", () => {
   });
 
   test("saves the entered fields — service/field trimmed, value verbatim — then fires onSaved and onClose", async () => {
-    const { onClose, onSaved } = renderModal();
+    const { onClose, onSaved, invalidateQueries } = renderModal();
 
     fireEvent.change(input("Service"), { target: { value: "  github  " } });
     fireEvent.change(input("Field"), { target: { value: "api_token " } });
@@ -139,6 +145,11 @@ describe("AddCredentialModal", () => {
     ]);
     expect(onClose.mock.calls.length).toBe(1);
     expect(toasts).toEqual([{ kind: "success", message: "Credential saved." }]);
+    // The modal owns the credentials-list refresh so every consumer's
+    // Settings → Credentials view reflects the new entry.
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: credentialsListQueryKey(ASSISTANT_ID),
+    });
   });
 
   test("omits an empty label from the payload and the onSaved meta", async () => {

--- a/clients/web/src/components/add-credential-modal.tsx
+++ b/clients/web/src/components/add-credential-modal.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { KeyRound, Loader2 } from "lucide-react";
 import {
   useEffect,
@@ -13,6 +14,15 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
+
+/**
+ * Cache key of the credentials list shown on Settings → Credentials. The
+ * modal invalidates it after every save; other credential mutations (e.g.
+ * delete) invalidate it from their own call sites.
+ */
+export function credentialsListQueryKey(assistantId: string) {
+  return ["credentials-list", assistantId] as const;
+}
 
 /** Identity of a credential that was just saved to the vault. */
 export interface SavedCredentialMeta {
@@ -34,24 +44,29 @@ export interface AddCredentialModalProps {
   /** Called when the modal closes — dismissal, Cancel, or a completed save. */
   onClose: () => void;
   /** Called after the credential is persisted to the vault. */
-  onSaved: (meta: SavedCredentialMeta) => void;
+  onSaved?: (meta: SavedCredentialMeta) => void;
   initialValues?: AddCredentialInitialValues;
+  /** Success toast copy; defaults to a generic "Credential saved." */
+  successToastMessage?: string;
 }
 
 /**
  * Modal form that stores a credential (service / field / secret value /
  * optional label) in the assistant's credential vault via the credentials-set
- * endpoint. Owns validation, the save mutation, and success/error toasts so
- * every call site shares identical behavior; callers handle what happens
- * after a save (e.g. invalidating their credentials list) in `onSaved`.
+ * endpoint. Owns validation, the save mutation, success/error toasts, and the
+ * credentials-list cache invalidation so every call site shares identical
+ * behavior; callers hook flow-specific follow-ups (e.g. rewriting a chat
+ * draft) into `onSaved`.
  */
 export function AddCredentialModal({
   open,
   onClose,
   onSaved,
   initialValues,
+  successToastMessage = "Credential saved.",
 }: AddCredentialModalProps) {
   const assistantId = useActiveAssistantId();
+  const queryClient = useQueryClient();
 
   const [service, setService] = useState(initialValues?.service ?? "");
   const [field, setField] = useState(initialValues?.field ?? "");
@@ -116,8 +131,11 @@ export function AddCredentialModal({
       },
       {
         onSuccess: () => {
-          toast.success("Credential saved.");
-          onSaved({
+          void queryClient.invalidateQueries({
+            queryKey: credentialsListQueryKey(assistantId),
+          });
+          toast.success(successToastMessage);
+          onSaved?.({
             service: trimmedService,
             field: trimmedField,
             label: trimmedLabel,

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -65,7 +65,9 @@ import { MicPermissionPrimer } from "@/domains/chat/components/mic-permission-pr
 import { OnboardingChoiceCard } from "@/domains/chat/components/onboarding-choice-card";
 import { ProviderBillingBanner } from "@/domains/chat/components/provider-billing-banner";
 import { SendErrorModal } from "@/domains/chat/components/send-error-modal";
+import { StoreCredentialDialog } from "@/domains/chat/components/store-credential-dialog";
 import { SuggestionDetailPanel } from "@/domains/chat/components/suggestion-detail-panel";
+import type { DetectedSecret } from "@vellumai/service-contracts/secret-detection";
 import type { ThreadSuggestion } from "@/domains/chat/suggestions/types";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BottomSheet } from "@vellumai/design-library";
@@ -574,7 +576,9 @@ export function ChatMainPanel({
 
   const sendDisabled = isSendDisabledFromTurn || typingDisabled;
 
-  const handleQuoteAddedToChat = useCallback(() => {
+  // rAF: modal/popover teardown restores focus on close, so the composer
+  // must claim it afterwards.
+  const focusComposer = useCallback(() => {
     requestAnimationFrame(() => {
       inputRef.current?.focus();
     });
@@ -823,6 +827,22 @@ export function ChatMainPanel({
     void submitMessage(undefined, { bypassSecretCheck: true });
   }, [allowSecretSendOnce, submitMessage]);
 
+  // "Store securely" on the notice: stage the previewed (first) detected
+  // secret and open the store-credential dialog for it. The dialog saves the
+  // key to the vault and rewrites the draft to reference the vault slot; the
+  // detection hook's draft subscription then clears the notice/blocked state
+  // on its own once the plaintext leaves the draft. Cancel just unstages —
+  // notice, blocked state, and draft all stay as they were.
+  const [secretToStore, setSecretToStore] = useState<DetectedSecret | null>(
+    null,
+  );
+  const handleStoreSecretSecurely = useCallback(() => {
+    setSecretToStore(draftSecretDetection.matches[0] ?? null);
+  }, [draftSecretDetection.matches]);
+  const handleStoreSecretClose = useCallback(() => {
+    setSecretToStore(null);
+  }, []);
+
   const handleSelectStarter = useCallback((starter: { prompt: string }) => {
     useComposerStore.getState().setInput(starter.prompt);
     void submitMessage(starter.prompt);
@@ -1041,6 +1061,7 @@ export function ChatMainPanel({
                 sendBlocked={draftSecretDetection.sendBlocked}
                 onDismiss={draftSecretDetection.dismiss}
                 onSendAnyway={handleSecretSendAnyway}
+                onStoreSecurely={handleStoreSecretSecurely}
               />
             )}
           <ComposerNotices
@@ -1224,8 +1245,21 @@ export function ChatMainPanel({
       />
       {sendErrorModalNode}
       {ruleEditorModalNode}
+      {/* Mounted only while a secret is staged: ChatMainPanel renders outside
+          ActiveAssistantGate, and the dialog's vault mutation requires the
+          active assistant id — which a detected draft secret implies. */}
+      {secretToStore !== null && (
+        <StoreCredentialDialog
+          secret={secretToStore}
+          open
+          onClose={handleStoreSecretClose}
+          // Leave the rewritten draft focused for the user to review and
+          // send — never auto-send.
+          onStored={focusComposer}
+        />
+      )}
       <TextSelectionPopover containerRef={transcriptContainerRef} />
-      <QuoteReplyBubble onAddToChat={handleQuoteAddedToChat} />
+      <QuoteReplyBubble onAddToChat={focusComposer} />
     </>
   );
 }

--- a/clients/web/src/domains/chat/components/composer-secret-notice.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-secret-notice.test.tsx
@@ -94,6 +94,49 @@ describe("ComposerSecretNotice (passive)", () => {
   });
 });
 
+describe("ComposerSecretNotice (non-storable match)", () => {
+  // A private key detected by its header alone — the END footer never
+  // arrived, so storing would leave the key body in the draft.
+  const headerOnlyPem: DetectedSecret = {
+    label: "Private Key",
+    value: "-----BEGIN RSA PRIVATE KEY-----",
+    start: 0,
+    end: "-----BEGIN RSA PRIVATE KEY-----".length,
+    wholeMessage: false,
+  };
+
+  test("passive state omits Store securely for a header-only private key", () => {
+    renderNotice({ matches: [headerOnlyPem] });
+    expect(
+      screen.queryByRole("button", { name: "Store securely" }),
+    ).toBeNull();
+  });
+
+  test("blocked state omits Store securely but keeps Send anyway / Dismiss", () => {
+    renderNotice({ matches: [headerOnlyPem], sendBlocked: true });
+    expect(
+      screen.queryByRole("button", { name: "Store securely" }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Send anyway" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
+  });
+
+  test("a complete PEM block still offers Store securely", () => {
+    const fullBlock: DetectedSecret = {
+      label: "Private Key",
+      value:
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIFAKEfakefakefake==\n-----END RSA PRIVATE KEY-----",
+      start: 0,
+      end: 92,
+      wholeMessage: false,
+    };
+    renderNotice({ matches: [fullBlock] });
+    expect(
+      screen.getByRole("button", { name: "Store securely" }),
+    ).toBeTruthy();
+  });
+});
+
 describe("ComposerSecretNotice (blocked send)", () => {
   test("shows the exact blocked copy, the masked value, and both actions", () => {
     const { container } = renderNotice({ sendBlocked: true });

--- a/clients/web/src/domains/chat/components/composer-secret-notice.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-secret-notice.test.tsx
@@ -1,8 +1,9 @@
 /**
  * Tests for `ComposerSecretNotice` — masked display, generic copy, and
  * dismissal in the passive state, plus the blocked-send state's exact copy
- * and "Send anyway" / "Dismiss" actions. The token is a synthetic value
- * invented for these tests.
+ * and "Send anyway" / "Dismiss" actions, and the "Store securely" action
+ * offered in both states. The token is a synthetic value invented for
+ * these tests.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -37,6 +38,7 @@ function renderNotice(overrides: Partial<ComposerSecretNoticeProps> = {}) {
       sendBlocked={false}
       onDismiss={() => {}}
       onSendAnyway={() => {}}
+      onStoreSecurely={() => {}}
       {...overrides}
     />,
   );
@@ -83,6 +85,13 @@ describe("ComposerSecretNotice (passive)", () => {
     const { container } = renderNotice({ matches: [] });
     expect(container.innerHTML).toBe("");
   });
+
+  test("Store securely action is offered and invokes onStoreSecurely", () => {
+    const onStoreSecurely = mock(() => {});
+    renderNotice({ onStoreSecurely });
+    fireEvent.click(screen.getByRole("button", { name: "Store securely" }));
+    expect(onStoreSecurely).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("ComposerSecretNotice (blocked send)", () => {
@@ -99,6 +108,14 @@ describe("ComposerSecretNotice (blocked send)", () => {
       screen.getByRole("button", { name: "Send anyway" }),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Store securely" })).toBeTruthy();
+  });
+
+  test("Store securely action invokes onStoreSecurely while blocked", () => {
+    const onStoreSecurely = mock(() => {});
+    renderNotice({ sendBlocked: true, onStoreSecurely });
+    fireEvent.click(screen.getByRole("button", { name: "Store securely" }));
+    expect(onStoreSecurely).toHaveBeenCalledTimes(1);
   });
 
   test("Send anyway invokes the bypass-and-resubmit handler once", () => {

--- a/clients/web/src/domains/chat/components/composer-secret-notice.tsx
+++ b/clients/web/src/domains/chat/components/composer-secret-notice.tsx
@@ -31,6 +31,12 @@ export interface ComposerSecretNoticeProps {
    * the daemon's per-message `bypassSecretCheck` override.
    */
   onSendAnyway: () => void;
+  /**
+   * Both states: opens the store-credential dialog for the previewed
+   * (first) detected secret so the user can vault it and have the draft
+   * rewritten instead of sending the plaintext key.
+   */
+  onStoreSecurely: () => void;
 }
 
 /**
@@ -41,8 +47,10 @@ export interface ComposerSecretNoticeProps {
  *   control, shown while typing.
  * - Blocked (`sendBlocked` true): the pre-send gate intercepted a submit;
  *   the draft is untouched and the user chooses "Send anyway" (single-use
- *   bypass + resubmit) or "Dismiss". Follow-up actions (e.g. storing the
- *   credential securely) slot in as additional buttons alongside these.
+ *   bypass + resubmit) or "Dismiss".
+ *
+ * Both states lead with "Store securely" — the recommended path — which
+ * opens the store-credential dialog for the previewed secret.
  *
  * The copy is deliberately generic — the detection label (which names the
  * vendor) stays internal and is never rendered. The detected value appears
@@ -59,11 +67,17 @@ export function ComposerSecretNotice({
   sendBlocked,
   onDismiss,
   onSendAnyway,
+  onStoreSecurely,
 }: ComposerSecretNoticeProps) {
   const first = matches[0];
   if (!first) {
     return null;
   }
+  const storeSecurelyButton = (
+    <Button variant="primary" size="compact" onClick={onStoreSecurely}>
+      Store securely
+    </Button>
+  );
   return (
     <div className="mb-2">
       <Notice
@@ -77,6 +91,7 @@ export function ComposerSecretNotice({
         actions={
           sendBlocked ? (
             <>
+              {storeSecurelyButton}
               <Button variant="outlined" size="compact" onClick={onSendAnyway}>
                 Send anyway
               </Button>
@@ -84,7 +99,9 @@ export function ComposerSecretNotice({
                 Dismiss
               </Button>
             </>
-          ) : undefined
+          ) : (
+            storeSecurelyButton
+          )
         }
       >
         <span className="font-mono">{maskSecretValue(first.value)}</span>

--- a/clients/web/src/domains/chat/components/composer-secret-notice.tsx
+++ b/clients/web/src/domains/chat/components/composer-secret-notice.tsx
@@ -1,6 +1,8 @@
 import { Button, Notice } from "@vellumai/design-library";
 import type { DetectedSecret } from "@vellumai/service-contracts/secret-detection";
 
+import { isStorableSecret } from "@/domains/chat/components/store-credential-dialog";
+
 /** Leading characters of the detected value kept visible in the masked preview. */
 const MASK_VISIBLE_CHARS = 6;
 const MASK_BULLETS = "•".repeat(8);
@@ -50,7 +52,8 @@ export interface ComposerSecretNoticeProps {
  *   bypass + resubmit) or "Dismiss".
  *
  * Both states lead with "Store securely" — the recommended path — which
- * opens the store-credential dialog for the previewed secret.
+ * opens the store-credential dialog for the previewed secret. The action is
+ * omitted for a non-storable match (see {@link isStorableSecret}).
  *
  * The copy is deliberately generic — the detection label (which names the
  * vendor) stays internal and is never rendered. The detected value appears
@@ -73,11 +76,14 @@ export function ComposerSecretNotice({
   if (!first) {
     return null;
   }
-  const storeSecurelyButton = (
+  // A non-storable match (a private key detected by its header alone — the
+  // END footer never arrived) gets no "Store securely" action: the store +
+  // rewrite would remove only the header and leave the key body behind.
+  const storeSecurelyButton = isStorableSecret(first) ? (
     <Button variant="primary" size="compact" onClick={onStoreSecurely}>
       Store securely
     </Button>
-  );
+  ) : null;
   return (
     <div className="mb-2">
       <Notice

--- a/clients/web/src/domains/chat/components/store-credential-dialog.test.tsx
+++ b/clients/web/src/domains/chat/components/store-credential-dialog.test.tsx
@@ -81,6 +81,7 @@ mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
 
 const {
   StoreCredentialDialog,
+  isStorableSecret,
   rewriteDraftWithStoredCredential,
   suggestCredentialSlot,
 } = await import("@/domains/chat/components/store-credential-dialog");
@@ -89,6 +90,27 @@ const {
 // OpenAI-project shape.
 const SYNTHETIC_PROJECT_KEY =
   "sk-proj-Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv1Wx2Yz3A";
+
+// Clearly fake PEM material — never a real key.
+const FAKE_PEM_HEADER = "-----BEGIN RSA PRIVATE KEY-----";
+const FAKE_PEM_BODY = "MIIFAKEfakefakefakefakefakefakefakefakefake==";
+const FAKE_PEM_BLOCK = `${FAKE_PEM_HEADER}\n${FAKE_PEM_BODY}\n-----END RSA PRIVATE KEY-----`;
+
+const fullPemSecret: DetectedSecret = {
+  label: "Private Key",
+  value: FAKE_PEM_BLOCK,
+  start: 12,
+  end: 12 + FAKE_PEM_BLOCK.length,
+  wholeMessage: false,
+};
+
+const headerOnlyPemSecret: DetectedSecret = {
+  label: "Private Key",
+  value: FAKE_PEM_HEADER,
+  start: 12,
+  end: 12 + FAKE_PEM_HEADER.length,
+  wholeMessage: false,
+};
 
 const detectedSecret: DetectedSecret = {
   label: "OpenAI Project Key",
@@ -175,6 +197,20 @@ describe("suggestCredentialSlot", () => {
     [""],
   ])("%p suggests empty fields", (label) => {
     expect(suggestCredentialSlot(label)).toEqual({ service: "", field: "" });
+  });
+});
+
+describe("isStorableSecret", () => {
+  test("non-private-key secrets are always storable", () => {
+    expect(isStorableSecret(detectedSecret)).toBe(true);
+  });
+
+  test("a complete PEM block is storable", () => {
+    expect(isStorableSecret(fullPemSecret)).toBe(true);
+  });
+
+  test("a header-only private-key match is not storable", () => {
+    expect(isStorableSecret(headerOnlyPemSecret)).toBe(false);
   });
 });
 
@@ -285,6 +321,48 @@ describe("StoreCredentialDialog", () => {
     expect(setCalls.length).toBe(0);
     expect(onStored.mock.calls.length).toBe(0);
     expect(onClose.mock.calls.length).toBe(1);
+  });
+
+  test("a full PEM block is stored whole and rewritten out of the draft with no residue", async () => {
+    const draft = `here is my\n${FAKE_PEM_BLOCK}\nplease deploy`;
+    useComposerStore.getState().setInput(draft);
+    const { onStored } = renderDialog({ secret: fullPemSecret });
+
+    fireEvent.change(input("Service"), { target: { value: "github-app" } });
+    fireEvent.change(input("Field"), { target: { value: "pem" } });
+    fireEvent.submit(
+      screen
+        .getByRole("button", { name: "Save" })
+        .closest("form") as HTMLFormElement,
+    );
+
+    // The mutation receives the ENTIRE block — header, body, and footer.
+    await waitFor(() => expect(setCalls.length).toBe(1));
+    expect(setCalls[0]!.body.value).toBe(FAKE_PEM_BLOCK);
+
+    await waitFor(() => expect(onStored.mock.calls.length).toBe(1));
+    const rewritten = useComposerStore.getState().input;
+    expect(rewritten).toBe(
+      "here is my\n[stored securely as github-app/pem]\nplease deploy",
+    );
+    // No fragment of the key survives anywhere — draft or DOM.
+    expect(rewritten).not.toContain("BEGIN");
+    expect(rewritten).not.toContain(FAKE_PEM_BODY);
+    expect(rewritten).not.toContain("END");
+    expect(document.body.innerHTML).not.toContain(FAKE_PEM_BODY);
+  });
+
+  test("a header-only private-key match is not storable — the dialog never opens", () => {
+    // A partial store would vault just the header and strip only the header
+    // from the draft, leaving the key body behind with nothing left for the
+    // detector to flag.
+    useComposerStore
+      .getState()
+      .setInput(`here is my\n${FAKE_PEM_HEADER}\n${FAKE_PEM_BODY}`);
+    renderDialog({ secret: headerOnlyPemSecret });
+
+    expect(screen.queryByLabelText("Value")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
   });
 
   test("unknown detection label opens with empty service/field for the user to fill", () => {

--- a/clients/web/src/domains/chat/components/store-credential-dialog.test.tsx
+++ b/clients/web/src/domains/chat/components/store-credential-dialog.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * Tests for the "Store securely" flow:
+ *
+ *   - `suggestCredentialSlot` maps internal detection labels to vault-slot
+ *     suggestions (unknown labels → empty strings);
+ *   - `rewriteDraftWithStoredCredential` swaps every occurrence of the
+ *     secret for its vault-slot placeholder and leaves the rest untouched;
+ *   - the dialog pre-fills the shared AddCredentialModal from the detected
+ *     secret — the value only ever inside the password input, never as
+ *     visible text;
+ *   - saving sends the exact detected value to the credentials-set mutation,
+ *     rewrites the composer draft (plaintext gone, placeholder present), and
+ *     reports the saved slot via `onStored`;
+ *   - cancelling leaves the draft untouched and saves nothing.
+ *
+ * Uses the real composer store (reset between tests). All tokens are
+ * synthetic values invented for these tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useMutation,
+  type UseMutationOptions,
+} from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import type { DetectedSecret } from "@vellumai/service-contracts/secret-detection";
+
+import { useComposerStore } from "@/domains/chat/composer-store";
+import type { StoreCredentialDialogProps } from "@/domains/chat/components/store-credential-dialog";
+
+const ASSISTANT_ID = "asst-test";
+mock.module("@/assistant/use-active-assistant-id", () => ({
+  useActiveAssistantId: () => ASSISTANT_ID,
+}));
+
+const toasts: Array<{ kind: "success" | "error"; message: string }> = [];
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: {
+    success: (message: string) => {
+      toasts.push({ kind: "success", message });
+    },
+    error: (message: string) => {
+      toasts.push({ kind: "error", message });
+    },
+  },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+interface SetCall {
+  path: { assistant_id: string };
+  body: {
+    service: string;
+    field: string;
+    value: string;
+    label?: string;
+  };
+}
+const setCalls: SetCall[] = [];
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  useCredentialsSetPostMutation: (
+    options: UseMutationOptions<unknown, Error, SetCall> = {},
+  ) =>
+    useMutation<unknown, Error, SetCall>({
+      mutationFn: (variables) => {
+        setCalls.push(variables);
+        return Promise.resolve({});
+      },
+      ...options,
+    }),
+}));
+
+const {
+  StoreCredentialDialog,
+  rewriteDraftWithStoredCredential,
+  suggestCredentialSlot,
+} = await import("@/domains/chat/components/store-credential-dialog");
+
+// Synthetic lookalike token — a random string matching the detector's
+// OpenAI-project shape.
+const SYNTHETIC_PROJECT_KEY =
+  "sk-proj-Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv1Wx2Yz3A";
+
+const detectedSecret: DetectedSecret = {
+  label: "OpenAI Project Key",
+  value: SYNTHETIC_PROJECT_KEY,
+  start: 8,
+  end: 8 + SYNTHETIC_PROJECT_KEY.length,
+  wholeMessage: false,
+};
+
+const DRAFT = `here is ${SYNTHETIC_PROJECT_KEY} for the deploy`;
+
+function renderDialog(props: Partial<StoreCredentialDialogProps> = {}) {
+  const queryClient = new QueryClient();
+  const onClose = mock<StoreCredentialDialogProps["onClose"]>(() => {});
+  const onStored = mock<StoreCredentialDialogProps["onStored"]>(() => {});
+  render(
+    <QueryClientProvider client={queryClient}>
+      <StoreCredentialDialog
+        secret={detectedSecret}
+        open
+        onClose={onClose}
+        onStored={onStored}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+  return { onClose, onStored };
+}
+
+function input(label: string): HTMLInputElement {
+  return screen.getByLabelText(label) as HTMLInputElement;
+}
+
+beforeEach(() => {
+  setCalls.length = 0;
+  toasts.length = 0;
+  useComposerStore.getState().setInput(DRAFT);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("suggestCredentialSlot", () => {
+  test.each([
+    ["OpenAI API Key", "openai", "api_key"],
+    ["OpenAI Project Key", "openai", "api_key"],
+    ["Anthropic API Key", "anthropic", "api_key"],
+    ["GitHub Token", "github", "token"],
+    ["GitHub Fine-Grained PAT", "github", "token"],
+    ["GitLab Token", "gitlab", "token"],
+    ["AWS Access Key", "aws", "access_key_id"],
+    ["Stripe Secret Key", "stripe", "secret_key"],
+    ["Stripe Restricted Key", "stripe", "restricted_key"],
+    ["Slack Bot Token", "slack", "bot_token"],
+    ["Slack User Token", "slack", "user_token"],
+    ["Slack App Token", "slack", "app_token"],
+    ["Telegram Bot Token", "telegram", "bot_token"],
+    ["Google API Key", "google", "api_key"],
+    ["Google OAuth Client Secret", "google", "oauth_client_secret"],
+    ["Twilio API Key", "twilio", "api_key"],
+    ["SendGrid API Key", "sendgrid", "api_key"],
+    ["Mailgun API Key", "mailgun", "api_key"],
+    ["npm Token", "npm", "token"],
+    ["PyPI API Token", "pypi", "api_token"],
+    ["Linear API Key", "linear", "api_key"],
+    ["Notion Integration Token", "notion", "integration_token"],
+    ["OpenRouter API Key", "openrouter", "api_key"],
+    ["Vercel AI Gateway API Key", "vercel", "ai_gateway_api_key"],
+    ["Fireworks API Key", "fireworks", "api_key"],
+    ["Perplexity API Key", "perplexity", "api_key"],
+    ["Tavily API Key", "tavily", "api_key"],
+    ["Firecrawl API Key", "firecrawl", "api_key"],
+  ])("%s → %s/%s", (label, service, field) => {
+    expect(suggestCredentialSlot(label)).toEqual({ service, field });
+  });
+
+  test.each([
+    // Owning service unknowable — the user names the slot.
+    ["Token-shaped message"],
+    ["Private Key"],
+    // Future/unmapped detector labels degrade to empty suggestions.
+    ["Some Future Vendor Key"],
+    [""],
+  ])("%p suggests empty fields", (label) => {
+    expect(suggestCredentialSlot(label)).toEqual({ service: "", field: "" });
+  });
+});
+
+describe("rewriteDraftWithStoredCredential", () => {
+  const slot = { service: "openai", field: "api_key" };
+  const placeholder = "[stored securely as openai/api_key]";
+
+  test("replaces the secret and keeps the surrounding draft", () => {
+    const rewritten = rewriteDraftWithStoredCredential(
+      DRAFT,
+      SYNTHETIC_PROJECT_KEY,
+      slot,
+    );
+    expect(rewritten).toBe(`here is ${placeholder} for the deploy`);
+    expect(rewritten).not.toContain(SYNTHETIC_PROJECT_KEY);
+  });
+
+  test("replaces every occurrence of the secret", () => {
+    const rewritten = rewriteDraftWithStoredCredential(
+      `${SYNTHETIC_PROJECT_KEY} and again ${SYNTHETIC_PROJECT_KEY}`,
+      SYNTHETIC_PROJECT_KEY,
+      slot,
+    );
+    expect(rewritten).toBe(`${placeholder} and again ${placeholder}`);
+    expect(rewritten).not.toContain(SYNTHETIC_PROJECT_KEY);
+  });
+});
+
+describe("StoreCredentialDialog", () => {
+  test("prefills the form from the detection — the value only inside the password input", () => {
+    renderDialog();
+
+    expect(input("Service").value).toBe("openai");
+    expect(input("Field").value).toBe("api_key");
+    const valueInput = input("Value");
+    expect(valueInput.type).toBe("password");
+    expect(valueInput.value).toBe(SYNTHETIC_PROJECT_KEY);
+    // Never rendered as visible text anywhere in the document (the modal
+    // portals to <body>, so assert against the whole page).
+    expect(document.body.textContent).not.toContain(SYNTHETIC_PROJECT_KEY);
+  });
+
+  test("save sends the exact detected value, rewrites the draft, and reports the slot", async () => {
+    const { onClose, onStored } = renderDialog();
+
+    fireEvent.submit(
+      screen
+        .getByRole("button", { name: "Save" })
+        .closest("form") as HTMLFormElement,
+    );
+
+    await waitFor(() => expect(setCalls.length).toBe(1));
+    expect(setCalls[0]).toEqual({
+      path: { assistant_id: ASSISTANT_ID },
+      body: {
+        service: "openai",
+        field: "api_key",
+        value: SYNTHETIC_PROJECT_KEY,
+        label: undefined,
+      },
+    });
+
+    await waitFor(() => expect(onStored.mock.calls.length).toBe(1));
+    expect(onStored.mock.calls[0]).toEqual([
+      { service: "openai", field: "api_key" },
+    ]);
+    expect(onClose.mock.calls.length).toBe(1);
+
+    const draft = useComposerStore.getState().input;
+    expect(draft).toBe(
+      "here is [stored securely as openai/api_key] for the deploy",
+    );
+    expect(draft).not.toContain(SYNTHETIC_PROJECT_KEY);
+    expect(toasts).toEqual([
+      {
+        kind: "success",
+        message: "Stored securely — the key never entered the chat",
+      },
+    ]);
+  });
+
+  test("the rewrite placeholder follows a user-edited service/field", async () => {
+    const { onStored } = renderDialog();
+
+    fireEvent.change(input("Service"), { target: { value: "my-openai" } });
+    fireEvent.change(input("Field"), { target: { value: "main_key" } });
+    fireEvent.submit(
+      screen
+        .getByRole("button", { name: "Save" })
+        .closest("form") as HTMLFormElement,
+    );
+
+    await waitFor(() => expect(onStored.mock.calls.length).toBe(1));
+    expect(onStored.mock.calls[0]).toEqual([
+      { service: "my-openai", field: "main_key" },
+    ]);
+    expect(useComposerStore.getState().input).toBe(
+      "here is [stored securely as my-openai/main_key] for the deploy",
+    );
+  });
+
+  test("cancel leaves the draft untouched and saves nothing", () => {
+    const { onClose, onStored } = renderDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(useComposerStore.getState().input).toBe(DRAFT);
+    expect(setCalls.length).toBe(0);
+    expect(onStored.mock.calls.length).toBe(0);
+    expect(onClose.mock.calls.length).toBe(1);
+  });
+
+  test("unknown detection label opens with empty service/field for the user to fill", () => {
+    renderDialog({
+      secret: {
+        label: "Token-shaped message",
+        value: SYNTHETIC_PROJECT_KEY,
+        start: 0,
+        end: SYNTHETIC_PROJECT_KEY.length,
+        wholeMessage: true,
+      },
+    });
+
+    expect(input("Service").value).toBe("");
+    expect(input("Field").value).toBe("");
+    expect(input("Value").value).toBe(SYNTHETIC_PROJECT_KEY);
+  });
+});

--- a/clients/web/src/domains/chat/components/store-credential-dialog.tsx
+++ b/clients/web/src/domains/chat/components/store-credential-dialog.tsx
@@ -1,0 +1,139 @@
+import type { DetectedSecret } from "@vellumai/service-contracts/secret-detection";
+
+import { AddCredentialModal } from "@/components/add-credential-modal";
+import { useComposerStore } from "@/domains/chat/composer-store";
+
+/** Vault slot (service + field) a detected secret is stored under. */
+export interface CredentialSlot {
+  service: string;
+  field: string;
+}
+
+const UNKNOWN_SLOT: CredentialSlot = { service: "", field: "" };
+
+/**
+ * Suggested vault slot per detection label from the shared secret-detection
+ * patterns (`@vellumai/service-contracts/secret-detection`). Labels without
+ * an entry — including "Token-shaped message" and "Private Key", where the
+ * owning service is unknowable — fall back to empty fields for the user to
+ * fill in. Suggestions only; every field stays editable in the dialog.
+ */
+const SLOT_BY_DETECTION_LABEL: Record<string, CredentialSlot> = {
+  "AWS Access Key": { service: "aws", field: "access_key_id" },
+  "GitHub Token": { service: "github", field: "token" },
+  "GitHub Fine-Grained PAT": { service: "github", field: "token" },
+  "GitLab Token": { service: "gitlab", field: "token" },
+  "Stripe Secret Key": { service: "stripe", field: "secret_key" },
+  "Stripe Restricted Key": { service: "stripe", field: "restricted_key" },
+  "Slack Bot Token": { service: "slack", field: "bot_token" },
+  "Slack User Token": { service: "slack", field: "user_token" },
+  "Slack App Token": { service: "slack", field: "app_token" },
+  "Telegram Bot Token": { service: "telegram", field: "bot_token" },
+  "Anthropic API Key": { service: "anthropic", field: "api_key" },
+  "OpenAI API Key": { service: "openai", field: "api_key" },
+  "OpenAI Project Key": { service: "openai", field: "api_key" },
+  "Google API Key": { service: "google", field: "api_key" },
+  "Google OAuth Client Secret": {
+    service: "google",
+    field: "oauth_client_secret",
+  },
+  "Twilio API Key": { service: "twilio", field: "api_key" },
+  "SendGrid API Key": { service: "sendgrid", field: "api_key" },
+  "Mailgun API Key": { service: "mailgun", field: "api_key" },
+  "npm Token": { service: "npm", field: "token" },
+  "PyPI API Token": { service: "pypi", field: "api_token" },
+  "Linear API Key": { service: "linear", field: "api_key" },
+  "Notion Integration Token": {
+    service: "notion",
+    field: "integration_token",
+  },
+  "OpenRouter API Key": { service: "openrouter", field: "api_key" },
+  "Vercel AI Gateway API Key": {
+    service: "vercel",
+    field: "ai_gateway_api_key",
+  },
+  "Fireworks API Key": { service: "fireworks", field: "api_key" },
+  "Perplexity API Key": { service: "perplexity", field: "api_key" },
+  "Tavily API Key": { service: "tavily", field: "api_key" },
+  "Firecrawl API Key": { service: "firecrawl", field: "api_key" },
+};
+
+/**
+ * Maps an internal detection label (e.g. "OpenAI API Key") to the vault slot
+ * the dialog pre-fills. Unknown labels yield empty strings.
+ */
+export function suggestCredentialSlot(label: string): CredentialSlot {
+  return SLOT_BY_DETECTION_LABEL[label] ?? UNKNOWN_SLOT;
+}
+
+/**
+ * Replaces every occurrence of a stored secret in the draft with a plaintext
+ * placeholder naming its vault slot. The placeholder is model-actionable: the
+ * assistant discovers stored credentials via `assistant credentials list` and
+ * uses them through `credential_ids` on proxied tools.
+ */
+export function rewriteDraftWithStoredCredential(
+  draft: string,
+  secretValue: string,
+  slot: CredentialSlot,
+): string {
+  return draft.replaceAll(
+    secretValue,
+    `[stored securely as ${slot.service}/${slot.field}]`,
+  );
+}
+
+export interface StoreCredentialDialogProps {
+  /** The detected secret being stored; seeds the form when the dialog opens. */
+  secret: DetectedSecret | null;
+  open: boolean;
+  /** Called when the dialog closes — dismissal, Cancel, or a completed save. */
+  onClose: () => void;
+  /**
+   * Called after the credential is saved and the draft rewrite has been
+   * applied to the composer store.
+   */
+  onStored: (slot: CredentialSlot) => void;
+}
+
+/**
+ * "Store securely" flow for a secret detected in the chat draft: wraps the
+ * shared {@link AddCredentialModal} pre-filled with the detected value
+ * (password input — never echoed as plaintext) and a service/field
+ * suggestion derived from the detection label. On save it rewrites the
+ * composer draft, replacing the secret with its vault-slot placeholder, so
+ * the plaintext key never enters the transcript. Cancel leaves the draft —
+ * and the composer secret notice — untouched.
+ */
+export function StoreCredentialDialog({
+  secret,
+  open,
+  onClose,
+  onStored,
+}: StoreCredentialDialogProps) {
+  const suggestion = suggestCredentialSlot(secret?.label ?? "");
+
+  const handleSaved = (meta: { service: string; field: string }) => {
+    if (!secret) {
+      return;
+    }
+    const slot: CredentialSlot = { service: meta.service, field: meta.field };
+    const { input, setInput } = useComposerStore.getState();
+    setInput(rewriteDraftWithStoredCredential(input, secret.value, slot));
+    onStored(slot);
+  };
+
+  return (
+    <AddCredentialModal
+      open={open && secret !== null}
+      onClose={onClose}
+      onSaved={handleSaved}
+      successToastMessage="Stored securely — the key never entered the chat"
+      initialValues={{
+        service: suggestion.service,
+        field: suggestion.field,
+        value: secret?.value ?? "",
+      }}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/components/store-credential-dialog.tsx
+++ b/clients/web/src/domains/chat/components/store-credential-dialog.tsx
@@ -1,4 +1,8 @@
-import type { DetectedSecret } from "@vellumai/service-contracts/secret-detection";
+import {
+  isCompletePrivateKeyBlock,
+  PRIVATE_KEY_LABEL,
+  type DetectedSecret,
+} from "@vellumai/service-contracts/secret-detection";
 
 import { AddCredentialModal } from "@/components/add-credential-modal";
 import { useComposerStore } from "@/domains/chat/composer-store";
@@ -67,6 +71,22 @@ export function suggestCredentialSlot(label: string): CredentialSlot {
 }
 
 /**
+ * True when storing this secret and rewriting the draft removes the entire
+ * secret. A `Private Key` match whose value lacks the PEM END footer is only
+ * the block header (the footer is absent from the draft — truncated or
+ * partial paste): storing it would vault the header alone and the rewrite
+ * would strip just the header, leaving the key body in the composer with
+ * nothing left for the detector to flag. Such a match must not be offered
+ * the "Store securely" action.
+ */
+export function isStorableSecret(secret: DetectedSecret): boolean {
+  return (
+    secret.label !== PRIVATE_KEY_LABEL ||
+    isCompletePrivateKeyBlock(secret.value)
+  );
+}
+
+/**
  * Replaces every occurrence of a stored secret in the draft with a plaintext
  * placeholder naming its vault slot. The placeholder is model-actionable: the
  * assistant discovers stored credentials via `assistant credentials list` and
@@ -104,6 +124,10 @@ export interface StoreCredentialDialogProps {
  * composer draft, replacing the secret with its vault-slot placeholder, so
  * the plaintext key never enters the transcript. Cancel leaves the draft —
  * and the composer secret notice — untouched.
+ *
+ * Never opens for a non-{@link isStorableSecret} match (a header-only
+ * private key): storing it would rewrite only the header and leave the key
+ * body in the draft, undetected.
  */
 export function StoreCredentialDialog({
   secret,
@@ -112,9 +136,10 @@ export function StoreCredentialDialog({
   onStored,
 }: StoreCredentialDialogProps) {
   const suggestion = suggestCredentialSlot(secret?.label ?? "");
+  const storable = secret !== null && isStorableSecret(secret);
 
   const handleSaved = (meta: { service: string; field: string }) => {
-    if (!secret) {
+    if (!secret || !isStorableSecret(secret)) {
       return;
     }
     const slot: CredentialSlot = { service: meta.service, field: meta.field };
@@ -125,7 +150,7 @@ export function StoreCredentialDialog({
 
   return (
     <AddCredentialModal
-      open={open && secret !== null}
+      open={open && storable}
       onClose={onClose}
       onSaved={handleSaved}
       successToastMessage="Stored securely — the key never entered the chat"

--- a/clients/web/src/domains/settings/credentials/credentials-page.tsx
+++ b/clients/web/src/domains/settings/credentials/credentials-page.tsx
@@ -3,6 +3,10 @@ import { Copy, KeyRound, Link2, Loader2, Plus, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import {
+  AddCredentialModal,
+  credentialsListQueryKey,
+} from "@/components/add-credential-modal";
 import { DetailCard } from "@/components/detail-card";
 import { NotFound } from "@/components/not-found";
 import { useCredentialsDeletePostMutation } from "@/generated/daemon/@tanstack/react-query.gen";
@@ -22,7 +26,6 @@ import {
 import { Tag } from "@vellumai/design-library/components/tag";
 import { toast } from "@vellumai/design-library/components/toast";
 
-import { AddCredentialModal } from "./add-credential-modal";
 import { CredentialRow, type StoredCredential } from "./credential-row";
 import {
   createCredentialRequest,
@@ -44,10 +47,6 @@ interface GeneratedLink {
   url: string;
   /** Epoch (seconds or ms) the link expires at, when the daemon reports it. */
   expiresAt: number | null;
-}
-
-function credentialsListQueryKey(assistantId: string) {
-  return ["credentials-list", assistantId] as const;
 }
 
 /** Below this count, scanning the list beats typing — so we hide the search. */
@@ -401,9 +400,6 @@ function CredentialsPageInner() {
       <AddCredentialModal
         open={isShowingAddForm}
         onClose={() => setIsShowingAddForm(false)}
-        onSaved={() => {
-          void queryClient.invalidateQueries({ queryKey: listQueryKey });
-        }}
       />
 
       <Modal.Root

--- a/packages/service-contracts/src/__tests__/secret-detection.test.ts
+++ b/packages/service-contracts/src/__tests__/secret-detection.test.ts
@@ -6,6 +6,7 @@ import * as subpathExport from "@vellumai/service-contracts/secret-detection";
 
 import {
   detectSecretsInText,
+  isCompletePrivateKeyBlock,
   PREFIX_PATTERNS,
   TOKEN_SHAPE,
 } from "../secret-detection.js";
@@ -204,6 +205,101 @@ describe("detectSecretsInText — whole-message token shape", () => {
     const results = detectSecretsInText(key);
     expect(results).toHaveLength(1);
     expect(results[0]!.label).toBe("GitLab Token");
+  });
+});
+
+describe("detectSecretsInText — PEM private-key blocks", () => {
+  // Clearly fake PEM material — never a real key.
+  const FAKE_PEM_BODY =
+    "MIIFAKEfakefakefakefakefakefakefakefakefake\n" +
+    "FAKEfakefakefakefakefakefakefakefakefake==";
+  const FULL_PEM_BLOCK = `-----BEGIN RSA PRIVATE KEY-----\n${FAKE_PEM_BODY}\n-----END RSA PRIVATE KEY-----`;
+
+  test("a complete PEM block is one match spanning header through footer", () => {
+    const text = `here is my key\n${FULL_PEM_BLOCK}\nplease use it`;
+    const start = text.indexOf(FULL_PEM_BLOCK);
+    expect(detectSecretsInText(text)).toEqual([
+      {
+        label: "Private Key",
+        value: FULL_PEM_BLOCK,
+        start,
+        end: start + FULL_PEM_BLOCK.length,
+        wholeMessage: false,
+      },
+    ]);
+  });
+
+  test("a PGP private-key block with the BLOCK suffix is captured whole", () => {
+    const block = `-----BEGIN PGP PRIVATE KEY BLOCK-----\n${FAKE_PEM_BODY}\n-----END PGP PRIVATE KEY BLOCK-----`;
+    const results = detectSecretsInText(block);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.value).toBe(block);
+  });
+
+  test("a header with a body but no END footer still fires — header-only span", () => {
+    // Truncated / partially pasted key: detection must not regress, the
+    // daemon ingress relies on the header alone to block.
+    const text = `-----BEGIN RSA PRIVATE KEY-----\n${FAKE_PEM_BODY}`;
+    const results = detectSecretsInText(text);
+    expect(results).toEqual([
+      {
+        label: "Private Key",
+        value: "-----BEGIN RSA PRIVATE KEY-----",
+        start: 0,
+        end: "-----BEGIN RSA PRIVATE KEY-----".length,
+        wholeMessage: false,
+      },
+    ]);
+    expect(isCompletePrivateKeyBlock(results[0]!.value)).toBe(false);
+  });
+
+  test("adjacent complete blocks match separately, not as one giant span", () => {
+    const text = `${FULL_PEM_BLOCK}\n\n${FULL_PEM_BLOCK}`;
+    const results = detectSecretsInText(text);
+    expect(results).toHaveLength(2);
+    expect(results[0]!.value).toBe(FULL_PEM_BLOCK);
+    expect(results[1]!.value).toBe(FULL_PEM_BLOCK);
+    expect(results[1]!.start).toBeGreaterThanOrEqual(results[0]!.end);
+  });
+
+  test("a footerless header never swallows a later complete block", () => {
+    // The body is tempered — it cannot cross another BEGIN header — so the
+    // truncated first key matches header-only and the second key matches
+    // as its own complete block.
+    const text = `-----BEGIN EC PRIVATE KEY-----\ntruncated\n\n${FULL_PEM_BLOCK}`;
+    const results = detectSecretsInText(text);
+    expect(results.map((r) => r.value)).toEqual([
+      "-----BEGIN EC PRIVATE KEY-----",
+      FULL_PEM_BLOCK,
+    ]);
+  });
+
+  test("a token-lookalike run inside the block body loses to the block", () => {
+    // Base64 can legally contain an AKIA + 16-uppercase run; the Private
+    // Key pattern is first in PREFIX_PATTERNS so the whole-block span wins
+    // the overlap dedupe instead of being fragmented by the AWS pattern.
+    const block = `-----BEGIN RSA PRIVATE KEY-----\nAKIAABCDEFGHIJKLMNOP\n${FAKE_PEM_BODY}\n-----END RSA PRIVATE KEY-----`;
+    const results = detectSecretsInText(block);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.label).toBe("Private Key");
+    expect(results[0]!.value).toBe(block);
+  });
+});
+
+describe("isCompletePrivateKeyBlock", () => {
+  test("true for a value ending at the END footer", () => {
+    expect(
+      isCompletePrivateKeyBlock(
+        "-----BEGIN OPENSSH PRIVATE KEY-----\nMIIFAKEfake==\n-----END OPENSSH PRIVATE KEY-----",
+      ),
+    ).toBe(true);
+  });
+
+  test("false for a header-only match and for non-PEM values", () => {
+    expect(
+      isCompletePrivateKeyBlock("-----BEGIN OPENSSH PRIVATE KEY-----"),
+    ).toBe(false);
+    expect(isCompletePrivateKeyBlock(`ghp_${filler(36)}`)).toBe(false);
   });
 });
 

--- a/packages/service-contracts/src/secret-detection.ts
+++ b/packages/service-contracts/src/secret-detection.ts
@@ -42,7 +42,48 @@ export interface SecretPrefixPattern {
  * here.**  If the service uses only opaque OAuth access tokens (no fixed
  * prefix), no pattern is needed.
  */
+/** Detection label for PEM private-key matches. */
+export const PRIVATE_KEY_LABEL = "Private Key";
+
+// PEM private-key header/footer type variants, shared by the Private Key
+// pattern and the complete-block check.
+const PEM_KEY_TYPE = String.raw`(?:RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY(?:\s+BLOCK)?`;
+const PEM_BEGIN = String.raw`-----BEGIN ${PEM_KEY_TYPE}-----`;
+const PEM_END = String.raw`-----END ${PEM_KEY_TYPE}-----`;
+
+const PEM_COMPLETE_BLOCK = new RegExp(`${PEM_END}$`);
+
+/**
+ * True when a `Private Key` match is a complete PEM block — it ends at an
+ * `-----END … PRIVATE KEY-----` footer (the pattern guarantees it starts at
+ * the BEGIN header). A header-only match means the footer is absent from
+ * the scanned text (truncated or partial paste), so the match does NOT
+ * cover the key body: storing or replacing such a value would leave key
+ * material behind.
+ */
+export function isCompletePrivateKeyBlock(value: string): boolean {
+  return PEM_COMPLETE_BLOCK.test(value);
+}
+
 export const PREFIX_PATTERNS: SecretPrefixPattern[] = [
+  // -- Private keys --
+  // First in the list on purpose: `detectSecretsInText` resolves overlapping
+  // spans by list order, and a PEM body is base64 — it can embed runs that
+  // look like other tokens (e.g. `AKIA` + 16 chars). The whole-block match
+  // must win those overlaps or the block would be fragmented.
+  {
+    label: PRIVATE_KEY_LABEL,
+    // Matches the entire PEM block (header through footer) when the END
+    // footer is present, so consumers that store or replace the matched
+    // value handle the whole key. The block tail is optional: a header with
+    // no footer (truncated or streamed partial paste) still matches alone,
+    // which ingress blocking relies on. The body is tempered — it never
+    // crosses another BEGIN header — so adjacent blocks match separately.
+    regex: new RegExp(
+      `${PEM_BEGIN}(?:(?:(?!-----BEGIN)[\\s\\S])*?${PEM_END})?`,
+    ),
+  },
+
   // -- AWS --
   { label: "AWS Access Key", regex: /AKIA[0-9A-Z]{16}/ },
 
@@ -112,13 +153,6 @@ export const PREFIX_PATTERNS: SecretPrefixPattern[] = [
 
   // -- PyPI --
   { label: "PyPI API Token", regex: /pypi-[A-Za-z0-9\-_]{50,}/ },
-
-  // -- Private keys --
-  {
-    label: "Private Key",
-    regex:
-      /-----BEGIN (?:RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY(?:\s+BLOCK)?-----/,
-  },
 
   // -- Linear --
   { label: "Linear API Key", regex: /lin_api_[A-Za-z0-9]{32,}/ },


### PR DESCRIPTION
## Summary
- StoreCredentialDialog wraps the shared AddCredentialModal, prefilled from the detection (service/field suggested internally, value masked)
- On save: draft rewritten to [stored securely as service/field], success toast, credentials list invalidated — the key never enters the transcript
- Store securely action wired into both notice states; AddCredentialModal moved to its two-consumer home

Part of plan: composer-secret-guard.md (PR 7 of 7)