### PR TITLE
refactor(surfaces): single-source ui_surface_show/update wire types, derive strict daemon helpers from the api

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-state-update.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-state-update.test.ts
@@ -384,7 +384,7 @@ describe("ui_update normalizes modeled fields for known surface types", () => {
 
     const update = sent.find((m) => m.type === "ui_surface_update");
     expect(update).toBeDefined();
-    expect(typeof (update as { data: { html: unknown } }).data.html).toBe(
+    expect(typeof (update as { data: Record<string, unknown> }).data.html).toBe(
       "string",
     );
   });

--- a/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
@@ -11,7 +11,7 @@ import type {
   ServerMessage,
   SurfaceType,
   UiSurfaceShow,
-  UiSurfaceUpdate,
+  UISurfaceUpdateEvent,
 } from "../daemon/message-protocol.js";
 
 function makeContext(
@@ -431,7 +431,7 @@ describe("task_progress surface compatibility", () => {
     expect(result.isError).toBe(false);
 
     const updateMessage = sent.find(
-      (msg): msg is UiSurfaceUpdate => msg.type === "ui_surface_update",
+      (msg): msg is UISurfaceUpdateEvent => msg.type === "ui_surface_update",
     );
     expect(updateMessage).toBeDefined();
     if (!updateMessage) {
@@ -470,7 +470,7 @@ describe("task_progress surface compatibility", () => {
 
     expect(result.isError).toBe(false);
     const updateMessage = sent.find(
-      (msg): msg is UiSurfaceUpdate => msg.type === "ui_surface_update",
+      (msg): msg is UISurfaceUpdateEvent => msg.type === "ui_surface_update",
     );
     expect(updateMessage).toBeDefined();
     if (!updateMessage) {

--- a/assistant/src/daemon/message-types/surfaces.ts
+++ b/assistant/src/daemon/message-types/surfaces.ts
@@ -2,7 +2,9 @@
 
 import type { UISurfaceCompleteEvent } from "../../api/events/ui-surface-complete.js";
 import type { UISurfaceDismissEvent } from "../../api/events/ui-surface-dismiss.js";
+import type { UISurfaceShowEvent } from "../../api/events/ui-surface-show.js";
 import type { UISurfaceUndoResultEvent } from "../../api/events/ui-surface-undo-result.js";
+import type { UISurfaceUpdateEvent } from "../../api/events/ui-surface-update.js";
 import type {
   AnySurfaceData,
   CardSurfaceData,
@@ -91,13 +93,18 @@ export const INTERACTIVE_SURFACE_TYPES: SurfaceType[] = [
   "task_preferences",
 ];
 
-export interface SurfaceAction {
-  id: string;
-  label: string;
-  style?: "primary" | "secondary" | "destructive";
-  /** Optional data payload returned to the daemon when this action is clicked. */
-  data?: Record<string, unknown>;
-}
+// The clickable-action shape and the five surface lifecycle events are
+// single-sourced from their canonical `api/events` wire schemas; re-exported so
+// the daemon's surface protocol barrel keeps surfacing them under their
+// canonical names.
+export type { SurfaceAction } from "../../api/events/ui-surface-show.js";
+export type {
+  UISurfaceCompleteEvent,
+  UISurfaceDismissEvent,
+  UISurfaceShowEvent,
+  UISurfaceUndoResultEvent,
+  UISurfaceUpdateEvent,
+};
 
 // Surface actions (user clicks) and undo requests are served by the HTTP
 // surface-action routes (`surface-actions`, `surfaces/:id/undo`), not by client
@@ -105,28 +112,17 @@ export interface SurfaceAction {
 
 // === Server → Client ===
 
-/** Common fields shared by all UiSurfaceShow variants. */
-interface UiSurfaceShowBase {
-  type: "ui_surface_show";
-  conversationId: string;
-  surfaceId: string;
-  title?: string;
-  actions?: SurfaceAction[];
-  display?: "inline" | "panel";
-  /** The message ID that this surface belongs to (for history loading). */
-  messageId?: string;
-  /** When `true`, clicking an action does not dismiss the surface — the client keeps the card visible and only marks the clicked `actionId` as spent so siblings remain clickable. */
-  persistent?: boolean;
-  /** Id of the tool call that produced this surface (the `ui_show` proxy tool). Lets the client gate app previews on the tool result's arrival rather than whole-turn streaming state. */
-  toolCallId?: string;
-}
-
 /**
- * The show event for one specific surface type: base fields plus the
- * correlated `surfaceType`/`data` pair, both indexed from
- * `SurfaceDataByType` so generic code keeps the pairing.
+ * The show event for one specific surface type: the canonical
+ * `UISurfaceShowEvent` base fields with the wire-opaque `surfaceType`/`data`
+ * replaced by the correlated pair indexed from `SurfaceDataByType`, so daemon
+ * construction code keeps the `surfaceType` ↔ `data` pairing that the opaque
+ * wire schema deliberately drops. Assignable to `UISurfaceShowEvent`.
  */
-export type UiSurfaceShowFor<K extends SurfaceType> = UiSurfaceShowBase & {
+export type UiSurfaceShowFor<K extends SurfaceType> = Omit<
+  UISurfaceShowEvent,
+  "surfaceType" | "data"
+> & {
   surfaceType: K;
   data: SurfaceDataByType[K];
 };
@@ -154,23 +150,17 @@ export type UiSurfaceShowFileUpload = UiSurfaceShowFor<"file_upload">;
 export type UiSurfaceShowDocumentPreview = UiSurfaceShowFor<"document_preview">;
 export type UiSurfaceShowWorkResult = UiSurfaceShowFor<"work_result">;
 
-export interface UiSurfaceUpdate {
-  type: "ui_surface_update";
-  conversationId: string;
-  surfaceId: string;
-  data: Partial<AnySurfaceData>;
-}
-
-// `ui_surface_dismiss`, `ui_surface_complete`, and `ui_surface_undo_result` are
-// single-sourced from their canonical `api/events` wire schemas. `ui_surface_show`
-// and `ui_surface_update` retain their strictly-correlated (`surfaceType` ↔ `data`)
-// daemon shapes here, which their producers/consumers depend on.
+// All five surface lifecycle events are single-sourced from their canonical
+// `api/events` wire schemas. The strict, per-`surfaceType` `UiSurfaceShow*`
+// types above are daemon-side construction helpers derived from the same
+// canonical `UISurfaceShowEvent` — they narrow `surfaceType` ↔ `data` for
+// typed construction and are assignable to the opaque wire type.
 
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _SurfacesServerMessages =
-  | UiSurfaceShow
-  | UiSurfaceUpdate
+  | UISurfaceShowEvent
+  | UISurfaceUpdateEvent
   | UISurfaceDismissEvent
   | UISurfaceCompleteEvent
   | UISurfaceUndoResultEvent;


### PR DESCRIPTION
## Prompt / plan

Follow-up to #38984, completing the `surfaces` domain reconciliation toward single-sourcing all server→client events from `api/events` (the road to deleting `ServerMessage`).

The prior PR left `ui_surface_show` / `ui_surface_update` as **strictly-correlated** raw daemon types (`surfaceType` ↔ `data`) while the canonical `api/events` schemas are **deliberately opaque** (`surfaceType: string`, `data: record`) — documented in `ui-surface-show.ts` as necessary so the `type`-discriminated stream parser doesn't drop messy-but-renderable surfaces. This PR resolves that divergence without losing the daemon-side construction type-safety.

### What changed
- **`_SurfacesServerMessages` now composes all five events from `api/events`** — `UISurfaceShowEvent` and `UISurfaceUpdateEvent` join the already-single-sourced dismiss/complete/undo_result. The daemon-side duplicate wire definitions are gone.
- **Strict construction helpers rederived from the canonical schema.** `UiSurfaceShowFor<K>` is now `Omit<UISurfaceShowEvent, "surfaceType" | "data"> & { surfaceType: K; data: SurfaceDataByType[K] }`. Base fields have a single source (the wire schema); the helpers only re-narrow the `surfaceType`↔`data` pairing for typed construction and stay assignable to the opaque wire type — so the two `as UiSurfaceShow` construction sites and the three per-type structure tests are unchanged.
- **`UiSurfaceUpdate` (strict `Partial<AnySurfaceData>`) removed.** It had no construction dependants (producers build plain literals; consumers take `unknown`); its only reference was a test type-guard, repointed to `UISurfaceUpdateEvent`.
- **Local `SurfaceAction` interface dropped**, re-exported from the canonical `ui-surface-show.ts` schema (it was a duplicate).

### Why it's safe
- No `surfaceType`↔`data` correlation is required by any consumer: the Slack task-progress observers (`slack-reply-session.ts`, `background-dispatch.ts`) read `msg.data` through helpers typed `data: unknown`.
- The strict helpers remain assignable to `UISurfaceShowEvent`, so all broadcast sites and the type-structure tests compile unchanged.
- **No `api/events` or web changes** — all five surface events were already registered in `AssistantEventSchema`, so this only deletes the daemon-side duplicates. The SSE-parity test confirms `ServerMessage` stays in parity with `AssistantEventSchema`.

## Test plan
- `bun run typecheck:fast` (tsgo) — clean
- `bun test src/api src/__tests__/runtime-events-sse-parity.test.ts src/__tests__/plugin-import-boundary-guard.test.ts` + all surface suites (task-progress, state-update, dynamic-page, file-upload, work-result structure tests) — 138 pass
- `bun run generate:openapi -- --check` — spec unchanged
- eslint + prettier on changed files
- Web unaffected (no `AssistantEventSchema` change) — generated types identical.

<!-- No new routes added; CLI verb checklist not applicable. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_