### PR TITLE
feat(assistant): add lightweight attachment history contract

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -1705,7 +1705,9 @@ paths:
     get:
       operationId: attachments_by_id_content_get
       summary: Get attachment content
-      description: Serve raw file bytes for an attachment. Supports Range headers.
+      description:
+        Serve original attachment bytes by default. Set representation=display for browser-displayable image bytes;
+        display representations do not support Range requests.
       tags:
         - attachments
       parameters:
@@ -1714,6 +1716,17 @@ paths:
           required: true
           schema:
             type: string
+        - name: representation
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - original
+              - display
+          description:
+            Content representation. 'original' preserves stored bytes and Range behavior; 'display' returns
+            browser-displayable bytes and rejects Range requests.
       responses:
         "200":
           description: Successful response
@@ -1722,6 +1735,10 @@ paths:
               schema:
                 type: string
                 format: binary
+        "400":
+          description: Invalid representation
+        "415":
+          description: Display representation unavailable
         "416":
           description: Range Not Satisfiable
   /v1/attachments/lookup:
@@ -18163,6 +18180,14 @@ paths:
           schema:
             type: integer
           description: Maximum number of messages to return.
+        - name: attachmentContent
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - metadata
+          description: Set to 'metadata' to omit attachment and tool-image bytes while retaining stable references and metadata.
       responses:
         "200":
           description: Successful response

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -10,6 +10,7 @@ import {
   deleteOrphanAttachments,
   getAttachmentById,
   getAttachmentContent,
+  getAttachmentMetadataById,
   getAttachmentMetadataForMessage,
   getAttachmentsByIds,
   getAttachmentsForMessage,
@@ -256,6 +257,45 @@ describe("getAttachmentMetadataForMessage", () => {
           thumbnailBase64: null,
         }),
       ]);
+
+      expect(selectSpy).toHaveBeenCalledTimes(1);
+      const projection = selectSpy.mock.calls[0]?.[0] as
+        | Record<string, unknown>
+        | undefined;
+      expect(Object.keys(projection ?? {})).toEqual([
+        "id",
+        "originalFilename",
+        "mimeType",
+        "sizeBytes",
+        "kind",
+        "createdAt",
+      ]);
+      expect(projection).not.toHaveProperty("dataBase64");
+      expect(projection).not.toHaveProperty("thumbnailBase64");
+    } finally {
+      selectSpy.mockRestore();
+    }
+  });
+
+  test("single-attachment metadata reuses the lightweight projection", () => {
+    const stored = uploadAttachment("image.png", "image/png", "AAAA");
+    rawRun(
+      "test:setSingleAttachmentThumbnail",
+      "UPDATE attachments SET thumbnail_base64 = ? WHERE id = ?",
+      "BBBB",
+      stored.id,
+    );
+
+    const db = getDb();
+    const selectSpy = spyOn(db, "select");
+    try {
+      expect(getAttachmentMetadataById(stored.id)).toEqual(
+        expect.objectContaining({
+          id: stored.id,
+          originalFilename: "image.png",
+          thumbnailBase64: null,
+        }),
+      );
 
       expect(selectSpy).toHaveBeenCalledTimes(1);
       const projection = selectSpy.mock.calls[0]?.[0] as

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import {
   attachInlineAttachmentToMessage,
@@ -10,6 +10,7 @@ import {
   deleteOrphanAttachments,
   getAttachmentById,
   getAttachmentContent,
+  getAttachmentMetadataForMessage,
   getAttachmentsByIds,
   getAttachmentsForMessage,
   getFilePathForAttachment,
@@ -224,6 +225,55 @@ describe("getAttachmentContent", () => {
 
     const content = getAttachmentContent(stored.id);
     expect(content).toBeNull();
+  });
+});
+
+describe("getAttachmentMetadataForMessage", () => {
+  beforeEach(resetTables);
+
+  test("lightweight projection selects neither content nor thumbnail columns", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "user", "Image");
+    const stored = uploadAttachment("image.png", "image/png", "AAAA");
+    const attachmentId = linkAttachmentToMessage(msg.id, stored.id, 0);
+    rawRun(
+      "test:setAttachmentThumbnail",
+      "UPDATE attachments SET thumbnail_base64 = ? WHERE id = ?",
+      "BBBB",
+      attachmentId,
+    );
+
+    const db = getDb();
+    const selectSpy = spyOn(db, "select");
+    try {
+      const result = getAttachmentMetadataForMessage(msg.id, {
+        includeThumbnail: false,
+      });
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: attachmentId,
+          originalFilename: "image.png",
+          thumbnailBase64: null,
+        }),
+      ]);
+
+      expect(selectSpy).toHaveBeenCalledTimes(1);
+      const projection = selectSpy.mock.calls[0]?.[0] as
+        | Record<string, unknown>
+        | undefined;
+      expect(Object.keys(projection ?? {})).toEqual([
+        "id",
+        "originalFilename",
+        "mimeType",
+        "sizeBytes",
+        "kind",
+        "createdAt",
+      ]);
+      expect(projection).not.toHaveProperty("dataBase64");
+      expect(projection).not.toHaveProperty("thumbnailBase64");
+    } finally {
+      selectSpy.mockRestore();
+    }
   });
 });
 

