### PR TITLE
feat(memory-db): relocate memory_segments and memory_embeddings to the memory database

### DIFF
--- a/assistant/src/__tests__/add-message-skip-indexing.test.ts
+++ b/assistant/src/__tests__/add-message-skip-indexing.test.ts
@@ -56,7 +56,8 @@ const LONG_TEXT =
 
 function resetTables(): void {
   const db = getDb();
-  db.run("DELETE FROM memory_segments");
+  // memory_segments and memory_jobs live on the memory connection.
+  getMemoryDb()!.run("DELETE FROM memory_segments");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
   getMemoryDb()!.run("DELETE FROM memory_jobs");
@@ -87,7 +88,7 @@ function messageRow(messageId: string) {
 }
 
 function segmentCountFor(messageId: string): number {
-  return getDb()
+  return getMemoryDb()!
     .select()
     .from(memorySegments)
     .where(eq(memorySegments.messageId, messageId))

--- a/assistant/src/__tests__/conversation-delete-schedule-cleanup.test.ts
+++ b/assistant/src/__tests__/conversation-delete-schedule-cleanup.test.ts
@@ -49,9 +49,9 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
     getRawDb().run("DELETE FROM cron_runs");
     getRawDb().run("DELETE FROM cron_jobs");
     getMemorySqlite()!.run("DELETE FROM memory_graph_nodes");
-    getRawDb().run("DELETE FROM memory_segments");
+    getMemorySqlite()!.run("DELETE FROM memory_segments");
     getRawDb().run("DELETE FROM memory_summaries");
-    getRawDb().run("DELETE FROM memory_embeddings");
+    getMemorySqlite()!.run("DELETE FROM memory_embeddings");
     getMemorySqlite()!.run("DELETE FROM memory_jobs");
     getRawDb().run("DELETE FROM tool_invocations");
     getLogsSqlite()!.run("DELETE FROM llm_request_logs");

--- a/assistant/src/__tests__/image-recovery-hook.test.ts
+++ b/assistant/src/__tests__/image-recovery-hook.test.ts
@@ -27,7 +27,7 @@ import {
   createConversation,
   getMessages,
 } from "../persistence/conversation-crud.js";
-import { getDb } from "../persistence/db-connection.js";
+import { getDb, getMemorySqlite } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import type {
@@ -70,8 +70,8 @@ function resetTables(): void {
   const db = getDb();
   db.run("DELETE FROM message_attachments");
   db.run("DELETE FROM attachments");
-  db.run("DELETE FROM memory_segments");
-  db.run("DELETE FROM memory_embeddings");
+  getMemorySqlite()?.run("DELETE FROM memory_segments");
+  getMemorySqlite()?.run("DELETE FROM memory_embeddings");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
 }

--- a/assistant/src/__tests__/memory-upsert-concurrency.test.ts
+++ b/assistant/src/__tests__/memory-upsert-concurrency.test.ts
@@ -32,7 +32,11 @@ mock.module("../persistence/embeddings/qdrant-client.js", () => ({
 }));
 
 import { getConfig } from "../config/loader.js";
-import { getDb, getMemorySqlite } from "../persistence/db-connection.js";
+import {
+  getDb,
+  getMemoryDb,
+  getMemorySqlite,
+} from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
   conversations,
@@ -51,10 +55,13 @@ await initializeDb();
 
 function resetTables() {
   const db = getDb();
-  db.run("DELETE FROM memory_embeddings");
-  getMemorySqlite()!.run("DELETE FROM memory_graph_nodes");
-  db.run("DELETE FROM memory_segments");
-  getMemorySqlite()!.run("DELETE FROM memory_jobs");
+  // memory_embeddings and memory_segments now live on the memory connection,
+  // alongside memory_graph_nodes and memory_jobs.
+  const memory = getMemorySqlite()!;
+  memory.run("DELETE FROM memory_embeddings");
+  memory.run("DELETE FROM memory_graph_nodes");
+  memory.run("DELETE FROM memory_segments");
+  memory.run("DELETE FROM memory_jobs");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
 }
@@ -113,7 +120,6 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
 
     seedConversationAndMessage(conversationId, messageId, text);
 
-    const db = getDb();
     const config = getConfig().memory;
 
     // Call indexMessageNow N times for the same messageId.  Even though we use
@@ -138,7 +144,7 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
       ),
     );
 
-    const segments = db
+    const segments = getMemoryDb()!
       .select()
       .from(memorySegments)
       .where(eq(memorySegments.messageId, messageId))
@@ -229,7 +235,7 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
     // for the wrong messageId.
     for (let i = 0; i < MSG_COUNT; i++) {
       const msgId = `msg-distinct-${i}`;
-      const segs = db
+      const segs = getMemoryDb()!
         .select()
         .from(memorySegments)
         .where(eq(memorySegments.messageId, msgId))
@@ -271,8 +277,7 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
       config,
     );
 
-    const db = getDb();
-    const segmentsAfterFirst = db
+    const segmentsAfterFirst = getMemoryDb()!
       .select()
       .from(memorySegments)
       .where(eq(memorySegments.messageId, messageId))
@@ -300,7 +305,7 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
       config,
     );
 
-    const segmentsAfterRehash = db
+    const segmentsAfterRehash = getMemoryDb()!
       .select()
       .from(memorySegments)
       .where(eq(memorySegments.messageId, messageId))
@@ -368,8 +373,7 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
       ),
     ]);
 
-    const db = getDb();
-    const segments = db
+    const segments = getMemoryDb()!
       .select()
       .from(memorySegments)
       .where(eq(memorySegments.messageId, messageId))
