### PR TITLE
style(memory): restore pinned-prettier formatting across the memory plugin

### DIFF
--- a/assistant/src/plugins/defaults/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/memory-v2.ts
@@ -168,13 +168,17 @@ async function activationEvidence(
   limit: number,
 ): Promise<RecallEvidence[]> {
   const trimmedQuery = query.trim();
-  if (trimmedQuery.length === 0) {return [];}
+  if (trimmedQuery.length === 0) {
+    return [];
+  }
 
   const denseResult = await embedWithRetry(context.config, [trimmedQuery], {
     signal: context.signal,
   });
   const denseVector = denseResult.vectors[0];
-  if (!denseVector || denseVector.length === 0) {return [];}
+  if (!denseVector || denseVector.length === 0) {
+    return [];
+  }
   const sparseVector = generateBm25QueryEmbedding(trimmedQuery);
 
   const tuning = resolveSubstrateTuning(context.config.memory);
@@ -184,7 +188,9 @@ async function activationEvidence(
     sparseVector,
     annLimit,
   );
-  if (hits.length === 0) {return [];}
+  if (hits.length === 0) {
+    return [];
+  }
 
   const { dense_weight: denseWeight, sparse_weight: sparseWeight } = tuning;
 
@@ -237,7 +243,9 @@ async function activationEvidence(
 
   const ranked = [...finalActivation.entries()]
     .sort(([slugA, valA], [slugB, valB]) => {
-      if (valB !== valA) {return valB - valA;}
+      if (valB !== valA) {
+        return valB - valA;
+      }
       return slugA < slugB ? -1 : slugA > slugB ? 1 : 0;
     })
     .slice(0, limit);
@@ -246,7 +254,9 @@ async function activationEvidence(
     ranked.map(async ([slug, score]) => {
       try {
         const page = await readPage(context.workingDir, slug);
-        if (!page) {return null;}
+        if (!page) {
+          return null;
+        }
         return { slug, score, body: page.body.trim() };
       } catch (err) {
         log.warn({ err, slug }, "Failed to read concept page during recall");
@@ -257,7 +267,9 @@ async function activationEvidence(
 
   const evidence: RecallEvidence[] = [];
   for (const entry of pages) {
-    if (!entry || entry.body.length === 0) {continue;}
+    if (!entry || entry.body.length === 0) {
+      continue;
+    }
     const locator = `memory/concepts/${entry.slug}.md`;
     evidence.push({
       id: `memory:v2:${entry.slug}`,
@@ -307,10 +319,14 @@ async function lexicalEvidence(
   limit: number,
 ): Promise<RecallEvidence[]> {
   const queryTerms = tokenizeSalientRecallTerms(query);
-  if (queryTerms.size === 0 || limit <= 0) {return [];}
+  if (queryTerms.size === 0 || limit <= 0) {
+    return [];
+  }
 
   const conceptsRoot = await resolveContainedConceptsRoot(context.workingDir);
-  if (!conceptsRoot) {return [];}
+  if (!conceptsRoot) {
+    return [];
+  }
 
   const matches: MemoryV2LexicalMatch[] = [];
   const visitedDirectories = new Set<string>([conceptsRoot]);
@@ -375,7 +391,9 @@ async function walkConceptsDirectory(
       continue;
     }
 
-    if (!isPathInsideRoot(entryRealPath, conceptsRoot)) {continue;}
+    if (!isPathInsideRoot(entryRealPath, conceptsRoot)) {
+      continue;
+    }
 
     let entryStats;
     try {
@@ -385,7 +403,9 @@ async function walkConceptsDirectory(
     }
 
     if (entryStats.isDirectory()) {
-      if (visitedDirectories.has(entryRealPath)) {continue;}
+      if (visitedDirectories.has(entryRealPath)) {
+        continue;
+      }
       visitedDirectories.add(entryRealPath);
       await walkConceptsDirectory(
         entryRealPath,
@@ -411,7 +431,9 @@ async function walkConceptsDirectory(
       conceptsRoot,
       queryTerms,
     );
-    if (match) {matches.push(match);}
+    if (match) {
+      matches.push(match);
+    }
   }
 }
 
@@ -429,7 +451,9 @@ async function searchConceptFile(
 
   const lines = contents.split(/\r?\n/);
   const bestLine = findBestLine(lines, queryTerms);
-  if (!bestLine) {return null;}
+  if (!bestLine) {
+    return null;
+  }
 
   const slug = slugFromConceptPath(conceptsRoot, filePath);
   const slugTerms = termOverlap(tokenizeSalientRecallTerms(slug), queryTerms);
@@ -458,7 +482,9 @@ function findBestLine(
   lines.forEach((line, lineIndex) => {
     const lineTerms = tokenizeSalientRecallTerms(line);
     const matchedTerms = termOverlap(lineTerms, queryTerms);
-    if (matchedTerms.size === 0) {return;}
+    if (matchedTerms.size === 0) {
+      return;
+    }
 
     const score = matchedTerms.size * 10 + Math.min(lineTerms.size, 12) / 100;
     if (!best || score > best.score) {
@@ -484,7 +510,9 @@ function buildLexicalExcerpt(
     .join("\n")
     .trim();
 
-  if (excerpt.length <= MEMORY_V2_LEXICAL_EXCERPT_MAX_CHARS) {return excerpt;}
+  if (excerpt.length <= MEMORY_V2_LEXICAL_EXCERPT_MAX_CHARS) {
+    return excerpt;
+  }
 
   const focusedLine = `${lineIndex + 1}: ${lines[lineIndex]?.trimEnd() ?? ""}`;
   if (focusedLine.length <= MEMORY_V2_LEXICAL_EXCERPT_MAX_CHARS) {
@@ -518,9 +546,13 @@ function compareLexicalMatches(
   a: MemoryV2LexicalMatch,
   b: MemoryV2LexicalMatch,
 ): number {
-  if (b.score !== a.score) {return b.score - a.score;}
+  if (b.score !== a.score) {
+    return b.score - a.score;
+  }
   const slugCompare = a.slug.localeCompare(b.slug);
-  if (slugCompare !== 0) {return slugCompare;}
+  if (slugCompare !== 0) {
+    return slugCompare;
+  }
   return a.lineNumber - b.lineNumber;
 }
 
@@ -546,7 +578,9 @@ function mergeMemoryV2Evidence(
     ),
   ]) {
     const key = `${item.locator}\0${normalizeExcerpt(item.excerpt)}`;
-    if (seen.has(key)) {continue;}
+    if (seen.has(key)) {
+      continue;
+    }
     seen.add(key);
     merged.push(item);
   }
@@ -570,7 +604,9 @@ function termOverlap(
 ): Set<string> {
   const matchedTerms = new Set<string>();
   for (const term of queryTerms) {
-    if (haystackTerms.has(term)) {matchedTerms.add(term);}
+    if (haystackTerms.has(term)) {
+      matchedTerms.add(term);
+    }
   }
   return matchedTerms;
 }
@@ -580,7 +616,9 @@ function normalizeExcerpt(excerpt: string): string {
 }
 
 function truncateExcerpt(text: string, maxChars: number): string {
-  if (text.length <= maxChars) {return text;}
+  if (text.length <= maxChars) {
+    return text;
+  }
   return `${text.slice(0, maxChars - 3).trimEnd()}...`;
 }
 

--- a/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/plugins/defaults/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -212,7 +212,9 @@ const realDbModule =
 mock.module("../../../../../persistence/db-connection.js", () => ({
   ...realDbModule,
   getDb: () => {
-    if (!testDbHandle) {throw new Error("test db not initialized");}
+    if (!testDbHandle) {
+      throw new Error("test db not initialized");
+    }
     return testDbHandle;
   },
   getMemorySqlite: () => memorySqliteHandle,
@@ -396,7 +398,9 @@ describe("ConversationGraphMemory.prepareMemory — v2 routing (per-turn path)",
     expect(lastMsg?.role).toBe("user");
     const firstBlock = lastMsg?.content[0];
     expect(firstBlock?.type).toBe("text");
-    if (firstBlock?.type !== "text") {throw new Error("unexpected block type");}
+    if (firstBlock?.type !== "text") {
+      throw new Error("unexpected block type");
+    }
     expect(firstBlock.text.startsWith("<memory>\n")).toBe(true);
     expect(firstBlock.text.endsWith("\n</memory>")).toBe(true);
     // No nested wrapper.
@@ -431,7 +435,9 @@ describe("ConversationGraphMemory.prepareMemory — v2 routing (per-turn path)",
     const lastMsg = reinjected.runMessages[reinjected.runMessages.length - 1];
     const firstBlock = lastMsg?.content[0];
     expect(firstBlock?.type).toBe("text");
-    if (firstBlock?.type !== "text") {throw new Error("unexpected block type");}
+    if (firstBlock?.type !== "text") {
+      throw new Error("unexpected block type");
+    }
     expect(firstBlock.text.startsWith("<memory>\n")).toBe(true);
     expect(firstBlock.text.endsWith("\n</memory>")).toBe(true);
     expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
@@ -537,7 +543,9 @@ describe("ConversationGraphMemory.prepareMemory — v2 routing (context-load pat
     expect(result.injectedBlockText).not.toContain("<memory>");
     const lastMsg = result.runMessages[result.runMessages.length - 1];
     const firstBlock = lastMsg?.content[0];
-    if (firstBlock?.type !== "text") {throw new Error("unexpected block type");}
+    if (firstBlock?.type !== "text") {
+      throw new Error("unexpected block type");
+    }
     expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
 
     // v1 retrieval is fully bypassed when v2 is enabled.

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -94,7 +94,9 @@ const liveByConversation = new Map<string, ConversationGraphMemory>();
 export function getLiveGraphMemory(
   conversationId: string | undefined,
 ): ConversationGraphMemory | undefined {
-  if (!conversationId) {return undefined;}
+  if (!conversationId) {
+    return undefined;
+  }
   return liveByConversation.get(conversationId);
 }
 
@@ -146,7 +148,9 @@ export class ConversationGraphMemory {
    * Called during conversation disposal.
    */
   persistState(): void {
-    if (!this.initialized) {return;}
+    if (!this.initialized) {
+      return;
+    }
     try {
       const snapshot: InContextTrackerSnapshot & {
         initialized: boolean;
@@ -170,10 +174,14 @@ export class ConversationGraphMemory {
    * On failure or missing row, silently falls back to full context-load.
    */
   restoreState(): void {
-    if (this.stateRestored) {return;}
+    if (this.stateRestored) {
+      return;
+    }
     try {
       const json = loadGraphMemoryState(this.conversationId);
-      if (!json) {return;}
+      if (!json) {
+        return;
+      }
 
       const snapshot = JSON.parse(json) as InContextTrackerSnapshot & {
         initialized: boolean;
@@ -374,7 +382,9 @@ export class ConversationGraphMemory {
    * not the original user message.
    */
   retrackCachedNodes(): void {
-    if (this.lastInjectedNodeIds.length === 0) {return;}
+    if (this.lastInjectedNodeIds.length === 0) {
+      return;
+    }
     this.tracker.add(this.lastInjectedNodeIds);
   }
 
@@ -494,12 +504,15 @@ export class ConversationGraphMemory {
     // Gate: skip for empty/tool-result-only messages — unless we need to
     // reload after compaction (needsReload) or haven't initialized yet.
     const lastMessage = messages[messages.length - 1];
-    if (!lastMessage || lastMessage.role !== "user") {return noopResult;}
+    if (!lastMessage || lastMessage.role !== "user") {
+      return noopResult;
+    }
     const hasUserContent = lastMessage.content.some(
       (block) => block.type === "text" && block.text.trim().length > 0,
     );
-    if (!hasUserContent && this.initialized && !this.needsReload)
-      {return noopResult;}
+    if (!hasUserContent && this.initialized && !this.needsReload) {
+      return noopResult;
+    }
 
     try {
       // Decide which retrieval mode to use
@@ -716,7 +729,9 @@ export class ConversationGraphMemory {
       } else if (msg.role === "assistant" && !assistantLast) {
         assistantLast = text;
       }
-      if (userLastBlocks.length > 0 && assistantLast) {break;}
+      if (userLastBlocks.length > 0 && assistantLast) {
+        break;
+      }
     }
 
     // v2 path — skip v1 retrieval entirely when the v2 engine is the live
@@ -1014,12 +1029,18 @@ export function countMemoryPrefixBlocks(content: ContentBlock[]): number {
  * `reinjectCachedMemory` is idempotent — no duplicate images after compaction.
  */
 export function stripExistingMemoryInjections(messages: Message[]): Message[] {
-  if (messages.length === 0) {return messages;}
+  if (messages.length === 0) {
+    return messages;
+  }
   const last = messages[messages.length - 1];
-  if (!last || last.role !== "user") {return messages;}
+  if (!last || last.role !== "user") {
+    return messages;
+  }
 
   const stripped = stripMemoryPrefixFromUserMessage(last);
-  if (stripped === last) {return messages;}
+  if (stripped === last) {
+    return messages;
+  }
 
   return [...messages.slice(0, -1), stripped];
 }
@@ -1034,9 +1055,13 @@ export function stripExistingMemoryInjections(messages: Message[]): Message[] {
  * assembly strips only the TAIL's fresh v2 prefix when v3 supersedes it.
  */
 function stripMemoryPrefixFromUserMessage(message: Message): Message {
-  if (message.role !== "user") {return message;}
+  if (message.role !== "user") {
+    return message;
+  }
   const firstNonMemory = countMemoryPrefixBlocks(message.content);
-  if (firstNonMemory === 0) {return message;}
+  if (firstNonMemory === 0) {
+    return message;
+  }
   return { ...message, content: message.content.slice(firstNonMemory) };
 }
 
@@ -1047,21 +1072,31 @@ function stripMemoryPrefixFromUserMessage(message: Message): Message {
  * rendering) that otherwise discard the prepended content.
  */
 export function extractMemoryPrefixBlocks(messages: Message[]): ContentBlock[] {
-  if (messages.length === 0) {return [];}
+  if (messages.length === 0) {
+    return [];
+  }
   const last = messages[messages.length - 1];
-  if (!last || last.role !== "user") {return [];}
+  if (!last || last.role !== "user") {
+    return [];
+  }
   const count = countMemoryPrefixBlocks(last.content);
   return count === 0 ? [] : last.content.slice(0, count);
 }
 
 function injectTextBlock(messages: Message[], text: string): Message[] {
-  if (text.trim().length === 0) {return messages;}
-  if (messages.length === 0) {return messages;}
+  if (text.trim().length === 0) {
+    return messages;
+  }
+  if (messages.length === 0) {
+    return messages;
+  }
   // Strip existing memory blocks from the last user message first to prevent
   // duplicates when the message was loaded from DB with a persisted block.
   const cleaned = stripExistingMemoryInjections(messages);
   const userTail = cleaned[cleaned.length - 1];
-  if (!userTail || userTail.role !== "user") {return messages;}
+  if (!userTail || userTail.role !== "user") {
+    return messages;
+  }
   return [
     ...cleaned.slice(0, -1),
     {
@@ -1082,13 +1117,19 @@ function injectMemoryBlock(
   text: string,
   images: Map<string, ResolvedImage>,
 ): Message[] {
-  if (text.trim().length === 0 && images.size === 0) {return messages;}
-  if (messages.length === 0) {return messages;}
+  if (text.trim().length === 0 && images.size === 0) {
+    return messages;
+  }
+  if (messages.length === 0) {
+    return messages;
+  }
   // Strip existing memory blocks from the last user message first to prevent
   // duplicates when the message was loaded from DB with a persisted block.
   const cleaned = stripExistingMemoryInjections(messages);
   const userTail = cleaned[cleaned.length - 1];
-  if (!userTail || userTail.role !== "user") {return messages;}
+  if (!userTail || userTail.role !== "user") {
+    return messages;
+  }
 
   const blocks: ContentBlock[] = [];
 
@@ -1129,7 +1170,9 @@ function injectMemoryBlock(
  */
 function extractUserText(message: Message): string | null {
   const joined = readRawUserText(message);
-  if (!joined) {return null;}
+  if (!joined) {
+    return null;
+  }
   return joined.length > 10 ? joined : null;
 }
 
@@ -1140,12 +1183,16 @@ function extractUserText(message: Message): string | null {
  * v1 needs would unnecessarily starve v2 on short greetings.
  */
 function readRawUserText(message: Message | undefined): string | null {
-  if (!message) {return null;}
+  if (!message) {
+    return null;
+  }
   const texts = message.content
     .filter((b): b is Extract<typeof b, { type: "text" }> => b.type === "text")
     .map((b) => b.text.trim())
     .filter((t) => t.length > 0);
-  if (texts.length === 0) {return null;}
+  if (texts.length === 0) {
+    return null;
+  }
   return texts.join(" ");
 }
 

--- a/assistant/src/plugins/defaults/memory/injectors.ts
+++ b/assistant/src/plugins/defaults/memory/injectors.ts
@@ -105,12 +105,19 @@ const pkbContextInjector: Injector = {
     runMessages?: Message[],
   ): Promise<InjectionBlock | null> {
     const mode = ctx.mode ?? "full";
-    if (mode !== "full") {return null;}
-    if (isPkbInjectionSilenced()) {return null;}
+    if (mode !== "full") {
+      return null;
+    }
+    if (isPkbInjectionSilenced()) {
+      return null;
+    }
     const content = readGatedPkbContext(ctx.trust);
-    if (!content) {return null;}
-    if (hasInjectedUserTextBlock(runMessages, KNOWLEDGE_BASE_BLOCK_PREFIXES))
-      {return null;}
+    if (!content) {
+      return null;
+    }
+    if (hasInjectedUserTextBlock(runMessages, KNOWLEDGE_BASE_BLOCK_PREFIXES)) {
+      return null;
+    }
     return {
       id: "pkb-context",
       text: buildPkbContextBlock(content),
@@ -140,9 +147,15 @@ const pkbReminderInjector: Injector = {
     runMessages?: Message[],
   ): Promise<InjectionBlock | null> {
     const mode = ctx.mode ?? "full";
-    if (mode !== "full") {return null;}
-    if (!isPkbActive(ctx.trust)) {return null;}
-    if (isPkbInjectionSilenced()) {return null;}
+    if (mode !== "full") {
+      return null;
+    }
+    if (!isPkbActive(ctx.trust)) {
+      return null;
+    }
+    if (isPkbInjectionSilenced()) {
+      return null;
+    }
     const reminder = await buildPkbReminderWithHints(ctx, runMessages);
     return {
       id: "pkb-reminder",
@@ -279,7 +292,9 @@ async function buildPkbReminderWithHints(
       hints = results
         .filter((r) => {
           const abs = resolve(pkbRoot, r.path);
-          if (inContext.has(abs)) {return false;}
+          if (inContext.has(abs)) {
+            return false;
+          }
           const threshold = r.path.replace(/\\/g, "/").startsWith("archive/")
             ? PKB_HINT_ARCHIVE_THRESHOLD
             : PKB_HINT_THRESHOLD;
@@ -288,8 +303,12 @@ async function buildPkbReminderWithHints(
         .sort((a, b) => {
           const aHasHybrid = a.hybridScore !== undefined;
           const bHasHybrid = b.hybridScore !== undefined;
-          if (aHasHybrid && !bHasHybrid) {return -1;}
-          if (!aHasHybrid && bHasHybrid) {return 1;}
+          if (aHasHybrid && !bHasHybrid) {
+            return -1;
+          }
+          if (!aHasHybrid && bHasHybrid) {
+            return 1;
+          }
           if (aHasHybrid && bHasHybrid) {
             return b.hybridScore! - a.hybridScore!;
           }
@@ -346,16 +365,23 @@ const memoryV2StaticInjector: Injector = {
     runMessages?: Message[],
   ): Promise<InjectionBlock | null> {
     const mode = ctx.mode ?? "full";
-    if (mode !== "full") {return null;}
+    if (mode !== "full") {
+      return null;
+    }
     // The consolidation agent reads and rewrites memory/buffer.md through
     // file tools; injecting the buffer section here would duplicate the
     // entire backlog into its context (and go stale as it edits the file).
     const content = readGatedMemoryV2Static(ctx.trust, {
       excludeBuffer: ctx.callSite === "memoryV2Consolidation",
     });
-    if (!content) {return null;}
-    if (hasInjectedUserTextBlock(runMessages, MEMORY_V2_STATIC_BLOCK_MATCHERS))
-      {return null;}
+    if (!content) {
+      return null;
+    }
+    if (
+      hasInjectedUserTextBlock(runMessages, MEMORY_V2_STATIC_BLOCK_MATCHERS)
+    ) {
+      return null;
+    }
     return {
       id: "memory-v2-static",
       text: buildMemoryV2StaticBlock(content),

--- a/assistant/src/plugins/defaults/memory/jobs/embed-concept-page.ts
+++ b/assistant/src/plugins/defaults/memory/jobs/embed-concept-page.ts
@@ -82,7 +82,9 @@ export async function embedConceptPageJob(
   config: AssistantConfig,
 ): Promise<void> {
   const slug = asString(job.payload.slug);
-  if (!slug) {return;}
+  if (!slug) {
+    return;
+  }
 
   const workspaceDir = getWorkspaceDir();
   const page = await readPage(workspaceDir, slug);
@@ -215,7 +217,9 @@ export async function embedConceptPageJob(
     writeModel = embedded.model;
     for (let i = 0; i < appliedSlots.length; i++) {
       const vector = embedded.vectors[i];
-      if (!vector) {continue;}
+      if (!vector) {
+        continue;
+      }
       if (appliedSlots[i] === "body") {
         bodyDense = vector;
         bodyFresh = true;
@@ -228,7 +232,9 @@ export async function embedConceptPageJob(
   // Body embedding is the ground truth — without it the page can't surface.
   // (Cache hit paths populate `bodyDense` above; a fresh embed that returned
   // no vectors short-circuits here too.)
-  if (!bodyDense) {return;}
+  if (!bodyDense) {
+    return;
+  }
 
   // Sparse is cheap (in-process tokenization) and changes any time the body
   // changes, so we always recompute it rather than caching alongside dense.
@@ -346,10 +352,14 @@ function readEmbeddingCache(
       ),
     )
     .get();
-  if (!row || row.dimensions !== expectedDim) {return null;}
+  if (!row || row.dimensions !== expectedDim) {
+    return null;
+  }
   // A row without a contentHash is a legacy/corrupt entry — treat as a miss
   // and force a re-embed rather than misalign the cache key.
-  if (row.contentHash === null) {return null;}
+  if (row.contentHash === null) {
+    return null;
+  }
   const dense = row.vectorBlob
     ? blobToVector(row.vectorBlob as Buffer)
     : (JSON.parse(row.vectorJson!) as number[]);

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-enqueue.ts
@@ -107,7 +107,9 @@ export function isMemoryRetrospectiveConversation(
  */
 function isLowYieldRetrospectiveSource(conversationId: string): boolean {
   const conversation = getConversation(conversationId);
-  if (!conversation) {return false;}
+  if (!conversation) {
+    return false;
+  }
   return (
     conversation.conversationType === "scheduled" ||
     conversation.source === MEMORY_V2_CONSOLIDATION_SOURCE

--- a/assistant/src/plugins/defaults/memory/src/__tests__/memory-v2-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/src/__tests__/memory-v2-routes.test.ts
@@ -26,7 +26,9 @@ let origWorkspaceDir: string | undefined;
 
 function findHandler(operationId: string): RouteDefinition["handler"] {
   const route = ROUTES.find((r) => r.operationId === operationId);
-  if (!route) {throw new Error(`Route ${operationId} not found`);}
+  if (!route) {
+    throw new Error(`Route ${operationId} not found`);
+  }
   return route.handler;
 }
 

--- a/assistant/src/plugins/defaults/memory/src/memory-graph-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-graph-routes.ts
@@ -61,7 +61,8 @@ export const ROUTES: RouteDefinition[] = [
       {
         name: "id",
         schema: { type: "string" },
-        description: "Node id from the graph payload (memory-v3: the concept-page slug).",
+        description:
+          "Node id from the graph payload (memory-v3: the concept-page slug).",
       },
     ],
     responseBody: MemoryGraphNodeDetailSchema,

--- a/assistant/src/plugins/defaults/memory/src/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-item-routes.test.ts
@@ -105,7 +105,9 @@ function getRoute(endpoint: string, method: string): RouteDefinition {
   const route = ROUTES.find(
     (r: RouteDefinition) => r.endpoint === endpoint && r.method === method,
   );
-  if (!route) {throw new Error(`No route: ${method} ${endpoint}`);}
+  if (!route) {
+    throw new Error(`No route: ${method} ${endpoint}`);
+  }
   return route;
 }
 

--- a/assistant/src/plugins/defaults/memory/src/memory-item-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-item-routes.ts
@@ -212,13 +212,19 @@ async function searchNodesSemantic(
     // search (the caller's `null` branch) instead of querying the v1
     // collection, which is in active retirement and a corrupted sparse
     // segment can OOM-crash the shared Qdrant process.
-    if (usesConceptPageMemory(config.memory)) {return null;}
+    if (usesConceptPageMemory(config.memory)) {
+      return null;
+    }
     const backendStatus = await getMemoryBackendStatus(config);
-    if (!backendStatus.provider) {return null;}
+    if (!backendStatus.provider) {
+      return null;
+    }
 
     const embedded = await embedWithBackend(config, [query]);
     const queryVector = embedded.vectors[0];
-    if (!queryVector) {return null;}
+    if (!queryVector) {
+      return null;
+    }
 
     const sparse = generateSparseEmbedding(query);
     const sparseVector = { indices: sparse.indices, values: sparse.values };
@@ -321,7 +327,9 @@ async function handleListMemoryItems(queryParams: Record<string, string>) {
   }
 
   const db = memoryDbOrNull("listMemoryItems");
-  if (!db) {throw new Error("memory database unavailable");}
+  if (!db) {
+    throw new Error("memory database unavailable");
+  }
 
   // Build fidelity filter based on status param
   const fidelityFilter =
@@ -344,7 +352,9 @@ async function handleListMemoryItems(queryParams: Record<string, string>) {
       const kindCountConditions = [
         inArray(memoryGraphNodes.id, semanticResult.ids),
       ];
-      if (fidelityFilter) {kindCountConditions.push(fidelityFilter);}
+      if (fidelityFilter) {
+        kindCountConditions.push(fidelityFilter);
+      }
 
       const kindCountRows = db
         .select({ kind: memoryGraphNodes.type, count: count() })
@@ -366,7 +376,9 @@ async function handleListMemoryItems(queryParams: Record<string, string>) {
         if (kindParam) {
           filterConditions.push(eq(memoryGraphNodes.type, kindParam));
         }
-        if (fidelityFilter) {filterConditions.push(fidelityFilter);}
+        if (fidelityFilter) {
+          filterConditions.push(fidelityFilter);
+        }
 
         if (filterConditions.length > 1) {
           const validIdSet = new Set(
@@ -394,9 +406,12 @@ async function handleListMemoryItems(queryParams: Record<string, string>) {
 
       // Hydrate nodes from DB
       const hydrationConditions = [inArray(memoryGraphNodes.id, pageIds)];
-      if (fidelityFilter) {hydrationConditions.push(fidelityFilter);}
-      if (kindParam)
-        {hydrationConditions.push(eq(memoryGraphNodes.type, kindParam));}
+      if (fidelityFilter) {
+        hydrationConditions.push(fidelityFilter);
+      }
+      if (kindParam) {
+        hydrationConditions.push(eq(memoryGraphNodes.type, kindParam));
+      }
 
       const rows = db
         .select()
@@ -420,7 +435,9 @@ async function handleListMemoryItems(queryParams: Record<string, string>) {
 
   // ── Kind counts for SQL path ───────────────────────────────────────
   const kindCountConditions = [];
-  if (fidelityFilter) {kindCountConditions.push(fidelityFilter);}
+  if (fidelityFilter) {
+    kindCountConditions.push(fidelityFilter);
+  }
   if (searchParam) {
     kindCountConditions.push(
       like(memoryGraphNodes.content, `%${searchParam}%`),
@@ -442,8 +459,12 @@ async function handleListMemoryItems(queryParams: Record<string, string>) {
 
   // ── SQL path (default or fallback) ──────────────────────────────────
   const conditions = [];
-  if (fidelityFilter) {conditions.push(fidelityFilter);}
-  if (kindParam) {conditions.push(eq(memoryGraphNodes.type, kindParam));}
+  if (fidelityFilter) {
+    conditions.push(fidelityFilter);
+  }
+  if (kindParam) {
+    conditions.push(eq(memoryGraphNodes.type, kindParam));
+  }
   if (searchParam) {
     conditions.push(like(memoryGraphNodes.content, `%${searchParam}%`));
   }
@@ -539,7 +560,9 @@ async function handleCreateMemoryItem(body: Record<string, unknown>) {
 
   // Check for duplicate content
   const db = memoryDbOrNull("createMemoryItem");
-  if (!db) {throw new Error("memory database unavailable");}
+  if (!db) {
+    throw new Error("memory database unavailable");
+  }
   const existing = db
     .select({ id: memoryGraphNodes.id })
     .from(memoryGraphNodes)
@@ -659,7 +682,9 @@ async function handleUpdateMemoryItem(
   if (contentChanged || reactivating) {
     const contentToCheck = changes.content ?? existing.content;
     const db = memoryDbOrNull("updateMemoryItem");
-    if (!db) {throw new Error("memory database unavailable");}
+    if (!db) {
+      throw new Error("memory database unavailable");
+    }
     const collision = db
       .select({ id: memoryGraphNodes.id })
       .from(memoryGraphNodes)

--- a/assistant/src/plugins/defaults/memory/src/memory-v2-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-v2-routes.ts
@@ -146,7 +146,9 @@ async function handleValidate({
   for (const slug of slugs) {
     try {
       const page = await readPage(workspaceDir, slug);
-      if (!page) {continue;}
+      if (!page) {
+        continue;
+      }
       knownSlugs.add(slug);
       const chars = page.body.length;
       if (chars > maxPageChars) {
@@ -245,7 +247,9 @@ async function handleListConceptPages({
     slugs.map(async (slug) => {
       try {
         const page = await readPage(workspaceDir, slug);
-        if (!page) {return null;}
+        if (!page) {
+          return null;
+        }
         const stats = await stat(join(conceptsDir, `${slug}.md`));
         return {
           slug,
@@ -349,7 +353,9 @@ async function handleEmaScores({
     modifiedAt: entry.modifiedAt,
   }));
   entries.sort((a, b) => {
-    if (a.score !== b.score) {return b.score - a.score;}
+    if (a.score !== b.score) {
+      return b.score - a.score;
+    }
     return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
   });
   return { entries };
@@ -458,7 +464,9 @@ function applySimulateOverrides(
   live: AssistantConfig,
   overrides: z.infer<typeof SimulateRouterOverridesSchema> | undefined,
 ): AssistantConfig {
-  if (!overrides) {return live;}
+  if (!overrides) {
+    return live;
+  }
   const liveRouter = live.memory.v2.router;
   const mergedRouter = {
     ...liveRouter,

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/cli-command-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/cli-command-store.test.ts
@@ -102,7 +102,9 @@ mock.module(
   "../../../../../persistence/embeddings/embedding-backend.js",
   () => ({
     embedWithBackend: async (_config: unknown, inputs: unknown[]) => {
-      if (state.embedThrows) {throw state.embedThrows;}
+      if (state.embedThrows) {
+        throw state.embedThrows;
+      }
       const vectors = state.embedReturn.length
         ? state.embedReturn
         : inputs.map(() => [0.1, 0.2, 0.3]);
@@ -127,7 +129,9 @@ mock.module("../page-index.js", () => ({
 
 mock.module("../qdrant.js", () => ({
   upsertConceptPageEmbedding: async (params: UpsertCall) => {
-    if (state.upsertThrows) {throw state.upsertThrows;}
+    if (state.upsertThrows) {
+      throw state.upsertThrows;
+    }
     state.callSequence.push("upsert");
     state.upsertCalls.push(params);
   },
@@ -144,7 +148,9 @@ mock.module("../qdrant.js", () => ({
     kind: string,
     allowedSuffixes: ReadonlySet<string>,
   ) => {
-    if (state.backfillThrows) {throw state.backfillThrows;}
+    if (state.backfillThrows) {
+      throw state.backfillThrows;
+    }
     state.callSequence.push("backfill");
     state.backfillCalls.push({ prefix, kind, allowedSuffixes });
     return 0;

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/consolidation-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/consolidation-job.test.ts
@@ -301,7 +301,9 @@ describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_p
     );
 
     expect(outcome.kind).toBe("invoked");
-    if (outcome.kind !== "invoked") {throw new Error("unreachable");}
+    if (outcome.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     expect(outcome.cutoff).toBe("Apr 27, 9:03 AM");
     expect(outcome.deferredEntries).toBe(2);
     expect(runnerCalls).toBe(1);
@@ -317,7 +319,9 @@ describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_p
     );
 
     expect(outcome.kind).toBe("invoked");
-    if (outcome.kind !== "invoked") {throw new Error("unreachable");}
+    if (outcome.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     expect(outcome.deferredEntries).toBe(0);
     // Cutoff is the run-start timestamp, not any buffer entry's.
     expect(outcome.cutoff).not.toBe("Apr 27, 9:03 AM");
@@ -332,7 +336,9 @@ describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_p
     );
 
     expect(outcome.kind).toBe("invoked");
-    if (outcome.kind !== "invoked") {throw new Error("unreachable");}
+    if (outcome.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     expect(outcome.deferredEntries).toBe(0);
   });
 
@@ -342,7 +348,9 @@ describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_p
     const outcome = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(outcome.kind).toBe("invoked");
-    if (outcome.kind !== "invoked") {throw new Error("unreachable");}
+    if (outcome.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     expect(outcome.deferredEntries).toBe(0);
   });
 
@@ -363,7 +371,9 @@ describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_p
     return memoryV2ConsolidateJob(makeJob(), configWithMaxEntries(2)).then(
       (outcome) => {
         expect(outcome.kind).toBe("invoked");
-        if (outcome.kind !== "invoked") {throw new Error("unreachable");}
+        if (outcome.kind !== "invoked") {
+          throw new Error("unreachable");
+        }
         expect(outcome.deferredEntries).toBe(0);
         expect(outcome.cutoff).not.toBe("Apr 27, 9:00 AM");
       },
@@ -391,7 +401,9 @@ describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_p
     );
 
     expect(outcome.kind).toBe("invoked");
-    if (outcome.kind !== "invoked") {throw new Error("unreachable");}
+    if (outcome.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     expect(outcome.cutoff).toBe("Apr 27, 9:03 AM");
     expect(outcome.deferredEntries).toBe(1);
   });
@@ -416,7 +428,9 @@ describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_p
     );
 
     expect(outcome.kind).toBe("invoked");
-    if (outcome.kind !== "invoked") {throw new Error("unreachable");}
+    if (outcome.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     // Two real entries, cap 2 → no chunking, full-buffer cutoff.
     expect(outcome.deferredEntries).toBe(0);
     expect(outcome.cutoff).not.toBe(" ");
@@ -440,7 +454,9 @@ describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_p
     );
 
     expect(outcome.kind).toBe("invoked");
-    if (outcome.kind !== "invoked") {throw new Error("unreachable");}
+    if (outcome.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     expect(outcome.deferredEntries).toBe(0);
     expect(outcome.cutoff).not.toBe("Apr 27, 9:01 AM");
   });
@@ -765,7 +781,9 @@ describe("memoryV2ConsolidateJob — progress check and follow-up coalescing", (
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(result.kind).toBe("invoked");
-    if (result.kind !== "invoked") {throw new Error("unreachable");}
+    if (result.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     expect(result.noProgress).toBe(false);
     expect(result.followUpJobIds).toEqual(["job-1"]);
     expect(enqueuedJobs.map((j) => j.type)).toEqual(["memory_v2_reembed"]);
@@ -783,7 +801,9 @@ describe("memoryV2ConsolidateJob — progress check and follow-up coalescing", (
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(result.kind).toBe("invoked");
-    if (result.kind !== "invoked") {throw new Error("unreachable");}
+    if (result.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     expect(result.noProgress).toBe(false);
     expect(enqueuedJobs.map((j) => j.type)).toEqual(["memory_v2_reembed"]);
   });
@@ -797,7 +817,9 @@ describe("memoryV2ConsolidateJob — progress check and follow-up coalescing", (
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(result.kind).toBe("invoked");
-    if (result.kind !== "invoked") {throw new Error("unreachable");}
+    if (result.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     expect(result.noProgress).toBe(true);
     expect(result.followUpJobIds).toEqual([]);
     expect(enqueuedJobs).toHaveLength(0);
@@ -817,7 +839,9 @@ describe("memoryV2ConsolidateJob — progress check and follow-up coalescing", (
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(result.kind).toBe("invoked");
-    if (result.kind !== "invoked") {throw new Error("unreachable");}
+    if (result.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     expect(result.noProgress).toBe(true);
     expect(result.followUpJobIds).toEqual([]);
     expect(enqueuedJobs).toHaveLength(0);
@@ -830,7 +854,9 @@ describe("memoryV2ConsolidateJob — progress check and follow-up coalescing", (
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(result.kind).toBe("invoked");
-    if (result.kind !== "invoked") {throw new Error("unreachable");}
+    if (result.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     expect(enqueuedJobs.map((j) => j.type)).toEqual(["memory_v3_maintain"]);
     expect(result.followUpJobIds).toHaveLength(1);
   });
@@ -843,7 +869,9 @@ describe("memoryV2ConsolidateJob — progress check and follow-up coalescing", (
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(result.kind).toBe("invoked");
-    if (result.kind !== "invoked") {throw new Error("unreachable");}
+    if (result.kind !== "invoked") {
+      throw new Error("unreachable");
+    }
     // Dedup is not no-progress: the run drained the buffer; the follow-ups
     // are simply already covered by pending rows.
     expect(result.noProgress).toBe(false);

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/qdrant.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/qdrant.test.ts
@@ -122,13 +122,17 @@ class MockQdrantClient {
   }
   async getCollection(_name: string) {
     state.getCollectionCalls++;
-    if (state.getCollectionThrows) {throw state.getCollectionThrows;}
+    if (state.getCollectionThrows) {
+      throw state.getCollectionThrows;
+    }
     return state.getCollectionInfo;
   }
   async createCollection(_name: string, params: unknown) {
     state.createCollectionCalls++;
     state.createCollectionParams = params;
-    if (state.createCollectionThrows) {throw state.createCollectionThrows;}
+    if (state.createCollectionThrows) {
+      throw state.createCollectionThrows;
+    }
     state.collectionExistsBeforeCreate = true;
     state.getCollectionInfo = FULL_SCHEMA_INFO;
     return {};
@@ -140,12 +144,16 @@ class MockQdrantClient {
   }
   async updateCollection(name: string, params: unknown) {
     state.updateCollectionCalls.push({ name, params });
-    if (state.updateCollectionThrows) {throw state.updateCollectionThrows;}
+    if (state.updateCollectionThrows) {
+      throw state.updateCollectionThrows;
+    }
     return {};
   }
   async count(_name: string, _opts: { exact: boolean }) {
     state.countCalls++;
-    if (state.countThrows) {throw state.countThrows;}
+    if (state.countThrows) {
+      throw state.countThrows;
+    }
     return { count: state.countResult };
   }
   async createPayloadIndex(
@@ -155,14 +163,18 @@ class MockQdrantClient {
     state.createIndexCalls.push(params);
     if (state.createIndexThrowQueue.length > 0) {
       const next = state.createIndexThrowQueue.shift();
-      if (next) {throw next;}
+      if (next) {
+        throw next;
+      }
     }
     return {};
   }
   async upsert(_name: string, params: { wait: boolean; points: MockPoint[] }) {
     if (state.upsertThrowQueue.length > 0) {
       const next = state.upsertThrowQueue.shift();
-      if (next) {throw next;}
+      if (next) {
+        throw next;
+      }
     }
     state.upsertCalls.push(params);
     return {};

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/sparse-bm25.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/sparse-bm25.test.ts
@@ -43,12 +43,15 @@ function dotProduct(
   d: { indices: number[]; values: number[] },
 ): number {
   const dMap = new Map<number, number>();
-  for (let i = 0; i < d.indices.length; i++)
-    {dMap.set(d.indices[i], d.values[i]);}
+  for (let i = 0; i < d.indices.length; i++) {
+    dMap.set(d.indices[i], d.values[i]);
+  }
   let sum = 0;
   for (let i = 0; i < q.indices.length; i++) {
     const dv = dMap.get(q.indices[i]);
-    if (dv !== undefined) {sum += q.values[i] * dv;}
+    if (dv !== undefined) {
+      sum += q.values[i] * dv;
+    }
   }
   return sum;
 }
@@ -234,7 +237,9 @@ describe("generateBm25QueryEmbedding", () => {
   test("emits binary occurrence per distinct token", () => {
     const vec = generateBm25QueryEmbedding("supplements supplements zinc");
     expect(vec.indices.length).toBe(2);
-    for (const v of vec.values) {expect(v).toBe(1);}
+    for (const v of vec.values) {
+      expect(v).toBe(1);
+    }
   });
 
   test("empty input yields empty vector", () => {
@@ -263,7 +268,9 @@ describe("end-to-end ranking: BM25 fixes the supplements bug", () => {
       const seen = new Set<number>();
       for (const t of tokens) {
         const idx = tokenHash(t, SPARSE_VOCAB_SIZE);
-        if (seen.has(idx)) {continue;}
+        if (seen.has(idx)) {
+          continue;
+        }
         seen.add(idx);
         df.set(idx, (df.get(idx) ?? 0) + 1);
       }

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/static-context.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/static-context.test.ts
@@ -60,8 +60,9 @@ function writeMemoryFile(name: string, body: string): void {
 
 function cleanupMemoryDir(): void {
   const memoryDir = join(TEST_DIR, "memory");
-  if (existsSync(memoryDir))
-    {rmSync(memoryDir, { recursive: true, force: true });}
+  if (existsSync(memoryDir)) {
+    rmSync(memoryDir, { recursive: true, force: true });
+  }
 }
 
 describe("readMemoryV2StaticContent", () => {
@@ -77,13 +78,17 @@ describe("readMemoryV2StaticContent", () => {
 
   test("returns null when config.memory.v2.enabled is off", () => {
     configMemoryV2Enabled = false;
-    for (const file of MEMORY_FILES) {writeMemoryFile(file, `Content ${file}`);}
+    for (const file of MEMORY_FILES) {
+      writeMemoryFile(file, `Content ${file}`);
+    }
     expect(readMemoryV2StaticContent()).toBeNull();
   });
 
   test("returns null when config.memory.enabled is off even with v2 on", () => {
     configMemoryEnabled = false;
-    for (const file of MEMORY_FILES) {writeMemoryFile(file, `Content ${file}`);}
+    for (const file of MEMORY_FILES) {
+      writeMemoryFile(file, `Content ${file}`);
+    }
     expect(readMemoryV2StaticContent()).toBeNull();
   });
 
@@ -120,7 +125,9 @@ describe("readMemoryV2StaticContent", () => {
   });
 
   test("excludeBuffer drops the Buffer section but keeps the other three", () => {
-    for (const file of MEMORY_FILES) {writeMemoryFile(file, `Content ${file}`);}
+    for (const file of MEMORY_FILES) {
+      writeMemoryFile(file, `Content ${file}`);
+    }
 
     const result = readMemoryV2StaticContent({ excludeBuffer: true });
     expect(result).not.toBeNull();
@@ -146,7 +153,9 @@ describe("readMemoryV2StaticContent", () => {
   });
 
   test("returns null when every file is empty", () => {
-    for (const file of MEMORY_FILES) {writeMemoryFile(file, "");}
+    for (const file of MEMORY_FILES) {
+      writeMemoryFile(file, "");
+    }
     expect(readMemoryV2StaticContent()).toBeNull();
   });
 

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/sweep-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/sweep-job.test.ts
@@ -168,7 +168,9 @@ function makeEntriesProvider(entries: string[]): Provider {
  */
 function extractFirstUserText(msgs: { content: unknown }[]): string {
   const first = msgs[0];
-  if (!first || !Array.isArray(first.content)) {return "";}
+  if (!first || !Array.isArray(first.content)) {
+    return "";
+  }
   const block = first.content.find(
     (b: unknown) =>
       typeof b === "object" &&

--- a/assistant/src/plugins/defaults/memory/substrate/boot-maintenance.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/boot-maintenance.ts
@@ -26,7 +26,9 @@ const log = getLogger("boot-maintenance");
  * `assistant/CLAUDE.md` daemon startup philosophy).
  */
 export function maybeSeedCapabilitySkills(config: AssistantConfig): void {
-  if (!usesConceptPageMemory(config.memory)) {return;}
+  if (!usesConceptPageMemory(config.memory)) {
+    return;
+  }
   void import("./skill-store.js")
     .then(({ seedV2SkillEntries }) => seedV2SkillEntries())
     .catch((err) => log.warn({ err }, "Failed to seed v2 skill entries"));
@@ -47,7 +49,9 @@ export function maybeSeedCapabilitySkills(config: AssistantConfig): void {
  * startup graph when the gate is off. Never awaits — startup must not block.
  */
 export function maybeSeedCliCommandCards(config: AssistantConfig): void {
-  if (!usesConceptPageMemory(config.memory)) {return;}
+  if (!usesConceptPageMemory(config.memory)) {
+    return;
+  }
   void import("./cli-command-store.js")
     .then(({ seedV2CliCommandEntries }) => seedV2CliCommandEntries())
     .catch((err) => log.warn({ err }, "Failed to seed v2 CLI-command entries"));
@@ -79,7 +83,9 @@ async function settledWithin(
   try {
     return await Promise.race([p.then(() => true), timedOut]);
   } finally {
-    if (timer) {clearTimeout(timer);}
+    if (timer) {
+      clearTimeout(timer);
+    }
   }
 }
 
@@ -135,11 +141,15 @@ export async function maybeReseedCapabilitiesAfterManagedCredential(
   config: AssistantConfig,
   opts: { reseedTimeoutMs?: number } = {},
 ): Promise<void> {
-  if (!usesConceptPageMemory(config.memory)) {return;}
+  if (!usesConceptPageMemory(config.memory)) {
+    return;
+  }
 
   const { hasManagedProxyPrereqs } =
     await import("../../../../providers/platform-proxy/context.js");
-  if (!(await hasManagedProxyPrereqs())) {return;}
+  if (!(await hasManagedProxyPrereqs())) {
+    return;
+  }
 
   // The managed credential has just landed, so the embedding backend is now
   // reachable. Retry the embedding-identity reconcile to close the
@@ -210,7 +220,9 @@ export async function maybeReseedCapabilitiesAfterManagedCredential(
     await import("../../../../config/memory-v3-gate.js");
   const v3Live = isMemoryV3Live(config);
   const enqueueMaintain = async (): Promise<void> => {
-    if (!v3Live) {return;}
+    if (!v3Live) {
+      return;
+    }
     try {
       const { enqueueMemoryJob } =
         await import("../../../../persistence/jobs-store.js");
@@ -263,7 +275,9 @@ export async function maybeReseedCapabilitiesAfterManagedCredential(
 export async function rebuildBm25CorpusStatsAndReseedSkills(
   config: AssistantConfig,
 ): Promise<void> {
-  if (!usesConceptPageMemory(config.memory)) {return;}
+  if (!usesConceptPageMemory(config.memory)) {
+    return;
+  }
 
   try {
     const { rebuildConceptPageCorpusStats } = await import("./sparse-bm25.js");
@@ -329,7 +343,9 @@ export async function rebuildBm25CorpusStatsAndReseedSkills(
 export async function maybeRebuildConceptCollection(
   config: AssistantConfig,
 ): Promise<void> {
-  if (!usesConceptPageMemory(config.memory)) {return;}
+  if (!usesConceptPageMemory(config.memory)) {
+    return;
+  }
 
   try {
     const {

--- a/assistant/src/plugins/defaults/memory/substrate/consolidation-job.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/consolidation-job.ts
@@ -618,7 +618,9 @@ function readBufferContent(bufferPath: string): string {
   try {
     return readFileSync(bufferPath, "utf-8");
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {return "";}
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return "";
+    }
     throw err;
   }
 }
@@ -691,9 +693,13 @@ function tryAcquireLock(lockPath: string): string | null {
   mkdirSync(dirname(lockPath), { recursive: true });
 
   const firstHolder = tryCreate(lockPath);
-  if (firstHolder === null) {return null;}
+  if (firstHolder === null) {
+    return null;
+  }
   const staleReason = holderStaleReason(firstHolder);
-  if (staleReason === null) {return firstHolder;}
+  if (staleReason === null) {
+    return firstHolder;
+  }
 
   log.info(
     { lockPath, holder: firstHolder, reason: staleReason },
@@ -727,7 +733,9 @@ function tryCreate(lockPath: string): string | null {
   try {
     fd = openSync(lockPath, "wx");
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {throw err;}
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw err;
+    }
     try {
       return readFileSync(lockPath, "utf-8").trim() || "unknown";
     } catch {
@@ -766,9 +774,13 @@ function parseHolder(
   holder: string,
 ): { pid: number; timestamp: number | null } | null {
   const match = /^(\d+)(?:\s+(\d+))?/.exec(holder);
-  if (!match) {return null;}
+  if (!match) {
+    return null;
+  }
   const pid = Number.parseInt(match[1], 10);
-  if (!Number.isFinite(pid) || pid <= 0) {return null;}
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return null;
+  }
   const timestamp =
     match[2] !== undefined ? Number.parseInt(match[2], 10) : null;
   return {
@@ -796,8 +808,12 @@ function parseHolder(
  */
 function holderStaleReason(holder: string): StaleReason | null {
   const parsed = parseHolder(holder);
-  if (parsed === null) {return "unparseable";}
-  if (!isProcessAlive(parsed.pid)) {return "pid_dead";}
+  if (parsed === null) {
+    return "unparseable";
+  }
+  if (!isProcessAlive(parsed.pid)) {
+    return "pid_dead";
+  }
   if (
     parsed.timestamp !== null &&
     Date.now() - parsed.timestamp > STALE_LOCK_TTL_MS
@@ -818,7 +834,9 @@ function releaseLock(lockPath: string): void {
     unlinkSync(lockPath);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") {return;}
+    if (code === "ENOENT") {
+      return;
+    }
     log.warn(
       { err, lockPath },
       "consolidation: failed to release lock (best-effort)",

--- a/assistant/src/plugins/defaults/memory/substrate/edge-index.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/edge-index.ts
@@ -81,13 +81,19 @@ export async function getEdgeIndex(workspaceDir: string): Promise<EdgeIndex> {
       } catch {
         return;
       }
-      if (!page) {return;}
+      if (!page) {
+        return;
+      }
       const out = new Set<string>();
       for (const target of page.frontmatter.edges) {
-        if (target === slug) {continue;}
+        if (target === slug) {
+          continue;
+        }
         out.add(target);
       }
-      if (out.size > 0) {outgoing.set(slug, out);}
+      if (out.size > 0) {
+        outgoing.set(slug, out);
+      }
       for (const target of out) {
         ensureSet(incoming, target).add(slug);
       }
@@ -105,7 +111,9 @@ export async function getEdgeIndex(workspaceDir: string): Promise<EdgeIndex> {
  * workspaces); omit it to clear unconditionally.
  */
 export function invalidateEdgeIndex(workspaceDir?: string): void {
-  if (!cache) {return;}
+  if (!cache) {
+    return;
+  }
   if (workspaceDir === undefined || cache.workspaceDir === workspaceDir) {
     cache = null;
   }
@@ -128,7 +136,9 @@ export function getReachable(
   direction: EdgeDirection,
 ): Set<string> {
   const result = new Set<string>();
-  if (hops <= 0) {return result;}
+  if (hops <= 0) {
+    return result;
+  }
 
   const adjacency = direction === "out" ? index.outgoing : index.incoming;
   const visited = new Set<string>([slug]);
@@ -138,9 +148,13 @@ export function getReachable(
     const next: string[] = [];
     for (const node of frontier) {
       const neighbors = adjacency.get(node);
-      if (!neighbors) {continue;}
+      if (!neighbors) {
+        continue;
+      }
       for (const neighbor of neighbors) {
-        if (visited.has(neighbor)) {continue;}
+        if (visited.has(neighbor)) {
+          continue;
+        }
         visited.add(neighbor);
         result.add(neighbor);
         next.push(neighbor);
@@ -175,7 +189,9 @@ export function validateEdgeTargets(
   for (const from of sources) {
     const targets = [...(index.outgoing.get(from) ?? [])].sort();
     for (const to of targets) {
-      if (!knownSlugs.has(to)) {missing.push({ from, to });}
+      if (!knownSlugs.has(to)) {
+        missing.push({ from, to });
+      }
     }
   }
   return { ok: missing.length === 0, missing };

--- a/assistant/src/plugins/defaults/memory/substrate/frontmatter-sweep.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/frontmatter-sweep.ts
@@ -46,7 +46,9 @@ export async function sweepConceptPageFrontmatter(
   config: AssistantConfig,
   workspaceDir: string,
 ): Promise<void> {
-  if (!usesConceptPageMemory(config.memory)) {return;}
+  if (!usesConceptPageMemory(config.memory)) {
+    return;
+  }
 
   let slugs: string[];
   try {
@@ -84,7 +86,9 @@ export async function sweepConceptPageFrontmatter(
     }
 
     const result = ConceptPageFrontmatterSchema.safeParse(parsed);
-    if (result.success) {continue;}
+    if (result.success) {
+      continue;
+    }
 
     for (const issue of result.error.issues) {
       log.warn(

--- a/assistant/src/plugins/defaults/memory/substrate/injected-block-slugs.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/injected-block-slugs.ts
@@ -44,7 +44,9 @@ export function extractInjectedConceptSlugs(block: string): string[] {
   const seen = new Set<string>();
   for (const match of block.matchAll(INJECTED_CONCEPT_HEADER_REGEX)) {
     const slug = match[1]!;
-    if (seen.has(slug)) {continue;}
+    if (seen.has(slug)) {
+      continue;
+    }
     seen.add(slug);
     slugs.push(slug);
   }
@@ -65,12 +67,16 @@ export function readInjectedBlock(
   metadata: string | null | undefined,
   key: string,
 ): string | null {
-  if (!metadata) {return null;}
+  if (!metadata) {
+    return null;
+  }
   try {
     const parsed: unknown = JSON.parse(metadata);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       const block = (parsed as Record<string, unknown>)[key];
-      if (typeof block === "string") {return block;}
+      if (typeof block === "string") {
+        return block;
+      }
     }
   } catch {
     // Malformed metadata — treat as no block.

--- a/assistant/src/plugins/defaults/memory/substrate/page-index.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/page-index.ts
@@ -189,7 +189,9 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
       continue;
     }
     const { page, mtimeMs } = result.value;
-    if (!page) {continue;}
+    if (!page) {
+      continue;
+    }
     if (page.parseWarning !== undefined) {
       parseFailures.push({ slug, error: page.parseWarning, dropped: false });
     }
@@ -263,7 +265,9 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
     const resolved: number[] = [];
     for (const targetSlug of draft.outgoingSlugs) {
       const target = bySlug.get(targetSlug);
-      if (target) {resolved.push(target.id);}
+      if (target) {
+        resolved.push(target.id);
+      }
     }
     resolved.sort((a, b) => a - b);
     entries[i].edges = resolved;
@@ -293,7 +297,9 @@ function firstErrorLine(reason: unknown): string {
  * specific cache entry; omit it to clear unconditionally.
  */
 export function invalidatePageIndex(workspaceDir?: string): void {
-  if (!cache) {return;}
+  if (!cache) {
+    return;
+  }
   if (workspaceDir === undefined || cache.workspaceDir === workspaceDir) {
     cache = null;
   }
@@ -308,7 +314,9 @@ export function invalidatePageIndex(workspaceDir?: string): void {
 function renderIndex(entries: readonly PageIndexEntry[]): string {
   const lines = entries.map((entry) => {
     const head = `[${entry.id}] ${entry.slug} — ${entry.summary}`;
-    if (entry.edges.length === 0) {return head;}
+    if (entry.edges.length === 0) {
+      return head;
+    }
     return `${head} (edges: ${entry.edges.join(", ")})`;
   });
   return lines.length > 0 ? `${lines.join("\n")}\n` : "";
@@ -392,9 +400,13 @@ function buildLocalPageIndex(
     const localEdges: number[] = [];
     for (const globalEdgeId of entries[i].edges) {
       const target = source.byId.get(globalEdgeId);
-      if (!target) {continue;}
+      if (!target) {
+        continue;
+      }
       const localTarget = localBySlug.get(target.slug);
-      if (localTarget) {localEdges.push(localTarget.id);}
+      if (localTarget) {
+        localEdges.push(localTarget.id);
+      }
     }
     localEdges.sort((a, b) => a - b);
     localEntries[i].edges = localEdges;
@@ -434,7 +446,9 @@ export function splitTier1(
     return { tier1: null, rest: pageIndex };
   }
   const sortedByRecency = [...pageIndex.entries].sort((a, b) => {
-    if (a.modifiedAt !== b.modifiedAt) {return b.modifiedAt - a.modifiedAt;}
+    if (a.modifiedAt !== b.modifiedAt) {
+      return b.modifiedAt - a.modifiedAt;
+    }
     return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
   });
   const tier1Entries = sortedByRecency.slice(0, tier1Size);
@@ -474,7 +488,9 @@ export function splitTier2(
     .map((entry) => ({ entry, score: scores.get(entry.slug) ?? 0 }))
     .filter((x) => x.score > 0)
     .sort((a, b) => {
-      if (a.score !== b.score) {return b.score - a.score;}
+      if (a.score !== b.score) {
+        return b.score - a.score;
+      }
       return a.entry.slug < b.entry.slug
         ? -1
         : a.entry.slug > b.entry.slug

--- a/assistant/src/plugins/defaults/memory/substrate/page-store.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/page-store.ts
@@ -359,23 +359,33 @@ export async function listPages(workspaceDir: string): Promise<string[]> {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
         // Root missing → return []. Nested missing dir is impossible mid-walk
         // (we only enqueue what readdir surfaced) but treat the same defensively.
-        if (dir === root) {return [];}
+        if (dir === root) {
+          return [];
+        }
         continue;
       }
       throw err;
     }
 
     for (const entry of entries) {
-      if (entry.name.startsWith(".")) {continue;}
+      if (entry.name.startsWith(".")) {
+        continue;
+      }
       const fullPath = join(dir, entry.name);
       if (entry.isDirectory()) {
         queue.push(fullPath);
         continue;
       }
-      if (!entry.isFile()) {continue;}
-      if (!entry.name.endsWith(PAGE_EXTENSION)) {continue;}
+      if (!entry.isFile()) {
+        continue;
+      }
+      if (!entry.name.endsWith(PAGE_EXTENSION)) {
+        continue;
+      }
       // Skip orphaned temp files left behind by a crashed atomic write.
-      if (entry.name.includes(".tmp.")) {continue;}
+      if (entry.name.includes(".tmp.")) {
+        continue;
+      }
       slugs.push(slugFromConceptPath(root, fullPath));
     }
   }
@@ -401,21 +411,31 @@ export async function hasConceptPages(workspaceDir: string): Promise<boolean> {
       entries = await readdir(dir, { withFileTypes: true });
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        if (dir === root) {return false;}
+        if (dir === root) {
+          return false;
+        }
         continue;
       }
       throw err;
     }
 
     for (const entry of entries) {
-      if (entry.name.startsWith(".")) {continue;}
+      if (entry.name.startsWith(".")) {
+        continue;
+      }
       if (entry.isDirectory()) {
         queue.push(join(dir, entry.name));
         continue;
       }
-      if (!entry.isFile()) {continue;}
-      if (!entry.name.endsWith(PAGE_EXTENSION)) {continue;}
-      if (entry.name.includes(".tmp.")) {continue;}
+      if (!entry.isFile()) {
+        continue;
+      }
+      if (!entry.name.endsWith(PAGE_EXTENSION)) {
+        continue;
+      }
+      if (entry.name.includes(".tmp.")) {
+        continue;
+      }
       return true;
     }
   }

--- a/assistant/src/plugins/defaults/memory/substrate/prompts/consolidation.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/prompts/consolidation.ts
@@ -962,7 +962,9 @@ export function resolveConsolidationPrompt(
     log,
     label: "consolidation prompt",
   });
-  if (override === null) {return renderConsolidationPrompt(cutoff, options);}
+  if (override === null) {
+    return renderConsolidationPrompt(cutoff, options);
+  }
 
   const substituted = substitutePlaceholders(override, cutoff, options);
   if (override.includes(PARSE_FAILURES_PLACEHOLDER)) {

--- a/assistant/src/plugins/defaults/memory/substrate/qdrant.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/qdrant.ts
@@ -135,13 +135,17 @@ export async function clearReembedSentinel(): Promise<void> {
   try {
     await unlink(reembedSentinelPath());
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {throw err;}
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
   }
 }
 
 /** Lazily create a Qdrant REST client bound to the resolved URL. */
 function getClient(): QdrantRestClient {
-  if (_client) {return _client;}
+  if (_client) {
+    return _client;
+  }
   _client = new QdrantRestClient({
     url: resolveQdrantUrl(),
     checkCompatibility: false,
@@ -162,8 +166,12 @@ function getClient(): QdrantRestClient {
 export async function ensureConceptPageCollection(): Promise<{
   migrated: boolean;
 }> {
-  if (_collectionReady) {return { migrated: false };}
-  if (_collectionReadyPromise) {return _collectionReadyPromise;}
+  if (_collectionReady) {
+    return { migrated: false };
+  }
+  if (_collectionReadyPromise) {
+    return _collectionReadyPromise;
+  }
 
   _collectionReadyPromise = ensureConceptPageCollectionOnce().finally(() => {
     _collectionReadyPromise = null;
@@ -253,7 +261,9 @@ async function ensureConceptPageCollectionOnce(): Promise<{
     }
   } catch (err) {
     // Treat "not found"-shaped errors as "needs creation" and fall through.
-    if (!isCollectionMissing(err)) {throw err;}
+    if (!isCollectionMissing(err)) {
+      throw err;
+    }
   }
 
   log.info(
@@ -346,7 +356,9 @@ async function ensurePayloadIndexes(): Promise<void> {
       try {
         await client.createPayloadIndex(MEMORY_V2_COLLECTION, index);
       } catch (err) {
-        if (isPayloadIndexAlreadyExists(err)) {return;}
+        if (isPayloadIndexAlreadyExists(err)) {
+          return;
+        }
         throw err;
       }
     }),
@@ -378,7 +390,9 @@ async function reconcileSparseIndexOnDisk(
         }
       | undefined
   )?.sparse_vectors;
-  if (!sparseParams) {return;}
+  if (!sparseParams) {
+    return;
+  }
 
   // Only touch channels that exist in the collection and whose placement
   // drifts from the target — an update naming an absent sparse vector fails.
@@ -387,7 +401,9 @@ async function reconcileSparseIndexOnDisk(
       name in sparseParams &&
       (sparseParams[name]?.index?.on_disk ?? false) !== onDisk,
   );
-  if (drifted.length === 0) {return;}
+  if (drifted.length === 0) {
+    return;
+  }
 
   try {
     await getClient().updateCollection(MEMORY_V2_COLLECTION, {
@@ -446,10 +462,14 @@ function missingNamedVectors(
 
   const missing: string[] = [];
   for (const name of REQUIRED_DENSE_VECTORS) {
-    if (!denseNames.has(name)) {missing.push(name);}
+    if (!denseNames.has(name)) {
+      missing.push(name);
+    }
   }
   for (const name of REQUIRED_SPARSE_VECTORS) {
-    if (!sparseNames.has(name)) {missing.push(name);}
+    if (!sparseNames.has(name)) {
+      missing.push(name);
+    }
   }
   return missing;
 }
@@ -475,14 +495,18 @@ function wrongSizeNamedVectors(
   // Named-vectors map only — mirror the `!("size" in dense)` guard in
   // `missingNamedVectors`. A single unnamed vector exposes `size` at the top
   // level; its dimension is the collection's and is handled by the caller.
-  if (!dense || typeof dense !== "object" || "size" in dense) {return [];}
+  if (!dense || typeof dense !== "object" || "size" in dense) {
+    return [];
+  }
   const map = dense as Record<string, unknown>;
   const wrong: string[] = [];
   for (const name of REQUIRED_DENSE_VECTORS) {
     const entry = map[name];
     if (entry && typeof entry === "object" && "size" in entry) {
       const size = (entry as { size?: unknown }).size;
-      if (typeof size === "number" && size !== expectedSize) {wrong.push(name);}
+      if (typeof size === "number" && size !== expectedSize) {
+        wrong.push(name);
+      }
     }
   }
   return wrong;
@@ -530,7 +554,9 @@ export async function upsertConceptPageEmbedding(params: {
   }
 
   const payload: Record<string, unknown> = { slug, updated_at: updatedAt };
-  if (kind !== undefined) {payload.kind = kind;}
+  if (kind !== undefined) {
+    payload.kind = kind;
+  }
 
   const upsertOnce = () =>
     client.upsert(MEMORY_V2_COLLECTION, {
@@ -629,21 +655,30 @@ export async function pruneSlugsWithPrefixExcept(
           kind?: unknown;
         } | null;
         const slug = payload?.slug;
-        if (typeof slug !== "string") {continue;}
-        if (!slug.startsWith(prefix)) {continue;}
-        if (requiredKind !== undefined && payload?.kind !== requiredKind)
-          {continue;}
+        if (typeof slug !== "string") {
+          continue;
+        }
+        if (!slug.startsWith(prefix)) {
+          continue;
+        }
+        if (requiredKind !== undefined && payload?.kind !== requiredKind) {
+          continue;
+        }
         const suffix = slug.slice(prefix.length);
         if (!activeSet.has(suffix)) {
           stalePointIds.push(point.id);
         }
       }
       const next = result.next_page_offset;
-      if (next == null) {break;}
+      if (next == null) {
+        break;
+      }
       offset = typeof next === "string" ? next : (next as number);
     }
 
-    if (stalePointIds.length === 0) {return;}
+    if (stalePointIds.length === 0) {
+      return;
+    }
 
     await client.delete(MEMORY_V2_COLLECTION, {
       wait: true,
@@ -688,7 +723,9 @@ export async function backfillKindOnPointsWithPrefix(
   kind: string,
   allowedSuffixes: ReadonlySet<string>,
 ): Promise<number> {
-  if (allowedSuffixes.size === 0) {return 0;}
+  if (allowedSuffixes.size === 0) {
+    return 0;
+  }
   await ensureConceptPageCollection();
 
   const client = getClient();
@@ -708,18 +745,28 @@ export async function backfillKindOnPointsWithPrefix(
       });
       for (const point of result.points) {
         const slug = (point.payload as { slug?: unknown } | null)?.slug;
-        if (typeof slug !== "string") {continue;}
-        if (!slug.startsWith(prefix)) {continue;}
+        if (typeof slug !== "string") {
+          continue;
+        }
+        if (!slug.startsWith(prefix)) {
+          continue;
+        }
         const suffix = slug.slice(prefix.length);
-        if (!allowedSuffixes.has(suffix)) {continue;}
+        if (!allowedSuffixes.has(suffix)) {
+          continue;
+        }
         pointIds.push(point.id);
       }
       const next = result.next_page_offset;
-      if (next == null) {break;}
+      if (next == null) {
+        break;
+      }
       offset = typeof next === "string" ? next : (next as number);
     }
 
-    if (pointIds.length === 0) {return 0;}
+    if (pointIds.length === 0) {
+      return 0;
+    }
 
     await client.setPayload(MEMORY_V2_COLLECTION, {
       payload: { kind },
@@ -783,7 +830,9 @@ export async function recreateConceptPageCollection(): Promise<void> {
   try {
     await client.deleteCollection(MEMORY_V2_COLLECTION);
   } catch (err) {
-    if (!isCollectionMissing(err)) {throw err;}
+    if (!isCollectionMissing(err)) {
+      throw err;
+    }
   }
   _collectionReady = false;
   _collectionReadyPromise = null;
@@ -801,7 +850,9 @@ export async function conceptPageCollectionExists(): Promise<boolean> {
     const result = await client.collectionExists(MEMORY_V2_COLLECTION);
     return result.exists;
   } catch (err) {
-    if (isCollectionMissing(err)) {return false;}
+    if (isCollectionMissing(err)) {
+      return false;
+    }
     throw err;
   }
 }
@@ -818,7 +869,9 @@ export async function dropLegacySkillsCollection(): Promise<void> {
   try {
     const client = getClient();
     const exists = await client.collectionExists("memory_v2_skills");
-    if (!exists.exists) {return;}
+    if (!exists.exists) {
+      return;
+    }
     await client.deleteCollection("memory_v2_skills");
     log.info("Deleted legacy memory_v2_skills Qdrant collection");
   } catch (err) {
@@ -948,7 +1001,9 @@ export async function hybridQueryConceptPages(
   ): void => {
     for (const point of points ?? []) {
       const slug = (point.payload as { slug?: unknown } | null)?.slug;
-      if (typeof slug !== "string") {continue;}
+      if (typeof slug !== "string") {
+        continue;
+      }
       const existing = merged.get(slug) ?? { slug };
       set(existing, point.score ?? 0);
       merged.set(slug, existing);

--- a/assistant/src/plugins/defaults/memory/substrate/sim.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/sim.ts
@@ -93,10 +93,16 @@ export function effectiveWeights(
   let max = -Infinity;
   let count = 0;
   for (const h of hits) {
-    if (h.sparseScore === undefined) {continue;}
+    if (h.sparseScore === undefined) {
+      continue;
+    }
     const norm = h.sparseScore / maxSparse;
-    if (norm < min) {min = norm;}
-    if (norm > max) {max = norm;}
+    if (norm < min) {
+      min = norm;
+    }
+    if (norm > max) {
+      max = norm;
+    }
     count++;
   }
   // With < 2 sparse-bearing hits the spread is undefined — fall back to base
@@ -303,7 +309,9 @@ export function fuseHalf(
   denseWeight: number,
   sparseWeight: number,
 ): number | undefined {
-  if (denseScore === undefined && sparseScore === undefined) {return undefined;}
+  if (denseScore === undefined && sparseScore === undefined) {
+    return undefined;
+  }
   const dense = denseScore !== undefined ? Math.max(0, denseScore) : 0;
   const sparseNormalized =
     sparseScore !== undefined && maxSparse > 0 ? sparseScore / maxSparse : 0;

--- a/assistant/src/plugins/defaults/memory/substrate/sparse-bm25.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/sparse-bm25.ts
@@ -101,15 +101,21 @@ export async function rebuildConceptPageCorpusStats(
 
   for (const slug of slugs) {
     const body = await readPageBodyForStats(workspaceDir, slug);
-    if (body === null) {continue;}
+    if (body === null) {
+      continue;
+    }
     const tokens = tokenizeStemmed(body);
-    if (tokens.length === 0) {continue;}
+    if (tokens.length === 0) {
+      continue;
+    }
     totalTokens += tokens.length;
     docsCounted += 1;
     const seen = new Set<number>();
     for (const token of tokens) {
       const idx = tokenHash(token, SPARSE_VOCAB_SIZE);
-      if (seen.has(idx)) {continue;}
+      if (seen.has(idx)) {
+        continue;
+      }
       seen.add(idx);
       df.set(idx, (df.get(idx) ?? 0) + 1);
     }
@@ -145,7 +151,9 @@ async function readPageBodyForStats(
     const closing = raw.indexOf("\n---", 3);
     if (closing !== -1) {
       const after = raw.indexOf("\n", closing + 4);
-      if (after !== -1) {return raw.slice(after + 1);}
+      if (after !== -1) {
+        return raw.slice(after + 1);
+      }
     }
   }
   return raw;
@@ -196,11 +204,15 @@ export function generateBm25DocEmbedding(
 
   for (const [idx, freq] of tf) {
     const idf = computeIdf(stats, idx);
-    if (idf === 0) {continue;} // Skip tokens that contribute nothing to scores.
+    if (idf === 0) {
+      continue;
+    } // Skip tokens that contribute nothing to scores.
     const saturated =
       (freq * (params.k1 + 1)) / (freq + params.k1 * lengthFactor);
     const weight = idf * saturated;
-    if (weight === 0) {continue;}
+    if (weight === 0) {
+      continue;
+    }
     indices.push(idx);
     values.push(weight);
   }
@@ -228,7 +240,9 @@ export function generateBm25QueryEmbedding(text: string): SparseEmbedding {
   const values: number[] = [];
   for (const token of tokens) {
     const idx = tokenHash(token, SPARSE_VOCAB_SIZE);
-    if (seen.has(idx)) {continue;}
+    if (seen.has(idx)) {
+      continue;
+    }
     seen.add(idx);
     indices.push(idx);
     values.push(1);

--- a/assistant/src/plugins/defaults/memory/substrate/static-context.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/static-context.ts
@@ -64,7 +64,9 @@ export function readMemoryV2StaticContent(
       continue;
     }
     const content = readPromptFile(getWorkspacePromptPath(file));
-    if (!content) {continue;}
+    if (!content) {
+      continue;
+    }
     sections.push(`${heading}\n\n${content}`);
   }
   return sections.length > 0 ? sections.join("\n\n") : null;

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/activation.test.ts
@@ -124,11 +124,15 @@ mock.module("../reranker.js", () => ({
       candidates: [...candidates],
     });
     return queries.map(() => {
-      if (rerankState.scores === null) {return new Map();}
+      if (rerankState.scores === null) {
+        return new Map();
+      }
       const out = new Map<string, number>();
       for (const slug of candidates) {
         const v = rerankState.scores.get(slug);
-        if (v !== undefined) {out.set(slug, v);}
+        if (v !== undefined) {
+          out.set(slug, v);
+        }
       }
       return out;
     });

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/backfill-jobs.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/backfill-jobs.test.ts
@@ -263,7 +263,9 @@ beforeEach(async () => {
     "buffer.md",
   ]) {
     const filePath = join(tmpWorkspace, "memory", filename);
-    if (existsSync(filePath)) {rmSync(filePath);}
+    if (existsSync(filePath)) {
+      rmSync(filePath);
+    }
   }
 
   migrationCalls.length = 0;

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/injection.test.ts
@@ -229,7 +229,9 @@ mock.module("../../substrate/page-store.js", () => ({
   ...realPageStoreModule,
   readPage: async (workspaceDir: string, slug: string) => {
     const err = pageStoreState.failingSlugs.get(slug);
-    if (err) {throw err;}
+    if (err) {
+      throw err;
+    }
     return realReadPage(workspaceDir, slug);
   },
 }));
@@ -269,7 +271,9 @@ mock.module("../router.js", () => ({
     // the closest equivalent under the new model.
     if (!result.sourceBySlug) {
       const map = new Map<string, string>();
-      for (const slug of result.selectedSlugs) {map.set(slug, "tier3:0");}
+      for (const slug of result.selectedSlugs) {
+        map.set(slug, "tier3:0");
+      }
       result.sourceBySlug = map;
     }
     return result;

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/reranker.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/reranker.test.ts
@@ -29,7 +29,9 @@ mock.module("../rerank-local.js", () => ({
         queries: [...queries],
         passages: [...passages],
       });
-      if (backendState.shouldThrow) {throw new Error("backend down");}
+      if (backendState.shouldThrow) {
+        throw new Error("backend down");
+      }
       return backendState.scores.slice(0, passages.length);
     },
   }),

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/router.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/router.test.ts
@@ -53,7 +53,9 @@ const warnLogs: Array<{ args: unknown[] }> = [];
 function makeRecordingLogger(): unknown {
   return new Proxy({} as Record<string, unknown>, {
     get: (_target, prop) => {
-      if (prop === "child") {return makeRecordingLogger;}
+      if (prop === "child") {
+        return makeRecordingLogger;
+      }
       if (prop === "warn") {
         return (...args: unknown[]) => {
           warnLogs.push({ args });
@@ -86,7 +88,9 @@ mock.module("../injection-events.js", () => ({
     const out = new Map<string, number>();
     for (const slug of slugs) {
       const score = scoresStub.get(slug);
-      if (score !== undefined && score > 0) {out.set(slug, score);}
+      if (score !== undefined && score > 0) {
+        out.set(slug, score);
+      }
     }
     return out;
   },
@@ -767,7 +771,9 @@ describe("runRouter — batched (batch_size set)", () => {
           systemPrompt: options?.systemPrompt,
           options,
         });
-        if (callCount === 1) {throw new Error("batch 1 boom");}
+        if (callCount === 1) {
+          throw new Error("batch 1 boom");
+        }
         return toolUseResponse([1]);
       },
     };

--- a/assistant/src/plugins/defaults/memory/v2/activation-store.ts
+++ b/assistant/src/plugins/defaults/memory/v2/activation-store.ts
@@ -26,7 +26,9 @@ export async function hydrate(
   conversationId: string,
 ): Promise<ActivationState | null> {
   const mdb = memoryDbOrNull("hydrateActivationState");
-  if (!mdb) {return null;}
+  if (!mdb) {
+    return null;
+  }
   const row = mdb
     .select({
       messageId: activationState.messageId,
@@ -38,7 +40,9 @@ export async function hydrate(
     .from(activationState)
     .where(eq(activationState.conversationId, conversationId))
     .get();
-  if (!row) {return null;}
+  if (!row) {
+    return null;
+  }
 
   return ActivationStateSchema.parse({
     messageId: row.messageId,
@@ -59,7 +63,9 @@ export async function save(
   state: ActivationState,
 ): Promise<void> {
   const mdb = memoryDbOrNull("saveActivationState");
-  if (!mdb) {return;}
+  if (!mdb) {
+    return;
+  }
   const stateJson = JSON.stringify(state.state);
   const everInjectedJson = JSON.stringify(state.everInjected);
   mdb
@@ -103,7 +109,9 @@ export function forkActivationState(
   newConversationId: string,
 ): void {
   const mdb = memoryDbOrNull("forkActivationState");
-  if (!mdb) {return;}
+  if (!mdb) {
+    return;
+  }
   const row = mdb
     .select({
       messageId: activationState.messageId,
@@ -115,7 +123,9 @@ export function forkActivationState(
     .from(activationState)
     .where(eq(activationState.conversationId, parentConversationId))
     .get();
-  if (!row) {return;}
+  if (!row) {
+    return;
+  }
 
   mdb
     .insert(activationState)
@@ -166,9 +176,13 @@ export function seedForkActivationState(
   newConversationId: string,
   inheritedSlugs: string[],
 ): void {
-  if (inheritedSlugs.length === 0) {return;}
+  if (inheritedSlugs.length === 0) {
+    return;
+  }
   const mdb = memoryDbOrNull("seedForkActivationState");
-  if (!mdb) {return;}
+  if (!mdb) {
+    return;
+  }
 
   const everInjected: EverInjectedEntry[] = inheritedSlugs.map((slug) => ({
     slug,

--- a/assistant/src/plugins/defaults/memory/v2/activation.ts
+++ b/assistant/src/plugins/defaults/memory/v2/activation.ts
@@ -110,7 +110,9 @@ export async function selectCandidates(
   if (priorState) {
     const epsilon = config.memory.v2.epsilon;
     for (const [slug, activation] of Object.entries(priorState.state)) {
-      if (activation > epsilon) {fromPrior.add(slug);}
+      if (activation > epsilon) {
+        fromPrior.add(slug);
+      }
     }
   }
 
@@ -146,7 +148,9 @@ export async function selectCandidates(
     const limit =
       config.memory.v2.ann_candidate_limit ?? UNLIMITED_ANN_CANDIDATE_LIMIT;
     const hits = await hybridQueryConceptPages(dense, sparse, limit);
-    for (const hit of hits) {fromAnn.add(hit.slug);}
+    for (const hit of hits) {
+      fromAnn.add(hit.slug);
+    }
   }
 
   const candidates = new Set<string>([...fromPrior, ...fromAnn]);
@@ -232,7 +236,9 @@ export async function computeOwnActivation(
 
   const activation = new Map<string, number>();
   const breakdown = new Map<string, OwnActivationBreakdown>();
-  if (candidates.size === 0) {return { activation, breakdown };}
+  if (candidates.size === 0) {
+    return { activation, breakdown };
+  }
 
   const { d, c_user, c_assistant, c_now } = config.memory.v2;
   const slugList = [...candidates];
@@ -347,12 +353,18 @@ function normalizeRerankScores(
   alpha: number,
 ): Map<string, number> {
   const out = new Map<string, number>();
-  if (rawScores.size === 0) {return out;}
+  if (rawScores.size === 0) {
+    return out;
+  }
   let maxScore = 0;
   for (const v of rawScores.values()) {
-    if (v > maxScore) {maxScore = v;}
+    if (v > maxScore) {
+      maxScore = v;
+    }
   }
-  if (maxScore === 0) {return out;}
+  if (maxScore === 0) {
+    return out;
+  }
   for (const [slug, raw] of rawScores) {
     out.set(slug, alpha * (raw / maxScore));
   }
@@ -402,7 +414,9 @@ export function selectInjections(
   }
 
   const ranked = [...A.entries()].sort(([slugA, valA], [slugB, valB]) => {
-    if (valB !== valA) {return valB - valA;} // higher activation first
+    if (valB !== valA) {
+      return valB - valA;
+    } // higher activation first
     return slugA < slugB ? -1 : slugA > slugB ? 1 : 0; // stable tie-break
   });
 

--- a/assistant/src/plugins/defaults/memory/v2/injection.ts
+++ b/assistant/src/plugins/defaults/memory/v2/injection.ts
@@ -247,7 +247,9 @@ export async function injectMemoryV2Block(
   // slugs drop out of consideration next turn.
   const nextStateMap: Record<string, number> = {};
   for (const [slug, value] of finalActivation) {
-    if (value > epsilon) {nextStateMap[slug] = value;}
+    if (value > epsilon) {
+      nextStateMap[slug] = value;
+    }
   }
 
   // Build the rich per-candidate telemetry rows up front (status assigned
@@ -500,7 +502,9 @@ async function finalizeInjection(args: {
     }
   }
 
-  if (caughtErr !== undefined && !args.bestEffort) {throw caughtErr;}
+  if (caughtErr !== undefined && !args.bestEffort) {
+    throw caughtErr;
+  }
   return { block, toInject: newlyInjected };
 }
 
@@ -667,7 +671,9 @@ async function injectViaRouter(args: {
   // `source: "carry_over"`. The `status` placeholder is overwritten by
   // `finalizeInjection`.
   const telemetrySlugs = new Set<string>(routerResult.selectedSlugs);
-  for (const entry of priorEverInjected) {telemetrySlugs.add(entry.slug);}
+  for (const entry of priorEverInjected) {
+    telemetrySlugs.add(entry.slug);
+  }
   const telemetryRows: MemoryV2ConceptRowRecord[] = [...telemetrySlugs].map(
     (slug) => ({
       slug,
@@ -840,9 +846,13 @@ async function renderInjectionBlock(
   const skillSlugs: string[] = [];
   const cliCommandSlugs: string[] = [];
   for (const slug of slugs) {
-    if (isSkillSlug(slug)) {skillSlugs.push(slug);}
-    else if (isCliCommandSlug(slug)) {cliCommandSlugs.push(slug);}
-    else {conceptSlugs.push(slug);}
+    if (isSkillSlug(slug)) {
+      skillSlugs.push(slug);
+    } else if (isCliCommandSlug(slug)) {
+      cliCommandSlugs.push(slug);
+    } else {
+      conceptSlugs.push(slug);
+    }
   }
 
   const settled = await Promise.allSettled(
@@ -880,14 +890,18 @@ async function renderInjectionBlock(
     // empty). Render the full page — frontmatter + body — so retrieval
     // still surfaces the same content the agent saw before this change.
     const content = renderPageContent(page).trim();
-    if (content.length === 0) {continue;}
+    if (content.length === 0) {
+      continue;
+    }
     sections.push(`# ${path}\n${content}`);
   }
 
   const skillLines: string[] = [];
   for (const slug of skillSlugs) {
     const entry = getSkillCapability(slug);
-    if (!entry) {continue;}
+    if (!entry) {
+      continue;
+    }
     skillLines.push(`- ${entry.content} → use skill_load to activate`);
   }
   if (skillLines.length > 0) {
@@ -897,7 +911,9 @@ async function renderInjectionBlock(
   const cliCommandLines: string[] = [];
   for (const slug of cliCommandSlugs) {
     const entry = getCliCommandCapability(slug);
-    if (!entry) {continue;}
+    if (!entry) {
+      continue;
+    }
     cliCommandLines.push(`- \`assistant ${entry.id}\`: ${entry.description}`);
   }
   if (cliCommandLines.length > 0) {

--- a/assistant/src/plugins/defaults/memory/v2/reranker.ts
+++ b/assistant/src/plugins/defaults/memory/v2/reranker.ts
@@ -36,13 +36,17 @@ function cacheKey(
 
 function evictExpired(now: number): void {
   for (const [k, v] of cache) {
-    if (now - v.ts > CACHE_TTL_MS) {cache.delete(k);}
+    if (now - v.ts > CACHE_TTL_MS) {
+      cache.delete(k);
+    }
   }
   if (cache.size > CACHE_MAX_ENTRIES) {
     const toDrop = cache.size - CACHE_MAX_ENTRIES;
     let i = 0;
     for (const k of cache.keys()) {
-      if (i++ >= toDrop) {break;}
+      if (i++ >= toDrop) {
+        break;
+      }
       cache.delete(k);
     }
   }
@@ -77,8 +81,12 @@ export async function rerankCandidates(
   candidates: readonly string[],
   config: AssistantConfig,
 ): Promise<Array<Map<string, number>>> {
-  if (queries.length === 0) {return [];}
-  if (candidates.length === 0) {return queries.map(() => new Map());}
+  if (queries.length === 0) {
+    return [];
+  }
+  if (candidates.length === 0) {
+    return queries.map(() => new Map());
+  }
 
   const { model, dtype } = config.memory.v2.rerank;
   const now = Date.now();
@@ -107,7 +115,9 @@ export async function rerankCandidates(
   const finalize = (): Array<Map<string, number>> =>
     results.map((r) => r ?? new Map());
 
-  if (uncachedIndices.length === 0) {return finalize();}
+  if (uncachedIndices.length === 0) {
+    return finalize();
+  }
 
   const workspaceDir = getWorkspaceDir();
   const pages = await Promise.all(
@@ -122,13 +132,17 @@ export async function rerankCandidates(
   const slugsForPassages: string[] = [];
   for (let i = 0; i < candidates.length; i++) {
     const page = pages[i];
-    if (!page) {continue;}
+    if (!page) {
+      continue;
+    }
     passages.push(buildPassage(candidates[i], page.body));
     slugsForPassages.push(candidates[i]);
   }
 
   if (passages.length === 0) {
-    for (const i of uncachedIndices) {results[i] = new Map();}
+    for (const i of uncachedIndices) {
+      results[i] = new Map();
+    }
     return finalize();
   }
 
@@ -154,7 +168,9 @@ export async function rerankCandidates(
       { err, model, n: batchPassages.length },
       "Rerank backend failed; falling back to pure fused scores",
     );
-    for (const i of uncachedIndices) {results[i] = new Map();}
+    for (const i of uncachedIndices) {
+      results[i] = new Map();
+    }
     return finalize();
   }
 
@@ -164,7 +180,9 @@ export async function rerankCandidates(
     const result = new Map<string, number>();
     for (let i = 0; i < slugsForPassages.length; i++) {
       const s = scores[offset + i];
-      if (typeof s !== "number" || Number.isNaN(s)) {continue;}
+      if (typeof s !== "number" || Number.isNaN(s)) {
+        continue;
+      }
       // sigmoid output should already be in [0, 1]; clamp defensively.
       result.set(slugsForPassages[i], Math.max(0, Math.min(1, s)));
     }

--- a/assistant/src/plugins/defaults/memory/v2/router.ts
+++ b/assistant/src/plugins/defaults/memory/v2/router.ts
@@ -285,8 +285,12 @@ export async function runRouter(
   // Tag each batch with its provenance string. Tier 3 batches carry their
   // bucket index so the inspector can attribute selections per-bucket.
   const taggedBatches: Array<{ source: RouterSource; index: PageIndex }> = [];
-  if (tier1) {taggedBatches.push({ source: "tier1", index: tier1 });}
-  if (tier2) {taggedBatches.push({ source: "tier2", index: tier2 });}
+  if (tier1) {
+    taggedBatches.push({ source: "tier1", index: tier1 });
+  }
+  if (tier2) {
+    taggedBatches.push({ source: "tier2", index: tier2 });
+  }
   tier3Batches.forEach((index, i) => {
     taggedBatches.push({ source: `tier3:${i}` as const, index });
   });
@@ -322,7 +326,9 @@ export async function runRouter(
     const result = batchResults[i];
     const source = taggedBatches[i].source;
     for (const slug of result.selectedSlugs) {
-      if (sourceBySlug.has(slug)) {continue;}
+      if (sourceBySlug.has(slug)) {
+        continue;
+      }
       sourceBySlug.set(slug, source);
       selectedSlugs.push(slug);
     }
@@ -354,7 +360,9 @@ export async function runRouter(
         "Router union across batches exceeded max_page_ids; truncating",
       );
       const dropped = selectedSlugs.splice(maxPageIds);
-      for (const slug of dropped) {sourceBySlug.delete(slug);}
+      for (const slug of dropped) {
+        sourceBySlug.delete(slug);
+      }
     }
   }
   return { selectedSlugs, sourceBySlug, failureReason: null };
@@ -402,7 +410,9 @@ async function runRouterBatch(
   const priorIds: number[] = [];
   for (const entry of priorEverInjected) {
     const local = batchIndex.bySlug.get(entry.slug);
-    if (local) {priorIds.push(local.id);}
+    if (local) {
+      priorIds.push(local.id);
+    }
   }
 
   // Trim the pairs down to the configured `<last_turn>` content budget,
@@ -513,7 +523,9 @@ async function runRouterBatch(
   const selectedSlugs: string[] = [];
   for (const id of finalIds) {
     const entry = batchIndex.byId.get(id);
-    if (!entry) {continue;}
+    if (!entry) {
+      continue;
+    }
     selectedSlugs.push(entry.slug);
   }
 
@@ -542,7 +554,9 @@ export function applyHistoricalCharBudget(
   pairs: readonly RouterTurnPair[],
   maxChars: number | null,
 ): RouterTurnPair[] {
-  if (maxChars === null || maxChars <= 0) {return [...pairs];}
+  if (maxChars === null || maxChars <= 0) {
+    return [...pairs];
+  }
 
   type WalkedMsg = {
     role: "user" | "assistant";
@@ -566,7 +580,9 @@ export function applyHistoricalCharBudget(
   const included = new Map<number, { assistant: string; user: string }>();
   for (const msg of walked) {
     const remaining = maxChars - used;
-    if (remaining <= 0) {break;}
+    if (remaining <= 0) {
+      break;
+    }
     let textToInclude: string;
     let stop = false;
     if (msg.text.length <= remaining) {
@@ -577,17 +593,24 @@ export function applyHistoricalCharBudget(
       // connects to the next message (in chronological order) without
       // a syntactic seam. The marker counts toward the budget so the
       // emitted text never exceeds `maxChars` cumulatively.
-      if (remaining <= HISTORICAL_TRUNCATION_MARKER.length) {break;}
+      if (remaining <= HISTORICAL_TRUNCATION_MARKER.length) {
+        break;
+      }
       const keepChars = remaining - HISTORICAL_TRUNCATION_MARKER.length;
       textToInclude = HISTORICAL_TRUNCATION_MARKER + msg.text.slice(-keepChars);
       used = maxChars;
       stop = true;
     }
     const slot = included.get(msg.pairIdx) ?? { assistant: "", user: "" };
-    if (msg.role === "user") {slot.user = textToInclude;}
-    else {slot.assistant = textToInclude;}
+    if (msg.role === "user") {
+      slot.user = textToInclude;
+    } else {
+      slot.assistant = textToInclude;
+    }
     included.set(msg.pairIdx, slot);
-    if (stop) {break;}
+    if (stop) {
+      break;
+    }
   }
 
   const sortedIdxs = [...included.keys()].sort((a, b) => a - b);

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/candidate-match.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/candidate-match.test.ts
@@ -262,7 +262,9 @@ describe("nearestExistingSkills — default scorer retries transient failures", 
     let calls = 0;
     simBatchImpl = async (_text, slugs) => {
       calls++;
-      if (calls === 1) {throw transientError();}
+      if (calls === 1) {
+        throw transientError();
+      }
       // Second attempt succeeds: the skill's capability page scores high.
       return new Map(
         slugs

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
@@ -490,7 +490,9 @@ function candidateSlugs(messages: Message[]): Slug[] {
   const entries: Array<{ id: number; slug: string }> = [];
   for (const msg of messages) {
     for (const block of msg.content) {
-      if (block.type !== "text") {continue;}
+      if (block.type !== "text") {
+        continue;
+      }
       const cards = /<candidate_cards>\n([\s\S]*?)\n<\/candidate_cards>/.exec(
         block.text,
       );
@@ -507,7 +509,9 @@ function candidateSlugs(messages: Message[]): Slug[] {
       if (finder) {
         for (const line of finder[1].split("\n")) {
           const m = /^\[(\d+)\] (?:\([^)]*\) )?(\S+)(?: — |$)/.exec(line);
-          if (m) {entries.push({ id: Number(m[1]), slug: m[2]! });}
+          if (m) {
+            entries.push({ id: Number(m[1]), slug: m[2]! });
+          }
         }
       }
     }
@@ -530,7 +534,9 @@ function makeProviderStub(): Provider {
       );
       const ids: number[] = [];
       candidateSlugs(messages).forEach((slug, i) => {
-        if (keep.includes(slug)) {ids.push(i + 1);}
+        if (keep.includes(slug)) {
+          ids.push(i + 1);
+        }
       });
       return toolUseResponse({ ids });
     },
@@ -614,13 +620,16 @@ async function runTurn(
 
   const activeBefore = getActiveSlugs(convId);
   const cards = await memoryV3Injector.produce(ctx);
-  if (!cards)
-    {throw new Error(`turn ${turnIndex}: cards injector returned null`);}
+  if (!cards) {
+    throw new Error(`turn ${turnIndex}: cards injector returned null`);
+  }
   // Runtime assembly invokes the block's attachment-commit callback at its
   // user-tail commit point — this is where the everInjected store records
   // the turn's cards (and the prune valve is scheduled).
   const commit = cards.meta?.[MEMORY_V3_COMMIT_META_KEY];
-  if (typeof commit === "function") {(commit as () => void)();}
+  if (typeof commit === "function") {
+    (commit as () => void)();
+  }
   const netNewSlugs = [...getActiveSlugs(convId)].filter(
     (slug) => !activeBefore.has(slug),
   );
@@ -883,7 +892,9 @@ beforeAll(async () => {
 afterAll(async () => {
   await flushPruneValveForTests();
   carryMockActive = false;
-  if (workspaceDir) {rmSync(workspaceDir, { recursive: true, force: true });}
+  if (workspaceDir) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -993,7 +1004,9 @@ describe("memory-v3 carry integration — cache contract", () => {
     let expected = 0;
     for (const record of records) {
       expected += record.netNewBytes;
-      if (record.turn === 7) {expected -= pruneWindow.bytesFreedExpected;}
+      if (record.turn === 7) {
+        expected -= pruneWindow.bytesFreedExpected;
+      }
       expect(record.residentBytes).toBe(expected);
     }
   });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
@@ -227,7 +227,9 @@ function candidateSlugs(messages: Message[]): Slug[] {
   const entries: Array<{ id: number; slug: string }> = [];
   for (const msg of messages) {
     for (const block of msg.content) {
-      if (block.type !== "text") {continue;}
+      if (block.type !== "text") {
+        continue;
+      }
       const cards = /<candidate_cards>\n([\s\S]*?)\n<\/candidate_cards>/.exec(
         block.text,
       );
@@ -244,7 +246,9 @@ function candidateSlugs(messages: Message[]): Slug[] {
       if (finder) {
         for (const line of finder[1].split("\n")) {
           const m = /^\[(\d+)\] (?:\([^)]*\) )?(\S+)(?: — |$)/.exec(line);
-          if (m) {entries.push({ id: Number(m[1]), slug: m[2]! });}
+          if (m) {
+            entries.push({ id: Number(m[1]), slug: m[2]! });
+          }
         }
       }
     }
@@ -269,8 +273,12 @@ function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
       const ids: number[] = [];
       const pinned_ids: number[] = [];
       pool.forEach((slug, i) => {
-        if (keep.includes(slug)) {ids.push(i + 1);}
-        if (pin.includes(slug)) {pinned_ids.push(i + 1);}
+        if (keep.includes(slug)) {
+          ids.push(i + 1);
+        }
+        if (pin.includes(slug)) {
+          pinned_ids.push(i + 1);
+        }
       });
       return toolUseResponse({ ids, pinned_ids });
     },

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -265,7 +265,9 @@ mock.module("../hot-set.js", () => ({
   computeHotSet: (
     ...args: Parameters<typeof realHotSet.computeHotSet>
   ): HotSetEntry[] => {
-    if (!shadowMockActive) {return realHotSet.computeHotSet(...args);}
+    if (!shadowMockActive) {
+      return realHotSet.computeHotSet(...args);
+    }
     hotSetOpts = args[0];
     return hotSetResult;
   },
@@ -388,7 +390,9 @@ mock.module("../sections.js", () => ({
   buildSectionIndex: async (
     ...args: Parameters<typeof realSections.buildSectionIndex>
   ) => {
-    if (!shadowMockActive) {return realSections.buildSectionIndex(...args);}
+    if (!shadowMockActive) {
+      return realSections.buildSectionIndex(...args);
+    }
     sectionBuilds++;
     // Capture the `pageBody` resolver so a test can exercise the capability
     // branch directly. Returning the FAKE index keeps the other tests cheap.
@@ -402,7 +406,9 @@ mock.module("../section-needle.js", () => ({
   buildSectionNeedle: (
     ...args: Parameters<typeof realSectionNeedle.buildSectionNeedle>
   ) => {
-    if (!shadowMockActive) {return realSectionNeedle.buildSectionNeedle(...args);}
+    if (!shadowMockActive) {
+      return realSectionNeedle.buildSectionNeedle(...args);
+    }
     needleBuilds++;
     return { query: () => [], bestSection: () => -1 };
   },
@@ -413,7 +419,9 @@ mock.module("../edge.js", () => ({
   buildEdgeGraph: async (
     ...args: Parameters<typeof realEdge.buildEdgeGraph>
   ) => {
-    if (!shadowMockActive) {return realEdge.buildEdgeGraph(...args);}
+    if (!shadowMockActive) {
+      return realEdge.buildEdgeGraph(...args);
+    }
     edgeBuilds++;
     return { adjacency: new Map(), hubs: new Set(), slugs: new Set() };
   },
@@ -424,8 +432,9 @@ mock.module("../learned-edges.js", () => ({
   computeLearnedEdgeGraph: (
     ...args: Parameters<typeof realLearnedEdges.computeLearnedEdgeGraph>
   ) => {
-    if (!shadowMockActive)
-      {return realLearnedEdges.computeLearnedEdgeGraph(...args);}
+    if (!shadowMockActive) {
+      return realLearnedEdges.computeLearnedEdgeGraph(...args);
+    }
     learnedGraphBuilds++;
     return { adjacency: new Map(), hubs: new Set(), slugs: new Set() };
   },
@@ -440,7 +449,9 @@ mock.module("../section-dense-store.js", () => ({
       return realSectionDenseStore.ensureSectionCollection(...args);
     }
     ensureCollectionCalls++;
-    if (ensureCollectionThrows) {throw new Error("qdrant unavailable");}
+    if (ensureCollectionThrows) {
+      throw new Error("qdrant unavailable");
+    }
   },
 }));
 
@@ -460,7 +471,9 @@ mock.module("../lanes-version-store.js", () => ({
     }
     // The store swallows read errors and returns `undefined`; mirror that so
     // `getLanes` exercises its "cannot judge staleness → serve memo" branch.
-    if (lanesVersionReadThrows) {return undefined;}
+    if (lanesVersionReadThrows) {
+      return undefined;
+    }
     return mockLanesVersion;
   },
   bumpLanesVersion: (workspaceDir: string) => {
@@ -555,7 +568,9 @@ async function produce(conversationId: string, turnIndex: number) {
     trust: {} as never,
   });
   const commit = block?.meta?.[MEMORY_V3_COMMIT_META_KEY];
-  if (typeof commit === "function") {(commit as () => void)();}
+  if (typeof commit === "function") {
+    (commit as () => void)();
+  }
   return block;
 }
 

--- a/assistant/src/plugins/defaults/memory/v3/capabilities.ts
+++ b/assistant/src/plugins/defaults/memory/v3/capabilities.ts
@@ -127,6 +127,8 @@ export async function capabilityOrDiskBody(
   slug: Slug,
   readDiskBody: (slug: Slug) => Promise<string>,
 ): Promise<string> {
-  if (isCapabilitySlug(slug)) {return renderCapabilityBody(slug) ?? "";}
+  if (isCapabilitySlug(slug)) {
+    return renderCapabilityBody(slug) ?? "";
+  }
   return readDiskBody(slug);
 }

--- a/assistant/src/plugins/defaults/memory/v3/card.ts
+++ b/assistant/src/plugins/defaults/memory/v3/card.ts
@@ -32,7 +32,9 @@ const SECTION_HEADING_REGEX = /^## (.*)$/m;
  */
 function renderLinkEntry(entry: string): string {
   const sep = entry.indexOf(" — ");
-  if (sep === -1) {return entry.trim();}
+  if (sep === -1) {
+    return entry.trim();
+  }
   const target = entry.slice(0, sep).trim();
   let note = entry.slice(sep + " — ".length).trim();
   if (note.length > LINK_NOTE_MAX_CHARS) {
@@ -59,13 +61,17 @@ function renderTocLine(
       .filter((entry): entry is string => typeof entry === "string")
       .map(renderLinkEntry)
       .filter((entry) => entry.length > 0);
-    if (entries.length > 0) {return `[linked: ${entries.join(" · ")}]`;}
+    if (entries.length > 0) {
+      return `[linked: ${entries.join(" · ")}]`;
+    }
   }
 
   const headings = [...body.matchAll(new RegExp(SECTION_HEADING_REGEX, "gm"))]
     .map((match) => match[1]!.trim())
     .filter((heading) => heading.length > 0);
-  if (headings.length === 0) {return null;}
+  if (headings.length === 0) {
+    return null;
+  }
   return `[sections: ${headings.map((h) => `§${h}`).join(" · ")}]`;
 }
 
@@ -81,9 +87,13 @@ const CURRENT_MAX_CHARS = 280;
  */
 function renderCurrentLine(fields: Record<string, unknown>): string | null {
   const current = fields.current;
-  if (typeof current !== "string") {return null;}
+  if (typeof current !== "string") {
+    return null;
+  }
   const collapsed = current.replace(/\s+/g, " ").trim();
-  if (collapsed.length === 0) {return null;}
+  if (collapsed.length === 0) {
+    return null;
+  }
   const capped =
     collapsed.length > CURRENT_MAX_CHARS
       ? `${collapsed.slice(0, CURRENT_MAX_CHARS).trimEnd()}…`
@@ -138,14 +148,20 @@ export function renderCard(
 
   let card = injectedConceptHeader(slug);
   const current = renderCurrentLine(fields);
-  if (current !== null) {card += `\n${current}`;}
+  if (current !== null) {
+    card += `\n${current}`;
+  }
   if (annotation !== undefined && annotation.length > 0) {
     card += `\n${annotation}`;
   }
-  if (head.length > 0) {card += `\n${head}`;}
+  if (head.length > 0) {
+    card += `\n${head}`;
+  }
 
   const toc = renderTocLine(body, fields);
-  if (toc !== null) {card += `\n\n${toc}`;}
+  if (toc !== null) {
+    card += `\n\n${toc}`;
+  }
 
   return card;
 }

--- a/assistant/src/plugins/defaults/memory/v3/edge.ts
+++ b/assistant/src/plugins/defaults/memory/v3/edge.ts
@@ -89,7 +89,9 @@ function parseLinkEntry(entry: string): {
   description: string | undefined;
 } {
   const sep = entry.indexOf(LINK_SEPARATOR);
-  if (sep === -1) {return { target: entry.trim(), description: undefined };}
+  if (sep === -1) {
+    return { target: entry.trim(), description: undefined };
+  }
   return {
     target: entry.slice(0, sep).trim(),
     description: entry.slice(sep + LINK_SEPARATOR.length).trim() || undefined,
@@ -104,11 +106,17 @@ function parseWikilinks(body: string): string[] {
   for (const match of body.matchAll(WIKILINK_REGEX)) {
     let target = match[1];
     const pipe = target.indexOf("|");
-    if (pipe !== -1) {target = target.slice(0, pipe);}
+    if (pipe !== -1) {
+      target = target.slice(0, pipe);
+    }
     const hash = target.indexOf("#");
-    if (hash !== -1) {target = target.slice(0, hash);}
+    if (hash !== -1) {
+      target = target.slice(0, hash);
+    }
     target = target.trim();
-    if (target) {targets.push(target);}
+    if (target) {
+      targets.push(target);
+    }
   }
   return targets;
 }
@@ -148,8 +156,12 @@ export async function buildEdgeGraph(
     target: Slug,
     description: string | undefined,
   ): void => {
-    if (target === source) {return;} // no self-edges
-    if (!slugs.has(target)) {return;} // drop unknown/dangling targets
+    if (target === source) {
+      return;
+    } // no self-edges
+    if (!slugs.has(target)) {
+      return;
+    } // drop unknown/dangling targets
     let out = adjacency.get(source);
     if (!out) {
       out = new Map();
@@ -175,7 +187,9 @@ export async function buildEdgeGraph(
     const links = parsed?.fields.links;
     if (Array.isArray(links)) {
       for (const entry of links) {
-        if (typeof entry !== "string") {continue;}
+        if (typeof entry !== "string") {
+          continue;
+        }
         const { target, description } = parseLinkEntry(entry);
         addEdge(source, target, description);
       }
@@ -194,13 +208,17 @@ export async function buildEdgeGraph(
     // (c) numeric page-index edges resolved to slugs — fallback.
     for (const targetId of article.edges) {
       const target = byId.get(targetId);
-      if (target) {addEdge(source, target, undefined);}
+      if (target) {
+        addEdge(source, target, undefined);
+      }
     }
   }
 
   const hubs = new Set<Slug>();
   for (const [slug, degree] of inDegree) {
-    if (degree > hubDegree) {hubs.add(slug);}
+    if (degree > hubDegree) {
+      hubs.add(slug);
+    }
   }
 
   return { adjacency, hubs, slugs };
@@ -229,17 +247,33 @@ export function edgeExpand(
   const surfaced = new Map<Slug, string | undefined>();
 
   for (const seed of seeds.slice(0, seedCount)) {
-    if (surfaced.size >= cap) {break;}
+    if (surfaced.size >= cap) {
+      break;
+    }
     const out = graph.adjacency.get(seed);
-    if (!out) {continue;}
+    if (!out) {
+      continue;
+    }
     let added = 0;
     for (const [target, description] of out) {
-      if (added >= perSeed) {break;}
-      if (surfaced.size >= cap) {break;}
-      if (seedSet.has(target)) {continue;} // already in the pool
-      if (surfaced.has(target)) {continue;} // already surfaced via another seed
-      if (graph.hubs.has(target)) {continue;} // hubs excluded
-      if (alive && !alive(target)) {continue;}
+      if (added >= perSeed) {
+        break;
+      }
+      if (surfaced.size >= cap) {
+        break;
+      }
+      if (seedSet.has(target)) {
+        continue;
+      } // already in the pool
+      if (surfaced.has(target)) {
+        continue;
+      } // already surfaced via another seed
+      if (graph.hubs.has(target)) {
+        continue;
+      } // hubs excluded
+      if (alive && !alive(target)) {
+        continue;
+      }
       surfaced.set(target, description);
       added++;
     }

--- a/assistant/src/plugins/defaults/memory/v3/page-content.ts
+++ b/assistant/src/plugins/defaults/memory/v3/page-content.ts
@@ -35,12 +35,18 @@ function withConceptHeader(slug: Slug, body: string): string {
  */
 export async function renderV3PageContent(slug: Slug): Promise<string> {
   const capability = renderCapabilityContent(slug);
-  if (capability !== null) {return capability;}
+  if (capability !== null) {
+    return capability;
+  }
   try {
     const page = await readPage(getWorkspaceDir(), slug);
-    if (!page) {return "";}
+    if (!page) {
+      return "";
+    }
     const content = renderPageContent(page).trim();
-    if (content.length === 0) {return "";}
+    if (content.length === 0) {
+      return "";
+    }
     return withConceptHeader(slug, content);
   } catch {
     return "";
@@ -62,10 +68,14 @@ export async function renderV3PageContent(slug: Slug): Promise<string> {
  */
 export async function renderV3CardContent(slug: Slug): Promise<string> {
   const capability = renderCapabilityContent(slug);
-  if (capability !== null) {return capability;}
+  if (capability !== null) {
+    return capability;
+  }
   try {
     const page = await readPage(getWorkspaceDir(), slug);
-    if (!page) {return "";}
+    if (!page) {
+      return "";
+    }
     return renderCard(slug, renderPageContent(page));
   } catch {
     return "";
@@ -93,10 +103,16 @@ export async function renderV3SectionContent(
   section: Section | undefined,
 ): Promise<string> {
   const capability = renderCapabilityContent(slug);
-  if (capability !== null) {return capability;}
-  if (!section) {return renderV3PageContent(slug);}
+  if (capability !== null) {
+    return capability;
+  }
+  if (!section) {
+    return renderV3PageContent(slug);
+  }
 
   const text = section.text.trim();
-  if (text.length === 0) {return "";}
+  if (text.length === 0) {
+    return "";
+  }
   return withConceptHeader(slug, text);
 }

--- a/assistant/src/plugins/defaults/memory/v3/prune.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.ts
@@ -133,7 +133,9 @@ export function parseCardSections(inner: string): {
     cardMatches.map((match) => ({ index: match.index!, slug: match[1]! }));
   for (const match of inner.matchAll(TOP_LEVEL_HEADER_REGEX)) {
     const i = match.index!;
-    if (cardStarts.has(i)) {continue;}
+    if (cardStarts.has(i)) {
+      continue;
+    }
     // Foreign header on a `\n\n` seam → starts its own chunk.
     if (i >= 2 && inner[i - 1] === "\n" && inner[i - 2] === "\n") {
       boundaries.push({ index: i, slug: null });
@@ -175,16 +177,24 @@ export function filterPrunedCardSections(
   prunedSlugs: ReadonlySet<string>,
 ): string {
   const { preamble, sections, pieces } = parseCardSections(inner);
-  if (sections.length === 0) {return inner;}
+  if (sections.length === 0) {
+    return inner;
+  }
 
   const kept = pieces.filter(
     (piece) => piece.kind !== "card" || !prunedSlugs.has(piece.slug),
   );
-  if (kept.length === pieces.length) {return inner;}
-  if (kept.length === 0) {return "";}
+  if (kept.length === pieces.length) {
+    return inner;
+  }
+  if (kept.length === 0) {
+    return "";
+  }
 
   const texts = kept.map((piece) => piece.text);
-  if (preamble.length > 0) {texts.unshift(preamble);}
+  if (preamble.length > 0) {
+    texts.unshift(preamble);
+  }
   return texts.join("\n\n");
 }
 
@@ -226,7 +236,9 @@ export function planPrune(
 ): PrunePlan | null {
   const activeEntries = getActiveEntries(conversationId);
   const resident = activeEntries.reduce((sum, e) => sum + e.bytes, 0);
-  if (resident <= deps.maxResidentBytes) {return null;}
+  if (resident <= deps.maxResidentBytes) {
+    return null;
+  }
 
   const memoryRaw = memorySqliteOrNull("planPrune");
   const selectionRows = memoryRaw
@@ -256,7 +268,9 @@ export function planPrune(
   const slugs: string[] = [];
   let bytesFreed = 0;
   for (const candidate of candidates) {
-    if (resident - bytesFreed <= deps.targetResidentBytes) {break;}
+    if (resident - bytesFreed <= deps.targetResidentBytes) {
+      break;
+    }
     slugs.push(candidate.slug);
     bytesFreed += candidate.bytes;
   }
@@ -293,7 +307,9 @@ export function collectPersistedV3Cards(conversationId: string): Set<string> {
       row.metadata,
       MEMORY_V3_INJECTED_BLOCK_METADATA_KEY,
     );
-    if (block === null) {continue;}
+    if (block === null) {
+      continue;
+    }
     for (const section of parseCardSections(unwrapMemoryBlock(block))
       .sections) {
       sections.add(section.text);
@@ -321,7 +337,9 @@ export function stripPrunedCardsFromMessages(
 ): number {
   let strippedBlocks = 0;
   for (const message of messages) {
-    if (message.role !== "user") {continue;}
+    if (message.role !== "user") {
+      continue;
+    }
     let changed = false;
     const nextContent: ContentBlock[] = [];
     for (const block of message.content) {
@@ -355,7 +373,9 @@ export function stripPrunedCardsFromMessages(
         nextContent.push({ type: "text", text: wrapMemoryBlock(filtered) });
       }
     }
-    if (changed) {message.content = nextContent;}
+    if (changed) {
+      message.content = nextContent;
+    }
   }
   return strippedBlocks;
 }
@@ -400,7 +420,9 @@ export async function runPruneValve(
 ): Promise<PrunePlan | null> {
   // Defensive read: test configs may omit the prune block entirely.
   const pruneConfig = getMemoryConfig()?.v3?.prune;
-  if (!pruneConfig) {return null;}
+  if (!pruneConfig) {
+    return null;
+  }
 
   // Planning needs only the store (cheap); the persisted-metadata scan for
   // the live strip's ownership test runs only once a plan exists — a
@@ -413,7 +435,9 @@ export async function runPruneValve(
     },
     conversationId,
   );
-  if (!plan) {return null;}
+  if (!plan) {
+    return null;
+  }
 
   markPruned(conversationId, plan.slugs, options.now ?? Date.now());
 

--- a/assistant/src/plugins/defaults/memory/v3/selection-log-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/selection-log-store.ts
@@ -63,7 +63,9 @@ function rowsForTurn(conversationId: string, turn: number): SelectionRow[] {
 }
 
 function rowsForMessageIds(messageIds: string[]): SelectionRow[] {
-  if (messageIds.length === 0) {return [];}
+  if (messageIds.length === 0) {
+    return [];
+  }
   const raw = memorySqliteOrNull("rowsForMessageIds");
   if (!raw) {
     return [];
@@ -87,7 +89,9 @@ const MAX_FORK_HOPS = 64;
  * stamps onto every message a fork copies, for the given message ids.
  */
 function forkSourceIdsOf(messageIds: string[]): string[] {
-  if (messageIds.length === 0) {return [];}
+  if (messageIds.length === 0) {
+    return [];
+  }
   const placeholders = messageIds.map(() => "?").join(", ");
   const rows = getSqliteFrom(getDb())
     .query(
@@ -117,10 +121,16 @@ function rowsViaForkSource(messageIds: string[]): SelectionRow[] {
   const visited = new Set(messageIds);
   for (let hop = 0; hop < MAX_FORK_HOPS; hop++) {
     const sources = forkSourceIdsOf(frontier).filter((id) => !visited.has(id));
-    if (sources.length === 0) {return [];}
-    for (const id of sources) {visited.add(id);}
+    if (sources.length === 0) {
+      return [];
+    }
+    for (const id of sources) {
+      visited.add(id);
+    }
     const rows = rowsForMessageIds(sources);
-    if (rows.length > 0) {return rows;}
+    if (rows.length > 0) {
+      return rows;
+    }
     frontier = sources;
   }
   return [];
@@ -140,7 +150,9 @@ async function reconstructMatchedSections(
   const sectionSlugs = rows
     .filter((r) => r.section_ordinal != null)
     .map((r) => r.slug);
-  if (sectionSlugs.length === 0) {return new Map();}
+  if (sectionSlugs.length === 0) {
+    return new Map();
+  }
 
   const workspaceDir = getWorkspaceDir();
   const pageBody = (slug: Slug): Promise<string> =>
@@ -155,9 +167,13 @@ async function reconstructMatchedSections(
 
   const sectionBySlug = new Map<Slug, Section>();
   for (const row of rows) {
-    if (row.section_ordinal == null) {continue;}
+    if (row.section_ordinal == null) {
+      continue;
+    }
     const section = sectionByOrdinal(index, row.slug, row.section_ordinal);
-    if (section) {sectionBySlug.set(row.slug, section);}
+    if (section) {
+      sectionBySlug.set(row.slug, section);
+    }
   }
   return sectionBySlug;
 }
@@ -165,7 +181,9 @@ async function reconstructMatchedSections(
 async function buildSelectionLog(
   rows: SelectionRow[],
 ): Promise<MemoryV3SelectionLog | null> {
-  if (rows.length === 0) {return null;}
+  if (rows.length === 0) {
+    return null;
+  }
 
   const config = getConfig();
   const selections = rows.map((r) => ({
@@ -226,7 +244,9 @@ export async function getMemoryV3SelectionForInspector(
   conversationId: string,
   turn: number | null | undefined,
 ): Promise<MemoryV3SelectionLog | null> {
-  if (turn == null) {return null;}
+  if (turn == null) {
+    return null;
+  }
   return buildSelectionLog(rowsForTurn(conversationId, turn));
 }
 
@@ -280,7 +300,9 @@ export function summarizeSelections(conversationId: string): SelectionSummary {
   const turns = new Set<number>();
   const slugs = new Set<string>();
   for (const row of rows) {
-    if (isSelectionSource(row.source)) {bySource[row.source] += 1;}
+    if (isSelectionSource(row.source)) {
+      bySource[row.source] += 1;
+    }
     turns.add(row.turn);
     slugs.add(row.slug);
   }


### PR DESCRIPTION
## Summary
- Reformats 49 files under `assistant/src/plugins/defaults/memory/` with the repo-pinned prettier (3.8.1), restoring them to the style they had on `main`
- No semantic changes: `prettier --write` was the only operation performed

## Why
An `eslint --fix` pass during the tier-separation stack rewrote one-line control-flow bodies to `{return x;}`, and the follow-up formatting was done with `bunx prettier`, which resolves **3.9.5** rather than the pinned **3.8.1**. The two disagree on brace style, so ~49 files landed non-conforming. CI has no format gate, so it merged silently — and it would trip every future editor via the whole-file pre-commit prettier hook, besides breaking the "pure move" property several PRs were reviewed on.

Only 1 file under this path failed `prettier --check` on `main`; the rest of the drift came from this stack.

Found by self-review of plan memory-tier-separation.md.