### PR TITLE
feat(web): map Slack Assistant Access defaults by conversation type

### DIFF
--- a/clients/web/src/domains/channels/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-list.tsx
@@ -3,10 +3,6 @@ import { useMemo, useState } from "react";
 
 import { cn } from "@vellumai/design-library";
 import { Card } from "@vellumai/design-library/components/card";
-import {
-  Dropdown,
-  type DropdownOption,
-} from "@vellumai/design-library/components/dropdown";
 import { Input } from "@vellumai/design-library/components/input";
 import { ListRow } from "@vellumai/design-library/components/list-row";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -14,10 +10,7 @@ import { VirtualList } from "@vellumai/design-library/components/virtual-list";
 
 import { EmptyState } from "@/components/empty-state";
 import { SlackChannelTierLegend } from "@/domains/channels/components/slack-channel-tier-legend";
-import {
-  CAPABILITY_TIER_META,
-  CAPABILITY_TIER_VALUES,
-} from "@/domains/channels/slack-channel-overrides";
+import { TierPicker } from "@/domains/channels/components/tier-picker";
 import type { RiskThreshold } from "@/utils/threshold-presets";
 import type { SlackChannel } from "@/domains/channels/slack-channels-query";
 
@@ -163,17 +156,24 @@ export interface SlackChannelListProps {
   onTierChange?: (channelId: string, tier: RiskThreshold) => void;
   /** Deletes the channel's persisted cells so the default wins again. */
   onTierReset?: (channelId: string) => void;
+  /**
+   * Whether to render the "Assistant Access levels" key in the footer. Off when
+   * the list sits under a primary card that already shows the key (the Slack
+   * sub-tab's default-access card). Defaults to on for standalone use.
+   */
+  showLegend?: boolean;
 }
 
 const EMPTY_PENDING_IDS: ReadonlySet<string> = new Set();
 
 /**
  * Presence channel list for the Slack sub-tab: every Slack channel the
- * assistant is a member of, with a per-row resolved-access badge. Rows
- * expand inline (single-open accordion; "Expand all" switches to multi-open)
- * to configure the channel's Assistant Access tier. Search and the kind chips
- * narrow the list client-side; the membership filter itself is server-side
- * (`?memberOnly=true`) with no toggle.
+ * assistant is a member of, each with an inline Assistant Access picker
+ * ({@link TierPicker}) that names the effective level and marks the one it
+ * inherits. Search and the kind chips narrow the list client-side; the
+ * membership filter itself is server-side (`?memberOnly=true`) with no toggle.
+ * The key sits in the footer unless {@link SlackChannelListProps.showLegend} is
+ * off (the default-access card owns it in the composed section).
  */
 export function SlackChannelList({
   assistantDisplayName,
@@ -189,6 +189,7 @@ export function SlackChannelList({
   pendingChannelIds = EMPTY_PENDING_IDS,
   onTierChange,
   onTierReset,
+  showLegend = true,
 }: SlackChannelListProps) {
   const [search, setSearch] = useState("");
   const [kindFilter, setKindFilter] = useState<SlackRoomKind | null>(null);
@@ -356,7 +357,8 @@ export function SlackChannelList({
             </>
           )}
         </Card.Body>
-        {accessControlsSupported &&
+        {showLegend &&
+        accessControlsSupported &&
         !loading &&
         !error &&
         allChannels.length > 0 ? (
@@ -369,16 +371,6 @@ export function SlackChannelList({
         ) : null}
       </Card.Root>
     </>
-  );
-}
-
-function TierDot({ color }: { color: string }) {
-  return (
-    <span
-      aria-hidden="true"
-      className="h-1.5 w-1.5 rounded-full"
-      style={{ backgroundColor: color }}
-    />
   );
 }
 
@@ -431,45 +423,8 @@ function SlackChannelRow({
     );
   }
 
-  // The picker lists the four levels only — no separate "Default" option.
-  // The level that equals the resolved default carries a muted "default"
-  // marker; the row shows that level as the effective access. Selecting the
-  // marked level clears the channel's cell (follows the default); selecting any
-  // other level pins an override. Following the default and picking the level
-  // it resolves to are the same choice, so there is nothing to "change from
-  // default to Conservative" between.
-  //
-  // This is safe because resolution is most-specific-wins and value-only: a
-  // cell equal to the default and no cell behave identically until the global
-  // default later drifts, and treating "pick the default level" as "clear the
-  // cell" is the intended drift-following behavior (see slack-channel-overrides
-  // and the gateway's ChannelPermissionStore.resolve). While the default is
-  // still unknown (`null`) no level is marked and the trigger shows a plain
-  // "Default" placeholder.
-  const effectiveTier = tierOverride ?? defaultTier;
-  const options: DropdownOption<RiskThreshold>[] = CAPABILITY_TIER_VALUES.map(
-    (tier) => ({
-      value: tier,
-      label: CAPABILITY_TIER_META[tier].label,
-      icon: <TierDot color={CAPABILITY_TIER_META[tier].dotColor} />,
-      suffix:
-        tier === defaultTier ? (
-          <span className="text-[color:var(--content-tertiary)]">default</span>
-        ) : undefined,
-      tooltip: CAPABILITY_TIER_META[tier].sublabel,
-    }),
-  );
-
-  const handleChange = (tier: RiskThreshold) => {
-    // Picking the level the default resolves to means "follow the default",
-    // which is the absence of a cell — clear it rather than pinning an equal one.
-    if (tier === defaultTier) {
-      onReset();
-    } else {
-      onTierChange(tier);
-    }
-  };
-
+  // Per-channel override: the shared picker names the effective level and marks
+  // the one that follows the resolved default (see {@link TierPicker}).
   return (
     <ListRow
       className={rowClassName}
@@ -483,14 +438,12 @@ function SlackChannelRow({
             </span>
           ) : null}
           <div className="w-48">
-            <Dropdown<RiskThreshold>
-              value={effectiveTier ?? ""}
-              onChange={handleChange}
-              options={options}
-              placeholder="Default"
+            <TierPicker
+              tier={tierOverride}
+              defaultTier={defaultTier}
               disabled={pending || overridesLoading || overridesError}
-              size="compact"
-              menuAlign="end"
+              onTierChange={onTierChange}
+              onReset={onReset}
               aria-label={`Assistant Access in ${channel.name}`}
             />
           </div>

--- a/clients/web/src/domains/channels/components/slack-channel-section.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-section.tsx
@@ -1,6 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
+import { ChevronDown } from "lucide-react";
+
+import { Collapsible } from "@vellumai/design-library/components/collapsible";
+import { Typography } from "@vellumai/design-library/components/typography";
 
 import { SlackChannelList } from "@/domains/channels/components/slack-channel-list";
+import { SlackChannelTypeDefaults } from "@/domains/channels/components/slack-channel-type-defaults";
 import { useChannelPermissionOverrides } from "@/domains/channels/hooks/use-channel-permission-overrides";
 import { memberSlackChannelsOptions } from "@/domains/channels/slack-channels-query";
 import { getGlobalThresholds } from "@/lib/threshold-api";
@@ -14,12 +19,15 @@ export interface SlackChannelSectionProps {
 }
 
 /**
- * Data container for the Slack sub-tab's room list: the member-only
- * channels query and the per-channel capabilities-tier persistence. Mounts
- * only while Slack is connected (the panel renders it conditionally), so
- * the queries need no connection gate of their own. Access controls are
- * version-gated by the overrides hook; against an older assistant the
- * list renders channels without tier badges or pickers.
+ * Data container for the Slack sub-tab. When access controls are supported the
+ * primary card maps each conversation type (Channels, Direct messages) to its
+ * default Assistant Access level, and the per-channel presence list drops into a
+ * collapsible below it — individual channels matter less than the type default,
+ * so they stay out of the way. Against an older assistant (no channel-permission
+ * routes) it falls back to the plain presence list with no pickers.
+ *
+ * Mounts only while Slack is connected (the panel renders it conditionally), so
+ * the queries need no connection gate of their own.
  */
 export function SlackChannelSection({
   assistantId,
@@ -55,7 +63,7 @@ export function SlackChannelSection({
       ? null
       : (overrides.defaultCellTier ?? interactive);
 
-  return (
+  const list = (
     <SlackChannelList
       assistantDisplayName={assistantDisplayName}
       slackHandle={slackHandle}
@@ -70,6 +78,49 @@ export function SlackChannelSection({
       pendingChannelIds={overrides.pendingChannelIds}
       onTierChange={overrides.onTierChange}
       onTierReset={overrides.onTierReset}
+      // The default-access card above owns the key when access controls are on.
+      showLegend={!overrides.supported}
     />
+  );
+
+  // Older assistant without the channel-permission routes: no per-type defaults
+  // to map, so show the plain presence list on its own.
+  if (
+    !overrides.supported ||
+    !overrides.onBucketChange ||
+    !overrides.onBucketReset
+  ) {
+    return list;
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SlackChannelTypeDefaults
+        assistantName={assistantDisplayName}
+        globalDefaultTier={interactive}
+        bucketTiers={overrides.bucketTiers}
+        loading={overrides.isLoading}
+        error={overrides.isError}
+        pendingBuckets={overrides.pendingBuckets}
+        onBucketChange={overrides.onBucketChange}
+        onBucketReset={overrides.onBucketReset}
+      />
+      <Collapsible.Root type="single" collapsible>
+        <Collapsible.Item value="individual-channels">
+          <Collapsible.Trigger className="group justify-between gap-2 px-1 py-2">
+            <Typography as="span" variant="body-small-emphasised">
+              Individual channels
+            </Typography>
+            <ChevronDown
+              aria-hidden="true"
+              className="h-4 w-4 shrink-0 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-180"
+            />
+          </Collapsible.Trigger>
+          <Collapsible.Content>
+            <div className="pt-3">{list}</div>
+          </Collapsible.Content>
+        </Collapsible.Item>
+      </Collapsible.Root>
+    </div>
   );
 }

--- a/clients/web/src/domains/channels/components/slack-channel-type-defaults.stories.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-type-defaults.stories.tsx
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+import { userEvent, within } from "storybook/test";
+
+import { Collapsible } from "@vellumai/design-library/components/collapsible";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+import type { SlackChannel } from "@/domains/channels/slack-channels-query";
+import type { ChannelDefaultBucket } from "@/domains/channels/slack-channel-overrides";
+import type { RiskThreshold } from "@/utils/threshold-presets";
+
+import { SlackChannelList } from "./slack-channel-list";
+import { SlackChannelTypeDefaults } from "./slack-channel-type-defaults";
+
+type BucketTiers = Record<ChannelDefaultBucket, RiskThreshold | undefined>;
+
+const NO_TIERS: BucketTiers = { channels: undefined, dm: undefined };
+
+function makeChannel(
+  overrides: Partial<SlackChannel> & Pick<SlackChannel, "id" | "name">,
+): SlackChannel {
+  return {
+    type: "channel",
+    isPrivate: false,
+    isMember: true,
+    memberCount: null,
+    topic: null,
+    imageUrl: null,
+    ...overrides,
+  };
+}
+
+const CHANNELS: SlackChannel[] = [
+  makeChannel({ id: "C001", name: "general", memberCount: 42 }),
+  makeChannel({ id: "C002", name: "engineering", memberCount: 18 }),
+  makeChannel({ id: "C003", name: "eng-releases", memberCount: 9 }),
+  makeChannel({ id: "C004", name: "design", memberCount: 7 }),
+  makeChannel({ id: "C005", name: "leadership", isPrivate: true, memberCount: 4 }),
+];
+
+const meta: Meta<typeof SlackChannelTypeDefaults> = {
+  title: "Channels/SlackChannelTypeDefaults",
+  component: SlackChannelTypeDefaults,
+  args: {
+    assistantName: "Example Assistant",
+    // Seeded global interactive threshold: Relaxed / medium.
+    globalDefaultTier: "medium",
+    loading: false,
+    error: false,
+    pendingBuckets: new Set<ChannelDefaultBucket>(),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 720, margin: "2rem auto" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SlackChannelTypeDefaults>;
+
+/** Both buckets follow the global default → each reads "Relaxed · default". */
+export const Default: Story = {
+  render: function DefaultDefaults(args) {
+    const [tiers, setTiers] = useState<BucketTiers>(NO_TIERS);
+    return (
+      <SlackChannelTypeDefaults
+        {...args}
+        bucketTiers={tiers}
+        onBucketChange={(bucket, tier) =>
+          setTiers((prev) => ({ ...prev, [bucket]: tier }))
+        }
+        onBucketReset={(bucket) =>
+          setTiers((prev) => ({ ...prev, [bucket]: undefined }))
+        }
+      />
+    );
+  },
+};
+
+/**
+ * DMs pinned tighter than channels: "Channels" follows the default (Relaxed),
+ * "Direct messages" is set to Strict.
+ */
+export const Customized: Story = {
+  render: function CustomizedDefaults(args) {
+    const [tiers, setTiers] = useState<BucketTiers>({
+      channels: undefined,
+      dm: "none",
+    });
+    return (
+      <SlackChannelTypeDefaults
+        {...args}
+        bucketTiers={tiers}
+        onBucketChange={(bucket, tier) =>
+          setTiers((prev) => ({ ...prev, [bucket]: tier }))
+        }
+        onBucketReset={(bucket) =>
+          setTiers((prev) => ({ ...prev, [bucket]: undefined }))
+        }
+      />
+    );
+  },
+};
+
+/**
+ * The full Slack sub-tab layout: the default-access card as the hero, with the
+ * per-channel presence list folded into the "Individual channels" collapsible
+ * below (collapsed by default). Mirrors `SlackChannelSection`.
+ */
+export const InContext: Story = {
+  render: function SectionLayout(args) {
+    const [tiers, setTiers] = useState<BucketTiers>(NO_TIERS);
+    const channelsDefault = tiers.channels ?? args.globalDefaultTier;
+    return (
+      <div className="flex flex-col gap-4">
+        <SlackChannelTypeDefaults
+          {...args}
+          bucketTiers={tiers}
+          onBucketChange={(bucket, tier) =>
+            setTiers((prev) => ({ ...prev, [bucket]: tier }))
+          }
+          onBucketReset={(bucket) =>
+            setTiers((prev) => ({ ...prev, [bucket]: undefined }))
+          }
+        />
+        <Collapsible.Root type="single" collapsible>
+          <Collapsible.Item value="individual-channels">
+            <Collapsible.Trigger className="group justify-between gap-2 px-1 py-2">
+              <Typography as="span" variant="body-small-emphasised">
+                Individual channels
+              </Typography>
+              <ChevronDown
+                aria-hidden="true"
+                className="h-4 w-4 shrink-0 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-180"
+              />
+            </Collapsible.Trigger>
+            <Collapsible.Content>
+              <div className="pt-3">
+                <SlackChannelList
+                  assistantDisplayName="Example Assistant"
+                  slackHandle="@example-assistant"
+                  channels={CHANNELS}
+                  defaultTier={channelsDefault}
+                  showLegend={false}
+                />
+              </div>
+            </Collapsible.Content>
+          </Collapsible.Item>
+        </Collapsible.Root>
+      </div>
+    );
+  },
+};
+
+/** The "Individual channels" collapsible expanded, showing the per-channel rows. */
+export const InContextExpanded: Story = {
+  ...InContext,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: /individual channels/i }),
+    );
+  },
+};

--- a/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
@@ -1,0 +1,129 @@
+import { Hash, MessageSquare } from "lucide-react";
+
+import { Card } from "@vellumai/design-library/components/card";
+import { ListRow } from "@vellumai/design-library/components/list-row";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+import { SlackChannelTierLegend } from "@/domains/channels/components/slack-channel-tier-legend";
+import { TierPicker } from "@/domains/channels/components/tier-picker";
+import type { ChannelDefaultBucket } from "@/domains/channels/slack-channel-overrides";
+import type { RiskThreshold } from "@/utils/threshold-presets";
+
+interface BucketRow {
+  bucket: ChannelDefaultBucket;
+  icon: typeof Hash;
+  title: string;
+  description: string;
+}
+
+/**
+ * The two default buckets, in cascade order. "Channels" is the adapter-wide
+ * default; "Direct messages" overrides it for DMs. Public and private aren't
+ * split — the gateway forwards them identically, so a per-kind default wouldn't
+ * take effect.
+ */
+const BUCKET_ROWS: readonly BucketRow[] = [
+  {
+    bucket: "channels",
+    icon: Hash,
+    title: "Channels",
+    description: "Public and private channels",
+  },
+  {
+    bucket: "dm",
+    icon: MessageSquare,
+    title: "Direct messages",
+    description: "1:1 and group DMs",
+  },
+];
+
+export interface SlackChannelTypeDefaultsProps {
+  /** Trimmed assistant name with a "your assistant" fallback, for copy. */
+  assistantName: string;
+  /**
+   * The owner's global Assistant Access default that the "Channels" bucket falls
+   * through to when it has no cell. `null` while the global threshold is still
+   * unknown. DMs fall through to the "Channels" tier, then to this.
+   */
+  globalDefaultTier: RiskThreshold | null;
+  /** The explicit tier per bucket, or `undefined` when the bucket follows its fall-through. */
+  bucketTiers?: Record<ChannelDefaultBucket, RiskThreshold | undefined>;
+  loading: boolean;
+  error: boolean;
+  pendingBuckets: ReadonlySet<ChannelDefaultBucket>;
+  onBucketChange: (bucket: ChannelDefaultBucket, tier: RiskThreshold) => void;
+  onBucketReset: (bucket: ChannelDefaultBucket) => void;
+}
+
+/**
+ * Primary "Default access" card for the Slack sub-tab: two rows mapping a
+ * conversation type (Channels, Direct messages) to its default Assistant Access
+ * level, with the always-visible tier key in the footer. Each row's picker names
+ * the effective level and marks the one it inherits, exactly like the per-room
+ * picker ({@link TierPicker}). Individual channels override these below.
+ */
+export function SlackChannelTypeDefaults({
+  assistantName,
+  globalDefaultTier,
+  bucketTiers,
+  loading,
+  error,
+  pendingBuckets,
+  onBucketChange,
+  onBucketReset,
+}: SlackChannelTypeDefaultsProps) {
+  return (
+    <Card.Root>
+      <Card.Header>
+        <div className="flex flex-col gap-1">
+          Default access
+          <Typography
+            as="p"
+            variant="body-small-default"
+            className="text-[color:var(--content-tertiary)]"
+          >
+            How much {assistantName} does on its own, by conversation type.
+            Individual channels can override this below.
+          </Typography>
+        </div>
+      </Card.Header>
+      <Card.Body>
+        {BUCKET_ROWS.map(({ bucket, icon: Icon, title, description }) => {
+          // DMs fall through to the Channels default, then the global default;
+          // Channels falls through to the global default.
+          const inheritedTier =
+            bucket === "dm"
+              ? (bucketTiers?.channels ?? globalDefaultTier)
+              : globalDefaultTier;
+          return (
+            <ListRow
+              key={bucket}
+              className="[&+&]:border-t [&+&]:border-[var(--border-base)]"
+              leading={<Icon className="h-4 w-4 text-[var(--content-tertiary)]" />}
+              title={title}
+              subtitle={description}
+              trailing={
+                <div className="w-48">
+                  <TierPicker
+                    tier={bucketTiers?.[bucket]}
+                    defaultTier={inheritedTier}
+                    disabled={loading || error || pendingBuckets.has(bucket)}
+                    onTierChange={(tier) => onBucketChange(bucket, tier)}
+                    onReset={() => onBucketReset(bucket)}
+                    aria-label={`Default Assistant Access for ${title}`}
+                  />
+                </div>
+              }
+            />
+          );
+        })}
+      </Card.Body>
+      <Card.Footer className="p-0">
+        <SlackChannelTierLegend
+          assistantName={assistantName}
+          defaultTier={globalDefaultTier}
+        />
+      </Card.Footer>
+    </Card.Root>
+  );
+}

--- a/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
@@ -18,9 +18,11 @@ interface BucketRow {
 
 /**
  * The two default buckets, in cascade order. "Channels" is the adapter-wide
- * default; "Direct messages" overrides it for DMs. Public and private aren't
- * split — the gateway forwards them identically, so a per-kind default wouldn't
- * take effect.
+ * default (every room); "Direct messages" overrides it for 1:1 DMs only. Only
+ * 1:1 DMs carry a `channelType` (`"dm"`) at tool time — the gateway collapses
+ * group DMs (mpim), private, and public rooms into `"channel"` (no type), so a
+ * `channel_type` cell for those never matches. Group DMs therefore follow the
+ * Channels default, and public/private can't be split here at all.
  */
 const BUCKET_ROWS: readonly BucketRow[] = [
   {
@@ -33,7 +35,7 @@ const BUCKET_ROWS: readonly BucketRow[] = [
     bucket: "dm",
     icon: MessageSquare,
     title: "Direct messages",
-    description: "1:1 and group DMs",
+    description: "One-on-one DMs",
   },
 ];
 

--- a/clients/web/src/domains/channels/components/tier-picker.tsx
+++ b/clients/web/src/domains/channels/components/tier-picker.tsx
@@ -1,0 +1,94 @@
+import {
+  Dropdown,
+  type DropdownOption,
+} from "@vellumai/design-library/components/dropdown";
+
+import {
+  CAPABILITY_TIER_META,
+  CAPABILITY_TIER_VALUES,
+} from "@/domains/channels/slack-channel-overrides";
+import type { RiskThreshold } from "@/utils/threshold-presets";
+
+/** Small accent dot, colored per tier via `CAPABILITY_TIER_META.dotColor`. */
+export function TierDot({ color }: { color: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="h-1.5 w-1.5 rounded-full"
+      style={{ backgroundColor: color }}
+    />
+  );
+}
+
+export interface TierPickerProps {
+  /** The persisted tier for this scope, or `undefined` when it follows the default. */
+  tier: RiskThreshold | undefined;
+  /**
+   * The tier this scope falls through to when it has no cell of its own — the
+   * level shown with a muted "default" marker. `null` while still unknown, in
+   * which case no level is marked and the trigger shows a "Default" placeholder.
+   */
+  defaultTier: RiskThreshold | null;
+  disabled?: boolean;
+  /** Persist an explicit tier for this scope. */
+  onTierChange: (tier: RiskThreshold) => void;
+  /** Clear this scope's cell so it follows the default again. */
+  onReset: () => void;
+  "aria-label": string;
+}
+
+/**
+ * The compact Assistant Access picker shared by the per-channel rows and the
+ * channel-type default rows. Lists the four levels only — no separate "Default"
+ * option: the level equal to the resolved default carries a muted "default"
+ * marker, selecting it clears this scope's cell (follow the default), and
+ * selecting any other level pins an override. This keeps "follow the default"
+ * and "pick the level it resolves to" the same choice, and is safe because
+ * resolution is most-specific-wins and value-only (see `slack-channel-overrides`
+ * and the gateway's `ChannelPermissionStore.resolve`).
+ */
+export function TierPicker({
+  tier,
+  defaultTier,
+  disabled,
+  onTierChange,
+  onReset,
+  "aria-label": ariaLabel,
+}: TierPickerProps) {
+  const effectiveTier = tier ?? defaultTier;
+  const options: DropdownOption<RiskThreshold>[] = CAPABILITY_TIER_VALUES.map(
+    (value) => ({
+      value,
+      label: CAPABILITY_TIER_META[value].label,
+      icon: <TierDot color={CAPABILITY_TIER_META[value].dotColor} />,
+      suffix:
+        value === defaultTier ? (
+          <span className="text-[color:var(--content-tertiary)]">default</span>
+        ) : undefined,
+      tooltip: CAPABILITY_TIER_META[value].sublabel,
+    }),
+  );
+
+  const handleChange = (next: RiskThreshold) => {
+    // Picking the level the default resolves to means "follow the default",
+    // which is the absence of a cell — clear it rather than pinning an equal one.
+    if (next === defaultTier) {
+      onReset();
+    } else {
+      onTierChange(next);
+    }
+  };
+
+  return (
+    <Dropdown<RiskThreshold>
+      value={effectiveTier ?? ""}
+      onChange={handleChange}
+      options={options}
+      placeholder="Default"
+      disabled={disabled}
+      size="compact"
+      menuAlign="end"
+      aria-label={ariaLabel}
+    />
+  );
+}

--- a/clients/web/src/domains/channels/hooks/use-channel-permission-overrides.ts
+++ b/clients/web/src/domains/channels/hooks/use-channel-permission-overrides.ts
@@ -3,8 +3,10 @@ import { useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
+  bucketDefaultFromCells,
   CHANNEL_TIER_CONTACT_TYPES,
   tierOverridesFromCells,
+  type ChannelDefaultBucket,
 } from "@/domains/channels/slack-channel-overrides";
 import type { RiskThreshold } from "@/utils/threshold-presets";
 import {
@@ -23,6 +25,7 @@ import { toastOnError } from "@/utils/mutation-error";
 type CellList = AssistantChannelPermissionOverridesListResponse;
 type Cell = CellList["cells"][number];
 type WireCell = Omit<Cell, "updatedAt">;
+type Selector = Cell["selector"];
 
 export interface ChannelPermissionOverridesController {
   /**
@@ -41,8 +44,16 @@ export interface ChannelPermissionOverridesController {
    * `undefined` while loading or unsupported.
    */
   defaultCellTier?: RiskThreshold | null;
+  /**
+   * The explicit tier for a channel-type default bucket, or `undefined` when the
+   * bucket has no cell (it follows the next tier up). `channels` is the
+   * adapter-scope default; `dm` is the direct-message default.
+   */
+  bucketTiers?: Record<ChannelDefaultBucket, RiskThreshold | undefined>;
   /** Channels with a cell write/delete in flight. */
   pendingChannelIds: ReadonlySet<string>;
+  /** Buckets with a default write/delete in flight. */
+  pendingBuckets: ReadonlySet<ChannelDefaultBucket>;
   /** True until the cells have loaded at least once. */
   isLoading: boolean;
   isError: boolean;
@@ -50,6 +61,10 @@ export interface ChannelPermissionOverridesController {
   onTierChange?: (channelExternalId: string, tier: RiskThreshold) => void;
   /** Delete the channel's cells so the next cascade tier up wins. */
   onTierReset?: (channelExternalId: string) => void;
+  /** Persist a channel-type default bucket's cells. */
+  onBucketChange?: (bucket: ChannelDefaultBucket, tier: RiskThreshold) => void;
+  /** Delete a bucket's cells so it follows the next tier up. */
+  onBucketReset?: (bucket: ChannelDefaultBucket) => void;
 }
 
 /** One channel-ID cell per non-guardian contact-type for the chosen tier. */
@@ -77,15 +92,49 @@ function isChannelCell(
   );
 }
 
+/** The selector for a channel-type default bucket: adapter-scope or channel_type:dm. */
+function bucketSelector(adapter: string, bucket: ChannelDefaultBucket): Selector {
+  return bucket === "channels"
+    ? { scope: "adapter", adapter }
+    : { scope: "channel_type", adapter, channelType: "dm" };
+}
+
+/** One bucket cell per non-guardian contact-type for the chosen tier. */
+function cellsForBucket(
+  adapter: string,
+  bucket: ChannelDefaultBucket,
+  tier: RiskThreshold,
+): WireCell[] {
+  const selector = bucketSelector(adapter, bucket);
+  return CHANNEL_TIER_CONTACT_TYPES.map((contactType) => ({
+    selector,
+    contactType,
+    threshold: tier,
+  }));
+}
+
+function isBucketCell(
+  cell: Cell,
+  adapter: string,
+  bucket: ChannelDefaultBucket,
+): boolean {
+  return bucket === "channels"
+    ? cell.selector.scope === "adapter" && cell.selector.adapter === adapter
+    : cell.selector.scope === "channel_type" &&
+        cell.selector.adapter === adapter &&
+        cell.selector.channelType === "dm";
+}
+
 /**
  * Per-channel capabilities-tier persistence for a channel adapter's room
  * list: reads the gateway's channel-permission cells and writes/deletes
- * channel-ID-tier cells (one per non-guardian contact-type). Optimistic —
- * the cell cache is patched immediately, rolled back and toasted on
- * failure, and revalidated on settle. Gated on the version gate in
- * `lib/backwards-compat/channel-access-controls.ts` (whether the connected
- * assistant can serve it); when off it reports `supported: false` with no
- * overrides or handlers.
+ * channel-ID-tier cells (one per non-guardian contact-type), plus the two
+ * broader-scope default buckets (`channels` → adapter cell, `dm` →
+ * channel_type:dm cell). Optimistic — the cell cache is patched immediately,
+ * rolled back and toasted on failure, and revalidated on settle. Gated on the
+ * version gate in `lib/backwards-compat/channel-access-controls.ts` (whether the
+ * connected assistant can serve it); when off it reports `supported: false` with
+ * no overrides or handlers.
  *
  * The adapter is a parameter so Telegram/Phone room lists reuse this hook
  * unchanged when they land.
@@ -113,8 +162,25 @@ export function useChannelPermissionOverrides({
   const query = useQuery({
     ...assistantChannelPermissionOverridesListOptions(pathOptions),
     enabled,
-    select: (data) => tierOverridesFromCells(data.cells, adapter),
   });
+
+  const cells = query.data?.cells;
+  const tierOverrides = useMemo(
+    () => (cells ? tierOverridesFromCells(cells, adapter) : undefined),
+    [cells, adapter],
+  );
+  const bucketTiers = useMemo<
+    Record<ChannelDefaultBucket, RiskThreshold | undefined> | undefined
+  >(
+    () =>
+      cells
+        ? {
+            channels: bucketDefaultFromCells(cells, adapter, "channels"),
+            dm: bucketDefaultFromCells(cells, adapter, "dm"),
+          }
+        : undefined,
+    [cells, adapter],
+  );
 
   // The default a cell-less room falls through to, resolved by the gateway
   // (the same resolver the runtime evaluator uses over IPC) with the same
@@ -140,19 +206,17 @@ export function useChannelPermissionOverrides({
     staleTime: 30_000,
   });
 
-  // Optimistically replace the channel's cells in the cached list, snapshot
-  // for rollback, and revalidate after the server settles either way.
+  // Optimistically replace the cells matching `matches` in the cached list,
+  // snapshot for rollback, and revalidate after the server settles either way.
   const applyOptimistic = (
-    channelExternalId: string,
+    matches: (cell: Cell) => boolean,
     nextCells: WireCell[],
   ): { previous: CellList | undefined } => {
     const previous = queryClient.getQueryData<CellList>(queryKey);
     const stampedAt = Date.now();
     queryClient.setQueryData<CellList>(queryKey, (old) => ({
       cells: [
-        ...(old?.cells ?? []).filter(
-          (cell) => !isChannelCell(cell, adapter, channelExternalId),
-        ),
+        ...(old?.cells ?? []).filter((cell) => !matches(cell)),
         ...nextCells.map((cell) => ({ ...cell, updatedAt: stampedAt })),
       ],
     }));
@@ -179,7 +243,7 @@ export function useChannelPermissionOverrides({
     },
     onMutate: ({ channelExternalId, tier }) =>
       applyOptimistic(
-        channelExternalId,
+        (cell) => isChannelCell(cell, adapter, channelExternalId),
         cellsForTier(adapter, channelExternalId, tier),
       ),
     onError: (err, _vars, context) => {
@@ -212,10 +276,66 @@ export function useChannelPermissionOverrides({
         ),
       );
     },
-    onMutate: ({ channelExternalId }) => applyOptimistic(channelExternalId, []),
+    onMutate: ({ channelExternalId }) =>
+      applyOptimistic(
+        (cell) => isChannelCell(cell, adapter, channelExternalId),
+        [],
+      ),
     onError: (err, _vars, context) => {
       queryClient.setQueryData(queryKey, context?.previous);
       toastOnError("Failed to reset channel settings")(err);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey }),
+  });
+
+  const bucketSetMutation = useMutation({
+    mutationFn: async ({
+      bucket,
+      tier,
+    }: {
+      bucket: ChannelDefaultBucket;
+      tier: RiskThreshold;
+    }) => {
+      await Promise.all(
+        cellsForBucket(adapter, bucket, tier).map((cell) =>
+          assistantChannelPermissionOverrideSet({
+            ...pathOptions,
+            body: cell,
+            throwOnError: true,
+          }),
+        ),
+      );
+    },
+    onMutate: ({ bucket, tier }) =>
+      applyOptimistic(
+        (cell) => isBucketCell(cell, adapter, bucket),
+        cellsForBucket(adapter, bucket, tier),
+      ),
+    onError: (err, _vars, context) => {
+      queryClient.setQueryData(queryKey, context?.previous);
+      toastOnError("Failed to save the default")(err);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey }),
+  });
+
+  const bucketDeleteMutation = useMutation({
+    mutationFn: async ({ bucket }: { bucket: ChannelDefaultBucket }) => {
+      const selector = bucketSelector(adapter, bucket);
+      await Promise.all(
+        CHANNEL_TIER_CONTACT_TYPES.map((contactType) =>
+          assistantChannelPermissionOverrideDelete({
+            ...pathOptions,
+            body: { selector, contactType },
+            throwOnError: true,
+          }),
+        ),
+      );
+    },
+    onMutate: ({ bucket }) =>
+      applyOptimistic((cell) => isBucketCell(cell, adapter, bucket), []),
+    onError: (err, _vars, context) => {
+      queryClient.setQueryData(queryKey, context?.previous);
+      toastOnError("Failed to reset the default")(err);
     },
     onSettled: () => queryClient.invalidateQueries({ queryKey }),
   });
@@ -236,34 +356,64 @@ export function useChannelPermissionOverrides({
     deleteMutation.variables,
   ]);
 
+  const pendingBuckets = useMemo(() => {
+    const buckets = new Set<ChannelDefaultBucket>();
+    if (bucketSetMutation.isPending && bucketSetMutation.variables) {
+      buckets.add(bucketSetMutation.variables.bucket);
+    }
+    if (bucketDeleteMutation.isPending && bucketDeleteMutation.variables) {
+      buckets.add(bucketDeleteMutation.variables.bucket);
+    }
+    return buckets;
+  }, [
+    bucketSetMutation.isPending,
+    bucketSetMutation.variables,
+    bucketDeleteMutation.isPending,
+    bucketDeleteMutation.variables,
+  ]);
+
   if (!enabled) {
     return {
       supported: false,
       tierOverrides: undefined,
       defaultCellTier: undefined,
+      bucketTiers: undefined,
       pendingChannelIds: new Set(),
+      pendingBuckets: new Set(),
       isLoading: false,
       isError: false,
       onTierChange: undefined,
       onTierReset: undefined,
+      onBucketChange: undefined,
+      onBucketReset: undefined,
     };
   }
 
   return {
     supported: true,
-    tierOverrides: query.data,
+    tierOverrides,
     defaultCellTier: defaultQuery.data,
+    bucketTiers,
     pendingChannelIds,
+    pendingBuckets,
     isLoading: query.isPending,
     isError: query.isError,
     onTierChange: (channelExternalId, tier) =>
       setMutation.mutate({ channelExternalId, tier }),
     onTierReset: (channelExternalId) => {
       // Skip the round-trip when nothing is persisted for the channel.
-      if (query.data?.[channelExternalId] === undefined) {
+      if (tierOverrides?.[channelExternalId] === undefined) {
         return;
       }
       deleteMutation.mutate({ channelExternalId });
+    },
+    onBucketChange: (bucket, tier) => bucketSetMutation.mutate({ bucket, tier }),
+    onBucketReset: (bucket) => {
+      // Skip the round-trip when the bucket has no cell.
+      if (bucketTiers?.[bucket] === undefined) {
+        return;
+      }
+      bucketDeleteMutation.mutate({ bucket });
     },
   };
 }

--- a/clients/web/src/domains/channels/hooks/use-channel-permission-overrides.ts
+++ b/clients/web/src/domains/channels/hooks/use-channel-permission-overrides.ts
@@ -158,6 +158,14 @@ export function useChannelPermissionOverrides({
     () => assistantChannelPermissionOverridesListQueryKey(pathOptions),
     [pathOptions],
   );
+  // The resolve query (the cell-less fall-through) is keyed separately and
+  // caches for 30s. A `channels`-bucket write changes an adapter-scope cell,
+  // which the resolve reads — so bucket writes must invalidate it too, or the
+  // per-channel rows keep their stale `defaultTier`.
+  const resolveQueryKey = useMemo(
+    () => ["channel-permission-resolve", assistantId, adapter] as const,
+    [assistantId, adapter],
+  );
 
   const query = useQuery({
     ...assistantChannelPermissionOverridesListOptions(pathOptions),
@@ -192,7 +200,7 @@ export function useChannelPermissionOverrides({
   // (0.10.7 gateways 404 it deterministically), and an errored query just
   // leaves the badge at a plain "Default".
   const defaultQuery = useQuery({
-    queryKey: ["channel-permission-resolve", assistantId, adapter],
+    queryKey: resolveQueryKey,
     queryFn: async () => {
       const { data } = await assistantChannelPermissionResolve({
         ...pathOptions,
@@ -315,7 +323,10 @@ export function useChannelPermissionOverrides({
       queryClient.setQueryData(queryKey, context?.previous);
       toastOnError("Failed to save the default")(err);
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey }),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: resolveQueryKey });
+    },
   });
 
   const bucketDeleteMutation = useMutation({
@@ -337,7 +348,10 @@ export function useChannelPermissionOverrides({
       queryClient.setQueryData(queryKey, context?.previous);
       toastOnError("Failed to reset the default")(err);
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey }),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: resolveQueryKey });
+    },
   });
 
   const pendingChannelIds = useMemo(() => {

--- a/clients/web/src/domains/channels/slack-channel-overrides.test.ts
+++ b/clients/web/src/domains/channels/slack-channel-overrides.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { THRESHOLD_PRESETS } from "@/utils/threshold-presets";
 
 import {
+  bucketDefaultFromCells,
   CAPABILITY_TIER_META,
   CAPABILITY_TIER_VALUES,
   tierOverridesFromCells,
@@ -97,5 +98,60 @@ describe("tierOverridesFromCells", () => {
       "slack",
     );
     expect(overrides).toEqual({ C1: "high" });
+  });
+});
+
+describe("bucketDefaultFromCells", () => {
+  const adapterCell = (
+    adapter: string,
+    threshold: ChannelTierCell["threshold"],
+    contactType = "trusted_contact",
+  ): ChannelTierCell => ({
+    selector: { scope: "adapter", adapter },
+    contactType,
+    threshold,
+  });
+
+  const dmCell = (
+    adapter: string,
+    threshold: ChannelTierCell["threshold"],
+    contactType = "trusted_contact",
+  ): ChannelTierCell => ({
+    selector: { scope: "channel_type", adapter, channelType: "dm" },
+    contactType,
+    threshold,
+  });
+
+  test("reads the adapter-scope cell as the 'channels' default", () => {
+    const cells = [adapterCell("slack", "medium")];
+    expect(bucketDefaultFromCells(cells, "slack", "channels")).toBe("medium");
+    expect(bucketDefaultFromCells(cells, "slack", "dm")).toBeUndefined();
+  });
+
+  test("reads the channel_type:dm cell as the 'dm' default", () => {
+    const cells = [dmCell("slack", "none")];
+    expect(bucketDefaultFromCells(cells, "slack", "dm")).toBe("none");
+    expect(bucketDefaultFromCells(cells, "slack", "channels")).toBeUndefined();
+  });
+
+  test("ignores other adapters and non-dm channel types", () => {
+    const cells: ChannelTierCell[] = [
+      adapterCell("telegram", "high"),
+      {
+        selector: { scope: "channel_type", adapter: "slack", channelType: "private" },
+        contactType: "trusted_contact",
+        threshold: "high",
+      },
+    ];
+    expect(bucketDefaultFromCells(cells, "slack", "channels")).toBeUndefined();
+    expect(bucketDefaultFromCells(cells, "slack", "dm")).toBeUndefined();
+  });
+
+  test("trusted_contact is representative when contact types diverge", () => {
+    const cells = [
+      adapterCell("slack", "none", "unknown"),
+      adapterCell("slack", "medium", "trusted_contact"),
+    ];
+    expect(bucketDefaultFromCells(cells, "slack", "channels")).toBe("medium");
   });
 });

--- a/clients/web/src/domains/channels/slack-channel-overrides.ts
+++ b/clients/web/src/domains/channels/slack-channel-overrides.ts
@@ -128,3 +128,42 @@ export function tierOverridesFromCells(
   }
   return overrides;
 }
+
+/**
+ * The two broader-scope default "buckets" the channel-type UI exposes:
+ * `"channels"` writes an `adapter`-scope cell (the default for every room of
+ * this adapter), `"dm"` writes a `channel_type: dm` cell (the default for direct
+ * messages, which overrides the adapter default for DMs). Public/private are not
+ * split — the gateway forwards Slack public and private rooms identically, so a
+ * `channel_type: public|private` cell would never match at tool time.
+ */
+export type ChannelDefaultBucket = "channels" | "dm";
+
+/**
+ * The persisted tier for a bucket's cell, if any — the `trusted_contact` cell is
+ * the representative when non-guardian contact-type cells diverge (the write
+ * path keeps them aligned). `undefined` when the bucket has no cell (it then
+ * follows the next tier up the cascade).
+ */
+export function bucketDefaultFromCells(
+  cells: ChannelTierCell[],
+  adapter: string,
+  bucket: ChannelDefaultBucket,
+): RiskThreshold | undefined {
+  let tier: RiskThreshold | undefined;
+  for (const cell of cells) {
+    const matches =
+      bucket === "channels"
+        ? cell.selector.scope === "adapter" && cell.selector.adapter === adapter
+        : cell.selector.scope === "channel_type" &&
+          cell.selector.adapter === adapter &&
+          cell.selector.channelType === "dm";
+    if (!matches) {
+      continue;
+    }
+    if (cell.contactType === "trusted_contact" || tier === undefined) {
+      tier = cell.threshold;
+    }
+  }
+  return tier;
+}

--- a/clients/web/src/domains/channels/slack-channel-overrides.ts
+++ b/clients/web/src/domains/channels/slack-channel-overrides.ts
@@ -132,10 +132,12 @@ export function tierOverridesFromCells(
 /**
  * The two broader-scope default "buckets" the channel-type UI exposes:
  * `"channels"` writes an `adapter`-scope cell (the default for every room of
- * this adapter), `"dm"` writes a `channel_type: dm` cell (the default for direct
- * messages, which overrides the adapter default for DMs). Public/private are not
- * split — the gateway forwards Slack public and private rooms identically, so a
- * `channel_type: public|private` cell would never match at tool time.
+ * this adapter), `"dm"` writes a `channel_type: dm` cell that overrides it for
+ * 1:1 DMs. Only 1:1 DMs (`im`) reach the runtime as `channelType: "dm"`; the
+ * gateway collapses group DMs (mpim), private, and public rooms into `"channel"`
+ * with no type, so a `channel_type: dm|private|public` cell never matches for
+ * those. Group DMs therefore follow the `"channels"` default, and public/private
+ * can't be split here without a gateway change.
  */
 export type ChannelDefaultBucket = "channels" | "dm";
 


### PR DESCRIPTION
## Prompt / plan
Makes the Slack sub-tab lead with a **default-access mapping by conversation type** instead of the per-channel list. Individual channels matter less than the type-level default, so the presence list drops into a collapsible below.

A walkthrough of the permission system settled the shape: the per-channel-*type* axis only makes sense where it actually resolves at runtime. The gateway forwards Slack public and private rooms identically (no conversation type), so a `channel_type: public|private` cell would never match — but `adapter` and `channel_type: dm` both resolve. So this ships **two buckets, no gateway change**:

- **Channels** → an `adapter`-scope cell (the default for every Slack room).
- **Direct messages** → a `channel_type: dm` cell, overriding it for DMs.

Each falls through to the owner's global default (`auto_approve_thresholds.interactive`, seeded Relaxed). This is auto-approve tuning only — it always composes under the untouched per-trust-class capability floor (non-guardians still escalate sensitive tools at every level), which the always-visible key states.

## What changed
- **`TierPicker`** — extracted the Pattern B compact picker (four levels; the level equal to the resolved default carries a muted "default" marker; selecting it clears the cell) so the per-channel rows and the new type rows share one component.
- **`useChannelPermissionOverrides`** — now also reads/writes the two default buckets (`channels` = adapter cell, `dm` = channel_type:dm), reusing the optimistic-update machinery. +4 unit tests for the new `bucketDefaultFromCells` helper.
- **`SlackChannelTypeDefaults`** — the primary "Default access" card: Channels + Direct messages rows, each with the picker, plus the always-visible tier key in the footer.
- **`SlackChannelSection`** — recomposed: default-access card as the hero, per-channel list in an "Individual channels" collapsible (collapsed by default). Falls back to the plain presence list on older assistants. `SlackChannelList` gained a `showLegend` prop so the key renders once.

No gateway, backend, or migration change — the `adapter`/`channel_type` scopes already resolve at tool time.

## Test plan
- `bunx tsc --noEmit` + ESLint clean (pre-commit).
- `bun test src/domains/channels` — 24 pass (incl. the new `bucketDefaultFromCells` cases).
- New Storybook stories under `Channels/SlackChannelTypeDefaults` (default, DM-tightened, in-context, expanded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeiZ9nRv2AdHtBCcGmCoJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeiZ9nRv2AdHtBCcGmCoJY)_