### PR TITLE
refactor(conversations): nuke the dead CLI-superseded wire protocol

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -461,7 +461,7 @@ subgraph "Text Q&A Session"
 
     %% Main Window Chat flow
     CHAT_VM -->|"conversation_create +<br/>user_message +<br/>cancel<br/>(HTTP POST)"| HTTP_RT
-    HTTP_RT -->|"conversation_info +<br/>conversation_title_updated +<br/>text deltas +<br/>message_complete +<br/>conversation_error +<br/>message_queued +<br/>message_dequeued +<br/>generation_handoff<br/>(SSE)"| CHAT_VM
+    HTTP_RT -->|"conversation_title_updated +<br/>text deltas +<br/>message_complete +<br/>conversation_error +<br/>message_queued +<br/>message_dequeued +<br/>generation_handoff<br/>(SSE)"| CHAT_VM
     CHAT_VIEW --> CHAT_VM
     MW_STATE -->|"app_open_request<br/>(dashboard-first bootstrap)"| HTTP_RT
 

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -64,7 +64,6 @@ export function sanitizeUrlForDisplay(rawUrl: unknown): string {
 export async function startCli(): Promise<void> {
   let conversationKey = CLI_CONVERSATION_KEY;
   let conversationId = "";
-  let pendingUserContent: string | null = null;
   let generating = false;
   let lastUsage: {
     inputTokens: number;
@@ -292,52 +291,6 @@ export async function startCli(): Promise<void> {
 
   function handleMessage(msg: ServerMessage): void {
     switch (msg.type) {
-      case "conversation_info":
-        pendingSessionPick = false;
-        conversationId = msg.conversationId;
-        process.stdout.write(
-          `\n  Conversation: ${msg.title}\n  Type your message. Ctrl+D to detach.\n\n`,
-        );
-        if (pendingUserContent) {
-          const content = pendingUserContent;
-          pendingUserContent = null;
-          sendUserMessage(content).then((result) => {
-            if (result.ok) {
-              generating = true;
-              spinner.start("Thinking...");
-            } else {
-              if (result.error === "secret_blocked" && result.message) {
-                process.stdout.write(`${result.message}\n`);
-                rl.question("Send anyway? (y/N): ", (answer) => {
-                  if (answer.trim().toLowerCase() === "y") {
-                    sendUserMessage(content, {
-                      bypassSecretCheck: true,
-                    }).then((retryResult) => {
-                      if (retryResult.ok) {
-                        generating = true;
-                        spinner.start("Thinking...");
-                      } else {
-                        process.stdout.write(
-                          "[Not connected — message not sent]\n",
-                        );
-                        prompt();
-                      }
-                    });
-                  } else {
-                    prompt();
-                  }
-                });
-              } else {
-                process.stdout.write("[Not connected — message not sent]\n");
-                prompt();
-              }
-            }
-          });
-        } else {
-          prompt();
-        }
-        break;
-
       case "assistant_text_delta":
         spinner.stop();
         process.stdout.write(msg.text);
@@ -507,70 +460,10 @@ export async function startCli(): Promise<void> {
         prompt();
         break;
 
-      case "conversation_list_response":
-        if (pendingSessionPick) {
-          renderConversationPicker(msg.conversations);
-        } else {
-          for (const conversation of msg.conversations) {
-            process.stdout.write(
-              `  ${conversation.id}  ${conversation.title}\n`,
-            );
-          }
-          prompt();
-        }
-        break;
-
       case "model_info":
         process.stdout.write(`\n  Model: ${msg.model} (${msg.provider})\n\n`);
         prompt();
         break;
-
-      case "history_response":
-        process.stdout.write("\n");
-        if (msg.messages.length === 0) {
-          process.stdout.write("  No messages in this conversation.\n");
-        } else {
-          for (const m of msg.messages) {
-            const label = m.role === "user" ? "you" : "assistant";
-            const preview = truncate(m.text, 120);
-            process.stdout.write(
-              `  ${label}> ${preview.replace(/\n/g, " ")}\n`,
-            );
-          }
-        }
-        process.stdout.write("\n");
-        prompt();
-        break;
-
-      case "undo_complete":
-        if (msg.removedCount === 0) {
-          process.stdout.write("\n  Nothing to undo.\n\n");
-        } else {
-          process.stdout.write(
-            `\n  Removed last exchange (${msg.removedCount} messages).\n\n`,
-          );
-        }
-        prompt();
-        break;
-
-      case "usage_response": {
-        process.stdout.write("\n");
-        process.stdout.write(`  Model:          ${msg.model}\n`);
-        process.stdout.write(
-          `  Input tokens:   ${msg.totalInputTokens.toLocaleString()}\n`,
-        );
-        process.stdout.write(
-          `  Output tokens:  ${msg.totalOutputTokens.toLocaleString()}\n`,
-        );
-        const costStr =
-          msg.estimatedCost > 0
-            ? `$${msg.estimatedCost.toFixed(4)}`
-            : "N/A (unknown model pricing)";
-        process.stdout.write(`  Estimated cost: ${costStr}\n`);
-        process.stdout.write("\n");
-        prompt();
-        break;
-      }
     }
   }
 

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -58,10 +58,7 @@ import type {
   _ComputerUseServerMessages,
 } from "./message-types/computer-use.js";
 import type { _ContactsServerMessages } from "./message-types/contacts.js";
-import type {
-  _ConversationsClientMessages,
-  _ConversationsServerMessages,
-} from "./message-types/conversations.js";
+import type { _ConversationsServerMessages } from "./message-types/conversations.js";
 import type { _DiagnosticsClientMessages } from "./message-types/diagnostics.js";
 import type { _DocumentCommentsServerMessages } from "./message-types/document-comments.js";
 import type { _DocumentsServerMessages } from "./message-types/documents.js";
@@ -118,7 +115,6 @@ export interface SubagentEvent {
 // === Client -> Server aggregate union ===
 
 export type ClientMessage =
-  | _ConversationsClientMessages
   | _MessagesClientMessages
   | _IntegrationsClientMessages
   | _ComputerUseClientMessages

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -1,4 +1,11 @@
-// Conversation lifecycle, auth, model config, and history types.
+// Conversation lifecycle, model config, and transport metadata types.
+//
+// Server→client events are single-sourced from their canonical `api/events`
+// wire schemas; this file composes them into the domain union consumed by
+// `message-protocol.ts` and defines the transport-metadata shapes the create /
+// messaging path uses. Conversation management (create, list, switch, rename,
+// history, undo, usage, clear, reorder) is served by the HTTP conversation
+// routes, not by client messages.
 
 import type { AssistantStatusEvent } from "../../api/events/assistant-status.js";
 import type { CompactionCircuitClosedEvent } from "../../api/events/compaction-circuit-closed.js";
@@ -21,18 +28,8 @@ import type {
   InterfaceId,
 } from "../../channels/types.js";
 import { supportsHostProxy } from "../../channels/types.js";
-import type { ConversationType } from "./shared.js";
-import type { UserMessageAttachment } from "./shared.js";
 
-// === Client → Server ===
-
-export interface ConversationListRequest {
-  type: "conversation_list";
-  /** Number of conversations to skip (for pagination). Defaults to 0. */
-  offset?: number;
-  /** Maximum number of conversations to return. Defaults to 50. */
-  limit?: number;
-}
+// === Transport metadata ===
 
 /** Shared fields for all transport metadata variants. */
 interface BaseTransportMetadata {
@@ -114,327 +111,28 @@ export function isHostProxyTransport(
   );
 }
 
-export interface ConversationCreateRequest {
-  type: "conversation_create";
-  title?: string;
-  systemPromptOverride?: string;
-  maxResponseTokens?: number;
-  correlationId?: string;
-  transport?: ConversationTransportMetadata;
-  conversationType?: ConversationType;
-  /** Skill IDs to pre-activate in the new conversation (loaded before the first message). */
-  preactivatedSkillIds?: string[];
-  /** If provided, automatically sent as the first user message after conversation creation. */
-  initialMessage?: string;
-}
-
-export interface ConversationSwitchRequest {
-  type: "conversation_switch";
-  conversationId: string;
-}
-
-export interface ConversationRenameRequest {
-  type: "conversation_rename";
-  conversationId: string;
-  title: string;
-}
-
-export interface AuthMessage {
-  type: "auth";
-  token: string;
-}
-
-export interface PingMessage {
-  type: "ping";
-}
-
-export interface CancelRequest {
-  type: "cancel";
-  conversationId?: string;
-}
-
-export interface DeleteQueuedMessage {
-  type: "delete_queued_message";
-  conversationId: string;
-  requestId: string;
-}
-
-export interface ModelGetRequest {
-  type: "model_get";
-}
-
-export interface ImageGenModelSetRequest {
-  type: "image_gen_model_set";
-  model: string;
-}
-
-export interface UndoRequest {
-  type: "undo";
-  conversationId: string;
-}
-
-export interface UsageRequest {
-  type: "usage_request";
-  conversationId: string;
-}
-
-export interface ConversationsClearRequest {
-  type: "conversations_clear";
-}
-
-export interface ReorderConversationsRequest {
-  type: "reorder_conversations";
-  updates: Array<{
-    conversationId: string;
-    displayOrder: number | null;
-    isPinned: boolean;
-  }>;
-}
-
 // === Server → Client ===
-
-export interface ConversationInfo {
-  type: "conversation_info";
-  conversationId: string;
-  title: string;
-  correlationId?: string;
-  conversationType?: ConversationType;
-  /**
-   * Per-conversation override for the LLM inference profile. `undefined`
-   * means the conversation inherits the workspace `llm.activeProfile`.
-   */
-  inferenceProfile?: string;
-}
-
-/** Channel binding metadata exposed in conversation list APIs. */
-interface ChannelBinding {
-  sourceChannel: ChannelId;
-  externalChatId: string;
-  externalChatName?: string | null;
-  externalThreadId?: string | null;
-  externalUserId?: string | null;
-  displayName?: string | null;
-  username?: string | null;
-  slackThread?: {
-    channelId: string;
-    threadTs: string;
-    link?: {
-      appUrl?: string;
-      webUrl?: string;
-    };
-  };
-  slackChannel?: {
-    channelId: string;
-    name?: string;
-    link?: {
-      webUrl?: string;
-    };
-  };
-}
-
-/** Attention state metadata for a conversation's latest assistant message. */
-interface AssistantAttention {
-  hasUnseenLatestAssistantMessage: boolean;
-  latestAssistantMessageAt?: number;
-  lastSeenAssistantMessageAt?: number;
-  lastSeenConfidence?: string;
-  lastSeenSignalType?: string;
-}
-
-interface ConversationForkParent {
-  conversationId: string;
-  messageId: string;
-  title: string;
-}
-
-export interface ConversationListResponse {
-  type: "conversation_list_response";
-  conversations: Array<{
-    id: string;
-    title: string;
-    createdAt?: number;
-    updatedAt: number;
-    conversationType?: ConversationType;
-    source?: string;
-    scheduleJobId?: string;
-    channelBinding?: ChannelBinding;
-    conversationOriginChannel?: ChannelId;
-    conversationOriginInterface?: InterfaceId;
-    assistantAttention?: AssistantAttention;
-    displayOrder?: number;
-    isPinned?: boolean;
-    forkParent?: ConversationForkParent;
-    /**
-     * Per-conversation override for the LLM inference profile. Omitted when
-     * the conversation inherits the workspace `llm.activeProfile`.
-     */
-    inferenceProfile?: string;
-  }>;
-  /** Whether more conversations exist beyond the returned page. */
-  hasMore?: boolean;
-}
-
-interface HistoryResponseToolCall {
-  name: string;
-  input: Record<string, unknown>;
-  result?: string;
-  isError?: boolean;
-  /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot). @deprecated Use imageDataList. */
-  imageData?: string;
-  /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot, image generation). */
-  imageDataList?: string[];
-  /** Workspace attachment ids for tool-result images persisted as references; clients fetch bytes by id on render instead of embedding base64. */
-  imageAttachmentIds?: string[];
-  /** Unix ms when the tool started executing. */
-  startedAt?: number;
-  /** Unix ms when the tool completed. */
-  completedAt?: number;
-  /** Confirmation decision for this tool call: "approved" | "denied" | "timed_out". */
-  confirmationDecision?: string;
-  /** Friendly label for the confirmation (e.g. "Edit File", "Run Command"). */
-  confirmationLabel?: string;
-  /** Risk level at the time of invocation ("low" | "medium" | "high" | "unknown"). */
-  riskLevel?: string;
-  /** Human-readable reason for the risk classification. */
-  riskReason?: string;
-  /**
-   * @deprecated Use `approvalMode` and `approvalReason` instead.
-   * Kept for backward compatibility during the migration window.
-   */
-  autoApproved?: boolean;
-  /** How the approval decision was reached: prompted, auto, blocked, or unknown (legacy). */
-  approvalMode?: string;
-  /** Why the approval decision was reached (stable enum for client display). */
-  approvalReason?: string;
-  /** Snapshot of the auto-approve threshold at execution time. */
-  riskThreshold?: string;
-}
-
-interface HistoryResponseSurface {
-  surfaceId: string;
-  surfaceType: string;
-  title?: string;
-  data: Record<string, unknown>;
-  actions?: Array<{
-    id: string;
-    label: string;
-    style?: string;
-    data?: Record<string, unknown>;
-  }>;
-  display?: string;
-  /** True when the surface was completed (e.g. form submitted, action taken). */
-  completed?: boolean;
-  /** Human-readable summary shown in the completion chip. */
-  completionSummary?: string;
-}
-
-export interface HistoryResponse {
-  type: "history_response";
-  conversationId: string;
-  messages: Array<{
-    /** Database ID used by clients for the rendered message. */
-    id?: string;
-    role: string;
-    text: string;
-    timestamp: number;
-    toolCalls?: HistoryResponseToolCall[];
-    /** True when tool_use blocks appeared before any text block in the original content. */
-    toolCallsBeforeText?: boolean;
-    attachments?: UserMessageAttachment[];
-    /** Text segments split by tool-call boundaries. Preserves interleaving order. */
-    textSegments?: string[];
-    /** Content block ordering using "text:N", "tool:N", "surface:N" encoding. */
-    contentOrder?: string[];
-    /** UI surfaces (widgets) embedded in the message. */
-    surfaces?: HistoryResponseSurface[];
-    /** Present when this message is a subagent lifecycle notification (running/completed/failed/aborted). */
-    subagentNotification?: {
-      subagentId: string;
-      label: string;
-      status: "running" | "completed" | "failed" | "aborted";
-      error?: string;
-      conversationId?: string;
-      objective?: string;
-    };
-    /** True when text or tool result content was truncated due to maxTextChars/maxToolResultChars. */
-    wasTruncated?: boolean;
-  }>;
-  /** Whether older messages exist beyond the returned page. */
-  hasMore: boolean;
-  /** Timestamp of the oldest message in the response (client uses as next pagination cursor). */
-  oldestTimestamp?: number;
-  /** ID of the oldest message in the response (tie-breaker for same-millisecond cursors). */
-  oldestMessageId?: string;
-}
-
-export interface UndoComplete {
-  type: "undo_complete";
-  removedCount: number;
-  conversationId?: string;
-}
-
-export interface UsageResponse {
-  type: "usage_response";
-  totalInputTokens: number;
-  totalOutputTokens: number;
-  estimatedCost: number;
-  model: string;
-}
-
-/**
- * Emitted when the compaction circuit breaker trips. After three consecutive
- * summary-LLM failures (with local fallback covering each), auto-compaction is
- * suspended until `openUntil` to avoid repeatedly hammering a broken provider.
- * User-initiated compaction (`/compact`, `force: true`) bypasses the breaker.
- *
- * `conversationId` scopes the event so clients can ignore breaker trips from
- * other conversations — `EventStreamClient` broadcasts every parsed server
- * message to all subscribers, so without this field a breaker trip in one
- * conversation would set the "auto-compaction paused" banner on every open
- * `ChatViewModel`.
- */
 
 // `open_conversation` is a migrated event: its canonical wire contract lives
 // in `../../api/events/open-conversation.ts` (imported as
 // `OpenConversationEvent`). Instructs the client to open and, by default,
 // focus a conversation — see that file for the full field docs.
 
-// --- Domain-level union aliases (consumed by the barrel file) ---
-
-export type _ConversationsClientMessages =
-  | AuthMessage
-  | PingMessage
-  | CancelRequest
-  | DeleteQueuedMessage
-  | ModelGetRequest
-  | ImageGenModelSetRequest
-  | UndoRequest
-  | UsageRequest
-  | ConversationListRequest
-  | ConversationCreateRequest
-  | ConversationSwitchRequest
-  | ConversationRenameRequest
-  | ConversationsClearRequest
-  | ReorderConversationsRequest;
+// --- Domain-level union alias (consumed by the barrel file) ---
 
 export type _ConversationsServerMessages =
   | AssistantStatusEvent
   | GenerationCancelledEvent
   | GenerationHandoffEvent
   | ModelInfoEvent
-  | HistoryResponse
-  | UndoComplete
   | UsageUpdateEvent
   | UsageProgressEvent
-  | UsageResponse
   | ContextCompactedEvent
   | CompactionCircuitOpenEvent
   | CompactionCircuitClosedEvent
   | ConversationErrorEvent
   | ConversationNoticeEvent
-  | ConversationInfo
   | ConversationTitleUpdatedEvent
-  | ConversationListResponse
   | ConversationListInvalidatedEvent
   | ScheduleConversationCreatedEvent
   | OpenConversationEvent;

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -325,7 +325,7 @@ The assistant can attach files and images to its replies. Attachments flow throu
 
 #### Desktop (HTTP+SSE)
 
-Attachments are sent inline (base64) in `message_complete`, `generation_handoff`, and `history_response` SSE events. The macOS app renders thumbnails for images and displays file metadata for documents.
+Attachments are sent inline (base64) in `message_complete` and `generation_handoff` SSE events; historical attachments are returned by the HTTP conversation-history route. The macOS app renders thumbnails for images and displays file metadata for documents.
 
 #### Runtime HTTP API
 


### PR DESCRIPTION
## Prompt / plan

Continuation of the event-type unification, clearing the conversations CLI-protocol tail on the road to deleting `ServerMessage`. A subagent classified all 19 raw (non-`api/events`) conversations wire types across two axes — wire liveness (producer/dispatcher) and type-contract importers — across the daemon, runtime routes, web, and CLI. I verified the zero-importer claim and the `cli.ts` cases myself.

Every one is dead: conversation management (create, list, switch, rename, history, undo, usage, clear, reorder) is served by the HTTP conversation routes now, and there is no `ClientMessage` wire dispatcher.

### Removed (dead — no producer, dispatcher, or type consumer)
- **5 server responses**: `conversation_info`, `conversation_list_response`, `history_response`, `undo_complete`, `usage_response` — no daemon producer; their only references were vestigial `cli.ts` `handleMessage` cases for replies the daemon never emits. Plus their nested helper types (`ChannelBinding`, `AssistantAttention`, `ConversationForkParent`, `HistoryResponseToolCall`, `HistoryResponseSurface`).
- **all 14 client requests**: `auth`, `ping`, `cancel`, `delete_queued_message`, `model_get`, `image_gen_model_set`, `undo`, `usage_request`, `conversation_list`, `conversation_create`, `conversation_switch`, `conversation_rename`, `conversations_clear`, `reorder_conversations`.
- **the 5 vestigial `cli.ts` cases** for the dead server replies, plus the now-orphaned `pendingUserContent` state they fed.

`_ConversationsClientMessages` is now empty and removed (with its `ClientMessage` aggregate entry). `_ConversationsServerMessages` keeps only the live, `api/events`-inferred event set.

### Retained
The **transport-metadata cluster** (`ConversationTransportMetadata`, `HostProxyTransportMetadata`, `NonHostProxyTransportMetadata`, `BaseTransportMetadata`, `isHostProxyTransport`) stays — it's imported by the live create / messaging / `conversation-routes` path, independent of the deleted wire messages.

### Why it's safe
- Zero name-importers for all 19 types (verified repo-wide, excluding the defs file and the barrel).
- No `api/events` or web changes — none of the removed types were registered in `AssistantEventSchema`, so this only deletes daemon-side dead definitions. The SSE-parity test confirms `ServerMessage` stays in parity.

## Test plan
- `bun run typecheck:fast` (tsgo) — clean
- `bun test src/api src/__tests__/runtime-events-sse-parity.test.ts src/__tests__/plugin-import-boundary-guard.test.ts` — 39 pass
- `bun run generate:openapi -- --check` — spec unchanged
- eslint + prettier on changed files (`cli.ts`, `conversations.ts`, `message-protocol.ts`)

<!-- No new routes added; CLI verb checklist not applicable. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_