### PR TITLE
feat(web): provision purchased machine specs behind the onboarding hatching screen

### DIFF
--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -37,8 +37,15 @@ let isLocalModeValue = false;
 
 // The observed subscription plan gates the free/no-wait decision (Fix 2).
 let subscriptionPlanId = "base";
+// Whether the subscription read is uncertain: a throw, or a resolved response
+// with no data (a 5xx under throwOnError:false). Either is "unknown", not "free".
+let subscriptionThrows = false;
+let subscriptionNoData = false;
 // Whether a resize operation reads as still in flight (Fix 1).
 let opStatusInFlight = false;
+// Whether the operational-status read resolves with no data (a 5xx under
+// throwOnError:false) — an uncertain read that must count as in-flight.
+let opStatusNoData = false;
 // Whether the no-id pre-flight getAssistant resolves an already-active
 // assistant (the reload path, Fix 3).
 let preflightActive = false;
@@ -56,6 +63,11 @@ let currentAssistant: AssistantShape;
 // exercised without a real 90s wait.
 let idPollCount = 0;
 let resizePollClockStepMs = 0;
+
+// The subscription/targets loop runs before the resize loop, so a cap-expiry
+// test that never reaches a confirmed-Pro read advances the clock here instead.
+let subscriptionCallCount = 0;
+let subscriptionPollClockStepMs = 0;
 
 interface OnboardingShape {
   max_machine_tier: string | null;
@@ -105,16 +117,31 @@ const onboardingRetrieveMock = mock(async () => {
   return { data: onboardingData };
 });
 
-const subscriptionRetrieveMock = mock(async () => ({
-  data: { plan_id: subscriptionPlanId },
-}));
+const subscriptionRetrieveMock = mock(async () => {
+  subscriptionCallCount += 1;
+  if (subscriptionCallCount >= 2 && subscriptionPollClockStepMs > 0) {
+    setSystemTime(new Date(Date.now() + subscriptionPollClockStepMs));
+  }
+  if (subscriptionThrows) {
+    throw new Error("subscription fetch failed");
+  }
+  if (subscriptionNoData) {
+    return { data: undefined };
+  }
+  return { data: { plan_id: subscriptionPlanId } };
+});
 
-const operationalStatusReadMock = mock(async () => ({
-  data: {
-    state: opStatusInFlight ? "resizing_machine" : "active",
-    active_operation: null,
-  },
-}));
+const operationalStatusReadMock = mock(async () => {
+  if (opStatusNoData) {
+    return { data: undefined };
+  }
+  return {
+    data: {
+      state: opStatusInFlight ? "resizing_machine" : "active",
+      active_operation: null,
+    },
+  };
+});
 
 const hatchLocalAssistantMock = mock(async () => ({
   ok: true as const,
@@ -325,10 +352,15 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     searchParams = new URLSearchParams();
     isLocalModeValue = false;
     subscriptionPlanId = "base";
+    subscriptionThrows = false;
+    subscriptionNoData = false;
     opStatusInFlight = false;
+    opStatusNoData = false;
     preflightActive = false;
     idPollCount = 0;
     resizePollClockStepMs = 0;
+    subscriptionCallCount = 0;
+    subscriptionPollClockStepMs = 0;
     onboardingThrows = false;
     onboardingData = null;
     currentAssistant = {
@@ -535,6 +567,104 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
       // Never met the targets — completion came from the cap, not convergence.
       expect(currentAssistant.machine_size).toBe("small");
       expect(ensureProvisionedMock).toHaveBeenCalledTimes(1);
+    },
+    20000,
+  );
+
+  test(
+    "an unknown (no-data) subscription read during a paid hatch keeps waiting, never completing at baseline",
+    async () => {
+      // The subscription endpoint resolves with no data (a 5xx under
+      // throwOnError:false) — an UNKNOWN result. Even with onboarding targets
+      // present and actuals already at the ceiling, an unknown read must not be
+      // mistaken for "free" and skip the purchased resize by completing early.
+      subscriptionNoData = true;
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+      currentAssistant.machine_size = "extra_large";
+      currentAssistant.provisioned_storage_gib = 50;
+
+      render(<HatchingScreen />);
+
+      // The reconcile fires and the subscription poll keeps retrying rather than
+      // concluding "free" and navigating away.
+      await waitFor(() =>
+        expect(ensureProvisionedMock).toHaveBeenCalledTimes(1),
+      );
+      await waitFor(
+        () =>
+          expect(
+            subscriptionRetrieveMock.mock.calls.length,
+          ).toBeGreaterThanOrEqual(2),
+        { timeout: 15000 },
+      );
+      expect(navigateMock).not.toHaveBeenCalled();
+
+      // A definitive Pro read now lands; with targets met the resize completes.
+      subscriptionNoData = false;
+      subscriptionPlanId = "pro";
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+    },
+    20000,
+  );
+
+  test(
+    "an erroring subscription endpoint still completes at the hard cap",
+    async () => {
+      // The subscription read persistently throws (always "unknown"). It never
+      // completes early, but the RESIZE_WAIT_MAX_MS cap is the ultimate escape
+      // so the user is not trapped.
+      subscriptionThrows = true;
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+      // The subscription loop's poll jumps the clock past the cap so completion
+      // falls through without a real 90s wait.
+      subscriptionPollClockStepMs = 91_000;
+
+      render(<HatchingScreen />);
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+      // Never entered the resize phase: the cap fired before a confirmed Pro read.
+      expect(screen.queryByText(RESIZE_LABEL)).toBeNull();
+    },
+    20000,
+  );
+
+  test(
+    "a failed operational-status read counts as in-flight and holds until a healthy read arrives",
+    async () => {
+      subscriptionPlanId = "pro";
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+      // Actuals already sit at the purchased ceiling, but the operational-status
+      // read returns no data (a 5xx under throwOnError:false). That uncertain
+      // read must count as in-flight so the screen does not navigate onto a pod
+      // that is still restarting.
+      currentAssistant.machine_size = "extra_large";
+      currentAssistant.provisioned_storage_gib = 50;
+      opStatusNoData = true;
+
+      render(<HatchingScreen />);
+
+      await waitFor(() => expect(screen.getByText(RESIZE_LABEL)).toBeTruthy());
+      // The resize loop keeps polling operational status while it holds.
+      await waitFor(
+        () =>
+          expect(
+            operationalStatusReadMock.mock.calls.length,
+          ).toBeGreaterThanOrEqual(2),
+        { timeout: 15000 },
+      );
+      expect(navigateMock).not.toHaveBeenCalled();
+
+      // A healthy status read (data present, no resize in flight) finally lands.
+      opStatusNoData = false;
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
     },
     20000,
   );

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -1,0 +1,399 @@
+/**
+ * Behavioral tests for the post-payment provisioning wait behind the onboarding
+ * hatching screen.
+ *
+ * A Pro user hatches a small warm-pool assistant; the screen fires the
+ * idempotent ensure-provisioned reconcile once and holds completion until the
+ * machine/storage resize to the purchased specs converges (then re-probes
+ * healthz). Failures, free orgs, and the hard cap all fall through to completion
+ * so the user is never trapped. Local hatches never enter this path.
+ *
+ * The screen keeps module-level hatch guards, so every test drives the flow to a
+ * genuine completion (which releases them) to stay isolated. Self-contained
+ * mocks — run this file solo (`mock.module` leaks across a shared `bun test`
+ * run).
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
+import type { ReactNode } from "react";
+
+const RESIZE_LABEL = "Setting up your machine…";
+
+// --- Mutable per-test state, reset in beforeEach ------------------------------
+
+const navigateMock = mock((_to: string, _opts?: unknown) => {});
+let searchParams = new URLSearchParams();
+
+let isLocalModeValue = false;
+
+interface AssistantShape {
+  id: string;
+  status: string;
+  machine_size: string | null;
+  provisioned_storage_gib: number | null;
+}
+let currentAssistant: AssistantShape;
+
+// The active-detection poll is the first id-keyed getAssistant; later id-polls
+// are the resize loop and may advance the fake clock so the cap-expiry path is
+// exercised without a real 90s wait.
+let idPollCount = 0;
+let resizePollClockStepMs = 0;
+
+interface OnboardingShape {
+  max_machine_tier: string | null;
+  selected_storage_gib: number | null;
+}
+let onboardingData: OnboardingShape | null = null;
+let onboardingThrows = false;
+
+// --- Mocks --------------------------------------------------------------------
+
+const getAssistantMock = mock(async (id?: string) => {
+  if (!id) {
+    // Pre-flight with no id: no assistant exists yet (auto_hatch).
+    return { ok: false as const, status: 404, error: {} };
+  }
+  idPollCount += 1;
+  if (idPollCount >= 2 && resizePollClockStepMs > 0) {
+    setSystemTime(new Date(Date.now() + resizePollClockStepMs));
+  }
+  return { ok: true as const, status: 200, data: { ...currentAssistant } };
+});
+
+const getAssistantHealthzMock = mock(async (_id: string) => ({
+  ok: true as const,
+  status: 200,
+  data: {},
+}));
+
+const hatchAssistantMock = mock(async () => ({
+  ok: true as const,
+  status: 201,
+  data: { id: "asst-1", status: "provisioning" },
+}));
+
+const ensureProvisionedMock = mock(async () => ({
+  data: { state: "started", reason: null, targets: {} },
+}));
+
+const onboardingRetrieveMock = mock(async () => {
+  if (onboardingThrows) {
+    throw new Error("onboarding fetch failed");
+  }
+  return { data: onboardingData };
+});
+
+const hatchLocalAssistantMock = mock(async () => ({
+  ok: true as const,
+  assistantId: "local-1",
+}));
+
+mock.module("react-router", () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [searchParams],
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: () => {},
+}));
+
+mock.module("@sentry/react", () => ({
+  captureMessage: () => {},
+}));
+
+const stableQueryClient = {};
+mock.module("@tanstack/react-query", () => ({
+  useQueryClient: () => stableQueryClient,
+}));
+
+mock.module("@/assistant/api", () => ({
+  getAssistant: getAssistantMock,
+  getAssistantHealthz: getAssistantHealthzMock,
+  hatchAssistant: hatchAssistantMock,
+}));
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate:
+    ensureProvisionedMock,
+  organizationsBillingSubscriptionOnboardingRetrieve: onboardingRetrieveMock,
+}));
+
+mock.module("@/assistant/seed-hatch-avatar", () => ({
+  seedHatchAvatar: async () => {},
+}));
+
+mock.module("@/assistant/lifecycle", () => ({
+  isPlatformHostedDisabled: () => false,
+  PLATFORM_HOSTED_DISABLED_MESSAGE: "disabled",
+  shouldRecoverFromHatchFailure: () => true,
+  resolveAssistantLifecycleState: (result: {
+    ok?: boolean;
+    status?: number;
+    data?: { status?: string };
+  }) => {
+    if (result?.ok && result.data?.status === "active") {
+      return { kind: "active" };
+    }
+    if (!result?.ok && result.status === 404) {
+      return { kind: "auto_hatch" };
+    }
+    return { kind: "provisioning" };
+  },
+}));
+
+mock.module("@/assistant/lifecycle-service", () => ({
+  lifecycleService: {
+    checkAssistant: async () => {},
+    markExpectingFirstMessage: () => {},
+  },
+}));
+
+mock.module("@/domains/onboarding/components/onboarding-layout", () => ({
+  OnboardingLayout: ({ children }: { children: ReactNode }) => children,
+}));
+
+mock.module("@/domains/onboarding/prefs", () => ({
+  readSelectedVersion: () => "",
+  writeSelectedVersion: () => {},
+}));
+
+mock.module("@/domains/onboarding/provider-key", () => ({
+  applyPendingProviderKey: async () => {},
+}));
+
+mock.module("@/domains/onboarding/plugin-attribution", () => ({
+  ATTRIBUTED_PLUGIN_PARAM: "attributed_plugin",
+}));
+
+mock.module("@/lib/local-mode", () => ({
+  isLocalMode: () => isLocalModeValue,
+  getPlatformRuntimeUrl: () => "https://runtime.example",
+  loadLockfile: async () => {},
+  primeLocalGatewayConnection: async () => {},
+  probeLocalGatewayReady: async () => true,
+  saveLockfileAssistant: async () => {},
+}));
+
+mock.module("@/lib/auth/gateway-session", () => ({
+  clearGatewayToken: () => {},
+}));
+
+mock.module("@/lib/navigation/navigation-resolver", () => ({
+  resolveNavigation: () => ({ action: "proceed" }),
+}));
+
+mock.module("@/lib/navigation/build-state", () => ({
+  buildNavigationState: () => ({}),
+}));
+
+mock.module("@/runtime/local-mode-host", () => ({
+  hatchLocalAssistant: hatchLocalAssistantMock,
+}));
+
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => false,
+}));
+
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => false,
+}));
+
+mock.module("@/assistant/selection", () => ({
+  setSelectedAssistant: () => {},
+}));
+
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    use: {
+      sessionStatus: () => "authenticated",
+    },
+    getState: () => ({
+      connectLocalAssistant: async () => {},
+    }),
+  },
+}));
+
+mock.module("@/stores/organization-store", () => ({
+  useOrganizationStore: {
+    getState: () => ({ currentOrganizationId: null }),
+  },
+}));
+
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: {
+    getState: () => ({ upsertFromApi: () => {} }),
+  },
+}));
+
+mock.module("@/stores/session-status", () => ({
+  isSessionSettled: () => true,
+}));
+
+mock.module("@/utils/api-errors", () => ({
+  extractErrorMessage: (_error: unknown, _detail: unknown, fallback: string) =>
+    fallback,
+}));
+
+mock.module("@/utils/avatar-bundled-components", () => ({
+  BUNDLED_COMPONENTS: {},
+}));
+
+mock.module("@/utils/avatar-random", () => ({
+  randomCharacterTraits: () => ({
+    bodyShape: "a",
+    eyeStyle: "b",
+    color: "c",
+  }),
+}));
+
+mock.module("@/utils/avatar-svg-compositor", () => ({
+  composeSvg: () => "<svg></svg>",
+}));
+
+mock.module("@/utils/routes", () => ({
+  routes: {
+    assistant: "/assistant",
+    onboarding: {
+      research: "/onboarding/research",
+      hosting: "/onboarding/hosting",
+      privacy: "/onboarding/privacy",
+    },
+  },
+}));
+
+mock.module("@vellumai/design-library/components/button", () => ({
+  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+}));
+
+mock.module("@vellumai/design-library/components/progress-bar", () => ({
+  ProgressBar: () => <div data-testid="progress-bar" />,
+}));
+
+const { HatchingScreen } = await import(
+  "@/domains/onboarding/pages/hatching-screen"
+);
+
+// --- Suite --------------------------------------------------------------------
+
+describe("HatchingScreen — post-payment provisioning wait", () => {
+  beforeEach(() => {
+    setSystemTime();
+    navigateMock.mockClear();
+    getAssistantMock.mockClear();
+    getAssistantHealthzMock.mockClear();
+    hatchAssistantMock.mockClear();
+    ensureProvisionedMock.mockClear();
+    onboardingRetrieveMock.mockClear();
+    hatchLocalAssistantMock.mockClear();
+    searchParams = new URLSearchParams();
+    isLocalModeValue = false;
+    idPollCount = 0;
+    resizePollClockStepMs = 0;
+    onboardingThrows = false;
+    onboardingData = null;
+    currentAssistant = {
+      id: "asst-1",
+      status: "active",
+      machine_size: "small",
+      provisioned_storage_gib: 10,
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    setSystemTime();
+  });
+
+  test(
+    "holds until actuals meet the purchased targets, then completes; reconcile fires once",
+    async () => {
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+
+      render(<HatchingScreen />);
+
+      // The resize wait is active — actuals (small/10) are below the purchased
+      // ceiling (extra_large/50), so the screen holds without completing.
+      await waitFor(() =>
+        expect(screen.getByText(RESIZE_LABEL)).toBeTruthy(),
+      );
+      expect(ensureProvisionedMock).toHaveBeenCalledTimes(1);
+      expect(navigateMock).not.toHaveBeenCalled();
+
+      // The server-side resize lands: actuals now meet the targets.
+      currentAssistant.machine_size = "extra_large";
+      currentAssistant.provisioned_storage_gib = 50;
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+      expect(ensureProvisionedMock).toHaveBeenCalledTimes(1);
+    },
+    20000,
+  );
+
+  test("free org with null targets completes with no added wait", async () => {
+    onboardingData = { max_machine_tier: null, selected_storage_gib: null };
+
+    render(<HatchingScreen />);
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+      timeout: 5000,
+    });
+    // No purchased ceiling to wait on: the resize phase is never entered.
+    expect(screen.queryByText(RESIZE_LABEL)).toBeNull();
+  });
+
+  test("a failed targets fetch completes as today", async () => {
+    onboardingThrows = true;
+
+    render(<HatchingScreen />);
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+      timeout: 5000,
+    });
+    expect(screen.queryByText(RESIZE_LABEL)).toBeNull();
+  });
+
+  test(
+    "the wait exceeding the hard cap completes anyway",
+    async () => {
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+      // Actuals stay below the targets; the resize poll jumps the clock past the
+      // RESIZE_WAIT_MAX_MS cap so completion falls through at baseline.
+      resizePollClockStepMs = 91_000;
+
+      render(<HatchingScreen />);
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+      // Never met the targets — completion came from the cap, not convergence.
+      expect(currentAssistant.machine_size).toBe("small");
+      expect(ensureProvisionedMock).toHaveBeenCalledTimes(1);
+    },
+    20000,
+  );
+
+  test("local hatches never fire the reconcile or targets fetch", async () => {
+    isLocalModeValue = true;
+    searchParams = new URLSearchParams("hosting=docker");
+
+    render(<HatchingScreen />);
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+      timeout: 5000,
+    });
+    expect(ensureProvisionedMock).not.toHaveBeenCalled();
+    expect(onboardingRetrieveMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -35,6 +35,14 @@ let searchParams = new URLSearchParams();
 
 let isLocalModeValue = false;
 
+// The observed subscription plan gates the free/no-wait decision (Fix 2).
+let subscriptionPlanId = "base";
+// Whether a resize operation reads as still in flight (Fix 1).
+let opStatusInFlight = false;
+// Whether the no-id pre-flight getAssistant resolves an already-active
+// assistant (the reload path, Fix 3).
+let preflightActive = false;
+
 interface AssistantShape {
   id: string;
   status: string;
@@ -60,6 +68,10 @@ let onboardingThrows = false;
 
 const getAssistantMock = mock(async (id?: string) => {
   if (!id) {
+    if (preflightActive) {
+      // Reload onto an already-active assistant.
+      return { ok: true as const, status: 200, data: { ...currentAssistant } };
+    }
     // Pre-flight with no id: no assistant exists yet (auto_hatch).
     return { ok: false as const, status: 404, error: {} };
   }
@@ -93,6 +105,17 @@ const onboardingRetrieveMock = mock(async () => {
   return { data: onboardingData };
 });
 
+const subscriptionRetrieveMock = mock(async () => ({
+  data: { plan_id: subscriptionPlanId },
+}));
+
+const operationalStatusReadMock = mock(async () => ({
+  data: {
+    state: opStatusInFlight ? "resizing_machine" : "active",
+    active_operation: null,
+  },
+}));
+
 const hatchLocalAssistantMock = mock(async () => ({
   ok: true as const,
   assistantId: "local-1",
@@ -123,9 +146,11 @@ mock.module("@/assistant/api", () => ({
 }));
 
 mock.module("@/generated/api/sdk.gen", () => ({
+  assistantsOperationalStatusDetailRead: operationalStatusReadMock,
   organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate:
     ensureProvisionedMock,
   organizationsBillingSubscriptionOnboardingRetrieve: onboardingRetrieveMock,
+  organizationsBillingSubscriptionRetrieve: subscriptionRetrieveMock,
 }));
 
 mock.module("@/assistant/seed-hatch-avatar", () => ({
@@ -294,9 +319,14 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     hatchAssistantMock.mockClear();
     ensureProvisionedMock.mockClear();
     onboardingRetrieveMock.mockClear();
+    subscriptionRetrieveMock.mockClear();
+    operationalStatusReadMock.mockClear();
     hatchLocalAssistantMock.mockClear();
     searchParams = new URLSearchParams();
     isLocalModeValue = false;
+    subscriptionPlanId = "base";
+    opStatusInFlight = false;
+    preflightActive = false;
     idPollCount = 0;
     resizePollClockStepMs = 0;
     onboardingThrows = false;
@@ -317,6 +347,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
   test(
     "holds until actuals meet the purchased targets, then completes; reconcile fires once",
     async () => {
+      subscriptionPlanId = "pro";
       onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
 
       render(<HatchingScreen />);
@@ -342,6 +373,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
   );
 
   test("free org with null targets completes with no added wait", async () => {
+    subscriptionPlanId = "base";
     onboardingData = { max_machine_tier: null, selected_storage_gib: null };
 
     render(<HatchingScreen />);
@@ -349,11 +381,12 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
       timeout: 5000,
     });
-    // No purchased ceiling to wait on: the resize phase is never entered.
+    // Not a Pro subscription: the resize phase is never entered.
     expect(screen.queryByText(RESIZE_LABEL)).toBeNull();
   });
 
-  test("a failed targets fetch completes as today", async () => {
+  test("a base plan whose targets fetch fails still completes, never trapping", async () => {
+    subscriptionPlanId = "base";
     onboardingThrows = true;
 
     render(<HatchingScreen />);
@@ -365,8 +398,130 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
   });
 
   test(
+    "a non-pro subscription completes immediately even when targets are present",
+    async () => {
+      // The free/no-wait decision is gated on plan_id, not on the targets: a
+      // base plan completes at baseline even though onboarding names a ceiling.
+      subscriptionPlanId = "base";
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+
+      render(<HatchingScreen />);
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 5000,
+      });
+      expect(screen.queryByText(RESIZE_LABEL)).toBeNull();
+    },
+  );
+
+  test(
+    "targets met but the resize operation still in flight holds until it clears",
+    async () => {
+      subscriptionPlanId = "pro";
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+      // Actuals already sit at the purchased ceiling, but the resize operation
+      // is still rolling out — completion must wait for the operation, not just
+      // targets-met, so the screen holds.
+      currentAssistant.machine_size = "extra_large";
+      currentAssistant.provisioned_storage_gib = 50;
+      opStatusInFlight = true;
+
+      render(<HatchingScreen />);
+
+      await waitFor(() => expect(screen.getByText(RESIZE_LABEL)).toBeTruthy());
+      // The resize loop keeps polling operational status while it holds.
+      await waitFor(
+        () =>
+          expect(
+            operationalStatusReadMock.mock.calls.length,
+          ).toBeGreaterThanOrEqual(2),
+        { timeout: 15000 },
+      );
+      expect(navigateMock).not.toHaveBeenCalled();
+
+      // The resize operation clears.
+      opStatusInFlight = false;
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+    },
+    20000,
+  );
+
+  test(
+    "plan pro with lagging targets keeps waiting (not free) until targets appear",
+    async () => {
+      subscriptionPlanId = "pro";
+      // Targets aren't visible yet — the entitlement/targets race.
+      onboardingData = null;
+      // Actuals already meet the eventual ceiling so completion is prompt once
+      // the targets land.
+      currentAssistant.machine_size = "extra_large";
+      currentAssistant.provisioned_storage_gib = 50;
+
+      render(<HatchingScreen />);
+
+      // The reconcile fires, and the subscription/targets poll keeps re-fetching
+      // rather than concluding "free" and completing at baseline.
+      await waitFor(() =>
+        expect(ensureProvisionedMock).toHaveBeenCalledTimes(1),
+      );
+      await waitFor(
+        () =>
+          expect(
+            onboardingRetrieveMock.mock.calls.length,
+          ).toBeGreaterThanOrEqual(2),
+        { timeout: 15000 },
+      );
+      expect(navigateMock).not.toHaveBeenCalled();
+
+      // Targets become visible; the flow now holds for and clears the resize.
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+    },
+    20000,
+  );
+
+  test(
+    "a preflight-active reload runs the provisioning wait before completing",
+    async () => {
+      // The baseline assistant is already active on reload; the preflight path
+      // must still reconcile and hold for the purchased resize.
+      preflightActive = true;
+      subscriptionPlanId = "pro";
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+      currentAssistant.machine_size = "small";
+      currentAssistant.provisioned_storage_gib = 10;
+
+      render(<HatchingScreen />);
+
+      await waitFor(() => expect(screen.getByText(RESIZE_LABEL)).toBeTruthy(), {
+        timeout: 15000,
+      });
+      // The preflight short-circuits the hatch request but still provisions.
+      expect(hatchAssistantMock).not.toHaveBeenCalled();
+      expect(ensureProvisionedMock).toHaveBeenCalledTimes(1);
+      expect(navigateMock).not.toHaveBeenCalled();
+
+      // The resize lands.
+      currentAssistant.machine_size = "extra_large";
+      currentAssistant.provisioned_storage_gib = 50;
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+    },
+    20000,
+  );
+
+  test(
     "the wait exceeding the hard cap completes anyway",
     async () => {
+      subscriptionPlanId = "pro";
       onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
       // Actuals stay below the targets; the resize poll jumps the clock past the
       // RESIZE_WAIT_MAX_MS cap so completion falls through at baseline.
@@ -384,7 +539,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     20000,
   );
 
-  test("local hatches never fire the reconcile or targets fetch", async () => {
+  test("local hatches never provision", async () => {
     isLocalModeValue = true;
     searchParams = new URLSearchParams("hosting=docker");
 
@@ -395,5 +550,7 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     });
     expect(ensureProvisionedMock).not.toHaveBeenCalled();
     expect(onboardingRetrieveMock).not.toHaveBeenCalled();
+    expect(subscriptionRetrieveMock).not.toHaveBeenCalled();
+    expect(operationalStatusReadMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -106,9 +106,19 @@ const hatchAssistantMock = mock(async () => ({
   data: { id: "asst-1", status: "provisioning" },
 }));
 
-const ensureProvisionedMock = mock(async () => ({
-  data: { state: "started", reason: null, targets: {} },
-}));
+// How many leading reconcile calls resolve with NO data — a 503 "nothing
+// queued" / network blip under throwOnError:false — before one succeeds. 0 =
+// always succeed. Infinity = never succeeds.
+let ensureProvisionedFailFirstN = 0;
+let ensureProvisionedCallCount = 0;
+
+const ensureProvisionedMock = mock(async () => {
+  ensureProvisionedCallCount += 1;
+  if (ensureProvisionedCallCount <= ensureProvisionedFailFirstN) {
+    return { data: undefined };
+  }
+  return { data: { state: "started", reason: null, targets: {} } };
+});
 
 const onboardingRetrieveMock = mock(async () => {
   if (onboardingThrows) {
@@ -361,6 +371,8 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     resizePollClockStepMs = 0;
     subscriptionCallCount = 0;
     subscriptionPollClockStepMs = 0;
+    ensureProvisionedFailFirstN = 0;
+    ensureProvisionedCallCount = 0;
     onboardingThrows = false;
     onboardingData = null;
     currentAssistant = {
@@ -665,6 +677,95 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
       await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
         timeout: 15000,
       });
+    },
+    20000,
+  );
+
+  test(
+    "a reconcile that fails on the first attempt re-fires on a later poll and provisioning proceeds",
+    async () => {
+      subscriptionPlanId = "pro";
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+      // The first reconcile fails (a 503 "nothing queued" resolves with no data
+      // under throwOnError:false); a failed reconcile must not permanently
+      // consume the fire-once guard, so a later poll re-fires it and it lands.
+      ensureProvisionedFailFirstN = 1;
+      // Actuals already sit at the ceiling so the resize completes promptly once
+      // the reconcile lands.
+      currentAssistant.machine_size = "extra_large";
+      currentAssistant.provisioned_storage_gib = 50;
+
+      render(<HatchingScreen />);
+
+      // The reconcile is re-fired after the first failure (called more than once).
+      await waitFor(
+        () =>
+          expect(
+            ensureProvisionedMock.mock.calls.length,
+          ).toBeGreaterThanOrEqual(2),
+        { timeout: 15000 },
+      );
+      // Provisioning still converges and the screen completes.
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+    },
+    20000,
+  );
+
+  test(
+    "a persistently-failing reconcile still completes at the hard cap",
+    async () => {
+      subscriptionPlanId = "pro";
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+      // The reconcile never succeeds (always resolves with no data), so it
+      // re-fires on every poll — but the RESIZE_WAIT_MAX_MS cap is the ultimate
+      // escape so the user is never trapped.
+      ensureProvisionedFailFirstN = Number.POSITIVE_INFINITY;
+      // Actuals stay below the ceiling; the resize poll jumps the clock past the
+      // cap so completion falls through at baseline.
+      resizePollClockStepMs = 91_000;
+
+      render(<HatchingScreen />);
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+      // Re-fired more than once before the cap released it.
+      expect(ensureProvisionedMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+      // Completion came from the cap, not convergence.
+      expect(currentAssistant.machine_size).toBe("small");
+    },
+    20000,
+  );
+
+  test(
+    "the resize deadline expiring while still in flight still health-probes before completing",
+    async () => {
+      subscriptionPlanId = "pro";
+      onboardingData = { max_machine_tier: "xl", selected_storage_gib: 50 };
+      // The resize never converges: the operation reads as perpetually in
+      // flight, so the loop can exit only via the RESIZE_WAIT_MAX_MS cap. Even
+      // on that deadline-expiry path a healthz probe must run before completion
+      // so the user is never routed onto a pod mid-restart.
+      currentAssistant.machine_size = "extra_large";
+      currentAssistant.provisioned_storage_gib = 50;
+      opStatusInFlight = true;
+      // The resize poll jumps the clock past the cap so the deadline fires
+      // without a real 90s wait.
+      resizePollClockStepMs = 91_000;
+
+      render(<HatchingScreen />);
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 15000,
+      });
+      // The connecting phase probes healthz once; the post-resize probe on the
+      // deadline path is the second — proving completion went through a health
+      // check even when the cap fired.
+      expect(
+        getAssistantHealthzMock.mock.calls.length,
+      ).toBeGreaterThanOrEqual(2);
     },
     20000,
   );

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -6,11 +6,14 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { getAssistant, getAssistantHealthz, hatchAssistant, type Assistant } from "@/assistant/api";
 import {
+    assistantsOperationalStatusDetailRead,
     organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate,
     organizationsBillingSubscriptionOnboardingRetrieve,
+    organizationsBillingSubscriptionRetrieve,
 } from "@/generated/api/sdk.gen";
 import { allowedMachineSizesForTier } from "@/lib/billing/machine-sizes";
 import {
+    isResizeOperationInFlight,
     targetsMet,
     type ProvisioningDimensions,
 } from "@/lib/billing/provisioning-targets";
@@ -323,7 +326,9 @@ export function HatchingScreen() {
                   useOrganizationStore.getState().currentOrganizationId ?? undefined,
               });
             }
-            handleHatchReady();
+            // Route the reload path through the same provisioning wait as the
+            // polled-active path so a purchased resize is never skipped.
+            await finishActiveHatch(existing.data.id);
             return;
           }
           // A clean 404 (`auto_hatch`) means no assistant existed yet, so the
@@ -501,10 +506,10 @@ export function HatchingScreen() {
     // Platform-only: once the assistant is active and healthz-ready, hold the
     // hatching screen until the server-side resize to the purchased machine and
     // storage specs converges, then re-probe healthz (the resize restarts the
-    // pod). The reconcile is idempotent and fire-and-forget; any failure, a free
-    // org with nothing purchased, or the RESIZE_WAIT_MAX_MS cap falls through to
-    // completion at baseline, so a Pro hatch emerges at the right size without
-    // ever trapping the user.
+    // pod). The reconcile is idempotent and fire-and-forget; a genuinely free
+    // org, and the RESIZE_WAIT_MAX_MS cap, fall through to completion at
+    // baseline, so a Pro hatch emerges at the right size without ever trapping
+    // the user.
     const awaitPurchasedProvisioning = async (
       assistantId: string,
     ): Promise<void> => {
@@ -520,41 +525,81 @@ export function HatchingScreen() {
         });
       }
 
-      // Resolve the purchased ceilings, mirroring the pro-onboarding derivation.
+      // The cap covers both waits below — the entitlement/targets confirmation
+      // and the resize itself — so a lagging subscription can never hold the
+      // user past RESIZE_WAIT_MAX_MS.
+      const resizeDeadline = Date.now() + RESIZE_WAIT_MAX_MS;
+
+      // Confirm the entitlement before concluding "free". A paid checkout can
+      // return before the onboarding targets are visible, so gate the no-wait
+      // completion on the actual subscription plan rather than on the first null
+      // targets. While the plan reads Pro but the targets aren't provisioned yet
+      // (the entitlement race), keep polling the subscription and targets within
+      // the cap instead of completing at baseline.
       let targets: ProvisioningDimensions | null = null;
-      try {
-        const onboarding =
-          await organizationsBillingSubscriptionOnboardingRetrieve({
+      while (!cancelled) {
+        let planId: string | null = null;
+        try {
+          const subscription = await organizationsBillingSubscriptionRetrieve({
             throwOnError: false,
           });
-        const data = onboarding.data;
-        if (data) {
-          targets = {
-            machineSize:
-              allowedMachineSizesForTier(data.max_machine_tier).at(-1) ?? null,
-            storageGib: data.selected_storage_gib ?? null,
-          };
+          if (cancelled) {
+            return;
+          }
+          planId = subscription.data?.plan_id ?? null;
+        } catch {
+          // Subscription endpoint blip; keep polling to the cap.
         }
-      } catch {
-        // Fire-and-forget: a failed targets fetch falls through to completion.
+
+        try {
+          const onboarding =
+            await organizationsBillingSubscriptionOnboardingRetrieve({
+              throwOnError: false,
+            });
+          if (cancelled) {
+            return;
+          }
+          const data = onboarding.data;
+          if (data) {
+            targets = {
+              machineSize:
+                allowedMachineSizesForTier(data.max_machine_tier).at(-1) ?? null,
+              storageGib: data.selected_storage_gib ?? null,
+            };
+          }
+        } catch {
+          // Targets fetch blip; keep polling to the cap.
+        }
+
+        const hasTargets =
+          targets != null &&
+          (targets.machineSize != null || targets.storageGib != null);
+
+        // Not Pro — genuinely free, or the subscription hasn't flipped. Complete
+        // exactly as a non-provisioned hatch does today.
+        if (planId !== "pro") {
+          return;
+        }
+        // Pro with a purchased ceiling to wait on: hold for the resize below.
+        if (hasTargets) {
+          break;
+        }
+        // Pro but the targets aren't visible yet: keep polling within the cap
+        // rather than completing at baseline onto an unprovisioned assistant.
+        if (Date.now() >= resizeDeadline) {
+          return;
+        }
+        await new Promise<void>((resolve) => {
+          pollTimer = setTimeout(resolve, POLL_INTERVAL_MS);
+        });
+        pollTimer = null;
       }
       if (cancelled) {
         return;
       }
 
-      // A free org (or nothing purchased) has no ceiling to wait on — complete
-      // exactly as a non-provisioned hatch does today.
-      if (
-        !targets ||
-        (targets.machineSize == null && targets.storageGib == null)
-      ) {
-        return;
-      }
-
-      // Hold in an in-progress phase while the resize lands. The cap is measured
-      // from here — the reconcile above is already in flight.
+      // Hold in an in-progress phase while the resize lands.
       transitionPhase("resizing");
-      const resizeDeadline = Date.now() + RESIZE_WAIT_MAX_MS;
 
       while (!cancelled) {
         let actuals: ProvisioningDimensions | null = null;
@@ -572,7 +617,27 @@ export function HatchingScreen() {
         } catch {
           // Assistant endpoint unreachable mid-resize; keep polling to the cap.
         }
-        if (targetsMet(targets, actuals)) {
+
+        let operationInFlight = false;
+        try {
+          const opStatus = await assistantsOperationalStatusDetailRead({
+            path: { id: assistantId },
+            throwOnError: false,
+          });
+          if (cancelled) {
+            return;
+          }
+          operationInFlight = isResizeOperationInFlight(opStatus.data);
+        } catch {
+          // Operational-status endpoint unreachable mid-resize: treat the resize
+          // as still in flight and keep polling to the cap rather than guessing.
+          operationInFlight = true;
+        }
+
+        // The platform persists the effective sizes before the pod finishes
+        // restarting, so completion requires the resize operation to have
+        // cleared — not just targets-met — to avoid landing on a soon-dead pod.
+        if (targetsMet(targets, actuals) && !operationInFlight) {
           break;
         }
         if (Date.now() >= resizeDeadline) {
@@ -607,6 +672,46 @@ export function HatchingScreen() {
         });
         pollTimer = null;
       }
+    };
+
+    // Both the preflight-active path (a reload onto an already-active assistant)
+    // and the polled-active path converge here: wait for healthz, hold for the
+    // purchased resize, then complete. Sharing this tail keeps a reload from
+    // skipping the provisioning wait.
+    const finishActiveHatch = async (assistantId: string): Promise<void> => {
+      // The platform may report "active" before the pod is ready to serve, so
+      // wait for the daemon to answer healthz before holding for the resize.
+      transitionPhase("connecting");
+      while (!cancelled) {
+        try {
+          const health = await getAssistantHealthz(assistantId);
+          if (health.ok) {
+            break;
+          }
+        } catch {
+          // Daemon not reachable yet.
+        }
+        if (Date.now() - pollStartMs >= MAX_HATCH_WAIT_MS) {
+          setError(
+            "Your assistant is taking longer than expected. Please try again.",
+          );
+          return;
+        }
+        await new Promise<void>((resolve) => {
+          pollTimer = setTimeout(resolve, POLL_INTERVAL_MS);
+        });
+        pollTimer = null;
+      }
+      if (cancelled) {
+        return;
+      }
+
+      await awaitPurchasedProvisioning(assistantId);
+      if (cancelled) {
+        return;
+      }
+
+      handleHatchReady();
     };
 
     const runPoll = async () => {
@@ -652,34 +757,11 @@ export function HatchingScreen() {
               });
             }
 
-            // Wait for the daemon to be reachable before navigating.
-            // The platform may report "active" before the pod is
-            // fully ready to serve requests.
-            transitionPhase("connecting");
-            while (!cancelled) {
-              try {
-                const health = await getAssistantHealthz(assistantId);
-                if (health.ok) break;
-              } catch {
-                // Daemon not reachable yet
-              }
-              if (Date.now() - pollStartMs >= MAX_HATCH_WAIT_MS) {
-                setError("Your assistant is taking longer than expected. Please try again.");
-                return;
-              }
-              await new Promise<void>(resolve => {
-                pollTimer = setTimeout(resolve, POLL_INTERVAL_MS);
-              });
-              pollTimer = null;
-            }
-            if (cancelled) return;
-
-            // Hold completion until the purchased machine/storage resize lands
-            // (platform hatches only; local hatches never reach this poll loop).
-            await awaitPurchasedProvisioning(assistantId);
-            if (cancelled) {
-              return;
-            }
+            // Wait for healthz, then hold for the purchased resize before
+            // completing (platform hatches only; local hatches never reach this
+            // poll loop).
+            await finishActiveHatch(assistantId);
+            return;
           }
 
           handleHatchReady();

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -538,7 +538,13 @@ export function HatchingScreen() {
       // the cap instead of completing at baseline.
       let targets: ProvisioningDimensions | null = null;
       while (!cancelled) {
-        let planId: string | null = null;
+        // Tri-state entitlement read. Only a CONFIRMED non-Pro plan — a
+        // successful response whose plan_id is definitively not "pro" —
+        // completes early. An unknown result (a thrown error, or a 5xx that
+        // resolves with no data under throwOnError:false) must not be mistaken
+        // for "free"; it behaves like "Pro but targets not yet provisioned" and
+        // keeps polling within the cap so a purchased resize is never skipped.
+        let subscriptionState: "pro" | "non_pro" | "unknown" = "unknown";
         try {
           const subscription = await organizationsBillingSubscriptionRetrieve({
             throwOnError: false,
@@ -546,9 +552,12 @@ export function HatchingScreen() {
           if (cancelled) {
             return;
           }
-          planId = subscription.data?.plan_id ?? null;
+          if (subscription.data) {
+            subscriptionState =
+              subscription.data.plan_id === "pro" ? "pro" : "non_pro";
+          }
         } catch {
-          // Subscription endpoint blip; keep polling to the cap.
+          // Subscription endpoint blip: stay "unknown" and keep polling to the cap.
         }
 
         try {
@@ -575,17 +584,20 @@ export function HatchingScreen() {
           targets != null &&
           (targets.machineSize != null || targets.storageGib != null);
 
-        // Not Pro — genuinely free, or the subscription hasn't flipped. Complete
-        // exactly as a non-provisioned hatch does today.
-        if (planId !== "pro") {
+        // Confirmed non-Pro — genuinely free. Complete exactly as a
+        // non-provisioned hatch does today.
+        if (subscriptionState === "non_pro") {
           return;
         }
-        // Pro with a purchased ceiling to wait on: hold for the resize below.
-        if (hasTargets) {
+        // Confirmed Pro with a purchased ceiling to wait on: hold for the resize
+        // below.
+        if (subscriptionState === "pro" && hasTargets) {
           break;
         }
-        // Pro but the targets aren't visible yet: keep polling within the cap
-        // rather than completing at baseline onto an unprovisioned assistant.
+        // Pro with targets not yet visible, or an unknown/errored subscription
+        // read: keep polling within the cap rather than completing at baseline
+        // onto an unprovisioned assistant. The cap is the ultimate escape so a
+        // persistently-erroring subscription endpoint still completes.
         if (Date.now() >= resizeDeadline) {
           return;
         }
@@ -618,7 +630,12 @@ export function HatchingScreen() {
           // Assistant endpoint unreachable mid-resize; keep polling to the cap.
         }
 
-        let operationInFlight = false;
+        // Default to in-flight so an uncertain status read withholds completion.
+        // Under throwOnError:false a 5xx resolves with no data rather than
+        // throwing, and isResizeOperationInFlight(undefined) is false — so only
+        // a successful read (data present) may downgrade to "not in flight".
+        // Otherwise the screen could navigate onto a pod that is still restarting.
+        let operationInFlight = true;
         try {
           const opStatus = await assistantsOperationalStatusDetailRead({
             path: { id: assistantId },
@@ -627,10 +644,12 @@ export function HatchingScreen() {
           if (cancelled) {
             return;
           }
-          operationInFlight = isResizeOperationInFlight(opStatus.data);
+          if (opStatus.data) {
+            operationInFlight = isResizeOperationInFlight(opStatus.data);
+          }
         } catch {
-          // Operational-status endpoint unreachable mid-resize: treat the resize
-          // as still in flight and keep polling to the cap rather than guessing.
+          // Operational-status endpoint unreachable mid-resize: retain the
+          // conservative in-flight value and keep polling to the cap.
           operationInFlight = true;
         }
 

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -513,17 +513,31 @@ export function HatchingScreen() {
     const awaitPurchasedProvisioning = async (
       assistantId: string,
     ): Promise<void> => {
-      // Fire the idempotent reconcile exactly once. It submits the same grow-only
-      // resize the subscribe webhook triggers, covering a webhook that never
-      // fired or whose resize was lost. A failure here never blocks hatching.
-      if (!provisioningReconcileFiredRef.current) {
-        provisioningReconcileFiredRef.current = true;
+      // Fire the idempotent grow-only reconcile — the same resize the subscribe
+      // webhook triggers — covering a webhook that never fired or whose resize
+      // was lost. It is marked done only when it SUCCEEDS: a 503 ("nothing
+      // queued"), a network error, or a pre-org-hydration mount leaves the guard
+      // unset so a later poll iteration re-fires the nudge. It never blocks
+      // completion (which keys off targets + op-status); the re-fires stay
+      // bounded by the RESIZE_WAIT_MAX_MS cap below.
+      const fireProvisioningReconcile = (): void => {
+        if (provisioningReconcileFiredRef.current) {
+          return;
+        }
         void organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate({
           throwOnError: false,
-        }).catch(() => {
-          // Fire-and-forget: the server converges the resize on its own.
-        });
-      }
+        })
+          .then((result) => {
+            // Success carries a body; a 503/5xx resolves with no data under
+            // throwOnError:false. Only a real success consumes the guard.
+            if (result.data != null) {
+              provisioningReconcileFiredRef.current = true;
+            }
+          })
+          .catch(() => {
+            // Network/thrown error: leave the guard unset to re-fire on a later poll.
+          });
+      };
 
       // The cap covers both waits below — the entitlement/targets confirmation
       // and the resize itself — so a lagging subscription can never hold the
@@ -538,6 +552,9 @@ export function HatchingScreen() {
       // the cap instead of completing at baseline.
       let targets: ProvisioningDimensions | null = null;
       while (!cancelled) {
+        // Re-fire the reconcile until it succeeds (or the cap): a failed first
+        // attempt must not permanently consume the guard.
+        fireProvisioningReconcile();
         // Tri-state entitlement read. Only a CONFIRMED non-Pro plan — a
         // successful response whose plan_id is definitively not "pro" —
         // completes early. An unknown result (a thrown error, or a 5xx that
@@ -614,6 +631,9 @@ export function HatchingScreen() {
       transitionPhase("resizing");
 
       while (!cancelled) {
+        // Keep nudging the resize in case the reconcile hasn't landed yet; the
+        // guard stops the re-fire once it succeeds.
+        fireProvisioningReconcile();
         let actuals: ProvisioningDimensions | null = null;
         try {
           const actualsResult = await getAssistant(assistantId);
@@ -660,8 +680,10 @@ export function HatchingScreen() {
           break;
         }
         if (Date.now() >= resizeDeadline) {
-          // Cap reached: proceed at baseline; the server reconciles later.
-          return;
+          // Cap reached: stop waiting for the resize but still fall through to
+          // the healthz probe below, so completion never routes onto a pod
+          // mid-restart. The server reconciles the remaining resize later.
+          break;
         }
         await new Promise<void>((resolve) => {
           pollTimer = setTimeout(resolve, POLL_INTERVAL_MS);
@@ -672,8 +694,9 @@ export function HatchingScreen() {
         return;
       }
 
-      // The resize restarts the pod, so re-probe healthz before completing to
-      // avoid landing on a mid-restart daemon.
+      // The resize restarts the pod, so re-probe healthz before completing —
+      // on both the converged and the cap-expiry exit above — to avoid landing
+      // on a mid-restart daemon.
       while (!cancelled) {
         try {
           const health = await getAssistantHealthz(assistantId);

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -5,6 +5,15 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { getAssistant, getAssistantHealthz, hatchAssistant, type Assistant } from "@/assistant/api";
+import {
+    organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate,
+    organizationsBillingSubscriptionOnboardingRetrieve,
+} from "@/generated/api/sdk.gen";
+import { allowedMachineSizesForTier } from "@/lib/billing/machine-sizes";
+import {
+    targetsMet,
+    type ProvisioningDimensions,
+} from "@/lib/billing/provisioning-targets";
 import { seedHatchAvatar } from "@/assistant/seed-hatch-avatar";
 import {
     isPlatformHostedDisabled,
@@ -44,6 +53,10 @@ import { ProgressBar } from "@vellumai/design-library/components/progress-bar";
 const POLL_INTERVAL_MS = 3000;
 const COMPLETION_NAVIGATE_DELAY_MS = 800;
 const MAX_HATCH_WAIT_MS = 300_000;
+// Hard cap on the post-payment resize wait, mirroring PROVISION_STALL_MS in the
+// pro-onboarding takeover. On expiry the assistant completes at baseline and the
+// server reconciles the purchased specs later — the user is never trapped.
+const RESIZE_WAIT_MAX_MS = 90_000;
 
 // Module-level state so HMR remounts, StrictMode double-mounts, and — critically
 // — the auth-driven provider remount survive without spawning duplicate hatches.
@@ -65,12 +78,18 @@ function releaseHatchGuards(): void {
   hatchTraitsCache = null;
 }
 
-type HatchPhase = "initializing" | "provisioning" | "connecting" | "ready";
+type HatchPhase =
+  | "initializing"
+  | "provisioning"
+  | "connecting"
+  | "resizing"
+  | "ready";
 
 const PHASE_TARGET: Record<HatchPhase, number> = {
   initializing: 0,
   provisioning: 0.33,
   connecting: 0.66,
+  resizing: 0.85,
   ready: 1.0,
 };
 
@@ -80,6 +99,7 @@ const PHASE_LABEL: Record<HatchPhase, string> = {
   initializing: "Getting things ready…",
   provisioning: "Setting up your assistant…",
   connecting: "Connecting to your assistant…",
+  resizing: "Setting up your machine…",
   ready: "Ready",
 };
 
@@ -153,6 +173,9 @@ export function HatchingScreen() {
   const segmentStartRef = useRef(0);
   const segmentStartTimeRef = useRef(0);
   const displayProgressRef = useRef(0);
+  // Fire-once guard for the idempotent post-payment provisioning reconcile, so a
+  // remount or an extra poll can't re-trigger it within a single hatch.
+  const provisioningReconcileFiredRef = useRef(false);
 
   const transitionPhase = useCallback((next: HatchPhase) => {
     segmentStartRef.current = displayProgressRef.current;
@@ -475,6 +498,117 @@ export function HatchingScreen() {
       pollTimer = setTimeout(runPoll, delay);
     };
 
+    // Platform-only: once the assistant is active and healthz-ready, hold the
+    // hatching screen until the server-side resize to the purchased machine and
+    // storage specs converges, then re-probe healthz (the resize restarts the
+    // pod). The reconcile is idempotent and fire-and-forget; any failure, a free
+    // org with nothing purchased, or the RESIZE_WAIT_MAX_MS cap falls through to
+    // completion at baseline, so a Pro hatch emerges at the right size without
+    // ever trapping the user.
+    const awaitPurchasedProvisioning = async (
+      assistantId: string,
+    ): Promise<void> => {
+      // Fire the idempotent reconcile exactly once. It submits the same grow-only
+      // resize the subscribe webhook triggers, covering a webhook that never
+      // fired or whose resize was lost. A failure here never blocks hatching.
+      if (!provisioningReconcileFiredRef.current) {
+        provisioningReconcileFiredRef.current = true;
+        void organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate({
+          throwOnError: false,
+        }).catch(() => {
+          // Fire-and-forget: the server converges the resize on its own.
+        });
+      }
+
+      // Resolve the purchased ceilings, mirroring the pro-onboarding derivation.
+      let targets: ProvisioningDimensions | null = null;
+      try {
+        const onboarding =
+          await organizationsBillingSubscriptionOnboardingRetrieve({
+            throwOnError: false,
+          });
+        const data = onboarding.data;
+        if (data) {
+          targets = {
+            machineSize:
+              allowedMachineSizesForTier(data.max_machine_tier).at(-1) ?? null,
+            storageGib: data.selected_storage_gib ?? null,
+          };
+        }
+      } catch {
+        // Fire-and-forget: a failed targets fetch falls through to completion.
+      }
+      if (cancelled) {
+        return;
+      }
+
+      // A free org (or nothing purchased) has no ceiling to wait on — complete
+      // exactly as a non-provisioned hatch does today.
+      if (
+        !targets ||
+        (targets.machineSize == null && targets.storageGib == null)
+      ) {
+        return;
+      }
+
+      // Hold in an in-progress phase while the resize lands. The cap is measured
+      // from here — the reconcile above is already in flight.
+      transitionPhase("resizing");
+      const resizeDeadline = Date.now() + RESIZE_WAIT_MAX_MS;
+
+      while (!cancelled) {
+        let actuals: ProvisioningDimensions | null = null;
+        try {
+          const actualsResult = await getAssistant(assistantId);
+          if (cancelled) {
+            return;
+          }
+          if (actualsResult.ok) {
+            actuals = {
+              machineSize: actualsResult.data.machine_size ?? null,
+              storageGib: actualsResult.data.provisioned_storage_gib ?? null,
+            };
+          }
+        } catch {
+          // Assistant endpoint unreachable mid-resize; keep polling to the cap.
+        }
+        if (targetsMet(targets, actuals)) {
+          break;
+        }
+        if (Date.now() >= resizeDeadline) {
+          // Cap reached: proceed at baseline; the server reconciles later.
+          return;
+        }
+        await new Promise<void>((resolve) => {
+          pollTimer = setTimeout(resolve, POLL_INTERVAL_MS);
+        });
+        pollTimer = null;
+      }
+      if (cancelled) {
+        return;
+      }
+
+      // The resize restarts the pod, so re-probe healthz before completing to
+      // avoid landing on a mid-restart daemon.
+      while (!cancelled) {
+        try {
+          const health = await getAssistantHealthz(assistantId);
+          if (health.ok) {
+            break;
+          }
+        } catch {
+          // Daemon not reachable yet during the post-resize restart.
+        }
+        if (Date.now() - pollStartMs >= MAX_HATCH_WAIT_MS) {
+          return;
+        }
+        await new Promise<void>((resolve) => {
+          pollTimer = setTimeout(resolve, POLL_INTERVAL_MS);
+        });
+        pollTimer = null;
+      }
+    };
+
     const runPoll = async () => {
       if (cancelled) return;
       if (Date.now() - pollStartMs >= MAX_HATCH_WAIT_MS) {
@@ -539,6 +673,13 @@ export function HatchingScreen() {
               pollTimer = null;
             }
             if (cancelled) return;
+
+            // Hold completion until the purchased machine/storage resize lands
+            // (platform hatches only; local hatches never reach this poll loop).
+            await awaitPurchasedProvisioning(assistantId);
+            if (cancelled) {
+              return;
+            }
           }
 
           handleHatchReady();

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -39,9 +39,9 @@ import {
   organizationsBillingSubscriptionRetrieveOptions,
   organizationsBillingSubscriptionRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
-import type { OperationalStatus } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { allowedMachineSizesForTier } from "@/lib/billing/machine-sizes";
+import { isResizeOperationInFlight } from "@/lib/billing/provisioning-targets";
 import { useOrganizationStore } from "@/stores/organization-store";
 
 import {
@@ -73,19 +73,9 @@ const TERMINAL_STATES: readonly ProvisioningStateKind[] = [
   "CONFIRM_TIMEOUT",
 ];
 
-function isResizeOperationInFlight(
-  status: OperationalStatus | null | undefined,
-): boolean {
-  if (!status) return false;
-  if (
-    status.state === "resizing_machine" ||
-    status.state === "resizing_storage"
-  ) {
-    return true;
-  }
-  const operation = status.active_operation?.operation;
-  return typeof operation === "string" && operation.startsWith("resize");
-}
+// The resize-in-flight primitive lives in lib/billing (shared across domains);
+// re-export it as the pro-onboarding entrypoint, mirroring targetsMet.
+export { isResizeOperationInFlight };
 
 export interface UseProProvisioningOptions {
   open: boolean;

--- a/clients/web/src/lib/billing/provisioning-targets.test.ts
+++ b/clients/web/src/lib/billing/provisioning-targets.test.ts
@@ -1,6 +1,41 @@
 import { describe, expect, test } from "bun:test";
 
-import { targetsMet } from "./provisioning-targets";
+import type { OperationalStatus } from "@/generated/api/types.gen";
+
+import { isResizeOperationInFlight, targetsMet } from "./provisioning-targets";
+
+function opStatus(
+  overrides: Partial<OperationalStatus>,
+): OperationalStatus {
+  return {
+    state: "active",
+    detail_state: "",
+    poll_after_ms: 0,
+    updated_at: "",
+    state_started_at: null,
+    active_operation: null,
+    assistant: {
+      id: "asst-1",
+      status: "active",
+      machine_id: null,
+      vembda_cluster_id: null,
+    },
+    pod: {
+      statefulset_found: null,
+      spec_replicas: null,
+      ready_replicas: null,
+      pod_name: null,
+      pod_phase: null,
+      has_restart_history: false,
+      max_restart_count: null,
+      fatal_reason: null,
+    },
+    runtime: { healthz_ok: true, assistant_version: null, checked_at: null },
+    storage: null,
+    detail: { reason: null, message: null },
+    ...overrides,
+  };
+}
 
 describe("targetsMet", () => {
   test("null targets are never met", () => {
@@ -83,6 +118,67 @@ describe("targetsMet", () => {
       targetsMet(
         { machineSize: null, storageGib: 50 },
         { machineSize: null, storageGib: null },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isResizeOperationInFlight", () => {
+  test("null / undefined status is not in flight", () => {
+    expect(isResizeOperationInFlight(null)).toBe(false);
+    expect(isResizeOperationInFlight(undefined)).toBe(false);
+  });
+
+  test("a resizing_machine state is in flight", () => {
+    expect(
+      isResizeOperationInFlight(opStatus({ state: "resizing_machine" })),
+    ).toBe(true);
+  });
+
+  test("a resizing_storage state is in flight", () => {
+    expect(
+      isResizeOperationInFlight(opStatus({ state: "resizing_storage" })),
+    ).toBe(true);
+  });
+
+  test("a resize active_operation is in flight even when the state is active", () => {
+    expect(
+      isResizeOperationInFlight(
+        opStatus({
+          state: "active",
+          active_operation: {
+            operation: "resize_machine",
+            operation_id: "op-1",
+            phase: "WAITING_FOR_PVC",
+            started_at: "",
+            updated_at: "",
+            target: {},
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("an active state with no resize operation is not in flight", () => {
+    expect(isResizeOperationInFlight(opStatus({ state: "active" }))).toBe(
+      false,
+    );
+  });
+
+  test("a non-resize active_operation is not in flight", () => {
+    expect(
+      isResizeOperationInFlight(
+        opStatus({
+          state: "restarting",
+          active_operation: {
+            operation: "restart",
+            operation_id: "op-2",
+            phase: "",
+            started_at: "",
+            updated_at: "",
+            target: {},
+          },
+        }),
       ),
     ).toBe(false);
   });

--- a/clients/web/src/lib/billing/provisioning-targets.ts
+++ b/clients/web/src/lib/billing/provisioning-targets.ts
@@ -7,7 +7,10 @@
  * hatching screen — can reuse it without an ESLint-banned cross-domain import.
  */
 
-import type { MachineSizeEnum } from "@/generated/api/types.gen";
+import type {
+  MachineSizeEnum,
+  OperationalStatus,
+} from "@/generated/api/types.gen";
 import { machineSizeRank } from "./machine-sizes";
 
 export interface ProvisioningDimensions {
@@ -36,4 +39,27 @@ export function targetsMet(
     targets.storageGib == null ||
     (actuals?.storageGib != null && actuals.storageGib >= targets.storageGib);
   return machineMet && storageMet;
+}
+
+/**
+ * True while a machine/storage resize is still rolling out: the operational
+ * state is itself a resize state, or the active operation is a resize. The
+ * platform persists the effective machine size / provisioned storage before the
+ * pod finishes restarting, so `targetsMet` can read true while a resize is still
+ * in flight — completion must also wait for this to clear.
+ */
+export function isResizeOperationInFlight(
+  status: OperationalStatus | null | undefined,
+): boolean {
+  if (!status) {
+    return false;
+  }
+  if (
+    status.state === "resizing_machine" ||
+    status.state === "resizing_storage"
+  ) {
+    return true;
+  }
+  const operation = status.active_operation?.operation;
+  return typeof operation === "string" && operation.startsWith("resize");
 }


### PR DESCRIPTION
## Summary
- The onboarding hatching screen fires the idempotent ensure-provisioned reconcile and holds until the machine/storage resize to the purchased specs converges (then healthz), with a 90s cap and graceful fall-through.
- Local mode and free orgs are unchanged.

Part of plan: pricing-checkout-flow.md (PR 3 of 4)