### PR TITLE
fix(web): plan-card CTA reads "View All Plans" on free, "Manage" on paid

### DIFF
--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -76,7 +76,7 @@ const PLAN_DISPLAY: Record<string, PlanDisplay> = {
   },
 };
 
-const DEFAULT_DISPLAY: PlanDisplay = PLAN_DISPLAY.base;
+const DEFAULT_DISPLAY: PlanDisplay = PLAN_DISPLAY.pro;
 
 export interface PlanCardProps {
   onManage: () => void;


### PR DESCRIPTION
## Summary
- Free-tier plan-card CTA now reads "View All Plans"; paid plans read "Manage".
- Repoint DEFAULT_DISPLAY to the Manage display so any non-free plan id resolves to Manage.

Part of plan: plan-cta-and-topup-config.md (PR 1 of 3)