### PR TITLE
feat(billing): redesign the Plan section — centered current card, promo-style recommended card, eyeless avatars

### DIFF
--- a/clients/web/src/components/avatar-renderer.tsx
+++ b/clients/web/src/components/avatar-renderer.tsx
@@ -7,7 +7,8 @@ import type { CharacterComponents } from "@/types/avatar";
 export interface AvatarRendererProps {
   components: CharacterComponents;
   bodyShapeId: string;
-  eyeStyleId: string;
+  /** Omit (or pass null) to render a body-only, eyeless avatar. */
+  eyeStyleId?: string | null;
   colorId: string;
   size?: number;
   className?: string;

--- a/clients/web/src/domains/settings/billing/plan-promo-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plan-promo-card.test.tsx
@@ -6,7 +6,7 @@
  * spinner and blocks the click while pending; and forces the dark palette.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
 const { PlanPromoCard } = await import("./plan-promo-card");

--- a/clients/web/src/domains/settings/billing/plan-promo-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plan-promo-card.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Tests for PlanPromoCard: the dark, layout-only "promo" card in the billing
+ * Plan section — a centered title, optional one-line blurb, and a single CTA.
+ * Verifies it renders the title, blurb, and CTA label; omits the blurb node
+ * when no blurb is passed; fires `onCtaClick` on click; shows the pending
+ * spinner and blocks the click while pending; and forces the dark palette.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+const { PlanPromoCard } = await import("./plan-promo-card");
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PlanPromoCard", () => {
+  test("renders the title, blurb, and CTA label", async () => {
+    const { findByRole, findByText } = render(
+      <PlanPromoCard
+        title="Upgrade to Mighty"
+        blurb="More power and storage"
+        ctaLabel="Power Up"
+        onCtaClick={() => {}}
+      />,
+    );
+    expect(await findByText("Upgrade to Mighty")).toBeTruthy();
+    expect(await findByText("More power and storage")).toBeTruthy();
+    expect(await findByRole("button", { name: "Power Up" })).toBeTruthy();
+  });
+
+  test("omits the blurb node when blurb is not provided", () => {
+    const { queryByText } = render(
+      <PlanPromoCard
+        title="Customize"
+        ctaLabel="Configure"
+        onCtaClick={() => {}}
+      />,
+    );
+    expect(queryByText("More power and storage")).toBeNull();
+  });
+
+  test("fires onCtaClick when the CTA is clicked", async () => {
+    let clicks = 0;
+    const { findByRole } = render(
+      <PlanPromoCard
+        title="Upgrade to Mighty"
+        ctaLabel="Power Up"
+        onCtaClick={() => {
+          clicks += 1;
+        }}
+      />,
+    );
+    const button = await findByRole("button", { name: "Power Up" });
+    fireEvent.click(button);
+    expect(clicks).toBe(1);
+  });
+
+  test("shows the spinner and blocks the click while pending", async () => {
+    let clicks = 0;
+    const { container, findByRole } = render(
+      <PlanPromoCard
+        title="Upgrade to Mighty"
+        ctaLabel="Power Up"
+        pending
+        onCtaClick={() => {
+          clicks += 1;
+        }}
+      />,
+    );
+    const button = await findByRole("button", { name: "Power Up" });
+    expect(button).toHaveProperty("disabled", true);
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
+    fireEvent.click(button);
+    expect(clicks).toBe(0);
+  });
+
+  test("forces the dark palette on the root", () => {
+    const { container } = render(
+      <PlanPromoCard
+        title="Upgrade to Mighty"
+        ctaLabel="Power Up"
+        onCtaClick={() => {}}
+      />,
+    );
+    expect(container.querySelector('[data-theme="dark"]')).not.toBeNull();
+  });
+
+  test("applies the passed className and ctaTestId", async () => {
+    const { container, findByTestId } = render(
+      <PlanPromoCard
+        title="Upgrade to Mighty"
+        ctaLabel="Power Up"
+        className="lg:flex-[2]"
+        ctaTestId="promo-cta"
+        onCtaClick={() => {}}
+      />,
+    );
+    expect(container.querySelector(".lg\\:flex-\\[2\\]")).not.toBeNull();
+    expect(await findByTestId("promo-cta")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/settings/billing/plan-promo-card.tsx
+++ b/clients/web/src/domains/settings/billing/plan-promo-card.tsx
@@ -1,0 +1,77 @@
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/utils/misc";
+import { Button } from "@vellumai/design-library/components/button";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+export interface PlanPromoCardProps {
+  title: string;
+  /** One-line supporting copy under the title; omitted on the customize variant. */
+  blurb?: string;
+  ctaLabel: string;
+  ctaTestId?: string;
+  pending?: boolean;
+  disabled?: boolean;
+  onCtaClick: () => void;
+  /** Extra root classes (e.g. the lg:flex-[2] width share); applied last. */
+  className?: string;
+}
+
+/**
+ * The dark "promo" card in the billing "Plan" section — a centered title,
+ * optional one-line blurb, and a single CTA. Purely presentational: the parent
+ * owns the copy, the pending/disabled state, and the CTA behavior. The forced
+ * `data-theme="dark"` scope resolves the semantic tokens to the mock's dark
+ * palette (surface ~#17191C, `--content-secondary` blurb ~#A9B2BB).
+ */
+export function PlanPromoCard({
+  title,
+  blurb,
+  ctaLabel,
+  ctaTestId,
+  pending = false,
+  disabled = false,
+  onCtaClick,
+  className,
+}: PlanPromoCardProps) {
+  return (
+    <div
+      data-theme="dark"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-5 rounded-xl bg-[var(--surface-base)] py-5 pl-3 pr-4",
+        className,
+      )}
+    >
+      <div className="flex flex-col items-center gap-2 text-center">
+        <Typography
+          as="span"
+          variant="body-large-default"
+          className="text-[var(--content-default)]"
+        >
+          {title}
+        </Typography>
+        {blurb ? (
+          <Typography
+            as="span"
+            variant="body-small-default"
+            className="text-[var(--content-secondary)]"
+          >
+            {blurb}
+          </Typography>
+        ) : null}
+      </div>
+      <Button
+        variant="primary"
+        className="h-8 shrink-0"
+        onClick={onCtaClick}
+        disabled={disabled || pending}
+        leftIcon={
+          pending ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined
+        }
+        data-testid={ctaTestId}
+      >
+        {ctaLabel}
+      </Button>
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/billing/plan-spec-card.test.tsx
+++ b/clients/web/src/domains/settings/billing/plan-spec-card.test.tsx
@@ -1,9 +1,9 @@
 /**
- * Tests for PlanSpecCard: the shared, layout-only plan card used for both the
- * light ("current") and dark ("recommended") columns in the billing Plan
- * section. Verifies it renders the name, tagline, and spec chips; forwards
- * `nameTestId`; forces the `data-theme` palette; and omits the divider + chip
- * row when there are no specs.
+ * Tests for PlanSpecCard: the layout-only current-plan card in the billing
+ * "Plan" section. Verifies it renders the name and spec chips; forwards
+ * `nameTestId`; forces the light `data-theme` palette; centers its content on
+ * both axes; and brackets the header row with a divider both above and below
+ * only when spec chips are present (otherwise just the centered header row).
  *
  * Rendered with `renderToStaticMarkup` (single-pass, no DOM) — so the lazy
  * `PlanTierAvatar` compositor bundle is mocked to a placeholder, keeping the
@@ -30,80 +30,88 @@ const SPECS: PlanSpec[] = [
   { icon: HardDrive, label: "10 GB" },
 ];
 
+/** Counts non-overlapping occurrences of `needle` in `haystack`. */
+function count(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
 describe("PlanSpecCard", () => {
-  test("renders name, tagline, spec labels, and the nameTestId", () => {
+  test("renders the name, spec labels, and forwards the nameTestId", () => {
     const html = renderToStaticMarkup(
       <PlanSpecCard
-        tone="light"
-        tierKey="free"
+        tierKey="mighty"
         name="Mighty"
         nameTestId="plan-card-name"
-        tagline="A great starter plan"
         specs={SPECS}
       />,
     );
     expect(html).toContain("Mighty");
-    expect(html).toContain("A great starter plan");
     expect(html).toContain("$25 credits");
     expect(html).toContain("10 GB");
     expect(html).toContain("plan-card-name");
   });
 
-  test("omits the divider + chip row when specs is null", () => {
+  test("forces the light data-theme scope", () => {
     const html = renderToStaticMarkup(
-      <PlanSpecCard
-        tone="light"
-        tierKey="free"
-        name="Free"
-        specs={null}
-      />,
+      <PlanSpecCard tierKey="mighty" name="Mighty" specs={SPECS} />,
     );
-    expect(html).toContain("Free");
-    expect(html).not.toContain("$25 credits");
-    expect(html).not.toContain("10 GB");
+    expect(html).toContain('data-theme="light"');
   });
 
-  test("omits the divider + chip row when specs is empty", () => {
+  test("centers its content on both axes", () => {
     const html = renderToStaticMarkup(
-      <PlanSpecCard tone="light" tierKey="free" name="Free" specs={[]} />,
+      <PlanSpecCard tierKey="free" name="Free" specs={null} />,
     );
-    expect(html).toContain("Free");
-    expect(html).not.toContain("$25 credits");
-    expect(html).not.toContain("10 GB");
-  });
-
-  test("forces data-theme=\"dark\" when tone is dark", () => {
-    const html = renderToStaticMarkup(
-      <PlanSpecCard
-        tone="dark"
-        tierKey="free"
-        name="Recommended"
-        specs={SPECS}
-      />,
-    );
-    expect(html).toContain('data-theme="dark"');
-  });
-
-  test("centers the card content when centered is set", () => {
-    const html = renderToStaticMarkup(
-      <PlanSpecCard
-        tone="light"
-        tierKey="free"
-        name="Free"
-        tagline="A great starter plan"
-        centered
-        specs={null}
-      />,
-    );
-    // The centering utilities land on both the root and the header row.
-    expect(html).toContain("justify-center");
     expect(html).toContain("items-center");
+    expect(html).toContain("justify-center");
+  });
+
+  test("brackets the header row with a divider both above and below when specs exist", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard tierKey="mighty" name="Mighty" specs={SPECS} />,
+    );
+    // A divider both above and below the header row → two divider rules.
+    expect(count(html, "bg-[var(--border-base)]")).toBe(2);
+    // The chip row is centered.
+    expect(html).toContain("justify-center");
+  });
+
+  test("omits the dividers + chip row when specs is null", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard tierKey="free" name="Free" specs={null} />,
+    );
+    expect(html).toContain("Free");
+    expect(html).not.toContain("bg-[var(--border-base)]");
+    expect(html).not.toContain("$25 credits");
+    expect(html).not.toContain("10 GB");
+  });
+
+  test("omits the dividers + chip row when specs is empty", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard tierKey="free" name="Free" specs={[]} />,
+    );
+    expect(html).toContain("Free");
+    expect(html).not.toContain("bg-[var(--border-base)]");
+    expect(html).not.toContain("$25 credits");
+    expect(html).not.toContain("10 GB");
+  });
+
+  test("renders the tag next to the name", () => {
+    const html = renderToStaticMarkup(
+      <PlanSpecCard
+        tierKey="free"
+        name="Free"
+        tag={<span>Current Plan</span>}
+        specs={null}
+      />,
+    );
+    expect(html).toContain("Free");
+    expect(html).toContain("Current Plan");
   });
 
   test("renders a wrapping pill for a multiline spec", () => {
     const html = renderToStaticMarkup(
       <PlanSpecCard
-        tone="dark"
         tierKey="mighty"
         name="Mighty"
         specs={[
@@ -124,7 +132,6 @@ describe("PlanSpecCard", () => {
   test("applies the passed className to the root", () => {
     const html = renderToStaticMarkup(
       <PlanSpecCard
-        tone="light"
         tierKey="free"
         name="Free"
         className="lg:flex-[3]"

--- a/clients/web/src/domains/settings/billing/plan-spec-card.tsx
+++ b/clients/web/src/domains/settings/billing/plan-spec-card.tsx
@@ -7,95 +7,65 @@ import { cn } from "@/utils/misc";
 import { Typography } from "@vellumai/design-library/components/typography";
 
 export interface PlanSpecCardProps {
-  /** Forces the card palette: "light" (current) or "dark" (recommended). */
-  tone: "light" | "dark";
   /** Tier key ("free" or a `ProPackage.key`) — selects the creature avatar. */
   tierKey: string;
   name: string;
   /** Test id applied to the plan-name node (e.g. "plan-card-name"). */
   nameTestId?: string;
-  /** Rendered right of the name, e.g. a "Your Current Plan" / "Recommended" tag. */
+  /** Rendered right of the name, e.g. a "Current Plan" tag. */
   tag?: ReactNode;
-  tagline?: string;
-  /** Absolute spec chips; when null/empty the divider + chip row are omitted. */
+  /** Absolute spec chips; when null/empty the dividers + chip row are omitted. */
   specs?: PlanSpec[] | null;
-  /** Header right-aligned action (e.g. the Upgrade button). */
-  action?: ReactNode;
-  /** Centers the card content on both axes (the minimal free current card). */
-  centered?: boolean;
   /** Extra root classes (e.g. a responsive width override); applied last. */
   className?: string;
 }
 
 /**
- * One plan card in the billing "Plan" section. Layout-only: the parent owns
- * the catalog data, the current-plan decision, and any CTA behavior. The
- * forced `data-theme` scope resolves the semantic tokens to the mock's
- * light (current) / dark (recommended) palettes.
+ * The current-plan card in the billing "Plan" section. Layout-only: the parent
+ * owns the catalog data, the current-plan decision, and any CTA behavior. The
+ * forced light `data-theme` scope resolves the semantic tokens to the mock's
+ * light (current-plan) palette. Content is centered on both axes: when spec
+ * chips are present, the header row sits between two dividers with a centered
+ * chip row beneath; otherwise only the centered header row renders.
  */
 export function PlanSpecCard({
-  tone,
   tierKey,
   name,
   nameTestId,
   tag,
-  tagline,
   specs,
-  action,
-  centered = false,
   className,
 }: PlanSpecCardProps) {
   const hasSpecs = specs != null && specs.length > 0;
   return (
     <div
-      data-theme={tone}
+      data-theme="light"
       className={cn(
-        "flex min-w-0 flex-1 flex-col gap-4 rounded-xl bg-[var(--surface-base)] py-3 pl-3 pr-4",
-        centered && "items-center justify-center",
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-4 rounded-xl bg-[var(--surface-base)] py-3 pl-3 pr-4",
         className,
       )}
     >
-      <div
-        className={cn(
-          "flex items-center gap-3",
-          centered ? "justify-center" : "justify-between",
-        )}
-      >
-        <div className="flex min-w-0 items-center gap-3">
-          <PlanTierAvatar tier={tierKey} />
-          <div className="flex min-w-0 flex-col gap-1.5">
-            <div className="flex flex-wrap items-center gap-1.5">
-              <Typography
-                as="span"
-                variant="body-large-default"
-                className="text-[var(--content-default)]"
-                data-testid={nameTestId}
-              >
-                {name}
-              </Typography>
-              {tag}
-            </div>
-            {tagline ? (
-              <Typography
-                as="span"
-                variant="body-small-default"
-                className="text-[var(--content-tertiary)]"
-              >
-                {tagline}
-              </Typography>
-            ) : null}
-          </div>
+      {hasSpecs ? (
+        <div className="h-px w-full bg-[var(--border-base)]" />
+      ) : null}
+      <div className="flex items-center gap-3">
+        <PlanTierAvatar tier={tierKey} size={48} />
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Typography
+            as="span"
+            variant="body-large-default"
+            className="text-[var(--content-default)]"
+            data-testid={nameTestId}
+          >
+            {name}
+          </Typography>
+          {tag}
         </div>
-        {action}
       </div>
       {hasSpecs ? (
         <>
-          {/* mt-auto anchors the divider + chips to the bottom of the card, so
-              the chip rows align across the two cards even when one card is
-              taller (e.g. a wrapped tagline) and `items-stretch` stretches the
-              other — matching the mock, where chips sit near the card bottom. */}
-          <div className="mt-auto h-px w-full bg-[var(--border-base)]" />
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="h-px w-full bg-[var(--border-base)]" />
+          <div className="flex flex-wrap items-center justify-center gap-2">
             {specs.map((spec) => (
               <SpecChip
                 key={spec.label}

--- a/clients/web/src/domains/settings/billing/plan-tier-meta.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tier-meta.tsx
@@ -47,8 +47,9 @@ export function PlanTierAvatar({
         <div aria-hidden className="inline-flex shrink-0">
             {components ? (
                 // Plan-tier avatars render eyeless (body-only); the eye style is
-                // deliberately omitted. `TIER_TRAITS[tier].eyeStyle` is retained
-                // for other consumers of the trait table.
+                // deliberately omitted here. `TIER_TRAITS[tier].eyeStyle` is
+                // kept so the trait table stays a complete creature descriptor
+                // matching the pricing-page creatures, not because it's read here.
                 <AvatarRenderer
                     components={components}
                     bodyShapeId={traits.bodyShape}

--- a/clients/web/src/domains/settings/billing/plan-tier-meta.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tier-meta.tsx
@@ -46,10 +46,12 @@ export function PlanTierAvatar({
     return (
         <div aria-hidden className="inline-flex shrink-0">
             {components ? (
+                // Plan-tier avatars render eyeless (body-only); the eye style is
+                // deliberately omitted. `TIER_TRAITS[tier].eyeStyle` is retained
+                // for other consumers of the trait table.
                 <AvatarRenderer
                     components={components}
                     bodyShapeId={traits.bodyShape}
-                    eyeStyleId={traits.eyeStyle}
                     colorId={traits.color}
                     size={size}
                 />

--- a/clients/web/src/domains/settings/billing/plans/plans-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/plans-copy.ts
@@ -21,6 +21,8 @@ export interface PlanTierCopy {
   recommended?: boolean;
   /** Feature rows appended after the catalog-derived rows. */
   extraFeatures?: readonly string[];
+  /** One-line pitch shown on the billing page's dark "Upgrade to X" card. */
+  upgradeBlurb?: string;
 }
 
 export const PLAN_TIER_COPY: Record<PlanTierKey, PlanTierCopy> = {
@@ -34,18 +36,21 @@ export const PLAN_TIER_COPY: Record<PlanTierKey, PlanTierCopy> = {
     cta: "Power Up",
     priceCaption: "Billed monthly",
     recommended: true,
+    upgradeBlurb: "$25 in Credits, more storage and power",
   },
   super: {
     tagline: "Stronger performance for heavier workloads.",
     cta: "Go Super",
     priceCaption: "Billed monthly",
     extraFeatures: ["Assistant email and subdomain"],
+    upgradeBlurb: "$45 credits, 3× storage, more power, and email.",
   },
   ultra: {
     tagline: "Our highest level of power and capacity.",
     cta: "Unleash Ultra",
     priceCaption: "Billed monthly",
     extraFeatures: ["Assistant email and subdomain"],
+    upgradeBlurb: "$115 credits, 2x storage, more power, and email.",
   },
 };
 

--- a/clients/web/src/domains/settings/components/plan-card-checkout.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card-checkout.test.tsx
@@ -1,11 +1,11 @@
 /**
  * Interaction tests for the PlanCard recommended-upgrade CTA.
  *
- * Clicking "Upgrade for _ more" fires the Stripe upgrade for the recommended
- * package and redirects to the returned checkout URL — and stashes the
- * purchased package first, so the post-checkout provisioning screen shows what
- * was actually bought instead of an intent left behind by an abandoned earlier
- * checkout.
+ * Clicking the promo card's "Upgrade" CTA fires the Stripe upgrade for the
+ * recommended package and redirects to the returned checkout URL — and stashes
+ * the purchased package first, so the post-checkout provisioning screen shows
+ * what was actually bought instead of an intent left behind by an abandoned
+ * earlier checkout.
  *
  * Strategy mirrors plans-page-checkout.test.tsx: mock the generated SDK to
  * capture the upgrade body and return a redirect, and mock `openUrl` to capture

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -518,7 +518,7 @@ describe("PlanCard", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
     expect(html).toContain("plan-card-name");
     expect(html).toContain("Free");
-    expect(html).toContain("Your Current Plan");
+    expect(html).toContain("Current Plan");
     expect(html).toContain("plan-card-renews");
     expect(html).toContain("auto renew");
   });
@@ -561,10 +561,8 @@ describe("PlanCard", () => {
     expect(html).toContain(PLAN_TIER_COPY.mighty.upgradeBlurb!);
     expect(html).not.toContain("more credits and storage");
     expect(html).not.toContain("Recommended");
-    // The centered free card still shows its "Your Current Plan" tag and its real
-    // tagline — the tagline follows "known plan", not "has chips".
-    expect(html).toContain("Your Current Plan");
-    expect(html).toContain(PLAN_TIER_COPY.free.tagline);
+    // The centered free card still shows its "Current Plan" tag.
+    expect(html).toContain("Current Plan");
   });
 
   test("Mighty → Super: current keeps its chips, recommended shows the promo card", () => {
@@ -652,9 +650,6 @@ describe("PlanCard", () => {
     // doesn't masquerade as a stock package.
     expect(html).toContain("Custom");
     expect(html).not.toContain("Mighty (Custom)");
-    // Its specs are unknowable (no chips), so the stock Mighty tagline must not
-    // render under the "Custom" name either — same gate as the chips.
-    expect(html).not.toContain(PLAN_TIER_COPY.mighty.tagline);
   });
 
   test("current-plan row labels an unpinned Pro sub as custom", () => {
@@ -668,10 +663,6 @@ describe("PlanCard", () => {
     expect(html).toContain("plan-card-name");
     expect(html).toContain("Custom");
     expect(html).not.toContain("Pro");
-    // `currentTier` falls back to "free" for an unpinned sub, but its specs are
-    // unknowable (no chips), so the stock free tagline must not leak in under
-    // the "Custom" name.
-    expect(html).not.toContain(PLAN_TIER_COPY.free.tagline);
   });
 
   test("a clean-pinned Pro sub whose package is absent from the catalog shows no chips", () => {
@@ -690,13 +681,12 @@ describe("PlanCard", () => {
     expect(html).not.toContain("Small Machine");
   });
 
-  test("a free user's current card is centered, chip-less, and keeps its tagline", () => {
+  test("a free user's current card is centered and chip-less", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
     // The free current card is a minimal centered card: centering classes on the
-    // card, its "Your Current Plan" tag, and the real free tagline, but NO chips.
+    // card and its "Current Plan" tag, but NO chips.
     expect(html).toContain("justify-center");
-    expect(html).toContain("Your Current Plan");
-    expect(html).toContain(PLAN_TIER_COPY.free.tagline);
+    expect(html).toContain("Current Plan");
     expect(html).not.toContain("$0 credits");
     expect(html).not.toContain("4 GB");
     expect(html).not.toContain("Small Machine");

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -1026,7 +1026,8 @@ describe("PlanCard recommended upgrade — change-package", () => {
     const onTierUpgraded = mock(() => {});
     // An unpinned (Custom) Pro sub is switch-eligible, so the customize CTA opens
     // the CustomPlanModal (not the change-package confirm, not the manage
-    // fallback).
+    // fallback). A healthy sub's current tiers load, so seed them.
+    onboardingResponse = CUSTOMIZE_ONBOARDING;
     const subscription: SubscriptionResponse = {
       ...proMightySubscription(),
       package: null,
@@ -1060,7 +1061,9 @@ describe("PlanCard recommended upgrade — change-package", () => {
     const onManage = mock(() => {});
     const onTierUpgraded = mock(() => {});
     // A customized pin is switch-eligible; the customize CTA edits its tiers in
-    // place via the CustomPlanModal.
+    // place via the CustomPlanModal. A healthy sub's current tiers load, so seed
+    // them.
+    onboardingResponse = CUSTOMIZE_ONBOARDING;
     const subscription = proMightySubscription();
     subscription.package = {
       key: "mighty",
@@ -1091,7 +1094,9 @@ describe("PlanCard recommended upgrade — change-package", () => {
     const onManage = mock(() => {});
     const onTierUpgraded = mock(() => {});
     // Ultra is the top catalog package, so there's no package to upgrade to; the
-    // top-tier sub gets the customize card instead of an "Upgrade to X" card.
+    // top-tier sub gets the customize card instead of an "Upgrade to X" card. A
+    // healthy sub's current tiers load, so seed them.
+    onboardingResponse = CUSTOMIZE_ONBOARDING;
     const { findByTestId, findByText } = renderCardInteractive(
       proUltraSubscription(),
       plansWithUltra(),
@@ -1110,6 +1115,39 @@ describe("PlanCard recommended upgrade — change-package", () => {
 
     await findByText("Just better.");
     expect(onManage).not.toHaveBeenCalled();
+    expect(navigateArgs).toEqual([]);
+  });
+
+  test("a switch-eligible sub whose current tiers fail to load routes customize to onManage", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // `currentReady` flips true even when the onboarding read settles without a
+    // storage tier (an error or a degraded response), leaving the seed null.
+    // Opening the configurator unseeded would let a submit overwrite the tiers
+    // the user already holds, so the customize CTA must route to manage instead.
+    onboardingResponse = {}; // settled, but no selected_storage_tier → null seed
+    const { findByTestId } = renderCardInteractive(
+      proUltraSubscription(),
+      plansWithUltra(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    const cta = (await findByTestId(
+      "recommended-customize-button",
+    )) as HTMLButtonElement;
+    // The CTA is enabled (the read settled, nothing pending) but routes to manage.
+    await waitFor(() => expect(cta.disabled).toBe(false));
+    fireEvent.click(cta);
+
+    await waitFor(() => {
+      expect(onManage).toHaveBeenCalledTimes(1);
+    });
+    // The configurator never opened.
+    expect(document.body.textContent).not.toContain("Just better.");
+    expect(
+      document.querySelector("[data-testid='confirm-package-switch-button']"),
+    ).toBeNull();
     expect(navigateArgs).toEqual([]);
   });
 

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -31,11 +31,13 @@ import {
   organizationsBillingSubscriptionRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type {
+  CreditTier,
   PackageChangeResponse,
   PlanListResponse,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
 import * as runtimeBrowser from "@/runtime/browser";
+import * as toastModule from "@vellumai/design-library/components/toast";
 import { PLAN_TIER_COPY } from "@/domains/settings/billing/plans/plans-copy";
 import { routes } from "@/utils/routes";
 
@@ -77,6 +79,16 @@ let changePackageImpl: () => Promise<{
 });
 let currentSub: SubscriptionResponse = baseSubscription();
 let currentPlans: PlanListResponse = basePlansResponse();
+// Change-tier mutation captures for the customize (CustomPlanModal) flow. Each
+// records the request body so a test can assert which dimension(s) a
+// `changeTiers` dispatch actually posted.
+let changeCreditTierCall: Captured | null = null;
+let changeMachineTierCall: Captured | null = null;
+let changeStorageTierCall: Captured | null = null;
+// The onboarding retrieve carries the current machine/storage tiers that seed
+// the CustomPlanModal. Defaults to empty (no seed) so existing tests are
+// unaffected; the customize tests set it to seed a starting configuration.
+let onboardingResponse: Record<string, unknown> = {};
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -93,7 +105,39 @@ mock.module("@/generated/api/sdk.gen", () => ({
   organizationsBillingPlansRetrieve: () =>
     Promise.resolve({ data: currentPlans, response: { ok: true } }),
   organizationsBillingSubscriptionOnboardingRetrieve: () =>
-    Promise.resolve({ data: {}, response: { ok: true } }),
+    Promise.resolve({ data: onboardingResponse, response: { ok: true } }),
+  // The three change-tier endpoints back the customize flow's `changeTiers`.
+  organizationsBillingSubscriptionChangeCreditTierCreate: (opts: Captured) => {
+    changeCreditTierCall = opts;
+    return Promise.resolve({
+      data: { status: "ok", credit_tier: null },
+      response: { ok: true },
+    });
+  },
+  organizationsBillingSubscriptionChangeMachineTierCreate: (opts: Captured) => {
+    changeMachineTierCall = opts;
+    return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
+  },
+  organizationsBillingSubscriptionChangeStorageTierCreate: (opts: Captured) => {
+    changeStorageTierCall = opts;
+    return Promise.resolve({ data: { status: "ok" }, response: { ok: true } });
+  },
+}));
+
+// Capture success toasts so the customize flow's credit-only vs resize branch
+// can be asserted (the resize takeover is opened via `onTierUpgraded`, not a
+// toast, so a credit-only change is the only one that toasts here).
+let toastSuccessCalls: string[] = [];
+mock.module("@vellumai/design-library/components/toast", () => ({
+  ...toastModule,
+  toast: Object.assign((..._args: unknown[]) => {}, {
+    success: (message: string) => {
+      toastSuccessCalls.push(String(message));
+    },
+    error: () => {},
+    info: () => {},
+    warning: () => {},
+  }),
 }));
 
 // Capture the Stripe checkout redirect instead of opening a browser.
@@ -208,6 +252,139 @@ function proMightySubscription(): SubscriptionResponse {
   };
 }
 
+/** Catalog with Mighty, Super, and Ultra — so Ultra is the top package. */
+function plansWithUltra(): PlanListResponse {
+  const plans = plansWithSuper();
+  const pro = plans.plans.find((p) => p.id === "pro");
+  if (pro && "packages" in pro && pro.packages) {
+    pro.packages.push({
+      key: "ultra",
+      name: "Ultra",
+      description:
+        "Large machine, 60 GB of storage, and $115 in monthly credits.",
+      version: 1,
+      machine_tier: "large",
+      storage_tier: "l",
+      credit_tier: "credits_115",
+      machine_size: "large",
+      storage_gib: 60,
+      credits_usd: 115,
+      include_platform_fee: true,
+      base_price_cents: 1000,
+      machine_price_cents: 7000,
+      storage_price_cents: 2000,
+      credit_price_cents: 11500,
+      total_price_cents: 20000,
+    });
+  }
+  return plans;
+}
+
+/** A subscriber cleanly pinned to the top (Ultra) Pro package. */
+function proUltraSubscription(): SubscriptionResponse {
+  return {
+    plan_id: "pro",
+    status: "active",
+    renewal_date: null,
+    current_period_end: "2026-08-10T00:00:00Z",
+    cancel_at_period_end: false,
+    cancel_at: null,
+    package: { key: "ultra", name: "Ultra", version: 1, customized: false },
+    entitlements: { managed_email: false, phone_number: false },
+  };
+}
+
+const CUSTOMIZE_CREDIT_TIERS: CreditTier[] = [
+  {
+    tier: "credits_25",
+    label: "$25 in credits",
+    credits_usd: 25,
+    price_cents: 2500,
+    lookup_key: "credits_25_lk",
+    legacy: false,
+  },
+  {
+    tier: "credits_45",
+    label: "$45 in credits",
+    credits_usd: 45,
+    price_cents: 4500,
+    lookup_key: "credits_45_lk",
+    legacy: false,
+  },
+];
+
+/**
+ * A Pro catalog whose machine/storage/credit tier LISTS are populated (the
+ * package-only fixtures leave them empty), so a seeded CustomPlanModal can drive
+ * a real tier change through `changeTiers`. Extends `plansWithSuper()` so the
+ * sub stays switch-eligible (Mighty → Super) and the customize card renders.
+ */
+function plansForCustomize(): PlanListResponse {
+  const plans = plansWithSuper();
+  const pro = plans.plans.find((p) => p.id === "pro");
+  if (pro && "machine_tiers" in pro) {
+    pro.machine_tiers = [
+      {
+        tier: "medium",
+        label: "Medium",
+        description: "Medium machine",
+        price_cents: 3500,
+        lookup_key: "machine_medium_lk",
+        cpu_limit: "2",
+        memory_gib: 4,
+      },
+      {
+        tier: "large",
+        label: "Large",
+        description: "Large machine",
+        price_cents: 7000,
+        lookup_key: "machine_large_lk",
+        cpu_limit: "4",
+        memory_gib: 8,
+      },
+    ];
+    pro.storage_tiers = [
+      {
+        tier: "xs",
+        label: "10 GB storage",
+        storage_gib: 10,
+        price_cents: 0,
+        lookup_key: "storage_xs_lk",
+        legacy: false,
+      },
+      {
+        tier: "s",
+        label: "30 GB storage",
+        storage_gib: 30,
+        price_cents: 1000,
+        lookup_key: "storage_s_lk",
+        legacy: false,
+      },
+    ];
+    pro.credit_tiers = CUSTOMIZE_CREDIT_TIERS;
+  }
+  return plans;
+}
+
+/**
+ * A customized (switch-eligible) Pro sub seeded on the Mighty package with an
+ * existing credit bundle, so the CustomPlanModal opens pre-filled.
+ */
+function proCustomizeSubscription(): SubscriptionResponse {
+  return {
+    ...proMightySubscription(),
+    package: { key: "mighty", name: "Mighty", version: 1, customized: true },
+    selected_credit_tier: "credits_25",
+  };
+}
+
+/** The onboarding response that seeds the CustomPlanModal's current tiers. */
+const CUSTOMIZE_ONBOARDING: Record<string, unknown> = {
+  max_machine_tier: "medium",
+  selected_storage_tier: "xs",
+  selected_storage_gib: 10,
+};
+
 /** A catalog with the `pro-packages` flag off — the Pro plan has no packages. */
 function emptyCatalogPlans(): PlanListResponse {
   const plans = basePlansResponse();
@@ -274,6 +451,28 @@ function renderCardInteractive(
   );
 }
 
+/** Opens a CustomPlanModal dropdown by its combobox aria-label. */
+function getDropdownTrigger(label: string): HTMLButtonElement {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    `button[role="combobox"][aria-label="${label}"]`,
+  );
+  if (!trigger) {
+    throw new Error(`expected a ${label} dropdown trigger`);
+  }
+  return trigger;
+}
+
+/** Clicks the first open dropdown option whose text starts with `prefix`. */
+function clickOptionStartingWith(prefix: string): void {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim().startsWith(prefix));
+  if (!option) {
+    throw new Error(`expected option starting with "${prefix}"`);
+  }
+  fireEvent.click(option);
+}
+
 /** Waits for the PackageSwitchConfirmModal (portaled) to open. */
 async function findConfirmDialogButton(): Promise<HTMLButtonElement> {
   return await waitFor(() => {
@@ -303,6 +502,11 @@ beforeEach(() => {
     response: { ok: true },
   });
   openedUrl = null;
+  changeCreditTierCall = null;
+  changeMachineTierCall = null;
+  changeStorageTierCall = null;
+  onboardingResponse = {};
+  toastSuccessCalls = [];
 });
 
 afterEach(() => {
@@ -330,11 +534,12 @@ describe("PlanCard", () => {
     expect(html).not.toContain("plan-card-invoices-button");
   });
 
-  test("renders the recommended-upgrade banner (Mighty from Free)", () => {
+  test("renders the recommended-upgrade promo card (Mighty from Free)", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
     expect(html).toContain("recommended-upgrade-button");
-    expect(html).toContain("Recommended");
-    expect(html).toContain("Mighty");
+    expect(html).toContain("Upgrade to Mighty");
+    // The dark promo card carries no "Recommended" tag.
+    expect(html).not.toContain("Recommended");
   });
 
   test("no upgrade banner when the package catalog is empty (flag off)", () => {
@@ -343,38 +548,34 @@ describe("PlanCard", () => {
     expect(html).not.toContain("recommended-upgrade-button");
   });
 
-  test("Free current card is chip-less; recommended shows the summary chip", () => {
+  test("Free current card is chip-less; recommended shows the promo blurb", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
     // The current (Free) card is now a minimal centered card with NO spec chips:
     // none of the free-baseline chip labels appear.
     expect(html).not.toContain("$0 credits");
     expect(html).not.toContain("4 GB");
     expect(html).not.toContain("Small Machine");
-    // The recommended (Mighty) card shows the single summary chip, replacing the
-    // old absolute per-resource chips (machine · credits · storage). Free→Mighty
-    // stays on the Small baseline, so the chip omits the machine claim.
-    expect(html).toContain("more credits and storage");
-    expect(html).not.toContain("stronger machine");
-    expect(html).not.toContain("$25 credits");
-    expect(html).not.toContain("10 GB");
-    expect(html).not.toContain("vCPU");
+    // The recommended (Mighty) promo card shows "Upgrade to Mighty" plus the
+    // per-tier blurb, replacing the old summary chip — and carries no tag/chips.
+    expect(html).toContain("Upgrade to Mighty");
+    expect(html).toContain(PLAN_TIER_COPY.mighty.upgradeBlurb!);
+    expect(html).not.toContain("more credits and storage");
+    expect(html).not.toContain("Recommended");
     // The centered free card still shows its "Your Current Plan" tag and its real
     // tagline — the tagline follows "known plan", not "has chips".
     expect(html).toContain("Your Current Plan");
     expect(html).toContain(PLAN_TIER_COPY.free.tagline);
   });
 
-  test("Mighty → Super: current keeps its chips, recommended shows the summary chip", () => {
+  test("Mighty → Super: current keeps its chips, recommended shows the promo card", () => {
     const html = renderCard(proMightySubscription(), plansWithSuper());
     // On Mighty, the recommended upgrade is the next catalog package, Super.
     expect(html).toContain("recommended-upgrade-button");
-    expect(html).toContain("Recommended");
-    expect(html).toContain("Super");
-    // The recommended (Super) card shows the single summary chip, not Super's
-    // absolute per-resource chips.
-    expect(html).toContain("more credits, storage, and a stronger machine");
-    expect(html).not.toContain("$45 credits");
-    expect(html).not.toContain("30 GB");
+    expect(html).toContain("Upgrade to Super");
+    expect(html).toContain(PLAN_TIER_COPY.super.upgradeBlurb!);
+    // The promo card carries no "Recommended" tag and no summary chip.
+    expect(html).not.toContain("Recommended");
+    expect(html).not.toContain("more credits, storage, and a stronger machine");
     // The current (Mighty) card keeps its absolute chips.
     expect(html).toContain("$25 credits");
     expect(html).toContain("10 GB");
@@ -383,31 +584,29 @@ describe("PlanCard", () => {
     // generic plan name "Pro").
     expect(html).toContain("plan-card-name");
     expect(html).toContain("Mighty");
-    expect(html).not.toContain("Pro");
   });
 
-  test("an unpinned Custom sub's banner drops the stock upgrade framing", () => {
-    // A legacy unpinned Pro sub's real tiers can diverge from any stock
-    // package, so the banner offers the named plan neutrally: a "Switch plan"
-    // tag and a "Switch to Mighty" CTA, with no "Recommended Upgrade" claim and
-    // no stock price/resource deltas that could point the wrong way.
+  test("an unpinned Custom sub gets the customize promo card", () => {
+    // A legacy unpinned Pro sub's real tiers can diverge from any stock package,
+    // so instead of a named-package upgrade it gets the "Create a custom plan"
+    // promo card whose "Customize" CTA opens the CustomPlanModal.
     const subscription: SubscriptionResponse = {
       ...proMightySubscription(),
       package: null,
     };
     const html = renderCard(subscription, plansWithSuper());
-    expect(html).toContain("recommended-upgrade-button");
-    expect(html).toContain("Switch plan");
-    expect(html).toContain("Switch to Mighty");
-    // A neutral switch drops the "Recommended" tag and renders no chips on the
-    // recommended card — not even the summary chip; the current "Custom" card
-    // also has no knowable chips. Asserting on the "more credits" prefix covers
-    // both the full and machine-less summary labels.
+    expect(html).toContain("recommended-customize-button");
+    expect(html).toContain("Create a custom plan");
+    expect(html).toContain("Customize");
+    // No upgrade/switch framing, no tag, and no chips.
+    expect(html).not.toContain("recommended-upgrade-button");
     expect(html).not.toContain("Recommended");
+    expect(html).not.toContain("Switch plan");
+    expect(html).not.toContain("Switch to");
     expect(html).not.toContain("more credits");
   });
 
-  test("a customized Pro sub's banner drops the stock upgrade framing", () => {
+  test("a customized Pro sub gets the customize promo card", () => {
     const subscription = proMightySubscription();
     subscription.package = {
       key: "mighty",
@@ -416,24 +615,28 @@ describe("PlanCard", () => {
       customized: true,
     };
     const html = renderCard(subscription, plansWithSuper());
-    // Recommended package is Super (next after the Mighty pin), offered as a
-    // neutral switch since the customized tiers can differ from stock Super.
-    expect(html).toContain("Switch plan");
-    expect(html).toContain("Switch to Super");
+    // A customized pin's tiers can differ from stock, so it gets the customize
+    // promo card rather than a named-package upgrade.
+    expect(html).toContain("recommended-customize-button");
+    expect(html).toContain("Create a custom plan");
+    expect(html).toContain("Customize");
+    expect(html).not.toContain("recommended-upgrade-button");
     expect(html).not.toContain("Recommended");
-    // A neutral switch renders no summary chip either. The "more credits" prefix
-    // covers both the full and machine-less summary labels.
+    expect(html).not.toContain("Switch to");
     expect(html).not.toContain("more credits");
   });
 
-  test("a base user's banner keeps the upgrade CTA (not a switch)", () => {
+  test("a base user's banner keeps the upgrade CTA (not a customize)", () => {
     // Base → Pro is a genuine Stripe-checkout upgrade, so the recommended card
-    // keeps its "Recommended" tag and a compact "Upgrade" CTA (no "Switch").
+    // stays on the "Upgrade to X" variant (no customize path).
     const html = renderCard(baseSubscription(), basePlansResponse());
-    expect(html).toContain("Recommended");
-    expect(html).toContain("Upgrade");
+    expect(html).toContain("recommended-upgrade-button");
+    expect(html).toContain("Upgrade to Mighty");
+    expect(html).not.toContain("recommended-customize-button");
+    expect(html).not.toContain("Create a custom plan");
     expect(html).not.toContain("Switch plan");
     expect(html).not.toContain("Switch to");
+    expect(html).not.toContain("Recommended");
   });
 
   test("current-plan row labels a customized package as custom", () => {
@@ -497,9 +700,10 @@ describe("PlanCard", () => {
     expect(html).not.toContain("$0 credits");
     expect(html).not.toContain("4 GB");
     expect(html).not.toContain("Small Machine");
-    // The recommended (Mighty) card shows the single summary chip. Free→Mighty
-    // keeps the Small baseline machine, so the chip claims only credits/storage.
-    expect(html).toContain("more credits and storage");
+    // The recommended (Mighty) promo card shows the per-tier blurb, not a chip.
+    expect(html).toContain("Upgrade to Mighty");
+    expect(html).toContain(PLAN_TIER_COPY.mighty.upgradeBlurb!);
+    expect(html).not.toContain("more credits and storage");
     expect(html).not.toContain("stronger machine");
   });
 });
@@ -827,12 +1031,12 @@ describe("PlanCard recommended upgrade — change-package", () => {
     expect(onTierUpgraded).not.toHaveBeenCalled();
   });
 
-  test("an unpinned Pro sub's recommended upgrade opens the neutral switch confirm", async () => {
+  test("an unpinned Pro sub's customize CTA opens the CustomPlanModal", async () => {
     const onManage = mock(() => {});
     const onTierUpgraded = mock(() => {});
-    // An unpinned (Custom) Pro sub is switch-eligible, so the banner CTA reaches
-    // the change-package confirm rather than the manage fallback. Its catalog
-    // rank is unknown, so the confirm copy stays direction-neutral.
+    // An unpinned (Custom) Pro sub is switch-eligible, so the customize CTA opens
+    // the CustomPlanModal (not the change-package confirm, not the manage
+    // fallback).
     const subscription: SubscriptionResponse = {
       ...proMightySubscription(),
       package: null,
@@ -844,23 +1048,29 @@ describe("PlanCard recommended upgrade — change-package", () => {
       onTierUpgraded,
     );
 
-    // The banner renders and its CTA opens the neutral switch confirm (currentKey
-    // is null, so the recommended package is Mighty).
-    fireEvent.click(await findByTestId("recommended-upgrade-button"));
-    await findByText("Switch to Mighty?");
-    await findByText(
-      "Your plan changes now. Any prorated difference is charged now or credited to your next invoice.",
-    );
+    const cta = (await findByTestId(
+      "recommended-customize-button",
+    )) as HTMLButtonElement;
+    // The CTA enables once the current tiers settle; opening it reveals the
+    // CustomPlanModal (its unique "Just better." subtitle).
+    await waitFor(() => expect(cta.disabled).toBe(false));
+    fireEvent.click(cta);
+
+    await findByText("Just better.");
+    // Never the change-package confirm nor the manage fallback.
+    expect(
+      document.querySelector("[data-testid='confirm-package-switch-button']"),
+    ).toBeNull();
+    expect(changePackageBody).toBeNull();
     expect(onManage).not.toHaveBeenCalled();
     expect(navigateArgs).toEqual([]);
   });
 
-  test("a customized Pro sub's recommended upgrade opens the neutral switch confirm", async () => {
+  test("a customized Pro sub's customize CTA opens the CustomPlanModal", async () => {
     const onManage = mock(() => {});
     const onTierUpgraded = mock(() => {});
-    // A customized pin is switch-eligible; the change-package endpoint re-pins it
-    // to the named target. Its catalog rank is ambiguous, so the confirm copy
-    // stays direction-neutral instead of claiming an upgrade.
+    // A customized pin is switch-eligible; the customize CTA edits its tiers in
+    // place via the CustomPlanModal.
     const subscription = proMightySubscription();
     subscription.package = {
       key: "mighty",
@@ -875,14 +1085,152 @@ describe("PlanCard recommended upgrade — change-package", () => {
       onTierUpgraded,
     );
 
-    // Recommended package is Super (next after the customized Mighty pin).
-    fireEvent.click(await findByTestId("recommended-upgrade-button"));
-    await findByText("Switch to Super?");
-    await findByText(
-      "Your plan changes now. Any prorated difference is charged now or credited to your next invoice.",
-    );
+    const cta = (await findByTestId(
+      "recommended-customize-button",
+    )) as HTMLButtonElement;
+    await waitFor(() => expect(cta.disabled).toBe(false));
+    fireEvent.click(cta);
+
+    await findByText("Just better.");
+    expect(changePackageBody).toBeNull();
     expect(onManage).not.toHaveBeenCalled();
     expect(navigateArgs).toEqual([]);
+  });
+
+  test("a top-tier (Ultra) clean pin's customize CTA opens the CustomPlanModal", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // Ultra is the top catalog package, so there's no package to upgrade to; the
+    // top-tier sub gets the customize card instead of an "Upgrade to X" card.
+    const { findByTestId, findByText } = renderCardInteractive(
+      proUltraSubscription(),
+      plansWithUltra(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    expect(
+      document.querySelector("[data-testid='recommended-upgrade-button']"),
+    ).toBeNull();
+    const cta = (await findByTestId(
+      "recommended-customize-button",
+    )) as HTMLButtonElement;
+    await waitFor(() => expect(cta.disabled).toBe(false));
+    fireEvent.click(cta);
+
+    await findByText("Just better.");
+    expect(onManage).not.toHaveBeenCalled();
+    expect(navigateArgs).toEqual([]);
+  });
+
+  test("a switch-ineligible custom sub's customize CTA falls back to onManage", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // A customized sub pending cancellation can't change tiers, so the customize
+    // CTA routes to the manage modal (AdjustPlanModal) — the same fallback the
+    // upgrade CTA uses — instead of opening the configurator.
+    const subscription = proMightySubscription();
+    subscription.package = {
+      key: "mighty",
+      name: "Mighty",
+      version: 1,
+      customized: true,
+    };
+    subscription.cancel_at = "2026-08-23T12:36:05Z";
+    const { findByTestId } = renderCardInteractive(
+      subscription,
+      plansWithSuper(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    fireEvent.click(await findByTestId("recommended-customize-button"));
+
+    await waitFor(() => {
+      expect(onManage).toHaveBeenCalledTimes(1);
+    });
+    // No configurator opened, no navigation.
+    expect(document.querySelector("[data-testid='confirm-package-switch-button']")).toBeNull();
+    expect(navigateArgs).toEqual([]);
+  });
+
+  test("a customize credit-only change toasts and does NOT open the resize takeover", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // The billing-page resize takeover is credit-agnostic (`onTierUpgraded` is
+    // argument-less), so a credit-only change must toast "Credit bundle updated."
+    // — like AdjustPlanModal — instead of popping a blank takeover.
+    onboardingResponse = CUSTOMIZE_ONBOARDING;
+    const { findByTestId, findByText, findByRole } = renderCardInteractive(
+      proCustomizeSubscription(),
+      plansForCustomize(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    const cta = (await findByTestId(
+      "recommended-customize-button",
+    )) as HTMLButtonElement;
+    await waitFor(() => expect(cta.disabled).toBe(false));
+    fireEvent.click(cta);
+    await findByText("Just better.");
+
+    // Swap ONLY the credit bundle, then Continue — a credit-only change.
+    fireEvent.click(getDropdownTrigger("Credit bundle"));
+    clickOptionStartingWith("$45 in credits");
+    fireEvent.click(await findByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      if (!changeCreditTierCall) {
+        throw new Error("credit-tier change not called");
+      }
+    });
+    // Only the credit dimension posts...
+    expect(
+      (changeCreditTierCall!.body as Record<string, unknown>).credit_tier,
+    ).toBe("credits_45");
+    expect(changeMachineTierCall).toBeNull();
+    expect(changeStorageTierCall).toBeNull();
+    // ...and it toasts rather than opening the credit-agnostic resize takeover.
+    await waitFor(() => {
+      expect(toastSuccessCalls).toContain("Credit bundle updated.");
+    });
+    expect(onTierUpgraded).not.toHaveBeenCalled();
+  });
+
+  test("a customize storage upgrade opens the resize takeover", async () => {
+    const onManage = mock(() => {});
+    const onTierUpgraded = mock(() => {});
+    // A real machine/storage resize DOES hand off to the takeover via
+    // `onTierUpgraded` (and does not toast the credit-bundle message).
+    onboardingResponse = CUSTOMIZE_ONBOARDING;
+    const { findByTestId, findByText, findByRole } = renderCardInteractive(
+      proCustomizeSubscription(),
+      plansForCustomize(),
+      onManage,
+      onTierUpgraded,
+    );
+
+    const cta = (await findByTestId(
+      "recommended-customize-button",
+    )) as HTMLButtonElement;
+    await waitFor(() => expect(cta.disabled).toBe(false));
+    fireEvent.click(cta);
+    await findByText("Just better.");
+
+    // Bump storage to a larger tier — a real resize.
+    fireEvent.click(getDropdownTrigger("Storage"));
+    clickOptionStartingWith("30 GB storage");
+    fireEvent.click(await findByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(onTierUpgraded).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      (changeStorageTierCall!.body as Record<string, unknown>).storage_tier,
+    ).toBe("s");
+    // A resize hands off to the takeover — no credit-bundle toast.
+    expect(toastSuccessCalls).not.toContain("Credit bundle updated.");
   });
 
   test("a cancelling Pro sub's recommended upgrade stays on the manage path", async () => {

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -476,7 +476,6 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
       ? "upgrade"
       : "switch";
 
-  const currentCopy = getPlanTierCopy(currentTier);
   const isFreePlan = currentPlan.id === "base";
   // Chips render only for a paid plan whose stock package specs are known.
   // Free shows a minimal centered card (no chips); a clean pin absent from the
@@ -487,10 +486,6 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
       ? (packages.find((p) => p.key === currentKey) ?? null)
       : null;
   const currentSpecs = currentPackage ? packageSpecs(currentPackage) : null;
-  // Tagline shows for a KNOWN plan (free, or a clean stock pin); hidden for a
-  // Custom/unknown sub whose real plan can't be named. (Note: this is gated on
-  // "known plan", NOT on having chips — free has no chips but a real tagline.)
-  const isKnownCurrentPlan = isFreePlan || isCleanPin(subscription.package);
 
   return (
     <Card padding="md">
@@ -531,24 +526,17 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
             {display.actionLabel}
           </Button>
         </div>
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-stretch">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-stretch">
           <PlanSpecCard
-            tone="light"
             tierKey={currentTier}
             name={planName}
             nameTestId="plan-card-name"
             className="lg:flex-[3]"
-            centered={isFreePlan}
             tag={
               <Tag className="bg-[var(--feed-digest-weak)] text-[var(--content-default)]">
-                Your Current Plan
+                Current Plan
               </Tag>
             }
-            // The tagline follows "known plan" (free, or a clean stock pin), not
-            // "has chips": free is centered with no chips but still shows its
-            // real tagline, while a Custom/unknown sub — whose real plan can't be
-            // named — hides it to avoid mislabeling a paid sub with stock copy.
-            tagline={isKnownCurrentPlan ? currentCopy?.tagline : undefined}
             specs={currentSpecs}
           />
           <RecommendedUpgrade

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -329,6 +329,15 @@ function RecommendedUpgrade({
     if (changeTiersPending || !currentReady) {
       return;
     }
+    // `currentReady` also flips true when the current-tier read settles with an
+    // error or a missing storage tier, leaving `customInitialSelection` null.
+    // Opening the configurator unseeded would let a submit diff the user's
+    // selections against null current tiers and overwrite tiers they already
+    // hold, so route to manage (which reads tiers independently) instead.
+    if (customInitialSelection == null) {
+      onManage();
+      return;
+    }
     setCustomPlanOpen(true);
   };
   // Disable only when the modal-open path is the live one — a switch-ineligible

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -1,6 +1,6 @@
-import { ArrowUp, Loader2, Sparkles } from "lucide-react";
+import { Loader2 } from "lucide-react";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { useNavigate } from "react-router";
 
@@ -13,14 +13,17 @@ import {
   type ProPackage,
   type SwitchRelation,
 } from "@/domains/settings/billing/package-types";
+import { PlanPromoCard } from "@/domains/settings/billing/plan-promo-card";
 import { useChangePackage } from "@/domains/settings/billing/use-change-package";
+import { useChangeTiers } from "@/domains/settings/billing/use-change-tiers";
+import {
+  CustomPlanModal,
+  type CustomPlanSeed,
+  type CustomPlanSelection,
+} from "@/domains/settings/billing/plans/custom-plan-modal";
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
-import {
-  machineLabel,
-  packageSpecs,
-  type PlanSpec,
-} from "@/domains/settings/billing/plan-spec";
+import { packageSpecs } from "@/domains/settings/billing/plan-spec";
 import { PlanSpecCard } from "@/domains/settings/billing/plan-spec-card";
 import { useCheckoutDismissRefresh } from "@/domains/settings/billing/use-checkout-dismiss-refresh";
 import {
@@ -99,6 +102,12 @@ function PlanHeading() {
 
 interface RecommendedUpgradeProps {
   packages: ProPackage[];
+  /**
+   * The live Pro plan from the catalog, supplying the machine/storage/credit
+   * tiers the `CustomPlanModal` configures. Undefined only when the Pro plan is
+   * absent from the catalog — in which case there is no customize path to offer.
+   */
+  proPlan: ProPlan | undefined;
   currentKey: string | null;
   /**
    * Whether the org already has a Pro subscription. Pro users change their
@@ -115,26 +124,29 @@ interface RecommendedUpgradeProps {
    */
   canChangePackage: boolean;
   /**
-   * How the target package relates to the current sub — drives the confirm
-   * copy. A clean pin's next package is an "upgrade"; a customized or unpinned
-   * (Custom) sub gets the direction-neutral "switch".
+   * How the target package relates to the current sub. A clean pin's next
+   * package is an "upgrade" (the promo "Upgrade to X" variant); a customized or
+   * unpinned (Custom) sub gets "switch", which routes to the "Create a custom
+   * plan" variant instead.
    */
   relation: SwitchRelation;
   /**
    * Manage-path delegate (AdjustPlanModal). Handles a cancelling or
-   * non-entitlement Pro sub that the change-package flow cannot switch, and the
-   * empty-catalog fallback.
+   * non-entitlement Pro sub that the change-package/change-tier flows cannot
+   * act on.
    */
   onManage: () => void;
   /**
    * Opens the provisioning takeover (resize modal) after a Pro user's in-place
-   * package change succeeds — the same signal the tier-change flow raises.
+   * package or tier change succeeds — the same signal the tier-change flow
+   * raises.
    */
   onTierUpgraded?: () => void;
 }
 
 function RecommendedUpgrade({
   packages,
+  proPlan,
   currentKey,
   isProUser,
   canChangePackage,
@@ -147,51 +159,65 @@ function RecommendedUpgrade({
     organizationsBillingSubscriptionUpgradeCreateMutation(),
   );
   const { changePackage, isPending: changePending } = useChangePackage();
+  // The customize variant edits the Pro sub's tiers in place; only enable the
+  // hook's org-scoped reads for a Pro sub (a base user never sees that variant).
+  const {
+    changeTiers,
+    isPending: changeTiersPending,
+    current,
+    currentReady,
+  } = useChangeTiers({ enabled: isProUser });
   const [pending, setPending] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [customPlanOpen, setCustomPlanOpen] = useState(false);
   // Native iOS keeps Checkout inside an in-app sheet; refetch when it closes.
   useCheckoutDismissRefresh();
 
-  const recommended = nextPackageUp(packages, currentKey);
-  if (!recommended) {
-    return null;
-  }
+  // Seed the custom-plan modal with the Pro sub's current tiers so an unrelated
+  // edit doesn't force re-picking — and dropping — a dimension the user still
+  // holds. Null until the current tiers load (mirrors plans-page).
+  const customInitialSelection = useMemo<CustomPlanSeed | null>(() => {
+    if (!isProUser || current.storageTier == null) {
+      return null;
+    }
+    // `machineTier` may be null for a baseline (Small) package — the modal
+    // seeds storage/credit and leaves the machine picker empty in that case.
+    return {
+      machineTier: current.machineTier,
+      storageTier: current.storageTier,
+      creditTier: current.creditTier,
+    };
+  }, [isProUser, current.machineTier, current.storageTier, current.creditTier]);
 
-  const currentPackage = currentKey
-    ? (packages.find((p) => p.key === currentKey) ?? null)
-    : null;
-  // "a stronger machine" only holds when the recommended tier's machine size
-  // actually steps up. Free→Mighty stays on the Small baseline (machine_size
-  // null), so only credits and storage increase there — drop the machine clause.
-  const machineUpgrades =
-    machineLabel(currentPackage) !== machineLabel(recommended);
-  const summarySpecs: PlanSpec[] = [
-    {
-      icon: ArrowUp,
-      label: machineUpgrades
-        ? "more credits, storage, and a stronger machine"
-        : "more credits and storage",
-      multiline: true,
-    },
-  ];
-  // A Custom (customized or unpinned) sub's real tiers can diverge from any
-  // stock package, so a stock price delta could misstate the change; the neutral
-  // "switch" relation offers the named plan by itself.
-  const isNeutralSwitch = relation === "switch";
-  // Keep the CTA short ("Upgrade") so it sits inline in the card header beside
-  // the plan name, matching the mock. A longer label ("Upgrade for $X/mo more")
-  // overflows the header and wraps onto its own line below the name. The value
-  // prop is the summary chip below, and the prorated charge is confirmed in the
-  // switch dialog.
-  const upgradeLabel = isNeutralSwitch
-    ? `Switch to ${recommended.name}`
-    : "Upgrade";
+  const recommended = nextPackageUp(packages, currentKey);
+  const hasCatalog = packages.length > 0;
+
+  // Upgrade variant: base users and Pro clean pins with a stronger package to
+  // step up to. A neutral "switch" (customized/unpinned sub) is never an
+  // upgrade — it routes to the customize variant below instead.
+  const showUpgrade = recommended != null && relation !== "switch";
+  // Customize variant: a Pro sub whose tiers can diverge from stock (customized
+  // or unpinned, i.e. relation "switch"), or a clean pin already on the top
+  // catalog package (no package left to upgrade to). Both open the new
+  // CustomPlanModal. Requires a live catalog — with the flag off there are no
+  // tiers to configure.
+  const showCustomize =
+    isProUser &&
+    hasCatalog &&
+    (relation === "switch" ||
+      (recommended == null &&
+        currentKey != null &&
+        packages.some((p) => p.key === currentKey)));
+
   const isPending = pending || upgradeMutation.isPending || changePending;
 
   // Pro users change their package in place: confirm the prorated charge, then
   // call change-package and hand off to the resize takeover on success. Base
   // users go through the Stripe-checkout path instead.
   const handleConfirmChange = async () => {
+    if (!recommended) {
+      return;
+    }
     const result = await changePackage(recommended.key);
     if (!result) {
       // The hook already toasted; leave the dialog open so the user can
@@ -209,6 +235,9 @@ function RecommendedUpgrade({
   };
 
   const handleUpgrade = async () => {
+    if (!recommended) {
+      return;
+    }
     // Any switch-eligible Pro sub (a clean pin, a customized pin, or an
     // unpinned Custom sub) can be one-click package-switched; a cancelling or
     // non-entitlement Pro sub stays on the manage path.
@@ -265,52 +294,98 @@ function RecommendedUpgrade({
     }
   };
 
-  const recommendedCopy = getPlanTierCopy(recommended.key);
-  const upgradeButton = (
-    <Button
-      variant="primary"
-      className="shrink-0"
-      onClick={handleUpgrade}
-      disabled={isPending}
-      leftIcon={
-        isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined
-      }
-      data-testid="recommended-upgrade-button"
-    >
-      {upgradeLabel}
-    </Button>
-  );
-  return (
-    <>
-      <PlanSpecCard
-        tone="dark"
-        tierKey={recommended.key}
-        name={recommended.name}
-        className="lg:flex-[2]"
-        tag={
-          <Tag
-            className="bg-[var(--feed-digest-weak)] text-[var(--credits-accent)]"
-            leftIcon={
-              <Sparkles className="h-3 w-3 text-[var(--credits-accent)]" />
-            }
-          >
-            {isNeutralSwitch ? "Switch plan" : "Recommended"}
-          </Tag>
-        }
-        tagline={recommendedCopy?.tagline}
-        specs={isNeutralSwitch ? null : summarySpecs}
-        action={upgradeButton}
-      />
-      <PackageSwitchConfirmModal
-        open={confirmOpen}
-        relation={relation}
-        packageName={recommended.name}
-        pending={isPending}
-        onConfirm={() => void handleConfirmChange()}
-        onCancel={() => setConfirmOpen(false)}
-      />
-    </>
-  );
+  // Active Pro orgs edit their tiers in place via the change-tier endpoints,
+  // mirroring AdjustPlanModal's billing-page semantics (not plans-page's). The
+  // billing-page resize takeover is credit-agnostic — `onTierUpgraded` is
+  // argument-less and opens a resize-only takeover with no credit prop — so a
+  // credit-only change must toast instead of popping a blank takeover.
+  const applyCustomTierChange = async (selection: CustomPlanSelection) => {
+    const result = await changeTiers(selection);
+    if (!result) {
+      // The hook toasted; keep the modal open so the user can retry.
+      return;
+    }
+    setCustomPlanOpen(false);
+    // Only a real machine/storage resize hands off to the takeover; a
+    // credit-only change toasts, like AdjustPlanModal.
+    if (result.needsResize) {
+      onTierUpgraded?.();
+    } else {
+      toast.success(
+        result.creditChanged ? "Credit bundle updated." : "Plan updated.",
+      );
+    }
+  };
+
+  // The customize CTA opens the configurator; a switch-ineligible sub (cancelling
+  // or non-entitlement status) falls back to the manage path, like the upgrade
+  // CTA. Guard the open like plans-page's `handleConfigure`: hold until the
+  // current tiers load and no tier change is in flight.
+  const handleCustomize = () => {
+    if (!canChangePackage) {
+      onManage();
+      return;
+    }
+    if (changeTiersPending || !currentReady) {
+      return;
+    }
+    setCustomPlanOpen(true);
+  };
+  // Disable only when the modal-open path is the live one — a switch-ineligible
+  // sub keeps the CTA enabled so it can reach the manage fallback.
+  const customizeDisabled =
+    canChangePackage && (changeTiersPending || !currentReady);
+
+  if (showUpgrade) {
+    return (
+      <>
+        <PlanPromoCard
+          className="lg:flex-[2]"
+          title={`Upgrade to ${recommended.name}`}
+          blurb={getPlanTierCopy(recommended.key)?.upgradeBlurb}
+          ctaLabel="Upgrade"
+          ctaTestId="recommended-upgrade-button"
+          pending={isPending}
+          onCtaClick={() => void handleUpgrade()}
+        />
+        <PackageSwitchConfirmModal
+          open={confirmOpen}
+          relation={relation}
+          packageName={recommended.name}
+          pending={isPending}
+          onConfirm={() => void handleConfirmChange()}
+          onCancel={() => setConfirmOpen(false)}
+        />
+      </>
+    );
+  }
+
+  if (showCustomize && proPlan) {
+    return (
+      <>
+        <PlanPromoCard
+          className="lg:flex-[2]"
+          title="Create a custom plan"
+          ctaLabel="Customize"
+          ctaTestId="recommended-customize-button"
+          pending={changeTiersPending}
+          disabled={customizeDisabled}
+          onCtaClick={handleCustomize}
+        />
+        <CustomPlanModal
+          open={customPlanOpen}
+          proPlan={proPlan}
+          pending={changeTiersPending}
+          currentStorageGib={current.storageGib}
+          initialSelection={customInitialSelection}
+          onClose={() => setCustomPlanOpen(false)}
+          onContinue={(selection) => void applyCustomTierChange(selection)}
+        />
+      </>
+    );
+  }
+
+  return null;
 }
 
 export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
@@ -478,6 +553,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
           />
           <RecommendedUpgrade
             packages={packages}
+            proPlan={proPlan}
             currentKey={currentKey}
             isProUser={currentPlan.id !== "base"}
             canChangePackage={canChangePackage}

--- a/clients/web/src/utils/avatar-svg-compositor.test.ts
+++ b/clients/web/src/utils/avatar-svg-compositor.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for the trait→SVG compositor, focused on the optional eye style.
+ * Plan-tier avatars render body-only (eyeless); every other consumer passes a
+ * real eye style and must keep its eyes. These assertions lock in both paths:
+ * an absent eye style emits exactly one `<path>` (the body) and the body path
+ * stays byte-identical whether or not eyes are drawn.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { CharacterComponents } from "@/types/avatar";
+import { composeSvg } from "@/utils/avatar-svg-compositor";
+
+const components: CharacterComponents = {
+  bodyShapes: [
+    {
+      id: "blob",
+      viewBox: { width: 100, height: 100 },
+      faceCenter: { x: 50, y: 50 },
+      svgPath: "M0 0h100v100H0z",
+    },
+  ],
+  eyeStyles: [
+    {
+      id: "grumpy",
+      sourceViewBox: { width: 40, height: 40 },
+      eyeCenter: { x: 20, y: 20 },
+      paths: [
+        { svgPath: "M10 10h5v5h-5z", color: "#000" },
+        { svgPath: "M25 10h5v5h-5z", color: "#000" },
+      ],
+    },
+  ],
+  colors: [{ id: "green", hex: "#0f0" }],
+  faceCenterOverrides: [],
+};
+
+const countPaths = (svg: string): number =>
+  (svg.match(/<path\b/g) ?? []).length;
+
+describe("composeSvg eye style handling", () => {
+  test("emits a body path plus one path per eye path when an eye style is given", () => {
+    const svg = composeSvg(components, "blob", "grumpy", "green", 64);
+    // 1 body + 2 eye paths.
+    expect(countPaths(svg)).toBe(3);
+  });
+
+  test("emits only the body path when the eye style is null", () => {
+    const svg = composeSvg(components, "blob", null, "green", 64);
+    expect(countPaths(svg)).toBe(1);
+    expect(svg).toContain(components.bodyShapes[0]!.svgPath);
+    // No eye path made it into the output.
+    expect(svg).not.toContain(components.eyeStyles[0]!.paths[0]!.svgPath);
+  });
+
+  test("emits only the body path when the eye style is omitted (undefined)", () => {
+    const svg = composeSvg(components, "blob", undefined, "green", 64);
+    expect(countPaths(svg)).toBe(1);
+  });
+
+  test("keeps the body path byte-identical whether or not eyes are drawn", () => {
+    const withEyes = composeSvg(components, "blob", "grumpy", "green", 64);
+    const bodyOnly = composeSvg(components, "blob", null, "green", 64);
+    const bodyPath = bodyOnly.replace(
+      /^<svg[^>]*>|<\/svg>$/g,
+      "",
+    );
+    // The eyed SVG contains exactly the same body path element.
+    expect(withEyes).toContain(bodyPath);
+  });
+
+  test("still throws for a present-but-unknown eye style id", () => {
+    expect(() => composeSvg(components, "blob", "nope", "green", 64)).toThrow(
+      'Unknown eye style: "nope"',
+    );
+  });
+});

--- a/clients/web/src/utils/avatar-svg-compositor.ts
+++ b/clients/web/src/utils/avatar-svg-compositor.ts
@@ -11,6 +11,27 @@ export interface AvatarTransforms {
 }
 
 /**
+ * Compute the body group's scale and translation for the target size. Shared by
+ * {@link computeTransforms} (which layers the eye math on top) and the eyeless
+ * body-only path so both derive the body matrix from one formula.
+ */
+function computeBodyPlacement(
+  bodyShape: BodyShapeDefinition,
+  size: number,
+): { bodyScale: number; bodyTx: number; bodyTy: number } {
+  const bodyVB = bodyShape.viewBox;
+  const bodyScale = Math.min(size / bodyVB.width, size / bodyVB.height);
+  const bodyTx = (size - bodyVB.width * bodyScale) / 2;
+  const bodyTy = (size - bodyVB.height * bodyScale) / 2;
+  return { bodyScale, bodyTx, bodyTy };
+}
+
+function computeBodyTransform(bodyShape: BodyShapeDefinition, size: number): string {
+  const { bodyScale, bodyTx, bodyTy } = computeBodyPlacement(bodyShape, size);
+  return `matrix(${bodyScale},0,0,${bodyScale},${bodyTx},${bodyTy})`;
+}
+
+/**
  * Compute the SVG transform strings for body and eye groups.
  */
 export function computeTransforms(
@@ -25,9 +46,7 @@ export function computeTransforms(
   const faceCenter = override ? override.faceCenter : bodyShape.faceCenter;
 
   const bodyVB = bodyShape.viewBox;
-  const bodyScale = Math.min(size / bodyVB.width, size / bodyVB.height);
-  const bodyTx = (size - bodyVB.width * bodyScale) / 2;
-  const bodyTy = (size - bodyVB.height * bodyScale) / 2;
+  const { bodyScale, bodyTx, bodyTy } = computeBodyPlacement(bodyShape, size);
 
   const eyeVB = eyeStyle.sourceViewBox;
   const remapScale = Math.min(
@@ -48,7 +67,9 @@ export function computeTransforms(
 }
 
 /**
- * Resolve the active definitions from components + trait IDs.
+ * Resolve the active definitions from components + trait IDs. When `eyeStyleId`
+ * is absent (null/undefined) the eye style is left unresolved (body-only
+ * avatars); a present-but-unknown id still throws, as before.
  */
 export function resolveDefinitions(
   components: CharacterComponents,
@@ -59,11 +80,34 @@ export function resolveDefinitions(
   bodyShape: BodyShapeDefinition;
   eyeStyle: EyeStyleDefinition;
   color: ColorDefinition;
+};
+export function resolveDefinitions(
+  components: CharacterComponents,
+  bodyShapeId: string,
+  eyeStyleId: string | null | undefined,
+  colorId: string,
+): {
+  bodyShape: BodyShapeDefinition;
+  eyeStyle: EyeStyleDefinition | undefined;
+  color: ColorDefinition;
+};
+export function resolveDefinitions(
+  components: CharacterComponents,
+  bodyShapeId: string,
+  eyeStyleId: string | null | undefined,
+  colorId: string,
+): {
+  bodyShape: BodyShapeDefinition;
+  eyeStyle: EyeStyleDefinition | undefined;
+  color: ColorDefinition;
 } {
   const bodyShape = components.bodyShapes.find((b) => b.id === bodyShapeId);
   if (!bodyShape) throw new Error(`Unknown body shape: "${bodyShapeId}"`);
-  const eyeStyle = components.eyeStyles.find((e) => e.id === eyeStyleId);
-  if (!eyeStyle) throw new Error(`Unknown eye style: "${eyeStyleId}"`);
+  let eyeStyle: EyeStyleDefinition | undefined;
+  if (eyeStyleId != null) {
+    eyeStyle = components.eyeStyles.find((e) => e.id === eyeStyleId);
+    if (!eyeStyle) throw new Error(`Unknown eye style: "${eyeStyleId}"`);
+  }
   const color = components.colors.find((c) => c.id === colorId);
   if (!color) throw new Error(`Unknown color: "${colorId}"`);
   return { bodyShape, eyeStyle, color };
@@ -80,7 +124,7 @@ function escapeAttr(s: string): string {
 export function composeSvg(
   components: CharacterComponents,
   bodyShapeId: string,
-  eyeStyleId: string,
+  eyeStyleId: string | null | undefined,
   colorId: string,
   size: number = 512,
 ): string {
@@ -95,11 +139,18 @@ export function composeSvg(
 
 export function composeSvgFromDefinitions(
   bodyShape: BodyShapeDefinition,
-  eyeStyle: EyeStyleDefinition,
+  eyeStyle: EyeStyleDefinition | null | undefined,
   color: ColorDefinition,
   components: CharacterComponents,
   size: number = 512,
 ): string {
+  // Body-only (eyeless) avatar: skip the eye-transform math and emit no eye paths.
+  if (!eyeStyle) {
+    const bodyTransform = computeBodyTransform(bodyShape, size);
+    const bodyPath = `<path d="${escapeAttr(bodyShape.svgPath)}" fill="${escapeAttr(color.hex)}" transform="${bodyTransform}"/>`;
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">${bodyPath}</svg>`;
+  }
+
   const { bodyTransform, eyeTransform } = computeTransforms(bodyShape, eyeStyle, components, size);
 
   const bodyPath = `<path d="${escapeAttr(bodyShape.svgPath)}" fill="${escapeAttr(color.hex)}" transform="${bodyTransform}"/>`;


### PR DESCRIPTION
## Summary
Redesigns the billing settings **Plan** section to match the new Figma mocks:
- **Current-plan card** is now fully centered — eyeless avatar + name + "Current Plan" tag between two dividers, with the spec chips centered beneath. The free variant is just the centered header row (no dividers/chips).
- **Recommended card** becomes a simpler dark promo card: "Upgrade to {plan}" + a per-tier one-line blurb + an "Upgrade" button (no avatar/tag/tagline/chips). CTA behavior is unchanged (Stripe checkout for base users; in-place `PackageSwitchConfirmModal` → change-package for Pro clean pins; `onManage` fallback for ineligible subs).
- **Top-tier (ultra) / customized / legacy Pro subs** now get a "Create a custom plan" / **Customize** card that opens the new `CustomPlanModal` (not `AdjustPlanModal`). Previously ultra showed no recommended card and custom subs showed "Switch to X".
- **Plan-tier avatars render without eyes** everywhere they appear as plan-tier creatures (billing cards + plans-page pro columns). Non-plan avatars (chat/subagents/onboarding) keep their eyes.

## Self-review result
PASS — all four review passes (external feedback, plan faithfulness, repo integration, slop audit) passed. One real minor finding (a misleading `TIER_TRAITS.eyeStyle` comment) was fixed in a follow-up commit. Codex also caught and I fixed a real credit-only bug during per-PR review (see PR #39098).

## PRs merged into this feature branch
- #39094 — render plan-tier avatars without eyes
- #39090 — add dark `PlanPromoCard` and per-tier upgrade blurbs
- #39098 — promo-style recommended card + custom-plan path for top-tier/custom subs
- #39108 — centered current-plan card layout
- #39113 — fix: correct the misleading `TIER_TRAITS.eyeStyle` comment (self-review remediation)

## Notes
- **Between-cards gap is 8px** (`gap-2`) to match this mock; this intentionally reverts the earlier 12px tweak, since the redesigned light/dark cards are visually distinct.
- **"Current Plan" tag background** reuses the pre-existing `--feed-digest-weak` token (mint); the mock shows a periwinkle `#CEDAEC`. Left as-is (pre-existing styling) — easy to swap if you want a closer match.
- Ultra upgrade blurb: "$115 credits, 2x storage, more power, and email." (per your input).

Part of plan: plan-section-promo-cards.md