### PR TITLE
Add octolens plugin to marketplace

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -16,7 +16,7 @@
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/admin-copilot",
       "license": "MIT",
-      "icon": "🧑‍💼"
+      "icon": "\ud83e\uddd1\u200d\ud83d\udcbc"
     },
     {
       "name": "agent-wrapped",
@@ -30,7 +30,7 @@
       "license": "MIT",
       "submittedBy": "marina",
       "homepage": "https://agent-wrapped.com",
-      "icon": "🎁"
+      "icon": "\ud83c\udf81"
     },
     {
       "name": "ai-hero-engineer-kit",
@@ -39,11 +39,11 @@
         "repo": "marinatrajk/ai-hero-engineer-kit",
         "ref": "18d33c62b15a3e2cc22dc070723fe3077749dcec"
       },
-      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' — plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
+      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' \u2014 plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
       "category": "developer",
       "homepage": "https://github.com/marinatrajk/ai-hero-engineer-kit",
       "license": "MIT",
-      "icon": "🧰"
+      "icon": "\ud83e\uddf0"
     },
     {
       "name": "amex-perk-reminder",
@@ -56,7 +56,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/amex-perk-reminder",
       "license": "MIT",
-      "icon": "💳"
+      "icon": "\ud83d\udcb3"
     },
     {
       "name": "astrology-horoscope",
@@ -69,7 +69,7 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/astrology-horoscope",
       "license": "MIT",
-      "icon": "🔮"
+      "icon": "\ud83d\udd2e"
     },
     {
       "name": "caveman",
@@ -82,7 +82,7 @@
       "category": "productivity",
       "homepage": "https://github.com/JuliusBrussee/caveman",
       "license": "MIT",
-      "icon": "🦴"
+      "icon": "\ud83e\uddb4"
     },
     {
       "name": "coffee-aficionado",
@@ -107,7 +107,7 @@
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/cofounder",
       "license": "MIT",
-      "icon": "🤝"
+      "icon": "\ud83e\udd1d"
     },
     {
       "name": "cognee",
@@ -120,7 +120,7 @@
       "description": "Cognee knowledge graph memory for Vellum Assistant: session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
       "category": "memory",
       "homepage": "https://github.com/topoteretes/cognee-integrations/tree/main/integrations/vellum-assistant",
-      "icon": "🕸️"
+      "icon": "\ud83d\udd78\ufe0f"
     },
     {
       "name": "creatorland",
@@ -134,7 +134,7 @@
       "category": "marketing",
       "homepage": "https://github.com/creatorland/creatorland-mcp-skills/tree/main/plugins/creatorland-data",
       "license": "MIT",
-      "icon": "🎨"
+      "icon": "\ud83c\udfa8"
     },
     {
       "name": "dynamic-notch",
@@ -147,7 +147,7 @@
       "category": "interface",
       "homepage": "https://github.com/AnitaKirkovska/dynamic-notch",
       "license": "MIT",
-      "icon": "💻"
+      "icon": "\ud83d\udcbb"
     },
     {
       "name": "family-briefing",
@@ -160,7 +160,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/family-briefing",
       "license": "MIT",
-      "icon": "👨‍👩‍👧‍👦"
+      "icon": "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66"
     },
     {
       "name": "fitness-companion",
@@ -173,7 +173,7 @@
       "category": "health",
       "homepage": "https://github.com/vellum-ai/fitness-companion",
       "license": "MIT",
-      "icon": "💪"
+      "icon": "\ud83d\udcaa"
     },
     {
       "name": "git-workflow",
@@ -186,7 +186,7 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/git-workflow",
       "license": "MIT",
-      "icon": "🔀"
+      "icon": "\ud83d\udd00"
     },
     {
       "name": "google-drive-search",
@@ -199,7 +199,7 @@
       "category": "productivity",
       "homepage": "https://github.com/ZeebBoyBlue/google-drive-search",
       "license": "Apache-2.0",
-      "icon": "🔍"
+      "icon": "\ud83d\udd0d"
     },
     {
       "name": "influencer-marketing",
@@ -212,7 +212,7 @@
       "category": "marketing",
       "homepage": "https://github.com/ZeebBoyBlue/influencer",
       "license": "MIT",
-      "icon": "📣"
+      "icon": "\ud83d\udce3"
     },
     {
       "name": "kitchen-companion",
@@ -225,7 +225,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/kitchen-companion",
       "license": "MIT",
-      "icon": "🍳"
+      "icon": "\ud83c\udf73"
     },
     {
       "name": "level-up",
@@ -238,7 +238,7 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/level-up",
       "license": "MIT",
-      "icon": "🆙"
+      "icon": "\ud83c\udd99"
     },
     {
       "name": "marketing-expert",
@@ -251,7 +251,7 @@
       "category": "marketing",
       "homepage": "https://github.com/vellum-ai/marketing-expert",
       "license": "MIT",
-      "icon": "📈"
+      "icon": "\ud83d\udcc8"
     },
     {
       "name": "markitdown-vellum",
@@ -260,11 +260,11 @@
         "repo": "simensgreen/markitdown-vellum",
         "ref": "5e5a4ecfd6c60d613778106442003a1ed302fc3c"
       },
