### PR TITLE
Billing plan copy + upgrade CTAs → plans takeover

### DIFF
--- a/clients/web/src/components/disk-pressure-banner.test.tsx
+++ b/clients/web/src/components/disk-pressure-banner.test.tsx
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { DiskPressureStatus } from "@vellumai/assistant-api";
+
+const { DiskPressureBanner } = await import("@/components/disk-pressure-banner");
+
+afterEach(() => {
+  cleanup();
+});
+
+const warningStatus: DiskPressureStatus = {
+  enabled: true,
+  state: "warning",
+  locked: false,
+  acknowledged: false,
+  overrideActive: false,
+  effectivelyLocked: false,
+  lockId: null,
+  usagePercent: 85,
+  thresholdPercent: 90,
+  path: "/workspace",
+  lastCheckedAt: null,
+  blockedCapabilities: [],
+  error: null,
+};
+
+describe("DiskPressureBanner warning variant", () => {
+  test("renders the storage-low copy and CTA labels", () => {
+    const onUpgradeStorage = mock(() => {});
+    const onReviewWorkspaceData = mock(() => {});
+
+    render(
+      <DiskPressureBanner
+        status={warningStatus}
+        mode="warning"
+        onAcknowledge={() => {}}
+        onUpgradeStorage={onUpgradeStorage}
+        onReviewWorkspaceData={onReviewWorkspaceData}
+      />,
+    );
+
+    expect(screen.getByText("Your storage is almost full")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Free up space or add more storage to avoid interruptions.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Manage Storage" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Upgrade" })).toBeTruthy();
+  });
+
+  test("invokes onUpgradeStorage when Upgrade is clicked", () => {
+    const onUpgradeStorage = mock(() => {});
+
+    render(
+      <DiskPressureBanner
+        status={warningStatus}
+        mode="warning"
+        onAcknowledge={() => {}}
+        onUpgradeStorage={onUpgradeStorage}
+        onReviewWorkspaceData={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    expect(onUpgradeStorage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/components/disk-pressure-banner.tsx
+++ b/clients/web/src/components/disk-pressure-banner.tsx
@@ -1,5 +1,5 @@
 
-import { AlertTriangle, HardDrive } from "lucide-react";
+import { AlertTriangle, Package } from "lucide-react";
 import { useState } from "react";
 
 import { formatDiskPressureUsage } from "@/assistant/disk-pressure";
@@ -46,8 +46,8 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
     return (
       <Notice
         tone="warning"
-        title="Storage is running low"
-        icon={<HardDrive className="h-4 w-4" aria-hidden="true" />}
+        title="Your storage is almost full"
+        icon={<Package className="h-4 w-4" aria-hidden="true" />}
         onDismiss={
           onDismissWarning
             ? () => onDismissWarning(dontShowAgain)
@@ -72,7 +72,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
             </span>
           </div>
           <p className="m-0">
-            Your assistant will enter a locked state if it runs out of storage.
+            Free up space or add more storage to avoid interruptions.
           </p>
           <div className="flex flex-wrap items-center gap-2">
             {onReviewWorkspaceData && (
@@ -81,7 +81,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
                 size="compact"
                 onClick={onReviewWorkspaceData}
               >
-                Review Workspace Data
+                Manage Storage
               </Button>
             )}
             {onUpgradeStorage && (
@@ -90,7 +90,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
                 size="compact"
                 onClick={onUpgradeStorage}
               >
-                Upgrade Storage
+                Upgrade
               </Button>
             )}
             {onDismissWarning ? (
@@ -115,7 +115,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
       <Notice
         tone="warning"
         title="Cleanup mode is active"
-        icon={<HardDrive className="h-4 w-4" aria-hidden="true" />}
+        icon={<Package className="h-4 w-4" aria-hidden="true" />}
         className="p-4"
         data-testid="disk-pressure-banner"
       >
@@ -144,7 +144,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
                 size="compact"
                 onClick={onReviewWorkspaceData}
               >
-                Review Workspace Data
+                Manage Storage
               </Button>
             )}
             {onUpgradeStorage && (
@@ -153,7 +153,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
                 size="compact"
                 onClick={onUpgradeStorage}
               >
-                Upgrade Storage
+                Upgrade
               </Button>
             )}
           </div>
@@ -169,7 +169,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
       <Notice
         tone="error"
         title="Storage is critically low"
-        icon={<HardDrive className="h-4 w-4" aria-hidden="true" />}
+        icon={<Package className="h-4 w-4" aria-hidden="true" />}
         className="p-4"
         data-testid="disk-pressure-banner"
       >
@@ -239,7 +239,7 @@ export function DiskPressureBanner(props: DiskPressureBannerProps) {
                   onUpgradeStorage();
                 }}
               >
-                Upgrade Storage
+                Upgrade
               </Button>
             )}
             <Button

--- a/clients/web/src/domains/chat/components/disk-pressure-banner-slot.tsx
+++ b/clients/web/src/domains/chat/components/disk-pressure-banner-slot.tsx
@@ -98,7 +98,7 @@ export function DiskPressureBannerSlot({
       onAcknowledge={() => void diskPressure.acknowledge()}
       onDismissWarning={dismissWarning}
       onReviewWorkspaceData={() => void navigate(`${routes.workspace}?sort=size`)}
-      onUpgradeStorage={assistantStateKind === "active" ? () => void navigate(`${routes.settings.usage}?tab=billing&adjust_plan=1`) : null}
+      onUpgradeStorage={assistantStateKind === "active" ? () => void navigate(routes.plans) : null}
     />
   );
 }

--- a/clients/web/src/domains/settings/ai/ai-page.test.tsx
+++ b/clients/web/src/domains/settings/ai/ai-page.test.tsx
@@ -5,7 +5,7 @@
  * admin `EntitlementOverride` that grants managed email to a Base org is
  * honored in-product. We verify both directions:
  *
- *  - Base org WITHOUT the entitlement → "Upgrade to Pro" notice, form gated.
+ *  - Base org WITHOUT the entitlement → "Upgrade" notice, form gated.
  *  - Base org WITH the entitlement (override) → domain/address form renders,
  *    proving the gate reads the entitlement and not the plan.
  *
@@ -91,8 +91,11 @@ function renderCard(subscription: SubscriptionResponse): string {
 describe("EmailServiceCard managed-email gate", () => {
   test("Base org without the managed_email entitlement sees the upgrade notice", () => {
     const html = renderCard(makeSubscription(false, "base"));
-    expect(html).toContain("Upgrade to Pro");
-    expect(html).toContain("Get a dedicated email address for your assistant");
+    expect(html).toContain("Upgrade");
+    expect(html).toContain("Give your assistant its own email address");
+    expect(html).toContain(
+      "Upgrade to a plan that includes an email address for your assistant. No provider setup required.",
+    );
     // The domain registration form must NOT render when gated.
     expect(html).not.toContain("Register");
   });
@@ -100,8 +103,7 @@ describe("EmailServiceCard managed-email gate", () => {
   test("Base org WITH the managed_email entitlement sees the form, not the notice", () => {
     // plan_id stays "base" — only the entitlement (admin override) is true.
     const html = renderCard(makeSubscription(true, "base"));
-    expect(html).not.toContain("Upgrade to Pro");
-    expect(html).not.toContain("Get a dedicated email address for your assistant");
+    expect(html).not.toContain("Give your assistant its own email address");
     // The domain registration form renders for entitled orgs.
     expect(html).toContain("Subdomain");
     expect(html).toContain("Register");
@@ -121,8 +123,7 @@ describe("EmailServiceCard managed-email gate", () => {
       cancel_at: null,
     } as unknown as SubscriptionResponse;
     const html = renderCard(subscriptionWithoutEntitlements);
-    expect(html).not.toContain("Upgrade to Pro");
-    expect(html).not.toContain("Get a dedicated email address for your assistant");
+    expect(html).not.toContain("Give your assistant its own email address");
     // The domain registration form renders (fail-open).
     expect(html).toContain("Subdomain");
     expect(html).toContain("Register");

--- a/clients/web/src/domains/settings/ai/email-managed-content.tsx
+++ b/clients/web/src/domains/settings/ai/email-managed-content.tsx
@@ -1,6 +1,6 @@
 import {
-    Crown,
     Loader2,
+    Mail,
     Trash2,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
@@ -278,21 +278,19 @@ export function EmailManagedContent({
     return (
       <Notice
         tone="info"
-        icon={<Crown className="h-4 w-4" aria-hidden />}
-        title="Get a dedicated email address for your assistant"
+        icon={<Mail className="h-4 w-4" aria-hidden />}
+        title="Give your assistant its own email address"
         actions={
           <Button
             size="compact"
-            onClick={() => navigate(`${routes.settings.usage}?tab=billing&adjust_plan`)}
+            onClick={() => navigate(routes.plans)}
           >
-            Upgrade to Pro
+            Upgrade
           </Button>
         }
       >
-        Pro plans include a managed{" "}
-        {`<your-subdomain>.${emailRootDomain}`} inbox — no provider
-        setup required. Or switch to <strong>Your Own</strong> to bring
-        an existing provider.
+        Upgrade to a plan that includes an email address for your
+        assistant. No provider setup required.
       </Notice>
     );
   }

--- a/clients/web/src/domains/settings/billing/plans/plans-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/plans-copy.ts
@@ -30,7 +30,7 @@ export const PLAN_TIER_COPY: Record<PlanTierKey, PlanTierCopy> = {
     priceCaption: "Forever",
   },
   mighty: {
-    tagline: "More capacity for consistent user.",
+    tagline: "More capacity for consistent use.",
     cta: "Power Up",
     priceCaption: "Billed monthly",
     recommended: true,
@@ -42,7 +42,7 @@ export const PLAN_TIER_COPY: Record<PlanTierKey, PlanTierCopy> = {
     extraFeatures: ["Assistant email and subdomain"],
   },
   ultra: {
-    tagline: "Our highest level of power and capacity.",
+    tagline: "Built for sustained, high-demand work.",
     cta: "Unleash Ultra",
     priceCaption: "Billed monthly",
     extraFeatures: ["Assistant email and subdomain"],

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -256,9 +256,15 @@ export function PlansPage() {
     notPlatformHosted || subscriptionQuery.isError || catalogEmpty;
   useEffect(() => {
     if (cannotResolve) {
-      navigate(routes.settings.usageBilling, { replace: true });
+      // Platform-hosted but catalog-empty (pro-packages off) or a failed
+      // subscription read still has an upgrade path via the billing adjust-plan
+      // modal; self-hosted / no session does not.
+      const target = notPlatformHosted
+        ? routes.settings.usageBilling
+        : `${routes.settings.usageBilling}&adjust_plan`;
+      navigate(target, { replace: true });
     }
-  }, [cannotResolve, navigate]);
+  }, [cannotResolve, notPlatformHosted, navigate]);
 
   const handleBack = () => {
     const idx = (window.history.state as { idx?: number } | null)?.idx ?? 0;

--- a/clients/web/src/domains/settings/components/resize-card.tsx
+++ b/clients/web/src/domains/settings/components/resize-card.tsx
@@ -98,9 +98,7 @@ export function ResizeCard({
     null,
   );
   const displaySize = selectedSize ?? largestSize ?? currentSize;
-  const [upgradeModalOpen, setUpgradeModalOpen] = useState<
-    "storage" | "machine" | null
-  >(null);
+  const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
   const [resizeError, setResizeError] = useState<string | null>(null);
 
   const resizeMutation = useAssistantsResizeMutation({
@@ -223,7 +221,7 @@ export function ResizeCard({
     <Button
       variant="ghost"
       size="compact"
-      onClick={() => setUpgradeModalOpen("storage")}
+      onClick={() => setUpgradeModalOpen(true)}
     >
       Resize
     </Button>
@@ -254,7 +252,7 @@ export function ResizeCard({
     <Button
       variant="ghost"
       size="compact"
-      onClick={() => setUpgradeModalOpen("machine")}
+      onClick={() => setUpgradeModalOpen(true)}
     >
       Resize
     </Button>
@@ -385,9 +383,9 @@ export function ResizeCard({
 
       {/* Upgrade modal (free plan) */}
       <Modal.Root
-        open={upgradeModalOpen != null}
+        open={upgradeModalOpen}
         onOpenChange={(o) => {
-          if (!o) setUpgradeModalOpen(null);
+          if (!o) setUpgradeModalOpen(false);
         }}
       >
         <Modal.Content size="sm">
@@ -399,12 +397,12 @@ export function ResizeCard({
             </Modal.Description>
           </Modal.Header>
           <Modal.Footer>
-            <Button variant="ghost" onClick={() => setUpgradeModalOpen(null)}>
+            <Button variant="ghost" onClick={() => setUpgradeModalOpen(false)}>
               Cancel
             </Button>
             <Button
               onClick={() => {
-                setUpgradeModalOpen(null);
+                setUpgradeModalOpen(false);
                 void navigate(routes.plans);
               }}
             >

--- a/clients/web/src/domains/settings/components/resize-card.tsx
+++ b/clients/web/src/domains/settings/components/resize-card.tsx
@@ -392,11 +392,10 @@ export function ResizeCard({
       >
         <Modal.Content size="sm">
           <Modal.Header>
-            <Modal.Title>Upgrade to Pro</Modal.Title>
+            <Modal.Title>Upgrade your plan</Modal.Title>
             <Modal.Description>
-              {upgradeModalOpen === "storage"
-                ? "Upgrade to the Pro plan to increase your storage allocation and get more space for your assistant."
-                : "Upgrade to the Pro plan to unlock larger machine sizes with more CPU and memory for your assistant."}
+              Move to a higher plan for more power, more storage, and a larger
+              credit bundle.
             </Modal.Description>
           </Modal.Header>
           <Modal.Footer>
@@ -406,7 +405,7 @@ export function ResizeCard({
             <Button
               onClick={() => {
                 setUpgradeModalOpen(null);
-                void navigate(`${routes.settings.usage}?tab=billing&adjust_plan=1`);
+                void navigate(routes.plans);
               }}
             >
               Upgrade
@@ -475,7 +474,7 @@ export function ResizeCard({
             <span className="text-label-small-default text-[var(--content-tertiary)]">
               Need more?{" "}
               <Link
-                to={`${routes.settings.usage}?tab=billing&adjust_plan=1`}
+                to={routes.plans}
                 className="text-[var(--content-secondary)] underline decoration-[var(--border-element)] underline-offset-2 transition-colors hover:text-[var(--content-default)]"
                 onClick={() => setResizeModalOpen(false)}
               >

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -149,7 +149,7 @@ export function GeneralPage() {
           }
           onUpgradeStorage={
             infraGate === "full"
-              ? () => void navigate(`${routes.settings.usage}?tab=billing&adjust_plan=1`)
+              ? () => void navigate(routes.plans)
               : null
           }
         />


### PR DESCRIPTION
## Summary
Refresh the Mighty/Ultra plan taglines and route the four remaining `?adjust_plan` upgrade CTAs — the storage-low banner (chat slot + General page), the assistant-email upsell, and the resize-card upgrade modal — to the full-screen plans takeover (`routes.plans`), with refreshed copy, icons, and CTA labels. To avoid a regression when `pro-packages` is off, the takeover's own catalog-empty/subscription-error self-redirect now preserves `adjust_plan`, so the upgrade modal still opens for platform-hosted users.

## Self-review result
**PASS** — Passes 1–3 (external feedback, plan faithfulness, integration) all PASS; Pass 4 (slop) found one dead discriminator, fixed in a follow-up PR. Codex raised one P2 (the `adjust_plan` dead-end when the catalog is unavailable), fixed once at the takeover layer and **cleared on Codex re-review** ("Didn't find any major issues. Swish!").

## PRs merged into feature branch
- #39091: refresh Mighty/Ultra plan takeover taglines
- #39096: storage-low banner Upgrade CTA → plans takeover (Package icon, new copy, "Manage Storage"/"Upgrade")
- #39095: assistant-email upsell → plans takeover (Mail icon, new copy)
- #39093: resize-card upgrade modal → plans takeover (+ shared takeover `adjust_plan` fallback fix)

### Fix PRs
- #39099: collapse resize-card `upgradeModalOpen` to a boolean (self-review slop fix)

## Deliberately unchanged
The takeover's ineligible/cancelling-sub bounce (`plans-page.tsx`) still routes to `?adjust_plan`, keeping the old `AdjustPlanModal` (and its reactivate path) reachable. Reactivate/cancellation-status parity remains a separate follow-up.

Part of plan: plan-copy-and-upgrade-ctas.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)