### PR TITLE
fix(memory): dispatch tier decisions via named predicates; stop v2 engine on v3-live persona leaves

### DIFF
--- a/assistant/src/config/memory-v3-gate.ts
+++ b/assistant/src/config/memory-v3-gate.ts
@@ -4,18 +4,24 @@ import type { AssistantConfig } from "./schema.js";
  * Whether memory as a whole is on — the user-facing master switch. Memory is
  * on unless `memory.enabled` is explicitly set to `false`. Canonical home for
  * the check; the config-singleton `isMemoryEnabled()` in
- * `persistence/jobs-store.ts` delegates here.
+ * `persistence/jobs-store.ts` delegates here. Accepts any object carrying the
+ * `memory` slice, so callers holding only the plugin-resolved slice (e.g. the
+ * memory plugin's `getMemoryConfig()`) can gate without the full config.
  */
-export function isMemoryEnabled(config: AssistantConfig): boolean {
+export function isMemoryEnabled(
+  config: Pick<AssistantConfig, "memory">,
+): boolean {
   return config.memory?.enabled !== false;
 }
 
 /**
  * Whether the legacy graph/PKB memory engine (tier v1) is the live tier:
  * memory is on and no concept-page consumer (v3 live or the v2 injection
- * engine) is.
+ * engine) is. Like {@link isMemoryEnabled}, accepts a `memory`-slice view.
  */
-export function isMemoryV1Active(config: AssistantConfig): boolean {
+export function isMemoryV1Active(
+  config: Pick<AssistantConfig, "memory">,
+): boolean {
   return isMemoryEnabled(config) && !usesConceptPageMemory(config.memory);
 }
 

--- a/assistant/src/daemon/embedding-reconcile.ts
+++ b/assistant/src/daemon/embedding-reconcile.ts
@@ -19,7 +19,10 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../config/loader.js";
-import { isMemoryV3Live } from "../config/memory-v3-gate.js";
+import {
+  isMemoryV2ExplicitlyDisabled,
+  isMemoryV3Live,
+} from "../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../config/types.js";
 import {
   probeBackendDimension,
@@ -239,8 +242,9 @@ export async function reconcileEmbeddingIdentity(
   // dimension recreate). Running here would enqueue `memory_v2_reembed` against
   // the disabled v2 index and persist a `vectorSize` after the v1 client was
   // already initialized at the old dimension. Defaults to true; gate strictly
-  // on the explicit `false` (and tolerate a missing `v2` node in test configs).
-  if (config.memory.v2?.enabled === false) {
+  // on the explicit `false` (and tolerate a missing `v2` node in test
+  // configs) — the semantics `isMemoryV2ExplicitlyDisabled` names.
+  if (isMemoryV2ExplicitlyDisabled(config)) {
     log.info(
       "Memory v2 disabled — skipping embedding-identity reconcile; v1 path owns its collection dimension",
     );

--- a/assistant/src/plugins/defaults/memory/context-search/sources/memory.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/memory.ts
@@ -24,6 +24,9 @@ export async function searchMemorySource(
     return { evidence: [] };
   }
 
+  // Tier dispatch: under the concept-page substrate (v2/v3) recall reads
+  // concept pages; on v1 it falls through to the legacy graph-node search
+  // below.
   if (usesConceptPageMemory(context.config.memory)) {
     return searchMemoryV2Source(query, context, normalizedLimit);
   }

--- a/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -1,9 +1,10 @@
 /**
  * Tests for the v2 routing wired into `ConversationGraphMemory.prepareMemory`.
  *
- * The wiring layer at `conversation-graph-memory.ts` reads
- * `config.memory.v2.enabled` to decide whether to swap v1's injection step
- * for the v2 activation pipeline.
+ * The wiring layer at `conversation-graph-memory.ts` dispatches on
+ * `isV2InjectionEngineActive` to decide whether to swap v1's injection step
+ * for the v2 activation pipeline — so the v2 engine runs only when memory is
+ * on, `memory.v2.enabled` is set, and v3 is not the live injected source.
  *
  * This file uses the *real* `injectMemoryV2Block` and stubs only the
  * lower-level deps (Qdrant client, embedding backend) the way
@@ -246,13 +247,18 @@ function createTestDb(): DrizzleDb {
   return db;
 }
 
-function makeConfig(v2Enabled: boolean, memoryEnabled = true): AssistantConfig {
+function makeConfig(
+  v2Enabled: boolean,
+  memoryEnabled = true,
+  v3Live = false,
+): AssistantConfig {
   // Pin `router.enabled: false` so these tests exercise the activation
   // pipeline. Router-mode coverage lives in `memory/v2/__tests__/injection.test.ts`.
   return applyNestedDefaults({
     memory: {
       enabled: memoryEnabled,
       v2: { enabled: v2Enabled, router: { enabled: false } },
+      v3: { live: v3Live },
     },
   }) as AssistantConfig;
 }
@@ -554,6 +560,62 @@ describe("ConversationGraphMemory.prepareMemory — v2 routing (context-load pat
 
     expect(result.mode).toBe("context-load");
     expect(result.injectedBlockText).toBeNull();
+  });
+});
+
+describe("ConversationGraphMemory.prepareMemory — v3-live suppresses the v2 engine", () => {
+  // `memory.v2.enabled` defaults true and stays set on v3-live assistants, so
+  // the dispatch must NOT read it directly: with v3 live, the v2
+  // router/activation pipeline (and its activation-log/injection-event
+  // writes) must not run even though the flag is on. This covers every
+  // `prepareMemory` caller, including ones without their own v3 guard (the
+  // persona workflow-leaf runner).
+  test("per-turn: v3 live with v2.enabled=true → v2 not routed, v1 fallback taken", async () => {
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+
+    const memory = makeMemory();
+    const config = makeConfig(true, true, true);
+    const messages = makeMessages("Tell me about Alice's editor preferences");
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.mode).toBe("per-turn");
+    expect(result.injectedBlockText).toBeNull();
+    expect(result.runMessages).toEqual(messages);
+    // Dispatch falls through to the v1 retriever (its stub returns zero
+    // nodes) instead of routing into the v2 engine.
+    expect(retrieveForTurnMock).toHaveBeenCalled();
+    // The v2 activation pipeline embeds its hybrid queries through the
+    // embedding backend; zero calls proves the pipeline never started.
+    expect(embedWithBackendMock).not.toHaveBeenCalled();
+    // And it persisted no activation state for the conversation.
+    expect(await hydrateActivationState("conv-test-1")).toBeNull();
+  });
+
+  test("context-load: v3 live with v2.enabled=true → v2 not routed, v1 fallback taken", async () => {
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+
+    const memory = new ConversationGraphMemory("conv-test-v3-cl");
+    const config = makeConfig(true, true, true);
+    const messages = makeMessages("first message of the conversation here");
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.mode).toBe("context-load");
+    expect(result.injectedBlockText).toBeNull();
+    expect(loadContextMemoryMock).toHaveBeenCalled();
+    expect(embedWithBackendMock).not.toHaveBeenCalled();
+    expect(await hydrateActivationState("conv-test-v3-cl")).toBeNull();
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -10,6 +10,7 @@ import type { ContentBlock, ImageContent, Message } from "@vellumai/plugin-api";
 import { and, desc, eq, inArray, ne, notInArray } from "drizzle-orm";
 import { z } from "zod";
 
+import { isV2InjectionEngineActive } from "../../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../../config/types.js";
 import { estimateTextTokens } from "../../../../context/token-estimator.js";
 import type { AssistantEvent } from "../../../../daemon/message-protocol.js";
@@ -581,7 +582,9 @@ export class ConversationGraphMemory {
       };
     }
 
-    // v1 fallback — only reached when the v2 flag or workspace config is off.
+    // v1 fallback — only reached when the v2 engine is not the live tier (v2
+    // disabled, memory off, or v3 live; under the concept-page substrate the
+    // retriever short-circuits to zero nodes).
     const result = await loadContextMemory({
       recentSummaries,
       userQuery,
@@ -703,8 +706,8 @@ export class ConversationGraphMemory {
       if (userLastBlocks.length > 0 && assistantLast) {break;}
     }
 
-    // v2 path — skip v1 retrieval entirely when v2 is enabled. See the
-    // matching comment in `runContextLoad` for rationale.
+    // v2 path — skip v1 retrieval entirely when the v2 engine is the live
+    // tier. See the matching comment in `runContextLoad` for rationale.
     const startedAt = Date.now();
     const v2 = await this.maybeRouteV2Injection(
       messages,
@@ -747,7 +750,9 @@ export class ConversationGraphMemory {
       };
     }
 
-    // v1 path (only reached when the v2 flag or workspace config is off).
+    // v1 path (only reached when the v2 engine is not the live tier — v2
+    // disabled, memory off, or v3 live; under the concept-page substrate the
+    // retriever short-circuits to zero nodes).
     const result = await retrieveForTurn({
       assistantLastMessage: assistantLast,
       userLastMessage: userLast,
@@ -851,11 +856,16 @@ export class ConversationGraphMemory {
   }
 
   /**
-   * Run the v2 activation pipeline when the workspace config
-   * (`memory.v2.enabled`) is on.
+   * Run the v2 activation pipeline when the v2 injection engine is the live
+   * tier ({@link isV2InjectionEngineActive}) — memory on, `memory.v2.enabled`
+   * set, and v3 not live. Every `prepareMemory` entry point shares this gate,
+   * including callers without their own v3 guard (e.g. the persona
+   * workflow-leaf runner), so a v3-live assistant never runs the v2
+   * router/activation pipeline or writes its activation/injection logs.
    *
    * The two outcomes the caller distinguishes via `routed`:
-   *   - `routed: false` — v2 disabled; caller falls through to the legacy v1
+   *   - `routed: false` — v2 engine not active (disabled, memory off, or v3
+   *                        live); caller falls through to the legacy v1
    *                        retrieval path.
    *   - `routed: true`  — v2 ran. `runMessages` is either the v2-prepended
    *                        message list (block was non-null) or the input
@@ -880,7 +890,7 @@ export class ConversationGraphMemory {
     runMessages: Message[];
     injectedBlockText: string | null;
   }> {
-    if (!config.memory.v2.enabled) {
+    if (!isV2InjectionEngineActive(config)) {
       return { routed: false, runMessages: messages, injectedBlockText: null };
     }
 

--- a/assistant/src/plugins/defaults/memory/hooks/__tests__/user-prompt-submit.test.ts
+++ b/assistant/src/plugins/defaults/memory/hooks/__tests__/user-prompt-submit.test.ts
@@ -1,37 +1,51 @@
 import { describe, expect, test } from "bun:test";
 
-import { shouldRunV2Retrieval } from "../user-prompt-submit.js";
+import { shouldRunLegacyMemoryRetrieval } from "../user-prompt-submit.js";
 
 /**
- * v2 graph-memory retrieval is the deprecated path. It is gated off under
- * `memory-v3-live` — v3 owns the injected-memory layer and runtime assembly
- * strips any v2 `<memory>` block, so running v2's per-turn retrieval (embedding
- * + hybrid search + the `memoryRetrieval` LLM router) would only have its
- * result discarded. It is also skipped for untrusted actors. The
- * conversation/abort-signal presence checks stay inline at the call site (for
- * type narrowing) and are deliberately NOT part of this policy decision.
+ * Legacy (v1/v2) graph-memory retrieval is the deprecated path — the gate
+ * covers both pre-v3 engines, which `prepareMemory` dispatches between
+ * internally. It is gated off under `memory-v3-live` — v3 owns the
+ * injected-memory layer and runtime assembly strips any legacy `<memory>`
+ * block, so running the legacy per-turn retrieval (embedding + hybrid search
+ * + the `memoryRetrieval` LLM router) would only have its result discarded.
+ * It is also skipped for untrusted actors. The conversation/abort-signal
+ * presence checks stay inline at the call site (for type narrowing) and are
+ * deliberately NOT part of this policy decision.
  */
-describe("shouldRunV2Retrieval", () => {
-  test("runs for a trusted actor when memory-v3-live is off (v2/shadow path)", () => {
+describe("shouldRunLegacyMemoryRetrieval", () => {
+  test("runs for a trusted actor when memory-v3-live is off (v1/v2 path)", () => {
     expect(
-      shouldRunV2Retrieval({ isTrustedActor: true, memoryV3Live: false }),
+      shouldRunLegacyMemoryRetrieval({
+        isTrustedActor: true,
+        memoryV3Live: false,
+      }),
     ).toBe(true);
   });
 
   test("is skipped under memory-v3-live even for a trusted actor", () => {
-    // The cutover: v3 owns memory, so v2 retrieval (and its LLM router) must
-    // not fire — this is the per-turn cost the gate removes.
+    // The cutover: v3 owns memory, so legacy retrieval (and its LLM router)
+    // must not fire — this is the per-turn cost the gate removes.
     expect(
-      shouldRunV2Retrieval({ isTrustedActor: true, memoryV3Live: true }),
+      shouldRunLegacyMemoryRetrieval({
+        isTrustedActor: true,
+        memoryV3Live: true,
+      }),
     ).toBe(false);
   });
 
   test("is skipped for an untrusted actor regardless of the flag", () => {
     expect(
-      shouldRunV2Retrieval({ isTrustedActor: false, memoryV3Live: false }),
+      shouldRunLegacyMemoryRetrieval({
+        isTrustedActor: false,
+        memoryV3Live: false,
+      }),
     ).toBe(false);
     expect(
-      shouldRunV2Retrieval({ isTrustedActor: false, memoryV3Live: true }),
+      shouldRunLegacyMemoryRetrieval({
+        isTrustedActor: false,
+        memoryV3Live: true,
+      }),
     ).toBe(false);
   });
 });

--- a/assistant/src/plugins/defaults/memory/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/memory/hooks/user-prompt-submit.ts
@@ -51,15 +51,18 @@ import { recordMemoryRecallLog } from "../memory-recall-log-store.js";
 import { MEMORY_V3_INJECTED_BLOCK_METADATA_KEY } from "../v3/ever-injected-store.js";
 
 /**
- * Whether to run v2 graph-memory retrieval this turn. v2 retrieval is the
+ * Whether to run legacy graph-memory retrieval this turn. It gates BOTH
+ * pre-v3 read paths — `prepareMemory` dispatches internally between v1
+ * retrieval and the v2 activation engine. The legacy retrieval is the
  * deprecated path: under `memory-v3-live`, v3 is the injected-memory source and
- * runtime assembly strips any v2 `<memory>` block, so running v2's retrieval
- * (embedding + hybrid search + the `memoryRetrieval` LLM router) only to
- * discard the result is pure per-turn waste. Untrusted actors never run it
- * either. The caller additionally requires the live conversation and its abort
- * signal to be present (kept inline at the call site for type narrowing).
+ * runtime assembly strips any legacy `<memory>` block, so running the legacy
+ * retrieval (embedding + hybrid search + the `memoryRetrieval` LLM router)
+ * only to discard the result is pure per-turn waste. Untrusted actors never
+ * run it either. The caller additionally requires the live conversation and
+ * its abort signal to be present (kept inline at the call site for type
+ * narrowing).
  */
-export function shouldRunV2Retrieval(params: {
+export function shouldRunLegacyMemoryRetrieval(params: {
   isTrustedActor: boolean;
   memoryV3Live: boolean;
 }): boolean {
@@ -281,16 +284,17 @@ const userPromptSubmitMemoryRetrieval: HookFunction<
     conversation?.trustContext,
   );
 
-  // v2 graph retrieval is the deprecated path: `shouldRunV2Retrieval` skips it
-  // under memory-v3-live (v3 owns the `<memory>` layer and assembly strips any
-  // v2 block) and for untrusted actors. The `conversation && abortSignal`
-  // presence checks stay inline so the block below narrows. NOTE: this removes
-  // the v2 fallback — under v3-live, a v3 empty/failed selection yields no NEW
-  // injected memory that turn (prior turns' frozen v3 cards still ride history).
+  // Legacy (v1/v2) graph retrieval is the deprecated path:
+  // `shouldRunLegacyMemoryRetrieval` skips it under memory-v3-live (v3 owns
+  // the `<memory>` layer and assembly strips any legacy block) and for
+  // untrusted actors. The `conversation && abortSignal` presence checks stay
+  // inline so the block below narrows. NOTE: under v3-live there is no legacy
+  // fallback — a v3 empty/failed selection yields no NEW injected memory that
+  // turn (prior turns' frozen v3 cards still ride history).
   const memoryV3Live = isMemoryV3Live(config);
   let v2BlockPersisted = false;
   if (
-    shouldRunV2Retrieval({ isTrustedActor, memoryV3Live }) &&
+    shouldRunLegacyMemoryRetrieval({ isTrustedActor, memoryV3Live }) &&
     conversation &&
     abortSignal
   ) {

--- a/assistant/src/plugins/defaults/memory/injectors.ts
+++ b/assistant/src/plugins/defaults/memory/injectors.ts
@@ -5,7 +5,7 @@
  * (with hybrid-search hints), and the memory-v2 static `<info>` block. Each
  * reads its inputs directly off the {@link TurnContext} (and the workspace
  * memory/PKB files), runs its own gating (injection mode, the personal-memory
- * trust gate, the v2 cutover guard, null-input short-circuits), and returns an
+ * trust gate, the memory-tier gate, null-input short-circuits), and returns an
  * {@link InjectionBlock} with the placement that yields the canonical
  * positional semantics.
  *
@@ -20,7 +20,7 @@ import { resolve } from "node:path";
 
 import type { Message } from "@vellumai/plugin-api";
 
-import { usesConceptPageMemory } from "../../../config/memory-v3-gate.js";
+import { isMemoryV1Active } from "../../../config/memory-v3-gate.js";
 import type { InjectionMatcher } from "../../../context/strip-injections.js";
 import { getInContextPkbPaths } from "../../../daemon/pkb-context-tracker.js";
 import { buildPkbReminder } from "../../../daemon/pkb-reminder-builder.js";
@@ -56,18 +56,18 @@ const PKB_HINT_THRESHOLD = 0.5;
 const PKB_HINT_ARCHIVE_THRESHOLD = 0.7;
 
 /**
- * Read-side cutover guard. Under concept-page memory both `pkb-context` and
- * `pkb-reminder` silence themselves entirely — the `<knowledge_base>` content
- * and the generic recall/remember nudge are both supplanted by the static
- * memory block. They are also silenced when memory is disabled outright:
- * these injectors have no other `memory.enabled` gate, and a workspace with
- * leftover `pkb/*` files must not keep surfacing long-term memory after the
- * user turns memory off. NOW.md is workspace state independent of PKB and
- * fires unchanged.
+ * Read-side tier gate. The PKB injectors (`pkb-context`, `pkb-reminder`) are
+ * the v1 injection surface, active only when v1 is the live memory tier
+ * ({@link isMemoryV1Active}). Under concept-page memory both silence
+ * themselves entirely — the `<knowledge_base>` content and the generic
+ * recall/remember nudge are both supplanted by the static memory block. They
+ * are also silenced when memory is disabled outright: these injectors have no
+ * other `memory.enabled` gate, and a workspace with leftover `pkb/*` files
+ * must not keep surfacing long-term memory after the user turns memory off.
+ * NOW.md is workspace state independent of PKB and fires unchanged.
  */
 function isPkbInjectionSilenced(): boolean {
-  const memory = getMemoryConfig();
-  return memory.enabled === false || usesConceptPageMemory(memory);
+  return !isMemoryV1Active({ memory: getMemoryConfig() });
 }
 
 /**

--- a/assistant/src/workflows/leaf-runner.ts
+++ b/assistant/src/workflows/leaf-runner.ts
@@ -128,6 +128,12 @@ async function resolveLeafContext(
  * persona leaf still gets the assistant's identity system prompt but NO personal
  * memory. Without this, a workflow launched by an untrusted actor whose manifest
  * grants `persona` could exfiltrate private memory in its output.
+ *
+ * On a v3-live assistant a persona leaf receives no injected memory at all:
+ * `prepareMemory`'s v2 route is gated on `isV2InjectionEngineActive` (v3 live
+ * suppresses it), the v1 retriever short-circuits to empty under the
+ * concept-page substrate, and v3 orchestration is conversation-turn-scoped so
+ * it does not run for workflow leaves.
  */
 async function injectPersonaMemory(
   opts: RunLeafOptions,


### PR DESCRIPTION
## Summary
- Routes v2-engine dispatch through isV2InjectionEngineActive — persona workflow leaves on v3-live assistants no longer run the v2 router/activation pipeline
- Renames shouldRunV2Retrieval → shouldRunLegacyMemoryRetrieval (it gates v1 AND v2); PKB injector gate expressed as isMemoryV1Active
- embedding-reconcile's explicit-false read goes through the named gate predicate

Part of plan: memory-tier-separation.md (PR 2 of 14)