### PR TITLE
fix(memory): sweep skip set is pending-only; lookback floor doubles the sweep interval

### DIFF
--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -62,7 +62,7 @@ export const MemoryRetrospectiveConfigSchema = z
       )
       .default(7 * 24 * 60 * 60 * 1000)
       .describe(
-        "How far back the scheduled retrospective sweep looks for stalled work. The sweep backstops turns that ended abnormally (crash / IPC drop), and such turns are by definition recent — so only conversations whose last message falls inside this window are scanned, and the retrospective job re-applies the same window at execution time so a stale queued backlog is skipped instead of run. Conversations dormant beyond the window are outside the sweep's scope entirely: their unprocessed tails are ordinary end-of-conversation remainders, not stalled work. Values below memory.retrospective.sweepIntervalMs are treated as equal to it — a lookback shorter than the sweep cadence would leave a blind span between passes.",
+        "How far back the scheduled retrospective sweep looks for stalled work. The sweep backstops turns that ended abnormally (crash / IPC drop), and such turns are by definition recent — so only conversations whose last message falls inside this window are scanned, and the retrospective job re-applies the same window at execution time so a stale queued backlog is skipped instead of run. Conversations dormant beyond the window are outside the sweep's scope entirely: their unprocessed tails are ordinary end-of-conversation remainders, not stalled work. Values below twice memory.retrospective.sweepIntervalMs are clamped up to that floor — scheduler and queue delay stretch the gap between consecutive scans past the nominal cadence, so a window at or under one interval would leave a permanent blind span between passes.",
       ),
 
     keepSupersededRuns: z

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -375,17 +375,16 @@ function mergeSkillCardEntries(
 }
 
 /**
- * Check whether a pending or running job of the given type already exists.
- * Used to prevent duplicate enqueues for long-running maintenance jobs.
+ * Source-conversation ids of every PENDING `memory_retrospective` job. The
+ * retrospective sweep skips these up front: a pending row already covers the
+ * source's unprocessed span, and a coalescing upsert against it must not
+ * consume the sweep's per-pass enqueue cap. Deliberately excludes `running`
+ * rows — a running job's fork and cursor are pre-run snapshots, so messages
+ * arriving mid-run need a follow-up row behind it, and the sweep must be able
+ * to create that follow-up. Mirrors `upsertMemoryRetrospectiveJob`'s
+ * pending-only coalescing.
  */
