### PR TITLE
refactor(assistant): validate MCP management bodies via parseBody

### DIFF
--- a/assistant/src/runtime/routes/__tests__/mcp-auth-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/mcp-auth-routes.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Request-body validation for the internal MCP management routes.
+ *
+ * Each handler validates with `parseBody` before it loads config or touches
+ * the credential store, so a malformed body is rejected with a
+ * `BadRequestError` (→ 400) without any side effects.
+ *
+ * These handlers are `async`, so `parseBody` throwing surfaces as a rejected
+ * promise — hence the `.rejects` form rather than `expect(() => …).toThrow`.
+ * The route adapters map that `BadRequestError` to a 400 the same way.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { BadRequestError } from "../errors.js";
+import { ROUTES } from "../mcp-auth-routes.js";
+
+const routeFor = (operationId: string) => {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`no route: ${operationId}`);
+  }
+  return route;
+};
+
+describe("mcp-auth route body validation", () => {
+  test("internal_mcp_auth_start rejects a missing serverId", async () => {
+    await expect(
+      routeFor("internal_mcp_auth_start").handler({
+        body: {} as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("internal_mcp_auth_revoke rejects a non-string serverId", async () => {
+    await expect(
+      routeFor("internal_mcp_auth_revoke").handler({
+        body: { serverId: 42 } as unknown as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("internal_mcp_update rejects a non-numeric maxTools", async () => {
+    await expect(
+      routeFor("internal_mcp_update").handler({
+        body: { name: "srv", maxTools: "lots" } as unknown as Record<
+          string,
+          unknown
+        >,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("internal_mcp_add rejects a body missing transportType", async () => {
+    await expect(
+      routeFor("internal_mcp_add").handler({
+        body: { name: "srv" } as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("internal_mcp_remove rejects a missing name", async () => {
+    await expect(
+      routeFor("internal_mcp_remove").handler({
+        body: {} as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+});

--- a/assistant/src/runtime/routes/mcp-auth-routes.ts
+++ b/assistant/src/runtime/routes/mcp-auth-routes.ts
@@ -34,9 +34,41 @@ import { getMcpToolsByServer } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition } from "./types.js";
 
 const log = getLogger("mcp-auth-routes");
+
+// ── Request schemas ─────────────────────────────────────────────────
+//
+// Each schema is declared once and referenced by both the route's
+// `requestBody` (the OpenAPI/wire contract) and the handler's `parseBody`
+// call, so the advertised shape and the validated shape can't drift.
+
+const McpServerIdParams = z.object({ serverId: z.string() });
+
+const McpUpdateParams = z.object({
+  name: z.string(),
+  enabled: z.boolean().optional(),
+  defaultRiskLevel: z.string().optional(),
+  maxTools: z.number().optional(),
+  allowedTools: z.array(z.string()).nullable().optional(),
+  blockedTools: z.array(z.string()).nullable().optional(),
+  headers: z.record(z.string(), z.string()).nullable().optional(),
+});
+
+const McpAddParams = z.object({
+  name: z.string(),
+  transportType: z.string(),
+  url: z.string().optional(),
+  command: z.string().optional(),
+  args: z.array(z.string()).optional(),
+  risk: z.string().optional(),
+  disabled: z.boolean().optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+});
+
+const McpRemoveParams = z.object({ name: z.string() });
 
 async function handleMcpAuthStart({
   body,
@@ -47,7 +79,7 @@ async function handleMcpAuthStart({
   state: string;
   already_authenticated?: boolean;
 }> {
-  const { serverId } = body as { serverId: string };
+  const { serverId } = parseBody(McpServerIdParams, body);
 
   const raw = loadRawConfig();
   const servers = (raw.mcp as Partial<McpConfig> | undefined)?.servers ?? {};
@@ -333,15 +365,7 @@ async function handleMcpUpdate({
     allowedTools,
     blockedTools,
     headers,
-  } = body as {
-    name: string;
-    enabled?: boolean;
-    defaultRiskLevel?: string;
-    maxTools?: number;
-    allowedTools?: string[] | null;
-    blockedTools?: string[] | null;
-    headers?: Record<string, string> | null;
-  };
+  } = parseBody(McpUpdateParams, body);
 
   const raw = loadRawConfig();
   const mcpConfig = raw.mcp as Record<string, unknown> | undefined;
@@ -423,16 +447,7 @@ async function handleMcpAdd({
   body?: Record<string, unknown>;
 }): Promise<{ added: true }> {
   const { name, transportType, url, command, args, risk, disabled, headers } =
-    body as {
-      name: string;
-      transportType: string;
-      url?: string;
-      command?: string;
-      args?: string[];
-      risk?: string;
-      disabled?: boolean;
-      headers?: Record<string, string>;
-    };
+    parseBody(McpAddParams, body);
 
   const riskLevel = risk ?? "high";
   if (!["low", "medium", "high"].includes(riskLevel)) {
@@ -507,7 +522,7 @@ async function handleMcpAuthRevoke({
 }: {
   body?: Record<string, unknown>;
 }): Promise<{ revoked: true }> {
-  const { serverId } = body as { serverId: string };
+  const { serverId } = parseBody(McpServerIdParams, body);
 
   const raw = loadRawConfig();
   const servers = (raw.mcp as Partial<McpConfig> | undefined)?.servers ?? {};
@@ -545,7 +560,7 @@ async function handleMcpRemove({
 }: {
   body?: Record<string, unknown>;
 }): Promise<{ removed: true }> {
-  const { name } = body as { name: string };
+  const { name } = parseBody(McpRemoveParams, body);
 
   const raw = loadRawConfig();
   const mcpConfig = raw.mcp as Record<string, unknown> | undefined;
@@ -595,7 +610,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Starts a daemon-owned MCP OAuth flow and returns the authorization URL for the CLI to open in the browser.",
     tags: ["internal"],
-    requestBody: z.object({ serverId: z.string() }),
+    requestBody: McpServerIdParams,
     handler: handleMcpAuthStart,
   },
   {
@@ -706,15 +721,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Updates fields on an existing MCP server config entry and triggers a reload.",
     tags: ["internal"],
-    requestBody: z.object({
-      name: z.string(),
-      enabled: z.boolean().optional(),
-      defaultRiskLevel: z.string().optional(),
-      maxTools: z.number().optional(),
-      allowedTools: z.array(z.string()).nullable().optional(),
-      blockedTools: z.array(z.string()).nullable().optional(),
-      headers: z.record(z.string(), z.string()).nullable().optional(),
-    }),
+    requestBody: McpUpdateParams,
     handler: handleMcpUpdate,
   },
   {
@@ -729,16 +736,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Writes a new MCP server entry to config.json and triggers a reload.",
     tags: ["internal"],
-    requestBody: z.object({
-      name: z.string(),
-      transportType: z.string(),
-      url: z.string().optional(),
-      command: z.string().optional(),
-      args: z.array(z.string()).optional(),
-      risk: z.string().optional(),
-      disabled: z.boolean().optional(),
-      headers: z.record(z.string(), z.string()).optional(),
-    }),
+    requestBody: McpAddParams,
     handler: handleMcpAdd,
   },
   {
@@ -753,7 +751,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Deletes stored OAuth tokens for an MCP server and triggers a reload.",
     tags: ["internal"],
-    requestBody: z.object({ serverId: z.string() }),
+    requestBody: McpServerIdParams,
     responseBody: z.object({ revoked: z.boolean() }),
     handler: handleMcpAuthRevoke,
   },
@@ -769,7 +767,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Removes an MCP server from config.json, cleans up OAuth credentials, and triggers a reload.",
     tags: ["internal"],
-    requestBody: z.object({ name: z.string() }),
+    requestBody: McpRemoveParams,
     handler: handleMcpRemove,
   },
 ];


### PR DESCRIPTION
## Prompt / plan

Part of **LUM-2796** — enforce each route's declared `requestBody` Zod schema at the adapter boundary ("parse, don't cast"), rolled out incrementally one route-file cluster at a time so schema-vs-reality bugs surface in small, reviewable PRs. This is cluster 3, following #39051 (`suggest_trust_rule`) and #39052 (`browser_tabs` + sequences).

The five internal MCP management routes each declared a `requestBody` schema **and** re-asserted the same shape in the handler with `body as {…}` — the shape written twice, free to drift, with no runtime validation (a malformed body flowed straight into config/credential writes). This restores a single source of truth:

- Extract the five inline `requestBody` schemas to named consts (`McpServerIdParams`, `McpUpdateParams`, `McpAddParams`, `McpRemoveParams`), each referenced by both the route's `requestBody` and the handler.
- Replace the `body as {…}` hand-casts with `parseBody(Schema, body)`, so a malformed body is rejected with a `BadRequestError` (→ 400) before any side effect, and the handler gets a typed value derived from the schema.
- `internal_mcp_auth_start` and `internal_mcp_auth_revoke` share `McpServerIdParams` (both take exactly `{ serverId: string }`), mirroring how the sequence routes share `SequenceIdParams`.

No behavior change for well-formed requests: the extracted schemas are structurally identical to the inline ones (verified field-by-field, including the `.nullable()` alignment on the update route), so the casts were already accurate — this is a pure de-cast plus the newly-enforced 400 on malformed input.

## Test plan

- New co-located `__tests__/mcp-auth-routes.test.ts`: one reject test per route (missing required field / wrong type) asserting `BadRequestError`. These handlers are `async`, so validation surfaces as a rejected promise (`.rejects.toThrow`). `bun test` → 5 pass.
- `bun run typecheck` (assistant) clean — confirms the schema-derived types satisfy every handler use site (e.g. `z.record(z.string(), z.string())` → `Record<string, string>` for `setMcpHeaders`), so no schema-vs-reality mismatch surfaced in this cluster.
- Pre-commit/pre-push: prettier + eslint (0 errors; the 8 `curly` warnings are pre-existing handler one-liners, untouched by this diff) + typecheck.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Wgp8RrNu1qTXeGPVaq9HD)_