### PR TITLE
feat(web): make Vellum an image generation provider instead of a mode

### DIFF
--- a/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
@@ -157,11 +157,11 @@ describe("ImageGenerationCard — provider-only configuration", () => {
     expect(trigger("Image generation provider")).toBeTruthy();
   });
 
-  test("the provider picker offers Vellum and Gemini", () => {
+  test("the provider picker offers Vellum, Gemini and OpenAI", () => {
     renderCard();
 
     fireEvent.click(trigger("Image generation provider"));
-    expect(visibleOptions()).toEqual(["Vellum", "Gemini"]);
+    expect(visibleOptions()).toEqual(["Vellum", "Gemini", "OpenAI"]);
   });
 
   test("Vellum hides the key field, lists every model, and saves the pair", async () => {
@@ -251,7 +251,20 @@ describe("ImageGenerationCard — provider-only configuration", () => {
     expect(screen.queryByText("API Key")).toBeNull();
   });
 
-  test("an openai daemon config renders honestly and is not clobbered", async () => {
+  test("selecting OpenAI shows the openai key field and gpt models", async () => {
+    renderCard();
+
+    fireEvent.click(trigger("Image generation provider"));
+    selectOption("OpenAI");
+
+    expect(
+      screen.getByPlaceholderText("Enter your OpenAI API key"),
+    ).toBeTruthy();
+    fireEvent.click(trigger("Image generation model"));
+    expect(visibleOptions()).toEqual(["GPT Image 2"]);
+  });
+
+  test("an openai daemon config renders as the selected provider", async () => {
     daemonConfigData = {
       services: {
         "image-generation": { mode: "your-own", provider: "openai" },

--- a/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
@@ -82,7 +82,7 @@ let daemonSupportsVellumProvider = true;
 mock.module(
   "@/lib/backwards-compat/use-supports-image-gen-vellum-provider",
   () => ({
-    MIN_VERSION: "0.10.12",
+    MIN_VERSION: "0.10.13",
     supportsImageGenVellumProvider: () => daemonSupportsVellumProvider,
   }),
 );

--- a/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
@@ -278,6 +278,53 @@ describe("ImageGenerationCard — provider-only configuration", () => {
     });
   });
 
+  test("a daemon predating the vellum enum still gets explicit BYOK provider writes", async () => {
+    // Only "vellum" is unrepresentable on old daemons; gemini/openai are in
+    // the old enum, so a provider switch must not be dropped.
+    daemonSupportsVellumProvider = false;
+    renderCard();
+
+    fireEvent.click(trigger("Image generation provider"));
+    selectOption("Gemini");
+    const keyInput = screen.getByPlaceholderText("Enter your Gemini API key");
+    fireEvent.change(keyInput, { target: { value: "gm-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: {
+        "image-generation": { provider: "gemini", mode: "your-own" },
+      },
+    });
+  });
+
+  test("a stale stored model is reconciled against the provider before save", async () => {
+    // gpt-image-2 was selectable under the legacy managed toggle; under a
+    // gemini daemon config it must snap to a gemini model, not save a
+    // provider/model mismatch.
+    localStorage.setItem("vellum:ai:imageGenModel", "gpt-image-2");
+    daemonConfigData = {
+      services: {
+        "image-generation": { mode: "your-own", provider: "gemini" },
+      },
+    };
+    renderCard();
+
+    expect(trigger("Image generation model").textContent).toContain(
+      "Nano Banana 2",
+    );
+
+    const keyInput = screen.getByPlaceholderText("Enter your Gemini API key");
+    fireEvent.change(keyInput, { target: { value: "gm-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(modelPutCalls.length).toBe(1));
+    expect(modelPutCalls[0]!.body).toMatchObject({
+      modelId: "gemini-3.1-flash-image-preview",
+    });
+    expect(provisionedKeys).toEqual([{ provider: "gemini", key: "gm-secret" }]);
+  });
+
   test("a daemon predating the vellum provider gets the legacy managed write", async () => {
     // Old daemon schemas reject provider "vellum" outright; the Vellum
     // selection degrades to the legacy mode-only representation the read

--- a/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
@@ -1,0 +1,298 @@
+/**
+ * Tests for `ImageGenerationCard`'s provider-only configuration (the
+ * Managed / Your Own mode toggle is gone — Vellum is a provider):
+ *
+ *   1. No mode segmented-control renders; the picker offers Vellum and
+ *      Gemini.
+ *   2. Vellum needs no API key, lists every model, and saves as a
+ *      provider+mode pair for old-daemon compatibility.
+ *   3. Gemini gates on a key and lists only gemini models.
+ *   4. Legacy managed-mode daemon configs render as Vellum; an openai
+ *      daemon config renders honestly without being clobbered.
+ *
+ * The design-library Dropdown is real, driven via its combobox trigger like
+ * `web-search-card.test.tsx`.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+const ASSISTANT_ID = "asst-test";
+mock.module("@/assistant/use-active-assistant-id", () => ({
+  useActiveAssistantId: () => ASSISTANT_ID,
+}));
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { success: () => {}, error: () => {} },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => false,
+}));
+
+// Controllable daemon config; `initialData` makes it available synchronously
+// like a warm cache.
+let daemonConfigData: { services: Record<string, unknown> } = { services: {} };
+interface SdkCall {
+  path?: unknown;
+  body?: unknown;
+}
+const configPatchCalls: SdkCall[] = [];
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  configGetOptions: () => ({
+    queryKey: ["config-get-test"],
+    queryFn: () => Promise.resolve(daemonConfigData),
+    initialData: daemonConfigData,
+  }),
+  configGetQueryKey: () => ["config-get-test"],
+  configGetSetQueryData: () => {},
+  useConfigPatchMutation: () => ({
+    mutateAsync: (opts: SdkCall) => {
+      configPatchCalls.push(opts);
+      return Promise.resolve(daemonConfigData);
+    },
+  }),
+}));
+
+const modelPutCalls: SdkCall[] = [];
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  modelImagegenPut: (opts: SdkCall) => {
+    modelPutCalls.push(opts);
+    return Promise.resolve({ response: { ok: true, status: 200 } });
+  },
+}));
+
+const provisionedKeys: Array<{ provider: string; key: string }> = [];
+mock.module("@/domains/settings/ai/use-daemon-config", () => ({
+  useProvisionProviderKey: () => (provider: string, key: string) => {
+    provisionedKeys.push({ provider, key });
+    return Promise.resolve();
+  },
+}));
+
+// Version gate for `provider: "vellum"` — supported by default; the
+// old-daemon test flips it off.
+let daemonSupportsVellumProvider = true;
+mock.module(
+  "@/lib/backwards-compat/use-supports-image-gen-vellum-provider",
+  () => ({
+    MIN_VERSION: "0.10.12",
+    supportsImageGenVellumProvider: () => daemonSupportsVellumProvider,
+  }),
+);
+mock.module("@/lib/backwards-compat/utils", () => ({
+  whenAssistantVersionKnown: () => Promise.resolve(),
+}));
+
+const { ImageGenerationCard } =
+  await import("@/domains/settings/ai/image-generation-card");
+const { LS_IMAGE_GEN_PROVIDER } = await import("@/utils/local-settings-keys");
+
+function renderCard() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ImageGenerationCard />
+    </QueryClientProvider>,
+  );
+}
+
+function trigger(label: string): HTMLButtonElement {
+  const el = document.querySelector<HTMLButtonElement>(
+    `button[role="combobox"][aria-label="${label}"]`,
+  );
+  if (!el) {
+    throw new Error(`expected the "${label}" dropdown trigger`);
+  }
+  return el;
+}
+
+function visibleOptions(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).map((o) => o.textContent?.trim() ?? "");
+}
+
+/** Click an option in the already-open listbox (the trigger toggles). */
+function selectOption(label: string): void {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim() === label);
+  if (!option) {
+    throw new Error(
+      `expected option "${label}" — saw: ${visibleOptions().join(", ")}`,
+    );
+  }
+  fireEvent.click(option);
+}
+
+describe("ImageGenerationCard — provider-only configuration", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    configPatchCalls.length = 0;
+    modelPutCalls.length = 0;
+    provisionedKeys.length = 0;
+    daemonSupportsVellumProvider = true;
+    daemonConfigData = { services: {} };
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  test("no Managed / Your Own mode toggle renders", () => {
+    renderCard();
+
+    expect(screen.queryByText("Managed")).toBeNull();
+    expect(screen.queryByText("Your Own")).toBeNull();
+    expect(trigger("Image generation provider")).toBeTruthy();
+  });
+
+  test("the provider picker offers Vellum and Gemini", () => {
+    renderCard();
+
+    fireEvent.click(trigger("Image generation provider"));
+    expect(visibleOptions()).toEqual(["Vellum", "Gemini"]);
+  });
+
+  test("Vellum hides the key field, lists every model, and saves the pair", async () => {
+    renderCard();
+
+    fireEvent.click(trigger("Image generation provider"));
+    selectOption("Vellum");
+
+    expect(screen.queryByText("API Key")).toBeNull();
+    expect(
+      screen.getByText(/Image generation runs through your Vellum account/),
+    ).toBeTruthy();
+
+    fireEvent.click(trigger("Image generation model"));
+    expect(visibleOptions()).toEqual([
+      "Nano Banana 2",
+      "Nano Banana Pro",
+      "GPT Image 2",
+    ]);
+    selectOption("GPT Image 2");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    // Written as a pair so the save stays valid on daemons whose schema
+    // still couples provider "vellum" to mode "managed".
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: {
+        "image-generation": { provider: "vellum", mode: "managed" },
+      },
+    });
+    await waitFor(() => expect(modelPutCalls.length).toBe(1));
+    expect(modelPutCalls[0]!.body).toMatchObject({ modelId: "gpt-image-2" });
+    expect(provisionedKeys).toHaveLength(0);
+    expect(localStorage.getItem(LS_IMAGE_GEN_PROVIDER)).toBe("vellum");
+  });
+
+  test("Gemini lists only gemini models and snaps an off-list model", async () => {
+    localStorage.setItem("vellum:ai:imageGenModel", "gpt-image-2");
+    renderCard();
+
+    fireEvent.click(trigger("Image generation provider"));
+    selectOption("Gemini");
+
+    expect(screen.getByText("API Key")).toBeTruthy();
+    expect(
+      screen.getByPlaceholderText("Enter your Gemini API key"),
+    ).toBeTruthy();
+
+    fireEvent.click(trigger("Image generation model"));
+    expect(visibleOptions()).toEqual(["Nano Banana 2", "Nano Banana Pro"]);
+    // The stored gpt model is not servable by a Gemini key — snapped.
+    expect(trigger("Image generation model").textContent).toContain(
+      "Nano Banana 2",
+    );
+  });
+
+  test("Gemini saves provider, mode and the provisioned key", async () => {
+    renderCard();
+
+    fireEvent.click(trigger("Image generation provider"));
+    selectOption("Gemini");
+
+    const keyInput = screen.getByPlaceholderText("Enter your Gemini API key");
+    fireEvent.change(keyInput, { target: { value: "gm-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: {
+        "image-generation": { provider: "gemini", mode: "your-own" },
+      },
+    });
+    expect(provisionedKeys).toEqual([{ provider: "gemini", key: "gm-secret" }]);
+  });
+
+  // A config written by the legacy mode toggle marks managed via `mode`.
+  test("a legacy managed-mode daemon renders as Vellum", () => {
+    daemonConfigData = {
+      services: { "image-generation": { mode: "managed", provider: "gemini" } },
+    };
+    renderCard();
+
+    expect(trigger("Image generation provider").textContent).toContain(
+      "Vellum",
+    );
+    expect(screen.queryByText("API Key")).toBeNull();
+  });
+
+  test("an openai daemon config renders honestly and is not clobbered", async () => {
+    daemonConfigData = {
+      services: {
+        "image-generation": { mode: "your-own", provider: "openai" },
+      },
+    };
+    renderCard();
+
+    expect(trigger("Image generation provider").textContent).toContain(
+      "OpenAI",
+    );
+    expect(
+      screen.getByPlaceholderText("Enter your OpenAI API key"),
+    ).toBeTruthy();
+
+    fireEvent.click(trigger("Image generation model"));
+    expect(visibleOptions()).toEqual(["GPT Image 2"]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: {
+        "image-generation": { provider: "openai", mode: "your-own" },
+      },
+    });
+  });
+
+  test("a daemon predating the vellum provider gets the legacy managed write", async () => {
+    // Old daemon schemas reject provider "vellum" outright; the Vellum
+    // selection degrades to the legacy mode-only representation the read
+    // bridge renders as Vellum again.
+    daemonSupportsVellumProvider = false;
+    renderCard();
+
+    fireEvent.click(trigger("Image generation provider"));
+    selectOption("Vellum");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    const body = configPatchCalls[0]!.body as {
+      services: { "image-generation": Record<string, unknown> };
+    };
+    expect(body.services["image-generation"]).toEqual({ mode: "managed" });
+  });
+});

--- a/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
@@ -325,6 +325,36 @@ describe("ImageGenerationCard — provider-only configuration", () => {
     expect(provisionedKeys).toEqual([{ provider: "gemini", key: "gm-secret" }]);
   });
 
+  test("a stale stored model reconciles with no daemon config at all", async () => {
+    // The narrowest variant: no daemon data, provider falls back to the
+    // localStorage default (gemini) while the stored model is a gpt one.
+    // The derived reconciliation must still gate the save and the key
+    // provisioning — never a gemini provider with an openai model/key.
+    localStorage.setItem("vellum:ai:imageGenModel", "gpt-image-2");
+    daemonConfigData = { services: {} };
+    renderCard();
+
+    expect(trigger("Image generation provider").textContent).toContain(
+      "Gemini",
+    );
+    expect(trigger("Image generation model").textContent).toContain(
+      "Nano Banana 2",
+    );
+
+    const keyInput = screen.getByPlaceholderText("Enter your Gemini API key");
+    fireEvent.change(keyInput, { target: { value: "gm-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(modelPutCalls.length).toBe(1));
+    expect(modelPutCalls[0]!.body).toMatchObject({
+      modelId: "gemini-3.1-flash-image-preview",
+    });
+    expect(provisionedKeys).toEqual([{ provider: "gemini", key: "gm-secret" }]);
+    expect(localStorage.getItem("vellum:ai:imageGenModel")).toBe(
+      "gemini-3.1-flash-image-preview",
+    );
+  });
+
   test("a daemon predating the vellum provider gets the legacy managed write", async () => {
     // Old daemon schemas reject provider "vellum" outright; the Vellum
     // selection degrades to the legacy mode-only representation the read

--- a/clients/web/src/domains/settings/ai/image-generation-card.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.tsx
@@ -6,83 +6,162 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { captureError } from "@/lib/sentry/capture-error";
 
-import {
-    getLocalSetting,
-    setLocalSetting,
-} from "@/utils/local-settings";
+import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Input } from "@vellumai/design-library/components/input";
 import { toast } from "@vellumai/design-library/components/toast";
 
-import { LS_IMAGE_GEN_MODE, LS_IMAGE_GEN_MODEL } from "@/utils/local-settings-keys";
-import { AVAILABLE_IMAGE_GEN_MODELS, IMAGE_GEN_MODEL_DISPLAY_NAMES, providerForImageGenModel } from "@/lib/provider-catalogs";
-import { parseServiceMode } from "@/domains/settings/ai/utils";
-import type { ServiceMode } from "@/generated/daemon/types.gen";
+import {
+  LS_IMAGE_GEN_MODEL,
+  LS_IMAGE_GEN_PROVIDER,
+} from "@/utils/local-settings-keys";
+import {
+  IMAGE_GEN_PROVIDER_DISPLAY_NAMES,
+  IMAGE_GEN_PROVIDERS,
+  IMAGE_GEN_MODEL_DISPLAY_NAMES,
+  imageGenModelsForProvider,
+  providerForImageGenModel,
+} from "@/lib/provider-catalogs";
 
-import {
-  ServiceCard,
-} from "@/domains/settings/ai/shared-ui";
-import {
-  ResetButton,
-  SaveButton,
-} from "@/components/service-form-controls";
+import { ByoServiceCard } from "@/domains/settings/ai/shared-ui";
+import { ResetButton, SaveButton } from "@/components/service-form-controls";
 import { useProvisionProviderKey } from "@/domains/settings/ai/use-daemon-config";
-import { configGetOptions, configGetQueryKey, configGetSetQueryData, useConfigPatchMutation } from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+  configGetOptions,
+  configGetQueryKey,
+  configGetSetQueryData,
+  useConfigPatchMutation,
+} from "@/generated/daemon/@tanstack/react-query.gen";
 import { useQuery } from "@tanstack/react-query";
 import { useDraftOverride } from "@/hooks/use-draft-override";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { modelImagegenPut } from "@/generated/daemon/sdk.gen";
+import { supportsImageGenVellumProvider } from "@/lib/backwards-compat/use-supports-image-gen-vellum-provider";
+import { whenAssistantVersionKnown } from "@/lib/backwards-compat/utils";
+
+const DEFAULT_IMAGE_GEN_MODEL = "gemini-3.1-flash-image-preview";
 
 export function ImageGenerationCard() {
   const assistantId = useActiveAssistantId();
   const queryClient = useQueryClient();
+  const isOrgReady = useIsOrgReady();
 
   const { data: daemonConfig } = useQuery({
     ...configGetOptions({ path: { assistant_id: assistantId } }),
+    enabled: isOrgReady,
     staleTime: 30_000,
   });
 
   const configMutation = useConfigPatchMutation({
     onSuccess: (data) => {
-      configGetSetQueryData(queryClient, { path: { assistant_id: assistantId } }, data);
+      configGetSetQueryData(
+        queryClient,
+        { path: { assistant_id: assistantId } },
+        data,
+      );
     },
   });
   const provisionProviderKey = useProvisionProviderKey();
+
   // Server value derived from daemon config, falling back to localStorage.
   // Updates automatically when the cache refreshes.
-  const serverImageGenMode = useMemo<ServiceMode>(() => {
+  const serverProvider = useMemo((): string => {
     if (!daemonConfig) {
-      return parseServiceMode(getLocalSetting(LS_IMAGE_GEN_MODE, "your-own"), "your-own");
+      return getLocalSetting(LS_IMAGE_GEN_PROVIDER, "gemini");
     }
-    return parseServiceMode(
-      daemonConfig.services?.["image-generation"]?.mode ?? getLocalSetting(LS_IMAGE_GEN_MODE, "your-own"),
-      "your-own",
-    );
+    const svc = daemonConfig.services?.["image-generation"] as
+      { provider?: string; mode?: string } | undefined;
+    // A config written by the legacy mode toggle marks managed via `mode` —
+    // the daemon routes it to Vellum, so the card renders it as Vellum too.
+    if (svc?.mode === "managed") {
+      return "vellum";
+    }
+    return svc?.provider || getLocalSetting(LS_IMAGE_GEN_PROVIDER, "gemini");
   }, [daemonConfig]);
 
-  const [imageGenMode, setDraftImageGenMode] = useDraftOverride(serverImageGenMode);
+  const [provider, setDraftProvider] = useDraftOverride(serverProvider);
 
   const [imageGenModel, setImageGenModel] = useState(() =>
-    getLocalSetting(LS_IMAGE_GEN_MODEL, "gemini-3.1-flash-image-preview"),
+    getLocalSetting(LS_IMAGE_GEN_MODEL, DEFAULT_IMAGE_GEN_MODEL),
   );
   const [imageGenApiKey, setImageGenApiKey] = useState("");
   const [saving, setSaving] = useState(false);
 
+  // `openai` is a valid daemon value the picker does not offer: render it
+  // when the daemon reports it, but never nudge users onto it.
+  const providerOptions = useMemo(() => {
+    const ids: string[] =
+      provider === "openai"
+        ? [...IMAGE_GEN_PROVIDERS, "openai"]
+        : [...IMAGE_GEN_PROVIDERS];
+    return ids.map((id) => ({
+      value: id,
+      label: IMAGE_GEN_PROVIDER_DISPLAY_NAMES[id] ?? id,
+    }));
+  }, [provider]);
+
+  const modelOptions = useMemo(
+    () =>
+      imageGenModelsForProvider(provider).map((model) => ({
+        value: model,
+        label: IMAGE_GEN_MODEL_DISPLAY_NAMES[model] ?? model,
+      })),
+    [provider],
+  );
+
+  const requiresApiKey = provider === "gemini" || provider === "openai";
+
+  const handleProviderChange = useCallback(
+    (next: string) => {
+      setDraftProvider(next);
+      // Snap the model onto the new provider's list when it falls off it
+      // (e.g. GPT Image 2 is not servable by a Gemini key).
+      const models = imageGenModelsForProvider(next);
+      if (!models.includes(imageGenModel)) {
+        setImageGenModel(models[0] ?? DEFAULT_IMAGE_GEN_MODEL);
+      }
+    },
+    [setDraftProvider, imageGenModel],
+  );
+
   const handleSave = useCallback(async () => {
     setSaving(true);
     const trimmed = imageGenApiKey.trim();
-    const hasUserKey = imageGenMode === "your-own" && trimmed.length > 0;
+    const hasUserKey = requiresApiKey && trimmed.length > 0;
     try {
       if (hasUserKey) {
-        await provisionProviderKey(providerForImageGenModel(imageGenModel), trimmed);
+        await provisionProviderKey(
+          providerForImageGenModel(imageGenModel),
+          trimmed,
+        );
       }
-      await configMutation.mutateAsync({
-        path: { assistant_id: assistantId },
-        body: { services: { "image-generation": { mode: imageGenMode } } },
-      }).catch((error) => {
-        toast.error("Failed to update assistant configuration. Please try again.");
-        captureError(error, { context: "patch_daemon_config" });
-        throw error;
-      });
+      // The provider is written as a pair with `mode`: a stale
+      // `mode: "managed"` from the legacy toggle would win over a BYOK choice
+      // unless reset. Daemons older than the vellum enum value reject the
+      // provider outright, so for them a Vellum selection writes only the
+      // legacy managed mode — the read bridge renders that pair as Vellum.
+      await whenAssistantVersionKnown();
+      const imageGenService: {
+        provider?: string;
+        mode: "managed" | "your-own";
+      } = supportsImageGenVellumProvider()
+        ? {
+            provider,
+            mode: provider === "vellum" ? "managed" : "your-own",
+          }
+        : { mode: provider === "vellum" ? "managed" : "your-own" };
+      await configMutation
+        .mutateAsync({
+          path: { assistant_id: assistantId },
+          body: { services: { "image-generation": imageGenService } },
+        })
+        .catch((error) => {
+          toast.error(
+            "Failed to update assistant configuration. Please try again.",
+          );
+          captureError(error, { context: "patch_daemon_config" });
+          throw error;
+        });
       try {
         await modelImagegenPut({
           path: { assistant_id: assistantId },
@@ -90,7 +169,9 @@ export function ImageGenerationCard() {
           throwOnError: true,
         });
       } catch (error) {
-        toast.error("Failed to update image generation model. Please try again.");
+        toast.error(
+          "Failed to update image generation model. Please try again.",
+        );
         captureError(error, { context: "set_image_gen_model" });
         throw error;
       } finally {
@@ -104,7 +185,7 @@ export function ImageGenerationCard() {
     }
     setSaving(false);
     try {
-      setLocalSetting(LS_IMAGE_GEN_MODE, imageGenMode);
+      setLocalSetting(LS_IMAGE_GEN_PROVIDER, provider);
       setLocalSetting(LS_IMAGE_GEN_MODEL, imageGenModel);
       if (hasUserKey) {
         setImageGenApiKey("");
@@ -116,7 +197,8 @@ export function ImageGenerationCard() {
     }
   }, [
     imageGenApiKey,
-    imageGenMode,
+    provider,
+    requiresApiKey,
     imageGenModel,
     assistantId,
     configMutation,
@@ -126,74 +208,69 @@ export function ImageGenerationCard() {
 
   const handleReset = useCallback(() => {
     setImageGenApiKey("");
-    setImageGenModel("gemini-3.1-flash-image-preview");
-    setLocalSetting(LS_IMAGE_GEN_MODEL, "gemini-3.1-flash-image-preview");
+    setImageGenModel(DEFAULT_IMAGE_GEN_MODEL);
+    setLocalSetting(LS_IMAGE_GEN_MODEL, DEFAULT_IMAGE_GEN_MODEL);
   }, []);
 
   return (
-    <ServiceCard
+    <ByoServiceCard
       title="Image Generation"
       subtitle="Configure which model your assistant uses to generate images"
-      mode={imageGenMode}
-      onModeChange={(m) => setDraftImageGenMode(m)}
     >
-      {imageGenMode === "managed" ? (
-        <div className="space-y-3">
+      <div className="space-y-4">
+        <div className="space-y-1">
           <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            Active Model
+            Provider
           </label>
-          <div className="flex items-end gap-3">
-            <Dropdown
-              className="flex-1"
-              value={imageGenModel}
-              onChange={setImageGenModel}
-              options={AVAILABLE_IMAGE_GEN_MODELS.map((model) => ({
-                value: model,
-                label: IMAGE_GEN_MODEL_DISPLAY_NAMES[model] ?? model,
-              }))}
-            />
-            <SaveButton onClick={handleSave} disabled={saving} />
-            {saving && (
-              <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />
-            )}
-          </div>
+          <Dropdown
+            aria-label="Image generation provider"
+            value={provider}
+            onChange={handleProviderChange}
+            options={providerOptions}
+          />
         </div>
-      ) : (
-        <div className="space-y-4">
+
+        {provider === "vellum" && (
+          <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
+            Image generation runs through your Vellum account.
+          </p>
+        )}
+
+        {requiresApiKey && (
           <Input
             label="API Key"
             type="password"
             value={imageGenApiKey}
             onChange={(e) => setImageGenApiKey(e.target.value)}
             placeholder={
-              providerForImageGenModel(imageGenModel) === "openai"
+              provider === "openai"
                 ? "Enter your OpenAI API key"
                 : "Enter your Gemini API key"
             }
             fullWidth
           />
+        )}
 
-          <div className="space-y-1">
-            <label className="block text-body-small-default text-[var(--content-tertiary)]">
-              Active Model
-            </label>
-            <Dropdown
-              value={imageGenModel}
-              onChange={setImageGenModel}
-              options={AVAILABLE_IMAGE_GEN_MODELS.map((model) => ({
-                value: model,
-                label: IMAGE_GEN_MODEL_DISPLAY_NAMES[model] ?? model,
-              }))}
-            />
-          </div>
-
-          <div className="flex items-center gap-2">
-            <SaveButton onClick={handleSave} disabled={saving} />
-            {saving && <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />}
-            <ResetButton onClick={handleReset} />
-          </div>
+        <div className="space-y-1">
+          <label className="block text-body-small-default text-[var(--content-tertiary)]">
+            Active Model
+          </label>
+          <Dropdown
+            aria-label="Image generation model"
+            value={imageGenModel}
+            onChange={setImageGenModel}
+            options={modelOptions}
+          />
         </div>
-      )}
-    </ServiceCard>
+
+        <div className="flex items-center gap-2">
+          <SaveButton onClick={handleSave} disabled={saving} />
+          {saving && (
+            <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />
+          )}
+          {requiresApiKey && <ResetButton onClick={handleReset} />}
+        </div>
+      </div>
+    </ByoServiceCard>
   );
 }

--- a/clients/web/src/domains/settings/ai/image-generation-card.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.tsx
@@ -94,18 +94,10 @@ export function ImageGenerationCard() {
   const [imageGenApiKey, setImageGenApiKey] = useState("");
   const [saving, setSaving] = useState(false);
 
-  // `openai` is a valid daemon value the picker does not offer: render it
-  // when the daemon reports it, but never nudge users onto it.
-  const providerOptions = useMemo(() => {
-    const ids: string[] =
-      provider === "openai"
-        ? [...IMAGE_GEN_PROVIDERS, "openai"]
-        : [...IMAGE_GEN_PROVIDERS];
-    return ids.map((id) => ({
-      value: id,
-      label: IMAGE_GEN_PROVIDER_DISPLAY_NAMES[id] ?? id,
-    }));
-  }, [provider]);
+  const providerOptions = IMAGE_GEN_PROVIDERS.map((id) => ({
+    value: id,
+    label: IMAGE_GEN_PROVIDER_DISPLAY_NAMES[id] ?? id,
+  }));
 
   const modelOptions = useMemo(
     () =>

--- a/clients/web/src/domains/settings/ai/image-generation-card.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.tsx
@@ -84,6 +84,13 @@ export function ImageGenerationCard() {
   const [imageGenModel, setImageGenModel] = useState(() =>
     getLocalSetting(LS_IMAGE_GEN_MODEL, DEFAULT_IMAGE_GEN_MODEL),
   );
+  // Reconcile the stored model against the provider's list on every render,
+  // not just on a provider change — a stale stored model (e.g. gpt-image-2
+  // under a Gemini config) must never reach a save or a key provisioning.
+  const providerModels = imageGenModelsForProvider(provider);
+  const effectiveModel = providerModels.includes(imageGenModel)
+    ? imageGenModel
+    : (providerModels[0] ?? DEFAULT_IMAGE_GEN_MODEL);
   const [imageGenApiKey, setImageGenApiKey] = useState("");
   const [saving, setSaving] = useState(false);
 
@@ -111,18 +118,9 @@ export function ImageGenerationCard() {
 
   const requiresApiKey = provider === "gemini" || provider === "openai";
 
-  const handleProviderChange = useCallback(
-    (next: string) => {
-      setDraftProvider(next);
-      // Snap the model onto the new provider's list when it falls off it
-      // (e.g. GPT Image 2 is not servable by a Gemini key).
-      const models = imageGenModelsForProvider(next);
-      if (!models.includes(imageGenModel)) {
-        setImageGenModel(models[0] ?? DEFAULT_IMAGE_GEN_MODEL);
-      }
-    },
-    [setDraftProvider, imageGenModel],
-  );
+  // Model reconciliation is derived (`effectiveModel`), so a provider change
+  // needs no imperative snap.
+  const handleProviderChange = setDraftProvider;
 
   const handleSave = useCallback(async () => {
     setSaving(true);
@@ -131,25 +129,28 @@ export function ImageGenerationCard() {
     try {
       if (hasUserKey) {
         await provisionProviderKey(
-          providerForImageGenModel(imageGenModel),
+          providerForImageGenModel(effectiveModel),
           trimmed,
         );
       }
       // The provider is written as a pair with `mode`: a stale
       // `mode: "managed"` from the legacy toggle would win over a BYOK choice
-      // unless reset. Daemons older than the vellum enum value reject the
-      // provider outright, so for them a Vellum selection writes only the
-      // legacy managed mode — the read bridge renders that pair as Vellum.
+      // unless reset. Only the `vellum` value is unrepresentable on daemons
+      // older than its enum entry — for those a Vellum selection writes the
+      // legacy managed mode alone (the read bridge renders that pair as
+      // Vellum), while BYOK providers keep their explicit provider write.
       await whenAssistantVersionKnown();
+      const vellumUnsupported =
+        provider === "vellum" && !supportsImageGenVellumProvider();
       const imageGenService: {
         provider?: string;
         mode: "managed" | "your-own";
-      } = supportsImageGenVellumProvider()
-        ? {
+      } = vellumUnsupported
+        ? { mode: "managed" }
+        : {
             provider,
             mode: provider === "vellum" ? "managed" : "your-own",
-          }
-        : { mode: provider === "vellum" ? "managed" : "your-own" };
+          };
       await configMutation
         .mutateAsync({
           path: { assistant_id: assistantId },
@@ -165,7 +166,7 @@ export function ImageGenerationCard() {
       try {
         await modelImagegenPut({
           path: { assistant_id: assistantId },
-          body: { modelId: imageGenModel },
+          body: { modelId: effectiveModel },
           throwOnError: true,
         });
       } catch (error) {
@@ -186,7 +187,7 @@ export function ImageGenerationCard() {
     setSaving(false);
     try {
       setLocalSetting(LS_IMAGE_GEN_PROVIDER, provider);
-      setLocalSetting(LS_IMAGE_GEN_MODEL, imageGenModel);
+      setLocalSetting(LS_IMAGE_GEN_MODEL, effectiveModel);
       if (hasUserKey) {
         setImageGenApiKey("");
       }
@@ -199,7 +200,7 @@ export function ImageGenerationCard() {
     imageGenApiKey,
     provider,
     requiresApiKey,
-    imageGenModel,
+    effectiveModel,
     assistantId,
     configMutation,
     provisionProviderKey,
@@ -257,7 +258,7 @@ export function ImageGenerationCard() {
           </label>
           <Dropdown
             aria-label="Image generation model"
-            value={imageGenModel}
+            value={effectiveModel}
             onChange={setImageGenModel}
             options={modelOptions}
           />

--- a/clients/web/src/lib/backwards-compat/use-supports-image-gen-vellum-provider.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-image-gen-vellum-provider.ts
@@ -1,0 +1,30 @@
+/**
+ * Backwards-compat gate: `vellum` as an image-generation provider value.
+ *
+ * The web app always serves the latest bundle, but the assistant can be any
+ * locally-installed version. Daemons older than MIN_VERSION validate
+ * `services["image-generation"].provider` against an enum that has no
+ * `vellum` member, so writing it can make the daemon's next config reload
+ * reject or reset the image-generation section while the UI reports a
+ * successful save.
+ *
+ * On the `false` branch the card persists a Vellum selection the way the
+ * legacy Managed toggle did: `{ mode: "managed" }` with no provider. The
+ * legacy read bridge renders that config as Vellum again, so the choice
+ * round-trips.
+ *
+ * MIN_VERSION targets 0.10.12 — the first release whose image-generation
+ * config enum includes `vellum` (#39109).
+ */
+import { assistantSupports } from "./utils";
+
+export const MIN_VERSION = "0.10.12";
+
+/**
+ * Snapshot gate for the save path: whether the active assistant accepts
+ * `provider: "vellum"` in the image-generation config. Callers should
+ * `await whenAssistantVersionKnown()` before reading.
+ */
+export function supportsImageGenVellumProvider(): boolean {
+  return assistantSupports(MIN_VERSION);
+}

--- a/clients/web/src/lib/backwards-compat/use-supports-image-gen-vellum-provider.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-image-gen-vellum-provider.ts
@@ -13,12 +13,12 @@
  * legacy read bridge renders that config as Vellum again, so the choice
  * round-trips.
  *
- * MIN_VERSION targets 0.10.12 — the first release whose image-generation
- * config enum includes `vellum` (#39109).
+ * MIN_VERSION targets 0.10.13 — the first release whose image-generation
+ * config enum includes `vellum` (#39109 merged after the 0.10.12 cut).
  */
 import { assistantSupports } from "./utils";
 
-export const MIN_VERSION = "0.10.12";
+export const MIN_VERSION = "0.10.13";
 
 /**
  * Snapshot gate for the save path: whether the active assistant accepts

--- a/clients/web/src/lib/provider-catalogs.ts
+++ b/clients/web/src/lib/provider-catalogs.ts
@@ -226,11 +226,10 @@ export const IMAGE_GEN_MODEL_DISPLAY_NAMES: Record<string, string> = {
 
 /**
  * Image-generation providers offered by the settings card. `vellum` is the
- * managed option (no API key; billed to the Vellum account); `gemini` uses
- * the user's key. `openai` stays a valid daemon value but is not offered —
- * the card renders it read-only when a daemon reports it.
+ * managed option (no API key; billed to the Vellum account); `gemini` and
+ * `openai` use the user's key and list only the models that key can serve.
  */
-export const IMAGE_GEN_PROVIDERS = ["vellum", "gemini"] as const;
+export const IMAGE_GEN_PROVIDERS = ["vellum", "gemini", "openai"] as const;
 
 export const IMAGE_GEN_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   vellum: "Vellum",

--- a/clients/web/src/lib/provider-catalogs.ts
+++ b/clients/web/src/lib/provider-catalogs.ts
@@ -225,6 +225,34 @@ export const IMAGE_GEN_MODEL_DISPLAY_NAMES: Record<string, string> = {
 };
 
 /**
+ * Image-generation providers offered by the settings card. `vellum` is the
+ * managed option (no API key; billed to the Vellum account); `gemini` uses
+ * the user's key. `openai` stays a valid daemon value but is not offered —
+ * the card renders it read-only when a daemon reports it.
+ */
+export const IMAGE_GEN_PROVIDERS = ["vellum", "gemini"] as const;
+
+export const IMAGE_GEN_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  vellum: "Vellum",
+  gemini: "Gemini",
+  openai: "OpenAI",
+};
+
+/**
+ * Models selectable under a provider. Vellum spans both backends (the daemon
+ * derives the managed proxy from the model prefix); BYOK providers list only
+ * the models their key can serve.
+ */
+export function imageGenModelsForProvider(provider: string): string[] {
+  if (provider === "vellum") {
+    return [...AVAILABLE_IMAGE_GEN_MODELS];
+  }
+  return AVAILABLE_IMAGE_GEN_MODELS.filter(
+    (m) => providerForImageGenModel(m) === provider,
+  );
+}
+
+/**
  * Image-generation provider for a model id, by prefix. Mirrors the daemon's
  * `providerForImageModelPrefix` / `providerForModel` (`assistant/src/media/`):
  * `gpt-*` / `dall-e-*` → openai, `gemini-*` → gemini, otherwise gemini.

--- a/clients/web/src/utils/local-settings-keys.ts
+++ b/clients/web/src/utils/local-settings-keys.ts
@@ -6,7 +6,7 @@
  * constants as the key argument.
  */
 
-export const LS_IMAGE_GEN_MODE = "vellum:ai:imageGenMode";
+export const LS_IMAGE_GEN_PROVIDER = "vellum:ai:imageGenProvider";
 export const LS_IMAGE_GEN_MODEL = "vellum:ai:imageGenModel";
 export const LS_WEB_SEARCH_PROVIDER = "vellum:ai:webSearchProvider";
 export const LS_WEB_FETCH_PROVIDER = "vellum:ai:webFetchProvider";

--- a/clients/web/src/utils/storage-migration.test.ts
+++ b/clients/web/src/utils/storage-migration.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { migrateKey, migratePrefix, migrateValue, removeKey, runStorageMigrations } from "./storage-migration";
+import {
+  migrateKey,
+  migratePrefix,
+  migrateValue,
+  removeKey,
+  runStorageMigrations,
+} from "./storage-migration";
 
 beforeEach(() => {
   localStorage.clear();
@@ -99,8 +105,12 @@ describe("migratePrefix", () => {
 
     migratePrefix("voice:ttsApiKey:", "vellum:voice:ttsApiKey:");
 
-    expect(localStorage.getItem("vellum:voice:ttsApiKey:openai")).toBe("sk-123");
-    expect(localStorage.getItem("vellum:voice:ttsApiKey:elevenlabs")).toBe("el-456");
+    expect(localStorage.getItem("vellum:voice:ttsApiKey:openai")).toBe(
+      "sk-123",
+    );
+    expect(localStorage.getItem("vellum:voice:ttsApiKey:elevenlabs")).toBe(
+      "el-456",
+    );
     expect(localStorage.getItem("voice:ttsApiKey:openai")).toBeNull();
     expect(localStorage.getItem("voice:ttsApiKey:elevenlabs")).toBeNull();
     // Unrelated key untouched
@@ -153,13 +163,21 @@ describe("runStorageMigrations", () => {
 
     runStorageMigrations();
 
-    expect(localStorage.getItem("vellum:voice:permissionPrimerSeen")).toBe("true");
+    expect(localStorage.getItem("vellum:voice:permissionPrimerSeen")).toBe(
+      "true",
+    );
     expect(localStorage.getItem("vellum:voice:ttsProvider")).toBe("openai");
     expect(localStorage.getItem("vellum:voice:sttProvider")).toBe("whisper");
     expect(localStorage.getItem("vellum:voice:activationKey")).toBe("Space");
-    expect(localStorage.getItem("vellum:voice:ttsApiKey:openai")).toBe("sk-123");
-    expect(localStorage.getItem("vellum:voice:ttsVoiceId:openai")).toBe("alloy");
-    expect(localStorage.getItem("vellum:voice:sttApiKey:deepgram")).toBe("dg-456");
+    expect(localStorage.getItem("vellum:voice:ttsApiKey:openai")).toBe(
+      "sk-123",
+    );
+    expect(localStorage.getItem("vellum:voice:ttsVoiceId:openai")).toBe(
+      "alloy",
+    );
+    expect(localStorage.getItem("vellum:voice:sttApiKey:deepgram")).toBe(
+      "dg-456",
+    );
     // Old keys removed
     expect(localStorage.getItem("voice:permissionPrimerSeen")).toBeNull();
     expect(localStorage.getItem("voice:ttsApiKey:openai")).toBeNull();
@@ -174,11 +192,15 @@ describe("runStorageMigrations", () => {
     runStorageMigrations();
 
     expect(localStorage.getItem("vellum:onboarding:tosAccepted")).toBe("true");
-    expect(localStorage.getItem("vellum:onboarding:aiDataConsent")).toBe("true");
+    expect(localStorage.getItem("vellum:onboarding:aiDataConsent")).toBe(
+      "true",
+    );
     // completed key is removed (no longer used), not migrated
     expect(localStorage.getItem("onboarding.completed")).toBeNull();
     expect(localStorage.getItem("vellum:onboarding:completed")).toBeNull();
-    expect(localStorage.getItem("vellum:onboarding:selectedVersion")).toBe("v1.0");
+    expect(localStorage.getItem("vellum:onboarding:selectedVersion")).toBe(
+      "v1.0",
+    );
     expect(localStorage.getItem("onboarding.tosAccepted")).toBeNull();
   });
 
@@ -193,7 +215,9 @@ describe("runStorageMigrations", () => {
     runStorageMigrations();
 
     expect(localStorage.getItem("vellum:ai:imageGenMode")).toBe("enabled");
-    expect(localStorage.getItem("vellum:ai:webSearchProvider")).toBe("perplexity");
+    expect(localStorage.getItem("vellum:ai:webSearchProvider")).toBe(
+      "perplexity",
+    );
     expect(localStorage.getItem("vellum:ai:geminiKey")).toBe("gk-789");
     expect(localStorage.getItem("vellum:ai:perplexityKey")).toBe("pplx-abc");
     expect(localStorage.getItem("vellum:ai:braveKey")).toBe("BSA-def");
@@ -243,9 +267,15 @@ describe("runStorageMigrations", () => {
 
     runStorageMigrations();
 
-    expect(localStorage.getItem("vellum:diskPressureDismissed:asst-1")).toBe("true");
-    expect(localStorage.getItem("vellum:diskPressureDismissed:asst-2")).toBe("true");
-    expect(localStorage.getItem("disk-pressure-warning-dismissed-asst-1")).toBeNull();
+    expect(localStorage.getItem("vellum:diskPressureDismissed:asst-1")).toBe(
+      "true",
+    );
+    expect(localStorage.getItem("vellum:diskPressureDismissed:asst-2")).toBe(
+      "true",
+    );
+    expect(
+      localStorage.getItem("disk-pressure-warning-dismissed-asst-1"),
+    ).toBeNull();
   });
 
   test("collapses the legacy per-org assistant map into one key", () => {
@@ -260,7 +290,9 @@ describe("runStorageMigrations", () => {
     expect(localStorage.getItem("vellum:selectedAssistantId")).toBe("asst-a");
     expect(localStorage.getItem("vellum:currentAssistantId:org-1")).toBeNull();
     expect(localStorage.getItem("vellum:currentAssistantId:org-2")).toBeNull();
-    expect(localStorage.getItem("vellum_current_assistant_id__org-1")).toBeNull();
+    expect(
+      localStorage.getItem("vellum_current_assistant_id__org-1"),
+    ).toBeNull();
   });
 
   test("collapse prefers the persisted active org's per-org selection", () => {
@@ -282,22 +314,33 @@ describe("runStorageMigrations", () => {
     localStorage.setItem("vellum:currentAssistantId:org-1", "per-org");
 
     runStorageMigrations();
-    expect(localStorage.getItem("vellum:selectedAssistantId")).toBe("tab-local");
+    expect(localStorage.getItem("vellum:selectedAssistantId")).toBe(
+      "tab-local",
+    );
     expect(localStorage.getItem("vellum:local:selectedAssistantId")).toBeNull();
     expect(localStorage.getItem("vellum:currentAssistantId:org-1")).toBeNull();
 
     // Re-running leaves the collapsed value untouched and removes nothing new.
     runStorageMigrations();
-    expect(localStorage.getItem("vellum:selectedAssistantId")).toBe("tab-local");
+    expect(localStorage.getItem("vellum:selectedAssistantId")).toBe(
+      "tab-local",
+    );
   });
 
   test("migrates vellumDebug key", () => {
-    localStorage.setItem("vellumDebug.flags.impersonateAssistantVersion", "0.8.6");
+    localStorage.setItem(
+      "vellumDebug.flags.impersonateAssistantVersion",
+      "0.8.6",
+    );
 
     runStorageMigrations();
 
-    expect(localStorage.getItem("vellum:debug:impersonateAssistantVersion")).toBe("0.8.6");
-    expect(localStorage.getItem("vellumDebug.flags.impersonateAssistantVersion")).toBeNull();
+    expect(
+      localStorage.getItem("vellum:debug:impersonateAssistantVersion"),
+    ).toBe("0.8.6");
+    expect(
+      localStorage.getItem("vellumDebug.flags.impersonateAssistantVersion"),
+    ).toBeNull();
   });
 
   test("migrates skillsTabTipDismissed to new name", () => {
@@ -362,5 +405,22 @@ describe("runStorageMigrations", () => {
     const snapshot2 = { ...localStorage };
 
     expect(snapshot1).toEqual(snapshot2);
+  });
+  test("converts a legacy imageGenMode into the equivalent provider", () => {
+    localStorage.setItem("vellum:ai:imageGenMode", "managed");
+    runStorageMigrations();
+    expect(localStorage.getItem("vellum:ai:imageGenProvider")).toBe("vellum");
+
+    localStorage.clear();
+    localStorage.setItem("vellum:ai:imageGenMode", "your-own");
+    runStorageMigrations();
+    expect(localStorage.getItem("vellum:ai:imageGenProvider")).toBe("gemini");
+  });
+
+  test("a stored imageGenProvider wins over the legacy mode", () => {
+    localStorage.setItem("vellum:ai:imageGenMode", "managed");
+    localStorage.setItem("vellum:ai:imageGenProvider", "gemini");
+    runStorageMigrations();
+    expect(localStorage.getItem("vellum:ai:imageGenProvider")).toBe("gemini");
   });
 });

--- a/clients/web/src/utils/storage-migration.ts
+++ b/clients/web/src/utils/storage-migration.ts
@@ -21,7 +21,11 @@
  * renaming the key. Idempotent — only writes when the current value
  * matches `oldValue` exactly.
  */
-export function migrateValue(key: string, oldValue: string, newValue: string): void {
+export function migrateValue(
+  key: string,
+  oldValue: string,
+  newValue: string,
+): void {
   if (typeof window === "undefined") return;
   try {
     if (localStorage.getItem(key) === oldValue) {
@@ -186,7 +190,10 @@ export function runStorageMigrations(): void {
   migrateKey("voice:activationKey", "vellum:voice:activationKey");
 
   // integrations. → vellum:integrations:
-  migrateKey("integrations.bannerDismissed", "vellum:integrations:bannerDismissed");
+  migrateKey(
+    "integrations.bannerDismissed",
+    "vellum:integrations:bannerDismissed",
+  );
 
   // onboarding. → vellum:onboarding:
   migrateKey("onboarding.tosAccepted", "vellum:onboarding:tosAccepted");
@@ -201,6 +208,18 @@ export function runStorageMigrations(): void {
   // vellum_ → vellum:ai: (AI settings page)
   migrateKey("vellum_image_gen_mode", "vellum:ai:imageGenMode");
   migrateKey("vellum_image_gen_model", "vellum:ai:imageGenModel");
+  // Image generation is configured by provider alone; convert a stored
+  // legacy mode into the equivalent provider so a previously-managed
+  // browser does not fall back to the BYOK default before the daemon
+  // config loads.
+  if (localStorage.getItem("vellum:ai:imageGenProvider") === null) {
+    const legacyImageGenMode = localStorage.getItem("vellum:ai:imageGenMode");
+    if (legacyImageGenMode === "managed") {
+      localStorage.setItem("vellum:ai:imageGenProvider", "vellum");
+    } else if (legacyImageGenMode === "your-own") {
+      localStorage.setItem("vellum:ai:imageGenProvider", "gemini");
+    }
+  }
   migrateKey("vellum_web_search_mode", "vellum:ai:webSearchMode");
   migrateKey("vellum_web_search_provider", "vellum:ai:webSearchProvider");
   migrateKey("vellum_email_mode", "vellum:ai:emailMode");
@@ -236,7 +255,10 @@ export function runStorageMigrations(): void {
   migratePrefix("ff:client:", "vellum:ff:");
 
   // Unprefixed per-entity → vellum:
-  migratePrefix("disk-pressure-warning-dismissed-", "vellum:diskPressureDismissed:");
+  migratePrefix(
+    "disk-pressure-warning-dismissed-",
+    "vellum:diskPressureDismissed:",
+  );
 
   // vellum_ per-org → vellum:
   migratePrefix("vellum_current_assistant_id__", "vellum:currentAssistantId:");


### PR DESCRIPTION
## Summary
- Swap `ServiceCard` → `ByoServiceCard` on the Image Generation card: the Managed | Your Own segmented control is gone, replaced by a provider dropdown (Vellum, Gemini) with the model dropdown always visible — Vellum lists every catalog model (managed proxies both backends), Gemini lists only gemini-prefix models and gates Save on a Gemini key (also fixing the pre-existing bug where GPT Image 2 was offered under a Gemini-key-only form)
- `openai` stays a valid daemon value the picker renders honestly (option + OpenAI key + gpt models) when a daemon reports it, without ever nudging users onto it or clobbering it
- Writes are version-gated via a new `use-supports-image-gen-vellum-provider` backwards-compat gate (MIN_VERSION 0.10.13): old daemons get the legacy `{mode}`-only body; supported daemons get the `provider`+`mode` pair; the config query gains the documented org-readiness gate; `LS_IMAGE_GEN_MODE` is dropped for `LS_IMAGE_GEN_PROVIDER`; 8-case test file added

## Original prompt
PR 3 of the image-generation vellum-provider plan (attached to #39109, now merged): convert the card to the provider-only model — Vellum = managed with model selection, Gemini = BYOK key + model selection — mirroring the STT/TTS and web-search conversions with all their review lessons pre-applied (version gate, write-pair bridge, org-readiness gate, honest rendering of unrepresentable providers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->