### PR TITLE
feat(billing): point the resize-card upgrade modal at the plans takeover

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -256,9 +256,15 @@ export function PlansPage() {
     notPlatformHosted || subscriptionQuery.isError || catalogEmpty;
   useEffect(() => {
     if (cannotResolve) {
-      navigate(routes.settings.usageBilling, { replace: true });
+      // Platform-hosted but catalog-empty (pro-packages off) or a failed
+      // subscription read still has an upgrade path via the billing adjust-plan
+      // modal; self-hosted / no session does not.
+      const target = notPlatformHosted
+        ? routes.settings.usageBilling
+        : `${routes.settings.usageBilling}&adjust_plan`;
+      navigate(target, { replace: true });
     }
-  }, [cannotResolve, navigate]);
+  }, [cannotResolve, notPlatformHosted, navigate]);
 
   const handleBack = () => {
     const idx = (window.history.state as { idx?: number } | null)?.idx ?? 0;

--- a/clients/web/src/domains/settings/components/resize-card.tsx
+++ b/clients/web/src/domains/settings/components/resize-card.tsx
@@ -392,11 +392,10 @@ export function ResizeCard({
       >
         <Modal.Content size="sm">
           <Modal.Header>
-            <Modal.Title>Upgrade to Pro</Modal.Title>
+            <Modal.Title>Upgrade your plan</Modal.Title>
             <Modal.Description>
-              {upgradeModalOpen === "storage"
-                ? "Upgrade to the Pro plan to increase your storage allocation and get more space for your assistant."
-                : "Upgrade to the Pro plan to unlock larger machine sizes with more CPU and memory for your assistant."}
+              Move to a higher plan for more power, more storage, and a larger
+              credit bundle.
             </Modal.Description>
           </Modal.Header>
           <Modal.Footer>
@@ -406,7 +405,7 @@ export function ResizeCard({
             <Button
               onClick={() => {
                 setUpgradeModalOpen(null);
-                void navigate(`${routes.settings.usage}?tab=billing&adjust_plan=1`);
+                void navigate(routes.plans);
               }}
             >
               Upgrade
@@ -475,7 +474,7 @@ export function ResizeCard({
             <span className="text-label-small-default text-[var(--content-tertiary)]">
               Need more?{" "}
               <Link
-                to={`${routes.settings.usage}?tab=billing&adjust_plan=1`}
+                to={routes.plans}
                 className="text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 transition-colors hover:text-[var(--content-default)]"
                 onClick={() => setResizeModalOpen(false)}
               >


### PR DESCRIPTION
## Summary
- Free-plan upgrade modal: new title/subtitle, "Upgrade" routes to the plans takeover
- Pro-resize footer "Upgrade plan" link also routes to the takeover

Part of plan: plan-copy-and-upgrade-ctas.md (PR 4 of 4)