### PR TITLE
fix(web): never render a same→same arrow in the provisioning target chips

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -456,6 +456,38 @@ describe("stalled", () => {
     fireEvent.click(apply);
     expect(onApply).not.toHaveBeenCalled();
   });
+
+  test("an unchanged machine dimension renders singular while storage still arrows", () => {
+    const { getByText, getAllByText, container } = renderState({
+      state: "STALLED",
+      targets: { machineSize: "medium", storageGib: 100 },
+      fromSnapshot: { machineSize: "medium", storageGib: 30 },
+    });
+
+    // Machine is unchanged: the label appears once (target only), never as a
+    // "Medium → Medium" self-arrow.
+    expect(getByText("Machine")).toBeTruthy();
+    expect(getAllByText("Medium").length).toBe(1);
+    // Storage changed: both endpoints render, with a single from→to arrow.
+    expect(getByText("30 GB")).toBeTruthy();
+    expect(getByText("100 GB")).toBeTruthy();
+    expect(container.querySelectorAll(".lucide-arrow-right").length).toBe(1);
+  });
+
+  test("both dimensions unchanged render singular with no arrows", () => {
+    const { getByText, container } = renderState({
+      state: "STALLED",
+      targets: { machineSize: "medium", storageGib: 30 },
+      fromSnapshot: { machineSize: "medium", storageGib: 30 },
+    });
+
+    expect(getByText("Machine")).toBeTruthy();
+    expect(getByText("Medium")).toBeTruthy();
+    expect(getByText("Storage")).toBeTruthy();
+    expect(getByText("30 GB")).toBeTruthy();
+    // Nothing changed, so neither chip draws a current→new arrow.
+    expect(container.querySelector(".lucide-arrow-right")).toBeNull();
+  });
 });
 
 describe("confirm_timeout", () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -12,7 +12,7 @@ import {
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import type { CreditTierEnum } from "@/generated/api/types.gen";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
-import { MACHINE_TIER_LABEL, SIZE_LABEL } from "@/lib/billing/machine-sizes";
+import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
 import { SURFACE_GROUND } from "@/utils/avatar-tone";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { Button } from "@vellumai/design-library/components/button";
@@ -457,10 +457,11 @@ function IntentChips({ intent }: { intent: CheckoutIntent }) {
 }
 
 /**
- * Machine/Storage from→to chips, driven by the resolved provisioning targets.
- * A dimension whose snapshot equals its target renders as a singular value with
- * no arrow (mirroring `buildResourceChanges`); the arrow appears only when the
- * values actually differ.
+ * Machine/Storage from→to chips, derived from the shared `buildResourceChanges`
+ * derivation (credits omitted) so the STALLED/DONE path can't drift from the
+ * WAITING `ResourceChangeChips`. An unchanged dimension renders as a singular
+ * value with no arrow (the helper omits its `from`); `done` strips the from-side
+ * entirely, so the terminal phase shows just the achieved target with a check.
  */
 function TargetChips({
   targets,
@@ -471,38 +472,19 @@ function TargetChips({
   fromSnapshot: ProvisioningDimensions;
   done?: boolean;
 }) {
+  const changes = buildResourceChanges({ targets, fromSnapshot, credits: null });
   return (
     <ChipRow>
-      {targets.machineSize != null && (
+      {changes.map((change) => (
         <DimensionChip
-          icon={Cpu}
-          label="Machine"
-          from={
-            !done &&
-            fromSnapshot.machineSize != null &&
-            fromSnapshot.machineSize !== targets.machineSize
-              ? SIZE_LABEL[fromSnapshot.machineSize]
-              : undefined
-          }
-          to={SIZE_LABEL[targets.machineSize]}
+          key={change.key}
+          icon={RESOURCE_CHIP_ICON[change.key]}
+          label={change.label}
+          from={done ? undefined : change.from}
+          to={change.to}
           done={done}
         />
-      )}
-      {targets.storageGib != null && (
-        <DimensionChip
-          icon={HardDrive}
-          label="Storage"
-          from={
-            !done &&
-            fromSnapshot.storageGib != null &&
-            fromSnapshot.storageGib !== targets.storageGib
-              ? `${fromSnapshot.storageGib} GB`
-              : undefined
-          }
-          to={`${targets.storageGib} GB`}
-          done={done}
-        />
-      )}
+      ))}
     </ChipRow>
   );
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -456,7 +456,12 @@ function IntentChips({ intent }: { intent: CheckoutIntent }) {
   );
 }
 
-/** Machine/Storage from→to chips, driven by the resolved provisioning targets. */
+/**
+ * Machine/Storage from→to chips, driven by the resolved provisioning targets.
+ * A dimension whose snapshot equals its target renders as a singular value with
+ * no arrow (mirroring `buildResourceChanges`); the arrow appears only when the
+ * values actually differ.
+ */
 function TargetChips({
   targets,
   fromSnapshot,
@@ -473,7 +478,9 @@ function TargetChips({
           icon={Cpu}
           label="Machine"
           from={
-            !done && fromSnapshot.machineSize != null
+            !done &&
+            fromSnapshot.machineSize != null &&
+            fromSnapshot.machineSize !== targets.machineSize
               ? SIZE_LABEL[fromSnapshot.machineSize]
               : undefined
           }
@@ -486,7 +493,9 @@ function TargetChips({
           icon={HardDrive}
           label="Storage"
           from={
-            !done && fromSnapshot.storageGib != null
+            !done &&
+            fromSnapshot.storageGib != null &&
+            fromSnapshot.storageGib !== targets.storageGib
               ? `${fromSnapshot.storageGib} GB`
               : undefined
           }


### PR DESCRIPTION
## Summary
- TargetChips now suppresses the from→to arrow when a dimension is unchanged, matching buildResourceChanges.
- Adds STALLED-phase tests for equal-value chips.

Part of plan: pro-takeover-exit-on-escape.md (PR 1 of 5)