### PR TITLE
refactor(web): two-column Assistant Access key

### DIFF
--- a/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
@@ -62,10 +62,12 @@ export interface SlackChannelTierLegendProps {
 
 /**
  * Always-visible Assistant Access key at the foot of the channel list card:
- * every tier as a compact "label + what it does" pair, laid out side by side so
- * the meaning is on screen without opening anything. The full behavior sentence
- * rides each pair's hover tooltip. The tier the global default resolves to is
- * marked "· default", matching the per-row picker so the two read together.
+ * every tier as a compact "label + what it does" pair in a two-column grid, so
+ * the meaning is on screen without opening anything. The terse sublabel shows
+ * inline (the touch-reachable case); the full behavior sentence rides each
+ * pair's hover/description `title` as progressive enhancement. The tier the
+ * global default resolves to is marked "· default", matching the per-row picker
+ * so the two read together.
  */
 export function SlackChannelTierLegend({
   assistantName,
@@ -76,7 +78,7 @@ export function SlackChannelTierLegend({
       <Typography as="span" variant="body-small-emphasised">
         Assistant Access levels
       </Typography>
-      <ul className="flex flex-wrap gap-x-4 gap-y-1.5">
+      <ul className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
         {CAPABILITY_TIER_VALUES.map((tier) => {
           const meta = CAPABILITY_TIER_META[tier];
           return (


### PR DESCRIPTION
## Prompt / plan
Follow-up to #39053. The always-visible "Assistant Access levels" key at the foot of the Slack channel list shipped as a wrapping inline row; this lays it back out as a **two-column grid** so the four levels read as an organized key, keeping the terse sublabels inline. The short sublabel shows inline (the touch-reachable case, addressing the iOS `title`-tooltip note from #39053 review); the full behavior sentence stays on each entry's hover/description `title` as progressive enhancement.

This is the first, self-contained slice of the channels-settings follow-up. The larger channel-type → default mapping (Public/Private/DM) and the gateway change to forward the Slack room-kind are tracked as separate PRs.

## Test plan
- `bunx tsc --noEmit` and ESLint clean (pre-commit hook).
- Re-verified each tier's copy against the live approval pipeline — Strict = asks before acting, Conservative = safe reads only, Relaxed = broader lookups, Full access = answers on its own; writes/sends/spends always escalate at every level (the sensitive-tool floor).
- Storybook visual check of `Channels/SlackChannelList` (two-column key at the card foot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeiZ9nRv2AdHtBCcGmCoJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeiZ9nRv2AdHtBCcGmCoJY)_