### PR TITLE
feat(web): update guided tour copy

### DIFF
--- a/clients/web/src/domains/chat/in-chat-onboarding/tour-steps.ts
+++ b/clients/web/src/domains/chat/in-chat-onboarding/tour-steps.ts
@@ -42,7 +42,7 @@ export const TOUR_INTRO: TourStep = {
 export const TOUR_SIDEBAR: TourStep = {
   id: "side-menu",
   title: "Your sidebar",
-  body: "Everything lives here — our chats, my page, your settings.",
+  body: "Everything lives here: our chats, my page, your settings.",
   icon: PanelLeft,
 };
 
@@ -55,7 +55,7 @@ export const TOUR_SIDEBAR: TourStep = {
 export const TOUR_COMPOSER: TourStep = {
   id: "chat-composer",
   title: "Your chat",
-  body: "Don't get distracted by all the noise, start by talking to me!",
+  body: "I have tons of features, but let's chat before you start exploring!",
   icon: MessageCircle,
 };
 
@@ -63,13 +63,13 @@ export const TOUR_STEPS: TourStep[] = [
   {
     id: "assistant-page",
     title: "Your Assistant",
-    body: "My personality, the library of things I've built for you, and more. I keep it all tidy — you never have to.",
+    body: "My personality, things I've built for you, and more. I keep it all tidy so you never have to.",
     icon: Brain,
   },
   {
     id: "new-chat",
     title: "New Chat",
-    body: "A fresh chat when you want one.",
+    body: "You probably already know this one.",
     icon: Plus,
   },
   {


### PR DESCRIPTION
## Summary
Refreshes the in-chat guided tour narration to match the latest copy doc:

| Step | Before | After |
|---|---|---|
| Sidebar | Everything lives here — our chats, my page, your settings. | Everything lives here: our chats, my page, your settings. |
| Assistant page | My personality, the library of things I've built for you, and more. I keep it all tidy — you never have to. | My personality, things I've built for you, and more. I keep it all tidy so you never have to. |
| New chat | A fresh chat when you want one. | You probably already know this one. |
| Chat input (finale) | Don't get distracted by all the noise, start by talking to me! | I have tons of features, but let's chat before you start exploring! |

Intro ("Let me show you around") and Settings copy already matched the doc, as do all chip titles and icons — the intro already renders without a chip.

Copy-only change; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)