### PR TITLE
test(web): use the real seeded default (Relaxed) in the channel-list story

### DIFF
--- a/clients/web/src/domains/channels/components/slack-channel-list.stories.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-list.stories.tsx
@@ -58,8 +58,9 @@ const meta: Meta<typeof SlackChannelList> = {
     slackHandle: "@example-assistant",
     channels: MIXED_CHANNELS,
     // Gateway-resolved fall-through (no broader-scope cells → the owner's
-    // global interactive threshold, Conservative here).
-    defaultTier: "low",
+    // global interactive threshold, which defaults to Relaxed / medium — the
+    // seeded `auto_approve_thresholds.interactive` value).
+    defaultTier: "medium",
   },
   decorators: [
     // Mirrors the Slack sub-tab's card column (flex flex-col gap-4 in
@@ -97,7 +98,7 @@ export const Empty: Story = {
 /**
  * `eng-releases` is pinned to Full access — its picker names that level with no
  * "default" marker, while every cell-less row shows the resolved default
- * ("Conservative · default"). Re-selecting the default-marked level clears the
+ * ("Relaxed · default"). Re-selecting the default-marked level clears the
  * override.
  */
 export const OverriddenChannel: Story = {


### PR DESCRIPTION
## Prompt / plan
A full walkthrough of the permission system confirmed that a Slack channel's resolved Assistant Access default comes from the global `auto_approve_thresholds.interactive` threshold, which is **seeded to `medium` (Relaxed)**. The `SlackChannelList` Storybook fixture hardcoded `defaultTier: "low"` (Conservative), which made the demo imply Conservative is the default for every channel — misleading, since no per-channel-type Access default is seeded and the real fall-through is Relaxed. This corrects the fixture (and the two doc comments that named Conservative) to the real seeded default, so the rows read "Relaxed · default".

Story-only; no runtime behavior changes.

## Test plan
- `bunx tsc --noEmit` + ESLint clean (pre-commit hook).
- Storybook `Channels/SlackChannelList` now renders "Relaxed · default" on cell-less rows; `OverriddenChannel` still contrasts a pinned "Full access" against the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeiZ9nRv2AdHtBCcGmCoJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeiZ9nRv2AdHtBCcGmCoJY)_