### PR TITLE
Plan CTA copy + Add-Credits "Configure Automatic Top-Ups" wiring

### DIFF
--- a/clients/web/src/components/add-credits-modal.test.tsx
+++ b/clients/web/src/components/add-credits-modal.test.tsx
@@ -47,6 +47,8 @@ describe("AddCreditsModal", () => {
     const link = screen.getByRole("link", {
       name: /Configure Automatic Top-Ups/,
     });
-    expect(link.getAttribute("href")).toBe(routes.settings.usageBilling);
+    expect(link.getAttribute("href")).toBe(
+      routes.settings.usageBillingConfigureTopUps,
+    );
   });
 });

--- a/clients/web/src/components/add-credits-modal.tsx
+++ b/clients/web/src/components/add-credits-modal.tsx
@@ -158,7 +158,7 @@ export function AddCreditsModal({ open, onOpenChange }: AddCreditsModalProps) {
             )}
 
             <Link
-              to={routes.settings.usageBilling}
+              to={routes.settings.usageBillingConfigureTopUps}
               className="flex items-center gap-1 text-body-small-default text-[var(--content-tertiary)] hover:text-[var(--content-secondary)]"
               onClick={() => onOpenChange(false)}
             >

--- a/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -1,6 +1,6 @@
 /**
- * Tests for the AutoTopUpCard enabled-state layout and the repeated-decline
- * cutoff notice:
+ * Tests for the AutoTopUpCard enabled-state layout, the repeated-decline
+ * cutoff notice, and the `configure_top_up` deeplink:
  *  - The enabled view renders the payment-method row above two summary chips
  *    (spend rule + monthly-cap progress) and Adjust swaps the chips for the
  *    inline form.
@@ -11,24 +11,30 @@
  *    renders no such notice; the notice is suppressed when `enabled`.
  *  - Toggling Enable on while cut off (even with a saved PM) does NOT open the
  *    form.
+ *  - Arriving with `?configure_top_up=1` replays the toggle-on path (reveal the
+ *    form, or the add-card gate with no PM), no-ops while enabled, and never
+ *    fires an update mutation.
  *
  * Strategy: the render-only cases pre-populate the React Query cache so the
  * card's `useQuery` resolves synchronously — `renderToStaticMarkup` is
  * single-pass, so a pending query would otherwise report `isLoading`. The
  * interaction cases use @testing-library/react (happy-dom via the test
  * preload). The remove flow mocks the SDK boundary so the mutation and the
- * follow-up GET are deterministic.
+ * follow-up GET are deterministic. Every render is wrapped in a MemoryRouter
+ * because the card reads `useSearchParams`.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
 
 import * as sdkGen from "@/generated/api/sdk.gen";
 import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 
 let removeCalls: Array<Record<string, unknown>> = [];
+let updateCalls: Array<Record<string, unknown>> = [];
 let removeShouldFail = false;
 let retrieveResponse: AutoTopUpConfigResponse;
 
@@ -55,6 +61,12 @@ mock.module("@/generated/api/sdk.gen", () => ({
       response: { ok: true },
     });
   },
+  // Record any auto-top-up update (the PUT that persists a config). The
+  // `configure_top_up` deeplink must never trigger this on mount.
+  organizationsBillingAutoTopUpUpdate: (opts: Record<string, unknown>) => {
+    updateCalls.push(opts);
+    return Promise.resolve({ data: retrieveResponse, response: { ok: true } });
+  },
   organizationsBillingAutoTopUpRetrieve: () =>
     Promise.resolve({ data: retrieveResponse, response: { ok: true } }),
 }));
@@ -74,12 +86,22 @@ function makeClient(config: AutoTopUpConfigResponse): QueryClient {
   return client;
 }
 
-function renderCard(config: AutoTopUpConfigResponse): string {
-  return renderToStaticMarkup(
+/**
+ * Wrap the card in a QueryClientProvider (cache pre-seeded from `config`) and a
+ * MemoryRouter at `route`, so both `useQuery` and `useSearchParams` resolve.
+ */
+function wrap(config: AutoTopUpConfigResponse, route = "/") {
+  return (
     <QueryClientProvider client={makeClient(config)}>
-      <AutoTopUpCard />
-    </QueryClientProvider>,
+      <MemoryRouter initialEntries={[route]}>
+        <AutoTopUpCard />
+      </MemoryRouter>
+    </QueryClientProvider>
   );
+}
+
+function renderCard(config: AutoTopUpConfigResponse, route = "/"): string {
+  return renderToStaticMarkup(wrap(config, route));
 }
 
 const ENABLED_WITH_CARD: AutoTopUpConfigResponse = {
@@ -104,6 +126,7 @@ const DISABLED_WITH_CARD: AutoTopUpConfigResponse = {
 
 beforeEach(() => {
   removeCalls = [];
+  updateCalls = [];
   removeShouldFail = false;
   retrieveResponse = { ...DISABLED_CONFIG };
 });
@@ -113,11 +136,7 @@ afterEach(cleanup);
 describe("AutoTopUpCard enabled-state layout", () => {
   test("renders both summary chips and Adjust swaps them for the form", () => {
     retrieveResponse = { ...ENABLED_WITH_CARD };
-    const { container, getByTestId } = render(
-      <QueryClientProvider client={makeClient(ENABLED_WITH_CARD)}>
-        <AutoTopUpCard />
-      </QueryClientProvider>,
-    );
+    const { container, getByTestId } = render(wrap(ENABLED_WITH_CARD));
 
     expect(getByTestId("auto-top-up-summary").textContent).toContain(
       "Add $200 when balance falls under $50",
@@ -158,11 +177,7 @@ describe("AutoTopUpCard enabled-state layout", () => {
 describe("AutoTopUpCard remove card", () => {
   test("confirming Remove calls the endpoint and disables Extra Usage", async () => {
     retrieveResponse = { ...ENABLED_WITH_CARD };
-    const { container, getByLabelText } = render(
-      <QueryClientProvider client={makeClient(ENABLED_WITH_CARD)}>
-        <AutoTopUpCard />
-      </QueryClientProvider>,
-    );
+    const { container, getByLabelText } = render(wrap(ENABLED_WITH_CARD));
 
     // Precondition: the card is on file and Extra Usage is on.
     expect(
@@ -215,9 +230,7 @@ describe("AutoTopUpCard remove card", () => {
   test("removing while in Adjust form mode exits the form and disables Extra Usage", async () => {
     retrieveResponse = { ...ENABLED_WITH_CARD };
     const { container, getByLabelText, getByTestId } = render(
-      <QueryClientProvider client={makeClient(ENABLED_WITH_CARD)}>
-        <AutoTopUpCard />
-      </QueryClientProvider>,
+      wrap(ENABLED_WITH_CARD),
     );
 
     // Enter Adjust form mode: the inline form (Save) mounts.
@@ -265,11 +278,7 @@ describe("AutoTopUpCard remove card", () => {
   test("a failed removal closes the confirm dialog and surfaces the error notice", async () => {
     removeShouldFail = true;
     retrieveResponse = { ...ENABLED_WITH_CARD };
-    const { container } = render(
-      <QueryClientProvider client={makeClient(ENABLED_WITH_CARD)}>
-        <AutoTopUpCard />
-      </QueryClientProvider>,
-    );
+    const { container } = render(wrap(ENABLED_WITH_CARD));
 
     fireEvent.click(
       container.querySelector('[data-testid="payment-method-remove"]')!,
@@ -326,11 +335,7 @@ describe("AutoTopUpCard disabled with a saved card", () => {
 
   test("confirming Remove from the disabled state calls the endpoint and clears the card", async () => {
     retrieveResponse = { ...DISABLED_WITH_CARD };
-    const { container, getByLabelText } = render(
-      <QueryClientProvider client={makeClient(DISABLED_WITH_CARD)}>
-        <AutoTopUpCard />
-      </QueryClientProvider>,
-    );
+    const { container, getByLabelText } = render(wrap(DISABLED_WITH_CARD));
 
     // Precondition: Extra Usage is off but the card row is on file.
     expect(getByLabelText("Enable Extra Usage").getAttribute("aria-checked")).toBe(
@@ -438,11 +443,7 @@ describe("AutoTopUpCard enable gate", () => {
       disabled_due_to_repeated_failures: true,
     };
 
-    const { container, getByLabelText } = render(
-      <QueryClientProvider client={makeClient(config)}>
-        <AutoTopUpCard />
-      </QueryClientProvider>,
-    );
+    const { container, getByLabelText } = render(wrap(config));
     const form = () =>
       container.querySelector('[data-testid="auto-top-up-save-button"]');
 
@@ -468,11 +469,7 @@ describe("AutoTopUpCard enable gate", () => {
       disabled_due_to_repeated_failures: false,
     };
 
-    const { container, getByLabelText } = render(
-      <QueryClientProvider client={makeClient(config)}>
-        <AutoTopUpCard />
-      </QueryClientProvider>,
-    );
+    const { container, getByLabelText } = render(wrap(config));
     const form = () =>
       container.querySelector('[data-testid="auto-top-up-save-button"]');
 
@@ -494,11 +491,7 @@ describe("AutoTopUpCard enable gate", () => {
       disabled_due_to_repeated_failures: false,
     };
 
-    const { container, getByLabelText } = render(
-      <QueryClientProvider client={makeClient(config)}>
-        <AutoTopUpCard />
-      </QueryClientProvider>,
-    );
+    const { container, getByLabelText } = render(wrap(config));
     const form = () =>
       container.querySelector('[data-testid="auto-top-up-save-button"]');
     const addPmButton = () =>
@@ -527,11 +520,7 @@ describe("AutoTopUpCard enable gate", () => {
       disabled_due_to_repeated_failures: false,
     };
 
-    const { container, getByLabelText } = render(
-      <QueryClientProvider client={makeClient(config)}>
-        <AutoTopUpCard />
-      </QueryClientProvider>,
-    );
+    const { container, getByLabelText } = render(wrap(config));
 
     fireEvent.click(getByLabelText("Enable Extra Usage"));
 
@@ -539,5 +528,88 @@ describe("AutoTopUpCard enable gate", () => {
       "Extra usage requires you to connect a credit card.",
     );
     expect(container.textContent).not.toContain("ACTION");
+  });
+});
+
+describe("AutoTopUpCard configure_top_up deeplink", () => {
+  test("arriving with ?configure_top_up=1 (disabled, PM on file) reveals the configure form", () => {
+    const config: AutoTopUpConfigResponse = {
+      ...DISABLED_CONFIG,
+      enabled: false,
+      has_payment_method: true,
+      disabled_due_to_repeated_failures: false,
+    };
+
+    const { container, getByLabelText } = render(
+      wrap(config, "/?configure_top_up=1"),
+    );
+
+    // The toggle-on path ran: the toggle flipped and the configure form opened,
+    // exactly as clicking the toggle would — with no update mutation.
+    expect(getByLabelText("Enable Extra Usage").getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(
+      container.querySelector('[data-testid="auto-top-up-save-button"]'),
+    ).not.toBeNull();
+    expect(updateCalls.length).toBe(0);
+  });
+
+  test("arriving with ?configure_top_up=1 and no PM shows the Add a Credit Card gate", () => {
+    const config: AutoTopUpConfigResponse = {
+      ...DISABLED_CONFIG,
+      enabled: false,
+      has_payment_method: false,
+      disabled_due_to_repeated_failures: false,
+    };
+
+    const { container, getByLabelText } = render(
+      wrap(config, "/?configure_top_up=1"),
+    );
+
+    // No PM on file → the add-card gate is shown instead of the form.
+    expect(getByLabelText("Enable Extra Usage").getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(
+      container.querySelector('[data-testid="auto-top-up-add-pm-button"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="auto-top-up-save-button"]'),
+    ).toBeNull();
+    expect(updateCalls.length).toBe(0);
+  });
+
+  test("arriving with ?configure_top_up=1 while already enabled is a no-op", () => {
+    retrieveResponse = { ...ENABLED_WITH_CARD };
+    const { container } = render(wrap(ENABLED_WITH_CARD, "/?configure_top_up=1"));
+
+    // Already enabled: the effect strips the param but does not enter the form
+    // or fire a mutation — the enabled summary stays put.
+    expect(
+      container.querySelector('[data-testid="auto-top-up-summary"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="auto-top-up-save-button"]'),
+    ).toBeNull();
+    expect(updateCalls.length).toBe(0);
+  });
+
+  test("without the param the card stays disabled and closed (no auto-open)", () => {
+    const config: AutoTopUpConfigResponse = {
+      ...DISABLED_CONFIG,
+      enabled: false,
+      has_payment_method: true,
+    };
+
+    const { container, getByLabelText } = render(wrap(config, "/"));
+
+    expect(getByLabelText("Enable Extra Usage").getAttribute("aria-checked")).toBe(
+      "false",
+    );
+    expect(
+      container.querySelector('[data-testid="auto-top-up-save-button"]'),
+    ).toBeNull();
+    expect(updateCalls.length).toBe(0);
   });
 });

--- a/clients/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -1,6 +1,7 @@
 import { Coins, Info, X } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useSearchParams } from "react-router";
 
 import {
     organizationsBillingAutoTopUpDisableCreateMutation,
@@ -147,6 +148,9 @@ export function AutoTopUpCard() {
     organizationsBillingAutoTopUpRemovePaymentMethodCreateMutation(),
   );
 
+  const [searchParams, setSearchParams] = useSearchParams();
+  const cardRef = useRef<HTMLDivElement>(null);
+
   const [mode, setMode] = useState<Mode>("view");
   const [pendingEnable, setPendingEnable] = useState(false);
   const [confirmingDisable, setConfirmingDisable] = useState(false);
@@ -165,6 +169,51 @@ export function AutoTopUpCard() {
       setShowAddPm(false);
     }
   }, [showAddPm, configQuery.data?.has_payment_method]);
+
+  // Arriving with `?configure_top_up=1` (deeplinked from the Add Credits
+  // modal) replays the toggle-on path once, then strips the param. Never
+  // mutates the server; persistence still requires Save. Must sit before the
+  // loading/error guards below (rules-of-hooks), so — like the no-PM effect
+  // above — it reads through `configQuery.data` instead of the post-guard
+  // `config`/handlers, reproducing the disabled→on branch of
+  // `handleToggleChange`: reveal the add-card gate with no usable PM, else open
+  // the configure form (the two `reset()`s match `enterFormMode`).
+  const configureTopUpRequested =
+    searchParams.get("configure_top_up") === "1";
+  useEffect(() => {
+    if (!configureTopUpRequested || configQuery.data == null) {
+      return;
+    }
+    const next = new URLSearchParams(searchParams);
+    next.delete("configure_top_up");
+    setSearchParams(next, { replace: true });
+    const cfg = configQuery.data;
+    if (cfg.enabled === true) {
+      return;
+    }
+    setPendingEnable(true);
+    // `cfg.enabled` is false here, so this matches `disabledAfterDeclines`.
+    if (
+      !cfg.has_payment_method ||
+      cfg.disabled_due_to_repeated_failures === true
+    ) {
+      setShowAddPm(true);
+      setBannerDismissed(false);
+    } else {
+      setShowAddPm(false);
+      updateMutation.reset();
+      disableMutation.reset();
+      setMode("form");
+    }
+    const reduceMotion =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+    cardRef.current?.scrollIntoView({
+      behavior: reduceMotion ? "auto" : "smooth",
+      block: "center",
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once per arrival; setters/mutations and `searchParams` intentionally excluded
+  }, [configureTopUpRequested, configQuery.data]);
 
   if (configQuery.isLoading) {
     return (
@@ -463,7 +512,7 @@ export function AutoTopUpCard() {
   const toggleChecked = enabled || pendingEnable;
 
   return (
-    <div data-testid="auto-top-up-card">
+    <div ref={cardRef} data-testid="auto-top-up-card">
       <div className="flex items-center justify-between gap-4">
         <Toggle
           checked={toggleChecked}

--- a/clients/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -170,14 +170,48 @@ export function AutoTopUpCard() {
     }
   }, [showAddPm, configQuery.data?.has_payment_method]);
 
+  /**
+   * Transition into form mode. Resets any prior mutation errors so stale
+   * field-level errors (from `updateMutation`) or the disable-failure
+   * banner (from `disableMutation`) don't render the moment the form
+   * re-mounts (e.g. after Cancel + re-Edit, or after a failed Disable).
+   * Hoisted above the loading/error guards so the deeplink effect below can
+   * reuse it; depends only on the mutations and `setMode`, all bound above.
+   */
+  const enterFormMode = () => {
+    updateMutation.reset();
+    disableMutation.reset();
+    setMode("form");
+  };
+
+  /**
+   * Shared "turn Extra Usage on from disabled" flow, used by both the toggle
+   * (`handleToggleChange`) and the `?configure_top_up=1` deeplink effect: with
+   * no usable PM (none on file, or auto-reload paused after repeated declines)
+   * reveal the add-card gate, otherwise open the configure form. Never persists
+   * — Save still does. Both callers run it only while disabled, so
+   * `disabled_due_to_repeated_failures` alone matches `disabledAfterDeclines`.
+   */
+  const beginEnableFlow = (cfg: AutoTopUpConfigResponse) => {
+    setPendingEnable(true);
+    if (
+      !cfg.has_payment_method ||
+      cfg.disabled_due_to_repeated_failures === true
+    ) {
+      setShowAddPm(true);
+      setBannerDismissed(false);
+      return;
+    }
+    setShowAddPm(false);
+    enterFormMode();
+  };
+
   // Arriving with `?configure_top_up=1` (deeplinked from the Add Credits
   // modal) replays the toggle-on path once, then strips the param. Never
   // mutates the server; persistence still requires Save. Must sit before the
-  // loading/error guards below (rules-of-hooks), so — like the no-PM effect
-  // above — it reads through `configQuery.data` instead of the post-guard
-  // `config`/handlers, reproducing the disabled→on branch of
-  // `handleToggleChange`: reveal the add-card gate with no usable PM, else open
-  // the configure form (the two `reset()`s match `enterFormMode`).
+  // loading/error guards below (rules-of-hooks), so it reads through
+  // `configQuery.data` and reuses `beginEnableFlow` (the same flow the toggle
+  // runs) rather than the post-guard `config`/handlers.
   const configureTopUpRequested =
     searchParams.get("configure_top_up") === "1";
   useEffect(() => {
@@ -191,20 +225,7 @@ export function AutoTopUpCard() {
     if (cfg.enabled === true) {
       return;
     }
-    setPendingEnable(true);
-    // `cfg.enabled` is false here, so this matches `disabledAfterDeclines`.
-    if (
-      !cfg.has_payment_method ||
-      cfg.disabled_due_to_repeated_failures === true
-    ) {
-      setShowAddPm(true);
-      setBannerDismissed(false);
-    } else {
-      setShowAddPm(false);
-      updateMutation.reset();
-      disableMutation.reset();
-      setMode("form");
-    }
+    beginEnableFlow(cfg);
     const reduceMotion =
       typeof window !== "undefined" &&
       window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
@@ -212,7 +233,7 @@ export function AutoTopUpCard() {
       behavior: reduceMotion ? "auto" : "smooth",
       block: "center",
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once per arrival; setters/mutations and `searchParams` intentionally excluded
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once per arrival; `beginEnableFlow`/`searchParams` intentionally excluded
   }, [configureTopUpRequested, configQuery.data]);
 
   if (configQuery.isLoading) {
@@ -248,18 +269,6 @@ export function AutoTopUpCard() {
   // while the config is currently disabled (`if (next && !enabled)`).
   const disabledAfterDeclines =
     config.disabled_due_to_repeated_failures === true && !enabled;
-
-  /**
-   * Transition into form mode. Resets any prior mutation errors so stale
-   * field-level errors (from `updateMutation`) or the disable-failure
-   * banner (from `disableMutation`) don't render the moment the form
-   * re-mounts (e.g. after Cancel + re-Edit, or after a failed Disable).
-   */
-  const enterFormMode = () => {
-    updateMutation.reset();
-    disableMutation.reset();
-    setMode("form");
-  };
 
   const exitFormMode = () => {
     setMode("view");
@@ -434,14 +443,7 @@ export function AutoTopUpCard() {
    */
   const handleToggleChange = (next: boolean) => {
     if (next && !enabled) {
-      setPendingEnable(true);
-      if (!config.has_payment_method || disabledAfterDeclines) {
-        setShowAddPm(true);
-        setBannerDismissed(false);
-        return;
-      }
-      setShowAddPm(false);
-      enterFormMode();
+      beginEnableFlow(config);
       return;
     }
     if (!next && !enabled && pendingEnable) {

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -76,7 +76,7 @@ const PLAN_DISPLAY: Record<string, PlanDisplay> = {
   },
 };
 
-const DEFAULT_DISPLAY: PlanDisplay = PLAN_DISPLAY.base;
+const DEFAULT_DISPLAY: PlanDisplay = PLAN_DISPLAY.pro;
 
 export interface PlanCardProps {
   onManage: () => void;

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -200,6 +200,7 @@ export const routes = {
     // Deep-link straight to the Billing sub-tab (only shown when signed in to
     // the Vellum platform).
     usageBilling: `${SETTINGS_USAGE_PATH}?tab=billing`,
+    usageBillingConfigureTopUps: `${SETTINGS_USAGE_PATH}?tab=billing&configure_top_up=1`,
     // Post-Stripe-Checkout return. The Billing tab opens the Pro onboarding
     // wizard while `session_id` is in the URL — the same param the platform's
     // web `success_url` lands on `/assistant/settings/billing` with.


### PR DESCRIPTION
## Summary
Two small, independent web changes:
- **Plan CTA copy** — the billing plan-card CTA reads **"View All Plans"** on the free tier and **"Manage"** on any paid plan (`DEFAULT_DISPLAY` repointed so non-free ids resolve to the Manage display).
- **"Configure Automatic Top-Ups"** in the Add Credits modal now deep-links to the billing page with a `configure_top_up=1` intent param, and `AutoTopUpCard` consumes it to auto-open the "Enable Extra Usage" flow (reveal the configure form, or the add-card gate when there's no card) — **without firing any server mutation**, then strips the param.

## Self-review result
PASS — 1 low-severity slop finding fixed (consolidated the enable flow into a shared `beginEnableFlow` used by both the toggle handler and the deeplink effect). Faithfulness + integration passes clean; end-to-end `configure_top_up` producer→consumer trace verified.

## PRs merged into feature branch
- #39118: plan-card CTA reads "View All Plans" on free, "Manage" on paid
- #39119: Configure Automatic Top-Ups routes to billing with configure_top_up intent
- #39120: auto-open Extra Usage toggle when arriving with configure_top_up (incl. react-hooks lint fix)

### Post-merge self-review fix (direct to branch)
- Shared the Extra Usage enable flow between the toggle and the deeplink (`beginEnableFlow`)

Part of plan: plan-cta-and-topup-config.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)