### PR TITLE
refactor(web): move targetsMet/ProvisioningDimensions to lib/billing for cross-domain use

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
@@ -9,10 +9,16 @@
  * pure function over polled inputs so every transition is unit-testable.
  */
 
-import type { MachineSizeEnum } from "@/generated/api/types.gen";
-import { machineSizeRank } from "@/lib/billing/machine-sizes";
+import {
+  type ProvisioningDimensions,
+  targetsMet,
+} from "@/lib/billing/provisioning-targets";
 
 import { PROVISION_STALL_MS, PROVISION_WAIT_GRACE_MS } from "./utils";
+
+// Re-exported from lib/billing so existing pro-onboarding consumers keep
+// importing them from here unchanged.
+export { targetsMet, type ProvisioningDimensions };
 
 export type ProvisioningStateKind =
   | "CONFIRMING"
@@ -35,11 +41,6 @@ export type ProvisioningServerVerdict =
   | "in_progress"
   | "started"
   | "not_applicable";
-
-export interface ProvisioningDimensions {
-  machineSize: MachineSizeEnum | null;
-  storageGib: number | null;
-}
 
 export interface DeriveProvisioningInput {
   planId: string | null | undefined;
@@ -75,27 +76,6 @@ export interface ProvisioningSnapshot {
   state: ProvisioningStateKind;
   /** Still WAITING past the grace window — the UI softens its copy. */
   softWaiting: boolean;
-}
-
-/**
- * A dimension with a null target is satisfied (e.g. the Mighty package has no
- * machine tier); a non-null target needs a known actual at or above it.
- * Machine sizes compare by rank, storage by GiB.
- */
-export function targetsMet(
-  targets: ProvisioningDimensions | null,
-  actuals: ProvisioningDimensions | null,
-): boolean {
-  if (!targets) return false;
-  const machineMet =
-    targets.machineSize == null ||
-    (actuals?.machineSize != null &&
-      machineSizeRank(actuals.machineSize) >=
-        machineSizeRank(targets.machineSize));
-  const storageMet =
-    targets.storageGib == null ||
-    (actuals?.storageGib != null && actuals.storageGib >= targets.storageGib);
-  return machineMet && storageMet;
 }
 
 export function deriveProvisioningState(

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-machine.ts
@@ -16,8 +16,8 @@ import {
 
 import { PROVISION_STALL_MS, PROVISION_WAIT_GRACE_MS } from "./utils";
 
-// Re-exported from lib/billing so existing pro-onboarding consumers keep
-// importing them from here unchanged.
+// The provisioning-target primitives live in lib/billing (shared across
+// domains); this module re-exports them as the pro-onboarding entrypoint.
 export { targetsMet, type ProvisioningDimensions };
 
 export type ProvisioningStateKind =

--- a/clients/web/src/lib/billing/provisioning-targets.test.ts
+++ b/clients/web/src/lib/billing/provisioning-targets.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+import { targetsMet } from "./provisioning-targets";
+
+describe("targetsMet", () => {
+  test("null targets are never met", () => {
+    expect(targetsMet(null, { machineSize: "large", storageGib: 50 })).toBe(
+      false,
+    );
+  });
+
+  test("both dimensions met → true", () => {
+    expect(
+      targetsMet(
+        { machineSize: "large", storageGib: 50 },
+        { machineSize: "large", storageGib: 50 },
+      ),
+    ).toBe(true);
+  });
+
+  test("machine compared by rank — a larger actual than the target counts", () => {
+    expect(
+      targetsMet(
+        { machineSize: "large", storageGib: 50 },
+        { machineSize: "extra_large", storageGib: 50 },
+      ),
+    ).toBe(true);
+  });
+
+  test("machine below the target → false", () => {
+    expect(
+      targetsMet(
+        { machineSize: "large", storageGib: 50 },
+        { machineSize: "small", storageGib: 50 },
+      ),
+    ).toBe(false);
+  });
+
+  test("machine met but storage short → false", () => {
+    expect(
+      targetsMet(
+        { machineSize: "large", storageGib: 50 },
+        { machineSize: "large", storageGib: 25 },
+      ),
+    ).toBe(false);
+  });
+
+  test("null machine target (Mighty) is satisfied by storage alone", () => {
+    expect(
+      targetsMet(
+        { machineSize: null, storageGib: 25 },
+        { machineSize: "small", storageGib: 25 },
+      ),
+    ).toBe(true);
+  });
+
+  test("null storage target dimension is treated as satisfied", () => {
+    expect(
+      targetsMet(
+        { machineSize: "medium", storageGib: null },
+        { machineSize: "medium", storageGib: null },
+      ),
+    ).toBe(true);
+  });
+
+  test("both target dimensions null → met", () => {
+    expect(
+      targetsMet(
+        { machineSize: null, storageGib: null },
+        { machineSize: "small", storageGib: 10 },
+      ),
+    ).toBe(true);
+  });
+
+  test("null actuals cannot meet a non-null machine target", () => {
+    expect(
+      targetsMet({ machineSize: "large", storageGib: null }, null),
+    ).toBe(false);
+  });
+
+  test("null actual storage cannot meet a non-null storage target", () => {
+    expect(
+      targetsMet(
+        { machineSize: null, storageGib: 50 },
+        { machineSize: null, storageGib: null },
+      ),
+    ).toBe(false);
+  });
+});

--- a/clients/web/src/lib/billing/provisioning-targets.ts
+++ b/clients/web/src/lib/billing/provisioning-targets.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure provisioning-target helpers shared across domains.
+ *
+ * `targetsMet` compares an assistant's actual machine size / provisioned
+ * storage against purchased ceilings. It lives here (rather than in the
+ * pro-onboarding domain) so cross-domain consumers — e.g. the onboarding
+ * hatching screen — can reuse it without an ESLint-banned cross-domain import.
+ */
+
+import type { MachineSizeEnum } from "@/generated/api/types.gen";
+import { machineSizeRank } from "./machine-sizes";
+
+export interface ProvisioningDimensions {
+  machineSize: MachineSizeEnum | null;
+  storageGib: number | null;
+}
+
+/**
+ * A dimension with a null target is satisfied (e.g. the Mighty package has no
+ * machine tier); a non-null target needs a known actual at or above it.
+ * Machine sizes compare by rank, storage by GiB.
+ */
+export function targetsMet(
+  targets: ProvisioningDimensions | null,
+  actuals: ProvisioningDimensions | null,
+): boolean {
+  if (!targets) {
+    return false;
+  }
+  const machineMet =
+    targets.machineSize == null ||
+    (actuals?.machineSize != null &&
+      machineSizeRank(actuals.machineSize) >=
+        machineSizeRank(targets.machineSize));
+  const storageMet =
+    targets.storageGib == null ||
+    (actuals?.storageGib != null && actuals.storageGib >= targets.storageGib);
+  return machineMet && storageMet;
+}


### PR DESCRIPTION
## Summary
- Relocate the pure targetsMet + ProvisioningDimensions to lib/billing/provisioning-targets.ts.
- provisioning-machine.ts re-exports them; all existing consumers unchanged. Zero behavior change.

Part of plan: pricing-checkout-flow.md (PR 2 of 3)