### PR TITLE
refactor(config): drop mode from the image-generation schema

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -32459,8 +32459,10 @@ components:
               anyOf:
                 - type: object
                   properties:
-                    mode:
-                      $ref: "#/components/schemas/ServiceMode"
+                    provider:
+                      type: string
+                    model:
+                      type: string
                   additionalProperties: {}
                 - type: "null"
             inference:
@@ -33271,8 +33273,10 @@ components:
             image-generation:
               type: object
               properties:
-                mode:
-                  $ref: "#/components/schemas/ServiceMode"
+                provider:
+                  type: string
+                model:
+                  type: string
               additionalProperties: {}
             inference:
               type: object

--- a/assistant/src/__tests__/config-loader-platform-defaults.test.ts
+++ b/assistant/src/__tests__/config-loader-platform-defaults.test.ts
@@ -102,8 +102,9 @@ const SCHEMA_MANAGED_DEFAULT_SERVICES = [
 ] as const;
 
 // web-search is absent from both lists: it carries no mode at all.
+// image-generation and web-search are absent from both lists: they carry
+// no mode at all.
 const SCHEMA_YOUR_OWN_DEFAULT_SERVICES = [
-  "image-generation",
   "outlook-oauth",
   "linear-oauth",
   "github-oauth",
@@ -214,13 +215,16 @@ describe("platform-managed config defaults", () => {
 
     const written = readConfig() as { services?: Record<string, unknown> };
     expect(written.services).toBeDefined();
-    // The existing value must be preserved — backfill path, not fresh-write path
+    // The raw value must be preserved — backfill path, not fresh-write path.
+    // (Migration 134 rewrites this legacy shape at daemon startup; the loader
+    // itself must simply leave it alone.)
     expect(
       (written.services!["image-generation"] as { mode?: string })?.mode,
     ).toBe("your-own");
-    // ...and the in-memory config must mirror the explicit user choice (the
-    // fill-defaults pass must not override an explicit "your-own").
-    expect(config.services["image-generation"].mode).toBe("your-own");
+    // The parsed config strips the legacy key and carries the filled
+    // provider; no mode survives the schema.
+    expect(config.services["image-generation"]).not.toHaveProperty("mode");
+    expect(config.services["image-generation"].provider).toBe("vellum");
   });
 
   test("IS_PLATFORM=true, config file with explicit notion-oauth mode='your-own' → preserved (schema default is 'managed')", () => {
@@ -323,11 +327,11 @@ describe("platform-managed config defaults", () => {
     const imageGen = (
       config.services as unknown as Record<
         string,
-        { mode: string; provider?: string }
+        { mode?: string; provider?: string }
       >
     )["image-generation"]!;
     expect(imageGen.provider).toBe("openai");
-    expect(imageGen.mode).toBe("your-own");
+    expect(imageGen).not.toHaveProperty("mode");
   });
 
   test("IS_PLATFORM=false, config file exists without services key → in-memory config keeps schema defaults (your-own except google/notion-oauth which are managed)", () => {
@@ -430,9 +434,11 @@ describe("GET /v1/config handler — context-default fill on raw response", () =
   test("IS_PLATFORM=true, raw config has explicit services.image-generation.mode='your-own' → preserved", () => {
     process.env.IS_PLATFORM = "true";
 
-    // User has explicitly chosen "your-own" for image-generation via the macOS
-    // Save flow. The patch handler persisted that to disk; the fill pass must
-    // not override an explicit user choice.
+    // A legacy raw shape: mode with no provider leaf. Migration 134 rewrites
+    // it (pinning provider gemini) before any real request reaches this
+    // function, so the fill's only obligation here is to be non-destructive:
+    // existing keys pass through untouched, absent leaves get the platform
+    // default.
     const raw: Record<string, unknown> = {
       services: {
         "image-generation": { mode: "your-own" },
@@ -443,8 +449,12 @@ describe("GET /v1/config handler — context-default fill on raw response", () =
       string,
       unknown
     >;
-    const services = result["services"] as Record<string, { mode: string }>;
+    const services = result["services"] as Record<
+      string,
+      { mode?: string; provider?: string }
+    >;
     expect(services["image-generation"]!.mode).toBe("your-own");
+    expect(services["image-generation"]!.provider).toBe("vellum");
     // web-search is not context-filled: a filled `mode` would override BYOK
     // configs on every load.
     expect(services["web-search"]).toBeUndefined();

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -68,7 +68,7 @@ describe("AssistantConfigSchema", () => {
     expect(result.services["image-generation"].model).toBe(
       "gemini-3.1-flash-image-preview",
     );
-    expect(result.services["image-generation"].mode).toBe("your-own");
+    expect(result.services["image-generation"]).not.toHaveProperty("mode");
     expect(result.services["web-search"].provider).toBe(
       "inference-provider-native",
     );

--- a/assistant/src/__tests__/config-set-platform-guard.test.ts
+++ b/assistant/src/__tests__/config-set-platform-guard.test.ts
@@ -174,8 +174,10 @@ describe("config set - platform connection guard for service mode paths", () => 
     mockIpcResult = { ok: true, result: { ok: true } };
   });
 
-  test("config set services.image-generation.mode your-own - succeeds without platform connection", async () => {
-    const { exitCode } = await runCli([
+  test("config set services.image-generation.mode - rejected with provider guidance, no IPC write emitted", async () => {
+    // The image-generation schema has no mode field; a raw write would be
+    // stripped at parse while the CLI reported success.
+    const { exitCode, stdout } = await runCli([
       "node",
       "assistant",
       "--json",
@@ -185,16 +187,13 @@ describe("config set - platform connection guard for service mode paths", () => 
       "your-own",
     ]);
 
-    expect(exitCode).toBe(0);
-    // The CLI should have emitted exactly one config_set IPC call.
-    const setCalls = mockIpcCalls.filter((c) => c.method === "config_set");
-    expect(setCalls).toHaveLength(1);
-    expect(setCalls[0]!.params).toEqual({
-      body: {
-        path: "services.image-generation.mode",
-        value: "your-own",
-      },
-    });
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("services.image-generation.provider vellum");
+    expect(mockIpcCalls.filter((c) => c.method === "config_set")).toHaveLength(
+      0,
+    );
   });
 
   test("config set calls.enabled true - succeeds without platform connection and parses to boolean", async () => {

--- a/assistant/src/__tests__/image-credentials.test.ts
+++ b/assistant/src/__tests__/image-credentials.test.ts
@@ -40,7 +40,7 @@ describe("resolveImageGenCredentials", () => {
 
       const result = await resolveImageGenCredentials({
         provider: "gemini",
-        mode: "managed",
+        managed: true,
       });
 
       expect(result.errorHint).toBeUndefined();
@@ -57,7 +57,7 @@ describe("resolveImageGenCredentials", () => {
 
       const result = await resolveImageGenCredentials({
         provider: "gemini",
-        mode: "managed",
+        managed: true,
       });
 
       expect(result.credentials).toBeUndefined();
@@ -71,7 +71,7 @@ describe("resolveImageGenCredentials", () => {
 
       const result = await resolveImageGenCredentials({
         provider: "gemini",
-        mode: "managed",
+        managed: true,
       });
 
       expect(result.credentials).toBeUndefined();
@@ -86,7 +86,7 @@ describe("resolveImageGenCredentials", () => {
 
       const result = await resolveImageGenCredentials({
         provider: "gemini",
-        mode: "your-own",
+        managed: false,
       });
 
       expect(result.errorHint).toBeUndefined();
@@ -101,7 +101,7 @@ describe("resolveImageGenCredentials", () => {
 
       const result = await resolveImageGenCredentials({
         provider: "gemini",
-        mode: "your-own",
+        managed: false,
       });
 
       expect(result.credentials).toBeUndefined();
@@ -114,7 +114,7 @@ describe("resolveImageGenCredentials", () => {
 
       const result = await resolveImageGenCredentials({
         provider: "openai",
-        mode: "your-own",
+        managed: false,
       });
 
       expect(result.errorHint).toBeUndefined();
@@ -129,7 +129,7 @@ describe("resolveImageGenCredentials", () => {
 
       const result = await resolveImageGenCredentials({
         provider: "openai",
-        mode: "your-own",
+        managed: false,
       });
 
       expect(result.credentials).toBeUndefined();
@@ -164,24 +164,10 @@ describe("resolveImageGenRouting", () => {
     ).toEqual({ backendProvider: "openai", managed: true });
   });
 
-  test("a legacy managed mode routes managed for BYOK providers", () => {
-    expect(
-      resolveImageGenRouting({
-        provider: "gemini",
-        model: "gemini-3.1-flash-image-preview",
-        mode: "managed",
-      }),
-    ).toEqual({ backendProvider: "gemini", managed: true });
-  });
-
   test("BYOK providers keep the override re-routing without managed", () => {
     expect(
       resolveImageGenRouting(
-        {
-          provider: "gemini",
-          model: "gemini-3.1-flash-image-preview",
-          mode: "your-own",
-        },
+        { provider: "gemini", model: "gemini-3.1-flash-image-preview" },
         "gpt-image-2",
       ),
     ).toEqual({ backendProvider: "openai", managed: false });
@@ -199,7 +185,7 @@ describe("resolveImageGenRouting", () => {
     });
     const result = await resolveImageGenCredentials({
       provider: routing.backendProvider,
-      mode: routing.managed ? "managed" : "your-own",
+      managed: routing.managed,
     });
 
     expect(result.credentials).toBeUndefined();

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -1298,3 +1298,30 @@ describe("code-owned default profiles — echoes over stale on-disk bodies", () 
     expectNothingCommitted();
   });
 });
+
+// ---------------------------------------------------------------------------
+// PATCH /v1/config — legacy service-mode scrub
+// ---------------------------------------------------------------------------
+
+describe("PATCH /v1/config — provider-only services scrub legacy mode", () => {
+  test("a paired provider+mode write persists without the mode key", async () => {
+    // Web clients pair provider writes with `mode` so their saves stay valid
+    // on daemons whose schemas still carry it; the raw config must not
+    // resurrect the removed field on every save.
+    await patchRoute.handler({
+      body: {
+        services: {
+          "image-generation": { provider: "vellum", mode: "managed" },
+          "web-search": { provider: "vellum", mode: "managed" },
+        },
+      },
+    } as never);
+
+    const raw = committedRaw() as Record<
+      string,
+      Record<string, Record<string, unknown>>
+    >;
+    expect(raw.services["image-generation"]).toEqual({ provider: "vellum" });
+    expect(raw.services["web-search"]).toEqual({ provider: "vellum" });
+  });
+});

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -24,12 +24,11 @@ let lastGenerateCredentials: unknown = null;
 
 /**
  * Seed the image-generation service entry in the real workspace config.
- * Omitted fields fall back to the schema defaults (`mode: "your-own"`,
- * `provider: "gemini"`, model `gemini-3.1-flash-image-preview`).
+ * Omitted fields fall back to the schema defaults (`provider: "gemini"`,
+ * model `gemini-3.1-flash-image-preview`).
  */
 function seedImageGenService(
   overrides: {
-    mode?: "your-own" | "managed";
     provider?: "vellum" | "gemini" | "openai";
     model?: string;
   } = {},
@@ -152,8 +151,8 @@ describe("image-studio skill script wrapper", () => {
     expect(result.content).toContain("No Gemini API key");
   });
 
-  test("managed mode uses managed proxy credentials", async () => {
-    seedImageGenService({ mode: "managed" });
+  test("provider vellum uses managed proxy credentials", async () => {
+    seedImageGenService({ provider: "vellum" });
     mockManagedBaseUrl = "https://platform.example.com/v1/runtime-proxy/gemini";
     mockManagedProxyContext = {
       enabled: true,
@@ -224,8 +223,8 @@ describe("image-studio skill script wrapper", () => {
     expect(lastGenerateProvider).toBeNull();
   });
 
-  test("managed mode returns error when managed proxy is unavailable", async () => {
-    seedImageGenService({ mode: "managed" });
+  test("provider vellum returns error when managed proxy is unavailable", async () => {
+    seedImageGenService({ provider: "vellum" });
     mockGeminiKey = "direct-key"; // should be ignored in managed mode
     mockManagedBaseUrl = undefined;
 
@@ -236,7 +235,7 @@ describe("image-studio skill script wrapper", () => {
   });
 
   test("your-own mode uses direct API key", async () => {
-    seedImageGenService({ mode: "your-own" });
+    seedImageGenService({ provider: "gemini" });
     mockGeminiKey = "direct-key";
     mockManagedBaseUrl = "https://platform.example.com/v1/runtime-proxy/gemini";
     mockManagedProxyContext = {
@@ -417,8 +416,8 @@ describe("image-studio skill script wrapper", () => {
     );
   });
 
-  test("managed mode credential error includes guidance not to change service config", async () => {
-    seedImageGenService({ mode: "managed" });
+  test("provider vellum credential error includes guidance not to change service config", async () => {
+    seedImageGenService({ provider: "vellum" });
     mockManagedBaseUrl = undefined;
 
     const result = await run({ prompt: "a cat" }, fakeContext);

--- a/assistant/src/__tests__/provider-platform-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-platform-proxy-integration.test.ts
@@ -153,7 +153,6 @@ function makeProvidersConfig(
     services: {
       inference: {},
       "image-generation": {
-        mode: "your-own",
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },

--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -30,8 +30,26 @@ function flattenConfig(
   return result;
 }
 
-/** Matches config paths like `services.image-generation.mode`, `services.web-search.mode`, etc. */
+/** Matches config paths like `services.google-oauth.mode` (mode-based services). */
 const SERVICE_MODE_PATH_RE = /^services\.[^.]+\.mode$/;
+
+/**
+ * Services configured by provider alone: their schemas strip a raw `mode`
+ * write, so the CLI rejects it with the provider-based replacement instead
+ * of printing success on a no-op.
+ */
+const REMOVED_MODE_PATHS: Record<string, string> = {
+  "services.web-search.mode":
+    "services.web-search.mode does not exist; web search is configured by provider alone. For managed search run `config set services.web-search.provider vellum`.",
+  "services.image-generation.mode":
+    "services.image-generation.mode does not exist; image generation is configured by provider alone. For managed image generation run `config set services.image-generation.provider vellum`.",
+};
+
+/** Provider paths whose "vellum" value requires a platform connection. */
+const VELLUM_PROVIDER_PATHS = new Set([
+  "services.web-search.provider",
+  "services.image-generation.provider",
+]);
 
 /**
  * Fetch the full raw config from the assistant via IPC.
@@ -69,13 +87,10 @@ export function registerConfigCommand(program: Command): void {
           // Web-search has no mode field: the schema strips it, so a write
           // here would print success while changing nothing. Reject it with
           // the provider-based replacement instead.
-          if (key === "services.web-search.mode") {
+          const removedModePath = REMOVED_MODE_PATHS[key];
+          if (removedModePath) {
             const { writeOutput } = await import("../output.js");
-            writeOutput(cmd, {
-              ok: false,
-              error:
-                "services.web-search.mode does not exist; web search is configured by provider alone. For managed search run `config set services.web-search.provider vellum`.",
-            });
+            writeOutput(cmd, { ok: false, error: removedModePath });
             process.exitCode = 1;
             return;
           }
@@ -85,7 +100,7 @@ export function registerConfigCommand(program: Command): void {
           // web search.
           const requiresPlatform =
             (SERVICE_MODE_PATH_RE.test(key) && parsed === "managed") ||
-            (key === "services.web-search.provider" && parsed === "vellum");
+            (VELLUM_PROVIDER_PATHS.has(key) && parsed === "vellum");
           if (requiresPlatform) {
             const { requirePlatformConnection } =
               await import("./oauth/shared.js");

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -49,7 +49,7 @@ export async function run(
   );
   const { credentials, errorHint } = await resolveImageGenCredentials({
     provider,
-    mode: managed ? "managed" : "your-own",
+    managed,
   });
   if (!credentials) {
     return {

--- a/assistant/src/config/raw-config-utils.ts
+++ b/assistant/src/config/raw-config-utils.ts
@@ -4,7 +4,7 @@
  * Ensures the `services` and service-level objects exist before writing,
  * so callers don't need to guard against undefined intermediate keys.
  *
- * Example: `setServiceField(raw, "image-generation", "mode", "managed")`
+ * Example: `setServiceField(raw, "image-generation", "provider", "vellum")`
  * produces `raw.services["image-generation"].mode = "managed"`.
  */
 export function setServiceField(

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -53,7 +53,13 @@ const BaseServiceSchema = z.object({
  */
 const InferenceServiceSchema = z.object({});
 
-const ImageGenerationServiceSchema = BaseServiceSchema.extend({
+/**
+ * Image generation carries no `mode`: `provider` is the only axis. `"vellum"`
+ * generates through the platform runtime proxy for the model-appropriate
+ * backend, billed to Vellum credits; `"gemini"`/`"openai"` use the user's
+ * key. A `mode` key sent by an older client is stripped at parse.
+ */
+const ImageGenerationServiceSchema = z.object({
   provider: z.enum(VALID_IMAGE_GEN_PROVIDERS).default("gemini"),
   model: z.string().default(DEFAULT_IMAGE_MODEL),
 });

--- a/assistant/src/media/app-icon-generator.ts
+++ b/assistant/src/media/app-icon-generator.ts
@@ -37,7 +37,7 @@ export async function generateAppIcon(
   const { backendProvider, managed } = resolveImageGenRouting(svc);
   const { credentials, errorHint } = await resolveImageGenCredentials({
     provider: backendProvider,
-    mode: managed ? "managed" : "your-own",
+    managed,
   });
   if (!credentials) {
     log.debug(

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -15,7 +15,7 @@ export async function generateAvatar(
   const { backendProvider, managed } = resolveImageGenRouting(svc);
   const { credentials, errorHint } = await resolveImageGenCredentials({
     provider: backendProvider,
-    mode: managed ? "managed" : "your-own",
+    managed,
   });
 
   if (!credentials) {

--- a/assistant/src/media/image-credentials.ts
+++ b/assistant/src/media/image-credentials.ts
@@ -23,14 +23,13 @@ import { providerForImageModelPrefix, providerForModel } from "./types.js";
  * proxies. Managed routing never falls back to a stored BYOK key, and a BYOK
  * provider never falls back to the proxy — billing follows the explicit
  * provider choice. Other providers use the caller's key, with an explicit
- * model override re-routing to the model's backend. A legacy
- * `mode: "managed"` also routes managed.
+ * model override re-routing to the model's backend.
  */
 export function resolveImageGenRouting(
-  svc: { provider: string; model: string; mode?: string },
+  svc: { provider: string; model: string },
   modelOverride?: unknown,
 ): { backendProvider: ImageGenProvider; managed: boolean } {
-  const managed = svc.provider === "vellum" || svc.mode === "managed";
+  const managed = svc.provider === "vellum";
   if (svc.provider === "vellum") {
     const model =
       typeof modelOverride === "string" && modelOverride
@@ -50,20 +49,20 @@ export function resolveImageGenRouting(
 /**
  * Resolve credentials for an image-generation request.
  *
- * - `mode === "managed"`: returns managed-proxy credentials when the
- *   platform URL and assistant API key are both configured, otherwise
- *   returns a hint telling the user to log in or switch modes.
- * - `mode === "your-own"`: returns direct credentials when the provider
- *   API key is present in secure storage (or the env-var fallback),
- *   otherwise returns a provider-aware hint pointing at Settings.
+ * - `managed`: returns managed-proxy credentials when the platform URL and
+ *   assistant API key are both configured, otherwise a hint telling the
+ *   user to log in.
+ * - otherwise: returns direct credentials when the provider API key is
+ *   present in secure storage (or the env-var fallback), otherwise a
+ *   provider-aware hint pointing at Settings.
  */
 export async function resolveImageGenCredentials(opts: {
   provider: ImageGenProvider;
-  mode: "managed" | "your-own";
+  managed: boolean;
 }): Promise<{ credentials?: ImageGenCredentials; errorHint?: string }> {
-  const { provider, mode } = opts;
+  const { provider, managed } = opts;
 
-  if (mode === "managed") {
+  if (managed) {
     // Resolve platform URL + assistant API key from a single snapshot so
     // baseUrl and assistantApiKey can't diverge if the credential is cleared
     // between lookups.
@@ -89,7 +88,6 @@ export async function resolveImageGenCredentials(opts: {
     };
   }
 
-  // mode === "your-own"
   const apiKey = await getProviderKeyAsync(provider);
   if (apiKey) {
     return { credentials: { type: "direct", apiKey } };

--- a/assistant/src/providers/__tests__/registry-native-web-search.test.ts
+++ b/assistant/src/providers/__tests__/registry-native-web-search.test.ts
@@ -52,7 +52,6 @@ function makeConfig(): ProvidersConfig {
     services: {
       inference: {},
       "image-generation": {
-        mode: "your-own",
         provider: "gemini",
         model: "gemini-3.1-flash-image-preview",
       },

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -75,7 +75,6 @@ export interface ProvidersConfig {
   services: {
     inference: Record<string, never>;
     "image-generation": {
-      mode: "managed" | "your-own";
       provider: string;
       model: string;
     };

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -703,7 +703,10 @@ const ConfigGetResponseSchema = z
           .passthrough()
           .optional(),
         "image-generation": z
-          .object({ mode: ServiceModeSchema.optional() })
+          .object({
+            provider: z.string().optional(),
+            model: z.string().optional(),
+          })
           .passthrough()
           .optional(),
         inference: z
@@ -807,7 +810,10 @@ const ConfigPatchRequestSchema = z
           .nullable()
           .optional(),
         "image-generation": z
-          .object({ mode: ServiceModeSchema.optional() })
+          .object({
+            provider: z.string().optional(),
+            model: z.string().optional(),
+          })
           .passthrough()
           .nullable()
           .optional(),

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1455,6 +1455,28 @@ export async function commitConfigWrite(
   }
 }
 
+/**
+ * Web clients pair provider writes with a legacy `mode` key so their saves
+ * stay valid on daemons whose schemas still carry it. The provider-only
+ * services (web-search, image-generation) parse-strip that key, but the
+ * deep-merge would still persist it to raw config.json on every save —
+ * scrub it so the removed field cannot be resurrected on disk.
+ */
+function scrubRemovedServiceModes(raw: Record<string, unknown>): void {
+  const services = raw.services as
+    | Record<string, Record<string, unknown> | undefined>
+    | undefined;
+  if (!services) {
+    return;
+  }
+  for (const key of ["web-search", "image-generation"]) {
+    const entry = services[key];
+    if (entry && typeof entry === "object" && "mode" in entry) {
+      delete entry.mode;
+    }
+  }
+}
+
 async function handlePatchConfig({ body }: RouteHandlerArgs) {
   if (
     !body ||
@@ -1473,6 +1495,7 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
   const patch = body as Record<string, unknown>;
   backfillNewCallSiteEntries(raw, patch);
   deepMergeOverwrite(raw, patch);
+  scrubRemovedServiceModes(raw);
 
   await commitConfigWrite(raw, "patch");
 

--- a/assistant/src/runtime/routes/image-generation-routes.ts
+++ b/assistant/src/runtime/routes/image-generation-routes.ts
@@ -104,7 +104,7 @@ async function handleImageGenerationGenerate(
   // Resolve credentials
   const { credentials, errorHint } = await resolveImageGenCredentials({
     provider,
-    mode: managed ? "managed" : "your-own",
+    managed,
   });
 
   if (!credentials) {


### PR DESCRIPTION
## Summary
- `ImageGenerationServiceSchema` is a plain `{ provider, model }` object — no `BaseServiceSchema`, no `mode`; a stale mode from an old client is stripped at parse (`ServiceModeSchema`/`getServiceMode` stay for the OAuth services and email); the daemon config GET/PATCH contract exposes explicit `provider`/`model` and `assistant/openapi.yaml` is regenerated
- The mode vocabulary leaves the internal API: `resolveImageGenRouting` drops its legacy bridge (managed ⇔ `provider === "vellum"` alone), `resolveImageGenCredentials` takes `{ provider, managed: boolean }`, and the four call sites pass `managed` straight through (safe pre-fleet: migration 134 scrubs mode at daemon startup before this code reads any config); `ProvidersConfig` drops the field
- CLI: `services.image-generation.mode` writes are rejected with guidance pointing at `config set services.image-generation.provider vellum`, and provider-vellum writes require a platform connection — the web-search and image-gen special cases are generalized into shared `REMOVED_MODE_PATHS`/`VELLUM_PROVIDER_PATHS` lookups; 12 suites (329 tests) green per-file
- The web card's provider+mode write-pair bridge is deliberately untouched: old daemons still need it, and this daemon strips the key

## Original prompt
Final code PR of the image-generation vellum-provider plan (attached to #39109; #39116 and #39117 merged): with routing, the card, and migration 134 shipped, remove the mode field from the image-generation schema and every contract carrying it, and retire the managed/your-own vocabulary from the credential API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)