@@ -467,7 +471,7 @@ describe("memory segment job atomicity under repeated indexer invocations", () =
     // duplicates regardless of how many indexer calls ran.
     for (let i = 0; i < MSG_COUNT; i++) {
       const msgId = `msg-atomicity-${i}`;
-      const segs = db
+      const segs = getMemoryDb()!
         .select()
         .from(memorySegments)
         .where(eq(memorySegments.messageId, msgId))
@@ -514,8 +518,7 @@ describe("memory segment job atomicity under repeated indexer invocations", () =
       ),
     );
 
-    const db = getDb();
-    const storedSegments = db
+    const storedSegments = getMemoryDb()!
       .select()
       .from(memorySegments)
       .where(eq(memorySegments.messageId, messageId))

--- a/assistant/src/__tests__/memory-upsert-concurrency.test.ts
+++ b/assistant/src/__tests__/memory-upsert-concurrency.test.ts
@@ -55,7 +55,7 @@ await initializeDb();
 
 function resetTables() {
   const db = getDb();
-  // memory_embeddings and memory_segments now live on the memory connection,
+  // memory_embeddings and memory_segments live on the memory connection,
   // alongside memory_graph_nodes and memory_jobs.
   const memory = getMemorySqlite()!;
   memory.run("DELETE FROM memory_embeddings");

--- a/assistant/src/__tests__/message-delete-segment-purge.test.ts
+++ b/assistant/src/__tests__/message-delete-segment-purge.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Message-scoped segment/embedding purge. Deleting a single message (its
+ * conversation lives on) must remove that message's memory_segments and their
+ * embeddings on the memory connection, while a sibling message's rows survive.
+ * The conversation-keyed purge does not apply here, so this explicit delete is
+ * the sole cleanup for message-scoped rows — there is no orphan-sweep backstop.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { setConfig } from "./helpers/set-config.js";
+
+// Disable memory so addMessage does not index into the real pipeline; the
+// message-delete cleanup under test is not gated on the plugin being enabled.
+setConfig("memory", { enabled: false, v2: { enabled: false } });
+
+import {
+  addMessage,
+  createConversation,
+  deleteMessageById,
+} from "../persistence/conversation-crud.js";
+import { getMemorySqlite, getSqlite } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+
+await initializeDb();
+
+function seedSegment(
+  segmentId: string,
+  messageId: string,
+  conversationId: string,
+): void {
+  const mem = getMemorySqlite()!;
+  mem.run(
+    `INSERT INTO memory_segments
+       (id, message_id, conversation_id, role, segment_index, text,
+        token_estimate, created_at, updated_at)
+     VALUES ('${segmentId}', '${messageId}', '${conversationId}', 'user', 0,
+             'text', 1, 0, 0)`,
+  );
+  mem.run(
+    `INSERT INTO memory_embeddings
+       (id, target_type, target_id, provider, model, dimensions,
+        created_at, updated_at)
+     VALUES ('emb-${segmentId}', 'segment', '${segmentId}', 'p', 'm', 3, 0, 0)`,
+  );
+}
+
+function memoryRows(table: string): string[] {
+  return (
+    getMemorySqlite()!
+      .query(`SELECT id FROM ${table} ORDER BY id`)
+      .all() as Array<{ id: string }>
+  ).map((r) => r.id);
+}
+
+beforeEach(() => {
+  const sqlite = getSqlite();
+  getMemorySqlite()!.run("DELETE FROM memory_embeddings");
+  getMemorySqlite()!.run("DELETE FROM memory_segments");
+  sqlite.run("DELETE FROM messages");
+  sqlite.run("DELETE FROM conversations");
+});
+
+describe("deleteMessageById segment purge", () => {
+  test("purges the deleted message's segments and embeddings, leaving a sibling's intact", async () => {
+    const conv = createConversation("conv");
+    const msgA = await addMessage(conv.id, "user", "a", { skipIndexing: true });
+    const msgB = await addMessage(conv.id, "user", "b", { skipIndexing: true });
+    seedSegment("seg-a", msgA.id, conv.id);
+    seedSegment("seg-b", msgB.id, conv.id);
+
+    const result = deleteMessageById(msgA.id);
+
+    // The deleted message's ids are returned for the caller's Qdrant purge.
+    expect(result.segmentIds).toEqual(["seg-a"]);
+    // Its segment and embedding are gone; the sibling message's survive.
+    expect(memoryRows("memory_segments")).toEqual(["seg-b"]);
+    expect(memoryRows("memory_embeddings")).toEqual(["emb-seg-b"]);
+    // The conversation and the sibling message live on.
+    expect(
+      getSqlite().query("SELECT COUNT(*) AS c FROM conversations").get(),
+    ).toEqual({ c: 1 });
+    expect(getSqlite().query("SELECT id FROM messages").all()).toEqual([
+      { id: msgB.id },
+    ]);
+  });
+
+  test("returns no ids and no-ops when the message has no segments", async () => {
+    const conv = createConversation("conv");
+    const msg = await addMessage(conv.id, "user", "no segments", {
+      skipIndexing: true,
+    });
+
+    const result = deleteMessageById(msg.id);
+
+    expect(result.segmentIds).toEqual([]);
+    expect(memoryRows("memory_segments")).toEqual([]);
+  });
+});

--- a/assistant/src/__tests__/message-delete-segment-purge.test.ts
+++ b/assistant/src/__tests__/message-delete-segment-purge.test.ts
@@ -3,7 +3,7 @@
  * conversation lives on) must remove that message's memory_segments and their
  * embeddings on the memory connection, while a sibling message's rows survive.
  * The conversation-keyed purge does not apply here, so this explicit delete is
- * the sole cleanup for message-scoped rows — there is no orphan-sweep backstop.
+ * the sole cleanup for message-scoped rows. There is no orphan-sweep backstop.
  */
 import { beforeEach, describe, expect, test } from "bun:test";
 

--- a/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
@@ -40,7 +40,7 @@ import {
   createConversation,
   getMessages,
 } from "../persistence/conversation-crud.js";
-import { getDb } from "../persistence/db-connection.js";
+import { getDb, getMemorySqlite } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { persistUnsendableImageDowngrades } from "../plugins/defaults/image-recovery/recover.js";
 import { base64Source } from "../providers/media-resolve.js";
@@ -52,8 +52,8 @@ function resetTables(): void {
   const db = getDb();
   db.run("DELETE FROM message_attachments");
   db.run("DELETE FROM attachments");
-  db.run("DELETE FROM memory_segments");
-  db.run("DELETE FROM memory_embeddings");
+  getMemorySqlite()?.run("DELETE FROM memory_segments");
+  getMemorySqlite()?.run("DELETE FROM memory_embeddings");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
 }

--- a/assistant/src/__tests__/persist-unsendable-image.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image.test.ts
@@ -20,7 +20,7 @@ import {
   createConversation,
   getMessages,
 } from "../persistence/conversation-crud.js";
-import { getDb } from "../persistence/db-connection.js";
+import { getDb, getMemorySqlite } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
   persistUnsendableImageDowngrades,
@@ -34,8 +34,8 @@ function resetTables(): void {
   const db = getDb();
   db.run("DELETE FROM message_attachments");
   db.run("DELETE FROM attachments");
-  db.run("DELETE FROM memory_segments");
-  db.run("DELETE FROM memory_embeddings");
+  getMemorySqlite()?.run("DELETE FROM memory_segments");
+  getMemorySqlite()?.run("DELETE FROM memory_embeddings");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
 }

--- a/assistant/src/conversations/job-handlers/summarization.ts
+++ b/assistant/src/conversations/job-handlers/summarization.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from "uuid";
 
 import type { AssistantConfig } from "../../config/types.js";
 import { estimateTextTokens } from "../../context/token-estimator.js";
-import { getDb } from "../../persistence/db-connection.js";
+import { getDb, getMemoryDb } from "../../persistence/db-connection.js";
 import { asString, truncate } from "../../persistence/job-utils.js";
 import {
   enqueueMemoryJob,
@@ -75,12 +75,17 @@ export async function buildConversationSummaryJob(
     conditions.push(gt(memorySegments.createdAt, lastCoveredAt));
   }
 
-  const rows = db
-    .select()
-    .from(memorySegments)
-    .where(and(...conditions))
-    .orderBy(asc(memorySegments.createdAt))
-    .all();
+  // Segments live on the memory connection; the summary row above and below
+  // stays on the main connection.
+  const mem = getMemoryDb();
+  const rows = mem
+    ? mem
+        .select()
+        .from(memorySegments)
+        .where(and(...conditions))
+        .orderBy(asc(memorySegments.createdAt))
+        .all()
+    : [];
   if (rows.length === 0) return;
 
   // Build segment text for LLM input (already in chronological order)

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -3335,14 +3335,22 @@ function purgeMessageSegments(messageIds: string[], context: string): string[] {
   if (!memoryDb || messageIds.length === 0) {
     return [];
   }
+  let ids: string[] = [];
   try {
-    const ids = memoryDb
+    ids = memoryDb
       .select({ id: memorySegments.id })
       .from(memorySegments)
       .where(inArray(memorySegments.messageId, messageIds))
       .all()
       .map((r) => r.id);
-    if (ids.length > 0) {
+  } catch (err) {
+    log.warn(
+      { err, context },
+      "Failed to read memory segments for deleted messages; continuing",
+    );
+  }
+  if (ids.length > 0) {
+    try {
       memoryDb
         .delete(memoryEmbeddings)
         .where(
@@ -3352,19 +3360,27 @@ function purgeMessageSegments(messageIds: string[], context: string): string[] {
           ),
         )
         .run();
-      memoryDb
-        .delete(memorySegments)
-        .where(inArray(memorySegments.messageId, messageIds))
-        .run();
+    } catch (err) {
+      log.warn(
+        { err, context },
+        "Failed to delete segment embeddings for deleted messages; continuing",
+      );
     }
-    return ids;
+  }
+  // Independent of the embedding delete above: a missing or partially migrated
+  // embedding cache must not leave the plaintext segment rows behind.
+  try {
+    memoryDb
+      .delete(memorySegments)
+      .where(inArray(memorySegments.messageId, messageIds))
+      .run();
   } catch (err) {
     log.warn(
       { err, context },
-      "Failed to purge memory segments for deleted messages; continuing",
+      "Failed to delete memory segments for deleted messages; continuing",
     );
-    return [];
   }
+  return ids;
 }
 
 /**

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -1870,36 +1870,10 @@ export function deleteConversation(id: string): DeletedMemoryIds {
     tx.delete(conversations).where(eq(conversations.id, id)).run();
   });
 
-  // Delete the conversation's segments and their embeddings on the memory
-  // connection after the main delete succeeds, rather than leaving the segment
-  // rows to the conversation-deleted hook: that hook is a no-op when the memory
-  // plugin is disabled and would keep the plaintext content in the memory
-  // database. Best-effort: a memory-DB failure must not abort the disk cleanup
-  // or the hook below.
-  if (memoryDb) {
-    try {
-      if (result.segmentIds.length > 0) {
-        memoryDb
-          .delete(memoryEmbeddings)
-          .where(
-            and(
-              eq(memoryEmbeddings.targetType, "segment"),
-              inArray(memoryEmbeddings.targetId, result.segmentIds),
-            ),
-          )
-          .run();
-      }
-      memoryDb
-        .delete(memorySegments)
-        .where(eq(memorySegments.conversationId, id))
-        .run();
-    } catch (err) {
-      log.warn(
-        { err, conversationId: id },
-        "Failed to delete memory segments for deleted conversation; continuing",
-      );
-    }
-  }
+  // Purge the conversation's segments and their embeddings on the memory
+  // connection after the main delete, unioning the pre-delete snapshot so the
+  // returned Qdrant cleanup list is complete.
+  result.segmentIds = purgeConversationSegments(id, result.segmentIds);
 
   // Remove the conversation's disk-view directory after the DB transaction
   if (createdAtForDiskCleanup != null) {
@@ -2042,36 +2016,11 @@ export async function deleteConversationGently(
     tx.delete(conversations).where(eq(conversations.id, id)).run();
   });
 
-  // Delete the conversation's segments and their embeddings on the memory
-  // connection, rather than leaving the segment rows to the conversation-deleted
-  // hook: that hook is a no-op when the memory plugin is disabled and would keep
-  // the plaintext content in the memory database. Best-effort, after the main
-  // delete succeeds. A memory-DB failure must not abort the hook/disk cleanup
-  // below.
-  if (memoryDb) {
-    try {
-      if (result.segmentIds.length > 0) {
-        memoryDb
-          .delete(memoryEmbeddings)
-          .where(
-            and(
-              eq(memoryEmbeddings.targetType, "segment"),
-              inArray(memoryEmbeddings.targetId, result.segmentIds),
-            ),
-          )
-          .run();
-      }
-      memoryDb
-        .delete(memorySegments)
-        .where(eq(memorySegments.conversationId, id))
-        .run();
-    } catch (err) {
-      log.warn(
-        { err, conversationId: id },
-        "Failed to delete memory segments for deleted conversation; continuing",
-      );
-    }
-  }
+  // Purge the conversation's segments and their embeddings on the memory
+  // connection after the batched delete, re-reading and unioning the pre-delete
+  // snapshot so a segment written during the awaited drain is still cleaned up
+  // and returned for Qdrant cleanup.
+  result.segmentIds = purgeConversationSegments(id, result.segmentIds);
 
   // Remove the conversation's disk-view directory after the DB transaction.
   if (createdAtForDiskCleanup != null) {
@@ -3416,6 +3365,75 @@ function purgeMessageSegments(messageIds: string[], context: string): string[] {
     );
     return [];
   }
+}
+
+/**
+ * Delete a conversation's memory_segments and their segment embeddings on the
+ * memory connection, returning the deleted segment ids for Qdrant cleanup.
+ * memory_segments has no cross-file FK to conversations, so a conversation
+ * delete does not cascade to it and the conversation-deleted hook is a no-op
+ * when the memory plugin is disabled; this purge runs regardless. It re-reads
+ * the ids and unions them with any already known, capturing rows a concurrent
+ * index wrote during an awaited batch delete while preserving ids the boot
+ * orphan sweep may have removed once the conversation row went away. Embeddings
+ * and segments are deleted under independent guards so a missing or broken
+ * embedding cache (such as a partial migration) cannot block deletion of the
+ * plaintext segment rows. Best-effort throughout.
+ */
+export function purgeConversationSegments(
+  conversationId: string,
+  knownSegmentIds: string[] = [],
+): string[] {
+  const memoryDb = getMemoryDb();
+  if (!memoryDb) {
+    return knownSegmentIds;
+  }
+  const ids = new Set(knownSegmentIds);
+  try {
+    for (const row of memoryDb
+      .select({ id: memorySegments.id })
+      .from(memorySegments)
+      .where(eq(memorySegments.conversationId, conversationId))
+      .all()) {
+      ids.add(row.id);
+    }
+  } catch (err) {
+    log.warn(
+      { err, conversationId },
+      "Failed to read memory segments for deleted conversation; continuing",
+    );
+  }
+  const segmentIds = [...ids];
+  if (segmentIds.length > 0) {
+    try {
+      memoryDb
+        .delete(memoryEmbeddings)
+        .where(
+          and(
+            eq(memoryEmbeddings.targetType, "segment"),
+            inArray(memoryEmbeddings.targetId, segmentIds),
+          ),
+        )
+        .run();
+    } catch (err) {
+      log.warn(
+        { err, conversationId },
+        "Failed to delete segment embeddings for deleted conversation; continuing",
+      );
+    }
+  }
+  try {
+    memoryDb
+      .delete(memorySegments)
+      .where(eq(memorySegments.conversationId, conversationId))
+      .run();
+  } catch (err) {
+    log.warn(
+      { err, conversationId },
+      "Failed to delete memory segments for deleted conversation; continuing",
+    );
+  }
+  return segmentIds;
 }
 
 export function deleteLastExchange(conversationId: string): number {

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -80,6 +80,7 @@ import {
   type DrizzleDb,
   getDb,
   getLogsDb,
+  getMemoryDb,
   getSqliteFrom,
   getTelemetryDb,
 } from "./db-connection.js";
@@ -1837,50 +1838,41 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   deletePendingTelemetryEventsForConversation(id);
 
   db.transaction((tx) => {
-    // Collect all message IDs for this conversation.
-    const messageRows = tx
-      .select({ id: messages.id })
-      .from(messages)
-      .where(eq(messages.conversationId, id))
-      .all();
-    const messageIds = messageRows.map((r) => r.id);
-
-    if (messageIds.length > 0) {
-      // Collect memory segment IDs linked to these messages before cascade.
-      const linkedSegments = tx
-        .select({ id: memorySegments.id })
-        .from(memorySegments)
-        .where(inArray(memorySegments.messageId, messageIds))
-        .all();
-      result.segmentIds = linkedSegments.map((r) => r.id);
-
-      // Delete non-cascading tables first.
-      tx.delete(toolInvocations)
-        .where(eq(toolInvocations.conversationId, id))
-        .run();
-      // Cascade deletes memory_segments, message_attachments.
-      tx.delete(messages).where(eq(messages.conversationId, id)).run();
-
-      // Clean up segment embeddings.
-      if (result.segmentIds.length > 0) {
-        tx.delete(memoryEmbeddings)
-          .where(
-            and(
-              eq(memoryEmbeddings.targetType, "segment"),
-              inArray(memoryEmbeddings.targetId, result.segmentIds),
-            ),
-          )
-          .run();
-      }
-    } else {
-      // No messages — just clean up non-message tables.
-      tx.delete(toolInvocations)
-        .where(eq(toolInvocations.conversationId, id))
-        .run();
-    }
-
+    // memory_segments no longer cascades from messages/conversations — it lives
+    // on the memory connection now and is purged by the conversation-deleted
+    // hook below. The main-DB cascade still removes message_attachments.
+    tx.delete(toolInvocations)
+      .where(eq(toolInvocations.conversationId, id))
+      .run();
+    tx.delete(messages).where(eq(messages.conversationId, id)).run();
     tx.delete(conversations).where(eq(conversations.id, id)).run();
   });
+
+  // Clean up the moved segment/embedding tables on the memory connection, after
+  // the main delete succeeds and before the conversation-deleted hook purges the
+  // segment rows. Collect the segment ids (keyed by conversation_id) for the
+  // caller's Qdrant vector purge, then delete their embeddings. Best-effort: a
+  // missing memory database no-ops, mirroring the cross-file split elsewhere.
+  const memoryDb = getMemoryDb();
+  if (memoryDb) {
+    result.segmentIds = memoryDb
+      .select({ id: memorySegments.id })
+      .from(memorySegments)
+      .where(eq(memorySegments.conversationId, id))
+      .all()
+      .map((r) => r.id);
+    if (result.segmentIds.length > 0) {
+      memoryDb
+        .delete(memoryEmbeddings)
+        .where(
+          and(
+            eq(memoryEmbeddings.targetType, "segment"),
+            inArray(memoryEmbeddings.targetId, result.segmentIds),
+          ),
+        )
+        .run();
+    }
+  }
 
   // Remove the conversation's disk-view directory after the DB transaction
   if (createdAtForDiskCleanup != null) {
@@ -1943,14 +1935,20 @@ export async function deleteConversationGently(
   const convBeforeDelete = getConversation(id);
   const createdAtForDiskCleanup = convBeforeDelete?.createdAt;
 
-  // Collect the linked memory segment ids before the message cascade removes
-  // them, so the caller can clean up the matching Qdrant vector entries.
-  result.segmentIds = db
-    .select({ id: memorySegments.id })
-    .from(memorySegments)
-    .where(eq(memorySegments.conversationId, id))
-    .all()
-    .map((r) => r.id);
+  // Collect the conversation's memory segment ids from the memory connection
+  // (memory_segments moved off the main DB) so the caller can clean up the
+  // matching Qdrant vectors. The segment rows are purged by the
+  // conversation-deleted hook; their embeddings are deleted after the main
+  // delete below. Best-effort: a missing memory database yields no ids.
+  const memoryDb = getMemoryDb();
+  result.segmentIds = memoryDb
+    ? memoryDb
+        .select({ id: memorySegments.id })
+        .from(memorySegments)
+        .where(eq(memorySegments.conversationId, id))
+        .all()
+        .map((r) => r.id)
+    : [];
 
   // Pending telemetry_events rows live in the dedicated telemetry connection;
   // delete them (by conversation_id, regardless of event name) before ANY
@@ -1987,7 +1985,8 @@ export async function deleteConversationGently(
   }
 
   // Bulk message delete off the event loop, in lock-friendly batches. Cascades
-  // to memory_segments, message_attachments, bookmarks, channel_inbound_events.
+  // to message_attachments, bookmarks, channel_inbound_events (memory_segments
+  // moved to the memory connection and is purged by the hook below).
   const del = await deleteConversationRowsInBatches({
     conversationId: id,
     table: "messages",
@@ -2005,23 +2004,24 @@ export async function deleteConversationGently(
     tx.delete(toolInvocations)
       .where(eq(toolInvocations.conversationId, id))
       .run();
-
-    // Clean up segment embeddings (not FK-linked to segments, so the message
-    // cascade above did not remove them).
-    if (result.segmentIds.length > 0) {
-      tx.delete(memoryEmbeddings)
-        .where(
-          and(
-            eq(memoryEmbeddings.targetType, "segment"),
-            inArray(memoryEmbeddings.targetId, result.segmentIds),
-          ),
-        )
-        .run();
-    }
-
     // Conversation row deletion cascades to remaining dependent tables.
     tx.delete(conversations).where(eq(conversations.id, id)).run();
   });
+
+  // Delete the segment embeddings on the memory connection (memory_embeddings is
+  // not FK-linked to segments, so nothing cascades them). Best-effort, after the
+  // main delete succeeds.
+  if (memoryDb && result.segmentIds.length > 0) {
+    memoryDb
+      .delete(memoryEmbeddings)
+      .where(
+        and(
+          eq(memoryEmbeddings.targetType, "segment"),
+          inArray(memoryEmbeddings.targetId, result.segmentIds),
+        ),
+      )
+      .run();
+  }
 
   // Remove the conversation's disk-view directory after the DB transaction.
   if (createdAtForDiskCleanup != null) {
@@ -3229,16 +3229,19 @@ export async function clearAll(): Promise<{
     "DELETE FROM telemetry_events WHERE name = 'skill_loaded'",
   );
 
-  // Delete in dependency order. Cascades handle memory_segments and
-  // tool_invocations, but we explicitly clear non-cascading memory
-  // tables too.
-  await runOrThrow("DELETE FROM memory_segments");
+  // Delete in dependency order. The cascade handles tool_invocations;
+  // memory_summaries is still on the main DB, so it clears here.
   await runOrThrow("DELETE FROM memory_summaries");
-  await runOrThrow("DELETE FROM memory_embeddings");
-  // memory_jobs and llm_request_logs each live in their own dedicated
-  // connection; clear them directly on those connections rather than through
-  // a sqlite3 subprocess.
+  // memory_jobs, memory_embeddings, and llm_request_logs each live on a
+  // dedicated connection; clear them there rather than through a main-DB
+  // sqlite3 subprocess. memory_segments is conversation-keyed and is purged by
+  // the CONVERSATIONS_CLEARED hook below (via CONVERSATION_KEYED_MEMORY_TABLES);
+  // memory_embeddings is polymorphic, so it is cleared here directly.
   rawMemoryRun("conversation:clearAll:memoryJobs", "DELETE FROM memory_jobs");
+  rawMemoryRun(
+    "conversation:clearAll:memoryEmbeddings",
+    "DELETE FROM memory_embeddings",
+  );
   await runOrThrow("DELETE FROM memory_checkpoints");
   rawLogsRun(
     "conversation:clearAll:requestLogs",
@@ -3385,6 +3388,35 @@ export function deleteLastExchange(conversationId: string): number {
       .where(eq(conversations.id, conversationId))
       .run();
   });
+
+  // The undone messages' segments moved to the memory connection, so the message
+  // cascade no longer removes them and the conversation-keyed purge does not
+  // apply (the conversation survives). Delete the segments and their embeddings
+  // explicitly — the sole cleanup for these message-scoped rows. Best-effort.
+  const memoryDb = getMemoryDb();
+  if (memoryDb && messageIds.length > 0) {
+    const segmentIds = memoryDb
+      .select({ id: memorySegments.id })
+      .from(memorySegments)
+      .where(inArray(memorySegments.messageId, messageIds))
+      .all()
+      .map((r) => r.id);
+    memoryDb
+      .delete(memorySegments)
+      .where(inArray(memorySegments.messageId, messageIds))
+      .run();
+    if (segmentIds.length > 0) {
+      memoryDb
+        .delete(memoryEmbeddings)
+        .where(
+          and(
+            eq(memoryEmbeddings.targetType, "segment"),
+            inArray(memoryEmbeddings.targetId, segmentIds),
+          ),
+        )
+        .run();
+    }
+  }
 
   deleteOrphanAttachments(candidateAttachmentIds);
 
@@ -3633,23 +3665,31 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
     .where(eq(messages.id, messageId))
     .get();
 
-  db.transaction((tx) => {
-    // Collect memory segment IDs linked to this message before cascade.
-    const linkedSegments = tx
+  // memory_segments and memory_embeddings live on the memory connection now.
+  // Deleting one message leaves its conversation alive, so the conversation-
+  // keyed purge never reclaims these rows — collect the segment ids first, then
+  // delete the segments and their embeddings explicitly below. This explicit
+  // delete is the sole cleanup for message-scoped segments (no orphan-sweep
+  // backstop). Best-effort: a missing memory database yields no ids and no-ops.
+  const memoryDb = getMemoryDb();
+  if (memoryDb) {
+    result.segmentIds = memoryDb
       .select({ id: memorySegments.id })
       .from(memorySegments)
       .where(eq(memorySegments.messageId, messageId))
-      .all();
-    result.segmentIds = linkedSegments.map((r) => r.id);
+      .all()
+      .map((r) => r.id);
+  }
 
+  db.transaction((tx) => {
     // Detach nullable FK references so the cascade doesn't destroy them.
     tx.update(channelInboundEvents)
       .set({ messageId: null })
       .where(eq(channelInboundEvents.messageId, messageId))
       .run();
 
-    // Now safe to delete — NOT NULL cascades remove memory_segments
-    // and message_attachments.
+    // NOT NULL cascades remove message_attachments (memory_segments moved to the
+    // memory connection and is deleted explicitly below).
     tx.delete(messages).where(eq(messages.id, messageId)).run();
 
     // Recalculate lastMessageAt after deletion.
@@ -3666,10 +3706,17 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
         .where(eq(conversations.id, msgRow.conversationId))
         .run();
     }
+  });
 
-    // Clean up segment embeddings from SQLite (Qdrant cleanup is the caller's job).
+  // Delete this message's segments and their embeddings on the memory connection.
+  if (memoryDb) {
+    memoryDb
+      .delete(memorySegments)
+      .where(eq(memorySegments.messageId, messageId))
+      .run();
     if (result.segmentIds.length > 0) {
-      tx.delete(memoryEmbeddings)
+      memoryDb
+        .delete(memoryEmbeddings)
         .where(
           and(
             eq(memoryEmbeddings.targetType, "segment"),
@@ -3678,7 +3725,7 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
         )
         .run();
     }
-  });
+  }
 
   deleteOrphanAttachments(candidateAttachmentIds);
 

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -1839,8 +1839,8 @@ export function deleteConversation(id: string): DeletedMemoryIds {
 
   // Collect the conversation's segment ids from the memory connection BEFORE the
   // delete: the startup orphan sweep purges memory_segments whose conversation_id
-  // no longer exists, so reading after the conversation row is gone could race
-  // it and return nothing (losing the Qdrant purge). Best-effort — a missing or
+  // does not exist, so reading after the conversation row is gone could race
+  // it and return nothing (losing the Qdrant purge). Best-effort: a missing or
   // locked memory database yields no ids and must not abort the delete.
   const memoryDb = getMemoryDb();
   if (memoryDb) {
@@ -1860,8 +1860,8 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   }
 
   db.transaction((tx) => {
-    // memory_segments no longer cascades from messages/conversations — it lives
-    // on the memory connection now and is purged by the conversation-deleted
+    // memory_segments does not cascade from messages/conversations; it lives
+    // on the memory connection and is purged by the conversation-deleted
     // hook below. The main-DB cascade still removes message_attachments.
     tx.delete(toolInvocations)
       .where(eq(toolInvocations.conversationId, id))
@@ -1871,7 +1871,7 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   });
 
   // Delete the segment embeddings on the memory connection after the main delete
-  // succeeds. Best-effort — a memory-DB failure must not abort the disk cleanup
+  // succeeds. Best-effort: a memory-DB failure must not abort the disk cleanup
   // and conversation-deleted hook below.
   if (memoryDb && result.segmentIds.length > 0) {
     try {
@@ -1954,7 +1954,7 @@ export async function deleteConversationGently(
   const createdAtForDiskCleanup = convBeforeDelete?.createdAt;
 
   // Collect the conversation's memory segment ids from the memory connection
-  // (memory_segments moved off the main DB) so the caller can clean up the
+  // (memory_segments is on the memory connection) so the caller can clean up the
   // matching Qdrant vectors. The segment rows are purged by the
   // conversation-deleted hook; their embeddings are deleted after the main
   // delete below. Best-effort: a missing memory database yields no ids.
@@ -2011,7 +2011,7 @@ export async function deleteConversationGently(
 
   // Bulk message delete off the event loop, in lock-friendly batches. Cascades
   // to message_attachments, bookmarks, channel_inbound_events (memory_segments
-  // moved to the memory connection and is purged by the hook below).
+  // is on the memory connection and is purged by the hook below).
   const del = await deleteConversationRowsInBatches({
     conversationId: id,
     table: "messages",
@@ -2035,7 +2035,7 @@ export async function deleteConversationGently(
 
   // Delete the segment embeddings on the memory connection (memory_embeddings is
   // not FK-linked to segments, so nothing cascades them). Best-effort, after the
-  // main delete succeeds — a memory-DB failure must not abort the hook/disk
+  // main delete succeeds. A memory-DB failure must not abort the hook/disk
   // cleanup below.
   if (memoryDb && result.segmentIds.length > 0) {
     try {

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -1860,9 +1860,9 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   }
 
   db.transaction((tx) => {
-    // memory_segments does not cascade from messages/conversations; it lives
-    // on the memory connection and is purged by the conversation-deleted
-    // hook below. The main-DB cascade still removes message_attachments.
+    // memory_segments does not cascade from messages/conversations; it lives on
+    // the memory connection and is purged directly below. The main-DB cascade
+    // still removes message_attachments.
     tx.delete(toolInvocations)
       .where(eq(toolInvocations.conversationId, id))
       .run();
@@ -1870,24 +1870,33 @@ export function deleteConversation(id: string): DeletedMemoryIds {
     tx.delete(conversations).where(eq(conversations.id, id)).run();
   });
 
-  // Delete the segment embeddings on the memory connection after the main delete
-  // succeeds. Best-effort: a memory-DB failure must not abort the disk cleanup
-  // and conversation-deleted hook below.
-  if (memoryDb && result.segmentIds.length > 0) {
+  // Delete the conversation's segments and their embeddings on the memory
+  // connection after the main delete succeeds, rather than leaving the segment
+  // rows to the conversation-deleted hook: that hook is a no-op when the memory
+  // plugin is disabled and would keep the plaintext content in the memory
+  // database. Best-effort: a memory-DB failure must not abort the disk cleanup
+  // or the hook below.
+  if (memoryDb) {
     try {
+      if (result.segmentIds.length > 0) {
+        memoryDb
+          .delete(memoryEmbeddings)
+          .where(
+            and(
+              eq(memoryEmbeddings.targetType, "segment"),
+              inArray(memoryEmbeddings.targetId, result.segmentIds),
+            ),
+          )
+          .run();
+      }
       memoryDb
-        .delete(memoryEmbeddings)
-        .where(
-          and(
-            eq(memoryEmbeddings.targetType, "segment"),
-            inArray(memoryEmbeddings.targetId, result.segmentIds),
-          ),
-        )
+        .delete(memorySegments)
+        .where(eq(memorySegments.conversationId, id))
         .run();
     } catch (err) {
       log.warn(
         { err, conversationId: id },
-        "Failed to delete segment embeddings for deleted conversation; continuing",
+        "Failed to delete memory segments for deleted conversation; continuing",
       );
     }
   }
@@ -2011,7 +2020,7 @@ export async function deleteConversationGently(
 
   // Bulk message delete off the event loop, in lock-friendly batches. Cascades
   // to message_attachments, bookmarks, channel_inbound_events (memory_segments
-  // is on the memory connection and is purged by the hook below).
+  // is on the memory connection and is purged directly below).
   const del = await deleteConversationRowsInBatches({
     conversationId: id,
     table: "messages",
@@ -2033,25 +2042,33 @@ export async function deleteConversationGently(
     tx.delete(conversations).where(eq(conversations.id, id)).run();
   });
 
-  // Delete the segment embeddings on the memory connection (memory_embeddings is
-  // not FK-linked to segments, so nothing cascades them). Best-effort, after the
-  // main delete succeeds. A memory-DB failure must not abort the hook/disk
-  // cleanup below.
-  if (memoryDb && result.segmentIds.length > 0) {
+  // Delete the conversation's segments and their embeddings on the memory
+  // connection, rather than leaving the segment rows to the conversation-deleted
+  // hook: that hook is a no-op when the memory plugin is disabled and would keep
+  // the plaintext content in the memory database. Best-effort, after the main
+  // delete succeeds. A memory-DB failure must not abort the hook/disk cleanup
+  // below.
+  if (memoryDb) {
     try {
+      if (result.segmentIds.length > 0) {
+        memoryDb
+          .delete(memoryEmbeddings)
+          .where(
+            and(
+              eq(memoryEmbeddings.targetType, "segment"),
+              inArray(memoryEmbeddings.targetId, result.segmentIds),
+            ),
+          )
+          .run();
+      }
       memoryDb
-        .delete(memoryEmbeddings)
-        .where(
-          and(
-            eq(memoryEmbeddings.targetType, "segment"),
-            inArray(memoryEmbeddings.targetId, result.segmentIds),
-          ),
-        )
+        .delete(memorySegments)
+        .where(eq(memorySegments.conversationId, id))
         .run();
     } catch (err) {
       log.warn(
         { err, conversationId: id },
-        "Failed to delete segment embeddings for deleted conversation; continuing",
+        "Failed to delete memory segments for deleted conversation; continuing",
       );
     }
   }

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -3265,12 +3265,18 @@ export async function clearAll(): Promise<{
   // Delete in dependency order. The cascade handles tool_invocations;
   // memory_summaries is still on the main DB, so it clears here.
   await runOrThrow("DELETE FROM memory_summaries");
-  // memory_jobs, memory_embeddings, and llm_request_logs each live on a
-  // dedicated connection; clear them there rather than through a main-DB
-  // sqlite3 subprocess. memory_segments is conversation-keyed and is purged by
-  // the CONVERSATIONS_CLEARED hook below (via CONVERSATION_KEYED_MEMORY_TABLES);
-  // memory_embeddings is polymorphic, so it is cleared here directly.
+  // memory_jobs, memory_segments, memory_embeddings, and llm_request_logs each
+  // live on a dedicated connection; clear them there rather than through a
+  // main-DB sqlite3 subprocess. memory_segments holds deleted message text, so
+  // clear it directly here instead of leaving it to the CONVERSATIONS_CLEARED
+  // hook below: that hook is a no-op when the memory plugin is disabled, which
+  // would keep the text searchable until the next startup sweep. memory_embeddings
+  // is polymorphic and cleared directly for the same reason.
   rawMemoryRun("conversation:clearAll:memoryJobs", "DELETE FROM memory_jobs");
+  rawMemoryRun(
+    "conversation:clearAll:memorySegments",
+    "DELETE FROM memory_segments",
+  );
   rawMemoryRun(
     "conversation:clearAll:memoryEmbeddings",
     "DELETE FROM memory_embeddings",
@@ -3348,6 +3354,53 @@ export async function clearAll(): Promise<{
   return { conversations: convCount, messages: msgCount };
 }
 
+/**
+ * Delete every memory_segment, and its segment embeddings, for the given
+ * message ids on the memory connection, returning the deleted segment ids.
+ * memory_segments has no cross-file FK to messages, so a message delete never
+ * cascades to it, and the conversation-keyed purge does not apply while the
+ * conversation survives. Callers run this before removing the message rows and
+ * again after; the second pass catches segments a concurrent backfill writes in
+ * the gap between the two. Best-effort: a missing or locked memory database is
+ * logged and treated as a no-op so it never aborts the delete.
+ */
+function purgeMessageSegments(messageIds: string[], context: string): string[] {
+  const memoryDb = getMemoryDb();
+  if (!memoryDb || messageIds.length === 0) {
+    return [];
+  }
+  try {
+    const ids = memoryDb
+      .select({ id: memorySegments.id })
+      .from(memorySegments)
+      .where(inArray(memorySegments.messageId, messageIds))
+      .all()
+      .map((r) => r.id);
+    if (ids.length > 0) {
+      memoryDb
+        .delete(memoryEmbeddings)
+        .where(
+          and(
+            eq(memoryEmbeddings.targetType, "segment"),
+            inArray(memoryEmbeddings.targetId, ids),
+          ),
+        )
+        .run();
+      memoryDb
+        .delete(memorySegments)
+        .where(inArray(memorySegments.messageId, messageIds))
+        .run();
+    }
+    return ids;
+  } catch (err) {
+    log.warn(
+      { err, context },
+      "Failed to purge memory segments for deleted messages; continuing",
+    );
+    return [];
+  }
+}
+
 export function deleteLastExchange(conversationId: string): number {
   const db = getDb();
 
@@ -3406,44 +3459,9 @@ export function deleteLastExchange(conversationId: string): number {
           .filter((id): id is string => id != null)
       : [];
 
-  // The undone messages' segments live on the memory connection, so the message
-  // delete no longer cascades them and the conversation-keyed purge does not
-  // apply (the conversation survives). Delete them and their embeddings
-  // explicitly BEFORE the messages are removed: a crash between the two then
-  // leaves live messages whose segments re-index rather than orphaned segments
-  // for gone messages (no orphan-sweep backstop). Best-effort — a locked/missing
-  // memory database must not abort the undo.
-  const memoryDb = getMemoryDb();
-  if (memoryDb && messageIds.length > 0) {
-    try {
-      const segmentIds = memoryDb
-        .select({ id: memorySegments.id })
-        .from(memorySegments)
-        .where(inArray(memorySegments.messageId, messageIds))
-        .all()
-        .map((r) => r.id);
-      if (segmentIds.length > 0) {
-        memoryDb
-          .delete(memoryEmbeddings)
-          .where(
-            and(
-              eq(memoryEmbeddings.targetType, "segment"),
-              inArray(memoryEmbeddings.targetId, segmentIds),
-            ),
-          )
-          .run();
-      }
-      memoryDb
-        .delete(memorySegments)
-        .where(inArray(memorySegments.messageId, messageIds))
-        .run();
-    } catch (err) {
-      log.warn(
-        { err, conversationId },
-        "Failed to clean up memory segments for undone messages; continuing",
-      );
-    }
-  }
+  // Purge the undone messages' segments before removing their rows so a crash
+  // between the two re-indexes live messages rather than orphaning segments.
+  purgeMessageSegments(messageIds, "deleteLastExchange");
 
   db.transaction((tx) => {
     tx.delete(messages).where(condition).run();
@@ -3460,6 +3478,10 @@ export function deleteLastExchange(conversationId: string): number {
       .where(eq(conversations.id, conversationId))
       .run();
   });
+
+  // Second purge now the message rows are gone, catching any segments a backfill
+  // wrote in the gap between the purge above and the delete.
+  purgeMessageSegments(messageIds, "deleteLastExchange:post-delete");
 
   deleteOrphanAttachments(candidateAttachmentIds);
 
@@ -3708,44 +3730,9 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
     .where(eq(messages.id, messageId))
     .get();
 
-  // memory_segments and memory_embeddings live on the memory connection now.
-  // Deleting one message leaves its conversation alive, so the conversation-
-  // keyed purge never reclaims these rows — this explicit delete is their sole
-  // cleanup (no orphan-sweep backstop). Run it BEFORE the message row is
-  // removed: a crash between the two then leaves a live message whose segments
-  // simply re-index, rather than orphaned segments for a message that is gone.
-  // Best-effort: a missing or locked memory database must not abort the delete.
-  const memoryDb = getMemoryDb();
-  if (memoryDb) {
-    try {
-      result.segmentIds = memoryDb
-        .select({ id: memorySegments.id })
-        .from(memorySegments)
-        .where(eq(memorySegments.messageId, messageId))
-        .all()
-        .map((r) => r.id);
-      if (result.segmentIds.length > 0) {
-        memoryDb
-          .delete(memoryEmbeddings)
-          .where(
-            and(
-              eq(memoryEmbeddings.targetType, "segment"),
-              inArray(memoryEmbeddings.targetId, result.segmentIds),
-            ),
-          )
-          .run();
-      }
-      memoryDb
-        .delete(memorySegments)
-        .where(eq(memorySegments.messageId, messageId))
-        .run();
-    } catch (err) {
-      log.warn(
-        { err, messageId },
-        "Failed to clean up memory segments for deleted message; continuing",
-      );
-    }
-  }
+  // Purge the message's segments before removing its row so a crash between the
+  // two re-indexes a live message rather than orphaning segments for a gone one.
+  result.segmentIds = purgeMessageSegments([messageId], "deleteMessageById");
 
   db.transaction((tx) => {
     // Detach nullable FK references so the cascade doesn't destroy them.
@@ -3754,8 +3741,8 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
       .where(eq(channelInboundEvents.messageId, messageId))
       .run();
 
-    // NOT NULL cascades remove message_attachments (memory_segments moved to the
-    // memory connection and was deleted above).
+    // NOT NULL cascades remove message_attachments. memory_segments is on the
+    // memory connection and was purged above.
     tx.delete(messages).where(eq(messages.id, messageId)).run();
 
     // Recalculate lastMessageAt after deletion.
@@ -3773,6 +3760,13 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
         .run();
     }
   });
+
+  // Second purge now the message row is gone: a backfill racing this delete can
+  // write segments after the purge above while its own existence check still
+  // sees the message present, so re-run the cleanup to remove any it added.
+  result.segmentIds.push(
+    ...purgeMessageSegments([messageId], "deleteMessageById:post-delete"),
+  );
 
   deleteOrphanAttachments(candidateAttachmentIds);
 

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -1837,6 +1837,28 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   deleteRequestLogsForConversation(id);
   deletePendingTelemetryEventsForConversation(id);
 
+  // Collect the conversation's segment ids from the memory connection BEFORE the
+  // delete: the startup orphan sweep purges memory_segments whose conversation_id
+  // no longer exists, so reading after the conversation row is gone could race
+  // it and return nothing (losing the Qdrant purge). Best-effort — a missing or
+  // locked memory database yields no ids and must not abort the delete.
+  const memoryDb = getMemoryDb();
+  if (memoryDb) {
+    try {
+      result.segmentIds = memoryDb
+        .select({ id: memorySegments.id })
+        .from(memorySegments)
+        .where(eq(memorySegments.conversationId, id))
+        .all()
+        .map((r) => r.id);
+    } catch (err) {
+      log.warn(
+        { err, conversationId: id },
+        "Failed to read memory segments for deleted conversation; continuing",
+      );
+    }
+  }
+
   db.transaction((tx) => {
     // memory_segments no longer cascades from messages/conversations — it lives
     // on the memory connection now and is purged by the conversation-deleted
@@ -1848,20 +1870,11 @@ export function deleteConversation(id: string): DeletedMemoryIds {
     tx.delete(conversations).where(eq(conversations.id, id)).run();
   });
 
-  // Clean up the moved segment/embedding tables on the memory connection, after
-  // the main delete succeeds and before the conversation-deleted hook purges the
-  // segment rows. Collect the segment ids (keyed by conversation_id) for the
-  // caller's Qdrant vector purge, then delete their embeddings. Best-effort: a
-  // missing memory database no-ops, mirroring the cross-file split elsewhere.
-  const memoryDb = getMemoryDb();
-  if (memoryDb) {
-    result.segmentIds = memoryDb
-      .select({ id: memorySegments.id })
-      .from(memorySegments)
-      .where(eq(memorySegments.conversationId, id))
-      .all()
-      .map((r) => r.id);
-    if (result.segmentIds.length > 0) {
+  // Delete the segment embeddings on the memory connection after the main delete
+  // succeeds. Best-effort — a memory-DB failure must not abort the disk cleanup
+  // and conversation-deleted hook below.
+  if (memoryDb && result.segmentIds.length > 0) {
+    try {
       memoryDb
         .delete(memoryEmbeddings)
         .where(
@@ -1871,6 +1884,11 @@ export function deleteConversation(id: string): DeletedMemoryIds {
           ),
         )
         .run();
+    } catch (err) {
+      log.warn(
+        { err, conversationId: id },
+        "Failed to delete segment embeddings for deleted conversation; continuing",
+      );
     }
   }
 
@@ -1941,14 +1959,21 @@ export async function deleteConversationGently(
   // conversation-deleted hook; their embeddings are deleted after the main
   // delete below. Best-effort: a missing memory database yields no ids.
   const memoryDb = getMemoryDb();
-  result.segmentIds = memoryDb
-    ? memoryDb
+  if (memoryDb) {
+    try {
+      result.segmentIds = memoryDb
         .select({ id: memorySegments.id })
         .from(memorySegments)
         .where(eq(memorySegments.conversationId, id))
         .all()
-        .map((r) => r.id)
-    : [];
+        .map((r) => r.id);
+    } catch (err) {
+      log.warn(
+        { err, conversationId: id },
+        "Failed to read memory segments for deleted conversation; continuing",
+      );
+    }
+  }
 
   // Pending telemetry_events rows live in the dedicated telemetry connection;
   // delete them (by conversation_id, regardless of event name) before ANY
@@ -2010,17 +2035,25 @@ export async function deleteConversationGently(
 
   // Delete the segment embeddings on the memory connection (memory_embeddings is
   // not FK-linked to segments, so nothing cascades them). Best-effort, after the
-  // main delete succeeds.
+  // main delete succeeds — a memory-DB failure must not abort the hook/disk
+  // cleanup below.
   if (memoryDb && result.segmentIds.length > 0) {
-    memoryDb
-      .delete(memoryEmbeddings)
-      .where(
-        and(
-          eq(memoryEmbeddings.targetType, "segment"),
-          inArray(memoryEmbeddings.targetId, result.segmentIds),
-        ),
-      )
-      .run();
+    try {
+      memoryDb
+        .delete(memoryEmbeddings)
+        .where(
+          and(
+            eq(memoryEmbeddings.targetType, "segment"),
+            inArray(memoryEmbeddings.targetId, result.segmentIds),
+          ),
+        )
+        .run();
+    } catch (err) {
+      log.warn(
+        { err, conversationId: id },
+        "Failed to delete segment embeddings for deleted conversation; continuing",
+      );
+    }
   }
 
   // Remove the conversation's disk-view directory after the DB transaction.
@@ -3373,6 +3406,45 @@ export function deleteLastExchange(conversationId: string): number {
           .filter((id): id is string => id != null)
       : [];
 
+  // The undone messages' segments live on the memory connection, so the message
+  // delete no longer cascades them and the conversation-keyed purge does not
+  // apply (the conversation survives). Delete them and their embeddings
+  // explicitly BEFORE the messages are removed: a crash between the two then
+  // leaves live messages whose segments re-index rather than orphaned segments
+  // for gone messages (no orphan-sweep backstop). Best-effort — a locked/missing
+  // memory database must not abort the undo.
+  const memoryDb = getMemoryDb();
+  if (memoryDb && messageIds.length > 0) {
+    try {
+      const segmentIds = memoryDb
+        .select({ id: memorySegments.id })
+        .from(memorySegments)
+        .where(inArray(memorySegments.messageId, messageIds))
+        .all()
+        .map((r) => r.id);
+      if (segmentIds.length > 0) {
+        memoryDb
+          .delete(memoryEmbeddings)
+          .where(
+            and(
+              eq(memoryEmbeddings.targetType, "segment"),
+              inArray(memoryEmbeddings.targetId, segmentIds),
+            ),
+          )
+          .run();
+      }
+      memoryDb
+        .delete(memorySegments)
+        .where(inArray(memorySegments.messageId, messageIds))
+        .run();
+    } catch (err) {
+      log.warn(
+        { err, conversationId },
+        "Failed to clean up memory segments for undone messages; continuing",
+      );
+    }
+  }
+
   db.transaction((tx) => {
     tx.delete(messages).where(condition).run();
     const maxResult = tx
@@ -3388,35 +3460,6 @@ export function deleteLastExchange(conversationId: string): number {
       .where(eq(conversations.id, conversationId))
       .run();
   });
-
-  // The undone messages' segments moved to the memory connection, so the message
-  // cascade no longer removes them and the conversation-keyed purge does not
-  // apply (the conversation survives). Delete the segments and their embeddings
-  // explicitly — the sole cleanup for these message-scoped rows. Best-effort.
-  const memoryDb = getMemoryDb();
-  if (memoryDb && messageIds.length > 0) {
-    const segmentIds = memoryDb
-      .select({ id: memorySegments.id })
-      .from(memorySegments)
-      .where(inArray(memorySegments.messageId, messageIds))
-      .all()
-      .map((r) => r.id);
-    memoryDb
-      .delete(memorySegments)
-      .where(inArray(memorySegments.messageId, messageIds))
-      .run();
-    if (segmentIds.length > 0) {
-      memoryDb
-        .delete(memoryEmbeddings)
-        .where(
-          and(
-            eq(memoryEmbeddings.targetType, "segment"),
-            inArray(memoryEmbeddings.targetId, segmentIds),
-          ),
-        )
-        .run();
-    }
-  }
 
   deleteOrphanAttachments(candidateAttachmentIds);
 
@@ -3667,18 +3710,41 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
 
   // memory_segments and memory_embeddings live on the memory connection now.
   // Deleting one message leaves its conversation alive, so the conversation-
-  // keyed purge never reclaims these rows — collect the segment ids first, then
-  // delete the segments and their embeddings explicitly below. This explicit
-  // delete is the sole cleanup for message-scoped segments (no orphan-sweep
-  // backstop). Best-effort: a missing memory database yields no ids and no-ops.
+  // keyed purge never reclaims these rows — this explicit delete is their sole
+  // cleanup (no orphan-sweep backstop). Run it BEFORE the message row is
+  // removed: a crash between the two then leaves a live message whose segments
+  // simply re-index, rather than orphaned segments for a message that is gone.
+  // Best-effort: a missing or locked memory database must not abort the delete.
   const memoryDb = getMemoryDb();
   if (memoryDb) {
-    result.segmentIds = memoryDb
-      .select({ id: memorySegments.id })
-      .from(memorySegments)
-      .where(eq(memorySegments.messageId, messageId))
-      .all()
-      .map((r) => r.id);
+    try {
+      result.segmentIds = memoryDb
+        .select({ id: memorySegments.id })
+        .from(memorySegments)
+        .where(eq(memorySegments.messageId, messageId))
+        .all()
+        .map((r) => r.id);
+      if (result.segmentIds.length > 0) {
+        memoryDb
+          .delete(memoryEmbeddings)
+          .where(
+            and(
+              eq(memoryEmbeddings.targetType, "segment"),
+              inArray(memoryEmbeddings.targetId, result.segmentIds),
+            ),
+          )
+          .run();
+      }
+      memoryDb
+        .delete(memorySegments)
+        .where(eq(memorySegments.messageId, messageId))
+        .run();
+    } catch (err) {
+      log.warn(
+        { err, messageId },
+        "Failed to clean up memory segments for deleted message; continuing",
+      );
+    }
   }
 
   db.transaction((tx) => {
@@ -3689,7 +3755,7 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
       .run();
 
     // NOT NULL cascades remove message_attachments (memory_segments moved to the
-    // memory connection and is deleted explicitly below).
+    // memory connection and was deleted above).
     tx.delete(messages).where(eq(messages.id, messageId)).run();
 
     // Recalculate lastMessageAt after deletion.
@@ -3707,25 +3773,6 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
         .run();
     }
   });
-
-  // Delete this message's segments and their embeddings on the memory connection.
-  if (memoryDb) {
-    memoryDb
-      .delete(memorySegments)
-      .where(eq(memorySegments.messageId, messageId))
-      .run();
-    if (result.segmentIds.length > 0) {
-      memoryDb
-        .delete(memoryEmbeddings)
-        .where(
-          and(
-            eq(memoryEmbeddings.targetType, "segment"),
-            inArray(memoryEmbeddings.targetId, result.segmentIds),
-          ),
-        )
-        .run();
-    }
-  }
 
   deleteOrphanAttachments(candidateAttachmentIds);
 

--- a/assistant/src/persistence/job-handlers/cleanup.ts
+++ b/assistant/src/persistence/job-handlers/cleanup.ts
@@ -4,6 +4,7 @@ import { runHook } from "../../plugins/pipeline.js";
 import { rotateToolInvocations } from "../../telemetry/tool-usage-store.js";
 import { getLogger } from "../../util/logger.js";
 import { getLogsDbPath } from "../../util/logs-db-path.js";
+import { purgeConversationSegments } from "../conversation-crud.js";
 import { runAsyncSqlite } from "../db-async-query.js";
 import { getDb } from "../db-connection.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
@@ -232,12 +233,14 @@ export function pruneOldConversationsJob(
     });
   }
 
-  // Fire the conversation-deleted signal for each pruned id, mirroring the
-  // single-delete primitive: the memory plugin's hook purges its relocated
+  // Purge each pruned conversation's segments directly, then fire the
+  // conversation-deleted signal. The hook is fire-and-forget and a no-op when
+  // the memory plugin is disabled, so relying on it alone would leave the
+  // deleted conversation's plaintext segment rows in the memory database; the
+  // direct purge removes them regardless. The hook still handles the derived
   // per-conversation tables and cancels the conversation's pending jobs.
-  // Fire-and-forget, after the rows are gone — a lost cleanup only leaves
-  // harmless orphan rows in derived tables.
   for (const id of prunedIds) {
+    purgeConversationSegments(id);
     void runHook(HOOKS.CONVERSATION_DELETED, { conversationId: id });
   }
   const pruned = prunedIds.length;

--- a/assistant/src/persistence/job-utils.ts
+++ b/assistant/src/persistence/job-utils.ts
@@ -5,7 +5,7 @@ import { and, eq } from "drizzle-orm";
 import type { AssistantConfig } from "../config/types.js";
 import { BackendUnavailableError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
-import { getDb } from "./db-connection.js";
+import { getMemoryDb } from "./db-connection.js";
 import {
   embedWithBackend,
   generateSparseEmbedding,
@@ -180,23 +180,26 @@ export async function embedAndUpsert(
   let vector: number[];
 
   // Check SQLite embedding cache for a matching content hash (primary provider only).
-  const db = getDb();
+  // The cache lives on the memory connection alongside `memory_embeddings`.
+  const mem = getMemoryDb();
   const expectedDim = config.memory.qdrant.vectorSize;
-  let cachedRow = db
-    .select({
-      vectorBlob: memoryEmbeddings.vectorBlob,
-      vectorJson: memoryEmbeddings.vectorJson,
-      dimensions: memoryEmbeddings.dimensions,
-    })
-    .from(memoryEmbeddings)
-    .where(
-      and(
-        eq(memoryEmbeddings.contentHash, contentHash),
-        eq(memoryEmbeddings.provider, provider),
-        eq(memoryEmbeddings.model, model),
-      ),
-    )
-    .get();
+  let cachedRow = mem
+    ? mem
+        .select({
+          vectorBlob: memoryEmbeddings.vectorBlob,
+          vectorJson: memoryEmbeddings.vectorJson,
+          dimensions: memoryEmbeddings.dimensions,
+        })
+        .from(memoryEmbeddings)
+        .where(
+          and(
+            eq(memoryEmbeddings.contentHash, contentHash),
+            eq(memoryEmbeddings.provider, provider),
+            eq(memoryEmbeddings.model, model),
+          ),
+        )
+        .get()
+    : undefined;
   if (cachedRow && cachedRow.dimensions !== expectedDim) cachedRow = undefined;
 
   if (cachedRow) {
@@ -265,7 +268,8 @@ export async function embedAndUpsert(
   // and leaves the point in place, and the next run re-embeds.
   try {
     const blobValue = vectorToBlob(vector);
-    db.insert(memoryEmbeddings)
+    mem
+      ?.insert(memoryEmbeddings)
       .values({
         id: randomUUID(),
         targetType,

--- a/assistant/src/persistence/migrations/340-sweep-orphaned-graph-node-vectors.test.ts
+++ b/assistant/src/persistence/migrations/340-sweep-orphaned-graph-node-vectors.test.ts
@@ -107,6 +107,15 @@ beforeEach(() => {
     source_type TEXT NOT NULL DEFAULT 'inferred',
     scope_id TEXT NOT NULL DEFAULT 'default'
   )`);
+  // memory_embeddings also moved to the memory DB (a later migration); this
+  // migration reads it on the main connection too, so recreate its shape here.
+  raw.run(/*sql*/ `CREATE TABLE IF NOT EXISTS memory_embeddings (
+    id TEXT PRIMARY KEY, target_type TEXT NOT NULL, target_id TEXT NOT NULL,
+    provider TEXT NOT NULL, model TEXT NOT NULL, dimensions INTEGER NOT NULL,
+    vector_json TEXT, vector_blob BLOB, content_hash TEXT,
+    created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+    UNIQUE (target_type, target_id, provider, model)
+  )`);
   raw.run("DELETE FROM memory_embeddings");
   raw.run("DELETE FROM memory_graph_nodes");
   getMemorySqlite()!.run("DELETE FROM memory_jobs");

--- a/assistant/src/persistence/migrations/340-sweep-orphaned-graph-node-vectors.test.ts
+++ b/assistant/src/persistence/migrations/340-sweep-orphaned-graph-node-vectors.test.ts
@@ -107,7 +107,7 @@ beforeEach(() => {
     source_type TEXT NOT NULL DEFAULT 'inferred',
     scope_id TEXT NOT NULL DEFAULT 'default'
   )`);
-  // memory_embeddings also moved to the memory DB (a later migration); this
+  // memory_embeddings is also on the memory DB; this
   // migration reads it on the main connection too, so recreate its shape here.
   raw.run(/*sql*/ `CREATE TABLE IF NOT EXISTS memory_embeddings (
     id TEXT PRIMARY KEY, target_type TEXT NOT NULL, target_id TEXT NOT NULL,

--- a/assistant/src/persistence/migrations/356-move-memory-segments-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/356-move-memory-segments-to-memory-db.ts
@@ -1,0 +1,95 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
+import {
+  type RelocationSpec,
+  runMemoryTableRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `memory_segments` from `main` into the dedicated memory database.
+ *
+ * The column list is explicit (never `SELECT *`) so the copy is insensitive to
+ * the physical order left by the `ALTER TABLE … ADD COLUMN` history: the base
+ * `CREATE` columns (migration 000) plus `scope_id` and `content_hash` (both
+ * added by migration 102). `scope_id` is a real `NOT NULL DEFAULT 'default'`
+ * column even though the Drizzle schema does not map it — dropping it here would
+ * lose that data on the drain.
+ *
+ * The `message_id`/`conversation_id` foreign keys to `messages`/`conversations`
+ * are NOT recreated on the memory side (see {@link ensureMemorySegmentsSchema}):
+ * SQLite cannot cascade across database files, so the conversation- and
+ * message-delete paths replace that cascade with explicit deletes on the memory
+ * connection. The `memory_segment_fts` table and its sync triggers (migration
+ * 101) were already removed by migration 154, so nothing else moves with it.
+ */
+export const MEMORY_SEGMENTS_RELOCATION: RelocationSpec = {
+  table: "memory_segments",
+  targetDbPath: getMemoryDbPath,
+  columns: [
+    "id",
+    "message_id",
+    "conversation_id",
+    "role",
+    "segment_index",
+    "text",
+    "token_estimate",
+    "scope_id",
+    "content_hash",
+    "created_at",
+    "updated_at",
+  ],
+};
+
+/**
+ * Create `memory_segments` on the memory connection. Idempotent
+ * (`IF NOT EXISTS`) — the dedicated connection performs no DDL on open, so this
+ * migration owns the schema. The `message_id`/`conversation_id` columns keep
+ * their values but drop the cross-file `REFERENCES`; the indexes mirror
+ * migrations 016 and 102.
+ */
+export function ensureMemorySegmentsSchema(memoryRaw: Database): void {
+  memoryRaw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_segments (
+      id              TEXT PRIMARY KEY,
+      message_id      TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      role            TEXT NOT NULL,
+      segment_index   INTEGER NOT NULL,
+      text            TEXT NOT NULL,
+      token_estimate  INTEGER NOT NULL,
+      scope_id        TEXT NOT NULL DEFAULT 'default',
+      content_hash    TEXT,
+      created_at      INTEGER NOT NULL,
+      updated_at      INTEGER NOT NULL
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_segments_message_segment
+      ON memory_segments(message_id, segment_index);
+    CREATE INDEX IF NOT EXISTS idx_memory_segments_conversation_created
+      ON memory_segments(conversation_id, created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_memory_segments_scope_id
+      ON memory_segments(scope_id);
+  `);
+}
+
+/**
+ * Move `memory_segments` into the dedicated memory database
+ * (`assistant-memory.db`), so the indexer, summarizer, semantic search, and the
+ * conversation/message delete paths all ride the memory connection.
+ *
+ * Registered with `dependsOn` on every migration that reads or writes
+ * `memory_segments` on main so the move never outruns one where those rows are
+ * still expected there — including `migrateDeletePrivateConversations`, which
+ * runs `DELETE FROM messages` relying on the segment cascade.
+ */
+export async function migrateMoveMemorySegmentsToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  await runMemoryTableRelocation(
+    database,
+    MEMORY_SEGMENTS_RELOCATION,
+    ensureMemorySegmentsSchema,
+  );
+}

--- a/assistant/src/persistence/migrations/356-move-memory-segments-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/356-move-memory-segments-to-memory-db.ts
@@ -14,7 +14,7 @@ import {
  * the physical order left by the `ALTER TABLE … ADD COLUMN` history: the base
  * `CREATE` columns (migration 000) plus `scope_id` and `content_hash` (both
  * added by migration 102). `scope_id` is a real `NOT NULL DEFAULT 'default'`
- * column even though the Drizzle schema does not map it — dropping it here would
+ * column even though the Drizzle schema does not map it, and dropping it here would
  * lose that data on the drain.
  *
  * The `message_id`/`conversation_id` foreign keys to `messages`/`conversations`
@@ -44,7 +44,7 @@ export const MEMORY_SEGMENTS_RELOCATION: RelocationSpec = {
 
 /**
  * Create `memory_segments` on the memory connection. Idempotent
- * (`IF NOT EXISTS`) — the dedicated connection performs no DDL on open, so this
+ * (`IF NOT EXISTS`). The dedicated connection performs no DDL on open, so this
  * migration owns the schema. The `message_id`/`conversation_id` columns keep
  * their values but drop the cross-file `REFERENCES`; the indexes mirror
  * migrations 016 and 102.
@@ -81,7 +81,7 @@ export function ensureMemorySegmentsSchema(memoryRaw: Database): void {
  *
  * Registered with `dependsOn` on every migration that reads or writes
  * `memory_segments` on main so the move never outruns one where those rows are
- * still expected there — including `migrateDeletePrivateConversations`, which
+ * still expected there, including `migrateDeletePrivateConversations`, which
  * runs `DELETE FROM messages` relying on the segment cascade.
  */
 export async function migrateMoveMemorySegmentsToMemoryDb(

--- a/assistant/src/persistence/migrations/357-move-memory-embeddings-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/357-move-memory-embeddings-to-memory-db.ts
@@ -1,0 +1,83 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
+import {
+  type RelocationSpec,
+  runMemoryTableRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `memory_embeddings` from `main` into the dedicated memory
+ * database.
+ *
+ * The column list is explicit: the base `CREATE` columns (migration 000,
+ * including `vector_blob`) plus `content_hash` (migration 102). `vector_json`
+ * was made nullable by migration 026a's table rebuild. The table is polymorphic
+ * (`target_type`/`target_id`, no foreign key), so there is no cascade to
+ * replace — every consumer already deletes embeddings explicitly, and those
+ * deletes move to the memory connection with the table.
+ */
+export const MEMORY_EMBEDDINGS_RELOCATION: RelocationSpec = {
+  table: "memory_embeddings",
+  targetDbPath: getMemoryDbPath,
+  columns: [
+    "id",
+    "target_type",
+    "target_id",
+    "provider",
+    "model",
+    "dimensions",
+    "vector_json",
+    "vector_blob",
+    "content_hash",
+    "created_at",
+    "updated_at",
+  ],
+};
+
+/**
+ * Create `memory_embeddings` on the memory connection. Idempotent. Recreates
+ * both the inline `UNIQUE (target_type, target_id, provider, model)` constraint
+ * and the equivalent named index so `ON CONFLICT` upserts resolve exactly as
+ * they did on main, plus the `content_hash` lookup index (migration 102).
+ */
+export function ensureMemoryEmbeddingsSchema(memoryRaw: Database): void {
+  memoryRaw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_embeddings (
+      id           TEXT PRIMARY KEY,
+      target_type  TEXT NOT NULL,
+      target_id    TEXT NOT NULL,
+      provider     TEXT NOT NULL,
+      model        TEXT NOT NULL,
+      dimensions   INTEGER NOT NULL,
+      vector_json  TEXT,
+      vector_blob  BLOB,
+      content_hash TEXT,
+      created_at   INTEGER NOT NULL,
+      updated_at   INTEGER NOT NULL,
+      UNIQUE (target_type, target_id, provider, model)
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_embeddings_target_provider_model
+      ON memory_embeddings(target_type, target_id, provider, model);
+    CREATE INDEX IF NOT EXISTS idx_memory_embeddings_content_hash
+      ON memory_embeddings(content_hash, provider, model);
+  `);
+}
+
+/**
+ * Move `memory_embeddings` into the dedicated memory database
+ * (`assistant-memory.db`), so both embedding writer families (the jobs worker's
+ * `embedAndUpsert` and the persistence-side cache) and every reader ride the
+ * memory connection.
+ */
+export async function migrateMoveMemoryEmbeddingsToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  await runMemoryTableRelocation(
+    database,
+    MEMORY_EMBEDDINGS_RELOCATION,
+    ensureMemoryEmbeddingsSchema,
+  );
+}

--- a/assistant/src/persistence/migrations/357-move-memory-embeddings-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/357-move-memory-embeddings-to-memory-db.ts
@@ -15,7 +15,7 @@ import {
  * including `vector_blob`) plus `content_hash` (migration 102). `vector_json`
  * was made nullable by migration 026a's table rebuild. The table is polymorphic
  * (`target_type`/`target_id`, no foreign key), so there is no cascade to
- * replace — every consumer already deletes embeddings explicitly, and those
+ * replace. Every consumer already deletes embeddings explicitly, and those
  * deletes move to the memory connection with the table.
  */
 export const MEMORY_EMBEDDINGS_RELOCATION: RelocationSpec = {

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -1488,15 +1488,20 @@ export const migrationSteps: MigrationStep[] = [
   {
     name: "migrateMoveMemorySegmentsToMemoryDb",
     run: migrateMoveMemorySegmentsToMemoryDb,
-    // Gate on every migration that creates, alters, or clears memory_segments on
-    // main. migrateDeletePrivateConversations relies on the message-delete
-    // cascade to clear private segments, so it must land before the move; the
-    // runtime conversation-delete path is handled separately by adding
-    // memory_segments to CONVERSATION_KEYED_MEMORY_TABLES.
+    // Gate on every migration that creates, alters, indexes, or reads
+    // memory_segments on main: the FTS triggers, FTS backfill, and index
+    // creation each fail against the dropped table if they run after the move.
+    // migrateDeletePrivateConversations relies on the message-delete cascade to
+    // clear private segments, so it must land before the move; the runtime
+    // conversation-delete path is handled separately by adding memory_segments
+    // to CONVERSATION_KEYED_MEMORY_TABLES.
     dependsOn: [
       "migrateCoreTables",
+      "migrateMemoryFtsBackfill",
       "migrateMemorySegmentsIndexes",
+      "createWatchersAndLogsTables",
       "addCoreColumns",
+      "createCoreIndexes",
       "migrateDeletePrivateConversations",
     ],
   },

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -463,6 +463,8 @@ import { migrateDropScheduleSkillScriptHandoff } from "./migrations/352-drop-sch
 import { migrateAddLlmUsageConversationType } from "./migrations/353-add-llm-usage-conversation-type.js";
 import { migrateBackfillAppConversationLineage } from "./migrations/354-backfill-app-conversation-lineage.js";
 import { migrateAddScheduleGroupId } from "./migrations/355-add-schedule-group-id.js";
+import { migrateMoveMemorySegmentsToMemoryDb } from "./migrations/356-move-memory-segments-to-memory-db.js";
+import { migrateMoveMemoryEmbeddingsToMemoryDb } from "./migrations/357-move-memory-embeddings-to-memory-db.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1483,4 +1485,36 @@ export const migrationSteps: MigrationStep[] = [
   migrateAddLlmUsageConversationType,
   migrateBackfillAppConversationLineage,
   migrateAddScheduleGroupId,
+  {
+    name: "migrateMoveMemorySegmentsToMemoryDb",
+    run: migrateMoveMemorySegmentsToMemoryDb,
+    // Gate on every migration that creates, alters, or clears memory_segments on
+    // main. migrateDeletePrivateConversations relies on the message-delete
+    // cascade to clear private segments, so it must land before the move; the
+    // runtime conversation-delete path is handled separately by adding
+    // memory_segments to CONVERSATION_KEYED_MEMORY_TABLES.
+    dependsOn: [
+      "migrateCoreTables",
+      "migrateMemorySegmentsIndexes",
+      "addCoreColumns",
+      "migrateDeletePrivateConversations",
+    ],
+  },
+  {
+    name: "migrateMoveMemoryEmbeddingsToMemoryDb",
+    run: migrateMoveMemoryEmbeddingsToMemoryDb,
+    // Gate on every migration that creates, alters, or writes rows in
+    // memory_embeddings on main so the move never drains a table another
+    // migration still expects there.
+    dependsOn: [
+      "migrateCoreTables",
+      "migrateEmbeddingVectorBlob",
+      "migrateEmbeddingsNullableVectorJson",
+      "addCoreColumns",
+      "createCoreIndexes",
+      "migrateDropSimplifiedMemory",
+      "migrateDeletePrivateConversations",
+      "migrateSweepOrphanedGraphNodeVectors",
+    ],
+  },
 ];

--- a/assistant/src/plugins/defaults/memory/__tests__/capability-seed-embed-gate.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/capability-seed-embed-gate.test.ts
@@ -74,7 +74,7 @@ mock.module("../../../../persistence/embeddings/qdrant-client.js", () => ({
 const { setConfig } =
   await import("../../../../__tests__/helpers/set-config.js");
 const { getConfig } = await import("../../../../config/loader.js");
-const { getDb, getMemoryDb } =
+const { getMemoryDb } =
   await import("../../../../persistence/db-connection.js");
 const { initializeDb } = await import("../../../../persistence/db-init.js");
 const { _resetQdrantBreaker: resetQdrantBreaker } =
@@ -101,7 +101,7 @@ function countCapabilityNodes(): number {
 }
 
 function countEmbeddingRows(targetId: string): number {
-  return getDb()
+  return getMemoryDb()!
     .select()
     .from(memoryEmbeddings)
     .where(
@@ -131,7 +131,7 @@ describe("capability seeding embed_graph_node gate", () => {
   beforeEach(() => {
     getMemoryDb()!.run("DELETE FROM memory_jobs");
     getMemoryDb()!.run("DELETE FROM memory_graph_nodes");
-    getDb().delete(memoryEmbeddings).run();
+    getMemoryDb()!.delete(memoryEmbeddings).run();
   });
 
   test("v3-live config: nodes are upserted but no embed_graph_node rows are enqueued", async () => {
@@ -158,7 +158,7 @@ describe("embedAndUpsert embedding-cache row", () => {
   beforeEach(() => {
     upsertShouldFail = false;
     upsertedTargetIds.length = 0;
-    getDb().delete(memoryEmbeddings).run();
+    getMemoryDb()!.delete(memoryEmbeddings).run();
     resetQdrantBreaker();
   });
 

--- a/assistant/src/plugins/defaults/memory/__tests__/conversation-memory-purge.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/conversation-memory-purge.test.ts
@@ -52,6 +52,7 @@ describe("conversation memory purge", () => {
         "conversation_graph_memory_state",
         "memory_recall_logs",
         "memory_retrospective_state",
+        "memory_segments",
         "memory_v2_activation_logs",
         "memory_v3_ever_injected",
         "memory_v3_selections",

--- a/assistant/src/plugins/defaults/memory/__tests__/conversation-row-batch-delete.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/conversation-row-batch-delete.test.ts
@@ -16,14 +16,19 @@ import {
   buildBatchDeleteScript,
   deleteConversationRowsInBatches,
 } from "../../../../persistence/conversation-row-batch-delete.js";
-import { getDb, getSqlite } from "../../../../persistence/db-connection.js";
+import {
+  getDb,
+  getMemorySqlite,
+  getSqlite,
+} from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
 
 await initializeDb();
 
 function resetTables(): void {
   const db = getDb();
-  db.run("DELETE FROM memory_segments");
+  // memory_segments lives on the dedicated memory connection now.
+  getMemorySqlite()?.run("DELETE FROM memory_segments");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
 }
@@ -84,33 +89,11 @@ describe("deleteConversationRowsInBatches", () => {
     expect(countMessages(keep.id)).toBe(1);
   });
 
-  test("cascades to memory_segments when foreign keys are enabled", async () => {
-    const conv = createConversation("with-segments");
-    const msg = await addMessage(conv.id, "user", "segment me", {
-      skipIndexing: true,
-    });
-    const db = getDb();
-    const now = Date.now();
-    db.run(
-      `INSERT INTO memory_segments
-        (id, message_id, conversation_id, role, segment_index, text, token_estimate, created_at, updated_at)
-       VALUES ('seg-1', '${msg.id}', '${conv.id}', 'user', 0, 'segment me', 2, ${now}, ${now})`,
-    );
-    expect(
-      getSqlite().query("SELECT COUNT(*) AS c FROM memory_segments").get(),
-    ).toEqual({ c: 1 });
-
-    const result = await deleteConversationRowsInBatches({
-      conversationId: conv.id,
-      table: "messages",
-      enableForeignKeys: true,
-      forceInProcess: true,
-    });
-    expect(result.ok).toBe(true);
-    expect(
-      getSqlite().query("SELECT COUNT(*) AS c FROM memory_segments").get(),
-    ).toEqual({ c: 0 });
-  });
+  // The low-level batch delete no longer cascades to memory_segments: the table
+  // moved to the memory connection (a different database file), so the main-DB
+  // cascade cannot reach it. deleteConversationGently purges those rows through
+  // the conversation-deleted hook instead — covered by conversation-memory-purge
+  // and the deleteConversationGently test below.
 });
 
 describe("deleteConversationGently", () => {
@@ -123,22 +106,23 @@ describe("deleteConversationGently", () => {
     const msg = await addMessage(conv.id, "user", "bye", {
       skipIndexing: true,
     });
-    const db = getDb();
     const now = Date.now();
-    db.run(
+    // memory_segments lives on the memory connection now — seed it there.
+    getMemorySqlite()!.run(
       `INSERT INTO memory_segments
         (id, message_id, conversation_id, role, segment_index, text, token_estimate, created_at, updated_at)
        VALUES ('seg-gentle', '${msg.id}', '${conv.id}', 'user', 0, 'bye', 1, ${now}, ${now})`,
     );
 
     const result = await deleteConversationGently(conv.id);
+    // The ids are collected from the memory connection for the caller's Qdrant
+    // purge. The segment rows are purged by the conversation-deleted hook, which
+    // is disabled in this memory-off suite — that purge is covered by
+    // conversation-memory-purge instead.
     expect(result.segmentIds).toEqual(["seg-gentle"]);
     expect(countMessages(conv.id)).toBe(0);
     expect(
       getSqlite().query(`SELECT COUNT(*) AS c FROM conversations`).get(),
-    ).toEqual({ c: 0 });
-    expect(
-      getSqlite().query("SELECT COUNT(*) AS c FROM memory_segments").get(),
     ).toEqual({ c: 0 });
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/conversation-row-batch-delete.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/conversation-row-batch-delete.test.ts
@@ -27,7 +27,7 @@ await initializeDb();
 
 function resetTables(): void {
   const db = getDb();
-  // memory_segments lives on the dedicated memory connection now.
+  // memory_segments lives on the dedicated memory connection.
   getMemorySqlite()?.run("DELETE FROM memory_segments");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
@@ -89,10 +89,10 @@ describe("deleteConversationRowsInBatches", () => {
     expect(countMessages(keep.id)).toBe(1);
   });
 
-  // The low-level batch delete no longer cascades to memory_segments: the table
-  // moved to the memory connection (a different database file), so the main-DB
+  // The low-level batch delete does not cascade to memory_segments: the table
+  // is on the memory connection (a different database file), so the main-DB
   // cascade cannot reach it. deleteConversationGently purges those rows through
-  // the conversation-deleted hook instead — covered by conversation-memory-purge
+  // the conversation-deleted hook instead, covered by conversation-memory-purge
   // and the deleteConversationGently test below.
 });
 
@@ -107,7 +107,7 @@ describe("deleteConversationGently", () => {
       skipIndexing: true,
     });
     const now = Date.now();
-    // memory_segments lives on the memory connection now — seed it there.
+    // memory_segments lives on the memory connection, so seed it there.
     getMemorySqlite()!.run(
       `INSERT INTO memory_segments
         (id, message_id, conversation_id, role, segment_index, text, token_estimate, created_at, updated_at)
@@ -117,7 +117,7 @@ describe("deleteConversationGently", () => {
     const result = await deleteConversationGently(conv.id);
     // The ids are collected from the memory connection for the caller's Qdrant
     // purge. The segment rows are purged by the conversation-deleted hook, which
-    // is disabled in this memory-off suite — that purge is covered by
+    // is disabled in this memory-off suite. That purge is covered by
     // conversation-memory-purge instead.
     expect(result.segmentIds).toEqual(["seg-gentle"]);
     expect(countMessages(conv.id)).toBe(0);

--- a/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
@@ -72,6 +72,8 @@ describe("memory database connection", () => {
     "memory_graph_edges",
     "memory_graph_triggers",
     "memory_graph_node_edits",
+    "memory_segments",
+    "memory_embeddings",
   ])("%s lives in the memory connection, not main", (table) => {
     const inMemory = getMemorySqlite()!
       .query<

--- a/assistant/src/plugins/defaults/memory/__tests__/embedding-cache.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/embedding-cache.test.ts
@@ -35,7 +35,8 @@ afterAll(() => {
 });
 
 // Deferred so internal `getWorkspaceDir()` resolves to the tmpdir set above.
-const { getDb } = await import("../../../../persistence/db-connection.js");
+const { getMemoryDb } =
+  await import("../../../../persistence/db-connection.js");
 const { resetDbForTesting } =
   await import("../../../../__tests__/db-test-helpers.js");
 const { initializeDb } = await import("../../../../persistence/db-init.js");
@@ -66,7 +67,7 @@ function seed(
     now: number;
   }> = {},
 ): void {
-  writeEmbeddingCache(getDb(), {
+  writeEmbeddingCache(getMemoryDb()!, {
     targetType: KEY.targetType,
     targetId: KEY.targetId,
     provider: KEY.provider,
@@ -79,13 +80,13 @@ function seed(
 
 describe("embedding-cache", () => {
   test("read returns null when nothing is cached", () => {
-    expect(readEmbeddingCache(getDb(), KEY)).toBeNull();
+    expect(readEmbeddingCache(getMemoryDb()!, KEY)).toBeNull();
   });
 
   test("write then read round-trips the vector and content hash", () => {
     seed({ dense: [1, 2, 3, 4], contentHash: "hash-a" });
 
-    const got = readEmbeddingCache(getDb(), KEY);
+    const got = readEmbeddingCache(getMemoryDb()!, KEY);
     expect(got).not.toBeNull();
     expect(got!.dense).toEqual([1, 2, 3, 4]);
     expect(got!.contentHash).toBe("hash-a");
@@ -93,12 +94,14 @@ describe("embedding-cache", () => {
 
   test("read misses when the configured dimension differs from the stored row", () => {
     seed();
-    expect(readEmbeddingCache(getDb(), { ...KEY, expectedDim: 8 })).toBeNull();
+    expect(
+      readEmbeddingCache(getMemoryDb()!, { ...KEY, expectedDim: 8 }),
+    ).toBeNull();
   });
 
   test("read is isolated by targetType / targetId / provider / model", () => {
     seed();
-    const db = getDb();
+    const db = getMemoryDb()!;
     expect(
       readEmbeddingCache(db, { ...KEY, targetType: "concept_page" }),
     ).toBeNull();
@@ -110,7 +113,7 @@ describe("embedding-cache", () => {
   });
 
   test("re-writing the same key upserts in place (one row, latest content)", () => {
-    const db = getDb();
+    const db = getMemoryDb()!;
     seed({ dense: [1, 2, 3, 4], contentHash: "hash-a", now: 1000 });
     seed({ dense: [5, 6, 7, 8], contentHash: "hash-b", now: 2000 });
 

--- a/assistant/src/plugins/defaults/memory/__tests__/indexer-tier-dispatch.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/indexer-tier-dispatch.test.ts
@@ -28,8 +28,15 @@ import { setConfig } from "../../../../__tests__/helpers/set-config.js";
 import { getConfig } from "../../../../config/loader.js";
 import type { MemoryConfig } from "../../../../config/types.js";
 import { getMemoryCheckpoint } from "../../../../persistence/checkpoints.js";
-import { getMemorySqlite } from "../../../../persistence/db-connection.js";
+import {
+  getDb,
+  getMemorySqlite,
+} from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
+import {
+  conversations,
+  messages,
+} from "../../../../persistence/schema/index.js";
 import { indexMessageNow } from "../indexer.js";
 
 await initializeDb();
@@ -53,13 +60,39 @@ function seedMemory(memory: Record<string, unknown>): MemoryConfig {
   return getConfig().memory;
 }
 
+/**
+ * Seed the conversation and message rows the dispatch indexes. indexMessageNow
+ * skips messages with no main-DB row (it has no cross-file FK to fall back on),
+ * so the source message must exist for the tier triggers to fire.
+ */
+function seedMessage(conversationId: string): string {
+  const messageId = `${conversationId}:m1`;
+  const db = getDb();
+  db.insert(conversations)
+    .values({ id: conversationId, createdAt: 0, updatedAt: 0 })
+    .onConflictDoNothing()
+    .run();
+  db.insert(messages)
+    .values({
+      id: messageId,
+      conversationId,
+      role: "user",
+      content: MESSAGE_TEXT,
+      createdAt: 0,
+    })
+    .onConflictDoNothing()
+    .run();
+  return messageId;
+}
+
 async function indexOneMessage(
   conversationId: string,
   slice: MemoryConfig,
 ): Promise<void> {
+  const messageId = seedMessage(conversationId);
   await indexMessageNow(
     {
-      messageId: `${conversationId}:m1`,
+      messageId,
       conversationId,
       role: "user",
       content: MESSAGE_TEXT,
@@ -125,5 +158,32 @@ describe("indexMessageNow tier dispatch", () => {
     expect(enqueuedJobTypes()).toContain("memory_v2_sweep");
     expect(enqueuedJobTypes()).not.toContain("build_conversation_summary");
     expect(graphExtractPendingCount(conversationId)).toBeNull();
+  });
+
+  test("skips a message with no source row instead of resurrecting it", async () => {
+    const conversationId = nextConversationId();
+    const slice = seedMemory({ enabled: true, v2: { enabled: false } });
+
+    // A body long enough to segment, but no seedMessage: the source row is
+    // absent, as it is for a delete that raced a queued v1 backfill. The
+    // dispatch must write no segments and enqueue no triggers rather than
+    // resurrect deleted text as searchable segments.
+    const messageId = `${conversationId}:m1`;
+    await indexMessageNow(
+      {
+        messageId,
+        conversationId,
+        role: "user",
+        content: "resurrect me please ".repeat(20),
+        createdAt: Date.now(),
+      },
+      slice,
+    );
+
+    const segmentRow = getMemorySqlite()!
+      .query("SELECT COUNT(*) AS n FROM memory_segments WHERE message_id = ?")
+      .get(messageId) as { n: number };
+    expect(segmentRow.n).toBe(0);
+    expect(enqueuedJobTypes()).toHaveLength(0);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/relocated-memory-test-rows.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/relocated-memory-test-rows.ts
@@ -86,6 +86,22 @@ export function seedRelocatedMemoryRow(
         )
         .run(conversationId, now);
       return;
+    case "memory_segments":
+      raw
+        .query(
+          `INSERT INTO memory_segments
+             (id, message_id, conversation_id, role, segment_index, text,
+              token_estimate, created_at, updated_at)
+           VALUES (?, ?, ?, 'user', 0, 'segment text', 3, ?, ?)`,
+        )
+        .run(
+          `${conversationId}-seg`,
+          `${conversationId}-msg`,
+          conversationId,
+          now,
+          now,
+        );
+      return;
     default:
       throw new Error(`unhandled relocated memory table ${table}`);
   }

--- a/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
@@ -51,6 +51,10 @@ const {
   MEMORY_GRAPH_NODE_EDITS_RELOCATION,
 } =
   await import("../../../../persistence/migrations/349-move-memory-graph-tables-to-memory-db.js");
+const { MEMORY_SEGMENTS_RELOCATION } =
+  await import("../../../../persistence/migrations/356-move-memory-segments-to-memory-db.js");
+const { MEMORY_EMBEDDINGS_RELOCATION } =
+  await import("../../../../persistence/migrations/357-move-memory-embeddings-to-memory-db.js");
 
 await initializeDb();
 
@@ -892,5 +896,123 @@ describe("memory graph cluster drain", () => {
         >(`SELECT COUNT(*) AS c FROM memory_graph_node_edits`)
         .get(),
     ).toEqual({ c: 0 });
+  });
+});
+
+describe("memory_segments drain", () => {
+  test("copies every row (full copy, including the unmapped scope_id) and drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    memory.exec(`DELETE FROM memory_segments`);
+    sqlite.exec(`DROP TABLE IF EXISTS main."memory_segments__relocating"`);
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_segments__relocating" (
+        id TEXT PRIMARY KEY, message_id TEXT NOT NULL,
+        conversation_id TEXT NOT NULL, role TEXT NOT NULL,
+        segment_index INTEGER NOT NULL, text TEXT NOT NULL,
+        token_estimate INTEGER NOT NULL,
+        scope_id TEXT NOT NULL DEFAULT 'default', content_hash TEXT,
+        created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+      )
+    `);
+    const insert = sqlite.prepare(
+      `INSERT INTO main."memory_segments__relocating"
+         (id, message_id, conversation_id, role, segment_index, text,
+          token_estimate, scope_id, content_hash, created_at, updated_at)
+       VALUES (?, ?, ?, 'user', ?, ?, 3, ?, ?, 0, 0)`,
+    );
+    insert.run("seg-1", "msg-1", "conv-1", 0, "first", "scope-a", "h1");
+    insert.run("seg-2", "msg-1", "conv-1", 1, "second", "default", null);
+
+    await drainStagedTable(sqlite, MEMORY_SEGMENTS_RELOCATION);
+
+    expect(existsInMain("memory_segments__relocating")).toBe(false);
+    const kept = memory
+      .query(
+        `SELECT id, message_id, conversation_id, segment_index, text, scope_id, content_hash
+           FROM memory_segments ORDER BY segment_index`,
+      )
+      .all();
+    expect(kept).toEqual([
+      {
+        id: "seg-1",
+        message_id: "msg-1",
+        conversation_id: "conv-1",
+        segment_index: 0,
+        text: "first",
+        scope_id: "scope-a",
+        content_hash: "h1",
+      },
+      {
+        id: "seg-2",
+        message_id: "msg-1",
+        conversation_id: "conv-1",
+        segment_index: 1,
+        text: "second",
+        scope_id: "default",
+        content_hash: null,
+      },
+    ]);
+  });
+});
+
+describe("memory_embeddings drain", () => {
+  test("copies every polymorphic row (full copy) and drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    memory.exec(`DELETE FROM memory_embeddings`);
+    sqlite.exec(`DROP TABLE IF EXISTS main."memory_embeddings__relocating"`);
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_embeddings__relocating" (
+        id TEXT PRIMARY KEY, target_type TEXT NOT NULL, target_id TEXT NOT NULL,
+        provider TEXT NOT NULL, model TEXT NOT NULL, dimensions INTEGER NOT NULL,
+        vector_json TEXT, vector_blob BLOB, content_hash TEXT,
+        created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+        UNIQUE (target_type, target_id, provider, model)
+      )
+    `);
+    const insert = sqlite.prepare(
+      `INSERT INTO main."memory_embeddings__relocating"
+         (id, target_type, target_id, provider, model, dimensions,
+          vector_json, vector_blob, content_hash, created_at, updated_at)
+       VALUES (?, ?, ?, 'p', 'm', 3, ?, NULL, ?, 0, 0)`,
+    );
+    insert.run("emb-1", "segment", "seg-1", "[0.1,0.2,0.3]", "h1");
+    insert.run("emb-2", "summary", "sum-1", "[0.4,0.5,0.6]", null);
+
+    await drainStagedTable(sqlite, MEMORY_EMBEDDINGS_RELOCATION);
+
+    expect(existsInMain("memory_embeddings__relocating")).toBe(false);
+    const kept = memory
+      .query(
+        `SELECT id, target_type, target_id, provider, model, dimensions,
+                vector_json, content_hash
+           FROM memory_embeddings ORDER BY id`,
+      )
+      .all();
+    expect(kept).toEqual([
+      {
+        id: "emb-1",
+        target_type: "segment",
+        target_id: "seg-1",
+        provider: "p",
+        model: "m",
+        dimensions: 3,
+        vector_json: "[0.1,0.2,0.3]",
+        content_hash: "h1",
+      },
+      {
+        id: "emb-2",
+        target_type: "summary",
+        target_id: "sum-1",
+        provider: "p",
+        model: "m",
+        dimensions: 3,
+        vector_json: "[0.4,0.5,0.6]",
+        content_hash: null,
+      },
+    ]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/conversation-memory-purge.ts
+++ b/assistant/src/plugins/defaults/memory/conversation-memory-purge.ts
@@ -20,6 +20,11 @@ export const CONVERSATION_KEYED_MEMORY_TABLES: readonly string[] = [
   "conversation_graph_memory_state",
   "memory_v3_ever_injected",
   "memory_retrospective_state",
+  // Re-derivable, but moved with its conversation_id column, so a conversation
+  // delete purges it here. A single-message delete (conversation survives) is
+  // NOT covered by this conversation-keyed purge — those message-scoped segments
+  // are deleted explicitly in the message-delete paths, with no sweep backstop.
+  "memory_segments",
 ];
 
 /**

--- a/assistant/src/plugins/defaults/memory/conversation-memory-purge.ts
+++ b/assistant/src/plugins/defaults/memory/conversation-memory-purge.ts
@@ -20,9 +20,9 @@ export const CONVERSATION_KEYED_MEMORY_TABLES: readonly string[] = [
   "conversation_graph_memory_state",
   "memory_v3_ever_injected",
   "memory_retrospective_state",
-  // Re-derivable, but moved with its conversation_id column, so a conversation
+  // Re-derivable, but carries its conversation_id column, so a conversation
   // delete purges it here. A single-message delete (conversation survives) is
-  // NOT covered by this conversation-keyed purge — those message-scoped segments
+  // NOT covered by this conversation-keyed purge. Those message-scoped segments
   // are deleted explicitly in the message-delete paths, with no sweep backstop.
   "memory_segments",
 ];

--- a/assistant/src/plugins/defaults/memory/indexer.ts
+++ b/assistant/src/plugins/defaults/memory/indexer.ts
@@ -121,8 +121,8 @@ export async function indexMessageNow(
   }> = [];
 
   // memory_segments has no cross-file FK to messages, so this call must not
-  // leave pieces for a message that no longer exists. Skip early when the source
-  // row is already gone — the common case of a backfill job running after the
+  // leave pieces for a message with no row. Skip early when the source
+  // row is already gone, the common case of a backfill job running after the
   // message was deleted. A post-write re-check below closes the narrower window
   // where the delete lands mid-transaction.
   const sourceMessage = getDb()
@@ -197,7 +197,7 @@ export async function indexMessageNow(
   // where a delete lands between it and this write. If the message is gone now,
   // drop the pieces this call just wrote and skip the embedding jobs, so a
   // delete racing a backfill leaves nothing searchable behind. No embeddings
-  // exist yet — the skipped jobs are what would have created them.
+  // exist yet. The skipped jobs are what would have created them.
   const stillExists = getDb()
     .select({ id: messages.id })
     .from(messages)

--- a/assistant/src/plugins/defaults/memory/indexer.ts
+++ b/assistant/src/plugins/defaults/memory/indexer.ts
@@ -16,12 +16,13 @@ import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
 } from "../../../persistence/checkpoints.js";
+import { getDb } from "../../../persistence/db-connection.js";
 import {
   enqueueMemoryJob,
   isMemoryEnabled,
   upsertDebouncedJob,
 } from "../../../persistence/jobs-store.js";
-import { memorySegments } from "../../../persistence/schema/index.js";
+import { memorySegments, messages } from "../../../persistence/schema/index.js";
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
 import { isAutoAnalysisConversation } from "../../../runtime/services/auto-analysis-guard.js";
 import { getLogger } from "./logging.js";
@@ -118,6 +119,21 @@ export async function indexMessageNow(
     type: "embed_segment" | "embed_attachment";
     payload: Record<string, unknown>;
   }> = [];
+
+  // memory_segments has no cross-file FK to messages, so re-check the source row
+  // on the main connection and skip when it is gone. Without this a message
+  // deleted after this job was queued (e.g. a delete racing a v1 backfill) would
+  // be resurrected as searchable segments the conversation-keyed purge cannot
+  // reclaim.
+  const sourceMessage = getDb()
+    .select({ id: messages.id })
+    .from(messages)
+    .where(eq(messages.id, input.messageId))
+    .get();
+  if (!sourceMessage) {
+    return { indexedSegments: 0, enqueuedJobs: 0 };
+  }
+
   mem.transaction((tx) => {
     for (const segment of segments) {
       if (segment.text.length < MIN_SEGMENT_CHARS) {

--- a/assistant/src/plugins/defaults/memory/indexer.ts
+++ b/assistant/src/plugins/defaults/memory/indexer.ts
@@ -120,11 +120,11 @@ export async function indexMessageNow(
     payload: Record<string, unknown>;
   }> = [];
 
-  // memory_segments has no cross-file FK to messages, so re-check the source row
-  // on the main connection and skip when it is gone. Without this a message
-  // deleted after this job was queued (e.g. a delete racing a v1 backfill) would
-  // be resurrected as searchable segments the conversation-keyed purge cannot
-  // reclaim.
+  // memory_segments has no cross-file FK to messages, so this call must not
+  // leave pieces for a message that no longer exists. Skip early when the source
+  // row is already gone — the common case of a backfill job running after the
+  // message was deleted. A post-write re-check below closes the narrower window
+  // where the delete lands mid-transaction.
   const sourceMessage = getDb()
     .select({ id: messages.id })
     .from(messages)
@@ -192,6 +192,24 @@ export async function indexMessageNow(
       }
     }
   });
+
+  // Re-check the source message after committing: the preflight leaves a window
+  // where a delete lands between it and this write. If the message is gone now,
+  // drop the pieces this call just wrote and skip the embedding jobs, so a
+  // delete racing a backfill leaves nothing searchable behind. No embeddings
+  // exist yet — the skipped jobs are what would have created them.
+  const stillExists = getDb()
+    .select({ id: messages.id })
+    .from(messages)
+    .where(eq(messages.id, input.messageId))
+    .get();
+  if (!stillExists) {
+    mem
+      .delete(memorySegments)
+      .where(eq(memorySegments.messageId, input.messageId))
+      .run();
+    return { indexedSegments: 0, enqueuedJobs: 0 };
+  }
 
   // Flush queued jobs onto the memory connection now the segment writes have
   // committed — enqueue only on success, mirroring the prior in-transaction

--- a/assistant/src/plugins/defaults/memory/indexer.ts
+++ b/assistant/src/plugins/defaults/memory/indexer.ts
@@ -16,7 +16,6 @@ import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
 } from "../../../persistence/checkpoints.js";
-import { getDb } from "../../../persistence/db-connection.js";
 import {
   enqueueMemoryJob,
   isMemoryEnabled,
@@ -26,6 +25,7 @@ import { memorySegments } from "../../../persistence/schema/index.js";
 import type { TrustClass } from "../../../runtime/actor-trust-resolver.js";
 import { isAutoAnalysisConversation } from "../../../runtime/services/auto-analysis-guard.js";
 import { getLogger } from "./logging.js";
+import { memoryDbOrNull } from "./memory-db.js";
 import { isMemoryRetrospectiveConversation } from "./memory-retrospective-enqueue.js";
 import { maybeEnqueueRetrospective } from "./memory-retrospective-trigger-check.js";
 import { extractMediaBlockMeta } from "./message-media.js";
@@ -80,7 +80,10 @@ export async function indexMessageNow(
     return { indexedSegments: 0, enqueuedJobs: 0 };
   }
 
-  const db = getDb();
+  const mem = memoryDbOrNull("indexMessageNow");
+  if (!mem) {
+    return { indexedSegments: 0, enqueuedJobs: 0 };
+  }
   const now = Date.now();
   const segments = segmentText(
     text,
@@ -115,7 +118,7 @@ export async function indexMessageNow(
     type: "embed_segment" | "embed_attachment";
     payload: Record<string, unknown>;
   }> = [];
-  db.transaction((tx) => {
+  mem.transaction((tx) => {
     for (const segment of segments) {
       if (segment.text.length < MIN_SEGMENT_CHARS) {
         skippedShortSegments++;

--- a/assistant/src/plugins/defaults/memory/jobs/__tests__/embed-concept-page.test.ts
+++ b/assistant/src/plugins/defaults/memory/jobs/__tests__/embed-concept-page.test.ts
@@ -138,7 +138,7 @@ afterAll(() => {
 // Imports are deferred to after the env var is set so any internal use of
 // `getWorkspaceDir()` resolves to the tmpdir.
 const { DEFAULT_CONFIG } = await import("../../../../../config/defaults.js");
-const { getDb, getMemoryDb } =
+const { getMemoryDb } =
   await import("../../../../../persistence/db-connection.js");
 const { resetDbForTesting } =
   await import("../../../../../__tests__/db-test-helpers.js");
@@ -248,7 +248,7 @@ describe("embedConceptPageJob — happy path", () => {
 
     await embedConceptPageJob(makeJob({ slug: "bob-uses-zsh" }), TEST_CONFIG);
 
-    const row = getDb()
+    const row = getMemoryDb()!
       .select()
       .from(memoryEmbeddings)
       .all()

--- a/assistant/src/plugins/defaults/memory/jobs/embed-concept-page.ts
+++ b/assistant/src/plugins/defaults/memory/jobs/embed-concept-page.ts
@@ -42,6 +42,7 @@ import { applyCorrectionIfCalibrated } from "../anisotropy.js";
 import { embedWithBackend } from "../embeddings.js";
 import { BackendUnavailableError } from "../host-utils.js";
 import { getLogger } from "../logging.js";
+import { memoryDbOrNull } from "../memory-db.js";
 import { getWorkspaceDir } from "../paths.js";
 import { readPage } from "../substrate/page-store.js";
 import {
@@ -120,7 +121,8 @@ export async function embedConceptPageJob(
   const cacheProvider = status.provider;
   const cacheModel = status.model!;
 
-  const db = getDb();
+  // The `memory_embeddings` cache lives on the memory connection.
+  const mem = memoryDbOrNull("embedConceptPageJob");
 
   // Cache lookup: same (targetType, targetId, provider, model) row gets
   // reused across runs as long as `contentHash` matches. The dim mismatch
@@ -130,13 +132,9 @@ export async function embedConceptPageJob(
   // its own cache row keyed by a distinct targetId so summary edits don't
   // invalidate the body cache and vice versa.
   const bodyContentHash = embeddingInputContentHash({ type: "text", text });
-  const bodyCache = readEmbeddingCache(
-    db,
-    slug,
-    cacheProvider,
-    cacheModel,
-    expectedDim,
-  );
+  const bodyCache = mem
+    ? readEmbeddingCache(mem, slug, cacheProvider, cacheModel, expectedDim)
+    : null;
   const bodyCacheHit = bodyCache?.contentHash === bodyContentHash;
 
   // Optional summary embedding — only when the page has a `summary` in its
@@ -149,15 +147,16 @@ export async function embedConceptPageJob(
   const summaryContentHash = hasSummary
     ? embeddingInputContentHash({ type: "text", text: summaryText })
     : undefined;
-  const summaryCache = hasSummary
-    ? readEmbeddingCache(
-        db,
-        summaryCacheId,
-        cacheProvider,
-        cacheModel,
-        expectedDim,
-      )
-    : null;
+  const summaryCache =
+    hasSummary && mem
+      ? readEmbeddingCache(
+          mem,
+          summaryCacheId,
+          cacheProvider,
+          cacheModel,
+          expectedDim,
+        )
+      : null;
   const summaryCacheHit =
     hasSummary && summaryCache?.contentHash === summaryContentHash;
 
@@ -262,8 +261,8 @@ export async function embedConceptPageJob(
   // the new vector overwrites the now-stale cache row under the new
   // provider/model identity. Best-effort: write failure is not fatal, we
   // still want the Qdrant upsert below to fire.
-  if (bodyFresh) {
-    writeEmbeddingCache(db, {
+  if (bodyFresh && mem) {
+    writeEmbeddingCache(mem, {
       slug,
       cacheId: slug,
       dense: bodyDense,
@@ -273,8 +272,8 @@ export async function embedConceptPageJob(
       now,
     });
   }
-  if (hasSummary && summaryFresh && summaryDense && summaryContentHash) {
-    writeEmbeddingCache(db, {
+  if (hasSummary && summaryFresh && summaryDense && summaryContentHash && mem) {
+    writeEmbeddingCache(mem, {
       slug,
       cacheId: summaryCacheId,
       dense: summaryDense,

--- a/assistant/src/plugins/defaults/memory/v1/graph/bootstrap.ts
+++ b/assistant/src/plugins/defaults/memory/v1/graph/bootstrap.ts
@@ -355,7 +355,7 @@ export function maybeEnqueueGraphBootstrap(): void {
     return; // Graph already populated
   }
 
-  // Check for historical data to bootstrap from. Segments now live on the
+  // Check for historical data to bootstrap from. Segments live on the
   // memory connection alongside the graph nodes read above.
   const segmentCount =
     memoryDb

--- a/assistant/src/plugins/defaults/memory/v1/graph/bootstrap.ts
+++ b/assistant/src/plugins/defaults/memory/v1/graph/bootstrap.ts
@@ -355,9 +355,10 @@ export function maybeEnqueueGraphBootstrap(): void {
     return; // Graph already populated
   }
 
-  // Check for historical data to bootstrap from
+  // Check for historical data to bootstrap from. Segments now live on the
+  // memory connection alongside the graph nodes read above.
   const segmentCount =
-    getDb()
+    memoryDb
       .select({ count: sql<number>`count(*)` })
       .from(memorySegments)
       .get()?.count ?? 0;

--- a/assistant/src/plugins/defaults/memory/v1/job-handlers/embedding.ts
+++ b/assistant/src/plugins/defaults/memory/v1/job-handlers/embedding.ts
@@ -13,6 +13,7 @@ import {
   memorySummaries,
   messages,
 } from "../../../../../persistence/schema/index.js";
+import { memoryDbOrNull } from "../../memory-db.js";
 import { extractMediaBlocks } from "../../message-media.js";
 
 export async function embedSegmentJob(job: MemoryJob): Promise<void> {
@@ -20,8 +21,11 @@ export async function embedSegmentJob(job: MemoryJob): Promise<void> {
   if (!segmentId) {
     return;
   }
-  const db = getDb();
-  const segment = db
+  const mem = memoryDbOrNull("embedSegmentJob");
+  if (!mem) {
+    return;
+  }
+  const segment = mem
     .select()
     .from(memorySegments)
     .where(eq(memorySegments.id, segmentId))

--- a/assistant/src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts
+++ b/assistant/src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts
@@ -31,7 +31,12 @@ const log = getLogger("memory-jobs-worker");
 
 export async function rebuildIndexJob(): Promise<void> {
   const db = getDb();
-  db.delete(memoryEmbeddings).run();
+  const memoryDb = memoryDbOrNull("rebuildIndexJob");
+
+  // memory_embeddings and memory_segments now live on the memory connection;
+  // wipe embeddings there and re-enqueue segments from there. Summaries and
+  // media stay on the main handle.
+  memoryDb?.delete(memoryEmbeddings).run();
 
   const summaries = db
     .select({ id: memorySummaries.id })
@@ -41,10 +46,9 @@ export async function rebuildIndexJob(): Promise<void> {
     enqueueMemoryJob("embed_summary", { summaryId: summary.id });
   }
 
-  const segments = db
-    .select({ id: memorySegments.id })
-    .from(memorySegments)
-    .all();
+  const segments =
+    memoryDb?.select({ id: memorySegments.id }).from(memorySegments).all() ??
+    [];
   for (const segment of segments) {
     enqueueMemoryJob("embed_segment", { segmentId: segment.id });
   }
@@ -84,9 +88,6 @@ export async function rebuildIndexJob(): Promise<void> {
   }
 
   // The graph cluster lives on the memory connection; re-embeds read it there.
-  // memory_embeddings/segments/summaries above stay on the main handle (Wave 4),
-  // and each read is a separate query, so the split across connections is fine.
-  const memoryDb = memoryDbOrNull("rebuildIndexJob");
   if (memoryDb) {
     // Re-embed graph nodes stored in the memory graph.
     const graphNodes = memoryDb

--- a/assistant/src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts
+++ b/assistant/src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts
@@ -33,7 +33,7 @@ export async function rebuildIndexJob(): Promise<void> {
   const db = getDb();
   const memoryDb = memoryDbOrNull("rebuildIndexJob");
 
-  // memory_embeddings and memory_segments now live on the memory connection;
+  // memory_embeddings and memory_segments live on the memory connection;
   // wipe embeddings there and re-enqueue segments from there. Summaries and
   // media stay on the main handle.
   memoryDb?.delete(memoryEmbeddings).run();

--- a/assistant/src/plugins/defaults/memory/v1/semantic-search.ts
+++ b/assistant/src/plugins/defaults/memory/v1/semantic-search.ts
@@ -13,6 +13,7 @@ import {
   memorySummaries,
 } from "../../../../persistence/schema/index.js";
 import { getMemoryConfig } from "../config.js";
+import { memoryDbOrNull } from "../memory-db.js";
 import { mapCosineToUnit } from "../validation.js";
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -101,6 +102,7 @@ export async function semanticSearch(
   }
 
   const db = getDb();
+  const mem = memoryDbOrNull("semanticSearch");
 
   // Batch-fetch all backing records upfront to avoid N+1 queries per result
   const summaryTargetIds: string[] = [];
@@ -123,8 +125,8 @@ export async function semanticSearch(
   }
 
   const segmentsMap = new Map<string, typeof memorySegments.$inferSelect>();
-  if (segmentTargetIds.length > 0) {
-    const allSegments = db
+  if (mem && segmentTargetIds.length > 0) {
+    const allSegments = mem
       .select()
       .from(memorySegments)
       .where(inArray(memorySegments.id, segmentTargetIds))

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts
@@ -115,6 +115,10 @@ mock.module("../../../../../persistence/embeddings/embedding-cache.js", () => ({
 
 mock.module("../../../../../persistence/db-connection.js", () => ({
   getDb: () => ({}),
+  // The section store now resolves the embedding cache on the memory connection
+  // via `memoryDbOrNull`; hand back truthy sentinels so it takes the cache path.
+  getMemoryDb: () => ({}),
+  getMemorySqlite: () => ({}),
 }));
 
 // Mock the underlying @qdrant/js-client-rest package. The mock client records

--- a/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
@@ -26,7 +26,6 @@ import { v5 as uuidv5 } from "uuid";
 
 import type { AssistantConfig } from "../../../../config/types.js";
 import { deleteMemoryCheckpoint } from "../../../../persistence/checkpoints.js";
-import { getDb } from "../../../../persistence/db-connection.js";
 import {
   geminiCacheExtras,
   getMemoryBackendStatus,
@@ -38,6 +37,7 @@ import {
 import { embeddingInputContentHash } from "../../../../persistence/embeddings/embedding-types.js";
 import { embedWithBackend, resolveQdrantUrl } from "../embeddings.js";
 import { getLogger } from "../logging.js";
+import { memoryDbOrNull } from "../memory-db.js";
 import type { Section } from "./types.js";
 
 const log = getLogger("memory-v3-section-dense-store");
@@ -323,7 +323,7 @@ async function embedSectionsCached(
   // no provider resolves (backend down/disabled) skip the cache and let the
   // batched embed below surface the failure exactly as the uncached path did.
   const status = await getMemoryBackendStatus(config);
-  const db = getDb();
+  const mem = memoryDbOrNull("embedSectionsCached");
 
   // Only Gemini's options change the vector for identical text, so fold the
   // extras into the cache identity only when Gemini is the resolved provider;
@@ -333,10 +333,10 @@ async function embedSectionsCached(
 
   const result: Array<number[] | undefined> = new Array(sections.length);
   const missIndices: number[] = [];
-  if (status.provider && status.model) {
+  if (mem && status.provider && status.model) {
     for (let i = 0; i < sections.length; i++) {
       const section = sections[i]!;
-      const cached = readEmbeddingCache(db, {
+      const cached = readEmbeddingCache(mem, {
         targetType: V3_SECTION_TARGET_TYPE,
         targetId: sectionCacheId(section.article, section.ordinal),
         provider: status.provider,
@@ -389,15 +389,17 @@ async function embedSectionsCached(
     if (!vector) continue;
     result[i] = vector;
     const section = sections[i]!;
-    writeEmbeddingCache(db, {
-      targetType: V3_SECTION_TARGET_TYPE,
-      targetId: sectionCacheId(section.article, section.ordinal),
-      dense: vector,
-      contentHash: hashes[i]!,
-      provider: writeProvider,
-      model: writeModel,
-      now,
-    });
+    if (mem) {
+      writeEmbeddingCache(mem, {
+        targetType: V3_SECTION_TARGET_TYPE,
+        targetId: sectionCacheId(section.article, section.ordinal),
+        dense: vector,
+        contentHash: hashes[i]!,
+        provider: writeProvider,
+        model: writeModel,
+        now,
+      });
+    }
   }
 
   return result;


### PR DESCRIPTION
Wave 4b of the ATL-1001 memory-DB cutover (targets the `clopen-set/memdb-wave4` feature branch). Moves `memory_segments` and `memory_embeddings` out of the main database into `assistant-memory.db` — together, since their cleanup is interleaved in every delete path.

- Repoints the indexer, summarizer, semantic search, both embedding writer families, and the graph/search routes to the memory connection. `memory_summaries` stays on main (a later PR moves it).
- Replaces the message/conversation FK cascade to `memory_segments`: conversation deletes and clear-all purge it through the conversation-deleted hook (`memory_segments` joins `CONVERSATION_KEYED_MEMORY_TABLES`); the message-delete paths (`deleteMessageById`, rewind) delete it explicitly on the memory connection. Message-scoped segments have no orphan-sweep backstop, so that explicit delete is their sole cleanup — a deliberate change from the old FK guarantee.
- `memory_embeddings` is polymorphic (no cascade); its explicit deletes ride the memory connection too.

Migrations 351/352 carry the real column sets (including the Drizzle-unmapped `memory_segments.scope_id`).