### PR TITLE
fix(memory): bound the retrospective sweep to a recency lookback window

### DIFF
--- a/assistant/src/cli/commands/memory/memory-retrospective.ts
+++ b/assistant/src/cli/commands/memory/memory-retrospective.ts
@@ -135,6 +135,11 @@ function renderOutcome(outcome: MemoryRetrospectiveOutcome): void {
     case "no_new_messages":
       log.info("No new messages to review since the last retrospective.");
       break;
+    case "source_dormant":
+      log.info(
+        "Source conversation is dormant beyond the sweep lookback; skipping.",
+      );
+      break;
     case "source_processing":
       log.info(
         "Source conversation is mid-turn; skipping (will retry next trigger).",

--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -52,6 +52,19 @@ export const MemoryRetrospectiveConfigSchema = z
         "Cadence of the scheduled retrospective sweep, the timer-driven backstop that re-scans conversations for unprocessed messages the event-driven triggers missed (e.g. a turn that ended in a crash or IPC drop before the post-turn hooks ran). A conversation is only swept when its last retrospective attempt is at least this old, so the sweep never competes with the responsive interval/message_count triggers on active conversations.",
       ),
 
+    sweepLookbackMs: z
+      .number({
+        error: "memory.retrospective.sweepLookbackMs must be a number",
+      })
+      .int("memory.retrospective.sweepLookbackMs must be an integer")
+      .positive(
+        "memory.retrospective.sweepLookbackMs must be a positive integer",
+      )
+      .default(7 * 24 * 60 * 60 * 1000)
+      .describe(
+        "How far back the scheduled retrospective sweep looks for stalled work. The sweep backstops turns that ended abnormally (crash / IPC drop), and such turns are by definition recent — so only conversations whose last message falls inside this window are scanned, and the retrospective job re-applies the same window at execution time so a stale queued backlog is skipped instead of run. Conversations dormant beyond the window are outside the sweep's scope entirely: their unprocessed tails are ordinary end-of-conversation remainders, not stalled work.",
+      ),
+
     keepSupersededRuns: z
       .boolean({
         error: "memory.retrospective.keepSupersededRuns must be a boolean",

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -78,6 +78,7 @@ type ConversationStub = {
   inferenceProfileExpiresAt?: number | null;
   originChannel?: string | null;
   originInterface?: string | null;
+  lastMessageAt?: number | null;
 };
 let conversationOverrides: Record<string, ConversationStub> = {};
 
@@ -342,6 +343,7 @@ function makeConfig(
         keepSupersededRuns: overrides.keepSupersededRuns ?? false,
         matchConversationProfile: overrides.matchConversationProfile ?? false,
         promptPath: overrides.promptPath ?? null,
+        sweepLookbackMs: 7 * 24 * 60 * 60 * 1000,
       },
     },
     ui: {
@@ -446,6 +448,34 @@ describe("memoryRetrospectiveJob", () => {
     // findMostRecentRetrospectiveFor.
     expect(forkCalls).toHaveLength(1);
     expect(forkCalls[0]!.conversationId).toBe("src-conv-1");
+  });
+
+  test("dormant source beyond the sweep lookback: completed as a no-op, both pointers untouched", async () => {
+    conversationOverrides["src-conv-1"] = {
+      source: "user",
+      forkParentMessageId: null,
+      lastMessageAt: Date.now() - 8 * 24 * 60 * 60 * 1000,
+    };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("source_dormant");
+    expect(stateUpserts).toHaveLength(0);
+    expect(lastRunAtBumps).toHaveLength(0);
+    expect(wakeCalls).toHaveLength(0);
+    expect(forkCalls).toHaveLength(0);
+  });
+
+  test("recent source inside the sweep lookback runs normally", async () => {
+    conversationOverrides["src-conv-1"] = {
+      source: "user",
+      forkParentMessageId: null,
+      lastMessageAt: Date.now() - 60_000,
+    };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
   });
 
   test("no-new-messages early return: neither field changes, no wake, no fork", async () => {

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
@@ -13,6 +13,8 @@ mock.module("../memory-retrospective-enqueue.js", () => ({
   },
 }));
 
+import { eq } from "drizzle-orm";
+
 import type { AssistantConfig } from "../../../../config/types.js";
 import { AUTO_ANALYSIS_SOURCE } from "../../../../persistence/auto-analysis-constants.js";
 import { createConversation } from "../../../../persistence/conversation-crud.js";
@@ -21,7 +23,10 @@ import {
   getMemorySqlite,
 } from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
-import { messages } from "../../../../persistence/schema/index.js";
+import {
+  conversations,
+  messages,
+} from "../../../../persistence/schema/index.js";
 import {
   MEMORY_RETROSPECTIVE_SOURCE,
   SKILL_CARD_MESSAGE_KIND,
@@ -30,17 +35,30 @@ import { upsertRetrospectiveState } from "../memory-retrospective-state.js";
 import {
   listSweepCandidateConversationIds,
   runRetrospectiveSweep,
+  SWEEP_MAX_ENQUEUES_PER_PASS,
 } from "../memory-retrospective-sweep.js";
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../v3/substrate/constants.js";
 
 await initializeDb();
 
 const SWEEP_INTERVAL_MS = 8 * 60 * 60 * 1000; // 8h
+const SWEEP_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000; // 7d
 
-function makeConfig(sweepIntervalMs = SWEEP_INTERVAL_MS): AssistantConfig {
+function makeConfig(
+  sweepIntervalMs = SWEEP_INTERVAL_MS,
+  sweepLookbackMs = SWEEP_LOOKBACK_MS,
+): AssistantConfig {
   return {
-    memory: { retrospective: { sweepIntervalMs } },
+    memory: { retrospective: { sweepIntervalMs, sweepLookbackMs } },
   } as unknown as AssistantConfig;
+}
+
+function setLastMessageAt(conversationId: string, ts: number | null): void {
+  getDb()
+    .update(conversations)
+    .set({ lastMessageAt: ts })
+    .where(eq(conversations.id, conversationId))
+    .run();
 }
 
 function resetTables(): void {
@@ -71,6 +89,12 @@ function insertMessage(
       metadata: opts.metadata ? JSON.stringify(opts.metadata) : null,
     })
     .run();
+  // Mirrors `addMessage`'s conversation-stamp bump so seeded conversations
+  // sit inside the sweep lookback window. The stamp is wall-clock (like
+  // production), independent of the message's logical `createdAt`, which the
+  // cursor accounting reads from the message rows. Dormancy tests override
+  // via `setLastMessageAt`.
+  setLastMessageAt(conversationId, Date.now());
   return id;
 }
 
@@ -211,6 +235,35 @@ describe("runRetrospectiveSweep", () => {
       { conversationId: conv.id, trigger: "sweep" },
     ]);
   });
+
+  test("conversation dormant beyond the lookback is not swept — a cold start over deep history enqueues nothing", async () => {
+    const conv = createConversation({ id: "conv-a" });
+    // Unprocessed tail exists (no state row at all), which is the shape of
+    // every historical conversation on a first sweep — but the conversation
+    // has been dormant past the lookback, so its tail is an ordinary
+    // end-of-conversation remainder, not stalled work.
+    insertMessage(conv.id, { createdAt: 1_000 });
+    setLastMessageAt(conv.id, Date.now() - SWEEP_LOOKBACK_MS - 60_000);
+
+    const result = await runRetrospectiveSweep(makeConfig());
+
+    expect(enqueueCalls).toEqual([]);
+    expect(result).toEqual({ scanned: 0, enqueued: 0 });
+  });
+
+  test("enqueues clamp at the per-pass cap and defer the remainder", async () => {
+    for (let i = 0; i < SWEEP_MAX_ENQUEUES_PER_PASS + 5; i++) {
+      const conv = createConversation({
+        id: `conv-${String(i).padStart(3, "0")}`,
+      });
+      insertMessage(conv.id, { createdAt: 1_000 });
+    }
+
+    const result = await runRetrospectiveSweep(makeConfig());
+
+    expect(result.enqueued).toBe(SWEEP_MAX_ENQUEUES_PER_PASS);
+    expect(enqueueCalls.length).toBe(SWEEP_MAX_ENQUEUES_PER_PASS);
+  });
 });
 
 describe("listSweepCandidateConversationIds", () => {
@@ -231,21 +284,45 @@ describe("listSweepCandidateConversationIds", () => {
     });
     createConversation({ id: "conv-auto", source: AUTO_ANALYSIS_SOURCE });
     createConversation({ id: "conv-scheduled", conversationType: "scheduled" });
+    for (const id of [
+      "conv-a",
+      "conv-b",
+      "conv-retro",
+      "conv-consolidate",
+      "conv-auto",
+      "conv-scheduled",
+    ]) {
+      setLastMessageAt(id, 5_000);
+    }
 
-    const ids = listSweepCandidateConversationIds("", 100);
+    const ids = listSweepCandidateConversationIds("", 100, 0);
 
     expect(ids).toEqual(["conv-a", "conv-b"]);
   });
 
   test("keyset cursor resumes past the given id", () => {
-    createConversation({ id: "conv-a" });
-    createConversation({ id: "conv-b" });
-    createConversation({ id: "conv-c" });
+    for (const id of ["conv-a", "conv-b", "conv-c"]) {
+      createConversation({ id });
+      setLastMessageAt(id, 5_000);
+    }
 
-    expect(listSweepCandidateConversationIds("conv-a", 100)).toEqual([
+    expect(listSweepCandidateConversationIds("conv-a", 100, 0)).toEqual([
       "conv-b",
       "conv-c",
     ]);
-    expect(listSweepCandidateConversationIds("", 1)).toEqual(["conv-a"]);
+    expect(listSweepCandidateConversationIds("", 1, 0)).toEqual(["conv-a"]);
+  });
+
+  test("lookback cutoff excludes dormant and never-stamped conversations", () => {
+    createConversation({ id: "conv-recent" });
+    setLastMessageAt("conv-recent", 5_000);
+    createConversation({ id: "conv-dormant" });
+    setLastMessageAt("conv-dormant", 1_000);
+    // No message stamp at all — `gt` NULL semantics exclude it.
+    createConversation({ id: "conv-unstamped" });
+
+    expect(listSweepCandidateConversationIds("", 100, 2_000)).toEqual([
+      "conv-recent",
+    ]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -124,6 +124,7 @@ const MEMORY_RETROSPECTIVE_RUN_CHECK_NAME = "memory_retrospective_run";
 export type MemoryRetrospectiveOutcome =
   | { kind: "disabled" }
   | { kind: "no_new_messages" }
+  | { kind: "source_dormant" }
   | { kind: "source_processing" }
   | { kind: "wake_failed"; reason?: string; conversationId?: string }
   | {
@@ -170,7 +171,9 @@ export async function memoryRetrospectiveJob(
 
   let outcome: MemoryRetrospectiveOutcome;
   try {
-    outcome = await runForkBasedRetrospective(sourceConversationId, config);
+    outcome = await runForkBasedRetrospective(sourceConversationId, config, {
+      enforceSweepLookback: true,
+    });
   } catch (err) {
     emitRunOutcome("error", err instanceof Error ? err.message : String(err));
     throw err;
@@ -196,6 +199,16 @@ export async function memoryRetrospectiveJob(
 export async function runForkBasedRetrospective(
   sourceConversationId: string,
   config: AssistantConfig,
+  opts?: {
+    /**
+     * Skip the run when the source's last message is older than
+     * `memory.retrospective.sweepLookbackMs`. The queue handler passes this so
+     * a stale pending backlog is completed as no-ops instead of run; the CLI's
+     * manual command omits it — an operator's explicit request overrides the
+     * window.
+     */
+    enforceSweepLookback?: boolean;
+  },
 ): Promise<MemoryRetrospectiveOutcome> {
   // Start stamp for the retrospective's end-to-end wall time, surfaced as
   // `durationMs` on the "invoked" log (start → invoked).
@@ -207,6 +220,29 @@ export async function runForkBasedRetrospective(
       "memory-retrospective (fork): source conversation not found; skipping",
     );
     return { kind: "no_new_messages" };
+  }
+
+  // Execution-time twin of the sweep's lookback window (see
+  // memory-retrospective-sweep.ts). Event triggers enqueue in response to a
+  // just-persisted message, so a legitimately-enqueued job's source sits
+  // inside the window when the job runs; a numeric stamp older than the
+  // window means the row is stale backlog, and running it would burn an
+  // inference pass on a conversation the sweep no longer considers stalled.
+  // A missing stamp is NOT dormancy here — the enqueue itself evidences
+  // activity, unlike the sweep's scan where the stamp is the only signal.
+  // Both state pointers stay untouched.
+  if (opts?.enforceSweepLookback === true) {
+    const lastMessageAt = sourceConversation.lastMessageAt;
+    if (
+      typeof lastMessageAt === "number" &&
+      startedAtMs - lastMessageAt > config.memory.retrospective.sweepLookbackMs
+    ) {
+      log.info(
+        { sourceConversationId, lastMessageAt },
+        "memory-retrospective (fork): source dormant beyond the sweep lookback; skipping",
+      );
+      return { kind: "source_dormant" };
+    }
   }
 
   // Forking mid-turn would capture a half-finished display turn — incremental

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
@@ -27,6 +27,14 @@
 // (filtered in `EXCLUDED_SOURCES`).
 //
 // Cost discipline:
+//   - The scan is bounded to conversations whose last message falls inside
+//     `memory.retrospective.sweepLookbackMs`. A crash-orphaned turn is by
+//     definition recent, so a conversation dormant beyond the window is not
+//     stalled work — its unprocessed tail is an ordinary end-of-conversation
+//     remainder. Without this bound, the scan degenerates into a full-history
+//     backfill: nearly every conversation ever carries a tail past its final
+//     retrospective cursor, so a cold start would enqueue an inference pass
+//     per conversation across the entire history.
 //   - The per-conversation gate skips any conversation whose last retrospective
 //     attempt is newer than the sweep interval, so the sweep never competes
 //     with the responsive event triggers on active conversations — it only
@@ -35,11 +43,18 @@
 //     `upsertMemoryRetrospectiveJob` coalesces against any already-pending job,
 //     so a conversation already queued by an event trigger is never
 //     double-processed.
+//   - Enqueues are capped at `SWEEP_MAX_ENQUEUES_PER_PASS` per pass. Inside
+//     the lookback window, organic stalled work is a handful of conversations;
+//     a pass wanting more signals an anomalous backlog. Each pass re-scans
+//     from the start, so the deferred remainder is picked up by later passes.
 //   - The scan is keyset-paginated in bounded batches with a yield between
 //     pages (mirrors `conversation-memory-orphan-sweep.ts`), so a large history
-//     never materializes all ids at once or holds the event loop. Every
-//     eligible conversation is examined each pass — there is no front-of-list
-//     limit that could starve later conversations.
+//     never materializes all ids at once or holds the event loop.
+//
+// The retrospective job re-applies the lookback window at execution time
+// (`runForkBasedRetrospective`'s `enforceSweepLookback` gate), so pending rows
+// that outlive the window — e.g. a backlog drained long after enqueue — are
+// completed as no-ops instead of run.
 
 import { and, asc, gt, ne, notInArray } from "drizzle-orm";
 
@@ -61,6 +76,15 @@ const log = getLogger("memory-retrospective-sweep");
 
 /** Rows per keyset-paginated page — bounds each statement and the id set held. */
 const SWEEP_BATCH = 200;
+
+/**
+ * Hard ceiling on retrospectives enqueued by a single sweep pass. Each
+ * enqueue fans out an LLM inference pass, so a pass that wants more than this
+ * many is anomalous (organic in-window stalled work is a handful of
+ * conversations at most) and gets clamped with a warning. Safe to defer: every
+ * pass re-scans from the start, so the remainder is enqueued by later passes.
+ */
+export const SWEEP_MAX_ENQUEUES_PER_PASS = 50;
 
 /**
  * Conversation `source` values excluded from the sweep up front:
@@ -112,10 +136,16 @@ function breathe(): Promise<void> {
  * string sorts before any real id, so the first page starts at the beginning.
  * `scheduled`-type conversations are filtered here (low-yield, matching the
  * enqueue guard); other low-yield cases are caught by the enqueue itself.
+ *
+ * `lastMessageAtCutoff` bounds the scan to the sweep's lookback window
+ * (indexed via `idx_conversations_last_message_at`). `gt` NULL semantics
+ * exclude rows with no recorded message stamp: absent any evidence of recent
+ * activity, a conversation is not sweepable.
  */
 export function listSweepCandidateConversationIds(
   cursor: string,
   limit: number,
+  lastMessageAtCutoff: number,
 ): string[] {
   return getDb()
     .select({ id: conversations.id })
@@ -123,6 +153,7 @@ export function listSweepCandidateConversationIds(
     .where(
       and(
         gt(conversations.id, cursor),
+        gt(conversations.lastMessageAt, lastMessageAtCutoff),
         notInArray(conversations.source, EXCLUDED_SOURCES),
         ne(conversations.conversationType, "scheduled"),
       ),
@@ -141,11 +172,12 @@ export interface RetrospectiveSweepResult {
 }
 
 /**
- * Scan all sweep-eligible conversations and enqueue a `sweep`-triggered
- * retrospective for any with unprocessed messages whose last attempt is older
- * than `sweepIntervalMs`. Idempotent and best-effort: enqueue coalescing
- * prevents duplicates, and the scan degrades to a no-op when memory is
- * disabled.
+ * Scan sweep-eligible conversations with activity inside the lookback window
+ * and enqueue a `sweep`-triggered retrospective for any with unprocessed
+ * messages whose last attempt is older than `sweepIntervalMs`, up to
+ * {@link SWEEP_MAX_ENQUEUES_PER_PASS} per pass. Idempotent and best-effort:
+ * enqueue coalescing prevents duplicates, and the scan degrades to a no-op
+ * when memory is disabled.
  */
 export async function runRetrospectiveSweep(
   config: AssistantConfig,
@@ -155,12 +187,17 @@ export async function runRetrospectiveSweep(
     return { scanned: 0, enqueued: 0 };
   }
   const sweepIntervalMs = config.memory.retrospective.sweepIntervalMs;
+  const lookbackCutoff = now - config.memory.retrospective.sweepLookbackMs;
 
   let scanned = 0;
   let enqueued = 0;
   let cursor = "";
   for (;;) {
-    const page = listSweepCandidateConversationIds(cursor, SWEEP_BATCH);
+    const page = listSweepCandidateConversationIds(
+      cursor,
+      SWEEP_BATCH,
+      lookbackCutoff,
+    );
     if (page.length === 0) {
       break;
     }
@@ -198,6 +235,13 @@ export async function runRetrospectiveSweep(
 
       enqueueMemoryRetrospectiveIfEnabled({ conversationId, trigger: "sweep" });
       enqueued += 1;
+      if (enqueued >= SWEEP_MAX_ENQUEUES_PER_PASS) {
+        log.warn(
+          { scanned, enqueued },
+          "Memory retrospective sweep hit the per-pass enqueue cap; deferring the remainder to the next pass",
+        );
+        return { scanned, enqueued };
+      }
     }
 
     await breathe();


### PR DESCRIPTION
## Summary
- The scheduled retrospective sweep now only considers conversations with activity inside a new `memory.retrospective.sweepLookbackMs` window (default 7 days). A crash-orphaned turn — the case the sweep exists to backstop — is by definition recent, while on a cold start over a long history the unbounded scan treated every conversation's post-final-retrospective tail as stalled work: a production install with a ~3k-conversation history saw 2,905 retrospectives enqueued in one minute (~$500 of LLM spend and thousands of stale memory-buffer entries).
- The retrospective job re-applies the same window at execution time (`enforceSweepLookback`, queue path only — the CLI's manual command is exempt), so a stale pending backlog already sitting in `memory_jobs` on an affected install is completed as no-ops after upgrade instead of run. A new `source_dormant` outcome kind makes the skips visible in the watchdog counter.
- Sweep enqueues are capped at 50 per pass with a loud warning when clamped; each pass re-scans from the start, so any deferred remainder is picked up by later passes.

## Original prompt
The first sweep run after upgrading to v0.10.12 (which shipped #38840) fanned out retrospectives across an install's entire conversation history, burning ~$500 of inference in a morning and flooding the memory buffer with re-extracted content. The fix was specified in three parts: a dormancy window at enqueue time via a new `sweepLookbackMs` config, the same predicate re-checked at job run time so already-enqueued backlogs are neutralized on upgrade, and a per-pass enqueue cap with anomaly logging. Tests cover the cold-start-over-history, recent-crash-tail, cap-clamp, and run-time-gate cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)