--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -49,6 +49,7 @@ function createTestArgs(conversationId: string) {
 }
 
 interface AttachmentPayload {
+  id?: string;
   data?: string;
   filename?: string;
   mimeType: string;
@@ -191,6 +192,168 @@ describe("handleListMessages attachments", () => {
     const docAtt = attachments.find((a) => a.mimeType === "application/pdf");
     expect(imgAtt!.data).toBe(IMAGE_BASE64);
     expect(docAtt!.data).toBeUndefined();
+  });
+
+  test("metadata mode retains attachment shapes without media bytes", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "large image" }]),
+    );
+    const largeImageBase64 = "A".repeat(1024 * 1024);
+    const stored = uploadAttachment("large.png", "image/png", largeImageBase64);
+    const attachmentId = linkAttachmentToMessage(msg.id, stored.id, 0);
+    rawRun(
+      "test:addLargeThumbnail",
+      "UPDATE attachments SET thumbnail_base64 = ? WHERE id = ?",
+      "B".repeat(256 * 1024),
+      attachmentId,
+    );
+
+    const defaultResponse = handleListMessages(createTestArgs(conv.id));
+    const metadataResponse = handleListMessages({
+      queryParams: {
+        conversationId: conv.id,
+        attachmentContent: "metadata",
+      },
+    });
+    const defaultJson = JSON.stringify(defaultResponse);
+    const metadataJson = JSON.stringify(metadataResponse);
+    const body = metadataResponse as {
+      messages: Array<{
+        attachments: AttachmentPayload[];
+        contentBlocks?: Array<{
+          type: string;
+          attachment?: AttachmentPayload;
+        }>;
+      }>;
+    };
+
+    expect(defaultJson.length).toBeGreaterThan(1024 * 1024);
+    expect(metadataJson.length).toBeLessThan(10_000);
+    expect(body.messages[0].attachments).toEqual([
+      expect.objectContaining({
+        id: attachmentId,
+        filename: "large.png",
+        mimeType: "image/png",
+        kind: "image",
+        fileBacked: true,
+      }),
+    ]);
+    expect(body.messages[0].attachments[0].data).toBeUndefined();
+    expect(body.messages[0].attachments[0].thumbnailData).toBeUndefined();
+    const attachmentBlock = body.messages[0].contentBlocks?.find(
+      (block) => block.type === "attachment",
+    );
+    expect(attachmentBlock?.attachment?.id).toBe(attachmentId);
+    expect(attachmentBlock?.attachment?.data).toBeUndefined();
+    expect(attachmentBlock?.attachment?.thumbnailData).toBeUndefined();
+  });
+
+  test("metadata mode omits nested tool image data and retains references", async () => {
+    const conv = createConversation();
+    const referenced = uploadAttachment(
+      "referenced.png",
+      "image/png",
+      "AQIDBA==",
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([
+        {
+          type: "tool_use",
+          id: "tool-with-images",
+          name: "browser_screenshot",
+          input: {},
+        },
+      ]),
+    );
+    const legacyToolResultContent = JSON.stringify([
+      {
+        type: "tool_result",
+        tool_use_id: "tool-with-images",
+        content: "captured",
+        contentBlocks: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "A".repeat(512 * 1024),
+            },
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "nested-tool",
+            content: "nested",
+            contentBlocks: [
+              {
+                type: "image",
+                source: {
+                  type: "workspace_ref",
+                  media_type: "image/png",
+                  attachmentId: referenced.id,
+                  sizeBytes: 4,
+                  width: 2,
+                  height: 2,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    const resultMessage = await addMessage(
+      conv.id,
+      "assistant",
+      legacyToolResultContent,
+    );
+    rawRun(
+      "test:restoreLegacyInlineToolMedia",
+      "UPDATE messages SET content = ? WHERE id = ?",
+      legacyToolResultContent,
+      resultMessage.id,
+    );
+    linkAttachmentToMessage(resultMessage.id, referenced.id, 0);
+
+    const defaultResponse = handleListMessages(createTestArgs(conv.id)) as {
+      messages: Array<{
+        toolCalls?: Array<{
+          imageData?: string;
+          imageDataList?: string[];
+          imageAttachmentIds?: string[];
+        }>;
+      }>;
+    };
+    const metadataResponse = handleListMessages({
+      queryParams: {
+        conversationId: conv.id,
+        attachmentContent: "metadata",
+      },
+    }) as typeof defaultResponse;
+
+    expect(defaultResponse.messages[0].toolCalls?.[0].imageData).toHaveLength(
+      512 * 1024,
+    );
+    const metadataToolCall = metadataResponse.messages[0].toolCalls?.[0];
+    expect(metadataToolCall?.imageData).toBeUndefined();
+    expect(metadataToolCall?.imageDataList).toBeUndefined();
+    expect(metadataToolCall?.imageAttachmentIds).toEqual([referenced.id]);
+    expect(JSON.stringify(metadataResponse)).not.toContain("AAAA");
+  });
+
+  test("rejects unknown attachment content modes", () => {
+    const conv = createConversation();
+    expect(() =>
+      handleListMessages({
+        queryParams: {
+          conversationId: conv.id,
+          attachmentContent: "inline",
+        },
+      }),
+    ).toThrow("attachmentContent must be 'metadata' when provided");
   });
 
   test("attachment-only assistant message synthesizes contentBlocks", async () => {

--- a/assistant/src/__tests__/list-messages-queued.test.ts
+++ b/assistant/src/__tests__/list-messages-queued.test.ts
@@ -34,14 +34,27 @@ function resetTables() {
   clearConversations();
 }
 
+interface QueuedAttachmentPayload {
+  id: string;
+  filename: string;
+  kind: string;
+  sizeBytes?: number;
+  data?: string;
+  thumbnailData?: string;
+}
+
 interface MessagePayload {
   id: string;
   role: string;
-  contentBlocks?: Array<{ type: string; text?: string }>;
+  contentBlocks?: Array<{
+    type: string;
+    text?: string;
+    attachment?: QueuedAttachmentPayload;
+  }>;
   clientMessageId?: string;
   queueStatus?: "queued" | "processing";
   queuePosition?: number;
-  attachments?: Array<{ id: string; filename: string; kind: string }>;
+  attachments?: QueuedAttachmentPayload[];
 }
 
 /** Register a live conversation whose in-memory queue holds `queued`. */
@@ -165,6 +178,48 @@ describe("handleListMessages in-memory queue", () => {
     expect(att?.filename).toBe("diagram.png");
     expect(att?.kind).toBe("image");
     expect(att?.id).toBe("req-att:attachment:0");
+  });
+
+  test("metadata mode omits queued image bytes while retaining derived size", () => {
+    const conv = createConversation();
+    registerLiveConversation(conv.id, [
+      makeQueued({
+        requestId: "req-lightweight-att",
+        content: "see attached",
+        attachments: [
+          {
+            filename: "diagram.png",
+            mimeType: "image/png",
+            data: "AAAA",
+            thumbnailData: "BBBB",
+          },
+        ],
+      }),
+    ]);
+
+    const response = handleListMessages({
+      queryParams: {
+        conversationId: conv.id,
+        attachmentContent: "metadata",
+      },
+    });
+    const body = response as { messages: MessagePayload[] };
+    const attachment = body.messages[0].attachments?.[0];
+
+    expect(attachment).toEqual(
+      expect.objectContaining({
+        id: "req-lightweight-att:attachment:0",
+        filename: "diagram.png",
+        kind: "image",
+        sizeBytes: 3,
+      }),
+    );
+    expect(attachment?.data).toBeUndefined();
+    expect(attachment?.thumbnailData).toBeUndefined();
+    expect(body.messages[0].contentBlocks?.[1]).toEqual({
+      type: "attachment",
+      attachment,
+    });
   });
 
   test("filters hidden queued messages from the snapshot, keeping positions contiguous", async () => {

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -8,6 +8,7 @@ import {
   describe,
   expect,
   mock,
+  spyOn,
   test,
 } from "bun:test";
 
@@ -44,6 +45,10 @@ import { ACTOR_PRINCIPALS } from "../runtime/auth/route-policy.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { ROUTES as ATTACHMENT_ROUTES } from "../runtime/routes/attachment-routes.js";
+import {
+  RangeNotSatisfiableError,
+  UnsupportedMediaTypeError,
+} from "../runtime/routes/errors.js";
 import { RouteResponse } from "../runtime/routes/types.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import {
@@ -72,6 +77,15 @@ const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
 const ATTACHMENT_CONTENT_ROUTE = ATTACHMENT_ROUTES.find(
   (candidate) => candidate.operationId === "attachment_content",
 )!;
+
+function expectOnlyProjectedAttachmentPreflightSelects(
+  calls: readonly (readonly unknown[])[],
+): void {
+  expect(calls).toHaveLength(2);
+  for (const call of calls) {
+    expect(call[0]).toBeDefined();
+  }
+}
 
 describe("Runtime attachment metadata", () => {
   let server: RuntimeHttpServer;
@@ -356,6 +370,49 @@ describe("Runtime attachment metadata", () => {
 
     expect(rangeRes.status).toBe(416);
     expect(missingRes.status).toBe(404);
+  });
+
+  test("inline display Range rejection does not select the content row", () => {
+    const stored = uploadAttachment(
+      "pixel.png",
+      "image/png",
+      PNG_1PX_BYTES.toString("base64"),
+    );
+    const selectSpy = spyOn(getDb(), "select");
+    try {
+      expect(() =>
+        ATTACHMENT_CONTENT_ROUTE.handler({
+          pathParams: { id: stored.id },
+          queryParams: { representation: "display" },
+          headers: { range: "bytes=0-3" },
+        }),
+      ).toThrow(RangeNotSatisfiableError);
+
+      expectOnlyProjectedAttachmentPreflightSelects(selectSpy.mock.calls);
+    } finally {
+      selectSpy.mockRestore();
+    }
+  });
+
+  test("inline non-image display rejects without selecting the content row", () => {
+    const stored = uploadAttachment(
+      "report.pdf",
+      "application/pdf",
+      "JVBERA==",
+    );
+    const selectSpy = spyOn(getDb(), "select");
+    try {
+      expect(() =>
+        ATTACHMENT_CONTENT_ROUTE.handler({
+          pathParams: { id: stored.id },
+          queryParams: { representation: "display" },
+        }),
+      ).toThrow(UnsupportedMediaTypeError);
+
+      expectOnlyProjectedAttachmentPreflightSelects(selectSpy.mock.calls);
+    } finally {
+      selectSpy.mockRestore();
+    }
   });
 
   test("display representation rejects non-image files before reading their path", async () => {

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -1,3 +1,6 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
 import {
   afterAll,
   afterEach,
@@ -27,6 +30,7 @@ mock.module("../daemon/approval-generators.js", () => ({
 }));
 
 import {
+  getFilePathForAttachment,
   linkAttachmentToMessage,
   uploadAttachment,
 } from "../persistence/attachments-store.js";
@@ -35,10 +39,17 @@ import { getOrCreateConversation } from "../persistence/conversation-key-store.j
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import * as deliveryChannels from "../persistence/delivery-channels.js";
-import { resetTestTables } from "../persistence/raw-query.js";
+import { rawRun, resetTestTables } from "../persistence/raw-query.js";
+import { ACTOR_PRINCIPALS } from "../runtime/auth/route-policy.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { ROUTES as ATTACHMENT_ROUTES } from "../runtime/routes/attachment-routes.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
+import {
+  fakeHeifHeaderBytes,
+  makeHeicFixtureBytes,
+  PNG_1PX_BYTES,
+} from "./heic-fixture.js";
 import {
   resolveLocalTrustVerdict,
   seedContactChannel,
@@ -82,6 +93,17 @@ describe("Runtime attachment metadata", () => {
 
   afterAll(async () => {
     await server?.stop();
+  });
+
+  test("attachment content representations retain attachment read authorization", () => {
+    const route = ATTACHMENT_ROUTES.find(
+      (candidate) => candidate.operationId === "attachment_content",
+    );
+
+    expect(route?.policy).toEqual({
+      requiredScopes: ["attachments.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    });
   });
 
   test("GET /messages includes attachment metadata for assistant messages", async () => {
@@ -216,6 +238,182 @@ describe("Runtime attachment metadata", () => {
     expect(res.status).toBe(404);
     expect(body.error.message).toBe("Attachment not found");
   });
+
+  test("display representation returns browser image bytes with bounded headers", async () => {
+    const stored = uploadAttachment(
+      "pixel.png",
+      "image/png",
+      PNG_1PX_BYTES.toString("base64"),
+    );
+
+    const res = await fetch(
+      `http://127.0.0.1:${port}/v1/attachments/${stored.id}/content?representation=display`,
+      { headers: AUTH_HEADERS },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect(res.headers.get("content-length")).toBe(
+      String(PNG_1PX_BYTES.length),
+    );
+    expect(res.headers.get("accept-ranges")).toBe("none");
+    expect(res.headers.get("cache-control")).toBeNull();
+    expect(Buffer.from(await res.arrayBuffer())).toEqual(PNG_1PX_BYTES);
+  });
+
+  test("explicit original representation preserves file-backed Range behavior", async () => {
+    const bytes = PNG_1PX_BYTES;
+    const mapping = getOrCreateConversation("original-range");
+    const message = await conversationStore.addMessage(
+      mapping.conversationId,
+      "user",
+      "image",
+    );
+    const stored = uploadAttachment(
+      "pixel.png",
+      "image/png",
+      bytes.toString("base64"),
+    );
+    const attachmentId = linkAttachmentToMessage(message.id, stored.id, 0);
+
+    const defaultRes = await fetch(
+      `http://127.0.0.1:${port}/v1/attachments/${attachmentId}/content`,
+      { headers: { ...AUTH_HEADERS, Range: "bytes=0-3" } },
+    );
+    const explicitRes = await fetch(
+      `http://127.0.0.1:${port}/v1/attachments/${attachmentId}/content?representation=original`,
+      { headers: { ...AUTH_HEADERS, Range: "bytes=0-3" } },
+    );
+
+    expect(defaultRes.status).toBe(206);
+    expect(explicitRes.status).toBe(defaultRes.status);
+    expect(defaultRes.headers.get("content-range")).toBe(
+      `bytes 0-3/${bytes.length}`,
+    );
+    expect(explicitRes.headers.get("content-range")).toBe(
+      `bytes 0-3/${bytes.length}`,
+    );
+    expect(Buffer.from(await explicitRes.arrayBuffer())).toEqual(
+      Buffer.from(await defaultRes.arrayBuffer()),
+    );
+  });
+
+  test("display representation rejects Range after resolving the attachment", async () => {
+    const stored = uploadAttachment(
+      "pixel.png",
+      "image/png",
+      PNG_1PX_BYTES.toString("base64"),
+    );
+
+    const rangeRes = await fetch(
+      `http://127.0.0.1:${port}/v1/attachments/${stored.id}/content?representation=display`,
+      { headers: { ...AUTH_HEADERS, Range: "bytes=0-3" } },
+    );
+    const missingRes = await fetch(
+      `http://127.0.0.1:${port}/v1/attachments/missing/content?representation=display`,
+      { headers: { ...AUTH_HEADERS, Range: "bytes=0-3" } },
+    );
+
+    expect(rangeRes.status).toBe(416);
+    expect(missingRes.status).toBe(404);
+  });
+
+  test("display representation rejects non-image files before reading their path", async () => {
+    const mapping = getOrCreateConversation("display-non-image");
+    const message = await conversationStore.addMessage(
+      mapping.conversationId,
+      "user",
+      "document",
+    );
+    const stored = uploadAttachment(
+      "report.pdf",
+      "application/pdf",
+      "JVBERA==",
+    );
+    const attachmentId = linkAttachmentToMessage(message.id, stored.id, 0);
+    const attachmentPath = getFilePathForAttachment(attachmentId)!;
+    const unreadablePath = join(dirname(attachmentPath), "not-a-file");
+    mkdirSync(unreadablePath);
+    rawRun(
+      "test:pointAttachmentAtDirectory",
+      "UPDATE attachments SET file_path = ? WHERE id = ?",
+      unreadablePath,
+      attachmentId,
+    );
+
+    const res = await fetch(
+      `http://127.0.0.1:${port}/v1/attachments/${attachmentId}/content?representation=display`,
+      { headers: AUTH_HEADERS },
+    );
+
+    expect(res.status).toBe(415);
+  });
+
+  test("display representation rejects HEIF when conversion is unavailable", async () => {
+    const stored = uploadAttachment(
+      "broken.heic",
+      "image/heic",
+      fakeHeifHeaderBytes().toString("base64"),
+    );
+
+    const res = await fetch(
+      `http://127.0.0.1:${port}/v1/attachments/${stored.id}/content?representation=display`,
+      { headers: AUTH_HEADERS },
+    );
+
+    expect(res.status).toBe(415);
+  });
+
+  test("display representation rejects corrupt HEIC candidates", async () => {
+    const stored = uploadAttachment(
+      "corrupt.heic",
+      "image/heic",
+      Buffer.from("not-heif").toString("base64"),
+    );
+
+    const res = await fetch(
+      `http://127.0.0.1:${port}/v1/attachments/${stored.id}/content?representation=display`,
+      { headers: AUTH_HEADERS },
+    );
+
+    expect(res.status).toBe(415);
+  });
+
+  test.skipIf(process.platform !== "darwin")(
+    "display representation converts legacy HEIF bytes to JPEG",
+    async () => {
+      const heic = makeHeicFixtureBytes();
+      if (!heic) {
+        return;
+      }
+      const id = randomUUID();
+      rawRun(
+        "test:insertLegacyHeicAttachment",
+        `INSERT INTO attachments
+          (id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        id,
+        "legacy.heic",
+        "image/heic",
+        heic.length,
+        "image",
+        heic.toString("base64"),
+        Date.now(),
+      );
+
+      const res = await fetch(
+        `http://127.0.0.1:${port}/v1/attachments/${id}/content?representation=display`,
+        { headers: AUTH_HEADERS },
+      );
+      const bytes = Buffer.from(await res.arrayBuffer());
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("image/jpeg");
+      expect(res.headers.get("content-length")).toBe(String(bytes.length));
+      expect(bytes.subarray(0, 3)).toEqual(Buffer.from([0xff, 0xd8, 0xff]));
+    },
+    30_000,
+  );
 });
 
 describe("WhatsApp channel ingress attachment resolution", () => {

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, truncateSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   afterAll,
@@ -44,6 +44,7 @@ import { ACTOR_PRINCIPALS } from "../runtime/auth/route-policy.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { ROUTES as ATTACHMENT_ROUTES } from "../runtime/routes/attachment-routes.js";
+import { RouteResponse } from "../runtime/routes/types.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import {
   fakeHeifHeaderBytes,
@@ -68,6 +69,9 @@ afterAll(() => {
 
 const TEST_TOKEN = "test-bearer-token-attach";
 const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
+const ATTACHMENT_CONTENT_ROUTE = ATTACHMENT_ROUTES.find(
+  (candidate) => candidate.operationId === "attachment_content",
+)!;
 
 describe("Runtime attachment metadata", () => {
   let server: RuntimeHttpServer;
@@ -96,11 +100,7 @@ describe("Runtime attachment metadata", () => {
   });
 
   test("attachment content representations retain attachment read authorization", () => {
-    const route = ATTACHMENT_ROUTES.find(
-      (candidate) => candidate.operationId === "attachment_content",
-    );
-
-    expect(route?.policy).toEqual({
+    expect(ATTACHMENT_CONTENT_ROUTE.policy).toEqual({
       requiredScopes: ["attachments.read"],
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     });
@@ -259,6 +259,46 @@ describe("Runtime attachment metadata", () => {
     expect(res.headers.get("accept-ranges")).toBe("none");
     expect(res.headers.get("cache-control")).toBeNull();
     expect(Buffer.from(await res.arrayBuffer())).toEqual(PNG_1PX_BYTES);
+  });
+
+  test("file-backed native display streams after a bounded format sniff", async () => {
+    const mapping = getOrCreateConversation("display-stream");
+    const message = await conversationStore.addMessage(
+      mapping.conversationId,
+      "user",
+      "image",
+    );
+    const stored = uploadAttachment(
+      "pixel.png",
+      "image/png",
+      PNG_1PX_BYTES.toString("base64"),
+    );
+    const attachmentId = linkAttachmentToMessage(message.id, stored.id, 0);
+    const attachmentPath = getFilePathForAttachment(attachmentId)!;
+    const expandedSize = 32 * 1024 * 1024;
+    truncateSync(attachmentPath, expandedSize);
+    rawRun(
+      "test:mislabeledNativeDisplayImage",
+      "UPDATE attachments SET mime_type = ?, size_bytes = ? WHERE id = ?",
+      "image/heic",
+      expandedSize,
+      attachmentId,
+    );
+
+    const result = await ATTACHMENT_CONTENT_ROUTE.handler({
+      pathParams: { id: attachmentId },
+      queryParams: { representation: "display" },
+    });
+
+    expect(result).toBeInstanceOf(RouteResponse);
+    const response = result as RouteResponse;
+    expect(response.body).toBeInstanceOf(Blob);
+    expect(response.body).not.toBeInstanceOf(Uint8Array);
+    expect(response.headers).toEqual({
+      "Content-Type": "image/png",
+      "Content-Length": String(expandedSize),
+      "Accept-Ranges": "none",
+    });
   });
 
   test("explicit original representation preserves file-backed Range behavior", async () => {

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -323,6 +323,7 @@ function collectToolResultImages(
   blocks: unknown[],
   imageDataList: string[],
   imageAttachmentIds: string[],
+  includeMediaData: boolean,
 ): void {
   for (const block of blocks) {
     if (!isRecord(block)) {
@@ -334,9 +335,11 @@ function collectToolResultImages(
         imageAttachmentIds.push(source.attachmentId);
         continue;
       }
-      const resolved = resolveMediaSourceData(source);
-      if (resolved) {
-        imageDataList.push(resolved.data);
+      if (includeMediaData) {
+        const resolved = resolveMediaSourceData(source);
+        if (resolved) {
+          imageDataList.push(resolved.data);
+        }
       }
       continue;
     }
@@ -349,6 +352,7 @@ function collectToolResultImages(
         block.contentBlocks,
         imageDataList,
         imageAttachmentIds,
+        includeMediaData,
       );
     }
   }
@@ -360,6 +364,7 @@ export function renderHistoryContent(
     ConversationMessageAttachment | null | undefined
   >,
   messageId?: string,
+  options?: { includeMediaData?: boolean },
 ): RenderedHistoryContent {
   if (!Array.isArray(content)) {
     let text: string;
@@ -743,6 +748,7 @@ export function renderHistoryContent(
           block.contentBlocks,
           imageDataList,
           imageAttachmentIds,
+          options?.includeMediaData !== false,
         );
       }
       const matched = toolUseId ? pendingToolUses.get(toolUseId) : null;

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -1167,7 +1167,9 @@ export function getAttachmentsForMessage(
     .orderBy(messageAttachments.position)
     .all();
 
-  if (links.length === 0) return [];
+  if (links.length === 0) {
+    return [];
+  }
 
   const ids = links
     .map((l) => l.attachmentId)
@@ -1183,8 +1185,29 @@ export function getAttachmentsForMessage(
  */
 export function getAttachmentMetadataForMessage(
   messageId: string,
+  options?: { includeThumbnail?: boolean },
 ): StoredAttachment[] {
   const db = getDb();
+  if (options?.includeThumbnail === false) {
+    return db
+      .select({
+        id: attachments.id,
+        originalFilename: attachments.originalFilename,
+        mimeType: attachments.mimeType,
+        sizeBytes: attachments.sizeBytes,
+        kind: attachments.kind,
+        createdAt: attachments.createdAt,
+      })
+      .from(messageAttachments)
+      .innerJoin(
+        attachments,
+        eq(messageAttachments.attachmentId, attachments.id),
+      )
+      .where(eq(messageAttachments.messageId, messageId))
+      .orderBy(messageAttachments.position)
+      .all()
+      .map((row) => ({ ...row, thumbnailBase64: null }));
+  }
   const links = db
     .select({ attachmentId: messageAttachments.attachmentId })
     .from(messageAttachments)
@@ -1192,11 +1215,15 @@ export function getAttachmentMetadataForMessage(
     .orderBy(messageAttachments.position)
     .all();
 
-  if (links.length === 0) return [];
+  if (links.length === 0) {
+    return [];
+  }
 
   const results: StoredAttachment[] = [];
   for (const link of links) {
-    if (!link.attachmentId) continue;
+    if (!link.attachmentId) {
+      continue;
+    }
     const row = db
       .select({
         id: attachments.id,
@@ -1210,7 +1237,9 @@ export function getAttachmentMetadataForMessage(
       .from(attachments)
       .where(eq(attachments.id, link.attachmentId))
       .get();
-    if (row) results.push(row);
+    if (row) {
+      results.push(row);
+    }
   }
   return results;
 }

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -43,6 +43,15 @@ export interface StoredAttachment {
   createdAt: number;
 }
 
+const attachmentMetadataProjection = {
+  id: attachments.id,
+  originalFilename: attachments.originalFilename,
+  mimeType: attachments.mimeType,
+  sizeBytes: attachments.sizeBytes,
+  kind: attachments.kind,
+  createdAt: attachments.createdAt,
+};
+
 export function classifyKind(mimeType: string): string {
   if (mimeType.startsWith("image/")) return "image";
   if (mimeType.startsWith("video/")) return "video";
@@ -1190,14 +1199,7 @@ export function getAttachmentMetadataForMessage(
   const db = getDb();
   if (options?.includeThumbnail === false) {
     return db
-      .select({
-        id: attachments.id,
-        originalFilename: attachments.originalFilename,
-        mimeType: attachments.mimeType,
-        sizeBytes: attachments.sizeBytes,
-        kind: attachments.kind,
-        createdAt: attachments.createdAt,
-      })
+      .select(attachmentMetadataProjection)
       .from(messageAttachments)
       .innerJoin(
         attachments,
@@ -1242,6 +1244,18 @@ export function getAttachmentMetadataForMessage(
     }
   }
   return results;
+}
+
+/** Retrieve one attachment without selecting content or thumbnail columns. */
+export function getAttachmentMetadataById(
+  attachmentId: string,
+): StoredAttachment | null {
+  const row = getDb()
+    .select(attachmentMetadataProjection)
+    .from(attachments)
+    .where(eq(attachments.id, attachmentId))
+    .get();
+  return row ? { ...row, thumbnailBase64: null } : null;
 }
 
 /**

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -33,6 +33,7 @@ import {
   validateAttachmentUpload,
 } from "../../persistence/attachments-store.js";
 import {
+  isHeicFilename,
   isHeifImage,
   jpegFilenameFor,
   normalizeImageBytes,
@@ -55,6 +56,18 @@ const MAX_UPLOAD_BODY_BYTES = 150 * 1024 * 1024;
 
 /** 100 MB — maximum file size for file-backed uploads (matches client memorySafetyLimit). */
 const MAX_FILE_BACKED_UPLOAD_BYTES = 100 * 1024 * 1024;
+
+const BROWSER_DISPLAY_IMAGE_MIME_TYPES = new Set([
+  "image/avif",
+  "image/bmp",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/svg+xml",
+  "image/vnd.microsoft.icon",
+  "image/webp",
+  "image/x-icon",
+]);
 
 /** Read the first `length` bytes of a file without loading the rest. */
 function readFileHead(path: string, length: number): Buffer {
@@ -506,16 +519,69 @@ function handleGetAttachmentRoute({ pathParams }: RouteHandlerArgs) {
   };
 }
 
+function displayAttachmentResponse(
+  mimeType: string,
+  originalBytes: Uint8Array,
+): RouteResponse {
+  const originalIsHeif = isHeifImage(originalBytes);
+  const normalized = normalizeImageBytes(mimeType, originalBytes);
+  if (originalIsHeif && !normalized.converted) {
+    throw new UnsupportedMediaTypeError(
+      "A browser-displayable representation is unavailable for this HEIF attachment",
+    );
+  }
+  if (!BROWSER_DISPLAY_IMAGE_MIME_TYPES.has(normalized.mimeType)) {
+    throw new UnsupportedMediaTypeError(
+      `A browser-displayable representation is unavailable for ${normalized.mimeType}`,
+    );
+  }
+  const bytes = Buffer.from(normalized.bytes);
+  return new RouteResponse(bytes, {
+    "Content-Type": normalized.mimeType,
+    "Content-Length": String(bytes.length),
+    "Accept-Ranges": "none",
+  });
+}
+
+function assertDisplayRequestSupported(
+  filename: string,
+  mimeType: string,
+  rangeHeader: string | undefined,
+): void {
+  if (rangeHeader) {
+    throw new RangeNotSatisfiableError(
+      "Range requests are not supported for display representations",
+    );
+  }
+  if (!mimeType.startsWith("image/") && !isHeicFilename(filename)) {
+    throw new UnsupportedMediaTypeError(
+      "Display representations are available only for image attachments",
+    );
+  }
+}
+
 /**
- * Serve raw file bytes for an attachment. For file-backed attachments this
- * streams from disk; for inline attachments it decodes the base64 data.
- * Supports Range headers for video seeking.
+ * Serve original bytes for an attachment, streaming file-backed content and
+ * decoding legacy inline base64. The optional display representation prepares
+ * image bytes for browsers. Original content supports Range for video seeking.
  */
 function handleGetAttachmentContentRoute({
   pathParams,
+  queryParams,
   headers = {},
 }: RouteHandlerArgs): RouteResponse {
   const attachmentId = pathParams!.id;
+  const representation = queryParams?.representation;
+  if (
+    representation !== undefined &&
+    representation !== "original" &&
+    representation !== "display"
+  ) {
+    throw new BadRequestError(
+      "representation must be 'original' or 'display' when provided",
+    );
+  }
+  const displayRepresentation = representation === "display";
   const filePath = getFilePathForAttachment(attachmentId);
   const isFileBacked = !!filePath;
 
@@ -532,6 +598,18 @@ function handleGetAttachmentContentRoute({
     }
     if (!existsSync(resolvedPath)) {
       throw new NotFoundError("Recording file not found on disk");
+    }
+
+    if (displayRepresentation) {
+      assertDisplayRequestSupported(
+        attachment.originalFilename,
+        attachment.mimeType,
+        headers["range"],
+      );
+      return displayAttachmentResponse(
+        attachment.mimeType,
+        readFileSync(resolvedPath),
+      );
     }
 
     const file = Bun.file(resolvedPath);
@@ -592,7 +670,18 @@ function handleGetAttachmentContentRoute({
     throw new NotFoundError("No content available");
   }
 
+  if (displayRepresentation) {
+    assertDisplayRequestSupported(
+      attachment.originalFilename,
+      attachment.mimeType,
+      headers["range"],
+    );
+  }
+
   const buffer = Buffer.from(attachment.dataBase64, "base64");
+  if (displayRepresentation) {
+    return displayAttachmentResponse(attachment.mimeType, buffer);
+  }
   return new RouteResponse(buffer, {
     "Content-Type": attachment.mimeType,
     "Content-Length": String(buffer.length),
@@ -726,14 +815,25 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Get attachment content",
     description:
-      "Serve raw file bytes for an attachment. Supports Range headers.",
+      "Serve original attachment bytes by default. Set representation=display for browser-displayable image bytes; display representations do not support Range requests.",
     tags: ["attachments"],
+    queryParams: [
+      {
+        name: "representation",
+        required: false,
+        description:
+          "Content representation. 'original' preserves stored bytes and Range behavior; 'display' returns browser-displayable bytes and rejects Range requests.",
+        schema: { type: "string", enum: ["original", "display"] },
+      },
+    ],
     responseStatus: ({ headers }) => (headers?.["range"] ? "206" : "200"),
     responseBody: {
       contentType: "application/octet-stream",
       schema: { type: "string", format: "binary" },
     },
     additionalResponses: {
+      "400": { description: "Invalid representation" },
+      "415": { description: "Display representation unavailable" },
       "416": { description: "Range Not Satisfiable" },
     },
     handler: handleGetAttachmentContentRoute,

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -21,6 +21,7 @@ import { z } from "zod";
 import {
   deleteAttachment,
   getAttachmentById,
+  getAttachmentMetadataById,
   getFilePathBySourcePath,
   StoredAttachment,
   uploadAttachment,
@@ -592,22 +593,20 @@ function handleGetAttachmentContentRoute({
   const filePath = getFilePathForAttachment(attachmentId);
   const isFileBacked = !!filePath;
 
-  const attachment = getAttachmentById(attachmentId, {
-    hydrateFileData: !isFileBacked,
-  });
-  if (!attachment) {
-    throw new NotFoundError("Attachment not found");
-  }
-  if (filePath) {
-    const resolvedPath = resolveAllowedFileBackedAttachmentPath(filePath);
-    if (!resolvedPath) {
-      throw new NotFoundError("Attachment content not found");
+  if (displayRepresentation) {
+    const attachment = getAttachmentMetadataById(attachmentId);
+    if (!attachment) {
+      throw new NotFoundError("Attachment not found");
     }
-    if (!existsSync(resolvedPath)) {
-      throw new NotFoundError("Recording file not found on disk");
-    }
+    if (filePath) {
+      const resolvedPath = resolveAllowedFileBackedAttachmentPath(filePath);
+      if (!resolvedPath) {
+        throw new NotFoundError("Attachment content not found");
+      }
+      if (!existsSync(resolvedPath)) {
+        throw new NotFoundError("Recording file not found on disk");
+      }
 
-    if (displayRepresentation) {
       assertDisplayRangeSupported(headers["range"]);
       assertDisplayImageCandidate(
         attachment.originalFilename,
@@ -632,6 +631,38 @@ function handleGetAttachmentContentRoute({
         "Content-Length": String(displayFile.size),
         "Accept-Ranges": "none",
       });
+    }
+
+    assertDisplayRangeSupported(headers["range"]);
+    assertDisplayImageCandidate(
+      attachment.originalFilename,
+      attachment.mimeType,
+    );
+    const inlineAttachment = getAttachmentById(attachmentId, {
+      hydrateFileData: true,
+    });
+    if (!inlineAttachment?.dataBase64) {
+      throw new NotFoundError("No content available");
+    }
+    return displayAttachmentResponse(
+      attachment.mimeType,
+      Buffer.from(inlineAttachment.dataBase64, "base64"),
+    );
+  }
+
+  const attachment = getAttachmentById(attachmentId, {
+    hydrateFileData: !isFileBacked,
+  });
+  if (!attachment) {
+    throw new NotFoundError("Attachment not found");
+  }
+  if (filePath) {
+    const resolvedPath = resolveAllowedFileBackedAttachmentPath(filePath);
+    if (!resolvedPath) {
+      throw new NotFoundError("Attachment content not found");
+    }
+    if (!existsSync(resolvedPath)) {
+      throw new NotFoundError("Recording file not found on disk");
     }
 
     const file = Bun.file(resolvedPath);
@@ -692,18 +723,7 @@ function handleGetAttachmentContentRoute({
     throw new NotFoundError("No content available");
   }
 
-  if (displayRepresentation) {
-    assertDisplayRangeSupported(headers["range"]);
-    assertDisplayImageCandidate(
-      attachment.originalFilename,
-      attachment.mimeType,
-    );
-  }
-
   const buffer = Buffer.from(attachment.dataBase64, "base64");
-  if (displayRepresentation) {
-    return displayAttachmentResponse(attachment.mimeType, buffer);
-  }
   return new RouteResponse(buffer, {
     "Content-Type": attachment.mimeType,
     "Content-Length": String(buffer.length),

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -37,6 +37,7 @@ import {
   isHeifImage,
   jpegFilenameFor,
   normalizeImageBytes,
+  sniffImageMimeType,
 } from "../../util/image-conversion.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { ACTOR_PRINCIPALS, LOCAL_PRINCIPALS } from "../auth/route-policy.js";
@@ -535,24 +536,30 @@ function displayAttachmentResponse(
       `A browser-displayable representation is unavailable for ${normalized.mimeType}`,
     );
   }
-  const bytes = Buffer.from(normalized.bytes);
-  return new RouteResponse(bytes, {
+  const responseBytes: Uint8Array<ArrayBuffer> =
+    normalized.bytes.buffer instanceof ArrayBuffer
+      ? new Uint8Array(
+          normalized.bytes.buffer,
+          normalized.bytes.byteOffset,
+          normalized.bytes.byteLength,
+        )
+      : new Uint8Array(normalized.bytes);
+  return new RouteResponse(responseBytes, {
     "Content-Type": normalized.mimeType,
-    "Content-Length": String(bytes.length),
+    "Content-Length": String(responseBytes.byteLength),
     "Accept-Ranges": "none",
   });
 }
 
-function assertDisplayRequestSupported(
-  filename: string,
-  mimeType: string,
-  rangeHeader: string | undefined,
-): void {
+function assertDisplayRangeSupported(rangeHeader: string | undefined): void {
   if (rangeHeader) {
     throw new RangeNotSatisfiableError(
       "Range requests are not supported for display representations",
     );
   }
+}
+
+function assertDisplayImageCandidate(filename: string, mimeType: string): void {
   if (!mimeType.startsWith("image/") && !isHeicFilename(filename)) {
     throw new UnsupportedMediaTypeError(
       "Display representations are available only for image attachments",
@@ -601,15 +608,30 @@ function handleGetAttachmentContentRoute({
     }
 
     if (displayRepresentation) {
-      assertDisplayRequestSupported(
+      assertDisplayRangeSupported(headers["range"]);
+      assertDisplayImageCandidate(
         attachment.originalFilename,
         attachment.mimeType,
-        headers["range"],
       );
-      return displayAttachmentResponse(
-        attachment.mimeType,
-        readFileSync(resolvedPath),
-      );
+      const head = readFileHead(resolvedPath, 12);
+      if (isHeifImage(head)) {
+        return displayAttachmentResponse(
+          attachment.mimeType,
+          readFileSync(resolvedPath),
+        );
+      }
+      const displayMimeType = sniffImageMimeType(head) ?? attachment.mimeType;
+      if (!BROWSER_DISPLAY_IMAGE_MIME_TYPES.has(displayMimeType)) {
+        throw new UnsupportedMediaTypeError(
+          `A browser-displayable representation is unavailable for ${displayMimeType}`,
+        );
+      }
+      const displayFile = Bun.file(resolvedPath);
+      return new RouteResponse(displayFile, {
+        "Content-Type": displayMimeType,
+        "Content-Length": String(displayFile.size),
+        "Accept-Ranges": "none",
+      });
     }
 
     const file = Bun.file(resolvedPath);
@@ -671,10 +693,10 @@ function handleGetAttachmentContentRoute({
   }
 
   if (displayRepresentation) {
-    assertDisplayRequestSupported(
+    assertDisplayRangeSupported(headers["range"]);
+    assertDisplayImageCandidate(
       attachment.originalFilename,
       attachment.mimeType,
-      headers["range"],
     );
   }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -650,6 +650,7 @@ async function tryConsumeGuardianReply(params: {
  */
 function buildQueuedMessagePayloads(
   conversationId: string,
+  includeAttachmentContent: boolean,
 ): RuntimeMessagePayload[] {
   const conversation = findConversation(conversationId);
   if (!conversation) {
@@ -672,10 +673,14 @@ function buildQueuedMessagePayloads(
           sizeBytes:
             a.sizeBytes ?? (a.data ? Math.floor((a.data.length * 3) / 4) : 0),
           kind: classifyKind(a.mimeType),
-          ...(a.mimeType.startsWith("image/") && a.data
+          ...(includeAttachmentContent &&
+          a.mimeType.startsWith("image/") &&
+          a.data
             ? { data: a.data }
             : {}),
-          ...(a.thumbnailData ? { thumbnailData: a.thumbnailData } : {}),
+          ...(includeAttachmentContent && a.thumbnailData
+            ? { thumbnailData: a.thumbnailData }
+            : {}),
         }),
       );
 
@@ -737,6 +742,7 @@ export function handleListMessages({
   const beforeTimestampRaw = queryParams?.beforeTimestamp;
   const limitRaw = queryParams?.limit;
   const pageRaw = queryParams?.page;
+  const attachmentContentRaw = queryParams?.attachmentContent;
 
   // Validate: reject NaN values with 400
   if (beforeTimestampRaw != null && isNaN(Number(beforeTimestampRaw))) {
@@ -748,7 +754,13 @@ export function handleListMessages({
   if (pageRaw != null && pageRaw !== "latest") {
     throw new BadRequestError("page must be 'latest' when provided");
   }
+  if (attachmentContentRaw != null && attachmentContentRaw !== "metadata") {
+    throw new BadRequestError(
+      "attachmentContent must be 'metadata' when provided",
+    );
+  }
   const isLatestPage = pageRaw === "latest";
+  const includeAttachmentContent = attachmentContentRaw !== "metadata";
 
   if (!resolvedConversationId) {
     // Unresolved conversation keys still need to advertise the stable
@@ -987,7 +999,9 @@ export function handleListMessages({
     if (m.id) {
       const idsToQuery = [m.id, ...mergedMessageIds];
       const linked = idsToQuery.flatMap((id) =>
-        getAttachmentMetadataForMessage(id),
+        getAttachmentMetadataForMessage(id, {
+          includeThumbnail: includeAttachmentContent,
+        }),
       );
       if (linked.length > 0) {
         msgAttachments = linked.map((a) => {
@@ -1001,7 +1015,7 @@ export function handleListMessages({
           const isImage = a.mimeType.startsWith("image/");
           const isLegacyHeic = !isImage && isHeicFilename(a.originalFilename);
           const full =
-            isImage || isLegacyHeic
+            includeAttachmentContent && (isImage || isLegacyHeic)
               ? getAttachmentById(a.id, { hydrateFileData: true })
               : null;
           const display = full?.dataBase64
@@ -1043,6 +1057,7 @@ export function handleListMessages({
       m.content,
       attachmentBlocks,
       m.id ?? undefined,
+      { includeMediaData: includeAttachmentContent },
     );
 
     const toolCalls = enrichToolCallsWithQuestion(
@@ -1180,7 +1195,12 @@ export function handleListMessages({
   // yet persisted, so they belong only on a request for the latest content —
   // never on an older-history page (`beforeTimestamp` set).
   if (beforeTimestamp == null) {
-    messages.push(...buildQueuedMessagePayloads(resolvedConversationId));
+    messages.push(
+      ...buildQueuedMessagePayloads(
+        resolvedConversationId,
+        includeAttachmentContent,
+      ),
+    );
   }
 
   if (isPaginated) {
@@ -2908,6 +2928,13 @@ export const ROUTES: RouteDefinition[] = [
         type: "integer",
         required: false,
         description: "Maximum number of messages to return.",
+      },
+      {
+        name: "attachmentContent",
+        required: false,
+        description:
+          "Set to 'metadata' to omit attachment and tool-image bytes while retaining stable references and metadata.",
+        schema: { type: "string", enum: ["metadata"] },
       },
     ],
     responseBody: z.object({


### PR DESCRIPTION
## Summary
- add opt-in `attachmentContent=metadata` history responses that retain legacy attachment/content-block shapes and stable tool image references without selecting, hydrating, or serializing attachment bytes
- add opt-in `representation=display` to the authenticated attachment-content route for browser-safe image bytes, including HEIF-to-JPEG conversion when available
- preserve the default/original history and attachment-content behavior, including file-backed Range responses
- document both query contracts in the generated OpenAPI specification

## Compatibility and bounds
- the legacy flat `attachments` array remains present
- default history responses continue to inline image/thumbnail data as before
- metadata mode covers persisted rows, queued rows, attachment content blocks, and nested tool-result media
- display mode is image-only, rejects Range, and fails explicitly when HEIF conversion or a browser-safe MIME is unavailable

## Validation
- `bun test src/__tests__/list-messages-attachments.test.ts src/__tests__/list-messages-queued.test.ts src/__tests__/attachments-store.test.ts src/__tests__/runtime-attachment-metadata.test.ts` (106 passed)
- `bun run typecheck:fast`
- pre-push `bunx tsc --noEmit`
- scoped ESLint and Prettier checks
- `bun run generate:openapi -- --check`

Closes #39011
Part of #39009
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->