### PR TITLE
feat(web): carry the selected package through signup and resume checkout after consent

### DIFF
--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -30,6 +30,14 @@ mock.module("@/lib/consent/consent-persistence", () => ({
   saveConsent: saveConsentMock,
 }));
 
+// Pending checkout intent — a pricing-CTA signup stashes the chosen package
+// (see navigation-resolver post-auth). Mutable so individual tests can pre-seed
+// it or leave it absent.
+let checkoutIntentValue: unknown = null;
+mock.module("@/lib/billing/checkout-intent", () => ({
+  readCheckoutIntent: () => checkoutIntentValue,
+}));
+
 const emitFunnelStepCompletedMock = mock((..._args: unknown[]) => {});
 mock.module("@/domains/onboarding/funnel-events", () => ({
   emitOnboardingFunnelStepCompleted: emitFunnelStepCompletedMock,
@@ -103,11 +111,13 @@ describe("PrivacyScreen — Start navigation", () => {
     emitFunnelStepCompletedMock.mockClear();
     nativePlatform = false;
     localMode = false;
+    checkoutIntentValue = null;
   });
   afterEach(() => {
     cleanup();
     nativePlatform = false;
     localMode = false;
+    checkoutIntentValue = null;
   });
 
   test("preview mode no-ops on Start without persisting consent", () => {
@@ -174,6 +184,45 @@ describe("PrivacyScreen — Start navigation", () => {
     clickStart();
 
     expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.hatching);
+  });
+
+  test("resumes checkout when a pending package intent is present", () => {
+    checkoutIntentValue = {
+      kind: "package",
+      packageKey: "super",
+      savedAt: Date.now(),
+    };
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    // Consent is still recorded before checkout resumes — payment after consent.
+    expect(saveConsentMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith(
+      `${routes.checkout}?package=super`,
+    );
+  });
+
+  test("resume fires only on the Start click, not on render (no loop)", () => {
+    checkoutIntentValue = {
+      kind: "package",
+      packageKey: "super",
+      savedAt: Date.now(),
+    };
+    searchParamsValue = new URLSearchParams();
+    render(<PrivacyScreen />);
+
+    // Mounting the screen must never navigate — the resume is action-gated, so
+    // a consented user returning here cannot loop between consent and checkout.
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    clickStart();
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      `${routes.checkout}?package=super`,
+    );
   });
 });
 

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -186,11 +186,12 @@ describe("PrivacyScreen — Start navigation", () => {
     expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.hatching);
   });
 
-  test("resumes checkout when a pending package intent is present", () => {
+  test("resumes checkout when a pending signup-marked package intent is present", () => {
     checkoutIntentValue = {
       kind: "package",
       packageKey: "super",
       savedAt: Date.now(),
+      resumeAfterOnboarding: true,
     };
     searchParamsValue = new URLSearchParams("hosting=managed");
     render(<PrivacyScreen />);
@@ -205,11 +206,33 @@ describe("PrivacyScreen — Start navigation", () => {
     );
   });
 
+  test("does NOT resume an unmarked billing-surface intent — onboarding proceeds normally", () => {
+    // An abandoned CheckoutPage/takeover checkout leaves a discriminator-less
+    // package intent. Without the signup marker it must not hijack onboarding:
+    // Start advances to the normal next step instead of launching checkout.
+    checkoutIntentValue = {
+      kind: "package",
+      packageKey: "super",
+      savedAt: Date.now(),
+    };
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(saveConsentMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(routes.onboarding.research)).toBe(true);
+    expect(target).not.toContain(routes.checkout);
+  });
+
   test("resume fires only on the Start click, not on render (no loop)", () => {
     checkoutIntentValue = {
       kind: "package",
       packageKey: "super",
       savedAt: Date.now(),
+      resumeAfterOnboarding: true,
     };
     searchParamsValue = new URLSearchParams();
     render(<PrivacyScreen />);

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/domains/onboarding/funnel-events";
 import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
+import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { isLocalMode } from "@/lib/local-mode";
 import {
     usePrivacyConsent,
@@ -70,6 +71,21 @@ export function PrivacyScreen() {
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
         userId,
       });
+    }
+
+    // A pricing-CTA signup stashes its chosen package (see navigation-resolver
+    // post-auth). With consent now recorded, resume checkout so payment happens
+    // after consent and before the assistant hatches. The checkout route owns
+    // the already-Pro case and re-stashes the intent, so leave the stash for its
+    // lifecycle to clear. Resuming only from this explicit Start click — never a
+    // render effect — keeps consent and checkout from looping.
+    const checkoutIntent = readCheckoutIntent();
+    if (checkoutIntent?.kind === "package") {
+      const params = new URLSearchParams({
+        package: checkoutIntent.packageKey,
+      });
+      void navigate(`${routes.checkout}?${params.toString()}`);
+      return;
     }
 
     const hostingParam = searchParams.get("hosting");

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -75,12 +75,19 @@ export function PrivacyScreen() {
 
     // A pricing-CTA signup stashes its chosen package (see navigation-resolver
     // post-auth). With consent now recorded, resume checkout so payment happens
-    // after consent and before the assistant hatches. The checkout route owns
-    // the already-Pro case and re-stashes the intent, so leave the stash for its
-    // lifecycle to clear. Resuming only from this explicit Start click — never a
-    // render effect — keeps consent and checkout from looping.
+    // after consent and before the assistant hatches. Resume ONLY a
+    // signup-marked intent (`resumeAfterOnboarding`): an ordinary billing-surface
+    // stash (an abandoned CheckoutPage/takeover checkout) carries no marker, so
+    // it's ignored here and left untouched for its own flow — onboarding proceeds
+    // normally. The checkout route owns the already-Pro case and re-stashes the
+    // intent, so leave the marked stash for its lifecycle to clear. Resuming only
+    // from this explicit Start click — never a render effect — keeps consent and
+    // checkout from looping.
     const checkoutIntent = readCheckoutIntent();
-    if (checkoutIntent?.kind === "package") {
+    if (
+      checkoutIntent?.kind === "package" &&
+      checkoutIntent.resumeAfterOnboarding === true
+    ) {
       const params = new URLSearchParams({
         package: checkoutIntent.packageKey,
       });

--- a/clients/web/src/lib/billing/checkout-intent.test.ts
+++ b/clients/web/src/lib/billing/checkout-intent.test.ts
@@ -29,6 +29,32 @@ describe("saveCheckoutIntent / readCheckoutIntent", () => {
     expect(intent!.savedAt).toBeLessThanOrEqual(Date.now());
   });
 
+  test("round-trips a signup-marked package intent, preserving the marker", () => {
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+  });
+
+  test("an ordinary package intent round-trips without the marker (takeover/CheckoutPage path)", () => {
+    // The billing takeover and CheckoutPage save discriminator-less intents;
+    // they must read back unchanged, with no marker present.
+    saveCheckoutIntent({ kind: "package", packageKey: "mighty" });
+
+    const intent = readCheckoutIntent();
+    expect(intent).toMatchObject({ kind: "package", packageKey: "mighty" });
+    expect(
+      (intent as { resumeAfterOnboarding?: true }).resumeAfterOnboarding,
+    ).toBeUndefined();
+  });
+
   test("round-trips a custom intent, including null tiers", () => {
     saveCheckoutIntent({
       kind: "custom",

--- a/clients/web/src/lib/billing/checkout-intent.test.ts
+++ b/clients/web/src/lib/billing/checkout-intent.test.ts
@@ -10,6 +10,8 @@ const STORAGE_KEY = "vellum.pro-checkout-intent";
 
 beforeEach(() => {
   sessionStorage.clear();
+  // Reset the module-level in-memory mirror so it can't leak across tests.
+  clearCheckoutIntent();
 });
 
 describe("saveCheckoutIntent / readCheckoutIntent", () => {
@@ -98,5 +100,49 @@ describe("clearCheckoutIntent", () => {
 
     expect(readCheckoutIntent()).toBeNull();
     expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("in-memory fallback when sessionStorage is unavailable", () => {
+  test("save then read round-trips via memory, and clear removes it", () => {
+    const originalSetItem = sessionStorage.setItem.bind(sessionStorage);
+    const originalGetItem = sessionStorage.getItem.bind(sessionStorage);
+    // Simulate storage disabled (private mode / quota / blocked): both the
+    // write and the read throw, so only the in-memory mirror can carry the
+    // stash across a same-tab signup → privacy hop.
+    sessionStorage.setItem = () => {
+      throw new Error("sessionStorage unavailable");
+    };
+    sessionStorage.getItem = () => {
+      throw new Error("sessionStorage unavailable");
+    };
+    try {
+      saveCheckoutIntent({ kind: "package", packageKey: "super" });
+
+      expect(readCheckoutIntent()).toMatchObject({
+        kind: "package",
+        packageKey: "super",
+      });
+
+      clearCheckoutIntent();
+      expect(readCheckoutIntent()).toBeNull();
+    } finally {
+      sessionStorage.setItem = originalSetItem;
+      sessionStorage.getItem = originalGetItem;
+    }
+  });
+
+  test("an in-memory mirror older than the TTL reads as null", () => {
+    saveCheckoutIntent({ kind: "package", packageKey: "super" });
+    // Drop the sessionStorage copy so the read falls back to memory, then age
+    // the read past the TTL so the stale mirror can't resurface.
+    sessionStorage.clear();
+    const originalNow = Date.now;
+    Date.now = () => originalNow() + 31 * 60 * 1000;
+    try {
+      expect(readCheckoutIntent()).toBeNull();
+    } finally {
+      Date.now = originalNow;
+    }
   });
 });

--- a/clients/web/src/lib/billing/checkout-intent.ts
+++ b/clients/web/src/lib/billing/checkout-intent.ts
@@ -14,7 +14,20 @@ import type {
  * that shouldn't resurface as a phantom "provisioning" state.
  */
 export type CheckoutIntent =
-  | { kind: "package"; packageKey: string; savedAt: number }
+  | {
+      kind: "package";
+      packageKey: string;
+      savedAt: number;
+      /**
+       * Marks a stash written by the post-auth signup carry (a pricing-CTA
+       * signup routed through consent). Only the onboarding privacy screen
+       * resumes checkout from a marked intent, so an ordinary billing-surface
+       * stash (CheckoutPage, the plans/adjust takeovers) can't hijack
+       * onboarding. Optional and backward-compatible: ordinary saves omit it,
+       * and the provisioning takeover ignores it.
+       */
+      resumeAfterOnboarding?: true;
+    }
   | {
       kind: "custom";
       machineTier: MachineTierEnum | null;

--- a/clients/web/src/lib/billing/checkout-intent.ts
+++ b/clients/web/src/lib/billing/checkout-intent.ts
@@ -34,31 +34,45 @@ type UnsavedCheckoutIntent = DistributiveOmit<CheckoutIntent, "savedAt">;
 const STORAGE_KEY = "vellum.pro-checkout-intent";
 const MAX_AGE_MS = 30 * 60 * 1000;
 
+/**
+ * In-memory mirror of the stash, so an unavailable sessionStorage (private
+ * mode, quota, storage disabled) can't silently drop the intent. The new-user
+ * flow relies on the stash surviving a same-tab signup → privacy hop, which
+ * has no Stripe round-trip to justify sessionStorage — the memory copy keeps
+ * that hop working even when `sessionStorage.setItem` throws.
+ */
+let inMemoryIntent: CheckoutIntent | null = null;
+
 export function saveCheckoutIntent(intent: UnsavedCheckoutIntent): void {
+  const stamped: CheckoutIntent = { ...intent, savedAt: Date.now() };
+  // Always keep the memory copy so a throwing sessionStorage can't lose it.
+  inMemoryIntent = stamped;
   try {
-    sessionStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({ ...intent, savedAt: Date.now() }),
-    );
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(stamped));
   } catch {
-    // sessionStorage may be unavailable (private mode, quota). The stash is a
-    // display-only optimization — never block the checkout redirect on it.
+    // sessionStorage may be unavailable (private mode, quota). The in-memory
+    // mirror above preserves the stash — never block the checkout redirect.
   }
 }
 
 /**
  * The stashed intent, or `null` when absent, unparsable, malformed, or older
- * than the TTL — anything unusable is cleared so it can't resurface.
+ * than the TTL — anything unusable is cleared so it can't resurface. Falls
+ * back to the in-memory mirror when sessionStorage is unreachable or empty.
  */
 export function readCheckoutIntent(): CheckoutIntent | null {
-  if (typeof sessionStorage === "undefined") return null;
   let raw: string | null = null;
-  try {
-    raw = sessionStorage.getItem(STORAGE_KEY);
-  } catch {
-    return null;
+  if (typeof sessionStorage !== "undefined") {
+    try {
+      raw = sessionStorage.getItem(STORAGE_KEY);
+    } catch {
+      // sessionStorage unreachable — fall back to the in-memory mirror.
+      return readInMemoryIntent();
+    }
   }
-  if (!raw) return null;
+  if (!raw) {
+    return readInMemoryIntent();
+  }
 
   let parsed: unknown;
   try {
@@ -75,11 +89,27 @@ export function readCheckoutIntent(): CheckoutIntent | null {
 }
 
 export function clearCheckoutIntent(): void {
+  inMemoryIntent = null;
   try {
     sessionStorage.removeItem(STORAGE_KEY);
   } catch {
     // see saveCheckoutIntent
   }
+}
+
+/**
+ * The in-memory mirror, applying the same TTL as the sessionStorage read so an
+ * abandoned intent can't resurface. Self-clears an expired mirror.
+ */
+function readInMemoryIntent(): CheckoutIntent | null {
+  if (!inMemoryIntent) {
+    return null;
+  }
+  if (Date.now() - inMemoryIntent.savedAt > MAX_AGE_MS) {
+    inMemoryIntent = null;
+    return null;
+  }
+  return inMemoryIntent;
 }
 
 function isCheckoutIntent(value: unknown): value is CheckoutIntent {

--- a/clients/web/src/lib/billing/post-auth-checkout.test.ts
+++ b/clients/web/src/lib/billing/post-auth-checkout.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  readCheckoutIntent,
+  saveCheckoutIntent,
+} from "@/lib/billing/checkout-intent";
+
+import {
+  checkoutPackageFromDestination,
+  resolveSignupCheckoutDestination,
+} from "./post-auth-checkout";
+
+describe("checkoutPackageFromDestination", () => {
+  test("returns the package slug for a checkout deep link", () => {
+    expect(
+      checkoutPackageFromDestination("/assistant/checkout?package=super"),
+    ).toBe("super");
+  });
+
+  test("returns null for a checkout link without a package", () => {
+    expect(checkoutPackageFromDestination("/assistant/checkout")).toBeNull();
+  });
+
+  test("returns null for a non-checkout destination", () => {
+    expect(checkoutPackageFromDestination("/assistant/home")).toBeNull();
+  });
+});
+
+describe("resolveSignupCheckoutDestination", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  test("signup on a checkout deep link stashes the package and routes to privacy", () => {
+    const result = resolveSignupCheckoutDestination({
+      intent: "signup",
+      returnTo: "/assistant/checkout?package=super",
+    });
+
+    expect(result).toEqual({
+      destination: "/assistant/onboarding/privacy",
+      stashedPackage: "super",
+    });
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "package",
+      packageKey: "super",
+    });
+  });
+
+  test("signup on a checkout link without a package routes to privacy and stashes nothing", () => {
+    const result = resolveSignupCheckoutDestination({
+      intent: "signup",
+      returnTo: "/assistant/checkout",
+    });
+
+    expect(result).toEqual({
+      destination: "/assistant/onboarding/privacy",
+      stashedPackage: null,
+    });
+    expect(readCheckoutIntent()).toBeNull();
+  });
+
+  test("non-checkout signup routes to privacy and clears a stale stash", () => {
+    saveCheckoutIntent({ kind: "package", packageKey: "abandoned" });
+
+    const result = resolveSignupCheckoutDestination({
+      intent: "signup",
+      returnTo: "/assistant/home",
+    });
+
+    expect(result).toEqual({
+      destination: "/assistant/onboarding/privacy",
+      stashedPackage: null,
+    });
+    expect(readCheckoutIntent()).toBeNull();
+  });
+
+  test("non-checkout login keeps its returnTo and clears a stale stash", () => {
+    saveCheckoutIntent({ kind: "package", packageKey: "abandoned" });
+
+    const result = resolveSignupCheckoutDestination({
+      intent: "login",
+      returnTo: "/assistant/home",
+    });
+
+    expect(result).toEqual({
+      destination: "/assistant/home",
+      stashedPackage: null,
+    });
+    expect(readCheckoutIntent()).toBeNull();
+  });
+
+  test("login on a checkout deep link keeps its returnTo, stashes nothing, and leaves an existing stash untouched", () => {
+    saveCheckoutIntent({ kind: "package", packageKey: "existing" });
+
+    const result = resolveSignupCheckoutDestination({
+      intent: "login",
+      returnTo: "/assistant/checkout?package=super",
+    });
+
+    expect(result).toEqual({
+      destination: "/assistant/checkout?package=super",
+      stashedPackage: null,
+    });
+    // A checkout deep link is never treated as an unrelated auth, so the
+    // stash is left in place rather than discarded.
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "package",
+      packageKey: "existing",
+    });
+  });
+});

--- a/clients/web/src/lib/billing/post-auth-checkout.test.ts
+++ b/clients/web/src/lib/billing/post-auth-checkout.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
+  clearCheckoutIntent,
   readCheckoutIntent,
   saveCheckoutIntent,
 } from "@/lib/billing/checkout-intent";
@@ -29,6 +30,8 @@ describe("checkoutPackageFromDestination", () => {
 describe("resolveSignupCheckoutDestination", () => {
   beforeEach(() => {
     sessionStorage.clear();
+    // Reset the module-level in-memory mirror so it can't leak across tests.
+    clearCheckoutIntent();
   });
 
   test("signup on a checkout deep link stashes the package and routes to privacy", () => {

--- a/clients/web/src/lib/billing/post-auth-checkout.test.ts
+++ b/clients/web/src/lib/billing/post-auth-checkout.test.ts
@@ -44,9 +44,12 @@ describe("resolveSignupCheckoutDestination", () => {
       destination: "/assistant/onboarding/privacy",
       stashedPackage: "super",
     });
+    // The signup carry marks its stash so only the onboarding privacy screen
+    // resumes it — an ordinary billing-surface stash carries no such marker.
     expect(readCheckoutIntent()).toMatchObject({
       kind: "package",
       packageKey: "super",
+      resumeAfterOnboarding: true,
     });
   });
 

--- a/clients/web/src/lib/billing/post-auth-checkout.ts
+++ b/clients/web/src/lib/billing/post-auth-checkout.ts
@@ -1,0 +1,75 @@
+import {
+  clearCheckoutIntent,
+  saveCheckoutIntent,
+} from "@/lib/billing/checkout-intent";
+import { routes } from "@/utils/routes";
+
+/**
+ * Whether a destination is the `/assistant/checkout` deep link, plus the
+ * `package` slug it carries (null when absent). The marketing pricing CTAs
+ * point here to start Stripe checkout for a chosen package.
+ */
+function parseCheckoutDestination(destination: string): {
+  isCheckout: boolean;
+  packageKey: string | null;
+} {
+  let url: URL;
+  try {
+    url = new URL(destination, "http://placeholder.invalid");
+  } catch {
+    return { isCheckout: false, packageKey: null };
+  }
+  if (url.pathname !== routes.checkout) {
+    return { isCheckout: false, packageKey: null };
+  }
+  return { isCheckout: true, packageKey: url.searchParams.get("package") || null };
+}
+
+/**
+ * The `package` slug of a deep-link checkout destination
+ * (`/assistant/checkout?package=`), or null when the destination is not a
+ * checkout link or carries no package.
+ */
+export function checkoutPackageFromDestination(destination: string): string | null {
+  return parseCheckoutDestination(destination).packageKey;
+}
+
+export interface SignupCheckoutResolution {
+  /** Where the auth should land. */
+  destination: string;
+  /** The package stashed for post-consent checkout resume, or null. */
+  stashedPackage: string | null;
+}
+
+/**
+ * The shared post-auth checkout decision for both the web
+ * (`resolvePostAuth`) and native (`resolveNativePostAuthDestination`) paths.
+ *
+ * A signup that carries a pricing-CTA checkout deep link stashes the package
+ * and routes through consent (privacy) first, so the consent screen resumes
+ * checkout after onboarding. Any auth that is NOT a checkout deep link
+ * discards a stale stash left by an abandoned earlier attempt — external OAuth
+ * can't run a cleanup callback, so the next auth entry self-cleans; the stash
+ * this flow sets is never touched. A signup otherwise routes to privacy; a
+ * login keeps its own `returnTo` and starts checkout directly from there.
+ */
+export function resolveSignupCheckoutDestination(args: {
+  intent: "login" | "signup";
+  returnTo: string;
+}): SignupCheckoutResolution {
+  const { intent, returnTo } = args;
+  const { isCheckout, packageKey } = parseCheckoutDestination(returnTo);
+
+  if (!isCheckout) {
+    clearCheckoutIntent();
+  }
+
+  if (intent === "signup") {
+    if (packageKey) {
+      saveCheckoutIntent({ kind: "package", packageKey });
+    }
+    return { destination: routes.onboarding.privacy, stashedPackage: packageKey };
+  }
+
+  return { destination: returnTo, stashedPackage: null };
+}

--- a/clients/web/src/lib/billing/post-auth-checkout.ts
+++ b/clients/web/src/lib/billing/post-auth-checkout.ts
@@ -66,7 +66,9 @@ export function resolveSignupCheckoutDestination(args: {
 
   if (intent === "signup") {
     if (packageKey) {
-      saveCheckoutIntent({ kind: "package", packageKey });
+      // Mark the stash as signup-originated so only the onboarding privacy
+      // screen resumes it — an ordinary billing-surface stash stays inert here.
+      saveCheckoutIntent({ kind: "package", packageKey, resumeAfterOnboarding: true });
     }
     return { destination: routes.onboarding.privacy, stashedPackage: packageKey };
   }

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -1,4 +1,6 @@
-import { describe, test, expect } from "bun:test";
+import { beforeEach, describe, test, expect } from "bun:test";
+
+import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
 
 import {
   resolveNavigation,
@@ -759,6 +761,10 @@ describe("resolveNavigation", () => {
   // post-auth
   // -----------------------------------------------------------------------
   describe("post-auth", () => {
+    beforeEach(() => {
+      sessionStorage.clear();
+    });
+
     const postAuth = (authIntent: "login" | "signup", returnTo: string | null, fallback = "/assistant") =>
       resolveNavigation(base, { kind: "post-auth", authIntent, returnTo, fallback });
 
@@ -767,6 +773,39 @@ describe("resolveNavigation", () => {
         action: "redirect",
         to: "/assistant/onboarding/privacy",
       });
+      // A non-checkout signup stashes no checkout intent.
+      expect(readCheckoutIntent()).toBeNull();
+    });
+
+    test("signup via the checkout deep link still routes through consent but stashes the package", () => {
+      expect(
+        postAuth("signup", "/assistant/checkout?package=super"),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/privacy",
+      });
+      expect(readCheckoutIntent()).toMatchObject({
+        kind: "package",
+        packageKey: "super",
+      });
+    });
+
+    test("signup via checkout without a package stashes nothing", () => {
+      expect(postAuth("signup", "/assistant/checkout")).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/privacy",
+      });
+      expect(readCheckoutIntent()).toBeNull();
+    });
+
+    test("login via the checkout deep link returns there directly and stashes nothing", () => {
+      expect(
+        postAuth("login", "/assistant/checkout?package=super"),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/checkout?package=super",
+      });
+      expect(readCheckoutIntent()).toBeNull();
     });
 
     test("signup goes to privacy without returnTo", () => {

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, test, expect } from "bun:test";
 
-import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
+import {
+  readCheckoutIntent,
+  saveCheckoutIntent,
+} from "@/lib/billing/checkout-intent";
 
 import {
   resolveNavigation,
@@ -854,6 +857,24 @@ describe("resolveNavigation", () => {
         action: "redirect",
         to: "/assistant",
       });
+    });
+
+    test("a non-checkout signup clears a stale stash from an abandoned attempt", () => {
+      saveCheckoutIntent({ kind: "package", packageKey: "abandoned" });
+      expect(postAuth("signup", "/some-return")).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/privacy",
+      });
+      expect(readCheckoutIntent()).toBeNull();
+    });
+
+    test("a non-checkout login clears a stale stash from an abandoned attempt", () => {
+      saveCheckoutIntent({ kind: "package", packageKey: "abandoned" });
+      expect(postAuth("login", "/assistant/home")).toEqual({
+        action: "redirect",
+        to: "/assistant/home",
+      });
+      expect(readCheckoutIntent()).toBeNull();
     });
   });
 

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, test, expect } from "bun:test";
 
 import {
+  clearCheckoutIntent,
   readCheckoutIntent,
   saveCheckoutIntent,
 } from "@/lib/billing/checkout-intent";
@@ -766,6 +767,9 @@ describe("resolveNavigation", () => {
   describe("post-auth", () => {
     beforeEach(() => {
       sessionStorage.clear();
+      // Reset the module-level in-memory mirror so a stash set by one case
+      // can't leak into the next through the sessionStorage fallback.
+      clearCheckoutIntent();
     });
 
     const postAuth = (authIntent: "login" | "signup", returnTo: string | null, fallback = "/assistant") =>

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -1,5 +1,6 @@
 import type { PlatformSessionStatus } from "@/stores/session-status";
 import { sanitizeReturnTo } from "@/domains/account/return-to";
+import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import { routes } from "@/utils/routes";
 
 // ---------------------------------------------------------------------------
@@ -430,6 +431,22 @@ function isImportFunnelDestination(destination: string): boolean {
   );
 }
 
+// The `package` slug of a deep-link checkout destination
+// (`/assistant/checkout?package=`), or null when the destination is not a
+// checkout link or carries no package.
+function checkoutPackageFromDestination(destination: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(destination, "http://placeholder.invalid");
+  } catch {
+    return null;
+  }
+  if (url.pathname !== routes.checkout) {
+    return null;
+  }
+  return url.searchParams.get("package") || null;
+}
+
 function resolvePostAuth(
   authIntent: "login" | "signup",
   returnTo: string | null,
@@ -439,6 +456,14 @@ function resolvePostAuth(
     const destination = sanitizeReturnTo(returnTo, fallback);
     if (isImportFunnelDestination(destination)) {
       return { action: "redirect", to: destination };
+    }
+    // Preserve a pricing-CTA checkout destination across signup: stash the
+    // package, then still route through consent first. sessionStorage survives
+    // the same-tab OAuth round-trip and the redirect to privacy, so the consent
+    // screen can resume checkout afterward.
+    const packageKey = checkoutPackageFromDestination(destination);
+    if (packageKey) {
+      saveCheckoutIntent({ kind: "package", packageKey });
     }
     return { action: "redirect", to: routes.onboarding.privacy };
   }

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -433,8 +433,9 @@ function isImportFunnelDestination(destination: string): boolean {
 
 // The `package` slug of a deep-link checkout destination
 // (`/assistant/checkout?package=`), or null when the destination is not a
-// checkout link or carries no package.
-function checkoutPackageFromDestination(destination: string): string | null {
+// checkout link or carries no package. Shared with the native signup paths so
+// they stash the same package before routing through consent.
+export function checkoutPackageFromDestination(destination: string): string | null {
   let url: URL;
   try {
     url = new URL(destination, "http://placeholder.invalid");

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -1,6 +1,6 @@
 import type { PlatformSessionStatus } from "@/stores/session-status";
 import { sanitizeReturnTo } from "@/domains/account/return-to";
-import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
+import { resolveSignupCheckoutDestination } from "@/lib/billing/post-auth-checkout";
 import { routes } from "@/utils/routes";
 
 // ---------------------------------------------------------------------------
@@ -431,44 +431,25 @@ function isImportFunnelDestination(destination: string): boolean {
   );
 }
 
-// The `package` slug of a deep-link checkout destination
-// (`/assistant/checkout?package=`), or null when the destination is not a
-// checkout link or carries no package. Shared with the native signup paths so
-// they stash the same package before routing through consent.
-export function checkoutPackageFromDestination(destination: string): string | null {
-  let url: URL;
-  try {
-    url = new URL(destination, "http://placeholder.invalid");
-  } catch {
-    return null;
-  }
-  if (url.pathname !== routes.checkout) {
-    return null;
-  }
-  return url.searchParams.get("package") || null;
-}
-
 function resolvePostAuth(
   authIntent: "login" | "signup",
   returnTo: string | null,
   fallback: string,
 ): NavigationDecision {
-  if (authIntent === "signup") {
-    const destination = sanitizeReturnTo(returnTo, fallback);
-    if (isImportFunnelDestination(destination)) {
-      return { action: "redirect", to: destination };
-    }
-    // Preserve a pricing-CTA checkout destination across signup: stash the
-    // package, then still route through consent first. sessionStorage survives
-    // the same-tab OAuth round-trip and the redirect to privacy, so the consent
-    // screen can resume checkout afterward.
-    const packageKey = checkoutPackageFromDestination(destination);
-    if (packageKey) {
-      saveCheckoutIntent({ kind: "package", packageKey });
-    }
-    return { action: "redirect", to: routes.onboarding.privacy };
+  const destination = sanitizeReturnTo(returnTo, fallback);
+  // The shared resolver stashes a pricing-CTA checkout package across signup,
+  // discards a stale stash for any non-checkout auth, and picks the
+  // destination (privacy for signup, the sanitized `returnTo` for login).
+  const { destination: resolved } = resolveSignupCheckoutDestination({
+    intent: authIntent,
+    returnTo: destination,
+  });
+  // The import funnel replaces onboarding: a signup that started on /import
+  // lands back there instead of the consent screen.
+  if (authIntent === "signup" && isImportFunnelDestination(destination)) {
+    return { action: "redirect", to: destination };
   }
-  return { action: "redirect", to: sanitizeReturnTo(returnTo, fallback) };
+  return { action: "redirect", to: resolved };
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/runtime/native-auth.test.ts
+++ b/clients/web/src/runtime/native-auth.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
+
+import { resolveNativePostAuthDestination } from "./native-auth";
+
+describe("resolveNativePostAuthDestination", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  test("native signup via the checkout deep link stashes the package and still routes to privacy", () => {
+    const destination = resolveNativePostAuthDestination(
+      "signup",
+      "/assistant/checkout?package=super",
+    );
+
+    expect(destination).toBe("/assistant/onboarding/privacy");
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "package",
+      packageKey: "super",
+    });
+  });
+
+  test("native signup with a non-checkout destination stashes nothing", () => {
+    const destination = resolveNativePostAuthDestination("signup", "/assistant/home");
+
+    expect(destination).toBe("/assistant/onboarding/privacy");
+    expect(readCheckoutIntent()).toBeNull();
+  });
+
+  test("native signup with no returnTo routes to privacy and stashes nothing", () => {
+    const destination = resolveNativePostAuthDestination("signup", null);
+
+    expect(destination).toBe("/assistant/onboarding/privacy");
+    expect(readCheckoutIntent()).toBeNull();
+  });
+
+  test("native login keeps its returnTo and stashes nothing even on the checkout link", () => {
+    const destination = resolveNativePostAuthDestination(
+      "login",
+      "/assistant/checkout?package=super",
+    );
+
+    expect(destination).toBe("/assistant/checkout?package=super");
+    expect(readCheckoutIntent()).toBeNull();
+  });
+});

--- a/clients/web/src/runtime/native-auth.test.ts
+++ b/clients/web/src/runtime/native-auth.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
+import {
+  readCheckoutIntent,
+  saveCheckoutIntent,
+} from "@/lib/billing/checkout-intent";
 
 import { resolveNativePostAuthDestination } from "./native-auth";
 
@@ -43,6 +46,24 @@ describe("resolveNativePostAuthDestination", () => {
     );
 
     expect(destination).toBe("/assistant/checkout?package=super");
+    expect(readCheckoutIntent()).toBeNull();
+  });
+
+  test("native non-checkout signup clears a stale stash from an abandoned attempt", () => {
+    saveCheckoutIntent({ kind: "package", packageKey: "abandoned" });
+
+    const destination = resolveNativePostAuthDestination("signup", "/assistant/home");
+
+    expect(destination).toBe("/assistant/onboarding/privacy");
+    expect(readCheckoutIntent()).toBeNull();
+  });
+
+  test("native non-checkout login clears a stale stash from an abandoned attempt", () => {
+    saveCheckoutIntent({ kind: "package", packageKey: "abandoned" });
+
+    const destination = resolveNativePostAuthDestination("login", "/assistant/home");
+
+    expect(destination).toBe("/assistant/home");
     expect(readCheckoutIntent()).toBeNull();
   });
 });

--- a/clients/web/src/runtime/native-auth.test.ts
+++ b/clients/web/src/runtime/native-auth.test.ts
@@ -1,15 +1,21 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
+  clearCheckoutIntent,
   readCheckoutIntent,
   saveCheckoutIntent,
 } from "@/lib/billing/checkout-intent";
 
-import { resolveNativePostAuthDestination } from "./native-auth";
+import {
+  clearStaleNativeCheckoutStash,
+  resolveNativePostAuthDestination,
+} from "./native-auth";
 
 describe("resolveNativePostAuthDestination", () => {
   beforeEach(() => {
     sessionStorage.clear();
+    // Reset the module-level in-memory mirror so it can't leak across tests.
+    clearCheckoutIntent();
   });
 
   test("native signup via the checkout deep link stashes the package and still routes to privacy", () => {
@@ -65,5 +71,45 @@ describe("resolveNativePostAuthDestination", () => {
 
     expect(destination).toBe("/assistant/home");
     expect(readCheckoutIntent()).toBeNull();
+  });
+});
+
+describe("clearStaleNativeCheckoutStash", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    clearCheckoutIntent();
+  });
+
+  test("a direct native login with a non-checkout destination clears a stale stash", () => {
+    // The direct login form passes no intent and a non-checkout returnTo.
+    saveCheckoutIntent({ kind: "package", packageKey: "abandoned" });
+
+    clearStaleNativeCheckoutStash(undefined, "/assistant/home");
+
+    expect(readCheckoutIntent()).toBeNull();
+  });
+
+  test("a native login onto a checkout deep link leaves an existing stash in place", () => {
+    saveCheckoutIntent({ kind: "package", packageKey: "existing" });
+
+    clearStaleNativeCheckoutStash(undefined, "/assistant/checkout?package=super");
+
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "package",
+      packageKey: "existing",
+    });
+  });
+
+  test("a signup keeps the stash its resolver just set", () => {
+    // A signup owns its stash via `resolveSignupCheckoutDestination`; the entry
+    // cleanup must not wipe it just because the destination is the privacy page.
+    saveCheckoutIntent({ kind: "package", packageKey: "super" });
+
+    clearStaleNativeCheckoutStash("signup", "/assistant/onboarding/privacy");
+
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "package",
+      packageKey: "super",
+    });
   });
 });

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -103,6 +103,13 @@ export async function startNativeLogin(options?: {
   loginHint?: string;
   intent?: string;
 }): Promise<void> {
+  // Every native auth entry routes through the shared stale-stash cleanup. The
+  // direct login form (`login-page.tsx`) calls this without going through
+  // `resolveNativePostAuthDestination`, so without this a stash abandoned by a
+  // prior native checkout-signup could leak into a later login and wrongly
+  // resume checkout from privacy.
+  clearStaleNativeCheckoutStash(options?.intent, options?.returnTo);
+
   const baseURL = options?.baseURL ?? deriveAuthBaseURL();
   const { sessionToken } = await NativeAuth.startAuth({
     baseURL,
@@ -243,6 +250,32 @@ export function resolveNativePostAuthDestination(
   // and apply the fallback — while still discarding a stale stash via the
   // shared resolver.
   return isSignup ? destination : (returnTo ?? null);
+}
+
+/**
+ * Discard a checkout stash abandoned by a prior native checkout-signup so it
+ * can't leak into a later native auth. Runs on every native auth entry (via
+ * `startNativeLogin`), including the direct login form that skips
+ * `resolveNativePostAuthDestination`.
+ *
+ * A signup owns its stash through `resolveSignupCheckoutDestination` — already
+ * run before we reach here, and its `returnTo` is the transformed privacy
+ * destination rather than the original checkout link — so we skip it to avoid
+ * wiping the package it just stashed. Otherwise the shared resolver clears a
+ * stale stash for a non-checkout destination and leaves an existing stash in
+ * place when the destination IS a checkout deep link (a legitimate resume).
+ */
+export function clearStaleNativeCheckoutStash(
+  intent: string | undefined,
+  returnTo: string | null | undefined,
+): void {
+  if (intent === "signup") {
+    return;
+  }
+  resolveSignupCheckoutDestination({
+    intent: "login",
+    returnTo: returnTo ?? "",
+  });
 }
 
 /**

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -7,8 +7,7 @@ import {
 } from "@/domains/account/social-auth";
 import { sanitizeReturnTo } from "@/domains/account/return-to";
 import { getSession } from "@/lib/auth/allauth-client";
-import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
-import { checkoutPackageFromDestination } from "@/lib/navigation/navigation-resolver";
+import { resolveSignupCheckoutDestination } from "@/lib/billing/post-auth-checkout";
 import { isPlatformLocal, startLoopbackAuth } from "@/lib/auth/loopback-auth";
 import { isLocalMode } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
@@ -222,24 +221,28 @@ export function getSessionTokenFromCookies(): string | null {
 }
 
 /**
- * Post-auth destination for the native (Capacitor/Electron) flows, mirroring
- * the web `resolvePostAuth` path. A signup always routes through consent
- * (privacy) first; before doing so it stashes any pricing-CTA checkout package
- * from the `returnTo` so the consent screen can resume checkout afterward. A
- * login keeps its sanitized `returnTo`.
+ * Post-auth destination for the native (Capacitor/Electron) flows. Delegates
+ * the signup checkout-stash + destination decision to the shared
+ * `resolveSignupCheckoutDestination`, which both this path and the web
+ * `resolvePostAuth` path use: a signup routes through consent (privacy) first,
+ * stashing any pricing-CTA checkout package so the consent screen resumes
+ * checkout afterward, and any non-checkout auth discards a stale stash. A login
+ * keeps its `returnTo` (the callers below sanitize and apply the fallback).
  */
 export function resolveNativePostAuthDestination(
   intent: string | undefined,
   returnTo: string | null | undefined,
 ): string | null {
-  if (intent !== "signup") {
-    return returnTo ?? null;
-  }
-  const packageKey = checkoutPackageFromDestination(returnTo ?? "");
-  if (packageKey) {
-    saveCheckoutIntent({ kind: "package", packageKey });
-  }
-  return routes.onboarding.privacy;
+  const isSignup = intent === "signup";
+  const { destination } = resolveSignupCheckoutDestination({
+    intent: isSignup ? "signup" : "login",
+    returnTo: returnTo ?? "",
+  });
+  // A signup takes the shared destination (privacy, resuming checkout after
+  // consent). A login keeps its raw `returnTo` — the callers below sanitize
+  // and apply the fallback — while still discarding a stale stash via the
+  // shared resolver.
+  return isSignup ? destination : (returnTo ?? null);
 }
 
 /**

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -7,6 +7,8 @@ import {
 } from "@/domains/account/social-auth";
 import { sanitizeReturnTo } from "@/domains/account/return-to";
 import { getSession } from "@/lib/auth/allauth-client";
+import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
+import { checkoutPackageFromDestination } from "@/lib/navigation/navigation-resolver";
 import { isPlatformLocal, startLoopbackAuth } from "@/lib/auth/loopback-auth";
 import { isLocalMode } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
@@ -220,6 +222,27 @@ export function getSessionTokenFromCookies(): string | null {
 }
 
 /**
+ * Post-auth destination for the native (Capacitor/Electron) flows, mirroring
+ * the web `resolvePostAuth` path. A signup always routes through consent
+ * (privacy) first; before doing so it stashes any pricing-CTA checkout package
+ * from the `returnTo` so the consent screen can resume checkout afterward. A
+ * login keeps its sanitized `returnTo`.
+ */
+export function resolveNativePostAuthDestination(
+  intent: string | undefined,
+  returnTo: string | null | undefined,
+): string | null {
+  if (intent !== "signup") {
+    return returnTo ?? null;
+  }
+  const packageKey = checkoutPackageFromDestination(returnTo ?? "");
+  if (packageKey) {
+    saveCheckoutIntent({ kind: "package", packageKey });
+  }
+  return routes.onboarding.privacy;
+}
+
+/**
  * Unified auth-flow entry point that transparently chooses between the
  * native iOS plugin path and the web form-POST path.
  *
@@ -242,10 +265,10 @@ export async function startAuthFlow(
   if (isNativePlatform()) {
     try {
       await startNativeLogin({
-        returnTo:
-          options.intent === "signup"
-            ? routes.onboarding.privacy
-            : options.returnTo ?? null,
+        returnTo: resolveNativePostAuthDestination(
+          options.intent,
+          options.returnTo,
+        ),
         loginHint: options.loginHint,
         intent: options.intent,
       });
@@ -277,9 +300,7 @@ export async function startAuthFlow(
         primeElectronSessionToken(result.sessionToken);
         await setMenuPlatformSession(true);
         const destination = sanitizeReturnTo(
-          options.intent === "signup"
-            ? routes.onboarding.privacy
-            : options.returnTo ?? null,
+          resolveNativePostAuthDestination(options.intent, options.returnTo),
           DEFAULT_POST_AUTH_DESTINATION,
         );
         window.location.href = destination;


### PR DESCRIPTION
## Summary
- resolvePostAuth preserves an /assistant/checkout?package= signup destination by stashing the package, then still routes through consent first.
- After consent, resumes to /assistant/checkout?package= so new users pay before hatching (PR 3 then resizes behind hatching).
- No charge before consent; no redirect loop.

Part of plan: pricing-checkout-flow.md (PR 4 of 4)