### PR TITLE
feat(risk): activate bash user-rule matching with specificity ordering

### DIFF
--- a/gateway/src/__tests__/bash-risk-classifier.test.ts
+++ b/gateway/src/__tests__/bash-risk-classifier.test.ts
@@ -8,6 +8,7 @@ import {
 import { classifySegment } from "../risk/bash-risk-classifier.js";
 import { DEFAULT_COMMAND_REGISTRY } from "../risk/command-registry/index.js";
 import type { CommandSegment } from "../risk/shell-parser.js";
+import type { UserRule } from "../risk/risk-types.js";
 import "./test-preload.js";
 
 // ---------------------------------------------------------------------------
@@ -272,6 +273,127 @@ describe("risk rule cache integration", () => {
     );
 
     expect(result.risk).toBe("high");
+    expect(result.matchType).toBe("user_rule");
+  });
+
+  // ── Step 1 user-defined short-circuit ──────────────────────────────────────
+
+  test("user-defined rule short-circuits arg-rule escalation", () => {
+    // Use action: prefix so the new row doesn't conflict with the seeded "rm" row.
+    // "rm" is untouched by other tests in this file, so isUserRule(literal) stays
+    // false and findBaseRisk returns the action:rm user_defined rule instead.
+    // Without the short-circuit, rm -rf /tmp would escalate to "high" via arg rules.
+    store.create({
+      tool: "bash",
+      pattern: "action:rm",
+      risk: "low",
+      description: "rm is always safe in this environment",
+    });
+
+    initTrustRuleCache(store);
+
+    const result = classifySegment(
+      segment("rm -rf /tmp/test"),
+      [],
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    // Step 1b short-circuits: user_defined rule bypasses the -rf arg escalation.
+    expect(result.risk).toBe("low");
+    expect(result.matchType).toBe("user_rule");
+  });
+
+  test("user-defined rule specificity: exact action match wins over prefix", () => {
+    // "action:rm /tmp" (exact match at step 1 of findBaseRisk) beats "action:rm"
+    // (prefix walk step 3). Specificity is inherent in the lookup order: exact
+    // before prefix, and longer prefixes before shorter ones in the prefix walk.
+    store.create({
+      tool: "bash",
+      pattern: "action:rm",
+      risk: "high",
+      description: "rm is dangerous",
+    });
+    store.create({
+      tool: "bash",
+      pattern: "action:rm /tmp",
+      risk: "low",
+      description: "rm in /tmp is safe",
+    });
+
+    initTrustRuleCache(store);
+
+    // "rm /tmp" hits the exact action: lookup ("action:rm /tmp") at step 1,
+    // never falling through to the broader prefix "action:rm".
+    const result = classifySegment(
+      segment("rm /tmp"),
+      [],
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    expect(result.risk).toBe("low");
+    expect(result.matchType).toBe("user_rule");
+  });
+
+  test("user-modified default rule does not short-circuit arg-rule escalation", () => {
+    // userModified=true but origin="default": step 4b handles this, not step 1.
+    // Arg rules still apply and can escalate above the user-set base risk.
+    store.update("default:bash:git-push", { risk: "low" });
+
+    initTrustRuleCache(store);
+
+    const result = classifySegment(
+      segment("git push --force"),
+      [],
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    // --force arg rule still escalates through step 4b
+    expect(result.risk).toBe("high");
+  });
+});
+
+// ── userRules param specificity ordering ──────────────────────────────────────
+
+describe("userRules param specificity ordering", () => {
+  beforeEach(() => {
+    resetGatewayDb();
+    resetTrustRuleCache();
+  });
+
+  afterEach(() => {
+    resetTrustRuleCache();
+    resetGatewayDb();
+  });
+
+  test("longer regex pattern wins over shorter when both match", () => {
+    const rules: UserRule[] = [
+      {
+        id: "r1",
+        pattern: "^git",
+        risk: "high",
+        label: "all git high",
+        createdAt: "",
+        source: "manual",
+      },
+      {
+        id: "r2",
+        pattern: "^git push",
+        risk: "low",
+        label: "git push low",
+        createdAt: "",
+        source: "manual",
+      },
+    ];
+
+    // Cache not initialized — only userRules[] param is active in step 1a.
+    const result = classifySegment(
+      segment("git push origin"),
+      rules,
+      DEFAULT_COMMAND_REGISTRY,
+    );
+
+    // "^git push" (length 9) beats "^git" (length 4)
+    expect(result.risk).toBe("low");
     expect(result.matchType).toBe("user_rule");
   });
 });

--- a/gateway/src/__tests__/bash-risk-classifier.test.ts
+++ b/gateway/src/__tests__/bash-risk-classifier.test.ts
@@ -5,7 +5,10 @@ import {
   initTrustRuleCache,
   resetTrustRuleCache,
 } from "../risk/trust-rule-cache.js";
-import { classifySegment } from "../risk/bash-risk-classifier.js";
+import {
+  BashRiskClassifier,
+  classifySegment,
+} from "../risk/bash-risk-classifier.js";
 import { DEFAULT_COMMAND_REGISTRY } from "../risk/command-registry/index.js";
 import type { CommandSegment } from "../risk/shell-parser.js";
 import type { UserRule } from "../risk/risk-types.js";
@@ -349,6 +352,34 @@ describe("risk rule cache integration", () => {
 
     // --force arg rule still escalates through step 4b
     expect(result.risk).toBe("high");
+  });
+
+  test("exact compound-command rule short-circuits at classify() level", async () => {
+    // The "This exact command" allowlist option stores the full raw command
+    // string as the trust-rule pattern (e.g. "rm -rf /tmp && echo done").
+    // classifySegment never sees that full string — it receives each segment
+    // ("rm -rf /tmp" and "echo done") separately. The pre-parse check in
+    // classify() is the only place the exact compound pattern can match.
+    const compound = "rm -rf /tmp && echo done";
+    store.create({
+      tool: "bash",
+      pattern: compound,
+      risk: "low",
+      description: "Approved: clean /tmp then echo done",
+    });
+
+    initTrustRuleCache(store);
+
+    const classifier = new BashRiskClassifier();
+    const result = await classifier.classify({
+      command: compound,
+      toolName: "bash",
+    });
+
+    // Without the classify()-level check, rm -rf would escalate to "high"
+    // via arg rules. The exact user_defined rule must short-circuit first.
+    expect(result.riskLevel).toBe("low");
+    expect(result.matchType).toBe("user_rule");
   });
 });
 

