### PR TITLE
feat(providers): send work-origin and turn linkage to managed inference billing

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { getDb, getSqlite } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
+  countRealUserTurns,
   getUsageDayBuckets,
   getUsageGroupBreakdown,
   getUsageGroupedSeries,
@@ -1672,6 +1673,97 @@ describe("getUsageGroupedSeries", () => {
 // ---------------------------------------------------------------------------
 // queryUnreportedUsageEvents tests
 // ---------------------------------------------------------------------------
+
+describe("countRealUserTurns", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test("returns 0 for a conversation with no real user turns", () => {
+    expect(countRealUserTurns("conv-empty")).toBe(0);
+  });
+
+  // The billing-origin snapshot stamps `turnIndex = countRealUserTurns(...)` at
+  // agent-loop start, when a coalesced batch has already persisted all N user
+  // messages. It must equal the `turn_index` the telemetry read path computes
+  // for an LLM call fired during the same run — both count real user turns via
+  // `realUserTurnContentFilter`, so a batch of 3 reads 3 on both paths (not the
+  // 1 that `ctx.turnCount + 1` would have produced for the single run).
+  test("a batch of 3 user messages counts 3, matching telemetry's turn_index", () => {
+    const db = getDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('conv-batch', 'standard', ${now}, ${now})`,
+    );
+    // The coalesced batch: three real user messages persisted before the
+    // single agent-loop run's first LLM call.
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('b1', 'conv-batch', 'user', 'one', 1000)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('b2', 'conv-batch', 'user', 'two', 1001)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('b3', 'conv-batch', 'user', 'three', 1002)`,
+    );
+    // The run's LLM call lands after the whole batch is persisted.
+    insertEventAt(2000, { conversationId: "conv-batch" });
+
+    expect(countRealUserTurns("conv-batch")).toBe(3);
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    // Snapshot turnIndex (countRealUserTurns) agrees with the telemetry row.
+    expect(events[0].turnIndex).toBe(3);
+    expect(events[0].turnIndex).toBe(countRealUserTurns("conv-batch"));
+  });
+
+  test("prior single turns plus a batch of 2 count as 3, matching telemetry", () => {
+    const db = getDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('conv-mix', 'standard', ${now}, ${now})`,
+    );
+    // One prior completed turn, then a 2-message batch.
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('p1', 'conv-mix', 'user', 'prior', 1000)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('c1', 'conv-mix', 'user', 'batch a', 2000)`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('c2', 'conv-mix', 'user', 'batch b', 2001)`,
+    );
+    insertEventAt(3000, { conversationId: "conv-mix" });
+
+    expect(countRealUserTurns("conv-mix")).toBe(3);
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events[0].turnIndex).toBe(3);
+  });
+
+  test("skips tool_result continuation rows, matching telemetry", () => {
+    const db = getDb();
+    const now = Date.now();
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('conv-tr2', 'standard', ${now}, ${now})`,
+    );
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('r1', 'conv-tr2', 'user', 'real text', 1000)`,
+    );
+    // Tool-result row persisted with role='user' — a continuation, not a turn.
+    db.run(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('t1', 'conv-tr2', 'user', '[{"type":"tool_result","tool_use_id":"x","content":""}]', 1500)`,
+    );
+    insertEventAt(2000, { conversationId: "conv-tr2" });
+
+    expect(countRealUserTurns("conv-tr2")).toBe(1);
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events[0].turnIndex).toBe(1);
+  });
+});
 
 describe("queryUnreportedUsageEvents", () => {
   beforeEach(() => {

--- a/assistant/src/__tests__/usage-origin-snapshot.test.ts
+++ b/assistant/src/__tests__/usage-origin-snapshot.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  queryUnreportedUsageEvents,
+  recordUsageEvent,
+} from "../persistence/llm-usage-store.js";
+import type { PricingResult, UsageEventInput } from "../usage/types.js";
+import { buildTurnUsageOriginSnapshot } from "../usage/usage-origin-snapshot.js";
+
+await initializeDb();
+
+const priced: PricingResult = {
+  estimatedCostUsd: 0.001,
+  pricingStatus: "priced",
+};
+
+function makeInput(conversationId: string): UsageEventInput {
+  return {
+    provider: "anthropic",
+    model: "claude-sonnet-4-20250514",
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheCreationInputTokens: null,
+    cacheReadInputTokens: null,
+    rawUsage: null,
+    actor: "main_agent",
+    conversationId,
+    runId: null,
+    requestId: null,
+  };
+}
+
+/** Record one usage event on a conversation at a specific created_at. */
+function insertEventAt(timestamp: number, conversationId: string): void {
+  const event = recordUsageEvent(makeInput(conversationId), priced);
+  getDb().run(
+    `UPDATE llm_usage_events SET created_at = ${timestamp} WHERE id = '${event.id}'`,
+  );
+}
+
+function insertConversation(
+  id: string,
+  conversationType = "standard",
+  createdAt = 0,
+): void {
+  getDb().run(
+    `INSERT OR IGNORE INTO conversations (id, conversation_type, created_at, updated_at) VALUES ('${id}', '${conversationType}', ${createdAt}, ${createdAt})`,
+  );
+}
+
+function insertUserMessage(
+  id: string,
+  conversationId: string,
+  createdAt: number,
+): void {
+  getDb().run(
+    `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('${id}', '${conversationId}', 'user', 'text', ${createdAt})`,
+  );
+}
+
+describe("buildTurnUsageOriginSnapshot", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+  });
+
+  test("top-level user conversation: turnIndex counted, parentTurnIndex null", () => {
+    insertConversation("conv-user");
+    insertUserMessage("u1", "conv-user", 1000);
+    insertUserMessage("u2", "conv-user", 2000);
+
+    const snapshot = buildTurnUsageOriginSnapshot(
+      {
+        conversationId: "conv-user",
+        conversationType: "standard",
+        source: "user",
+        parentConversationId: null,
+        forkParentConversationId: null,
+      },
+      "mainAgent",
+    );
+
+    expect(snapshot.turnIndex).toBe(2);
+    expect(snapshot.parentConversationId).toBeNull();
+    expect(snapshot.parentTurnIndex).toBeNull();
+    expect(snapshot.workOrigin).toBe("user_interactive");
+  });
+
+  // A subagent's background conversation carries the live subagent parent. Its
+  // parentTurnIndex must count the PARENT conversation's real user turns —
+  // matching the telemetry read path, which counts the same population up to
+  // the child's creation. At snapshot time the parent's turns already exist, so
+  // counting them all equals telemetry's cutoff count.
+  test("subagent child: parentTurnIndex counts the parent's turns and agrees with telemetry", () => {
+    const db = getDb();
+    insertConversation("parent-1");
+    insertUserMessage("p1", "parent-1", 1000);
+    insertUserMessage("p2", "parent-1", 2000);
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, parent_conversation_id) VALUES ('child-1', 'background', 3000, 3000, 'parent-1')`,
+    );
+    insertUserMessage("c1", "child-1", 3100);
+    insertEventAt(4000, "child-1");
+
+    const snapshot = buildTurnUsageOriginSnapshot(
+      {
+        conversationId: "child-1",
+        conversationType: "background",
+        source: "subagent",
+        parentConversationId: "parent-1",
+        forkParentConversationId: null,
+      },
+      "subagentSpawn",
+    );
+
+    expect(snapshot.parentConversationId).toBe("parent-1");
+    expect(snapshot.turnIndex).toBe(1);
+    expect(snapshot.parentTurnIndex).toBe(2);
+    expect(snapshot.workOrigin).toBe("delegated_child");
+
+    // Telemetry resolves the same parent and counts the same population.
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events).toHaveLength(1);
+    expect(events[0].parentConversationId).toBe("parent-1");
+    expect(events[0].parentTurnIndex).toBe(snapshot.parentTurnIndex);
+  });
+
+  // A retrospective fork is a background conversation with no live subagent
+  // parent; its spawn parent is the source via fork_parent_conversation_id. The
+  // parentTurnIndex counts the SOURCE's real user turns.
+  test("retrospective fork: resolves the fork parent and counts its turns", () => {
+    const db = getDb();
+    insertConversation("source-1");
+    insertUserMessage("s1", "source-1", 1000);
+    insertUserMessage("s2", "source-1", 2000);
+    // Fork through the latest source message (s2), as real retrospectives do.
+    db.run(
+      `INSERT INTO conversations (id, conversation_type, created_at, updated_at, fork_parent_conversation_id, fork_parent_message_id) VALUES ('retro-1', 'background', 3000, 3000, 'source-1', 's2')`,
+    );
+    insertEventAt(4000, "retro-1");
+
+    const snapshot = buildTurnUsageOriginSnapshot(
+      {
+        conversationId: "retro-1",
+        conversationType: "background",
+        source: "memory-retrospective-fork",
+        parentConversationId: null,
+        forkParentConversationId: "source-1",
+      },
+      "memoryRetrospective",
+    );
+
+    expect(snapshot.parentConversationId).toBe("source-1");
+    expect(snapshot.parentTurnIndex).toBe(2);
+    expect(snapshot.workOrigin).toBe("delegated_child");
+
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
+    expect(events[0].parentConversationId).toBe("source-1");
+    expect(events[0].parentTurnIndex).toBe(snapshot.parentTurnIndex);
+  });
+
+  test("user-initiated (standard) fork does not inherit fork-parent attribution", () => {
+    insertConversation("source-2");
+    insertConversation("user-fork");
+    insertUserMessage("s1", "source-2", 1000);
+    insertUserMessage("f1", "user-fork", 2000);
+
+    const snapshot = buildTurnUsageOriginSnapshot(
+      {
+        conversationId: "user-fork",
+        conversationType: "standard",
+        source: "user",
+        parentConversationId: null,
+        forkParentConversationId: "source-2",
+      },
+      "mainAgent",
+    );
+
+    expect(snapshot.parentConversationId).toBeNull();
+    expect(snapshot.parentTurnIndex).toBeNull();
+    expect(snapshot.workOrigin).toBe("user_interactive");
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -49,6 +49,7 @@ import {
   applyStreamingSubstitution,
   applySubstitutions,
 } from "../tools/sensitive-output-placeholders.js";
+import type { UsageOriginSnapshot } from "../usage/work-origin.js";
 import { ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { CompactionCircuit } from "./compaction-circuit.js";
@@ -623,6 +624,14 @@ interface AgentLoopRunOptionsBase {
     mark(name: string): void;
     markFirstToken(kind: "thinking" | "text"): void;
   };
+  /**
+   * Immutable record-time usage attribution for every LLM call this run emits,
+   * built once by the conversation orchestrator from the turn's conversation
+   * metadata and call site. Threaded onto each send's `SendMessageConfig` so
+   * `RetryProvider` can forward it as billing-origin headers on the managed
+   * proxy. Absent for standalone loop runs with no conversation attribution.
+   */
+  usageOriginSnapshot?: UsageOriginSnapshot;
 }
 
 interface AgentLoopRunOptionsWithContextWindow extends AgentLoopRunOptionsBase {
@@ -1004,6 +1013,7 @@ export class AgentLoop {
       isNonInteractive = false,
       model: runModel,
       latencyTracker,
+      usageOriginSnapshot,
     } = options;
     // Snapshot the system prompt once per run. The instance field is mutable
     // (the conversation may update it between turns), but a single run must
@@ -1444,6 +1454,14 @@ export class AgentLoop {
           if (this.conversationId) {
             providerConfig.selectionSeed = this.conversationId;
           }
+        }
+
+        // Immutable record-time usage attribution, rides the same per-call
+        // config as `callSite`/`selectionSeed`. `RetryProvider` maps it to the
+        // billing-origin headers on the managed-proxy path and strips it before
+        // the wire request; harmless (and stripped) on every other transport.
+        if (usageOriginSnapshot) {
+          providerConfig.usageOriginSnapshot = usageOriginSnapshot;
         }
 
         // Per-call inference-profile override. The resolver layers

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -54,6 +54,7 @@ import {
   backfillMessageIdOnLogs,
   recordSyntheticAgentErrorMessageLog,
 } from "../persistence/llm-request-log-store.js";
+import { countRealUserTurns } from "../persistence/llm-usage-store.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import type { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import { enqueueMemoryRetrospectiveOnCompaction } from "../plugins/defaults/memory/memory-retrospective-enqueue.js";
@@ -358,18 +359,23 @@ export async function runAgentLoopImpl(
   // Immutable record-time usage attribution for every LLM call this turn emits,
   // carrying the same work-origin classification the `llm_usage` telemetry
   // derives so managed billing rows and usage telemetry share one vocabulary.
-  // `turnIndex` is the current turn's 1-based position (`turnCount` holds the
-  // count of prior turns until incremented at turn end, matching the read
-  // path's "1-indexed position of the user turn this call belongs to").
-  // `parentConversationId` is the subagent-spawn parent; precise parent-turn
-  // attribution is resolved by the telemetry flush, so it rides null here.
+  // `turnIndex` is derived from the same real-user-turn population the telemetry
+  // read path counts (via `countRealUserTurns`), not `ctx.turnCount`: a coalesced
+  // batch persists N user messages before this single run, and `turnCount`
+  // increments once per run — so `turnCount + 1` would under-count a batch by
+  // N-1 and disagree with the billed row. Spawn linkage passes the subagent
+  // parent plus the fork parent; `buildUsageOriginSnapshot` resolves the
+  // subagent/background-fork precedence to match the telemetry `parentIdSql`, so
+  // retrospective forks classify as `delegated_child` on both paths. Precise
+  // parent-turn attribution is resolved by the telemetry flush, so it rides null.
   const usageOriginSnapshot = buildUsageOriginSnapshot({
     conversationType: ctx.conversationType ?? null,
     conversationSource: ctx.source ?? null,
     callSite: turnCallSite,
     conversationId: ctx.conversationId,
-    turnIndex: ctx.turnCount + 1,
+    turnIndex: countRealUserTurns(ctx.conversationId),
     parentConversationId: ctx.parentConversationId ?? null,
+    forkParentConversationId: ctx.forkParentConversationId ?? null,
     parentTurnIndex: null,
   });
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -54,7 +54,6 @@ import {
   backfillMessageIdOnLogs,
   recordSyntheticAgentErrorMessageLog,
 } from "../persistence/llm-request-log-store.js";
-import { countRealUserTurns } from "../persistence/llm-usage-store.js";
 import { HOOKS } from "../plugin-api/constants.js";
 import type { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import { enqueueMemoryRetrospectiveOnCompaction } from "../plugins/defaults/memory/memory-retrospective-enqueue.js";
@@ -69,7 +68,7 @@ import {
   startToolProfilingRequest,
 } from "../tools/tool-profiler.js";
 import type { UsageActor } from "../usage/actors.js";
-import { buildUsageOriginSnapshot } from "../usage/work-origin.js";
+import { buildTurnUsageOriginSnapshot } from "../usage/usage-origin-snapshot.js";
 import { getLogger } from "../util/logger.js";
 import { timeAgo } from "../util/time.js";
 import { getWorkspaceGitService } from "../workspace/git-service.js";
@@ -359,25 +358,14 @@ export async function runAgentLoopImpl(
   // Immutable record-time usage attribution for every LLM call this turn emits,
   // carrying the same work-origin classification the `llm_usage` telemetry
   // derives so managed billing rows and usage telemetry share one vocabulary.
-  // `turnIndex` is derived from the same real-user-turn population the telemetry
-  // read path counts (via `countRealUserTurns`), not `ctx.turnCount`: a coalesced
-  // batch persists N user messages before this single run, and `turnCount`
-  // increments once per run — so `turnCount + 1` would under-count a batch by
-  // N-1 and disagree with the billed row. Spawn linkage passes the subagent
-  // parent plus the fork parent; `buildUsageOriginSnapshot` resolves the
-  // subagent/background-fork precedence to match the telemetry `parentIdSql`, so
-  // retrospective forks classify as `delegated_child` on both paths. Precise
-  // parent-turn attribution is resolved by the telemetry flush, so it rides null.
-  const usageOriginSnapshot = buildUsageOriginSnapshot({
-    conversationType: ctx.conversationType ?? null,
-    conversationSource: ctx.source ?? null,
-    callSite: turnCallSite,
-    conversationId: ctx.conversationId,
-    turnIndex: countRealUserTurns(ctx.conversationId),
-    parentConversationId: ctx.parentConversationId ?? null,
-    forkParentConversationId: ctx.forkParentConversationId ?? null,
-    parentTurnIndex: null,
-  });
+  // Both turn indexes are derived from the same real-user-turn population the
+  // telemetry read path counts (via `countRealUserTurns` inside
+  // `buildTurnUsageOriginSnapshot`), and the subagent/background-fork spawn
+  // precedence is resolved to match the telemetry `parentIdSql` — so a
+  // retrospective fork classifies as `delegated_child` and carries its parent
+  // turn index on both paths. The wake path builds the identical snapshot via
+  // the same helper.
+  const usageOriginSnapshot = buildTurnUsageOriginSnapshot(ctx, turnCallSite);
 
   // Expose the turn's request origin (e.g. "memory_consolidation") on the live
   // conversation so the tool context — and through it `buildPolicyContext` —

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -68,6 +68,7 @@ import {
   startToolProfilingRequest,
 } from "../tools/tool-profiler.js";
 import type { UsageActor } from "../usage/actors.js";
+import { buildUsageOriginSnapshot } from "../usage/work-origin.js";
 import { getLogger } from "../util/logger.js";
 import { timeAgo } from "../util/time.js";
 import { getWorkspaceGitService } from "../workspace/git-service.js";
@@ -353,6 +354,24 @@ export async function runAgentLoopImpl(
   // Expose the turn's call site on the live conversation so the runtime
   // injection assembly self-resolves it for the turn's plugin contexts.
   ctx.currentCallSite = turnCallSite;
+
+  // Immutable record-time usage attribution for every LLM call this turn emits,
+  // carrying the same work-origin classification the `llm_usage` telemetry
+  // derives so managed billing rows and usage telemetry share one vocabulary.
+  // `turnIndex` is the current turn's 1-based position (`turnCount` holds the
+  // count of prior turns until incremented at turn end, matching the read
+  // path's "1-indexed position of the user turn this call belongs to").
+  // `parentConversationId` is the subagent-spawn parent; precise parent-turn
+  // attribution is resolved by the telemetry flush, so it rides null here.
+  const usageOriginSnapshot = buildUsageOriginSnapshot({
+    conversationType: ctx.conversationType ?? null,
+    conversationSource: ctx.source ?? null,
+    callSite: turnCallSite,
+    conversationId: ctx.conversationId,
+    turnIndex: ctx.turnCount + 1,
+    parentConversationId: ctx.parentConversationId ?? null,
+    parentTurnIndex: null,
+  });
 
   // Expose the turn's request origin (e.g. "memory_consolidation") on the live
   // conversation so the tool context — and through it `buildPolicyContext` —
@@ -1085,6 +1104,7 @@ export async function runAgentLoopImpl(
           isNonInteractive,
           modelProfileKey,
           latencyTracker,
+          usageOriginSnapshot,
           ...(ctx.modelOverride ? { model: ctx.modelOverride } : {}),
         }),
         abortController.signal,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -516,6 +516,15 @@ export class Conversation {
    * @internal
    */
   source?: string;
+  /**
+   * The source conversation this one was forked from
+   * (`conversations.fork_parent_conversation_id`), cached on load so the
+   * usage-attribution snapshot resolves a background fork's spawn parent
+   * (retrospective forks) without a per-turn DB row read. Undefined when the
+   * conversation is not a fork.
+   * @internal
+   */
+  forkParentConversationId?: string;
   /** @internal */ assistantId?: string;
   /** @internal */ commandIntent?: {
     type: string;
@@ -991,6 +1000,7 @@ export class Conversation {
     this.originInterface = parseInterfaceId(conv?.originInterface) ?? undefined;
     this.originChannel = parseChannelId(conv?.originChannel) ?? undefined;
     this.source = conv?.source ?? undefined;
+    this.forkParentConversationId = conv?.forkParentConversationId ?? undefined;
     this.contextSummary = conv?.contextSummary ?? null;
     this.slackContextCompactionWatermarkTs =
       conv?.slackContextCompactionWatermarkTs ?? null;

--- a/assistant/src/persistence/llm-usage-store.ts
+++ b/assistant/src/persistence/llm-usage-store.ts
@@ -18,7 +18,7 @@ import {
   type ScheduleAttributionFilter,
   type ScheduleAttributionSqlParam,
 } from "./schedule-attribution-sql.js";
-import { conversations, llmUsageEvents } from "./schema/index.js";
+import { conversations, llmUsageEvents, messages } from "./schema/index.js";
 import {
   bucketEventsByDay,
   bucketEventsByHour,
@@ -131,6 +131,46 @@ export function recordUsageEvent(
     })
     .run();
   return event;
+}
+
+/**
+ * Count the conversation's real user turns — the same population the
+ * `llm_usage` telemetry `turn_index` subquery counts in
+ * {@link queryUnreportedUsageEvents}: `role='user'` rows that survive
+ * {@link realUserTurnContentFilter} (tool-result continuations excluded).
+ * Shared through that filter so a call's billing-origin `turnIndex` (stamped
+ * live at agent-loop start) agrees with the `turn_index` the telemetry read
+ * path derives for the same call.
+ *
+ * Evaluated at loop start, once the turn's user message(s) are persisted, this
+ * equals telemetry's `created_at <=` count for the turn's LLM calls: a coalesced
+ * batch of N user messages persists all N rows before the single agent-loop run,
+ * and the processing lock blocks any further real user turn from landing until
+ * the run finishes — so no unbounded/bounded skew arises. Returns 0 for a
+ * conversation with no real user turn yet (matching the read path's
+ * pre-first-turn 0).
+ *
+ * Best-effort (mirroring {@link lookupConversationAttribution}): a query failure
+ * degrades to 0 rather than throwing, so a billing-attribution detail can never
+ * abort the user's turn.
+ */
+export function countRealUserTurns(conversationId: string): number {
+  try {
+    const row = getDb()
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(messages)
+      .where(
+        and(
+          eq(messages.conversationId, conversationId),
+          eq(messages.role, "user"),
+          realUserTurnContentFilter("messages"),
+        ),
+      )
+      .get();
+    return row?.count ? Number(row.count) : 0;
+  } catch {
+    return 0;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -27,6 +27,7 @@ mock.module("../registry.js", () => ({
 // ── Imports (after mocks) ───────────────────────────────────────────────────
 
 import { CODE_DEFAULT_PROFILE_ENTRIES } from "../../config/default-profile-catalog.js";
+import type { UsageOriginSnapshot } from "../../usage/work-origin.js";
 import { RetryProvider } from "../retry.js";
 import type {
   Message,
@@ -77,6 +78,21 @@ function setLlmConfig(raw: unknown): void {
   // Seed the raw fixture; the real loader schema-merges it over defaults, the
   // same cascade `getConfig().llm` produces in production.
   setConfig("llm", raw);
+}
+
+function makeSnapshot(
+  overrides: Partial<UsageOriginSnapshot> = {},
+): UsageOriginSnapshot {
+  return {
+    conversationType: null,
+    conversationSource: null,
+    workOrigin: null,
+    conversationId: null,
+    turnIndex: null,
+    parentConversationId: null,
+    parentTurnIndex: null,
+    ...overrides,
+  };
 }
 
 beforeEach(() => {
@@ -740,6 +756,168 @@ describe("RetryProvider — callSite resolution", () => {
 
     const config = seen?.config as Record<string, unknown>;
     expect(config.model).toBe("explicit-override");
+  });
+});
+
+// ── RetryProvider — billing-origin (X-Vellum-*) headers ─────────────────────
+//
+// `usageOriginSnapshot` rides the per-call config from conversation-aware call
+// sites. On the managed-proxy transport (`forwardUsageAttributionHeaders:
+// true`) `RetryProvider` maps it to the seven billing-origin headers, merges
+// them into `usageAttributionHeaders`, and strips the snapshot from the wire
+// config. Direct/user-key transports must receive neither.
+
+describe("RetryProvider — billing-origin headers", () => {
+  async function sendWithSnapshot(
+    snapshot: UsageOriginSnapshot,
+    opts: { forward: boolean } = { forward: true },
+  ): Promise<Record<string, unknown>> {
+    setLlmConfig({
+      callSites: {
+        mainAgent: { provider: "anthropic", model: "claude-x" },
+      },
+    });
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+      opts.forward ? { forwardUsageAttributionHeaders: true } : {},
+    );
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent", usageOriginSnapshot: snapshot },
+    });
+    return seen?.config as Record<string, unknown>;
+  }
+
+  test("forwards the full snapshot as merged X-Vellum-* headers and strips the snapshot", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({
+        conversationType: "standard",
+        conversationSource: "user",
+        workOrigin: "delegated_child",
+        conversationId: "conv-123",
+        turnIndex: 3,
+        parentConversationId: "conv-parent",
+        parentTurnIndex: 2,
+      }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Conversation-Type"]).toBe("standard");
+    expect(headers["X-Vellum-Conversation-Source"]).toBe("user");
+    expect(headers["X-Vellum-Work-Origin"]).toBe("delegated_child");
+    expect(headers["X-Vellum-Conversation-Id"]).toBe("conv-123");
+    expect(headers["X-Vellum-Turn-Index"]).toBe("3");
+    expect(headers["X-Vellum-Parent-Conversation-Id"]).toBe("conv-parent");
+    expect(headers["X-Vellum-Parent-Turn-Index"]).toBe("2");
+    // Merged alongside the call-site attribution headers, not replacing them.
+    expect(headers["X-Vellum-LLM-Call-Site"]).toBe("mainAgent");
+    expect(headers["X-Vellum-Resolved-Provider"]).toBe("anthropic");
+    expect(headers["X-Vellum-Resolved-Model"]).toBe("claude-x");
+    // The snapshot itself is a routing concern and must never reach the wire.
+    expect(config.usageOriginSnapshot).toBeUndefined();
+  });
+
+  test("omits null fields from a partial snapshot", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({
+        conversationType: "background",
+        conversationSource: "subagent",
+        workOrigin: "user_created_background",
+        conversationId: "conv-partial",
+        // turnIndex + parent linkage unresolved at send time.
+      }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Conversation-Type"]).toBe("background");
+    expect(headers["X-Vellum-Conversation-Source"]).toBe("subagent");
+    expect(headers["X-Vellum-Work-Origin"]).toBe("user_created_background");
+    expect(headers["X-Vellum-Conversation-Id"]).toBe("conv-partial");
+    expect("X-Vellum-Turn-Index" in headers).toBe(false);
+    expect("X-Vellum-Parent-Conversation-Id" in headers).toBe(false);
+    expect("X-Vellum-Parent-Turn-Index" in headers).toBe(false);
+  });
+
+  test("auxiliary (no conversation) snapshot emits only the work-origin billing header", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({ workOrigin: "memory_maintenance" }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    // Work origin is the only non-null billing-origin field; the conversation
+    // ids/type/source headers are all omitted.
+    expect(headers["X-Vellum-Work-Origin"]).toBe("memory_maintenance");
+    expect("X-Vellum-Conversation-Type" in headers).toBe(false);
+    expect("X-Vellum-Conversation-Source" in headers).toBe(false);
+    expect("X-Vellum-Conversation-Id" in headers).toBe(false);
+    expect("X-Vellum-Turn-Index" in headers).toBe(false);
+    expect("X-Vellum-Parent-Conversation-Id" in headers).toBe(false);
+    expect("X-Vellum-Parent-Turn-Index" in headers).toBe(false);
+  });
+
+  test("parent-linked snapshot carries the parent conversation/turn headers", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({
+        conversationType: "background",
+        conversationSource: "subagent",
+        workOrigin: "delegated_child",
+        conversationId: "conv-child",
+        parentConversationId: "conv-root",
+        parentTurnIndex: 5,
+      }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Parent-Conversation-Id"]).toBe("conv-root");
+    expect(headers["X-Vellum-Parent-Turn-Index"]).toBe("5");
+    expect(headers["X-Vellum-Work-Origin"]).toBe("delegated_child");
+  });
+
+  test("turn index 0 is a valid non-negative integer and is emitted", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({ conversationId: "conv-zero", turnIndex: 0 }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Turn-Index"]).toBe("0");
+  });
+
+  test("omits values that violate the platform charset / integer contract", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({
+        // Space is outside `^[A-Za-z0-9._:@/-]+$` — omit the whole value
+        // rather than send a value the platform sanitizer would reject.
+        conversationId: "conv 123",
+        conversationType: "standard",
+        workOrigin: "user_interactive",
+        // Negative and non-integer indexes are not decimal turn indexes.
+        turnIndex: -1,
+        parentConversationId: "conv-ok",
+        parentTurnIndex: 2.5,
+      }),
+    );
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect("X-Vellum-Conversation-Id" in headers).toBe(false);
+    expect("X-Vellum-Turn-Index" in headers).toBe(false);
+    expect("X-Vellum-Parent-Turn-Index" in headers).toBe(false);
+    // Valid siblings still flow.
+    expect(headers["X-Vellum-Conversation-Type"]).toBe("standard");
+    expect(headers["X-Vellum-Work-Origin"]).toBe("user_interactive");
+    expect(headers["X-Vellum-Parent-Conversation-Id"]).toBe("conv-ok");
+  });
+
+  test("user-key / direct provider transports receive NO billing-origin headers", async () => {
+    const config = await sendWithSnapshot(
+      makeSnapshot({
+        conversationType: "standard",
+        conversationSource: "user",
+        workOrigin: "user_interactive",
+        conversationId: "conv-123",
+        turnIndex: 1,
+      }),
+      { forward: false },
+    );
+    // No managed proxy → no attribution headers at all (billing or call-site).
+    expect(config.usageAttributionHeaders).toBeUndefined();
+    // The snapshot is still stripped from the wire config on every transport.
+    expect(config.usageOriginSnapshot).toBeUndefined();
   });
 });
 

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -4,6 +4,7 @@ import {
   resolveUsageAttribution,
   sanitizeUsageMetadataValue,
 } from "../usage/attribution.js";
