### PR TITLE
fix(web): stop a mid-stream app surface from crashing the assistant

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/surface-router.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-router.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+// Replace one surface renderer with a component that always throws so we can
+// assert the boundary contains the failure. Declared before importing
+// `SurfaceRouter` so the mock is in place when the router resolves its imports.
+mock.module("@/domains/chat/components/surfaces/card-surface", () => ({
+  CardSurface: () => {
+    throw new Error("boom");
+  },
+}));
+
+import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
+import type { Surface } from "@/domains/chat/types/types";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeSurface(overrides: Partial<Surface> = {}): Surface {
+  return {
+    surfaceId: "surface-1",
+    surfaceType: "card",
+    title: "My App",
+    display: "inline",
+    data: {},
+    ...overrides,
+  } as Surface;
+}
+
+describe("SurfaceRouter error boundary", () => {
+  test("contains a surface render failure behind an inline fallback", () => {
+    const { getByRole } = render(<SurfaceRouter surface={makeSurface()} onAction={() => {}} />);
+
+    const alert = getByRole("alert");
+    expect(alert.textContent).toContain("My App");
+    expect(alert.textContent).toContain("couldn't be displayed");
+  });
+
+  test("a crashing surface does not take down a sibling surface", () => {
+    const { getByRole, getByText } = render(
+      <>
+        <SurfaceRouter surface={makeSurface()} onAction={() => {}} />
+        <SurfaceRouter
+          surface={makeSurface({
+            surfaceId: "surface-2",
+            surfaceType: "copy_block",
+            data: { text: "still here" },
+          })}
+          onAction={() => {}}
+        />
+      </>,
+    );
+
+    // The card surface is contained…
+    expect(getByRole("alert").textContent).toContain("My App");
+    // …while the sibling copy_block surface renders normally.
+    expect(getByText("still here")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/components/surfaces/surface-router.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-router.tsx
@@ -1,4 +1,5 @@
-import { CheckCircle, XCircle } from "lucide-react";
+import { AlertTriangle, CheckCircle, XCircle } from "lucide-react";
+import * as Sentry from "@sentry/react";
 
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import { INHERENTLY_INTERACTIVE_SURFACE_TYPES } from "@/domains/chat/types/types";
@@ -42,7 +43,7 @@ export interface SurfaceRouterProps {
   onVellumLinkClick?: (href: string, linkText: string) => void;
 }
 
-export function SurfaceRouter({
+function SurfaceRouterInner({
   surface,
   onAction,
   assistantId,
@@ -153,4 +154,43 @@ export function SurfaceRouter({
         </SurfaceContainer>
       );
   }
+}
+
+/**
+ * Renders one transcript surface, isolated behind an error boundary so a render
+ * failure inside a single surface — most consequentially the `dynamic_page`
+ * app viewer, whose sandboxed iframe drives async layout changes that can
+ * cascade into a render loop when the surface arrives mid-stream — degrades to
+ * an inline fallback instead of unwinding the whole transcript and
+ * white-screening the assistant.
+ *
+ * The boundary is keyed on `surfaceId`: a surface that crashes stays in the
+ * fallback until it is replaced by a different surface at the same position,
+ * so a surface caught in a render loop is not immediately re-mounted (and
+ * re-looped) by the next stream update to its own data.
+ */
+export function SurfaceRouter(props: SurfaceRouterProps) {
+  const { surface } = props;
+  return (
+    <Sentry.ErrorBoundary
+      key={surface.surfaceId}
+      beforeCapture={(scope) => {
+        scope.setTag("boundary", "chat-surface");
+        scope.setTag("surfaceType", surface.surfaceType ?? "unknown");
+      }}
+      fallback={
+        <div
+          role="alert"
+          className="flex items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] px-3 py-2 text-body-small-default text-[var(--content-quiet)]"
+        >
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          {surface.title
+            ? `"${surface.title}" couldn't be displayed.`
+            : "This content couldn't be displayed."}
+        </div>
+      }
+    >
+      <SurfaceRouterInner {...props} />
+    </Sentry.ErrorBoundary>
+  );
 }

--- a/clients/web/src/domains/chat/transcript/use-transcript-messages.test.tsx
+++ b/clients/web/src/domains/chat/transcript/use-transcript-messages.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { AssistantEvent } from "@/types/event-types";
+import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
+
+function textRow(id: string, text: string): DisplayMessage {
+  return {
+    id,
+    role: "assistant",
+    textSegments: [text],
+    contentOrder: [{ type: "text", id: "0" }],
+    contentBlocks: [{ type: "text", text }],
+  };
+}
+
+function snapshot(messages: DisplayMessage[], seq: number): PaginatedHistoryResult {
+  return { messages, hasMore: false, oldestTimestamp: null, oldestMessageId: null, seq };
+}
+
+function envelope(seq: number, message: AssistantEvent): AssistantEventEnvelope {
+  return {
+    id: `e${seq}`,
+    seq,
+    emittedAt: new Date(1000 + seq).toISOString(),
+    message,
+  } as AssistantEventEnvelope;
+}
+
+beforeEach(() => {
+  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+});
+afterEach(() => {
+  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+});
+
+describe("useTranscriptMessages reference stability", () => {
+  test("a no-op stream event does not re-derive the transcript", () => {
+    useChatSessionStore.setState({
+      snapshot: snapshot([textRow("a1", "hello")], 1),
+    });
+
+    const { result } = renderHook(() => useTranscriptMessages());
+    const first = result.current;
+    expect(first.map((m) => m.id)).toEqual(["a1"]);
+    const snapshotBefore = useChatSessionStore.getState().snapshot;
+
+    // A turn-lifecycle event mints a new snapshot object but leaves `messages`
+    // (transcript content) untouched. The reducer reuses the same `messages`
+    // array reference for these events, so the derived transcript must stay
+    // referentially stable — this is what keeps the SSE burst that accompanies
+    // an app surface arriving mid-stream from thrashing every downstream memo.
+    act(() => {
+      useChatSessionStore
+        .getState()
+        .applyEnvelopeToSnapshot(envelope(2, { type: "sync_changed" } as AssistantEvent));
+    });
+
+    // The snapshot object identity changed…
+    expect(useChatSessionStore.getState().snapshot).not.toBe(snapshotBefore);
+    // …but the derived transcript reference did not.
+    expect(result.current).toBe(first);
+  });
+
+  test("a content-changing event does re-derive the transcript", () => {
+    useChatSessionStore.setState({
+      snapshot: snapshot([textRow("a1", "hello")], 1),
+    });
+
+    const { result } = renderHook(() => useTranscriptMessages());
+    const first = result.current;
+
+    act(() => {
+      useChatSessionStore.getState().applyEnvelopeToSnapshot(
+        envelope(2, {
+          type: "assistant_text_delta",
+          messageId: "a1",
+          text: " world",
+        } as AssistantEvent),
+      );
+    });
+
+    expect(result.current).not.toBe(first);
+  });
+});

--- a/clients/web/src/domains/chat/transcript/use-transcript-messages.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-messages.ts
@@ -19,7 +19,7 @@ import { filterDismissedSurfaces } from "@/domains/chat/utils/dismissed-surfaces
 import type { DisplayMessage } from "@/domains/chat/types/types";
 
 export function useTranscriptMessages(): DisplayMessage[] {
-  const snapshot = useChatSessionStore.use.snapshot();
+  const messages = useChatSessionStore.use.snapshot()?.messages;
   const optimisticSends = useChatSessionStore.use.optimisticSends();
   const dismissedSurfaceIds = useChatSessionStore.use.dismissedSurfaceIds();
 
@@ -27,10 +27,14 @@ export function useTranscriptMessages(): DisplayMessage[] {
     // Dismissed surfaces are client state that hides server-sent surface rows;
     // apply it at read time (returns the same ref when nothing is dismissed,
     // so the steady-state union stays referentially stable).
-    const visibleHistory = filterDismissedSurfaces(
-      snapshot?.messages,
-      dismissedSurfaceIds,
-    );
+    const visibleHistory = filterDismissedSurfaces(messages, dismissedSurfaceIds);
     return selectTranscriptMessages(visibleHistory, optimisticSends);
-  }, [snapshot, optimisticSends, dismissedSurfaceIds]);
+    // Key on `snapshot.messages`, not the whole snapshot: the rolling-snapshot
+    // reducer mints a new snapshot object on every stream event but reuses the
+    // same `messages` array for events that don't change transcript content
+    // (turn lifecycle, subagent/workflow progress, sync). Depending on the
+    // messages array avoids re-deriving the transcript — and thrashing every
+    // downstream memo and the scroll classifier — on that no-op churn, which
+    // is heaviest exactly when an app surface arrives mid-stream.
+  }, [messages, optimisticSends, dismissedSurfaceIds]);
 }


### PR DESCRIPTION
## Prompt / plan

Bug report: the assistant white-screens when opening the app viewer while the assistant is still streaming. The `vellum-assistant-web` Sentry project shows **React error #185 ("Maximum update depth exceeded")** as the most frequent crash, with multiple culprit variants firing the same day (`animated-avatar.tsx`, `use-transcript-scroll.ts`, a Radix popover `onDismiss`) plus ~20 one-off instances over two weeks. Breadcrumbs show `[event-bus] handler threw sse.event Error: Minified React error #185` repeating.

### Root cause

When an `app_open` fires mid-turn, the daemon sends a `ui_surface_show` for a `dynamic_page` surface while SSE is still pumping `message_delta`/progress events. The surface's sandboxed iframe (`srcDoc`) load drives async layout / `ResizeObserver` changes that interact with the surrounding transcript re-rendering under that event burst, and one of the interacting seams (surface, avatar, scroll classifier, popover) trips React's update-depth guard. Because the store update is driven **synchronously from SSE dispatch**, the #185 unwinds the entire tree rather than a local subtree — hence the whole-app white-screen and the "handler threw sse.event" breadcrumb. The multiple culprits are the same cascade tripping the counter in whichever child happens to be committing.

Two verified contributors, fixed at the right seams:

- **No containment around surfaces.** A render loop anywhere in the transcript subtree took down the whole assistant. Each transcript surface is now isolated behind an error boundary (single source of truth inside `SurfaceRouter`). A render failure in one surface — the `dynamic_page` app viewer most consequentially — degrades to an inline fallback and keeps the rest of the assistant alive, reported to Sentry tagged `boundary: chat-surface` / `surfaceType` so residual occurrences stay visible. The boundary is keyed on `surfaceId` so a crashed surface isn't immediately re-mounted and re-looped by the next update to its own data.

- **Transcript re-derived on no-op events.** `applyEvent` (`rolling-snapshot.ts`) mints a new snapshot object on every non-duplicate stream event but reuses the same `messages` array for events that don't change transcript content (turn lifecycle, subagent/workflow progress, sync). `useTranscriptMessages` keyed its memo on the whole snapshot object, so it re-derived the transcript — and thrashed every downstream memo and the scroll classifier — on that churn, which is heaviest exactly when an app surface arrives mid-stream. The memo now keys on `snapshot.messages`.

The heavily-tuned scroll hook and avatar are deliberately left untouched: their individual seams are already guarded against self-sustaining loops, so the fix targets containment + the shared trigger rather than the symptom sites.

## Test plan

- New `surface-router.test.tsx`: a throwing surface is contained behind the inline fallback, and a crashing surface does not take down a sibling surface.
- New `use-transcript-messages.test.tsx`: a no-op stream event (`sync_changed`) does not change the derived transcript reference, while a content-changing event (`assistant_text_delta`) does.
- `bunx tsc --noEmit` clean; `eslint` clean on changed files; existing transcript + surface suites pass under the isolated per-file runner (23 files).

<!-- CLI verb checklist omitted: no new IPC routes. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNub98WRqJdsZ9MN1xQMYB)_