### PR TITLE
feat(memory): workspace migration copying explicit memory.v2 substrate tunables to memory.substrate

### DIFF
--- a/assistant/src/workspace/migrations/135-copy-substrate-tunables.ts
+++ b/assistant/src/workspace/migrations/135-copy-substrate-tunables.ts
@@ -1,0 +1,151 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-135");
+
+/**
+ * The fifteen substrate tunables shared between the historical `memory.v2`
+ * namespace and the new `memory.substrate` namespace. `memory.v2.k` and
+ * `memory.v2.hops` were renamed to `spread_k` / `spread_hops` on the substrate
+ * side; every other key keeps its name.
+ *
+ * Inlined per the migrations self-containment rule (no `../../config/`
+ * imports).
+ */
+const SUBSTRATE_KEY_PAIRS: ReadonlyArray<{
+  v2Key: string;
+  substrateKey: string;
+}> = [
+  { v2Key: "sweep_enabled", substrateKey: "sweep_enabled" },
+  { v2Key: "dense_weight", substrateKey: "dense_weight" },
+  { v2Key: "sparse_weight", substrateKey: "sparse_weight" },
+  { v2Key: "min_sparse_spread", substrateKey: "min_sparse_spread" },
+  { v2Key: "full_sparse_spread", substrateKey: "full_sparse_spread" },
+  { v2Key: "bm25_k1", substrateKey: "bm25_k1" },
+  { v2Key: "bm25_b", substrateKey: "bm25_b" },
+  {
+    v2Key: "consolidation_interval_hours",
+    substrateKey: "consolidation_interval_hours",
+  },
+  {
+    v2Key: "consolidation_max_buffer_lines",
+    substrateKey: "consolidation_max_buffer_lines",
+  },
+  {
+    v2Key: "consolidation_max_entries_per_run",
+    substrateKey: "consolidation_max_entries_per_run",
+  },
+  { v2Key: "max_page_chars", substrateKey: "max_page_chars" },
+  {
+    v2Key: "consolidation_prompt_path",
+    substrateKey: "consolidation_prompt_path",
+  },
+  { v2Key: "k", substrateKey: "spread_k" },
+  { v2Key: "hops", substrateKey: "spread_hops" },
+  { v2Key: "ann_candidate_limit", substrateKey: "ann_candidate_limit" },
+];
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Copy explicitly-set substrate tunables from `memory.v2` to
+ * `memory.substrate` so the substrate namespace becomes self-sufficient before
+ * the runtime resolver's substrate→v2 fallback (and eventually the whole
+ * `memory.v2` subtree) is deleted.
+ *
+ * Presence-based, not value-based: a key is copied when it is EXPLICITLY
+ * present under `memory.v2` and absent under `memory.substrate` — an explicit
+ * `null` on a nullable key (`ann_candidate_limit`,
+ * `consolidation_prompt_path`, ...) is an explicit value and is copied, since
+ * the resolver treats an explicit substrate `null` as set. The common case is
+ * a no-op: `memory.v2` tuning defaults were never persisted to config.json.
+ *
+ * `memory.v2.*` is never modified — the v2 injection engine still reads it
+ * until the whole subtree is deleted with v2. An already-present
+ * `memory.substrate` key is never clobbered. `memory.substrate` is only
+ * written at all when at least one key copies, so a fresh config never gains
+ * an empty object.
+ *
+ * Weight-pair safety: copying a lone explicit weight (say `dense_weight`)
+ * cannot create an invalid config. The parent memory schema validates the
+ * RESOLVED pair — the copied substrate weight plus the `memory.v2` fallback
+ * for its twin — which is exactly the pair the v2 schema's own refinement
+ * already accepted before the migration. Same effective values, same
+ * validity.
+ */
+export const copySubstrateTunablesMigration: WorkspaceMigration = {
+  id: "135-copy-substrate-tunables",
+  description:
+    "Copy explicitly-set memory.v2 substrate tunables to memory.substrate (k→spread_k, hops→spread_hops) without touching memory.v2 or clobbering existing memory.substrate values",
+
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) {
+      return;
+    }
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!isPlainObject(raw)) {
+        return;
+      }
+      config = raw;
+    } catch {
+      return;
+    }
+
+    const memory = config.memory;
+    if (!isPlainObject(memory)) {
+      return;
+    }
+    const v2 = memory.v2;
+    if (!isPlainObject(v2)) {
+      return;
+    }
+    // A malformed (non-object) persisted memory.substrate is left alone — the
+    // config loader surfaces that error; this migration must not clobber it.
+    if (memory.substrate !== undefined && !isPlainObject(memory.substrate)) {
+      return;
+    }
+
+    // Staged separately so memory.substrate is only attached when a key
+    // actually copies — never introduce an empty object.
+    const substrate: Record<string, unknown> = isPlainObject(memory.substrate)
+      ? memory.substrate
+      : {};
+
+    let copied = false;
+    for (const { v2Key, substrateKey } of SUBSTRATE_KEY_PAIRS) {
+      if (v2Key in v2 && !(substrateKey in substrate)) {
+        substrate[substrateKey] = v2[v2Key];
+        copied = true;
+      }
+    }
+    if (!copied) {
+      return;
+    }
+    memory.substrate = substrate;
+
+    try {
+      writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+      log.info(
+        "Copied explicitly-set memory.v2 substrate tunables to memory.substrate",
+      );
+    } catch (err) {
+      log.warn({ err }, "Failed to write config.json with copied tunables");
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: a copied value is indistinguishable from one the user set
+    // under memory.substrate directly, so removal could destroy deliberate
+    // overrides. The copy is also behavior-preserving, so there is nothing to
+    // unwind.
+  },
+};

