### PR TITLE
fix(voice): surface out-of-credits failures instead of stopping silently (LUM-2829)

### DIFF
--- a/assistant/src/api/events/conversation-error.ts
+++ b/assistant/src/api/events/conversation-error.ts
@@ -48,6 +48,15 @@ export const ConversationErrorCodeSchema = z.enum([
 
 export type ConversationErrorCode = z.infer<typeof ConversationErrorCodeSchema>;
 
+/**
+ * `errorCategory` value meaning "the org is out of Vellum credits". Clients key
+ * their credits paywall off it. Exported because the same classification is
+ * raised outside the agent loop — a live-voice STT/TTS credit failure never
+ * produces a `conversation_error`, so it stamps this onto its own error frame
+ * to reach the same billing surface.
+ */
+export const CREDITS_EXHAUSTED_ERROR_CATEGORY = "credits_exhausted";
+
 export const ConversationErrorEventSchema = z.object({
   type: z.literal("conversation_error"),
   conversationId: z.string(),

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -1324,7 +1324,13 @@ export async function startVoiceTurn(
             // turnComplete promise settles instead of hanging forever.
             eventSink.onMessageComplete(msg);
           } else if (msg.type === "error") {
-            eventSink.onError(msg.message);
+            // Carries its own classification, and the agent loop can emit this
+            // ahead of the matching `conversation_error` — a client that tears
+            // down on the first terminal frame never sees the second, so this
+            // one must be categorized too.
+            eventSink.onError(msg.message, {
+              errorCategory: msg.errorCategory,
+            });
           } else if (msg.type === "conversation_error") {
             eventSink.onError(msg.userMessage, {
               errorCategory: msg.errorCategory,

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -210,6 +210,16 @@ export interface VoiceToolResultEvent {
   resultPreview: string;
 }
 
+/** Structured classification accompanying a voice-turn failure. */
+export interface VoiceRunErrorDetail {
+  /**
+   * `errorCategory` from the originating `conversation_error` (e.g.
+   * `credits_exhausted`). Absent for failures raised outside the agent loop's
+   * classifier.
+   */
+  errorCategory?: string;
+}
+
 /**
  * Real-time event sink for voice TTS streaming. Agent-loop events are
  * forwarded here for real-time text-to-speech without modifying the
@@ -225,7 +235,13 @@ export interface VoiceRunEventSink {
       { type: "message_complete" } | { type: "generation_cancelled" }
     >,
   ): void;
-  onError(message: string): void;
+  /**
+   * `detail` carries the structured classification when the failure came from a
+   * `conversation_error` (whose `errorCategory` drives client billing
+   * surfaces). Optional so consumers that only need the message — telephony,
+   * where there is no UI to route to — implement the one-arg form unchanged.
+   */
+  onError(message: string, detail?: VoiceRunErrorDetail): void;
   onToolUse(
     toolName: string,
     input: Record<string, unknown>,
@@ -285,8 +301,13 @@ export interface VoiceTurnOptions {
   onTextDelta?: (text: string) => void;
   /** Called when the agent loop completes a full response. */
   onComplete?: () => void;
-  /** Called when the agent loop encounters an error. */
-  onError?: (message: string) => void;
+  /**
+   * Called when the agent loop encounters an error. `detail` carries the
+   * structured classification (e.g. `errorCategory: "credits_exhausted"`) when
+   * the failure came from a `conversation_error`; consumers with no UI to route
+   * to (telephony) can ignore it.
+   */
+  onError?: (message: string, detail?: VoiceRunErrorDetail) => void;
   /** Event-name callbacks used by non-phone voice clients. */
   callbacks?: VoiceTurnCallbacks;
   /** Optional AbortSignal for external cancellation (e.g. barge-in). */
@@ -584,8 +605,8 @@ export async function startVoiceTurn(
         }
       }
     },
-    onError: (message) => {
-      opts.onError?.(message);
+    onError: (message, detail) => {
+      opts.onError?.(message, detail);
     },
     onToolUse: (toolName, input, toolUseId) => {
       log.debug({ toolName, input }, "Voice turn tool_use event");
@@ -1305,7 +1326,9 @@ export async function startVoiceTurn(
           } else if (msg.type === "error") {
             eventSink.onError(msg.message);
           } else if (msg.type === "conversation_error") {
-            eventSink.onError(msg.userMessage);
+            eventSink.onError(msg.userMessage, {
+              errorCategory: msg.errorCategory,
+            });
           } else if (msg.type === "tool_use_start") {
             eventSink.onToolUse(msg.toolName, msg.input, msg.toolUseId);
           } else if (msg.type === "tool_result") {

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -1,6 +1,7 @@
-import type {
-  ConversationErrorCode,
-  ConversationErrorEvent,
+import {
+  type ConversationErrorCode,
+  type ConversationErrorEvent,
+  CREDITS_EXHAUSTED_ERROR_CATEGORY,
 } from "../api/events/conversation-error.js";
 import {
   ORDERING_ERROR_PATTERNS,
@@ -689,7 +690,7 @@ function managedBalanceClassification(): Omit<
     userMessage:
       "You've run out of credits. Add funds to continue using the assistant.",
     retryable: false,
-    errorCategory: "credits_exhausted",
+    errorCategory: CREDITS_EXHAUSTED_ERROR_CATEGORY,
   };
 }
 

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -2,9 +2,10 @@ import { readFileSync } from "node:fs";
 import { describe, expect, mock, test } from "bun:test";
 
 import type { VoiceTurnOptions } from "../../calls/voice-session-bridge.js";
-import type {
-  StreamingTranscriber,
-  SttStreamServerEvent,
+import {
+  type StreamingTranscriber,
+  SttError,
+  type SttStreamServerEvent,
 } from "../../stt/types.js";
 import {
   LiveVoiceSession,
@@ -178,7 +179,9 @@ async function waitFor(
   message = "Timed out waiting for live voice STT test condition",
 ): Promise<void> {
   for (let attempt = 0; attempt < 40; attempt += 1) {
-    if (predicate()) return;
+    if (predicate()) {
+      return;
+    }
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   throw new Error(message);
@@ -413,7 +416,9 @@ describe("LiveVoiceSession STT", () => {
     let resolverCalls = 0;
     const resolver: LiveVoiceStreamingTranscriberResolver = mock(async () => {
       resolverCalls += 1;
-      if (resolverCalls === 1) return firstTranscriber;
+      if (resolverCalls === 1) {
+        return firstTranscriber;
+      }
       return new Promise<StreamingTranscriber | null>(() => {});
     });
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
@@ -450,7 +455,9 @@ describe("LiveVoiceSession STT", () => {
     let resolverCalls = 0;
     const resolver: LiveVoiceStreamingTranscriberResolver = mock(async () => {
       resolverCalls += 1;
-      if (resolverCalls === 1) return new MockStreamingTranscriber();
+      if (resolverCalls === 1) {
+        return new MockStreamingTranscriber();
+      }
       throw new Error("next stt unavailable");
     });
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
@@ -653,6 +660,32 @@ describe("LiveVoiceSession STT", () => {
           "Live voice transcription could not be started: provider credentials rejected",
       },
     ]);
+  });
+
+  test("tags a credits-exhausted startup failure for the billing surface", async () => {
+    const { context, frames } = createContext();
+    // Credits already gone when the relay is dialed — the common way into this
+    // state, since the user hits the wall on the next utterance rather than
+    // mid-stream. Without the category the client falls back to a generic
+    // failure notice and never reaches the paywall.
+    const resolver: LiveVoiceStreamingTranscriberResolver = mock(async () => {
+      throw new SttError(
+        "credits-exhausted",
+        "Managed speech is paused: your Vellum organization is out of credits.",
+        { userFacing: true },
+      );
+    });
+    const session = new LiveVoiceSession(context, {
+      resolveTranscriber: resolver,
+    });
+
+    await session.start();
+    await waitFor(() => frames.some((frame) => frame.type === "error"));
+
+    expect(frames.find((frame) => frame.type === "error")).toMatchObject({
+      code: "invalid_field",
+      errorCategory: "credits_exhausted",
+    });
   });
 
   test("retains transcriber handle when stop() throws so close() can clean up", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -283,6 +283,25 @@ describe("LiveVoiceSession STT", () => {
     }
   });
 
+  test("marks credit exhaustion non-recoverable and tags it for the billing surface", async () => {
+    const { frames, session, transcriber } = createSessionWithTranscriber();
+
+    await session.start();
+    transcriber.emit({
+      type: "error",
+      category: "credits-exhausted",
+      message:
+        "Managed speech is paused: your Vellum organization is out of credits.",
+    });
+    await waitFor(() => frames.some((frame) => frame.type === "error"));
+
+    const frame = frames.find((f) => f.type === "error");
+    // Recoverable would leave a hands-free client listening forever against a
+    // relay that can never transcribe again — the silent failure this fixes.
+    expect(frame).not.toHaveProperty("recoverable");
+    expect(frame).toMatchObject({ errorCategory: "credits_exhausted" });
+  });
+
   test("forwards binary audio to the transcriber and emits STT frames", async () => {
     const { frames, session, transcriber } = createSessionWithTranscriber();
 

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -15,6 +15,7 @@ import type {
   StreamingTranscriber,
   SttStreamServerEvent,
 } from "../../stt/types.js";
+import { TtsCreditsExhaustedError } from "../../tts/types.js";
 import { pickAckPhrase } from "../ack-phrases.js";
 import type {
   VoiceAckTextInput,
@@ -416,6 +417,58 @@ describe("LiveVoiceSession TTS", () => {
       type: "tts_done",
       turnId: "live-turn-1",
     });
+  });
+
+  test("forwards the agent loop's billing category onto the error frame", async () => {
+    let onError: VoiceTurnOptions["onError"];
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      onError = options.onError;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio: null,
+    });
+
+    await startReleasedTurn(session);
+    // The LLM leg's `conversation_error` classification, which the bridge would
+    // otherwise flatten to a bare string — losing the client's route to the
+    // billing banner and its "Add credits" CTA.
+    onError?.("You've run out of credits.", {
+      errorCategory: "credits_exhausted",
+    });
+    await waitFor(() => frames.some((frame) => frame.type === "error"));
+
+    expect(frames.find((f) => f.type === "error")).toMatchObject({
+      message: "You've run out of credits.",
+      errorCategory: "credits_exhausted",
+    });
+  });
+
+  test("treats a TTS credit failure as terminal, not a recoverable segment blip", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const streamTtsAudio = mock(async () => {
+      throw new TtsCreditsExhaustedError("Vellum credits are exhausted");
+    });
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta("This should persist."));
+    await waitFor(() => frames.some((frame) => frame.type === "error"));
+
+    // Unlike an ordinary segment failure, every later segment fails the same
+    // way — marking it recoverable leaves the assistant permanently mute while
+    // the room keeps animating, with nothing shown to the user.
+    const frame = frames.find((f) => f.type === "error");
+    expect(frame).not.toHaveProperty("recoverable");
+    expect(frame).toMatchObject({ errorCategory: "credits_exhausted" });
   });
 
   test("sanitizes markdown spanning deltas before TTS while deltas stay raw", async () => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -49,10 +49,11 @@ import {
 import type { ResolveStreamingTranscriberOptions } from "../providers/speech-to-text/resolve.js";
 import { publishConversationListAndMetadataChanged } from "../runtime/sync/resource-sync-events.js";
 import { detectPcm16SpeechActivity } from "../stt/speech-energy.js";
-import type {
-  StreamingTranscriber,
-  SttStreamServerErrorEvent,
-  SttStreamServerEvent,
+import {
+  type StreamingTranscriber,
+  SttError,
+  type SttStreamServerErrorEvent,
+  type SttStreamServerEvent,
 } from "../stt/types.js";
 import { getSubagentManager } from "../subagent/index.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
@@ -339,7 +340,12 @@ type UtteranceStartResult =
   | { status: "started" }
   | { status: "stale" }
   | { status: "unavailable"; message: string }
-  | { status: "error"; message: string };
+  // `errorCategory` carries a billing classification (credit exhaustion) from
+  // the transcriber's startup failure through to the client's error frame. A
+  // dial that fails because the org is out of credits is the common way into
+  // this state — the user hits the wall on the next utterance, not mid-stream —
+  // so it must reach the billing banner like a mid-stream failure does.
+  | { status: "error"; message: string; errorCategory?: string };
 
 // One TTS segment flowing through the turn's synthesis pipeline. Synthesis
 // may run ahead of the emission slot (prefetch), but frames only reach the
@@ -1011,6 +1017,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         message: `Live voice transcription could not be started: ${errorMessage(
           err,
         )}`,
+        ...(err instanceof SttError && err.category === "credits-exhausted"
+          ? { errorCategory: CREDITS_EXHAUSTED_ERROR_CATEGORY }
+          : {}),
       };
     }
   }
@@ -1096,6 +1105,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           ? LiveVoiceProtocolErrorCode.CredentialsUnavailable
           : LiveVoiceProtocolErrorCode.InvalidField,
       message: result.message,
+      ...(result.status === "error" && result.errorCategory !== undefined
+        ? { errorCategory: result.errorCategory }
+        : {}),
     });
     // The manager only observes failures thrown from start(); an arm that
     // fails after the early `ready` must release the session slot itself,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 
+import { CREDITS_EXHAUSTED_ERROR_CATEGORY } from "../api/events/conversation-error.js";
 import {
   MediaTurnDetector,
   type TurnDetectorConfig,
@@ -55,6 +56,7 @@ import type {
 } from "../stt/types.js";
 import { getSubagentManager } from "../subagent/index.js";
 import { extractSpeakableSegments } from "../tts/speakable-segments.js";
+import { isTtsCreditsExhaustedError } from "../tts/types.js";
 import { createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
 import { pickAckPhrase, pickProgressPhrase } from "./ack-phrases.js";
@@ -2381,8 +2383,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   // Providers emit `error` mid-stream and may keep streaming; `closed` /
   // `final` still drive turn lifecycle. Only transient categories are
-  // recoverable — auth/rate-limit/invalid-audio will not self-heal, so
-  // hands-free clients must surface them instead of suppressing them.
+  // recoverable — auth/rate-limit/invalid-audio/credits-exhausted will not
+  // self-heal, so hands-free clients must surface them instead of suppressing
+  // them. `credits-exhausted` in particular used to ride in `provider-error`,
+  // which made an out-of-credits call look like it had simply stopped
+  // listening: the client suppressed it and left the mic open forever.
   private async sendTranscriberErrorFrame(
     event: SttStreamServerErrorEvent,
   ): Promise<void> {
@@ -2393,6 +2398,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       code: LiveVoiceProtocolErrorCode.InvalidField,
       message: event.message,
       ...(recoverable ? { recoverable: true } : {}),
+      ...(event.category === "credits-exhausted"
+        ? { errorCategory: CREDITS_EXHAUSTED_ERROR_CATEGORY }
+        : {}),
     });
   }
 
@@ -3018,7 +3026,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             this.maybeNarrateProgress(current, "ops");
           },
         },
-        onError: (message) => {
+        onError: (message, detail) => {
           const current = this.activeAssistantTurn;
           if (
             !this.isActiveAssistantTurn(token) ||
@@ -3031,6 +3039,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               type: "error",
               code: LiveVoiceProtocolErrorCode.InvalidField,
               message,
+              // Billing classification from the agent loop's
+              // `conversation_error`, forwarded so a voice turn that dies on
+              // credits reaches the same paywall a text turn would.
+              ...(detail?.errorCategory !== undefined
+                ? { errorCategory: detail.errorCategory }
+                : {}),
             });
             const currentTurn = this.activeAssistantTurn;
             if (currentTurn?.token !== token) {
@@ -3839,14 +3853,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       await job.frames;
 
       if (failed && this.isForwardingTts(token)) {
-        // Per-segment failure: the turn (and session) continue, so the
-        // error is recoverable for the client.
+        // Per-segment failure: the turn (and session) continue, so the error is
+        // recoverable for the client — except credit exhaustion, where every
+        // later segment fails the same way. Marking that recoverable leaves the
+        // assistant listening and thinking but permanently mute, so it is
+        // terminal and carries the billing category to the client's paywall.
+        const creditsExhausted = isTtsCreditsExhaustedError(synthesisError);
         await this.sendFrame(
           {
             type: "error",
             code: LiveVoiceProtocolErrorCode.InvalidField,
             message: `Live voice TTS failed: ${errorMessage(synthesisError)}`,
-            recoverable: true,
+            ...(creditsExhausted
+              ? { errorCategory: CREDITS_EXHAUSTED_ERROR_CATEGORY }
+              : { recoverable: true }),
           },
           () => this.isForwardingTts(token),
         );

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -2397,9 +2397,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // `final` still drive turn lifecycle. Only transient categories are
   // recoverable — auth/rate-limit/invalid-audio/credits-exhausted will not
   // self-heal, so hands-free clients must surface them instead of suppressing
-  // them. `credits-exhausted` in particular used to ride in `provider-error`,
-  // which made an out-of-credits call look like it had simply stopped
-  // listening: the client suppressed it and left the mic open forever.
+  // them. `credits-exhausted` must stay out of the recoverable set for that
+  // reason: a hands-free client suppresses recoverable errors and returns to
+  // listening, which against an exhausted balance is a mic left open forever on
+  // a relay that can never transcribe again.
   private async sendTranscriberErrorFrame(
     event: SttStreamServerErrorEvent,
   ): Promise<void> {

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -297,6 +297,18 @@ export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
    * from older daemons) means the error is terminal for the session.
    */
   readonly recoverable?: boolean;
+  /**
+   * Billing/quota classification, using the same vocabulary as the
+   * `conversation_error` SSE event's `errorCategory` (e.g. `credits_exhausted`)
+   * so clients can route a voice failure to the same billing surface a text
+   * turn would raise. Absent for ordinary failures and on frames from older
+   * daemons.
+   *
+   * Needed because the speech legs never reach the agent loop: an STT or TTS
+   * credit failure produces no `conversation_error`, so this frame is the only
+   * carrier of the reason the room is closing.
+   */
+  readonly errorCategory?: string;
 }
 
 export type LiveVoiceServerFrame =

--- a/assistant/src/providers/speech-to-text/__tests__/vellum-managed-realtime.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/vellum-managed-realtime.test.ts
@@ -184,10 +184,14 @@ describe("VellumManagedRealtimeTranscriber", () => {
     );
     sockets[0]!.simulateClose(1011, "insufficient_balance");
 
+    // Its own category, not `provider-error`: the live-voice session treats
+    // provider errors as recoverable and would suppress this, leaving a
+    // hands-free call listening forever against a relay that can never
+    // transcribe again.
     expect(events).toEqual([
       expect.objectContaining({
         type: "error",
-        category: "provider-error",
+        category: "credits-exhausted",
         message: expect.stringContaining("credits"),
       }),
       { type: "closed" },
@@ -292,7 +296,7 @@ describe("VellumManagedRealtimeTranscriber", () => {
     expect(events).toEqual([
       expect.objectContaining({
         type: "error",
-        category: "provider-error",
+        category: "credits-exhausted",
         message: expect.stringContaining("credits"),
       }),
       { type: "closed" },

--- a/assistant/src/providers/speech-to-text/__tests__/vellum-managed.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/vellum-managed.test.ts
@@ -81,7 +81,7 @@ describe("sttErrorFromManagedSpeech", () => {
       messageIncludes: "no connection",
     },
     {
-      name: "insufficient_balance → provider-error, user-facing credit copy",
+      name: "insufficient_balance → credits-exhausted, user-facing credit copy",
       failure: {
         ok: false,
         kind: "platform-error",
@@ -89,7 +89,7 @@ describe("sttErrorFromManagedSpeech", () => {
         code: "insufficient_balance",
         message: "balance",
       },
-      category: "provider-error",
+      category: "credits-exhausted",
       userFacing: true,
       messageIncludes: "Vellum credits",
     },

--- a/assistant/src/providers/speech-to-text/__tests__/vellum-speech-relay-connection.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/vellum-speech-relay-connection.test.ts
@@ -68,8 +68,10 @@ describe("mapVelayError", () => {
       category: "auth",
       message: expect.stringContaining("restart the assistant"),
     });
+    // Its own category, NOT `provider-error`: consumers that retry or suppress
+    // transient provider blips (hands-free live voice) must surface this.
     expect(mapVelayError({ code: "insufficient_balance" })).toMatchObject({
-      category: "provider-error",
+      category: "credits-exhausted",
       message: expect.stringContaining("credits"),
     });
     expect(mapVelayError({ code: "provider_unreachable" }).category).toBe(

--- a/assistant/src/providers/speech-to-text/vellum-managed.ts
+++ b/assistant/src/providers/speech-to-text/vellum-managed.ts
@@ -60,7 +60,7 @@ export function sttErrorFromManagedSpeech(
   }
   if (failure.code === "insufficient_balance") {
     return managed(
-      "provider-error",
+      "credits-exhausted",
       "Vellum credits are exhausted — add funds to your Vellum account to continue using managed transcription.",
     );
   }

--- a/assistant/src/providers/speech-to-text/vellum-speech-relay-connection.ts
+++ b/assistant/src/providers/speech-to-text/vellum-speech-relay-connection.ts
@@ -118,7 +118,7 @@ export function mapVelayError(error: VelayErrorInfo): {
       };
     case "insufficient_balance":
       return {
-        category: "provider-error",
+        category: "credits-exhausted",
         message:
           "Managed speech is paused: your Vellum organization is out of credits. Top up credits to continue.",
       };

--- a/assistant/src/providers/voice-error-copy.ts
+++ b/assistant/src/providers/voice-error-copy.ts
@@ -41,6 +41,11 @@ export function describeSttFailure(
       return "Transcription timed out.";
     case "invalid-audio":
       return "The audio could not be transcribed (unsupported or corrupted format).";
+    case "credits-exhausted":
+      // Managed-speech adapters mark their credit failures `userFacing` and
+      // return above with copy naming the remediation; this is the fallback for
+      // any future non-user-facing source of the category.
+      return "Vellum credits are exhausted — add funds to your Vellum account to continue.";
     default:
       return `${provider} returned an error while transcribing.`;
   }

--- a/assistant/src/runtime/routes/errors.ts
+++ b/assistant/src/runtime/routes/errors.ts
@@ -55,6 +55,13 @@ export class TooManyRequestsError extends RouteError {
   }
 }
 
+export class PaymentRequiredError extends RouteError {
+  constructor(message: string) {
+    super(message, "PAYMENT_REQUIRED", 402);
+    this.name = "PaymentRequiredError";
+  }
+}
+
 export class ForbiddenError extends RouteError {
   constructor(message: string) {
     super(message, "FORBIDDEN", 403);

--- a/assistant/src/runtime/routes/stt-routes.ts
+++ b/assistant/src/runtime/routes/stt-routes.ts
@@ -29,6 +29,7 @@ import {
   BadGatewayError,
   BadRequestError,
   GatewayTimeoutError,
+  PaymentRequiredError,
   type RouteError,
   ServiceUnavailableError,
   TooManyRequestsError,
@@ -214,6 +215,8 @@ const STT_ERROR_MAP: Record<SttErrorCategory, () => RouteError> = {
   timeout: () => new GatewayTimeoutError("STT transcription timed out"),
   "invalid-audio": () =>
     new BadRequestError("Audio payload was rejected by the STT provider"),
+  "credits-exhausted": () =>
+    new PaymentRequiredError("Vellum credits are exhausted"),
   "provider-error": () => new BadGatewayError("STT provider error"),
 };
 

--- a/assistant/src/stt/types.ts
+++ b/assistant/src/stt/types.ts
@@ -143,6 +143,14 @@ export type SttErrorCategory =
   | "timeout"
   /** The audio payload was rejected (unsupported format, too large, etc.). */
   | "invalid-audio"
+  /**
+   * Managed speech is out of Vellum credits. Distinct from `provider-error`
+   * because it is definitionally non-transient: every subsequent request fails
+   * identically until the user tops up, so callers that retry or suppress
+   * transient provider blips (e.g. hands-free live voice) must surface this
+   * instead of swallowing it.
+   */
+  | "credits-exhausted"
   /** Any other provider-side or network failure. */
   | "provider-error";
 

--- a/assistant/src/tts/providers/vellum-provider.ts
+++ b/assistant/src/tts/providers/vellum-provider.ts
@@ -25,14 +25,16 @@ import {
   mapVelayError,
   probeVelayRejection,
   resolveSpeechRelayConnection,
+  type VelayErrorInfo,
 } from "../../providers/speech-to-text/vellum-speech-relay-connection.js";
 import { getLogger } from "../../util/logger.js";
 import type { TtsProviderDefinition } from "../provider-definition.js";
-import type {
-  TtsProvider,
-  TtsProviderCapabilities,
-  TtsSynthesisRequest,
-  TtsSynthesisResult,
+import {
+  TtsCreditsExhaustedError,
+  type TtsProvider,
+  type TtsProviderCapabilities,
+  type TtsSynthesisRequest,
+  type TtsSynthesisResult,
 } from "../types.js";
 import { synthesizeOverVellumTtsSocket } from "./vellum-tts-socket.js";
 
@@ -68,9 +70,21 @@ function resolveManagedVoice(request: TtsSynthesisRequest): string | undefined {
   return request.voiceId ?? getConfig().services.tts.providers.vellum.model;
 }
 
+/**
+ * A relay `{code, detail}` as a throwable. Credit exhaustion keeps its own type
+ * so the live-voice session can tell it apart from a transient relay blip
+ * (which it treats as a recoverable, session-surviving segment failure).
+ */
+function relayError(error: VelayErrorInfo): Error {
+  const mapped = mapVelayError(error);
+  return mapped.category === "credits-exhausted"
+    ? new TtsCreditsExhaustedError(mapped.message)
+    : new Error(mapped.message);
+}
+
 function synthesisError(failure: ManagedSpeechFailure): Error {
   if (failure.code === "insufficient_balance") {
-    return new Error(
+    return new TtsCreditsExhaustedError(
       "Vellum credits are exhausted — add funds to your Vellum account to continue using managed speech.",
     );
   }
@@ -154,8 +168,7 @@ async function performStreamingSynthesis(
         new Error(`Managed streaming TTS failed: ${detail}`),
       makeEmptyError: () =>
         new Error("Managed streaming TTS returned no audio"),
-      makeRelayError: (code, detail) =>
-        new Error(mapVelayError({ code, detail }).message),
+      makeRelayError: (code, detail) => relayError({ code, detail }),
     });
     return {
       audio,
@@ -180,7 +193,7 @@ async function performStreamingSynthesis(
       `${connection.httpBaseUrl}${TTS_STREAM_PATH}?${probeParams.toString()}`,
     );
     if (rejection) {
-      throw new Error(mapVelayError(rejection).message);
+      throw relayError(rejection);
     }
     throw err;
   }

--- a/assistant/src/tts/types.ts
+++ b/assistant/src/tts/types.ts
@@ -125,6 +125,38 @@ export interface TtsSynthesisResult {
 }
 
 // ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Synthesis failed because the org is out of Vellum credits.
+ *
+ * Its own type because credit exhaustion is definitionally non-transient:
+ * callers that tolerate a one-off synthesis failure (live voice treats a failed
+ * segment as recoverable and keeps the session alive) must instead treat this
+ * as terminal — every subsequent segment fails identically until the user tops
+ * up, so retrying only produces a session that has silently stopped speaking.
+ */
+export class TtsCreditsExhaustedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TtsCreditsExhaustedError";
+  }
+}
+
+/**
+ * Whether a thrown value is (or wraps) a {@link TtsCreditsExhaustedError}.
+ * Checks one level of `cause` so the signal survives a provider or stream layer
+ * that re-wraps the failure.
+ */
+export function isTtsCreditsExhaustedError(err: unknown): boolean {
+  if (err instanceof TtsCreditsExhaustedError) {
+    return true;
+  }
+  return err instanceof Error && err.cause instanceof TtsCreditsExhaustedError;
+}
+
+// ---------------------------------------------------------------------------
 // Alignment / viseme events
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/components/add-credits-modal.test.tsx
+++ b/clients/web/src/components/add-credits-modal.test.tsx
@@ -1,28 +1,37 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
 import { routes } from "@/utils/routes";
 
+// Captured so tests can fire the "user came back from checkout" signal, which
+// on native is the only notification the app gets.
+let browserFinished: (() => void) | null = null;
 mock.module("@/runtime/browser", () => ({
   openUrl: () => Promise.resolve(),
-  openUrlFinishedListener: () => () => {},
+  openUrlFinishedListener: (cb: () => void) => {
+    browserFinished = cb;
+    return () => {
+      browserFinished = null;
+    };
+  },
 }));
 
 const { AddCreditsModal } = await import("@/components/add-credits-modal");
 
 afterEach(() => {
   cleanup();
+  browserFinished = null;
 });
 
-function renderModal() {
+function renderModal(props: { onCheckoutReturn?: () => void } = {}) {
   const client = new QueryClient();
   return render(
     <QueryClientProvider client={client}>
       <MemoryRouter>
-        <AddCreditsModal open onOpenChange={() => {}} />
+        <AddCreditsModal open onOpenChange={() => {}} {...props} />
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -48,5 +57,30 @@ describe("AddCreditsModal", () => {
       name: /Configure Automatic Top-Ups/,
     });
     expect(link.getAttribute("href")).toBe(routes.settings.usageBilling);
+  });
+
+  test("notifies the caller when the user returns from checkout", () => {
+    // On native the app state survives checkout, so callers that latched off
+    // the old balance (a surface disabled because credits ran out) need this
+    // signal to reconcile — without it they stay stale against a topped-up
+    // account.
+    const onCheckoutReturn = mock(() => {});
+    renderModal({ onCheckoutReturn });
+
+    act(() => {
+      browserFinished?.();
+    });
+
+    expect(onCheckoutReturn).toHaveBeenCalledTimes(1);
+  });
+
+  test("survives a checkout return with no caller hook", () => {
+    renderModal();
+
+    expect(() => {
+      act(() => {
+        browserFinished?.();
+      });
+    }).not.toThrow();
   });
 });

--- a/clients/web/src/components/add-credits-modal.test.tsx
+++ b/clients/web/src/components/add-credits-modal.test.tsx
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
 import { routes } from "@/utils/routes";
@@ -9,8 +16,12 @@ import { routes } from "@/utils/routes";
 // Captured so tests can fire the "user came back from checkout" signal, which
 // on native is the only notification the app gets.
 let browserFinished: (() => void) | null = null;
+let openedUrls: string[] = [];
 mock.module("@/runtime/browser", () => ({
-  openUrl: () => Promise.resolve(),
+  openUrl: (url: string) => {
+    openedUrls.push(url);
+    return Promise.resolve();
+  },
   openUrlFinishedListener: (cb: () => void) => {
     browserFinished = cb;
     return () => {
@@ -19,11 +30,31 @@ mock.module("@/runtime/browser", () => ({
   },
 }));
 
+let mockIsElectron = false;
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => mockIsElectron,
+}));
+
+// Stub the generated billing endpoints so the summary resolves and the
+// Continue button enables — otherwise every checkout-launch assertion would be
+// vacuously true against a permanently disabled button.
+mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
+  organizationsBillingSummaryRetrieveOptions: () => ({
+    queryKey: ["billing-summary"],
+    queryFn: async () => ({ allowed_top_up_amounts: ["10.00", "20.00"] }),
+  }),
+  organizationsBillingTopUpsCheckoutSessionCreateMutation: () => ({
+    mutationFn: async () => ({ checkout_url: "https://stripe.test/session" }),
+  }),
+}));
+
 const { AddCreditsModal } = await import("@/components/add-credits-modal");
 
 afterEach(() => {
   cleanup();
   browserFinished = null;
+  mockIsElectron = false;
+  openedUrls = [];
 });
 
 function renderModal(props: { onCheckoutReturn?: () => void } = {}) {
@@ -82,5 +113,78 @@ describe("AddCreditsModal", () => {
         browserFinished?.();
       });
     }).not.toThrow();
+  });
+
+  describe("Electron checkout return", () => {
+    // Electron hands checkout to the *system* browser and `browserFinished` is
+    // Capacitor-only, so regaining window focus is the only available signal
+    // that the user came back. Without it the modal sits open and callers stay
+    // latched to the pre-top-up balance.
+    test("regaining focus after launching checkout reports the return", async () => {
+      mockIsElectron = true;
+      const onCheckoutReturn = mock(() => {});
+      renderModal({ onCheckoutReturn });
+
+      // Launch checkout for real — that is what arms the focus handler.
+      const button = await screen.findByRole("button", { name: "Continue" });
+      await waitFor(() => {
+        expect((button as HTMLButtonElement).disabled).toBe(false);
+      });
+      fireEvent.click(button);
+      await waitFor(() => {
+        expect(openedUrls).toEqual(["https://stripe.test/session"]);
+      });
+
+      act(() => {
+        window.dispatchEvent(new Event("focus"));
+      });
+
+      expect(onCheckoutReturn).toHaveBeenCalledTimes(1);
+    });
+
+    test("only the first refocus counts — later ones are ordinary app use", async () => {
+      mockIsElectron = true;
+      const onCheckoutReturn = mock(() => {});
+      renderModal({ onCheckoutReturn });
+
+      const button = await screen.findByRole("button", { name: "Continue" });
+      await waitFor(() => {
+        expect((button as HTMLButtonElement).disabled).toBe(false);
+      });
+      fireEvent.click(button);
+      await waitFor(() => {
+        expect(openedUrls).toHaveLength(1);
+      });
+
+      act(() => {
+        window.dispatchEvent(new Event("focus"));
+        window.dispatchEvent(new Event("focus"));
+      });
+
+      expect(onCheckoutReturn).toHaveBeenCalledTimes(1);
+    });
+
+    test("focus without a launched checkout is ignored", () => {
+      mockIsElectron = true;
+      const onCheckoutReturn = mock(() => {});
+      renderModal({ onCheckoutReturn });
+
+      act(() => {
+        window.dispatchEvent(new Event("focus"));
+      });
+
+      expect(onCheckoutReturn).not.toHaveBeenCalled();
+    });
+
+    test("no focus handler off Electron — native uses browserFinished", () => {
+      const onCheckoutReturn = mock(() => {});
+      renderModal({ onCheckoutReturn });
+
+      act(() => {
+        window.dispatchEvent(new Event("focus"));
+      });
+
+      expect(onCheckoutReturn).not.toHaveBeenCalled();
+    });
   });
 });

--- a/clients/web/src/components/add-credits-modal.tsx
+++ b/clients/web/src/components/add-credits-modal.tsx
@@ -1,5 +1,5 @@
 import { AlertCircle, ChevronRight, Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useLocation, useSearchParams } from "react-router";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -9,6 +9,7 @@ import {
   organizationsBillingTopUpsCheckoutSessionCreateMutation,
 } from "@/generated/api/@tanstack/react-query.gen";
 import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
+import { isElectron } from "@/runtime/is-electron";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
@@ -101,19 +102,47 @@ export function AddCreditsModal({
     organizationsBillingTopUpsCheckoutSessionCreateMutation(),
   );
 
+  // Whether this modal launched checkout, so the Electron focus handler below
+  // only reacts to a return from *its* flow — not to any incidental refocus.
+  const checkoutLaunchedRef = useRef(false);
+
+  const handleCheckoutReturn = useCallback(() => {
+    onOpenChange(false);
+    void queryClient.invalidateQueries(
+      organizationsBillingSummaryRetrieveOptions(),
+    );
+    onCheckoutReturn?.();
+  }, [onOpenChange, queryClient, onCheckoutReturn]);
+
   // On native, SFSafariViewController stays on top of the app — the modal
   // remains mounted while Stripe checkout runs. When the user finishes (or
   // cancels), `browserFinished` fires: close the modal and refetch billing
   // summary so the balance reflects the completed top-up.
   useEffect(() => {
-    return openUrlFinishedListener(() => {
-      onOpenChange(false);
-      void queryClient.invalidateQueries(
-        organizationsBillingSummaryRetrieveOptions(),
-      );
-      onCheckoutReturn?.();
-    });
-  }, [onOpenChange, queryClient, onCheckoutReturn]);
+    return openUrlFinishedListener(handleCheckoutReturn);
+  }, [handleCheckoutReturn]);
+
+  // Electron has no equivalent signal: `openUrl` hands the URL to the *system*
+  // browser and `browserFinished` is Capacitor-only, so without this the app
+  // never learns the user came back — the modal sits open and anything latched
+  // off the pre-top-up balance stays stale. Regaining window focus after we
+  // launched checkout is the available proxy. Plain web needs nothing: its
+  // `openUrl` navigates the same tab, so returning remounts the app.
+  useEffect(() => {
+    if (!isElectron()) {
+      return;
+    }
+    const onFocus = () => {
+      if (!checkoutLaunchedRef.current) {
+        return;
+      }
+      // One-shot: a later refocus is just the user using the app.
+      checkoutLaunchedRef.current = false;
+      handleCheckoutReturn();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [handleCheckoutReturn]);
 
   const handleAddFunds = () => {
     if (checkoutMutation.isPending) {
@@ -132,6 +161,7 @@ export function AddCreditsModal({
           // On native (iOS), open in SFSafariViewController so the user stays
           // inside the app and Stripe's redirect back to return_path lands in
           // the in-app browser rather than breaking out to Safari.
+          checkoutLaunchedRef.current = true;
           void openUrl(data.checkout_url);
         },
       },

--- a/clients/web/src/components/add-credits-modal.tsx
+++ b/clients/web/src/components/add-credits-modal.tsx
@@ -1,4 +1,3 @@
-
 import { AlertCircle, ChevronRight, Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link, useLocation, useSearchParams } from "react-router";
@@ -6,8 +5,8 @@ import { Link, useLocation, useSearchParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
-    organizationsBillingSummaryRetrieveOptions,
-    organizationsBillingTopUpsCheckoutSessionCreateMutation,
+  organizationsBillingSummaryRetrieveOptions,
+  organizationsBillingTopUpsCheckoutSessionCreateMutation,
 } from "@/generated/api/@tanstack/react-query.gen";
 import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
 import { routes } from "@/utils/routes";
@@ -16,8 +15,16 @@ import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Modal } from "@vellumai/design-library/components/modal";
 
 const DEFAULT_TOP_UP_AMOUNTS: [string, ...string[]] = [
-  "10.00", "20.00", "30.00", "40.00", "50.00",
-  "60.00", "70.00", "80.00", "90.00", "100.00",
+  "10.00",
+  "20.00",
+  "30.00",
+  "40.00",
+  "50.00",
+  "60.00",
+  "70.00",
+  "80.00",
+  "90.00",
+  "100.00",
 ];
 
 function formatCredits(value: string): string {
@@ -49,9 +56,26 @@ function extractCheckoutError(error: unknown): string {
 interface AddCreditsModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /**
+   * The top-up flow returned from the external checkout browser. Fires on
+   * cancel as well as success — the outcome isn't observable from here, only
+   * that the user is back — so callers must treat it as "re-check billing
+   * state", not "payment succeeded".
+   *
+   * Exists because on the native/Electron path the app state survives checkout:
+   * anything a caller latched off the *old* balance (e.g. a surface disabled
+   * because credits ran out) would otherwise stay stale until something else
+   * happened to clear it. On web, checkout navigates away and the app remounts
+   * fresh, so there is nothing to reconcile.
+   */
+  onCheckoutReturn?: () => void;
 }
 
-export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
+export function AddCreditsModal({
+  open,
+  onOpenChange,
+  onCheckoutReturn,
+}: AddCreditsModalProps) {
   const queryClient = useQueryClient();
   const { pathname } = useLocation();
   const [searchParams] = useSearchParams();
@@ -63,16 +87,15 @@ export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
     organizationsBillingSummaryRetrieveOptions(),
   );
 
-  const topUpAmounts =
-    summary?.allowed_top_up_amounts?.length
-      ? summary.allowed_top_up_amounts
-      : DEFAULT_TOP_UP_AMOUNTS;
+  const topUpAmounts = summary?.allowed_top_up_amounts?.length
+    ? summary.allowed_top_up_amounts
+    : DEFAULT_TOP_UP_AMOUNTS;
 
   const [selectedAmount, setSelectedAmount] = useState<string | null>(null);
   const amount =
     selectedAmount && topUpAmounts.includes(selectedAmount)
       ? selectedAmount
-      : topUpAmounts[0] ?? DEFAULT_TOP_UP_AMOUNTS[0];
+      : (topUpAmounts[0] ?? DEFAULT_TOP_UP_AMOUNTS[0]);
 
   const checkoutMutation = useMutation(
     organizationsBillingTopUpsCheckoutSessionCreateMutation(),
@@ -88,8 +111,9 @@ export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
       void queryClient.invalidateQueries(
         organizationsBillingSummaryRetrieveOptions(),
       );
+      onCheckoutReturn?.();
     });
-  }, [onOpenChange, queryClient]);
+  }, [onOpenChange, queryClient, onCheckoutReturn]);
 
   const handleAddFunds = () => {
     if (checkoutMutation.isPending) {

--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -7,14 +7,7 @@
  * listeners) live here so they don't execute during non-active states.
  */
 
-import {
-  lazy,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
@@ -33,6 +26,7 @@ import type { TranscriptHandle } from "@/domains/chat/transcript/transcript";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import type { UIContext } from "@/domains/chat/turn-selectors";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { getChatBillingBannerDecision } from "@/domains/chat/utils/error-classification";
 
 import { peekPendingPreChatContext } from "@/domains/onboarding/prechat";
 
@@ -97,7 +91,9 @@ import type { ChatMainPanelProps } from "@/domains/chat/components/chat-route-co
 export function ActiveChatView() {
   const showLlmInspector = useCanUseLlmInspector();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { conversationId: urlConversationId } = useParams<{ conversationId?: string }>();
+  const { conversationId: urlConversationId } = useParams<{
+    conversationId?: string;
+  }>();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const assistantState = useAssistantLifecycleStore.use.assistantState();
   const turnPhase = useTurnStore.use.phase();
@@ -112,6 +108,20 @@ export function ActiveChatView() {
   const [refreshEpoch, setRefreshEpoch] = useState(0);
   const [assetsRefreshKey, setAssetsRefreshKey] = useState(0);
   const [showAddCreditsModal, setShowAddCreditsModal] = useState(false);
+
+  // Returning from checkout invalidates the billing queries, but the chat error
+  // that raised the paywall is client state and would survive — leaving the
+  // billing banner painted and voice entry disabled against a balance that may
+  // now be fine. Drop it and let the next turn re-raise the wall if it is still
+  // there; a stale block is worse than one wasted turn. Only billing errors are
+  // cleared, so an unrelated error under the modal is left alone.
+  const clearBillingChatError = useCallback(() => {
+    useChatSessionStore
+      .getState()
+      .setError((prev) =>
+        getChatBillingBannerDecision(prev) !== null ? null : prev,
+      );
+  }, []);
 
   // -------------------------------------------------------------------------
   // Zustand store selectors
@@ -131,12 +141,14 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   // Pin-sync side-effect
   // -------------------------------------------------------------------------
-  useActiveAppPinSync(useCallback((appId: string) => {
-    const didClose = useViewerStore.getState().handleAppUnpinned(appId);
-    if (didClose) {
-      useConversationStore.getState().setEditingConversationId(null);
-    }
-  }, []));
+  useActiveAppPinSync(
+    useCallback((appId: string) => {
+      const didClose = useViewerStore.getState().handleAppUnpinned(appId);
+      if (didClose) {
+        useConversationStore.getState().setEditingConversationId(null);
+      }
+    }, []),
+  );
 
   // -------------------------------------------------------------------------
   // Shared refs — owned here, read/written by hooks
@@ -169,7 +181,7 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   const reachability = useAssistantReachability(assistantId);
   const reachabilityReadyEpoch = useMemo(() => {
-    if (reachability.state.phase === "ready") return refreshEpoch + 1;
+    if (reachability.state.phase === "ready") {return refreshEpoch + 1;}
     return 0;
   }, [reachability.state.phase, refreshEpoch]);
 
@@ -264,7 +276,8 @@ export function ActiveChatView() {
     assistantStateKind: assistantState.kind,
     activeConversationId,
     conversationExistsOnServer,
-    latestPageOldestTimestamp: historyResult.pagination.latestPageOldestTimestamp,
+    latestPageOldestTimestamp:
+      historyResult.pagination.latestPageOldestTimestamp,
     reachability,
     setAssetsRefreshKey,
   });
@@ -301,7 +314,8 @@ export function ActiveChatView() {
     sendMessage,
     reachabilityPhase: reachability.state.phase,
     reachabilityProbe: reachability.probe,
-    getPendingInitialMessage: () => peekPendingPreChatContext()?.initialMessage ?? undefined,
+    getPendingInitialMessage: () =>
+      peekPendingPreChatContext()?.initialMessage ?? undefined,
     getPendingInitialMessageHidden: () =>
       peekPendingPreChatContext()?.initialMessageHidden === true,
   });
@@ -325,7 +339,7 @@ export function ActiveChatView() {
   });
 
   useEffect(() => {
-    if (reachability.state.phase !== "failed") return;
+    if (reachability.state.phase !== "failed") {return;}
     useChatSessionStore.getState().setError({
       message: "Connection lost. Please try again.",
     });
@@ -337,8 +351,8 @@ export function ActiveChatView() {
   const pendingFollowupMessage =
     useOnboardingFocusStore.use.pendingFollowupMessage();
   useEffect(() => {
-    if (!pendingFollowupMessage) return;
-    if (isSending(useTurnStore.getState().phase)) return;
+    if (!pendingFollowupMessage) {return;}
+    if (isSending(useTurnStore.getState().phase)) {return;}
     useOnboardingFocusStore.getState().clearFollowup();
     void sendMessage(pendingFollowupMessage);
   }, [pendingFollowupMessage, sendMessage]);
@@ -362,7 +376,7 @@ export function ActiveChatView() {
       lifecycleService.clearExpectingFirstMessage();
       return;
     }
-    if (isSending(useTurnStore.getState().phase)) return;
+    if (isSending(useTurnStore.getState().phase)) {return;}
     lifecycleService.markExpectingFirstMessage();
     void sendMessage(message);
   }, [sendMessage]);
@@ -421,14 +435,15 @@ export function ActiveChatView() {
   // `onSummarizeUpToHere`, so the hover button never renders and the dialog
   // is unreachable.
   const supportsSummarizeUpToHere = useSupportsSummarizeUpToHere();
-  const [pendingSummarizeMessageId, setPendingSummarizeMessageId] =
-    useState<string | null>(null);
+  const [pendingSummarizeMessageId, setPendingSummarizeMessageId] = useState<
+    string | null
+  >(null);
   const [summarizePending, setSummarizePending] = useState(false);
   const handleSummarizeUpToHere = useCallback((messageId: string) => {
     setPendingSummarizeMessageId(messageId);
   }, []);
   const handleConfirmSummarize = useCallback(() => {
-    if (!pendingSummarizeMessageId) return;
+    if (!pendingSummarizeMessageId) {return;}
     setSummarizePending(true);
     // Errors toast inside the handler; the dialog just closes.
     void handleSummarizeUpToMessage(pendingSummarizeMessageId).finally(() => {
@@ -568,6 +583,7 @@ export function ActiveChatView() {
           <AddCreditsModal
             open={showAddCreditsModal}
             onOpenChange={setShowAddCreditsModal}
+            onCheckoutReturn={clearBillingChatError}
           />
         </LazyBoundary>
       ) : null}

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -533,6 +533,7 @@ beforeEach(() => {
   // The voice entry point gates on the chat session error (a billing wall
   // disables it), so clear it or a billing case leaks into later renders.
   useChatSessionStore.getState().setError(null);
+  useChatSessionStore.getState().setNotice(null);
 });
 
 /**
@@ -1333,6 +1334,23 @@ describe("ChatComposer — live-voice integration", () => {
     const liveVoice = getByLabelText("Start voice mode") as HTMLButtonElement;
     expect(liveVoice.disabled).toBe(true);
     expect(liveVoice.title).toBe("Out of credits — add credits to use voice");
+  });
+
+  test("a billing NOTICE disables voice too — same source the banner uses", () => {
+    // The banner renders off `error ?? notice`, so gating on `error` alone would
+    // leave voice enabled underneath a visible paywall.
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    useChatSessionStore.getState().setNotice({
+      message: "You've run out of credits.",
+      errorCategory: "credits_exhausted",
+    });
+
+    const { getByLabelText } = renderVoiceComposer();
+
+    expect(
+      (getByLabelText("Start voice mode") as HTMLButtonElement).disabled,
+    ).toBe(true);
   });
 
   test("voice entry is open again once the billing error clears", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -1281,6 +1281,26 @@ describe("ChatComposer — live-voice integration", () => {
     expect(useLiveVoiceStore.getState().error).toBeNull();
   });
 
+  test("a billing failure suppresses the generic notice — the banner owns that surface", () => {
+    // GIVEN a session that failed on credits. The controller mirrors this into
+    // the chat session store, where the orchestration stack's billing banner
+    // (with its "Add credits" CTA) renders it.
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    seedLiveVoiceSession("listening");
+    useLiveVoiceStore
+      .getState()
+      .fail("You've run out of credits.", "credits_exhausted");
+
+    // WHEN the composer renders
+    const { queryByText, queryByLabelText } = renderVoiceComposer();
+
+    // THEN it does not also render the plain error Notice — one surface, not
+    // two, and the one the user gets has an actionable CTA.
+    expect(queryByText("You've run out of credits.")).toBeNull();
+    expect(queryByLabelText("Dismiss")).toBeNull();
+  });
+
   test("no live-voice error notice while idle or without an error", () => {
     // GIVEN the flag is on with an idle session and no error
     useTurnStore.setState(INITIAL_TURN_STATE);

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -13,7 +13,10 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createRef } from "react";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 
-import { type ChatAttachment, useComposerStore } from "@/domains/chat/composer-store";
+import {
+  type ChatAttachment,
+  useComposerStore,
+} from "@/domains/chat/composer-store";
 import type { VoiceInputButtonHandle } from "@/domains/chat/components/voice-input-button";
 import type { LiveVoicePreflightVerdict } from "@/domains/chat/voice/live-voice/live-voice-preflight-api";
 import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
@@ -28,6 +31,7 @@ import {
   shouldSubmitOnEnter,
 } from "@/domains/chat/components/chat-composer/chat-composer-utils";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 
 let mockIsMobile = false;
 mock.module("@/hooks/use-is-mobile", () => ({
@@ -159,7 +163,9 @@ mock.module("@/domains/chat/voice/voice-recording-store", () => ({
 // room; mock it so no real daemon call is made and the verdict is controllable
 // per-test. Defaults to `ready` so every existing entry-point test keeps
 // starting the session. The not-ready cases below flip `mockPreflightVerdict`.
-let mockPreflightVerdict: LiveVoicePreflightVerdict | null = { status: "ready" };
+let mockPreflightVerdict: LiveVoicePreflightVerdict | null = {
+  status: "ready",
+};
 const preflightSpy = mock(
   (_assistantId: string): Promise<LiveVoicePreflightVerdict | null> =>
     Promise.resolve(mockPreflightVerdict),
@@ -216,15 +222,21 @@ function resetLiveVoiceMocks() {
 // voice-input-button imports) resolve against the mocked modules. The pure
 // helpers (computeGhostSuffix / shouldSubmitOnEnter) come from
 // `chat-composer-utils`, imported statically above.
-const { ChatComposer } = await import(
-  "@/domains/chat/components/chat-composer/chat-composer"
-);
+const { ChatComposer } =
+  await import("@/domains/chat/components/chat-composer/chat-composer");
 
 // ---------------------------------------------------------------------------
 // shouldSubmitOnEnter — keyboard policy
 // ---------------------------------------------------------------------------
 
-const ENTER = { key: "Enter", shiftKey: false, metaKey: false, ctrlKey: false, isComposing: false, keyCode: 13 };
+const ENTER = {
+  key: "Enter",
+  shiftKey: false,
+  metaKey: false,
+  ctrlKey: false,
+  isComposing: false,
+  keyCode: 13,
+};
 const ENTER_WITH_SHIFT = { ...ENTER, shiftKey: true };
 const ENTER_DURING_IME = { ...ENTER, isComposing: true };
 const ENTER_IME_KEYCODE = { ...ENTER, keyCode: 229 };
@@ -329,7 +341,14 @@ describe("shouldSubmitOnEnter — non-Enter keys", () => {
   test("Space is ignored (key !== 'Enter')", () => {
     expect(
       shouldSubmitOnEnter(
-        { key: " ", shiftKey: false, metaKey: false, ctrlKey: false, isComposing: false, keyCode: 32 },
+        {
+          key: " ",
+          shiftKey: false,
+          metaKey: false,
+          ctrlKey: false,
+          isComposing: false,
+          keyCode: 32,
+        },
         false,
         READY_POLICY,
       ),
@@ -349,11 +368,15 @@ describe("shouldSubmitOnEnter — cmdEnterMode=true", () => {
   });
 
   test("Cmd+Enter with content submits", () => {
-    expect(shouldSubmitOnEnter(CMD_ENTER, false, CMD_ENTER_POLICY)).toBe("submit");
+    expect(shouldSubmitOnEnter(CMD_ENTER, false, CMD_ENTER_POLICY)).toBe(
+      "submit",
+    );
   });
 
   test("Ctrl+Enter with content submits (Windows/Linux)", () => {
-    expect(shouldSubmitOnEnter(CTRL_ENTER, false, CMD_ENTER_POLICY)).toBe("submit");
+    expect(shouldSubmitOnEnter(CTRL_ENTER, false, CMD_ENTER_POLICY)).toBe(
+      "submit",
+    );
   });
 
   test("Cmd+Enter when sendDisabled returns 'prevent'", () => {
@@ -376,15 +399,21 @@ describe("shouldSubmitOnEnter — cmdEnterMode=true", () => {
   });
 
   test("Shift+Enter is still ignored in cmdEnterMode", () => {
-    expect(shouldSubmitOnEnter(ENTER_WITH_SHIFT, false, CMD_ENTER_POLICY)).toBe("ignore");
+    expect(shouldSubmitOnEnter(ENTER_WITH_SHIFT, false, CMD_ENTER_POLICY)).toBe(
+      "ignore",
+    );
   });
 
   test("IME composition is still ignored in cmdEnterMode", () => {
-    expect(shouldSubmitOnEnter(ENTER_DURING_IME, false, CMD_ENTER_POLICY)).toBe("ignore");
+    expect(shouldSubmitOnEnter(ENTER_DURING_IME, false, CMD_ENTER_POLICY)).toBe(
+      "ignore",
+    );
   });
 
   test("pointer:coarse is still ignored in cmdEnterMode", () => {
-    expect(shouldSubmitOnEnter(CMD_ENTER, true, CMD_ENTER_POLICY)).toBe("ignore");
+    expect(shouldSubmitOnEnter(CMD_ENTER, true, CMD_ENTER_POLICY)).toBe(
+      "ignore",
+    );
   });
 });
 
@@ -501,6 +530,9 @@ beforeEach(() => {
     stagedQuotes: [],
     replyBubble: null,
   });
+  // The voice entry point gates on the chat session error (a billing wall
+  // disables it), so clear it or a billing case leaks into later renders.
+  useChatSessionStore.getState().setError(null);
 });
 
 /**
@@ -619,7 +651,10 @@ describe("ChatComposer — send/stop button visibility", () => {
   });
 
   test("isAssistantBusy=false keeps the Send button even during awaiting_user_input", () => {
-    useTurnStore.setState({ ...INITIAL_TURN_STATE, phase: "awaiting_user_input" });
+    useTurnStore.setState({
+      ...INITIAL_TURN_STATE,
+      phase: "awaiting_user_input",
+    });
     const html = renderComposer({ isAssistantBusy: false });
     expect(html).toContain('aria-label="Send message"');
     expect(html).not.toContain('aria-label="Stop generating"');
@@ -758,7 +793,7 @@ describe("ChatComposer — attachments strip", () => {
     const html = renderComposer({ chatAttachments: [] });
     // ChatAttachmentsStrip renders nothing when the list is empty — sanity
     // check that no obvious attachment chip markup leaks in.
-    expect(html).not.toContain("aria-label=\"Remove attachment\"");
+    expect(html).not.toContain('aria-label="Remove attachment"');
   });
 
   test("with attachments, renders the strip wrapper", () => {
@@ -1254,9 +1289,7 @@ describe("ChatComposer — live-voice integration", () => {
     expect(queryByRole("group", { name: "Voice session" })).toBeNull();
     expect(getByLabelText("Start voice mode")).toBeTruthy();
     // ...with dictation treated as available again (failed = inactive)
-    const dictation = getByLabelText(
-      "Start voice input",
-    ) as HTMLButtonElement;
+    const dictation = getByLabelText("Start voice input") as HTMLButtonElement;
     expect(dictation.disabled).toBe(false);
   });
 
@@ -1279,6 +1312,39 @@ describe("ChatComposer — live-voice integration", () => {
     // THEN the store is reset back to idle (which clears the error)
     expect(useLiveVoiceStore.getState().state).toBe("idle");
     expect(useLiveVoiceStore.getState().error).toBeNull();
+  });
+
+  test("a billing wall disables voice entry — don't open a room we know will die", () => {
+    // GIVEN the org is out of credits (any failed turn, text or voice, parks
+    // this on the chat session store and paints the billing banner)
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    useChatSessionStore.getState().setError({
+      message: "You've run out of credits.",
+      code: "PROVIDER_BILLING",
+      errorCategory: "credits_exhausted",
+    });
+
+    // WHEN the composer renders
+    const { getByLabelText } = renderVoiceComposer();
+
+    // THEN voice entry is closed, with the reason on hover — a session started
+    // now would open a room that immediately winds back down.
+    const liveVoice = getByLabelText("Start voice mode") as HTMLButtonElement;
+    expect(liveVoice.disabled).toBe(true);
+    expect(liveVoice.title).toBe("Out of credits — add credits to use voice");
+  });
+
+  test("voice entry is open again once the billing error clears", () => {
+    // GIVEN no chat error (the state after any send, which resets it)
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+
+    const { getByLabelText } = renderVoiceComposer();
+
+    const liveVoice = getByLabelText("Start voice mode") as HTMLButtonElement;
+    expect(liveVoice.disabled).toBe(false);
+    expect(liveVoice.title).toBe("Start voice mode");
   });
 
   test("a billing failure suppresses the generic notice — the banner owns that surface", () => {
@@ -1415,7 +1481,9 @@ describe("ChatComposer — live-voice transcript area", () => {
     );
     // ...with a caret, in place of the visually hidden (still-mounted,
     // still-uneditable) textarea
-    expect(region.querySelector('[data-testid="voice-transcript-caret"]')).toBeTruthy();
+    expect(
+      region.querySelector('[data-testid="voice-transcript-caret"]'),
+    ).toBeTruthy();
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
     expect(textarea.className).toContain("hidden");
     expect(textarea.disabled).toBe(true);
@@ -1501,7 +1569,10 @@ describe("ChatComposer — live-voice transcript area", () => {
   // speech. The composer suppresses the ghost while it owns the session.
   test("ghost suffix renders normally with no active session (baseline)", () => {
     // GIVEN an empty draft and a pending autocomplete suggestion, no session
-    const html = renderComposer({ input: "", suggestion: "ghost completion text" });
+    const html = renderComposer({
+      input: "",
+      suggestion: "ghost completion text",
+    });
 
     // THEN the ghost suffix paints into the composer's mirror cell
     expect(html).toContain("ghost completion text");
@@ -1514,7 +1585,9 @@ describe("ChatComposer — live-voice transcript area", () => {
     seedLiveVoiceSession("listening");
 
     // WHEN the composer renders with the suggestion present
-    const { container } = renderVoiceComposer({ suggestion: "ghost completion text" });
+    const { container } = renderVoiceComposer({
+      suggestion: "ghost completion text",
+    });
 
     // THEN the ghost is gone — the shared grid cell is left for the streaming
     // transcript, not the suggestion overlay

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -30,6 +30,7 @@ import { VoiceComposerBar } from "@/domains/chat/components/chat-composer/voice-
 import { VoiceLiveTranscript } from "@/domains/chat/components/chat-composer/voice-live-transcript";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { getChatBillingBannerDecision } from "@/domains/chat/utils/error-classification";
 import {
     VoiceInputButton,
     type VoiceInputButtonHandle,
@@ -269,6 +270,15 @@ export function ChatComposer({
   // drives it through the store-registered `starter`/`controls` seams.
   const liveVoiceState = useLiveVoiceStore.use.state();
   const liveVoiceError = useLiveVoiceStore.use.error();
+  const liveVoiceErrorCategory = useLiveVoiceStore.use.errorCategory();
+  // A billing failure is already rendered by the orchestration stack's billing
+  // banner (the voice controller mirrors it into the chat session store, the
+  // same place a text turn's `conversation_error` lands). Suppress the generic
+  // voice Notice so the user gets one surface with a working CTA, not two.
+  const liveVoiceFailureIsBilling =
+    getChatBillingBannerDecision({
+      errorCategory: liveVoiceErrorCategory ?? undefined,
+    }) !== null;
   // Whether any session is live anywhere (this thread or another). `failed`
   // is a retryable/inactive state, so it must count as inactive — otherwise
   // dictation would stay unavailable after a failed start.
@@ -575,13 +585,16 @@ export function ChatComposer({
           Keyed on the session state (not entry eligibility) for the same
           reason as `isLiveVoiceActive`: a session that fails right after an
           eligibility drop must still surface its error. */}
-      {showVoiceInput && liveVoiceState === "failed" && liveVoiceError && (
-        <div className="mb-2">
-          <Notice tone="error" onDismiss={dismissLiveVoiceFailure}>
-            {liveVoiceError}
-          </Notice>
-        </div>
-      )}
+      {showVoiceInput &&
+        liveVoiceState === "failed" &&
+        liveVoiceError &&
+        !liveVoiceFailureIsBilling && (
+          <div className="mb-2">
+            <Notice tone="error" onDismiss={dismissLiveVoiceFailure}>
+              {liveVoiceError}
+            </Notice>
+          </div>
+        )}
       {/* Pre-open "configure voice" prompt — surfaced when the readiness
           preflight returns `not-ready` (no usable STT/TTS provider that
           couldn't be auto-configured). The room stays closed; the action

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -1,27 +1,27 @@
 import { ArrowUp, Square } from "lucide-react";
 import {
-    type FormEvent,
-    type ReactNode,
-    type RefObject,
-    useCallback,
-    useEffect,
-    useLayoutEffect,
-    useMemo,
-    useRef,
-    useState,
+  type FormEvent,
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
 } from "react";
 import { flushSync } from "react-dom";
 import { useNavigate } from "react-router";
 
 import {
-    AttachFileButton,
-    ChatAttachmentsStrip,
+  AttachFileButton,
+  ChatAttachmentsStrip,
 } from "@/domains/chat/components/chat-attachments/chat-attachments";
 import {
-    selectPathReferencePaths,
-    selectUploadedIds,
-    selectUploadingCount,
-    useComposerStore,
+  selectPathReferencePaths,
+  selectUploadedIds,
+  selectUploadingCount,
+  useComposerStore,
 } from "@/domains/chat/composer-store";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
@@ -31,22 +31,23 @@ import { VoiceLiveTranscript } from "@/domains/chat/components/chat-composer/voi
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { getChatBillingBannerDecision } from "@/domains/chat/utils/error-classification";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import {
-    VoiceInputButton,
-    type VoiceInputButtonHandle,
+  VoiceInputButton,
+  type VoiceInputButtonHandle,
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import {
-    dismissLiveVoiceFailure,
-    endLiveVoiceSession,
-    getLiveVoiceInputAmplitude,
-    isLiveVoiceSessionActive,
-    releaseLiveVoiceTurn,
-    setLiveVoiceEntryOrigin,
-    setLiveVoiceMuted,
-    stopLiveVoiceResponse,
-    useIsLiveVoiceSessionOwnedBy,
-    useLiveVoiceStore,
+  dismissLiveVoiceFailure,
+  endLiveVoiceSession,
+  getLiveVoiceInputAmplitude,
+  isLiveVoiceSessionActive,
+  releaseLiveVoiceTurn,
+  setLiveVoiceEntryOrigin,
+  setLiveVoiceMuted,
+  stopLiveVoiceResponse,
+  useIsLiveVoiceSessionOwnedBy,
+  useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { preflightLiveVoice } from "@/domains/chat/voice/live-voice/live-voice-preflight-api";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
@@ -62,20 +63,25 @@ import { routes } from "@/utils/routes";
 import { Button, Notice, Popover } from "@vellumai/design-library";
 
 import {
-    computeGhostSuffix,
-    shouldSubmitOnEnter,
+  computeGhostSuffix,
+  shouldSubmitOnEnter,
 } from "@/domains/chat/components/chat-composer/chat-composer-utils";
-import { EMOJI_MIN_FILTER_LENGTH, EMOJI_TRIGGER_RE, type EmojiEntry, useEmojiSearch } from "@/domains/chat/components/chat-composer/emoji-catalog";
+import {
+  EMOJI_MIN_FILTER_LENGTH,
+  EMOJI_TRIGGER_RE,
+  type EmojiEntry,
+  useEmojiSearch,
+} from "@/domains/chat/components/chat-composer/emoji-catalog";
 import { EmojiPickerPopup } from "@/domains/chat/components/chat-composer/emoji-picker-popup";
 import {
-    applyMarkdownFormatting,
-    matchFormattingShortcut,
+  applyMarkdownFormatting,
+  matchFormattingShortcut,
 } from "@/domains/chat/components/chat-composer/markdown-formatting";
 import {
-    SLASH_PREFIX_RE,
-    type SlashCommand,
-    filteredCommands,
-    selectedInputText,
+  SLASH_PREFIX_RE,
+  type SlashCommand,
+  filteredCommands,
+  selectedInputText,
 } from "@/domains/chat/components/chat-composer/slash-command-catalog";
 import { SlashCommandPopup } from "@/domains/chat/components/chat-composer/slash-command-popup";
 import { useTextPopup } from "@/domains/chat/components/chat-composer/use-text-popup";
@@ -238,7 +244,8 @@ export function ChatComposer({
       selectPathReferencePaths(attachments).length > 0);
 
   const voicePhase = useVoiceRecordingStore.use.phase();
-  const isVoiceActive = voicePhase === "recording" || voicePhase === "processing";
+  const isVoiceActive =
+    voicePhase === "recording" || voicePhase === "processing";
   // Holds the MediaStream opened by VoiceInputButton so we can reuse it for
   // amplitude analysis rather than opening a second getUserMedia request.
   const voiceStreamRef = useRef<MediaStream | null>(null);
@@ -279,6 +286,13 @@ export function ChatComposer({
     getChatBillingBannerDecision({
       errorCategory: liveVoiceErrorCategory ?? undefined,
     }) !== null;
+  // A billing wall blocks the whole turn, not just one leg, so a voice session
+  // started now is guaranteed to die. Disable entry instead of opening a room
+  // that immediately winds down — the billing banner sitting above the composer
+  // already explains it and carries the CTA. Self-clearing: any send resets the
+  // chat error (see `use-send-message`), so this can never strand the button.
+  const chatError = useChatSessionStore.use.error();
+  const billingBlocksVoice = getChatBillingBannerDecision(chatError) !== null;
   // Whether any session is live anywhere (this thread or another). `failed`
   // is a retryable/inactive state, so it must count as inactive — otherwise
   // dictation would stay unavailable after a failed start.
@@ -313,8 +327,8 @@ export function ChatComposer({
   // by `VoiceLiveTranscript`, which subscribes to the store on its own,
   // keeping the composer's deliberate opt-out of high-frequency live-voice
   // updates (amplitude ticks, transcript deltas) intact.
-  const hasLiveVoiceTranscript = useLiveVoiceStore(
-    (s) => Boolean(s.partialTranscript || s.finalTranscript),
+  const hasLiveVoiceTranscript = useLiveVoiceStore((s) =>
+    Boolean(s.partialTranscript || s.finalTranscript),
   );
   // The in-composer transcript shows the *user's* own speech, so it must
   // honor the "Show the words you say" voice preference (default OFF). When
@@ -526,10 +540,8 @@ export function ChatComposer({
     phase === "queued" || phase === "thinking" || phase === "streaming";
   const showInlineVoicePreview =
     isVoiceActive && !isLocallyGenerating && !isElectronHost;
-  const hideTextareaForVoice =
-    isNative && showInlineVoicePreview;
-  const hasStagedQuotes =
-    useQuoteReplyStore.use.stagedQuotes().length > 0;
+  const hideTextareaForVoice = isNative && showInlineVoicePreview;
+  const hasStagedQuotes = useQuoteReplyStore.use.stagedQuotes().length > 0;
   const canSendMessageContent =
     Boolean(input.trim()) || canSendAttachments || hasStagedQuotes;
   // Voice mode occupies the send slot while there is nothing to send: the
@@ -539,7 +551,10 @@ export function ChatComposer({
   // send arrow — byte-identical to before — whenever voice mode is unavailable.
   const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
   const showVoiceModeInSendSlot =
-    showVoiceInput && Boolean(assistantId) && voiceMode && !canSendMessageContent;
+    showVoiceInput &&
+    Boolean(assistantId) &&
+    voiceMode &&
+    !canSendMessageContent;
 
   const ghostSuffix = useMemo(
     () =>
@@ -674,7 +689,10 @@ export function ChatComposer({
                   // restored draft — retire the "draft restored" marker (and its
                   // notice). Keeps `restoredDraftConversationId` an accurate
                   // signal for "unedited restored draft" (see use-deep-link-consumer).
-                  if (useComposerStore.getState().restoredDraftConversationId !== null) {
+                  if (
+                    useComposerStore.getState().restoredDraftConversationId !==
+                    null
+                  ) {
                     useComposerStore.getState().clearRestoredDraftNotice();
                   }
                 }}
@@ -853,7 +871,9 @@ export function ChatComposer({
               // overlay bridge no-ops there.
               <div
                 className={hideTextareaForVoice ? "px-2 pt-3" : "px-2"}
-                aria-label={voicePhase === "processing" ? "Transcribing" : "Recording"}
+                aria-label={
+                  voicePhase === "processing" ? "Transcribing" : "Recording"
+                }
                 aria-live="polite"
               >
                 <StreamingWaveform
@@ -920,7 +940,9 @@ export function ChatComposer({
                             <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
                           }
                           type="submit"
-                          disabled={sendDisabled || attachmentsUploadingCount > 0}
+                          disabled={
+                            sendDisabled || attachmentsUploadingCount > 0
+                          }
                           title={
                             sendDisabled
                               ? "Type a message to send"
@@ -975,7 +997,13 @@ export function ChatComposer({
                             disabled={
                               typingDisabled ||
                               isVoiceActive ||
-                              isLiveVoiceSessionLive
+                              isLiveVoiceSessionLive ||
+                              billingBlocksVoice
+                            }
+                            disabledReason={
+                              billingBlocksVoice
+                                ? "Out of credits — add credits to use voice"
+                                : undefined
                             }
                           />
                         ) : (

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -291,8 +291,14 @@ export function ChatComposer({
   // that immediately winds down — the billing banner sitting above the composer
   // already explains it and carries the CTA. Self-clearing: any send resets the
   // chat error (see `use-send-message`), so this can never strand the button.
+  // Both sources, matching what the billing banner renders from (`error ??
+  // notice`): gating on `error` alone would leave voice enabled underneath a
+  // visible paywall whenever the wall arrived as a non-terminal notice.
   const chatError = useChatSessionStore.use.error();
-  const billingBlocksVoice = getChatBillingBannerDecision(chatError) !== null;
+  const chatNotice = useChatSessionStore.use.notice();
+  const billingBlocksVoice =
+    getChatBillingBannerDecision(chatError) !== null ||
+    getChatBillingBannerDecision(chatNotice) !== null;
   // Whether any session is live anywhere (this thread or another). `failed`
   // is a retryable/inactive state, so it must count as inactive — otherwise
   // dictation would stay unavailable after a failed start.

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -404,11 +404,16 @@ export function ChatMainPanel({
    */
   const onBillingRemediation = useCallback(
     (action: () => void) => () => {
-      useChatSessionStore
-        .getState()
-        .setError((prev) =>
-          getChatBillingBannerDecision(prev) !== null ? null : prev,
-        );
+      // Both sources, because the banner renders off `error ?? notice` — a
+      // billing-shaped `notice` (e.g. a non-terminal `conversation_notice`)
+      // would otherwise keep the paywall painted after the CTA was engaged.
+      const state = useChatSessionStore.getState();
+      state.setError((prev) =>
+        getChatBillingBannerDecision(prev) !== null ? null : prev,
+      );
+      state.setNotice((prev) =>
+        getChatBillingBannerDecision(prev) !== null ? null : prev,
+      );
       action();
     },
     [],

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -387,6 +387,33 @@ export function ChatMainPanel({
     void navigate(routes.plans);
   }, [navigate]);
 
+  /**
+   * Wrap a billing banner's CTA so acting on it also drops the billing error
+   * that raised the banner.
+   *
+   * The error is client state that outlives the remediation: the user tops up,
+   * raises their limit, or fixes a provider key, comes back, and it is still
+   * latched — keeping the banner painted and any surface gated on it (voice
+   * entry) disabled against billing that may now be fine. Enumerating the
+   * return path per CTA is fragile — there is one for a modal, one per settings
+   * route, one for the plans takeover — so hang it off the single act every
+   * remediation shares: engaging the CTA.
+   *
+   * Worst case the wall was real and the next turn re-raises it, which beats a
+   * surface stuck off with no way back but a text message.
+   */
+  const onBillingRemediation = useCallback(
+    (action: () => void) => () => {
+      useChatSessionStore
+        .getState()
+        .setError((prev) =>
+          getChatBillingBannerDecision(prev) !== null ? null : prev,
+        );
+      action();
+    },
+    [],
+  );
+
   const checkAssistant = useCallback(() => lifecycleService.checkAssistant(), []);
 
   const handleDismissUnknownNudge = useCallback(
@@ -1006,15 +1033,21 @@ export function ChatMainPanel({
           onOpenTextInsertionSettings={handleOpenTextInsertionSettings}
           billingBannerSlot={
             billingBannerDecision === "daily_limit" ? (
-              <DailyLimitBanner onAdjustLimit={pushToBillingSettings} />
+              <DailyLimitBanner
+                onAdjustLimit={onBillingRemediation(pushToBillingSettings)}
+              />
             ) : billingBannerDecision === "managed_credits" ? (
               <CreditsExhaustedBanner
                 mode={creditPaywallMode}
-                onAddCredits={() => setShowAddCreditsModal(true)}
-                onUpgrade={pushToPlansTakeover}
+                onAddCredits={onBillingRemediation(() =>
+                  setShowAddCreditsModal(true),
+                )}
+                onUpgrade={onBillingRemediation(pushToPlansTakeover)}
               />
             ) : billingBannerDecision === "provider_billing" ? (
-              <ProviderBillingBanner onOpenSettings={pushToAiSettings} />
+              <ProviderBillingBanner
+                onOpenSettings={onBillingRemediation(pushToAiSettings)}
+              />
             ) : null
           }
           diskPressureBanner={diskPressureBannerSlot}

--- a/clients/web/src/domains/chat/components/live-voice-button.tsx
+++ b/clients/web/src/domains/chat/components/live-voice-button.tsx
@@ -31,11 +31,20 @@ interface LiveVoiceButtonProps {
   onStart: (origin?: { x: number; y: number }) => void;
   /** Disable the control (e.g. while dictation is recording). */
   disabled?: boolean;
+  /**
+   * Why the control is disabled, shown as its tooltip. Without this a disabled
+   * voice button is a dead control with no explanation — the caller knows the
+   * reason (out of credits, dictation running), this surfaces it on hover.
+   * Ignored unless `disabled`; the accessible name stays "Start voice mode" so
+   * the control keeps one stable identity.
+   */
+  disabledReason?: string;
 }
 
 export function LiveVoiceButton({
   onStart,
   disabled = false,
+  disabledReason,
 }: LiveVoiceButtonProps) {
   const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
 
@@ -51,11 +60,14 @@ export function LiveVoiceButton({
       iconOnly={<AudioLines strokeWidth={2} />}
       onClick={(event) => {
         const rect = event.currentTarget.getBoundingClientRect();
-        onStart({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+        onStart({
+          x: rect.left + rect.width / 2,
+          y: rect.top + rect.height / 2,
+        });
       }}
       disabled={disabled}
       aria-label="Start voice mode"
-      title="Start voice mode"
+      title={(disabled && disabledReason) || "Start voice mode"}
     />
   );
 }

--- a/clients/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -84,12 +84,12 @@ mock.module("@/utils/voice-input-device", () => ({
 // Capture the command handler map the component registers so tests can
 // deliver the escape monitor's `cancelDictation` relay directly (the real
 // hook is an Electron IPC subscription and no-ops in this environment).
-const commandHandlers: Record<string, ((command: unknown) => void) | undefined> =
-  {};
+const commandHandlers: Record<
+  string,
+  ((command: unknown) => void) | undefined
+> = {};
 mock.module("@/runtime/vellum-commands", () => ({
-  useVellumCommands: (
-    handlers: Record<string, (command: unknown) => void>,
-  ) => {
+  useVellumCommands: (handlers: Record<string, (command: unknown) => void>) => {
     Object.assign(commandHandlers, handlers);
   },
 }));
@@ -105,17 +105,14 @@ class FakeMediaRecorder {
   onstop: (() => void) | null = null;
   onerror: (() => void) | null = null;
 
-  constructor(
-    _stream: unknown,
-    _options?: unknown,
-  ) {}
+  constructor(_stream: unknown, _options?: unknown) {}
 
   start(): void {
     this.state = "recording";
   }
 
   stop(): void {
-    if (this.state === "inactive") return;
+    if (this.state === "inactive") {return;}
     this.state = "inactive";
     this.ondataavailable?.({
       data: new Blob(["audio"], { type: "audio/webm;codecs=opus" }),
@@ -139,12 +136,14 @@ Object.defineProperty(navigator, "mediaDevices", {
 // Imported after the mocks so the component resolves against them. The
 // recording store is intentionally real — phase transitions are part of the
 // behavior under test.
-const { VoiceInputButton } = await import(
-  "@/domains/chat/components/voice-input-button"
-);
-const { useVoiceRecordingStore } = await import(
-  "@/domains/chat/voice/voice-recording-store"
-);
+const { VoiceInputButton } =
+  await import("@/domains/chat/components/voice-input-button");
+const { useVoiceRecordingStore } =
+  await import("@/domains/chat/voice/voice-recording-store");
+const { errorCodeForReason } =
+  await import("@/domains/chat/components/voice-input-button");
+const { formatVoiceError } = await import("@/domains/chat/utils/chat");
+type SttFailureReason = import("@/domains/chat/voice/stt-api").SttFailureReason;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -380,8 +379,7 @@ describe("VoiceInputButton — native partials fallback", () => {
 
   test("waits for empty native final when stop races native startup", async () => {
     let resolveNativeStart:
-      | ((stop: (() => Promise<string | null>) | null) => void)
-      | null = null;
+      ((stop: (() => Promise<string | null>) | null) => void) | null = null;
     nativePartialsImpl = () =>
       new Promise<(() => Promise<string | null>) | null>((resolve) => {
         resolveNativeStart = resolve;
@@ -413,8 +411,7 @@ describe("VoiceInputButton — native partials fallback", () => {
 
   test("configuration errors still surface when native startup resolves unavailable after stop", async () => {
     let resolveNativeStart:
-      | ((stop: (() => Promise<string | null>) | null) => void)
-      | null = null;
+      ((stop: (() => Promise<string | null>) | null) => void) | null = null;
     nativePartialsImpl = () =>
       new Promise<(() => Promise<string | null>) | null>((resolve) => {
         resolveNativeStart = resolve;
@@ -602,5 +599,44 @@ describe("VoiceInputButton — forced native provider (macOS Native Dictation)",
     expect(postSttTranscribeSpy).not.toHaveBeenCalled();
     expect(onTranscript).not.toHaveBeenCalled();
     expect(lastBreadcrumb().data.outcome).toBe("error");
+  });
+});
+
+describe("errorCodeForReason", () => {
+  // The taxonomy spans three files — the daemon's HTTP status, the reason
+  // union + `reasonFromHttp` in `stt-api.ts`, and the copy map in
+  // `utils/chat.ts`. A reason that reaches `formatVoiceError` without its own
+  // entry silently degrades to the generic "transcription failed", which is how
+  // an actionable failure loses its remediation. Pin the whole chain.
+  test("every reason maps to a code with real copy", () => {
+    const reasons: SttFailureReason[] = [
+      "config-missing",
+      "audio-rejected",
+      "auth-failed",
+      "rate-limited",
+      "credits-exhausted",
+      "provider-error",
+      "unavailable",
+      "timeout",
+    ];
+    const generic = formatVoiceError("definitely-not-a-real-code");
+
+    for (const reason of reasons) {
+      const copy = formatVoiceError(errorCodeForReason(reason));
+      expect(copy).not.toBe(generic);
+      expect(copy.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("an exhausted balance names credits, not a provider glitch", () => {
+    // The daemon returns 402 for `credits-exhausted`; without a mapping this
+    // reads as "the provider is having trouble — try again", which is wrong
+    // advice for a wall that retrying cannot clear.
+    const copy = formatVoiceError(errorCodeForReason("credits-exhausted"));
+
+    expect(copy).toContain("credits");
+    expect(copy).not.toBe(
+      formatVoiceError(errorCodeForReason("provider-error")),
+    );
   });
 });

--- a/clients/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -84,12 +84,12 @@ mock.module("@/utils/voice-input-device", () => ({
 // Capture the command handler map the component registers so tests can
 // deliver the escape monitor's `cancelDictation` relay directly (the real
 // hook is an Electron IPC subscription and no-ops in this environment).
-const commandHandlers: Record<
-  string,
-  ((command: unknown) => void) | undefined
-> = {};
+const commandHandlers: Record<string, ((command: unknown) => void) | undefined> =
+  {};
 mock.module("@/runtime/vellum-commands", () => ({
-  useVellumCommands: (handlers: Record<string, (command: unknown) => void>) => {
+  useVellumCommands: (
+    handlers: Record<string, (command: unknown) => void>,
+  ) => {
     Object.assign(commandHandlers, handlers);
   },
 }));
@@ -105,14 +105,17 @@ class FakeMediaRecorder {
   onstop: (() => void) | null = null;
   onerror: (() => void) | null = null;
 
-  constructor(_stream: unknown, _options?: unknown) {}
+  constructor(
+    _stream: unknown,
+    _options?: unknown,
+  ) {}
 
   start(): void {
     this.state = "recording";
   }
 
   stop(): void {
-    if (this.state === "inactive") {return;}
+    if (this.state === "inactive") return;
     this.state = "inactive";
     this.ondataavailable?.({
       data: new Blob(["audio"], { type: "audio/webm;codecs=opus" }),
@@ -136,14 +139,18 @@ Object.defineProperty(navigator, "mediaDevices", {
 // Imported after the mocks so the component resolves against them. The
 // recording store is intentionally real — phase transitions are part of the
 // behavior under test.
-const { VoiceInputButton } =
-  await import("@/domains/chat/components/voice-input-button");
-const { useVoiceRecordingStore } =
-  await import("@/domains/chat/voice/voice-recording-store");
-const { errorCodeForReason } =
-  await import("@/domains/chat/components/voice-input-button");
+const { VoiceInputButton } = await import(
+  "@/domains/chat/components/voice-input-button"
+);
+const { useVoiceRecordingStore } = await import(
+  "@/domains/chat/voice/voice-recording-store"
+);
+const { errorCodeForReason } = await import(
+  "@/domains/chat/components/voice-input-button"
+);
 const { formatVoiceError } = await import("@/domains/chat/utils/chat");
-type SttFailureReason = import("@/domains/chat/voice/stt-api").SttFailureReason;
+type SttFailureReason =
+  import("@/domains/chat/voice/stt-api").SttFailureReason;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -379,7 +386,8 @@ describe("VoiceInputButton — native partials fallback", () => {
 
   test("waits for empty native final when stop races native startup", async () => {
     let resolveNativeStart:
-      ((stop: (() => Promise<string | null>) | null) => void) | null = null;
+      | ((stop: (() => Promise<string | null>) | null) => void)
+      | null = null;
     nativePartialsImpl = () =>
       new Promise<(() => Promise<string | null>) | null>((resolve) => {
         resolveNativeStart = resolve;
@@ -411,7 +419,8 @@ describe("VoiceInputButton — native partials fallback", () => {
 
   test("configuration errors still surface when native startup resolves unavailable after stop", async () => {
     let resolveNativeStart:
-      ((stop: (() => Promise<string | null>) | null) => void) | null = null;
+      | ((stop: (() => Promise<string | null>) | null) => void)
+      | null = null;
     nativePartialsImpl = () =>
       new Promise<(() => Promise<string | null>) | null>((resolve) => {
         resolveNativeStart = resolve;
@@ -603,11 +612,11 @@ describe("VoiceInputButton — forced native provider (macOS Native Dictation)",
 });
 
 describe("errorCodeForReason", () => {
-  // The taxonomy spans three files — the daemon's HTTP status, the reason
-  // union + `reasonFromHttp` in `stt-api.ts`, and the copy map in
-  // `utils/chat.ts`. A reason that reaches `formatVoiceError` without its own
-  // entry silently degrades to the generic "transcription failed", which is how
-  // an actionable failure loses its remediation. Pin the whole chain.
+  // The taxonomy spans three files — the daemon's HTTP status, the reason union
+  // + `reasonFromHttp` in `stt-api.ts`, and the copy map in `utils/chat.ts`. A
+  // reason that reaches `formatVoiceError` without its own entry silently
+  // degrades to the generic "transcription failed", which is how an actionable
+  // failure loses its remediation. Pin the whole chain.
   test("every reason maps to a code with real copy", () => {
     const reasons: SttFailureReason[] = [
       "config-missing",
@@ -629,9 +638,9 @@ describe("errorCodeForReason", () => {
   });
 
   test("an exhausted balance names credits, not a provider glitch", () => {
-    // The daemon returns 402 for `credits-exhausted`; without a mapping this
-    // reads as "the provider is having trouble — try again", which is wrong
-    // advice for a wall that retrying cannot clear.
+    // The daemon returns 402 for `credits-exhausted`; with no mapping this reads
+    // as "the provider is having trouble — try again", which is wrong advice for
+    // a wall that retrying cannot clear.
     const copy = formatVoiceError(errorCodeForReason("credits-exhausted"));
 
     expect(copy).toContain("credits");

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -1,11 +1,12 @@
+
 import { Loader2, Mic, Square } from "lucide-react";
 import {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useSyncExternalStore,
+    forwardRef,
+    useCallback,
+    useEffect,
+    useImperativeHandle,
+    useRef,
+    useSyncExternalStore,
 } from "react";
 import * as Sentry from "@sentry/react";
 
@@ -19,9 +20,9 @@ import {
   type StopNativeDictationPartials,
 } from "@/runtime/native-dictation-partials";
 import {
-  postSttTranscribe,
-  prefersMacosNativeStt,
-  type SttFailureReason,
+    postSttTranscribe,
+    prefersMacosNativeStt,
+    type SttFailureReason,
 } from "@/domains/chat/voice/stt-api";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -44,7 +45,7 @@ import { Button, cn } from "@vellumai/design-library";
  * Returns null if MediaRecorder is unavailable or no supported type is found.
  */
 export function getBestMimeType(): string | null {
-  if (typeof MediaRecorder === "undefined") {return null;}
+  if (typeof MediaRecorder === "undefined") return null;
   const candidates = [
     "audio/webm;codecs=opus",
     "audio/ogg;codecs=opus",
@@ -116,7 +117,7 @@ interface SpeechRecognitionWindow {
  * Exported for unit testing.
  */
 export function getSpeechRecognitionCtor(): SpeechRecognitionConstructor | null {
-  if (typeof window === "undefined") {return null;}
+  if (typeof window === "undefined") return null;
   const w = window as unknown as SpeechRecognitionWindow;
   return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
 }
@@ -140,7 +141,7 @@ export function getSpeechRecognitionCtor(): SpeechRecognitionConstructor | null 
  * signal inside React code.
  */
 export function isBatchSttSupported(): boolean {
-  if (typeof window === "undefined") {return false;}
+  if (typeof window === "undefined") return false;
   return (
     typeof MediaRecorder !== "undefined" &&
     typeof navigator !== "undefined" &&
@@ -191,7 +192,11 @@ export function errorCodeForReason(reason: SttFailureReason): string {
 // ---------------------------------------------------------------------------
 
 type DictationSessionOutcome =
-  "completed" | "empty" | "error" | "cancelled" | "aborted";
+  | "completed"
+  | "empty"
+  | "error"
+  | "cancelled"
+  | "aborted";
 
 interface NativeFinalResult {
   text: string | null;
@@ -321,8 +326,9 @@ export const VoiceInputButton = forwardRef<
   const nativePartialsStopRef = useRef<StopNativeDictationPartials | null>(
     null,
   );
-  const nativePartialsStartRef =
-    useRef<Promise<StopNativeDictationPartials | null> | null>(null);
+  const nativePartialsStartRef = useRef<
+    Promise<StopNativeDictationPartials | null> | null
+  >(null);
   const nativePartialsTextRef = useRef("");
   // Resolves with the recognizer's final transcript of the whole utterance
   // after stopNativePartials — short dictations end before the first
@@ -384,7 +390,7 @@ export const VoiceInputButton = forwardRef<
     const stop = nativePartialsStopRef.current;
     nativePartialsStopRef.current = null;
     const pendingStart = nativePartialsStartRef.current;
-    if (!stop && !pendingStart) {return;}
+    if (!stop && !pendingStart) return;
     // The promise resolves once the helper's recognizer drains the session
     // (dictation.finalized); recorder.onstop awaits it alongside batch STT.
     const final = stop
@@ -393,7 +399,7 @@ export const VoiceInputButton = forwardRef<
           stopRan: true,
         }))
       : pendingStart!.then(async (readyStop) => {
-          if (!readyStop) {return { text: null, stopRan: false };}
+          if (!readyStop) return { text: null, stopRan: false };
           return {
             text: (await readyStop()) ?? null,
             stopRan: true,
@@ -444,7 +450,7 @@ export const VoiceInputButton = forwardRef<
     )
       .then((stop) => {
         // The unavailable case logs its reason in native-dictation-partials.
-        if (!stop) {return null;}
+        if (!stop) return null;
         console.info("dictation: native partials running");
         // The session may have ended while the helper call was in flight.
         if (
@@ -474,7 +480,7 @@ export const VoiceInputButton = forwardRef<
     stopDictationStream();
     stopNativePartials();
     const recorder = mediaRecorderRef.current;
-    if (!recorder) {return;}
+    if (!recorder) return;
     if (recorder.state !== "inactive") {
       try {
         recorder.stop();
@@ -497,7 +503,7 @@ export const VoiceInputButton = forwardRef<
    */
   const cancelRecording = useCallback(() => {
     const recorder = mediaRecorderRef.current;
-    if (!recorder) {return;}
+    if (!recorder) return;
     discardedRef.current = true;
     stopSpeechRecognition();
     stopDictationStream();
@@ -510,7 +516,12 @@ export const VoiceInputButton = forwardRef<
       }
     }
     vsReset();
-  }, [stopSpeechRecognition, stopDictationStream, stopNativePartials, vsReset]);
+  }, [
+    stopSpeechRecognition,
+    stopDictationStream,
+    stopNativePartials,
+    vsReset,
+  ]);
 
   // Esc during recording discards the partial result. Capture phase so it
   // wins over composer/modal Escape handlers while a recording is live. Two
@@ -518,10 +529,10 @@ export const VoiceInputButton = forwardRef<
   // push-to-talk fallback) and both see the shared store phase; the
   // recorder-ownership guard keeps the non-recording instance inert.
   useEffect(() => {
-    if (!recording) {return;}
+    if (!recording) return;
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") {return;}
-      if (!mediaRecorderRef.current) {return;}
+      if (event.key !== "Escape") return;
+      if (!mediaRecorderRef.current) return;
       event.preventDefault();
       event.stopPropagation();
       cancelRecording();
@@ -538,7 +549,7 @@ export const VoiceInputButton = forwardRef<
   // same recorder-ownership guard applies.
   useVellumCommands({
     cancelDictation: () => {
-      if (!mediaRecorderRef.current) {return;}
+      if (!mediaRecorderRef.current) return;
       cancelRecording();
     },
   });
@@ -580,7 +591,7 @@ export const VoiceInputButton = forwardRef<
   ]);
 
   const startRecording = useCallback(async () => {
-    if (mediaRecorderRef.current) {return;}
+    if (mediaRecorderRef.current) return;
     cancelledStartRef.current = false;
     discardedRef.current = false;
     const sessionId = ++sessionIdRef.current;
@@ -631,7 +642,7 @@ export const VoiceInputButton = forwardRef<
           let accumulated = "";
           for (let i = 0; i < event.results.length; i += 1) {
             const result = event.results[i];
-            if (!result?.[0]) {continue;}
+            if (!result?.[0]) continue;
             if (result.isFinal) {
               accumulated += result[0].transcript;
             } else {
@@ -682,7 +693,7 @@ export const VoiceInputButton = forwardRef<
 
     if (cancelledStartRef.current) {
       stopSpeechRecognition();
-      for (const track of stream.getTracks()) {track.stop();}
+      for (const track of stream.getTracks()) track.stop();
       return;
     }
 
@@ -769,8 +780,7 @@ export const VoiceInputButton = forwardRef<
         return;
       }
 
-      const audioBlob =
-        chunks.length > 0 ? new Blob(chunks, { type: mimeType }) : null;
+      const audioBlob = chunks.length > 0 ? new Blob(chunks, { type: mimeType }) : null;
       const abortCtrl = new AbortController();
       transcribeAbortRef.current = abortCtrl;
 
@@ -787,10 +797,7 @@ export const VoiceInputButton = forwardRef<
         let daemonFailure: SttFailureReason | null = null;
         try {
           if (audioBlob && assistantId && !nativeSttForced) {
-            if (
-              typeof navigator !== "undefined" &&
-              navigator.onLine === false
-            ) {
+            if (typeof navigator !== "undefined" && navigator.onLine === false) {
               // Provably offline — don't burn the provider timeout to learn
               // what we already know.
               console.info("dictation: skipping batch STT (offline)");
@@ -861,7 +868,7 @@ export const VoiceInputButton = forwardRef<
 
         // A newer session started while we were awaiting — don't
         // overwrite its voice state with this stale completion.
-        if (sessionIdRef.current !== sessionId) {return;}
+        if (sessionIdRef.current !== sessionId) return;
 
         try {
           if (text) {
@@ -977,12 +984,12 @@ export const VoiceInputButton = forwardRef<
     ref,
     () => ({
       start: () => {
-        if (disabled || !assistantId || !supported) {return;}
+        if (disabled || !assistantId || !supported) return;
         // Refuse to start while the previous session is still transcribing.
         // Mirrors the visual `disabled` + `aria-busy` state on the button
         // and prevents push-to-talk from silently dropping the in-flight
         // transcript by incrementing the session id mid-flight.
-        if (useVoiceRecordingStore.getState().phase === "processing") {return;}
+        if (useVoiceRecordingStore.getState().phase === "processing") return;
         startRecording();
       },
       stop: stopRecording,
@@ -992,7 +999,7 @@ export const VoiceInputButton = forwardRef<
 
   const isNative = useIsNativePlatform();
 
-  if (!renderButton || !supported || !assistantId) {return null;}
+  if (!renderButton || !supported || !assistantId) return null;
 
   // The button has three visible states:
   //   - idle:       mic icon, click to start
@@ -1030,7 +1037,7 @@ export const VoiceInputButton = forwardRef<
         recording ? "[&_svg]:size-5 touch-mobile:[&_svg]:size-5" : undefined
       }
       onClick={() => {
-        if (processing) {return;}
+        if (processing) return;
         if (recording) {
           stopRecording();
         } else {

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -1,12 +1,11 @@
-
 import { Loader2, Mic, Square } from "lucide-react";
 import {
-    forwardRef,
-    useCallback,
-    useEffect,
-    useImperativeHandle,
-    useRef,
-    useSyncExternalStore,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useSyncExternalStore,
 } from "react";
 import * as Sentry from "@sentry/react";
 
@@ -20,9 +19,9 @@ import {
   type StopNativeDictationPartials,
 } from "@/runtime/native-dictation-partials";
 import {
-    postSttTranscribe,
-    prefersMacosNativeStt,
-    type SttFailureReason,
+  postSttTranscribe,
+  prefersMacosNativeStt,
+  type SttFailureReason,
 } from "@/domains/chat/voice/stt-api";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -45,7 +44,7 @@ import { Button, cn } from "@vellumai/design-library";
  * Returns null if MediaRecorder is unavailable or no supported type is found.
  */
 export function getBestMimeType(): string | null {
-  if (typeof MediaRecorder === "undefined") return null;
+  if (typeof MediaRecorder === "undefined") {return null;}
   const candidates = [
     "audio/webm;codecs=opus",
     "audio/ogg;codecs=opus",
@@ -117,7 +116,7 @@ interface SpeechRecognitionWindow {
  * Exported for unit testing.
  */
 export function getSpeechRecognitionCtor(): SpeechRecognitionConstructor | null {
-  if (typeof window === "undefined") return null;
+  if (typeof window === "undefined") {return null;}
   const w = window as unknown as SpeechRecognitionWindow;
   return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
 }
@@ -141,7 +140,7 @@ export function getSpeechRecognitionCtor(): SpeechRecognitionConstructor | null 
  * signal inside React code.
  */
 export function isBatchSttSupported(): boolean {
-  if (typeof window === "undefined") return false;
+  if (typeof window === "undefined") {return false;}
   return (
     typeof MediaRecorder !== "undefined" &&
     typeof navigator !== "undefined" &&
@@ -169,6 +168,8 @@ export function errorCodeForReason(reason: SttFailureReason): string {
       return "stt-auth-failed";
     case "rate-limited":
       return "stt-rate-limited";
+    case "credits-exhausted":
+      return "stt-credits-exhausted";
     case "provider-error":
       return "stt-provider-error";
     case "unavailable":
@@ -190,11 +191,7 @@ export function errorCodeForReason(reason: SttFailureReason): string {
 // ---------------------------------------------------------------------------
 
 type DictationSessionOutcome =
-  | "completed"
-  | "empty"
-  | "error"
-  | "cancelled"
-  | "aborted";
+  "completed" | "empty" | "error" | "cancelled" | "aborted";
 
 interface NativeFinalResult {
   text: string | null;
@@ -324,9 +321,8 @@ export const VoiceInputButton = forwardRef<
   const nativePartialsStopRef = useRef<StopNativeDictationPartials | null>(
     null,
   );
-  const nativePartialsStartRef = useRef<
-    Promise<StopNativeDictationPartials | null> | null
-  >(null);
+  const nativePartialsStartRef =
+    useRef<Promise<StopNativeDictationPartials | null> | null>(null);
   const nativePartialsTextRef = useRef("");
   // Resolves with the recognizer's final transcript of the whole utterance
   // after stopNativePartials — short dictations end before the first
@@ -388,7 +384,7 @@ export const VoiceInputButton = forwardRef<
     const stop = nativePartialsStopRef.current;
     nativePartialsStopRef.current = null;
     const pendingStart = nativePartialsStartRef.current;
-    if (!stop && !pendingStart) return;
+    if (!stop && !pendingStart) {return;}
     // The promise resolves once the helper's recognizer drains the session
     // (dictation.finalized); recorder.onstop awaits it alongside batch STT.
     const final = stop
@@ -397,7 +393,7 @@ export const VoiceInputButton = forwardRef<
           stopRan: true,
         }))
       : pendingStart!.then(async (readyStop) => {
-          if (!readyStop) return { text: null, stopRan: false };
+          if (!readyStop) {return { text: null, stopRan: false };}
           return {
             text: (await readyStop()) ?? null,
             stopRan: true,
@@ -448,7 +444,7 @@ export const VoiceInputButton = forwardRef<
     )
       .then((stop) => {
         // The unavailable case logs its reason in native-dictation-partials.
-        if (!stop) return null;
+        if (!stop) {return null;}
         console.info("dictation: native partials running");
         // The session may have ended while the helper call was in flight.
         if (
@@ -478,7 +474,7 @@ export const VoiceInputButton = forwardRef<
     stopDictationStream();
     stopNativePartials();
     const recorder = mediaRecorderRef.current;
-    if (!recorder) return;
+    if (!recorder) {return;}
     if (recorder.state !== "inactive") {
       try {
         recorder.stop();
@@ -501,7 +497,7 @@ export const VoiceInputButton = forwardRef<
    */
   const cancelRecording = useCallback(() => {
     const recorder = mediaRecorderRef.current;
-    if (!recorder) return;
+    if (!recorder) {return;}
     discardedRef.current = true;
     stopSpeechRecognition();
     stopDictationStream();
@@ -514,12 +510,7 @@ export const VoiceInputButton = forwardRef<
       }
     }
     vsReset();
-  }, [
-    stopSpeechRecognition,
-    stopDictationStream,
-    stopNativePartials,
-    vsReset,
-  ]);
+  }, [stopSpeechRecognition, stopDictationStream, stopNativePartials, vsReset]);
 
   // Esc during recording discards the partial result. Capture phase so it
   // wins over composer/modal Escape handlers while a recording is live. Two
@@ -527,10 +518,10 @@ export const VoiceInputButton = forwardRef<
   // push-to-talk fallback) and both see the shared store phase; the
   // recorder-ownership guard keeps the non-recording instance inert.
   useEffect(() => {
-    if (!recording) return;
+    if (!recording) {return;}
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      if (!mediaRecorderRef.current) return;
+      if (event.key !== "Escape") {return;}
+      if (!mediaRecorderRef.current) {return;}
       event.preventDefault();
       event.stopPropagation();
       cancelRecording();
@@ -547,7 +538,7 @@ export const VoiceInputButton = forwardRef<
   // same recorder-ownership guard applies.
   useVellumCommands({
     cancelDictation: () => {
-      if (!mediaRecorderRef.current) return;
+      if (!mediaRecorderRef.current) {return;}
       cancelRecording();
     },
   });
@@ -589,7 +580,7 @@ export const VoiceInputButton = forwardRef<
   ]);
 
   const startRecording = useCallback(async () => {
-    if (mediaRecorderRef.current) return;
+    if (mediaRecorderRef.current) {return;}
     cancelledStartRef.current = false;
     discardedRef.current = false;
     const sessionId = ++sessionIdRef.current;
@@ -640,7 +631,7 @@ export const VoiceInputButton = forwardRef<
           let accumulated = "";
           for (let i = 0; i < event.results.length; i += 1) {
             const result = event.results[i];
-            if (!result?.[0]) continue;
+            if (!result?.[0]) {continue;}
             if (result.isFinal) {
               accumulated += result[0].transcript;
             } else {
@@ -691,7 +682,7 @@ export const VoiceInputButton = forwardRef<
 
     if (cancelledStartRef.current) {
       stopSpeechRecognition();
-      for (const track of stream.getTracks()) track.stop();
+      for (const track of stream.getTracks()) {track.stop();}
       return;
     }
 
@@ -778,7 +769,8 @@ export const VoiceInputButton = forwardRef<
         return;
       }
 
-      const audioBlob = chunks.length > 0 ? new Blob(chunks, { type: mimeType }) : null;
+      const audioBlob =
+        chunks.length > 0 ? new Blob(chunks, { type: mimeType }) : null;
       const abortCtrl = new AbortController();
       transcribeAbortRef.current = abortCtrl;
 
@@ -795,7 +787,10 @@ export const VoiceInputButton = forwardRef<
         let daemonFailure: SttFailureReason | null = null;
         try {
           if (audioBlob && assistantId && !nativeSttForced) {
-            if (typeof navigator !== "undefined" && navigator.onLine === false) {
+            if (
+              typeof navigator !== "undefined" &&
+              navigator.onLine === false
+            ) {
               // Provably offline — don't burn the provider timeout to learn
               // what we already know.
               console.info("dictation: skipping batch STT (offline)");
@@ -866,7 +861,7 @@ export const VoiceInputButton = forwardRef<
 
         // A newer session started while we were awaiting — don't
         // overwrite its voice state with this stale completion.
-        if (sessionIdRef.current !== sessionId) return;
+        if (sessionIdRef.current !== sessionId) {return;}
 
         try {
           if (text) {
@@ -982,12 +977,12 @@ export const VoiceInputButton = forwardRef<
     ref,
     () => ({
       start: () => {
-        if (disabled || !assistantId || !supported) return;
+        if (disabled || !assistantId || !supported) {return;}
         // Refuse to start while the previous session is still transcribing.
         // Mirrors the visual `disabled` + `aria-busy` state on the button
         // and prevents push-to-talk from silently dropping the in-flight
         // transcript by incrementing the session id mid-flight.
-        if (useVoiceRecordingStore.getState().phase === "processing") return;
+        if (useVoiceRecordingStore.getState().phase === "processing") {return;}
         startRecording();
       },
       stop: stopRecording,
@@ -997,7 +992,7 @@ export const VoiceInputButton = forwardRef<
 
   const isNative = useIsNativePlatform();
 
-  if (!renderButton || !supported || !assistantId) return null;
+  if (!renderButton || !supported || !assistantId) {return null;}
 
   // The button has three visible states:
   //   - idle:       mic icon, click to start
@@ -1035,7 +1030,7 @@ export const VoiceInputButton = forwardRef<
         recording ? "[&_svg]:size-5 touch-mobile:[&_svg]:size-5" : undefined
       }
       onClick={() => {
-        if (processing) return;
+        if (processing) {return;}
         if (recording) {
           stopRecording();
         } else {

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -190,7 +190,7 @@ export function hasAnyInteractiveSurface(
   for (const msg of messages) {
     if (msg.surfaces) {
       for (const s of msg.surfaces) {
-        if (isSurfaceInteractive(s)) {return true;}
+        if (isSurfaceInteractive(s)) return true;
       }
     }
   }
@@ -216,9 +216,9 @@ export function shouldClearFirstMessageGateOnConversationChange({
   autoGreetPending: boolean;
   assistantMessagePresent: boolean;
 }): boolean {
-  if (previousConversationId == null) {return false;}
-  if (nextConversationId == null) {return false;}
-  if (previousConversationId === nextConversationId) {return false;}
+  if (previousConversationId == null) return false;
+  if (nextConversationId == null) return false;
+  if (previousConversationId === nextConversationId) return false;
 
   return !(
     autoGreetPending &&
@@ -304,8 +304,8 @@ export function identitiesEqual(
   a: IdentityGetResponse | null,
   b: IdentityGetResponse | null,
 ): boolean {
-  if (a === b) {return true;}
-  if (a === null || b === null) {return false;}
+  if (a === b) return true;
+  if (a === null || b === null) return false;
   return (
     a.name === b.name &&
     a.role === b.role &&
@@ -371,7 +371,7 @@ export function attachConfirmationToToolCall(
   if (toolUseId) {
     for (let mi = messages.length - 1; mi >= 0; mi--) {
       const msg = messages[mi];
-      if (!msg?.toolCalls?.length) {continue;}
+      if (!msg?.toolCalls?.length) continue;
       const tcIdx = msg.toolCalls.findIndex((tc) => tc.id === toolUseId);
       if (tcIdx !== -1) {
         return applyConfirmationToToolCall(messages, mi, tcIdx, pending);
@@ -382,7 +382,7 @@ export function attachConfirmationToToolCall(
   // 2. Fallback: last running tool call in the latest assistant message with tool calls
   for (let mi = messages.length - 1; mi >= 0; mi--) {
     const msg = messages[mi];
-    if (msg?.role !== "assistant" || !msg.toolCalls?.length) {continue;}
+    if (msg?.role !== "assistant" || !msg.toolCalls?.length) continue;
 
     for (let ti = msg.toolCalls.length - 1; ti >= 0; ti--) {
       const tc = msg.toolCalls[ti];
@@ -412,7 +412,7 @@ export function extractWirePendingConfirmation(
 ): PendingConfirmationState | null {
   for (let mi = messages.length - 1; mi >= 0; mi--) {
     const msg = messages[mi];
-    if (!msg?.toolCalls?.length) {continue;}
+    if (!msg?.toolCalls?.length) continue;
     for (let ti = msg.toolCalls.length - 1; ti >= 0; ti--) {
       const tc = msg.toolCalls[ti];
       if (tc?.pendingConfirmation) {
@@ -439,7 +439,7 @@ export function extractWirePendingQuestion(
 ): PendingQuestionState | null {
   for (let mi = messages.length - 1; mi >= 0; mi--) {
     const msg = messages[mi];
-    if (!msg?.toolCalls?.length) {continue;}
+    if (!msg?.toolCalls?.length) continue;
     for (let ti = msg.toolCalls.length - 1; ti >= 0; ti--) {
       const tc = msg.toolCalls[ti];
       if (tc?.pendingQuestion) {
@@ -472,7 +472,7 @@ export function extractWirePendingAcpConnect(
 ): PendingAcpConnectState | null {
   for (let mi = messages.length - 1; mi >= 0; mi--) {
     const msg = messages[mi];
-    if (!msg?.toolCalls?.length) {continue;}
+    if (!msg?.toolCalls?.length) continue;
     for (let ti = msg.toolCalls.length - 1; ti >= 0; ti--) {
       const tc = msg.toolCalls[ti];
       if (tc?.errorCode === ACP_CLAUDE_OAUTH_MISSING_CODE && tc.id) {
@@ -493,14 +493,14 @@ export function deriveCommandText(
   input: Record<string, unknown> | undefined,
   toolName: string,
 ): string {
-  if (!input) {return toolName;}
+  if (!input) return toolName;
   const preferredKeys = ["command", "cmd", "path", "file", "url"];
   for (const key of preferredKeys) {
     const val = input[key];
-    if (typeof val === "string" && val.trim()) {return val.trim();}
+    if (typeof val === "string" && val.trim()) return val.trim();
   }
   for (const val of Object.values(input)) {
-    if (typeof val === "string" && val.trim()) {return val.trim();}
+    if (typeof val === "string" && val.trim()) return val.trim();
   }
   try {
     const json = JSON.stringify(input);
@@ -532,9 +532,9 @@ const MS_PER_MINUTE = 60_000;
 
 export function formatRelativeTime(timestamp: number): string {
   const diffMin = Math.floor((Date.now() - timestamp) / MS_PER_MINUTE);
-  if (diffMin < 1) {return "just now";}
-  if (diffMin < MINUTES_PER_HOUR) {return `${diffMin}m ago`;}
+  if (diffMin < 1) return "just now";
+  if (diffMin < MINUTES_PER_HOUR) return `${diffMin}m ago`;
   const diffHr = Math.floor(diffMin / MINUTES_PER_HOUR);
-  if (diffHr < HOURS_PER_DAY) {return `${diffHr}h ago`;}
+  if (diffHr < HOURS_PER_DAY) return `${diffHr}h ago`;
   return `${Math.floor(diffHr / HOURS_PER_DAY)}d ago`;
 }

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -190,7 +190,7 @@ export function hasAnyInteractiveSurface(
   for (const msg of messages) {
     if (msg.surfaces) {
       for (const s of msg.surfaces) {
-        if (isSurfaceInteractive(s)) return true;
+        if (isSurfaceInteractive(s)) {return true;}
       }
     }
   }
@@ -216,9 +216,9 @@ export function shouldClearFirstMessageGateOnConversationChange({
   autoGreetPending: boolean;
   assistantMessagePresent: boolean;
 }): boolean {
-  if (previousConversationId == null) return false;
-  if (nextConversationId == null) return false;
-  if (previousConversationId === nextConversationId) return false;
+  if (previousConversationId == null) {return false;}
+  if (nextConversationId == null) {return false;}
+  if (previousConversationId === nextConversationId) {return false;}
 
   return !(
     autoGreetPending &&
@@ -245,6 +245,8 @@ const VOICE_ERROR_MESSAGES: Readonly<Record<string, string>> = {
     "Too many transcription requests. Please wait a moment and try again.",
   "stt-auth-failed":
     "The speech-to-text provider rejected the assistant\u2019s credentials. Update the API key in Settings \u2192 Voice.",
+  "stt-credits-exhausted":
+    "You’re out of credits, so dictation can’t transcribe. Add credits to keep using it.",
   "stt-provider-error":
     "The speech-to-text provider is having trouble right now. Try again in a moment.",
   "stt-unavailable":
@@ -302,8 +304,8 @@ export function identitiesEqual(
   a: IdentityGetResponse | null,
   b: IdentityGetResponse | null,
 ): boolean {
-  if (a === b) return true;
-  if (a === null || b === null) return false;
+  if (a === b) {return true;}
+  if (a === null || b === null) {return false;}
   return (
     a.name === b.name &&
     a.role === b.role &&
@@ -369,7 +371,7 @@ export function attachConfirmationToToolCall(
   if (toolUseId) {
     for (let mi = messages.length - 1; mi >= 0; mi--) {
       const msg = messages[mi];
-      if (!msg?.toolCalls?.length) continue;
+      if (!msg?.toolCalls?.length) {continue;}
       const tcIdx = msg.toolCalls.findIndex((tc) => tc.id === toolUseId);
       if (tcIdx !== -1) {
         return applyConfirmationToToolCall(messages, mi, tcIdx, pending);
@@ -380,7 +382,7 @@ export function attachConfirmationToToolCall(
   // 2. Fallback: last running tool call in the latest assistant message with tool calls
   for (let mi = messages.length - 1; mi >= 0; mi--) {
     const msg = messages[mi];
-    if (msg?.role !== "assistant" || !msg.toolCalls?.length) continue;
+    if (msg?.role !== "assistant" || !msg.toolCalls?.length) {continue;}
 
     for (let ti = msg.toolCalls.length - 1; ti >= 0; ti--) {
       const tc = msg.toolCalls[ti];
@@ -410,7 +412,7 @@ export function extractWirePendingConfirmation(
 ): PendingConfirmationState | null {
   for (let mi = messages.length - 1; mi >= 0; mi--) {
     const msg = messages[mi];
-    if (!msg?.toolCalls?.length) continue;
+    if (!msg?.toolCalls?.length) {continue;}
     for (let ti = msg.toolCalls.length - 1; ti >= 0; ti--) {
       const tc = msg.toolCalls[ti];
       if (tc?.pendingConfirmation) {
@@ -437,7 +439,7 @@ export function extractWirePendingQuestion(
 ): PendingQuestionState | null {
   for (let mi = messages.length - 1; mi >= 0; mi--) {
     const msg = messages[mi];
-    if (!msg?.toolCalls?.length) continue;
+    if (!msg?.toolCalls?.length) {continue;}
     for (let ti = msg.toolCalls.length - 1; ti >= 0; ti--) {
       const tc = msg.toolCalls[ti];
       if (tc?.pendingQuestion) {
@@ -470,7 +472,7 @@ export function extractWirePendingAcpConnect(
 ): PendingAcpConnectState | null {
   for (let mi = messages.length - 1; mi >= 0; mi--) {
     const msg = messages[mi];
-    if (!msg?.toolCalls?.length) continue;
+    if (!msg?.toolCalls?.length) {continue;}
     for (let ti = msg.toolCalls.length - 1; ti >= 0; ti--) {
       const tc = msg.toolCalls[ti];
       if (tc?.errorCode === ACP_CLAUDE_OAUTH_MISSING_CODE && tc.id) {
@@ -491,14 +493,14 @@ export function deriveCommandText(
   input: Record<string, unknown> | undefined,
   toolName: string,
 ): string {
-  if (!input) return toolName;
+  if (!input) {return toolName;}
   const preferredKeys = ["command", "cmd", "path", "file", "url"];
   for (const key of preferredKeys) {
     const val = input[key];
-    if (typeof val === "string" && val.trim()) return val.trim();
+    if (typeof val === "string" && val.trim()) {return val.trim();}
   }
   for (const val of Object.values(input)) {
-    if (typeof val === "string" && val.trim()) return val.trim();
+    if (typeof val === "string" && val.trim()) {return val.trim();}
   }
   try {
     const json = JSON.stringify(input);
@@ -530,9 +532,9 @@ const MS_PER_MINUTE = 60_000;
 
 export function formatRelativeTime(timestamp: number): string {
   const diffMin = Math.floor((Date.now() - timestamp) / MS_PER_MINUTE);
-  if (diffMin < 1) return "just now";
-  if (diffMin < MINUTES_PER_HOUR) return `${diffMin}m ago`;
+  if (diffMin < 1) {return "just now";}
+  if (diffMin < MINUTES_PER_HOUR) {return `${diffMin}m ago`;}
   const diffHr = Math.floor(diffMin / MINUTES_PER_HOUR);
-  if (diffHr < HOURS_PER_DAY) return `${diffHr}h ago`;
+  if (diffHr < HOURS_PER_DAY) {return `${diffHr}h ago`;}
   return `${Math.floor(diffHr / HOURS_PER_DAY)}d ago`;
 }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -73,6 +73,13 @@ export interface LiveVoiceClientError {
    * kept open — the session is still live. Absent means the client tore down.
    */
   readonly recoverable?: boolean;
+  /**
+   * Billing/quota classification from the server `error` frame, in the same
+   * vocabulary as a `conversation_error` (e.g. `credits_exhausted`). Lets the
+   * session controller route the failure to the chat billing banner instead of
+   * a generic notice.
+   */
+  readonly errorCategory?: string;
 }
 
 /**
@@ -457,7 +464,11 @@ export class LiveVoiceChannelClient {
           });
           return;
         }
-        this.fail("protocol-error", frame.message, frame.code);
+        this.fail("protocol-error", frame.message, frame.code, {
+          // `in` narrows past LiveVoiceInvalidJsonFrame, which carries no category.
+          errorCategory:
+            "errorCategory" in frame ? frame.errorCategory : undefined,
+        });
         return;
       case "unknown_frame":
         // Frame types from a newer server than this client. Ignore so
@@ -515,10 +526,18 @@ export class LiveVoiceChannelClient {
     reason: LiveVoiceClientErrorReason,
     message: string,
     code?: string,
+    detail?: { errorCategory?: string },
   ): void {
     if (this.state === "closed") return;
     this.teardown();
-    this.emit("error", { reason, message, ...(code ? { code } : {}) });
+    this.emit("error", {
+      reason,
+      message,
+      ...(code ? { code } : {}),
+      ...(detail?.errorCategory !== undefined
+        ? { errorCategory: detail.errorCategory }
+        : {}),
+    });
     // Locally initiated after surfacing the failure; never a reconnect trigger.
     this.emit("closed", { code: null, reason: message });
   }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -322,6 +322,41 @@ describe("dismissLiveVoiceFailure", () => {
   });
 });
 
+describe("fail", () => {
+  test("carries the billing category so surfaces can route to the paywall", () => {
+    useLiveVoiceStore.getState().fail("out of credits", "credits_exhausted");
+
+    expect(useLiveVoiceStore.getState().state).toBe("failed");
+    expect(useLiveVoiceStore.getState().errorCategory).toBe(
+      "credits_exhausted",
+    );
+  });
+
+  test("leaves errorCategory null for an ordinary failure", () => {
+    useLiveVoiceStore.getState().fail("boom");
+
+    expect(useLiveVoiceStore.getState().errorCategory).toBeNull();
+  });
+
+  test("clears the wind-down notice — the beat is over once the failure lands", () => {
+    useLiveVoiceStore.getState().setClosingNotice("Out of credits");
+
+    useLiveVoiceStore.getState().fail("out of credits", "credits_exhausted");
+
+    expect(useLiveVoiceStore.getState().closingNotice).toBeNull();
+  });
+
+  test("reset clears both, so a later session starts clean", () => {
+    useLiveVoiceStore.getState().fail("out of credits", "credits_exhausted");
+    useLiveVoiceStore.getState().setClosingNotice("Out of credits");
+
+    useLiveVoiceStore.getState().reset();
+
+    expect(useLiveVoiceStore.getState().errorCategory).toBeNull();
+    expect(useLiveVoiceStore.getState().closingNotice).toBeNull();
+  });
+});
+
 describe("isLiveVoiceMicLive", () => {
   test("true for the whole listening→speaking span (amplitude keeps flowing for barge-in)", () => {
     const micLive: LiveVoiceSessionState[] = [

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -281,6 +281,20 @@ export interface LiveVoiceState {
   playbackProgressProvider: (() => LiveVoicePlaybackProgress | null) | null;
   /** Human-readable error message when `state === "failed"`, `null` otherwise. */
   error: string | null;
+  /**
+   * Billing/quota classification of `error`, in the `conversation_error`
+   * vocabulary (e.g. `credits_exhausted`). `null` for ordinary failures.
+   * Surfaces route on this instead of the message so a credits failure reaches
+   * the billing banner (with its CTA) rather than a generic error notice.
+   */
+  errorCategory: string | null;
+  /**
+   * Short farewell line shown in the voice room while a terminal failure is
+   * being wound down — set for the beat between "the session is over" and the
+   * room actually unmounting, so the exit reads as caused rather than as the
+   * room crashing. `null` outside that window.
+   */
+  closingNotice: string | null;
 }
 
 export interface LiveVoiceActions {
@@ -338,7 +352,9 @@ export interface LiveVoiceActions {
     provider: (() => LiveVoicePlaybackProgress | null) | null,
   ) => void;
   /** Transition to `failed` with a message. */
-  fail: (message: string) => void;
+  fail: (message: string, errorCategory?: string) => void;
+  /** Show (or clear) the room's wind-down line. See {@link LiveVoiceState.closingNotice}. */
+  setClosingNotice: (closingNotice: string | null) => void;
   /**
    * Reset every session field back to the idle defaults. Deliberately leaves
    * `starter` registered — it belongs to the controller's mount lifecycle,
@@ -355,7 +371,9 @@ export type LiveVoiceStore = LiveVoiceState & LiveVoiceActions;
 // ---------------------------------------------------------------------------
 
 /** Whether `state` is a live session phase (anything but idle/failed). */
-export function isLiveVoiceSessionActive(state: LiveVoiceSessionState): boolean {
+export function isLiveVoiceSessionActive(
+  state: LiveVoiceSessionState,
+): boolean {
   return state !== "idle" && state !== "failed";
 }
 
@@ -438,6 +456,8 @@ const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   outputAmplitudeProvider: null,
   playbackProgressProvider: null,
   error: null,
+  errorCategory: null,
+  closingNotice: null,
 };
 
 const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
@@ -465,7 +485,8 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   appendAssistantTranscript: (delta) =>
     set((s) => ({ assistantTranscript: s.assistantTranscript + delta })),
   clearAssistantTranscript: () => set({ assistantTranscript: "" }),
-  clearUserTranscripts: () => set({ partialTranscript: "", finalTranscript: "" }),
+  clearUserTranscripts: () =>
+    set({ partialTranscript: "", finalTranscript: "" }),
   setInputAmplitude: (inputAmplitude) => set({ inputAmplitude }),
   setMuted: (muted) => set({ muted }),
   setHandsFree: (handsFree) => set({ handsFree }),
@@ -475,7 +496,15 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
     set({ outputAmplitudeProvider }),
   setPlaybackProgressProvider: (playbackProgressProvider) =>
     set({ playbackProgressProvider }),
-  fail: (message) => set({ state: "failed", error: message }),
+  fail: (message, errorCategory) =>
+    set({
+      state: "failed",
+      error: message,
+      errorCategory: errorCategory ?? null,
+      // The wind-down beat is over once the failure lands.
+      closingNotice: null,
+    }),
+  setClosingNotice: (closingNotice) => set({ closingNotice }),
   reset: () => set({ ...INITIAL_SESSION_STATE }),
 }));
 

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -276,6 +276,13 @@ export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
    * from older daemons) means the error is terminal for the session.
    */
   readonly recoverable?: boolean;
+  /**
+   * Billing/quota classification using the same vocabulary as the
+   * `conversation_error` SSE event's `errorCategory` (e.g. `credits_exhausted`),
+   * so a voice failure routes to the same billing banner a text turn raises.
+   * Absent for ordinary failures and on frames from older daemons.
+   */
+  readonly errorCategory?: string;
 }
 
 export type LiveVoiceServerFrame =

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -50,6 +50,8 @@ const { useLiveVoice } =
 const { useLiveVoiceStore, getLiveVoicePlaybackProgress } =
   await import("@/domains/chat/voice/live-voice/live-voice-store");
 const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
+const { useChatSessionStore } =
+  await import("@/domains/chat/chat-session-store");
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -64,6 +66,7 @@ function renderController(
   extraOptions: {
     observeAudioState?: boolean;
     reconnectBackoffMs?: number[];
+    billingExitHoldMs?: number;
     /**
      * Configure each FakeCapture at creation — before the controller calls
      * `capture.start()`, which happens synchronously at connect time (so
@@ -134,6 +137,9 @@ beforeEach(() => {
     pauseBeforeReplyMs: null,
     interruptSensitivity: null,
   });
+  // A billing failure mirrors itself into the chat session store (that's where
+  // the banner reads from), so clear it too or it leaks across tests.
+  useChatSessionStore.getState().setError(null);
 });
 
 afterEach(() => {
@@ -1752,6 +1758,70 @@ describe("failure", () => {
     expect(h.view.result.current.error).toBe("kaboom");
     expect(h.client.closed).toBe(true);
     expect(h.getCapture().shutdownCount).toBe(1);
+  });
+
+  test("a billing failure holds the room for a beat, then fails", async () => {
+    const h = renderController({ billingExitHoldMs: 20 });
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("error", {
+        reason: "protocol-error",
+        message: "You've run out of credits.",
+        errorCategory: "credits_exhausted",
+      } satisfies LiveVoiceClientError);
+    });
+
+    // The beat: the room is still mounted (an active state, not `failed`) and
+    // shows why it is closing, instead of vanishing mid-animation.
+    expect(useLiveVoiceStore.getState().closingNotice).toBe("Out of credits");
+    expect(h.view.result.current.state).not.toBe("failed");
+    // Audio is already stopped — the beat is cosmetic, not a live session.
+    expect(h.getCapture().shutdownCount).toBe(1);
+
+    await act(async () => {
+      await sleep(40);
+    });
+
+    expect(h.view.result.current.state).toBe("failed");
+    expect(useLiveVoiceStore.getState().errorCategory).toBe(
+      "credits_exhausted",
+    );
+    expect(useLiveVoiceStore.getState().closingNotice).toBeNull();
+  });
+
+  test("the billing banner is armed immediately, so an early exit still lands on it", async () => {
+    const h = renderController({ billingExitHoldMs: 10_000 });
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("error", {
+        reason: "protocol-error",
+        message: "You've run out of credits.",
+        errorCategory: "credits_exhausted",
+      } satisfies LiveVoiceClientError);
+    });
+
+    // Published before the hold elapses: a user who hits ✕ during the beat
+    // cancels the pending fail, so this is their only surface.
+    expect(useChatSessionStore.getState().error).toMatchObject({
+      errorCategory: "credits_exhausted",
+    });
+  });
+
+  test("a non-billing failure fails immediately, with no wind-down beat", async () => {
+    const h = renderController({ billingExitHoldMs: 10_000 });
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("error", {
+        reason: "protocol-error",
+        message: "kaboom",
+      } satisfies LiveVoiceClientError);
+    });
+
+    expect(h.view.result.current.state).toBe("failed");
+    expect(useLiveVoiceStore.getState().closingNotice).toBeNull();
   });
 
   test("busy frame fails the session", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -102,6 +102,8 @@ import {
   interruptSensitivityToMs,
   useVoicePrefsStore,
 } from "@/stores/voice-prefs-store";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { getChatBillingBannerDecision } from "@/domains/chat/utils/error-classification";
 
 // ---------------------------------------------------------------------------
 // Thresholds (mirror the macOS LiveVoiceChannelManager defaults)
@@ -135,6 +137,21 @@ const MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS = 120;
  * attempts — after the last one the session fails.
  */
 const RECONNECT_BACKOFF_MS = [1200, 3000, 6000];
+
+// ---------------------------------------------------------------------------
+// Billing wind-down
+// ---------------------------------------------------------------------------
+
+/**
+ * How long the room holds after a billing failure before it closes. Long enough
+ * to read the reason, short enough not to feel like a stall — the user cannot
+ * act on it from inside the room, so this is an explanation, not a decision
+ * point.
+ */
+const BILLING_EXIT_HOLD_MS = 1500;
+
+/** The room's wind-down line for a billing failure. */
+const BILLING_CLOSING_NOTICE = "Out of credits";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -202,6 +219,12 @@ export interface UseLiveVoiceOptions {
    * seconds; production uses {@link RECONNECT_BACKOFF_MS}.
    */
   reconnectBackoffMs?: number[];
+  /**
+   * Override how long the room holds after a billing failure before closing.
+   * Test seam, same rationale as {@link LiveVoiceControllerOptions.reconnectBackoffMs};
+   * production uses {@link BILLING_EXIT_HOLD_MS}.
+   */
+  billingExitHoldMs?: number;
 }
 
 /**
@@ -380,6 +403,11 @@ export function useLiveVoice(
   // from `reconnectAttemptRef` so the room shows "Connecting…", not
   // "Reconnecting…"), sharing `reconnectTimerRef` for cancellation. Both reset
   // on a fresh `start()`, on `ready`, and on teardown/stop.
+  //
+  // `reconnectTimerRef` also carries the billing wind-down beat — same
+  // cancellation semantics: stop()/teardown()/unmount must drop it, and the two
+  // can never be pending at once (the beat only starts after the session has
+  // been detached from the transport, so no reconnect can be queued).
   const hasReadyRef = useRef(false);
   const initialConnectAttemptRef = useRef(0);
   const connectSessionRef = useRef<
@@ -939,7 +967,30 @@ export function useLiveVoice(
               return;
             }
           }
-          finishWithError(session, teardown, err.message);
+          // A billing failure (out of credits) ends the session, but closing
+          // the room the instant it lands reads as the room crashing — the
+          // takeover just vanishes mid-animation. Hold it for a beat with a
+          // reason, then finish. The banner is armed underneath immediately, so
+          // an impatient ✕ during the beat still lands on it.
+          if (
+            getChatBillingBannerDecision({
+              errorCategory: err.errorCategory,
+            }) !== null
+          ) {
+            publishBillingFailure(err.message, err.errorCategory);
+            sessionRef.current = null;
+            disposeSessionPrimitives(session);
+            clearReconnectTimer();
+            const s = useLiveVoiceStore.getState();
+            s.setClosingNotice(BILLING_CLOSING_NOTICE);
+            reconnectTimerRef.current = setTimeout(() => {
+              reconnectTimerRef.current = null;
+              teardown();
+              useLiveVoiceStore.getState().fail(err.message, err.errorCategory);
+            }, optionsRef.current.billingExitHoldMs ?? BILLING_EXIT_HOLD_MS);
+            return;
+          }
+          finishWithError(session, teardown, err.message, err.errorCategory);
         }),
         client.on("closed", (info) => {
           // A transport close after a clean end()/teardown is expected; only an
@@ -1444,7 +1495,27 @@ function finishWithError(
   session: SessionContext,
   teardown: () => void,
   message: string,
+  errorCategory?: string,
 ): void {
   teardown();
-  useLiveVoiceStore.getState().fail(message);
+  useLiveVoiceStore.getState().fail(message, errorCategory);
+  publishBillingFailure(message, errorCategory);
+}
+
+/**
+ * Mirror a billing failure into the chat session store so the composer's
+ * existing billing banner (with its "Add credits" CTA) renders it — the one
+ * surface a text turn's `conversation_error` would have reached.
+ *
+ * The speech legs never touch the agent loop, so an STT/TTS credit failure
+ * produces no `conversation_error` and this is its only route to that banner.
+ * For an LLM-leg failure the SSE event sets the same thing; re-setting it is
+ * idempotent. Non-billing failures stay on the composer's voice notice.
+ */
+function publishBillingFailure(
+  message: string,
+  errorCategory: string | undefined,
+): void {
+  if (getChatBillingBannerDecision({ errorCategory }) === null) return;
+  useChatSessionStore.getState().setError({ message, errorCategory });
 }

--- a/clients/web/src/domains/chat/voice/stt-api.ts
+++ b/clients/web/src/domains/chat/voice/stt-api.ts
@@ -5,7 +5,10 @@ import {
 } from "@/generated/daemon/sdk.gen";
 import { MACOS_NATIVE_STT_PROVIDER_ID } from "@/lib/provider-catalogs";
 import { isNativeDictationSupported } from "@/runtime/native-dictation-partials";
-import { getLocalSetting, removeLocalSetting } from "@/utils/local-settings";
+import {
+  getLocalSetting,
+  removeLocalSetting,
+} from "@/utils/local-settings";
 import {
   LS_STT_API_KEY_PREFIX,
   LS_STT_PROVIDER,
@@ -69,7 +72,7 @@ export function prefersMacosNativeStt(): boolean {
 }
 
 function normalizeSttProviderId(provider: string): string {
-  if (provider === "openai" || provider === "whisper") {return "openai-whisper";}
+  if (provider === "openai" || provider === "whisper") return "openai-whisper";
   return provider;
 }
 
@@ -96,7 +99,7 @@ function legacyKeyAliases(provider: string): string[] {
 function readLegacyLocalSttKey(provider: string): string {
   for (const alias of legacyKeyAliases(provider)) {
     const value = getLocalSetting(LS_STT_API_KEY_PREFIX + alias, "");
-    if (value.trim()) {return value;}
+    if (value.trim()) return value;
   }
   return "";
 }
@@ -114,7 +117,7 @@ async function migrateLegacyLocalSttSettings(
     getLocalSetting(LS_STT_PROVIDER, DEFAULT_STT_PROVIDER_ID),
   );
   const credentialValue = readLegacyLocalSttKey(provider).trim();
-  if (!credentialValue) {return false;}
+  if (!credentialValue) return false;
 
   const credentialProvider = credentialProviderForSttProvider(provider);
   try {
@@ -151,10 +154,7 @@ async function migrateLegacyLocalSttSettings(
       throwOnError: true,
     });
   } catch (err) {
-    console.warn(
-      "postSttTranscribe: legacy STT settings migration failed",
-      err,
-    );
+    console.warn("postSttTranscribe: legacy STT settings migration failed", err);
     return false;
   }
 
@@ -192,7 +192,7 @@ function reasonFromHttp(
     case 503: {
       const text = (message ?? "").toLowerCase();
       if (text.includes("not configured") || text.includes("no speech-to-text"))
-        {return "config-missing";}
+        return "config-missing";
       return "unavailable";
     }
     case 504:
@@ -209,12 +209,12 @@ function reasonFromHttp(
  * This function handles both shapes.
  */
 function extractMessage(data: unknown): string | undefined {
-  if (typeof data === "string") {return data;}
+  if (typeof data === "string") return data;
   if (data && typeof data === "object") {
     const record = data as Record<string, unknown>;
     for (const key of ["detail", "message"] as const) {
       const value = record[key];
-      if (typeof value === "string" && value.length > 0) {return value;}
+      if (typeof value === "string" && value.length > 0) return value;
     }
     // Recurse into `{ error: { message: "..." } }` envelope from httpError().
     if (record.error && typeof record.error === "object") {
@@ -343,6 +343,6 @@ export async function postSttTranscribe(
   }
 
   const migratedAfterFailure = await migrateLegacyLocalSttSettings(assistantId);
-  if (!migratedAfterFailure) {return firstAttempt;}
+  if (!migratedAfterFailure) return firstAttempt;
   return send();
 }

--- a/clients/web/src/domains/chat/voice/stt-api.ts
+++ b/clients/web/src/domains/chat/voice/stt-api.ts
@@ -5,10 +5,7 @@ import {
 } from "@/generated/daemon/sdk.gen";
 import { MACOS_NATIVE_STT_PROVIDER_ID } from "@/lib/provider-catalogs";
 import { isNativeDictationSupported } from "@/runtime/native-dictation-partials";
-import {
-  getLocalSetting,
-  removeLocalSetting,
-} from "@/utils/local-settings";
+import { getLocalSetting, removeLocalSetting } from "@/utils/local-settings";
 import {
   LS_STT_API_KEY_PREFIX,
   LS_STT_PROVIDER,
@@ -32,6 +29,7 @@ export type SttFailureReason =
   | "audio-rejected"
   | "auth-failed"
   | "rate-limited"
+  | "credits-exhausted"
   | "provider-error"
   | "unavailable"
   | "timeout"
@@ -71,7 +69,7 @@ export function prefersMacosNativeStt(): boolean {
 }
 
 function normalizeSttProviderId(provider: string): string {
-  if (provider === "openai" || provider === "whisper") return "openai-whisper";
+  if (provider === "openai" || provider === "whisper") {return "openai-whisper";}
   return provider;
 }
 
@@ -98,7 +96,7 @@ function legacyKeyAliases(provider: string): string[] {
 function readLegacyLocalSttKey(provider: string): string {
   for (const alias of legacyKeyAliases(provider)) {
     const value = getLocalSetting(LS_STT_API_KEY_PREFIX + alias, "");
-    if (value.trim()) return value;
+    if (value.trim()) {return value;}
   }
   return "";
 }
@@ -116,7 +114,7 @@ async function migrateLegacyLocalSttSettings(
     getLocalSetting(LS_STT_PROVIDER, DEFAULT_STT_PROVIDER_ID),
   );
   const credentialValue = readLegacyLocalSttKey(provider).trim();
-  if (!credentialValue) return false;
+  if (!credentialValue) {return false;}
 
   const credentialProvider = credentialProviderForSttProvider(provider);
   try {
@@ -153,7 +151,10 @@ async function migrateLegacyLocalSttSettings(
       throwOnError: true,
     });
   } catch (err) {
-    console.warn("postSttTranscribe: legacy STT settings migration failed", err);
+    console.warn(
+      "postSttTranscribe: legacy STT settings migration failed",
+      err,
+    );
     return false;
   }
 
@@ -182,6 +183,8 @@ function reasonFromHttp(
     case 401:
     case 403:
       return "auth-failed";
+    case 402:
+      return "credits-exhausted";
     case 429:
       return "rate-limited";
     case 502:
@@ -189,7 +192,7 @@ function reasonFromHttp(
     case 503: {
       const text = (message ?? "").toLowerCase();
       if (text.includes("not configured") || text.includes("no speech-to-text"))
-        return "config-missing";
+        {return "config-missing";}
       return "unavailable";
     }
     case 504:
@@ -206,12 +209,12 @@ function reasonFromHttp(
  * This function handles both shapes.
  */
 function extractMessage(data: unknown): string | undefined {
-  if (typeof data === "string") return data;
+  if (typeof data === "string") {return data;}
   if (data && typeof data === "object") {
     const record = data as Record<string, unknown>;
     for (const key of ["detail", "message"] as const) {
       const value = record[key];
-      if (typeof value === "string" && value.length > 0) return value;
+      if (typeof value === "string" && value.length > 0) {return value;}
     }
     // Recurse into `{ error: { message: "..." } }` envelope from httpError().
     if (record.error && typeof record.error === "object") {
@@ -340,6 +343,6 @@ export async function postSttTranscribe(
   }
 
   const migratedAfterFailure = await migrateLegacyLocalSttSettings(assistantId);
-  if (!migratedAfterFailure) return firstAttempt;
+  if (!migratedAfterFailure) {return firstAttempt;}
   return send();
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -555,6 +555,33 @@ describe("VoiceRoom — connect feedback", () => {
   });
 });
 
+describe("VoiceRoom — wind-down notice", () => {
+  test("shows why the room is closing instead of vanishing mid-session", () => {
+    startOwnedSession("listening");
+    useLiveVoiceStore.getState().setClosingNotice("Out of credits");
+    render(<VoiceRoom />);
+    expect(screen.getByTestId("voice-room-closing-label").textContent).toBe(
+      "Out of credits",
+    );
+  });
+
+  test("outranks the connect label — a session dying mid-connect is closing, not connecting", () => {
+    startOwnedSession("connecting");
+    useLiveVoiceStore.getState().setClosingNotice("Out of credits");
+    render(<VoiceRoom />);
+    expect(screen.queryByTestId("voice-room-connect-label")).toBeNull();
+    expect(screen.getByTestId("voice-room-closing-label").textContent).toBe(
+      "Out of credits",
+    );
+  });
+
+  test("absent for an ordinary session", () => {
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    expect(screen.queryByTestId("voice-room-closing-label")).toBeNull();
+  });
+});
+
 describe("VoiceRoom — audio-aware status label (JARVIS-1279)", () => {
   // The sr-only aria-live region uses the "…"-suffixed state labels, distinct
   // from the caption's un-suffixed text (e.g. "Thinking" vs "Thinking…").

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -122,6 +122,9 @@ export function VoiceRoom() {
 function VoiceRoomOverlay() {
   const state = useLiveVoiceStore.use.state();
   const reconnecting = useLiveVoiceStore.use.reconnecting();
+  // Set for the beat between a terminal billing failure landing and the room
+  // closing, so the exit reads as caused. See `use-live-voice`'s wind-down.
+  const closingNotice = useLiveVoiceStore.use.closingNotice();
   // `speaking` stays set across a mid-turn tool run; gate `responding` on audio
   // actually flowing so the room reads `thinking` while the tool works.
   const assistantAudioActive = useLiveVoiceStore.use.assistantAudioActive();
@@ -153,6 +156,10 @@ function VoiceRoomOverlay() {
   const labelState =
     state === "speaking" && !assistantAudioActive ? "thinking" : state;
   const stateLabel = liveVoiceStateLabel(labelState, reconnecting);
+  // The under-avatar status line: the wind-down reason when the room is
+  // closing, otherwise the connect label (nothing once the session is running).
+  const statusLabel =
+    closingNotice ?? (state === "connecting" ? stateLabel : null);
 
   // The state caption (e.g. "Listening…") shows only while the assistant
   // transcript is hidden; the captions toggle itself lives in the room's
@@ -279,7 +286,9 @@ function VoiceRoomOverlay() {
           {/* Same state caption + gating as the color look (stands down while
               the assistant transcript is on), in the same shared lower zone —
               both looks name the beat from one baseline. */}
-          {!showAssistantTranscript ? <VoiceStateCaption visual={visual} /> : null}
+          {!showAssistantTranscript ? (
+            <VoiceStateCaption visual={visual} />
+          ) : null}
         </>
       )}
 
@@ -386,12 +395,22 @@ function VoiceRoomOverlay() {
           shows the idle visual, which otherwise reads as dead air — surface
           the "Connecting…" / "Reconnecting…" label so the user knows when to
           start talking. aria-hidden: the sr-only live region below already
-          announces every state change. */}
+          announces every state change.
+
+          The same slot carries the wind-down line (`closingNotice`, e.g. "Out
+          of credits") for the beat before a terminal billing failure closes the
+          room — without it the takeover just vanishes and reads as a crash
+          rather than a consequence. It outranks the connect label: a session
+          that dies mid-connect is closing, not connecting. */}
       <AnimatePresence>
-        {state === "connecting" ? (
+        {statusLabel ? (
           <motion.p
-            key="connect-label"
-            data-testid="voice-room-connect-label"
+            key="room-status-label"
+            data-testid={
+              closingNotice
+                ? "voice-room-closing-label"
+                : "voice-room-connect-label"
+            }
             aria-hidden
             className="pointer-events-none absolute left-1/2 top-[calc(50%+8.5rem)] z-0 -translate-x-1/2 text-sm text-[var(--content-tertiary)]"
             initial={reduce ? false : { opacity: 0 }}
@@ -399,7 +418,7 @@ function VoiceRoomOverlay() {
             exit={{ opacity: 0 }}
             transition={{ duration: reduce ? 0 : 0.3 }}
           >
-            {stateLabel}
+            {statusLabel}
           </motion.p>
         ) : null}
       </AnimatePresence>


### PR DESCRIPTION
## Summary

- **Both silent speech paths are now terminal.** STT credit exhaustion gets its own `credits-exhausted` category instead of riding in `provider-error` (which `sendTranscriberErrorFrame` treats as recoverable, so the hands-free client suppressed it and left the mic open forever). TTS gets `TtsCreditsExhaustedError` so a zero balance is no longer treated like a one-off bad segment — every later segment fails identically, so retrying just produces a permanently mute assistant.
- **The billing classification survives end to end.** `errorCategory` now flows through the bridge sink (`onError(message, detail?)` — the telephony consumer keeps the one-arg form), the live-voice error frame, the client transport, and the web store, and is mirrored into the chat session store so the existing `CreditsExhaustedBanner` renders with a working "Add credits" CTA instead of grey prose. The composer's generic voice Notice is suppressed for billing failures so there's one surface, not two.
- **The room's exit reads as caused.** A ~1.5s "Out of credits" beat before the takeover closes, replacing a fade-out that read as the room crashing. The banner is armed underneath immediately, so an impatient ✕ during the beat still lands on it.

## Original prompt

Alex reported that running out of credits during voice mode gives no notification — it just stops working, with no way to tell why. They floated two options: surface the out-of-credits notice inside the voice room, or auto-close the room so it's visible in the main conversation.

Investigation found neither was the actual gap: the room already auto-closes into a chat-surface message on the LLM path. The real bug was that the two speech legs (STT and TTS) classified credit exhaustion as a transient provider error and silently suppressed it, and that even the working path lost its `errorCategory` and so rendered without the "Add credits" CTA. Keeping the room open was considered and rejected — out of credits is unrecoverable in-room, and `AddCreditsModal` mounts under the Outlet so it would render beneath the room's `fixed inset-0 z-50` anyway.

Ticket: LUM-2829