### PR TITLE
fix(web): warn on identical secret-bearing drafts across conversation switches

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.test.tsx
@@ -217,6 +217,52 @@ describe("useDraftSecretDetection detection", () => {
     expect(result.current.matches).toHaveLength(1);
   });
 
+  test("an identical restored draft with the same secret warns immediately after a switch", () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    // The same pasted key is drafted in both conversations, so the restored
+    // draft is byte-identical to the outgoing one.
+    const sharedDraft = `here is ${SYNTHETIC_PROJECT_KEY}`;
+    setDraft(sharedDraft);
+    const { result, rerender } = renderDetection("conv-1", NEVER_ELAPSES_MS);
+    expect(result.current.matches).toHaveLength(1);
+
+    rerender({ conversationId: "conv-2" });
+    expect(result.current.matches).toEqual([]);
+
+    // Conversation B's restored draft equals conversation A's byte-for-byte,
+    // so the composer input is unchanged across the swap and the
+    // subscription's identity guard would skip the scan. The armed
+    // immediate-scan must still run so the repeated secret warns without a
+    // keystroke or a debounce wait.
+    setDraft(sharedDraft);
+    expect(result.current.matches).toHaveLength(1);
+    expect(result.current.matches[0]?.value).toBe(SYNTHETIC_PROJECT_KEY);
+    expect(result.current.dismissed).toBe(false);
+
+    // The immediate scan is single-use — an unchanged draft afterward is an
+    // ordinary keystroke path again and early-outs (no re-scan needed), while
+    // an actual edit waits out the (never-elapsing) debounce.
+    setDraft(`${sharedDraft} plus ${SYNTHETIC_GITHUB_TOKEN}`);
+    expect(result.current.matches).toHaveLength(1);
+  });
+
+  test("a switch to an empty draft still clears matches (identity fix does not resurrect)", async () => {
+    seedFlags({ composerSecretGuard: true, hasHydrated: true });
+    setDraft(`conversation A: ${SYNTHETIC_PROJECT_KEY}`);
+    const { result, rerender } = renderDetection("conv-1", 0);
+    expect(result.current.matches).toHaveLength(1);
+
+    rerender({ conversationId: "conv-2" });
+    expect(result.current.matches).toEqual([]);
+
+    // Conversation B has no saved draft: the switch swap clears the composer.
+    setDraft("");
+    await waitFor(() => {
+      expect(result.current.matches).toEqual([]);
+    });
+    expect(result.current.dismissed).toBe(false);
+  });
+
   test("scanning waits out the debounce between keystrokes", async () => {
     seedFlags({ composerSecretGuard: true, hasHydrated: true });
     const { result } = renderDetection();

--- a/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
+++ b/clients/web/src/domains/chat/hooks/use-draft-secret-detection.ts
@@ -211,7 +211,14 @@ export function useDraftSecretDetection({
 
     let timer: ReturnType<typeof setTimeout> | null = null;
     const unsubscribe = useComposerStore.subscribe((state, prevState) => {
-      if (state.input === prevState.input) {
+      const scanImmediately = scanNextInputImmediatelyRef.current;
+      // Unchanged input is normally ignored, but a conversation-switch draft
+      // swap must still be scanned even when the incoming draft is
+      // byte-identical to the outgoing one (e.g. the same pasted key drafted
+      // in both conversations). Skipping it here would leave the repeated
+      // secret un-warned until the next edit, since the identity guard would
+      // otherwise consume the switch notification without scanning.
+      if (state.input === prevState.input && !scanImmediately) {
         return;
       }
       // Any draft edit invalidates an armed send bypass AND the blocked
@@ -227,7 +234,7 @@ export function useDraftSecretDetection({
         clearTimeout(timer);
         timer = null;
       }
-      if (scanNextInputImmediatelyRef.current) {
+      if (scanImmediately) {
         // Conversation-switch draft swap: surface the incoming draft's
         // secrets without waiting out the keystroke debounce.
         scanNextInputImmediatelyRef.current = false;


### PR DESCRIPTION
## Summary
Fixes a self-review gap (Codex P2 on #38959, previously unaddressed): when a conversation switch restores a draft byte-identical to the outgoing one, the composer-store subscription's identity early-out skipped the armed immediate-scan, leaving a pasted secret un-warned until the next keystroke. The switch path now scans the incoming draft even when it's unchanged.

Part of plan: composer-secret-guard.md (self-review remediation)