-/**
- * Source-conversation ids of every pending or running `memory_retrospective`
- * job. The retrospective sweep skips these up front: an already-queued source
- * has nothing for the sweep to add (the row will run on its own), and a
- * coalescing upsert against it must not consume the sweep's per-pass enqueue
- * cap.
- */
-export function listActiveMemoryRetrospectiveSourceConversationIds(): string[] {
+export function listPendingMemoryRetrospectiveSourceConversationIds(): string[] {
   return memoryDb()
     .select({
       conversationId: sql<string>`json_extract(${memoryJobs.payload}, '$.conversationId')`,
@@ -394,7 +393,7 @@ export function listActiveMemoryRetrospectiveSourceConversationIds(): string[] {
     .where(
       and(
         eq(memoryJobs.type, "memory_retrospective"),
-        inArray(memoryJobs.status, ["pending", "running"]),
+        eq(memoryJobs.status, "pending"),
       ),
     )
     .all()
@@ -402,6 +401,10 @@ export function listActiveMemoryRetrospectiveSourceConversationIds(): string[] {
     .filter((id): id is string => typeof id === "string" && id.length > 0);
 }
 
+/**
+ * Check whether a pending or running job of the given type already exists.
+ * Used to prevent duplicate enqueues for long-running maintenance jobs.
+ */
 export function hasActiveJobOfType(type: MemoryJobType): boolean {
   const db = memoryDb();
   return (

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-sweep.test.ts
@@ -274,18 +274,45 @@ describe("runRetrospectiveSweep", () => {
     expect(result).toEqual({ scanned: 4, enqueued: 1 });
   });
 
-  test("a lookback below the sweep interval is clamped up to the interval", async () => {
-    // lookback 1 minute, interval 8h: without clamping, work appearing
-    // between passes would age out of the window before the next pass runs.
+  test("a running retrospective does not suppress the sweep — a mid-run arrival needs a follow-up row", async () => {
+    // The running job's fork and cursor are pre-run snapshots; the sweep must
+    // still be able to enqueue the follow-up behind it (the upsert's
+    // pending-only coalescing creates a fresh pending row).
     const conv = createConversation({ id: "conv-a" });
     insertMessage(conv.id, { createdAt: 1_000 });
-    setLastMessageAt(conv.id, Date.now() - 2 * 60 * 60 * 1000); // 2h ago
+    upsertMemoryRetrospectiveJob({ conversationId: conv.id });
+    getMemorySqlite()!.exec(
+      `UPDATE memory_jobs SET status = 'running' WHERE type = 'memory_retrospective'`,
+    );
 
-    await runRetrospectiveSweep(makeConfig(SWEEP_INTERVAL_MS, 60_000));
+    const result = await runRetrospectiveSweep(makeConfig());
 
     expect(enqueueCalls).toEqual([
       { conversationId: conv.id, trigger: "sweep" },
     ]);
+    expect(result).toEqual({ scanned: 1, enqueued: 1 });
+  });
+
+  test("a lookback below the sweep cadence is clamped to twice the interval", async () => {
+    // lookback 1 minute, interval 8h → effective window 16h. The doubled
+    // floor covers work that lands in the scheduler/queue skew right after a
+    // pass (older than one interval by the time the next pass executes)
+    // while staying bounded across extended downtime.
+    const seen = createConversation({ id: "conv-seen" });
+    insertMessage(seen.id, { createdAt: 1_000 });
+    setLastMessageAt(seen.id, Date.now() - 10 * 60 * 60 * 1000); // 10h: past one interval
+    const beyond = createConversation({ id: "conv-beyond" });
+    insertMessage(beyond.id, { createdAt: 1_000 });
+    setLastMessageAt(beyond.id, Date.now() - 17 * 60 * 60 * 1000); // 17h: past the floor
+
+    const result = await runRetrospectiveSweep(
+      makeConfig(SWEEP_INTERVAL_MS, 60_000),
+    );
+
+    expect(enqueueCalls).toEqual([
+      { conversationId: seen.id, trigger: "sweep" },
+    ]);
+    expect(result).toEqual({ scanned: 1, enqueued: 1 });
   });
 
   test("enqueues clamp at the per-pass cap and defer the remainder", async () => {

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-sweep.ts
@@ -47,8 +47,10 @@
 //     the lookback window, organic stalled work is a handful of conversations;
 //     a pass wanting more signals an anomalous backlog. Each pass re-scans
 //     from the start, so the deferred remainder is picked up by later passes.
-//     Sources with an already-pending/running retrospective job are skipped
-//     before the cap, so coalescing no-ops never consume it.
+//     Sources with an already-pending retrospective job are skipped before
+//     the cap, so coalescing no-ops never consume it; a running job does not
+//     suppress the sweep (its cursor is a pre-run snapshot — a mid-run
+//     arrival needs a follow-up row behind it).
 //   - The scan is keyset-paginated in bounded batches with a yield between
 //     pages (mirrors `conversation-memory-orphan-sweep.ts`), so a large history
 //     never materializes all ids at once or holds the event loop.
@@ -67,7 +69,7 @@ import { getDb } from "../../../persistence/db-connection.js";
 import type { MemoryJob } from "../../../persistence/jobs-store.js";
 import {
   isMemoryEnabled,
-  listActiveMemoryRetrospectiveSourceConversationIds,
+  listPendingMemoryRetrospectiveSourceConversationIds,
 } from "../../../persistence/jobs-store.js";
 import { conversations } from "../../../persistence/schema/index.js";
 import { getLogger } from "./logging.js";
@@ -137,18 +139,25 @@ function breathe(): Promise<void> {
 }
 
 /**
- * The lookback window the sweep actually applies. A configured lookback
- * shorter than the sweep cadence would leave a blind span in every interval —
- * work appearing right after one pass would age out of the window before the
- * next pass runs — so the effective window is never smaller than
- * `sweepIntervalMs`. Shared by the sweep scan and the retrospective job's
- * execution-time gate; the two must agree or the gate would kill jobs the
- * scan legitimately enqueued.
+ * The lookback window the sweep actually applies: never smaller than TWICE
+ * `sweepIntervalMs`. One interval is not enough — the pass checkpoint is
+ * stamped at enqueue but the cutoff is computed at execution, so tick, queue,
+ * and runtime delay stretch the gap between consecutive executions past the
+ * nominal cadence, and a message landing in that skew right after a pass
+ * would sit permanently outside an exact-interval window. The doubled floor
+ * absorbs the skew while staying BOUNDED: deriving the window from elapsed
+ * time since the previous pass would cover arbitrary gaps, but after
+ * extended downtime it would recreate the cold-start backfill this window
+ * exists to prevent. Outages longer than a full interval can therefore still
+ * leave tails outside the window — accepted by design, like the cold start.
+ * Shared by the sweep scan and the retrospective job's execution-time gate;
+ * the two must agree or the gate would kill jobs the scan legitimately
+ * enqueued.
  */
 export function effectiveSweepLookbackMs(config: AssistantConfig): number {
   return Math.max(
     config.memory.retrospective.sweepLookbackMs,
-    config.memory.retrospective.sweepIntervalMs,
+    2 * config.memory.retrospective.sweepIntervalMs,
   );
 }
 
@@ -209,8 +218,8 @@ export async function runRetrospectiveSweep(
   }
   const sweepIntervalMs = config.memory.retrospective.sweepIntervalMs;
   const lookbackCutoff = now - effectiveSweepLookbackMs(config);
-  const activeSourceIds = new Set(
-    listActiveMemoryRetrospectiveSourceConversationIds(),
+  const pendingSourceIds = new Set(
+    listPendingMemoryRetrospectiveSourceConversationIds(),
   );
 
   let scanned = 0;
@@ -230,12 +239,14 @@ export async function runRetrospectiveSweep(
     for (const conversationId of page) {
       scanned += 1;
 
-      // An already-queued source has nothing for the sweep to add — its
-      // pending row runs on its own. Skipping it up front keeps coalescing
-      // upserts from consuming the per-pass enqueue cap: counted no-ops would
-      // starve conversations later in id order across passes (every pass
-      // restarts from the lowest id) until they age out of the lookback.
-      if (activeSourceIds.has(conversationId)) {
+      // A source with a pending row has nothing for the sweep to add — the
+      // row runs on its own. Skipping it up front keeps coalescing upserts
+      // from consuming the per-pass enqueue cap: counted no-ops would starve
+      // conversations later in id order across passes (every pass restarts
+      // from the lowest id). A RUNNING job does not suppress the sweep — its
+      // cursor is a pre-run snapshot, so a mid-run arrival needs a follow-up
+      // row, and the upsert's pending-only coalescing creates exactly that.
+      if (pendingSourceIds.has(conversationId)) {
         continue;
       }
 


### PR DESCRIPTION
## Summary
Addresses both Codex P2 findings on #39189:

- **The sweep's skip set is now pending-only** (`listPendingMemoryRetrospectiveSourceConversationIds()`, renamed from the pending+running variant). A running job's fork and cursor are pre-run snapshots, so messages arriving mid-run need a follow-up row behind it — and the sweep must be able to create that follow-up when the arrival's own turn ended abnormally. Mirrors `upsertMemoryRetrospectiveJob`'s deliberate pending-only coalescing; the cost is at most an occasional cheap `no_new_messages` no-op. Also restores `hasActiveJobOfType`'s doc comment, which the previous PR's insertion had displaced.
- **The lookback clamp floor is now 2× `sweepIntervalMs`** (was 1×). The pass checkpoint stamps at enqueue while the cutoff computes at execution, so tick/queue/runtime skew stretches consecutive execution gaps past the nominal cadence — an exact-interval window leaves a permanent blind span right after each pass. The doubled floor absorbs that skew while staying **bounded**: Codex's alternative (deriving the window from elapsed time since the previous pass) would cover arbitrary gaps but would recreate the cold-start backfill after extended downtime — the exact failure #39188 fixed. Outages longer than a full interval can still leave tails outside the window; that residual is accepted by design, consistent with the cold-start rule, and documented at `effectiveSweepLookbackMs`.

## Original prompt
Second follow-up to the retrospective-sweep hardening (#39188, #39189): evaluate and address the two Codex review comments on #39189 — the skip set wrongly including `running` jobs (suppressing required follow-up rows for mid-run arrivals), and the exact-interval clamp still leaving a scheduler-skew blind span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)