### PR TITLE
docs(gateway): refresh AGENTS.md wording after the slack/ reorg

### DIFF
--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -15,14 +15,14 @@ Why: the gateway is the single point of ingress, handling TLS termination, auth,
 
 ### Provider Webhook Payload Validation
 
-Provider webhook payloads (Telegram, WhatsApp, Slack, email/Resend, …) are **untrusted external input**. Parse them with tolerant Zod schemas in the provider's `normalize.ts` (or the webhook route, where normalization is split) — never trust a blanket `as` / `as unknown as` cast off `JSON.parse`.
+Provider webhook payloads (Telegram, WhatsApp, Slack, email/Resend, …) are **untrusted external input**. Parse them with tolerant Zod schemas co-located in the provider module — a `normalize.ts`, a dedicated schemas file (`slack/message-schemas.ts`), or the webhook route where normalization is split — never trust a blanket `as` / `as unknown as` cast off `JSON.parse`.
 
-- **Schema-first, co-located.** Define the schema inline in the module that consumes it and derive the type with `z.infer` (single source of truth). These input schemas have a single consumer, so they stay local — do **not** hoist them to `packages/gateway-client` (that package is for schemas that cross the gateway↔daemon↔web wire, e.g. the normalized `GatewayInboundEvent` output).
+- **Schema-first, co-located.** Define the schema in a module co-located with the normalizer(s) that consume it and derive the type with `z.infer` (single source of truth). These input schemas stay local to the provider directory — do **not** hoist them to `packages/gateway-client` (that package is for schemas that cross the gateway↔daemon↔web wire, e.g. the normalized `GatewayInboundEvent` output).
 - **Tolerant, not strict.** Validate each field's type but `.optional().catch(undefined)` it so a malformed field collapses rather than rejecting the whole payload; the existing downstream null-checks then drop an unprocessable message. Require only the fields the normalizer actually keys on (identity / dedup). `safeParse` at the boundary and drop-or-acknowledge malformed input **individually**, so one bad message can't crash a batch.
 - **`receivedAt` is the gateway's wall clock** (`new Date().toISOString()`), never a provider-supplied timestamp — routing an untrusted time into `new Date()` is a crash class, and receipt time is the correct semantic anyway.
 - **Preserve `raw`.** In a direct normalizer, keep the original payload verbatim on the event (`raw: payload`); only the parsed working copy is schema-shaped. Split-normalization paths that first map the provider payload onto a shared canonical shape (the email family — email/Resend/Mailgun → `VellumEmailPayload`) carry that canonical payload as `raw`, by the email channel's design.
 
-Reference implementations: `telegram/normalize.ts` (plus a compile-time cross-check against the `@grammyjs/types` dev dependency), `whatsapp/normalize.ts`, and `http/routes/resend-webhook.ts`.
+Reference implementations: `telegram/normalize.ts` (plus a compile-time cross-check against the `@grammyjs/types` dev dependency), `whatsapp/normalize.ts`, `http/routes/resend-webhook.ts`, and the `slack/` module — schemas in `slack/message-schemas.ts` (cross-checked against `@slack/types`), with normalizers split by event family (see _Module Organization_).
 
 ### Gateway-Only API Consumption
 
@@ -103,7 +103,7 @@ Organize gateway code **by concern, not by technical layer** — group by what c
 - **No single-file directories.** A directory holding exactly one file should be flattened up a level — directories organize multiple files.
 - **Split by concern, not by line count** — but a file that has grown to span multiple concerns (past a few hundred lines) is the signal to extract, not to keep appending.
 
-The `slack/` module is being reorganized to this shape and is the worked example.
+The `slack/` module is the worked example of this shape.
 
 ## Channel Trust Classification & Admission Policy
 


### PR DESCRIPTION
## Prompt / plan

Final PR of the `slack/normalize.ts` reorg arc — the docs cleanup now that the code structure is complete (#39034 convention → #39028 user-directory → #39037 shared helpers → #39042 normalizers-by-family, `normalize.ts` deleted).

### What changed

Two `gateway/AGENTS.md` wording refreshes flagged during the arc:

- **Module Organization** — the "the `slack/` module **is being reorganized** to this shape" line goes present-tense: "**is the worked example** of this shape." (vex flagged the temporal wording on #39034; correct to update it now that the reorg has landed.)
- **Provider Webhook Payload Validation** — the schemas no longer live only in a provider `normalize.ts`. Reword "in the provider's `normalize.ts`" → "**co-located in the provider module** — a `normalize.ts`, a dedicated schemas file (`slack/message-schemas.ts`), or the split webhook route", soften the "inline in the consuming module" bullet to "co-located with the normalizer(s) that consume it", and add the `slack/` module to the reference implementations (schemas cross-checked against `@slack/types`, normalizers split by event family).

### Why it's safe

Docs-only change. No code touched.

## Test plan

- Docs-only; `prettier` clean. No stale `slack/normalize.ts` references remain in the gateway docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd1vE2wVWy61oSNVLUZ92f)_