### PR TITLE
feat(image-gen): accept provider vellum and route it through the managed proxy

### DIFF
--- a/assistant/src/__tests__/config-model-image-provider.test.ts
+++ b/assistant/src/__tests__/config-model-image-provider.test.ts
@@ -107,3 +107,23 @@ describe("setImageGenModel — provider derived from model prefix", () => {
     expect(imageGen?.provider).toBe("openai");
   });
 });
+
+describe("setImageGenModel with provider vellum", () => {
+  test("a model change leaves provider vellum untouched", () => {
+    writeConfig({
+      services: {
+        "image-generation": { provider: "vellum", model: "gpt-image-2" },
+      },
+    });
+
+    setImageGenModel("gemini-3-pro-image-preview", makeCtx());
+
+    const raw = readConfig() as {
+      services: { "image-generation": { provider: string; model: string } };
+    };
+    expect(raw.services["image-generation"].model).toBe(
+      "gemini-3-pro-image-preview",
+    );
+    expect(raw.services["image-generation"].provider).toBe("vellum");
+  });
+});

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -99,6 +99,17 @@ describe("AssistantConfigSchema", () => {
     expect(result.auditLog).toEqual({ retentionDays: 0 });
   });
 
+  test("accepts vellum as an image generation provider", () => {
+    const result = AssistantConfigSchema.parse({
+      services: {
+        "image-generation": { provider: "vellum", model: "gpt-image-2" },
+      },
+    });
+
+    expect(result.services["image-generation"].provider).toBe("vellum");
+    expect(result.services["image-generation"].model).toBe("gpt-image-2");
+  });
+
   test("accepts Tavily as a web search provider", () => {
     const result = AssistantConfigSchema.parse({
       services: {

--- a/assistant/src/__tests__/image-credentials.test.ts
+++ b/assistant/src/__tests__/image-credentials.test.ts
@@ -21,7 +21,10 @@ mock.module("../providers/platform-proxy/context.js", () => ({
 }));
 
 // Import after mocks
-import { resolveImageGenCredentials } from "../media/image-credentials.js";
+import {
+  resolveImageGenCredentials,
+  resolveImageGenRouting,
+} from "../media/image-credentials.js";
 
 describe("resolveImageGenCredentials", () => {
   beforeEach(() => {
@@ -133,5 +136,73 @@ describe("resolveImageGenCredentials", () => {
       expect(result.errorHint).toBeDefined();
       expect(result.errorHint).toContain("OpenAI API key");
     });
+  });
+});
+
+describe("resolveImageGenRouting", () => {
+  test("provider vellum is managed with a gemini backend for gemini models", () => {
+    expect(
+      resolveImageGenRouting({
+        provider: "vellum",
+        model: "gemini-3.1-flash-image-preview",
+      }),
+    ).toEqual({ backendProvider: "gemini", managed: true });
+  });
+
+  test("provider vellum derives an openai backend from a gpt model", () => {
+    expect(
+      resolveImageGenRouting({ provider: "vellum", model: "gpt-image-2" }),
+    ).toEqual({ backendProvider: "openai", managed: true });
+  });
+
+  test("a model override wins over the stored model under vellum", () => {
+    expect(
+      resolveImageGenRouting(
+        { provider: "vellum", model: "gemini-3.1-flash-image-preview" },
+        "gpt-image-2",
+      ),
+    ).toEqual({ backendProvider: "openai", managed: true });
+  });
+
+  test("a legacy managed mode routes managed for BYOK providers", () => {
+    expect(
+      resolveImageGenRouting({
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+        mode: "managed",
+      }),
+    ).toEqual({ backendProvider: "gemini", managed: true });
+  });
+
+  test("BYOK providers keep the override re-routing without managed", () => {
+    expect(
+      resolveImageGenRouting(
+        {
+          provider: "gemini",
+          model: "gemini-3.1-flash-image-preview",
+          mode: "your-own",
+        },
+        "gpt-image-2",
+      ),
+    ).toEqual({ backendProvider: "openai", managed: false });
+  });
+
+  test("vellum with an unavailable platform is a hard error, not a BYOK fallback", async () => {
+    // Billing rule: an explicit vellum choice never silently spends a stored
+    // provider key.
+    mockProviderKey = "gemini-key-should-not-be-used";
+    mockPlatformBaseUrl = "";
+
+    const routing = resolveImageGenRouting({
+      provider: "vellum",
+      model: "gemini-3.1-flash-image-preview",
+    });
+    const result = await resolveImageGenCredentials({
+      provider: routing.backendProvider,
+      mode: routing.managed ? "managed" : "your-own",
+    });
+
+    expect(result.credentials).toBeUndefined();
+    expect(result.errorHint).toContain("Managed proxy is not available");
   });
 });

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -30,7 +30,8 @@ let lastGenerateCredentials: unknown = null;
 function seedImageGenService(
   overrides: {
     mode?: "your-own" | "managed";
-    provider?: "gemini" | "openai";
+    provider?: "vellum" | "gemini" | "openai";
+    model?: string;
   } = {},
 ): void {
   setConfig("services", { "image-generation": overrides });
@@ -170,6 +171,57 @@ describe("image-studio skill script wrapper", () => {
       assistantApiKey: "managed-key-123",
       baseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
     });
+  });
+
+  test("provider vellum routes managed to the gemini proxy for gemini models", async () => {
+    seedImageGenService({ provider: "vellum" });
+    mockManagedProxyContext = {
+      enabled: true,
+      platformBaseUrl: "https://platform.example.com",
+      assistantApiKey: "managed-key-123",
+    };
+
+    const result = await run({ prompt: "a hippo" }, fakeContext);
+
+    expect(result.isError).toBe(false);
+    expect(lastGenerateProvider).toBe("gemini");
+    expect(lastGenerateCredentials).toEqual({
+      type: "managed-proxy",
+      assistantApiKey: "managed-key-123",
+      baseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
+    });
+  });
+
+  test("provider vellum routes a gpt model to the openai proxy", async () => {
+    seedImageGenService({ provider: "vellum", model: "gpt-image-2" });
+    mockManagedProxyContext = {
+      enabled: true,
+      platformBaseUrl: "https://platform.example.com",
+      assistantApiKey: "managed-key-123",
+    };
+
+    const result = await run({ prompt: "a hippo" }, fakeContext);
+
+    expect(result.isError).toBe(false);
+    expect(lastGenerateProvider).toBe("openai");
+    expect(lastGenerateCredentials).toEqual({
+      type: "managed-proxy",
+      assistantApiKey: "managed-key-123",
+      baseUrl: "https://platform.example.com/v1/runtime-proxy/openai",
+    });
+  });
+
+  test("provider vellum with no platform is a hard error, not a BYOK fallback", async () => {
+    // Billing rule: an explicit vellum choice never silently spends a stored
+    // provider key.
+    seedImageGenService({ provider: "vellum" });
+    mockGeminiKey = "gemini-key-should-not-be-used";
+
+    const result = await run({ prompt: "a hippo" }, fakeContext);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Managed proxy is not available");
+    expect(lastGenerateProvider).toBeNull();
   });
 
   test("managed mode returns error when managed proxy is unavailable", async () => {

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -1,4 +1,7 @@
-import { resolveImageGenCredentials } from "../../../../media/image-credentials.js";
+import {
+  resolveImageGenCredentials,
+  resolveImageGenRouting,
+} from "../../../../media/image-credentials.js";
 import {
   describeImageModels,
   resolveImageModel,
@@ -6,7 +9,6 @@ import {
 import {
   generateImage,
   mapImageGenError,
-  providerForModel,
 } from "../../../../media/image-service.js";
 import { getFilePathBySourcePath } from "../../../../persistence/attachments-store.js";
 import type { ImageContent } from "../../../../providers/types.js";
@@ -37,13 +39,17 @@ export async function run(
     }
     modelOverride = entry.id;
   }
-  // Derive provider from the explicit model when supplied so that requesting
-  // e.g. `gpt-image-2` while config.provider === "gemini" routes to OpenAI
-  // instead of silently falling back to the Gemini default model.
-  const provider = providerForModel(modelOverride, svc.provider);
+  // Backend and managed-ness resolve together: an explicit model re-routes
+  // to the model's backend (e.g. `gpt-image-2` under a gemini config routes
+  // to OpenAI), and provider "vellum" runs managed with a model-derived
+  // backend.
+  const { backendProvider: provider, managed } = resolveImageGenRouting(
+    svc,
+    modelOverride,
+  );
   const { credentials, errorHint } = await resolveImageGenCredentials({
     provider,
-    mode: svc.mode,
+    mode: managed ? "managed" : "your-own",
   });
   if (!credentials) {
     return {

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -20,7 +20,9 @@ export const VALID_INFERENCE_PROVIDERS = [
   "openrouter",
 ] as const;
 
-const VALID_IMAGE_GEN_PROVIDERS = ["gemini", "openai"] as const;
+// `vellum` generates through the platform runtime proxy; the backend
+// (gemini/openai) derives from the selected model's prefix at request time.
+const VALID_IMAGE_GEN_PROVIDERS = ["vellum", "gemini", "openai"] as const;
 
 /**
  * Derived from `SEARCH_PROVIDER_CATALOG`. Adding a new web-search provider

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -98,13 +98,21 @@ export function setImageGenModel(modelId: string, ctx: ModelSetContext): void {
   // Keep the derived provider in sync with the selected model so downstream
   // routing never sends a Gemini request to an OpenAI model (or vice versa).
   // The prefix logic is shared with workspace migration 006-services-config
-  // via providerForImageModelPrefix().
-  setServiceField(
-    raw,
-    "image-generation",
-    "provider",
-    providerForImageModelPrefix(modelId),
-  );
+  // via providerForImageModelPrefix(). Provider "vellum" is exempt: it is
+  // managed for every model (the backend derives from the model at request
+  // time), and rewriting it here would silently move a managed user onto a
+  // BYOK provider they may hold no key for.
+  const services = raw.services as
+    | Record<string, { provider?: string }>
+    | undefined;
+  if (services?.["image-generation"]?.provider !== "vellum") {
+    setServiceField(
+      raw,
+      "image-generation",
+      "provider",
+      providerForImageModelPrefix(modelId),
+    );
+  }
 
   const wasSuppressed = ctx.suppressConfigReload;
   ctx.setSuppressConfigReload(true);

--- a/assistant/src/media/app-icon-generator.ts
+++ b/assistant/src/media/app-icon-generator.ts
@@ -12,7 +12,10 @@ import { join } from "node:path";
 import { getAppDirPath } from "../apps/app-store.js";
 import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
-import { resolveImageGenCredentials } from "./image-credentials.js";
+import {
+  resolveImageGenCredentials,
+  resolveImageGenRouting,
+} from "./image-credentials.js";
 import { generateImage, mapImageGenError } from "./image-service.js";
 
 const log = getLogger("app-icon-generator");
@@ -31,9 +34,10 @@ export async function generateAppIcon(
 ): Promise<void> {
   const config = getConfig();
   const svc = config.services["image-generation"];
+  const { backendProvider, managed } = resolveImageGenRouting(svc);
   const { credentials, errorHint } = await resolveImageGenCredentials({
-    provider: svc.provider,
-    mode: svc.mode,
+    provider: backendProvider,
+    mode: managed ? "managed" : "your-own",
   });
   if (!credentials) {
     log.debug(
@@ -64,9 +68,12 @@ export async function generateAppIcon(
     "- Modern aesthetic similar to Apple's design language";
 
   try {
-    log.info({ appId, appName, provider: svc.provider }, "Generating app icon");
+    log.info(
+      { appId, appName, provider: backendProvider },
+      "Generating app icon",
+    );
 
-    const result = await generateImage(svc.provider, credentials, {
+    const result = await generateImage(backendProvider, credentials, {
       prompt,
       mode: "generate",
       model: svc.model,
@@ -74,7 +81,7 @@ export async function generateAppIcon(
 
     if (result.images.length === 0) {
       log.warn(
-        { appId, provider: svc.provider },
+        { appId, provider: backendProvider },
         "Provider returned no image for app icon",
       );
       return;
@@ -88,9 +95,9 @@ export async function generateAppIcon(
 
     log.info({ appId, iconPath }, "App icon saved");
   } catch (error) {
-    const message = mapImageGenError(svc.provider, error);
+    const message = mapImageGenError(backendProvider, error);
     log.warn(
-      { appId, provider: svc.provider, error: message },
+      { appId, provider: backendProvider, error: message },
       "App icon generation failed — skipping",
     );
   }

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -1,6 +1,9 @@
 import { getConfig } from "../config/loader.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
-import { resolveImageGenCredentials } from "./image-credentials.js";
+import {
+  resolveImageGenCredentials,
+  resolveImageGenRouting,
+} from "./image-credentials.js";
 import { generateImage, mapImageGenError } from "./image-service.js";
 
 export async function generateAvatar(
@@ -9,9 +12,10 @@ export async function generateAvatar(
   const config = getConfig();
   const svc = config.services["image-generation"];
 
+  const { backendProvider, managed } = resolveImageGenRouting(svc);
   const { credentials, errorHint } = await resolveImageGenCredentials({
-    provider: svc.provider,
-    mode: svc.mode,
+    provider: backendProvider,
+    mode: managed ? "managed" : "your-own",
   });
 
   if (!credentials) {
@@ -20,7 +24,7 @@ export async function generateAvatar(
 
   let result;
   try {
-    result = await generateImage(svc.provider, credentials, {
+    result = await generateImage(backendProvider, credentials, {
       prompt,
       mode: "generate",
       model: svc.model,
@@ -30,7 +34,7 @@ export async function generateAvatar(
     // (e.g. avatar-generator) don't need provider context to surface a
     // useful error.
     throw new ProviderError(
-      mapImageGenError(svc.provider, error),
+      mapImageGenError(backendProvider, error),
       svc.provider,
     );
   }

--- a/assistant/src/media/image-credentials.ts
+++ b/assistant/src/media/image-credentials.ts
@@ -29,8 +29,6 @@ export function resolveImageGenRouting(
   svc: { provider: string; model: string; mode?: string },
   modelOverride?: unknown,
 ): { backendProvider: ImageGenProvider; managed: boolean } {
-  // ponytail: the `mode` half is the pre-migration-133 signal; delete it once
-  // migration 133 has shipped everywhere.
   const managed = svc.provider === "vellum" || svc.mode === "managed";
   if (svc.provider === "vellum") {
     const model =

--- a/assistant/src/media/image-credentials.ts
+++ b/assistant/src/media/image-credentials.ts
@@ -12,6 +12,41 @@ import { PLATFORM_PROVIDER_META } from "../providers/platform-proxy/constants.js
 import { resolveManagedProxyContext } from "../providers/platform-proxy/context.js";
 import { getProviderKeyAsync } from "../security/secure-keys.js";
 import type { ImageGenCredentials, ImageGenProvider } from "./types.js";
+import { providerForImageModelPrefix, providerForModel } from "./types.js";
+
+/**
+ * Resolve which backend serves an image request and whether it runs managed.
+ *
+ * `vellum` is unconditionally managed and carries no backend of its own: the
+ * backend derives from the model prefix (`gpt-*`/`dall-e-*` proxy OpenAI,
+ * anything else proxies Gemini), so one managed provider spans both runtime
+ * proxies. Managed routing never falls back to a stored BYOK key, and a BYOK
+ * provider never falls back to the proxy — billing follows the explicit
+ * provider choice. Other providers keep today's behavior: the caller's key,
+ * with an explicit model override re-routing to the model's backend.
+ */
+export function resolveImageGenRouting(
+  svc: { provider: string; model: string; mode?: string },
+  modelOverride?: unknown,
+): { backendProvider: ImageGenProvider; managed: boolean } {
+  // ponytail: the `mode` half is the pre-migration-133 signal; delete it once
+  // migration 133 has shipped everywhere.
+  const managed = svc.provider === "vellum" || svc.mode === "managed";
+  if (svc.provider === "vellum") {
+    const model =
+      typeof modelOverride === "string" && modelOverride
+        ? modelOverride
+        : svc.model;
+    return { backendProvider: providerForImageModelPrefix(model), managed };
+  }
+  return {
+    backendProvider: providerForModel(
+      modelOverride,
+      svc.provider as ImageGenProvider,
+    ),
+    managed,
+  };
+}
 
 /**
  * Resolve credentials for an image-generation request.

--- a/assistant/src/media/image-credentials.ts
+++ b/assistant/src/media/image-credentials.ts
@@ -22,8 +22,9 @@ import { providerForImageModelPrefix, providerForModel } from "./types.js";
  * anything else proxies Gemini), so one managed provider spans both runtime
  * proxies. Managed routing never falls back to a stored BYOK key, and a BYOK
  * provider never falls back to the proxy — billing follows the explicit
- * provider choice. Other providers keep today's behavior: the caller's key,
- * with an explicit model override re-routing to the model's backend.
+ * provider choice. Other providers use the caller's key, with an explicit
+ * model override re-routing to the model's backend. A legacy
+ * `mode: "managed"` also routes managed.
  */
 export function resolveImageGenRouting(
   svc: { provider: string; model: string; mode?: string },

--- a/assistant/src/media/image-service.ts
+++ b/assistant/src/media/image-service.ts
@@ -63,17 +63,5 @@ export function mapImageGenError(
  *   - `gemini-*`            → `gemini`
  *   - anything else (or `undefined`) → the provided `fallback`
  */
-export function providerForModel(
-  model: unknown,
-  fallback: ImageGenProvider,
-): ImageGenProvider {
-  // `model` originates from an LLM tool call's `input.model`, which is a
-  // `Record<string, unknown>` without runtime validation — so a non-string
-  // value (e.g. `{"model": 123}`) must not crash `.startsWith`.
-  if (typeof model !== "string" || !model) return fallback;
-  if (model.startsWith("gpt-") || model.startsWith("dall-e-")) return "openai";
-  if (model.startsWith("gemini-")) return "gemini";
-  return fallback;
-}
-
 export type { ImageGenCredentials } from "./types.js";
+export { providerForModel } from "./types.js";

--- a/assistant/src/media/types.ts
+++ b/assistant/src/media/types.ts
@@ -34,8 +34,7 @@ export const MAX_VARIANTS = 4;
 
 /**
  * Derive the image-generation provider from a model identifier by prefix.
- * Shared with the runtime dispatcher `providerForModel` in
- * `image-service.ts`; prefixes must stay in sync with that function.
+ * Sibling of {@link providerForModel} below; prefixes must stay in sync.
  * Unknown models fall through to "gemini".
  */
 export function providerForImageModelPrefix(model: string): ImageGenProvider {
@@ -43,6 +42,28 @@ export function providerForImageModelPrefix(model: string): ImageGenProvider {
     return "openai";
   }
   return "gemini";
+}
+
+/**
+ * Like {@link providerForImageModelPrefix}, but for untrusted caller input:
+ * a non-string or empty `model` (e.g. an LLM tool call's raw `input.model`)
+ * and unknown prefixes fall back to the provided provider instead of gemini.
+ * Prefixes must stay in sync with providerForImageModelPrefix.
+ */
+export function providerForModel(
+  model: unknown,
+  fallback: ImageGenProvider,
+): ImageGenProvider {
+  if (typeof model !== "string" || !model) {
+    return fallback;
+  }
+  if (model.startsWith("gpt-") || model.startsWith("dall-e-")) {
+    return "openai";
+  }
+  if (model.startsWith("gemini-")) {
+    return "gemini";
+  }
+  return fallback;
 }
 
 /**
@@ -74,7 +95,9 @@ export function isImageProviderBillingError(args: {
   status?: number;
   message?: string;
 }): boolean {
-  if (args.status === 402) return true;
+  if (args.status === 402) {
+    return true;
+  }
   const message = args.message ?? "";
   return BILLING_MESSAGE_PATTERNS.some((pattern) => pattern.test(message));
 }

--- a/assistant/src/runtime/routes/image-generation-routes.ts
+++ b/assistant/src/runtime/routes/image-generation-routes.ts
@@ -1,16 +1,15 @@
 import { z } from "zod";
 
 import { getConfig } from "../../config/loader.js";
-import { resolveImageGenCredentials } from "../../media/image-credentials.js";
+import {
+  resolveImageGenCredentials,
+  resolveImageGenRouting,
+} from "../../media/image-credentials.js";
 import {
   describeImageModels,
   resolveImageModel,
 } from "../../media/image-models.js";
-import {
-  generateImage,
-  mapImageGenError,
-  providerForModel,
-} from "../../media/image-service.js";
+import { generateImage, mapImageGenError } from "../../media/image-service.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   BadRequestError,
@@ -95,13 +94,17 @@ async function handleImageGenerationGenerate(
     resolvedModel = entry.id;
   }
 
-  // Derive provider from explicit model override when supplied
-  const provider = providerForModel(resolvedModel, svc.provider);
+  // Backend and managed-ness resolve together; an explicit model override
+  // re-routes to the model's backend.
+  const { backendProvider: provider, managed } = resolveImageGenRouting(
+    svc,
+    resolvedModel,
+  );
 
   // Resolve credentials
   const { credentials, errorHint } = await resolveImageGenCredentials({
     provider,
-    mode: svc.mode,
+    mode: managed ? "managed" : "your-own",
   });
 
   if (!credentials) {


### PR DESCRIPTION
## Summary
- Adds `vellum` (leading) to `VALID_IMAGE_GEN_PROVIDERS` and a single `resolveImageGenRouting()` helper that the four read sites (image-studio tool, daemon route, app-icon generator, avatar router) now share: vellum is unconditionally managed with a model-prefix-derived backend (`gpt-*`/`dall-e-*` → `/v1/runtime-proxy/openai`, else `/v1/runtime-proxy/gemini`), preserving the managed GPT Image 2 capability from #36345; the legacy `mode: "managed"` bridge routes unchanged until migration 133
- Billing rule enforced and regression-tested: vellum + platform unavailable is a hard error that never consults a stored BYOK key, and `setImageGenModel` no longer rewrites the provider when it is vellum (a model change must not silently move a managed user onto a key they may not hold)
- `providerForModel` moves from `image-service.ts` to `media/types.ts` beside its sibling prefix helper (re-exported for compat) so the credential module needs no import from the mocked dispatcher module

## Original prompt
PR 1 of the image-generation vellum-provider plan (attached below): convert the Image Generation card's Managed/Your Own toggle to the provider model shipped for STT/TTS and web search — provider Vellum = managed with model selection, provider Gemini = BYOK key. This PR is daemon-side routing only; the migration (PR 2), card (PR 3), and schema mode-drop (PR 4) follow. The dual managed backend (image-gen's blocker vs the web-search conversion) is resolved by deriving the proxy backend from the model prefix.

## Plan
<details>
<summary>Full plan: image-gen-vellum-provider.md</summary>

# Image Generation: replace the Managed/Your Own toggle with provider "vellum"

## Overview

Convert the Image Generation card to the provider-only model already shipped for STT/TTS (migration 130) and web search (migration 132, PRs #38677–#38727). The card offers two providers — **Vellum** (managed, model selection preserved) and **Gemini** (BYOK key + model selection) — with no mode toggle. `provider: "vellum"` routes through the platform runtime proxy; migration 133 folds `mode: "managed"` configs onto it.

**The structural difference from web search** (this is why image-gen was previously deferred): image-gen's `mode` and `provider` are orthogonal. Managed mode proxies a *specific backend* — `PLATFORM_PROVIDER_META[provider]` picks `/v1/runtime-proxy/gemini` vs `/v1/runtime-proxy/openai` (`image-credentials.ts:36-59`) — and OpenAI image gen (`gpt-image-2`) is fully implemented in both modes, not vestigial. Meanwhile `provider` is already a *derived* field: `setImageGenModel` (`config-model.ts:95-127`) rewrites it from the model prefix on every model change, and the web card never sends provider at all (only `mode` + `model`).

**Resolution:** `vellum` becomes a config-provider value whose *backend* is derived from the selected model's prefix at credential-resolution time — `vellum` + `gemini-*` → gemini proxy, `vellum` + `gpt-*` → openai proxy. The codebase already has the prefix machinery (`providerForModel` in `image-service.ts:64-73`, `providerForImageModelPrefix` in `media/types.ts`). This preserves today's managed-OpenAI capability with zero new concepts. `setImageGenModel`'s provider derivation is suppressed when the config provider is `vellum` (a model change must not kick the user off managed).

Decisions baked in, carrying the web-search lessons forward:

- **Billing rule**: `vellum` is unconditionally managed — platform-unavailable and 402-class errors surface as hard errors, never a silent fall-through to a stored BYOK key, and vice versa. (There is no "native" middle ground here, so no stranded-fallback logic is needed at all — simpler than web search.)
- **OpenAI stays in the schema enum but leaves the card.** The user-facing providers are Vellum and Gemini only. `openai` remains a valid config value (existing configs, CLI writes, `gpt-*` model derivation for BYOK) — removing it would need its own migration story for openai-BYOK users and is out of scope.
- **Model lists per provider**: Vellum → all catalog models (Nano Banana 2, Nano Banana Pro, GPT Image 2 — managed proxies both backends). Gemini → gemini-prefix models only (the card collects only a Gemini key; today's card offering GPT Image 2 under a Gemini-key-only form is a pre-existing bug this fixes).
- **Deployment-default swap ships ATOMICALLY with the migration** (the #38689 review lesson: `fillContextDefaultsForMissingKeys` re-fills per-leaf on every load, so a surviving `mode: "managed"` fill would override every migrated config). Unlike web search, image-gen cannot simply delete the fill — the schema default is `provider: "gemini"` (BYOK), so a keyless platform boot would break. The fill becomes `{ provider: "vellum" }`.
- **Client catalog exposure ships atomically with the card** (the #38677 review lesson) — here that's free because the card's model list is a static file with no provider dropdown today, but the new provider dropdown and any catalog additions land in the card PR only.
- **Version-gate the card's provider writes** (the #38688 review lesson): old daemons reject `provider: "vellum"` against their enum and can reset the section on reload. Old daemons get the legacy write (`mode` only, no provider). New gate file mirrors `use-supports-web-search-vellum-provider.ts`. MIN_VERSION = the first release whose schema enum contains image-gen `vellum` — check `assistant/package.json` version at implementation time (0.10.12 if this ships before the next release cut; bump if 0.10.12 has already cut).
- **`assistant/openapi.yaml` must be regenerated** in the contract PR (`bun run generate:openapi` — the #38727 CI lesson).
- **Comment rules**: present-tense invariants only, no migration-history narrative outside the migration file itself, braces on every touched control statement, migration tests resolve the entry via `WORKSPACE_MIGRATIONS` (never import the migration module).
- Verified non-blockers: no macOS/Swift reader of image-gen mode, no billing meter keyed on mode, no onboarding/doctor step.

Out of scope: the OAuth services and email still use `mode`; `ServiceModeSchema`, `BaseServiceSchema`, `getServiceMode`, and `ModeToggle` all survive for them. After this ships, image-gen was the last `ServiceCard`/`ModeToggle` consumer in the AI settings page — but `ModeToggle` removal is deferred until email's future conversion decides its fate.

## PR 1: Accept provider "vellum" and route it through the managed proxy

### Depends on
None

### Branch
image-gen-vellum/pr-1-runtime-routing

### Title
feat(image-gen): accept provider vellum and route it through the managed proxy

### Files
- `assistant/src/config/schemas/services.ts` (enum only)
- `assistant/src/media/image-credentials.ts`
- `assistant/src/media/image-service.ts`
- `assistant/src/daemon/handlers/config-model.ts`
- `assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts`
- `assistant/src/runtime/routes/image-generation-routes.ts`
- `assistant/src/media/app-icon-generator.ts`
- `assistant/src/media/avatar-router.ts`
- Tests: `media-generate-image.test.ts`, `image-credentials.test.ts`, `config-model-image-provider.test.ts`, `config-schema.test.ts`

### Implementation steps
1. `services.ts:23`: `VALID_IMAGE_GEN_PROVIDERS = ["vellum", "gemini", "openai"] as const` — vellum leads. No other schema change in this PR (`mode` stays until PR 4; the write-pair bridge depends on it).
2. Add ONE routing helper in `image-credentials.ts` so the four read sites stop duplicating the provider+mode plumbing:
   ```ts
   /**
    * Resolve the backend and credential path for an image request.
    * `vellum` is unconditionally managed; its backend comes from the model
    * prefix (vellum + gpt-* proxies OpenAI, anything else proxies Gemini).
    * Other providers use the caller's key. A legacy `mode: "managed"` routes
    * managed until migration 133 folds it onto provider vellum.
    */
   export function resolveImageGenRouting(
     svc: { provider: string; model: string; mode?: string },
     modelOverride?: string,
   ): { backendProvider: "gemini" | "openai"; managed: boolean }
   ```
   - `managed = svc.provider === "vellum" || svc.mode === "managed"` (the bridge half gets the ponytail delete-me comment referencing PR 4).
   - `backendProvider`: when `svc.provider` is `"gemini"`/`"openai"`, today's behavior verbatim — `providerForModel(modelOverride, svc.provider)`. When `"vellum"`, derive from `modelOverride ?? svc.model` via `providerForImageModelPrefix`, defaulting to `"gemini"`.
3. `resolveImageGenCredentials` keeps its shape but is called with `{ provider: backendProvider, mode: managed ? "managed" : "your-own" }` — its `PLATFORM_PROVIDER_META[provider]` lookup then always receives a real backend. Managed-unavailable stays the hard error it already is (`image-credentials.ts:36-59`); do NOT add any BYOK fallback for vellum (billing rule).
4. Update the four read sites (`media-generate-image.ts:25-61`, `image-generation-routes.ts:82-127`, `app-icon-generator.ts:33-35`, `avatar-router.ts:10-14`) to call `resolveImageGenRouting(svc, modelOverride?)` and pass its outputs through. Behavior today (gemini/openai + either mode) must be byte-identical — the existing tests prove it.
5. `config-model.ts` `setImageGenModel` (L95-127): suppress the provider rewrite when the stored provider is `"vellum"` — write only `model`. Comment: a model change must not silently move a managed user onto a BYOK provider. BYOK derivation (gemini/openai from prefix) unchanged.
6. Tests:
   - `image-credentials.test.ts` + a new `resolveImageGenRouting` block: vellum + `gemini-3.1-flash-image-preview` → gemini backend, managed; vellum + `gpt-image-2` → openai backend, managed; vellum + platform unavailable → hard error, and a stored gemini key is NOT consulted (billing-rule regression guard, the #38338 class); legacy `mode: "managed"` + provider gemini → managed gemini (bridge unchanged).
   - `media-generate-image.test.ts`: seed `{ provider: "vellum", model: "gpt-image-2" }` (no mode) → managed-proxy creds with `/v1/runtime-proxy/openai` baseUrl; keep every existing mode-seeded case green.
   - `config-model-image-provider.test.ts`: model change under provider vellum leaves provider untouched; under gemini still derives.
   - `config-schema.test.ts`: schema accepts `provider: "vellum"`.

### Acceptance criteria
- `provider: "vellum"` + any catalog model routes managed to the model-appropriate runtime proxy; platform-unavailable is a hard error with no BYOK fallback.
- All existing mode-based behavior byte-identical (legacy managed configs, BYOK both providers, `gpt-*` override routing).
- A model change never rewrites provider `vellum`.
- Nothing user-facing exposes vellum yet (no card, no catalog exposure — the #38677 lesson).

## PR 2: Migration 133 + platform default swap (atomic)

### Depends on
PR 1 (hard runtime dependency: a migrated `provider: "vellum"` config must route; without PR 1 it fails the enum and resets the section)

### Branch
image-gen-vellum/pr-2-migration-133

### Title
feat(config): migrate image-generation mode onto provider vellum

### Files
- `assistant/src/workspace/migrations/133-image-generation-mode-to-provider.ts`
- `assistant/src/workspace/migrations/registry.ts`
- `assistant/src/config/loader.ts`
- `assistant/src/__tests__/workspace-migration-133-image-generation-mode-to-provider.test.ts`
- `assistant/src/__tests__/config-loader-platform-defaults.test.ts`
- `assistant/src/config/__tests__/deployment-context-defaults.test.ts`

### Implementation steps
1. Migration modeled on `132-web-search-mode-to-provider.ts` (self-contained, braces, idempotent, malformed-JSON safe). `run()`: read `services["image-generation"]`; absent → no-op; `mode === "managed"` → `provider = "vellum"` (regardless of the stored gemini/openai value — the managed backend is model-derived now, so nothing is lost; `model` is preserved verbatim); `delete mode` in all cases. NO Provider-Native-style exemption exists here — every managed config becomes vellum. `down()`: `mode = provider === "vellum" ? "managed" : "your-own"`, documenting that the pre-migration provider under managed mode is not recoverable (it was derived from model anyway and re-derives on the next model write).
2. Register LAST in `registry.ts` (ceiling comment is load-bearing; `getLastWorkspaceMigrationId()` must report 133).
3. `loader.ts` `getDeploymentContextDefaults()` (L138-172): replace `"image-generation": managed` with `"image-generation": { provider: "vellum" }`. This must be THIS PR (atomicity — the fill is per-leaf and in-memory on every load; a surviving mode fill would re-manage every migrated config, and deleting the fill outright would strand keyless platform boots on the BYOK schema default `gemini`). Update the `applyContextDefaultsToRawConfig` comment in `conversation-query-routes.ts` (L462-471) that names `services.image-generation.mode` as the filled field.
4. Migration test (resolve the entry from `WORKSPACE_MIGRATIONS` by id — never import the module): ceiling pin at 133; `mode:"managed"`+`provider:"gemini"`+model → `provider:"vellum"`, model preserved, no mode; `mode:"managed"`+`provider:"openai"`+`model:"gpt-image-2"` → `provider:"vellum"`, model preserved (managed-openai user keeps working via model-derived backend); `mode:"your-own"`+gemini → provider preserved, mode deleted; idempotency; `down()` round-trip; post-migration re-parse through `AssistantConfigSchema`.
5. `config-loader-platform-defaults.test.ts` (L81, 105, 189-213, 292-320, 414-431, 461-479) and `deployment-context-defaults.test.ts`: platform fill now asserts `provider === "vellum"` and no `mode` for image-generation; explicit on-disk `provider: "openai"`/`"gemini"` still wins over the fill; move `image-generation` out of any managed-mode service lists the way web-search was.

### Acceptance criteria
- Full chain on a legacy managed config yields `{ provider: "vellum", model: <unchanged> }`; registry ceiling 133.
- Platform boots default image-gen to vellum in-memory; explicit user providers untouched.
- No code path can re-inject `mode` into image-generation.

## PR 3: Image Generation card — Vellum/Gemini providers, no toggle

### Depends on
PR 1 (NOT PR 2: the write bridge pairs `mode`, so pre-migration daemons take the legacy path — same asymmetry as web-search PR 5)

### Branch
image-gen-vellum/pr-3-web-card

### Title
feat(web): make Vellum an image generation provider instead of a mode

### Files
- `clients/web/src/domains/settings/ai/image-generation-card.tsx`
- `clients/web/src/domains/settings/ai/image-generation-card.test.tsx` (new)
- `clients/web/src/lib/provider-catalogs.ts`
- `clients/web/src/lib/backwards-compat/use-supports-image-gen-vellum-provider.ts` (new)
- `clients/web/src/utils/local-settings-keys.ts`

### Implementation steps
1. Swap `ServiceCard` → `ByoServiceCard`; delete mode state, `parseServiceMode` use, and `LS_IMAGE_GEN_MODE` (from `local-settings-keys.ts:9`; the `storage-migration.ts:200` mapping for the pre-rename key stays — it migrates old browsers' data and is inert once the key is unused... verify `session-cleanup.test.ts:49,161,173` and `storage-migration.test.ts:186-201` and update only if they assert the constant itself).
2. Provider dropdown (new — today the card has none): **Vellum, Gemini**, from a small list in `provider-catalogs.ts` alongside `AVAILABLE_IMAGE_GEN_MODELS`. Read bridge from daemon config: `svc.mode === "managed"` → render Vellum; else `svc.provider === "openai"` → the card cannot represent it — render Gemini? NO: follow the STT precedent for unrepresentable providers (`speech-to-text-card` keeps unrepresentable daemon values un-coerced): derive the selected entry only when representable, otherwise show the daemon value read-only in the dropdown trigger without coercing, and never clobber it on save unless the user actively picks a new provider. Simplest compliant form: include a hidden third entry for `openai` that renders as "OpenAI" when the daemon reports it but is not offered in the dropdown options.
3. Model dropdown: sourced as today from `AVAILABLE_IMAGE_GEN_MODELS`/`IMAGE_GEN_MODEL_DISPLAY_NAMES`, filtered by provider — Vellum → all three; Gemini → `providerForImageGenModel(id) === "gemini"` only. If the current model becomes invalid on provider switch (GPT Image 2 → Gemini), snap to the first gemini model.
4. API-key field (`Enter your Gemini API key`) and its provisioning path render only for Gemini; "Image generation runs through your Vellum account." line for Vellum (mirrors the STT/web-search copy).
5. Save. Keep the two-call shape (config PATCH + `modelImagegenPut`):
   - New gate file `use-supports-image-gen-vellum-provider.ts` (mirror the web-search gate: `assistantSupports(MIN_VERSION)` snapshot + `whenAssistantVersionKnown()` before reading; MIN_VERSION per the Overview note).
   - Supported daemon: PATCH `{ "image-generation": { provider: <selected>, mode: provider === "vellum" ? "managed" : "your-own" } }` (pair-write bridge — old-schema daemons in the window still key on mode; the new daemon strips it after PR 4).
   - Unsupported daemon: legacy body `{ "image-generation": { mode: ... } }` only — exactly what the card sends today.
   - Then `modelImagegenPut` as today. On new daemons PR 1's rule keeps provider vellum intact; on old daemons it derives provider from the model exactly as today.
6. Reset: clears the key, model back to `gemini-3.1-flash-image-preview`, provider to Gemini (the schema default) — mirror web-search's reset-to-schema-default.
7. `image-generation-card.test.tsx` from scratch, modeled on `web-search-card.test.tsx` (mock the generated react-query barrel, `use-daemon-config`, credential presence, org-readiness false, the gate): no Managed/Your Own control; options exactly [Vellum, Gemini]; Vellum hides the key field, shows all 3 models, saves `{provider:"vellum", mode:"managed"}` + model PUT; Gemini shows the key field and only gemini models, saves `{provider:"gemini", mode:"your-own"}`; legacy daemon `{mode:"managed"}` renders as Vellum; daemon `{provider:"openai", mode:"your-own"}` renders OpenAI without clobbering on a model-only save; unsupported-version daemon + Vellum → body is `{mode:"managed"}` with NO provider key.

### Acceptance criteria
- Card matches the target: provider dropdown (Vellum | Gemini), model dropdown always, key field only for Gemini, no segmented control.
- A daemon on the old schema accepts every write the card can produce.
- An openai-BYOK config is rendered honestly and never silently rewritten.
- All card tests pass; lint clean.

## PR 4: Drop mode from the image-generation schema and contracts

### Depends on
PR 2, PR 3

### Branch
image-gen-vellum/pr-4-drop-mode

### Title
refactor(config): drop mode from the image-generation schema

### Files
- `assistant/src/config/schemas/services.ts`
- `assistant/src/runtime/routes/conversation-query-routes.ts`
- `assistant/src/media/image-credentials.ts`
- `assistant/src/cli/commands/config.ts`
- `assistant/openapi.yaml` (regenerated — `bun run generate:openapi`)
- Test fixtures across the §7 suite (see step 5)

### Implementation steps
1. `ImageGenerationServiceSchema` → plain `z.object({ provider, model })`, no `BaseServiceSchema`. One-axis doc comment in the present tense (mirror web-search's): vellum generates through the platform runtime proxy for the model-appropriate backend, billed to Vellum credits; gemini/openai use the user's key; a `mode` key sent by an older client is stripped at parse.
2. `conversation-query-routes.ts` GET/PATCH image-generation entries (L705-708, L809-813): replace the `mode`-only object with explicit `provider`/`model` optional strings, passthrough retained. Regenerate `openapi.yaml`.
3. `image-credentials.ts`: delete the `svc.mode === "managed"` half of `resolveImageGenRouting` (managed ⇔ `provider === "vellum"` alone) and the `mode` member of its parameter type.
4. `cli/commands/config.ts`: extend the web-search rejection to image-generation — `services.image-generation.mode` writes error with "image generation is configured by provider alone; for managed image generation run `config set services.image-generation.provider vellum`"; add `services.image-generation.provider vellum` to the platform-connection guard alongside web-search's. (Generalize the two special-cases into a small lookup rather than a third copy-paste branch.)
5. Fixtures: `config-schema.test.ts:67-71` (no mode; explicit mode stripped), `config-set-platform-guard.test.ts:177-194` (mode case → rejection case + provider-vellum guard case), `media-generate-image.test.ts` mode-seeded cases re-seeded onto provider vellum (managed) / gemini (BYOK), `inference-no-mode-boot-e2e.test.ts:155`, `image-credentials.test.ts` bridge cases removed, `raw-config-utils.ts` doc example updated off image-gen mode. Run the migration-133, platform-defaults, and deployment-context suites to catch schema-default drift (the `SCHEMA_YOUR_OWN_DEFAULT_SERVICES`-list class of failure from web-search PR 6).
6. Do NOT remove the card's pair-write bridge (old daemons still need it; the daemon strips the key).

### Acceptance criteria
- `services["image-generation"]` parses to `{ provider, model }`; stale `mode` inert from any client.
- `tsc` and full assistant suite green; OpenAPI Spec Check passes (regenerated yaml committed).
- CLI: mode writes rejected with guidance; provider-vellum writes platform-gated.

## PR 5 (conditional, vellum-assistant-platform repo): docs

### Depends on
PR 3

### Branch
image-gen-vellum/docs (in `vellum-assistant-platform`)

### Title
docs(image-generation): provider framing for the Vellum/Gemini card

### Implementation steps
1. Grep `web/src/app/(marketing)/docs` for image-generation content describing the Managed/Your Own toggle. If none exists, close this PR as not-needed.
2. If found: rewrite around the two providers (Vellum managed/metered; Gemini BYOK), per-provider billing, and the model list. **Marketing hard rules apply: NO em dashes anywhere, no banned marketing vocabulary** (read `web/src/app/(marketing)/AGENTS.md` first — learned on platform#9409).
3. Check the vendored `web-search-provider-catalog` precedent: if an image-gen model/provider catalog copy exists in the platform repo, sync it (it has a generator: `bun run sync:<name>` + CI drift guard).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)