### PR TITLE
fix(memory): reconcile capability embeddings on content change and failed upserts

### DIFF
--- a/assistant/src/persistence/job-utils.ts
+++ b/assistant/src/persistence/job-utils.ts
@@ -230,8 +230,40 @@ export async function embedAndUpsert(
       ? generateSparseEmbedding(normalized.text)
       : undefined;
 
-  // Persist embedding in SQLite for cross-restart cache
   const now = Date.now();
+  const qdrant = requireQdrantClient();
+
+  try {
+    const modality = normalized.type;
+    await withQdrantBreaker(() =>
+      qdrant.upsert(
+        targetType,
+        targetId,
+        vector,
+        {
+          text: payloadText,
+          modality,
+          created_at: (extraPayload?.created_at as number) ?? now,
+          ...(extraPayload as Record<string, unknown> | undefined),
+        },
+        sparseVector,
+      ),
+    );
+  } catch (err) {
+    log.warn(
+      { err, targetType, targetId },
+      "Failed to upsert embedding to Qdrant",
+    );
+    throw err;
+  }
+
+  // Persist the embedding in SQLite for the cross-restart cache, after the
+  // point is live in Qdrant. Consumers read a row as "this target is indexed"
+  // — the graph-node orphan sweep and the capability-seed reconcile both do —
+  // so a row written ahead of the upsert would mark a missing point as
+  // embedded and suppress the re-embed that would restore it. Best-effort in
+  // the other direction: a write failure logs and leaves the point in place,
+  // and the next run re-embeds.
   try {
     const blobValue = vectorToBlob(vector);
     db.insert(memoryEmbeddings)
@@ -266,31 +298,5 @@ export async function embedAndUpsert(
       .run();
   } catch (err) {
     log.warn({ err, targetType, targetId }, "Failed to write embedding cache");
-  }
-
-  const qdrant = requireQdrantClient();
-
-  try {
-    const modality = normalized.type;
-    await withQdrantBreaker(() =>
-      qdrant.upsert(
-        targetType,
-        targetId,
-        vector,
-        {
-          text: payloadText,
-          modality,
-          created_at: (extraPayload?.created_at as number) ?? now,
-          ...(extraPayload as Record<string, unknown> | undefined),
-        },
-        sparseVector,
-      ),
-    );
-  } catch (err) {
-    log.warn(
-      { err, targetType, targetId },
-      "Failed to upsert embedding to Qdrant",
-    );
-    throw err;
   }
 }

--- a/assistant/src/plugins/defaults/memory/__tests__/capability-seed-embed-gate.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/capability-seed-embed-gate.test.ts
@@ -4,10 +4,20 @@
  * tier), but `embed_graph_node` rows target the v1 Qdrant collection and
  * dispatch discards them while concept-page memory is active — so the seeder
  * writes those rows only when v1 is the active tier. On the v1 path the
- * seeder also reconciles unchanged nodes that lack a stored embedding, so a
- * capability seeded while a higher tier was active still gets its v1 point.
- * Enqueues coalesce with a pending `embed_graph_node` row for the same node,
- * so back-to-back seed passes queue at most one job per node.
+ * seeder also reconciles unchanged nodes whose current content has no
+ * embedding under the current backend, so a capability seeded (or edited)
+ * while a higher tier was active still gets its v1 point. A node counts as
+ * embedded only when a `memory_embeddings` row matches its id, the backend's
+ * (provider, model) identity, and the content hash of the text the embed job
+ * would send — anything else re-enqueues. Enqueues coalesce with a pending
+ * `embed_graph_node` row for the same node, so back-to-back seed passes queue
+ * at most one job per node.
+ *
+ * The second block covers the invariant that reconcile leans on:
+ * `embedAndUpsert` writes its `memory_embeddings` row only once the Qdrant
+ * upsert has succeeded, so a cache row never claims a point that is not
+ * there. It lives here because `embedAndUpsert` has no dedicated test file
+ * and the capability reconcile is what the honesty of that row protects.
  */
 import { randomUUID } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -19,10 +29,11 @@ import {
   beforeEach,
   describe,
   expect,
+  mock,
   test,
 } from "bun:test";
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { assertNotLiveDb } from "../../../../__tests__/assert-not-live-db.js";
 
