### PR TITLE
fix(providers): accept secrets-API wire names as connection credential refs

### DIFF
--- a/assistant/src/providers/inference/__tests__/connections-credential-normalize.test.ts
+++ b/assistant/src/providers/inference/__tests__/connections-credential-normalize.test.ts
@@ -1,0 +1,87 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { migrateCreateProviderConnections } from "../../../persistence/migrations/243-provider-connections.js";
+import { migrateProviderConnectionStatusLabel } from "../../../persistence/migrations/244-provider-connection-status-label.js";
+import { migrateProviderConnectionBaseUrlAndModels } from "../../../persistence/migrations/250-provider-connection-base-url-and-models.js";
+import { migrateDropProviderConnectionStatus } from "../../../persistence/migrations/265-drop-provider-connection-status.js";
+import * as schema from "../../../persistence/schema/index.js";
+import { providerConnections } from "../../../persistence/schema/inference.js";
+import { normalizeCredentialRef } from "../../../security/credential-key.js";
+import { createConnection, getConnection } from "../connections.js";
+
+function bootDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  const db = drizzle(sqlite, { schema });
+  migrateCreateProviderConnections(db);
+  migrateProviderConnectionStatusLabel(db);
+  migrateDropProviderConnectionStatus(db);
+  migrateProviderConnectionBaseUrlAndModels(db);
+  return db;
+}
+
+describe("normalizeCredentialRef", () => {
+  test("maps the secrets-API wire name to the vault key", () => {
+    expect(normalizeCredentialRef("openrouter:api_key")).toBe(
+      "credential/openrouter/api_key",
+    );
+  });
+
+  test("splits compound service names at the last colon", () => {
+    expect(normalizeCredentialRef("integration:google:access_token")).toBe(
+      "credential/integration:google/access_token",
+    );
+  });
+
+  test("leaves vault keys and other refs untouched", () => {
+    expect(normalizeCredentialRef("credential/openrouter/api_key")).toBe(
+      "credential/openrouter/api_key",
+    );
+    expect(normalizeCredentialRef("openrouter")).toBe("openrouter");
+    expect(normalizeCredentialRef("openrouter:")).toBe("openrouter:");
+    expect(normalizeCredentialRef(":api_key")).toBe(":api_key");
+  });
+});
+
+describe("connection credential normalization", () => {
+  test("createConnection stores the vault-key form for a wire-name credential", () => {
+    const db = bootDb();
+    const result = createConnection(db, {
+      name: "openrouter-conn",
+      provider: "openrouter",
+      auth: { type: "api_key", credential: "openrouter:api_key" },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok && result.connection.auth.type === "api_key") {
+      expect(result.connection.auth.credential).toBe(
+        "credential/openrouter/api_key",
+      );
+    }
+  });
+
+  test("getConnection heals a stored wire-name credential without a migration", () => {
+    const db = bootDb();
+    const now = Date.now();
+    db.insert(providerConnections)
+      .values({
+        name: "legacy-openrouter",
+        provider: "openrouter",
+        auth: JSON.stringify({
+          type: "api_key",
+          credential: "openrouter:api_key",
+        }),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    const conn = getConnection(db, "legacy-openrouter");
+    expect(conn).not.toBeNull();
+    if (conn?.auth.type === "api_key") {
+      expect(conn.auth.credential).toBe("credential/openrouter/api_key");
+    }
+  });
+});

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import type { DrizzleDb } from "../../persistence/db-connection.js";
 import { providerConnections } from "../../persistence/schema/inference.js";
+import { normalizeCredentialRef } from "../../security/credential-key.js";
 import { getLogger } from "../../util/logger.js";
 import { clearConnectionProviderCache } from "../registry.js";
 import {
@@ -28,6 +29,21 @@ const log = getLogger("providers/inference/connections");
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Parse an auth value (stored JSON or caller input), normalizing any
+ * credential reference to the vault-key form. Normalizing on read as well as
+ * write heals rows that were stored with the secrets-API wire name (e.g.
+ * `openrouter:api_key`) without a migration.
+ */
+function parseAuth(raw: unknown): Auth | null {
+  const parsed = AuthSchema.safeParse(raw);
+  if (!parsed.success) return null;
+  const auth = parsed.data;
+  return "credential" in auth
+    ? { ...auth, credential: normalizeCredentialRef(auth.credential) }
+    : auth;
+}
 
 function parseModelsColumn(raw: string | null): ConnectionModel[] | null {
   if (raw === null || raw === "") return null;
@@ -56,14 +72,14 @@ export function listConnections(
     : db.select().from(providerConnections).all();
 
   return rows.flatMap((row) => {
-    const auth = AuthSchema.safeParse(JSON.parse(row.auth));
-    if (!auth.success) return [];
+    const auth = parseAuth(JSON.parse(row.auth));
+    if (!auth) return [];
     const provider = ConnectionProviderSchema.safeParse(row.provider);
     if (!provider.success) return [];
     return [
       {
         ...row,
-        auth: auth.data,
+        auth,
         provider: provider.data,
         label: row.label ?? null,
         baseUrl: row.baseUrl ?? null,
@@ -85,13 +101,13 @@ export function getConnection(
     .get();
 
   if (!row) return null;
-  const auth = AuthSchema.safeParse(JSON.parse(row.auth));
-  if (!auth.success) return null;
+  const auth = parseAuth(JSON.parse(row.auth));
+  if (!auth) return null;
   const provider = ConnectionProviderSchema.safeParse(row.provider);
   if (!provider.success) return null;
   return {
     ...row,
-    auth: auth.data,
+    auth,
     provider: provider.data,
     label: row.label ?? null,
     baseUrl: row.baseUrl ?? null,
@@ -152,8 +168,8 @@ export function createConnection(
   // Safe cast: VALID_CONNECTION_PROVIDERS.includes() guards above.
   const provider = input.provider as ConnectionProvider;
 
-  const authResult = AuthSchema.safeParse(input.auth);
-  if (!authResult.success) {
+  const auth = parseAuth(input.auth);
+  if (!auth) {
     return { ok: false, error: { code: "invalid_auth" } };
   }
 
@@ -182,7 +198,7 @@ export function createConnection(
     .values({
       name: input.name,
       provider,
-      auth: JSON.stringify(authResult.data),
+      auth: JSON.stringify(auth),
       label,
       baseUrl,
       models: models === null ? null : JSON.stringify(models),
@@ -200,7 +216,7 @@ export function createConnection(
     connection: {
       name: input.name,
       provider,
-      auth: authResult.data,
+      auth,
       label,
       baseUrl,
       models,
@@ -223,8 +239,8 @@ export function updateConnection(
     return { ok: false, error: { code: "not_found" } };
   }
 
-  const authResult = AuthSchema.safeParse(input.auth);
-  if (!authResult.success) {
+  const auth = parseAuth(input.auth);
+  if (!auth) {
     return { ok: false, error: { code: "invalid_auth" } };
   }
 
@@ -248,7 +264,7 @@ export function updateConnection(
     label?: string | null;
     baseUrl?: string | null;
     models?: string | null;
-  } = { auth: JSON.stringify(authResult.data), updatedAt: now };
+  } = { auth: JSON.stringify(auth), updatedAt: now };
   if (input.label !== undefined) setClause.label = input.label;
   if (input.baseUrl !== undefined) setClause.baseUrl = input.baseUrl;
   if (input.models !== undefined)
@@ -267,7 +283,7 @@ export function updateConnection(
     ok: true,
     connection: {
       ...existing,
-      auth: authResult.data,
+      auth,
       label: input.label !== undefined ? input.label : existing.label,
       baseUrl: nextBaseUrl,
       models: nextModels,

--- a/assistant/src/security/credential-key.ts
+++ b/assistant/src/security/credential-key.ts
@@ -12,3 +12,20 @@
 export function credentialKey(service: string, field: string): string {
   return `credential/${service}/${field}`;
 }
+
+/**
+ * Normalize a credential reference to the vault-key form.
+ *
+ * The secrets API names credentials `{service}:{field}` on the wire (e.g.
+ * `openrouter:api_key`), while the vault stores them as
+ * `credential/{service}/{field}`. Callers routinely reuse the wire name where
+ * a vault key is expected, producing references that never resolve. Map the
+ * wire name to the vault key (same lastIndexOf split the secrets routes use);
+ * leave anything else untouched.
+ */
+export function normalizeCredentialRef(ref: string): string {
+  if (ref.startsWith("credential/")) return ref;
+  const colonIdx = ref.lastIndexOf(":");
+  if (colonIdx < 1 || colonIdx === ref.length - 1) return ref;
+  return credentialKey(ref.slice(0, colonIdx), ref.slice(colonIdx + 1));
+}


### PR DESCRIPTION
## Problem

A provider connection whose `auth.credential` holds the secrets-API wire name (e.g. `openrouter:api_key`) is stored without complaint but can never resolve: the vault key is `credential/openrouter/api_key`, and `resolveAuth` looks the ref up verbatim, so inference fails with `credential_not_found`.

This is an easy state to get into because the wire name is the product's own canonical identifier for the same credential on the secrets side — `assistant credentials set openrouter:api_key`, secret listings, and the oauth CLI all speak `service:field`, while connections expect the vault-key form. Anyone (human or agent) who learns a credential's name from the secrets side and reuses it in a connection produces a row that's dead on arrival. Seen in the wild via a Doctor diagnosis.

## Fix

- `normalizeCredentialRef()` in `security/credential-key.ts` (the declared single source of truth for key format): maps `service:field` to `credential/{service}/{field}` using the same `lastIndexOf(":")` split the secret routes use; leaves `credential/`-prefixed refs and anything else untouched.
- `connections.ts` collapses its four `AuthSchema.safeParse` sites into one `parseAuth()` helper that applies the normalization. Because it runs on both write (`createConnection`/`updateConnection`) and read (`getConnection`/`listConnections`), every writer is covered (routes, CLI, explicit `auth` objects) and existing wire-name rows heal on load — no migration needed.

Deliberately not a zod `.transform()` on `AuthSchema`: the generate-openapi script runs `z.toJSONSchema()` over these schemas and transforms don't survive it.

## Tests

`connections-credential-normalize.test.ts`: wire-name mapping, compound-name last-colon split (`integration:google:access_token`), untouched passthroughs (vault keys, bare names, edge colons), write-time normalization through `createConnection`, and read-time healing of a pre-existing wire-name row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jxg6rVrcc2G6PwZce8BerP
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->