### PR TITLE
feat(channels): native ask_question wizard on Telegram

### DIFF
--- a/assistant/src/__tests__/channel-approval.test.ts
+++ b/assistant/src/__tests__/channel-approval.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ApprovalAction } from "../runtime/channel-approval-types.js";
-import { parseCallbackData } from "../runtime/routes/channel-route-shared.js";
+import {
+  parseCallbackData,
+  parseQuestionCallbackData,
+} from "../runtime/routes/channel-route-shared.js";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Callback data parser
@@ -23,12 +26,15 @@ describe("parseCallbackData", () => {
     ["apr:req-123:approve_10m", "approve_once"],
     ["apr:req-123:approve_conversation", "approve_once"],
     ["apr:req-123:approve_always", "approve_once"],
-  ])('maps legacy action "%s" to %s (backward compat)', (data, expectedAction) => {
-    const result = parseCallbackData(data);
-    expect(result).not.toBeNull();
-    expect(result!.action).toBe(expectedAction as ApprovalAction);
-    expect(result!.requestId).toBe("req-123");
-  });
+  ])(
+    'maps legacy action "%s" to %s (backward compat)',
+    (data, expectedAction) => {
+      const result = parseCallbackData(data);
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe(expectedAction as ApprovalAction);
+      expect(result!.requestId).toBe("req-123");
+    },
+  );
 
   test("parses slack source channel", () => {
     const result = parseCallbackData("apr:req-789:approve_once", "slack");
@@ -52,5 +58,52 @@ describe("parseCallbackData", () => {
 
   test("returns null for empty requestId", () => {
     expect(parseCallbackData("apr::approve_once")).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Question wizard callback data parser
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("parseQuestionCallbackData", () => {
+  test("parses an option-index tap", () => {
+    expect(parseQuestionCallbackData("qst:req-1:q1:0")).toEqual({
+      requestId: "req-1",
+      questionId: "q1",
+      selection: 0,
+    });
+    expect(parseQuestionCallbackData("qst:req-1:q2:3")).toEqual({
+      requestId: "req-1",
+      questionId: "q2",
+      selection: 3,
+    });
+  });
+
+  test("parses a skip tap", () => {
+    expect(parseQuestionCallbackData("qst:req-1:q1:skip")).toEqual({
+      requestId: "req-1",
+      questionId: "q1",
+      selection: "skip",
+    });
+  });
+
+  test("returns null for a non-question prefix", () => {
+    expect(parseQuestionCallbackData("apr:req-1:q1:0")).toBeNull();
+  });
+
+  test("returns null for the wrong number of fields", () => {
+    expect(parseQuestionCallbackData("qst:req-1:q1")).toBeNull();
+    expect(parseQuestionCallbackData("qst:req-1:q1:0:extra")).toBeNull();
+  });
+
+  test("returns null for a non-integer or negative option index", () => {
+    expect(parseQuestionCallbackData("qst:req-1:q1:abc")).toBeNull();
+    expect(parseQuestionCallbackData("qst:req-1:q1:-1")).toBeNull();
+    expect(parseQuestionCallbackData("qst:req-1:q1:1.5")).toBeNull();
+  });
+
+  test("returns null for an empty requestId or questionId", () => {
+    expect(parseQuestionCallbackData("qst::q1:0")).toBeNull();
+    expect(parseQuestionCallbackData("qst:req-1::0")).toBeNull();
   });
 });

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -401,6 +401,31 @@ describe("resolveChannelCapabilities", () => {
     ).toBe(false);
   });
 
+  test("supportsInlineQuestions is true only for channels with a question wizard", () => {
+    // Strict subset of supportsInlineOptions: gates ask_question parking, so it
+    // must be true only where the adapter actually renders the wizard (Telegram
+    // today) — otherwise a parked question would hang with no card to deliver.
+    expect(resolveChannelCapabilities("telegram").supportsInlineQuestions).toBe(
+      true,
+    );
+    // Renders approval buttons but has no question wizard yet → must stay false.
+    expect(resolveChannelCapabilities("whatsapp").supportsInlineQuestions).toBe(
+      false,
+    );
+    expect(resolveChannelCapabilities("slack").supportsInlineQuestions).toBe(
+      false,
+    );
+    expect(resolveChannelCapabilities("email").supportsInlineQuestions).toBe(
+      false,
+    );
+    expect(
+      resolveChannelCapabilities(undefined, "macos").supportsInlineQuestions,
+    ).toBe(false);
+    expect(
+      resolveChannelCapabilities("unknown-thing").supportsInlineQuestions,
+    ).toBe(false);
+  });
+
   test("propagates chatType when provided", () => {
     const caps = resolveChannelCapabilities("telegram", null, "group");
     expect(caps.chatType).toBe("group");

--- a/assistant/src/daemon/__tests__/channel-ui-capability.test.ts
+++ b/assistant/src/daemon/__tests__/channel-ui-capability.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { channelSupportsInlineOptions } from "../channel-ui-capability.js";
+import {
+  channelSupportsInlineOptions,
+  channelSupportsInlineQuestions,
+  conversationSupportsInlineQuestions,
+} from "../channel-ui-capability.js";
 
 // Single source of truth for which channels' adapters can render inline
 // tappable options. `resolveChannelCapabilities` populates
@@ -22,5 +26,57 @@ describe("channelSupportsInlineOptions", () => {
   test("false for unknown and empty channel ids", () => {
     expect(channelSupportsInlineOptions("")).toBe(false);
     expect(channelSupportsInlineOptions("mystery")).toBe(false);
+  });
+});
+
+// Strict subset of channelSupportsInlineOptions: only channels whose adapter
+// renders the ask_question wizard. Gates ask_question parking, so Slack/WhatsApp
+// (approval buttons but no wizard yet) must be false to avoid hanging the turn.
+describe("channelSupportsInlineQuestions", () => {
+  test("true only for channels with a question wizard (Telegram today)", () => {
+    expect(channelSupportsInlineQuestions("telegram")).toBe(true);
+  });
+
+  test("false for approval-button channels without a question wizard", () => {
+    expect(channelSupportsInlineQuestions("whatsapp")).toBe(false);
+    expect(channelSupportsInlineQuestions("slack")).toBe(false);
+  });
+
+  test("false for the app, text/voice-only, unknown, and empty ids", () => {
+    expect(channelSupportsInlineQuestions("vellum")).toBe(false);
+    expect(channelSupportsInlineQuestions("phone")).toBe(false);
+    expect(channelSupportsInlineQuestions("email")).toBe(false);
+    expect(channelSupportsInlineQuestions("")).toBe(false);
+    expect(channelSupportsInlineQuestions("mystery")).toBe(false);
+  });
+});
+
+describe("conversationSupportsInlineQuestions", () => {
+  test("reads the per-turn capability, then the structural fallback", () => {
+    expect(
+      conversationSupportsInlineQuestions({
+        currentTurnChannelCapabilities: {
+          supportsDynamicUi: false,
+          supportsInlineQuestions: true,
+        },
+      }),
+    ).toBe(true);
+    expect(
+      conversationSupportsInlineQuestions({
+        channelCapabilities: {
+          supportsDynamicUi: false,
+          supportsInlineQuestions: true,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test("defaults to false when unset (opt-in per channel)", () => {
+    expect(
+      conversationSupportsInlineQuestions({
+        channelCapabilities: { supportsDynamicUi: false },
+      }),
+    ).toBe(false);
+    expect(conversationSupportsInlineQuestions({})).toBe(false);
   });
 });

--- a/assistant/src/daemon/channel-ui-capability.ts
+++ b/assistant/src/daemon/channel-ui-capability.ts
@@ -8,8 +8,12 @@
 export interface DynamicUiCapabilityView {
   readonly currentTurnChannelCapabilities?: {
     readonly supportsDynamicUi: boolean;
+    readonly supportsInlineOptions?: boolean;
   };
-  readonly channelCapabilities?: { readonly supportsDynamicUi: boolean };
+  readonly channelCapabilities?: {
+    readonly supportsDynamicUi: boolean;
+    readonly supportsInlineOptions?: boolean;
+  };
 }
 
 /**
@@ -52,4 +56,20 @@ const INLINE_OPTIONS_CHANNELS: ReadonlySet<string> = new Set([
  */
 export function channelSupportsInlineOptions(channel: string): boolean {
   return INLINE_OPTIONS_CHANNELS.has(channel);
+}
+
+/**
+ * Whether the conversation's current-turn channel can render inline tappable
+ * options (question option pickers, approval buttons). Opt-in per channel:
+ * defaults to `false` when unset (unlike dynamic UI, which defaults to
+ * supported). Prefers the per-turn capabilities, falling back to the structural
+ * channel capabilities.
+ */
+export function conversationSupportsInlineOptions(
+  conversation: DynamicUiCapabilityView,
+): boolean {
+  const caps =
+    conversation.currentTurnChannelCapabilities ??
+    conversation.channelCapabilities;
+  return caps?.supportsInlineOptions === true;
 }

--- a/assistant/src/daemon/channel-ui-capability.ts
+++ b/assistant/src/daemon/channel-ui-capability.ts
@@ -9,10 +9,12 @@ export interface DynamicUiCapabilityView {
   readonly currentTurnChannelCapabilities?: {
     readonly supportsDynamicUi: boolean;
     readonly supportsInlineOptions?: boolean;
+    readonly supportsInlineQuestions?: boolean;
   };
   readonly channelCapabilities?: {
     readonly supportsDynamicUi: boolean;
     readonly supportsInlineOptions?: boolean;
+    readonly supportsInlineQuestions?: boolean;
   };
 }
 
@@ -72,4 +74,42 @@ export function conversationSupportsInlineOptions(
     conversation.currentTurnChannelCapabilities ??
     conversation.channelCapabilities;
   return caps?.supportsInlineOptions === true;
+}
+
+/**
+ * Channels whose adapter renders the `ask_question` wizard as native inline
+ * option buttons. A strict subset of {@link INLINE_OPTIONS_CHANNELS}: rendering
+ * inline approval buttons (all of Telegram/Slack/WhatsApp) is a different, more
+ * general capability than implementing the multi-step question wizard, which so
+ * far only the Telegram adapter does. Onboarding another channel's question
+ * wizard = build its renderer, then add it here — no shared-handling change.
+ *
+ * Kept distinct from `supportsInlineOptions` on purpose: gating questions on the
+ * broader approval capability would park `ask_question` on Slack/WhatsApp with
+ * no wizard to deliver it, hanging the turn until the response timeout instead
+ * of degrading to the text fallback.
+ */
+const INLINE_QUESTION_CHANNELS: ReadonlySet<string> = new Set(["telegram"]);
+
+/**
+ * Whether a channel's adapter renders the `ask_question` wizard natively. Pure
+ * set-membership on the canonical channel id (no normalization).
+ */
+export function channelSupportsInlineQuestions(channel: string): boolean {
+  return INLINE_QUESTION_CHANNELS.has(channel);
+}
+
+/**
+ * Whether the conversation's current-turn channel renders the `ask_question`
+ * wizard natively. Opt-in per channel: defaults to `false` when unset. Prefers
+ * the per-turn capabilities, falling back to the structural channel
+ * capabilities.
+ */
+export function conversationSupportsInlineQuestions(
+  conversation: DynamicUiCapabilityView,
+): boolean {
+  const caps =
+    conversation.currentTurnChannelCapabilities ??
+    conversation.channelCapabilities;
+  return caps?.supportsInlineQuestions === true;
 }

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -74,7 +74,10 @@ import { resolveCapabilities } from "../runtime/capabilities.js";
 import type { SubagentState } from "../subagent/types.js";
 import { TERMINAL_STATUSES } from "../subagent/types.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
-import { channelSupportsInlineOptions } from "./channel-ui-capability.js";
+import {
+  channelSupportsInlineOptions,
+  channelSupportsInlineQuestions,
+} from "./channel-ui-capability.js";
 import { findConversationOrSubagent } from "./conversation-registry.js";
 import type { SurfaceShowPair } from "./conversation-surfaces.js";
 import { canonicalizeTimeZone, formatTurnTimestamp } from "./date-context.js";
@@ -100,11 +103,20 @@ export interface ChannelCapabilities {
   supportsDynamicUi: boolean;
   /**
    * Whether the channel's adapter can render inline tappable options — approval
-   * buttons and (next) question option pickers. Distinct from `supportsDynamicUi`:
-   * a text-only channel can render inline buttons without dynamic UI. Optional;
-   * absent is treated as `false`.
+   * buttons today. Distinct from `supportsDynamicUi`: a text-only channel can
+   * render inline buttons without dynamic UI. Optional; absent is treated as
+   * `false`.
    */
   supportsInlineOptions?: boolean;
+  /**
+   * Whether the channel's adapter renders the `ask_question` wizard natively
+   * (inline option buttons, advanced in place). A strict subset of
+   * `supportsInlineOptions` — the wizard is implemented per adapter, Telegram
+   * first — so it gates `ask_question` parking without hanging the turn on
+   * channels that render approval buttons but have no question wizard yet.
+   * Optional; absent is treated as `false`.
+   */
+  supportsInlineQuestions?: boolean;
   /** Whether the channel supports voice/microphone input. */
   supportsVoiceInput: boolean;
   /** The client OS/interface identifier (e.g. "macos", "ios", "web"). */
@@ -291,6 +303,7 @@ export function resolveChannelCapabilities(
         dashboardCapable: supportsDesktopUi,
         supportsDynamicUi: supportsDesktopUi || iface === "web",
         supportsInlineOptions: channelSupportsInlineOptions(channel),
+        supportsInlineQuestions: channelSupportsInlineQuestions(channel),
         supportsVoiceInput: supportsDesktopUi,
         clientOS: iface ?? undefined,
         chatType: resolvedChatType,
@@ -306,6 +319,7 @@ export function resolveChannelCapabilities(
         dashboardCapable: false,
         supportsDynamicUi: false,
         supportsInlineOptions: channelSupportsInlineOptions(channel),
+        supportsInlineQuestions: channelSupportsInlineQuestions(channel),
         supportsVoiceInput: false,
         chatType: resolvedChatType,
       };
@@ -315,6 +329,7 @@ export function resolveChannelCapabilities(
         dashboardCapable: false,
         supportsDynamicUi: false,
         supportsInlineOptions: channelSupportsInlineOptions(channel),
+        supportsInlineQuestions: channelSupportsInlineQuestions(channel),
         supportsVoiceInput: false,
         chatType: resolvedChatType,
       };

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -64,7 +64,7 @@ import {
 import { getLogger } from "../util/logger.js";
 import {
   conversationSupportsDynamicUi,
-  conversationSupportsInlineOptions,
+  conversationSupportsInlineQuestions,
 } from "./channel-ui-capability.js";
 import type { Conversation } from "./conversation.js";
 import { projectSkillTools } from "./conversation-skill-tools.js";
@@ -426,7 +426,7 @@ export function createToolExecutor(
       // channels that can't render dynamic surfaces (Telegram, SMS) instead of
       // emitting one the channel silently drops.
       supportsDynamicUi: conversationSupportsDynamicUi(ctx),
-      supportsInlineOptions: conversationSupportsInlineOptions(ctx),
+      supportsInlineQuestions: conversationSupportsInlineQuestions(ctx),
       proxyToolResolver: (
         toolName: string,
         proxyInput: Record<string, unknown>,

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -62,7 +62,10 @@ import {
   type UsageAttributionSnapshot,
 } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
-import { conversationSupportsDynamicUi } from "./channel-ui-capability.js";
+import {
+  conversationSupportsDynamicUi,
+  conversationSupportsInlineOptions,
+} from "./channel-ui-capability.js";
 import type { Conversation } from "./conversation.js";
 import { projectSkillTools } from "./conversation-skill-tools.js";
 import {
@@ -423,6 +426,7 @@ export function createToolExecutor(
       // channels that can't render dynamic surfaces (Telegram, SMS) instead of
       // emitting one the channel silently drops.
       supportsDynamicUi: conversationSupportsDynamicUi(ctx),
+      supportsInlineOptions: conversationSupportsInlineOptions(ctx),
       proxyToolResolver: (
         toolName: string,
         proxyInput: Record<string, unknown>,

--- a/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
+++ b/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
@@ -22,6 +22,8 @@ const slack = {
 const telegram = {
   sendTelegramReply: mock((..._args: unknown[]) => Promise.resolve()),
   sendTelegramRichReply: mock((..._args: unknown[]) => Promise.resolve()),
+  sendTelegramQuestion: mock((..._args: unknown[]) => Promise.resolve("101")),
+  editTelegramMessageText: mock((..._args: unknown[]) => Promise.resolve()),
   sendTelegramTypingIndicator: mock((..._args: unknown[]) => Promise.resolve()),
   sendTelegramAttachments: mock((..._args: unknown[]) =>
     Promise.resolve({ allFailed: false, failureCount: 0 }),

--- a/assistant/src/messaging/providers/telegram-bot/send.test.ts
+++ b/assistant/src/messaging/providers/telegram-bot/send.test.ts
@@ -30,8 +30,24 @@ mock.module("./api.js", () => ({
 }));
 
 const { TelegramNonRetryableError } = await import("./api.js");
-const { sendTelegramRichReply } = await import("./send.js");
+const { sendTelegramRichReply, sendTelegramQuestion, editTelegramMessageText } =
+  await import("./send.js");
 const { telegramTransport } = await import("./transport.js");
+
+const question = {
+  requestId: "req-1",
+  plainTextFallback: "Which fruit?",
+  questions: [
+    {
+      id: "q1",
+      question: "Which fruit?",
+      options: [
+        { id: "a", label: "Apple" },
+        { id: "b", label: "Banana" },
+      ],
+    },
+  ],
+};
 
 const approval: ApprovalUIMetadata = {
   requestId: "req-1",
@@ -145,6 +161,97 @@ describe("sendTelegramRichReply", () => {
 
     expect(callsTo("sendRichMessage")).toHaveLength(1);
     expect(callsTo("sendMessage")).toHaveLength(0);
+  });
+});
+
+describe("sendTelegramQuestion", () => {
+  test("sends a fresh card with the option + Skip keyboard and returns its id", async () => {
+    callTelegramBotApiMock.mockImplementationOnce(
+      async () => ({ message_id: 101 }) as never,
+    );
+
+    const ts = await sendTelegramQuestion(
+      "chat-1",
+      "Which fruit?",
+      question,
+      undefined,
+    );
+
+    expect(ts).toBe("101");
+    expect(callsTo("sendMessage")).toHaveLength(1);
+    expect(callsTo("sendMessage")[0][1]).toMatchObject({
+      chat_id: "chat-1",
+      text: "Which fruit?",
+      reply_markup: {
+        inline_keyboard: [
+          [{ text: "Apple", callback_data: "qst:req-1:q1:0" }],
+          [{ text: "Banana", callback_data: "qst:req-1:q1:1" }],
+          [{ text: "Skip", callback_data: "qst:req-1:q1:skip" }],
+        ],
+      },
+    });
+  });
+
+  test("edits in place to advance when messageTs is set (one call, keyboard included)", async () => {
+    const ts = await sendTelegramQuestion(
+      "chat-1",
+      "Which fruit?",
+      question,
+      "101",
+    );
+
+    expect(ts).toBe("101");
+    // A single editMessageText carries both text and keyboard — no separate send.
+    expect(callsTo("sendMessage")).toHaveLength(0);
+    expect(callsTo("editMessageText")).toHaveLength(1);
+    expect(callsTo("editMessageText")[0][1]).toMatchObject({
+      chat_id: "chat-1",
+      message_id: 101,
+      text: "Which fruit?",
+      reply_markup: {
+        inline_keyboard: [
+          [{ text: "Apple", callback_data: "qst:req-1:q1:0" }],
+          [{ text: "Banana", callback_data: "qst:req-1:q1:1" }],
+          [{ text: "Skip", callback_data: "qst:req-1:q1:skip" }],
+        ],
+      },
+    });
+  });
+
+  test("throws when a callback_data would exceed Telegram's 64-byte limit", async () => {
+    const longQuestion = {
+      requestId: "r".repeat(80),
+      plainTextFallback: "Q?",
+      questions: [
+        {
+          id: "q1",
+          question: "Q?",
+          options: [
+            { id: "a", label: "A" },
+            { id: "b", label: "B" },
+          ],
+        },
+      ],
+    };
+    await expect(
+      sendTelegramQuestion("chat-1", "Q?", longQuestion, undefined),
+    ).rejects.toThrow(/64-byte limit/);
+  });
+});
+
+describe("editTelegramMessageText", () => {
+  test("edits text and clears the keyboard by omitting reply_markup", async () => {
+    await editTelegramMessageText("chat-1", "101", "Recorded.");
+
+    expect(callsTo("editMessageText")).toHaveLength(1);
+    const body = callsTo("editMessageText")[0][1] as Record<string, unknown>;
+    expect(body).toMatchObject({
+      chat_id: "chat-1",
+      message_id: 101,
+      text: "Recorded.",
+    });
+    // No reply_markup → Telegram removes the inline keyboard.
+    expect(body.reply_markup).toBeUndefined();
   });
 });
 

--- a/assistant/src/messaging/providers/telegram-bot/send.ts
+++ b/assistant/src/messaging/providers/telegram-bot/send.ts
@@ -5,7 +5,10 @@
  * and typing indicators by calling the Telegram Bot API directly via ./api.ts.
  */
 
-import type { ApprovalUIMetadata } from "@vellumai/gateway-client";
+import type {
+  ApprovalUIMetadata,
+  QuestionUIMetadata,
+} from "@vellumai/gateway-client";
 
 import { getAttachmentContent } from "../../../persistence/attachments-store.js";
 import type { RuntimeAttachmentMetadata } from "../../../runtime/http-types.js";
@@ -13,6 +16,7 @@ import { getLogger } from "../../../util/logger.js";
 import {
   callTelegramBotApi,
   callTelegramBotApiMultipart,
+  type TelegramMessage,
   TelegramNonRetryableError,
 } from "./api.js";
 import { renderTelegramHtml } from "./render.js";
@@ -91,8 +95,22 @@ function splitText(text: string, maxLen: number): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// Inline keyboard (approval buttons)
+// Inline keyboards (approval + question buttons)
 // ---------------------------------------------------------------------------
+
+/** Telegram rejects a send whose callback_data exceeds 64 bytes; fail loudly at
+ *  build time rather than let the Bot API reject the whole message. */
+function assertCallbackDataWithinLimit(
+  callbackData: string,
+  label: string,
+): void {
+  const bytes = Buffer.byteLength(callbackData);
+  if (bytes > TELEGRAM_MAX_CALLBACK_DATA_BYTES) {
+    throw new Error(
+      `callback_data for ${label} is ${bytes} bytes, exceeding Telegram's ${TELEGRAM_MAX_CALLBACK_DATA_BYTES}-byte limit`,
+    );
+  }
+}
 
 function buildInlineKeyboard(approval: ApprovalUIMetadata): {
   inline_keyboard: Array<Array<{ text: string; callback_data: string }>>;
@@ -100,19 +118,35 @@ function buildInlineKeyboard(approval: ApprovalUIMetadata): {
   return {
     inline_keyboard: approval.actions.map((action) => {
       const callbackData = `apr:${approval.requestId}:${action.id}`;
-      if (Buffer.byteLength(callbackData) > TELEGRAM_MAX_CALLBACK_DATA_BYTES) {
-        throw new Error(
-          `callback_data for action "${action.id}" is ${Buffer.byteLength(callbackData)} bytes, exceeding Telegram's ${TELEGRAM_MAX_CALLBACK_DATA_BYTES}-byte limit`,
-        );
-      }
-      return [
-        {
-          text: action.label,
-          callback_data: callbackData,
-        },
-      ];
+      assertCallbackDataWithinLimit(callbackData, `action "${action.id}"`);
+      return [{ text: action.label, callback_data: callbackData }];
     }),
   };
+}
+
+/**
+ * Inline keyboard for the current step of a channel-native question wizard: one
+ * button per option, then a Skip button. The metadata carries a single question
+ * entry (the daemon delivers one wizard step at a time). Callbacks encode
+ * `qst:<requestId>:<questionId>:<optionIndex>` (or `:skip`) — the raw option id
+ * never crosses the wire; it is resolved server-side from the index.
+ */
+function buildQuestionKeyboard(question: QuestionUIMetadata): {
+  inline_keyboard: Array<Array<{ text: string; callback_data: string }>>;
+} {
+  const entry = question.questions[0];
+  if (!entry) {
+    throw new Error("buildQuestionKeyboard requires a question entry");
+  }
+  const rows = entry.options.map((option, optIdx) => {
+    const callbackData = `qst:${question.requestId}:${entry.id}:${optIdx}`;
+    assertCallbackDataWithinLimit(callbackData, `option "${option.id}"`);
+    return [{ text: option.label, callback_data: callbackData }];
+  });
+  const skipData = `qst:${question.requestId}:${entry.id}:skip`;
+  assertCallbackDataWithinLimit(skipData, "skip");
+  rows.push([{ text: "Skip", callback_data: skipData }]);
+  return { inline_keyboard: rows };
 }
 
 // ---------------------------------------------------------------------------
@@ -213,6 +247,55 @@ export async function sendTelegramRichReply(
     }
     throw err;
   }
+}
+
+/**
+ * Deliver one step of a channel-native question wizard. Without `messageTs`,
+ * send a fresh message and return its id so the wizard can edit it later; with
+ * `messageTs`, edit that message in place to advance to the next question. Both
+ * carry the option keyboard in a single Bot API call.
+ */
+export async function sendTelegramQuestion(
+  chatId: string,
+  text: string,
+  question: QuestionUIMetadata,
+  messageTs: string | undefined,
+  opts?: TelegramSendOptions,
+): Promise<string | undefined> {
+  const replyMarkup = buildQuestionKeyboard(question);
+  if (messageTs) {
+    await callTelegramBotApi("editMessageText", {
+      chat_id: chatId,
+      message_id: Number(messageTs),
+      text,
+      reply_markup: replyMarkup,
+    });
+    return messageTs;
+  }
+  const result = await callTelegramBotApi<TelegramMessage>("sendMessage", {
+    chat_id: chatId,
+    text,
+    reply_markup: replyMarkup,
+    ...threadIdPayloadFields(opts),
+  });
+  return String(result.message_id);
+}
+
+/**
+ * Edit an existing message's text and drop its inline keyboard in a single call
+ * — used to finalize a question wizard (show the recorded answers, remove the
+ * now-stale buttons). Omitting `reply_markup` on `editMessageText` clears it.
+ */
+export async function editTelegramMessageText(
+  chatId: string,
+  messageTs: string,
+  text: string,
+): Promise<void> {
+  await callTelegramBotApi("editMessageText", {
+    chat_id: chatId,
+    message_id: Number(messageTs),
+    text,
+  });
 }
 
 export type TelegramAttachmentResult = {

--- a/assistant/src/messaging/providers/telegram-bot/transport.ts
+++ b/assistant/src/messaging/providers/telegram-bot/transport.ts
@@ -7,7 +7,9 @@ import type {
 } from "../channel-transport.js";
 import type { TelegramSendOptions } from "./send.js";
 import {
+  editTelegramMessageText,
   sendTelegramAttachments,
+  sendTelegramQuestion,
   sendTelegramReply,
   sendTelegramRichReply,
   sendTelegramTypingIndicator,
@@ -28,8 +30,36 @@ export const telegramTransport: ChannelTransport = {
   channel: "telegram",
 
   async deliver(ctx, payload) {
-    const { chatId, text, attachments, approval } = payload;
+    const { chatId, text, attachments, approval, question } = payload;
     const opts = threadOptions(ctx);
+
+    // Channel-native question wizard step: send the first message (returning its
+    // id so the wizard can edit it later) or, with `messageTs`, edit in place to
+    // advance. Handled before the generic text path — a question payload also
+    // carries the step's display text.
+    if (question) {
+      const ts = await sendTelegramQuestion(
+        chatId,
+        text ?? question.plainTextFallback,
+        question,
+        payload.messageTs,
+        opts,
+      );
+      log.info(
+        { chatId, edit: !!payload.messageTs },
+        "Telegram question step delivered (direct)",
+      );
+      return { ok: true, ts };
+    }
+
+    // Wizard finalize: rewrite the message text and drop the inline keyboard in
+    // one edit. Telegram payloads only set `messageTs` for this today; honoring
+    // it matches the field's "update existing message" semantics.
+    if (payload.messageTs && text) {
+      await editTelegramMessageText(chatId, payload.messageTs, text);
+      log.info({ chatId }, "Telegram message edited in place (direct)");
+      return { ok: true, ts: payload.messageTs };
+    }
 
     if (text) {
       // `useBlocks` is the channel-neutral "render richly" intent set by the

--- a/assistant/src/runtime/__tests__/channel-questions.test.ts
+++ b/assistant/src/runtime/__tests__/channel-questions.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for the channel-native question wizard state machine
+ * (`channel-questions.ts`).
+ *
+ * Exercises the record → advance → submit transitions against the real
+ * `pendingInteractions` tracker and the shared `resolvePendingQuestion`
+ * resolver (no mocks): tap recording with the index guard, free-text recording,
+ * multi-question advancement, completion + rpcResolve payload, and the
+ * outbound-rendering helpers the watcher consumes.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { QuestionEntry } from "../../api/events/question-request.js";
+import type { QuestionPromptResult } from "../../permissions/question-prompter.js";
+import {
+  _clearAllQuestionWizardState,
+  buildQuestionWizardStep,
+  buildQuestionWizardSummary,
+  ensureQuestionWizardState,
+  getPendingQuestionInfoByConversation,
+  getQuestionWizardStateByConversation,
+  recordQuestionFreeTextForConversation,
+  recordQuestionTap,
+  setQuestionWizardMessageTs,
+} from "../channel-questions.js";
+import * as pendingInteractions from "../pending-interactions.js";
+
+const CONV = "conv-1";
+
+function registerQuestion(
+  requestId: string,
+  entries: QuestionEntry[],
+  rpcResolve: (value: unknown) => void = () => {},
+): void {
+  const optionsById: Record<string, string[]> = {};
+  for (const e of entries) {
+    optionsById[e.id] = e.options.map((o) => o.id);
+  }
+  pendingInteractions.register(requestId, {
+    conversationId: CONV,
+    kind: "question",
+    rpcResolve,
+    metadata: { orderedIds: entries.map((e) => e.id), optionsById },
+    questionDetails: { entries },
+  });
+}
+
+const singleEntry: QuestionEntry[] = [
+  {
+    id: "q1",
+    question: "Which fruit?",
+    description: "Pick one.",
+    options: [
+      { id: "a", label: "Apple" },
+      { id: "b", label: "Banana" },
+    ],
+    freeTextPlaceholder: "Type a fruit",
+  },
+];
+
+const twoEntries: QuestionEntry[] = [
+  {
+    id: "q1",
+    question: "Which fruit?",
+    options: [
+      { id: "a", label: "Apple" },
+      { id: "b", label: "Banana" },
+    ],
+  },
+  {
+    id: "q2",
+    question: "Which size?",
+    options: [
+      { id: "s", label: "Small" },
+      { id: "l", label: "Large" },
+    ],
+  },
+];
+
+beforeEach(() => {
+  pendingInteractions.clear();
+  _clearAllQuestionWizardState();
+});
+
+afterEach(() => {
+  pendingInteractions.clear();
+  _clearAllQuestionWizardState();
+});
+
+describe("getPendingQuestionInfoByConversation", () => {
+  test("returns only pending question interactions with details", () => {
+    registerQuestion("req-1", singleEntry);
+    pendingInteractions.register("conf-1", {
+      conversationId: CONV,
+      kind: "confirmation",
+    });
+
+    const infos = getPendingQuestionInfoByConversation(CONV);
+    expect(infos).toHaveLength(1);
+    expect(infos[0].requestId).toBe("req-1");
+    expect(infos[0].entries[0].id).toBe("q1");
+  });
+});
+
+describe("buildQuestionWizardStep", () => {
+  test("renders the current entry as single-entry metadata", () => {
+    registerQuestion("req-1", twoEntries);
+    const state = ensureQuestionWizardState("req-1")!;
+
+    const step = buildQuestionWizardStep(state);
+    expect(step).not.toBeNull();
+    expect(step!.stepIndex).toBe(0);
+    expect(step!.question.requestId).toBe("req-1");
+    expect(step!.question.questions).toHaveLength(1);
+    expect(step!.question.questions[0].id).toBe("q1");
+    expect(step!.question.questions[0].options.map((o) => o.label)).toEqual([
+      "Apple",
+      "Banana",
+    ]);
+    // Multi-question batches show progress in the body text.
+    expect(step!.text).toContain("Which fruit?");
+    expect(step!.text).toContain("(1/2)");
+  });
+
+  test("returns null once every question is answered", () => {
+    registerQuestion("req-1", singleEntry);
+    const state = ensureQuestionWizardState("req-1")!;
+    recordQuestionTap("req-1", "q1", 0);
+    expect(buildQuestionWizardStep(state)).toBeNull();
+  });
+});
+
+describe("recordQuestionTap", () => {
+  test("records an option and completes a one-question batch", () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion("req-1", singleEntry, (v) =>
+      resolved.push(v as QuestionPromptResult),
+    );
+
+    const result = recordQuestionTap("req-1", "q1", 1);
+    expect(result).toMatchObject({ status: "recorded", completed: true });
+
+    // The batch resolved through the shared resolver with the chosen option.
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].overall).toBe("completed");
+    expect(resolved[0].entries).toEqual([
+      { questionId: "q1", decision: "option", optionId: "b" },
+    ]);
+    // The pending interaction was consumed.
+    expect(pendingInteractions.get("req-1")).toBeUndefined();
+  });
+
+  test("records a skip and completes", () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion("req-1", singleEntry, (v) =>
+      resolved.push(v as QuestionPromptResult),
+    );
+
+    const result = recordQuestionTap("req-1", "q1", "skip");
+    expect(result).toMatchObject({ status: "recorded", completed: true });
+    expect(resolved[0].entries).toEqual([
+      { questionId: "q1", decision: "skipped" },
+    ]);
+  });
+
+  test("advances through a multi-question batch, resolving only at the end", () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion("req-1", twoEntries, (v) =>
+      resolved.push(v as QuestionPromptResult),
+    );
+
+    const first = recordQuestionTap("req-1", "q1", 0);
+    expect(first).toMatchObject({ status: "recorded", completed: false });
+    expect(resolved).toHaveLength(0);
+    expect(pendingInteractions.get("req-1")).toBeDefined();
+
+    // The wizard now shows the second question.
+    const state = getQuestionWizardStateByConversation(CONV)!;
+    expect(buildQuestionWizardStep(state)!.stepIndex).toBe(1);
+
+    const second = recordQuestionTap("req-1", "q2", 1);
+    expect(second).toMatchObject({ status: "recorded", completed: true });
+    expect(resolved[0].entries).toEqual([
+      { questionId: "q1", decision: "option", optionId: "a" },
+      { questionId: "q2", decision: "option", optionId: "l" },
+    ]);
+  });
+
+  test("index-guards taps for a non-current question", () => {
+    registerQuestion("req-1", twoEntries);
+    // Current question is q1; a tap for q2 is out of order → stale, no advance.
+    expect(recordQuestionTap("req-1", "q2", 0)).toEqual({ status: "stale" });
+    const state = getQuestionWizardStateByConversation(CONV)!;
+    expect(buildQuestionWizardStep(state)!.stepIndex).toBe(0);
+  });
+
+  test("rejects an out-of-range option index as stale", () => {
+    registerQuestion("req-1", singleEntry);
+    expect(recordQuestionTap("req-1", "q1", 9)).toEqual({ status: "stale" });
+    expect(pendingInteractions.get("req-1")).toBeDefined();
+  });
+
+  test("returns no_pending for an unregistered requestId", () => {
+    expect(recordQuestionTap("nope", "q1", 0)).toEqual({
+      status: "no_pending",
+    });
+  });
+});
+
+describe("recordQuestionFreeTextForConversation", () => {
+  test("records free text against the current question", () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion("req-1", singleEntry, (v) =>
+      resolved.push(v as QuestionPromptResult),
+    );
+
+    const result = recordQuestionFreeTextForConversation(CONV, "kiwi");
+    expect(result).toMatchObject({ status: "recorded", completed: true });
+    expect(resolved[0].entries).toEqual([
+      { questionId: "q1", decision: "free_text", text: "kiwi" },
+    ]);
+  });
+
+  test("mixes free text and taps across a batch", () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion("req-1", twoEntries, (v) =>
+      resolved.push(v as QuestionPromptResult),
+    );
+
+    recordQuestionFreeTextForConversation(CONV, "mango");
+    recordQuestionTap("req-1", "q2", 0);
+
+    expect(resolved[0].entries).toEqual([
+      { questionId: "q1", decision: "free_text", text: "mango" },
+      { questionId: "q2", decision: "option", optionId: "s" },
+    ]);
+  });
+
+  test("returns no_pending when no question is parked", () => {
+    expect(recordQuestionFreeTextForConversation(CONV, "hi")).toEqual({
+      status: "no_pending",
+    });
+  });
+});
+
+describe("buildQuestionWizardSummary", () => {
+  test("recaps each answer by label / text after completion", () => {
+    registerQuestion("req-1", twoEntries);
+    recordQuestionFreeTextForConversation(CONV, "mango");
+    recordQuestionTap("req-1", "q2", 1);
+
+    // State lingers until the watcher finalizes; summary reflects the answers.
+    const state = getQuestionWizardStateByConversation(CONV)!;
+    const summary = buildQuestionWizardSummary(state);
+    expect(summary).toContain("mango");
+    expect(summary).toContain("Large");
+  });
+
+  test("reports an externally-resolved wizard as no longer active", () => {
+    registerQuestion("req-1", twoEntries);
+    const state = ensureQuestionWizardState("req-1")!;
+    // Only the first of two questions answered → incomplete.
+    recordQuestionTap("req-1", "q1", 0);
+    expect(buildQuestionWizardSummary(state)).toBe(
+      "This question is no longer active.",
+    );
+  });
+});
+
+describe("setQuestionWizardMessageTs", () => {
+  test("stores the delivered card id for later edits", () => {
+    registerQuestion("req-1", singleEntry);
+    ensureQuestionWizardState("req-1");
+    setQuestionWizardMessageTs("req-1", "555");
+    // Round-trips via the conversation lookup the watcher uses.
+    expect(getQuestionWizardStateByConversation(CONV)?.messageTs).toBe("555");
+  });
+});

--- a/assistant/src/runtime/__tests__/question-resolution.test.ts
+++ b/assistant/src/runtime/__tests__/question-resolution.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the shared question resolver (`question-resolution.ts`) — the single
+ * implementation `/v1/question-response` and the channel wizard both funnel
+ * through. Focuses on the discriminated outcome (resolved / not_found / invalid)
+ * that lets each caller map to its own surface.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { QuestionPromptResult } from "../../permissions/question-prompter.js";
+import * as pendingInteractions from "../pending-interactions.js";
+import { resolvePendingQuestion } from "../question-resolution.js";
+
+function registerQuestion(
+  requestId: string,
+  questions: Array<{ id: string; options: string[] }>,
+  rpcResolve: (value: unknown) => void = () => {},
+): void {
+  const optionsById: Record<string, string[]> = {};
+  for (const q of questions) {
+    optionsById[q.id] = q.options;
+  }
+  pendingInteractions.register(requestId, {
+    conversationId: "conv-1",
+    kind: "question",
+    rpcResolve,
+    metadata: { orderedIds: questions.map((q) => q.id), optionsById },
+  });
+}
+
+beforeEach(() => pendingInteractions.clear());
+afterEach(() => pendingInteractions.clear());
+
+describe("resolvePendingQuestion", () => {
+  test("resolved: submits, fires rpcResolve, and consumes the interaction", () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion("req-1", [{ id: "q1", options: ["a", "b"] }], (v) =>
+      resolved.push(v as QuestionPromptResult),
+    );
+
+    const outcome = resolvePendingQuestion("req-1", {
+      kind: "submit",
+      submissions: [{ questionId: "q1", kind: "option", optionId: "a" }],
+    });
+
+    expect(outcome).toMatchObject({
+      status: "resolved",
+      conversationId: "conv-1",
+    });
+    expect(resolved[0].overall).toBe("completed");
+    expect(pendingInteractions.get("req-1")).toBeUndefined();
+  });
+
+  test("close: reports every question skipped, overall closed", () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion(
+      "req-1",
+      [
+        { id: "q1", options: ["a"] },
+        { id: "q2", options: ["b"] },
+      ],
+      (v) => resolved.push(v as QuestionPromptResult),
+    );
+
+    const outcome = resolvePendingQuestion("req-1", { kind: "close" });
+    expect(outcome.status).toBe("resolved");
+    expect(resolved[0]).toEqual({
+      overall: "closed",
+      entries: [
+        { questionId: "q1", decision: "skipped" },
+        { questionId: "q2", decision: "skipped" },
+      ],
+    });
+  });
+
+  test("not_found: unknown or wrong-kind requestId leaves nothing resolved", () => {
+    expect(resolvePendingQuestion("missing", { kind: "close" })).toEqual({
+      status: "not_found",
+    });
+
+    pendingInteractions.register("conf-1", {
+      conversationId: "conv-1",
+      kind: "confirmation",
+    });
+    expect(
+      resolvePendingQuestion("conf-1", {
+        kind: "submit",
+        submissions: [{ questionId: "q1", kind: "skip" }],
+      }),
+    ).toEqual({ status: "not_found" });
+  });
+
+  test("invalid: a bad submission leaves the interaction intact for a retry", () => {
+    let resolveCount = 0;
+    registerQuestion(
+      "req-1",
+      [{ id: "q1", options: ["a", "b"] }],
+      () => resolveCount++,
+    );
+
+    const outcome = resolvePendingQuestion("req-1", {
+      kind: "submit",
+      submissions: [{ questionId: "q1", kind: "option", optionId: "nope" }],
+    });
+
+    expect(outcome.status).toBe("invalid");
+    // Interaction untouched — the prompt can be resubmitted.
+    expect(pendingInteractions.get("req-1")).toBeDefined();
+    expect(resolveCount).toBe(0);
+  });
+});

--- a/assistant/src/runtime/channel-questions.ts
+++ b/assistant/src/runtime/channel-questions.ts
@@ -1,0 +1,380 @@
+/**
+ * Channel-native `ask_question` wizard orchestration.
+ *
+ * The channel analog of {@link file://./channel-approvals.ts}. When
+ * `ask_question` parks on a wizard-capable channel (Telegram today), the
+ * pending `question` interaction is rendered as an inline-keyboard "wizard":
+ * one question at a time, each advanced by editing the same message in place.
+ *
+ * Responsibility split (mirrors the approval seam):
+ *  - This module owns the in-memory wizard state (accumulated answers + the
+ *    delivered Telegram message id) and the record → submit transitions.
+ *  - Outbound rendering is driven by the watcher in `background-dispatch.ts`
+ *    (`startPendingQuestionPromptWatcher`) — the single outbound owner. It
+ *    reads {@link buildQuestionWizardStep} to send/advance the card and
+ *    {@link buildQuestionWizardSummary} to finalize it.
+ *  - Inbound taps (`qst:` callbacks) and free-text replies only mutate state,
+ *    via {@link recordQuestionTap} / {@link recordQuestionFreeTextForConversation}.
+ *
+ * Progress is tracked implicitly by `answers.size`: answers accumulate strictly
+ * in question order (each step answers the current question), so the current
+ * step is `entries[answers.size]` and the batch is complete when
+ * `answers.size === entries.length`. Submission funnels through the shared
+ * {@link resolvePendingQuestion} so the channel path and `/v1/question-response`
+ * validate and resolve identically.
+ *
+ * State is in-memory and keyed by requestId: lost on daemon restart mid-wizard,
+ * after which the parked turn's idle timeout cleans up. Durable wizard state is
+ * out of scope.
+ */
+
+import type { QuestionUIMetadata } from "@vellumai/gateway-client";
+
+import type {
+  QuestionEntry,
+  QuestionOption,
+} from "../api/events/question-request.js";
+import type { QuestionBatchSubmission } from "../permissions/question-prompter.js";
+import { getLogger } from "../util/logger.js";
+import * as pendingInteractions from "./pending-interactions.js";
+import {
+  type QuestionResolutionOutcome,
+  resolvePendingQuestion,
+} from "./question-resolution.js";
+
+const log = getLogger("channel-questions");
+
+interface QuestionWizardState {
+  requestId: string;
+  conversationId: string;
+  /** The daemon-assigned entries (q1, q2, …) with their options. */
+  entries: QuestionEntry[];
+  /** Recorded answers keyed by questionId; size doubles as the progress cursor. */
+  answers: Map<string, QuestionBatchSubmission>;
+  /** Telegram message id of the wizard card, set once the watcher delivers it. */
+  messageTs?: string;
+}
+
+/** Wizard states keyed by requestId. */
+const wizards = new Map<string, QuestionWizardState>();
+
+// ---------------------------------------------------------------------------
+// Pending question discovery
+// ---------------------------------------------------------------------------
+
+/** Minimal projection of a pending `question` interaction for channel flows. */
+export interface PendingQuestionInfo {
+  requestId: string;
+  entries: QuestionEntry[];
+}
+
+/**
+ * Pending `question` interactions for a conversation, mapped to the channel
+ * projection. Mirrors `getApprovalInfoByConversation`.
+ */
+export function getPendingQuestionInfoByConversation(
+  conversationId: string,
+): PendingQuestionInfo[] {
+  return pendingInteractions
+    .getByConversation(conversationId)
+    .filter((i) => i.kind === "question" && i.questionDetails)
+    .map((i) => ({
+      requestId: i.requestId,
+      entries: i.questionDetails!.entries,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Wizard state lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the wizard state for a requestId, initializing it from the pending
+ * `question` interaction on first access. Returns `null` when no
+ * conversation-scoped `question` interaction is registered for the requestId
+ * (already resolved, wrong kind, or conversation-less).
+ */
+export function ensureQuestionWizardState(
+  requestId: string,
+): QuestionWizardState | null {
+  const existing = wizards.get(requestId);
+  if (existing) {
+    return existing;
+  }
+
+  const interaction = pendingInteractions.get(requestId);
+  if (
+    !interaction ||
+    interaction.kind !== "question" ||
+    !interaction.questionDetails ||
+    !interaction.conversationId
+  ) {
+    return null;
+  }
+
+  const state: QuestionWizardState = {
+    requestId,
+    conversationId: interaction.conversationId,
+    entries: interaction.questionDetails.entries,
+    answers: new Map(),
+  };
+  wizards.set(requestId, state);
+  return state;
+}
+
+/** The lingering wizard state for a conversation, if any (for finalize). */
+export function getQuestionWizardStateByConversation(
+  conversationId: string,
+): QuestionWizardState | undefined {
+  for (const state of wizards.values()) {
+    if (state.conversationId === conversationId) {
+      return state;
+    }
+  }
+  return undefined;
+}
+
+/** Record the delivered card's message id so later steps edit it in place. */
+export function setQuestionWizardMessageTs(
+  requestId: string,
+  messageTs: string,
+): void {
+  const state = wizards.get(requestId);
+  if (state) {
+    state.messageTs = messageTs;
+  }
+}
+
+/** Remove a wizard's state (after finalize, or when it can't be rendered). */
+export function clearQuestionWizardState(requestId: string): void {
+  wizards.delete(requestId);
+}
+
+/** The current (first unanswered) entry, or `undefined` when complete. */
+function currentEntry(state: QuestionWizardState): QuestionEntry | undefined {
+  return state.entries[state.answers.size];
+}
+
+// ---------------------------------------------------------------------------
+// Outbound rendering (consumed by the watcher)
+// ---------------------------------------------------------------------------
+
+/** One wizard step's display text + the single-entry metadata to render it. */
+export interface QuestionWizardStep {
+  /** 0-based index of the question this step shows. */
+  stepIndex: number;
+  /** Message body text (question + optional description + progress). */
+  text: string;
+  /** Single-entry metadata the Telegram adapter turns into an option keyboard. */
+  question: QuestionUIMetadata;
+}
+
+/**
+ * The step the wizard should currently render, or `null` when every question is
+ * answered (the watcher finalizes instead). The metadata carries exactly the
+ * current entry — the adapter renders `questions[0]`.
+ */
+export function buildQuestionWizardStep(
+  state: QuestionWizardState,
+): QuestionWizardStep | null {
+  const stepIndex = state.answers.size;
+  const entry = state.entries[stepIndex];
+  if (!entry) {
+    return null;
+  }
+
+  const total = state.entries.length;
+  const text = formatStepText(entry, stepIndex, total);
+  const question: QuestionUIMetadata = {
+    requestId: state.requestId,
+    questions: [
+      {
+        id: entry.id,
+        question: entry.question,
+        ...(entry.description ? { description: entry.description } : {}),
+        options: entry.options.map(toUiOption),
+        ...(entry.freeTextPlaceholder
+          ? { freeTextPlaceholder: entry.freeTextPlaceholder }
+          : {}),
+      },
+    ],
+    plainTextFallback: text,
+  };
+  return { stepIndex, text, question };
+}
+
+function toUiOption(option: QuestionOption): {
+  id: string;
+  label: string;
+  description?: string;
+} {
+  return {
+    id: option.id,
+    label: option.label,
+    ...(option.description ? { description: option.description } : {}),
+  };
+}
+
+function formatStepText(
+  entry: QuestionEntry,
+  stepIndex: number,
+  total: number,
+): string {
+  const parts = [entry.question];
+  if (entry.description) {
+    parts.push(entry.description);
+  }
+  if (total > 1) {
+    parts.push(`\n(${stepIndex + 1}/${total})`);
+  }
+  return parts.join("\n");
+}
+
+/**
+ * Final-card text once the wizard is done: a recap of each question and the
+ * recorded answer when the batch completed, or a neutral notice when the
+ * interaction was resolved externally (timeout / supersede) before completion.
+ * The watcher delivers this with the keyboard removed.
+ */
+export function buildQuestionWizardSummary(state: QuestionWizardState): string {
+  if (state.answers.size < state.entries.length) {
+    return "This question is no longer active.";
+  }
+  return state.entries
+    .map((entry) => {
+      const answer = state.answers.get(entry.id);
+      return `${entry.question}\n→ ${describeAnswer(entry, answer)}`;
+    })
+    .join("\n\n");
+}
+
+function describeAnswer(
+  entry: QuestionEntry,
+  answer: QuestionBatchSubmission | undefined,
+): string {
+  if (!answer || answer.kind === "skip") {
+    return "Skipped";
+  }
+  if (answer.kind === "free_text") {
+    return answer.text;
+  }
+  const option = entry.options.find((o) => o.id === answer.optionId);
+  return option?.label ?? answer.optionId;
+}
+
+// ---------------------------------------------------------------------------
+// Inbound recording (consumed by the intercepts)
+// ---------------------------------------------------------------------------
+
+/** Outcome of recording an inbound answer against the wizard. */
+export type QuestionRecordResult =
+  /** No conversation-scoped pending question for this id — nothing to record. */
+  | { status: "no_pending" }
+  /** Tap for a non-current question or an out-of-range option — ignore. */
+  | { status: "stale" }
+  /** Answer recorded. `completed` → the batch was submitted; see `outcome`. */
+  | {
+      status: "recorded";
+      requestId: string;
+      completed: boolean;
+      outcome?: QuestionResolutionOutcome;
+    };
+
+/**
+ * Record a tap (`qst:<requestId>:<questionId>:<optionIndex|skip>`) against the
+ * wizard. Index-guarded: only a tap for the current question advances; taps for
+ * an already-answered or not-yet-current question are `stale`.
+ */
+export function recordQuestionTap(
+  requestId: string,
+  questionId: string,
+  selection: number | "skip",
+): QuestionRecordResult {
+  const state = ensureQuestionWizardState(requestId);
+  if (!state) {
+    return { status: "no_pending" };
+  }
+
+  const entry = currentEntry(state);
+  if (!entry || entry.id !== questionId) {
+    return { status: "stale" };
+  }
+
+  let submission: QuestionBatchSubmission;
+  if (selection === "skip") {
+    submission = { questionId, kind: "skip" };
+  } else {
+    const option = entry.options[selection];
+    if (!option) {
+      return { status: "stale" };
+    }
+    submission = { questionId, kind: "option", optionId: option.id };
+  }
+  state.answers.set(questionId, submission);
+  return submitIfComplete(state);
+}
+
+/**
+ * Record a free-text reply as the answer to the wizard's current question.
+ * Looks the wizard up by conversation (a free-text reply carries no requestId).
+ */
+export function recordQuestionFreeTextForConversation(
+  conversationId: string,
+  text: string,
+): QuestionRecordResult {
+  const info = getPendingQuestionInfoByConversation(conversationId)[0];
+  if (!info) {
+    return { status: "no_pending" };
+  }
+
+  const state = ensureQuestionWizardState(info.requestId);
+  if (!state) {
+    return { status: "no_pending" };
+  }
+
+  const entry = currentEntry(state);
+  if (!entry) {
+    return { status: "stale" };
+  }
+
+  state.answers.set(entry.id, {
+    questionId: entry.id,
+    kind: "free_text",
+    text,
+  });
+  return submitIfComplete(state);
+}
+
+/**
+ * Submit the accumulated batch once every question is answered, via the shared
+ * resolver. Leaves the wizard state in place so the watcher can finalize the
+ * card from it; the watcher clears it afterward.
+ */
+function submitIfComplete(state: QuestionWizardState): QuestionRecordResult {
+  if (state.answers.size < state.entries.length) {
+    return { status: "recorded", requestId: state.requestId, completed: false };
+  }
+
+  const submissions = state.entries.map((e) => state.answers.get(e.id)!);
+  const outcome = resolvePendingQuestion(state.requestId, {
+    kind: "submit",
+    submissions,
+  });
+  if (outcome.status !== "resolved") {
+    log.warn(
+      { requestId: state.requestId, outcome: outcome.status },
+      "Question wizard completed but resolution did not settle",
+    );
+  }
+  return {
+    status: "recorded",
+    requestId: state.requestId,
+    completed: true,
+    outcome,
+  };
+}
+
+/** Test-only: drop all wizard state. */
+export function _clearAllQuestionWizardState(): void {
+  wizards.clear();
+}

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -13,6 +13,7 @@
 import type {
   ChannelDeliveryResult,
   ChannelReplyPayload,
+  QuestionUIMetadata,
 } from "@vellumai/gateway-client";
 import {
   ChannelDeliveryError,
@@ -62,4 +63,31 @@ export async function deliverApprovalPrompt(
     undefined,
     log,
   );
+}
+
+/**
+ * Deliver one step of a channel-native question wizard. Without `messageTs`,
+ * sends a fresh card and the delivery result's `ts` is the new message id
+ * (captured by the watcher so later steps edit in place); with `messageTs`,
+ * edits that message to advance. Parallels {@link deliverApprovalPrompt}.
+ */
+export async function deliverQuestionPrompt(
+  callbackUrl: string,
+  chatId: string,
+  text: string,
+  question: QuestionUIMetadata,
+  messageTs: string | undefined,
+  assistantId?: string,
+): Promise<ChannelDeliveryResult> {
+  const payload: ChannelReplyPayload = {
+    chatId,
+    text,
+    question,
+    ...(messageTs ? { messageTs } : {}),
+    assistantId,
+  };
+  if (isDirectDelivery(callbackUrl)) {
+    return deliverDirect(callbackUrl, payload);
+  }
+  return _deliverChannelReply(callbackUrl, payload, undefined, log);
 }

--- a/assistant/src/runtime/question-resolution.ts
+++ b/assistant/src/runtime/question-resolution.ts
@@ -1,0 +1,152 @@
+/**
+ * Shared resolution core for pending `ask_question` interactions.
+ *
+ * A pending `question` interaction (registered by {@link QuestionPrompter}) can
+ * be resolved from two places:
+ *
+ *  - `POST /v1/question-response` — an app/web client submits the user's
+ *    batched selection (see `routes/question-routes.ts`).
+ *  - the channel-native question wizard — a Telegram tap or free-text reply
+ *    accumulates answers and submits the completed batch (see
+ *    `channel-questions.ts`).
+ *
+ * Both funnel through {@link resolvePendingQuestion} so the validate → consume
+ * → `rpcResolve` sequence has a single implementation. The helper is
+ * transport-agnostic: it returns a discriminated outcome rather than throwing
+ * route errors, so each caller maps the outcome to its own surface (HTTP status
+ * codes for the route; silent state cleanup for a stale channel tap).
+ */
+
+import {
+  buildBatchEntries,
+  type QuestionBatchMetadata,
+  type QuestionBatchSubmission,
+  QuestionBatchValidationError,
+  type QuestionPromptResult,
+} from "../permissions/question-prompter.js";
+import * as pendingInteractions from "./pending-interactions.js";
+
+/**
+ * How to resolve a pending question: a batched submission (one entry per
+ * question) or a close (every question reported as `skipped`).
+ */
+export type QuestionResolutionInput =
+  | { kind: "submit"; submissions: QuestionBatchSubmission[] }
+  | { kind: "close" };
+
+/**
+ * Outcome of {@link resolvePendingQuestion}.
+ *
+ *  - `resolved` — the interaction was consumed and the prompter's caller
+ *    settled. `conversationId` is the owning conversation (absent for
+ *    conversation-less prompts).
+ *  - `not_found` — no pending `question` interaction matched the requestId
+ *    (already answered, timed out, superseded, or wrong kind). Callers treat
+ *    this as a stale request.
+ *  - `invalid` — the submission failed validation. The interaction is left
+ *    intact (timer still running) so the user can submit a correct batch.
+ */
+export type QuestionResolutionOutcome =
+  | {
+      status: "resolved";
+      result: QuestionPromptResult;
+      conversationId?: string;
+    }
+  | { status: "not_found" }
+  | { status: "invalid"; message: string };
+
+/**
+ * Resolve a pending `question` interaction with a batched submission or a
+ * close. Validation runs BEFORE the interaction is consumed, so an `invalid`
+ * outcome leaves the pending prompt (and its timer) intact for a retry.
+ */
+export function resolvePendingQuestion(
+  requestId: string,
+  input: QuestionResolutionInput,
+): QuestionResolutionOutcome {
+  const interaction = pendingInteractions.get(requestId);
+  if (!interaction || interaction.kind !== "question") {
+    return { status: "not_found" };
+  }
+
+  let result: QuestionPromptResult;
+  try {
+    if (input.kind === "close") {
+      const { orderedIds } = readBatchMetadata(interaction);
+      result = {
+        entries: orderedIds.map((id) => ({
+          questionId: id,
+          decision: "skipped" as const,
+        })),
+        overall: "closed",
+      };
+    } else {
+      result = buildCompletedResult(input.submissions, interaction);
+    }
+  } catch (err) {
+    if (err instanceof QuestionBatchValidationError) {
+      return { status: "invalid", message: err.message };
+    }
+    throw err;
+  }
+
+  // Validation passed — deregister now to clear the prompter timer, then hand
+  // the result to the prompter's caller via rpcResolve.
+  pendingInteractions.resolve(
+    requestId,
+    input.kind === "close" ? "cancelled" : "answered",
+  );
+
+  (
+    interaction.rpcResolve as
+      | ((value: QuestionPromptResult) => void)
+      | undefined
+  )?.(result);
+
+  return {
+    status: "resolved",
+    result,
+    conversationId: interaction.conversationId,
+  };
+}
+
+/**
+ * Build a `completed` QuestionPromptResult from a batched submission and the
+ * per-question metadata the prompter stashed on the interaction. Delegates the
+ * validation + ordering loop to {@link buildBatchEntries} so the prompter, the
+ * route, and the channel wizard share a single implementation.
+ */
+function buildCompletedResult(
+  submissions: QuestionBatchSubmission[],
+  interaction: ReturnType<typeof pendingInteractions.get>,
+): QuestionPromptResult {
+  const { orderedIds, optionsById } = readBatchMetadata(interaction);
+  if (orderedIds.length === 0) {
+    throw new QuestionBatchValidationError(
+      "No registered question ids for this batch",
+    );
+  }
+  const entries = buildBatchEntries(
+    orderedIds,
+    (qid, oid) => (optionsById[qid] ?? []).includes(oid),
+    new Set(Object.keys(optionsById)),
+    submissions,
+  );
+  return { entries, overall: "completed" };
+}
+
+/**
+ * Pull the prompter-stashed batch bookkeeping off a pending interaction.
+ * Returns empty defaults if the metadata is absent.
+ */
+export function readBatchMetadata(
+  interaction: ReturnType<typeof pendingInteractions.get>,
+): QuestionBatchMetadata {
+  const meta = interaction?.metadata as
+    | Partial<QuestionBatchMetadata>
+    | undefined;
+  return {
+    orderedIds: meta?.orderedIds ?? [],
+    optionsById: meta?.optionsById ?? {},
+  };
+}

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -69,6 +69,47 @@ export function parseCallbackData(
 }
 
 // ---------------------------------------------------------------------------
+// Question callback data parser
+// format: "qst:<requestId>:<questionId>:<optionIndex|skip>"
+// ---------------------------------------------------------------------------
+
+/** Parsed `qst:` wizard tap. `selection` is an option index or an explicit skip. */
+export interface QuestionCallbackData {
+  requestId: string;
+  questionId: string;
+  selection: number | "skip";
+}
+
+/**
+ * Parse a question wizard callback. The scheme has exactly four colon-delimited
+ * fields and no field contains a colon (requestId is a uuid, questionId is
+ * `q<n>`, the last is a non-negative integer or the literal `skip`), so a strict
+ * arity check is correct — unlike the approval parser, whose action can itself
+ * contain colons. Returns `null` for anything that isn't a well-formed `qst:`
+ * callback so callers can fall through to other handlers.
+ */
+export function parseQuestionCallbackData(
+  data: string,
+): QuestionCallbackData | null {
+  const parts = data.split(":");
+  if (parts.length !== 4 || parts[0] !== "qst") {
+    return null;
+  }
+  const [, requestId, questionId, raw] = parts;
+  if (!requestId || !questionId || !raw) {
+    return null;
+  }
+  if (raw === "skip") {
+    return { requestId, questionId, selection: "skip" };
+  }
+  const index = Number(raw);
+  if (!Number.isInteger(index) || index < 0) {
+    return null;
+  }
+  return { requestId, questionId, selection: index };
+}
+
+// ---------------------------------------------------------------------------
 // Reaction callback data parser — format: "reaction:<emoji_name>"
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -99,6 +99,10 @@ import {
   notifyGuardianOfAccessRequest,
 } from "../access-request-helper.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
+import {
+  getPendingQuestionInfoByConversation,
+  recordQuestionFreeTextForConversation,
+} from "../channel-questions.js";
 import { deliverChannelReply } from "../gateway-client.js";
 import { trustContextFromVerdict } from "../trust-verdict-consumer.js";
 import { canonicalChannelAssistantId } from "./channel-route-shared.js";
@@ -115,6 +119,7 @@ import { handleEditIntercept } from "./inbound-stages/edit-intercept.js";
 import { handleGuardianActivationIntercept } from "./inbound-stages/guardian-activation-intercept.js";
 import { handleGuardianReplyIntercept } from "./inbound-stages/guardian-reply-intercept.js";
 import { prepareChannelInboundContent } from "./inbound-stages/inbound-content-prep.js";
+import { handleQuestionCallbackIntercept } from "./inbound-stages/question-callback-intercept.js";
 import {
   handleSlackReactionIntercept,
   isSlackReactionEvent,
@@ -124,6 +129,38 @@ import { tryTranscribeAudioAttachments } from "./inbound-stages/transcribe-audio
 import type { RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("runtime-http");
+
+/**
+ * Record an inferred "seen" signal for a handled channel callback tap
+ * (Telegram/Slack only). Best-effort — a failure never blocks the interaction.
+ * Mirrors the inline recording on the approval interception path.
+ */
+function recordChannelCallbackSeenSignal(
+  sourceChannel: string,
+  conversationId: string,
+  callbackData: string | undefined,
+): void {
+  if (sourceChannel !== "telegram" && sourceChannel !== "slack") return;
+  try {
+    const preview =
+      callbackData && callbackData.length > 80
+        ? callbackData.slice(0, 80) + "..."
+        : (callbackData ?? "");
+    recordConversationSeenSignal({
+      conversationId,
+      signalType: `${sourceChannel}_callback` as SignalType,
+      confidence: "inferred",
+      sourceChannel,
+      source: "inbound-message-handler",
+      evidenceText: `User tapped callback: '${preview}'`,
+    });
+  } catch (err) {
+    log.warn(
+      { err, conversationId },
+      "Failed to record seen signal for channel callback",
+    );
+  }
+}
 
 // Gates the per-channel admission floor stage. When off, the floor is never
 // enforced and inbound falls back to ACL-only behavior (the gateway also skips
@@ -1069,6 +1106,31 @@ export async function handleChannelInbound({
     return bootstrapResponse;
   }
 
+  // ── Question wizard tap (Stage 1) ──
+  // A `qst:` callback answers a parked ask_question wizard. Handle it before the
+  // guardian router / approval interception so it never reaches the agent as
+  // literal text, and return early whether the tap was fresh or stale. Outbound
+  // advance/finalize is the watcher's job — this only records the answer.
+  if (hasCallbackData) {
+    const questionTap = handleQuestionCallbackIntercept({
+      conversationId: result.conversationId,
+      callbackData: body.callbackData,
+    });
+    if (questionTap.handled) {
+      recordChannelCallbackSeenSignal(
+        sourceChannel,
+        result.conversationId,
+        body.callbackData,
+      );
+      return {
+        accepted: true,
+        duplicate: false,
+        eventId: result.eventId,
+        question: questionTap.type,
+      };
+    }
+  }
+
   // All guardian reply routing flows through the guardian reply router below
   // (routeGuardianReply), which handles request code matching, callback
   // parsing, and NL classification against the gateway's guardian_requests.
@@ -1235,6 +1297,37 @@ export async function handleChannelInbound({
         approval: "stale_ignored",
       };
     }
+  }
+
+  // ── Question wizard free-text answer (Stage 2) ──
+  // A typed reply while an ask_question wizard is parked answers the current
+  // question. Resolve it inline and return early — the parked turn continues.
+  // This is also the deadlock fix: routing the reply through background dispatch
+  // would defer it (withChannelTurnAdmission) until the conversation is idle,
+  // but the parked tool holds the processing lock, so idle never comes.
+  if (
+    !result.duplicate &&
+    !hasCallbackData &&
+    trimmedContent.length > 0 &&
+    getPendingQuestionInfoByConversation(result.conversationId).length > 0
+  ) {
+    const rec = recordQuestionFreeTextForConversation(
+      result.conversationId,
+      trimmedContent,
+    );
+    if (rec.status === "recorded") {
+      // The turn is fully handled here (no background dispatch); mark the inbound
+      // event processed so the retry sweep doesn't reprocess it.
+      markProcessed(result.eventId);
+      return {
+        accepted: true,
+        duplicate: false,
+        eventId: result.eventId,
+        question: rec.completed ? "answer_completed" : "answer_recorded",
+      };
+    }
+    // status "no_pending" (a race resolved the question between the check and
+    // the record) falls through to normal processing.
   }
 
   // For new (non-duplicate) messages, run the secret ingress check

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -17,6 +17,7 @@ import {
   getGuardianDelivery,
   guardianForChannel,
 } from "../../../contacts/guardian-delivery-reader.js";
+import { channelSupportsInlineQuestions } from "../../../daemon/channel-ui-capability.js";
 import { isConversationBusyError } from "../../../daemon/conversation-messaging.js";
 import type { AssistantEvent } from "../../../daemon/message-protocol.js";
 import type { TrustContext } from "../../../daemon/trust-context-types.js";
@@ -41,7 +42,19 @@ import {
   getApprovalInfoByConversation,
   getChannelApprovalPrompt,
 } from "../../channel-approvals.js";
-import { deliverChannelReply } from "../../gateway-client.js";
+import {
+  buildQuestionWizardStep,
+  buildQuestionWizardSummary,
+  clearQuestionWizardState,
+  ensureQuestionWizardState,
+  getPendingQuestionInfoByConversation,
+  getQuestionWizardStateByConversation,
+  setQuestionWizardMessageTs,
+} from "../../channel-questions.js";
+import {
+  deliverChannelReply,
+  deliverQuestionPrompt,
+} from "../../gateway-client.js";
 import type {
   ApprovalCopyGenerator,
   MessageProcessor,
@@ -197,6 +210,15 @@ export function processChannelMessageInBackground(
           replyCallbackUrl,
           assistantId,
           approvalCopyGenerator,
+        })
+      : undefined;
+    const stopQuestionWatcher = replyCallbackUrl
+      ? startPendingQuestionPromptWatcher({
+          conversationId,
+          sourceChannel,
+          externalChatId,
+          replyCallbackUrl,
+          assistantId,
         })
       : undefined;
     const stopTcApprovalNotifier = replyCallbackUrl
@@ -372,6 +394,7 @@ export function processChannelMessageInBackground(
       stopTypingHeartbeat?.();
       slackThinkingStatus?.stop();
       stopApprovalWatcher?.();
+      stopQuestionWatcher?.();
       stopTcApprovalNotifier?.();
     }
   }).catch((err) => {
@@ -857,6 +880,132 @@ function startPendingApprovalPromptWatcher(params: {
   void poll();
   return () => {
     active = false;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pending question wizard watcher
+// ---------------------------------------------------------------------------
+
+const PENDING_QUESTION_POLL_INTERVAL_MS = 300;
+
+/**
+ * Watch for a parked `ask_question` on a wizard-capable channel and render it
+ * as an inline-option wizard: deliver the first question, edit the same message
+ * in place to advance as answers land, and finalize it to a recap once the
+ * interaction resolves. The single outbound owner — taps (`qst:` callbacks) and
+ * free-text replies only mutate wizard state (see channel-questions.ts); this
+ * watcher reconciles the message to that state.
+ *
+ * Gated on the channel's question-wizard renderer, NOT the broader inline-options
+ * (approval) capability and NOT guardian identity: a question targets whoever is
+ * chatting, guardian or not, so — unlike the approval watcher — there is no
+ * bound-guardian check.
+ */
+function startPendingQuestionPromptWatcher(params: {
+  conversationId: string;
+  sourceChannel: ChannelId;
+  externalChatId: string;
+  replyCallbackUrl: string;
+  assistantId?: string;
+}): () => void {
+  const {
+    conversationId,
+    sourceChannel,
+    externalChatId,
+    replyCallbackUrl,
+    assistantId,
+  } = params;
+
+  if (!channelSupportsInlineQuestions(sourceChannel)) {
+    return () => {};
+  }
+
+  let active = true;
+  // The step each wizard's card currently reflects, keyed by requestId — drives
+  // the edit-to-advance. Local to this watcher (one per parked turn), so it
+  // never races another conversation's poller.
+  const renderedStep = new Map<string, number>();
+  const finalized = new Set<string>();
+  // Single-flight across polls: never overlap two outbound edits/sends.
+  let delivering = false;
+
+  const reconcile = async (): Promise<void> => {
+    if (delivering) return;
+
+    const info = getPendingQuestionInfoByConversation(conversationId)[0];
+    if (info) {
+      const state = ensureQuestionWizardState(info.requestId);
+      if (!state) return;
+      const step = buildQuestionWizardStep(state);
+      // All questions answered but not yet resolved — the next tick (once the
+      // interaction clears) finalizes.
+      if (!step) return;
+      if (renderedStep.get(info.requestId) === step.stepIndex) return;
+
+      delivering = true;
+      try {
+        const result = await deliverQuestionPrompt(
+          replyCallbackUrl,
+          externalChatId,
+          step.text,
+          step.question,
+          state.messageTs,
+          assistantId,
+        );
+        if (result.ts) setQuestionWizardMessageTs(info.requestId, result.ts);
+        renderedStep.set(info.requestId, step.stepIndex);
+      } finally {
+        delivering = false;
+      }
+      return;
+    }
+
+    // No pending question: finalize a lingering wizard card for this
+    // conversation (the interaction resolved — submitted, timed out, or
+    // superseded).
+    const stale = getQuestionWizardStateByConversation(conversationId);
+    if (!stale) return;
+    if (finalized.has(stale.requestId)) return;
+    finalized.add(stale.requestId);
+
+    if (stale.messageTs) {
+      delivering = true;
+      try {
+        await deliverChannelReply(replyCallbackUrl, {
+          chatId: externalChatId,
+          text: buildQuestionWizardSummary(stale),
+          messageTs: stale.messageTs,
+          assistantId,
+        });
+      } finally {
+        delivering = false;
+      }
+    }
+    clearQuestionWizardState(stale.requestId);
+  };
+
+  const poll = async (): Promise<void> => {
+    while (active) {
+      try {
+        await reconcile();
+      } catch (err) {
+        log.warn(
+          { err, conversationId },
+          "Pending question prompt watcher failed",
+        );
+      }
+      await delay(PENDING_QUESTION_POLL_INTERVAL_MS);
+    }
+  };
+
+  void poll();
+  return () => {
+    active = false;
+    // Best-effort finalize: if the wizard resolved in the last poll gap and the
+    // turn is ending before the next tick, reconcile once more so the card
+    // doesn't linger with stale buttons.
+    void reconcile().catch(() => {});
   };
 }
 

--- a/assistant/src/runtime/routes/inbound-stages/question-callback-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/question-callback-intercept.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the Stage 1 question tap intercept
+ * (`question-callback-intercept.ts`). Verifies a `qst:` callback is always
+ * consumed (never falls through to the agent as literal text), scoped to a
+ * pending question for the conversation, and records the answer.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { QuestionEntry } from "../../../api/events/question-request.js";
+import { _clearAllQuestionWizardState } from "../../channel-questions.js";
+import * as pendingInteractions from "../../pending-interactions.js";
+import { handleQuestionCallbackIntercept } from "./question-callback-intercept.js";
+
+const CONV = "conv-1";
+
+const entries: QuestionEntry[] = [
+  {
+    id: "q1",
+    question: "Which fruit?",
+    options: [
+      { id: "a", label: "Apple" },
+      { id: "b", label: "Banana" },
+    ],
+  },
+];
+
+function registerQuestion(
+  requestId: string,
+  rpcResolve: (value: unknown) => void = () => {},
+): void {
+  pendingInteractions.register(requestId, {
+    conversationId: CONV,
+    kind: "question",
+    rpcResolve,
+    metadata: { orderedIds: ["q1"], optionsById: { q1: ["a", "b"] } },
+    questionDetails: { entries },
+  });
+}
+
+beforeEach(() => {
+  pendingInteractions.clear();
+  _clearAllQuestionWizardState();
+});
+afterEach(() => {
+  pendingInteractions.clear();
+  _clearAllQuestionWizardState();
+});
+
+describe("handleQuestionCallbackIntercept", () => {
+  test("passes through non-question callbacks (other stages handle them)", () => {
+    expect(
+      handleQuestionCallbackIntercept({
+        conversationId: CONV,
+        callbackData: "apr:req-1:approve_once",
+      }),
+    ).toEqual({ handled: false });
+    expect(handleQuestionCallbackIntercept({ conversationId: CONV })).toEqual({
+      handled: false,
+    });
+  });
+
+  test("records a valid tap and reports completion", () => {
+    let resolved: unknown;
+    registerQuestion("req-1", (v) => (resolved = v));
+
+    const result = handleQuestionCallbackIntercept({
+      conversationId: CONV,
+      callbackData: "qst:req-1:q1:0",
+    });
+
+    expect(result).toEqual({ handled: true, type: "answer_completed" });
+    expect(resolved).toMatchObject({ overall: "completed" });
+    expect(pendingInteractions.get("req-1")).toBeUndefined();
+  });
+
+  test("consumes a qst: tap for a non-matching conversation as stale (never reaches the agent)", () => {
+    registerQuestion("req-1");
+    const result = handleQuestionCallbackIntercept({
+      conversationId: "other-conv",
+      callbackData: "qst:req-1:q1:0",
+    });
+    expect(result).toEqual({ handled: true, type: "stale_ignored" });
+    // The real conversation's question is untouched.
+    expect(pendingInteractions.get("req-1")).toBeDefined();
+  });
+
+  test("consumes an out-of-order tap as stale", () => {
+    registerQuestion("req-1");
+    const result = handleQuestionCallbackIntercept({
+      conversationId: CONV,
+      callbackData: "qst:req-1:q2:0",
+    });
+    expect(result).toEqual({ handled: true, type: "stale_ignored" });
+  });
+});

--- a/assistant/src/runtime/routes/inbound-stages/question-callback-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/question-callback-intercept.ts
@@ -1,0 +1,75 @@
+/**
+ * Stage 1 of channel question handling: intercept a `qst:` wizard tap.
+ *
+ * A tap on an `ask_question` option button arrives as `callbackData`
+ * (`qst:<requestId>:<questionId>:<optionIndex|skip>`, set as the message content
+ * by the gateway). This stage records the answer against the wizard and returns
+ * `handled` so the inbound handler returns early — a `qst:` callback must never
+ * reach the agent as literal text, whether it's fresh or stale.
+ *
+ * Outbound advance/finalize is the watcher's job (channel-questions.ts + the
+ * background-dispatch watcher own the single outbound message); this stage only
+ * mutates wizard state.
+ */
+import { getLogger } from "../../../util/logger.js";
+import {
+  getPendingQuestionInfoByConversation,
+  recordQuestionTap,
+} from "../../channel-questions.js";
+import { parseQuestionCallbackData } from "../channel-route-shared.js";
+
+const log = getLogger("runtime-http");
+
+export interface QuestionCallbackInterceptParams {
+  conversationId: string;
+  callbackData?: string;
+}
+
+export interface QuestionCallbackInterceptResult {
+  /** `true` when the callback was a `qst:` tap — the caller returns early. */
+  handled: boolean;
+  /** Outcome for logging / seen-signal wording. */
+  type?: "answer_recorded" | "answer_completed" | "stale_ignored";
+}
+
+/**
+ * Record a `qst:` wizard tap. Returns `{ handled: false }` when the callback is
+ * not a question tap (so other inbound stages run); otherwise always
+ * `{ handled: true }` — a well-formed `qst:` callback is consumed here even when
+ * stale (no matching pending question, out-of-order, or bad index).
+ */
+export function handleQuestionCallbackIntercept(
+  params: QuestionCallbackInterceptParams,
+): QuestionCallbackInterceptResult {
+  const { conversationId, callbackData } = params;
+  if (!callbackData) return { handled: false };
+
+  const parsed = parseQuestionCallbackData(callbackData);
+  if (!parsed) return { handled: false };
+
+  // Scope the tap to a pending question for THIS conversation. A stale button
+  // from a resolved (or different) conversation is consumed and ignored, never
+  // applied to another pending question.
+  const pendingForConversation =
+    getPendingQuestionInfoByConversation(conversationId);
+  if (!pendingForConversation.some((i) => i.requestId === parsed.requestId)) {
+    log.info(
+      { conversationId, requestId: parsed.requestId },
+      "Question callback for no matching pending question; ignoring stale tap",
+    );
+    return { handled: true, type: "stale_ignored" };
+  }
+
+  const result = recordQuestionTap(
+    parsed.requestId,
+    parsed.questionId,
+    parsed.selection,
+  );
+  if (result.status === "recorded") {
+    return {
+      handled: true,
+      type: result.completed ? "answer_completed" : "answer_recorded",
+    };
+  }
+  return { handled: true, type: "stale_ignored" };
+}

--- a/assistant/src/runtime/routes/question-routes.ts
+++ b/assistant/src/runtime/routes/question-routes.ts
@@ -22,15 +22,16 @@
 import { z } from "zod";
 
 import {
-  buildBatchEntries,
-  type QuestionBatchMetadata,
   type QuestionBatchSubmission,
   QuestionBatchValidationError,
-  type QuestionPromptResult,
 } from "../../permissions/question-prompter.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import * as pendingInteractions from "../pending-interactions.js";
+import {
+  readBatchMetadata,
+  resolvePendingQuestion,
+} from "../question-resolution.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -111,35 +112,20 @@ function handleQuestionResponse({ body }: RouteHandlerArgs) {
   const response: QuestionResponseBody = parsed.data;
   const { requestId } = response;
 
-  const interaction = pendingInteractions.get(requestId);
-  if (!interaction || interaction.kind !== "question") {
-    log.warn(
-      { requestId, foundKind: interaction?.kind },
-      "Question response for unknown or wrong-kind requestId",
-    );
-    throw new NotFoundError(
-      "No pending question interaction found for this requestId",
-    );
-  }
-
-  // Build + validate the result BEFORE touching `pendingInteractions`, so a
-  // bad payload leaves the pending interaction (and its timer) intact and the
-  // user gets another chance to submit a correct batch.
-  let result: QuestionPromptResult;
+  // The legacy single-question shim needs the interaction's stashed metadata to
+  // synthesize a one-element batch; peek (don't consume) before resolving.
+  let input;
   try {
-    if (response.kind === "close") {
-      const { orderedIds } = readBatchMetadata(interaction);
-      result = {
-        entries: orderedIds.map((id) => ({
-          questionId: id,
-          decision: "skipped" as const,
-        })),
-        overall: "closed",
-      };
-    } else {
-      const submissions = buildSubmissions(response, interaction);
-      result = buildCompletedResult(submissions, interaction);
-    }
+    input =
+      response.kind === "close"
+        ? ({ kind: "close" } as const)
+        : ({
+            kind: "submit",
+            submissions: buildSubmissions(
+              response,
+              pendingInteractions.get(requestId),
+            ),
+          } as const);
   } catch (err) {
     if (err instanceof QuestionBatchValidationError) {
       throw new BadRequestError(err.message);
@@ -147,34 +133,36 @@ function handleQuestionResponse({ body }: RouteHandlerArgs) {
     throw err;
   }
 
-  // Validation passed — deregister now to clear the prompter timer, then
-  // hand the result to the prompter's caller via rpcResolve.
-  pendingInteractions.resolve(
-    requestId,
-    response.kind === "close" ? "cancelled" : "answered",
-  );
+  const outcome = resolvePendingQuestion(requestId, input);
+
+  if (outcome.status === "not_found") {
+    log.warn(
+      { requestId },
+      "Question response for unknown or wrong-kind requestId",
+    );
+    throw new NotFoundError(
+      "No pending question interaction found for this requestId",
+    );
+  }
+  if (outcome.status === "invalid") {
+    throw new BadRequestError(outcome.message);
+  }
 
   log.info(
     {
       requestId,
-      overall: result.overall,
-      conversationId: interaction.conversationId,
+      overall: outcome.result.overall,
+      conversationId: outcome.conversationId,
     },
     "Question resolved",
   );
-
-  (
-    interaction.rpcResolve as
-      | ((value: QuestionPromptResult) => void)
-      | undefined
-  )?.(result);
 
   return { success: true };
 }
 
 /**
  * Normalize the incoming body to a `QuestionBatchSubmission[]` for the
- * submit/legacy paths. Returns `null` for the `close` path (no submissions).
+ * submit/legacy paths.
  */
 function buildSubmissions(
   body: SubmitBody | LegacyOptionBody | LegacyFreeTextBody,
@@ -201,47 +189,6 @@ function buildSubmissions(
     return [{ questionId, kind: "option", optionId: body.optionId }];
   }
   return [{ questionId, kind: "free_text", text: body.text }];
-}
-
-/**
- * Build a `completed` QuestionPromptResult from a batched submission and the
- * per-question metadata the prompter stashed on the interaction. Delegates
- * the validation + ordering loop to {@link buildBatchEntries} so the
- * prompter and the route share a single implementation.
- */
-function buildCompletedResult(
-  submissions: QuestionBatchSubmission[],
-  interaction: ReturnType<typeof pendingInteractions.get>,
-): QuestionPromptResult {
-  const { orderedIds, optionsById } = readBatchMetadata(interaction);
-  if (orderedIds.length === 0) {
-    throw new QuestionBatchValidationError(
-      "No registered question ids for this batch",
-    );
-  }
-  const entries = buildBatchEntries(
-    orderedIds,
-    (qid, oid) => (optionsById[qid] ?? []).includes(oid),
-    new Set(Object.keys(optionsById)),
-    submissions,
-  );
-  return { entries, overall: "completed" };
-}
-
-/**
- * Pull the prompter-stashed batch bookkeeping off a pending interaction.
- * Returns empty defaults if the metadata is absent.
- */
-function readBatchMetadata(
-  interaction: ReturnType<typeof pendingInteractions.get>,
-): QuestionBatchMetadata {
-  const meta = interaction?.metadata as
-    | Partial<QuestionBatchMetadata>
-    | undefined;
-  return {
-    orderedIds: meta?.orderedIds ?? [],
-    optionsById: meta?.optionsById ?? {},
-  };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/tools/ask-question/ask-question-tool.test.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.test.ts
@@ -342,6 +342,35 @@ describe("AskQuestionTool text fallback (supportsDynamicUi === false)", () => {
     expect(calls).toHaveLength(0);
     expect(result.content.toLowerCase()).toContain("no interactive user");
   });
+
+  test("parks (no text fallback) on a wizard-capable channel even without dynamic UI", async () => {
+    setNextResult(singleCompleted({ decision: "option", optionId: "a" }));
+
+    // A channel whose adapter renders the question wizard (Telegram) has no
+    // dynamic UI but must still park on the prompter — the watcher delivers the
+    // pending question as a native option wizard, so falling back to text would
+    // regress it to an untappable message.
+    await askQuestionTool.execute(
+      validInput,
+      makeContext({ supportsDynamicUi: false, supportsInlineQuestions: true }),
+    );
+
+    expect(calls).toHaveLength(1);
+  });
+
+  test("text fallback when a channel renders approval buttons but no question wizard", async () => {
+    // `supportsInlineQuestions` is narrower than "renders inline buttons": a
+    // channel with approval buttons but no question wizard (false/unset here)
+    // must degrade to text rather than park on a prompt no adapter can deliver.
+    const result = await askQuestionTool.execute(
+      validInput,
+      makeContext({ supportsDynamicUi: false, supportsInlineQuestions: false }),
+    );
+
+    expect(calls).toHaveLength(0);
+    expect(result.isError).toBe(false);
+    expect(result.content.toLowerCase()).toContain("plain-text");
+  });
 });
 
 describe("formatQuestionsAsTextFallback", () => {

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -237,21 +237,21 @@ export const askQuestionTool = {
     }
 
     // Text fallback only when the turn has NEITHER an app dynamic-UI surface NOR
-    // an inline-button channel adapter (e.g. SMS, email, or a channel with no
-    // inline renderer). Hand the model the formatted question(s) to present in
-    // its reply and wait for a free-text answer — mirrors the isInteractive
-    // guard above.
+    // a channel adapter that renders the question wizard (e.g. SMS, email, or a
+    // channel with approval buttons but no question wizard yet). Hand the model
+    // the formatted question(s) to present in its reply and wait for a free-text
+    // answer — mirrors the isInteractive guard above.
     //
     // Otherwise park on the prompter below: the app (`supportsDynamicUi`)
-    // renders the SSE question card, and an inline-button channel
-    // (`supportsInlineOptions`, e.g. Telegram) has the pending question
+    // renders the SSE question card, and a wizard-capable channel
+    // (`supportsInlineQuestions`, e.g. Telegram) has the pending question
     // delivered as a native option wizard by the channel watcher
     // (runtime/routes/inbound-stages/background-dispatch.ts) — a tap or a typed
     // reply resolves it. On a channel turn the prompter's SSE broadcast is a
     // harmless no-op (no SSE client), so the same park path serves both.
     if (
       context.supportsDynamicUi === false &&
-      context.supportsInlineOptions !== true
+      context.supportsInlineQuestions !== true
     ) {
       return {
         content: formatQuestionsAsTextFallback(questions),

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -236,17 +236,23 @@ export const askQuestionTool = {
       };
     }
 
-    // The active channel can't render the interactive question card (e.g.
-    // Telegram, SMS). A broadcast question_request would reach app clients but
-    // never the channel the turn came from, so the user would see nothing.
-    // Degrade to text: hand the model the formatted question(s) and options to
-    // present in its reply — which IS what gets delivered to the channel — and
-    // wait for a free-text answer. Mirrors the isInteractive guard above:
-    // return immediately instead of parking on a prompt the surface can't
-    // answer. (UI surface tools like ui_show are instead dropped from the wire
-    // for these channels; ask_question stays available because a question with
-    // options reads cleanly as text.)
-    if (context.supportsDynamicUi === false) {
+    // Text fallback only when the turn has NEITHER an app dynamic-UI surface NOR
+    // an inline-button channel adapter (e.g. SMS, email, or a channel with no
+    // inline renderer). Hand the model the formatted question(s) to present in
+    // its reply and wait for a free-text answer — mirrors the isInteractive
+    // guard above.
+    //
+    // Otherwise park on the prompter below: the app (`supportsDynamicUi`)
+    // renders the SSE question card, and an inline-button channel
+    // (`supportsInlineOptions`, e.g. Telegram) has the pending question
+    // delivered as a native option wizard by the channel watcher
+    // (runtime/routes/inbound-stages/background-dispatch.ts) — a tap or a typed
+    // reply resolves it. On a channel turn the prompter's SSE broadcast is a
+    // harmless no-op (no SSE client), so the same park path serves both.
+    if (
+      context.supportsDynamicUi === false &&
+      context.supportsInlineOptions !== true
+    ) {
       return {
         content: formatQuestionsAsTextFallback(questions),
         isError: false,

--- a/assistant/src/tools/tool-types.ts
+++ b/assistant/src/tools/tool-types.ts
@@ -241,13 +241,14 @@ export interface ToolContext {
    */
   supportsDynamicUi?: boolean;
   /**
-   * Whether the current turn's channel can render inline tappable options
-   * (question option pickers, approval buttons) natively; `false`/absent on
-   * channels without an inline-button adapter. UI-dependent tools read this to
-   * deliver a channel-native option prompt instead of plain text. Distinct from
-   * `supportsDynamicUi` (the app's dynamic-UI surfaces).
+   * Whether the current turn's channel renders the `ask_question` wizard
+   * natively (inline option buttons advanced in place); `false`/absent on
+   * channels whose adapter does not implement it. `ask_question` reads this to
+   * park on a channel-native option wizard instead of returning plain text.
+   * Narrower than "renders inline buttons" (approvals) — see the ToolContext
+   * field of the same name.
    */
-  supportsInlineOptions?: boolean;
+  supportsInlineQuestions?: boolean;
   /** When true, tools with side effects should always prompt for confirmation. */
   forcePromptSideEffects?: boolean;
   /**

--- a/assistant/src/tools/tool-types.ts
+++ b/assistant/src/tools/tool-types.ts
@@ -240,6 +240,14 @@ export interface ToolContext {
    * equivalent instead of emitting a surface the channel silently drops.
    */
   supportsDynamicUi?: boolean;
+  /**
+   * Whether the current turn's channel can render inline tappable options
+   * (question option pickers, approval buttons) natively; `false`/absent on
+   * channels without an inline-button adapter. UI-dependent tools read this to
+   * deliver a channel-native option prompt instead of plain text. Distinct from
+   * `supportsDynamicUi` (the app's dynamic-UI surfaces).
+   */
+  supportsInlineOptions?: boolean;
   /** When true, tools with side effects should always prompt for confirmation. */
   forcePromptSideEffects?: boolean;
   /**

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -199,6 +199,16 @@ export interface ToolContext {
    */
   supportsDynamicUi?: boolean;
   /**
+   * Whether the current turn's channel can render inline tappable options
+   * (question option pickers, approval buttons) natively — `true` on channels
+   * with an inline-button adapter (Telegram, WhatsApp, Slack), `false`/absent
+   * elsewhere. UI-dependent tools read this to deliver a channel-native option
+   * prompt instead of plain text. Distinct from `supportsDynamicUi` (the app's
+   * dynamic-UI surfaces): a text-only channel supports inline options without
+   * dynamic UI.
+   */
+  supportsInlineOptions?: boolean;
+  /**
    * When set, the tool execution is part of a task run. Used to retrieve ephemeral permission rules.
    * @legacy
    */

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -199,15 +199,16 @@ export interface ToolContext {
    */
   supportsDynamicUi?: boolean;
   /**
-   * Whether the current turn's channel can render inline tappable options
-   * (question option pickers, approval buttons) natively — `true` on channels
-   * with an inline-button adapter (Telegram, WhatsApp, Slack), `false`/absent
-   * elsewhere. UI-dependent tools read this to deliver a channel-native option
-   * prompt instead of plain text. Distinct from `supportsDynamicUi` (the app's
-   * dynamic-UI surfaces): a text-only channel supports inline options without
-   * dynamic UI.
+   * Whether the current turn's channel renders the `ask_question` wizard
+   * natively (inline option buttons advanced in place) — `true` on channels
+   * whose adapter implements it (Telegram today), `false`/absent elsewhere.
+   * `ask_question` reads this to park on a channel-native option wizard instead
+   * of returning a plain-text fallback. Narrower than "renders inline buttons"
+   * (approvals): a channel can render approval buttons yet not implement the
+   * question wizard, in which case this stays `false` so the turn degrades to
+   * text rather than parking on a prompt no adapter can deliver.
    */
-  supportsInlineOptions?: boolean;
+  supportsInlineQuestions?: boolean;
   /**
    * When set, the tool execution is part of a task run. Used to retrieve ephemeral permission rules.
    * @legacy

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -196,6 +196,13 @@ export type RuntimeInboundResponse = {
     | "assistant_turn"
     | "guardian_decision_applied"
     | "stale_ignored";
+  /**
+   * Set when a `qst:` wizard tap (or a free-text answer to a parked question)
+   * was consumed by the runtime. The gateway does not act on it — Telegram is a
+   * direct-delivery channel, so the daemon's question watcher owns advancing and
+   * finalizing the wizard card. Typed here so the response contract is complete.
+   */
+  question?: "answer_recorded" | "answer_completed" | "stale_ignored";
   assistantMessage?: {
     id: string;
     role: "assistant";

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -27,6 +27,9 @@ export {
   ChannelDeliveryResultSchema,
   ChannelReplyPayloadSchema,
   PermissionRequestDetailsSchema,
+  QuestionUIEntrySchema,
+  QuestionUIMetadataSchema,
+  QuestionUIOptionSchema,
   SlackStreamOpSchema,
   SlackStreamTaskSchema,
 } from "./outbound-contract.js";
@@ -38,6 +41,9 @@ export type {
   ChannelDeliveryResult,
   ChannelReplyPayload,
   PermissionRequestDetails,
+  QuestionUIEntry,
+  QuestionUIMetadata,
+  QuestionUIOption,
   SlackStreamOp,
   SlackStreamTask,
 } from "./outbound-contract.js";

--- a/packages/gateway-client/src/outbound-contract.ts
+++ b/packages/gateway-client/src/outbound-contract.ts
@@ -66,6 +66,50 @@ export const ApprovalUIMetadataSchema = z.object({
 export type ApprovalUIMetadata = z.infer<typeof ApprovalUIMetadataSchema>;
 
 // ---------------------------------------------------------------------------
+// Question UI types
+// ---------------------------------------------------------------------------
+
+/** One selectable option in a question. `id` is the LLM-supplied option id; it
+ *  is resolved server-side from a callback-carried index and never placed on
+ *  the wire in `callback_data`. */
+export const QuestionUIOptionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+});
+
+export type QuestionUIOption = z.infer<typeof QuestionUIOptionSchema>;
+
+/** One question in a (possibly batched) `ask_question` prompt. `id` is the
+ *  daemon-assigned handle (`q1`..`q5`); the option set matches the tool's 2–4
+ *  bound with an always-available free-text path. */
+export const QuestionUIEntrySchema = z.object({
+  id: z.string(),
+  question: z.string(),
+  description: z.string().optional(),
+  options: z.array(QuestionUIOptionSchema).min(2).max(4),
+  freeTextPlaceholder: z.string().optional(),
+});
+
+export type QuestionUIEntry = z.infer<typeof QuestionUIEntrySchema>;
+
+/**
+ * Channel-native rendering payload for the `ask_question` tool — the "what" a
+ * per-adapter renderer turns into inline buttons (Telegram inline keyboard,
+ * Slack Block Kit). Carries the full batch (≤5); a channel adapter renders one
+ * entry at a time as an edit-in-place wizard and resolves the batch once every
+ * entry is answered or skipped. `plainTextFallback` is the text rendering used
+ * when inline delivery is unavailable.
+ */
+export const QuestionUIMetadataSchema = z.object({
+  requestId: z.string(),
+  questions: z.array(QuestionUIEntrySchema).min(1).max(5),
+  plainTextFallback: z.string(),
+});
+
+export type QuestionUIMetadata = z.infer<typeof QuestionUIMetadataSchema>;
+
+// ---------------------------------------------------------------------------
 // Slack streaming operations
 // ---------------------------------------------------------------------------
 
@@ -168,6 +212,10 @@ export const ChannelReplyPayloadSchema = z.object({
   assistantId: z.string().optional(),
   attachments: z.array(AttachmentMetadataSchema).optional(),
   approval: ApprovalUIMetadataSchema.optional(),
+  /** Channel-native `ask_question` prompt. Rendered as inline option buttons by
+   *  the per-adapter renderer; pair with `messageTs` to advance the wizard
+   *  in-place. */
+  question: QuestionUIMetadataSchema.optional(),
   chatAction: z.literal("typing").optional(),
   /**
    * When true, deliver via `chat.postEphemeral` so only the target `user`


### PR DESCRIPTION
Superseded by #39228, which delivers the same user-facing feature (tappable `ask_question` options on channels) by extending the existing guardian-request pipeline instead of building a question-specific delivery stack (own contract, callback scheme, watcher, wizard state machine, and inbound stages). The pieces of this branch that survived — the shared `resolvePendingQuestion` core and the `question-routes` refactor — were re-landed there.