### PR TITLE
feat(live-voice): add minimize_room server frame to the wire protocol

### DIFF
--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -22,6 +22,7 @@ const _LIVE_VOICE_SERVER_FRAME_TYPES = [
   "tts_audio",
   "tts_done",
   "turn_cancelled",
+  "minimize_room",
   "metrics",
   "archived",
   "error",
@@ -242,6 +243,18 @@ export interface LiveVoiceTurnCancelledServerFrame extends LiveVoiceServerFrameB
   readonly turnId: string;
 }
 
+/**
+ * Assistant-requested room minimize: the just-completed turn asked (via the
+ * inline [-1] control marker) for the client to dismiss the full-screen
+ * voice room so the user can see the screen behind it. Sent only after the
+ * turn's TTS has fully drained, at most once per turn. Advisory — clients
+ * without a room (pop-outs, older clients) ignore it.
+ */
+export interface LiveVoiceMinimizeRoomServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "minimize_room";
+  readonly turnId: string;
+}
+
 export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "metrics";
   readonly event?: string;
@@ -312,6 +325,7 @@ export type LiveVoiceServerFrame =
   | LiveVoiceTtsAudioServerFrame
   | LiveVoiceTtsDoneServerFrame
   | LiveVoiceTurnCancelledServerFrame
+  | LiveVoiceMinimizeRoomServerFrame
   | LiveVoiceMetricsServerFrame
   | LiveVoiceArchivedServerFrame
   | LiveVoiceErrorServerFrame;
@@ -331,6 +345,7 @@ export type LiveVoiceServerFramePayload =
   | WithoutSeq<LiveVoiceTtsAudioServerFrame>
   | WithoutSeq<LiveVoiceTtsDoneServerFrame>
   | WithoutSeq<LiveVoiceTurnCancelledServerFrame>
+  | WithoutSeq<LiveVoiceMinimizeRoomServerFrame>
   | WithoutSeq<LiveVoiceMetricsServerFrame>
   | WithoutSeq<LiveVoiceArchivedServerFrame>
   | WithoutSeq<LiveVoiceErrorServerFrame>;

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -403,7 +403,7 @@ describe("server frame dispatch", () => {
     expect(got.archived).toHaveLength(1);
   });
 
