### PR TITLE
feat(memory): fly the map to a just-created memory and pulse it

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17480,8 +17480,8 @@ paths:
       summary: Create a memory by remembering a fact
       description:
         Append a user-authored fact to the memory buffer via handleRemember. The fact surfaces in the memory graph
-        immediately as a pending node, and a consolidation run is nudged (deduped, backoff-respecting) so it files into
-        concept pages promptly.
+        immediately as a pending node (its id is returned so clients can navigate to it), and a consolidation run is
+        nudged (deduped, backoff-respecting) so it files into concept pages promptly.
       tags:
         - memory
       requestBody:
@@ -17507,6 +17507,11 @@ paths:
                     type: string
                   success:
                     type: boolean
+                  pendingNodeId:
+                    description:
+                      Graph node id (`buffer:<hash>`) of the pending entry this create appended, for fly-to-node navigation.
+                      Absent when the buffer can't be re-read.
+                    type: string
                 required:
                   - message
                   - success

--- a/assistant/src/plugins/defaults/memory/graph-topology/pending-buffer.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/pending-buffer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   buildPendingGraph,
+  findPendingEntryForContent,
   parseBufferEntries,
   PENDING_KIND,
   PENDING_NODE_ID_PREFIX,
@@ -142,5 +143,39 @@ describe("buildPendingGraph", () => {
     expect(nodes).toHaveLength(200);
     expect(nodes[0]!.label).toBe("fact number 50");
     expect(nodes[199]!.label).toBe("fact number 249");
+  });
+});
+
+describe("findPendingEntryForContent", () => {
+  const entries = parseBufferEntries(
+    "- [Jul 20, 3:15 PM] alpha fact\n" +
+      "- [Jul 20, 3:16 PM] beta fact\n" +
+      "- [Jul 20, 3:17 PM] alpha fact\n",
+  );
+
+  test("returns the LAST entry matching the content, not the buffer tail", () => {
+    const match = findPendingEntryForContent(entries, "alpha fact");
+    expect(match!.id).toBe(entries[2]!.id);
+    // Interleave shape: with "beta fact" sitting at the tail instead, the
+    // alpha lookup must still resolve to alpha, never beta.
+    const interleaved = parseBufferEntries(
+      "- [Jul 20, 3:15 PM] alpha fact\n- [Jul 20, 3:16 PM] beta fact\n",
+    );
+    expect(findPendingEntryForContent(interleaved, "alpha fact")!.id).toBe(
+      interleaved[0]!.id,
+    );
+  });
+
+  test("normalizes multiline content the way the buffer parse folds it", () => {
+    const multi = parseBufferEntries(
+      "- [Jul 20, 3:15 PM] headline\nsecond line\n",
+    );
+    const match = findPendingEntryForContent(multi, "headline\nsecond line");
+    expect(match!.id).toBe(multi[0]!.id);
+  });
+
+  test("returns undefined when nothing matches or content is blank", () => {
+    expect(findPendingEntryForContent(entries, "unknown fact")).toBeUndefined();
+    expect(findPendingEntryForContent(entries, "   ")).toBeUndefined();
   });
 });

--- a/assistant/src/plugins/defaults/memory/graph-topology/pending-buffer.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/pending-buffer.ts
@@ -18,6 +18,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { formatRememberEntry } from "../graph/tool-handlers.js";
 import type { MemoryGraphEdge, MemoryGraphNode } from "./types.js";
 
 /** Node id prefix marking a pending buffer entry (id = prefix + text hash). */
@@ -203,4 +204,32 @@ export async function readPendingBufferEntries(
     "utf-8",
   ).catch(() => "");
   return parseBufferEntries(content);
