### PR TITLE
polish(web): Slack channel access — mobile responsiveness + layout

### DIFF
--- a/clients/web/src/domains/channels/components/slack-channel-list.stories.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-list.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, within } from "storybook/test";
 
+import { Card } from "@vellumai/design-library/components/card";
+
 import type { SlackChannel } from "@/domains/channels/slack-channels-query";
 
 import { SlackChannelList } from "./slack-channel-list";
@@ -63,8 +65,9 @@ const meta: Meta<typeof SlackChannelList> = {
     defaultTier: "medium",
   },
   decorators: [
-    // Mirrors the Slack sub-tab's card column (flex flex-col gap-4 in
-    // assistant-channels-list.tsx), which owns inter-card spacing.
+    // The list renders bare; in the Slack sub-tab it drops into the
+    // "Per-channel overrides" collapsible card, so wrap it in that same card
+    // frame here. The outer column mirrors the sub-tab's inter-card spacing.
     (Story) => (
       <div
         style={{
@@ -75,7 +78,9 @@ const meta: Meta<typeof SlackChannelList> = {
           gap: 16,
         }}
       >
-        <Story />
+        <Card.Root noPadding clipContents>
+          <Story />
+        </Card.Root>
       </div>
     ),
   ],
@@ -132,9 +137,9 @@ export const LoadError: Story = {
 };
 
 /**
- * Past ~100 rows the list virtualizes. Shown in a fixed-height panel (the real
- * settings context) so the card fills the space and the rows scroll inside it,
- * with the "Assistant Access levels" key pinned in the footer.
+ * Past ~100 rows the list virtualizes. The virtualized scroller self-bounds to
+ * a fixed height inside the card, so the rows scroll within it without the whole
+ * collapsible growing unbounded.
  */
 export const ManyChannels: Story = {
   args: {
@@ -147,11 +152,4 @@ export const ManyChannels: Story = {
       }),
     ),
   },
