### PR TITLE
fix(assistant): resolve the voice front model through a profile, not a model pin

### DIFF
--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -159,8 +159,7 @@ describe("resolver integration", () => {
       }
       const expected = CODE_DEFAULT_PROFILE_ENTRIES[dflt.profile];
       const resolved = resolveCallSiteConfig(callSite as LLMCallSite, llm);
-      // A site-level model pin (e.g. voiceFrontDecision's latency pin)
-      // legitimately overrides the profile's model.
+      // A site-level model pin legitimately overrides the profile's model.
       expect(resolved.model).toBe((dflt.model ?? expected.model) as string);
     }
   });
@@ -207,6 +206,44 @@ describe("resolver integration", () => {
       CODE_DEFAULT_PROFILE_ENTRIES.balanced.model as string,
     );
     expect(resolved.model).not.toBe("claude-sonnet-4-6");
+  });
+
+  test("a pre-existing user profile cannot shadow an internal profile's call sites", () => {
+    // `latency-optimized` was a legal custom profile name before it was
+    // reserved, so a workspace can already hold one. The user-shadow rule
+    // that lets a user replace a default they can select must not apply to a
+    // name they were never able to select: the voice front model would
+    // silently run on an arbitrary user model.
+    const llm = LLMSchema.parse({
+      profiles: {
+        "latency-optimized": {
+          source: "user",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          provider_connection: "anthropic-personal",
+          maxTokens: 32000,
+          effort: "high",
+        },
+      },
+    });
+    const body = CODE_DEFAULT_PROFILE_ENTRIES["latency-optimized"];
+    for (const callSite of ["voiceFrontDoor", "voiceFrontDecision"] as const) {
+      const resolved = resolveCallSiteConfig(callSite, llm);
+      expect(resolved.model).toBe(body.model as string);
+      expect(resolved.model).not.toBe("claude-opus-4-6");
+      expect(String(resolved.provider)).toBe("vellum");
+    }
+    // The entry itself is untouched — still on disk, still listed, and still
+    // a valid `activeProfile` reference for the user who created it.
+    expect(getEffectiveProfiles(llm.profiles)["latency-optimized"]?.model).toBe(
+      "claude-opus-4-6",
+    );
+    expect(() =>
+      LLMSchema.parse({
+        activeProfile: "latency-optimized",
+        profiles: llm.profiles,
+      }),
+    ).not.toThrow();
   });
 });
 

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -121,28 +121,25 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     effort: "low",
     thinking: { enabled: false },
   },
+  // Endpoint decisions gate live-voice turn-end latency, and `cost-optimized`'s
+  // upstream cannot fit any usable decision budget (~1s+ per forced tool call).
+  // `latency-optimized` is the internal latency-class profile (see
+  // default-profile-catalog.ts): managed installs get the pinned latency model,
+  // BYOK installs resolve their own provider's latency model through the intent
+  // table rather than a model id they may hold no credential for.
   voiceFrontDecision: {
-    profile: "cost-optimized",
-    // Endpoint decisions gate live-voice turn-end latency, and the default
-    // profile's upstream cannot fit any usable decision budget (~1s+ per
-    // forced tool call). Pin a latency-optimized model instead — the bare
-    // model pin lets the catalog imply the provider, which preserves the
-    // provider-agnostic managed connection. Replace only with a model whose
-    // managed credentials are provisioned in every environment.
-    model: "claude-haiku-4-5-20251001",
+    profile: "latency-optimized",
     effort: "low",
     thinking: { enabled: false },
   },
+  // The front-door leg fronts EVERY unified live-voice turn and its leading
+  // tokens ARE the endpointing/triage verdict, so both TTFT variance and
+  // judgment quality gate the whole call. Same latency class as the endpoint
+  // decider: live drives showed the cost-optimized upstream with multi-second
+  // cross-session TTFT tails and over-escalation of small talk under open-task
+  // context pressure.
   voiceFrontDoor: {
-    profile: "cost-optimized",
-    // The front-door leg fronts EVERY unified live-voice turn and its
-    // leading tokens ARE the endpointing/triage verdict, so both TTFT
-    // variance and judgment quality gate the whole call. Pin the same
-    // latency-class model the endpoint decider uses: live drives showed the
-    // cost-optimized upstream with multi-second cross-session TTFT tails
-    // and over-escalation of small talk under open-task context pressure.
-    // Same model-pin caveat as voiceFrontDecision above.
-    model: "claude-haiku-4-5-20251001",
+    profile: "latency-optimized",
     effort: "low",
     thinking: { enabled: false },
   },

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -64,70 +64,69 @@ export type DefaultProfileTemplate = Omit<
  * Overwritten in workspace config on every daemon boot so Vellum can push
  * model/config updates to customers in new releases.
  */
