### PR TITLE
fix(access-request): reflect the resolved outcome on a rejected access-request card

### DIFF
--- a/assistant/src/__tests__/introduction-card-resolver.test.ts
+++ b/assistant/src/__tests__/introduction-card-resolver.test.ts
@@ -59,7 +59,10 @@ const sim = createGuardianGatewaySim();
 mock.module("../channels/gateway-guardian-requests.js", () => sim.module);
 
 import { applyGuardianDecision } from "../approvals/guardian-decision-primitive.js";
-import type { ActorContext } from "../approvals/guardian-request-resolvers.js";
+import {
+  type ActorContext,
+  introductionOutcomeForAction,
+} from "../approvals/guardian-request-resolvers.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { serializeRequesterSignals } from "../runtime/introduction-policy.js";
 
@@ -229,6 +232,11 @@ describe("introduction card decisions", () => {
       // Silent park (docs/trusted-contact-access.md): leave-unverified never
       // sends the requester a notice — they only learn if they message again.
       expect(deliverReplyCalls).toHaveLength(0);
+      // The card projection reflects the resolved OUTCOME, not the raw button:
+      // a generic `reject` parks the contact just like `leave_unverified`, so
+      // the resolved card must read the neutral park — never "Denied".
+      expect(withdrawCalls).toHaveLength(1);
+      expect(withdrawCalls[0].decidedAction).toBe("leave_unverified");
     }
   });
 
@@ -256,8 +264,10 @@ describe("introduction card decisions", () => {
         c.payload.text.includes("Your access request was declined."),
     );
     expect(declineNotices).toHaveLength(1);
-    // The terminal decision projects onto the delivered cards.
+    // The terminal decision projects onto the delivered cards, and block stays
+    // an active denial on the card — never normalized to a park.
     expect(withdrawCalls).toHaveLength(1);
+    expect(withdrawCalls[0].decidedAction).toBe("block");
   });
 
   test("block persist failure leaves the request pending and retryable (fail closed)", async () => {
@@ -362,5 +372,22 @@ describe("introduction card decisions", () => {
     }
     // The request is untouched by the rejected actions.
     expect(sim.getRequest(req.id)?.status).toBe("pending");
+  });
+});
+
+describe("introductionOutcomeForAction", () => {
+  test("folds the generic decision pair onto the introduction outcomes", () => {
+    // `reject` and `leave_unverified` both park the contact at `unverified`;
+    // `approve_once` starts the handshake. Introduction actions map to
+    // themselves. Callers that must present the resolved outcome (the card
+    // projection) rely on this so a `reject` park never reads as "Denied".
+    expect(introductionOutcomeForAction("reject")).toBe("leave_unverified");
+    expect(introductionOutcomeForAction("leave_unverified")).toBe(
+      "leave_unverified",
+    );
+    expect(introductionOutcomeForAction("approve_once")).toBe("verify_code");
+    expect(introductionOutcomeForAction("verify_code")).toBe("verify_code");
+    expect(introductionOutcomeForAction("trust")).toBe("trust");
+    expect(introductionOutcomeForAction("block")).toBe("block");
   });
 });

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -52,6 +52,7 @@ import {
   type ChannelDeliveryContext,
   type DecisionOutcomePlan,
   getResolver,
+  introductionOutcomeForAction,
   type ResolverEmissionContext,
 } from "./guardian-request-resolvers.js";
 
