### PR TITLE
fix(memory): stop v1 graph bootstrap and maintenance handlers running under the substrate

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -151,6 +151,7 @@ mock.module("../persistence/jobs-store.js", () => ({
   MESSAGE_LEXICAL_JOB_TYPES: [],
   rescheduleMemoryJob: mock(() => {}),
   resetRunningJobsToPending: mock(() => 0),
+  upsertEmbedGraphNodeJob: mock(() => "job-embed-node"),
   SLOW_LLM_JOB_TYPES: [],
   upsertDebouncedJob: mock(() => "job-debounced"),
   upsertMemoryRetrospectiveJob: mock(() => "job-memory-retrospective"),

--- a/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
+++ b/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
@@ -40,8 +40,13 @@ setDefaultTimeout(30_000);
 // claimed jobs without lane awareness and ran them through a single
 // workerConcurrency-sized pool — would pin its slots on the first claimed
 // slow jobs and force the fast jobs to queue behind a 200ms LLM call.
+// `memory.v2.enabled` is off so v1 is the active memory tier: the slow-lane
+// job here is `graph_consolidate`, whose handler completes v1 graph rows as
+// a no-op while concept-page memory is active — this test needs it to
+// genuinely run.
 // Everything else (including `memory.enabled: true`) is the schema default.
 setConfig("memory", {
+  v2: { enabled: false },
   jobs: {
     slowLlmConcurrency: 1,
     fastConcurrency: 5,

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -455,6 +455,36 @@ export function upsertEmbedConceptPageJob(payload: { slug: string }): string {
   return enqueueMemoryJob("embed_concept_page", { slug: payload.slug });
 }
 
+/**
+ * Enqueue an `embed_graph_node` job, coalescing with an existing pending row
+ * for the same node id. The payload carries only the node id — the handler
+ * reads the node's content at execution time — so a pending row is exactly
+ * equivalent to a fresh enqueue and a duplicate would only redo identical
+ * embedding work and Qdrant upserts. A running row never matches: it may have
+ * embedded a pre-write snapshot of the node, so the new enqueue must survive
+ * it. Same synchronous check-then-insert rationale as
+ * {@link upsertEmbedConceptPageJob}. Returns the id of the pending row,
+ * existing or newly inserted.
+ */
+export function upsertEmbedGraphNodeJob(payload: { nodeId: string }): string {
+  const db = memoryDb();
+  const existing = db
+    .select({ id: memoryJobs.id })
+    .from(memoryJobs)
+    .where(
+      and(
+        eq(memoryJobs.type, "embed_graph_node"),
+        eq(memoryJobs.status, "pending"),
+        sql`json_extract(${memoryJobs.payload}, '$.nodeId') = ${payload.nodeId}`,
+      ),
+    )
+    .get();
+  if (existing) {
+    return existing.id;
+  }
+  return enqueueMemoryJob("embed_graph_node", { nodeId: payload.nodeId });
+}
+
 export function enqueuePruneOldLlmRequestLogsJob(retentionMs?: number): string {
   const db = memoryDb();
   const existing = db

--- a/assistant/src/plugins/defaults/memory/__tests__/capability-seed-embed-gate.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/capability-seed-embed-gate.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Capability-node seeding across memory tiers: the graph-node upserts run on
+ * every tier (the `list_memory` surface reads capability nodes regardless of
+ * tier), but `embed_graph_node` rows target the v1 Qdrant collection and
+ * dispatch discards them while concept-page memory is active — so the seeder
+ * writes those rows only when v1 is the active tier.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+const tmpWorkspace = mkdtempSync(join(tmpdir(), "capability-seed-embed-gate-"));
+const previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+
+const { setConfig } =
+  await import("../../../../__tests__/helpers/set-config.js");
+const { getMemoryDb } =
+  await import("../../../../persistence/db-connection.js");
+const { initializeDb } = await import("../../../../persistence/db-init.js");
+const { memoryGraphNodes, memoryJobs } =
+  await import("../../../../persistence/schema/index.js");
+const { seedCliGraphNodes } = await import("../graph/capability-seed.js");
+
+function countEmbedGraphNodeJobs(): number {
+  return getMemoryDb()!
+    .select()
+    .from(memoryJobs)
+    .where(eq(memoryJobs.type, "embed_graph_node"))
+    .all().length;
+}
+
+function countCapabilityNodes(): number {
+  return getMemoryDb()!
+    .select()
+    .from(memoryGraphNodes)
+    .where(eq(memoryGraphNodes.type, "procedural"))
+    .all().length;
+}
+
+describe("capability seeding embed_graph_node gate", () => {
+  beforeAll(async () => {
+    await initializeDb();
+  }, 30_000);
+
+  afterAll(() => {
+    if (previousWorkspaceEnv === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+    }
+    rmSync(tmpWorkspace, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    getMemoryDb()!.run("DELETE FROM memory_jobs");
+    getMemoryDb()!.run("DELETE FROM memory_graph_nodes");
+  });
+
+  test("v3-live config: nodes are upserted but no embed_graph_node rows are enqueued", async () => {
+    setConfig("memory", { v3: { live: true } });
+
+    await seedCliGraphNodes();
+
+    expect(countCapabilityNodes()).toBeGreaterThan(0);
+    expect(countEmbedGraphNodeJobs()).toBe(0);
+  });
+
+  test("v1 config: newly created capability nodes enqueue embed_graph_node rows", async () => {
+    setConfig("memory", { v2: { enabled: false }, v3: { live: false } });
+
+    await seedCliGraphNodes();
+
+    const nodes = countCapabilityNodes();
+    expect(nodes).toBeGreaterThan(0);
+    expect(countEmbedGraphNodeJobs()).toBe(nodes);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/capability-seed-embed-gate.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/capability-seed-embed-gate.test.ts
@@ -3,8 +3,11 @@
  * every tier (the `list_memory` surface reads capability nodes regardless of
  * tier), but `embed_graph_node` rows target the v1 Qdrant collection and
  * dispatch discards them while concept-page memory is active — so the seeder
- * writes those rows only when v1 is the active tier.
+ * writes those rows only when v1 is the active tier. On the v1 path the
+ * seeder also reconciles unchanged nodes that lack a stored embedding, so a
+ * capability seeded while a higher tier was active still gets its v1 point.
  */
+import { randomUUID } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -19,16 +22,18 @@ import {
 
 import { eq } from "drizzle-orm";
 
+import { assertNotLiveDb } from "../../../../__tests__/assert-not-live-db.js";
+
 const tmpWorkspace = mkdtempSync(join(tmpdir(), "capability-seed-embed-gate-"));
 const previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
 process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
 
 const { setConfig } =
   await import("../../../../__tests__/helpers/set-config.js");
-const { getMemoryDb } =
+const { getDb, getMemoryDb } =
   await import("../../../../persistence/db-connection.js");
 const { initializeDb } = await import("../../../../persistence/db-init.js");
-const { memoryGraphNodes, memoryJobs } =
+const { memoryEmbeddings, memoryGraphNodes, memoryJobs } =
   await import("../../../../persistence/schema/index.js");
 const { seedCliGraphNodes } = await import("../graph/capability-seed.js");
 
@@ -48,6 +53,39 @@ function countCapabilityNodes(): number {
     .all().length;
 }
 
+/**
+ * Insert a `memory_embeddings` row for every capability node, simulating
+ * completed `embed_graph_node` jobs. The reconcile path only checks row
+ * presence on the `(target_type, target_id)` prefix, so provider/model/vector
+ * values are arbitrary.
+ */
+function insertEmbeddingRowsForAllCapabilityNodes(): void {
+  const nodes = getMemoryDb()!
+    .select({ id: memoryGraphNodes.id })
+    .from(memoryGraphNodes)
+    .where(eq(memoryGraphNodes.type, "procedural"))
+    .all();
+  const now = Date.now();
+  for (const node of nodes) {
+    getDb()
+      .insert(memoryEmbeddings)
+      .values({
+        id: randomUUID(),
+        targetType: "graph_node",
+        targetId: node.id,
+        provider: "test-provider",
+        model: "test-model",
+        dimensions: 4,
+        vectorJson: JSON.stringify([0, 0, 0, 0]),
+        vectorBlob: null,
+        contentHash: "test-hash",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  }
+}
+
 describe("capability seeding embed_graph_node gate", () => {
   beforeAll(async () => {
     await initializeDb();
@@ -59,12 +97,14 @@ describe("capability seeding embed_graph_node gate", () => {
     } else {
       process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
     }
+    assertNotLiveDb(tmpWorkspace);
     rmSync(tmpWorkspace, { recursive: true, force: true });
   });
 
   beforeEach(() => {
     getMemoryDb()!.run("DELETE FROM memory_jobs");
     getMemoryDb()!.run("DELETE FROM memory_graph_nodes");
+    getDb().delete(memoryEmbeddings).run();
   });
 
   test("v3-live config: nodes are upserted but no embed_graph_node rows are enqueued", async () => {
@@ -84,5 +124,31 @@ describe("capability seeding embed_graph_node gate", () => {
     const nodes = countCapabilityNodes();
     expect(nodes).toBeGreaterThan(0);
     expect(countEmbedGraphNodeJobs()).toBe(nodes);
+  });
+
+  test("v1 after v3-live seeding: unchanged nodes with no embedding row re-enqueue embed_graph_node", async () => {
+    setConfig("memory", { v3: { live: true } });
+    await seedCliGraphNodes();
+    expect(countEmbedGraphNodeJobs()).toBe(0);
+
+    setConfig("memory", { v2: { enabled: false }, v3: { live: false } });
+    await seedCliGraphNodes();
+
+    const nodes = countCapabilityNodes();
+    expect(nodes).toBeGreaterThan(0);
+    expect(countEmbedGraphNodeJobs()).toBe(nodes);
+  });
+
+  test("v1 with embedding rows present: unchanged nodes do not enqueue duplicates", async () => {
+    setConfig("memory", { v2: { enabled: false }, v3: { live: false } });
+    await seedCliGraphNodes();
+    expect(countCapabilityNodes()).toBeGreaterThan(0);
+
+    insertEmbeddingRowsForAllCapabilityNodes();
+    getMemoryDb()!.run("DELETE FROM memory_jobs");
+
+    await seedCliGraphNodes();
+
+    expect(countEmbedGraphNodeJobs()).toBe(0);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/capability-seed-embed-gate.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/capability-seed-embed-gate.test.ts
@@ -6,6 +6,8 @@
  * writes those rows only when v1 is the active tier. On the v1 path the
  * seeder also reconciles unchanged nodes that lack a stored embedding, so a
  * capability seeded while a higher tier was active still gets its v1 point.
+ * Enqueues coalesce with a pending `embed_graph_node` row for the same node,
+ * so back-to-back seed passes queue at most one job per node.
  */
 import { randomUUID } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -132,6 +134,17 @@ describe("capability seeding embed_graph_node gate", () => {
     expect(countEmbedGraphNodeJobs()).toBe(0);
 
     setConfig("memory", { v2: { enabled: false }, v3: { live: false } });
+    await seedCliGraphNodes();
+
+    const nodes = countCapabilityNodes();
+    expect(nodes).toBeGreaterThan(0);
+    expect(countEmbedGraphNodeJobs()).toBe(nodes);
+  });
+
+  test("v1 double-seed with no embedding rows: exactly one pending embed job per node", async () => {
+    setConfig("memory", { v2: { enabled: false }, v3: { live: false } });
+
+    await seedCliGraphNodes();
     await seedCliGraphNodes();
 
     const nodes = countCapabilityNodes();

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v1-graph-substrate-noop.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v1-graph-substrate-noop.test.ts
@@ -33,6 +33,8 @@ import type { MemoryJob } from "../../../../persistence/jobs-store.js";
 
 let bootstrapCalls = 0;
 let maybeEnqueueBootstrapCalls = 0;
+let seedSkillGraphNodeCalls = 0;
+let seedCliGraphNodeCalls = 0;
 let decayCalls = 0;
 let consolidateCalls = 0;
 let patternScanCalls = 0;
@@ -60,6 +62,17 @@ mock.module("../graph/bootstrap.js", () => ({
   resetBootstrapCheckpoint: () => {},
   migrateToolCreatedItems: () => {},
   cleanupStaleItemVectors: async () => {},
+}));
+
+mock.module("../graph/capability-seed.js", () => ({
+  deleteSkillCapabilityNode: () => {},
+  seedSkillGraphNodes: () => {
+    seedSkillGraphNodeCalls += 1;
+  },
+  seedCliGraphNodes: async () => {
+    seedCliGraphNodeCalls += 1;
+  },
+  seedUninstalledCatalogSkillMemories: async () => {},
 }));
 
 mock.module("../graph/decay.js", () => ({
@@ -123,12 +136,21 @@ const { memoryJobs } = await import("../../../../persistence/schema/index.js");
 const { memoryJobHandlers } = await import("../job-handlers.js");
 const { registerMemoryPluginJobHandlers } =
   await import("../job-handler-registration.js");
-const { maybeEnqueueGraphMaintenanceJobs, runMemoryJobsOnce } =
-  await import("../jobs-worker.js");
+const {
+  GRAPH_MAINTENANCE_CHECKPOINTS,
+  maybeEnqueueGraphMaintenanceJobs,
+  runMemoryJobsOnce,
+} = await import("../jobs-worker.js");
+const { deleteMemoryCheckpoint, getMemoryCheckpoint } =
+  await import("../../../../persistence/checkpoints.js");
+
+const V1_ENTRY_RECONCILE_KEY = GRAPH_MAINTENANCE_CHECKPOINTS.v1EntryReconcile;
 
 function resetCallCounts(): void {
   bootstrapCalls = 0;
   maybeEnqueueBootstrapCalls = 0;
+  seedSkillGraphNodeCalls = 0;
+  seedCliGraphNodeCalls = 0;
   decayCalls = 0;
   consolidateCalls = 0;
   patternScanCalls = 0;
@@ -257,15 +279,48 @@ describe("v1 graph jobs under concept-page memory", () => {
     expect(decayCalls).toBe(1);
   });
 
-  test("the periodic maintenance scheduler re-checks bootstrap on a v1 config", () => {
+  test("the first v1 tick runs the entry reconcile once, checkpoints it, and later ticks skip it", () => {
+    deleteMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY);
+
     maybeEnqueueGraphMaintenanceJobs(v1Config(), Date.now());
 
     expect(maybeEnqueueBootstrapCalls).toBe(1);
+    expect(seedSkillGraphNodeCalls).toBe(1);
+    expect(seedCliGraphNodeCalls).toBe(1);
+    expect(getMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY)).not.toBeNull();
+
+    // Second tick: the persisted checkpoint suppresses the reconcile even
+    // though the (mocked, empty) graph is unchanged — the tight re-enqueue
+    // loop the per-tick bootstrap check allowed is impossible.
+    maybeEnqueueGraphMaintenanceJobs(v1Config(), Date.now());
+
+    expect(maybeEnqueueBootstrapCalls).toBe(1);
+    expect(seedSkillGraphNodeCalls).toBe(1);
+    expect(seedCliGraphNodeCalls).toBe(1);
   });
 
-  test("the periodic maintenance scheduler skips the bootstrap check under concept-page memory", () => {
+  test("a substrate tick clears the checkpoint so a hot transition back to v1 reconciles again", () => {
+    deleteMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY);
+
+    maybeEnqueueGraphMaintenanceJobs(v1Config(), Date.now());
+
+    expect(maybeEnqueueBootstrapCalls).toBe(1);
+    expect(getMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY)).not.toBeNull();
+
+    // Substrate tick: never runs the reconcile, and re-arms it by clearing
+    // the checkpoint.
     maybeEnqueueGraphMaintenanceJobs(applyNestedDefaults({}), Date.now());
 
-    expect(maybeEnqueueBootstrapCalls).toBe(0);
+    expect(maybeEnqueueBootstrapCalls).toBe(1);
+    expect(seedSkillGraphNodeCalls).toBe(1);
+    expect(getMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY)).toBeNull();
+
+    // Returning to v1 runs the reconcile exactly once more.
+    maybeEnqueueGraphMaintenanceJobs(v1Config(), Date.now());
+
+    expect(maybeEnqueueBootstrapCalls).toBe(2);
+    expect(seedSkillGraphNodeCalls).toBe(2);
+    expect(seedCliGraphNodeCalls).toBe(2);
+    expect(getMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY)).not.toBeNull();
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v1-graph-substrate-noop.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v1-graph-substrate-noop.test.ts
@@ -32,6 +32,7 @@ import type { AssistantConfig } from "../../../../config/types.js";
 import type { MemoryJob } from "../../../../persistence/jobs-store.js";
 
 let bootstrapCalls = 0;
+let maybeEnqueueBootstrapCalls = 0;
 let decayCalls = 0;
 let consolidateCalls = 0;
 let patternScanCalls = 0;
@@ -53,7 +54,9 @@ mock.module("../graph/bootstrap.js", () => ({
     };
   },
   bootstrapFromJournal: async () => ({ extracted: 0, errors: 0 }),
-  maybeEnqueueGraphBootstrap: () => {},
+  maybeEnqueueGraphBootstrap: () => {
+    maybeEnqueueBootstrapCalls += 1;
+  },
   resetBootstrapCheckpoint: () => {},
   migrateToolCreatedItems: () => {},
   cleanupStaleItemVectors: async () => {},
@@ -120,10 +123,12 @@ const { memoryJobs } = await import("../../../../persistence/schema/index.js");
 const { memoryJobHandlers } = await import("../job-handlers.js");
 const { registerMemoryPluginJobHandlers } =
   await import("../job-handler-registration.js");
-const { runMemoryJobsOnce } = await import("../jobs-worker.js");
+const { maybeEnqueueGraphMaintenanceJobs, runMemoryJobsOnce } =
+  await import("../jobs-worker.js");
 
 function resetCallCounts(): void {
   bootstrapCalls = 0;
+  maybeEnqueueBootstrapCalls = 0;
   decayCalls = 0;
   consolidateCalls = 0;
   patternScanCalls = 0;
@@ -250,5 +255,17 @@ describe("v1 graph jobs under concept-page memory", () => {
     await handlerFor("graph_decay")(fakeJob("graph_decay"), v1Config());
 
     expect(decayCalls).toBe(1);
+  });
+
+  test("the periodic maintenance scheduler re-checks bootstrap on a v1 config", () => {
+    maybeEnqueueGraphMaintenanceJobs(v1Config(), Date.now());
+
+    expect(maybeEnqueueBootstrapCalls).toBe(1);
+  });
+
+  test("the periodic maintenance scheduler skips the bootstrap check under concept-page memory", () => {
+    maybeEnqueueGraphMaintenanceJobs(applyNestedDefaults({}), Date.now());
+
+    expect(maybeEnqueueBootstrapCalls).toBe(0);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v1-graph-substrate-noop.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v1-graph-substrate-noop.test.ts
@@ -1,0 +1,252 @@
+/**
+ * V1 graph lifecycle rows (`graph_bootstrap`, `graph_decay`,
+ * `graph_consolidate`, `graph_pattern_scan`, `graph_narrative_refine`) must
+ * complete as no-ops while concept-page memory is active: their handlers
+ * mutate the legacy v1 graph — the bootstrap runs LLM extraction into it —
+ * which only the v1 tier reads, so a stale or hand-enqueued row must not
+ * consume LLM budget or write the dormant store. On a v1 config the same
+ * handlers run their real implementations.
+ *
+ * `memory.enabled` and `memory.v2.enabled` both default true, so the real
+ * loader reading this file's (empty) workspace config already yields the
+ * substrate-active state the worker-level tests need. The handler-level
+ * tests pass explicit configs instead.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import type { AssistantConfig } from "../../../../config/types.js";
+import type { MemoryJob } from "../../../../persistence/jobs-store.js";
+
+let bootstrapCalls = 0;
+let decayCalls = 0;
+let consolidateCalls = 0;
+let patternScanCalls = 0;
+let narrativeCalls = 0;
+
+mock.module("../graph/bootstrap.js", () => ({
+  bootstrapFromHistory: async () => {
+    bootstrapCalls += 1;
+    return {
+      conversationsProcessed: 0,
+      conversationsSkipped: 0,
+      totalNodesCreated: 0,
+      totalNodesUpdated: 0,
+      totalNodesReinforced: 0,
+      totalEdgesCreated: 0,
+      totalTriggersCreated: 0,
+      errors: [],
+      elapsedMs: 0,
+    };
+  },
+  bootstrapFromJournal: async () => ({ extracted: 0, errors: 0 }),
+  maybeEnqueueGraphBootstrap: () => {},
+  resetBootstrapCheckpoint: () => {},
+  migrateToolCreatedItems: () => {},
+  cleanupStaleItemVectors: async () => {},
+}));
+
+mock.module("../graph/decay.js", () => ({
+  runDecayTick: () => {
+    decayCalls += 1;
+    return { nodesProcessed: 0, fidelityTransitions: 0, nodesGone: 0 };
+  },
+}));
+
+mock.module("../graph/consolidation.js", () => ({
+  runConsolidation: async () => {
+    consolidateCalls += 1;
+    return { totalUpdated: 0, totalDeleted: 0, totalMergeEdges: 0 };
+  },
+}));
+
+mock.module("../graph/pattern-scan.js", () => ({
+  runPatternScan: async () => {
+    patternScanCalls += 1;
+    return { patternsDetected: 0, edgesCreated: 0 };
+  },
+}));
+
+mock.module("../graph/narrative.js", () => ({
+  runNarrativeRefinement: async () => {
+    narrativeCalls += 1;
+    return { nodesUpdated: 0, arcsIdentified: 0 };
+  },
+}));
+
+mock.module("../../../../persistence/db-maintenance.js", () => ({
+  maybeRunDbMaintenance: () => {},
+  maybeRunPassiveWalCheckpoint: () => {},
+}));
+
+const tmpWorkspace = mkdtempSync(
+  join(tmpdir(), "jobs-worker-v1-graph-substrate-noop-"),
+);
+const previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+
+const { setConfig } =
+  await import("../../../../__tests__/helpers/set-config.js");
+
+// Generous lane caps so a single `runMemoryJobsOnce` tick claims every seeded
+// row (the default slow-LLM cap is 1). `memory.v2.enabled` keeps its default
+// (true), so concept-page memory is active.
+setConfig("memory", {
+  jobs: { slowLlmConcurrency: 8, fastConcurrency: 8 },
+});
+
+const { applyNestedDefaults } = await import("../../../../config/loader.js");
+const { getMemoryDb } =
+  await import("../../../../persistence/db-connection.js");
+const { initializeDb } = await import("../../../../persistence/db-init.js");
+const { _resetQdrantBreaker } =
+  await import("../../../../persistence/embeddings/qdrant-circuit-breaker.js");
+const { enqueueMemoryJob } =
+  await import("../../../../persistence/jobs-store.js");
+const { memoryJobs } = await import("../../../../persistence/schema/index.js");
+const { memoryJobHandlers } = await import("../job-handlers.js");
+const { registerMemoryPluginJobHandlers } =
+  await import("../job-handler-registration.js");
+const { runMemoryJobsOnce } = await import("../jobs-worker.js");
+
+function resetCallCounts(): void {
+  bootstrapCalls = 0;
+  decayCalls = 0;
+  consolidateCalls = 0;
+  patternScanCalls = 0;
+  narrativeCalls = 0;
+}
+
+function jobStatus(jobId: string): string | undefined {
+  return getMemoryDb()!
+    .select()
+    .from(memoryJobs)
+    .where(eq(memoryJobs.id, jobId))
+    .all()[0]?.status;
+}
+
+function handlerFor(type: string) {
+  const entry = memoryJobHandlers.find((candidate) => candidate.type === type);
+  if (!entry) {
+    throw new Error(`No handler registered for job type: ${type}`);
+  }
+  return entry.handler;
+}
+
+function fakeJob(type: string): MemoryJob {
+  return {
+    id: `job-${type}`,
+    type,
+    payload: {},
+    status: "running",
+    attempts: 0,
+    deferrals: 0,
+    runAfter: 0,
+    lastError: null,
+    startedAt: null,
+    createdAt: 0,
+    updatedAt: 0,
+  } as MemoryJob;
+}
+
+function v1Config(): AssistantConfig {
+  const config = applyNestedDefaults({});
+  config.memory.v2.enabled = false;
+  return config;
+}
+
+function v3LiveConfig(): AssistantConfig {
+  const config = applyNestedDefaults({});
+  config.memory.v3.live = true;
+  return config;
+}
+
+describe("v1 graph jobs under concept-page memory", () => {
+  beforeAll(async () => {
+    registerMemoryPluginJobHandlers();
+    await initializeDb();
+  }, 30_000);
+
+  afterAll(() => {
+    if (previousWorkspaceEnv === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+    }
+    rmSync(tmpWorkspace, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    getMemoryDb()!.run("DELETE FROM memory_jobs");
+    resetCallCounts();
+    _resetQdrantBreaker();
+  });
+
+  test("a graph_bootstrap row completes as a no-op without running the bootstrap", async () => {
+    const jobId = enqueueMemoryJob("graph_bootstrap", {});
+
+    await runMemoryJobsOnce();
+
+    expect(bootstrapCalls).toBe(0);
+    expect(jobStatus(jobId)).toBe("completed");
+  });
+
+  test("v1 maintenance rows complete as no-ops without running their implementations", async () => {
+    const jobIds = {
+      decay: enqueueMemoryJob("graph_decay", {}),
+      consolidate: enqueueMemoryJob("graph_consolidate", {}),
+      patternScan: enqueueMemoryJob("graph_pattern_scan", {}),
+      narrative: enqueueMemoryJob("graph_narrative_refine", {}),
+    };
+
+    await runMemoryJobsOnce();
+
+    expect(decayCalls).toBe(0);
+    expect(consolidateCalls).toBe(0);
+    expect(patternScanCalls).toBe(0);
+    expect(narrativeCalls).toBe(0);
+    expect(jobStatus(jobIds.decay)).toBe("completed");
+    expect(jobStatus(jobIds.consolidate)).toBe("completed");
+    expect(jobStatus(jobIds.patternScan)).toBe("completed");
+    expect(jobStatus(jobIds.narrative)).toBe("completed");
+  });
+
+  test("the graph_bootstrap handler no-ops on a v3-live config", async () => {
+    await handlerFor("graph_bootstrap")(
+      fakeJob("graph_bootstrap"),
+      v3LiveConfig(),
+    );
+
+    expect(bootstrapCalls).toBe(0);
+  });
+
+  test("the graph_bootstrap handler runs the bootstrap on a v1 config", async () => {
+    await handlerFor("graph_bootstrap")(fakeJob("graph_bootstrap"), v1Config());
+
+    expect(bootstrapCalls).toBe(1);
+  });
+
+  test("the graph_decay handler no-ops on a v3-live config", async () => {
+    await handlerFor("graph_decay")(fakeJob("graph_decay"), v3LiveConfig());
+
+    expect(decayCalls).toBe(0);
+  });
+
+  test("the graph_decay handler runs the decay tick on a v1 config", async () => {
+    await handlerFor("graph_decay")(fakeJob("graph_decay"), v1Config());
+
+    expect(decayCalls).toBe(1);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v1-graph-substrate-noop.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v1-graph-substrate-noop.test.ts
@@ -27,6 +27,7 @@ import {
 
 import { eq } from "drizzle-orm";
 
+import { assertNotLiveDb } from "../../../../__tests__/assert-not-live-db.js";
 import type { AssistantConfig } from "../../../../config/types.js";
 import type { MemoryJob } from "../../../../persistence/jobs-store.js";
 
@@ -185,6 +186,7 @@ describe("v1 graph jobs under concept-page memory", () => {
     } else {
       process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
     }
+    assertNotLiveDb(tmpWorkspace);
     rmSync(tmpWorkspace, { recursive: true, force: true });
   });
 

--- a/assistant/src/plugins/defaults/memory/graph/bootstrap.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/bootstrap.test.ts
@@ -11,6 +11,7 @@ import {
 
 import { eq } from "drizzle-orm";
 
+import { assertNotLiveDb } from "../../../../__tests__/assert-not-live-db.js";
 import { setConfig } from "../../../../__tests__/helpers/set-config.js";
 import { setMemoryCheckpoint } from "../../../../persistence/checkpoints.js";
 import { getMemoryDb } from "../../../../persistence/db-connection.js";
@@ -86,6 +87,7 @@ describe("maybeEnqueueGraphBootstrap", () => {
   });
 
   afterAll(() => {
+    assertNotLiveDb(journalDir);
     rmSync(journalDir, { recursive: true, force: true });
     setConfig("memory", {});
   });

--- a/assistant/src/plugins/defaults/memory/graph/bootstrap.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/bootstrap.test.ts
@@ -1,5 +1,17 @@
-import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 
+import { eq } from "drizzle-orm";
+
+import { setConfig } from "../../../../__tests__/helpers/set-config.js";
 import { setMemoryCheckpoint } from "../../../../persistence/checkpoints.js";
 import { getMemoryDb } from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
@@ -9,7 +21,11 @@ import {
   rawRun,
   resetTestTables,
 } from "../../../../persistence/raw-query.js";
-import { migrateToolCreatedItems } from "./bootstrap.js";
+import { memoryJobs } from "../../../../persistence/schema/index.js";
+import {
+  maybeEnqueueGraphBootstrap,
+  migrateToolCreatedItems,
+} from "./bootstrap.js";
 
 // ---------------------------------------------------------------------------
 // The checkpoint key used by migrateToolCreatedItems (not exported, so we
@@ -54,6 +70,50 @@ beforeEach(() => {
   // memory_jobs lives in the dedicated memory connection; the rest in main.
   resetTestTables("memory_graph_nodes", "memory_checkpoints");
   getMemoryDb()!.run("DELETE FROM memory_jobs");
+});
+
+// ---------------------------------------------------------------------------
+// maybeEnqueueGraphBootstrap
+// ---------------------------------------------------------------------------
+
+describe("maybeEnqueueGraphBootstrap", () => {
+  // A journal directory counts as historical data to bootstrap from, so on a
+  // v1 config an empty graph plus this directory triggers an enqueue.
+  const journalDir = join(process.env.VELLUM_WORKSPACE_DIR!, "journal");
+
+  beforeEach(() => {
+    mkdirSync(journalDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(journalDir, { recursive: true, force: true });
+    setConfig("memory", {});
+  });
+
+  function countBootstrapJobs(): number {
+    return getMemoryDb()!
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.type, "graph_bootstrap"))
+      .all().length;
+  }
+
+  test("does not enqueue while concept-page memory is active", () => {
+    // `memory.v2.enabled` defaults true, so the substrate is active.
+    setConfig("memory", {});
+
+    maybeEnqueueGraphBootstrap();
+
+    expect(countBootstrapJobs()).toBe(0);
+  });
+
+  test("enqueues on a v1 config when historical data exists", () => {
+    setConfig("memory", { v2: { enabled: false } });
+
+    maybeEnqueueGraphBootstrap();
+
+    expect(countBootstrapJobs()).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/plugins/defaults/memory/graph/bootstrap.ts
+++ b/assistant/src/plugins/defaults/memory/graph/bootstrap.ts
@@ -313,8 +313,10 @@ export function resetBootstrapCheckpoint(): void {
 
 /**
  * Enqueue a graph_bootstrap job if the graph is empty (no non-procedural nodes)
- * but historical data exists (segments or journal files). Called on daemon startup
- * to auto-populate the graph for users upgrading from the old extraction system.
+ * but historical data exists (segments or journal files). Called on daemon
+ * startup to auto-populate the graph for users upgrading from the old
+ * extraction system, and again from the v1 branch of the periodic maintenance
+ * scheduler so a config hot-reload onto v1 bootstraps without a restart.
  *
  * Idempotent: does nothing if graph nodes already exist or a bootstrap job is
  * already pending/running.

--- a/assistant/src/plugins/defaults/memory/graph/bootstrap.ts
+++ b/assistant/src/plugins/defaults/memory/graph/bootstrap.ts
@@ -16,6 +16,7 @@ import { and, asc, ne, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../../../../config/loader.js";
+import { isMemoryV1Active } from "../../../../config/memory-v3-gate.js";
 import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
@@ -319,9 +320,17 @@ export function resetBootstrapCheckpoint(): void {
  * already pending/running.
  */
 export function maybeEnqueueGraphBootstrap(): void {
+  // The bootstrap LLM-extracts history into the legacy v1 graph, which only
+  // the v1 tier reads — so enqueue only when v1 is the active memory tier.
+  if (!isMemoryV1Active(getConfig())) {
+    return;
+  }
+
   // Graph nodes live on the memory connection; segments still live on main.
   const memoryDb = memoryDbOrNull("maybeEnqueueGraphBootstrap");
-  if (!memoryDb) return;
+  if (!memoryDb) {
+    return;
+  }
 
   // Check for non-procedural graph nodes (procedural = capability seeds, not real memories)
   const nonProceduralCount =
@@ -336,7 +345,9 @@ export function maybeEnqueueGraphBootstrap(): void {
       )
       .get()?.count ?? 0;
 
-  if (nonProceduralCount > 0) return; // Graph already populated
+  if (nonProceduralCount > 0) {
+    return; // Graph already populated
+  }
 
   // Check for historical data to bootstrap from
   const segmentCount =
@@ -347,12 +358,14 @@ export function maybeEnqueueGraphBootstrap(): void {
 
   const hasJournalFiles = existsSync(join(getWorkspaceDir(), "journal"));
 
-  if (segmentCount === 0 && !hasJournalFiles) return; // Nothing to bootstrap from
+  if (segmentCount === 0 && !hasJournalFiles) {
+    return; // Nothing to bootstrap from
+  }
 
   // Don't enqueue if already in progress
-  if (hasActiveJobOfType("graph_bootstrap")) return;
-
-  if (!isMemoryEnabled()) return;
+  if (hasActiveJobOfType("graph_bootstrap")) {
+    return;
+  }
 
   log.info(
     { segmentCount, hasJournalFiles },

--- a/assistant/src/plugins/defaults/memory/graph/capability-seed.ts
+++ b/assistant/src/plugins/defaults/memory/graph/capability-seed.ts
@@ -10,15 +10,13 @@ import { and, eq, like, sql } from "drizzle-orm";
 
 import { isAssistantFeatureFlagEnabled } from "../../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../../config/loader.js";
+import { isMemoryV1Active } from "../../../../config/memory-v3-gate.js";
 import { resolveSkillStates } from "../../../../config/skill-state.js";
 import {
   loadSkillCatalog,
   type SkillSummary,
 } from "../../../../config/skills.js";
-import {
-  enqueueMemoryJob,
-  isMemoryEnabled,
-} from "../../../../persistence/jobs-store.js";
+import { enqueueMemoryJob } from "../../../../persistence/jobs-store.js";
 import { memoryGraphNodes } from "../../../../persistence/schema/index.js";
 import {
   getCachedCatalogSync,
@@ -259,10 +257,17 @@ function buildSkillContent(input: SkillCapabilityInput): string {
  *
  * We store the sourceKey in sourceConversations[0] as a stable identifier
  * (capability nodes aren't tied to a real conversation).
+ *
+ * The node write itself is all-tier — the `list_memory` surface reads
+ * capability nodes on every tier. The `embed_graph_node` enqueue is v1-only:
+ * those rows target the v1 Qdrant collection, and dispatch discards them
+ * while concept-page memory is active.
  */
 function upsertCapabilityNode(sourceKey: string, content: string): void {
   const db = memoryDbOrNull("upsertCapabilityNode");
-  if (!db) return;
+  if (!db) {
+    return;
+  }
 
   // Find existing node by sourceKey stored in source_conversations JSON
   const existing = db
@@ -304,7 +309,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
       })
       .where(eq(memoryGraphNodes.id, existing.id))
       .run();
-    if (isMemoryEnabled()) {
+    if (isMemoryV1Active(getConfig())) {
       enqueueMemoryJob("embed_graph_node", { nodeId: existing.id });
     }
     return;
@@ -338,7 +343,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
     imageRefs: null,
   });
 
-  if (isMemoryEnabled()) {
+  if (isMemoryV1Active(getConfig())) {
     enqueueMemoryJob("embed_graph_node", { nodeId: node.id });
   }
   log.info({ sourceKey, nodeId: node.id }, "Created capability graph node");

--- a/assistant/src/plugins/defaults/memory/graph/capability-seed.ts
+++ b/assistant/src/plugins/defaults/memory/graph/capability-seed.ts
@@ -16,8 +16,12 @@ import {
   loadSkillCatalog,
   type SkillSummary,
 } from "../../../../config/skills.js";
+import { getDb } from "../../../../persistence/db-connection.js";
 import { enqueueMemoryJob } from "../../../../persistence/jobs-store.js";
-import { memoryGraphNodes } from "../../../../persistence/schema/index.js";
+import {
+  memoryEmbeddings,
+  memoryGraphNodes,
+} from "../../../../persistence/schema/index.js";
 import {
   getCachedCatalogSync,
   getCatalog,
@@ -252,6 +256,38 @@ function buildSkillContent(input: SkillCapabilityInput): string {
 }
 
 /**
+ * Reconcile a capability node that lacks a stored dense embedding: enqueue
+ * `embed_graph_node` for it. A capability seeded or updated while
+ * concept-page memory is active gets no embed row, so when the assistant
+ * runs under v1 the unchanged-content short-circuit alone would leave its
+ * v1 Qdrant point missing. One indexed `memory_embeddings` prefix lookup
+ * per capability node, on the v1 path only. Fail-open: a lookup error logs
+ * and skips — reconciliation never blocks seeding.
+ */
+function enqueueEmbedIfMissing(nodeId: string): void {
+  try {
+    const row = getDb()
+      .select({ id: memoryEmbeddings.id })
+      .from(memoryEmbeddings)
+      .where(
+        and(
+          eq(memoryEmbeddings.targetType, "graph_node"),
+          eq(memoryEmbeddings.targetId, nodeId),
+        ),
+      )
+      .get();
+    if (!row) {
+      enqueueMemoryJob("embed_graph_node", { nodeId });
+    }
+  } catch (err) {
+    log.warn(
+      { err, nodeId },
+      "Capability embedding reconcile failed; skipping",
+    );
+  }
+}
+
+/**
  * Core upsert: find an existing capability node by its sourceKey,
  * create or update as needed.
  *
@@ -261,7 +297,8 @@ function buildSkillContent(input: SkillCapabilityInput): string {
  * The node write itself is all-tier — the `list_memory` surface reads
  * capability nodes on every tier. The `embed_graph_node` enqueue is v1-only:
  * those rows target the v1 Qdrant collection, and dispatch discards them
- * while concept-page memory is active.
+ * while concept-page memory is active. On the v1 path an unchanged node with
+ * no stored embedding still enqueues (see {@link enqueueEmbedIfMissing}).
  */
 function upsertCapabilityNode(sourceKey: string, content: string): void {
   const db = memoryDbOrNull("upsertCapabilityNode");
@@ -296,6 +333,9 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
         .set(updates)
         .where(eq(memoryGraphNodes.id, existing.id))
         .run();
+      if (isMemoryV1Active(getConfig())) {
+        enqueueEmbedIfMissing(existing.id);
+      }
       return;
     }
 

--- a/assistant/src/plugins/defaults/memory/graph/capability-seed.ts
+++ b/assistant/src/plugins/defaults/memory/graph/capability-seed.ts
@@ -17,7 +17,10 @@ import {
   type SkillSummary,
 } from "../../../../config/skills.js";
 import { getDb } from "../../../../persistence/db-connection.js";
-import { enqueueMemoryJob } from "../../../../persistence/jobs-store.js";
+import {
+  enqueueMemoryJob,
+  upsertEmbedGraphNodeJob,
+} from "../../../../persistence/jobs-store.js";
 import {
   memoryEmbeddings,
   memoryGraphNodes,
@@ -261,8 +264,12 @@ function buildSkillContent(input: SkillCapabilityInput): string {
  * concept-page memory is active gets no embed row, so when the assistant
  * runs under v1 the unchanged-content short-circuit alone would leave its
  * v1 Qdrant point missing. One indexed `memory_embeddings` prefix lookup
- * per capability node, on the v1 path only. Fail-open: a lookup error logs
- * and skips — reconciliation never blocks seeding.
+ * per capability node, on the v1 path only. The enqueue coalesces with a
+ * pending `embed_graph_node` row for the same node, so back-to-back seed
+ * passes (e.g. `refreshSkillCapabilityMemories` seeding before and after
+ * the catalog resolves) queue at most one job per node while the first is
+ * still pending. Fail-open: a lookup error logs and skips — reconciliation
+ * never blocks seeding.
  */
 function enqueueEmbedIfMissing(nodeId: string): void {
   try {
@@ -277,7 +284,7 @@ function enqueueEmbedIfMissing(nodeId: string): void {
       )
       .get();
     if (!row) {
-      enqueueMemoryJob("embed_graph_node", { nodeId });
+      upsertEmbedGraphNodeJob({ nodeId });
     }
   } catch (err) {
     log.warn(
@@ -350,7 +357,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
       .where(eq(memoryGraphNodes.id, existing.id))
       .run();
     if (isMemoryV1Active(getConfig())) {
-      enqueueMemoryJob("embed_graph_node", { nodeId: existing.id });
+      upsertEmbedGraphNodeJob({ nodeId: existing.id });
     }
     return;
   }
@@ -384,7 +391,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
   });
 
   if (isMemoryV1Active(getConfig())) {
-    enqueueMemoryJob("embed_graph_node", { nodeId: node.id });
+    upsertEmbedGraphNodeJob({ nodeId: node.id });
   }
   log.info({ sourceKey, nodeId: node.id }, "Created capability graph node");
 }

--- a/assistant/src/plugins/defaults/memory/job-handlers.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers.ts
@@ -12,7 +12,10 @@
  * the underlying handler is honored.
  */
 
-import { usesConceptPageMemory } from "../../../config/memory-v3-gate.js";
+import {
+  isMemoryV1Active,
+  usesConceptPageMemory,
+} from "../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../config/types.js";
 import type { MemoryJob } from "../../../persistence/jobs-store.js";
 import type { JobHandlerEntry } from "../../types.js";
@@ -58,7 +61,28 @@ const log = getLogger("memory-job-handlers");
 
 // ── Graph lifecycle job handlers ──────────────────────────────────
 
-function graphDecayJob(job: MemoryJob): void {
+/**
+ * Tier gate shared by the v1 graph lifecycle handlers below. These jobs
+ * mutate (and some LLM-process into) the legacy v1 graph, which only the v1
+ * tier reads — so a stale or hand-enqueued row claimed while v1 is not the
+ * active memory tier must complete as a logged no-op instead of doing that
+ * work. Returns true when the row should be skipped.
+ */
+function isStaleV1GraphJob(job: MemoryJob, config: AssistantConfig): boolean {
+  if (isMemoryV1Active(config)) {
+    return false;
+  }
+  log.info(
+    { jobId: job.id, type: job.type },
+    "Skipping v1 graph job — the legacy graph is not the active memory tier",
+  );
+  return true;
+}
+
+function graphDecayJob(job: MemoryJob, config: AssistantConfig): void {
+  if (isStaleV1GraphJob(job, config)) {
+    return;
+  }
   const result = runDecayTick();
   log.info({ jobId: job.id, ...result }, "Graph decay tick complete");
 }
@@ -67,6 +91,9 @@ async function graphConsolidateJob(
   job: MemoryJob,
   config: AssistantConfig,
 ): Promise<void> {
+  if (isStaleV1GraphJob(job, config)) {
+    return;
+  }
   const result = await runConsolidation(config);
   log.info(
     {
@@ -83,6 +110,9 @@ async function graphPatternScanJob(
   job: MemoryJob,
   config: AssistantConfig,
 ): Promise<void> {
+  if (isStaleV1GraphJob(job, config)) {
+    return;
+  }
   const result = await runPatternScan(config);
   log.info(
     {
@@ -98,6 +128,9 @@ async function graphNarrativeRefineJob(
   job: MemoryJob,
   config: AssistantConfig,
 ): Promise<void> {
+  if (isStaleV1GraphJob(job, config)) {
+    return;
+  }
   const result = await runNarrativeRefinement(config);
   log.info(
     {
@@ -107,6 +140,16 @@ async function graphNarrativeRefineJob(
     },
     "Graph narrative refinement complete",
   );
+}
+
+async function graphBootstrapJob(
+  job: MemoryJob,
+  config: AssistantConfig,
+): Promise<void> {
+  if (isStaleV1GraphJob(job, config)) {
+    return;
+  }
+  await bootstrapFromHistory();
 }
 
 /**
@@ -160,7 +203,7 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
       await graphExtractJob(job, config);
     },
   },
-  { type: "graph_decay", handler: (job) => graphDecayJob(job) },
+  { type: "graph_decay", handler: (job, config) => graphDecayJob(job, config) },
   {
     type: "graph_consolidate",
     handler: (job, config) => graphConsolidateJob(job, config),
@@ -173,7 +216,10 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
     type: "graph_narrative_refine",
     handler: (job, config) => graphNarrativeRefineJob(job, config),
   },
-  { type: "graph_bootstrap", handler: () => bootstrapFromHistory() },
+  {
+    type: "graph_bootstrap",
+    handler: (job, config) => graphBootstrapJob(job, config),
+  },
   {
     type: "embed_concept_page",
     handler: (job, config) => embedConceptPageJob(job, config),

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -59,6 +59,7 @@ import {
 } from "../../../persistence/jobs-store.js";
 import type { JobHandler } from "../../types.js";
 import { sweepOrphanConversationMemoryTables } from "./conversation-memory-orphan-sweep.js";
+import { maybeEnqueueGraphBootstrap } from "./graph/bootstrap.js";
 import { getLogger } from "./logging.js";
 import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
 import { getWorkspaceDir } from "./paths.js";
@@ -1082,6 +1083,22 @@ export function maybeEnqueueGraphMaintenanceJobs(
           jobType: "graph_narrative_refine",
         },
       ];
+
+  // Bootstrap re-check on the v1 branch. Startup runs this once, but a
+  // config hot-reload that flips concept-page memory off lands the assistant
+  // on v1 without a restart — so the maintenance tick re-checks whenever v1
+  // is active, and an assistant entering v1 with an empty graph still
+  // bootstraps from its historical segments. The callee self-guards (tier
+  // gate, populated-graph, has-history, and active-job checks), so the call
+  // is cheap and idempotent. Best-effort: a failure logs and never blocks
+  // the maintenance enqueues below.
+  if (!conceptPagesActive) {
+    try {
+      maybeEnqueueGraphBootstrap();
+    } catch (err) {
+      log.warn({ err }, "Periodic graph bootstrap check failed");
+    }
+  }
 
   // v3 self-maintenance backstop. Orthogonal to the mutual exclusion above:
   // it owns its own checkpoint and operates on the v3 topic tree, so it

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -13,6 +13,7 @@ import {
   shouldLogDiskPressureBackgroundSkip,
 } from "../../../daemon/disk-pressure-background-gate.js";
 import {
+  deleteMemoryCheckpoint,
   getMemoryCheckpoint,
   setMemoryCheckpoint,
 } from "../../../persistence/checkpoints.js";
@@ -60,6 +61,10 @@ import {
 import type { JobHandler } from "../../types.js";
 import { sweepOrphanConversationMemoryTables } from "./conversation-memory-orphan-sweep.js";
 import { maybeEnqueueGraphBootstrap } from "./graph/bootstrap.js";
+import {
+  seedCliGraphNodes,
+  seedSkillGraphNodes,
+} from "./graph/capability-seed.js";
 import { getLogger } from "./logging.js";
 import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
 import { getWorkspaceDir } from "./paths.js";
@@ -843,6 +848,11 @@ export const GRAPH_MAINTENANCE_CHECKPOINTS = {
   memoryV3Maintain: "memory_v3_maintain_last_run",
   pkbFiling: "pkb_filing_last_run",
   pkbCompaction: "pkb_compaction_last_run",
+  // One-shot done-marker (epoch-ms), not a cadence checkpoint like the
+  // entries above: present while the assistant stays on v1, cleared by the
+  // substrate branch so the next return to v1 reconciles again. See
+  // `maybeRunV1EntryReconcile`.
+  v1EntryReconcile: "v1_entry_reconcile_done",
 } as const;
 
 /**
@@ -1036,6 +1046,60 @@ export function consolidationBackoffRemainingMs(
   return Math.max(0, state.lastFailureAt + backoffMs - nowMs);
 }
 
+/**
+ * Run the one-time v1-entry reconcile unless it already ran for the current
+ * stay on the v1 tier: the graph bootstrap check (populates an empty graph
+ * from historical segments; self-guarded by tier/populated/has-history/
+ * active-job gates) plus both capability seeders (their unchanged-content
+ * path backfills v1 embeddings missing for nodes seeded under another tier).
+ * The checkpoint is written even when individual steps fail — this is a
+ * transition-edge trigger, not a retry loop; a failed step gets another
+ * chance on the next transition or restart.
+ */
+function maybeRunV1EntryReconcile(nowMs: number): void {
+  try {
+    const done = getMemoryCheckpoint(
+      GRAPH_MAINTENANCE_CHECKPOINTS.v1EntryReconcile,
+    );
+    if (done !== null) {
+      return;
+    }
+  } catch (err) {
+    // A failed read skips this tick instead of running unmarked — running
+    // without the durable marker is exactly what makes a per-tick re-enqueue
+    // loop possible.
+    log.warn({ err }, "Reading the v1-entry reconcile checkpoint failed");
+    return;
+  }
+
+  try {
+    maybeEnqueueGraphBootstrap();
+  } catch (err) {
+    log.warn({ err }, "V1-entry graph bootstrap check failed");
+  }
+  try {
+    seedSkillGraphNodes();
+  } catch (err) {
+    log.warn({ err }, "V1-entry skill capability seeding failed");
+  }
+  try {
+    void seedCliGraphNodes().catch((err) => {
+      log.warn({ err }, "V1-entry CLI capability seeding failed");
+    });
+  } catch (err) {
+    log.warn({ err }, "V1-entry CLI capability seeding failed");
+  }
+
+  try {
+    setMemoryCheckpoint(
+      GRAPH_MAINTENANCE_CHECKPOINTS.v1EntryReconcile,
+      String(nowMs),
+    );
+  } catch (err) {
+    log.warn({ err }, "Writing the v1-entry reconcile checkpoint failed");
+  }
+}
+
 export function maybeEnqueueGraphMaintenanceJobs(
   config: AssistantConfig,
   nowMs = Date.now(),
@@ -1084,20 +1148,26 @@ export function maybeEnqueueGraphMaintenanceJobs(
         },
       ];
 
-  // Bootstrap re-check on the v1 branch. Startup runs this once, but a
-  // config hot-reload that flips concept-page memory off lands the assistant
-  // on v1 without a restart — so the maintenance tick re-checks whenever v1
-  // is active, and an assistant entering v1 with an empty graph still
-  // bootstraps from its historical segments. The callee self-guards (tier
-  // gate, populated-graph, has-history, and active-job checks), so the call
-  // is cheap and idempotent. Best-effort: a failure logs and never blocks
-  // the maintenance enqueues below.
-  if (!conceptPagesActive) {
+  // One-shot v1-entry reconcile. Startup covers a fresh v1 boot (capability
+  // seeding and the bootstrap check in `startup.ts`), but a config hot-reload
+  // that flips concept-page memory off lands the assistant on v1 without a
+  // restart — leaving capability nodes without v1 embeddings and the graph
+  // possibly empty despite existing history. A durable checkpoint marks the
+  // reconcile done for the current stay on v1, so it runs exactly once per
+  // transition regardless of the bootstrap's outcome — an unconditional
+  // per-tick bootstrap check would tight-loop when extraction yields no
+  // non-procedural nodes (the emptiness test stays true while the processed
+  // job zeroes the next poll delay). The substrate branch clears the
+  // checkpoint so a later return to v1 reconciles again. Best-effort: every
+  // step logs on failure and never blocks the maintenance enqueues below.
+  if (conceptPagesActive) {
     try {
-      maybeEnqueueGraphBootstrap();
+      deleteMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.v1EntryReconcile);
     } catch (err) {
-      log.warn({ err }, "Periodic graph bootstrap check failed");
+      log.warn({ err }, "Clearing the v1-entry reconcile checkpoint failed");
     }
+  } else {
+    maybeRunV1EntryReconcile(nowMs);
   }
 
   // v3 self-maintenance backstop. Orthogonal to the mutual exclusion above:


### PR DESCRIPTION
## Summary
- Gates graph_bootstrap (enqueue + handler) on isMemoryV1Active — substrate assistants no longer run LLM bootstrap into the legacy graph
- graph_decay/consolidate/pattern_scan/narrative_refine handlers no-op stale rows under the substrate, mirroring graph_extract
- capability-seed skips embed_graph_node rows that dispatch would discard; node upserts stay all-tier

Part of plan: memory-tier-separation.md (PR 3 of 14)