### PR TITLE
refactor(assistant): validate suggest_trust_rule request body at the route boundary

### DIFF
--- a/assistant/src/runtime/routes/__tests__/suggest-trust-rule-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/suggest-trust-rule-routes.test.ts
@@ -63,6 +63,7 @@ mock.module("../../../providers/provider-send-message.js", () => ({
 // Import the module under test AFTER mocks are set up
 // ---------------------------------------------------------------------------
 
+import { BadRequestError } from "../errors.js";
 import { ROUTES } from "../suggest-trust-rule-routes.js";
 
 const suggestTrustRuleRoute = ROUTES[0];
@@ -221,6 +222,34 @@ describe("suggestTrustRuleRoute", () => {
       expect(
         (result as { directoryScopeOptions?: unknown }).directoryScopeOptions,
       ).toBeUndefined();
+    });
+  });
+
+  describe("request body validation", () => {
+    test("rejects a body missing required fields with BadRequestError", async () => {
+      await expect(
+        suggestTrustRuleRoute.handler({
+          body: { tool: "bash" } as Record<string, unknown>,
+        }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    test("rejects a body with an out-of-enum intent", async () => {
+      await expect(
+        suggestTrustRuleRoute.handler({
+          body: {
+            ...baseRequest,
+            intent: "sideways",
+          } as unknown as Record<string, unknown>,
+        }),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    test("validates before reaching the provider", async () => {
+      await expect(
+        suggestTrustRuleRoute.handler({ body: {} as Record<string, unknown> }),
+      ).rejects.toThrow(BadRequestError);
+      expect(mockSendMessage).not.toHaveBeenCalled();
     });
   });
 });

--- a/assistant/src/runtime/routes/parse-body.ts
+++ b/assistant/src/runtime/routes/parse-body.ts
@@ -1,0 +1,33 @@
+import type { z } from "zod";
+
+import { BadRequestError } from "./errors.js";
+
+/**
+ * Validate a route's request body against its declared Zod schema and return
+ * the parsed, typed value. Throws {@link BadRequestError} — which both the HTTP
+ * and IPC adapters already map to a `400` — when the body doesn't match.
+ *
+ * This replaces the `body as {…}` casts in route handlers: those assert a shape
+ * at compile time but validate nothing at runtime, so malformed input reaches
+ * handler logic (and today surfaces as a confusing `500`, since a raw `ZodError`
+ * isn't a `RouteError`). Parsing here makes the declared `requestBody` schema
+ * the single source of truth for both the wire contract and runtime enforcement.
+ */
+export function parseBody<Schema extends z.ZodTypeAny>(
+  schema: Schema,
+  body: unknown,
+): z.infer<Schema> {
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    throw new BadRequestError(formatBodyIssues(result.error));
+  }
+  return result.data;
+}
+
+/** Render Zod issues into a compact, PII-free `field: message` summary. */
+function formatBodyIssues(error: z.ZodError): string {
+  const detail = error.issues
+    .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+    .join("; ");
+  return `Invalid request body: ${detail}`;
+}

--- a/assistant/src/runtime/routes/suggest-trust-rule-routes.ts
+++ b/assistant/src/runtime/routes/suggest-trust-rule-routes.ts
@@ -15,6 +15,7 @@ import {
   userMessage,
 } from "../../providers/provider-send-message.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ── Request / response shapes ─────────────────────────────────────────
@@ -29,24 +30,10 @@ interface DirectoryScopeOption {
   label: string;
 }
 
-interface SuggestTrustRuleRequest {
-  tool: string;
-  command: string;
-  riskAssessment: {
-    risk: string;
-    reasoning: string;
-    reasonDescription: string;
-  };
-  scopeOptions: ScopeOption[];
-  directoryScopeOptions?: DirectoryScopeOption[];
-  currentThreshold: string;
-  intent: "auto_approve" | "escalate";
-  existingRule?: {
-    id: string;
-    pattern: string;
-    risk: string;
-  };
-}
+// The request shape is derived from the Zod schema (`RequestSchema`, defined
+// below and declared as the route's `requestBody`) so the wire contract and the
+// handler's type are a single source of truth rather than two hand-kept copies.
+type SuggestTrustRuleRequest = z.infer<typeof RequestSchema>;
 
 interface SuggestTrustRuleResponse {
   pattern: string;
@@ -173,7 +160,7 @@ function buildUserMessage(req: SuggestTrustRuleRequest): string {
 async function handleSuggestTrustRule({
   body = {},
 }: RouteHandlerArgs): Promise<SuggestTrustRuleResponse> {
-  const req = body as unknown as SuggestTrustRuleRequest;
+  const req = parseBody(RequestSchema, body);
 
   const provider = await getConfiguredProvider("trustRuleSuggestion");
   if (!provider) {


### PR DESCRIPTION
## Prompt / plan

Kicks off **LUM-2796** — enforcing the `requestBody` Zod schemas that 103 routes declare but that are **codegen-only** today: neither the HTTP nor the IPC adapter validates against them, so handlers re-assert the shape with `body as {…}` casts (106 across 45 files) that check nothing at runtime. Malformed input reaches handler logic, and a raw `ZodError` surfaces as a `500` rather than a `400`.

Approach: **incremental, per-route** — de-cast and validate one small cluster at a time, fixing any schema-vs-reality mismatches as they surface, rather than a global flip (which is what sent the sibling ticket LUM-2437 to Won't Do). No feature flags or shadow infrastructure.

This PR lays the groundwork and does the first, safest route:

- **New `parseBody(schema, body)` helper** (`routes/parse-body.ts`): `safeParse`s the body against the route's declared schema and throws `BadRequestError` — which both adapters already map to `400` — on mismatch, returning the typed result. This is the shared util the per-route conversions reuse instead of hand-rolling `safeParse` + throw.
- **`suggest_trust_rule` de-casted**: replaced `body as unknown as SuggestTrustRuleRequest` with `parseBody(RequestSchema, body)`, and collapsed the hand-kept `SuggestTrustRuleRequest` interface into `z.infer<typeof RequestSchema>` so the wire contract and the handler type are a single source of truth. Its only caller is the gateway, which sends a field-identical body — validation passes unchanged for real traffic.

Subsequent PRs convert further route clusters the same way.

## Test plan

- **New unit tests** (`suggest-trust-rule-routes.test.ts`): rejects a body missing required fields → `BadRequestError`; rejects an out-of-enum `intent` → `BadRequestError`; validates before reaching the provider. Existing happy-path tests unchanged (9 total pass).
- `bun run typecheck` clean in `assistant/` (confirms the schema-derived type and the de-cast).
- prettier + eslint clean on the changed files (pre-commit hook passed, incl. assistant typecheck).
- The gateway (sole caller) sends a field-identical body, so its `suggest_trust_rule` IPC calls are unaffected — no gateway change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Wgp8RrNu1qTXeGPVaq9HD

---
_Generated by [Claude Code](https://claude.ai/code/session_018Wgp8RrNu1qTXeGPVaq9HD)_