-      "description": "Convert workspace documents (PDF, DOCX, PPTX, XLSX, images, MSG, …) to markdown via @cognipeer/to-markdown, with Vellum vision OCR or Tesseract.",
+      "description": "Convert workspace documents (PDF, DOCX, PPTX, XLSX, images, MSG, \u2026) to markdown via @cognipeer/to-markdown, with Vellum vision OCR or Tesseract.",
       "category": "productivity",
       "homepage": "https://github.com/simensgreen/markitdown-vellum",
       "license": "MIT",
-      "icon": "📄"
+      "icon": "\ud83d\udcc4"
     },
     {
       "name": "model-router",
@@ -277,7 +277,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/model-router",
       "license": "MIT",
-      "icon": "🚦"
+      "icon": "\ud83d\udea6"
     },
     {
       "name": "motion-design",
@@ -290,7 +290,7 @@
       "category": "creative",
       "homepage": "https://github.com/vellum-ai/motion-design",
       "license": "MIT",
-      "icon": "🎬"
+      "icon": "\ud83c\udfac"
     },
     {
       "name": "originkit",
@@ -303,7 +303,7 @@
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/originkit",
       "license": "MIT",
-      "icon": "🧱"
+      "icon": "\ud83e\uddf1"
     },
     {
       "name": "personal-finance",
@@ -316,7 +316,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/personal-finance",
       "license": "MIT",
-      "icon": "💰"
+      "icon": "\ud83d\udcb0"
     },
     {
       "name": "plant-doctor",
@@ -329,7 +329,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/plant-doctor",
       "license": "MIT",
-      "icon": "🪴"
+      "icon": "\ud83e\udeb4"
     },
     {
       "name": "polyglot",
@@ -342,7 +342,7 @@
       "category": "education",
       "homepage": "https://github.com/vellum-ai/polyglot",
       "license": "MIT",
-      "icon": "🗣️"
+      "icon": "\ud83d\udde3\ufe0f"
     },
     {
       "name": "proactive-slacks",
@@ -355,7 +355,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
       "license": "MIT",
-      "icon": "💬"
+      "icon": "\ud83d\udcac"
     },
     {
       "name": "reading-pal",
@@ -368,7 +368,7 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/reading-pal",
       "license": "MIT",
-      "icon": "📚"
+      "icon": "\ud83d\udcda"
     },
     {
       "name": "simple-memory",
@@ -381,7 +381,7 @@
       "category": "memory",
       "homepage": "https://github.com/vellum-ai/simple-memory",
       "license": "MIT",
-      "icon": "🧠"
+      "icon": "\ud83e\udde0"
     },
     {
       "name": "smb-inbox-brief",
@@ -394,7 +394,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/smb-inbox-brief",
       "license": "MIT",
-      "icon": "📧"
+      "icon": "\ud83d\udce7"
     },
     {
       "name": "tennis-companion",
@@ -407,7 +407,7 @@
       "category": "health",
       "homepage": "https://github.com/vellum-ai/tennis-companion",
       "license": "MIT",
-      "icon": "🎾"
+      "icon": "\ud83c\udfbe"
     },
     {
       "name": "travel-planner",
@@ -420,7 +420,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/travel-planner",
       "license": "MIT",
-      "icon": "✈️"
+      "icon": "\u2708\ufe0f"
     },
     {
       "name": "vellum-client-qa",
@@ -433,7 +433,7 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/vellum-client-qa",
       "license": "MIT",
-      "icon": "🧪"
+      "icon": "\ud83e\uddea"
     },
     {
       "name": "virlo",
@@ -447,7 +447,7 @@
       "category": "marketing",
       "homepage": "https://github.com/Virlo-AI/virlo-integrations/tree/main/integrations/vellum",
       "license": "MIT",
-      "icon": "📱"
+      "icon": "\ud83d\udcf1"
     },
     {
       "name": "writing-coach",
@@ -460,7 +460,7 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/writing-coach",
       "license": "MIT",
-      "icon": "✍️"
+      "icon": "\u270d\ufe0f"
     },
     {
       "name": "battleship",
@@ -473,7 +473,19 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/battleship",
       "license": "MIT",
-      "icon": "⚓"
+      "icon": "\u2693"
+    },
+    {
+      "name": "octolens",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/octolens",
+        "ref": "27d00e2c0c17db73adb4cfce1365c174e4d4fd9c"
+      },
+      "description": "Social listening plugin for Octolens. Monitor brand mentions, competitor activity, and industry conversations across 13+ platforms. Query mentions, run analytics, manage keywords and feeds via REST API tools, or connect the Octolens MCP server for natural-language workflows.",
+      "category": "growth",
+      "homepage": "https://github.com/vellum-ai/octolens",
+      "license": "MIT"
     }
   ]
 }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -16,7 +16,7 @@
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/admin-copilot",
       "license": "MIT",