-  decorators: [
-    (Story) => (
-      <div style={{ height: 480, display: "flex", flexDirection: "column" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };

--- a/clients/web/src/domains/channels/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-list.tsx
@@ -430,24 +430,20 @@ function SlackChannelRow({
       className={rowClassName}
       leading={<Icon className="h-4 w-4 text-[var(--content-tertiary)]" />}
       title={channel.name}
+      // Member count rides the subtitle (not the trailing cluster), so the
+      // fixed-width picker never squeezes the channel name off narrow screens.
+      subtitle={metaLabel ?? undefined}
       trailing={
-        <>
-          {metaLabel != null ? (
-            <span className="text-body-small-default text-[color:var(--content-tertiary)]">
-              {metaLabel}
-            </span>
-          ) : null}
-          <div className="w-48">
-            <TierPicker
-              tier={tierOverride}
-              defaultTier={defaultTier}
-              disabled={pending || overridesLoading || overridesError}
-              onTierChange={onTierChange}
-              onReset={onReset}
-              aria-label={`Assistant Access in ${channel.name}`}
-            />
-          </div>
-        </>
+        <div className="w-40 sm:w-48">
+          <TierPicker
+            tier={tierOverride}
+            defaultTier={defaultTier}
+            disabled={pending || overridesLoading || overridesError}
+            onTierChange={onTierChange}
+            onReset={onReset}
+            aria-label={`Assistant Access in ${channel.name}`}
+          />
+        </div>
       }
     />
   );

--- a/clients/web/src/domains/channels/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-list.tsx
@@ -2,14 +2,12 @@ import { Hash, Lock, Search } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { cn } from "@vellumai/design-library";
-import { Card } from "@vellumai/design-library/components/card";
 import { Input } from "@vellumai/design-library/components/input";
 import { ListRow } from "@vellumai/design-library/components/list-row";
 import { Typography } from "@vellumai/design-library/components/typography";
 import { VirtualList } from "@vellumai/design-library/components/virtual-list";
 
 import { EmptyState } from "@/components/empty-state";
-import { SlackChannelTierLegend } from "@/domains/channels/components/slack-channel-tier-legend";
 import { TierPicker } from "@/domains/channels/components/tier-picker";
 import type { RiskThreshold } from "@/utils/threshold-presets";
 import type { SlackChannel } from "@/domains/channels/slack-channels-query";
@@ -156,12 +154,6 @@ export interface SlackChannelListProps {
   onTierChange?: (channelId: string, tier: RiskThreshold) => void;
   /** Deletes the channel's persisted cells so the default wins again. */
   onTierReset?: (channelId: string) => void;
-  /**
-   * Whether to render the "Assistant Access levels" key in the footer. Off when
-   * the list sits under a primary card that already shows the key (the Slack
-   * sub-tab's default-access card). Defaults to on for standalone use.
-   */
-  showLegend?: boolean;
 }
 
 const EMPTY_PENDING_IDS: ReadonlySet<string> = new Set();
@@ -172,8 +164,11 @@ const EMPTY_PENDING_IDS: ReadonlySet<string> = new Set();
  * ({@link TierPicker}) that names the effective level and marks the one it
  * inherits. Search and the kind chips narrow the list client-side; the
  * membership filter itself is server-side (`?memberOnly=true`) with no toggle.
- * The key sits in the footer unless {@link SlackChannelListProps.showLegend} is
- * off (the default-access card owns it in the composed section).
+ *
+ * Renders bare — presence hint, search, chips, and rows, no card of its own —
+ * because it only ever mounts inside the "Per-channel overrides" collapsible
+ * card in {@link SlackChannelSection}, whose header is the toggle. The Assistant
+ * Access key lives in the sibling default-access card, not here.
  */
 export function SlackChannelList({
   assistantDisplayName,
@@ -189,7 +184,6 @@ export function SlackChannelList({
   pendingChannelIds = EMPTY_PENDING_IDS,
   onTierChange,
   onTierReset,
-  showLegend = true,
 }: SlackChannelListProps) {
   const [search, setSearch] = useState("");
   const [kindFilter, setKindFilter] = useState<SlackRoomKind | null>(null);
@@ -221,156 +215,126 @@ export function SlackChannelList({
   );
 
   return (
-    <>
-      <Card.Root className="flex min-h-0 flex-1 flex-col">
-        <Card.Header>
-          <div className="flex flex-col gap-1">
-            Where {assistantDisplayName} is present
-            <Typography
-              as="p"
-              variant="body-small-default"
-              className="text-[color:var(--content-tertiary)]"
+    <div className="flex flex-col gap-3 p-4">
+      <Typography
+        as="p"
+        variant="body-small-default"
+        className="text-[color:var(--content-tertiary)]"
+      >
+        {presenceHint}
+      </Typography>
+      {loading ? (
+        <Typography
+          as="span"
+          variant="body-small-default"
+          className="text-[color:var(--content-tertiary)]"
+        >
+          Loading…
+        </Typography>
+      ) : error ? (
+        <Typography
+          as="span"
+          variant="body-small-default"
+          className="text-[color:var(--content-negative)]"
+        >
+          Couldn’t load channels. Try reopening this page.
+        </Typography>
+      ) : allChannels.length === 0 ? (
+        <EmptyState icon={<Hash className="h-6 w-6" />} title="No channels yet" />
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="min-w-56 flex-1">
+              <Input
+                type="search"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search channels"
+                aria-label="Search channels"
+                leftIcon={<Search className="h-4 w-4" />}
+                fullWidth
+              />
+            </div>
+            <div
+              className="flex items-center gap-2"
+              role="group"
+              aria-label="Filter channels by type"
             >
-              {presenceHint}
-            </Typography>
+              {CHANNEL_KIND_FILTERS.map(({ value, label }) => {
+                const active = kindFilter === value;
+                const count =
+                  value === null ? allChannels.length : kindCounts[value];
+                return (
+                  <button
+                    key={value ?? "all"}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={() => setKindFilter(value)}
+                    className={cn(
+                      "inline-flex h-6 items-center rounded-full px-2.5 text-body-small-emphasised leading-none transition-colors",
+                      active
+                        ? "bg-[var(--content-default)] text-[var(--surface-base)]"
+                        : "bg-[var(--tag-bg-neutral)] text-[color:var(--content-secondary)] hover:text-[color:var(--content-default)]",
+                    )}
+                  >
+                    {label} {count}
+                  </button>
+                );
+              })}
+            </div>
           </div>
-        </Card.Header>
-        <Card.Body className="flex min-h-0 flex-1 flex-col gap-3">
-          {loading ? (
+          {visibleChannels.length === 0 ? (
             <Typography
               as="span"
               variant="body-small-default"
-              className="text-[color:var(--content-tertiary)]"
+              className="py-4 text-center text-[color:var(--content-tertiary)]"
             >
-              Loading…
+              No channels match.
             </Typography>
-          ) : error ? (
-            <Typography
-              as="span"
-              variant="body-small-default"
-              className="text-[color:var(--content-negative)]"
-            >
-              Couldn’t load channels. Try reopening this page.
-            </Typography>
-          ) : allChannels.length === 0 ? (
-            <EmptyState
-              icon={<Hash className="h-6 w-6" />}
-              title="No channels yet"
-            />
-          ) : (
-            <>
-              <div className="flex flex-wrap items-center gap-3">
-                <div className="min-w-56 flex-1">
-                  <Input
-                    type="search"
-                    value={search}
-                    onChange={(event) => setSearch(event.target.value)}
-                    placeholder="Search channels"
-                    aria-label="Search channels"
-                    leftIcon={<Search className="h-4 w-4" />}
-                    fullWidth
+          ) : visibleChannels.length > VIRTUALIZE_THRESHOLD ? (
+            // Virtuoso sizes its scroller to 100% of the wrapper, so the
+            // wrapper needs a bounded height to scroll within the collapsible.
+            <div className="h-96">
+              <VirtualList
+                items={visibleChannels}
+                computeItemKey={(_, channel) => channel.id}
+                itemContent={(_, channel) => (
+                  <SlackChannelRow
+                    channel={channel}
+                    pending={pendingChannelIds.has(channel.id)}
+                    overridesLoading={tierOverridesLoading}
+                    overridesError={tierOverridesError}
+                    defaultTier={defaultTier}
+                    accessControls={accessControlsSupported}
+                    tierOverride={tierOverrides?.[channel.id]}
+                    onTierChange={(tier) => onTierChange?.(channel.id, tier)}
+                    onReset={() => onTierReset?.(channel.id)}
                   />
-                </div>
-                <div
-                  className="flex items-center gap-2"
-                  role="group"
-                  aria-label="Filter channels by type"
-                >
-                  {CHANNEL_KIND_FILTERS.map(({ value, label }) => {
-                    const active = kindFilter === value;
-                    const count =
-                      value === null ? allChannels.length : kindCounts[value];
-                    return (
-                      <button
-                        key={value ?? "all"}
-                        type="button"
-                        aria-pressed={active}
-                        onClick={() => setKindFilter(value)}
-                        className={cn(
-                          "inline-flex h-6 items-center rounded-full px-2.5 text-body-small-emphasised leading-none transition-colors",
-                          active
-                            ? "bg-[var(--content-default)] text-[var(--surface-base)]"
-                            : "bg-[var(--tag-bg-neutral)] text-[color:var(--content-secondary)] hover:text-[color:var(--content-default)]",
-                        )}
-                      >
-                        {label} {count}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-              {visibleChannels.length === 0 ? (
-                <Typography
-                  as="span"
-                  variant="body-small-default"
-                  className="py-4 text-center text-[color:var(--content-tertiary)]"
-                >
-                  No channels match.
-                </Typography>
-              ) : (
-                visibleChannels.length > VIRTUALIZE_THRESHOLD ? (
-                  // Virtuoso sizes its scroller to 100% of the wrapper, so the
-                  // wrapper fills the card's flex scroll area.
-                  <div className="min-h-0 flex-1">
-                    <VirtualList
-                      items={visibleChannels}
-                      computeItemKey={(_, channel) => channel.id}
-                      itemContent={(_, channel) => (
-                        <SlackChannelRow
-                          channel={channel}
-                          pending={pendingChannelIds.has(channel.id)}
-                          overridesLoading={tierOverridesLoading}
-                          overridesError={tierOverridesError}
-                          defaultTier={defaultTier}
-                          accessControls={accessControlsSupported}
-                          tierOverride={tierOverrides?.[channel.id]}
-                          onTierChange={(tier) =>
-                            onTierChange?.(channel.id, tier)
-                          }
-                          onReset={() => onTierReset?.(channel.id)}
-                        />
-                      )}
-                      className="h-full"
-                    />
-                  </div>
-                ) : (
-                  // Rows scroll within the card's flex area; the always-visible
-                  // Assistant Access levels key stays pinned in the footer.
-                  <div className="min-h-0 flex-1 overflow-y-auto">
-                    {visibleChannels.map((channel) => (
-                      <SlackChannelRow
-                        key={channel.id}
-                        channel={channel}
-                        pending={pendingChannelIds.has(channel.id)}
-                        overridesLoading={tierOverridesLoading}
-                        overridesError={tierOverridesError}
-                        defaultTier={defaultTier}
-                        accessControls={accessControlsSupported}
-                        tierOverride={tierOverrides?.[channel.id]}
-                        onTierChange={(tier) => onTierChange?.(channel.id, tier)}
-                        onReset={() => onTierReset?.(channel.id)}
-                      />
-                    ))}
-                  </div>
-                )
-              )}
-            </>
+                )}
+                className="h-full"
+              />
+            </div>
+          ) : (
+            <div className="max-h-96 overflow-y-auto">
+              {visibleChannels.map((channel) => (
+                <SlackChannelRow
+                  key={channel.id}
+                  channel={channel}
+                  pending={pendingChannelIds.has(channel.id)}
+                  overridesLoading={tierOverridesLoading}
+                  overridesError={tierOverridesError}
+                  defaultTier={defaultTier}
+                  accessControls={accessControlsSupported}
+                  tierOverride={tierOverrides?.[channel.id]}
+                  onTierChange={(tier) => onTierChange?.(channel.id, tier)}
+                  onReset={() => onTierReset?.(channel.id)}
+                />
+              ))}
+            </div>
           )}
-        </Card.Body>
-        {showLegend &&
-        accessControlsSupported &&
-        !loading &&
-        !error &&
-        allChannels.length > 0 ? (
-          <Card.Footer className="p-0">
-            <SlackChannelTierLegend
-              assistantName={assistantDisplayName}
-              defaultTier={defaultTier}
-            />
-          </Card.Footer>
-        ) : null}
-      </Card.Root>
-    </>
+        </>
+      )}
+    </div>
   );
 }
 

--- a/clients/web/src/domains/channels/components/slack-channel-section.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-section.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { ChevronDown } from "lucide-react";
 
+import { Card } from "@vellumai/design-library/components/card";
 import { Collapsible } from "@vellumai/design-library/components/collapsible";
 import { Typography } from "@vellumai/design-library/components/typography";
 
@@ -21,10 +22,12 @@ export interface SlackChannelSectionProps {
 /**
  * Data container for the Slack sub-tab. When access controls are supported the
  * primary card maps each conversation type (Channels, Direct messages) to its
- * default Assistant Access level, and the per-channel presence list drops into a
- * collapsible below it — individual channels matter less than the type default,
- * so they stay out of the way. Against an older assistant (no channel-permission
- * routes) it falls back to the plain presence list with no pickers.
+ * default Assistant Access level, and the per-channel presence list lives in a
+ * single "Per-channel overrides" card below it that expands in place — the card
+ * header is the toggle, so there's no bare trigger stacked on a second card.
+ * Individual channels matter less than the type default, so they start
+ * collapsed. Against an older assistant (no channel-permission routes) it falls
+ * back to the bare presence list in a plain card with no pickers.
  *
  * Mounts only while Slack is connected (the panel renders it conditionally), so
  * the queries need no connection gate of their own.
@@ -78,19 +81,22 @@ export function SlackChannelSection({
       pendingChannelIds={overrides.pendingChannelIds}
       onTierChange={overrides.onTierChange}
       onTierReset={overrides.onTierReset}
-      // The default-access card above owns the key when access controls are on.
-      showLegend={!overrides.supported}
     />
   );
 
   // Older assistant without the channel-permission routes: no per-type defaults
-  // to map, so show the plain presence list on its own.
+  // to map, so show the bare presence list in a plain card of its own — nothing
+  // to collapse, and no default-access card above to own the framing.
   if (
     !overrides.supported ||
     !overrides.onBucketChange ||
     !overrides.onBucketReset
   ) {
-    return list;
+    return (
+      <Card.Root noPadding clipContents>
+        {list}
+      </Card.Root>
+    );
   }
 
   return (
@@ -105,22 +111,26 @@ export function SlackChannelSection({
         onBucketChange={overrides.onBucketChange}
         onBucketReset={overrides.onBucketReset}
       />
-      <Collapsible.Root type="single" collapsible>
-        <Collapsible.Item value="individual-channels">
-          <Collapsible.Trigger className="group justify-between gap-2 px-1 py-2">
-            <Typography as="span" variant="body-small-emphasised">
-              Individual channels
-            </Typography>
-            <ChevronDown
-              aria-hidden="true"
-              className="h-4 w-4 shrink-0 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-180"
-            />
-          </Collapsible.Trigger>
-          <Collapsible.Content>
-            <div className="pt-3">{list}</div>
-          </Collapsible.Content>
-        </Collapsible.Item>
-      </Collapsible.Root>
+      {/* One card that expands: the header is the toggle, the bare list drops
+          straight in below it — no trigger-then-separate-card double frame. */}
+      <Card.Root noPadding clipContents>
+        <Collapsible.Root type="single" collapsible>
+          <Collapsible.Item value="per-channel-overrides">
+            <Collapsible.Trigger className="group justify-between gap-2 px-4 py-3">
+              <Typography as="span" variant="body-small-emphasised">
+                Per-channel overrides
+              </Typography>
+              <ChevronDown
+                aria-hidden="true"
+                className="h-4 w-4 shrink-0 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-180"
+              />
+            </Collapsible.Trigger>
+            <Collapsible.Content className="border-[var(--border-base)] data-[state=open]:border-t">
+              {list}
+            </Collapsible.Content>
+          </Collapsible.Item>
+        </Collapsible.Root>
+      </Card.Root>
     </div>
   );
 }

--- a/clients/web/src/domains/channels/components/slack-channel-type-defaults.stories.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-type-defaults.stories.tsx
@@ -3,6 +3,7 @@ import { ChevronDown } from "lucide-react";
 import { useState } from "react";
 import { userEvent, within } from "storybook/test";
 
+import { Card } from "@vellumai/design-library/components/card";
 import { Collapsible } from "@vellumai/design-library/components/collapsible";
 import { Typography } from "@vellumai/design-library/components/typography";
 
@@ -108,8 +109,8 @@ export const Customized: Story = {
 
 /**
  * The full Slack sub-tab layout: the default-access card as the hero, with the
- * per-channel presence list folded into the "Individual channels" collapsible
- * below (collapsed by default). Mirrors `SlackChannelSection`.
+ * bare per-channel presence list folded into the "Per-channel overrides" card
+ * that expands in place (collapsed by default). Mirrors `SlackChannelSection`.
  */
 export const InContext: Story = {
   render: function SectionLayout(args) {
@@ -127,42 +128,41 @@ export const InContext: Story = {
             setTiers((prev) => ({ ...prev, [bucket]: undefined }))
           }
         />
-        <Collapsible.Root type="single" collapsible>
-          <Collapsible.Item value="individual-channels">
-            <Collapsible.Trigger className="group justify-between gap-2 px-1 py-2">
-              <Typography as="span" variant="body-small-emphasised">
-                Individual channels
-              </Typography>
-              <ChevronDown
-                aria-hidden="true"
-                className="h-4 w-4 shrink-0 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-180"
-              />
-            </Collapsible.Trigger>
-            <Collapsible.Content>
-              <div className="pt-3">
+        <Card.Root noPadding clipContents>
+          <Collapsible.Root type="single" collapsible>
+            <Collapsible.Item value="per-channel-overrides">
+              <Collapsible.Trigger className="group justify-between gap-2 px-4 py-3">
+                <Typography as="span" variant="body-small-emphasised">
+                  Per-channel overrides
+                </Typography>
+                <ChevronDown
+                  aria-hidden="true"
+                  className="h-4 w-4 shrink-0 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-180"
+                />
+              </Collapsible.Trigger>
+              <Collapsible.Content className="border-[var(--border-base)] data-[state=open]:border-t">
                 <SlackChannelList
                   assistantDisplayName="Example Assistant"
                   slackHandle="@example-assistant"
                   channels={CHANNELS}
                   defaultTier={channelsDefault}
-                  showLegend={false}
                 />
-              </div>
-            </Collapsible.Content>
-          </Collapsible.Item>
-        </Collapsible.Root>
+              </Collapsible.Content>
+            </Collapsible.Item>
+          </Collapsible.Root>
+        </Card.Root>
       </div>
     );
   },
 };
 
-/** The "Individual channels" collapsible expanded, showing the per-channel rows. */
+/** The "Per-channel overrides" card expanded, showing the per-channel rows. */
 export const InContextExpanded: Story = {
   ...InContext,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(
-      canvas.getByRole("button", { name: /individual channels/i }),
+      canvas.getByRole("button", { name: /per-channel overrides/i }),
     );
   },
 };

--- a/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
@@ -105,7 +105,7 @@ export function SlackChannelTypeDefaults({
               title={title}
               subtitle={description}
               trailing={
-                <div className="w-48">
+                <div className="w-40 sm:w-48">
                   <TierPicker
                     tier={bucketTiers?.[bucket]}
                     defaultTier={inheritedTier}


### PR DESCRIPTION
## Prompt / plan
Follow-up to #39080 (map Slack Assistant Access defaults by conversation type). That PR shipped the feature and its correctness fixes; this one is the look + mobile polish we deferred.

**Landed:**
- **Mobile responsiveness** — the per-channel and type-default rows put a fixed-width picker in `ListRow`'s `shrink-0` trailing cluster, which collapsed the `flex-1` title on phone widths (the channel name disappeared, type titles truncated). Member count moves to the row subtitle, and the picker shrinks to `w-40` under the `sm` breakpoint, so names/titles survive narrow screens.
- **Layout** — the per-channel presence list is now a single **"Per-channel overrides"** card whose header *is* the expand toggle, instead of a bare "Individual channels" heading floating above a second card with its own "Where … is present" header (the double-header that read awkwardly). `SlackChannelList` always renders bare now — it only ever mounts inside that card — so the `bare`/`showLegend` toggle props, the card wrapper, and the legend branch are gone (net −28 lines). The virtualized and plain row lists self-bound to a fixed height so they scroll within the collapsible instead of collapsing to zero height or growing unbounded. The older-assistant fallback (no channel-permission routes) wraps the bare list in a plain card of its own.

## Test plan
- `bunx tsc --noEmit` + ESLint clean (pre-commit); 38 channel-domain tests pass.
- Storybook `Channels/SlackChannelTypeDefaults` (`InContext` / `InContextExpanded`) and `Channels/SlackChannelList` — verified collapsed + expanded at desktop (1200px) and 390px phone width.

### Known nit (deferred)
At 390px, long labels truncate consistently across the surface — "Direct messag…" in the Default-access card and "incident-resp…" in the channel list — standard list behavior for very narrow screens, and each has clarifying context (subtitle / icon + member count). Left as-is rather than desyncing the two row layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeiZ9nRv2AdHtBCcGmCoJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeiZ9nRv2AdHtBCcGmCoJY)_