@@ -508,11 +509,20 @@ export async function applyGuardianDecision(
   // projection, so awaiting its Slack round-trips would only add latency to
   // the decision response that interactive callers wait on. The projector
   // never throws; the `.catch` is a defensive backstop.
+  // For access requests the resolver folds the generic decision pair onto the
+  // introduction outcomes (`reject` → `leave_unverified`, `approve_once` →
+  // `verify_code`), so the resolved card must reflect the OUTCOME, not the raw
+  // button — otherwise a `reject` that actually parked the contact at
+  // `unverified` would still render "Denied". Other kinds have no such mapping.
+  const cardAction =
+    request.kind === "access_request"
+      ? introductionOutcomeForAction(effectiveAction)
+      : effectiveAction;
   void withdrawGuardianRequestCards({
     request: resolved,
     status: targetStatus,
     originChannel: actorContext.channel,
-    decidedAction: effectiveAction,
+    decidedAction: cardAction,
   }).catch((err) => {
     log.warn(
       { err, requestId },

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -512,6 +512,23 @@ const OUTCOME_BY_ACTION = {
   block: "block",
 } as const satisfies Record<ApprovalAction, IntroductionOutcome>;
 
+/**
+ * The introduction outcome a decision action resolves to for an access request.
+ * The generic decision pair folds onto the card outcomes (`reject` →
+ * `leave_unverified`, `approve_once` → `verify_code`); the introduction actions
+ * map to themselves. Every outcome is itself an `ApprovalAction`, so a caller
+ * that must reflect the resolved *outcome* rather than the raw button — the
+ * resolved-card projection, so a `reject` that parked the contact at
+ * `unverified` reads as the neutral "Left unverified" and not "Denied" — can
+ * normalize through this. It does not apply the bot handshake→trust coercion,
+ * which does not affect the park/deny distinction the card cares about.
+ */
+export function introductionOutcomeForAction(
+  action: ApprovalAction,
+): ApprovalAction {
+  return OUTCOME_BY_ACTION[action];
+}
+
 /** Derived access-request decision facts shared by `prepare` and `resolve`. */
 interface AccessRequestDerivation {
   channel: NotificationSourceChannel;


### PR DESCRIPTION
Follow-up to #39022, addressing a Codex review finding that landed as that PR merged.

## Prompt / plan

#39022 made a `leave_unverified` park render neutrally instead of "Denied". Codex flagged (P2) that the fix keyed the card off the **raw** guardian action, but for an access request the resolver folds the generic decision pair onto the introduction outcomes — `reject` → `leave_unverified` (a park), `approve_once` → `verify_code`. The primitive allows a generic `reject` on an access request (it isn't an introduction-card action, so the kind-mismatch gate doesn't fire), and the resolver parks the contact at `unverified`. But `reject` ∉ `PARK_ACTION_SET`, so the resolved card still rendered "Denied"/red — the same mislabel #39022 fixed, leaking through the `reject` alias.

Reachable via non-card decision paths: a conversational "reject"/"no", a reaction, or an older/generic `apr:<id>:reject` button. The introduction card's own buttons (`leave_unverified` / `block`) were already correct.

## The fix

Present the resolved card by the **outcome**, not the raw button:

- Export the resolver's authoritative action→outcome mapping as `introductionOutcomeForAction` (reusing `OUTCOME_BY_ACTION`, the single source of truth; it does not apply the bot handshake→trust coercion, which doesn't affect the park/deny split).
- In the decision primitive, for `access_request` decisions, normalize the action through it before projecting the card. `PARK_ACTION_SET` stays generic and unchanged; other request kinds are untouched (no such mapping).

## Before → after (the resolved card)

| Decision on an access request | Before | After |
| --- | --- | --- |
| Generic `reject` (conversational / reaction / old button) | "Denied" (red) — but the contact was parked at `unverified` | "Left unverified" (neutral) — matches the outcome |
| `leave_unverified` button | "Left unverified" (already correct in #39022) | Unchanged |
| `block` | "Denied" | Unchanged |
| Other kinds (`tool_approval`, …) `reject` | "Denied" | Unchanged (no outcome mapping) |

## Why it's safe

- **Presentation-only.** No ACL / admission / notification change. The resolver already mapped `reject` → park, so the contact state was always correct; only the card label was wrong.
- **Single source of truth.** The card outcome derives from the resolver's own `OUTCOME_BY_ACTION`, so it can't drift from the actual ACL outcome.
- **Scoped to `access_request`.** `PARK_ACTION_SET` is unchanged, so no false "park" label on other request kinds.

## Test plan

- `introduction-card-resolver.test.ts`: the existing `leave_unverified` / `reject` loop now also asserts the card projection receives `decidedAction: "leave_unverified"` for **both**; the `block` test asserts it stays `"block"`; a new unit test pins `introductionOutcomeForAction` across all six actions.
- `bunx tsc --noEmit` clean; eslint + prettier clean; canonical primitive (30), guardian-card-withdrawal (18), slack withdraw (11), introduction-card-resolver (11) suites green; pre-commit + pre-push hooks re-verified format + lint + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5AUkuGpZ7J15ZjXzgzST4

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5AUkuGpZ7J15ZjXzgzST4)_