### PR TITLE
feat(subagent): iteration budget with soft wrap-up nudge and hard cap

### DIFF
--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -45,6 +45,11 @@ interface FakeConversationConfig {
    * captures partial trailing text.
    */
   onLoopStart?: () => void;
+  /**
+   * Sets `lastRunIterationBudgetReached` on the fake conversation, simulating a
+   * run that stopped by reaching its per-run LLM-call ceiling.
+   */
+  iterationBudgetReached?: boolean;
 }
 
 let nextConversationConfig: FakeConversationConfig = {};
@@ -63,6 +68,7 @@ class FakeConversation {
   subagentDeniedToolNames = new Set<string>();
   conversationType = "background";
   hasSystemPromptOverride = false;
+  lastRunIterationBudgetReached = false;
 
   private sendToClient: (msg: ServerMessage) => void;
   private readonly cfg: FakeConversationConfig;
@@ -80,6 +86,8 @@ class FakeConversation {
     this.sendToClient = sendToClient;
     this.cfg = nextConversationConfig;
     this.messages = this.cfg.messages ?? [];
+    this.lastRunIterationBudgetReached =
+      this.cfg.iterationBudgetReached ?? false;
   }
 
   updateClient(sendToClient: (msg: ServerMessage) => void) {
@@ -125,7 +133,9 @@ class FakeConversation {
           this.resolveAbort = resolve;
         });
       }
-      if (this.cfg.resolveOnAbort) return;
+      if (this.cfg.resolveOnAbort) {
+        return;
+      }
       throw new Error("aborted");
     }
     if (this.cfg.runError) {
@@ -465,6 +475,47 @@ describe("SubagentManager.spawnAndAwait", () => {
     await expect(manager.spawnAndAwait(makeConfig(), () => {})).rejects.toThrow(
       "boom",
     );
+  });
+
+  test("appends a truncation notice when a synchronous run hits its iteration budget", async () => {
+    // The synchronous caller (advisor consult, voice continuation) receives the
+    // child's text directly with no parent-injected notification, so the
+    // truncation must ride along on the returned string or it is lost entirely.
+    nextConversationConfig = {
+      iterationBudgetReached: true,
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "partial answer" }],
+        },
+      ],
+    };
+
+    const manager = new SubagentManager();
+    const text = await manager.spawnAndAwait(makeConfig(), () => {});
+
+    // The best-available text is still returned...
+    expect(text).toContain("partial answer");
+    // ...but the caller is told the run stopped early and may be incomplete.
+    expect(text).toContain("reached its iteration budget");
+    expect(text).toContain("may be incomplete");
+  });
+
+  test("returns the final text unchanged when a synchronous run stays within budget", async () => {
+    nextConversationConfig = {
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "clean answer" }],
+        },
+      ],
+    };
+
+    const manager = new SubagentManager();
+    const text = await manager.spawnAndAwait(makeConfig(), () => {});
+
+    // Uncapped runs are byte-identical — no truncation note is appended.
+    expect(text).toBe("clean answer");
   });
 });
 

--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -501,6 +501,84 @@ describe("SubagentManager.spawnAndAwait", () => {
     expect(text).toContain("may be incomplete");
   });
 
+  test("inlines the final tool output for a capped synchronous run (not just the stale preamble)", async () => {
+    // A capped run breaks the loop right after appending the final iteration's
+    // tool results, so the trailing assistant text is only the pre-tool
+    // preamble. The last real work lives in the trailing tool-result message —
+    // the async path recovers it via the read pointer, but the synchronous
+    // caller has no such round-trip, so it must ride along on the returned text.
+    nextConversationConfig = {
+      iterationBudgetReached: true,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "I'll inspect the logs next" },
+            { type: "tool_use", id: "t1", name: "read_file", input: {} },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t1",
+              content: "LOG LINE: the last real work the subagent did",
+              is_error: false,
+            },
+          ],
+        },
+      ],
+    };
+
+    const manager = new SubagentManager();
+    const text = await manager.spawnAndAwait(makeConfig(), () => {});
+
+    // The final iteration's tool output — the run's last real work — is present.
+    expect(text).toContain("LOG LINE: the last real work the subagent did");
+    // The preamble is preserved alongside it, not presented as the whole result.
+    expect(text).toContain("I'll inspect the logs next");
+    // And the caller is told the run stopped early and may be incomplete.
+    expect(text).toContain("reached its iteration budget");
+    expect(text).toContain("may be incomplete");
+  });
+
+  test("bounds an oversized inlined tool output on the synchronous capped path", async () => {
+    const big = "X".repeat(5_000);
+    nextConversationConfig = {
+      iterationBudgetReached: true,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "preamble" },
+            { type: "tool_use", id: "t1", name: "read_file", input: {} },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t1",
+              content: big,
+              is_error: false,
+            },
+          ],
+        },
+      ],
+    };
+
+    const manager = new SubagentManager();
+    const text = await manager.spawnAndAwait(makeConfig(), () => {});
+
+    // Bounded to the 4000-char head; the wording reports the truncation honestly.
+    expect(text).toContain("truncated to the first 4000 characters");
+    expect(text).toContain("X".repeat(4_000));
+    expect(text).not.toContain("X".repeat(4_001));
+    expect(text).toContain("reached its iteration budget");
+  });
+
   test("returns the final text unchanged when a synchronous run stays within budget", async () => {
     nextConversationConfig = {
       messages: [

--- a/assistant/src/__tests__/subagent-terminal-message.test.ts
+++ b/assistant/src/__tests__/subagent-terminal-message.test.ts
@@ -147,7 +147,7 @@ describe("buildSubagentTerminalMessage", () => {
     expect(msg).not.toContain("re-spawn");
   });
 
-  test("routes a budget-capped run to the read pointer instead of inlining stale preamble", () => {
+  test("inlines the final tool output for a budget-capped run instead of the stale preamble", () => {
     const msg = buildSubagentTerminalMessage({
       label: "long-run",
       subagentId: "sa-10",
@@ -159,17 +159,101 @@ describe("buildSubagentTerminalMessage", () => {
       // stale snapshot that hides the last iteration's output.
       finalText: "I'll inspect the config next...",
       iterationBudgetReached: true,
+      // The last real work lives in the trailing tool-result message.
+      finalToolResultText: "CONFIG: port=8080\nmode=prod",
     });
 
     // The stale preamble must NOT be presented as the result.
     expect(msg).not.toContain("I'll inspect the config next");
-    // Instead the parent is pointed at the latest child output (which includes
-    // the final iteration's tool results)...
+    // The parent reaches the final iteration's tool output directly — this is
+    // the content subagent_read (assistant messages only) cannot surface.
+    expect(msg).toContain("CONFIG: port=8080");
+    expect(msg).toContain("final iteration's tool output");
+    expect(msg).not.toContain("truncated"); // short output — not truncated
+    // The read pointer is retained for the earlier assistant history...
     expect(msg).toContain('subagent_read with subagent_id "sa-10"');
-    // ...and told the run was truncated so it can continue rather than treating
-    // the output as final.
+    expect(msg).toContain("earlier assistant messages");
+    // ...and the run is flagged as truncated so the parent can continue.
     expect(msg).toContain("reached its iteration budget");
     expect(msg).toContain("may be incomplete");
+    expect(msg).toContain("re-spawn it to continue");
+  });
+
+  test("bounds an oversized inlined tool output and says it truncated", () => {
+    const big = "X".repeat(5_000);
+    const msg = buildSubagentTerminalMessage({
+      label: "long-run",
+      subagentId: "sa-10b",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "preamble",
+      iterationBudgetReached: true,
+      finalToolResultText: big,
+    });
+
+    // Bounded to the head; the note reports the exact budget honestly.
+    expect(msg).toContain("truncated to the first 4000 characters");
+    expect(msg).toContain("X".repeat(4_000));
+    expect(msg).not.toContain("X".repeat(4_001));
+    expect(msg).toContain('subagent_read with subagent_id "sa-10b"');
+    expect(msg).toContain("re-spawn it to continue");
+  });
+
+  test("fork capped-run inline points read at last_n: 1 and can stay internal", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "fork-run",
+      subagentId: "sa-10c",
+      isFork: true,
+      outcome: "completed",
+      silent: true,
+      finalText: "I'll keep going...",
+      iterationBudgetReached: true,
+      finalToolResultText: "partial fork findings",
+    });
+
+    expect(msg).toContain("partial fork findings");
+    expect(msg).toContain(
+      'subagent_read with subagent_id "sa-10c" and last_n: 1',
+    );
+    expect(msg).toContain("Keep the result internal.");
+  });
+
+  test("a queued follow-up still defers a capped run to the read pointer, not the tool output", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "interactive-cap",
+      subagentId: "sa-10d",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "stale preamble",
+      iterationBudgetReached: true,
+      finalToolResultText: "tool output that is also stale",
+      deferred: true,
+    });
+
+    // A draining follow-up turn supersedes both the preamble and this snapshot.
+    expect(msg).not.toContain("tool output that is also stale");
+    expect(msg).toContain("Queued follow-up guidance is still being processed");
+    expect(msg).toContain('subagent_read with subagent_id "sa-10d"');
+  });
+
+  test("falls back to the read pointer when a capped run left no tool output", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "long-empty-tools",
+      subagentId: "sa-10e",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "I'll inspect next...",
+      iterationBudgetReached: true,
+      // No trailing tool-result content to inline.
+      finalToolResultText: "   ",
+    });
+
+    expect(msg).not.toContain("I'll inspect next");
+    expect(msg).toContain('subagent_read with subagent_id "sa-10e"');
+    expect(msg).toContain("reached its iteration budget");
     expect(msg).toContain("re-spawn it to continue");
   });
 
