### PR TITLE
fix(web): pair card prefills the tunnel URL, rejects service-website links, names its assistant

### DIFF
--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -748,6 +748,53 @@ describe("pair command", () => {
     expect(fetchCalled).toBe(false);
   });
 
+  test("--qr refuses a tunnel-provider website URL (Tailscale admin invite) without minting", async () => {
+    let fetchCalled = false;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const errors: string[] = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (...a: unknown[]) => {
+        errors.push(a.join(" "));
+      },
+    );
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    process.argv = [
+      "bun",
+      "vellum",
+      "pair",
+      "--qr",
+      "--url",
+      "https://login.tailscale.com/admin/invite/abc123",
+    ];
+    let exited = false;
+    try {
+      await pair();
+    } catch (e) {
+      exited = (e as Error).message === "exit:1";
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+      globalThis.fetch = origFetch;
+    }
+
+    // The admin-invite link is a vendor website — named as such, not mislabeled
+    // as non-https, and refused before any challenge is minted.
+    expect(exited).toBe(true);
+    const joined = errors.join("\n");
+    expect(joined).toContain("Tailscale's website");
+    expect(joined).not.toContain("is not https");
+    expect(fetchCalled).toBe(false);
+  });
+
   test("--qr refuses when the web remote ingress feature flag is off", async () => {
     const calls: Array<[string, RequestInit | undefined]> = [];
     const origFetch = globalThis.fetch;

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -19,6 +19,7 @@ import {
   buildRemoteWebPairingUrl,
   normalizePublicBaseUrl,
   resolvePublicBaseUrl,
+  tunnelProviderWebsiteName,
   type PublicBaseUrlRejection,
   type RemoteWebPairingChallengeRequest,
   type RemoteWebPairingChallengeResponse,
@@ -451,6 +452,9 @@ export async function pair(): Promise<void> {
         unparseable: `${advertisedUrl} isn't a valid URL`,
         loopback: `${advertisedUrl} is a loopback address`,
         "non-https": `${advertisedUrl} is not https`,
+        "service-website": `${advertisedUrl} is ${
+          tunnelProviderWebsiteName(advertisedUrl) ?? "a tunnel provider"
+        }'s website, not your assistant's address`,
       };
       console.error(
         "Error: --qr needs a public https URL the phone can open — " +

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -12,10 +12,16 @@ let gatewayPath: string | undefined = "/assistant/__gateway/20100";
 let supportsPairingRoutes = true;
 let webRemoteIngressOn = true;
 let flagsHydrated = true;
+let selectedAssistant: {
+  assistantId: string;
+  cloud: string;
+  name?: string;
+  ingressUrl?: string;
+} = { assistantId: "self", cloud: "local" };
 
 mock.module("@/lib/local-mode", () => ({
   getLocalGatewayUrl: () => gatewayPath,
-  getSelectedAssistant: () => ({ assistantId: "self", cloud: "local" }),
+  getSelectedAssistant: () => selectedAssistant,
 }));
 
 mock.module("@/lib/backwards-compat/remote-web-pairing-gate", () => ({
@@ -104,6 +110,7 @@ beforeEach(() => {
   supportsPairingRoutes = true;
   webRemoteIngressOn = true;
   flagsHydrated = true;
+  selectedAssistant = { assistantId: "self", cloud: "local" };
   requests = [];
   localStorage.clear();
 });
@@ -242,5 +249,75 @@ describe("PairDeviceCard", () => {
       ),
     ).toBeTruthy();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("prefills the URL field from the assistant's recorded tunnel URL", () => {
+    selectedAssistant = {
+      assistantId: "self",
+      cloud: "local",
+      ingressUrl: "https://tunnel.example.ts.net",
+    };
+    render(<PairDeviceCard />);
+
+    const input = screen.getByLabelText("Public URL") as HTMLInputElement;
+    expect(input.value).toBe("https://tunnel.example.ts.net");
+    // Helper text explains the prefilled address came from `vellum tunnel`.
+    expect(screen.getByText(/comes from/)).toBeTruthy();
+    // A recorded tunnel URL suppresses the no-tunnel empty state.
+    expect(screen.queryByText("No tunnel detected")).toBeNull();
+  });
+
+  test("shows honest no-tunnel guidance when no ingress URL and no stored value", () => {
+    render(<PairDeviceCard />);
+
+    expect(screen.getByText("No tunnel detected")).toBeTruthy();
+    expect(screen.getByText(/vellum tunnel --provider tailscale/)).toBeTruthy();
+    // The manual field stays available beneath the guidance.
+    expect(screen.getByLabelText("Public URL")).toBeTruthy();
+    expect(
+      (screen.getByLabelText("Public URL") as HTMLInputElement).value,
+    ).toBe("");
+  });
+
+  test("rejects a tunnel-provider website URL (Tailscale admin invite) with a service-website message", () => {
+    const fetchMock = installFetch(() => jsonResponse(challengeBody()));
+    render(<PairDeviceCard />);
+    typeUrl("https://login.tailscale.com/admin/invite/abc123");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Generate pairing QR" }),
+    );
+
+    expect(
+      screen.getByText(
+        "This is Tailscale's website, not your assistant's address. Run `vellum tunnel` on the host to get one.",
+      ),
+    ).toBeTruthy();
+    // The bad URL is refused client-side — no challenge is ever minted.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("names the assistant it pairs in the subtitle", () => {
+    selectedAssistant = {
+      assistantId: "self",
+      cloud: "local",
+      name: "My Assistant",
+    };
+    render(<PairDeviceCard />);
+
+    expect(
+      screen.getByText(
+        "Scan from your phone's camera to open My Assistant on it.",
+      ),
+    ).toBeTruthy();
+  });
+
+  test("falls back to generic copy when the assistant has no name", () => {
+    render(<PairDeviceCard />);
+
+    expect(
+      screen.getByText(
+        "Scan from your phone's camera to open this assistant on it.",
+      ),
+    ).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -7,7 +7,7 @@ import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { useSupportsRemoteWebPairing } from "@/lib/backwards-compat/remote-web-pairing-gate";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
-import { resolvePairDeviceGatewayBase } from "./pair-device-client";
+import { resolvePairDeviceTarget } from "./pair-device-client";
 import { PairDeviceReady } from "./pair-device-ready";
 import { usePairDevice } from "./use-pair-device";
 
@@ -18,27 +18,37 @@ import { usePairDevice } from "./use-pair-device";
  * https pair URL as a QR with a copyable link and expiry countdown.
  *
  * Rendered only in desktop/local mode against an on-machine gateway (the gate
- * lives in {@link resolvePairDeviceGatewayBase}) whose assistant version
- * serves the pairing routes ({@link useSupportsRemoteWebPairing}); a remote or
- * platform session, or an older assistant, sees nothing. Generating also
- * requires the `web-remote-ingress` flag — checked before minting, like the
- * CLI, so a rendered QR always represents a scannable pairing.
+ * lives in {@link resolvePairDeviceTarget}) whose assistant version serves the
+ * pairing routes ({@link useSupportsRemoteWebPairing}); a remote or platform
+ * session, or an older assistant, sees nothing. Generating also requires the
+ * `web-remote-ingress` flag — checked before minting, like the CLI, so a
+ * rendered QR always represents a scannable pairing.
  */
 export function PairDeviceCard() {
-  const base = resolvePairDeviceGatewayBase();
+  const target = resolvePairDeviceTarget();
   const supported = useSupportsRemoteWebPairing();
   const flagsHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
-  const webRemoteIngressOn = useAssistantFeatureFlagStore.use.webRemoteIngress();
-  const pair = usePairDevice(base, webRemoteIngressOn);
+  const webRemoteIngressOn =
+    useAssistantFeatureFlagStore.use.webRemoteIngress();
+  const pair = usePairDevice(
+    target?.base ?? null,
+    webRemoteIngressOn,
+    target?.ingressUrl ?? null,
+  );
   const { copy, copied } = useCopyToClipboard();
 
-  if (!base || !supported) {
+  if (!target || !supported) {
     return null;
   }
 
   const { phase } = pair;
   const isMinting = phase.kind === "minting";
   const isReady = phase.kind === "ready";
+  const prefilledFromTunnel = pair.prefillSource === "tunnel";
+  // Honest empty state: no recorded tunnel URL, no stored value, field still
+  // empty. Advanced users can still type an address into the field below.
+  const showNoTunnelGuidance =
+    pair.prefillSource === "none" && pair.publicBaseUrl.trim() === "";
   // Until the feature-flag store hydrates, webRemoteIngressOn is the registry
   // default (false), not this assistant's real value, so the mint precheck
   // can't be trusted until hasHydrated is true.
@@ -62,15 +72,28 @@ export function PairDeviceCard() {
   return (
     <DetailCard
       title="Pair a device"
-      subtitle="Scan from your phone's camera to open this assistant on it."
+      subtitle={`Scan from your phone's camera to open ${
+        target.assistantName ?? "this assistant"
+      } on it.`}
     >
       <div className="flex flex-col gap-4">
+        {showNoTunnelGuidance && (
+          <Notice tone="info" title="No tunnel detected">
+            {
+              "On this computer, run `vellum tunnel --provider tailscale` (or another provider) — its address appears here."
+            }
+          </Notice>
+        )}
         <div className="flex flex-col gap-3">
           <Input
             label="Public URL"
             fullWidth
             placeholder="https://your-assistant.ts.net"
-            helperText="The https address your phone can reach this assistant at (e.g. your Tailscale or tunnel URL)."
+            helperText={
+              prefilledFromTunnel
+                ? "This address comes from `vellum tunnel` on this computer. Edit it if your phone reaches this assistant at a different URL."
+                : "The https address your phone can reach this assistant at (e.g. your Tailscale or tunnel URL)."
+            }
             value={pair.publicBaseUrl}
             errorText={pair.inputError ?? undefined}
             disabled={isMinting}

--- a/clients/web/src/domains/settings/pair-device/pair-device-client.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-client.ts
@@ -55,23 +55,41 @@ export interface DevicePairing {
   expiresAt: string;
 }
 
+/** What the "Pair a device" card needs about the assistant it pairs. */
+export interface PairDeviceTarget {
+  /** Absolute local-gateway base URL to mint the pairing challenge against. */
+  base: string;
+  /** The paired assistant's display name, or `null` when it has none. */
+  assistantName: string | null;
+  /**
+   * The public https URL `vellum tunnel` recorded for this assistant, or `null`
+   * when none is recorded — used to prefill the URL field.
+   */
+  ingressUrl: string | null;
+}
+
 /**
- * The absolute local-gateway base URL to mint against, or `null` when device
- * pairing isn't available from here. `getLocalGatewayUrl` already resolves only
- * in desktop/local mode (never remote-gateway or platform mode) and only for an
- * on-machine assistant with a recorded loopback gateway — exactly the cases
- * where a host-presence mint is possible — so this doubles as the section's
- * visibility gate.
+ * Resolve the selected assistant and its local-gateway base URL, or `null` when
+ * device pairing isn't available from here. `getLocalGatewayUrl` already
+ * resolves only in desktop/local mode (never remote-gateway or platform mode)
+ * and only for an on-machine assistant with a recorded loopback gateway —
+ * exactly the cases where a host-presence mint is possible — so a `null` here
+ * doubles as the section's visibility gate.
  */
-export function resolvePairDeviceGatewayBase(): string | null {
+export function resolvePairDeviceTarget(): PairDeviceTarget | null {
   if (typeof window === "undefined") {
     return null;
   }
-  const path = getLocalGatewayUrl(getSelectedAssistant());
+  const assistant = getSelectedAssistant();
+  const path = getLocalGatewayUrl(assistant);
   if (!path) {
     return null;
   }
-  return `${window.location.origin}${path}`;
+  return {
+    base: `${window.location.origin}${path}`,
+    assistantName: assistant?.name?.trim() || null,
+    ingressUrl: assistant?.ingressUrl?.trim() || null,
+  };
 }
 
 function serverErrorMessage(payload: unknown): string | null {

--- a/clients/web/src/domains/settings/pair-device/pair-device-url.test.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-url.test.ts
@@ -4,6 +4,7 @@ import {
   buildRemoteWebPairingUrl,
   isLoopbackUrl,
   normalizePublicBaseUrl,
+  publicBaseUrlRejectionMessage,
   resolvePublicBaseUrl,
 } from "./pair-device-url";
 
@@ -72,6 +73,58 @@ describe("resolvePublicBaseUrl", () => {
       ok: false,
       reason: "unparseable",
     });
+  });
+
+  test("rejects a tunnel provider's website (e.g. a Tailscale admin invite link)", () => {
+    // The exact papercut: a lost user pastes a Tailscale admin invite URL, which
+    // is https and non-loopback and so would otherwise be accepted.
+    expect(
+      resolvePublicBaseUrl("https://login.tailscale.com/admin/invite/abc123"),
+    ).toEqual({ ok: false, reason: "service-website" });
+    expect(resolvePublicBaseUrl("https://ngrok.com")).toEqual({
+      ok: false,
+      reason: "service-website",
+    });
+    expect(resolvePublicBaseUrl("https://dash.cloudflare.com/login")).toEqual({
+      ok: false,
+      reason: "service-website",
+    });
+  });
+
+  test("accepts a user's real Tailscale endpoint, not just the vendor site", () => {
+    // A genuine *.ts.net endpoint is never a listed vendor host.
+    expect(resolvePublicBaseUrl("https://my-box.tail1234.ts.net")).toEqual({
+      ok: true,
+      url: "https://my-box.tail1234.ts.net",
+    });
+  });
+});
+
+describe("publicBaseUrlRejectionMessage", () => {
+  test("names the specific vendor for a service-website URL", () => {
+    expect(
+      publicBaseUrlRejectionMessage(
+        "service-website",
+        "https://login.tailscale.com/admin/invite/abc",
+      ),
+    ).toBe(
+      "This is Tailscale's website, not your assistant's address. Run `vellum tunnel` on the host to get one.",
+    );
+    expect(
+      publicBaseUrlRejectionMessage("service-website", "https://ngrok.com"),
+    ).toContain("ngrok's website");
+    expect(
+      publicBaseUrlRejectionMessage(
+        "service-website",
+        "https://dash.cloudflare.com",
+      ),
+    ).toContain("Cloudflare's website");
+  });
+
+  test("falls back to a generic vendor label without a value", () => {
+    expect(publicBaseUrlRejectionMessage("service-website")).toContain(
+      "the tunnel provider's website",
+    );
   });
 });
 

--- a/clients/web/src/domains/settings/pair-device/pair-device-url.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-url.ts
@@ -15,11 +15,18 @@ export {
   type PublicBaseUrlResult,
 } from "@vellumai/service-contracts/remote-web-pairing";
 
-import type { PublicBaseUrlRejection } from "@vellumai/service-contracts/remote-web-pairing";
+import {
+  tunnelProviderWebsiteName,
+  type PublicBaseUrlRejection,
+} from "@vellumai/service-contracts/remote-web-pairing";
 
-/** Inline validation message for each rejection reason. */
+/**
+ * Inline validation message for each rejection reason. `value` is the raw input
+ * that was rejected, used to name the specific vendor for a service-website URL.
+ */
 export function publicBaseUrlRejectionMessage(
   reason: PublicBaseUrlRejection,
+  value?: string,
 ): string {
   switch (reason) {
     case "unparseable":
@@ -28,6 +35,10 @@ export function publicBaseUrlRejectionMessage(
       return "This is a loopback address your phone can't reach. Enter the assistant's public https URL.";
     case "non-https":
       return "The URL must use https so your phone can connect securely.";
+    case "service-website": {
+      const service =
+        (value && tunnelProviderWebsiteName(value)) || "the tunnel provider";
+      return `This is ${service}'s website, not your assistant's address. Run \`vellum tunnel\` on the host to get one.`;
+    }
   }
 }
-

--- a/clients/web/src/domains/settings/pair-device/use-pair-device.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pair-device.ts
@@ -17,6 +17,29 @@ import {
 /** localStorage key for the last public URL that successfully minted a code. */
 const PUBLIC_BASE_URL_STORAGE_KEY = "vellum:pair-device:public-base-url";
 
+/** Where the URL field's initial value came from. */
+export type PairDevicePrefillSource = "tunnel" | "stored" | "none";
+
+/**
+ * Resolve the URL field's initial value and its provenance. Priority: the
+ * assistant's `vellum tunnel`-recorded ingress URL, then the last URL that
+ * successfully minted a code, then empty.
+ */
+function resolvePrefill(recordedIngressUrl: string | null): {
+  url: string;
+  source: PairDevicePrefillSource;
+} {
+  const tunnel = recordedIngressUrl?.trim();
+  if (tunnel) {
+    return { url: tunnel, source: "tunnel" };
+  }
+  const stored = getLocalSetting(PUBLIC_BASE_URL_STORAGE_KEY, "").trim();
+  if (stored) {
+    return { url: stored, source: "stored" };
+  }
+  return { url: "", source: "none" };
+}
+
 export type PairDevicePhase =
   | { kind: "idle" }
   | { kind: "minting" }
@@ -24,9 +47,11 @@ export type PairDevicePhase =
   | { kind: "error"; message: string; hint?: string };
 
 export interface PairDeviceController {
-  /** The public URL to advertise, editable and prefilled from the last success. */
+  /** The public URL to advertise, editable and prefilled from the tunnel/last success. */
   publicBaseUrl: string;
   setPublicBaseUrl: (value: string) => void;
+  /** Where {@link publicBaseUrl}'s initial value came from. */
+  prefillSource: PairDevicePrefillSource;
   /** Client-side validation message for the URL field, or `null`. */
   inputError: string | null;
   phase: PairDevicePhase;
@@ -46,15 +71,16 @@ export interface PairDeviceController {
  * `webRemoteIngressEnabled` is the host's `web-remote-ingress` flag — when off,
  * generating reports the enable guidance without minting (the loopback routes
  * succeed regardless of the flag, but a scan can only connect through public
- * ingress, so a minted QR would be unusable).
+ * ingress, so a minted QR would be unusable). `recordedIngressUrl` is the
+ * assistant's `vellum tunnel`-recorded public URL, used to prefill the field.
  */
 export function usePairDevice(
   base: string | null,
   webRemoteIngressEnabled: boolean,
+  recordedIngressUrl: string | null,
 ): PairDeviceController {
-  const [publicBaseUrl, setPublicBaseUrlState] = useState(() =>
-    getLocalSetting(PUBLIC_BASE_URL_STORAGE_KEY, ""),
-  );
+  const [prefill] = useState(() => resolvePrefill(recordedIngressUrl));
+  const [publicBaseUrl, setPublicBaseUrlState] = useState(prefill.url);
   const [inputError, setInputError] = useState<string | null>(null);
   const [phase, setPhase] = useState<PairDevicePhase>({ kind: "idle" });
   const [nowMs, setNowMs] = useState(() => Date.now());
@@ -85,9 +111,10 @@ export function usePairDevice(
     if (!base) {
       return;
     }
-    const resolved = resolvePublicBaseUrl(publicBaseUrl.trim());
+    const trimmed = publicBaseUrl.trim();
+    const resolved = resolvePublicBaseUrl(trimmed);
     if (!resolved.ok) {
-      setInputError(publicBaseUrlRejectionMessage(resolved.reason));
+      setInputError(publicBaseUrlRejectionMessage(resolved.reason, trimmed));
       return;
     }
     setInputError(null);
@@ -148,6 +175,7 @@ export function usePairDevice(
   return {
     publicBaseUrl,
     setPublicBaseUrl,
+    prefillSource: prefill.source,
     inputError,
     phase,
     remainingMs,

--- a/packages/local-mode/src/lockfile-contract.test.ts
+++ b/packages/local-mode/src/lockfile-contract.test.ts
@@ -24,6 +24,7 @@ describe("parseLockfile", () => {
           platformAssistantId: "platform-assistant-1",
           platformBaseUrl: "https://platform.example.com",
           platformOrganizationId: "org_1",
+          ingressUrl: "https://tunnel.example.ts.net",
           resources: { gatewayPort: 7777, daemonPort: 7778 },
         },
       ],
@@ -183,6 +184,30 @@ describe("parseLockfile", () => {
       { assistantId: "asst_1", cloud: "vellum", organizationId: "org_1" },
       { assistantId: "asst_2", cloud: "vellum" },
       { assistantId: "asst_3", cloud: "local" },
+    ]);
+  });
+
+  test("keeps a well-typed ingressUrl and drops it when mistyped", () => {
+    // The tunnel-recorded public URL rides the entry so remote-web pairing
+    // surfaces can prefill it; a mistyped value is dropped, entry preserved.
+    const raw = {
+      assistants: [
+        {
+          assistantId: "asst_1",
+          cloud: "local",
+          ingressUrl: "https://tunnel.example.ts.net",
+        },
+        { assistantId: "asst_2", cloud: "local", ingressUrl: 7 }, // mistyped
+      ],
+      activeAssistant: null,
+    };
+    expect(parseLockfile(raw).assistants).toEqual([
+      {
+        assistantId: "asst_1",
+        cloud: "local",
+        ingressUrl: "https://tunnel.example.ts.net",
+      },
+      { assistantId: "asst_2", cloud: "local" },
     ]);
   });
 

--- a/packages/local-mode/src/lockfile-contract.ts
+++ b/packages/local-mode/src/lockfile-contract.ts
@@ -115,6 +115,13 @@ export const LockfileAssistantSchema = z.object({
   platformBaseUrl: z.string().optional(),
   /** Platform organization UUID used for a self-hosted local assistant registration. */
   platformOrganizationId: z.string().optional(),
+  /**
+   * Public https URL a `vellum tunnel` provider recorded for this assistant
+   * (mirrored from the workspace ingress config). A public address, so it is
+   * renderer-safe: remote-web pairing surfaces (the CLI `--qr` flow, the web
+   * "Pair a device" card) default to it instead of asking the user to retype it.
+   */
+  ingressUrl: z.string().optional(),
   resources: LocalAssistantResourcesSchema.optional(),
 });
 

--- a/packages/local-mode/src/lockfile.test.ts
+++ b/packages/local-mode/src/lockfile.test.ts
@@ -81,6 +81,30 @@ describe("getLockfileData", () => {
     }
   });
 
+  test("surfaces a tunnel-recorded ingressUrl to the renderer", () => {
+    // The exact read the "Pair a device" card relies on: `vellum tunnel` stamps
+    // ingressUrl onto the entry, and the host read must carry it through.
+    writeOnDisk({
+      activeAssistant: "asst_1",
+      assistants: [
+        {
+          assistantId: "asst_1",
+          cloud: "local",
+          runtimeUrl: "http://127.0.0.1:7777",
+          ingressUrl: "https://tunnel.example.ts.net",
+        },
+      ],
+    });
+
+    const result = getLockfileData([lockfilePath]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.assistants[0]?.ingressUrl).toBe(
+        "https://tunnel.example.ts.net",
+      );
+    }
+  });
+
   test("fails with status 500 on malformed JSON", () => {
     fs.writeFileSync(lockfilePath, "{ not json");
     const result = getLockfileData([lockfilePath]);

--- a/packages/service-contracts/src/remote-web-pairing.ts
+++ b/packages/service-contracts/src/remote-web-pairing.ts
@@ -109,11 +109,76 @@ export type RemoteWebPairingTokenResponse =
 // only) so both Node and browser callers share one implementation.
 
 /** Why a public base URL can't be advertised in a pairing challenge. */
-export type PublicBaseUrlRejection = "unparseable" | "loopback" | "non-https";
+export type PublicBaseUrlRejection =
+  | "unparseable"
+  | "loopback"
+  | "non-https"
+  | "service-website";
 
 export type PublicBaseUrlResult =
   | { ok: true; url: string }
   | { ok: false; reason: PublicBaseUrlRejection };
+
+/**
+ * Hosts that are a tunnel/ingress vendor's own website, not a user's assistant
+ * endpoint. These are the tunnel vendors our docs mention, and their sites are
+ * exactly where a lost user grabs a URL from — e.g. a Tailscale admin invite
+ * link (`login.tailscale.com/admin/invite/…`), which is https and non-loopback
+ * and so clears every other check. Pairing refuses them with a targeted message
+ * rather than minting a challenge the scanning device can never reach.
+ */
+export const TUNNEL_PROVIDER_WEBSITE_HOSTS = [
+  "login.tailscale.com",
+  "tailscale.com",
+  "www.tailscale.com",
+  "ngrok.com",
+  "dashboard.ngrok.com",
+  "dash.cloudflare.com",
+  "cloudflare.com",
+  "www.cloudflare.com",
+] as const;
+
+/**
+ * A URL whose exact host is a tunnel/ingress vendor's own website (see
+ * {@link TUNNEL_PROVIDER_WEBSITE_HOSTS}). Exact-host only: a user's real
+ * Tailscale endpoint (`*.ts.net`) or Cloudflare-fronted domain is never a
+ * listed host, so a legitimate address is never mistaken for a vendor site.
+ */
+export function isTunnelProviderWebsiteUrl(url: string): boolean {
+  let hostname: string;
+  try {
+    // WHATWG URL lowercases the hostname during parsing.
+    hostname = new URL(url).hostname;
+  } catch {
+    return false;
+  }
+  return (TUNNEL_PROVIDER_WEBSITE_HOSTS as readonly string[]).includes(
+    hostname,
+  );
+}
+
+/**
+ * The display name of the tunnel/ingress vendor a service-website URL points
+ * at (`"Tailscale"` / `"ngrok"` / `"Cloudflare"`), or null when the host is not
+ * a known vendor site. Drives the "This is <Name>'s website" pairing guidance.
+ */
+export function tunnelProviderWebsiteName(url: string): string | null {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return null;
+  }
+  if (
+    !(TUNNEL_PROVIDER_WEBSITE_HOSTS as readonly string[]).includes(hostname)
+  ) {
+    return null;
+  }
+  if (hostname.includes("tailscale")) return "Tailscale";
+  if (hostname.includes("ngrok")) return "ngrok";
+  if (hostname.includes("cloudflare")) return "Cloudflare";
+  return null;
+}
 
 /**
  * A loopback URL — `localhost`, `[::1]`, or `127.x.x.x`. A pairing link that
@@ -166,6 +231,9 @@ export function resolvePublicBaseUrl(raw: string): PublicBaseUrlResult {
   }
   if (isLoopbackPublicUrl(normalized)) {
     return { ok: false, reason: "loopback" };
+  }
+  if (isTunnelProviderWebsiteUrl(normalized)) {
+    return { ok: false, reason: "service-website" };
   }
   if (new URL(normalized).protocol !== "https:") {
     return { ok: false, reason: "non-https" };


### PR DESCRIPTION
## Summary
- Card prefills the Public URL from the lockfile-recorded tunnel address (ingressUrl surfaced through the renderer-safe contract); honest no-tunnel-yet guidance replaces the hopeful empty field
- Shared URL validation gains a service-website rejection (login.tailscale.com and friends) — a first-time user pasted a Tailscale admin invite link and our https-only validation accepted it
- Card names the assistant it pairs (multi-instance users enabled the flag on one assistant while the card read another)

From live first-user testing (Slack, tonight). Part of plan: ios-self-hosted-connect.md (papercuts).