### PR TITLE
fix(web): scroll the Slack channels panel + access-copy accuracy pass

### DIFF
--- a/clients/web/src/domains/channels/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/channels/components/assistant-channels-list.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 
-import { cn } from "@vellumai/design-library";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
 import { DetailCard } from "@/components/detail-card";
@@ -257,17 +256,11 @@ export function AssistantChannelsList({
           />
         </aside>
 
-        {/* Slack brings its own cards (connection card + channel list) and owns
-            its internal table scroll, so it fills the panel; the other adapters
-            render bare content in a scrollable card to match. */}
-        <section
-          className={cn(
-            "min-h-0 min-w-0 flex-1",
-            selected.key === "slack"
-              ? "flex flex-col overflow-hidden"
-              : "overflow-y-auto",
-          )}
-        >
+        {/* Slack brings its own cards (connection, default access, per-channel
+            overrides) so it renders bare; the other adapters get a DetailCard
+            wrapper. Both scroll as a whole when the stacked content overflows —
+            the per-channel list self-bounds its own rows within that. */}
+        <section className="min-h-0 min-w-0 flex-1 overflow-y-auto">
           {selected.key === "slack" ? detail : <DetailCard>{detail}</DetailCard>}
         </section>
       </div>

--- a/clients/web/src/domains/channels/components/channel-panel.tsx
+++ b/clients/web/src/domains/channels/components/channel-panel.tsx
@@ -95,10 +95,12 @@ export function ChannelPanel({
 
   // Slack is its own adapter shape — a token-pair channel with dedicated
   // connected/disconnected cards (connection card vs. setup wizard) that own
-  // their card chrome, so it returns bare (the parent skips the DetailCard).
+  // their card chrome, so it returns bare (the parent skips the DetailCard). The
+  // cards stack at natural height and the parent section owns the vertical
+  // scroll, so no min-h-0/flex-1 fill here.
   if (channel.key === "slack") {
     return (
-      <div className="flex min-h-0 flex-1 flex-col gap-4">
+      <div className="flex flex-col gap-4">
         {connected ? (
           <SlackConnectionCard
             slackHandle={channel.address}

--- a/clients/web/src/domains/channels/components/slack-channel-list.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-list.tsx
@@ -292,8 +292,11 @@ export function SlackChannelList({
               No channels match.
             </Typography>
           ) : visibleChannels.length > VIRTUALIZE_THRESHOLD ? (
-            // Virtuoso sizes its scroller to 100% of the wrapper, so the
-            // wrapper needs a bounded height to scroll within the collapsible.
+            // Virtuoso sizes its scroller to 100% of the wrapper, so the wrapper
+            // needs a bounded height. h-96 (~24rem) is tall enough to show a
+            // useful run of rows while the list scrolls within the collapsible
+            // rather than stretching the panel; the plain branch below caps at
+            // the same height.
             <div className="h-96">
               <VirtualList
                 items={visibleChannels}

--- a/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
@@ -112,8 +112,8 @@ export function SlackChannelTierLegend({
         variant="body-small-default"
         className="text-[color:var(--content-tertiary)]"
       >
-        Writes, sends, and spends always come to you first — at every level.
-        Your{" "}
+        These levels only cover how much it looks up on its own before answering.
+        Writing, sending, and spending always ask first — at every level. Your{" "}
         <Link
           to={routes.settings.privacy}
           className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"

--- a/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
@@ -6,6 +6,7 @@ import {
   CAPABILITY_TIER_META,
   CAPABILITY_TIER_VALUES,
 } from "@/domains/channels/slack-channel-overrides";
+import { TierDot } from "@/domains/channels/components/tier-picker";
 import type { RiskThreshold } from "@/utils/threshold-presets";
 import { routes } from "@/utils/routes";
 
@@ -26,15 +27,15 @@ import { routes } from "@/utils/routes";
  * footnote describes them as tuning, not overriding.
  *
  * Channel actors are non-guardians, so the sensitive-tool floor applies on top
- * of the tier: every side-effect tool (file writes, bash, sends —
- * `assistant/src/tools/side-effects.ts`) and all host execution escalates to
- * the owner without a scoped grant, at every tier
- * (`assistant/src/tools/tool-approval-handler.ts`). That's why the examples
- * here are read-only — the tier moves the line for what the assistant looks up
- * on its own, while actions keep coming to the owner — and why this copy is
- * intentionally narrower than the global preset descriptions in
- * `threshold-presets.ts`, which describe the guardian's own conversations where
- * the floor self-approves.
+ * of the tier: every side-effect tool (file writes, bash, web fetches —
+ * `assistant/src/tools/side-effects.ts`) plus all host execution — the MCP and
+ * bundled-skill tools, which is where sends and spends live (messaging, phone
+ * calls) — escalates to the owner without a scoped grant, at every tier
+ * (`assistant/src/tools/tool-approval-handler.ts`). So the tier only moves the
+ * line for the read/lookup tools the assistant runs on its own; every action
+ * keeps coming to the owner. This copy is therefore intentionally narrower than
+ * the global preset descriptions in `threshold-presets.ts`, which describe the
+ * guardian's own conversations where the floor self-approves.
  */
 function tierDescription(tier: RiskThreshold, assistantName: string): string {
   switch (tier) {
@@ -43,7 +44,7 @@ function tierDescription(tier: RiskThreshold, assistantName: string): string {
     case "low":
       return `${assistantName} replies and runs safe, read-only actions on its own, like web searches and reading files in its workspace. Anything that writes, sends, or spends asks you first.`;
     case "medium":
-      return `${assistantName} also handles medium-risk requests on its own, like network requests that use your connected accounts. Anything that writes, sends, or spends still asks you first.`;
+      return `${assistantName} reads and looks up more widely on its own, beyond the safe basics. Anything that writes, sends, or spends still asks you first.`;
     case "high":
       return `${assistantName} answers any request on its own without asking. Tools that take action — writing, sending, spending — still come to you first.`;
   }
@@ -87,11 +88,7 @@ export function SlackChannelTierLegend({
               className="flex items-center gap-1.5"
               title={tierDescription(tier, assistantName)}
             >
-              <span
-                aria-hidden="true"
-                className="h-1.5 w-1.5 shrink-0 rounded-full"
-                style={{ backgroundColor: meta.dotColor }}
-              />
+              <TierDot color={meta.dotColor} />
               <Typography as="span" variant="body-small-emphasised">
                 {meta.label}
               </Typography>

--- a/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-tier-legend.tsx
@@ -24,7 +24,7 @@ import { routes } from "@/utils/routes";
  * channel's tier. At `none` nothing is within threshold, so every action
  * prompts; Trust Rules move an action between levels (changing when it asks)
  * but cannot bypass Strict or hard-block at Full access, which is why the
- * footnote describes them as tuning, not overriding.
+ * description frames them as tuning, not overriding.
  *
  * Channel actors are non-guardians, so the sensitive-tool floor applies on top
  * of the tier: every side-effect tool (file writes, bash, web fetches —
@@ -62,13 +62,14 @@ export interface SlackChannelTierLegendProps {
 }
 
 /**
- * Always-visible Assistant Access key at the foot of the channel list card:
- * every tier as a compact "label + what it does" pair in a two-column grid, so
- * the meaning is on screen without opening anything. The terse sublabel shows
- * inline (the touch-reachable case); the full behavior sentence rides each
- * pair's hover/description `title` as progressive enhancement. The tier the
- * global default resolves to is marked "· default", matching the per-row picker
- * so the two read together.
+ * Always-visible Assistant Access key in the default-access card footer: a
+ * heading, a one-line description of what the levels do (and what always
+ * escalates), then every tier as a compact "label + what it does" pair in a
+ * two-column grid, so the meaning is on screen without opening anything. The
+ * terse sublabel shows inline (the touch-reachable case); the full behavior
+ * sentence rides each pair's hover/description `title` as progressive
+ * enhancement. The tier the global default resolves to is marked "· default",
+ * matching the per-row picker so the two read together.
  */
 export function SlackChannelTierLegend({
   assistantName,
@@ -78,6 +79,21 @@ export function SlackChannelTierLegend({
     <div className="flex flex-col gap-2 px-4 py-3">
       <Typography as="span" variant="body-small-emphasised">
         Assistant Access levels
+      </Typography>
+      <Typography
+        as="p"
+        variant="body-small-default"
+        className="text-[color:var(--content-tertiary)]"
+      >
+        These levels only cover how much it looks up on its own before answering.
+        Writing, sending, and spending always ask first — at every level. Your{" "}
+        <Link
+          to={routes.settings.privacy}
+          className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
+        >
+          Trust Rules
+        </Link>{" "}
+        fine-tune when it asks.
       </Typography>
       <ul className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
         {CAPABILITY_TIER_VALUES.map((tier) => {
@@ -104,21 +120,6 @@ export function SlackChannelTierLegend({
           );
         })}
       </ul>
-      <Typography
-        as="p"
-        variant="body-small-default"
-        className="text-[color:var(--content-tertiary)]"
-      >
-        These levels only cover how much it looks up on its own before answering.
-        Writing, sending, and spending always ask first — at every level. Your{" "}
-        <Link
-          to={routes.settings.privacy}
-          className="text-[var(--content-link)] underline hover:text-[var(--content-link-hover)]"
-        >
-          Trust Rules
-        </Link>{" "}
-        fine-tune when it asks.
-      </Typography>
     </div>
   );
 }

--- a/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
@@ -88,7 +88,9 @@ export function SlackChannelTypeDefaults({
           </Typography>
         </div>
       </Card.Header>
-      <Card.Body>
+      {/* Rows carry their own py-3, so keep the body's vertical padding small
+          to avoid a doubled gap above the first / below the last row. */}
+      <Card.Body className="py-1">
         {BUCKET_ROWS.map(({ bucket, icon: Icon, title, description }) => {
           // DMs fall through to the Channels default, then the global default;
           // Channels falls through to the global default.

--- a/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
+++ b/clients/web/src/domains/channels/components/slack-channel-type-defaults.tsx
@@ -17,12 +17,11 @@ interface BucketRow {
 }
 
 /**
- * The two default buckets, in cascade order. "Channels" is the adapter-wide
- * default (every room); "Direct messages" overrides it for 1:1 DMs only. Only
- * 1:1 DMs carry a `channelType` (`"dm"`) at tool time — the gateway collapses
- * group DMs (mpim), private, and public rooms into `"channel"` (no type), so a
- * `channel_type` cell for those never matches. Group DMs therefore follow the
- * Channels default, and public/private can't be split here at all.
+ * The two default buckets, in cascade order: "Channels" is the adapter-wide
+ * default (every room), "Direct messages" overrides it for 1:1 DMs only. See
+ * {@link ChannelDefaultBucket} in `slack-channel-overrides` for why only 1:1 DMs
+ * carry a `channelType` at tool time — group DMs, private, and public rooms all
+ * collapse to `"channel"`, so they follow the Channels default.
  */
 const BUCKET_ROWS: readonly BucketRow[] = [
   {

--- a/clients/web/src/domains/channels/components/tier-picker.tsx
+++ b/clients/web/src/domains/channels/components/tier-picker.tsx
@@ -14,7 +14,7 @@ export function TierDot({ color }: { color: string }) {
   return (
     <span
       aria-hidden="true"
-      className="h-1.5 w-1.5 rounded-full"
+      className="h-1.5 w-1.5 shrink-0 rounded-full"
       style={{ backgroundColor: color }}
     />
   );

--- a/clients/web/src/domains/channels/hooks/use-channel-permission-overrides.ts
+++ b/clients/web/src/domains/channels/hooks/use-channel-permission-overrides.ts
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   bucketDefaultFromCells,
   CHANNEL_TIER_CONTACT_TYPES,
+  isBucketCell,
   tierOverridesFromCells,
   type ChannelDefaultBucket,
 } from "@/domains/channels/slack-channel-overrides";
@@ -113,18 +114,6 @@ function cellsForBucket(
   }));
 }
 
-function isBucketCell(
-  cell: Cell,
-  adapter: string,
-  bucket: ChannelDefaultBucket,
-): boolean {
-  return bucket === "channels"
-    ? cell.selector.scope === "adapter" && cell.selector.adapter === adapter
-    : cell.selector.scope === "channel_type" &&
-        cell.selector.adapter === adapter &&
-        cell.selector.channelType === "dm";
-}
-
 /**
  * Per-channel capabilities-tier persistence for a channel adapter's room
  * list: reads the gateway's channel-permission cells and writes/deletes
@@ -136,8 +125,8 @@ function isBucketCell(
  * connected assistant can serve it); when off it reports `supported: false` with
  * no overrides or handlers.
  *
- * The adapter is a parameter so Telegram/Phone room lists reuse this hook
- * unchanged when they land.
+ * `adapter` filters the gateway's cell list, which returns every adapter's
+ * cells (only caller today is Slack).
  */
 export function useChannelPermissionOverrides({
   assistantId,
@@ -323,9 +312,13 @@ export function useChannelPermissionOverrides({
       queryClient.setQueryData(queryKey, context?.previous);
       toastOnError("Failed to save the default")(err);
     },
-    onSettled: () => {
+    onSettled: (_data, _err, { bucket }) => {
       queryClient.invalidateQueries({ queryKey });
-      queryClient.invalidateQueries({ queryKey: resolveQueryKey });
+      // Only the adapter-scope `channels` cell feeds the resolve query; a `dm`
+      // write leaves the room-list fall-through unchanged.
+      if (bucket === "channels") {
+        queryClient.invalidateQueries({ queryKey: resolveQueryKey });
+      }
     },
   });
 
@@ -348,9 +341,13 @@ export function useChannelPermissionOverrides({
       queryClient.setQueryData(queryKey, context?.previous);
       toastOnError("Failed to reset the default")(err);
     },
-    onSettled: () => {
+    onSettled: (_data, _err, { bucket }) => {
       queryClient.invalidateQueries({ queryKey });
-      queryClient.invalidateQueries({ queryKey: resolveQueryKey });
+      // Only the adapter-scope `channels` cell feeds the resolve query; a `dm`
+      // reset leaves the room-list fall-through unchanged.
+      if (bucket === "channels") {
+        queryClient.invalidateQueries({ queryKey: resolveQueryKey });
+      }
     },
   });
 

--- a/clients/web/src/domains/channels/hooks/use-channel-permission-overrides.ts
+++ b/clients/web/src/domains/channels/hooks/use-channel-permission-overrides.ts
@@ -383,7 +383,15 @@ export function useChannelPermissionOverrides({
     bucketDeleteMutation.variables,
   ]);
 
-  if (!enabled) {
+  // The version gate can't know whether *this* assistant's gateway actually
+  // wired up the channel-permission routes — a build that reports a supported
+  // version but still 404s the list route would otherwise leave the pickers
+  // permanently disabled (they hold disabled until overrides load, which never
+  // happens). Treat a list-route error like an unsupported assistant and
+  // degrade to the read-only channel list, the same fall-back the version gate
+  // uses. A 404 won't recover on retry; a transient error self-heals on the
+  // query's next refetch, flipping this back to supported.
+  if (!enabled || query.isError) {
     return {
       supported: false,
       tierOverrides: undefined,

--- a/clients/web/src/domains/channels/slack-channel-overrides.test.ts
+++ b/clients/web/src/domains/channels/slack-channel-overrides.test.ts
@@ -38,7 +38,7 @@ describe("CAPABILITY_TIER_META", () => {
     expect(CAPABILITY_TIER_META.none.sublabel).toBe("asks before acting");
     expect(CAPABILITY_TIER_META.low.sublabel).toBe("safe reads only");
     expect(CAPABILITY_TIER_META.medium.sublabel).toBe("broader lookups");
-    expect(CAPABILITY_TIER_META.high.sublabel).toBe("answers on its own");
+    expect(CAPABILITY_TIER_META.high.sublabel).toBe("researches on its own");
   });
 });
 

--- a/clients/web/src/domains/channels/slack-channel-overrides.test.ts
+++ b/clients/web/src/domains/channels/slack-channel-overrides.test.ts
@@ -38,7 +38,7 @@ describe("CAPABILITY_TIER_META", () => {
     expect(CAPABILITY_TIER_META.none.sublabel).toBe("asks before acting");
     expect(CAPABILITY_TIER_META.low.sublabel).toBe("safe reads only");
     expect(CAPABILITY_TIER_META.medium.sublabel).toBe("broader lookups");
-    expect(CAPABILITY_TIER_META.high.sublabel).toBe("researches on its own");
+    expect(CAPABILITY_TIER_META.high.sublabel).toBe("answers on its own");
   });
 });
 

--- a/clients/web/src/domains/channels/slack-channel-overrides.ts
+++ b/clients/web/src/domains/channels/slack-channel-overrides.ts
@@ -69,7 +69,7 @@ export const CAPABILITY_TIER_META: Record<RiskThreshold, CapabilityTierMeta> = {
   },
   high: {
     label: presetFromThreshold("high").label,
-    sublabel: "researches on its own",
+    sublabel: "answers on its own",
     tone: "positive",
     dotColor: "var(--system-positive-strong)",
   },
@@ -142,6 +142,24 @@ export function tierOverridesFromCells(
 export type ChannelDefaultBucket = "channels" | "dm";
 
 /**
+ * Whether a cell is the broader-scope default cell for `bucket`: `"channels"` is
+ * the adapter-scope cell, `"dm"` is the `channel_type: dm` cell. Shared by the
+ * read path here and the write/optimistic path in
+ * `use-channel-permission-overrides` so the two can't drift.
+ */
+export function isBucketCell(
+  cell: Pick<ChannelTierCell, "selector">,
+  adapter: string,
+  bucket: ChannelDefaultBucket,
+): boolean {
+  return bucket === "channels"
+    ? cell.selector.scope === "adapter" && cell.selector.adapter === adapter
+    : cell.selector.scope === "channel_type" &&
+        cell.selector.adapter === adapter &&
+        cell.selector.channelType === "dm";
+}
+
+/**
  * The persisted tier for a bucket's cell, if any — the `trusted_contact` cell is
  * the representative when non-guardian contact-type cells diverge (the write
  * path keeps them aligned). `undefined` when the bucket has no cell (it then
@@ -154,13 +172,7 @@ export function bucketDefaultFromCells(
 ): RiskThreshold | undefined {
   let tier: RiskThreshold | undefined;
   for (const cell of cells) {
-    const matches =
-      bucket === "channels"
-        ? cell.selector.scope === "adapter" && cell.selector.adapter === adapter
-        : cell.selector.scope === "channel_type" &&
-          cell.selector.adapter === adapter &&
-          cell.selector.channelType === "dm";
-    if (!matches) {
+    if (!isBucketCell(cell, adapter, bucket)) {
       continue;
     }
     if (cell.contactType === "trusted_contact" || tier === undefined) {

--- a/clients/web/src/domains/channels/slack-channel-overrides.ts
+++ b/clients/web/src/domains/channels/slack-channel-overrides.ts
@@ -69,7 +69,7 @@ export const CAPABILITY_TIER_META: Record<RiskThreshold, CapabilityTierMeta> = {
   },
   high: {
     label: presetFromThreshold("high").label,
-    sublabel: "answers on its own",
+    sublabel: "researches on its own",
     tone: "positive",
     dotColor: "var(--system-positive-strong)",
   },


### PR DESCRIPTION
## Prompt / plan
Follow-up to #39086 (Slack channel-access mobile + layout polish), from reviewing the merged result in the live app.

**1. Scroll.** The Slack detail pane was pinned to `overflow-hidden` from when the channel list was a fixed-height pane with its own scrollbar. The consolidated layout stacks normal-height cards, so once the stack exceeds the viewport the bottom was clipped with no way to scroll. Let the pane scroll as a whole like every other adapter (`overflow-y-auto`); the per-channel list still self-bounds its own rows.

**2. Copy scope + layout.** The access-level key read as if the levels governed whether the assistant *sends* things — they don't (the tier only sets how far it looks up/answers on its own; writes/sends/spends always escalate via the capability floor). Reworded the key's description to state that outright, and reordered it to **heading → description → color legend**. Also tightened the default-access rows' vertical padding (the rows carry their own `py-3`, so the card body's `p-4` doubled the gap).

**3. Degrade on a missing route.** The version gate renders the pickers based on the assistant's reported version, but can't know whether that build's gateway actually wired up the channel-permission routes. An assistant reporting a supported version whose gateway 404s the list route left the pickers **permanently disabled** (they hold disabled until overrides load, which never happens). Now a list-route error degrades to the read-only channel list — the same fall-back the version gate uses for older assistants — instead of a dead disabled state.

**4. Self-review cleanup.** A pass over everything this line of work touched, for invented copy / over-engineering / slop:
- Reverted an invented sublabel (`"researches on its own"` → `"answers on its own"`).
- Corrected the Relaxed-tier example (connected-account network requests floor via host tools; they escalate, so they aren't an auto-approved example).
- Fixed a doc comment that mis-cited where sends floor (host tools, not `side-effects.ts`).
- Deduped a byte-identical bucket-match predicate; legend consumes the shared `TierDot`; stopped invalidating the resolve query on DM-bucket writes; collapsed duplicated doc prose; trimmed a speculative comment.

## Test plan
- `bunx tsc --noEmit` + ESLint clean (pre-commit); 38 channel-domain tests pass.
- Storybook `Channels/SlackChannelTypeDefaults` + `SlackChannelList` verified at desktop (1200px) and mobile (390px).
- Traced enforcement to confirm the reworded copy is accurate: every send/spend tool (MCP → host, `messaging_send`/phone → host, `bash` → side-effect) is caught by the tier-independent floor; the tier governs only read/lookup sandbox tools.
- Degrade path confirmed against a dev assistant whose gateway 404s `channel-permission-overrides`.

## Known follow-up (not in this PR)
`network_request` is inconsistently classified in the assistant/gateway risk tables — always-Medium, **not** in `SIDE_EFFECT_TOOLS`, sandbox-target siblings. Inert today (no such tool registered), but a future live `network_request` tool following the sandbox web-tool pattern would bypass the floor and auto-approve sends at Relaxed/Full. Worth an issue against assistant/gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeiZ9nRv2AdHtBCcGmCoJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeiZ9nRv2AdHtBCcGmCoJY)_