### PR TITLE
Billing page mobile polish: responsive Credit Balance rows + compact plan cards

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
@@ -65,6 +65,15 @@ describe("PlanColumnCard CTA", () => {
     expect(button).toHaveProperty("disabled", false);
     expect(button.className).toContain("bg-[var(--primary-base)]");
   });
+
+  test("compacts card padding on phones, restoring it at sm", async () => {
+    const { container } = render(
+      <PlanColumnCard {...baseProps} isCurrent={false} />,
+    );
+    const root = container.querySelector("[data-theme]");
+    expect(root?.className).toContain("p-3");
+    expect(root?.className).toContain("sm:p-4");
+  });
 });
 
 describe("PlanColumnCard Recommended badge", () => {

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.test.tsx
@@ -65,15 +65,6 @@ describe("PlanColumnCard CTA", () => {
     expect(button).toHaveProperty("disabled", false);
     expect(button.className).toContain("bg-[var(--primary-base)]");
   });
-
-  test("compacts card padding on phones, restoring it at sm", async () => {
-    const { container } = render(
-      <PlanColumnCard {...baseProps} isCurrent={false} />,
-    );
-    const root = container.querySelector("[data-theme]");
-    expect(root?.className).toContain("p-3");
-    expect(root?.className).toContain("sm:p-4");
-  });
 });
 
 describe("PlanColumnCard Recommended badge", () => {

--- a/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plan-column-card.tsx
@@ -59,7 +59,7 @@ export function PlanColumnCard({
   return (
     <div
       data-theme={tone}
-      className="flex w-full flex-col gap-4 rounded-2xl bg-[var(--surface-lift)] p-4"
+      className="flex w-full flex-col gap-3 rounded-2xl bg-[var(--surface-lift)] p-3 sm:gap-4 sm:p-4"
     >
       <PlanTierAvatar tier={tierKey} size={50} />
 
@@ -75,7 +75,7 @@ export function PlanColumnCard({
           ) : null}
         </div>
 
-        <p className="h-9 overflow-hidden text-[14px] font-medium leading-[18px] text-[var(--content-tertiary)]">
+        <p className="overflow-hidden text-[14px] font-medium leading-[18px] text-[var(--content-tertiary)] sm:h-9">
           {tagline}
         </p>
       </div>
@@ -102,7 +102,7 @@ export function PlanColumnCard({
 
       <div className="h-px w-full bg-[var(--border-hover)]" />
 
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2 sm:gap-4">
         <span className="text-[12px] font-medium text-[var(--content-tertiary)]">
           Includes:
         </span>

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -500,10 +500,9 @@ export function PlansPage() {
       <div className="my-auto flex w-full flex-col items-center">
         <header className="flex flex-col items-center gap-2 text-center">
           <h1
-            className="text-[var(--content-emphasised)]"
+            className="text-[40px] text-[var(--content-emphasised)] sm:text-[60px]"
             style={{
               fontFamily: "var(--font-serif)",
-              fontSize: "60px",
               fontWeight: 400,
               lineHeight: 1.2,
               letterSpacing: "1.2px",
@@ -520,7 +519,7 @@ export function PlansPage() {
             to two-up then one-up; `items-start` keeps each card at its natural
             content height, so the four-feature Super/Ultra columns are taller
             than the featured Mighty column. */}
-        <div className="mt-10 grid w-full max-w-[1312px] grid-cols-1 items-start gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="mt-6 grid w-full max-w-[1312px] grid-cols-1 items-start gap-4 sm:mt-10 sm:grid-cols-2 sm:gap-6 lg:grid-cols-4">
           <PlanColumnCard
             tierKey="free"
             name="Free"
@@ -568,7 +567,7 @@ export function PlansPage() {
         </div>
 
         <CustomPlanRow
-          className="mt-10"
+          className="mt-6 sm:mt-10"
           onConfigure={handleConfigure}
           configureDisabled={(isProUser && !currentReady) || billingActionPending}
           isCurrent={showCurrentPlan}
@@ -620,7 +619,7 @@ export function PlansPage() {
           resizeCredits={resizeCreditTier}
         />
 
-        <p className="mt-10 text-center text-[12px] font-medium text-[var(--content-tertiary)]">
+        <p className="mt-6 text-center text-[12px] font-medium text-[var(--content-tertiary)] sm:mt-10">
           You can cancel or change your plan anytime you want. To learn more{" "}
           <a
             href={DOCS_URL}
@@ -667,7 +666,7 @@ export function PlansPage() {
       </div>
 
       <div
-        className="plans-takeover-content-enter flex min-h-full flex-col items-center px-6 pb-8"
+        className="plans-takeover-content-enter flex min-h-full flex-col items-center px-4 pb-8 sm:px-6"
         style={{ paddingTop: electron ? "5rem" : "4rem" }}
       >
         {body}

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -556,7 +556,7 @@ export function AdjustPlanModal({ open, onClose, onTierUpgraded }: AdjustPlanMod
                     Failed to load plans. Please try again later.
                   </Notice>
                 ) : (
-                  <div className="space-y-6">
+                  <div className="space-y-4 sm:space-y-6">
                     <div className="space-y-2 pb-2 pt-4 text-center">
                       <Typography as="p" variant="title-medium">
                         Your Assistant, Your Way

--- a/clients/web/src/domains/settings/components/billing-panel.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel.tsx
@@ -102,8 +102,8 @@ export function BillingPanel() {
     ]);
 
     const creditBalanceHeader = (
-        <div className="flex items-start justify-between gap-4">
-            <div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+            <div className="min-w-0">
                 <Typography
                     as="h2"
                     variant="title-medium"

--- a/clients/web/src/domains/settings/components/payment-method-row.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.test.tsx
@@ -49,8 +49,8 @@ describe("PaymentMethodRow", () => {
     expect(row.textContent).not.toContain("null");
   });
 
-  test("renders a long unmapped brand and truncates the brand label", () => {
-    const { getByTestId, getByText } = render(
+  test("renders a long unmapped brand verbatim", () => {
+    const { getByTestId } = render(
       <PaymentMethodRow
         brand="internationalmaestro"
         last4="0005"
@@ -60,7 +60,6 @@ describe("PaymentMethodRow", () => {
     );
     const row = getByTestId("payment-method-row");
     expect(row.textContent).toContain("internationalmaestro");
-    expect(getByText("internationalmaestro").className).toContain("truncate");
   });
 
   test("fires onUpdateCard when Update Card is clicked", () => {

--- a/clients/web/src/domains/settings/components/payment-method-row.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.test.tsx
@@ -49,6 +49,20 @@ describe("PaymentMethodRow", () => {
     expect(row.textContent).not.toContain("null");
   });
 
+  test("renders a long unmapped brand and truncates the brand label", () => {
+    const { getByTestId, getByText } = render(
+      <PaymentMethodRow
+        brand="internationalmaestro"
+        last4="0005"
+        onUpdateCard={() => {}}
+        onRemove={() => {}}
+      />,
+    );
+    const row = getByTestId("payment-method-row");
+    expect(row.textContent).toContain("internationalmaestro");
+    expect(getByText("internationalmaestro").className).toContain("truncate");
+  });
+
   test("fires onUpdateCard when Update Card is clicked", () => {
     const onUpdateCard = mock(() => {});
     const { getByTestId } = render(

--- a/clients/web/src/domains/settings/components/payment-method-row.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.tsx
@@ -25,16 +25,16 @@ export function PaymentMethodRow({
       data-testid="payment-method-row"
       className="flex items-center justify-between gap-2 rounded-lg bg-[var(--surface-base)] pl-3 pr-2 py-1.5"
     >
-      <div className="flex items-center gap-2">
+      <div className="flex min-w-0 items-center gap-2">
         <CreditCard
           aria-hidden
-          className="h-4 w-4 text-[var(--content-default)]"
+          className="h-4 w-4 shrink-0 text-[var(--content-default)]"
         />
-        <div>
+        <div className="min-w-0">
           <Typography
             as="p"
             variant="body-medium-default"
-            className="text-[var(--content-default)]"
+            className="truncate text-[var(--content-default)]"
           >
             {brand ? brandLabel(brand) : "Saved card"}
           </Typography>
@@ -42,14 +42,14 @@ export function PaymentMethodRow({
             <Typography
               as="p"
               variant="body-small-default"
-              className="text-[var(--content-tertiary)]"
+              className="truncate text-[var(--content-tertiary)]"
             >
               Ending in {last4}
             </Typography>
           )}
         </div>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex shrink-0 items-center gap-2">
         <Button
           variant="outlined"
           onClick={onUpdateCard}

--- a/clients/web/src/domains/settings/components/plan-card-content.tsx
+++ b/clients/web/src/domains/settings/components/plan-card-content.tsx
@@ -109,185 +109,146 @@ export function PlanCardContent({
   const showProTierChange = isProCard && isCurrent && proTierChangeMode;
 
   return (
-    <Card
-      padding="lg"
-      className="flex flex-col bg-[var(--surface-base)] max-sm:[&_[data-slot=card-body]]:p-4"
-    >
-      <div className="flex flex-col gap-4">
-        <span
-          aria-hidden
-          className="flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)]"
-        >
-          {isProCard ? (
-            <Crown className="h-5 w-5 text-[var(--content-default)]" />
-          ) : (
-            <Palmtree className="h-5 w-5 text-[var(--content-default)]" />
-          )}
-        </span>
-        <div className="flex min-h-6 items-center gap-2">
-          <Typography as="h3" variant="title-small">
-            {plan.name}
-          </Typography>
-          {isCurrent && <Tag tone="positive">Current</Tag>}
-        </div>
-        <Typography
-          as="p"
-          variant="body-small-default"
-          className="-mt-2 text-[var(--content-tertiary)]"
-        >
-          {isBaseCard
-            ? "All you need for a capable assistant"
-            : "More features, more compute, more storage"}
-        </Typography>
-        {showCancellationOnPro && cancelDate && (
+    <Card.Root className="flex flex-col bg-[var(--surface-base)]">
+      <Card.Body padding="lg" className="max-sm:p-4">
+        <div className="flex flex-col gap-4">
+          <span
+            aria-hidden
+            className="flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)]"
+          >
+            {isProCard ? (
+              <Crown className="h-5 w-5 text-[var(--content-default)]" />
+            ) : (
+              <Palmtree className="h-5 w-5 text-[var(--content-default)]" />
+            )}
+          </span>
+          <div className="flex min-h-6 items-center gap-2">
+            <Typography as="h3" variant="title-small">
+              {plan.name}
+            </Typography>
+            {isCurrent && <Tag tone="positive">Current</Tag>}
+          </div>
           <Typography
             as="p"
             variant="body-small-default"
-            className="text-[var(--system-mid-strong)]"
-            data-testid="modal-cancels-on"
+            className="-mt-2 text-[var(--content-tertiary)]"
           >
-            Your plan ends on {formatDate(cancelDate)}
+            {isBaseCard
+              ? "All you need for a capable assistant"
+              : "More features, more compute, more storage"}
           </Typography>
-        )}
-        <hr className="border-t border-[var(--border-base)]" />
-        <div className="flex flex-col gap-1">
-          {isBaseCard ? (
-            <>
-              <Typography as="p" variant="title-medium">
-                Free
-              </Typography>
-              <Typography
-                as="p"
-                variant="body-small-default"
-                className="text-[var(--content-tertiary)]"
-              >
-                Forever
-              </Typography>
-            </>
-          ) : isCurrent &&
-            !(proPickerShown && proLiveTotalCents != null) &&
-            (proCurrentTotalCents == null || currentCreditPriceUnknown) ? (
-            onboardingLoading ? (
-              <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                <Typography as="span" variant="body-medium-lighter">
-                  Loading your plan...
+          {showCancellationOnPro && cancelDate && (
+            <Typography
+              as="p"
+              variant="body-small-default"
+              className="text-[var(--system-mid-strong)]"
+              data-testid="modal-cancels-on"
+            >
+              Your plan ends on {formatDate(cancelDate)}
+            </Typography>
+          )}
+          <hr className="border-t border-[var(--border-base)]" />
+          <div className="flex flex-col gap-1">
+            {isBaseCard ? (
+              <>
+                <Typography as="p" variant="title-medium">
+                  Free
                 </Typography>
-              </div>
-            ) : (
-              <Typography
-                as="p"
-                variant="body-medium-lighter"
-                className="text-[var(--content-tertiary)]"
-                data-testid="modal-pro-price-unavailable"
-              >
-                Current plan pricing unavailable
-              </Typography>
-            )
-          ) : (
-            <>
-              <div className="flex items-center gap-1">
-                <Typography
-                  as="p"
-                  variant="title-medium"
-                  data-testid="modal-pro-price"
-                >
-                  {proPickerShown && proLiveTotalCents != null ? (
-                    <>
-                      {formatMonthly(proLiveTotalCents)}
-                      {proTotalDelta != null && proTotalDelta !== 0 && (
-                        <span className="ml-1 text-[var(--content-tertiary)]">
-                          ({formatDelta(proTotalDelta)})
-                        </span>
-                      )}
-                    </>
-                  ) : proCurrentTotalCents != null ? (
-                    `Currently ${formatMonthly(proCurrentTotalCents)}`
-                  ) : plan.id === "pro" ? (
-                    `From ${formatMonthly(
-                      plan.base_price_cents +
-                        minTierPriceCents(plan.machine_tiers) +
-                        minTierPriceCents(plan.storage_tiers),
-                    )}`
-                  ) : null}
-                </Typography>
-                {proPickerShown &&
-                  proTotalDelta != null &&
-                  proTotalDelta !== 0 && (
-                    <span
-                      title={`Your Pro Plan subscription will change from ${formatMonthly(proCurrentTotalCents!)} to ${formatMonthly(proLiveTotalCents!)}.`}
-                    >
-                      <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
-                    </span>
-                  )}
-              </div>
-              {plan.id === "pro" && (
                 <Typography
                   as="p"
                   variant="body-small-default"
                   className="text-[var(--content-tertiary)]"
-                  data-testid="modal-pro-base-fee"
                 >
-                  {formatDollars(plan.base_price_cents)} base fee
+                  Forever
                 </Typography>
-              )}
-            </>
+              </>
+            ) : isCurrent &&
+              !(proPickerShown && proLiveTotalCents != null) &&
+              (proCurrentTotalCents == null || currentCreditPriceUnknown) ? (
+              onboardingLoading ? (
+                <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <Typography as="span" variant="body-medium-lighter">
+                    Loading your plan...
+                  </Typography>
+                </div>
+              ) : (
+                <Typography
+                  as="p"
+                  variant="body-medium-lighter"
+                  className="text-[var(--content-tertiary)]"
+                  data-testid="modal-pro-price-unavailable"
+                >
+                  Current plan pricing unavailable
+                </Typography>
+              )
+            ) : (
+              <>
+                <div className="flex items-center gap-1">
+                  <Typography
+                    as="p"
+                    variant="title-medium"
+                    data-testid="modal-pro-price"
+                  >
+                    {proPickerShown && proLiveTotalCents != null ? (
+                      <>
+                        {formatMonthly(proLiveTotalCents)}
+                        {proTotalDelta != null && proTotalDelta !== 0 && (
+                          <span className="ml-1 text-[var(--content-tertiary)]">
+                            ({formatDelta(proTotalDelta)})
+                          </span>
+                        )}
+                      </>
+                    ) : proCurrentTotalCents != null ? (
+                      `Currently ${formatMonthly(proCurrentTotalCents)}`
+                    ) : plan.id === "pro" ? (
+                      `From ${formatMonthly(
+                        plan.base_price_cents +
+                          minTierPriceCents(plan.machine_tiers) +
+                          minTierPriceCents(plan.storage_tiers),
+                      )}`
+                    ) : null}
+                  </Typography>
+                  {proPickerShown &&
+                    proTotalDelta != null &&
+                    proTotalDelta !== 0 && (
+                      <span
+                        title={`Your Pro Plan subscription will change from ${formatMonthly(proCurrentTotalCents!)} to ${formatMonthly(proLiveTotalCents!)}.`}
+                      >
+                        <Info className="h-3 w-3 text-[var(--content-tertiary)]" />
+                      </span>
+                    )}
+                </div>
+                {plan.id === "pro" && (
+                  <Typography
+                    as="p"
+                    variant="body-small-default"
+                    className="text-[var(--content-tertiary)]"
+                    data-testid="modal-pro-base-fee"
+                  >
+                    {formatDollars(plan.base_price_cents)} base fee
+                  </Typography>
+                )}
+              </>
+            )}
+          </div>
+          <PlanFeatureList
+            features={plan.included_features}
+            variant="checklist"
+          />
+          {isProCard && !creditTiersEnabled && (
+            <Typography
+              as="p"
+              variant="body-small-default"
+              className="text-[var(--content-tertiary)]"
+              data-testid="modal-credits-not-included"
+            >
+              *Credits not included
+            </Typography>
           )}
         </div>
-        <PlanFeatureList features={plan.included_features} variant="checklist" />
-        {isProCard && !creditTiersEnabled && (
-          <Typography
-            as="p"
-            variant="body-small-default"
-            className="text-[var(--content-tertiary)]"
-            data-testid="modal-credits-not-included"
-          >
-            *Credits not included
-          </Typography>
-        )}
-      </div>
-      <div className="mt-4 flex flex-1 flex-col justify-end gap-4">
-        {!isCurrent && isProCard && (
-          <>
-            <hr className="border-t border-[var(--border-base)]" />
-            {creditTiersEnabled && (
-              <CreditBundlePicker
-                creditTiers={creditTiers}
-                selectedCreditTier={displayCreditTier}
-                onCreditTierChange={onCreditTierChange}
-                disabled={upgradePending}
-              />
-            )}
-            <TierPicker
-              machineTiers={machineTiersForPicker}
-              storageTiers={storageTiersForPicker}
-              selectedMachineTier={selectedMachineTier}
-              selectedStorageTier={selectedStorageTier}
-              onMachineTierChange={onMachineTierChange}
-              onStorageTierChange={onStorageTierChange}
-            />
-            <Button
-              variant="primary"
-              className="w-full"
-              onClick={onUpgrade}
-              disabled={
-                upgradePending || !selectedMachineTier || !selectedStorageTier
-              }
-              data-testid="modal-upgrade-to-pro-button"
-            >
-              Upgrade to Pro
-            </Button>
-          </>
-        )}
-        {showProTierChange &&
-          (onboardingLoading ? (
-            <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              <Typography as="span" variant="body-medium-lighter">
-                Loading your plan...
-              </Typography>
-            </div>
-          ) : (
+        <div className="mt-4 flex flex-1 flex-col justify-end gap-4">
+          {!isCurrent && isProCard && (
             <>
               <hr className="border-t border-[var(--border-base)]" />
               {creditTiersEnabled && (
@@ -295,7 +256,7 @@ export function PlanCardContent({
                   creditTiers={creditTiers}
                   selectedCreditTier={displayCreditTier}
                   onCreditTierChange={onCreditTierChange}
-                  disabled={tierChangePending}
+                  disabled={upgradePending}
                 />
               )}
               <TierPicker
@@ -305,55 +266,96 @@ export function PlanCardContent({
                 selectedStorageTier={selectedStorageTier}
                 onMachineTierChange={onMachineTierChange}
                 onStorageTierChange={onStorageTierChange}
-                currentMachinePriceCents={currentMachinePrice}
-                currentStoragePriceCents={currentStoragePrice}
               />
-              {tierChangeError && (
-                <Notice tone="error">{tierChangeError}</Notice>
-              )}
               <Button
                 variant="primary"
                 className="w-full"
-                onClick={onApplyTierChange}
+                onClick={onUpgrade}
                 disabled={
-                  tierChangePending ||
-                  (!machineChanged && !storageChanged && !creditChanged)
+                  upgradePending || !selectedMachineTier || !selectedStorageTier
                 }
-                data-testid="modal-change-tier-button"
+                data-testid="modal-upgrade-to-pro-button"
               >
-                Update Plan
+                Upgrade to Pro
               </Button>
             </>
-          ))}
-        {!isCurrent && isBaseCard && onPro && !cancelAtPeriodEnd && (
-          <>
-            <hr className="border-t border-[var(--border-base)]" />
-            <Button
-              variant="outlined"
-              className="w-full"
-              onClick={onDowngradeClick}
-              disabled={portalPending}
-              data-testid="modal-downgrade-to-base-button"
-            >
-              Downgrade to Base
-            </Button>
-          </>
-        )}
-        {showCancellationOnPro && (
-          <>
-            <hr className="border-t border-[var(--border-base)]" />
-            <Button
-              variant="outlined"
-              className="w-full"
-              onClick={onKeepPlan}
-              disabled={portalPending}
-              data-testid="modal-keep-plan-button"
-            >
-              Keep your Plan
-            </Button>
-          </>
-        )}
-      </div>
-    </Card>
+          )}
+          {showProTierChange &&
+            (onboardingLoading ? (
+              <div className="flex items-center gap-2 text-[var(--content-tertiary)]">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <Typography as="span" variant="body-medium-lighter">
+                  Loading your plan...
+                </Typography>
+              </div>
+            ) : (
+              <>
+                <hr className="border-t border-[var(--border-base)]" />
+                {creditTiersEnabled && (
+                  <CreditBundlePicker
+                    creditTiers={creditTiers}
+                    selectedCreditTier={displayCreditTier}
+                    onCreditTierChange={onCreditTierChange}
+                    disabled={tierChangePending}
+                  />
+                )}
+                <TierPicker
+                  machineTiers={machineTiersForPicker}
+                  storageTiers={storageTiersForPicker}
+                  selectedMachineTier={selectedMachineTier}
+                  selectedStorageTier={selectedStorageTier}
+                  onMachineTierChange={onMachineTierChange}
+                  onStorageTierChange={onStorageTierChange}
+                  currentMachinePriceCents={currentMachinePrice}
+                  currentStoragePriceCents={currentStoragePrice}
+                />
+                {tierChangeError && (
+                  <Notice tone="error">{tierChangeError}</Notice>
+                )}
+                <Button
+                  variant="primary"
+                  className="w-full"
+                  onClick={onApplyTierChange}
+                  disabled={
+                    tierChangePending ||
+                    (!machineChanged && !storageChanged && !creditChanged)
+                  }
+                  data-testid="modal-change-tier-button"
+                >
+                  Update Plan
+                </Button>
+              </>
+            ))}
+          {!isCurrent && isBaseCard && onPro && !cancelAtPeriodEnd && (
+            <>
+              <hr className="border-t border-[var(--border-base)]" />
+              <Button
+                variant="outlined"
+                className="w-full"
+                onClick={onDowngradeClick}
+                disabled={portalPending}
+                data-testid="modal-downgrade-to-base-button"
+              >
+                Downgrade to Base
+              </Button>
+            </>
+          )}
+          {showCancellationOnPro && (
+            <>
+              <hr className="border-t border-[var(--border-base)]" />
+              <Button
+                variant="outlined"
+                className="w-full"
+                onClick={onKeepPlan}
+                disabled={portalPending}
+                data-testid="modal-keep-plan-button"
+              >
+                Keep your Plan
+              </Button>
+            </>
+          )}
+        </div>
+      </Card.Body>
+    </Card.Root>
   );
 }

--- a/clients/web/src/domains/settings/components/plan-card-content.tsx
+++ b/clients/web/src/domains/settings/components/plan-card-content.tsx
@@ -109,7 +109,10 @@ export function PlanCardContent({
   const showProTierChange = isProCard && isCurrent && proTierChangeMode;
 
   return (
-    <Card padding="lg" className="flex flex-col bg-[var(--surface-base)]">
+    <Card
+      padding="lg"
+      className="flex flex-col bg-[var(--surface-base)] max-sm:[&_[data-slot=card-body]]:p-4"
+    >
       <div className="flex flex-col gap-4">
         <span
           aria-hidden

--- a/clients/web/src/domains/settings/components/referral-content.tsx
+++ b/clients/web/src/domains/settings/components/referral-content.tsx
@@ -38,7 +38,7 @@ function StatChip({ icon, value, label }: StatChipProps) {
       <Typography
         variant="body-small-default"
         as="span"
-        className="text-[var(--content-tertiary)]"
+        className="min-w-0 truncate text-[var(--content-tertiary)]"
       >
         {label}
       </Typography>


### PR DESCRIPTION
## Summary
Width-based responsive fixes for the web billing page at phone width (the iOS Capacitor app renders this same bundle), plus tighter Pro plan cards on small screens. Every change is mobile-first with `sm:` restoring today's exact desktop values, so ≥640px renders byte-identically.

## Self-review result
PASS — 4-pass fresh-eyes review found 3 gaps, all fixed across 2 fix PRs, then re-reviewed clean:
- PR 4's adjust-plan card padding reached into the design-library `Card` internal `data-slot="card-body"`; refactored to the public `Card.Root`/`Card.Body` compound API (desktop unchanged).
- Two brittle happy-dom class-string test assertions removed (kept the behavioral unmapped-brand check).

## PRs merged into feature branch
- #39103: stack the Credit Balance header buttons below the title on phones
- #39104: let the payment-method label truncate instead of clipping the row (+ referral chip)
- #39106: tighten plans-takeover cards and section rhythm on phones
- #39105: compact the adjust-plan modal cards on phones

### Fix PRs
- #39110: drop non-behavioral class-string assertions from the billing responsive tests
- #39111: use the Card compound API for adjust-plan card phone padding

Part of plan: billing-mobile-polish.md