-      "icon": "\ud83e\uddd1\u200d\ud83d\udcbc"
+      "icon": "🧑‍💼"
     },
     {
       "name": "agent-wrapped",
@@ -30,7 +30,7 @@
       "license": "MIT",
       "submittedBy": "marina",
       "homepage": "https://agent-wrapped.com",
-      "icon": "\ud83c\udf81"
+      "icon": "🎁"
     },
     {
       "name": "ai-hero-engineer-kit",
@@ -39,11 +39,11 @@
         "repo": "marinatrajk/ai-hero-engineer-kit",
         "ref": "18d33c62b15a3e2cc22dc070723fe3077749dcec"
       },
-      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' \u2014 plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
+      "description": "Five engineering skills adapted from Matt Pocock's '5 Agent Skills I Use Every Day' — plans, PRDs, vertical-slice issues, TDD loop, and codebase deepening in one install.",
       "category": "developer",
       "homepage": "https://github.com/marinatrajk/ai-hero-engineer-kit",
       "license": "MIT",
-      "icon": "\ud83e\uddf0"
+      "icon": "🧰"
     },
     {
       "name": "amex-perk-reminder",
@@ -56,7 +56,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/amex-perk-reminder",
       "license": "MIT",
-      "icon": "\ud83d\udcb3"
+      "icon": "💳"
     },
     {
       "name": "astrology-horoscope",
@@ -69,7 +69,7 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/astrology-horoscope",
       "license": "MIT",
-      "icon": "\ud83d\udd2e"
+      "icon": "🔮"
     },
     {
       "name": "caveman",
@@ -82,7 +82,7 @@
       "category": "productivity",
       "homepage": "https://github.com/JuliusBrussee/caveman",
       "license": "MIT",
-      "icon": "\ud83e\uddb4"
+      "icon": "🦴"
     },
     {
       "name": "coffee-aficionado",
@@ -107,7 +107,7 @@
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/cofounder",
       "license": "MIT",
-      "icon": "\ud83e\udd1d"
+      "icon": "🤝"
     },
     {
       "name": "cognee",
@@ -120,7 +120,7 @@
       "description": "Cognee knowledge graph memory for Vellum Assistant: session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
       "category": "memory",
       "homepage": "https://github.com/topoteretes/cognee-integrations/tree/main/integrations/vellum-assistant",
-      "icon": "\ud83d\udd78\ufe0f"
+      "icon": "🕸️"
     },
     {
       "name": "creatorland",
@@ -134,7 +134,7 @@
       "category": "marketing",
       "homepage": "https://github.com/creatorland/creatorland-mcp-skills/tree/main/plugins/creatorland-data",
       "license": "MIT",
-      "icon": "\ud83c\udfa8"
+      "icon": "🎨"
     },
     {
       "name": "dynamic-notch",
@@ -147,7 +147,7 @@
       "category": "interface",
       "homepage": "https://github.com/AnitaKirkovska/dynamic-notch",
       "license": "MIT",
-      "icon": "\ud83d\udcbb"
+      "icon": "💻"
     },
     {
       "name": "family-briefing",
@@ -160,7 +160,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/family-briefing",
       "license": "MIT",
-      "icon": "\ud83d\udc68\u200d\ud83d\udc69\u200d\ud83d\udc67\u200d\ud83d\udc66"
+      "icon": "👨‍👩‍👧‍👦"
     },
     {
       "name": "fitness-companion",
@@ -173,7 +173,7 @@
       "category": "health",
       "homepage": "https://github.com/vellum-ai/fitness-companion",
       "license": "MIT",
-      "icon": "\ud83d\udcaa"
+      "icon": "💪"
     },
     {
       "name": "git-workflow",
@@ -186,7 +186,7 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/git-workflow",
       "license": "MIT",
-      "icon": "\ud83d\udd00"
+      "icon": "🔀"
     },
     {
       "name": "google-drive-search",
@@ -199,7 +199,7 @@
       "category": "productivity",
       "homepage": "https://github.com/ZeebBoyBlue/google-drive-search",
       "license": "Apache-2.0",
-      "icon": "\ud83d\udd0d"
+      "icon": "🔍"
     },
     {
       "name": "influencer-marketing",
@@ -212,7 +212,7 @@
       "category": "marketing",
       "homepage": "https://github.com/ZeebBoyBlue/influencer",
       "license": "MIT",
-      "icon": "\ud83d\udce3"
+      "icon": "📣"
     },
     {
       "name": "kitchen-companion",
@@ -225,7 +225,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/kitchen-companion",
       "license": "MIT",
-      "icon": "\ud83c\udf73"
+      "icon": "🍳"
     },
     {
       "name": "level-up",
@@ -238,7 +238,7 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/level-up",
       "license": "MIT",
-      "icon": "\ud83c\udd99"
+      "icon": "🆙"
     },
     {
       "name": "marketing-expert",
@@ -251,7 +251,7 @@
       "category": "marketing",
       "homepage": "https://github.com/vellum-ai/marketing-expert",
       "license": "MIT",
-      "icon": "\ud83d\udcc8"
+      "icon": "📈"
     },
     {
       "name": "markitdown-vellum",
@@ -260,11 +260,11 @@
         "repo": "simensgreen/markitdown-vellum",
         "ref": "5e5a4ecfd6c60d613778106442003a1ed302fc3c"
       },
