### PR TITLE
refactor(web): drop the redundant background-confirm reset effect and a stale comment

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -317,16 +317,6 @@ export function BillingOnboardingModal({
     setBackgroundConfirmOpen(false);
   }, []);
 
-  // A resize that settles while the confirm is open dismisses it: the moment
-  // provisioning stops being busy the wizard advances to the domain or complete
-  // step, so a lingering confirm would cover that step — and its "Continue"
-  // would force-close the wizard over it.
-  useEffect(() => {
-    if (!machineBusy && backgroundConfirmOpen) {
-      setBackgroundConfirmOpen(false);
-    }
-  }, [machineBusy, backgroundConfirmOpen]);
-
   // The fetch-error variant of the provisioning step is a standard dismissible
   // card, not the locked full-bleed takeover — otherwise the light error UI is
   // marooned in the dark full-screen viewport and the user can't act on it.

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -66,8 +66,8 @@ const AVATAR_GROWTH = 1.414;
 
 // The stage reserves the grown height from first paint, so the takeover needs
 // `size * AVATAR_GROWTH + 309` of viewport before the phase block underneath —
-// which carries the escape hatch and the stalled retry — starts to clip. Step
-// the creature down instead of pushing those actions off a short screen.
+// which carries the escape hatch — starts to clip. Step the creature down
+// instead of pushing that control off a short screen.
 const AVATAR_SIZE_STEPS: Array<{ minHeight: number; size: number }> = [
   { minHeight: 680, size: AVATAR_SIZE },
   { minHeight: 600, size: 184 },


### PR DESCRIPTION
## Summary
- Remove the reset effect that duplicated the ConfirmDialog's `open={backgroundConfirmOpen && machineBusy}` gate (the gate closes it declaratively on settle).
- Fix a stale comment that referenced a separate 'stalled retry' control that no longer exists.

Self-review remediation for plan: pro-takeover-exit-on-escape.md