### PR TITLE
docs: phone guide — version callout, per-stage verification, one recommended path

### DIFF
--- a/docs/self-hosted-phone.md
+++ b/docs/self-hosted-phone.md
@@ -6,13 +6,24 @@ straight to it over an HTTPS address you control, and a QR code pairs the
 device in a single scan.
 
 Connect from a mobile browser (add it to your home screen for a full-screen
-PWA) or, on a recent build, from the native **Vellum iOS app** pointed at your
-own server (see [Using the Vellum iOS app](#6-using-the-vellum-ios-app)). Both
-reach the same assistant.
+PWA) or from the native **Vellum iOS app** pointed at your own server (see
+[Using the Vellum iOS app](#6-using-the-vellum-ios-app)). Both reach the same
+assistant.
 
 This is a CLI-driven flow for people who already run their assistant locally
-(`vellum wake`). If you use the managed Vellum Cloud app, you don't need any
-of this; sign in and your phone is already connected.
+(`vellum wake`). If you use the managed Vellum Cloud app, you don't need any of
+this; sign in and your phone is already connected.
+
+> **Check your version first.** This flow uses recent additions to the `vellum`
+> CLI and the assistant it runs: remote web ingress (Step 1), `vellum tunnel`
+> providers (Step 4), `vellum pair --qr` (Step 5), and the iOS app's connect
+> handler (Step 6). They ship in the next release; until then they're available
+> on builds from source. Check what you have with `vellum --version` (it prints
+> `@vellumai/cli v<version>`). If `vellum tunnel --provider tailscale` reports
+> `not yet implemented` or `vellum pair --qr` isn't recognized, your CLI
+> predates this flow — update it once the release lands, or build from source
+> (the web app in [Step 2](#2-the-web-app-ships-with-the-cli) and the iOS shell
+> in [Step 7](#7-native-ios-shell-optional-for-developers) both note how).
 
 ## How it works
 
@@ -43,6 +54,9 @@ terminates TLS and makes the edge reachable from your phone.
 - **Tailscale** installed on both the host machine and your phone, both
   signed into the same tailnet. (Only needed for the default private path;
   see [Step 4](#4-put-an-https-address-in-front) for public alternatives.)
+- If you run more than one local assistant, decide which one goes on your
+  phone: every step below applies to a single assistant (see
+  [Step 1](#1-enable-remote-web-ingress)).
 
 ## 1. Enable remote web ingress
 
@@ -52,6 +66,15 @@ assistant:
 ```bash
 vellum flags set web-remote-ingress true
 ```
+
+> **One assistant at a time.** The feature flag, the tunnel URL, and pairing
+> all belong to a _specific_ assistant. With several local assistants, point
+> every step at the same one. `vellum ps` lists them and marks the active one
+> with `*`. `pair`, `tunnel`, and `nginx-ingress` take an assistant name as
+> their first argument (e.g. `vellum tunnel my-assistant`); `vellum flags`
+> takes `--assistant <name>`.
+
+**Verify:** `vellum flags get web-remote-ingress` prints `Enabled: true`.
 
 ## 2. The web app ships with the CLI
 
@@ -77,6 +100,11 @@ cd clients/web && VITE_PLATFORM_MODE=false bun run build
 
 </details>
 
+**Verify:** `vellum client --interface web` prints
+`Vellum web interface: http://localhost:<port>/assistant/` and that page loads
+your assistant on the host. Press Ctrl+C to stop it — your phone doesn't use
+this local server.
+
 ## 3. Start the nginx edge
 
 ```bash
@@ -95,6 +123,9 @@ The listen port defaults to `7840`; override it with the
 `VELLUM_NGINX_INGRESS_PORT` environment variable if it clashes with
 something else.
 
+**Verify:** `vellum nginx-ingress status` reports `running` with a
+`Listen:  http://127.0.0.1:7840` line.
+
 ## 4. Put an HTTPS address in front
 
 Your phone needs an HTTPS URL that reaches the nginx edge. The default path
@@ -106,9 +137,22 @@ vellum tunnel --provider tailscale
 
 While the nginx edge is running, the tunnel automatically targets it and
 records the public URL in your workspace config (`ingress.publicBaseUrl`), so
-channel integrations (Telegram, Twilio, …) can reach the assistant too. Note
-the `https://…ts.net` address it prints; the pairing step reuses it
+channel integrations (Telegram, Twilio, …) can reach the assistant too. It
+prints the address it established:
+
+```
+Tunnel established: https://your-machine.your-tailnet.ts.net
+```
+
+That `https://<machine>.<tailnet>.ts.net` is **your own machine's address on
+your tailnet, not a Tailscale website** — it's the URL your phone opens. You
+won't type it again by hand: the pairing step reuses this saved address
 automatically.
+
+**Verify:** open that `https://…ts.net` address in your **phone's** browser
+(with Tailscale connected). You should get the assistant's sign-in page. If it
+doesn't load, stop and fix this before pairing — a broken HTTPS front is the
+most common reason later steps fail.
 
 <details>
 <summary>Manual Tailscale fallback (no <code>vellum tunnel</code> needed)</summary>
@@ -138,6 +182,11 @@ vellum tunnel --provider cloudflare   # quick tunnel, no account required
 vellum tunnel --provider ngrok        # requires an ngrok account
 ```
 
+A Cloudflare quick tunnel prints a `https://<random>.trycloudflare.com`
+address (ngrok prints a similar per-tunnel URL). Either one is the public
+address of **your** machine — use it wherever this guide asks for your HTTPS
+URL.
+
 **Privacy trade-off:** these publish a public-internet URL, so anyone who
 learns the URL can reach your assistant's sign-in and pairing page (pairing
 still requires local approval, but the surface is public). The Tailscale path
@@ -155,18 +204,21 @@ vellum pair --qr
 
 If you put the HTTPS front in place with `vellum tunnel` (Step 4),
 `vellum pair --qr` reuses that saved address automatically and prints
-`Using saved ingress URL … (from vellum tunnel; override with --url)`. Pass
-`--url` to advertise a different address, or when using the manual
-`tailscale serve` fallback, which doesn't save one:
+`Using saved ingress URL … (from vellum tunnel; override with --url)` — so you
+don't need to know or retype your URL. Pass `--url` to advertise a different
+address, or when using the manual `tailscale serve` fallback, which doesn't
+save one:
 
 ```bash
-vellum pair --qr --url https://your-assistant.ts.net
+vellum pair --qr --url https://your-machine.your-tailnet.ts.net
 ```
 
-The command mints a pairing challenge and approves it locally (running it on
-the host is the proof of presence), then renders a QR code and the same URL
-as text in your terminal. The advertised URL must be public HTTPS; the
-command refuses loopback and plain-HTTP addresses.
+The advertised URL must be public HTTPS — e.g.
+`https://<machine>.<tailnet>.ts.net` (Tailscale) or
+`https://<random>.trycloudflare.com` (a Cloudflare quick tunnel); the command
+refuses loopback and plain-HTTP addresses. It mints a pairing challenge and
+approves it locally (running it on the host is the proof of presence), then
+renders a QR code and the same URL as text in your terminal.
 
 On your phone:
 
@@ -177,10 +229,11 @@ On your phone:
    offers **Open in the Vellum app** or **Continue in this browser**; tap
    **Continue in this browser** to pair here (see
    [Using the Vellum iOS app](#6-using-the-vellum-ios-app) for the app path).
-   The page then shows **Connected**; pairing is already approved, so there's
-   nothing to confirm.
 3. Use the browser **Share → Add to Home Screen** to install the assistant as
    an app icon.
+
+**Verify:** after scanning, the pairing page shows **Connected** — pairing is
+already approved, so there's nothing to confirm — and your assistant loads.
 
 The pairing session survives assistant restarts via a refresh cookie, so you
 stay signed in. Pairing codes are **single-use and expire after 10 minutes**;
@@ -190,63 +243,66 @@ run `vellum pair --qr` again to add another device or replace a lapsed code.
 
 The native **Vellum iOS app** can point at your self-hosted assistant instead
 of Vellum Cloud, giving you the full app shell against your own server rather
-than a home-screen web page. Steps 1–4 are identical; only the way the phone
+than a home-screen web page. Steps 1–5 are identical; only the way the phone
 connects changes.
 
-> **Build requirement.** These app features ship in the next app release
-> (TestFlight, then the App Store). On an older build, use the browser / Add to
-> Home Screen path in [Step 5](#5-pair-your-phone), which keeps working
-> unchanged. Building the shell from source
-> ([Step 7](#7-native-ios-shell-optional-for-developers)) also produces a build
-> that carries them today.
+> **Build requirement.** The app's connect handler ships in the next app
+> release (TestFlight, then the App Store) — see the version note at the top of
+> this guide. On an older build, use the browser / Add to Home Screen path in
+> [Step 5](#5-pair-your-phone), which keeps working unchanged. Building the
+> shell from source ([Step 7](#7-native-ios-shell-optional-for-developers))
+> produces a build that carries it today.
 
-All three connection methods below reach the same nginx edge you set up above.
+**Recommended: scan the Step 5 QR, then tap "Open in the Vellum app."** You
+don't need a different command — the QR from `vellum pair --qr` (Step 5)
+already works for the app:
 
-### Open the app from the default QR
+1. Point the phone's **system camera** at the QR and open the pairing page in
+   Safari.
+2. Tap **Open in the Vellum app** (instead of **Continue in this browser**).
+   The app saves your server and finishes pairing. Because the handoff happens
+   before the single-use code is spent, **Continue in this browser** still
+   works if the app isn't installed.
 
-The QR from `vellum pair --qr` (Step 5) already serves app users. On iOS its
-pairing page leads with **Open in the Vellum app** and offers **Continue in
-this browser** underneath. Tapping **Open in the Vellum app** hands the pairing
-to the app _before_ the single-use code is spent, so **Continue in this
-browser** still works if the app isn't installed. Use this QR when your phones
-are a mix of app and browser users.
+The saved server and the pairing belong to the assistant you targeted in
+Steps 1–5. With several local assistants, keep them all pointed at the same
+one (`vellum ps` shows the active one).
 
-### Scan straight into the app with `--app`
+**Verify:** the app opens to your own assistant, not Vellum Cloud.
 
-To make a QR that opens the app directly, add `--app`:
+<details>
+<summary>Other ways to connect</summary>
+
+**One-scan app QR** — use when every target phone already has the app
+installed (this QR opens the app directly and has no browser fallback):
 
 ```bash
 vellum pair --qr --app
 ```
 
 This encodes the pairing as a `vellum-assistant://connect` link; the plain
-https pairing URL is printed beneath it as a fallback. Point the **system
-camera** at the QR and the app opens (cold-launching if it was closed), saves
-your server, and completes pairing in a single scan. Like plain `--qr`, it
-reuses the `vellum tunnel` address automatically; pass `--url` to override.
-
-An `--app` QR only opens on a phone that already has the app installed, so
-use it when every target device has the app. Use `--app-scheme` to target
-a non-production build (`vellum-assistant-dev` for a dev build,
+https pairing URL is printed beneath it. Point the **system camera** at it and
+the app opens (cold-launching if it was closed), saves your server, and
+completes pairing in a single scan. Like plain `--qr`, it reuses the
+`vellum tunnel` address; pass `--url` to override. Target a non-production
+build with `--app-scheme` (`vellum-assistant-dev` for a dev build,
 `vellum-assistant-staging` for staging):
 
 ```bash
 vellum pair --qr --app --app-scheme vellum-assistant-dev
 ```
 
-### Enter the server by hand in Settings
+**Enter the server by hand** — use when you'd rather not scan. Open the iOS
+**Settings** app, tap **Vellum**, and use the **Self-Hosted Server** section:
+enter your assistant's HTTPS URL, the same `https://<machine>.<tailnet>.ts.net`
+address `vellum pair --qr` prints. Leaving the field empty keeps the app on
+Vellum Cloud; the app reloads on next launch. You still pair the device once —
+by any method above, or a browser sign-in — for the app to have access. If the
+app can't reach the configured server, it shows **Can't reach `<host>`.** with
+**Retry** and **Use Vellum Cloud**; **Use Vellum Cloud** (or clearing the
+field yourself) returns the app to Vellum Cloud.
 
-To point the app at your server without scanning, open the iOS **Settings**
-app, tap **Vellum**, and use the **Self-Hosted Server** section: enter your
-assistant's HTTPS URL, the same `https://…ts.net` address `vellum pair --qr`
-prints. Leaving the field empty keeps the app on Vellum Cloud. The app applies
-the change when you reopen it. You still pair the device once — by any method
-above, or a browser sign-in — for the app to have access.
-
-If the app can't reach the configured server, it shows an alert
-(**Can't reach `your-assistant.ts.net`.**) with **Retry** and **Use Vellum
-Cloud**. **Use Vellum Cloud** clears the field and returns the app to Vellum
-Cloud; clearing the field yourself does the same.
+</details>
 
 The [Good to know](#good-to-know) notes below apply to the app just as they do
 to the browser path.
@@ -260,12 +316,15 @@ HTTPS URL:
 
 ```bash
 cd clients/web
-VELLUM_SERVER_URL=https://your-assistant.ts.net bun run ios:open
+VELLUM_SERVER_URL=https://your-machine.your-tailnet.ts.net bun run ios:open
 ```
 
 `VELLUM_SERVER_URL` must be a valid `https:` URL (iOS App Transport Security
 requires real TLS). See [`clients/ios/README.md`](../clients/ios/README.md)
 for prerequisites, signing, and the full build flow.
+
+**Verify:** the app launches on the simulator or device pointed at your host
+URL — you reach your own assistant, not Vellum Cloud.
 
 ## Good to know
 


### PR DESCRIPTION
## Summary
- Honest version callout (flow needs the next release or a from-source build) — a first-time user on the released CLI hit 'not yet implemented' and concluded the features don't exist
- Every stage ends with a verify-before-continuing check; §6 leads with one recommended path (pair --qr → scan → Open in app) with alternatives collapsed
- Multi-assistant scoping called out (flag/tunnel/pairing are per-assistant); public-URL examples show what a real one looks like

From live first-user testing (Slack, tonight). Part of plan: ios-self-hosted-connect.md (papercuts).