### PR TITLE
feat(web): /assistant/checkout deep-link route that starts Stripe checkout for a package

### DIFF
--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -14,6 +14,7 @@ import { MemoryRouter, useLocation } from "react-router";
 
 import * as sdkGen from "@/generated/api/sdk.gen";
 import * as browserRuntime from "@/runtime/browser";
+import * as orgReadyMod from "@/hooks/use-is-org-ready";
 import * as platformGateMod from "@/hooks/use-platform-gate";
 import type { PlatformGateState } from "@/hooks/use-platform-gate";
 
@@ -25,6 +26,8 @@ const upgradeCalls: Captured[] = [];
 let openedUrl: string | null = null;
 // Gate value the mocked `usePlatformGate` returns (default: session-only full).
 let gateValue: PlatformGateState = "full";
+// Org-readiness the mocked `useIsOrgReady` returns (default: hydrated/ready).
+let orgReadyValue = true;
 // When true the upgrade rejects — drives the error path. Otherwise it resolves
 // with `upgradeData`.
 let upgradeRejects = false;
@@ -58,6 +61,11 @@ mock.module("@/hooks/use-platform-gate", () => ({
   usePlatformGate: () => gateValue,
 }));
 
+mock.module("@/hooks/use-is-org-ready", () => ({
+  ...orgReadyMod,
+  useIsOrgReady: () => orgReadyValue,
+}));
+
 const { CheckoutPage } = await import("./checkout-page");
 
 function LocationProbe() {
@@ -83,6 +91,7 @@ beforeEach(() => {
   upgradeCalls.length = 0;
   openedUrl = null;
   gateValue = "full";
+  orgReadyValue = true;
   upgradeRejects = false;
   upgradeData = { status: "redirect", checkout_url: CHECKOUT_URL, message: "" };
   sessionStorage.removeItem(INTENT_KEY);
@@ -113,6 +122,37 @@ describe("CheckoutPage", () => {
       kind: "package",
       packageKey: "super",
     });
+  });
+
+  test("holds the upgrade until org is ready, then fires once it hydrates", async () => {
+    orgReadyValue = false;
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    // A fresh element each render so the rerender doesn't hit React's
+    // same-reference bailout and actually re-reads the org-readiness value.
+    const makeTree = () => (
+      <MemoryRouter initialEntries={["/assistant/checkout?package=super"]}>
+        <QueryClientProvider client={client}>
+          <CheckoutPage />
+        </QueryClientProvider>
+        <LocationProbe />
+      </MemoryRouter>
+    );
+    const { getByLabelText, getByTestId, rerender } = render(makeTree());
+
+    // Org store not yet hydrated: the spinner shows, nothing fires, and the
+    // route holds instead of redirecting.
+    getByLabelText("Preparing checkout");
+    expect(upgradeCalls.length).toBe(0);
+    expect(getByTestId("loc").textContent).toBe(
+      "/assistant/checkout?package=super",
+    );
+
+    // Once the org id lands, the upgrade fires exactly once.
+    orgReadyValue = true;
+    rerender(makeTree());
+    await waitFor(() => expect(upgradeCalls.length).toBe(1));
   });
 
   test("a no_op result navigates to plans and stashes no intent", async () => {

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Tests for the deep-link CheckoutPage.
+ *
+ * Mirrors plans-page.test.tsx's interaction harness: the generated SDK, the
+ * browser runtime, and the platform gate are `mock.module()`'d, and
+ * `CheckoutPage` is dynamically imported after the mocks register. A
+ * `LocationProbe` reads the router location so redirects can be asserted.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, useLocation } from "react-router";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+import * as browserRuntime from "@/runtime/browser";
+import * as platformGateMod from "@/hooks/use-platform-gate";
+import type { PlatformGateState } from "@/hooks/use-platform-gate";
+
+const CHECKOUT_URL = "https://stripe.test/checkout/session";
+const INTENT_KEY = "vellum.pro-checkout-intent";
+
+type Captured = { body?: unknown };
+const upgradeCalls: Captured[] = [];
+let openedUrl: string | null = null;
+// Gate value the mocked `usePlatformGate` returns (default: session-only full).
+let gateValue: PlatformGateState = "full";
+// When true the upgrade rejects — drives the error path. Otherwise it resolves
+// with `upgradeData`.
+let upgradeRejects = false;
+let upgradeData: { status: string; checkout_url: string | null; message: string } = {
+  status: "redirect",
+  checkout_url: CHECKOUT_URL,
+  message: "",
+};
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingSubscriptionUpgradeCreate: (opts: Captured) => {
+    upgradeCalls.push(opts);
+    if (upgradeRejects) {
+      return Promise.reject(new Error("checkout failed"));
+    }
+    return Promise.resolve({ data: upgradeData, response: { ok: true } });
+  },
+}));
+
+mock.module("@/runtime/browser", () => ({
+  ...browserRuntime,
+  openUrl: (url: string) => {
+    openedUrl = url;
+    return Promise.resolve();
+  },
+}));
+
+mock.module("@/hooks/use-platform-gate", () => ({
+  ...platformGateMod,
+  usePlatformGate: () => gateValue,
+}));
+
+const { CheckoutPage } = await import("./checkout-page");
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="loc">{location.pathname + location.search}</div>;
+}
+
+function renderCheckout(entry: string) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <QueryClientProvider client={client}>
+        <CheckoutPage />
+      </QueryClientProvider>
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  upgradeCalls.length = 0;
+  openedUrl = null;
+  gateValue = "full";
+  upgradeRejects = false;
+  upgradeData = { status: "redirect", checkout_url: CHECKOUT_URL, message: "" };
+  sessionStorage.removeItem(INTENT_KEY);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CheckoutPage", () => {
+  test("valid package + full gate fires the upgrade, stashes intent, opens Stripe", async () => {
+    renderCheckout("/assistant/checkout?package=super");
+
+    await waitFor(() => expect(upgradeCalls.length).toBe(1));
+    expect(upgradeCalls[0]!.body).toEqual({
+      target_plan_id: "pro",
+      package: "super",
+      confirm: true,
+      return_target: "web",
+    });
+
+    await waitFor(() => expect(openedUrl).toBe(CHECKOUT_URL));
+    // The package intent is stashed before the redirect so the post-checkout
+    // provisioning screen can render it.
+    const stashed = sessionStorage.getItem(INTENT_KEY);
+    expect(stashed).not.toBeNull();
+    expect(JSON.parse(stashed!)).toMatchObject({
+      kind: "package",
+      packageKey: "super",
+    });
+  });
+
+  test("a no_op result navigates to plans and stashes no intent", async () => {
+    upgradeData = { status: "no_op", checkout_url: null, message: "" };
+    const { getByTestId } = renderCheckout("/assistant/checkout?package=super");
+
+    await waitFor(() => expect(upgradeCalls.length).toBe(1));
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
+    );
+    expect(openedUrl).toBeNull();
+    expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+  });
+
+  test("an error renders the retry UI, and Try again re-fires the upgrade", async () => {
+    upgradeRejects = true;
+    const { findByRole } = renderCheckout("/assistant/checkout?package=super");
+
+    await waitFor(() => expect(upgradeCalls.length).toBe(1));
+    // The error state offers a retry and a non-dead-end escape to plans.
+    await findByRole("button", { name: "Try again" });
+    await findByRole("link", { name: "View plans" });
+
+    fireEvent.click(await findByRole("button", { name: "Try again" }));
+    await waitFor(() => expect(upgradeCalls.length).toBe(2));
+  });
+
+  test("missing package navigates to plans without firing the upgrade", async () => {
+    const { getByTestId } = renderCheckout("/assistant/checkout");
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
+    );
+    expect(upgradeCalls.length).toBe(0);
+  });
+
+  test("a gated session skips the upgrade and falls back to plans", async () => {
+    gateValue = "gated";
+    const { getByTestId } = renderCheckout("/assistant/checkout?package=super");
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
+    );
+    expect(upgradeCalls.length).toBe(0);
+  });
+});

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -1,0 +1,116 @@
+import { Loader2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router";
+
+import { useMutation } from "@tanstack/react-query";
+
+import { organizationsBillingSubscriptionUpgradeCreateMutation } from "@/generated/api/@tanstack/react-query.gen";
+import { usePlatformGate } from "@/hooks/use-platform-gate";
+import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
+import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
+import { openUrl } from "@/runtime/browser";
+import { routes } from "@/utils/routes";
+import { Button } from "@vellumai/design-library/components/button";
+
+/**
+ * Deep-link checkout entrypoint (`/assistant/checkout?package=<slug>`). The
+ * marketing pricing CTAs route a chosen Pro package here — reachable by a
+ * brand-new user with no assistant yet, so the route sits outside
+ * `ActiveAssistantGate` and is exempted from the resolver's no-assistant funnel
+ * redirect. This page fires the subscription-upgrade POST and hands off to
+ * Stripe.
+ *
+ * Flow:
+ *   - Missing `package` → back to the plans takeover.
+ *   - Gate `"disabled"`/`"gated"` → back to plans (its own gating owns the
+ *     messaging).
+ *   - Gate `"full"` → fire the upgrade once and either redirect to Stripe
+ *     (`redirect`), fall back to plans (`no_op`, already Pro), or surface a
+ *     retryable error. It never dead-ends.
+ */
+export function CheckoutPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const packageKey = searchParams.get("package") ?? "";
+  // Default (session-only) gate: a signed-in platform session reads `"full"`
+  // even without an active assistant. See `use-platform-gate.ts`.
+  const gate = usePlatformGate();
+
+  const { mutateAsync } = useMutation(
+    organizationsBillingSubscriptionUpgradeCreateMutation(),
+  );
+  const [failed, setFailed] = useState(false);
+  // StrictMode double-invokes mount effects; the ref fires the upgrade once.
+  const startedRef = useRef(false);
+
+  const runCheckout = useCallback(async () => {
+    setFailed(false);
+    try {
+      const result = await mutateAsync({
+        body: {
+          target_plan_id: "pro",
+          package: packageKey,
+          confirm: true,
+          return_target: checkoutReturnTarget(),
+        },
+      });
+      if (result.status === "redirect" && result.checkout_url) {
+        // Stash the selection so the post-checkout provisioning screen can show
+        // the purchased package before the subscribe webhook lands.
+        saveCheckoutIntent({ kind: "package", packageKey });
+        void openUrl(result.checkout_url);
+        return;
+      }
+      // `no_op` — already Pro, nothing to provision. Hand off to the plans
+      // takeover rather than stranding the user on a blank splash.
+      navigate(routes.plans, { replace: true });
+    } catch {
+      setFailed(true);
+    }
+  }, [mutateAsync, navigate, packageKey]);
+
+  useEffect(() => {
+    // No package to check out, or a session that can't reach checkout: fall
+    // back to the plans takeover, which owns its own gating and messaging.
+    if (!packageKey || gate === "disabled" || gate === "gated") {
+      navigate(routes.plans, { replace: true });
+      return;
+    }
+    if (gate !== "full" || startedRef.current) {
+      return;
+    }
+    startedRef.current = true;
+    void runCheckout();
+  }, [gate, navigate, packageKey, runCheckout]);
+
+  if (failed) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-4 px-6 text-center">
+        <p className="text-[var(--content-default)]">
+          We couldn&rsquo;t start your checkout. Please try again.
+        </p>
+        <div className="flex items-center gap-4">
+          <Button onClick={() => void runCheckout()}>Try again</Button>
+          <Link
+            to={routes.plans}
+            className="text-sm text-[var(--content-tertiary)] underline"
+          >
+            View plans
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3">
+      <Loader2
+        className="h-6 w-6 animate-spin text-[var(--content-tertiary)]"
+        aria-label="Preparing checkout"
+      />
+      <p className="text-sm text-[var(--content-tertiary)]">
+        Preparing checkout&hellip;
+      </p>
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -5,6 +5,7 @@ import { Link, useNavigate, useSearchParams } from "react-router";
 import { useMutation } from "@tanstack/react-query";
 
 import { organizationsBillingSubscriptionUpgradeCreateMutation } from "@/generated/api/@tanstack/react-query.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
@@ -35,6 +36,10 @@ export function CheckoutPage() {
   // Default (session-only) gate: a signed-in platform session reads `"full"`
   // even without an active assistant. See `use-platform-gate.ts`.
   const gate = usePlatformGate();
+  // The request interceptor reads `Vellum-Organization-Id` from the org store,
+  // which hydrates asynchronously after auth. On a cold deep link the platform
+  // session can settle before the org id lands, so gate the fire on this too.
+  const isOrgReady = useIsOrgReady();
 
   const { mutateAsync } = useMutation(
     organizationsBillingSubscriptionUpgradeCreateMutation(),
@@ -76,12 +81,15 @@ export function CheckoutPage() {
       navigate(routes.plans, { replace: true });
       return;
     }
-    if (gate !== "full" || startedRef.current) {
+    // Hold until the platform gate is full AND the org store is ready. Firing
+    // before the org id hydrates sends a header-less request that fails; the
+    // "Preparing checkout…" spinner keeps showing meanwhile.
+    if (gate !== "full" || !isOrgReady || startedRef.current) {
       return;
     }
     startedRef.current = true;
     void runCheckout();
-  }, [gate, navigate, packageKey, runCheckout]);
+  }, [gate, isOrgReady, navigate, packageKey, runCheckout]);
 
   if (failed) {
     return (

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -535,6 +535,21 @@ describe("resolveNavigation", () => {
       ).toEqual(ALLOW);
     });
 
+    // Checkout is exempt from the no-assistant funnel, NOT from consent: a
+    // no-assistant user with a stale consent toggle deep-linking to checkout is
+    // routed to review-terms first, never straight into a paid Stripe session.
+    test("routes a stale-consent no-assistant user off /assistant/checkout to review-terms", () => {
+      expect(
+        guard(
+          s({ hasAssistants: false, analyticsConsentCurrent: false }),
+          "/assistant/checkout?package=super",
+        ),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/review-terms?returnTo=%2Fassistant%2Fcheckout%3Fpackage%3Dsuper",
+      });
+    });
+
     test("still funnels a no-assistant user returning to a billing URL", () => {
       expect(
         guard(

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -525,6 +525,25 @@ describe("resolveNavigation", () => {
       });
     });
 
+    // The marketing pricing CTAs deep-link a brand-new (no-assistant) user
+    // into `/assistant/checkout` to start Stripe checkout, so that route must
+    // NOT be funneled into onboarding — while every other billing surface still
+    // is, so a no-assistant user returning to a billing URL provisions first.
+    test("does not funnel a consent-settled no-assistant user off /assistant/checkout", () => {
+      expect(
+        guard(s({ hasAssistants: false }), "/assistant/checkout?package=super"),
+      ).toEqual(ALLOW);
+    });
+
+    test("still funnels a no-assistant user returning to a billing URL", () => {
+      expect(
+        guard(
+          s({ hasAssistants: false }),
+          "/assistant/settings/usage?tab=billing&session_id=x",
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/hatching" });
+    });
+
     test("redirects brand-new platform user with no assistant to privacy, unaffected by stale-toggle gate", () => {
       expect(
         guard(

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -286,12 +286,6 @@ function allowSetupRoutes(
 ): NavigationDecision | null {
   if (path === routes.reviewTerms) return { action: "allow" };
 
-  // The marketing pricing CTAs deep-link a brand-new user (no assistant yet)
-  // straight into Stripe checkout for a chosen package. Exempt that route from
-  // the no-assistant funnel redirect the same way onboarding paths are —
-  // `requireAuth` above still gates it, so only a signed-in user reaches here.
-  if (path === routes.checkout) return { action: "allow" };
-
   if (isOnboardingPath(path)) {
     if (path === routes.onboarding.hatching && !hasCompletedOnboarding(state)) {
       return { action: "redirect", to: onboardingEntrypoint(state.isLocalMode) };
@@ -304,10 +298,18 @@ function allowSetupRoutes(
 
 function requireAssistant(
   state: NavigationState,
-  _path: string,
+  path: string,
   pathnameWithSearch: string,
 ): NavigationDecision | null {
   if (state.hasAssistants) return null;
+
+  // The marketing pricing CTAs deep-link a brand-new user (no assistant yet)
+  // straight into Stripe checkout for a chosen package. Exempt that route from
+  // the no-assistant funnel redirect only here — `requireConsent` runs after
+  // this step, so consent is still enforced before any paid checkout starts.
+  // Every other billing surface still funnels a no-assistant user into
+  // provisioning first.
+  if (path === routes.checkout) return null;
 
   if (state.isLocalMode) {
     if (state.platformSession === "unknown") return { action: "wait" };

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -286,6 +286,12 @@ function allowSetupRoutes(
 ): NavigationDecision | null {
   if (path === routes.reviewTerms) return { action: "allow" };
 
+  // The marketing pricing CTAs deep-link a brand-new user (no assistant yet)
+  // straight into Stripe checkout for a chosen package. Exempt that route from
+  // the no-assistant funnel redirect the same way onboarding paths are —
+  // `requireAuth` above still gates it, so only a signed-in user reaches here.
+  if (path === routes.checkout) return { action: "allow" };
+
   if (isOnboardingPath(path)) {
     if (path === routes.onboarding.hatching && !hasCompletedOnboarding(state)) {
       return { action: "redirect", to: onboardingEntrypoint(state.isLocalMode) };

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -289,6 +289,17 @@ export const routeTree = [
           ],
         },
 
+        // Deep-link checkout — starts Stripe checkout for a package chosen on
+        // the marketing pricing page. Placed OUTSIDE ActiveAssistantGate (and
+        // the onboarding-completed guard) so a brand-new user with no assistant
+        // yet can reach it; `authMiddleware` on `/assistant` still applies, and
+        // the navigation resolver exempts it from the no-assistant funnel
+        // redirect. The page gates on the session-only platform gate itself.
+        {
+          path: "checkout",
+          lazy: { Component: () => import("@/domains/settings/billing/checkout-page").then((m) => m.CheckoutPage) },
+        },
+
         // Settings and logs require a resolved assistant. The gate
         // defers child rendering until the lifecycle reaches active/
         // self_hosted, so route components can use useActiveAssistantId().

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -185,6 +185,15 @@ export const routes = {
    *  chrome, a sibling of the settings/logs full-screen shells. */
   plans: r("/assistant/plans"),
 
+  /**
+   * Deep-link checkout entrypoint. The marketing pricing CTAs route here (via
+   * auth `returnTo`) with `?package=<slug>` to start Stripe checkout for a
+   * chosen Pro package. Sits behind auth but OUTSIDE `ActiveAssistantGate` so a
+   * brand-new user with no assistant can reach it; the resolver exempts it from
+   * the no-assistant funnel redirect.
+   */
+  checkout: r("/assistant/checkout"),
+
   settings: {
     root: r("/assistant/settings"),
     general: r("/assistant/settings/general"),


### PR DESCRIPTION
## Summary
- New session-gated /assistant/checkout?package= route: fires the subscription-upgrade POST and redirects to Stripe.
- Reachable by a no-assistant new user (outside ActiveAssistantGate; exempted from the funnel redirect).
- Handles no_op (already Pro), errors (retry + View plans), and missing package.

Part of plan: pricing-checkout-flow.md (PR 1 of 3)