### PR TITLE
fix(web): pin channel-access gate to 0.10.8, where the routes actually shipped

### DIFF
--- a/clients/web/src/lib/backwards-compat/channel-access-controls.test.ts
+++ b/clients/web/src/lib/backwards-compat/channel-access-controls.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { renderHook } from "@testing-library/react";
+
+import { useSupportsChannelAccessControls } from "@/lib/backwards-compat/channel-access-controls";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+function setVersion(version: string | null) {
+  useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+}
+
+beforeEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+// The channel-permission-overrides list/set/delete routes first shipped in
+// 0.10.8 (v0.10.7's gateway index has zero occurrences of the handler). A
+// 0.10.7 assistant that passed this gate would render the pickers and then 404
+// the route that isn't there — the dead disabled state. `false` = render the
+// read-only channel list without access controls. Exhaustive semver semantics
+// (pre-release handling, unparseable versions) live in `utils.test.ts`.
+describe("useSupportsChannelAccessControls", () => {
+  test("false when version is unknown", () => {
+    setVersion(null);
+    const { result } = renderHook(() => useSupportsChannelAccessControls());
+    expect(result.current).toBe(false);
+  });
+
+  test("false on 0.10.7 — the route isn't there yet (guards the off-by-one)", () => {
+    setVersion("0.10.7");
+    const { result } = renderHook(() => useSupportsChannelAccessControls());
+    expect(result.current).toBe(false);
+  });
+
+  test("true on 0.10.8+, the first release carrying the routes", () => {
+    setVersion("0.10.8");
+    const { result } = renderHook(() => useSupportsChannelAccessControls());
+    expect(result.current).toBe(true);
+  });
+
+  test("true for RC builds of the cutover patch", () => {
+    setVersion("0.10.8-rc.1");
+    const { result } = renderHook(() => useSupportsChannelAccessControls());
+    expect(result.current).toBe(true);
+  });
+});

--- a/clients/web/src/lib/backwards-compat/channel-access-controls.ts
+++ b/clients/web/src/lib/backwards-compat/channel-access-controls.ts
@@ -3,13 +3,14 @@
  * Channels tab (tier badges, the segmented picker, the legend card).
  *
  * The surface requires the gateway's channel-permission-overrides
- * list/set/delete routes, which shipped with 0.10.7 — the pinned version
- * below. The web bundle always serves latest while gateways update on the
- * user's schedule, so on an older assistant the requests 404 and the
- * panel would render a dead error state with a permanently disabled
- * picker. When unsupported, the channel list renders without access
- * controls instead (read-path degrade); channels remain visible and the
- * rest of the tab works.
+ * list/set/delete routes, which shipped in 0.10.8 (`git tag --contains` the
+ * route commit — v0.10.7 has zero occurrences of the handler, v0.10.8 has
+ * them) — the pinned version below. The web bundle always serves latest while
+ * gateways update on the user's schedule, so on an older assistant the
+ * requests 404 and the panel would render a dead error state with a
+ * permanently disabled picker. When unsupported, the channel list renders
+ * without access controls instead (read-path degrade); channels remain
+ * visible and the rest of the tab works.
  *
  * The read-only `/resolve` operation behind the "{Tier} • default"
  * badges ships after 0.10.7 and degrades on its own: while resolve is
@@ -24,7 +25,7 @@
  */
 import { useAssistantSupports } from "./utils";
 
-export const MIN_VERSION = "0.10.7";
+export const MIN_VERSION = "0.10.8";
 
 /** Render-path gate for the Channels tab's Assistant Access controls. */
 export function useSupportsChannelAccessControls(): boolean {


### PR DESCRIPTION
## Prompt / plan
While diagnosing why the per-channel Assistant Access pickers render but then sit permanently disabled on some assistants, found an off-by-one in the version gate.

The Channels tab's access controls gate on the gateway's `channel-permission-overrides` list/set/delete routes via `MIN_VERSION`. It was pinned to **0.10.7**, but those routes first shipped in **0.10.8**:
- `git tag --contains` the wiring commit (`c77b2ef`) → first release is **v0.10.8**.
- `v0.10.7`'s `gateway/src/index.ts` has **0** occurrences of `handleChannelPermissionOverridesList`; `v0.10.8` has **3**.

So an assistant on exactly **0.10.7** passed the gate, rendered the pickers, then 404'd the route that isn't there — a dead, permanently-disabled state. (The daemon serves that 404 because the request falls through the gateway's runtime-proxy catch-all; gateway-only routes like this one aren't on the daemon — which is why the daemon-served channels list loads fine while these pickers don't.)

Bump `MIN_VERSION` to `0.10.8` so a 0.10.7 assistant degrades to the read-only channel list (the gate's intended fallback) instead of broken pickers. Add a boundary test.

## Test plan
- New `channel-access-controls.test.ts`: `0.10.7` → false, `0.10.8` / `0.10.8-rc.1` → true, unknown → false. Passes.
- `bunx tsc --noEmit` + ESLint clean (pre-commit).

## Note — related but separate
This fixes the 0.10.7 boundary. A separately-observed case (assistant on `0.10.11-dev` still 404ing the route) is **not** this bug — it's an assistant/gateway version skew (the daemon updated, the gateway in front of it did not), which this gate can't detect because it reads the *assistant* version while the route lives in the *gateway*. Worth a follow-up look at the update path and/or gating on the gateway version for gateway-route features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeiZ9nRv2AdHtBCcGmCoJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeiZ9nRv2AdHtBCcGmCoJY)_