### PR TITLE
refactor(subagents): reconcile subagent_event onto the api schema, nuke dead wire protocol

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -49,6 +49,7 @@ export * from "./message-types/workspace.js";
 // Import domain-level union aliases for composition
 import type { DiskPressureStatusChangedEvent } from "../api/events/disk-pressure-status-changed.js";
 import type { HookEvent } from "../api/events/hook-event.js";
+import type { SubagentEventEvent } from "../api/events/subagent-event.js";
 import type { _AcpServerMessages } from "./message-types/acp.js";
 import type { _AppsServerMessages } from "./message-types/apps.js";
 import type { _BackgroundToolsServerMessages } from "./message-types/background-tools.js";
@@ -89,10 +90,7 @@ import type {
 import type { _SchedulesServerMessages } from "./message-types/schedules.js";
 import type { _SettingsServerMessages } from "./message-types/settings.js";
 import type { _SkillsServerMessages } from "./message-types/skills.js";
-import type {
-  _SubagentsClientMessages,
-  _SubagentsServerMessages,
-} from "./message-types/subagents.js";
+import type { _SubagentsServerMessages } from "./message-types/subagents.js";
 import type { _SurfacesServerMessages } from "./message-types/surfaces.js";
 import type { _SyncInvalidationServerMessages } from "./message-types/sync.js";
 import type { _UpgradesServerMessages } from "./message-types/upgrades.js";
@@ -102,16 +100,6 @@ import type {
   _WorkspaceServerMessages,
 } from "./message-types/workspace.js";
 
-// === SubagentEvent -- defined here because it references ServerMessage ===
-
-/** Wraps any ServerMessage emitted by a subagent conversation for routing to the client. */
-export interface SubagentEvent {
-  type: "subagent_event";
-  subagentId: string;
-  conversationId: string;
-  event: ServerMessage;
-}
-
 // === Client -> Server aggregate union ===
 
 export type ClientMessage =
@@ -119,7 +107,6 @@ export type ClientMessage =
   | _IntegrationsClientMessages
   | _ComputerUseClientMessages
   | _HostBrowserClientMessages
-  | _SubagentsClientMessages
   | _WorkspaceClientMessages
   | _DiagnosticsClientMessages
   | _NotificationsClientMessages;
@@ -159,7 +146,7 @@ export type ServerMessage =
   | _WorkflowsServerMessages
   | DiskPressureStatusChangedEvent
   | HookEvent
-  | SubagentEvent;
+  | SubagentEventEvent;
 
 // === Contract schema ===
 

--- a/assistant/src/daemon/message-types/subagents.ts
+++ b/assistant/src/daemon/message-types/subagents.ts
@@ -1,63 +1,16 @@
-// Subagent lifecycle and communication types.
+// Subagent lifecycle events.
 //
-// The `subagent_spawned` and `subagent_status_changed` server events are
-// single-sourced from their canonical `api/events` wire schemas; this file
-// composes them into the domain union consumed by `message-protocol.ts`.
+// Server→client events are single-sourced from their canonical `api/events`
+// wire schemas; this file composes them into the domain union consumed by
+// `message-protocol.ts`. Subagent detail, abort, status, message, and history
+// are served by the HTTP subagent routes (the detail response is the canonical
+// `api/responses/subagent-detail.ts` shape), not by client messages.
 
 import type { SubagentSpawnedEvent } from "../../api/events/subagent-spawned.js";
 import type { SubagentStatusChangedEvent } from "../../api/events/subagent-status-changed.js";
-import type { UsageStats } from "./shared.js";
 
-// === Server → Client ===
-
-export interface SubagentDetailResponse {
-  type: "subagent_detail_response";
-  subagentId: string;
-  objective?: string;
-  usage?: UsageStats;
-  events: Array<{
-    type: string;
-    content: string;
-    toolName?: string;
-    isError?: boolean;
-    messageId?: string;
-  }>;
-}
-
-// === Client → Server ===
-
-export interface SubagentAbortRequest {
-  type: "subagent_abort";
-  subagentId: string;
-}
-
-export interface SubagentStatusRequest {
-  type: "subagent_status";
-  /** If omitted, returns all subagents for the conversation. */
-  subagentId?: string;
-}
-
-export interface SubagentMessageRequest {
-  type: "subagent_message";
-  subagentId: string;
-  content: string;
-}
-
-export interface SubagentDetailRequest {
-  type: "subagent_detail_request";
-  subagentId: string;
-  conversationId: string;
-}
-
-// --- Domain-level union aliases (consumed by the barrel file) ---
-
-export type _SubagentsClientMessages =
-  | SubagentAbortRequest
-  | SubagentStatusRequest
-  | SubagentMessageRequest
-  | SubagentDetailRequest;
+// --- Domain-level union alias (consumed by the barrel file) ---
 
 export type _SubagentsServerMessages =
   | SubagentSpawnedEvent
-  | SubagentStatusChangedEvent
-  | SubagentDetailResponse;
+  | SubagentStatusChangedEvent;


### PR DESCRIPTION
## Prompt / plan

Continuation of the event-type unification — the two subagent reconciliations, the last domain work before the final `ServerMessage` collapse.

### 1. `subagent_event` — break the recursion, adopt the canonical schema
`message-protocol.ts` defined its own `SubagentEvent` interface with `event: ServerMessage` — a **recursive** type, which is the only reason it had to live outside the `message-types/` files. The canonical `api/events/subagent-event.ts` already models this as `SubagentEventEvent`, whose inner `event` is a deliberately-**opaque** `SubagentInnerEvent` passthrough (keyed on `type` with convenience hint fields) — precisely to avoid coupling the subagent envelope to every other event schema. This PR removes the recursive definition and composes `SubagentEventEvent` into `ServerMessage` instead. The subagent manager's envelope producer wraps a real `ServerMessage` as the inner `event`, which satisfies the passthrough — verified by tsgo and the subagent tests.

### 2. `SubagentDetailResponse` — drop the dead duplicate
The canonical subagent-detail shape is `api/responses/subagent-detail.ts` (the `GET /subagents/:id` REST response). The `message-types` `SubagentDetailResponse` (a `type: "subagent_detail_response"` wire message) was a dead duplicate — **no producer, no type consumer**. Removed.

### 3. Dead subagent client requests
`subagent_abort`, `subagent_status`, `subagent_message`, `subagent_detail_request` are all dead: abort/status/message/detail are served by the HTTP subagent routes, and no dispatcher consumes the wire literals (the `subagent_abort`/`subagent_message` grep hits are LLM **tool** names, a separate namespace). Removed; `_SubagentsClientMessages` is now empty and dropped (with its `ClientMessage` aggregate entry).

`_SubagentsServerMessages` now composes just the two live api-inferred events (`SubagentSpawnedEvent`, `SubagentStatusChangedEvent`).

### Why it's safe
- Zero name-importers for the recursive `SubagentEvent`, the dead `SubagentDetailResponse`, and the 4 client-request types (verified repo-wide).
- **No `api/events` or web change** — `SubagentEventEvent` was already registered in `AssistantEventSchema`; this only removes the daemon-side duplicate + dead definitions. openapi `--check` unchanged; the SSE-parity test confirms `ServerMessage` stays in parity.

## Test plan
- `bun run typecheck:fast` (tsgo) — clean (confirms the producer envelope still satisfies the opaque inner type)
- `bun test src/api src/__tests__/runtime-events-sse-parity.test.ts src/__tests__/plugin-import-boundary-guard.test.ts` — 39 pass
- `bun test src/__tests__/subagent-notify-parent.test.ts src/__tests__/subagent-tools.test.ts` — 100 pass
- `bun run generate:openapi -- --check` — spec unchanged
- eslint + prettier on changed files

<!-- No new routes added; CLI verb checklist not applicable. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_