@@ -30,14 +41,70 @@ const tmpWorkspace = mkdtempSync(join(tmpdir(), "capability-seed-embed-gate-"));
 const previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
 process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
 
+/** Identity the stubbed embedding backend reports for every lookup. */
+const TEST_PROVIDER = "local";
+const TEST_MODEL = "test-model";
+
+// ── Embedding backend stub ─────────────────────────────────────────
+// The reconcile lookup keys on the backend's (provider, model) identity, and
+// `embedAndUpsert` embeds through the same module. Both are stubbed so the
+// tests run without a backend; the remaining exports stay real so unrelated
+// importers keep working.
+const realEmbeddingBackend =
+  await import("../../../../persistence/embeddings/embedding-backend.js");
+mock.module("../../../../persistence/embeddings/embedding-backend.js", () => ({
+  ...realEmbeddingBackend,
+  getMemoryBackendStatus: async () => ({
+    enabled: true,
+    degraded: false,
+    provider: TEST_PROVIDER,
+    model: TEST_MODEL,
+    reason: null,
+  }),
+  embedWithBackend: async (_config: unknown, inputs: unknown[]) => ({
+    provider: TEST_PROVIDER,
+    model: TEST_MODEL,
+    vectors: inputs.map(() => [0.1, 0.2, 0.3, 0.4]),
+  }),
+  generateSparseEmbedding: () => ({ indices: [1], values: [1] }),
+  selectedBackendSupportsMultimodal: async () => false,
+}));
+
+// ── Qdrant client stub ─────────────────────────────────────────────
+// `upsertShouldFail` drives the failed-upsert case; upserted target ids are
+// recorded so a success can be told apart from a no-op.
+let upsertShouldFail = false;
+const upsertedTargetIds: string[] = [];
+const realQdrantClient =
+  await import("../../../../persistence/embeddings/qdrant-client.js");
+mock.module("../../../../persistence/embeddings/qdrant-client.js", () => ({
+  ...realQdrantClient,
+  getQdrantClient: () => ({
+    upsert: async (_targetType: string, targetId: string) => {
+      if (upsertShouldFail) {
+        throw new Error("qdrant upsert failed");
+      }
+      upsertedTargetIds.push(targetId);
+    },
+  }),
+}));
+
 const { setConfig } =
   await import("../../../../__tests__/helpers/set-config.js");
+const { getConfig } = await import("../../../../config/loader.js");
 const { getDb, getMemoryDb } =
   await import("../../../../persistence/db-connection.js");
 const { initializeDb } = await import("../../../../persistence/db-init.js");
+const { embeddingInputContentHash } =
+  await import("../../../../persistence/embeddings/embedding-types.js");
+const { _resetQdrantBreaker: resetQdrantBreaker } =
+  await import("../../../../persistence/embeddings/qdrant-circuit-breaker.js");
+const { embedAndUpsert } = await import("../../../../persistence/job-utils.js");
 const { memoryEmbeddings, memoryGraphNodes, memoryJobs } =
   await import("../../../../persistence/schema/index.js");
 const { seedCliGraphNodes } = await import("../graph/capability-seed.js");
