### PR TITLE
fix(billing): correct misleading TIER_TRAITS.eyeStyle comment

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-tier-meta.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tier-meta.tsx
@@ -47,8 +47,9 @@ export function PlanTierAvatar({
         <div aria-hidden className="inline-flex shrink-0">
             {components ? (
                 // Plan-tier avatars render eyeless (body-only); the eye style is
-                // deliberately omitted. `TIER_TRAITS[tier].eyeStyle` is retained
-                // for other consumers of the trait table.
+                // deliberately omitted here. `TIER_TRAITS[tier].eyeStyle` is
+                // kept so the trait table stays a complete creature descriptor
+                // matching the pricing-page creatures, not because it's read here.
                 <AvatarRenderer
                     components={components}
                     bodyShapeId={traits.bodyShape}


### PR DESCRIPTION
## Summary
Self-review (slop audit) flagged that the retained `TIER_TRAITS.eyeStyle` field's justification comment was false — it claimed the field was 'retained for other consumers of the trait table', but PlanTierAvatar was its only reader and now renders eyeless, and TIER_TRAITS has no importers outside plan-tier-meta.tsx. Rewrote the comment to state the honest reason: the field is kept so the trait table stays a complete creature descriptor matching the pricing-page creatures. No behavior change; the field is intentionally retained per the plan.

Part of plan: plan-section-promo-cards.md (self-review remediation)