### PR TITLE
feat(web): provisioning takeover — single background CTA that exits, honest slow-copy, error-gated snag state

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -786,7 +786,7 @@ describe("BillingOnboardingModal", () => {
   );
 
   test("escape hatch appears once time-eligible even while routing is unsettled", async () => {
-    // The escape button no longer waits on routing — it's the always-available
+    // The escape button is independent of routing — it's the always-available
     // recovery for a hung routing refetch. Hold the onboarding fetch open so
     // routing never settles; the hatch must still appear the moment the watch
     // passes the escape window.

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -34,6 +34,7 @@ import type {
 import { readCheckoutIntent, saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import * as toastMod from "@vellumai/design-library/components/toast";
 
 import * as proOnboardingUtils from "./utils";
 
@@ -70,6 +71,19 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
     isLoading: false,
     invalidate: () => {},
   }),
+}));
+
+// Capture the escape toast so the exit-on-escape path can assert its message;
+// keep the real module's other methods intact.
+const toastInfoCalls: string[] = [];
+mock.module("@vellumai/design-library/components/toast", () => ({
+  ...toastMod,
+  toast: {
+    ...toastMod.toast,
+    info: (message: string) => {
+      toastInfoCalls.push(message);
+    },
+  },
 }));
 
 const realDateNow = Date.now.bind(Date);
@@ -326,6 +340,7 @@ beforeEach(() => {
   domainsFails = false;
   domainsHold = null;
   dateNowOffsetMs = 0;
+  toastInfoCalls.length = 0;
   sessionStorage.clear();
 });
 
@@ -612,89 +627,44 @@ describe("BillingOnboardingModal", () => {
   });
 
   test(
-    "a busy takeover past the escape grace with routing hung is dismissable via the backdrop",
+    "the stall shows the honest taking-longer copy — no Apply — and escaping kicks the reconcile, toasts, and closes",
     async () => {
-      // The purest dead-end: an active WAITING/RESIZING takeover whose
-      // post-confirm onboarding refetch is held open, so routing never settles
-      // and the in-content escape button (gated on routing) never appears.
-      // Once the watch runs past the escape grace, the fallback background
-      // dismiss must unlock — the takeover has no persistent close control, so
-      // this fallback is what keeps the user from being stranded.
-      onboardingHold = new Promise(() => {});
       subscriptionPlanId = "pro";
-      const { getByText, onClose } = renderModal();
+      const { getByText, getByTestId, queryByText, queryByTestId, onClose } =
+        renderModal();
 
       await waitFor(
         () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
         { timeout: 5000 },
       );
+      // The wizard reconciled once on the pro transition.
+      await waitFor(() => expect(ensureCalls).toBe(1));
 
-      // Past the escape grace (60s) but before the stall threshold (90s):
-      // escapeEligible latches while the state stays busy, not STALLED.
-      dateNowOffsetMs = 70_000;
-
-      // The X stays hidden throughout — the fallback exit is the backdrop.
-      expect(document.body.querySelector('[aria-label="Close"]')).toBeNull();
-
-      // The 1s clock tick re-derives escapeEligible; once it lands the backdrop
-      // unlocks, so re-click until the dismiss flows through to onClose.
+      // Jump the wall clock past the stall threshold; the hook's next clock
+      // tick re-derives the state as STALLED.
+      dateNowOffsetMs = 200_000;
       await waitFor(
-        () => {
-          const overlay = document.body.querySelector(
-            '[data-slot="modal-overlay"]',
-          );
-          expect(overlay).not.toBeNull();
-          fireEvent.click(overlay as Element);
-          expect(onClose).toHaveBeenCalled();
-        },
+        () =>
+          expect(getByText("This is taking longer than expected")).toBeTruthy(),
         { timeout: 5000 },
       );
+      // Apply & Restart is gone from the takeover.
+      expect(queryByTestId("provisioning-apply")).toBeNull();
 
-      // Still the busy takeover, not the stalled path (which has its own Apply).
-      expect(getByText("Upgrading your assistant…")).toBeTruthy();
+      // "Continue in the background" fires the idempotent reconcile as a
+      // fire-and-forget kick, toasts, and closes — it never advances the wizard.
+      fireEvent.click(getByTestId("provisioning-escape"));
+      await waitFor(() => expect(ensureCalls).toBe(2));
+      expect(onClose).toHaveBeenCalled();
+      expect(toastInfoCalls).toContain(
+        "Your upgrade continues in the background.",
+      );
+      // No advance to the email/All-set steps while the machine is busy.
+      expect(queryByText("Assistant Email")).toBeNull();
+      expect(queryByText("You're all set!")).toBeNull();
     },
     20_000,
   );