+import type { UsageOriginSnapshot } from "../usage/work-origin.js";
 import { ProviderError, type ProviderErrorReason } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -42,6 +43,27 @@ const USAGE_ATTRIBUTION_HEADER_NAMES = {
   resolvedModel: "X-Vellum-Resolved-Model",
   resolvedMixArm: "X-Vellum-Resolved-Mix-Arm",
 } as const;
+
+/** Billing-origin attribution headers derived from a
+ *  {@link UsageOriginSnapshot}, forwarded only on the managed-proxy transport
+ *  path so the billing backend can key rows by the same work-origin vocabulary
+ *  the `llm_usage` telemetry uses. */
+const USAGE_ORIGIN_HEADER_NAMES = {
+  conversationType: "X-Vellum-Conversation-Type",
+  conversationSource: "X-Vellum-Conversation-Source",
+  workOrigin: "X-Vellum-Work-Origin",
+  conversationId: "X-Vellum-Conversation-Id",
+  turnIndex: "X-Vellum-Turn-Index",
+  parentConversationId: "X-Vellum-Parent-Conversation-Id",
+  parentTurnIndex: "X-Vellum-Parent-Turn-Index",
+} as const;
+
+/** Platform header-sanitizer contract: accepted values match this charset and
+ *  cap at {@link MAX_ORIGIN_HEADER_VALUE_LENGTH} characters. Values outside the
+ *  contract are omitted rather than truncated/rewritten — a corrupted billing
+ *  identifier is worse than an absent one. */
+const ORIGIN_HEADER_VALUE_PATTERN = /^[A-Za-z0-9._:@/-]+$/;
+const MAX_ORIGIN_HEADER_VALUE_LENGTH = 256;
 
 /** Providers whose transports consume `promptCacheKey` (OpenAI Responses
  *  `prompt_cache_key`); `RetryProvider` derives it from `selectionSeed` for
@@ -365,6 +387,10 @@ function normalizeSendMessageOptions(
   delete nextConfig.forceOverrideProfile;
   delete nextConfig.selectionSeed;
   delete nextConfig.conversationId;
+  // Attribution-only: mapped to billing-origin headers below (managed-proxy
+  // path) and never a wire-format field. Strip unconditionally so it cannot
+  // leak into a provider request body.
+  delete nextConfig.usageOriginSnapshot;
 
   if (config.callSite !== undefined) {
     const resolved = resolveCallSiteConfig(config.callSite, getConfig().llm, {
@@ -488,6 +514,27 @@ function normalizeSendMessageOptions(
     // leaks unknown fields into provider request bodies — Anthropic (and other
     // strict-schema clients) reject the request with
     // "Extra inputs are not permitted".
+  }
+
+  // Billing-origin attribution headers share the managed-proxy-only forwarding
+  // gate with the call-site attribution headers above, but derive from the
+  // immutable `usageOriginSnapshot` a conversation-aware call site stamped
+  // rather than from call-site resolution — so they flow even for a snapshot
+  // carried without a `callSite`. Sanitized to the platform header contract and
+  // merged into the same header map the transport forwards; null snapshot
+  // fields are omitted entirely.
+  if (
+    normalizeOptions.forwardUsageAttributionHeaders === true &&
+    config.usageOriginSnapshot
+  ) {
+    const originHeaders = buildUsageOriginHeaders(config.usageOriginSnapshot);
+    if (Object.keys(originHeaders).length > 0) {
+      const existing =
+        (nextConfig.usageAttributionHeaders as
+          | Record<string, string>
+          | undefined) ?? {};
+      nextConfig.usageAttributionHeaders = { ...existing, ...originHeaders };
+    }
   }
 
   // Convert schema-shape `{ enabled, streamThinking }` into Anthropic's
@@ -758,6 +805,103 @@ function addSanitizedHeader(
   if (sanitized != null) {
     headers[name] = sanitized;
   }
+}
+
+/**
+ * Map a {@link UsageOriginSnapshot} to the seven `X-Vellum-*` billing-origin
+ * headers, sanitizing each value to the platform header-sanitizer contract and
+ * omitting any null/invalid field entirely. Ids and vocabulary values go
+ * through the string charset gate; turn indexes serialize only as non-negative
+ * decimal integers.
+ */
+function buildUsageOriginHeaders(
+  snapshot: UsageOriginSnapshot,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  addOriginStringHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.conversationType,
+    snapshot.conversationType,
+  );
+  addOriginStringHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.conversationSource,
+    snapshot.conversationSource,
+  );
+  addOriginStringHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.workOrigin,
+    snapshot.workOrigin,
+  );
+  addOriginStringHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.conversationId,
+    snapshot.conversationId,
+  );
+  addOriginStringHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.parentConversationId,
+    snapshot.parentConversationId,
+  );
+  addOriginTurnIndexHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.turnIndex,
+    snapshot.turnIndex,
+  );
+  addOriginTurnIndexHeader(
+    headers,
+    USAGE_ORIGIN_HEADER_NAMES.parentTurnIndex,
+    snapshot.parentTurnIndex,
+  );
+  return headers;
+}
+
+function addOriginStringHeader(
+  headers: Record<string, string>,
+  name: string,
+  value: string | null,
+): void {
+  const sanitized = sanitizeOriginHeaderValue(value);
+  if (sanitized != null) {
+    headers[name] = sanitized;
+  }
+}
+
+function addOriginTurnIndexHeader(
+  headers: Record<string, string>,
+  name: string,
+  value: number | null,
+): void {
+  const sanitized = sanitizeOriginTurnIndex(value);
+  if (sanitized != null) {
+    headers[name] = sanitized;
+  }
+}
+
+/** Enforce the platform charset + length contract; omit (return null) any value
+ *  that violates it rather than rewriting it. */
+function sanitizeOriginHeaderValue(value: string | null): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > MAX_ORIGIN_HEADER_VALUE_LENGTH ||
+    !ORIGIN_HEADER_VALUE_PATTERN.test(trimmed)
+  ) {
+    return null;
+  }
+  return trimmed;
+}
+
+/** Serialize a turn index as a non-negative decimal integer; omit anything
+ *  else (null, non-integer, negative). */
+function sanitizeOriginTurnIndex(value: number | null): string | null {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    return null;
+  }
+  return String(value);
 }
 
 /**

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -2,6 +2,7 @@ import type { ToolDefinition } from "../tools/tool-types.js";
 export type { ToolDefinition };
 
 import type { LLMCallSite } from "../config/schemas/llm.js";
+import type { UsageOriginSnapshot } from "../usage/work-origin.js";
 import { ProviderError, type ProviderErrorReason } from "../util/errors.js";
 
 export interface TextContent {
@@ -280,6 +281,16 @@ export interface SendMessageConfig {
    * JSON request bodies.
    */
   usageAttributionHeaders?: Record<string, string>;
