### PR TITLE
fix(cli): wake's ingress restore retries the flag probe through gateway startup

### DIFF
--- a/cli/src/__tests__/wake.test.ts
+++ b/cli/src/__tests__/wake.test.ts
@@ -179,7 +179,7 @@ mock.module("../lib/nginx-ingress.js", () => ({
   startRemoteWebIngress: startRemoteWebIngressMock,
 }));
 
-const { wake } = await import("../commands/wake.js");
+const { wake, WEB_INGRESS_FLAG_RETRY } = await import("../commands/wake.js");
 
 let tempDir: string;
 let originalArgv: string[];
@@ -408,8 +408,18 @@ describe("vellum wake — web ingress restore", () => {
     ingress: { enabled: true, publicBaseUrl: "https://assistant.example.com" },
   };
 
+  const originalRetry = { ...WEB_INGRESS_FLAG_RETRY };
+
   beforeEach(() => {
     process.argv = ["bun", "vellum", "wake", "local-assistant"];
+    // Shrink the startup-window retry so failure-path tests stay fast.
+    WEB_INGRESS_FLAG_RETRY.attempts = 3;
+    WEB_INGRESS_FLAG_RETRY.intervalMs = 5;
+  });
+
+  afterEach(() => {
+    WEB_INGRESS_FLAG_RETRY.attempts = originalRetry.attempts;
+    WEB_INGRESS_FLAG_RETRY.intervalMs = originalRetry.intervalMs;
   });
 
   test("restores the edge when ingress is enabled, the flag is on, and it is not already running", async () => {
@@ -515,8 +525,35 @@ describe("vellum wake — web ingress restore", () => {
 
     await wake();
 
+    // The probe retries through the startup window before giving up.
+    expect(isAssistantFeatureFlagEnabledMock.mock.calls.length).toBe(3);
     expect(startRemoteWebIngressMock).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith("Wake complete.");
+  });
+
+  test("a flag probe that fails while the gateway is starting retries and then restores", async () => {
+    loadRawConfigMock.mockReturnValue(enabledConfig);
+    isAssistantFeatureFlagEnabledMock
+      .mockRejectedValueOnce(
+        new Error(
+          'Failed to fetch feature flags: HTTP 503 {"status":"starting"}',
+        ),
+      )
+      .mockRejectedValueOnce(
+        new Error(
+          'Failed to fetch feature flags: HTTP 503 {"status":"starting"}',
+        ),
+      )
+      .mockResolvedValueOnce(true);
+
+    await wake();
+
+    expect(isAssistantFeatureFlagEnabledMock.mock.calls.length).toBe(3);
+    expect(logSpy).toHaveBeenCalledWith(
+      "   Waiting for the gateway before restoring the web ingress edge...",
+    );
+    expect(startRemoteWebIngressMock).toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith("Wake complete.");
   });
 });

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -426,6 +426,52 @@ export async function wake(): Promise<void> {
 }
 
 /**
+ * Retry policy for the flag probe that gates the web-ingress restore. The
+ * gateway has typically been up for milliseconds at this point and answers
+ * `503 {"status":"starting"}` (or refuses connections) until its startup
+ * completes, so a single probe races it. Mutable so tests can shrink the
+ * window.
+ */
+export const WEB_INGRESS_FLAG_RETRY = {
+  attempts: 15,
+  intervalMs: 2_000,
+};
+
+/**
+ * Probe the `web-remote-ingress` flag, riding out the gateway's startup
+ * window: transient failures retry on an interval until the attempt budget is
+ * spent, then the last error propagates to the caller's warn path.
+ */
+async function verifyWebIngressFlagWithRetry(
+  assistantId: string,
+  gatewayPort: number,
+): Promise<boolean> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= WEB_INGRESS_FLAG_RETRY.attempts; attempt++) {
+    try {
+      return await isAssistantFeatureFlagEnabled(
+        assistantId,
+        WEB_REMOTE_INGRESS_FLAG,
+        { runtimeUrl: `http://127.0.0.1:${gatewayPort}` },
+      );
+    } catch (err) {
+      lastError = err;
+      if (attempt === 1) {
+        console.log(
+          "   Waiting for the gateway before restoring the web ingress edge...",
+        );
+      }
+      if (attempt < WEB_INGRESS_FLAG_RETRY.attempts) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, WEB_INGRESS_FLAG_RETRY.intervalMs),
+        );
+      }
+    }
+  }
+  throw lastError;
+}
+
+/**
  * Bring the nginx web ingress edge back up after a wake when the workspace
  * config still wants it. Only restores when ingress is explicitly enabled with
  * a saved public URL and the `web-remote-ingress` flag is on — the edge is
@@ -460,11 +506,7 @@ async function restoreWebIngressIfEnabled(
 
   let flagEnabled: boolean;
   try {
-    flagEnabled = await isAssistantFeatureFlagEnabled(
-      assistantId,
-      WEB_REMOTE_INGRESS_FLAG,
-      { runtimeUrl: `http://127.0.0.1:${gatewayPort}` },
-    );
+    flagEnabled = await verifyWebIngressFlagWithRetry(assistantId, gatewayPort);
   } catch (err) {
     console.warn(
       `   Could not verify the \`${WEB_REMOTE_INGRESS_FLAG}\` flag to restore the web ingress edge; leaving it down. Bring it up manually with \`vellum nginx-ingress up\`. ${


### PR DESCRIPTION
## Summary
- The restore's web-remote-ingress probe fires milliseconds after the gateway starts, which answers 503 {"status":"starting"} until ready — a single probe races it and the edge stays down (hit live tonight on a routine sleep/wake)
- The probe now retries on an interval (15 × 2s window, mutable for tests) with a one-time waiting line; the attempt budget spent → the existing warn path, wake never fails
- Tests: retry-then-restore and retries-exhausted both pinned; suite 16/16

Fixes the startup race #39006's author flagged as its one concern.