### PR TITLE
fix(memory): v1-entry reconcile — re-arm when memory is off, no per-tick delete, no startup race

### DIFF
--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -312,8 +312,11 @@ on v1-era machinery.
    move to a tier-neutral home first.
 3. **The v1-entry reconcile goes with v1.** `maybeRunV1EntryReconcile` in
    `jobs-worker.ts` and its `v1_entry_reconcile_done` checkpoint exist only to
-   re-run bootstrap + capability seeders when an assistant enters v1; delete
-   both in the same change.
+   re-run bootstrap + capability seeders when an assistant enters v1. Three
+   sites carry it and all go in the same change: the reconcile itself,
+   `rearmV1EntryReconcile` (clears the marker on every tick that is off v1), and
+   the boot-time claim in `startup.ts` that keeps the daemon's own seeding pass
+   from racing the worker's.
 
 ### External consumers to repoint or retire
 

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v1-graph-substrate-noop.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-v1-graph-substrate-noop.test.ts
@@ -124,6 +124,24 @@ setConfig("memory", {
   jobs: { slowLlmConcurrency: 8, fastConcurrency: 8 },
 });
 
+// Instrument the checkpoint module before `jobs-worker.js` binds it, so the
+// worker's writes go through this wrapper: the maintenance tick must reach
+// `deleteMemoryCheckpoint` only when the v1-entry marker is actually present,
+// and a spy is the only way to see a delete that targets an absent row.
+// The snapshot is taken eagerly: `mock.module` rebinds the live namespace, so
+// a wrapper reading `deleteMemoryCheckpoint` off it would call itself.
+const realCheckpoints = {
+  ...(await import("../../../../persistence/checkpoints.js")),
+};
+const checkpointDeletes: string[] = [];
+mock.module("../../../../persistence/checkpoints.js", () => ({
+  ...realCheckpoints,
+  deleteMemoryCheckpoint: (key: string) => {
+    checkpointDeletes.push(key);
+    realCheckpoints.deleteMemoryCheckpoint(key);
+  },
+}));
+
 const { applyNestedDefaults } = await import("../../../../config/loader.js");
 const { getMemoryDb } =
   await import("../../../../persistence/db-connection.js");
@@ -141,7 +159,7 @@ const {
   maybeEnqueueGraphMaintenanceJobs,
   runMemoryJobsOnce,
 } = await import("../jobs-worker.js");
-const { deleteMemoryCheckpoint, getMemoryCheckpoint } =
+const { deleteMemoryCheckpoint, getMemoryCheckpoint, setMemoryCheckpoint } =
   await import("../../../../persistence/checkpoints.js");
 
 const V1_ENTRY_RECONCILE_KEY = GRAPH_MAINTENANCE_CHECKPOINTS.v1EntryReconcile;
@@ -195,6 +213,12 @@ function v1Config(): AssistantConfig {
   return config;
 }
 
