### PR TITLE
feat(billing): promo-style recommended card with custom-plan path for top-tier and custom subs

### DIFF
--- a/clients/web/src/domains/settings/components/plan-card-checkout.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card-checkout.test.tsx
@@ -1,11 +1,11 @@
 /**
  * Interaction tests for the PlanCard recommended-upgrade CTA.
  *
- * Clicking "Upgrade for _ more" fires the Stripe upgrade for the recommended
- * package and redirects to the returned checkout URL — and stashes the
- * purchased package first, so the post-checkout provisioning screen shows what
- * was actually bought instead of an intent left behind by an abandoned earlier
- * checkout.
+ * Clicking the promo card's "Upgrade" CTA fires the Stripe upgrade for the
+ * recommended package and redirects to the returned checkout URL — and stashes
+ * the purchased package first, so the post-checkout provisioning screen shows
+ * what was actually bought instead of an intent left behind by an abandoned
+ * earlier checkout.
  *
  * Strategy mirrors plans-page-checkout.test.tsx: mock the generated SDK to
  * capture the upgrade body and return a redirect, and mock `openUrl` to capture

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -31,11 +31,13 @@ import {
   organizationsBillingSubscriptionRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type {
+  CreditTier,
   PackageChangeResponse,
   PlanListResponse,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
 import * as runtimeBrowser from "@/runtime/browser";
+import * as toastModule from "@vellumai/design-library/components/toast";
 import { PLAN_TIER_COPY } from "@/domains/settings/billing/plans/plans-copy";
 import { routes } from "@/utils/routes";
 
@@ -77,6 +79,16 @@ let changePackageImpl: () => Promise<{
 });
 let currentSub: SubscriptionResponse = baseSubscription();
 let currentPlans: PlanListResponse = basePlansResponse();
+// Change-tier mutation captures for the customize (CustomPlanModal) flow. Each
+// records the request body so a test can assert which dimension(s) a
+// `changeTiers` dispatch actually posted.
+let changeCreditTierCall: Captured | null = null;
+let changeMachineTierCall: Captured | null = null;
+let changeStorageTierCall: Captured | null = null;
+// The onboarding retrieve carries the current machine/storage tiers that seed
+// the CustomPlanModal. Defaults to empty (no seed) so existing tests are
+// unaffected; the customize tests set it to seed a starting configuration.
+let onboardingResponse: Record<string, unknown> = {};
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -93,7 +105,39 @@ mock.module("@/generated/api/sdk.gen", () => ({
   organizationsBillingPlansRetrieve: () =>
     Promise.resolve({ data: currentPlans, response: { ok: true } }),
   organizationsBillingSubscriptionOnboardingRetrieve: () =>
-    Promise.resolve({ data: {}, response: { ok: true } }),
+    Promise.resolve({ data: onboardingResponse, response: { ok: true } }),
+  // The three change-tier endpoints back the customize flow's `changeTiers`.
+  organizationsBillingSubscriptionChangeCreditTierCreate: (opts: Captured) => {
+    changeCreditTierCall = opts;
+    return Promise.resolve({
+      data: { status: "ok", credit_tier: null },
+      response: { ok: true },
+    });
+  },
+  organizationsBillingSubscriptionChangeMachineTierCreate: (opts: Captured) => {
+    changeMachineTierCall = opts;
+    return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
+  },
+  organizationsBillingSubscriptionChangeStorageTierCreate: (opts: Captured) => {
+    changeStorageTierCall = opts;
+    return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
+  },
+}));
+
+// Capture success toasts so the customize flow's credit-only vs resize branch
+// can be asserted (the resize takeover is opened via `onTierUpgraded`, not a
+// toast, so a credit-only change is the only one that toasts here).
+let toastSuccessCalls: string[] = [];
+mock.module("@vellumai/design-library/components/toast", () => ({
+  ...toastModule,
+  toast: Object.assign((..._args: unknown[]) => {}, {
+    success: (message: string) => {
+      toastSuccessCalls.push(String(message));
+    },
+    error: () => {},
+    info: () => {},
+    warning: () => {},
+  }),
 }));
 
 // Capture the Stripe checkout redirect instead of opening a browser.
@@ -250,6 +294,97 @@ function proUltraSubscription(): SubscriptionResponse {
   };
 }
 
+const CUSTOMIZE_CREDIT_TIERS: CreditTier[] = [
+  {
+    tier: "credits_25",
+    label: "$25 in credits",
+    credits_usd: 25,
+    price_cents: 2500,
+    lookup_key: "credits_25_lk",
+    legacy: false,
+  },
+  {
+    tier: "credits_45",
+    label: "$45 in credits",
+    credits_usd: 45,
+    price_cents: 4500,
+    lookup_key: "credits_45_lk",
+    legacy: false,
+  },
+];
+
+/**
+ * A Pro catalog whose machine/storage/credit tier LISTS are populated (the
+ * package-only fixtures leave them empty), so a seeded CustomPlanModal can drive
+ * a real tier change through `changeTiers`. Extends `plansWithSuper()` so the
+ * sub stays switch-eligible (Mighty → Super) and the customize card renders.
+ */
+function plansForCustomize(): PlanListResponse {
+  const plans = plansWithSuper();
+  const pro = plans.plans.find((p) => p.id === "pro");
+  if (pro && "machine_tiers" in pro) {
+    pro.machine_tiers = [
+      {
+        tier: "medium",
+        label: "Medium",
+        description: "Medium machine",
+        price_cents: 3500,
+        lookup_key: "machine_medium_lk",
+        cpu_limit: "2",
+        memory_gib: 4,
+      },
+      {
+        tier: "large",
+        label: "Large",
+        description: "Large machine",
+        price_cents: 7000,
+        lookup_key: "machine_large_lk",
+        cpu_limit: "4",
+        memory_gib: 8,
+      },
+    ];
+    pro.storage_tiers = [
+      {
+        tier: "xs",
+        label: "10 GB storage",
+        storage_gib: 10,
+        price_cents: 0,
+        lookup_key: "storage_xs_lk",
+        legacy: false,
+      },
+      {
+        tier: "s",
+        label: "30 GB storage",
+        storage_gib: 30,
+        price_cents: 1000,
+        lookup_key: "storage_s_lk",
+        legacy: false,
+      },
+    ];
+    pro.credit_tiers = CUSTOMIZE_CREDIT_TIERS;
+  }
+  return plans;
+}
+
+/**
+ * A customized (switch-eligible) Pro sub seeded on the Mighty package with an
+ * existing credit bundle, so the CustomPlanModal opens pre-filled.
+ */
+function proCustomizeSubscription(): SubscriptionResponse {
+  return {
+    ...proMightySubscription(),
+    package: { key: "mighty", name: "Mighty", version: 1, customized: true },
+    selected_credit_tier: "credits_25",
+  };
+}
+
+/** The onboarding response that seeds the CustomPlanModal's current tiers. */
+const CUSTOMIZE_ONBOARDING: Record<string, unknown> = {
+  max_machine_tier: "medium",
+  selected_storage_tier: "xs",
+  selected_storage_gib: 10,
+};
+
 /** A catalog with the `pro-packages` flag off — the Pro plan has no packages. */
 function emptyCatalogPlans(): PlanListResponse {
   const plans = basePlansResponse();
@@ -316,6 +451,28 @@ function renderCardInteractive(
   );
 }
 