+const { formatNodeForEmbedding } = await import("../graph/graph-search.js");
+const { rowToNode } = await import("../graph/store.js");
 
 function countEmbedGraphNodeJobs(): number {
   return getMemoryDb()!
@@ -47,40 +114,60 @@ function countEmbedGraphNodeJobs(): number {
     .all().length;
 }
 
-function countCapabilityNodes(): number {
+function capabilityNodeRows(): Array<typeof memoryGraphNodes.$inferSelect> {
   return getMemoryDb()!
     .select()
     .from(memoryGraphNodes)
     .where(eq(memoryGraphNodes.type, "procedural"))
+    .all();
+}
+
+function countCapabilityNodes(): number {
+  return capabilityNodeRows().length;
+}
+
+function countEmbeddingRows(targetId: string): number {
+  return getDb()
+    .select()
+    .from(memoryEmbeddings)
+    .where(
+      and(
+        eq(memoryEmbeddings.targetType, "graph_node"),
+        eq(memoryEmbeddings.targetId, targetId),
+      ),
+    )
     .all().length;
 }
 
 /**
  * Insert a `memory_embeddings` row for every capability node, simulating
- * completed `embed_graph_node` jobs. The reconcile path only checks row
- * presence on the `(target_type, target_id)` prefix, so provider/model/vector
- * values are arbitrary.
+ * completed `embed_graph_node` jobs. Defaults match what the embed job would
+ * write — the stub backend's identity and the hash of the text
+ * `embedGraphNodeDirect` embeds — so overriding one facet isolates it.
  */
-function insertEmbeddingRowsForAllCapabilityNodes(): void {
-  const nodes = getMemoryDb()!
-    .select({ id: memoryGraphNodes.id })
-    .from(memoryGraphNodes)
-    .where(eq(memoryGraphNodes.type, "procedural"))
-    .all();
+function insertEmbeddingRowsForAllCapabilityNodes(
+  overrides: {
+    provider?: string;
+    model?: string;
+    contentHash?: string;
+  } = {},
+): void {
   const now = Date.now();
-  for (const node of nodes) {
+  for (const row of capabilityNodeRows()) {
     getDb()
       .insert(memoryEmbeddings)
       .values({
         id: randomUUID(),
         targetType: "graph_node",
-        targetId: node.id,
-        provider: "test-provider",
-        model: "test-model",
+        targetId: row.id,
+        provider: overrides.provider ?? TEST_PROVIDER,
+        model: overrides.model ?? TEST_MODEL,
         dimensions: 4,
         vectorJson: JSON.stringify([0, 0, 0, 0]),
         vectorBlob: null,
-        contentHash: "test-hash",
+        contentHash:
+          overrides.contentHash ??
+          embeddingInputContentHash(formatNodeForEmbedding(rowToNode(row))),
         createdAt: now,
         updatedAt: now,
       })
@@ -88,21 +175,21 @@ function insertEmbeddingRowsForAllCapabilityNodes(): void {
   }
 }
 
+beforeAll(async () => {
+  await initializeDb();
+}, 30_000);
+
+afterAll(() => {
+  if (previousWorkspaceEnv === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+  }
+  assertNotLiveDb(tmpWorkspace);
+  rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
 describe("capability seeding embed_graph_node gate", () => {
-  beforeAll(async () => {
-    await initializeDb();
-  }, 30_000);
-
-  afterAll(() => {
-    if (previousWorkspaceEnv === undefined) {
-      delete process.env.VELLUM_WORKSPACE_DIR;
-    } else {
-      process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
-    }
-    assertNotLiveDb(tmpWorkspace);
-    rmSync(tmpWorkspace, { recursive: true, force: true });
-  });
-
   beforeEach(() => {
     getMemoryDb()!.run("DELETE FROM memory_jobs");
     getMemoryDb()!.run("DELETE FROM memory_graph_nodes");
@@ -152,7 +239,7 @@ describe("capability seeding embed_graph_node gate", () => {
     expect(countEmbedGraphNodeJobs()).toBe(nodes);
   });
 
-  test("v1 with embedding rows present: unchanged nodes do not enqueue duplicates", async () => {
+  test("v1 with current embedding rows present: unchanged nodes do not enqueue duplicates", async () => {
     setConfig("memory", { v2: { enabled: false }, v3: { live: false } });
     await seedCliGraphNodes();
     expect(countCapabilityNodes()).toBeGreaterThan(0);
@@ -163,5 +250,81 @@ describe("capability seeding embed_graph_node gate", () => {
     await seedCliGraphNodes();
 
     expect(countEmbedGraphNodeJobs()).toBe(0);
+  });
+
+  test("v1 with a stale content hash: unchanged nodes re-enqueue embed_graph_node", async () => {
+    setConfig("memory", { v2: { enabled: false }, v3: { live: false } });
+    await seedCliGraphNodes();
+
+    // The hash a capability's previous description would have left behind.
+    insertEmbeddingRowsForAllCapabilityNodes({
+      contentHash: "hash-of-the-previous-description",
+    });
+    getMemoryDb()!.run("DELETE FROM memory_jobs");
+
+    await seedCliGraphNodes();
+
+    const nodes = countCapabilityNodes();
+    expect(nodes).toBeGreaterThan(0);
+    expect(countEmbedGraphNodeJobs()).toBe(nodes);
+  });
+
+  test("v1 with rows from another embedding provider: unchanged nodes re-enqueue", async () => {
+    setConfig("memory", { v2: { enabled: false }, v3: { live: false } });
+    await seedCliGraphNodes();
+
+    insertEmbeddingRowsForAllCapabilityNodes({ provider: "other-provider" });
+    getMemoryDb()!.run("DELETE FROM memory_jobs");
+
+    await seedCliGraphNodes();
+
+    const nodes = countCapabilityNodes();
+    expect(nodes).toBeGreaterThan(0);
+    expect(countEmbedGraphNodeJobs()).toBe(nodes);
+  });
+
+  test("v1 with rows from another embedding model: unchanged nodes re-enqueue", async () => {
+    setConfig("memory", { v2: { enabled: false }, v3: { live: false } });
+    await seedCliGraphNodes();
+
+    insertEmbeddingRowsForAllCapabilityNodes({ model: "other-model" });
+    getMemoryDb()!.run("DELETE FROM memory_jobs");
+
+    await seedCliGraphNodes();
+
+    const nodes = countCapabilityNodes();
+    expect(nodes).toBeGreaterThan(0);
+    expect(countEmbedGraphNodeJobs()).toBe(nodes);
+  });
+});
+
+describe("embedAndUpsert embedding-cache row", () => {
+  beforeEach(() => {
+    upsertShouldFail = false;
+    upsertedTargetIds.length = 0;
+    getDb().delete(memoryEmbeddings).run();
+    resetQdrantBreaker();
+  });
+
+  test("a failed Qdrant upsert leaves no cache row", async () => {
+    upsertShouldFail = true;
+
+    await expect(
+      embedAndUpsert(getConfig(), "graph_node", "node-upsert-fails", "text"),
+    ).rejects.toThrow("qdrant upsert failed");
+
+    expect(countEmbeddingRows("node-upsert-fails")).toBe(0);
+  });
+
+  test("a successful Qdrant upsert writes the cache row", async () => {
+    await embedAndUpsert(
+      getConfig(),
+      "graph_node",
+      "node-upsert-succeeds",
+      "text",
+    );
+
+    expect(upsertedTargetIds).toEqual(["node-upsert-succeeds"]);
+    expect(countEmbeddingRows("node-upsert-succeeds")).toBe(1);
   });
 });

--- a/assistant/src/plugins/defaults/memory/graph/capability-seed.ts
+++ b/assistant/src/plugins/defaults/memory/graph/capability-seed.ts
@@ -17,6 +17,8 @@ import {
   type SkillSummary,
 } from "../../../../config/skills.js";
 import { getDb } from "../../../../persistence/db-connection.js";
+import { getMemoryBackendStatus } from "../../../../persistence/embeddings/embedding-backend.js";
+import { embeddingInputContentHash } from "../../../../persistence/embeddings/embedding-types.js";
 import {
   enqueueMemoryJob,
   upsertEmbedGraphNodeJob,
@@ -32,10 +34,12 @@ import {
 import { getLogger } from "../logging.js";
 import { memoryDbOrNull } from "../memory-db.js";
 import type { SkillCapabilityInput } from "../substrate/skill-content.js";
-import { createNode } from "./store.js";
+import { formatNodeForEmbedding } from "./graph-search.js";
+import { createNode, rowToNode } from "./store.js";
 import {
   CAPABILITY_CLI_SOURCE_PREFIX as CLI_SOURCE_PREFIX,
   CAPABILITY_SKILL_SOURCE_PREFIX as SKILL_SOURCE_PREFIX,
+  type MemoryNode,
 } from "./types.js";
 
 const log = getLogger("graph-capability-seed");
@@ -78,11 +82,12 @@ const CAPABILITY_SIGNIFICANCE = 0.6;
 function upsertSkillCapabilityNode(
   skillId: string,
   input: SkillCapabilityInput,
+  reconcile: ReconcileQueue,
 ): void {
   try {
     const content = buildSkillContent(input);
     const sourceKey = `${SKILL_SOURCE_PREFIX}${skillId}`;
-    upsertCapabilityNode(sourceKey, content);
+    upsertCapabilityNode(sourceKey, content, reconcile);
   } catch (err) {
     log.warn({ err, skillId }, "Failed to upsert skill capability graph node");
   }
@@ -94,11 +99,12 @@ function upsertSkillCapabilityNode(
 function upsertCliCapabilityNode(
   commandName: string,
   description: string,
+  reconcile: ReconcileQueue,
 ): void {
   try {
     const content = `The "assistant ${commandName}" CLI command is available. ${description}.`;
     const sourceKey = `${CLI_SOURCE_PREFIX}${commandName}`;
-    upsertCapabilityNode(sourceKey, content);
+    upsertCapabilityNode(sourceKey, content, reconcile);
   } catch (err) {
     log.warn(
       { err, commandName },
@@ -130,6 +136,7 @@ export function seedSkillGraphNodes(): void {
     const resolved = resolveSkillStates(catalog, config);
     const enabled = resolved.filter((r) => r.state === "enabled");
 
+    const reconcile: ReconcileQueue = [];
     const seenKeys = new Set<string>();
     for (const { summary } of enabled) {
       const input = fromSkillSummary(summary);
@@ -146,7 +153,7 @@ export function seedSkillGraphNodes(): void {
         }
       }
 
-      upsertSkillCapabilityNode(summary.id, input);
+      upsertSkillCapabilityNode(summary.id, input, reconcile);
       seenKeys.add(`${SKILL_SOURCE_PREFIX}${summary.id}`);
     }
 
@@ -183,6 +190,11 @@ export function seedSkillGraphNodes(): void {
     // stop appearing as duplicates. Idempotent — once cleaned, subsequent
     // runs find nothing.
     cleanupOldFormatCapabilityNodes();
+
+    // The node writes above are synchronous; only the reconcile tail needs to
+    // resolve the embedding backend, so it runs detached to keep this entry
+    // point synchronous for its callers. It never rejects.
+    void reconcileCapabilityEmbeddings(reconcile);
   } catch (err) {
     log.warn({ err }, "Failed to seed skill graph nodes");
   }
@@ -194,13 +206,15 @@ export function seedSkillGraphNodes(): void {
  */
 export async function seedCliGraphNodes(): Promise<void> {
   try {
+    const reconcile: ReconcileQueue = [];
     const seenKeys = new Set<string>();
     for (const help of CLI_COMMAND_HELP) {
-      upsertCliCapabilityNode(help.name, help.description);
+      upsertCliCapabilityNode(help.name, help.description, reconcile);
       seenKeys.add(`${CLI_SOURCE_PREFIX}${help.name}`);
     }
 
     pruneStaleCapabilities(CLI_SOURCE_PREFIX, seenKeys);
+    await reconcileCapabilityEmbeddings(reconcile);
   } catch (err) {
     log.warn({ err }, "Failed to seed CLI graph nodes");
   }
@@ -222,6 +236,7 @@ export async function seedUninstalledCatalogSkillMemories(): Promise<void> {
     const installedCatalog = loadSkillCatalog();
     const installedIds = new Set(installedCatalog.map((s) => s.id));
 
+    const reconcile: ReconcileQueue = [];
     const config = getConfig();
     for (const entry of fullCatalog) {
       if (installedIds.has(entry.id)) {
@@ -233,8 +248,10 @@ export async function seedUninstalledCatalogSkillMemories(): Promise<void> {
         continue;
       }
 
-      upsertSkillCapabilityNode(entry.id, fromCatalogSkill(entry));
+      upsertSkillCapabilityNode(entry.id, fromCatalogSkill(entry), reconcile);
     }
+
+    await reconcileCapabilityEmbeddings(reconcile);
   } catch (err) {
     log.warn({ err }, "Failed to seed uninstalled catalog skill memories");
   }
@@ -259,38 +276,78 @@ function buildSkillContent(input: SkillCapabilityInput): string {
 }
 
 /**
- * Reconcile a capability node that lacks a stored dense embedding: enqueue
- * `embed_graph_node` for it. A capability seeded or updated while
- * concept-page memory is active gets no embed row, so when the assistant
- * runs under v1 the unchanged-content short-circuit alone would leave its
- * v1 Qdrant point missing. One indexed `memory_embeddings` prefix lookup
- * per capability node, on the v1 path only. The enqueue coalesces with a
- * pending `embed_graph_node` row for the same node, so back-to-back seed
- * passes (e.g. `refreshSkillCapabilityMemories` seeding before and after
- * the catalog resolves) queue at most one job per node while the first is
- * still pending. Fail-open: a lookup error logs and skips — reconciliation
- * never blocks seeding.
+ * Capability nodes a seeding pass left content-unchanged, and so are candidates
+ * for v1 embedding reconciliation. Collected during the pass and drained by
+ * {@link reconcileCapabilityEmbeddings} once at the end: resolving the
+ * embedding backend reaches the credential store, so it happens once per pass
+ * rather than once per capability.
  */
-function enqueueEmbedIfMissing(nodeId: string): void {
+type ReconcileQueue = MemoryNode[];
+
+/**
+ * Enqueue `embed_graph_node` for every queued capability node whose current
+ * content has no dense embedding under the current embedding backend.
+ *
+ * A capability seeded or updated while concept-page memory is active gets no
+ * embed row, so when the assistant runs under v1 the unchanged-content
+ * short-circuit alone would leave its v1 Qdrant point missing or stale. A node
+ * counts as embedded only when a `memory_embeddings` row matches all three
+ * facets of its current embedding identity:
+ *
+ *  - `(target_type, target_id)` — the node itself;
+ *  - `(provider, model)` — the table is keyed per backend, so a row written by
+ *    a previous backend describes vectors that are not in play any more;
+ *  - `content_hash` — of the exact text `embedGraphNodeDirect` embeds for a
+ *    node without image refs (capability nodes carry none), so a capability
+ *    whose description changed under a higher tier re-embeds instead of
+ *    keeping the vector built from the old text.
+ *
+ * That is one indexed `memory_embeddings` lookup per queued node (the unique
+ * index covers target + provider + model). Rows are written only after the
+ * Qdrant upsert succeeds (see `embedAndUpsert`), so a present row also means
+ * the point itself landed. The enqueue coalesces with a pending
+ * `embed_graph_node` row for the same node, so back-to-back seed passes (e.g.
+ * `refreshSkillCapabilityMemories` seeding before and after the catalog
+ * resolves) queue at most one job per node while the first is still pending.
+ *
+ * Fail-open and never rejects: an unresolvable backend or a lookup error logs
+ * and skips the pass — reconciliation never blocks seeding.
+ */
+async function reconcileCapabilityEmbeddings(
+  nodes: ReconcileQueue,
+): Promise<void> {
+  if (nodes.length === 0) {
+    return;
+  }
   try {
-    const row = getDb()
-      .select({ id: memoryEmbeddings.id })
-      .from(memoryEmbeddings)
-      .where(
-        and(
-          eq(memoryEmbeddings.targetType, "graph_node"),
-          eq(memoryEmbeddings.targetId, nodeId),
-        ),
-      )
-      .get();
-    if (!row) {
-      upsertEmbedGraphNodeJob({ nodeId });
+    const status = await getMemoryBackendStatus(getConfig());
+    if (!status.provider || !status.model) {
+      return;
+    }
+    const db = getDb();
+    for (const node of nodes) {
+      const contentHash = embeddingInputContentHash(
+        formatNodeForEmbedding(node),
+      );
+      const row = db
+        .select({ id: memoryEmbeddings.id })
+        .from(memoryEmbeddings)
+        .where(
+          and(
+            eq(memoryEmbeddings.targetType, "graph_node"),
+            eq(memoryEmbeddings.targetId, node.id),
+            eq(memoryEmbeddings.provider, status.provider),
+            eq(memoryEmbeddings.model, status.model),
+            eq(memoryEmbeddings.contentHash, contentHash),
+          ),
+        )
+        .get();
+      if (!row) {
+        upsertEmbedGraphNodeJob({ nodeId: node.id });
+      }
     }
   } catch (err) {
-    log.warn(
-      { err, nodeId },
-      "Capability embedding reconcile failed; skipping",
-    );
+    log.warn({ err }, "Capability embedding reconcile failed; skipping");
   }
 }
 
@@ -304,10 +361,15 @@ function enqueueEmbedIfMissing(nodeId: string): void {
  * The node write itself is all-tier — the `list_memory` surface reads
  * capability nodes on every tier. The `embed_graph_node` enqueue is v1-only:
  * those rows target the v1 Qdrant collection, and dispatch discards them
- * while concept-page memory is active. On the v1 path an unchanged node with
- * no stored embedding still enqueues (see {@link enqueueEmbedIfMissing}).
+ * while concept-page memory is active. On the v1 path an unchanged node joins
+ * the pass's reconcile queue, which enqueues it when its current content has
+ * no embedding (see {@link reconcileCapabilityEmbeddings}).
  */
-function upsertCapabilityNode(sourceKey: string, content: string): void {
+function upsertCapabilityNode(
+  sourceKey: string,
+  content: string,
+  reconcile: ReconcileQueue,
+): void {
   const db = memoryDbOrNull("upsertCapabilityNode");
   if (!db) {
     return;
@@ -341,7 +403,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
         .where(eq(memoryGraphNodes.id, existing.id))
         .run();
       if (isMemoryV1Active(getConfig())) {
-        enqueueEmbedIfMissing(existing.id);
+        reconcile.push(rowToNode(existing));
       }
       return;
     }
@@ -401,7 +463,9 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
  */
 function deleteCapabilityNode(sourceKey: string): void {
   const db = memoryDbOrNull("deleteCapabilityNode");
-  if (!db) {return;}
+  if (!db) {
+    return;
+  }
   const existing = db
     .select()
     .from(memoryGraphNodes)
@@ -432,7 +496,9 @@ function deleteCapabilityNode(sourceKey: string): void {
  */
 function cleanupOldFormatCapabilityNodes(): void {
   const db = memoryDbOrNull("cleanupOldFormatCapabilityNodes");
-  if (!db) {return;}
+  if (!db) {
+    return;
+  }
   const now = Date.now();
 
   // --- skill:* old-format nodes ---
@@ -499,7 +565,9 @@ function cleanupOldFormatCapabilityNodes(): void {
  */
 function pruneStaleCapabilities(prefix: string, activeKeys: Set<string>): void {
   const db = memoryDbOrNull("pruneStaleCapabilities");
-  if (!db) {return;}
+  if (!db) {
+    return;
+  }
   const allCapabilities = db
     .select()
     .from(memoryGraphNodes)

--- a/assistant/src/plugins/defaults/memory/graph/graph-search.ts
+++ b/assistant/src/plugins/defaults/memory/graph/graph-search.ts
@@ -34,8 +34,10 @@ const log = getLogger("graph-search");
 /**
  * Format a graph node's content for embedding. Prepends type metadata
  * so the embedding captures structural information alongside content.
+ * Callers that need the content hash of a node's stored embedding hash this
+ * exact string, so the format has a single definition.
  */
-function formatNodeForEmbedding(node: MemoryNode): string {
+export function formatNodeForEmbedding(node: MemoryNode): string {
   const parts = [`[${node.type}]`];
   if (node.emotionalCharge.intensity > 0.3) {
     const valenceLabel =

--- a/assistant/src/plugins/defaults/memory/graph/store.ts
+++ b/assistant/src/plugins/defaults/memory/graph/store.ts
@@ -54,7 +54,10 @@ function memoryDb(): DrizzleDb {
 // Row ↔ Domain conversion helpers
 // ---------------------------------------------------------------------------
 
-function rowToNode(row: typeof memoryGraphNodes.$inferSelect): MemoryNode {
+/** Project a `memory_graph_nodes` row onto its domain node. */
+export function rowToNode(
+  row: typeof memoryGraphNodes.$inferSelect,
+): MemoryNode {
   return {
     id: row.id,
     content: row.content,


### PR DESCRIPTION
## Summary
- enqueueEmbedIfMissing now compares the cached contentHash, so a capability whose description changed while the substrate was active is re-embedded on return to v1 instead of keeping a stale vector
- A failed Qdrant upsert no longer leaves a cache row that makes the node look embedded

Found by self-review of plan memory-tier-separation.md (PRs #39168, #39175).