### PR TITLE
fix(access-request): render an optimistically-completed reject as the parked outcome

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29396,6 +29396,12 @@ paths:
                     description:
                       Guardian-facing reply from the resolver (e.g. verification code for access-request approvals). Present only
                       when applied is true and the resolver produced a reply.
+                  decidedAction:
+                    type: string
+                    description:
+                      The action to present on the resolved card — the resolved outcome, not necessarily the raw button (an
+                      access-request 'reject' resolves to the 'leave_unverified' park). Present only when applied is
+                      true; lets a client completing the card optimistically render the correct tone.
                 required:
                   - ok
                 additionalProperties: false

--- a/assistant/src/__tests__/introduction-card-resolver.test.ts
+++ b/assistant/src/__tests__/introduction-card-resolver.test.ts
@@ -225,6 +225,12 @@ describe("introduction card decisions", () => {
       });
 
       expect(result.applied).toBe(true);
+      if (!result.applied) {
+        continue;
+      }
+      // The primitive returns the resolved outcome so a caller completing the
+      // card optimistically (the in-app path) renders the park, not a denial.
+      expect(result.decidedAction).toBe("leave_unverified");
       expect(sim.getRequest(req.id)?.status).toBe("denied");
       expect(outcomesOfType("seed_unverified")).toHaveLength(1);
       expect(outcomesOfType("block")).toHaveLength(0);
@@ -250,6 +256,11 @@ describe("introduction card decisions", () => {
     });
 
     expect(result.applied).toBe(true);
+    if (!result.applied) {
+      return;
+    }
+    // Block stays an active denial in the returned outcome too.
+    expect(result.decidedAction).toBe("block");
     expect(sim.getRequest(req.id)?.status).toBe("denied");
     const blocks = outcomesOfType("block");
     expect(blocks).toHaveLength(1);

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -171,6 +171,15 @@ export type GuardianDecisionResult =
       resolverFailed?: boolean;
       resolverFailureReason?: string;
       resolverReplyText?: string;
