### PR TITLE
feat(chat): file action modal for vellum:// links — Go to file or Download

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -455,18 +455,6 @@ describe("extractVellumLinks", () => {
     expect(result.directiveRequests[0].filename).toBe("doc.pdf");
   });
 
-  test("ignores vellum://open/ reference links", () => {
-    // `open` links point at a workspace file for in-app navigation; they must
-    // never be materialized as attachments.
-    const text =
-      "See [skills/foo/SKILL.md](vellum://open/skills/foo/SKILL.md) and [report.pdf](vellum://workspace/scratch/report.pdf)";
-    const result = extractVellumLinks(text);
-
-    expect(result.parseWarnings).toHaveLength(0);
-    expect(result.directiveRequests).toHaveLength(1);
-    expect(result.directiveRequests[0].path).toBe("scratch/report.pdf");
-  });
-
   test("extracts multiple links", () => {
     const text = [
       "Here are the files:",
@@ -651,12 +639,6 @@ describe("stripVellumLinks", () => {
     expect(stripVellumLinks(text)).toBe("a.png and b.pdf");
   });
 
-  test("replaces vellum://open/ reference links with their link text", () => {
-    const text =
-      "See [skills/foo/SKILL.md](vellum://open/skills/foo/SKILL.md) for details";
-    expect(stripVellumLinks(text)).toBe("See skills/foo/SKILL.md for details");
-  });
-
   test("preserves text with no vellum links", () => {
     const text = "Plain text with [link](https://example.com)";
     expect(stripVellumLinks(text)).toBe(text);
@@ -718,9 +700,6 @@ describe("incompleteVellumLinkSuffixLength", () => {
     ["at slash", "grab [a.pdf](vellum://host/"],
     ["at authority", "grab [a.pdf](vellum://host"],
     ["partial authority", "grab [a.pdf](vellum://ho"],
-    ["open mid path", "see [SKILL.md](vellum://open/skills/fo"],
-    ["open at slash", "see [SKILL.md](vellum://open/"],
-    ["partial open authority", "see [SKILL.md](vellum://op"],
     ["partial scheme", "grab [a.pdf](vel"],
     ["open paren", "grab [a.pdf]("],
     ["closed label", "grab [a.pdf]"],

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -337,15 +337,6 @@ export function extractVellumLinks(text: string): VellumLinkExtractResult {
 }
 
 /**
- * Like {@link VELLUM_LINK_RE} but also matching `vellum://open/` reference
- * links. Used only for channel sanitization: reference links must degrade to
- * their bracket text off-web, but must never be materialized as attachments,
- * so the extraction regex keeps excluding `open`.
- */
-const VELLUM_STRIPPABLE_LINK_RE =
-  /(!?)\[([^\]]*)\]\(vellum:\/\/(workspace|host|open)(\/[^)]*)\)/g;
-
-/**
  * Replace `[text](vellum://...)` and `![alt](vellum://...)` markdown links with
  * their bracket text. Used to sanitize text before channel delivery (Slack,
  * Telegram, etc.) where the `vellum://` scheme has no meaning. The image form's
@@ -353,7 +344,7 @@ const VELLUM_STRIPPABLE_LINK_RE =
  * text is empty).
  */
 export function stripVellumLinks(text: string): string {
-  return text.replace(VELLUM_STRIPPABLE_LINK_RE, "$2");
+  return text.replace(VELLUM_LINK_RE, "$2");
 }
 
 /** Regex fragment matching any prefix of `literal`, including empty and full. */
@@ -380,7 +371,7 @@ const INCOMPLETE_VELLUM_LINK_TAIL_RE = new RegExp(
     "(?:\\(" +
     anyPrefixOf("vellum://") +
     "(?:" +
-    `(?:${anyPrefixOf("workspace")}|${anyPrefixOf("host")}|${anyPrefixOf("open")})` +
+    `(?:${anyPrefixOf("workspace")}|${anyPrefixOf("host")})` +
     "(?:/[^)]*)?" +
     ")?" +
     ")?" +

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -320,7 +320,7 @@ To share a workspace file, use a markdown link with the \`vellum://\` scheme:
 
 The path after \`workspace/\` is relative to your working directory. The file renders as a downloadable attachment. For host filesystem files, use \`vellum://host/absolute/path\`.
 
-To reference a workspace file you are discussing without attaching it, link it with the \`open\` scheme instead: \`[skills/foo/SKILL.md](vellum://open/skills/foo/SKILL.md)\`. In the app this opens the file in the workspace browser and creates no attachment.
+Use the same link form when referencing a workspace file you are discussing — in the app, clicking the link lets the user open the file in the workspace browser or download it.
 
 Embed images/GIFs inline using standard markdown: \`![description](URL)\`.
 `,

--- a/clients/web/src/domains/chat/components/chat-markdown-message.tsx
+++ b/clients/web/src/domains/chat/components/chat-markdown-message.tsx
@@ -38,7 +38,6 @@ import {
   rehypeRedactedCredential,
 } from "@/domains/chat/utils/rehype-redacted-credential";
 import { rehypeStreamWordFade } from "@/domains/chat/utils/rehype-stream-word-fade";
-import { isVellumOpenLink } from "@/utils/open-workspace-file";
 
 /** Returns true when `href` is a known `vellum://` attachment link. */
 export function isVellumLink(href: string | undefined): boolean {
@@ -51,12 +50,11 @@ export function isVellumLink(href: string | undefined): boolean {
 
 /**
  * Extends react-markdown's default URL sanitization to allow known
- * `vellum://workspace/` and `vellum://host/` attachment URIs plus
- * `vellum://open/` reference URIs. Other `vellum://` shapes are rejected to
- * limit protocol-handler attack surface.
+ * `vellum://workspace/` and `vellum://host/` attachment URIs. Other
+ * `vellum://` shapes are rejected to limit protocol-handler attack surface.
  */
 function vellumUrlTransform(url: string): string {
-  if (isVellumLink(url) || isVellumOpenLink(url)) {
+  if (isVellumLink(url)) {
     return url;
   }
   return defaultUrlTransform(url);
@@ -287,7 +285,7 @@ export const ChatMarkdownMessage = memo(function ChatMarkdownMessage({
       href,
       children,
     }: Pick<AnchorHTMLAttributes<HTMLAnchorElement>, "href" | "children">) => {
-      if (onVellumLinkClick && (isVellumLink(href) || isVellumOpenLink(href))) {
+      if (onVellumLinkClick && isVellumLink(href)) {
         return (
           <a
             href={href}

--- a/clients/web/src/domains/chat/components/vellum-file-action-modal.tsx
+++ b/clients/web/src/domains/chat/components/vellum-file-action-modal.tsx
@@ -1,0 +1,107 @@
+import {
+  ArrowDownToLine,
+  ExternalLink,
+  FileText,
+  Image as ImageIcon,
+  Video,
+  type LucideIcon,
+} from "lucide-react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { Modal } from "@vellumai/design-library/components/modal";
+
+/** A `vellum://` file link the user clicked, pending an action choice. */
+export interface VellumFileActionTarget {
+  /** Decoded display filename (resolved via the shared attachment-naming rule). */
+  filename: string;
+  /**
+   * Workspace-relative path when the file lives in the assistant workspace.
+   * Absent for `vellum://host/` links, which cannot open in the workspace
+   * browser — the modal then offers download only.
+   */
+  workspacePath?: string;
+}
+
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+  "bmp",
+  "heic",
+]);
+
+const VIDEO_EXTENSIONS = new Set(["mp4", "mov", "webm", "mkv", "avi"]);
+
+function iconForFilename(filename: string): LucideIcon {
+  const extension = filename.split(".").pop()?.toLowerCase() ?? "";
+  if (IMAGE_EXTENSIONS.has(extension)) {
+    return ImageIcon;
+  }
+  if (VIDEO_EXTENSIONS.has(extension)) {
+    return Video;
+  }
+  return FileText;
+}
+
+/**
+ * Action chooser shown when a `vellum://` file link is clicked in chat:
+ * "Go to file" opens the file in the workspace browser (workspace files
+ * only), "Download file" saves it locally.
+ */
+export function VellumFileActionModal({
+  target,
+  onGoToFile,
+  onDownload,
+  onClose,
+}: {
+  target: VellumFileActionTarget | null;
+  onGoToFile: () => void;
+  onDownload: () => void;
+  onClose: () => void;
+}) {
+  // Mounted only while a link click is pending an action choice — the
+  // transcript renders one instance per message row, so an always-mounted
+  // dialog would add per-row Radix overhead for a modal that is almost
+  // never open.
+  if (target == null) {
+    return null;
+  }
+  return (
+    <Modal.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <Modal.Title icon={iconForFilename(target.filename)}>
+            {target.filename}
+          </Modal.Title>
+          {target.workspacePath ? (
+            <Modal.Description className="truncate font-mono">
+              {target.workspacePath}
+            </Modal.Description>
+          ) : null}
+        </Modal.Header>
+        <Modal.Footer>
+          {target.workspacePath ? (
+            <Button variant="outlined" onClick={onGoToFile}>
+              <ExternalLink aria-hidden className="h-4 w-4" />
+              Go to file
+            </Button>
+          ) : null}
+          <Button variant="primary" onClick={onDownload}>
+            <ArrowDownToLine aria-hidden className="h-4 w-4" />
+            Download file
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -82,11 +82,10 @@ mock.module("@vellumai/design-library/components/button", () => ({
 }));
 
 // `openWorkspaceFile` lazily imports the app router, which these tests don't
-// build. Stub it to record the workspace paths opened by `vellum://open/`
-// reference-link clicks.
+// build. Stub it to record the workspace paths opened via the file action
+// modal's "Go to file" button.
 const openWorkspaceFileMock = mock(async (_path: string) => {});
 mock.module("@/utils/open-workspace-file", () => ({
-  VELLUM_OPEN_PREFIX: "vellum://open/",
   openWorkspaceFile: openWorkspaceFileMock,
 }));
 
@@ -1275,24 +1274,6 @@ describe("TranscriptMessageBody", () => {
     expect(downloadAttachmentMock).not.toHaveBeenCalled();
     // Choosing an action dismisses the modal.
     expect(screen.queryByRole("button", { name: "Go to file" })).toBeNull();
-  });
-
-  test("legacy vellum://open/ links open the same modal as workspace links", () => {
-    openWorkspaceFileMock.mockClear();
-    render(
-      <TranscriptMessageBody
-        message={{
-          id: "a-open-legacy",
-          role: "assistant",
-          contentBlocks: [textBlock("see the notes")],
-        }}
-        onSurfaceAction={noop}
-      />,
-    );
-
-    clickVellumLink("vellum://open/notes/plan.md", "plan");
-    clickModalAction("Go to file");
-    expect(openWorkspaceFileMock).toHaveBeenCalledWith("notes/plan.md");
   });
 
   test("host link modal offers download only, not Go to file", () => {

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -1,6 +1,14 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 // The transcript transitively pulls in the viewer store → the generated daemon
 // SDK (not built in CI/worktree checkouts). Stub the two endpoints it references
@@ -28,6 +36,49 @@ mock.module("@/domains/chat/utils/acp-run-actions", () => ({
 }));
 mock.module("@/domains/chat/utils/background-task-actions", () => ({
   stopBackgroundTask: stopBackgroundTaskMock,
+}));
+
+// The vellum file action modal builds on the design-library Modal (Radix
+// dialog). Stub the design-library primitives with bare elements so these
+// tests exercise the modal's action wiring without pulling in Radix's portal
+// and focus machinery.
+mock.module("@vellumai/design-library/components/modal", () => {
+  const passthrough =
+    (slot: string) =>
+    ({ children }: { children?: ReactNode }) => (
+      <div data-testid={slot}>{children}</div>
+    );
+  return {
+    Modal: {
+      Root: ({
+        open,
+        children,
+      }: {
+        open?: boolean;
+        children?: ReactNode;
+      }) => (open ? <div role="dialog">{children}</div> : null),
+      Content: passthrough("modal-content"),
+      Header: passthrough("modal-header"),
+      Title: ({ children }: { children?: ReactNode }) => (
+        <div data-testid="modal-title">{children}</div>
+      ),
+      Description: passthrough("modal-description"),
+      Footer: passthrough("modal-footer"),
+    },
+  };
+});
+mock.module("@vellumai/design-library/components/button", () => ({
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children?: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
 }));
 
 // `openWorkspaceFile` lazily imports the app router, which these tests don't
@@ -231,6 +282,22 @@ import { MIN_VERSION as REDACTED_CHIPS_MIN_VERSION } from "@/lib/backwards-compa
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
 const noop = () => {};
+
+/**
+ * Drives a `vellum://` link click through the mocked markdown renderer. The
+ * click stages the file in component state (opening the action modal), so it
+ * must run inside `act`.
+ */
+function clickVellumLink(href: string, linkText: string) {
+  act(() => {
+    lastVellumLinkClick?.(href, linkText);
+  });
+}
+
+/** Clicks an action button inside the vellum file action modal. */
+function clickModalAction(name: string) {
+  fireEvent.click(screen.getByRole("button", { name }));
+}
 
 // `TranscriptMessageBody` renders a row's body by walking its unified
 // `contentBlocks` projection — the sole source of truth. Each block embeds its
@@ -1091,10 +1158,8 @@ describe("TranscriptMessageBody", () => {
 
     // Bare label + percent-encoded path: the daemon stored the DECODED
     // basename ("qa shot.png"), so the click must decode before matching.
-    lastVellumLinkClick?.(
-      "vellum://workspace/scratch/qa%20shot.png",
-      "desktop",
-    );
+    clickVellumLink("vellum://workspace/scratch/qa%20shot.png", "desktop");
+    clickModalAction("Download file");
     expect(downloadAttachmentMock).toHaveBeenCalledTimes(1);
     expect(
       (downloadAttachmentMock.mock.calls[0] as unknown[])[0],
@@ -1130,7 +1195,8 @@ describe("TranscriptMessageBody", () => {
       />,
     );
 
-    lastVellumLinkClick?.("vellum://workspace/b/result.png", "second");
+    clickVellumLink("vellum://workspace/b/result.png", "second");
+    clickModalAction("Download file");
     expect(downloadAttachmentMock).toHaveBeenCalledTimes(1);
     expect(
       (downloadAttachmentMock.mock.calls[0] as unknown[])[0],
@@ -1169,52 +1235,54 @@ describe("TranscriptMessageBody", () => {
       />,
     );
 
-    lastVellumLinkClick?.(
-      "vellum://workspace/qa-delete-desktop-dialog.png",
-      "desktop",
-    );
+    clickVellumLink("vellum://workspace/qa-delete-desktop-dialog.png", "desktop");
+    clickModalAction("Download file");
     expect(downloadAttachmentMock).toHaveBeenCalledTimes(1);
     expect(
       (downloadAttachmentMock.mock.calls[0] as unknown[])[0],
     ).toMatchObject({ id: "att-real" });
   });
 
-  test("vellum://open/ link click navigates to the workspace file, never downloads", () => {
+  test("workspace link click opens the action modal; Go to file navigates", () => {
     downloadAttachmentMock.mockClear();
     openWorkspaceFileMock.mockClear();
     render(
       <TranscriptMessageBody
         message={{
-          id: "a-open",
+          id: "a-modal",
           role: "assistant",
           contentBlocks: [textBlock("see the skill")],
-          attachments: [
-            {
-              // Even an attachment whose filename matches the link must not
-              // shadow reference-link navigation.
-              id: "att-skill",
-              filename: "SKILL.md",
-              mimeType: "text/markdown",
-              sizeBytes: 5,
-              previewUrl: null,
-            },
-          ],
         }}
         onSurfaceAction={noop}
       />,
     );
 
-    lastVellumLinkClick?.("vellum://open/skills/foo/SKILL.md", "SKILL.md");
-    expect(openWorkspaceFileMock).toHaveBeenCalledWith("skills/foo/SKILL.md");
+    clickVellumLink(
+      "vellum://workspace/skills/foo/weekly%20plan.md",
+      "weekly plan.md",
+    );
+    // Both actions are offered for a workspace file.
+    expect(screen.getByRole("button", { name: "Go to file" })).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Download file" }),
+    ).not.toBeNull();
+
+    clickModalAction("Go to file");
+    // The workspace path is percent-decoded before navigation.
+    expect(openWorkspaceFileMock).toHaveBeenCalledWith(
+      "skills/foo/weekly plan.md",
+    );
     expect(downloadAttachmentMock).not.toHaveBeenCalled();
+    // Choosing an action dismisses the modal.
+    expect(screen.queryByRole("button", { name: "Go to file" })).toBeNull();
   });
 
-  test("vellum://open/ link click decodes percent-encoded paths", () => {
+  test("legacy vellum://open/ links open the same modal as workspace links", () => {
     openWorkspaceFileMock.mockClear();
     render(
       <TranscriptMessageBody
         message={{
-          id: "a-open-enc",
+          id: "a-open-legacy",
           role: "assistant",
           contentBlocks: [textBlock("see the notes")],
         }}
@@ -1222,8 +1290,29 @@ describe("TranscriptMessageBody", () => {
       />,
     );
 
-    lastVellumLinkClick?.("vellum://open/notes/weekly%20plan.md", "plan");
-    expect(openWorkspaceFileMock).toHaveBeenCalledWith("notes/weekly plan.md");
+    clickVellumLink("vellum://open/notes/plan.md", "plan");
+    clickModalAction("Go to file");
+    expect(openWorkspaceFileMock).toHaveBeenCalledWith("notes/plan.md");
+  });
+
+  test("host link modal offers download only, not Go to file", () => {
+    render(
+      <TranscriptMessageBody
+        message={{
+          id: "a-host",
+          role: "assistant",
+          contentBlocks: [textBlock("host file")],
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    clickVellumLink("vellum://host/Users/user1/doc.pdf", "doc.pdf");
+    // Host files cannot open in the workspace browser.
+    expect(screen.queryByRole("button", { name: "Go to file" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Download file" }),
+    ).not.toBeNull();
   });
 
   test("vellum link click still matches link text and raw basename", () => {
@@ -1256,14 +1345,16 @@ describe("TranscriptMessageBody", () => {
     );
 
     // Link text still wins when it names the attachment.
-    lastVellumLinkClick?.("vellum://workspace/out/final.pdf", "report.pdf");
+    clickVellumLink("vellum://workspace/out/final.pdf", "report.pdf");
+    clickModalAction("Download file");
     expect(
       (downloadAttachmentMock.mock.calls[0] as unknown[])[0],
     ).toMatchObject({ id: "att-label" });
 
     // Malformed percent-encoding: decodeURIComponent throws, raw basename
     // fallback still finds the attachment.
-    lastVellumLinkClick?.("vellum://workspace/qa%ZZshot.png", "shot");
+    clickVellumLink("vellum://workspace/qa%ZZshot.png", "shot");
+    clickModalAction("Download file");
     expect(
       (downloadAttachmentMock.mock.calls[1] as unknown[])[0],
     ).toMatchObject({ id: "att-raw" });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -50,10 +50,7 @@ import type { DisplayMessage } from "@/domains/chat/types/types";
 import { wireSurfaceToDisplay } from "@/domains/chat/utils/map-runtime-message";
 import { isPointerCoarse } from "@/utils/pointer";
 import { useLongPress } from "@/hooks/use-long-press";
-import {
-  openWorkspaceFile,
-  VELLUM_OPEN_PREFIX,
-} from "@/utils/open-workspace-file";
+import { openWorkspaceFile } from "@/utils/open-workspace-file";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
@@ -435,15 +432,11 @@ export function TranscriptMessageBody({
         message.attachments?.find((a) => a.filename === linkText) ??
         message.attachments?.find((a) => a.filename === pathBasename) ??
         message.attachments?.find((a) => a.filename === rawBasename);
-      // `vellum://open/` is the legacy reference-only scheme; treat it as a
-      // workspace link so old transcripts keep working.
-      const workspacePrefix = ["vellum://workspace/", VELLUM_OPEN_PREFIX].find(
-        (prefix) => href.startsWith(prefix),
-      );
+      const WORKSPACE_PREFIX = "vellum://workspace/";
       setPendingVellumFile({
         filename: attachment?.filename ?? expectedFilename,
-        workspacePath: workspacePrefix
-          ? safeDecodeURIComponent(href.slice(workspacePrefix.length))
+        workspacePath: href.startsWith(WORKSPACE_PREFIX)
+          ? safeDecodeURIComponent(href.slice(WORKSPACE_PREFIX.length))
           : undefined,
         attachment,
         isHost: href.startsWith("vellum://host/"),

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -16,6 +16,10 @@ import { downloadAttachment } from "@/domains/chat/components/chat-attachments/d
 import { MessageAttachments } from "@/domains/chat/components/chat-attachments/message-attachments";
 import { ToolResultImages } from "@/domains/chat/components/chat-attachments/tool-result-images";
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import {
+  VellumFileActionModal,
+  type VellumFileActionTarget,
+} from "@/domains/chat/components/vellum-file-action-modal";
 import { toast } from "@vellumai/design-library";
 import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions";
 import { MessageLongPressActions } from "@/domains/chat/components/message-hover-actions/message-long-press-actions";
@@ -42,6 +46,7 @@ import { stopAcpRun } from "@/domains/chat/utils/acp-run-actions";
 import { stopBackgroundTask } from "@/domains/chat/utils/background-task-actions";
 import { captureError } from "@/lib/sentry/capture-error";
 import { getExternalLinkUrl } from "@/domains/chat/types/types";
+import type { DisplayMessage } from "@/domains/chat/types/types";
 import { wireSurfaceToDisplay } from "@/domains/chat/utils/map-runtime-message";
 import { isPointerCoarse } from "@/utils/pointer";
 import { useLongPress } from "@/hooks/use-long-press";
@@ -396,16 +401,18 @@ export function TranscriptMessageBody({
     useViewerStore.getState().openBackgroundTaskDetail(id);
   }, []);
 
+  // The `vellum://` file link awaiting an action choice in the modal, plus
+  // the context needed to execute either action.
+  const [pendingVellumFile, setPendingVellumFile] = useState<
+    | (VellumFileActionTarget & {
+        attachment?: NonNullable<DisplayMessage["attachments"]>[number];
+        isHost: boolean;
+      })
+    | null
+  >(null);
+
   const handleVellumLinkClick = useCallback(
     (href: string, linkText: string) => {
-      // `vellum://open/` links are references, not attachments: navigate to
-      // the workspace browser with the file selected instead of downloading.
-      if (href.startsWith(VELLUM_OPEN_PREFIX)) {
-        void openWorkspaceFile(
-          safeDecodeURIComponent(href.slice(VELLUM_OPEN_PREFIX.length)),
-        );
-        return;
-      }
       const rawBasename = href.split("/").pop() ?? "";
       // The daemon percent-decodes vellum:// paths before storing attachment
       // filenames, so match on the decoded basename. Keep the raw form as a
@@ -423,56 +430,85 @@ export function TranscriptMessageBody({
         pathBasename,
         "label",
       );
-      const att =
+      const attachment =
         message.attachments?.find((a) => a.filename === expectedFilename) ??
         message.attachments?.find((a) => a.filename === linkText) ??
         message.attachments?.find((a) => a.filename === pathBasename) ??
         message.attachments?.find((a) => a.filename === rawBasename);
-      if (att) {
-        void downloadAttachment(att, assistantId);
-      } else if (href.startsWith("vellum://workspace/")) {
-        // Fallback for files not registered as message attachments — e.g.
-        // files linked only inside component/surface HTML. The daemon's
-        // cleanAssistantContent only extracts vellum:// links from assistant
-        // TEXT blocks, not from dynamic_page surface HTML, so a file cited
-        // only in a component never becomes an attachment. Fetch it by path
-        // from the workspace file content endpoint instead — the same route
-        // the workspace browser uses. Inlined here to avoid a cross-domain
-        // import (chat -> workspace).
-        const WORKSPACE_PREFIX = "vellum://workspace/";
-        const filePath = safeDecodeURIComponent(
-          href.slice(WORKSPACE_PREFIX.length),
-        );
-        const filename = resolveAttachmentFilename(
-          linkText || undefined,
-          pathBasename,
-          "label",
-        );
-        void (async () => {
-          try {
-            const { data, error } = await workspaceFileContentGet({
-              path: { assistant_id: assistantId ?? "" },
-              query: { path: filePath },
-              parseAs: "blob",
-              throwOnError: false,
-            });
-            if (error || !(data instanceof Blob)) {
-              throw new Error("workspace file content fetch failed");
-            }
-            await saveFile(data, filename);
-          } catch {
-            toast.error("Failed to download file", { description: filename });
-          }
-        })();
-      } else {
-        const isHost = href.startsWith("vellum://host/");
-        toast.error(
-          `File not available for download${isHost ? " (host file approval may have timed out)" : ""}`,
-          { description: linkText || pathBasename },
-        );
-      }
+      // `vellum://open/` is the legacy reference-only scheme; treat it as a
+      // workspace link so old transcripts keep working.
+      const workspacePrefix = ["vellum://workspace/", VELLUM_OPEN_PREFIX].find(
+        (prefix) => href.startsWith(prefix),
+      );
+      setPendingVellumFile({
+        filename: attachment?.filename ?? expectedFilename,
+        workspacePath: workspacePrefix
+          ? safeDecodeURIComponent(href.slice(workspacePrefix.length))
+          : undefined,
+        attachment,
+        isHost: href.startsWith("vellum://host/"),
+      });
     },
-    [message.attachments, assistantId],
+    [message.attachments],
+  );
+
+  const handleGoToPendingFile = useCallback(() => {
+    const workspacePath = pendingVellumFile?.workspacePath;
+    setPendingVellumFile(null);
+    if (workspacePath) {
+      void openWorkspaceFile(workspacePath);
+    }
+  }, [pendingVellumFile]);
+
+  const handleDownloadPendingFile = useCallback(() => {
+    const pending = pendingVellumFile;
+    setPendingVellumFile(null);
+    if (!pending) {
+      return;
+    }
+    if (pending.attachment) {
+      void downloadAttachment(pending.attachment, assistantId);
+    } else if (pending.workspacePath) {
+      // Fallback for files not registered as message attachments — e.g.
+      // files linked only inside component/surface HTML. The daemon's
+      // cleanAssistantContent only extracts vellum:// links from assistant
+      // TEXT blocks, not from dynamic_page surface HTML, so a file cited
+      // only in a component never becomes an attachment. Fetch it by path
+      // from the workspace file content endpoint instead — the same route
+      // the workspace browser uses. Inlined here to avoid a cross-domain
+      // import (chat -> workspace).
+      const { workspacePath, filename } = pending;
+      void (async () => {
+        try {
+          const { data, error } = await workspaceFileContentGet({
+            path: { assistant_id: assistantId ?? "" },
+            query: { path: workspacePath },
+            parseAs: "blob",
+            throwOnError: false,
+          });
+          if (error || !(data instanceof Blob)) {
+            throw new Error("workspace file content fetch failed");
+          }
+          await saveFile(data, filename);
+        } catch {
+          toast.error("Failed to download file", { description: filename });
+        }
+      })();
+    } else {
+      toast.error(
+        `File not available for download${pending.isHost ? " (host file approval may have timed out)" : ""}`,
+        { description: pending.filename },
+      );
+    }
+  }, [pendingVellumFile, assistantId]);
+
+  const vellumFileModal = (
+    <VellumFileActionModal
+      target={pendingVellumFile}
+      onGoToFile={handleGoToPendingFile}
+      onDownload={handleDownloadPendingFile}
+      onClose={() => setPendingVellumFile(null)}
+    />
   );
 
   const renderTextWithInlineSurfaces = (
@@ -968,6 +1004,7 @@ export function TranscriptMessageBody({
           {renderUserContent(userItems)}
           {trailer}
         </div>
+        {vellumFileModal}
         {isTouch && (
           <div onClick={(e) => e.stopPropagation()}>
             <MessageLongPressActions
@@ -1010,6 +1047,7 @@ export function TranscriptMessageBody({
         )}
         {trailer}
       </div>
+      {vellumFileModal}
       {isTouch && !isAssistant && (
         <div onClick={(e) => e.stopPropagation()}>
           <MessageLongPressActions

--- a/clients/web/src/utils/open-workspace-file.ts
+++ b/clients/web/src/utils/open-workspace-file.ts
@@ -1,17 +1,5 @@
 import { routes } from "@/utils/routes";
 
-/** Prefix of `vellum://open/` reference links (workspace-relative path follows). */
-export const VELLUM_OPEN_PREFIX = "vellum://open/";
-
-/**
- * Returns true when `href` is a `vellum://open/` reference link — a pointer
- * to a workspace file that opens in the workspace browser, as opposed to a
- * `vellum://workspace|host/` attachment link that downloads.
- */
-export function isVellumOpenLink(href: string | undefined): boolean {
-  return href != null && href.startsWith(VELLUM_OPEN_PREFIX);
-}
-
 /**
  * Navigates to the workspace browser with the given workspace-relative file
  * path selected (via the `?file=` deep-link param).

--- a/clients/web/src/utils/sandbox-bridge.test.ts
+++ b/clients/web/src/utils/sandbox-bridge.test.ts
@@ -276,9 +276,9 @@ describe("buildLinkInterceptorScript", () => {
     expect(out).toContain(FRAME_ID);
   });
 
-  it("intercepts workspace, host, and open vellum:// authorities", () => {
+  it("intercepts only the workspace and host vellum:// authorities", () => {
     const out = buildLinkInterceptorScript(FRAME_ID);
-    expect(out).toContain("(workspace|host|open)");
+    expect(out).toContain("(workspace|host)");
   });
 
   it("checks vellum:// scheme before external http(s) schemes", () => {

--- a/clients/web/src/utils/sandbox-bridge.ts
+++ b/clients/web/src/utils/sandbox-bridge.ts
@@ -131,8 +131,7 @@ export function buildStoragePolyfill(): string {
  * Two categories of links are intercepted:
  *
  * 1. **`vellum://` deep links** (`vellum://workspace/...`,
- *    `vellum://host/...`, `vellum://open/...`) — forwarded to the parent
- *    window via
+ *    `vellum://host/...`) — forwarded to the parent window via
  *    `postMessage({ type: 'vellum_open_link', ... })` so the host app can
  *    perform in-app navigation (open a workspace file, launch a host app,
  *    etc.). These are checked **before** external schemes because
@@ -168,7 +167,7 @@ export function buildLinkInterceptorScript(frameId: string): string {
           // navigation. Checked before external schemes because
           // window.open() cannot handle custom schemes (a vellum:// URL
           // would be silently dropped or open a broken tab).
-          if (/^vellum:\\/\\/(workspace|host|open)\\//i.test(rawHref)) {
+          if (/^vellum:\\/\\/(workspace|host)\\//i.test(rawHref)) {
             e.preventDefault();
             window.parent.postMessage({
               type: 'vellum_open_link',


### PR DESCRIPTION
## Summary
- Clicking a `vellum://` file link in chat now opens a **file action modal** (new `VellumFileActionModal`, built on the design-library Modal) showing a file-type icon, filename, and workspace path, with two actions: **Go to file** (navigates to `/assistant/workspace?file=…`) and **Download file** (existing attachment/workspace-fetch download logic, moved intact into the modal's download handler). Host (`vellum://host/`) files get download-only since they can't open in the workspace browser.
- Consolidates references back onto `vellum://workspace/` and **removes the `vellum://open/` scheme entirely** — prompt guidance, url whitelist, sandbox link interceptor, channel strip regex, streaming tail guard, and extractor-adjacent tests. Per product decision, links persisted with the short-lived `open` scheme render as inert text; no compat shim is kept.
- The modal mounts only while a click is pending, so the per-message transcript row carries no Radix dialog overhead; transcript tests stub the design-library modal/button primitives and drive the full click → modal → action flows (both buttons, host-only-download, percent-decoding).

Supersedes the interaction model shipped in #38979 (direct navigate on `open` links / direct download on workspace links) — everything now converges on the modal.

## Original prompt
After #38979 (distinct `vellum://open/` reference scheme) merged, Pragun reconsidered and chose the consolidated design: one `vellum://` link scheme where clicking opens a modal with a preview icon and two buttons — "Go to file" opening the file in the workspace browser, and "Download file" downloading it. He explicitly opted to drop backward compatibility for historic `vellum://open/` links in favor of a cleaner codebase. Built as a new PR on main since #38979 was already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)