### PR TITLE
fix(web): let the payment-method label truncate instead of clipping the row

### DIFF
--- a/clients/web/src/domains/settings/components/payment-method-row.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.test.tsx
@@ -49,6 +49,20 @@ describe("PaymentMethodRow", () => {
     expect(row.textContent).not.toContain("null");
   });
 
+  test("renders a long unmapped brand and truncates the brand label", () => {
+    const { getByTestId, getByText } = render(
+      <PaymentMethodRow
+        brand="internationalmaestro"
+        last4="0005"
+        onUpdateCard={() => {}}
+        onRemove={() => {}}
+      />,
+    );
+    const row = getByTestId("payment-method-row");
+    expect(row.textContent).toContain("internationalmaestro");
+    expect(getByText("internationalmaestro").className).toContain("truncate");
+  });
+
   test("fires onUpdateCard when Update Card is clicked", () => {
     const onUpdateCard = mock(() => {});
     const { getByTestId } = render(

--- a/clients/web/src/domains/settings/components/payment-method-row.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.tsx
@@ -25,16 +25,16 @@ export function PaymentMethodRow({
       data-testid="payment-method-row"
       className="flex items-center justify-between gap-2 rounded-lg bg-[var(--surface-base)] pl-3 pr-2 py-1.5"
     >
-      <div className="flex items-center gap-2">
+      <div className="flex min-w-0 items-center gap-2">
         <CreditCard
           aria-hidden
-          className="h-4 w-4 text-[var(--content-default)]"
+          className="h-4 w-4 shrink-0 text-[var(--content-default)]"
         />
-        <div>
+        <div className="min-w-0">
           <Typography
             as="p"
             variant="body-medium-default"
-            className="text-[var(--content-default)]"
+            className="truncate text-[var(--content-default)]"
           >
             {brand ? brandLabel(brand) : "Saved card"}
           </Typography>
@@ -42,14 +42,14 @@ export function PaymentMethodRow({
             <Typography
               as="p"
               variant="body-small-default"
-              className="text-[var(--content-tertiary)]"
+              className="truncate text-[var(--content-tertiary)]"
             >
               Ending in {last4}
             </Typography>
           )}
         </div>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex shrink-0 items-center gap-2">
         <Button
           variant="outlined"
           onClick={onUpdateCard}

--- a/clients/web/src/domains/settings/components/referral-content.tsx
+++ b/clients/web/src/domains/settings/components/referral-content.tsx
@@ -38,7 +38,7 @@ function StatChip({ icon, value, label }: StatChipProps) {
       <Typography
         variant="body-small-default"
         as="span"
-        className="text-[var(--content-tertiary)]"
+        className="min-w-0 truncate text-[var(--content-tertiary)]"
       >
         {label}
       </Typography>


### PR DESCRIPTION
## Summary
- PaymentMethodRow: min-w-0 + truncate on the brand/last4 label, shrink-0 on the buttons, so long brands ellipsize and the actions never clip.
- Referral StatChip label truncates to match the SummaryChip pattern.

Part of plan: billing-mobile-polish.md (PR 2 of 4)