### PR TITLE
refactor(memory): group spine composition points by tier

### DIFF
--- a/assistant/src/plugins/defaults/memory/indexer.ts
+++ b/assistant/src/plugins/defaults/memory/indexer.ts
@@ -27,6 +27,8 @@ import { isMemoryRetrospectiveConversation } from "./memory-retrospective-enqueu
 import { maybeEnqueueRetrospective } from "./memory-retrospective-trigger-check.js";
 import { extractMediaBlockMeta } from "./message-media.js";
 import { segmentText } from "./segmenter.js";
+// SUBSTRATE (v2+v3) — the only tier-owned import here; the v1 triggers reach
+// their work through job-type strings alone.
 import { resolveSubstrateTuning } from "./substrate/tuning.js";
 
 const log = getLogger("memory-indexer");
@@ -207,101 +209,43 @@ export async function indexMessageNow(
         ? triggerConfig
         : null;
 
-    // Recursion guard: skip graph extraction + auto-analysis enqueues
-    // when the source conversation is itself an auto-analysis
-    // conversation. The analysis agent writes memory directly via tools,
-    // so extracting from its reflective musings would double-count and
-    // analyzing its own output would loop indefinitely.
-    if (!isAutoAnalysisSource) {
-      // ── Graph extraction (v1) ───────────────────────────────────────
-      // Suppressed when concept-page memory is active — it reads memory
-      // from buffer.md and concept pages, so the v1 graph would be stale
-      // data nobody consumes. Pending-count tracking is suppressed too;
-      // otherwise a later switch back to v1 would fire an immediate batch
-      // from counts accumulated in the meantime.
-      let extractRunAfter: number;
-      if (conceptConfig == null) {
-        const graphPendingKey = `graph_extract:${input.conversationId}:pending_count`;
-        const graphCurrentVal = getMemoryCheckpoint(graphPendingKey);
-        const graphPendingCount =
-          (graphCurrentVal ? parseInt(graphCurrentVal, 10) : 0) + 1;
-        setMemoryCheckpoint(graphPendingKey, String(graphPendingCount));
-
-        const graphBatchFired = graphPendingCount >= batchSize;
-        if (graphBatchFired) {
-          setMemoryCheckpoint(graphPendingKey, "0");
-        }
-
-        // Single pending `graph_extract` row per conversation. If the
-        // batch threshold just fired, pull `runAfter` back to now so the
-        // job runs immediately; otherwise debounce by the idle timeout.
-        // Routing both paths through `upsertDebouncedJob` ensures the
-        // row's `runAfter` reflects whichever trigger ran last, so a
-        // batch crossing always takes effect immediately.
-        extractRunAfter = graphBatchFired
-          ? Date.now()
-          : Date.now() + idleTimeoutMs;
-        if (isMemoryEnabled()) {
-          upsertDebouncedJob(
-            "graph_extract",
-            {
-              conversationId: input.conversationId,
-            },
-            extractRunAfter,
-          );
-        }
-      } else {
-        extractRunAfter = Date.now() + idleTimeoutMs;
-      }
-
-      // Memory sweep: when concept-page memory is on AND `sweep_enabled` is
-      // set, every extraction trigger also enqueues a sweep. The sweep
-      // itself reads recent messages globally, so the `conversationId` here
-      // is just the dedup key — one pending row per active conversation.
-      // `sweep_enabled` defaults to false because `remember()` is the
-      // primary capture path; the sweep is opt-in.
-      if (
-        conceptConfig != null &&
-        resolveSubstrateTuning(conceptConfig.memory).sweep_enabled
-      ) {
-        upsertDebouncedJob(
-          "memory_v2_sweep",
-          { conversationId: input.conversationId },
-          extractRunAfter,
-        );
-      }
-
-      // ── Memory retrospective triggers ─────────────────────────────────
-      // The retrospective is a focused,
-      // memory-only pass that re-reads messages since its last successful
-      // run and saves what the in-conversation `remember` calls didn't
-      // capture. Triggers (interval / message_count) are evaluated by
-      // `maybeEnqueueRetrospective`, which also enforces the per-conversation
-      // cooldown gate against retry storms. Recursion guard skips the
-      // memory-retrospective background conversation itself.
-      if (
-        triggerConfig != null &&
-        !isMemoryRetrospectiveConversation(input.conversationId)
-      ) {
-        maybeEnqueueRetrospective(input.conversationId, triggerConfig);
-      }
+    // Per-tier trigger dispatch: the v1 extraction/summarization triggers
+    // run only when no concept-page consumer is active; the substrate sweep
+    // trigger runs otherwise. `isAutoAnalysisSource` is the recursion guard
+    // threaded into both arms: the analysis agent writes memory directly via
+    // tools, so extracting from its reflective musings would double-count
+    // and analyzing its own output would loop indefinitely.
+    if (conceptConfig == null) {
+      enqueueV1IndexTriggers(
+        input.conversationId,
+        isAutoAnalysisSource,
+        batchSize,
+        idleTimeoutMs,
+      );
+    } else {
+      enqueueSubstrateIndexTriggers(
+        input.conversationId,
+        conceptConfig,
+        isAutoAnalysisSource,
+        idleTimeoutMs,
+      );
     }
 
-    // ── Conversation summarization (v1) ───────────────────────────────
-    // Summaries feed the v1 graph retrieval pipeline (fetchRecentSummaries,
-    // semantic search). Suppressed when concept-page memory is active — its
-    // readers (concept pages, activation pipeline, v3 lanes) do not consume
-    // `memorySummaries`, so the summarization LLM call would produce rows
-    // nothing reads. Stale v1 rows are short-circuited at dispatch in
-    // jobs-worker.ts. Debounced on the same idle timeout — no threshold
-    // trigger needed since summaries compress the whole conversation, not
-    // incremental batches.
-    if (conceptConfig == null && isMemoryEnabled()) {
-      upsertDebouncedJob(
-        "build_conversation_summary",
-        { conversationId: input.conversationId },
-        Date.now() + idleTimeoutMs,
-      );
+    // ── Memory retrospective triggers (all tiers) ─────────────────────
+    // The retrospective is a focused,
+    // memory-only pass that re-reads messages since its last successful
+    // run and saves what the in-conversation `remember` calls didn't
+    // capture. Triggers (interval / message_count) are evaluated by
+    // `maybeEnqueueRetrospective`, which also enforces the per-conversation
+    // cooldown gate against retry storms. Recursion guards skip auto-analysis
+    // conversations and the memory-retrospective background conversation
+    // itself.
+    if (
+      !isAutoAnalysisSource &&
+      triggerConfig != null &&
+      !isMemoryRetrospectiveConversation(input.conversationId)
+    ) {
+      maybeEnqueueRetrospective(input.conversationId, triggerConfig);
     }
   }
 
@@ -356,6 +300,100 @@ export async function indexMessageNow(
     indexedSegments: storedSegments,
     enqueuedJobs,
   };
+}
+
+// ── V1 index-time triggers — delete with v1 ───────────────────────
+
+/**
+ * V1 extraction/summarization triggers; run only when the legacy graph engine
+ * is the live tier (no concept-page consumer active — under the substrate the
+ * v1 graph and `memorySummaries` would be stale data nobody consumes, and
+ * pending-count tracking is suppressed too so a later switch back to v1 does
+ * not fire an immediate batch from counts accumulated in the meantime).
+ *
+ * Tracks the per-conversation pending-message count to debounce the
+ * `graph_extract` batch job, and debounces the conversation-summary build
+ * that feeds the v1 graph retrieval pipeline (fetchRecentSummaries, semantic
+ * search).
+ *
+ * `isAutoAnalysisSource` suppresses only the graph-extraction arm — summaries
+ * compress the whole conversation and build for auto-analysis conversations
+ * too.
+ */
+function enqueueV1IndexTriggers(
+  conversationId: string,
+  isAutoAnalysisSource: boolean,
+  batchSize: number,
+  idleTimeoutMs: number,
+): void {
+  if (!isAutoAnalysisSource) {
+    const graphPendingKey = `graph_extract:${conversationId}:pending_count`;
+    const graphCurrentVal = getMemoryCheckpoint(graphPendingKey);
+    const graphPendingCount =
+      (graphCurrentVal ? parseInt(graphCurrentVal, 10) : 0) + 1;
+    setMemoryCheckpoint(graphPendingKey, String(graphPendingCount));
+
+    const graphBatchFired = graphPendingCount >= batchSize;
+    if (graphBatchFired) {
+      setMemoryCheckpoint(graphPendingKey, "0");
+    }
+
+    // Single pending `graph_extract` row per conversation. If the
+    // batch threshold just fired, pull `runAfter` back to now so the
+    // job runs immediately; otherwise debounce by the idle timeout.
+    // Routing both paths through `upsertDebouncedJob` ensures the
+    // row's `runAfter` reflects whichever trigger ran last, so a
+    // batch crossing always takes effect immediately.
+    const extractRunAfter = graphBatchFired
+      ? Date.now()
+      : Date.now() + idleTimeoutMs;
+    if (isMemoryEnabled()) {
+      upsertDebouncedJob("graph_extract", { conversationId }, extractRunAfter);
+    }
+  }
+
+  // Conversation summarization. Stale v1 rows are short-circuited at
+  // dispatch in jobs-worker.ts. Debounced on the same idle timeout — no
+  // threshold trigger needed since summaries compress the whole
+  // conversation, not incremental batches.
+  if (isMemoryEnabled()) {
+    upsertDebouncedJob(
+      "build_conversation_summary",
+      { conversationId },
+      Date.now() + idleTimeoutMs,
+    );
+  }
+}
+
+// ── SUBSTRATE (v2+v3) index-time triggers ─────────────────────────
+
+/**
+ * Substrate index-time trigger; runs while concept-page memory is active.
+ * When `sweep_enabled` is set, every extraction trigger debounces a
+ * `memory_v2_sweep`. The sweep itself reads recent messages globally, so the
+ * `conversationId` here is just the dedup key — one pending row per active
+ * conversation. `sweep_enabled` defaults to false because `remember()` is
+ * the primary capture path; the sweep is opt-in.
+ *
+ * `isAutoAnalysisSource` is the same recursion guard the v1 arm applies: the
+ * analysis agent writes memory directly, so its output is never swept.
+ */
+function enqueueSubstrateIndexTriggers(
+  conversationId: string,
+  conceptConfig: ReturnType<typeof getConfig>,
+  isAutoAnalysisSource: boolean,
+  idleTimeoutMs: number,
+): void {
+  if (isAutoAnalysisSource) {
+    return;
+  }
+  if (resolveSubstrateTuning(conceptConfig.memory).sweep_enabled) {
+    upsertDebouncedJob(
+      "memory_v2_sweep",
+      { conversationId },
+      Date.now() + idleTimeoutMs,
+    );
+  }
 }
 
 export function enqueueBackfillJob(force = false): string {

--- a/assistant/src/plugins/defaults/memory/injectors.ts
+++ b/assistant/src/plugins/defaults/memory/injectors.ts
@@ -37,7 +37,9 @@ import { getMemoryConfig } from "./config.js";
 import { getLiveGraphMemory } from "./graph/conversation-graph-memory.js";
 import { getLogger } from "./logging.js";
 import { getSandboxWorkingDir } from "./paths.js";
+// SUBSTRATE (v2+v3) — feeds `memoryV2StaticInjector`.
 import { readMemoryV2StaticContent } from "./substrate/static-context.js";
+// V1 — delete with v1. Feeds the PKB injector pair.
 import { getPkbAutoInjectList } from "./v1/pkb/autoinject.js";
 import { readPkbContext } from "./v1/pkb/context.js";
 import { searchPkbFiles } from "./v1/pkb/pkb-search.js";
@@ -384,7 +386,14 @@ function buildMemoryV2StaticBlock(content: string): string {
  * readability convenience.
  */
 export const memoryInjectors: Injector[] = [
+  // V1 — delete with v1. The PKB pair is the legacy engine's entire injection
+  // surface; both self-silence through `isPkbInjectionSilenced` whenever v1 is
+  // not the live tier.
   pkbContextInjector,
   pkbReminderInjector,
+  // SUBSTRATE (v2+v3). Emits the static `<info>` block read off the concept
+  // pages, so it serves the v2 injection engine and v3 alike. Its block id
+  // `memory-v2-static` is FROZEN: `daemon/conversation-runtime-assembly.ts`
+  // switches on it to capture the block into persisted message metadata.
   memoryV2StaticInjector,
 ];

--- a/assistant/src/plugins/defaults/memory/job-handlers.ts
+++ b/assistant/src/plugins/defaults/memory/job-handlers.ts
@@ -10,6 +10,11 @@
  * Each handler is wrapped in an arrow that reads the imported binding at
  * dispatch time rather than capturing it eagerly, so a per-test `mock.module` of
  * the underlying handler is honored.
+ *
+ * The table is grouped into labeled per-tier sections (V1 / SUBSTRATE / V2
+ * ENGINE / V3 / RETROSPECTIVE) so retiring a tier is deleting its section and
+ * its import group. Registration keys off `type` alone, so the literal order
+ * is a readability convenience.
  */
 
 import {
@@ -19,18 +24,24 @@ import {
 import type { AssistantConfig } from "../../../config/types.js";
 import type { MemoryJob } from "../../../persistence/jobs-store.js";
 import type { JobHandlerEntry } from "../../types.js";
+// The all-tier graph store: `embedGraphNodeJob` serves the V1 section,
+// `embedGraphTriggerJob` the SUBSTRATE one.
 import {
   embedGraphNodeJob,
   embedGraphTriggerJob,
 } from "./graph/graph-search.js";
+// SUBSTRATE (v2+v3).
 import { embedConceptPageJob } from "./jobs/embed-concept-page.js";
 import { getLogger } from "./logging.js";
+// RETROSPECTIVE (all tiers).
 import { memoryRetrospectiveJob } from "./memory-retrospective-job.js";
 import { skillCardInsertJob } from "./memory-retrospective-skill-card.js";
 import { memoryRetrospectiveSweepJob } from "./memory-retrospective-sweep.js";
+// SUBSTRATE (v2+v3).
 import { memoryV2ConsolidateJob } from "./substrate/consolidation-job.js";
 import { memoryV2ReembedJob } from "./substrate/reembed-job.js";
 import { memoryV2SweepJob } from "./substrate/sweep-job.js";
+// V1 — delete with v1.
 import { pkbCompactionJob, pkbFilingJob } from "./v1/filing-jobs.js";
 import { bootstrapFromHistory } from "./v1/graph/bootstrap.js";
 import { runConsolidation } from "./v1/graph/consolidation.js";
@@ -51,10 +62,12 @@ import {
   sweepOrphanedGraphNodePointsJob,
 } from "./v1/job-handlers/index-maintenance.js";
 import { embedPkbFileJob } from "./v1/jobs/embed-pkb-file.js";
+// V2 ENGINE — delete with v2.
 import {
   memoryV2ActivationRecomputeJob,
   memoryV2MigrateJob,
 } from "./v2/backfill-jobs.js";
+// V3.
 import { maintainJob as memoryV3MaintainJob } from "./v3/maintain-job.js";
 
 const log = getLogger("memory-job-handlers");
@@ -157,6 +170,12 @@ async function graphBootstrapJob(
  * worker dispatch table by the memory plugin's `init` hook.
  */
 export const memoryJobHandlers: readonly JobHandlerEntry[] = [
+  // V1 — delete with v1.
+  // Segment/summary/media embedding, the Qdrant index-maintenance jobs, the
+  // graph lifecycle, and PKB filing. Their stale-row guards live at dispatch
+  // (`V1_QDRANT_JOB_TYPES` in `jobs-worker.ts`, `isStaleV1GraphJob` above,
+  // the inline `graph_extract` check) and at the `jobs-worker.ts` scheduling
+  // sites.
   {
     type: "embed_segment",
     handler: (job) => embedSegmentJob(job),
@@ -189,10 +208,6 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
     handler: (job, config) => embedPkbFileJob(job, config),
   },
   {
-    type: "graph_trigger_embed",
-    handler: (job, config) => embedGraphTriggerJob(job, config),
-  },
-  {
     type: "graph_extract",
     handler: async (job, config) => {
       // Stale rows enqueued by any unguarded v1 path must not consume
@@ -221,6 +236,25 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
     handler: (job, config) => graphBootstrapJob(job, config),
   },
   {
+    type: "pkb_filing",
+    handler: (job) => pkbFilingJob(job),
+  },
+  {
+    type: "pkb_compaction",
+    handler: () => pkbCompactionJob(),
+  },
+
+  // SUBSTRATE (v2+v3).
+  // Concept-page embedding, the buffer sweep and consolidator, and the
+  // corpus reembed — shared by the v2 injection engine and v3, so they
+  // outlive v1 and v2 alike. `graph_trigger_embed` deliberately lives here
+  // rather than with the v1 graph jobs: it embeds trigger text the substrate
+  // reads (locked by `__tests__/jobs-worker-v2-graph-trigger-embed.test.ts`).
+  {
+    type: "graph_trigger_embed",
+    handler: (job, config) => embedGraphTriggerJob(job, config),
+  },
+  {
     type: "embed_concept_page",
     handler: (job, config) => embedConceptPageJob(job, config),
   },
@@ -233,29 +267,35 @@ export const memoryJobHandlers: readonly JobHandlerEntry[] = [
     handler: (job, config) => memoryV2ConsolidateJob(job, config),
   },
   {
-    type: "pkb_filing",
-    handler: (job) => pkbFilingJob(job),
+    type: "memory_v2_reembed",
+    handler: (job, config) => memoryV2ReembedJob(job, config),
   },
-  {
-    type: "pkb_compaction",
-    handler: () => pkbCompactionJob(),
-  },
+
+  // V2 ENGINE — delete with v2.
+  // Operator-triggered backfills owned by the activation/router engine: the
+  // one-shot v1→v2 synthesis and the persisted-activation recompute. The job
+  // types share the `memory_v2_` prefix with the substrate entries above, but
+  // the work is engine-local.
   {
     type: "memory_v2_migrate",
     handler: (job, config) => memoryV2MigrateJob(job, config),
   },
   {
-    type: "memory_v2_reembed",
-    handler: (job, config) => memoryV2ReembedJob(job, config),
-  },
-  {
     type: "memory_v2_activation_recompute",
     handler: (job, config) => memoryV2ActivationRecomputeJob(job, config),
   },
+
+  // V3.
+  // Topic-tree self-maintenance; the handler no-ops when v3 is not live.
   {
     type: "memory_v3_maintain",
     handler: (job, config) => memoryV3MaintainJob(job, config),
   },
+
+  // RETROSPECTIVE (all tiers).
+  // The retrospective pass and its cross-conversation sweep are tier-agnostic
+  // and survive every tier deletion. `skill_card_insert` is emitted only on
+  // v3 but is owned by the retrospective, so it groups here.
   {
     type: "memory_retrospective",
     handler: (job, config) => memoryRetrospectiveJob(job, config),

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -67,12 +67,15 @@ import {
 import { getLogger } from "./logging.js";
 import { sweepOrphanMemoryRetrospectiveConversations } from "./memory-retrospective-startup-cleanup.js";
 import { getWorkspaceDir } from "./paths.js";
+// SUBSTRATE (v2+v3) — feeds `enqueueSubstrateMaintenanceJobs`.
 import {
   type ConsolidationFailureKind,
   countBufferLines,
   readConsolidationFailureState,
 } from "./substrate/consolidation-job.js";
 import { resolveSubstrateTuning } from "./substrate/tuning.js";
+// V1 — delete with v1. Feeds `enqueueV1MaintenanceJobs` and the one-shot
+// v1-entry reconcile.
 import { maybeEnqueueGraphBootstrap } from "./v1/graph/bootstrap.js";
 import { hasPkbBufferContent } from "./v1/pkb-schedule.js";
 import { spawnMemoryWorkerProcess } from "./worker-control.js";
@@ -914,35 +917,6 @@ export function maybeEnqueueRetrospectiveSweepJob(
 }
 
 /**
- * Enqueue periodic graph maintenance jobs.
- *
- * Mutually exclusive between v1 and concept-page memory:
- *   - concept-page memory active ({@link usesConceptPageMemory}) → only one
- *     buffer-drainer is scheduled (see below).
- *   - inactive → the four v1 entries (decay, consolidate, pattern_scan,
- *     narrative) are scheduled instead.
- *
- * The `memory/buffer.md` is shared, so exactly one consolidator owns the drain
- * at a time. When concept-page memory is active, the concept-page consolidator
- * (`memory_v2_consolidate`) is the sole buffer-drainer.
- *
- * Read/write paths route to concept pages when the gate is on, so v1 graph
- * data goes unread; running v1 maintenance alongside it is wasted compute and
- * LLM spend. The v1 code path remains live so disabling concept-page memory
- * fully re-engages v1.
- *
- * Uses durable checkpoints so intervals survive daemon restarts — jobs only
- * fire when the actual elapsed time since last run exceeds the interval.
- * Sweep is intentionally not on this schedule: it is debounced from the
- * live `graph_extract` trigger path (see `indexMessageNow` in `indexer.ts`)
- * so it runs on the same idle/message-count cadence.
- *
- * Independently of the v1/concept-page split, a flag-gated
- * `memory_v3_maintain` backstop is appended when a v3 path is active so the
- * topic tree self-heals even if the primary post-consolidation follow-up
- * enqueue is missed.
- */
-/**
  * Whether `hour` falls inside the PKB jobs' configured active window. A `null`
  * bound on either side means no restriction. Windows may wrap midnight
  * (start > end, e.g. 22–6).
@@ -1102,6 +1076,35 @@ function maybeRunV1EntryReconcile(nowMs: number): void {
   }
 }
 
+/**
+ * Enqueue periodic graph maintenance jobs.
+ *
+ * Mutually exclusive between v1 and concept-page memory:
+ *   - concept-page memory active ({@link usesConceptPageMemory}) → only one
+ *     buffer-drainer is scheduled ({@link enqueueSubstrateMaintenanceJobs}).
+ *   - inactive → the four v1 entries (decay, consolidate, pattern_scan,
+ *     narrative) are scheduled instead ({@link enqueueV1MaintenanceJobs}).
+ *
+ * The `memory/buffer.md` is shared, so exactly one consolidator owns the drain
+ * at a time. When concept-page memory is active, the concept-page consolidator
+ * (`memory_v2_consolidate`) is the sole buffer-drainer.
+ *
+ * Read/write paths route to concept pages when the gate is on, so v1 graph
+ * data goes unread; running v1 maintenance alongside it is wasted compute and
+ * LLM spend. The v1 code path remains live so disabling concept-page memory
+ * fully re-engages v1.
+ *
+ * Uses durable checkpoints so intervals survive daemon restarts — jobs only
+ * fire when the actual elapsed time since last run exceeds the interval.
+ * Sweep is intentionally not on this schedule: it is debounced from the
+ * live `graph_extract` trigger path (see `indexMessageNow` in `indexer.ts`)
+ * so it runs on the same idle/message-count cadence.
+ *
+ * Independently of the v1/concept-page split, a flag-gated
+ * `memory_v3_maintain` backstop is scheduled when a v3 path is active so the
+ * topic tree self-heals even if the primary post-consolidation follow-up
+ * enqueue is missed ({@link enqueueV3BackstopJobs}).
+ */
 export function maybeEnqueueGraphMaintenanceJobs(
   config: AssistantConfig,
   nowMs = Date.now(),
@@ -1111,135 +1114,62 @@ export function maybeEnqueueGraphMaintenanceJobs(
     return;
   }
 
-  const conceptPagesActive = usesConceptPageMemory(config.memory);
+  if (usesConceptPageMemory(config.memory)) {
+    // The substrate branch also re-arms the one-shot v1-entry reconcile:
+    // clearing its done-marker means the next transition back to v1
+    // reconciles again (see {@link maybeRunV1EntryReconcile}).
+    try {
+      deleteMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.v1EntryReconcile);
+    } catch (err) {
+      log.warn({ err }, "Clearing the v1-entry reconcile checkpoint failed");
+    }
+    enqueueSubstrateMaintenanceJobs(config, nowMs);
+  } else {
+    enqueueV1MaintenanceJobs(config, nowMs);
+  }
+
+  // v3 self-maintenance backstop. Orthogonal to the mutual exclusion above:
+  // it owns its own checkpoint and operates on the v3 topic tree. Gated on
+  // the same config that gates the v3 plugin so it stays inert when v3 is
+  // off. The job handler itself no-ops when v3 is off, so this guard is
+  // belt-and-suspenders that also avoids a wasted enqueue.
+  if (isMemoryV3Live(config)) {
+    enqueueV3BackstopJobs(nowMs);
+  }
+}
+
+// ── SUBSTRATE (v2+v3) maintenance ─────────────────────────────────
+
+/**
+ * Substrate maintenance entries; scheduled only while concept-page memory is
+ * active. The concept-page consolidator (`memory_v2_consolidate`) is the sole
+ * buffer-drainer, enqueued on an interval cadence plus a size-based trigger,
+ * both gated by the consolidation failure backoff.
+ */
+function enqueueSubstrateMaintenanceJobs(
+  config: AssistantConfig,
+  nowMs: number,
+): void {
   const tuning = resolveSubstrateTuning(config.memory);
 
-  // The single buffer-drainer entry for the concept-page branch. Referenced
-  // again below by the size-based trigger.
+  // The single buffer-drainer entry, shared by the interval cadence and the
+  // size-based trigger below.
   const consolidateEntry = {
     key: GRAPH_MAINTENANCE_CHECKPOINTS.memoryV2Consolidate,
     intervalMs: tuning.consolidation_interval_hours * 60 * 60 * 1000,
     jobType: "memory_v2_consolidate" as MemoryJobType,
   };
 
-  const schedule: Array<{
-    key: string;
-    intervalMs: number;
-    jobType: MemoryJobType;
-  }> = conceptPagesActive
-    ? [consolidateEntry]
-    : [
-        {
-          key: GRAPH_MAINTENANCE_CHECKPOINTS.decay,
-          intervalMs: GRAPH_DECAY_INTERVAL_MS,
-          jobType: "graph_decay",
-        },
-        {
-          key: GRAPH_MAINTENANCE_CHECKPOINTS.consolidate,
-          intervalMs: GRAPH_CONSOLIDATE_INTERVAL_MS,
-          jobType: "graph_consolidate",
-        },
-        {
-          key: GRAPH_MAINTENANCE_CHECKPOINTS.patternScan,
-          intervalMs: GRAPH_PATTERN_SCAN_INTERVAL_MS,
-          jobType: "graph_pattern_scan",
-        },
-        {
-          key: GRAPH_MAINTENANCE_CHECKPOINTS.narrative,
-          intervalMs: GRAPH_NARRATIVE_INTERVAL_MS,
-          jobType: "graph_narrative_refine",
-        },
-      ];
-
-  // One-shot v1-entry reconcile. Startup covers a fresh v1 boot (capability
-  // seeding and the bootstrap check in `startup.ts`), but a config hot-reload
-  // that flips concept-page memory off lands the assistant on v1 without a
-  // restart — leaving capability nodes without v1 embeddings and the graph
-  // possibly empty despite existing history. A durable checkpoint marks the
-  // reconcile done for the current stay on v1, so it runs exactly once per
-  // transition regardless of the bootstrap's outcome — an unconditional
-  // per-tick bootstrap check would tight-loop when extraction yields no
-  // non-procedural nodes (the emptiness test stays true while the processed
-  // job zeroes the next poll delay). The substrate branch clears the
-  // checkpoint so a later return to v1 reconciles again. Best-effort: every
-  // step logs on failure and never blocks the maintenance enqueues below.
-  if (conceptPagesActive) {
-    try {
-      deleteMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.v1EntryReconcile);
-    } catch (err) {
-      log.warn({ err }, "Clearing the v1-entry reconcile checkpoint failed");
-    }
-  } else {
-    maybeRunV1EntryReconcile(nowMs);
-  }
-
-  // v3 self-maintenance backstop. Orthogonal to the mutual exclusion above:
-  // it owns its own checkpoint and operates on the v3 topic tree, so it
-  // runs under either branch. Gated on the same config that gates the v3 plugin
-  // so it stays inert when v3 is off. The post-consolidation follow-up in
-  // `consolidation-job.ts` remains the primary trigger; this interval only
-  // self-heals when that follow-up is missed (failed enqueue). The job handler
-  // itself no-ops when v3 is off, so
-  // this guard is belt-and-suspenders that also avoids a wasted enqueue.
-  if (isMemoryV3Live(config)) {
-    schedule.push({
-      key: GRAPH_MAINTENANCE_CHECKPOINTS.memoryV3Maintain,
-      intervalMs: GRAPH_V3_MAINTAIN_INTERVAL_MS,
-      jobType: "memory_v3_maintain",
-    });
-  }
-
+  const lastRun = parseInt(
+    getMemoryCheckpoint(consolidateEntry.key) ?? "0",
+    10,
+  );
   let enqueuedConsolidate = false;
-  for (const { key, intervalMs, jobType } of schedule) {
-    const lastRun = parseInt(getMemoryCheckpoint(key) ?? "0", 10);
-    if (nowMs - lastRun >= intervalMs) {
-      // Noop scheduled consolidation when the buffer has too few entries to
-      // justify an LLM run — mirrors the heartbeat max-consecutive-runs skip.
-      // The checkpoint advances so the next check fires after the regular
-      // interval. Manual "Run now" is unaffected (routes layer, not schedule).
-      if (jobType === consolidateEntry.jobType) {
-        // Failure backoff: skip WITHOUT advancing the checkpoint so the
-        // enqueue fires on the first tick after the window elapses instead
-        // of a full interval later.
-        const backoffRemainingMs = consolidationBackoffRemainingMs(
-          intervalMs,
-          nowMs,
-        );
-        if (backoffRemainingMs > 0) {
-          log.debug(
-            { backoffRemainingMs },
-            "Scheduled consolidation skipped: failure backoff active",
-          );
-          continue;
-        }
-        const bufferLines = memoryBufferLineCount();
-        if (bufferLines < MIN_BUFFER_LINES_FOR_CONSOLIDATION) {
-          // Staleness override: the minimum only defers while entries are
-          // still arriving. Once a non-empty buffer has sat unwritten for a
-          // full interval, drain it anyway — otherwise a buffer that never
-          // reaches the minimum re-skips every interval forever and its
-          // facts never become concept pages.
-          const stale =
-            bufferLines > 0 && memoryBufferIdleMs(nowMs) >= intervalMs;
-          if (!stale) {
-            log.debug(
-              "Scheduled consolidation skipped: buffer under minimum line threshold",
-            );
-            setMemoryCheckpoint(key, String(nowMs));
-            continue;
-          }
-        }
-      }
-      const payload =
-        jobType === consolidateEntry.jobType
-          ? AUTOMATIC_CONSOLIDATION_JOB_PAYLOAD
-          : {};
-      enqueueMemoryJob(jobType, payload);
-      setMemoryCheckpoint(key, String(nowMs));
-      if (jobType === consolidateEntry.jobType) {
-        enqueuedConsolidate = true;
-      }
-    }
+  if (nowMs - lastRun >= consolidateEntry.intervalMs) {
+    enqueuedConsolidate = maybeEnqueueScheduledConsolidation(
+      consolidateEntry,
+      nowMs,
+    );
   }
 
   // Size-based trigger: when the shared buffer crosses the configured line
@@ -1255,7 +1185,6 @@ export function maybeEnqueueGraphMaintenanceJobs(
   // backoff skip leaves the checkpoint alone.
   const maxLines = tuning.consolidation_max_buffer_lines;
   if (
-    conceptPagesActive &&
     !enqueuedConsolidate &&
     maxLines !== null &&
     !hasActiveJobOfType(consolidateEntry.jobType)
@@ -1279,6 +1208,117 @@ export function maybeEnqueueGraphMaintenanceJobs(
       }
     }
   }
+}
+
+/**
+ * Interval-cadence arm of the substrate consolidation schedule: enqueue the
+ * consolidate job unless the failure backoff or the minimum-buffer-lines gate
+ * (with its staleness override) skips it. Returns true when the job was
+ * enqueued.
+ */
+function maybeEnqueueScheduledConsolidation(
+  entry: { key: string; intervalMs: number; jobType: MemoryJobType },
+  nowMs: number,
+): boolean {
+  // Failure backoff: skip WITHOUT advancing the checkpoint so the enqueue
+  // fires on the first tick after the window elapses instead of a full
+  // interval later.
+  const backoffRemainingMs = consolidationBackoffRemainingMs(
+    entry.intervalMs,
+    nowMs,
+  );
+  if (backoffRemainingMs > 0) {
+    log.debug(
+      { backoffRemainingMs },
+      "Scheduled consolidation skipped: failure backoff active",
+    );
+    return false;
+  }
+  // Noop scheduled consolidation when the buffer has too few entries to
+  // justify an LLM run — mirrors the heartbeat max-consecutive-runs skip.
+  // The checkpoint advances so the next check fires after the regular
+  // interval. Manual "Run now" is unaffected (routes layer, not schedule).
+  const bufferLines = memoryBufferLineCount();
+  if (bufferLines < MIN_BUFFER_LINES_FOR_CONSOLIDATION) {
+    // Staleness override: the minimum only defers while entries are still
+    // arriving. Once a non-empty buffer has sat unwritten for a full
+    // interval, drain it anyway — otherwise a buffer that never reaches the
+    // minimum re-skips every interval forever and its facts never become
+    // concept pages.
+    const stale =
+      bufferLines > 0 && memoryBufferIdleMs(nowMs) >= entry.intervalMs;
+    if (!stale) {
+      log.debug(
+        "Scheduled consolidation skipped: buffer under minimum line threshold",
+      );
+      setMemoryCheckpoint(entry.key, String(nowMs));
+      return false;
+    }
+  }
+  enqueueMemoryJob(entry.jobType, AUTOMATIC_CONSOLIDATION_JOB_PAYLOAD);
+  setMemoryCheckpoint(entry.key, String(nowMs));
+  return true;
+}
+
+// ── V1 (legacy engine) maintenance — delete with v1 ───────────────
+
+/**
+ * v1-only maintenance entries; scheduled only when the legacy graph engine is
+ * the live memory tier. Covers the one-shot v1-entry reconcile, the four v1
+ * graph lifecycle jobs (decay, consolidate, pattern_scan, narrative), and the
+ * PKB filing/compaction schedule.
+ */
+function enqueueV1MaintenanceJobs(
+  config: AssistantConfig,
+  nowMs: number,
+): void {
+  // One-shot v1-entry reconcile. Startup covers a fresh v1 boot (capability
+  // seeding and the bootstrap check in `startup.ts`), but a config hot-reload
+  // that flips concept-page memory off lands the assistant on v1 without a
+  // restart — leaving capability nodes without v1 embeddings and the graph
+  // possibly empty despite existing history. A durable checkpoint marks the
+  // reconcile done for the current stay on v1, so it runs exactly once per
+  // transition regardless of the bootstrap's outcome — an unconditional
+  // per-tick bootstrap check would tight-loop when extraction yields no
+  // non-procedural nodes (the emptiness test stays true while the processed
+  // job zeroes the next poll delay). The substrate branch clears the
+  // checkpoint so a later return to v1 reconciles again. Best-effort: every
+  // step logs on failure and never blocks the maintenance enqueues below.
+  maybeRunV1EntryReconcile(nowMs);
+
+  const schedule: Array<{
+    key: string;
+    intervalMs: number;
+    jobType: MemoryJobType;
+  }> = [
+    {
+      key: GRAPH_MAINTENANCE_CHECKPOINTS.decay,
+      intervalMs: GRAPH_DECAY_INTERVAL_MS,
+      jobType: "graph_decay",
+    },
+    {
+      key: GRAPH_MAINTENANCE_CHECKPOINTS.consolidate,
+      intervalMs: GRAPH_CONSOLIDATE_INTERVAL_MS,
+      jobType: "graph_consolidate",
+    },
+    {
+      key: GRAPH_MAINTENANCE_CHECKPOINTS.patternScan,
+      intervalMs: GRAPH_PATTERN_SCAN_INTERVAL_MS,
+      jobType: "graph_pattern_scan",
+    },
+    {
+      key: GRAPH_MAINTENANCE_CHECKPOINTS.narrative,
+      intervalMs: GRAPH_NARRATIVE_INTERVAL_MS,
+      jobType: "graph_narrative_refine",
+    },
+  ];
+  for (const { key, intervalMs, jobType } of schedule) {
+    const lastRun = parseInt(getMemoryCheckpoint(key) ?? "0", 10);
+    if (nowMs - lastRun >= intervalMs) {
+      enqueueMemoryJob(jobType, {});
+      setMemoryCheckpoint(key, String(nowMs));
+    }
+  }
 
   // PKB filing/compaction — v1-only, like the v1 graph entries above (under
   // concept-page memory the consolidation job owns periodic background memory
@@ -1294,60 +1334,80 @@ export function maybeEnqueueGraphMaintenanceJobs(
   //  - either PKB job already pending/running: skip WITHOUT advancing, so the
   //    next worker tick retries. Filing and compaction both rewrite the PKB
   //    tree, so at most one of the two is ever in the queue.
-  if (!conceptPagesActive) {
-    const filingConfig = config.filing;
-    const withinActiveHours = isWithinPkbActiveHours(
-      new Date(nowMs).getHours(),
-      filingConfig.activeHoursStart ?? null,
-      filingConfig.activeHoursEnd ?? null,
-    );
-    const pkbSchedule: Array<{
-      key: string;
-      intervalMs: number;
-      jobType: MemoryJobType;
-      enabled: boolean;
-      hasWork: () => boolean;
-    }> = [
-      {
-        key: GRAPH_MAINTENANCE_CHECKPOINTS.pkbFiling,
-        intervalMs: filingConfig.intervalMs,
-        jobType: "pkb_filing",
-        enabled: filingConfig.enabled,
-        hasWork: () => hasPkbBufferContent(),
-      },
-      {
-        key: GRAPH_MAINTENANCE_CHECKPOINTS.pkbCompaction,
-        intervalMs: filingConfig.compactionIntervalMs,
-        jobType: "pkb_compaction",
-        enabled: filingConfig.compactionEnabled,
-        hasWork: () => true,
-      },
-    ];
-    for (const { key, intervalMs, jobType, enabled, hasWork } of pkbSchedule) {
-      if (!enabled) {
-        continue;
-      }
-      const checkpoint = getMemoryCheckpoint(key);
-      if (checkpoint === null) {
-        setMemoryCheckpoint(key, String(nowMs));
-        continue;
-      }
-      const lastRun = parseInt(checkpoint, 10);
-      if (nowMs - lastRun < intervalMs) {
-        continue;
-      }
-      if (!withinActiveHours || !hasWork()) {
-        setMemoryCheckpoint(key, String(nowMs));
-        continue;
-      }
-      if (
-        hasActiveJobOfType("pkb_filing") ||
-        hasActiveJobOfType("pkb_compaction")
-      ) {
-        continue;
-      }
-      enqueueMemoryJob(jobType, {});
-      setMemoryCheckpoint(key, String(nowMs));
+  const filingConfig = config.filing;
+  const withinActiveHours = isWithinPkbActiveHours(
+    new Date(nowMs).getHours(),
+    filingConfig.activeHoursStart ?? null,
+    filingConfig.activeHoursEnd ?? null,
+  );
+  const pkbSchedule: Array<{
+    key: string;
+    intervalMs: number;
+    jobType: MemoryJobType;
+    enabled: boolean;
+    hasWork: () => boolean;
+  }> = [
+    {
+      key: GRAPH_MAINTENANCE_CHECKPOINTS.pkbFiling,
+      intervalMs: filingConfig.intervalMs,
+      jobType: "pkb_filing",
+      enabled: filingConfig.enabled,
+      hasWork: () => hasPkbBufferContent(),
+    },
+    {
+      key: GRAPH_MAINTENANCE_CHECKPOINTS.pkbCompaction,
+      intervalMs: filingConfig.compactionIntervalMs,
+      jobType: "pkb_compaction",
+      enabled: filingConfig.compactionEnabled,
+      hasWork: () => true,
+    },
+  ];
+  for (const { key, intervalMs, jobType, enabled, hasWork } of pkbSchedule) {
+    if (!enabled) {
+      continue;
     }
+    const checkpoint = getMemoryCheckpoint(key);
+    if (checkpoint === null) {
+      setMemoryCheckpoint(key, String(nowMs));
+      continue;
+    }
+    const lastRun = parseInt(checkpoint, 10);
+    if (nowMs - lastRun < intervalMs) {
+      continue;
+    }
+    if (!withinActiveHours || !hasWork()) {
+      setMemoryCheckpoint(key, String(nowMs));
+      continue;
+    }
+    if (
+      hasActiveJobOfType("pkb_filing") ||
+      hasActiveJobOfType("pkb_compaction")
+    ) {
+      continue;
+    }
+    enqueueMemoryJob(jobType, {});
+    setMemoryCheckpoint(key, String(nowMs));
+  }
+}
+
+// ── V3 backstop ───────────────────────────────────────────────────
+
+/**
+ * v3 self-maintenance backstop on its own durable checkpoint. The
+ * post-consolidation follow-up in `consolidation-job.ts` is the primary
+ * trigger; this interval only self-heals when that follow-up is missed
+ * (failed enqueue).
+ */
+function enqueueV3BackstopJobs(nowMs: number): void {
+  const lastRun = parseInt(
+    getMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.memoryV3Maintain) ?? "0",
+    10,
+  );
+  if (nowMs - lastRun >= GRAPH_V3_MAINTAIN_INTERVAL_MS) {
+    enqueueMemoryJob("memory_v3_maintain", {});
+    setMemoryCheckpoint(
+      GRAPH_MAINTENANCE_CHECKPOINTS.memoryV3Maintain,
+      String(nowMs),
+    );
   }
 }

--- a/assistant/src/plugins/defaults/memory/startup.ts
+++ b/assistant/src/plugins/defaults/memory/startup.ts
@@ -12,6 +12,13 @@
  * before this is kicked off — so the memory handlers are guaranteed to be in the
  * dispatch table before the jobs worker started near the end of this function
  * claims its first job.
+ *
+ * This is a multi-tier composition point, so the body carries `// ---- ... ----`
+ * section labels naming which tier owns each group of steps. The labels do not
+ * form a single contiguous run per tier: the v1 Qdrant collection ensure has to
+ * precede the shared embedding-identity reconcile, and the v1 graph bootstrap
+ * belongs to the post-worker seeding tail. Steps only move when the move is
+ * provably unobservable.
  */
 
 import { join } from "node:path";
@@ -38,6 +45,9 @@ import { resolveQdrantUrl } from "./embeddings.js";
 import { startMemoryJobsWorker } from "./jobs-worker.js";
 import { getLogger } from "./logging.js";
 import { getWorkspaceDir } from "./paths.js";
+// ---- substrate (v2+v3) ---- the only tier-owned static import group here;
+// the v1 steps reach their modules through dynamic `./v1/*` imports so the
+// legacy engine loads only on the tier that runs it.
 import {
   maybeRebuildConceptCollection,
   rebuildBm25CorpusStatsAndReseedSkills,
@@ -47,6 +57,8 @@ import { sweepConceptPageFrontmatter } from "./substrate/frontmatter-sweep.js";
 const log = getLogger("memory-startup");
 
 export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
+  // ---- shared infra ----
+  // Boot the Qdrant process every tier's vector work sits on.
   const qdrantUrl = resolveQdrantUrl();
   log.info({ qdrantUrl }, "Daemon startup: initializing Qdrant");
   const manager = createQdrantManager({ url: qdrantUrl });
@@ -80,6 +92,13 @@ export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
   }
 
   if (qdrantStarted) {
+    // ---- v1 (legacy engine) ----
+    // Stays ahead of the shared embedding-identity reconcile below: that
+    // reconcile persists a new `memory.qdrant.vectorSize` on a commit-fresh or
+    // migrate action, and the v1 client must have been constructed at the
+    // dimension it owns before that happens (see `daemon/embedding-reconcile.ts`,
+    // which skips itself entirely on a v2-disabled install for the same reason).
+    //
     // Skip the v1 Qdrant collection lifecycle when concept-page memory is
     // active — the v1 collection has no writers or readers (graph search is
     // bypassed) in that state, so ensuring/migrating it just maintains a
@@ -128,6 +147,7 @@ export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
       }
     }
 
+    // ---- shared infra ----
     // Initialize the messages lexical index — a dedicated sparse-only Qdrant
     // collection that is the lexical (BM25-style) replacement for SQLite FTS5
     // over message content. Independent of the v1 dense collection lifecycle
@@ -161,27 +181,19 @@ export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
       );
     }
 
-    // Detect schema drift on the v2 concept-page collection (e.g.
-    // pre-#29823 collections lacking summary_dense / summary_sparse) and
-    // recreate + enqueue a reembed when needed. Awaited inline so the
-    // reembed enqueue happens before the memory worker drains its first
-    // batch; the call's own try/catch keeps any v2-side failure from
-    // blocking the v1 PKB reconcile or BM25 build below.
-    try {
-      await maybeRebuildConceptCollection(config);
-    } catch (err) {
-      log.warn(
-        { err },
-        "Memory v2 collection schema check threw — continuing startup",
-      );
-    }
-
+    // ---- v1 (legacy engine) ----
     // Reconcile the PKB Qdrant index against the on-disk tree. Gated off
     // while concept-page memory is active because PKB is the v1 storage
     // layer; in that state the v1 collection is not initialized, so calling
     // `getQdrantClient()` here would throw. Fire-and-forget so enqueued
     // re-index jobs drain in the background and first-turn latency stays
     // unaffected.
+    //
+    // Sits ahead of the substrate block purely so each tier's steps are
+    // contiguous: the two are mutually exclusive on `usesConceptPageMemory`
+    // — every substrate step below re-checks the same predicate and returns
+    // immediately when v1 is the live tier — so their relative order is
+    // unobservable.
     if (!usesConceptPageMemory(config.memory)) {
       void (async () => {
         try {
@@ -198,6 +210,22 @@ export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
       })();
     }
 
+    // ---- substrate (v2+v3) ----
+    // Detect schema drift on the v2 concept-page collection (e.g.
+    // pre-#29823 collections lacking summary_dense / summary_sparse) and
+    // recreate + enqueue a reembed when needed. Awaited inline so the
+    // reembed enqueue happens before the memory worker drains its first
+    // batch; the call's own try/catch keeps any v2-side failure from
+    // blocking the BM25 build or the frontmatter sweep below.
+    try {
+      await maybeRebuildConceptCollection(config);
+    } catch (err) {
+      log.warn(
+        { err },
+        "Memory v2 collection schema check threw — continuing startup",
+      );
+    }
+
     void rebuildBm25CorpusStatsAndReseedSkills(config);
 
     try {
@@ -210,6 +238,7 @@ export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
     }
   }
 
+  // ---- shared infra ----
   // `startMemoryJobsWorker` spawns the out-of-process memory worker as a child
   // of the daemon; it is the sole drainer of the memory job queue. Shutdown
   // stops it — see shutdown-handlers.ts and the memory plugin's `shutdown`
@@ -219,7 +248,11 @@ export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
   log.info("Daemon startup: starting memory worker");
   startMemoryJobsWorker();
 
-  // Seed capability graph nodes (new memory graph system)
+  // Seed capability graph nodes (new memory graph system). All-tier, not v1:
+  // `refreshSkillCapabilityMemories` seeds both the graph nodes the
+  // `list_memory` surface reads on every tier and the substrate's skill /
+  // CLI-command cards, and `capability-seed.ts` self-skips the v1-only
+  // `embed_graph_node` enqueues when v1 is not the live tier.
   try {
     const { seedCliGraphNodes } = await import("./graph/capability-seed.js");
     refreshSkillCapabilityMemories(config);
@@ -228,6 +261,7 @@ export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
     log.warn({ err }, "Graph capability seeding failed — continuing");
   }
 
+  // ---- v1 (legacy engine) ----
   // Auto-bootstrap: if the graph has no non-procedural nodes but historical
   // segments exist, enqueue a one-time graph_bootstrap job to populate the
   // graph from conversation history and journal files.


### PR DESCRIPTION
## Summary
- jobs-worker maintenance scheduling and indexer triggers extracted into per-tier helpers behind an explicit dispatch skeleton
- startup/job-handlers/injectors annotated into labeled per-tier sections
- Pure code motion: zero test modifications

Part of plan: memory-tier-separation.md (PR 13 of 14)