### PR TITLE
refactor(web): self-review cleanup for the pricing-checkout flow

### DIFF
--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -784,4 +784,24 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     expect(subscriptionRetrieveMock).not.toHaveBeenCalled();
     expect(operationalStatusReadMock).not.toHaveBeenCalled();
   });
+
+  test("a local-mode preflight-active reload completes without provisioning", async () => {
+    // A local-mode session with no hosting param (or hosting=vellum-cloud) makes
+    // useLocalHatch false, so a reload onto an already-active assistant flows
+    // through the platform preflight path into finishActiveHatch. The
+    // provisioning wait must still short-circuit for local mode — no billing
+    // reads, no resize wait — so local hatching stays byte-identical.
+    isLocalModeValue = true;
+    preflightActive = true;
+
+    render(<HatchingScreen />);
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+      timeout: 5000,
+    });
+    expect(ensureProvisionedMock).not.toHaveBeenCalled();
+    expect(subscriptionRetrieveMock).not.toHaveBeenCalled();
+    expect(onboardingRetrieveMock).not.toHaveBeenCalled();
+    expect(operationalStatusReadMock).not.toHaveBeenCalled();
+  });
 });

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -513,6 +513,13 @@ export function HatchingScreen() {
     const awaitPurchasedProvisioning = async (
       assistantId: string,
     ): Promise<void> => {
+      // Local hatches never provision purchased specs — a self-hosted daemon has
+      // no billing surface to read. Short-circuit so a local-mode reload that
+      // falls through the platform preflight path (hosting=vellum-cloud or no
+      // param, where useLocalHatch is false) stays byte-identical to today.
+      if (isLocalMode()) {
+        return;
+      }
       // Fire the idempotent grow-only reconcile — the same resize the subscribe
       // webhook triggers — covering a webhook that never fired or whose resize
       // was lost. It is marked done only when it SUCCEEDS: a 503 ("nothing

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -79,10 +79,10 @@ export function PrivacyScreen() {
     // signup-marked intent (`resumeAfterOnboarding`): an ordinary billing-surface
     // stash (an abandoned CheckoutPage/takeover checkout) carries no marker, so
     // it's ignored here and left untouched for its own flow — onboarding proceeds
-    // normally. The checkout route owns the already-Pro case and re-stashes the
-    // intent, so leave the marked stash for its lifecycle to clear. Resuming only
-    // from this explicit Start click — never a render effect — keeps consent and
-    // checkout from looping.
+    // normally. The checkout route owns the marked stash's lifecycle from here —
+    // re-stashing on a Stripe redirect, clearing it on an already-Pro no_op — so
+    // this screen just hands off. Resuming only from this explicit Start click —
+    // never a render effect — keeps consent and checkout from looping.
     const checkoutIntent = readCheckoutIntent();
     if (
       checkoutIntent?.kind === "package" &&

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -12,6 +12,7 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useLocation } from "react-router";
 
+import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import * as browserRuntime from "@/runtime/browser";
 import * as orgReadyMod from "@/hooks/use-is-org-ready";
@@ -155,8 +156,15 @@ describe("CheckoutPage", () => {
     await waitFor(() => expect(upgradeCalls.length).toBe(1));
   });
 
-  test("a no_op result navigates to plans and stashes no intent", async () => {
+  test("a no_op result navigates to plans and clears any marked stash", async () => {
     upgradeData = { status: "no_op", checkout_url: null, message: "" };
+    // A marked stash from the onboarding signup carry survives into this bounce;
+    // the already-Pro no_op must clear it rather than leave it lingering its TTL.
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
     const { getByTestId } = renderCheckout("/assistant/checkout?package=super");
 
     await waitFor(() => expect(upgradeCalls.length).toBe(1));

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -7,7 +7,10 @@ import { useMutation } from "@tanstack/react-query";
 import { organizationsBillingSubscriptionUpgradeCreateMutation } from "@/generated/api/@tanstack/react-query.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
-import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
+import {
+  clearCheckoutIntent,
+  saveCheckoutIntent,
+} from "@/lib/billing/checkout-intent";
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
 import { openUrl } from "@/runtime/browser";
 import { routes } from "@/utils/routes";
@@ -66,8 +69,10 @@ export function CheckoutPage() {
         void openUrl(result.checkout_url);
         return;
       }
-      // `no_op` — already Pro, nothing to provision. Hand off to the plans
-      // takeover rather than stranding the user on a blank splash.
+      // `no_op` — already Pro, nothing to provision. Clear the marked stash so
+      // an already-Pro bounce doesn't leave it lingering for its TTL, then hand
+      // off to the plans takeover rather than stranding the user on a blank splash.
+      clearCheckoutIntent();
       navigate(routes.plans, { replace: true });
     } catch {
       setFailed(true);

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-pro-provisioning.ts
@@ -73,10 +73,6 @@ const TERMINAL_STATES: readonly ProvisioningStateKind[] = [
   "CONFIRM_TIMEOUT",
 ];
 
-// The resize-in-flight primitive lives in lib/billing (shared across domains);
-// re-export it as the pro-onboarding entrypoint, mirroring targetsMet.
-export { isResizeOperationInFlight };
-
 export interface UseProProvisioningOptions {
   open: boolean;
 }

--- a/clients/web/src/lib/billing/post-auth-checkout.test.ts
+++ b/clients/web/src/lib/billing/post-auth-checkout.test.ts
@@ -6,26 +6,7 @@ import {
   saveCheckoutIntent,
 } from "@/lib/billing/checkout-intent";
 
-import {
-  checkoutPackageFromDestination,
-  resolveSignupCheckoutDestination,
-} from "./post-auth-checkout";
-
-describe("checkoutPackageFromDestination", () => {
-  test("returns the package slug for a checkout deep link", () => {
-    expect(
-      checkoutPackageFromDestination("/assistant/checkout?package=super"),
-    ).toBe("super");
-  });
-
-  test("returns null for a checkout link without a package", () => {
-    expect(checkoutPackageFromDestination("/assistant/checkout")).toBeNull();
-  });
-
-  test("returns null for a non-checkout destination", () => {
-    expect(checkoutPackageFromDestination("/assistant/home")).toBeNull();
-  });
-});
+import { resolveSignupCheckoutDestination } from "./post-auth-checkout";
 
 describe("resolveSignupCheckoutDestination", () => {
   beforeEach(() => {
@@ -40,10 +21,7 @@ describe("resolveSignupCheckoutDestination", () => {
       returnTo: "/assistant/checkout?package=super",
     });
 
-    expect(result).toEqual({
-      destination: "/assistant/onboarding/privacy",
-      stashedPackage: "super",
-    });
+    expect(result).toBe("/assistant/onboarding/privacy");
     // The signup carry marks its stash so only the onboarding privacy screen
     // resumes it — an ordinary billing-surface stash carries no such marker.
     expect(readCheckoutIntent()).toMatchObject({
@@ -59,10 +37,7 @@ describe("resolveSignupCheckoutDestination", () => {
       returnTo: "/assistant/checkout",
     });
 
-    expect(result).toEqual({
-      destination: "/assistant/onboarding/privacy",
-      stashedPackage: null,
-    });
+    expect(result).toBe("/assistant/onboarding/privacy");
     expect(readCheckoutIntent()).toBeNull();
   });
 
@@ -74,10 +49,7 @@ describe("resolveSignupCheckoutDestination", () => {
       returnTo: "/assistant/home",
     });
 
-    expect(result).toEqual({
-      destination: "/assistant/onboarding/privacy",
-      stashedPackage: null,
-    });
+    expect(result).toBe("/assistant/onboarding/privacy");
     expect(readCheckoutIntent()).toBeNull();
   });
 
@@ -89,10 +61,7 @@ describe("resolveSignupCheckoutDestination", () => {
       returnTo: "/assistant/home",
     });
 
-    expect(result).toEqual({
-      destination: "/assistant/home",
-      stashedPackage: null,
-    });
+    expect(result).toBe("/assistant/home");
     expect(readCheckoutIntent()).toBeNull();
   });
 
@@ -104,10 +73,7 @@ describe("resolveSignupCheckoutDestination", () => {
       returnTo: "/assistant/checkout?package=super",
     });
 
-    expect(result).toEqual({
-      destination: "/assistant/checkout?package=super",
-      stashedPackage: null,
-    });
+    expect(result).toBe("/assistant/checkout?package=super");
     // A checkout deep link is never treated as an unrelated auth, so the
     // stash is left in place rather than discarded.
     expect(readCheckoutIntent()).toMatchObject({

--- a/clients/web/src/lib/billing/post-auth-checkout.ts
+++ b/clients/web/src/lib/billing/post-auth-checkout.ts
@@ -26,23 +26,7 @@ function parseCheckoutDestination(destination: string): {
 }
 
 /**
- * The `package` slug of a deep-link checkout destination
- * (`/assistant/checkout?package=`), or null when the destination is not a
- * checkout link or carries no package.
- */
-export function checkoutPackageFromDestination(destination: string): string | null {
-  return parseCheckoutDestination(destination).packageKey;
-}
-
-export interface SignupCheckoutResolution {
-  /** Where the auth should land. */
-  destination: string;
-  /** The package stashed for post-consent checkout resume, or null. */
-  stashedPackage: string | null;
-}
-
-/**
- * The shared post-auth checkout decision for both the web
+ * The shared post-auth checkout destination for both the web
  * (`resolvePostAuth`) and native (`resolveNativePostAuthDestination`) paths.
  *
  * A signup that carries a pricing-CTA checkout deep link stashes the package
@@ -56,7 +40,7 @@ export interface SignupCheckoutResolution {
 export function resolveSignupCheckoutDestination(args: {
   intent: "login" | "signup";
   returnTo: string;
-}): SignupCheckoutResolution {
+}): string {
   const { intent, returnTo } = args;
   const { isCheckout, packageKey } = parseCheckoutDestination(returnTo);
 
@@ -70,8 +54,8 @@ export function resolveSignupCheckoutDestination(args: {
       // screen resumes it — an ordinary billing-surface stash stays inert here.
       saveCheckoutIntent({ kind: "package", packageKey, resumeAfterOnboarding: true });
     }
-    return { destination: routes.onboarding.privacy, stashedPackage: packageKey };
+    return routes.onboarding.privacy;
   }
 
-  return { destination: returnTo, stashedPackage: null };
+  return returnTo;
 }

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -440,7 +440,7 @@ function resolvePostAuth(
   // The shared resolver stashes a pricing-CTA checkout package across signup,
   // discards a stale stash for any non-checkout auth, and picks the
   // destination (privacy for signup, the sanitized `returnTo` for login).
-  const { destination: resolved } = resolveSignupCheckoutDestination({
+  const resolved = resolveSignupCheckoutDestination({
     intent: authIntent,
     returnTo: destination,
   });

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -241,7 +241,7 @@ export function resolveNativePostAuthDestination(
   returnTo: string | null | undefined,
 ): string | null {
   const isSignup = intent === "signup";
-  const { destination } = resolveSignupCheckoutDestination({
+  const destination = resolveSignupCheckoutDestination({
     intent: isSignup ? "signup" : "login",
     returnTo: returnTo ?? "",
   });


### PR DESCRIPTION
## Summary
- Local-mode preflight reload no longer runs the provisioning wait (keeps local hatching byte-identical).
- Remove dead exports/fields (checkoutPackageFromDestination, stashedPackage return, isResizeOperationInFlight re-export).
- Clear the checkout stash on the already-Pro no_op bounce.

Self-review remediation for plan: pricing-checkout-flow.md