### PR TITLE
fix(chat): reconcile activeConversationIsProcessing with the snapshot close-gate

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-chat-ui-state.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-ui-state.ts
@@ -17,6 +17,7 @@ import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { useTurnStore } from "@/domains/chat/turn-store";
 import {
   isAssistantBusy as isAssistantBusySelector,
+  isConversationProcessing,
   isSendDisabled,
   shouldShowThinkingIndicator,
   type UIContext,
@@ -92,12 +93,27 @@ export function useChatUIState(): ChatUIState {
   // Conversation processing. The daemon's `isProcessing` flag is the single
   // source of truth on 0.8.8+; older daemons fall back to the client
   // optimistic mirror. See `lib/backwards-compat/conversation-processing-state`.
-  const activeConversationIsProcessing = useActiveConversationIsProcessing();
+  const conversationRowIsProcessing = useActiveConversationIsProcessing();
 
   const activeConversationHasPendingAssistantResponse = useMemo(
     () => hasPendingAssistantResponse(transcript),
     [transcript],
   );
+
+  // Reconcile the conversation-row flag against the daemon's authoritative
+  // snapshot close-gate. The row flag can latch `true` when a terminal SSE
+  // event is dropped and the row query hasn't refetched yet; when the rolling
+  // snapshot has closed the turn the conversation is done. Without this the row
+  // flag disagrees with the snapshot the indicator selectors already honor,
+  // producing the "impossible" triple (`activeConversationIsProcessing: true`
+  // while both the busy spinner and the thinking dots are suppressed) and
+  // stranding the last assistant message in its streaming look via
+  // `liveAssistantRowId`.
+  const activeConversationIsProcessing = isConversationProcessing({
+    activeConversationIsProcessing: conversationRowIsProcessing,
+    snapshotProcessing,
+    hasPendingAssistantResponse: activeConversationHasPendingAssistantResponse,
+  });
 
   // `liveAssistantRowId` operates on raw (unsanitized) messages. This is
   // correct: sanitisation only removes blank user rows and sorts — it never

--- a/clients/web/src/domains/chat/turn-selectors.test.ts
+++ b/clients/web/src/domains/chat/turn-selectors.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 
 import {
   isAssistantBusy,
+  isConversationProcessing,
+  isTurnClosedBySnapshot,
   shouldShowThinkingIndicator,
   type UIContext,
 } from "@/domains/chat/turn-selectors";
@@ -18,6 +20,85 @@ const ctx = (over: Partial<UIContext> = {}): UIContext => ({
   activeConversationIsProcessing: false,
   hasPendingAssistantResponse: false,
   ...over,
+});
+
+describe("isTurnClosedBySnapshot — the shared close-gate", () => {
+  test("closes the turn when the snapshot reports idle and no reply is pending", () => {
+    expect(
+      isTurnClosedBySnapshot(ctx({ snapshotProcessing: false })),
+    ).toBe(true);
+  });
+
+  test("does NOT close during the just-sent window (a reply is pending)", () => {
+    expect(
+      isTurnClosedBySnapshot(
+        ctx({ snapshotProcessing: false, hasPendingAssistantResponse: true }),
+      ),
+    ).toBe(false);
+  });
+
+  test("undefined processing (pre-0.8.8 / cold snapshot) never closes the turn", () => {
+    expect(
+      isTurnClosedBySnapshot(ctx({ snapshotProcessing: undefined })),
+    ).toBe(false);
+  });
+
+  test("processing:true never closes the turn", () => {
+    expect(isTurnClosedBySnapshot(ctx({ snapshotProcessing: true }))).toBe(false);
+  });
+});
+
+describe("isConversationProcessing — row flag reconciled with the close-gate", () => {
+  test("the impossible triple can't survive: a snapshot-closed turn reads not-processing", () => {
+    // The reported state: the conversation-row `isProcessing` flag is latched
+    // true (dropped terminal SSE event, row query not yet refetched) while the
+    // rolling snapshot has authoritatively closed the turn. The reconciled flag
+    // must agree with the suppressed indicators, not with the stale row.
+    const c = ctx({
+      activeConversationIsProcessing: true,
+      snapshotProcessing: false,
+    });
+    expect(isConversationProcessing(c)).toBe(false);
+    // ...and it lines up with the indicator selectors on the same context.
+    expect(isAssistantBusy("thinking", c)).toBe(false);
+    expect(shouldShowThinkingIndicator("thinking", 0, c)).toBe(false);
+  });
+
+  test("stays processing while the row flag is set and the snapshot hasn't closed", () => {
+    expect(
+      isConversationProcessing(
+        ctx({ activeConversationIsProcessing: true, snapshotProcessing: true }),
+      ),
+    ).toBe(true);
+  });
+
+  test("stays processing in the just-sent window even when the snapshot still reads idle", () => {
+    expect(
+      isConversationProcessing(
+        ctx({
+          activeConversationIsProcessing: true,
+          snapshotProcessing: false,
+          hasPendingAssistantResponse: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("not processing when the row flag itself is false", () => {
+    expect(
+      isConversationProcessing(
+        ctx({ activeConversationIsProcessing: false, snapshotProcessing: true }),
+      ),
+    ).toBe(false);
+  });
+
+  test("pre-0.8.8 (undefined snapshot) trusts the row flag unchanged", () => {
+    expect(
+      isConversationProcessing(
+        ctx({ activeConversationIsProcessing: true, snapshotProcessing: undefined }),
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("shouldShowThinkingIndicator — authoritative processing close-gate", () => {

--- a/clients/web/src/domains/chat/turn-selectors.ts
+++ b/clients/web/src/domains/chat/turn-selectors.ts
@@ -45,6 +45,53 @@ export interface UIContext {
 // ---------------------------------------------------------------------------
 
 /**
+ * The daemon's authoritative CLOSE-gate, shared by every processing-derived
+ * selector so the rule lives in exactly one place.
+ *
+ * `snapshotProcessing === false` is the rolling snapshot's verdict that the
+ * turn is over — trusted even when the local `phase` or the conversation-row
+ * `isProcessing` flag was left stale by a dropped terminal SSE event. The
+ * `hasPendingAssistantResponse` guard exempts the just-sent window (before the
+ * first token, where the snapshot still reads the prior idle) so a fresh send
+ * isn't closed early. `undefined` processing (pre-0.8.8 / cold snapshot) never
+ * closes the turn, leaving phase-driven behavior untouched.
+ */
+export function isTurnClosedBySnapshot(
+  ctx: Pick<UIContext, "snapshotProcessing" | "hasPendingAssistantResponse">,
+): boolean {
+  return ctx.snapshotProcessing === false && !ctx.hasPendingAssistantResponse;
+}
+
+/**
+ * Whether the active conversation is processing, reconciled against the
+ * authoritative snapshot close-gate.
+ *
+ * The conversation-row `isProcessing` flag (`activeConversationIsProcessing`)
+ * and the rolling-snapshot `processing` flag are two server-derived views of
+ * the same turn arriving on different channels. The row flag can latch `true`
+ * when a terminal SSE event is dropped and the row query hasn't refetched yet;
+ * once the snapshot has authoritatively closed the turn
+ * ({@link isTurnClosedBySnapshot}) the conversation is done regardless.
+ *
+ * Reconciling here keeps the row flag from disagreeing with the snapshot the
+ * indicator selectors already honor — the disagreement is what produces the
+ * "impossible" triple (`activeConversationIsProcessing: true` while both
+ * `isAssistantBusy` and `shouldShowThinkingIndicator` are suppressed) and what
+ * strands the last assistant message in its streaming look through
+ * `liveAssistantRowId`.
+ */
+export function isConversationProcessing(
+  ctx: Pick<
+    UIContext,
+    | "activeConversationIsProcessing"
+    | "snapshotProcessing"
+    | "hasPendingAssistantResponse"
+  >,
+): boolean {
+  return ctx.activeConversationIsProcessing === true && !isTurnClosedBySnapshot(ctx);
+}
+
+/**
  * Whether the "Thinking..." indicator should be visible.
  *
  * Mirrors macOS TranscriptProjector.wouldShowThinking:
@@ -86,7 +133,7 @@ export function shouldShowThinkingIndicator(
   // right after a send — before the first token, where the snapshot still
   // legitimately reads the prior idle — keeps showing the dots. `undefined`
   // (older daemons / cold snapshot) leaves the phase-driven behavior untouched.
-  if (ctx.snapshotProcessing === false && !ctx.hasPendingAssistantResponse) {
+  if (isTurnClosedBySnapshot(ctx)) {
     return false;
   }
 
@@ -134,7 +181,7 @@ export function isAssistantBusy(
   phase: TurnPhase,
   ctx: UIContext,
 ): boolean {
-  if (ctx.snapshotProcessing === false && !ctx.hasPendingAssistantResponse) {
+  if (isTurnClosedBySnapshot(ctx)) {
     return false;
   }
 


### PR DESCRIPTION
**Closed — the diagnosis was inverted.**

This PR assumed the rolling-snapshot `processing` flag was the fresh authority and the conversation-row `activeConversationIsProcessing` flag was the stale latch. The reporter's ground truth is the opposite: the conversation *was* genuinely processing, so `activeConversationIsProcessing: true` was correct and `isAssistantBusy: false` (suppressed by the snapshot close-gate firing on a stale `snapshotProcessing === false`) was the bug.

Reconciling the row flag *down* to the snapshot would hide the busy spinner during real processing — worse than the original symptom. A corrected fix is being scoped separately.