### PR TITLE
fix(memory): retrospective sweep skips pending sources; lookback clamps to the sweep interval

### DIFF
--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -62,7 +62,7 @@ export const MemoryRetrospectiveConfigSchema = z
       )
       .default(7 * 24 * 60 * 60 * 1000)
       .describe(
-        "How far back the scheduled retrospective sweep looks for stalled work. The sweep backstops turns that ended abnormally (crash / IPC drop), and such turns are by definition recent — so only conversations whose last message falls inside this window are scanned, and the retrospective job re-applies the same window at execution time so a stale queued backlog is skipped instead of run. Conversations dormant beyond the window are outside the sweep's scope entirely: their unprocessed tails are ordinary end-of-conversation remainders, not stalled work.",
+        "How far back the scheduled retrospective sweep looks for stalled work. The sweep backstops turns that ended abnormally (crash / IPC drop), and such turns are by definition recent — so only conversations whose last message falls inside this window are scanned, and the retrospective job re-applies the same window at execution time so a stale queued backlog is skipped instead of run. Conversations dormant beyond the window are outside the sweep's scope entirely: their unprocessed tails are ordinary end-of-conversation remainders, not stalled work. Values below memory.retrospective.sweepIntervalMs are treated as equal to it — a lookback shorter than the sweep cadence would leave a blind span between passes.",
       ),
 
     keepSupersededRuns: z

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -378,6 +378,30 @@ function mergeSkillCardEntries(
  * Check whether a pending or running job of the given type already exists.
  * Used to prevent duplicate enqueues for long-running maintenance jobs.
  */
+/**
+ * Source-conversation ids of every pending or running `memory_retrospective`
+ * job. The retrospective sweep skips these up front: an already-queued source
+ * has nothing for the sweep to add (the row will run on its own), and a
+ * coalescing upsert against it must not consume the sweep's per-pass enqueue
+ * cap.
+ */
+export function listActiveMemoryRetrospectiveSourceConversationIds(): string[] {
+  return memoryDb()
+    .select({
+      conversationId: sql<string>`json_extract(${memoryJobs.payload}, '$.conversationId')`,
+    })
+    .from(memoryJobs)
+    .where(
+      and(
+        eq(memoryJobs.type, "memory_retrospective"),
+        inArray(memoryJobs.status, ["pending", "running"]),
+      ),
+    )
+    .all()
+    .map((row) => row.conversationId)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+}
+
 export function hasActiveJobOfType(type: MemoryJobType): boolean {
   const db = memoryDb();
   return (

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -343,6 +343,7 @@ function makeConfig(
         keepSupersededRuns: overrides.keepSupersededRuns ?? false,
         matchConversationProfile: overrides.matchConversationProfile ?? false,
         promptPath: overrides.promptPath ?? null,
+        sweepIntervalMs: 8 * 60 * 60 * 1000,
         sweepLookbackMs: 7 * 24 * 60 * 60 * 1000,
       },
     },

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
@@ -23,6 +23,7 @@ import {
   getMemorySqlite,
 } from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
+import { upsertMemoryRetrospectiveJob } from "../../../../persistence/jobs-store.js";
 import {
   conversations,
   messages,
@@ -65,6 +66,7 @@ function resetTables(): void {
   const db = getDb();
   db.run(`DELETE FROM messages`);
   getMemorySqlite()!.exec(`DELETE FROM memory_retrospective_state`);
+  getMemorySqlite()!.exec(`DELETE FROM memory_jobs`);
   db.run(`DELETE FROM conversations`);
 }
 
@@ -249,6 +251,41 @@ describe("runRetrospectiveSweep", () => {
 
     expect(enqueueCalls).toEqual([]);
     expect(result).toEqual({ scanned: 0, enqueued: 0 });
+  });
+
+  test("source with an already-pending job is skipped and does not consume the cap", async () => {
+    // Three stalled sources already have pending rows (e.g. the worker is
+    // backed up); one fresh source has none. The pending ones must be skipped
+    // outright — counting their coalescing upserts toward the cap would
+    // starve later ids across passes.
+    for (const id of ["conv-a", "conv-b", "conv-c"]) {
+      const conv = createConversation({ id });
+      insertMessage(conv.id, { createdAt: 1_000 });
+      upsertMemoryRetrospectiveJob({ conversationId: conv.id });
+    }
+    const fresh = createConversation({ id: "conv-d" });
+    insertMessage(fresh.id, { createdAt: 1_000 });
+
+    const result = await runRetrospectiveSweep(makeConfig());
+
+    expect(enqueueCalls).toEqual([
+      { conversationId: fresh.id, trigger: "sweep" },
+    ]);
+    expect(result).toEqual({ scanned: 4, enqueued: 1 });
+  });
+
+  test("a lookback below the sweep interval is clamped up to the interval", async () => {
+    // lookback 1 minute, interval 8h: without clamping, work appearing
+    // between passes would age out of the window before the next pass runs.
+    const conv = createConversation({ id: "conv-a" });
+    insertMessage(conv.id, { createdAt: 1_000 });
+    setLastMessageAt(conv.id, Date.now() - 2 * 60 * 60 * 1000); // 2h ago
+
+    await runRetrospectiveSweep(makeConfig(SWEEP_INTERVAL_MS, 60_000));
+
+    expect(enqueueCalls).toEqual([
+      { conversationId: conv.id, trigger: "sweep" },
+    ]);
   });
 
   test("enqueues clamp at the per-pass cap and defer the remainder", async () => {

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -97,6 +97,7 @@ import {
   getRetrospectiveState,
   upsertRetrospectiveState,
 } from "./memory-retrospective-state.js";
+import { effectiveSweepLookbackMs } from "./memory-retrospective-sweep.js";
 
 const log = getLogger("memory-retrospective-job");
 
@@ -235,7 +236,7 @@ export async function runForkBasedRetrospective(
     const lastMessageAt = sourceConversation.lastMessageAt;
     if (
       typeof lastMessageAt === "number" &&
-      startedAtMs - lastMessageAt > config.memory.retrospective.sweepLookbackMs
+      startedAtMs - lastMessageAt > effectiveSweepLookbackMs(config)
     ) {
       log.info(
         { sourceConversationId, lastMessageAt },

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
@@ -47,6 +47,8 @@
 //     the lookback window, organic stalled work is a handful of conversations;
 //     a pass wanting more signals an anomalous backlog. Each pass re-scans
 //     from the start, so the deferred remainder is picked up by later passes.
+//     Sources with an already-pending/running retrospective job are skipped
+//     before the cap, so coalescing no-ops never consume it.
 //   - The scan is keyset-paginated in bounded batches with a yield between
 //     pages (mirrors `conversation-memory-orphan-sweep.ts`), so a large history
 //     never materializes all ids at once or holds the event loop.
@@ -63,7 +65,10 @@ import { AUTO_ANALYSIS_SOURCE } from "../../../persistence/auto-analysis-constan
 import { getConversationRecentProvenanceTrustClass } from "../../../persistence/conversation-crud.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import type { MemoryJob } from "../../../persistence/jobs-store.js";
-import { isMemoryEnabled } from "../../../persistence/jobs-store.js";
+import {
+  isMemoryEnabled,
+  listActiveMemoryRetrospectiveSourceConversationIds,
+} from "../../../persistence/jobs-store.js";
 import { conversations } from "../../../persistence/schema/index.js";
 import { getLogger } from "./logging.js";
 import { countRetrospectiveMessagesAfter } from "./memory-retrospective-accounting.js";
@@ -132,6 +137,22 @@ function breathe(): Promise<void> {
 }
 
 /**
+ * The lookback window the sweep actually applies. A configured lookback
+ * shorter than the sweep cadence would leave a blind span in every interval —
+ * work appearing right after one pass would age out of the window before the
+ * next pass runs — so the effective window is never smaller than
+ * `sweepIntervalMs`. Shared by the sweep scan and the retrospective job's
+ * execution-time gate; the two must agree or the gate would kill jobs the
+ * scan legitimately enqueued.
+ */
+export function effectiveSweepLookbackMs(config: AssistantConfig): number {
+  return Math.max(
+    config.memory.retrospective.sweepLookbackMs,
+    config.memory.retrospective.sweepIntervalMs,
+  );
+}
+
+/**
  * One keyset page of sweep-eligible conversation ids past `cursor`. The empty
  * string sorts before any real id, so the first page starts at the beginning.
  * `scheduled`-type conversations are filtered here (low-yield, matching the
@@ -187,7 +208,10 @@ export async function runRetrospectiveSweep(
     return { scanned: 0, enqueued: 0 };
   }
   const sweepIntervalMs = config.memory.retrospective.sweepIntervalMs;
-  const lookbackCutoff = now - config.memory.retrospective.sweepLookbackMs;
+  const lookbackCutoff = now - effectiveSweepLookbackMs(config);
+  const activeSourceIds = new Set(
+    listActiveMemoryRetrospectiveSourceConversationIds(),
+  );
 
   let scanned = 0;
   let enqueued = 0;
@@ -205,6 +229,15 @@ export async function runRetrospectiveSweep(
 
     for (const conversationId of page) {
       scanned += 1;
+
+      // An already-queued source has nothing for the sweep to add — its
+      // pending row runs on its own. Skipping it up front keeps coalescing
+      // upserts from consuming the per-pass enqueue cap: counted no-ops would
+      // starve conversations later in id order across passes (every pass
+      // restarts from the lowest id) until they age out of the lookback.
+      if (activeSourceIds.has(conversationId)) {
+        continue;
+      }
 
       // Memory trust boundary: never enqueue a retrospective (which runs under
       // guardian trust with `remember`) for a conversation whose actor isn't


### PR DESCRIPTION
## Summary
Addresses both Codex P2 findings on #39188:

- **Pending sources no longer consume the sweep cap.** Sources with an already-pending/running `memory_retrospective` job are skipped up front (new `listActiveMemoryRetrospectiveSourceConversationIds()` in the jobs store) — previously a coalescing upsert still incremented `enqueued`, so ≥50 stalled-pending candidates at the front of the id order (e.g. during a provider outage) could starve later conversations across passes until they aged out of the lookback.
- **A lookback below the sweep cadence is clamped up to it.** New `effectiveSweepLookbackMs()` = `max(sweepLookbackMs, sweepIntervalMs)`, shared by the sweep scan and the job's execution-time gate (the two must agree, or the gate would kill jobs the scan legitimately enqueued). Clamping was chosen over cross-field validation deliberately: rejecting `lookback < interval` would invalidate the legitimate "park the sweep with a very large interval" configuration.

## Original prompt
Follow-up to the retrospective-sweep cold-start fix (#39188, already merged): evaluate and address the two Codex review comments — coalesced upserts counting toward the per-pass cap (starvation risk), and `sweepLookbackMs < sweepIntervalMs` leaving a blind span between passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)