--- a/assistant/src/workspace/migrations/135-copy-substrate-tunables.ts
+++ b/assistant/src/workspace/migrations/135-copy-substrate-tunables.ts
@@ -7,45 +7,89 @@ import type { WorkspaceMigration } from "./types.js";
 const log = getLogger("workspace-migration-135");
 
 /**
+ * Marks the two optional `memory.v2` keys that ship with no schema default
+ * (`min_sparse_spread`, `full_sparse_spread`) — for those, raw presence IS
+ * user intent, so they copy on presence alone.
+ */
+const NO_DEFAULT: unique symbol = Symbol("no-default");
+
+/**
  * The fifteen substrate tunables shared between the historical `memory.v2`
- * namespace and the new `memory.substrate` namespace. `memory.v2.k` and
- * `memory.v2.hops` were renamed to `spread_k` / `spread_hops` on the substrate
- * side; every other key keeps its name.
+ * namespace and the new `memory.substrate` namespace, each paired with the
+ * shipped `memory.v2` schema default (from `config/schemas/memory-v2.ts`).
+ * `memory.v2.k` and `memory.v2.hops` were renamed to `spread_k` /
+ * `spread_hops` on the substrate side; every other key keeps its name.
  *
- * Inlined per the migrations self-containment rule (no `../../config/`
- * imports).
+ * The defaults matter because raw presence in config.json is NOT user intent:
+ * the config loader serializes the fully-parsed configuration for
+ * normally-created workspaces, so defaulted `memory.v2` leaves are persisted
+ * for most existing assistants. Copying those seeded values would populate
+ * the override-only `memory.substrate` namespace with today's defaults and
+ * permanently pin those assistants when substrate defaults are later retuned
+ * — the same default-pinning problem migration 119 solves for `memory.v3`
+ * tuning, distinguished the same way (value-vs-shipped-default comparison,
+ * table inlined per the migrations self-containment rule).
  */
 const SUBSTRATE_KEY_PAIRS: ReadonlyArray<{
   v2Key: string;
   substrateKey: string;
+  shippedDefault: number | boolean | string | null | typeof NO_DEFAULT;
 }> = [
-  { v2Key: "sweep_enabled", substrateKey: "sweep_enabled" },
-  { v2Key: "dense_weight", substrateKey: "dense_weight" },
-  { v2Key: "sparse_weight", substrateKey: "sparse_weight" },
-  { v2Key: "min_sparse_spread", substrateKey: "min_sparse_spread" },
-  { v2Key: "full_sparse_spread", substrateKey: "full_sparse_spread" },
-  { v2Key: "bm25_k1", substrateKey: "bm25_k1" },
-  { v2Key: "bm25_b", substrateKey: "bm25_b" },
+  {
+    v2Key: "sweep_enabled",
+    substrateKey: "sweep_enabled",
+    shippedDefault: false,
+  },
+  { v2Key: "dense_weight", substrateKey: "dense_weight", shippedDefault: 0.85 },
+  {
+    v2Key: "sparse_weight",
+    substrateKey: "sparse_weight",
+    shippedDefault: 0.15,
+  },
+  {
+    v2Key: "min_sparse_spread",
+    substrateKey: "min_sparse_spread",
+    shippedDefault: NO_DEFAULT,
+  },
+  {
+    v2Key: "full_sparse_spread",
+    substrateKey: "full_sparse_spread",
+    shippedDefault: NO_DEFAULT,
+  },
+  { v2Key: "bm25_k1", substrateKey: "bm25_k1", shippedDefault: 1.2 },
+  { v2Key: "bm25_b", substrateKey: "bm25_b", shippedDefault: 0.4 },
   {
     v2Key: "consolidation_interval_hours",
     substrateKey: "consolidation_interval_hours",
+    shippedDefault: 8,
   },
   {
     v2Key: "consolidation_max_buffer_lines",
     substrateKey: "consolidation_max_buffer_lines",
+    shippedDefault: 100,
   },
   {
     v2Key: "consolidation_max_entries_per_run",
     substrateKey: "consolidation_max_entries_per_run",
+    shippedDefault: 150,
   },
-  { v2Key: "max_page_chars", substrateKey: "max_page_chars" },
+  {
+    v2Key: "max_page_chars",
+    substrateKey: "max_page_chars",
+    shippedDefault: 5000,
+  },
   {
     v2Key: "consolidation_prompt_path",
     substrateKey: "consolidation_prompt_path",
+    shippedDefault: null,
   },
-  { v2Key: "k", substrateKey: "spread_k" },
-  { v2Key: "hops", substrateKey: "spread_hops" },
-  { v2Key: "ann_candidate_limit", substrateKey: "ann_candidate_limit" },
+  { v2Key: "k", substrateKey: "spread_k", shippedDefault: 0.5 },
+  { v2Key: "hops", substrateKey: "spread_hops", shippedDefault: 2 },
+  {
+    v2Key: "ann_candidate_limit",
+    substrateKey: "ann_candidate_limit",
+    shippedDefault: null,
+  },
 ];
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -53,33 +97,38 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Copy explicitly-set substrate tunables from `memory.v2` to
+ * Copy user-overridden substrate tunables from `memory.v2` to
  * `memory.substrate` so the substrate namespace carries the user's tuned
  * values itself, independent of the runtime resolver's substrate→v2 fallback.
  *
