### PR TITLE
feat(cli): cross-environment hint — 'your assistant lives in vellum-dev, this CLI targets production'

### DIFF
--- a/cli/src/__tests__/assistant-config.test.ts
+++ b/cli/src/__tests__/assistant-config.test.ts
@@ -1,5 +1,19 @@
-import { describe, test, expect, beforeEach, afterAll } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+  spyOn,
+} from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -16,6 +30,7 @@ import {
   lookupAssistantByIdentifier,
   removeAssistantEntry,
   loadAllAssistants,
+  resolveTargetAssistant,
   saveAssistantEntry,
   getActiveAssistant,
   migrateLegacyEntry,
@@ -698,5 +713,106 @@ describe("env-scoped lockfile and migration", () => {
         process.env.VELLUM_ENVIRONMENT = prevEnv;
       }
     }
+  });
+});
+
+describe("cross-environment hint on resolution failure", () => {
+  let dataHome: string;
+  let prevXdg: string | undefined;
+  let prevEnv: string | undefined;
+
+  beforeEach(() => {
+    prevXdg = process.env.XDG_DATA_HOME;
+    prevEnv = process.env.VELLUM_ENVIRONMENT;
+    dataHome = mkdtempSync(join(tmpdir(), "cli-config-xdg-"));
+    process.env.XDG_DATA_HOME = dataHome;
+    // Pin the current env to production so the detector skips it and the hint
+    // copy is deterministic. The current-env lockfile is emptied so resolution
+    // genuinely finds nothing.
+    process.env.VELLUM_ENVIRONMENT = "production";
+    rmSync(join(testDir, ".vellum.lock.json"), { force: true });
+    rmSync(join(testDir, ".vellum.lockfile.json"), { force: true });
+  });
+
+  afterEach(() => {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_DATA_HOME;
+    } else {
+      process.env.XDG_DATA_HOME = prevXdg;
+    }
+    if (prevEnv === undefined) {
+      delete process.env.VELLUM_ENVIRONMENT;
+    } else {
+      process.env.VELLUM_ENVIRONMENT = prevEnv;
+    }
+    rmSync(dataHome, { recursive: true, force: true });
+  });
+
+  // A dev-env assistant lives under the dev data dir, invisible to this
+  // production CLI — the exact split the hint explains.
+  function seedDevAssistant(): void {
+    mkdirSync(join(dataHome, "vellum-dev", "assistants", "dev-bot"), {
+      recursive: true,
+    });
+  }
+
+  function captureResolveTargetAssistantError(): string {
+    const errors: string[] = [];
+    const errorSpy = spyOn(console, "error").mockImplementation(
+      (...args: unknown[]) => {
+        errors.push(args.join(" "));
+      },
+    );
+    const exitSpy = spyOn(process, "exit").mockImplementation(((
+      _code?: number,
+    ) => {
+      throw new Error("exit");
+    }) as typeof process.exit);
+    try {
+      expect(() => resolveTargetAssistant()).toThrow("exit");
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+    return errors.join("\n");
+  }
+
+  test("formatAssistantLookupError appends the hint when another env has assistants", () => {
+    seedDevAssistant();
+    const msg = formatAssistantLookupError("ghost", { status: "not_found" });
+    expect(msg).toContain("No assistant found with name or ID 'ghost'.");
+    expect(msg).toContain("Install vellum Command");
+    expect(msg).toContain("VELLUM_ENVIRONMENT=dev");
+  });
+
+  test("formatAssistantLookupError stays bare when no other env has assistants", () => {
+    // dataHome is empty — detection finds nothing, so the message is intact.
+    const msg = formatAssistantLookupError("ghost", { status: "not_found" });
+    expect(msg).toBe("No assistant found with name or ID 'ghost'.");
+  });
+
+  test("ambiguous lookup never gets the hint", () => {
+    seedDevAssistant();
+    const msg = formatAssistantLookupError("Alice", {
+      status: "ambiguous",
+      matches: [
+        makeEntry("assistant-1", "http://localhost:7821", { name: "Alice" }),
+        makeEntry("assistant-2", "http://localhost:7822", { name: "Alice" }),
+      ],
+    });
+    expect(msg).not.toContain("Install vellum Command");
+  });
+
+  test("resolveTargetAssistant zero-assistants error carries the hint", () => {
+    seedDevAssistant();
+    const combined = captureResolveTargetAssistantError();
+    expect(combined).toContain("No assistant found. Run 'vellum hatch' first.");
+    expect(combined).toContain("Install vellum Command");
+  });
+
+  test("resolveTargetAssistant zero-assistants error stays bare without other envs", () => {
+    const combined = captureResolveTargetAssistantError();
+    expect(combined).toContain("No assistant found. Run 'vellum hatch' first.");
+    expect(combined).not.toContain("Install vellum Command");
   });
 });

