### PR TITLE
perf(memory): batch retrospective runs and cap per-assistant daily volume

### DIFF
--- a/assistant/src/__tests__/jobs-store-upsert-retrospective.test.ts
+++ b/assistant/src/__tests__/jobs-store-upsert-retrospective.test.ts
@@ -1,0 +1,110 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { and, eq } from "drizzle-orm";
+
+import { getMemoryDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  completeMemoryJob,
+  upsertMemoryRetrospectiveJob,
+} from "../persistence/jobs-store.js";
+import { memoryJobs } from "../persistence/schema/index.js";
+
+function pendingRetrospectiveRows(conversationId: string) {
+  const db = getMemoryDb()!;
+  return db
+    .select()
+    .from(memoryJobs)
+    .where(
+      and(
+        eq(memoryJobs.type, "memory_retrospective"),
+        eq(memoryJobs.status, "pending"),
+      ),
+    )
+    .all()
+    .filter((row) => {
+      const payload = JSON.parse(row.payload) as { conversationId?: string };
+      return payload.conversationId === conversationId;
+    });
+}
+
+describe("upsertMemoryRetrospectiveJob create-vs-coalesce", () => {
+  beforeAll(async () => {
+    await initializeDb();
+  });
+
+  beforeEach(() => {
+    getMemoryDb()!.run("DELETE FROM memory_jobs");
+  });
+
+  test("reports true and inserts a new pending row on first enqueue", () => {
+    const created = upsertMemoryRetrospectiveJob(
+      { conversationId: "conv-1" },
+      1_000,
+    );
+
+    expect(created).toBe(true);
+    expect(pendingRetrospectiveRows("conv-1")).toHaveLength(1);
+  });
+
+  test("reports false and does NOT insert a second row when a pending job exists", () => {
+    expect(
+      upsertMemoryRetrospectiveJob({ conversationId: "conv-1" }, 1_000),
+    ).toBe(true);
+
+    const coalesced = upsertMemoryRetrospectiveJob(
+      { conversationId: "conv-1" },
+      2_000,
+    );
+
+    expect(coalesced).toBe(false);
+    expect(pendingRetrospectiveRows("conv-1")).toHaveLength(1);
+  });
+
+  test("coalesce still pulls runAfter earlier (min semantics) and never pushes it out", () => {
+    expect(
+      upsertMemoryRetrospectiveJob({ conversationId: "conv-1" }, 5_000),
+    ).toBe(true);
+
+    // A sooner trigger pulls the pending row's runAfter earlier.
+    expect(
+      upsertMemoryRetrospectiveJob({ conversationId: "conv-1" }, 3_000),
+    ).toBe(false);
+    expect(pendingRetrospectiveRows("conv-1")[0]!.runAfter).toBe(3_000);
+
+    // A later trigger never pushes the pending row further out.
+    expect(
+      upsertMemoryRetrospectiveJob({ conversationId: "conv-1" }, 9_000),
+    ).toBe(false);
+    expect(pendingRetrospectiveRows("conv-1")[0]!.runAfter).toBe(3_000);
+  });
+
+  test("a fresh enqueue after the prior job completes reports true again", () => {
+    expect(
+      upsertMemoryRetrospectiveJob({ conversationId: "conv-1" }, 1_000),
+    ).toBe(true);
+    const [pending] = pendingRetrospectiveRows("conv-1");
+    completeMemoryJob(pending!.id);
+
+    // No pending row remains, so the next enqueue is a genuine new creation.
+    const created = upsertMemoryRetrospectiveJob(
+      { conversationId: "conv-1" },
+      2_000,
+    );
+
+    expect(created).toBe(true);
+    expect(pendingRetrospectiveRows("conv-1")).toHaveLength(1);
+  });
+
+  test("distinct conversations each create their own pending job", () => {
+    expect(
+      upsertMemoryRetrospectiveJob({ conversationId: "conv-1" }, 1_000),
+    ).toBe(true);
+    expect(
+      upsertMemoryRetrospectiveJob({ conversationId: "conv-2" }, 1_000),
+    ).toBe(true);
+
+    expect(pendingRetrospectiveRows("conv-1")).toHaveLength(1);
+    expect(pendingRetrospectiveRows("conv-2")).toHaveLength(1);
+  });
+});

--- a/assistant/src/config/schemas/__tests__/memory-retrospective.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-retrospective.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { MemoryRetrospectiveConfigSchema } from "../memory-retrospective.js";
+
+describe("MemoryRetrospectiveConfigSchema", () => {
+  test("parses an empty object to documented defaults", () => {
+    const parsed = MemoryRetrospectiveConfigSchema.parse({});
+    expect(parsed).toEqual({
+      timeThresholdMs: 30 * 60 * 1000,
+      messageThreshold: 25,
+      minCooldownMs: 10 * 60 * 1000,
+      maxRunsPerAssistantPerDay: 40,
+      sweepIntervalMs: 8 * 60 * 60 * 1000,
+      keepSupersededRuns: false,
+      matchConversationProfile: false,
+      promptPath: null,
+    });
+  });
+
+  test("an explicit override is preserved and only unset fields take defaults (backward compat)", () => {
+    // Configs written against the prior defaults keep their explicit values;
+    // a field they never set (the new cap) falls back to its default.
+    const parsed = MemoryRetrospectiveConfigSchema.parse({
+      messageThreshold: 10,
+      minCooldownMs: 5 * 60 * 1000,
+    });
+    expect(parsed.messageThreshold).toBe(10);
+    expect(parsed.minCooldownMs).toBe(5 * 60 * 1000);
+    expect(parsed.maxRunsPerAssistantPerDay).toBe(40);
+  });
+
+  test("rejects a non-positive cap", () => {
+    expect(() =>
+      MemoryRetrospectiveConfigSchema.parse({ maxRunsPerAssistantPerDay: 0 }),
+    ).toThrow();
+    expect(() =>
+      MemoryRetrospectiveConfigSchema.parse({ maxRunsPerAssistantPerDay: -1 }),
+    ).toThrow();
+  });
+});

--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -23,9 +23,9 @@ export const MemoryRetrospectiveConfigSchema = z
       .positive(
         "memory.retrospective.messageThreshold must be a positive integer",
       )
-      .default(10)
+      .default(25)
       .describe(
-        "New messages since the last successful retrospective run before the message-count trigger fires.",
+        "New messages since the last successful retrospective run before the message-count trigger fires. A single agentic turn easily adds ten-plus messages, so a low threshold re-arms the trigger every turn; batching more messages per run keeps memory coverage identical while spreading the fixed per-run fork overhead across more content.",
       ),
 
     minCooldownMs: z
@@ -34,9 +34,23 @@ export const MemoryRetrospectiveConfigSchema = z
       .nonnegative(
         "memory.retrospective.minCooldownMs must be a non-negative integer",
       )