+      /**
+       * The action as it should be presented on the resolved card — the
+       * resolved outcome, not necessarily the raw button. For an access request
+       * the generic decision pair is folded onto the introduction outcomes
+       * (`reject` → `leave_unverified`), so a caller completing the card
+       * optimistically can render the neutral park instead of a denial. Omitted
+       * when the decision did not commit (persist failure).
+       */
+      decidedAction?: ApprovalAction;
     }
   | {
       applied: false;
@@ -549,6 +558,7 @@ export async function applyGuardianDecision(
     applied: true,
     requestId,
     grantMinted,
+    decidedAction: cardAction,
     ...(resolverFailed ? { resolverFailed, resolverFailureReason } : {}),
     ...(resolverReplyText ? { resolverReplyText } : {}),
   };

--- a/assistant/src/runtime/guardian-action-service.ts
+++ b/assistant/src/runtime/guardian-action-service.ts
@@ -47,7 +47,19 @@ export interface ProcessGuardianDecisionParams {
 }
 
 export type ProcessGuardianDecisionResult =
-  | { ok: true; applied: true; requestId: string; replyText?: string }
+  | {
+      ok: true;
+      applied: true;
+      requestId: string;
+      replyText?: string;
+      /**
+       * The action to present on the resolved card — the resolved outcome, not
+       * necessarily the raw button (an access-request `reject` resolves to the
+       * `leave_unverified` park). Lets a client completing the card
+       * optimistically render the correct tone.
+       */
+      decidedAction?: string;
+    }
   | {
       ok: true;
       applied: false;
@@ -136,6 +148,7 @@ export async function processGuardianDecision(
       applied: true,
       requestId: decisionResult.requestId,
       replyText: decisionResult.resolverReplyText,
+      decidedAction: decisionResult.decidedAction,
     };
   }
 

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -72,6 +72,7 @@ async function handleSurfaceAction({
   applied?: boolean;
   reason?: string;
   replyText?: string;
+  decidedAction?: string;
 }> {
   const conversationId = body?.conversationId as string | null | undefined;
   const surfaceId = body?.surfaceId as string | undefined;
@@ -136,6 +137,9 @@ async function handleSurfaceAction({
       ...(!result.applied ? { reason: result.reason } : {}),
       ...(result.applied && result.replyText
         ? { replyText: result.replyText }
+        : {}),
+      ...(result.applied && result.decidedAction
+        ? { decidedAction: result.decidedAction }
         : {}),
     };
   }
@@ -313,6 +317,12 @@ export const ROUTES: RouteDefinition[] = [
         .string()
         .describe(
           "Guardian-facing reply from the resolver (e.g. verification code for access-request approvals). Present only when applied is true and the resolver produced a reply.",
+        )
+        .optional(),
+      decidedAction: z
+        .string()
+        .describe(
+          "The action to present on the resolved card — the resolved outcome, not necessarily the raw button (an access-request 'reject' resolves to the 'leave_unverified' park). Present only when applied is true; lets a client completing the card optimistically render the correct tone.",
         )
         .optional(),
     }),

--- a/clients/web/src/domains/chat/api/surfaces.ts
+++ b/clients/web/src/domains/chat/api/surfaces.ts
@@ -15,7 +15,19 @@ import { assertHasResponse, extractErrorMessage } from "@/utils/api-errors";
 
 export type SurfaceActionResult =
   | { ok: false }
-  | { ok: true; applied?: boolean; reason?: string; replyText?: string };
+  | {
+      ok: true;
+      applied?: boolean;
+      reason?: string;
+      replyText?: string;
+      /**
+       * The resolved outcome action for a guardian decision (apr:*) — not
+       * necessarily the raw button (an access-request `reject` resolves to the
+       * `leave_unverified` park). Used to render the correct completion tone
+       * when the card is completed optimistically.
+       */
+      decidedAction?: string;
+    };
 
 export async function submitSurfaceAction(
   assistantId: string,
@@ -48,6 +60,7 @@ export async function submitSurfaceAction(
       ...(typeof body.applied === "boolean" ? { applied: body.applied } : {}),
       ...(body.reason ? { reason: body.reason } : {}),
       ...(body.replyText ? { replyText: body.replyText } : {}),
+      ...(body.decidedAction ? { decidedAction: body.decidedAction } : {}),
     };
   } catch {
     return { ok: false };

--- a/clients/web/src/domains/chat/completion-tone.test.ts
+++ b/clients/web/src/domains/chat/completion-tone.test.ts
@@ -23,6 +23,25 @@ describe("guardianDecisionTone", () => {
     );
   });
 
+  it("prefers the server-resolved outcome over the raw action id", () => {
+    // The daemon folds an access-request `reject` onto the `leave_unverified`
+    // park; when it reports that resolved action, the optimistic completion must
+    // render the neutral park even though the raw button was `reject`.
+    expect(
+      guardianDecisionTone("apr:req1:reject", {
+        applied: true,
+        decidedAction: "leave_unverified",
+      }),
+    ).toBe("neutral");
+    // A resolved block stays a denial.
+    expect(
+      guardianDecisionTone("apr:req1:reject", {
+        applied: true,
+        decidedAction: "block",
+      }),
+    ).toBe("danger");
+  });
+
   it("marks approve and trust as success", () => {
     expect(
       guardianDecisionTone("apr:req1:approve_once", { applied: true }),

--- a/clients/web/src/domains/chat/completion-tone.ts
+++ b/clients/web/src/domains/chat/completion-tone.ts
@@ -47,12 +47,16 @@ function guardianDecisionAction(actionId: string): string {
  */
 export function guardianDecisionTone(
   actionId: string,
-  result: { applied?: boolean },
+  result: { applied?: boolean; decidedAction?: string },
 ): SurfaceCompletionTone {
   if (result.applied === false) {
     return "neutral";
   }
-  const action = guardianDecisionAction(actionId);
+  // Prefer the server's resolved outcome when present: for an access request the
+  // daemon folds `reject` onto the `leave_unverified` park, so keying tone off
+  // the raw button would mislabel that park as a denial. Fall back to the action
+  // id for paths that don't carry the resolved action.
+  const action = result.decidedAction ?? guardianDecisionAction(actionId);
   if (PARK_DECISION_ACTIONS.has(action)) {
     return "neutral";
   }


### PR DESCRIPTION
Follow-up to #39032, addressing the client-side gap Codex flagged on that PR (and that vex-assistant-bot recommended splitting out).

## Prompt / plan

#39032 made the server present an access-request `reject` as its resolved `leave_unverified` park on the cross-surface withdrawal path. But the **in-app card is completed optimistically by the acting web client**, which computed its completion tone from the raw button (`apr:<id>:reject`) — and when the decision originates in the web app (`originChannel === "vellum"`), `withdrawVellumCard()` skips the clicked card, so the server normalization never reached it. Result: a generic `reject` on an access request (a stale/legacy reject button on the Vellum surface) still rendered a red "danger" completion even though the resolver parked the contact at `unverified`.

## The fix — return the resolved outcome, let the client render it

Single source of truth on the server; the client just uses it:

- `applyGuardianDecision` now returns `decidedAction` — the normalized card action (from the daemon's `OUTCOME_BY_ACTION`, so `reject` → `leave_unverified`).
- `processGuardianDecision` and the `surfaces/:id/action` route response surface it (`openapi.yaml` regenerated; web types follow).
- The web `guardianDecisionTone` prefers the server's `decidedAction` over the raw action id, falling back to the id when it's absent.

No client-side re-derivation of the decision model — the outcome is computed once, on the daemon. `block` stays a denial; other request kinds are unaffected (no such mapping).

## Before → after (optimistic in-app completion)

| Guardian action on an access-request card | Before | After |
| --- | --- | --- |
| Generic `reject` (stale/legacy button, Vellum surface) | Red "danger" completion — but the contact was parked at `unverified` | Neutral completion — matches the resolved park |
| `leave_unverified` button | Neutral (already correct) | Unchanged |
| `block` | Danger | Unchanged |
| Non-access decisions (`tool_approval`, …) | As before | Unchanged (server returns the raw action) |

## Why it's safe

- **Presentation-only.** No ACL / admission / notification change; `decidedAction` is an additive, optional response field.
- **Backwards-compatible.** `guardianDecisionTone` falls back to the raw action id when the server doesn't send `decidedAction`, so older / other paths are unchanged.
- **Single source of truth.** The outcome is the daemon's `OUTCOME_BY_ACTION`, never re-derived on the client.

## Test plan

- `introduction-card-resolver.test.ts`: the `reject` / `leave_unverified` path now also asserts the primitive returns `decidedAction: "leave_unverified"`; the `block` path asserts `"block"`.
- `completion-tone.test.ts`: `guardianDecisionTone` prefers the server outcome (`reject` + `decidedAction: leave_unverified` → neutral; `+ block` → danger) and still falls back to the raw id when it's absent.
- `bunx tsc --noEmit` clean (assistant + web, web via the regenerated types); `generate:openapi --check` clean; eslint + prettier clean; resolver (11), canonical primitive (30), completion-tone (11), send-message-utils (23), surface-actions (8) suites green; pre-commit + pre-push hooks re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5AUkuGpZ7J15ZjXzgzST4

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5AUkuGpZ7J15ZjXzgzST4)_