-      "description": "Convert workspace documents (PDF, DOCX, PPTX, XLSX, images, MSG, \u2026) to markdown via @cognipeer/to-markdown, with Vellum vision OCR or Tesseract.",
+      "description": "Convert workspace documents (PDF, DOCX, PPTX, XLSX, images, MSG, …) to markdown via @cognipeer/to-markdown, with Vellum vision OCR or Tesseract.",
       "category": "productivity",
       "homepage": "https://github.com/simensgreen/markitdown-vellum",
       "license": "MIT",
-      "icon": "\ud83d\udcc4"
+      "icon": "📄"
     },
     {
       "name": "model-router",
@@ -277,7 +277,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/model-router",
       "license": "MIT",
-      "icon": "\ud83d\udea6"
+      "icon": "🚦"
     },
     {
       "name": "motion-design",
@@ -290,7 +290,7 @@
       "category": "creative",
       "homepage": "https://github.com/vellum-ai/motion-design",
       "license": "MIT",
-      "icon": "\ud83c\udfac"
+      "icon": "🎬"
     },
     {
       "name": "originkit",
@@ -303,7 +303,7 @@
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/originkit",
       "license": "MIT",
-      "icon": "\ud83e\uddf1"
+      "icon": "🧱"
     },
     {
       "name": "personal-finance",
@@ -316,7 +316,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/personal-finance",
       "license": "MIT",
-      "icon": "\ud83d\udcb0"
+      "icon": "💰"
     },
     {
       "name": "plant-doctor",
@@ -329,7 +329,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/vellum-ai/plant-doctor",
       "license": "MIT",
-      "icon": "\ud83e\udeb4"
+      "icon": "🪴"
     },
     {
       "name": "polyglot",
@@ -342,7 +342,7 @@
       "category": "education",
       "homepage": "https://github.com/vellum-ai/polyglot",
       "license": "MIT",
-      "icon": "\ud83d\udde3\ufe0f"
+      "icon": "🗣️"
     },
     {
       "name": "proactive-slacks",
@@ -355,7 +355,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/proactive-slacks",
       "license": "MIT",
-      "icon": "\ud83d\udcac"
+      "icon": "💬"
     },
     {
       "name": "reading-pal",
@@ -368,7 +368,7 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/reading-pal",
       "license": "MIT",
-      "icon": "\ud83d\udcda"
+      "icon": "📚"
     },
     {
       "name": "simple-memory",
@@ -381,7 +381,7 @@
       "category": "memory",
       "homepage": "https://github.com/vellum-ai/simple-memory",
       "license": "MIT",
-      "icon": "\ud83e\udde0"
+      "icon": "🧠"
     },
     {
       "name": "smb-inbox-brief",
@@ -394,7 +394,7 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/smb-inbox-brief",
       "license": "MIT",
-      "icon": "\ud83d\udce7"
+      "icon": "📧"
     },
     {
       "name": "tennis-companion",
@@ -407,7 +407,7 @@
       "category": "health",
       "homepage": "https://github.com/vellum-ai/tennis-companion",
       "license": "MIT",
-      "icon": "\ud83c\udfbe"
+      "icon": "🎾"
     },
     {
       "name": "travel-planner",
@@ -420,7 +420,7 @@
       "category": "lifestyle",
       "homepage": "https://github.com/AnitaKirkovska/travel-planner",
       "license": "MIT",
-      "icon": "\u2708\ufe0f"
+      "icon": "✈️"
     },
     {
       "name": "vellum-client-qa",
@@ -433,7 +433,7 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/vellum-client-qa",
       "license": "MIT",
-      "icon": "\ud83e\uddea"
+      "icon": "🧪"
     },
     {
       "name": "virlo",
@@ -447,7 +447,7 @@
       "category": "marketing",
       "homepage": "https://github.com/Virlo-AI/virlo-integrations/tree/main/integrations/vellum",
       "license": "MIT",
-      "icon": "\ud83d\udcf1"
+      "icon": "📱"
     },
     {
       "name": "writing-coach",
@@ -460,7 +460,7 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/writing-coach",
       "license": "MIT",
-      "icon": "\u270d\ufe0f"
+      "icon": "✍️"
     },
     {
       "name": "battleship",
@@ -473,14 +473,14 @@
       "category": "hobby",
       "homepage": "https://github.com/vellum-ai/battleship",
       "license": "MIT",
-      "icon": "\u2693"
+      "icon": "⚓"
     },
     {
       "name": "octolens",
       "source": {
         "source": "github",
         "repo": "vellum-ai/octolens",
-        "ref": "27d00e2c0c17db73adb4cfce1365c174e4d4fd9c"
+        "ref": "d9117f5c6b97b3bff75dec1a04bedc32571c6538"
       },
       "description": "Social listening plugin for Octolens. Monitor brand mentions, competitor activity, and industry conversations across 13+ platforms. Query mentions, run analytics, manage keywords and feeds via REST API tools, or connect the Octolens MCP server for natural-language workflows.",
       "category": "growth",


### PR DESCRIPTION
## Octolens Plugin

Social listening plugin for [Octolens](https://octolens.com). Monitors brand mentions, competitor activity, and industry conversations across 13+ platforms (Reddit, X, GitHub, Hacker News, LinkedIn, YouTube, Bluesky, TikTok, podcasts, newsletters, and more).

### Surfaces

- **4 REST API tools:** `octolens_mentions`, `octolens_analytics`, `octolens_keywords`, `octolens_feeds`
- **1 skill:** `social-listening` with workflow guides for both REST and MCP paths
- **1 hook:** `init.ts` for setup checks and guidance

### Dual-path design

**REST API tools** (built-in): For programmatic access, scheduled jobs, and structured queries. Requires an Octolens API key stored locally.

**MCP server** (external): For interactive natural-language workflows. Connects via `assistant mcp add octolens -t streamable-http -u https://app.octolens.com/api/mcp/v2` with OAuth.

Users can use either or both.

### Repo

- GitHub: https://github.com/vellum-ai/octolens
- Pin: `27d00e2c0c17db73adb4cfce1365c174e4d4fd9c`
- License: MIT