### PR TITLE
refactor(web): retire the stalledAction API from useProProvisioning

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -465,12 +465,12 @@ describe("useProProvisioning", () => {
   );
 
   test(
-    "a dead-end no_active_pro apply stays STALLED and surfaces why",
+    "a dead-end no_active_pro kick stays STALLED and surfaces why",
     async () => {
-      // The auto reconcile consumes the once-per-open re-ask, so a later manual
-      // apply that still gets no_active_pro can queue nothing and re-ask
-      // nothing. Resuming the watch there would hide the recovery button for
-      // another stall window with no resize running.
+      // The auto reconcile consumes the once-per-open re-ask, so a later kick
+      // that still gets no_active_pro can queue nothing and re-ask nothing.
+      // Resuming the watch there would drop the user out of STALLED for another
+      // stall window with no resize running.
       ensureResponse = makeEnsureResponse("not_applicable", "no_active_pro");
       const { client } = renderProbe();
       await reachResizing(client);
@@ -481,51 +481,24 @@ describe("useProProvisioning", () => {
       });
 
       const callsBefore = ensureCalls;
-      act(() => latest!.stalledAction.onApply());
+      act(() => latest!.kickProvisioning());
       await waitFor(() => expect(ensureCalls).toBeGreaterThan(callsBefore));
 
       await waitFor(
         () =>
-          expect(latest!.stalledAction.error).toEqual({
+          expect(latest!.kickError).toEqual({
             error: "no_active_pro",
           }),
         { timeout: 5000 },
       );
-      // Still STALLED, so Apply & Restart remains on screen.
+      // Still STALLED, so the flow keeps polling for a self-recovery.
       expect(latest!.state).toBe("STALLED");
     },
     20_000,
   );
 
   test(
-    "a hung automatic reconcile leaves Apply & Restart enabled",
-    async () => {
-      // `ensureResponse` defaults to held-in-flight, so the automatic reconcile
-      // fired on Pro confirm never settles — exactly the case that strands the
-      // user in STALLED. Its pending state must not disable their only recovery
-      // control; `pending` tracks user-initiated applies only.
-      const { client } = renderProbe();
-      await reachResizing(client);
-      expect(ensureCalls).toBeGreaterThan(0);
-
-      dateNowOffsetMs = 200_000;
-      await waitFor(() => expect(latest!.state).toBe("STALLED"), {
-        timeout: 5000,
-      });
-
-      expect(latest!.stalledAction.pending).toBe(false);
-
-      // And a manual apply does report pending while it is in flight.
-      act(() => latest!.stalledAction.onApply());
-      await waitFor(() => expect(latest!.stalledAction.pending).toBe(true), {
-        timeout: 5000,
-      });
-    },
-    20_000,
-  );
-
-  test(
-    "the stalled action re-calls ensure-provisioned, leaves STALLED and can reach DONE",
+    "the escape kick re-calls ensure-provisioned, leaves STALLED and can reach DONE",
     async () => {
       const { client } = renderProbe();
       await reachResizing(client);
@@ -541,12 +514,12 @@ describe("useProProvisioning", () => {
       // The reconcile answers "started": the verdict alone lifts the wizard
       // back to RESIZING and the success re-bases the stall clock.
       ensureResponse = makeEnsureResponse("started");
-      act(() => latest!.stalledAction.onApply());
+      act(() => latest!.kickProvisioning());
       await waitFor(() => expect(ensureCalls).toBe(autoCalls + 1));
       await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
         timeout: 5000,
       });
-      expect(latest!.stalledAction.error).toBeNull();
+      expect(latest!.kickError).toBeNull();
 
       // The landing resize also retires the operation marker: the platform
       // reports `resizing_machine` until the rollout converges, so met actuals
@@ -562,7 +535,7 @@ describe("useProProvisioning", () => {
   );
 
   test(
-    "a failed stalled retry surfaces its error without leaving STALLED wedged",
+    "a failed escape kick surfaces its error without leaving STALLED wedged",
     async () => {
       const { client } = renderProbe();
       await reachResizing(client);
@@ -573,9 +546,9 @@ describe("useProProvisioning", () => {
       });
 
       ensureError = { error: "provisioning_submission_failed" };
-      act(() => latest!.stalledAction.onApply());
+      act(() => latest!.kickProvisioning());
       await waitFor(() =>
-        expect(latest!.stalledAction.error).toEqual({
+        expect(latest!.kickError).toEqual({
           error: "provisioning_submission_failed",
         }),
       );
@@ -624,7 +597,7 @@ describe("useProProvisioning", () => {
   );
 
   test(
-    "escapeEligible flips after the escape window and re-bases on manual-apply resume",
+    "escapeEligible flips after the escape window and re-bases on an escape-kick resume",
     async () => {
       const { client } = renderProbe();
       await reachResizing(client);
@@ -643,10 +616,10 @@ describe("useProProvisioning", () => {
       });
       expect(latest!.escapeEligible).toBe(true);
 
-      // A successful stalled retry re-bases the watch clock, so eligibility
+      // A successful escape kick re-bases the watch clock, so eligibility
       // starts over.
       ensureResponse = makeEnsureResponse("started");
-      act(() => latest!.stalledAction.onApply());
+      act(() => latest!.kickProvisioning());
       await waitFor(() => expect(latest!.escapeEligible).toBe(false), {
         timeout: 5000,
       });
@@ -656,7 +629,7 @@ describe("useProProvisioning", () => {
   );
 
   test(
-    "kickProvisioning fires the reconcile, never flips pending, and a success clears kickError",
+    "kickProvisioning fires the reconcile, captures kickError, and a success clears it",
     async () => {
       const { client } = renderProbe();
       await reachResizing(client);
@@ -667,9 +640,8 @@ describe("useProProvisioning", () => {
         timeout: 5000,
       });
 
-      // A fire-and-forget escape kick that fails captures kickError without
-      // ever flipping the manual-pending flag — a hung escape-fired call must
-      // never strand later UI.
+      // A fire-and-forget escape kick that fails captures kickError — a hung
+      // escape-fired call must never strand later UI.
       ensureError = { error: "provisioning_submission_failed" };
       act(() => latest!.kickProvisioning());
       await waitFor(() => expect(ensureCalls).toBe(autoCalls + 1));
@@ -678,11 +650,6 @@ describe("useProProvisioning", () => {
           error: "provisioning_submission_failed",
         }),
       );
-      expect(latest!.stalledAction.pending).toBe(false);
-      // kickError and stalledAction.error are the same value.
-      expect(latest!.stalledAction.error).toEqual({
-        error: "provisioning_submission_failed",
-      });
       // The failure is not terminal: still STALLED, still polling.
       expect(latest!.state).toBe("STALLED");
 
@@ -696,7 +663,6 @@ describe("useProProvisioning", () => {
       await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
         timeout: 5000,
       });
-      expect(latest!.stalledAction.pending).toBe(false);
     },
     20_000,
   );
@@ -1247,7 +1213,6 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
       );
       // The verdict is still never adopted — inference keeps the flow WAITING.
       expect(latest!.state).toBe("WAITING");
-      expect(latest!.stalledAction.pending).toBe(false);
     },
     20_000,
   );
@@ -1263,18 +1228,14 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
       await waitFor(() => expect(latest!.state).toBe("WAITING"), {
         timeout: 5000,
       });
-      // The automatic call failing no longer blocks: no new blocking state,
-      // no auto-retry storm. But it is no longer *silent* — the failure is
-      // captured in kickError (and its stalledAction.error alias) so the
-      // takeover can surface the snag variant.
+      // The automatic call failing does not block: no new blocking state, no
+      // auto-retry storm. It is not silent either — the failure is captured in
+      // kickError so the takeover can surface the snag variant.
       await waitFor(() =>
         expect(latest!.kickError).toEqual({
           error: "provisioning_submission_failed",
         }),
       );
-      expect(latest!.stalledAction.error).toEqual({
-        error: "provisioning_submission_failed",
-      });
       expect(latest!.confirmError).toBe(false);
       expect(latest!.targetsError).toBe(false);
       await new Promise((resolve) => setTimeout(resolve, 500));
@@ -1343,9 +1304,9 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
         timeout: 5000,
       });
 
-      // Any reconcile now captures its error; this one is fired while open but
-      // only rejects after close, so generation-gating must still discard it.
-      act(() => latest!.stalledAction.onApply());
+      // A reconcile captures its error; this one is fired while open but only
+      // rejects after close, so generation-gating must still discard it.
+      act(() => latest!.kickProvisioning());
       await waitFor(() => expect(ensureCalls).toBe(2), { timeout: 5000 });
 
       act(() => setOpen(false));
@@ -1359,7 +1320,7 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
       await waitFor(() => expect(latest!.state).toBe("WAITING"), {
         timeout: 5000,
       });
-      expect(latest!.stalledAction.error).toBeNull();
+      expect(latest!.kickError).toBeNull();
     },
     20_000,
   );

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -13,15 +13,16 @@
  * subscription error maps to `confirmError`, and a post-confirm onboarding
  * fetch failure with no cached data maps to `targetsError`.
  *
- * On top of the observation it also *acts* once: the moment the subscription
- * first reports Pro it calls the idempotent ensure-provisioned reconcile
- * endpoint, so a webhook that never fired (or whose resize was lost) still
- * gets provisioned. The returned verdict feeds the state machine's
- * `serverVerdict` slot; the endpoint failing never blocks the flow — the
- * polling above converges on its own. But a reconcile failure from *any*
- * source (auto, manual, or the fire-and-forget escape kick) is now held in
- * `ensureError` so the takeover can honestly surface the ≥90s snag variant;
- * any later success clears it.
+ * On top of the observation it also *acts*: the moment the subscription first
+ * reports Pro it fires the idempotent ensure-provisioned reconcile endpoint
+ * automatically, and `kickProvisioning` fires the same reconcile on demand, so
+ * a webhook that never fired (or whose resize was lost) still gets
+ * provisioned. The returned verdict feeds the state machine's `serverVerdict`
+ * slot; the endpoint failing never blocks the flow — the polling above
+ * converges on its own. A reconcile failure from any source is held in
+ * `ensureError` (exposed as `kickError`) so the takeover can honestly surface
+ * the ≥90s snag variant; any later success clears it. The reconcile carries no
+ * pending flag.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -90,17 +91,6 @@ export interface UseProProvisioningOptions {
   open: boolean;
 }
 
-/**
- * Stalled-state recovery affordance. `error` mirrors `ensureError`: a reconcile
- * failure from any source (auto, manual, or the fire-and-forget escape kick),
- * cleared by a later success.
- */
-export interface ProvisioningRetryAction {
-  onApply: () => void;
-  pending: boolean;
-  error: unknown;
-}
-
 export interface ProProvisioningResult {
   state: ProvisioningStateKind;
   softWaiting: boolean;
@@ -128,27 +118,22 @@ export interface ProProvisioningResult {
   /**
    * The watch has run long enough (without resolving) that the "continue in
    * the background" escape hatch may be offered. Re-bases with the stall clock
-   * after a manual-apply resume.
+   * after a successful `kickProvisioning` resume.
    */
   escapeEligible: boolean;
   /** Reset the confirm timeout and re-poll the subscription. */
   retryConfirm: () => void;
   /**
-   * STALLED-state recovery: re-calls the idempotent ensure-provisioned
+   * Fire-and-forget "escape" kick: fires the idempotent ensure-provisioned
    * reconcile (grow-only, in-flight-guarded, so a repeat never double-fires a
    * resize) and re-bases the stall clock on success so observation resumes.
-   */
-  stalledAction: ProvisioningRetryAction;
-  /**
-   * Fire-and-forget "escape" kick: fires the idempotent ensure-provisioned
-   * reconcile without touching the manual-pending flag, so a hung call can
-   * never strand later UI. Used when closing the takeover into the background.
+   * Carries no pending flag, so a hung call can never strand later UI. Used
+   * when closing the takeover into the background.
    */
   kickProvisioning: () => void;
   /**
    * Latest ensure-provisioned failure from any source; cleared by a later
-   * success. Drives the ≥90s snag variant on the takeover. (Alias of
-   * `stalledAction.error`.)
+   * success. Drives the ≥90s snag variant on the takeover.
    */
   kickError: unknown;
 }
@@ -169,7 +154,7 @@ export function useProProvisioning({
   // after this instant may confirm pro.
   const [openedAt, setOpenedAt] = useState<number | null>(null);
   const [proConfirmedAt, setProConfirmedAt] = useState<number | null>(null);
-  // Stall-clock re-base set by a successful manual reconcile; proConfirmedAt
+  // Stall-clock re-base set by a successful kick reconcile; proConfirmedAt
   // otherwise.
   const [resumedAt, setResumedAt] = useState<number | null>(null);
   // Latest adopted ensure-provisioned verdict; null while the endpoint hasn't
@@ -194,16 +179,9 @@ export function useProProvisioning({
   const [targetsMetAssistantId, setTargetsMetAssistantId] = useState<
     string | null
   >(null);
-  // Latest reconcile failure from any source (auto/manual/escape); cleared by a
-  // later success — see runEnsureProvisioned.
+  // Latest reconcile failure from any source (auto/escape); cleared by a later
+  // success — see runEnsureProvisioned.
   const [ensureError, setEnsureError] = useState<unknown>(null);
-  // Pending state for the *manual* reconcile only. The mutation's own
-  // `isPending` is shared with the automatic call fired on Pro confirm, and a
-  // hung automatic call is precisely the case that strands the user in
-  // STALLED — gating Apply & Restart on it would disable their only recovery
-  // path. The endpoint is idempotent and in-flight guarded, so letting a manual
-  // apply overlap a slow automatic one is safe.
-  const [manualPending, setManualPending] = useState(false);
   const [raceRetryScheduled, setRaceRetryScheduled] = useState(false);
   // Fire-once-per-open guard for the automatic reconcile. A ref (not state) so
   // it can't be lost to a re-render between the check and the call, and it
@@ -246,7 +224,6 @@ export function useProProvisioning({
     setTargetsMetAt(null);
     setTargetsMetAssistantId(null);
     setEnsureError(null);
-    setManualPending(false);
     setRaceRetryScheduled(false);
     ensureRequestedRef.current = false;
     ensureRaceRetriedRef.current = false;
@@ -326,11 +303,7 @@ export function useProProvisioning({
   const { mutate: ensureProvisioned } = ensureProvisionedMutation;
 
   const runEnsureProvisioned = useCallback(
-    (source: "auto" | "manual" | "escape") => {
-      if (source === "manual") {
-        setEnsureError(null);
-        setManualPending(true);
-      }
+    (source: "auto" | "escape") => {
       // The open this call belongs to. Both callbacks drop out when the wizard
       // has since closed, so a late response can't drive a later session.
       const generation = ensureGenerationRef.current;
@@ -355,21 +328,21 @@ export function useProProvisioning({
                 ensureRaceRetriedRef.current = true;
                 setRaceRetryScheduled(true);
                 // A re-ask is already queued, so observation may resume.
-                if (source !== "auto") {
+                if (source === "escape") {
                   resumeWatch();
                 }
               } else {
                 // Dead end: the verdict is deliberately not adopted, nothing
                 // was queued, and the once-per-open re-ask is spent. Re-basing
-                // the stall clock here would drop the user out of STALLED —
-                // hiding Apply & Restart for another stall window — with no
-                // resize running and nothing said. Hold the state and explain,
-                // regardless of source, so a repeat dead end surfaces why.
+                // the stall clock here would drop the user out of STALLED with
+                // no resize running and nothing said. Hold the state and
+                // explain, regardless of source, so a repeat dead end surfaces
+                // why.
                 setEnsureError({ error: "no_active_pro" });
               }
             } else {
               setServerVerdict(data.state);
-              if (source !== "auto") {
+              if (source === "escape") {
                 resumeWatch();
               }
             }
@@ -380,19 +353,10 @@ export function useProProvisioning({
             }
             // 503 (submission couldn't be queued) or a network blip: nothing
             // was queued and nothing is broken — the actuals polling still
-            // converges, so the flow never blocks on this. The automatic call
-            // no longer degrades *silently*, though: its error is held for the
-            // ≥90s snag variant on the takeover and cleared by any later
-            // success, so a failure from any source is captured alike.
+            // converges, so the flow never blocks on this. The error is held
+            // for the ≥90s snag variant on the takeover and cleared by any
+            // later success, so a failure from any source is captured alike.
             setEnsureError(error);
-          },
-          // Unconditional (not generation-gated): the button's pending state
-          // must clear even for a response that belongs to a closed wizard,
-          // otherwise a reopen inherits a stuck-disabled Apply & Restart.
-          onSettled: () => {
-            if (source === "manual") {
-              setManualPending(false);
-            }
           },
         },
       );
@@ -431,17 +395,8 @@ export function useProProvisioning({
     return () => clearTimeout(t);
   }, [raceRetryScheduled, runEnsureProvisioned]);
 
-  const stalledAction = useMemo<ProvisioningRetryAction>(
-    () => ({
-      onApply: () => runEnsureProvisioned("manual"),
-      pending: manualPending,
-      error: ensureError,
-    }),
-    [runEnsureProvisioned, manualPending, ensureError],
-  );
-
-  // Fire-and-forget escape kick: fires the reconcile but never flips
-  // manualPending, so a hung escape-fired call can't strand later UI.
+  // Fire-and-forget escape kick: fires the reconcile with no pending flag, so a
+  // hung escape-fired call can't strand later UI.
   const kickProvisioning = useCallback(
     () => runEnsureProvisioned("escape"),
     [runEnsureProvisioned],
@@ -647,7 +602,6 @@ export function useProProvisioning({
     escapeEligible:
       msSinceWatchStart != null && msSinceWatchStart >= PROVISION_ESCAPE_MS,
     retryConfirm,
-    stalledAction,
     kickProvisioning,
     kickError: ensureError,
   };


### PR DESCRIPTION
## Summary
- Removes the now-unused stalledAction / ProvisioningRetryAction / manualPending recovery API.
- kickProvisioning / kickError remain the recovery surface, runtime behavior unchanged.

Part of plan: pro-takeover-exit-on-escape.md (PR 5 of 6)