### PR TITLE
refactor(events): make AssistantEvent unambiguous — remove ServerMessage, rename the envelope to AssistantEventEnvelope

### DIFF
--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { VellumAcpClientHandler } from "../acp/client-handler.js";
 import { AcpSessionManager } from "../acp/session-manager.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 
 // ---------------------------------------------------------------------------
@@ -10,8 +10,8 @@ import * as pendingInteractions from "../runtime/pending-interactions.js";
 // ---------------------------------------------------------------------------
 
 describe("VellumAcpClientHandler", () => {
-  let sent: ServerMessage[];
-  let sendToVellum: (msg: ServerMessage) => void;
+  let sent: AssistantEvent[];
+  let sendToVellum: (msg: AssistantEvent) => void;
   let handler: VellumAcpClientHandler;
 
   beforeEach(() => {

--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -11,7 +11,7 @@ import { Minimatch } from "minimatch";
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent } from "../agent/loop.js";
 import type { ConfirmationStateChangedEvent } from "../api/events/confirmation-state-changed.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 import type { ConfirmationDetails } from "../runtime/pending-interactions.js";
 
@@ -188,7 +188,7 @@ function makeProvider() {
 }
 
 function makeConversation(
-  sendToClient?: (msg: ServerMessage) => void,
+  sendToClient?: (msg: AssistantEvent) => void,
   conversationId = CONV_ID,
 ): Conversation {
   return new Conversation(
@@ -257,7 +257,7 @@ beforeEach(() => {
 
 describe("approval cascading", () => {
   test("allow (one-time) does NOT cascade", () => {
-    const emitted: ServerMessage[] = [];
+    const emitted: AssistantEvent[] = [];
     const conversationObj = makeConversation(
       (msg) => emitted.push(msg),
       CONV_ID,
@@ -291,7 +291,7 @@ describe("approval cascading", () => {
   });
 
   test("deny (one-time) does NOT cascade", () => {
-    const emitted: ServerMessage[] = [];
+    const emitted: AssistantEvent[] = [];
     const conversationObj = makeConversation(
       (msg) => emitted.push(msg),
       CONV_ID,
@@ -325,7 +325,7 @@ describe("approval cascading", () => {
   });
 
   test("already-resolved request handled gracefully", () => {
-    const emitted: ServerMessage[] = [];
+    const emitted: AssistantEvent[] = [];
     const conversationObj = makeConversation(
       (msg) => emitted.push(msg),
       CONV_ID,

--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -7,7 +7,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { Conversation } from "../daemon/conversation.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { SecretPromptResult } from "../permissions/secret-prompt-types.js";
 
 mock.module("../config/env.js", () => ({
@@ -123,7 +123,7 @@ function makeIdleSession(opts?: {
     runAgentLoop: async (
       _content: string,
       _messageId: string,
-      options?: { onEvent?: (msg: ServerMessage) => void },
+      options?: { onEvent?: (msg: AssistantEvent) => void },
     ) => {
       const onEvent = options?.onEvent ?? (() => {});
       onEvent({ type: "assistant_text_delta", text: "Hello!" });
@@ -186,7 +186,7 @@ function makeConfirmationEmittingSession(opts?: {
     runAgentLoop: async (
       _content: string,
       _messageId: string,
-      options?: { onEvent?: (msg: ServerMessage) => void },
+      options?: { onEvent?: (msg: AssistantEvent) => void },
     ) => {
       const onEvent = options?.onEvent ?? (() => {});
       // Simulate PermissionPrompter.prompt(): self-register in pendingInteractions

--- a/assistant/src/__tests__/assistant-event-hub-self-exclusion.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub-self-exclusion.test.ts
@@ -14,14 +14,14 @@
  */
 import { describe, expect, test } from "bun:test";
 
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   AssistantEventHub,
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
 
-function makeSyncChangedEvent(originClientId?: string): AssistantEvent {
+function makeSyncChangedEvent(originClientId?: string): AssistantEventEnvelope {
   return {
     id: "evt_test_sync",
     conversationId: undefined,
@@ -37,9 +37,9 @@ function makeSyncChangedEvent(originClientId?: string): AssistantEvent {
 describe("AssistantEventHub — self-echo suppression (excludeClientId)", () => {
   test("skips the named client and delivers to every other client", async () => {
     const hub = new AssistantEventHub();
-    const receivedA: AssistantEvent[] = [];
-    const receivedB: AssistantEvent[] = [];
-    const receivedC: AssistantEvent[] = [];
+    const receivedA: AssistantEventEnvelope[] = [];
+    const receivedB: AssistantEventEnvelope[] = [];
+    const receivedC: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "client",
@@ -82,8 +82,8 @@ describe("AssistantEventHub — self-echo suppression (excludeClientId)", () => 
 
   test("delivers to every subscriber when excludeClientId is omitted", async () => {
     const hub = new AssistantEventHub();
-    const receivedA: AssistantEvent[] = [];
-    const receivedB: AssistantEvent[] = [];
+    const receivedA: AssistantEventEnvelope[] = [];
+    const receivedB: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "client",
@@ -112,7 +112,7 @@ describe("AssistantEventHub — self-echo suppression (excludeClientId)", () => 
 
   test("excludeClientId does not match process-type subscribers", async () => {
     const hub = new AssistantEventHub();
-    const receivedProcess: AssistantEvent[] = [];
+    const receivedProcess: AssistantEventEnvelope[] = [];
 
     // A process subscriber sits in the same hub as a client whose id
     // matches `excludeClientId`. It must never be suppressed because
@@ -134,8 +134,8 @@ describe("AssistantEventHub — self-echo suppression (excludeClientId)", () => 
 
   test("excludeClientId composes with conversation-scoped subscribers", async () => {
     const hub = new AssistantEventHub();
-    const receivedA: AssistantEvent[] = [];
-    const receivedB: AssistantEvent[] = [];
+    const receivedA: AssistantEventEnvelope[] = [];
+    const receivedB: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "client",
@@ -159,7 +159,7 @@ describe("AssistantEventHub — self-echo suppression (excludeClientId)", () => 
     });
 
     // Scoped event for sess_x; both clients filter to sess_x; exclude A.
-    const event: AssistantEvent = {
+    const event: AssistantEventEnvelope = {
       id: "evt_scoped",
       conversationId: "sess_x",
       emittedAt: "2026-05-03T00:00:00.000Z",
@@ -179,8 +179,8 @@ describe("AssistantEventHub — self-echo suppression (excludeClientId)", () => 
 
 describe("broadcastMessage — derives excludeClientId from sync_changed.originClientId", () => {
   test("skips the originating client when originClientId is present", async () => {
-    const receivedA: AssistantEvent[] = [];
-    const receivedB: AssistantEvent[] = [];
+    const receivedA: AssistantEventEnvelope[] = [];
+    const receivedB: AssistantEventEnvelope[] = [];
 
     const subA = assistantEventHub.subscribe({
       type: "client",
@@ -221,8 +221,8 @@ describe("broadcastMessage — derives excludeClientId from sync_changed.originC
   });
 
   test("fans out to every client when originClientId is absent", async () => {
-    const receivedA: AssistantEvent[] = [];
-    const receivedB: AssistantEvent[] = [];
+    const receivedA: AssistantEventEnvelope[] = [];
+    const receivedB: AssistantEventEnvelope[] = [];
 
     const subA = assistantEventHub.subscribe({
       type: "client",
@@ -260,7 +260,7 @@ describe("broadcastMessage — derives excludeClientId from sync_changed.originC
   });
 
   test("ignores an empty-string originClientId (treats as absent)", async () => {
-    const receivedA: AssistantEvent[] = [];
+    const receivedA: AssistantEventEnvelope[] = [];
 
     const subA = assistantEventHub.subscribe({
       type: "client",

--- a/assistant/src/__tests__/assistant-event-hub-targeted.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub-targeted.test.ts
@@ -13,10 +13,12 @@
  */
 import { describe, expect, test } from "bun:test";
 
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
 
-function makeEvent(overrides: Partial<AssistantEvent> = {}): AssistantEvent {
+function makeEvent(
+  overrides: Partial<AssistantEventEnvelope> = {},
+): AssistantEventEnvelope {
   return {
     id: "evt_test",
     conversationId: "sess_web",
@@ -35,8 +37,8 @@ function makeEvent(overrides: Partial<AssistantEvent> = {}): AssistantEvent {
 describe("AssistantEventHub — targeted delivery (targetClientId)", () => {
   test("delivers only to the named client, bypassing conversation filter", async () => {
     const hub = new AssistantEventHub();
-    const receivedA: AssistantEvent[] = [];
-    const receivedB: AssistantEvent[] = [];
+    const receivedA: AssistantEventEnvelope[] = [];
+    const receivedB: AssistantEventEnvelope[] = [];
 
     // client-a is subscribed to "sess_macos" — different from the event's "sess_web"
     hub.subscribe({
@@ -75,8 +77,8 @@ describe("AssistantEventHub — targeted delivery (targetClientId)", () => {
 
   test("does not deliver to a client with a different clientId", async () => {
     const hub = new AssistantEventHub();
-    const receivedA: AssistantEvent[] = [];
-    const receivedB: AssistantEvent[] = [];
+    const receivedA: AssistantEventEnvelope[] = [];
+    const receivedB: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "client",
@@ -106,7 +108,7 @@ describe("AssistantEventHub — targeted delivery (targetClientId)", () => {
 
   test("targeted delivery with wrong capability does not deliver", async () => {
     const hub = new AssistantEventHub();
-    const receivedA: AssistantEvent[] = [];
+    const receivedA: AssistantEventEnvelope[] = [];
 
     // client-a only has host_file capability, NOT host_bash
     hub.subscribe({
@@ -130,7 +132,7 @@ describe("AssistantEventHub — targeted delivery (targetClientId)", () => {
 
   test("targeted delivery with matching capability delivers", async () => {
     const hub = new AssistantEventHub();
-    const receivedA: AssistantEvent[] = [];
+    const receivedA: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "client",
@@ -152,7 +154,7 @@ describe("AssistantEventHub — targeted delivery (targetClientId)", () => {
 
   test("process-type subscriber is never matched by targetClientId", async () => {
     const hub = new AssistantEventHub();
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "process",
@@ -173,8 +175,8 @@ describe("AssistantEventHub — targeted delivery (targetClientId)", () => {
 describe("AssistantEventHub — untargeted capability targeting is unchanged", () => {
   test("targetCapability without targetClientId still applies conversation scoping", async () => {
     const hub = new AssistantEventHub();
-    const receivedA: AssistantEvent[] = [];
-    const receivedB: AssistantEvent[] = [];
+    const receivedA: AssistantEventEnvelope[] = [];
+    const receivedB: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "client",

--- a/assistant/src/__tests__/assistant-event-hub.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   AssistantEventHub,
   broadcastMessage,
@@ -12,7 +12,9 @@ import {
 } from "../runtime/assistant-stream-state.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 
-function makeEvent(overrides: Partial<AssistantEvent> = {}): AssistantEvent {
+function makeEvent(
+  overrides: Partial<AssistantEventEnvelope> = {},
+): AssistantEventEnvelope {
   return {
     id: "evt_test",
     conversationId: "sess_1",
@@ -31,7 +33,7 @@ function makeEvent(overrides: Partial<AssistantEvent> = {}): AssistantEvent {
 describe("AssistantEventHub — fanout", () => {
   test("delivers event to a single matching subscriber", async () => {
     const hub = new AssistantEventHub();
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "process",
@@ -75,8 +77,8 @@ describe("AssistantEventHub — fanout", () => {
 
   test("conversationId filter further restricts delivery", async () => {
     const hub = new AssistantEventHub();
-    const receivedA: AssistantEvent[] = [];
-    const receivedB: AssistantEvent[] = [];
+    const receivedA: AssistantEventEnvelope[] = [];
+    const receivedB: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "process",
@@ -101,7 +103,7 @@ describe("AssistantEventHub — fanout", () => {
 
   test("subscriber without conversationId filter receives all conversations", async () => {
     const hub = new AssistantEventHub();
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "process",
@@ -159,7 +161,7 @@ describe("AssistantEventHub — fanout", () => {
 describe("AssistantEventHub — unsubscribe cleanup", () => {
   test("dispose stops event delivery", async () => {
     const hub = new AssistantEventHub();
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
 
     const s = hub.subscribe({
       type: "process",
@@ -234,8 +236,8 @@ describe("AssistantEventHub — unsubscribe cleanup", () => {
 
   test("disposing one subscription does not affect others", async () => {
     const hub = new AssistantEventHub();
-    const received1: AssistantEvent[] = [];
-    const received2: AssistantEvent[] = [];
+    const received1: AssistantEventEnvelope[] = [];
+    const received2: AssistantEventEnvelope[] = [];
 
     const s1 = hub.subscribe({
       type: "process",
@@ -341,7 +343,7 @@ describe("AssistantEventHub — exception isolation", () => {
 describe("AssistantEventHub — re-entrancy / snapshot isolation", () => {
   test("subscriber added during publish does not receive the in-flight event", async () => {
     const hub = new AssistantEventHub();
-    const lateReceived: AssistantEvent[] = [];
+    const lateReceived: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "process",
@@ -363,7 +365,7 @@ describe("AssistantEventHub — re-entrancy / snapshot isolation", () => {
 
   test("subscriber that disposes itself mid-publish does not affect remaining subscribers", async () => {
     const hub = new AssistantEventHub();
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     let s: ReturnType<typeof hub.subscribe>;
 
     // eslint-disable-next-line prefer-const

--- a/assistant/src/__tests__/assistant-event.test.ts
+++ b/assistant/src/__tests__/assistant-event.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   formatSseFrame,
   formatSseHeartbeat,
@@ -8,9 +8,9 @@ import {
 
 // ── Type / shape tests ────────────────────────────────────────────────────────
 
-describe("AssistantEvent shape", () => {
+describe("AssistantEventEnvelope shape", () => {
   test("accepts a minimal valid event", () => {
-    const event: AssistantEvent = {
+    const event: AssistantEventEnvelope = {
       id: "evt_001",
       emittedAt: "2026-02-18T21:20:00.000Z",
       message: {
@@ -27,7 +27,7 @@ describe("AssistantEvent shape", () => {
   });
 
   test("accepts a full event with conversationId", () => {
-    const event: AssistantEvent = {
+    const event: AssistantEventEnvelope = {
       id: "evt_002",
       conversationId: "conv_456",
       emittedAt: "2026-02-18T21:20:00.000Z",
@@ -45,7 +45,7 @@ describe("AssistantEvent shape", () => {
 // ── SSE framing tests ─────────────────────────────────────────────────────────
 
 describe("formatSseFrame", () => {
-  const baseEvent: AssistantEvent = {
+  const baseEvent: AssistantEventEnvelope = {
     id: "evt_003",
     conversationId: "sess_xyz",
     emittedAt: "2026-02-18T00:00:00.000Z",
@@ -73,7 +73,7 @@ describe("formatSseFrame", () => {
     const dataLine = frame.split("\n").find((l) => l.startsWith("data: "))!;
     const parsed = JSON.parse(
       dataLine.slice("data: ".length),
-    ) as AssistantEvent;
+    ) as AssistantEventEnvelope;
 
     expect(parsed.id).toBe(baseEvent.id);
     expect(parsed.conversationId).toBe(baseEvent.conversationId);
@@ -82,13 +82,16 @@ describe("formatSseFrame", () => {
   });
 
   test("id line uses the event id verbatim", () => {
-    const event: AssistantEvent = { ...baseEvent, id: "unique-evt-id-xyz" };
+    const event: AssistantEventEnvelope = {
+      ...baseEvent,
+      id: "unique-evt-id-xyz",
+    };
     const frame = formatSseFrame(event);
     expect(frame).toContain("id: unique-evt-id-xyz\n");
   });
 
   test("strips newline characters from event.id to prevent SSE frame injection", () => {
-    const event: AssistantEvent = {
+    const event: AssistantEventEnvelope = {
       ...baseEvent,
       id: 'foo\ndata: {"injected":true}',
     };
@@ -113,7 +116,7 @@ describe("formatSseFrame", () => {
   });
 
   test("seq lands in the JSON payload (envelope) when set, never in SSE id", () => {
-    const event: AssistantEvent = {
+    const event: AssistantEventEnvelope = {
       ...baseEvent,
       id: "uuid-event-id",
       seq: 42,

--- a/assistant/src/__tests__/assistant-stream-state.test.ts
+++ b/assistant/src/__tests__/assistant-stream-state.test.ts
@@ -8,7 +8,7 @@ import {
 import { dirname, join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import type {
   EventTargeting,
   ReplaySubscriber,
@@ -26,7 +26,9 @@ import {
 
 const CONV = "conv_test";
 
-function mkEvent(overrides: Partial<AssistantEvent> = {}): AssistantEvent {
+function mkEvent(
+  overrides: Partial<AssistantEventEnvelope> = {},
+): AssistantEventEnvelope {
   const conversationId =
     "conversationId" in overrides ? overrides.conversationId : CONV;
   return {
@@ -39,7 +41,7 @@ function mkEvent(overrides: Partial<AssistantEvent> = {}): AssistantEvent {
       text: "x",
     },
     ...overrides,
-  } as AssistantEvent;
+  } as AssistantEventEnvelope;
 }
 
 describe("assistant-stream-state", () => {

--- a/assistant/src/__tests__/avatar-identity-sync.test.ts
+++ b/assistant/src/__tests__/avatar-identity-sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { ROUTES as AVATAR_ROUTES } from "../runtime/routes/avatar-routes.js";
 import { publishIdentityChanged } from "../runtime/sync/resource-sync-events.js";
@@ -19,7 +19,7 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 
 describe("avatar and identity sync events", () => {
   test("notify_avatar_updated emits legacy avatar event and sync tag", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {
@@ -50,7 +50,7 @@ describe("avatar and identity sync events", () => {
   });
 
   test("identity changes emit legacy identity event and identity sync tags", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {

--- a/assistant/src/__tests__/channel-setup-panel-ack.test.ts
+++ b/assistant/src/__tests__/channel-setup-panel-ack.test.ts
@@ -18,10 +18,13 @@ import {
   type SurfaceConversationContext,
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
-import type { ServerMessage, SurfaceType } from "../daemon/message-protocol.js";
+import type {
+  AssistantEvent,
+  SurfaceType,
+} from "../daemon/message-protocol.js";
 
 function makeContext(
-  sent: ServerMessage[] = [],
+  sent: AssistantEvent[] = [],
   overrides: Partial<SurfaceConversationContext> = {},
 ): SurfaceConversationContext {
   return {
@@ -48,12 +51,12 @@ function makeContext(
   };
 }
 
-function findOpenPanel(sent: ServerMessage[]): OpenPanelEvent | undefined {
+function findOpenPanel(sent: AssistantEvent[]): OpenPanelEvent | undefined {
   return sent.find((msg): msg is OpenPanelEvent => msg.type === "open_panel");
 }
 
 async function waitForOpenPanel(
-  sent: ServerMessage[],
+  sent: AssistantEvent[],
 ): Promise<OpenPanelEvent> {
   for (let i = 0; i < 20 && !findOpenPanel(sent); i++) {
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -65,7 +68,7 @@ async function waitForOpenPanel(
 
 describe("ui_show channel_setup acknowledgment", () => {
   test("emits open_panel with a surfaceId and succeeds once the client acks", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const resultPromise = surfaceProxyResolver(ctx, "ui_show", {
@@ -100,7 +103,7 @@ describe("ui_show channel_setup acknowledgment", () => {
   });
 
   test("returns a tool error when the client nacks", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const resultPromise = surfaceProxyResolver(ctx, "ui_show", {
@@ -120,7 +123,7 @@ describe("ui_show channel_setup acknowledgment", () => {
   });
 
   test("fails closed without emitting when no interactive client is connected", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, { hasNoClient: true });
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -134,7 +137,7 @@ describe("ui_show channel_setup acknowledgment", () => {
   });
 
   test("times out into a tool error when no client acknowledges", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const ack = await openChannelSetupPanel(
@@ -155,7 +158,7 @@ describe("ui_show channel_setup acknowledgment", () => {
   });
 
   test("resolves cancelled when the turn is aborted mid-wait", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
     const controller = new AbortController();
 

--- a/assistant/src/__tests__/chat-reveal-guard-priming.test.ts
+++ b/assistant/src/__tests__/chat-reveal-guard-priming.test.ts
@@ -88,7 +88,7 @@ import {
   createEventHandlerState,
   dispatchAgentEvent,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { _resetStreamStateForTesting } from "../runtime/assistant-stream-state.js";
 import {
   recordForChatMint,
@@ -107,16 +107,16 @@ import {
   SYNTHETIC_OPENAI_PROJECT_KEY,
 } from "./secret-fixtures.js";
 
-function toolResults(events: ServerMessage[]): string[] {
+function toolResults(events: AssistantEvent[]): string[] {
   return events
     .filter(
-      (e): e is Extract<ServerMessage, { type: "tool_result" }> =>
+      (e): e is Extract<AssistantEvent, { type: "tool_result" }> =>
         (e as { type?: string }).type === "tool_result",
     )
     .map((e) => (typeof e.result === "string" ? e.result : ""));
 }
 
-function createMockDeps(collected: ServerMessage[]): EventHandlerDeps {
+function createMockDeps(collected: AssistantEvent[]): EventHandlerDeps {
   return {
     ctx: {
       conversationId: "test-conversation",
@@ -126,7 +126,7 @@ function createMockDeps(collected: ServerMessage[]): EventHandlerDeps {
       markWorkspaceTopLevelDirty: () => {},
       currentTurnSurfaces: [],
     } as unknown as EventHandlerDeps["ctx"],
-    onEvent: (msg: ServerMessage) => {
+    onEvent: (msg: AssistantEvent) => {
       collected.push(msg);
     },
     reqId: "test-req-id",
@@ -146,10 +146,10 @@ function createMockDeps(collected: ServerMessage[]): EventHandlerDeps {
   } as EventHandlerDeps;
 }
 
-function streamedText(events: ServerMessage[]): string {
+function streamedText(events: AssistantEvent[]): string {
   return events
     .filter(
-      (e): e is Extract<ServerMessage, { type: "assistant_text_delta" }> =>
+      (e): e is Extract<AssistantEvent, { type: "assistant_text_delta" }> =>
         (e as { type?: string }).type === "assistant_text_delta",
     )
     .map((e) => e.text)
@@ -182,7 +182,7 @@ beforeEach(() => {
 
 describe("live reveal guard priming barrier", () => {
   test("a text delta dispatched while priming is pending waits for the guard and emits the sentinel", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -223,7 +223,7 @@ describe("live reveal guard priming barrier", () => {
   });
 
   test("a plaintext echo cannot beat the guard onto the wire", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -250,7 +250,7 @@ describe("live reveal guard priming barrier", () => {
   });
 
   test("a denied or failed reveal never reads the store and stays unrevealable", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -308,7 +308,7 @@ describe("live reveal guard priming barrier", () => {
   });
 
   test("a proven reveal primes even when the enclosing command exits non-zero", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -340,7 +340,7 @@ describe("live reveal guard priming barrier", () => {
   });
 
   test("steady-state deltas with no priming in flight emit synchronously", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -354,7 +354,7 @@ describe("live reveal guard priming barrier", () => {
   });
 
   test("a rotate-and-re-reveal in one window guards both served values", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -395,7 +395,7 @@ describe("live reveal guard priming barrier", () => {
 
 describe("reveal stdout redaction on the live tool_result", () => {
   test("an opaque revealed value in the reveal's own stdout is redacted before emit", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -424,7 +424,7 @@ describe("reveal stdout redaction on the live tool_result", () => {
   });
 
   test("buffers the RAW tool result so persist redacts exactly once", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -454,7 +454,7 @@ describe("reveal stdout redaction on the live tool_result", () => {
   });
 
   test("a tool_result that never revealed anything is forwarded unchanged", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -478,10 +478,10 @@ describe("reveal stdout redaction on the live tool_result", () => {
   });
 });
 
-function outputChunks(events: ServerMessage[]): string[] {
+function outputChunks(events: AssistantEvent[]): string[] {
   return events
     .filter(
-      (e): e is Extract<ServerMessage, { type: "tool_output_chunk" }> =>
+      (e): e is Extract<AssistantEvent, { type: "tool_output_chunk" }> =>
         (e as { type?: string }).type === "tool_output_chunk",
     )
     .map((e) => e.chunk);
@@ -489,7 +489,7 @@ function outputChunks(events: ServerMessage[]): string[] {
 
 describe("live tool output chunk redaction", () => {
   test("reveal stdout chunks are redacted before forwarding", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -517,7 +517,7 @@ describe("live tool output chunk redaction", () => {
   });
 
   test("a value split across chunks is held back, then flushed redacted", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -549,7 +549,7 @@ describe("live tool output chunk redaction", () => {
   });
 
   test("a held remainder is DISCARDED at tool_result, never emitted raw", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -587,7 +587,7 @@ describe("live tool output chunk redaction", () => {
   });
 
   test("chunks from a tool with no reveal candidates pass through verbatim", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -608,7 +608,7 @@ describe("live tool output chunk redaction", () => {
   });
 
   test("a later tool echoing an already-promoted value is redacted too", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -662,7 +662,7 @@ describe("for-chat re-mint authority (two legs: staged AND executed)", () => {
   } as Extract<AgentEvent, { type: "tool_result" }>;
 
   test("staged by this run + route-minted: the echoed sentinel re-mints on the live wire", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -694,7 +694,7 @@ describe("for-chat re-mint authority (two legs: staged AND executed)", () => {
     // same identity. That mint passes the watermark and staging checks but
     // carries the OTHER conversation's nonce, so it grants nothing here
     // and the echoed sentinel neutralizes like any forgery.
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -721,7 +721,7 @@ describe("for-chat re-mint authority (two legs: staged AND executed)", () => {
     // other conversation's mint lands later. This run's own mint must
     // still re-mint its echoed sentinel — an identity-only dedupe in the
     // registry would have dropped it in favor of the foreign-nonce record.
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -750,7 +750,7 @@ describe("for-chat re-mint authority (two legs: staged AND executed)", () => {
   });
 
   test("a mint alone — identity never staged by this run — neutralizes", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 
@@ -771,7 +771,7 @@ describe("for-chat re-mint authority (two legs: staged AND executed)", () => {
   });
 
   test("staging alone — a quoted command that never executed — neutralizes", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const state = createEventHandlerState();
     const deps = createMockDeps(events);
 

--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent } from "../agent/loop.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
@@ -233,7 +233,7 @@ function makeProvider() {
 }
 
 function makeConversation(
-  collected: ServerMessage[],
+  collected: AssistantEvent[],
   id = "conv-compact-events",
 ): Conversation {
   return new Conversation(
@@ -254,7 +254,7 @@ function makeConversation(
 
 describe("forceCompact event emission", () => {
   test("emits context_compacted and a usage_update without contextWindow when compacted", async () => {
-    const collected: ServerMessage[] = [];
+    const collected: AssistantEvent[] = [];
     mockCompactResult = {
       messages: [],
       compacted: true,
@@ -279,7 +279,7 @@ describe("forceCompact event emission", () => {
     );
     expect(compactedEvents.length).toBe(1);
     const compactedEvent = compactedEvents[0] as Extract<
-      ServerMessage,
+      AssistantEvent,
       { type: "context_compacted" }
     >;
     expect(compactedEvent.conversationId).toBe("conv-compact-events");
@@ -298,7 +298,7 @@ describe("forceCompact event emission", () => {
     const usageEvents = collected.filter((m) => m.type === "usage_update");
     expect(usageEvents.length).toBe(1);
     const usageEvent = usageEvents[0] as Extract<
-      ServerMessage,
+      AssistantEvent,
       { type: "usage_update" }
     >;
     // `context_compacted` is now the single source of truth for the UI
@@ -312,7 +312,7 @@ describe("forceCompact event emission", () => {
   });
 
   test("emits context_compacted even when summary LLM was skipped (truncation-only path)", async () => {
-    const collected: ServerMessage[] = [];
+    const collected: AssistantEvent[] = [];
     mockCompactResult = {
       messages: [],
       compacted: true,
@@ -342,7 +342,7 @@ describe("forceCompact event emission", () => {
     );
     expect(compactedEvents.length).toBe(1);
     const compactedEvent = compactedEvents[0] as Extract<
-      ServerMessage,
+      AssistantEvent,
       { type: "context_compacted" }
     >;
     expect(compactedEvent.conversationId).toBe("conv-compact-trunc");
@@ -356,7 +356,7 @@ describe("forceCompact event emission", () => {
   });
 
   test("skips emission when compacted is false", async () => {
-    const collected: ServerMessage[] = [];
+    const collected: AssistantEvent[] = [];
     mockCompactResult = {
       messages: [],
       compacted: false,

--- a/assistant/src/__tests__/config-sounds-sync.test.ts
+++ b/assistant/src/__tests__/config-sounds-sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import {
   publishConfigChanged,
@@ -22,7 +22,7 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 
 describe("config and sounds sync events", () => {
   test("config changes emit legacy config event and sync tag", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {
@@ -48,7 +48,7 @@ describe("config and sounds sync events", () => {
   });
 
   test("sounds config changes emit legacy sounds event and sync tag", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {
@@ -74,7 +74,7 @@ describe("config and sounds sync events", () => {
   });
 
   test("schedule changes emit a sync tag", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {

--- a/assistant/src/__tests__/conversation-agent-loop-disk-pressure.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-disk-pressure.test.ts
@@ -4,7 +4,7 @@ import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentLoop } from "../agent/loop.js";
 import type { Conversation } from "../daemon/conversation.js";
 import type { DiskPressureStatus } from "../daemon/disk-pressure-guard.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 
 type Context = Conversation;
 
@@ -157,7 +157,7 @@ describe("runAgentLoopImpl disk pressure gate", () => {
   });
 
   test("blocks background turns inside the cleanup-safe finally path", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const activityStates: unknown[][] = [];
     const drainQueue = mock(async (_reason: unknown) => {});
     const ctx = makeCtx({

--- a/assistant/src/__tests__/conversation-agent-loop-fatal-cleanup.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-fatal-cleanup.test.ts
@@ -19,7 +19,7 @@ import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentLoop } from "../agent/loop.js";
 import type { Conversation } from "../daemon/conversation.js";
 import type { DiskPressureStatus } from "../daemon/disk-pressure-guard.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { setConfig } from "./helpers/set-config.js";
 
 // Short turn-boundary commit wait and no second-pass retitling keep the loop
@@ -157,7 +157,7 @@ describe("runAgentLoopImpl fatal-failure cleanup (ATL-1009)", () => {
   });
 
   test("clears the processing flag before the turn-boundary commit, so a commit that throws cannot latch it", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     // The turn-boundary commit throwing inside the `finally` is precisely the
     // ATL-1007 failure mode. Because the flag is cleared first, the throw can
     // no longer leave `processing_started_at` latched.
@@ -188,7 +188,7 @@ describe("runAgentLoopImpl fatal-failure cleanup (ATL-1009)", () => {
   });
 
   test("clears the processing flag on a clean fatal failure (commit succeeds)", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const drainQueue = mock(async (_reason: unknown) => {});
     const commitTurnChanges = mock(async () => {});
     const ctx = makeCtx({

--- a/assistant/src/__tests__/conversation-agent-loop-handlers-max-tokens.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-handlers-max-tokens.test.ts
@@ -6,11 +6,11 @@ import {
   type EventHandlerDeps,
   handleMaxTokensReached,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 
 describe("max tokens reached handler", () => {
   test("emits and stores an inline continuation card", () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = {
       conversationId: "conv-1",
       surfaceState: new Map(),
@@ -18,7 +18,7 @@ describe("max tokens reached handler", () => {
     };
     const deps = {
       ctx,
-      onEvent: (msg: ServerMessage) => sent.push(msg),
+      onEvent: (msg: AssistantEvent) => sent.push(msg),
       reqId: "req-1",
       isFirstMessage: false,
       shouldGenerateTitle: false,
@@ -40,7 +40,7 @@ describe("max tokens reached handler", () => {
 
     const show = sent.find((msg) => msg.type === "ui_surface_show");
     expect(show).toBeDefined();
-    if (!show || show.type !== "ui_surface_show") return;
+    if (!show || show.type !== "ui_surface_show") {return;}
 
     expect(show.surfaceType).toBe("card");
     expect((show.data as { title?: unknown }).title).toBe(

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -15,7 +15,7 @@ import { createRequire } from "node:module";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { LoopToolExecutor } from "../agent/loop.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import type { Message, Provider, ToolDefinition } from "../providers/types.js";
 import { ContextOverflowError } from "../providers/types.js";
@@ -763,7 +763,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   test.todo(
     "context too large after progress triggers compaction retry instead of immediate failure",
     async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       let reducerCalled = false;
 
       mockReducerStepFn = (msgs: Message[]) => {
@@ -848,7 +848,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   // loop calibrates the estimator from the rejection and drives the reduction
   // ladder on the next gate pass, recovering before the rerun.
   test("overflow recovery compacts below limit even when estimation underestimates", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     let reducerCalled = false;
 
     // GIVEN the estimator reports 185k and the context manager's compaction
@@ -929,7 +929,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   test.todo(
     "forced compaction targets a lower budget when estimation has been inaccurate",
     async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       let capturedTargetTokens: number | undefined;
 
       // Estimator says 185k (below 190k budget = 200k * 0.95)
@@ -1017,7 +1017,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   test.todo(
     "overflow recovery succeeds for 75+ message conversation with many tool calls",
     async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const longHistory = buildLongConversation(75);
       let reducerCalled = false;
 
@@ -1099,7 +1099,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   test.todo(
     "exhausted reducer tiers with progress still attempts emergency compaction",
     async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       let emergencyCompactCalled = false;
 
       // Start with reducer already exhausted
@@ -1206,7 +1206,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   test.todo(
     "onCheckpoint yields when token estimate exceeds mid-loop budget threshold",
     async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       let compactionCalled = false;
 
       // estimatePromptTokens is called:
@@ -1307,7 +1307,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   test.todo(
     "mid-loop budget check prevents context_too_large when tools produce large results",
     async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       let compactionCalled = false;
 
       // Budget = 200_000 * 0.95 = 190_000
@@ -1430,7 +1430,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   test("ladder escalation ends the turn with context_too_large when exhausted", async () => {
     // GIVEN an estimate below the mid-loop threshold, so only the provider's
     // rejection — not the proactive gate — drives recovery
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     mockEstimateTokens = 100_000;
 
     // AND a ladder that reduces on the first rung and reports exhaustion on
@@ -1497,7 +1497,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
    */
   test("single-rung recovery succeeds and the turn continues in place", async () => {
     // GIVEN an estimate below the mid-loop threshold
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     mockEstimateTokens = 100_000;
 
     // AND a ladder rung that reduces without reporting exhaustion
@@ -1554,7 +1554,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
    */
   test("multi-rung escalation recovers when a later rung fits", async () => {
     // GIVEN an estimate below the mid-loop threshold
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     mockEstimateTokens = 100_000;
 
     // AND a ladder that reduces further on each successive rung
@@ -1619,7 +1619,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
    */
   test("budget_yield_unrecovered: classified error emitted, persisted, and stamped", async () => {
     // GIVEN an estimate below the mid-loop threshold
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     mockEstimateTokens = 100_000;
 
     // AND a ladder whose terminal rung applies `auto_compress_latest_turn` and

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -16,7 +16,7 @@ import {
   queueConversationNotice,
   resetConversationNoticesForTests,
 } from "../daemon/conversation-notices.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getConversationDirName } from "../persistence/conversation-directories.js";
 import type { UserPromptSubmitContext } from "../plugin-api/types.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
@@ -1017,7 +1017,7 @@ describe("session-agent-loop", () => {
         },
       });
 
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const ctx = makeCtx({ providerResponses: [textResponse("ok")] });
       const runSpy = spyOn(ctx.agentLoop, "run");
 
@@ -1041,7 +1041,7 @@ describe("session-agent-loop", () => {
 
   describe("conversation notices", () => {
     test("emits queued billing notices after a successful turn", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const ctx = makeCtx({ providerResponses: [textResponse("ok")] });
       queueConversationNotice(ctx.conversationId, "memory-v3-test", {
         source: "memory_v3",
@@ -1078,7 +1078,7 @@ describe("session-agent-loop", () => {
       resolveAssistantAttachmentsMock.mockImplementation(async () => {
         throw new Error("attachment resolution failed");
       });
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const ctx = makeCtx({ providerResponses: [textResponse("ok")] });
       queueConversationNotice(ctx.conversationId, "memory-v3-test", {
         source: "memory_v3",
@@ -1289,7 +1289,7 @@ describe("session-agent-loop", () => {
         action: "block",
         reason: "trusted-contact",
       };
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const activityStates: unknown[][] = [];
       const ctx = makeCtx({
         emitActivityState: (...args: unknown[]) => {
@@ -1361,7 +1361,7 @@ describe("session-agent-loop", () => {
 
   describe("tool execution errors via agent loop", () => {
     test("error events from agent loop are classified and emitted", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       // The model calls a tool whose executor throws, surfacing an `error`
       // event from the loop's catch handler.
@@ -1380,7 +1380,7 @@ describe("session-agent-loop", () => {
     });
 
     test("non-error agent loop completion does not emit conversation_error", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       const ctx = makeCtx({
         providerResponses: [textResponse("All good")],
@@ -1398,7 +1398,7 @@ describe("session-agent-loop", () => {
 
   describe("LLM request log persistence", () => {
     test("record request log captures the actual provider name", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const rawRequest = {
         model: "gpt-4.1",
         messages: [{ role: "user", content: "Hello" }],
@@ -1508,7 +1508,7 @@ describe("session-agent-loop", () => {
     });
 
     test("record request log handles Responses API shaped payloads", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const rawRequest = {
         model: "gpt-5.4",
         instructions: "Be helpful.",
@@ -1571,7 +1571,7 @@ describe("session-agent-loop", () => {
 
   describe("usage accounting", () => {
     test("records the actual provider for usage accounting", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       const ctx = makeCtx({
         providerResponses: [
@@ -1627,7 +1627,7 @@ describe("session-agent-loop", () => {
     });
 
     test("persists the served model onto the assistant row's metadata at finalize", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       const ctx = makeCtx({
         providerResponses: [
@@ -1654,7 +1654,7 @@ describe("session-agent-loop", () => {
 
   describe("checkpoint handoff (infinite loop prevention)", () => {
     test("yields at checkpoint when canHandoffAtCheckpoint returns true", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       // A tool turn drives the loop to its first mid-loop checkpoint, where the
       // orchestrator yields for a queued handoff.
@@ -1682,7 +1682,7 @@ describe("session-agent-loop", () => {
     });
 
     test("continues when canHandoffAtCheckpoint returns false", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       // The tool turn reaches a checkpoint, but with handoff disabled the loop
       // continues to the next turn and completes normally.
@@ -1717,7 +1717,7 @@ describe("session-agent-loop", () => {
 
   describe("user cancellation", () => {
     test("emits generation_cancelled when abort signal fires", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const abortController = new AbortController();
 
       // The provider completes its response but the user cancels mid-turn, so
@@ -1739,7 +1739,7 @@ describe("session-agent-loop", () => {
     });
 
     test("handles AbortError thrown from agent loop as user cancellation", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const abortController = new AbortController();
 
       // The provider rejects with an AbortError after the user cancels.
@@ -1764,7 +1764,7 @@ describe("session-agent-loop", () => {
     });
 
     test("skips resolveAssistantAttachments when cancelled", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const abortController = new AbortController();
       resolveAssistantAttachmentsMock.mockClear();
 
@@ -1821,7 +1821,7 @@ describe("session-agent-loop", () => {
 
     test("clears state and surfaces a processing error when the provider call fails", async () => {
       // GIVEN a real loop whose provider rejects with an unexpected error
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const ctx = makeCtx({
         loopProvider: {
           name: "mock-provider",
@@ -1868,7 +1868,7 @@ describe("session-agent-loop", () => {
       // GIVEN a provider whose call wedges: it acknowledges the user cancel
       // (aborts the signal) but its promise never settles and never observes
       // the signal — the exact condition that latched `processing` true.
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const abortController = new AbortController();
       let drainReason: string | undefined;
       // The provider's call wedges on this promise. It settles only on test
@@ -1925,7 +1925,7 @@ describe("session-agent-loop", () => {
 
   describe("stale pending surface cleanup", () => {
     test("auto-completes non-dynamic_page pending surfaces on regular user message", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       const ctx = makeCtx();
       // Pre-populate a stale pending table surface
@@ -1956,7 +1956,7 @@ describe("session-agent-loop", () => {
     });
 
     test("does not auto-complete surfaces when request is a surface action", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       const ctx = makeCtx();
       ctx.pendingSurfaceActions.set("active-table-1", { surfaceType: "table" });
@@ -1982,7 +1982,7 @@ describe("session-agent-loop", () => {
     });
 
     test("no-op when no pending surfaces exist", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       const ctx = makeCtx();
       // No pending surfaces
@@ -1998,7 +1998,7 @@ describe("session-agent-loop", () => {
     });
 
     test("does not auto-complete surfaces for internal/subagent turns (no isUserMessage)", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       const ctx = makeCtx();
       ctx.pendingSurfaceActions.set("active-table-1", { surfaceType: "table" });
@@ -2024,7 +2024,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx();
       ctx.pendingSurfaceActions.set("stale-table-1", { surfaceType: "table" });
 
-      const throwingOnEvent = (msg: ServerMessage) => {
+      const throwingOnEvent = (msg: AssistantEvent) => {
         _eventCount++;
         if (msg.type === "ui_surface_complete") {
           throw new Error("onEvent sink failed");
@@ -2130,7 +2130,7 @@ describe("session-agent-loop", () => {
         throw new Error("simulated DB failure");
       });
 
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const ctx = makeCtx();
 
       // Should not throw; agent loop continues and emits message_complete.
@@ -2145,7 +2145,7 @@ describe("session-agent-loop", () => {
 
   describe("error-only response with no assistant text", () => {
     test("synthesizes error assistant message when provider returns no response", async () => {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       // GIVEN a real loop whose provider rejects with a generic error
       // (non-ordering, non-context-too-large) so the loop emits `error` and
@@ -2179,7 +2179,7 @@ describe("session-agent-loop", () => {
       // its `llm_request_logs` row orphaned. Without the backfill call in
       // the synthetic-message branch, a later turn's `handleMessageComplete`
       // sweep would wrong-attach this row to the wrong assistant message.
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       // GIVEN a real loop whose provider rejects: the loop emits
       // `provider_error` (writing an `llm_request_logs` row with
@@ -2225,7 +2225,7 @@ describe("session-agent-loop", () => {
         retryable: false,
         errorCategory: "managed_key_invalid",
       };
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       const ctx = makeCtx({
         loopProvider: {
@@ -2351,7 +2351,7 @@ describe("session-agent-loop", () => {
         metadata: null,
       };
 
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       let messageCompleteSeenWhenIndexed: boolean | undefined;
       indexMessageNowMock.mockImplementationOnce(async () => {
         messageCompleteSeenWhenIndexed = events.some(
@@ -3370,7 +3370,7 @@ describe("session-agent-loop", () => {
 
     test("applyCompactionResult records Slack timestamp watermark when provided", async () => {
       const ctx = makeCtx();
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
 
       await applyCompactionResult(
         ctx,

--- a/assistant/src/__tests__/conversation-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/conversation-confirmation-signals.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent } from "../agent/loop.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -176,7 +176,7 @@ function makeProvider() {
 }
 
 function makeConversation(
-  sendToClient?: (msg: ServerMessage) => void,
+  sendToClient?: (msg: AssistantEvent) => void,
 ): Conversation {
   return new Conversation(
     "conv-signals-test",
@@ -212,7 +212,7 @@ function seedPendingConfirmation(
 
 describe("centralized confirmation emissions", () => {
   test("handleConfirmationResponse emits confirmation_state_changed with approved state for allow decision", () => {
-    const emitted: ServerMessage[] = [];
+    const emitted: AssistantEvent[] = [];
     const conversation = makeConversation((msg) => emitted.push(msg));
 
     seedPendingConfirmation(conversation, "req-allow-1");
@@ -240,7 +240,7 @@ describe("centralized confirmation emissions", () => {
   });
 
   test("handleConfirmationResponse emits confirmation_state_changed with denied state for deny decision", () => {
-    const emitted: ServerMessage[] = [];
+    const emitted: AssistantEvent[] = [];
     const conversation = makeConversation((msg) => emitted.push(msg));
 
     seedPendingConfirmation(conversation, "req-deny-1");
@@ -264,7 +264,7 @@ describe("centralized confirmation emissions", () => {
   });
 
   test("handleConfirmationResponse emits assistant_activity_state with thinking phase", () => {
-    const emitted: ServerMessage[] = [];
+    const emitted: AssistantEvent[] = [];
     const conversation = makeConversation((msg) => emitted.push(msg));
 
     seedPendingConfirmation(conversation, "req-activity-1");
@@ -287,7 +287,7 @@ describe("centralized confirmation emissions", () => {
   });
 
   test("handleConfirmationResponse passes emissionContext source", () => {
-    const emitted: ServerMessage[] = [];
+    const emitted: AssistantEvent[] = [];
     const conversation = makeConversation((msg) => emitted.push(msg));
 
     seedPendingConfirmation(conversation, "req-ctx-1");
@@ -314,7 +314,7 @@ describe("centralized confirmation emissions", () => {
 
 describe("activity version ordering", () => {
   test("emitActivityState produces monotonically increasing activityVersion", () => {
-    const emitted: ServerMessage[] = [];
+    const emitted: AssistantEvent[] = [];
     const conversation = makeConversation((msg) => emitted.push(msg));
 
     conversation.emitActivityState("thinking", "message_dequeued");
@@ -326,7 +326,7 @@ describe("activity version ordering", () => {
 
     const activityMsgs = emitted.filter(
       (m) => m.type === "assistant_activity_state",
-    ) as Array<ServerMessage & { activityVersion: number }>;
+    ) as Array<AssistantEvent & { activityVersion: number }>;
 
     expect(activityMsgs).toHaveLength(4);
 
@@ -342,7 +342,7 @@ describe("activity version ordering", () => {
   });
 
   test("handleConfirmationResponse increments activityVersion for its activity emission", () => {
-    const emitted: ServerMessage[] = [];
+    const emitted: AssistantEvent[] = [];
     const conversation = makeConversation((msg) => emitted.push(msg));
 
     // Emit a baseline activity state
@@ -350,7 +350,7 @@ describe("activity version ordering", () => {
 
     const baselineMsg = emitted.find(
       (m) => m.type === "assistant_activity_state",
-    ) as ServerMessage & { activityVersion: number };
+    ) as AssistantEvent & { activityVersion: number };
     const baselineVersion = baselineMsg.activityVersion;
 
     // Now handle a confirmation
@@ -359,7 +359,7 @@ describe("activity version ordering", () => {
 
     const activityMsgs = emitted.filter(
       (m) => m.type === "assistant_activity_state",
-    ) as Array<ServerMessage & { activityVersion: number; reason: string }>;
+    ) as Array<AssistantEvent & { activityVersion: number; reason: string }>;
 
     // The confirmation_resolved activity message should have a higher version
     const resolvedMsg = activityMsgs.find(
@@ -372,7 +372,7 @@ describe("activity version ordering", () => {
 
 describe("sendToClient receives state signals", () => {
   test("emitActivityState delivers to sendToClient", () => {
-    const clientMsgs: ServerMessage[] = [];
+    const clientMsgs: AssistantEvent[] = [];
     const conversation = makeConversation((msg) => clientMsgs.push(msg));
 
     conversation.emitActivityState("thinking", "message_dequeued");
@@ -383,7 +383,7 @@ describe("sendToClient receives state signals", () => {
   });
 
   test("emitConfirmationStateChanged delivers to sendToClient", () => {
-    const clientMsgs: ServerMessage[] = [];
+    const clientMsgs: AssistantEvent[] = [];
     const conversation = makeConversation((msg) => clientMsgs.push(msg));
 
     conversation.emitConfirmationStateChanged({
@@ -399,7 +399,7 @@ describe("sendToClient receives state signals", () => {
   });
 
   test("handleConfirmationResponse delivers state signals to sendToClient", () => {
-    const clientMsgs: ServerMessage[] = [];
+    const clientMsgs: AssistantEvent[] = [];
     const conversation = makeConversation((msg) => clientMsgs.push(msg));
 
     seedPendingConfirmation(conversation, "req-signal-confirm");

--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -652,7 +652,7 @@ describe("web_search_tool_result structural guard", () => {
     // provider, not the local tool executor, so they never flow here.
     "agent/loop.ts",
 
-    // Matches the `tool_result` ServerMessage SSE event (api/events/
+    // Matches the `tool_result` AssistantEvent SSE event (api/events/
     // tool-result.ts), not a conversation content block. There is no
     // web_search_tool_result SSE event — web-search activity travels as
     // activityMetadata on the same tool_result event. Same event-vs-block

--- a/assistant/src/__tests__/conversation-key-store-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-key-store-disk-view.test.ts
@@ -21,7 +21,7 @@ import {
   conversationKeys,
   conversations,
 } from "../persistence/schema/index.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   _resetStreamStateForTesting,
   _simulateRestartForTesting,
@@ -87,7 +87,7 @@ describe("conversation-key-store disk view", () => {
     // /messages for their entire first turn — the anchor-less snapshot that
     // let mid-turn refetches wipe streamed transcript content on clients.
     _resetStreamStateForTesting();
-    const event: AssistantEvent = {
+    const event: AssistantEventEnvelope = {
       id: "seed-evt",
       conversationId: "other-conversation",
       emittedAt: new Date().toISOString(),
@@ -95,7 +95,7 @@ describe("conversation-key-store disk view", () => {
         type: "assistant_text_delta",
         conversationId: "other-conversation",
         text: "x",
-      } as AssistantEvent["message"],
+      } as AssistantEventEnvelope["message"],
     };
     stampAndBuffer(event);
     const baseline = getCurrentSeq();
@@ -116,7 +116,7 @@ describe("conversation-key-store disk view", () => {
     // its ceiling — a conversation created before the first stamp must seed
     // from that ceiling, not report NULL as if the assistant were brand new.
     _resetStreamStateForTesting();
-    const event: AssistantEvent = {
+    const event: AssistantEventEnvelope = {
       id: "restart-evt",
       conversationId: "other-conversation",
       emittedAt: new Date().toISOString(),
@@ -124,7 +124,7 @@ describe("conversation-key-store disk view", () => {
         type: "assistant_text_delta",
         conversationId: "other-conversation",
         text: "x",
-      } as AssistantEvent["message"],
+      } as AssistantEventEnvelope["message"],
     };
     stampAndBuffer(event);
     _simulateRestartForTesting();

--- a/assistant/src/__tests__/conversation-loop-db-lock-resilience.test.ts
+++ b/assistant/src/__tests__/conversation-loop-db-lock-resilience.test.ts
@@ -48,9 +48,9 @@ mock.module("../persistence/conversation-crud.js", () => ({
     id: role === "user" ? "tool-result-row" : "assistant-row",
   }),
   recordConversationPersistedSeq: (id: string, seq: number) => {
-    if (!Number.isFinite(seq) || seq <= 0) return;
+    if (!Number.isFinite(seq) || seq <= 0) {return;}
     const prev = persistedSeqByConversation.get(id);
-    if (prev == null || prev < seq) persistedSeqByConversation.set(id, seq);
+    if (prev == null || prev < seq) {persistedSeqByConversation.set(id, seq);}
   },
   getConversationPersistedSeq: (id: string) =>
     persistedSeqByConversation.get(id) ?? null,
@@ -86,7 +86,7 @@ import {
   createEventHandlerState,
   handleMessageComplete,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getConversationPersistedSeq } from "../persistence/conversation-crud.js";
 
 const CONVERSATION_ID = "test-session-id";
@@ -101,7 +101,7 @@ function createMockDeps(): EventHandlerDeps {
       markWorkspaceTopLevelDirty: () => {},
       currentTurnSurfaces: [],
     } as unknown as EventHandlerDeps["ctx"],
-    onEvent: (_msg: ServerMessage) => {},
+    onEvent: (_msg: AssistantEvent) => {},
     reqId: "test-req-id",
     isFirstMessage: false,
     shouldGenerateTitle: false,

--- a/assistant/src/__tests__/conversation-message-sync-tags.test.ts
+++ b/assistant/src/__tests__/conversation-message-sync-tags.test.ts
@@ -4,7 +4,7 @@ import {
   conversationMessagesSyncTag,
   type SyncChangedEvent,
 } from "../daemon/message-types/sync.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   assistantEventHub,
   broadcastMessage,
@@ -15,8 +15,8 @@ import { waitFor } from "./helpers/wait-for.js";
 async function captureEvents(
   action: () => void | Promise<unknown>,
   expectedCount: number,
-): Promise<AssistantEvent[]> {
-  const received: AssistantEvent[] = [];
+): Promise<AssistantEventEnvelope[]> {
+  const received: AssistantEventEnvelope[] = [];
   const subscription = assistantEventHub.subscribe({
     type: "process",
     callback: (event) => {
@@ -34,7 +34,7 @@ async function captureEvents(
   }
 }
 
-function syncMessages(events: AssistantEvent[]): SyncChangedEvent[] {
+function syncMessages(events: AssistantEventEnvelope[]): SyncChangedEvent[] {
   return events
     .map((event) => event.message)
     .filter(

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -9,7 +9,7 @@ import type {
   CheckpointInfo,
   ExitReason,
 } from "../agent/loop.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 import { stampAndBuffer } from "../runtime/assistant-stream-state.js";
 import { setConfig } from "./helpers/set-config.js";
@@ -376,7 +376,7 @@ type ConversationWithWorkspaceDeps = Conversation & {
 };
 
 function makeConversation(
-  sendToClient?: (msg: ServerMessage) => void,
+  sendToClient?: (msg: AssistantEvent) => void,
 ): Conversation {
   const provider = {
     name: "mock",
@@ -504,8 +504,8 @@ describe("Conversation message queue", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const events2: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const events2: AssistantEvent[] = [];
 
     // Start first message — this will block on AgentLoop.run
     const p1 = conversation.processMessage({
@@ -553,9 +553,9 @@ describe("Conversation message queue", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const events2: ServerMessage[] = [];
-    const events3: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const events2: AssistantEvent[] = [];
+    const events3: AssistantEvent[] = [];
 
     // Start first message
     const p1 = conversation.processMessage({
@@ -673,7 +673,7 @@ describe("Conversation message queue", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events2: ServerMessage[] = [];
+    const events2: AssistantEvent[] = [];
 
     // Start first message
     const p1 = conversation.processMessage({
@@ -714,8 +714,8 @@ describe("Conversation message queue", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events2: ServerMessage[] = [];
-    const events3: ServerMessage[] = [];
+    const events2: AssistantEvent[] = [];
+    const events3: AssistantEvent[] = [];
 
     // Start first message
     conversation.processMessage({
@@ -785,7 +785,7 @@ describe("Conversation message queue", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
 
     // Start a message — blocks on AgentLoop.run
     const p1 = conversation.processMessage({
@@ -851,9 +851,9 @@ describe("Conversation message queue", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const events2: ServerMessage[] = [];
-    const events3: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const events2: AssistantEvent[] = [];
+    const events3: AssistantEvent[] = [];
 
     // Start first message — blocks on AgentLoop.run
     const p1 = conversation.processMessage({
@@ -973,10 +973,10 @@ describe("Batched drain", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events2: ServerMessage[] = [];
-    const events3: ServerMessage[] = [];
-    const events4: ServerMessage[] = [];
-    const events5: ServerMessage[] = [];
+    const events2: AssistantEvent[] = [];
+    const events3: AssistantEvent[] = [];
+    const events4: AssistantEvent[] = [];
+    const events5: AssistantEvent[] = [];
 
     // Start in-flight message (msg-1)
     const p1 = conversation.processMessage({
@@ -1085,9 +1085,9 @@ describe("Batched drain", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const eventsHello: ServerMessage[] = [];
-    const eventsSlash: ServerMessage[] = [];
-    const eventsWorld: ServerMessage[] = [];
+    const eventsHello: AssistantEvent[] = [];
+    const eventsSlash: AssistantEvent[] = [];
+    const eventsWorld: AssistantEvent[] = [];
 
     // Start in-flight message
     const p1 = conversation.processMessage({
@@ -1158,9 +1158,9 @@ describe("Batched drain", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const eventsPlainA: ServerMessage[] = [];
-    const eventsSlash: ServerMessage[] = [];
-    const eventsPlainB: ServerMessage[] = [];
+    const eventsPlainA: AssistantEvent[] = [];
+    const eventsSlash: AssistantEvent[] = [];
+    const eventsPlainB: AssistantEvent[] = [];
 
     // Start in-flight message
     const p1 = conversation.processMessage({
@@ -1343,7 +1343,7 @@ describe("Batched drain", () => {
     // A third would push the queue over budget → rejected. Capture its
     // onEvent callback so we can verify the queue_full error event reaches
     // the rejected caller (not just the synchronous return value).
-    const rejectedEvents: ServerMessage[] = [];
+    const rejectedEvents: AssistantEvent[] = [];
     const rejected = conversation.enqueueMessage({
       content: "z".repeat(500),
       onEvent: (e) => rejectedEvents.push(e),
@@ -1421,8 +1421,8 @@ describe("Batched drain correctness fixes", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const eventsSurface: ServerMessage[] = [];
-    const eventsRegular: ServerMessage[] = [];
+    const eventsSurface: AssistantEvent[] = [];
+    const eventsRegular: AssistantEvent[] = [];
 
     // Start in-flight message
     const p1 = conversation.processMessage({
@@ -1485,10 +1485,10 @@ describe("Batched drain correctness fixes", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const events2: ServerMessage[] = [];
-    const events3: ServerMessage[] = [];
-    const events4: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const events2: AssistantEvent[] = [];
+    const events3: AssistantEvent[] = [];
+    const events4: AssistantEvent[] = [];
 
     // Start in-flight message
     const p1 = conversation.processMessage({
@@ -1516,7 +1516,7 @@ describe("Batched drain correctness fixes", () => {
     // this before enqueueing so the wrapped callback is what drainBatch
     // invokes.
     let aborted = false;
-    const onMsg3Event = (e: ServerMessage) => {
+    const onMsg3Event = (e: AssistantEvent) => {
       events3.push(e);
       if (!aborted && e.type === "message_dequeued") {
         aborted = true;
@@ -1564,10 +1564,10 @@ describe("Batched drain correctness fixes", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const events2: ServerMessage[] = [];
-    const events3: ServerMessage[] = [];
-    const events4: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const events2: AssistantEvent[] = [];
+    const events3: AssistantEvent[] = [];
+    const events4: AssistantEvent[] = [];
 
     // Start in-flight message
     const p1 = conversation.processMessage({
@@ -1627,10 +1627,10 @@ describe("Batched drain correctness fixes", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const events2: ServerMessage[] = [];
-    const events3: ServerMessage[] = [];
-    const events4: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const events2: AssistantEvent[] = [];
+    const events3: AssistantEvent[] = [];
+    const events4: AssistantEvent[] = [];
 
     const p1 = conversation.processMessage({
       content: "msg-1",
@@ -1679,7 +1679,7 @@ describe("Batched drain correctness fixes", () => {
   });
 
   test("drainBatch emits exactly one activity-state event for the whole batch", async () => {
-    const activityStates: ServerMessage[] = [];
+    const activityStates: AssistantEvent[] = [];
     const conversation = makeConversation((msg) => {
       if ("type" in msg && msg.type === "assistant_activity_state") {
         activityStates.push(msg);
@@ -1870,7 +1870,7 @@ describe("Conversation checkpoint handoff", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
 
     // Start processing first message
     const p1 = conversation.processMessage({
@@ -1955,10 +1955,10 @@ describe("Conversation checkpoint handoff", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const events2: ServerMessage[] = [];
-    const events3: ServerMessage[] = [];
-    const events4: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const events2: AssistantEvent[] = [];
+    const events3: AssistantEvent[] = [];
+    const events4: AssistantEvent[] = [];
 
     // Start first message (mid-tool-use — will yield at the next checkpoint)
     const p1 = conversation.processMessage({
@@ -2025,8 +2025,8 @@ describe("Conversation checkpoint handoff", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const events2: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const events2: AssistantEvent[] = [];
 
     // Start processing first message
     const p1 = conversation.processMessage({
@@ -2094,8 +2094,8 @@ describe("Conversation checkpoint handoff", () => {
 
     const dequeueOrder: string[] = [];
 
-    const eventsA: ServerMessage[] = [];
-    const makeHandler = (label: string) => (e: ServerMessage) => {
+    const eventsA: AssistantEvent[] = [];
+    const makeHandler = (label: string) => (e: AssistantEvent) => {
       if (e.type === "message_dequeued") {
         dequeueOrder.push(label);
       }
@@ -2205,9 +2205,9 @@ describe("Conversation checkpoint handoff", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const eventsA: ServerMessage[] = [];
-    const eventsB: ServerMessage[] = [];
-    const eventsC: ServerMessage[] = [];
+    const eventsA: AssistantEvent[] = [];
+    const eventsB: AssistantEvent[] = [];
+    const eventsC: AssistantEvent[] = [];
 
     // Start processing message A
     const pA = conversation.processMessage({
@@ -2305,8 +2305,8 @@ describe("Conversation host attachment directives", () => {
     writeFileSync(hostPath, "host attachment content");
 
     try {
-      const clientEvents: ServerMessage[] = [];
-      const events: ServerMessage[] = [];
+      const clientEvents: AssistantEvent[] = [];
+      const events: AssistantEvent[] = [];
       const conversation = makeConversation((msg) => clientEvents.push(msg));
       await conversation.loadFromDb();
 
@@ -2375,8 +2375,8 @@ describe("Conversation host attachment directives", () => {
     writeFileSync(hostPath, "host attachment content");
 
     try {
-      const clientEvents: ServerMessage[] = [];
-      const events: ServerMessage[] = [];
+      const clientEvents: AssistantEvent[] = [];
+      const events: AssistantEvent[] = [];
       const conversation = makeConversation((msg) => clientEvents.push(msg));
       await conversation.loadFromDb();
 
@@ -2463,7 +2463,7 @@ describe("Conversation attachment event payloads", () => {
   });
 
   test("message_complete includes assistant attachments", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
@@ -2526,7 +2526,7 @@ describe("Conversation attachment event payloads", () => {
   });
 
   test("generation_handoff includes assistant attachments", async () => {
-    const events1: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
@@ -2610,7 +2610,7 @@ describe("Regression: cancel semantics and error channel split", () => {
   });
 
   test("user cancellation emits generation_cancelled, never conversation_error", async () => {
-    const msgEvents: ServerMessage[] = [];
+    const msgEvents: AssistantEvent[] = [];
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
@@ -2644,7 +2644,7 @@ describe("Regression: cancel semantics and error channel split", () => {
   });
 
   test("post-processing failure still attempts turn-boundary commit", async () => {
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const conversation = makeConversation();
     await conversation.loadFromDb();
     linkAttachmentShouldThrow = true;
@@ -2699,7 +2699,7 @@ describe("Regression: cancel semantics and error channel split", () => {
   });
 
   test("provider failure during processing emits both conversation_error and generic error", async () => {
-    const allEvents: ServerMessage[] = [];
+    const allEvents: AssistantEvent[] = [];
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
@@ -2730,7 +2730,7 @@ describe("Regression: cancel semantics and error channel split", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const eventsPerMsg: ServerMessage[][] = [[], [], []];
+    const eventsPerMsg: AssistantEvent[][] = [[], [], []];
 
     conversation.processMessage({
       content: "msg-1",
@@ -2787,8 +2787,8 @@ describe("Regression: cancel semantics and error channel split", () => {
 
       turnCommitHangForever = true;
 
-      const events1: ServerMessage[] = [];
-      const events2: ServerMessage[] = [];
+      const events1: AssistantEvent[] = [];
+      const events2: AssistantEvent[] = [];
 
       // Start first message (promise intentionally not awaited — we test queue drain behavior)
       const _p1 = conversation.processMessage({
@@ -2937,11 +2937,11 @@ describe("persisted-seq anchor advance on user_message_echo", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const eventsQueued: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const eventsQueued: AssistantEvent[] = [];
     // Mirror `broadcastMessage`'s inline stamp so `getCurrentSeq()` read
     // right after the emit is this echo's seq, as in production.
-    const stampingOnEvent = (sink: ServerMessage[]) => (e: ServerMessage) => {
+    const stampingOnEvent = (sink: AssistantEvent[]) => (e: AssistantEvent) => {
       stampAndBuffer(e as unknown as Parameters<typeof stampAndBuffer>[0]);
       sink.push(e);
     };
@@ -2965,7 +2965,7 @@ describe("persisted-seq anchor advance on user_message_echo", () => {
     await waitForPendingRun(2);
 
     const echo = eventsQueued.find((e) => e.type === "user_message_echo") as
-      | (ServerMessage & { seq?: number })
+      | (AssistantEvent & { seq?: number })
       | undefined;
     const echoSeq = echo?.seq;
     if (typeof echoSeq !== "number") {
@@ -2988,8 +2988,8 @@ describe("persisted-seq anchor advance on user_message_echo", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const eventsNotif: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const eventsNotif: AssistantEvent[] = [];
 
     const p1 = conversation.processMessage({
       content: "msg-1",
@@ -3037,8 +3037,8 @@ describe("subagent notification user_message_echo suppression", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const eventsNotif: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const eventsNotif: AssistantEvent[] = [];
 
     // Occupy the conversation so the injected notification queues.
     const p1 = conversation.processMessage({
@@ -3088,8 +3088,8 @@ describe("subagent notification user_message_echo suppression", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const eventsNormal: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const eventsNormal: AssistantEvent[] = [];
 
     const p1 = conversation.processMessage({
       content: "msg-1",
@@ -3119,8 +3119,8 @@ describe("subagent notification user_message_echo suppression", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const eventsHidden: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const eventsHidden: AssistantEvent[] = [];
 
     // Occupy the conversation so the hidden send queues — e.g. the user
     // closes the channel-setup wizard while the assistant is mid-turn.
@@ -3167,8 +3167,8 @@ describe("subagent notification user_message_echo suppression", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const eventsNotif: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const eventsNotif: AssistantEvent[] = [];
 
     // Occupy the conversation so the injected notification queues.
     const p1 = conversation.processMessage({
@@ -3210,8 +3210,8 @@ describe("subagent notification user_message_echo suppression", () => {
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const eventsNotif: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const eventsNotif: AssistantEvent[] = [];
 
     // Occupy the conversation so the injected wake queues.
     const p1 = conversation.processMessage({

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent, AgentLoopRunResult } from "../agent/loop.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import {
   conversationMessagesSyncTag,
   type SyncChangedEvent,
@@ -301,9 +301,9 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const eventsSlash: ServerMessage[] = [];
-    const events3: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const eventsSlash: AssistantEvent[] = [];
+    const events3: AssistantEvent[] = [];
 
     // Start first message — blocks on agent loop
     const p1 = conversation.processMessage({
@@ -348,8 +348,8 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const sharedEvents: ServerMessage[] = [];
-    const sharedOnEvent = (event: ServerMessage) => sharedEvents.push(event);
+    const sharedEvents: AssistantEvent[] = [];
+    const sharedOnEvent = (event: AssistantEvent) => sharedEvents.push(event);
 
     const p1 = conversation.processMessage({
       content: "msg-1",
@@ -390,8 +390,8 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const events1: ServerMessage[] = [];
-    const eventsSlash: ServerMessage[] = [];
+    const events1: AssistantEvent[] = [];
+    const eventsSlash: AssistantEvent[] = [];
 
     // Start first message — blocks on agent loop
     const p1 = conversation.processMessage({
@@ -433,9 +433,9 @@ describe("Conversation queue — slash-like messages pass through to agent loop"
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const eventsHi: ServerMessage[] = [];
-    const eventsCompact: ServerMessage[] = [];
-    const eventsBye: ServerMessage[] = [];
+    const eventsHi: AssistantEvent[] = [];
+    const eventsCompact: AssistantEvent[] = [];
+    const eventsBye: AssistantEvent[] = [];
 
     // Start in-flight message
     const p1 = conversation.processMessage({

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent } from "../agent/loop.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -255,7 +255,7 @@ describe("Conversation slash command — passthrough for unknown tokens", () => 
 
   test("normal messages still go through standard path", async () => {
     const conversation = makeConversation();
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     await conversation.processMessage({
       content: "hello world",
       attachments: [],

--- a/assistant/src/__tests__/conversation-speed-override.test.ts
+++ b/assistant/src/__tests__/conversation-speed-override.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent, AgentLoopConfig } from "../agent/loop.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -208,7 +208,7 @@ function makeProvider() {
   };
 }
 
-function makeSendToClient(): (msg: ServerMessage) => void {
+function makeSendToClient(): (msg: AssistantEvent) => void {
   return () => {};
 }
 

--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 
-let broadcastedMessages: ServerMessage[] = [];
+let broadcastedMessages: AssistantEvent[] = [];
 const realEventHub = await import("../runtime/assistant-event-hub.js");
 mock.module("../runtime/assistant-event-hub.js", () => ({
   ...realEventHub,
-  broadcastMessage: (msg: ServerMessage) => broadcastedMessages.push(msg),
+  broadcastMessage: (msg: AssistantEvent) => broadcastedMessages.push(msg),
 }));
 
 const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
@@ -25,13 +25,15 @@ interface ProcessMessageCall {
   sourceActorPrincipalId?: string;
 }
 
-function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext & {
+function makeContext(
+  sent: AssistantEvent[] = [],
+): SurfaceConversationContext & {
   processMessageCalls: ProcessMessageCall[];
 } {
   const processMessageCalls: ProcessMessageCall[] = [];
   return {
     conversationId: "conv-1",
-    sendToClient: (msg: ServerMessage) => sent.push(msg),
+    sendToClient: (msg: AssistantEvent) => sent.push(msg),
     pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
     lastSurfaceAction: new Map<
       string,
@@ -67,7 +69,7 @@ describe("surface action delivery to assistant", () => {
   });
 
   test("table action button click triggers processMessage with action content", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     // Step 1: Show a table surface with actions
@@ -128,7 +130,7 @@ describe("surface action delivery to assistant", () => {
   });
 
   test("idle pending follow-up path threads submitter principal into processMessage", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -161,7 +163,7 @@ describe("surface action delivery to assistant", () => {
   });
 
   test("idle history-restored path threads submitter principal into processMessage", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     // History-restored surface: surfaceState exists, pendingSurfaceActions
@@ -191,7 +193,7 @@ describe("surface action delivery to assistant", () => {
   });
 
   test("table action without selection data still triggers processMessage", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     // Show table surface
@@ -267,7 +269,7 @@ describe("surface action delivery to assistant", () => {
   });
 
   test("action on history-restored surface (no pending) still processes", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     // Simulate a history-restored surface: surfaceState exists, but
@@ -295,7 +297,7 @@ describe("surface action delivery to assistant", () => {
   });
 
   test("confirmation surface broadcasts ui_surface_complete on action", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const showResult = await surfaceProxyResolver(ctx, "ui_show", {
@@ -331,7 +333,7 @@ describe("surface action delivery to assistant", () => {
   });
 
   test("file_upload surface broadcasts ui_surface_complete on action", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const showResult = await surfaceProxyResolver(ctx, "ui_show", {
@@ -370,7 +372,7 @@ describe("surface action delivery to assistant", () => {
   });
 
   test("file_upload completion event does not include base64 file blobs", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -414,7 +416,7 @@ describe("surface action delivery to assistant", () => {
   });
 
   test("choice surface broadcasts ui_surface_complete on action", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const showResult = await surfaceProxyResolver(ctx, "ui_show", {
@@ -457,7 +459,7 @@ describe("surface action delivery to assistant", () => {
   });
 
   test("oauth_connect surface broadcasts ui_surface_complete on action", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const showResult = await surfaceProxyResolver(ctx, "ui_show", {
@@ -499,7 +501,7 @@ describe("surface action delivery to assistant", () => {
   });
 
   test("table surface does NOT broadcast ui_surface_complete (not one-shot)", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {

--- a/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 
 // Analytics consent is granted so recordActivationEvent writes rows.
 let shareAnalytics = true;
@@ -9,11 +9,11 @@ mock.module("../platform/consent-cache.js", () => ({
   getRawShareAnalytics: () => shareAnalytics,
 }));
 
-let broadcastedMessages: ServerMessage[] = [];
+let broadcastedMessages: AssistantEvent[] = [];
 const realEventHub = await import("../runtime/assistant-event-hub.js");
 mock.module("../runtime/assistant-event-hub.js", () => ({
   ...realEventHub,
-  broadcastMessage: (msg: ServerMessage) => broadcastedMessages.push(msg),
+  broadcastMessage: (msg: AssistantEvent) => broadcastedMessages.push(msg),
 }));
 
 // Stub the child-conversation launcher so the launch_conversation commit path
@@ -60,14 +60,14 @@ interface ProcessMessageCall {
 
 function makeContext(
   conversationId: string,
-  sent: ServerMessage[] = [],
+  sent: AssistantEvent[] = [],
 ): SurfaceConversationContext & {
   processMessageCalls: ProcessMessageCall[];
 } {
   const processMessageCalls: ProcessMessageCall[] = [];
   return {
     conversationId,
-    sendToClient: (msg: ServerMessage) => sent.push(msg),
+    sendToClient: (msg: AssistantEvent) => sent.push(msg),
     pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
     lastSurfaceAction: new Map<
       string,
@@ -103,7 +103,7 @@ function resetTables(): void {
 /** Render a choice surface tagged (or not) with an activation_moment. */
 async function showTaggedChoice(
   ctx: SurfaceConversationContext,
-  sent: ServerMessage[],
+  sent: AssistantEvent[],
   activationMoment?: string,
 ): Promise<string> {
   await surfaceProxyResolver(ctx, "ui_show", {
@@ -134,7 +134,7 @@ describe("activation moment emission from ui_show surface commits", () => {
     markActivationSession("conv-marked");
     expect(isActivationSession("conv-marked")).toBe(true);
 
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext("conv-marked", sent);
     const surfaceId = await showTaggedChoice(ctx, sent, "moment_2");
 
@@ -152,7 +152,7 @@ describe("activation moment emission from ui_show surface commits", () => {
 
   test("a queue-rejected commit does NOT emit; the tag survives for the retry", async () => {
     markActivationSession("conv-rejected");
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext("conv-rejected", sent);
     const surfaceId = await showTaggedChoice(ctx, sent, "moment_2");
 
@@ -183,7 +183,7 @@ describe("activation moment emission from ui_show surface commits", () => {
 
   test("first_wow_executed records at SHOW time (no commit) and never double-emits", async () => {
     markActivationSession("conv-wow");
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext("conv-wow", sent);
 
     // A display-only result surface tagged with the execution moment.
@@ -211,7 +211,7 @@ describe("activation moment emission from ui_show surface commits", () => {
   });
 
   test("first_wow_executed in an UNMARKED session writes no row at show time", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext("conv-wow-unmarked", sent);
     await surfaceProxyResolver(ctx, "ui_show", {
       surface_type: "card",
@@ -224,7 +224,7 @@ describe("activation moment emission from ui_show surface commits", () => {
 
   test("does not forward the daemon-only tag to the client", async () => {
     markActivationSession("conv-marked-2");
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext("conv-marked-2", sent);
     await showTaggedChoice(ctx, sent, "moment_2");
 
@@ -239,7 +239,7 @@ describe("activation moment emission from ui_show surface commits", () => {
 
   test("untagged surface writes no row", async () => {
     markActivationSession("conv-untagged");
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext("conv-untagged", sent);
     const surfaceId = await showTaggedChoice(ctx, sent, undefined);
 
@@ -252,7 +252,7 @@ describe("activation moment emission from ui_show surface commits", () => {
   });
 
   test("tagged surface in an UNMARKED session writes no row", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext("conv-not-rail", sent);
     const surfaceId = await showTaggedChoice(ctx, sent, "moment_2");
 
@@ -266,7 +266,7 @@ describe("activation moment emission from ui_show surface commits", () => {
 
   test("an invalid activation_moment token is ignored (no row)", async () => {
     markActivationSession("conv-bad-tag");
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext("conv-bad-tag", sent);
     const surfaceId = await showTaggedChoice(ctx, sent, "bogus_moment");
 
@@ -280,7 +280,7 @@ describe("activation moment emission from ui_show surface commits", () => {
 
   test("FIX 1: launch_conversation commit on a tagged surface records exactly one row", async () => {
     markActivationSession("conv-launch");
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext("conv-launch", sent);
 
     // A launcher card tagged with a commit-timing moment. The committed action
@@ -312,7 +312,7 @@ describe("activation moment emission from ui_show surface commits", () => {
 
   test("FIX 2: commit-timing tag survives a surfaceState restore from history", async () => {
     markActivationSession("conv-restore");
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext("conv-restore", sent);
     const surfaceId = await showTaggedChoice(ctx, sent, "moment_2");
 
@@ -361,7 +361,7 @@ describe("activation moment emission from ui_show surface commits", () => {
 
   test("intermediate selection_changed does NOT emit; the terminal commit does", async () => {
     markActivationSession("conv-table");
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext("conv-table", sent);
 
     // A table surface stays pending across selection_changed (non-terminal).

--- a/assistant/src/__tests__/conversation-surfaces-app-open.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-app-open.test.ts
@@ -7,7 +7,10 @@ import {
   type SurfaceConversationContext,
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
-import type { ServerMessage, SurfaceType } from "../daemon/message-protocol.js";
+import type {
+  AssistantEvent,
+  SurfaceType,
+} from "../daemon/message-protocol.js";
 
 interface ContextOptions {
   hasNoClient?: boolean;
@@ -15,7 +18,7 @@ interface ContextOptions {
 }
 
 function makeContext(
-  sent: ServerMessage[] = [],
+  sent: AssistantEvent[] = [],
   options: ContextOptions = {},
 ): SurfaceConversationContext {
   return {
@@ -43,7 +46,7 @@ function makeContext(
 
 describe("app_open render-capability gate", () => {
   test("returns an error without broadcasting on a clientless turn", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, { hasNoClient: true });
 
     const result = await surfaceProxyResolver(ctx, "app_open", {
@@ -56,7 +59,7 @@ describe("app_open render-capability gate", () => {
   });
 
   test("returns an error on a channel without dynamic UI (e.g. Slack)", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, {
       channelCapabilities: { channel: "slack", supportsDynamicUi: false },
     });

--- a/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 
 const realEventHub = await import("../runtime/assistant-event-hub.js");
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
   ...realEventHub,
-  broadcastMessage: (_msg: ServerMessage) => {},
+  broadcastMessage: (_msg: AssistantEvent) => {},
 }));
 
 // Mock the persistence layer the surface helpers reach into so we can
@@ -53,7 +53,7 @@ import type {
   SurfaceType,
 } from "../daemon/message-protocol.js";
 
-function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext {
+function makeContext(sent: AssistantEvent[] = []): SurfaceConversationContext {
   return {
     conversationId: "conv-persist-1",
     sendToClient: (msg) => sent.push(msg),
@@ -111,7 +111,7 @@ describe("ui_surface_update persistence", () => {
   });
 
   test("ui_update schedules a debounced DB write that lands within ~600ms", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     // Seed an existing in-memory surface and a persisted message that
@@ -164,7 +164,7 @@ describe("ui_surface_update persistence", () => {
   });
 
   test("multiple rapid updates collapse to a single DB write", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const surfaceId = "surface-debounced-2";
@@ -431,7 +431,7 @@ describe("ui_dismiss persisted-state convergence", () => {
   });
 
   test("passive dismiss drops the surface from the turn snapshot and strips the persisted block", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
     const surfaceId = "surface-dismiss-1";
     // A progress card the model marked `completed` while leaving step 4 spinning.
@@ -479,7 +479,7 @@ describe("ui_dismiss persisted-state convergence", () => {
   });
 
   test("dismiss cancels a pending debounced persist so a stale update cannot re-add the block", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
     const surfaceId = "surface-dismiss-2";
     const data: CardSurfaceData = {

--- a/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
@@ -19,11 +19,11 @@
 
 import { describe, expect, mock, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 
-let broadcastImpl: (msg: ServerMessage) => void = () => {};
+let broadcastImpl: (msg: AssistantEvent) => void = () => {};
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: ServerMessage) => broadcastImpl(msg),
+  broadcastMessage: (msg: AssistantEvent) => broadcastImpl(msg),
 }));
 
 import {
@@ -42,11 +42,11 @@ function createMockContext(
     channel: string;
   }>,
 ): SurfaceConversationContext & {
-  sentMessages: ServerMessage[];
+  sentMessages: AssistantEvent[];
   enqueuedMessages: Array<{ content: string; requestId: string }>;
 } {
-  const sentMessages: ServerMessage[] = [];
-  broadcastImpl = (msg: ServerMessage) => sentMessages.push(msg);
+  const sentMessages: AssistantEvent[] = [];
+  broadcastImpl = (msg: AssistantEvent) => sentMessages.push(msg);
   const enqueuedMessages: Array<{ content: string; requestId: string }> = [];
 
   return {
@@ -59,7 +59,7 @@ function createMockContext(
           supportsDynamicUi: overrides.supportsDynamicUi ?? true,
         }
       : undefined,
-    sendToClient: (msg: ServerMessage) => sentMessages.push(msg),
+    sendToClient: (msg: AssistantEvent) => sentMessages.push(msg),
     pendingSurfaceActions: new Map(),
     lastSurfaceAction: new Map(),
     surfaceState: new Map(),
@@ -91,7 +91,7 @@ function createMockContext(
 type AnyRecord = Record<string, unknown>;
 
 function findByType(
-  messages: ServerMessage[],
+  messages: AssistantEvent[],
   type: string,
 ): AnyRecord | undefined {
   return messages.find(
@@ -99,7 +99,7 @@ function findByType(
   ) as unknown as AnyRecord | undefined;
 }
 
-function findAllByType(messages: ServerMessage[], type: string): AnyRecord[] {
+function findAllByType(messages: AssistantEvent[], type: string): AnyRecord[] {
   return messages.filter(
     (m) => (m as unknown as AnyRecord).type === type,
   ) as unknown as AnyRecord[];

--- a/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { InteractiveUiResult } from "../runtime/interactive-ui.js";
 
-let broadcastImpl: (msg: ServerMessage) => void = () => {};
+let broadcastImpl: (msg: AssistantEvent) => void = () => {};
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: ServerMessage) => broadcastImpl(msg),
+  broadcastMessage: (msg: AssistantEvent) => broadcastImpl(msg),
 }));
 
 import {
@@ -30,11 +30,11 @@ function createMockContext(
     channel: string;
   }>,
 ): SurfaceConversationContext & {
-  sentMessages: ServerMessage[];
+  sentMessages: AssistantEvent[];
   enqueuedMessages: Array<{ content: string; requestId: string }>;
 } {
-  const sentMessages: ServerMessage[] = [];
-  broadcastImpl = (msg: ServerMessage) => sentMessages.push(msg);
+  const sentMessages: AssistantEvent[] = [];
+  broadcastImpl = (msg: AssistantEvent) => sentMessages.push(msg);
   const enqueuedMessages: Array<{ content: string; requestId: string }> = [];
 
   return {
@@ -47,7 +47,7 @@ function createMockContext(
           supportsDynamicUi: overrides.supportsDynamicUi ?? true,
         }
       : undefined,
-    sendToClient: (msg: ServerMessage) => sentMessages.push(msg),
+    sendToClient: (msg: AssistantEvent) => sentMessages.push(msg),
     pendingSurfaceActions: new Map(),
     lastSurfaceAction: new Map(),
     surfaceState: new Map(),
@@ -128,7 +128,7 @@ describe("showStandaloneSurface", () => {
 
   afterEach(() => {
     // Safety cleanup of any lingering timers
-    for (const t of timers) clearTimeout(t);
+    for (const t of timers) {clearTimeout(t);}
   });
 
   test("fails closed when no client is connected", async () => {
@@ -299,7 +299,7 @@ describe("showStandaloneSurface", () => {
   test("timeout still resolves when emit throws", async () => {
     const ctx = createMockContext();
     let showEmitted = false;
-    broadcastImpl = (msg: ServerMessage) => {
+    broadcastImpl = (msg: AssistantEvent) => {
       const type = (msg as unknown as Record<string, unknown>).type;
       if (type === "ui_surface_show") {
         showEmitted = true;
@@ -478,7 +478,7 @@ describe("cleanupStandaloneSurface", () => {
     clearTimeout(timer);
     const tombstoneTimer =
       ctx.recentlyCompletedStandaloneSurfaces!.get("surf-c1");
-    if (tombstoneTimer) clearTimeout(tombstoneTimer);
+    if (tombstoneTimer) {clearTimeout(tombstoneTimer);}
   });
 
   test("is idempotent — safe to call multiple times", () => {
@@ -530,7 +530,7 @@ describe("standalone surface cleanup on conversation dispose", () => {
         type: "ui_surface_dismiss",
         conversationId: ctx.conversationId,
         surfaceId,
-      } as ServerMessage);
+      } as AssistantEvent);
       entry.resolve({ status: "cancelled", surfaceId });
     }
     ctx.pendingStandaloneSurfaces!.clear();
@@ -579,7 +579,7 @@ describe("standalone surface cleanup on conversation dispose", () => {
         type: "ui_surface_dismiss",
         conversationId: ctx.conversationId,
         surfaceId,
-      } as ServerMessage);
+      } as AssistantEvent);
       entry.resolve({ status: "cancelled", surfaceId });
     }
     ctx.pendingStandaloneSurfaces!.clear();

--- a/assistant/src/__tests__/conversation-surfaces-state-update.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-state-update.test.ts
@@ -7,7 +7,10 @@ import {
   type SurfaceConversationContext,
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
-import type { ServerMessage, SurfaceType } from "../daemon/message-protocol.js";
+import type {
+  AssistantEvent,
+  SurfaceType,
+} from "../daemon/message-protocol.js";
 
 /**
  * Build a minimal SurfaceConversationContext for testing.
@@ -15,7 +18,7 @@ import type { ServerMessage, SurfaceType } from "../daemon/message-protocol.js";
  * whether an LLM turn was triggered.
  */
 function makeContext(opts?: {
-  sent?: ServerMessage[];
+  sent?: AssistantEvent[];
 }): SurfaceConversationContext & {
   enqueueCalls: Array<{ content: string; requestId: string }>;
   processCalls: Array<{ content: string; requestId?: string }>;
@@ -244,7 +247,7 @@ describe("cleanup on dismiss", () => {
 
 describe("ui_update preserves client-owned keys the daemon schema omits", () => {
   test("a valid patch keeps unmodeled keys on the merged, sent, and stored data", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext({ sent });
     // A document_preview whose stored data carries `content`/`mimeType`
     // (read by the client renderer, not modeled by the daemon schema).
@@ -290,7 +293,7 @@ describe("ui_update preserves client-owned keys the daemon schema omits", () => 
 
 describe("ui_update on a restored unknown surface type", () => {
   test("forwards the merge opaquely instead of throwing on the schema registry", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext({ sent });
     // Restore preserves an unknown-but-non-empty surfaceType verbatim (a
     // newer/custom client-rendered surface). Indexing SURFACE_DATA_SCHEMAS with
@@ -360,7 +363,7 @@ describe("ui_update on a restored unknown surface type", () => {
 
 describe("ui_update normalizes modeled fields for known surface types", () => {
   test("a malformed dynamic_page html patch is stored as its schema-coerced string", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext({ sent });
     ctx.surfaceState.set("page-1", {
       surfaceType: "dynamic_page",

--- a/assistant/src/__tests__/conversation-surfaces-table-action.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-table-action.test.ts
@@ -5,7 +5,10 @@ import {
   handleSurfaceAction,
   type SurfaceConversationContext,
 } from "../daemon/conversation-surfaces.js";
-import type { ServerMessage, SurfaceType } from "../daemon/message-protocol.js";
+import type {
+  AssistantEvent,
+  SurfaceType,
+} from "../daemon/message-protocol.js";
 
 /**
  * Build a minimal SurfaceConversationContext for testing table surface actions.
@@ -27,7 +30,7 @@ function makeContext(): SurfaceConversationContext & {
     surfaceId?: string;
     displayContent?: string;
   }>;
-  sentMessages: ServerMessage[];
+  sentMessages: AssistantEvent[];
 } {
   const enqueueCalls: Array<{
     content: string;
@@ -43,7 +46,7 @@ function makeContext(): SurfaceConversationContext & {
     surfaceId?: string;
     displayContent?: string;
   }> = [];
-  const sentMessages: ServerMessage[] = [];
+  const sentMessages: AssistantEvent[] = [];
 
   return {
     conversationId: "test-convo",

--- a/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
@@ -6,16 +6,16 @@ import {
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
 import type {
+  AssistantEvent,
   CardSurfaceData,
   DynamicPageSurfaceData,
-  ServerMessage,
   SurfaceType,
   UiSurfaceShow,
   UISurfaceUpdateEvent,
 } from "../daemon/message-protocol.js";
 
 function makeContext(
-  sent: ServerMessage[] = [],
+  sent: AssistantEvent[] = [],
   channelCapabilities?: SurfaceConversationContext["channelCapabilities"],
 ): SurfaceConversationContext {
   return {
@@ -42,7 +42,7 @@ function makeContext(
 
 describe("task_progress surface compatibility", () => {
   test("blocks ui_show when channel lacks dynamic UI support", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, {
       channel: "phone",
       supportsDynamicUi: false,
@@ -61,7 +61,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("blocks ui_update when channel lacks dynamic UI support", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, {
       channel: "telegram",
       supportsDynamicUi: false,
@@ -80,7 +80,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("allows Slack ui_show for task_progress card when dynamic UI is otherwise disabled", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, {
       channel: "slack",
       supportsDynamicUi: false,
@@ -110,7 +110,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("blocks Slack ui_show for non-task_progress card when dynamic UI is disabled", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, {
       channel: "slack",
       supportsDynamicUi: false,
@@ -130,7 +130,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("blocks Slack ui_show when normalized card data is not task_progress", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, {
       channel: "slack",
       supportsDynamicUi: false,
@@ -151,7 +151,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("blocks Slack ui_show for non-card task_progress input when dynamic UI is disabled", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, {
       channel: "slack",
       supportsDynamicUi: false,
@@ -171,7 +171,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("ui_show maps legacy top-level task_progress fields into card data", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -208,7 +208,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("ui_show fills well-formed templateData for a stepless task_progress card", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -237,7 +237,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("ui_show coerces invalid status and malformed steps on a task_progress card", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -279,7 +279,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("ui_show normalizes top-level dynamic_page fields into data", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -308,7 +308,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("ui_show supports file_upload surfaces directly", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -344,7 +344,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("ui_show file_upload normalizes a comma-joined acceptedTypes string", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     // The model may emit acceptedTypes as a comma-joined string; the renderer
@@ -375,7 +375,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("ui_show dynamic_page uses data.html when properly nested", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -399,7 +399,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("ui_update normalizes top-level task_progress fields into templateData", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
     const existingCard: CardSurfaceData = {
       title: "Ordering from DoorDash",
@@ -448,7 +448,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("allows Slack ui_update for stored task_progress card when dynamic UI is disabled", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, {
       channel: "slack",
       supportsDynamicUi: false,
@@ -482,7 +482,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("blocks Slack ui_update when stored surface is not a task_progress card", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, {
       channel: "slack",
       supportsDynamicUi: false,
@@ -505,7 +505,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("blocks Slack ui_update that would convert a plain card to task_progress", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, {
       channel: "slack",
       supportsDynamicUi: false,
@@ -531,7 +531,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("blocks Slack ui_update that would change task_progress card template", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, {
       channel: "slack",
       supportsDynamicUi: false,
@@ -562,7 +562,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("blocks Slack ui_update when the surface is not already stored", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent, {
       channel: "slack",
       supportsDynamicUi: false,
@@ -581,7 +581,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("ui_show rejects new interactive surface when a non-dynamic_page pending surface exists", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     // Pre-populate a pending table surface (simulates a previously shown interactive surface)
@@ -603,7 +603,7 @@ describe("task_progress surface compatibility", () => {
   });
 
   test("ui_show allows new interactive surface when only dynamic_page surfaces are pending", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     // dynamic_page pending entries should not block new interactive surfaces
@@ -622,7 +622,7 @@ describe("task_progress surface compatibility", () => {
 });
 
 describe("ui_show card content recovery", () => {
-  function shownCard(sent: ServerMessage[]): CardSurfaceData | undefined {
+  function shownCard(sent: AssistantEvent[]): CardSurfaceData | undefined {
     const show = sent.find(
       (m): m is UiSurfaceShow => m.type === "ui_surface_show",
     );
@@ -633,7 +633,7 @@ describe("ui_show card content recovery", () => {
   }
 
   test("recovers body from a copy_block-style `text` field", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -650,7 +650,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("recovers body from a confirmation-style `message` field", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -662,7 +662,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("recovers top-level subtitle and metadata into the card", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -678,7 +678,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("title-only card with actions renders with actions intact", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -699,7 +699,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("title-only card without actions renders without error", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -713,7 +713,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("card with body and actions is interactive", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -734,7 +734,7 @@ describe("ui_show card content recovery", () => {
   // ── Body alias recovery from cross-surface keys ────────────────────
 
   test("recovers body from choice/form-style `description` field", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -749,7 +749,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("recovers body from work_result-style `summary` field", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -761,7 +761,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("recovers body from confirmation-style `detail` field", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -773,7 +773,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("recovers body from top-level `description`", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -787,7 +787,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("concatenates multiple body aliases when they co-occur", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -809,7 +809,7 @@ describe("ui_show card content recovery", () => {
   // ── Title alias recovery ────────────────────────────────────────────
 
   test("recovers title from `heading` alias", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -821,7 +821,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("recovers title from `header` alias", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -835,7 +835,7 @@ describe("ui_show card content recovery", () => {
   // ── Subtitle alias recovery ─────────────────────────────────────────
 
   test("recovers subtitle from `subheading` alias", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -847,7 +847,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("recovers subtitle from table-style `caption` alias", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -861,7 +861,7 @@ describe("ui_show card content recovery", () => {
   // ── Alias precedence ───────────────────────────────────────────────
 
   test("canonical `body` takes precedence over aliased `description`", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -873,7 +873,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("card with recovered `description` and actions keeps actions (has content)", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -892,7 +892,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("recovers actions nested inside data when top-level actions is absent", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -914,7 +914,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("top-level actions take precedence over data.actions", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -935,7 +935,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("genuinely empty card (no title, body, subtitle, metadata, template, or actions) is rejected", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -949,7 +949,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("a card with a real body broadcasts unchanged", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     await surfaceProxyResolver(ctx, "ui_show", {
@@ -961,7 +961,7 @@ describe("ui_show card content recovery", () => {
   });
 
   test("a task_progress card with empty data broadcasts (template renders a shell)", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {

--- a/assistant/src/__tests__/conversation-sync-tags.test.ts
+++ b/assistant/src/__tests__/conversation-sync-tags.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { ROUTES as CONVERSATION_LIST_ROUTES } from "../runtime/routes/conversation-list-routes.js";
 import { ROUTES as CONVERSATION_MANAGEMENT_ROUTES } from "../runtime/routes/conversation-management-routes.js";
@@ -50,8 +50,8 @@ function findRoute(
 async function captureEvents(
   action: () => void | Promise<unknown>,
   expectedCount: number,
-): Promise<AssistantEvent[]> {
-  const received: AssistantEvent[] = [];
+): Promise<AssistantEventEnvelope[]> {
+  const received: AssistantEventEnvelope[] = [];
   const subscription = assistantEventHub.subscribe({
     type: "process",
     callback: (event) => {
@@ -371,7 +371,7 @@ describe("conversation sync tags", () => {
       JSON.stringify([{ type: "text", text: "first" }]),
     );
 
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {
@@ -404,7 +404,7 @@ describe("conversation sync tags", () => {
     // messages advance the attention cursor via projectAssistantMessage.
     const conversation = createConversation("User message");
 
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {

--- a/assistant/src/__tests__/conversation-wait-for-idle.test.ts
+++ b/assistant/src/__tests__/conversation-wait-for-idle.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent } from "../agent/loop.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -195,7 +195,7 @@ function makeConversation(): Conversation {
     `conv-wait-for-idle-${conversationSeq}`,
     makeProvider(),
     "system prompt",
-    (_msg: ServerMessage) => {},
+    (_msg: AssistantEvent) => {},
     "/tmp",
     { maxTokens: 4096 },
   );

--- a/assistant/src/__tests__/daemon-assistant-events.test.ts
+++ b/assistant/src/__tests__/daemon-assistant-events.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests that daemon outbound messages are mirrored into the
- * assistant-events hub as AssistantEvent objects.
+ * assistant-events hub as AssistantEventEnvelope objects.
  *
  * Tests:
  *   - send()      → one mirrored assistant event per message
@@ -10,7 +10,7 @@ import { describe, expect, test } from "bun:test";
 
 // ── Imports (after mocks) ────────────────────────────────────────────────────
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
 
@@ -54,7 +54,7 @@ describe("buildAssistantEvent", () => {
 describe("daemon send → one mirrored assistant event", () => {
   test("publishing a single event to the hub delivers exactly one event", async () => {
     const hub = new AssistantEventHub();
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "process",
@@ -78,7 +78,7 @@ describe("daemon send → one mirrored assistant event", () => {
 
   test("conversationId falls back to explicit parameter when message lacks it", async () => {
     const hub = new AssistantEventHub();
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "process",
@@ -100,7 +100,7 @@ describe("daemon send → one mirrored assistant event", () => {
 describe("daemon broadcast → one mirrored event per message (not per socket)", () => {
   test("one broadcast publish produces exactly one hub event regardless of subscriber count", async () => {
     const hub = new AssistantEventHub();
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
 
     // Two subscribers (simulating two wire clients)
     hub.subscribe({
@@ -130,7 +130,7 @@ describe("daemon broadcast → one mirrored event per message (not per socket)",
 
   test("broadcast publishes once; single send publishes once — not additive", async () => {
     const hub = new AssistantEventHub();
-    const publishedEvents: AssistantEvent[] = [];
+    const publishedEvents: AssistantEventEnvelope[] = [];
 
     hub.subscribe({
       type: "process",

--- a/assistant/src/__tests__/daemon-assistant-events.test.ts
+++ b/assistant/src/__tests__/daemon-assistant-events.test.ts
@@ -9,7 +9,7 @@
 import { describe, expect, test } from "bun:test";
 
 // ── Imports (after mocks) ────────────────────────────────────────────────────
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
@@ -20,7 +20,7 @@ import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
 
 describe("buildAssistantEvent", () => {
   test("returns event with correct shape", () => {
-    const msg: ServerMessage = {
+    const msg: AssistantEvent = {
       type: "assistant_text_delta",
       conversationId: "sess_1",
       text: "hi",
@@ -36,14 +36,14 @@ describe("buildAssistantEvent", () => {
   });
 
   test("generates unique ids for each call", () => {
-    const msg: ServerMessage = { type: "message_complete" };
+    const msg: AssistantEvent = { type: "message_complete" };
     const a = buildAssistantEvent(msg);
     const b = buildAssistantEvent(msg);
     expect(a.id).not.toBe(b.id);
   });
 
   test("conversationId is undefined when omitted", () => {
-    const msg: ServerMessage = { type: "message_complete" };
+    const msg: AssistantEvent = { type: "message_complete" };
     const event = buildAssistantEvent(msg);
     expect(event.conversationId).toBeUndefined();
   });
@@ -63,7 +63,7 @@ describe("daemon send → one mirrored assistant event", () => {
       },
     });
 
-    const msg: ServerMessage = {
+    const msg: AssistantEvent = {
       type: "assistant_text_delta",
       conversationId: "sess_a",
       text: "hello",
@@ -87,7 +87,7 @@ describe("daemon send → one mirrored assistant event", () => {
       },
     });
 
-    const msg: ServerMessage = { type: "message_complete" }; // no conversationId field
+    const msg: AssistantEvent = { type: "message_complete" }; // no conversationId field
     const event = buildAssistantEvent(msg, "sess_explicit");
 
     await hub.publish(event);
@@ -117,7 +117,7 @@ describe("daemon broadcast → one mirrored event per message (not per socket)",
     });
 
     // Simulate broadcast: server calls publishAssistantEvent once
-    const msg: ServerMessage = {
+    const msg: AssistantEvent = {
       type: "message_complete",
       conversationId: "sess_b",
     };
@@ -139,12 +139,12 @@ describe("daemon broadcast → one mirrored event per message (not per socket)",
       },
     });
 
-    const msgA: ServerMessage = {
+    const msgA: AssistantEvent = {
       type: "assistant_text_delta",
       conversationId: "s1",
       text: "a",
     };
-    const msgB: ServerMessage = {
+    const msgB: AssistantEvent = {
       type: "message_complete",
       conversationId: "s1",
     };

--- a/assistant/src/__tests__/emit-event-signal.test.ts
+++ b/assistant/src/__tests__/emit-event-signal.test.ts
@@ -1,7 +1,7 @@
 /**
  * Behavioral test for the generic CLI→daemon event bridge.
  *
- * Callers write a JSON-encoded {@link ServerMessage} to
+ * Callers write a JSON-encoded {@link AssistantEvent} to
  * `<signalsDir>/emit-event`. {@link handleEmitEventSignal} reads that
  * payload and republishes it through the {@link assistantEventHub} so
  * SSE subscribers receive it.
@@ -10,7 +10,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { handleEmitEventSignal } from "../signals/emit-event.js";
@@ -33,10 +33,10 @@ afterEach(() => {
 });
 
 describe("handleEmitEventSignal", () => {
-  test("reads a ServerMessage from the signal file and publishes it to the event hub", async () => {
+  test("reads a AssistantEvent from the signal file and publishes it to the event hub", async () => {
     mkdirSync(getSignalsDir(), { recursive: true });
 
-    const payload: ServerMessage = { type: "contacts_changed" };
+    const payload: AssistantEvent = { type: "contacts_changed" };
 
     writeFileSync(signalPath(), JSON.stringify(payload), "utf-8");
 

--- a/assistant/src/__tests__/emit-event-signal.test.ts
+++ b/assistant/src/__tests__/emit-event-signal.test.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
 import type { ServerMessage } from "../daemon/message-protocol.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { handleEmitEventSignal } from "../signals/emit-event.js";
 import { getSignalsDir } from "../util/platform.js";
@@ -40,7 +40,7 @@ describe("handleEmitEventSignal", () => {
 
     writeFileSync(signalPath(), JSON.stringify(payload), "utf-8");
 
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     let resolveDelivered: (() => void) | null = null;
     const delivered = new Promise<void>((resolve) => {
       resolveDelivered = resolve;

--- a/assistant/src/__tests__/events-tail-route.test.ts
+++ b/assistant/src/__tests__/events-tail-route.test.ts
@@ -13,7 +13,7 @@
  */
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   _resetStreamStateForTesting,
   stampAndBuffer,
@@ -30,7 +30,7 @@ if (!tailRoute) {
 }
 
 interface TailResponse {
-  events: AssistantEvent[];
+  events: AssistantEventEnvelope[];
   complete: boolean;
   frontier: number | null;
 }
@@ -45,7 +45,9 @@ function callTail(
   }) as TailResponse;
 }
 
-function mkEvent(overrides: Partial<AssistantEvent> = {}): AssistantEvent {
+function mkEvent(
+  overrides: Partial<AssistantEventEnvelope> = {},
+): AssistantEventEnvelope {
   const conversationId =
     "conversationId" in overrides ? overrides.conversationId : CONV;
   return {
@@ -58,7 +60,7 @@ function mkEvent(overrides: Partial<AssistantEvent> = {}): AssistantEvent {
       text: "x",
     },
     ...overrides,
-  } as AssistantEvent;
+  } as AssistantEventEnvelope;
 }
 
 describe("GET events/tail", () => {

--- a/assistant/src/__tests__/helpers/native-web-search-harness.ts
+++ b/assistant/src/__tests__/helpers/native-web-search-harness.ts
@@ -4,7 +4,7 @@
  *
  * Both `native-web-search.test.ts` and `web-search-backend-failure.test.ts`
  * exercise the same handler the same way: build a set of mocked
- * `EventHandlerDeps` (capturing emitted `ServerMessage`s and `rlog.warn`
+ * `EventHandlerDeps` (capturing emitted `AssistantEvent`s and `rlog.warn`
  * records), then drive a `server_tool_start` → `server_tool_complete` pair.
  * This module is the single source of truth for that harness so the two suites
  * cannot drift apart.
@@ -19,10 +19,10 @@ import type {
   EventHandlerState,
 } from "../../daemon/conversation-agent-loop-handlers.js";
 import { dispatchAgentEvent } from "../../daemon/conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../daemon/message-protocol.js";
 
-/** A `tool_result` `ServerMessage` emitted by the handler. */
-export type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
+/** A `tool_result` `AssistantEvent` emitted by the handler. */
+export type ToolResultEvent = Extract<AssistantEvent, { type: "tool_result" }>;
 
 /** A captured `rlog.warn(obj, msg)` call. */
 export interface LogRecord {
@@ -32,15 +32,15 @@ export interface LogRecord {
 
 export interface HandlerHarness {
   deps: EventHandlerDeps;
-  /** Every `ServerMessage` the handler emitted via `onEvent`. */
-  events: ServerMessage[];
+  /** Every `AssistantEvent` the handler emitted via `onEvent`. */
+  events: AssistantEvent[];
   /** Every `rlog.warn(obj, msg)` call the handler made. */
   warnings: LogRecord[];
 }
 
 /** Build mocked handler deps that capture emitted events and warn logs. */
 export function createHandlerDeps(reqId = "req-web-search"): HandlerHarness {
-  const events: ServerMessage[] = [];
+  const events: AssistantEvent[] = [];
   const warnings: LogRecord[] = [];
   const rlog = {
     warn: (obj: Record<string, unknown>, msg?: string) =>
@@ -60,7 +60,7 @@ export function createHandlerDeps(reqId = "req-web-search"): HandlerHarness {
       markWorkspaceTopLevelDirty: () => {},
       currentTurnSurfaces: [],
     } as unknown as EventHandlerDeps["ctx"],
-    onEvent: (msg: ServerMessage) => events.push(msg),
+    onEvent: (msg: AssistantEvent) => events.push(msg),
     reqId,
     isFirstMessage: false,
     shouldGenerateTitle: false,
@@ -110,13 +110,13 @@ export async function completeNativeWebSearch(
 }
 
 /** All `tool_result` events emitted so far, in order. */
-export function toolResults(events: ServerMessage[]): ToolResultEvent[] {
+export function toolResults(events: AssistantEvent[]): ToolResultEvent[] {
   return events.filter((e): e is ToolResultEvent => e.type === "tool_result");
 }
 
 /** The most recent `tool_result` event, if any. */
 export function lastToolResult(
-  events: ServerMessage[],
+  events: AssistantEvent[],
 ): ToolResultEvent | undefined {
   const results = toolResults(events);
   return results[results.length - 1];

--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -59,7 +59,7 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
 const pendingInteractions = await import("../runtime/pending-interactions.js");
 const { HostBrowserProxy } = await import("../daemon/host-browser-proxy.js");
 
-/** Extract the ServerMessage payloads from published events. */
+/** Extract the AssistantEvent payloads from published events. */
 function getPublishedMessages(): unknown[] {
   return publishedEvents;
 }

--- a/assistant/src/__tests__/host-transfer-pending-interactions.test.ts
+++ b/assistant/src/__tests__/host-transfer-pending-interactions.test.ts
@@ -3,7 +3,7 @@
  * registration.
  *
  * Verifies:
- * - HostTransferRequestEvent and HostTransferCancelEvent are part of ServerMessage
+ * - HostTransferRequestEvent and HostTransferCancelEvent are part of AssistantEvent
  * - "host_transfer" is a valid PendingInteraction kind
  * - host_transfer interactions survive removeByConversation (not auto-denied)
  */
@@ -13,7 +13,7 @@ import type {
   HostTransferCancelEvent,
   HostTransferRequestEvent,
 } from "../api/events/host-transfer.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 
 // ---------------------------------------------------------------------------
@@ -21,7 +21,7 @@ import * as pendingInteractions from "../runtime/pending-interactions.js";
 // ---------------------------------------------------------------------------
 
 describe("HostTransfer message types", () => {
-  test("host_transfer to_host request is assignable to ServerMessage", () => {
+  test("host_transfer to_host request is assignable to AssistantEvent", () => {
     const msg: HostTransferRequestEvent = {
       type: "host_transfer_request",
       requestId: "req-1",
@@ -33,11 +33,11 @@ describe("HostTransfer message types", () => {
       sha256: "abc123",
       overwrite: false,
     };
-    const _sm: ServerMessage = msg;
+    const _sm: AssistantEvent = msg;
     expect(_sm.type).toBe("host_transfer_request");
   });
 
-  test("host_transfer to_sandbox request is assignable to ServerMessage", () => {
+  test("host_transfer to_sandbox request is assignable to AssistantEvent", () => {
     const msg: HostTransferRequestEvent = {
       type: "host_transfer_request",
       requestId: "req-2",
@@ -46,17 +46,17 @@ describe("HostTransfer message types", () => {
       transferId: "xfer-2",
       sourcePath: "/home/user/file.txt",
     };
-    const _sm: ServerMessage = msg;
+    const _sm: AssistantEvent = msg;
     expect(_sm.type).toBe("host_transfer_request");
   });
 
-  test("HostTransferCancelEvent is assignable to ServerMessage", () => {
+  test("HostTransferCancelEvent is assignable to AssistantEvent", () => {
     const msg: HostTransferCancelEvent = {
       type: "host_transfer_cancel",
       requestId: "req-3",
       conversationId: "conv-1",
     };
-    const _sm: ServerMessage = msg;
+    const _sm: AssistantEvent = msg;
     expect(_sm.type).toBe("host_transfer_cancel");
   });
 

--- a/assistant/src/__tests__/list-messages-page-latest.test.ts
+++ b/assistant/src/__tests__/list-messages-page-latest.test.ts
@@ -31,7 +31,7 @@ import {
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { messages } from "../persistence/schema/index.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   _resetStreamStateForTesting,
   getCurrentSeq,
@@ -130,7 +130,7 @@ function advanceGlobalSeq(count: number): void {
         conversationId: "seq-bump-conv",
         text: "x",
       },
-    } as AssistantEvent);
+    } as AssistantEventEnvelope);
   }
 }
 

--- a/assistant/src/__tests__/memory-retrieval-hook.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-hook.test.ts
@@ -68,7 +68,7 @@ import type { UserPromptSubmitContext } from "@vellumai/plugin-api";
 
 import type { AssistantConfig } from "../config/schema.js";
 import type { Conversation } from "../daemon/conversation.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { QdrantSparseVector } from "../persistence/embeddings/qdrant-client.js";
 import type { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import userPromptSubmitMemoryRetrieval from "../plugins/defaults/memory/hooks/user-prompt-submit.js";
@@ -337,7 +337,7 @@ describe("user-prompt-submit hook (memory retrieval)", () => {
     expect(logEntry.reason).toBe("graph:none");
     // The `memory_recalled` summary publishes through the shared broadcast hub.
     expect(broadcastMessageMock).toHaveBeenCalledTimes(1);
-    const emitted = broadcastMessageMock.mock.calls[0]?.[0] as ServerMessage;
+    const emitted = broadcastMessageMock.mock.calls[0]?.[0] as AssistantEvent;
     expect(emitted.type).toBe("memory_recalled");
   });
 
@@ -449,7 +449,7 @@ describe("user-prompt-submit hook (memory retrieval)", () => {
         _msgs: Message[],
         _cfg: AssistantConfig,
         _signal: AbortSignal,
-        _onEvent: (msg: ServerMessage) => void,
+        _onEvent: (msg: AssistantEvent) => void,
       ) => Promise.reject(new Error("retrieval failed")),
     );
     const graphMemory = {
@@ -472,7 +472,7 @@ describe("user-prompt-submit hook (memory retrieval)", () => {
         _msgs: Message[],
         _cfg: AssistantConfig,
         signal: AbortSignal,
-        _onEvent: (msg: ServerMessage) => void,
+        _onEvent: (msg: AssistantEvent) => void,
       ) => {
         capturedSignal = signal;
         return {

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -98,7 +98,7 @@ mock.module("../notifications/conversation-pairing.js", () => ({
   },
 }));
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { VellumAdapter } from "../notifications/adapters/macos.js";
 import { NotificationBroadcaster } from "../notifications/broadcaster.js";
 import type { NotificationSignal } from "../notifications/signal.js";
@@ -179,7 +179,7 @@ describe("notification deep-link metadata", () => {
 
   describe("VellumAdapter", () => {
     test("broadcasts notification_intent with deepLinkMetadata from payload", async () => {
-      const messages: ServerMessage[] = [];
+      const messages: AssistantEvent[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       await adapter.send(
@@ -207,7 +207,7 @@ describe("notification deep-link metadata", () => {
     });
 
     test("broadcasts notification_intent without deepLinkMetadata when absent", async () => {
-      const messages: ServerMessage[] = [];
+      const messages: AssistantEvent[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       await adapter.send(
@@ -226,7 +226,7 @@ describe("notification deep-link metadata", () => {
     });
 
     test("includes conversationId in deepLinkMetadata for navigation", async () => {
-      const messages: ServerMessage[] = [];
+      const messages: AssistantEvent[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       const conversationId = "conv-deep-link-test";
@@ -279,7 +279,7 @@ describe("notification deep-link metadata", () => {
     });
 
     test("sourceEventName is included in the event payload", async () => {
-      const messages: ServerMessage[] = [];
+      const messages: AssistantEvent[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       await adapter.send(
@@ -296,7 +296,7 @@ describe("notification deep-link metadata", () => {
     });
 
     test("deepLinkMetadata with conversationId enables client-side navigation", async () => {
-      const messages: ServerMessage[] = [];
+      const messages: AssistantEvent[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       // Simulate a notification that should deep-link to a specific conversation
@@ -320,7 +320,7 @@ describe("notification deep-link metadata", () => {
     });
 
     test("deep-link payload includes messageId when present", async () => {
-      const messages: ServerMessage[] = [];
+      const messages: AssistantEvent[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       await adapter.send(
@@ -341,7 +341,7 @@ describe("notification deep-link metadata", () => {
     // ── Deep-link conversationId present regardless of reuse/new ──────
 
     test("deep-link payload includes conversationId for a newly created conversation", async () => {
-      const messages: ServerMessage[] = [];
+      const messages: AssistantEvent[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       // Simulates the broadcaster merging pairing.conversationId into deep-link
@@ -362,7 +362,7 @@ describe("notification deep-link metadata", () => {
     });
 
     test("deep-link payload includes conversationId for a reused conversation", async () => {
-      const messages: ServerMessage[] = [];
+      const messages: AssistantEvent[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       // Simulates the broadcaster merging pairing.conversationId into deep-link
@@ -388,7 +388,7 @@ describe("notification deep-link metadata", () => {
     // ── Reused conversation deep-link stability regressions ─────────────────
 
     test("reused conversation preserves the same conversationId across follow-up notifications", async () => {
-      const messages: ServerMessage[] = [];
+      const messages: AssistantEvent[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       const stableConversationId = "conv-bound-telegram-dest-001";
@@ -438,7 +438,7 @@ describe("notification deep-link metadata", () => {
     });
 
     test("reused conversation deep-link messageId changes per delivery for scroll targeting", async () => {
-      const messages: ServerMessage[] = [];
+      const messages: AssistantEvent[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       const conversationId = "conv-reused-scroll-test";
@@ -475,7 +475,7 @@ describe("notification deep-link metadata", () => {
     });
 
     test("deep-link metadata is stable when conversation is reused via binding-key continuation", async () => {
-      const messages: ServerMessage[] = [];
+      const messages: AssistantEvent[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 
       // Simulates the binding-key continuation path: multiple notifications

--- a/assistant/src/__tests__/notification-vellum-adapter.test.ts
+++ b/assistant/src/__tests__/notification-vellum-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { VellumAdapter } from "../notifications/adapters/macos.js";
 import type {
   ChannelDeliveryPayload,
@@ -30,9 +30,9 @@ function makeDestination(
 
 function captureBroadcast(): {
   adapter: VellumAdapter;
-  sent: ServerMessage[];
+  sent: AssistantEvent[];
 } {
-  const sent: ServerMessage[] = [];
+  const sent: AssistantEvent[] = [];
   const adapter = new VellumAdapter((msg) => sent.push(msg));
   return { adapter, sent };
 }
@@ -48,7 +48,7 @@ describe("VellumAdapter silent flag", () => {
     expect(result.success).toBe(true);
     expect(sent).toHaveLength(1);
     const intent = sent[0] as Extract<
-      ServerMessage,
+      AssistantEvent,
       { type: "notification_intent" }
     >;
     expect(intent.type).toBe("notification_intent");
@@ -60,7 +60,7 @@ describe("VellumAdapter silent flag", () => {
     await adapter.send(makePayload({ urgency: "medium" }), makeDestination());
 
     const intent = sent[0] as Extract<
-      ServerMessage,
+      AssistantEvent,
       { type: "notification_intent" }
     >;
     expect(intent.silent).toBe(true);
@@ -71,7 +71,7 @@ describe("VellumAdapter silent flag", () => {
     await adapter.send(makePayload({ urgency: "high" }), makeDestination());
 
     const intent = sent[0] as Extract<
-      ServerMessage,
+      AssistantEvent,
       { type: "notification_intent" }
     >;
     expect(intent.silent).toBe(false);
@@ -82,7 +82,7 @@ describe("VellumAdapter silent flag", () => {
     await adapter.send(makePayload({ urgency: "critical" }), makeDestination());
 
     const intent = sent[0] as Extract<
-      ServerMessage,
+      AssistantEvent,
       { type: "notification_intent" }
     >;
     expect(intent.silent).toBe(false);
@@ -101,7 +101,7 @@ describe("VellumAdapter silent flag", () => {
     );
 
     const intent = sent[0] as Extract<
-      ServerMessage,
+      AssistantEvent,
       { type: "notification_intent" }
     >;
     expect(intent.deliveryId).toBe("delivery-xyz");

--- a/assistant/src/__tests__/outbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/outbound-slack-persistence.test.ts
@@ -66,7 +66,7 @@ mock.module("../persistence/conversation-crud.js", () => ({
     updates: Record<string, unknown>,
   ) => {
     const row = persistedRows.find((candidate) => candidate.id === messageId);
-    if (!row) return;
+    if (!row) {return;}
     const existing =
       row.metadata && typeof row.metadata === "string"
         ? (JSON.parse(row.metadata) as Record<string, unknown>)
@@ -78,18 +78,18 @@ mock.module("../persistence/conversation-crud.js", () => ({
     // `lastAssistantPersisted()` assertions continue to find the row that
     // was reserved at `llm_call_started` time.
     const row = persistedRows.find((candidate) => candidate.id === messageId);
-    if (row) row.content = content;
+    if (row) {row.content = content;}
     const call = addMessageCalls.find((c) => c.id === messageId);
-    if (call) call.content = content;
+    if (call) {call.content = content;}
   },
   markMessageContentInflight: () => {},
   finalizeMessageContent: (messageId: string, content: string) => {
     // The finalize seam writes through `finalizeMessageContent`; mirror it
     // into the same captures as `updateMessageContent`.
     const row = persistedRows.find((candidate) => candidate.id === messageId);
-    if (row) row.content = content;
+    if (row) {row.content = content;}
     const call = addMessageCalls.find((c) => c.id === messageId);
-    if (call) call.content = content;
+    if (call) {call.content = content;}
   },
   // The handler treats provenance as a flat spread; returning {} keeps the
   // metadata snapshot focused on the fields under test.
@@ -162,7 +162,7 @@ import {
   handleLlmCallStarted,
   handleMessageComplete,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import { deliverReplyViaCallback } from "../runtime/channel-reply-delivery.js";
 import { setConfig } from "./helpers/set-config.js";
@@ -194,7 +194,7 @@ function makeDeps(
       },
       clientTimezone: overrides.clientTimezone,
     } as unknown as EventHandlerDeps["ctx"],
-    onEvent: (_msg: ServerMessage) => {},
+    onEvent: (_msg: AssistantEvent) => {},
     reqId: "test-req-id",
     isFirstMessage: false,
     shouldGenerateTitle: false,
@@ -233,7 +233,7 @@ function makeMessageCompleteEvent(
 /** Find the most recently persisted assistant-role message in the capture log. */
 function lastAssistantPersisted(): AddMessageCall {
   for (let i = addMessageCalls.length - 1; i >= 0; i--) {
-    if (addMessageCalls[i].role === "assistant") return addMessageCalls[i];
+    if (addMessageCalls[i].role === "assistant") {return addMessageCalls[i];}
   }
   throw new Error("No assistant message was persisted via addMessage");
 }

--- a/assistant/src/__tests__/pending-interactions-resolved-event.test.ts
+++ b/assistant/src/__tests__/pending-interactions-resolved-event.test.ts
@@ -10,14 +10,14 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 
 // Capture every broadcast emitted by the tracker. The real hub is replaced
 // with a thin recorder so we can assert payloads deterministically.
-const publishedMessages: ServerMessage[] = [];
+const publishedMessages: AssistantEvent[] = [];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: ServerMessage) => {
+  broadcastMessage: (msg: AssistantEvent) => {
     publishedMessages.push(msg);
   },
   capabilityForMessageType: () => undefined,
@@ -41,7 +41,7 @@ afterEach(() => {
 function lastResolvedEvent() {
   const evt = publishedMessages.find((m) => m.type === "interaction_resolved");
   expect(evt).toBeDefined();
-  return evt as Extract<ServerMessage, { type: "interaction_resolved" }>;
+  return evt as Extract<AssistantEvent, { type: "interaction_resolved" }>;
 }
 
 describe("pendingInteractions.resolve emits interaction_resolved", () => {
@@ -181,7 +181,7 @@ describe("removeByConversation emits interaction_resolved per entry", () => {
 
     const events = publishedMessages.filter(
       (m) => m.type === "interaction_resolved",
-    ) as Extract<ServerMessage, { type: "interaction_resolved" }>[];
+    ) as Extract<AssistantEvent, { type: "interaction_resolved" }>[];
     expect(events).toHaveLength(2);
     expect(events.every((e) => e.state === "superseded")).toBe(true);
     const requestIds = new Set(events.map((e) => e.requestId));
@@ -207,7 +207,7 @@ describe("removeByConversation emits interaction_resolved per entry", () => {
     );
     expect(events).toHaveLength(1);
     expect(
-      (events[0] as Extract<ServerMessage, { type: "interaction_resolved" }>)
+      (events[0] as Extract<AssistantEvent, { type: "interaction_resolved" }>)
         .state,
     ).toBe("cancelled");
   });

--- a/assistant/src/__tests__/plugin-event-hub-facade.test.ts
+++ b/assistant/src/__tests__/plugin-event-hub-facade.test.ts
@@ -11,12 +11,12 @@
 import { describe, expect, test } from "bun:test";
 
 import { assistantEventHub as pluginHub } from "../plugin-api/index.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub as rawHub } from "../runtime/assistant-event-hub.js";
 
 /** Minimal event envelope; the facade guard keys only off `message.type`. */
-function envelope(type: string): AssistantEvent {
-  return { message: { type } } as unknown as AssistantEvent;
+function envelope(type: string): AssistantEventEnvelope {
+  return { message: { type } } as unknown as AssistantEventEnvelope;
 }
 
 function eventType(event: unknown): unknown {
@@ -24,7 +24,7 @@ function eventType(event: unknown): unknown {
 }
 
 /** Register a host-capable desktop client subscriber on the raw hub. */
-function subscribeHostClient(clientId: string, sink: AssistantEvent[]) {
+function subscribeHostClient(clientId: string, sink: AssistantEventEnvelope[]) {
   return rawHub.subscribe({
     type: "client",
     clientId,
@@ -65,11 +65,14 @@ describe("plugin-facing assistantEventHub facade", () => {
     const proto = Object.getPrototypeOf(pluginHub) as { publish?: unknown };
     expect(typeof proto?.publish).not.toBe("function");
 
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const sub = subscribeHostClient("facade-proto-client", received);
     try {
       const p = Object.getPrototypeOf(pluginHub) as {
-        publish?: (event: AssistantEvent, options?: unknown) => Promise<void>;
+        publish?: (
+          event: AssistantEventEnvelope,
+          options?: unknown,
+        ) => Promise<void>;
       } | null;
       await p?.publish?.call(pluginHub, envelope("host_bash_request"), {
         targetClientId: "facade-proto-client",
@@ -97,7 +100,7 @@ describe("plugin-facing assistantEventHub facade", () => {
   });
 
   test("snapshots the event so a mutating type getter cannot bypass the guard (Codex P1)", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const sub = subscribeHostClient("facade-toctou-client", received);
     try {
       // `message.type` reads benign first (what the guard would see) then turns
@@ -111,7 +114,7 @@ describe("plugin-facing assistantEventHub facade", () => {
           return reads === 1 ? "sync_changed" : "host_bash_request";
         },
       });
-      const sneaky = { message } as unknown as AssistantEvent;
+      const sneaky = { message } as unknown as AssistantEventEnvelope;
 
       await pluginHub.publish(sneaky, {
         targetClientId: "facade-toctou-client",
@@ -127,7 +130,7 @@ describe("plugin-facing assistantEventHub facade", () => {
   });
 
   test("freezes the published snapshot so a subscriber cannot mutate it mid-fanout (Codex P1)", async () => {
-    const hostReceived: AssistantEvent[] = [];
+    const hostReceived: AssistantEventEnvelope[] = [];
     // A malicious subscriber registered first tries to turn the in-flight event
     // into a host request before the host-capable client (registered after)
     // receives the same fanned-out object.
@@ -154,7 +157,7 @@ describe("plugin-facing assistantEventHub facade", () => {
   });
 
   test("rejects host events disguised as boxed strings (Codex P1)", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const sub = subscribeHostClient("facade-boxed-client", received);
     try {
       // `new String(...)` is typeof "object" (slipping a naive string guard) but
@@ -164,7 +167,7 @@ describe("plugin-facing assistantEventHub facade", () => {
       const boxedType = new String("host_bash_request");
       const boxed = {
         message: { type: boxedType },
-      } as unknown as AssistantEvent;
+      } as unknown as AssistantEventEnvelope;
       let rejected: unknown;
       try {
         await pluginHub.publish(boxed, {
@@ -183,7 +186,7 @@ describe("plugin-facing assistantEventHub facade", () => {
   });
 
   test("delegates non-host publish to the shared singleton", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     // Subscribe on the RAW hub, publish through the FACADE: delivery proves the
     // facade delegates to the same instance (shared subscriber state). The
     // delivered event is a snapshot, so it is compared by value, not identity.
@@ -214,7 +217,7 @@ describe("plugin-facing assistantEventHub facade", () => {
   });
 
   test("downgrades plugin client subscriptions to in-process (no host-event interception) (Codex P1)", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     // Ask for a host-capable client subscription; the facade must register a
     // process subscriber, which never receives capability-targeted host events.
     const sub = pluginHub.subscribe({
@@ -237,7 +240,7 @@ describe("plugin-facing assistantEventHub facade", () => {
   });
 
   test("isolates plugin callbacks so they cannot mutate the in-flight fanout event (Codex P1)", async () => {
-    const hostReceived: AssistantEvent[] = [];
+    const hostReceived: AssistantEventEnvelope[] = [];
     // The plugin subscribes first and, from its callback, tries to rewrite the
     // shared in-flight event into a host request. It must only see an isolated
     // copy, leaving the real client's event untouched.
@@ -292,7 +295,7 @@ describe("plugin-facing assistantEventHub facade", () => {
         {
           message: { type: "host_bash_request" },
           conversationId: "conv-1",
-        } as unknown as AssistantEvent,
+        } as unknown as AssistantEventEnvelope,
         { targetCapability: "host_bash" },
       );
       expect(getterCalls).toBe(callsAfterSubscribe);

--- a/assistant/src/__tests__/request-secret-standalone-channel-gate.test.ts
+++ b/assistant/src/__tests__/request-secret-standalone-channel-gate.test.ts
@@ -8,16 +8,16 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { setConfig } from "./helpers/set-config.js";
 
 // A short permission timeout keeps a leaked prompt from lingering; the default
 // `secretDetection.allowOneTimeSend` (false) drives the broadcast field.
 setConfig("timeouts", { permissionTimeoutSec: 0.01 });
 
-let broadcastMessages: ServerMessage[] = [];
+let broadcastMessages: AssistantEvent[] = [];
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: ServerMessage) => broadcastMessages.push(msg),
+  broadcastMessage: (msg: AssistantEvent) => broadcastMessages.push(msg),
 }));
 
 const _piStore = new Map<string, { rpcResolve?: (value: unknown) => void }>();

--- a/assistant/src/__tests__/runtime-events-sse-parity.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-parity.test.ts
@@ -21,7 +21,7 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 import { getOrCreateConversation } from "../persistence/conversation-key-store.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 
@@ -33,7 +33,7 @@ await initializeDb();
 
 /**
  * Subscribe to the SSE endpoint for a given conversationKey, publish one
- * event, read the first SSE frame, and return the parsed AssistantEvent.
+ * event, read the first SSE frame, and return the parsed AssistantEventEnvelope.
  *
  * Uses handleSubscribeAssistantEvents directly (bypassing HTTP) to avoid
  * chunked-transfer buffering in Bun's loopback implementation.
@@ -41,7 +41,7 @@ await initializeDb();
 async function publishAndReadFrame(
   conversationKey: string,
   message: ServerMessage,
-): Promise<AssistantEvent> {
+): Promise<AssistantEventEnvelope> {
   const { conversationId } = getOrCreateConversation(conversationKey);
 
   const ac = new AbortController();
@@ -69,7 +69,7 @@ async function publishAndReadFrame(
   // SSE frame: "event: assistant_event\nid: <id>\ndata: <json>\n\n"
   const dataLine = frame.split("\n").find((l) => l.startsWith("data: "));
   if (!dataLine) throw new Error(`No data line in SSE frame:\n${frame}`);
-  return JSON.parse(dataLine.slice("data: ".length)) as AssistantEvent;
+  return JSON.parse(dataLine.slice("data: ".length)) as AssistantEventEnvelope;
 }
 
 // ---------------------------------------------------------------------------
@@ -337,7 +337,7 @@ describe("SSE HTTP parity — streaming/delta message types", () => {
     const dataLine = frame.split("\n").find((l) => l.startsWith("data: "))!;
     const received = JSON.parse(
       dataLine.slice("data: ".length),
-    ) as AssistantEvent;
+    ) as AssistantEventEnvelope;
 
     // Envelope fields
     expect(received.id).toBe(published.id);

--- a/assistant/src/__tests__/runtime-events-sse-parity.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-parity.test.ts
@@ -1,7 +1,7 @@
 /**
  * HTTP parity tests for the SSE assistant-events endpoint.
  *
- * Asserts that every streaming/delta ServerMessage type is preserved
+ * Asserts that every streaming/delta AssistantEvent type is preserved
  * exactly — field-for-field — when delivered through the SSE route.
  *
  * Message types covered:
@@ -17,7 +17,7 @@
  */
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getOrCreateConversation } from "../persistence/conversation-key-store.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
@@ -40,7 +40,7 @@ await initializeDb();
  */
 async function publishAndReadFrame(
   conversationKey: string,
-  message: ServerMessage,
+  message: AssistantEvent,
 ): Promise<AssistantEventEnvelope> {
   const { conversationId } = getOrCreateConversation(conversationKey);
 
@@ -68,7 +68,7 @@ async function publishAndReadFrame(
   const frame = new TextDecoder().decode(value);
   // SSE frame: "event: assistant_event\nid: <id>\ndata: <json>\n\n"
   const dataLine = frame.split("\n").find((l) => l.startsWith("data: "));
-  if (!dataLine) throw new Error(`No data line in SSE frame:\n${frame}`);
+  if (!dataLine) {throw new Error(`No data line in SSE frame:\n${frame}`);}
   return JSON.parse(dataLine.slice("data: ".length)) as AssistantEventEnvelope;
 }
 
@@ -317,7 +317,7 @@ describe("SSE HTTP parity — streaming/delta message types", () => {
       abortSignal: ac.signal,
     });
 
-    const msg: ServerMessage = {
+    const msg: AssistantEvent = {
       type: "assistant_text_delta" as const,
       text: "envelope test",
     };

--- a/assistant/src/__tests__/runtime-events-sse.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse.test.ts
@@ -4,7 +4,7 @@
  * Tests:
  *   - 401 unauthorized (missing bearer token)
  *   - 200 when conversationKey is omitted (unfiltered subscription)
- *   - Happy path: stream receives a published AssistantEvent
+ *   - Happy path: stream receives a published AssistantEventEnvelope
  *   - Unfiltered: streams events from multiple conversations
  */
 import { beforeEach, describe, expect, test } from "bun:test";

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -51,7 +51,7 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { recordUsageEvent } from "../persistence/llm-usage-store.js";
 import { rawRun } from "../persistence/raw-query.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { BadRequestError, NotFoundError } from "../runtime/routes/errors.js";
 import { ROUTES as HEARTBEAT_ROUTES } from "../runtime/routes/heartbeat-routes.js";
@@ -417,7 +417,7 @@ describe("GET /schedules — default defer exclusion", () => {
   });
 
   test("mutation routes emit schedule sync invalidation", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -15,7 +15,7 @@ mock.module("../background-wake/publisher.js", () => ({
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import {
   cancelSchedule,
@@ -56,7 +56,7 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 }
 
 async function expectScheduleSyncEvent(
-  received: AssistantEvent[],
+  received: AssistantEventEnvelope[],
 ): Promise<void> {
   await waitFor(() =>
     received.some(
@@ -85,7 +85,7 @@ describe("schedule sync invalidation", () => {
   });
 
   test("store-level schedule mutations emit schedule sync invalidation", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {

--- a/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
+++ b/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SecretRequestEvent } from "../api/events/secret-request.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { setConfig } from "./helpers/set-config.js";
 
 // Capture all logger calls so we can verify secret values never appear
@@ -30,9 +30,9 @@ mock.module("../util/logger.js", () => ({
 }));
 
 // Capture broadcastMessage calls
-const broadcastedMessages: ServerMessage[] = [];
+const broadcastedMessages: AssistantEvent[] = [];
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: ServerMessage) => {
+  broadcastMessage: (msg: AssistantEvent) => {
     broadcastedMessages.push(msg);
   },
 }));

--- a/assistant/src/__tests__/secret-prompter-channel-fallback.test.ts
+++ b/assistant/src/__tests__/secret-prompter-channel-fallback.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SecretRequestEvent } from "../api/events/secret-request.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { setConfig } from "./helpers/set-config.js";
 
 // Use a tiny timeout so the setTimeout branch fires quickly in tests
@@ -25,9 +25,9 @@ mock.module("../util/logger.js", () => ({
   }),
 }));
 
-let broadcastMessages: ServerMessage[] = [];
+let broadcastMessages: AssistantEvent[] = [];
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: ServerMessage) => broadcastMessages.push(msg),
+  broadcastMessage: (msg: AssistantEvent) => broadcastMessages.push(msg),
 }));
 
 // Use a real Map so SecretPrompter can store and retrieve promptResolve/promptReject callbacks.

--- a/assistant/src/__tests__/secret-response-routing.test.ts
+++ b/assistant/src/__tests__/secret-response-routing.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SecretRequestEvent } from "../api/events/secret-request.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { SecretPromptResult } from "../permissions/secret-prompt-types.js";
 
-let broadcastedMessages: ServerMessage[] = [];
+let broadcastedMessages: AssistantEvent[] = [];
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: ServerMessage) => broadcastedMessages.push(msg),
+  broadcastMessage: (msg: AssistantEvent) => broadcastedMessages.push(msg),
 }));
 
 // Use a real Map so SecretPrompter can store and retrieve promptResolve/promptReject callbacks.

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
 
 import type { Conversation } from "../daemon/conversation.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import {
   getConversationByKey,
   getOrCreateConversation,
@@ -143,7 +143,7 @@ function makeCompletingConversation(): Conversation {
     runAgentLoop: async (
       _content: string,
       _messageId: string,
-      options?: { onEvent?: (msg: ServerMessage) => void },
+      options?: { onEvent?: (msg: AssistantEvent) => void },
     ) => {
       const onEvent = options?.onEvent ?? (() => {});
       onEvent({ type: "assistant_text_delta", text: "Hello!" });
@@ -162,7 +162,7 @@ function makeHangingConversation(): Conversation {
   const messages: unknown[] = [];
   const enqueuedMessages: Array<{
     content: string;
-    onEvent?: (msg: ServerMessage) => void;
+    onEvent?: (msg: AssistantEvent) => void;
     requestId?: string;
   }> = [];
   return {
@@ -191,7 +191,7 @@ function makeHangingConversation(): Conversation {
     getQueueDepth: () => enqueuedMessages.length,
     enqueueMessage: (options: {
       content: string;
-      onEvent?: (msg: ServerMessage) => void;
+      onEvent?: (msg: AssistantEvent) => void;
       requestId?: string;
     }) => {
       enqueuedMessages.push({

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -100,7 +100,7 @@ mock.module(
 import { __resetGuardianDeliveryCacheForTest } from "../contacts/guardian-delivery-reader.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import type { ApprovalConversationGenerator } from "../runtime/http-types.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
@@ -375,7 +375,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
   });
 
   test("publishes events to assistantEventHub when conversation is idle", async () => {
-    const publishedEvents: AssistantEvent[] = [];
+    const publishedEvents: AssistantEventEnvelope[] = [];
 
     await startServer(() => makeCompletingConversation());
 
@@ -384,7 +384,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
       await import("../runtime/assistant-event-hub.js");
     routeEventHub.subscribe({
       type: "process",
-      callback: (event: AssistantEvent) => {
+      callback: (event: AssistantEventEnvelope) => {
         publishedEvents.push(event);
       },
     });

--- a/assistant/src/__tests__/starter-task-flow.test.ts
+++ b/assistant/src/__tests__/starter-task-flow.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, mock, test } from "bun:test";
 
-import type { ServerMessage, SurfaceType } from "../daemon/message-protocol.js";
+import type {
+  AssistantEvent,
+  SurfaceType,
+} from "../daemon/message-protocol.js";
 
 mock.module("../apps/app-store.js", () => ({
   getApp: (id: string) => {
-    if (id !== "test-app") return null;
+    if (id !== "test-app") {return null;}
     return {
       id,
       name: "Test App",
@@ -116,7 +119,7 @@ describe("starter task surface actions", () => {
   });
 
   test("app_open registers dynamic_page surface as action-capable", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext();
     ctx.sendToClient = (msg) => sent.push(msg);
 

--- a/assistant/src/__tests__/subagent-call-site-routing.test.ts
+++ b/assistant/src/__tests__/subagent-call-site-routing.test.ts
@@ -17,7 +17,7 @@
  */
 import { afterAll, describe, expect, mock, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getProvider as getProviderImport } from "../providers/registry.js";
 import { setConfig } from "./helpers/set-config.js";
 
@@ -42,7 +42,7 @@ class FakeConversation {
     provider: unknown,
     _systemPrompt: string,
     _maxTokens: number,
-    _sendToClient: (msg: ServerMessage) => void,
+    _sendToClient: (msg: AssistantEvent) => void,
   ) {
     capturedProvider = provider;
     this.capturedState = {

--- a/assistant/src/__tests__/subagent-disposal.test.ts
+++ b/assistant/src/__tests__/subagent-disposal.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { SubagentManager } from "../subagent/manager.js";
 import type { SubagentState } from "../subagent/types.js";
 
@@ -13,7 +13,7 @@ interface FakeManagedSubagent {
       role: string;
       content: Array<{ type: string; text: string }>;
     }>;
-    sendToClient: (msg: ServerMessage) => void;
+    sendToClient: (msg: AssistantEvent) => void;
     persistUserMessage?: () => { id: string; deduplicated: boolean };
     runAgentLoop?: () => Promise<void>;
     enqueueMessage?: () => { rejected: boolean; queued: boolean };
@@ -25,7 +25,7 @@ interface FakeManagedSubagent {
     subagentDeniedToolNames: Set<string>;
   } | null;
   state: SubagentState;
-  parentSendToClient: (msg: ServerMessage) => void;
+  parentSendToClient: (msg: AssistantEvent) => void;
   retainedUntil?: number;
   hadEnqueuedMessages?: boolean;
 }
@@ -60,7 +60,7 @@ function injectFakeSubagent(
   manager: SubagentManager,
   subagentId: string,
   state: SubagentState,
-  parentSendToClient?: (msg: ServerMessage) => void,
+  parentSendToClient?: (msg: AssistantEvent) => void,
   conversation?: FakeManagedSubagent["conversation"],
 ): void {
   const internals = asInternals(manager);
@@ -332,8 +332,8 @@ describe("SubagentManager terminal disposal", () => {
 describe("SubagentManager.abort usage", () => {
   test("emits the conversation's latest usage on abort, not zeros", () => {
     const manager = new SubagentManager();
-    const sent: ServerMessage[] = [];
-    const sender = (msg: ServerMessage) => sent.push(msg);
+    const sent: AssistantEvent[] = [];
+    const sender = (msg: AssistantEvent) => sent.push(msg);
 
     const subagentId = "sa-abort-usage";
     // state.usage starts at {0,0,0}; the live (fake) conversation has accrued
@@ -347,7 +347,7 @@ describe("SubagentManager.abort usage", () => {
     expect(aborted).toBe(true);
 
     const statusMsg = sent.find(
-      (m): m is Extract<ServerMessage, { type: "subagent_status_changed" }> =>
+      (m): m is Extract<AssistantEvent, { type: "subagent_status_changed" }> =>
         m.type === "subagent_status_changed",
     );
     expect(statusMsg).toBeDefined();
@@ -365,8 +365,8 @@ describe("SubagentManager.abort usage", () => {
 
   test("keeps the last-known state.usage when the conversation was already released", () => {
     const manager = new SubagentManager();
-    const sent: ServerMessage[] = [];
-    const sender = (msg: ServerMessage) => sent.push(msg);
+    const sent: AssistantEvent[] = [];
+    const sender = (msg: AssistantEvent) => sent.push(msg);
 
     const subagentId = "sa-abort-no-conv";
     // No live conversation (released), but state carries a last-known usage —
@@ -381,7 +381,7 @@ describe("SubagentManager.abort usage", () => {
     });
 
     const statusMsg = sent.find(
-      (m): m is Extract<ServerMessage, { type: "subagent_status_changed" }> =>
+      (m): m is Extract<AssistantEvent, { type: "subagent_status_changed" }> =>
         m.type === "subagent_status_changed",
     );
     expect(statusMsg!.usage).toEqual({

--- a/assistant/src/__tests__/subagent-fork-notifications.test.ts
+++ b/assistant/src/__tests__/subagent-fork-notifications.test.ts
@@ -29,7 +29,7 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   broadcastMessage: () => {},
 }));
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { SubagentManager } from "../subagent/manager.js";
 import type { SubagentState } from "../subagent/types.js";
 
@@ -42,7 +42,7 @@ interface FakeManagedSubagent {
       role: string;
       content: Array<{ type: string; text: string }>;
     }>;
-    sendToClient: (msg: ServerMessage) => void;
+    sendToClient: (msg: AssistantEvent) => void;
     loadFromDb?: () => Promise<void>;
     persistUserMessage?: () => { id: string; deduplicated: boolean };
     runAgentLoop?: () => Promise<void>;
@@ -54,7 +54,7 @@ interface FakeManagedSubagent {
     subagentDeniedToolNames: Set<string>;
   } | null;
   state: SubagentState;
-  parentSendToClient: (msg: ServerMessage) => void;
+  parentSendToClient: (msg: AssistantEvent) => void;
 }
 
 /** Type-safe accessor for SubagentManager's private internals via bracket notation. */
@@ -73,7 +73,7 @@ function injectFakeSubagent(
   manager: SubagentManager,
   subagentId: string,
   state: SubagentState,
-  parentSendToClient?: (msg: ServerMessage) => void,
+  parentSendToClient?: (msg: AssistantEvent) => void,
 ): void {
   const fakeSession: FakeManagedSubagent["conversation"] = {
     abort: () => {},

--- a/assistant/src/__tests__/subagent-fork-prompt-role.test.ts
+++ b/assistant/src/__tests__/subagent-fork-prompt-role.test.ts
@@ -15,7 +15,7 @@
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 
 // ── Captured constructor state ──────────────────────────────────────────────
 
@@ -36,7 +36,7 @@ class FakeConversation {
     _id: string,
     _provider: unknown,
     systemPrompt: string,
-    _sendToClient: (msg: ServerMessage) => void,
+    _sendToClient: (msg: AssistantEvent) => void,
     _workingDir: string,
     _options?: unknown,
   ) {
@@ -148,7 +148,7 @@ describe("SubagentManager fork — prompt source and role decoupling", () => {
   ): Promise<CapturedConversationState> {
     await manager.spawn(makeForkSpawnConfig(overrides), () => {});
     const created = capturedConversations[0];
-    if (!created) throw new Error("Expected a subagent conversation");
+    if (!created) {throw new Error("Expected a subagent conversation");}
     return created;
   }
 

--- a/assistant/src/__tests__/subagent-fork-spawn.test.ts
+++ b/assistant/src/__tests__/subagent-fork-spawn.test.ts
@@ -5,7 +5,7 @@ import {
   findConversation,
   setConversation,
 } from "../daemon/conversation-registry.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { Message } from "../providers/types.js";
 import { SubagentManager } from "../subagent/manager.js";
 import type { SubagentConfig, SubagentState } from "../subagent/types.js";
@@ -16,7 +16,7 @@ interface FakeManagedSubagent {
     abort: () => void;
     dispose: () => void;
     messages: Message[];
-    sendToClient: (msg: ServerMessage) => void;
+    sendToClient: (msg: AssistantEvent) => void;
     persistUserMessage?: () => { id: string; deduplicated: boolean };
     runAgentLoop?: () => Promise<void>;
     enqueueMessage?: () => { rejected: boolean; queued: boolean };
@@ -31,7 +31,7 @@ interface FakeManagedSubagent {
     subagentDeniedToolNames: Set<string>;
   } | null;
   state: SubagentState;
-  parentSendToClient: (msg: ServerMessage) => void;
+  parentSendToClient: (msg: AssistantEvent) => void;
   retainedUntil?: number;
   hadEnqueuedMessages?: boolean;
 }
@@ -66,7 +66,7 @@ function injectFakeSubagent(
   manager: SubagentManager,
   subagentId: string,
   state: SubagentState,
-  parentSendToClient?: (msg: ServerMessage) => void,
+  parentSendToClient?: (msg: AssistantEvent) => void,
   conversation?: FakeManagedSubagent["conversation"],
 ): void {
   const internals = asInternals(manager);

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -29,7 +29,7 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   broadcastMessage: () => {},
 }));
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { SubagentManager } from "../subagent/manager.js";
 import type { SubagentState } from "../subagent/types.js";
 
@@ -42,7 +42,7 @@ interface FakeManagedSubagent {
       role: string;
       content: Array<{ type: string; text: string }>;
     }>;
-    sendToClient: (msg: ServerMessage) => void;
+    sendToClient: (msg: AssistantEvent) => void;
     loadFromDb?: () => Promise<void>;
     persistUserMessage?: () => { id: string; deduplicated: boolean };
     runAgentLoop?: () => Promise<void>;
@@ -54,7 +54,7 @@ interface FakeManagedSubagent {
     subagentDeniedToolNames: Set<string>;
   } | null;
   state: SubagentState;
-  parentSendToClient: (msg: ServerMessage) => void;
+  parentSendToClient: (msg: AssistantEvent) => void;
 }
 
 /** Type-safe accessor for SubagentManager's private internals via bracket notation. */
@@ -77,7 +77,7 @@ function injectFakeSubagent(
   manager: SubagentManager,
   subagentId: string,
   state: SubagentState,
-  parentSendToClient?: (msg: ServerMessage) => void,
+  parentSendToClient?: (msg: AssistantEvent) => void,
 ): void {
   const fakeSession: FakeManagedSubagent["conversation"] = {
     abort: () => {},
@@ -137,8 +137,8 @@ describe("SubagentManager abort notification", () => {
     const state = makeState(subagentId);
     injectFakeSubagent(manager, subagentId, state);
 
-    const clientMessages: ServerMessage[] = [];
-    const sendToClient = (msg: ServerMessage) => clientMessages.push(msg);
+    const clientMessages: AssistantEvent[] = [];
+    const sendToClient = (msg: AssistantEvent) => clientMessages.push(msg);
 
     const result = manager.abort(subagentId, sendToClient);
 
@@ -160,8 +160,8 @@ describe("SubagentManager abort notification", () => {
     injectFakeSubagent(manager, subagentId, state, parentSender);
 
     // A different sender (simulating abort from a different thread's socket).
-    const abortingSender = ((_msg: ServerMessage) => {}) as (
-      msg: ServerMessage,
+    const abortingSender = ((_msg: AssistantEvent) => {}) as (
+      msg: AssistantEvent,
     ) => void;
 
     manager.abort(subagentId, abortingSender);
@@ -175,8 +175,8 @@ describe("SubagentManager abort notification", () => {
     const manager = new SubagentManager();
     const subagentId = "sub-1";
 
-    const clientMessages: ServerMessage[] = [];
-    const sendToClient = (msg: ServerMessage) => clientMessages.push(msg);
+    const clientMessages: AssistantEvent[] = [];
+    const sendToClient = (msg: AssistantEvent) => clientMessages.push(msg);
 
     // Pass the sender as parentSendToClient so the stored sender receives the status update.
     injectFakeSubagent(

--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -13,7 +13,7 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { Message } from "../providers/types.js";
 
 // ── Fake Conversation ───────────────────────────────────────────────────────
@@ -36,7 +36,7 @@ interface FakeConversationConfig {
    */
   resolveOnAbort?: boolean;
   /** Deltas to emit through sendToClient before runAgentLoop resolves. */
-  emitDeltas?: ServerMessage[];
+  emitDeltas?: AssistantEvent[];
   /**
    * Invoked synchronously at the very start of runAgentLoop (after the loop has
    * begun, so the run is past the early-terminal guard and marked "running").
@@ -64,7 +64,7 @@ class FakeConversation {
   conversationType = "background";
   hasSystemPromptOverride = false;
 
-  private sendToClient: (msg: ServerMessage) => void;
+  private sendToClient: (msg: AssistantEvent) => void;
   private readonly cfg: FakeConversationConfig;
   private aborted = false;
   private resolveAbort?: () => void;
@@ -73,7 +73,7 @@ class FakeConversation {
     _id: string,
     _provider: unknown,
     _systemPrompt: string,
-    sendToClient: (msg: ServerMessage) => void,
+    sendToClient: (msg: AssistantEvent) => void,
     _workingDir: string,
     _options?: unknown,
   ) {
@@ -82,7 +82,7 @@ class FakeConversation {
     this.messages = this.cfg.messages ?? [];
   }
 
-  updateClient(sendToClient: (msg: ServerMessage) => void) {
+  updateClient(sendToClient: (msg: AssistantEvent) => void) {
     // The manager re-points sendToClient via updateClient; honor it so the
     // wrappedSendToClient tap is the one the deltas flow through.
     this.sendToClient = sendToClient;
@@ -125,7 +125,7 @@ class FakeConversation {
           this.resolveAbort = resolve;
         });
       }
-      if (this.cfg.resolveOnAbort) return;
+      if (this.cfg.resolveOnAbort) {return;}
       throw new Error("aborted");
     }
     if (this.cfg.runError) {
@@ -199,7 +199,7 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
 }
 
 /** Statuses broadcast to the parent via `subagent_status_changed` events. */
-function broadcastStatuses(events: ServerMessage[]): string[] {
+function broadcastStatuses(events: AssistantEvent[]): string[] {
   return events
     .filter((m) => m.type === "subagent_status_changed")
     .map((m) => (m as { status: string }).status);
@@ -326,14 +326,14 @@ describe("SubagentManager.spawnAndAwait", () => {
         { role: "assistant", content: [{ type: "text", text: "done" }] },
       ],
       emitDeltas: [
-        { type: "assistant_text_delta", text: "Hello " } as ServerMessage,
+        { type: "assistant_text_delta", text: "Hello " } as AssistantEvent,
         {
           type: "assistant_thinking_delta",
           thinking: "(pondering) ",
-        } as ServerMessage,
-        { type: "assistant_text_delta", text: "world" } as ServerMessage,
+        } as AssistantEvent,
+        { type: "assistant_text_delta", text: "world" } as AssistantEvent,
         // Non-delta events must not be forwarded to onText.
-        { type: "subagent_status_changed" } as ServerMessage,
+        { type: "subagent_status_changed" } as AssistantEvent,
       ],
     };
 
@@ -382,7 +382,7 @@ describe("SubagentManager.spawnAndAwait", () => {
     // terminal first so this is recorded and broadcast as "aborted".
     nextConversationConfig = { resolveOnAbort: true };
 
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const controller = new AbortController();
     const manager = new SubagentManager();
     const promise = manager.spawnAndAwait(
@@ -441,7 +441,7 @@ describe("SubagentManager.spawnAndAwait", () => {
     const controller = new AbortController();
     controller.abort();
 
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const manager = new SubagentManager();
     await expect(
       manager.spawnAndAwait(makeConfig(), (msg) => events.push(msg), {

--- a/assistant/src/__tests__/sync-message-contract.test.ts
+++ b/assistant/src/__tests__/sync-message-contract.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  type AssistantEvent,
   buildSyncChangedMessage,
   conversationMessagesSyncTag,
-  type ServerMessage,
   SYNC_TAGS,
   SyncChangedEventSchema,
 } from "../daemon/message-protocol.js";
 
 describe("sync message contract", () => {
-  test("sync_changed is assignable to ServerMessage", () => {
-    const message: ServerMessage = {
+  test("sync_changed is assignable to AssistantEvent", () => {
+    const message: AssistantEvent = {
       type: "sync_changed",
       tags: [SYNC_TAGS.assistantAvatar],
     };

--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -48,9 +48,9 @@ mock.module("../persistence/conversation-crud.js", () => ({
   provenanceFromTrustContext: () => ({}),
   reserveMessage: reserveMessageMock,
   recordConversationPersistedSeq: (id: string, seq: number) => {
-    if (!Number.isFinite(seq) || seq <= 0) return;
+    if (!Number.isFinite(seq) || seq <= 0) {return;}
     const prev = persistedSeqByConversation.get(id);
-    if (prev == null || prev < seq) persistedSeqByConversation.set(id, seq);
+    if (prev == null || prev < seq) {persistedSeqByConversation.set(id, seq);}
   },
   getConversationPersistedSeq: (id: string) =>
     persistedSeqByConversation.get(id) ?? null,
@@ -91,7 +91,7 @@ import {
   handleToolUse,
   handleToolUsePreviewStart,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getConversationPersistedSeq } from "../persistence/conversation-crud.js";
 import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
@@ -105,7 +105,7 @@ import {
 function createMockDeps(
   overrides: Partial<EventHandlerDeps> = {},
 ): EventHandlerDeps {
-  const emittedEvents: ServerMessage[] = [];
+  const emittedEvents: AssistantEvent[] = [];
   const emittedActivityStates: Array<{
     phase: string;
     reason: string;
@@ -135,7 +135,7 @@ function createMockDeps(
       markWorkspaceTopLevelDirty: () => {},
       currentTurnSurfaces: [],
     } as unknown as EventHandlerDeps["ctx"],
-    onEvent: (msg: ServerMessage) => {
+    onEvent: (msg: AssistantEvent) => {
       emittedEvents.push(msg);
     },
     reqId: "test-req-id",
@@ -158,7 +158,7 @@ function createMockDeps(
 
 /** Collect events by wrapping onEvent. */
 function createEventCollector(): {
-  events: ServerMessage[];
+  events: AssistantEvent[];
   activityStates: Array<{
     phase: string;
     reason: string;
@@ -166,14 +166,14 @@ function createEventCollector(): {
     requestId?: string;
     statusText?: string;
   }>;
-  onEvent: (msg: ServerMessage) => void;
+  onEvent: (msg: AssistantEvent) => void;
   emitActivityState: (
     phase: string,
     reason: string,
     options?: { anchor?: string; requestId?: string; statusText?: string },
   ) => void;
 } {
-  const events: ServerMessage[] = [];
+  const events: AssistantEvent[] = [];
   const activityStates: Array<{
     phase: string;
     reason: string;
@@ -184,7 +184,7 @@ function createEventCollector(): {
   return {
     events,
     activityStates,
-    onEvent: (msg: ServerMessage) => events.push(msg),
+    onEvent: (msg: AssistantEvent) => events.push(msg),
     emitActivityState: (phase, reason, options) =>
       activityStates.push({
         phase,
@@ -392,7 +392,7 @@ describe("tool preview lifecycle", () => {
       const collector = createEventCollector();
       const conversationId = "test-session-id";
       const deps = createMockDeps({
-        onEvent: (msg: ServerMessage) => {
+        onEvent: (msg: AssistantEvent) => {
           collector.events.push(msg);
           stampAndBuffer(msg as unknown as AssistantEventEnvelope);
         },
@@ -446,10 +446,10 @@ describe("tool preview lifecycle", () => {
     /** onEvent that stamps conversation-scoped events like the runtime hub. */
     function makeStampingDeps(
       overrides: Partial<EventHandlerDeps["ctx"]> = {},
-    ): { deps: EventHandlerDeps; events: ServerMessage[] } {
-      const events: ServerMessage[] = [];
+    ): { deps: EventHandlerDeps; events: AssistantEvent[] } {
+      const events: AssistantEvent[] = [];
       const deps = createMockDeps({
-        onEvent: (msg: ServerMessage) => {
+        onEvent: (msg: AssistantEvent) => {
           events.push(msg);
           stampAndBuffer(msg as unknown as AssistantEventEnvelope);
         },
@@ -611,11 +611,11 @@ describe("tool preview lifecycle", () => {
     /** onEvent that stamps conversation-scoped events like the runtime hub. */
     function makeStampingDeps(): {
       deps: EventHandlerDeps;
-      events: ServerMessage[];
+      events: AssistantEvent[];
     } {
-      const events: ServerMessage[] = [];
+      const events: AssistantEvent[] = [];
       const deps = createMockDeps({
-        onEvent: (msg: ServerMessage) => {
+        onEvent: (msg: AssistantEvent) => {
           events.push(msg);
           stampAndBuffer(msg as unknown as AssistantEventEnvelope);
         },
@@ -803,7 +803,7 @@ describe("tool preview lifecycle", () => {
     /** Deps wired to a fresh collector. */
     function makeCollectingDeps(): {
       deps: EventHandlerDeps;
-      events: ServerMessage[];
+      events: AssistantEvent[];
     } {
       const collector = createEventCollector();
       const deps = createMockDeps({
@@ -817,7 +817,7 @@ describe("tool preview lifecycle", () => {
     }
 
     function emittedToolResult(
-      events: ServerMessage[],
+      events: AssistantEvent[],
     ): Record<string, unknown> {
       const toolResult = events.find((e) => e.type === "tool_result");
       expect(toolResult).toBeDefined();

--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -93,7 +93,7 @@ import {
 } from "../daemon/conversation-agent-loop-handlers.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { getConversationPersistedSeq } from "../persistence/conversation-crud.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   _resetStreamStateForTesting,
   getCurrentSeq,
@@ -394,7 +394,7 @@ describe("tool preview lifecycle", () => {
       const deps = createMockDeps({
         onEvent: (msg: ServerMessage) => {
           collector.events.push(msg);
-          stampAndBuffer(msg as unknown as AssistantEvent);
+          stampAndBuffer(msg as unknown as AssistantEventEnvelope);
         },
         ctx: {
           ...createMockDeps().ctx,
@@ -408,12 +408,12 @@ describe("tool preview lifecycle", () => {
         type: "assistant_text_delta",
         text: "hello",
         conversationId,
-      } as unknown as AssistantEvent);
+      } as unknown as AssistantEventEnvelope);
       stampAndBuffer({
         type: "assistant_text_delta",
         text: " world",
         conversationId,
-      } as unknown as AssistantEvent);
+      } as unknown as AssistantEventEnvelope);
 
       // WHEN a tool_use is handled (its block is already durable)
       handleToolUse(state, deps, {
@@ -430,7 +430,7 @@ describe("tool preview lifecycle", () => {
       expect(toolUseStart).toBeDefined();
       expect(getConversationPersistedSeq(conversationId)).toBe(getCurrentSeq());
       expect(getConversationPersistedSeq(conversationId)).toBe(
-        (toolUseStart as unknown as AssistantEvent).seq ?? null,
+        (toolUseStart as unknown as AssistantEventEnvelope).seq ?? null,
       );
     });
   });
@@ -451,7 +451,7 @@ describe("tool preview lifecycle", () => {
       const deps = createMockDeps({
         onEvent: (msg: ServerMessage) => {
           events.push(msg);
-          stampAndBuffer(msg as unknown as AssistantEvent);
+          stampAndBuffer(msg as unknown as AssistantEventEnvelope);
         },
         ctx: {
           ...createMockDeps().ctx,
@@ -494,7 +494,7 @@ describe("tool preview lifecycle", () => {
         },
       ]);
       expect(state.lastStreamedContentSeq).toBe(
-        (thinkingDelta as unknown as AssistantEvent).seq ?? undefined,
+        (thinkingDelta as unknown as AssistantEventEnvelope).seq ?? undefined,
       );
     });
 
@@ -531,7 +531,7 @@ describe("tool preview lifecycle", () => {
       expect(thinkingDelta).toBeDefined();
       expect(getConversationPersistedSeq(conversationId)).toBe(getCurrentSeq());
       expect(getConversationPersistedSeq(conversationId)).toBe(
-        (thinkingDelta as unknown as AssistantEvent).seq ?? null,
+        (thinkingDelta as unknown as AssistantEventEnvelope).seq ?? null,
       );
     });
 
@@ -562,7 +562,7 @@ describe("tool preview lifecycle", () => {
       expect(toolResult).toBeDefined();
       expect(getConversationPersistedSeq(conversationId)).toBe(getCurrentSeq());
       expect(getConversationPersistedSeq(conversationId)).toBe(
-        (toolResult as unknown as AssistantEvent).seq ?? null,
+        (toolResult as unknown as AssistantEventEnvelope).seq ?? null,
       );
     });
 
@@ -617,7 +617,7 @@ describe("tool preview lifecycle", () => {
       const deps = createMockDeps({
         onEvent: (msg: ServerMessage) => {
           events.push(msg);
-          stampAndBuffer(msg as unknown as AssistantEvent);
+          stampAndBuffer(msg as unknown as AssistantEventEnvelope);
         },
         ctx: {
           ...createMockDeps().ctx,

--- a/assistant/src/__tests__/tool-result-metadata-plumbing.test.ts
+++ b/assistant/src/__tests__/tool-result-metadata-plumbing.test.ts
@@ -34,18 +34,18 @@ import {
   createEventHandlerState,
   handleToolResult,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 
-type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
+type ToolResultEvent = Extract<AssistantEvent, { type: "tool_result" }>;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function createCollectorDeps(): {
   deps: EventHandlerDeps;
-  events: ServerMessage[];
+  events: AssistantEvent[];
 } {
-  const events: ServerMessage[] = [];
+  const events: AssistantEvent[] = [];
   const deps = {
     ctx: {
       conversationId: "conv-meta",
@@ -55,7 +55,7 @@ function createCollectorDeps(): {
       markWorkspaceTopLevelDirty: () => {},
       currentTurnSurfaces: [],
     } as unknown as EventHandlerDeps["ctx"],
-    onEvent: (msg: ServerMessage) => events.push(msg),
+    onEvent: (msg: AssistantEvent) => events.push(msg),
     reqId: "req-meta",
     isFirstMessage: false,
     shouldGenerateTitle: false,

--- a/assistant/src/__tests__/tool-start-timestamp.test.ts
+++ b/assistant/src/__tests__/tool-start-timestamp.test.ts
@@ -47,11 +47,11 @@ import {
   createEventHandlerState,
   handleToolUse,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function makeDeps(onEvent: (event: ServerMessage) => void): EventHandlerDeps {
+function makeDeps(onEvent: (event: AssistantEvent) => void): EventHandlerDeps {
   return {
     ctx: {
       conversationId: "test-conv",
@@ -120,7 +120,7 @@ describe("handleToolUse — tool start timestamp", () => {
         input: { command: "ls" },
       },
     ]);
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
     const before = Date.now();
 
     // WHEN the tool begins
@@ -155,7 +155,7 @@ describe("handleToolUse — tool start timestamp", () => {
         input: { command: "ls" },
       },
     ]);
-    const events: ServerMessage[] = [];
+    const events: AssistantEvent[] = [];
 
     // WHEN the tool begins
     handleToolUse(

--- a/assistant/src/__tests__/ui-choice-copy-surfaces.test.ts
+++ b/assistant/src/__tests__/ui-choice-copy-surfaces.test.ts
@@ -7,10 +7,10 @@ import {
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
 import type {
+  AssistantEvent,
   ChoiceSurfaceData,
   CopyBlockSurfaceData,
   OAuthConnectSurfaceData,
-  ServerMessage,
   SurfaceType,
   UiSurfaceShow,
 } from "../daemon/message-protocol.js";
@@ -18,7 +18,7 @@ import { INTERACTIVE_SURFACE_TYPES } from "../daemon/message-protocol.js";
 import { uiShowTool } from "../tools/ui-surface/definitions.js";
 import { uiShowTeachingError } from "../tools/ui-surface/surface-shape-docs.js";
 
-function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext {
+function makeContext(sent: AssistantEvent[] = []): SurfaceConversationContext {
   return {
     conversationId: "session-1",
     sendToClient: (msg) => sent.push(msg),
@@ -67,7 +67,7 @@ describe("choice and copy_block surface definitions", () => {
 
 describe("choice and copy_block surface proxying", () => {
   test("ui_show normalizes choice options and creates recommended action payloads", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -126,7 +126,7 @@ describe("choice and copy_block surface proxying", () => {
   });
 
   test("ui_show rejects choice surfaces without valid options", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -142,7 +142,7 @@ describe("choice and copy_block surface proxying", () => {
   });
 
   test("ui_show passes copy_block data through without awaiting action", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -174,7 +174,7 @@ describe("choice and copy_block surface proxying", () => {
   });
 
   test("ui_show passes oauth_connect data through and awaits action", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -211,7 +211,7 @@ describe("choice and copy_block surface proxying", () => {
   });
 
   test("ui_show rejects oauth_connect without providerKey", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -225,7 +225,7 @@ describe("choice and copy_block surface proxying", () => {
   });
 
   test("ui_show recovers copy_block data sent as a JSON-encoded string", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -249,7 +249,7 @@ describe("choice and copy_block surface proxying", () => {
   });
 
   test("ui_show recovers copy_block fields placed at the top level of the input", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -275,7 +275,7 @@ describe("choice and copy_block surface proxying", () => {
   });
 
   test("ui_show rejects an unknown surface_type with the valid values", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -291,7 +291,7 @@ describe("choice and copy_block surface proxying", () => {
 
   test("ui_show rejects daemon-internal surface types and omits them from the valid list", async () => {
     for (const internalType of ["skill_card", "call_summary"]) {
-      const sent: ServerMessage[] = [];
+      const sent: AssistantEvent[] = [];
       const ctx = makeContext(sent);
 
       const result = await surfaceProxyResolver(ctx, "ui_show", {
@@ -325,7 +325,7 @@ describe("choice and copy_block surface proxying", () => {
   });
 
   test("uiShowTool.execute renders a copy_block whose text is at the top level", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
     const result = await uiShowTool.execute(
       { surface_type: "copy_block", text: "bunx vellum doctor", data: {} },
@@ -347,7 +347,7 @@ describe("choice and copy_block surface proxying", () => {
   });
 
   test("uiShowTool.execute renders a dynamic_page whose html is at the top level", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
     const result = await uiShowTool.execute(
       { surface_type: "dynamic_page", html: "<p>hello</p>", data: {} },

--- a/assistant/src/__tests__/ui-work-result-surface.test.ts
+++ b/assistant/src/__tests__/ui-work-result-surface.test.ts
@@ -6,7 +6,7 @@ import {
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
 import type {
-  ServerMessage,
+  AssistantEvent,
   SurfaceType,
   UiSurfaceShow,
   UiSurfaceShowWorkResult,
@@ -15,7 +15,7 @@ import type {
 import { INTERACTIVE_SURFACE_TYPES } from "../daemon/message-protocol.js";
 import { uiShowTool } from "../tools/ui-surface/definitions.js";
 
-function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext {
+function makeContext(sent: AssistantEvent[] = []): SurfaceConversationContext {
   return {
     conversationId: "session-1",
     sendToClient: (msg) => sent.push(msg),
@@ -108,7 +108,7 @@ describe("work_result surface protocol", () => {
   });
 
   test("ui_show can emit a work_result surface", async () => {
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const ctx = makeContext(sent);
 
     const result = await surfaceProxyResolver(ctx, "ui_show", {

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -66,7 +66,7 @@ import {
   revokeScopedApprovalGrantsForContext,
 } from "../approvals/scoped-approval-grants.js";
 import { startVoiceTurn } from "../calls/voice-session-bridge.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { scopedApprovalGrants } from "../persistence/schema/index.js";
@@ -100,7 +100,7 @@ function createMockSession(opts?: {
   const toolName = opts?.toolName ?? TOOL_NAME;
   const toolInput = opts?.toolInput ?? TOOL_INPUT;
 
-  let clientCallback: ((msg: ServerMessage) => void) | null = null;
+  let clientCallback: ((msg: AssistantEvent) => void) | null = null;
   let confirmationDecision: {
     requestId: string;
     decision: string;
@@ -118,7 +118,7 @@ function createMockSession(opts?: {
     currentRequestId: requestId,
     abort: () => {},
     persistUserMessage: async () => ({ id: "msg-1", deduplicated: false }),
-    updateClient: (cb: (msg: ServerMessage) => void, _reset?: boolean) => {
+    updateClient: (cb: (msg: AssistantEvent) => void, _reset?: boolean) => {
       clientCallback = cb;
     },
     handleConfirmationResponse: (
@@ -136,7 +136,7 @@ function createMockSession(opts?: {
     runAgentLoop: async (
       _content: string,
       _messageId: string,
-      options?: { onEvent?: (msg: ServerMessage) => void },
+      options?: { onEvent?: (msg: AssistantEvent) => void },
     ) => {
       // Emit a confirmation_request through the client callback
       if (clientCallback) {
@@ -148,10 +148,10 @@ function createMockSession(opts?: {
           riskLevel: "medium",
           allowlistOptions: [],
           scopeOptions: [],
-        } as ServerMessage);
+        } as AssistantEvent);
       }
       // Then complete the turn
-      options?.onEvent?.({ type: "message_complete" } as ServerMessage);
+      options?.onEvent?.({ type: "message_complete" } as AssistantEvent);
     },
   };
 

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -6,7 +6,7 @@ import type {
 } from "../channels/types.js";
 import type { Conversation } from "../daemon/conversation.js";
 import { persistUserMessage as persistUserMessageImpl } from "../daemon/conversation-messaging.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { setConfig } from "./helpers/set-config.js";
 
 /** Seed the config the voice bridge reads: disclosure copy, plus disabled
@@ -47,7 +47,7 @@ await initializeDb();
  * Build a session that emits multiple events via the onEvent callback,
  * simulating assistant text deltas followed by message_complete.
  */
-function makeStreamingSession(events: ServerMessage[]): Conversation {
+function makeStreamingSession(events: AssistantEvent[]): Conversation {
   return {
     isProcessing: () => false,
     persistUserMessage: async () => ({
@@ -66,7 +66,7 @@ function makeStreamingSession(events: ServerMessage[]): Conversation {
     runAgentLoop: async (
       _content: string,
       _messageId: string,
-      options?: { onEvent?: (msg: ServerMessage) => void },
+      options?: { onEvent?: (msg: AssistantEvent) => void },
     ) => {
       const onEvent = options?.onEvent ?? (() => {});
       for (const event of events) {
@@ -80,7 +80,7 @@ function makeStreamingSession(events: ServerMessage[]): Conversation {
 
 function makePersistingStreamingSession(
   conversationId: string,
-  events: ServerMessage[],
+  events: AssistantEvent[],
 ): Conversation & { callSessionId?: string } {
   type PersistUserMessageContext = Parameters<typeof persistUserMessageImpl>[0];
 
@@ -121,7 +121,7 @@ function makePersistingStreamingSession(
     runAgentLoop: async (
       _content: string,
       _messageId: string,
-      options?: { onEvent?: (msg: ServerMessage) => void },
+      options?: { onEvent?: (msg: AssistantEvent) => void },
     ) => {
       const onEvent = options?.onEvent ?? (() => {});
       for (const event of events) {
@@ -174,7 +174,7 @@ describe("voice-session-bridge", () => {
 
   test("startVoiceTurn forwards text deltas to onTextDelta callback", async () => {
     const conversation = createConversation("voice bridge delta test");
-    const events: ServerMessage[] = [
+    const events: AssistantEvent[] = [
       {
         type: "assistant_text_delta",
         text: "Hello ",
@@ -215,7 +215,7 @@ describe("voice-session-bridge", () => {
 
   test("startVoiceTurn forwards error events to onError callback", async () => {
     const conversation = createConversation("voice bridge error test");
-    const events: ServerMessage[] = [
+    const events: AssistantEvent[] = [
       { type: "error", message: "Provider unavailable" },
     ];
     const session = makeStreamingSession(events);
@@ -282,7 +282,7 @@ describe("voice-session-bridge", () => {
 
   test("startVoiceTurn passes callSite: 'callAgent' to runAgentLoop", async () => {
     const conversation = createConversation("voice bridge callSite test");
-    const events: ServerMessage[] = [
+    const events: AssistantEvent[] = [
       { type: "message_complete", conversationId: conversation.id },
     ];
 
@@ -296,7 +296,7 @@ describe("voice-session-bridge", () => {
       ) => {
         capturedOptions = options;
         const onEvent =
-          (options as { onEvent?: (msg: ServerMessage) => void })?.onEvent ??
+          (options as { onEvent?: (msg: AssistantEvent) => void })?.onEvent ??
           (() => {});
         for (const event of events) {
           onEvent(event);
@@ -375,7 +375,7 @@ describe("voice-session-bridge", () => {
     const conversation = createConversation(
       "voice bridge channel context test",
     );
-    const events: ServerMessage[] = [
+    const events: AssistantEvent[] = [
       { type: "message_complete", conversationId: conversation.id },
     ];
 
@@ -410,7 +410,7 @@ describe("voice-session-bridge", () => {
     const conversation = createConversation(
       "voice bridge phone metadata default test",
     );
-    const events: ServerMessage[] = [
+    const events: AssistantEvent[] = [
       { type: "message_complete", conversationId: conversation.id },
     ];
     const session = makePersistingStreamingSession(conversation.id, events);
@@ -451,7 +451,7 @@ describe("voice-session-bridge", () => {
     const conversation = createConversation(
       "voice bridge local live voice metadata test",
     );
-    const events: ServerMessage[] = [
+    const events: AssistantEvent[] = [
       {
         type: "assistant_text_delta",
         text: "Hi",
@@ -473,8 +473,8 @@ describe("voice-session-bridge", () => {
 
     voiceConversationFactory = () => session;
 
-    const textDeltaEvents: ServerMessage[] = [];
-    const completeEvents: ServerMessage[] = [];
+    const textDeltaEvents: AssistantEvent[] = [];
+    const completeEvents: AssistantEvent[] = [];
     let persistedUserMessageId: string | undefined;
     let persistedAssistantMessageId: string | undefined;
 
@@ -529,7 +529,7 @@ describe("voice-session-bridge", () => {
     const conversation = createConversation(
       "voice bridge guardian context test",
     );
-    const events: ServerMessage[] = [
+    const events: AssistantEvent[] = [
       { type: "message_complete", conversationId: conversation.id },
     ];
 
@@ -572,7 +572,7 @@ describe("voice-session-bridge", () => {
     const conversation = createConversation(
       "voice bridge inbound opener framing test",
     );
-    const events: ServerMessage[] = [
+    const events: AssistantEvent[] = [
       { type: "message_complete", conversationId: conversation.id },
     ];
 
@@ -633,7 +633,7 @@ describe("voice-session-bridge", () => {
     const conversation = createConversation(
       "voice bridge inbound disclosure rewrite test",
     );
-    const events: ServerMessage[] = [
+    const events: AssistantEvent[] = [
       { type: "message_complete", conversationId: conversation.id },
     ];
 
@@ -684,7 +684,7 @@ describe("voice-session-bridge", () => {
       "voice bridge auto-deny non-guardian test",
     );
 
-    let clientHandler: (msg: ServerMessage) => void = () => {};
+    let clientHandler: (msg: AssistantEvent) => void = () => {};
     const handleConfirmationCalls: Array<{
       requestId: string;
       decision: string;
@@ -704,7 +704,7 @@ describe("voice-session-bridge", () => {
       setTurnChannelContext: () => {},
       setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
-      updateClient: (handler: (msg: ServerMessage) => void) => {
+      updateClient: (handler: (msg: AssistantEvent) => void) => {
         clientHandler = handler;
       },
       ensureActorScopedHistory: async () => {},
@@ -719,7 +719,7 @@ describe("voice-session-bridge", () => {
           riskLevel: "high",
           allowlistOptions: [],
           scopeOptions: [],
-        } as ServerMessage);
+        } as AssistantEvent);
         // The auto-deny resolves the prompter immediately, so the agent loop
         // can continue. In production the loop would continue; here we just
         // return to simulate completion.
@@ -776,7 +776,7 @@ describe("voice-session-bridge", () => {
       "voice bridge auto-deny vellum copy test",
     );
 
-    let clientHandler: (msg: ServerMessage) => void = () => {};
+    let clientHandler: (msg: AssistantEvent) => void = () => {};
     const handleConfirmationCalls: Array<{
       requestId: string;
       decision: string;
@@ -796,7 +796,7 @@ describe("voice-session-bridge", () => {
       setTurnChannelContext: () => {},
       setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
-      updateClient: (handler: (msg: ServerMessage) => void) => {
+      updateClient: (handler: (msg: AssistantEvent) => void) => {
         clientHandler = handler;
       },
       ensureActorScopedHistory: async () => {},
@@ -809,7 +809,7 @@ describe("voice-session-bridge", () => {
           riskLevel: "medium",
           allowlistOptions: [],
           scopeOptions: [],
-        } as ServerMessage);
+        } as AssistantEvent);
       },
       handleConfirmationResponse: (
         requestId: string,
@@ -860,7 +860,7 @@ describe("voice-session-bridge", () => {
       "voice bridge auto-deny unverified test",
     );
 
-    let clientHandler: (msg: ServerMessage) => void = () => {};
+    let clientHandler: (msg: AssistantEvent) => void = () => {};
     const handleConfirmationCalls: Array<{
       requestId: string;
       decision: string;
@@ -879,7 +879,7 @@ describe("voice-session-bridge", () => {
       setTurnChannelContext: () => {},
       setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
-      updateClient: (handler: (msg: ServerMessage) => void) => {
+      updateClient: (handler: (msg: AssistantEvent) => void) => {
         clientHandler = handler;
       },
       ensureActorScopedHistory: async () => {},
@@ -892,7 +892,7 @@ describe("voice-session-bridge", () => {
           riskLevel: "medium",
           allowlistOptions: [],
           scopeOptions: [],
-        } as ServerMessage);
+        } as AssistantEvent);
       },
       handleConfirmationResponse: (requestId: string, decision: string) => {
         handleConfirmationCalls.push({ requestId, decision });
@@ -927,7 +927,7 @@ describe("voice-session-bridge", () => {
       "voice bridge auto-deny unknown actor test",
     );
 
-    let clientHandler: (msg: ServerMessage) => void = () => {};
+    let clientHandler: (msg: AssistantEvent) => void = () => {};
     const handleConfirmationCalls: Array<{
       requestId: string;
       decision: string;
@@ -946,7 +946,7 @@ describe("voice-session-bridge", () => {
       setTurnChannelContext: () => {},
       setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
-      updateClient: (handler: (msg: ServerMessage) => void) => {
+      updateClient: (handler: (msg: AssistantEvent) => void) => {
         clientHandler = handler;
       },
       ensureActorScopedHistory: async () => {},
@@ -959,7 +959,7 @@ describe("voice-session-bridge", () => {
           riskLevel: "medium",
           allowlistOptions: [],
           scopeOptions: [],
-        } as ServerMessage);
+        } as AssistantEvent);
       },
       handleConfirmationResponse: (requestId: string, decision: string) => {
         handleConfirmationCalls.push({ requestId, decision });
@@ -990,7 +990,7 @@ describe("voice-session-bridge", () => {
       "voice bridge auto-allow guardian test",
     );
 
-    let clientHandler: (msg: ServerMessage) => void = () => {};
+    let clientHandler: (msg: AssistantEvent) => void = () => {};
     const handleConfirmationCalls: Array<{
       requestId: string;
       decision: string;
@@ -1009,7 +1009,7 @@ describe("voice-session-bridge", () => {
       setTurnChannelContext: () => {},
       setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
-      updateClient: (handler: (msg: ServerMessage) => void) => {
+      updateClient: (handler: (msg: AssistantEvent) => void) => {
         clientHandler = handler;
       },
       ensureActorScopedHistory: async () => {},
@@ -1022,7 +1022,7 @@ describe("voice-session-bridge", () => {
           riskLevel: "low",
           allowlistOptions: [],
           scopeOptions: [],
-        } as ServerMessage);
+        } as AssistantEvent);
         // For verified guardian voice turns, the confirmation should be
         // auto-approved so the run can continue without a chat approval UI.
       },
@@ -1066,7 +1066,7 @@ describe("voice-session-bridge", () => {
     conversationId: string,
     requestId: string,
   ): Conversation {
-    let clientHandler: (msg: ServerMessage) => void = () => {};
+    let clientHandler: (msg: AssistantEvent) => void = () => {};
     return {
       isProcessing: () => false,
       persistUserMessage: async () => ({
@@ -1080,7 +1080,7 @@ describe("voice-session-bridge", () => {
       setTurnChannelContext: () => {},
       setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
-      updateClient: (handler: (msg: ServerMessage) => void) => {
+      updateClient: (handler: (msg: AssistantEvent) => void) => {
         clientHandler = handler;
       },
       ensureActorScopedHistory: async () => {},
@@ -1094,7 +1094,7 @@ describe("voice-session-bridge", () => {
           allowlistOptions: [],
           scopeOptions: [],
           conversationId,
-        } as ServerMessage);
+        } as AssistantEvent);
       },
       handleConfirmationResponse: (resolvedRequestId: string) => {
         broadcastMessage({
@@ -1103,7 +1103,7 @@ describe("voice-session-bridge", () => {
           conversationId,
           kind: "confirmation",
           state: "approved",
-        } as ServerMessage);
+        } as AssistantEvent);
       },
       abort: () => {},
     } as unknown as Conversation;
@@ -1113,7 +1113,7 @@ describe("voice-session-bridge", () => {
     conversationId: string,
     turn: () => Promise<unknown>,
   ): Promise<{ requestIndex: number; resolvedIndex: number }> {
-    const published: ServerMessage[] = [];
+    const published: AssistantEvent[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       filter: { conversationId },
@@ -1202,7 +1202,7 @@ describe("voice-session-bridge", () => {
       "voice bridge secret auto-resolve test",
     );
 
-    let clientHandler: (msg: ServerMessage) => void = () => {};
+    let clientHandler: (msg: AssistantEvent) => void = () => {};
     const handleSecretCalls: Array<{
       requestId: string;
       value?: string;
@@ -1222,7 +1222,7 @@ describe("voice-session-bridge", () => {
       setTurnChannelContext: () => {},
       setTurnInterfaceContext: () => {},
       setVoiceCallControlPrompt: () => {},
-      updateClient: (handler: (msg: ServerMessage) => void) => {
+      updateClient: (handler: (msg: AssistantEvent) => void) => {
         clientHandler = handler;
       },
       ensureActorScopedHistory: async () => {},
@@ -1233,7 +1233,7 @@ describe("voice-session-bridge", () => {
           service: "github",
           field: "token",
           label: "GitHub Token",
-        } as ServerMessage);
+        } as AssistantEvent);
       },
       handleConfirmationResponse: () => {},
       handleSecretResponse: (
@@ -1508,7 +1508,7 @@ describe("voice-session-bridge", () => {
     const conversation = createConversation(
       "voice bridge user echo ordering test",
     );
-    const events: ServerMessage[] = [
+    const events: AssistantEvent[] = [
       {
         type: "assistant_text_delta",
         text: "Hi ",
@@ -1524,7 +1524,7 @@ describe("voice-session-bridge", () => {
     const session = makeStreamingSession(events);
     injectDeps(() => session);
 
-    const published: ServerMessage[] = [];
+    const published: AssistantEvent[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       filter: { conversationId: conversation.id },
@@ -1571,13 +1571,13 @@ describe("voice-session-bridge", () => {
     const conversation = createConversation(
       "voice bridge opener echo suppression test",
     );
-    const events: ServerMessage[] = [
+    const events: AssistantEvent[] = [
       { type: "message_complete", conversationId: conversation.id },
     ];
     const session = makeStreamingSession(events);
     injectDeps(() => session);
 
-    const published: ServerMessage[] = [];
+    const published: AssistantEvent[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       filter: { conversationId: conversation.id },

--- a/assistant/src/acp/__tests__/client-handler.test.ts
+++ b/assistant/src/acp/__tests__/client-handler.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { SessionNotification } from "@agentclientprotocol/sdk";
 
-import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import { VellumAcpClientHandler } from "../client-handler.js";
 
 const ACP_SESSION_ID = "acp-session-abc";
@@ -10,9 +10,9 @@ const PARENT_CONVERSATION_ID = "conv-xyz";
 
 function makeHandler(): {
   handler: VellumAcpClientHandler;
-  sent: ServerMessage[];
+  sent: AssistantEvent[];
 } {
-  const sent: ServerMessage[] = [];
+  const sent: AssistantEvent[] = [];
   const handler = new VellumAcpClientHandler(
     ACP_SESSION_ID,
     (msg) => {

--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -11,7 +11,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AcpSessionUpdateEvent } from "../../api/events/acp-session-update.js";
-import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import { getSqlite } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import { VellumAcpClientHandler } from "../client-handler.js";
@@ -47,8 +47,8 @@ function buildSessionWithFakeProcess(opts: {
   emitUpdate: (update: AcpSessionUpdateEvent) => void;
 } {
   const manager = new AcpSessionManager(1);
-  const sent: ServerMessage[] = [];
-  const sendToVellum = (msg: ServerMessage) => sent.push(msg);
+  const sent: AssistantEvent[] = [];
+  const sendToVellum = (msg: AssistantEvent) => sent.push(msg);
 
   type PromptResolution = {
     stopReason: string;
@@ -81,7 +81,7 @@ function buildSessionWithFakeProcess(opts: {
   ).eventBuffers;
   eventBuffers.set(opts.id, []);
 
-  const wrappedSend = (msg: ServerMessage) => {
+  const wrappedSend = (msg: AssistantEvent) => {
     if (msg.type === "acp_session_update") {
       (
         manager as unknown as {
@@ -464,7 +464,7 @@ describe("AcpSessionManager — terminal persistence", () => {
 
   test("emits acp_session_usage and persists input/output tokens from PromptResponse.usage", async () => {
     const id = "session-io-usage-1";
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const handles = buildSessionWithFakeProcess({
       id,
       agentId: "agent-io",
@@ -478,11 +478,11 @@ describe("AcpSessionManager — terminal persistence", () => {
     // Capture the usage event emitted at turn end.
     const captureSend = (
       handles.manager as unknown as {
-        sessions: Map<string, { sendToVellum: (m: ServerMessage) => void }>;
+        sessions: Map<string, { sendToVellum: (m: AssistantEvent) => void }>;
       }
     ).sessions.get(id);
     const originalSend = captureSend!.sendToVellum;
-    captureSend!.sendToVellum = (msg: ServerMessage) => {
+    captureSend!.sendToVellum = (msg: AssistantEvent) => {
       sent.push(msg);
       originalSend(msg);
     };
@@ -515,7 +515,7 @@ describe("AcpSessionManager — terminal persistence", () => {
 
   test("does not emit usage or write token columns when PromptResponse carries no usage", async () => {
     const id = "session-io-no-usage-1";
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const handles = buildSessionWithFakeProcess({
       id,
       agentId: "agent-io-none",
@@ -525,11 +525,11 @@ describe("AcpSessionManager — terminal persistence", () => {
 
     const entry = (
       handles.manager as unknown as {
-        sessions: Map<string, { sendToVellum: (m: ServerMessage) => void }>;
+        sessions: Map<string, { sendToVellum: (m: AssistantEvent) => void }>;
       }
     ).sessions.get(id);
     const originalSend = entry!.sendToVellum;
-    entry!.sendToVellum = (msg: ServerMessage) => {
+    entry!.sendToVellum = (msg: AssistantEvent) => {
       sent.push(msg);
       originalSend(msg);
     };

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -208,7 +208,7 @@ const BUN_BIN = "/usr/local/bin/bun";
 const BUN_ADD_KEY = `${BUN_BIN} add`;
 
 import type { AcpSessionUpdateEvent } from "../../api/events/acp-session-update.js";
-import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import { getSqlite } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import type { AcpSessionState } from "../types.js";
@@ -292,7 +292,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     });
 
     const manager = new AcpSessionManager(4);
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     await manager.resumeFromHistory("resume-1", (msg) => sent.push(msg));
 
     const fake = fakeInstances[0]!;
@@ -355,7 +355,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     });
 
     const manager = new AcpSessionManager(4);
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     await manager.resumeFromHistory("resume-seq-1", (msg) => sent.push(msg));
 
     const fake = fakeInstances[0]!;
@@ -716,7 +716,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     insertHistoryRow({ id: "race-1" });
 
     const manager = new AcpSessionManager(4);
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const [a, b] = await Promise.allSettled([
       manager.resumeFromHistory("race-1", (msg) => sent.push(msg)),
       manager.resumeFromHistory("race-1", (msg) => sent.push(msg)),
@@ -862,7 +862,7 @@ describe("AcpSessionManager.steerOrResume", () => {
     insertHistoryRow({ id: "sor-resume-1" });
 
     const manager = new AcpSessionManager(4);
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const result = await manager.steerOrResume(
       "sor-resume-1",
       "continue the work",
@@ -904,7 +904,7 @@ describe("AcpSessionManager.steerOrResume", () => {
     insertHistoryRow({ id: "sor-race-1" });
 
     const manager = new AcpSessionManager(4);
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const [a, b] = await Promise.all([
       manager.steerOrResume("sor-race-1", "first instruction", (msg) =>
         sent.push(msg),
@@ -943,7 +943,7 @@ describe("AcpSessionManager.steerOrResume", () => {
     });
 
     const manager = new AcpSessionManager(4);
-    const sent: ServerMessage[] = [];
+    const sent: AssistantEvent[] = [];
     const first = manager.steerOrResume(
       "sor-init-1",
       "first instruction",

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -32,7 +32,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 
 import type { AcpSessionUpdateEvent } from "../api/events/acp-session-update.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { redactJsonStringLeaves } from "../security/redact-json.js";
 import { redactSensitiveFields } from "../security/redaction.js";
 import { redactSecrets } from "../security/secret-scanner.js";
@@ -72,7 +72,7 @@ interface TerminalState {
 
 /**
  * Vellum's ACP Client handler. Receives events from an ACP agent and
- * forwards them as ServerMessage objects to connected Vellum clients.
+ * forwards them as AssistantEvent objects to connected Vellum clients.
  */
 export class VellumAcpClientHandler implements Client {
   private terminals = new Map<string, TerminalState>();
@@ -101,7 +101,7 @@ export class VellumAcpClientHandler implements Client {
 
   constructor(
     private readonly acpSessionId: string,
-    private readonly sendToVellum: (msg: ServerMessage) => void,
+    private readonly sendToVellum: (msg: AssistantEvent) => void,
     private readonly parentConversationId: string,
   ) {}
 

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -10,7 +10,7 @@ import { eq, inArray } from "drizzle-orm";
 
 import type { AcpSessionUpdateEvent } from "../api/events/acp-session-update.js";
 import { findConversation } from "../daemon/conversation-registry.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getDb } from "../persistence/db-connection.js";
 import { acpSessionHistory } from "../persistence/schema/index.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
@@ -69,7 +69,7 @@ interface SessionEntry {
   state: AcpSessionState;
   clientHandler: VellumAcpClientHandler;
   /** Wrapped sender that also appends to the ring buffer. */
-  sendToVellum: (msg: ServerMessage) => void;
+  sendToVellum: (msg: AssistantEvent) => void;
   currentPrompt: Promise<unknown> | null;
   parentConversationId: string;
   cwd: string;
@@ -195,7 +195,7 @@ export class AcpSessionManager {
     task: string,
     cwd: string,
     parentConversationId: string,
-    sendToVellum: (msg: ServerMessage) => void,
+    sendToVellum: (msg: AssistantEvent) => void,
     parentToolUseId?: string,
   ): Promise<{ acpSessionId: string; protocolSessionId: string }> {
     this.assertCapacity();
@@ -275,7 +275,7 @@ export class AcpSessionManager {
     parentConversationId: string;
     cwd: string;
     startedAt: number;
-    sendToVellum: (msg: ServerMessage) => void;
+    sendToVellum: (msg: AssistantEvent) => void;
     parentToolUseId?: string;
     task?: string;
   }): SessionEntry {
@@ -287,7 +287,7 @@ export class AcpSessionManager {
     // Wrap the sender so every emitted message is mirrored into the buffer
     // when it's an `acp_session_update`. The wrapper preserves the original
     // call semantics: it forwards every message unchanged.
-    const wrappedSend = (msg: ServerMessage) => {
+    const wrappedSend = (msg: AssistantEvent) => {
       if (msg.type === "acp_session_update") {
         this.appendToBuffer(acpSessionId, msg);
       } else if (msg.type === "acp_session_usage") {
@@ -383,7 +383,7 @@ export class AcpSessionManager {
    */
   async resumeFromHistory(
     acpSessionId: string,
-    sendToVellum: (msg: ServerMessage) => void,
+    sendToVellum: (msg: AssistantEvent) => void,
   ): Promise<void> {
     if (
       this.sessions.has(acpSessionId) ||
@@ -448,7 +448,7 @@ export class AcpSessionManager {
   private async performResume(
     acpSessionId: string,
     row: ResumableHistoryRow,
-    sendToVellum: (msg: ServerMessage) => void,
+    sendToVellum: (msg: AssistantEvent) => void,
   ): Promise<void> {
     // Resolve the adapter, silently auto-installing a missing allowlisted
     // binary via the same sandboxed `bun` path as spawn (see
@@ -658,7 +658,7 @@ export class AcpSessionManager {
   async steerOrResume(
     acpSessionId: string,
     instruction: string,
-    sendToVellum: (msg: ServerMessage) => void,
+    sendToVellum: (msg: AssistantEvent) => void,
   ): Promise<{ resumed: boolean }> {
     try {
       await this.steer(acpSessionId, instruction);

--- a/assistant/src/api/events/subagent-event.ts
+++ b/assistant/src/api/events/subagent-event.ts
@@ -1,7 +1,7 @@
 /**
  * `subagent_event` SSE event.
  *
- * Server → client envelope wrapping any inner `ServerMessage`
+ * Server → client envelope wrapping any inner `AssistantEvent`
  * emitted by a subagent's conversation. The daemon's subagent
  * manager rebroadcasts the subagent's own stream through the
  * parent conversation's `sendToClient`, tagged with the subagent's
@@ -9,7 +9,7 @@
  * to route inner events to the appropriate inline subagent surface.
  *
  * The inner `event` is opaque on the wire — it is itself a fully
- * structured `ServerMessage` (any member of the canonical event
+ * structured `AssistantEvent` (any member of the canonical event
  * union) and re-validating it here would duplicate work and
  * tightly couple subagent canonicalization to every other event
  * schema. Clients re-parse `event` through the same event parser

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -16,7 +16,7 @@ import {
   getRequestByPendingQuestionOrNull,
   listGuardianRequestDeliveriesOrEmpty,
 } from "../channels/gateway-guardian-requests.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
@@ -166,7 +166,7 @@ export class CallController {
   /** Monotonic run id used to suppress stale turn side effects after interruption. */
   private llmRunVersion = 0;
   /** Optional broadcast function for emitting events to connected clients. */
-  private broadcast?: (msg: ServerMessage) => void;
+  private broadcast?: (msg: AssistantEvent) => void;
   /** Assistant identity for scoping guardian bindings. */
   private assistantId: string;
   /** Guardian trust context for the current caller, when available. */
@@ -195,7 +195,7 @@ export class CallController {
     transport: CallTransport,
     task: string | null,
     opts?: {
-      broadcast?: (msg: ServerMessage) => void;
+      broadcast?: (msg: AssistantEvent) => void;
       assistantId?: string;
       trustContext?: TrustContext;
     },
@@ -260,8 +260,8 @@ export class CallController {
    * Kick off the first outbound call utterance from the assistant.
    */
   async startInitialGreeting(): Promise<void> {
-    if (this.initialGreetingStarted) return;
-    if (this.state !== "idle") return;
+    if (this.initialGreetingStarted) {return;}
+    if (this.state !== "idle") {return;}
 
     this.initialGreetingStarted = true;
     this.resetSilenceTimer();
@@ -275,8 +275,8 @@ export class CallController {
    * greet naturally with context that verification just happened.
    */
   async startPostVerificationGreeting(): Promise<void> {
-    if (this.initialGreetingStarted) return;
-    if (this.state !== "idle") return;
+    if (this.initialGreetingStarted) {return;}
+    if (this.state !== "idle") {return;}
 
     this.initialGreetingStarted = true;
     this.resetSilenceTimer();
@@ -473,10 +473,10 @@ export class CallController {
    */
   destroy(): void {
     this.destroyed = true;
-    if (this.silenceTimer) clearTimeout(this.silenceTimer);
+    if (this.silenceTimer) {clearTimeout(this.silenceTimer);}
     this.cancelPendingEndCall();
-    if (this.durationTimer) clearTimeout(this.durationTimer);
-    if (this.durationWarningTimer) clearTimeout(this.durationWarningTimer);
+    if (this.durationTimer) {clearTimeout(this.durationTimer);}
+    if (this.durationWarningTimer) {clearTimeout(this.durationWarningTimer);}
     if (this.pendingGuardianInput) {
       clearTimeout(this.pendingGuardianInput.timer);
       this.pendingGuardianInput = null;
@@ -559,7 +559,7 @@ export class CallController {
     transcript: string,
     speaker?: PromptSpeakerContext,
   ): string {
-    if (!speaker) return transcript;
+    if (!speaker) {return transcript;}
     const safeId = speaker.speakerId.replaceAll('"', "'");
     const safeLabel = speaker.speakerLabel.replaceAll('"', "'");
     const confidencePart =
@@ -580,7 +580,7 @@ export class CallController {
   }
 
   private async runTurnInner(content: string): Promise<void> {
-    if (this.destroyed) return;
+    if (this.destroyed) {return;}
     const runVersion = ++this.llmRunVersion;
     const runSignal = this.abortController.signal;
 
@@ -603,7 +603,7 @@ export class CallController {
         runVersion,
         runSignal,
       );
-      if (!this.isCurrentRun(runVersion)) return;
+      if (!this.isCurrentRun(runVersion)) {return;}
 
       await this.handleTurnCompletion(fullResponseText);
     } catch (err: unknown) {
@@ -838,15 +838,15 @@ export class CallController {
         enqueueSynthesisSegments(synthProvider, segments);
       } else {
         const cleaned = sanitizeForTts(safeText);
-        if (cleaned.length === 0) return;
+        if (cleaned.length === 0) {return;}
         this.beginSpeakingOnAudioStart(runVersion);
         this.transport.sendTextToken(cleaned, false);
       }
     };
 
     const flushSafeText = (): void => {
-      if (!this.isCurrentRun(runVersion)) return;
-      if (ttsBuffer.length === 0) return;
+      if (!this.isCurrentRun(runVersion)) {return;}
+      if (ttsBuffer.length === 0) {return;}
       const bracketIdx = ttsBuffer.indexOf("[");
       if (bracketIdx === -1) {
         // No bracket at all — safe to flush everything
@@ -883,7 +883,7 @@ export class CallController {
     // Use a promise to track completion of the voice turn
     const turnComplete = new Promise<void>((resolve, reject) => {
       const onTextDelta = (text: string): void => {
-        if (!this.isCurrentRun(runVersion)) return;
+        if (!this.isCurrentRun(runVersion)) {return;}
         fullResponseText += text;
         ttsBuffer += text;
         ttsBuffer = stripInternalSpeechMarkers(ttsBuffer);
@@ -989,7 +989,7 @@ export class CallController {
     // latency; re-check the run wasn't superseded meanwhile so a stale turn
     // doesn't inject its end-of-turn marker (or fallback text) into the next
     // turn's output stream.
-    if (!this.isCurrentRun(runVersion)) return fullResponseText;
+    if (!this.isCurrentRun(runVersion)) {return fullResponseText;}
 
     // Signal end of this turn's speech.  An empty token with `last: true`
     // tells the transport to start listening — it does NOT trigger TTS
@@ -1447,7 +1447,7 @@ export class CallController {
   }
 
   private clearPendingGuardianInputForCallEnd(): boolean {
-    if (!this.pendingGuardianInput) return false;
+    if (!this.pendingGuardianInput) {return false;}
 
     clearTimeout(this.pendingGuardianInput.timer);
 
@@ -1476,7 +1476,7 @@ export class CallController {
     // The teardown has run to completion; drop the token so a later utterance
     // can't read it as a still-pending end-call.
     this.pendingEndCall = null;
-    if (this.destroyed) return;
+    if (this.destroyed) {return;}
 
     const currentSession = getCallSession(this.callSessionId);
     if (currentSession && isTerminalState(currentSession.status)) {
@@ -1518,7 +1518,7 @@ export class CallController {
   }
 
   private isExpectedAbortError(err: unknown): boolean {
-    if (!(err instanceof Error)) return false;
+    if (!(err instanceof Error)) {return false;}
     return err.name === "AbortError" || err.name === "APIUserAbortError";
   }
 
@@ -1541,7 +1541,7 @@ export class CallController {
    * waiting for the processing lock or generating with no audio yet.
    */
   private beginSpeaking(runVersion: number): void {
-    if (!this.isCurrentRun(runVersion)) return;
+    if (!this.isCurrentRun(runVersion)) {return;}
     if (this.state === "processing") {
       this.state = "speaking";
     }
@@ -1650,7 +1650,7 @@ export class CallController {
         !this.pendingGuardianInput ||
         this.pendingGuardianInput.questionId !== pendingQuestion.id
       )
-        return;
+        {return;}
 
       log.info(
         { callSessionId: this.callSessionId },
@@ -1727,8 +1727,8 @@ export class CallController {
    * Drain any instructions that were queued while the LLM was active.
    */
   private flushPendingInstructions(): void {
-    if (this.destroyed) return;
-    if (this.pendingInstructions.length === 0) return;
+    if (this.destroyed) {return;}
+    if (this.pendingInstructions.length === 0) {return;}
 
     const parts = this.pendingInstructions.map((instr) =>
       instr.startsWith("[") ? instr : `[USER_INSTRUCTION: ${instr}]`,
@@ -1814,8 +1814,8 @@ export class CallController {
   }
 
   private resetSilenceTimer(): void {
-    if (this.silenceTimer) clearTimeout(this.silenceTimer);
-    if (this.destroyed) return;
+    if (this.silenceTimer) {clearTimeout(this.silenceTimer);}
+    if (this.destroyed) {return;}
     this.silenceTimer = setTimeout(() => {
       // During an in-call guardian consultation, suppress the generic
       // "Are you still there?" — it is confusing when the caller is

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -20,7 +20,7 @@ import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
 import { CONVERSATION_BUSY_MESSAGE } from "../daemon/conversation-messaging.js";
 import { resolveChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import {
   deleteMessageById,
@@ -217,11 +217,11 @@ export interface VoiceToolResultEvent {
  */
 export interface VoiceRunEventSink {
   onTextDelta(
-    msg: Extract<ServerMessage, { type: "assistant_text_delta" }>,
+    msg: Extract<AssistantEvent, { type: "assistant_text_delta" }>,
   ): void;
   onMessageComplete(
     msg: Extract<
-      ServerMessage,
+      AssistantEvent,
       { type: "message_complete" } | { type: "generation_cancelled" }
     >,
   ): void;
@@ -236,11 +236,11 @@ export interface VoiceRunEventSink {
 
 export interface VoiceTurnCallbacks {
   assistant_text_delta?: (
-    msg: Extract<ServerMessage, { type: "assistant_text_delta" }>,
+    msg: Extract<AssistantEvent, { type: "assistant_text_delta" }>,
   ) => void;
   message_complete?: (
     msg: Extract<
-      ServerMessage,
+      AssistantEvent,
       { type: "message_complete" } | { type: "generation_cancelled" }
     >,
   ) => void;
@@ -1034,7 +1034,7 @@ export async function startVoiceTurn(
   // Hook into conversation to intercept confirmation_request and secret_request events.
   // Voice auto-denies/auto-allows/auto-resolves these since there's no interactive UI.
   let lastError: string | null = null;
-  conversation.updateClient(async (msg: ServerMessage) => {
+  conversation.updateClient(async (msg: AssistantEvent) => {
     if (msg.type === "confirmation_request") {
       // Broadcast the request BEFORE resolving it: resolution synchronously
       // broadcasts `interaction_resolved` (handleConfirmationResponse →
@@ -1283,7 +1283,7 @@ export async function startVoiceTurn(
         frontDoorToolsSuppressed = true;
       }
       await conversation.runAgentLoop(persistedContent, messageId, {
-        onEvent: (msg: ServerMessage) => {
+        onEvent: (msg: AssistantEvent) => {
           if (msg.type === "assistant_turn_start") {
             reservedAssistantRowId = msg.messageId;
           } else if (msg.type === "error") {

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -18,7 +18,7 @@ import {
   updateStatusText,
 } from "./cli/main-screen.jsx";
 import { renderHistoryContent } from "./daemon/handlers/shared.js";
-import type { ServerMessage } from "./daemon/message-protocol.js";
+import type { AssistantEvent } from "./daemon/message-protocol.js";
 import {
   getConversation,
   getMessages,
@@ -289,7 +289,7 @@ export async function startCli(): Promise<void> {
     });
   }
 
-  function handleMessage(msg: ServerMessage): void {
+  function handleMessage(msg: AssistantEvent): void {
     switch (msg.type) {
       case "assistant_text_delta":
         spinner.stop();

--- a/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
@@ -126,7 +126,7 @@ const { createSurfaceMutex, handleSurfaceAction } =
 type SurfaceConversationContext =
   import("../conversation-surfaces.js").SurfaceConversationContext;
 type TrustContext = import("../trust-context-types.js").TrustContext;
-type ServerMessage = import("../message-protocol.js").ServerMessage;
+type AssistantEvent = import("../message-protocol.js").AssistantEvent;
 type SurfaceType = import("../message-protocol.js").SurfaceType;
 
 // ── Harness reset helper ───────────────────────────────────────────
@@ -145,7 +145,7 @@ function resetProcessHarness(): void {
 // ── Surface-context harness ────────────────────────────────────────
 
 interface HarnessContext extends SurfaceConversationContext {
-  sent: ServerMessage[];
+  sent: AssistantEvent[];
   enqueueCalls: Array<{ content: string }>;
   processCalls: Array<{ content: string }>;
 }
@@ -153,7 +153,7 @@ interface HarnessContext extends SurfaceConversationContext {
 function makeContext(
   overrides?: Partial<SurfaceConversationContext>,
 ): HarnessContext {
-  const sent: ServerMessage[] = [];
+  const sent: AssistantEvent[] = [];
   const enqueueCalls: Array<{ content: string }> = [];
   const processCalls: Array<{ content: string }> = [];
 

--- a/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
+++ b/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
@@ -38,17 +38,17 @@ import {
   createEventHandlerState,
   dispatchAgentEvent,
 } from "../conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../message-protocol.js";
+import type { AssistantEvent } from "../message-protocol.js";
 
-type ToolResultEvent = Extract<ServerMessage, { type: "tool_result" }>;
+type ToolResultEvent = Extract<AssistantEvent, { type: "tool_result" }>;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function createCollectorDeps(providerName = "anthropic"): {
   deps: EventHandlerDeps;
-  events: ServerMessage[];
+  events: AssistantEvent[];
 } {
-  const events: ServerMessage[] = [];
+  const events: AssistantEvent[] = [];
   const deps = {
     ctx: {
       conversationId: "conv-native-meta",
@@ -58,7 +58,7 @@ function createCollectorDeps(providerName = "anthropic"): {
       markWorkspaceTopLevelDirty: () => {},
       currentTurnSurfaces: [],
     } as unknown as EventHandlerDeps["ctx"],
-    onEvent: (msg: ServerMessage) => events.push(msg),
+    onEvent: (msg: AssistantEvent) => events.push(msg),
     reqId: "req-native-meta",
     isFirstMessage: false,
     shouldGenerateTitle: false,

--- a/assistant/src/daemon/__tests__/web-search-status-text.test.ts
+++ b/assistant/src/daemon/__tests__/web-search-status-text.test.ts
@@ -30,7 +30,7 @@ import {
   formatFetchStatusText,
   formatSearchStatusText,
 } from "../conversation-agent-loop-handlers.js";
-import type { ServerMessage } from "../message-protocol.js";
+import type { AssistantEvent } from "../message-protocol.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -68,7 +68,7 @@ function createCollectorDeps(): {
       markWorkspaceTopLevelDirty: () => {},
       currentTurnSurfaces: [],
     } as unknown as EventHandlerDeps["ctx"],
-    onEvent: (_msg: ServerMessage) => {},
+    onEvent: (_msg: AssistantEvent) => {},
     reqId: "req-status-text",
     isFirstMessage: false,
     shouldGenerateTitle: false,

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -130,8 +130,8 @@ import {
   type InflightContentWriter,
 } from "./inflight-message-content.js";
 import type {
+  AssistantEvent,
   CardSurfaceData,
-  ServerMessage,
   SurfaceAction,
   UiSurfaceShow,
 } from "./message-protocol.js";
@@ -511,7 +511,7 @@ export interface EventHandlerState {
 /** Immutable context shared across event handlers within a single agent loop run. */
 export interface EventHandlerDeps {
   readonly ctx: Conversation;
-  readonly onEvent: (msg: ServerMessage) => void;
+  readonly onEvent: (msg: AssistantEvent) => void;
   readonly reqId: string;
   readonly isFirstMessage: boolean;
   /** Whether the conversation title is replaceable — controls firstAssistantText accumulation for title generation. */
@@ -3309,7 +3309,7 @@ export async function dispatchAgentEvent(
       case "compaction_circuit_open":
       case "compaction_circuit_closed":
         // Circuit-breaker transitions are already in wire-contract shape
-        // (a subset of ServerMessage), so forward them to the client sink
+        // (a subset of AssistantEvent), so forward them to the client sink
         // unchanged. They drive the client's "auto-compaction paused"
         // banner.
         deps.onEvent(event);

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -116,7 +116,7 @@ import {
   registerInflightTurn,
   unregisterInflightTurn,
 } from "./inflight-turn-registry.js";
-import type { ServerMessage, UsageStats } from "./message-protocol.js";
+import type { AssistantEvent, UsageStats } from "./message-protocol.js";
 import type { TrustContext } from "./trust-context-types.js";
 import { resolveTurnCallSite } from "./turn-call-site.js";
 import { runWithLatencySubSpans } from "./turn-latency-sub-spans.js";
@@ -240,7 +240,7 @@ export async function runAgentLoopImpl(
   ctx: Conversation,
   content: string,
   userMessageId: string,
-  onEvent: (msg: ServerMessage) => void,
+  onEvent: (msg: AssistantEvent) => void,
   options?: {
     isInteractive?: boolean;
     isUserMessage?: boolean;
@@ -1680,7 +1680,7 @@ function emitUsage(
   inputTokens: number,
   outputTokens: number,
   model: string,
-  onEvent: (msg: ServerMessage) => void,
+  onEvent: (msg: AssistantEvent) => void,
   actor: UsageActor,
   requestId: string | null = null,
   cacheCreationInputTokens = 0,
@@ -1769,7 +1769,7 @@ export async function applyCompactionResult(
     summaryCallSite?: LLMCallSite;
     summaryOverrideProfile?: string | null;
   },
-  onEvent: (msg: ServerMessage) => void,
+  onEvent: (msg: AssistantEvent) => void,
   reqId: string | null,
   options: {
     slackContextCompactionWatermarkTs?: string | null;

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -64,7 +64,7 @@ import { withSqliteRetry } from "../util/sqlite-retry.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import type { SlackInboundMessageMetadata } from "./handlers/shared.js";
 import type {
-  ServerMessage,
+  AssistantEvent,
   UserMessageAttachment,
 } from "./message-protocol.js";
 import type { ConversationTransportMetadata } from "./message-types/conversations.js";
@@ -187,10 +187,10 @@ function resolveIngressSecretTarget(
   for (const detectedType of detectedTypes) {
     const normalizedType = normalizeIngressSecretTypeLabel(detectedType);
     const mapped = INGRESS_SECRET_TARGETS[normalizedType];
-    if (!mapped) continue;
+    if (!mapped) {continue;}
     mappedTargets.set(`${mapped.service}:${mapped.field}`, mapped);
   }
-  if (mappedTargets.size === 1) return mappedTargets.values().next().value!;
+  if (mappedTargets.size === 1) {return mappedTargets.values().next().value!;}
 
   return {
     service: "detected",
@@ -275,7 +275,7 @@ function computeReferenceImageDimensions(
   mediaType: string,
 ): { width: number; height: number } | null {
   const bytes = getAttachmentContent(attachmentId);
-  if (!bytes) return null;
+  if (!bytes) {return null;}
   const optimized = optimizeImageForTransport(
     bytes.toString("base64"),
     mediaType,
@@ -330,7 +330,7 @@ function materializeUserAttachment(
       );
       return stored ? { kind: "stored", stored } : { kind: "transient" };
     }
-    if (!a.data) return { kind: "rejected" };
+    if (!a.data) {return { kind: "rejected" };}
     const validation = validateAttachmentUpload(a.filename, a.mimeType);
     if (!validation.ok) {
       log.warn(
@@ -395,7 +395,7 @@ function referenceBlockForAttachment(
 function inlineBlockForAttachment(
   a: MessageAttachmentInput,
 ): ContentBlock | null {
-  if (!a.data) return null;
+  if (!a.data) {return null;}
   return attachmentsToContentBlocks([a])[0] ?? null;
 }
 
@@ -431,7 +431,7 @@ function prepareUserAttachmentReferences(
       });
       continue;
     }
-    if (outcome.kind === "rejected") continue;
+    if (outcome.kind === "rejected") {continue;}
     // transient: keep the upload by inlining its bytes (dropped only when the
     // recoverable failure left us with no bytes to inline).
     const inline = inlineBlockForAttachment(a);
@@ -450,24 +450,24 @@ function prepareUserAttachmentReferences(
 function extractTurnChannelContext(
   metadata?: Record<string, unknown>,
 ): TurnChannelContext | null {
-  if (!metadata) return null;
+  if (!metadata) {return null;}
   const userMessageChannel = parseChannelId(metadata.userMessageChannel);
   const assistantMessageChannel = parseChannelId(
     metadata.assistantMessageChannel,
   );
-  if (!userMessageChannel || !assistantMessageChannel) return null;
+  if (!userMessageChannel || !assistantMessageChannel) {return null;}
   return { userMessageChannel, assistantMessageChannel };
 }
 
 function extractTurnInterfaceContext(
   metadata?: Record<string, unknown>,
 ): TurnInterfaceContext | null {
-  if (!metadata) return null;
+  if (!metadata) {return null;}
   const userMessageInterface = parseInterfaceId(metadata.userMessageInterface);
   const assistantMessageInterface = parseInterfaceId(
     metadata.assistantMessageInterface,
   );
-  if (!userMessageInterface || !assistantMessageInterface) return null;
+  if (!userMessageInterface || !assistantMessageInterface) {return null;}
   return { userMessageInterface, assistantMessageInterface };
 }
 
@@ -530,7 +530,7 @@ export function buildSlackMetaForPersistence(params: {
 export interface EnqueueMessageOptions {
   content: string;
   attachments?: UserMessageAttachment[];
-  onEvent?: (msg: ServerMessage) => void;
+  onEvent?: (msg: AssistantEvent) => void;
   requestId?: string;
   activeSurfaceId?: string;
   currentPage?: string;
@@ -890,7 +890,7 @@ export async function persistQueuedMessageBody(
     // though the store anchor was lost, then persist the corrected content.
     let repairedBlocks: ContentBlock[] | null = null;
     preparedAttachments.forEach((p, idx) => {
-      if (!p.link) return;
+      if (!p.link) {return;}
       try {
         const scopedAttachmentId = linkAttachmentToMessage(
           persistedUserMessage.id,
@@ -982,7 +982,7 @@ export function redirectToSecurePrompt(
       conversationId,
     )
     .then(async (result): Promise<void> => {
-      if (!result.value) return;
+      if (!result.value) {return;}
 
       const { setSecureKeyAsync } = await import("../security/secure-keys.js");
       const { upsertCredentialMetadata } =

--- a/assistant/src/daemon/conversation-notifiers.ts
+++ b/assistant/src/daemon/conversation-notifiers.ts
@@ -23,7 +23,7 @@ import {
   provenanceFromTrustContext,
 } from "../persistence/conversation-crud.js";
 import type { Message } from "../providers/types.js";
-import type { ServerMessage } from "./message-protocol.js";
+import type { AssistantEvent } from "./message-protocol.js";
 import type { TrustContext } from "./trust-context-types.js";
 
 /**
@@ -31,7 +31,7 @@ import type { TrustContext } from "./trust-context-types.js";
  * invocation time. Properties are read lazily from this reference.
  */
 export interface NotifierConversationContext {
-  sendToClient: (msg: ServerMessage) => void;
+  sendToClient: (msg: AssistantEvent) => void;
   messages: Message[];
   trustContext?: TrustContext;
 }

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -57,7 +57,7 @@ import {
 import { getModelInfo } from "./handlers/config-model.js";
 import { preactivateHostProxySkills } from "./host-proxy-preactivation.js";
 import type {
-  ServerMessage,
+  AssistantEvent,
   UserMessageAttachment,
 } from "./message-protocol.js";
 import { buildTransportHints } from "./transport-hints.js";
@@ -192,7 +192,7 @@ export function formatCleanResult(result: CleanResult): string {
 /** Build a model_info event with fresh config data. */
 export async function buildModelInfoEvent(
   conversationId?: string,
-): Promise<ServerMessage> {
+): Promise<AssistantEvent> {
   return { type: "model_info", conversationId, ...(await getModelInfo()) };
 }
 
@@ -1503,7 +1503,7 @@ async function drainBatch(
   const successfulEventSinks = Array.from(
     new Set(successfulBatch.map((qm) => qm.onEvent)),
   );
-  const fanOutOnEvent = (msg: ServerMessage) => {
+  const fanOutOnEvent = (msg: AssistantEvent) => {
     for (const onEvent of successfulEventSinks) {
       onEvent(msg);
     }
@@ -1567,7 +1567,7 @@ async function drainBatch(
 export interface ProcessMessageOptions {
   content: string;
   attachments: UserMessageAttachment[];
-  onEvent?: (msg: ServerMessage) => void;
+  onEvent?: (msg: AssistantEvent) => void;
   requestId?: string;
   activeSurfaceId?: string;
   currentPage?: string;

--- a/assistant/src/daemon/conversation-queue-manager.ts
+++ b/assistant/src/daemon/conversation-queue-manager.ts
@@ -12,7 +12,7 @@ import type {
 import type { AuthContext } from "../runtime/auth/types.js";
 import { getLogger } from "../util/logger.js";
 import type {
-  ServerMessage,
+  AssistantEvent,
   UserMessageAttachment,
 } from "./message-protocol.js";
 import type { ConversationTransportMetadata } from "./message-types/conversations.js";
@@ -23,7 +23,7 @@ export interface QueuedMessage {
   content: string;
   attachments: UserMessageAttachment[];
   requestId: string;
-  onEvent: (msg: ServerMessage) => void;
+  onEvent: (msg: AssistantEvent) => void;
   activeSurfaceId?: string;
   currentPage?: string;
   metadata?: Record<string, unknown>;
@@ -156,7 +156,7 @@ export class MessageQueue {
    */
   shiftN(count: number): QueuedMessage[] {
     const n = Math.min(Math.max(0, count), this.items.length);
-    if (n === 0) return [];
+    if (n === 0) {return [];}
     const removed = this.items.splice(0, n);
     for (const item of removed) {
       this.currentBytes -= estimateItemBytes(item);
@@ -188,8 +188,8 @@ export class MessageQueue {
    */
   promoteToHead(requestId: string): QueuedMessage | undefined {
     const idx = this.items.findIndex((m) => m.requestId === requestId);
-    if (idx === -1) return undefined;
-    if (idx === 0) return this.items[0]; // already at head
+    if (idx === -1) {return undefined;}
+    if (idx === 0) {return this.items[0];} // already at head
     const [promoted] = this.items.splice(idx, 1);
     this.items.unshift(promoted);
     return promoted;
@@ -201,7 +201,7 @@ export class MessageQueue {
    */
   removeByRequestId(requestId: string): QueuedMessage | undefined {
     const idx = this.items.findIndex((m) => m.requestId === requestId);
-    if (idx === -1) return undefined;
+    if (idx === -1) {return undefined;}
     const [removed] = this.items.splice(idx, 1);
     this.currentBytes -= estimateItemBytes(removed);
     return removed;
@@ -220,7 +220,7 @@ function estimateItemBytes(item: QueuedMessage): number {
   let bytes = item.content.length * 2; // JS strings are UTF-16
   for (const a of item.attachments) {
     bytes += a.data.length * 2;
-    if (a.extractedText) bytes += a.extractedText.length * 2;
+    if (a.extractedText) {bytes += a.extractedText.length * 2;}
   }
   // Include transport metadata in the estimate so large transport
   // payloads (e.g. hostHomeDir, hostUsername) count against the budget.

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -70,13 +70,13 @@ import type { HostAppControlProxy } from "./host-app-control-proxy.js";
 import type { HostCuProxy } from "./host-cu-proxy.js";
 import type {
   AnySurfaceData,
+  AssistantEvent,
   CardSurfaceData,
   ChoiceSurfaceData,
   ConfirmationSurfaceData,
   DynamicPagePreview,
   DynamicPageSurfaceData,
   FormSurfaceData,
-  ServerMessage,
   SurfaceAction,
   SurfaceData,
   SurfaceType,
@@ -818,7 +818,7 @@ export interface SurfaceConversationContext {
     channel: string;
     supportsDynamicUi: boolean;
   };
-  sendToClient(msg: ServerMessage): void;
+  sendToClient(msg: AssistantEvent): void;
   pendingSurfaceActions: Map<string, { surfaceType: SurfaceType }>;
   lastSurfaceAction: Map<
     string,
@@ -2001,7 +2001,7 @@ export async function handleSurfaceAction(
     // Pass conversationId so events without an inline conversationId (e.g.
     // text_delta) are published with the correct conversation scope and
     // reach the SSE subscriber filtered to this conversation.
-    const onEvent = (msg: ServerMessage) =>
+    const onEvent = (msg: AssistantEvent) =>
       broadcastMessage(msg, ctx.conversationId);
 
     const result = ctx.enqueueMessage({
@@ -2228,7 +2228,7 @@ export async function handleSurfaceAction(
   // Pass conversationId so events without an inline conversationId (e.g.
   // text_delta) are published with the correct conversation scope and
   // reach the SSE subscriber filtered to this conversation.
-  const onEvent = (msg: ServerMessage) =>
+  const onEvent = (msg: AssistantEvent) =>
     broadcastMessage(msg, ctx.conversationId);
 
   log.info(

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -73,7 +73,7 @@ import {
   isDoordashCommand,
   markDoordashStepInProgress,
 } from "./doordash-steps.js";
-import type { ServerMessage } from "./message-protocol.js";
+import type { AssistantEvent } from "./message-protocol.js";
 import { runPostExecutionSideEffects } from "./tool-side-effects.js";
 import { FALLBACK_TURN_TRUST, resolveTrustClass } from "./trust-context.js";
 
@@ -391,8 +391,8 @@ export function createToolExecutor(
       enabledPluginSet: effectiveEnabledPluginSet,
       sendToClient: (msg) => {
         // Tool context's sendToClient uses a loose { type: string; [key: string]: unknown }
-        // signature, but at runtime these are always ServerMessage instances.
-        ctx.sendToClient(msg as ServerMessage);
+        // signature, but at runtime these are always AssistantEvent instances.
+        ctx.sendToClient(msg as AssistantEvent);
         if (msg.type === "ui_surface_show") {
           // The tool-context sendToClient signature is loose, so the show
           // message's fields are untyped here; map them through the same

--- a/assistant/src/daemon/conversation-usage.ts
+++ b/assistant/src/daemon/conversation-usage.ts
@@ -16,7 +16,7 @@ import {
   resolvePricingForUsageWithOverrides,
   usesAnthropicPricingRules,
 } from "../util/pricing.js";
-import type { ServerMessage, UsageStats } from "./message-protocol.js";
+import type { AssistantEvent, UsageStats } from "./message-protocol.js";
 
 const log = getLogger("conversation-usage");
 
@@ -27,12 +27,12 @@ export interface UsageContext {
 }
 
 function normalizeTokenCount(value: number | null | undefined): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  if (typeof value !== "number" || !Number.isFinite(value)) {return 0;}
   return Math.max(value, 0);
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
-  if (typeof value !== "object" || value == null) return null;
+  if (typeof value !== "object" || value == null) {return null;}
   return value as Record<string, unknown>;
 }
 
@@ -42,7 +42,7 @@ function extractAnthropicCacheCreationFromResponse(
   const rawResponse = asRecord(response);
   const usage = asRecord(rawResponse?.usage);
   const cacheCreation = asRecord(usage?.cache_creation);
-  if (!cacheCreation) return null;
+  if (!cacheCreation) {return null;}
 
   return {
     ephemeral_5m_input_tokens: normalizeTokenCount(
@@ -64,7 +64,7 @@ function extractAnthropicCacheCreation(
 
   for (const response of responses) {
     const details = extractAnthropicCacheCreationFromResponse(response);
-    if (!details) continue;
+    if (!details) {continue;}
     foundDetails = true;
     ephemeral5mInputTokens += normalizeTokenCount(
       details.ephemeral_5m_input_tokens,
@@ -74,7 +74,7 @@ function extractAnthropicCacheCreation(
     );
   }
 
-  if (!foundDetails) return null;
+  if (!foundDetails) {return null;}
 
   return {
     ephemeral_5m_input_tokens: ephemeral5mInputTokens,
@@ -96,8 +96,8 @@ function extractAnthropicSpeed(
   for (const response of responses) {
     const rec = asRecord(response);
     const usage = asRecord(rec?.usage);
-    if (usage?.speed === "fast") return "fast";
-    if (usage?.speed === "standard") foundStandard = true;
+    if (usage?.speed === "fast") {return "fast";}
+    if (usage?.speed === "standard") {foundStandard = true;}
   }
   return foundStandard ? "standard" : null;
 }
@@ -143,7 +143,7 @@ function resolveAttribution(
     | null
     | undefined,
 ): UsageAttributionSnapshot | null {
-  if (attribution == null) return null;
+  if (attribution == null) {return null;}
   return isUsageAttributionSnapshot(attribution)
     ? attribution
     : resolveUsageAttribution(attribution);
@@ -154,7 +154,7 @@ export function recordUsage(
   inputTokens: number,
   outputTokens: number,
   model: string,
-  onEvent: (msg: ServerMessage) => void,
+  onEvent: (msg: AssistantEvent) => void,
   actor: UsageActor,
   requestId: string | null = null,
   cacheCreationInputTokens = 0,
@@ -165,7 +165,7 @@ export function recordUsage(
   attribution?: UsageAttributionInput | UsageAttributionSnapshot | null,
   cronRunId: string | null = null,
 ): void {
-  if (inputTokens <= 0 && outputTokens <= 0) return;
+  if (inputTokens <= 0 && outputTokens <= 0) {return;}
 
   const normalizedCacheCreationInputTokens = normalizeTokenCount(
     cacheCreationInputTokens,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -164,7 +164,7 @@ import { HostAppControlProxy } from "./host-app-control-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
 import { shouldAttachHostProxyForCapability } from "./host-proxy-preactivation.js";
 import type {
-  ServerMessage,
+  AssistantEvent,
   SurfaceType,
   UsageStats,
 } from "./message-protocol.js";
@@ -320,7 +320,7 @@ export class Conversation {
   /** @internal */ prompter: PermissionPrompter;
   /** @internal */ secretPrompter: SecretPrompter;
   private executor: ToolExecutor;
-  /** @internal */ sendToClient: (msg: ServerMessage) => void;
+  /** @internal */ sendToClient: (msg: AssistantEvent) => void;
   /** @internal */ workingDir: string;
   /** @internal */ allowedToolNames?: Set<string>;
   /**
@@ -672,7 +672,7 @@ export class Conversation {
   originChannel: ChannelId | undefined = undefined;
   /** @internal */ activityVersion = 0;
   /** Last emitted activity state message, retained for replay on SSE reconnection. */
-  /** @internal */ lastActivityStateMsg: ServerMessage | null = null;
+  /** @internal */ lastActivityStateMsg: AssistantEvent | null = null;
   /** Set by the agent loop to track confirmation outcomes for persistence. */
   onConfirmationOutcome?: (
     requestId: string,
@@ -685,7 +685,7 @@ export class Conversation {
     conversationId: string,
     provider: Provider,
     systemPrompt: string,
-    sendToClient: (msg: ServerMessage) => void,
+    sendToClient: (msg: AssistantEvent) => void,
     workingDir: string,
     options?: ConversationConstructorOptions,
   ) {
@@ -1431,7 +1431,7 @@ export class Conversation {
   }
 
   updateClient(
-    sendToClient: (msg: ServerMessage) => void,
+    sendToClient: (msg: AssistantEvent) => void,
     hasNoClient = false,
   ): void {
     this.sendToClient = sendToClient;
@@ -1453,7 +1453,7 @@ export class Conversation {
   }
 
   /** Returns the current sendToClient reference for identity comparison. */
-  getCurrentSender(): (msg: ServerMessage) => void {
+  getCurrentSender(): (msg: AssistantEvent) => void {
     return this.sendToClient;
   }
 
@@ -1866,10 +1866,10 @@ export class Conversation {
   emitConfirmationStateChanged(
     params: Omit<ConfirmationStateChangedEvent, "type">,
   ): void {
-    const msg: ServerMessage = {
+    const msg: AssistantEvent = {
       type: "confirmation_state_changed",
       ...params,
-    } as ServerMessage;
+    } as AssistantEvent;
     try {
       this.sendToClient(msg);
     } catch (err) {
@@ -1891,7 +1891,7 @@ export class Conversation {
   ): void {
     const { anchor = "assistant_turn", requestId, statusText } = options ?? {};
     this.activityVersion++;
-    const msg: ServerMessage = {
+    const msg: AssistantEvent = {
       type: "assistant_activity_state",
       conversationId: this.conversationId,
       activityVersion: this.activityVersion,
@@ -1900,7 +1900,7 @@ export class Conversation {
       requestId,
       reason,
       ...(statusText ? { statusText } : {}),
-    } as ServerMessage;
+    } as AssistantEvent;
     this.lastActivityStateMsg = msg;
     try {
       this.sendToClient(msg);
@@ -2454,7 +2454,7 @@ export class Conversation {
     content: string,
     userMessageId: string,
     options?: {
-      onEvent?: (msg: ServerMessage) => void;
+      onEvent?: (msg: AssistantEvent) => void;
       isInteractive?: boolean;
       isUserMessage?: boolean;
       titleText?: string;

--- a/assistant/src/daemon/host-proxy-base.ts
+++ b/assistant/src/daemon/host-proxy-base.ts
@@ -24,23 +24,23 @@ import type { PendingInteraction } from "../runtime/pending-interactions.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
-import type { ServerMessage } from "./message-protocol.js";
+import type { AssistantEvent } from "./message-protocol.js";
 
 const log = getLogger("host-proxy-base");
 
 /**
  * `broadcastMessage` is statically typed against the discriminated
- * `ServerMessage` union. The base class assembles envelopes from
+ * `AssistantEvent` union. The base class assembles envelopes from
  * constructor-supplied event names and untyped extra fields, so static
  * narrowing is impossible — subclasses are responsible for passing event
- * names that match a real `ServerMessage` variant.
+ * names that match a real `AssistantEvent` variant.
  */
 function broadcastDynamic(
   envelope: Record<string, unknown>,
   targetClientId?: string,
 ): void {
   broadcastMessage(
-    envelope as unknown as ServerMessage,
+    envelope as unknown as AssistantEvent,
     undefined,
     targetClientId ? { targetClientId } : undefined,
   );

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -5,8 +5,8 @@
  * each exports a `_<Domain>ClientMessages` alias that this file composes into
  * the aggregate `ClientMessage` union.
  *
- * The server->client union `ServerMessage` is single-sourced from the canonical
- * `AssistantEventSchema` in `../api` -- `ServerMessage` is `z.infer` of that
+ * The server->client union `AssistantEvent` is single-sourced from the canonical
+ * `AssistantEventSchema` in `../api` -- `AssistantEvent` is `z.infer` of that
  * schema, so every hub-published event type appears in it automatically.
  */
 
@@ -24,8 +24,11 @@ export * from "./message-types/surfaces.js";
 export * from "./message-types/sync.js";
 export * from "./message-types/web-activity.js";
 
-// Canonical server->client event union.
-import type { AssistantEvent } from "../api/index.js";
+// Canonical server->client event union: every message the daemon can send to a
+// client, single-sourced from `AssistantEventSchema` (`z.infer`). Re-exported
+// here so daemon code can import it alongside the ClientMessage union.
+export type { AssistantEvent } from "../api/index.js";
+
 // Client-message domain aliases for the ClientMessage union.
 import type { _ComputerUseClientMessages } from "./message-types/computer-use.js";
 import type { _DiagnosticsClientMessages } from "./message-types/diagnostics.js";
@@ -41,12 +44,3 @@ export type ClientMessage =
   | _HostBrowserClientMessages
   | _DiagnosticsClientMessages
   | _NotificationsClientMessages;
-
-// === Server -> Client aggregate union ===
-
-/**
- * Every message the daemon can send to a client. Single-sourced from the
- * canonical `AssistantEventSchema` (`z.infer`), so this stays in lock-step
- * with the published wire contract.
- */
-export type ServerMessage = AssistantEvent;

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -69,14 +69,14 @@ import {
   preactivateHostProxySkills,
   shouldAttachHostProxyForCapability,
 } from "./host-proxy-preactivation.js";
-import type { ServerMessage } from "./message-protocol.js";
+import type { AssistantEvent } from "./message-protocol.js";
 import type { SubagentToolGateMode } from "./tool-setup-types.js";
 
 const log = getLogger("process-message");
 
 type ProcessMessageOptions = ConversationCreateOptions & {
   /** Per-turn observer for live agent-loop events. Does not replace SSE broadcast. */
-  onEvent?: (msg: ServerMessage) => void;
+  onEvent?: (msg: AssistantEvent) => void;
   /** IDs of user-uploaded attachments to resolve and include in the turn. */
   attachmentIds?: string[];
   /** Originating channel (e.g. "slack", "telegram"). Defaults to "vellum". */
@@ -152,9 +152,9 @@ export function deriveIngressIdempotencyKey(options?: {
 }
 
 function buildEventEmitter(
-  observer?: (msg: ServerMessage) => void,
-): (msg: ServerMessage) => void {
-  if (!observer) return broadcastMessage;
+  observer?: (msg: AssistantEvent) => void,
+): (msg: AssistantEvent) => void {
+  if (!observer) {return broadcastMessage;}
   return (msg) => {
     broadcastMessage(msg);
     try {

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -26,7 +26,7 @@ import { getWorkspaceDir } from "../util/platform.js";
 import { ensureAppSourceWatcher } from "./app-source-watcher.js";
 import { refreshSurfacesForApp } from "./conversation-surfaces.js";
 import { isDoordashCommand, updateDoordashProgress } from "./doordash-steps.js";
-import type { ServerMessage } from "./message-protocol.js";
+import type { AssistantEvent } from "./message-protocol.js";
 import type { ToolSetupContext } from "./tool-setup-types.js";
 
 const log = getLogger("tool-side-effects");
@@ -181,7 +181,7 @@ registerAppSurfaceRefreshHook("app_update");
 
 registerHook("voice_config_update", (_name, input) => {
   const setting = input.setting as string | undefined;
-  if (!setting) return;
+  if (!setting) {return;}
 
   const SETTING_TO_KEY: Record<string, string> = {
     activation_key: "pttActivationKey",
@@ -191,7 +191,7 @@ registerHook("voice_config_update", (_name, input) => {
     fish_audio_reference_id: "fishAudioReferenceId",
   };
   const key = SETTING_TO_KEY[setting];
-  if (!key) return;
+  if (!key) {return;}
 
   // `ttsVoiceId` is an ElevenLabs concept on the desktop client. When the
   // active provider is managed (vellum) or anything else, the voice lives only
@@ -222,7 +222,7 @@ registerHook("voice_config_update", (_name, input) => {
     type: "client_settings_update",
     key,
     value: coerced,
-  } as unknown as ServerMessage);
+  } as unknown as AssistantEvent);
 });
 
 // Dispatch pending Slack DM delivery when a CLI verification command
@@ -231,8 +231,8 @@ registerHook("voice_config_update", (_name, input) => {
 // This hook runs in the unsandboxed daemon process and delivers the DM.
 registerHook("bash", async (_name, input, result) => {
   const command = (input.command ?? "") as string;
-  if (!command.includes("channel-verification-sessions")) return;
-  if (!result.content.includes("_pendingSlackDm")) return;
+  if (!command.includes("channel-verification-sessions")) {return;}
+  if (!result.content.includes("_pendingSlackDm")) {return;}
 
   type PendingDm = { userId: string; text: string; assistantId: string };
   type Parsed = { _pendingSlackDm?: PendingDm };
@@ -288,18 +288,18 @@ registerHook("bash", async (_name, input, result) => {
     // multi-object output (e.g. cancel + create chained with &&).
   }
   if (singleObject !== undefined) {
-    if ((await dispatch(singleObject)) !== null) return;
+    if ((await dispatch(singleObject)) !== null) {return;}
   }
   for (const line of result.content.split("\n")) {
     const trimmed = line.trim();
-    if (!trimmed.startsWith("{")) continue;
+    if (!trimmed.startsWith("{")) {continue;}
     let parsed: Parsed;
     try {
       parsed = JSON.parse(trimmed) as Parsed;
     } catch {
       continue;
     }
-    if ((await dispatch(parsed)) === "delivered") return;
+    if ((await dispatch(parsed)) === "delivered") {return;}
   }
 });
 
@@ -311,7 +311,7 @@ function invalidateEdgeIndexIfConceptPage(
   input: Record<string, unknown>,
 ): void {
   const rawPath = input.path;
-  if (typeof rawPath !== "string" || rawPath.length === 0) return;
+  if (typeof rawPath !== "string" || rawPath.length === 0) {return;}
   const workspaceDir = getWorkspaceDir();
   const conceptsRoot = getConceptsDir(workspaceDir);
   const absPath = isAbsolute(rawPath)

--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -27,7 +27,7 @@ import { publishConversationMessagesChanged } from "../runtime/sync/resource-syn
 import type { CompletedBackgroundTool } from "../tools/background-tool-registry.js";
 import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
-import type { ServerMessage } from "./message-protocol.js";
+import type { AssistantEvent } from "./message-protocol.js";
 import type {
   SubagentToolGateMode,
   WakeToolContextPin,
@@ -37,7 +37,7 @@ const log = getLogger("wake-conversation-ops");
 
 /**
  * Translate a raw {@link AgentEvent} from the agent loop into the
- * corresponding {@link ServerMessage} wire frame. The normal user-turn
+ * corresponding {@link AssistantEvent} wire frame. The normal user-turn
  * path does this via the full state-aware handler in
  * `conversation-agent-loop-handlers.ts`; the wake path has no tool
  * accounting, title generation, or activity-state tracking to worry
@@ -48,7 +48,7 @@ const log = getLogger("wake-conversation-ops");
 function translateAgentEventToServerMessage(
   event: AgentEvent,
   conversationId: string,
-): ServerMessage | null {
+): AssistantEvent | null {
   switch (event.type) {
     case "text_delta":
       return {
@@ -176,7 +176,7 @@ export function emitWakeAgentEvent(
     event,
     conversation.conversationId,
   );
-  if (!frame) return;
+  if (!frame) {return;}
   broadcastMessage(frame);
 }
 

--- a/assistant/src/ipc/routes/__tests__/conversation-sync-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/conversation-sync-ipc-routes.test.ts
@@ -35,7 +35,7 @@ import {
   registerInflightTurn,
   unregisterInflightTurn,
 } from "../../../daemon/inflight-turn-registry.js";
-import type { AssistantEvent } from "../../../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../../../runtime/assistant-event.js";
 import {
   _resetStreamStateForTesting,
   stampAndBuffer,
@@ -50,7 +50,7 @@ function stampEvent(): void {
   stampAndBuffer({
     conversationId: "conv-x",
     message: { type: "assistant_text_delta", text: "x" },
-  } as unknown as AssistantEvent);
+  } as unknown as AssistantEventEnvelope);
 }
 
 describe("conversation-sync IPC route", () => {

--- a/assistant/src/ipc/routes/events-ipc-routes.ts
+++ b/assistant/src/ipc/routes/events-ipc-routes.ts
@@ -27,7 +27,7 @@ import {
   HOST_PROXY_CAPABILITIES,
   INTERFACE_IDS,
 } from "../../channels/types.js";
-import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
 import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
 
@@ -37,12 +37,12 @@ export const EVENTS_PUBLISH_IPC_METHOD = "/events/publish";
 /**
  * The event envelope reuses the shared wire schema's transport fields (`id`,
  * `emittedAt`, `conversationId`, `seq`) and overrides only `message`: the hub
- * publishes runtime `ServerMessage`-typed events, whose union is defined
+ * publishes runtime `AssistantEvent`-typed events, whose union is defined
  * separately from the api schema's message union, so the override yields a
  * value assignable to `assistantEventHub.publish` without a cast.
  */
 const EventEnvelopeSchema = AssistantEventEnvelopeSchema.extend({
-  message: z.custom<ServerMessage>(
+  message: z.custom<AssistantEvent>(
     (value) => value != null && typeof value === "object",
   ),
 });

--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -19,7 +19,7 @@
  */
 
 import type { InterfaceId } from "../../channels/types.js";
-import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import { getLogger } from "../../util/logger.js";
 import type {
   ChannelAdapter,
@@ -44,7 +44,7 @@ export interface BroadcastFnOptions {
 }
 
 export type BroadcastFn = (
-  msg: ServerMessage,
+  msg: AssistantEvent,
   conversationId?: string,
   options?: BroadcastFnOptions,
 ) => void;
@@ -107,7 +107,7 @@ export class VellumAdapter implements ChannelAdapter {
         deepLinkMetadata: payload.deepLinkTarget,
         targetGuardianPrincipalId,
         silent,
-      } as ServerMessage);
+      } as AssistantEvent);
 
       log.info(
         {

--- a/assistant/src/permissions/confirmation-guardian-request.test.ts
+++ b/assistant/src/permissions/confirmation-guardian-request.test.ts
@@ -50,7 +50,7 @@ mock.module("../runtime/confirmation-request-guardian-bridge.js", () => ({
   },
 }));
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { createGuardianRequestForConfirmation } from "./confirmation-guardian-request.js";
 
 const MSG = {
@@ -59,7 +59,7 @@ const MSG = {
   toolName: "Bash",
   input: { command: "ls" },
   riskLevel: "medium",
-} as unknown as ServerMessage & { type: "confirmation_request" };
+} as unknown as AssistantEvent & { type: "confirmation_request" };
 
 describe("createGuardianRequestForConfirmation", () => {
   beforeEach(() => {

--- a/assistant/src/permissions/confirmation-guardian-request.ts
+++ b/assistant/src/permissions/confirmation-guardian-request.ts
@@ -17,7 +17,7 @@
  * therefore the emitters — stays cheap and free of import-time side effects.
  */
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { IntegrityError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 
@@ -30,7 +30,7 @@ const log = getLogger("confirmation-guardian-request");
  * never thrown.
  */
 export async function createGuardianRequestForConfirmation(
-  msg: ServerMessage & { type: "confirmation_request" },
+  msg: AssistantEvent & { type: "confirmation_request" },
   conversationId: string,
   opts?: {
     /**

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../config/loader.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { redactSensitiveFields } from "../security/redaction.js";
 import type { ExecutionTarget } from "../tools/tool-types.js";
@@ -36,10 +36,10 @@ export class PermissionPrompter {
    * pendingInteractions, matching the host proxy pattern.
    */
   private ownedIds = new Set<string>();
-  private sendToClient: (msg: ServerMessage) => void;
+  private sendToClient: (msg: AssistantEvent) => void;
   private onStateChanged?: ConfirmationStateCallback;
 
-  constructor(sendToClient: (msg: ServerMessage) => void) {
+  constructor(sendToClient: (msg: AssistantEvent) => void) {
     this.sendToClient = sendToClient;
   }
 
@@ -47,7 +47,7 @@ export class PermissionPrompter {
     this.onStateChanged = cb;
   }
 
-  updateSender(sendToClient: (msg: ServerMessage) => void): void {
+  updateSender(sendToClient: (msg: AssistantEvent) => void): void {
     this.sendToClient = sendToClient;
   }
 
@@ -145,7 +145,7 @@ export class PermissionPrompter {
         signal.addEventListener("abort", onAbort, { once: true });
       }
 
-      const confirmationMsg: ServerMessage & {
+      const confirmationMsg: AssistantEvent & {
         type: "confirmation_request";
       } = {
         type: "confirmation_request",

--- a/assistant/src/permissions/question-prompter.test.ts
+++ b/assistant/src/permissions/question-prompter.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { setConfig } from "../__tests__/helpers/set-config.js";
 import type { QuestionRequestEvent } from "../api/events/question-request.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type {
   QuestionBatchSubmission,
   QuestionPromptResult,
@@ -48,7 +48,7 @@ mock.module("../runtime/pending-interactions.js", () => ({
   register: (id: string, entry: MockInteraction) => _piStore.set(id, entry),
   resolve: (id: string) => {
     const e = _piStore.get(id);
-    if (e?.timer != null) clearTimeout(e.timer);
+    if (e?.timer != null) {clearTimeout(e.timer);}
     _piStore.delete(id);
     return e;
   },
@@ -66,18 +66,18 @@ mock.module("../runtime/pending-interactions.js", () => ({
 // prompter would have broadcast — but preserve every other export from
 // the real module so other tests in the same `bun test` run (which
 // share module-level mocks) still see e.g. `assistantEventHub`.
-let _sentBuffer: ServerMessage[] = [];
+let _sentBuffer: AssistantEvent[] = [];
 const realEventHub = await import("../runtime/assistant-event-hub.js");
 mock.module("../runtime/assistant-event-hub.js", () => ({
   ...realEventHub,
-  broadcastMessage: (msg: ServerMessage) => _sentBuffer.push(msg),
+  broadcastMessage: (msg: AssistantEvent) => _sentBuffer.push(msg),
 }));
 
 const { QuestionPrompter, QuestionBatchValidationError, buildBatchEntries } =
   await import("./question-prompter.js");
 
 function makePrompter() {
-  const sent: ServerMessage[] = [];
+  const sent: AssistantEvent[] = [];
   _sentBuffer = sent;
   const prompter = new QuestionPrompter();
   return { prompter, sent };
@@ -106,7 +106,7 @@ function resolveBatch(
     submissions,
   );
   const result: QuestionPromptResult = { entries, overall: "completed" };
-  if (interaction.timer != null) clearTimeout(interaction.timer);
+  if (interaction.timer != null) {clearTimeout(interaction.timer);}
   _piStore.delete(requestId);
   interaction.rpcResolve?.(result);
   return result;
@@ -128,7 +128,7 @@ function closeBatch(requestId: string): QuestionPromptResult {
     })),
     overall: "closed",
   };
-  if (interaction.timer != null) clearTimeout(interaction.timer);
+  if (interaction.timer != null) {clearTimeout(interaction.timer);}
   _piStore.delete(requestId);
   interaction.rpcResolve?.(result);
   return result;
@@ -412,7 +412,7 @@ describe("QuestionPrompter", () => {
     // Simulate `removeByConversation` clearing the registry entry before
     // the abort signal fires.
     const interaction = _piStore.get(req.requestId);
-    if (interaction?.timer != null) clearTimeout(interaction.timer);
+    if (interaction?.timer != null) {clearTimeout(interaction.timer);}
     _piStore.delete(req.requestId);
 
     ac.abort();

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../config/loader.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
@@ -11,7 +11,7 @@ import type {
   SecretPromptResult,
 } from "./secret-prompt-types.js";
 
-type SecretRequestMessage = Extract<ServerMessage, { type: "secret_request" }>;
+type SecretRequestMessage = Extract<AssistantEvent, { type: "secret_request" }>;
 
 const log = getLogger("secret-prompter");
 

--- a/assistant/src/plugin-api/__tests__/publish-event.test.ts
+++ b/assistant/src/plugin-api/__tests__/publish-event.test.ts
@@ -7,11 +7,11 @@
 
 import { describe, expect, test } from "bun:test";
 
-import type { AssistantEvent } from "../../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../../runtime/assistant-event.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
 import { publishEvent } from "../publish-event.js";
 
-function syncEvent(): AssistantEvent {
+function syncEvent(): AssistantEventEnvelope {
   return {
     id: "evt-1",
     conversationId: "conv-1",
@@ -19,13 +19,13 @@ function syncEvent(): AssistantEvent {
     message: {
       type: "sync_changed",
       tags: ["my-app:items"],
-    } as unknown as AssistantEvent["message"],
+    } as unknown as AssistantEventEnvelope["message"],
   };
 }
 
 describe("publishEvent", () => {
   test("delivers a plain event to hub subscribers", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const sub = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {
@@ -42,12 +42,12 @@ describe("publishEvent", () => {
   });
 
   test("rejects a host-proxy control event", async () => {
-    const hostEvent: AssistantEvent = {
+    const hostEvent: AssistantEventEnvelope = {
       id: "evt-2",
       emittedAt: "2026-01-01T00:00:00.000Z",
       message: {
         type: "host_bash_request",
-      } as unknown as AssistantEvent["message"],
+      } as unknown as AssistantEventEnvelope["message"],
     };
     await expect(publishEvent(hostEvent)).rejects.toThrow(/host-proxy/);
   });

--- a/assistant/src/plugin-api/conversation-turn.ts
+++ b/assistant/src/plugin-api/conversation-turn.ts
@@ -14,7 +14,7 @@
  */
 
 import type { LLMCallSite } from "../config/schemas/llm.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { UserMessageAttachment } from "../daemon/message-types/shared.js";
 import type { ContentBlock, MediaSource } from "../providers/types.js";
 
@@ -144,9 +144,9 @@ export async function runConversationTurn(
   const { resolveMediaSourceData } =
     await import("../providers/media-resolve.js");
   const { getConversation, getMessageById, getMessages } =
-      await import("../persistence/conversation-crud.js");
+    await import("../persistence/conversation-crud.js");
   const { publishConversationListAndMetadataChanged } =
-      await import("../runtime/sync/resource-sync-events.js");
+    await import("../runtime/sync/resource-sync-events.js");
 
   // Plugin-driven turns run as the guardian: plugins are installed by the
   // guardian, so their conversations inherit guardian trust. This lets the
@@ -193,7 +193,7 @@ export async function runConversationTurn(
   // buildEventEmitter pattern from process-message.ts so plugin-driven
   // turns reach the same subscribers as HTTP-driven turns.
   let assistantMessageId: string | undefined;
-  const onEvent = (msg: ServerMessage): void => {
+  const onEvent = (msg: AssistantEvent): void => {
     broadcastMessage(msg, conversationId);
     if (msg.type === "message_complete" && msg.messageId) {
       assistantMessageId = msg.messageId;

--- a/assistant/src/plugin-api/event-hub-facade.ts
+++ b/assistant/src/plugin-api/event-hub-facade.ts
@@ -40,7 +40,7 @@
  * mid-fanout (the hub delivers one object to every subscriber in turn).
  */
 
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   type AssistantEventFilter,
   type AssistantEventHub,
@@ -105,7 +105,9 @@ const startsWith = Function.prototype.call.bind(
 ) as (str: string, search: string) => boolean;
 
 /** The blocked event type if `event` is a host-proxy control event, else `undefined`. */
-function hostControlEventType(event: AssistantEvent): string | undefined {
+function hostControlEventType(
+  event: AssistantEventEnvelope,
+): string | undefined {
   const type: unknown = event.message?.type;
   return typeof type === "string" &&
     startsWith(type, HOST_CONTROL_EVENT_TYPE_PREFIX)
@@ -134,7 +136,7 @@ export const pluginAssistantEventHub: PluginEventHub = Object.freeze({
       type: "process",
       filter,
       callback: (event) => {
-        let isolated: AssistantEvent;
+        let isolated: AssistantEventEnvelope;
         try {
           isolated = deepFreeze(wireSnapshot(event));
         } catch {
@@ -146,7 +148,7 @@ export const pluginAssistantEventHub: PluginEventHub = Object.freeze({
   },
 
   publish: async (event, options) => {
-    let snapshot: AssistantEvent;
+    let snapshot: AssistantEventEnvelope;
     let snapshotOptions: Parameters<AssistantEventHub["publish"]>[1];
     try {
       snapshot = deepFreeze(wireSnapshot(event));

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -128,6 +128,13 @@ export { RiskLevel } from "./types.js";
 // re-binds each from the assistant's globalThis-parked namespace so they
 // share module identity with the assistant's own singletons.
 export type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
+/**
+ * @deprecated Renamed to {@link AssistantEventEnvelope}. Retained as a
+ * compatibility alias so existing plugins that import `AssistantEvent` from
+ * `@vellumai/plugin-api` (the SSE envelope a hub subscriber receives) keep
+ * compiling. Prefer `AssistantEventEnvelope` in new plugin code.
+ */
+export type { AssistantEventEnvelope as AssistantEvent } from "../runtime/assistant-event.js";
 export type {
   AssistantEventCallback,
   AssistantEventFilter,

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -127,7 +127,7 @@ export { RiskLevel } from "./types.js";
 // Workspace-local plugins resolve these via the boot-time shim, which
 // re-binds each from the assistant's globalThis-parked namespace so they
 // share module identity with the assistant's own singletons.
-export type { AssistantEvent } from "../runtime/assistant-event.js";
+export type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 export type {
   AssistantEventCallback,
   AssistantEventFilter,

--- a/assistant/src/plugin-api/publish-event.ts
+++ b/assistant/src/plugin-api/publish-event.ts
@@ -14,7 +14,7 @@
  * `sync_changed`) so subscribed clients re-fetch the data that changed.
  */
 
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   pluginAssistantEventHub,
   type PluginEventHub,
@@ -32,7 +32,7 @@ export type PublishEventOptions = NonNullable<
  * host-proxy control event, which plugins may not publish.
  */
 export function publishEvent(
-  event: AssistantEvent,
+  event: AssistantEventEnvelope,
   options?: PublishEventOptions,
 ): Promise<void> {
   return pluginAssistantEventHub.publish(event, options);

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 import type { AssistantConfig } from "../../../../config/types.js";
 import { estimateTextTokens } from "../../../../context/token-estimator.js";
-import type { ServerMessage } from "../../../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../../../daemon/message-protocol.js";
 import { getDb } from "../../../../persistence/db-connection.js";
 import { embedWithRetry } from "../../../../persistence/embeddings/embed.js";
 import { generateSparseEmbedding } from "../../../../persistence/embeddings/embedding-backend.js";
@@ -80,7 +80,7 @@ const liveByConversation = new Map<string, ConversationGraphMemory>();
 export function getLiveGraphMemory(
   conversationId: string | undefined,
 ): ConversationGraphMemory | undefined {
-  if (!conversationId) return undefined;
+  if (!conversationId) {return undefined;}
   return liveByConversation.get(conversationId);
 }
 
@@ -132,7 +132,7 @@ export class ConversationGraphMemory {
    * Called during conversation disposal.
    */
   persistState(): void {
-    if (!this.initialized) return;
+    if (!this.initialized) {return;}
     try {
       const snapshot: InContextTrackerSnapshot & {
         initialized: boolean;
@@ -156,10 +156,10 @@ export class ConversationGraphMemory {
    * On failure or missing row, silently falls back to full context-load.
    */
   restoreState(): void {
-    if (this.stateRestored) return;
+    if (this.stateRestored) {return;}
     try {
       const json = loadGraphMemoryState(this.conversationId);
-      if (!json) return;
+      if (!json) {return;}
 
       const snapshot = JSON.parse(json) as InContextTrackerSnapshot & {
         initialized: boolean;
@@ -360,7 +360,7 @@ export class ConversationGraphMemory {
    * not the original user message.
    */
   retrackCachedNodes(): void {
-    if (this.lastInjectedNodeIds.length === 0) return;
+    if (this.lastInjectedNodeIds.length === 0) {return;}
     this.tracker.add(this.lastInjectedNodeIds);
   }
 
@@ -419,7 +419,7 @@ export class ConversationGraphMemory {
     messages: Message[],
     config: AssistantConfig,
     abortSignal: AbortSignal,
-    onEvent: (msg: ServerMessage) => void,
+    onEvent: (msg: AssistantEvent) => void,
   ): Promise<{
     runMessages: Message[];
     injectedTokens: number;
@@ -480,12 +480,12 @@ export class ConversationGraphMemory {
     // Gate: skip for empty/tool-result-only messages — unless we need to
     // reload after compaction (needsReload) or haven't initialized yet.
     const lastMessage = messages[messages.length - 1];
-    if (!lastMessage || lastMessage.role !== "user") return noopResult;
+    if (!lastMessage || lastMessage.role !== "user") {return noopResult;}
     const hasUserContent = lastMessage.content.some(
       (block) => block.type === "text" && block.text.trim().length > 0,
     );
     if (!hasUserContent && this.initialized && !this.needsReload)
-      return noopResult;
+      {return noopResult;}
 
     try {
       // Decide which retrieval mode to use
@@ -530,7 +530,7 @@ export class ConversationGraphMemory {
     recentSummaries: string[],
     userQuery: string | undefined,
     signal: AbortSignal,
-    onEvent: (msg: ServerMessage) => void,
+    onEvent: (msg: AssistantEvent) => void,
   ) {
     // Use the raw user text (no >10-char filter) so even short greetings
     // ("hi") get a fresh top-K activation dump on the first user message.
@@ -650,7 +650,7 @@ export class ConversationGraphMemory {
       type: "memory_status",
       enabled: true,
       degraded: false,
-    } as ServerMessage);
+    } as AssistantEvent);
 
     this.lastInjectedBlock = contextBlock;
     this.lastInjectedNodeIds = [
@@ -700,7 +700,7 @@ export class ConversationGraphMemory {
       } else if (msg.role === "assistant" && !assistantLast) {
         assistantLast = text;
       }
-      if (userLastBlocks.length > 0 && assistantLast) break;
+      if (userLastBlocks.length > 0 && assistantLast) {break;}
     }
 
     // v2 path — skip v1 retrieval entirely when v2 is enabled. See the
@@ -991,12 +991,12 @@ export function countMemoryPrefixBlocks(content: ContentBlock[]): number {
  * `reinjectCachedMemory` is idempotent — no duplicate images after compaction.
  */
 export function stripExistingMemoryInjections(messages: Message[]): Message[] {
-  if (messages.length === 0) return messages;
+  if (messages.length === 0) {return messages;}
   const last = messages[messages.length - 1];
-  if (!last || last.role !== "user") return messages;
+  if (!last || last.role !== "user") {return messages;}
 
   const stripped = stripMemoryPrefixFromUserMessage(last);
-  if (stripped === last) return messages;
+  if (stripped === last) {return messages;}
 
   return [...messages.slice(0, -1), stripped];
 }
@@ -1011,9 +1011,9 @@ export function stripExistingMemoryInjections(messages: Message[]): Message[] {
  * assembly strips only the TAIL's fresh v2 prefix when v3 supersedes it.
  */
 function stripMemoryPrefixFromUserMessage(message: Message): Message {
-  if (message.role !== "user") return message;
+  if (message.role !== "user") {return message;}
   const firstNonMemory = countMemoryPrefixBlocks(message.content);
-  if (firstNonMemory === 0) return message;
+  if (firstNonMemory === 0) {return message;}
   return { ...message, content: message.content.slice(firstNonMemory) };
 }
 
@@ -1024,21 +1024,21 @@ function stripMemoryPrefixFromUserMessage(message: Message): Message {
  * rendering) that otherwise discard the prepended content.
  */
 export function extractMemoryPrefixBlocks(messages: Message[]): ContentBlock[] {
-  if (messages.length === 0) return [];
+  if (messages.length === 0) {return [];}
   const last = messages[messages.length - 1];
-  if (!last || last.role !== "user") return [];
+  if (!last || last.role !== "user") {return [];}
   const count = countMemoryPrefixBlocks(last.content);
   return count === 0 ? [] : last.content.slice(0, count);
 }
 
 function injectTextBlock(messages: Message[], text: string): Message[] {
-  if (text.trim().length === 0) return messages;
-  if (messages.length === 0) return messages;
+  if (text.trim().length === 0) {return messages;}
+  if (messages.length === 0) {return messages;}
   // Strip existing memory blocks from the last user message first to prevent
   // duplicates when the message was loaded from DB with a persisted block.
   const cleaned = stripExistingMemoryInjections(messages);
   const userTail = cleaned[cleaned.length - 1];
-  if (!userTail || userTail.role !== "user") return messages;
+  if (!userTail || userTail.role !== "user") {return messages;}
   return [
     ...cleaned.slice(0, -1),
     {
@@ -1059,13 +1059,13 @@ function injectMemoryBlock(
   text: string,
   images: Map<string, ResolvedImage>,
 ): Message[] {
-  if (text.trim().length === 0 && images.size === 0) return messages;
-  if (messages.length === 0) return messages;
+  if (text.trim().length === 0 && images.size === 0) {return messages;}
+  if (messages.length === 0) {return messages;}
   // Strip existing memory blocks from the last user message first to prevent
   // duplicates when the message was loaded from DB with a persisted block.
   const cleaned = stripExistingMemoryInjections(messages);
   const userTail = cleaned[cleaned.length - 1];
-  if (!userTail || userTail.role !== "user") return messages;
+  if (!userTail || userTail.role !== "user") {return messages;}
 
   const blocks: ContentBlock[] = [];
 
@@ -1106,7 +1106,7 @@ function injectMemoryBlock(
  */
 function extractUserText(message: Message): string | null {
   const joined = readRawUserText(message);
-  if (!joined) return null;
+  if (!joined) {return null;}
   return joined.length > 10 ? joined : null;
 }
 
@@ -1117,12 +1117,12 @@ function extractUserText(message: Message): string | null {
  * v1 needs would unnecessarily starve v2 on short greetings.
  */
 function readRawUserText(message: Message | undefined): string | null {
-  if (!message) return null;
+  if (!message) {return null;}
   const texts = message.content
     .filter((b): b is Extract<typeof b, { type: "text" }> => b.type === "text")
     .map((b) => b.text.trim())
     .filter((t) => t.length > 0);
-  if (texts.length === 0) return null;
+  if (texts.length === 0) {return null;}
   return texts.join(" ");
 }
 

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -91,8 +91,8 @@ export type {
 /**
  * The complete set of compaction circuit-breaker transition events:
  * `compaction_circuit_open` when the breaker trips and `compaction_circuit_closed`
- * on the open→closed transition. Both are a subset of `ServerMessage`, so any
- * existing `ServerMessage` sink remains assignable to a
+ * on the open→closed transition. Both are a subset of `AssistantEvent`, so any
+ * existing `AssistantEvent` sink remains assignable to a
  * `(msg: CompactionCircuitEvent) => void` parameter.
  */
 export type CompactionCircuitEvent =

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -42,7 +42,7 @@ export function capabilityForMessageType(
 }
 import { appendEventToStream } from "../signals/event-stream.js";
 import { getLogger } from "../util/logger.js";
-import type { AssistantEvent } from "./assistant-event.js";
+import type { AssistantEventEnvelope } from "./assistant-event.js";
 import { buildAssistantEvent } from "./assistant-event.js";
 import { stampAndBuffer } from "./assistant-stream-state.js";
 
@@ -57,7 +57,7 @@ export type AssistantEventFilter = {
 };
 
 export type AssistantEventCallback = (
-  event: AssistantEvent,
+  event: AssistantEventEnvelope,
 ) => void | Promise<void>;
 
 /** Opaque handle returned by `subscribe`. Call `dispose()` to remove the subscription. */
@@ -138,7 +138,7 @@ type SubscriberInput = DistributiveOmit<
 // ── Hub ───────────────────────────────────────────────────────────────────────
 
 /**
- * Lightweight pub/sub hub for `AssistantEvent` messages.
+ * Lightweight pub/sub hub for `AssistantEventEnvelope` messages.
  *
  * Filtering is applied at subscription level:
  *   - `conversationId`: scoped events match subscribers with same conversationId
@@ -301,7 +301,7 @@ export class AssistantEventHub {
    * delivery to remaining subscribers.
    */
   async publish(
-    event: AssistantEvent,
+    event: AssistantEventEnvelope,
     options?: {
       targetCapability?: HostProxyCapability;
       targetClientId?: string;
@@ -430,7 +430,7 @@ export class AssistantEventHub {
    * event based on the same conversation matching rules as publish().
    */
   hasSubscribersForEvent(
-    event: Pick<AssistantEvent, "conversationId">,
+    event: Pick<AssistantEventEnvelope, "conversationId">,
   ): boolean {
     for (const entry of this.subscribers) {
       if (!entry.active) continue;
@@ -563,7 +563,7 @@ export class AssistantEventHub {
  */
 export const assistantEventHub = new AssistantEventHub({ maxSubscribers: 100 });
 
-// ── Convenience: ServerMessage → AssistantEvent publish ───────────────────────
+// ── Convenience: ServerMessage → AssistantEventEnvelope publish ───────────────────────
 
 /**
  * Promise chain that serializes publishes so subscribers always observe
@@ -572,7 +572,7 @@ export const assistantEventHub = new AssistantEventHub({ maxSubscribers: 100 });
 let _hubChain = Promise.resolve();
 
 /**
- * Wraps a `ServerMessage` in an `AssistantEvent` envelope and publishes it
+ * Wraps a `ServerMessage` in an `AssistantEventEnvelope` envelope and publishes it
  * to the process-level hub.
  *
  * When `conversationId` is omitted, it is auto-extracted from the message

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -13,7 +13,7 @@
  */
 
 import type { HostProxyCapability, InterfaceId } from "../channels/types.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 
 // ---------------------------------------------------------------------------
 // Message type → capability inference
@@ -332,7 +332,7 @@ export class AssistantEventHub {
     const errors: unknown[] = [];
 
     for (const entry of snapshot) {
-      if (!entry.active) continue;
+      if (!entry.active) {continue;}
 
       // Self-echo suppression: the originating client never receives the
       // event back. Checked before every other rule so it composes with
@@ -350,18 +350,18 @@ export class AssistantEventHub {
       // `targetCapability` below.
       if (targetInterfaceId != null) {
         if (entry.type !== "client" || entry.interfaceId !== targetInterfaceId)
-          continue;
+          {continue;}
       }
 
       if (targetClientId != null) {
         // Targeted: bypass conversation filter, deliver only to the named client.
         if (entry.type !== "client" || entry.clientId !== targetClientId)
-          continue;
+          {continue;}
         if (
           targetCapability != null &&
           !entry.capabilities.includes(targetCapability)
         )
-          continue;
+          {continue;}
       } else {
         // Untargeted: existing conversation-scoped + capability logic.
         if (
@@ -369,7 +369,7 @@ export class AssistantEventHub {
           entry.filter.conversationId != null &&
           entry.filter.conversationId !== event.conversationId
         )
-          continue;
+          {continue;}
 
         // Capability targeting: targeted events only go to subscribers that
         // declare the required capability.
@@ -378,7 +378,7 @@ export class AssistantEventHub {
             entry.type !== "client" ||
             !entry.capabilities.includes(targetCapability)
           )
-            continue;
+            {continue;}
         }
       }
 
@@ -408,7 +408,7 @@ export class AssistantEventHub {
         entry.type === "client" &&
         entry.clientId === clientId
       )
-        return entry;
+        {return entry;}
     }
     return undefined;
   }
@@ -433,7 +433,7 @@ export class AssistantEventHub {
     event: Pick<AssistantEventEnvelope, "conversationId">,
   ): boolean {
     for (const entry of this.subscribers) {
-      if (!entry.active) continue;
+      if (!entry.active) {continue;}
       if (
         event.conversationId != null &&
         entry.filter.conversationId != null &&
@@ -563,7 +563,7 @@ export class AssistantEventHub {
  */
 export const assistantEventHub = new AssistantEventHub({ maxSubscribers: 100 });
 
-// ── Convenience: ServerMessage → AssistantEventEnvelope publish ───────────────────────
+// ── Convenience: AssistantEvent → AssistantEventEnvelope publish ───────────────────────
 
 /**
  * Promise chain that serializes publishes so subscribers always observe
@@ -572,7 +572,7 @@ export const assistantEventHub = new AssistantEventHub({ maxSubscribers: 100 });
 let _hubChain = Promise.resolve();
 
 /**
- * Wraps a `ServerMessage` in an `AssistantEventEnvelope` envelope and publishes it
+ * Wraps a `AssistantEvent` in an `AssistantEventEnvelope` envelope and publishes it
  * to the process-level hub.
  *
  * When `conversationId` is omitted, it is auto-extracted from the message
@@ -588,7 +588,7 @@ let _hubChain = Promise.resolve();
  * services should call this directly instead of threading a broadcast callback.
  */
 export function broadcastMessage(
-  msg: ServerMessage,
+  msg: AssistantEvent,
   conversationId?: string,
   options?: { targetClientId?: string; targetInterfaceId?: InterfaceId },
 ): void {
@@ -666,7 +666,7 @@ export function broadcastMessage(
     });
 }
 
-function extractConversationId(msg: ServerMessage): string | undefined {
+function extractConversationId(msg: AssistantEvent): string | undefined {
   const record = msg as unknown as Record<string, unknown>;
   if ("conversationId" in msg && typeof record.conversationId === "string") {
     return record.conversationId as string;

--- a/assistant/src/runtime/assistant-event.ts
+++ b/assistant/src/runtime/assistant-event.ts
@@ -97,17 +97,18 @@ export function formatSseHeartbeat(): string {
 
 // -- Daemon-side specialization ------------------------------------------------
 
-/**
- * Daemon-side event envelope: the canonical `AssistantEventEnvelope` wrapping
- * an `AssistantEvent` message payload.
- */
-export type AssistantEvent = AssistantEventEnvelope;
+// Re-export the canonical envelope so daemon callers import it alongside the
+// builder below.
+export type { AssistantEventEnvelope };
 
-/** Build a daemon event envelope around an `AssistantEvent` message payload. */
+/**
+ * Build a daemon event envelope (`AssistantEventEnvelope`) around an
+ * `AssistantEvent` message payload.
+ */
 export function buildAssistantEvent(
   message: AssistantEventMessage,
   conversationId?: string,
-): AssistantEvent {
+): AssistantEventEnvelope {
   return baseBuildAssistantEvent<AssistantEventMessage>(
     message,
     conversationId,

--- a/assistant/src/runtime/assistant-stream-state.ts
+++ b/assistant/src/runtime/assistant-stream-state.ts
@@ -69,7 +69,7 @@ import {
 } from "../api/constants/sse-replay.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
-import type { AssistantEvent } from "./assistant-event.js";
+import type { AssistantEventEnvelope } from "./assistant-event.js";
 
 const log = getLogger("assistant-stream-state");
 
@@ -122,7 +122,7 @@ export interface ReplaySubscriber {
 
 interface RingEntry {
   seq: number;
-  event: AssistantEvent;
+  event: AssistantEventEnvelope;
   emittedAt: number;
   sizeBytes: number;
   targeting?: EventTargeting;
@@ -214,7 +214,7 @@ export function isStreamSeqStampingDisabled(): boolean {
  * Mutates `event.seq` in place.
  */
 export function stampAndBuffer(
-  event: AssistantEvent,
+  event: AssistantEventEnvelope,
   options?: { targeting?: EventTargeting },
 ): void {
   if (stampingDisabled) {
@@ -289,7 +289,7 @@ export function getReplayWindow(
   lastSeenSeq: number,
   subscriber?: ReplaySubscriber,
   conversationId?: string,
-): readonly AssistantEvent[] | null {
+): readonly AssistantEventEnvelope[] | null {
   evict();
 
   if (state.ring.length === 0) {

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -12,7 +12,7 @@ import { isConversationBusyError } from "../daemon/conversation-messaging.js";
 import { findConversation } from "../daemon/conversation-registry.js";
 import { getDiskPressureStatus } from "../daemon/disk-pressure-guard.js";
 import { classifyDiskPressureTurnPolicy } from "../daemon/disk-pressure-policy.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import { updateDeliveredSegmentCount } from "../persistence/delivery-channels.js";
 import {
@@ -368,7 +368,7 @@ export async function sweepFailedEvents(
         ? payload.slackStreamMessageTs
         : undefined;
     let replyMessageId: string | undefined;
-    const observeAgentEvent = (msg: ServerMessage): void => {
+    const observeAgentEvent = (msg: AssistantEvent): void => {
       if (
         msg.type === "message_complete" &&
         (msg.source === undefined || msg.source === "main") &&

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -16,7 +16,7 @@ import type {
 // Re-export so route modules (background-dispatch, etc.) can pull the type
 // from the runtime barrel without reaching into daemon internals.
 export type { SlackInboundMessageMetadata };
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { AssistantEventHub } from "./assistant-event-hub.js";
 
 export type {
@@ -84,7 +84,7 @@ export interface RuntimeMessageConversationOptions {
    */
   displayContent?: string;
   /** Optional callback to receive real-time agent loop events (text deltas, tool starts, etc.). */
-  onEvent?: (msg: ServerMessage) => void;
+  onEvent?: (msg: AssistantEvent) => void;
   /**
    * Optional LLM call-site identifier. Channel ingress and other inbound paths
    * may pass this so the daemon's per-call provider config picks up the right

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -19,7 +19,7 @@ import {
 } from "../../acp/session-manager.js";
 import type { AcpSessionState } from "../../acp/types.js";
 import { getConfig } from "../../config/loader.js";
-import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import { createGuardianRequestForConfirmation } from "../../permissions/confirmation-guardian-request.js";
 import type { UserDecision } from "../../permissions/types.js";
 import { getDb } from "../../persistence/db-connection.js";
@@ -159,7 +159,7 @@ function awaitRouteApproval(args: {
         settle(decision, decision === "allow" ? "approved" : "rejected"),
     });
 
-    const confirmationMsg: ServerMessage & {
+    const confirmationMsg: AssistantEvent & {
       type: "confirmation_request";
     } = {
       type: "confirmation_request",

--- a/assistant/src/runtime/routes/canned-message-complete.ts
+++ b/assistant/src/runtime/routes/canned-message-complete.ts
@@ -1,5 +1,5 @@
 import { createAssistantMessage } from "../../agent/message-types.js";
-import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import {
   addMessage,
   recordConversationPersistedSeq,
@@ -28,7 +28,7 @@ import { publishConversationMessagesChanged } from "../sync/resource-sync-events
 // `state.assistantTurnId` directly, grep for `emitCannedMessageComplete` to
 // find every call site and inline-then-delete.
 export function emitCannedMessageComplete(
-  send: (msg: ServerMessage) => void,
+  send: (msg: AssistantEvent) => void,
   conversationId: string,
   persistedAssistantId: string,
 ): void {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -81,7 +81,7 @@ import {
   shouldAttachHostProxyForCapability,
 } from "../../daemon/host-proxy-preactivation.js";
 import { getAssistantName } from "../../daemon/identity-helpers.js";
-import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import type {
   HostProxyTransportMetadata,
   NonHostProxyTransportMetadata,
@@ -494,7 +494,7 @@ async function tryConsumeGuardianReply(params: {
     filePath?: string;
   }>;
   conversation: Conversation;
-  onEvent: (msg: ServerMessage) => void;
+  onEvent: (msg: AssistantEvent) => void;
   approvalConversationGenerator?: ApprovalConversationGenerator;
   /** Verified actor identity from actor-token middleware. */
   verifiedActorExternalUserId?: string;

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -18,7 +18,7 @@ import {
   guardianForChannel,
 } from "../../../contacts/guardian-delivery-reader.js";
 import { isConversationBusyError } from "../../../daemon/conversation-messaging.js";
-import type { ServerMessage } from "../../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../../daemon/message-protocol.js";
 import type { TrustContext } from "../../../daemon/trust-context-types.js";
 import {
   getSiblingStreamedReplyTs,
@@ -238,7 +238,7 @@ export function processChannelMessageInBackground(
         // the redelivery path can reuse to edit the reply in place.
         onStreamOpen: (streamTs) => storeStreamedReplyTs(eventId, streamTs),
       });
-      const observeAgentEvent = (msg: ServerMessage): void => {
+      const observeAgentEvent = (msg: AssistantEvent): void => {
         if (
           msg.type === "message_complete" &&
           (msg.source === undefined || msg.source === "main") &&
@@ -447,7 +447,7 @@ function startTelegramTypingHeartbeat(
 // ---------------------------------------------------------------------------
 
 type SlackThinkingStatusController = {
-  observeEvent: (msg: ServerMessage) => void;
+  observeEvent: (msg: AssistantEvent) => void;
   stop: () => void;
 };
 
@@ -533,7 +533,7 @@ function createSlackThinkingStatusController(params: {
     slackThinkingStatus?.updateLoadingMessages(currentLoadingMessages);
   };
 
-  const observeTaskProgress = (msg: ServerMessage): void => {
+  const observeTaskProgress = (msg: AssistantEvent): void => {
     if (msg.type === "ui_surface_show") {
       const progress = getTaskProgressDataFromSurfaceData(msg.data);
       if (!progress) {

--- a/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { Conversation } from "../../../../daemon/conversation.js";
-import type { ServerMessage } from "../../../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../../../daemon/message-protocol.js";
 
 let _mockConversation: MockConversation | undefined;
 
@@ -18,8 +18,8 @@ mock.module("../../../../context/token-estimator.js", () => ({
 
 mock.module("../helpers.js", () => ({
   getConversationById: async (id: string) => {
-    if (!_mockConversation) return undefined;
-    if (_mockConversation.conversationId !== id) return undefined;
+    if (!_mockConversation) {return undefined;}
+    if (_mockConversation.conversationId !== id) {return undefined;}
     return _mockConversation as unknown as Conversation;
   },
   listConversationsByTitlePrefix: () => [],
@@ -41,13 +41,13 @@ interface MockConversation {
   agentLoop: { compactionCircuit: MockCompactionCircuit };
   contextCompactedMessageCount: number;
   contextCompactedAt: number | null;
-  sentMessages: ServerMessage[];
-  sendToClient: (msg: ServerMessage) => void;
+  sentMessages: AssistantEvent[];
+  sendToClient: (msg: AssistantEvent) => void;
   getMessages: () => unknown[];
 }
 
 function makeConversation(id = "conv-playground-test"): MockConversation {
-  const sentMessages: ServerMessage[] = [];
+  const sentMessages: AssistantEvent[] = [];
   return {
     conversationId: id,
     agentLoop: {
@@ -68,7 +68,7 @@ function findRoute() {
   const route = ROUTES.find(
     (r) => r.operationId === "playgroundInjectCompactionFailures",
   );
-  if (!route) throw new Error("inject-failures route not registered");
+  if (!route) {throw new Error("inject-failures route not registered");}
   return route;
 }
 

--- a/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
@@ -20,7 +20,7 @@ mock.module("../helpers.js", () => ({
 }));
 
 import type { Conversation } from "../../../../daemon/conversation.js";
-import type { ServerMessage } from "../../../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../../../daemon/message-protocol.js";
 import { RouteError } from "../../errors.js";
 import { ROUTES } from "../index.js";
 
@@ -33,7 +33,7 @@ interface FakeConversationState {
 
 interface FakeConversation {
   conversation: Conversation;
-  sent: ServerMessage[];
+  sent: AssistantEvent[];
   state: FakeConversationState;
 }
 
@@ -47,7 +47,7 @@ function makeFakeConversation(
     contextCompactedAt: null,
     ...overrides,
   };
-  const sent: ServerMessage[] = [];
+  const sent: AssistantEvent[] = [];
   const compactionCircuit = {
     get consecutiveCompactionFailures(): number {
       return state.consecutiveCompactionFailures;
@@ -72,7 +72,7 @@ function makeFakeConversation(
       return state.contextCompactedAt;
     },
     getMessages: () => [],
-    sendToClient: (msg: ServerMessage) => {
+    sendToClient: (msg: AssistantEvent) => {
       sent.push(msg);
     },
   } as unknown as Conversation;
@@ -84,7 +84,7 @@ function findRoute() {
   const route = ROUTES.find(
     (r) => r.operationId === "playgroundResetCompactionCircuit",
   );
-  if (!route) throw new Error("reset-circuit route not registered");
+  if (!route) {throw new Error("reset-circuit route not registered");}
   return route;
 }
 

--- a/assistant/src/runtime/routes/workspace-routes.test.ts
+++ b/assistant/src/runtime/routes/workspace-routes.test.ts
@@ -18,7 +18,7 @@ import { join } from "node:path";
 import { beforeAll, describe, expect, test } from "bun:test";
 
 import { SYNC_TAGS } from "../../daemon/message-types/sync.js";
-import type { AssistantEvent } from "../assistant-event.js";
+import type { AssistantEventEnvelope } from "../assistant-event.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
 
 // ---------------------------------------------------------------------------
@@ -557,7 +557,7 @@ describe("POST /v1/workspace/write", () => {
   });
 
   test("publishes sounds sync events when writing sounds config", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {

--- a/assistant/src/runtime/slack-reply-session.test.ts
+++ b/assistant/src/runtime/slack-reply-session.test.ts
@@ -28,7 +28,7 @@ mock.module("./gateway-client.js", () => ({
   },
 }));
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { SLACK_STREAM_MARKDOWN_LIMIT } from "../messaging/providers/slack/api.js";
 import {
   createSlackReplySession,
@@ -39,34 +39,34 @@ const CHANNEL = "D-STREAM";
 const THREAD_TS = "1700000000.000001";
 const CALLBACK_URL = `https://example.test/deliver/slack?channel=${CHANNEL}&threadTs=${THREAD_TS}`;
 
-const textDelta = (text: string): ServerMessage =>
+const textDelta = (text: string): AssistantEvent =>
   ({
     type: "assistant_text_delta",
     text,
     conversationId: "conv-stream",
-  }) as ServerMessage;
+  }) as AssistantEvent;
 
-const toolUseStart = (toolUseId: string): ServerMessage =>
+const toolUseStart = (toolUseId: string): AssistantEvent =>
   ({
     type: "tool_use_start",
     toolName: "web_search",
     input: { query: "example" },
     conversationId: "conv-stream",
     toolUseId,
-  }) as ServerMessage;
+  }) as AssistantEvent;
 
-const messageComplete = (messageId: string): ServerMessage =>
+const messageComplete = (messageId: string): AssistantEvent =>
   ({
     type: "message_complete",
     conversationId: "conv-stream",
     messageId,
-  }) as ServerMessage;
+  }) as AssistantEvent;
 
 const taskProgressShow = (
   surfaceId: string,
   steps: Array<{ label: string; status: string; detail?: string }>,
   templateTitle?: string,
-): ServerMessage =>
+): AssistantEvent =>
   ({
     type: "ui_surface_show",
     conversationId: "conv-stream",
@@ -80,18 +80,18 @@ const taskProgressShow = (
         steps,
       },
     },
-  }) as ServerMessage;
+  }) as AssistantEvent;
 
 const taskProgressUpdate = (
   surfaceId: string,
   steps: Array<{ label: string; status: string }>,
-): ServerMessage =>
+): AssistantEvent =>
   ({
     type: "ui_surface_update",
     conversationId: "conv-stream",
     surfaceId,
     data: { templateData: { steps } },
-  }) as ServerMessage;
+  }) as AssistantEvent;
 
 const tick = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
@@ -351,7 +351,7 @@ describe("createSlackReplySession", () => {
   test("falls back when stopStream throws after streaming text", async () => {
     deliverImpl = async (_url, payload) => {
       const op = payload.slackStream as { action: string };
-      if (op.action === "stop") throw new Error("stop failed");
+      if (op.action === "stop") {throw new Error("stop failed");}
       return { ok: true, ts: "stream-ts-1" };
     };
     const session = createSlackReplySession({

--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -9,7 +9,7 @@ import {
   incompleteVellumLinkSuffixLength,
   stripVellumLinks,
 } from "../daemon/assistant-attachments.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { SLACK_STREAM_MARKDOWN_LIMIT } from "../messaging/providers/slack/api.js";
 import { renderSlackBlocks } from "../messaging/providers/slack/render.js";
 import { getLogger } from "../util/logger.js";
@@ -51,7 +51,7 @@ export type SlackStreamReconciliation =
   | { mode: "fallback" };
 
 export type SlackReplySession = {
-  observeEvent: (msg: ServerMessage) => void;
+  observeEvent: (msg: AssistantEvent) => void;
   /**
    * Settle in-flight stream operations, finalize the stream, and report how
    * durable delivery should reconcile. Call once after processing completes.
@@ -79,12 +79,12 @@ export function shouldStreamSlackReply(params: {
   recipientUserId?: string;
   recipientTeamId?: string;
 }): boolean {
-  if (params.sourceChannel !== "slack") return false;
-  if (!isSlackDeliveryCallbackUrl(params.replyCallbackUrl)) return false;
+  if (params.sourceChannel !== "slack") {return false;}
+  if (!isSlackDeliveryCallbackUrl(params.replyCallbackUrl)) {return false;}
   if (extractThreadTsFromCallbackUrl(params.replyCallbackUrl) === null) {
     return false;
   }
-  if (params.chatType === "im") return true;
+  if (params.chatType === "im") {return true;}
   return Boolean(params.recipientUserId && params.recipientTeamId);
 }
 
@@ -130,7 +130,7 @@ export function createSlackReplySession(params: {
   const coalesceMs = params.coalesceMs ?? STREAM_COALESCE_MS;
   const replyCallbackUrl = params.replyCallbackUrl;
   const threadTs = extractThreadTsFromCallbackUrl(replyCallbackUrl);
-  if (threadTs === null) return undefined;
+  if (threadTs === null) {return undefined;}
 
   let state: StreamState = "idle";
   let started = false;
@@ -172,7 +172,7 @@ export function createSlackReplySession(params: {
   // (and `stripVellumLinks` can remove it). Once `finished`, no delta can
   // extend the text, so the full cleaned reply is safe to emit.
   const streamableText = (): string => {
-    if (finished) return cleanedText();
+    if (finished) {return cleanedText();}
     const hold = incompleteVellumLinkSuffixLength(rawText);
     const stable = hold > 0 ? rawText.slice(0, rawText.length - hold) : rawText;
     return stripVellumLinks(stable).replace(NO_RESPONSE_INLINE_RE, "");
@@ -205,7 +205,7 @@ export function createSlackReplySession(params: {
   const enqueueStart = (): void => {
     enqueue(async () => {
       const clean = streamableText();
-      if (clean.trim().length === 0) return;
+      if (clean.trim().length === 0) {return;}
       const firstChunk = clean.slice(0, SLACK_STREAM_MARKDOWN_LIMIT);
       const title = activeProgress?.title;
       const tasks = planTasks();
@@ -259,7 +259,7 @@ export function createSlackReplySession(params: {
 
   const enqueueAppend = (): void => {
     enqueue(async () => {
-      if (state !== "streaming" || !streamTs) return;
+      if (state !== "streaming" || !streamTs) {return;}
       const clean = streamableText();
       const title = activeProgress?.title;
       const tasks = planTasks();
@@ -329,9 +329,9 @@ export function createSlackReplySession(params: {
       clearTimeout(coalesceTimer);
       coalesceTimer = undefined;
     }
-    if (finished || state === "fallback") return;
+    if (finished || state === "fallback") {return;}
     if (!started) {
-      if (!hasDeliverableAssistantText(streamableText())) return;
+      if (!hasDeliverableAssistantText(streamableText())) {return;}
       started = true;
       enqueueStart();
       return;
@@ -340,7 +340,7 @@ export function createSlackReplySession(params: {
   };
 
   const scheduleFlush = (): void => {
-    if (coalesceTimer || finished) return;
+    if (coalesceTimer || finished) {return;}
     coalesceTimer = setTimeout(() => {
       coalesceTimer = undefined;
       flush();
@@ -356,15 +356,15 @@ export function createSlackReplySession(params: {
     }
   };
 
-  const observeTaskProgress = (msg: ServerMessage): void => {
+  const observeTaskProgress = (msg: AssistantEvent): void => {
     if (msg.type === "ui_surface_show") {
       const progress = getTaskProgressDataFromSurfaceData(msg.data);
-      if (!progress) return;
+      if (!progress) {return;}
       taskProgressBySurfaceId.set(msg.surfaceId, progress);
     } else if (msg.type === "ui_surface_update") {
       const existing = taskProgressBySurfaceId.get(msg.surfaceId);
       const progress = mergeTaskProgressData(existing, msg.data);
-      if (!progress) return;
+      if (!progress) {return;}
       taskProgressBySurfaceId.set(msg.surfaceId, progress);
     } else {
       return;
@@ -375,7 +375,7 @@ export function createSlackReplySession(params: {
 
   return {
     observeEvent(msg) {
-      if (finished) return;
+      if (finished) {return;}
 
       if (msg.type === "ui_surface_show" || msg.type === "ui_surface_update") {
         observeTaskProgress(msg);
@@ -415,7 +415,7 @@ export function createSlackReplySession(params: {
 
       enqueueAppend();
       enqueue(async () => {
-        if (state !== "streaming" || !streamTs) return;
+        if (state !== "streaming" || !streamTs) {return;}
         const clean = cleanedText();
         const remaining = clean.slice(confirmedLength);
         const blocks = imageBlocks(clean);

--- a/assistant/src/runtime/sync/sync-publisher.test.ts
+++ b/assistant/src/runtime/sync/sync-publisher.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { SYNC_TAGS } from "../../daemon/message-types/sync.js";
-import type { AssistantEvent } from "../assistant-event.js";
+import type { AssistantEventEnvelope } from "../assistant-event.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
 import { publishSyncInvalidation } from "./sync-publisher.js";
 
@@ -18,7 +18,7 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 
 describe("sync publisher", () => {
   test("publishes a deduped sync_changed event", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {
@@ -104,7 +104,7 @@ describe("sync publisher", () => {
   });
 
   test("forwards originClientId when provided", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {
@@ -132,7 +132,7 @@ describe("sync publisher", () => {
   });
 
   test("omits originClientId when not provided", async () => {
-    const received: AssistantEvent[] = [];
+    const received: AssistantEventEnvelope[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
       callback: (event) => {
@@ -141,7 +141,9 @@ describe("sync publisher", () => {
     });
 
     try {
-      const message = await publishSyncInvalidation([SYNC_TAGS.assistantAvatar]);
+      const message = await publishSyncInvalidation([
+        SYNC_TAGS.assistantAvatar,
+      ]);
 
       await waitFor(() => received.length === 1);
 

--- a/assistant/src/signals/emit-event.ts
+++ b/assistant/src/signals/emit-event.ts
@@ -1,7 +1,7 @@
 /**
  * Handle generic event signals from the CLI.
  *
- * When the CLI writes a JSON-encoded {@link ServerMessage} to
+ * When the CLI writes a JSON-encoded {@link AssistantEvent} to
  * `signals/emit-event`, the daemon's ConfigWatcher detects the file
  * change and invokes {@link handleEmitEventSignal}, which reads the
  * payload and publishes it to connected clients via the in-process
@@ -15,7 +15,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
@@ -26,7 +26,7 @@ const log = getLogger("signal:emit-event");
 export function handleEmitEventSignal(): void {
   try {
     const content = readFileSync(join(getSignalsDir(), "emit-event"), "utf-8");
-    const message = JSON.parse(content) as ServerMessage;
+    const message = JSON.parse(content) as AssistantEvent;
 
     assistantEventHub
       .publish(buildAssistantEvent(message))

--- a/assistant/src/signals/event-stream.ts
+++ b/assistant/src/signals/event-stream.ts
@@ -25,7 +25,7 @@ import {
 import { join } from "node:path";
 
 import { getIsContainerized } from "../config/env-registry.js";
-import type { AssistantEvent } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { getSignalsDir } from "../util/platform.js";
 
 // ── Write side (daemon) ──────────────────────────────────────────────
@@ -85,7 +85,7 @@ let sequence = 0;
  */
 export function appendEventToStream(
   conversationId: string,
-  event: AssistantEvent,
+  event: AssistantEventEnvelope,
 ): void {
   if (getIsContainerized()) return;
 
@@ -120,7 +120,7 @@ export interface EventStreamWatcher {
 
 /**
  * Register as a subscriber for a conversation's event stream and
- * invoke `callback` for each new {@link AssistantEvent} written.
+ * invoke `callback` for each new {@link AssistantEventEnvelope} written.
  *
  * Creates a subscriber directory at
  * `signals/events/<conversationId>.<pid>/`. The daemon writes each
@@ -131,7 +131,7 @@ export interface EventStreamWatcher {
  */
 export function watchEventStream(
   conversationId: string,
-  callback: (event: AssistantEvent) => void,
+  callback: (event: AssistantEventEnvelope) => void,
 ): EventStreamWatcher {
   if (getIsContainerized()) {
     return { dispose() {} };
@@ -160,7 +160,7 @@ export function watchEventStream(
       processedFiles.add(file);
       try {
         const data = readFileSync(join(subDir, file), "utf-8");
-        const event = JSON.parse(data) as AssistantEvent;
+        const event = JSON.parse(data) as AssistantEventEnvelope;
         callback(event);
       } catch {
         // Skip unreadable or malformed event files.

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -18,7 +18,7 @@ import {
   removeSubagentConversation,
   setSubagentConversation,
 } from "../daemon/conversation-registry.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../persistence/conversation-bootstrap.js";
 import {
   deleteSubagentRecord,
@@ -95,7 +95,7 @@ function extractFinalAssistantText(messages: Message[]): string {
  * other event type. Used by the synchronous `onText` tap to forward
  * `assistant_text_delta` / `assistant_thinking_delta` chunks to the caller.
  */
-function extractDeltaText(msg: ServerMessage): string | null {
+function extractDeltaText(msg: AssistantEvent): string | null {
   if (msg.type === "assistant_text_delta") {
     return msg.text;
   }
@@ -220,7 +220,7 @@ interface ManagedSubagent {
   conversation: Conversation | null;
   state: SubagentState;
   /** Mutable reference to the parent's current sendToClient. Updated on reconnect. */
-  parentSendToClient: (msg: ServerMessage) => void;
+  parentSendToClient: (msg: AssistantEvent) => void;
   /** Epoch ms after which this terminal entry can be removed by the TTL sweep. */
   retainedUntil?: number;
   /**
@@ -308,7 +308,7 @@ export class SubagentManager {
    */
   async spawn(
     config: Omit<SubagentConfig, "id">,
-    parentSendToClient: (msg: ServerMessage) => void,
+    parentSendToClient: (msg: AssistantEvent) => void,
   ): Promise<string> {
     const { subagentId } = await this.setUpSubagent(config, parentSendToClient);
 
@@ -331,7 +331,7 @@ export class SubagentManager {
    */
   private async setUpSubagent(
     config: Omit<SubagentConfig, "id">,
-    parentSendToClient: (msg: ServerMessage) => void,
+    parentSendToClient: (msg: AssistantEvent) => void,
     opts?: { synchronous?: boolean; onText?: (chunk: string) => void },
   ): Promise<{ subagentId: string; managed: ManagedSubagent }> {
     // ── Limit checks ────────────────────────────────────────────────
@@ -478,7 +478,7 @@ export class SubagentManager {
 
     // Wrap sendToClient to envelope all events with the subagent ID.
     // Reads from managed.parentSendToClient so reconnects are picked up.
-    const wrappedSendToClient = (msg: ServerMessage): void => {
+    const wrappedSendToClient = (msg: AssistantEvent): void => {
       // Tap streaming text/thinking deltas for the synchronous caller (if any),
       // in addition to the normal envelope below. Reads from managed.onText so
       // the synchronous path can forward chunks without altering event routing.
@@ -493,7 +493,7 @@ export class SubagentManager {
         subagentId,
         conversationId: config.parentConversationId,
         event: msg,
-      } as ServerMessage);
+      } as AssistantEvent);
     };
 
     const conversation = new Conversation(
@@ -621,7 +621,7 @@ export class SubagentManager {
       objective: config.objective,
       isFork: config.fork ?? false,
       parentToolUseId: config.parentToolUseId,
-    } as ServerMessage);
+    } as AssistantEvent);
 
     log.info(
       {
@@ -649,7 +649,7 @@ export class SubagentManager {
    */
   async spawnAndAwait(
     config: Omit<SubagentConfig, "id">,
-    parentSendToClient: (msg: ServerMessage) => void,
+    parentSendToClient: (msg: AssistantEvent) => void,
     opts?: { signal?: AbortSignal; onText?: (chunk: string) => void },
   ): Promise<string> {
     const { subagentId, managed } = await this.setUpSubagent(
@@ -878,7 +878,7 @@ export class SubagentManager {
 
   abort(
     subagentId: string,
-    parentSendToClient?: (msg: ServerMessage) => void,
+    parentSendToClient?: (msg: AssistantEvent) => void,
     callerConversationId?: string,
     options?: { suppressNotification?: boolean },
   ): boolean {
@@ -965,7 +965,7 @@ export class SubagentManager {
    */
   abortAllForParent(
     parentConversationId: string,
-    parentSendToClient?: (msg: ServerMessage) => void,
+    parentSendToClient?: (msg: AssistantEvent) => void,
   ): number {
     const children = this.parentToChildren.get(parentConversationId);
     if (!children) {
@@ -1081,7 +1081,7 @@ export class SubagentManager {
    */
   updateParentSender(
     parentConversationId: string,
-    newSendToClient: (msg: ServerMessage) => void,
+    newSendToClient: (msg: AssistantEvent) => void,
   ): void {
     const children = this.parentToChildren.get(parentConversationId);
     if (!children) {
@@ -1104,7 +1104,7 @@ export class SubagentManager {
         status: managed.state.status,
         error: managed.state.error,
         usage: managed.state.usage,
-      } as ServerMessage);
+      } as AssistantEvent);
     }
   }
 
@@ -1383,7 +1383,7 @@ export class SubagentManager {
   private setStatus(
     subagentId: string,
     status: SubagentStatus,
-    parentSendToClient: (msg: ServerMessage) => void,
+    parentSendToClient: (msg: AssistantEvent) => void,
     error?: string,
   ): void {
     const managed = this.subagents.get(subagentId);
@@ -1410,7 +1410,7 @@ export class SubagentManager {
       status,
       error,
       usage: managed.state.usage,
-    } as ServerMessage);
+    } as AssistantEvent);
 
     // Mirror the transition to the durable record.
     this.persistState(managed.state);

--- a/assistant/src/tools/acp/context.ts
+++ b/assistant/src/tools/acp/context.ts
@@ -2,19 +2,19 @@
  * Shared ToolContext accessors for the ACP tools.
  */
 
-import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import type { ToolContext } from "../types.js";
 
 /**
- * Narrows `ToolContext.sendToClient` to the `ServerMessage` sender the ACP
+ * Narrows `ToolContext.sendToClient` to the `AssistantEvent` sender the ACP
  * session manager expects. ToolContext types the callback against an
  * index-signature message shape (`{ type: string; [key: string]: unknown }`)
- * that ServerMessage's union members don't structurally satisfy, so the
+ * that AssistantEvent's union members don't structurally satisfy, so the
  * cast lives here once instead of being duplicated at every ACP tool call
  * site.
  */
 export function getSendToClient(
   context: ToolContext,
-): ((msg: ServerMessage) => void) | undefined {
-  return context.sendToClient as ((msg: ServerMessage) => void) | undefined;
+): ((msg: AssistantEvent) => void) | undefined {
+  return context.sendToClient as ((msg: AssistantEvent) => void) | undefined;
 }

--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -1,11 +1,11 @@
-import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import { browserManager } from "./browser-manager.js";
 
 // Track which conversations have an active browser page.
 const activeBrowserConversations = new Set<string>();
 
 // Registry of sendToClient callbacks per conversation
-const conversationSenders = new Map<string, (msg: ServerMessage) => void>();
+const conversationSenders = new Map<string, (msg: AssistantEvent) => void>();
 
 /**
  * Register a sendToClient callback for a conversation.
@@ -13,7 +13,7 @@ const conversationSenders = new Map<string, (msg: ServerMessage) => void>();
  */
 export function registerConversationSender(
   conversationId: string,
-  sendToClient: (msg: ServerMessage) => void,
+  sendToClient: (msg: AssistantEvent) => void,
 ): void {
   conversationSenders.set(conversationId, sendToClient);
 }
@@ -27,12 +27,12 @@ export function unregisterConversationSender(conversationId: string): void {
 
 function getSender(
   conversationId: string,
-): ((msg: ServerMessage) => void) | undefined {
+): ((msg: AssistantEvent) => void) | undefined {
   return conversationSenders.get(conversationId);
 }
 
 export async function ensureScreencast(conversationId: string): Promise<void> {
-  if (activeBrowserConversations.has(conversationId)) return;
+  if (activeBrowserConversations.has(conversationId)) {return;}
 
   activeBrowserConversations.add(conversationId);
 
@@ -49,7 +49,7 @@ export async function ensureScreencast(conversationId: string): Promise<void> {
 export async function stopBrowserScreencast(
   conversationId: string,
 ): Promise<void> {
-  if (!activeBrowserConversations.has(conversationId)) return;
+  if (!activeBrowserConversations.has(conversationId)) {return;}
 
   // Safe no-op if CDP screencast was never started
   await browserManager.stopScreencast(conversationId);

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -2,7 +2,7 @@ import { validateInferenceProfileKey } from "../../config/inference-profile-vali
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
 import { getConfig } from "../../config/loader.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
-import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import {
   getConversationOverrideProfile,
   getMessages,
@@ -105,7 +105,7 @@ export async function executeSubagentSpawn(
       context,
       label,
       objective,
-      sendToClient: sendToClient as (msg: ServerMessage) => void,
+      sendToClient: sendToClient as (msg: AssistantEvent) => void,
       requestedOverrideProfile,
     });
   }
@@ -238,7 +238,7 @@ async function runAdvisorConsult(args: {
   label: string;
   /** The agent's own `objective` — its framing of what it wants advised on. */
   objective: string;
-  sendToClient: (msg: ServerMessage) => void;
+  sendToClient: (msg: AssistantEvent) => void;
   requestedOverrideProfile: string | undefined;
 }): Promise<ToolExecutionResult> {
   const { context, label, objective, sendToClient, requestedOverrideProfile } =

--- a/assistant/src/workflows/leaf-runner.ts
+++ b/assistant/src/workflows/leaf-runner.ts
@@ -44,7 +44,7 @@ import { z } from "zod";
 import { type AgentEvent, AgentLoop } from "../agent/loop.js";
 import { getEffectiveProfile } from "../config/default-profile-catalog.js";
 import { getConfig } from "../config/loader.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { isPersonalMemoryAllowed } from "../daemon/trust-context.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
@@ -133,16 +133,16 @@ async function injectPersonaMemory(
   opts: RunLeafOptions,
   messages: Message[],
 ): Promise<Message[]> {
-  if (!isPersonalMemoryAllowed(opts.trustContext)) return messages;
+  if (!isPersonalMemoryAllowed(opts.trustContext)) {return messages;}
 
   const config = getConfig();
-  if (config.memory?.enabled === false) return messages;
+  if (config.memory?.enabled === false) {return messages;}
 
   const ephemeralConversationId = `workflow-leaf:${randomUUID()}`;
   const graphMemory = new ConversationGraphMemory(ephemeralConversationId);
   // The memory pipeline broadcasts retrieval progress to the shared event hub
   // (matching the main-agent hook); a leaf has no per-turn event callback.
-  const onEvent = (msg: ServerMessage): void => {
+  const onEvent = (msg: AssistantEvent): void => {
     broadcastMessage(msg);
   };
   // `prepareMemory` requires a non-aborting signal; reuse the caller's when
@@ -552,7 +552,7 @@ async function executeLeafTool(
 function finalAssistantText(history: Message[]): string {
   for (let i = history.length - 1; i >= 0; i--) {
     const msg = history[i];
-    if (msg.role !== "assistant") continue;
+    if (msg.role !== "assistant") {continue;}
     const text = msg.content
       .filter(
         (b): b is Extract<typeof b, { type: "text" }> => b.type === "text",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -214,7 +214,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-23T16:26:29.000Z"
+      "updatedAt": "2026-07-23T16:33:06.000Z"
     },
     {
       "id": "email-setup",
@@ -731,7 +731,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-23T14:02:39.000Z"
+      "updatedAt": "2026-07-24T20:43:31.000Z"
     },
     {
       "id": "public-ingress",
@@ -1268,7 +1268,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-23T16:26:29.000Z"
+      "updatedAt": "2026-07-23T16:33:06.000Z"
     },
     {
       "id": "watch-together",

--- a/skills/plugin-builder/references/plugins.md
+++ b/skills/plugin-builder/references/plugins.md
@@ -110,7 +110,7 @@ Values, not just types, that a plugin consumes at module-load or init time. A bo
 | Export                       | Kind  | Purpose                                                                                                |
 | ---------------------------- | ----- | ------------------------------------------------------------------------------------------------------ |
 | `assistantEventHub`          | value | The assistant's pub/sub hub for runtime events. Subscribe to react to activity outside the hook chain. |
-| `AssistantEvent`             | type  | Payload shape of an event published on the hub.                                                        |
+| `AssistantEventEnvelope`     | type  | Envelope a hub subscriber receives (`AssistantEvent` is a deprecated alias).                           |
 | `AssistantEventHub`          | type  | Interface of the event hub itself.                                                                     |
 | `AssistantEventCallback`     | type  | Subscriber callback invoked for each matching event.                                                   |
 | `AssistantEventFilter`       | type  | Filter narrowing which events a subscription receives.                                                 |


### PR DESCRIPTION
## Why

Two follow-ups from the review of #39130, both aimed at removing the `AssistantEvent` naming ambiguity that made the daemon event types confusing:

- **"Yea let's remove `ServerMessage` entirely in a future PR."** — `ServerMessage` had become a bare alias of the api-canonical event union (`z.infer<AssistantEventSchema>`). It carried no meaning of its own and shadowed the single-source name.
- **"We should remove this left-hand-side type, especially since it will cause confusion with the existing `AssistantEvent` type."** — the daemon-side `AssistantEvent = AssistantEventEnvelope` alias collided with the api message union also named `AssistantEvent`. One name meant two different things (the message union vs. the SSE envelope wrapping it).

This PR resolves the collision so `AssistantEvent` means exactly one thing everywhere: the canonical server→client message union inferred from `AssistantEventSchema`.

## What

**Commit 1 — rename the daemon event envelope `AssistantEvent` → `AssistantEventEnvelope` (32 files).**
Frees the `AssistantEvent` name. `runtime/assistant-event.ts` now re-exports the canonical `AssistantEventEnvelope` from `../api` and `buildAssistantEvent` returns it; the generic `BaseAssistantEvent<TMessage>` framing envelope and SSE helpers are unchanged. All 31 envelope-consumer files updated to the new name.

**Commit 2 — remove `ServerMessage`; rename its consumers to `AssistantEvent` (114 files).**
`daemon/message-protocol.ts` drops `export type ServerMessage = AssistantEvent` and re-exports `AssistantEvent` straight from `../api`. Every `ServerMessage` consumer is renamed to `AssistantEvent` (whole-word substitution to avoid colliding with `AssistantEventHub`, `buildAssistantEvent`, etc.).

Net result: `AssistantEvent` = the api message union; `AssistantEventEnvelope` = the SSE wrapper around it. No third name in between.

## Test plan

- `bun run typecheck:fast` — clean
- `bun test src/api src/__tests__/runtime-events-sse-parity.test.ts src/__tests__/plugin-import-boundary-guard.test.ts` and the event-hub / daemon-assistant-events / plugin-api suites — pass
- `bun run generate:openapi -- --check` — unchanged (SSE event types don't drive route-generated openapi)
- eslint + prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_