### PR TITLE
feat(memory-db): relocate memory_summaries to the memory database

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -336,11 +336,8 @@ subgraph "Text Q&A Session"
             DB_CONV["conversations"]
             DB_MSG["messages"]
             DB_TOOL["tool_invocations"]
-            DB_SEG["memory_segments"]
             DB_ITEMS["memory_items"]
             DB_SRC["memory_item_sources"]
-            DB_SUM["memory_summaries"]
-            DB_EMB["memory_embeddings"]
             DB_JOBS["memory_jobs"]
             DB_ATTACH["attachments"]
             DB_CHAN["channel_inbound_events"]
@@ -351,6 +348,12 @@ subgraph "Text Q&A Session"
             DB_TASKS["tasks"]
             DB_TASK_RUNS["task_runs"]
             DB_CONTACTS["contacts<br/>(migrating to gateway)"]
+        end
+
+        subgraph "SQLite Database ($VELLUM_WORKSPACE_DIR/data/db/assistant-memory.db)"
+            DB_SEG["memory_segments"]
+            DB_SUM["memory_summaries"]
+            DB_EMB["memory_embeddings"]
         end
 
         subgraph "Skill Tool System"

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -820,14 +820,18 @@ graph LR
         SL["logs/session-*.json<br/>───────────────<br/>Per-session JSON log<br/>task, start/end times, result<br/>Per-turn: AX tree, screenshot,<br/>action, token usage"]
     end
 
+    subgraph "$VELLUM_WORKSPACE_DIR/data/db/assistant-memory.db (SQLite + WAL)"
+        direction TB
+        SEG["memory_segments<br/>───────────────<br/>Text chunks for retrieval<br/>Linked to messages<br/>token_estimate per segment"]
+        SUM["memory_summaries<br/>───────────────<br/>scope: conversation | weekly<br/>Compressed history for context<br/>window management"]
+        EMB["memory_embeddings<br/>───────────────<br/>target: segment | item | summary<br/>provider + model metadata<br/>vector_json (float array)<br/>Powers semantic search"]
+    end
+
     subgraph "$VELLUM_WORKSPACE_DIR/data/db/assistant.db (SQLite + WAL)"
         direction TB
         CONV["conversations<br/>───────────────<br/>id, title, timestamps<br/>token counts, estimated cost<br/>context_summary (compaction)<br/>conversation_type: 'standard' | 'background' | 'scheduled'"]
         MSG["messages<br/>───────────────<br/>id, conversation_id (FK)<br/>role: user | assistant<br/>content: JSON array<br/>created_at"]
         TOOL["tool_invocations<br/>───────────────<br/>tool_name, input, result<br/>decision, risk_level<br/>duration_ms"]
-        SEG["memory_segments<br/>───────────────<br/>Text chunks for retrieval<br/>Linked to messages<br/>token_estimate per segment"]
-        SUM["memory_summaries<br/>───────────────<br/>scope: conversation | weekly<br/>Compressed history for context<br/>window management"]
-        EMB["memory_embeddings<br/>───────────────<br/>target: segment | item | summary<br/>provider + model metadata<br/>vector_json (float array)<br/>Powers semantic search"]
         JOBS["memory_jobs<br/>───────────────<br/>Async task queue<br/>Types: embed, extract,<br/>summarize, backfill, cleanup<br/>Status: pending → running →<br/>completed | failed"]
         ATT["attachments<br/>───────────────<br/>base64-encoded file data<br/>mime_type, size_bytes<br/>Linked to messages via<br/>message_attachments join"]
         REM["reminders<br/>───────────────<br/>One-time scheduled reminders<br/>label, message, fireAt<br/>mode: notify | execute<br/>status: pending → fired | cancelled<br/>routing_intent: single_channel |<br/>multi_channel | all_channels<br/>routing_hints_json (free-form)"]
@@ -1967,9 +1971,9 @@ Connected channels are resolved at signal emission time: vellum is always includ
 | User preferences                         | UserDefaults                                           | plist                               | Foundation                         | Permanent                                               |
 | Session logs                             | `~/Library/.../logs/session-*.json`                    | JSON per session                    | Swift Codable                      | Unbounded                                               |
 | Conversations & messages                 | `$VELLUM_WORKSPACE_DIR/data/db/assistant.db`           | SQLite + WAL                        | Drizzle ORM (Bun)                  | Permanent                                               |
-| Memory segments                          | `$VELLUM_WORKSPACE_DIR/data/db/assistant.db`           | SQLite                              | Drizzle ORM                        | Permanent                                               |
+| Memory segments                          | `$VELLUM_WORKSPACE_DIR/data/db/assistant-memory.db`    | SQLite                              | Drizzle ORM                        | Permanent                                               |
 | Extracted facts                          | `$VELLUM_WORKSPACE_DIR/data/db/assistant.db`           | SQLite                              | Drizzle ORM                        | Permanent, deduped                                      |