- * Presence-based, not value-based: a key is copied when it is EXPLICITLY
- * present under `memory.v2` and absent under `memory.substrate` — an explicit
- * `null` on a nullable key (`ann_candidate_limit`,
- * `consolidation_prompt_path`, ...) is an explicit value and is copied, since
- * the resolver treats an explicit substrate `null` as set. The common case is
- * a no-op: `memory.v2` tuning defaults were never persisted to config.json.
+ * Value-based, not presence-based: a key is copied only when it is present
+ * under `memory.v2`, absent under `memory.substrate`, AND its value differs
+ * from the shipped v2 schema default. The config loader persists the
+ * fully-parsed configuration for normally-created workspaces, so a defaulted
+ * `memory.v2` leaf in config.json is seeded, not user intent — copying it
+ * would pin the assistant to today's value when substrate defaults are later
+ * retuned (migration 119's rationale). A persisted value equal to its shipped
+ * default is treated as seeded even if a user typed it deliberately — the
+ * acceptable trade-off 119 already makes — so `memory.substrate` stays an
+ * override-only surface. The two no-default keys (`min_sparse_spread`,
+ * `full_sparse_spread`) copy on presence alone.
  *
  * `memory.v2.*` is never modified — the v2 injection engine still reads it.
  * An already-present `memory.substrate` key is never clobbered. `memory.substrate` is only
  * written at all when at least one key copies, so a fresh config never gains
  * an empty object.
  *
- * Weight-pair safety: copying a lone explicit weight (say `dense_weight`)
- * cannot create an invalid config. The parent memory schema validates the
- * RESOLVED pair — the copied substrate weight plus the `memory.v2` fallback
- * for its twin — which is exactly the pair the v2 schema's own refinement
- * already accepted before the migration. Same effective values, same
- * validity.
+ * Weight-pair safety: copying cannot create an invalid config. The v2
+ * schema's own refinement validates `dense_weight + sparse_weight` on the
+ * PERSISTED values (absent leaves resolve to defaults before the check), so a
+ * valid config carrying a non-default weight necessarily carries its
+ * non-default twin — both differ from their defaults, both copy, and the
+ * copied substrate pair is exactly the pair v2 already accepted.
  */
 export const copySubstrateTunablesMigration: WorkspaceMigration = {
   id: "135-copy-substrate-tunables",
   description:
-    "Copy explicitly-set memory.v2 substrate tunables to memory.substrate (k→spread_k, hops→spread_hops) without touching memory.v2 or clobbering existing memory.substrate values",
+    "Copy memory.v2 substrate tunables that differ from their shipped defaults to memory.substrate (k→spread_k, hops→spread_hops) without touching memory.v2, clobbering existing memory.substrate values, or pinning loader-seeded defaults",
   // run() only ever adds missing memory.substrate keys and never clobbers
   // present ones, so retrying after a failed write attempt is safe.
   retryFailedCheckpoint: true,
@@ -126,11 +175,18 @@ export const copySubstrateTunablesMigration: WorkspaceMigration = {
       : {};
 
     let copied = false;
-    for (const { v2Key, substrateKey } of SUBSTRATE_KEY_PAIRS) {
-      if (v2Key in v2 && !(substrateKey in substrate)) {
-        substrate[substrateKey] = v2[v2Key];
-        copied = true;
+    for (const { v2Key, substrateKey, shippedDefault } of SUBSTRATE_KEY_PAIRS) {
+      if (!(v2Key in v2) || substrateKey in substrate) {
+        continue;
       }
+      // A persisted value equal to the shipped default is loader-seeded, not a
+      // user override — skip it so the substrate namespace stays override-only.
+      // Strict equality suffices: every tunable value is a primitive or null.
+      if (shippedDefault !== NO_DEFAULT && v2[v2Key] === shippedDefault) {
+        continue;
+      }
+      substrate[substrateKey] = v2[v2Key];
+      copied = true;
     }
     if (!copied) {
       return;
@@ -147,7 +203,7 @@ export const copySubstrateTunablesMigration: WorkspaceMigration = {
     writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
     renameSync(tmpPath, configPath);
     log.info(
-      "Copied explicitly-set memory.v2 substrate tunables to memory.substrate",
+      "Copied non-default memory.v2 substrate tunables to memory.substrate",
     );
   },
 

--- a/assistant/src/workspace/migrations/135-copy-substrate-tunables.ts
+++ b/assistant/src/workspace/migrations/135-copy-substrate-tunables.ts
@@ -34,6 +34,12 @@ const SUBSTRATE_KEY_PAIRS: ReadonlyArray<{
   v2Key: string;
   substrateKey: string;
   shippedDefault: number | boolean | string | null | typeof NO_DEFAULT;
+  /**
+   * Additional values the loader has seeded as this key's default in earlier
+   * releases (multi-default keys, mirroring migration 119). A persisted value
+   * matching any of them is seeded, not a user override.
+   */
+  priorDefaults?: ReadonlyArray<number | boolean | string | null>;
 }> = [
   {
     v2Key: "sweep_enabled",
@@ -57,7 +63,13 @@ const SUBSTRATE_KEY_PAIRS: ReadonlyArray<{
     shippedDefault: NO_DEFAULT,
   },
   { v2Key: "bm25_k1", substrateKey: "bm25_k1", shippedDefault: 1.2 },
-  { v2Key: "bm25_b", substrateKey: "bm25_b", shippedDefault: 0.4 },
+  {
+    v2Key: "bm25_b",
+    substrateKey: "bm25_b",
+    shippedDefault: 0.4,
+    // Workspaces seeded before migration 075 carry the earlier 0.75 default.
+    priorDefaults: [0.75],
+  },
   {
     v2Key: "consolidation_interval_hours",
     substrateKey: "consolidation_interval_hours",
@@ -175,14 +187,24 @@ export const copySubstrateTunablesMigration: WorkspaceMigration = {
       : {};
 
     let copied = false;
-    for (const { v2Key, substrateKey, shippedDefault } of SUBSTRATE_KEY_PAIRS) {
+    for (const {
+      v2Key,
+      substrateKey,
+      shippedDefault,
+      priorDefaults,
+    } of SUBSTRATE_KEY_PAIRS) {
       if (!(v2Key in v2) || substrateKey in substrate) {
         continue;
       }
-      // A persisted value equal to the shipped default is loader-seeded, not a
-      // user override — skip it so the substrate namespace stays override-only.
-      // Strict equality suffices: every tunable value is a primitive or null.
-      if (shippedDefault !== NO_DEFAULT && v2[v2Key] === shippedDefault) {
+      // A persisted value equal to a shipped default (current or from an
+      // earlier release) is loader-seeded, not a user override — skip it so
+      // the substrate namespace stays override-only. Strict equality
+      // suffices: every tunable value is a primitive or null.
+      const value = v2[v2Key];
+      if (shippedDefault !== NO_DEFAULT && value === shippedDefault) {
+        continue;
+      }
+      if (priorDefaults?.some((seeded) => seeded === value)) {
         continue;
       }
       substrate[substrateKey] = v2[v2Key];

--- a/assistant/src/workspace/migrations/135-copy-substrate-tunables.ts
+++ b/assistant/src/workspace/migrations/135-copy-substrate-tunables.ts
@@ -90,9 +90,13 @@ export const copySubstrateTunablesMigration: WorkspaceMigration = {
       return;
     }
 
+    // A filesystem read failure propagates so the failed checkpoint retries
+    // on the next boot; only malformed JSON is a permanent no-op (the config
+    // loader owns surfacing that error).
+    const rawText = readFileSync(configPath, "utf-8");
     let config: Record<string, unknown>;
     try {
-      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      const raw = JSON.parse(rawText);
       if (!isPlainObject(raw)) {
         return;
       }

--- a/assistant/src/workspace/migrations/135-copy-substrate-tunables.ts
+++ b/assistant/src/workspace/migrations/135-copy-substrate-tunables.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getLogger } from "../../util/logger.js";
@@ -54,9 +54,8 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 /**
  * Copy explicitly-set substrate tunables from `memory.v2` to
- * `memory.substrate` so the substrate namespace becomes self-sufficient before
- * the runtime resolver's substrate→v2 fallback (and eventually the whole
- * `memory.v2` subtree) is deleted.
+ * `memory.substrate` so the substrate namespace carries the user's tuned
+ * values itself, independent of the runtime resolver's substrate→v2 fallback.
  *
  * Presence-based, not value-based: a key is copied when it is EXPLICITLY
  * present under `memory.v2` and absent under `memory.substrate` — an explicit
@@ -65,9 +64,8 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * the resolver treats an explicit substrate `null` as set. The common case is
  * a no-op: `memory.v2` tuning defaults were never persisted to config.json.
  *
- * `memory.v2.*` is never modified — the v2 injection engine still reads it
- * until the whole subtree is deleted with v2. An already-present
- * `memory.substrate` key is never clobbered. `memory.substrate` is only
+ * `memory.v2.*` is never modified — the v2 injection engine still reads it.
+ * An already-present `memory.substrate` key is never clobbered. `memory.substrate` is only
  * written at all when at least one key copies, so a fresh config never gains
  * an empty object.
  *
@@ -82,6 +80,9 @@ export const copySubstrateTunablesMigration: WorkspaceMigration = {
   id: "135-copy-substrate-tunables",
   description:
     "Copy explicitly-set memory.v2 substrate tunables to memory.substrate (k→spread_k, hops→spread_hops) without touching memory.v2 or clobbering existing memory.substrate values",
+  // run() only ever adds missing memory.substrate keys and never clobbers
+  // present ones, so retrying after a failed write attempt is safe.
+  retryFailedCheckpoint: true,
 
   run(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");
@@ -132,14 +133,18 @@ export const copySubstrateTunablesMigration: WorkspaceMigration = {
     }
     memory.substrate = substrate;
 
-    try {
-      writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
-      log.info(
-        "Copied explicitly-set memory.v2 substrate tunables to memory.substrate",
-      );
-    } catch (err) {
-      log.warn({ err }, "Failed to write config.json with copied tunables");
-    }
+    // Write-then-rename keeps the migration rerunnable: a crash mid-write
+    // must not leave a truncated config.json that a retry reads as malformed
+    // and "completes" past, stranding the user's v2 overrides. A write or
+    // rename failure propagates to the runner, which checkpoints this
+    // migration as failed and (via retryFailedCheckpoint) retries it on the
+    // next boot instead of recording it as completed.
+    const tmpPath = `${configPath}.tmp`;
+    writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
+    renameSync(tmpPath, configPath);
+    log.info(
+      "Copied explicitly-set memory.v2 substrate tunables to memory.substrate",
+    );
   },
 
   down(_workspaceDir: string): void {

--- a/assistant/src/workspace/migrations/__tests__/135-copy-substrate-tunables.test.ts
+++ b/assistant/src/workspace/migrations/__tests__/135-copy-substrate-tunables.test.ts
@@ -225,6 +225,20 @@ describe("135-copy-substrate-tunables", () => {
     expect(memory().substrate).toEqual({ ann_candidate_limit: 500 });
   });
 
+  test("skips bm25_b values seeded by the earlier 0.75 default (multi-default key)", () => {
+    write({
+      memory: {
+        v2: { bm25_b: 0.75, bm25_k1: 1.5 },
+      },
+    });
+
+    MIG.run(workspaceDir);
+
+    // 0.75 matches the pre-migration-075 shipped default and is seeded, not a
+    // user override; the tuned bm25_k1 still copies.
+    expect(memory().substrate).toEqual({ bm25_k1: 1.5 });
+  });
+
   test("copies the no-default spread keys on presence alone", () => {
     // min_sparse_spread / full_sparse_spread ship with no schema default, so
     // the loader never seeds them — raw presence IS user intent.

--- a/assistant/src/workspace/migrations/__tests__/135-copy-substrate-tunables.test.ts
+++ b/assistant/src/workspace/migrations/__tests__/135-copy-substrate-tunables.test.ts
@@ -116,6 +116,23 @@ describe("135-copy-substrate-tunables", () => {
     expect(memory().substrate).toEqual({ bm25_b: 0.6 });
   });
 
+  test("throws on a filesystem read failure so the failed checkpoint retries; malformed JSON stays a no-op", () => {
+    write({ memory: { v2: { bm25_b: 0.6 } } });
+
+    // An unreadable config.json is a transient fs failure, not malformed
+    // content — it must surface to the runner instead of completing.
+    chmodSync(configPath, 0o000);
+    try {
+      expect(() => MIG.run(workspaceDir)).toThrow();
+    } finally {
+      chmodSync(configPath, 0o644);
+    }
+
+    // The retry succeeds once the file is readable again.
+    MIG.run(workspaceDir);
+    expect(memory().substrate).toEqual({ bm25_b: 0.6 });
+  });
+
   test("renames k→spread_k and hops→spread_hops; a tuned bm25_b lands on the substrate key (v2-fallback removal safe)", () => {
     write({
       memory: {

--- a/assistant/src/workspace/migrations/__tests__/135-copy-substrate-tunables.test.ts
+++ b/assistant/src/workspace/migrations/__tests__/135-copy-substrate-tunables.test.ts
@@ -1,4 +1,11 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -80,6 +87,33 @@ describe("135-copy-substrate-tunables", () => {
       v2: { enabled: true, consolidation_interval_hours: 6 },
       substrate: { consolidation_interval_hours: 6 },
     });
+    // Temp-then-rename persistence leaves no temp file behind on success.
+    expect(existsSync(configPath + ".tmp")).toBe(false);
+  });
+
+  test("throws on a write failure, leaving config.json byte-for-byte intact (retryable via failed checkpoint)", () => {
+    write({ memory: { v2: { bm25_b: 0.6 } } });
+    const before = readRaw();
+
+    // A read-only workspace dir blocks creation of the config.json.tmp
+    // staging file, standing in for any persistence failure.
+    chmodSync(workspaceDir, 0o555);
+    try {
+      expect(() => MIG.run(workspaceDir)).toThrow();
+    } finally {
+      chmodSync(workspaceDir, 0o755);
+    }
+
+    // The failure surfaces to the runner (failed checkpoint, not completed)
+    // and the migration opts into retrying that checkpoint on the next boot.
+    expect(MIG.retryFailedCheckpoint).toBe(true);
+    // config.json is untouched — the failed write targeted the temp file.
+    expect(readRaw()).toBe(before);
+    expect(existsSync(configPath + ".tmp")).toBe(false);
+
+    // The retry succeeds once the workspace is writable again.
+    MIG.run(workspaceDir);
+    expect(memory().substrate).toEqual({ bm25_b: 0.6 });
   });
 
   test("renames k→spread_k and hops→spread_hops; a tuned bm25_b lands on the substrate key (v2-fallback removal safe)", () => {

--- a/assistant/src/workspace/migrations/__tests__/135-copy-substrate-tunables.test.ts
+++ b/assistant/src/workspace/migrations/__tests__/135-copy-substrate-tunables.test.ts
@@ -91,47 +91,59 @@ describe("135-copy-substrate-tunables", () => {
     expect(existsSync(configPath + ".tmp")).toBe(false);
   });
 
-  test("throws on a write failure, leaving config.json byte-for-byte intact (retryable via failed checkpoint)", () => {
-    write({ memory: { v2: { bm25_b: 0.6 } } });
-    const before = readRaw();
+  // Root bypasses file permission checks, so chmod cannot make the workspace
+  // read-only — skip rather than assert a failure path that cannot be
+  // exercised.
+  test.skipIf(process.getuid?.() === 0)(
+    "throws on a write failure, leaving config.json byte-for-byte intact (retryable via failed checkpoint)",
+    () => {
+      write({ memory: { v2: { bm25_b: 0.6 } } });
+      const before = readRaw();
 
-    // A read-only workspace dir blocks creation of the config.json.tmp
-    // staging file, standing in for any persistence failure.
-    chmodSync(workspaceDir, 0o555);
-    try {
-      expect(() => MIG.run(workspaceDir)).toThrow();
-    } finally {
-      chmodSync(workspaceDir, 0o755);
-    }
+      // A read-only workspace dir blocks creation of the config.json.tmp
+      // staging file, standing in for any persistence failure.
+      chmodSync(workspaceDir, 0o555);
+      try {
+        expect(() => MIG.run(workspaceDir)).toThrow();
+      } finally {
+        chmodSync(workspaceDir, 0o755);
+      }
 
-    // The failure surfaces to the runner (failed checkpoint, not completed)
-    // and the migration opts into retrying that checkpoint on the next boot.
-    expect(MIG.retryFailedCheckpoint).toBe(true);
-    // config.json is untouched — the failed write targeted the temp file.
-    expect(readRaw()).toBe(before);
-    expect(existsSync(configPath + ".tmp")).toBe(false);
+      // The failure surfaces to the runner (failed checkpoint, not completed)
+      // and the migration opts into retrying that checkpoint on the next boot.
+      expect(MIG.retryFailedCheckpoint).toBe(true);
+      // config.json is untouched — the failed write targeted the temp file.
+      expect(readRaw()).toBe(before);
+      expect(existsSync(configPath + ".tmp")).toBe(false);
 
-    // The retry succeeds once the workspace is writable again.
-    MIG.run(workspaceDir);
-    expect(memory().substrate).toEqual({ bm25_b: 0.6 });
-  });
+      // The retry succeeds once the workspace is writable again.
+      MIG.run(workspaceDir);
+      expect(memory().substrate).toEqual({ bm25_b: 0.6 });
+    },
+  );
 
-  test("throws on a filesystem read failure so the failed checkpoint retries; malformed JSON stays a no-op", () => {
-    write({ memory: { v2: { bm25_b: 0.6 } } });
+  // Root bypasses file permission checks, so chmod 0o000 cannot make the
+  // file unreadable — skip rather than assert a failure path that cannot be
+  // exercised.
+  test.skipIf(process.getuid?.() === 0)(
+    "throws on a filesystem read failure so the failed checkpoint retries; malformed JSON stays a no-op",
+    () => {
+      write({ memory: { v2: { bm25_b: 0.6 } } });
 
-    // An unreadable config.json is a transient fs failure, not malformed
-    // content — it must surface to the runner instead of completing.
-    chmodSync(configPath, 0o000);
-    try {
-      expect(() => MIG.run(workspaceDir)).toThrow();
-    } finally {
-      chmodSync(configPath, 0o644);
-    }
+      // An unreadable config.json is a transient fs failure, not malformed
+      // content — it must surface to the runner instead of completing.
+      chmodSync(configPath, 0o000);
+      try {
+        expect(() => MIG.run(workspaceDir)).toThrow();
+      } finally {
+        chmodSync(configPath, 0o644);
+      }
 
-    // The retry succeeds once the file is readable again.
-    MIG.run(workspaceDir);
-    expect(memory().substrate).toEqual({ bm25_b: 0.6 });
-  });
+      // The retry succeeds once the file is readable again.
+      MIG.run(workspaceDir);
+      expect(memory().substrate).toEqual({ bm25_b: 0.6 });
+    },
+  );
 
   test("renames k→spread_k and hops→spread_hops; a tuned bm25_b lands on the substrate key (v2-fallback removal safe)", () => {
     write({
@@ -163,37 +175,93 @@ describe("135-copy-substrate-tunables", () => {
     expect(memory().v2).toEqual({ bm25_b: 0.6, max_page_chars: 9000 });
   });
 
-  test("copies explicit nulls on nullable keys (explicit substrate null counts as set)", () => {
+  test("skips loader-seeded values equal to the shipped defaults, including null-default keys", () => {
+    // The config loader persists the fully-parsed config for normally-created
+    // workspaces, so every defaulted v2 leaf is present in config.json. None
+    // of these are user intent — the migration must not pin them into the
+    // override-only substrate namespace.
     write({
       memory: {
-        v2: { ann_candidate_limit: null, consolidation_prompt_path: null },
+        v2: {
+          enabled: true,
+          sweep_enabled: false,
+          dense_weight: 0.85,
+          sparse_weight: 0.15,
+          bm25_k1: 1.2,
+          bm25_b: 0.4,
+          consolidation_interval_hours: 8,
+          consolidation_max_buffer_lines: 100,
+          consolidation_max_entries_per_run: 150,
+          max_page_chars: 5000,
+          consolidation_prompt_path: null,
+          k: 0.5,
+          hops: 2,
+          ann_candidate_limit: null,
+        },
+      },
+    });
+    const before = readRaw();
+
+    MIG.run(workspaceDir);
+
+    // Nothing differs from a shipped default → no copy, no write at all.
+    expect(readRaw()).toBe(before);
+  });
+
+  test("copies non-default values on nullable keys but skips their seeded null defaults", () => {
+    write({
+      memory: {
+        v2: {
+          ann_candidate_limit: 500,
+          consolidation_prompt_path: null,
+        },
+      },
+    });
+
+    MIG.run(workspaceDir);
+
+    // 500 differs from the shipped null default and copies; the seeded null
+    // equals its default and stays out of the substrate namespace.
+    expect(memory().substrate).toEqual({ ann_candidate_limit: 500 });
+  });
+
+  test("copies the no-default spread keys on presence alone", () => {
+    // min_sparse_spread / full_sparse_spread ship with no schema default, so
+    // the loader never seeds them — raw presence IS user intent.
+    write({
+      memory: {
+        v2: { min_sparse_spread: 0.05, full_sparse_spread: 0.3 },
       },
     });
 
     MIG.run(workspaceDir);
 
     expect(memory().substrate).toEqual({
-      ann_candidate_limit: null,
-      consolidation_prompt_path: null,
+      min_sparse_spread: 0.05,
+      full_sparse_spread: 0.3,
     });
   });
 
-  test("a lone explicit memory.v2.dense_weight still parses after migration (resolved-pair weight check)", () => {
-    // 0.85 is valid against v2's default sparse_weight 0.15; after migration
-    // the lone substrate dense_weight resolves against the SAME v2 fallback
-    // pair, so the parent schema's resolved-pair check must still accept it.
-    write({ memory: { v2: { dense_weight: 0.85 } } });
+  test("a tuned weight pair copies whole and still parses after migration (resolved-pair weight check)", () => {
+    // The v2 refinement validates dense_weight + sparse_weight on the
+    // persisted values, so a valid config with a non-default dense_weight
+    // necessarily persists its non-default twin — both copy, and the copied
+    // substrate pair is exactly the pair v2 already accepted.
+    write({ memory: { v2: { dense_weight: 0.9, sparse_weight: 0.1 } } });
 
     MIG.run(workspaceDir);
 
-    expect(memory().substrate).toEqual({ dense_weight: 0.85 });
+    expect(memory().substrate).toEqual({
+      dense_weight: 0.9,
+      sparse_weight: 0.1,
+    });
     expect(() => MemoryConfigSchema.parse(memory())).not.toThrow();
   });
 
   test("is idempotent — a second run leaves the file byte-for-byte unchanged", () => {
     write({
       memory: {
-        v2: { bm25_b: 0.6, k: 0.4, ann_candidate_limit: null },
+        v2: { bm25_b: 0.6, k: 0.4, ann_candidate_limit: 500 },
         substrate: { sweep_enabled: true },
       },
     });
@@ -207,7 +275,7 @@ describe("135-copy-substrate-tunables", () => {
       sweep_enabled: true,
       bm25_b: 0.6,
       spread_k: 0.4,
-      ann_candidate_limit: null,
+      ann_candidate_limit: 500,
     });
   });
 

--- a/assistant/src/workspace/migrations/__tests__/135-copy-substrate-tunables.test.ts
+++ b/assistant/src/workspace/migrations/__tests__/135-copy-substrate-tunables.test.ts
@@ -1,0 +1,171 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { MemoryConfigSchema } from "../../../config/schemas/memory.js";
+import { copySubstrateTunablesMigration as MIG } from "../135-copy-substrate-tunables.js";
+
+let workspaceDir: string;
+let configPath: string;
+
+function write(obj: unknown): void {
+  writeFileSync(configPath, JSON.stringify(obj, null, 2) + "\n");
+}
+function readRaw(): string {
+  return readFileSync(configPath, "utf-8");
+}
+function read(): Record<string, unknown> {
+  return JSON.parse(readRaw());
+}
+function memory(): Record<string, unknown> {
+  return read().memory as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "copy-substrate-tunables-"));
+  configPath = join(workspaceDir, "config.json");
+});
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("135-copy-substrate-tunables", () => {
+  test("has the expected id", () => {
+    expect(MIG.id).toBe("135-copy-substrate-tunables");
+  });
+
+  test("no-ops when config.json is absent, unparseable, or has no memory config", () => {
+    // Absent config.json.
+    expect(() => MIG.run(workspaceDir)).not.toThrow();
+
+    // Unparseable config.json is left byte-for-byte alone.
+    writeFileSync(configPath, "{not json");
+    MIG.run(workspaceDir);
+    expect(readRaw()).toBe("{not json");
+
+    // No memory config — fresh-workspace shape.
+    write({ llm: { provider: "anthropic" } });
+    const before = readRaw();
+    MIG.run(workspaceDir);
+    expect(readRaw()).toBe(before);
+
+    // memory present but no v2 subtree.
+    write({ memory: { enabled: true } });
+    const beforeNoV2 = readRaw();
+    MIG.run(workspaceDir);
+    expect(readRaw()).toBe(beforeNoV2);
+  });
+
+  test("never introduces memory.substrate when memory.v2 sets no substrate tunables", () => {
+    write({ memory: { v2: { enabled: true, hybrid_min_score: 0.02 } } });
+    const before = readRaw();
+
+    MIG.run(workspaceDir);
+
+    // Nothing copied → no write at all, so no empty substrate object appears.
+    expect(readRaw()).toBe(before);
+  });
+
+  test("copies an explicit memory.v2.consolidation_interval_hours, leaving memory.v2 untouched", () => {
+    write({
+      memory: {
+        v2: { enabled: true, consolidation_interval_hours: 6 },
+      },
+    });
+
+    MIG.run(workspaceDir);
+
+    expect(memory()).toEqual({
+      v2: { enabled: true, consolidation_interval_hours: 6 },
+      substrate: { consolidation_interval_hours: 6 },
+    });
+  });
+
+  test("renames k→spread_k and hops→spread_hops; a tuned bm25_b lands on the substrate key (v2-fallback removal safe)", () => {
+    write({
+      memory: {
+        v2: { k: 0.4, hops: 3, bm25_b: 0.6 },
+      },
+    });
+
+    MIG.run(workspaceDir);
+
+    const substrate = memory().substrate as Record<string, unknown>;
+    // The substrate namespace now carries the tuned values itself: resolving
+    // WITHOUT the resolver's substrate→v2 fallback yields the same behavior.
+    expect(substrate).toEqual({ spread_k: 0.4, spread_hops: 3, bm25_b: 0.6 });
+    expect(memory().v2).toEqual({ k: 0.4, hops: 3, bm25_b: 0.6 });
+  });
+
+  test("never clobbers an already-set memory.substrate key, but still copies its unset siblings", () => {
+    write({
+      memory: {
+        v2: { bm25_b: 0.6, max_page_chars: 9000 },
+        substrate: { bm25_b: 0.3 },
+      },
+    });
+
+    MIG.run(workspaceDir);
+
+    expect(memory().substrate).toEqual({ bm25_b: 0.3, max_page_chars: 9000 });
+    expect(memory().v2).toEqual({ bm25_b: 0.6, max_page_chars: 9000 });
+  });
+
+  test("copies explicit nulls on nullable keys (explicit substrate null counts as set)", () => {
+    write({
+      memory: {
+        v2: { ann_candidate_limit: null, consolidation_prompt_path: null },
+      },
+    });
+
+    MIG.run(workspaceDir);
+
+    expect(memory().substrate).toEqual({
+      ann_candidate_limit: null,
+      consolidation_prompt_path: null,
+    });
+  });
+
+  test("a lone explicit memory.v2.dense_weight still parses after migration (resolved-pair weight check)", () => {
+    // 0.85 is valid against v2's default sparse_weight 0.15; after migration
+    // the lone substrate dense_weight resolves against the SAME v2 fallback
+    // pair, so the parent schema's resolved-pair check must still accept it.
+    write({ memory: { v2: { dense_weight: 0.85 } } });
+
+    MIG.run(workspaceDir);
+
+    expect(memory().substrate).toEqual({ dense_weight: 0.85 });
+    expect(() => MemoryConfigSchema.parse(memory())).not.toThrow();
+  });
+
+  test("is idempotent — a second run leaves the file byte-for-byte unchanged", () => {
+    write({
+      memory: {
+        v2: { bm25_b: 0.6, k: 0.4, ann_candidate_limit: null },
+        substrate: { sweep_enabled: true },
+      },
+    });
+
+    MIG.run(workspaceDir);
+    const afterFirst = readRaw();
+    MIG.run(workspaceDir);
+
+    expect(readRaw()).toBe(afterFirst);
+    expect(memory().substrate).toEqual({
+      sweep_enabled: true,
+      bm25_b: 0.6,
+      spread_k: 0.4,
+      ann_candidate_limit: null,
+    });
+  });
+
+  test("down() is a forward-only no-op", () => {
+    write({ memory: { v2: { bm25_b: 0.6 }, substrate: { bm25_b: 0.6 } } });
+    const before = readRaw();
+
+    expect(() => MIG.down(workspaceDir)).not.toThrow();
+
+    expect(readRaw()).toBe(before);
+  });
+});

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -132,6 +132,7 @@ import { dropWebFetchModeMigration } from "./131-drop-web-fetch-mode.js";
 import { webSearchModeToProviderMigration } from "./132-web-search-mode-to-provider.js";
 import { collapseProviderConnectionsMigration } from "./133-collapse-provider-connections.js";
 import { imageGenerationModeToProviderMigration } from "./134-image-generation-mode-to-provider.js";
+import { copySubstrateTunablesMigration } from "./135-copy-substrate-tunables.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -279,4 +280,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   webSearchModeToProviderMigration,
   collapseProviderConnectionsMigration,
   imageGenerationModeToProviderMigration,
+  copySubstrateTunablesMigration,
 ];


### PR DESCRIPTION
## Summary
- New workspace migration copies the fifteen substrate tunables from memory.v2 to memory.substrate when explicitly set and not already overridden
- memory.v2 values untouched; idempotent; fresh workspaces no-op

Part of plan: memory-tier-separation.md (PR 11 of 14)