### PR TITLE
feat(billing): centered current-plan card layout matching the new mock

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-spec-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plan-spec-card.test.tsx
@@ -1,9 +1,9 @@
 /**
- * Tests for PlanSpecCard: the shared, layout-only plan card used for both the
- * light ("current") and dark ("recommended") columns in the billing Plan
- * section. Verifies it renders the name, tagline, and spec chips; forwards
- * `nameTestId`; forces the `data-theme` palette; and omits the divider + chip
- * row when there are no specs.
+ * Tests for PlanSpecCard: the layout-only current-plan card in the billing
+ * "Plan" section. Verifies it renders the name and spec chips; forwards
+ * `nameTestId`; forces the light `data-theme` palette; centers its content on
+ * both axes; and brackets the header row with a divider both above and below
+ * only when spec chips are present (otherwise just the centered header row).
  *
  * Rendered with `renderToStaticMarkup` (single-pass, no DOM) — so the lazy
  * `PlanTierAvatar` compositor bundle is mocked to a placeholder, keeping the
@@ -30,80 +30,88 @@ const SPECS: PlanSpec[] = [
   { icon: HardDrive, label: "10 GB" },
 ];
 
+/** Counts non-overlapping occurrences of `needle` in `haystack`. */
+function count(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
 describe("PlanSpecCard", () => {
-  test("renders name, tagline, spec labels, and the nameTestId", () => {
+  test("renders the name, spec labels, and forwards the nameTestId", () => {
     const html = renderToStaticMarkup(
       <PlanSpecCard
-        tone="light"
-        tierKey="free"
+        tierKey="mighty"
         name="Mighty"
         nameTestId="plan-card-name"
-        tagline="A great starter plan"
         specs={SPECS}
       />,
     );
     expect(html).toContain("Mighty");
-    expect(html).toContain("A great starter plan");
     expect(html).toContain("$25 credits");
     expect(html).toContain("10 GB");
     expect(html).toContain("plan-card-name");
   });
 
-  test("omits the divider + chip row when specs is null", () => {
+  test("forces the light data-theme scope", () => {
     const html = renderToStaticMarkup(
-      <PlanSpecCard
-        tone="light"
-        tierKey="free"
-        name="Free"
-        specs={null}
-      />,
+      <PlanSpecCard tierKey="mighty" name="Mighty" specs={SPECS} />,
     );
-    expect(html).toContain("Free");
-    expect(html).not.toContain("$25 credits");
-    expect(html).not.toContain("10 GB");
+    expect(html).toContain('data-theme="light"');
   });
 
-  test("omits the divider + chip row when specs is empty", () => {
+  test("centers its content on both axes", () => {
     const html = renderToStaticMarkup(
-      <PlanSpecCard tone="light" tierKey="free" name="Free" specs={[]} />,
+      <PlanSpecCard tierKey="free" name="Free" specs={null} />,
     );
-    expect(html).toContain("Free");
-    expect(html).not.toContain("$25 credits");
-    expect(html).not.toContain("10 GB");
-  });
-
-  test("forces data-theme=\"dark\" when tone is dark", () => {
-    const html = renderToStaticMarkup(
-      <PlanSpecCard
-        tone="dark"
-        tierKey="free"
-        name="Recommended"
-        specs={SPECS}
-      />,
-    );
-    expect(html).toContain('data-theme="dark"');
-  });
-
-  test("centers the card content when centered is set", () => {
-    const html = renderToStaticMarkup(
-      <PlanSpecCard
-        tone="light"
-        tierKey="free"
-        name="Free"
-        tagline="A great starter plan"
-        centered
-        specs={null}
-      />,
-    );
-    // The centering utilities land on both the root and the header row.
-    expect(html).toContain("justify-center");
     expect(html).toContain("items-center");
+    expect(html).toContain("justify-center");
+  });
+
+  test("brackets the header row with a divider both above and below when specs exist", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard tierKey="mighty" name="Mighty" specs={SPECS} />,
+    );
+    // A divider both above and below the header row → two divider rules.
+    expect(count(html, "bg-[var(--border-base)]")).toBe(2);
+    // The chip row is centered.
+    expect(html).toContain("justify-center");
+  });
+
+  test("omits the dividers + chip row when specs is null", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard tierKey="free" name="Free" specs={null} />,
+    );
+    expect(html).toContain("Free");
+    expect(html).not.toContain("bg-[var(--border-base)]");
+    expect(html).not.toContain("$25 credits");
+    expect(html).not.toContain("10 GB");
+  });
+
+  test("omits the dividers + chip row when specs is empty", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard tierKey="free" name="Free" specs={[]} />,
+    );
+    expect(html).toContain("Free");
+    expect(html).not.toContain("bg-[var(--border-base)]");
+    expect(html).not.toContain("$25 credits");
+    expect(html).not.toContain("10 GB");
+  });
+
+  test("renders the tag next to the name", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard
+        tierKey="free"
+        name="Free"
+        tag={<span>Current Plan</span>}
+        specs={null}
+      />,
+    );
+    expect(html).toContain("Free");
+    expect(html).toContain("Current Plan");
   });
 
   test("renders a wrapping pill for a multiline spec", () => {
     const html = renderToStaticMarkup(
       <PlanSpecCard
-        tone="dark"
         tierKey="mighty"
         name="Mighty"
         specs={[
@@ -124,7 +132,6 @@ describe("PlanSpecCard", () => {
   test("applies the passed className to the root", () => {
     const html = renderToStaticMarkup(
       <PlanSpecCard
-        tone="light"
         tierKey="free"
         name="Free"
         className="lg:flex-[3]"

--- a/clients/web/src/domains/settings/billing/plan-spec-card.tsx
+++ b/clients/web/src/domains/settings/billing/plan-spec-card.tsx
@@ -7,95 +7,65 @@ import { cn } from "@/utils/misc";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 export interface PlanSpecCardProps {
-  /** Forces the card palette: "light" (current) or "dark" (recommended). */
-  tone: "light" | "dark";
   /** Tier key ("free" or a `ProPackage.key`) — selects the creature avatar. */
   tierKey: string;
   name: string;
   /** Test id applied to the plan-name node (e.g. "plan-card-name"). */
   nameTestId?: string;
-  /** Rendered right of the name, e.g. a "Your Current Plan" / "Recommended" tag. */
+  /** Rendered right of the name, e.g. a "Current Plan" tag. */
   tag?: ReactNode;
-  tagline?: string;
-  /** Absolute spec chips; when null/empty the divider + chip row are omitted. */
+  /** Absolute spec chips; when null/empty the dividers + chip row are omitted. */
   specs?: PlanSpec[] | null;
-  /** Header right-aligned action (e.g. the Upgrade button). */
-  action?: ReactNode;
-  /** Centers the card content on both axes (the minimal free current card). */
-  centered?: boolean;
   /** Extra root classes (e.g. a responsive width override); applied last. */
   className?: string;
 }
 
 /**
- * One plan card in the billing "Plan" section. Layout-only: the parent owns
- * the catalog data, the current-plan decision, and any CTA behavior. The
- * forced `data-theme` scope resolves the semantic tokens to the mock's
- * light (current) / dark (recommended) palettes.
+ * The current-plan card in the billing "Plan" section. Layout-only: the parent
+ * owns the catalog data, the current-plan decision, and any CTA behavior. The
+ * forced light `data-theme` scope resolves the semantic tokens to the mock's
+ * light (current-plan) palette. Content is centered on both axes: when spec
+ * chips are present, the header row sits between two dividers with a centered
+ * chip row beneath; otherwise only the centered header row renders.
  */
 export function PlanSpecCard({
-  tone,
   tierKey,
   name,
   nameTestId,
   tag,
-  tagline,
   specs,
-  action,
-  centered = false,
   className,
 }: PlanSpecCardProps) {
   const hasSpecs = specs != null && specs.length > 0;
   return (
     <div
-      data-theme={tone}
+      data-theme="light"
       className={cn(
-        "flex min-w-0 flex-1 flex-col gap-4 rounded-xl bg-[var(--surface-base)] py-3 pl-3 pr-4",
-        centered && "items-center justify-center",
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-4 rounded-xl bg-[var(--surface-base)] py-3 pl-3 pr-4",
         className,
       )}
     >
-      <div
-        className={cn(
-          "flex items-center gap-3",
-          centered ? "justify-center" : "justify-between",
-        )}
-      >
-        <div className="flex min-w-0 items-center gap-3">
-          <PlanTierAvatar tier={tierKey} />
-          <div className="flex min-w-0 flex-col gap-1.5">
-            <div className="flex flex-wrap items-center gap-1.5">
-              <Typography
-                as="span"
-                variant="body-large-default"
-                className="text-[var(--content-default)]"
-                data-testid={nameTestId}
-              >
-                {name}
-              </Typography>
-              {tag}
-            </div>
-            {tagline ? (
-              <Typography
-                as="span"
-                variant="body-small-default"
-                className="text-[var(--content-tertiary)]"
-              >
-                {tagline}
-              </Typography>
-            ) : null}
-          </div>
+      {hasSpecs ? (
+        <div className="h-px w-full bg-[var(--border-base)]" />
+      ) : null}
+      <div className="flex items-center gap-3">
+        <PlanTierAvatar tier={tierKey} size={48} />
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Typography
+            as="span"
+            variant="body-large-default"
+            className="text-[var(--content-default)]"
+            data-testid={nameTestId}
+          >
+            {name}
+          </Typography>
+          {tag}
         </div>
-        {action}
       </div>
       {hasSpecs ? (
         <>
-          {/* mt-auto anchors the divider + chips to the bottom of the card, so
-              the chip rows align across the two cards even when one card is
-              taller (e.g. a wrapped tagline) and `items-stretch` stretches the
-              other — matching the mock, where chips sit near the card bottom. */}
-          <div className="mt-auto h-px w-full bg-[var(--border-base)]" />
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="h-px w-full bg-[var(--border-base)]" />
+          <div className="flex flex-wrap items-center justify-center gap-2">
             {specs.map((spec) => (
               <SpecChip
                 key={spec.label}

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -518,7 +518,7 @@ describe("PlanCard", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
     expect(html).toContain("plan-card-name");
     expect(html).toContain("Free");
-    expect(html).toContain("Your Current Plan");
+    expect(html).toContain("Current Plan");
     expect(html).toContain("plan-card-renews");
     expect(html).toContain("auto renew");
   });
@@ -561,10 +561,8 @@ describe("PlanCard", () => {
     expect(html).toContain(PLAN_TIER_COPY.mighty.upgradeBlurb!);
     expect(html).not.toContain("more credits and storage");
     expect(html).not.toContain("Recommended");
-    // The centered free card still shows its "Your Current Plan" tag and its real
-    // tagline — the tagline follows "known plan", not "has chips".
-    expect(html).toContain("Your Current Plan");
-    expect(html).toContain(PLAN_TIER_COPY.free.tagline);
+    // The centered free card still shows its "Current Plan" tag.
+    expect(html).toContain("Current Plan");
   });
 
   test("Mighty → Super: current keeps its chips, recommended shows the promo card", () => {
@@ -652,9 +650,6 @@ describe("PlanCard", () => {
     // doesn't masquerade as a stock package.
     expect(html).toContain("Custom");
     expect(html).not.toContain("Mighty (Custom)");
-    // Its specs are unknowable (no chips), so the stock Mighty tagline must not
-    // render under the "Custom" name either — same gate as the chips.
-    expect(html).not.toContain(PLAN_TIER_COPY.mighty.tagline);
   });
 
   test("current-plan row labels an unpinned Pro sub as custom", () => {
@@ -668,10 +663,6 @@ describe("PlanCard", () => {
     expect(html).toContain("plan-card-name");
     expect(html).toContain("Custom");
     expect(html).not.toContain("Pro");
-    // `currentTier` falls back to "free" for an unpinned sub, but its specs are
-    // unknowable (no chips), so the stock free tagline must not leak in under
-    // the "Custom" name.
-    expect(html).not.toContain(PLAN_TIER_COPY.free.tagline);
   });
 
   test("a clean-pinned Pro sub whose package is absent from the catalog shows no chips", () => {
@@ -690,13 +681,12 @@ describe("PlanCard", () => {
     expect(html).not.toContain("Small Machine");
   });
 
-  test("a free user's current card is centered, chip-less, and keeps its tagline", () => {
+  test("a free user's current card is centered and chip-less", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
     // The free current card is a minimal centered card: centering classes on the
-    // card, its "Your Current Plan" tag, and the real free tagline, but NO chips.
+    // card and its "Current Plan" tag, but NO chips.
     expect(html).toContain("justify-center");
-    expect(html).toContain("Your Current Plan");
-    expect(html).toContain(PLAN_TIER_COPY.free.tagline);
+    expect(html).toContain("Current Plan");
     expect(html).not.toContain("$0 credits");
     expect(html).not.toContain("4 GB");
     expect(html).not.toContain("Small Machine");

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -476,7 +476,6 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
       ? "upgrade"
       : "switch";
 
-  const currentCopy = getPlanTierCopy(currentTier);
   const isFreePlan = currentPlan.id === "base";
   // Chips render only for a paid plan whose stock package specs are known.
   // Free shows a minimal centered card (no chips); a clean pin absent from the
@@ -487,10 +486,6 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
       ? (packages.find((p) => p.key === currentKey) ?? null)
       : null;
   const currentSpecs = currentPackage ? packageSpecs(currentPackage) : null;
-  // Tagline shows for a KNOWN plan (free, or a clean stock pin); hidden for a
-  // Custom/unknown sub whose real plan can't be named. (Note: this is gated on
-  // "known plan", NOT on having chips — free has no chips but a real tagline.)
-  const isKnownCurrentPlan = isFreePlan || isCleanPin(subscription.package);
 
   return (
     <Card padding="md">
@@ -531,24 +526,17 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
             {display.actionLabel}
           </Button>
         </div>
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-stretch">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-stretch">
           <PlanSpecCard
-            tone="light"
             tierKey={currentTier}
             name={planName}
             nameTestId="plan-card-name"
             className="lg:flex-[3]"
-            centered={isFreePlan}
             tag={
               <Tag className="bg-[var(--feed-digest-weak)] text-[var(--content-default)]">
-                Your Current Plan
+                Current Plan
               </Tag>
             }
-            // The tagline follows "known plan" (free, or a clean stock pin), not
-            // "has chips": free is centered with no chips but still shows its
-            // real tagline, while a Custom/unknown sub — whose real plan can't be
-            // named — hides it to avoid mislabeling a paid sub with stock copy.
-            tagline={isKnownCurrentPlan ? currentCopy?.tagline : undefined}
             specs={currentSpecs}
           />
           <RecommendedUpgrade


### PR DESCRIPTION
## Summary
- Current-plan card is now fully centered: eyeless avatar + name + 'Current Plan' tag between two dividers, centered chips beneath (no tagline)
- Free variant renders just the centered header row (no dividers/chips)
- Simplify PlanSpecCard to its single remaining consumer (drop tone/action/tagline/centered)
- Between-cards gap back to the mock's 8px (gap-2)

Part of plan: plan-section-promo-cards.md (PR 4 of 4)