### PR TITLE
refactor(memory): make fetchRecentSummaries a two-step, dropping the summaries×conversations JOIN

### DIFF
--- a/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-recent-summaries.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-recent-summaries.test.ts
@@ -118,4 +118,21 @@ describe("fetchRecentSummaries", () => {
   test("returns an empty list when there are no summaries", () => {
     expect(recentSummaries()).toEqual([]);
   });
+
+  test("finds user summaries even behind 100+ newer background summaries", () => {
+    // 3 (older) user summaries, then many newer background summaries. A
+    // fixed-window scan would cut the user rows off; the full scan must still
+    // return them.
+    seedConversation("u1", "standard");
+    seedSummary("u1", "user u1", 1);
+    seedConversation("u2", "standard");
+    seedSummary("u2", "user u2", 2);
+    seedConversation("u3", "standard");
+    seedSummary("u3", "user u3", 3);
+    for (let i = 0; i < 110; i++) {
+      seedConversation(`bg${i}`, "background");
+      seedSummary(`bg${i}`, `bg ${i}`, 100 + i); // all newer than the users
+    }
+    expect(recentSummaries()).toEqual(["user u3", "user u2", "user u1"]);
+  });
 });

--- a/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-recent-summaries.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-recent-summaries.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for `ConversationGraphMemory.fetchRecentSummaries` — the cross-DB-ready
+ * two-step that replaced the `memory_summaries × conversations` JOIN. It reads
+ * candidate summaries, resolves each conversation's type separately, and
+ * partitions in JS: up to 3 user summaries (most recent first), then at most 1
+ * background/scheduled to fill, excluding the current conversation and any
+ * summary whose conversation row is gone (the old innerJoin's drop).
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDb } from "../../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../../persistence/db-init.js";
+import {
+  conversations,
+  memorySummaries,
+} from "../../../../../persistence/schema/index.js";
+import { ConversationGraphMemory } from "../conversation-graph-memory.js";
+
+await initializeDb();
+
+const CURRENT = "conv-current";
+
+function seedConversation(id: string, type: string): void {
+  getDb()
+    .insert(conversations)
+    .values({ id, conversationType: type, createdAt: 0, updatedAt: 0 })
+    .run();
+}
+
+function seedSummary(
+  scopeKey: string,
+  summary: string,
+  updatedAt: number,
+): void {
+  getDb()
+    .insert(memorySummaries)
+    .values({
+      id: `sum-${scopeKey}`,
+      scope: "conversation",
+      scopeKey,
+      summary,
+      tokenEstimate: 10,
+      version: 1,
+      startAt: 0,
+      endAt: updatedAt,
+      createdAt: updatedAt,
+      updatedAt,
+    })
+    .run();
+}
+
+function recentSummaries(): string[] {
+  const cgm = new ConversationGraphMemory(CURRENT);
+  return (
+    cgm as unknown as { fetchRecentSummaries: () => string[] }
+  ).fetchRecentSummaries();
+}
+
+beforeEach(() => {
+  getDb().delete(memorySummaries).run();
+  getDb().delete(conversations).run();
+});
+
+describe("fetchRecentSummaries", () => {
+  test("returns the 3 most-recent user summaries and no background when 3+ users exist", () => {
+    ["u1", "u2", "u3", "u4"].forEach((id, i) => {
+      seedConversation(id, "standard");
+      seedSummary(id, `user ${id}`, 100 + i); // u4 is newest at 103
+    });
+    // A background summary that is newer than every user summary must still be
+    // dropped once 3 user summaries are available.
+    seedConversation("b1", "background");
+    seedSummary("b1", "bg b1", 1000);
+
+    expect(recentSummaries()).toEqual(["user u4", "user u3", "user u2"]);
+  });
+
+  test("fills the remaining slot with the single most-recent background when fewer than 3 users", () => {
+    seedConversation("u1", "standard");
+    seedSummary("u1", "user u1", 200);
+    seedConversation("u2", "standard");
+    seedSummary("u2", "user u2", 100);
+    seedConversation("b1", "background");
+    seedSummary("b1", "bg b1", 300); // newest overall
+    seedConversation("b2", "scheduled");
+    seedSummary("b2", "bg b2", 250);
+
+    expect(recentSummaries()).toEqual(["user u1", "user u2", "bg b1"]);
+  });
+
+  test("returns a single background summary when there are no user summaries", () => {
+    seedConversation("b1", "background");
+    seedSummary("b1", "bg b1", 100);
+    seedConversation("b2", "scheduled");
+    seedSummary("b2", "bg b2", 200); // newest
+
+    expect(recentSummaries()).toEqual(["bg b2"]);
+  });
+
+  test("excludes the current conversation and orphan summaries", () => {
+    seedSummary(CURRENT, "self summary", 500); // excluded: current conversation
+    seedSummary("orphan", "orphan summary", 400); // excluded: no conversation row
+    seedConversation("u1", "standard");
+    seedSummary("u1", "user u1", 100);
+
+    expect(recentSummaries()).toEqual(["user u1"]);
+  });
+
+  test("orders results most-recent first by updatedAt", () => {
+    seedConversation("a", "standard");
+    seedSummary("a", "older", 100);
+    seedConversation("b", "standard");
+    seedSummary("b", "newer", 200);
+
+    expect(recentSummaries()).toEqual(["newer", "older"]);
+  });
+
+  test("returns an empty list when there are no summaries", () => {
+    expect(recentSummaries()).toEqual([]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-recent-summaries.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-recent-summaries.test.ts
@@ -1,10 +1,11 @@
 /**
- * Tests for `ConversationGraphMemory.fetchRecentSummaries` — the cross-DB-ready
- * two-step that replaced the `memory_summaries × conversations` JOIN. It reads
- * candidate summaries, resolves each conversation's type separately, and
- * partitions in JS: up to 3 user summaries (most recent first), then at most 1
- * background/scheduled to fill, excluding the current conversation and any
- * summary whose conversation row is gone (the old innerJoin's drop).
+ * Tests for `ConversationGraphMemory.fetchRecentSummaries`. It pages through
+ * candidate conversation summaries most-recent first, resolves each
+ * conversation's type with a separate lookup rather than a JOIN (so the two
+ * tables need not share a connection), and partitions in JS: up to 3 user
+ * summaries (most recent first), then at most 1 background/scheduled to fill. It
+ * excludes the current conversation and any summary whose conversation row is
+ * gone.
  */
 import { beforeEach, describe, expect, test } from "bun:test";
 
@@ -119,17 +120,17 @@ describe("fetchRecentSummaries", () => {
     expect(recentSummaries()).toEqual([]);
   });
 
-  test("finds user summaries even behind 100+ newer background summaries", () => {
-    // 3 (older) user summaries, then many newer background summaries. A
-    // fixed-window scan would cut the user rows off; the full scan must still
-    // return them.
+  test("pages past a full page of newer background summaries to find users", () => {
+    // 3 (older) user summaries, then more than one page of newer background
+    // summaries. A single fixed window would cut the user rows off; paging must
+    // walk past the first background-only page to return them.
     seedConversation("u1", "standard");
     seedSummary("u1", "user u1", 1);
     seedConversation("u2", "standard");
     seedSummary("u2", "user u2", 2);
     seedConversation("u3", "standard");
     seedSummary("u3", "user u3", 3);
-    for (let i = 0; i < 110; i++) {
+    for (let i = 0; i < 250; i++) {
       seedConversation(`bg${i}`, "background");
       seedSummary(`bg${i}`, `bg ${i}`, 100 + i); // all newer than the users
     }

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -115,16 +115,6 @@ export type GraphMemoryResult = Awaited<
 >;
 
 /**
- * How many recent conversation summaries {@link
- * ConversationGraphMemory.fetchRecentSummaries} scans to find the 3 it returns.
- * The scan no longer joins `conversations`, so it over-fetches and partitions in
- * JS; background/scheduled conversations are a small minority, so this window
- * contains the 3 most-recent user summaries in every realistic history, and the
- * read is best-effort regardless.
- */
-const RECENT_SUMMARY_CANDIDATE_LIMIT = 100;
-
-/**
  * Manages memory graph state for a single conversation.
  * Create one per Conversation instance. Persists across turns.
  */
@@ -236,16 +226,13 @@ export class ConversationGraphMemory {
     try {
       const db = getDb();
 
-      // Read candidate summaries most-recent first. This can't join
-      // `conversations` because `memory_summaries` is moving to the dedicated
-      // memory database while `conversations` stays on main, so the
-      // conversationType filter runs as a second lookup below. Over-fetch a
-      // window (see RECENT_SUMMARY_CANDIDATE_LIMIT) and partition in JS.
-      const candidates = db
-        .select({
-          scopeKey: memorySummaries.scopeKey,
-          summary: memorySummaries.summary,
-        })
+      // Read the candidate conversation summaries' keys, most-recent first. Only
+      // ids/timestamps are read here so the full summary text is fetched for
+      // just the few rows actually returned. The conversationType filter is a
+      // separate lookup rather than a JOIN, so summaries and conversations need
+      // not share a database connection.
+      const candidateKeys = db
+        .select({ scopeKey: memorySummaries.scopeKey })
         .from(memorySummaries)
         .where(
           and(
@@ -254,60 +241,81 @@ export class ConversationGraphMemory {
           ),
         )
         .orderBy(desc(memorySummaries.updatedAt))
-        .limit(RECENT_SUMMARY_CANDIDATE_LIMIT)
-        .all();
+        .all()
+        .map((r) => r.scopeKey);
 
-      if (candidates.length === 0) {
+      if (candidateKeys.length === 0) {
         return [];
       }
 
-      // Resolve each candidate conversation's type on the main connection. A
-      // summary whose conversation row is gone is dropped, matching the old
-      // innerJoin. Chunk the id list under SQLite's bound-parameter limit.
+      // Resolve each candidate conversation's type. A summary whose conversation
+      // row is gone is dropped, matching the old innerJoin. Chunk the id list
+      // under SQLite's bound-parameter limit.
       const typeByConversation = new Map<string, string>();
-      const ids = candidates.map((c) => c.scopeKey);
       const CHUNK = 500;
-      for (let i = 0; i < ids.length; i += CHUNK) {
+      for (let i = 0; i < candidateKeys.length; i += CHUNK) {
         const rows = db
           .select({
             id: conversations.id,
             type: conversations.conversationType,
           })
           .from(conversations)
-          .where(inArray(conversations.id, ids.slice(i, i + CHUNK)))
+          .where(inArray(conversations.id, candidateKeys.slice(i, i + CHUNK)))
           .all();
         for (const r of rows) {
           typeByConversation.set(r.id, r.type);
         }
       }
 
-      // Partition in the candidates' most-recent-first order: up to 3 user
-      // summaries, then at most 1 background/scheduled to fill — exactly the two
-      // limited queries this replaces.
-      const userSummaries: string[] = [];
-      const backgroundSummaries: string[] = [];
-      for (const candidate of candidates) {
-        const type = typeByConversation.get(candidate.scopeKey);
+      // Walk every candidate in most-recent-first order (not a fixed window, so
+      // the 3 most-recent user summaries are still found behind any number of
+      // newer background rows) and pick up to 3 user keys, then at most 1
+      // background/scheduled to fill — exactly the two limited queries this
+      // replaces.
+      const selectedKeys: string[] = [];
+      const backgroundKeys: string[] = [];
+      for (const scopeKey of candidateKeys) {
+        const type = typeByConversation.get(scopeKey);
         if (type === undefined) {
           continue; // orphan summary — the old innerJoin dropped it
         }
         if (type === "background" || type === "scheduled") {
-          if (backgroundSummaries.length < 1) {
-            backgroundSummaries.push(candidate.summary);
-          }
-        } else if (userSummaries.length < 3) {
-          userSummaries.push(candidate.summary);
+          if (backgroundKeys.length < 1) backgroundKeys.push(scopeKey);
+        } else if (selectedKeys.length < 3) {
+          selectedKeys.push(scopeKey);
         }
-        if (userSummaries.length >= 3) {
-          break;
-        }
+        if (selectedKeys.length >= 3) break;
+      }
+      if (selectedKeys.length < 3) {
+        selectedKeys.push(
+          ...backgroundKeys.slice(0, Math.min(1, 3 - selectedKeys.length)),
+        );
+      }
+      if (selectedKeys.length === 0) {
+        return [];
       }
 
-      if (userSummaries.length >= 3) {
-        return userSummaries;
-      }
-      const remaining = Math.min(1, 3 - userSummaries.length);
-      return [...userSummaries, ...backgroundSummaries.slice(0, remaining)];
+      // Fetch the summary text for the selected rows only, then return them in
+      // the selection order (user summaries most-recent first, then the one
+      // background summary).
+      const textByKey = new Map<string, string>();
+      const selectedRows = db
+        .select({
+          scopeKey: memorySummaries.scopeKey,
+          summary: memorySummaries.summary,
+        })
+        .from(memorySummaries)
+        .where(
+          and(
+            eq(memorySummaries.scope, "conversation"),
+            inArray(memorySummaries.scopeKey, selectedKeys),
+          ),
+        )
+        .all();
+      for (const r of selectedRows) textByKey.set(r.scopeKey, r.summary);
+      return selectedKeys
+        .map((k) => textByKey.get(k))
+        .filter((s): s is string => s !== undefined);
     } catch (err) {
       log.warn({ err }, "Failed to fetch recent conversation summaries");
       return [];

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -15,7 +15,7 @@ import type {
   ImageContent,
   Message,
 } from "@vellumai/plugin-api";
-import { and, desc, eq, inArray, ne } from "drizzle-orm";
+import { and, desc, eq, inArray, lt, ne, or, type SQL } from "drizzle-orm";
 import { z } from "zod";
 
 import {
@@ -246,28 +246,48 @@ export class ConversationGraphMemory {
       // background/scheduled summary fills a remaining slot.
       const selectedKeys: string[] = [];
       let backgroundKey: string | null = null;
-      for (
-        let offset = 0;
-        selectedKeys.length < 3;
-        offset += RECENT_SUMMARY_PAGE_SIZE
-      ) {
-        const page = db
-          .select({ scopeKey: memorySummaries.scopeKey })
+      // Keyset cursor over (updatedAt, scopeKey) in most-recent-first order.
+      // Null on the first page; each page advances it past its last row so the
+      // scan resumes through the index rather than re-walking every prior row as
+      // a growing OFFSET would, which keeps the whole read linear in the rows
+      // actually visited. scopeKey is unique per conversation summary, so the
+      // pair is a stable tiebreaker across equal updatedAt values.
+      let cursor: { updatedAt: number; scopeKey: string } | null = null;
+      while (selectedKeys.length < 3) {
+        const beyondCursor: SQL | undefined = cursor
+          ? or(
+              lt(memorySummaries.updatedAt, cursor.updatedAt),
+              and(
+                eq(memorySummaries.updatedAt, cursor.updatedAt),
+                lt(memorySummaries.scopeKey, cursor.scopeKey),
+              ),
+            )
+          : undefined;
+        const page: Array<{ scopeKey: string; updatedAt: number }> = db
+          .select({
+            scopeKey: memorySummaries.scopeKey,
+            updatedAt: memorySummaries.updatedAt,
+          })
           .from(memorySummaries)
           .where(
             and(
               eq(memorySummaries.scope, "conversation"),
               ne(memorySummaries.scopeKey, this.conversationId),
+              beyondCursor,
             ),
           )
-          .orderBy(desc(memorySummaries.updatedAt))
+          .orderBy(
+            desc(memorySummaries.updatedAt),
+            desc(memorySummaries.scopeKey),
+          )
           .limit(RECENT_SUMMARY_PAGE_SIZE)
-          .offset(offset)
-          .all()
-          .map((r) => r.scopeKey);
+          .all();
         if (page.length === 0) {
           break;
         }
+        const lastRow = page[page.length - 1]!;
+        cursor = { updatedAt: lastRow.updatedAt, scopeKey: lastRow.scopeKey };
+        const pageKeys = page.map((r) => r.scopeKey);
 
         const typeByConversation = new Map<string, string>();
         const rows = db
@@ -276,13 +296,13 @@ export class ConversationGraphMemory {
             type: conversations.conversationType,
           })
           .from(conversations)
-          .where(inArray(conversations.id, page))
+          .where(inArray(conversations.id, pageKeys))
           .all();
         for (const r of rows) {
           typeByConversation.set(r.id, r.type);
         }
 
-        for (const scopeKey of page) {
+        for (const scopeKey of pageKeys) {
           const type = typeByConversation.get(scopeKey);
           if (type === undefined) {
             continue; // its conversation row is gone — skip it

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -15,7 +15,7 @@ import type {
   ImageContent,
   Message,
 } from "@vellumai/plugin-api";
-import { and, desc, eq, inArray, ne, notInArray } from "drizzle-orm";
+import { and, desc, eq, inArray, ne } from "drizzle-orm";
 import { z } from "zod";
 
 import {
@@ -113,6 +113,16 @@ export function getLiveGraphMemory(
 export type GraphMemoryResult = Awaited<
   ReturnType<ConversationGraphMemory["prepareMemory"]>
 >;
+
+/**
+ * How many recent conversation summaries {@link
+ * ConversationGraphMemory.fetchRecentSummaries} scans to find the 3 it returns.
+ * The scan no longer joins `conversations`, so it over-fetches and partitions in
+ * JS; background/scheduled conversations are a small minority, so this window
+ * contains the 3 most-recent user summaries in every realistic history, and the
+ * read is best-effort regardless.
+ */
+const RECENT_SUMMARY_CANDIDATE_LIMIT = 100;
 
 /**
  * Manages memory graph state for a single conversation.
@@ -225,59 +235,79 @@ export class ConversationGraphMemory {
   private fetchRecentSummaries(): string[] {
     try {
       const db = getDb();
-      const baseWhere = and(
-        eq(memorySummaries.scope, "conversation"),
-        ne(memorySummaries.scopeKey, this.conversationId),
-      );
 
-      // Fetch user conversations first (up to 3)
-      const userRows = db
-        .select({ summary: memorySummaries.summary })
+      // Read candidate summaries most-recent first. This can't join
+      // `conversations` because `memory_summaries` is moving to the dedicated
+      // memory database while `conversations` stays on main, so the
+      // conversationType filter runs as a second lookup below. Over-fetch a
+      // window (see RECENT_SUMMARY_CANDIDATE_LIMIT) and partition in JS.
+      const candidates = db
+        .select({
+          scopeKey: memorySummaries.scopeKey,
+          summary: memorySummaries.summary,
+        })
         .from(memorySummaries)
-        .innerJoin(
-          conversations,
-          eq(memorySummaries.scopeKey, conversations.id),
-        )
         .where(
           and(
-            baseWhere,
-            notInArray(conversations.conversationType, [
-              "background",
-              "scheduled",
-            ]),
+            eq(memorySummaries.scope, "conversation"),
+            ne(memorySummaries.scopeKey, this.conversationId),
           ),
         )
         .orderBy(desc(memorySummaries.updatedAt))
-        .limit(3)
+        .limit(RECENT_SUMMARY_CANDIDATE_LIMIT)
         .all();
 
-      if (userRows.length >= 3) {
-        return userRows.map((r) => r.summary);
+      if (candidates.length === 0) {
+        return [];
       }
 
-      // Fill remaining slots with at most 1 background/scheduled conversation
-      const remaining = Math.min(1, 3 - userRows.length);
-      const bgRows = db
-        .select({ summary: memorySummaries.summary })
-        .from(memorySummaries)
-        .innerJoin(
-          conversations,
-          eq(memorySummaries.scopeKey, conversations.id),
-        )
-        .where(
-          and(
-            baseWhere,
-            inArray(conversations.conversationType, [
-              "background",
-              "scheduled",
-            ]),
-          ),
-        )
-        .orderBy(desc(memorySummaries.updatedAt))
-        .limit(remaining)
-        .all();
+      // Resolve each candidate conversation's type on the main connection. A
+      // summary whose conversation row is gone is dropped, matching the old
+      // innerJoin. Chunk the id list under SQLite's bound-parameter limit.
+      const typeByConversation = new Map<string, string>();
+      const ids = candidates.map((c) => c.scopeKey);
+      const CHUNK = 500;
+      for (let i = 0; i < ids.length; i += CHUNK) {
+        const rows = db
+          .select({
+            id: conversations.id,
+            type: conversations.conversationType,
+          })
+          .from(conversations)
+          .where(inArray(conversations.id, ids.slice(i, i + CHUNK)))
+          .all();
+        for (const r of rows) {
+          typeByConversation.set(r.id, r.type);
+        }
+      }
 
-      return [...userRows, ...bgRows].map((r) => r.summary);
+      // Partition in the candidates' most-recent-first order: up to 3 user
+      // summaries, then at most 1 background/scheduled to fill — exactly the two
+      // limited queries this replaces.
+      const userSummaries: string[] = [];
+      const backgroundSummaries: string[] = [];
+      for (const candidate of candidates) {
+        const type = typeByConversation.get(candidate.scopeKey);
+        if (type === undefined) {
+          continue; // orphan summary — the old innerJoin dropped it
+        }
+        if (type === "background" || type === "scheduled") {
+          if (backgroundSummaries.length < 1) {
+            backgroundSummaries.push(candidate.summary);
+          }
+        } else if (userSummaries.length < 3) {
+          userSummaries.push(candidate.summary);
+        }
+        if (userSummaries.length >= 3) {
+          break;
+        }
+      }
+
+      if (userSummaries.length >= 3) {
+        return userSummaries;
+      }
+      const remaining = Math.min(1, 3 - userSummaries.length);
+      return [...userSummaries, ...backgroundSummaries.slice(0, remaining)];
     } catch (err) {
       log.warn({ err }, "Failed to fetch recent conversation summaries");
       return [];

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -249,8 +249,8 @@ export class ConversationGraphMemory {
       }
 
       // Resolve each candidate conversation's type. A summary whose conversation
-      // row is gone is dropped, matching the old innerJoin. Chunk the id list
-      // under SQLite's bound-parameter limit.
+      // row is gone is skipped (only summaries for a live conversation count).
+      // Chunk the id list under SQLite's bound-parameter limit.
       const typeByConversation = new Map<string, string>();
       const CHUNK = 500;
       for (let i = 0; i < candidateKeys.length; i += CHUNK) {
@@ -277,14 +277,18 @@ export class ConversationGraphMemory {
       for (const scopeKey of candidateKeys) {
         const type = typeByConversation.get(scopeKey);
         if (type === undefined) {
-          continue; // orphan summary — the old innerJoin dropped it
+          continue; // its conversation row is gone — skip it
         }
         if (type === "background" || type === "scheduled") {
-          if (backgroundKeys.length < 1) backgroundKeys.push(scopeKey);
+          if (backgroundKeys.length < 1) {
+            backgroundKeys.push(scopeKey);
+          }
         } else if (selectedKeys.length < 3) {
           selectedKeys.push(scopeKey);
         }
-        if (selectedKeys.length >= 3) break;
+        if (selectedKeys.length >= 3) {
+          break;
+        }
       }
       if (selectedKeys.length < 3) {
         selectedKeys.push(

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -73,6 +73,15 @@ const log = getLogger("graph-conversation-memory");
 
 const ESTIMATED_IMAGE_TOKENS = 1000;
 
+/**
+ * Page size for {@link ConversationGraphMemory.fetchRecentSummaries}. It reads
+ * candidate summaries a page at a time and stops once three user summaries are
+ * found, so the common case (recent conversations are user ones) touches a
+ * single page regardless of history size. Also bounds the per-page conversation
+ * lookup below SQLite's bound-parameter limit.
+ */
+const RECENT_SUMMARY_PAGE_SIZE = 200;
+
 // ---------------------------------------------------------------------------
 // Per-conversation state
 // ---------------------------------------------------------------------------
@@ -226,74 +235,76 @@ export class ConversationGraphMemory {
     try {
       const db = getDb();
 
-      // Read the candidate conversation summaries' keys, most-recent first. Only
-      // ids/timestamps are read here so the full summary text is fetched for
-      // just the few rows actually returned. The conversationType filter is a
-      // separate lookup rather than a JOIN, so summaries and conversations need
-      // not share a database connection.
-      const candidateKeys = db
-        .select({ scopeKey: memorySummaries.scopeKey })
-        .from(memorySummaries)
-        .where(
-          and(
-            eq(memorySummaries.scope, "conversation"),
-            ne(memorySummaries.scopeKey, this.conversationId),
-          ),
-        )
-        .orderBy(desc(memorySummaries.updatedAt))
-        .all()
-        .map((r) => r.scopeKey);
+      // Page through candidate summary keys most-recent first, resolving each
+      // page's conversation types before moving on, and stop as soon as 3 user
+      // summaries are found. Only keys are read here so the full text is fetched
+      // for just the rows returned. conversationType is a separate lookup rather
+      // than a JOIN, so summaries and conversations need not share a database
+      // connection; keeping it per-page bounds both the scan and the lookup to
+      // the pages actually needed, rather than the user's entire history. A
+      // summary whose conversation row is gone is skipped, and at most 1
+      // background/scheduled summary fills a remaining slot.
+      const selectedKeys: string[] = [];
+      let backgroundKey: string | null = null;
+      for (
+        let offset = 0;
+        selectedKeys.length < 3;
+        offset += RECENT_SUMMARY_PAGE_SIZE
+      ) {
+        const page = db
+          .select({ scopeKey: memorySummaries.scopeKey })
+          .from(memorySummaries)
+          .where(
+            and(
+              eq(memorySummaries.scope, "conversation"),
+              ne(memorySummaries.scopeKey, this.conversationId),
+            ),
+          )
+          .orderBy(desc(memorySummaries.updatedAt))
+          .limit(RECENT_SUMMARY_PAGE_SIZE)
+          .offset(offset)
+          .all()
+          .map((r) => r.scopeKey);
+        if (page.length === 0) {
+          break;
+        }
 
-      if (candidateKeys.length === 0) {
-        return [];
-      }
-
-      // Resolve each candidate conversation's type. A summary whose conversation
-      // row is gone is skipped (only summaries for a live conversation count).
-      // Chunk the id list under SQLite's bound-parameter limit.
-      const typeByConversation = new Map<string, string>();
-      const CHUNK = 500;
-      for (let i = 0; i < candidateKeys.length; i += CHUNK) {
+        const typeByConversation = new Map<string, string>();
         const rows = db
           .select({
             id: conversations.id,
             type: conversations.conversationType,
           })
           .from(conversations)
-          .where(inArray(conversations.id, candidateKeys.slice(i, i + CHUNK)))
+          .where(inArray(conversations.id, page))
           .all();
         for (const r of rows) {
           typeByConversation.set(r.id, r.type);
         }
-      }
 
-      // Walk every candidate in most-recent-first order (not a fixed window, so
-      // the 3 most-recent user summaries are still found behind any number of
-      // newer background rows) and pick up to 3 user keys, then at most 1
-      // background/scheduled to fill — exactly the two limited queries this
-      // replaces.
-      const selectedKeys: string[] = [];
-      const backgroundKeys: string[] = [];
-      for (const scopeKey of candidateKeys) {
-        const type = typeByConversation.get(scopeKey);
-        if (type === undefined) {
-          continue; // its conversation row is gone — skip it
-        }
-        if (type === "background" || type === "scheduled") {
-          if (backgroundKeys.length < 1) {
-            backgroundKeys.push(scopeKey);
+        for (const scopeKey of page) {
+          const type = typeByConversation.get(scopeKey);
+          if (type === undefined) {
+            continue; // its conversation row is gone — skip it
           }
-        } else if (selectedKeys.length < 3) {
-          selectedKeys.push(scopeKey);
+          if (type === "background" || type === "scheduled") {
+            if (backgroundKey === null) {
+              backgroundKey = scopeKey;
+            }
+          } else if (selectedKeys.length < 3) {
+            selectedKeys.push(scopeKey);
+            if (selectedKeys.length >= 3) {
+              break;
+            }
+          }
         }
-        if (selectedKeys.length >= 3) {
-          break;
+
+        if (page.length < RECENT_SUMMARY_PAGE_SIZE) {
+          break; // last page reached
         }
       }
-      if (selectedKeys.length < 3) {
-        selectedKeys.push(
-          ...backgroundKeys.slice(0, Math.min(1, 3 - selectedKeys.length)),
-        );
+      if (selectedKeys.length < 3 && backgroundKey !== null) {
+        selectedKeys.push(backgroundKey);
       }
       if (selectedKeys.length === 0) {
         return [];
@@ -316,7 +327,9 @@ export class ConversationGraphMemory {
           ),
         )
         .all();
-      for (const r of selectedRows) textByKey.set(r.scopeKey, r.summary);
+      for (const r of selectedRows) {
+        textByKey.set(r.scopeKey, r.summary);
+      }
       return selectedKeys
         .map((k) => textByKey.get(k))
         .filter((s): s is string => s !== undefined);


### PR DESCRIPTION
Prepares `memory_summaries` for the memory-DB cutover (ATL-1001, Wave 4). `fetchRecentSummaries` currently joins `memory_summaries` to `conversations` to filter by `conversationType` — impossible once summaries move to `assistant-memory.db` while `conversations` stays on main.

Rewrites it as a two-step: read candidate conversation summaries, resolve each conversation's type in a second lookup on the main connection, then partition in JS — up to 3 user summaries (most recent first), then at most 1 background/scheduled to fill, excluding the current conversation and any summary whose conversation row is gone (matching the old `innerJoin` drop). Behavior-preserving on the current schema; the later summaries move just points step 1 at the memory connection.