### PR TITLE
fix(web): image-gen card shows when a provider API key is already saved

### DIFF
--- a/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.test.tsx
@@ -68,6 +68,17 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
 }));
 
+mock.module("@/domains/settings/ai/use-stored-credential-presence", () => ({
+  useStoredCredentialPresence: () => ({
+    hasStoredCredential: false,
+    isLoading: false,
+  }),
+  credentialPresenceQueryKey: (...parts: unknown[]) => [
+    "credential-presence-test",
+    ...parts,
+  ],
+}));
+
 const provisionedKeys: Array<{ provider: string; key: string }> = [];
 mock.module("@/domains/settings/ai/use-daemon-config", () => ({
   useProvisionProviderKey: () => (provider: string, key: string) => {

--- a/clients/web/src/domains/settings/ai/image-generation-card.tsx
+++ b/clients/web/src/domains/settings/ai/image-generation-card.tsx
@@ -25,7 +25,12 @@ import {
 
 import { ByoServiceCard } from "@/domains/settings/ai/shared-ui";
 import { ResetButton, SaveButton } from "@/components/service-form-controls";
+import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
 import { useProvisionProviderKey } from "@/domains/settings/ai/use-daemon-config";
+import {
+  credentialPresenceQueryKey,
+  useStoredCredentialPresence,
+} from "@/domains/settings/ai/use-stored-credential-presence";
 import {
   configGetOptions,
   configGetQueryKey,
@@ -110,6 +115,14 @@ export function ImageGenerationCard() {
 
   const requiresApiKey = provider === "gemini" || provider === "openai";
 
+  const { hasStoredCredential: imageGenHasStoredKey } =
+    useStoredCredentialPresence({
+      assistantId,
+      credentialKind: "api_key",
+      credentialName: provider,
+      enabled: requiresApiKey,
+    });
+
   // Model reconciliation is derived (`effectiveModel`), so a provider change
   // needs no imperative snap.
   const handleProviderChange = setDraftProvider;
@@ -181,6 +194,15 @@ export function ImageGenerationCard() {
       setLocalSetting(LS_IMAGE_GEN_PROVIDER, provider);
       setLocalSetting(LS_IMAGE_GEN_MODEL, effectiveModel);
       if (hasUserKey) {
+        // Optimistic update: mark key as stored immediately, then
+        // background-refetch confirms server state.
+        const presenceKey = credentialPresenceQueryKey(
+          assistantId,
+          "api_key",
+          provider,
+        );
+        queryClient.setQueryData(presenceKey, true);
+        void queryClient.invalidateQueries({ queryKey: presenceKey });
         setImageGenApiKey("");
       }
       toast.success("Image generation settings saved.");
@@ -235,11 +257,12 @@ export function ImageGenerationCard() {
             type="password"
             value={imageGenApiKey}
             onChange={(e) => setImageGenApiKey(e.target.value)}
-            placeholder={
+            placeholder={secretPlaceholder(
               provider === "openai"
                 ? "Enter your OpenAI API key"
-                : "Enter your Gemini API key"
-            }
+                : "Enter your Gemini API key",
+              imageGenHasStoredKey,
+            )}
             fullWidth
           />
         )}


### PR DESCRIPTION
## Summary
- The image-generation card's API Key input gave no indication that a key was already provisioned — after saving (the input clears by design) it looked like there was no key at all.
- Adopts the exact saved-credential pattern used by the web-search and web-fetch cards: `useStoredCredentialPresence` for the selected BYOK provider (`openai`/`gemini`), `secretPlaceholder` to render `••••••••` when a key exists, and the optimistic presence-cache update + invalidation after a successful save.
- No other behavior changes to the card.

## Original prompt
While testing managed image generation, the user entered an OpenAI key in the Image Generation settings card and saved it, but the card still showed the empty "Enter your OpenAI API key" placeholder, making it look like no key was stored. They asked to make it clear when a saved API key exists, using the same treatment the sibling web-search/web-fetch cards already have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jxg6rVrcc2G6PwZce8BerP
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/39150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->