### PR TITLE
fix(web): stack the Credit Balance header buttons below the title on phones

### DIFF
--- a/clients/web/src/domains/settings/components/billing-panel.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel.tsx
@@ -102,8 +102,8 @@ export function BillingPanel() {
     ]);
 
     const creditBalanceHeader = (
-        <div className="flex items-start justify-between gap-4">
-            <div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+            <div className="min-w-0">
                 <Typography
                     as="h2"
                     variant="title-medium"


### PR DESCRIPTION
## Summary
- Credit Balance header stacks title above the two buttons below 640px; restores the row layout at sm+.

Part of plan: billing-mobile-polish.md (PR 1 of 4)