### PR TITLE
Pro provisioning takeover: exit-on-escape consolidation + confirm-before-backgrounding

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -276,9 +276,6 @@ const { TAKEOVER_SURFACE, TAKEOVER_SURFACE_VAR } = await import(
   "./provisioning-state"
 );
 
-const BACKGROUND_LINE =
-  "Assistant will go offline briefly while it resizes. Chat might not work during that time.";
-
 /**
  * Fast celebration dwell. Long enough for waitFor (50ms polls) to reliably
  * observe the transient DONE / NOT_APPLICABLE copy before it auto-advances.
@@ -413,7 +410,6 @@ describe("BillingOnboardingModal", () => {
       timeout: 5000,
     });
     expect(queryByText("Assistant Email")).toBeNull();
-    expect(queryByText(BACKGROUND_LINE)).toBeNull();
     expect(readCheckoutIntent()).toBeNull();
     // Checkout mode never fires the modal-level domains query.
     expect(domainsCalls).toBe(0);
@@ -756,7 +752,6 @@ describe("BillingOnboardingModal", () => {
         "Your upgrade continues in the background.",
       );
       expect(queryByText("You're all set!")).toBeNull();
-      expect(queryByText(BACKGROUND_LINE)).toBeNull();
     },
     30_000,
   );

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -34,6 +34,7 @@ import type {
 import { readCheckoutIntent, saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import * as toastMod from "@vellumai/design-library/components/toast";
 
 import * as proOnboardingUtils from "./utils";
 
@@ -70,6 +71,19 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
     isLoading: false,
     invalidate: () => {},
   }),
+}));
+
+// Capture the escape toast so the exit-on-escape path can assert its message;
+// keep the real module's other methods intact.
+const toastInfoCalls: string[] = [];
+mock.module("@vellumai/design-library/components/toast", () => ({
+  ...toastMod,
+  toast: {
+    ...toastMod.toast,
+    info: (message: string) => {
+      toastInfoCalls.push(message);
+    },
+  },
 }));
 
 const realDateNow = Date.now.bind(Date);
@@ -326,6 +340,7 @@ beforeEach(() => {
   domainsFails = false;
   domainsHold = null;
   dateNowOffsetMs = 0;
+  toastInfoCalls.length = 0;
   sessionStorage.clear();
 });
 
@@ -612,89 +627,44 @@ describe("BillingOnboardingModal", () => {
   });
 
   test(
-    "a busy takeover past the escape grace with routing hung is dismissable via the backdrop",
+    "the stall shows the honest taking-longer copy — no Apply — and escaping kicks the reconcile, toasts, and closes",
     async () => {
-      // The purest dead-end: an active WAITING/RESIZING takeover whose
-      // post-confirm onboarding refetch is held open, so routing never settles
-      // and the in-content escape button (gated on routing) never appears.
-      // Once the watch runs past the escape grace, the fallback background
-      // dismiss must unlock — the takeover has no persistent close control, so
-      // this fallback is what keeps the user from being stranded.
-      onboardingHold = new Promise(() => {});
       subscriptionPlanId = "pro";
-      const { getByText, onClose } = renderModal();
+      const { getByText, getByTestId, queryByText, queryByTestId, onClose } =
+        renderModal();
 
       await waitFor(
         () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
         { timeout: 5000 },
       );
+      // The wizard reconciled once on the pro transition.
+      await waitFor(() => expect(ensureCalls).toBe(1));
 
-      // Past the escape grace (60s) but before the stall threshold (90s):
-      // escapeEligible latches while the state stays busy, not STALLED.
-      dateNowOffsetMs = 70_000;
-
-      // The X stays hidden throughout — the fallback exit is the backdrop.
-      expect(document.body.querySelector('[aria-label="Close"]')).toBeNull();
-
-      // The 1s clock tick re-derives escapeEligible; once it lands the backdrop
-      // unlocks, so re-click until the dismiss flows through to onClose.
+      // Jump the wall clock past the stall threshold; the hook's next clock
+      // tick re-derives the state as STALLED.
+      dateNowOffsetMs = 200_000;
       await waitFor(
-        () => {
-          const overlay = document.body.querySelector(
-            '[data-slot="modal-overlay"]',
-          );
-          expect(overlay).not.toBeNull();
-          fireEvent.click(overlay as Element);
-          expect(onClose).toHaveBeenCalled();
-        },
+        () =>
+          expect(getByText("This is taking longer than expected")).toBeTruthy(),
         { timeout: 5000 },
       );
+      // Apply & Restart is gone from the takeover.
+      expect(queryByTestId("provisioning-apply")).toBeNull();
 
-      // Still the busy takeover, not the stalled path (which has its own Apply).
-      expect(getByText("Upgrading your assistant…")).toBeTruthy();
+      // "Continue in the background" fires the idempotent reconcile as a
+      // fire-and-forget kick, toasts, and closes — it never advances the wizard.
+      fireEvent.click(getByTestId("provisioning-escape"));
+      await waitFor(() => expect(ensureCalls).toBe(2));
+      expect(onClose).toHaveBeenCalled();
+      expect(toastInfoCalls).toContain(
+        "Your upgrade continues in the background.",
+      );
+      // No advance to the email/All-set steps while the machine is busy.
+      expect(queryByText("Assistant Email")).toBeNull();
+      expect(queryByText("You're all set!")).toBeNull();
     },
     20_000,
   );
-
-  test("stall surfaces Apply & Restart; a successful apply resumes resizing through DONE", async () => {
-    subscriptionPlanId = "pro";
-    const { client, getByText, getByTestId } = renderModal();
-
-    await waitFor(
-      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    // The wizard reconciled once on the pro transition.
-    await waitFor(() => expect(ensureCalls).toBe(1));
-
-    // Jump the wall clock past the stall threshold; the hook's next clock
-    // tick re-derives the state as STALLED.
-    dateNowOffsetMs = 200_000;
-    await waitFor(() => expect(getByText("We couldn't finish this automatically")).toBeTruthy(), {
-      timeout: 5000,
-    });
-
-    // The stalled button re-calls the same idempotent reconcile.
-    fireEvent.click(getByTestId("provisioning-apply"));
-    await waitFor(() => expect(ensureCalls).toBe(2));
-
-    // The successful apply resumes observation: back to the resizing UI…
-    await waitFor(
-      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-
-    // …and the resize landing completes the normal DONE → advance flow.
-    assistantResponse = makeAssistant("large", 50);
-    await client.invalidateQueries();
-    await waitFor(
-      () => expect(getByText("All done!")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy(), {
-      timeout: 5000,
-    });
-  });
 
   test("onboarding fetch failure after confirm shows the fetch-error state", async () => {
     subscriptionPlanId = "pro";
@@ -757,64 +727,20 @@ describe("BillingOnboardingModal", () => {
     );
   });
 
-  test("domain submit stays disabled while the machine is resizing", async () => {
-    subscriptionPlanId = "pro";
-    const { client, getByText, getByTestId, getByLabelText } = renderModal();
-
-    await waitFor(
-      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-
-    // The escape hatch is a late fallback: it appears only once the watch has
-    // run past the escape window (and the onboarding fetch has settled).
-    dateNowOffsetMs = 61_000;
-    await waitFor(
-      () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    fireEvent.click(getByTestId("provisioning-escape"));
-    await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy());
-
-    expect(
-      getByText(
-        "Your assistant is restarting — you can set the domain in a moment.",
-      ),
-    ).toBeTruthy();
-    // Wait for the handle prefill: with an empty subdomain the submit would be
-    // disabled regardless, masking a missing machine-busy guard.
-    await waitFor(() =>
-      expect((getByLabelText("Handle (public)") as HTMLInputElement).value).toBe(
-        "casey",
-      ),
-    );
-    expect(
-      (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
-    ).toBe(true);
-
-    // The still-mounted hook sees the resize land and lifts the guard.
-    assistantResponse = makeAssistant("large", 50);
-    await client.invalidateQueries();
-    await waitFor(
-      () =>
-        expect(
-          (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
-        ).toBe(false),
-      { timeout: 5000 },
-    );
-  });
-
   test(
-    "escape advances to complete with the background-finishing line, which clears on DONE",
+    "escaping a busy takeover kicks the reconcile, toasts, and closes — it never advances to complete",
     async () => {
       subscriptionPlanId = "pro";
       onboardingResponse = makeOnboarding({ domain_setup_available: false });
-      const { client, getByText, getByTestId, queryByText } = renderModal();
+      const { getByText, getByTestId, queryByText, onClose } = renderModal();
 
       await waitFor(
         () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
         { timeout: 15_000 },
       );
+      // The wizard reconciled once on the pro transition.
+      await waitFor(() => expect(ensureCalls).toBe(1));
+
       dateNowOffsetMs = 61_000;
       await waitFor(
         () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
@@ -822,14 +748,15 @@ describe("BillingOnboardingModal", () => {
       );
       fireEvent.click(getByTestId("provisioning-escape"));
 
-      await waitFor(() => expect(getByText("You're all set!")).toBeTruthy());
-      expect(getByText(BACKGROUND_LINE)).toBeTruthy();
-
-      assistantResponse = makeAssistant("large", 50);
-      await client.invalidateQueries();
-      await waitFor(() => expect(queryByText(BACKGROUND_LINE)).toBeNull(), {
-        timeout: 15_000,
-      });
+      // A fire-and-forget kick, an error-free toast, and a close — no advance to
+      // the All-set step, no background-finishing line.
+      await waitFor(() => expect(ensureCalls).toBe(2));
+      expect(onClose).toHaveBeenCalled();
+      expect(toastInfoCalls).toContain(
+        "Your upgrade continues in the background.",
+      );
+      expect(queryByText("You're all set!")).toBeNull();
+      expect(queryByText(BACKGROUND_LINE)).toBeNull();
     },
     30_000,
   );
@@ -858,184 +785,65 @@ describe("BillingOnboardingModal", () => {
     20_000,
   );
 
-  test("escape hatch waits for fresh routing data even once time-eligible", async () => {
-    let releaseOnboarding!: () => void;
-    onboardingHold = new Promise((resolve) => {
-      releaseOnboarding = resolve;
-    });
+  test("escape hatch appears once time-eligible even while routing is unsettled", async () => {
+    // The escape button is independent of routing — it's the always-available
+    // recovery for a hung routing refetch. Hold the onboarding fetch open so
+    // routing never settles; the hatch must still appear the moment the watch
+    // passes the escape window.
+    onboardingHold = new Promise(() => {});
     subscriptionPlanId = "pro";
-    const { getByText, getByTestId, queryByTestId } = renderModal();
+    const { getByText, getByTestId } = renderModal();
 
     await waitFor(
       () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
       { timeout: 5000 },
     );
     dateNowOffsetMs = 61_000;
-    // Time-eligible, but domain_setup_available could still be stale — the
-    // hatch must wait for the onboarding fetch to settle.
-    await new Promise((resolve) => setTimeout(resolve, 1200));
-    expect(queryByTestId("provisioning-escape")).toBeNull();
-
-    releaseOnboarding();
     await waitFor(
       () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
       { timeout: 5000 },
     );
   });
 
-  test("a failed apply surfaces its error and a late-landing resize still recovers", async () => {
-    subscriptionPlanId = "pro";
-    const { client, getByText, getByTestId } = renderModal();
-
-    await waitFor(
-      () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-    dateNowOffsetMs = 200_000;
-    await waitFor(() => expect(getByText("We couldn't finish this automatically")).toBeTruthy(), {
-      timeout: 5000,
-    });
-
-    // Only a user-initiated reconcile surfaces its failure — the automatic one
-    // on the pro transition degrades silently.
-    ensureError = { error: "provisioning_submission_failed" };
-    fireEvent.click(getByTestId("provisioning-apply"));
-    await waitFor(() => expect(ensureCalls).toBe(2));
-    await waitFor(() =>
-      expect(
-        getByText("We couldn't queue your upgrade just now. Try again in a moment."),
-      ).toBeTruthy(),
-    );
-    expect(getByText("We couldn't finish this automatically")).toBeTruthy();
-
-    // If a server-side resize was in fact still running, its landing is
-    // observed by the actuals polling and replaces the stalled UI.
-    assistantResponse = makeAssistant("large", 50);
-    await client.invalidateQueries();
-    await waitFor(
-      () => expect(getByText("All done!")).toBeTruthy(),
-      { timeout: 5000 },
-    );
-  });
-
   test(
-    "a stall after escaping to complete offers Apply & Restart there",
+    "a failed auto-reconcile shows the snag variant; escaping retries in the background and closes",
     async () => {
       subscriptionPlanId = "pro";
-      onboardingResponse = makeOnboarding({ domain_setup_available: false });
-      const { client, getByText, getByTestId, queryByText, queryByTestId } =
-        renderModal();
-
-      await waitFor(
-        () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
-        { timeout: 15_000 },
-      );
-      dateNowOffsetMs = 61_000;
-      await waitFor(
-        () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
-        { timeout: 15_000 },
-      );
-      fireEvent.click(getByTestId("provisioning-escape"));
-      await waitFor(() => expect(getByText("You're all set!")).toBeTruthy());
-      expect(getByText(BACKGROUND_LINE)).toBeTruthy();
-
-      // The backgrounded resize stalls: the finishing line swaps for a warning
-      // with a manual apply.
-      dateNowOffsetMs = 200_000;
-      await waitFor(
-        () => expect(getByTestId("complete-stalled-apply")).toBeTruthy(),
-        { timeout: 15_000 },
-      );
-      expect(queryByText(BACKGROUND_LINE)).toBeNull();
-
-      // Applying resumes observation — the finishing line returns…
-      fireEvent.click(getByTestId("complete-stalled-apply"));
-      await waitFor(() => expect(ensureCalls).toBe(2));
-      await waitFor(() => expect(getByText(BACKGROUND_LINE)).toBeTruthy(), {
-        timeout: 15_000,
-      });
-
-      // …and the resize landing clears it.
-      assistantResponse = makeAssistant("large", 50);
-      await client.invalidateQueries();
-      await waitFor(() => expect(queryByText(BACKGROUND_LINE)).toBeNull(), {
-        timeout: 15_000,
-      });
-      expect(queryByTestId("complete-stalled-apply")).toBeNull();
-    },
-    30_000,
-  );
-
-  test(
-    "a stall while the user is on the domain step offers the apply controls and keeps the submit locked",
-    async () => {
-      subscriptionPlanId = "pro";
-      const {
-        client,
-        getByText,
-        getByTestId,
-        getByLabelText,
-        queryByText,
-        queryByTestId,
-      } = renderModal();
+      // The automatic reconcile on the pro transition fails, so its error is
+      // held as kickError — the ≥90s stall then shows the "snag" variant.
+      ensureError = { error: "provisioning_submission_failed" };
+      const { getByText, getByTestId, queryByTestId, onClose } = renderModal();
 
       await waitFor(
         () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
         { timeout: 5000 },
       );
-      dateNowOffsetMs = 61_000;
-      await waitFor(
-        () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
-        { timeout: 5000 },
-      );
-      fireEvent.click(getByTestId("provisioning-escape"));
-      await waitFor(() => expect(getByText("Assistant Email")).toBeTruthy());
-      await waitFor(() =>
-        expect((getByLabelText("Handle (public)") as HTMLInputElement).value).toBe(
-          "casey",
-        ),
-      );
+      await waitFor(() => expect(ensureCalls).toBe(1));
 
-      // The flow stalls while the user is on the domain step: the machine may
-      // still be mid-restart, so the guardian-channel submit stays locked and
-      // the neutral busy notice swaps for the stalled warning + manual apply.
       dateNowOffsetMs = 200_000;
-      await waitFor(
-        () => expect(getByTestId("domain-stalled-apply")).toBeTruthy(),
-        { timeout: 5000 },
-      );
-      expect(
-        queryByText(
-          "Your assistant is restarting — you can set the domain in a moment.",
-        ),
-      ).toBeNull();
-      expect(
-        (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
-      ).toBe(true);
-
-      // Applying resumes observation: the stalled controls give way to the
-      // neutral busy notice while the resize is re-observed…
-      fireEvent.click(getByTestId("domain-stalled-apply"));
-      await waitFor(() => expect(ensureCalls).toBe(2));
-      await waitFor(() =>
-        expect(
-          getByText(
-            "Your assistant is restarting — you can set the domain in a moment.",
-          ),
-        ).toBeTruthy(),
-      );
-      expect(queryByTestId("domain-stalled-apply")).toBeNull();
-
-      // …and the resize landing lifts the guard.
-      assistantResponse = makeAssistant("large", 50);
-      await client.invalidateQueries();
       await waitFor(
         () =>
           expect(
-            (getByTestId("onboarding-domain-set") as HTMLButtonElement)
-              .disabled,
-          ).toBe(false),
+            getByText("We hit a snag upgrading your assistant"),
+          ).toBeTruthy(),
         { timeout: 5000 },
+      );
+      // The mapped error is the caption, and Apply & Restart is gone.
+      expect(
+        getByText(
+          "We couldn't queue your upgrade just now. Try again in a moment.",
+        ),
+      ).toBeTruthy();
+      expect(queryByTestId("provisioning-apply")).toBeNull();
+
+      // The snag CTA reads "Retry in the background": it re-kicks the reconcile,
+      // toasts the error-aware line, and closes.
+      expect(getByText("Retry in the background")).toBeTruthy();
+      fireEvent.click(getByTestId("provisioning-escape"));
+      await waitFor(() => expect(ensureCalls).toBe(2));
+      expect(onClose).toHaveBeenCalled();
+      expect(toastInfoCalls).toContain(
+        "We'll retry your upgrade in the background.",
       );
     },
     20_000,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -623,7 +623,7 @@ describe("BillingOnboardingModal", () => {
   });
 
   test(
-    "the stall shows the honest taking-longer copy — no Apply — and escaping kicks the reconcile, toasts, and closes",
+    "the stall shows the honest taking-longer copy — no Apply — and confirming the background exit kicks the reconcile, toasts, and closes",
     async () => {
       subscriptionPlanId = "pro";
       const { getByText, getByTestId, queryByText, queryByTestId, onClose } =
@@ -647,9 +647,16 @@ describe("BillingOnboardingModal", () => {
       // Apply & Restart is gone from the takeover.
       expect(queryByTestId("provisioning-apply")).toBeNull();
 
-      // "Continue in the background" fires the idempotent reconcile as a
-      // fire-and-forget kick, toasts, and closes — it never advances the wizard.
+      // "Continue in the background" opens the confirm; it warns chat is
+      // unavailable and does not kick or close on its own.
       fireEvent.click(getByTestId("provisioning-escape"));
+      expect(getByText("Continue in the background?")).toBeTruthy();
+      expect(ensureCalls).toBe(1);
+      expect(onClose).not.toHaveBeenCalled();
+
+      // Confirming with "Continue" fires the idempotent reconcile as a
+      // fire-and-forget kick, toasts, and closes — it never advances the wizard.
+      fireEvent.click(getByText("Continue"));
       await waitFor(() => expect(ensureCalls).toBe(2));
       expect(onClose).toHaveBeenCalled();
       expect(toastInfoCalls).toContain(
@@ -658,6 +665,94 @@ describe("BillingOnboardingModal", () => {
       // No advance to the email/All-set steps while the machine is busy.
       expect(queryByText("Assistant Email")).toBeNull();
       expect(queryByText("You're all set!")).toBeNull();
+    },
+    20_000,
+  );
+
+  test(
+    "waiting on the background confirm keeps the user on the takeover — no kick, no close",
+    async () => {
+      subscriptionPlanId = "pro";
+      const { getByText, getByTestId, queryByText, onClose } = renderModal();
+
+      await waitFor(
+        () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      await waitFor(() => expect(ensureCalls).toBe(1));
+
+      dateNowOffsetMs = 61_000;
+      await waitFor(
+        () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+
+      // Open the confirm, then dismiss it with "Wait".
+      fireEvent.click(getByTestId("provisioning-escape"));
+      expect(getByText("Continue in the background?")).toBeTruthy();
+      fireEvent.click(getByText("Wait"));
+
+      // The dialog closes and nothing was kicked or closed — still upgrading.
+      await waitFor(() =>
+        expect(queryByText("Continue in the background?")).toBeNull(),
+      );
+      expect(ensureCalls).toBe(1);
+      expect(onClose).not.toHaveBeenCalled();
+    },
+    20_000,
+  );
+
+  test(
+    "a resize settling while the background confirm is open dismisses it without force-closing the advanced step",
+    async () => {
+      subscriptionPlanId = "pro";
+      // Route to complete so the dialog's own "Continue"/"Wait" are the only
+      // ones on screen — the domain step renders its own "Continue" button.
+      onboardingResponse = makeOnboarding({ domain_setup_available: false });
+      const { client, getByText, getByTestId, queryByText, onClose } =
+        renderModal();
+
+      await waitFor(
+        () => expect(getByText("Upgrading your assistant…")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      await waitFor(() => expect(ensureCalls).toBe(1));
+      // Wait for the pre-resize actuals to land (the "from" card) before
+      // mutating, mirroring the other DONE-transition tests.
+      await waitFor(() => expect(getByText("10 GB")).toBeTruthy(), {
+        timeout: 5000,
+      });
+
+      // Elapse the escape window so the background CTA surfaces while busy, then
+      // open the confirm.
+      dateNowOffsetMs = 61_000;
+      await waitFor(
+        () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
+        { timeout: 5000 },
+      );
+      fireEvent.click(getByTestId("provisioning-escape"));
+      expect(getByText("Continue in the background?")).toBeTruthy();
+
+      // The resize finishes while the confirm is still open: actuals meet the
+      // targets, so the machine settles and the wizard advances to complete.
+      assistantResponse = makeAssistant("large", 50);
+      await client.invalidateQueries();
+      await waitFor(() => expect(getByText("You're all set!")).toBeTruthy(), {
+        timeout: 5000,
+      });
+
+      // The confirm auto-dismissed the moment provisioning stopped being busy,
+      // so its "Continue" can't fire and force-close the wizard over the
+      // now-uncovered complete step.
+      expect(queryByText("Continue in the background?")).toBeNull();
+      expect(
+        queryByText(
+          "Your assistant is still upgrading. Chatting won't be available until it finishes — you can keep waiting here, or continue and we'll let you know when it's ready.",
+        ),
+      ).toBeNull();
+      expect(queryByText("Continue")).toBeNull();
+      expect(queryByText("Wait")).toBeNull();
+      expect(onClose).not.toHaveBeenCalled();
     },
     20_000,
   );
@@ -724,7 +819,7 @@ describe("BillingOnboardingModal", () => {
   });
 
   test(
-    "escaping a busy takeover kicks the reconcile, toasts, and closes — it never advances to complete",
+    "confirming the background exit on a busy takeover kicks the reconcile, toasts, and closes — it never advances to complete",
     async () => {
       subscriptionPlanId = "pro";
       onboardingResponse = makeOnboarding({ domain_setup_available: false });
@@ -742,10 +837,16 @@ describe("BillingOnboardingModal", () => {
         () => expect(getByTestId("provisioning-escape")).toBeTruthy(),
         { timeout: 15_000 },
       );
+      // The escape CTA opens the confirm; nothing kicks or closes until confirmed.
       fireEvent.click(getByTestId("provisioning-escape"));
+      expect(getByText("Continue in the background?")).toBeTruthy();
+      expect(ensureCalls).toBe(1);
+      expect(onClose).not.toHaveBeenCalled();
 
-      // A fire-and-forget kick, an error-free toast, and a close — no advance to
-      // the All-set step, no background-finishing line.
+      // Confirming with "Continue": a fire-and-forget kick, an error-free toast,
+      // and a close — no advance to the All-set step, no background-finishing
+      // line.
+      fireEvent.click(getByText("Continue"));
       await waitFor(() => expect(ensureCalls).toBe(2));
       expect(onClose).toHaveBeenCalled();
       expect(toastInfoCalls).toContain(
@@ -831,10 +932,16 @@ describe("BillingOnboardingModal", () => {
       ).toBeTruthy();
       expect(queryByTestId("provisioning-apply")).toBeNull();
 
-      // The snag CTA reads "Retry in the background": it re-kicks the reconcile,
-      // toasts the error-aware line, and closes.
+      // The snag CTA reads "Retry in the background": clicking it opens the
+      // confirm; confirming with "Continue" re-kicks the reconcile, toasts the
+      // error-aware line, and closes.
       expect(getByText("Retry in the background")).toBeTruthy();
       fireEvent.click(getByTestId("provisioning-escape"));
+      expect(getByText("Continue in the background?")).toBeTruthy();
+      expect(ensureCalls).toBe(1);
+      expect(onClose).not.toHaveBeenCalled();
+
+      fireEvent.click(getByText("Continue"));
       await waitFor(() => expect(ensureCalls).toBe(2));
       expect(onClose).toHaveBeenCalled();
       expect(toastInfoCalls).toContain(

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -687,10 +687,10 @@ describe("BillingOnboardingModal", () => {
         { timeout: 5000 },
       );
 
-      // Open the confirm, then dismiss it with "Wait".
+      // Open the confirm, then dismiss it with "Keep waiting".
       fireEvent.click(getByTestId("provisioning-escape"));
       expect(getByText("Continue in the background?")).toBeTruthy();
-      fireEvent.click(getByText("Wait"));
+      fireEvent.click(getByText("Keep waiting"));
 
       // The dialog closes and nothing was kicked or closed — still upgrading.
       await waitFor(() =>
@@ -706,8 +706,8 @@ describe("BillingOnboardingModal", () => {
     "a resize settling while the background confirm is open dismisses it without force-closing the advanced step",
     async () => {
       subscriptionPlanId = "pro";
-      // Route to complete so the dialog's own "Continue"/"Wait" are the only
-      // ones on screen — the domain step renders its own "Continue" button.
+      // Route to complete so the dialog's own "Continue"/"Keep waiting" are the
+      // only ones on screen — the domain step renders its own "Continue" button.
       onboardingResponse = makeOnboarding({ domain_setup_available: false });
       const { client, getByText, getByTestId, queryByText, onClose } =
         renderModal();
@@ -751,7 +751,7 @@ describe("BillingOnboardingModal", () => {
         ),
       ).toBeNull();
       expect(queryByText("Continue")).toBeNull();
-      expect(queryByText("Wait")).toBeNull();
+      expect(queryByText("Keep waiting")).toBeNull();
       expect(onClose).not.toHaveBeenCalled();
     },
     20_000,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -644,7 +644,7 @@ describe("BillingOnboardingModal", () => {
           expect(getByText("This is taking longer than expected")).toBeTruthy(),
         { timeout: 5000 },
       );
-      // Apply & Restart is gone from the takeover.
+      // The stalled takeover renders no Apply & Restart control.
       expect(queryByTestId("provisioning-apply")).toBeNull();
 
       // "Continue in the background" opens the confirm; it warns chat is
@@ -924,7 +924,8 @@ describe("BillingOnboardingModal", () => {
           ).toBeTruthy(),
         { timeout: 5000 },
       );
-      // The mapped error is the caption, and Apply & Restart is gone.
+      // The mapped error is the caption; the snag takeover renders no Apply &
+      // Restart control.
       expect(
         getByText(
           "We couldn't queue your upgrade just now. Try again in a moment.",

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -317,16 +317,6 @@ export function BillingOnboardingModal({
     setBackgroundConfirmOpen(false);
   }, []);
 
-  // A resize that settles while the confirm is open dismisses it: the moment
-  // provisioning stops being busy the wizard advances to the domain or complete
-  // step, so a lingering confirm would cover that step — and its "Continue"
-  // would force-close the wizard over it.
-  useEffect(() => {
-    if (!machineBusy && backgroundConfirmOpen) {
-      setBackgroundConfirmOpen(false);
-    }
-  }, [machineBusy, backgroundConfirmOpen]);
-
   // The fetch-error variant of the provisioning step is a standard dismissible
   // card, not the locked full-bleed takeover — otherwise the light error UI is
   // marooned in the dark full-screen viewport and the user can't act on it.

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -15,6 +15,7 @@ import {
   readCheckoutIntent,
   type CheckoutIntent,
 } from "@/lib/billing/checkout-intent";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -110,6 +111,9 @@ export function BillingOnboardingModal({
   // hook's `openedAt`: only a domains response fetched at/after this instant is
   // trusted for routing. Null while closed.
   const [domainsOpenedAt, setDomainsOpenedAt] = useState<number | null>(null);
+  // Gates the "Continue in the background" exit behind a confirm that warns
+  // chatting stays unavailable until the upgrade finishes.
+  const [backgroundConfirmOpen, setBackgroundConfirmOpen] = useState(false);
 
   // The hook owns the on-open subscription/onboarding cache invalidation and
   // every provisioning poll; it keeps tracking across step changes so a
@@ -132,6 +136,7 @@ export function BillingOnboardingModal({
     setTakeoverExit("idle");
     setDisplayedPhase(null);
     setDomainsOpenedAt(null);
+    setBackgroundConfirmOpen(false);
   }, [open, isResize]);
 
   useEffect(
@@ -285,19 +290,42 @@ export function BillingOnboardingModal({
     );
   }, [domainSetupAvailable, isResize, hasExistingDomain]);
 
-  // "Continue in the background" kicks the idempotent ensure-provisioned
-  // reconcile, shows an error-aware toast, and closes the takeover so the user
-  // is handed back to the app rather than parked on the email/All-set steps
-  // mid-provisioning.
+  // "Continue in the background" opens a confirm that warns chatting stays
+  // unavailable until the upgrade finishes, so the user chooses to keep waiting
+  // or to be handed back to the app while the machine is still restarting.
   const escapeProvisioning = useCallback(() => {
+    setBackgroundConfirmOpen(true);
+  }, []);
+
+  // Confirming the exit kicks the idempotent ensure-provisioned reconcile, shows
+  // an error-aware toast, dismisses the confirm, and closes the takeover so the
+  // user is handed back to the app rather than parked on the email/All-set steps
+  // mid-provisioning.
+  const confirmBackgroundExit = useCallback(() => {
     provisioning.kickProvisioning();
     toast.info(
       provisioning.kickError != null
         ? "We'll retry your upgrade in the background."
         : "Your upgrade continues in the background.",
     );
+    setBackgroundConfirmOpen(false);
     onClose();
   }, [provisioning, onClose]);
+
+  // Cancelling keeps the user on the takeover, still waiting on the upgrade.
+  const cancelBackgroundExit = useCallback(() => {
+    setBackgroundConfirmOpen(false);
+  }, []);
+
+  // A resize that settles while the confirm is open dismisses it: the moment
+  // provisioning stops being busy the wizard advances to the domain or complete
+  // step, so a lingering confirm would cover that step — and its "Continue"
+  // would force-close the wizard over it.
+  useEffect(() => {
+    if (!machineBusy && backgroundConfirmOpen) {
+      setBackgroundConfirmOpen(false);
+    }
+  }, [machineBusy, backgroundConfirmOpen]);
 
   // The fetch-error variant of the provisioning step is a standard dismissible
   // card, not the locked full-bleed takeover — otherwise the light error UI is
@@ -337,65 +365,86 @@ export function BillingOnboardingModal({
       : "[animation:fadeIn_0.25s_ease-out_both]";
 
   return (
-    <Modal.Root
-      open={open}
-      onOpenChange={(o) => {
-        if (!o) {
-          onClose();
-        }
-      }}
-    >
-      <Modal.Content
-        size="md"
-        // The final step is terminal — nothing is in flight to interrupt, so it
-        // gets the standard dismiss. Earlier steps keep their exits in-content.
-        hideCloseButton={step !== "complete"}
-        dismissOnOverlayClick={!lockTakeover}
-        onEscapeKeyDown={lockTakeover ? (e) => e.preventDefault() : undefined}
-        onInteractOutside={lockTakeover ? (e) => e.preventDefault() : undefined}
-        data-theme={isTakeover ? "dark" : undefined}
-        overlayClassName={overlayClass}
-        className={isTakeover ? provisioningContentClass : "overflow-hidden"}
-        style={{ [TAKEOVER_SURFACE_VAR]: tintHex } as CSSProperties}
+    <>
+      <Modal.Root
+        open={open}
+        onOpenChange={(o) => {
+          if (!o) {
+            onClose();
+          }
+        }}
       >
-        {/* Keyed on step so the fade replays as we swap takeover ⇄ card. The
-            takeover is the modal's opening step, so it mounts at full size
-            rather than growing into it — it gets a longer, softer entrance so
-            a full-bleed dark canvas doesn't just appear over the billing page. */}
-        <div
-          key={step}
-          className={`flex min-h-0 flex-1 flex-col motion-reduce:[animation:none] ${stepEntrance}`}
+        <Modal.Content
+          size="md"
+          // The final step is terminal — nothing is in flight to interrupt, so
+          // it gets the standard dismiss. Earlier steps keep exits in-content.
+          hideCloseButton={step !== "complete"}
+          dismissOnOverlayClick={!lockTakeover}
+          onEscapeKeyDown={lockTakeover ? (e) => e.preventDefault() : undefined}
+          onInteractOutside={
+            lockTakeover ? (e) => e.preventDefault() : undefined
+          }
+          data-theme={isTakeover ? "dark" : undefined}
+          overlayClassName={overlayClass}
+          className={isTakeover ? provisioningContentClass : "overflow-hidden"}
+          style={{ [TAKEOVER_SURFACE_VAR]: tintHex } as CSSProperties}
         >
