### PR TITLE
fix(memory): surface memory.substrate shadowing; fix the v3-migration freeze/restore steps

### DIFF
--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -113,21 +113,31 @@ export function registerConfigCommand(program: Command): void {
           // Direct-replacement set semantics (preserves null, replaces objects).
           // See conversation-query-routes.ts:handleSetConfig for why this is a
           // separate route from config_patch.
-          const result = await cliIpcCall("config_set", {
-            body: { path: key, value: parsed },
-          });
+          const result = await cliIpcCall<{ ok: boolean; warning?: string }>(
+            "config_set",
+            { body: { path: key, value: parsed } },
+          );
           if (!result.ok) {
             exitFromIpcResult(result, cmd);
             return;
           }
           log.info(`Set ${key} = ${JSON.stringify(parsed)}`);
+          // A write the daemon accepted but that another namespace overrides
+          // is reported alongside the success, so a no-op set never reads as
+          // an effective one.
+          const warning = result.result?.warning;
+          if (warning) {
+            log.warn(`Warning: ${warning}`);
+          }
         },
       );
 
       subcommand(config, "get").action(
         async (key: string, _opts: unknown, cmd: Command) => {
           const raw = await fetchRawConfig(cmd);
-          if (!raw) return;
+          if (!raw) {
+            return;
+          }
           const value = getNestedValue(raw, key);
           if (value === undefined) {
             log.info(`(not set)`);
@@ -136,6 +146,17 @@ export function registerConfigCommand(program: Command): void {
               typeof value === "object"
                 ? JSON.stringify(value, null, 2)
                 : String(value),
+            );
+          }
+          // A `memory.v2` substrate tunable is not the effective value when
+          // its `memory.substrate` twin is set — print the key that wins so a
+          // read cannot confirm a value the runtime ignores.
+          const { findSubstrateShadowing } =
+            await import("../../config/substrate-twin-shadowing.js");
+          const shadowing = findSubstrateShadowing(raw, key);
+          if (shadowing) {
+            log.warn(
+              `Shadowed: ${shadowing.substratePath} = ${JSON.stringify(shadowing.substrateValue)} takes precedence and is the effective value.`,
             );
           }
         },
@@ -158,7 +179,9 @@ export function registerConfigCommand(program: Command): void {
       subcommand(config, "list").action(
         async (opts: { search?: string }, cmd: Command) => {
           const raw = await fetchRawConfig(cmd);
-          if (!raw) return;
+          if (!raw) {
+            return;
+          }
           if (Object.keys(raw).length === 0) {
             log.info("No configuration set");
             return;

--- a/assistant/src/config/__tests__/substrate-twin-shadowing.test.ts
+++ b/assistant/src/config/__tests__/substrate-twin-shadowing.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+
+import { MemorySubstrateConfigSchema } from "../schemas/memory-substrate.js";
+import { MemoryV2ConfigSchema } from "../schemas/memory-v2.js";
+import {
+  describeShadowedConfigSet,
+  findSubstrateShadowing,
+  SUBSTRATE_KEY_BY_V2_KEY,
+} from "../substrate-twin-shadowing.js";
+
+describe("substrate twin table", () => {
+  test("pairs exactly the memory.substrate schema's keys", () => {
+    // Drift guard: a substrate key with no entry here is a tunable whose
+    // shadowing goes unreported, which is the silent no-op this module exists
+    // to prevent.
+    expect(new Set(Object.values(SUBSTRATE_KEY_BY_V2_KEY))).toEqual(
+      new Set(Object.keys(MemorySubstrateConfigSchema.shape)),
+    );
+  });
+
+  test("names a real memory.v2 key on every left-hand side", () => {
+    const v2Keys = new Set(Object.keys(MemoryV2ConfigSchema.shape));
+    for (const v2Key of Object.keys(SUBSTRATE_KEY_BY_V2_KEY)) {
+      expect(v2Keys).toContain(v2Key);
+    }
+  });
+});
+
+describe("findSubstrateShadowing", () => {
+  test("reports the winning substrate twin for a shadowed memory.v2 key", () => {
+    const raw = {
+      memory: {
+        v2: { consolidation_interval_hours: 4 },
+        substrate: { consolidation_interval_hours: 876000 },
+      },
+    };
+
+    expect(
+      findSubstrateShadowing(raw, "memory.v2.consolidation_interval_hours"),
+    ).toEqual({
+      substratePath: "memory.substrate.consolidation_interval_hours",
+      substrateValue: 876000,
+    });
+  });
+
+  test("maps the renamed spread keys to their substrate names", () => {
+    const raw = { memory: { v2: {}, substrate: { spread_k: 0.4 } } };
+
+    expect(findSubstrateShadowing(raw, "memory.v2.k")).toEqual({
+      substratePath: "memory.substrate.spread_k",
+      substrateValue: 0.4,
+    });
+    // hops has no twin set, so nothing shadows it.
+    expect(findSubstrateShadowing(raw, "memory.v2.hops")).toBeUndefined();
+  });
+
+  test("treats an explicit null twin as set, matching resolveSubstrateTuning", () => {
+    // `orV2` falls back only on `undefined`, so a null substrate value wins —
+    // and it is exactly the value the consolidation freeze writes.
+    const raw = {
+      memory: {
+        v2: { consolidation_max_buffer_lines: 100 },
+        substrate: { consolidation_max_buffer_lines: null },
+      },
+    };
+
+    expect(
+      findSubstrateShadowing(raw, "memory.v2.consolidation_max_buffer_lines"),
+    ).toEqual({
+      substratePath: "memory.substrate.consolidation_max_buffer_lines",
+      substrateValue: null,
+    });
+  });
+
+  test("returns nothing for unshadowed paths", () => {
+    const raw = {
+      memory: {
+        v2: { bm25_b: 0.6, enabled: true },
+        substrate: { bm25_b: 0.3 },
+      },
+    };
+
+    // No memory.substrate subtree at all.
+    expect(
+      findSubstrateShadowing(
+        { memory: { v2: { bm25_b: 0.6 } } },
+        "memory.v2.bm25_b",
+      ),
+    ).toBeUndefined();
+    // A v2 key with no substrate twin.
+    expect(findSubstrateShadowing(raw, "memory.v2.enabled")).toBeUndefined();
+    // The substrate key itself is what wins — writing it is never shadowed.
+    expect(
+      findSubstrateShadowing(raw, "memory.substrate.bm25_b"),
+    ).toBeUndefined();
+    // Paths outside the memory namespace, and the wrong depth.
+    expect(findSubstrateShadowing(raw, "memory.v2")).toBeUndefined();
+    expect(findSubstrateShadowing(raw, "llm.v2.bm25_b")).toBeUndefined();
+  });
+});
+
+describe("describeShadowedConfigSet", () => {
+  test("names the winning key, its value, and the command that retunes it", () => {
+    const message = describeShadowedConfigSet(
+      {
+        substratePath: "memory.substrate.consolidation_interval_hours",
+        substrateValue: 876000,
+      },
+      "memory.v2.consolidation_interval_hours",
+    );
+
+    expect(message).toContain(
+      "memory.substrate.consolidation_interval_hours is set (876000)",
+    );
+    expect(message).toContain("does not change the effective value");
+    expect(message).toContain(
+      "assistant config set memory.substrate.consolidation_interval_hours",
+    );
+  });
+});

--- a/assistant/src/config/substrate-twin-shadowing.ts
+++ b/assistant/src/config/substrate-twin-shadowing.ts
@@ -1,0 +1,104 @@
+// ---------------------------------------------------------------------------
+// Memory substrate — twin-namespace shadowing detection
+// ---------------------------------------------------------------------------
+
+/**
+ * `memory.v2` key → `memory.substrate` key, for the fifteen substrate tunables
+ * that exist in both namespaces. `k` / `hops` are the historical `memory.v2`
+ * names for `spread_k` / `spread_hops`; every other key shares its name with
+ * its twin.
+ *
+ * The runtime precedence lives in `resolveSubstrateTuning`
+ * (`plugins/defaults/memory/substrate/tuning.ts`), which resolves each tunable
+ * as `memory.substrate.X ?? memory.v2.X`. This table is the config surface's
+ * view of the same pairing, kept honest by
+ * `__tests__/substrate-twin-shadowing.test.ts`, which asserts it covers exactly
+ * the `memory.substrate` schema's keys.
+ */
+export const SUBSTRATE_KEY_BY_V2_KEY: Readonly<Record<string, string>> = {
+  sweep_enabled: "sweep_enabled",
+  dense_weight: "dense_weight",
+  sparse_weight: "sparse_weight",
+  min_sparse_spread: "min_sparse_spread",
+  full_sparse_spread: "full_sparse_spread",
+  bm25_k1: "bm25_k1",
+  bm25_b: "bm25_b",
+  consolidation_interval_hours: "consolidation_interval_hours",
+  consolidation_max_buffer_lines: "consolidation_max_buffer_lines",
+  consolidation_max_entries_per_run: "consolidation_max_entries_per_run",
+  max_page_chars: "max_page_chars",
+  consolidation_prompt_path: "consolidation_prompt_path",
+  k: "spread_k",
+  hops: "spread_hops",
+  ann_candidate_limit: "ann_candidate_limit",
+};
+
+/** A `memory.substrate` value that wins over the `memory.v2` key it shadows. */
+export type SubstrateShadowing = {
+  /** Dotted path of the winning key, e.g. `memory.substrate.spread_k`. */
+  substratePath: string;
+  /** The winning key's persisted value — the effective tunable. */
+  substrateValue: unknown;
+};
+
+function readPlainObject(value: unknown): Record<string, unknown> | undefined {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * The `memory.substrate` twin that shadows `path`, or `undefined` when `path`
+ * is not a shadowable `memory.v2` tunable or its twin is unset.
+ *
+ * `memory.substrate` is override-only and wins whenever its key is present, so
+ * a write to (or read of) the `memory.v2` twin is inert once the substrate key
+ * exists — including when it holds an explicit `null`, which
+ * `resolveSubstrateTuning` treats as present. Detection therefore keys on
+ * presence, not truthiness.
+ *
+ * `raw` is the unparsed config object (`loadRawConfig()` / the `config_get`
+ * payload), so the check sees exactly what is persisted.
+ */
+export function findSubstrateShadowing(
+  raw: Record<string, unknown>,
+  path: string,
+): SubstrateShadowing | undefined {
+  const segments = path.split(".");
+  if (segments.length !== 3 || segments[0] !== "memory") {
+    return undefined;
+  }
+  const [, namespace, key] = segments as [string, string, string];
+  if (namespace !== "v2") {
+    return undefined;
+  }
+  const substrateKey = SUBSTRATE_KEY_BY_V2_KEY[key];
+  if (substrateKey === undefined) {
+    return undefined;
+  }
+  const substrate = readPlainObject(readPlainObject(raw.memory)?.substrate);
+  if (!substrate || !(substrateKey in substrate)) {
+    return undefined;
+  }
+  return {
+    substratePath: `memory.substrate.${substrateKey}`,
+    substrateValue: substrate[substrateKey],
+  };
+}
+
+/**
+ * Operator-facing warning for a `config set` that lands on a shadowed
+ * `memory.v2` tunable: the write persists but changes no behavior, so it names
+ * the winning key and the command that actually retunes it.
+ */
+export function describeShadowedConfigSet(
+  shadowing: SubstrateShadowing,
+  path: string,
+): string {
+  const value = JSON.stringify(shadowing.substrateValue) ?? "undefined";
+  return (
+    `${shadowing.substratePath} is set (${value}) and takes precedence over ${path}, ` +
+    `so this write does not change the effective value. ` +
+    `Run 'assistant config set ${shadowing.substratePath} <value>' to retune it.`
+  );
+}

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -143,6 +143,12 @@ disjoint cases: the substrate schema's own refinement (both set), the v2
 schema's (neither set), and the parent `MemoryConfigSchema.superRefine` (the
 mixed case, over the RESOLVED pair). Keep all three when touching the weights.
 
+Because `memory.substrate` wins, a `config set` on a shadowed `memory.v2` twin
+persists but changes nothing. `config/substrate-twin-shadowing.ts` pairs the two
+namespaces so that no-op is visible: the `config_set` route returns a `warning`
+naming the winning key, and `assistant config get` prints a `Shadowed:` line
+with the value actually in effect.
+
 Workspace migration 135 copies explicitly-set NON-DEFAULT `memory.v2` substrate
 tunables into `memory.substrate`. It skips loader-seeded defaults — including
 `bm25_b`'s earlier `0.75` default — because raw presence in `config.json` is not

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -55,6 +55,10 @@ import {
 } from "../../config/schemas/llm.js";
 import { VALID_MEMORY_EMBEDDING_PROVIDERS } from "../../config/schemas/memory-storage.js";
 import { ServiceModeSchema } from "../../config/schemas/services.js";
+import {
+  describeShadowedConfigSet,
+  findSubstrateShadowing,
+} from "../../config/substrate-twin-shadowing.js";
 import { getConfigWatcher } from "../../daemon/config-watcher.js";
 import {
   getEmbeddingConfigInfo,
@@ -1597,6 +1601,16 @@ async function handleSetConfig({ body }: RouteHandlerArgs) {
   }
 
   await commitConfigWrite(raw, "set");
+  // A `memory.v2` substrate tunable whose `memory.substrate` twin is set
+  // persists but changes nothing — the substrate namespace wins in
+  // `resolveSubstrateTuning`. Report that alongside the success so the caller
+  // can tell the operator, rather than letting the write read as effective.
+  const shadowing = findSubstrateShadowing(raw, path);
+  if (shadowing) {
+    const warning = describeShadowedConfigSet(shadowing, path);
+    log.warn({ path, substratePath: shadowing.substratePath }, warning);
+    return { ok: true, warning };
+  }
   return { ok: true };
 }
 

--- a/assistant/src/workspace/migrations/135-copy-substrate-tunables.ts
+++ b/assistant/src/workspace/migrations/135-copy-substrate-tunables.ts
@@ -125,6 +125,16 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * override-only surface. The two no-default keys (`min_sparse_spread`,
  * `full_sparse_spread`) copy on presence alone.
  *
+ * That rule is narrower than "explicitly present", and the gap is deliberate:
+ * a value equal to a shipped default never copies, even when the user typed it
+ * on purpose. For every key whose shipped default is the current one that costs
+ * nothing — `memory.substrate` plus the shipped defaults resolve to exactly
+ * what the resolver's fallback produces. `bm25_b`'s retired `0.75` is the sole
+ * exception: it is skipped as seeded yet differs from today's `0.4`, so on a
+ * workspace carrying it the value survives only through the resolver's
+ * `memory.v2` fallback. That is the one case where dropping the fallback would
+ * change behavior — see the equivalence proof in this migration's test.
+ *
  * `memory.v2.*` is never modified — the v2 injection engine still reads it.
  * An already-present `memory.substrate` key is never clobbered. `memory.substrate` is only
  * written at all when at least one key copies, so a fresh config never gains

--- a/assistant/src/workspace/migrations/__tests__/135-copy-substrate-tunables.test.ts
+++ b/assistant/src/workspace/migrations/__tests__/135-copy-substrate-tunables.test.ts
@@ -11,10 +11,88 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { MemoryConfigSchema } from "../../../config/schemas/memory.js";
+import { MemoryV2ConfigSchema } from "../../../config/schemas/memory-v2.js";
+import {
+  resolveSubstrateTuning,
+  type SubstrateTuning,
+} from "../../../plugins/defaults/memory/substrate/tuning.js";
 import { copySubstrateTunablesMigration as MIG } from "../135-copy-substrate-tunables.js";
 
 let workspaceDir: string;
 let configPath: string;
+
+/** The shipped `memory.v2` defaults, i.e. the effective value of an unset key. */
+const V2_SCHEMA_DEFAULTS = MemoryV2ConfigSchema.parse({});
+
+function pick<T>(
+  substrate: Record<string, unknown>,
+  key: string,
+  fallback: T,
+): T {
+  // Presence, not truthiness: `resolveSubstrateTuning` falls back only on
+  // `undefined`, so an explicit `null` counts as set.
+  return key in substrate ? (substrate[key] as T) : fallback;
+}
+
+/**
+ * `resolveSubstrateTuning` with the `memory.v2` fallback stripped: every
+ * tunable resolves from `memory.substrate` alone, or from the shipped v2
+ * schema default when the substrate key is absent.
+ *
+ * Migration 135's whole purpose is to make this resolver agree with the real
+ * one on a migrated workspace — that agreement is what lets the fallback be
+ * removed later without changing anyone's behavior.
+ */
+function resolveSubstrateOnly(
+  substrate: Record<string, unknown>,
+): SubstrateTuning {
+  const d = V2_SCHEMA_DEFAULTS;
+  return {
+    sweep_enabled: pick(substrate, "sweep_enabled", d.sweep_enabled),
+    dense_weight: pick(substrate, "dense_weight", d.dense_weight),
+    sparse_weight: pick(substrate, "sparse_weight", d.sparse_weight),
+    min_sparse_spread: pick(
+      substrate,
+      "min_sparse_spread",
+      d.min_sparse_spread,
+    ),
+    full_sparse_spread: pick(
+      substrate,
+      "full_sparse_spread",
+      d.full_sparse_spread,
+    ),
+    bm25_k1: pick(substrate, "bm25_k1", d.bm25_k1),
+    bm25_b: pick(substrate, "bm25_b", d.bm25_b),
+    consolidation_interval_hours: pick(
+      substrate,
+      "consolidation_interval_hours",
+      d.consolidation_interval_hours,
+    ),
+    consolidation_max_buffer_lines: pick(
+      substrate,
+      "consolidation_max_buffer_lines",
+      d.consolidation_max_buffer_lines,
+    ),
+    consolidation_max_entries_per_run: pick(
+      substrate,
+      "consolidation_max_entries_per_run",
+      d.consolidation_max_entries_per_run,
+    ),
+    max_page_chars: pick(substrate, "max_page_chars", d.max_page_chars),
+    consolidation_prompt_path: pick(
+      substrate,
+      "consolidation_prompt_path",
+      d.consolidation_prompt_path,
+    ),
+    spread_k: pick(substrate, "spread_k", d.k),
+    spread_hops: pick(substrate, "spread_hops", d.hops),
+    ann_candidate_limit: pick(
+      substrate,
+      "ann_candidate_limit",
+      d.ann_candidate_limit,
+    ),
+  };
+}
 
 function write(obj: unknown): void {
   writeFileSync(configPath, JSON.stringify(obj, null, 2) + "\n");
@@ -145,7 +223,7 @@ describe("135-copy-substrate-tunables", () => {
     },
   );
 
-  test("renames k→spread_k and hops→spread_hops; a tuned bm25_b lands on the substrate key (v2-fallback removal safe)", () => {
+  test("renames k→spread_k and hops→spread_hops; a tuned bm25_b lands on the substrate key", () => {
     write({
       memory: {
         v2: { k: 0.4, hops: 3, bm25_b: 0.6 },
@@ -154,11 +232,75 @@ describe("135-copy-substrate-tunables", () => {
 
     MIG.run(workspaceDir);
 
-    const substrate = memory().substrate as Record<string, unknown>;
-    // The substrate namespace now carries the tuned values itself: resolving
-    // WITHOUT the resolver's substrate→v2 fallback yields the same behavior.
-    expect(substrate).toEqual({ spread_k: 0.4, spread_hops: 3, bm25_b: 0.6 });
+    expect(memory().substrate).toEqual({
+      spread_k: 0.4,
+      spread_hops: 3,
+      bm25_b: 0.6,
+    });
     expect(memory().v2).toEqual({ k: 0.4, hops: 3, bm25_b: 0.6 });
+  });
+
+  test("a migrated workspace resolves identically with the v2 fallback stripped", () => {
+    // A normally-created workspace: loader-seeded defaults alongside real user
+    // overrides, including the two no-default spread keys and the nullable
+    // keys on both sides of the copy rule.
+    write({
+      memory: {
+        v2: {
+          enabled: true,
+          // Seeded defaults — the migration must leave these behind.
+          sweep_enabled: false,
+          dense_weight: 0.85,
+          sparse_weight: 0.15,
+          bm25_k1: 1.2,
+          consolidation_max_entries_per_run: 150,
+          consolidation_prompt_path: null,
+          hops: 2,
+          // User overrides — the migration must carry these across.
+          bm25_b: 0.6,
+          consolidation_interval_hours: 6,
+          consolidation_max_buffer_lines: null,
+          max_page_chars: 9000,
+          k: 0.4,
+          ann_candidate_limit: 500,
+          min_sparse_spread: 0.05,
+          full_sparse_spread: 0.3,
+        },
+      },
+    });
+
+    MIG.run(workspaceDir);
+
+    const parsed = MemoryConfigSchema.parse(memory());
+    const withFallback = resolveSubstrateTuning(parsed);
+    const substrateOnly = resolveSubstrateOnly(
+      memory().substrate as Record<string, unknown>,
+    );
+
+    // The load-bearing claim: after the copy, the substrate namespace plus the
+    // shipped defaults reproduce the resolver's substrate→v2 fallback exactly.
+    expect(substrateOnly).toEqual(withFallback);
+    // Anchored against the operator's actual intent, so the equality above
+    // cannot pass by both sides being wrong in the same way.
+    expect(withFallback.consolidation_interval_hours).toBe(6);
+    expect(withFallback.consolidation_max_buffer_lines).toBeNull();
+    expect(withFallback.spread_k).toBe(0.4);
+    expect(withFallback.spread_hops).toBe(2);
+    expect(withFallback.min_sparse_spread).toBe(0.05);
+  });
+
+  test("bm25_b at the historical 0.75 default is the one value the copy rule cannot carry", () => {
+    // The skip list treats 0.75 as loader-seeded, so it never reaches
+    // memory.substrate and only the fallback keeps it in effect. Recorded here
+    // because it is the single case where dropping the fallback would change
+    // behavior.
+    write({ memory: { v2: { bm25_b: 0.75 } } });
+
+    MIG.run(workspaceDir);
+
+    const parsed = MemoryConfigSchema.parse(memory());
+    expect(resolveSubstrateTuning(parsed).bm25_b).toBe(0.75);
+    expect(resolveSubstrateOnly({}).bm25_b).toBe(0.4);
   });
 
   test("never clobbers an already-set memory.substrate key, but still copies its unset siblings", () => {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -869,7 +869,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-24T20:54:04.000Z"
+      "updatedAt": "2026-07-24T22:39:12.000Z"
     },
     {
       "id": "start-the-day",
@@ -1107,7 +1107,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-22T18:02:37.000Z"
+      "updatedAt": "2026-07-25T16:23:54.000Z"
     },
     {
       "id": "vellum-oauth-integrations",

--- a/skills/vellum-memory-v3-migration/SKILL.md
+++ b/skills/vellum-memory-v3-migration/SKILL.md
@@ -89,15 +89,18 @@ If the user declines, stop — no snapshot, no work. If `assistant ui confirm` i
 
 Consolidation is the **only** process that writes `memory/concepts/`. If it fires mid-migration it adds pages absent from your snapshot (never reformed) that the cutover then clobbers. Freeze it in two parts — disable the triggers, then wait out any run already in flight — before you snapshot. This leaves v2 retrieval live (unlike disabling `memory.v2.enabled` wholesale).
 
-**(a) Record, then disable, both triggers.** Consolidation fires on a size trigger (`consolidation_max_buffer_lines`) and a time trigger (`consolidation_interval_hours`) — those are the only two paths. Capture the current values first so you can restore them at cutover:
+**(a) Record, then disable, both triggers.** Consolidation fires on a size trigger (`consolidation_max_buffer_lines`) and a time trigger (`consolidation_interval_hours`) — those are the only two paths. Each lives in **two namespaces**: `memory.substrate.X` overrides `memory.v2.X`, and the substrate key wins whenever it is present. Freeze in the winning namespace, and record the whole substrate override object first — that object, verbatim, is what Step 9 restores:
 
 ```
 cd "$VELLUM_WORKSPACE_DIR"   # the workspace root — NOT /workspace on local installs
-assistant config get memory.v2.consolidation_max_buffer_lines   # record (default 100)
-assistant config get memory.v2.consolidation_interval_hours     # record (default 4)
-assistant config set memory.v2.consolidation_max_buffer_lines null     # size trigger off
-assistant config set memory.v2.consolidation_interval_hours 876000     # time trigger off (~100y)
+assistant config get memory.substrate                           # record VERBATIM — may print "(not set)"
+assistant config get memory.v2.consolidation_max_buffer_lines   # record (shipped default 100)
+assistant config get memory.v2.consolidation_interval_hours     # record (shipped default 8)
+assistant config set memory.substrate.consolidation_max_buffer_lines null     # size trigger off
+assistant config set memory.substrate.consolidation_interval_hours 876000     # time trigger off (~100y)
 ```
+
+Freezing via `memory.v2.*` is **not** enough: on a workspace whose substrate twins are already set, a `memory.v2` write persists but changes no behavior. `config set` prints a `Warning:` naming the winning key when that happens, and `config get` on a shadowed `memory.v2` key prints a `Shadowed:` line with the value actually in effect — treat either as a signal that you are editing the wrong namespace.
 
 **(b) Wait out any in-flight run.** A run holds `memory/.v2-state/consolidation.lock` (`<pid> <ms>`) while working (hard-capped at 15 min) and removes it when done. The triggers are off now, so no new run can start — just wait for the lock to clear:
 
@@ -206,13 +209,18 @@ rsync -a --delete .mv3/staging/ memory/concepts/                     # deploy th
 assistant memory v3 backfill-sections                                # seed section embeddings; verify non-zero
 assistant memory v3 rebuild-index                                    # invalidate lanes so next turn rebuilds
 assistant config set memory.v3.live true                             # v3 becomes the live injected source
-# restore the two triggers to the values you recorded in Step 1 (defaults shown — use YOUR recorded values):
-assistant config set memory.v2.consolidation_max_buffer_lines 100    # re-enable size trigger
-assistant config set memory.v2.consolidation_interval_hours 4        # re-enable time trigger
+# Restore consolidation in the namespace that wins: replace memory.substrate
+# with the object you recorded in Step 1 (use '{}' if it printed "(not set)").
+# Re-read memory.substrate first if the assistant was upgraded mid-migration —
+# an upgrade can copy memory.v2 overrides into it, and those must survive.
+assistant config set memory.substrate '<the object recorded in Step 1>'
+# Verify the EFFECTIVE values, not the shadowed ones:
+assistant config get memory.v2.consolidation_max_buffer_lines        # expect YOUR value, no "Shadowed:" line
+assistant config get memory.v2.consolidation_interval_hours          # expect YOUR value, no "Shadowed:" line
 assistant config get memory.v3.live                                  # expect: true
 ```
 
-`memory.v3.live` is plain workspace config the assistant owns — no feature flag, no operator hand-off. **Order matters:** set `memory.v3.live true` _before_ restoring the triggers, so the next consolidation is v3-shape, not v2. (`memory.v2.enabled` stayed `true` throughout — retrieval was never interrupted; only the triggers were paused.) Keep `.mv3/backup-concepts.*` and `.mv3/snapshot/` until the user confirms the live wiki is good. **Rollback:** `rsync -a --delete` from the backup over `memory/concepts/`, then `assistant config set memory.v3.live false` (the restored triggers then run v2-shape consolidation on the restored corpus).
+`memory.v3.live` is plain workspace config the assistant owns — no feature flag, no operator hand-off. **Order matters:** set `memory.v3.live true` _before_ restoring the triggers, so the next consolidation is v3-shape, not v2. (`memory.v2.enabled` stayed `true` throughout — retrieval was never interrupted; only the triggers were paused.) A `Shadowed:` line on either verify read means a `memory.substrate` twin is still set and consolidation is still frozen — the restore did not take; fix the substrate object before you call the cutover done. Keep `.mv3/backup-concepts.*` and `.mv3/snapshot/` until the user confirms the live wiki is good. **Rollback:** `rsync -a --delete` from the backup over `memory/concepts/`, then `assistant config set memory.v3.live false` (the restored triggers then run v2-shape consolidation on the restored corpus).
 
 ```
 git add -A && git commit -m "memory-v3-migration: complete (wiki deployed, sections backfilled)" --allow-empty
@@ -231,7 +239,7 @@ Close the inference session if you opened one (`assistant inference session clos
 - **Editorial judgment is the assistant's.** Taxonomy (Step 3) and final review (Step 7) are the assistant's calls; fan-out leaves draft, they never mark an article final.
 - **Cluster-grain authoring.** One agent per topic cluster, not per page — keeps the run under the engine's 500-agent cap and keeps topical judgment coherent.
 - **No eval, no cutover.** The wiki ships only after `assistant memory v3 eval-tally` returns `gate: pass` (wiki wins or ties) on a pinned, reproducible turn set — never on a hand tally. A `fail`, a low-confidence verdict, or an unrun gate blocks cutover.
-- **Freeze consolidation, then go live by config.** Before the snapshot (Step 1) disable both consolidation triggers (`consolidation_max_buffer_lines: null`, `consolidation_interval_hours` huge) and wait out any in-flight run via `memory/.v2-state/consolidation.lock` — consolidation is the only live-corpus writer. At cutover (Step 9) set `memory.v3.live true` _then_ restore the triggers; the order keeps the next consolidation in v3 shape.
+- **Freeze consolidation in `memory.substrate`, then go live by config.** Before the snapshot (Step 1) disable both consolidation triggers under `memory.substrate` (`consolidation_max_buffer_lines: null`, `consolidation_interval_hours` huge) — that namespace overrides `memory.v2`, so a `memory.v2` write is inert wherever a substrate twin exists — and wait out any in-flight run via `memory/.v2-state/consolidation.lock`; consolidation is the only live-corpus writer. Restore by replacing `memory.substrate` with the object recorded in Step 1, and verify with reads that print no `Shadowed:` line. At cutover (Step 9) set `memory.v3.live true` _then_ restore the triggers; the order keeps the next consolidation in v3 shape.
 - **Lowercase, dash-separated flat slugs.** `the-cutover.md`, not `Arcs/The-Cutover.md`. v3 slugs are flat; hubs organize via `main:`/`links:`, not folders.
 - **Three sentinel commits**, all prefixed `memory-v3-migration:` — start / staged+audited / complete.
 


### PR DESCRIPTION
## Summary
- The v3-migration skill's consolidation freeze/restore now targets the namespace that actually wins, so restore is no longer a silent no-op on migrated workspaces
- Shadowing is now discoverable instead of silent
- Migration 135 gains the resolved-equivalence proof test its acceptance criterion called for, and documents its non-default-only copy rule

Found by self-review of plan memory-tier-separation.md (PRs #39172, #39173).