### PR TITLE
fix(assistant): text fallback for ask_question on channels without dynamic UI

### DIFF
--- a/assistant/src/daemon/channel-ui-capability.ts
+++ b/assistant/src/daemon/channel-ui-capability.ts
@@ -1,4 +1,16 @@
-import type { Conversation } from "./conversation.js";
+/**
+ * Minimal capability view {@link conversationSupportsDynamicUi} reads. The live
+ * `Conversation` (whose fields are the richer `ChannelCapabilities`), the tool
+ * executor's `ToolSetupContext`, and partial test doubles all satisfy it
+ * structurally, so the helper stays a dependency-free leaf callable from any
+ * layer without importing `Conversation`.
+ */
+export interface DynamicUiCapabilityView {
+  readonly currentTurnChannelCapabilities?: {
+    readonly supportsDynamicUi: boolean;
+  };
+  readonly channelCapabilities?: { readonly supportsDynamicUi: boolean };
+}
 
 /**
  * Whether the conversation's connected client can render dynamic UI surfaces
@@ -8,15 +20,10 @@ import type { Conversation } from "./conversation.js";
  * reliable on every run path, including queue-drained turns that carry no
  * per-call options).
  *
- * Pure projection of the conversation's public capability state — the
- * `Conversation` reference is type-only, so this stays a dependency-free leaf
- * and is safe to call with a partial test double.
+ * Pure projection of the conversation's public capability state.
  */
 export function conversationSupportsDynamicUi(
-  conversation: Pick<
-    Conversation,
-    "currentTurnChannelCapabilities" | "channelCapabilities"
-  >,
+  conversation: DynamicUiCapabilityView,
 ): boolean {
   const caps =
     conversation.currentTurnChannelCapabilities ??

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -62,6 +62,7 @@ import {
   type UsageAttributionSnapshot,
 } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
+import { conversationSupportsDynamicUi } from "./channel-ui-capability.js";
 import type { Conversation } from "./conversation.js";
 import { projectSkillTools } from "./conversation-skill-tools.js";
 import {
@@ -418,6 +419,10 @@ export function createToolExecutor(
         ctx.currentTurnIsNonInteractive !== undefined
           ? !ctx.currentTurnIsNonInteractive
           : !ctx.hasNoClient && !ctx.headlessLock,
+      // Lets UI-dependent tools (e.g. `ask_question`) degrade to text on
+      // channels that can't render dynamic surfaces (Telegram, SMS) instead of
+      // emitting one the channel silently drops.
+      supportsDynamicUi: conversationSupportsDynamicUi(ctx),
       proxyToolResolver: (
         toolName: string,
         proxyInput: Record<string, unknown>,

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -118,6 +118,18 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   /** The interface ID of the connected client driving the current turn (e.g. "macos", "chrome-extension"). Propagated into ToolContext for browser backend selection. */
   readonly transportInterface?: InterfaceId;
   /**
+   * Per-turn snapshot of the channel's UI capabilities, captured at turn start
+   * (mirrors {@link Conversation.currentTurnChannelCapabilities}). Read per tool
+   * call — together with the structural {@link SurfaceConversationContext.channelCapabilities}
+   * fallback — to derive `ToolContext.supportsDynamicUi`, so UI-dependent tools
+   * (e.g. `ask_question`) can degrade to text on channels that can't render
+   * dynamic surfaces.
+   */
+  readonly currentTurnChannelCapabilities?: {
+    readonly channel: string;
+    readonly supportsDynamicUi: boolean;
+  };
+  /**
    * The conversation's per-chat plugin scope (mirrors
    * {@link Conversation.enabledPlugins}). `null`/absent means no per-chat
    * restriction. Read per tool call to derive the effective enabled-plugin set

--- a/assistant/src/tools/ask-question/ask-question-tool.test.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.test.ts
@@ -34,7 +34,8 @@ mock.module("../../permissions/question-prompter.js", () => ({
 
 // Import after the mock so the tool's `import { QuestionPrompter }` binds
 // to the stub class above.
-const { askQuestionTool } = await import("./ask-question-tool.js");
+const { askQuestionTool, formatQuestionsAsTextFallback } =
+  await import("./ask-question-tool.js");
 
 type PromptParams = QuestionPromptParams;
 
@@ -287,6 +288,91 @@ describe("AskQuestionTool.execute", () => {
       makeContext({ signal: ac.signal }),
     );
     expect(calls[0]?.signal).toBe(ac.signal);
+  });
+});
+
+// ── Text fallback on channels without dynamic UI ────────────────────
+
+describe("AskQuestionTool text fallback (supportsDynamicUi === false)", () => {
+  test("returns a formatted text block without ever prompting", async () => {
+    const result = await askQuestionTool.execute(
+      validInput,
+      makeContext({ supportsDynamicUi: false }),
+    );
+
+    // The channel can't render the interactive card, so the prompter must
+    // never be invoked — broadcasting a question_request would reach app
+    // clients but never the channel the turn came from. Instead the model gets
+    // text to relay in its reply, which IS what reaches the channel.
+    expect(calls).toHaveLength(0);
+    expect(result.isError).toBe(false);
+    // Carries the question, both option labels, the option description, and an
+    // instruction to present the question as plain text.
+    expect(result.content).toContain(singleQ.question);
+    expect(result.content).toContain("Apple");
+    expect(result.content).toContain("Banana");
+    expect(result.content).toContain("Ripe");
+    expect(result.content).toContain("Options:");
+    expect(result.content.toLowerCase()).toContain("plain-text");
+  });
+
+  test("still prompts when supportsDynamicUi is true or unset", async () => {
+    setNextResult(singleCompleted({ decision: "option", optionId: "a" }));
+
+    // The fallback keys off an explicit `false`; a dynamic-UI channel (true)
+    // and a client that never set the flag (unset) both take the card path.
+    await askQuestionTool.execute(
+      validInput,
+      makeContext({ supportsDynamicUi: true }),
+    );
+    await askQuestionTool.execute(validInput, makeContext());
+
+    expect(calls).toHaveLength(2);
+  });
+
+  test("isInteractive:false short-circuits before the text fallback", async () => {
+    const result = await askQuestionTool.execute(
+      validInput,
+      makeContext({ isInteractive: false, supportsDynamicUi: false }),
+    );
+
+    // No interactive user present wins over the channel fallback: there is no
+    // one to answer at all, so proceed with defaults rather than emitting a
+    // question the turn would never get a reply to.
+    expect(calls).toHaveLength(0);
+    expect(result.content.toLowerCase()).toContain("no interactive user");
+  });
+});
+
+describe("formatQuestionsAsTextFallback", () => {
+  test("renders a single question with un-numbered options by label", () => {
+    const text = formatQuestionsAsTextFallback([singleQ]);
+
+    expect(text).toContain("Question: Which fruit?");
+    expect(text).toContain("Pick one to add to the smoothie.");
+    expect(text).toContain("Options:");
+    expect(text).toContain("- Apple");
+    expect(text).toContain("- Banana — Ripe");
+    // A single question is not numbered.
+    expect(text).not.toContain("Question 1:");
+  });
+
+  test("numbers questions in a multi-question batch", () => {
+    const q2 = {
+      question: "Preferred time?",
+      options: [
+        { id: "morning", label: "Morning" },
+        { id: "afternoon", label: "Afternoon" },
+      ],
+    };
+
+    const text = formatQuestionsAsTextFallback([singleQ, q2]);
+
+    expect(text).toContain("2 questions");
+    expect(text).toContain("Question 1: Which fruit?");
+    expect(text).toContain("Question 2: Preferred time?");
+    expect(text).toContain("- Morning");
+    expect(text).toContain("- Afternoon");
   });
 });
 

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -113,6 +113,47 @@ const OPTION_ITEMS_SCHEMA = {
   required: ["id", "label"],
 } as const;
 
+// ── Text fallback for channels without dynamic UI ───────────────────
+
+/**
+ * Render a batch of questions and their options as a plain-text block for
+ * channels that can't display the interactive question card (Telegram, SMS,
+ * …). Returned as the tool result so the model relays it to the user in its
+ * reply — which is what actually gets delivered to the channel — and waits for
+ * a free-text answer instead of re-invoking `ask_question`.
+ *
+ * Options are shown by `label` (+ optional `description`), never their `id`:
+ * the id is the machine value the card would return, meaningless to a user
+ * typing a free-text answer.
+ */
+export function formatQuestionsAsTextFallback(
+  questions: SingleQuestion[],
+): string {
+  const multi = questions.length > 1;
+  const header = multi
+    ? `This channel can't display tappable option buttons. Present these ${questions.length} questions to the user as a plain-text message — list every option so they can reply with a choice or in their own words — then wait for their answer. Do not call ask_question again for these.`
+    : "This channel can't display tappable option buttons. Present this question to the user as a plain-text message — list every option so they can reply with a choice or in their own words — then wait for their answer. Do not call ask_question again for this.";
+
+  const blocks = questions.map((q, i) => {
+    const lines: string[] = [];
+    lines.push(
+      multi ? `Question ${i + 1}: ${q.question}` : `Question: ${q.question}`,
+    );
+    if (q.description) {
+      lines.push(q.description);
+    }
+    lines.push("Options:");
+    for (const o of q.options) {
+      lines.push(
+        o.description ? `- ${o.label} — ${o.description}` : `- ${o.label}`,
+      );
+    }
+    return lines.join("\n");
+  });
+
+  return [header, "", blocks.join("\n\n")].join("\n");
+}
+
 // ── Tool ────────────────────────────────────────────────────────────
 
 /**
@@ -191,6 +232,23 @@ export const askQuestionTool = {
       return {
         content:
           "No interactive user is present to answer; proceeding with reasonable defaults.",
+        isError: false,
+      };
+    }
+
+    // The active channel can't render the interactive question card (e.g.
+    // Telegram, SMS). A broadcast question_request would reach app clients but
+    // never the channel the turn came from, so the user would see nothing.
+    // Degrade to text: hand the model the formatted question(s) and options to
+    // present in its reply — which IS what gets delivered to the channel — and
+    // wait for a free-text answer. Mirrors the isInteractive guard above:
+    // return immediately instead of parking on a prompt the surface can't
+    // answer. (UI surface tools like ui_show are instead dropped from the wire
+    // for these channels; ask_question stays available because a question with
+    // options reads cleanly as text.)
+    if (context.supportsDynamicUi === false) {
+      return {
+        content: formatQuestionsAsTextFallback(questions),
         isError: false,
       };
     }

--- a/assistant/src/tools/tool-types.ts
+++ b/assistant/src/tools/tool-types.ts
@@ -232,6 +232,14 @@ export interface ToolContext {
   sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
   /** True when an interactive client is connected (not just a no-op callback). */
   isInteractive?: boolean;
+  /**
+   * Whether the current turn's channel can render dynamic UI surfaces
+   * (interactive cards, tappable option pickers, secure prompts). `false` on
+   * text-only channels (e.g. Telegram, SMS); `undefined` is treated as
+   * supported. UI-dependent tools read this to degrade to a text-formatted
+   * equivalent instead of emitting a surface the channel silently drops.
+   */
+  supportsDynamicUi?: boolean;
   /** When true, tools with side effects should always prompt for confirmation. */
   forcePromptSideEffects?: boolean;
   /**

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -190,6 +190,15 @@ export interface ToolContext {
   /** True when an interactive client is connected (not just a no-op callback). */
   isInteractive?: boolean;
   /**
+   * Whether the current turn's channel can render dynamic UI surfaces
+   * (interactive cards, tappable option pickers, secure prompts). `false` on
+   * text-only channels (e.g. Telegram, SMS). UI-dependent tools read this to
+   * degrade to a text-formatted equivalent instead of emitting a surface the
+   * channel silently drops. `undefined` means unknown and is treated as
+   * supported (desktop/web/app clients).
+   */
+  supportsDynamicUi?: boolean;
+  /**
    * When set, the tool execution is part of a task run. Used to retrieve ephemeral permission rules.
    * @legacy
    */


### PR DESCRIPTION
## Prompt / plan

Structured question prompts (`ask_question`) were invisible to users on Telegram. The tool broadcasts a `question_request` event that only app clients render, so on a channel whose capabilities report `supportsDynamicUi: false` the prompt was silently dropped — no buttons, no text, nothing in the chat. The user only saw it if they returned to the Vellum app.

**Approach:** thread the turn's channel dynamic-UI capability into `ToolContext` and have `ask_question` degrade to text when the channel can't render the card, instead of parking on a surface it can't display.

- `conversationSupportsDynamicUi()` (`daemon/channel-ui-capability.ts`) is relaxed from a `Pick<Conversation, …>` param to a small structural `DynamicUiCapabilityView`, so it's callable from the tool-setup layer as well as the conversation / agent-loop layers. Logic unchanged; it also becomes a true dependency-free leaf (no more `Conversation` type import).
- `ToolContext` gains a `supportsDynamicUi?: boolean` in the stable core, next to `isInteractive` (mirrored in the neutral `@vellumai/plugin-api` copy in `tool-types.ts`). `conversation-tool-setup.ts` populates it via `conversationSupportsDynamicUi(ctx)`; `ToolSetupContext` gains the `currentTurnChannelCapabilities` snapshot the executor reads from the live `Conversation`.
- `ask_question` returns a plain-text rendering of the question(s) + options (`formatQuestionsAsTextFallback`) when `supportsDynamicUi === false`. The model relays that in its reply — which is what actually reaches the channel — and waits for a free-text answer. This mirrors the existing `isInteractive === false` short-circuit in the same tool.

**Scope of the gap:** the UI-surface tools (`ui_show` / `ui_update` / `ui_dismiss`) already drop off the wire on non-dynamic-UI channels (`isToolActiveForContext` gates them on `supportsDynamicUi`), so the model can't call them there and nothing is silently dropped. `ask_question` was the outlier — gated only on `!hasNoClient`, so with the app also connected it stayed callable but had no degradation path. It stays available (a question with options reads cleanly as text) and now degrades to text instead of vanishing.

## Test plan

- `bun test src/tools/ask-question/ask-question-tool.test.ts` — added cases: the text fallback returns formatted content **without** invoking the prompter; the tool still prompts when `supportsDynamicUi` is `true` or unset; `isInteractive: false` still wins over the fallback; and `formatQuestionsAsTextFallback` single- vs. multi-question formatting. **29 pass.**
- Regression-checked the touched surfaces in isolation: `conversation-tool-setup` (58), `tool-executor` (80), `subagent-tool-gate-mode` (31), `conversation-runtime-assembly` (203), plus the other `conversationSupportsDynamicUi` callers (`credential-prompt-route`, `request-secret-standalone-channel-gate`) — all green. (Those two share `mock.module` globals with tool-setup and fail only when the files are run together in one process, on `main` too — pre-existing test-isolation artifact, unrelated to this change.)
- `bun run typecheck:fast`, `eslint`, and `prettier --check` clean; pre-commit and pre-push hooks pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MiUW6fdeCuTGU7vJWu8Y5U)_