-
-  test("stall surfaces Apply & Restart; a successful apply resumes resizing through DONE", async () => {
-    subscriptionPlanId = "pro";
-    const { client, getByText, getByTestId } = renderModal();
-
-    await waitFor(
-      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    // The wizard reconciled once on the pro transition.
-    await waitFor(() => expect(ensureCalls).toBe(1));
-
-    // Jump the wall clock past the stall threshold; the hook's next clock
-    // tick re-derives the state as STALLED.
-    dateNowOffsetMs = 200_000;
-    await waitFor(() => expect(getByText("We couldn't finish this automatically")).toBeTruthy(), {
-      timeout: 5000,
-    });
-
-    // The stalled button re-calls the same idempotent reconcile.
-    fireEvent.click(getByTestId("provisioning-apply"));
-    await waitFor(() => expect(ensureCalls).toBe(2));
-
-    // The successful apply resumes observation: back to the resizing UI…
-    await waitFor(
-      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-
-    // …and the resize landing completes the normal DONE → advance flow.
-    assistantResponse = makeAssistant("large", 50);
-    await client.invalidateQueries();
-    await waitFor(
-      () => expect(getByText("All done!")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy(), {
-      timeout: 5000,
-    });
-  });
 
   test("onboarding fetch failure after confirm shows the fetch-error state", async () => {
     subscriptionPlanId = "pro";
@@ -757,64 +727,20 @@ describe("BillingOnboardingModal", () => {
     );
   });
 
-  test("domain submit stays disabled while the machine is resizing", async () => {
-    subscriptionPlanId = "pro";
-    const { client, getByText, getByTestId, getByLabelText } = renderModal();
-
-    await waitFor(
-      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-
-    // The escape hatch is a late fallback: it appears only once the watch has
-    // run past the escape window (and the onboarding fetch has settled).
-    dateNowOffsetMs = 61_000;
-    await waitFor(
-      () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    fireEvent.click(getByTestId("provisioning-escape"));
-    await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy());
-
-    expect(
-      getByText(
-        "Your assistant is restarting — you can set the domain in a moment.",
-      ),
-    ).toBeTruthy();
-    // Wait for the handle prefill: with an empty subdomain the submit would be
-    // disabled regardless, masking a missing machine-busy guard.
-    await waitFor(() =>
-      expect((getByLabelText("Handle (public)") as HTMLInputElement).value).toBe(
-        "casey",
-      ),
-    );
-    expect(
-      (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
-    ).toBe(true);
-
-    // The still-mounted hook sees the resize land and lifts the guard.
-    assistantResponse = makeAssistant("large", 50);
-    await client.invalidateQueries();
-    await waitFor(
-      () =>
-        expect(
-          (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
-        ).toBe(false),
-      { timeout: 5000 },
-    );
-  });
-
   test(
-    "escape advances to complete with the background-finishing line, which clears on DONE",
+    "escaping a busy takeover kicks the reconcile, toasts, and closes — it never advances to complete",
     async () => {
       subscriptionPlanId = "pro";
       onboardingResponse = makeOnboarding({ domain_setup_available: false });
-      const { client, getByText, getByTestId, queryByText } = renderModal();
+      const { getByText, getByTestId, queryByText, onClose } = renderModal();
 
       await waitFor(
         () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
         { timeout: 15_000 },
       );
+      // The wizard reconciled once on the pro transition.
+      await waitFor(() => expect(ensureCalls).toBe(1));
+
       dateNowOffsetMs = 61_000;
       await waitFor(
         () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
@@ -822,14 +748,15 @@ describe("BillingOnboardingModal", () => {
       );
       fireEvent.click(getByTestId("provisioning-escape"));
 
-      await waitFor(() => expect(getByText("You're all set!")).toBeTruthy());
-      expect(getByText(BACKGROUND_LINE)).toBeTruthy();
-
-      assistantResponse = makeAssistant("large", 50);
-      await client.invalidateQueries();
-      await waitFor(() => expect(queryByText(BACKGROUND_LINE)).toBeNull(), {
-        timeout: 15_000,
-      });
+      // A fire-and-forget kick, an error-free toast, and a close — no advance to
+      // the All-set step, no background-finishing line.
+      await waitFor(() => expect(ensureCalls).toBe(2));
+      expect(onClose).toHaveBeenCalled();
+      expect(toastInfoCalls).toContain(
+        "Your upgrade continues in the background.",
+      );
+      expect(queryByText("You're all set!")).toBeNull();
+      expect(queryByText(BACKGROUND_LINE)).toBeNull();
     },
     30_000,
   );
@@ -858,184 +785,65 @@ describe("BillingOnboardingModal", () => {
     20_000,
   );
 
-  test("escape hatch waits for fresh routing data even once time-eligible", async () => {
-    let releaseOnboarding!: () => void;
-    onboardingHold = new Promise((resolve) => {
-      releaseOnboarding = resolve;
-    });
+  test("escape hatch appears once time-eligible even while routing is unsettled", async () => {
+    // The escape button no longer waits on routing — it's the always-available
+    // recovery for a hung routing refetch. Hold the onboarding fetch open so
+    // routing never settles; the hatch must still appear the moment the watch
+    // passes the escape window.
+    onboardingHold = new Promise(() => {});
     subscriptionPlanId = "pro";
-    const { getByText, getByTestId, queryByTestId } = renderModal();
+    const { getByText, getByTestId } = renderModal();
 
     await waitFor(
       () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
     dateNowOffsetMs = 61_000;
-    // Time-eligible, but domain_setup_available could still be stale — the
-    // hatch must wait for the onboarding fetch to settle.
-    await new Promise((resolve) => setTimeout(resolve, 1200));
-    expect(queryByTestId("provisioning-escape")).toBeNull();
-
-    releaseOnboarding();
     await waitFor(
       () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
       { timeout: 5000 },
     );
   });
 
-  test("a failed apply surfaces its error and a late-landing resize still recovers", async () => {
-    subscriptionPlanId = "pro";
-    const { client, getByText, getByTestId } = renderModal();
-
-    await waitFor(
-      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    dateNowOffsetMs = 200_000;
-    await waitFor(() => expect(getByText("We couldn't finish this automatically")).toBeTruthy(), {
-      timeout: 5000,
-    });
-
-    // Only a user-initiated reconcile surfaces its failure — the automatic one
-    // on the pro transition degrades silently.
-    ensureError = { error: "provisioning_submission_failed" };
-    fireEvent.click(getByTestId("provisioning-apply"));
-    await waitFor(() => expect(ensureCalls).toBe(2));
-    await waitFor(() =>
-      expect(
-        getByText("We couldn't queue your upgrade just now. Try again in a moment."),
-      ).toBeTruthy(),
-    );
-    expect(getByText("We couldn't finish this automatically")).toBeTruthy();
-
-    // If a server-side resize was in fact still running, its landing is
-    // observed by the actuals polling and replaces the stalled UI.
-    assistantResponse = makeAssistant("large", 50);
-    await client.invalidateQueries();
-    await waitFor(
-      () => expect(getByText("All done!")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-  });
-
   test(
-    "a stall after escaping to complete offers Apply & Restart there",
+    "a failed auto-reconcile shows the snag variant; escaping retries in the background and closes",
     async () => {
       subscriptionPlanId = "pro";
-      onboardingResponse = makeOnboarding({ domain_setup_available: false });
-      const { client, getByText, getByTestId, queryByText, queryByTestId } =
-        renderModal();
-
-      await waitFor(
-        () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
-        { timeout: 15_000 },
-      );
-      dateNowOffsetMs = 61_000;
-      await waitFor(
-        () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
-        { timeout: 15_000 },
-      );
-      fireEvent.click(getByTestId("provisioning-escape"));
-      await waitFor(() => expect(getByText("You're all set!")).toBeTruthy());
-      expect(getByText(BACKGROUND_LINE)).toBeTruthy();
-
-      // The backgrounded resize stalls: the finishing line swaps for a warning
-      // with a manual apply.
-      dateNowOffsetMs = 200_000;
-      await waitFor(
-        () => expect(getByTestId("complete-stalled-apply")).toBeTruthy(),
-        { timeout: 15_000 },
-      );
-      expect(queryByText(BACKGROUND_LINE)).toBeNull();
-
-      // Applying resumes observation — the finishing line returns…
-      fireEvent.click(getByTestId("complete-stalled-apply"));
-      await waitFor(() => expect(ensureCalls).toBe(2));
-      await waitFor(() => expect(getByText(BACKGROUND_LINE)).toBeTruthy(), {
-        timeout: 15_000,
-      });
-
-      // …and the resize landing clears it.
-      assistantResponse = makeAssistant("large", 50);
-      await client.invalidateQueries();
-      await waitFor(() => expect(queryByText(BACKGROUND_LINE)).toBeNull(), {
-        timeout: 15_000,
-      });
-      expect(queryByTestId("complete-stalled-apply")).toBeNull();
-    },
-    30_000,
-  );
-
-  test(
-    "a stall while the user is on the domain step offers the apply controls and keeps the submit locked",
-    async () => {
-      subscriptionPlanId = "pro";
-      const {
-        client,
-        getByText,
-        getByTestId,
-        getByLabelText,
-        queryByText,
-        queryByTestId,
-      } = renderModal();
+      // The automatic reconcile on the pro transition fails, so its error is
+      // held as kickError — the ≥90s stall then shows the "snag" variant.
+      ensureError = { error: "provisioning_submission_failed" };
+      const { getByText, getByTestId, queryByTestId, onClose } = renderModal();
 
       await waitFor(
         () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
         { timeout: 5000 },
       );
-      dateNowOffsetMs = 61_000;
-      await waitFor(
-        () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
-        { timeout: 5000 },
-      );
-      fireEvent.click(getByTestId("provisioning-escape"));
-      await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy());
-      await waitFor(() =>
-        expect((getByLabelText("Handle (public)") as HTMLInputElement).value).toBe(
-          "casey",
-        ),
-      );
+      await waitFor(() => expect(ensureCalls).toBe(1));
 
-      // The flow stalls while the user is on the domain step: the machine may
-      // still be mid-restart, so the guardian-channel submit stays locked and
-      // the neutral busy notice swaps for the stalled warning + manual apply.
       dateNowOffsetMs = 200_000;
-      await waitFor(
-        () => expect(getByTestId("domain-stalled-apply")).toBeTruthy(),
-        { timeout: 5000 },
-      );
-      expect(
-        queryByText(
-          "Your assistant is restarting — you can set the domain in a moment.",
-        ),
-      ).toBeNull();
-      expect(
-        (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
-      ).toBe(true);
-
-      // Applying resumes observation: the stalled controls give way to the
-      // neutral busy notice while the resize is re-observed…
-      fireEvent.click(getByTestId("domain-stalled-apply"));
-      await waitFor(() => expect(ensureCalls).toBe(2));
-      await waitFor(() =>
-        expect(
-          getByText(
-            "Your assistant is restarting — you can set the domain in a moment.",
-          ),
-        ).toBeTruthy(),
-      );
-      expect(queryByTestId("domain-stalled-apply")).toBeNull();
-
-      // …and the resize landing lifts the guard.
-      assistantResponse = makeAssistant("large", 50);
-      await client.invalidateQueries();
       await waitFor(
         () =>
           expect(
-            (getByTestId("onboarding-domain-set") as HTMLButtonElement)
-              .disabled,
-          ).toBe(false),
+            getByText("We hit a snag upgrading your assistant"),
+          ).toBeTruthy(),
         { timeout: 5000 },
+      );
+      // The mapped error is the caption, and Apply & Restart is gone.
+      expect(
+        getByText(
+          "We couldn't queue your upgrade just now. Try again in a moment.",
+        ),
+      ).toBeTruthy();
+      expect(queryByTestId("provisioning-apply")).toBeNull();
+
+      // The snag CTA reads "Retry in the background": it re-kicks the reconcile,
+      // toasts the error-aware line, and closes.
+      expect(getByText("Retry in the background")).toBeTruthy();
+      fireEvent.click(getByTestId("provisioning-escape"));
+      await waitFor(() => expect(ensureCalls).toBe(2));
+      expect(onClose).toHaveBeenCalled();
+      expect(toastInfoCalls).toContain(
+        "We'll retry your upgrade in the background.",
       );
     },
     20_000,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -157,9 +157,9 @@ export function BillingOnboardingModal({
   const provisioningSettled = isSettled(provisioning.state);
 
   // The lock describes the screen the user is looking at, so it reads the
-  // takeover's held phase rather than the live one. The steps after it keep
-  // tracking live provisioning: a resize backgrounded via the escape hatch has
-  // to unblock the domain step when it actually finishes.
+  // takeover's held phase rather than the live one. The domain step still keys
+  // its submit guard off live provisioning, so a resize that finishes after a
+  // genuine advance into that step unblocks it the moment it settles.
   const onScreenPhase = displayedPhase ?? provisioning.state;
   const onScreenSettled = isSettled(onScreenPhase);
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -324,9 +324,9 @@ export function BillingOnboardingModal({
 
   // Lock Esc/backdrop while provisioning is active. The takeover exposes no
   // persistent close control, but the in-content "Continue in the background"
-  // button becomes available the moment the escape window elapses (no longer
-  // gated on routing), so a hung routing refetch can't strand the user. Only a
-  // terminal ready state unlocks the backdrop itself.
+  // button is independent of routing freshness — it needs only the machine busy
+  // and the escape window elapsed — so a hung routing refetch can't strand the
+  // user. Only a terminal ready state unlocks the backdrop itself.
   const lockTakeover = isTakeover && !onScreenSettled;
 
   // Full-bleed dark content that fills the viewport for the takeover.

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -287,10 +287,10 @@ export function BillingOnboardingModal({
     );
   }, [domainSetupAvailable, isResize, hasExistingDomain]);
 
-  // "Continue in the background" no longer advances the wizard while the
-  // machine is busy — it kicks the idempotent ensure-provisioned reconcile,
-  // toasts (error-aware), and closes the takeover so the user is handed back to
-  // the app rather than parked on the email/All-set steps mid-provisioning.
+  // "Continue in the background" kicks the idempotent ensure-provisioned
+  // reconcile, shows an error-aware toast, and closes the takeover so the user
+  // is handed back to the app rather than parked on the email/All-set steps
+  // mid-provisioning.
   const escapeProvisioning = useCallback(() => {
     provisioning.kickProvisioning();
     toast.info(
@@ -350,7 +350,9 @@ export function BillingOnboardingModal({
     <Modal.Root
       open={open}
       onOpenChange={(o) => {
-        if (!o) onClose();
+        if (!o) {
+          onClose();
+        }
       }}
     >
       <Modal.Content

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -191,8 +191,8 @@ export function BillingOnboardingModal({
   // recently-cached list without a refetch. Force one refetch for this open the
   // moment the query is enabled, exactly as use-pro-provisioning invalidates the
   // subscription and onboarding queries on open; without it a fresh-enough cache
-  // never advances `domainsUpdatedAt` past the fence and routing can only fall
-  // through the escape hatch.
+  // never advances `domainsUpdatedAt` past the fence and routing strands,
+  // leaving the escape CTA (which closes the takeover) as the only way out.
   //
   // `assistantId` can CHANGE mid-open: `provisioning.assistantId` starts on the
   // active assistant and flips to the onboarding payload's primary once that
@@ -243,9 +243,10 @@ export function BillingOnboardingModal({
     !domainsFetching && (domainsFreshData || domainsFreshError);
   // Routing must never use a stale domain_setup_available: until the first
   // post-confirm fetch settles, TanStack may still serve pre-checkout cached
-  // data. Both the celebration dwell and the escape hatch wait on this.
-  // Latched: once fresh data has landed, a later background refetch must not
-  // yank the escape hatch or restart the dwell.
+  // data. The celebration dwell and the DONE advance wait on this; the escape
+  // CTA does not — it gates only on the machine being busy and the escape
+  // window having elapsed. Latched: once fresh data has landed, a later
+  // background refetch must not restart the dwell or flip the routing decision.
   const [routingSettled, setRoutingSettled] = useState(false);
   const routingInputsSettled =
     onboardingSettled && (!domainAnswerNeeded || domainsKnown);

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -156,12 +156,11 @@ export function BillingOnboardingModal({
   const machineBusy = isMachineBusy(provisioning.state);
   const provisioningSettled = isSettled(provisioning.state);
 
-  // The lock and the close toast describe the screen the user is looking at, so
-  // they read the takeover's held phase rather than the live one. The steps
-  // after it keep tracking live provisioning: a resize backgrounded via the
-  // escape hatch has to unblock the domain step when it actually finishes.
+  // The lock describes the screen the user is looking at, so it reads the
+  // takeover's held phase rather than the live one. The steps after it keep
+  // tracking live provisioning: a resize backgrounded via the escape hatch has
+  // to unblock the domain step when it actually finishes.
   const onScreenPhase = displayedPhase ?? provisioning.state;
-  const onScreenBusy = isMachineBusy(onScreenPhase);
   const onScreenSettled = isSettled(onScreenPhase);
 
   const { targets, assistantId, domainSetupAvailable, onboardingSettled } =
@@ -288,10 +287,19 @@ export function BillingOnboardingModal({
     );
   }, [domainSetupAvailable, isResize, hasExistingDomain]);
 
+  // "Continue in the background" no longer advances the wizard while the
+  // machine is busy — it kicks the idempotent ensure-provisioned reconcile,
+  // toasts (error-aware), and closes the takeover so the user is handed back to
+  // the app rather than parked on the email/All-set steps mid-provisioning.
   const escapeProvisioning = useCallback(() => {
-    setFinishedInBackground(true);
-    advanceFromProvisioning();
-  }, [advanceFromProvisioning]);
+    provisioning.kickProvisioning();
+    toast.info(
+      provisioning.kickError != null
+        ? "We'll retry your upgrade in the background."
+        : "Your upgrade continues in the background.",
+    );
+    onClose();
+  }, [provisioning, onClose]);
 
   // Stalled recovery re-calls the idempotent, org-wide ensure-provisioned
   // reconcile — the same path the wizard fires on Pro confirmation. Its errors
@@ -308,27 +316,18 @@ export function BillingOnboardingModal({
     step === "provisioning" &&
     (provisioning.confirmError || provisioning.targetsError);
 
-  const handleClose = () => {
-    if (step === "provisioning" && !provisioningError && onScreenBusy) {
-      toast.info("Your upgrade continues in the background.");
-    }
-    onClose();
-  };
-
   // The live provisioning takeover is the user's first real touchpoint with the
   // flow; we lock it so an accidental backdrop click or Esc can't bail them out
-  // mid-provisioning. Sanctioned exits (escape hatch, stalled apply, timeout
+  // mid-provisioning. Sanctioned exits (the escape hatch and the timeout
   // actions) live inside the step content.
   const isTakeover = step === "provisioning" && !provisioningError;
 
   // Lock Esc/backdrop while provisioning is active. The takeover exposes no
-  // persistent close control, so two escape valves guarantee a hung routing
-  // refetch can't strand the user: terminal ready states unlock, and a busy
-  // state stuck past the escape grace with routing still hung unlocks to a plain
-  // background-dismiss (the in-content escape hatch needs routing to have settled).
-  const stuckAwaitingRouting =
-    onScreenBusy && provisioning.escapeEligible && !routingSettled;
-  const lockTakeover = isTakeover && !onScreenSettled && !stuckAwaitingRouting;
+  // persistent close control, but the in-content "Continue in the background"
+  // button becomes available the moment the escape window elapses (no longer
+  // gated on routing), so a hung routing refetch can't strand the user. Only a
+  // terminal ready state unlocks the backdrop itself.
+  const lockTakeover = isTakeover && !onScreenSettled;
 
   // Full-bleed dark content that fills the viewport for the takeover.
   const provisioningContentClass =
@@ -351,7 +350,7 @@ export function BillingOnboardingModal({
     <Modal.Root
       open={open}
       onOpenChange={(o) => {
-        if (!o) handleClose();
+        if (!o) onClose();
       }}
     >
       <Modal.Content
@@ -423,12 +422,10 @@ export function BillingOnboardingModal({
           celebrating={routingSettled}
           onCelebrationEnd={advanceFromProvisioning}
           assistantId={assistantId}
-          escapeAvailable={
-            machineBusy && routingSettled && provisioning.escapeEligible
-          }
+          escapeAvailable={machineBusy && provisioning.escapeEligible}
           onEscape={escapeProvisioning}
           onPhaseChange={setDisplayedPhase}
-          stalledAction={stalledAction}
+          kickError={provisioning.kickError}
           confirm={{
             onRetry: provisioning.retryConfirm,
             onGoToBilling: onClose,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -83,7 +83,6 @@ function baseProps(
     onCelebrationEnd: () => {},
     escapeAvailable: false,
     onEscape: () => {},
-    stalledAction: { onApply: () => {}, pending: false, error: null },
     confirm: { onRetry: () => {}, onGoToBilling: () => {} },
     ...overrides,
   };
@@ -421,40 +420,62 @@ describe("done / not_applicable", () => {
 });
 
 describe("stalled", () => {
-  test("renders the stalled status, keeps the chips, and Apply & Restart invokes the callback", () => {
-    const onApply = mock(() => {});
-    const { getByText, getByTestId } = renderState({
+  test("with no captured error shows the honest taking-longer copy, chips, and the background button — never an Apply", () => {
+    const onEscape = mock(() => {});
+    const { getByText, queryByTestId, getByTestId } = renderState({
       state: "STALLED",
       targets: { machineSize: "large", storageGib: null },
       fromSnapshot: { machineSize: "small", storageGib: null },
-      stalledAction: { onApply, pending: false, error: null },
+      escapeAvailable: true,
+      onEscape,
     });
 
-    expect(getByText("We couldn't finish this automatically")).toBeTruthy();
-    expect(
-      getByText("Apply the changes below to finish setting up your upgrade."),
-    ).toBeTruthy();
+    expect(getByText("This is taking longer than expected")).toBeTruthy();
+    expect(getByText("This may take a couple of minutes.")).toBeTruthy();
     expect(getByText("Machine")).toBeTruthy();
-    fireEvent.click(getByTestId("provisioning-apply"));
-    expect(onApply).toHaveBeenCalledTimes(1);
+    // Apply & Restart is gone from the takeover entirely.
+    expect(queryByTestId("provisioning-apply")).toBeNull();
+    expect(getByText("Continue in the background")).toBeTruthy();
+    fireEvent.click(getByTestId("provisioning-escape"));
+    expect(onEscape).toHaveBeenCalledTimes(1);
   });
 
-  test("disables the Apply button while pending and renders the extracted error as the caption", () => {
-    const onApply = mock(() => {});
-    const { getByText, getByTestId } = renderState({
+  test("with a captured reconcile error shows the snag copy, the mapped error, and a Retry-in-background button", () => {
+    const { getByText, queryByTestId } = renderState({
       state: "STALLED",
-      stalledAction: {
-        onApply,
-        pending: true,
-        error: { detail: "Resize already in progress." },
-      },
+      escapeAvailable: true,
+      kickError: { detail: "Resize already in progress." },
     });
 
+    expect(getByText("We hit a snag upgrading your assistant")).toBeTruthy();
     expect(getByText("Resize already in progress.")).toBeTruthy();
-    const apply = getByTestId("provisioning-apply") as HTMLButtonElement;
-    expect(apply.disabled).toBe(true);
-    fireEvent.click(apply);
-    expect(onApply).not.toHaveBeenCalled();
+    expect(queryByTestId("provisioning-apply")).toBeNull();
+    expect(getByText("Retry in the background")).toBeTruthy();
+  });
+
+  test("the background button relabels to Retry once a reconcile has errored", () => {
+    const { getByText, queryByText, rerender } = renderState({
+      state: "STALLED",
+      escapeAvailable: true,
+    });
+
+    expect(getByText("Continue in the background")).toBeTruthy();
+    expect(queryByText("Retry in the background")).toBeNull();
+
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <ProvisioningState
+          {...baseProps({
+            state: "STALLED",
+            escapeAvailable: true,
+            kickError: { error: "provisioning_submission_failed" },
+          })}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(getByText("Retry in the background")).toBeTruthy();
+    expect(queryByText("Continue in the background")).toBeNull();
   });
 
   test("an unchanged machine dimension renders singular while storage still arrows", () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -22,7 +22,7 @@ import type {
   ProvisioningDimensions,
   ProvisioningStateKind,
 } from "./provisioning-machine";
-import { SERIF_HEADING_STYLE, type StalledApplyAction } from "./primitives";
+import { SERIF_HEADING_STYLE } from "./primitives";
 import {
   buildResourceChanges,
   type ResourceChangeKey,
@@ -130,7 +130,11 @@ export interface ProvisioningStateProps {
   onEscape: () => void;
   /** Reports the phase actually on screen, which lags `state` by the hold. */
   onPhaseChange?: (phase: ProvisioningStateKind) => void;
-  stalledAction: StalledApplyAction;
+  /**
+   * ensure-provisioned failure held by the hook; with STALLED it selects the
+   * snag variant.
+   */
+  kickError?: unknown;
   confirm: { onRetry: () => void; onGoToBilling: () => void };
   /** Test hook — overrides the per-phase minimum; 0 disables the hold. */
   phaseMinMs?: number;
@@ -502,7 +506,7 @@ export function ProvisioningState({
   escapeAvailable,
   onEscape,
   onPhaseChange,
-  stalledAction,
+  kickError,
   confirm,
   dwellMs = PROVISION_MIN_DWELL_MS,
   phaseMinMs = PROVISION_PHASE_MIN_MS,
@@ -581,7 +585,7 @@ export function ProvisioningState({
     </div>
   );
 
-  function escapeButton() {
+  function escapeButton(label = "Continue in the background") {
     if (!escapeAvailable) {
       return null;
     }
@@ -591,7 +595,7 @@ export function ProvisioningState({
         data-testid="provisioning-escape"
         onClick={onEscape}
       >
-        Continue in the background
+        {label}
       </Button>
     );
   }
@@ -676,25 +680,33 @@ export function ProvisioningState({
     }
 
     if (heldState === "STALLED") {
+      // With no captured reconcile error the wait is just slow — say so
+      // honestly. Only an actual failure escalates to the "snag" variant with
+      // the mapped error and a retry-flavoured escape label.
+      const snag = kickError != null;
       return (
         <>
           <Copy
-            status="We couldn't finish this automatically"
-            caption={extractOnboardingErrorMessage(
-              stalledAction.error,
-              "Apply the changes below to finish setting up your upgrade.",
-            )}
+            status={
+              snag
+                ? "We hit a snag upgrading your assistant"
+                : "This is taking longer than expected"
+            }
+            caption={
+              snag
+                ? extractOnboardingErrorMessage(
+                    kickError,
+                    "Retry in the background — we'll keep working on your upgrade.",
+                  )
+                : "This may take a couple of minutes."
+            }
           />
-          <TargetChips targets={targets} fromSnapshot={fromSnapshot} />
-          <Button
-            variant="primary"
-            data-testid="provisioning-apply"
-            disabled={stalledAction.pending}
-            onClick={stalledAction.onApply}
-          >
-            Apply &amp; Restart
-          </Button>
-          {escapeButton()}
+          <ResourceChangeChips
+            intent={intent}
+            targets={targets}
+            fromSnapshot={fromSnapshot}
+          />
+          {snag ? escapeButton("Retry in the background") : escapeButton()}
         </>
       );
     }


### PR DESCRIPTION
## Summary
- Continue in the background now fires ensure-provisioned and closes the modal (no advancing to email/All-set while busy).
- 90s STALLED shows honest 'taking longer' copy; an errored reconcile shows a 'we hit a snag' variant with a 'Retry in the background' CTA.
- Removes Apply & Restart from the takeover and the routing-hung escape valve.

Part of plan: pro-takeover-exit-on-escape.md (PR 3 of 5)