### PR TITLE
fix(plugin-api): forward publishEvent to the daemon from side processes

### DIFF
--- a/assistant/src/__tests__/plugin-event-hub-facade.test.ts
+++ b/assistant/src/__tests__/plugin-event-hub-facade.test.ts
@@ -13,6 +13,12 @@ import { describe, expect, test } from "bun:test";
 import type { AssistantEventEnvelope } from "../api/index.js";
 import { assistantEventHub as pluginHub } from "../plugin-api/index.js";
 import { assistantEventHub as rawHub } from "../runtime/assistant-event-hub.js";
+import { markCurrentProcessAsMainDaemon } from "../runtime/process-role.js";
+
+// The facade's `publish` fans out locally only in the daemon; elsewhere it
+// forwards over IPC. These assertions check local delivery, so mark this
+// process the main daemon.
+markCurrentProcessAsMainDaemon();
 
 /** Minimal event envelope; the facade guard keys only off `message.type`. */
 function envelope(type: string): AssistantEventEnvelope {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -46,6 +46,7 @@ import {
 } from "../runtime/http-server.js";
 import { warmLocalGuardianPrincipalCache } from "../runtime/local-actor-identity.js";
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
+import { markCurrentProcessAsMainDaemon } from "../runtime/process-role.js";
 import { publishConfigChanged } from "../runtime/sync/resource-sync-events.js";
 import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
@@ -104,6 +105,11 @@ function loadDotEnv(): void {
 
 // Entry point for the daemon process itself
 export async function runDaemon(): Promise<void> {
+  // Identify this process as the daemon before anything can publish: it owns
+  // the event hub real clients subscribe to, so plugin-facing publishes made
+  // here fan out locally rather than routing to a daemon over IPC.
+  markCurrentProcessAsMainDaemon();
+
   const startupStartedAt = Date.now();
   // dotenv loads before the first log call so the lazy root logger
   // initializes against the final VELLUM_WORKSPACE_DIR / log path, not

--- a/assistant/src/ipc/__tests__/events-publish-client.test.ts
+++ b/assistant/src/ipc/__tests__/events-publish-client.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests the side-process → daemon publish forwarder. It calls the daemon's
+ * `/events/publish` IPC route with the event envelope, and is best-effort: a
+ * transport failure is logged, never thrown.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantEventEnvelope } from "../../api/index.js";
+
+interface IpcCall {
+  method: string;
+  params?: Record<string, unknown>;
+}
+const ipcCalls: IpcCall[] = [];
+let ipcResult: { ok: boolean; error?: string } = { ok: true };
+
+mock.module("../cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    return ipcResult;
+  },
+}));
+
+const { EVENTS_PUBLISH_IPC_METHOD, forwardEventPublishToDaemon } =
+  await import("../events-publish-client.js");
+
+function event(): AssistantEventEnvelope {
+  return {
+    id: "e1",
+    conversationId: "c1",
+    emittedAt: "2026-01-01T00:00:00.000Z",
+    message: {
+      type: "sync_changed",
+    } as unknown as AssistantEventEnvelope["message"],
+  };
+}
+
+beforeEach(() => {
+  ipcCalls.length = 0;
+  ipcResult = { ok: true };
+});
+
+describe("forwardEventPublishToDaemon", () => {
+  test("calls the /events/publish route with the event (and options when present)", async () => {
+    await forwardEventPublishToDaemon(event(), { excludeClientId: "tab-1" });
+    expect(ipcCalls).toHaveLength(1);
+    expect(ipcCalls[0].method).toBe(EVENTS_PUBLISH_IPC_METHOD);
+    expect(ipcCalls[0].params).toEqual({
+      body: { event: event(), options: { excludeClientId: "tab-1" } },
+    });
+  });
+
+  test("passes undefined options through when none are given", async () => {
+    await forwardEventPublishToDaemon(event(), undefined);
+    expect(ipcCalls[0].params).toEqual({
+      body: { event: event(), options: undefined },
+    });
+  });
+
+  test("does not throw when the IPC transport fails", async () => {
+    ipcResult = { ok: false, error: "connect failed" };
+    await expect(
+      forwardEventPublishToDaemon(event(), undefined),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/assistant/src/ipc/events-publish-client.ts
+++ b/assistant/src/ipc/events-publish-client.ts
@@ -1,0 +1,44 @@
+/**
+ * Client transport for forwarding an event publish to the daemon.
+ *
+ * The daemon owns the event hub and the client connections it fans out to. A
+ * side process (a sidecar worker, the route host) that publishes to its *own*
+ * in-process hub reaches no SSE subscriber, so it must hand the event to the
+ * daemon instead. This module is that hand-off: it calls the daemon's
+ * `/events/publish` IPC route ({@link EVENTS_PUBLISH_IPC_METHOD}), which
+ * republishes the event on the daemon's real hub.
+ *
+ * The method-name constant lives here (not in the route module) so callers can
+ * import it without pulling in the route handler's dependency graph.
+ */
+
+import type { AssistantEventEnvelope } from "../api/index.js";
+import type { AssistantEventPublishOptions } from "../runtime/assistant-event-publish-options.js";
+import { getLogger } from "../util/logger.js";
+import { cliIpcCall } from "./cli-client.js";
+
+const log = getLogger("events-publish-client");
+
+/** IPC method name — the raw publish transport other processes call. */
+export const EVENTS_PUBLISH_IPC_METHOD = "/events/publish";
+
+/**
+ * Forward an event publish to the daemon over IPC. Best-effort: a transport
+ * failure is logged, not thrown — a dropped UI-invalidation must never surface
+ * as a handler error (mirroring the local hub, whose subscriber failures are
+ * isolated from the publisher).
+ */
+export async function forwardEventPublishToDaemon(
+  event: AssistantEventEnvelope,
+  options: AssistantEventPublishOptions | undefined,
+): Promise<void> {
+  const result = await cliIpcCall(EVENTS_PUBLISH_IPC_METHOD, {
+    body: { event, options },
+  });
+  if (!result.ok) {
+    log.warn(
+      { err: result.error, eventType: event.message?.type },
+      "Failed to forward event publish to the daemon",
+    );
+  }
+}

--- a/assistant/src/ipc/routes/__tests__/events-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/events-ipc-routes.test.ts
@@ -1,10 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
+import { EVENTS_PUBLISH_IPC_METHOD } from "../../../ipc/events-publish-client.js";
 import { assistantEventHub } from "../../../runtime/assistant-event-hub.js";
-import {
-  EVENTS_PUBLISH_IPC_METHOD,
-  handleEventsPublish,
-} from "../events-ipc-routes.js";
+import { handleEventsPublish } from "../events-ipc-routes.js";
 
 describe(`${EVENTS_PUBLISH_IPC_METHOD} IPC route`, () => {
   const disposers: Array<() => void> = [];

--- a/assistant/src/ipc/routes/events-ipc-routes.ts
+++ b/assistant/src/ipc/routes/events-ipc-routes.ts
@@ -23,27 +23,14 @@
 import { z } from "zod";
 
 import { AssistantEventEnvelopeSchema } from "../../api/index.js";
-import {
-  HOST_PROXY_CAPABILITIES,
-  INTERFACE_IDS,
-} from "../../channels/types.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
+import { AssistantEventPublishOptionsSchema } from "../../runtime/assistant-event-publish-options.js";
 import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
-
-/** IPC method name — the raw publish transport other processes call. */
-export const EVENTS_PUBLISH_IPC_METHOD = "/events/publish";
-
-/** Publish targeting/suppression options — see the hub's `publish`. */
-const PublishOptionsSchema = z.object({
-  targetCapability: z.enum(HOST_PROXY_CAPABILITIES).optional(),
-  targetClientId: z.string().optional(),
-  targetInterfaceId: z.enum(INTERFACE_IDS).optional(),
-  excludeClientId: z.string().optional(),
-});
+import { EVENTS_PUBLISH_IPC_METHOD } from "../events-publish-client.js";
 
 const EventsPublishParamsSchema = z.object({
   event: AssistantEventEnvelopeSchema,
-  options: PublishOptionsSchema.optional(),
+  options: AssistantEventPublishOptionsSchema.optional(),
 });
 
 export async function handleEventsPublish({

--- a/assistant/src/plugin-api/__tests__/publish-event-forwarding.test.ts
+++ b/assistant/src/plugin-api/__tests__/publish-event-forwarding.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests the daemon-vs-side-process routing in the event-hub facade (exercised
+ * through {@link publishEvent}).
+ *
+ * In the daemon the event publishes on the local hub; in a side process (where
+ * seq stamping is disabled) the local hub reaches no SSE subscriber, so the
+ * event is forwarded to the daemon over IPC instead. The `host_*` guard must
+ * run before either path. The process-role signal and the IPC forward are
+ * mocked so the test controls the branch without spawning a subprocess.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantEventEnvelope } from "../../api/index.js";
+
+let sideProcess = false;
+const forwardCalls: Array<{
+  event: AssistantEventEnvelope;
+  options: unknown;
+}> = [];
+
+mock.module("../../runtime/process-role.js", () => ({
+  isMainDaemonProcess: () => !sideProcess,
+  markCurrentProcessAsMainDaemon: () => {},
+}));
+
+mock.module("../../ipc/events-publish-client.js", () => ({
+  EVENTS_PUBLISH_IPC_METHOD: "/events/publish",
+  forwardEventPublishToDaemon: async (
+    event: AssistantEventEnvelope,
+    options: unknown,
+  ) => {
+    forwardCalls.push({ event, options });
+  },
+}));
+
+const { assistantEventHub } =
+  await import("../../runtime/assistant-event-hub.js");
+const { publishEvent } = await import("../publish-event.js");
+
+function syncEvent(): AssistantEventEnvelope {
+  return {
+    id: "evt-1",
+    conversationId: "conv-1",
+    emittedAt: "2026-01-01T00:00:00.000Z",
+    message: {
+      type: "sync_changed",
+      tags: ["my-app:items"],
+    } as unknown as AssistantEventEnvelope["message"],
+  };
+}
+
+function collectLocalDeliveries(): {
+  received: AssistantEventEnvelope[];
+  dispose: () => void;
+} {
+  const received: AssistantEventEnvelope[] = [];
+  const sub = assistantEventHub.subscribe({
+    type: "process",
+    callback: (event) => {
+      received.push(event);
+    },
+  });
+  return { received, dispose: () => sub.dispose() };
+}
+
+beforeEach(() => {
+  sideProcess = false;
+  forwardCalls.length = 0;
+});
+
+describe("publishEvent — daemon vs side-process routing", () => {
+  test("in the daemon, publishes on the local hub (no IPC forward)", async () => {
+    sideProcess = false;
+    const local = collectLocalDeliveries();
+    try {
+      await publishEvent(syncEvent());
+    } finally {
+      local.dispose();
+    }
+    expect(local.received).toHaveLength(1);
+    expect(local.received[0].message.type).toBe("sync_changed");
+    expect(forwardCalls).toHaveLength(0);
+  });
+
+  test("in a side process, forwards to the daemon (no local publish)", async () => {
+    sideProcess = true;
+    const local = collectLocalDeliveries();
+    try {
+      await publishEvent(syncEvent());
+    } finally {
+      local.dispose();
+    }
+    expect(forwardCalls).toHaveLength(1);
+    expect(forwardCalls[0].event.message.type).toBe("sync_changed");
+    // The local hub reaches no SSE subscriber in a side process, so nothing is
+    // delivered locally.
+    expect(local.received).toHaveLength(0);
+  });
+
+  test("rejects a host-proxy event before forwarding, even in a side process", async () => {
+    sideProcess = true;
+    const hostEvent: AssistantEventEnvelope = {
+      id: "evt-2",
+      emittedAt: "2026-01-01T00:00:00.000Z",
+      message: {
+        type: "host_bash_request",
+      } as unknown as AssistantEventEnvelope["message"],
+    };
+    await expect(publishEvent(hostEvent)).rejects.toThrow(/host-proxy/);
+    expect(forwardCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/plugin-api/__tests__/publish-event.test.ts
+++ b/assistant/src/plugin-api/__tests__/publish-event.test.ts
@@ -9,7 +9,12 @@ import { describe, expect, test } from "bun:test";
 
 import type { AssistantEventEnvelope } from "../../api/index.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
+import { markCurrentProcessAsMainDaemon } from "../../runtime/process-role.js";
 import { publishEvent } from "../publish-event.js";
+
+// These assertions exercise the daemon-side publish path (local hub delivery),
+// so mark this process the main daemon (otherwise the facade would forward).
+markCurrentProcessAsMainDaemon();
 
 function syncEvent(): AssistantEventEnvelope {
   return {

--- a/assistant/src/plugin-api/event-hub-facade.ts
+++ b/assistant/src/plugin-api/event-hub-facade.ts
@@ -41,11 +41,13 @@
  */
 
 import type { AssistantEventEnvelope } from "../api/index.js";
+import { forwardEventPublishToDaemon } from "../ipc/events-publish-client.js";
 import {
   type AssistantEventFilter,
   type AssistantEventHub,
   assistantEventHub,
 } from "../runtime/assistant-event-hub.js";
+import { isMainDaemonProcess } from "../runtime/process-role.js";
 
 /**
  * The subset of {@link AssistantEventHub} workspace plugins may use. Picking
@@ -165,6 +167,14 @@ export const pluginAssistantEventHub: PluginEventHub = Object.freeze({
       throw new Error(
         `Plugins may not publish daemon-to-client host-proxy control events (type "${blockedType}").`,
       );
+    }
+    // Outside the main daemon (a sidecar worker, the route host) this process's
+    // hub reaches no SSE subscriber, so hand the already-guarded,
+    // wire-canonicalized event to the daemon — it republishes on the hub real
+    // clients subscribe to. The `host_*` guard above runs on both paths (the
+    // daemon's publish route is a raw transport that does not re-check it).
+    if (!isMainDaemonProcess()) {
+      return forwardEventPublishToDaemon(snapshot, snapshotOptions);
     }
     return assistantEventHub.publish(snapshot, snapshotOptions);
   },

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -154,7 +154,7 @@ export { getModelProfiles } from "./model-profiles.js";
 // hub without holding the general hub handle. Route/hook authors surfacing a UI
 // invalidation (e.g. `sync_changed`) import this. Delegates to the same
 // capability-restricted facade, so host-proxy control events stay rejected.
-export type { PublishEventOptions } from "./publish-event.js";
+export type { AssistantEventPublishOptions } from "../runtime/assistant-event-publish-options.js";
 export { publishEvent } from "./publish-event.js";
 // Check whether a model or profile can process image input. Accepts a concrete
 // model id, a profile key, or a `ModelProfileInfo`; a bare string is resolved

--- a/assistant/src/plugin-api/publish-event.ts
+++ b/assistant/src/plugin-api/publish-event.ts
@@ -12,18 +12,15 @@
  *
  * Typical use is a route or hook surfacing a UI-invalidation event (e.g.
  * `sync_changed`) so subscribed clients re-fetch the data that changed.
+ *
+ * Transitional: this is a thin shim over the facade while direct hub access is
+ * deprecated out. Once callers no longer hold the raw `assistantEventHub`
+ * handle, this wrapper is expected to be folded away.
  */
 
 import type { AssistantEventEnvelope } from "../api/index.js";
-import {
-  pluginAssistantEventHub,
-  type PluginEventHub,
-} from "./event-hub-facade.js";
-
-/** Publish options, mirroring the hub's `publish` options (targeting, self-echo suppression). */
-export type PublishEventOptions = NonNullable<
-  Parameters<PluginEventHub["publish"]>[1]
->;
+import type { AssistantEventPublishOptions } from "../runtime/assistant-event-publish-options.js";
+import { pluginAssistantEventHub } from "./event-hub-facade.js";
 
 /**
  * Publish a runtime event to the assistant's event hub. Resolves once fanout to
@@ -33,7 +30,7 @@ export type PublishEventOptions = NonNullable<
  */
 export function publishEvent(
   event: AssistantEventEnvelope,
-  options?: PublishEventOptions,
+  options?: AssistantEventPublishOptions,
 ): Promise<void> {
   return pluginAssistantEventHub.publish(event, options);
 }

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -44,6 +44,7 @@ import type { AssistantEventEnvelope } from "../api/index.js";
 import { appendEventToStream } from "../signals/event-stream.js";
 import { getLogger } from "../util/logger.js";
 import { buildAssistantEvent } from "./assistant-event.js";
+import type { AssistantEventPublishOptions } from "./assistant-event-publish-options.js";
 import { stampAndBuffer } from "./assistant-stream-state.js";
 
 const log = getLogger("assistant-event-hub");
@@ -302,19 +303,7 @@ export class AssistantEventHub {
    */
   async publish(
     event: AssistantEventEnvelope,
-    options?: {
-      targetCapability?: HostProxyCapability;
-      targetClientId?: string;
-      targetInterfaceId?: InterfaceId;
-      /**
-       * Skip the subscriber with this `clientId`. Used for self-echo
-       * suppression on `sync_changed`: the route handler echoes the
-       * originating tab's `X-Vellum-Client-Id` back on the event, and the
-       * hub uses it here to avoid re-delivering the invalidation to the
-       * tab that already mutated its own optimistic state.
-       */
-      excludeClientId?: string;
-    },
+    options?: AssistantEventPublishOptions,
   ): Promise<void> {
     if (event.conversationId) {
       try {

--- a/assistant/src/runtime/assistant-event-publish-options.ts
+++ b/assistant/src/runtime/assistant-event-publish-options.ts
@@ -1,0 +1,31 @@
+/**
+ * Canonical schema + type for the targeting/suppression options accepted by the
+ * assistant event hub's `publish`.
+ *
+ * Kept in its own module so both the in-process consumer (the hub's `publish`
+ * signature) and the wire consumer (the `/events/publish` IPC route's param
+ * validation) reuse one definition instead of drifting apart.
+ */
+
+import { z } from "zod";
+
+import { HOST_PROXY_CAPABILITIES, INTERFACE_IDS } from "../channels/types.js";
+
+export const AssistantEventPublishOptionsSchema = z.object({
+  targetCapability: z.enum(HOST_PROXY_CAPABILITIES).optional(),
+  targetClientId: z.string().optional(),
+  targetInterfaceId: z.enum(INTERFACE_IDS).optional(),
+  /**
+   * Skip the subscriber with this `clientId`. Used for self-echo suppression on
+   * `sync_changed`: the route handler echoes the originating tab's
+   * `X-Vellum-Client-Id` back on the event, and the hub uses it here to avoid
+   * re-delivering the invalidation to the tab that already mutated its own
+   * optimistic state.
+   */
+  excludeClientId: z.string().optional(),
+});
+
+/** Targeting/suppression options for {@link AssistantEventHub.publish}. */
+export type AssistantEventPublishOptions = z.infer<
+  typeof AssistantEventPublishOptionsSchema
+>;

--- a/assistant/src/runtime/process-role.ts
+++ b/assistant/src/runtime/process-role.ts
@@ -1,0 +1,33 @@
+/**
+ * Process-role signal: whether this OS process is the main assistant daemon or
+ * something else (a sidecar worker — the resource monitor, memory jobs worker,
+ * schedule worker, route host — the CLI, a test, …).
+ *
+ * The daemon owns the singletons real clients connect to — the event hub and
+ * its SSE fan-out chief among them. Any other process runs its own disjoint
+ * copies, so anything it publishes locally reaches no client; such code routes
+ * to the live daemon over IPC when {@link isMainDaemonProcess} is false.
+ *
+ * Only the daemon knows it is the daemon: its entrypoint calls
+ * {@link markCurrentProcessAsMainDaemon} once at startup. Every other process
+ * (which never runs that entrypoint) is a non-daemon by default — no per-worker
+ * bookkeeping to keep in sync.
+ */
+
+let mainDaemon = false;
+
+/**
+ * Mark the current process as the main assistant daemon. Called once, early in
+ * the daemon entrypoint (`runDaemon`), before anything can publish an event.
+ */
+export function markCurrentProcessAsMainDaemon(): void {
+  mainDaemon = true;
+}
+
+/**
+ * Whether this is the main assistant daemon process. False everywhere the
+ * daemon entrypoint did not run — sidecar workers, the route host, the CLI.
+ */
+export function isMainDaemonProcess(): boolean {
+  return mainDaemon;
+}


### PR DESCRIPTION
## Prompt / plan

Follow-up to #39082 (adds `publishEvent`), addressing Codex's review + your comments.

**Codex — "forward route events to the daemon hub."** `publishEvent` (via the event-hub facade) published on the *calling process's* hub. In a side process — a sidecar worker, or the route host once `/x/*` handlers run there — that hub has no SSE subscribers, so an event like an app's `sync_changed` resolved but reached nobody.

**Fix:** the facade's `publish` now branches on the **process role**. The main daemon publishes on the local hub; any other process forwards the event to the daemon's `/events/publish` IPC route, which republishes on the hub real clients subscribe to. The `host_*` control-event guard runs **before** the branch, so it protects the forwarded path too (the IPC route is a raw transport that deliberately doesn't re-check it). Forwarding is best-effort — a transport failure is logged, not thrown.

This makes `publishEvent` **safe to invoke from side processes** — the prerequisite before merging the config-removal PR (#39087) that moves `/x/*` handlers into the route host.

### Files
- `runtime/process-role.ts` (new) — `isMainDaemonProcess` / `markCurrentProcessAsMainDaemon`. Only the daemon marks itself (in `runDaemon`); every other process is a non-daemon by default (no per-worker bookkeeping).
- `plugin-api/event-hub-facade.ts` — the daemon-vs-side-process branch, after the guard.
- `ipc/events-publish-client.ts` (new) — `forwardEventPublishToDaemon` + the `/events/publish` method constant (lives here so callers don't pull the route module's dep graph).
- `runtime/assistant-event-publish-options.ts` (new) — one zod schema + `AssistantEventPublishOptions` type, reused by the hub's `publish` signature and the `/events/publish` route (drops the duplicate schema).
- `plugin-api/publish-event.ts` — uses `AssistantEventPublishOptions` directly; transitional-shim note.

Scope: `runConversationTurn` has the same cross-process gap but is a bigger lift — left for a separate change.

### Review rounds addressed
- Process-level check instead of the seq-stamping proxy; **inverted** so only the daemon marks itself (not every worker).
- Reuse the existing zod schema for the publish options.
- Use `AssistantEventPublishOptions` directly; drop the redundant `PublishEventOptions` alias.
- Delete the redundant `EVENTS_PUBLISH_IPC_METHOD` re-export; simplify the forward body to `{ event, options }`.
- Rebased onto latest `main` (adopting the `AssistantEventEnvelope` single-sourcing); conflicts resolved.

## Test plan

- `tsc`, `eslint`, `prettier` (pre-commit + pre-push) — clean.
- New `plugin-api/__tests__/publish-event-forwarding.test.ts` (3): daemon publishes locally (no forward); side process forwards (no local delivery); `host_*` rejected before forwarding.
- New `ipc/__tests__/events-publish-client.test.ts` (3): calls `/events/publish` with the envelope; passes options through; swallows transport failure.
- Existing `plugin-event-hub-facade.test.ts` (12), `publish-event.test.ts` (2), `events-ipc-routes.test.ts` (4), `worker-entrypoint-guards.test.ts` (4) — all pass.

## CLI verb checklist

No new routes — reuses the existing `/events/publish` IPC route; adds a client-side forwarder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FosQeirkpt7G1K2SSbMx1N