-          {renderStep()}
-        </div>
-        {takeoverExit !== "idle" && (
+          {/* Keyed on step so the fade replays as we swap takeover ⇄ card. The
+              takeover is the modal's opening step, so it mounts at full size
+              rather than growing into it — it gets a longer, softer entrance so
+              a full-bleed dark canvas doesn't just appear over the billing page. */}
           <div
-            aria-hidden
-            data-testid="takeover-exit-sheet"
-            className={
-              // `fixed` escapes the card's box once the modal has shrunk back,
-              // so the sheet still covers the viewport while it clears. Reversed
-              // fadeIn is the fade-out; no second keyframe needed.
-              `pointer-events-none fixed inset-0 z-50 ${
-                takeoverExit === "covering"
-                  ? "[animation:fadeIn_200ms_ease-in_both]"
-                  : "[animation:fadeIn_380ms_ease-out_both_reverse]"
-              }`
-            }
-            style={{ backgroundColor: TAKEOVER_SURFACE }}
+            key={step}
+            className={`flex min-h-0 flex-1 flex-col motion-reduce:[animation:none] ${stepEntrance}`}
           >
-            {/* A custom-image takeover's colour lives in this blurred image, not
-                the ground fill, so the sheet reproduces it to match. The
-                `TAKEOVER_SURFACE` fill shows through while it decodes. The
-                sheet's own fade drives the reveal, so the backdrop doesn't
-                re-fade over it. */}
-            {backdropImageUrl && (
-              <TakeoverBackdrop imageUrl={backdropImageUrl} animateIn={false} />
-            )}
+            {renderStep()}
           </div>
-        )}
-      </Modal.Content>
-    </Modal.Root>
+          {takeoverExit !== "idle" && (
+            <div
+              aria-hidden
+              data-testid="takeover-exit-sheet"
+              className={
+                // `fixed` escapes the card's box once the modal has shrunk back,
+                // so the sheet still covers the viewport while it clears.
+                // Reversed fadeIn is the fade-out; no second keyframe needed.
+                `pointer-events-none fixed inset-0 z-50 ${
+                  takeoverExit === "covering"
+                    ? "[animation:fadeIn_200ms_ease-in_both]"
+                    : "[animation:fadeIn_380ms_ease-out_both_reverse]"
+                }`
+              }
+              style={{ backgroundColor: TAKEOVER_SURFACE }}
+            >
+              {/* A custom-image takeover's colour lives in this blurred image,
+                  not the ground fill, so the sheet reproduces it to match. The
+                  `TAKEOVER_SURFACE` fill shows through while it decodes. The
+                  sheet's own fade drives the reveal, so the backdrop doesn't
+                  re-fade over it. */}
+              {backdropImageUrl && (
+                <TakeoverBackdrop
+                  imageUrl={backdropImageUrl}
+                  animateIn={false}
+                />
+              )}
+            </div>
+          )}
+        </Modal.Content>
+      </Modal.Root>
+      {/* Stacks over the locked full-bleed takeover as its own Modal.Root; its
+          Escape/backdrop closes only this confirm, never the takeover behind. */}
+      <ConfirmDialog
+        // Gated on the live machine state too: a resize that settles while the
+        // confirm is open closes it declaratively, so its buttons can't act
+        // after the wizard has advanced past provisioning.
+        open={backgroundConfirmOpen && machineBusy}
+        title="Continue in the background?"
+        message="Your assistant is still upgrading. Chatting won't be available until it finishes — you can keep waiting here, or continue and we'll let you know when it's ready."
+        confirmLabel="Continue"
+        cancelLabel="Wait"
+        onConfirm={confirmBackgroundExit}
+        onCancel={cancelBackgroundExit}
+      />
+    </>
   );
 
   function renderStep() {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -430,7 +430,7 @@ export function BillingOnboardingModal({
         title="Continue in the background?"
         message="Your assistant is still upgrading. Chatting won't be available until it finishes — you can keep waiting here, or continue and we'll let you know when it's ready."
         confirmLabel="Continue"
-        cancelLabel="Wait"
+        cancelLabel="Keep waiting"
         onConfirm={confirmBackgroundExit}
         onCancel={cancelBackgroundExit}
       />

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -99,7 +99,6 @@ export function BillingOnboardingModal({
   const isResize = mode === "resize";
   const queryClient = useQueryClient();
   const [step, setStep] = useState<WizardStep>("provisioning");
-  const [finishedInBackground, setFinishedInBackground] = useState(false);
   const [takeoverExit, setTakeoverExit] = useState<TakeoverExit>("idle");
   const exitTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
   const [intent, setIntent] = useState<CheckoutIntent | null>(null);
@@ -130,7 +129,6 @@ export function BillingOnboardingModal({
     exitTimers.current.forEach(clearTimeout);
     exitTimers.current = [];
     setStep("provisioning");
-    setFinishedInBackground(false);
     setTakeoverExit("idle");
     setDisplayedPhase(null);
     setDomainsOpenedAt(null);
@@ -154,7 +152,6 @@ export function BillingOnboardingModal({
   // while that resize is in flight — including a stall, where the machine may
   // still be mid-restart.
   const machineBusy = isMachineBusy(provisioning.state);
-  const provisioningSettled = isSettled(provisioning.state);
 
   // The lock describes the screen the user is looking at, so it reads the
   // takeover's held phase rather than the live one. The domain step still keys
@@ -302,14 +299,6 @@ export function BillingOnboardingModal({
     onClose();
   }, [provisioning, onClose]);
 
-  // Stalled recovery re-calls the idempotent, org-wide ensure-provisioned
-  // reconcile — the same path the wizard fires on Pro confirmation. Its errors
-  // surface as-is; a server-side resize that is still running converges the
-  // actuals polling to DONE and replaces the stalled UI regardless.
-  const { stalledAction } = provisioning;
-  const stalledActionIfStalled =
-    provisioning.state === "STALLED" ? stalledAction : undefined;
-
   // The fetch-error variant of the provisioning step is a standard dismissible
   // card, not the locked full-bleed takeover — otherwise the light error UI is
   // marooned in the dark full-screen viewport and the user can't act on it.
@@ -443,19 +432,12 @@ export function BillingOnboardingModal({
       return (
         <DomainStep
           machineBusy={machineBusy}
-          stalledAction={stalledActionIfStalled}
           assistantId={assistantId}
           onExit={() => setStep("complete")}
         />
       );
     }
 
-    return (
-      <CompleteState
-        finishedInBackground={finishedInBackground && !provisioningSettled}
-        stalledAction={stalledActionIfStalled}
-        assistantId={assistantId}
-      />
-    );
+    return <CompleteState assistantId={assistantId} />;
   }
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -156,12 +156,11 @@ export function BillingOnboardingModal({
   const machineBusy = isMachineBusy(provisioning.state);
   const provisioningSettled = isSettled(provisioning.state);
 
-  // The lock and the close toast describe the screen the user is looking at, so
-  // they read the takeover's held phase rather than the live one. The steps
-  // after it keep tracking live provisioning: a resize backgrounded via the
-  // escape hatch has to unblock the domain step when it actually finishes.
+  // The lock describes the screen the user is looking at, so it reads the
+  // takeover's held phase rather than the live one. The domain step still keys
+  // its submit guard off live provisioning, so a resize that finishes after a
+  // genuine advance into that step unblocks it the moment it settles.
   const onScreenPhase = displayedPhase ?? provisioning.state;
-  const onScreenBusy = isMachineBusy(onScreenPhase);
   const onScreenSettled = isSettled(onScreenPhase);
 
   const { targets, assistantId, domainSetupAvailable, onboardingSettled } =
@@ -192,8 +191,8 @@ export function BillingOnboardingModal({
   // recently-cached list without a refetch. Force one refetch for this open the
   // moment the query is enabled, exactly as use-pro-provisioning invalidates the
   // subscription and onboarding queries on open; without it a fresh-enough cache
-  // never advances `domainsUpdatedAt` past the fence and routing can only fall
-  // through the escape hatch.
+  // never advances `domainsUpdatedAt` past the fence and routing strands,
+  // leaving the escape CTA (which closes the takeover) as the only way out.
   //
   // `assistantId` can CHANGE mid-open: `provisioning.assistantId` starts on the
   // active assistant and flips to the onboarding payload's primary once that
@@ -244,9 +243,10 @@ export function BillingOnboardingModal({
     !domainsFetching && (domainsFreshData || domainsFreshError);
   // Routing must never use a stale domain_setup_available: until the first
   // post-confirm fetch settles, TanStack may still serve pre-checkout cached
-  // data. Both the celebration dwell and the escape hatch wait on this.
-  // Latched: once fresh data has landed, a later background refetch must not
-  // yank the escape hatch or restart the dwell.
+  // data. The celebration dwell and the DONE advance wait on this; the escape
+  // CTA does not — it gates only on the machine being busy and the escape
+  // window having elapsed. Latched: once fresh data has landed, a later
+  // background refetch must not restart the dwell or flip the routing decision.
   const [routingSettled, setRoutingSettled] = useState(false);
   const routingInputsSettled =
     onboardingSettled && (!domainAnswerNeeded || domainsKnown);
@@ -288,10 +288,19 @@ export function BillingOnboardingModal({
     );
   }, [domainSetupAvailable, isResize, hasExistingDomain]);
 
+  // "Continue in the background" kicks the idempotent ensure-provisioned
+  // reconcile, shows an error-aware toast, and closes the takeover so the user
+  // is handed back to the app rather than parked on the email/All-set steps
+  // mid-provisioning.
   const escapeProvisioning = useCallback(() => {
-    setFinishedInBackground(true);
-    advanceFromProvisioning();
-  }, [advanceFromProvisioning]);
+    provisioning.kickProvisioning();
+    toast.info(
+      provisioning.kickError != null
+        ? "We'll retry your upgrade in the background."
+        : "Your upgrade continues in the background.",
+    );
+    onClose();
+  }, [provisioning, onClose]);
 
   // Stalled recovery re-calls the idempotent, org-wide ensure-provisioned
   // reconcile — the same path the wizard fires on Pro confirmation. Its errors
@@ -308,27 +317,18 @@ export function BillingOnboardingModal({
     step === "provisioning" &&
     (provisioning.confirmError || provisioning.targetsError);
 
-  const handleClose = () => {
-    if (step === "provisioning" && !provisioningError && onScreenBusy) {
-      toast.info("Your upgrade continues in the background.");
-    }
-    onClose();
-  };
-
   // The live provisioning takeover is the user's first real touchpoint with the
   // flow; we lock it so an accidental backdrop click or Esc can't bail them out
-  // mid-provisioning. Sanctioned exits (escape hatch, stalled apply, timeout
+  // mid-provisioning. Sanctioned exits (the escape hatch and the timeout
   // actions) live inside the step content.
   const isTakeover = step === "provisioning" && !provisioningError;
 
   // Lock Esc/backdrop while provisioning is active. The takeover exposes no
-  // persistent close control, so two escape valves guarantee a hung routing
-  // refetch can't strand the user: terminal ready states unlock, and a busy
-  // state stuck past the escape grace with routing still hung unlocks to a plain
-  // background-dismiss (the in-content escape hatch needs routing to have settled).
-  const stuckAwaitingRouting =
-    onScreenBusy && provisioning.escapeEligible && !routingSettled;
-  const lockTakeover = isTakeover && !onScreenSettled && !stuckAwaitingRouting;
+  // persistent close control, but the in-content "Continue in the background"
+  // button is independent of routing freshness — it needs only the machine busy
+  // and the escape window elapsed — so a hung routing refetch can't strand the
+  // user. Only a terminal ready state unlocks the backdrop itself.
+  const lockTakeover = isTakeover && !onScreenSettled;
 
   // Full-bleed dark content that fills the viewport for the takeover.
   const provisioningContentClass =
@@ -351,7 +351,9 @@ export function BillingOnboardingModal({
     <Modal.Root
       open={open}
       onOpenChange={(o) => {
-        if (!o) handleClose();
+        if (!o) {
+          onClose();
+        }
       }}
     >
       <Modal.Content
@@ -423,12 +425,10 @@ export function BillingOnboardingModal({
           celebrating={routingSettled}
           onCelebrationEnd={advanceFromProvisioning}
           assistantId={assistantId}
-          escapeAvailable={
-            machineBusy && routingSettled && provisioning.escapeEligible
-          }
+          escapeAvailable={machineBusy && provisioning.escapeEligible}
           onEscape={escapeProvisioning}
           onPhaseChange={setDisplayedPhase}
-          stalledAction={stalledAction}
+          kickError={provisioning.kickError}
           confirm={{
             onRetry: provisioning.retryConfirm,
             onGoToBilling: onClose,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.test.tsx
@@ -13,9 +13,6 @@ import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import { routes } from "@/utils/routes";
 
-const OFFLINE_NOTICE =
-  "Assistant will go offline briefly while it resizes. Chat might not work during that time.";
-
 let avatarComponents: unknown = { colors: [] };
 mock.module("@/utils/use-bundled-avatar-components", () => ({
   preloadBundledAvatarComponents: () => {},
@@ -115,44 +112,5 @@ describe("CompleteState return button", () => {
     expect(getByTestId("onboarding-complete-return").textContent).toBe(
       "Return to your assistant",
     );
-  });
-});
-
-describe("CompleteState offline notice", () => {
-  test("is absent when not finishing in the background", () => {
-    const { queryByText } = render(<CompleteState />);
-    expect(queryByText(OFFLINE_NOTICE)).toBeNull();
-  });
-
-  test("shows only while finishing in background and clears once done", () => {
-    const { queryByText, rerender } = render(
-      <CompleteState finishedInBackground />,
-    );
-    expect(queryByText(OFFLINE_NOTICE)).toBeTruthy();
-    // The still-mounted provisioning hook reaching DONE flips the prop off;
-    // mirror that transition and confirm the notice clears.
-    rerender(<CompleteState finishedInBackground={false} />);
-    expect(queryByText(OFFLINE_NOTICE)).toBeNull();
-  });
-
-  test("stalled recovery controls take precedence over the offline notice", () => {
-    const onApply = mock(() => {});
-    const { getByTestId, getByText, queryByText } = render(
-      <CompleteState
-        finishedInBackground
-        stalledAction={{ onApply, pending: false, error: null }}
-      />,
-    );
-
-    expect(
-      getByText(/We couldn't finish your machine upgrade automatically/),
-    ).toBeTruthy();
-    expect(queryByText(OFFLINE_NOTICE)).toBeNull();
-
-    fireEvent.click(getByTestId("complete-stalled-apply"));
-    expect(onApply).toHaveBeenCalledTimes(1);
-
-    // The Return button stays available across all completion variants.
-    expect(getByTestId("onboarding-complete-return")).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/complete-state.tsx
@@ -4,31 +4,13 @@ import { setSelectedAssistant } from "@/assistant/selection";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
-import { Notice } from "@vellumai/design-library/components/notice";
 
-import type { StalledApplyAction } from "./primitives";
-import {
-  CreatureCorners,
-  StalledApplyControls,
-  SUBTLE_NOTICE_CLASS,
-  SUBTLE_NOTICE_TEXT_CLASS,
-  WizardCardHeading,
-} from "./primitives";
+import { CreatureCorners, WizardCardHeading } from "./primitives";
 import { usePreferredOrActiveAssistant } from "./use-preferred-or-active-assistant";
 
-/** Shown while a backgrounded resize is still finishing; cleared once done. */
-const OFFLINE_WHILE_RESIZING =
-  "Assistant will go offline briefly while it resizes. Chat might not work during that time.";
-
 export function CompleteState({
-  finishedInBackground = false,
-  stalledAction,
   assistantId,
 }: {
-  /** The user backgrounded the machine resize; hidden once it completes. */
-  finishedInBackground?: boolean;
-  /** Set only while the backgrounded resize is stalled — offers manual apply. */
-  stalledAction?: StalledApplyAction;
   /** The provisioning target assistant (onboarding primary, else active). */
   assistantId?: string | null;
 }) {
@@ -37,8 +19,6 @@ export function CompleteState({
   const assistant = usePreferredOrActiveAssistant(assistantId, isOrgReady);
   const assistantName = assistant?.name || "your assistant";
 
-  // `justify-center` only bites when the notice is absent — with it the content
-  // exceeds the min-height and sits at the mock's top offset.
   return (
     <div className="relative flex min-h-[320px] flex-col items-center justify-center overflow-hidden px-8 pb-16 [animation:onboarding-step-in_350ms_ease-out] motion-reduce:[animation:none]">
       <CreatureCorners variant="full" />
@@ -67,22 +47,6 @@ export function CompleteState({
           >
             Return to {assistantName}
           </Button>
-
-          {stalledAction ? (
-            <StalledApplyControls
-              action={stalledAction}
-              buttonTestId="complete-stalled-apply"
-              className="w-full"
-            />
-          ) : (
-            finishedInBackground && (
-              <Notice tone="info" className={SUBTLE_NOTICE_CLASS}>
-                <span className={SUBTLE_NOTICE_TEXT_CLASS}>
-                  {OFFLINE_WHILE_RESIZING}
-                </span>
-              </Notice>
-            )
-          )}
         </div>
       </div>
     </div>

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.test.tsx
@@ -208,52 +208,13 @@ describe("DomainStep domain registration", () => {
   });
 });
 
-describe("DomainStep stalled resize", () => {
-  test("stalledAction swaps the busy notice for the warning and apply controls", async () => {
-    const onApply = mock(() => {});
+describe("DomainStep machine busy", () => {
+  test("machine-busy shows the neutral restarting notice and disables Next", async () => {
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
 
-    const { getByText, getByTestId, queryByText } = render(
-      <QueryClientProvider client={client}>
-        <DomainStep
-          onExit={() => {}}
-          machineBusy
-          stalledAction={{ onApply, pending: false, error: null }}
-        />
-      </QueryClientProvider>,
-    );
-
-    await waitFor(() =>
-      expect(getByTestId("domain-stalled-apply")).toBeTruthy(),
-    );
-    expect(
-      getByText(/We couldn't finish your machine upgrade automatically/),
-    ).toBeTruthy();
-    expect(
-      queryByText(
-        "Your assistant is restarting — you can set the domain in a moment.",
-      ),
-    ).toBeNull();
-
-    fireEvent.click(getByTestId("domain-stalled-apply"));
-    expect(onApply).toHaveBeenCalledTimes(1);
-
-    // The guardian-channel submit stays locked while the machine is busy.
-    await waitFor(() =>
-      expect(
-        (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,
-      ).toBe(true),
-    );
-  });
-
-  test("plain machine-busy keeps the neutral notice and disables Next", async () => {
-    const client = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-
-    const { getByText, getByTestId, queryByTestId } = render(
+    const { getByText, getByTestId } = render(
       <QueryClientProvider client={client}>
         <DomainStep onExit={() => {}} machineBusy />
       </QueryClientProvider>,
@@ -266,7 +227,6 @@ describe("DomainStep stalled resize", () => {
         ),
       ).toBeTruthy(),
     );
-    expect(queryByTestId("domain-stalled-apply")).toBeNull();
     // The restart guard keeps Next disabled while the machine is busy.
     expect(
       (getByTestId("onboarding-domain-set") as HTMLButtonElement).disabled,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -13,10 +13,8 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Notice } from "@vellumai/design-library/components/notice";
 
-import type { StalledApplyAction } from "./primitives";
 import {
     CreatureCorners,
-    StalledApplyControls,
     SUBTLE_NOTICE_CLASS,
     SUBTLE_NOTICE_TEXT_CLASS,
     WizardCardHeading,
@@ -31,14 +29,11 @@ const LABEL_CLASSES = "text-[11px] font-medium text-[var(--content-secondary)]";
 export function DomainStep({
   onExit,
   machineBusy = false,
-  stalledAction,
   assistantId: preferredAssistantId,
 }: {
   onExit: () => void;
   /** The assistant machine is restarting (webhook-driven resize in flight). */
   machineBusy?: boolean;
-  /** Set only while the resize is stalled — offers the manual apply here. */
-  stalledAction?: StalledApplyAction;
   /** The provisioning target assistant (onboarding primary, else active). */
   assistantId?: string | null;
 }) {
@@ -196,19 +191,10 @@ export function DomainStep({
           )}
         </div>
 
-        {stalledAction && !isLocked ? (
-          <StalledApplyControls
-            action={stalledAction}
-            buttonTestId="domain-stalled-apply"
-          />
-        ) : (
-          machineBusy &&
-          !isLocked && (
-            <Notice tone="neutral">
-              Your assistant is restarting — you can set the domain in a
-              moment.
-            </Notice>
-          )
+        {machineBusy && !isLocked && (
+          <Notice tone="neutral">
+            Your assistant is restarting — you can set the domain in a moment.
+          </Notice>
         )}
         {!isLocked && (
           <Notice tone="info" className={SUBTLE_NOTICE_CLASS}>

--- a/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/primitives.tsx
@@ -1,65 +1,8 @@
 import type { CSSProperties } from "react";
 import type { LucideIcon } from "lucide-react";
 
-import { Button } from "@vellumai/design-library/components/button";
-import { Notice } from "@vellumai/design-library/components/notice";
-
 import { AvatarRenderer } from "@/components/avatar-renderer";
-import { cn } from "@/utils/misc";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
-
-import { extractOnboardingErrorMessage } from "./utils";
-
-/** The manual Apply & Restart recovery threaded down from the modal. */
-export interface StalledApplyAction {
-  onApply: () => void;
-  pending: boolean;
-  error: unknown;
-}
-
-/** Warning shown when a backgrounded resize stalls mid-wizard. */
-const STALLED_UPGRADE_WARNING =
-  "We couldn't finish your machine upgrade automatically. Apply it now to finish — your assistant will briefly restart.";
-
-/**
- * Warning notice + Apply & Restart button for recovering a stalled resize.
- * Shared by the complete screen and the domain step so the recovery affordance
- * can't drift between them. (The dark provisioning takeover renders its own
- * inline button by design.)
- */
-export function StalledApplyControls({
-  action,
-  buttonTestId,
-  className,
-}: {
-  action: StalledApplyAction;
-  buttonTestId: string;
-  className?: string;
-}) {
-  return (
-    <div className={cn("flex flex-col items-center gap-2", className)}>
-      <Notice tone="warning" className="w-full text-left">
-        {STALLED_UPGRADE_WARNING}
-      </Notice>
-      {action.error != null && (
-        <Notice tone="error" className="w-full text-left">
-          {extractOnboardingErrorMessage(
-            action.error,
-            "Couldn't apply changes. Please try again.",
-          )}
-        </Notice>
-      )}
-      <Button
-        variant="outlined"
-        data-testid={buttonTestId}
-        disabled={action.pending}
-        onClick={action.onApply}
-      >
-        Apply &amp; Restart
-      </Button>
-    </div>
-  );
-}
 
 export function IconBadge({ icon: Icon }: { icon: LucideIcon }) {
   return (

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -83,7 +83,6 @@ function baseProps(
     onCelebrationEnd: () => {},
     escapeAvailable: false,
     onEscape: () => {},
-    stalledAction: { onApply: () => {}, pending: false, error: null },
     confirm: { onRetry: () => {}, onGoToBilling: () => {} },
     ...overrides,
   };
@@ -421,40 +420,62 @@ describe("done / not_applicable", () => {
 });
 
 describe("stalled", () => {
-  test("renders the stalled status, keeps the chips, and Apply & Restart invokes the callback", () => {
-    const onApply = mock(() => {});
-    const { getByText, getByTestId } = renderState({
+  test("with no captured error shows the honest taking-longer copy, chips, and the background button — never an Apply", () => {
+    const onEscape = mock(() => {});
+    const { getByText, queryByTestId, getByTestId } = renderState({
       state: "STALLED",
       targets: { machineSize: "large", storageGib: null },
       fromSnapshot: { machineSize: "small", storageGib: null },
-      stalledAction: { onApply, pending: false, error: null },
+      escapeAvailable: true,
+      onEscape,
     });
 
-    expect(getByText("We couldn't finish this automatically")).toBeTruthy();
-    expect(
-      getByText("Apply the changes below to finish setting up your upgrade."),
-    ).toBeTruthy();
+    expect(getByText("This is taking longer than expected")).toBeTruthy();
+    expect(getByText("This may take a couple of minutes.")).toBeTruthy();
     expect(getByText("Machine")).toBeTruthy();
-    fireEvent.click(getByTestId("provisioning-apply"));
-    expect(onApply).toHaveBeenCalledTimes(1);
+    // Apply & Restart is gone from the takeover entirely.
+    expect(queryByTestId("provisioning-apply")).toBeNull();
+    expect(getByText("Continue in the background")).toBeTruthy();
+    fireEvent.click(getByTestId("provisioning-escape"));
+    expect(onEscape).toHaveBeenCalledTimes(1);
   });
 
-  test("disables the Apply button while pending and renders the extracted error as the caption", () => {
-    const onApply = mock(() => {});
-    const { getByText, getByTestId } = renderState({
+  test("with a captured reconcile error shows the snag copy, the mapped error, and a Retry-in-background button", () => {
+    const { getByText, queryByTestId } = renderState({
       state: "STALLED",
-      stalledAction: {
-        onApply,
-        pending: true,
-        error: { detail: "Resize already in progress." },
-      },
+      escapeAvailable: true,
+      kickError: { detail: "Resize already in progress." },
     });
 
+    expect(getByText("We hit a snag upgrading your assistant")).toBeTruthy();
     expect(getByText("Resize already in progress.")).toBeTruthy();
-    const apply = getByTestId("provisioning-apply") as HTMLButtonElement;
-    expect(apply.disabled).toBe(true);
-    fireEvent.click(apply);
-    expect(onApply).not.toHaveBeenCalled();
+    expect(queryByTestId("provisioning-apply")).toBeNull();
+    expect(getByText("Retry in the background")).toBeTruthy();
+  });
+
+  test("the background button relabels to Retry once a reconcile has errored", () => {
+    const { getByText, queryByText, rerender } = renderState({
+      state: "STALLED",
+      escapeAvailable: true,
+    });
+
+    expect(getByText("Continue in the background")).toBeTruthy();
+    expect(queryByText("Retry in the background")).toBeNull();
+
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <ProvisioningState
+          {...baseProps({
+            state: "STALLED",
+            escapeAvailable: true,
+            kickError: { error: "provisioning_submission_failed" },
+          })}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(getByText("Retry in the background")).toBeTruthy();
+    expect(queryByText("Continue in the background")).toBeNull();
   });
 
   test("an unchanged machine dimension renders singular while storage still arrows", () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -456,6 +456,38 @@ describe("stalled", () => {
     fireEvent.click(apply);
     expect(onApply).not.toHaveBeenCalled();
   });
+
+  test("an unchanged machine dimension renders singular while storage still arrows", () => {
+    const { getByText, getAllByText, container } = renderState({
+      state: "STALLED",
+      targets: { machineSize: "medium", storageGib: 100 },
+      fromSnapshot: { machineSize: "medium", storageGib: 30 },
+    });
+
+    // Machine is unchanged: the label appears once (target only), never as a
+    // "Medium → Medium" self-arrow.
+    expect(getByText("Machine")).toBeTruthy();
+    expect(getAllByText("Medium").length).toBe(1);
+    // Storage changed: both endpoints render, with a single from→to arrow.
+    expect(getByText("30 GB")).toBeTruthy();
+    expect(getByText("100 GB")).toBeTruthy();
+    expect(container.querySelectorAll(".lucide-arrow-right").length).toBe(1);
+  });
+
+  test("both dimensions unchanged render singular with no arrows", () => {
+    const { getByText, container } = renderState({
+      state: "STALLED",
+      targets: { machineSize: "medium", storageGib: 30 },
+      fromSnapshot: { machineSize: "medium", storageGib: 30 },
+    });
+
+    expect(getByText("Machine")).toBeTruthy();
+    expect(getByText("Medium")).toBeTruthy();
+    expect(getByText("Storage")).toBeTruthy();
+    expect(getByText("30 GB")).toBeTruthy();
+    // Nothing changed, so neither chip draws a current→new arrow.
+    expect(container.querySelector(".lucide-arrow-right")).toBeNull();
+  });
 });
 
 describe("confirm_timeout", () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -433,7 +433,7 @@ describe("stalled", () => {
     expect(getByText("This is taking longer than expected")).toBeTruthy();
     expect(getByText("This may take a couple of minutes.")).toBeTruthy();
     expect(getByText("Machine")).toBeTruthy();
-    // Apply & Restart is gone from the takeover entirely.
+    // The takeover renders no Apply & Restart control in any phase.
     expect(queryByTestId("provisioning-apply")).toBeNull();
     expect(getByText("Continue in the background")).toBeTruthy();
     fireEvent.click(getByTestId("provisioning-escape"));

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -22,7 +22,7 @@ import type {
   ProvisioningDimensions,
   ProvisioningStateKind,
 } from "./provisioning-machine";
-import { SERIF_HEADING_STYLE, type StalledApplyAction } from "./primitives";
+import { SERIF_HEADING_STYLE } from "./primitives";
 import {
   buildResourceChanges,
   type ResourceChangeKey,
@@ -130,7 +130,11 @@ export interface ProvisioningStateProps {
   onEscape: () => void;
   /** Reports the phase actually on screen, which lags `state` by the hold. */
   onPhaseChange?: (phase: ProvisioningStateKind) => void;
-  stalledAction: StalledApplyAction;
+  /**
+   * ensure-provisioned failure held by the hook; with STALLED it selects the
+   * snag variant.
+   */
+  kickError?: unknown;
   confirm: { onRetry: () => void; onGoToBilling: () => void };
   /** Test hook — overrides the per-phase minimum; 0 disables the hold. */
   phaseMinMs?: number;
@@ -502,7 +506,7 @@ export function ProvisioningState({
   escapeAvailable,
   onEscape,
   onPhaseChange,
-  stalledAction,
+  kickError,
   confirm,
   dwellMs = PROVISION_MIN_DWELL_MS,
   phaseMinMs = PROVISION_PHASE_MIN_MS,
@@ -581,7 +585,7 @@ export function ProvisioningState({
     </div>
   );
 
-  function escapeButton() {
+  function escapeButton(label = "Continue in the background") {
     if (!escapeAvailable) {
       return null;
     }
@@ -591,7 +595,7 @@ export function ProvisioningState({
         data-testid="provisioning-escape"
         onClick={onEscape}
       >
-        Continue in the background
+        {label}
       </Button>
     );
   }
@@ -676,25 +680,33 @@ export function ProvisioningState({
     }
 
     if (heldState === "STALLED") {
+      // With no captured reconcile error the wait is just slow — say so
+      // honestly. Only an actual failure escalates to the "snag" variant with
+      // the mapped error and a retry-flavoured escape label.
+      const snag = kickError != null;
       return (
         <>
           <Copy
-            status="We couldn't finish this automatically"
-            caption={extractOnboardingErrorMessage(
-              stalledAction.error,
-              "Apply the changes below to finish setting up your upgrade.",
-            )}
+            status={
+              snag
+                ? "We hit a snag upgrading your assistant"
+                : "This is taking longer than expected"
+            }
+            caption={
+              snag
+                ? extractOnboardingErrorMessage(
+                    kickError,
+                    "Retry in the background — we'll keep working on your upgrade.",
+                  )
+                : "This may take a couple of minutes."
+            }
           />
-          <TargetChips targets={targets} fromSnapshot={fromSnapshot} />
-          <Button
-            variant="primary"
-            data-testid="provisioning-apply"
-            disabled={stalledAction.pending}
-            onClick={stalledAction.onApply}
-          >
-            Apply &amp; Restart
-          </Button>
-          {escapeButton()}
+          <ResourceChangeChips
+            intent={intent}
+            targets={targets}
+            fromSnapshot={fromSnapshot}
+          />
+          {snag ? escapeButton("Retry in the background") : escapeButton()}
         </>
       );
     }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -12,7 +12,7 @@ import {
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import type { CreditTierEnum } from "@/generated/api/types.gen";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
-import { MACHINE_TIER_LABEL, SIZE_LABEL } from "@/lib/billing/machine-sizes";
+import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
 import { SURFACE_GROUND } from "@/utils/avatar-tone";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 import { Button } from "@vellumai/design-library/components/button";
@@ -456,7 +456,13 @@ function IntentChips({ intent }: { intent: CheckoutIntent }) {
   );
 }
 
-/** Machine/Storage from→to chips, driven by the resolved provisioning targets. */
+/**
+ * Machine/Storage from→to chips, derived from the shared `buildResourceChanges`
+ * derivation (credits omitted) so the STALLED/DONE path can't drift from the
+ * WAITING `ResourceChangeChips`. An unchanged dimension renders as a singular
+ * value with no arrow (the helper omits its `from`); `done` strips the from-side
+ * entirely, so the terminal phase shows just the achieved target with a check.
+ */
 function TargetChips({
   targets,
   fromSnapshot,
@@ -466,34 +472,19 @@ function TargetChips({
   fromSnapshot: ProvisioningDimensions;
   done?: boolean;
 }) {
+  const changes = buildResourceChanges({ targets, fromSnapshot, credits: null });
   return (
     <ChipRow>
-      {targets.machineSize != null && (
+      {changes.map((change) => (
         <DimensionChip
-          icon={Cpu}
-          label="Machine"
-          from={
-            !done && fromSnapshot.machineSize != null
-              ? SIZE_LABEL[fromSnapshot.machineSize]
-              : undefined
-          }
-          to={SIZE_LABEL[targets.machineSize]}
+          key={change.key}
+          icon={RESOURCE_CHIP_ICON[change.key]}
+          label={change.label}
+          from={done ? undefined : change.from}
+          to={change.to}
           done={done}
         />
-      )}
-      {targets.storageGib != null && (
-        <DimensionChip
-          icon={HardDrive}
-          label="Storage"
-          from={
-            !done && fromSnapshot.storageGib != null
-              ? `${fromSnapshot.storageGib} GB`
-              : undefined
-          }
-          to={`${targets.storageGib} GB`}
-          done={done}
-        />
-      )}
+      ))}
     </ChipRow>
   );
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -66,8 +66,8 @@ const AVATAR_GROWTH = 1.414;
 
 // The stage reserves the grown height from first paint, so the takeover needs
 // `size * AVATAR_GROWTH + 309` of viewport before the phase block underneath —
-// which carries the escape hatch and the stalled retry — starts to clip. Step
-// the creature down instead of pushing those actions off a short screen.
+// which carries the escape hatch — starts to clip. Step the creature down
+// instead of pushing that control off a short screen.
 const AVATAR_SIZE_STEPS: Array<{ minHeight: number; size: number }> = [
   { minHeight: 680, size: AVATAR_SIZE },
   { minHeight: 600, size: 184 },

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -655,6 +655,52 @@ describe("useProProvisioning", () => {
     20_000,
   );
 
+  test(
+    "kickProvisioning fires the reconcile, never flips pending, and a success clears kickError",
+    async () => {
+      const { client } = renderProbe();
+      await reachResizing(client);
+      const autoCalls = ensureCalls;
+
+      dateNowOffsetMs = 200_000;
+      await waitFor(() => expect(latest!.state).toBe("STALLED"), {
+        timeout: 5000,
+      });
+
+      // A fire-and-forget escape kick that fails captures kickError without
+      // ever flipping the manual-pending flag — a hung escape-fired call must
+      // never strand later UI.
+      ensureError = { error: "provisioning_submission_failed" };
+      act(() => latest!.kickProvisioning());
+      await waitFor(() => expect(ensureCalls).toBe(autoCalls + 1));
+      await waitFor(() =>
+        expect(latest!.kickError).toEqual({
+          error: "provisioning_submission_failed",
+        }),
+      );
+      expect(latest!.stalledAction.pending).toBe(false);
+      // kickError and stalledAction.error are the same value.
+      expect(latest!.stalledAction.error).toEqual({
+        error: "provisioning_submission_failed",
+      });
+      // The failure is not terminal: still STALLED, still polling.
+      expect(latest!.state).toBe("STALLED");
+
+      // A subsequent successful escape kick clears kickError and re-bases the
+      // stall clock — the `started` verdict lifts the wizard back to RESIZING.
+      ensureError = null;
+      ensureResponse = makeEnsureResponse("started");
+      act(() => latest!.kickProvisioning());
+      await waitFor(() => expect(ensureCalls).toBe(autoCalls + 2));
+      await waitFor(() => expect(latest!.kickError).toBeNull());
+      await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
+        timeout: 5000,
+      });
+      expect(latest!.stalledAction.pending).toBe(false);
+    },
+    20_000,
+  );
+
   test("org-scoped queries hold until the org id is available", async () => {
     isOrgReadyMock = false;
     const { rerender } = renderProbe();
@@ -1182,7 +1228,32 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
   );
 
   test(
-    "a 503 leaves the wizard inferring rather than erroring",
+    "a dead-end no_active_pro on the automatic path sets kickError",
+    async () => {
+      // The auto reconcile hits no_active_pro and schedules its one race
+      // retry; the retry (also auto) hits the same dead end. With the
+      // once-per-open re-ask spent, the repeat dead end now surfaces kickError
+      // regardless of source.
+      ensureResponse = makeEnsureResponse("not_applicable", "no_active_pro");
+      subscriptionPlanId = "pro";
+      renderProbe();
+
+      // Two automatic calls: the initial one and its single race retry.
+      await waitFor(() => expect(ensureCalls).toBe(2), { timeout: 5000 });
+      await waitFor(
+        () =>
+          expect(latest!.kickError).toEqual({ error: "no_active_pro" }),
+        { timeout: 5000 },
+      );
+      // The verdict is still never adopted — inference keeps the flow WAITING.
+      expect(latest!.state).toBe("WAITING");
+      expect(latest!.stalledAction.pending).toBe(false);
+    },
+    20_000,
+  );
+
+  test(
+    "a 503 on the automatic call never blocks the flow but is captured in kickError",
     async () => {
       ensureError = { error: "provisioning_submission_failed" };
       subscriptionPlanId = "pro";
@@ -1192,9 +1263,18 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
       await waitFor(() => expect(latest!.state).toBe("WAITING"), {
         timeout: 5000,
       });
-      // The automatic call failing is silent: no error surface, no new
-      // blocking state, no auto-retry storm.
-      expect(latest!.stalledAction.error).toBeNull();
+      // The automatic call failing no longer blocks: no new blocking state,
+      // no auto-retry storm. But it is no longer *silent* — the failure is
+      // captured in kickError (and its stalledAction.error alias) so the
+      // takeover can surface the snag variant.
+      await waitFor(() =>
+        expect(latest!.kickError).toEqual({
+          error: "provisioning_submission_failed",
+        }),
+      );
+      expect(latest!.stalledAction.error).toEqual({
+        error: "provisioning_submission_failed",
+      });
       expect(latest!.confirmError).toBe(false);
       expect(latest!.targetsError).toBe(false);
       await new Promise((resolve) => setTimeout(resolve, 500));
@@ -1263,7 +1343,8 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
         timeout: 5000,
       });
 
-      // A user-initiated reconcile — the only source that surfaces an error.
+      // Any reconcile now captures its error; this one is fired while open but
+      // only rejects after close, so generation-gating must still discard it.
       act(() => latest!.stalledAction.onApply());
       await waitFor(() => expect(ensureCalls).toBe(2), { timeout: 5000 });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.test.tsx
@@ -465,12 +465,12 @@ describe("useProProvisioning", () => {
   );
 
   test(
-    "a dead-end no_active_pro apply stays STALLED and surfaces why",
+    "a dead-end no_active_pro kick stays STALLED and surfaces why",
     async () => {
-      // The auto reconcile consumes the once-per-open re-ask, so a later manual
-      // apply that still gets no_active_pro can queue nothing and re-ask
-      // nothing. Resuming the watch there would hide the recovery button for
-      // another stall window with no resize running.
+      // The auto reconcile consumes the once-per-open re-ask, so a later kick
+      // that still gets no_active_pro can queue nothing and re-ask nothing.
+      // Resuming the watch there would drop the user out of STALLED for another
+      // stall window with no resize running.
       ensureResponse = makeEnsureResponse("not_applicable", "no_active_pro");
       const { client } = renderProbe();
       await reachResizing(client);
@@ -481,51 +481,24 @@ describe("useProProvisioning", () => {
       });
 
       const callsBefore = ensureCalls;
-      act(() => latest!.stalledAction.onApply());
+      act(() => latest!.kickProvisioning());
       await waitFor(() => expect(ensureCalls).toBeGreaterThan(callsBefore));
 
       await waitFor(
         () =>
-          expect(latest!.stalledAction.error).toEqual({
+          expect(latest!.kickError).toEqual({
             error: "no_active_pro",
           }),
         { timeout: 5000 },
       );
-      // Still STALLED, so Apply & Restart remains on screen.
+      // Still STALLED, so the flow keeps polling for a self-recovery.
       expect(latest!.state).toBe("STALLED");
     },
     20_000,
   );
 
   test(
-    "a hung automatic reconcile leaves Apply & Restart enabled",
-    async () => {
-      // `ensureResponse` defaults to held-in-flight, so the automatic reconcile
-      // fired on Pro confirm never settles — exactly the case that strands the
-      // user in STALLED. Its pending state must not disable their only recovery
-      // control; `pending` tracks user-initiated applies only.
-      const { client } = renderProbe();
-      await reachResizing(client);
-      expect(ensureCalls).toBeGreaterThan(0);
-
-      dateNowOffsetMs = 200_000;
-      await waitFor(() => expect(latest!.state).toBe("STALLED"), {
-        timeout: 5000,
-      });
-
-      expect(latest!.stalledAction.pending).toBe(false);
-
-      // And a manual apply does report pending while it is in flight.
-      act(() => latest!.stalledAction.onApply());
-      await waitFor(() => expect(latest!.stalledAction.pending).toBe(true), {
-        timeout: 5000,
-      });
-    },
-    20_000,
-  );
-
-  test(
-    "the stalled action re-calls ensure-provisioned, leaves STALLED and can reach DONE",
+    "the escape kick re-calls ensure-provisioned, leaves STALLED and can reach DONE",
     async () => {
       const { client } = renderProbe();
       await reachResizing(client);
@@ -541,12 +514,12 @@ describe("useProProvisioning", () => {
       // The reconcile answers "started": the verdict alone lifts the wizard
       // back to RESIZING and the success re-bases the stall clock.
       ensureResponse = makeEnsureResponse("started");
-      act(() => latest!.stalledAction.onApply());
+      act(() => latest!.kickProvisioning());
       await waitFor(() => expect(ensureCalls).toBe(autoCalls + 1));
       await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
         timeout: 5000,
       });
-      expect(latest!.stalledAction.error).toBeNull();
+      expect(latest!.kickError).toBeNull();
 
       // The landing resize also retires the operation marker: the platform
       // reports `resizing_machine` until the rollout converges, so met actuals
@@ -562,7 +535,7 @@ describe("useProProvisioning", () => {
   );
 
   test(
-    "a failed stalled retry surfaces its error without leaving STALLED wedged",
+    "a failed escape kick surfaces its error without leaving STALLED wedged",
     async () => {
       const { client } = renderProbe();
       await reachResizing(client);
@@ -573,9 +546,9 @@ describe("useProProvisioning", () => {
       });
 
       ensureError = { error: "provisioning_submission_failed" };
-      act(() => latest!.stalledAction.onApply());
+      act(() => latest!.kickProvisioning());
       await waitFor(() =>
-        expect(latest!.stalledAction.error).toEqual({
+        expect(latest!.kickError).toEqual({
           error: "provisioning_submission_failed",
         }),
       );
@@ -624,7 +597,7 @@ describe("useProProvisioning", () => {
   );
 
   test(
-    "escapeEligible flips after the escape window and re-bases on manual-apply resume",
+    "escapeEligible flips after the escape window and re-bases on an escape-kick resume",
     async () => {
       const { client } = renderProbe();
       await reachResizing(client);
@@ -643,10 +616,10 @@ describe("useProProvisioning", () => {
       });
       expect(latest!.escapeEligible).toBe(true);
 
-      // A successful stalled retry re-bases the watch clock, so eligibility
+      // A successful escape kick re-bases the watch clock, so eligibility
       // starts over.
       ensureResponse = makeEnsureResponse("started");
-      act(() => latest!.stalledAction.onApply());
+      act(() => latest!.kickProvisioning());
       await waitFor(() => expect(latest!.escapeEligible).toBe(false), {
         timeout: 5000,
       });
@@ -656,7 +629,7 @@ describe("useProProvisioning", () => {
   );
 
   test(
-    "kickProvisioning fires the reconcile, never flips pending, and a success clears kickError",
+    "kickProvisioning fires the reconcile, captures kickError, and a success clears it",
     async () => {
       const { client } = renderProbe();
       await reachResizing(client);
@@ -667,9 +640,8 @@ describe("useProProvisioning", () => {
         timeout: 5000,
       });
 
-      // A fire-and-forget escape kick that fails captures kickError without
-      // ever flipping the manual-pending flag — a hung escape-fired call must
-      // never strand later UI.
+      // A fire-and-forget escape kick that fails captures kickError — a hung
+      // escape-fired call must never strand later UI.
       ensureError = { error: "provisioning_submission_failed" };
       act(() => latest!.kickProvisioning());
       await waitFor(() => expect(ensureCalls).toBe(autoCalls + 1));
@@ -678,11 +650,6 @@ describe("useProProvisioning", () => {
           error: "provisioning_submission_failed",
         }),
       );
-      expect(latest!.stalledAction.pending).toBe(false);
-      // kickError and stalledAction.error are the same value.
-      expect(latest!.stalledAction.error).toEqual({
-        error: "provisioning_submission_failed",
-      });
       // The failure is not terminal: still STALLED, still polling.
       expect(latest!.state).toBe("STALLED");
 
@@ -696,7 +663,6 @@ describe("useProProvisioning", () => {
       await waitFor(() => expect(latest!.state).toBe("RESIZING"), {
         timeout: 5000,
       });
-      expect(latest!.stalledAction.pending).toBe(false);
     },
     20_000,
   );
@@ -1247,7 +1213,6 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
       );
       // The verdict is still never adopted — inference keeps the flow WAITING.
       expect(latest!.state).toBe("WAITING");
-      expect(latest!.stalledAction.pending).toBe(false);
     },
     20_000,
   );
@@ -1263,18 +1228,14 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
       await waitFor(() => expect(latest!.state).toBe("WAITING"), {
         timeout: 5000,
       });
-      // The automatic call failing no longer blocks: no new blocking state,
-      // no auto-retry storm. But it is no longer *silent* — the failure is
-      // captured in kickError (and its stalledAction.error alias) so the
-      // takeover can surface the snag variant.
+      // The automatic call failing does not block: no new blocking state, no
+      // auto-retry storm. It is not silent either — the failure is captured in
+      // kickError so the takeover can surface the snag variant.
       await waitFor(() =>
         expect(latest!.kickError).toEqual({
           error: "provisioning_submission_failed",
         }),
       );
-      expect(latest!.stalledAction.error).toEqual({
-        error: "provisioning_submission_failed",
-      });
       expect(latest!.confirmError).toBe(false);
       expect(latest!.targetsError).toBe(false);
       await new Promise((resolve) => setTimeout(resolve, 500));
@@ -1343,9 +1304,9 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
         timeout: 5000,
       });
 
-      // Any reconcile now captures its error; this one is fired while open but
-      // only rejects after close, so generation-gating must still discard it.
-      act(() => latest!.stalledAction.onApply());
+      // A reconcile captures its error; this one is fired while open but only
+      // rejects after close, so generation-gating must still discard it.
+      act(() => latest!.kickProvisioning());
       await waitFor(() => expect(ensureCalls).toBe(2), { timeout: 5000 });
 
       act(() => setOpen(false));
@@ -1359,7 +1320,7 @@ describe("useProProvisioning — ensure-provisioned reconcile", () => {
       await waitFor(() => expect(latest!.state).toBe("WAITING"), {
         timeout: 5000,
       });
-      expect(latest!.stalledAction.error).toBeNull();
+      expect(latest!.kickError).toBeNull();
     },
     20_000,
   );

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -13,15 +13,16 @@
  * subscription error maps to `confirmError`, and a post-confirm onboarding
  * fetch failure with no cached data maps to `targetsError`.
  *
- * On top of the observation it also *acts* once: the moment the subscription
- * first reports Pro it calls the idempotent ensure-provisioned reconcile
- * endpoint, so a webhook that never fired (or whose resize was lost) still
- * gets provisioned. The returned verdict feeds the state machine's
- * `serverVerdict` slot; the endpoint failing never blocks the flow — the
- * polling above converges on its own. But a reconcile failure from *any*
- * source (auto, manual, or the fire-and-forget escape kick) is now held in
- * `ensureError` so the takeover can honestly surface the ≥90s snag variant;
- * any later success clears it.
+ * On top of the observation it also *acts*: the moment the subscription first
+ * reports Pro it fires the idempotent ensure-provisioned reconcile endpoint
+ * automatically, and `kickProvisioning` fires the same reconcile on demand, so
+ * a webhook that never fired (or whose resize was lost) still gets
+ * provisioned. The returned verdict feeds the state machine's `serverVerdict`
+ * slot; the endpoint failing never blocks the flow — the polling above
+ * converges on its own. A reconcile failure from any source is held in
+ * `ensureError` (exposed as `kickError`) so the takeover can honestly surface
+ * the ≥90s snag variant; any later success clears it. The reconcile carries no
+ * pending flag.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -90,17 +91,6 @@ export interface UseProProvisioningOptions {
   open: boolean;
 }
 
-/**
- * Stalled-state recovery affordance. `error` mirrors `ensureError`: a reconcile
- * failure from any source (auto, manual, or the fire-and-forget escape kick),
- * cleared by a later success.
- */
-export interface ProvisioningRetryAction {
-  onApply: () => void;
-  pending: boolean;
-  error: unknown;
-}
-
 export interface ProProvisioningResult {
   state: ProvisioningStateKind;
   softWaiting: boolean;
@@ -128,27 +118,22 @@ export interface ProProvisioningResult {
   /**
    * The watch has run long enough (without resolving) that the "continue in
    * the background" escape hatch may be offered. Re-bases with the stall clock
-   * after a manual-apply resume.
+   * after a successful `kickProvisioning` resume.
    */
   escapeEligible: boolean;
   /** Reset the confirm timeout and re-poll the subscription. */
   retryConfirm: () => void;
   /**
-   * STALLED-state recovery: re-calls the idempotent ensure-provisioned
+   * Fire-and-forget "escape" kick: fires the idempotent ensure-provisioned
    * reconcile (grow-only, in-flight-guarded, so a repeat never double-fires a
    * resize) and re-bases the stall clock on success so observation resumes.
-   */
-  stalledAction: ProvisioningRetryAction;
-  /**
-   * Fire-and-forget "escape" kick: fires the idempotent ensure-provisioned
-   * reconcile without touching the manual-pending flag, so a hung call can
-   * never strand later UI. Used when closing the takeover into the background.
+   * Carries no pending flag, so a hung call can never strand later UI. Used
+   * when closing the takeover into the background.
    */
   kickProvisioning: () => void;
   /**
    * Latest ensure-provisioned failure from any source; cleared by a later
-   * success. Drives the ≥90s snag variant on the takeover. (Alias of
-   * `stalledAction.error`.)
+   * success. Drives the ≥90s snag variant on the takeover.
    */
   kickError: unknown;
 }
@@ -169,7 +154,7 @@ export function useProProvisioning({
   // after this instant may confirm pro.
   const [openedAt, setOpenedAt] = useState<number | null>(null);
   const [proConfirmedAt, setProConfirmedAt] = useState<number | null>(null);
-  // Stall-clock re-base set by a successful manual reconcile; proConfirmedAt
+  // Stall-clock re-base set by a successful kick reconcile; proConfirmedAt
   // otherwise.
   const [resumedAt, setResumedAt] = useState<number | null>(null);
   // Latest adopted ensure-provisioned verdict; null while the endpoint hasn't
@@ -194,16 +179,9 @@ export function useProProvisioning({
   const [targetsMetAssistantId, setTargetsMetAssistantId] = useState<
     string | null
   >(null);
-  // Latest reconcile failure from any source (auto/manual/escape); cleared by a
-  // later success — see runEnsureProvisioned.
+  // Latest reconcile failure from any source (auto/escape); cleared by a later
+  // success — see runEnsureProvisioned.
   const [ensureError, setEnsureError] = useState<unknown>(null);
-  // Pending state for the *manual* reconcile only. The mutation's own
-  // `isPending` is shared with the automatic call fired on Pro confirm, and a
-  // hung automatic call is precisely the case that strands the user in
-  // STALLED — gating Apply & Restart on it would disable their only recovery
-  // path. The endpoint is idempotent and in-flight guarded, so letting a manual
-  // apply overlap a slow automatic one is safe.
-  const [manualPending, setManualPending] = useState(false);
   const [raceRetryScheduled, setRaceRetryScheduled] = useState(false);
   // Fire-once-per-open guard for the automatic reconcile. A ref (not state) so
   // it can't be lost to a re-render between the check and the call, and it
@@ -246,7 +224,6 @@ export function useProProvisioning({
     setTargetsMetAt(null);
     setTargetsMetAssistantId(null);
     setEnsureError(null);
-    setManualPending(false);
     setRaceRetryScheduled(false);
     ensureRequestedRef.current = false;
     ensureRaceRetriedRef.current = false;
@@ -326,11 +303,7 @@ export function useProProvisioning({
   const { mutate: ensureProvisioned } = ensureProvisionedMutation;
 
   const runEnsureProvisioned = useCallback(
-    (source: "auto" | "manual" | "escape") => {
-      if (source === "manual") {
-        setEnsureError(null);
-        setManualPending(true);
-      }
+    (source: "auto" | "escape") => {
       // The open this call belongs to. Both callbacks drop out when the wizard
       // has since closed, so a late response can't drive a later session.
       const generation = ensureGenerationRef.current;
@@ -355,21 +328,21 @@ export function useProProvisioning({
                 ensureRaceRetriedRef.current = true;
                 setRaceRetryScheduled(true);
                 // A re-ask is already queued, so observation may resume.
-                if (source !== "auto") {
+                if (source === "escape") {
                   resumeWatch();
                 }
               } else {
                 // Dead end: the verdict is deliberately not adopted, nothing
                 // was queued, and the once-per-open re-ask is spent. Re-basing
-                // the stall clock here would drop the user out of STALLED —
-                // hiding Apply & Restart for another stall window — with no
-                // resize running and nothing said. Hold the state and explain,
-                // regardless of source, so a repeat dead end surfaces why.
+                // the stall clock here would drop the user out of STALLED with
+                // no resize running and nothing said. Hold the state and
+                // explain, regardless of source, so a repeat dead end surfaces
+                // why.
                 setEnsureError({ error: "no_active_pro" });
               }
             } else {
               setServerVerdict(data.state);
-              if (source !== "auto") {
+              if (source === "escape") {
                 resumeWatch();
               }
             }
@@ -380,19 +353,10 @@ export function useProProvisioning({
             }
             // 503 (submission couldn't be queued) or a network blip: nothing
             // was queued and nothing is broken — the actuals polling still
-            // converges, so the flow never blocks on this. The automatic call
-            // no longer degrades *silently*, though: its error is held for the
-            // ≥90s snag variant on the takeover and cleared by any later
-            // success, so a failure from any source is captured alike.
+            // converges, so the flow never blocks on this. The error is held
+            // for the ≥90s snag variant on the takeover and cleared by any
+            // later success, so a failure from any source is captured alike.
             setEnsureError(error);
-          },
-          // Unconditional (not generation-gated): the button's pending state
-          // must clear even for a response that belongs to a closed wizard,
-          // otherwise a reopen inherits a stuck-disabled Apply & Restart.
-          onSettled: () => {
-            if (source === "manual") {
-              setManualPending(false);
-            }
           },
         },
       );
@@ -431,17 +395,8 @@ export function useProProvisioning({
     return () => clearTimeout(t);
   }, [raceRetryScheduled, runEnsureProvisioned]);
 
-  const stalledAction = useMemo<ProvisioningRetryAction>(
-    () => ({
-      onApply: () => runEnsureProvisioned("manual"),
-      pending: manualPending,
-      error: ensureError,
-    }),
-    [runEnsureProvisioned, manualPending, ensureError],
-  );
-
-  // Fire-and-forget escape kick: fires the reconcile but never flips
-  // manualPending, so a hung escape-fired call can't strand later UI.
+  // Fire-and-forget escape kick: fires the reconcile with no pending flag, so a
+  // hung escape-fired call can't strand later UI.
   const kickProvisioning = useCallback(
     () => runEnsureProvisioned("escape"),
     [runEnsureProvisioned],
@@ -647,7 +602,6 @@ export function useProProvisioning({
     escapeEligible:
       msSinceWatchStart != null && msSinceWatchStart >= PROVISION_ESCAPE_MS,
     retryConfirm,
-    stalledAction,
     kickProvisioning,
     kickError: ensureError,
   };

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -91,9 +91,9 @@ export interface UseProProvisioningOptions {
 }
 
 /**
- * Stalled-state recovery affordance, shaped for `StalledApplyAction`. `error`
- * mirrors `ensureError`: a reconcile failure from any source (auto, manual, or
- * the fire-and-forget escape kick), cleared by a later success.
+ * Stalled-state recovery affordance. `error` mirrors `ensureError`: a reconcile
+ * failure from any source (auto, manual, or the fire-and-forget escape kick),
+ * cleared by a later success.
  */
 export interface ProvisioningRetryAction {
   onApply: () => void;

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -17,8 +17,11 @@
  * first reports Pro it calls the idempotent ensure-provisioned reconcile
  * endpoint, so a webhook that never fired (or whose resize was lost) still
  * gets provisioned. The returned verdict feeds the state machine's
- * `serverVerdict` slot; the endpoint failing is not an error state — the
- * polling above converges on its own.
+ * `serverVerdict` slot; the endpoint failing never blocks the flow — the
+ * polling above converges on its own. But a reconcile failure from *any*
+ * source (auto, manual, or the fire-and-forget escape kick) is now held in
+ * `ensureError` so the takeover can honestly surface the ≥90s snag variant;
+ * any later success clears it.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -89,8 +92,8 @@ export interface UseProProvisioningOptions {
 
 /**
  * Stalled-state recovery affordance, shaped for `StalledApplyAction`. `error`
- * is only ever populated by a user-initiated call — the automatic reconcile
- * failing is deliberately silent.
+ * mirrors `ensureError`: a reconcile failure from any source (auto, manual, or
+ * the fire-and-forget escape kick), cleared by a later success.
  */
 export interface ProvisioningRetryAction {
   onApply: () => void;
@@ -136,6 +139,18 @@ export interface ProProvisioningResult {
    * resize) and re-bases the stall clock on success so observation resumes.
    */
   stalledAction: ProvisioningRetryAction;
+  /**
+   * Fire-and-forget "escape" kick: fires the idempotent ensure-provisioned
+   * reconcile without touching the manual-pending flag, so a hung call can
+   * never strand later UI. Used when closing the takeover into the background.
+   */
+  kickProvisioning: () => void;
+  /**
+   * Latest ensure-provisioned failure from any source; cleared by a later
+   * success. Drives the ≥90s snag variant on the takeover. (Alias of
+   * `stalledAction.error`.)
+   */
+  kickError: unknown;
 }
 
 export function useProProvisioning({
@@ -179,7 +194,8 @@ export function useProProvisioning({
   const [targetsMetAssistantId, setTargetsMetAssistantId] = useState<
     string | null
   >(null);
-  // Only ever set by a user-initiated reconcile — see runEnsureProvisioned.
+  // Latest reconcile failure from any source (auto/manual/escape); cleared by a
+  // later success — see runEnsureProvisioned.
   const [ensureError, setEnsureError] = useState<unknown>(null);
   // Pending state for the *manual* reconcile only. The mutation's own
   // `isPending` is shared with the automatic call fired on Pro confirm, and a
@@ -310,7 +326,7 @@ export function useProProvisioning({
   const { mutate: ensureProvisioned } = ensureProvisionedMutation;
 
   const runEnsureProvisioned = useCallback(
-    (source: "auto" | "manual") => {
+    (source: "auto" | "manual" | "escape") => {
       if (source === "manual") {
         setEnsureError(null);
         setManualPending(true);
@@ -339,20 +355,21 @@ export function useProProvisioning({
                 ensureRaceRetriedRef.current = true;
                 setRaceRetryScheduled(true);
                 // A re-ask is already queued, so observation may resume.
-                if (source === "manual") {
+                if (source !== "auto") {
                   resumeWatch();
                 }
-              } else if (source === "manual") {
+              } else {
                 // Dead end: the verdict is deliberately not adopted, nothing
                 // was queued, and the once-per-open re-ask is spent. Re-basing
                 // the stall clock here would drop the user out of STALLED —
                 // hiding Apply & Restart for another stall window — with no
-                // resize running and nothing said. Hold the state and explain.
+                // resize running and nothing said. Hold the state and explain,
+                // regardless of source, so a repeat dead end surfaces why.
                 setEnsureError({ error: "no_active_pro" });
               }
             } else {
               setServerVerdict(data.state);
-              if (source === "manual") {
+              if (source !== "auto") {
                 resumeWatch();
               }
             }
@@ -363,11 +380,11 @@ export function useProProvisioning({
             }
             // 503 (submission couldn't be queued) or a network blip: nothing
             // was queued and nothing is broken — the actuals polling still
-            // converges, so the automatic call degrades silently to inference.
-            // Only a user-initiated retry earns a visible error.
-            if (source === "manual") {
-              setEnsureError(error);
-            }
+            // converges, so the flow never blocks on this. The automatic call
+            // no longer degrades *silently*, though: its error is held for the
+            // ≥90s snag variant on the takeover and cleared by any later
+            // success, so a failure from any source is captured alike.
+            setEnsureError(error);
           },
           // Unconditional (not generation-gated): the button's pending state
           // must clear even for a response that belongs to a closed wizard,
@@ -421,6 +438,13 @@ export function useProProvisioning({
       error: ensureError,
     }),
     [runEnsureProvisioned, manualPending, ensureError],
+  );
+
+  // Fire-and-forget escape kick: fires the reconcile but never flips
+  // manualPending, so a hung escape-fired call can't strand later UI.
+  const kickProvisioning = useCallback(
+    () => runEnsureProvisioned("escape"),
+    [runEnsureProvisioned],
   );
 
   const onboardingQuery = useQuery({
@@ -624,5 +648,7 @@ export function useProProvisioning({
       msSinceWatchStart != null && msSinceWatchStart >= PROVISION_ESCAPE_MS,
     retryConfirm,
     stalledAction,
+    kickProvisioning,
+    kickError: ensureError,
   };
 }


### PR DESCRIPTION
## Summary
Consolidates the pro-onboarding provisioning takeover onto a single **Continue in the background** CTA and makes its failure messaging honest. Clicking it now opens a confirmation dialog warning that chat is unavailable until the upgrade finishes; **Continue** fires the idempotent ensure-provisioned reconcile and closes the modal, **Wait** keeps the user on the takeover. The old 90s "Apply & Restart" / "We couldn't finish this automatically" screen is replaced by friendly "taking longer than expected" copy, with a "We hit a snag" + "Retry in the background" variant shown only when a reconcile actually errors. All now-unreachable downstream stalled/background UI is deleted, and the hook's `stalledAction` API is retired in favor of `kickProvisioning`/`kickError`.

## Behavior
- **60s:** "Continue in the background" appears (no longer gated on routing).
- **Click it:** a ConfirmDialog explains chat is unavailable → **Wait** (stay) / **Continue** (kick + toast + close). The dialog auto-dismisses if the resize settles while it's open.
- **90s, no error:** "This is taking longer than expected" / "This may take a couple of minutes." — no failure claim.
- **90s + errored reconcile:** "We hit a snag upgrading your assistant" + mapped error + "Retry in the background".
- Applies uniformly to checkout and both resize/credits-change takeover mount points.

## Self-review result
PASS across all four fresh-eyes passes (external feedback, plan faithfulness, repo integration, slop/reuse). 2 minor gaps found and fixed (#39131): a redundant reset effect and a stale comment.

## PRs merged into this feature branch
- #39121: fix(web): never render a same→same arrow in the provisioning target chips
- #39122: feat(web): capture ensure-provisioned errors from all sources and expose a fire-and-forget kick
- #39123: feat(web): provisioning takeover — single background CTA that exits, honest slow-copy, error-gated snag state
- #39127: refactor(web): drop the now-unreachable stalled recovery and background-finishing UI from the onboarding steps
- #39128: refactor(web): retire the stalledAction API from useProProvisioning
- #39129: feat(web): confirm before backgrounding the upgrade, warning that chat is unavailable
- #39131: refactor(web): drop the redundant background-confirm reset effect and a stale comment (self-review remediation)

Part of plan: pro-takeover-exit-on-escape.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)