### PR TITLE
refactor(web): drop the now-unreachable stalled recovery and background-finishing UI from the onboarding steps

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -276,9 +276,6 @@ const { TAKEOVER_SURFACE, TAKEOVER_SURFACE_VAR } = await import(
   "./provisioning-state"
 );
 
-const BACKGROUND_LINE =
-  "Assistant will go offline briefly while it resizes. Chat might not work during that time.";
-
 /**
  * Fast celebration dwell. Long enough for waitFor (50ms polls) to reliably
  * observe the transient DONE / NOT_APPLICABLE copy before it auto-advances.
@@ -413,7 +410,6 @@ describe("BillingOnboardingModal", () => {
       timeout: 5000,
     });
     expect(queryByText("Assistant Email")).toBeNull();
-    expect(queryByText(BACKGROUND_LINE)).toBeNull();
     expect(readCheckoutIntent()).toBeNull();
     // Checkout mode never fires the modal-level domains query.
     expect(domainsCalls).toBe(0);
@@ -756,7 +752,6 @@ describe("BillingOnboardingModal", () => {
         "Your upgrade continues in the background.",
       );
       expect(queryByText("You're all set!")).toBeNull();
-      expect(queryByText(BACKGROUND_LINE)).toBeNull();
     },
     30_000,
   );

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -99,7 +99,6 @@ export function BillingOnboardingModal({
   const isResize = mode === "resize";
   const queryClient = useQueryClient();
   const [step, setStep] = useState<WizardStep>("provisioning");
-  const [finishedInBackground, setFinishedInBackground] = useState(false);
   const [takeoverExit, setTakeoverExit] = useState<TakeoverExit>("idle");
   const exitTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
   const [intent, setIntent] = useState<CheckoutIntent | null>(null);
@@ -130,7 +129,6 @@ export function BillingOnboardingModal({
     exitTimers.current.forEach(clearTimeout);
     exitTimers.current = [];
     setStep("provisioning");
-    setFinishedInBackground(false);
     setTakeoverExit("idle");
     setDisplayedPhase(null);
     setDomainsOpenedAt(null);
@@ -154,7 +152,6 @@ export function BillingOnboardingModal({
   // while that resize is in flight — including a stall, where the machine may
   // still be mid-restart.
   const machineBusy = isMachineBusy(provisioning.state);
-  const provisioningSettled = isSettled(provisioning.state);
 
   // The lock describes the screen the user is looking at, so it reads the
   // takeover's held phase rather than the live one. The domain step still keys
@@ -302,14 +299,6 @@ export function BillingOnboardingModal({
     onClose();
   }, [provisioning, onClose]);
 
-  // Stalled recovery re-calls the idempotent, org-wide ensure-provisioned
-  // reconcile — the same path the wizard fires on Pro confirmation. Its errors
-  // surface as-is; a server-side resize that is still running converges the
-  // actuals polling to DONE and replaces the stalled UI regardless.
-  const { stalledAction } = provisioning;
-  const stalledActionIfStalled =
-    provisioning.state === "STALLED" ? stalledAction : undefined;
-
   // The fetch-error variant of the provisioning step is a standard dismissible
   // card, not the locked full-bleed takeover — otherwise the light error UI is
   // marooned in the dark full-screen viewport and the user can't act on it.
@@ -443,19 +432,12 @@ export function BillingOnboardingModal({
       return (
         <DomainStep
           machineBusy={machineBusy}
-          stalledAction={stalledActionIfStalled}
           assistantId={assistantId}
           onExit={() => setStep("complete")}
         />
       );
     }
 
-    return (
-      <CompleteState
-        finishedInBackground={finishedInBackground && !provisioningSettled}
-        stalledAction={stalledActionIfStalled}
-        assistantId={assistantId}
-      />
-    );
+    return <CompleteState assistantId={assistantId} />;
   }
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.test.tsx
@@ -13,9 +13,6 @@ import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import { routes } from "@/utils/routes";
 
-const OFFLINE_NOTICE =
-  "Assistant will go offline briefly while it resizes. Chat might not work during that time.";
-
 let avatarComponents: unknown = { colors: [] };
 mock.module("@/utils/use-bundled-avatar-components", () => ({
   preloadBundledAvatarComponents: () => {},
@@ -115,44 +112,5 @@ describe("CompleteState return button", () => {
     expect(getByTestId("onboarding-complete-return").textContent).toBe(
       "Return to your assistant",
     );
-  });
-});
-
-describe("CompleteState offline notice", () => {
-  test("is absent when not finishing in the background", () => {
-    const { queryByText } = render(<CompleteState />);
-    expect(queryByText(OFFLINE_NOTICE)).toBeNull();
-  });
-
-  test("shows only while finishing in background and clears once done", () => {
-    const { queryByText, rerender } = render(
-      <CompleteState finishedInBackground />,
-    );
-    expect(queryByText(OFFLINE_NOTICE)).toBeTruthy();
-    // The still-mounted provisioning hook reaching DONE flips the prop off;
-    // mirror that transition and confirm the notice clears.
-    rerender(<CompleteState finishedInBackground={false} />);
-    expect(queryByText(OFFLINE_NOTICE)).toBeNull();
-  });
-
-  test("stalled recovery controls take precedence over the offline notice", () => {
-    const onApply = mock(() => {});
-    const { getByTestId, getByText, queryByText } = render(
-      <CompleteState
-        finishedInBackground
-        stalledAction={{ onApply, pending: false, error: null }}
-      />,
-    );
-
-    expect(
-      getByText(/We couldn't finish your machine upgrade automatically/),
-    ).toBeTruthy();
-    expect(queryByText(OFFLINE_NOTICE)).toBeNull();
-
-    fireEvent.click(getByTestId("complete-stalled-apply"));
-    expect(onApply).toHaveBeenCalledTimes(1);
-
-    // The Return button stays available across all completion variants.
-    expect(getByTestId("onboarding-complete-return")).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
@@ -4,31 +4,13 @@ import { setSelectedAssistant } from "@/assistant/selection";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
-import { Notice } from "@vellumai/design-library/components/notice";
 
-import type { StalledApplyAction } from "./primitives";
-import {
-  CreatureCorners,
-  StalledApplyControls,
-  SUBTLE_NOTICE_CLASS,
-  SUBTLE_NOTICE_TEXT_CLASS,
-  WizardCardHeading,
-} from "./primitives";
+import { CreatureCorners, WizardCardHeading } from "./primitives";
 import { usePreferredOrActiveAssistant } from "./use-preferred-or-active-assistant";
 
-/** Shown while a backgrounded resize is still finishing; cleared once done. */
-const OFFLINE_WHILE_RESIZING =
-  "Assistant will go offline briefly while it resizes. Chat might not work during that time.";
-
 export function CompleteState({
-  finishedInBackground = false,
-  stalledAction,
   assistantId,
 }: {
-  /** The user backgrounded the machine resize; hidden once it completes. */
-  finishedInBackground?: boolean;
-  /** Set only while the backgrounded resize is stalled — offers manual apply. */
-  stalledAction?: StalledApplyAction;
   /** The provisioning target assistant (onboarding primary, else active). */
   assistantId?: string | null;
 }) {
@@ -37,8 +19,6 @@ export function CompleteState({
   const assistant = usePreferredOrActiveAssistant(assistantId, isOrgReady);
   const assistantName = assistant?.name || "your assistant";
 
-  // `justify-center` only bites when the notice is absent — with it the content
-  // exceeds the min-height and sits at the mock's top offset.
   return (
     <div className="relative flex min-h-[320px] flex-col items-center justify-center overflow-hidden px-8 pb-16 [animation:onboarding-step-in_350ms_ease-out] motion-reduce:[animation:none]">
       <CreatureCorners variant="full" />
@@ -67,22 +47,6 @@ export function CompleteState({
           >
             Return to {assistantName}
           </Button>
-
-          {stalledAction ? (
-            <StalledApplyControls
-              action={stalledAction}
-              buttonTestId="complete-stalled-apply"
-              className="w-full"
-            />
-          ) : (
-            finishedInBackground && (
-              <Notice tone="info" className={SUBTLE_NOTICE_CLASS}>
-                <span className={SUBTLE_NOTICE_TEXT_CLASS}>
-                  {OFFLINE_WHILE_RESIZING}
-                </span>
-              </Notice>
-            )
-          )}
         </div>
       </div>
     </div>

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
@@ -208,52 +208,13 @@ describe("DomainStep domain registration", () => {
   });
 });
 
-describe("DomainStep stalled resize", () => {
-  test("stalledAction swaps the busy notice for the warning and apply controls", async () => {
-    const onApply = mock(() => {});
+describe("DomainStep machine busy", () => {
+  test("machine-busy shows the neutral restarting notice and disables Next", async () => {
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
 
-    const { getByText, getByTestId, queryByText } = render(
-      <QueryClientProvider client={client}>
-        <DomainStep
-          onExit={() => {}}
-          machineBusy
-          stalledAction={{ onApply, pending: false, error: null }}
-        />
-      </QueryClientProvider>,
-    );
-
-    await waitFor(() =>
-      expect(getByTestId("domain-stalled-apply")).toBeTruthy(),
-    );
-    expect(
-      getByText(/We couldn't finish your machine upgrade automatically/),
-    ).toBeTruthy();
-    expect(
-      queryByText(
-        "Your assistant is restarting — you can set the domain in a moment.",
-      ),
-    ).toBeNull();
-
-    fireEvent.click(getByTestId("domain-stalled-apply"));
-    expect(onApply).toHaveBeenCalledTimes(1);
-
-    // The guardian-channel submit stays locked while the machine is busy.
-    await waitFor(() =>
-      expect(
-        (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
-      ).toBe(true),
-    );
-  });
-
-  test("plain machine-busy keeps the neutral notice and disables Next", async () => {
-    const client = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-
-    const { getByText, getByTestId, queryByTestId } = render(
+    const { getByText, getByTestId } = render(
       <QueryClientProvider client={client}>
         <DomainStep onExit={() => {}} machineBusy />
       </QueryClientProvider>,
@@ -266,7 +227,6 @@ describe("DomainStep stalled resize", () => {
         ),
       ).toBeTruthy(),
     );
-    expect(queryByTestId("domain-stalled-apply")).toBeNull();
     // The restart guard keeps Next disabled while the machine is busy.
     expect(
       (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -13,10 +13,8 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Notice } from "@vellumai/design-library/components/notice";
 
-import type { StalledApplyAction } from "./primitives";
 import {
     CreatureCorners,
-    StalledApplyControls,
     SUBTLE_NOTICE_CLASS,
     SUBTLE_NOTICE_TEXT_CLASS,
     WizardCardHeading,
@@ -31,14 +29,11 @@ const LABEL_CLASSES = "text-[11px] font-medium text-[var(--content-secondary)]";
 export function DomainStep({
   onExit,
   machineBusy = false,
-  stalledAction,
   assistantId: preferredAssistantId,
 }: {
   onExit: () => void;
   /** The assistant machine is restarting (webhook-driven resize in flight). */
   machineBusy?: boolean;
-  /** Set only while the resize is stalled — offers the manual apply here. */
-  stalledAction?: StalledApplyAction;
   /** The provisioning target assistant (onboarding primary, else active). */
   assistantId?: string | null;
 }) {
@@ -196,19 +191,10 @@ export function DomainStep({
           )}
         </div>
 
-        {stalledAction && !isLocked ? (
-          <StalledApplyControls
-            action={stalledAction}
-            buttonTestId="domain-stalled-apply"
-          />
-        ) : (
-          machineBusy &&
-          !isLocked && (
-            <Notice tone="neutral">
-              Your assistant is restarting — you can set the domain in a
-              moment.
-            </Notice>
-          )
+        {machineBusy && !isLocked && (
+          <Notice tone="neutral">
+            Your assistant is restarting — you can set the domain in a moment.
+          </Notice>
         )}
         {!isLocked && (
           <Notice tone="info" className={SUBTLE_NOTICE_CLASS}>

--- a/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
@@ -1,65 +1,8 @@
 import type { CSSProperties } from "react";
 import type { LucideIcon } from "lucide-react";
 
-import { Button } from "@vellumai/design-library/components/button";
-import { Notice } from "@vellumai/design-library/components/notice";
-
 import { AvatarRenderer } from "@/components/avatar-renderer";
-import { cn } from "@/utils/misc";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
-
-import { extractOnboardingErrorMessage } from "./utils";
-
-/** The manual Apply & Restart recovery threaded down from the modal. */
-export interface StalledApplyAction {
-  onApply: () => void;
-  pending: boolean;
-  error: unknown;
-}
-
-/** Warning shown when a backgrounded resize stalls mid-wizard. */
-const STALLED_UPGRADE_WARNING =
-  "We couldn't finish your machine upgrade automatically. Apply it now to finish — your assistant will briefly restart.";
-
-/**
- * Warning notice + Apply & Restart button for recovering a stalled resize.
- * Shared by the complete screen and the domain step so the recovery affordance
- * can't drift between them. (The dark provisioning takeover renders its own
- * inline button by design.)
- */
-export function StalledApplyControls({
-  action,
-  buttonTestId,
-  className,
-}: {
-  action: StalledApplyAction;
-  buttonTestId: string;
-  className?: string;
-}) {
-  return (
-    <div className={cn("flex flex-col items-center gap-2", className)}>
-      <Notice tone="warning" className="w-full text-left">
-        {STALLED_UPGRADE_WARNING}
-      </Notice>
-      {action.error != null && (
-        <Notice tone="error" className="w-full text-left">
-          {extractOnboardingErrorMessage(
-            action.error,
-            "Couldn't apply changes. Please try again.",
-          )}
-        </Notice>
-      )}
-      <Button
-        variant="outlined"
-        data-testid={buttonTestId}
-        disabled={action.pending}
-        onClick={action.onApply}
-      >
-        Apply &amp; Restart
-      </Button>
-    </div>
-  );
-}
 
 export function IconBadge({ icon: Icon }: { icon: LucideIcon }) {
   return (

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -91,9 +91,9 @@ export interface UseProProvisioningOptions {
 }
 
 /**
- * Stalled-state recovery affordance, shaped for `StalledApplyAction`. `error`
- * mirrors `ensureError`: a reconcile failure from any source (auto, manual, or
- * the fire-and-forget escape kick), cleared by a later success.
+ * Stalled-state recovery affordance. `error` mirrors `ensureError`: a reconcile
+ * failure from any source (auto, manual, or the fire-and-forget escape kick),
+ * cleared by a later success.
  */
 export interface ProvisioningRetryAction {
   onApply: () => void;


### PR DESCRIPTION
## Summary
- Removes StalledApplyControls + StalledApplyAction + STALLED_UPGRADE_WARNING (unreachable after the takeover exits on escape).
- Drops finishedInBackground and the All-set 'goes offline briefly' notice.
- Email step keeps its machineBusy Next-guard + neutral restarting notice.

Part of plan: pro-takeover-exit-on-escape.md (PR 4 of 5)