-| Embeddings                               | `$VELLUM_WORKSPACE_DIR/data/db/assistant.db`           | JSON float arrays                   | Drizzle ORM                        | Permanent                                               |
+| Embeddings                               | `$VELLUM_WORKSPACE_DIR/data/db/assistant-memory.db`    | JSON float arrays                   | Drizzle ORM                        | Permanent                                               |
 | Async job queue                          | `$VELLUM_WORKSPACE_DIR/data/db/assistant.db`           | SQLite                              | Drizzle ORM                        | Completed jobs persist                                  |
 | Attachments                              | `$VELLUM_WORKSPACE_DIR/data/db/assistant.db`           | Base64 in SQLite                    | Drizzle ORM                        | Permanent                                               |
 | Sandbox filesystem                       | `$VELLUM_WORKSPACE_DIR`                                | Real filesystem tree                | Node FS APIs                       | Persistent across sessions                              |

--- a/assistant/src/__tests__/conversation-delete-schedule-cleanup.test.ts
+++ b/assistant/src/__tests__/conversation-delete-schedule-cleanup.test.ts
@@ -50,7 +50,7 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
     getRawDb().run("DELETE FROM cron_jobs");
     getMemorySqlite()!.run("DELETE FROM memory_graph_nodes");
     getMemorySqlite()!.run("DELETE FROM memory_segments");
-    getRawDb().run("DELETE FROM memory_summaries");
+    getMemorySqlite()!.run("DELETE FROM memory_summaries");
     getMemorySqlite()!.run("DELETE FROM memory_embeddings");
     getMemorySqlite()!.run("DELETE FROM memory_jobs");
     getRawDb().run("DELETE FROM tool_invocations");

--- a/assistant/src/conversations/job-handlers/summarization.ts
+++ b/assistant/src/conversations/job-handlers/summarization.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from "uuid";
 
 import type { AssistantConfig } from "../../config/types.js";
 import { estimateTextTokens } from "../../context/token-estimator.js";
