### PR TITLE
Default the voice-mode flag on

### DIFF
--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -123,7 +123,7 @@
       "key": "voice-mode",
       "label": "Voice Mode",
       "description": "Show the live voice conversation button in the composer",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "voice-duplex-handoff",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -123,7 +123,7 @@
       "key": "voice-mode",
       "label": "Voice Mode",
       "description": "Show the live voice conversation button in the composer",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "voice-duplex-handoff",


### PR DESCRIPTION
## What

Flips `voice-mode`'s registry `defaultEnabled` from `false` → `true` and re-syncs the bundled copies.

## Why

Voice mode is launching, so the live voice button in the composer should be on by default. The registry default is the **fallback** value a consumer resolves to when it has no remote platform snapshot (undeclared flags fail closed). Direct precedent: `channel-trust-floors` flipped its registry default the same way.

## Changes

- `meta/feature-flags/feature-flag-registry.json` — `voice-mode` → `defaultEnabled: true`
- `clients/web/src/lib/feature-flags/feature-flag-registry.json` — synced copy (via `bun run meta/sync-bundled-copies.ts`)
- Assistant/gateway bundled copies regenerate at build (gitignored); `--check` confirms no drift.

## ⚠️ Complementary platform step

This only sets the **local/fallback** default. **Production serving is LaunchDarkly targeting** in `vellum-assistant-platform` — the `voice-mode` flag must also be set to serve `true` there (dashboard/terraform) for the rollout to actually reach managed users. `voice-mode` already has a platform terraform entry (it's not in `PENDING_PLATFORM_PRS.md`), so this is a targeting change on the existing flag, not a new provision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)