### PR TITLE
fix(web): compact the adjust-plan modal cards on phones

### DIFF
--- a/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -556,7 +556,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                     Failed to load plans. Please try again later.
                   </Notice>
                 ) : (
-                  <div className="space-y-6">
+                  <div className="space-y-4 sm:space-y-6">
                     <div className="space-y-2 pb-2 pt-4 text-center">
                       <Typography as="p" variant="title-medium">
                         Your Assistant, Your Way

--- a/clients/web/src/domains/settings/components/plan-card-content.tsx
+++ b/clients/web/src/domains/settings/components/plan-card-content.tsx
@@ -109,7 +109,10 @@ export function PlanCardContent({
   const showProTierChange = isProCard && isCurrent && proTierChangeMode;
 
   return (
-    <Card padding="lg" className="flex flex-col bg-[var(--surface-base)]">
+    <Card
+      padding="lg"
+      className="flex flex-col bg-[var(--surface-base)] max-sm:[&_[data-slot=card-body]]:p-4"
+    >
       <div className="flex flex-col gap-4">
         <span
           aria-hidden


### PR DESCRIPTION
## Summary
- Adjust-plan modal: card padding p-4 (p-6 at sm+) and body space-y-4 (space-y-6 at sm+) so the cards are tighter on phones.

Part of plan: billing-mobile-polish.md (PR 4 of 4)