### PR TITLE
fix(assistant): request-body parse errors return 400, not 500

### DIFF
--- a/assistant/src/runtime/routes/__tests__/defer-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/defer-routes.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Request-body validation for the defer routes.
+ *
+ * Each handler validates with `parseBody`, so a malformed body is rejected
+ * with a `BadRequestError` (→ 400) instead of the raw `ZodError` a bare
+ * `.parse()` surfaces — which neither adapter maps, so it becomes a 500.
+ * Validation runs before the schedule store is touched.
+ *
+ * These handlers are `async`, so the rejection surfaces as a rejected promise.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { ROUTES } from "../defer-routes.js";
+import { BadRequestError } from "../errors.js";
+
+const routeFor = (operationId: string) => {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`no route: ${operationId}`);
+  }
+  return route;
+};
+
+describe("defer route body validation", () => {
+  test("defer_create rejects a body missing conversationId", async () => {
+    await expect(
+      routeFor("defer_create").handler({ body: {} as Record<string, unknown> }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("defer_list rejects a non-string conversationId", async () => {
+    await expect(
+      routeFor("defer_list").handler({
+        body: { conversationId: 123 } as unknown as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/events-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/events-routes.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Request-body validation for the emit_event route.
+ *
+ * The handler validates with `parseBody`, so a malformed body is rejected with
+ * a `BadRequestError` (→ 400) instead of the raw `ZodError` a bare `.parse()`
+ * surfaces — which neither adapter maps, so it becomes a 500 — before any
+ * event is emitted.
+ *
+ * The handler is synchronous, so `parseBody` throws during the call — hence
+ * `expect(() => …).toThrow` rather than the `.rejects` form.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { BadRequestError } from "../errors.js";
+import { ROUTES } from "../events-routes.js";
+
+const routeFor = (operationId: string) => {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`no route: ${operationId}`);
+  }
+  return route;
+};
+
+describe("emit_event body validation", () => {
+  test("rejects an out-of-enum kind with BadRequestError", () => {
+    expect(() =>
+      routeFor("emit_event").handler({
+        body: { kind: "bogus" } as Record<string, unknown>,
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("rejects a body missing kind with BadRequestError", () => {
+    expect(() =>
+      routeFor("emit_event").handler({ body: {} as Record<string, unknown> }),
+    ).toThrow(BadRequestError);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/ui-request-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/ui-request-routes.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Request-body validation for the ui_request route.
+ *
+ * The handler validates with `parseBody`, so a malformed body is rejected with
+ * a `BadRequestError` (→ 400) instead of the raw `ZodError` a bare `.parse()`
+ * surfaces — which neither adapter maps, so it becomes a 500 — before any
+ * interactive UI surface is requested.
+ *
+ * The handler is `async`, so the rejection surfaces as a rejected promise.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { BadRequestError } from "../errors.js";
+import { ROUTES } from "../ui-request-routes.js";
+
+const route = ROUTES[0];
+
+describe("ui_request body validation", () => {
+  test("rejects a body missing required fields with BadRequestError", async () => {
+    await expect(
+      route.handler({ body: {} as Record<string, unknown> }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("rejects an out-of-enum surfaceType with BadRequestError", async () => {
+    await expect(
+      route.handler({
+        body: {
+          conversationId: "c1",
+          surfaceType: "bogus",
+          data: {},
+        } as unknown as Record<string, unknown>,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/user-routes-cli.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-routes-cli.test.ts
@@ -17,6 +17,7 @@ import {
   getWorkspacePluginsDir,
   getWorkspaceRoutesDir,
 } from "../../../util/platform.js";
+import { BadRequestError } from "../errors.js";
 import type { RouteHandlerArgs } from "../types.js";
 import { ROUTES } from "../user-routes-cli.js";
 
@@ -186,5 +187,11 @@ describe("routes inspect", () => {
     await expect(
       inspectHandler({ body: { path: "plugins/dead/status" } }),
     ).rejects.toThrow();
+  });
+
+  test("rejects a body missing path with BadRequestError", async () => {
+    await expect(
+      inspectHandler({ body: {} as Record<string, unknown> }),
+    ).rejects.toThrow(BadRequestError);
   });
 });

--- a/assistant/src/runtime/routes/__tests__/watcher-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/watcher-routes.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Request-body validation for the watcher routes.
+ *
+ * Each handler validates with `parseBody`, so a malformed body is rejected
+ * with a `BadRequestError` (→ 400) instead of the raw `ZodError` a bare
+ * `.parse()` surfaces — which neither adapter maps, so it becomes a 500.
+ * Validation runs before the watcher store is touched.
+ *
+ * These handlers are synchronous, so `parseBody` throws during the call —
+ * hence `expect(() => …).toThrow` rather than the `.rejects` form.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { BadRequestError } from "../errors.js";
+import { ROUTES } from "../watcher-routes.js";
+
+const routeFor = (operationId: string) => {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`no route: ${operationId}`);
+  }
+  return route;
+};
+
+describe("watcher route body validation", () => {
+  test("watcher_create rejects a body missing required fields", () => {
+    expect(() =>
+      routeFor("watcher_create").handler({
+        body: {} as Record<string, unknown>,
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("watcher_update rejects a body missing watcher_id", () => {
+    expect(() =>
+      routeFor("watcher_update").handler({
+        body: { name: "renamed" } as Record<string, unknown>,
+      }),
+    ).toThrow(BadRequestError);
+  });
+});

--- a/assistant/src/runtime/routes/defer-routes.ts
+++ b/assistant/src/runtime/routes/defer-routes.ts
@@ -16,6 +16,7 @@ import {
 } from "../../schedule/schedule-store.js";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ── Constants ─────────────────────────────────────────────────────────
@@ -63,8 +64,10 @@ const DeferCancelParams = z.object({
 // ── Handlers ──────────────────────────────────────────────────────────
 
 async function handleDeferCreate({ body = {} }: RouteHandlerArgs) {
-  const { conversationId, hint, delaySeconds, fireAt, name } =
-    DeferCreateParams.parse(body);
+  const { conversationId, hint, delaySeconds, fireAt, name } = parseBody(
+    DeferCreateParams,
+    body,
+  );
 
   const conversation = getConversation(conversationId);
   if (!conversation) {
@@ -113,7 +116,7 @@ async function handleDeferCreate({ body = {} }: RouteHandlerArgs) {
 }
 
 async function handleDeferList({ body = {} }: RouteHandlerArgs) {
-  const { conversationId } = DeferListParams.parse(body);
+  const { conversationId } = parseBody(DeferListParams, body);
 
   const jobs = listSchedules({
     mode: "wake",
@@ -138,7 +141,7 @@ async function handleDeferList({ body = {} }: RouteHandlerArgs) {
 }
 
 async function handleDeferCancel({ body = {} }: RouteHandlerArgs) {
-  const { id, all, conversationId } = DeferCancelParams.parse(body);
+  const { id, all, conversationId } = parseBody(DeferCancelParams, body);
 
   if (id) {
     const job = getSchedule(id);

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -48,6 +48,7 @@ import {
   NotFoundError,
   ServiceUnavailableError,
 } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("events-routes");
@@ -652,7 +653,7 @@ export const ROUTES: RouteDefinition[] = [
     requestBody: EmitEventBodySchema,
     responseStatus: "204",
     handler: ({ body }) => {
-      const { kind } = EmitEventBodySchema.parse(body);
+      const { kind } = parseBody(EmitEventBodySchema, body);
       if (kind === "contacts_changed") {
         notifyContactsChanged();
       }

--- a/assistant/src/runtime/routes/ui-request-routes.ts
+++ b/assistant/src/runtime/routes/ui-request-routes.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { requestInteractiveUi } from "../interactive-ui.js";
 import { RESERVED_ACTION_IDS } from "../interactive-ui-types.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ── Param schema ──────────────────────────────────────────────────────
@@ -36,7 +37,7 @@ const UiRequestParams = z.object({
 // ── Handler ───────────────────────────────────────────────────────────
 
 async function handleUiRequest({ body = {} }: RouteHandlerArgs) {
-  const validated = UiRequestParams.parse(body);
+  const validated = parseBody(UiRequestParams, body);
   return requestInteractiveUi(validated);
 }
 

--- a/assistant/src/runtime/routes/user-routes-cli.ts
+++ b/assistant/src/runtime/routes/user-routes-cli.ts
@@ -16,6 +16,7 @@ import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
 import { getWorkspaceDir, getWorkspaceRoutesDir } from "../../util/platform.js";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { NotFoundError } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 import {
   HANDLER_EXTENSIONS,
@@ -211,7 +212,7 @@ async function handleUserRoutesList() {
 }
 
 async function handleUserRoutesInspect({ body = {} }: RouteHandlerArgs) {
-  const routePath = normalizeInspectPath(InspectParams.parse(body).path);
+  const routePath = normalizeInspectPath(parseBody(InspectParams, body).path);
 
   const location = routePath.includes("..")
     ? null

--- a/assistant/src/runtime/routes/watcher-routes.ts
+++ b/assistant/src/runtime/routes/watcher-routes.ts
@@ -18,6 +18,7 @@ import {
 } from "../../watcher/watcher-store.js";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
+import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ── Param schemas ─────────────────────────────────────────────────────
@@ -69,7 +70,7 @@ function handleWatcherCreate({ body = {} }: RouteHandlerArgs) {
     poll_interval_ms: pollIntervalMs,
     config,
     credential_service: credentialServiceOverride,
-  } = WatcherCreateParams.parse(body);
+  } = parseBody(WatcherCreateParams, body);
 
   const provider = getWatcherProvider(providerId);
   if (!provider) {
@@ -98,8 +99,10 @@ function handleWatcherCreate({ body = {} }: RouteHandlerArgs) {
 }
 
 function handleWatcherList({ body = {} }: RouteHandlerArgs) {
-  const { watcher_id: watcherId, enabled_only: enabledOnly } =
-    WatcherListParams.parse(body);
+  const { watcher_id: watcherId, enabled_only: enabledOnly } = parseBody(
+    WatcherListParams,
+    body,
+  );
 
   if (watcherId) {
     const watcher = getWatcher(watcherId);
@@ -121,7 +124,7 @@ function handleWatcherUpdate({ body = {} }: RouteHandlerArgs) {
     poll_interval_ms: pollIntervalMs,
     enabled,
     config,
-  } = WatcherUpdateParams.parse(body);
+  } = parseBody(WatcherUpdateParams, body);
 
   const updates: {
     name?: string;
@@ -152,7 +155,7 @@ function handleWatcherUpdate({ body = {} }: RouteHandlerArgs) {
 }
 
 function handleWatcherDelete({ body = {} }: RouteHandlerArgs) {
-  const { watcher_id: watcherId } = WatcherDeleteParams.parse(body);
+  const { watcher_id: watcherId } = parseBody(WatcherDeleteParams, body);
 
   const watcher = getWatcher(watcherId);
   if (!watcher) {
@@ -172,7 +175,7 @@ function handleWatcherDigest({ body = {} }: RouteHandlerArgs) {
     watcher_id: watcherId,
     hours,
     limit,
-  } = WatcherDigestParams.parse(body);
+  } = parseBody(WatcherDigestParams, body);
 
   const since = Date.now() - hours * 3_600_000;
   const events = listWatcherEvents({ watcherId, limit, since });


### PR DESCRIPTION
## Prompt / plan

Part of **LUM-2796** — enforce each route's declared `requestBody` Zod schema at the boundary. This cluster fixes a **latent bug** surfaced while auditing how routes handle their body: several routes validate with a bare `Schema.parse(body)`, which throws a `ZodError` on malformed input. Neither the HTTP nor the IPC adapter maps `ZodError`, so those routes return **500 for what is a client error**.

Routing them through the shared `parseBody` helper (which throws `BadRequestError` → mapped to 400 by both adapters) fixes the status without changing anything else. Converted **11 routes across 5 files**:

- `defer-routes` — `defer_create`, `defer_list`, `defer_cancel`
- `watcher-routes` — `watcher_create`, `watcher_list`, `watcher_update`, `watcher_delete`, `watcher_digest`
- `ui-request-routes` — `ui_request`
- `events-routes` — `emit_event`
- `user-routes-cli` — `user_routes_inspect`

Each route **already** declared `requestBody: <schema>` **and** called `<schema>.parse(body)`, so this is the strongest "clean" case: `parseBody` returns the identical parsed value `.parse` did, so valid requests behave identically — only the error status for malformed input changes (500 → 400). No schema changes, no OpenAPI changes.

## Test plan

- New co-located reject tests for defer / watcher / ui_request / emit_event, plus a case added to the existing `user-routes-cli` test: a malformed body rejects with `BadRequestError`. Sync handlers (watcher, emit_event) use `expect(() => …).toThrow`; async handlers (defer, ui_request, user_routes_inspect) use `.rejects.toThrow`. `bun test` → 17 pass.
- `bun run typecheck` (assistant) clean — `parseBody`'s `z.infer<Schema>` return type is identical to `Schema.parse(body)`, so no call site needed adjustment.
- `bun run generate:openapi -- --check` → spec unchanged (the `requestBody` declarations were already present and are untouched).
- Pre-commit/pre-push: prettier + eslint (0 errors; the remaining `curly` warnings are pre-existing handler one-liners) + typecheck.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Wgp8RrNu1qTXeGPVaq9HD)_