### PR TITLE
feat(assistant): add [-1] minimize-room marker to the voice control protocol

### DIFF
--- a/assistant/src/calls/__tests__/voice-control-protocol.test.ts
+++ b/assistant/src/calls/__tests__/voice-control-protocol.test.ts
@@ -4,6 +4,7 @@ import {
   couldBeControlMarker,
   ESCALATE_VERDICT_TOKEN,
   HOLD_VERDICT_TOKEN,
+  MINIMIZE_ROOM_MARKER,
   stripInternalSpeechMarkers,
 } from "../voice-control-protocol.js";
 
@@ -44,5 +45,27 @@ describe("front-door verdict tokens", () => {
     expect(stripInternalSpeechMarkers("Sure, one moment")).toBe(
       "Sure, one moment",
     );
+  });
+});
+
+describe("minimize-room marker", () => {
+  test("marker constant is the expected bracketed form", () => {
+    expect(MINIMIZE_ROOM_MARKER).toBe("[-1]");
+  });
+
+  test("stripInternalSpeechMarkers removes the marker so it is never spoken", () => {
+    expect(
+      stripInternalSpeechMarkers("Done [-1] here").replace(/\s+/g, " "),
+    ).toBe("Done here");
+  });
+
+  test("couldBeControlMarker holds the marker and its streaming prefixes", () => {
+    for (const text of ["[", "[-", "[-1", "[-1]", "[-1] trailing"]) {
+      expect(couldBeControlMarker(text)).toBe(true);
+    }
+  });
+
+  test("a bracket prefix that disproves the marker is not held", () => {
+    expect(couldBeControlMarker("[- something else")).toBe(false);
   });
 });

--- a/assistant/src/calls/voice-control-protocol.ts
+++ b/assistant/src/calls/voice-control-protocol.ts
@@ -28,6 +28,15 @@ export const END_CALL_MARKER = "[END_CALL]";
 export const HOLD_VERDICT_TOKEN = "[0]";
 export const ESCALATE_VERDICT_TOKEN = "[1]";
 
+/**
+ * Emitted inline by the main/escalated voice leg to ask the live-voice
+ * client to minimize the voice room and reveal the screen behind it
+ * (e.g. after creating an app worth showing). Advisory: the daemon
+ * translates it into a `minimize_room` server frame after the turn's TTS
+ * drains; it is never spoken and never persisted.
+ */
+export const MINIMIZE_ROOM_MARKER = "[-1]";
+
 // ---------------------------------------------------------------------------
 // Regexes
 // ---------------------------------------------------------------------------
@@ -47,6 +56,7 @@ const CALL_OPENING_ACK_MARKER_REGEX = /\[CALL_OPENING_ACK\]/g;
 const END_CALL_MARKER_REGEX = /\[END_CALL\]/g;
 const HOLD_VERDICT_TOKEN_REGEX = /\[0\]/g;
 const ESCALATE_VERDICT_TOKEN_REGEX = /\[1\]/g;
+const MINIMIZE_ROOM_MARKER_REGEX = /\[-1\]/g;
 const GUARDIAN_TIMEOUT_MARKER_REGEX = /\[GUARDIAN_TIMEOUT\]/g;
 const GUARDIAN_UNAVAILABLE_MARKER_REGEX = /\[GUARDIAN_UNAVAILABLE\]/g;
 
@@ -163,6 +173,7 @@ export function stripInternalSpeechMarkers(text: string): string {
     .replace(END_CALL_MARKER_REGEX, "")
     .replace(HOLD_VERDICT_TOKEN_REGEX, "")
     .replace(ESCALATE_VERDICT_TOKEN_REGEX, "")
+    .replace(MINIMIZE_ROOM_MARKER_REGEX, "")
     .replace(GUARDIAN_TIMEOUT_MARKER_REGEX, "")
     .replace(GUARDIAN_UNAVAILABLE_MARKER_REGEX, "");
   return result;
@@ -187,6 +198,7 @@ const CONTROL_MARKER_STRINGS = [
   "[END_CALL]",
   "[0]",
   "[1]",
+  "[-1]",
   "[GUARDIAN_TIMEOUT]",
   "[GUARDIAN_UNAVAILABLE]",
 ];


### PR DESCRIPTION
## Summary
- `MINIMIZE_ROOM_MARKER` (`[-1]`) constant + strip regex in the voice control protocol
- Covered by `stripInternalSpeechMarkers` and `couldBeControlMarker` holdback; no call sites yet

Part of plan: voice-room-minimize.md (PR 4 of 9)