### PR TITLE
feat(telemetry): record result visibility from conversation seen signals

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29949,6 +29949,65 @@ paths:
                   required:
                     - type
                     - fields
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      const: assistant_result_seen
+                    fields:
+                      type: object
+                      properties:
+                        conversation_id:
+                          type: string
+                          minLength: 1
+                          maxLength: 128
+                        assistant_message_id:
+                          type: string
+                          minLength: 1
+                          maxLength: 128
+                        assistant_message_recorded_at:
+                          type: integer
+                          minimum: -9007199254740991
+                          maximum: 9007199254740991
+                        signal_type:
+                          type: string
+                          minLength: 1
+                          maxLength: 64
+                        confidence:
+                          type: string
+                          minLength: 1
+                          maxLength: 32
+                        source_channel:
+                          anyOf:
+                            - type: string
+                              minLength: 1
+                              maxLength: 64
+                            - type: "null"
+                        source_interface:
+                          anyOf:
+                            - type: string
+                              minLength: 1
+                              maxLength: 64
+                            - type: "null"
+                      required:
+                        - conversation_id
+                        - assistant_message_id
+                        - assistant_message_recorded_at
+                        - signal_type
+                        - confidence
+                      description:
+                        Wire event fields, excluding the daemon-stamped base fields (type, daemon_event_id, recorded_at,
+                        assistant_version).
+                    daemon_event_id:
+                      description:
+                        "Optional collapse key: rows sharing an id collapse downstream (e.g. a retried report). Defaults to a fresh
+                        per-row id."
+                      type: string
+                      minLength: 1
+                      maxLength: 128
+                  required:
+                    - type
+                    - fields
               type: object
       responses:
         "200":

--- a/assistant/src/__tests__/conversation-attention-store.test.ts
+++ b/assistant/src/__tests__/conversation-attention-store.test.ts
@@ -17,8 +17,31 @@ import {
   conversations,
   messages,
 } from "../persistence/schema/index.js";
+import {
+  pendingOutboxPayloads,
+  resetOutboxTable,
+  setShareAnalytics,
+} from "../telemetry/__tests__/outbox-test-harness.js";
+import { buildAssistantResultSeenDaemonEventId } from "../telemetry/assistant-result-seen.js";
 
 await initializeDb();