+function memoryDisabledConfig(): AssistantConfig {
+  const config = applyNestedDefaults({});
+  config.memory.enabled = false;
+  return config;
+}
+
 function v3LiveConfig(): AssistantConfig {
   const config = applyNestedDefaults({});
   config.memory.v3.live = true;
@@ -220,6 +244,7 @@ describe("v1 graph jobs under concept-page memory", () => {
   beforeEach(() => {
     getMemoryDb()!.run("DELETE FROM memory_jobs");
     resetCallCounts();
+    checkpointDeletes.length = 0;
     _resetQdrantBreaker();
   });
 
@@ -322,5 +347,68 @@ describe("v1 graph jobs under concept-page memory", () => {
     expect(seedSkillGraphNodeCalls).toBe(2);
     expect(seedCliGraphNodeCalls).toBe(2);
     expect(getMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY)).not.toBeNull();
+  });
+
+  test("a memory-disabled tick re-arms the reconcile so re-enabling into v1 runs it", () => {
+    deleteMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY);
+
+    maybeEnqueueGraphMaintenanceJobs(v1Config(), Date.now());
+
+    expect(maybeEnqueueBootstrapCalls).toBe(1);
+    expect(getMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY)).not.toBeNull();
+
+    // Memory off is leaving v1: capability nodes keep being written with no
+    // `embed_graph_node` rows behind them, so the marker is cleared.
+    maybeEnqueueGraphMaintenanceJobs(memoryDisabledConfig(), Date.now());
+
+    expect(maybeEnqueueBootstrapCalls).toBe(1);
+    expect(seedSkillGraphNodeCalls).toBe(1);
+    expect(getMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY)).toBeNull();
+
+    // Re-enabling straight back into v1 reconciles instead of reading a stale
+    // done-marker and skipping.
+    maybeEnqueueGraphMaintenanceJobs(v1Config(), Date.now());
+
+    expect(maybeEnqueueBootstrapCalls).toBe(2);
+    expect(seedSkillGraphNodeCalls).toBe(2);
+    expect(seedCliGraphNodeCalls).toBe(2);
+    expect(getMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY)).not.toBeNull();
+  });
+
+  test("ticks off v1 issue no checkpoint delete while the marker is absent", () => {
+    deleteMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY);
+    checkpointDeletes.length = 0;
+
+    // The steady state of every v2/v3 (and memory-off) assistant: the marker
+    // was never written, so each tick is one indexed read and no write.
+    maybeEnqueueGraphMaintenanceJobs(applyNestedDefaults({}), Date.now());
+    maybeEnqueueGraphMaintenanceJobs(applyNestedDefaults({}), Date.now());
+    maybeEnqueueGraphMaintenanceJobs(memoryDisabledConfig(), Date.now());
+
+    expect(checkpointDeletes).toEqual([]);
+
+    // A marker left by a stay on v1 is cleared exactly once; the ticks after it
+    // are reads again.
+    maybeEnqueueGraphMaintenanceJobs(v1Config(), Date.now());
+    checkpointDeletes.length = 0;
+
+    maybeEnqueueGraphMaintenanceJobs(applyNestedDefaults({}), Date.now());
+    maybeEnqueueGraphMaintenanceJobs(applyNestedDefaults({}), Date.now());
+
+    expect(checkpointDeletes).toEqual([V1_ENTRY_RECONCILE_KEY]);
+  });
+
+  test("a v1 tick whose marker startup already claimed runs no seeding", () => {
+    // `runMemoryStartup` runs the bootstrap check and both seeders in the
+    // daemon and claims the marker before it spawns this worker, so the
+    // worker's first tick of a v1 boot must not repeat that pass against the
+    // same `memory_graph_nodes` rows.
+    setMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY, String(Date.now()));
+
+    maybeEnqueueGraphMaintenanceJobs(v1Config(), Date.now());
+
+    expect(maybeEnqueueBootstrapCalls).toBe(0);
+    expect(seedSkillGraphNodeCalls).toBe(0);
+    expect(seedCliGraphNodeCalls).toBe(0);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/startup-v1-entry-reconcile-claim.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/startup-v1-entry-reconcile-claim.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Daemon startup owns the v1-entry reconcile for a v1 boot: it runs the
+ * capability seeding and the graph bootstrap check itself, so it claims the
+ * one-shot `v1_entry_reconcile_done` marker BEFORE spawning the out-of-process
+ * memory worker. That ordering is what keeps the worker's first tick from
+ * running the same three steps against the same `memory_graph_nodes` rows
+ * concurrently — the worker process does not exist yet when the marker lands,
+ * so its reconcile can only ever see the claim.
+ *
+ * Qdrant is mocked as unavailable so the startup path reaches the claim without
+ * a vector store: the claim, the worker spawn, and the seeding tail all sit
+ * outside the Qdrant block, so the ordering under test is identical either way.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { assertNotLiveDb } from "../../../../__tests__/assert-not-live-db.js";
+import type { AssistantConfig } from "../../../../config/types.js";
+
+/**
+ * Persisted checkpoint key, spelled out rather than imported: the mocks below
+ * have to be installed before `jobs-worker.js` is loaded. A test asserts it
+ * still matches the exported constant.
+ */
+const V1_ENTRY_RECONCILE_KEY = "v1_entry_reconcile_done";
+
+const tmpWorkspace = mkdtempSync(
+  join(tmpdir(), "memory-startup-v1-entry-claim-"),
+);
+const previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+
+const { setConfig } =
+  await import("../../../../__tests__/helpers/set-config.js");
+setConfig("memory", {});
+
+const { applyNestedDefaults } = await import("../../../../config/loader.js");
+const { initializeDb } = await import("../../../../persistence/db-init.js");
+const { deleteMemoryCheckpoint, getMemoryCheckpoint } =
+  await import("../../../../persistence/checkpoints.js");
+
+/** Marker value observed at the instant the worker spawn was requested. */
+let checkpointAtSpawn: string | null = null;
+let spawnCalls = 0;
+/** Startup steps that run after the spawn, in call order. */
+const stepsAfterSpawn: string[] = [];
+
+mock.module("../../../../persistence/embeddings/qdrant-manager.js", () => ({
+  createQdrantManager: () => ({
+    start: async () => {
+      throw new Error("Qdrant is unavailable in this test");
+    },
+  }),
+  stopQdrantManager: async () => {},
+}));
+
+mock.module("../worker-control.js", () => ({
+  spawnMemoryWorkerProcess: async () => {
+    spawnCalls += 1;
+    checkpointAtSpawn = getMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY);
+    return { pid: 4242, alreadyRunning: false };
+  },
+  probeMemoryWorker: () => ({ running: false }),
+  stopMemoryWorkerProcess: () => ({ running: false }),
+}));
+
+mock.module("../../../../daemon/skill-memory-refresh.js", () => ({
+  refreshSkillCapabilityMemories: () => {
+    stepsAfterSpawn.push("refreshSkillCapabilityMemories");
+  },
+}));
+
+mock.module("../graph/capability-seed.js", () => ({
+  deleteSkillCapabilityNode: () => {},
+  seedSkillGraphNodes: () => {},
+  seedCliGraphNodes: async () => {
+    stepsAfterSpawn.push("seedCliGraphNodes");
+  },
+  seedUninstalledCatalogSkillMemories: async () => {},
+}));
+
+mock.module("../v1/graph/bootstrap.js", () => ({
+  bootstrapFromHistory: async () => ({}),
+  bootstrapFromJournal: async () => ({ extracted: 0, errors: 0 }),
+  maybeEnqueueGraphBootstrap: () => {
+    stepsAfterSpawn.push("maybeEnqueueGraphBootstrap");
+  },
+  resetBootstrapCheckpoint: () => {},
+  migrateToolCreatedItems: () => {},
+  cleanupStaleItemVectors: async () => {},
+}));
+
+const { GRAPH_MAINTENANCE_CHECKPOINTS } = await import("../jobs-worker.js");
+const { runMemoryStartup } = await import("../startup.js");
+
+/** Bun.sleep is patched out so the Qdrant start retries do not idle 15s. */
+const realBunSleep = Bun.sleep;
+
+function v1Config(): AssistantConfig {
+  const config = applyNestedDefaults({});
+  config.memory.v2.enabled = false;
+  return config;
+}
+
+function substrateConfig(): AssistantConfig {
+  return applyNestedDefaults({});
+}
+
+function memoryDisabledConfig(): AssistantConfig {
+  const config = applyNestedDefaults({});
+  config.memory.enabled = false;
+  return config;
+}
+
+describe("v1-entry reconcile claim at daemon startup", () => {
+  beforeAll(async () => {
+    (Bun as { sleep: typeof Bun.sleep }).sleep = (async () =>
+      undefined) as typeof Bun.sleep;
+    await initializeDb();
+  }, 30_000);
+
+  afterAll(() => {
+    (Bun as { sleep: typeof Bun.sleep }).sleep = realBunSleep;
+    if (previousWorkspaceEnv === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+    }
+    assertNotLiveDb(tmpWorkspace);
+    rmSync(tmpWorkspace, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    deleteMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY);
+    checkpointAtSpawn = null;
+    spawnCalls = 0;
+    stepsAfterSpawn.length = 0;
+  });
+
+  test("the checkpoint key matches the worker's exported constant", () => {
+    expect(GRAPH_MAINTENANCE_CHECKPOINTS.v1EntryReconcile).toBe(
+      V1_ENTRY_RECONCILE_KEY,
+    );
+  });
+
+  test("a v1 boot claims the reconcile before the worker is spawned", async () => {
+    await runMemoryStartup(v1Config());
+
+    expect(spawnCalls).toBe(1);
+    expect(checkpointAtSpawn).not.toBeNull();
+    expect(getMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY)).not.toBeNull();
+    // The claim covers exactly the three steps the worker's reconcile runs.
+    expect(stepsAfterSpawn).toEqual([
+      "refreshSkillCapabilityMemories",
+      "seedCliGraphNodes",
+      "maybeEnqueueGraphBootstrap",
+    ]);
+  });
+
+  test("a substrate boot leaves the reconcile unclaimed", async () => {
+    await runMemoryStartup(substrateConfig());
+
+    expect(spawnCalls).toBe(1);
+    expect(checkpointAtSpawn).toBeNull();
+    expect(getMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY)).toBeNull();
+  });
+
+  test("a memory-disabled boot leaves the reconcile unclaimed", async () => {
+    await runMemoryStartup(memoryDisabledConfig());
+
+    expect(spawnCalls).toBe(1);
+    expect(checkpointAtSpawn).toBeNull();
+    expect(getMemoryCheckpoint(V1_ENTRY_RECONCILE_KEY)).toBeNull();
+  });
+});

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 
 import { getConfig } from "../../../config/loader.js";
 import {
+  isMemoryEnabled,
+  isMemoryV1Active,
   isMemoryV3Live,
   usesConceptPageMemory,
 } from "../../../config/memory-v3-gate.js";
