### PR TITLE
feat(plugin-api): add publishEvent helper for emitting runtime events

### DIFF
--- a/assistant/src/plugin-api/__tests__/publish-event.test.ts
+++ b/assistant/src/plugin-api/__tests__/publish-event.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the plugin-facing {@link publishEvent} helper. It is a thin wrapper
+ * over the capability-restricted event-hub facade, so these assert the two
+ * behaviours a caller relies on: a plain event reaches hub subscribers, and a
+ * host-proxy control event is rejected.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { AssistantEvent } from "../../runtime/assistant-event.js";
+import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
+import { publishEvent } from "../publish-event.js";
+
+function syncEvent(): AssistantEvent {
+  return {
+    id: "evt-1",
+    conversationId: "conv-1",
+    emittedAt: "2026-01-01T00:00:00.000Z",
+    message: {
+      type: "sync_changed",
+      tags: ["my-app:items"],
+    } as unknown as AssistantEvent["message"],
+  };
+}
+
+describe("publishEvent", () => {
+  test("delivers a plain event to hub subscribers", async () => {
+    const received: AssistantEvent[] = [];
+    const sub = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        received.push(event);
+      },
+    });
+    try {
+      await publishEvent(syncEvent());
+    } finally {
+      sub.dispose();
+    }
+    expect(received).toHaveLength(1);
+    expect(received[0].message.type).toBe("sync_changed");
+  });
+
+  test("rejects a host-proxy control event", async () => {
+    const hostEvent: AssistantEvent = {
+      id: "evt-2",
+      emittedAt: "2026-01-01T00:00:00.000Z",
+      message: {
+        type: "host_bash_request",
+      } as unknown as AssistantEvent["message"],
+    };
+    await expect(publishEvent(hostEvent)).rejects.toThrow(/host-proxy/);
+  });
+});

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -144,12 +144,18 @@ export type {
 export type { PluginEventHub } from "./event-hub-facade.js";
 /**
  * @deprecated Direct hub access is being replaced by narrower, purpose-built
- * importable helpers (e.g. a plugin-driven publish wrapper) so plugins don't
- * hold the general publish/subscribe surface. Avoid new usage; prefer the
- * scoped helpers as they land.
+ * importable helpers so plugins don't hold the general publish/subscribe
+ * surface. To emit an event, prefer {@link publishEvent}; avoid new usage of
+ * the raw hub.
  */
 export { pluginAssistantEventHub as assistantEventHub } from "./event-hub-facade.js";
 export { getModelProfiles } from "./model-profiles.js";
+// Purpose-built publish wrapper: emit a runtime event to the assistant's event
+// hub without holding the general hub handle. Route/hook authors surfacing a UI
+// invalidation (e.g. `sync_changed`) import this. Delegates to the same
+// capability-restricted facade, so host-proxy control events stay rejected.
+export type { PublishEventOptions } from "./publish-event.js";
+export { publishEvent } from "./publish-event.js";
 // Check whether a model or profile can process image input. Accepts a concrete
 // model id, a profile key, or a `ModelProfileInfo`; a bare string is resolved
 // as a model id first and then as a profile key. Profile resolution merges over

--- a/assistant/src/plugin-api/publish-event.ts
+++ b/assistant/src/plugin-api/publish-event.ts
@@ -1,0 +1,39 @@
+/**
+ * Plugin-facing helper for publishing a runtime event to the assistant's event
+ * hub.
+ *
+ * This is the narrow, purpose-built wrapper that replaces handing plugins the
+ * general `assistantEventHub` handle: a plugin that only needs to *emit* an
+ * event imports `publishEvent` instead of the whole publish/subscribe surface.
+ * It delegates to the capability-restricted {@link pluginAssistantEventHub}
+ * facade, so the same guards apply — the event is canonicalized to its JSON
+ * wire form and daemon-to-client host-proxy control events (`host_*`) are
+ * rejected.
+ *
+ * Typical use is a route or hook surfacing a UI-invalidation event (e.g.
+ * `sync_changed`) so subscribed clients re-fetch the data that changed.
+ */
+
+import type { AssistantEvent } from "../runtime/assistant-event.js";
+import {
+  pluginAssistantEventHub,
+  type PluginEventHub,
+} from "./event-hub-facade.js";
+
+/** Publish options, mirroring the hub's `publish` options (targeting, self-echo suppression). */
+export type PublishEventOptions = NonNullable<
+  Parameters<PluginEventHub["publish"]>[1]
+>;
+
+/**
+ * Publish a runtime event to the assistant's event hub. Resolves once fanout to
+ * all subscribers has been attempted (a throwing subscriber never aborts
+ * delivery to the rest). Rejects if the event is non-serializable or is a
+ * host-proxy control event, which plugins may not publish.
+ */
+export function publishEvent(
+  event: AssistantEvent,
+  options?: PublishEventOptions,
+): Promise<void> {
+  return pluginAssistantEventHub.publish(event, options);
+}


### PR DESCRIPTION
## Prompt / plan

Scoped-down slice of the route-host follow-up. Adds `publishEvent` to `@vellumai/plugin-api` — the narrow, purpose-built wrapper the plugin-api index already earmarked to replace handing plugins the general `assistantEventHub` handle. A caller that only needs to *emit* an event imports `publishEvent` instead of the whole publish/subscribe surface; it delegates to the capability-restricted event-hub facade, so the same guards apply (JSON wire-form canonicalization, and daemon-to-client `host_*` control events are rejected).

**Additive.** There are no production consumers of the plugin-facing publish path today (no default plugin, hook, tool, or route publishes through it), so this introduces the API without changing behaviour — nothing to cut over yet. Typical use: a route or hook surfacing a UI-invalidation event (e.g. `sync_changed`) so subscribed clients re-fetch.

The larger `userRoutes` config removal (making the route host the sole `/x/*` path, cutting the injected context) is split out into a separate **draft** PR stacked on this one: #39087.

## Test plan

- `bunx tsc --noEmit`, `eslint`, `prettier` (pre-commit + pre-push hooks) — all clean.
- `bun test src/plugin-api/__tests__/publish-event.test.ts` — 2 pass (delivers a plain event to subscribers; rejects a `host_*` control event).
- `bun test src/__tests__/plugin-event-hub-facade.test.ts` — the underlying facade `publish` guards are unchanged.

## CLI verb checklist

No new routes — this adds a plugin-api helper only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FosQeirkpt7G1K2SSbMx1N