### PR TITLE
feat(billing): point the assistant-email upsell at the plans takeover

### DIFF
--- a/clients/web/src/domains/settings/ai/ai-page.test.tsx
+++ b/clients/web/src/domains/settings/ai/ai-page.test.tsx
@@ -5,7 +5,7 @@
  * admin `EntitlementOverride` that grants managed email to a Base org is
  * honored in-product. We verify both directions:
  *
- *  - Base org WITHOUT the entitlement → "Upgrade to Pro" notice, form gated.
+ *  - Base org WITHOUT the entitlement → "Upgrade" notice, form gated.
  *  - Base org WITH the entitlement (override) → domain/address form renders,
  *    proving the gate reads the entitlement and not the plan.
  *
@@ -91,8 +91,11 @@ function renderCard(subscription: SubscriptionResponse): string {
 describe("EmailServiceCard managed-email gate", () => {
   test("Base org without the managed_email entitlement sees the upgrade notice", () => {
     const html = renderCard(makeSubscription(false, "base"));
-    expect(html).toContain("Upgrade to Pro");
-    expect(html).toContain("Get a dedicated email address for your assistant");
+    expect(html).toContain("Upgrade");
+    expect(html).toContain("Give your assistant its own email address");
+    expect(html).toContain(
+      "Upgrade to a plan that includes an email address for your assistant. No provider setup required.",
+    );
     // The domain registration form must NOT render when gated.
     expect(html).not.toContain("Register");
   });
@@ -100,8 +103,7 @@ describe("EmailServiceCard managed-email gate", () => {
   test("Base org WITH the managed_email entitlement sees the form, not the notice", () => {
     // plan_id stays "base" — only the entitlement (admin override) is true.
     const html = renderCard(makeSubscription(true, "base"));
-    expect(html).not.toContain("Upgrade to Pro");
-    expect(html).not.toContain("Get a dedicated email address for your assistant");
+    expect(html).not.toContain("Give your assistant its own email address");
     // The domain registration form renders for entitled orgs.
     expect(html).toContain("Subdomain");
     expect(html).toContain("Register");
@@ -121,8 +123,7 @@ describe("EmailServiceCard managed-email gate", () => {
       cancel_at: null,
     } as unknown as SubscriptionResponse;
     const html = renderCard(subscriptionWithoutEntitlements);
-    expect(html).not.toContain("Upgrade to Pro");
-    expect(html).not.toContain("Get a dedicated email address for your assistant");
+    expect(html).not.toContain("Give your assistant its own email address");
     // The domain registration form renders (fail-open).
     expect(html).toContain("Subdomain");
     expect(html).toContain("Register");

--- a/clients/web/src/domains/settings/ai/email-managed-content.tsx
+++ b/clients/web/src/domains/settings/ai/email-managed-content.tsx
@@ -1,6 +1,6 @@
 import {
-    Crown,
     Loader2,
+    Mail,
     Trash2,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
@@ -278,21 +278,19 @@ export function EmailManagedContent({
     return (
       <Notice
         tone="info"
-        icon={<Crown className="h-4 w-4" aria-hidden />}
-        title="Get a dedicated email address for your assistant"
+        icon={<Mail className="h-4 w-4" aria-hidden />}
+        title="Give your assistant its own email address"
         actions={
           <Button
             size="compact"
-            onClick={() => navigate(`${routes.settings.usage}?tab=billing&adjust_plan`)}
+            onClick={() => navigate(routes.plans)}
           >
-            Upgrade to Pro
+            Upgrade
           </Button>
         }
       >
-        Pro plans include a managed{" "}
-        {`<your-subdomain>.${emailRootDomain}`} inbox — no provider
-        setup required. Or switch to <strong>Your Own</strong> to bring
-        an existing provider.
+        Upgrade to a plan that includes an email address for your
+        assistant. No provider setup required.
       </Notice>
     );
   }


### PR DESCRIPTION
## Summary
- Closed-envelope (Mail) icon, new title/subtitle
- CTA relabeled "Upgrade" and routed to the plans takeover (routes.plans)

Part of plan: plan-copy-and-upgrade-ctas.md (PR 3 of 4)