### PR TITLE
feat(config): migrate image-generation mode onto provider vellum

### DIFF
--- a/assistant/src/__tests__/config-loader-platform-defaults.test.ts
+++ b/assistant/src/__tests__/config-loader-platform-defaults.test.ts
@@ -76,9 +76,10 @@ function readConfig(): Record<string, unknown> {
 // Without IS_PLATFORM, services split by Zod schema default: google/notion-oauth
 // resolve to "managed" (per JARVIS-966), the rest resolve to "your-own".
 // web-search is deliberately absent: `provider` is its only axis, so the
-// platform context injects no mode for it.
+// platform context injects no mode for it. image-generation is also absent:
+// its managed axis is the provider ("vellum" proxies through the platform),
+// so the platform context fills `provider: "vellum"` rather than a mode.
 const MANAGED_SERVICES = [
-  "image-generation",
   "google-oauth",
   "outlook-oauth",
   "linear-oauth",
@@ -132,7 +133,7 @@ describe("platform-managed config defaults", () => {
     }
   });
 
-  test("IS_PLATFORM=true, no config file → all 7 managed service modes written as 'managed'", () => {
+  test("IS_PLATFORM=true, no config file → all 6 managed service modes written as 'managed', image-generation provider written as 'vellum'", () => {
     process.env.IS_PLATFORM = "true";
 
     loadConfig();
@@ -147,6 +148,15 @@ describe("platform-managed config defaults", () => {
     expect((services["web-search"] as { provider?: string })?.provider).toBe(
       "inference-provider-native",
     );
+    // image-generation's managed axis is its provider: the platform context
+    // fills "vellum" and never injects a managed mode (the persisted mode is
+    // the schema default).
+    const imageGen = services["image-generation"] as {
+      provider?: string;
+      mode?: string;
+    };
+    expect(imageGen?.provider).toBe("vellum");
+    expect(imageGen?.mode).not.toBe("managed");
   });
 
   test("IS_PLATFORM=false, no config file → service modes follow schema defaults (your-own except google/notion-oauth which are managed)", () => {
@@ -279,6 +289,8 @@ describe("platform-managed config defaults", () => {
           .mode,
       ).toBe("managed");
     }
+    // ...and for image-generation's provider, whose fill is "vellum".
+    expect(config.services["image-generation"].provider).toBe("vellum");
 
     // The on-disk file is NOT modified by the fill pass — disk reflects only
     // what was already there. Existing-file branch never re-writes config.json.
@@ -286,15 +298,13 @@ describe("platform-managed config defaults", () => {
     expect(onDisk["services"]).toBeUndefined();
   });
 
-  test("IS_PLATFORM=true, config file exists with a partial service subtree → preserves user fields, fills missing mode", () => {
+  test("IS_PLATFORM=true, config file exists with an explicit image-generation provider → provider wins over the vellum fill", () => {
     process.env.IS_PLATFORM = "true";
 
-    // User has an image-generation provider configured but never explicitly
-    // chose a mode for that service. The fill pass must apply
-    // `mode: "managed"` without clobbering the user-supplied provider.
-    // (The inference schema dropped per-service model/provider in
-    // migration 039 — image-generation still carries them, so it's the
-    // right schema to exercise the partial-subtree case.)
+    // User has an explicit BYOK image-generation provider on disk. The fill
+    // pass targets exactly that leaf (`provider: "vellum"`), so the explicit
+    // value must win and no mode is injected — the effective mode is the
+    // schema default.
     writeFileSync(
       CONFIG_PATH,
       JSON.stringify(
@@ -316,8 +326,8 @@ describe("platform-managed config defaults", () => {
         { mode: string; provider?: string }
       >
     )["image-generation"]!;
-    expect(imageGen.mode).toBe("managed");
     expect(imageGen.provider).toBe("openai");
+    expect(imageGen.mode).toBe("your-own");
   });
 
   test("IS_PLATFORM=false, config file exists without services key → in-memory config keeps schema defaults (your-own except google/notion-oauth which are managed)", () => {
@@ -404,11 +414,17 @@ describe("GET /v1/config handler — context-default fill on raw response", () =
       string,
       unknown
     >;
-    const services = result["services"] as Record<string, { mode: string }>;
+    const services = result["services"] as Record<
+      string,
+      { mode?: string; provider?: string }
+    >;
     expect(services).toBeDefined();
     for (const svc of MANAGED_SERVICES) {
       expect(services[svc]!.mode).toBe("managed");
     }
+    // image-generation is filled by provider, not mode.
+    expect(services["image-generation"]!.provider).toBe("vellum");
+    expect(services["image-generation"]!.mode).toBeUndefined();
   });
 
   test("IS_PLATFORM=true, raw config has explicit services.image-generation.mode='your-own' → preserved", () => {
@@ -455,12 +471,12 @@ describe("GET /v1/config handler — context-default fill on raw response", () =
     expect(result["services"]).toBeUndefined();
   });
 
-  test("IS_PLATFORM=true, raw config has partial services subtree → preserves user fields, fills missing mode", () => {
+  test("IS_PLATFORM=true, raw config has an explicit image-generation provider → preserved, no mode injected", () => {
     process.env.IS_PLATFORM = "true";
 
-    // User set image-generation.provider but never chose a mode.
-    // The fill pass adds the missing mode without clobbering the user-supplied
-    // provider.
+    // User set image-generation.provider explicitly. The fill targets that
+    // same leaf (`provider: "vellum"`), so the explicit value wins and no
+    // mode is injected.
     const raw: Record<string, unknown> = {
       services: {
         "image-generation": { provider: "openai" },
@@ -473,10 +489,10 @@ describe("GET /v1/config handler — context-default fill on raw response", () =
     >;
     const services = result["services"] as Record<
       string,
-      { mode: string; provider?: string }
+      { mode?: string; provider?: string }
     >;
-    expect(services["image-generation"]!.mode).toBe("managed");
     expect(services["image-generation"]!.provider).toBe("openai");
+    expect(services["image-generation"]!.mode).toBeUndefined();
     // services.inference.mode is synthesized as a legacy wire-only field for
     // older macOS clients during the rollout window (Phase 1.2 schema removal
     // landed before the macOS Providers UI ships).

--- a/assistant/src/__tests__/workspace-migration-134-image-generation-mode-to-provider.test.ts
+++ b/assistant/src/__tests__/workspace-migration-134-image-generation-mode-to-provider.test.ts
@@ -1,0 +1,272 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { AssistantConfigSchema } from "../config/schema.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { getLastWorkspaceMigrationId } from "../workspace/migrations/runner.js";
+
+// Migration files expose no API to other code (see migrations AGENTS.md);
+// the registry is the one sanctioned importer, so the test exercises the
+// registered entry rather than importing the module directly.
+const imageGenerationModeToProviderMigration = WORKSPACE_MIGRATIONS.find(
+  (m) => m.id === "134-image-generation-mode-to-provider",
+);
+if (!imageGenerationModeToProviderMigration) {
+  throw new Error("migration 134 is not registered in WORKSPACE_MIGRATIONS");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-134-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function imageGen(config: Record<string, unknown>): Record<string, any> {
+  return (config.services as Record<string, any>)["image-generation"];
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("134-image-generation-mode-to-provider", () => {
+  // getLastWorkspaceMigrationId() reports the final array entry as the
+  // registry ceiling to the identity and rollback routes, so the
+  // highest-numbered migration must sit last in the registry.
+  test("the registry ceiling stays at the highest-numbered migration", () => {
+    const numericId = (id: string) => Number.parseInt(id, 10);
+    const highest = Math.max(
+      ...WORKSPACE_MIGRATIONS.map((m) => numericId(m.id)).filter(
+        Number.isFinite,
+      ),
+    );
+    const last = getLastWorkspaceMigrationId(WORKSPACE_MIGRATIONS);
+    expect(last).not.toBeNull();
+    expect(numericId(last!)).toBe(highest);
+  });
+
+  test("rewrites a managed gemini service to provider vellum, model preserved", () => {
+    writeConfig({
+      services: {
+        "image-generation": {
+          mode: "managed",
+          provider: "gemini",
+          model: "gemini-3-pro-image-preview",
+        },
+      },
+    });
+
+    imageGenerationModeToProviderMigration.run(workspaceDir);
+
+    expect(imageGen(readConfig())).toEqual({
+      provider: "vellum",
+      model: "gemini-3-pro-image-preview",
+    });
+  });
+
+  // Managed OpenAI has no exemption: the backend derives from the model
+  // prefix at request time, so a managed gpt-image-2 user keeps routing to
+  // the OpenAI proxy through provider vellum.
+  test("rewrites a managed openai service to provider vellum, model preserved", () => {
+    writeConfig({
+      services: {
+        "image-generation": {
+          mode: "managed",
+          provider: "openai",
+          model: "gpt-image-2",
+        },
+      },
+    });
+
+    imageGenerationModeToProviderMigration.run(workspaceDir);
+
+    expect(imageGen(readConfig())).toEqual({
+      provider: "vellum",
+      model: "gpt-image-2",
+    });
+  });
+
+  test("keeps the BYOK provider and drops mode for your-own", () => {
+    writeConfig({
+      services: {
+        "image-generation": {
+          mode: "your-own",
+          provider: "gemini",
+          model: "gemini-3.1-flash-image-preview",
+        },
+      },
+    });
+
+    imageGenerationModeToProviderMigration.run(workspaceDir);
+
+    expect(imageGen(readConfig())).toEqual({
+      provider: "gemini",
+      model: "gemini-3.1-flash-image-preview",
+    });
+  });
+
+  test("is idempotent", () => {
+    writeConfig({
+      services: {
+        "image-generation": {
+          mode: "managed",
+          provider: "gemini",
+          model: "gpt-image-2",
+        },
+      },
+    });
+
+    imageGenerationModeToProviderMigration.run(workspaceDir);
+    const once = readConfig();
+    imageGenerationModeToProviderMigration.run(workspaceDir);
+
+    expect(readConfig()).toEqual(once);
+  });
+
+  test("leaves configs without an image-generation mode alone", () => {
+    const original = {
+      services: {
+        "image-generation": { provider: "vellum", model: "gpt-image-2" },
+        "google-oauth": { mode: "managed" },
+      },
+    };
+    writeConfig(original);
+
+    imageGenerationModeToProviderMigration.run(workspaceDir);
+
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("survives a missing config and malformed JSON", () => {
+    expect(() =>
+      imageGenerationModeToProviderMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    writeFileSync(join(workspaceDir, "config.json"), "{ not json");
+    expect(() =>
+      imageGenerationModeToProviderMigration.run(workspaceDir),
+    ).not.toThrow();
+  });
+
+  // The migrated shape is what the daemon actually parses, so a managed user
+  // must land on vellum with their model intact rather than falling back to
+  // a keyless BYOK provider.
+  test("migrated output parses to the vellum provider", () => {
+    writeConfig({
+      services: {
+        "image-generation": {
+          mode: "managed",
+          provider: "openai",
+          model: "gpt-image-2",
+        },
+      },
+    });
+
+    imageGenerationModeToProviderMigration.run(workspaceDir);
+    const parsed = AssistantConfigSchema.parse(readConfig());
+
+    expect(parsed.services["image-generation"].provider).toBe("vellum");
+    expect(parsed.services["image-generation"].model).toBe("gpt-image-2");
+  });
+
+  describe("down", () => {
+    test("round-trip restores the managed pair", () => {
+      writeConfig({
+        services: {
+          "image-generation": {
+            mode: "managed",
+            provider: "gemini",
+            model: "gemini-3-pro-image-preview",
+          },
+        },
+      });
+
+      imageGenerationModeToProviderMigration.run(workspaceDir);
+      imageGenerationModeToProviderMigration.down!(workspaceDir);
+
+      // The pre-migration backend provider (gemini) is not recoverable — it
+      // was overwritten with vellum on the way up and re-derives from the
+      // model prefix on the next model write.
+      expect(imageGen(readConfig())).toEqual({
+        mode: "managed",
+        provider: "vellum",
+        model: "gemini-3-pro-image-preview",
+      });
+    });
+
+    test("restores your-own for a BYOK provider", () => {
+      writeConfig({
+        services: {
+          "image-generation": {
+            provider: "gemini",
+            model: "gemini-3.1-flash-image-preview",
+          },
+        },
+      });
+
+      imageGenerationModeToProviderMigration.down!(workspaceDir);
+
+      expect(imageGen(readConfig())).toEqual({
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      });
+    });
+
+    test("does not re-add mode when it is already present", () => {
+      writeConfig({
+        services: {
+          "image-generation": { mode: "your-own", provider: "gemini" },
+        },
+      });
+
+      imageGenerationModeToProviderMigration.down!(workspaceDir);
+
+      expect(imageGen(readConfig())).toEqual({
+        mode: "your-own",
+        provider: "gemini",
+      });
+    });
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-134-image-generation-mode-to-provider.test.ts
+++ b/assistant/src/__tests__/workspace-migration-134-image-generation-mode-to-provider.test.ts
@@ -146,6 +146,18 @@ describe("134-image-generation-mode-to-provider", () => {
     });
   });
 
+  test("pins the gemini default for your-own with no persisted provider", () => {
+    // With `mode` gone, an absent provider leaf would be context-filled to
+    // "vellum" on platform deployments — a silent your-own -> managed flip.
+    writeConfig({
+      services: { "image-generation": { mode: "your-own" } },
+    });
+
+    imageGenerationModeToProviderMigration.run(workspaceDir);
+
+    expect(imageGen(readConfig())).toEqual({ provider: "gemini" });
+  });
+
   test("is idempotent", () => {
     writeConfig({
       services: {

--- a/assistant/src/config/__tests__/deployment-context-defaults.test.ts
+++ b/assistant/src/config/__tests__/deployment-context-defaults.test.ts
@@ -164,6 +164,15 @@ describe("deployment-context embedding-provider default (via loadConfig)", () =>
     >;
     expect(webSearchRaw.mode).not.toBe("managed");
 
+    // image-generation's managed axis is its provider: the seeded value is
+    // the platform fill "vellum", never an injected managed mode.
+    const imageGenRaw = (servicesRaw["image-generation"] ?? {}) as Record<
+      string,
+      unknown
+    >;
+    expect(imageGenRaw.provider).toBe("vellum");
+    expect(imageGenRaw.mode).not.toBe("managed");
+
     // Regression guard: on the NEXT load (config.json now exists with the
     // provider leaf absent), the platform default re-applies in memory rather
     // than being lost to a persisted "auto" read back as an explicit choice.

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -156,7 +156,13 @@ export function getDeploymentContextDefaults(): Record<string, unknown> {
     // default (`gemini-embedding-2`).
     memory: { embeddings: { provider: "gemini" } },
     services: {
-      "image-generation": managed,
+      // Image-generation is provider-only for the managed axis: `vellum`
+      // generates through the platform runtime proxy (the backend derives
+      // from the selected model's prefix at request time). Hosted assistants
+      // default to it here; fill-only, so an explicit on-disk BYOK provider
+      // (gemini/openai) always wins. Filling a `mode` instead would
+      // re-manage BYOK configs on every load.
+      "image-generation": { provider: "vellum" },
       "google-oauth": managed,
       "outlook-oauth": managed,
       "linear-oauth": managed,

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -459,10 +459,10 @@ async function handleSetEmbeddingConfig({ body }: RouteHandlerArgs) {
  * response needs the same treatment so external clients (macOS, web, CLI)
  * see the effective value rather than `undefined` when the daemon hasn't
  * persisted an explicit choice yet. For example, on a freshly-hatched
- * platform-managed assistant, `services.image-generation.mode` may be absent
- * from disk (only `llm.profiles` was written by `seedInferenceProfiles`); the
- * fill pass ensures clients receive `"managed"` rather than falling back to
- * their own defaults.
+ * platform-managed assistant, `services.image-generation.provider` may be
+ * absent from disk (only `llm.profiles` was written by
+ * `seedInferenceProfiles`); the fill pass ensures clients receive `"vellum"`
+ * rather than falling back to their own defaults.
  *
  * Guards against `loadRawConfig()` handing us a value that is technically
  * valid JSON but not a plain object (e.g. literal `null`, a number, or an

--- a/assistant/src/workspace/migrations/134-image-generation-mode-to-provider.ts
+++ b/assistant/src/workspace/migrations/134-image-generation-mode-to-provider.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { WorkspaceMigration } from "./types.js";
@@ -62,7 +62,12 @@ export const imageGenerationModeToProviderMigration: WorkspaceMigration = {
     }
     delete service.mode;
 
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    // Write-then-rename keeps the migration rerunnable: a crash mid-write
+    // must not leave a truncated config.json that a retry reads as malformed
+    // and "completes" past, quarantining the user's unrelated settings.
+    const tmpPath = `${configPath}.tmp`;
+    writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
+    renameSync(tmpPath, configPath);
   },
   down(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");
@@ -98,7 +103,12 @@ export const imageGenerationModeToProviderMigration: WorkspaceMigration = {
     // model prefix, so it re-derives on the next model write.
     service.mode = service.provider === "vellum" ? "managed" : "your-own";
 
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    // Write-then-rename keeps the migration rerunnable: a crash mid-write
+    // must not leave a truncated config.json that a retry reads as malformed
+    // and "completes" past, quarantining the user's unrelated settings.
+    const tmpPath = `${configPath}.tmp`;
+    writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
+    renameSync(tmpPath, configPath);
   },
 };
 

--- a/assistant/src/workspace/migrations/134-image-generation-mode-to-provider.ts
+++ b/assistant/src/workspace/migrations/134-image-generation-mode-to-provider.ts
@@ -52,6 +52,13 @@ export const imageGenerationModeToProviderMigration: WorkspaceMigration = {
 
     if (service.mode === "managed") {
       service.provider = "vellum";
+    } else if (!("provider" in service)) {
+      // An explicit non-managed mode with no persisted provider resolves to
+      // the gemini schema default. Pin that choice: with `mode` gone, an
+      // absent provider leaf would otherwise be context-filled to "vellum"
+      // on platform deployments, silently flipping a your-own config to
+      // managed billing.
+      service.provider = "gemini";
     }
     delete service.mode;
 

--- a/assistant/src/workspace/migrations/134-image-generation-mode-to-provider.ts
+++ b/assistant/src/workspace/migrations/134-image-generation-mode-to-provider.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Fold `services["image-generation"].mode` into the provider field.
+ *
+ * Configs written by older versions carry two axes: `mode: "managed"` routes
+ * generation through the Vellum platform runtime proxy while `provider`
+ * names the backend the proxy fronts (gemini or openai). The schema treats
+ * `provider` as the only axis, with `"vellum"` meaning managed and the
+ * backend derived from the selected model's prefix at request time, so this
+ * migration rewrites every managed service to `provider: "vellum"`. There is
+ * no per-provider exemption: the stored backend value under managed mode is
+ * itself derived from the model on every model write, so replacing it loses
+ * nothing — `model` is preserved verbatim and keeps routing the managed
+ * request to the same backend.
+ *
+ * Idempotent: a config with no `mode` key is left untouched.
+ */
+export const imageGenerationModeToProviderMigration: WorkspaceMigration = {
+  id: "134-image-generation-mode-to-provider",
+  description:
+    "Fold services.image-generation mode into provider (managed -> provider: vellum)",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) {
+      return;
+    }
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return;
+      }
+      config = raw as Record<string, unknown>;
+    } catch {
+      return; // Malformed JSON — skip
+    }
+
+    const services = readObj(config, "services");
+    if (!services) {
+      return;
+    }
+
+    const service = readObj(services, "image-generation");
+    if (!service || !("mode" in service)) {
+      return;
+    }
+
+    if (service.mode === "managed") {
+      service.provider = "vellum";
+    }
+    delete service.mode;
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) {
+      return;
+    }
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return;
+      }
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const services = readObj(config, "services");
+    if (!services) {
+      return;
+    }
+
+    const service = readObj(services, "image-generation");
+    if (!service || "mode" in service) {
+      return;
+    }
+
+    // Schemas that predate this migration accept provider "vellum" alongside
+    // mode "managed", so the managed pair round-trips exactly. The backend
+    // provider a managed service holds before `run()` is not recoverable —
+    // `run()` overwrites it with "vellum". That value is derived from the
+    // model prefix, so it re-derives on the next model write.
+    service.mode = service.provider === "vellum" ? "managed" : "your-own";
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers (self-contained per migration AGENTS.md)
+// ---------------------------------------------------------------------------
+
+function readObj(
+  parent: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = parent[key];
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -131,6 +131,7 @@ import { speechModeToProviderMigration } from "./130-speech-mode-to-provider.js"
 import { dropWebFetchModeMigration } from "./131-drop-web-fetch-mode.js";
 import { webSearchModeToProviderMigration } from "./132-web-search-mode-to-provider.js";
 import { collapseProviderConnectionsMigration } from "./133-collapse-provider-connections.js";
+import { imageGenerationModeToProviderMigration } from "./134-image-generation-mode-to-provider.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -277,4 +278,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   dropWebFetchModeMigration,
   webSearchModeToProviderMigration,
   collapseProviderConnectionsMigration,
+  imageGenerationModeToProviderMigration,
 ];


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge #39116 (the Image Generation card conversion) before this PR.** The web bundle deploys continuously; this migration removes `mode` from configs, and only #39116's card derives its state from `provider`. Merging this first would render managed users as BYOK on fresh browsers until the card ships.

## Summary
- Workspace migration `134-image-generation-mode-to-provider`: `mode: "managed"` on `services.image-generation` becomes `provider: "vellum"` with `mode` deleted in all cases. There is no exemption for the stored `gemini`/`openai` backend — under managed mode that value is derived from the model on every model write, so nothing is lost: `model` is preserved verbatim and the vellum proxy derives the backend from the model prefix at request time (PR 1, #39109).
- The platform deployment-default fill swaps atomically in this same PR: `getDeploymentContextDefaults()` fills `"image-generation": { provider: "vellum" }` instead of `mode: "managed"`. The fill is per-leaf and applied in-memory on every load, so a surviving mode fill would re-manage every migrated config on each platform boot; deleting the fill outright would strand keyless platform boots on the BYOK schema default (`gemini`).
- Migration registered last in the registry so `getLastWorkspaceMigrationId()` keeps reporting the highest id (ceiling now 134); the migration test pins this.
- Note for managed users: this is the billing-flip moment in name only — they stay managed (billed to Vellum credits as before), but the `mode` key disappears from their config and `provider: "vellum"` becomes the sole managed switch.

## Original prompt
PR 2 of the image-gen vellum-provider plan (attached to #39109): migration 134 (image-generation mode → provider vellum) plus the platform deployment-default swap, atomically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->