+
+type AssistantResultSeenPayload = {
+  daemon_event_id: string;
+  conversation_id: string;
+  assistant_message_id: string;
+  assistant_message_recorded_at: number;
+  signal_type: string;
+  confidence: string;
+  source_channel: string | null;
+  source_interface: string | null;
+};
+
+function seenTelemetryPayloads(): AssistantResultSeenPayload[] {
+  return pendingOutboxPayloads<AssistantResultSeenPayload>(
+    "assistant_result_seen",
+  );
+}
 
 function ensureConversation(id: string): void {
   const db = getDb();
@@ -62,6 +85,10 @@ function insertAssistantMessage(
 describe("conversation-attention-store", () => {
   beforeEach(() => {
     clearTables();
+    // recordConversationSeenSignal emits assistant_result_seen telemetry as a
+    // side effect; keep the outbox and consent deterministic for every test.
+    resetOutboxTable();
+    setShareAnalytics(true);
   });
 
   // ── projectAssistantMessage ─────────────────────────────────────
@@ -269,7 +296,7 @@ describe("conversation-attention-store", () => {
 
     test("appends an immutable event row", () => {
       ensureConversation("conv-1");
-      const event = recordConversationSeenSignal({
+      const { event } = recordConversationSeenSignal({
         conversationId: "conv-1",
         sourceChannel: "vellum",
         signalType: "macos_conversation_opened",
@@ -371,7 +398,7 @@ describe("conversation-attention-store", () => {
     test("records evidence text and metadata in event", () => {
       ensureConversation("conv-1");
 
-      const event = recordConversationSeenSignal({
+      const { event } = recordConversationSeenSignal({
         conversationId: "conv-1",
         sourceChannel: "telegram",
         signalType: "telegram_callback",
@@ -440,6 +467,192 @@ describe("conversation-attention-store", () => {
       expect(state.lastSeenAssistantMessageAt).toBe(1000);
       // Signal metadata should reflect the latest signal
       expect(state.lastSeenSignalType).toBe("telegram_inbound_message");
+    });
+  });
+
+  // ── assistant_result_seen telemetry ──────────────────────────────
+
+  describe("recordConversationSeenSignal — assistant_result_seen telemetry", () => {
+    test("emits one event when a seen signal newly covers an assistant message", () => {
+      ensureConversation("conv-1");
+      projectAssistantMessage({
+        conversationId: "conv-1",
+        messageId: "msg-1",
+        messageAt: 1000,
+      });
+
+      const { event, newlySeenAssistantMessage } = recordConversationSeenSignal(
+        {
+          conversationId: "conv-1",
+          sourceChannel: "vellum",
+          signalType: "macos_conversation_opened",
+          confidence: "explicit",
+          source: "http-api",
+        },
+      );
+
+      expect(newlySeenAssistantMessage).toEqual({
+        id: "msg-1",
+        recordedAt: 1000,
+      });
+
+      const payloads = seenTelemetryPayloads();
+      expect(payloads).toHaveLength(1);
+      const payload = payloads[0]!;
+      expect(payload.conversation_id).toBe("conv-1");
+      expect(payload.assistant_message_id).toBe("msg-1");
+      expect(payload.assistant_message_recorded_at).toBe(1000);
+      expect(payload.signal_type).toBe("macos_conversation_opened");
+      expect(payload.confidence).toBe("explicit");
+      expect(payload.source_channel).toBe("vellum");
+      expect(payload.source_interface).toBe("http-api");
+      // Deterministic id keyed on attention event id + covered message id.
+      expect(payload.daemon_event_id).toBe(
+        buildAssistantResultSeenDaemonEventId(event.id, "msg-1"),
+      );
+    });
+
+    test("maps a notification-view signal onto the wire fields", () => {
+      ensureConversation("conv-1");
+      projectAssistantMessage({
+        conversationId: "conv-1",
+        messageId: "msg-1",
+        messageAt: 1000,
+      });
+
+      recordConversationSeenSignal({
+        conversationId: "conv-1",
+        sourceChannel: "vellum",
+        signalType: "macos_notification_view",
+        confidence: "inferred",
+        source: "notification",
+      });
+
+      const payloads = seenTelemetryPayloads();
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0]!.signal_type).toBe("macos_notification_view");
+      expect(payloads[0]!.confidence).toBe("inferred");
+      expect(payloads[0]!.source_interface).toBe("notification");
+    });
+
+    test("emits for a bulk mark-read signal", () => {
+      ensureConversation("conv-1");
+      projectAssistantMessage({
+        conversationId: "conv-1",
+        messageId: "msg-1",
+        messageAt: 1000,
+      });
+
+      recordConversationSeenSignal({
+        conversationId: "conv-1",
+        sourceChannel: "vellum",
+        signalType: "web_bulk_mark_read",
+        confidence: "explicit",
+        source: "http-api",
+      });
+
+      const payloads = seenTelemetryPayloads();
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0]!.signal_type).toBe("web_bulk_mark_read");
+    });
+
+    test("emits nothing when there is no assistant message to cover", () => {
+      ensureConversation("conv-1");
+
+      const { newlySeenAssistantMessage } = recordConversationSeenSignal({
+        conversationId: "conv-1",
+        sourceChannel: "telegram",
+        signalType: "telegram_inbound_message",
+        confidence: "inferred",
+        source: "inbound-message-handler",
+      });
+
+      expect(newlySeenAssistantMessage).toBeNull();
+      expect(seenTelemetryPayloads()).toHaveLength(0);
+    });
+
+    test("a repeated seen signal emits a single event", () => {
+      ensureConversation("conv-1");
+      projectAssistantMessage({
+        conversationId: "conv-1",
+        messageId: "msg-1",
+        messageAt: 1000,
+      });
+
+      recordConversationSeenSignal({
+        conversationId: "conv-1",
+        sourceChannel: "vellum",
+        signalType: "macos_conversation_opened",
+        confidence: "explicit",
+        source: "http-api",
+      });
+      // Second signal advances nothing (already seen) — no additional event.
+      const second = recordConversationSeenSignal({
+        conversationId: "conv-1",
+        sourceChannel: "vellum",
+        signalType: "macos_conversation_opened",
+        confidence: "explicit",
+        source: "http-api",
+      });
+
+      expect(second.newlySeenAssistantMessage).toBeNull();
+      expect(seenTelemetryPayloads()).toHaveLength(1);
+    });
+
+    test("omits evidence text and attention metadata from the event", () => {
+      ensureConversation("conv-1");
+      projectAssistantMessage({
+        conversationId: "conv-1",
+        messageId: "msg-1",
+        messageAt: 1000,
+      });
+
+      recordConversationSeenSignal({
+        conversationId: "conv-1",
+        sourceChannel: "vellum",
+        signalType: "macos_conversation_opened",
+        confidence: "explicit",
+        source: "http-api",
+        evidenceText: "User opened the conversation at 9am",
+        metadata: { secretKey: "secretValue" },
+      });
+
+      const payloads = seenTelemetryPayloads();
+      expect(payloads).toHaveLength(1);
+      const keys = Object.keys(payloads[0]!);
+      expect(keys).not.toContain("evidence_text");
+      expect(keys).not.toContain("evidenceText");
+      expect(keys).not.toContain("metadata");
+      expect(keys).not.toContain("metadata_json");
+      expect(JSON.stringify(payloads[0])).not.toContain("secretValue");
+      expect(JSON.stringify(payloads[0])).not.toContain(
+        "User opened the conversation",
+      );
+    });
+
+    test("emits nothing when analytics consent is opted out, but still records the seen signal", () => {
+      setShareAnalytics(false);
+      ensureConversation("conv-1");
+      projectAssistantMessage({
+        conversationId: "conv-1",
+        messageId: "msg-1",
+        messageAt: 1000,
+      });
+
+      recordConversationSeenSignal({
+        conversationId: "conv-1",
+        sourceChannel: "vellum",
+        signalType: "macos_conversation_opened",
+        confidence: "explicit",
+        source: "http-api",
+      });
+
+      expect(seenTelemetryPayloads()).toHaveLength(0);
+      // The seen signal itself is unaffected by telemetry consent.
+      const state = getAttentionStateByConversationIds(["conv-1"]).get(
+        "conv-1",
+      )!;
+      expect(state.lastSeenAssistantMessageId).toBe("msg-1");
     });
   });
 

--- a/assistant/src/persistence/conversation-attention-store.ts
+++ b/assistant/src/persistence/conversation-attention-store.ts
@@ -9,7 +9,9 @@
 import { and, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { recordAssistantResultSeen } from "../telemetry/assistant-result-seen.js";
 import { UserError } from "../util/errors.js";
+import { getLogger } from "../util/logger.js";
 import { getDb } from "./db-connection.js";
 import {
   conversationAssistantAttentionState,
@@ -17,6 +19,8 @@ import {
   conversations,
   messages,
 } from "./schema/index.js";
+
+const log = getLogger("conversation-attention-store");
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -59,6 +63,19 @@ export interface AttentionState {
   lastSeenEvidenceText: string | null;
   createdAt: number;
   updatedAt: number;
+}
+
+/** Post-transaction outcome of {@link recordConversationSeenSignal}. */
+export interface RecordSeenSignalResult {
+  /** The appended immutable attention evidence row. */
+  event: AttentionEvent;
+  /**
+   * The assistant message this signal newly marked as seen — the seen cursor
+   * advanced to cover it. Null when the signal advanced nothing: the
+   * conversation has no assistant message, or its latest was already seen.
+   * Result-seen telemetry is emitted only when this is non-null.
+   */
+  newlySeenAssistantMessage: { id: string; recordedAt: number } | null;
 }
 
 // ── Row mappers ──────────────────────────────────────────────────────
@@ -250,6 +267,8 @@ export function seedForkedConversationAttention(params: {
 /**
  * Record a "seen" signal: appends an immutable event row and advances the
  * seen cursor in the state projection to the current latest assistant message.
+ * When the cursor advances to newly cover an assistant message, emits an
+ * `assistant_result_seen` telemetry event (consent-gated) for that message.
  */
 export function recordConversationSeenSignal(params: {
   conversationId: string;
@@ -260,7 +279,7 @@ export function recordConversationSeenSignal(params: {
   evidenceText?: string;
   metadata?: Record<string, unknown>;
   observedAt?: number;
-}): AttentionEvent {
+}): RecordSeenSignalResult {
   const {
     conversationId,
     sourceChannel,
@@ -291,100 +310,152 @@ export function recordConversationSeenSignal(params: {
     createdAt: now,
   };
 
-  db.transaction((tx) => {
-    // 1. Append immutable evidence row
-    tx.insert(conversationAttentionEvents).values(event).run();
+  // Assistant message the seen cursor newly advances to cover, returned from
+  // the transaction and used to emit result-seen telemetry after it commits.
+  const newlySeenAssistantMessage = db.transaction(
+    (tx): { id: string; recordedAt: number } | null => {
+      // 1. Append immutable evidence row
+      tx.insert(conversationAttentionEvents).values(event).run();
 
-    // 2. Advance the seen cursor to the current latest assistant message
-    const state = tx
-      .select()
-      .from(conversationAssistantAttentionState)
-      .where(
-        eq(conversationAssistantAttentionState.conversationId, conversationId),
-      )
-      .get();
-
-    if (!state) {
-      // No state row yet — look up the conversation's latest assistant message so
-      // upgraded databases (with existing messages but no attention row) correctly
-      // initialize the full state on the first seen signal.
-      const latestMsg = tx
-        .select({ id: messages.id, createdAt: messages.createdAt })
-        .from(messages)
+      // 2. Advance the seen cursor to the current latest assistant message
+      const state = tx
+        .select()
+        .from(conversationAssistantAttentionState)
         .where(
-          and(
-            eq(messages.conversationId, conversationId),
-            eq(messages.role, "assistant"),
+          eq(
+            conversationAssistantAttentionState.conversationId,
+            conversationId,
           ),
         )
-        .orderBy(desc(messages.createdAt))
-        .limit(1)
         .get();
 
-      const latestMsgId = latestMsg?.id ?? null;
-      const latestMsgAt = latestMsg?.createdAt ?? null;
+      if (!state) {
+        // No state row yet — look up the conversation's latest assistant message so
+        // upgraded databases (with existing messages but no attention row) correctly
+        // initialize the full state on the first seen signal.
+        const latestMsg = tx
+          .select({ id: messages.id, createdAt: messages.createdAt })
+          .from(messages)
+          .where(
+            and(
+              eq(messages.conversationId, conversationId),
+              eq(messages.role, "assistant"),
+            ),
+          )
+          .orderBy(desc(messages.createdAt))
+          .limit(1)
+          .get();
 
-      tx.insert(conversationAssistantAttentionState)
-        .values({
-          conversationId,
-          latestAssistantMessageId: latestMsgId,
-          latestAssistantMessageAt: latestMsgAt,
-          lastSeenAssistantMessageId: latestMsgId,
-          lastSeenAssistantMessageAt: latestMsgAt,
-          lastSeenEventAt: eventObservedAt,
-          lastSeenConfidence: confidence,
-          lastSeenSignalType: signalType,
-          lastSeenSourceChannel: sourceChannel,
-          lastSeenSource: source,
-          lastSeenEvidenceText: evidenceText ?? null,
-          createdAt: now,
-          updatedAt: now,
-        })
+        const latestMsgId = latestMsg?.id ?? null;
+        const latestMsgAt = latestMsg?.createdAt ?? null;
+
+        tx.insert(conversationAssistantAttentionState)
+          .values({
+            conversationId,
+            latestAssistantMessageId: latestMsgId,
+            latestAssistantMessageAt: latestMsgAt,
+            lastSeenAssistantMessageId: latestMsgId,
+            lastSeenAssistantMessageAt: latestMsgAt,
+            lastSeenEventAt: eventObservedAt,
+            lastSeenConfidence: confidence,
+            lastSeenSignalType: signalType,
+            lastSeenSourceChannel: sourceChannel,
+            lastSeenSource: source,
+            lastSeenEvidenceText: evidenceText ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .run();
+        return latestMsgId != null && latestMsgAt != null
+          ? { id: latestMsgId, recordedAt: latestMsgAt }
+          : null;
+      }
+
+      // Only advance the seen cursor if there is a latest assistant message to mark as seen,
+      // and the seen cursor hasn't already reached or passed it (monotonic invariant).
+      const shouldAdvanceSeen =
+        state.latestAssistantMessageAt != null &&
+        (state.lastSeenAssistantMessageAt == null ||
+          state.latestAssistantMessageAt > state.lastSeenAssistantMessageAt);
+
+      // Guard seen metadata monotonicity: only update lastSeen* metadata when the
+      // new signal's observedAt is at least as recent as the existing projection.
+      // Out-of-order delivery (e.g. delayed channel callbacks) must not regress
+      // the projected channel/source/confidence metadata.
+      const isNewerSignal =
+        state.lastSeenEventAt == null ||
+        eventObservedAt >= state.lastSeenEventAt;
+
+      const updates: Record<string, unknown> = {
+        updatedAt: now,
+      };
+
+      if (isNewerSignal) {
+        updates.lastSeenEventAt = eventObservedAt;
+        updates.lastSeenConfidence = confidence;
+        updates.lastSeenSignalType = signalType;
+        updates.lastSeenSourceChannel = sourceChannel;
+        updates.lastSeenSource = source;
+        updates.lastSeenEvidenceText = evidenceText ?? null;
+      }
+
+      const advancedTo =
+        shouldAdvanceSeen &&
+        state.latestAssistantMessageId != null &&
+        state.latestAssistantMessageAt != null
+          ? {
+              id: state.latestAssistantMessageId,
+              recordedAt: state.latestAssistantMessageAt,
+            }
+          : null;
+
+      if (shouldAdvanceSeen) {
+        updates.lastSeenAssistantMessageId = state.latestAssistantMessageId;
+        updates.lastSeenAssistantMessageAt = state.latestAssistantMessageAt;
+      }
+
+      tx.update(conversationAssistantAttentionState)
+        .set(updates)
+        .where(
+          eq(
+            conversationAssistantAttentionState.conversationId,
+            conversationId,
+          ),
+        )
         .run();
-      return;
+      return advancedTo;
+    },
+  );
+
+  // Emit result-seen telemetry only when the cursor advanced to newly cover an
+  // assistant message. A redundant signal (already seen) or one on a
+  // conversation with no assistant message advances nothing and emits nothing,
+  // so a repeated seen produces a single event. Best-effort: a telemetry
+  // failure never disturbs the recorded seen signal.
+  if (newlySeenAssistantMessage) {
+    try {
+      recordAssistantResultSeen({
+        conversationId,
+        attentionEventId: eventId,
+        assistantMessageId: newlySeenAssistantMessage.id,
+        assistantMessageRecordedAt: newlySeenAssistantMessage.recordedAt,
+        signalType,
+        confidence,
+        sourceChannel,
+        sourceInterface: source,
+      });
+    } catch (err) {
+      log.warn(
+        { err, conversationId },
+        "Failed to record assistant_result_seen telemetry",
+      );
     }
+  }
 
-    // Only advance the seen cursor if there is a latest assistant message to mark as seen,
-    // and the seen cursor hasn't already reached or passed it (monotonic invariant).
-    const shouldAdvanceSeen =
-      state.latestAssistantMessageAt != null &&
-      (state.lastSeenAssistantMessageAt == null ||
-        state.latestAssistantMessageAt > state.lastSeenAssistantMessageAt);
-
-    // Guard seen metadata monotonicity: only update lastSeen* metadata when the
-    // new signal's observedAt is at least as recent as the existing projection.
-    // Out-of-order delivery (e.g. delayed channel callbacks) must not regress
-    // the projected channel/source/confidence metadata.
-    const isNewerSignal =
-      state.lastSeenEventAt == null || eventObservedAt >= state.lastSeenEventAt;
-
-    const updates: Record<string, unknown> = {
-      updatedAt: now,
-    };
-
-    if (isNewerSignal) {
-      updates.lastSeenEventAt = eventObservedAt;
-      updates.lastSeenConfidence = confidence;
-      updates.lastSeenSignalType = signalType;
-      updates.lastSeenSourceChannel = sourceChannel;
-      updates.lastSeenSource = source;
-      updates.lastSeenEvidenceText = evidenceText ?? null;
-    }
-
-    if (shouldAdvanceSeen) {
-      updates.lastSeenAssistantMessageId = state.latestAssistantMessageId;
-      updates.lastSeenAssistantMessageAt = state.latestAssistantMessageAt;
-    }
-
-    tx.update(conversationAssistantAttentionState)
-      .set(updates)
-      .where(
-        eq(conversationAssistantAttentionState.conversationId, conversationId),
-      )
-      .run();
-  });
-
-  return rowToEvent(event as typeof conversationAttentionEvents.$inferSelect);
+  return {
+    event: rowToEvent(event as typeof conversationAttentionEvents.$inferSelect),
+    newlySeenAssistantMessage,
+  };
 }
 
 // ── markConversationUnread ───────────────────────────────────────────

--- a/assistant/src/telemetry/__tests__/telemetry-event-fixtures.ts
+++ b/assistant/src/telemetry/__tests__/telemetry-event-fixtures.ts
@@ -14,6 +14,7 @@
  * imports are type-only; this module has no runtime side effects.
  */
 import type {
+  AssistantResultSeenTelemetryEvent,
   AuthFallbackTelemetryEvent,
   ConfigSettingTelemetryEvent,
   LifecycleTelemetryEvent,
@@ -247,6 +248,20 @@ export const onboardingResearch: OnboardingResearchTelemetryEvent = {
   installed_plugins: ["gmail", "calendar"],
 };
 
+const assistantResultSeen: AssistantResultSeenTelemetryEvent = {
+  type: "assistant_result_seen",
+  daemon_event_id: "assistant_result_seen:evt-seen-001",
+  recorded_at: RECORDED_AT,
+  assistant_version: "1.2.3",
+  conversation_id: "conv-xyz",
+  assistant_message_id: "msg-2",
+  assistant_message_recorded_at: RECORDED_AT - 1_000,
+  signal_type: "macos_conversation_opened",
+  confidence: "explicit",
+  source_channel: "vellum",
+  source_interface: "http-api",
+};
+
 /** One daemon-typed, wire-valid sample per generated wire event type. */
 export const wireEventSamples = [
   llmUsage,
@@ -259,4 +274,5 @@ export const wireEventSamples = [
   watchdog,
   configSetting,
   onboardingResearch,
+  assistantResultSeen,
 ] as const;

--- a/assistant/src/telemetry/assistant-result-seen.ts
+++ b/assistant/src/telemetry/assistant-result-seen.ts
@@ -1,0 +1,73 @@
+import { createHash } from "node:crypto";
+
+import { APP_VERSION } from "../version.js";
+import { recordTelemetryOutboxEvent } from "./telemetry-events-outbox.js";
+import type { AssistantResultSeenTelemetryEvent } from "./types.js";
+
+/**
+ * Input for one `assistant_result_seen` telemetry event. Metadata only — the
+ * signal's evidence text and arbitrary attention metadata are deliberately
+ * omitted; only the seen-cursor coordinates and provenance dimensions ship.
+ */
+export interface AssistantResultSeenRecord {
+  conversationId: string;
+  /** Id of the attention evidence row this seen signal appended. */
+  attentionEventId: string;
+  /** Assistant message the signal newly marked as seen. */
+  assistantMessageId: string;
+  /** Epoch-ms `created_at` of the covered assistant message. */
+  assistantMessageRecordedAt: number;
+  signalType: string;
+  confidence: string;
+  sourceChannel: string | null;
+  sourceInterface: string | null;
+}
+
+/**
+ * Deterministic `daemon_event_id` for an `assistant_result_seen` event, keyed
+ * on the attention event id and the covered assistant message id. A retried
+ * emission of the same seen signal produces the same id, so the ingest-side
+ * dedup (keyed on `daemon_event_id`, earliest-wins) collapses it to one row.
+ * SHA-256 hex keeps the id within the wire's 128-char bound regardless of the
+ * component id lengths.
+ */
+export function buildAssistantResultSeenDaemonEventId(
+  attentionEventId: string,
+  assistantMessageId: string,
+): string {
+  const digest = createHash("sha256")
+    .update(`${attentionEventId}:${assistantMessageId}`)
+    .digest("hex");
+  return `assistant_result_seen:${digest}`;
+}
+
+/**
+ * Record an `assistant_result_seen` telemetry event on the `telemetry_events`
+ * outbox, with the conversation id in its dedicated column so conversation
+ * deletion redacts pending rows via an indexed delete. Consent gating and
+ * degraded-mode `null` are {@link recordTelemetryOutboxEvent}'s.
+ */
+export function recordAssistantResultSeen(
+  record: AssistantResultSeenRecord,
+): void {
+  recordTelemetryOutboxEvent(
+    "assistant_result_seen",
+    (_id, createdAt): AssistantResultSeenTelemetryEvent => ({
+      type: "assistant_result_seen",
+      daemon_event_id: buildAssistantResultSeenDaemonEventId(
+        record.attentionEventId,
+        record.assistantMessageId,
+      ),
+      recorded_at: createdAt,
+      assistant_version: APP_VERSION,
+      conversation_id: record.conversationId,
+      assistant_message_id: record.assistantMessageId,
+      assistant_message_recorded_at: record.assistantMessageRecordedAt,
+      signal_type: record.signalType,
+      confidence: record.confidence,
+      source_channel: record.sourceChannel,
+      source_interface: record.sourceInterface,
+    }),
+    { conversationId: record.conversationId },
+  );
+}

--- a/assistant/src/telemetry/telemetry-event-sources.test.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.test.ts
@@ -46,6 +46,7 @@ describe("telemetry event source partition", () => {
       "watchdog",
       "config_setting",
       "onboarding_research",
+      "assistant_result_seen",
       ORPHAN_OUTBOX_DRAIN_SOURCE_ID,
     ]);
   });

--- a/assistant/src/telemetry/telemetry-wire.generated.ts
+++ b/assistant/src/telemetry/telemetry-wire.generated.ts
@@ -385,6 +385,23 @@ export type OnboardingResearchTelemetryEvent = z.infer<
   typeof onboardingResearchTelemetryEventSchema
 >;
 
+export const assistantResultSeenTelemetryEventSchema = z.object({
+  type: z.literal("assistant_result_seen"),
+  daemon_event_id: z.string().trim().min(1).max(128),
+  recorded_at: z.number().int(),
+  assistant_version: z.string().trim().min(1).max(64).nullable().optional(),
+  conversation_id: z.string().trim().min(1).max(128),
+  assistant_message_id: z.string().trim().min(1).max(128),
+  assistant_message_recorded_at: z.number().int(),
+  signal_type: z.string().trim().min(1).max(64),
+  confidence: z.string().trim().min(1).max(32),
+  source_channel: z.string().trim().min(1).max(64).nullable().optional(),
+  source_interface: z.string().trim().min(1).max(64).nullable().optional(),
+});
+export type AssistantResultSeenTelemetryEvent = z.infer<
+  typeof assistantResultSeenTelemetryEventSchema
+>;
+
 export type WireEventMap = {
   llm_usage: LlmUsageTelemetryEvent;
   turn: TurnTelemetryEvent;
@@ -396,6 +413,7 @@ export type WireEventMap = {
   watchdog: WatchdogTelemetryEvent;
   config_setting: ConfigSettingTelemetryEvent;
   onboarding_research: OnboardingResearchTelemetryEvent;
+  assistant_result_seen: AssistantResultSeenTelemetryEvent;
 };
 
 export const telemetryEventSchema = z.discriminatedUnion("type", [
@@ -409,6 +427,7 @@ export const telemetryEventSchema = z.discriminatedUnion("type", [
   watchdogTelemetryEventSchema,
   configSettingTelemetryEventSchema,
   onboardingResearchTelemetryEventSchema,
+  assistantResultSeenTelemetryEventSchema,
 ]);
 export type TelemetryEvent = z.infer<typeof telemetryEventSchema>;
 

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -583,6 +583,15 @@ export type AuthFallbackTelemetryEvent = EventMap["auth_fallback"];
  */
 export type ConfigSettingTelemetryEvent = EventMap["config_setting"];
 
+/**
+ * Assistant-result-seen event — one per seen signal that newly advanced the
+ * conversation's attention cursor to cover an assistant message. Metadata only
+ * (no evidence text or attention metadata). 1:1 with the wire contract
+ * (`AssistantResultSeenTelemetryEventSerializer`).
+ */
+export type AssistantResultSeenTelemetryEvent =
+  EventMap["assistant_result_seen"];
+
 // ---- Compile-time drift guards ----
 // Each `Overrides` entry is pinned to its wire type in BOTH directions, so a
 // wire sync PR that moves the platform contract turns red here instead of


### PR DESCRIPTION
## Why

PR 7 of the Inference Cost Instrumentation Gap Plan (platform contract: vellum-ai/vellum-assistant-platform#9479). "Was costly output ever seen?" is currently a bounded inference; this makes it an observed, PII-free event.

**Merge order: after platform #9479 and its generated-wire sync land.** The wire sections here are byte-identical to the platform generator's output (verified through the sync workflow's prettier pass).

## What

- `recordConversationSeenSignal()` returns the post-transaction seen-cursor snapshot (latest assistant message id/timestamp covered) and emits `assistant_result_seen` once, in the shared store path — routes, inbound approval, and telegram ingress are covered with zero per-site duplication (the plan's file list missed the telegram path; consolidating in the store catches it).
- Emission fires only when the cursor NEWLY advances over an assistant message: redundant signals and no-assistant-message conversations emit nothing.
- Deterministic `daemon_event_id` = `assistant_result_seen:` + sha256(attentionEventId:assistantMessageId) — retries collapse at ingest.
- Consent gating inherited from the typed outbox (confirmed opt-out drops; cursor still advances). No message text, evidence, or metadata bags on the wire.

## Verification

- 40 store tests (7 new: explicit open, notification interaction, bulk mark-read, no-assistant-message, duplicate signal, opt-out, snapshot shape); 27 telemetry drift-guard tests; full `tsc --noEmit` + lint clean.
- Pre-existing cross-file `mock.module` leak between two attention test files reproduces on main — unrelated, noted for a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->