@@ -854,9 +856,10 @@ export const GRAPH_MAINTENANCE_CHECKPOINTS = {
   pkbFiling: "pkb_filing_last_run",
   pkbCompaction: "pkb_compaction_last_run",
   // One-shot done-marker (epoch-ms), not a cadence checkpoint like the
-  // entries above: present while the assistant stays on v1, cleared by the
-  // substrate branch so the next return to v1 reconciles again. See
-  // `maybeRunV1EntryReconcile`.
+  // entries above: present while the assistant stays on v1, cleared by every
+  // tick that is off v1 (substrate active or memory disabled) so the next
+  // return to v1 reconciles again. Daemon startup claims it directly on a v1
+  // boot. See `maybeRunV1EntryReconcile` and `rearmV1EntryReconcile`.
   v1EntryReconcile: "v1_entry_reconcile_done",
 } as const;
 
@@ -1031,6 +1034,12 @@ export function consolidationBackoffRemainingMs(
  * The checkpoint is written even when individual steps fail — this is a
  * transition-edge trigger, not a retry loop; a failed step gets another
  * chance on the next transition or restart.
+ *
+ * This covers the HOT transition onto v1 only. A v1 boot is claimed by
+ * `runMemoryStartup` before the worker process is spawned (it runs the same
+ * three steps in the daemon), so a marker present here on the worker's first
+ * tick means boot already reconciled and this returns without a second,
+ * concurrent pass over the same `memory_graph_nodes` rows.
  */
 function maybeRunV1EntryReconcile(nowMs: number): void {
   try {
@@ -1077,6 +1086,34 @@ function maybeRunV1EntryReconcile(nowMs: number): void {
 }
 
 /**
+ * Re-arm the one-shot v1-entry reconcile by clearing its done-marker, so the
+ * next tick that lands on v1 reconciles again. Called from every tick that is
+ * off the v1 tier — both the substrate branch and the memory-disabled branch.
+ * Memory being off counts as leaving v1 for the same reason the substrate does:
+ * capability nodes keep being written (`refreshSkillCapabilityMemories` is
+ * all-tier) while no `embed_graph_node` rows are enqueued, so those nodes are
+ * absent from v1 semantic retrieval until a reconcile backfills them.
+ *
+ * Reads before deleting. The marker is absent on essentially every tick of a
+ * non-v1 assistant (it is only ever written on v1), so the read keeps the
+ * steady state one indexed lookup instead of a WAL-dirtying DELETE on every
+ * poll of a 1.5s–30s loop.
+ */
+function rearmV1EntryReconcile(): void {
+  try {
+    const done = getMemoryCheckpoint(
+      GRAPH_MAINTENANCE_CHECKPOINTS.v1EntryReconcile,
+    );
+    if (done === null) {
+      return;
+    }
+    deleteMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.v1EntryReconcile);
+  } catch (err) {
+    log.warn({ err }, "Clearing the v1-entry reconcile checkpoint failed");
+  }
+}
+
+/**
  * Enqueue periodic graph maintenance jobs.
  *
  * Mutually exclusive between v1 and concept-page memory:
@@ -1104,25 +1141,28 @@ function maybeRunV1EntryReconcile(nowMs: number): void {
  * `memory_v3_maintain` backstop is scheduled when a v3 path is active so the
  * topic tree self-heals even if the primary post-consolidation follow-up
  * enqueue is missed ({@link enqueueV3BackstopJobs}).
+ *
+ * Every tick that is off v1 — including the memory-disabled one, which returns
+ * before scheduling anything — re-arms the one-shot v1-entry reconcile
+ * ({@link rearmV1EntryReconcile}).
  */
 export function maybeEnqueueGraphMaintenanceJobs(
   config: AssistantConfig,
   nowMs = Date.now(),
 ): void {
-  const memoryEnabled = config.memory.enabled !== false;
-  if (!memoryEnabled) {
+  // Off the v1 tier — memory disabled or the concept-page substrate active —
+  // the only work this tick owes v1 is re-arming the one-shot entry reconcile.
+  // It runs ahead of the memory-disabled return so both non-v1 states re-arm,
+  // not just the substrate one.
+  if (!isMemoryV1Active(config)) {
+    rearmV1EntryReconcile();
+  }
+
+  if (!isMemoryEnabled(config)) {
     return;
   }
 
   if (usesConceptPageMemory(config.memory)) {
-    // The substrate branch also re-arms the one-shot v1-entry reconcile:
-    // clearing its done-marker means the next transition back to v1
-    // reconciles again (see {@link maybeRunV1EntryReconcile}).
-    try {
-      deleteMemoryCheckpoint(GRAPH_MAINTENANCE_CHECKPOINTS.v1EntryReconcile);
-    } catch (err) {
-      log.warn({ err }, "Clearing the v1-entry reconcile checkpoint failed");
-    }
     enqueueSubstrateMaintenanceJobs(config, nowMs);
   } else {
     enqueueV1MaintenanceJobs(config, nowMs);
@@ -1272,18 +1312,20 @@ function enqueueV1MaintenanceJobs(
   config: AssistantConfig,
   nowMs: number,
 ): void {
-  // One-shot v1-entry reconcile. Startup covers a fresh v1 boot (capability
-  // seeding and the bootstrap check in `startup.ts`), but a config hot-reload
-  // that flips concept-page memory off lands the assistant on v1 without a
-  // restart — leaving capability nodes without v1 embeddings and the graph
-  // possibly empty despite existing history. A durable checkpoint marks the
+  // One-shot v1-entry reconcile, covering the config hot-reload that flips
+  // concept-page memory off (or memory back on) and lands the assistant on v1
+  // without a restart — leaving capability nodes without v1 embeddings and the
+  // graph possibly empty despite existing history. A fresh v1 boot is covered
+  // by `startup.ts`, which runs the same steps in the daemon and claims the
+  // checkpoint before spawning this worker, so this call returns immediately on
+  // the worker's first tick after a v1 boot. The durable checkpoint marks the
   // reconcile done for the current stay on v1, so it runs exactly once per
   // transition regardless of the bootstrap's outcome — an unconditional
   // per-tick bootstrap check would tight-loop when extraction yields no
   // non-procedural nodes (the emptiness test stays true while the processed
-  // job zeroes the next poll delay). The substrate branch clears the
-  // checkpoint so a later return to v1 reconciles again. Best-effort: every
-  // step logs on failure and never blocks the maintenance enqueues below.
+  // job zeroes the next poll delay). Any tick off v1 clears the checkpoint so a
+  // later return to v1 reconciles again. Best-effort: every step logs on
+  // failure and never blocks the maintenance enqueues below.
   maybeRunV1EntryReconcile(nowMs);
 
   const schedule: Array<{

--- a/assistant/src/plugins/defaults/memory/startup.ts
+++ b/assistant/src/plugins/defaults/memory/startup.ts
@@ -23,10 +23,14 @@
 
 import { join } from "node:path";
 
-import { usesConceptPageMemory } from "../../../config/memory-v3-gate.js";
+import {
+  isMemoryV1Active,
+  usesConceptPageMemory,
+} from "../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../config/schema.js";
 import { reconcileEmbeddingIdentity } from "../../../daemon/embedding-reconcile.js";
 import { refreshSkillCapabilityMemories } from "../../../daemon/skill-memory-refresh.js";
+import { setMemoryCheckpoint } from "../../../persistence/checkpoints.js";
 import { selectEmbeddingBackend } from "../../../persistence/embeddings/embedding-backend.js";
 import {
   initMessagesLexicalIndex,
@@ -42,7 +46,10 @@ import {
   isMemoryEnabled,
 } from "../../../persistence/jobs-store.js";
 import { resolveQdrantUrl } from "./embeddings.js";
-import { startMemoryJobsWorker } from "./jobs-worker.js";
+import {
+  GRAPH_MAINTENANCE_CHECKPOINTS,
+  startMemoryJobsWorker,
+} from "./jobs-worker.js";
 import { getLogger } from "./logging.js";
 import { getWorkspaceDir } from "./paths.js";
 // ---- substrate (v2+v3) ---- the only tier-owned static import group here;
@@ -235,6 +242,28 @@ export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
         { err },
         "Concept page frontmatter sweep threw — continuing startup",
       );
+    }
+  }
+
+  // ---- v1 (legacy engine) ----
+  // Claim the one-shot v1-entry reconcile for this boot. The seeding and
+  // bootstrap steps below are exactly what the worker's `maybeRunV1EntryReconcile`
+  // runs, and they run here on every boot, so the worker only owes v1 the HOT
+  // config transition. Writing the marker synchronously BEFORE the worker is
+  // spawned is what makes that ordering total: the worker process does not
+  // exist yet, so its first tick reads a marker that is already present and
+  // skips, and the two processes never upsert the same `memory_graph_nodes`
+  // rows concurrently. A crash between this write and the steps below re-runs
+  // both on the next boot. Best-effort — a checkpoint failure must not block
+  // the worker start.
+  if (isMemoryV1Active(config)) {
+    try {
+      setMemoryCheckpoint(
+        GRAPH_MAINTENANCE_CHECKPOINTS.v1EntryReconcile,
+        String(Date.now()),
+      );
+    } catch (err) {
+      log.warn({ err }, "Claiming the v1-entry reconcile checkpoint failed");
     }
   }
 


### PR DESCRIPTION
## Summary
- Disabling memory now re-arms the v1-entry reconcile marker, so re-enabling into v1 reconciles instead of silently skipping
- The substrate branch reads before clearing, ending an unconditional checkpoint DELETE on every worker poll
- The reconcile no longer races the daemon's own boot-time capability seeding

Found by self-review of plan memory-tier-separation.md (PRs #39168, #39176).