--- a/cli/src/__tests__/flags.test.ts
+++ b/cli/src/__tests__/flags.test.ts
@@ -239,3 +239,80 @@ describe("vellum flags --assistant routing", () => {
     expect(fetchCalls.length).toBe(0);
   });
 });
+
+describe("vellum flags cross-environment hint", () => {
+  let xdgDataHome: string;
+  let prevXdg: string | undefined;
+  let prevEnv: string | undefined;
+
+  beforeEach(() => {
+    process.env.VELLUM_LOCKFILE_DIR = testDir;
+    rmSync(join(testDir, ".vellum.lock.json"), { force: true });
+    prevXdg = process.env.XDG_DATA_HOME;
+    prevEnv = process.env.VELLUM_ENVIRONMENT;
+    xdgDataHome = mkdtempSync(join(tmpdir(), "cli-flags-hint-xdg-"));
+    process.env.XDG_DATA_HOME = xdgDataHome;
+    // Pin production so the detector skips it and the lockfile routes to
+    // testDir; the VELLUM_ENVIRONMENT var beats this machine's env config.
+    process.env.VELLUM_ENVIRONMENT = "production";
+    // An unreachable gateway: every request throws like a dead socket would.
+    // Cast through `unknown` since an always-throwing stub returns
+    // `Promise<never>`, which does not structurally overlap with `fetch`.
+    globalThis.fetch = (async () => {
+      throw new TypeError("fetch failed");
+    }) as unknown as typeof globalThis.fetch;
+    process.exit = ((code?: number) => {
+      throw new Error(`process.exit:${code}`);
+    }) as typeof process.exit;
+    consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.exit = originalExit;
+    globalThis.fetch = originalFetch;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    if (prevXdg === undefined) {
+      delete process.env.XDG_DATA_HOME;
+    } else {
+      process.env.XDG_DATA_HOME = prevXdg;
+    }
+    if (prevEnv === undefined) {
+      delete process.env.VELLUM_ENVIRONMENT;
+    } else {
+      process.env.VELLUM_ENVIRONMENT = prevEnv;
+    }
+    rmSync(xdgDataHome, { recursive: true, force: true });
+  });
+
+  // A dev-env assistant lives under the dev data dir, invisible to this
+  // production CLI — the split the hint explains.
+  function seedDevAssistant(): void {
+    mkdirSync(join(xdgDataHome, "vellum-dev", "assistants", "dev-bot"), {
+      recursive: true,
+    });
+  }
+
+  test("gateway-unreachable error gains the hint when another env has assistants", async () => {
+    writeLockfile([makeEntry("alice-1", { name: "Alice" })], "alice-1");
+    seedDevAssistant();
+    process.argv = ["bun", "vellum", "flags", "set", "voice-mode", "true"];
+    await expect(flags()).rejects.toThrow(/Install vellum Command/);
+  });
+
+  test("gateway-unreachable error stays bare when no other env has assistants", async () => {
+    writeLockfile([makeEntry("alice-1", { name: "Alice" })], "alice-1");
+    // xdgDataHome is empty — detection finds nothing, so the message is intact.
+    process.argv = ["bun", "vellum", "flags", "set", "voice-mode", "true"];
+    let error: Error | undefined;
+    try {
+      await flags();
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error?.message).toContain("Could not reach the assistant gateway");
+    expect(error?.message).not.toContain("Install vellum Command");
+  });
+});

--- a/cli/src/commands/flags.ts
+++ b/cli/src/commands/flags.ts
@@ -4,6 +4,7 @@ import {
   formatAssistantLookupError,
   lookupAssistantByIdentifier,
 } from "../lib/assistant-config.js";
