### PR TITLE
feat(billing): render plan-tier avatars without eyes

### DIFF
--- a/clients/web/src/components/avatar-renderer.tsx
+++ b/clients/web/src/components/avatar-renderer.tsx
@@ -7,7 +7,8 @@ import type { CharacterComponents } from "@/types/avatar";
 export interface AvatarRendererProps {
   components: CharacterComponents;
   bodyShapeId: string;
-  eyeStyleId: string;
+  /** Omit (or pass null) to render a body-only, eyeless avatar. */
+  eyeStyleId?: string | null;
   colorId: string;
   size?: number;
   className?: string;

--- a/clients/web/src/domains/settings/billing/plan-tier-meta.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tier-meta.tsx
@@ -46,10 +46,12 @@ export function PlanTierAvatar({
     return (
         <div aria-hidden className="inline-flex shrink-0">
             {components ? (
+                // Plan-tier avatars render eyeless (body-only); the eye style is
+                // deliberately omitted. `TIER_TRAITS[tier].eyeStyle` is retained
+                // for other consumers of the trait table.
                 <AvatarRenderer
                     components={components}
                     bodyShapeId={traits.bodyShape}
-                    eyeStyleId={traits.eyeStyle}
                     colorId={traits.color}
                     size={size}
                 />

--- a/clients/web/src/utils/avatar-svg-compositor.test.ts
+++ b/clients/web/src/utils/avatar-svg-compositor.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for the trait→SVG compositor, focused on the optional eye style.
+ * Plan-tier avatars render body-only (eyeless); every other consumer passes a
+ * real eye style and must keep its eyes. These assertions lock in both paths:
+ * an absent eye style emits exactly one `<path>` (the body) and the body path
+ * stays byte-identical whether or not eyes are drawn.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { CharacterComponents } from "@/types/avatar";
+import { composeSvg } from "@/utils/avatar-svg-compositor";
+
+const components: CharacterComponents = {
+  bodyShapes: [
+    {
+      id: "blob",
+      viewBox: { width: 100, height: 100 },
+      faceCenter: { x: 50, y: 50 },
+      svgPath: "M0 0h100v100H0z",
+    },
+  ],
+  eyeStyles: [
+    {
+      id: "grumpy",
+      sourceViewBox: { width: 40, height: 40 },
+      eyeCenter: { x: 20, y: 20 },
+      paths: [
+        { svgPath: "M10 10h5v5h-5z", color: "#000" },
+        { svgPath: "M25 10h5v5h-5z", color: "#000" },
+      ],
+    },
+  ],
+  colors: [{ id: "green", hex: "#0f0" }],
+  faceCenterOverrides: [],
+};
+
+const countPaths = (svg: string): number =>
+  (svg.match(/<path\b/g) ?? []).length;
+
+describe("composeSvg eye style handling", () => {
+  test("emits a body path plus one path per eye path when an eye style is given", () => {
+    const svg = composeSvg(components, "blob", "grumpy", "green", 64);
+    // 1 body + 2 eye paths.
+    expect(countPaths(svg)).toBe(3);
+  });
+
+  test("emits only the body path when the eye style is null", () => {
+    const svg = composeSvg(components, "blob", null, "green", 64);
+    expect(countPaths(svg)).toBe(1);
+    expect(svg).toContain(components.bodyShapes[0]!.svgPath);
+    // No eye path made it into the output.
+    expect(svg).not.toContain(components.eyeStyles[0]!.paths[0]!.svgPath);
+  });
+
+  test("emits only the body path when the eye style is omitted (undefined)", () => {
+    const svg = composeSvg(components, "blob", undefined, "green", 64);
+    expect(countPaths(svg)).toBe(1);
+  });
+
+  test("keeps the body path byte-identical whether or not eyes are drawn", () => {
+    const withEyes = composeSvg(components, "blob", "grumpy", "green", 64);
+    const bodyOnly = composeSvg(components, "blob", null, "green", 64);
+    const bodyPath = bodyOnly.replace(
+      /^<svg[^>]*>|<\/svg>$/g,
+      "",
+    );
+    // The eyed SVG contains exactly the same body path element.
+    expect(withEyes).toContain(bodyPath);
+  });
+
+  test("still throws for a present-but-unknown eye style id", () => {
+    expect(() => composeSvg(components, "blob", "nope", "green", 64)).toThrow(
+      'Unknown eye style: "nope"',
+    );
+  });
+});

--- a/clients/web/src/utils/avatar-svg-compositor.ts
+++ b/clients/web/src/utils/avatar-svg-compositor.ts
@@ -11,6 +11,27 @@ export interface AvatarTransforms {
 }
 
 /**
+ * Compute the body group's scale and translation for the target size. Shared by
+ * {@link computeTransforms} (which layers the eye math on top) and the eyeless
+ * body-only path so both derive the body matrix from one formula.
+ */
+function computeBodyPlacement(
+  bodyShape: BodyShapeDefinition,
+  size: number,
+): { bodyScale: number; bodyTx: number; bodyTy: number } {
+  const bodyVB = bodyShape.viewBox;
+  const bodyScale = Math.min(size / bodyVB.width, size / bodyVB.height);
+  const bodyTx = (size - bodyVB.width * bodyScale) / 2;
+  const bodyTy = (size - bodyVB.height * bodyScale) / 2;
+  return { bodyScale, bodyTx, bodyTy };
+}
+
+function computeBodyTransform(bodyShape: BodyShapeDefinition, size: number): string {
+  const { bodyScale, bodyTx, bodyTy } = computeBodyPlacement(bodyShape, size);
+  return `matrix(${bodyScale},0,0,${bodyScale},${bodyTx},${bodyTy})`;
+}
+
+/**
  * Compute the SVG transform strings for body and eye groups.
  */
 export function computeTransforms(
@@ -25,9 +46,7 @@ export function computeTransforms(
   const faceCenter = override ? override.faceCenter : bodyShape.faceCenter;
 
   const bodyVB = bodyShape.viewBox;
-  const bodyScale = Math.min(size / bodyVB.width, size / bodyVB.height);
-  const bodyTx = (size - bodyVB.width * bodyScale) / 2;
-  const bodyTy = (size - bodyVB.height * bodyScale) / 2;
+  const { bodyScale, bodyTx, bodyTy } = computeBodyPlacement(bodyShape, size);
 
   const eyeVB = eyeStyle.sourceViewBox;
   const remapScale = Math.min(
@@ -48,7 +67,9 @@ export function computeTransforms(
 }
 
 /**
- * Resolve the active definitions from components + trait IDs.
+ * Resolve the active definitions from components + trait IDs. When `eyeStyleId`
+ * is absent (null/undefined) the eye style is left unresolved (body-only
+ * avatars); a present-but-unknown id still throws, as before.
  */
 export function resolveDefinitions(
   components: CharacterComponents,
@@ -59,11 +80,34 @@ export function resolveDefinitions(
   bodyShape: BodyShapeDefinition;
   eyeStyle: EyeStyleDefinition;
   color: ColorDefinition;
+};
+export function resolveDefinitions(
+  components: CharacterComponents,
+  bodyShapeId: string,
+  eyeStyleId: string | null | undefined,
+  colorId: string,
+): {
+  bodyShape: BodyShapeDefinition;
+  eyeStyle: EyeStyleDefinition | undefined;
+  color: ColorDefinition;
+};
+export function resolveDefinitions(
+  components: CharacterComponents,
+  bodyShapeId: string,
+  eyeStyleId: string | null | undefined,
+  colorId: string,
+): {
+  bodyShape: BodyShapeDefinition;
+  eyeStyle: EyeStyleDefinition | undefined;
+  color: ColorDefinition;
 } {
   const bodyShape = components.bodyShapes.find((b) => b.id === bodyShapeId);
   if (!bodyShape) throw new Error(`Unknown body shape: "${bodyShapeId}"`);
-  const eyeStyle = components.eyeStyles.find((e) => e.id === eyeStyleId);
-  if (!eyeStyle) throw new Error(`Unknown eye style: "${eyeStyleId}"`);
+  let eyeStyle: EyeStyleDefinition | undefined;
+  if (eyeStyleId != null) {
+    eyeStyle = components.eyeStyles.find((e) => e.id === eyeStyleId);
+    if (!eyeStyle) throw new Error(`Unknown eye style: "${eyeStyleId}"`);
+  }
   const color = components.colors.find((c) => c.id === colorId);
   if (!color) throw new Error(`Unknown color: "${colorId}"`);
   return { bodyShape, eyeStyle, color };
@@ -80,7 +124,7 @@ function escapeAttr(s: string): string {
 export function composeSvg(
   components: CharacterComponents,
   bodyShapeId: string,
-  eyeStyleId: string,
+  eyeStyleId: string | null | undefined,
   colorId: string,
   size: number = 512,
 ): string {
@@ -95,11 +139,18 @@ export function composeSvg(
 
 export function composeSvgFromDefinitions(
   bodyShape: BodyShapeDefinition,
-  eyeStyle: EyeStyleDefinition,
+  eyeStyle: EyeStyleDefinition | null | undefined,
   color: ColorDefinition,
   components: CharacterComponents,
   size: number = 512,
 ): string {
+  // Body-only (eyeless) avatar: skip the eye-transform math and emit no eye paths.
+  if (!eyeStyle) {
+    const bodyTransform = computeBodyTransform(bodyShape, size);
+    const bodyPath = `<path d="${escapeAttr(bodyShape.svgPath)}" fill="${escapeAttr(color.hex)}" transform="${bodyTransform}"/>`;
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">${bodyPath}</svg>`;
+  }
+
   const { bodyTransform, eyeTransform } = computeTransforms(bodyShape, eyeStyle, components, size);
 
   const bodyPath = `<path d="${escapeAttr(bodyShape.svgPath)}" fill="${escapeAttr(color.hex)}" transform="${bodyTransform}"/>`;


### PR DESCRIPTION
## Summary
- Make the eye style optional in composeSvg / AvatarRenderer (body-only when absent)
- PlanTierAvatar now renders eyeless creatures for both billing Plan cards and plans-page pro columns
- Non-plan avatar consumers (chat/subagents/onboarding) keep their eyes

Part of plan: plan-section-promo-cards.md (PR 1 of 4)