-import { getDb, getMemoryDb } from "../../persistence/db-connection.js";
+import { getMemoryDb } from "../../persistence/db-connection.js";
 import { asString, truncate } from "../../persistence/job-utils.js";
 import {
   enqueueMemoryJob,
@@ -51,7 +51,8 @@ export async function buildConversationSummaryJob(
 ): Promise<void> {
   const conversationId = asString(job.payload.conversationId);
   if (!conversationId) return;
-  const db = getDb();
+  const db = getMemoryDb();
+  if (!db) return;
 
   const existing = db
     .select()
@@ -75,17 +76,13 @@ export async function buildConversationSummaryJob(
     conditions.push(gt(memorySegments.createdAt, lastCoveredAt));
   }
 
-  // Segments live on the memory connection; the summary row above and below
-  // stays on the main connection.
-  const mem = getMemoryDb();
-  const rows = mem
-    ? mem
-        .select()
-        .from(memorySegments)
-        .where(and(...conditions))
-        .orderBy(asc(memorySegments.createdAt))
-        .all()
-    : [];
+  // memory_segments and memory_summaries both live on the memory connection.
+  const rows = db
+    .select()
+    .from(memorySegments)
+    .where(and(...conditions))
+    .orderBy(asc(memorySegments.createdAt))
+    .all();
   if (rows.length === 0) return;
 
   // Build segment text for LLM input (already in chronological order)

--- a/assistant/src/conversations/job-handlers/summarization.ts
+++ b/assistant/src/conversations/job-handlers/summarization.ts
@@ -52,7 +52,9 @@ export async function buildConversationSummaryJob(
   const conversationId = asString(job.payload.conversationId);
   if (!conversationId) return;
   const db = getMemoryDb();
-  if (!db) return;
+  if (!db) {
+    return;
+  }
 
   const existing = db
     .select()

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -3228,16 +3228,14 @@ export async function clearAll(): Promise<{
     "DELETE FROM telemetry_events WHERE name = 'skill_loaded'",
   );
 
-  // Delete in dependency order. The cascade handles tool_invocations;
-  // memory_summaries is still on the main DB, so it clears here.
-  await runOrThrow("DELETE FROM memory_summaries");
-  // memory_jobs, memory_segments, memory_embeddings, and llm_request_logs each
-  // live on a dedicated connection; clear them there rather than through a
-  // main-DB sqlite3 subprocess. memory_segments holds deleted message text, so
-  // clear it directly here instead of leaving it to the CONVERSATIONS_CLEARED
-  // hook below: that hook is a no-op when the memory plugin is disabled, which
-  // would keep the text searchable until the next startup sweep. memory_embeddings
-  // is polymorphic and cleared directly for the same reason.
+  // Delete in dependency order. The cascade handles tool_invocations. memory_jobs,
+  // memory_segments, memory_embeddings, and memory_summaries each live on a
+  // dedicated connection; clear them there rather than through a main-DB sqlite3
+  // subprocess. Clear all four directly rather than routing memory_segments
+  // through the CONVERSATIONS_CLEARED hook below: that hook is a no-op when the
+  // memory plugin is disabled, which would keep memory_segments' deleted message
+  // text searchable until the next startup sweep. memory_embeddings and
+  // memory_summaries are not conversation-keyed, so the hook never covered them.
   rawMemoryRun("conversation:clearAll:memoryJobs", "DELETE FROM memory_jobs");
   rawMemoryRun(
     "conversation:clearAll:memorySegments",
@@ -3246,6 +3244,10 @@ export async function clearAll(): Promise<{
   rawMemoryRun(
     "conversation:clearAll:memoryEmbeddings",
     "DELETE FROM memory_embeddings",
+  );
+  rawMemoryRun(
+    "conversation:clearAll:memorySummaries",
+    "DELETE FROM memory_summaries",
   );
   await runOrThrow("DELETE FROM memory_checkpoints");
   rawLogsRun(

--- a/assistant/src/persistence/migrations/358-move-memory-summaries-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/358-move-memory-summaries-to-memory-db.ts
@@ -1,0 +1,86 @@
+import type { Database } from "bun:sqlite";
+
+import { getMemoryDbPath } from "../../util/memory-db-path.js";
+import type { DrizzleDb } from "../db-connection.js";
+import {
+  type RelocationSpec,
+  runMemoryTableRelocation,
+} from "./helpers/relocation.js";
+
+/**
+ * How to drain `memory_summaries` from `main` into the dedicated memory
+ * database — the last table of the memory-DB cutover.
+ *
+ * The column list is explicit: the base `CREATE` columns (migration 000) plus
+ * `version` and `scope_id` (both added by migration 102). `scope_id` is a real
+ * `NOT NULL DEFAULT 'default'` column that the Drizzle schema does not map, so
+ * dropping it here would lose that data on the drain. `memory_summaries` has no
+ * foreign key (its `UNIQUE (scope, scope_key)` is its only constraint), so there
+ * is no cascade to replace; it is scope-keyed, not conversation-keyed, so it
+ * does NOT join `CONVERSATION_KEYED_MEMORY_TABLES`.
+ */
+export const MEMORY_SUMMARIES_RELOCATION: RelocationSpec = {
+  table: "memory_summaries",
+  targetDbPath: getMemoryDbPath,
+  columns: [
+    "id",
+    "scope",
+    "scope_key",
+    "summary",
+    "token_estimate",
+    "start_at",
+    "end_at",
+    "created_at",
+    "updated_at",
+    "version",
+    "scope_id",
+  ],
+};
+
+/**
+ * Create `memory_summaries` on the memory connection. Idempotent. Recreates the
+ * inline `UNIQUE (scope, scope_key)` constraint so `ON CONFLICT` upserts resolve
+ * exactly as they did on main, plus the scope/scope_id/scope_updated lookup
+ * indexes (migrations 018, 104, 348).
+ */
+export function ensureMemorySummariesSchema(memoryRaw: Database): void {
+  memoryRaw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_summaries (
+      id             TEXT PRIMARY KEY,
+      scope          TEXT NOT NULL,
+      scope_key      TEXT NOT NULL,
+      summary        TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL,
+      start_at       INTEGER NOT NULL,
+      end_at         INTEGER NOT NULL,
+      created_at     INTEGER NOT NULL,
+      updated_at     INTEGER NOT NULL,
+      version        INTEGER NOT NULL DEFAULT 1,
+      scope_id       TEXT NOT NULL DEFAULT 'default',
+      UNIQUE (scope, scope_key)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_updated
+      ON memory_summaries(scope, updated_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_time
+      ON memory_summaries(scope, end_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope_id
+      ON memory_summaries(scope_id);
+  `);
+}
+
+/**
+ * Move `memory_summaries` into the dedicated memory database
+ * (`assistant-memory.db`), so the summarizer writer and every reader ride the
+ * memory connection. `fetchRecentSummaries` reads it there for step 1 of its
+ * two-step and looks up conversationType on the main connection for step 2.
+ */
+export async function migrateMoveMemorySummariesToMemoryDb(
+  database: DrizzleDb,
+): Promise<void> {
+  await runMemoryTableRelocation(
+    database,
+    MEMORY_SUMMARIES_RELOCATION,
+    ensureMemorySummariesSchema,
+  );
+}

--- a/assistant/src/persistence/migrations/358-move-memory-summaries-to-memory-db.ts
+++ b/assistant/src/persistence/migrations/358-move-memory-summaries-to-memory-db.ts
@@ -9,7 +9,7 @@ import {
 
 /**
  * How to drain `memory_summaries` from `main` into the dedicated memory
- * database — the last table of the memory-DB cutover.
+ * database. The last table of the memory-DB cutover.
  *
  * The column list is explicit: the base `CREATE` columns (migration 000) plus
  * `version` and `scope_id` (both added by migration 102). `scope_id` is a real

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -465,6 +465,7 @@ import { migrateBackfillAppConversationLineage } from "./migrations/354-backfill
 import { migrateAddScheduleGroupId } from "./migrations/355-add-schedule-group-id.js";
 import { migrateMoveMemorySegmentsToMemoryDb } from "./migrations/356-move-memory-segments-to-memory-db.js";
 import { migrateMoveMemoryEmbeddingsToMemoryDb } from "./migrations/357-move-memory-embeddings-to-memory-db.js";
+import { migrateMoveMemorySummariesToMemoryDb } from "./migrations/358-move-memory-summaries-to-memory-db.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1520,6 +1521,22 @@ export const migrationSteps: MigrationStep[] = [
       "migrateDropSimplifiedMemory",
       "migrateDeletePrivateConversations",
       "migrateSweepOrphanedGraphNodeVectors",
+    ],
+  },
+  {
+    name: "migrateMoveMemorySummariesToMemoryDb",
+    run: migrateMoveMemorySummariesToMemoryDb,
+    // Gate on every migration that creates, alters, indexes, or clears
+    // memory_summaries on main. migrateDeletePrivateConversations deletes
+    // private-scoped summaries by scope_id directly (a real column, though the
+    // Drizzle schema does not map it), so it must land before the move.
+    dependsOn: [
+      "migrateCoreTables",
+      "migrateRemainingTableIndexes",
+      "addCoreColumns",
+      "createCoreIndexes",
+      "migrateDeletePrivateConversations",
+      "migrateMemorySummariesScopeUpdatedIndex",
     ],
   },
 ];

--- a/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/db-memory-attach.test.ts
@@ -74,6 +74,7 @@ describe("memory database connection", () => {
     "memory_graph_node_edits",
     "memory_segments",
     "memory_embeddings",
+    "memory_summaries",
   ])("%s lives in the memory connection, not main", (table) => {
     const inMemory = getMemorySqlite()!
       .query<

--- a/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/table-relocation.test.ts
@@ -55,6 +55,8 @@ const { MEMORY_SEGMENTS_RELOCATION } =
   await import("../../../../persistence/migrations/356-move-memory-segments-to-memory-db.js");
 const { MEMORY_EMBEDDINGS_RELOCATION } =
   await import("../../../../persistence/migrations/357-move-memory-embeddings-to-memory-db.js");
+const { MEMORY_SUMMARIES_RELOCATION } =
+  await import("../../../../persistence/migrations/358-move-memory-summaries-to-memory-db.js");
 
 await initializeDb();
 
@@ -1012,6 +1014,65 @@ describe("memory_embeddings drain", () => {
         dimensions: 3,
         vector_json: "[0.4,0.5,0.6]",
         content_hash: null,
+      },
+    ]);
+  });
+});
+
+describe("memory_summaries drain", () => {
+  test("copies every row (full copy, including the unmapped scope_id) and drops staging", async () => {
+    const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
+
+    memory.exec(`DELETE FROM memory_summaries`);
+    sqlite.exec(`DROP TABLE IF EXISTS main."memory_summaries__relocating"`);
+    sqlite.exec(/*sql*/ `
+      CREATE TABLE main."memory_summaries__relocating" (
+        id TEXT PRIMARY KEY, scope TEXT NOT NULL, scope_key TEXT NOT NULL,
+        summary TEXT NOT NULL, token_estimate INTEGER NOT NULL,
+        start_at INTEGER NOT NULL, end_at INTEGER NOT NULL,
+        created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+        version INTEGER NOT NULL DEFAULT 1,
+        scope_id TEXT NOT NULL DEFAULT 'default',
+        UNIQUE (scope, scope_key)
+      )
+    `);
+    const insert = sqlite.prepare(
+      `INSERT INTO main."memory_summaries__relocating"
+         (id, scope, scope_key, summary, token_estimate, start_at, end_at,
+          created_at, updated_at, version, scope_id)
+       VALUES (?, 'conversation', ?, ?, 10, 0, 0, 0, ?, ?, ?)`,
+    );
+    insert.run("sum-1", "conv-1", "first summary", 100, 2, "scope-a");
+    insert.run("sum-2", "conv-2", "second summary", 200, 1, "default");
+
+    await drainStagedTable(sqlite, MEMORY_SUMMARIES_RELOCATION);
+
+    expect(existsInMain("memory_summaries__relocating")).toBe(false);
+    const kept = memory
+      .query(
+        `SELECT id, scope, scope_key, summary, updated_at, version, scope_id
+           FROM memory_summaries ORDER BY id`,
+      )
+      .all();
+    expect(kept).toEqual([
+      {
+        id: "sum-1",
+        scope: "conversation",
+        scope_key: "conv-1",
+        summary: "first summary",
+        updated_at: 100,
+        version: 2,
+        scope_id: "scope-a",
+      },
+      {
+        id: "sum-2",
+        scope: "conversation",
+        scope_key: "conv-2",
+        summary: "second summary",
+        updated_at: 200,
+        version: 1,
+        scope_id: "default",
       },
     ]);
   });

--- a/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-recent-summaries.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-recent-summaries.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for `ConversationGraphMemory.fetchRecentSummaries`. It pages through
+ * candidate conversation summaries most-recent first, resolves each
+ * conversation's type with a separate lookup rather than a JOIN (so the two
+ * tables need not share a connection), and partitions in JS: up to 3 user
+ * summaries (most recent first), then at most 1 background/scheduled to fill. It
+ * excludes the current conversation and any summary whose conversation row is
+ * gone.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getDb,
+  getMemoryDb,
+} from "../../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../../persistence/db-init.js";
+import {
+  conversations,
+  memorySummaries,
+} from "../../../../../persistence/schema/index.js";
+import { ConversationGraphMemory } from "../conversation-graph-memory.js";
+
+await initializeDb();
+
+const CURRENT = "conv-current";
+
+function seedConversation(id: string, type: string): void {
+  getDb()
+    .insert(conversations)
+    .values({ id, conversationType: type, createdAt: 0, updatedAt: 0 })
+    .run();
+}
+
+function seedSummary(
+  scopeKey: string,
+  summary: string,
+  updatedAt: number,
+): void {
+  getMemoryDb()!
+    .insert(memorySummaries)
+    .values({
+      id: `sum-${scopeKey}`,
+      scope: "conversation",
+      scopeKey,
+      summary,
+      tokenEstimate: 10,
+      version: 1,
+      startAt: 0,
+      endAt: updatedAt,
+      createdAt: updatedAt,
+      updatedAt,
+    })
+    .run();
+}
+
+function recentSummaries(): string[] {
+  const cgm = new ConversationGraphMemory(CURRENT);
+  return (
+    cgm as unknown as { fetchRecentSummaries: () => string[] }
+  ).fetchRecentSummaries();
+}
+
+beforeEach(() => {
+  getMemoryDb()!.delete(memorySummaries).run();
+  getDb().delete(conversations).run();
+});
+
+describe("fetchRecentSummaries", () => {
+  test("returns the 3 most-recent user summaries and no background when 3+ users exist", () => {
+    ["u1", "u2", "u3", "u4"].forEach((id, i) => {
+      seedConversation(id, "standard");
+      seedSummary(id, `user ${id}`, 100 + i); // u4 is newest at 103
+    });
+    // A background summary that is newer than every user summary must still be
+    // dropped once 3 user summaries are available.
+    seedConversation("b1", "background");
+    seedSummary("b1", "bg b1", 1000);
+
+    expect(recentSummaries()).toEqual(["user u4", "user u3", "user u2"]);
+  });
+
+  test("fills the remaining slot with the single most-recent background when fewer than 3 users", () => {
+    seedConversation("u1", "standard");
+    seedSummary("u1", "user u1", 200);
+    seedConversation("u2", "standard");
+    seedSummary("u2", "user u2", 100);
+    seedConversation("b1", "background");
+    seedSummary("b1", "bg b1", 300); // newest overall
+    seedConversation("b2", "scheduled");
+    seedSummary("b2", "bg b2", 250);
+
+    expect(recentSummaries()).toEqual(["user u1", "user u2", "bg b1"]);
+  });
+
+  test("returns a single background summary when there are no user summaries", () => {
+    seedConversation("b1", "background");
+    seedSummary("b1", "bg b1", 100);
+    seedConversation("b2", "scheduled");
+    seedSummary("b2", "bg b2", 200); // newest
+
+    expect(recentSummaries()).toEqual(["bg b2"]);
+  });
+
+  test("excludes the current conversation and orphan summaries", () => {
+    seedSummary(CURRENT, "self summary", 500); // excluded: current conversation
+    seedSummary("orphan", "orphan summary", 400); // excluded: no conversation row
+    seedConversation("u1", "standard");
+    seedSummary("u1", "user u1", 100);
+
+    expect(recentSummaries()).toEqual(["user u1"]);
+  });
+
+  test("orders results most-recent first by updatedAt", () => {
+    seedConversation("a", "standard");
+    seedSummary("a", "older", 100);
+    seedConversation("b", "standard");
+    seedSummary("b", "newer", 200);
+
+    expect(recentSummaries()).toEqual(["newer", "older"]);
+  });
+
+  test("returns an empty list when there are no summaries", () => {
+    expect(recentSummaries()).toEqual([]);
+  });
+
+  test("pages past a full page of newer background summaries to find users", () => {
+    // 3 (older) user summaries, then more than one page of newer background
+    // summaries. A single fixed window would cut the user rows off; paging must
+    // walk past the first background-only page to return them.
+    seedConversation("u1", "standard");
+    seedSummary("u1", "user u1", 1);
+    seedConversation("u2", "standard");
+    seedSummary("u2", "user u2", 2);
+    seedConversation("u3", "standard");
+    seedSummary("u3", "user u3", 3);
+    for (let i = 0; i < 250; i++) {
+      seedConversation(`bg${i}`, "background");
+      seedSummary(`bg${i}`, `bg ${i}`, 100 + i); // all newer than the users
+    }
+    expect(recentSummaries()).toEqual(["user u3", "user u2", "user u1"]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -15,7 +15,7 @@ import type {
   ImageContent,
   Message,
 } from "@vellumai/plugin-api";
-import { and, desc, eq, inArray, ne, sql, type SQL } from "drizzle-orm";
+import { and, desc, eq, inArray, ne, type SQL, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import {
@@ -240,11 +240,11 @@ export class ConversationGraphMemory {
       }
 
       // Page through candidate summary keys most-recent first from the memory
-      // connection (memory_summaries lives there), resolving each page's
+      // connection (which holds memory_summaries), resolving each page's
       // conversation types on the main connection before moving on, and stop as
       // soon as 3 user summaries are found. Only keys are read here so the full
       // text is fetched for just the rows returned. conversationType is a
-      // separate lookup rather than a JOIN, since the two tables no longer share
+      // separate lookup rather than a JOIN, since the two tables do not share
       // a database file; keeping it per-page bounds the scan to the pages
       // actually needed. A summary whose conversation row is gone is skipped, and
       // at most 1 background/scheduled summary fills a remaining slot.
@@ -302,7 +302,7 @@ export class ConversationGraphMemory {
         for (const scopeKey of pageKeys) {
           const type = typeByConversation.get(scopeKey);
           if (type === undefined) {
-            continue; // its conversation row is gone — skip it
+            continue; // its conversation row is gone, skip it
           }
           if (type === "background" || type === "scheduled") {
             if (backgroundKey === null) {

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -15,7 +15,7 @@ import type {
   ImageContent,
   Message,
 } from "@vellumai/plugin-api";
-import { and, desc, eq, inArray, ne, notInArray } from "drizzle-orm";
+import { and, desc, eq, inArray, ne, sql, type SQL } from "drizzle-orm";
 import { z } from "zod";
 
 import {
@@ -24,7 +24,7 @@ import {
 } from "../../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../../config/types.js";
 import { estimateTextTokens } from "../../../../context/token-estimator.js";
-import { getDb } from "../../../../persistence/db-connection.js";
+import { getDb, getMemoryDb } from "../../../../persistence/db-connection.js";
 import { embedWithRetry } from "../../../../persistence/embeddings/embed.js";
 import { generateSparseEmbedding } from "../../../../persistence/embeddings/embedding-backend.js";
 import type { QdrantSparseVector } from "../../../../persistence/embeddings/qdrant-client.js";
@@ -72,6 +72,15 @@ import type { RetrievalMetrics } from "./types.js";
 const log = getLogger("graph-conversation-memory");
 
 const ESTIMATED_IMAGE_TOKENS = 1000;
+
+/**
+ * Page size for {@link ConversationGraphMemory.fetchRecentSummaries}. It reads
+ * candidate summary keys a page at a time and stops once three user summaries
+ * are found, so the common case (recent conversations are user ones) touches a
+ * single page regardless of history size. Also bounds the per-page conversation
+ * lookup below SQLite's bound-parameter limit.
+ */
+const RECENT_SUMMARY_PAGE_SIZE = 200;
 
 // ---------------------------------------------------------------------------
 // Per-conversation state
@@ -225,59 +234,122 @@ export class ConversationGraphMemory {
   private fetchRecentSummaries(): string[] {
     try {
       const db = getDb();
-      const baseWhere = and(
-        eq(memorySummaries.scope, "conversation"),
-        ne(memorySummaries.scopeKey, this.conversationId),
-      );
-
-      // Fetch user conversations first (up to 3)
-      const userRows = db
-        .select({ summary: memorySummaries.summary })
-        .from(memorySummaries)
-        .innerJoin(
-          conversations,
-          eq(memorySummaries.scopeKey, conversations.id),
-        )
-        .where(
-          and(
-            baseWhere,
-            notInArray(conversations.conversationType, [
-              "background",
-              "scheduled",
-            ]),
-          ),
-        )
-        .orderBy(desc(memorySummaries.updatedAt))
-        .limit(3)
-        .all();
-
-      if (userRows.length >= 3) {
-        return userRows.map((r) => r.summary);
+      const memoryDb = getMemoryDb();
+      if (!memoryDb) {
+        return [];
       }
 
-      // Fill remaining slots with at most 1 background/scheduled conversation
-      const remaining = Math.min(1, 3 - userRows.length);
-      const bgRows = db
-        .select({ summary: memorySummaries.summary })
+      // Page through candidate summary keys most-recent first from the memory
+      // connection (memory_summaries lives there), resolving each page's
+      // conversation types on the main connection before moving on, and stop as
+      // soon as 3 user summaries are found. Only keys are read here so the full
+      // text is fetched for just the rows returned. conversationType is a
+      // separate lookup rather than a JOIN, since the two tables no longer share
+      // a database file; keeping it per-page bounds the scan to the pages
+      // actually needed. A summary whose conversation row is gone is skipped, and
+      // at most 1 background/scheduled summary fills a remaining slot.
+      const selectedKeys: string[] = [];
+      let backgroundKey: string | null = null;
+      // Keyset cursor over (updatedAt, scopeKey), most-recent first. Written as a
+      // row-value comparison so SQLite seeks on the (scope, updated_at) index and
+      // resumes past the last row instead of re-walking every prior page as a
+      // growing OFFSET would. scopeKey is unique per conversation summary, so the
+      // pair is a stable tiebreaker across the (near-never) equal updatedAt.
+      let cursor: { updatedAt: number; scopeKey: string } | null = null;
+      while (selectedKeys.length < 3) {
+        const beyondCursor: SQL | undefined = cursor
+          ? sql`(${memorySummaries.updatedAt}, ${memorySummaries.scopeKey}) < (${cursor.updatedAt}, ${cursor.scopeKey})`
+          : undefined;
+        const page: Array<{ scopeKey: string; updatedAt: number }> = memoryDb
+          .select({
+            scopeKey: memorySummaries.scopeKey,
+            updatedAt: memorySummaries.updatedAt,
+          })
+          .from(memorySummaries)
+          .where(
+            and(
+              eq(memorySummaries.scope, "conversation"),
+              ne(memorySummaries.scopeKey, this.conversationId),
+              beyondCursor,
+            ),
+          )
+          .orderBy(
+            desc(memorySummaries.updatedAt),
+            desc(memorySummaries.scopeKey),
+          )
+          .limit(RECENT_SUMMARY_PAGE_SIZE)
+          .all();
+        if (page.length === 0) {
+          break;
+        }
+        const lastRow = page[page.length - 1]!;
+        cursor = { updatedAt: lastRow.updatedAt, scopeKey: lastRow.scopeKey };
+        const pageKeys = page.map((r) => r.scopeKey);
+
+        const typeByConversation = new Map<string, string>();
+        const rows = db
+          .select({
+            id: conversations.id,
+            type: conversations.conversationType,
+          })
+          .from(conversations)
+          .where(inArray(conversations.id, pageKeys))
+          .all();
+        for (const r of rows) {
+          typeByConversation.set(r.id, r.type);
+        }
+
+        for (const scopeKey of pageKeys) {
+          const type = typeByConversation.get(scopeKey);
+          if (type === undefined) {
+            continue; // its conversation row is gone — skip it
+          }
+          if (type === "background" || type === "scheduled") {
+            if (backgroundKey === null) {
+              backgroundKey = scopeKey;
+            }
+          } else if (selectedKeys.length < 3) {
+            selectedKeys.push(scopeKey);
+            if (selectedKeys.length >= 3) {
+              break;
+            }
+          }
+        }
+
+        if (page.length < RECENT_SUMMARY_PAGE_SIZE) {
+          break; // last page reached
+        }
+      }
+      if (selectedKeys.length < 3 && backgroundKey !== null) {
+        selectedKeys.push(backgroundKey);
+      }
+      if (selectedKeys.length === 0) {
+        return [];
+      }
+
+      // Fetch the summary text for the selected rows only, then return them in
+      // the selection order (user summaries most-recent first, then the one
+      // background summary).
+      const textByKey = new Map<string, string>();
+      const selectedRows = memoryDb
+        .select({
+          scopeKey: memorySummaries.scopeKey,
+          summary: memorySummaries.summary,
+        })
         .from(memorySummaries)
-        .innerJoin(
-          conversations,
-          eq(memorySummaries.scopeKey, conversations.id),
-        )
         .where(
           and(
-            baseWhere,
-            inArray(conversations.conversationType, [
-              "background",
-              "scheduled",
-            ]),
+            eq(memorySummaries.scope, "conversation"),
+            inArray(memorySummaries.scopeKey, selectedKeys),
           ),
         )
-        .orderBy(desc(memorySummaries.updatedAt))
-        .limit(remaining)
         .all();
-
-      return [...userRows, ...bgRows].map((r) => r.summary);
+      for (const r of selectedRows) {
+        textByKey.set(r.scopeKey, r.summary);
+      }
+      return selectedKeys
+        .map((k) => textByKey.get(k))
+        .filter((s): s is string => s !== undefined);
     } catch (err) {
       log.warn({ err }, "Failed to fetch recent conversation summaries");
       return [];

--- a/assistant/src/plugins/defaults/memory/v1/job-handlers/embedding.ts
+++ b/assistant/src/plugins/defaults/memory/v1/job-handlers/embedding.ts
@@ -45,7 +45,8 @@ export async function embedSummaryJob(job: MemoryJob): Promise<void> {
   if (!summaryId) {
     return;
   }
-  const db = getDb();
+  const db = memoryDbOrNull("embedSummaryJob");
+  if (!db) return;
   const summary = db
     .select()
     .from(memorySummaries)

--- a/assistant/src/plugins/defaults/memory/v1/job-handlers/embedding.ts
+++ b/assistant/src/plugins/defaults/memory/v1/job-handlers/embedding.ts
@@ -46,7 +46,9 @@ export async function embedSummaryJob(job: MemoryJob): Promise<void> {
     return;
   }
   const db = memoryDbOrNull("embedSummaryJob");
-  if (!db) return;
+  if (!db) {
+    return;
+  }
   const summary = db
     .select()
     .from(memorySummaries)

--- a/assistant/src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts
+++ b/assistant/src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts
@@ -33,15 +33,14 @@ export async function rebuildIndexJob(): Promise<void> {
   const db = getDb();
   const memoryDb = memoryDbOrNull("rebuildIndexJob");
 
-  // memory_embeddings and memory_segments live on the memory connection;
-  // wipe embeddings there and re-enqueue segments from there. Summaries and
-  // media stay on the main handle.
+  // memory_embeddings, memory_segments, and memory_summaries live on the memory
+  // connection; wipe embeddings there and re-enqueue segments and summaries from
+  // there. Media stays on the main handle.
   memoryDb?.delete(memoryEmbeddings).run();
 
-  const summaries = db
-    .select({ id: memorySummaries.id })
-    .from(memorySummaries)
-    .all();
+  const summaries =
+    memoryDb?.select({ id: memorySummaries.id }).from(memorySummaries).all() ??
+    [];
   for (const summary of summaries) {
     enqueueMemoryJob("embed_summary", { summaryId: summary.id });
   }

--- a/assistant/src/plugins/defaults/memory/v1/semantic-search.ts
+++ b/assistant/src/plugins/defaults/memory/v1/semantic-search.ts
@@ -1,7 +1,6 @@
 import { inArray } from "drizzle-orm";
 
 import { usesConceptPageMemory } from "../../../../config/memory-v3-gate.js";
-import { getDb } from "../../../../persistence/db-connection.js";
 import { withQdrantBreaker } from "../../../../persistence/embeddings/qdrant-circuit-breaker.js";
 import type {
   QdrantSearchResult,
@@ -101,7 +100,6 @@ export async function semanticSearch(
     );
   }
 
-  const db = getDb();
   const mem = memoryDbOrNull("semanticSearch");
 
   // Batch-fetch all backing records upfront to avoid N+1 queries per result
@@ -115,8 +113,8 @@ export async function semanticSearch(
   }
 
   const summariesMap = new Map<string, typeof memorySummaries.$inferSelect>();
-  if (summaryTargetIds.length > 0) {
-    const allSummaries = db
+  if (mem && summaryTargetIds.length > 0) {
+    const allSummaries = mem
       .select()
       .from(memorySummaries)
       .where(inArray(memorySummaries.id, summaryTargetIds))

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts
@@ -115,8 +115,8 @@ mock.module("../../../../../persistence/embeddings/embedding-cache.js", () => ({
 
 mock.module("../../../../../persistence/db-connection.js", () => ({
   getDb: () => ({}),
-  // The section store now resolves the embedding cache on the memory connection
-  // via `memoryDbOrNull`; hand back truthy sentinels so it takes the cache path.
+  // The section store resolves the embedding cache on the memory connection via
+  // `memoryDbOrNull`; hand back truthy sentinels so it takes the cache path.
   getMemoryDb: () => ({}),
   getMemorySqlite: () => ({}),
 }));


### PR DESCRIPTION
Wave 4c of the ATL-1001 memory-DB cutover (targets the `clopen-set/memdb-wave4` feature branch) — the final table.

Moves `memory_summaries` out of the main database into `assistant-memory.db`:
- Repoints the summarizer writer and every reader (semantic search, index maintenance, the embed-summary job) to the memory connection.
- Flips step 1 of `fetchRecentSummaries` (the summary read) to the memory connection; step 2 (the `conversationType` lookup) stays on main.
- Clears it on the memory connection during clear-all.

No cascade to replace — `memory_summaries` has no foreign key and is scope-keyed, so it stays out of `CONVERSATION_KEYED_MEMORY_TABLES`. Migration 353 carries the real column set (including the Drizzle-unmapped `scope_id`) and depends on `migrateDeletePrivateConversations`, which deletes private-scoped summaries by that column.

Stacked on the 4b branch (shares the summarizer/semantic/index-maintenance consumer files); rebase after 4b merges into the feature branch.