+  /**
+   * Immutable record-time attribution of *why* this LLM call happened,
+   * populated by conversation-aware call sites. `RetryProvider` maps it to the
+   * seven `X-Vellum-*` billing-origin headers (conversation type/source, work
+   * origin, conversation/turn ids, parent conversation/turn ids) and merges
+   * them into {@link usageAttributionHeaders} only on the managed-proxy
+   * transport path. A resolution/routing-time concern only; stripped before any
+   * provider wire request so it never leaks into a JSON request body.
+   */
+  usageOriginSnapshot?: UsageOriginSnapshot;
   /**
    * Controls local usage-ledger writes for attributed provider calls.
    * Defaults to `auto`; conversation paths that aggregate usage separately

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -56,6 +56,13 @@ interface WakeConversationProbe {
      * system prompt before `agentLoop.run()`.
      */
     personaOverride?: unknown;
+    /**
+     * The immutable billing-origin `usageOriginSnapshot` forwarded on the run
+     * config — the wake path must build it from the live conversation (via
+     * `buildTurnUsageOriginSnapshot`) so scheduled / retrospective / background
+     * wakes send the same `X-Vellum-*` headers a normal turn does.
+     */
+    usageOriginSnapshot?: unknown;
     order: number;
   }>;
   /** Every `setProcessing` value, in call order. */
