### PR TITLE
test(memory): memory tier boundary guard

### DIFF
--- a/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
@@ -1,0 +1,457 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { Glob } from "bun";
+
+/**
+ * Guard tests for the memory plugin's tier boundaries. See
+ * `assistant/docs/architecture/memory.md` for the full tier map.
+ *
+ * The memory plugin is layered into tier directories: `substrate/` is the
+ * shared concept-page substrate used by both v2 and v3, `v1/` is the legacy
+ * PKB/graph engine, `v2/` is the activation-spreading engine, and `v3/` (plus
+ * its `v3-eval/` sibling) is the lane/orchestrator engine. Everything else
+ * under the plugin root — including `graph/` (the all-tier legacy store and
+ * dispatcher) — is spine code that composes tiers.
+ *
+ * Guard 1 — tier import edges (production files only):
+ *   - `substrate/` imports no tier directory (it is the bottom layer).
+ *   - `v1/` imports no other tier directory (shared `graph/` modules and
+ *     plugin-root infra are fine — they are spine, not tiers).
+ *   - `v2/` may import `substrate/` but not `v1/`, `v3/`, or `v3-eval/`.
+ *   - `v3/` and `v3-eval/` may import `substrate/` (and each other) but not
+ *     `v1/` or `v2/`.
+ *   - A spine file importing from two or more tier directories is a
+ *     composition point and must be on the frozen {@link SPINE_ALLOWLIST}.
+ *
+ * Guard 2 — tier-key config reads (`memory.v2.*` / `memory.v3.*`) across all
+ * of `assistant/src/`. Tier selection flows through the predicates in
+ * `src/config/memory-v3-gate.ts` (from which `src/config/memory-tier.ts`
+ * derives) and substrate tunables resolve via `substrate/tuning.ts`, so raw
+ * tier-key reads outside the frozen {@link TIER_KEY_READ_ALLOWLIST} are a
+ * layering leak. Detection strips comments and string/template literals
+ * first (so job names like "memory.v2.sweep" and schema error strings do not
+ * false-positive), then matches `memory.v2` / `memory.v3` property chains —
+ * including optional chaining and reads inside template interpolations.
+ *
+ * Both allowlists carry a reverse "stale exemption" test so an entry whose
+ * multi-tier import or tier-key read disappears fails loudly and gets
+ * removed instead of lingering.
+ *
+ * Tests run from `assistant/`, so paths resolve against `process.cwd()`.
+ * Test files (`*.test.ts`, `__tests__/`) are out of scope — the boundary
+ * guarded is the shipped runtime.
+ */
+
+/** `assistant/src/plugins/defaults/memory`, relative to the `assistant/` cwd. */
+const MEM_REL = join("src", "plugins", "defaults", "memory");
+const MEM_ABS = join(process.cwd(), MEM_REL);
+
+const TIER_DIRS = ["substrate", "v1", "v2", "v3", "v3-eval"] as const;
+type Tier = (typeof TIER_DIRS)[number];
+
+/** Tier directories each tier must not import from. */
+const FORBIDDEN_TIER_IMPORTS: Record<Tier, ReadonlySet<Tier>> = {
+  substrate: new Set(["v1", "v2", "v3", "v3-eval"]),
+  v1: new Set(["substrate", "v2", "v3", "v3-eval"]),
+  v2: new Set(["v1", "v3", "v3-eval"]),
+  v3: new Set(["v1", "v2"]),
+  "v3-eval": new Set(["v1", "v2"]),
+};
+
+/**
+ * Spine files allowed to import from two or more tier directories — the
+ * composition points where the plugin wires tiers together. Paths are
+ * relative to the plugin root, posix-separated. Frozen — do not add: new
+ * multi-tier composition belongs in an existing spine file, and shrinking
+ * this list is how the tier deletion runbooks retire an engine.
+ */
+const SPINE_ALLOWLIST: ReadonlySet<string> = new Set([
+  "fork-conversation-memory.ts",
+  "graph-topology/build-memory-graph.ts",
+  "graph/conversation-graph-memory.ts",
+  "injectors.ts",
+  "job-handlers.ts",
+  "jobs-worker.ts",
+  "src/memory-v2-routes.ts",
+  "startup.ts",
+]);
+
+/**
+ * Files allowed to read `memory.v2.*` / `memory.v3.*` config keys directly.
+ * Paths are relative to the `assistant/` cwd, posix-separated; a trailing
+ * `/` marks a directory prefix. Frozen — do not add: route new tier
+ * decisions through `src/config/memory-v3-gate.ts` (or `memory-tier.ts`) and
+ * new substrate tunables through `substrate/tuning.ts`; see the tier
+ * deletion runbooks before touching this list.
+ *
+ * - `config/memory-v3-gate.ts` — the gate module; the one sanctioned home
+ *   for raw tier-predicate reads.
+ * - `config/loader.ts` — seeds/normalizes the persisted `memory.v3` shape.
+ * - `telemetry/config-setting-snapshot.ts` — reports tier keys as-is.
+ * - migrations (persistence + workspace) — append-only history that rewrites
+ *   or reads historical tier keys.
+ * - `substrate/tuning.ts` — the substrate tunable resolver (`memory.v2`
+ *   fallback lives here by design).
+ * - `v2/`, `v3/` — each engine reads its own tier's tuning namespace.
+ * - `graph/conversation-graph-memory.ts` — reads `memory.v2.router` for the
+ *   all-tier dispatcher's historical-pairs routing.
+ * - `graph-topology/build-memory-graph.ts` — reads `memory.v3.edge` tuning
+ *   when building the graph view.
+ * - `src/memory-v2-routes.ts` — the v2 tuning routes read and merge
+ *   `memory.v2` config directly.
+ */
+const TIER_KEY_READ_ALLOWLIST: readonly string[] = [
+  "src/config/loader.ts",
+  "src/config/memory-v3-gate.ts",
+  "src/persistence/migrations/",
+  "src/plugins/defaults/memory/graph-topology/build-memory-graph.ts",
+  "src/plugins/defaults/memory/graph/conversation-graph-memory.ts",
+  "src/plugins/defaults/memory/src/memory-v2-routes.ts",
+  "src/plugins/defaults/memory/substrate/tuning.ts",
+  "src/plugins/defaults/memory/v2/",
+  "src/plugins/defaults/memory/v3/",
+  "src/telemetry/config-setting-snapshot.ts",
+  "src/workspace/migrations/",
+];
+
+/** Matches `import ... from "X"`, `export ... from "X"`, `import("X")`,
+ *  `require("X")`, and side-effect `import "X"` — including multi-line forms,
+ *  since the between-keyword-and-`from` span never contains a quote. */
+function importSpecifierRegex(): RegExp {
+  return /(?:import|export)\b[^'"]*?from\s*['"]([^'"]+)['"]|(?:import|require)\(\s*['"]([^'"]+)['"]\s*\)|^\s*import\s+['"]([^'"]+)['"]/gm;
+}
+
+/** Tier directory a plugin-root-relative path lives in, or `"spine"`. */
+function tierOf(relToMem: string): Tier | "spine" {
+  const first = relToMem.split("/")[0]!;
+  return (TIER_DIRS as readonly string[]).includes(first)
+    ? (first as Tier)
+    : "spine";
+}
+
+/** Production `.ts` files under `root`, posix-relative, tests excluded. */
+function productionFiles(root: string): string[] {
+  const files: string[] = [];
+  for (const rel of new Glob("**/*.ts").scanSync({ cwd: root })) {
+    const posix = rel.split("\\").join("/");
+    if (posix.endsWith(".test.ts") || posix.split("/").includes("__tests__")) {
+      continue;
+    }
+    files.push(posix);
+  }
+  return files.sort();
+}
+
+interface TierImport {
+  /** Importing file, relative to the plugin root. */
+  file: string;
+  sourceTier: Tier | "spine";
+  targetTier: Tier;
+  specifier: string;
+}
+
+/** Every intra-plugin import that lands in a tier directory. */
+function collectTierImports(): TierImport[] {
+  const imports: TierImport[] = [];
+  for (const file of productionFiles(MEM_ABS)) {
+    const absPath = join(MEM_ABS, file);
+    const source = readFileSync(absPath, "utf-8");
+    const regex = importSpecifierRegex();
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(source)) !== null) {
+      const specifier = match[1] ?? match[2] ?? match[3];
+      if (!specifier || !specifier.startsWith(".")) {
+        continue;
+      }
+      const resolved = resolve(dirname(absPath), specifier);
+      const relToMem = relative(MEM_ABS, resolved).split("\\").join("/");
+      if (relToMem.startsWith("..")) {
+        continue;
+      }
+      const targetTier = tierOf(relToMem);
+      if (targetTier === "spine") {
+        continue;
+      }
+      imports.push({
+        file,
+        sourceTier: tierOf(file),
+        targetTier,
+        specifier,
+      });
+    }
+  }
+  return imports;
+}
+
+/** Distinct tier directories each spine file imports from. */
+function spineTierUsage(imports: TierImport[]): Map<string, Set<Tier>> {
+  const usage = new Map<string, Set<Tier>>();
+  for (const imp of imports) {
+    if (imp.sourceTier !== "spine") {
+      continue;
+    }
+    let tiers = usage.get(imp.file);
+    if (!tiers) {
+      usage.set(imp.file, (tiers = new Set()));
+    }
+    tiers.add(imp.targetTier);
+  }
+  return usage;
+}
+
+/**
+ * Source with comments and string/template literals blanked out, so tier-key
+ * matching only sees executable property chains. Line structure is
+ * preserved. Template interpolations (`${...}`) are kept — they are code —
+ * via a mode stack that tracks nested templates and interpolation braces.
+ * Regex literals are not lexed; single/double-quoted string skipping stops
+ * at end-of-line so a quote inside a regex desyncs at most one line.
+ */
+function stripCommentsAndStrings(source: string): string {
+  let out = "";
+  let i = 0;
+  const n = source.length;
+  // Interpolation brace depths for enclosing template literals, innermost
+  // last; empty means top-level code.
+  const templateDepths: number[] = [];
+  let braceDepth = 0;
+
+  const keepNewlinesOf = (text: string): void => {
+    out += text.replace(/[^\n]/g, "");
+  };
+
+  // Scans template-literal content from `start` (just past the opening
+  // backtick, or past an interpolation's closing brace), appending newlines.
+  // Stops after the closing backtick, or pushes interpolation state and
+  // stops after a `${`. Returns the index to resume lexing at.
+  const scanTemplateContent = (start: number): number => {
+    let j = start;
+    while (j < n) {
+      if (source[j] === "\\") {
+        j += 2;
+        continue;
+      }
+      if (source[j] === "`") {
+        return j + 1;
+      }
+      if (source[j] === "$" && source[j + 1] === "{") {
+        templateDepths.push(braceDepth);
+        braceDepth = 0;
+        return j + 2;
+      }
+      if (source[j] === "\n") {
+        out += "\n";
+      }
+      j++;
+    }
+    return j;
+  };
+
+  while (i < n) {
+    const c = source[i]!;
+    const next = source[i + 1];
+    if (c === "/" && next === "/") {
+      const end = source.indexOf("\n", i);
+      i = end === -1 ? n : end;
+      continue;
+    }
+    if (c === "/" && next === "*") {
+      const end = source.indexOf("*/", i + 2);
+      const stop = end === -1 ? n : end + 2;
+      keepNewlinesOf(source.slice(i, stop));
+      i = stop;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      i++;
+      while (i < n && source[i] !== c && source[i] !== "\n") {
+        i += source[i] === "\\" ? 2 : 1;
+      }
+      if (source[i] === c) {
+        i++;
+      }
+      continue;
+    }
+    if (c === "`") {
+      i = scanTemplateContent(i + 1);
+      continue;
+    }
+    if (templateDepths.length > 0) {
+      if (c === "{") {
+        braceDepth++;
+      } else if (c === "}") {
+        if (braceDepth === 0) {
+          // Interpolation closed — resume the enclosing template literal.
+          braceDepth = templateDepths.pop()!;
+          i = scanTemplateContent(i + 1);
+          continue;
+        }
+        braceDepth--;
+      }
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+/** Matches a `memory.v2` / `memory.v3` property chain, including optional
+ *  chaining (`config.memory?.v3?.live`). Runs on stripped source only. */
+const TIER_KEY_READ = /\bmemory\s*\??\.\s*v[23]\b/;
+
+function isTierKeyExempt(file: string): boolean {
+  return TIER_KEY_READ_ALLOWLIST.some((entry) =>
+    entry.endsWith("/") ? file.startsWith(entry) : file === entry,
+  );
+}
+
+/** Production files under `src/` with a tier-key config read, sorted. */
+function collectTierKeyReaders(): string[] {
+  const readers: string[] = [];
+  for (const file of productionFiles(join(process.cwd(), "src"))) {
+    const posix = `src/${file}`;
+    const stripped = stripCommentsAndStrings(
+      readFileSync(join(process.cwd(), posix), "utf-8"),
+    );
+    if (TIER_KEY_READ.test(stripped)) {
+      readers.push(posix);
+    }
+  }
+  return readers;
+}
+
+describe("memory tier boundary guard", () => {
+  const tierImports = collectTierImports();
+
+  test("tier directories only import their allowed tiers", () => {
+    const violations: string[] = [];
+    for (const imp of tierImports) {
+      if (imp.sourceTier === "spine" || imp.sourceTier === imp.targetTier) {
+        continue;
+      }
+      if (FORBIDDEN_TIER_IMPORTS[imp.sourceTier].has(imp.targetTier)) {
+        violations.push(
+          `  - ${MEM_REL}/${imp.file} (${imp.sourceTier}/) imports "${imp.specifier}" (${imp.targetTier}/)`,
+        );
+      }
+    }
+    violations.sort();
+    const message = [
+      "Forbidden tier import edges in the memory plugin:",
+      ...violations,
+      "",
+      "substrate/ imports no tier; v1/ imports no other tier; v2/ may import",
+      "substrate/ only; v3/ and v3-eval/ may import substrate/ (and each",
+      "other) only. Shared code belongs in substrate/ or the plugin spine.",
+    ].join("\n");
+    expect(violations, message).toEqual([]);
+  });
+
+  test("multi-tier composition only happens at frozen spine files", () => {
+    const violations: string[] = [];
+    for (const [file, tiers] of spineTierUsage(tierImports)) {
+      if (tiers.size >= 2 && !SPINE_ALLOWLIST.has(file)) {
+        violations.push(
+          `  - ${MEM_REL}/${file} imports from {${[...tiers].sort().join(", ")}}`,
+        );
+      }
+    }
+    violations.sort();
+    const message = [
+      "Spine files newly composing multiple tiers (not on SPINE_ALLOWLIST):",
+      ...violations,
+      "",
+      "The allowlist is frozen — do not add. Route new multi-tier wiring",
+      "through an existing composition point, or push the shared logic into",
+      "substrate/.",
+    ].join("\n");
+    expect(violations, message).toEqual([]);
+  });
+
+  test("every spine allowlist entry still composes multiple tiers", () => {
+    const usage = spineTierUsage(tierImports);
+    const stale: string[] = [];
+    for (const file of [...SPINE_ALLOWLIST].sort()) {
+      if ((usage.get(file)?.size ?? 0) < 2) {
+        stale.push(`  - ${file}`);
+      }
+    }
+    const message = [
+      "Stale SPINE_ALLOWLIST entries (no longer import 2+ tiers — remove",
+      "them so the freeze stays tight):",
+      ...stale,
+    ].join("\n");
+    expect(stale, message).toEqual([]);
+  });
+
+  test("tier-key config reads are frozen to the gate module and exemptions", () => {
+    const violations = collectTierKeyReaders()
+      .filter((file) => !isTierKeyExempt(file))
+      .map((file) => `  - ${file}`);
+    const message = [
+      "New memory.v2.* / memory.v3.* config reads outside the frozen",
+      "TIER_KEY_READ_ALLOWLIST:",
+      ...violations,
+      "",
+      "Tier decisions go through src/config/memory-v3-gate.ts (or",
+      "src/config/memory-tier.ts); substrate tunables resolve via",
+      "substrate/tuning.ts. Do not extend the allowlist.",
+    ].join("\n");
+    expect(violations, message).toEqual([]);
+  });
+
+  test("every tier-key exemption still has a tier-key read", () => {
+    const readers = collectTierKeyReaders();
+    const stale: string[] = [];
+    for (const entry of TIER_KEY_READ_ALLOWLIST) {
+      const matched = entry.endsWith("/")
+        ? readers.some((file) => file.startsWith(entry))
+        : readers.includes(entry);
+      if (!matched) {
+        stale.push(`  - ${entry}`);
+      }
+    }
+    const message = [
+      "Stale TIER_KEY_READ_ALLOWLIST entries (no tier-key read matches —",
+      "remove them so the freeze stays tight):",
+      ...stale,
+    ].join("\n");
+    expect(stale, message).toEqual([]);
+  });
+});
+
+describe("tier-key read detection", () => {
+  const detects = (source: string): boolean =>
+    TIER_KEY_READ.test(stripCommentsAndStrings(source));
+
+  test("property chains are detected, with and without optional chaining", () => {
+    expect(detects(`const on = config.memory.v2.enabled;`)).toBe(true);
+    expect(detects(`return config.memory?.v3?.live === true;`)).toBe(true);
+    expect(detects(`seed.memory.v3 = { live: seed.memory.v3.live };`)).toBe(
+      true,
+    );
+  });
+
+  test("string literals and comments are ignored", () => {
+    expect(detects(`enqueue("memory.v2.sweep");`)).toBe(false);
+    expect(detects(`// falls back to memory.v2.k\nconst k = 1;`)).toBe(false);
+    expect(detects(`/** memory.v3.live gates injection */\nconst x = 1;`)).toBe(
+      false,
+    );
+    expect(detects("const label = `memory.v3.edge tuning`;")).toBe(false);
+  });
+
+  test("reads inside template interpolations are detected", () => {
+    expect(detects("const msg = `k=${config.memory.v2.k}`;")).toBe(true);
+    expect(
+      detects("const msg = `memory.v3.live=${config.memory?.v3?.live}`;"),
+    ).toBe(true);
+  });
+
+  test("unrelated identifiers do not match", () => {
+    expect(detects(`const memoryV2 = loadV2();`)).toBe(false);
+    expect(detects(`const x = inMemory.v2Cache;`)).toBe(false);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
@@ -3,6 +3,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import { Glob } from "bun";
+import ts from "typescript";
 
 /**
  * Guard tests for the memory plugin's tier boundaries. See
@@ -35,13 +36,17 @@ import { Glob } from "bun";
  * only and `v3/` for `memory.v3` only, matching the documented boundary that
  * an engine reads its own tuning namespace and no other.
  *
- * Detection strips comments and string/template literals first (so job names
- * like "memory.v2.sweep" and schema error strings do not false-positive),
- * then matches three read forms: dot chains (`config.memory?.v3?.live`),
- * computed literal access (`config.memory["v3"]`), and destructuring off a
- * `memory` object (`const { v2 } = config.memory`, `const { memory: { v3 } }
- * = config`). Bare `"v2"` / `"v3"` string literals survive stripping so
- * computed access stays visible; every other literal is blanked.
+ * Detection parses each production file into a TypeScript AST
+ * (`ts.createSourceFile`, no type-checker) and walks it for reads off a
+ * `memory` object: property access including optional chaining
+ * (`config.memory?.v3.live`), element access with a string literal
+ * (`config.memory["v3"]`), and destructuring in any position — variable
+ * declarations (`const { v2 } = config.memory ?? {}`), assignments
+ * (`({ v3 } = config.memory)`), function and catch parameters, and nested
+ * patterns (`const { memory: { v3 } } = config`). The parser classifies
+ * comments and string, template, and regex literals for us, so job names
+ * like "memory.v2.sweep" and doc comments never false-positive and no
+ * literal can desync the scan.
  *
  * Both allowlists carry a reverse "stale exemption" test — per (path, keys)
  * pair for tier keys — so an entry whose multi-tier import or tier-key read
@@ -243,181 +248,233 @@ function spineTierUsage(imports: TierImport[]): Map<string, Set<Tier>> {
   return usage;
 }
 
+/** An object destructuring pattern, in binding or assignment-target form. */
+type ObjectPattern = ts.ObjectBindingPattern | ts.ObjectLiteralExpression;
+
+/** One property destructured by an {@link ObjectPattern}. */
+interface PatternEntry {
+  /** Property read off the source object; `undefined` when computed. */
+  readonly key: string | undefined;
+  /** Sub-pattern this property destructures into, if it has one. */
+  readonly nested: ObjectPattern | undefined;
+}
+
+/** Parses one file; `.tsx` parses as TSX, everything else as TS. */
+function parseSourceFile(fileName: string, sourceText: string): ts.SourceFile {
+  return ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    fileName.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+}
+
+/** Expression with parentheses, `!`, and type assertions peeled off. */
+function unwrapExpression(node: ts.Expression): ts.Expression {
+  let current = node;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isTypeAssertionExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/** Text of a string-ish literal, or `undefined` for anything computed. */
+function literalText(node: ts.Node | undefined): string | undefined {
+  return node !== undefined && ts.isStringLiteralLike(node)
+    ? node.text
+    : undefined;
+}
+
+/** Static name of a property or binding name, or `undefined` if computed. */
+function staticNameText(
+  name: ts.PropertyName | ts.BindingName | undefined,
+): string | undefined {
+  if (name === undefined) {
+    return undefined;
+  }
+  if (
+    ts.isIdentifier(name) ||
+    ts.isStringLiteral(name) ||
+    ts.isNumericLiteral(name)
+  ) {
+    return name.text;
+  }
+  return undefined;
+}
+
 /**
- * Source with comments and string/template literals blanked out, so tier-key
- * matching only sees executable property chains. Bare `"v2"` / `"v3"`
- * literals survive verbatim — they are the key half of computed access
- * (`config.memory["v3"]`) — while every other literal, including compound
- * names like "memory.v2.sweep", is dropped. Line structure is preserved.
- * Template interpolations (`${...}`) are kept — they are code — via a mode
- * stack that tracks nested templates and interpolation braces. Regex
- * literals are not lexed; single/double-quoted string skipping stops at
- * end-of-line so a quote inside a regex desyncs at most one line.
+ * Whether an expression resolves to a `memory` object: a bare `memory`
+ * identifier, any `.memory` / `["memory"]` access, or either arm of a
+ * `??`/`||` fallback or a conditional (`config.memory ?? {}`).
  */
-function stripCommentsAndStrings(source: string): string {
-  let out = "";
-  let i = 0;
-  const n = source.length;
-  // Interpolation brace depths for enclosing template literals, innermost
-  // last; empty means top-level code.
-  const templateDepths: number[] = [];
-  let braceDepth = 0;
+function resolvesToMemory(node: ts.Expression): boolean {
+  const expr = unwrapExpression(node);
+  if (ts.isIdentifier(expr)) {
+    return expr.text === "memory";
+  }
+  if (ts.isPropertyAccessExpression(expr)) {
+    return expr.name.text === "memory";
+  }
+  if (ts.isElementAccessExpression(expr)) {
+    return literalText(expr.argumentExpression) === "memory";
+  }
+  if (
+    ts.isBinaryExpression(expr) &&
+    (expr.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken ||
+      expr.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+  ) {
+    return resolvesToMemory(expr.left) || resolvesToMemory(expr.right);
+  }
+  if (ts.isConditionalExpression(expr)) {
+    return resolvesToMemory(expr.whenTrue) || resolvesToMemory(expr.whenFalse);
+  }
+  return false;
+}
 
-  const keepNewlinesOf = (text: string): void => {
-    out += text.replace(/[^\n]/g, "");
-  };
+/** Assignment-pattern target with its parentheses and `= default` removed. */
+function unwrapAssignmentTarget(node: ts.Expression): ts.Expression {
+  const expr = unwrapExpression(node);
+  if (
+    ts.isBinaryExpression(expr) &&
+    expr.operatorToken.kind === ts.SyntaxKind.EqualsToken
+  ) {
+    return unwrapAssignmentTarget(expr.left);
+  }
+  return expr;
+}
 
-  // Scans template-literal content from `start` (just past the opening
-  // backtick, or past an interpolation's closing brace), appending newlines.
-  // Stops after the closing backtick, or pushes interpolation state and
-  // stops after a `${`. Returns the index to resume lexing at.
-  const scanTemplateContent = (start: number): number => {
-    let j = start;
-    while (j < n) {
-      if (source[j] === "\\") {
-        j += 2;
+/** Properties a pattern destructures, in either binding or assignment form. */
+function patternEntries(pattern: ObjectPattern): PatternEntry[] {
+  const entries: PatternEntry[] = [];
+  if (ts.isObjectBindingPattern(pattern)) {
+    for (const element of pattern.elements) {
+      if (element.dotDotDotToken !== undefined) {
+        // A rest element carries no single key.
         continue;
       }
-      if (source[j] === "`") {
-        return j + 1;
-      }
-      if (source[j] === "$" && source[j + 1] === "{") {
-        templateDepths.push(braceDepth);
-        braceDepth = 0;
-        return j + 2;
-      }
-      if (source[j] === "\n") {
-        out += "\n";
-      }
-      j++;
+      entries.push({
+        key: staticNameText(element.propertyName ?? element.name),
+        nested: ts.isObjectBindingPattern(element.name)
+          ? element.name
+          : undefined,
+      });
     }
-    return j;
+    return entries;
+  }
+  for (const property of pattern.properties) {
+    if (ts.isShorthandPropertyAssignment(property)) {
+      entries.push({ key: property.name.text, nested: undefined });
+      continue;
+    }
+    if (!ts.isPropertyAssignment(property)) {
+      // Spreads and methods carry no single key.
+      continue;
+    }
+    const target = unwrapAssignmentTarget(property.initializer);
+    entries.push({
+      key: staticNameText(property.name),
+      nested: ts.isObjectLiteralExpression(target) ? target : undefined,
+    });
+  }
+  return entries;
+}
+
+/** Adds every tier key bound directly by `pattern`. */
+function addTopLevelTierKeys(pattern: ObjectPattern, keys: Set<TierKey>): void {
+  for (const entry of patternEntries(pattern)) {
+    if (entry.key === "v2" || entry.key === "v3") {
+      keys.add(entry.key);
+    }
+  }
+}
+
+/**
+ * Adds tier keys taken through a nested `memory:` sub-pattern at any depth,
+ * as in `const { memory: { v3 } } = config`.
+ */
+function addNestedMemoryPatternKeys(
+  pattern: ObjectPattern,
+  keys: Set<TierKey>,
+): void {
+  for (const entry of patternEntries(pattern)) {
+    if (entry.nested === undefined) {
+      continue;
+    }
+    if (entry.key === "memory") {
+      addTopLevelTierKeys(entry.nested, keys);
+    }
+    addNestedMemoryPatternKeys(entry.nested, keys);
+  }
+}
+
+/**
+ * Tier namespaces a source file reads off a `memory` object, found by walking
+ * its TypeScript AST: property access (`config.memory?.v3.live`), element
+ * access with a string literal (`config.memory["v3"]`), and destructuring in
+ * every position — declarations, assignments, parameters, and nested
+ * patterns. Comments and string, template, and regex literals are classified
+ * by the parser, so no literal reads as code or desyncs the walk. Dynamic
+ * computed keys (`memory[key]`) stay out of reach without a type-checker.
+ */
+function tierKeysRead(sourceText: string, fileName: string): Set<TierKey> {
+  const keys = new Set<TierKey>();
+
+  const readPattern = (
+    pattern: ObjectPattern,
+    source: ts.Expression | undefined,
+  ): void => {
+    if (source !== undefined && resolvesToMemory(source)) {
+      addTopLevelTierKeys(pattern, keys);
+    }
+    addNestedMemoryPatternKeys(pattern, keys);
   };
 
-  while (i < n) {
-    const c = source[i]!;
-    const next = source[i + 1];
-    if (c === "/" && next === "/") {
-      const end = source.indexOf("\n", i);
-      i = end === -1 ? n : end;
-      continue;
-    }
-    if (c === "/" && next === "*") {
-      const end = source.indexOf("*/", i + 2);
-      const stop = end === -1 ? n : end + 2;
-      keepNewlinesOf(source.slice(i, stop));
-      i = stop;
-      continue;
-    }
-    if (c === '"' || c === "'") {
-      const start = ++i;
-      while (i < n && source[i] !== c && source[i] !== "\n") {
-        i += source[i] === "\\" ? 2 : 1;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      resolvesToMemory(node.expression)
+    ) {
+      const key = node.name.text;
+      if (key === "v2" || key === "v3") {
+        keys.add(key);
       }
-      const content = source.slice(start, i);
-      if (source[i] === c) {
-        i++;
+    } else if (
+      ts.isElementAccessExpression(node) &&
+      resolvesToMemory(node.expression)
+    ) {
+      const key = literalText(node.argumentExpression);
+      if (key === "v2" || key === "v3") {
+        keys.add(key);
       }
-      // Tier-key literals stay so computed access survives stripping.
-      if (content === "v2" || content === "v3") {
-        out += `${c}${content}${c}`;
-      }
-      continue;
-    }
-    if (c === "`") {
-      i = scanTemplateContent(i + 1);
-      continue;
-    }
-    if (templateDepths.length > 0) {
-      if (c === "{") {
-        braceDepth++;
-      } else if (c === "}") {
-        if (braceDepth === 0) {
-          // Interpolation closed — resume the enclosing template literal.
-          braceDepth = templateDepths.pop()!;
-          i = scanTemplateContent(i + 1);
-          continue;
-        }
-        braceDepth--;
+    } else if (
+      (ts.isVariableDeclaration(node) ||
+        ts.isParameter(node) ||
+        ts.isBindingElement(node)) &&
+      ts.isObjectBindingPattern(node.name)
+    ) {
+      // A binding element's initializer is its default value — reading a
+      // tier key from it is still a raw read.
+      readPattern(node.name, node.initializer);
+    } else if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+    ) {
+      const target = unwrapExpression(node.left);
+      if (ts.isObjectLiteralExpression(target)) {
+        readPattern(target, node.right);
       }
     }
-    out += c;
-    i++;
-  }
-  return out;
-}
+    ts.forEachChild(node, visit);
+  };
 
-/** `memory.v2` / `memory.v3` property chain, incl. `config.memory?.v3?.live`. */
-const TIER_KEY_DOT_READ = /\bmemory\s*\??\.\s*(v[23])\b/g;
-
-/** Computed literal access — `config.memory["v3"]`, `memory?.['v2']`. */
-const TIER_KEY_COMPUTED_READ =
-  /\bmemory\s*(?:\?\.)?\s*\[\s*(['"])(v[23])\1\s*\]/g;
-
-/** A `const`/`let`/`var` destructuring declaration: pattern and its source. */
-const DESTRUCTURING_DECLARATION =
-  /\b(?:const|let|var)\s+(\{[\s\S]*?\})\s*=\s*([^;\n]+)/g;
-
-/** A right-hand side that is (a chain ending in) a `memory` object. */
-const DESTRUCTURED_FROM_MEMORY = /(?:^|\.)\s*memory\s*$/;
-
-/** A `memory: { ... }` sub-pattern inside a destructuring pattern. */
-const NESTED_MEMORY_PATTERN = /\bmemory\s*:\s*(\{[^{}]*\})/g;
-
-/** A tier key bound at the top level of an object pattern: `{ v2, v3: t }`. */
-const PATTERN_TIER_KEY = /[{,]\s*(v[23])\s*(?=[,:}=])/g;
-
-/**
- * Pattern text at the outermost brace depth, with nested groups blanked, so
- * only the keys destructured directly off the object are read.
- */
-function topLevelPatternContent(pattern: string): string {
-  let depth = 0;
-  let out = "";
-  for (const char of pattern) {
-    if (char === "{" || char === "[") {
-      depth++;
-      out += depth === 1 ? char : " ";
-      continue;
-    }
-    if (char === "}" || char === "]") {
-      out += depth === 1 ? char : " ";
-      depth--;
-      continue;
-    }
-    out += depth === 1 ? char : " ";
-  }
-  return out;
-}
-
-/**
- * Tier namespaces the stripped source reads: dot chains, computed literal
- * access, and destructuring off a `memory` object. Dynamic computed keys
- * (`memory[key]`) are out of reach of a lexer this size.
- */
-function tierKeysRead(stripped: string): Set<TierKey> {
-  const keys = new Set<TierKey>();
-  for (const match of stripped.matchAll(TIER_KEY_DOT_READ)) {
-    keys.add(match[1] as TierKey);
-  }
-  for (const match of stripped.matchAll(TIER_KEY_COMPUTED_READ)) {
-    keys.add(match[2] as TierKey);
-  }
-  for (const declaration of stripped.matchAll(DESTRUCTURING_DECLARATION)) {
-    const pattern = declaration[1]!;
-    const patterns: string[] = [];
-    if (DESTRUCTURED_FROM_MEMORY.test(declaration[2]!.trim())) {
-      patterns.push(topLevelPatternContent(pattern));
-    }
-    for (const nested of pattern.matchAll(NESTED_MEMORY_PATTERN)) {
-      patterns.push(nested[1]!);
-    }
-    for (const candidate of patterns) {
-      for (const key of candidate.matchAll(PATTERN_TIER_KEY)) {
-        keys.add(key[1] as TierKey);
-      }
-    }
-  }
+  ts.forEachChild(parseSourceFile(fileName, sourceText), visit);
   return keys;
 }
 
@@ -435,10 +492,8 @@ function collectTierKeyReaders(): Map<string, Set<TierKey>> {
   const readers = new Map<string, Set<TierKey>>();
   for (const file of productionFiles(join(process.cwd(), "src"))) {
     const posix = `src/${file}`;
-    const stripped = stripCommentsAndStrings(
-      readFileSync(join(process.cwd(), posix), "utf-8"),
-    );
-    const keys = tierKeysRead(stripped);
+    const absolute = join(process.cwd(), posix);
+    const keys = tierKeysRead(readFileSync(absolute, "utf-8"), absolute);
     if (keys.size > 0) {
       readers.set(posix, keys);
     }
@@ -448,6 +503,9 @@ function collectTierKeyReaders(): Map<string, Set<TierKey>> {
 
 describe("memory tier boundary guard", () => {
   const tierImports = collectTierImports();
+  // Scanned once and shared: the forward and reverse tier-key tests read the
+  // same snapshot of the tree.
+  const tierKeyReaders = collectTierKeyReaders();
 
   test("tier directories only import their allowed tiers", () => {
     const violations: string[] = [];
@@ -512,7 +570,7 @@ describe("memory tier boundary guard", () => {
 
   test("tier-key config reads are frozen to the gate module and exemptions", () => {
     const violations: string[] = [];
-    for (const [file, keys] of collectTierKeyReaders()) {
+    for (const [file, keys] of tierKeyReaders) {
       for (const key of [...keys].sort()) {
         if (!isTierKeyExempt(file, key)) {
           violations.push(`  - ${file} reads memory.${key}.*`);
@@ -534,7 +592,7 @@ describe("memory tier boundary guard", () => {
   });
 
   test("every tier-key exemption still has a matching tier-key read", () => {
-    const readers = collectTierKeyReaders();
+    const readers = tierKeyReaders;
     const stale: string[] = [];
     for (const entry of TIER_KEY_READ_ALLOWLIST) {
       for (const key of entry.keys) {
@@ -561,7 +619,7 @@ describe("memory tier boundary guard", () => {
 
 describe("tier-key read detection", () => {
   const keysOf = (source: string): TierKey[] =>
-    [...tierKeysRead(stripCommentsAndStrings(source))].sort();
+    [...tierKeysRead(source, "guard-fixture.ts")].sort();
 
   test("property chains are detected, with and without optional chaining", () => {
     expect(keysOf(`const on = config.memory.v2.enabled;`)).toEqual(["v2"]);
@@ -590,17 +648,41 @@ describe("tier-key read detection", () => {
     expect(keysOf(`const { memory: { v3 } } = config;`)).toEqual(["v3"]);
   });
 
+  test("destructuring is detected through wrappers and in every position", () => {
+    expect(keysOf(`const { v2 } = config.memory ?? {};`)).toEqual(["v2"]);
+    expect(keysOf(`const { v3 } = (config.memory as MemoryConfig)!;`)).toEqual([
+      "v3",
+    ]);
+    expect(keysOf(`({ v3 } = config.memory);`)).toEqual(["v3"]);
+    expect(keysOf(`({ memory: { v3 } } = config);`)).toEqual(["v3"]);
+    expect(keysOf(`function read({ v2 } = config.memory) {}`)).toEqual(["v2"]);
+    expect(keysOf(`try { run(); } catch ({ memory: { v3 } }) {}`)).toEqual([
+      "v3",
+    ]);
+  });
+
   test("string literals and comments are ignored", () => {
     expect(keysOf(`enqueue("memory.v2.sweep");`)).toEqual([]);
     expect(keysOf(`const job = { name: "memory.v2.sweep" };`)).toEqual([]);
+    expect(keysOf(`"memory.v2.sweep";`)).toEqual([]);
     expect(keysOf(`// falls back to memory.v2.k\nconst k = 1;`)).toEqual([]);
+    expect(keysOf(`// memory.v3.live gates injection\nconst x = 1;`)).toEqual(
+      [],
+    );
     expect(
       keysOf(`/** memory.v3.live gates injection */\nconst x = 1;`),
     ).toEqual([]);
     expect(keysOf("const label = `memory.v3.edge tuning`;")).toEqual([]);
   });
 
-  test("bare tier-key literals survive stripping without matching alone", () => {
+  test("a regex literal containing a quote cannot hide a read", () => {
+    expect(
+      keysOf(`const on = /"/.test(v) && config.memory.v2.enabled;`),
+    ).toEqual(["v2"]);
+    expect(keysOf(`const q = /"/.test(v);`)).toEqual([]);
+  });
+
+  test("bare tier-key literals do not match on their own", () => {
     expect(keysOf(`const tier = "v3";`)).toEqual([]);
     expect(keysOf(`log("v2", "memory.v2.sweep");`)).toEqual([]);
     expect(keysOf(`const t = pages["v2"];`)).toEqual([]);
@@ -621,5 +703,8 @@ describe("tier-key read detection", () => {
     expect(keysOf(`const x = inMemory.v2Cache;`)).toEqual([]);
     expect(keysOf(`const { v2 } = engines;`)).toEqual([]);
     expect(keysOf(`const { lanes: { v3 } } = registry;`)).toEqual([]);
+    expect(keysOf(`const seed = { memory: { v3: { live: true } } };`)).toEqual(
+      [],
+    );
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
@@ -30,18 +30,27 @@ import { Glob } from "bun";
  * `src/config/memory-v3-gate.ts` (from which `src/config/memory-tier.ts`
  * derives) and substrate tunables resolve via `substrate/tuning.ts`, so raw
  * tier-key reads outside the frozen {@link TIER_KEY_READ_ALLOWLIST} are a
- * layering leak. Detection strips comments and string/template literals
- * first (so job names like "memory.v2.sweep" and schema error strings do not
- * false-positive), then matches `memory.v2` / `memory.v3` property chains —
- * including optional chaining and reads inside template interpolations.
+ * layering leak. Each finding carries WHICH key it read, and every exemption
+ * is a (path, keys) pair — so the `v2/` engine stays exempt for `memory.v2`
+ * only and `v3/` for `memory.v3` only, matching the documented boundary that
+ * an engine reads its own tuning namespace and no other.
  *
- * Both allowlists carry a reverse "stale exemption" test so an entry whose
- * multi-tier import or tier-key read disappears fails loudly and gets
- * removed instead of lingering.
+ * Detection strips comments and string/template literals first (so job names
+ * like "memory.v2.sweep" and schema error strings do not false-positive),
+ * then matches three read forms: dot chains (`config.memory?.v3?.live`),
+ * computed literal access (`config.memory["v3"]`), and destructuring off a
+ * `memory` object (`const { v2 } = config.memory`, `const { memory: { v3 } }
+ * = config`). Bare `"v2"` / `"v3"` string literals survive stripping so
+ * computed access stays visible; every other literal is blanked.
+ *
+ * Both allowlists carry a reverse "stale exemption" test — per (path, keys)
+ * pair for tier keys — so an entry whose multi-tier import or tier-key read
+ * disappears fails loudly and gets removed instead of lingering.
  *
  * Tests run from `assistant/`, so paths resolve against `process.cwd()`.
- * Test files (`*.test.ts`, `__tests__/`) are out of scope — the boundary
- * guarded is the shipped runtime.
+ * Both `.ts` and `.tsx` production files are scanned (the assistant tsconfig
+ * ships both); test files (`*.test.ts`, `*.test.tsx`, `__tests__/`) are out
+ * of scope — the boundary guarded is the shipped runtime.
  */
 
 /** `assistant/src/plugins/defaults/memory`, relative to the `assistant/` cwd. */
@@ -78,42 +87,67 @@ const SPINE_ALLOWLIST: ReadonlySet<string> = new Set([
   "startup.ts",
 ]);
 
+/** The two tier config namespaces this guard tracks. */
+type TierKey = "v2" | "v3";
+
+interface TierKeyExemption {
+  /**
+   * Path relative to the `assistant/` cwd, posix-separated; a trailing `/`
+   * marks a directory prefix.
+   */
+  readonly path: string;
+  /** Tier namespaces this path may read — and only these. */
+  readonly keys: readonly TierKey[];
+}
+
 /**
- * Files allowed to read `memory.v2.*` / `memory.v3.*` config keys directly.
- * Paths are relative to the `assistant/` cwd, posix-separated; a trailing
- * `/` marks a directory prefix. Frozen — do not add: route new tier
- * decisions through `src/config/memory-v3-gate.ts` (or `memory-tier.ts`) and
- * new substrate tunables through `substrate/tuning.ts`; see the tier
- * deletion runbooks before touching this list.
+ * Files allowed to read `memory.v2.*` / `memory.v3.*` config keys directly,
+ * paired with the exact namespaces each may read. Frozen — do not add and do
+ * not widen an entry's keys: route new tier decisions through
+ * `src/config/memory-v3-gate.ts` (or `memory-tier.ts`) and new substrate
+ * tunables through `substrate/tuning.ts`; see the tier deletion runbooks
+ * before touching this list.
  *
- * - `config/memory-v3-gate.ts` — the gate module; the one sanctioned home
- *   for raw tier-predicate reads.
- * - `config/loader.ts` — seeds/normalizes the persisted `memory.v3` shape.
- * - `telemetry/config-setting-snapshot.ts` — reports tier keys as-is.
- * - migrations (persistence + workspace) — append-only history that rewrites
- *   or reads historical tier keys.
- * - `substrate/tuning.ts` — the substrate tunable resolver (`memory.v2`
- *   fallback lives here by design).
- * - `v2/`, `v3/` — each engine reads its own tier's tuning namespace.
- * - `graph/conversation-graph-memory.ts` — reads `memory.v2.router` for the
- *   all-tier dispatcher's historical-pairs routing.
- * - `graph-topology/build-memory-graph.ts` — reads `memory.v3.edge` tuning
- *   when building the graph view.
- * - `src/memory-v2-routes.ts` — the v2 tuning routes read and merge
+ * - `config/memory-v3-gate.ts` (both) — the gate module; the one sanctioned
+ *   home for raw tier-predicate reads, and it compares v2 against v3.
+ * - `config/loader.ts` (v3) — seeds/normalizes the persisted `memory.v3`
+ *   shape.
+ * - `telemetry/config-setting-snapshot.ts` (both) — reports both tier keys
+ *   as-is.
+ * - `persistence/migrations/` (v2), `workspace/migrations/` (both) —
+ *   append-only history that rewrites or reads historical tier keys.
+ * - `substrate/tuning.ts` (v2) — the substrate tunable resolver; the
+ *   substrate→`memory.v2` fallback lives here by design.
+ * - `v2/` (v2), `v3/` (v3) — each engine reads its own tuning namespace and
+ *   never the other engine's.
+ * - `graph/conversation-graph-memory.ts` (v2) — reads `memory.v2.router` for
+ *   the all-tier dispatcher's historical-pairs routing.
+ * - `graph-topology/build-memory-graph.ts` (v3) — reads `memory.v3.edge`
+ *   tuning when building the graph view.
+ * - `src/memory-v2-routes.ts` (v2) — the v2 tuning routes read and merge
  *   `memory.v2` config directly.
  */
-const TIER_KEY_READ_ALLOWLIST: readonly string[] = [
-  "src/config/loader.ts",
-  "src/config/memory-v3-gate.ts",
-  "src/persistence/migrations/",
-  "src/plugins/defaults/memory/graph-topology/build-memory-graph.ts",
-  "src/plugins/defaults/memory/graph/conversation-graph-memory.ts",
-  "src/plugins/defaults/memory/src/memory-v2-routes.ts",
-  "src/plugins/defaults/memory/substrate/tuning.ts",
-  "src/plugins/defaults/memory/v2/",
-  "src/plugins/defaults/memory/v3/",
-  "src/telemetry/config-setting-snapshot.ts",
-  "src/workspace/migrations/",
+const TIER_KEY_READ_ALLOWLIST: readonly TierKeyExemption[] = [
+  { path: "src/config/loader.ts", keys: ["v3"] },
+  { path: "src/config/memory-v3-gate.ts", keys: ["v2", "v3"] },
+  { path: "src/persistence/migrations/", keys: ["v2"] },
+  {
+    path: "src/plugins/defaults/memory/graph-topology/build-memory-graph.ts",
+    keys: ["v3"],
+  },
+  {
+    path: "src/plugins/defaults/memory/graph/conversation-graph-memory.ts",
+    keys: ["v2"],
+  },
+  {
+    path: "src/plugins/defaults/memory/src/memory-v2-routes.ts",
+    keys: ["v2"],
+  },
+  { path: "src/plugins/defaults/memory/substrate/tuning.ts", keys: ["v2"] },
+  { path: "src/plugins/defaults/memory/v2/", keys: ["v2"] },
+  { path: "src/plugins/defaults/memory/v3/", keys: ["v3"] },
+  { path: "src/telemetry/config-setting-snapshot.ts", keys: ["v2", "v3"] },
+  { path: "src/workspace/migrations/", keys: ["v2", "v3"] },
 ];
 
 /** Matches `import ... from "X"`, `export ... from "X"`, `import("X")`,
@@ -131,12 +165,20 @@ function tierOf(relToMem: string): Tier | "spine" {
     : "spine";
 }
 
-/** Production `.ts` files under `root`, posix-relative, tests excluded. */
+/**
+ * Production `.ts`/`.tsx` files under `root`, posix-relative, tests excluded.
+ * TSX ships too (the assistant tsconfig includes TSX under `src/`), so it is
+ * scanned alongside TS.
+ */
 function productionFiles(root: string): string[] {
   const files: string[] = [];
-  for (const rel of new Glob("**/*.ts").scanSync({ cwd: root })) {
+  for (const rel of new Glob("**/*.{ts,tsx}").scanSync({ cwd: root })) {
     const posix = rel.split("\\").join("/");
-    if (posix.endsWith(".test.ts") || posix.split("/").includes("__tests__")) {
+    if (
+      posix.endsWith(".test.ts") ||
+      posix.endsWith(".test.tsx") ||
+      posix.split("/").includes("__tests__")
+    ) {
       continue;
     }
     files.push(posix);
@@ -203,11 +245,14 @@ function spineTierUsage(imports: TierImport[]): Map<string, Set<Tier>> {
 
 /**
  * Source with comments and string/template literals blanked out, so tier-key
- * matching only sees executable property chains. Line structure is
- * preserved. Template interpolations (`${...}`) are kept — they are code —
- * via a mode stack that tracks nested templates and interpolation braces.
- * Regex literals are not lexed; single/double-quoted string skipping stops
- * at end-of-line so a quote inside a regex desyncs at most one line.
+ * matching only sees executable property chains. Bare `"v2"` / `"v3"`
+ * literals survive verbatim — they are the key half of computed access
+ * (`config.memory["v3"]`) — while every other literal, including compound
+ * names like "memory.v2.sweep", is dropped. Line structure is preserved.
+ * Template interpolations (`${...}`) are kept — they are code — via a mode
+ * stack that tracks nested templates and interpolation braces. Regex
+ * literals are not lexed; single/double-quoted string skipping stops at
+ * end-of-line so a quote inside a regex desyncs at most one line.
  */
 function stripCommentsAndStrings(source: string): string {
   let out = "";
@@ -265,12 +310,17 @@ function stripCommentsAndStrings(source: string): string {
       continue;
     }
     if (c === '"' || c === "'") {
-      i++;
+      const start = ++i;
       while (i < n && source[i] !== c && source[i] !== "\n") {
         i += source[i] === "\\" ? 2 : 1;
       }
+      const content = source.slice(start, i);
       if (source[i] === c) {
         i++;
+      }
+      // Tier-key literals stay so computed access survives stripping.
+      if (content === "v2" || content === "v3") {
+        out += `${c}${content}${c}`;
       }
       continue;
     }
@@ -297,26 +347,100 @@ function stripCommentsAndStrings(source: string): string {
   return out;
 }
 
-/** Matches a `memory.v2` / `memory.v3` property chain, including optional
- *  chaining (`config.memory?.v3?.live`). Runs on stripped source only. */
-const TIER_KEY_READ = /\bmemory\s*\??\.\s*v[23]\b/;
+/** `memory.v2` / `memory.v3` property chain, incl. `config.memory?.v3?.live`. */
+const TIER_KEY_DOT_READ = /\bmemory\s*\??\.\s*(v[23])\b/g;
 
-function isTierKeyExempt(file: string): boolean {
-  return TIER_KEY_READ_ALLOWLIST.some((entry) =>
-    entry.endsWith("/") ? file.startsWith(entry) : file === entry,
+/** Computed literal access — `config.memory["v3"]`, `memory?.['v2']`. */
+const TIER_KEY_COMPUTED_READ =
+  /\bmemory\s*(?:\?\.)?\s*\[\s*(['"])(v[23])\1\s*\]/g;
+
+/** A `const`/`let`/`var` destructuring declaration: pattern and its source. */
+const DESTRUCTURING_DECLARATION =
+  /\b(?:const|let|var)\s+(\{[\s\S]*?\})\s*=\s*([^;\n]+)/g;
+
+/** A right-hand side that is (a chain ending in) a `memory` object. */
+const DESTRUCTURED_FROM_MEMORY = /(?:^|\.)\s*memory\s*$/;
+
+/** A `memory: { ... }` sub-pattern inside a destructuring pattern. */
+const NESTED_MEMORY_PATTERN = /\bmemory\s*:\s*(\{[^{}]*\})/g;
+
+/** A tier key bound at the top level of an object pattern: `{ v2, v3: t }`. */
+const PATTERN_TIER_KEY = /[{,]\s*(v[23])\s*(?=[,:}=])/g;
+
+/**
+ * Pattern text at the outermost brace depth, with nested groups blanked, so
+ * only the keys destructured directly off the object are read.
+ */
+function topLevelPatternContent(pattern: string): string {
+  let depth = 0;
+  let out = "";
+  for (const char of pattern) {
+    if (char === "{" || char === "[") {
+      depth++;
+      out += depth === 1 ? char : " ";
+      continue;
+    }
+    if (char === "}" || char === "]") {
+      out += depth === 1 ? char : " ";
+      depth--;
+      continue;
+    }
+    out += depth === 1 ? char : " ";
+  }
+  return out;
+}
+
+/**
+ * Tier namespaces the stripped source reads: dot chains, computed literal
+ * access, and destructuring off a `memory` object. Dynamic computed keys
+ * (`memory[key]`) are out of reach of a lexer this size.
+ */
+function tierKeysRead(stripped: string): Set<TierKey> {
+  const keys = new Set<TierKey>();
+  for (const match of stripped.matchAll(TIER_KEY_DOT_READ)) {
+    keys.add(match[1] as TierKey);
+  }
+  for (const match of stripped.matchAll(TIER_KEY_COMPUTED_READ)) {
+    keys.add(match[2] as TierKey);
+  }
+  for (const declaration of stripped.matchAll(DESTRUCTURING_DECLARATION)) {
+    const pattern = declaration[1]!;
+    const patterns: string[] = [];
+    if (DESTRUCTURED_FROM_MEMORY.test(declaration[2]!.trim())) {
+      patterns.push(topLevelPatternContent(pattern));
+    }
+    for (const nested of pattern.matchAll(NESTED_MEMORY_PATTERN)) {
+      patterns.push(nested[1]!);
+    }
+    for (const candidate of patterns) {
+      for (const key of candidate.matchAll(PATTERN_TIER_KEY)) {
+        keys.add(key[1] as TierKey);
+      }
+    }
+  }
+  return keys;
+}
+
+function isTierKeyExempt(file: string, key: TierKey): boolean {
+  return TIER_KEY_READ_ALLOWLIST.some(
+    (entry) =>
+      (entry.path.endsWith("/")
+        ? file.startsWith(entry.path)
+        : file === entry.path) && entry.keys.includes(key),
   );
 }
 
-/** Production files under `src/` with a tier-key config read, sorted. */
-function collectTierKeyReaders(): string[] {
-  const readers: string[] = [];
+/** Production files under `src/` mapped to the tier keys each one reads. */
+function collectTierKeyReaders(): Map<string, Set<TierKey>> {
+  const readers = new Map<string, Set<TierKey>>();
   for (const file of productionFiles(join(process.cwd(), "src"))) {
     const posix = `src/${file}`;
     const stripped = stripCommentsAndStrings(
       readFileSync(join(process.cwd(), posix), "utf-8"),
     );
-    if (TIER_KEY_READ.test(stripped)) {
-      readers.push(posix);
+    const keys = tierKeysRead(stripped);
+    if (keys.size > 0) {
+      readers.set(posix, keys);
     }
   }
   return readers;
@@ -387,12 +511,19 @@ describe("memory tier boundary guard", () => {
   });
 
   test("tier-key config reads are frozen to the gate module and exemptions", () => {
-    const violations = collectTierKeyReaders()
-      .filter((file) => !isTierKeyExempt(file))
-      .map((file) => `  - ${file}`);
+    const violations: string[] = [];
+    for (const [file, keys] of collectTierKeyReaders()) {
+      for (const key of [...keys].sort()) {
+        if (!isTierKeyExempt(file, key)) {
+          violations.push(`  - ${file} reads memory.${key}.*`);
+        }
+      }
+    }
+    violations.sort();
     const message = [
       "New memory.v2.* / memory.v3.* config reads outside the frozen",
-      "TIER_KEY_READ_ALLOWLIST:",
+      "TIER_KEY_READ_ALLOWLIST (an engine directory is exempt for its own",
+      "tier key only):",
       ...violations,
       "",
       "Tier decisions go through src/config/memory-v3-gate.ts (or",
@@ -402,20 +533,26 @@ describe("memory tier boundary guard", () => {
     expect(violations, message).toEqual([]);
   });
 
-  test("every tier-key exemption still has a tier-key read", () => {
+  test("every tier-key exemption still has a matching tier-key read", () => {
     const readers = collectTierKeyReaders();
     const stale: string[] = [];
     for (const entry of TIER_KEY_READ_ALLOWLIST) {
-      const matched = entry.endsWith("/")
-        ? readers.some((file) => file.startsWith(entry))
-        : readers.includes(entry);
-      if (!matched) {
-        stale.push(`  - ${entry}`);
+      for (const key of entry.keys) {
+        const matched = [...readers].some(
+          ([file, keys]) =>
+            (entry.path.endsWith("/")
+              ? file.startsWith(entry.path)
+              : file === entry.path) && keys.has(key),
+        );
+        if (!matched) {
+          stale.push(`  - ${entry.path} (memory.${key}.*)`);
+        }
       }
     }
+    stale.sort();
     const message = [
-      "Stale TIER_KEY_READ_ALLOWLIST entries (no tier-key read matches —",
-      "remove them so the freeze stays tight):",
+      "Stale TIER_KEY_READ_ALLOWLIST (path, key) pairs (no tier-key read",
+      "matches — remove them so the freeze stays tight):",
       ...stale,
     ].join("\n");
     expect(stale, message).toEqual([]);
@@ -423,35 +560,66 @@ describe("memory tier boundary guard", () => {
 });
 
 describe("tier-key read detection", () => {
-  const detects = (source: string): boolean =>
-    TIER_KEY_READ.test(stripCommentsAndStrings(source));
+  const keysOf = (source: string): TierKey[] =>
+    [...tierKeysRead(stripCommentsAndStrings(source))].sort();
 
   test("property chains are detected, with and without optional chaining", () => {
-    expect(detects(`const on = config.memory.v2.enabled;`)).toBe(true);
-    expect(detects(`return config.memory?.v3?.live === true;`)).toBe(true);
-    expect(detects(`seed.memory.v3 = { live: seed.memory.v3.live };`)).toBe(
-      true,
-    );
+    expect(keysOf(`const on = config.memory.v2.enabled;`)).toEqual(["v2"]);
+    expect(keysOf(`return config.memory?.v3?.live === true;`)).toEqual(["v3"]);
+    expect(keysOf(`seed.memory.v3 = { live: seed.memory.v3.live };`)).toEqual([
+      "v3",
+    ]);
+  });
+
+  test("computed literal access is detected", () => {
+    expect(keysOf(`const live = config.memory["v3"].live;`)).toEqual(["v3"]);
+    expect(keysOf(`const k = config.memory['v2'].k;`)).toEqual(["v2"]);
+    expect(keysOf(`const live = config.memory?.["v3"]?.live;`)).toEqual(["v3"]);
+    expect(keysOf(`const both = [memory["v2"], memory["v3"]];`)).toEqual([
+      "v2",
+      "v3",
+    ]);
+  });
+
+  test("destructuring off a memory object is detected", () => {
+    expect(keysOf(`const { v2 } = config.memory;`)).toEqual(["v2"]);
+    expect(keysOf(`const { v3: tuning } = getConfig().memory;`)).toEqual([
+      "v3",
+    ]);
+    expect(keysOf(`const { v2, v3 } = config?.memory;`)).toEqual(["v2", "v3"]);
+    expect(keysOf(`const { memory: { v3 } } = config;`)).toEqual(["v3"]);
   });
 
   test("string literals and comments are ignored", () => {
-    expect(detects(`enqueue("memory.v2.sweep");`)).toBe(false);
-    expect(detects(`// falls back to memory.v2.k\nconst k = 1;`)).toBe(false);
-    expect(detects(`/** memory.v3.live gates injection */\nconst x = 1;`)).toBe(
-      false,
-    );
-    expect(detects("const label = `memory.v3.edge tuning`;")).toBe(false);
+    expect(keysOf(`enqueue("memory.v2.sweep");`)).toEqual([]);
+    expect(keysOf(`const job = { name: "memory.v2.sweep" };`)).toEqual([]);
+    expect(keysOf(`// falls back to memory.v2.k\nconst k = 1;`)).toEqual([]);
+    expect(
+      keysOf(`/** memory.v3.live gates injection */\nconst x = 1;`),
+    ).toEqual([]);
+    expect(keysOf("const label = `memory.v3.edge tuning`;")).toEqual([]);
+  });
+
+  test("bare tier-key literals survive stripping without matching alone", () => {
+    expect(keysOf(`const tier = "v3";`)).toEqual([]);
+    expect(keysOf(`log("v2", "memory.v2.sweep");`)).toEqual([]);
+    expect(keysOf(`const t = pages["v2"];`)).toEqual([]);
   });
 
   test("reads inside template interpolations are detected", () => {
-    expect(detects("const msg = `k=${config.memory.v2.k}`;")).toBe(true);
+    expect(keysOf("const msg = `k=${config.memory.v2.k}`;")).toEqual(["v2"]);
     expect(
-      detects("const msg = `memory.v3.live=${config.memory?.v3?.live}`;"),
-    ).toBe(true);
+      keysOf("const msg = `memory.v3.live=${config.memory?.v3?.live}`;"),
+    ).toEqual(["v3"]);
+    expect(keysOf('const msg = `live=${config.memory["v3"].live}`;')).toEqual([
+      "v3",
+    ]);
   });
 
   test("unrelated identifiers do not match", () => {
-    expect(detects(`const memoryV2 = loadV2();`)).toBe(false);
-    expect(detects(`const x = inMemory.v2Cache;`)).toBe(false);
+    expect(keysOf(`const memoryV2 = loadV2();`)).toEqual([]);
+    expect(keysOf(`const x = inMemory.v2Cache;`)).toEqual([]);
+    expect(keysOf(`const { v2 } = engines;`)).toEqual([]);
+    expect(keysOf(`const { lanes: { v3 } } = registry;`)).toEqual([]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
@@ -36,14 +36,25 @@ import ts from "typescript";
  * only and `v3/` for `memory.v3` only, matching the documented boundary that
  * an engine reads its own tuning namespace and no other.
  *
- * Detection parses each production file into a TypeScript AST
- * (`ts.createSourceFile`, no type-checker) and walks it for reads off a
- * `memory` object: property access including optional chaining
- * (`config.memory?.v3.live`), element access with a string literal
- * (`config.memory["v3"]`), and destructuring in any position — variable
- * declarations (`const { v2 } = config.memory ?? {}`), assignments
+ * Both guards read one TypeScript AST per file (`ts.createSourceFile`, no
+ * type-checker): {@link scanProductionSources} parses every production file
+ * under `src/` once and hands each guard the projection it needs, so a file
+ * inside the memory plugin is never parsed twice.
+ *
+ * Guard 1 collects module specifiers from the AST — `import`/`export ... from`
+ * (including `import type`), `import x = require("…")`, dynamic `import("…")`,
+ * `require("…")`, and type-position `import("…").Foo` — so import-shaped text
+ * in a comment or string literal can neither invent an edge nor hide a real
+ * one.
+ *
+ * Guard 2 walks the AST for reads off a `memory` object: property access
+ * including optional chaining (`config.memory?.v3.live`), element access with
+ * a string literal (`config.memory["v3"]`), and destructuring in any position
+ * — variable declarations (`const { v2 } = config.memory ?? {}`), assignments
  * (`({ v3 } = config.memory)`), function and catch parameters, and nested
- * patterns (`const { memory: { v3 } } = config`). The parser classifies
+ * patterns (`const { memory: { v3 } } = config`). Identifiers aliased to a
+ * memory object (`const memoryConfig = getConfig().memory`) count as memory
+ * objects too — see {@link collectMemoryAliases}. The parser classifies
  * comments and string, template, and regex literals for us, so job names
  * like "memory.v2.sweep" and doc comments never false-positive and no
  * literal can desync the scan.
@@ -58,9 +69,12 @@ import ts from "typescript";
  * of scope — the boundary guarded is the shipped runtime.
  */
 
-/** `assistant/src/plugins/defaults/memory`, relative to the `assistant/` cwd. */
-const MEM_REL = join("src", "plugins", "defaults", "memory");
-const MEM_ABS = join(process.cwd(), MEM_REL);
+/**
+ * `assistant/src/plugins/defaults/memory`, relative to the `assistant/` cwd
+ * and posix-separated (every path this guard compares is posix).
+ */
+const MEM_REL = "src/plugins/defaults/memory";
+const MEM_ABS = join(process.cwd(), ...MEM_REL.split("/"));
 
 const TIER_DIRS = ["substrate", "v1", "v2", "v3", "v3-eval"] as const;
 type Tier = (typeof TIER_DIRS)[number];
@@ -155,13 +169,6 @@ const TIER_KEY_READ_ALLOWLIST: readonly TierKeyExemption[] = [
   { path: "src/workspace/migrations/", keys: ["v2", "v3"] },
 ];
 
-/** Matches `import ... from "X"`, `export ... from "X"`, `import("X")`,
- *  `require("X")`, and side-effect `import "X"` — including multi-line forms,
- *  since the between-keyword-and-`from` span never contains a quote. */
-function importSpecifierRegex(): RegExp {
-  return /(?:import|export)\b[^'"]*?from\s*['"]([^'"]+)['"]|(?:import|require)\(\s*['"]([^'"]+)['"]\s*\)|^\s*import\s+['"]([^'"]+)['"]/gm;
-}
-
 /** Tier directory a plugin-root-relative path lives in, or `"spine"`. */
 function tierOf(relToMem: string): Tier | "spine" {
   const first = relToMem.split("/")[0]!;
@@ -200,16 +207,17 @@ interface TierImport {
 }
 
 /** Every intra-plugin import that lands in a tier directory. */
-function collectTierImports(): TierImport[] {
+function collectTierImports(sources: readonly ScannedSource[]): TierImport[] {
   const imports: TierImport[] = [];
-  for (const file of productionFiles(MEM_ABS)) {
-    const absPath = join(MEM_ABS, file);
-    const source = readFileSync(absPath, "utf-8");
-    const regex = importSpecifierRegex();
-    let match: RegExpExecArray | null;
-    while ((match = regex.exec(source)) !== null) {
-      const specifier = match[1] ?? match[2] ?? match[3];
-      if (!specifier || !specifier.startsWith(".")) {
+  const memPrefix = `${MEM_REL}/`;
+  for (const source of sources) {
+    if (!source.path.startsWith(memPrefix)) {
+      continue;
+    }
+    const file = source.path.slice(memPrefix.length);
+    const absPath = join(MEM_ABS, ...file.split("/"));
+    for (const specifier of source.specifiers) {
+      if (!specifier.startsWith(".")) {
         continue;
       }
       const resolved = resolve(dirname(absPath), specifier);
@@ -292,6 +300,52 @@ function literalText(node: ts.Node | undefined): string | undefined {
     : undefined;
 }
 
+/**
+ * Module specifiers a file depends on, taken from the AST: `import ... from`
+ * and re-exporting `export ... from` declarations, `import x = require("…")`,
+ * dynamic `import("…")`, `require("…")`, and type-position
+ * `import("…").Foo`. Type-only imports count — the guard freezes layering,
+ * not emitted code, and a `v3/` file importing a `v1/` type is still a tier
+ * edge. Only string-literal specifiers are collected; a computed
+ * `import(path)` has no static target to attribute.
+ */
+function importSpecifiers(sourceFile: ts.SourceFile): string[] {
+  const specifiers: string[] = [];
+  const add = (node: ts.Node | undefined): void => {
+    const text = literalText(node);
+    if (text !== undefined) {
+      specifiers.push(text);
+    }
+  };
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      // An `export { x }` with no module specifier is not an edge.
+      add(node.moduleSpecifier);
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference)
+    ) {
+      add(node.moduleReference.expression);
+    } else if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      const isImportCall = callee.kind === ts.SyntaxKind.ImportKeyword;
+      const isRequireCall =
+        ts.isIdentifier(callee) && callee.text === "require";
+      if (isImportCall || isRequireCall) {
+        add(node.arguments[0]);
+      }
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument)
+    ) {
+      add(node.argument.literal);
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return specifiers;
+}
+
 /** Static name of a property or binding name, or `undefined` if computed. */
 function staticNameText(
   name: ts.PropertyName | ts.BindingName | undefined,
@@ -311,13 +365,17 @@ function staticNameText(
 
 /**
  * Whether an expression resolves to a `memory` object: a bare `memory`
- * identifier, any `.memory` / `["memory"]` access, or either arm of a
- * `??`/`||` fallback or a conditional (`config.memory ?? {}`).
+ * identifier or a known `aliases` identifier, any `.memory` / `["memory"]`
+ * access, or either arm of a `??`/`||` fallback or a conditional
+ * (`config.memory ?? {}`).
  */
-function resolvesToMemory(node: ts.Expression): boolean {
+function resolvesToMemory(
+  node: ts.Expression,
+  aliases: ReadonlySet<string>,
+): boolean {
   const expr = unwrapExpression(node);
   if (ts.isIdentifier(expr)) {
-    return expr.text === "memory";
+    return expr.text === "memory" || aliases.has(expr.text);
   }
   if (ts.isPropertyAccessExpression(expr)) {
     return expr.name.text === "memory";
@@ -330,12 +388,95 @@ function resolvesToMemory(node: ts.Expression): boolean {
     (expr.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken ||
       expr.operatorToken.kind === ts.SyntaxKind.BarBarToken)
   ) {
-    return resolvesToMemory(expr.left) || resolvesToMemory(expr.right);
+    return (
+      resolvesToMemory(expr.left, aliases) ||
+      resolvesToMemory(expr.right, aliases)
+    );
   }
   if (ts.isConditionalExpression(expr)) {
-    return resolvesToMemory(expr.whenTrue) || resolvesToMemory(expr.whenFalse);
+    return (
+      resolvesToMemory(expr.whenTrue, aliases) ||
+      resolvesToMemory(expr.whenFalse, aliases)
+    );
   }
   return false;
+}
+
+/** A binding that may name a `memory` object. */
+interface AliasCandidate {
+  /** Identifier the binding introduces. */
+  readonly name: string;
+  /** Initializer (or default value) the binding takes, if any. */
+  readonly initializer: ts.Expression | undefined;
+  /** Whether the binding destructures a `memory` property off its source. */
+  readonly fromMemoryProperty: boolean;
+}
+
+/** Every identifier binding in a file that could name a `memory` object. */
+function aliasCandidates(sourceFile: ts.SourceFile): AliasCandidate[] {
+  const candidates: AliasCandidate[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isVariableDeclaration(node) ||
+        ts.isParameter(node) ||
+        ts.isBindingElement(node)) &&
+      ts.isIdentifier(node.name)
+    ) {
+      candidates.push({
+        name: node.name.text,
+        initializer: node.initializer,
+        fromMemoryProperty:
+          ts.isBindingElement(node) &&
+          staticNameText(node.propertyName ?? node.name) === "memory",
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return candidates;
+}
+
+/**
+ * Identifiers a file binds to a `memory` config object, so later reads through
+ * the alias are seen: `const memoryConfig = getConfig().memory` (the shape
+ * `workspace/migrations/105-enable-memory-v3-live-for-new-workspaces.ts`
+ * uses), `const m = config.memory ?? {}`, `const { memory: m } = config`, and
+ * a parameter defaulted to any of those. Aliases of aliases resolve too — the
+ * pass iterates to a fixed point, so `const a = config.memory; const b = a;`
+ * makes both `a` and `b` memory objects.
+ *
+ * The set is file-level and scope-free on purpose: an inner scope that
+ * shadows an alias name with something unrelated is deliberately still
+ * treated as the alias. That over-detects rather than under-detects, which is
+ * the safe direction for a freeze guard — the cost of a shadowed name is one
+ * exemption discussion, while missing an aliased read is a silent layering
+ * leak. Reassignment (`let m; m = config.memory;`) is out of scope; use a
+ * declaration.
+ */
+function collectMemoryAliases(sourceFile: ts.SourceFile): Set<string> {
+  const candidates = aliasCandidates(sourceFile);
+  const aliases = new Set<string>();
+  for (const candidate of candidates) {
+    if (candidate.fromMemoryProperty) {
+      aliases.add(candidate.name);
+    }
+  }
+  // Alias chains resolve in any declaration order, so iterate until the set
+  // stops growing (bounded by the number of candidates).
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const candidate of candidates) {
+      if (aliases.has(candidate.name) || candidate.initializer === undefined) {
+        continue;
+      }
+      if (resolvesToMemory(candidate.initializer, aliases)) {
+        aliases.add(candidate.name);
+        grew = true;
+      }
+    }
+  }
+  return aliases;
 }
 
 /** Assignment-pattern target with its parentheses and `= default` removed. */
@@ -419,18 +560,22 @@ function addNestedMemoryPatternKeys(
  * its TypeScript AST: property access (`config.memory?.v3.live`), element
  * access with a string literal (`config.memory["v3"]`), and destructuring in
  * every position — declarations, assignments, parameters, and nested
- * patterns. Comments and string, template, and regex literals are classified
- * by the parser, so no literal reads as code or desyncs the walk. Dynamic
- * computed keys (`memory[key]`) stay out of reach without a type-checker.
+ * patterns. Identifiers aliased to a memory object count as memory objects
+ * (see {@link collectMemoryAliases}), so `alias.v3.live`, `alias["v2"]`, and
+ * `const { v3 } = alias` are all reads. Comments and string, template, and
+ * regex literals are classified by the parser, so no literal reads as code or
+ * desyncs the walk. Dynamic computed keys (`memory[key]`) stay out of reach
+ * without a type-checker.
  */
-function tierKeysRead(sourceText: string, fileName: string): Set<TierKey> {
+function tierKeysOf(sourceFile: ts.SourceFile): Set<TierKey> {
   const keys = new Set<TierKey>();
+  const aliases = collectMemoryAliases(sourceFile);
 
   const readPattern = (
     pattern: ObjectPattern,
     source: ts.Expression | undefined,
   ): void => {
-    if (source !== undefined && resolvesToMemory(source)) {
+    if (source !== undefined && resolvesToMemory(source, aliases)) {
       addTopLevelTierKeys(pattern, keys);
     }
     addNestedMemoryPatternKeys(pattern, keys);
@@ -439,7 +584,7 @@ function tierKeysRead(sourceText: string, fileName: string): Set<TierKey> {
   const visit = (node: ts.Node): void => {
     if (
       ts.isPropertyAccessExpression(node) &&
-      resolvesToMemory(node.expression)
+      resolvesToMemory(node.expression, aliases)
     ) {
       const key = node.name.text;
       if (key === "v2" || key === "v3") {
@@ -447,7 +592,7 @@ function tierKeysRead(sourceText: string, fileName: string): Set<TierKey> {
       }
     } else if (
       ts.isElementAccessExpression(node) &&
-      resolvesToMemory(node.expression)
+      resolvesToMemory(node.expression, aliases)
     ) {
       const key = literalText(node.argumentExpression);
       if (key === "v2" || key === "v3") {
@@ -474,7 +619,7 @@ function tierKeysRead(sourceText: string, fileName: string): Set<TierKey> {
     ts.forEachChild(node, visit);
   };
 
-  ts.forEachChild(parseSourceFile(fileName, sourceText), visit);
+  ts.forEachChild(sourceFile, visit);
   return keys;
 }
 
@@ -488,24 +633,65 @@ function isTierKeyExempt(file: string, key: TierKey): boolean {
 }
 
 /** Production files under `src/` mapped to the tier keys each one reads. */
-function collectTierKeyReaders(): Map<string, Set<TierKey>> {
+function collectTierKeyReaders(
+  sources: readonly ScannedSource[],
+): Map<string, Set<TierKey>> {
   const readers = new Map<string, Set<TierKey>>();
-  for (const file of productionFiles(join(process.cwd(), "src"))) {
-    const posix = `src/${file}`;
-    const absolute = join(process.cwd(), posix);
-    const keys = tierKeysRead(readFileSync(absolute, "utf-8"), absolute);
-    if (keys.size > 0) {
-      readers.set(posix, keys);
+  for (const source of sources) {
+    if (source.tierKeys.size > 0) {
+      readers.set(source.path, source.tierKeys);
     }
   }
   return readers;
 }
 
+/** One production source file, parsed once and projected for both guards. */
+interface ScannedSource {
+  /** Path relative to the `assistant/` cwd, posix-separated. */
+  readonly path: string;
+  /**
+   * Module specifiers this file imports, re-exports, or requires — collected
+   * only for files inside the memory plugin, the only ones guard 1 attributes
+   * a tier edge to.
+   */
+  readonly specifiers: readonly string[];
+  /** Tier namespaces this file reads off a `memory` object. */
+  readonly tierKeys: Set<TierKey>;
+}
+
+/**
+ * Every production file under `src/`, parsed once. Both guards read this one
+ * pass — the memory plugin's files are a subset of it, so no file is parsed
+ * twice.
+ */
+function scanProductionSources(): ScannedSource[] {
+  const srcRoot = join(process.cwd(), "src");
+  const memPrefix = `${MEM_REL}/`;
+  const sources: ScannedSource[] = [];
+  for (const file of productionFiles(srcRoot)) {
+    const path = `src/${file}`;
+    const absolute = join(srcRoot, ...file.split("/"));
+    const sourceFile = parseSourceFile(
+      absolute,
+      readFileSync(absolute, "utf-8"),
+    );
+    sources.push({
+      path,
+      specifiers: path.startsWith(memPrefix)
+        ? importSpecifiers(sourceFile)
+        : [],
+      tierKeys: tierKeysOf(sourceFile),
+    });
+  }
+  return sources;
+}
+
 describe("memory tier boundary guard", () => {
-  const tierImports = collectTierImports();
-  // Scanned once and shared: the forward and reverse tier-key tests read the
-  // same snapshot of the tree.
-  const tierKeyReaders = collectTierKeyReaders();
+  // Parsed once and shared: every guard test reads the same snapshot of the
+  // tree, and no file is parsed twice.
+  const sources = scanProductionSources();
+  const tierImports = collectTierImports(sources);
+  const tierKeyReaders = collectTierKeyReaders(sources);
 
   test("tier directories only import their allowed tiers", () => {
     const violations: string[] = [];
@@ -619,7 +805,7 @@ describe("memory tier boundary guard", () => {
 
 describe("tier-key read detection", () => {
   const keysOf = (source: string): TierKey[] =>
-    [...tierKeysRead(source, "guard-fixture.ts")].sort();
+    [...tierKeysOf(parseSourceFile("guard-fixture.ts", source))].sort();
 
   test("property chains are detected, with and without optional chaining", () => {
     expect(keysOf(`const on = config.memory.v2.enabled;`)).toEqual(["v2"]);
@@ -706,5 +892,108 @@ describe("tier-key read detection", () => {
     expect(keysOf(`const seed = { memory: { v3: { live: true } } };`)).toEqual(
       [],
     );
+  });
+
+  test("reads through an aliased memory object are detected", () => {
+    expect(
+      keysOf(`const memoryConfig = getConfig().memory;\nmemoryConfig.v3.live;`),
+    ).toEqual(["v3"]);
+    expect(
+      keysOf(`const m = config.memory ?? {};\nconst k = m["v2"].k;`),
+    ).toEqual(["v2"]);
+    expect(keysOf(`const m = config.memory;\nconst { v3 } = m;`)).toEqual([
+      "v3",
+    ]);
+    expect(keysOf(`const { memory: m } = config;\nm.v2.enabled;`)).toEqual([
+      "v2",
+    ]);
+    expect(
+      keysOf(`function read(m = config.memory) { return m.v3.live; }`),
+    ).toEqual(["v3"]);
+    // The migration-105 shape: cast, then re-alias the cast.
+    expect(
+      keysOf(
+        `const memory = config.memory;\nconst memoryConfig = memory as Record<string, unknown>;\nif (memoryConfig.v3 === undefined) memoryConfig.v3 = {};`,
+      ),
+    ).toEqual(["v3"]);
+  });
+
+  test("alias chains resolve in any declaration order", () => {
+    expect(keysOf(`const a = config.memory;\nconst b = a;\nb.v2.k;`)).toEqual([
+      "v2",
+    ]);
+    expect(
+      keysOf(
+        `function f() { return b.v3.live; }\nconst b = a;\nconst a = m.memory;`,
+      ),
+    ).toEqual(["v3"]);
+  });
+
+  test("aliases of unrelated objects do not match", () => {
+    expect(keysOf(`const cfg = getConfig();\nconst k = cfg.v2;`)).toEqual([]);
+    expect(keysOf(`const store = memories.byId;\nstore.v3.live;`)).toEqual([]);
+  });
+});
+
+describe("import specifier detection", () => {
+  const specifiersOf = (source: string): string[] =>
+    importSpecifiers(parseSourceFile("guard-fixture.ts", source)).sort();
+
+  test("every import form is collected", () => {
+    expect(specifiersOf(`import { a } from "./v1/a.js";`)).toEqual([
+      "./v1/a.js",
+    ]);
+    expect(specifiersOf(`import "./v1/side-effect.js";`)).toEqual([
+      "./v1/side-effect.js",
+    ]);
+    expect(specifiersOf(`import type { A } from "./v1/types.js";`)).toEqual([
+      "./v1/types.js",
+    ]);
+    expect(specifiersOf(`export { a } from "./v2/a.js";`)).toEqual([
+      "./v2/a.js",
+    ]);
+    expect(specifiersOf(`export * from "./v2/all.js";`)).toEqual([
+      "./v2/all.js",
+    ]);
+    expect(specifiersOf(`const m = await import("./v3/lazy.js");`)).toEqual([
+      "./v3/lazy.js",
+    ]);
+    expect(specifiersOf(`const m = require("./v3/legacy.js");`)).toEqual([
+      "./v3/legacy.js",
+    ]);
+    expect(specifiersOf(`import a = require("./v1/legacy.js");`)).toEqual([
+      "./v1/legacy.js",
+    ]);
+    expect(specifiersOf(`type A = import("./v1/types.js").A;`)).toEqual([
+      "./v1/types.js",
+    ]);
+    expect(
+      specifiersOf(
+        `import {\n  a,\n} from\n  "./v1/multiline.js";\nexport { b };`,
+      ),
+    ).toEqual(["./v1/multiline.js"]);
+  });
+
+  test("import-shaped text in comments and strings is not an edge", () => {
+    expect(
+      specifiersOf(`// import { x } from "./v1/x.js";\nconst a = 1;`),
+    ).toEqual([]);
+    expect(
+      specifiersOf(
+        `/** Replaces \`import { x } from "./v1/x.js"\`. */\nconst a = 1;`,
+      ),
+    ).toEqual([]);
+    expect(
+      specifiersOf(`throw new Error('add import { x } from "./v2/x.js"');`),
+    ).toEqual([]);
+    expect(specifiersOf('const hint = `import("./v3/x.js")`;')).toEqual([]);
+  });
+
+  test("a quote in a comment cannot hide a real import", () => {
+    expect(
+      specifiersOf(
+        `import {\n  // the plugin's loader\n  a,\n} from "./v1/a.js";`,
+      ),
+    ).toEqual(["./v1/a.js"]);
   });
 });


### PR DESCRIPTION
## Summary
- New guard test: substrate/v1/v2/v3 import edges enforced; multi-tier composition only at frozen spine files
- Tier-key config reads restricted to the gate module + frozen exemptions, with stale-entry reverse tests

Part of plan: memory-tier-separation.md (PR 12 of 14)