### PR TITLE
fix(cli): loud failures for stale CLIs — unknown pair flags error, tunnel errors hint at updating

### DIFF
--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -159,6 +159,100 @@ describe("pair command", () => {
     expect(fetchCalled).toBe(true);
   });
 
+  test("rejects an unknown --flag before any network call", async () => {
+    let fetchCalled = false;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const errors: string[] = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...a: unknown[]) => {
+        errors.push(a.join(" "));
+      },
+    );
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    process.argv = ["bun", "vellum", "pair", "--frobnicate"];
+    let exited = false;
+    try {
+      await pair();
+    } catch (e) {
+      exited = (e as Error).message === "exit:1";
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    // A `--` flag this version doesn't know is a hard error, and it points at
+    // the CLI self-update path — never a silent fall-through to another flow.
+    expect(exited).toBe(true);
+    const joined = errors.join("\n");
+    expect(joined).toContain("unknown option '--frobnicate'");
+    expect(joined).toContain("your CLI may be out of date");
+    expect(joined).toContain("bun install -g vellum@latest");
+    expect(fetchCalled).toBe(false);
+  });
+
+  test("rejects an unknown --flag even alongside a multi-word positional name", async () => {
+    writeFileSync(
+      join(testDir, ".vellum.lock.json"),
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "pair-test",
+            name: "My Assistant",
+            runtimeUrl: RUNTIME_URL,
+            localUrl: LOCAL_URL,
+            cloud: "local",
+          },
+        ],
+        activeAssistant: "pair-test",
+      }),
+    );
+
+    let fetchCalled = false;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const errors: string[] = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...a: unknown[]) => {
+        errors.push(a.join(" "));
+      },
+    );
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    // Positional name tokens must not rescue an unknown flag from rejection.
+    process.argv = ["bun", "vellum", "pair", "My", "Assistant", "--frobnicate"];
+    let exited = false;
+    try {
+      await pair();
+    } catch (e) {
+      exited = (e as Error).message === "exit:1";
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    expect(exited).toBe(true);
+    expect(errors.join("\n")).toContain("unknown option '--frobnicate'");
+    expect(fetchCalled).toBe(false);
+  });
+
   test("refuses to advertise a loopback URL without --url (suggests the assistant's own port)", async () => {
     // Local hatch on a NON-default gateway port (e.g. a 2nd instance).
     const LOOPBACK_CUSTOM = "http://127.0.0.1:7842";
@@ -210,6 +304,11 @@ describe("pair command", () => {
     // The suggested --url uses the assistant's actual port, not the default.
     expect(errors.join("\n")).toContain(":7842");
     expect(errors.join("\n")).not.toContain(":7830");
+
+    // The refusal cross-points to the QR flow (the phone-pairing path) and its
+    // https prerequisite, so a user who wanted a QR isn't left at a dead end.
+    expect(errors.join("\n")).toContain("vellum pair --qr");
+    expect(errors.join("\n")).toContain("vellum tunnel --provider tailscale");
 
     // Exited with an error before minting — no token created for a dead URL.
     expect(exited).toBe(true);

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -5,6 +5,7 @@ import {
   describe,
   expect,
   mock,
+  spyOn,
   test,
 } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -159,6 +160,58 @@ describe("tunnel nginx ingress feature flag", () => {
       "Could not verify the `web-remote-ingress` feature flag",
     );
 
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+    expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects an unknown --provider with a stale-CLI hint", async () => {
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "bogus"];
+    const errors: string[] = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...a: unknown[]) => {
+        errors.push(a.join(" "));
+      },
+    );
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    let exited = false;
+    try {
+      await tunnel();
+    } catch (e) {
+      exited = (e as Error).message === "exit:1";
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+
+    expect(exited).toBe(true);
+    const joined = errors.join("\n");
+    expect(joined).toContain("unknown tunnel provider 'bogus'");
+    expect(joined).toContain("your CLI may be out of date");
+    expect(joined).toContain("bun install -g vellum@latest");
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+    expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("a not-yet-implemented provider error carries the stale-CLI hint", async () => {
+    // The default `vellum` provider has no runtime yet, so it exercises the
+    // not-yet-implemented path without any network call.
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "vellum"];
+
+    let err: Error | undefined;
+    try {
+      await tunnel();
+    } catch (e) {
+      err = e as Error;
+    }
+
+    expect(err?.message).toContain("is not yet implemented");
+    expect(err?.message).toContain("your CLI may be out of date");
+    expect(err?.message).toContain("bun install -g vellum@latest");
     expect(runNgrokTunnelMock).not.toHaveBeenCalled();
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
   });

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -46,6 +46,7 @@ import {
 } from "../lib/feature-flags.js";
 import { getLocalLanIPv4 } from "../lib/local.js";
 import { isLoopbackUrl, loopbackSafeFetch } from "../lib/loopback-fetch.js";
+import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
 
 function assistantDisplayName(entry: AssistantEntry): string {
   return entry.name || entry.assistantName || entry.assistantId;
@@ -277,6 +278,22 @@ export async function pair(): Promise<void> {
   );
   args = afterAppScheme;
 
+  // Any `--`-prefixed token left after known-flag extraction is an option this
+  // CLI version doesn't support. Fail loud before any network call rather than
+  // letting it fall through: an unknown flag would otherwise be silently
+  // dropped and the command would run the wrong flow (e.g. `--qr` on an older
+  // CLI minting a copy-paste bundle instead of a QR). Positional names never
+  // start with `--`, so multi-word assistant targets are unaffected.
+  const unknownFlag = args.find((a) => a.startsWith("--"));
+  if (unknownFlag) {
+    console.error(`Error: unknown option '${unknownFlag}'.`);
+    console.error("Run `vellum pair --help` to see available options.");
+    console.error(
+      `If this option is from newer docs, ${STALE_CLI_UPDATE_HINT}`,
+    );
+    process.exit(1);
+  }
+
   if (webPairing && webApproveCode) {
     console.error("Error: use either --web or --web-approve, not both.");
     process.exit(1);
@@ -370,6 +387,10 @@ export async function pair(): Promise<void> {
     );
     console.error(
       `Re-run with a reachable URL, e.g.:\n  vellum pair --url ${suggestion}`,
+    );
+    console.error(
+      "Pairing a phone by QR instead? Use: vellum pair --qr " +
+        "(needs an https URL — run `vellum tunnel --provider tailscale` first).",
     );
     process.exit(1);
   }

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -8,6 +8,7 @@ import {
   WEB_REMOTE_INGRESS_FLAG,
 } from "../lib/feature-flags.js";
 import { runNgrokTunnel } from "../lib/ngrok";
+import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
 import { runTailscaleTunnel } from "../lib/tailscale-tunnel.js";
 
 const VALID_PROVIDERS = ["vellum", "ngrok", "cloudflare", "tailscale"] as const;
@@ -78,9 +79,18 @@ function parseArgs(): TunnelArgs {
       process.exit(0);
     } else if (arg === "--provider") {
       const next = args[i + 1];
-      if (!next || !VALID_PROVIDERS.includes(next as TunnelProvider)) {
+      if (!next || next.startsWith("-")) {
         console.error(
           `Error: --provider requires one of: ${VALID_PROVIDERS.join(", ")}`,
+        );
+        process.exit(1);
+      }
+      if (!VALID_PROVIDERS.includes(next as TunnelProvider)) {
+        console.error(
+          `Error: unknown tunnel provider '${next}'. Valid providers: ${VALID_PROVIDERS.join(", ")}.`,
+        );
+        console.error(
+          `If this provider is documented, ${STALE_CLI_UPDATE_HINT}`,
         );
         process.exit(1);
       }
@@ -199,5 +209,8 @@ export async function tunnel(): Promise<void> {
     return;
   }
 
-  throw new Error(`Tunnel provider '${provider}' is not yet implemented.`);
+  throw new Error(
+    `Tunnel provider '${provider}' is not yet implemented. ` +
+      `If this provider is documented, ${STALE_CLI_UPDATE_HINT}`,
+  );
 }

--- a/cli/src/lib/stale-cli-hint.ts
+++ b/cli/src/lib/stale-cli-hint.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared tail for errors where this CLI doesn't recognize an option or provider
+ * the user named. The name may be valid in a newer release, so point the user
+ * at the self-update path before they conclude the feature doesn't exist.
+ *
+ * `bun install -g vellum@latest` refreshes the `vellum` binary directly — the
+ * mechanism the installer and the CLI's own self-update use. (`vellum upgrade`
+ * targets the assistant runtime, not the CLI binary, for local assistants.)
+ */
+export const STALE_CLI_UPDATE_HINT =
+  "your CLI may be out of date — update it with `bun install -g vellum@latest` and retry.";


### PR DESCRIPTION
## Summary
- `vellum pair` errors on unrecognized `--` flags instead of silently running the wrong flow (a first-time user's `--qr` on an older CLI silently minted a copy-paste bundle and she reasonably concluded the QR feature didn't exist)
- The bundle loopback refusal cross-points to the QR flow; tunnel's unknown/unimplemented-provider errors hint the CLI may be out of date

The stale-CLI hint points at `bun install -g vellum@latest` (the mechanism the installer and the CLI's own self-update use to refresh the `vellum` binary) rather than `vellum upgrade`, which targets the assistant runtime — not the CLI binary — for local assistants. Shared as one `STALE_CLI_UPDATE_HINT` constant across the three call sites.

From live first-user testing (Slack, tonight). Part of plan: ios-self-hosted-connect.md (papercuts).