-      .default(5 * 60 * 1000)
+      .default(10 * 60 * 1000)
       .describe(
         "Minimum milliseconds between attempts (success or failure). Prevents tight retry loops across trigger types. Pre-compaction bypasses this gate.",
+      ),
+
+    maxRunsPerAssistantPerDay: z
+      .number({
+        error:
+          "memory.retrospective.maxRunsPerAssistantPerDay must be a number",
+      })
+      .int("memory.retrospective.maxRunsPerAssistantPerDay must be an integer")
+      .positive(
+        "memory.retrospective.maxRunsPerAssistantPerDay must be a positive integer",
+      )
+      .default(40)
+      .describe(
+        "Runaway backstop: the maximum number of retrospective enqueue attempts the assistant makes in a UTC day, counted across all conversations. Normal usage sits far below it (median is roughly eight attempts/day), so this only clips pathological tails where a single conversation loops thousands of times. The interval and message-count thresholds do the broad volume reduction; this is the ceiling. Pre-compaction bypasses this gate exactly as it bypasses the cooldown — the last-chance capture before context truncation neither checks nor consumes the daily budget.",
       ),
 
     sweepIntervalMs: z

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -245,6 +245,12 @@ export function upsertDebouncedJob(
  * does NOT push a sooner-scheduled row further out (consumer takes the
  * minimum). The trigger metadata is intentionally not retained — it is only
  * useful for observability at enqueue time.
+ *
+ * Returns `true` only when a NEW pending job is inserted; `false` when the
+ * call coalesced into an already-pending row (whether or not it pulled
+ * `runAfter` earlier). Budget-metered callers count one unit of the daily cap
+ * only on a `true` return, so repeated coalesced triggers against one pending
+ * row never drain the day's budget for a single retrospective.
  */
 export function upsertMemoryRetrospectiveJob(
   payload: { conversationId: string },
@@ -254,7 +260,7 @@ export function upsertMemoryRetrospectiveJob(
   ) => unknown
     ? T
     : never,
-): void {
+): boolean {
   const db = dbOverride ?? memoryDb();
   const existing = db
     .select()
@@ -277,9 +283,10 @@ export function upsertMemoryRetrospectiveJob(
         .where(eq(memoryJobs.id, existing.id))
         .run();
     }
-    return;
+    return false;
   }
   enqueueMemoryJob("memory_retrospective", payload, runAfter, dbOverride);
+  return true;
 }
 
 /**

--- a/assistant/src/persistence/migrations/351-memory-retrospective-daily-count.ts
+++ b/assistant/src/persistence/migrations/351-memory-retrospective-daily-count.ts
@@ -1,0 +1,47 @@
+import type { Database } from "bun:sqlite";
+
+import type { DrizzleDb } from "../db-connection.js";
+import { getMemorySqlite } from "../db-connection.js";
+
+/**
+ * Create the `memory_retrospective_daily_count` table on the memory connection
+ * (`assistant-memory.db`) — one row per UTC day (`day_key`) holding the
+ * assistant-wide count of retrospective enqueue attempts, backing the
+ * `memory.retrospective.maxRunsPerAssistantPerDay` runaway backstop. Idempotent
+ * (`IF NOT EXISTS`); exported so tests can stand up the memory-side schema
+ * directly.
+ *
+ * The table is not conversation-keyed — it spans every conversation — so it
+ * deliberately stays out of `CONVERSATION_KEYED_MEMORY_TABLES`; stale prior-day
+ * rows are pruned by the plugin at reservation time rather than by a delete
+ * cascade.
+ */
+export function ensureMemoryRetrospectiveDailyCountSchema(
+  memoryRaw: Database,
+): void {
+  memoryRaw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_retrospective_daily_count (
+      day_key TEXT PRIMARY KEY,
+      run_count INTEGER NOT NULL
+    )
+  `);
+}
+
+/**
+ * Fresh table (no data to relocate), so this only ensures the schema on the
+ * memory connection. Throws when the memory database cannot be opened so the
+ * runner records the step as failed and retries it on a later boot rather than
+ * checkpointing a table that was never created; the throw is caught per-step by
+ * the runner, so startup is not aborted.
+ */
+export function migrateMemoryRetrospectiveDailyCount(
+  _database: DrizzleDb,
+): void {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
+    throw new Error(
+      "memory database unavailable — deferring memory_retrospective_daily_count creation",
+    );
+  }
+  ensureMemoryRetrospectiveDailyCountSchema(memoryRaw);
+}

--- a/assistant/src/persistence/schema/memory-core.ts
+++ b/assistant/src/persistence/schema/memory-core.ts
@@ -110,3 +110,17 @@ export const memoryRetrospectiveState = sqliteTable(
     rememberedLog: text("remembered_log"),
   },
 );
+
+// Assistant-wide count of retrospective enqueue attempts per UTC day, the
+// backstop for `memory.retrospective.maxRunsPerAssistantPerDay`. One row per
+// day (`day_key` is a UTC `YYYY-MM-DD` string), spanning all conversations —
+// not conversation-keyed, so it survives conversation deletion. Lives in the
+// dedicated memory database (`assistant-memory.db`), not main — access it via
+// the memory connection (`getMemoryDb()` / `getMemorySqlite()`).
+export const memoryRetrospectiveDailyCount = sqliteTable(
+  "memory_retrospective_daily_count",
+  {
+    dayKey: text("day_key").primaryKey(),
+    runCount: integer("run_count").notNull(),
+  },
+);

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -458,6 +458,7 @@ import { migrateDeleteStrayGreetingConversation } from "./migrations/347-delete-
 import { migrateMemorySummariesScopeUpdatedIndex } from "./migrations/348-memory-summaries-scope-updated-index.js";
 import { migrateMoveMemoryGraphTablesToMemoryDb } from "./migrations/349-move-memory-graph-tables-to-memory-db.js";
 import { migrateConversationsTotalInputTokensNullable } from "./migrations/350-conversations-total-input-tokens-nullable.js";
+import { migrateMemoryRetrospectiveDailyCount } from "./migrations/351-memory-retrospective-daily-count.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1473,4 +1474,5 @@ export const migrationSteps: MigrationStep[] = [
     ],
   },
   migrateConversationsTotalInputTokensNullable,
+  migrateMemoryRetrospectiveDailyCount,
 ];

--- a/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
@@ -12,7 +12,8 @@
  *      `memory_v2_activation_logs`, `memory_recall_logs`,
  *      `memory_v3_selections`, `activation_sessions`, `activation_state`,
  *      `conversation_graph_memory_state`, `memory_v3_ever_injected`,
- *      `memory_retrospective_state`, and the graph cluster
+ *      `memory_retrospective_state`, `memory_retrospective_daily_count`, and
+ *      the graph cluster
  *      `memory_graph_nodes` / `memory_graph_edges` / `memory_graph_triggers` /
  *      `memory_graph_node_edits`) live in the dedicated memory connection, not
  *      in the main connection — proving the physical split.
@@ -68,6 +69,7 @@ describe("memory database connection", () => {
     "conversation_graph_memory_state",
     "memory_v3_ever_injected",
     "memory_retrospective_state",
+    "memory_retrospective_daily_count",
     "memory_graph_nodes",
     "memory_graph_edges",
     "memory_graph_triggers",

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-daily-count.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-daily-count.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getMemorySqlite } from "../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../persistence/db-init.js";
+import {
+  getRetrospectiveDailyCount,
+  reserveDailyRetrospectiveBudget,
+  utcDayKey,
+} from "../memory-retrospective-daily-count.js";
+
+await initializeDb();
+
+const DAY1 = Date.parse("2026-07-23T12:00:00Z");
+const DAY1_LATER = Date.parse("2026-07-23T23:30:00Z"); // same UTC day as DAY1
+const DAY2 = Date.parse("2026-07-24T00:30:00Z"); // next UTC day
+
+function resetTable(): void {
+  getMemorySqlite()!.exec(`DELETE FROM memory_retrospective_daily_count`);
+}
+
+describe("utcDayKey", () => {
+  test("keys by UTC calendar day, ignoring the wall-clock time", () => {
+    expect(utcDayKey(DAY1)).toBe("2026-07-23");
+    expect(utcDayKey(DAY1_LATER)).toBe("2026-07-23");
+    expect(utcDayKey(DAY2)).toBe("2026-07-24");
+  });
+});
+
+describe("reserveDailyRetrospectiveBudget", () => {
+  beforeEach(() => {
+    resetTable();
+  });
+
+  test("allows and increments while under the cap, then skips at the cap", () => {
+    const cap = 40;
+    for (let i = 0; i < cap; i += 1) {
+      expect(reserveDailyRetrospectiveBudget(cap, DAY1)).toBe(true);
+    }
+    expect(getRetrospectiveDailyCount(DAY1)).toBe(cap);
+
+    // The 41st attempt on the same UTC day is skipped and does not record.
+    expect(reserveDailyRetrospectiveBudget(cap, DAY1_LATER)).toBe(false);
+    expect(getRetrospectiveDailyCount(DAY1)).toBe(cap);
+  });
+
+  test("a new UTC day resets the count and prunes the prior day's row", () => {
+    const cap = 40;
+    for (let i = 0; i < cap; i += 1) {
+      reserveDailyRetrospectiveBudget(cap, DAY1);
+    }
+    expect(reserveDailyRetrospectiveBudget(cap, DAY1)).toBe(false);
+
+    // First attempt on the next UTC day is allowed against a fresh count...
+    expect(reserveDailyRetrospectiveBudget(cap, DAY2)).toBe(true);
+    expect(getRetrospectiveDailyCount(DAY2)).toBe(1);
+
+    // ...and the rollover opportunistically drops the stale prior-day row.
+    expect(getRetrospectiveDailyCount(DAY1)).toBe(0);
+    const remaining = getMemorySqlite()!
+      .query<
+        { n: number },
+        []
+      >(`SELECT COUNT(*) AS n FROM memory_retrospective_daily_count`)
+      .get();
+    expect(remaining?.n).toBe(1);
+  });
+
+  test("a non-positive cap fails open without recording", () => {
+    expect(reserveDailyRetrospectiveBudget(0, DAY1)).toBe(true);
+    expect(reserveDailyRetrospectiveBudget(-5, DAY1)).toBe(true);
+    expect(getRetrospectiveDailyCount(DAY1)).toBe(0);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-daily-count.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-daily-count.test.ts
@@ -4,7 +4,8 @@ import { getMemorySqlite } from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
 import {
   getRetrospectiveDailyCount,
-  reserveDailyRetrospectiveBudget,
+  isDailyRetrospectiveBudgetExhausted,
+  recordDailyRetrospectiveRun,
   utcDayKey,
 } from "../memory-retrospective-daily-count.js";
 
@@ -26,32 +27,35 @@ describe("utcDayKey", () => {
   });
 });
 
-describe("reserveDailyRetrospectiveBudget", () => {
+describe("isDailyRetrospectiveBudgetExhausted / recordDailyRetrospectiveRun", () => {
   beforeEach(() => {
     resetTable();
   });
 
-  test("allows and increments while under the cap, then skips at the cap", () => {
+  test("stays unexhausted while under the cap, then reports exhausted at the cap", () => {
     const cap = 40;
     for (let i = 0; i < cap; i += 1) {
-      expect(reserveDailyRetrospectiveBudget(cap, DAY1)).toBe(true);
+      expect(isDailyRetrospectiveBudgetExhausted(cap, DAY1)).toBe(false);
+      recordDailyRetrospectiveRun(cap, DAY1);
     }
     expect(getRetrospectiveDailyCount(DAY1)).toBe(cap);
 
-    // The 41st attempt on the same UTC day is skipped and does not record.
-    expect(reserveDailyRetrospectiveBudget(cap, DAY1_LATER)).toBe(false);
+    // The 41st attempt on the same UTC day sees an exhausted budget and, being
+    // skipped, records nothing.
+    expect(isDailyRetrospectiveBudgetExhausted(cap, DAY1_LATER)).toBe(true);
     expect(getRetrospectiveDailyCount(DAY1)).toBe(cap);
   });
 
   test("a new UTC day resets the count and prunes the prior day's row", () => {
     const cap = 40;
     for (let i = 0; i < cap; i += 1) {
-      reserveDailyRetrospectiveBudget(cap, DAY1);
+      recordDailyRetrospectiveRun(cap, DAY1);
     }
-    expect(reserveDailyRetrospectiveBudget(cap, DAY1)).toBe(false);
+    expect(isDailyRetrospectiveBudgetExhausted(cap, DAY1)).toBe(true);
 
     // First attempt on the next UTC day is allowed against a fresh count...
-    expect(reserveDailyRetrospectiveBudget(cap, DAY2)).toBe(true);
+    expect(isDailyRetrospectiveBudgetExhausted(cap, DAY2)).toBe(false);
+    recordDailyRetrospectiveRun(cap, DAY2);
     expect(getRetrospectiveDailyCount(DAY2)).toBe(1);
 
     // ...and the rollover opportunistically drops the stale prior-day row.
@@ -65,9 +69,11 @@ describe("reserveDailyRetrospectiveBudget", () => {
     expect(remaining?.n).toBe(1);
   });
 
-  test("a non-positive cap fails open without recording", () => {
-    expect(reserveDailyRetrospectiveBudget(0, DAY1)).toBe(true);
-    expect(reserveDailyRetrospectiveBudget(-5, DAY1)).toBe(true);
+  test("a non-positive cap is never exhausted and records nothing", () => {
+    expect(isDailyRetrospectiveBudgetExhausted(0, DAY1)).toBe(false);
+    expect(isDailyRetrospectiveBudgetExhausted(-5, DAY1)).toBe(false);
+    recordDailyRetrospectiveRun(0, DAY1);
+    recordDailyRetrospectiveRun(-5, DAY1);
     expect(getRetrospectiveDailyCount(DAY1)).toBe(0);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-enqueue.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-enqueue.test.ts
@@ -44,14 +44,15 @@ describe("enqueueMemoryRetrospectiveIfEnabled", () => {
     upsertCalls.length = 0;
   });
 
-  test("standard source — interval trigger enqueues with runAfter ≈ now", () => {
+  test("standard source — interval trigger enqueues with runAfter ≈ now and reports true", () => {
     const before = Date.now();
-    enqueueMemoryRetrospectiveIfEnabled({
+    const enqueued = enqueueMemoryRetrospectiveIfEnabled({
       conversationId: "c1",
       trigger: "interval",
     });
     const after = Date.now();
 
+    expect(enqueued).toBe(true);
     expect(upsertCalls).toHaveLength(1);
     const call = upsertCalls[0]!;
     expect(call.payload).toEqual({ conversationId: "c1" });
@@ -71,41 +72,45 @@ describe("enqueueMemoryRetrospectiveIfEnabled", () => {
     expect(call.runAfter).toBeGreaterThan(before + 100);
   });
 
-  test("recursion guard — source = 'memory-retrospective' skips enqueue", () => {
+  test("recursion guard — source = 'memory-retrospective' skips enqueue and reports false", () => {
     sourceTag = "memory-retrospective";
-    enqueueMemoryRetrospectiveIfEnabled({
+    const enqueued = enqueueMemoryRetrospectiveIfEnabled({
       conversationId: "c1",
       trigger: "interval",
     });
+    expect(enqueued).toBe(false);
     expect(upsertCalls).toHaveLength(0);
   });
 
-  test("scheduled conversation — skips enqueue", () => {
+  test("scheduled conversation — skips enqueue and reports false", () => {
     convType = "scheduled";
-    enqueueMemoryRetrospectiveIfEnabled({
+    const enqueued = enqueueMemoryRetrospectiveIfEnabled({
       conversationId: "c1",
       trigger: "interval",
     });
+    expect(enqueued).toBe(false);
     expect(upsertCalls).toHaveLength(0);
   });
 
-  test("memory_v2_consolidation source — skips enqueue", () => {
+  test("memory_v2_consolidation source — skips enqueue and reports false", () => {
     convType = "background";
     convSource = "memory_v2_consolidation";
-    enqueueMemoryRetrospectiveIfEnabled({
+    const enqueued = enqueueMemoryRetrospectiveIfEnabled({
       conversationId: "c1",
       trigger: "interval",
     });
+    expect(enqueued).toBe(false);
     expect(upsertCalls).toHaveLength(0);
   });
 
-  test("heartbeat (background) source — still enqueues", () => {
+  test("heartbeat (background) source — still enqueues and reports true", () => {
     convType = "background";
     convSource = "heartbeat";
-    enqueueMemoryRetrospectiveIfEnabled({
+    const enqueued = enqueueMemoryRetrospectiveIfEnabled({
       conversationId: "c1",
       trigger: "interval",
     });
+    expect(enqueued).toBe(true);
     expect(upsertCalls).toHaveLength(1);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-enqueue.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-enqueue.test.ts
@@ -7,6 +7,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 let sourceTag: string | null = null;
 let convType = "standard";
 let convSource = "user";
+// Simulates whether the real `upsertMemoryRetrospectiveJob` inserted a NEW row
+// (true) or coalesced into an already-pending one (false). The enqueue helper
+// must propagate this verbatim so budget-metered callers only count creations.
+let upsertCreated = true;
 const upsertCalls: Array<{
   payload: { conversationId: string };
   runAfter: number;
@@ -27,6 +31,7 @@ mock.module("../../../../persistence/jobs-store.js", () => ({
     runAfter: number,
   ) => {
     upsertCalls.push({ payload, runAfter });
+    return upsertCreated;
   },
 }));
 
@@ -41,6 +46,7 @@ describe("enqueueMemoryRetrospectiveIfEnabled", () => {
     sourceTag = null;
     convType = "standard";
     convSource = "user";
+    upsertCreated = true;
     upsertCalls.length = 0;
   });
 
@@ -70,6 +76,21 @@ describe("enqueueMemoryRetrospectiveIfEnabled", () => {
     expect(upsertCalls).toHaveLength(1);
     const call = upsertCalls[0]!;
     expect(call.runAfter).toBeGreaterThan(before + 100);
+  });
+
+  test("coalesced upsert (existing pending job) — reports false even for an eligible source", () => {
+    // The source is eligible, so the upsert IS attempted, but it coalesces into
+    // an already-pending row rather than inserting a new one. The helper must
+    // report false so budget-metered callers do not count a run that cannot
+    // spawn a second retrospective.
+    upsertCreated = false;
+    const enqueued = enqueueMemoryRetrospectiveIfEnabled({
+      conversationId: "c1",
+      trigger: "interval",
+    });
+    expect(enqueued).toBe(false);
+    // The upsert still ran (the runAfter-min pull is its responsibility).
+    expect(upsertCalls).toHaveLength(1);
   });
 
   test("recursion guard — source = 'memory-retrospective' skips enqueue and reports false", () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
@@ -37,9 +37,21 @@ await initializeDb();
 
 const SWEEP_INTERVAL_MS = 8 * 60 * 60 * 1000; // 8h
 
-function makeConfig(sweepIntervalMs = SWEEP_INTERVAL_MS): AssistantConfig {
+// High enough that the trust/interval/accounting tests never trip the cap; the
+// cap-specific tests pass an explicit low value.
+const DEFAULT_MAX_RUNS_PER_DAY = 10_000;
+
+function makeConfig(
+  opts: { sweepIntervalMs?: number; maxRunsPerAssistantPerDay?: number } = {},
+): AssistantConfig {
   return {
-    memory: { retrospective: { sweepIntervalMs } },
+    memory: {
+      retrospective: {
+        sweepIntervalMs: opts.sweepIntervalMs ?? SWEEP_INTERVAL_MS,
+        maxRunsPerAssistantPerDay:
+          opts.maxRunsPerAssistantPerDay ?? DEFAULT_MAX_RUNS_PER_DAY,
+      },
+    },
   } as unknown as AssistantConfig;
 }
 
@@ -47,7 +59,20 @@ function resetTables(): void {
   const db = getDb();
   db.run(`DELETE FROM messages`);
   getMemorySqlite()!.exec(`DELETE FROM memory_retrospective_state`);
+  getMemorySqlite()!.exec(`DELETE FROM memory_retrospective_daily_count`);
   db.run(`DELETE FROM conversations`);
+}
+
+/** Pre-seed a UTC day's retrospective attempt count on the memory connection. */
+function seedDailyCount(now: number, count: number): void {
+  const dayKey = new Date(now).toISOString().slice(0, 10);
+  getMemorySqlite()!
+    .query(
+      `INSERT INTO memory_retrospective_daily_count (day_key, run_count)
+       VALUES (?, ?)
+       ON CONFLICT(day_key) DO UPDATE SET run_count = excluded.run_count`,
+    )
+    .run(dayKey, count);
 }
 
 let messageSeq = 0;
@@ -210,6 +235,42 @@ describe("runRetrospectiveSweep", () => {
     expect(enqueueCalls).toEqual([
       { conversationId: conv.id, trigger: "sweep" },
     ]);
+  });
+
+  test("at the daily cap: no conversation is swept even with unprocessed work", async () => {
+    const now = Date.now();
+    const conv = createConversation({ id: "conv-a" });
+    insertMessage(conv.id, { createdAt: 1_000 });
+    seedDailyCount(now, 40); // already at cap
+
+    const result = await runRetrospectiveSweep(
+      makeConfig({ maxRunsPerAssistantPerDay: 40 }),
+      now,
+    );
+
+    expect(enqueueCalls).toEqual([]);
+    expect(result.enqueued).toBe(0);
+  });
+
+  test("halts once the shared daily budget is exhausted mid-pass", async () => {
+    const now = Date.now();
+    // Two conversations both have unprocessed work; the budget only affords one.
+    createConversation({ id: "conv-a" });
+    insertMessage("conv-a", { createdAt: 1_000 });
+    createConversation({ id: "conv-b" });
+    insertMessage("conv-b", { createdAt: 1_000 });
+
+    const result = await runRetrospectiveSweep(
+      makeConfig({ maxRunsPerAssistantPerDay: 1 }),
+      now,
+    );
+
+    // conv-a (sorted first) takes the last unit; conv-b is left for a later
+    // pass once the budget refreshes.
+    expect(enqueueCalls).toEqual([
+      { conversationId: "conv-a", trigger: "sweep" },
+    ]);
+    expect(result.enqueued).toBe(1);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
@@ -3,13 +3,17 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // Record enqueues instead of writing job rows — the sweep's scan/gate decision
 // is the unit under test, not the jobs store's coalescing. The enqueue's own
 // recursion/low-yield guards are covered by memory-retrospective-enqueue tests.
+// `enqueueResult` simulates whether the real helper actually queued a job: a
+// source it skips returns false, and the sweep must consume no budget for it.
 let enqueueCalls: Array<{ conversationId: string; trigger: string }> = [];
+let enqueueResult = true;
 mock.module("../memory-retrospective-enqueue.js", () => ({
   enqueueMemoryRetrospectiveIfEnabled: (args: {
     conversationId: string;
     trigger: string;
   }) => {
     enqueueCalls.push(args);
+    return enqueueResult;
   },
 }));
 
@@ -75,6 +79,17 @@ function seedDailyCount(now: number, count: number): void {
     .run(dayKey, count);
 }
 
+function readDailyCount(now: number): number {
+  const dayKey = new Date(now).toISOString().slice(0, 10);
+  const row = getMemorySqlite()!
+    .query<
+      { run_count: number },
+      [string]
+    >(`SELECT run_count FROM memory_retrospective_daily_count WHERE day_key = ?`)
+    .get(dayKey);
+  return row?.run_count ?? 0;
+}
+
 let messageSeq = 0;
 function insertMessage(
   conversationId: string,
@@ -103,6 +118,7 @@ describe("runRetrospectiveSweep", () => {
   beforeEach(() => {
     resetTables();
     enqueueCalls = [];
+    enqueueResult = true;
   });
 
   test("never-run conversation with unprocessed messages is swept", async () => {
@@ -271,6 +287,46 @@ describe("runRetrospectiveSweep", () => {
       { conversationId: "conv-a", trigger: "sweep" },
     ]);
     expect(result.enqueued).toBe(1);
+  });
+
+  test("an eligible sweep enqueue consumes exactly one unit", async () => {
+    const now = Date.now();
+    const conv = createConversation({ id: "conv-a" });
+    insertMessage(conv.id, { createdAt: 1_000 });
+    seedDailyCount(now, 5);
+
+    const result = await runRetrospectiveSweep(
+      makeConfig({ maxRunsPerAssistantPerDay: 40 }),
+      now,
+    );
+
+    expect(enqueueCalls).toEqual([
+      { conversationId: conv.id, trigger: "sweep" },
+    ]);
+    expect(result.enqueued).toBe(1);
+    expect(readDailyCount(now)).toBe(6);
+  });
+
+  test("a source the enqueue helper skips consumes no budget and is not counted", async () => {
+    const now = Date.now();
+    const conv = createConversation({ id: "conv-a" });
+    insertMessage(conv.id, { createdAt: 1_000 });
+    seedDailyCount(now, 5);
+    // The enqueue is attempted (budget under cap), but the helper skips this
+    // source and queues nothing, so the day's count must not move and the sweep
+    // reports it as scanned-not-enqueued.
+    enqueueResult = false;
+
+    const result = await runRetrospectiveSweep(
+      makeConfig({ maxRunsPerAssistantPerDay: 40 }),
+      now,
+    );
+
+    expect(enqueueCalls).toEqual([
+      { conversationId: conv.id, trigger: "sweep" },
+    ]);
+    expect(result).toEqual({ scanned: 1, enqueued: 0 });
+    expect(readDailyCount(now)).toBe(5);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
@@ -307,6 +307,41 @@ describe("runRetrospectiveSweep", () => {
     expect(readDailyCount(now)).toBe(6);
   });
 
+  test("a sweep enqueue that coalesces into a pending job consumes no budget; a fresh creation after it completes consumes one", async () => {
+    const now = Date.now();
+    const conv = createConversation({ id: "conv-a" });
+    insertMessage(conv.id, { createdAt: 1_000 });
+    seedDailyCount(now, 5);
+
+    // A conversation already queued by an event trigger: the sweep's enqueue
+    // coalesces into the pending row (helper returns false). No matter how many
+    // sweep passes run while that job stays pending, none may drain the budget.
+    enqueueResult = false;
+    let result = await runRetrospectiveSweep(
+      makeConfig({ maxRunsPerAssistantPerDay: 40 }),
+      now,
+    );
+    expect(result).toEqual({ scanned: 1, enqueued: 0 });
+    expect(readDailyCount(now)).toBe(5);
+
+    result = await runRetrospectiveSweep(
+      makeConfig({ maxRunsPerAssistantPerDay: 40 }),
+      now,
+    );
+    expect(result.enqueued).toBe(0);
+    expect(readDailyCount(now)).toBe(5);
+
+    // Once that job completes, a later pass creates a genuinely new job → one
+    // unit consumed.
+    enqueueResult = true;
+    result = await runRetrospectiveSweep(
+      makeConfig({ maxRunsPerAssistantPerDay: 40 }),
+      now,
+    );
+    expect(result.enqueued).toBe(1);
+    expect(readDailyCount(now)).toBe(6);
+  });
+
   test("a source the enqueue helper skips consumes no budget and is not counted", async () => {
     const now = Date.now();
     const conv = createConversation({ id: "conv-a" });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-trigger-check.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-trigger-check.test.ts
@@ -159,9 +159,37 @@ describe("shouldEnqueueRetrospective", () => {
 function resetTables(): void {
   const db = getDb();
   db.run(`DELETE FROM messages`);
-  // `memory_retrospective_state` lives on the memory connection now.
+  // `memory_retrospective_state` and the daily-attempt counter both live on
+  // the memory connection now.
   getMemorySqlite()!.exec(`DELETE FROM memory_retrospective_state`);
+  getMemorySqlite()!.exec(`DELETE FROM memory_retrospective_daily_count`);
   db.run(`DELETE FROM conversations`);
+}
+
+/** Today's UTC day key, matching `maybeEnqueueRetrospective`'s internal clock. */
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Pre-seed today's retrospective attempt count on the memory connection. */
+function seedDailyCount(count: number): void {
+  getMemorySqlite()!
+    .query(
+      `INSERT INTO memory_retrospective_daily_count (day_key, run_count)
+       VALUES (?, ?)
+       ON CONFLICT(day_key) DO UPDATE SET run_count = excluded.run_count`,
+    )
+    .run(todayKey(), count);
+}
+
+function readDailyCount(): number {
+  const row = getMemorySqlite()!
+    .query<
+      { run_count: number },
+      [string]
+    >(`SELECT run_count FROM memory_retrospective_daily_count WHERE day_key = ?`)
+    .get(todayKey());
+  return row?.run_count ?? 0;
 }
 
 let messageSeq = 0;
@@ -199,12 +227,22 @@ function insertSkillCardMessage(
   });
 }
 
+// High enough that the accounting tests never trip the cap; the cap-specific
+// tests pass an explicit low value.
+const DEFAULT_MAX_RUNS_PER_DAY = 10_000;
+
 function makeConfig(
-  overrides: Partial<typeof THRESHOLDS> = {},
+  overrides: Partial<typeof THRESHOLDS> & {
+    maxRunsPerAssistantPerDay?: number;
+  } = {},
 ): AssistantConfig {
   return {
     memory: {
-      retrospective: { ...THRESHOLDS, ...overrides },
+      retrospective: {
+        ...THRESHOLDS,
+        maxRunsPerAssistantPerDay: DEFAULT_MAX_RUNS_PER_DAY,
+        ...overrides,
+      },
     },
   } as unknown as AssistantConfig;
 }
@@ -305,5 +343,105 @@ describe("maybeEnqueueRetrospective — kind-aware accounting", () => {
     expect(enqueueCalls).toEqual([
       { conversationId: conv.id, trigger: "interval" },
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maybeEnqueueRetrospective — daily runaway cap.
+//
+// The cap counts enqueue attempts across all conversations for the assistant in
+// a UTC day. A trigger that would otherwise fire is skipped once the day's
+// count reaches `maxRunsPerAssistantPerDay`. A firing enqueue reserves one unit
+// of the day's budget.
+// ---------------------------------------------------------------------------
+
+describe("maybeEnqueueRetrospective — daily runaway cap", () => {
+  beforeEach(() => {
+    resetTables();
+    enqueueCalls = [];
+  });
+
+  test("at the cap: a would-be trigger is skipped and the count is untouched", () => {
+    const conv = createConversation("conv");
+    insertMessage(conv.id, { createdAt: 2_000 }); // first-run interval would fire
+    seedDailyCount(40); // already at cap
+
+    maybeEnqueueRetrospective(
+      conv.id,
+      makeConfig({ maxRunsPerAssistantPerDay: 40 }),
+    );
+
+    expect(enqueueCalls).toEqual([]);
+    expect(readDailyCount()).toBe(40);
+  });
+
+  test("one below the cap: the enqueue fires and consumes the last unit", () => {
+    const conv = createConversation("conv");
+    insertMessage(conv.id, { createdAt: 2_000 });
+    seedDailyCount(39);
+
+    maybeEnqueueRetrospective(
+      conv.id,
+      makeConfig({ maxRunsPerAssistantPerDay: 40 }),
+    );
+
+    expect(enqueueCalls).toEqual([
+      { conversationId: conv.id, trigger: "interval" },
+    ]);
+    expect(readDailyCount()).toBe(40);
+
+    // A subsequent qualifying turn is now capped.
+    insertMessage(conv.id, { createdAt: 3_000 });
+    maybeEnqueueRetrospective(
+      conv.id,
+      makeConfig({ maxRunsPerAssistantPerDay: 40 }),
+    );
+    expect(enqueueCalls).toEqual([
+      { conversationId: conv.id, trigger: "interval" },
+    ]);
+    expect(readDailyCount()).toBe(40);
+  });
+
+  test("the cap spans conversations: attempts from different conversations share the budget", () => {
+    const a = createConversation("conv-a");
+    const b = createConversation("conv-b");
+    insertMessage(a.id, { createdAt: 2_000 });
+    insertMessage(b.id, { createdAt: 2_000 });
+    seedDailyCount(1);
+
+    maybeEnqueueRetrospective(
+      a.id,
+      makeConfig({ maxRunsPerAssistantPerDay: 2 }),
+    );
+    maybeEnqueueRetrospective(
+      b.id,
+      makeConfig({ maxRunsPerAssistantPerDay: 2 }),
+    );
+
+    // conv-a takes the last unit; conv-b is capped even though it is a
+    // different conversation.
+    expect(enqueueCalls).toEqual([
+      { conversationId: a.id, trigger: "interval" },
+    ]);
+    expect(readDailyCount()).toBe(2);
+  });
+
+  test("a would-be-quiet turn under the cap never touches the counter", async () => {
+    const conv = createConversation("conv");
+    const cutoff = insertMessage(conv.id, { createdAt: 1_000 });
+    // Cooldown not elapsed and no new work → no trigger, so no reservation.
+    await upsertRetrospectiveState({
+      conversationId: conv.id,
+      lastProcessedMessageId: cutoff,
+      lastRunAt: Date.now() - 60_000,
+    });
+
+    maybeEnqueueRetrospective(
+      conv.id,
+      makeConfig({ maxRunsPerAssistantPerDay: 40 }),
+    );
+
+    expect(enqueueCalls).toEqual([]);
+    expect(readDailyCount()).toBe(0);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-trigger-check.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-trigger-check.test.ts
@@ -489,4 +489,33 @@ describe("maybeEnqueueRetrospective — daily runaway cap", () => {
     ]);
     expect(readDailyCount()).toBe(6);
   });
+
+  test("a trigger that coalesces into a pending job consumes no budget; a fresh job after it completes consumes one", () => {
+    const conv = createConversation("conv");
+    insertMessage(conv.id, { createdAt: 2_000 });
+    seedDailyCount(5);
+    const config = makeConfig({ maxRunsPerAssistantPerDay: 40 });
+
+    // First qualifying turn creates the pending job → one unit consumed.
+    enqueueResult = true;
+    maybeEnqueueRetrospective(conv.id, config);
+    expect(readDailyCount()).toBe(6);
+
+    // Subsequent qualifying turns while that job is still pending only
+    // coalesce (helper returns false). A slow/stopped worker could repeat this
+    // arbitrarily many times — none of them may drain the day's budget.
+    enqueueResult = false;
+    insertMessage(conv.id, { createdAt: 3_000 });
+    maybeEnqueueRetrospective(conv.id, config);
+    insertMessage(conv.id, { createdAt: 4_000 });
+    maybeEnqueueRetrospective(conv.id, config);
+    expect(readDailyCount()).toBe(6);
+
+    // Once the pending job completes, the next turn creates a genuinely new
+    // job → one more unit consumed.
+    enqueueResult = true;
+    insertMessage(conv.id, { createdAt: 5_000 });
+    maybeEnqueueRetrospective(conv.id, config);
+    expect(readDailyCount()).toBe(7);
+  });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-trigger-check.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-trigger-check.test.ts
@@ -1,14 +1,19 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // Record enqueues instead of writing job rows — the trigger decision is the
-// unit under test here, not the jobs store's gating.
+// unit under test here, not the jobs store's gating. `enqueueResult` simulates
+// whether the real helper actually queued a job: an ineligible source (scheduled
+// thread, consolidation source, recursion guard) returns false; a normal enqueue
+// returns true. The daily budget must be consumed only on a true return.
 let enqueueCalls: Array<{ conversationId: string; trigger: string }> = [];
+let enqueueResult = true;
 mock.module("../memory-retrospective-enqueue.js", () => ({
   enqueueMemoryRetrospectiveIfEnabled: (args: {
     conversationId: string;
     trigger: string;
   }) => {
     enqueueCalls.push(args);
+    return enqueueResult;
   },
 }));
 
@@ -251,6 +256,7 @@ describe("maybeEnqueueRetrospective — kind-aware accounting", () => {
   beforeEach(() => {
     resetTables();
     enqueueCalls = [];
+    enqueueResult = true;
   });
 
   test("card-only tail past the cursor: no enqueue, even when the interval threshold has long elapsed", async () => {
@@ -359,6 +365,7 @@ describe("maybeEnqueueRetrospective — daily runaway cap", () => {
   beforeEach(() => {
     resetTables();
     enqueueCalls = [];
+    enqueueResult = true;
   });
 
   test("at the cap: a would-be trigger is skipped and the count is untouched", () => {
@@ -443,5 +450,43 @@ describe("maybeEnqueueRetrospective — daily runaway cap", () => {
 
     expect(enqueueCalls).toEqual([]);
     expect(readDailyCount()).toBe(0);
+  });
+
+  test("an ineligible source the enqueue helper skips consumes no budget", () => {
+    const conv = createConversation("conv");
+    insertMessage(conv.id, { createdAt: 2_000 }); // first-run interval fires
+    seedDailyCount(5);
+    // The trigger fires and the budget is under cap, so the enqueue is
+    // attempted — but the helper skips this source (e.g. a scheduled thread or
+    // consolidation conversation), returning false. Nothing was queued, so the
+    // day's count must not move: a stream of low-yield turns can never exhaust
+    // the budget on its own.
+    enqueueResult = false;
+
+    maybeEnqueueRetrospective(
+      conv.id,
+      makeConfig({ maxRunsPerAssistantPerDay: 40 }),
+    );
+
+    expect(enqueueCalls).toEqual([
+      { conversationId: conv.id, trigger: "interval" },
+    ]);
+    expect(readDailyCount()).toBe(5);
+  });
+
+  test("an eligible enqueue consumes exactly one unit", () => {
+    const conv = createConversation("conv");
+    insertMessage(conv.id, { createdAt: 2_000 });
+    seedDailyCount(5);
+
+    maybeEnqueueRetrospective(
+      conv.id,
+      makeConfig({ maxRunsPerAssistantPerDay: 40 }),
+    );
+
+    expect(enqueueCalls).toEqual([
+      { conversationId: conv.id, trigger: "interval" },
+    ]);
+    expect(readDailyCount()).toBe(6);
   });
 });

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-daily-count.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-daily-count.ts
@@ -3,16 +3,16 @@
 // ---------------------------------------------------------------------------
 //
 // A single assistant-wide counter, keyed by UTC date, backing the
-// `memory.retrospective.maxRunsPerAssistantPerDay` cap. Each retrospective
-// enqueue decision from the responsive path (post-turn trigger check) and the
-// timer sweep reserves one unit of the day's budget; once the day's count
-// reaches the cap those paths stop enqueuing until the next UTC day, whose
-// fresh `day_key` starts a new count with no cron needed.
+// `memory.retrospective.maxRunsPerAssistantPerDay` cap. The responsive path
+// (post-turn trigger check) and the timer sweep check the day's budget before
+// enqueuing and record one unit only after an enqueue actually lands; once the
+// day's count reaches the cap those paths stop enqueuing until the next UTC day,
+// whose fresh `day_key` starts a new count with no cron needed.
 //
 // The counter is NOT conversation-keyed — it spans every conversation — so it
 // deliberately stays out of `CONVERSATION_KEYED_MEMORY_TABLES` and survives
 // conversation deletion. Stale prior-day rows are pruned opportunistically on
-// the first reservation of each new day (see `reserveDailyRetrospectiveBudget`).
+// the first recorded run of each new day (see `recordDailyRetrospectiveRun`).
 //
 // The row lives on the dedicated memory connection (`assistant-memory.db`),
 // resolved via `memoryDbOrNull`; every read/write degrades to a no-op (and the
@@ -50,43 +50,63 @@ export function getRetrospectiveDailyCount(now: number): number {
 }
 
 /**
- * Reserve one unit of the assistant's daily retrospective budget for `now`'s
- * UTC day. Returns `true` — recording the reservation (incrementing the day's
- * count) — when the day's count is still below `maxRunsPerDay`; returns `false`
- * WITHOUT recording once the cap is reached, so a capped attempt costs nothing.
+ * Whether the assistant's daily retrospective budget for `now`'s UTC day is
+ * exhausted — its recorded count has reached `maxRunsPerDay`. Callers check this
+ * BEFORE enqueuing and skip when it returns `true`. The count is bumped
+ * separately, only after an enqueue actually lands, via
+ * `recordDailyRetrospectiveRun`, so a source the enqueue helper skips (scheduled
+ * thread, consolidation source, recursion guard) never consumes budget.
  *
- * Fail-open on every degraded path: an unavailable memory database, a
- * non-positive/non-finite cap, or a thrown SQLite error all return `true`
- * without capping, matching the memory subsystem's degrade-don't-block posture
- * (a down memory connection already fails the cooldown gate open too).
- *
- * Rolling the counter is cheap and idempotent: a primary-key upsert bumps the
- * current day's row, and a single `day_key < today` delete prunes stale rows.
- * The delete only removes anything on the first reservation of a new UTC day;
- * on every later same-day call there are no older rows, so it is a no-op.
+ * Fails open — returns `false` (not exhausted) — on every degraded path: a
+ * non-positive/non-finite cap (cap disabled), an unavailable memory database, or
+ * a thrown SQLite error, matching the memory subsystem's degrade-don't-block
+ * posture (a down memory connection already fails the cooldown gate open too).
  */
-export function reserveDailyRetrospectiveBudget(
+export function isDailyRetrospectiveBudgetExhausted(
   maxRunsPerDay: number,
   now: number,
 ): boolean {
   if (!Number.isFinite(maxRunsPerDay) || maxRunsPerDay <= 0) {
-    return true;
+    return false;
   }
-  const mdb = memoryDbOrNull("reserveDailyRetrospectiveBudget");
+  try {
+    return getRetrospectiveDailyCount(now) >= maxRunsPerDay;
+  } catch (err) {
+    log.warn(
+      { err, dayKey: utcDayKey(now) },
+      "daily retrospective budget check failed; allowing enqueue",
+    );
+    return false;
+  }
+}
+
+/**
+ * Record one retrospective enqueue against `now`'s UTC day, bumping the day's
+ * count. Call ONLY after an enqueue actually landed — a skipped or ineligible
+ * enqueue must not consume budget.
+ *
+ * No-ops on a disabled cap (non-positive/non-finite `maxRunsPerDay`) so a
+ * disabled backstop never writes rows, and degrades to a no-op on an unavailable
+ * memory database or a thrown SQLite error.
+ *
+ * Rolling the counter is cheap and idempotent: a primary-key upsert bumps the
+ * current day's row, and a single `day_key < today` delete prunes stale rows.
+ * The delete only removes anything on the first recorded run of a new UTC day;
+ * on every later same-day call there are no older rows, so it is a no-op.
+ */
+export function recordDailyRetrospectiveRun(
+  maxRunsPerDay: number,
+  now: number,
+): void {
+  if (!Number.isFinite(maxRunsPerDay) || maxRunsPerDay <= 0) {
+    return;
+  }
+  const mdb = memoryDbOrNull("recordDailyRetrospectiveRun");
   if (!mdb) {
-    return true;
+    return;
   }
   const dayKey = utcDayKey(now);
   try {
-    const row = mdb
-      .select({ runCount: memoryRetrospectiveDailyCount.runCount })
-      .from(memoryRetrospectiveDailyCount)
-      .where(eq(memoryRetrospectiveDailyCount.dayKey, dayKey))
-      .get();
-    if ((row?.runCount ?? 0) >= maxRunsPerDay) {
-      return false;
-    }
-
     mdb
       .insert(memoryRetrospectiveDailyCount)
       .values({ dayKey, runCount: 1 })
@@ -102,13 +122,10 @@ export function reserveDailyRetrospectiveBudget(
       .delete(memoryRetrospectiveDailyCount)
       .where(lt(memoryRetrospectiveDailyCount.dayKey, dayKey))
       .run();
-
-    return true;
   } catch (err) {
     log.warn(
       { err, dayKey },
-      "daily retrospective budget reservation failed; allowing enqueue",
+      "daily retrospective run recording failed; continuing",
     );
-    return true;
   }
 }

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-daily-count.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-daily-count.ts
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------
+// Memory retrospective — per-UTC-day attempt counter (runaway backstop).
+// ---------------------------------------------------------------------------
+//
+// A single assistant-wide counter, keyed by UTC date, backing the
+// `memory.retrospective.maxRunsPerAssistantPerDay` cap. Each retrospective
+// enqueue decision from the responsive path (post-turn trigger check) and the
+// timer sweep reserves one unit of the day's budget; once the day's count
+// reaches the cap those paths stop enqueuing until the next UTC day, whose
+// fresh `day_key` starts a new count with no cron needed.
+//
+// The counter is NOT conversation-keyed — it spans every conversation — so it
+// deliberately stays out of `CONVERSATION_KEYED_MEMORY_TABLES` and survives
+// conversation deletion. Stale prior-day rows are pruned opportunistically on
+// the first reservation of each new day (see `reserveDailyRetrospectiveBudget`).
+//
+// The row lives on the dedicated memory connection (`assistant-memory.db`),
+// resolved via `memoryDbOrNull`; every read/write degrades to a no-op (and the
+// cap fails open) when that connection is unavailable — a degraded memory
+// subsystem must never block the responsive path.
+
+import { eq, lt, sql } from "drizzle-orm";
+
+import { memoryRetrospectiveDailyCount } from "../../../persistence/schema/index.js";
+import { getLogger } from "./logging.js";
+import { memoryDbOrNull } from "./memory-db.js";
+
+const log = getLogger("memory-retrospective-daily-count");
+
+/** The UTC calendar-day key (`YYYY-MM-DD`) for a millisecond timestamp. */
+export function utcDayKey(now: number): string {
+  return new Date(now).toISOString().slice(0, 10);
+}
+
+/**
+ * Retrospective enqueue attempts recorded for `now`'s UTC day so far. Returns 0
+ * when no row exists yet or the memory connection is unavailable.
+ */
+export function getRetrospectiveDailyCount(now: number): number {
+  const mdb = memoryDbOrNull("getRetrospectiveDailyCount");
+  if (!mdb) {
+    return 0;
+  }
+  const row = mdb
+    .select({ runCount: memoryRetrospectiveDailyCount.runCount })
+    .from(memoryRetrospectiveDailyCount)
+    .where(eq(memoryRetrospectiveDailyCount.dayKey, utcDayKey(now)))
+    .get();
+  return row?.runCount ?? 0;
+}
+
+/**
+ * Reserve one unit of the assistant's daily retrospective budget for `now`'s
+ * UTC day. Returns `true` — recording the reservation (incrementing the day's
+ * count) — when the day's count is still below `maxRunsPerDay`; returns `false`
+ * WITHOUT recording once the cap is reached, so a capped attempt costs nothing.
+ *
+ * Fail-open on every degraded path: an unavailable memory database, a
+ * non-positive/non-finite cap, or a thrown SQLite error all return `true`
+ * without capping, matching the memory subsystem's degrade-don't-block posture
+ * (a down memory connection already fails the cooldown gate open too).
+ *
+ * Rolling the counter is cheap and idempotent: a primary-key upsert bumps the
+ * current day's row, and a single `day_key < today` delete prunes stale rows.
+ * The delete only removes anything on the first reservation of a new UTC day;
+ * on every later same-day call there are no older rows, so it is a no-op.
+ */
+export function reserveDailyRetrospectiveBudget(
+  maxRunsPerDay: number,
+  now: number,
+): boolean {
+  if (!Number.isFinite(maxRunsPerDay) || maxRunsPerDay <= 0) {
+    return true;
+  }
+  const mdb = memoryDbOrNull("reserveDailyRetrospectiveBudget");
+  if (!mdb) {
+    return true;
+  }
+  const dayKey = utcDayKey(now);
+  try {
+    const row = mdb
+      .select({ runCount: memoryRetrospectiveDailyCount.runCount })
+      .from(memoryRetrospectiveDailyCount)
+      .where(eq(memoryRetrospectiveDailyCount.dayKey, dayKey))
+      .get();
+    if ((row?.runCount ?? 0) >= maxRunsPerDay) {
+      return false;
+    }
+
+    mdb
+      .insert(memoryRetrospectiveDailyCount)
+      .values({ dayKey, runCount: 1 })
+      .onConflictDoUpdate({
+        target: memoryRetrospectiveDailyCount.dayKey,
+        set: {
+          runCount: sql`${memoryRetrospectiveDailyCount.runCount} + 1`,
+        },
+      })
+      .run();
+
+    mdb
+      .delete(memoryRetrospectiveDailyCount)
+      .where(lt(memoryRetrospectiveDailyCount.dayKey, dayKey))
+      .run();
+
+    return true;
+  } catch (err) {
+    log.warn(
+      { err, dayKey },
+      "daily retrospective budget reservation failed; allowing enqueue",
+    );
+    return true;
+  }
+}

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
@@ -47,14 +47,21 @@ export type MemoryRetrospectiveTrigger =
 
 const COMPACTION_DEBOUNCE_MS = 500;
 
+/**
+ * Enqueue a retrospective job for `conversationId`, applying the recursion and
+ * low-yield source guards. Returns `true` only when a job is actually queued —
+ * `false` on any skip (memory disabled, recursion guard, low-yield source) or an
+ * upsert failure. Budget-metered callers reserve one unit of the daily cap only
+ * on a `true` return, so a skipped source never consumes budget.
+ */
 export function enqueueMemoryRetrospectiveIfEnabled(args: {
   conversationId: string;
   trigger: MemoryRetrospectiveTrigger;
-}): void {
+}): boolean {
   const { conversationId, trigger } = args;
 
   if (!isMemoryEnabled()) {
-    return;
+    return false;
   }
 
   if (isMemoryRetrospectiveConversation(conversationId)) {
@@ -62,7 +69,7 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
       { conversationId, trigger },
       "Skipping memory-retrospective enqueue: source is a memory-retrospective conversation",
     );
-    return;
+    return false;
   }
 
   if (isLowYieldRetrospectiveSource(conversationId)) {
@@ -70,7 +77,7 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
       { conversationId, trigger },
       "Skipping memory-retrospective enqueue: scheduled or consolidation source",
     );
-    return;
+    return false;
   }
 
   const runAfter =
@@ -78,11 +85,13 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
 
   try {
     upsertMemoryRetrospectiveJob({ conversationId }, runAfter);
+    return true;
   } catch (err) {
     log.warn(
       { err, conversationId, trigger },
       "Failed to upsert memory-retrospective job",
     );
+    return false;
   }
 }
 
@@ -107,7 +116,9 @@ export function isMemoryRetrospectiveConversation(
  */
 function isLowYieldRetrospectiveSource(conversationId: string): boolean {
   const conversation = getConversation(conversationId);
-  if (!conversation) return false;
+  if (!conversation) {
+    return false;
+  }
   return (
     conversation.conversationType === "scheduled" ||
     conversation.source === MEMORY_V2_CONSOLIDATION_SOURCE

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
@@ -49,10 +49,12 @@ const COMPACTION_DEBOUNCE_MS = 500;
 
 /**
  * Enqueue a retrospective job for `conversationId`, applying the recursion and
- * low-yield source guards. Returns `true` only when a job is actually queued —
- * `false` on any skip (memory disabled, recursion guard, low-yield source) or an
- * upsert failure. Budget-metered callers reserve one unit of the daily cap only
- * on a `true` return, so a skipped source never consumes budget.
+ * low-yield source guards. Returns `true` only when a NEW pending job is
+ * created — `false` on any skip (memory disabled, recursion guard, low-yield
+ * source), an upsert failure, OR a coalesce into an already-pending row for the
+ * conversation. Budget-metered callers reserve one unit of the daily cap only
+ * on a `true` return, so neither a skipped source nor a coalesced trigger (which
+ * cannot spawn a second retrospective) consumes budget.
  */
 export function enqueueMemoryRetrospectiveIfEnabled(args: {
   conversationId: string;
@@ -84,8 +86,7 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
     trigger === "compaction" ? Date.now() + COMPACTION_DEBOUNCE_MS : Date.now();
 
   try {
-    upsertMemoryRetrospectiveJob({ conversationId }, runAfter);
-    return true;
+    return upsertMemoryRetrospectiveJob({ conversationId }, runAfter);
   } catch (err) {
     log.warn(
       { err, conversationId, trigger },

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
@@ -53,6 +53,7 @@ import { conversations } from "../../../persistence/schema/index.js";
 import { getLogger } from "./logging.js";
 import { countRetrospectiveMessagesAfter } from "./memory-retrospective-accounting.js";
 import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
+import { reserveDailyRetrospectiveBudget } from "./memory-retrospective-daily-count.js";
 import { enqueueMemoryRetrospectiveIfEnabled } from "./memory-retrospective-enqueue.js";
 import { getRetrospectiveState } from "./memory-retrospective-state.js";
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "./v3/substrate/constants.js";
@@ -155,10 +156,12 @@ export async function runRetrospectiveSweep(
     return { scanned: 0, enqueued: 0 };
   }
   const sweepIntervalMs = config.memory.retrospective.sweepIntervalMs;
+  const maxRunsPerDay = config.memory.retrospective.maxRunsPerAssistantPerDay;
 
   let scanned = 0;
   let enqueued = 0;
   let cursor = "";
+  let capReached = false;
   for (;;) {
     const page = listSweepCandidateConversationIds(cursor, SWEEP_BATCH);
     if (page.length === 0) {
@@ -196,12 +199,25 @@ export async function runRetrospectiveSweep(
         continue;
       }
 
+      // Runaway backstop: reserve one unit of the assistant's daily budget,
+      // shared with the responsive trigger-check path. Once the day is capped
+      // no further conversations can enqueue this pass, so stop scanning. The
+      // compaction path never routes through here, so it bypasses the cap.
+      if (!reserveDailyRetrospectiveBudget(maxRunsPerDay, now)) {
+        log.debug(
+          { scanned, enqueued },
+          "daily retrospective cap reached; halting sweep",
+        );
+        capReached = true;
+        break;
+      }
+
       enqueueMemoryRetrospectiveIfEnabled({ conversationId, trigger: "sweep" });
       enqueued += 1;
     }
 
     await breathe();
-    if (page.length < SWEEP_BATCH) {
+    if (capReached || page.length < SWEEP_BATCH) {
       break;
     }
   }

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
@@ -204,9 +204,10 @@ export async function runRetrospectiveSweep(
 
       // Runaway backstop: stop scanning once the assistant's daily budget
       // (shared with the responsive trigger-check path) is exhausted. The budget
-      // is consumed only when an enqueue actually lands, so a source the enqueue
-      // helper skips costs nothing. The compaction path never routes through
-      // here, so it bypasses the cap.
+      // is consumed only when a NEW pending job is created, so a source the
+      // enqueue helper skips — and a conversation already queued by an event
+      // trigger, whose sweep enqueue merely coalesces — costs nothing. The
+      // compaction path never routes through here, so it bypasses the cap.
       if (isDailyRetrospectiveBudgetExhausted(maxRunsPerDay, now)) {
         log.debug(
           { scanned, enqueued },

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
@@ -53,7 +53,10 @@ import { conversations } from "../../../persistence/schema/index.js";
 import { getLogger } from "./logging.js";
 import { countRetrospectiveMessagesAfter } from "./memory-retrospective-accounting.js";
 import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
-import { reserveDailyRetrospectiveBudget } from "./memory-retrospective-daily-count.js";
+import {
+  isDailyRetrospectiveBudgetExhausted,
+  recordDailyRetrospectiveRun,
+} from "./memory-retrospective-daily-count.js";
 import { enqueueMemoryRetrospectiveIfEnabled } from "./memory-retrospective-enqueue.js";
 import { getRetrospectiveState } from "./memory-retrospective-state.js";
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "./v3/substrate/constants.js";
@@ -199,11 +202,12 @@ export async function runRetrospectiveSweep(
         continue;
       }
 
-      // Runaway backstop: reserve one unit of the assistant's daily budget,
-      // shared with the responsive trigger-check path. Once the day is capped
-      // no further conversations can enqueue this pass, so stop scanning. The
-      // compaction path never routes through here, so it bypasses the cap.
-      if (!reserveDailyRetrospectiveBudget(maxRunsPerDay, now)) {
+      // Runaway backstop: stop scanning once the assistant's daily budget
+      // (shared with the responsive trigger-check path) is exhausted. The budget
+      // is consumed only when an enqueue actually lands, so a source the enqueue
+      // helper skips costs nothing. The compaction path never routes through
+      // here, so it bypasses the cap.
+      if (isDailyRetrospectiveBudgetExhausted(maxRunsPerDay, now)) {
         log.debug(
           { scanned, enqueued },
           "daily retrospective cap reached; halting sweep",
@@ -212,8 +216,15 @@ export async function runRetrospectiveSweep(
         break;
       }
 
-      enqueueMemoryRetrospectiveIfEnabled({ conversationId, trigger: "sweep" });
-      enqueued += 1;
+      if (
+        enqueueMemoryRetrospectiveIfEnabled({
+          conversationId,
+          trigger: "sweep",
+        })
+      ) {
+        recordDailyRetrospectiveRun(maxRunsPerDay, now);
+        enqueued += 1;
+      }
     }
 
     await breathe();

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-trigger-check.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-trigger-check.ts
@@ -24,6 +24,7 @@
 import type { AssistantConfig } from "../../../config/types.js";
 import { getLogger } from "./logging.js";
 import { countRetrospectiveMessagesAfter } from "./memory-retrospective-accounting.js";
+import { reserveDailyRetrospectiveBudget } from "./memory-retrospective-daily-count.js";
 import { enqueueMemoryRetrospectiveIfEnabled } from "./memory-retrospective-enqueue.js";
 import { getRetrospectiveState } from "./memory-retrospective-state.js";
 
@@ -53,12 +54,20 @@ export function shouldEnqueueRetrospective(args: {
     minCooldownMs,
   } = args;
 
-  if (state && now - state.lastRunAt < minCooldownMs) return null;
+  if (state && now - state.lastRunAt < minCooldownMs) {
+    return null;
+  }
 
-  if (state && now - state.lastRunAt >= timeThresholdMs) return "interval";
-  if (!state) return "interval";
+  if (state && now - state.lastRunAt >= timeThresholdMs) {
+    return "interval";
+  }
+  if (!state) {
+    return "interval";
+  }
 
-  if (newMessageCount >= messageThreshold) return "message_count";
+  if (newMessageCount >= messageThreshold) {
+    return "message_count";
+  }
   return null;
 }
 
@@ -77,17 +86,39 @@ export function maybeEnqueueRetrospective(
       conversationId,
       state?.lastProcessedMessageId ?? null,
     );
-    if (newMessageCount === 0) return;
+    if (newMessageCount === 0) {
+      return;
+    }
 
+    const now = Date.now();
     const trigger = shouldEnqueueRetrospective({
       state,
       newMessageCount,
-      now: Date.now(),
+      now,
       timeThresholdMs: config.memory.retrospective.timeThresholdMs,
       messageThreshold: config.memory.retrospective.messageThreshold,
       minCooldownMs: config.memory.retrospective.minCooldownMs,
     });
-    if (!trigger) return;
+    if (!trigger) {
+      return;
+    }
+
+    // Runaway backstop: reserve one unit of the assistant's daily budget. A
+    // capped day skips the enqueue without recording. Pre-compaction enqueues
+    // route around this path entirely, so they bypass the cap exactly as they
+    // bypass the cooldown gate above.
+    if (
+      !reserveDailyRetrospectiveBudget(
+        config.memory.retrospective.maxRunsPerAssistantPerDay,
+        now,
+      )
+    ) {
+      log.debug(
+        { conversationId, trigger },
+        "daily retrospective cap reached; skipping enqueue",
+      );
+      return;
+    }
 
     enqueueMemoryRetrospectiveIfEnabled({ conversationId, trigger });
   } catch (err) {

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-trigger-check.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-trigger-check.ts
@@ -107,9 +107,10 @@ export function maybeEnqueueRetrospective(
     }
 
     // Runaway backstop: skip once the assistant's daily budget for this UTC day
-    // is exhausted. The budget is consumed only when an enqueue actually lands
-    // (below), so a source the enqueue helper skips (scheduled thread,
-    // consolidation source, recursion guard) costs nothing. Pre-compaction
+    // is exhausted. The budget is consumed only when a NEW pending job is
+    // created (below), so a source the enqueue helper skips (scheduled thread,
+    // consolidation source, recursion guard) — and a trigger that merely
+    // coalesces into an already-pending job — costs nothing. Pre-compaction
     // enqueues route around this path entirely, so they bypass the cap exactly
     // as they bypass the cooldown gate above.
     const maxRunsPerDay = config.memory.retrospective.maxRunsPerAssistantPerDay;

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-trigger-check.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-trigger-check.ts
@@ -24,7 +24,10 @@
 import type { AssistantConfig } from "../../../config/types.js";
 import { getLogger } from "./logging.js";
 import { countRetrospectiveMessagesAfter } from "./memory-retrospective-accounting.js";
-import { reserveDailyRetrospectiveBudget } from "./memory-retrospective-daily-count.js";
+import {
+  isDailyRetrospectiveBudgetExhausted,
+  recordDailyRetrospectiveRun,
+} from "./memory-retrospective-daily-count.js";
 import { enqueueMemoryRetrospectiveIfEnabled } from "./memory-retrospective-enqueue.js";
 import { getRetrospectiveState } from "./memory-retrospective-state.js";
 
@@ -103,16 +106,14 @@ export function maybeEnqueueRetrospective(
       return;
     }
 
-    // Runaway backstop: reserve one unit of the assistant's daily budget. A
-    // capped day skips the enqueue without recording. Pre-compaction enqueues
-    // route around this path entirely, so they bypass the cap exactly as they
-    // bypass the cooldown gate above.
-    if (
-      !reserveDailyRetrospectiveBudget(
-        config.memory.retrospective.maxRunsPerAssistantPerDay,
-        now,
-      )
-    ) {
+    // Runaway backstop: skip once the assistant's daily budget for this UTC day
+    // is exhausted. The budget is consumed only when an enqueue actually lands
+    // (below), so a source the enqueue helper skips (scheduled thread,
+    // consolidation source, recursion guard) costs nothing. Pre-compaction
+    // enqueues route around this path entirely, so they bypass the cap exactly
+    // as they bypass the cooldown gate above.
+    const maxRunsPerDay = config.memory.retrospective.maxRunsPerAssistantPerDay;
+    if (isDailyRetrospectiveBudgetExhausted(maxRunsPerDay, now)) {
       log.debug(
         { conversationId, trigger },
         "daily retrospective cap reached; skipping enqueue",
@@ -120,7 +121,9 @@ export function maybeEnqueueRetrospective(
       return;
     }
 
-    enqueueMemoryRetrospectiveIfEnabled({ conversationId, trigger });
+    if (enqueueMemoryRetrospectiveIfEnabled({ conversationId, trigger })) {
+      recordDailyRetrospectiveRun(maxRunsPerDay, now);
+    }
   } catch (err) {
     log.warn({ err, conversationId }, "trigger-check failed; skipping enqueue");
   }


### PR DESCRIPTION
## Why

The memory retrospective background pass fired **58,502 times over Jul 8–22** (~$600/mo) — event count correlates 0.897 with mainAgent turn count, i.e. it effectively runs once per user turn, because the 10-message threshold is crossed by nearly every agentic turn (tool messages count). Each run pays a fixed ~21k-token fork overhead (system prompt + tools + window replay) on a Fireworks-served model with zero cache reuse, so run COUNT is the entire cost driver: less frequent runs process the same accumulated window at identical memory coverage.

Per-assistant-per-day distribution: p50 8, p90 34, p99 137, **max 2,336/day** (one runaway assistant did 3,236 runs in 13 days — the same failure family as the earlier ~1000-call remember loop).

## What

- `messageThreshold` default 10 → 25 (batches a few turns per run).
- `minCooldownMs` default 5min → 10min (pre-compaction bypass semantics unchanged).
- New `memory.retrospective.maxRunsPerAssistantPerDay` (default 40) — a runaway backstop counting enqueue attempts per UTC day across conversations, enforced at the enqueue decision in the post-turn trigger check and the timer sweep. Pre-compaction enqueues bypass the cap exactly as they already bypass the cooldown (last-chance capture before truncation). Fail-open when the memory DB is unavailable.
- Counter lives in a new `memory_retrospective_daily_count` table on the dedicated memory DB (idempotent migration 351, appended to steps); date-keyed reset, opportunistic prune, not conversation-keyed.

Estimated effect: threshold change cuts routine volume roughly in half; the cap clips only pathological tails (a 40/day cap touches p99+ assistant-days). Combined ~$300–400/mo at current volume. Existing configs pinning old thresholds keep their values (zod defaults apply only when unset; covered by a backward-compat test).

## Verification

- 55 tests across the 5 changed-feature files + 43 guard/migration/adjacent tests pass; `tsc --noEmit` clean; lint clean.
- Post-deploy: `memoryRetrospective` events/day in `telemetry.llm_usage_raw` should drop from ~3,900/day fleet-wide, with per-assistant max ≤ ~40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->