### PR TITLE
refactor(events): import specific event variants instead of deriving from the union

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -8,6 +8,11 @@
 
 import { v7 as uuidv7 } from "uuid";
 
+import type {
+  AssistantTextDeltaEvent,
+  GenerationCancelledEvent,
+  MessageCompleteEvent,
+} from "../api/index.js";
 import { consumeGrantForInvocation } from "../approvals/approval-primitive.js";
 import type {
   ChannelId,
@@ -216,15 +221,8 @@ export interface VoiceToolResultEvent {
  * standard channel path.
  */
 export interface VoiceRunEventSink {
-  onTextDelta(
-    msg: Extract<AssistantEvent, { type: "assistant_text_delta" }>,
-  ): void;
-  onMessageComplete(
-    msg: Extract<
-      AssistantEvent,
-      { type: "message_complete" } | { type: "generation_cancelled" }
-    >,
-  ): void;
+  onTextDelta(msg: AssistantTextDeltaEvent): void;
+  onMessageComplete(msg: MessageCompleteEvent | GenerationCancelledEvent): void;
   onError(message: string): void;
   onToolUse(
     toolName: string,
@@ -235,14 +233,9 @@ export interface VoiceRunEventSink {
 }
 
 export interface VoiceTurnCallbacks {
-  assistant_text_delta?: (
-    msg: Extract<AssistantEvent, { type: "assistant_text_delta" }>,
-  ) => void;
+  assistant_text_delta?: (msg: AssistantTextDeltaEvent) => void;
   message_complete?: (
-    msg: Extract<
-      AssistantEvent,
-      { type: "message_complete" } | { type: "generation_cancelled" }
-    >,
+    msg: MessageCompleteEvent | GenerationCancelledEvent,
   ) => void;
   persisted_user_message_id?: (messageId: string) => void;
   persisted_assistant_message_id?: (messageId: string) => void;

--- a/assistant/src/ipc/routes/__tests__/events-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/events-ipc-routes.test.ts
@@ -39,17 +39,29 @@ describe(`${EVENTS_PUBLISH_IPC_METHOD} IPC route`, () => {
   test("publishes a full event envelope onto the daemon hub", async () => {
     const received = subscribe();
 
+    const message = {
+      type: "generation_cancelled",
+      conversationId: "conv-events-test",
+    };
     const result = await handleEventsPublish({
-      body: { event: fullEvent({ type: "test_event", value: 42 }) },
+      body: { event: fullEvent(message) },
     });
 
     expect(result).toEqual({ ok: true });
     expect(received).toHaveLength(1);
     expect((received[0] as { id: string }).id).toBe("evt-1");
-    expect((received[0] as { message: unknown }).message).toEqual({
-      type: "test_event",
-      value: 42,
-    });
+    expect((received[0] as { message: unknown }).message).toEqual(message);
+  });
+
+  test("rejects a message that is not a known event type", async () => {
+    const received = subscribe();
+
+    await expect(
+      handleEventsPublish({
+        body: { event: fullEvent({ type: "not_a_real_event" }) },
+      }),
+    ).rejects.toThrow();
+    expect(received).toHaveLength(0);
   });
 
   test("rejects an incomplete envelope (missing id)", async () => {
@@ -60,7 +72,7 @@ describe(`${EVENTS_PUBLISH_IPC_METHOD} IPC route`, () => {
         body: {
           event: {
             emittedAt: "2026-07-21T00:00:00.000Z",
-            message: { type: "test_event" },
+            message: { type: "generation_cancelled" },
           },
         },
       }),

--- a/assistant/src/ipc/routes/events-ipc-routes.ts
+++ b/assistant/src/ipc/routes/events-ipc-routes.ts
@@ -27,25 +27,11 @@ import {
   HOST_PROXY_CAPABILITIES,
   INTERFACE_IDS,
 } from "../../channels/types.js";
-import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
 import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
 
 /** IPC method name — the raw publish transport other processes call. */
 export const EVENTS_PUBLISH_IPC_METHOD = "/events/publish";
-
-/**
- * The event envelope reuses the shared wire schema's transport fields (`id`,
- * `emittedAt`, `conversationId`, `seq`) and overrides only `message`: the hub
- * publishes runtime `AssistantEvent`-typed events, whose union is defined
- * separately from the api schema's message union, so the override yields a
- * value assignable to `assistantEventHub.publish` without a cast.
- */
-const EventEnvelopeSchema = AssistantEventEnvelopeSchema.extend({
-  message: z.custom<AssistantEvent>(
-    (value) => value != null && typeof value === "object",
-  ),
-});
 
 /** Publish targeting/suppression options — see the hub's `publish`. */
 const PublishOptionsSchema = z.object({
@@ -56,7 +42,7 @@ const PublishOptionsSchema = z.object({
 });
 
 const EventsPublishParamsSchema = z.object({
-  event: EventEnvelopeSchema,
+  event: AssistantEventEnvelopeSchema,
   options: PublishOptionsSchema.optional(),
 });
 

--- a/assistant/src/permissions/confirmation-guardian-request.ts
+++ b/assistant/src/permissions/confirmation-guardian-request.ts
@@ -17,7 +17,7 @@
  * therefore the emitters — stays cheap and free of import-time side effects.
  */
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { ConfirmationRequestEvent } from "../api/index.js";
 import { IntegrityError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 
@@ -30,7 +30,7 @@ const log = getLogger("confirmation-guardian-request");
  * never thrown.
  */
 export async function createGuardianRequestForConfirmation(
-  msg: AssistantEvent & { type: "confirmation_request" },
+  msg: ConfirmationRequestEvent,
   conversationId: string,
   opts?: {
     /**

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from "uuid";
 
+import type { SecretRequestEvent } from "../api/index.js";
 import { getConfig } from "../config/loader.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
@@ -11,7 +11,7 @@ import type {
   SecretPromptResult,
 } from "./secret-prompt-types.js";
 
-type SecretRequestMessage = Extract<AssistantEvent, { type: "secret_request" }>;
+type SecretRequestMessage = SecretRequestEvent;
 
 const log = getLogger("secret-prompter");
 

--- a/assistant/src/runtime/assistant-event.ts
+++ b/assistant/src/runtime/assistant-event.ts
@@ -12,10 +12,7 @@
 
 import { randomUUID } from "node:crypto";
 
-import type {
-  AssistantEvent as AssistantEventMessage,
-  AssistantEventEnvelope,
-} from "../api/index.js";
+import type { AssistantEvent, AssistantEventEnvelope } from "../api/index.js";
 
 // -- Generic base --------------------------------------------------------------
 
@@ -106,11 +103,8 @@ export type { AssistantEventEnvelope };
  * `AssistantEvent` message payload.
  */
 export function buildAssistantEvent(
-  message: AssistantEventMessage,
+  message: AssistantEvent,
   conversationId?: string,
 ): AssistantEventEnvelope {
-  return baseBuildAssistantEvent<AssistantEventMessage>(
-    message,
-    conversationId,
-  );
+  return baseBuildAssistantEvent<AssistantEvent>(message, conversationId);
 }


### PR DESCRIPTION
## Why

Follow-up cleanup from the review of #39144. Now that `AssistantEvent` is single-sourced from `AssistantEventSchema` and every event member has its own named type in `api/events`, several call sites can name the specific type directly instead of re-deriving it from the union.

This is the first of a few small follow-ups; the two larger import-sweeps (dropping the `AssistantEvent` re-export from `message-protocol` and the `AssistantEventEnvelope` re-export from `runtime/assistant-event`, each ~30–40 files) will land as their own PRs.

## What

- **`voice-session-bridge`, `confirmation-guardian-request`, `secret-prompter`** — replace `Extract<AssistantEvent, { type: "x" }>` (and the `AssistantEvent & { type: "x" }` intersection) with a direct import of the explicitly-defined event member (`AssistantTextDeltaEvent`, `MessageCompleteEvent`, `GenerationCancelledEvent`, `ConfirmationRequestEvent`, `SecretRequestEvent`).
- **`events-ipc` publish route** — delete the local `EventEnvelopeSchema` that loosely re-validated `message` via `z.custom`. The runtime event union is now the api union, so `AssistantEventEnvelopeSchema` validates the payload directly. This means the published message is now strictly validated against the canonical event schema; the route test uses a real event type and adds coverage for the unknown-type reject path.
- **`assistant-event`** — drop the `AssistantEvent as AssistantEventMessage` import alias now that the name is free, using `AssistantEvent` directly.

## Test plan

- `bun run typecheck:fast` — clean
- `bun test` on the touched suites (`events-ipc-routes`, `confirmation-guardian-request`, `secret-prompter-channel-fallback`, `daemon-assistant-events`, `runtime-events-sse-parity`, `voice-scoped-grant-consumer`) — pass in isolation
- eslint + prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_