### PR TITLE
feat(billing): add dark PlanPromoCard and per-tier upgrade blurbs

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-promo-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plan-promo-card.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Tests for PlanPromoCard: the dark, layout-only "promo" card in the billing
+ * Plan section — a centered title, optional one-line blurb, and a single CTA.
+ * Verifies it renders the title, blurb, and CTA label; omits the blurb node
+ * when no blurb is passed; fires `onCtaClick` on click; shows the pending
+ * spinner and blocks the click while pending; and forces the dark palette.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+const { PlanPromoCard } = await import("./plan-promo-card");
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PlanPromoCard", () => {
+  test("renders the title, blurb, and CTA label", async () => {
+    const { findByRole, findByText } = render(
+      <PlanPromoCard
+        title="Upgrade to Mighty"
+        blurb="More power and storage"
+        ctaLabel="Power Up"
+        onCtaClick={() => {}}
+      />,
+    );
+    expect(await findByText("Upgrade to Mighty")).toBeTruthy();
+    expect(await findByText("More power and storage")).toBeTruthy();
+    expect(await findByRole("button", { name: "Power Up" })).toBeTruthy();
+  });
+
+  test("omits the blurb node when blurb is not provided", () => {
+    const { queryByText } = render(
+      <PlanPromoCard
+        title="Customize"
+        ctaLabel="Configure"
+        onCtaClick={() => {}}
+      />,
+    );
+    expect(queryByText("More power and storage")).toBeNull();
+  });
+
+  test("fires onCtaClick when the CTA is clicked", async () => {
+    let clicks = 0;
+    const { findByRole } = render(
+      <PlanPromoCard
+        title="Upgrade to Mighty"
+        ctaLabel="Power Up"
+        onCtaClick={() => {
+          clicks += 1;
+        }}
+      />,
+    );
+    const button = await findByRole("button", { name: "Power Up" });
+    fireEvent.click(button);
+    expect(clicks).toBe(1);
+  });
+
+  test("shows the spinner and blocks the click while pending", async () => {
+    let clicks = 0;
+    const { container, findByRole } = render(
+      <PlanPromoCard
+        title="Upgrade to Mighty"
+        ctaLabel="Power Up"
+        pending
+        onCtaClick={() => {
+          clicks += 1;
+        }}
+      />,
+    );
+    const button = await findByRole("button", { name: "Power Up" });
+    expect(button).toHaveProperty("disabled", true);
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
+    fireEvent.click(button);
+    expect(clicks).toBe(0);
+  });
+
+  test("forces the dark palette on the root", () => {
+    const { container } = render(
+      <PlanPromoCard
+        title="Upgrade to Mighty"
+        ctaLabel="Power Up"
+        onCtaClick={() => {}}
+      />,
+    );
+    expect(container.querySelector('[data-theme="dark"]')).not.toBeNull();
+  });
+
+  test("applies the passed className and ctaTestId", async () => {
+    const { container, findByTestId } = render(
+      <PlanPromoCard
+        title="Upgrade to Mighty"
+        ctaLabel="Power Up"
+        className="lg:flex-[2]"
+        ctaTestId="promo-cta"
+        onCtaClick={() => {}}
+      />,
+    );
+    expect(container.querySelector(".lg\\:flex-\\[2\\]")).not.toBeNull();
+    expect(await findByTestId("promo-cta")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/settings/billing/plan-promo-card.tsx
+++ b/clients/web/src/domains/settings/billing/plan-promo-card.tsx
@@ -1,0 +1,77 @@
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/utils/misc";
+import { Button } from "@vellumai/design-library/components/button";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+export interface PlanPromoCardProps {
+  title: string;
+  /** One-line supporting copy under the title; omitted on the customize variant. */
+  blurb?: string;
+  ctaLabel: string;
+  ctaTestId?: string;
+  pending?: boolean;
+  disabled?: boolean;
+  onCtaClick: () => void;
+  /** Extra root classes (e.g. the lg:flex-[2] width share); applied last. */
+  className?: string;
+}
+
+/**
+ * The dark "promo" card in the billing "Plan" section — a centered title,
+ * optional one-line blurb, and a single CTA. Purely presentational: the parent
+ * owns the copy, the pending/disabled state, and the CTA behavior. The forced
+ * `data-theme="dark"` scope resolves the semantic tokens to the mock's dark
+ * palette (surface ~#17191C, `--content-secondary` blurb ~#A9B2BB).
+ */
+export function PlanPromoCard({
+  title,
+  blurb,
+  ctaLabel,
+  ctaTestId,
+  pending = false,
+  disabled = false,
+  onCtaClick,
+  className,
+}: PlanPromoCardProps) {
+  return (
+    <div
+      data-theme="dark"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-5 rounded-xl bg-[var(--surface-base)] py-5 pl-3 pr-4",
+        className,
+      )}
+    >
+      <div className="flex flex-col items-center gap-2 text-center">
+        <Typography
+          as="span"
+          variant="body-large-default"
+          className="text-[var(--content-default)]"
+        >
+          {title}
+        </Typography>
+        {blurb ? (
+          <Typography
+            as="span"
+            variant="body-small-default"
+            className="text-[var(--content-secondary)]"
+          >
+            {blurb}
+          </Typography>
+        ) : null}
+      </div>
+      <Button
+        variant="primary"
+        className="h-8 shrink-0"
+        onClick={onCtaClick}
+        disabled={disabled || pending}
+        leftIcon={
+          pending ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined
+        }
+        data-testid={ctaTestId}
+      >
+        {ctaLabel}
+      </Button>
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/billing/plans/plans-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/plans-copy.ts
@@ -21,6 +21,8 @@ export interface PlanTierCopy {
   recommended?: boolean;
   /** Feature rows appended after the catalog-derived rows. */
   extraFeatures?: readonly string[];
+  /** One-line pitch shown on the billing page's dark "Upgrade to X" card. */
+  upgradeBlurb?: string;
 }
 
 export const PLAN_TIER_COPY: Record<PlanTierKey, PlanTierCopy> = {
@@ -34,18 +36,21 @@ export const PLAN_TIER_COPY: Record<PlanTierKey, PlanTierCopy> = {
     cta: "Power Up",
     priceCaption: "Billed monthly",
     recommended: true,
+    upgradeBlurb: "$25 in Credits, more storage and power",
   },
   super: {
     tagline: "Stronger performance for heavier workloads.",
     cta: "Go Super",
     priceCaption: "Billed monthly",
     extraFeatures: ["Assistant email and subdomain"],
+    upgradeBlurb: "$45 credits, 3× storage, more power, and email.",
   },
   ultra: {
     tagline: "Our highest level of power and capacity.",
     cta: "Unleash Ultra",
     priceCaption: "Billed monthly",
     extraFeatures: ["Assistant email and subdomain"],
+    upgradeBlurb: "$115 credits, 2x storage, more power, and email.",
   },
 };
 


### PR DESCRIPTION
## Summary
- New presentational dark PlanPromoCard (centered title/blurb/CTA) matching the plan-section mock
- Add upgradeBlurb per-tier copy (mighty/super/ultra) to PLAN_TIER_COPY
- Not yet wired into the page — consumed by a later PR

Part of plan: plan-section-promo-cards.md (PR 2 of 4)