+}
+
+/**
+ * Resolve the pending entry a just-appended remember produced: the LAST
+ * entry whose text matches `content` run through the same
+ * timestamp-format + parse normalization the buffer applies (so multiline
+ * facts compare against their folded, trimmed form). Content matching —
+ * rather than taking the buffer tail — keeps a concurrently interleaved
+ * remember from another writer from being reported as this request's
+ * entry. Concurrent *identical* content remains ambiguous, which is
+ * harmless: the id is a navigation hint to visually identical nodes.
+ */
+export function findPendingEntryForContent(
+  entries: readonly PendingBufferEntry[],
+  content: string,
+): PendingBufferEntry | undefined {
+  const normalized = parseBufferEntries(
+    formatRememberEntry(content.trim(), new Date()),
+  )[0]?.text;
+  if (!normalized) {
+    return undefined;
+  }
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i]!.text === normalized) {
+      return entries[i];
+    }
+  }
+  return undefined;
 }

--- a/assistant/src/plugins/defaults/memory/src/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-item-routes.test.ts
@@ -91,6 +91,7 @@ import {
   NotFoundError,
 } from "../../../../runtime/routes/errors.js";
 import type { RouteDefinition } from "../../../../runtime/routes/types.js";
+import { readPendingBufferEntries } from "../graph-topology/pending-buffer.js";
 import { invalidatePageIndex } from "../v3/substrate/page-index.js";
 import { writePage } from "../v3/substrate/page-store.js";
 import type { ConceptPage } from "../v3/substrate/types.js";