+import { crossEnvironmentAssistantHint } from "../lib/environments/detect.js";
 
 type FeatureFlagEntry = {
   key: string;
@@ -132,7 +133,9 @@ function rethrowFetchError(err: unknown): never {
     (err.message.includes("fetch") || err.message.includes("connect"))
   ) {
     throw new Error(
-      "Could not reach the assistant gateway. Is it running? Try 'vellum wake'.",
+      `Could not reach the assistant gateway. Is it running? Try 'vellum wake'.${
+        crossEnvironmentAssistantHint() ?? ""
+      }`,
     );
   }
   throw err;

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -18,6 +18,7 @@ import {
 } from "@vellumai/local-mode/contract";
 
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./constants.js";
+import { crossEnvironmentAssistantHint } from "./environments/detect.js";
 import {
   getDefaultPorts,
   getLockfilePath,
@@ -423,7 +424,7 @@ export function formatAssistantLookupError(
     return `Multiple assistants match '${identifier}': ${matches}. Use the assistant ID to disambiguate.`;
   }
 
-  return `No assistant found with name or ID '${identifier}'.`;
+  return `No assistant found with name or ID '${identifier}'.${crossEnvironmentAssistantHint() ?? ""}`;
 }
 
 export function removeAssistantEntry(assistantId: string): void {
@@ -580,7 +581,9 @@ export function resolveTargetAssistant(nameArg?: string): AssistantEntry {
     if (all.length === 1) return all[0];
 
     if (all.length === 0) {
-      console.error("No assistant found. Run 'vellum hatch' first.");
+      console.error(
+        `No assistant found. Run 'vellum hatch' first.${crossEnvironmentAssistantHint() ?? ""}`,
+      );
     } else {
       console.error(
         `Multiple assistants found. Set an active assistant with 'vellum use <name>'.`,

--- a/cli/src/lib/environments/__tests__/detect.test.ts
+++ b/cli/src/lib/environments/__tests__/detect.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  crossEnvironmentAssistantHint,
+  detectOtherEnvironmentAssistants,
+} from "../detect.js";
+import { getSeed } from "../resolve.js";
+
+const prod = getSeed("production")!;
+
+/** Create `<XDG_DATA_HOME>/vellum-<env>/assistants/<id>/` for a non-prod env. */
+function seedAssistantDir(dataHome: string, envName: string, id: string): void {
+  mkdirSync(join(dataHome, `vellum-${envName}`, "assistants", id), {
+    recursive: true,
+  });
+}
+
+describe("cross-environment assistant detection", () => {
+  let dataHome: string;
+  let prevXdg: string | undefined;
+  let prevEnv: string | undefined;
+
+  beforeEach(() => {
+    prevXdg = process.env.XDG_DATA_HOME;
+    prevEnv = process.env.VELLUM_ENVIRONMENT;
+    dataHome = mkdtempSync(join(tmpdir(), "cli-detect-xdg-"));
+    process.env.XDG_DATA_HOME = dataHome;
+    // Pin the current env so the hint's "this CLI targets '<env>'" copy and
+    // the current-env skip are deterministic regardless of machine config.
+    process.env.VELLUM_ENVIRONMENT = "production";
+  });
+
+  afterEach(() => {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_DATA_HOME;
+    } else {
+      process.env.XDG_DATA_HOME = prevXdg;
+    }
+    if (prevEnv === undefined) {
+      delete process.env.VELLUM_ENVIRONMENT;
+    } else {
+      process.env.VELLUM_ENVIRONMENT = prevEnv;
+    }
+    rmSync(dataHome, { recursive: true, force: true });
+  });
+
+  test("finds an env whose data dir holds an assistant subdirectory", () => {
+    seedAssistantDir(dataHome, "dev", "dev-bot");
+    expect(detectOtherEnvironmentAssistants(prod)).toContain("dev");
+  });
+
+  test("reports every other env that holds assistants", () => {
+    seedAssistantDir(dataHome, "dev", "dev-bot");
+    seedAssistantDir(dataHome, "staging", "staging-bot");
+    const others = detectOtherEnvironmentAssistants(prod);
+    expect(others).toContain("dev");
+    expect(others).toContain("staging");
+  });
+
+  test("skips the current environment even when it holds assistants", () => {
+    // production's own multi-instance dir (no env suffix).
+    mkdirSync(join(dataHome, "vellum", "assistants", "prod-bot"), {
+      recursive: true,
+    });
+    expect(detectOtherEnvironmentAssistants(prod)).toEqual([]);
+  });
+
+  test("ignores an env dir that holds no assistant subdirectory", () => {
+    mkdirSync(join(dataHome, "vellum-dev", "assistants"), { recursive: true });
+    expect(detectOtherEnvironmentAssistants(prod)).toEqual([]);
+  });
+
+  test("returns empty when no env data dirs exist", () => {
+    expect(detectOtherEnvironmentAssistants(prod)).toEqual([]);
+  });
+
+  test("swallows fs errors (data root is a file, not a dir) and returns empty", () => {
+    const filePath = join(dataHome, "not-a-dir");
+    writeFileSync(filePath, "x");
+    process.env.XDG_DATA_HOME = filePath;
+    expect(detectOtherEnvironmentAssistants(prod)).toEqual([]);
+    expect(crossEnvironmentAssistantHint()).toBeNull();
+  });
+
+  test("hint names the env, the current env, and both fixes", () => {
+    seedAssistantDir(dataHome, "dev", "dev-bot");
+    const hint = crossEnvironmentAssistantHint();
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("'dev'");
+    expect(hint).toContain("This CLI targets 'production'");
+    expect(hint).toContain("Install vellum Command");
+    expect(hint).toContain("VELLUM_ENVIRONMENT=dev");
+  });
+
+  test("hint is null when no other env has assistants", () => {
+    expect(crossEnvironmentAssistantHint()).toBeNull();
+  });
+});

--- a/cli/src/lib/environments/detect.ts
+++ b/cli/src/lib/environments/detect.ts
@@ -1,0 +1,79 @@
+import { readdirSync } from "fs";
+
+import { SEEDS, type EnvironmentDefinition } from "@vellumai/environments";
+
+import { getMultiInstanceDir } from "./paths.js";
+import { getCurrentEnvironment } from "./resolve.js";
+
+/**
+ * Names of OTHER environments (every seed except `currentEnv`) whose
+ * multi-instance data dir exists and holds at least one assistant
+ * subdirectory.
+ *
+ * Each environment has its own on-host data layout — see
+ * {@link getMultiInstanceDir}. A user who hatched via a dev/staging desktop
+ * app but runs the production npm CLI (or vice versa) targets a different
+ * layout than the app did, so the assistant the app created is invisible to
+ * this CLI. This cheap filesystem scan surfaces that split so callers can
+ * point the user at the environment that actually holds their assistants.
+ *
+ * Never throws: a missing or unreadable dir just means that environment has no
+ * discoverable assistants, so it is skipped. Returns an empty array on any
+ * error.
+ */
+export function detectOtherEnvironmentAssistants(
+  currentEnv: EnvironmentDefinition,
+): string[] {
+  const found: string[] = [];
+  for (const env of Object.values(SEEDS)) {
+    if (env.name === currentEnv.name) {
+      continue;
+    }
+    try {
+      const hasAssistant = readdirSync(getMultiInstanceDir(env), {
+        withFileTypes: true,
+      }).some((dirent) => dirent.isDirectory());
+      if (hasAssistant) {
+        found.push(env.name);
+      }
+    } catch {
+      // Missing or unreadable dir — this environment has no discoverable
+      // assistants. Skip it.
+    }
+  }
+  return found;
+}
+
+/**
+ * One-line hint appended to "no assistant found" and "gateway unreachable"
+ * errors when another environment's data dir holds assistants. A first-time
+ * user who hatched via a dev/staging desktop app while running the production
+ * npm CLI otherwise gets a bare failure with no clue the two tools target
+ * different environments.
+ *
+ * Returns null when nothing is found so callers can append unconditionally:
+ * `message + (crossEnvironmentAssistantHint() ?? "")`. Detection failure never
+ * propagates — the caller's original error must survive intact.
+ */
+export function crossEnvironmentAssistantHint(): string | null {
+  let currentEnv: EnvironmentDefinition;
+  let others: string[];
+  try {
+    currentEnv = getCurrentEnvironment();
+    others = detectOtherEnvironmentAssistants(currentEnv);
+  } catch {
+    return null;
+  }
+  if (others.length === 0) {
+    return null;
+  }
+
+  const quoted = others.map((name) => `'${name}'`).join(", ");
+  const noun = others.length > 1 ? "environments" : "environment";
+  return (
+    `\n\nFound assistants in the ${quoted} ${noun} (managed by a dev/staging ` +
+    `desktop app). This CLI targets '${currentEnv.name}'. Use the desktop ` +
+    `app's 'Install vellum Command…' menu item to get a matching CLI, or ` +
+    `set VELLUM_ENVIRONMENT=${others[0]}.`
+  );
+}


### PR DESCRIPTION
## Summary
- When assistant resolution finds nothing or the gateway is unreachable, the CLI now checks whether OTHER environments' data dirs contain assistants and says so — with the fix (the desktop app's 'Install vellum Command…' or VELLUM_ENVIRONMENT)
- A first-time user hatched via the dev desktop app while her shell ran the production npm CLI; the bare 'unable to connect' gave no clue the tools target different environments

From live first-user testing (Slack, tonight). Part of plan: ios-self-hosted-connect.md (papercuts).