@@ -199,5 +283,33 @@ describe("buildSubagentTerminalMessage", () => {
     });
 
     expect(msg).not.toContain("iteration budget");
+  });
+
+  test("normal completion output is byte-identical (unaffected by the capped-run path)", () => {
+    const opts = {
+      label: "research-pricing",
+      subagentId: "sa-1",
+      isFork: false as const,
+      outcome: "completed" as const,
+      silent: false,
+      finalText: "Competitor X charges $20/mo.",
+    };
+
+    const msg = buildSubagentTerminalMessage(opts);
+
+    // Frozen expectation: the inline-completion wording must not drift when the
+    // budget-capped tool-output path is added.
+    expect(msg).toBe(
+      '[Subagent "research-pricing" completed — result below]\n\n' +
+        "Competitor X charges $20/mo.\n\n" +
+        "(Incorporate this into your reply to the user as appropriate.)",
+    );
+
+    // A stray finalToolResultText can never leak into a non-capped completion.
+    const withToolText = buildSubagentTerminalMessage({
+      ...opts,
+      finalToolResultText: "should be ignored",
+    });
+    expect(withToolText).toBe(msg);
   });
 });

--- a/assistant/src/__tests__/subagent-terminal-message.test.ts
+++ b/assistant/src/__tests__/subagent-terminal-message.test.ts
@@ -146,4 +146,52 @@ describe("buildSubagentTerminalMessage", () => {
     expect(msg).not.toContain("does not permit");
     expect(msg).not.toContain("re-spawn");
   });
+
+  test("appends a truncation notice when the run reached its iteration budget", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "long-run",
+      subagentId: "sa-10",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "Partial progress so far.",
+      iterationBudgetReached: true,
+    });
+
+    // The partial result is still inlined for the parent to use...
+    expect(msg).toContain("Partial progress so far.");
+    // ...but flagged as possibly incomplete with a respawn hint so the parent
+    // can continue rather than treating it as final.
+    expect(msg).toContain("reached its iteration budget");
+    expect(msg).toContain("may be incomplete");
+    expect(msg).toContain("re-spawn it to continue");
+  });
+
+  test("attaches the truncation notice to the read-pointer path too", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "long-empty",
+      subagentId: "sa-11",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "   ",
+      iterationBudgetReached: true,
+    });
+
+    expect(msg).toContain('subagent_read with subagent_id "sa-11"');
+    expect(msg).toContain("reached its iteration budget");
+  });
+
+  test("omits the truncation notice on a normally-completed run", () => {
+    const msg = buildSubagentTerminalMessage({
+      label: "normal",
+      subagentId: "sa-12",
+      isFork: false,
+      outcome: "completed",
+      silent: false,
+      finalText: "Done cleanly.",
+    });
+
+    expect(msg).not.toContain("iteration budget");
+  });
 });

--- a/assistant/src/__tests__/subagent-terminal-message.test.ts
+++ b/assistant/src/__tests__/subagent-terminal-message.test.ts
@@ -147,21 +147,27 @@ describe("buildSubagentTerminalMessage", () => {
     expect(msg).not.toContain("re-spawn");
   });
 
