### PR TITLE
feat(web): capture ensure-provisioned errors from all sources and expose a fire-and-forget kick

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -655,6 +655,52 @@ describe("useProProvisioning", () => {
     20_000,
   );
 
+  test(
+    "kickProvisioning fires the reconcile, never flips pending, and a success clears kickError",
+    async () => {
+      const { client } = renderProbe();
+      await reachResizing(client);
+      const autoCalls = ensureCalls;
+
+      dateNowOffsetMs = 200_000;
+      await waitFor(() => expect(latest!.state).toBe("STALLED"), {
+        timeout: 5000,
+      });
+
+      // A fire-and-forget escape kick that fails captures kickError without
+      // ever flipping the manual-pending flag — a hung escape-fired call must
+      // never strand later UI.
+      ensureError = { error: "provisioning_submission_failed" };
+      act(() => latest!.kickProvisioning());
+      await waitFor(() => expect(ensureCalls).toBe(autoCalls + 1));
+      await waitFor(() =>
+        expect(latest!.kickError).toEqual({
+          error: "provisioning_submission_failed",
+        }),
+      );
+      expect(latest!.stalledAction.pending).toBe(false);
+      // kickError and stalledAction.error are the same value.
+      expect(latest!.stalledAction.error).toEqual({
+        error: "provisioning_submission_failed",
+      });
+      // The failure is not terminal: still STALLED, still polling.
+      expect(latest!.state).toBe("STALLED");
+
+      // A subsequent successful escape kick clears kickError and re-bases the
+      // stall clock — the `started` verdict lifts the wizard back to RESIZING.
+      ensureError = null;
+      ensureResponse = makeEnsureResponse("started");
+      act(() => latest!.kickProvisioning());
+      await waitFor(() => expect(ensureCalls).toBe(autoCalls + 2));
+      await waitFor(() => expect(latest!.kickError).toBeNull());
+      await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
+        timeout: 5000,
+      });
+      expect(latest!.stalledAction.pending).toBe(false);
+    },
+    20_000,
+  );
+
   test("org-scoped queries hold until the org id is available", async () => {
     isOrgReadyMock = false;
     const { rerender } = renderProbe();
@@ -1182,7 +1228,32 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
   );
 
   test(
-    "a 503 leaves the wizard inferring rather than erroring",
+    "a dead-end no_active_pro on the automatic path sets kickError",
+    async () => {
+      // The auto reconcile hits no_active_pro and schedules its one race
+      // retry; the retry (also auto) hits the same dead end. With the
+      // once-per-open re-ask spent, the repeat dead end now surfaces kickError
+      // regardless of source.
+      ensureResponse = makeEnsureResponse("not_applicable", "no_active_pro");
+      subscriptionPlanId = "pro";
+      renderProbe();
+
+      // Two automatic calls: the initial one and its single race retry.
+      await waitFor(() => expect(ensureCalls).toBe(2), { timeout: 5000 });
+      await waitFor(
+        () =>
+          expect(latest!.kickError).toEqual({ error: "no_active_pro" }),
+        { timeout: 5000 },
+      );
+      // The verdict is still never adopted — inference keeps the flow WAITING.
+      expect(latest!.state).toBe("WAITING");
+      expect(latest!.stalledAction.pending).toBe(false);
+    },
+    20_000,
+  );
+
+  test(
+    "a 503 on the automatic call never blocks the flow but is captured in kickError",
     async () => {
       ensureError = { error: "provisioning_submission_failed" };
       subscriptionPlanId = "pro";
@@ -1192,9 +1263,18 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
       await waitFor(() => expect(latest!.state).toBe("WAITING"), {
         timeout: 5000,
       });
-      // The automatic call failing is silent: no error surface, no new
-      // blocking state, no auto-retry storm.
-      expect(latest!.stalledAction.error).toBeNull();
+      // The automatic call failing no longer blocks: no new blocking state,
+      // no auto-retry storm. But it is no longer *silent* — the failure is
+      // captured in kickError (and its stalledAction.error alias) so the
+      // takeover can surface the snag variant.
+      await waitFor(() =>
+        expect(latest!.kickError).toEqual({
+          error: "provisioning_submission_failed",
+        }),
+      );
+      expect(latest!.stalledAction.error).toEqual({
+        error: "provisioning_submission_failed",
+      });
       expect(latest!.confirmError).toBe(false);
       expect(latest!.targetsError).toBe(false);
       await new Promise((resolve) => setTimeout(resolve, 500));
@@ -1263,7 +1343,8 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
         timeout: 5000,
       });
 
-      // A user-initiated reconcile — the only source that surfaces an error.
+      // Any reconcile now captures its error; this one is fired while open but
+      // only rejects after close, so generation-gating must still discard it.
       act(() => latest!.stalledAction.onApply());
       await waitFor(() => expect(ensureCalls).toBe(2), { timeout: 5000 });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -17,8 +17,11 @@
  * first reports Pro it calls the idempotent ensure-provisioned reconcile
  * endpoint, so a webhook that never fired (or whose resize was lost) still
  * gets provisioned. The returned verdict feeds the state machine's
- * `serverVerdict` slot; the endpoint failing is not an error state — the
- * polling above converges on its own.
+ * `serverVerdict` slot; the endpoint failing never blocks the flow — the
+ * polling above converges on its own. But a reconcile failure from *any*
+ * source (auto, manual, or the fire-and-forget escape kick) is now held in
+ * `ensureError` so the takeover can honestly surface the ≥90s snag variant;
+ * any later success clears it.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -89,8 +92,8 @@ export interface UseProProvisioningOptions {
 
 /**
  * Stalled-state recovery affordance, shaped for `StalledApplyAction`. `error`
- * is only ever populated by a user-initiated call — the automatic reconcile
- * failing is deliberately silent.
+ * mirrors `ensureError`: a reconcile failure from any source (auto, manual, or
+ * the fire-and-forget escape kick), cleared by a later success.
  */
 export interface ProvisioningRetryAction {
   onApply: () => void;
@@ -136,6 +139,18 @@ export interface ProProvisioningResult {
    * resize) and re-bases the stall clock on success so observation resumes.
    */
   stalledAction: ProvisioningRetryAction;
+  /**
+   * Fire-and-forget "escape" kick: fires the idempotent ensure-provisioned
+   * reconcile without touching the manual-pending flag, so a hung call can
+   * never strand later UI. Used when closing the takeover into the background.
+   */
+  kickProvisioning: () => void;
+  /**
+   * Latest ensure-provisioned failure from any source; cleared by a later
+   * success. Drives the ≥90s snag variant on the takeover. (Alias of
+   * `stalledAction.error`.)
+   */
+  kickError: unknown;
 }
 
 export function useProProvisioning({
@@ -179,7 +194,8 @@ export function useProProvisioning({
   const [targetsMetAssistantId, setTargetsMetAssistantId] = useState<
     string | null
   >(null);
-  // Only ever set by a user-initiated reconcile — see runEnsureProvisioned.
+  // Latest reconcile failure from any source (auto/manual/escape); cleared by a
+  // later success — see runEnsureProvisioned.
   const [ensureError, setEnsureError] = useState<unknown>(null);
   // Pending state for the *manual* reconcile only. The mutation's own
   // `isPending` is shared with the automatic call fired on Pro confirm, and a
@@ -310,7 +326,7 @@ export function useProProvisioning({
   const { mutate: ensureProvisioned } = ensureProvisionedMutation;
 
   const runEnsureProvisioned = useCallback(
-    (source: "auto" | "manual") => {
+    (source: "auto" | "manual" | "escape") => {
       if (source === "manual") {
         setEnsureError(null);
         setManualPending(true);
@@ -339,20 +355,21 @@ export function useProProvisioning({
                 ensureRaceRetriedRef.current = true;
                 setRaceRetryScheduled(true);
                 // A re-ask is already queued, so observation may resume.
-                if (source === "manual") {
+                if (source !== "auto") {
                   resumeWatch();
                 }
-              } else if (source === "manual") {
+              } else {
                 // Dead end: the verdict is deliberately not adopted, nothing
                 // was queued, and the once-per-open re-ask is spent. Re-basing
                 // the stall clock here would drop the user out of STALLED —
                 // hiding Apply & Restart for another stall window — with no
-                // resize running and nothing said. Hold the state and explain.
+                // resize running and nothing said. Hold the state and explain,
+                // regardless of source, so a repeat dead end surfaces why.
                 setEnsureError({ error: "no_active_pro" });
               }
             } else {
               setServerVerdict(data.state);
-              if (source === "manual") {
+              if (source !== "auto") {
                 resumeWatch();
               }
             }
@@ -363,11 +380,11 @@ export function useProProvisioning({
             }
             // 503 (submission couldn't be queued) or a network blip: nothing
             // was queued and nothing is broken — the actuals polling still
-            // converges, so the automatic call degrades silently to inference.
-            // Only a user-initiated retry earns a visible error.
-            if (source === "manual") {
-              setEnsureError(error);
-            }
+            // converges, so the flow never blocks on this. The automatic call
+            // no longer degrades *silently*, though: its error is held for the
+            // ≥90s snag variant on the takeover and cleared by any later
+            // success, so a failure from any source is captured alike.
+            setEnsureError(error);
           },
           // Unconditional (not generation-gated): the button's pending state
           // must clear even for a response that belongs to a closed wizard,
@@ -421,6 +438,13 @@ export function useProProvisioning({
       error: ensureError,
     }),
     [runEnsureProvisioned, manualPending, ensureError],
+  );
+
+  // Fire-and-forget escape kick: fires the reconcile but never flips
+  // manualPending, so a hung escape-fired call can't strand later UI.
+  const kickProvisioning = useCallback(
+    () => runEnsureProvisioned("escape"),
+    [runEnsureProvisioned],
   );
 
   const onboardingQuery = useQuery({
@@ -624,5 +648,7 @@ export function useProProvisioning({
       msSinceWatchStart != null && msSinceWatchStart >= PROVISION_ESCAPE_MS,
     retryConfirm,
     stalledAction,
+    kickProvisioning,
+    kickError: ensureError,
   };
 }


### PR DESCRIPTION
## Summary
- ensure-provisioned failures are now captured from auto/manual/escape sources into kickError.
- Adds kickProvisioning (fire-and-forget escape kick) that never touches manual-pending.
- stalledAction API unchanged (additive).

Part of plan: pro-takeover-exit-on-escape.md (PR 2 of 5)