### PR TITLE
test(web): drop non-behavioral class-string assertions from the billing responsive tests

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
@@ -65,15 +65,6 @@ describe("PlanColumnCard CTA", () => {
     expect(button).toHaveProperty("disabled", false);
     expect(button.className).toContain("bg-[var(--primary-base)]");
   });
-
-  test("compacts card padding on phones, restoring it at sm", async () => {
-    const { container } = render(
-      <PlanColumnCard {...baseProps} isCurrent={false} />,
-    );
-    const root = container.querySelector("[data-theme]");
-    expect(root?.className).toContain("p-3");
-    expect(root?.className).toContain("sm:p-4");
-  });
 });
 
 describe("PlanColumnCard Recommended badge", () => {

--- a/clients/web/src/domains/settings/components/payment-method-row.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.test.tsx
@@ -49,8 +49,8 @@ describe("PaymentMethodRow", () => {
     expect(row.textContent).not.toContain("null");
   });
 
-  test("renders a long unmapped brand and truncates the brand label", () => {
-    const { getByTestId, getByText } = render(
+  test("renders a long unmapped brand verbatim", () => {
+    const { getByTestId } = render(
       <PaymentMethodRow
         brand="internationalmaestro"
         last4="0005"
@@ -60,7 +60,6 @@ describe("PaymentMethodRow", () => {
     );
     const row = getByTestId("payment-method-row");
     expect(row.textContent).toContain("internationalmaestro");
-    expect(getByText("internationalmaestro").className).toContain("truncate");
   });
 
   test("fires onUpdateCard when Update Card is clicked", () => {


### PR DESCRIPTION
## Summary
Fixes gaps from plan review for billing-mobile-polish.md.
- Delete the tautological (and self-defeating) responsive-padding class-string test in plan-column-card.test.tsx.
- Keep the behavioral unmapped-brand assertion in payment-method-row.test.tsx; drop the non-behavioral truncate class-string check.