### PR TITLE
fix(web): tighten plans-takeover cards and section rhythm on phones

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
@@ -65,6 +65,15 @@ describe("PlanColumnCard CTA", () => {
     expect(button).toHaveProperty("disabled", false);
     expect(button.className).toContain("bg-[var(--primary-base)]");
   });
+
+  test("compacts card padding on phones, restoring it at sm", async () => {
+    const { container } = render(
+      <PlanColumnCard {...baseProps} isCurrent={false} />,
+    );
+    const root = container.querySelector("[data-theme]");
+    expect(root?.className).toContain("p-3");
+    expect(root?.className).toContain("sm:p-4");
+  });
 });
 
 describe("PlanColumnCard Recommended badge", () => {

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
@@ -59,7 +59,7 @@ export function PlanColumnCard({
   return (
     <div
       data-theme={tone}
-      className="flex w-full flex-col gap-4 rounded-2xl bg-[var(--surface-lift)] p-4"
+      className="flex w-full flex-col gap-3 rounded-2xl bg-[var(--surface-lift)] p-3 sm:gap-4 sm:p-4"
     >
       <PlanTierAvatar tier={tierKey} size={50} />
 
@@ -75,7 +75,7 @@ export function PlanColumnCard({
           ) : null}
         </div>
 
-        <p className="h-9 overflow-hidden text-[14px] font-medium leading-[18px] text-[var(--content-tertiary)]">
+        <p className="overflow-hidden text-[14px] font-medium leading-[18px] text-[var(--content-tertiary)] sm:h-9">
           {tagline}
         </p>
       </div>
@@ -102,7 +102,7 @@ export function PlanColumnCard({
 
       <div className="h-px w-full bg-[var(--border-hover)]" />
 
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2 sm:gap-4">
         <span className="text-[12px] font-medium text-[var(--content-tertiary)]">
           Includes:
         </span>

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -500,10 +500,9 @@ export function PlansPage() {
       <div className="my-auto flex w-full flex-col items-center">
         <header className="flex flex-col items-center gap-2 text-center">
           <h1
-            className="text-[var(--content-emphasised)]"
+            className="text-[40px] text-[var(--content-emphasised)] sm:text-[60px]"
             style={{
               fontFamily: "var(--font-serif)",
-              fontSize: "60px",
               fontWeight: 400,
               lineHeight: 1.2,
               letterSpacing: "1.2px",
@@ -520,7 +519,7 @@ export function PlansPage() {
             to two-up then one-up; `items-start` keeps each card at its natural
             content height, so the four-feature Super/Ultra columns are taller
             than the featured Mighty column. */}
-        <div className="mt-10 grid w-full max-w-[1312px] grid-cols-1 items-start gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="mt-6 grid w-full max-w-[1312px] grid-cols-1 items-start gap-4 sm:mt-10 sm:grid-cols-2 sm:gap-6 lg:grid-cols-4">
           <PlanColumnCard
             tierKey="free"
             name="Free"
@@ -568,7 +567,7 @@ export function PlansPage() {
         </div>
 
         <CustomPlanRow
-          className="mt-10"
+          className="mt-6 sm:mt-10"
           onConfigure={handleConfigure}
           configureDisabled={(isProUser && !currentReady) || billingActionPending}
           isCurrent={showCurrentPlan}
@@ -620,7 +619,7 @@ export function PlansPage() {
           resizeCredits={resizeCreditTier}
         />
 
-        <p className="mt-10 text-center text-[12px] font-medium text-[var(--content-tertiary)]">
+        <p className="mt-6 text-center text-[12px] font-medium text-[var(--content-tertiary)] sm:mt-10">
           You can cancel or change your plan anytime you want. To learn more{" "}
           <a
             href={DOCS_URL}
@@ -667,7 +666,7 @@ export function PlansPage() {
       </div>
 
       <div
-        className="plans-takeover-content-enter flex min-h-full flex-col items-center px-6 pb-8"
+        className="plans-takeover-content-enter flex min-h-full flex-col items-center px-4 pb-8 sm:px-6"
         style={{ paddingTop: electron ? "5rem" : "4rem" }}
       >
         {body}


### PR DESCRIPTION
## Summary
- Plans takeover: compact card padding/gaps, natural tagline height, tighter section spacing, and a 40px h1 below 640px; sm: restores today's desktop values.

Part of plan: billing-mobile-polish.md (PR 3 of 4)