-  test("dispatches speech_started / utterance_end / utterance_discarded / turn_cancelled to their events", async () => {
+  test("dispatches speech_started / utterance_end / utterance_discarded / turn_cancelled / minimize_room to their events", async () => {
     const { client, ws } = await ready();
 
     const { got, record } = makeRecorder();
@@ -411,12 +411,14 @@ describe("server frame dispatch", () => {
     client.on("utteranceEnd", record("utteranceEnd"));
     client.on("utteranceDiscarded", record("utteranceDiscarded"));
     client.on("turnCancelled", record("turnCancelled"));
+    client.on("minimizeRoom", record("minimizeRoom"));
 
     ws.receive({ type: "speech_started", seq: 2 });
     ws.receive({ type: "utterance_end", seq: 3, reason: "silence" });
     ws.receive({ type: "utterance_end", seq: 4, reason: "max-duration" });
     ws.receive({ type: "utterance_discarded", seq: 5 });
     ws.receive({ type: "turn_cancelled", seq: 6, turnId: "t1" });
+    ws.receive({ type: "minimize_room", seq: 7, turnId: "t1" });
 
     expect(got.speechStarted).toEqual([{ type: "speech_started", seq: 2 }]);
     expect(got.utteranceEnd).toEqual([
@@ -428,6 +430,9 @@ describe("server frame dispatch", () => {
     ]);
     expect(got.turnCancelled).toEqual([
       { type: "turn_cancelled", seq: 6, turnId: "t1" },
+    ]);
+    expect(got.minimizeRoom).toEqual([
+      { type: "minimize_room", seq: 7, turnId: "t1" },
     ]);
   });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -28,6 +28,7 @@ import {
   type LiveVoiceClientStartFrame,
   LIVE_VOICE_AUDIO_FORMAT,
   type LiveVoiceMetricsServerFrame,
+  type LiveVoiceMinimizeRoomServerFrame,
   type LiveVoiceReadyServerFrame,
   type LiveVoiceSpeechStartedServerFrame,
   type LiveVoiceSttFinalServerFrame,
@@ -112,6 +113,8 @@ export interface LiveVoiceClientEventMap {
   ttsDone: LiveVoiceTtsDoneServerFrame;
   /** Barge-in aborted the turn — drop buffered tts_audio; no tts_done follows. */
   turnCancelled: LiveVoiceTurnCancelledServerFrame;
+  /** The completed turn asked the client to dismiss the full-screen room. */
+  minimizeRoom: LiveVoiceMinimizeRoomServerFrame;
   metrics: LiveVoiceMetricsServerFrame;
   archived: LiveVoiceArchivedServerFrame;
   busy: LiveVoiceBusyServerFrame;
@@ -194,6 +197,7 @@ export class LiveVoiceChannelClient {
     ttsAudio: new Set(),
     ttsDone: new Set(),
     turnCancelled: new Set(),
+    minimizeRoom: new Set(),
     metrics: new Set(),
     archived: new Set(),
     busy: new Set(),
@@ -419,6 +423,9 @@ export class LiveVoiceChannelClient {
         return;
       case "turn_cancelled":
         this.emit("turnCancelled", frame);
+        return;
+      case "minimize_room":
+        this.emit("minimizeRoom", frame);
         return;
       case "metrics":
         this.emit("metrics", frame);

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.test.ts
@@ -122,8 +122,13 @@ describe("parseServerFrame", () => {
   });
 
   test("passes through a known-type frame missing a field (only the type discriminator is validated)", () => {
+    // Deliberately not a well-formed LiveVoiceMinimizeRoomServerFrame (no
+    // turnId) — the parser validates only the type discriminator, so the raw
+    // object passes through unchanged. The cast reflects that documented gap.
     const raw = { type: "minimize_room", seq: 21 };
-    expect(parseServerFrame(JSON.stringify(raw))).toEqual(raw);
+    expect(parseServerFrame(JSON.stringify(raw))).toEqual(
+      raw as unknown as LiveVoiceServerFrame,
+    );
   });
 
   test("round-trips utterance_end with a max-duration reason", () => {

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.test.ts
@@ -27,6 +27,7 @@ describe("parseServerFrame", () => {
     { type: "utterance_end", seq: 13, reason: "silence" },
     { type: "utterance_discarded", seq: 18 },
     { type: "turn_cancelled", seq: 14, turnId: "t2" },
+    { type: "minimize_room", seq: 20, turnId: "t3" },
     { type: "stt_partial", seq: 3, text: "hel" },
     { type: "stt_final", seq: 4, text: "hello" },
     { type: "thinking", seq: 5, turnId: "t1" },
@@ -118,6 +119,11 @@ describe("parseServerFrame", () => {
       code: "invalid_json",
       message: expect.any(String),
     });
+  });
+
+  test("passes through a known-type frame missing a field (only the type discriminator is validated)", () => {
+    const raw = { type: "minimize_room", seq: 21 };
+    expect(parseServerFrame(JSON.stringify(raw))).toEqual(raw);
   });
 
   test("round-trips utterance_end with a max-duration reason", () => {

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -117,6 +117,7 @@ const LIVE_VOICE_SERVER_FRAME_TYPES = [
   "tts_audio",
   "tts_done",
   "turn_cancelled",
+  "minimize_room",
   "metrics",
   "archived",
   "error",
@@ -214,6 +215,18 @@ export interface LiveVoiceTurnCancelledServerFrame extends LiveVoiceServerFrameB
   readonly turnId: string;
 }
 
+/**
+ * Assistant-requested room minimize: the just-completed turn asked (via the
+ * inline [-1] control marker) for the client to dismiss the full-screen
+ * voice room so the user can see the screen behind it. Sent only after the
+ * turn's TTS has fully drained, at most once per turn. Advisory — clients
+ * without a room (pop-outs, older clients) ignore it.
+ */
+export interface LiveVoiceMinimizeRoomServerFrame extends LiveVoiceServerFrameBase {
+  readonly type: "minimize_room";
+  readonly turnId: string;
+}
+
 export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "metrics";
   /**
@@ -291,6 +304,7 @@ export type LiveVoiceServerFrame =
   | LiveVoiceTtsAudioServerFrame
   | LiveVoiceTtsDoneServerFrame
   | LiveVoiceTurnCancelledServerFrame
+  | LiveVoiceMinimizeRoomServerFrame
   | LiveVoiceMetricsServerFrame
   | LiveVoiceArchivedServerFrame
   | LiveVoiceErrorServerFrame;


### PR DESCRIPTION
## Summary
- New `minimize_room` server frame (daemon + web protocol types, parse case)
- Web client emits `minimizeRoom`; no sender or consumer yet (additive plumbing)

Part of plan: voice-room-minimize.md (PR 5 of 9)