### PR TITLE
feat(memory-v3): opt-in span-query dense pass (spanQueryK)

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -22,6 +22,7 @@ describe("MemoryV3ConfigSchema", () => {
       needleK: 100,
       denseK: 100,
       replyQueryK: 12,
+      spanQueryK: 0,
       selectorEnabled: true,
       selectorPromptPath: null,
       edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -383,6 +383,14 @@ export const MemoryV3ConfigSchema = z
       .describe(
         "Per-lane article budget for the reply-query finder pass: needle and dense each re-run over the assistant's previous message as separate queries (never concatenated with the user's message). 0 disables the pass. Deliberately small next to needleK/denseK — the pass adds the assistant-side retrieval signal, not a second full sweep.",
       ),
+    spanQueryK: z
+      .number({ error: "memory.v3.spanQueryK must be a number" })
+      .int("memory.v3.spanQueryK must be an integer")
+      .nonnegative("memory.v3.spanQueryK must be a non-negative integer")
+      .default(0)
+      .describe(
+        "Per-chunk article budget for the span-query dense pass: the current message's clause spans (merged into at most 8 contiguous chunks) re-run through the dense lane as separate queries, union-additive into the candidate pool. 0 disables the pass; it is also inert when denseK is 0 or the message yields fewer than two chunks. Deliberately small next to denseK — the pass rescues motifs a long message's single query vector averages away, not a second full sweep.",
+      ),
     selectorEnabled: z
       .boolean({ error: "memory.v3.selectorEnabled must be a boolean" })
       .default(true)

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -1855,4 +1855,29 @@ describe("orchestrate — span-query pass", () => {
       new Set(["topic-a", "topic-b", "topic-c", "topic-d"]),
     );
   });
+
+  test("an article hit by several chunks records its highest-scoring section", async () => {
+    const lanes = await buildLanes();
+    // Both chunks surface topic-d; the EARLIER chunk's hit is the weaker one.
+    // Chunk order must not decide the recorded section — the strong match
+    // (ordinal 1, `## Notes`) wins over the lead (ordinal 0).
+    denseHits = [];
+    denseHitsByQuery.set(CHUNK_1, [
+      { article: "topic-d", section: 0, score: 0.2 },
+    ]);
+    denseHitsByQuery.set(CHUNK_2, [
+      { article: "topic-d", section: 1, score: 0.9 },
+    ]);
+
+    const result = await orchestrate(
+      makeTurn(1, TWO_CHUNK_MESSAGE),
+      depsOf(lanes, { denseK: 100, spanQueryK: 7, selectorEnabled: false }),
+    );
+
+    expect(result.matchedSections.get("topic-d")?.ordinal).toBe(1);
+    expect(result.matchedSections.get("topic-d")?.text).toContain("grape");
+    expect(
+      result.lanes.finder.filter((c) => c.slug === "topic-d"),
+    ).toHaveLength(1);
+  });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -71,6 +71,12 @@ mock.module("../../../../../util/logger.js", () => ({
 const realDense = { ...(await import("../dense.js")) };
 let denseMockActive = false;
 let denseHits: Array<{ article: Slug; section: number; score?: number }> = [];
+// Per-query hit override for tests that need the full-message and span-chunk
+// dense calls to return DIFFERENT results; falls back to `denseHits`.
+let denseHitsByQuery = new Map<
+  string,
+  Array<{ article: Slug; section: number; score?: number }>
+>();
 let denseCalls: Array<{ query: string; k: number }> = [];
 mock.module("../dense.js", () => ({
   ...realDense,
@@ -79,7 +85,7 @@ mock.module("../dense.js", () => ({
       return realDense.denseLane(...args);
     }
     denseCalls.push({ query: args[1], k: args[2] });
-    return args[2] <= 0 ? [] : denseHits;
+    return args[2] <= 0 ? [] : (denseHitsByQuery.get(args[1]) ?? denseHits);
   },
   // Orchestrate now calls the SCORED variant; the mock must intercept it too
   // (else the `...realDense` spread resolves the real lane and hits Qdrant).
@@ -94,7 +100,10 @@ mock.module("../dense.js", () => ({
     denseCalls.push({ query: args[1], k: args[2] });
     return args[2] <= 0
       ? []
-      : denseHits.map((h) => ({ ...h, score: h.score ?? 1 }));
+      : (denseHitsByQuery.get(args[1]) ?? denseHits).map((h) => ({
+          ...h,
+          score: h.score ?? 1,
+        }));
   },
 }));
 
@@ -330,6 +339,7 @@ beforeEach(() => {
   watchdogMockActive = true;
   providerStub = null;
   denseHits = [];
+  denseHitsByQuery = new Map();
   denseCalls = [];
   recordedGateEvents = [];
   recordedSelectionEvents = [];
@@ -1751,5 +1761,98 @@ describe("latency sub-spans", () => {
     } finally {
       nowSpy.mockRestore();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Span-query pass: the dense lane re-run over the current message's clause
+// chunks as separate queries at `spanQueryK`, union-additive into the pool.
+// ---------------------------------------------------------------------------
+
+describe("orchestrate — span-query pass", () => {
+  const TWO_CHUNK_MESSAGE =
+    "apple appears in the first sentence here. elderberry shows up in the second sentence.";
+  const CHUNK_1 = "apple appears in the first sentence here.";
+  const CHUNK_2 = "elderberry shows up in the second sentence.";
+
+  test("spanQueryK omitted (default) runs no span dense calls", async () => {
+    const lanes = await buildLanes();
+
+    await orchestrate(
+      makeTurn(1, TWO_CHUNK_MESSAGE),
+      depsOf(lanes, { denseK: 100, selectorEnabled: false }),
+    );
+
+    expect(denseCalls).toEqual([{ query: TWO_CHUNK_MESSAGE, k: 100 }]);
+  });
+
+  test("span pass is inert when denseK=0", async () => {
+    const lanes = await buildLanes();
+
+    await orchestrate(
+      makeTurn(1, TWO_CHUNK_MESSAGE),
+      depsOf(lanes, { denseK: 0, spanQueryK: 7, selectorEnabled: false }),
+    );
+
+    expect(denseCalls).toEqual([]);
+  });
+
+  test("single-chunk message skips the span pass", async () => {
+    const lanes = await buildLanes();
+
+    await orchestrate(
+      makeTurn(1, "apple in one single sentence."),
+      depsOf(lanes, { denseK: 100, spanQueryK: 7, selectorEnabled: false }),
+    );
+
+    expect(denseCalls).toEqual([
+      { query: "apple in one single sentence.", k: 100 },
+    ]);
+  });
+
+  test("multi-chunk message adds span-lane candidates additively", async () => {
+    const lanes = await buildLanes();
+    // Full-message dense (and any chunk without an override) returns topic-b;
+    // chunk 1 re-surfaces topic-a (already a needle hit — attribution must
+    // stay "needle"); chunk 2 surfaces topic-d, which no other lane reaches
+    // ("grape" is not in the message, and the topic-a → topic-d curated edge
+    // must not re-surface an already-seen slug).
+    denseHits = [{ article: "topic-b", section: 0 }];
+    denseHitsByQuery.set(CHUNK_1, [{ article: "topic-a", section: 1 }]);
+    denseHitsByQuery.set(CHUNK_2, [{ article: "topic-d", section: 0 }]);
+
+    const result = await orchestrate(
+      makeTurn(1, TWO_CHUNK_MESSAGE),
+      depsOf(lanes, { denseK: 100, spanQueryK: 7, selectorEnabled: false }),
+    );
+
+    expect(denseCalls).toEqual([
+      { query: TWO_CHUNK_MESSAGE, k: 100 },
+      { query: CHUNK_1, k: 7 },
+      { query: CHUNK_2, k: 7 },
+    ]);
+    const laneOf = new Map(
+      result.lanes.finder.map((c) => [c.slug, c.lane] as const),
+    );
+    // "apple"/"elderberry" needle hits keep their lanes; the full-message
+    // dense hit keeps "dense"; only the genuinely span-surfaced page tags
+    // "span".
+    expect(laneOf.get("topic-a")).toBe("needle");
+    expect(laneOf.get("topic-c")).toBe("needle");
+    expect(laneOf.get("topic-b")).toBe("dense");
+    expect(laneOf.get("topic-d")).toBe("span");
+    expect(result.lanes.finder.filter((c) => c.slug === "topic-a").length).toBe(
+      1,
+    );
+    // The span hit's matched section is recorded for injection/spotlight.
+    expect(result.matchedSections.get("topic-d")?.article).toBe("topic-d");
+    expect(result.matchedSections.get("topic-d")?.text).toContain(
+      "lead for topic d",
+    );
+    // Additive: the span-only page joins the passthrough selections alongside
+    // every other lane's candidates.
+    expect(new Set(result.selections.map((s) => s.slug))).toEqual(
+      new Set(["topic-a", "topic-b", "topic-c", "topic-d"]),
+    );
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -1880,4 +1880,54 @@ describe("orchestrate — span-query pass", () => {
       result.lanes.finder.filter((c) => c.slug === "topic-d"),
     ).toHaveLength(1);
   });
+
+  test("a strictly stronger span cosine upgrades a dense-recorded section, keeping the lane", async () => {
+    const lanes = await buildLanes();
+    // Full-message dense records topic-b's lead (ordinal 0) at cosine 0.4;
+    // chunk 2 finds `## More` (ordinal 1) at 0.9 — same encoder and
+    // collection, strictly stronger, so the recorded section and finder
+    // descriptor upgrade while the lane attribution stays "dense".
+    denseHits = [{ article: "topic-b", section: 0, score: 0.4 }];
+    denseHitsByQuery.set(CHUNK_2, [
+      { article: "topic-b", section: 1, score: 0.9 },
+    ]);
+
+    const result = await orchestrate(
+      makeTurn(1, TWO_CHUNK_MESSAGE),
+      depsOf(lanes, { denseK: 100, spanQueryK: 7, selectorEnabled: false }),
+    );
+
+    expect(result.matchedSections.get("topic-b")?.ordinal).toBe(1);
+    expect(result.matchedSections.get("topic-b")?.text).toContain(
+      "cherry date",
+    );
+    const entry = result.lanes.finder.find((c) => c.slug === "topic-b");
+    expect(entry?.lane).toBe("dense");
+    expect(entry?.descriptor).toContain("cherry date");
+  });
+
+  test("weaker span hits and needle-recorded sections are not overridden", async () => {
+    const lanes = await buildLanes();
+    // topic-b: span cosine 0.3 < full-message 0.4 — the lead stays recorded.
+    // topic-a: needle recorded the `## Details` match; span scores are not
+    // comparable to BM25, so the span hit must not touch it.
+    denseHits = [{ article: "topic-b", section: 0, score: 0.4 }];
+    denseHitsByQuery.set(CHUNK_1, [
+      { article: "topic-a", section: 0, score: 0.99 },
+    ]);
+    denseHitsByQuery.set(CHUNK_2, [
+      { article: "topic-b", section: 1, score: 0.3 },
+    ]);
+
+    const result = await orchestrate(
+      makeTurn(1, TWO_CHUNK_MESSAGE),
+      depsOf(lanes, { denseK: 100, spanQueryK: 7, selectorEnabled: false }),
+    );
+
+    expect(result.matchedSections.get("topic-b")?.ordinal).toBe(0);
+    expect(result.matchedSections.get("topic-a")?.text).toContain("apple");
+    expect(result.lanes.finder.find((c) => c.slug === "topic-a")?.lane).toBe(
+      "needle",
+    );
+  });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
@@ -403,6 +403,7 @@ describe("summarizeSelections", () => {
       dense: 0,
       edge: 2,
       reply: 0,
+      span: 0,
       learned: 0,
       entity: 0,
     });
@@ -421,6 +422,7 @@ describe("summarizeSelections", () => {
         dense: 0,
         edge: 0,
         reply: 0,
+        span: 0,
         learned: 0,
         entity: 0,
       },
@@ -443,6 +445,7 @@ describe("summarizeSelections", () => {
         dense: 0,
         edge: 0,
         reply: 0,
+        span: 0,
         learned: 0,
         entity: 0,
       },

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
@@ -498,6 +498,7 @@ describe("memory-v3 integration — selection-log readout", () => {
         dense: 0,
         edge: 0,
         reply: 0,
+        span: 0,
         learned: 0,
         entity: 0,
       },

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/tuning-profile.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/tuning-profile.test.ts
@@ -47,6 +47,7 @@ describe("resolveV3Tuning", () => {
       needleK: v3.needleK,
       denseK: v3.denseK,
       replyQueryK: v3.replyQueryK,
+      spanQueryK: v3.spanQueryK,
       selectorEnabled: v3.selectorEnabled,
       learnedEdgesCap: v3.learnedEdges.cap,
       edgeSeedCount: v3.edge.seedCount,

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -9,7 +9,11 @@
  *          PREVIOUS message as separate queries at a smaller budget
  *          (`replyQueryK` per lane), surfacing the threads the assistant is
  *          actively developing that the user's message references without
- *          naming — and
+ *          naming —
+ *        - the span-query pass — the dense lane re-run over the current
+ *          message's clause chunks as separate queries at a small per-chunk
+ *          budget (`spanQueryK`), rescuing motifs a long multi-topic message's
+ *          single query vector averages away — and
  *        - link-graph edge expansion (`edgeExpand`) over the top
  *          user-message needle+dense article seeds, and
  *        - learned-edge expansion (`edgeExpand` over the co-selection NPMI
@@ -74,6 +78,7 @@ import type {
 } from "./pool-select.js";
 import { selectAllPoolCandidates, selectPool } from "./pool-select.js";
 import type { SectionNeedle } from "./section-needle.js";
+import { spanChunksOf } from "./span-query.js";
 import type {
   FinderLane,
   MemoryRoutingTurn,
@@ -195,6 +200,12 @@ export interface OrchestrateDeps {
    *  over `turn.previousAssistantMessage` as separate queries). `0` or
    *  omitted disables the pass (canonical value: `memory.v3.replyQueryK`). */
   replyQueryK?: number;
+  /** Per-chunk article budget for the span-query pass (dense re-run over the
+   *  current message's clause chunks as separate queries). `0` or omitted
+   *  disables the pass; it is also inert when the dense lane is disabled or
+   *  the message yields fewer than two chunks (canonical value:
+   *  `memory.v3.spanQueryK`). */
+  spanQueryK?: number;
   /** Number of top needle+dense seeds expanded. When omitted, the edge lane's
    *  own default applies (canonical value: `memory.v3.edge.seedCount`). */
   edgeSeeds?: number;
@@ -359,15 +370,23 @@ export async function orchestrate(
   // a vector that matches neither) at its own, smaller budget; it runs in the
   // same parallel batch.
   // `denseK = 0` disables dense retrieval for the whole turn, including the
-  // reply-query dense pass.
+  // reply-query and span-query dense passes.
   const replyK = deps.replyQueryK ?? 0;
   const replyQuery =
     replyK > 0 ? (turn.previousAssistantMessage ?? "").trim() : "";
   const denseEnabled = denseK > 0;
-  const [needled, densed, replyNeedled, replyDensed] = await timeLatencySubSpan(
-    "v3_lanes",
-    "Memory search",
-    () =>
+  // The span-query pass re-runs the dense lane over the current message's
+  // clause chunks as SEPARATE queries (a single embedding of a multi-topic
+  // message averages its intents into a vector that matches none of them —
+  // the within-message form of the averaging the reply pass avoids across
+  // speakers). A single-chunk message would just duplicate the full-message
+  // dense query, so the pass needs at least two chunks to run.
+  const spanK = deps.spanQueryK ?? 0;
+  const spanChunks =
+    spanK > 0 && denseEnabled ? spanChunksOf(turn.currentMessage) : [];
+  const spanQueries = spanChunks.length >= 2 ? spanChunks : [];
+  const [needled, densed, replyNeedled, replyDensed, spanDensed] =
+    await timeLatencySubSpan("v3_lanes", "Memory search", () =>
       Promise.all([
         Promise.resolve(deps.needle.queryScored(turn.currentMessage, needleK)),
         denseEnabled
@@ -381,8 +400,13 @@ export async function orchestrate(
         replyQuery.length > 0 && denseEnabled
           ? denseLaneScored(deps.denseConfig, replyQuery, replyK)
           : Promise.resolve([]),
+        Promise.all(
+          spanQueries.map((chunk) =>
+            denseLaneScored(deps.denseConfig, chunk, spanK),
+          ),
+        ),
       ]),
-  );
+    );
   // Everything from here to the step-3 selection — finder assembly, the
   // entity lane, the injection gate, edge + learned-edge expansion, pool
   // assembly — is synchronous in-memory work, measured as one `v3_expand`
@@ -469,7 +493,23 @@ export async function orchestrate(
     );
   }
 
-  // Step 1b'': entity lane — sections whose `## ` heading NAMES a distinctive
+  // Step 1b'': span-query hits — union-additive at the pass's own small
+  // budget. Candidates the primary or reply lanes already surfaced keep their
+  // attribution (`addFinder`'s first-lane-wins dedupe); only genuinely
+  // span-surfaced articles tag `"span"`. Like the reply pass, span hits are
+  // excluded from the injection gate (which scores current-message needle +
+  // dense only) and from the edge-expansion seeds.
+  for (const hit of spanDensed.flat()) {
+    if (!deps.sectionIndex.byArticle.has(hit.article)) continue;
+    addFinder(
+      hit.article,
+      sectionByOrdinal(deps.sectionIndex, hit.article, hit.section),
+      undefined,
+      "span",
+    );
+  }
+
+  // Step 1b''': entity lane — sections whose `## ` heading NAMES a distinctive
   // entity the message mentions. Additive BM25 buries a single named entity
   // under a long, multi-topic message's bulk theme; this keys on the heading
   // vocabulary so the page the user named surfaces regardless of the bulk
@@ -501,8 +541,8 @@ export async function orchestrate(
     }
   }
 
-  // Step 1b''': opt-in injection gate. With the CURRENT-message finder lanes in
-  // hand (needle + dense — NOT reply/entity/edge, which only add recall), decide
+  // Step 1b'''': opt-in injection gate. With the CURRENT-message finder lanes in
+  // hand (needle + dense — NOT reply/span/entity/edge, which only add recall), decide
   // whether retrieval is confident enough to spend the selectPool LLM call this
   // turn. Default-off via `?.enabled`; pass-open on any throw (a gate bug must
   // never drop a turn's memory). A closed gate either hard-skips selection

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -65,6 +65,7 @@ import {
 } from "../../../../daemon/turn-latency-sub-spans.js";
 import { recordWatchdogEvent } from "../../../../telemetry/watchdog-events-store.js";
 import { getLogger } from "../logging.js";
+import type { DenseHitScored } from "./dense.js";
 import { denseLaneScored } from "./dense.js";
 import type { EdgeGraph } from "./edge.js";
 import { edgeExpand } from "./edge.js";
@@ -499,7 +500,19 @@ export async function orchestrate(
   // span-surfaced articles tag `"span"`. Like the reply pass, span hits are
   // excluded from the injection gate (which scores current-message needle +
   // dense only) and from the edge-expansion seeds.
+  //
+  // An article can be surfaced by SEVERAL chunks; dedupe by best cosine score
+  // before `addFinder`, since chunk order would otherwise decide which section
+  // gets recorded — letting an earlier chunk's weak match mask the strong
+  // buried-clause match the pass exists to recover.
+  const bestSpanHits = new Map<Slug, DenseHitScored>();
   for (const hit of spanDensed.flat()) {
+    const prev = bestSpanHits.get(hit.article);
+    if (!prev || hit.score > prev.score) {
+      bestSpanHits.set(hit.article, hit);
+    }
+  }
+  for (const hit of bestSpanHits.values()) {
     if (!deps.sectionIndex.byArticle.has(hit.article)) continue;
     addFinder(
       hit.article,

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -473,7 +473,9 @@ export async function orchestrate(
     // articles. The section index is rebuilt from `getPageIndex` at `initLanes`,
     // so `byArticle` holds exactly the live pages (synthetic capability slugs
     // included) — only truly-deleted pages are dropped here.
-    if (!deps.sectionIndex.byArticle.has(hit.article)) continue;
+    if (!deps.sectionIndex.byArticle.has(hit.article)) {
+      continue;
+    }
     const section = sectionByOrdinal(
       deps.sectionIndex,
       hit.article,
@@ -529,7 +531,9 @@ export async function orchestrate(
   // comparable, and the reply pass's own convention is first-wins); lane
   // attribution never changes here.
   for (const hit of bestSpanHits.values()) {
-    if (!deps.sectionIndex.byArticle.has(hit.article)) continue;
+    if (!deps.sectionIndex.byArticle.has(hit.article)) {
+      continue;
+    }
     const section = sectionByOrdinal(
       deps.sectionIndex,
       hit.article,

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -462,18 +462,27 @@ export async function orchestrate(
   // Step 1b: dense hits — `section` is the matched ORDINAL; resolve it to the
   // concrete `Section` via the section index. Falls back to undefined (blank
   // descriptor) if the ordinal is not in the in-memory index.
+  //
+  // `denseOwnedSection` tracks the articles whose recorded matched section
+  // came from THIS loop (needle records first and wins ties), along with the
+  // hit's cosine score — the span pass upgrades those sections when a clause
+  // query finds a strictly stronger match under the same metric.
+  const denseOwnedSection = new Map<Slug, number>();
   for (const hit of densed) {
     // A deleted page's points can linger in Qdrant; keep only live-index
     // articles. The section index is rebuilt from `getPageIndex` at `initLanes`,
     // so `byArticle` holds exactly the live pages (synthetic capability slugs
     // included) — only truly-deleted pages are dropped here.
     if (!deps.sectionIndex.byArticle.has(hit.article)) continue;
-    addFinder(
+    const section = sectionByOrdinal(
+      deps.sectionIndex,
       hit.article,
-      sectionByOrdinal(deps.sectionIndex, hit.article, hit.section),
-      undefined,
-      "dense",
+      hit.section,
     );
+    if (section && !matchedSections.has(hit.article)) {
+      denseOwnedSection.set(hit.article, hit.score);
+    }
+    addFinder(hit.article, section, undefined, "dense");
   }
 
   // Step 1b': reply-query hits — candidates the user-message lanes already
@@ -512,14 +521,30 @@ export async function orchestrate(
       bestSpanHits.set(hit.article, hit);
     }
   }
+  // For an article a primary lane already surfaced, upgrade its matched
+  // section/descriptor ONLY when the existing section was recorded by the
+  // full-message dense hit and the span's cosine is strictly higher — same
+  // encoder, same collection, so the comparison is evidence, not judgment.
+  // Needle- and reply-recorded sections stay (BM25 and cosine scores are not
+  // comparable, and the reply pass's own convention is first-wins); lane
+  // attribution never changes here.
   for (const hit of bestSpanHits.values()) {
     if (!deps.sectionIndex.byArticle.has(hit.article)) continue;
-    addFinder(
+    const section = sectionByOrdinal(
+      deps.sectionIndex,
       hit.article,
-      sectionByOrdinal(deps.sectionIndex, hit.article, hit.section),
-      undefined,
-      "span",
+      hit.section,
     );
+    const denseScore = denseOwnedSection.get(hit.article);
+    if (section && denseScore !== undefined && hit.score > denseScore) {
+      matchedSections.set(hit.article, section);
+      const existing = finder.find((c) => c.slug === hit.article);
+      if (existing) {
+        existing.descriptor = section.text;
+      }
+      continue;
+    }
+    addFinder(hit.article, section, undefined, "span");
   }
 
   // Step 1b''': entity lane — sections whose `## ` heading NAMES a distinctive

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -733,6 +733,7 @@ export async function observeTurn(
       activeSlugs: getActiveSlugs(conversationId),
       entityCap: v3.entity.cap,
       replyQueryK: tuning.replyQueryK,
+      spanQueryK: tuning.spanQueryK,
       edgeSeeds: tuning.edgeSeedCount,
       edgePerSeed: tuning.edgePerSeed,
       edgeCap: tuning.edgeCap,

--- a/assistant/src/plugins/defaults/memory/v3/span-query.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/span-query.test.ts
@@ -33,6 +33,32 @@ describe("spanChunksOf", () => {
     expect(spanChunksOf("  \n\n  ")).toEqual([]);
   });
 
+  test("fullwidth CJK terminators split without trailing whitespace", () => {
+    const chunks = spanChunksOf(
+      "这是消息里的第一句完整的话。这是紧跟着的第二句完整的话！第三句也一样长够十五个字符？",
+    );
+    expect(chunks).toEqual([
+      "这是消息里的第一句完整的话。",
+      "这是紧跟着的第二句完整的话！",
+      "第三句也一样长够十五个字符？",
+    ]);
+  });
+
+  test("non-ASCII spaced terminators split like ASCII ones", () => {
+    const chunks = spanChunksOf(
+      "पहला वाक्य यहाँ लिखा गया है। दूसरा वाक्य भी यहाँ मौजूद है।",
+    );
+    expect(chunks).toEqual([
+      "पहला वाक्य यहाँ लिखा गया है।",
+      "दूसरा वाक्य भी यहाँ मौजूद है।",
+    ]);
+  });
+
+  test("ASCII periods still do not split decimals or dotted numbers", () => {
+    expect(spanChunksOf("the value came out to 3.14159 in the final run.")) //
+      .toEqual(["the value came out to 3.14159 in the final run."]);
+  });
+
   test("a message at the cap is returned unchanged", () => {
     const sentences = Array.from(
       { length: MAX_SPAN_CHUNKS },

--- a/assistant/src/plugins/defaults/memory/v3/span-query.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/span-query.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import { MAX_SPAN_CHUNKS, spanChunksOf } from "./span-query.js";
+
+describe("spanChunksOf", () => {
+  test("short message passes through as its clause spans", () => {
+    const chunks = spanChunksOf(
+      "the first sentence is here. and a second sentence follows!",
+    );
+    expect(chunks).toEqual([
+      "the first sentence is here.",
+      "and a second sentence follows!",
+    ]);
+  });
+
+  test("newlines split spans like sentence punctuation", () => {
+    const chunks = spanChunksOf(
+      "a line without terminal punctuation\nanother line of the message",
+    );
+    expect(chunks).toEqual([
+      "a line without terminal punctuation",
+      "another line of the message",
+    ]);
+  });
+
+  test("sub-15-char fragments are dropped", () => {
+    const chunks = spanChunksOf("ok. this sentence is long enough to keep.");
+    expect(chunks).toEqual(["this sentence is long enough to keep."]);
+  });
+
+  test("empty and whitespace-only messages yield no chunks", () => {
+    expect(spanChunksOf("")).toEqual([]);
+    expect(spanChunksOf("  \n\n  ")).toEqual([]);
+  });
+
+  test("a message at the cap is returned unchanged", () => {
+    const sentences = Array.from(
+      { length: MAX_SPAN_CHUNKS },
+      (_, i) => `sentence number ${i} padded for length.`,
+    );
+    expect(spanChunksOf(sentences.join(" "))).toEqual(sentences);
+  });
+
+  test("over-cap messages merge into ≤cap contiguous chunks covering every span", () => {
+    const sentences = Array.from(
+      { length: 30 },
+      (_, i) => `sentence number ${i} padded for length.`,
+    );
+    const chunks = spanChunksOf(sentences.join(" "));
+    expect(chunks.length).toBe(MAX_SPAN_CHUNKS);
+    // Contiguous coverage: rejoining the chunks reproduces every span in order.
+    expect(chunks.join(" ")).toBe(sentences.join(" "));
+    // Near-equal partition: no chunk hoards spans (30/8 → sizes 3 or 4).
+    for (const chunk of chunks) {
+      const n = chunk.match(/sentence number/g)?.length ?? 0;
+      expect(n).toBeGreaterThanOrEqual(3);
+      expect(n).toBeLessThanOrEqual(4);
+    }
+  });
+});

--- a/assistant/src/plugins/defaults/memory/v3/span-query.ts
+++ b/assistant/src/plugins/defaults/memory/v3/span-query.ts
@@ -9,7 +9,7 @@
  * at full strength.
  *
  * Chunking is pure text processing: split at newlines and sentence
- * punctuation, drop sub-{@link MIN_SPAN_CHARS} fragments. A message yielding
+ * punctuation, drop fragments below {@link MIN_SPAN_WEIGHT}. A message yielding
  * more than {@link MAX_SPAN_CHUNKS} spans is NOT truncated to its head — all
  * spans are partitioned into {@link MAX_SPAN_CHUNKS} contiguous near-equal
  * groups, so the whole message stays covered and long messages are simply
@@ -20,9 +20,24 @@
  *  `MAX_SPAN_CHUNKS × spanQueryK` extra candidates and as many embed calls. */
 export const MAX_SPAN_CHUNKS = 8;
 
-/** Spans shorter than this carry no retrieval signal ("ok.", bare emoji
- *  lines) and are dropped before chunking. */
-const MIN_SPAN_CHARS = 15;
+/** Spans weighing less than this carry no retrieval signal ("ok.", bare emoji
+ *  lines) and are dropped before chunking. Weight, not raw length — see
+ *  {@link spanWeight}. */
+const MIN_SPAN_WEIGHT = 15;
+
+/** Dense CJK scripts pack roughly a clause into the character budget English
+ *  needs for a few words, so a raw char floor tuned for spaced scripts would
+ *  drop nearly every realistic Chinese/Japanese/Korean sentence. Weigh those
+ *  chars at 3× so the floor measures comparable information content. */
+const DENSE_SCRIPT = /[\p{sc=Han}\p{sc=Hiragana}\p{sc=Katakana}\p{sc=Hangul}]/u;
+
+function spanWeight(span: string): number {
+  let weight = 0;
+  for (const ch of span) {
+    weight += DENSE_SCRIPT.test(ch) ? 3 : 1;
+  }
+  return weight;
+}
 
 /**
  * Split `message` into at most {@link MAX_SPAN_CHUNKS} contiguous clause
@@ -31,10 +46,16 @@ const MIN_SPAN_CHARS = 15;
  * whole message. Deterministic; returns `[]` for empty/whitespace input.
  */
 export function spanChunksOf(message: string): string[] {
+  // Boundaries: newlines; any Unicode sentence terminator (`\p{STerm}` covers
+  // ASCII `.!?` plus CJK `。！？`, Arabic `؟`, Devanagari `।`, …) or ellipsis
+  // followed by whitespace; and a zero-width split after fullwidth CJK
+  // terminators, which conventionally have NO trailing space. The whitespace
+  // requirement on the general arm keeps ASCII `.` from splitting decimals
+  // and dotted abbreviations; fullwidth terminators never appear there.
   const spans = message
-    .split(/\n+|(?<=[.!?…])\s+/)
+    .split(/\n+|(?<=[\p{STerm}…])\s+|(?<=[。！？｡])/u)
     .map((s) => s.trim())
-    .filter((s) => s.length >= MIN_SPAN_CHARS);
+    .filter((s) => spanWeight(s) >= MIN_SPAN_WEIGHT);
   if (spans.length <= MAX_SPAN_CHUNKS) {
     return spans;
   }

--- a/assistant/src/plugins/defaults/memory/v3/span-query.ts
+++ b/assistant/src/plugins/defaults/memory/v3/span-query.ts
@@ -1,0 +1,50 @@
+/**
+ * Memory v3 — deterministic clause chunking for the span-query dense pass.
+ *
+ * A single embedding of a long, multi-topic message averages its distinct
+ * retrieval intents into one vector that matches none of them — the
+ * within-message form of the cross-speaker averaging the reply-query pass
+ * exists to avoid. The span pass re-runs the dense lane over the message's
+ * clause spans as separate queries so a motif buried in one clause retrieves
+ * at full strength.
+ *
+ * Chunking is pure text processing: split at newlines and sentence
+ * punctuation, drop sub-{@link MIN_SPAN_CHARS} fragments. A message yielding
+ * more than {@link MAX_SPAN_CHUNKS} spans is NOT truncated to its head — all
+ * spans are partitioned into {@link MAX_SPAN_CHUNKS} contiguous near-equal
+ * groups, so the whole message stays covered and long messages are simply
+ * queried at paragraph grain instead of clause grain.
+ */
+
+/** Hard cap on span chunks per message — bounds the pass at
+ *  `MAX_SPAN_CHUNKS × spanQueryK` extra candidates and as many embed calls. */
+export const MAX_SPAN_CHUNKS = 8;
+
+/** Spans shorter than this carry no retrieval signal ("ok.", bare emoji
+ *  lines) and are dropped before chunking. */
+const MIN_SPAN_CHARS = 15;
+
+/**
+ * Split `message` into at most {@link MAX_SPAN_CHUNKS} contiguous clause
+ * chunks. Messages with that many spans or fewer return them unchanged;
+ * longer messages merge adjacent spans into near-equal groups covering the
+ * whole message. Deterministic; returns `[]` for empty/whitespace input.
+ */
+export function spanChunksOf(message: string): string[] {
+  const spans = message
+    .split(/\n+|(?<=[.!?…])\s+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length >= MIN_SPAN_CHARS);
+  if (spans.length <= MAX_SPAN_CHUNKS) {
+    return spans;
+  }
+  const chunks: string[] = [];
+  for (let i = 0; i < MAX_SPAN_CHUNKS; i++) {
+    const lo = Math.floor((i * spans.length) / MAX_SPAN_CHUNKS);
+    const hi = Math.floor(((i + 1) * spans.length) / MAX_SPAN_CHUNKS);
+    if (hi > lo) {
+      chunks.push(spans.slice(lo, hi).join(" "));
+    }
+  }
+  return chunks;
+}

--- a/assistant/src/plugins/defaults/memory/v3/tuning-profile.ts
+++ b/assistant/src/plugins/defaults/memory/v3/tuning-profile.ts
@@ -28,6 +28,7 @@ export interface ResolvedV3Tuning {
   needleK: number;
   denseK: number;
   replyQueryK: number;
+  spanQueryK: number;
   selectorEnabled: boolean;
   learnedEdgesCap: number;
   edgeSeedCount: number;
@@ -55,6 +56,7 @@ export const MEMORY_V3_NEW_USER_TUNING: ResolvedV3Tuning = {
   needleK: 12,
   denseK: 0,
   replyQueryK: 0,
+  spanQueryK: 0,
   selectorEnabled: false,
   learnedEdgesCap: 0,
   edgeSeedCount: 6,
@@ -82,6 +84,7 @@ export function resolveV3Tuning(
     needleK: v3.needleK,
     denseK: v3.denseK,
     replyQueryK: v3.replyQueryK,
+    spanQueryK: v3.spanQueryK,
     selectorEnabled: v3.selectorEnabled,
     learnedEdgesCap: v3.learnedEdges.cap,
     edgeSeedCount: v3.edge.seedCount,

--- a/assistant/src/plugins/defaults/memory/v3/types.ts
+++ b/assistant/src/plugins/defaults/memory/v3/types.ts
@@ -96,7 +96,9 @@ export interface MemoryRoutingTurn {
  * frecency hot set, modification-recency fresh set); `needle` / `dense` /
  * `edge` are the per-turn finder lanes over the user's message; `reply` marks
  * finder candidates first surfaced by the reply-query pass (needle + dense
- * re-run over the assistant's previous message); `learned` marks candidates
+ * re-run over the assistant's previous message); `span` marks candidates first
+ * surfaced by the span-query pass (dense re-run over the current message's
+ * clause chunks as separate queries); `learned` marks candidates
  * surfaced by the co-selection NPMI association graph; `entity` marks
  * candidates surfaced because the message named an entity that titles a section
  * heading (the heading-anchored entity lane).
@@ -114,6 +116,7 @@ export const SELECTION_SOURCES = [
   "dense",
   "edge",
   "reply",
+  "span",
   "learned",
   "entity",
 ] as const;


### PR DESCRIPTION
## Summary
- Adds an opt-in **span-query pass** to the memory-v3 dense lane: the current message's clause spans (merged into at most 8 contiguous chunks) re-run through the dense lane as separate queries at a small per-chunk budget (`memory.v3.spanQueryK`, default 0 = off), union-additive into the candidate pool. A single embedding of a long multi-topic message averages its distinct retrieval intents into a vector that matches none of them; per-clause sub-queries retrieve what a buried clause asks for at full strength — the within-message form of the averaging the reply-query pass already avoids across speakers.
- New pure `span-query.ts` (`spanChunksOf`: newline/sentence-punct split, sub-15-char fragments dropped, >8-span messages merged into ≤8 contiguous near-equal chunks so the whole message stays covered), a new `"span"` finder lane in `SELECTION_SOURCES` for selection-log/telemetry attribution, `spanQueryK` threading through config schema → tuning profile → orchestrator → live caller, and tests (chunker unit tests + orchestrate lane-composition tests).
- Span hits are excluded from the injection gate (which scores current-message needle+dense only) and from edge-expansion seeds, mirroring the reply pass; the pass is inert when `denseK` is 0 or the message yields fewer than two chunks. Lean new-user profile keeps it off.

## Validation
Offline eval on a 320-turn live-trace benchmark against a production-scale corpus (~1.6k pages / ~11k sections): merge-to-8 span union at k'=15 recovered 20/374 candidate misses (≈ +2pts candidate recall) at +19 pool candidates/turn, with zero regressions by construction (the pass only ever adds candidates — the full-message dense top-K is untouched). Replacement-style MaxSim re-ranking over the same query set was tested and rejected (+14 recoveries / −43 regressions at fixed K). Truncating to the first 8 spans instead of merging was also rejected: it cut exactly the long messages where single-vector dilution is worst.

## Rollout
Ships default-off. Intended rollout is per-assistant config opt-in (`memory.v3.spanQueryK: 15`), watching the `span` lane's selection rate in the existing selection telemetry.

## Original prompt
Follow-up to an offline retrieval study of the v3 dense lane (single full-message query vector vs multi-vector alternatives). The study found the only dense-lane variant that survives measurement is an additive per-clause sub-query union — task-type asymmetric embeddings are a no-op on the current embedding model, and MaxSim re-ranking regresses more than it recovers. Requested: implement the winning variant behind a default-off `spanQueryK` config knob following the existing reply-query-pass pattern, and open the PR for review without auto-merging (core memory path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)