-  test("appends a truncation notice when the run reached its iteration budget", () => {
+  test("routes a budget-capped run to the read pointer instead of inlining stale preamble", () => {
     const msg = buildSubagentTerminalMessage({
       label: "long-run",
       subagentId: "sa-10",
       isFork: false,
       outcome: "completed",
       silent: false,
-      finalText: "Partial progress so far.",
+      // When the hard cap fires, the loop stops after appending the final tool
+      // results, so the trailing assistant text is the pre-tool preamble — a
+      // stale snapshot that hides the last iteration's output.
+      finalText: "I'll inspect the config next...",
       iterationBudgetReached: true,
     });
 
-    // The partial result is still inlined for the parent to use...
-    expect(msg).toContain("Partial progress so far.");
-    // ...but flagged as possibly incomplete with a respawn hint so the parent
-    // can continue rather than treating it as final.
+    // The stale preamble must NOT be presented as the result.
+    expect(msg).not.toContain("I'll inspect the config next");
+    // Instead the parent is pointed at the latest child output (which includes
+    // the final iteration's tool results)...
+    expect(msg).toContain('subagent_read with subagent_id "sa-10"');
+    // ...and told the run was truncated so it can continue rather than treating
+    // the output as final.
     expect(msg).toContain("reached its iteration budget");
     expect(msg).toContain("may be incomplete");
     expect(msg).toContain("re-spawn it to continue");

--- a/assistant/src/agent/loop-iteration-budget-retry.test.ts
+++ b/assistant/src/agent/loop-iteration-budget-retry.test.ts
@@ -1,0 +1,277 @@
+/**
+ * The iteration-budget hard cap is evaluated at the top of each loop iteration,
+ * before the provider call. A retryable failure of the cap-th provider call
+ * (context-overflow reduction or a post-model-call history repair) re-enters the
+ * loop to recover — but its `llm_call_started` row is still pending and its real
+ * error is unresolved. If the cap fired at that re-entry it would strand the
+ * empty row and swallow the error as a clean `iteration_budget_reached`.
+ *
+ * These tests drive the REAL loop (mocking only the provider boundary) and prove
+ * the cap bounds NEW work only: a pending retry runs first, then either the run
+ * completes / the cap stops cleanly, or the failure surfaces as the failure it
+ * is. The overflow path reuses the capturing-manager harness from
+ * `agent-loop-compaction-strip.test.ts`; the repair path registers a
+ * post-model-call recovery hook.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { ScriptedResponse } from "../__tests__/helpers/mock-provider.js";
+import { createMockProvider } from "../__tests__/helpers/mock-provider.js";
+import type { ContextWindowConfig } from "../config/types.js";
+import { HOOKS } from "../plugin-api/constants.js";
+import type { PostModelCallContext } from "../plugin-api/types.js";
+import {
+  createContextWindowManager,
+  disposeContextWindowManager,
+  getContextWindowManager,
+} from "../plugins/defaults/compaction/manager-store.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type {
+  ContentBlock,
+  Message,
+  Provider,
+  ProviderResponse,
+} from "../providers/types.js";
+import { ContextOverflowError } from "../providers/types.js";
+import type { AgentEvent } from "./loop.js";
+import { AgentLoop } from "./loop.js";
+
+const endTurn = (text: string): ProviderResponse => ({
+  content: [{ type: "text", text }],
+  model: "mock-model",
+  usage: { inputTokens: 1, outputTokens: 1 },
+  stopReason: "end_turn",
+});
+
+const toolUseTurn = (id: string): ProviderResponse => ({
+  content: [
+    { type: "text", text: "working" },
+    { type: "tool_use", id, name: "noop", input: {} },
+  ],
+  model: "mock-model",
+  usage: { inputTokens: 1, outputTokens: 1 },
+  stopReason: "tool_use",
+});
+
+const overflowError = (): ContextOverflowError =>
+  new ContextOverflowError("prompt too long", "mock", {
+    actualTokens: 999_999,
+  });
+
+function makeLoop(responses: ScriptedResponse[], conversationId: string) {
+  const { provider, calls } = createMockProvider(responses);
+  const loop = new AgentLoop({
+    provider,
+    systemPrompt: "sys",
+    conversationId,
+    tools: [
+      { name: "noop", description: "", input_schema: { type: "object" } },
+    ],
+    toolExecutor: async (name) => ({ content: `ran ${name}`, isError: false }),
+  });
+  return { loop, calls };
+}
+
+const baseRun = {
+  requestId: "req-budget-retry",
+  callSite: "subagentSpawn" as const,
+  trust: { sourceChannel: "vellum" as const, trustClass: "unknown" as const },
+};
+
+/** Options that arm the loop's overflow-recovery ladder. */
+const overflowRun = {
+  modelProfileKey: "balanced",
+  compactInPlace: false as const,
+  resolveContextWindow: () => ({
+    maxInputTokens: 10,
+    overflowRecovery: { enabled: true, safetyMarginRatio: 0 },
+  }),
+};
+
+/**
+ * Register a per-conversation manager whose `recoverContextOverflow` returns the
+ * history unchanged and reports the given `exhausted` state, so the loop's
+ * overflow branch can drive without real summarization. Records how many times
+ * recovery ran.
+ */
+function installRecoveryManager(
+  conversationId: string,
+  opts: { exhausted: boolean },
+): { recoveryCount: () => number } {
+  createContextWindowManager({
+    provider: { name: "mock-provider" } as unknown as Provider,
+    config: {} as unknown as ContextWindowConfig,
+    conversationId,
+  });
+  const manager = getContextWindowManager(conversationId);
+  let recoveries = 0;
+  if (manager) {
+    manager.recoverContextOverflow = (async (messages: Message[]) => {
+      recoveries += 1;
+      return { messages, compacted: true, exhausted: opts.exhausted };
+    }) as unknown as typeof manager.recoverContextOverflow;
+  }
+  return { recoveryCount: () => recoveries };
+}
+
+function exitReasonOf(events: AgentEvent[]): string | undefined {
+  const exit = events.find((e) => e.type === "agent_loop_exit");
+  return exit && exit.type === "agent_loop_exit" ? exit.reason : undefined;
+}
+
+function historyHasAssistantText(history: Message[], text: string): boolean {
+  return history.some(
+    (m) =>
+      m.role === "assistant" &&
+      (m.content as ContentBlock[]).some(
+        (b) => b.type === "text" && b.text === text,
+      ),
+  );
+}
+
+describe("AgentLoop — iteration budget vs. retryable failure at the cap", () => {
+  beforeEach(() => {
+    // Isolate from any globally-registered plugin hooks; the loop's compaction
+    // re-injection and tool-result hooks fail open when none are present.
+    resetPluginRegistryForTests();
+  });
+  afterEach(() => {
+    disposeContextWindowManager("overflow-recover");
+    disposeContextWindowManager("overflow-exhausted");
+    resetPluginRegistryForTests();
+  });
+
+  test("an overflow rejection AT the cap runs its recovery, then the cap stops cleanly", async () => {
+    // maxCallsPerRun = 2. Call 1 is a tool turn; call 2 (the cap-th) is
+    // rejected as context-too-large; the recovery re-issues as call 3 (a tool
+    // turn that completes). The cap then stops at the next clean boundary.
+    const conversationId = "overflow-recover";
+    const { loop, calls } = makeLoop(
+      [
+        toolUseTurn("t1"),
+        overflowError(),
+        toolUseTurn("t2"),
+        toolUseTurn("t3"),
+      ],
+      conversationId,
+    );
+    const recovery = installRecoveryManager(conversationId, {
+      exhausted: false,
+    });
+
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run({
+      ...baseRun,
+      ...overflowRun,
+      onEvent: (event) => {
+        events.push(event);
+      },
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      iterationBudget: { softNudgeAtCalls: 10, maxCallsPerRun: 2 },
+    });
+
+    // The recovery ran once and the re-issued call (call 3) was actually made —
+    // the cap did NOT truncate the in-flight recovery.
+    expect(recovery.recoveryCount()).toBe(1);
+    expect(calls.length).toBe(3);
+    // The recovered call's assistant output is finalized in history, not stranded.
+    expect(historyHasAssistantText(history, "working")).toBe(true);
+    // The overflow was recovered, not surfaced as a hard error.
+    expect(events.some((e) => e.type === "error")).toBe(false);
+    // Only after the recovery completed did the cap stop the run — cleanly.
+    expect(exitReasonOf(events)).toBe("iteration_budget_reached");
+  });
+
+  test("an UNRECOVERABLE overflow at the cap surfaces as the failure, not a clean budget stop", async () => {
+    // The recovery ladder is exhausted, so the re-issued call (call 3) rejects
+    // again with no rung left. The loop must surface the overflow as the
+    // terminal it is — NOT convert it into `iteration_budget_reached`.
+    const conversationId = "overflow-exhausted";
+    const { loop, calls } = makeLoop(
+      [toolUseTurn("t1"), overflowError(), overflowError()],
+      conversationId,
+    );
+    const recovery = installRecoveryManager(conversationId, {
+      exhausted: true,
+    });
+
+    const events: AgentEvent[] = [];
+    await loop.run({
+      ...baseRun,
+      ...overflowRun,
+      onEvent: (event) => {
+        events.push(event);
+      },
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      iterationBudget: { softNudgeAtCalls: 10, maxCallsPerRun: 2 },
+    });
+
+    // Recovery was attempted and the retry (call 3) was made past the cap...
+    expect(recovery.recoveryCount()).toBe(1);
+    expect(calls.length).toBe(3);
+    // ...and the real overflow failure surfaces as its own terminal — the cap
+    // did not swallow it into a clean `iteration_budget_reached`.
+    expect(exitReasonOf(events)).toBe("context_too_large");
+    // Each rejected provider call was logged as a provider_error, not hidden.
+    expect(events.filter((e) => e.type === "provider_error").length).toBe(2);
+  });
+});
+
+describe("AgentLoop — iteration budget vs. post-model-call repair at the cap", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+  });
+  afterEach(() => {
+    resetPluginRegistryForTests();
+  });
+
+  test("a post-model-call repair AT the cap runs its retry to completion", async () => {
+    // A hook that, on a provider rejection, repairs the history and asks the
+    // loop to retry. maxCallsPerRun = 2: call 1 is a tool turn, call 2 (the
+    // cap-th) is a plain rejection the hook recovers, and call 3 completes.
+    registerPlugin({
+      manifest: { name: "test-repair", version: "0.0.0" },
+      hooks: {
+        [HOOKS.POST_MODEL_CALL]: async (ctx: PostModelCallContext) => {
+          // Only act on a provider rejection; finalized replies pass through.
+          if (ctx.error) {
+            ctx.decision = "continue";
+            ctx.messages = [...ctx.messages];
+          }
+        },
+      },
+    });
+
+    const conversationId = "repair-at-cap";
+    const { loop, calls } = makeLoop(
+      [
+        toolUseTurn("t1"),
+        new Error("transient provider rejection"),
+        endTurn("recovered and done"),
+      ],
+      conversationId,
+    );
+
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run({
+      ...baseRun,
+      onEvent: (event) => {
+        events.push(event);
+      },
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      iterationBudget: { softNudgeAtCalls: 10, maxCallsPerRun: 2 },
+    });
+
+    // The repaired retry (call 3) was actually issued — the cap did not stop the
+    // run at the pending, unfinalized failed call.
+    expect(calls.length).toBe(3);
+    // The run reached a genuine completion, not a swallowed budget stop.
+    expect(exitReasonOf(events)).toBe("no_tool_calls");
+    expect(historyHasAssistantText(history, "recovered and done")).toBe(true);
+    // The rejection was recovered, so no terminal error surfaced.
+    expect(events.some((e) => e.type === "error")).toBe(false);
+  });
+});

--- a/assistant/src/agent/loop-iteration-budget.test.ts
+++ b/assistant/src/agent/loop-iteration-budget.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Verifies the per-run iteration governor the loop applies to unattended
+ * (subagent) runs: a one-time wrap-up nudge at the soft threshold, and a
+ * graceful stop with the `iteration_budget_reached` exit reason at the hard
+ * cap. Drives the REAL loop, mocking only the provider boundary — the same
+ * pattern as `loop-exclusive-tool.test.ts`.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { createMockProvider } from "../__tests__/helpers/mock-provider.js";
+import type {
+  ContentBlock,
+  Message,
+  ProviderResponse,
+} from "../providers/types.js";
+import type { AgentEvent } from "./loop.js";
+import { AgentLoop } from "./loop.js";
+
+const NUDGE_MARKER = "ITERATION BUDGET NOTICE";
+
+const endTurn = (text: string): ProviderResponse => ({
+  content: [{ type: "text", text }],
+  model: "mock-model",
+  usage: { inputTokens: 1, outputTokens: 1 },
+  stopReason: "end_turn",
+});
+
+const toolUseTurn = (id: string): ProviderResponse => ({
+  content: [
+    { type: "text", text: "working" },
+    { type: "tool_use", id, name: "noop", input: {} },
+  ],
+  model: "mock-model",
+  usage: { inputTokens: 1, outputTokens: 1 },
+  stopReason: "tool_use",
+});
+
+/** Count how many text blocks across the history carry the nudge marker. */
+function countNudges(history: Message[]): number {
+  let count = 0;
+  for (const message of history) {
+    for (const block of message.content as ContentBlock[]) {
+      if (block.type === "text" && block.text.includes(NUDGE_MARKER)) {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+function makeLoop(responses: ProviderResponse[], conversationId: string) {
+  const { provider, calls } = createMockProvider(responses);
+  const loop = new AgentLoop({
+    provider,
+    systemPrompt: "sys",
+    conversationId,
+    tools: [
+      { name: "noop", description: "", input_schema: { type: "object" } },
+    ],
+    toolExecutor: async (name) => ({ content: `ran ${name}`, isError: false }),
+  });
+  return { loop, calls };
+}
+
+const baseRun = {
+  requestId: "req-budget",
+  callSite: "subagentSpawn" as const,
+  trust: { sourceChannel: "vellum" as const, trustClass: "unknown" as const },
+};
+
+describe("AgentLoop — per-run iteration budget", () => {
+  test("injects the wrap-up nudge exactly once when the soft threshold is crossed", async () => {
+    // Four tool-use turns then a natural end. Soft nudge at 3 fires after the
+    // third call; the run finishes on its own well under the cap.
+    const { loop, calls } = makeLoop(
+      [
+        toolUseTurn("t1"),
+        toolUseTurn("t2"),
+        toolUseTurn("t3"),
+        toolUseTurn("t4"),
+        endTurn("done"),
+      ],
+      "budget-soft",
+    );
+
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run({
+      ...baseRun,
+      onEvent: (event) => {
+        events.push(event);
+      },
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      iterationBudget: { softNudgeAtCalls: 3, maxCallsPerRun: 100 },
+    });
+
+    // The nudge appears exactly once, even though two further calls followed it.
+    expect(countNudges(history)).toBe(1);
+    // The run ended naturally (the model stopped calling tools), not by the cap.
+    expect(calls.length).toBe(5);
+    const exit = events.find((e) => e.type === "agent_loop_exit");
+    expect(exit && exit.type === "agent_loop_exit" && exit.reason).toBe(
+      "no_tool_calls",
+    );
+  });
+
+  test("stops gracefully at the hard cap with the iteration_budget_reached reason", async () => {
+    // A provider that always requests a tool would loop forever; the cap stops
+    // it. The mock repeats its last scripted response once exhausted.
+    const { loop, calls } = makeLoop([toolUseTurn("loop")], "budget-hard");
+
+    const events: AgentEvent[] = [];
+    // No throw — a capped run is a normal completion.
+    const { history } = await loop.run({
+      ...baseRun,
+      onEvent: (event) => {
+        events.push(event);
+      },
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      iterationBudget: { softNudgeAtCalls: 3, maxCallsPerRun: 5 },
+    });
+
+    // Exactly `maxCallsPerRun` provider calls were made — no more.
+    expect(calls.length).toBe(5);
+    // The terminal exit reason marks the budget stop.
+    const exit = events.find((e) => e.type === "agent_loop_exit");
+    expect(exit && exit.type === "agent_loop_exit" && exit.reason).toBe(
+      "iteration_budget_reached",
+    );
+    // The soft nudge (3 < 5) still fired once on the way to the cap.
+    expect(countNudges(history)).toBe(1);
+    // The agent's last output is preserved in the returned history.
+    expect(
+      history.some(
+        (m) =>
+          m.role === "assistant" &&
+          (m.content as ContentBlock[]).some(
+            (b) => b.type === "text" && b.text === "working",
+          ),
+      ),
+    ).toBe(true);
+  });
+
+  test("leaves a run under the soft threshold untouched", async () => {
+    const { loop, calls } = makeLoop(
+      [toolUseTurn("t1"), toolUseTurn("t2"), endTurn("done")],
+      "budget-under",
+    );
+
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run({
+      ...baseRun,
+      onEvent: (event) => {
+        events.push(event);
+      },
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      iterationBudget: { softNudgeAtCalls: 60, maxCallsPerRun: 100 },
+    });
+
+    // No nudge, normal completion, no budget exit.
+    expect(countNudges(history)).toBe(0);
+    expect(calls.length).toBe(3);
+    const exit = events.find((e) => e.type === "agent_loop_exit");
+    expect(exit && exit.type === "agent_loop_exit" && exit.reason).toBe(
+      "no_tool_calls",
+    );
+  });
+
+  test("does not govern a run with no iteration budget configured", async () => {
+    // Same always-tool provider as the hard-cap test, but with no budget: the
+    // script exhausts into a terminating endTurn so the run still ends. The
+    // point is that no nudge is injected and no budget exit is emitted.
+    const { loop } = makeLoop(
+      [toolUseTurn("t1"), toolUseTurn("t2"), endTurn("done")],
+      "budget-off",
+    );
+
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run({
+      ...baseRun,
+      onEvent: (event) => {
+        events.push(event);
+      },
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+    });
+
+    expect(countNudges(history)).toBe(0);
+    const exit = events.find((e) => e.type === "agent_loop_exit");
+    expect(exit && exit.type === "agent_loop_exit" && exit.reason).not.toBe(
+      "iteration_budget_reached",
+    );
+  });
+
+  test("honors a tighter configured cap (governor reads the passed thresholds)", async () => {
+    // A cap of 2 proves the loop honors whatever budget it is handed rather
+    // than any hardcoded ceiling.
+    const { loop, calls } = makeLoop([toolUseTurn("loop")], "budget-custom");
+
+    const events: AgentEvent[] = [];
+    await loop.run({
+      ...baseRun,
+      onEvent: (event) => {
+        events.push(event);
+      },
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      iterationBudget: { softNudgeAtCalls: 1, maxCallsPerRun: 2 },
+    });
+
+    expect(calls.length).toBe(2);
+    const exit = events.find((e) => e.type === "agent_loop_exit");
+    expect(exit && exit.type === "agent_loop_exit" && exit.reason).toBe(
+      "iteration_budget_reached",
+    );
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1061,6 +1061,14 @@ export class AgentLoop {
     const iterationBudget = options.iterationBudget;
     let llmCallCount = 0;
     let iterationBudgetNudged = false;
+    // Set at a retry/repair re-entry (overflow reduction, post-model-call
+    // repair, or a discarded-reply re-query) to mark that the NEXT iteration is
+    // recovering a provider call already counted this run — its `llm_call_started`
+    // reservation is still pending, not finalized. The hard cap consults it so it
+    // never truncates recovery of an already-started call: the cap bounds NEW
+    // work, so a pending retry runs to completion (or surfaces its failure)
+    // first. Consumed (reset) at the top of every iteration.
+    let pendingProviderCallRetry = false;
     let exitReason: ExitReason | null = null;
     // Armed at the end of a tool-use iteration so the budget gate runs at the
     // top of the NEXT iteration — before that iteration's provider call —
@@ -1196,6 +1204,14 @@ export class AgentLoop {
         break;
       }
 
+      // Consume the retry marker for this iteration. When set, the previous
+      // provider call failed (or its reply was discarded) on a retryable path
+      // and this trip is its recovery — its reserved assistant row is still
+      // pending. Reset before the cap check so the flag suspends the cap for
+      // exactly this one recovery iteration.
+      const retryingPreviousCall = pendingProviderCallRetry;
+      pendingProviderCallRetry = false;
+
       // ── Iteration-budget hard cap ─────────────────────────────────
       // A subagent run that has already made `maxCallsPerRun` provider calls
       // stops here — before issuing another — so cost is bounded. The prior
@@ -1203,7 +1219,23 @@ export class AgentLoop {
       // normal completion (`iteration_budget_reached`), and the parent-facing
       // truncation notice is attached by the subagent manager off this exit
       // reason. Inert when no budget is configured (interactive turns).
-      if (iterationBudget && llmCallCount >= iterationBudget.maxCallsPerRun) {
+      //
+      // The cap bounds NEW work only. A retry/repair re-entry
+      // (`retryingPreviousCall`) is recovering a call already counted this run
+      // whose `llm_call_started` row is still pending — the overflow reduction
+      // ladder, a post-model-call history repair, or a discarded-reply re-query.
+      // Stopping here would strand that empty row and swallow the provider's real
+      // error as a clean `iteration_budget_reached`. So a pending retry always
+      // runs first: it either completes (finalizing the row) and lets a later
+      // clean boundary trip the cap, or surfaces its failure as the failure it
+      // is. That retry may push `llmCallCount` one past the cap; accepting one
+      // extra call is the cost of never truncating recovery of an already-started
+      // call, and the retry mechanisms carry their own independent ceilings.
+      if (
+        iterationBudget &&
+        llmCallCount >= iterationBudget.maxCallsPerRun &&
+        !retryingPreviousCall
+      ) {
         rlog.warn(
           {
             turn: toolUseTurns,
@@ -2061,6 +2093,10 @@ export class AgentLoop {
               "post-model-call requested a retry — re-querying the model",
             );
             history = postModelCallMessages;
+            // This re-query discards the reply without finalizing its reserved
+            // row, so the next trip is recovering an already-counted call — the
+            // hard cap must let it run rather than strand the empty row.
+            pendingProviderCallRetry = true;
             continue;
           } else {
             rlog.warn(
@@ -2495,6 +2531,10 @@ export class AgentLoop {
             isInteractive: !isNonInteractive,
           };
           budgetGateArmed = true;
+          // The provider rejected this call; the next trip reduces context and
+          // re-issues it. That is recovery of an already-counted call whose
+          // reserved row is still pending, so the hard cap must not truncate it.
+          pendingProviderCallRetry = true;
           rlog.warn(
             {
               turn: toolUseTurns,
@@ -2553,6 +2593,11 @@ export class AgentLoop {
             // onto the new array; the repaired history is the base the retry's
             // output appends after.
             newMessagesStart = history.length;
+            // The provider call failed and the hook repaired the history to
+            // re-issue it, so the next trip is recovering an already-counted
+            // call whose reserved row is still pending — the hard cap must let it
+            // run rather than convert the rejection into a clean budget stop.
+            pendingProviderCallRetry = true;
             continue;
           }
         }

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -623,6 +623,17 @@ interface AgentLoopRunOptionsBase {
     mark(name: string): void;
     markFirstToken(kind: "thinking" | "text"): void;
   };
+  /**
+   * Per-run LLM-call governor for unattended runs (subagent spawns). When set,
+   * the loop injects a one-time wrap-up nudge into the history once
+   * `softNudgeAtCalls` provider calls have been made, and stops the run
+   * gracefully with the {@link AgentLoopExitReason} `iteration_budget_reached`
+   * once `maxCallsPerRun` calls have been made. It is a cost backstop: a run
+   * that never stops re-reads its full accumulated context on every late call,
+   * so cost grows super-linearly. Omitted for interactive turns, which stay
+   * uncapped.
+   */
+  iterationBudget?: { softNudgeAtCalls: number; maxCallsPerRun: number };
 }
 
 interface AgentLoopRunOptionsWithContextWindow extends AgentLoopRunOptionsBase {
@@ -708,6 +719,28 @@ function deferredForExclusiveMessage(exclusiveToolName: string): string {
     `(not run: \`${exclusiveToolName}\` was called this turn and runs first, on its own, ` +
     `so the rest of your tool calls were held back. Read its output, then call this tool ` +
     `again if it is still the right next step.)`
+  );
+}
+
+/**
+ * One-time wrap-up directive appended to a tool-result message once a run has
+ * used most of its per-run iteration budget (see
+ * {@link AgentLoopRunOptionsBase.iterationBudget}). Phrased as a system
+ * directive so the model treats it as a hard signal to stop exploring and
+ * return its best final answer before the hard cap ends the run.
+ */
+function iterationBudgetNudgeMessage(
+  callsSoFar: number,
+  maxCallsPerRun: number,
+): string {
+  return (
+    "⎯⎯⎯ ITERATION BUDGET NOTICE ⎯⎯⎯\n" +
+    `You have made ${callsSoFar} tool-use iterations on this task and are approaching ` +
+    `the hard limit of ${maxCallsPerRun}. Stop exploring now and return your best final ` +
+    "answer with what you have gathered so far. If the task is genuinely incomplete, say " +
+    "so explicitly and summarize your progress and what remains, so it can be continued in " +
+    "a fresh run.\n" +
+    "⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯"
   );
 }
 
@@ -1021,6 +1054,13 @@ export class AgentLoop {
     let toolUseTurns = 0;
     let postModelCallContinues = 0;
     let lastLlmCallTime = 0;
+    // Per-run LLM-call governor (subagent spawns). `llmCallCount` counts every
+    // provider call attempted this run; the hard cap ends the run before the
+    // (maxCallsPerRun + 1)th call, and the soft nudge fires once. Both are inert
+    // when `options.iterationBudget` is absent (interactive turns).
+    const iterationBudget = options.iterationBudget;
+    let llmCallCount = 0;
+    let iterationBudgetNudged = false;
     let exitReason: ExitReason | null = null;
     // Armed at the end of a tool-use iteration so the budget gate runs at the
     // top of the NEXT iteration — before that iteration's provider call —
@@ -1153,6 +1193,26 @@ export class AgentLoop {
     while (true) {
       if (signal?.aborted) {
         await stopTurn("aborted_pre_call");
+        break;
+      }
+
+      // ── Iteration-budget hard cap ─────────────────────────────────
+      // A subagent run that has already made `maxCallsPerRun` provider calls
+      // stops here — before issuing another — so cost is bounded. The prior
+      // iteration's assistant output is already in `history`; the run ends as a
+      // normal completion (`iteration_budget_reached`), and the parent-facing
+      // truncation notice is attached by the subagent manager off this exit
+      // reason. Inert when no budget is configured (interactive turns).
+      if (iterationBudget && llmCallCount >= iterationBudget.maxCallsPerRun) {
+        rlog.warn(
+          {
+            turn: toolUseTurns,
+            llmCallCount,
+            maxCallsPerRun: iterationBudget.maxCallsPerRun,
+          },
+          "Iteration budget reached — stopping the run gracefully",
+        );
+        await stopTurn("iteration_budget_reached");
         break;
       }
 
@@ -1687,6 +1747,10 @@ export class AgentLoop {
         // Latency: the request is about to leave for the provider. The span
         // from here to the first streamed token is time-to-first-token.
         latencyTracker?.mark("request_sent");
+        // Count the call for the per-run iteration budget. Incremented at the
+        // send site so retries (overflow recovery, post-model-call re-query)
+        // each count as the real provider calls they are.
+        llmCallCount++;
         let response: ProviderResponse;
         try {
           response = await traceAsyncSection("agent-loop:provider-send", () =>
@@ -2301,6 +2365,34 @@ export class AgentLoop {
         // guidance while the client-facing and persisted tool output stay the
         // tool's actual result.
         resultBlocks.push(...additionalContextBlocks);
+
+        // ── Iteration-budget soft nudge ───────────────────────────────
+        // Once a subagent run crosses `softNudgeAtCalls`, append a one-time
+        // wrap-up directive to this tool-result message so the next provider
+        // call reads it inline and returns its best result before the hard cap
+        // ends the run. Fires exactly once per run; inert without a budget.
+        if (
+          iterationBudget &&
+          !iterationBudgetNudged &&
+          llmCallCount >= iterationBudget.softNudgeAtCalls
+        ) {
+          iterationBudgetNudged = true;
+          resultBlocks.push({
+            type: "text",
+            text: iterationBudgetNudgeMessage(
+              llmCallCount,
+              iterationBudget.maxCallsPerRun,
+            ),
+          });
+          rlog.info(
+            {
+              turn: toolUseTurns,
+              llmCallCount,
+              softNudgeAtCalls: iterationBudget.softNudgeAtCalls,
+            },
+            "Injected iteration-budget wrap-up nudge",
+          );
+        }
 
         // Add tool results as a user message and continue the loop.
         history.push({ role: "user", content: resultBlocks });

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -53,6 +53,7 @@ import {
 import { SecretDetectionConfigSchema } from "./schemas/security.js";
 import { ServicesSchema } from "./schemas/services.js";
 import { SkillsConfigSchema } from "./schemas/skills.js";
+import { SubagentConfigSchema } from "./schemas/subagent.js";
 import {
   RateLimitConfigSchema,
   TimeoutConfigSchema,
@@ -128,6 +129,7 @@ export const AssistantConfigSchema = z.object({
   ),
   ui: UiConfigSchema.default(UiConfigSchema.parse({})),
   tools: ToolsConfigSchema.default(ToolsConfigSchema.parse({})),
+  subagent: SubagentConfigSchema.default(SubagentConfigSchema.parse({})),
   workflows: WorkflowsConfigSchema.default(WorkflowsConfigSchema.parse({})),
   // Per-plugin config blocks keyed by plugin name. The schema is intentionally
   // permissive — each plugin's manifest supplies its own validator which the

--- a/assistant/src/config/schemas/__tests__/subagent.test.ts
+++ b/assistant/src/config/schemas/__tests__/subagent.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+import { SubagentConfigSchema } from "../subagent.js";
+
+describe("SubagentConfigSchema", () => {
+  test("defaults the iteration budget to soft 60 / hard 100", () => {
+    expect(SubagentConfigSchema.parse({})).toEqual({
+      softNudgeAtCalls: 60,
+      maxCallsPerRun: 100,
+    });
+  });
+
+  test("honors explicit threshold overrides", () => {
+    expect(
+      SubagentConfigSchema.parse({ softNudgeAtCalls: 40, maxCallsPerRun: 80 }),
+    ).toEqual({ softNudgeAtCalls: 40, maxCallsPerRun: 80 });
+  });
+
+  test("allows soft threshold equal to the hard cap", () => {
+    expect(
+      SubagentConfigSchema.parse({ softNudgeAtCalls: 50, maxCallsPerRun: 50 }),
+    ).toEqual({ softNudgeAtCalls: 50, maxCallsPerRun: 50 });
+  });
+
+  test("rejects a soft threshold above the hard cap", () => {
+    expect(() =>
+      SubagentConfigSchema.parse({
+        softNudgeAtCalls: 120,
+        maxCallsPerRun: 100,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects non-positive thresholds", () => {
+    expect(() => SubagentConfigSchema.parse({ maxCallsPerRun: 0 })).toThrow();
+    expect(() =>
+      SubagentConfigSchema.parse({ softNudgeAtCalls: -1 }),
+    ).toThrow();
+  });
+
+  test("rejects non-integer thresholds", () => {
+    expect(() =>
+      SubagentConfigSchema.parse({ maxCallsPerRun: 100.5 }),
+    ).toThrow();
+  });
+});

--- a/assistant/src/config/schemas/subagent.ts
+++ b/assistant/src/config/schemas/subagent.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+/**
+ * Per-run iteration budget for subagent spawns.
+ *
+ * A subagent runs as an unattended background conversation whose tool-use loop
+ * iterates LLM calls on its own. Late iterations carry the full accumulated
+ * context, so a run that never stops re-reads a large cache on every call and
+ * its cost grows super-linearly. Production data (Jul 2026) put the per-spawn
+ * call count at p50 9, p90 36, p99 ~115, with a worst-case single spawn making
+ * 293 calls that read 65.8M cache tokens ($15.99). These thresholds bound that
+ * tail: a one-time soft nudge asks the agent to wrap up, and a hard cap ends the
+ * run gracefully with a truncation notice so the parent can respawn to continue.
+ */
+export const SubagentConfigSchema = z
+  .object({
+    softNudgeAtCalls: z
+      .number({ error: "subagent.softNudgeAtCalls must be a number" })
+      .int("subagent.softNudgeAtCalls must be an integer")
+      .positive("subagent.softNudgeAtCalls must be a positive integer")
+      .default(60)
+      .describe(
+        "LLM-call count within one subagent run at which a one-time wrap-up nudge is injected into the loop, telling the agent its iteration budget is nearly exhausted and it should return its best result now. Must be <= maxCallsPerRun. p99 of production subagent runs is ~115 calls, so a soft nudge at 60 lands well before the cap for the runaway tail while leaving typical runs (p50 9, p90 36) untouched.",
+      ),
+    maxCallsPerRun: z
+      .number({ error: "subagent.maxCallsPerRun must be a number" })
+      .int("subagent.maxCallsPerRun must be an integer")
+      .positive("subagent.maxCallsPerRun must be a positive integer")
+      .default(100)
+      .describe(
+        "Hard ceiling on LLM calls within one subagent run. When reached, the loop stops gracefully — the run completes with whatever the agent last produced plus a truncation notice so the parent can respawn to continue. A cost backstop, not a normal exit: p99 of production runs is ~115 calls and the extreme tail reached 293 calls in one spawn ($15.99), so 100 bounds cost while leaving typical runs (p50 9, p90 36) untouched.",
+      ),
+  })
+  .describe(
+    "Per-run iteration budget for subagent spawns (soft wrap-up nudge + hard cap as a cost backstop).",
+  )
+  .superRefine((config, ctx) => {
+    if (config.softNudgeAtCalls > config.maxCallsPerRun) {
+      // Emit on both fields so the loader's delete-and-retry strips both sides
+      // in one pass rather than cascading to a full-defaults reset.
+      const message =
+        "subagent.softNudgeAtCalls must be <= subagent.maxCallsPerRun";
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["softNudgeAtCalls"],
+        message,
+      });
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["maxCallsPerRun"],
+        message,
+      });
+    }
+  });
+
+export type SubagentConfig = z.infer<typeof SubagentConfigSchema>;

--- a/assistant/src/config/schemas/subagent.ts
+++ b/assistant/src/config/schemas/subagent.ts
@@ -6,11 +6,10 @@ import { z } from "zod";
  * A subagent runs as an unattended background conversation whose tool-use loop
  * iterates LLM calls on its own. Late iterations carry the full accumulated
  * context, so a run that never stops re-reads a large cache on every call and
- * its cost grows super-linearly. Production data (Jul 2026) put the per-spawn
- * call count at p50 9, p90 36, p99 ~115, with a worst-case single spawn making
- * 293 calls that read 65.8M cache tokens ($15.99). These thresholds bound that
- * tail: a one-time soft nudge asks the agent to wrap up, and a hard cap ends the
- * run gracefully with a truncation notice so the parent can respawn to continue.
+ * its cost grows super-linearly. These thresholds bound that tail: a one-time
+ * soft nudge asks the agent to wrap up, and a hard cap ends the run gracefully
+ * with a truncation notice so the parent can respawn to continue. The defaults
+ * leave typical deep work untouched and clip only pathological tails.
  */
 export const SubagentConfigSchema = z
   .object({
@@ -20,7 +19,7 @@ export const SubagentConfigSchema = z
       .positive("subagent.softNudgeAtCalls must be a positive integer")
       .default(60)
       .describe(
-        "LLM-call count within one subagent run at which a one-time wrap-up nudge is injected into the loop, telling the agent its iteration budget is nearly exhausted and it should return its best result now. Must be <= maxCallsPerRun. p99 of production subagent runs is ~115 calls, so a soft nudge at 60 lands well before the cap for the runaway tail while leaving typical runs (p50 9, p90 36) untouched.",
+        "LLM-call count within one subagent run at which a one-time wrap-up nudge is injected into the loop, telling the agent its iteration budget is nearly exhausted and it should return its best result now. Must be <= maxCallsPerRun. The soft threshold warns a long-running run to conclude before it reaches the hard cap, while leaving typical deep work untouched.",
       ),
     maxCallsPerRun: z
       .number({ error: "subagent.maxCallsPerRun must be a number" })
@@ -28,7 +27,7 @@ export const SubagentConfigSchema = z
       .positive("subagent.maxCallsPerRun must be a positive integer")
       .default(100)
       .describe(
-        "Hard ceiling on LLM calls within one subagent run. When reached, the loop stops gracefully — the run completes with whatever the agent last produced plus a truncation notice so the parent can respawn to continue. A cost backstop, not a normal exit: p99 of production runs is ~115 calls and the extreme tail reached 293 calls in one spawn ($15.99), so 100 bounds cost while leaving typical runs (p50 9, p90 36) untouched.",
+        "Hard ceiling on LLM calls within one subagent run. When reached, the loop stops gracefully — the run completes with whatever the agent last produced plus a truncation notice so the parent can respawn to continue. A cost backstop bounding an unattended run, not a normal exit: it clips only pathological tails while leaving typical deep work untouched.",
       ),
   })
   .describe(

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -596,6 +596,9 @@ export async function runAgentLoopImpl(
 
   ctx.lastAssistantAttachments = [];
   ctx.lastAttachmentWarnings = [];
+  // Cleared per run so a reused subagent conversation (a queued follow-up turn)
+  // doesn't inherit the prior run's iteration-budget verdict.
+  ctx.lastRunIterationBudgetReached = false;
 
   startToolProfilingRequest(ctx.conversationId);
   let turnStarted = false;
@@ -1008,6 +1011,16 @@ export async function runAgentLoopImpl(
     const eventHandler = (event: AgentEvent): Promise<void> => {
       if (
         event.type === "agent_loop_exit" &&
+        event.reason === "iteration_budget_reached"
+      ) {
+        // The subagent run hit its per-run LLM-call cap. Flag it on the
+        // conversation so the subagent manager attaches a truncation notice to
+        // the parent-facing terminal message after the run resolves; still
+        // dispatch below so the DB row is stamped with the exit reason.
+        ctx.lastRunIterationBudgetReached = true;
+      }
+      if (
+        event.type === "agent_loop_exit" &&
         (event.reason === "context_too_large" ||
           event.reason === "budget_yield_unrecovered")
       ) {
@@ -1053,6 +1066,20 @@ export async function runAgentLoopImpl(
     const loopTrust =
       ctx.currentTurnTrustContext ?? ctx.trustContext ?? FALLBACK_TURN_TRUST;
 
+    // Per-run iteration budget, applied only to subagent spawns — the
+    // unattended runs whose tool-use loop can iterate LLM calls without a human
+    // in the loop. `subagentSpawn` is the exclusive call site for those runs
+    // (`resolveTurnCallSite` keeps subagent conversations on it), so gating here
+    // leaves interactive `mainAgent` turns and other background call sites
+    // (heartbeat, memory consolidation) uncapped.
+    const subagentIterationBudget =
+      turnCallSite === "subagentSpawn"
+        ? {
+            softNudgeAtCalls: config.subagent.softNudgeAtCalls,
+            maxCallsPerRun: config.subagent.maxCallsPerRun,
+          }
+        : undefined;
+
     /**
      * Shared closure: runs the agent loop with the wrapper's turn context and
      * maps the loop's returned checkpoint pause-reason into the wrapper's yield
@@ -1085,6 +1112,9 @@ export async function runAgentLoopImpl(
           isNonInteractive,
           modelProfileKey,
           latencyTracker,
+          ...(subagentIterationBudget
+            ? { iterationBudget: subagentIterationBudget }
+            : {}),
           ...(ctx.modelOverride ? { model: ctx.modelOverride } : {}),
         }),
         abortController.signal,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -354,6 +354,15 @@ export class Conversation {
    */
   subagentDeniedToolNames = new Set<string>();
   /**
+   * True when the most recent agent-loop run ended by reaching the subagent
+   * per-run LLM-call ceiling (`subagent.maxCallsPerRun`), exiting with
+   * `iteration_budget_reached`. Read by the subagent manager after the run
+   * resolves so it attaches a truncation notice to the parent-facing terminal
+   * message. Reset at the start of every run. Ephemeral, never persisted.
+   * @internal
+   */
+  lastRunIterationBudgetReached = false;
+  /**
    * How {@link subagentAllowedTools} is enforced — see
    * {@link SubagentToolGateMode}. Set and restored alongside the allowlist
    * by `scopeWakeAllowedTools`.

--- a/assistant/src/hooks/types.ts
+++ b/assistant/src/hooks/types.ts
@@ -389,6 +389,13 @@ export type AgentLoopExitReason =
   | "budget_yield_unrecovered"
   /** Provider stopped because the configured output-token limit was reached. */
   | "max_tokens_reached"
+  /**
+   * A subagent run reached its configured per-run LLM-call ceiling
+   * (`subagent.maxCallsPerRun`) and the loop stopped gracefully as a cost
+   * backstop. The run completes normally with the agent's last output plus a
+   * truncation notice surfaced to the parent — not an error path.
+   */
+  | "iteration_budget_reached"
   /** User cancellation landed after a non-terminal checkpoint yield. */
   | "aborted_after_checkpoint"
   /** User cancellation observed while the catch handler synthesized an error turn. */

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -133,13 +133,34 @@ export function buildSubagentSystemPrompt(
 }
 
 /**
+ * The parent-facing note appended when a subagent run stopped by reaching its
+ * per-run LLM-call ceiling (`subagent.maxCallsPerRun`). Shared by the async
+ * terminal-message path (`buildSubagentTerminalMessage`) and the synchronous
+ * `spawnAndAwait` return, so both surfaces carry the identical truncation
+ * signal. Path-agnostic wording ("its output") so it reads correctly whether it
+ * trails inlined text or a `subagent_read` pointer.
+ */
+function iterationBudgetTruncationNote(isFork: boolean): string {
+  const noun = isFork ? "fork" : "subagent";
+  return (
+    `\n\nNote: this ${noun} reached its iteration budget and was stopped before ` +
+    `it signaled completion — its output may be incomplete. If more work is ` +
+    `needed, re-spawn it to continue from here.`
+  );
+}
+
+/**
  * Build the message injected into the parent conversation when a subagent
  * reaches a terminal state.
  *
  * For a completed subagent the final synthesis is inlined directly, so the
  * parent acts on the result without a `subagent_read` round-trip and has
  * nothing left to re-spawn. The `subagent_read` pointer survives only as a
- * fallback for the rare run that ends with no trailing assistant text.
+ * fallback for the rare run that ends with no trailing assistant text, or when
+ * the run was stopped at its iteration budget — where the trailing assistant
+ * text is a pre-tool preamble, so the parent must read the latest child output
+ * (including the final iteration's tool results) rather than act on the stale
+ * snapshot.
  *
  * Exported for unit testing.
  */
@@ -180,7 +201,7 @@ export function buildSubagentTerminalMessage(opts: {
   // partial answer. Tell the parent explicitly so it can decide whether to
   // respawn the subagent to continue rather than treating the output as final.
   const truncationNote = iterationBudgetReached
-    ? `\n\nNote: this ${prefix.toLowerCase()} reached its iteration budget and was stopped before it signaled completion — the result above may be incomplete. If more work is needed, re-spawn it to continue from here.`
+    ? iterationBudgetTruncationNote(isFork)
     : "";
 
   // When the subagent reached for tools its role does not permit, tell the
@@ -201,7 +222,12 @@ export function buildSubagentTerminalMessage(opts: {
   }
 
   const trimmed = finalText?.trim() ?? "";
-  if (trimmed && !deferred) {
+  // A budget-capped run breaks the loop after appending the final iteration's
+  // tool results, so the trailing assistant text is the pre-tool preamble — a
+  // stale snapshot that hides the last iteration's output. Force such runs onto
+  // the read-pointer path so the parent retrieves the actual latest output via
+  // `subagent_read` instead of acting on the preamble.
+  if (trimmed && !deferred && !iterationBudgetReached) {
     return (
       `[${prefix} "${label}" completed — result below]\n\n` +
       `${trimmed}\n\n` +
@@ -213,13 +239,16 @@ export function buildSubagentTerminalMessage(opts: {
     );
   }
 
-  // Read-pointer path: either the run left no trailing assistant text to inline,
-  // or a queued follow-up turn is still draining — so the current synthesis is a
-  // stale snapshot and the parent should read the latest output instead.
+  // Read-pointer path: the run left no trailing assistant text to inline, a
+  // queued follow-up turn is still draining, or the run was stopped at its
+  // iteration budget — in each case the trailing text is a stale snapshot and
+  // the parent should read the latest output instead.
   const lastN = isFork ? " and last_n: 1" : "";
   const reason = deferred
     ? `Queued follow-up guidance is still being processed`
-    : `The ${prefix.toLowerCase()} produced no final text`;
+    : iterationBudgetReached
+      ? `The ${prefix.toLowerCase()} was stopped at its iteration budget`
+      : `The ${prefix.toLowerCase()} produced no final text`;
   return (
     `[${prefix} "${label}" completed]\n\n` +
     `${reason}. Use subagent_read with subagent_id "${subagentId}"${lastN} for the latest output.` +
@@ -839,6 +868,13 @@ export class SubagentManager {
             deniedTools,
             iterationBudgetReached,
           );
+        } else if (iterationBudgetReached) {
+          // The synchronous caller (advisor consult, voice continuation)
+          // receives this text directly instead of a parent-injected
+          // notification, so append the same truncation note here — otherwise a
+          // capped run returns a possibly-partial answer with no indication it
+          // stopped early.
+          finalText += iterationBudgetTruncationNote(managed.state.isFork);
         }
       }
     } catch (err) {

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -155,6 +155,12 @@ export function buildSubagentTerminalMessage(opts: {
   deferred?: boolean;
   /** Tools the subagent attempted but that its role allowlist denied. */
   deniedTools?: string[];
+  /**
+   * The run stopped by reaching its per-run LLM-call ceiling
+   * (`subagent.maxCallsPerRun`), so the result is whatever it had produced when
+   * the budget ran out — potentially incomplete.
+   */
+  iterationBudgetReached?: boolean;
 }): string {
   const {
     label,
@@ -166,8 +172,16 @@ export function buildSubagentTerminalMessage(opts: {
     error,
     deferred,
     deniedTools,
+    iterationBudgetReached,
   } = opts;
   const prefix = isFork ? "Fork" : "Subagent";
+
+  // The run hit its iteration budget and stopped early, so the result may be a
+  // partial answer. Tell the parent explicitly so it can decide whether to
+  // respawn the subagent to continue rather than treating the output as final.
+  const truncationNote = iterationBudgetReached
+    ? `\n\nNote: this ${prefix.toLowerCase()} reached its iteration budget and was stopped before it signaled completion — the result above may be incomplete. If more work is needed, re-spawn it to continue from here.`
+    : "";
 
   // When the subagent reached for tools its role does not permit, tell the
   // parent so it re-spawns with a capable role instead of blindly retrying (a
@@ -194,7 +208,8 @@ export function buildSubagentTerminalMessage(opts: {
       (silent
         ? `(Use these findings internally; do not relay the raw ${prefix.toLowerCase()} output to the user.)`
         : `(Incorporate this into your reply to the user as appropriate.)`) +
-      deniedNote
+      deniedNote +
+      truncationNote
     );
   }
 
@@ -209,7 +224,8 @@ export function buildSubagentTerminalMessage(opts: {
     `[${prefix} "${label}" completed]\n\n` +
     `${reason}. Use subagent_read with subagent_id "${subagentId}"${lastN} for the latest output.` +
     (silent ? ` Keep the result internal.` : ``) +
-    deniedNote
+    deniedNote +
+    truncationNote
   );
 }
 
@@ -798,6 +814,10 @@ export class SubagentManager {
       // Capture any tools the subagent reached for but its role denied, before a
       // release nulls the conversation reference, so we can tell the parent.
       const deniedTools = [...conversation.subagentDeniedToolNames];
+      // Whether the run stopped by reaching its per-run LLM-call ceiling. Read
+      // before a release nulls the conversation reference so the parent-facing
+      // terminal message can carry a truncation notice.
+      const iterationBudgetReached = conversation.lastRunIterationBudgetReached;
       // Copy usage stats from the conversation before sending status (which includes usage).
       managed.state.usage = { ...conversation.usageStats };
       // Only update state + notify if still non-terminal (guards against abort race).
@@ -805,7 +825,7 @@ export class SubagentManager {
         managed.state.completedAt = Date.now();
         this.setStatus(subagentId, "completed", getSender());
 
-        log.info({ subagentId }, "Subagent completed");
+        log.info({ subagentId, iterationBudgetReached }, "Subagent completed");
 
         // Notify the parent conversation, inlining the subagent's final
         // synthesis so the LLM acts on the result without a subagent_read
@@ -817,6 +837,7 @@ export class SubagentManager {
             "completed",
             finalText,
             deniedTools,
+            iterationBudgetReached,
           );
         }
       }
@@ -1429,6 +1450,7 @@ export class SubagentManager {
     outcome: "completed" | "failed",
     finalText?: string,
     deniedTools?: string[],
+    iterationBudgetReached?: boolean,
   ): void {
     const { config } = managed.state;
     const isFork = managed.state.isFork;
@@ -1450,6 +1472,7 @@ export class SubagentManager {
       // read pointer so the parent picks up the queued turn's output instead.
       deferred: managed.hadEnqueuedMessages === true,
       deniedTools,
+      iterationBudgetReached,
     });
 
     const notification: SubagentNotificationInfo = {

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -115,6 +115,9 @@ function extractTrailingToolResultText(messages: Message[]): string {
   }
   const parts: string[] = [];
   for (const block of last.content) {
+    if (block.type === "web_search_tool_result") {
+      continue; // provider-encrypted payload — nothing inlineable
+    }
     if (block.type === "tool_result" && block.content.trim()) {
       parts.push(block.content);
     }

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -141,6 +141,37 @@ function truncateInlinedToolResult(text: string): {
 }
 
 /**
+ * Compose the text a synchronous `spawnAndAwait` caller receives for a
+ * budget-capped run. A capped run breaks the tool-use loop right after appending
+ * the final iteration's tool results, so `preamble` (the trailing assistant
+ * text) is only the pre-tool snapshot — the last real work lives in the trailing
+ * tool-result message. The synchronous caller gets the child's text directly
+ * with no `subagent_read` round-trip, so a bounded excerpt of that tool output
+ * is inlined after the preamble (mirroring the async terminal-message path). A
+ * tool-less run (the advisor consult) has no trailing tool output, so the
+ * preamble is returned unchanged. The shared truncation note is appended by the
+ * caller.
+ */
+function inlineCappedSyncToolOutput(
+  preamble: string,
+  finalToolResultText: string | undefined,
+): string {
+  const trimmedToolResult = finalToolResultText?.trim() ?? "";
+  if (!trimmedToolResult) {
+    return preamble;
+  }
+  const excerpt = truncateInlinedToolResult(trimmedToolResult);
+  const truncatedClause = excerpt.truncated
+    ? ` (truncated to the first ${MAX_INLINED_TOOL_RESULT_CHARS} characters)`
+    : "";
+  const trimmedPreamble = preamble.trim();
+  return (
+    (trimmedPreamble ? `${trimmedPreamble}\n\n` : "") +
+    `Final tool output${truncatedClause}:\n\n${excerpt.text}`
+  );
+}
+
+/**
  * Pull the user-visible text out of a streaming delta event, or null for any
  * other event type. Used by the synchronous `onText` tap to forward
  * `assistant_text_delta` / `assistant_thinking_delta` chunks to the caller.
@@ -971,10 +1002,16 @@ export class SubagentManager {
         } else if (iterationBudgetReached) {
           // The synchronous caller (advisor consult, voice continuation)
           // receives this text directly instead of a parent-injected
-          // notification, so append the same truncation note here — otherwise a
-          // capped run returns a possibly-partial answer with no indication it
-          // stopped early.
-          finalText += iterationBudgetTruncationNote(managed.state.isFork);
+          // notification. A capped run breaks the loop after appending the final
+          // iteration's tool results, so `finalText` is only the pre-tool
+          // preamble — the last real work is stranded in the trailing
+          // tool-result message. Inline a bounded excerpt of it (the async path
+          // does the same via `finalToolResultText`; the read pointer that path
+          // relies on is unavailable here), then append the same truncation note
+          // so the caller knows the run stopped early and may be incomplete.
+          finalText =
+            inlineCappedSyncToolOutput(finalText, finalToolResultText) +
+            iterationBudgetTruncationNote(managed.state.isFork);
         }
       }
     } catch (err) {

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -36,6 +36,7 @@ import type { Message, TextContent } from "../providers/types.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import { getSandboxWorkingDir } from "../util/platform.js";
+import { safeStringSlice } from "../util/unicode.js";
 import { injectMessageIntoParent } from "./notify.js";
 import {
   SUBAGENT_LIMITS,
@@ -88,6 +89,55 @@ function extractFinalAssistantText(messages: Message[]): string {
       .join("");
   }
   return "";
+}
+
+/**
+ * Byte-ish budget for the final-tool-result excerpt inlined into a
+ * budget-capped run's terminal message. Bounds how much of the last
+ * iteration's tool output is copied into the parent conversation; the rest is
+ * recovered by re-spawning to continue (the excerpt is not retrievable via
+ * `subagent_read`, which returns only the assistant-text history).
+ */
+const MAX_INLINED_TOOL_RESULT_CHARS = 4_000;
+
+/**
+ * Concatenate the text of the `tool_result` blocks in the conversation's
+ * trailing message. A budget-capped run breaks the tool-use loop right after
+ * appending the final iteration's tool results as a user-role message, so the
+ * trailing assistant message is only the pre-tool preamble — this recovers that
+ * last real work so it can be inlined into the parent terminal message. Returns
+ * an empty string when the trailing message carries no tool results.
+ */
+function extractTrailingToolResultText(messages: Message[]): string {
+  const last = messages[messages.length - 1];
+  if (!last) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const block of last.content) {
+    if (block.type === "tool_result" && block.content.trim()) {
+      parts.push(block.content);
+    }
+  }
+  return parts.join("\n\n");
+}
+
+/**
+ * Bound an inlined tool-result excerpt to {@link MAX_INLINED_TOOL_RESULT_CHARS},
+ * keeping the head (the tool's first output) and never splitting a surrogate
+ * pair. Reports whether it truncated so the caller's note can say so accurately.
+ */
+function truncateInlinedToolResult(text: string): {
+  text: string;
+  truncated: boolean;
+} {
+  if (text.length <= MAX_INLINED_TOOL_RESULT_CHARS) {
+    return { text, truncated: false };
+  }
+  return {
+    text: safeStringSlice(text, 0, MAX_INLINED_TOOL_RESULT_CHARS),
+    truncated: true,
+  };
 }
 
 /**
@@ -155,12 +205,19 @@ function iterationBudgetTruncationNote(isFork: boolean): string {
  *
  * For a completed subagent the final synthesis is inlined directly, so the
  * parent acts on the result without a `subagent_read` round-trip and has
- * nothing left to re-spawn. The `subagent_read` pointer survives only as a
- * fallback for the rare run that ends with no trailing assistant text, or when
- * the run was stopped at its iteration budget — where the trailing assistant
- * text is a pre-tool preamble, so the parent must read the latest child output
- * (including the final iteration's tool results) rather than act on the stale
- * snapshot.
+ * nothing left to re-spawn.
+ *
+ * A run stopped at its iteration budget breaks the loop after appending the
+ * final iteration's tool results, so its trailing assistant text is a pre-tool
+ * preamble. `subagent_read` returns only the assistant-text history, so that
+ * pointer alone would strand the last real work in the trailing tool-result
+ * message. When `finalToolResultText` is supplied, a bounded excerpt of it is
+ * inlined so the parent reaches that output directly, with the `subagent_read`
+ * pointer retained for the earlier assistant messages.
+ *
+ * The `subagent_read` pointer is otherwise the fallback for the rare run that
+ * ends with no trailing assistant text, a queued follow-up turn still draining,
+ * or a capped run whose trailing message carried no tool output.
  *
  * Exported for unit testing.
  */
@@ -182,6 +239,13 @@ export function buildSubagentTerminalMessage(opts: {
    * the budget ran out — potentially incomplete.
    */
   iterationBudgetReached?: boolean;
+  /**
+   * Concatenated text of the trailing tool-result message for a budget-capped
+   * run. A bounded excerpt is inlined so the parent reaches the final
+   * iteration's output, which `subagent_read` (assistant messages only) cannot
+   * surface. Ignored unless `iterationBudgetReached` is set.
+   */
+  finalToolResultText?: string;
 }): string {
   const {
     label,
@@ -194,6 +258,7 @@ export function buildSubagentTerminalMessage(opts: {
     deferred,
     deniedTools,
     iterationBudgetReached,
+    finalToolResultText,
   } = opts;
   const prefix = isFork ? "Fork" : "Subagent";
 
@@ -239,10 +304,36 @@ export function buildSubagentTerminalMessage(opts: {
     );
   }
 
+  // Budget-capped run with recoverable tool output: the trailing assistant
+  // text is a pre-tool preamble, but the final iteration's tool results carry
+  // the run's last real work. `subagent_read` returns only assistant messages,
+  // so inline a bounded excerpt of that tool output directly and keep the read
+  // pointer for the earlier assistant history. Skipped when a follow-up turn is
+  // still draining — that snapshot is stale for a different reason.
+  const trimmedToolResult = finalToolResultText?.trim() ?? "";
+  if (iterationBudgetReached && trimmedToolResult && !deferred) {
+    const excerpt = truncateInlinedToolResult(trimmedToolResult);
+    const readLastN = isFork ? " and last_n: 1" : "";
+    const truncatedClause = excerpt.truncated
+      ? `, truncated to the first ${MAX_INLINED_TOOL_RESULT_CHARS} characters`
+      : "";
+    const silentClause = silent ? " Keep the result internal." : "";
+    return (
+      `[${prefix} "${label}" completed — final tool output below (stopped at iteration budget)]\n\n` +
+      `${excerpt.text}\n\n` +
+      `(This ${prefix.toLowerCase()} reached its iteration budget and was stopped before it ` +
+      `signaled completion. The text above is the final iteration's tool output${truncatedClause} — ` +
+      `its last real work, not a synthesis. Use subagent_read with subagent_id "${subagentId}"${readLastN} ` +
+      `for its earlier assistant messages; its output may be incomplete, so re-spawn it to continue ` +
+      `from here.${silentClause})` +
+      deniedNote
+    );
+  }
+
   // Read-pointer path: the run left no trailing assistant text to inline, a
   // queued follow-up turn is still draining, or the run was stopped at its
-  // iteration budget — in each case the trailing text is a stale snapshot and
-  // the parent should read the latest output instead.
+  // iteration budget with no tool output to inline — in each case the trailing
+  // text is a stale snapshot and the parent should read the latest output.
   const lastN = isFork ? " and last_n: 1" : "";
   const reason = deferred
     ? `Queued follow-up guidance is still being processed`
@@ -847,6 +938,14 @@ export class SubagentManager {
       // before a release nulls the conversation reference so the parent-facing
       // terminal message can carry a truncation notice.
       const iterationBudgetReached = conversation.lastRunIterationBudgetReached;
+      // A capped run stops right after appending the final iteration's tool
+      // results, so those results — not the trailing assistant preamble — hold
+      // its last real work. Extract them (before a release nulls the
+      // conversation) so the terminal message can inline them; `subagent_read`
+      // returns only assistant messages and cannot surface them.
+      const finalToolResultText = iterationBudgetReached
+        ? extractTrailingToolResultText(conversation.messages)
+        : undefined;
       // Copy usage stats from the conversation before sending status (which includes usage).
       managed.state.usage = { ...conversation.usageStats };
       // Only update state + notify if still non-terminal (guards against abort race).
@@ -867,6 +966,7 @@ export class SubagentManager {
             finalText,
             deniedTools,
             iterationBudgetReached,
+            finalToolResultText,
           );
         } else if (iterationBudgetReached) {
           // The synchronous caller (advisor consult, voice continuation)
@@ -1487,6 +1587,7 @@ export class SubagentManager {
     finalText?: string,
     deniedTools?: string[],
     iterationBudgetReached?: boolean,
+    finalToolResultText?: string,
   ): void {
     const { config } = managed.state;
     const isFork = managed.state.isFork;
@@ -1509,6 +1610,7 @@ export class SubagentManager {
       deferred: managed.hadEnqueuedMessages === true,
       deniedTools,
       iterationBudgetReached,
+      finalToolResultText,
     });
 
     const notification: SubagentNotificationInfo = {


### PR DESCRIPTION
## Why

Production (Jul 8–22): `subagentSpawn` cost $1,557/15d. Call-count per spawn: p50 9, p90 36, p99 115, **max 293 LLM calls in one spawn** — the agent loop's `while (true)` has NO iteration bound (context-budget gates manage token growth but never stop on call count). Late iterations re-read the full accumulated context every call, so cost grows super-linearly: the top spawn made 293 calls reading 65.8M cache tokens ($15.99 for one subagent); ≥50-call spawns were $263/15d.

## What

- Generic opt-in `iterationBudget` option on the shared agent loop: a one-time wrap-up nudge injected into the tool-result stream at `softNudgeAtCalls`, and a graceful stop (`agent_loop_exit: iteration_budget_reached`, no throw) at `maxCallsPerRun`.
- Wired ONLY for `turnCallSite === "subagentSpawn"` — interactive mainAgent turns and other background call sites stay uncapped. Heartbeat/consolidation can reuse the same option later (one-line gate widening).
- On a capped run the parent gets the partial result plus an explicit truncation notice with a respawn hint.
- New `subagent` config section: `softNudgeAtCalls` 60 / `maxCallsPerRun` 100 (defaults chosen against the p99=115 distribution — normal deep work is untouched; only the runaway tail is clipped, and the nudge gives the model 40 calls of warning to conclude cleanly).

Estimated effect: ~$240+/mo directly (uniform-cost estimate; real savings higher because capped iterations are the most expensive ones), plus protection against the unbounded-spawn failure mode.

## Verification

- New loop tests drive the real loop via mock provider: nudge exactly once; stop at exactly the cap with output preserved; under-threshold runs byte-identical; unbudgeted runs ungoverned. Schema + terminal-message tests extended. All pass; `tsc --noEmit` + lint clean.
- Pre-existing (unrelated) bun `mock.module` cross-file leak in some subagent test combos reproduces on the base commit — flagged for follow-up, not touched.
- Post-deploy: `telemetry.llm_usage_raw` subagentSpawn `llm_call_count` max should clamp to ~100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->