### PR TITLE
fix(secret-detection): bounded whole-block private-key redaction (close header-only leak)

### DIFF
--- a/assistant/src/__tests__/log-redact.test.ts
+++ b/assistant/src/__tests__/log-redact.test.ts
@@ -26,6 +26,24 @@ describe("redactLogString", () => {
     expect(redactLogString(input)).toBe(input);
   });
 
+  test("redacts a whole PEM private-key block — body and footer, not just the header", () => {
+    // Synthetic fake PEM material only — never a real key. `redactLogString`
+    // replaces the matched span in place, so the match must cover
+    // header→body→footer or the base64 body and END footer leak into logs.
+    const fakeBody =
+      "MIIFAKEfakefakefakefakefakefakefakefakefake\n" +
+      "FAKEfakefakefakefakefakefakefakefakefake==";
+    const block = `-----BEGIN RSA PRIVATE KEY-----\n${fakeBody}\n-----END RSA PRIVATE KEY-----`;
+    const result = redactLogString(`error dumping key: ${block} <eol>`);
+    expect(result).toContain("[REDACTED]");
+    expect(result).not.toContain("MIIFAKE");
+    expect(result).not.toContain("FAKEfake");
+    expect(result).not.toContain("-----BEGIN");
+    expect(result).not.toContain("-----END");
+    expect(result).toContain("error dumping key:");
+    expect(result).toContain("<eol>");
+  });
+
   describe("plugin-declared patterns", () => {
     // Synthetic token mirroring the incident's shape (never a real credential).
     const pluginKey = "virlo_tkn_Qm7pW2xLbV9sKjR4tNcY8dZh3Fg";

--- a/assistant/src/__tests__/secret-scanner.test.ts
+++ b/assistant/src/__tests__/secret-scanner.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   _isPlaceholder,
   redactSecrets,
+  redactSecretsWith,
   scanText,
   type SecretMatch,
 } from "../security/secret-scanner.js";
@@ -430,6 +431,41 @@ describe("redaction", () => {
     const result = redactSecrets(input);
     expect(result).toContain('<redacted type="AWS Access Key" />');
     expect(result).toContain('<redacted type="GitHub Token" />');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PEM private-key body redaction — the scanner replaces the matched span in
+// place, so the match must cover header→body→footer or the base64 body and
+// END footer survive redaction (the header-only-matcher leak this fixes).
+// Synthetic fake PEM material only — never a real key.
+// ---------------------------------------------------------------------------
+describe("private-key block redaction", () => {
+  const FAKE_PEM_BODY =
+    "MIIFAKEfakefakefakefakefakefakefakefakefake\n" +
+    "FAKEfakefakefakefakefakefakefakefakefake==";
+  const FULL_PEM_BLOCK = `-----BEGIN RSA PRIVATE KEY-----\n${FAKE_PEM_BODY}\n-----END RSA PRIVATE KEY-----`;
+
+  test("redactSecrets removes the whole block — body and footer, not just the header", () => {
+    const input = `here is the key:\n${FULL_PEM_BLOCK}\nuse it well`;
+    const result = redactSecrets(input);
+    expect(result).toContain('<redacted type="Private Key" />');
+    // The base64 body must not survive.
+    expect(result).not.toContain("MIIFAKE");
+    expect(result).not.toContain("FAKEfake");
+    // Header and footer must not survive either.
+    expect(result).not.toContain("-----BEGIN");
+    expect(result).not.toContain("-----END");
+    // Surrounding text is preserved.
+    expect(result).toContain("here is the key:");
+    expect(result).toContain("use it well");
+  });
+
+  test("redactSecretsWith removes the whole block", () => {
+    const result = redactSecretsWith(FULL_PEM_BLOCK, () => "[KEY]");
+    expect(result).toBe("[KEY]");
+    expect(result).not.toContain("MIIFAKE");
+    expect(result).not.toContain("-----END");
   });
 });
 

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -71,11 +71,12 @@ function derivePluginScannerPattern(p: SecretPrefixPattern): SecretPattern {
   };
 }
 
-// Static patterns derived from the shared source of truth. The scanner detects
-// and redacts but never stores or rewrites a private key, so it uses the
-// header-only private-key matcher (via REDACTION_PREFIX_PATTERNS) — the
-// whole-block redaction the chat-persist path needs is handled by
-// candidate protection running before this scanner.
+// Static patterns derived from the shared source of truth. This scanner
+// redacts by replacing the matched span in place, so it uses the bounded
+// whole-block private-key matcher (via REDACTION_PREFIX_PATTERNS): the match
+// must cover header → body → footer or the key body would survive redaction.
+// The bound keeps it O(n) on large serialized strings; `detectSecretsInText`
+// (chat) keeps the unbounded whole-block matcher for full-key capture.
 const PREFIX_DERIVED: SecretPattern[] =
   REDACTION_PREFIX_PATTERNS.map(deriveScannerPattern);
 

--- a/assistant/src/util/log-redact.ts
+++ b/assistant/src/util/log-redact.ts
@@ -19,9 +19,10 @@ import { REDACTION_PREFIX_PATTERNS } from "../security/secret-patterns.js";
 
 const BEARER_RE = /Bearer [A-Za-z0-9._\-]+/g;
 
-// This serializer only needs to DETECT and mask a secret, never store or
-// rewrite it, so it uses the header-only private-key matcher (via
-// REDACTION_PREFIX_PATTERNS) to stay O(n) on large serialized strings.
+// This serializer redacts by replacing the matched span in place, so it uses
+// the bounded whole-block private-key matcher (via REDACTION_PREFIX_PATTERNS):
+// the match must cover header → body → footer or the key body would survive
+// redaction. The body bound keeps it O(n) on large serialized strings.
 const STATIC_API_KEY_PATTERNS: RegExp[] = REDACTION_PREFIX_PATTERNS.map(
   (p) => new RegExp(p.regex.source, "g"),
 );

--- a/packages/service-contracts/src/__tests__/secret-detection.test.ts
+++ b/packages/service-contracts/src/__tests__/secret-detection.test.ts
@@ -7,8 +7,9 @@ import * as subpathExport from "@vellumai/service-contracts/secret-detection";
 import {
   detectSecretsInText,
   isCompletePrivateKeyBlock,
+  PEM_REDACTION_MAX_BODY_LENGTH,
   PREFIX_PATTERNS,
-  PRIVATE_KEY_HEADER_REGEX,
+  PRIVATE_KEY_REDACTION_REGEX,
   REDACTION_PREFIX_PATTERNS,
   TOKEN_SHAPE,
   TOKEN_SHAPE_LABEL,
@@ -232,7 +233,7 @@ describe("detectSecretsInText — whole-message token shape", () => {
   });
 });
 
-describe("REDACTION_PREFIX_PATTERNS — header-only private key", () => {
+describe("REDACTION_PREFIX_PATTERNS — bounded whole-block private key", () => {
   const FAKE_PEM_BODY =
     "MIIFAKEfakefakefakefakefakefakefakefakefake\n" +
     "FAKEfakefakefakefakefakefakefakefakefake==";
@@ -246,17 +247,68 @@ describe("REDACTION_PREFIX_PATTERNS — header-only private key", () => {
     return new RegExp(entry!.regex.source, "g");
   }
 
-  test("the redaction variant matches the PEM header only, not the whole block", () => {
+  test("the redaction private-key entry is the bounded whole-block matcher", () => {
+    const entry = REDACTION_PREFIX_PATTERNS.find(
+      (p) => p.label === "Private Key",
+    );
+    expect(entry!.regex.source).toBe(PRIVATE_KEY_REDACTION_REGEX.source);
+  });
+
+  test("the redaction variant matches the WHOLE block, not just the header", () => {
     const regex = redactionPrivateKeyRegex();
     const match = regex.exec(FULL_PEM_BLOCK);
+    expect(match).not.toBeNull();
+    // The full header→body→footer span, so an in-place replace removes the
+    // key body and footer, not only the BEGIN line.
+    expect(match![0]).toBe(FULL_PEM_BLOCK);
+  });
+
+  test("an in-place replace with the redaction regex leaves no body or footer", () => {
+    const regex = redactionPrivateKeyRegex();
+    const text = `before\n${FULL_PEM_BLOCK}\nafter`;
+    const redacted = text.replace(regex, "[REDACTED]");
+    expect(redacted).toBe("before\n[REDACTED]\nafter");
+    // The base64 body and the END footer are gone.
+    expect(redacted).not.toContain("MIIFAKE");
+    expect(redacted).not.toContain("-----END");
+    expect(redacted).not.toContain("-----BEGIN");
+  });
+
+  test("a footerless key still redacts header-only (truncated-key fallback)", () => {
+    const regex = redactionPrivateKeyRegex();
+    const text = `-----BEGIN RSA PRIVATE KEY-----\n${FAKE_PEM_BODY}`;
+    const match = regex.exec(text);
+    expect(match).not.toBeNull();
+    // No END within the bound → optional footer group fails → header-only
+    // match, preserving the detection-fires guarantee.
+    expect(match![0]).toBe("-----BEGIN RSA PRIVATE KEY-----");
+  });
+
+  test("a body longer than the bound falls back to header-only, not a hang", () => {
+    const regex = redactionPrivateKeyRegex();
+    // Footer sits just past the body bound, so the whole-block branch can't
+    // reach it and the match degrades to the header (fail-open on redaction:
+    // an unbounded key is not a realistic PEM).
+    const overlongBody = "a".repeat(PEM_REDACTION_MAX_BODY_LENGTH + 100);
+    const text = `-----BEGIN RSA PRIVATE KEY-----\n${overlongBody}\n-----END RSA PRIVATE KEY-----`;
+    const match = regex.exec(text);
     expect(match).not.toBeNull();
     expect(match![0]).toBe("-----BEGIN RSA PRIVATE KEY-----");
   });
 
-  test("PRIVATE_KEY_HEADER_REGEX matches a footerless header", () => {
-    expect(
-      PRIVATE_KEY_HEADER_REGEX.test("-----BEGIN OPENSSH PRIVATE KEY-----"),
-    ).toBe(true);
+  test("many footerless BEGIN headers redact fast (bounded, no O(n²) hang)", () => {
+    const regex = redactionPrivateKeyRegex();
+    // A pathological paste: thousands of footerless headers, each followed by
+    // filler that an unbounded matcher would rescan hunting for a footer. The
+    // body bound caps each rescan, so the whole sweep stays linear.
+    const chunk = `-----BEGIN RSA PRIVATE KEY-----\n${filler(200)}\n`;
+    const text = chunk.repeat(5000);
+    const startedAt = Date.now();
+    const redacted = text.replace(regex, "[REDACTED]");
+    const elapsedMs = Date.now() - startedAt;
+    expect(redacted).toContain("[REDACTED]");
+    expect(redacted).not.toContain("-----BEGIN");
+    expect(elapsedMs).toBeLessThan(2000);
   });
 
   test("every non-private-key pattern is shared verbatim with PREFIX_PATTERNS", () => {

--- a/packages/service-contracts/src/secret-detection.ts
+++ b/packages/service-contracts/src/secret-detection.ts
@@ -62,18 +62,44 @@ const PEM_END = String.raw`-----END ${PEM_KEY_TYPE}-----`;
 const PEM_COMPLETE_BLOCK = new RegExp(`${PEM_END}$`);
 
 /**
- * Header-only private-key matcher: matches just the `-----BEGIN … PRIVATE
- * KEY-----` header, with no optional block-body capture.
- *
- * Detect/redact-only consumers (log serializers, the tool-output scanner) use
- * this instead of the whole-block {@link PREFIX_PATTERNS} entry: they only need
- * to KNOW a private key is present and mask it — they never store or rewrite
- * the block — so they must not pay the O(n²) cost the whole-block matcher incurs
- * on large serialized strings, where every footerless header rescans to EOF
- * looking for a footer. `detectSecretsInText` (chat) keeps the whole-block
- * matcher, which the store/rewrite path relies on to capture the full key.
+ * Whole-block PEM body atom: one tempered body character. `(?!-----BEGIN)`
+ * keeps the body from crossing into an adjacent block, so two keys never
+ * merge into one span.
  */
-export const PRIVATE_KEY_HEADER_REGEX = new RegExp(PEM_BEGIN);
+const PEM_BLOCK_TAIL = String.raw`(?:(?!-----BEGIN)[\s\S])`;
+
+/**
+ * Upper bound on the PEM body scan distance for the redaction matcher. An
+ * RSA-8192 PEM is ~6.4 KB, so 16 KiB clears real keys with headroom while
+ * capping the per-header rescan distance. The bound is what keeps the
+ * redaction matcher O(n) on large serialized strings full of footerless
+ * `-----BEGIN … PRIVATE KEY-----` headers: each header rescans at most this
+ * far looking for a footer instead of to EOF, which is what the unbounded
+ * whole-block matcher does (its O(n²) worst case).
+ */
+export const PEM_REDACTION_MAX_BODY_LENGTH = 16384;
+
+/**
+ * Whole-block private-key matcher for detect-AND-REDACT consumers (log
+ * serializers, the tool-output scanner, staged-export rewrite).
+ *
+ * These consumers replace the matched span in place, so the match must cover
+ * the ENTIRE key — header → body → footer — or the base64 body and `-----END-----`
+ * footer survive redaction. This captures the whole block, but with a
+ * length-BOUNDED body quantifier ({@link PEM_REDACTION_MAX_BODY_LENGTH}) so a
+ * stream of footerless headers cannot drive the O(n²) worst case the unbounded
+ * whole-block matcher incurs. The footer group is optional, so a truncated /
+ * footerless key still matches header-only — preserving the detection-fires
+ * guarantee ingress blocking relies on. Tempered + lazy + bounded ⇒ no
+ * catastrophic backtracking.
+ *
+ * `detectSecretsInText` (chat) keeps the unbounded whole-block
+ * {@link PREFIX_PATTERNS} entry, which the store/rewrite path relies on to
+ * capture arbitrarily large keys in full.
+ */
+export const PRIVATE_KEY_REDACTION_REGEX = new RegExp(
+  `${PEM_BEGIN}(?:${PEM_BLOCK_TAIL}{0,${PEM_REDACTION_MAX_BODY_LENGTH}}?${PEM_END})?`,
+);
 
 /**
  * True when a `Private Key` match is a complete PEM block — it ends at an
@@ -101,9 +127,7 @@ export const PREFIX_PATTERNS: SecretPrefixPattern[] = [
     // no footer (truncated or streamed partial paste) still matches alone,
     // which ingress blocking relies on. The body is tempered — it never
     // crosses another BEGIN header — so adjacent blocks match separately.
-    regex: new RegExp(
-      `${PEM_BEGIN}(?:(?:(?!-----BEGIN)[\\s\\S])*?${PEM_END})?`,
-    ),
+    regex: new RegExp(`${PEM_BEGIN}(?:${PEM_BLOCK_TAIL}*?${PEM_END})?`),
   },
 
   // -- AWS --
@@ -202,18 +226,20 @@ export const PREFIX_PATTERNS: SecretPrefixPattern[] = [
 ];
 
 /**
- * {@link PREFIX_PATTERNS} variant for detect/redact-only consumers (log
- * serializers, the tool-output scanner). Identical to `PREFIX_PATTERNS` except
- * the private-key entry matches the PEM header alone
- * ({@link PRIVATE_KEY_HEADER_REGEX}): those consumers only DETECT or REDACT a
- * private key — they never store or rewrite the block — so they route here to
- * avoid the whole-block matcher's O(n²) worst case on large serialized strings.
- * `detectSecretsInText` (chat) uses `PREFIX_PATTERNS` for full-block capture.
+ * {@link PREFIX_PATTERNS} variant for detect-AND-redact consumers (log
+ * serializers, the tool-output scanner, staged-export rewrite). Identical to
+ * `PREFIX_PATTERNS` except the private-key entry uses the length-BOUNDED
+ * whole-block matcher ({@link PRIVATE_KEY_REDACTION_REGEX}): those consumers
+ * replace the matched span in place, so the match must cover the whole key
+ * (header → body → footer) or the body leaks — but they route to the bounded
+ * matcher to avoid the unbounded whole-block matcher's O(n²) worst case on
+ * large serialized strings. `detectSecretsInText` (chat) uses `PREFIX_PATTERNS`
+ * for unbounded full-block capture.
  */
 export const REDACTION_PREFIX_PATTERNS: SecretPrefixPattern[] =
   PREFIX_PATTERNS.map((p) =>
     p.label === PRIVATE_KEY_LABEL
-      ? { label: PRIVATE_KEY_LABEL, regex: PRIVATE_KEY_HEADER_REGEX }
+      ? { label: PRIVATE_KEY_LABEL, regex: PRIVATE_KEY_REDACTION_REGEX }
       : p,
   );
 


### PR DESCRIPTION
## Summary
Fixes a redaction leak introduced by the header-only private-key matcher: secret-scanner and log-redact replace the matched span in place, so a header-only match left the base64 key body + footer in redacted output (staged exports, logs, guardian prompts). The redaction matcher is now a length-BOUNDED whole-block PEM matcher (header→body→footer, body scan capped ~16KB, header-only fallback for truncated keys) — redacts the full block while keeping the O(n) bound that motivated the header-only change. Chat detectSecretsInText is unchanged (PEM P1 stays fixed).

Part of plan: composer-secret-guard.md (self-review remediation round 2)