### PR TITLE
refactor(assistant): validate Vercel config body via parseBody

### DIFF
--- a/assistant/src/runtime/routes/integrations/__tests__/vercel.test.ts
+++ b/assistant/src/runtime/routes/integrations/__tests__/vercel.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Request-body validation for the Vercel integration config route.
+ *
+ * `handlePostVercelConfig` validates with `parseBody` before it dispatches on
+ * `action` or touches the credential store, so a malformed body is rejected
+ * with a `BadRequestError` (→ 400) without any side effects. Both fields are
+ * optional, so validation only trips on a wrong type / out-of-enum value.
+ *
+ * The handler is `async`, so `parseBody` throwing surfaces as a rejected
+ * promise — hence the `.rejects` form.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { BadRequestError } from "../../errors.js";
+import { ROUTES } from "../vercel.js";
+
+const routeFor = (operationId: string) => {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`no route: ${operationId}`);
+  }
+  return route;
+};
+
+describe("integrations_vercel_config_post body validation", () => {
+  test("rejects an action outside the enum with BadRequestError", async () => {
+    await expect(
+      routeFor("integrations_vercel_config_post").handler({
+        body: { action: "frobnicate" } as unknown as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("rejects a non-string apiToken with BadRequestError", async () => {
+    await expect(
+      routeFor("integrations_vercel_config_post").handler({
+        body: { action: "set", apiToken: 123 } as unknown as Record<
+          string,
+          unknown
+        >,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+});

--- a/assistant/src/runtime/routes/integrations/vercel.ts
+++ b/assistant/src/runtime/routes/integrations/vercel.ts
@@ -17,12 +17,21 @@ import {
   setVercelConfig,
 } from "../../../daemon/handlers/config-vercel.js";
 import { BadRequestError } from "../errors.js";
+import { parseBody } from "../parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
 
 const vercelConfigResponseSchema = z.object({
   hasToken: z.boolean(),
   success: z.boolean(),
   error: z.string().optional(),
+});
+
+// Declared once and referenced by both the route's `requestBody` (the
+// OpenAPI/wire contract) and the handler's `parseBody` call, so the
+// advertised shape and the validated shape can't drift.
+const VercelConfigParams = z.object({
+  action: z.enum(["get", "set", "delete"]).optional(),
+  apiToken: z.string().optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -34,10 +43,7 @@ async function handleGetVercelConfig() {
 }
 
 async function handlePostVercelConfig({ body = {} }: RouteHandlerArgs) {
-  const { action, apiToken } = body as {
-    action?: "get" | "set" | "delete";
-    apiToken?: string;
-  };
+  const { action, apiToken } = parseBody(VercelConfigParams, body);
 
   switch (action) {
     case "delete":
@@ -86,10 +92,7 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Set or delete the Vercel API token. Action is determined by the body action field.",
     tags: ["integrations"],
-    requestBody: z.object({
-      action: z.enum(["get", "set", "delete"]).optional(),
-      apiToken: z.string().optional(),
-    }),
+    requestBody: VercelConfigParams,
     responseBody: vercelConfigResponseSchema,
     handler: handlePostVercelConfig,
   },


### PR DESCRIPTION
## Prompt / plan

Part of **LUM-2796** — enforce each route's declared `requestBody` Zod schema at the adapter boundary ("parse, don't cast"), rolled out one small route cluster at a time so schema-vs-reality mismatches surface in reviewable PRs. This is cluster 4, following #39051 (`suggest_trust_rule`), #39052 (`browser_tabs` + sequences), and #39054 (MCP management routes).

`handlePostVercelConfig` declared a `requestBody` schema **and** re-asserted the same shape in the handler with `body as {…}` — the shape written twice, free to drift, with no runtime validation (a malformed body flowed into the `action` dispatch and on to the credential store). This restores a single source of truth:

- Extract the inline `requestBody` schema to a named const `VercelConfigParams`, referenced by both the route's `requestBody` and the handler.
- Replace the `body as {…}` cast with `parseBody(VercelConfigParams, body)`, so a malformed body is rejected with a `BadRequestError` (→ 400) before dispatch, and the handler gets a typed value derived from the schema.

The cast was already structurally identical to the schema (`action` and `apiToken` both optional, same types), so well-formed requests are unaffected — this is a pure de-cast plus a newly-enforced 400 on malformed input. Enforcing the declared `action` enum means an out-of-enum `action` now returns 400 instead of silently falling through to the `set` branch; the only caller (the Swift client) sends `get`/`set`/`delete`, so real traffic is unchanged.

## Test plan

- New co-located `integrations/__tests__/vercel.test.ts`: an out-of-enum `action` and a non-string `apiToken` each reject with `BadRequestError`. The handler is `async`, so validation surfaces as a rejected promise (`.rejects.toThrow`). `bun test` → 2 pass.
- `bun run typecheck` (assistant) clean — confirms the schema-derived types (`action`/`apiToken` optional) satisfy the handler's `switch` and `setVercelConfig(apiToken)` use sites.
- `bun run generate:openapi -- --check` → spec unchanged (the extracted named const is structurally identical to the inline schema).
- Pre-commit/pre-push: prettier + eslint (clean, no warnings) + typecheck.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Wgp8RrNu1qTXeGPVaq9HD)_