### PR TITLE
fix(secret-detection): shared-module consistency (label, bounds, docstring, guard test) + hot-path private-key matcher

### DIFF
--- a/assistant/src/security/secret-ingress.ts
+++ b/assistant/src/security/secret-ingress.ts
@@ -13,6 +13,9 @@ import {
   isPlaceholderContext,
   isPlaceholderValue,
   TOKEN_SHAPE,
+  TOKEN_SHAPE_LABEL,
+  TOKEN_SHAPE_MAX_LENGTH,
+  TOKEN_SHAPE_MIN_LENGTH,
 } from "@vellumai/service-contracts/secret-detection";
 
 import { getConfig } from "../config/loader.js";
@@ -61,9 +64,6 @@ const getGlobalPatterns = memoizePluginPatternDerivation(
 // ---------------------------------------------------------------------------
 // Token-shape heuristic (whole-message only)
 // ---------------------------------------------------------------------------
-
-const TOKEN_SHAPE_MIN_LENGTH = 20;
-const TOKEN_SHAPE_MAX_LENGTH = 512;
 
 /**
  * Check whether the entire message content is a single token-shaped value
@@ -151,7 +151,7 @@ export function checkIngressForSecrets(content: string): IngressCheckResult {
     secretDetection.blockTokenShapedMessages &&
     isBlockedTokenShapedMessage(content)
   ) {
-    detectedTypes.push("Token-shaped value");
+    detectedTypes.push(TOKEN_SHAPE_LABEL);
   }
 
   if (detectedTypes.length === 0) {

--- a/assistant/src/security/secret-patterns.ts
+++ b/assistant/src/security/secret-patterns.ts
@@ -6,5 +6,6 @@
 
 export {
   PREFIX_PATTERNS,
+  REDACTION_PREFIX_PATTERNS,
   type SecretPrefixPattern,
 } from "@vellumai/service-contracts/secret-detection";

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -12,7 +12,7 @@
 import { memoizePluginPatternDerivation } from "./plugin-secret-patterns.js";
 import { isAllowlisted } from "./secret-allowlist.js";
 import {
-  PREFIX_PATTERNS,
+  REDACTION_PREFIX_PATTERNS,
   type SecretPrefixPattern,
 } from "./secret-patterns.js";
 
@@ -71,9 +71,13 @@ function derivePluginScannerPattern(p: SecretPrefixPattern): SecretPattern {
   };
 }
 
-// Static patterns derived from the shared source of truth.
+// Static patterns derived from the shared source of truth. The scanner detects
+// and redacts but never stores or rewrites a private key, so it uses the
+// header-only private-key matcher (via REDACTION_PREFIX_PATTERNS) — the
+// whole-block redaction the chat-persist path needs is handled by
+// candidate protection running before this scanner.
 const PREFIX_DERIVED: SecretPattern[] =
-  PREFIX_PATTERNS.map(deriveScannerPattern);
+  REDACTION_PREFIX_PATTERNS.map(deriveScannerPattern);
 
 // Scanner-only patterns that require surrounding context or are not
 // simple prefix matches — these stay defined here.

--- a/assistant/src/util/log-redact.ts
+++ b/assistant/src/util/log-redact.ts
@@ -11,15 +11,18 @@
  */
 
 import { memoizePluginPatternDerivation } from "../security/plugin-secret-patterns.js";
-import { PREFIX_PATTERNS } from "../security/secret-patterns.js";
+import { REDACTION_PREFIX_PATTERNS } from "../security/secret-patterns.js";
 
 // ---------------------------------------------------------------------------
-// Sensitive-value patterns (derived from shared PREFIX_PATTERNS)
+// Sensitive-value patterns (derived from shared REDACTION_PREFIX_PATTERNS)
 // ---------------------------------------------------------------------------
 
 const BEARER_RE = /Bearer [A-Za-z0-9._\-]+/g;
 
-const STATIC_API_KEY_PATTERNS: RegExp[] = PREFIX_PATTERNS.map(
+// This serializer only needs to DETECT and mask a secret, never store or
+// rewrite it, so it uses the header-only private-key matcher (via
+// REDACTION_PREFIX_PATTERNS) to stay O(n) on large serialized strings.
+const STATIC_API_KEY_PATTERNS: RegExp[] = REDACTION_PREFIX_PATTERNS.map(
   (p) => new RegExp(p.regex.source, "g"),
 );
 

--- a/clients/web/src/domains/chat/components/store-credential-dialog.test.tsx
+++ b/clients/web/src/domains/chat/components/store-credential-dialog.test.tsx
@@ -32,7 +32,12 @@ import {
   waitFor,
 } from "@testing-library/react";
 
-import type { DetectedSecret } from "@vellumai/service-contracts/secret-detection";
+import {
+  PREFIX_PATTERNS,
+  PRIVATE_KEY_LABEL,
+  TOKEN_SHAPE_LABEL,
+  type DetectedSecret,
+} from "@vellumai/service-contracts/secret-detection";
 
 import { useComposerStore } from "@/domains/chat/composer-store";
 import type { StoreCredentialDialogProps } from "@/domains/chat/components/store-credential-dialog";
@@ -190,13 +195,30 @@ describe("suggestCredentialSlot", () => {
 
   test.each([
     // Owning service unknowable — the user names the slot.
-    ["Token-shaped message"],
-    ["Private Key"],
+    [TOKEN_SHAPE_LABEL],
+    [PRIVATE_KEY_LABEL],
     // Future/unmapped detector labels degrade to empty suggestions.
     ["Some Future Vendor Key"],
     [""],
   ])("%p suggests empty fields", (label) => {
     expect(suggestCredentialSlot(label)).toEqual({ service: "", field: "" });
+  });
+
+  // Guard: the slot map is keyed by hardcoded label strings with no static
+  // binding to the shared PREFIX_PATTERNS label set, so a label rename in the
+  // shared module would silently degrade that pattern to an empty prefill.
+  // Every prefix label except the intentionally-unmapped private key (owning
+  // service unknowable) must resolve to a non-empty slot, so a rename fails
+  // here instead of shipping a broken suggestion.
+  test.each(
+    PREFIX_PATTERNS.map((p) => p.label).filter(
+      (label) => label !== PRIVATE_KEY_LABEL,
+    ),
+  )("%s has a slot-map entry", (label) => {
+    expect(suggestCredentialSlot(label)).not.toEqual({
+      service: "",
+      field: "",
+    });
   });
 });
 
@@ -368,7 +390,7 @@ describe("StoreCredentialDialog", () => {
   test("unknown detection label opens with empty service/field for the user to fill", () => {
     renderDialog({
       secret: {
-        label: "Token-shaped message",
+        label: TOKEN_SHAPE_LABEL,
         value: SYNTHETIC_PROJECT_KEY,
         start: 0,
         end: SYNTHETIC_PROJECT_KEY.length,

--- a/clients/web/src/domains/chat/components/store-credential-dialog.tsx
+++ b/clients/web/src/domains/chat/components/store-credential-dialog.tsx
@@ -18,7 +18,7 @@ const UNKNOWN_SLOT: CredentialSlot = { service: "", field: "" };
 /**
  * Suggested vault slot per detection label from the shared secret-detection
  * patterns (`@vellumai/service-contracts/secret-detection`). Labels without
- * an entry — including "Token-shaped message" and "Private Key", where the
+ * an entry — including the token-shape label and "Private Key", where the
  * owning service is unknowable — fall back to empty fields for the user to
  * fill in. Suggestions only; every field stays editable in the dialog.
  */

--- a/packages/service-contracts/src/__tests__/secret-detection.test.ts
+++ b/packages/service-contracts/src/__tests__/secret-detection.test.ts
@@ -8,7 +8,11 @@ import {
   detectSecretsInText,
   isCompletePrivateKeyBlock,
   PREFIX_PATTERNS,
+  PRIVATE_KEY_HEADER_REGEX,
+  REDACTION_PREFIX_PATTERNS,
   TOKEN_SHAPE,
+  TOKEN_SHAPE_LABEL,
+  TOKEN_SHAPE_MAX_LENGTH,
 } from "../secret-detection.js";
 
 // All fixtures below are synthetic lookalike tokens — never real key material.
@@ -171,7 +175,7 @@ describe("detectSecretsInText — whole-message token shape", () => {
     expect(TOKEN_SHAPE.test(token)).toBe(true);
     expect(detectSecretsInText(token)).toEqual([
       {
-        label: "Token-shaped message",
+        label: TOKEN_SHAPE_LABEL,
         value: token,
         start: 0,
         end: token.length,
@@ -184,7 +188,7 @@ describe("detectSecretsInText — whole-message token shape", () => {
     const token = `acme_secret_${filler(18)}`;
     expect(detectSecretsInText(`  ${token} \n`)).toEqual([
       {
-        label: "Token-shaped message",
+        label: TOKEN_SHAPE_LABEL,
         value: token,
         start: 2,
         end: 2 + token.length,
@@ -205,6 +209,70 @@ describe("detectSecretsInText — whole-message token shape", () => {
     const results = detectSecretsInText(key);
     expect(results).toHaveLength(1);
     expect(results[0]!.label).toBe("GitLab Token");
+  });
+
+  test("a token-shaped value over the max length is not matched", () => {
+    // Same shape as a valid token but a tail longer than the shared max — the
+    // daemon ingress caps the whole-message heuristic here, so the client must
+    // too or a >512-char paste would warn client-side yet pass server-side.
+    const tail = filler(TOKEN_SHAPE_MAX_LENGTH + 1);
+    const token = `virlo_tkn_${tail}`;
+    expect(token.length).toBeGreaterThan(TOKEN_SHAPE_MAX_LENGTH);
+    expect(TOKEN_SHAPE.test(token)).toBe(true);
+    expect(detectSecretsInText(token)).toEqual([]);
+  });
+
+  test("a token-shaped value exactly at the max length is still matched", () => {
+    const prefix = "virlo_tkn_";
+    const token = `${prefix}${filler(TOKEN_SHAPE_MAX_LENGTH - prefix.length)}`;
+    expect(token.length).toBe(TOKEN_SHAPE_MAX_LENGTH);
+    const results = detectSecretsInText(token);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.label).toBe(TOKEN_SHAPE_LABEL);
+  });
+});
+
+describe("REDACTION_PREFIX_PATTERNS — header-only private key", () => {
+  const FAKE_PEM_BODY =
+    "MIIFAKEfakefakefakefakefakefakefakefakefake\n" +
+    "FAKEfakefakefakefakefakefakefakefakefake==";
+  const FULL_PEM_BLOCK = `-----BEGIN RSA PRIVATE KEY-----\n${FAKE_PEM_BODY}\n-----END RSA PRIVATE KEY-----`;
+
+  function redactionPrivateKeyRegex(): RegExp {
+    const entry = REDACTION_PREFIX_PATTERNS.find(
+      (p) => p.label === "Private Key",
+    );
+    expect(entry).toBeDefined();
+    return new RegExp(entry!.regex.source, "g");
+  }
+
+  test("the redaction variant matches the PEM header only, not the whole block", () => {
+    const regex = redactionPrivateKeyRegex();
+    const match = regex.exec(FULL_PEM_BLOCK);
+    expect(match).not.toBeNull();
+    expect(match![0]).toBe("-----BEGIN RSA PRIVATE KEY-----");
+  });
+
+  test("PRIVATE_KEY_HEADER_REGEX matches a footerless header", () => {
+    expect(
+      PRIVATE_KEY_HEADER_REGEX.test("-----BEGIN OPENSSH PRIVATE KEY-----"),
+    ).toBe(true);
+  });
+
+  test("every non-private-key pattern is shared verbatim with PREFIX_PATTERNS", () => {
+    for (let i = 0; i < PREFIX_PATTERNS.length; i++) {
+      if (PREFIX_PATTERNS[i]!.label === "Private Key") {
+        continue;
+      }
+      expect(REDACTION_PREFIX_PATTERNS[i]).toBe(PREFIX_PATTERNS[i]);
+    }
+  });
+
+  test("detectSecretsInText still captures the whole block (P1 stays fixed)", () => {
+    const results = detectSecretsInText(FULL_PEM_BLOCK);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.label).toBe("Private Key");
+    expect(results[0]!.value).toBe(FULL_PEM_BLOCK);
   });
 });
 

--- a/packages/service-contracts/src/secret-detection.ts
+++ b/packages/service-contracts/src/secret-detection.ts
@@ -7,9 +7,17 @@
  *
  * This module is intentionally data-only: no imports, no entropy logic,
  * no config — safe for hot-path consumers like log serializers, and
- * browser-safe so web clients can bundle it directly.  The pattern values
- * are shared verbatim by the daemon and web clients so client and server
- * detection can never disagree.
+ * browser-safe so web clients can bundle it directly.
+ *
+ * The exported `PATTERNS`/constants are shared verbatim by the daemon and the
+ * web clients, so the two sides agree on what a secret *looks like*. The web
+ * composer scanner is a conservative superset pre-filter of the daemon ingress
+ * check, not an identical twin: the daemon additionally applies a per-user
+ * secret allowlist and config gating (`secretDetection.enabled` /
+ * `blockIngress`) on top of these shared patterns, so the client may warn on a
+ * few values the server would accept (e.g. an allowlisted token). Only the
+ * shared patterns and length bounds in this module are guaranteed identical
+ * across client and server.
  */
 
 // ---------------------------------------------------------------------------
@@ -52,6 +60,20 @@ const PEM_BEGIN = String.raw`-----BEGIN ${PEM_KEY_TYPE}-----`;
 const PEM_END = String.raw`-----END ${PEM_KEY_TYPE}-----`;
 
 const PEM_COMPLETE_BLOCK = new RegExp(`${PEM_END}$`);
+
+/**
+ * Header-only private-key matcher: matches just the `-----BEGIN … PRIVATE
+ * KEY-----` header, with no optional block-body capture.
+ *
+ * Detect/redact-only consumers (log serializers, the tool-output scanner) use
+ * this instead of the whole-block {@link PREFIX_PATTERNS} entry: they only need
+ * to KNOW a private key is present and mask it — they never store or rewrite
+ * the block — so they must not pay the O(n²) cost the whole-block matcher incurs
+ * on large serialized strings, where every footerless header rescans to EOF
+ * looking for a footer. `detectSecretsInText` (chat) keeps the whole-block
+ * matcher, which the store/rewrite path relies on to capture the full key.
+ */
+export const PRIVATE_KEY_HEADER_REGEX = new RegExp(PEM_BEGIN);
 
 /**
  * True when a `Private Key` match is a complete PEM block — it ends at an
@@ -179,6 +201,22 @@ export const PREFIX_PATTERNS: SecretPrefixPattern[] = [
   { label: "Firecrawl API Key", regex: /fc-[A-Za-z0-9]{20,}/ },
 ];
 
+/**
+ * {@link PREFIX_PATTERNS} variant for detect/redact-only consumers (log
+ * serializers, the tool-output scanner). Identical to `PREFIX_PATTERNS` except
+ * the private-key entry matches the PEM header alone
+ * ({@link PRIVATE_KEY_HEADER_REGEX}): those consumers only DETECT or REDACT a
+ * private key — they never store or rewrite the block — so they route here to
+ * avoid the whole-block matcher's O(n²) worst case on large serialized strings.
+ * `detectSecretsInText` (chat) uses `PREFIX_PATTERNS` for full-block capture.
+ */
+export const REDACTION_PREFIX_PATTERNS: SecretPrefixPattern[] =
+  PREFIX_PATTERNS.map((p) =>
+    p.label === PRIVATE_KEY_LABEL
+      ? { label: PRIVATE_KEY_LABEL, regex: PRIVATE_KEY_HEADER_REGEX }
+      : p,
+  );
+
 // ---------------------------------------------------------------------------
 // Token-shape heuristic (whole-message only)
 // ---------------------------------------------------------------------------
@@ -193,6 +231,21 @@ export const PREFIX_PATTERNS: SecretPrefixPattern[] = [
  */
 export const TOKEN_SHAPE =
   /^[A-Za-z0-9][A-Za-z0-9_-]*[_-](?:tkn|token|key|secret|api|pat|sk|auth)[_-]([A-Za-z0-9_-]{16,})$/i;
+
+/**
+ * Length bounds for the whole-message token-shape heuristic, shared by the
+ * daemon ingress check and the web composer scanner so both accept and reject
+ * the same whole-message tokens. Below the min a "token" is too short to be a
+ * plausible secret; above the max it is almost certainly a paste of something
+ * else (a base64 blob, a minified line) rather than a single credential.
+ */
+export const TOKEN_SHAPE_MIN_LENGTH = 20;
+export const TOKEN_SHAPE_MAX_LENGTH = 512;
+
+/** Detection label for a whole-message token-shape match, shared by the daemon
+ * ingress check and the web composer scanner so both report the same
+ * user-facing type. */
+export const TOKEN_SHAPE_LABEL = "Token-shaped value";
 
 // ---------------------------------------------------------------------------
 // Placeholder suppression (ingress semantics: user-typed input, near-zero
@@ -364,7 +417,11 @@ export function detectSecretsInText(text: string): DetectedSecret[] {
 
   if (matches.length === 0) {
     const trimmed = text.trim();
-    const shapeMatch = TOKEN_SHAPE.exec(trimmed);
+    const shapeMatch =
+      trimmed.length >= TOKEN_SHAPE_MIN_LENGTH &&
+      trimmed.length <= TOKEN_SHAPE_MAX_LENGTH
+        ? TOKEN_SHAPE.exec(trimmed)
+        : null;
     if (
       shapeMatch !== null &&
       !isPlaceholderValue(trimmed) &&
@@ -372,7 +429,7 @@ export function detectSecretsInText(text: string): DetectedSecret[] {
     ) {
       const start = text.length - text.trimStart().length;
       matches.push({
-        label: "Token-shaped message",
+        label: TOKEN_SHAPE_LABEL,
         value: trimmed,
         start,
         end: start + trimmed.length,


### PR DESCRIPTION
## Summary
Self-review remediation on the shared secret-detection module:
- Single exported TOKEN_SHAPE_LABEL used by both the daemon and the web scanner (was two divergent strings)
- Token-shape length bounds moved into the shared module and applied by detectSecretsInText, so client and server agree (was client-only unbounded)
- Guard test binds the store-dialog slot map to PREFIX_PATTERNS labels so a rename fails loudly
- Docstring corrected: the client is a conservative superset pre-filter of daemon ingress, not an identical twin
- log-redact/secret-scanner use a header-only private-key matcher (O(n) hot path); chat detectSecretsInText keeps whole-block capture (P1 stays fixed)

Part of plan: composer-secret-guard.md (self-review remediation)