### PR TITLE
feat(web): Configure Automatic Top-Ups routes to billing with configure_top_up intent

### DIFF
--- a/clients/web/src/components/add-credits-modal.test.tsx
+++ b/clients/web/src/components/add-credits-modal.test.tsx
@@ -47,6 +47,8 @@ describe("AddCreditsModal", () => {
     const link = screen.getByRole("link", {
       name: /Configure Automatic Top-Ups/,
     });
-    expect(link.getAttribute("href")).toBe(routes.settings.usageBilling);
+    expect(link.getAttribute("href")).toBe(
+      routes.settings.usageBillingConfigureTopUps,
+    );
   });
 });

--- a/clients/web/src/components/add-credits-modal.tsx
+++ b/clients/web/src/components/add-credits-modal.tsx
@@ -158,7 +158,7 @@ export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
             )}
 
             <Link
-              to={routes.settings.usageBilling}
+              to={routes.settings.usageBillingConfigureTopUps}
               className="flex items-center gap-1 text-body-small-default text-[var(--content-tertiary)] hover:text-[var(--content-secondary)]"
               onClick={() => onOpenChange(false)}
             >

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -200,6 +200,7 @@ export const routes = {
     // Deep-link straight to the Billing sub-tab (only shown when signed in to
     // the Vellum platform).
     usageBilling: `${SETTINGS_USAGE_PATH}?tab=billing`,
+    usageBillingConfigureTopUps: `${SETTINGS_USAGE_PATH}?tab=billing&configure_top_up=1`,
     // Post-Stripe-Checkout return. The Billing tab opens the Pro onboarding
     // wizard while `session_id` is in the URL — the same param the platform's
     // web `success_url` lands on `/assistant/settings/billing` with.


### PR DESCRIPTION
## Summary
- Add `usageBillingConfigureTopUps` route (`?tab=billing&configure_top_up=1`).
- Point the Add Credits modal's "Configure Automatic Top-Ups" link at it.

Part of plan: plan-cta-and-topup-config.md (PR 2 of 3)