### PR TITLE
feat(web): confirm before backgrounding the upgrade, warning that chat is unavailable

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -623,7 +623,7 @@ describe("BillingOnboardingModal", () => {
   });
 
   test(
-    "the stall shows the honest taking-longer copy — no Apply — and escaping kicks the reconcile, toasts, and closes",
+    "the stall shows the honest taking-longer copy — no Apply — and confirming the background exit kicks the reconcile, toasts, and closes",
     async () => {
       subscriptionPlanId = "pro";
       const { getByText, getByTestId, queryByText, queryByTestId, onClose } =
@@ -647,9 +647,16 @@ describe("BillingOnboardingModal", () => {
       // Apply & Restart is gone from the takeover.
       expect(queryByTestId("provisioning-apply")).toBeNull();
 
-      // "Continue in the background" fires the idempotent reconcile as a
-      // fire-and-forget kick, toasts, and closes — it never advances the wizard.
+      // "Continue in the background" opens the confirm; it warns chat is
+      // unavailable and does not kick or close on its own.
       fireEvent.click(getByTestId("provisioning-escape"));
+      expect(getByText("Continue in the background?")).toBeTruthy();
+      expect(ensureCalls).toBe(1);
+      expect(onClose).not.toHaveBeenCalled();
+
+      // Confirming with "Continue" fires the idempotent reconcile as a
+      // fire-and-forget kick, toasts, and closes — it never advances the wizard.
+      fireEvent.click(getByText("Continue"));
       await waitFor(() => expect(ensureCalls).toBe(2));
       expect(onClose).toHaveBeenCalled();
       expect(toastInfoCalls).toContain(
@@ -658,6 +665,39 @@ describe("BillingOnboardingModal", () => {
       // No advance to the email/All-set steps while the machine is busy.
       expect(queryByText("Assistant Email")).toBeNull();
       expect(queryByText("You're all set!")).toBeNull();
+    },
+    20_000,
+  );
+
+  test(
+    "waiting on the background confirm keeps the user on the takeover — no kick, no close",
+    async () => {
+      subscriptionPlanId = "pro";
+      const { getByText, getByTestId, queryByText, onClose } = renderModal();
+
+      await waitFor(
+        () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      await waitFor(() => expect(ensureCalls).toBe(1));
+
+      dateNowOffsetMs = 61_000;
+      await waitFor(
+        () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+
+      // Open the confirm, then dismiss it with "Wait".
+      fireEvent.click(getByTestId("provisioning-escape"));
+      expect(getByText("Continue in the background?")).toBeTruthy();
+      fireEvent.click(getByText("Wait"));
+
+      // The dialog closes and nothing was kicked or closed — still upgrading.
+      await waitFor(() =>
+        expect(queryByText("Continue in the background?")).toBeNull(),
+      );
+      expect(ensureCalls).toBe(1);
+      expect(onClose).not.toHaveBeenCalled();
     },
     20_000,
   );
@@ -724,7 +764,7 @@ describe("BillingOnboardingModal", () => {
   });
 
   test(
-    "escaping a busy takeover kicks the reconcile, toasts, and closes — it never advances to complete",
+    "confirming the background exit on a busy takeover kicks the reconcile, toasts, and closes — it never advances to complete",
     async () => {
       subscriptionPlanId = "pro";
       onboardingResponse = makeOnboarding({ domain_setup_available: false });
@@ -742,10 +782,16 @@ describe("BillingOnboardingModal", () => {
         () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
         { timeout: 15_000 },
       );
+      // The escape CTA opens the confirm; nothing kicks or closes until confirmed.
       fireEvent.click(getByTestId("provisioning-escape"));
+      expect(getByText("Continue in the background?")).toBeTruthy();
+      expect(ensureCalls).toBe(1);
+      expect(onClose).not.toHaveBeenCalled();
 
-      // A fire-and-forget kick, an error-free toast, and a close — no advance to
-      // the All-set step, no background-finishing line.
+      // Confirming with "Continue": a fire-and-forget kick, an error-free toast,
+      // and a close — no advance to the All-set step, no background-finishing
+      // line.
+      fireEvent.click(getByText("Continue"));
       await waitFor(() => expect(ensureCalls).toBe(2));
       expect(onClose).toHaveBeenCalled();
       expect(toastInfoCalls).toContain(
@@ -831,10 +877,16 @@ describe("BillingOnboardingModal", () => {
       ).toBeTruthy();
       expect(queryByTestId("provisioning-apply")).toBeNull();
 
-      // The snag CTA reads "Retry in the background": it re-kicks the reconcile,
-      // toasts the error-aware line, and closes.
+      // The snag CTA reads "Retry in the background": clicking it opens the
+      // confirm; confirming with "Continue" re-kicks the reconcile, toasts the
+      // error-aware line, and closes.
       expect(getByText("Retry in the background")).toBeTruthy();
       fireEvent.click(getByTestId("provisioning-escape"));
+      expect(getByText("Continue in the background?")).toBeTruthy();
+      expect(ensureCalls).toBe(1);
+      expect(onClose).not.toHaveBeenCalled();
+
+      fireEvent.click(getByText("Continue"));
       await waitFor(() => expect(ensureCalls).toBe(2));
       expect(onClose).toHaveBeenCalled();
       expect(toastInfoCalls).toContain(

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -702,6 +702,61 @@ describe("BillingOnboardingModal", () => {
     20_000,
   );
 
+  test(
+    "a resize settling while the background confirm is open dismisses it without force-closing the advanced step",
+    async () => {
+      subscriptionPlanId = "pro";
+      // Route to complete so the dialog's own "Continue"/"Wait" are the only
+      // ones on screen — the domain step renders its own "Continue" button.
+      onboardingResponse = makeOnboarding({ domain_setup_available: false });
+      const { client, getByText, getByTestId, queryByText, onClose } =
+        renderModal();
+
+      await waitFor(
+        () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      await waitFor(() => expect(ensureCalls).toBe(1));
+      // Wait for the pre-resize actuals to land (the "from" card) before
+      // mutating, mirroring the other DONE-transition tests.
+      await waitFor(() => expect(getByText("10 GB")).toBeTruthy(), {
+        timeout: 5000,
+      });
+
+      // Elapse the escape window so the background CTA surfaces while busy, then
+      // open the confirm.
+      dateNowOffsetMs = 61_000;
+      await waitFor(
+        () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      fireEvent.click(getByTestId("provisioning-escape"));
+      expect(getByText("Continue in the background?")).toBeTruthy();
+
+      // The resize finishes while the confirm is still open: actuals meet the
+      // targets, so the machine settles and the wizard advances to complete.
+      assistantResponse = makeAssistant("large", 50);
+      await client.invalidateQueries();
+      await waitFor(() => expect(getByText("You're all set!")).toBeTruthy(), {
+        timeout: 5000,
+      });
+
+      // The confirm auto-dismissed the moment provisioning stopped being busy,
+      // so its "Continue" can't fire and force-close the wizard over the
+      // now-uncovered complete step.
+      expect(queryByText("Continue in the background?")).toBeNull();
+      expect(
+        queryByText(
+          "Your assistant is still upgrading. Chatting won't be available until it finishes — you can keep waiting here, or continue and we'll let you know when it's ready.",
+        ),
+      ).toBeNull();
+      expect(queryByText("Continue")).toBeNull();
+      expect(queryByText("Wait")).toBeNull();
+      expect(onClose).not.toHaveBeenCalled();
+    },
+    20_000,
+  );
+
   test("onboarding fetch failure after confirm shows the fetch-error state", async () => {
     subscriptionPlanId = "pro";
     onboardingFails = true;

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -317,6 +317,16 @@ export function BillingOnboardingModal({
     setBackgroundConfirmOpen(false);
   }, []);
 
+  // A resize that settles while the confirm is open dismisses it: the moment
+  // provisioning stops being busy the wizard advances to the domain or complete
+  // step, so a lingering confirm would cover that step — and its "Continue"
+  // would force-close the wizard over it.
+  useEffect(() => {
+    if (!machineBusy && backgroundConfirmOpen) {
+      setBackgroundConfirmOpen(false);
+    }
+  }, [machineBusy, backgroundConfirmOpen]);
+
   // The fetch-error variant of the provisioning step is a standard dismissible
   // card, not the locked full-bleed takeover — otherwise the light error UI is
   // marooned in the dark full-screen viewport and the user can't act on it.
@@ -423,7 +433,10 @@ export function BillingOnboardingModal({
       {/* Stacks over the locked full-bleed takeover as its own Modal.Root; its
           Escape/backdrop closes only this confirm, never the takeover behind. */}
       <ConfirmDialog
-        open={backgroundConfirmOpen}
+        // Gated on the live machine state too: a resize that settles while the
+        // confirm is open closes it declaratively, so its buttons can't act
+        // after the wizard has advanced past provisioning.
+        open={backgroundConfirmOpen && machineBusy}
         title="Continue in the background?"
         message="Your assistant is still upgrading. Chatting won't be available until it finishes — you can keep waiting here, or continue and we'll let you know when it's ready."
         confirmLabel="Continue"

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -15,6 +15,7 @@ import {
   readCheckoutIntent,
   type CheckoutIntent,
 } from "@/lib/billing/checkout-intent";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -110,6 +111,9 @@ export function BillingOnboardingModal({
   // hook's `openedAt`: only a domains response fetched at/after this instant is
   // trusted for routing. Null while closed.
   const [domainsOpenedAt, setDomainsOpenedAt] = useState<number | null>(null);
+  // Gates the "Continue in the background" exit behind a confirm that warns
+  // chatting stays unavailable until the upgrade finishes.
+  const [backgroundConfirmOpen, setBackgroundConfirmOpen] = useState(false);
 
   // The hook owns the on-open subscription/onboarding cache invalidation and
   // every provisioning poll; it keeps tracking across step changes so a
@@ -132,6 +136,7 @@ export function BillingOnboardingModal({
     setTakeoverExit("idle");
     setDisplayedPhase(null);
     setDomainsOpenedAt(null);
+    setBackgroundConfirmOpen(false);
   }, [open, isResize]);
 
   useEffect(
@@ -285,19 +290,32 @@ export function BillingOnboardingModal({
     );
   }, [domainSetupAvailable, isResize, hasExistingDomain]);
 
-  // "Continue in the background" kicks the idempotent ensure-provisioned
-  // reconcile, shows an error-aware toast, and closes the takeover so the user
-  // is handed back to the app rather than parked on the email/All-set steps
-  // mid-provisioning.
+  // "Continue in the background" opens a confirm that warns chatting stays
+  // unavailable until the upgrade finishes, so the user chooses to keep waiting
+  // or to be handed back to the app while the machine is still restarting.
   const escapeProvisioning = useCallback(() => {
+    setBackgroundConfirmOpen(true);
+  }, []);
+
+  // Confirming the exit kicks the idempotent ensure-provisioned reconcile, shows
+  // an error-aware toast, dismisses the confirm, and closes the takeover so the
+  // user is handed back to the app rather than parked on the email/All-set steps
+  // mid-provisioning.
+  const confirmBackgroundExit = useCallback(() => {
     provisioning.kickProvisioning();
     toast.info(
       provisioning.kickError != null
         ? "We'll retry your upgrade in the background."
         : "Your upgrade continues in the background.",
     );
+    setBackgroundConfirmOpen(false);
     onClose();
   }, [provisioning, onClose]);
+
+  // Cancelling keeps the user on the takeover, still waiting on the upgrade.
+  const cancelBackgroundExit = useCallback(() => {
+    setBackgroundConfirmOpen(false);
+  }, []);
 
   // The fetch-error variant of the provisioning step is a standard dismissible
   // card, not the locked full-bleed takeover — otherwise the light error UI is
@@ -337,65 +355,83 @@ export function BillingOnboardingModal({
       : "[animation:fadeIn_0.25s_ease-out_both]";
 
   return (
-    <Modal.Root
-      open={open}
-      onOpenChange={(o) => {
-        if (!o) {
-          onClose();
-        }
-      }}
-    >
-      <Modal.Content
-        size="md"
-        // The final step is terminal — nothing is in flight to interrupt, so it
-        // gets the standard dismiss. Earlier steps keep their exits in-content.
-        hideCloseButton={step !== "complete"}
-        dismissOnOverlayClick={!lockTakeover}
-        onEscapeKeyDown={lockTakeover ? (e) => e.preventDefault() : undefined}
-        onInteractOutside={lockTakeover ? (e) => e.preventDefault() : undefined}
-        data-theme={isTakeover ? "dark" : undefined}
-        overlayClassName={overlayClass}
-        className={isTakeover ? provisioningContentClass : "overflow-hidden"}
-        style={{ [TAKEOVER_SURFACE_VAR]: tintHex } as CSSProperties}
+    <>
+      <Modal.Root
+        open={open}
+        onOpenChange={(o) => {
+          if (!o) {
+            onClose();
+          }
+        }}
       >
-        {/* Keyed on step so the fade replays as we swap takeover ⇄ card. The
-            takeover is the modal's opening step, so it mounts at full size
-            rather than growing into it — it gets a longer, softer entrance so
-            a full-bleed dark canvas doesn't just appear over the billing page. */}
-        <div
-          key={step}
-          className={`flex min-h-0 flex-1 flex-col motion-reduce:[animation:none] ${stepEntrance}`}
+        <Modal.Content
+          size="md"
+          // The final step is terminal — nothing is in flight to interrupt, so
+          // it gets the standard dismiss. Earlier steps keep exits in-content.
+          hideCloseButton={step !== "complete"}
+          dismissOnOverlayClick={!lockTakeover}
+          onEscapeKeyDown={lockTakeover ? (e) => e.preventDefault() : undefined}
+          onInteractOutside={
+            lockTakeover ? (e) => e.preventDefault() : undefined
+          }
+          data-theme={isTakeover ? "dark" : undefined}
+          overlayClassName={overlayClass}
+          className={isTakeover ? provisioningContentClass : "overflow-hidden"}
+          style={{ [TAKEOVER_SURFACE_VAR]: tintHex } as CSSProperties}
         >
-          {renderStep()}
-        </div>
-        {takeoverExit !== "idle" && (
+          {/* Keyed on step so the fade replays as we swap takeover ⇄ card. The
+              takeover is the modal's opening step, so it mounts at full size
+              rather than growing into it — it gets a longer, softer entrance so
+              a full-bleed dark canvas doesn't just appear over the billing page. */}
           <div
-            aria-hidden
-            data-testid="takeover-exit-sheet"
-            className={
-              // `fixed` escapes the card's box once the modal has shrunk back,
-              // so the sheet still covers the viewport while it clears. Reversed
-              // fadeIn is the fade-out; no second keyframe needed.
-              `pointer-events-none fixed inset-0 z-50 ${
-                takeoverExit === "covering"
-                  ? "[animation:fadeIn_200ms_ease-in_both]"
-                  : "[animation:fadeIn_380ms_ease-out_both_reverse]"
-              }`
-            }
-            style={{ backgroundColor: TAKEOVER_SURFACE }}
+            key={step}
+            className={`flex min-h-0 flex-1 flex-col motion-reduce:[animation:none] ${stepEntrance}`}
           >
-            {/* A custom-image takeover's colour lives in this blurred image, not
-                the ground fill, so the sheet reproduces it to match. The
-                `TAKEOVER_SURFACE` fill shows through while it decodes. The
-                sheet's own fade drives the reveal, so the backdrop doesn't
-                re-fade over it. */}
-            {backdropImageUrl && (
-              <TakeoverBackdrop imageUrl={backdropImageUrl} animateIn={false} />
-            )}
+            {renderStep()}
           </div>
-        )}
-      </Modal.Content>
-    </Modal.Root>
+          {takeoverExit !== "idle" && (
+            <div
+              aria-hidden
+              data-testid="takeover-exit-sheet"
+              className={
+                // `fixed` escapes the card's box once the modal has shrunk back,
+                // so the sheet still covers the viewport while it clears.
+                // Reversed fadeIn is the fade-out; no second keyframe needed.
+                `pointer-events-none fixed inset-0 z-50 ${
+                  takeoverExit === "covering"
+                    ? "[animation:fadeIn_200ms_ease-in_both]"
+                    : "[animation:fadeIn_380ms_ease-out_both_reverse]"
+                }`
+              }
+              style={{ backgroundColor: TAKEOVER_SURFACE }}
+            >
+              {/* A custom-image takeover's colour lives in this blurred image,
+                  not the ground fill, so the sheet reproduces it to match. The
+                  `TAKEOVER_SURFACE` fill shows through while it decodes. The
+                  sheet's own fade drives the reveal, so the backdrop doesn't
+                  re-fade over it. */}
+              {backdropImageUrl && (
+                <TakeoverBackdrop
+                  imageUrl={backdropImageUrl}
+                  animateIn={false}
+                />
+              )}
+            </div>
+          )}
+        </Modal.Content>
+      </Modal.Root>
+      {/* Stacks over the locked full-bleed takeover as its own Modal.Root; its
+          Escape/backdrop closes only this confirm, never the takeover behind. */}
+      <ConfirmDialog
+        open={backgroundConfirmOpen}
+        title="Continue in the background?"
+        message="Your assistant is still upgrading. Chatting won't be available until it finishes — you can keep waiting here, or continue and we'll let you know when it's ready."
+        confirmLabel="Continue"
+        cancelLabel="Wait"
+        onConfirm={confirmBackgroundExit}
+        onCancel={cancelBackgroundExit}
+      />
+    </>
   );
 
   function renderStep() {


### PR DESCRIPTION
## Summary
- 'Continue in the background' now opens a confirmation dialog warning that chat is unavailable until the upgrade finishes.
- Wait keeps the user on the takeover; Continue fires the reconcile kick, toasts, and closes the modal.

Part of plan: pro-takeover-exit-on-escape.md (PR 6 of 6)