### PR TITLE
refactor(billing): collapse resize-card upgradeModalOpen to a boolean

### DIFF
--- a/clients/web/src/domains/settings/components/resize-card.tsx
+++ b/clients/web/src/domains/settings/components/resize-card.tsx
@@ -98,9 +98,7 @@ export function ResizeCard({
     null,
   );
   const displaySize = selectedSize ?? largestSize ?? currentSize;
-  const [upgradeModalOpen, setUpgradeModalOpen] = useState<
-    "storage" | "machine" | null
-  >(null);
+  const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
   const [resizeError, setResizeError] = useState<string | null>(null);
 
   const resizeMutation = useAssistantsResizeMutation({
@@ -223,7 +221,7 @@ export function ResizeCard({
     <Button
       variant="ghost"
       size="compact"
-      onClick={() => setUpgradeModalOpen("storage")}
+      onClick={() => setUpgradeModalOpen(true)}
     >
       Resize
     </Button>
@@ -254,7 +252,7 @@ export function ResizeCard({
     <Button
       variant="ghost"
       size="compact"
-      onClick={() => setUpgradeModalOpen("machine")}
+      onClick={() => setUpgradeModalOpen(true)}
     >
       Resize
     </Button>
@@ -385,9 +383,9 @@ export function ResizeCard({
 
       {/* Upgrade modal (free plan) */}
       <Modal.Root
-        open={upgradeModalOpen != null}
+        open={upgradeModalOpen}
         onOpenChange={(o) => {
-          if (!o) setUpgradeModalOpen(null);
+          if (!o) setUpgradeModalOpen(false);
         }}
       >
         <Modal.Content size="sm">
@@ -399,12 +397,12 @@ export function ResizeCard({
             </Modal.Description>
           </Modal.Header>
           <Modal.Footer>
-            <Button variant="ghost" onClick={() => setUpgradeModalOpen(null)}>
+            <Button variant="ghost" onClick={() => setUpgradeModalOpen(false)}>
               Cancel
             </Button>
             <Button
               onClick={() => {
-                setUpgradeModalOpen(null);
+                setUpgradeModalOpen(false);
                 void navigate(routes.plans);
               }}
             >


### PR DESCRIPTION
Self-review slop fix: the storage/machine discriminator is dead after the upgrade modal's description became static (PR #39093). Collapse to a boolean.

Part of plan: plan-copy-and-upgrade-ctas.md (self-review fix)