### PR TITLE
docs: phone guide mentions the settings Pair-a-device card

### DIFF
--- a/docs/self-hosted-phone.md
+++ b/docs/self-hosted-phone.md
@@ -239,6 +239,12 @@ The pairing session survives assistant restarts via a refresh cookie, so you
 stay signed in. Pairing codes are **single-use and expire after 10 minutes**;
 run `vellum pair --qr` again to add another device or replace a lapsed code.
 
+**Prefer a UI over the terminal?** The desktop app has the same flow as a
+card: **Settings → General → Pair a device**. It prefills the address
+`vellum tunnel` recorded (or shows "No tunnel detected" guidance when there
+isn't one), rejects lookalike tunnel-provider website URLs, and names the
+assistant it pairs — generate the QR there and scan it the same way.
+
 ## 6. Using the Vellum iOS app
 
 The native **Vellum iOS app** can point at your self-hosted assistant instead


### PR DESCRIPTION
## Summary
- One paragraph after Step 5: the desktop app's Settings → General → Pair a device card as the UI alternative — prefilled tunnel address, no-tunnel guidance, service-website rejection, per-assistant naming (all merged in #39035)

Follow-up the guide restructure (#39033) deliberately deferred until the card behavior existed on main.