### PR TITLE
refactor(assistant): validate browser_tabs and sequence bodies via parseBody

### DIFF
--- a/assistant/src/runtime/routes/__tests__/browser-tabs-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/browser-tabs-routes.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Request-body validation for the browser_tabs route.
+ *
+ * The handler validates with `parseBody` before touching the Chrome-extension
+ * backend, so a malformed body is rejected with a `BadRequestError` (→ 400)
+ * without any CDP wiring.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { ROUTES } from "../browser-tabs-routes.js";
+import { BadRequestError } from "../errors.js";
+
+const route = ROUTES[0];
+
+describe("browser_tabs request body validation", () => {
+  test("rejects a command outside the enum with BadRequestError", async () => {
+    await expect(
+      route.handler({
+        body: { command: "frobnicate" } as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("rejects a non-numeric tabId with BadRequestError", async () => {
+    await expect(
+      route.handler({
+        body: { command: "select", tabId: "not-a-number" } as unknown as Record<
+          string,
+          unknown
+        >,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/sequence-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/sequence-routes.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Request-body validation for the sequence routes.
+ *
+ * Each handler validates with `parseBody` before opening the DB, so a malformed
+ * body is rejected with a `BadRequestError` (→ 400) without any DB access. The
+ * schemas are `.strict()`, so unknown keys are rejected too.
+ *
+ * These handlers are synchronous, so `parseBody` throws during the call — hence
+ * `expect(() => …).toThrow` rather than the `.rejects` form. The route adapters
+ * catch synchronous throws the same way they catch rejected promises.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { BadRequestError } from "../errors.js";
+import { ROUTES } from "../sequence-routes.js";
+
+const routeFor = (operationId: string) => {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`no route: ${operationId}`);
+  }
+  return route;
+};
+
+describe("sequence route body validation", () => {
+  test("sequence_get rejects a missing id", () => {
+    expect(() =>
+      routeFor("sequence_get").handler({ body: {} as Record<string, unknown> }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("sequence_list rejects a status outside the enum", () => {
+    expect(() =>
+      routeFor("sequence_list").handler({
+        body: { status: "bogus" } as Record<string, unknown>,
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("sequence_guardrails_set rejects a body missing value", () => {
+    expect(() =>
+      routeFor("sequence_guardrails_set").handler({
+        body: { key: "dailySendCap" } as Record<string, unknown>,
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("the strict schema rejects unknown keys", () => {
+    expect(() =>
+      routeFor("sequence_get").handler({
+        body: { id: "seq_1", extra: "nope" } as Record<string, unknown>,
+      }),
+    ).toThrow(BadRequestError);
+  });
+});

--- a/assistant/src/runtime/routes/browser-tabs-routes.ts
+++ b/assistant/src/runtime/routes/browser-tabs-routes.ts
@@ -19,6 +19,7 @@ import type { ToolContext } from "../../tools/types.js";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { browserCliConversationKey } from "./browser-routes.js";
 import { BadRequestError } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const BrowserTabsParams = z.object({
@@ -34,7 +35,7 @@ const BrowserTabsParams = z.object({
 
 async function handleBrowserTabs({ body = {} }: RouteHandlerArgs) {
   const { command, sessionId, conversationId, tabId, url, targetClientId } =
-    BrowserTabsParams.parse(body);
+    parseBody(BrowserTabsParams, body);
 
   const conversation = conversationId
     ? findConversation(conversationId)

--- a/assistant/src/runtime/routes/parse-body.ts
+++ b/assistant/src/runtime/routes/parse-body.ts
@@ -5,13 +5,11 @@ import { BadRequestError } from "./errors.js";
 /**
  * Validate a route's request body against its declared Zod schema and return
  * the parsed, typed value. Throws {@link BadRequestError} — which both the HTTP
- * and IPC adapters already map to a `400` — when the body doesn't match.
+ * and IPC adapters map to a `400` — when the body doesn't match its schema.
  *
- * This replaces the `body as {…}` casts in route handlers: those assert a shape
- * at compile time but validate nothing at runtime, so malformed input reaches
- * handler logic (and today surfaces as a confusing `500`, since a raw `ZodError`
- * isn't a `RouteError`). Parsing here makes the declared `requestBody` schema
- * the single source of truth for both the wire contract and runtime enforcement.
+ * The route's declared `requestBody` schema is the single source of truth for
+ * both the OpenAPI/wire contract and runtime validation, so malformed input is
+ * rejected with a `400` rather than flowing into handler logic.
  */
 export function parseBody<Schema extends z.ZodTypeAny>(
   schema: Schema,

--- a/assistant/src/runtime/routes/sequence-routes.ts
+++ b/assistant/src/runtime/routes/sequence-routes.ts
@@ -22,6 +22,7 @@ import {
 } from "../../sequence/store.js";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ── Schemas ─────────────────────────────────────────────────────────
@@ -54,8 +55,8 @@ const GuardrailSetParams = z
 // ── Handlers ────────────────────────────────────────────────────────
 
 function handleSequenceList({ body = {} }: RouteHandlerArgs) {
+  const { status } = parseBody(SequenceListParams, body);
   getDb();
-  const { status } = SequenceListParams.parse(body);
   const filter = status ? { status } : undefined;
   const seqs = listSequences(filter);
 
@@ -68,8 +69,8 @@ function handleSequenceList({ body = {} }: RouteHandlerArgs) {
 }
 
 function handleSequenceGet({ body = {} }: RouteHandlerArgs) {
+  const { id } = parseBody(SequenceIdParams, body);
   getDb();
-  const { id } = SequenceIdParams.parse(body);
   const seq = getSequence(id);
   if (!seq) throw new NotFoundError(`Sequence not found: ${id}`);
 
@@ -90,8 +91,8 @@ function handleSequenceGet({ body = {} }: RouteHandlerArgs) {
 }
 
 function handleSequencePause({ body = {} }: RouteHandlerArgs) {
+  const { id } = parseBody(SequenceIdParams, body);
   getDb();
-  const { id } = SequenceIdParams.parse(body);
   const seq = getSequence(id);
   if (!seq) throw new NotFoundError(`Sequence not found: ${id}`);
   if (seq.status === "paused") {
@@ -102,8 +103,8 @@ function handleSequencePause({ body = {} }: RouteHandlerArgs) {
 }
 
 function handleSequenceResume({ body = {} }: RouteHandlerArgs) {
+  const { id } = parseBody(SequenceIdParams, body);
   getDb();
-  const { id } = SequenceIdParams.parse(body);
   const seq = getSequence(id);
   if (!seq) throw new NotFoundError(`Sequence not found: ${id}`);
   if (seq.status === "active") {
@@ -114,8 +115,8 @@ function handleSequenceResume({ body = {} }: RouteHandlerArgs) {
 }
 
 function handleCancelEnrollment({ body = {} }: RouteHandlerArgs) {
+  const { enrollmentId } = parseBody(CancelEnrollmentParams, body);
   getDb();
-  const { enrollmentId } = CancelEnrollmentParams.parse(body);
   exitEnrollment(enrollmentId, "cancelled");
   return { ok: true, message: `Enrollment ${enrollmentId} cancelled.` };
 }
@@ -144,7 +145,7 @@ function handleGuardrailsShow() {
 }
 
 function handleGuardrailsSet({ body = {} }: RouteHandlerArgs) {
-  const { key, value } = GuardrailSetParams.parse(body);
+  const { key, value } = parseBody(GuardrailSetParams, body);
   const numVal = Number(value);
   const boolVal =
     value === "true" ? true : value === "false" ? false : undefined;

--- a/assistant/src/runtime/routes/suggest-trust-rule-routes.ts
+++ b/assistant/src/runtime/routes/suggest-trust-rule-routes.ts
@@ -30,9 +30,9 @@ interface DirectoryScopeOption {
   label: string;
 }
 
-// The request shape is derived from the Zod schema (`RequestSchema`, defined
-// below and declared as the route's `requestBody`) so the wire contract and the
-// handler's type are a single source of truth rather than two hand-kept copies.
+// The request shape is derived from the Zod schema (`RequestSchema`, declared
+// as the route's `requestBody`) so the wire contract and the handler's type
+// stay a single source of truth.
 type SuggestTrustRuleRequest = z.infer<typeof RequestSchema>;
 
 interface SuggestTrustRuleResponse {


### PR DESCRIPTION
## Prompt / plan

Second cluster of the incremental **LUM-2796** rollout (per-route request-body validation; #39051 landed the `parseBody` helper + the first route).

`browser_tabs` and the `sequences/*` routes already validate their body — but with a raw `Schema.parse(body)` that throws a `ZodError`, which neither adapter maps, so malformed input surfaces as a **500** instead of a **400**. This switches them to the shared `parseBody` helper so bad input returns a clean `BadRequestError` (400). For the sequence handlers it also moves validation **ahead of `getDb()`**, so a malformed body fails fast without opening the DB.

No cast is removed here (these routes already parse) — it's the 500→400 consistency pass plus standardizing on `parseBody`. The cast-removal clusters follow.

This PR also carries the two-line present-tense reword of the `parseBody` doc comment (Codex's non-blocking style P2 from #39051, which raced that PR's merge).

## Test plan

- **New reject tests**: `browser-tabs-routes.test.ts` (command outside the enum, non-numeric `tabId`) and `sequence-routes.test.ts` (missing `id`, out-of-enum `status`, missing `value`, unknown key against the `.strict()` schema) — all assert `BadRequestError`. 6 pass.
- `bun run typecheck` clean in `assistant/`; prettier + eslint clean on the changed files (pre-commit hook passed).
- Behavior is otherwise unchanged: `parseBody` returns the same parsed data as `Schema.parse` for valid input; only the error path changes (500 → 400). Callers are the CLI `browser` / `sequence` commands.

_Note: `sequence-routes.ts` has pre-existing `curly` lint warnings in `handleGuardrailsSet` — left untouched, as they're outside this change._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Wgp8RrNu1qTXeGPVaq9HD

---
_Generated by [Claude Code](https://claude.ai/code/session_018Wgp8RrNu1qTXeGPVaq9HD)_