@@ -1186,6 +1187,7 @@ describe("Memory Item Routes", () => {
     interface RememberBody {
       success: boolean;
       message: string;
+      pendingNodeId?: string;
     }
 
     test("appends a valid fact and returns { success, message }", async () => {
@@ -1196,6 +1198,39 @@ describe("Memory Item Routes", () => {
       const body = (await res.json()) as RememberBody;
       expect(body.success).toBe(true);
       expect(body.message.length).toBeGreaterThan(0);
+    });
+
+    test("returns the pending node id of the appended entry", async () => {
+      const res = await callHandler(getRoute("memory/remember", "POST"), {
+        body: { content: "Prefers window seats on morning flights" },
+      });
+      const body = (await res.json()) as RememberBody;
+      expect(body.success).toBe(true);
+      expect(body.pendingNodeId).toStartWith("buffer:");
+
+      // The id must resolve against the graph's own buffer parse — the same
+      // source the memory-graph endpoint renders pending nodes from.
+      const entries = await readPendingBufferEntries(tmpWorkspace);
+      expect(entries.at(-1)!.id).toBe(body.pendingNodeId!);
+      expect(entries.at(-1)!.text).toBe(
+        "Prefers window seats on morning flights",
+      );
+    });
+
+    test("duplicate content gets the deduped (suffixed) pending id", async () => {
+      const first = (await (
+        await callHandler(getRoute("memory/remember", "POST"), {
+          body: { content: "same fact twice" },
+        })
+      ).json()) as RememberBody;
+      const second = (await (
+        await callHandler(getRoute("memory/remember", "POST"), {
+          body: { content: "same fact twice" },
+        })
+      ).json()) as RememberBody;
+
+      expect(first.pendingNodeId).toStartWith("buffer:");
+      expect(second.pendingNodeId).toBe(`${first.pendingNodeId!}-2`);
     });
 
     test("nudges a consolidation run after a successful create", async () => {

--- a/assistant/src/plugins/defaults/memory/src/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-item-routes.ts
@@ -73,6 +73,7 @@ import type {
   MemoryType,
   NewNode,
 } from "../graph/types.js";
+import { readPendingBufferEntries } from "../graph-topology/pending-buffer.js";
 import { consolidationBackoffRemainingMs } from "../jobs-worker.js";
 import { getLogger } from "../logging.js";
 import { memoryDbOrNull } from "../memory-db.js";
@@ -1076,11 +1077,20 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Create a memory by remembering a fact",
     description:
-      "Append a user-authored fact to the memory buffer via handleRemember. The fact surfaces in the memory graph immediately as a pending node, and a consolidation run is nudged (deduped, backoff-respecting) so it files into concept pages promptly.",
+      "Append a user-authored fact to the memory buffer via handleRemember. The fact surfaces in the memory graph immediately as a pending node (its id is returned so clients can navigate to it), and a consolidation run is nudged (deduped, backoff-respecting) so it files into concept pages promptly.",
     tags: ["memory"],
     requestBody: z.object({ content: z.string() }),
-    responseBody: z.object({ message: z.string(), success: z.boolean() }),
-    handler: ({ body }) => {
+    responseBody: z.object({
+      message: z.string(),
+      success: z.boolean(),
+      pendingNodeId: z
+        .string()
+        .optional()
+        .describe(
+          "Graph node id (`buffer:<hash>`) of the pending entry this create appended, for fly-to-node navigation. Absent when the buffer can't be re-read.",
+        ),
+    }),
+    handler: async ({ body }) => {
       const parsed = z.object({ content: z.string() }).safeParse(body ?? {});
       if (!parsed.success) {
         throw new BadRequestError("content (string) is required");
@@ -1094,10 +1104,25 @@ export const ROUTES: RouteDefinition[] = [
         "web",
         config,
       );
-      if (result.success) {
-        maybeEnqueueConsolidationForCreate(config);
+      if (!result.success) {
+        return result;
       }
-      return result;
+      maybeEnqueueConsolidationForCreate(config);
+
+      // Resolve the pending graph-node id of the entry just appended so the
+      // client can fly the map to it. The append is synchronous, so the
+      // buffer's last entry is ours (a concurrent remember could interleave;
+      // the id is a navigation hint, not a correctness contract). Best-effort
+      // — the create already succeeded, so a read failure returns no id
+      // rather than an error.
+      let pendingNodeId: string | undefined;
+      try {
+        const entries = await readPendingBufferEntries(getWorkspaceDir());
+        pendingNodeId = entries.at(-1)?.id;
+      } catch (err) {
+        log.warn({ err }, "Failed to resolve pending node id after create");
+      }
+      return pendingNodeId ? { ...result, pendingNodeId } : result;
     },
   },
 ];

--- a/assistant/src/plugins/defaults/memory/src/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-item-routes.ts
@@ -73,7 +73,10 @@ import type {
   MemoryType,
   NewNode,
 } from "../graph/types.js";
-import { readPendingBufferEntries } from "../graph-topology/pending-buffer.js";
+import {
+  findPendingEntryForContent,
+  readPendingBufferEntries,
+} from "../graph-topology/pending-buffer.js";
 import { consolidationBackoffRemainingMs } from "../jobs-worker.js";
 import { getLogger } from "../logging.js";
 import { memoryDbOrNull } from "../memory-db.js";
@@ -1110,15 +1113,18 @@ export const ROUTES: RouteDefinition[] = [
       maybeEnqueueConsolidationForCreate(config);
 
       // Resolve the pending graph-node id of the entry just appended so the
-      // client can fly the map to it. The append is synchronous, so the
-      // buffer's last entry is ours (a concurrent remember could interleave;
-      // the id is a navigation hint, not a correctness contract). Best-effort
-      // — the create already succeeded, so a read failure returns no id
-      // rather than an error.
+      // client can fly the map to it. Matched by this request's content
+      // (normalized through the same buffer parse) rather than the buffer
+      // tail, so a concurrently interleaved remember from another writer is
+      // never reported as this one's entry. Best-effort — the create already
+      // succeeded, so a read failure returns no id rather than an error.
       let pendingNodeId: string | undefined;
       try {
         const entries = await readPendingBufferEntries(getWorkspaceDir());
-        pendingNodeId = entries.at(-1)?.id;
+        pendingNodeId = findPendingEntryForContent(
+          entries,
+          parsed.data.content,
+        )?.id;
       } catch (err) {
         log.warn({ err }, "Failed to resolve pending node id after create");
       }

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-view.tsx
@@ -8,7 +8,14 @@ import {
   ZoomIn,
   ZoomOut,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { VIRTUAL_CENTER } from "@/domains/intelligence/components/constellation-view/constants";
 import { memoryGraphOptions } from "@/domains/intelligence/memory-graph/get-memory-graph";
@@ -69,6 +76,12 @@ const SELECTION_DIM_EDGE = 0.03;
 
 // Below this node count the graph is small enough to scan by eye — no search box.
 const SEARCH_MIN_NODES = 12;
+
+// How long a just-created memory announces itself: expanding rings around the
+// node after the camera lands on it (a static highlight ring under reduced
+// motion). Long enough to register, short enough that rapid consecutive
+// creates don't feel noisy.
+const BORN_PULSE_MS = 2600;
 
 interface Projected {
   id: string;
@@ -140,6 +153,14 @@ function makeEgoTest(
     selectedId != null && (id === selectedId || (neighbors?.has(id) ?? false));
 }
 
+export interface ConceptGraphViewHandle {
+  /** Fly the camera to a node and run the short "born" pulse marking where it
+   * landed. An id the current layout doesn't know yet (the usual case right
+   * after a create, while the graph refetch is in flight) is parked and
+   * applied as soon as a layout containing it arrives. */
+  focusNode(id: string): void;
+}
+
 export interface ConceptGraphViewProps {
   assistantId: string;
   className?: string;
@@ -153,6 +174,10 @@ export interface ConceptGraphViewProps {
    * flex sibling of the stats/search cluster and cannot overlap it at any
    * container width. */
   headerAction?: React.ReactNode;
+  /** Imperative surface for page-driven navigation (fly-to-node after a
+   * create). A plain prop rather than forwardRef so callers that don't need
+   * it never see a ref signature. */
+  handleRef?: React.Ref<ConceptGraphViewHandle>;
 }
 
 function CenteredMessage({ title, detail }: { title: string; detail?: string }) {
@@ -183,6 +208,7 @@ export function ConceptGraphView({
   onToggleFullscreen,
   onOpenThread,
   headerAction,
+  handleRef,
 }: ConceptGraphViewProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -310,6 +336,12 @@ export function ConceptGraphView({
   // Set on dismiss so the 60fps loop eases the camera back out to the overview
   // framing (zoom + pitch), then clears itself once settled.
   const resetViewRef = useRef(false);
+  // A just-created memory announcing itself: the render loop draws expanding
+  // rings around this node for BORN_PULSE_MS after the camera lands on it.
+  const bornRef = useRef<{ id: string; start: number } | null>(null);
+  // A focusNode() request for an id the current layout doesn't know yet —
+  // applied by the layout effect once the post-create refetch delivers it.
+  const pendingFocusRef = useRef<string | null>(null);
 
   // Bumped only when the focused node changes, so the DOM tooltip re-renders.
   // The canvas itself never needs React state.
@@ -488,6 +520,43 @@ export function ConceptGraphView({
     },
     [openNodeDetail, focusOn],
   );
+
+  // Fly to a node and start its "born" pulse. Under reduced motion the loop
+  // only redraws on input, so schedule the redraw that retires the static
+  // highlight ring once the window ends.
+  const applyBorn = useCallback(
+    (id: string) => {
+      bornRef.current = { id, start: performance.now() };
+      focusOn(id);
+      window.setTimeout(() => {
+        view.current.dirty = true;
+      }, BORN_PULSE_MS + 60);
+    },
+    [focusOn],
+  );
+
+  const focusNode = useCallback(
+    (id: string) => {
+      if (layout.nodes.some((n) => n.id === id)) {
+        applyBorn(id);
+      } else {
+        pendingFocusRef.current = id;
+      }
+    },
+    [layout.nodes, applyBorn],
+  );
+
+  // Apply a parked focusNode() request once a layout containing the node
+  // lands (the post-create refetch resolving).
+  useEffect(() => {
+    const id = pendingFocusRef.current;
+    if (id && layout.nodes.some((n) => n.id === id)) {
+      pendingFocusRef.current = null;
+      applyBorn(id);
+    }
+  }, [layout.nodes, applyBorn]);
+
+  useImperativeHandle(handleRef, () => ({ focusNode }), [focusNode]);
 
   // Fully dismiss the detail drawer back to the overview: empty the trail
   // (closing the drawer), clear any active search (the box hides behind the
@@ -925,6 +994,35 @@ export function ConceptGraphView({
         ctx.setLineDash(isPending ? [3, 3] : []);
         ctx.stroke();
         ctx.setLineDash([]);
+
+        // Born pulse: a just-created memory announces itself with staggered
+        // expanding rings for BORN_PULSE_MS after the camera lands on it —
+        // a single static highlight ring under reduced motion.
+        const born = bornRef.current;
+        if (born && born.id === node.id) {
+          const bornElapsed = t - born.start;
+          if (bornElapsed > BORN_PULSE_MS) {
+            bornRef.current = null;
+          } else if (reduceMotion) {
+            ctx.globalAlpha = 0.7;
+            ctx.lineWidth = 1.5;
+            ctx.beginPath();
+            ctx.arc(p.sx, p.sy, p.sr + 7, 0, Math.PI * 2);
+            ctx.stroke();
+          } else {
+            for (let ring = 0; ring < 3; ring++) {
+              const prog = (bornElapsed - ring * 320) / 1100;
+              if (prog <= 0 || prog >= 1) {
+                continue;
+              }
+              ctx.globalAlpha = (1 - prog) * 0.8;
+              ctx.lineWidth = 1.5;
+              ctx.beginPath();
+              ctx.arc(p.sx, p.sy, p.sr + prog * 46 * p.depth, 0, Math.PI * 2);
+              ctx.stroke();
+            }
+          }
+        }
       }
       ctx.shadowBlur = 0;
 

--- a/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/create-memory-modal.tsx
@@ -12,6 +12,10 @@ export interface CreateMemoryModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   assistantId: string;
+  /** Fired after a successful save, with the created entry's pending graph
+   * node id when the daemon provides one — the page uses it to fly the map
+   * to the new memory. */
+  onCreated?: (pendingNodeId: string | undefined) => void;
 }
 
 /**
@@ -27,6 +31,7 @@ export function CreateMemoryModal({
   open,
   onOpenChange,
   assistantId,
+  onCreated,
 }: CreateMemoryModalProps) {
   const queryClient = useQueryClient();
   const [content, setContent] = useState("");
@@ -47,9 +52,18 @@ export function CreateMemoryModal({
         toast.error(result.message || "Couldn't save that memory.");
         return;
       }
-      toast.success("Got it — it's on your map while I file it away.");
+      // When the daemon returns the pending node id the map flies to it, so
+      // the toast just confirms; otherwise it sets the "look for it" tone.
+      toast.success(
+        result.pendingNodeId
+          ? "Got it — taking you to it."
+          : "Got it — it's on your map while I file it away.",
+      );
       setContent("");
       onOpenChange(false);
+      // Hand the id to the page before the refetch: the graph view parks the
+      // fly-to request until a layout containing the node lands.
+      onCreated?.(result.pendingNodeId);
       // Invalidate the graph so the refetch shows the fact as a pending node
       // immediately (it becomes a concept node once consolidation files it),
       // and the stats query so the identity Memory card's count refreshes too
@@ -69,7 +83,7 @@ export function CreateMemoryModal({
     } finally {
       setIsSaving(false);
     }
-  }, [assistantId, content, onOpenChange, queryClient]);
+  }, [assistantId, content, onOpenChange, onCreated, queryClient]);
 
   return (
     <Modal.Root open={open} onOpenChange={onOpenChange}>

--- a/clients/web/src/domains/intelligence/memory-graph/create-memory.ts
+++ b/clients/web/src/domains/intelligence/memory-graph/create-memory.ts
@@ -14,6 +14,10 @@ import { memoryRememberPost } from "@/generated/daemon/sdk.gen";
 export interface CreateMemoryResult {
   message: string;
   success: boolean;
+  /** Graph node id (`buffer:<hash>`) of the pending entry this create
+   * appended, for fly-to-node navigation. Absent on daemons predating the
+   * field or when the server couldn't re-read the buffer. */
+  pendingNodeId?: string;
 }
 
 export async function createMemory(

--- a/clients/web/src/domains/intelligence/memory-page.tsx
+++ b/clients/web/src/domains/intelligence/memory-page.tsx
@@ -3,7 +3,10 @@ import { Plus } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
-import { ConceptGraphView } from "@/domains/intelligence/components/concept-graph/concept-graph-view";
+import {
+  ConceptGraphView,
+  type ConceptGraphViewHandle,
+} from "@/domains/intelligence/components/concept-graph/concept-graph-view";
 import { CreateMemoryModal } from "@/domains/intelligence/components/concept-graph/create-memory-modal";
 import { memoryGraphOptions } from "@/domains/intelligence/memory-graph/get-memory-graph";
 import { memoryStatsOptions } from "@/domains/intelligence/memory-graph/get-memory-stats";
@@ -26,6 +29,9 @@ interface MemoryPageProps {
 export function MemoryPage({ onOpenThread }: MemoryPageProps) {
   const assistantId = useActiveAssistantId();
   const [createOpen, setCreateOpen] = useState(false);
+  // Imperative handle into the graph view: after a create, fly the map to the
+  // new pending node so the user sees exactly where their memory landed.
+  const graphRef = useRef<ConceptGraphViewHandle | null>(null);
 
   // Two backend conditions must hold before revealing the hand-authoring CTA:
   //  1. The graph backend is actually supported. `GET /memory/stats` reads
@@ -61,6 +67,7 @@ export function MemoryPage({ onOpenThread }: MemoryPageProps) {
         assistantId={assistantId}
         className="h-full w-full"
         onOpenThread={onOpenThread}
+        handleRef={graphRef}
         headerAction={
           showCreate ? (
             /* Rendered into the graph header's right slot — a flex sibling of
@@ -83,6 +90,11 @@ export function MemoryPage({ onOpenThread }: MemoryPageProps) {
           open={createOpen}
           onOpenChange={setCreateOpen}
           assistantId={assistantId}
+          onCreated={(pendingNodeId) => {
+            if (pendingNodeId) {
+              graphRef.current?.focusNode(pendingNodeId);
+            }
+          }}
         />
       ) : null}
     </div>


### PR DESCRIPTION
Implements **Option A (fly & pulse)** from the post-create UX proposal: https://claude.ai/code/artifact/1dd188be-16a9-457e-baf3-911e087f7c4e — after saving a memory, the map flies to the new pending node and pulses it, instead of leaving the user to hunt a rotating brain for the amber dot.

## Daemon

- `POST /memory/remember` additionally returns **`pendingNodeId`** — the `buffer:<hash>` graph id of the entry it just appended, resolved by re-reading the buffer through the *same* parse the memory-graph endpoint renders pending nodes from (so the id is guaranteed to match a node the next graph fetch contains, including the `-2` dedupe suffix for duplicate text). Optional + best-effort: a buffer read failure returns the previous response shape rather than failing a create that already succeeded. Spec regenerated.

## Web

- `ConceptGraphView` gains an imperative handle: `handleRef` → `focusNode(id)`.
  - **Flight** reuses the existing search jump-to camera ease (`focusOn`) — no new camera machinery.
  - **Born pulse**: three staggered expanding rings in the node's own color for ~2.6s after the camera lands, drawn in the same node-loop spot as the recency pulse. Under reduced motion: a single static highlight ring, with a scheduled redraw to retire it (the reduced-motion loop only redraws on input).
  - **Race handling**: the node usually doesn't exist until the post-create refetch resolves, so an unknown id is parked in a ref and applied by a layout effect once a layout containing it arrives. If the id already exists (duplicate content), it applies immediately.
- `CreateMemoryModal` reports the id up via a new `onCreated` callback; the Memory page wires it into the view. Toast copy: "Got it — taking you to it." when navigation will happen; the previous copy is kept when the daemon doesn't return an id (backwards compat is just the optional field — no compat-registry gate needed for a response-field read).

## Testing

- Route tests: `pendingNodeId` round-trips against `readPendingBufferEntries` (last-entry id + text), and duplicate content returns the suffixed id. 61/61 green.
- `tsc` + eslint clean in both packages; all `domains/intelligence` web tests green; pending-buffer suite green.
- Worth a visual pass on the dev build: create a memory and watch the flight + pulse land (normal and reduced-motion), and try two rapid creates — the second should simply re-fly.

Pre-existing prettier drift in the touched web files left in place, per prior practice on these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)