--- a/gateway/src/risk/bash-risk-classifier.ts
+++ b/gateway/src/risk/bash-risk-classifier.ts
@@ -283,14 +283,37 @@ export function classifySegment(
   registry: Record<string, CommandRiskSpec>,
   toolName: "bash" | "host_bash" = "bash",
 ): { risk: Risk; reason: string; matchType: RiskAssessment["matchType"] } {
-  // 1. Check user rules first (highest priority)
-  // TODO: implement user rule matching with specificity ordering.
-  // For now, userRules is always empty so this is a no-op.
-  for (const rule of userRules) {
+  // 1. Check user rules first (highest priority — short-circuits remaining pipeline).
+  // Sort by pattern length descending so more specific regex patterns win.
+  const sortedUserRules = userRules
+    .slice()
+    .sort((a, b) => b.pattern.length - a.pattern.length);
+  for (const rule of sortedUserRules) {
     const re = getCompiledPattern(rule.pattern);
     if (re.test(segment.command)) {
       return { risk: rule.risk, reason: rule.label, matchType: "user_rule" };
     }
+  }
+
+  // 1b. Short-circuit on user-defined trust rules from the cache.
+  // Rules with origin="user_defined" (created by the user) bypass the
+  // classification pipeline entirely, including arg-rule escalation.
+  // Rules with userModified=true (seeded defaults the user adjusted) fall
+  // through to step 4b, which overrides baseRisk while arg rules still apply.
+  try {
+    const cacheRule = getTrustRuleCache().findBaseRisk(
+      toolName,
+      segment.command,
+    );
+    if (cacheRule?.origin === "user_defined") {
+      return {
+        risk: cacheRule.risk,
+        reason: cacheRule.description,
+        matchType: "user_rule",
+      };
+    }
+  } catch {
+    // Cache not initialized (tests / pre-init path) — fall through to registry.
   }
 
   // 2. Look up command in default registry

--- a/gateway/src/risk/bash-risk-classifier.ts
+++ b/gateway/src/risk/bash-risk-classifier.ts
@@ -1008,6 +1008,30 @@ export class BashRiskClassifier implements RiskClassifier<BashClassifierInput> {
       };
     }
 
+    // Pre-parse exact compound-command check.
+    // A compound command like "rm -rf /tmp && echo done" is split into segments
+    // before classifySegment is called, so step 1b inside classifySegment only
+    // sees each half. The "This exact command" allowlist option stores the full
+    // raw string as the trust-rule pattern, making it unreachable per-segment.
+    // Checking here — before cachedParse — is the only place that raw pattern
+    // can match. Only exact user-defined rules are probed (findBaseRisk tries
+    // the literal first, then the action: sibling, then progressively shorter
+    // prefixes); a compound command with && / || / ; only hits the literal step.
+    try {
+      const fullRule = getTrustRuleCache().findBaseRisk(toolName, command);
+      if (fullRule?.origin === "user_defined") {
+        return {
+          riskLevel: fullRule.risk,
+          reason: fullRule.description,
+          scopeOptions: [],
+          matchType: "user_rule",
+          allowlistOptions: [],
+        };
+      }
+    } catch {
+      // Cache not initialized — fall through to per-segment classification.
+    }
+
     const parsed = await cachedParse(command);
 
     let maxRiskLevel: Risk = "low";


### PR DESCRIPTION
Step 1 of classifySegment had a dead loop — userRules is always [] at runtime, and it iterated without sorting. Wire it up and fix both gaps:

- Sort the userRules[] param by pattern length descending so longer (more specific) regex patterns win over broader ones.
- Add step 1b: pull user-defined trust rules (origin="user_defined") from TrustRuleCache and short-circuit the whole pipeline, bypassing arg-rule escalation. User-modified default rules (userModified=true) continue to fall through to step 4b where arg rules still apply.

findBaseRisk() already walks prefixes longest-first, so specificity is built in. The step 1b lookup uses segment.command (full string including flags) so flag-specific user patterns can match before the flag is stripped for the step 4b positional-pattern lookup.

Tests added to the integration suite cover: user-defined short-circuit, exact-match specificity over prefix, and the user-modified-vs-user-defined distinction (modified rules do not short-circuit).

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