@@ -187,7 +194,9 @@ mock.module("../assistant-event-hub.js", () => ({
     const probe = frame.conversationId
       ? wakeConvRegistry.get(frame.conversationId)
       : undefined;
-    if (!probe) return;
+    if (!probe) {
+      return;
+    }
     if (frame.type === "ui_surface_show") {
       const source = (
         frame.data as
@@ -331,6 +340,37 @@ mock.module("../../persistence/llm-request-log-store.js", () => ({
     return "log-id-test";
   },
   backfillMessageIdOnLogs: () => {},
+}));
+
+// Stub the DB-backed billing-origin snapshot assembly (it counts real user
+// turns via `countRealUserTurns`, which needs a live SQLite DB these unit
+// tests don't set up). Records its call args and returns a fixed sentinel so
+// tests can assert the wake builds the snapshot from the live conversation and
+// forwards it verbatim onto `agentLoop.run`.
+const buildTurnUsageOriginSnapshotCalls: Array<{
+  conversationId: string;
+  callSite: string | null;
+}> = [];
+const SENTINEL_USAGE_ORIGIN_SNAPSHOT = {
+  conversationType: "background",
+  conversationSource: "memory-retrospective",
+  workOrigin: "delegated_child",
+  conversationId: "sentinel-conv",
+  turnIndex: 2,
+  parentConversationId: "sentinel-parent",
+  parentTurnIndex: 5,
+};
+mock.module("../../usage/usage-origin-snapshot.js", () => ({
+  buildTurnUsageOriginSnapshot: (
+    conversation: { conversationId: string },
+    callSite: string | null,
+  ) => {
+    buildTurnUsageOriginSnapshotCalls.push({
+      conversationId: conversation.conversationId,
+      callSite,
+    });
+    return SENTINEL_USAGE_ORIGIN_SNAPSHOT;
+  },
 }));
 
 import type {
@@ -512,6 +552,7 @@ function makeWakeConversation(options: {
           trust: options.trust,
           allowedTools: snapshotAllowedTools(),
           personaOverride: wakePersonaOverride,
+          usageOriginSnapshot: options.usageOriginSnapshot,
           order: order++,
         });
         return runBody(input, onEvent, options);
@@ -606,6 +647,7 @@ beforeEach(() => {
   wakeConvRegistry.clear();
   recordRequestLogCalls.length = 0;
   recordUsageCalls.length = 0;
+  buildTurnUsageOriginSnapshotCalls.length = 0;
   publishMessagesChangedCalls.length = 0;
   mockGetOrCreateConversationCalls.length = 0;
   mockResolverTarget = null;
@@ -646,6 +688,35 @@ describe("wakeAgentForOpportunity", () => {
 
     expect(result).toEqual({ invoked: true, producedToolCalls: false });
     expect(conversation.runCalls).toHaveLength(1);
+  });
+
+  test("forwards a billing-origin usageOriginSnapshot built from the live conversation onto agentLoop.run", async () => {
+    const conversation = makeWakeConversation({
+      conversationId: "retro-fork-1",
+      scriptedAssistant: null,
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "retrospective",
+        source: "memory-retrospective",
+        callSite: "memoryRetrospective",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(conversation.runCalls).toHaveLength(1);
+    // The wake built the snapshot from THIS conversation and the resolved call
+    // site, then forwarded the exact snapshot onto the run config — so the
+    // managed proxy sends the same X-Vellum-* headers a normal turn would.
+    expect(buildTurnUsageOriginSnapshotCalls).toEqual([
+      { conversationId: "retro-fork-1", callSite: "memoryRetrospective" },
+    ]);
+    expect(conversation.runCalls[0]!.usageOriginSnapshot).toBe(
+      SENTINEL_USAGE_ORIGIN_SNAPSHOT,
+    );
   });
 
   test("blocks background wakes during disk pressure before marking processing", async () => {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -114,6 +114,7 @@ import {
   wrapUntrustedContent,
 } from "../security/untrusted-content.js";
 import type { CompletedBackgroundTool } from "../tools/background-tool-registry.js";
+import { buildTurnUsageOriginSnapshot } from "../usage/usage-origin-snapshot.js";
 import { getLogger } from "../util/logger.js";
 import { createKeyedSingleFlight } from "../util/single-flight.js";
 
@@ -1349,6 +1350,17 @@ export async function wakeAgentForOpportunity(
         conversation.currentTurnTrustContext = opts.trustContext;
       }
 
+      // Immutable record-time usage attribution for every LLM call this wake
+      // emits. Built from the SAME helper `runAgentLoopImpl` uses, so a
+      // scheduled / retrospective / background wake carries the same
+      // work-origin classification, turn indexes, and spawn-parent linkage as a
+      // normal turn — without it these wakes recorded llm_usage but sent no
+      // billing-origin headers on the managed proxy.
+      const usageOriginSnapshot = buildTurnUsageOriginSnapshot(
+        conversation,
+        callSite,
+      );
+
       let updatedHistory: Message[];
       try {
         ({ history: updatedHistory } = await conversation.agentLoop.run({
@@ -1356,6 +1368,7 @@ export async function wakeAgentForOpportunity(
           onEvent,
           requestId: `wake:${source}`,
           onCheckpoint,
+          usageOriginSnapshot,
           // Route through the caller-supplied call site (defaults to
           // `mainAgent` so a normal user-turn wake shares the user's chat
           // selection). Without an explicit callSite, the resolver in

--- a/assistant/src/usage/usage-origin-snapshot.ts
+++ b/assistant/src/usage/usage-origin-snapshot.ts
@@ -1,0 +1,72 @@
+import { countRealUserTurns } from "../persistence/llm-usage-store.js";
+import {
+  buildUsageOriginSnapshot,
+  resolveSpawnParentConversationId,
+  type UsageOriginSnapshot,
+} from "./work-origin.js";
+
+/**
+ * The conversation-level fields a per-turn {@link UsageOriginSnapshot} is
+ * assembled from. A structural subset of `Conversation` so both the normal
+ * agent-loop wrapper (`runAgentLoopImpl`) and the background wake path
+ * (`wakeAgentForOpportunity`) can build the snapshot from their live
+ * conversation without depending on the class.
+ */
+export interface ConversationUsageOriginContext {
+  conversationId: string;
+  conversationType?: string | null;
+  source?: string | null;
+  parentConversationId?: string | null;
+  forkParentConversationId?: string | null;
+}
+
+/**
+ * Assemble the immutable per-turn {@link UsageOriginSnapshot} for a live
+ * conversation turn — the single assembly point shared by every path that
+ * records LLM usage (`runAgentLoopImpl` for user/subagent turns,
+ * `wakeAgentForOpportunity` for scheduled / retrospective / background wakes).
+ *
+ * Both turn indexes are derived from the SAME real-user-turn population the
+ * `llm_usage` telemetry read path counts (via {@link countRealUserTurns}), so
+ * the managed billing-origin headers and usage telemetry agree:
+ *
+ * - `turnIndex` counts this conversation's own real user turns (evaluated once
+ *   the turn's user message(s) are persisted).
+ * - `parentTurnIndex` counts the SPAWNING conversation's real user turns — a
+ *   best-effort live approximation of the telemetry read path's parent-turn
+ *   cutoff — and is null when this conversation was not spawned by another. It
+ *   mirrors the telemetry `parentTurnIndex`, which is a count (never null) when
+ *   a spawn parent exists and null otherwise.
+ *
+ * Both `countRealUserTurns` calls are best-effort (a query failure degrades to
+ * 0 rather than aborting the turn). The subagent/background-fork lineage
+ * precedence lives in {@link resolveSpawnParentConversationId}, shared with
+ * {@link buildUsageOriginSnapshot} and the telemetry classifier.
+ */
+export function buildTurnUsageOriginSnapshot(
+  conversation: ConversationUsageOriginContext,
+  callSite: string | null,
+): UsageOriginSnapshot {
+  const parentConversationId = conversation.parentConversationId ?? null;
+  const forkParentConversationId =
+    conversation.forkParentConversationId ?? null;
+  const conversationType = conversation.conversationType ?? null;
+  const spawnParentConversationId = resolveSpawnParentConversationId({
+    parentConversationId,
+    conversationType,
+    forkParentConversationId,
+  });
+  return buildUsageOriginSnapshot({
+    conversationType,
+    conversationSource: conversation.source ?? null,
+    callSite,
+    conversationId: conversation.conversationId,
+    turnIndex: countRealUserTurns(conversation.conversationId),
+    parentConversationId,
+    forkParentConversationId,
+    parentTurnIndex:
+      spawnParentConversationId !== null
+        ? countRealUserTurns(spawnParentConversationId)
+        : null,
+  });
+}

--- a/assistant/src/usage/work-origin.test.ts
+++ b/assistant/src/usage/work-origin.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildUsageOriginSnapshot,
   classifyWorkOrigin,
+  resolveSpawnParentConversationId,
   type WorkOrigin,
   type WorkOriginInput,
 } from "./work-origin.js";
@@ -223,4 +225,113 @@ describe("classifyWorkOrigin", () => {
       expect(classifyWorkOrigin(c.input)).toBe(c.expected);
     });
   }
+});
+
+describe("resolveSpawnParentConversationId", () => {
+  test("subagent parent wins over a fork parent", () => {
+    expect(
+      resolveSpawnParentConversationId({
+        parentConversationId: "parent-1",
+        conversationType: "background",
+        forkParentConversationId: "source-1",
+      }),
+    ).toBe("parent-1");
+  });
+
+  test("background fork falls back to the fork parent", () => {
+    expect(
+      resolveSpawnParentConversationId({
+        parentConversationId: null,
+        conversationType: "background",
+        forkParentConversationId: "source-1",
+      }),
+    ).toBe("source-1");
+  });
+
+  test("standard (user-initiated) fork does NOT resolve the fork parent", () => {
+    expect(
+      resolveSpawnParentConversationId({
+        parentConversationId: null,
+        conversationType: "standard",
+        forkParentConversationId: "source-1",
+      }),
+    ).toBeNull();
+  });
+
+  test("no parent and no fork → null", () => {
+    expect(
+      resolveSpawnParentConversationId({
+        parentConversationId: null,
+        conversationType: "standard",
+        forkParentConversationId: null,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("buildUsageOriginSnapshot — spawn-parent resolution", () => {
+  // A retrospective-fork background conversation: no live subagent parent, but
+  // its `fork_parent_conversation_id` points back at the source. The snapshot
+  // must resolve the fork parent and classify `delegated_child`, matching the
+  // telemetry read path's `parentIdSql` fallback + `classifyWorkOrigin` for the
+  // same conversation (see the "parent linkage falls back to
+  // fork_parent_conversation_id" case in llm-usage-store.test.ts).
+  test("retrospective fork carries the fork parent and classifies delegated_child", () => {
+    const snapshot = buildUsageOriginSnapshot({
+      conversationType: "background",
+      conversationSource: "memory-retrospective",
+      callSite: "memoryRetrospective",
+      conversationId: "retro-1",
+      turnIndex: 1,
+      parentConversationId: null,
+      forkParentConversationId: "source-1",
+      parentTurnIndex: null,
+    });
+    expect(snapshot.parentConversationId).toBe("source-1");
+    expect(snapshot.workOrigin).toBe("delegated_child");
+    // Telemetry resolves the identical parent for the same row and runs the
+    // same classifier, so the two agree.
+    expect(
+      classifyWorkOrigin({
+        conversationType: "background",
+        conversationSource: "memory-retrospective",
+        callSite: "memoryRetrospective",
+        parentConversationId: resolveSpawnParentConversationId({
+          parentConversationId: null,
+          conversationType: "background",
+          forkParentConversationId: "source-1",
+        }),
+      }),
+    ).toBe("delegated_child");
+  });
+
+  test("subagent spawn keeps the live parent (fork parent unset)", () => {
+    const snapshot = buildUsageOriginSnapshot({
+      conversationType: "background",
+      conversationSource: "subagent",
+      callSite: "subagentSpawn",
+      conversationId: "child-1",
+      turnIndex: 1,
+      parentConversationId: "parent-1",
+      forkParentConversationId: null,
+      parentTurnIndex: null,
+    });
+    expect(snapshot.parentConversationId).toBe("parent-1");
+    expect(snapshot.workOrigin).toBe("delegated_child");
+  });
+
+  test("standard user fork keeps itself (no delegated attribution)", () => {
+    const snapshot = buildUsageOriginSnapshot({
+      conversationType: "standard",
+      conversationSource: "user",
+      callSite: "mainAgent",
+      conversationId: "user-fork-1",
+      turnIndex: 2,
+      parentConversationId: null,
+      forkParentConversationId: "source-1",
+      parentTurnIndex: null,
+    });
+    expect(snapshot.parentConversationId).toBeNull();
+    expect(snapshot.workOrigin).toBe("user_interactive");
+  });
 });

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -172,6 +172,32 @@ export function classifyWorkOrigin(input: WorkOriginInput): WorkOrigin {
 }
 
 /**
+ * Resolve the id of the conversation that spawned this one, applying the same
+ * precedence the `llm_usage` telemetry read path encodes in its `parentIdSql`
+ * (see {@link queryUnreportedUsageEvents}): the live subagent-spawn parent
+ * (`parent_conversation_id`) wins; failing that, a `background` conversation
+ * falls back to its `fork_parent_conversation_id` (retrospective forks), so a
+ * fork's usage is attributed to the delegating turn. User-initiated forks also
+ * stamp `fork_parent_conversation_id` but are first-class `standard`
+ * conversations whose usage belongs to themselves, so the fallback is gated to
+ * `background` — matching the telemetry query exactly. Null when the
+ * conversation was not spawned by another.
+ */
+export function resolveSpawnParentConversationId(input: {
+  parentConversationId: string | null;
+  conversationType: string | null;
+  forkParentConversationId: string | null;
+}): string | null {
+  if (input.parentConversationId !== null) {
+    return input.parentConversationId;
+  }
+  if (input.conversationType === "background") {
+    return input.forkParentConversationId;
+  }
+  return null;
+}
+
+/**
  * An immutable, record-time attribution of an in-flight LLM call, carried on
  * the provider send config so the managed-proxy transport can forward it to
  * the billing backend as `X-Vellum-*` headers. Every field is explicitly
@@ -187,6 +213,10 @@ export function classifyWorkOrigin(input: WorkOriginInput): WorkOrigin {
  * descendant attribution (subagent spawns, background forks); null when the
  * conversation was not spawned by another or the linkage is unresolved at send
  * time (the usage telemetry resolves precise parent-turn attribution at flush).
+ * `parentConversationId` is the resolved spawn parent
+ * ({@link resolveSpawnParentConversationId}) — the subagent-spawn parent, or a
+ * background fork's source conversation — so it classifies as `delegated_child`
+ * identically to the telemetry row.
  */
 export interface UsageOriginSnapshot {
   conversationType: string | null;
@@ -203,6 +233,13 @@ export interface UsageOriginSnapshot {
  * from the same {@link classifyWorkOrigin} the usage telemetry uses. Callers pass
  * the record-time conversation metadata and call site; nulls are preserved
  * verbatim so auxiliary (no-conversation) calls stay distinguishable.
+ *
+ * The spawn parent is resolved via {@link resolveSpawnParentConversationId} —
+ * the live subagent-spawn `parentConversationId`, with a `background`-only
+ * fallback to `forkParentConversationId` — mirroring the telemetry read path's
+ * `parentIdSql`. Passing the fork lineage in (rather than a pre-resolved
+ * parent) keeps the subagent/fork precedence in one place shared with the
+ * telemetry classifier.
  */
 export function buildUsageOriginSnapshot(input: {
   conversationType: string | null;
@@ -211,8 +248,14 @@ export function buildUsageOriginSnapshot(input: {
   conversationId: string | null;
   turnIndex: number | null;
   parentConversationId: string | null;
+  forkParentConversationId: string | null;
   parentTurnIndex: number | null;
 }): UsageOriginSnapshot {
+  const spawnParentConversationId = resolveSpawnParentConversationId({
+    parentConversationId: input.parentConversationId,
+    conversationType: input.conversationType,
+    forkParentConversationId: input.forkParentConversationId,
+  });
   return {
     conversationType: input.conversationType,
     conversationSource: input.conversationSource,
@@ -220,11 +263,11 @@ export function buildUsageOriginSnapshot(input: {
       conversationType: input.conversationType,
       conversationSource: input.conversationSource,
       callSite: input.callSite,
-      parentConversationId: input.parentConversationId,
+      parentConversationId: spawnParentConversationId,
     }),
     conversationId: input.conversationId,
     turnIndex: input.turnIndex,
-    parentConversationId: input.parentConversationId,
+    parentConversationId: spawnParentConversationId,
     parentTurnIndex: input.parentTurnIndex,
   };
 }

--- a/assistant/src/usage/work-origin.ts
+++ b/assistant/src/usage/work-origin.ts
@@ -170,3 +170,61 @@ export function classifyWorkOrigin(input: WorkOriginInput): WorkOrigin {
   }
   return "unknown";
 }
+
+/**
+ * An immutable, record-time attribution of an in-flight LLM call, carried on
+ * the provider send config so the managed-proxy transport can forward it to
+ * the billing backend as `X-Vellum-*` headers. Every field is explicitly
+ * nullable so a non-conversation auxiliary call stays distinguishable from a
+ * conversation-scoped one (null ≠ "unattributed default"). The {@link workOrigin}
+ * is the SAME bucket the `llm_usage` telemetry read path derives via
+ * {@link classifyWorkOrigin}, so managed billing rows and usage telemetry share
+ * one classifier and vocabulary.
+ *
+ * `turnIndex` is the 1-indexed position of the user turn the call belongs to,
+ * matching the `llm_usage` read-path convention. `parentConversationId` /
+ * `parentTurnIndex` carry the spawning conversation's linkage for billed
+ * descendant attribution (subagent spawns, background forks); null when the
+ * conversation was not spawned by another or the linkage is unresolved at send
+ * time (the usage telemetry resolves precise parent-turn attribution at flush).
+ */
+export interface UsageOriginSnapshot {
+  conversationType: string | null;
+  conversationSource: string | null;
+  workOrigin: WorkOrigin | null;
+  conversationId: string | null;
+  turnIndex: number | null;
+  parentConversationId: string | null;
+  parentTurnIndex: number | null;
+}
+
+/**
+ * Build a {@link UsageOriginSnapshot}, deriving {@link UsageOriginSnapshot.workOrigin}
+ * from the same {@link classifyWorkOrigin} the usage telemetry uses. Callers pass
+ * the record-time conversation metadata and call site; nulls are preserved
+ * verbatim so auxiliary (no-conversation) calls stay distinguishable.
+ */
+export function buildUsageOriginSnapshot(input: {
+  conversationType: string | null;
+  conversationSource: string | null;
+  callSite: string | null;
+  conversationId: string | null;
+  turnIndex: number | null;
+  parentConversationId: string | null;
+  parentTurnIndex: number | null;
+}): UsageOriginSnapshot {
+  return {
+    conversationType: input.conversationType,
+    conversationSource: input.conversationSource,
+    workOrigin: classifyWorkOrigin({
+      conversationType: input.conversationType,
+      conversationSource: input.conversationSource,
+      callSite: input.callSite,
+      parentConversationId: input.parentConversationId,
+    }),
+    conversationId: input.conversationId,
+    turnIndex: input.turnIndex,
+    parentConversationId: input.parentConversationId,
+    parentTurnIndex: input.parentTurnIndex,
+  };
+}


### PR DESCRIPTION
## Why

PR 4 of the Inference Cost Instrumentation Gap Plan. Authoritative billed rows and `llm_usage` telemetry must share one origin/lineage vocabulary so billed dollars reconcile to telemetry estimates and descendant costs attribute to root turns.

**Stacked on #39057 (PR 2) — merge that first**; also requires platform vellum-ai/vellum-assistant-platform#9478 (PR 3, the trusted header map) deployed before values are recorded.

## What

- Immutable `UsageOriginSnapshot` on the provider send-message config, built once per turn in the conversation loop (conversation type/source, work origin via the same `classifyWorkOrigin()` as telemetry, conversation/turn ids, parent linkage). Explicit nulls keep auxiliary non-conversation calls distinguishable.
- The seven `X-Vellum-*` headers ride the existing `usageAttributionHeaders` mechanism and are attached ONLY when `forwardUsageAttributionHeaders` is true (managed-proxy / platform-auth transports). Direct/user-key calls get none (test-asserted). Values sanitized to the platform contract (charset, ≤256, non-negative decimal turn indexes); invalid values omitted, never rewritten.
- Subagent conversations ride the same path — `parentConversationId` yields `delegated_child`, giving billed descendant-cost attribution.

## Verification

- 46 retry-callsite tests (8 new: full/partial/auxiliary/parent-linked snapshots, sanitization, direct-transport negative); PR2 classifier + retry regression + config plumbing suites green; typecheck/lint clean; no new circular deps.
- Post-deploy: platform `runtime_proxy` usage metadata gains work_origin/lineage on managed rows; coverage measurable by rollout date in the billed mart (platform #9480).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->