### PR TITLE
feat(billing): point the storage-low banner's Upgrade CTA at the plans takeover

### DIFF
--- a/clients/web/src/components/disk-pressure-banner.test.tsx
+++ b/clients/web/src/components/disk-pressure-banner.test.tsx
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { DiskPressureStatus } from "@vellumai/assistant-api";
+
+const { DiskPressureBanner } = await import("@/components/disk-pressure-banner");
+
+afterEach(() => {
+  cleanup();
+});
+
+const warningStatus: DiskPressureStatus = {
+  enabled: true,
+  state: "warning",
+  locked: false,
+  acknowledged: false,
+  overrideActive: false,
+  effectivelyLocked: false,
+  lockId: null,
+  usagePercent: 85,
+  thresholdPercent: 90,
+  path: "/workspace",
+  lastCheckedAt: null,
+  blockedCapabilities: [],
+  error: null,
+};
+
+describe("DiskPressureBanner warning variant", () => {
+  test("renders the storage-low copy and CTA labels", () => {
+    const onUpgradeStorage = mock(() => {});
+    const onReviewWorkspaceData = mock(() => {});
+
+    render(
+      <DiskPressureBanner
+        status={warningStatus}
+        mode="warning"
+        onAcknowledge={() => {}}
+        onUpgradeStorage={onUpgradeStorage}
+        onReviewWorkspaceData={onReviewWorkspaceData}
+      />,
+    );
+
+    expect(screen.getByText("Your storage is almost full")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Free up space or add more storage to avoid interruptions.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Manage Storage" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Upgrade" })).toBeTruthy();
+  });
+
+  test("invokes onUpgradeStorage when Upgrade is clicked", () => {
+    const onUpgradeStorage = mock(() => {});
+
+    render(
+      <DiskPressureBanner
+        status={warningStatus}
+        mode="warning"
+        onAcknowledge={() => {}}
+        onUpgradeStorage={onUpgradeStorage}
+        onReviewWorkspaceData={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    expect(onUpgradeStorage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/components/disk-pressure-banner.tsx
+++ b/clients/web/src/components/disk-pressure-banner.tsx
@@ -1,5 +1,5 @@
 
-import { AlertTriangle, HardDrive } from "lucide-react";
+import { AlertTriangle, Package } from "lucide-react";
 import { useState } from "react";
 
 import { formatDiskPressureUsage } from "@/assistant/disk-pressure";
@@ -46,8 +46,8 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
     return (
       <Notice
         tone="warning"
-        title="Storage is running low"
-        icon={<HardDrive className="h-4 w-4" aria-hidden="true" />}
+        title="Your storage is almost full"
+        icon={<Package className="h-4 w-4" aria-hidden="true" />}
         onDismiss={
           onDismissWarning
             ? () => onDismissWarning(dontShowAgain)
@@ -72,7 +72,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
             </span>
           </div>
           <p className="m-0">
-            Your assistant will enter a locked state if it runs out of storage.
+            Free up space or add more storage to avoid interruptions.
           </p>
           <div className="flex flex-wrap items-center gap-2">
             {onReviewWorkspaceData && (
@@ -81,7 +81,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
                 size="compact"
                 onClick={onReviewWorkspaceData}
               >
-                Review Workspace Data
+                Manage Storage
               </Button>
             )}
             {onUpgradeStorage && (
@@ -90,7 +90,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
                 size="compact"
                 onClick={onUpgradeStorage}
               >
-                Upgrade Storage
+                Upgrade
               </Button>
             )}
             {onDismissWarning ? (
@@ -115,7 +115,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
       <Notice
         tone="warning"
         title="Cleanup mode is active"
-        icon={<HardDrive className="h-4 w-4" aria-hidden="true" />}
+        icon={<Package className="h-4 w-4" aria-hidden="true" />}
         className="p-4"
         data-testid="disk-pressure-banner"
       >
@@ -144,7 +144,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
                 size="compact"
                 onClick={onReviewWorkspaceData}
               >
-                Review Workspace Data
+                Manage Storage
               </Button>
             )}
             {onUpgradeStorage && (
@@ -153,7 +153,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
                 size="compact"
                 onClick={onUpgradeStorage}
               >
-                Upgrade Storage
+                Upgrade
               </Button>
             )}
           </div>
@@ -169,7 +169,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
       <Notice
         tone="error"
         title="Storage is critically low"
-        icon={<HardDrive className="h-4 w-4" aria-hidden="true" />}
+        icon={<Package className="h-4 w-4" aria-hidden="true" />}
         className="p-4"
         data-testid="disk-pressure-banner"
       >
@@ -239,7 +239,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
                   onUpgradeStorage();
                 }}
               >
-                Upgrade Storage
+                Upgrade
               </Button>
             )}
             <Button

--- a/clients/web/src/domains/chat/components/disk-pressure-banner-slot.tsx
+++ b/clients/web/src/domains/chat/components/disk-pressure-banner-slot.tsx
@@ -98,7 +98,7 @@ export function DiskPressureBannerSlot({
       onAcknowledge={() => void diskPressure.acknowledge()}
       onDismissWarning={dismissWarning}
       onReviewWorkspaceData={() => void navigate(`${routes.workspace}?sort=size`)}
-      onUpgradeStorage={assistantStateKind === "active" ? () => void navigate(`${routes.settings.usage}?tab=billing&adjust_plan=1`) : null}
+      onUpgradeStorage={assistantStateKind === "active" ? () => void navigate(routes.plans) : null}
     />
   );
 }

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -149,7 +149,7 @@ export function GeneralPage() {
           }
           onUpgradeStorage={
             infraGate === "full"
-              ? () => void navigate(`${routes.settings.usage}?tab=billing&adjust_plan=1`)
+              ? () => void navigate(routes.plans)
               : null
           }
         />


### PR DESCRIPTION
## Summary
- Package icon, new warning title/subtitle, "Manage Storage" + "Upgrade" labels
- Upgrade CTA now routes to the plans takeover (routes.plans) from the chat slot and General page

Part of plan: plan-copy-and-upgrade-ctas.md (PR 2 of 4)