-const VELLUM_PROFILE_IMPLS: Record<ProfileMatrixKey, DefaultProfileTemplate> =
-  {
-    balanced: {
-      model: "accounts/fireworks/models/glm-5p2",
-      provider: "vellum",
-      source: "managed",
-      label: "Balanced",
-      description: "Good balance of quality, cost, and speed",
-      maxTokens: 32000,
-      effort: "high",
-      thinking: { enabled: true, streamThinking: true },
-      contextWindow: {
-        maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
-      },
+const VELLUM_PROFILE_IMPLS: Record<ProfileMatrixKey, DefaultProfileTemplate> = {
+  balanced: {
+    model: "accounts/fireworks/models/glm-5p2",
+    provider: "vellum",
+    source: "managed",
+    label: "Balanced",
+    description: "Good balance of quality, cost, and speed",
+    maxTokens: 32000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: {
+      maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
     },
-    "quality-optimized": {
-      model: "claude-fable-5",
-      provider: "vellum",
-      source: "managed",
-      label: "Quality",
-      description: "High-quality results with the most capable model",
-      maxTokens: 32000,
-      effort: "high",
-      thinking: { enabled: true, streamThinking: true },
-      contextWindow: {
-        maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
-      },
+  },
+  "quality-optimized": {
+    model: "claude-fable-5",
+    provider: "vellum",
+    source: "managed",
+    label: "Quality",
+    description: "High-quality results with the most capable model",
+    maxTokens: 32000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: {
+      maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
     },
-    "cost-optimized": {
-      model: "accounts/fireworks/models/deepseek-v4-flash",
-      provider: "vellum",
-      source: "managed",
-      label: "Speed",
-      description: "Fastest responses at lower cost (DeepSeek V4 Flash)",
-      maxTokens: 8192,
-      // Explicit reasoning opt-out. OpenAI-compat APIs default reasoning to
-      // "medium" when the field is omitted, and effort-driven providers encode
-      // disabled thinking through this same knob (see
-      // DISABLED_THINKING_USES_EFFORT_PROVIDERS in providers/retry.ts).
-      effort: "none",
-      thinking: { enabled: false, streamThinking: false },
-      contextWindow: {
-        maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
-      },
+  },
+  "cost-optimized": {
+    model: "accounts/fireworks/models/deepseek-v4-flash",
+    provider: "vellum",
+    source: "managed",
+    label: "Speed",
+    description: "Fastest responses at lower cost (DeepSeek V4 Flash)",
+    maxTokens: 8192,
+    // Explicit reasoning opt-out. OpenAI-compat APIs default reasoning to
+    // "medium" when the field is omitted, and effort-driven providers encode
+    // disabled thinking through this same knob (see
+    // DISABLED_THINKING_USES_EFFORT_PROVIDERS in providers/retry.ts).
+    effort: "none",
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: {
+      maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
     },
-    "latency-optimized": {
-      // The managed latency class. `cost-optimized`'s upstream showed
-      // multi-second cross-session TTFT tails on live voice drives, which the
-      // front model's leading tokens cannot absorb — they ARE the turn-taking
-      // verdict. Replace only with a model whose managed credentials are
-      // provisioned in every environment.
-      model: "claude-haiku-4-5-20251001",
-      provider: "vellum",
-      source: "managed",
-      label: "Latency",
-      description: "Lowest time-to-first-token, for real-time call sites",
-      maxTokens: 8192,
-      effort: "low",
-      thinking: { enabled: false, streamThinking: false },
-      contextWindow: {
-        maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
-      },
+  },
+  "latency-optimized": {
+    // The managed latency class. `cost-optimized`'s upstream showed
+    // multi-second cross-session TTFT tails on live voice drives, which the
+    // front model's leading tokens cannot absorb — they ARE the turn-taking
+    // verdict. Replace only with a model whose managed credentials are
+    // provisioned in every environment.
+    model: "claude-haiku-4-5-20251001",
+    provider: "vellum",
+    source: "managed",
+    label: "Latency",
+    description: "Lowest time-to-first-token, for real-time call sites",
+    maxTokens: 8192,
+    effort: "low",
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: {
+      maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
     },
-  };
+  },
+};
 
 /**
  * The BYOK implementation of each default profile intent, shared by every
@@ -412,6 +411,17 @@ function resolveAgainstBody(
 ): ProfileEntry | undefined {
   if (body == null) {
     return workspace;
+  }
+  // An internal profile's body is code-owned outright — no workspace overlay,
+  // not even a user-owned shadow. The shadow rule below exists so a user can
+  // deliberately replace a default they can see and select; an internal name
+  // was never selectable, so a same-named workspace entry (legal before the
+  // name was reserved) is unrelated state, not an override. Honoring it would
+  // silently hand a latency-class call site an arbitrary user model. The
+  // entry itself is untouched: it stays in `llm.profiles`, stays listed, and
+  // stays valid as an `activeProfile` reference.
+  if (isInternalProfileKey(name)) {
+    return { ...body };
   }
   if (workspace == null) {
     return name === OS_BETA_PROFILE_KEY ? undefined : { ...body };

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -8,7 +8,11 @@ import {
   DEFAULT_PROFILE_PROVIDERS,
   type DefaultProfileKey,
   type DefaultProfileProvider,
+  INTERNAL_PROFILE_KEYS,
+  type InternalProfileKey,
   OS_BETA_PROFILE_KEY,
+  PROFILE_MATRIX_KEYS,
+  type ProfileMatrixKey,
 } from "./default-profile-names.js";
 import { resolveDefaultConnectionName } from "./default-provider-resolution.js";
 import {
@@ -60,7 +64,7 @@ export type DefaultProfileTemplate = Omit<
  * Overwritten in workspace config on every daemon boot so Vellum can push
  * model/config updates to customers in new releases.
  */
-const VELLUM_PROFILE_IMPLS: Record<DefaultProfileKey, DefaultProfileTemplate> =
+const VELLUM_PROFILE_IMPLS: Record<ProfileMatrixKey, DefaultProfileTemplate> =
   {
     balanced: {
       model: "accounts/fireworks/models/glm-5p2",
@@ -105,6 +109,24 @@ const VELLUM_PROFILE_IMPLS: Record<DefaultProfileKey, DefaultProfileTemplate> =
         maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
       },
     },
+    "latency-optimized": {
+      // The managed latency class. `cost-optimized`'s upstream showed
+      // multi-second cross-session TTFT tails on live voice drives, which the
+      // front model's leading tokens cannot absorb — they ARE the turn-taking
+      // verdict. Replace only with a model whose managed credentials are
+      // provisioned in every environment.
+      model: "claude-haiku-4-5-20251001",
+      provider: "vellum",
+      source: "managed",
+      label: "Latency",
+      description: "Lowest time-to-first-token, for real-time call sites",
+      maxTokens: 8192,
+      effort: "low",
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: {
+        maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+      },
+    },
   };
 
 /**
@@ -115,7 +137,7 @@ const VELLUM_PROFILE_IMPLS: Record<DefaultProfileKey, DefaultProfileTemplate> =
  * chosen provider).
  */
 const BYOK_PROFILE_IMPLS: Record<
-  DefaultProfileKey,
+  ProfileMatrixKey,
   Omit<DefaultProfileTemplate, "provider">
 > = {
   balanced: {
@@ -148,6 +170,16 @@ const BYOK_PROFILE_IMPLS: Record<
     thinking: { enabled: false, streamThinking: false },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
+  "latency-optimized": {
+    intent: "latency-optimized",
+    source: "user",
+    label: "Latency",
+    description: "Lowest time-to-first-token, for real-time call sites",
+    maxTokens: 8192,
+    effort: "low",
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
 };
 
 /**
@@ -155,10 +187,10 @@ const BYOK_PROFILE_IMPLS: Record<
  * implementation of default profile `key` on `provider`.
  */
 export const PROFILE_IMPLS: Record<
-  DefaultProfileKey,
+  ProfileMatrixKey,
   Record<DefaultProfileProvider, DefaultProfileTemplate>
 > = Object.fromEntries(
-  DEFAULT_PROFILE_KEYS.map((key) => [
+  PROFILE_MATRIX_KEYS.map((key) => [
     key,
     Object.fromEntries(
       DEFAULT_PROFILE_PROVIDERS.map((provider) => [
@@ -170,14 +202,16 @@ export const PROFILE_IMPLS: Record<
     ) as Record<DefaultProfileProvider, DefaultProfileTemplate>,
   ]),
 ) as Record<
-  DefaultProfileKey,
+  ProfileMatrixKey,
   Record<DefaultProfileProvider, DefaultProfileTemplate>
 >;
 
 /**
  * Managed profiles, i.e. the `vellum` column keyed by profile name. Seeded
  * into workspace config on every daemon boot; platform overlays
- * (`preserveProfileNames`) take precedence when present.
+ * (`preserveProfileNames`) take precedence when present. Keyed by the
+ * user-facing defaults only — an internal profile is code-resolved and never
+ * materialized into workspace config.
  */
 export const MANAGED_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
   Object.fromEntries(
@@ -224,6 +258,7 @@ export const OS_BETA_PROFILE_TEMPLATE: DefaultProfileTemplate = {
 // the on-disk entry's `source` being `managed`.
 export const INVARIANT_PROFILE_NAMES = new Set<string>([
   ...DEFAULT_PROFILE_KEYS,
+  ...INTERNAL_PROFILE_KEYS,
   OS_BETA_PROFILE_KEY,
 ]);
 
@@ -236,6 +271,7 @@ export const INVARIANT_PROFILE_NAMES = new Set<string>([
 // same-named user profile.
 export const MANAGED_PROFILE_NAMES = new Set<string>([
   ...DEFAULT_PROFILE_KEYS,
+  ...INTERNAL_PROFILE_KEYS,
   OS_BETA_PROFILE_KEY,
 ]);
 
@@ -271,7 +307,7 @@ export function materializeProfile(
 // `PROVIDER_MODEL_INTENTS`' own check): exactly one of `intent`/`model` is
 // set, and every pinned model id exists in PROVIDER_CATALOG for its
 // underlying provider — catching drift when a model is renamed or removed.
-for (const key of DEFAULT_PROFILE_KEYS) {
+for (const key of PROFILE_MATRIX_KEYS) {
   for (const provider of DEFAULT_PROFILE_PROVIDERS) {
     const impl = PROFILE_IMPLS[key][provider];
     if ((impl.model == null) === (impl.intent == null)) {
@@ -303,7 +339,7 @@ for (const key of DEFAULT_PROFILE_KEYS) {
 
 function buildDefaultProfileEntries(): Record<string, ProfileEntry> {
   const entries: Record<string, ProfileEntry> = {};
-  for (const key of DEFAULT_PROFILE_KEYS) {
+  for (const key of PROFILE_MATRIX_KEYS) {
     const impl = PROFILE_IMPLS[key].vellum;
     entries[key] = materializeProfile(impl, impl.provider);
   }
@@ -423,11 +459,27 @@ export function isDefaultProfileKey(name: string): name is DefaultProfileKey {
   return (DEFAULT_PROFILE_KEYS as readonly string[]).includes(name);
 }
 
+/**
+ * Whether a name is implemented by the intent × provider matrix — the
+ * user-facing defaults plus the internal call-site-only profiles. This is the
+ * predicate resolution uses: an internal profile must resolve through the
+ * default provider's column exactly like a default, even though it is never
+ * listed or seeded.
+ */
+export function isMatrixProfileKey(name: string): name is ProfileMatrixKey {
+  return (PROFILE_MATRIX_KEYS as readonly string[]).includes(name);
+}
+
+/** Whether a name is a code-owned profile that must never be listed to users. */
+export function isInternalProfileKey(name: string): name is InternalProfileKey {
+  return (INTERNAL_PROFILE_KEYS as readonly string[]).includes(name);
+}
+
 function defaultProfileBodyForProvider(
   name: string,
   defaultProvider: DefaultProviderConfig | null,
 ): ProfileEntry | undefined {
-  if (defaultProvider == null || !isDefaultProfileKey(name)) {
+  if (defaultProvider == null || !isMatrixProfileKey(name)) {
     return CODE_DEFAULT_PROFILE_ENTRIES[name];
   }
   const impl = PROFILE_IMPLS[name][defaultProvider.provider];
@@ -446,6 +498,12 @@ function defaultProfileBodyForProvider(
  * available code default, merged per `getEffectiveProfile`. This is the
  * record all runtime readers of `llm.profiles` should consume; the raw
  * workspace record is a write-path concern.
+ *
+ * Internal profiles are omitted: they exist only to be named by a call-site
+ * default, so listing them would offer them as selectable models and let
+ * `activeProfile`/`overrideProfile` validation accept them. Resolution
+ * reaches them by name through `resolveDefaultProfileForProvider`, which
+ * does not go through this record.
  */
 export function getEffectiveProfiles(
   workspaceProfiles: Record<string, ProfileEntry> | undefined,
@@ -457,6 +515,9 @@ export function getEffectiveProfiles(
     ...(workspaceProfiles ?? {}),
   };
   for (const name of Object.keys(catalogEntries)) {
+    if (isInternalProfileKey(name)) {
+      continue;
+    }
     const entry = getEffectiveProfile(workspaceProfiles, name, catalogEntries);
     if (entry != null) {
       effective[name] = entry;
@@ -481,6 +542,9 @@ export function getEffectiveProfilesForProvider(
     ...(workspaceProfiles ?? {}),
   };
   for (const name of Object.keys(CODE_DEFAULT_PROFILE_ENTRIES)) {
+    if (isInternalProfileKey(name)) {
+      continue;
+    }
     const entry = resolveDefaultProfileForProvider(
       workspaceProfiles,
       name,

--- a/assistant/src/config/default-profile-names.ts
+++ b/assistant/src/config/default-profile-names.ts
@@ -15,6 +15,33 @@ export const DEFAULT_PROFILE_KEYS = [
 export type DefaultProfileKey = (typeof DEFAULT_PROFILE_KEYS)[number];
 
 /**
+ * Code-owned profiles that exist only to be named by a call-site default —
+ * never offered as a user-selectable model. They resolve through the same
+ * intent × provider matrix as the defaults, but are deliberately excluded
+ * from the workspace seed and from every profile listing, so the picker
+ * still shows exactly Balanced / Speed / Quality.
+ *
+ * `latency-optimized` is the latency-class profile the live-voice front
+ * model runs on: `cost-optimized`'s upstream cannot meet the turn-taking
+ * latency envelope, and the alternative — a raw model pin on the call site —
+ * resolves to a provider BYOK installs may hold no credential for.
+ */
+export const INTERNAL_PROFILE_KEYS = ["latency-optimized"] as const;
+export type InternalProfileKey = (typeof INTERNAL_PROFILE_KEYS)[number];
+
+/**
+ * Every key implemented by the intent × provider matrix: the user-selectable
+ * defaults plus the internal call-site-only profiles. This is the set the
+ * resolver dereferences against; `DEFAULT_PROFILE_KEYS` alone is the
+ * user-facing subset.
+ */
+export const PROFILE_MATRIX_KEYS = [
+  ...DEFAULT_PROFILE_KEYS,
+  ...INTERNAL_PROFILE_KEYS,
+] as const;
+export type ProfileMatrixKey = DefaultProfileKey | InternalProfileKey;
+
+/**
  * Flag-gated default profile: only available while the `os-beta` feature
  * flag has reconciled it into the workspace (see `sync-gated-profiles.ts`).
  * Deliberately NOT part of `DEFAULT_PROFILE_KEYS`: it is never

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -12,7 +12,7 @@ import {
 import { CALL_SITE_DEFAULTS } from "./call-site-defaults.js";
 import {
   getEffectiveProfile,
-  isDefaultProfileKey,
+  isMatrixProfileKey,
   resolveDefaultProfileForProvider,
 } from "./default-profile-catalog.js";
 import {
@@ -233,7 +233,7 @@ function providerAwareEntry(
     name,
     defaultProvider,
   );
-  if (!isDefaultProfileKey(name) || entry?.mix != null) {
+  if (!isMatrixProfileKey(name) || entry?.mix != null) {
     return entry;
   }
   if (

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -8,6 +8,7 @@ import {
 import {
   DEFAULT_PROFILE_KEYS,
   DEFAULT_PROFILE_PROVIDERS,
+  INTERNAL_PROFILE_KEYS,
 } from "../default-profile-names.js";
 
 /**
@@ -668,11 +669,18 @@ export const LLMSchema = z
       ...Object.keys(config.profiles ?? {}),
       ...DEFAULT_PROFILE_KEYS,
     ]);
+    // Internal profiles exist only to be named by a call site, so they are
+    // valid reference targets there and nowhere else — never for
+    // `activeProfile`/`advisorProfile`, which are user-facing selections.
+    const callSiteProfileNames = new Set([
+      ...profileNames,
+      ...INTERNAL_PROFILE_KEYS,
+    ]);
     for (const [siteId, siteConfig] of Object.entries(config.callSites ?? {})) {
       if (siteConfig?.profile == null) {
         continue;
       }
-      if (!profileNames.has(siteConfig.profile)) {
+      if (!callSiteProfileNames.has(siteConfig.profile)) {
         ctx.addIssue({
           code: "custom",
           path: ["callSites", siteId, "profile"],


### PR DESCRIPTION
## What

The live-voice front model call sites — `voiceFrontDoor` (the triage front-door leg fronting every voice turn) and `voiceFrontDecision` (semantic endpointing / acks) — named the `cost-optimized` profile and then overrode its model with a raw `claude-haiku-4-5-20251001` pin.

`resolveOverrideOrDefault` treats a bare model pin as catalog-implied: it stamps the model's catalog provider and drops the winner's connection unless it's the provider-agnostic Vellum managed one. On a BYOK install (openai / gemini / fireworks / ollama), that resolved the voice front model to an Anthropic model id the workspace holds no credential for.

## How

Add `latency-optimized` as an **internal, code-owned profile** in the intent × provider matrix:

- **`vellum` column** pins the same latency model as before, so managed resolution is byte-for-byte unchanged.
- **BYOK columns** carry `intent: "latency-optimized"`, which already exists per provider in `model-intents.ts` — each provider resolves its own latency model through its personal connection.

Both call sites now just name the profile and keep their `effort: "low"` / thinking-off tweak.

Internal profiles are deliberately **not** user-selectable. They are excluded from the workspace seed (`MANAGED_PROFILE_TEMPLATES`) and from both listing functions (`getEffectiveProfiles`, `getEffectiveProfilesForProvider`), so the picker still shows exactly Balanced / Speed / Quality. Schema validation accepts the name for a call-site `profile` reference and rejects it for `activeProfile` / `advisorProfile`; the name is also added to `MANAGED_PROFILE_NAMES` so a user profile can't shadow it.

The escalated leg is untouched — it carries no override and still runs on the ordinary `callAgent` resolution.

## Resolved config, before → after

| install | before | after |
| --- | --- | --- |
| platform (vellum) | `vellum/claude-haiku-4-5-20251001` | unchanged |
| BYOK openai | `anthropic/claude-haiku-4-5-20251001` (no connection) | `openai/gpt-5.4-nano` via `openai-personal` |
| BYOK gemini | `anthropic/claude-haiku-4-5-20251001` (no connection) | `gemini/gemini-3.1-flash-lite` via `gemini-personal` |
| BYOK anthropic | `anthropic/claude-haiku-4-5-20251001` (no connection) | unchanged model, now via `anthropic-personal` |

## Migration

None needed. No migration ever persisted these two call sites into workspace `llm.callSites`, so the shipped default change takes effect immediately — verified against `prune-seeded-callsite-defaults.ts` and `src/workspace/migrations/`.

## Testing

- `bunx tsc --noEmit` clean.
- Green: `src/config` (36 catalog/gated-profile/callsite-strip tests), `src/live-voice` (340), `llm-resolver`, `model-intents`, `llm-callsite-catalog`, `call-site-routing-*`, `agent-loop-callsite-precedence`, `llm-catalog-parity`, `profile-materialization`, `config-schema`, `retry-callsite`, `voice-triage-escalate`, `front-decision`.
- Resolution table above verified by driving `resolveCallSiteConfig` across all five default-provider shapes (incl. no `defaultProvider`).
- Note: running `src/config` and `src/live-voice` in one `bun test` process produces 15 failures from cross-file mock leakage (incl. `audio-transcribe`, unrelated to this diff). Each file/directory passes on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)