+/** Opens a CustomPlanModal dropdown by its combobox aria-label. */
+function getDropdownTrigger(label: string): HTMLButtonElement {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    `button[role="combobox"][aria-label="${label}"]`,
+  );
+  if (!trigger) {
+    throw new Error(`expected a ${label} dropdown trigger`);
+  }
+  return trigger;
+}
+
+/** Clicks the first open dropdown option whose text starts with `prefix`. */
+function clickOptionStartingWith(prefix: string): void {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim().startsWith(prefix));
+  if (!option) {
+    throw new Error(`expected option starting with "${prefix}"`);
+  }
+  fireEvent.click(option);
+}
+
 /** Waits for the PackageSwitchConfirmModal (portaled) to open. */
 async function findConfirmDialogButton(): Promise<HTMLButtonElement> {
   return await waitFor(() => {
@@ -345,6 +502,11 @@ beforeEach(() => {
     response: { ok: true },
   });
   openedUrl = null;
+  changeCreditTierCall = null;
+  changeMachineTierCall = null;
+  changeStorageTierCall = null;
+  onboardingResponse = {};
+  toastSuccessCalls = [];
 });
 
 afterEach(() => {
@@ -990,6 +1152,85 @@ describe("PlanCard recommended upgrade — change-package", () => {
     // No configurator opened, no navigation.
     expect(document.querySelector("[data-testid='confirm-package-switch-button']")).toBeNull();
     expect(navigateArgs).toEqual([]);
+  });
+
+  test("a customize credit-only change toasts and does NOT open the resize takeover", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // The billing-page resize takeover is credit-agnostic (`onTierUpgraded` is
+    // argument-less), so a credit-only change must toast "Credit bundle updated."
+    // — like AdjustPlanModal — instead of popping a blank takeover.
+    onboardingResponse = CUSTOMIZE_ONBOARDING;
+    const { findByTestId, findByText, findByRole } = renderCardInteractive(
+      proCustomizeSubscription(),
+      plansForCustomize(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    const cta = (await findByTestId(
+      "recommended-customize-button",
+    )) as HTMLButtonElement;
+    await waitFor(() => expect(cta.disabled).toBe(false));
+    fireEvent.click(cta);
+    await findByText("Just better.");
+
+    // Swap ONLY the credit bundle, then Continue — a credit-only change.
+    fireEvent.click(getDropdownTrigger("Credit bundle"));
+    clickOptionStartingWith("$45 in credits");
+    fireEvent.click(await findByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      if (!changeCreditTierCall) {
+        throw new Error("credit-tier change not called");
+      }
+    });
+    // Only the credit dimension posts...
+    expect(
+      (changeCreditTierCall!.body as Record<string, unknown>).credit_tier,
+    ).toBe("credits_45");
+    expect(changeMachineTierCall).toBeNull();
+    expect(changeStorageTierCall).toBeNull();
+    // ...and it toasts rather than opening the credit-agnostic resize takeover.
+    await waitFor(() => {
+      expect(toastSuccessCalls).toContain("Credit bundle updated.");
+    });
+    expect(onTierUpgraded).not.toHaveBeenCalled();
+  });
+
+  test("a customize storage upgrade opens the resize takeover", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // A real machine/storage resize DOES hand off to the takeover via
+    // `onTierUpgraded` (and does not toast the credit-bundle message).
+    onboardingResponse = CUSTOMIZE_ONBOARDING;
+    const { findByTestId, findByText, findByRole } = renderCardInteractive(
+      proCustomizeSubscription(),
+      plansForCustomize(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    const cta = (await findByTestId(
+      "recommended-customize-button",
+    )) as HTMLButtonElement;
+    await waitFor(() => expect(cta.disabled).toBe(false));
+    fireEvent.click(cta);
+    await findByText("Just better.");
+
+    // Bump storage to a larger tier — a real resize.
+    fireEvent.click(getDropdownTrigger("Storage"));
+    clickOptionStartingWith("30 GB storage");
+    fireEvent.click(await findByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(onTierUpgraded).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      (changeStorageTierCall!.body as Record<string, unknown>).storage_tier,
+    ).toBe("s");
+    // A resize hands off to the takeover — no credit-bundle toast.
+    expect(toastSuccessCalls).not.toContain("Credit bundle updated.");
   });
 
   test("a cancelling Pro sub's recommended upgrade stays on the manage path", async () => {

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -208,6 +208,48 @@ function proMightySubscription(): SubscriptionResponse {
   };
 }
 
+/** Catalog with Mighty, Super, and Ultra — so Ultra is the top package. */
+function plansWithUltra(): PlanListResponse {
+  const plans = plansWithSuper();
+  const pro = plans.plans.find((p) => p.id === "pro");
+  if (pro && "packages" in pro && pro.packages) {
+    pro.packages.push({
+      key: "ultra",
+      name: "Ultra",
+      description:
+        "Large machine, 60 GB of storage, and $115 in monthly credits.",
+      version: 1,
+      machine_tier: "large",
+      storage_tier: "l",
+      credit_tier: "credits_115",
+      machine_size: "large",
+      storage_gib: 60,
+      credits_usd: 115,
+      include_platform_fee: true,
+      base_price_cents: 1000,
+      machine_price_cents: 7000,
+      storage_price_cents: 2000,
+      credit_price_cents: 11500,
+      total_price_cents: 20000,
+    });
+  }
+  return plans;
+}
+
+/** A subscriber cleanly pinned to the top (Ultra) Pro package. */
+function proUltraSubscription(): SubscriptionResponse {
+  return {
+    plan_id: "pro",
+    status: "active",
+    renewal_date: null,
+    current_period_end: "2026-08-10T00:00:00Z",
+    cancel_at_period_end: false,
+    cancel_at: null,
+    package: { key: "ultra", name: "Ultra", version: 1, customized: false },
+    entitlements: { managed_email: false, phone_number: false },
+  };
+}
+
 /** A catalog with the `pro-packages` flag off — the Pro plan has no packages. */
 function emptyCatalogPlans(): PlanListResponse {
   const plans = basePlansResponse();
@@ -330,11 +372,12 @@ describe("PlanCard", () => {
     expect(html).not.toContain("plan-card-invoices-button");
   });
 
-  test("renders the recommended-upgrade banner (Mighty from Free)", () => {
+  test("renders the recommended-upgrade promo card (Mighty from Free)", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
     expect(html).toContain("recommended-upgrade-button");
-    expect(html).toContain("Recommended");
-    expect(html).toContain("Mighty");
+    expect(html).toContain("Upgrade to Mighty");
+    // The dark promo card carries no "Recommended" tag.
+    expect(html).not.toContain("Recommended");
   });
 
   test("no upgrade banner when the package catalog is empty (flag off)", () => {
@@ -343,38 +386,34 @@ describe("PlanCard", () => {
     expect(html).not.toContain("recommended-upgrade-button");
   });
 
-  test("Free current card is chip-less; recommended shows the summary chip", () => {
+  test("Free current card is chip-less; recommended shows the promo blurb", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
     // The current (Free) card is now a minimal centered card with NO spec chips:
     // none of the free-baseline chip labels appear.
     expect(html).not.toContain("$0 credits");
     expect(html).not.toContain("4 GB");
     expect(html).not.toContain("Small Machine");
-    // The recommended (Mighty) card shows the single summary chip, replacing the
-    // old absolute per-resource chips (machine · credits · storage). Free→Mighty
-    // stays on the Small baseline, so the chip omits the machine claim.
-    expect(html).toContain("more credits and storage");
-    expect(html).not.toContain("stronger machine");
-    expect(html).not.toContain("$25 credits");
-    expect(html).not.toContain("10 GB");
-    expect(html).not.toContain("vCPU");
+    // The recommended (Mighty) promo card shows "Upgrade to Mighty" plus the
+    // per-tier blurb, replacing the old summary chip — and carries no tag/chips.
+    expect(html).toContain("Upgrade to Mighty");
+    expect(html).toContain(PLAN_TIER_COPY.mighty.upgradeBlurb!);
+    expect(html).not.toContain("more credits and storage");
+    expect(html).not.toContain("Recommended");
     // The centered free card still shows its "Your Current Plan" tag and its real
     // tagline — the tagline follows "known plan", not "has chips".
     expect(html).toContain("Your Current Plan");
     expect(html).toContain(PLAN_TIER_COPY.free.tagline);
   });
 
-  test("Mighty → Super: current keeps its chips, recommended shows the summary chip", () => {
+  test("Mighty → Super: current keeps its chips, recommended shows the promo card", () => {
     const html = renderCard(proMightySubscription(), plansWithSuper());
     // On Mighty, the recommended upgrade is the next catalog package, Super.
     expect(html).toContain("recommended-upgrade-button");
-    expect(html).toContain("Recommended");
-    expect(html).toContain("Super");
-    // The recommended (Super) card shows the single summary chip, not Super's
-    // absolute per-resource chips.
-    expect(html).toContain("more credits, storage, and a stronger machine");
-    expect(html).not.toContain("$45 credits");
-    expect(html).not.toContain("30 GB");
+    expect(html).toContain("Upgrade to Super");
+    expect(html).toContain(PLAN_TIER_COPY.super.upgradeBlurb!);
+    // The promo card carries no "Recommended" tag and no summary chip.
+    expect(html).not.toContain("Recommended");
+    expect(html).not.toContain("more credits, storage, and a stronger machine");
     // The current (Mighty) card keeps its absolute chips.
     expect(html).toContain("$25 credits");
     expect(html).toContain("10 GB");
@@ -383,31 +422,29 @@ describe("PlanCard", () => {
     // generic plan name "Pro").
     expect(html).toContain("plan-card-name");
     expect(html).toContain("Mighty");
-    expect(html).not.toContain("Pro");
   });
 
-  test("an unpinned Custom sub's banner drops the stock upgrade framing", () => {
-    // A legacy unpinned Pro sub's real tiers can diverge from any stock
-    // package, so the banner offers the named plan neutrally: a "Switch plan"
-    // tag and a "Switch to Mighty" CTA, with no "Recommended Upgrade" claim and
-    // no stock price/resource deltas that could point the wrong way.
+  test("an unpinned Custom sub gets the customize promo card", () => {
+    // A legacy unpinned Pro sub's real tiers can diverge from any stock package,
+    // so instead of a named-package upgrade it gets the "Create a custom plan"
+    // promo card whose "Customize" CTA opens the CustomPlanModal.
     const subscription: SubscriptionResponse = {
       ...proMightySubscription(),
       package: null,
     };
     const html = renderCard(subscription, plansWithSuper());
-    expect(html).toContain("recommended-upgrade-button");
-    expect(html).toContain("Switch plan");
-    expect(html).toContain("Switch to Mighty");
-    // A neutral switch drops the "Recommended" tag and renders no chips on the
-    // recommended card — not even the summary chip; the current "Custom" card
-    // also has no knowable chips. Asserting on the "more credits" prefix covers
-    // both the full and machine-less summary labels.
+    expect(html).toContain("recommended-customize-button");
+    expect(html).toContain("Create a custom plan");
+    expect(html).toContain("Customize");
+    // No upgrade/switch framing, no tag, and no chips.
+    expect(html).not.toContain("recommended-upgrade-button");
     expect(html).not.toContain("Recommended");
+    expect(html).not.toContain("Switch plan");
+    expect(html).not.toContain("Switch to");
     expect(html).not.toContain("more credits");
   });
 
-  test("a customized Pro sub's banner drops the stock upgrade framing", () => {
+  test("a customized Pro sub gets the customize promo card", () => {
     const subscription = proMightySubscription();
     subscription.package = {
       key: "mighty",
@@ -416,24 +453,28 @@ describe("PlanCard", () => {
       customized: true,
     };
     const html = renderCard(subscription, plansWithSuper());
-    // Recommended package is Super (next after the Mighty pin), offered as a
-    // neutral switch since the customized tiers can differ from stock Super.
-    expect(html).toContain("Switch plan");
-    expect(html).toContain("Switch to Super");
+    // A customized pin's tiers can differ from stock, so it gets the customize
+    // promo card rather than a named-package upgrade.
+    expect(html).toContain("recommended-customize-button");
+    expect(html).toContain("Create a custom plan");
+    expect(html).toContain("Customize");
+    expect(html).not.toContain("recommended-upgrade-button");
     expect(html).not.toContain("Recommended");
-    // A neutral switch renders no summary chip either. The "more credits" prefix
-    // covers both the full and machine-less summary labels.
+    expect(html).not.toContain("Switch to");
     expect(html).not.toContain("more credits");
   });
 
-  test("a base user's banner keeps the upgrade CTA (not a switch)", () => {
+  test("a base user's banner keeps the upgrade CTA (not a customize)", () => {
     // Base → Pro is a genuine Stripe-checkout upgrade, so the recommended card
-    // keeps its "Recommended" tag and a compact "Upgrade" CTA (no "Switch").
+    // stays on the "Upgrade to X" variant (no customize path).
     const html = renderCard(baseSubscription(), basePlansResponse());
-    expect(html).toContain("Recommended");
-    expect(html).toContain("Upgrade");
+    expect(html).toContain("recommended-upgrade-button");
+    expect(html).toContain("Upgrade to Mighty");
+    expect(html).not.toContain("recommended-customize-button");
+    expect(html).not.toContain("Create a custom plan");
     expect(html).not.toContain("Switch plan");
     expect(html).not.toContain("Switch to");
+    expect(html).not.toContain("Recommended");
   });
 
   test("current-plan row labels a customized package as custom", () => {
@@ -497,9 +538,10 @@ describe("PlanCard", () => {
     expect(html).not.toContain("$0 credits");
     expect(html).not.toContain("4 GB");
     expect(html).not.toContain("Small Machine");
-    // The recommended (Mighty) card shows the single summary chip. Free→Mighty
-    // keeps the Small baseline machine, so the chip claims only credits/storage.
-    expect(html).toContain("more credits and storage");
+    // The recommended (Mighty) promo card shows the per-tier blurb, not a chip.
+    expect(html).toContain("Upgrade to Mighty");
+    expect(html).toContain(PLAN_TIER_COPY.mighty.upgradeBlurb!);
+    expect(html).not.toContain("more credits and storage");
     expect(html).not.toContain("stronger machine");
   });
 });
@@ -827,12 +869,12 @@ describe("PlanCard recommended upgrade — change-package", () => {
     expect(onTierUpgraded).not.toHaveBeenCalled();
   });
 
-  test("an unpinned Pro sub's recommended upgrade opens the neutral switch confirm", async () => {
+  test("an unpinned Pro sub's customize CTA opens the CustomPlanModal", async () => {
     const onManage = mock(() => {});
     const onTierUpgraded = mock(() => {});
-    // An unpinned (Custom) Pro sub is switch-eligible, so the banner CTA reaches
-    // the change-package confirm rather than the manage fallback. Its catalog
-    // rank is unknown, so the confirm copy stays direction-neutral.
+    // An unpinned (Custom) Pro sub is switch-eligible, so the customize CTA opens
+    // the CustomPlanModal (not the change-package confirm, not the manage
+    // fallback).
     const subscription: SubscriptionResponse = {
       ...proMightySubscription(),
       package: null,
@@ -844,23 +886,29 @@ describe("PlanCard recommended upgrade — change-package", () => {
       onTierUpgraded,
     );
 
-    // The banner renders and its CTA opens the neutral switch confirm (currentKey
-    // is null, so the recommended package is Mighty).
-    fireEvent.click(await findByTestId("recommended-upgrade-button"));
-    await findByText("Switch to Mighty?");
-    await findByText(
-      "Your plan changes now. Any prorated difference is charged now or credited to your next invoice.",
-    );
+    const cta = (await findByTestId(
+      "recommended-customize-button",
+    )) as HTMLButtonElement;
+    // The CTA enables once the current tiers settle; opening it reveals the
+    // CustomPlanModal (its unique "Just better." subtitle).
+    await waitFor(() => expect(cta.disabled).toBe(false));
+    fireEvent.click(cta);
+
+    await findByText("Just better.");
+    // Never the change-package confirm nor the manage fallback.
+    expect(
+      document.querySelector("[data-testid='confirm-package-switch-button']"),
+    ).toBeNull();
+    expect(changePackageBody).toBeNull();
     expect(onManage).not.toHaveBeenCalled();
     expect(navigateArgs).toEqual([]);
   });
 
-  test("a customized Pro sub's recommended upgrade opens the neutral switch confirm", async () => {
+  test("a customized Pro sub's customize CTA opens the CustomPlanModal", async () => {
     const onManage = mock(() => {});
     const onTierUpgraded = mock(() => {});
-    // A customized pin is switch-eligible; the change-package endpoint re-pins it
-    // to the named target. Its catalog rank is ambiguous, so the confirm copy
-    // stays direction-neutral instead of claiming an upgrade.
+    // A customized pin is switch-eligible; the customize CTA edits its tiers in
+    // place via the CustomPlanModal.
     const subscription = proMightySubscription();
     subscription.package = {
       key: "mighty",
@@ -875,13 +923,72 @@ describe("PlanCard recommended upgrade — change-package", () => {
       onTierUpgraded,
     );
 
-    // Recommended package is Super (next after the customized Mighty pin).
-    fireEvent.click(await findByTestId("recommended-upgrade-button"));
-    await findByText("Switch to Super?");
-    await findByText(
-      "Your plan changes now. Any prorated difference is charged now or credited to your next invoice.",
-    );
+    const cta = (await findByTestId(
+      "recommended-customize-button",
+    )) as HTMLButtonElement;
+    await waitFor(() => expect(cta.disabled).toBe(false));
+    fireEvent.click(cta);
+
+    await findByText("Just better.");
+    expect(changePackageBody).toBeNull();
     expect(onManage).not.toHaveBeenCalled();
+    expect(navigateArgs).toEqual([]);
+  });
+
+  test("a top-tier (Ultra) clean pin's customize CTA opens the CustomPlanModal", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // Ultra is the top catalog package, so there's no package to upgrade to; the
+    // top-tier sub gets the customize card instead of an "Upgrade to X" card.
+    const { findByTestId, findByText } = renderCardInteractive(
+      proUltraSubscription(),
+      plansWithUltra(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    expect(
+      document.querySelector("[data-testid='recommended-upgrade-button']"),
+    ).toBeNull();
+    const cta = (await findByTestId(
+      "recommended-customize-button",
+    )) as HTMLButtonElement;
+    await waitFor(() => expect(cta.disabled).toBe(false));
+    fireEvent.click(cta);
+
+    await findByText("Just better.");
+    expect(onManage).not.toHaveBeenCalled();
+    expect(navigateArgs).toEqual([]);
+  });
+
+  test("a switch-ineligible custom sub's customize CTA falls back to onManage", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // A customized sub pending cancellation can't change tiers, so the customize
+    // CTA routes to the manage modal (AdjustPlanModal) — the same fallback the
+    // upgrade CTA uses — instead of opening the configurator.
+    const subscription = proMightySubscription();
+    subscription.package = {
+      key: "mighty",
+      name: "Mighty",
+      version: 1,
+      customized: true,
+    };
+    subscription.cancel_at = "2026-08-23T12:36:05Z";
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    fireEvent.click(await findByTestId("recommended-customize-button"));
+
+    await waitFor(() => {
+      expect(onManage).toHaveBeenCalledTimes(1);
+    });
+    // No configurator opened, no navigation.
+    expect(document.querySelector("[data-testid='confirm-package-switch-button']")).toBeNull();
     expect(navigateArgs).toEqual([]);
   });
 

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -1,6 +1,6 @@
-import { ArrowUp, Loader2, Sparkles } from "lucide-react";
+import { Loader2 } from "lucide-react";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { useNavigate } from "react-router";
 
@@ -13,14 +13,17 @@ import {
   type ProPackage,
   type SwitchRelation,
 } from "@/domains/settings/billing/package-types";
+import { PlanPromoCard } from "@/domains/settings/billing/plan-promo-card";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
+import { useChangeTiers } from "@/domains/settings/billing/use-change-tiers";
+import {
+  CustomPlanModal,
+  type CustomPlanSeed,
+  type CustomPlanSelection,
+} from "@/domains/settings/billing/plans/custom-plan-modal";
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
-import {
-  machineLabel,
-  packageSpecs,
-  type PlanSpec,
-} from "@/domains/settings/billing/plan-spec";
+import { packageSpecs } from "@/domains/settings/billing/plan-spec";
 import { PlanSpecCard } from "@/domains/settings/billing/plan-spec-card";
 import { useCheckoutDismissRefresh } from "@/domains/settings/billing/use-checkout-dismiss-refresh";
 import {
@@ -99,6 +102,12 @@ function PlanHeading() {
 
 interface RecommendedUpgradeProps {
   packages: ProPackage[];
+  /**
+   * The live Pro plan from the catalog, supplying the machine/storage/credit
+   * tiers the `CustomPlanModal` configures. Undefined only when the Pro plan is
+   * absent from the catalog — in which case there is no customize path to offer.
+   */
+  proPlan: ProPlan | undefined;
   currentKey: string | null;
   /**
    * Whether the org already has a Pro subscription. Pro users change their
@@ -115,26 +124,29 @@ interface RecommendedUpgradeProps {
    */
   canChangePackage: boolean;
   /**
-   * How the target package relates to the current sub — drives the confirm
-   * copy. A clean pin's next package is an "upgrade"; a customized or unpinned
-   * (Custom) sub gets the direction-neutral "switch".
+   * How the target package relates to the current sub. A clean pin's next
+   * package is an "upgrade" (the promo "Upgrade to X" variant); a customized or
+   * unpinned (Custom) sub gets "switch", which routes to the "Create a custom
+   * plan" variant instead.
    */
   relation: SwitchRelation;
   /**
    * Manage-path delegate (AdjustPlanModal). Handles a cancelling or
-   * non-entitlement Pro sub that the change-package flow cannot switch, and the
-   * empty-catalog fallback.
+   * non-entitlement Pro sub that the change-package/change-tier flows cannot
+   * act on.
    */
   onManage: () => void;
   /**
    * Opens the provisioning takeover (resize modal) after a Pro user's in-place
-   * package change succeeds — the same signal the tier-change flow raises.
+   * package or tier change succeeds — the same signal the tier-change flow
+   * raises.
    */
   onTierUpgraded?: () => void;
 }
 
 function RecommendedUpgrade({
   packages,
+  proPlan,
   currentKey,
   isProUser,
   canChangePackage,
@@ -147,51 +159,65 @@ function RecommendedUpgrade({
     organizationsBillingSubscriptionUpgradeCreateMutation(),
   );
   const { changePackage, isPending: changePending } = useChangePackage();
+  // The customize variant edits the Pro sub's tiers in place; only enable the
+  // hook's org-scoped reads for a Pro sub (a base user never sees that variant).
+  const {
+    changeTiers,
+    isPending: changeTiersPending,
+    current,
+    currentReady,
+  } = useChangeTiers({ enabled: isProUser });
   const [pending, setPending] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [customPlanOpen, setCustomPlanOpen] = useState(false);
   // Native iOS keeps Checkout inside an in-app sheet; refetch when it closes.
   useCheckoutDismissRefresh();
 
-  const recommended = nextPackageUp(packages, currentKey);
-  if (!recommended) {
-    return null;
-  }
+  // Seed the custom-plan modal with the Pro sub's current tiers so an unrelated
+  // edit doesn't force re-picking — and dropping — a dimension the user still
+  // holds. Null until the current tiers load (mirrors plans-page).
+  const customInitialSelection = useMemo<CustomPlanSeed | null>(() => {
+    if (!isProUser || current.storageTier == null) {
+      return null;
+    }
+    // `machineTier` may be null for a baseline (Small) package — the modal
+    // seeds storage/credit and leaves the machine picker empty in that case.
+    return {
+      machineTier: current.machineTier,
+      storageTier: current.storageTier,
+      creditTier: current.creditTier,
+    };
+  }, [isProUser, current.machineTier, current.storageTier, current.creditTier]);
 
-  const currentPackage = currentKey
-    ? (packages.find((p) => p.key === currentKey) ?? null)
-    : null;
-  // "a stronger machine" only holds when the recommended tier's machine size
-  // actually steps up. Free→Mighty stays on the Small baseline (machine_size
-  // null), so only credits and storage increase there — drop the machine clause.
-  const machineUpgrades =
-    machineLabel(currentPackage) !== machineLabel(recommended);
-  const summarySpecs: PlanSpec[] = [
-    {
-      icon: ArrowUp,
-      label: machineUpgrades
-        ? "more credits, storage, and a stronger machine"
-        : "more credits and storage",
-      multiline: true,
-    },
-  ];
-  // A Custom (customized or unpinned) sub's real tiers can diverge from any
-  // stock package, so a stock price delta could misstate the change; the neutral
-  // "switch" relation offers the named plan by itself.
-  const isNeutralSwitch = relation === "switch";
-  // Keep the CTA short ("Upgrade") so it sits inline in the card header beside
-  // the plan name, matching the mock. A longer label ("Upgrade for $X/mo more")
-  // overflows the header and wraps onto its own line below the name. The value
-  // prop is the summary chip below, and the prorated charge is confirmed in the
-  // switch dialog.
-  const upgradeLabel = isNeutralSwitch
-    ? `Switch to ${recommended.name}`
-    : "Upgrade";
+  const recommended = nextPackageUp(packages, currentKey);
+  const hasCatalog = packages.length > 0;
+
+  // Upgrade variant: base users and Pro clean pins with a stronger package to
+  // step up to. A neutral "switch" (customized/unpinned sub) is never an
+  // upgrade — it routes to the customize variant below instead.
+  const showUpgrade = recommended != null && relation !== "switch";
+  // Customize variant: a Pro sub whose tiers can diverge from stock (customized
+  // or unpinned, i.e. relation "switch"), or a clean pin already on the top
+  // catalog package (no package left to upgrade to). Both open the new
+  // CustomPlanModal. Requires a live catalog — with the flag off there are no
+  // tiers to configure.
+  const showCustomize =
+    isProUser &&
+    hasCatalog &&
+    (relation === "switch" ||
+      (recommended == null &&
+        currentKey != null &&
+        packages.some((p) => p.key === currentKey)));
+
   const isPending = pending || upgradeMutation.isPending || changePending;
 
   // Pro users change their package in place: confirm the prorated charge, then
   // call change-package and hand off to the resize takeover on success. Base
   // users go through the Stripe-checkout path instead.
   const handleConfirmChange = async () => {
+    if (!recommended) {
+      return;
+    }
     const result = await changePackage(recommended.key);
     if (!result) {
       // The hook already toasted; leave the dialog open so the user can
@@ -209,6 +235,9 @@ function RecommendedUpgrade({
   };
 
   const handleUpgrade = async () => {
+    if (!recommended) {
+      return;
+    }
     // Any switch-eligible Pro sub (a clean pin, a customized pin, or an
     // unpinned Custom sub) can be one-click package-switched; a cancelling or
     // non-entitlement Pro sub stays on the manage path.
@@ -265,52 +294,92 @@ function RecommendedUpgrade({
     }
   };
 
-  const recommendedCopy = getPlanTierCopy(recommended.key);
-  const upgradeButton = (
-    <Button
-      variant="primary"
-      className="shrink-0"
-      onClick={handleUpgrade}
-      disabled={isPending}
-      leftIcon={
-        isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined
-      }
-      data-testid="recommended-upgrade-button"
-    >
-      {upgradeLabel}
-    </Button>
-  );
-  return (
-    <>
-      <PlanSpecCard
-        tone="dark"
-        tierKey={recommended.key}
-        name={recommended.name}
-        className="lg:flex-[2]"
-        tag={
-          <Tag
-            className="bg-[var(--feed-digest-weak)] text-[var(--credits-accent)]"
-            leftIcon={
-              <Sparkles className="h-3 w-3 text-[var(--credits-accent)]" />
-            }
-          >
-            {isNeutralSwitch ? "Switch plan" : "Recommended"}
-          </Tag>
-        }
-        tagline={recommendedCopy?.tagline}
-        specs={isNeutralSwitch ? null : summarySpecs}
-        action={upgradeButton}
-      />
-      <PackageSwitchConfirmModal
-        open={confirmOpen}
-        relation={relation}
-        packageName={recommended.name}
-        pending={isPending}
-        onConfirm={() => void handleConfirmChange()}
-        onCancel={() => setConfirmOpen(false)}
-      />
-    </>
-  );
+  // Active Pro orgs edit their tiers in place via the change-tier endpoints;
+  // mirrors plans-page's `applyCustomTierChange`. On success the billing page
+  // opens its own resize takeover (via `onTierUpgraded`).
+  const applyCustomTierChange = async (selection: CustomPlanSelection) => {
+    const result = await changeTiers(selection);
+    if (!result) {
+      // The hook toasted; keep the modal open so the user can retry.
+      return;
+    }
+    setCustomPlanOpen(false);
+    if (result.needsResize || result.creditChanged) {
+      onTierUpgraded?.();
+    } else {
+      toast.success("Plan updated.");
+    }
+  };
+
+  // The customize CTA opens the configurator; a switch-ineligible sub (cancelling
+  // or non-entitlement status) falls back to the manage path, like the upgrade
+  // CTA. Guard the open like plans-page's `handleConfigure`: hold until the
+  // current tiers load and no tier change is in flight.
+  const handleCustomize = () => {
+    if (!canChangePackage) {
+      onManage();
+      return;
+    }
+    if (changeTiersPending || !currentReady) {
+      return;
+    }
+    setCustomPlanOpen(true);
+  };
+  // Disable only when the modal-open path is the live one — a switch-ineligible
+  // sub keeps the CTA enabled so it can reach the manage fallback.
+  const customizeDisabled =
+    canChangePackage && (changeTiersPending || !currentReady);
+
+  if (showUpgrade) {
+    return (
+      <>
+        <PlanPromoCard
+          className="lg:flex-[2]"
+          title={`Upgrade to ${recommended.name}`}
+          blurb={getPlanTierCopy(recommended.key)?.upgradeBlurb}
+          ctaLabel="Upgrade"
+          ctaTestId="recommended-upgrade-button"
+          pending={isPending}
+          onCtaClick={() => void handleUpgrade()}
+        />
+        <PackageSwitchConfirmModal
+          open={confirmOpen}
+          relation={relation}
+          packageName={recommended.name}
+          pending={isPending}
+          onConfirm={() => void handleConfirmChange()}
+          onCancel={() => setConfirmOpen(false)}
+        />
+      </>
+    );
+  }
+
+  if (showCustomize && proPlan) {
+    return (
+      <>
+        <PlanPromoCard
+          className="lg:flex-[2]"
+          title="Create a custom plan"
+          ctaLabel="Customize"
+          ctaTestId="recommended-customize-button"
+          pending={changeTiersPending}
+          disabled={customizeDisabled}
+          onCtaClick={handleCustomize}
+        />
+        <CustomPlanModal
+          open={customPlanOpen}
+          proPlan={proPlan}
+          pending={changeTiersPending}
+          currentStorageGib={current.storageGib}
+          initialSelection={customInitialSelection}
+          onClose={() => setCustomPlanOpen(false)}
+          onContinue={(selection) => void applyCustomTierChange(selection)}
+        />
+      </>
+    );
+  }
+
+  return null;
 }
 
 export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
@@ -478,6 +547,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
           />
           <RecommendedUpgrade
             packages={packages}
+            proPlan={proPlan}
             currentKey={currentKey}
             isProUser={currentPlan.id !== "base"}
             canChangePackage={canChangePackage}

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -294,9 +294,11 @@ function RecommendedUpgrade({
     }
   };
 
-  // Active Pro orgs edit their tiers in place via the change-tier endpoints;
-  // mirrors plans-page's `applyCustomTierChange`. On success the billing page
-  // opens its own resize takeover (via `onTierUpgraded`).
+  // Active Pro orgs edit their tiers in place via the change-tier endpoints,
+  // mirroring AdjustPlanModal's billing-page semantics (not plans-page's). The
+  // billing-page resize takeover is credit-agnostic — `onTierUpgraded` is
+  // argument-less and opens a resize-only takeover with no credit prop — so a
+  // credit-only change must toast instead of popping a blank takeover.
   const applyCustomTierChange = async (selection: CustomPlanSelection) => {
     const result = await changeTiers(selection);
     if (!result) {
@@ -304,10 +306,14 @@ function RecommendedUpgrade({
       return;
     }
     setCustomPlanOpen(false);
-    if (result.needsResize || result.creditChanged) {
+    // Only a real machine/storage resize hands off to the takeover; a
+    // credit-only change toasts, like AdjustPlanModal.
+    if (result.needsResize) {
       onTierUpgraded?.();
     } else {
-      toast.success("Plan updated.");
+      toast.success(
+        result.creditChanged ? "Credit bundle updated." : "Plan updated.",
+      );
     }
   };
 


### PR DESCRIPTION
## Summary
- Recommended slot now renders PlanPromoCard: 'Upgrade to X' + per-tier blurb (unchanged CTA behavior)
- Ultra / customized / legacy Pro subs get a 'Create a custom plan' / Customize card opening CustomPlanModal (not AdjustPlanModal)
- Removed the old Sparkles tag, ArrowUp summary chip, 'Switch to X' label, and recommended-card tagline

Part of plan: plan-section-promo-cards.md (PR 3 of 4)