### PR TITLE
feat(memory): named tier predicates — isMemoryV1Active, isV2InjectionEngineActive

### DIFF
--- a/assistant/src/config/memory-tier.ts
+++ b/assistant/src/config/memory-tier.ts
@@ -1,30 +1,35 @@
-import { isMemoryV3Live } from "./memory-v3-gate.js";
+import {
+  isMemoryEnabled,
+  isMemoryV3Live,
+  isV2InjectionEngineActive,
+} from "./memory-v3-gate.js";
 import type { AssistantConfig } from "./schema.js";
 
 export type MemoryTier = "off" | "v1" | "v2" | "v3";
 
 /**
  * Derive the coarse memory tier for an assistant, as a single bucket for
- * telemetry. Precedence mirrors the runtime memory-source semantics:
+ * telemetry. Precedence is defined by the named gate predicates in
+ * `memory-v3-gate.ts` — this function is fully derived from them, so the tier
+ * buckets and the runtime gates can never disagree:
  *
- * - `"off"` wins over everything: an explicit `memory.enabled === false`
- *   disables the whole memory system regardless of v2/v3 settings.
+ * - `"off"` wins over everything: {@link isMemoryEnabled} is false when an
+ *   explicit `memory.enabled === false` disables the whole memory system,
+ *   regardless of v2/v3 settings.
  * - `"v3"` wins over `"v2"`: when memory-v3 is live it suppresses v2 injection
  *   (see {@link isMemoryV3Live}).
- * - `"v2"` when v2 is explicitly enabled and v3 is not live.
+ * - `"v2"` when the v2 injection engine performs turn-time selection
+ *   (see {@link isV2InjectionEngineActive}).
  * - `"v1"` otherwise (memory on, neither v2 nor v3 selected).
- *
- * Optional chaining is defensive — a partial config (e.g. a mocked config in
- * tests) resolves to the correct bucket rather than throwing.
  */
 export function memoryTier(config: AssistantConfig): MemoryTier {
-  if (config.memory?.enabled === false) {
+  if (!isMemoryEnabled(config)) {
     return "off";
   }
   if (isMemoryV3Live(config)) {
     return "v3";
   }
-  if (config.memory?.v2?.enabled === true) {
+  if (isV2InjectionEngineActive(config)) {
     return "v2";
   }
   return "v1";

--- a/assistant/src/config/memory-v3-gate.test.ts
+++ b/assistant/src/config/memory-v3-gate.test.ts
@@ -168,9 +168,9 @@ describe("tier predicate truth table", () => {
   });
 
   test("v2.enabled stays true on v3-live assistants; the engine predicate still reports inactive", () => {
-    // No migration writes memory.v2.enabled=false at v3 cutover, so a
-    // v3-live config typically still carries v2.enabled=true. A direct
-    // `memory.v2.enabled` read says "on"; the predicate must say "off".
+    // v2.enabled and v3.live may both be true; only the v3 injection engine
+    // is active then. A direct `memory.v2.enabled` read says "on"; the
+    // predicate must say "off".
     const config = makeConfig(undefined, true, true);
     expect(config.memory?.v2?.enabled).toBe(true);
     expect(isV2InjectionEngineActive(config)).toBe(false);

--- a/assistant/src/config/memory-v3-gate.test.ts
+++ b/assistant/src/config/memory-v3-gate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { memoryTier } from "./memory-tier.js";
 import {
   isMemoryEnabled,
   isMemoryV1Active,
@@ -148,6 +149,13 @@ describe("tier predicate truth table", () => {
       expect(isMemoryV1Active(config)).toBe(expV1);
       expect(isV2InjectionEngineActive(config)).toBe(expV2Engine);
       expect(isMemoryV2ExplicitlyDisabled(config)).toBe(expV2Disabled);
+      // The predicates and memoryTier() share one implementation; assert the
+      // tier buckets agree with the predicates on every combination.
+      expect(isMemoryEnabled(config)).toBe(memoryTier(config) !== "off");
+      expect(isMemoryV1Active(config)).toBe(memoryTier(config) === "v1");
+      expect(isV2InjectionEngineActive(config)).toBe(
+        memoryTier(config) === "v2",
+      );
     });
   }
 

--- a/assistant/src/config/memory-v3-gate.test.ts
+++ b/assistant/src/config/memory-v3-gate.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
-import { usesConceptPageMemory } from "./memory-v3-gate.js";
+import {
+  isMemoryEnabled,
+  isMemoryV1Active,
+  isMemoryV2ExplicitlyDisabled,
+  isV2InjectionEngineActive,
+  usesConceptPageMemory,
+} from "./memory-v3-gate.js";
+import type { AssistantConfig } from "./schema.js";
 
 describe("usesConceptPageMemory", () => {
   test("false when memory is explicitly disabled, even with v3 live", () => {
@@ -36,5 +43,130 @@ describe("usesConceptPageMemory", () => {
   test("false on missing config (defensive optional chaining)", () => {
     expect(usesConceptPageMemory(undefined)).toBe(false);
     expect(usesConceptPageMemory({})).toBe(false);
+  });
+});
+
+type TriState = boolean | undefined;
+
+function makeConfig(
+  enabled: TriState,
+  v2Enabled: TriState,
+  v3Live: TriState,
+): AssistantConfig {
+  return {
+    memory: {
+      ...(enabled === undefined ? {} : { enabled }),
+      ...(v2Enabled === undefined ? {} : { v2: { enabled: v2Enabled } }),
+      ...(v3Live === undefined ? {} : { v3: { live: v3Live } }),
+    },
+  } as AssistantConfig;
+}
+
+describe("tier predicate truth table", () => {
+  // Rows: [enabled, v2.enabled, v3.live] → expected
+  // [isMemoryEnabled, isMemoryV1Active, isV2InjectionEngineActive, isMemoryV2ExplicitlyDisabled].
+  // undefined = key unset. Covers all 27 {enabled, v2.enabled, v3.live}
+  // tri-state combinations.
+  const rows: Array<{
+    inputs: [TriState, TriState, TriState];
+    expected: [boolean, boolean, boolean, boolean];
+  }> = [
+    // memory on by default (enabled unset)
+    {
+      inputs: [undefined, undefined, undefined],
+      expected: [true, true, false, false],
+    },
+    {
+      inputs: [undefined, undefined, true],
+      expected: [true, false, false, false],
+    },
+    {
+      inputs: [undefined, undefined, false],
+      expected: [true, true, false, false],
+    },
+    {
+      inputs: [undefined, true, undefined],
+      expected: [true, false, true, false],
+    },
+    { inputs: [undefined, true, true], expected: [true, false, false, false] },
+    { inputs: [undefined, true, false], expected: [true, false, true, false] },
+    {
+      inputs: [undefined, false, undefined],
+      expected: [true, true, false, true],
+    },
+    { inputs: [undefined, false, true], expected: [true, false, false, true] },
+    { inputs: [undefined, false, false], expected: [true, true, false, true] },
+    // memory explicitly on
+    {
+      inputs: [true, undefined, undefined],
+      expected: [true, true, false, false],
+    },
+    { inputs: [true, undefined, true], expected: [true, false, false, false] },
+    { inputs: [true, undefined, false], expected: [true, true, false, false] },
+    { inputs: [true, true, undefined], expected: [true, false, true, false] },
+    { inputs: [true, true, true], expected: [true, false, false, false] },
+    { inputs: [true, true, false], expected: [true, false, true, false] },
+    { inputs: [true, false, undefined], expected: [true, true, false, true] },
+    { inputs: [true, false, true], expected: [true, false, false, true] },
+    { inputs: [true, false, false], expected: [true, true, false, true] },
+    // memory explicitly off — no tier is active, but the explicit v2
+    // opt-out is still visible
+    {
+      inputs: [false, undefined, undefined],
+      expected: [false, false, false, false],
+    },
+    {
+      inputs: [false, undefined, true],
+      expected: [false, false, false, false],
+    },
+    {
+      inputs: [false, undefined, false],
+      expected: [false, false, false, false],
+    },
+    {
+      inputs: [false, true, undefined],
+      expected: [false, false, false, false],
+    },
+    { inputs: [false, true, true], expected: [false, false, false, false] },
+    { inputs: [false, true, false], expected: [false, false, false, false] },
+    {
+      inputs: [false, false, undefined],
+      expected: [false, false, false, true],
+    },
+    { inputs: [false, false, true], expected: [false, false, false, true] },
+    { inputs: [false, false, false], expected: [false, false, false, true] },
+  ];
+
+  const show = (v: TriState) => (v === undefined ? "unset" : String(v));
+
+  for (const { inputs, expected } of rows) {
+    const [enabled, v2Enabled, v3Live] = inputs;
+    const [expEnabled, expV1, expV2Engine, expV2Disabled] = expected;
+    test(`enabled=${show(enabled)} v2.enabled=${show(v2Enabled)} v3.live=${show(v3Live)}`, () => {
+      const config = makeConfig(enabled, v2Enabled, v3Live);
+      expect(isMemoryEnabled(config)).toBe(expEnabled);
+      expect(isMemoryV1Active(config)).toBe(expV1);
+      expect(isV2InjectionEngineActive(config)).toBe(expV2Engine);
+      expect(isMemoryV2ExplicitlyDisabled(config)).toBe(expV2Disabled);
+    });
+  }
+
+  test("empty config: memory on, v1 is the live tier", () => {
+    const config = {} as AssistantConfig;
+    expect(isMemoryEnabled(config)).toBe(true);
+    expect(isMemoryV1Active(config)).toBe(true);
+    expect(isV2InjectionEngineActive(config)).toBe(false);
+    expect(isMemoryV2ExplicitlyDisabled(config)).toBe(false);
+  });
+
+  test("v2.enabled stays true on v3-live assistants; the engine predicate still reports inactive", () => {
+    // No migration writes memory.v2.enabled=false at v3 cutover, so a
+    // v3-live config typically still carries v2.enabled=true. A direct
+    // `memory.v2.enabled` read says "on"; the predicate must say "off".
+    const config = makeConfig(undefined, true, true);
+    expect(config.memory?.v2?.enabled).toBe(true);
+    expect(isV2InjectionEngineActive(config)).toBe(false);
+    // The substrate is still active — v3 is a concept-page consumer.
+    expect(usesConceptPageMemory(config.memory)).toBe(true);
   });
 });

--- a/assistant/src/config/memory-v3-gate.ts
+++ b/assistant/src/config/memory-v3-gate.ts
@@ -1,6 +1,52 @@
 import type { AssistantConfig } from "./schema.js";
 
 /**
+ * Whether memory as a whole is on — the user-facing master switch. Memory is
+ * on unless `memory.enabled` is explicitly set to `false`. Canonical home for
+ * the check; `persistence/jobs-store.ts` carries a config-singleton twin of it
+ * for its many call sites.
+ */
+export function isMemoryEnabled(config: AssistantConfig): boolean {
+  return config.memory?.enabled !== false;
+}
+
+/**
+ * Whether the legacy graph/PKB memory engine (tier v1) is the live tier:
+ * memory is on and no concept-page consumer (v3 live or the v2 injection
+ * engine) is. Deleting v1 removes this predicate and every site it gates.
+ */
+export function isMemoryV1Active(config: AssistantConfig): boolean {
+  return isMemoryEnabled(config) && !usesConceptPageMemory(config.memory);
+}
+
+/**
+ * Whether the v2 activation/router engine performs turn-time selection:
+ * memory is on, `memory.v2.enabled` is set, and v3 is NOT the live injected
+ * source. Distinct from `usesConceptPageMemory`: `memory.v2.enabled` defaults
+ * true and no migration ever writes it false, so on v3-live assistants this
+ * predicate is the ONLY correct way to ask "should v2 select this turn" — a
+ * direct `memory.v2.enabled` read misbehaves under v3.
+ */
+export function isV2InjectionEngineActive(config: AssistantConfig): boolean {
+  return (
+    isMemoryEnabled(config) &&
+    config.memory?.v2?.enabled === true &&
+    !isMemoryV3Live(config)
+  );
+}
+
+/**
+ * Whether `memory.v2.enabled` is explicitly `false` — deliberately NOT the
+ * negation of `isV2InjectionEngineActive`, since the key defaults true. Names
+ * the odd explicit-false semantics `daemon/embedding-reconcile.ts` relies on
+ * (an explicit opt-out suppresses concept-page reconcile work even where the
+ * default would allow it); a v2-deletion-day decision point.
+ */
+export function isMemoryV2ExplicitlyDisabled(config: AssistantConfig): boolean {
+  return config.memory?.v2?.enabled === false;
+}
+
+/**
  * Whether memory-v3 is the live injected memory source for this assistant,
  * suppressing v2 injection. Gated by workspace config (`memory.v3.live`): new
  * assistants are switched on at creation via a workspace migration, while

--- a/assistant/src/config/memory-v3-gate.ts
+++ b/assistant/src/config/memory-v3-gate.ts
@@ -13,7 +13,7 @@ export function isMemoryEnabled(config: AssistantConfig): boolean {
 /**
  * Whether the legacy graph/PKB memory engine (tier v1) is the live tier:
  * memory is on and no concept-page consumer (v3 live or the v2 injection
- * engine) is. Deleting v1 removes this predicate and every site it gates.
+ * engine) is.
  */
 export function isMemoryV1Active(config: AssistantConfig): boolean {
   return isMemoryEnabled(config) && !usesConceptPageMemory(config.memory);
@@ -23,9 +23,9 @@ export function isMemoryV1Active(config: AssistantConfig): boolean {
  * Whether the v2 activation/router engine performs turn-time selection:
  * memory is on, `memory.v2.enabled` is set, and v3 is NOT the live injected
  * source. Distinct from `usesConceptPageMemory`: `memory.v2.enabled` defaults
- * true and no migration ever writes it false, so on v3-live assistants this
- * predicate is the ONLY correct way to ask "should v2 select this turn" — a
- * direct `memory.v2.enabled` read misbehaves under v3.
+ * true and typically stays set on v3-live assistants, so this predicate is the
+ * ONLY correct way to ask "should v2 select this turn" — a direct
+ * `memory.v2.enabled` read misbehaves under v3.
  */
 export function isV2InjectionEngineActive(config: AssistantConfig): boolean {
   return (
@@ -38,9 +38,9 @@ export function isV2InjectionEngineActive(config: AssistantConfig): boolean {
 /**
  * Whether `memory.v2.enabled` is explicitly `false` — deliberately NOT the
  * negation of `isV2InjectionEngineActive`, since the key defaults true. Names
- * the odd explicit-false semantics `daemon/embedding-reconcile.ts` relies on
- * (an explicit opt-out suppresses concept-page reconcile work even where the
- * default would allow it); a v2-deletion-day decision point.
+ * the explicit-false semantics `daemon/embedding-reconcile.ts` relies on: an
+ * explicit opt-out suppresses concept-page reconcile work even where the
+ * default would allow it.
  */
 export function isMemoryV2ExplicitlyDisabled(config: AssistantConfig): boolean {
   return config.memory?.v2?.enabled === false;

--- a/assistant/src/config/memory-v3-gate.ts
+++ b/assistant/src/config/memory-v3-gate.ts
@@ -3,8 +3,8 @@ import type { AssistantConfig } from "./schema.js";
 /**
  * Whether memory as a whole is on — the user-facing master switch. Memory is
  * on unless `memory.enabled` is explicitly set to `false`. Canonical home for
- * the check; `persistence/jobs-store.ts` carries a config-singleton twin of it
- * for its many call sites.
+ * the check; the config-singleton `isMemoryEnabled()` in
+ * `persistence/jobs-store.ts` delegates here.
  */
 export function isMemoryEnabled(config: AssistantConfig): boolean {
   return config.memory?.enabled !== false;

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, inArray, lte, notInArray, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../config/loader.js";
+import { isMemoryEnabled as isMemoryEnabledForConfig } from "../config/memory-v3-gate.js";
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
 import { type DrizzleDb, getMemoryDb } from "./db-connection.js";
@@ -127,10 +128,11 @@ export const MEMORY_V2_CONSOLIDATION_JOB_TRIGGERS = {
   remember: "remember",
 } as const;
 
-/** Returns `false` only when `config.memory.enabled` is explicitly `false`; defaults to `true` on missing config or load errors. */
+/** Config-singleton wrapper over the canonical gate predicate in
+ * `config/memory-v3-gate.ts`; defaults to `true` on config load errors. */
 export function isMemoryEnabled(): boolean {
   try {
-    return getConfig().memory?.enabled !== false;
+    return isMemoryEnabledForConfig(getConfig());
   } catch {
     return true;
   }


### PR DESCRIPTION
## Summary
- Adds isMemoryEnabled / isMemoryV1Active / isV2InjectionEngineActive / isMemoryV2ExplicitlyDisabled to the memory gate module with truth-table tests
- No call-site changes; predicates are adopted in later PRs

Part of plan: memory-tier-separation.md (PR 1 of 14)