### PR TITLE
Route managed Quality profile to GPT-5.6 Sol

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -855,10 +855,9 @@ describe("loadConfig startup behavior", () => {
     expect(effective.balanced?.model).toBe("accounts/fireworks/models/glm-5p2");
     expect(effective.balanced?.effort).toBe("high");
     expect(effective.balanced?.source).toBe("managed");
-    // Quality pins Anthropic Fable, the most capable managed model.
+    // Quality pins OpenAI Sol, the most capable managed model.
     expect(effective["quality-optimized"]?.provider).toBe("vellum");
-    expect(effective["quality-optimized"]?.model).toBe("claude-fable-5");
-    expect(effective["quality-optimized"]?.model).toBe("claude-fable-5");
+    expect(effective["quality-optimized"]?.model).toBe("gpt-5.6-sol");
     // Speed is served by DeepSeek V4 Flash on Fireworks.
     expect(effective["cost-optimized"]?.provider).toBe("vellum");
     expect(effective["cost-optimized"]?.model).toBe(
@@ -916,7 +915,7 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     expect(raw.llm.profiles["quality-optimized"]).toEqual(legacy);
-    // The shadow wins over the catalog body (which serves claude-fable-5).
+    // The shadow wins over the catalog body (which serves gpt-5.6-sol).
     const effectiveQuality = getEffectiveProfile(
       raw.llm.profiles,
       "quality-optimized",
@@ -941,7 +940,7 @@ describe("loadConfig startup behavior", () => {
       "quality-optimized",
     );
     expect(effectiveQuality?.source).toBe("managed");
-    expect(effectiveQuality?.model).toBe("claude-fable-5");
+    expect(effectiveQuality?.model).toBe("gpt-5.6-sol");
   });
 
   test("platform boot leaves a drifted managed entry byte-identical; resolution serves catalog content", () => {

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -53,6 +53,15 @@ describe("getEffectiveProfiles", () => {
     }
   });
 
+  test("the managed Quality profile routes GPT-5.6 Sol through OpenAI", () => {
+    const quality = CODE_DEFAULT_PROFILE_ENTRIES["quality-optimized"];
+    expect(quality.model).toBe("gpt-5.6-sol");
+    expect(resolveRoutingIdentity(quality.provider, quality.model)).toEqual({
+      connectionName: "vellum",
+      expectedProvider: "openai",
+    });
+  });
+
   test("defaults absent from the workspace resolve from the catalog; os-beta stays flag-gated", () => {
     const effective = getEffectiveProfiles(undefined);
     expect(Object.keys(effective).sort()).toEqual(

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -79,7 +79,7 @@ const VELLUM_PROFILE_IMPLS: Record<ProfileMatrixKey, DefaultProfileTemplate> = {
     },
   },
   "quality-optimized": {
-    model: "claude-fable-5",
+    model: "gpt-5.6-sol",
     provider: "vellum",
     source: "managed",
     label: "Quality",


### PR DESCRIPTION
## Summary

- route the code-owned Vellum-managed Quality profile through OpenAI GPT-5.6 Sol
- keep BYOK OpenAI profile defaults unchanged
- add regression coverage for the managed OpenAI dispatch target

## Original prompt

Replace the Vellum-managed Quality profile model from Claude Fable 5 with OpenAI GPT-5.6 Sol.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->