### PR TITLE
feat(permissions): route out-of-workspace file tools through the risk lane instead of hard-failing

### DIFF
--- a/assistant/src/__tests__/file-edit-tool.test.ts
+++ b/assistant/src/__tests__/file-edit-tool.test.ts
@@ -128,15 +128,35 @@ describe("file_edit tool (sandbox)", () => {
     expect(result.content).toContain("old_string not found");
   });
 
-  test("blocks path traversal escape", async () => {
+  test("edits a file outside the workspace boundary (non-containerized)", async () => {
     const dir = makeTempDir();
+    const outside = makeTempDir();
+    const target = join(outside, "escape.txt");
+    writeFileSync(target, "hello world\n");
 
     const result = await fileEditTool.execute(
-      { path: "../../../etc/hosts", old_string: "a", new_string: "b" },
+      { path: target, old_string: "hello world", new_string: "updated" },
       makeContext(dir),
     );
 
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("outside the working directory");
+    expect(result.isError).toBe(false);
+    expect(readFileSync(target, "utf-8")).toBe("updated\n");
+  });
+
+  test("blocks path traversal escape when containerized", async () => {
+    const dir = makeTempDir();
+    process.env.IS_CONTAINERIZED = "true";
+    try {
+      const result = await fileEditTool.execute(
+        { path: "../../../etc/hosts", old_string: "a", new_string: "b" },
+        makeContext(dir),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("outside the working directory");
+      expect(result.content).toContain("host_file_edit");
+    } finally {
+      delete process.env.IS_CONTAINERIZED;
+    }
   });
 });

--- a/assistant/src/__tests__/file-read-tool.test.ts
+++ b/assistant/src/__tests__/file-read-tool.test.ts
@@ -7,7 +7,14 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 
 import { finalizeTool } from "../tools/tool-defaults.js";
 import type { Tool, ToolContext } from "../tools/types.js";
@@ -81,15 +88,34 @@ describe("file_read tool (sandbox)", () => {
     expect(result.content).toContain("is a directory");
   });
 
-  test("rejects path traversal outside working dir", async () => {
+  test("reads a file outside the workspace boundary (non-containerized)", async () => {
     const dir = makeTempDir();
+    const outside = makeTempDir();
+    const target = join(outside, "escape.txt");
+    writeFileSync(target, "outside content");
 
     const result = await fileReadTool.execute(
-      { path: "../../../etc/passwd" },
+      { path: target },
       makeContext(dir),
     );
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("outside the working directory");
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("outside content");
+  });
+
+  test("rejects path traversal outside working dir when containerized", async () => {
+    const dir = makeTempDir();
+    process.env.IS_CONTAINERIZED = "true";
+    try {
+      const result = await fileReadTool.execute(
+        { path: "../../../etc/passwd" },
+        makeContext(dir),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("outside the working directory");
+    } finally {
+      delete process.env.IS_CONTAINERIZED;
+    }
   });
 });
 
@@ -166,22 +192,48 @@ describe("file_read image support", () => {
     expect(result.content).toContain("file not found");
   });
 
-  test("blocks image path traversal outside working dir", async () => {
+  test("reads an image outside the workspace boundary (non-containerized)", async () => {
     const dir = makeTempDir();
+    const outside = makeTempDir();
+    writeFileSync(join(outside, "photo.jpg"), JPEG_HEADER);
 
     const result = await fileReadTool.execute(
-      { path: "../../etc/secret.png" },
+      { path: join(outside, "photo.jpg") },
       makeContext(dir),
     );
 
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("outside the working directory");
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Image loaded");
+  });
+
+  test("blocks image path traversal outside working dir when containerized", async () => {
+    const dir = makeTempDir();
+    process.env.IS_CONTAINERIZED = "true";
+    try {
+      const result = await fileReadTool.execute(
+        { path: "../../etc/secret.png" },
+        makeContext(dir),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("outside the working directory");
+    } finally {
+      delete process.env.IS_CONTAINERIZED;
+    }
   });
 });
 
-// ── Out-of-bounds hint for host_file_read ─────────────────────────────
+// ── Out-of-bounds hint for host_file_read (containerized) ─────────────
 
 describe("file_read out-of-bounds hint", () => {
+  beforeEach(() => {
+    process.env.IS_CONTAINERIZED = "true";
+  });
+
+  afterEach(() => {
+    delete process.env.IS_CONTAINERIZED;
+  });
+
   test("suggests host_file_read for out-of-bounds text file path", async () => {
     const dir = makeTempDir();
 

--- a/assistant/src/__tests__/file-write-tool.test.ts
+++ b/assistant/src/__tests__/file-write-tool.test.ts
@@ -144,16 +144,35 @@ describe("file_write tool (sandbox)", () => {
     expect(readFileSync(filePath, "utf-8")).toBe("deep content");
   });
 
-  test("blocks path traversal escape", async () => {
+  test("writes outside the workspace boundary (non-containerized)", async () => {
     const dir = makeTempDir();
+    const outside = makeTempDir();
+    const target = join(outside, "escape.txt");
 
     const result = await fileWriteTool.execute(
-      { path: "../../escape.txt", content: "escaped" },
+      { path: target, content: "escaped" },
       makeContext(dir),
     );
 
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("outside the working directory");
+    expect(result.isError).toBe(false);
+    expect(readFileSync(target, "utf-8")).toBe("escaped");
+  });
+
+  test("blocks path traversal escape when containerized", async () => {
+    const dir = makeTempDir();
+    process.env.IS_CONTAINERIZED = "true";
+    try {
+      const result = await fileWriteTool.execute(
+        { path: "../../escape.txt", content: "escaped" },
+        makeContext(dir),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("outside the working directory");
+      expect(result.content).toContain("host_file_write");
+    } finally {
+      delete process.env.IS_CONTAINERIZED;
+    }
   });
 
   test("blocks oversize content", async () => {

--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -302,6 +302,23 @@ describe("sandboxPolicyWithHostFallback", () => {
     }
   });
 
+  test("denies the gateway security dir even when it sits inside the boundary", () => {
+    const boundary = makeTempDir();
+    const securityDir = join(boundary, "protected");
+    mkdirSync(securityDir);
+    process.env.GATEWAY_SECURITY_DIR = securityDir;
+
+    for (const policy of [sandboxPolicy, sandboxPolicyWithHostFallback]) {
+      const result = policy("protected/trust.json", boundary, {
+        mustExist: false,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe("denied");
+      }
+    }
+  });
+
   test("denies a symlink that resolves into the gateway security dir", () => {
     const boundary = makeTempDir();
     const outside = makeTempDir();

--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -95,6 +95,15 @@ describe("sandboxPolicy", () => {
     }
   });
 
+  test("resolveRealPath follows a trailing dangling symlink to its destination", () => {
+    const dir = makeTempDir();
+    const outside = makeTempDir();
+    const destination = join(outside, "not-yet.txt");
+    symlinkSync(destination, join(dir, "dangle"));
+
+    expect(resolveRealPath(join(dir, "dangle"))).toBe(destination);
+  });
+
   test("rejects a dangling symlink whose destination escapes the boundary", () => {
     const boundary = makeTempDir();
     const outside = makeTempDir();

--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -95,6 +95,21 @@ describe("sandboxPolicy", () => {
     }
   });
 
+  test("rejects a dangling symlink whose destination escapes the boundary", () => {
+    const boundary = makeTempDir();
+    const outside = makeTempDir();
+
+    // A dangling link inside the boundary pointing at a nonexistent outside
+    // file: a write through it would create the outside destination.
+    symlinkSync(join(outside, "not-yet.txt"), join(boundary, "dangle"));
+
+    const result = sandboxPolicy("dangle", boundary, { mustExist: false });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("out_of_bounds");
+    }
+  });
+
   test("rejects parent dir symlink escape in mustExist=false flow", () => {
     const boundary = makeTempDir();
     const outside = makeTempDir();
@@ -335,6 +350,29 @@ describe("sandboxPolicyWithHostFallback", () => {
       if (!result.ok) {
         expect(result.reason).toBe("denied");
       }
+    }
+  });
+
+  test("denies a dangling symlink pointing into the gateway security dir", () => {
+    const boundary = makeTempDir();
+    const outside = makeTempDir();
+    const securityDir = makeTempDir();
+    process.env.GATEWAY_SECURITY_DIR = securityDir;
+    // The destination does NOT exist — a write through the link would create
+    // it inside the security dir.
+    symlinkSync(
+      join(securityDir, "new-signing-key"),
+      join(outside, "innocent.txt"),
+    );
+
+    const result = sandboxPolicyWithHostFallback(
+      join(outside, "innocent.txt"),
+      boundary,
+      { mustExist: false },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("denied");
     }
   });
 

--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -14,6 +14,7 @@ import {
   hostPolicy,
   resolveRealPath,
   sandboxPolicy,
+  sandboxPolicyWithHostFallback,
 } from "../tools/shared/filesystem/path-policy.js";
 
 // ── Mock setup for skill path classifier ────────────────────────────────────
@@ -188,6 +189,107 @@ describe("sandboxPolicy", () => {
     if (!result.ok) {
       expect(result.reason).toBe("out_of_bounds");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sandbox policy with host fallback
+// ---------------------------------------------------------------------------
+
+describe("sandboxPolicyWithHostFallback", () => {
+  afterEach(() => {
+    delete process.env.IS_CONTAINERIZED;
+  });
+
+  test("matches sandboxPolicy for in-bounds paths", () => {
+    const boundary = makeTempDir();
+    mkdirSync(join(boundary, "sub"));
+
+    const result = sandboxPolicyWithHostFallback("sub/file.txt", boundary);
+    expect(result).toEqual(sandboxPolicy("sub/file.txt", boundary));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe(join(boundary, "sub", "file.txt"));
+    }
+  });
+
+  test("allows an absolute path outside the boundary", () => {
+    const boundary = makeTempDir();
+    const outside = makeTempDir();
+    const target = join(outside, "file.txt");
+    writeFileSync(target, "x");
+
+    const result = sandboxPolicyWithHostFallback(target, boundary);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe(target);
+    }
+  });
+
+  test("allows a relative traversal escape", () => {
+    const boundary = makeTempDir();
+
+    const result = sandboxPolicyWithHostFallback("../escape.txt", boundary, {
+      mustExist: false,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe(join(boundary, "..", "escape.txt"));
+    }
+  });
+
+  test("allows a symlink that escapes the boundary", () => {
+    const boundary = makeTempDir();
+    const outside = makeTempDir();
+    symlinkSync(outside, join(boundary, "escape-link"));
+
+    const result = sandboxPolicyWithHostFallback("escape-link", boundary);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved).toBe(join(boundary, "escape-link"));
+    }
+  });
+
+  test("denies out-of-bounds denylisted basenames", () => {
+    const boundary = makeTempDir();
+    const outside = makeTempDir();
+
+    const result = sandboxPolicyWithHostFallback(
+      join(outside, "backup.key"),
+      boundary,
+      { mustExist: false },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("denied");
+    }
+  });
+
+  test("keeps the hard boundary when containerized", () => {
+    const boundary = makeTempDir();
+    const outside = makeTempDir();
+    process.env.IS_CONTAINERIZED = "true";
+
+    const result = sandboxPolicyWithHostFallback(
+      join(outside, "file.txt"),
+      boundary,
+      { mustExist: false },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("out_of_bounds");
+      expect(result.error).toContain("outside the working directory");
+    }
+  });
+
+  test("still accepts in-bounds paths when containerized", () => {
+    const boundary = makeTempDir();
+    process.env.IS_CONTAINERIZED = "true";
+
+    const result = sandboxPolicyWithHostFallback("file.txt", boundary, {
+      mustExist: false,
+    });
+    expect(result.ok).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -430,6 +430,25 @@ describe("sandboxPolicyWithHostFallback", () => {
     }
   });
 
+  test("fails closed to the hard boundary when a security-dir override is relative", () => {
+    const boundary = makeTempDir();
+    const outside = makeTempDir();
+    // A relative override resolves against the owning service's cwd, which
+    // the daemon cannot know — the deny set is unmirrorable, so no escape
+    // is permitted at all.
+    process.env.GATEWAY_SECURITY_DIR = "relative/security-dir";
+
+    const result = sandboxPolicyWithHostFallback(
+      join(outside, "file.txt"),
+      boundary,
+      { mustExist: false },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("out_of_bounds");
+    }
+  });
+
   test("keeps the hard boundary when containerized", () => {
     const boundary = makeTempDir();
     const outside = makeTempDir();

--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -16,6 +16,7 @@ import {
   sandboxPolicy,
   sandboxPolicyWithHostFallback,
 } from "../tools/shared/filesystem/path-policy.js";
+import { getDotEnvPath } from "../util/platform.js";
 
 // ── Mock setup for skill path classifier ────────────────────────────────────
 // The classifier imports getWorkspaceSkillsDir and getBundledSkillsDir, which
@@ -323,6 +324,18 @@ describe("sandboxPolicyWithHostFallback", () => {
       if (!result.ok) {
         expect(result.reason).toBe("denied");
       }
+    }
+  });
+
+  test("denies the daemon dotenv", () => {
+    const boundary = makeTempDir();
+
+    const result = sandboxPolicyWithHostFallback(getDotEnvPath(), boundary, {
+      mustExist: false,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("denied");
     }
   });
 

--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -199,6 +199,7 @@ describe("sandboxPolicy", () => {
 describe("sandboxPolicyWithHostFallback", () => {
   afterEach(() => {
     delete process.env.IS_CONTAINERIZED;
+    delete process.env.GATEWAY_SECURITY_DIR;
   });
 
   test("matches sandboxPolicy for in-bounds paths", () => {
@@ -258,6 +259,63 @@ describe("sandboxPolicyWithHostFallback", () => {
       join(outside, "backup.key"),
       boundary,
       { mustExist: false },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("denied");
+    }
+  });
+
+  test("denies paths inside the gateway security dir (env override)", () => {
+    const boundary = makeTempDir();
+    const securityDir = makeTempDir();
+    process.env.GATEWAY_SECURITY_DIR = securityDir;
+
+    const result = sandboxPolicyWithHostFallback(
+      join(securityDir, "trust.json"),
+      boundary,
+      { mustExist: false },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("denied");
+      expect(result.error).toContain("gateway security directory");
+    }
+  });
+
+  test("denies the default gateway security dir when the env is unset", () => {
+    const boundary = makeTempDir();
+
+    const result = sandboxPolicyWithHostFallback(
+      join(
+        process.env.HOME!,
+        ".vellum",
+        "protected",
+        "actor-token-signing-key",
+      ),
+      boundary,
+      { mustExist: false },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("denied");
+    }
+  });
+
+  test("denies a symlink that resolves into the gateway security dir", () => {
+    const boundary = makeTempDir();
+    const outside = makeTempDir();
+    const securityDir = makeTempDir();
+    process.env.GATEWAY_SECURITY_DIR = securityDir;
+    writeFileSync(join(securityDir, "trust.json"), "{}");
+    symlinkSync(
+      join(securityDir, "trust.json"),
+      join(outside, "innocent.json"),
+    );
+
+    const result = sandboxPolicyWithHostFallback(
+      join(outside, "innocent.json"),
+      boundary,
     );
     expect(result.ok).toBe(false);
     if (!result.ok) {

--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -327,6 +327,22 @@ describe("sandboxPolicyWithHostFallback", () => {
     }
   });
 
+  test("a root-configured security dir denies every absolute target", () => {
+    const boundary = makeTempDir();
+    const outside = makeTempDir();
+    process.env.GATEWAY_SECURITY_DIR = "/";
+
+    const result = sandboxPolicyWithHostFallback(
+      join(outside, "trust.json"),
+      boundary,
+      { mustExist: false },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("denied");
+    }
+  });
+
   test("denies the daemon dotenv", () => {
     const boundary = makeTempDir();
 

--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -200,6 +200,7 @@ describe("sandboxPolicyWithHostFallback", () => {
   afterEach(() => {
     delete process.env.IS_CONTAINERIZED;
     delete process.env.GATEWAY_SECURITY_DIR;
+    delete process.env.CREDENTIAL_SECURITY_DIR;
   });
 
   test("matches sandboxPolicy for in-bounds paths", () => {
@@ -279,7 +280,25 @@ describe("sandboxPolicyWithHostFallback", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toBe("denied");
-      expect(result.error).toContain("gateway security directory");
+      expect(result.error).toContain("service security directory");
+    }
+  });
+
+  test("denies paths inside the CES security dir (env override)", () => {
+    const boundary = makeTempDir();
+    const securityDir = makeTempDir();
+    process.env.CREDENTIAL_SECURITY_DIR = securityDir;
+
+    for (const basename of ["keys.enc", "store.key"]) {
+      const result = sandboxPolicyWithHostFallback(
+        join(securityDir, basename),
+        boundary,
+        { mustExist: false },
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe("denied");
+      }
     }
   });
 

--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -376,6 +376,30 @@ describe("sandboxPolicyWithHostFallback", () => {
     }
   });
 
+  test("denies a long dangling symlink chain into the gateway security dir", () => {
+    const boundary = makeTempDir();
+    const outside = makeTempDir();
+    const securityDir = makeTempDir();
+    process.env.GATEWAY_SECURITY_DIR = securityDir;
+
+    // A 33-link chain exceeds macOS's own 32-link traversal limit but stays
+    // within Linux's 40 — the policy must resolve past it either way.
+    let target = join(securityDir, "new-signing-key");
+    for (let i = 32; i >= 0; i--) {
+      const link = join(outside, `link-${i}`);
+      symlinkSync(target, link);
+      target = link;
+    }
+
+    const result = sandboxPolicyWithHostFallback(target, boundary, {
+      mustExist: false,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("denied");
+    }
+  });
+
   test("denies a symlink that resolves into the gateway security dir", () => {
     const boundary = makeTempDir();
     const outside = makeTempDir();

--- a/assistant/src/__tests__/platform-bash-auto-approve.test.ts
+++ b/assistant/src/__tests__/platform-bash-auto-approve.test.ts
@@ -92,6 +92,7 @@ mock.module("../tools/registry.js", () => ({
 
 mock.module("../tools/shared/filesystem/path-policy.js", () => ({
   sandboxPolicy: () => ({ ok: false }),
+  sandboxPolicyWithHostFallback: () => ({ ok: false }),
   hostPolicy: () => ({ ok: false }),
 }));
 

--- a/assistant/src/__tests__/require-fresh-approval.test.ts
+++ b/assistant/src/__tests__/require-fresh-approval.test.ts
@@ -168,6 +168,7 @@ mock.module("../workflows/run-manager.js", () => ({
 
 mock.module("../tools/shared/filesystem/path-policy.js", () => ({
   sandboxPolicy: () => ({ ok: false }),
+  sandboxPolicyWithHostFallback: () => ({ ok: false }),
   hostPolicy: () => ({ ok: false }),
 }));
 

--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -582,6 +582,24 @@ describe("isSensitiveTool", () => {
           workingDir,
         ),
       ).toBe(false);
+      // `path` is the executed field — a benign `file_path` must not mask it.
+      expect(
+        isSensitiveTool(
+          "file_read",
+          "sandbox",
+          { path: "/etc/hosts", file_path: "notes.txt" },
+          workingDir,
+        ),
+      ).toBe(true);
+      // Container-style /workspace paths remap to the workspace.
+      expect(
+        isSensitiveTool(
+          "file_read",
+          "sandbox",
+          { path: "/workspace/notes.txt" },
+          workingDir,
+        ),
+      ).toBe(false);
       // Without a workingDir the boundary is unknown — name/target rule only.
       expect(
         isSensitiveTool("file_read", "sandbox", { path: "/etc/hosts" }),

--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -60,6 +60,10 @@ function resetAuditCalls(): void {
   auditCalls.prompted.length = 0;
 }
 
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import {
   mintGrantFromDecision,
   type MintGrantParams,
@@ -554,6 +558,52 @@ describe("isSensitiveTool", () => {
     ).toBe(false);
     // Without input, skill_load falls back to the name/target rule.
     expect(isSensitiveTool("skill_load", "sandbox")).toBe(false);
+  });
+
+  test("an out-of-workspace file_read is sensitive; an in-workspace one is not", () => {
+    const workingDir = mkdtempSync(join(tmpdir(), "sensitive-tool-test-"));
+    try {
+      // Out-of-workspace file access is host-equivalent: the host-fallback
+      // path policy executes the escape, so it carries the host capability
+      // floor even for the read-only sandbox tool.
+      expect(
+        isSensitiveTool(
+          "file_read",
+          "sandbox",
+          { path: "/etc/hosts" },
+          workingDir,
+        ),
+      ).toBe(true);
+      expect(
+        isSensitiveTool(
+          "file_read",
+          "sandbox",
+          { path: "notes.txt" },
+          workingDir,
+        ),
+      ).toBe(false);
+      // Without a workingDir the boundary is unknown — name/target rule only.
+      expect(
+        isSensitiveTool("file_read", "sandbox", { path: "/etc/hosts" }),
+      ).toBe(false);
+      // Containerized installs keep the hard execution boundary, so the
+      // escape never executes and does not need the floor.
+      process.env.IS_CONTAINERIZED = "true";
+      try {
+        expect(
+          isSensitiveTool(
+            "file_read",
+            "sandbox",
+            { path: "/etc/hosts" },
+            workingDir,
+          ),
+        ).toBe(false);
+      } finally {
+        delete process.env.IS_CONTAINERIZED;
+      }
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
+++ b/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
@@ -59,7 +59,9 @@ mock.module("../permissions/gateway-threshold-reader.js", () => ({
   refreshAutoApproveThreshold: async () => null,
 }));
 
+const realWorkspacePolicy = await import("../permissions/workspace-policy.js");
 mock.module("../permissions/workspace-policy.js", () => ({
+  ...realWorkspacePolicy,
   isWorkspaceScopedInvocation: () => false,
   isOutOfWorkspaceFileInvocation: () => false,
   isPathWithinWorkspaceRoot: () => false,

--- a/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
+++ b/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
@@ -61,6 +61,7 @@ mock.module("../permissions/gateway-threshold-reader.js", () => ({
 
 mock.module("../permissions/workspace-policy.js", () => ({
   isWorkspaceScopedInvocation: () => false,
+  isOutOfWorkspaceFileInvocation: () => false,
   isPathWithinWorkspaceRoot: () => false,
 }));
 

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -128,6 +128,7 @@ mock.module("../tools/registry.js", () => ({
 
 mock.module("../tools/shared/filesystem/path-policy.js", () => ({
   sandboxPolicy: () => ({ ok: false }),
+  sandboxPolicyWithHostFallback: () => ({ ok: false }),
   hostPolicy: () => ({ ok: false }),
 }));
 

--- a/assistant/src/__tests__/workspace-policy.test.ts
+++ b/assistant/src/__tests__/workspace-policy.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
 
 import * as envRegistry from "../config/env-registry.js";
 import {
+  isOutOfWorkspaceFileInvocation,
   isPathWithinWorkspaceRoot,
   isWorkspaceScopedInvocation,
 } from "../permissions/workspace-policy.js";
@@ -280,5 +281,72 @@ describe("isWorkspaceScopedInvocation", () => {
         isWorkspaceScopedInvocation("mystery_tool", {}, workspaceRoot),
       ).toBe(false);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isOutOfWorkspaceFileInvocation
+// ---------------------------------------------------------------------------
+
+describe("isOutOfWorkspaceFileInvocation", () => {
+  test("returns true for a file tool targeting an outside path", () => {
+    expect(
+      isOutOfWorkspaceFileInvocation(
+        "file_read",
+        { path: join(outsideDir, "notes.txt") },
+        workspaceRoot,
+      ),
+    ).toBe(true);
+  });
+
+  test("returns true for an in-workspace symlink that resolves outside", () => {
+    expect(
+      isOutOfWorkspaceFileInvocation(
+        "file_write",
+        { path: symlinkToOutside },
+        workspaceRoot,
+      ),
+    ).toBe(true);
+  });
+
+  test("returns false for an in-workspace relative path", () => {
+    expect(
+      isOutOfWorkspaceFileInvocation(
+        "file_write",
+        { path: "src/index.ts" },
+        workspaceRoot,
+      ),
+    ).toBe(false);
+  });
+
+  test("returns false for non-path tools", () => {
+    expect(
+      isOutOfWorkspaceFileInvocation(
+        "bash",
+        { command: "cat /etc/hosts" },
+        workspaceRoot,
+      ),
+    ).toBe(false);
+  });
+
+  test("returns false when the input carries no path", () => {
+    expect(isOutOfWorkspaceFileInvocation("file_read", {}, workspaceRoot)).toBe(
+      false,
+    );
+  });
+
+  test("returns false when containerized", () => {
+    const spy = spyOn(envRegistry, "getIsContainerized").mockReturnValue(true);
+    try {
+      expect(
+        isOutOfWorkspaceFileInvocation(
+          "file_read",
+          { path: join(outsideDir, "notes.txt") },
+          workspaceRoot,
+        ),
+      ).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/assistant/src/__tests__/workspace-policy.test.ts
+++ b/assistant/src/__tests__/workspace-policy.test.ts
@@ -195,6 +195,26 @@ describe("isWorkspaceScopedInvocation", () => {
         ),
       ).toBe(true);
     });
+
+    test("keys on `path` (the executed field) when both fields are present", () => {
+      expect(
+        isWorkspaceScopedInvocation(
+          "file_write",
+          { path: "/etc/passwd", file_path: join(workspaceRoot, "x.txt") },
+          workspaceRoot,
+        ),
+      ).toBe(false);
+    });
+
+    test("treats container-style /workspace paths as workspace-scoped", () => {
+      expect(
+        isWorkspaceScopedInvocation(
+          "file_read",
+          { path: "/workspace/src/index.ts" },
+          workspaceRoot,
+        ),
+      ).toBe(true);
+    });
   });
 
   // ── Bash ───────────────────────────────────────────────────────────
@@ -314,6 +334,35 @@ describe("isOutOfWorkspaceFileInvocation", () => {
       isOutOfWorkspaceFileInvocation(
         "file_write",
         { path: "src/index.ts" },
+        workspaceRoot,
+      ),
+    ).toBe(false);
+  });
+
+  test("keys on `path` when both `path` and `file_path` are present", () => {
+    // `path` is the field the file tools execute; an input carrying both
+    // must not dodge the containment check via a benign `file_path`.
+    expect(
+      isOutOfWorkspaceFileInvocation(
+        "file_read",
+        { path: join(outsideDir, "notes.txt"), file_path: "src/index.ts" },
+        workspaceRoot,
+      ),
+    ).toBe(true);
+    expect(
+      isOutOfWorkspaceFileInvocation(
+        "file_read",
+        { path: "src/index.ts", file_path: join(outsideDir, "notes.txt") },
+        workspaceRoot,
+      ),
+    ).toBe(false);
+  });
+
+  test("remaps container-style /workspace paths before the containment check", () => {
+    expect(
+      isOutOfWorkspaceFileInvocation(
+        "file_read",
+        { path: "/workspace/src/index.ts" },
         workspaceRoot,
       ),
     ).toBe(false);

--- a/assistant/src/__tests__/workspace-policy.test.ts
+++ b/assistant/src/__tests__/workspace-policy.test.ts
@@ -329,6 +329,25 @@ describe("isOutOfWorkspaceFileInvocation", () => {
     ).toBe(true);
   });
 
+  test("returns true for an in-workspace DANGLING symlink whose destination is outside", () => {
+    // The destination does not exist — a write through the link creates it
+    // outside the workspace, so containment must see the destination.
+    const dangling = join(workspaceRoot, "dangling-out");
+    symlinkSync(join(outsideDir, "not-yet.txt"), dangling);
+    try {
+      expect(
+        isOutOfWorkspaceFileInvocation(
+          "file_write",
+          { path: dangling },
+          workspaceRoot,
+        ),
+      ).toBe(true);
+      expect(isPathWithinWorkspaceRoot(dangling, workspaceRoot)).toBe(false);
+    } finally {
+      rmSync(dangling, { force: true });
+    }
+  });
+
   test("returns false for an in-workspace relative path", () => {
     expect(
       isOutOfWorkspaceFileInvocation(

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -115,9 +115,12 @@ mock.module("./trust-store.js", () => ({
   onRulesChanged: () => {},
 }));
 
-// Mock workspace policy.
+// Mock workspace policy. Spread the real module so pure path helpers
+// (resolveSandboxBase) keep their real behavior for param building.
+const realWorkspacePolicy = await import("./workspace-policy.js");
 let mockIsPathWithinWorkspaceRoot = true;
 mock.module("./workspace-policy.js", () => ({
+  ...realWorkspacePolicy,
   isWorkspaceScopedInvocation: () => false,
   isOutOfWorkspaceFileInvocation: () => false,
   isPathWithinWorkspaceRoot: () => mockIsPathWithinWorkspaceRoot,

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -143,9 +143,13 @@ mock.module("../tools/network/url-safety.js", () => ({
 import type { ClassificationResult } from "./ipc-risk-types.js";
 
 let mockIpcClassifyRiskResult: ClassificationResult | undefined;
+let lastClassifyRiskParams: Record<string, unknown> | undefined;
 
 mock.module("../ipc/gateway-client.js", () => ({
-  ipcClassifyRisk: async () => mockIpcClassifyRiskResult,
+  ipcClassifyRisk: async (params: Record<string, unknown>) => {
+    lastClassifyRiskParams = params;
+    return mockIpcClassifyRiskResult;
+  },
   ipcCall: async () => undefined,
   ipcCallPersistent: async () => undefined,
   resetPersistentClient: () => {},
@@ -155,6 +159,7 @@ mock.module("../ipc/gateway-client.js", () => ({
 
 import {
   mkdtempSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   unlinkSync,
@@ -180,6 +185,7 @@ describe("Permission Checker (gateway IPC)", () => {
   beforeEach(() => {
     mockIsContainerized = false;
     mockIpcClassifyRiskResult = undefined;
+    lastClassifyRiskParams = undefined;
     mockCachedThreshold = "low";
     mockRefreshedThreshold = null;
     mockProcToSkillsActive = true;
@@ -244,6 +250,44 @@ describe("Permission Checker (gateway IPC)", () => {
       await expect(classifyRisk("bash", { command: "ls" })).rejects.toThrow(
         /Gateway IPC classify_risk failed/,
       );
+    });
+
+    test("sends canonicalized boundary params for sandbox file tools", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "medium",
+        reason: "File write outside the workspace",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      const workingDir = mkdtempSync(join(tmpdir(), "checker-boundary-"));
+      try {
+        await classifyRisk(
+          "file_write",
+          { path: "/tmp/checker-boundary-outside.txt" },
+          workingDir,
+        );
+        expect(lastClassifyRiskParams?.isContainerized).toBe(false);
+        // The boundary is canonicalized so the gateway compares canonical
+        // against canonical (macOS tmpdir lives behind a /var symlink).
+        expect(lastClassifyRiskParams?.resolvedWorkingDir).toBe(
+          realpathSync(workingDir),
+        );
+      } finally {
+        rmSync(workingDir, { recursive: true, force: true });
+      }
+    });
+
+    test("omits the canonicalized boundary for host file tools", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "medium",
+        reason: "Host file write (default)",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      await classifyRisk("host_file_write", {
+        path: "/tmp/checker-boundary-host.txt",
+      });
+      expect(lastClassifyRiskParams?.resolvedWorkingDir).toBeUndefined();
     });
 
     test("caches results for identical inputs", async () => {

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -119,6 +119,7 @@ mock.module("./trust-store.js", () => ({
 let mockIsPathWithinWorkspaceRoot = true;
 mock.module("./workspace-policy.js", () => ({
   isWorkspaceScopedInvocation: () => false,
+  isOutOfWorkspaceFileInvocation: () => false,
   isPathWithinWorkspaceRoot: () => mockIsPathWithinWorkspaceRoot,
 }));
 

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -281,6 +281,32 @@ describe("Permission Checker (gateway IPC)", () => {
       }
     });
 
+    test("classifies a dangling symlink by its destination", async () => {
+      mockIpcClassifyRiskResult = {
+        risk: "medium",
+        reason: "File write outside the workspace",
+        matchType: "registry",
+        scopeOptions: [],
+      };
+      const workingDir = realpathSync(
+        mkdtempSync(join(tmpdir(), "checker-dangling-")),
+      );
+      const outside = realpathSync(
+        mkdtempSync(join(tmpdir(), "checker-dangling-out-")),
+      );
+      try {
+        const destination = join(outside, "not-yet.txt");
+        symlinkSync(destination, join(workingDir, "dangle"));
+        await classifyRisk("file_write", { path: "dangle" }, workingDir);
+        // The destination does not exist, but a write through the link
+        // creates it — classification must see the destination.
+        expect(lastClassifyRiskParams?.resolvedPath).toBe(destination);
+      } finally {
+        rmSync(workingDir, { recursive: true, force: true });
+        rmSync(outside, { recursive: true, force: true });
+      }
+    });
+
     test("omits the canonicalized boundary for host file tools", async () => {
       mockIpcClassifyRiskResult = {
         risk: "medium",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -155,7 +155,7 @@ function fileToolFsStateKey(
     return undefined;
   }
   const resolved = resolveFileToolPaths(toolName, input, workingDir);
-  return `${resolved.resolvedPath ?? ""}\0${resolved.resolvedTransferDestPath ?? ""}`;
+  return `${resolved.resolvedPath ?? ""}\0${resolved.resolvedTransferDestPath ?? ""}\0${resolved.resolvedWorkingDir ?? ""}`;
 }
 
 /** Clear the risk classification cache. Called when trust rules change. Exported for test setup. */
@@ -441,6 +441,13 @@ interface FileToolResolution {
   effectiveWorkingDir: string;
   isHostTool: boolean;
   resolvedPath?: string;
+  /**
+   * Symlink-canonicalized working dir for sandbox file tools, paired with
+   * `resolvedPath` so the gateway's workspace-boundary check compares
+   * canonical against canonical (a symlinked workspace prefix, e.g. macOS
+   * /var → /private/var, must not read as an escape). Unset for host tools.
+   */
+  resolvedWorkingDir?: string;
   transferSandboxDestPath?: string;
   transferSandboxWorkingDir?: string;
   resolvedTransferDestPath?: string;
@@ -490,6 +497,9 @@ function resolveFileToolPaths(
       effectiveWorkingDir,
       isHostTool,
     ),
+    resolvedWorkingDir: isHostTool
+      ? undefined
+      : resolveRealPath(effectiveWorkingDir),
     transferSandboxDestPath,
     transferSandboxWorkingDir,
     // The to_sandbox destination is a workspace write — symlink-resolve it too
@@ -573,7 +583,9 @@ function buildClassifyRiskParams(
       tool: toolName,
       path: resolved.filePath,
       resolvedPath: resolved.resolvedPath,
+      resolvedWorkingDir: resolved.resolvedWorkingDir,
       workingDir: resolved.effectiveWorkingDir,
+      isContainerized: getIsContainerized(),
       fileContext: buildFileContext(),
       transferSandboxDestPath: resolved.transferSandboxDestPath,
       transferSandboxWorkingDir: resolved.transferSandboxWorkingDir,

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -53,6 +53,7 @@ import {
 import {
   isPathWithinWorkspaceRoot,
   isWorkspaceScopedInvocation,
+  resolveSandboxBase,
 } from "./workspace-policy.js";
 
 // ── Risk classification cache ────────────────────────────────────────────────
@@ -389,25 +390,6 @@ function buildFileContext(): FileContext {
  * filesystem this process cannot see (e.g. host_file paths proxied to a remote
  * client), so this never regresses below today's lexical behavior.
  */
-// The Docker sandbox mounts the workspace at /workspace, and the model emits
-// container-scoped paths (e.g. "/workspace/tools/evil.ts") even on local turns.
-// Mirror the gateway's resolveSandboxPath remap so the symlink-resolved path we
-// forward lines up with the gateway's lexical fallback and the protected dirs.
-const CONTAINER_WORKSPACE_PREFIX = "/workspace/";
-const CONTAINER_WORKSPACE_EXACT = "/workspace";
-
-function resolveSandboxBase(rawPath: string, workingDir: string): string {
-  let effectivePath = rawPath;
-  if (!rawPath.startsWith(workingDir + "/") && rawPath !== workingDir) {
-    if (rawPath.startsWith(CONTAINER_WORKSPACE_PREFIX)) {
-      effectivePath = rawPath.slice(CONTAINER_WORKSPACE_PREFIX.length);
-    } else if (rawPath === CONTAINER_WORKSPACE_EXACT) {
-      effectivePath = ".";
-    }
-  }
-  return resolve(workingDir, effectivePath);
-}
-
 function resolveClassificationPath(
   filePath: string,
   workingDir: string,

--- a/assistant/src/permissions/ipc-risk-types.ts
+++ b/assistant/src/permissions/ipc-risk-types.ts
@@ -103,6 +103,14 @@ export interface ClassifyRiskParams {
    * protected directory. Falls back to lexical `path` resolution when absent.
    */
   resolvedPath?: string;
+  /**
+   * The sandbox file tool's working directory with symlinks resolved
+   * (canonicalized by the daemon). Paired with `resolvedPath` for the
+   * workspace-boundary check so a symlinked workspace prefix (e.g. macOS
+   * /var → /private/var) does not read as an escape. Absent for host tools;
+   * the gateway falls back to a lexical-vs-lexical comparison when unset.
+   */
+  resolvedWorkingDir?: string;
   skill?: string;
   mode?: string;
   script?: string;

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -77,6 +77,44 @@ const ALWAYS_SCOPED_TOOLS = new Set([
 ]);
 
 /**
+ * Extract a path-scoped tool's target path from its input, resolving
+ * relative paths against the workspace root (not process.cwd()). Returns
+ * `""` when the input carries no usable path.
+ */
+function resolvePathScopedTarget(
+  toolInput: Record<string, unknown>,
+  workspaceRoot: string,
+): string {
+  const rawPath =
+    typeof toolInput.file_path === "string"
+      ? toolInput.file_path
+      : typeof toolInput.path === "string"
+        ? toolInput.path
+        : "";
+  if (rawPath === "" || rawPath.startsWith("/")) {
+    return rawPath;
+  }
+  return resolve(workspaceRoot, rawPath);
+}
+
+/**
+ * Whether a sandbox file-tool invocation targets a path outside the
+ * workspace root. Always false in containerized mode — the execution-time
+ * boundary is hard there, so an escaping path never executes. Non-path
+ * tools are never classified by this predicate.
+ */
+export function isOutOfWorkspaceFileInvocation(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  workspaceRoot: string,
+): boolean {
+  if (getIsContainerized()) return false;
+  if (!PATH_SCOPED_TOOLS.has(toolName)) return false;
+  const filePath = resolvePathScopedTarget(toolInput, workspaceRoot);
+  return filePath !== "" && !isPathWithinWorkspaceRoot(filePath, workspaceRoot);
+}
+
+/**
  * Determine whether a tool invocation only affects resources within the
  * workspace root. This is a conservative classification — unknown tools
  * default to NOT workspace-scoped.
@@ -91,17 +129,7 @@ export function isWorkspaceScopedInvocation(
   if (HOST_TOOLS.has(toolName)) return false;
 
   if (PATH_SCOPED_TOOLS.has(toolName)) {
-    const rawPath =
-      typeof toolInput.file_path === "string"
-        ? toolInput.file_path
-        : typeof toolInput.path === "string"
-          ? toolInput.path
-          : "";
-    // Resolve relative paths against workspaceRoot (not process.cwd())
-    const filePath =
-      rawPath !== "" && !rawPath.startsWith("/")
-        ? resolve(workspaceRoot, rawPath)
-        : rawPath;
+    const filePath = resolvePathScopedTarget(toolInput, workspaceRoot);
     return (
       filePath !== "" && isPathWithinWorkspaceRoot(filePath, workspaceRoot)
     );

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -34,7 +34,9 @@ export function isPathWithinWorkspaceRoot(
   filePath: string,
   workspaceRoot: string,
 ): boolean {
-  if (!filePath || !workspaceRoot) return false;
+  if (!filePath || !workspaceRoot) {
+    return false;
+  }
 
   const canonicalPath = canonicalize(filePath);
   const canonicalRoot = canonicalize(workspaceRoot);
@@ -108,8 +110,12 @@ export function isOutOfWorkspaceFileInvocation(
   toolInput: Record<string, unknown>,
   workspaceRoot: string,
 ): boolean {
-  if (getIsContainerized()) return false;
-  if (!PATH_SCOPED_TOOLS.has(toolName)) return false;
+  if (getIsContainerized()) {
+    return false;
+  }
+  if (!PATH_SCOPED_TOOLS.has(toolName)) {
+    return false;
+  }
   const filePath = resolvePathScopedTarget(toolInput, workspaceRoot);
   return filePath !== "" && !isPathWithinWorkspaceRoot(filePath, workspaceRoot);
 }
@@ -124,9 +130,15 @@ export function isWorkspaceScopedInvocation(
   toolInput: Record<string, unknown>,
   workspaceRoot: string,
 ): boolean {
-  if (ALWAYS_SCOPED_TOOLS.has(toolName)) return true;
-  if (NETWORK_TOOLS.has(toolName)) return false;
-  if (HOST_TOOLS.has(toolName)) return false;
+  if (ALWAYS_SCOPED_TOOLS.has(toolName)) {
+    return true;
+  }
+  if (NETWORK_TOOLS.has(toolName)) {
+    return false;
+  }
+  if (HOST_TOOLS.has(toolName)) {
+    return false;
+  }
 
   if (PATH_SCOPED_TOOLS.has(toolName)) {
     const filePath = resolvePathScopedTarget(toolInput, workspaceRoot);
@@ -140,7 +152,9 @@ export function isWorkspaceScopedInvocation(
   // bash is NOT workspace-scoped here — path resolution for allowlisted commands is
   // handled upstream in the checker's hasSandboxAutoApprove computation, which validates
   // all path arguments against the workspace root for non-containerized environments.
-  if (toolName === "bash") return getIsContainerized();
+  if (toolName === "bash") {
+    return getIsContainerized();
+  }
 
   // Unknown tool — conservative default.
   return false;

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -78,25 +78,56 @@ const ALWAYS_SCOPED_TOOLS = new Set([
   "ui_dismiss",
 ]);
 
+// The Docker sandbox mounts the workspace at /workspace, and the model emits
+// container-scoped paths (e.g. "/workspace/tools/evil.ts") even on local
+// turns. The execution-time path policy and the gateway classifier both
+// apply this remap, so every workspace-containment decision here must too.
+const CONTAINER_WORKSPACE_PREFIX = "/workspace/";
+const CONTAINER_WORKSPACE_EXACT = "/workspace";
+
 /**
- * Extract a path-scoped tool's target path from its input, resolving
- * relative paths against the workspace root (not process.cwd()). Returns
- * `""` when the input carries no usable path.
+ * Resolve a sandbox file path to its lexical base the same way the
+ * execution-time `sandboxPolicy` and the gateway classifier do: remap a
+ * container-scoped `/workspace/...` path onto `workingDir`, then resolve
+ * (relative paths resolve against `workingDir`, not process.cwd()).
+ */
+export function resolveSandboxBase(
+  rawPath: string,
+  workingDir: string,
+): string {
+  let effectivePath = rawPath;
+  if (!rawPath.startsWith(workingDir + "/") && rawPath !== workingDir) {
+    if (rawPath.startsWith(CONTAINER_WORKSPACE_PREFIX)) {
+      effectivePath = rawPath.slice(CONTAINER_WORKSPACE_PREFIX.length);
+    } else if (rawPath === CONTAINER_WORKSPACE_EXACT) {
+      effectivePath = ".";
+    }
+  }
+  return resolve(workingDir, effectivePath);
+}
+
+/**
+ * Extract a path-scoped tool's target path from its input. `path` takes
+ * priority over `file_path` — the file tools execute `input.path` and the
+ * risk classifier reads the fields in the same order, so containment
+ * decisions must be derived from the field that actually executes (an input
+ * carrying both fields is not runtime-stripped). Returns `""` when the
+ * input carries no usable path.
  */
 function resolvePathScopedTarget(
   toolInput: Record<string, unknown>,
   workspaceRoot: string,
 ): string {
   const rawPath =
-    typeof toolInput.file_path === "string"
-      ? toolInput.file_path
-      : typeof toolInput.path === "string"
-        ? toolInput.path
+    typeof toolInput.path === "string"
+      ? toolInput.path
+      : typeof toolInput.file_path === "string"
+        ? toolInput.file_path
         : "";
-  if (rawPath === "" || rawPath.startsWith("/")) {
-    return rawPath;
+  if (rawPath === "") {
+    return "";
   }
-  return resolve(workspaceRoot, rawPath);
+  return resolveSandboxBase(rawPath, workspaceRoot);
 }
 
 /**

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -2,15 +2,23 @@ import { realpathSync } from "node:fs";
 import { basename, dirname, normalize, resolve } from "node:path";
 
 import { getIsContainerized } from "../config/env-registry.js";
+import { resolveTrailingLinkTarget } from "../util/fs-symlinks.js";
 
 /**
- * Resolve a path to its canonical form. When the target itself doesn't
- * exist (e.g. a new file being written), walk up to the nearest existing
- * ancestor and append the remaining segments so that symlinks in parent
- * directories (like macOS `/var` -> `/private/var`) are still resolved.
+ * Resolve a path to its canonical form. A trailing (possibly dangling)
+ * symlink chain is followed first so a link whose destination does not
+ * exist yet still canonicalizes to that destination — a write through the
+ * link creates it. When the target itself doesn't exist (e.g. a new file
+ * being written), walk up to the nearest existing ancestor and append the
+ * remaining segments so that symlinks in parent directories (like macOS
+ * `/var` -> `/private/var`) are still resolved.
  */
 function canonicalize(p: string): string {
-  const abs = resolve(p);
+  const abs = resolveTrailingLinkTarget(resolve(p));
+  return canonicalizeExisting(abs);
+}
+
+function canonicalizeExisting(abs: string): string {
   try {
     return realpathSync(abs);
   } catch {
@@ -21,7 +29,7 @@ function canonicalize(p: string): string {
       // Reached filesystem root — nothing left to resolve.
       return normalize(abs);
     }
-    return `${canonicalize(parent)}/${name}`;
+    return `${canonicalizeExisting(parent)}/${name}`;
   }
 }
 

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -23,7 +23,7 @@ import { PermissionChecker } from "./permission-checker.js";
 import { getToolOwner } from "./registry.js";
 import { extractAndSanitize } from "./sensitive-output-placeholders.js";
 import { applyEdit } from "./shared/filesystem/edit-engine.js";
-import { sandboxPolicy } from "./shared/filesystem/path-policy.js";
+import { sandboxPolicyWithHostFallback } from "./shared/filesystem/path-policy.js";
 import { MAX_FILE_SIZE_BYTES } from "./shared/filesystem/size-guard.js";
 import { ToolApprovalHandler } from "./tool-approval-handler.js";
 import { resolveToolInvocationAlias } from "./tool-name-aliases.js";
@@ -489,7 +489,7 @@ function computePreviewDiff(
       if (!rawPath || typeof content !== "string") {
         return undefined;
       }
-      const pathCheck = sandboxPolicy(rawPath, workingDir, {
+      const pathCheck = sandboxPolicyWithHostFallback(rawPath, workingDir, {
         mustExist: false,
       });
       if (!pathCheck.ok) {
@@ -519,7 +519,7 @@ function computePreviewDiff(
       ) {
         return undefined;
       }
-      const pathCheck = sandboxPolicy(rawPath, workingDir);
+      const pathCheck = sandboxPolicyWithHostFallback(rawPath, workingDir);
       if (!pathCheck.ok) {
         return undefined;
       }

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -23,7 +23,7 @@ import { PermissionChecker } from "./permission-checker.js";
 import { getToolOwner } from "./registry.js";
 import { extractAndSanitize } from "./sensitive-output-placeholders.js";
 import { applyEdit } from "./shared/filesystem/edit-engine.js";
-import { sandboxPolicyWithHostFallback } from "./shared/filesystem/path-policy.js";
+import { sandboxPolicy } from "./shared/filesystem/path-policy.js";
 import { MAX_FILE_SIZE_BYTES } from "./shared/filesystem/size-guard.js";
 import { ToolApprovalHandler } from "./tool-approval-handler.js";
 import { resolveToolInvocationAlias } from "./tool-name-aliases.js";
@@ -469,6 +469,11 @@ export function computePerToolTimeoutMs(
 /**
  * Compute a preview diff for file tools so the confirmation prompt can show
  * what will change. Returns undefined for non-file tools or on any error.
+ * Out-of-workspace targets deliberately produce no preview (strict
+ * sandboxPolicy): the preview runs before the user answers the prompt, and
+ * external file content must not be read — let alone shipped in the
+ * confirmation payload — ahead of approval. Host file tools have no preview
+ * for the same reason.
  */
 function computePreviewDiff(
   toolName: string,
@@ -489,7 +494,7 @@ function computePreviewDiff(
       if (!rawPath || typeof content !== "string") {
         return undefined;
       }
-      const pathCheck = sandboxPolicyWithHostFallback(rawPath, workingDir, {
+      const pathCheck = sandboxPolicy(rawPath, workingDir, {
         mustExist: false,
       });
       if (!pathCheck.ok) {
@@ -519,7 +524,7 @@ function computePreviewDiff(
       ) {
         return undefined;
       }
-      const pathCheck = sandboxPolicyWithHostFallback(rawPath, workingDir);
+      const pathCheck = sandboxPolicy(rawPath, workingDir);
       if (!pathCheck.ok) {
         return undefined;
       }

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -1,7 +1,7 @@
 import { RiskLevel } from "../../permissions/types.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { formatEditDiff } from "../shared/filesystem/format-diff.js";
-import { sandboxPolicy } from "../shared/filesystem/path-policy.js";
+import { sandboxPolicyWithHostFallback } from "../shared/filesystem/path-policy.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -88,7 +88,7 @@ export const fileEditTool = {
     const replaceAll = input.replace_all === true;
 
     const ops = new FileSystemOps((path, opts) =>
-      sandboxPolicy(path, context.workingDir, opts),
+      sandboxPolicyWithHostFallback(path, context.workingDir, opts),
     );
 
     const result = ops.editFileSafe({
@@ -116,8 +116,13 @@ export const fileEditTool = {
             content: `Error editing file: ${error.message}`,
             isError: true,
           };
-        default:
-          return { content: `Error: ${error.message}`, isError: true };
+        default: {
+          const hint =
+            error.code === "PATH_OUT_OF_BOUNDS"
+              ? ". To edit files outside the workspace, use the host_file_edit tool instead."
+              : "";
+          return { content: `Error: ${error.message}${hint}`, isError: true };
+        }
       }
     }
 

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -10,7 +10,7 @@ import {
   IMAGE_EXTENSIONS,
   readImageFile,
 } from "../shared/filesystem/image-read.js";
-import { sandboxPolicy } from "../shared/filesystem/path-policy.js";
+import { sandboxPolicyWithHostFallback } from "../shared/filesystem/path-policy.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -65,7 +65,10 @@ export const fileReadTool = {
     // For image files, delegate to the shared image reader.
     const ext = extname(rawPath).toLowerCase();
     if (IMAGE_EXTENSIONS.has(ext)) {
-      const pathCheck = sandboxPolicy(rawPath, context.workingDir);
+      const pathCheck = sandboxPolicyWithHostFallback(
+        rawPath,
+        context.workingDir,
+      );
       if (!pathCheck.ok) {
         return {
           content: `Error: ${pathCheck.error}. To read files outside the workspace, use the host_file_read tool instead.`,
@@ -77,7 +80,10 @@ export const fileReadTool = {
 
     // For audio files, delegate to the shared audio reader.
     if (AUDIO_EXTENSIONS.has(ext)) {
-      const pathCheck = sandboxPolicy(rawPath, context.workingDir);
+      const pathCheck = sandboxPolicyWithHostFallback(
+        rawPath,
+        context.workingDir,
+      );
       if (!pathCheck.ok) {
         return {
           content: `Error: ${pathCheck.error}. To read files outside the workspace, use the host_file_read tool instead.`,
@@ -88,7 +94,7 @@ export const fileReadTool = {
     }
 
     const ops = new FileSystemOps((path, opts) =>
-      sandboxPolicy(path, context.workingDir, opts),
+      sandboxPolicyWithHostFallback(path, context.workingDir, opts),
     );
 
     const result = ops.readFileSafe({

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -7,7 +7,7 @@ import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { formatWriteSummary } from "../shared/filesystem/format-diff.js";
-import { sandboxPolicy } from "../shared/filesystem/path-policy.js";
+import { sandboxPolicyWithHostFallback } from "../shared/filesystem/path-policy.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -116,7 +116,7 @@ export const fileWriteTool = {
     }
 
     const ops = new FileSystemOps((path, opts) =>
-      sandboxPolicy(path, context.workingDir, opts),
+      sandboxPolicyWithHostFallback(path, context.workingDir, opts),
     );
 
     const result = ops.writeFileSafe({ path: rawPath, content: fileContent });
@@ -137,7 +137,11 @@ export const fileWriteTool = {
           isError: true,
         };
       }
-      return { content: `Error: ${error.message}`, isError: true };
+      const hint =
+        error.code === "PATH_OUT_OF_BOUNDS"
+          ? ". To write files outside the workspace, use the host_file_write tool instead."
+          : "";
+      return { content: `Error: ${error.message}${hint}`, isError: true };
     }
 
     const { filePath, oldContent, newContent, isNewFile } = result.value;

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from "node:fs";
+import { lstatSync, readlinkSync, realpathSync } from "node:fs";
 import { homedir, userInfo } from "node:os";
 import {
   basename,
@@ -92,6 +92,31 @@ interface SandboxTarget {
 }
 
 /**
+ * Follow a trailing symlink chain manually so a DANGLING link reports its
+ * destination. `realpathSync` throws on a link whose destination does not
+ * exist, which makes canonicalization fall back to the benign link path —
+ * but a write through the link creates the destination, so containment
+ * checks must see it. Bounded well above the kernel's own symlink-depth
+ * limit; a deeper chain fails the eventual filesystem operation itself.
+ */
+function resolveTrailingLinkTarget(path: string): string {
+  let current = path;
+  for (let depth = 0; depth < 32; depth++) {
+    let linkTarget: string;
+    try {
+      if (!lstatSync(current).isSymbolicLink()) {
+        return current;
+      }
+      linkTarget = readlinkSync(current);
+    } catch {
+      return current;
+    }
+    current = resolve(dirname(current), linkTarget);
+  }
+  return current;
+}
+
+/**
  * Resolve a user-supplied path against the boundary directory: apply the
  * container /workspace remap, resolve to an absolute path, and canonicalize
  * symlinks on both the target and the boundary.
@@ -116,19 +141,24 @@ function resolveSandboxTarget(
 
   const resolved = resolve(boundaryDir, effectivePath);
 
+  // Follow a trailing (possibly dangling) symlink chain first — a write
+  // through a dangling link creates the link's destination, so the
+  // containment and denial checks below must run against it.
+  const linkTarget = resolveTrailingLinkTarget(resolved);
+
   // Resolve symlinks to catch symlink-based escapes.
   // For mustExist=false, walk up to the nearest existing ancestor and
   // resolve it, then re-append the trailing components.
-  let realResolved = resolved;
+  let realResolved = linkTarget;
   if (mustExist) {
     try {
-      realResolved = realpathSync(resolved);
+      realResolved = realpathSync(linkTarget);
     } catch {
       // File doesn't exist - will be caught by the tool's own existence check
-      realResolved = resolved;
+      realResolved = linkTarget;
     }
   } else {
-    realResolved = resolveRealPath(resolved);
+    realResolved = resolveRealPath(linkTarget);
   }
 
   // Resolve the boundary directory's real path too (in case it's a symlink)

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -11,6 +11,7 @@ import {
 
 import { getIsContainerized } from "../../../config/env-registry.js";
 import { resolveTrailingLinkTarget } from "../../../util/fs-symlinks.js";
+import { getDotEnvPath } from "../../../util/platform.js";
 
 /**
  * Result type shared by both sandbox and host path policies.
@@ -196,26 +197,30 @@ function safeUserInfoHomedir(): string {
   }
 }
 
-/**
- * Security directories owned by other services: gateway trust material and
- * token signing keys (GATEWAY_SECURITY_DIR) and CES credential keys
- * (CREDENTIAL_SECURITY_DIR — `keys.enc`, `store.key`). The daemon must
- * never read from or write to them — that data flows through the gateway
- * and CES APIs (root AGENTS.md). The env-based resolution mirrors the
- * owning services' own resolution, since the cross-package import boundary
- * bars importing it; the shared bare-metal default `<home>/.vellum/protected`
- * is always denied. A relative override resolves against the owning
- * service's cwd, which this process cannot know — the daemon-cwd-resolved
- * form is denied as a best effort alongside the always-denied default.
- */
 const SECURITY_DIR_ENV_VARS = [
   "GATEWAY_SECURITY_DIR",
   "CREDENTIAL_SECURITY_DIR",
 ] as const;
 
-function getServiceSecurityDirs(): string[] {
-  const dirs = new Set<string>();
-  dirs.add(
+/**
+ * Secret-bearing paths the file tools must never touch, in any policy:
+ *
+ * - Gateway trust material and token signing keys (GATEWAY_SECURITY_DIR)
+ *   and CES credential keys (CREDENTIAL_SECURITY_DIR — `keys.enc`,
+ *   `store.key`). The daemon must never read from or write to them — that
+ *   data flows through the gateway and CES APIs (root AGENTS.md). The
+ *   env-based resolution mirrors the owning services', since the
+ *   cross-package import boundary bars importing it; the shared bare-metal
+ *   default `<home>/.vellum/protected` is always denied. Only absolute
+ *   overrides join the set — a relative override is unmirrorable and
+ *   disables the host fallback outright (see
+ *   {@link securityDirConfigMirrorable}).
+ * - The daemon dotenv (`<vellumRoot>/.env`), which carries provider
+ *   secrets.
+ */
+function getProtectedServicePaths(): string[] {
+  const paths = new Set<string>();
+  paths.add(
     join(
       process.env.HOME || safeUserInfoHomedir() || homedir(),
       ".vellum",
@@ -225,10 +230,11 @@ function getServiceSecurityDirs(): string[] {
   for (const name of SECURITY_DIR_ENV_VARS) {
     const override = process.env[name]?.trim();
     if (override && isAbsolute(override)) {
-      dirs.add(resolve(override));
+      paths.add(resolve(override));
     }
   }
-  return [...dirs];
+  paths.add(getDotEnvPath());
+  return [...paths];
 }
 
 /**
@@ -249,17 +255,18 @@ function isWithinDir(path: string, dir: string): boolean {
 }
 
 /**
- * Deny a target that lands in a service-owned security directory. Both the
+ * Deny a target that lands in (or on) a protected service path. Both the
  * lexical and symlink-resolved target are checked against both the lexical
- * and symlink-resolved directory, so neither a symlinked target nor a
+ * and symlink-resolved protected path, so neither a symlinked target nor a
  * symlinked directory prefix can mask the hit.
  */
 function securityDirDenial(target: SandboxTarget): PathResult | null {
-  for (const securityDir of getServiceSecurityDirs()) {
-    const realSecurityDir = resolveRealPath(securityDir);
+  for (const protectedPath of getProtectedServicePaths()) {
+    const realProtectedPath = resolveRealPath(protectedPath);
     const hit = [target.resolved, target.realResolved].some(
       (path) =>
-        isWithinDir(path, securityDir) || isWithinDir(path, realSecurityDir),
+        isWithinDir(path, protectedPath) ||
+        isWithinDir(path, realProtectedPath),
     );
     if (hit) {
       return {

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -8,6 +8,8 @@ import {
   resolve,
 } from "node:path";
 
+import { getIsContainerized } from "../../../config/env-registry.js";
+
 /**
  * Result type shared by both sandbox and host path policies.
  */
@@ -79,26 +81,25 @@ export function resolveRealPath(absolutePath: string): string {
 // Sandbox policy
 // ---------------------------------------------------------------------------
 
+interface SandboxTarget {
+  /** Lexically resolved absolute path (boundary-relative input resolved). */
+  resolved: string;
+  /** Symlink-canonicalized form of `resolved`. */
+  realResolved: string;
+  /** Symlink-canonicalized boundary directory. */
+  realBoundary: string;
+}
+
 /**
- * Resolve a user-supplied path against a boundary directory and verify
- * that the result stays within it.
- *
- * For existing paths, symlinks are resolved via realpathSync so a symlink
- * pointing outside the boundary is caught. For new paths (e.g. file_write),
- * pass `mustExist: false` - the nearest existing ancestor directory is
- * resolved via realpathSync to catch symlinks in parent dirs.
- *
- * Paths starting with `/workspace/` are treated as container-scoped and
- * remapped relative to the boundary directory (the Docker sandbox mounts
- * the host workspace at /workspace).
+ * Resolve a user-supplied path against the boundary directory: apply the
+ * container /workspace remap, resolve to an absolute path, and canonicalize
+ * symlinks on both the target and the boundary.
  */
-export function sandboxPolicy(
+function resolveSandboxTarget(
   rawPath: string,
   boundaryDir: string,
-  options?: { mustExist?: boolean },
-): PathResult {
-  const mustExist = options?.mustExist ?? true;
-
+  mustExist: boolean,
+): SandboxTarget {
   // Remap container-scoped /workspace paths to the host boundary dir.
   // Skip remapping if the path already starts with boundaryDir to avoid
   // double-nesting (e.g. /workspace/project/file.ts → /workspace/project/project/file.ts
@@ -137,26 +138,118 @@ export function sandboxPolicy(
     realBoundary = boundaryDir;
   }
 
-  const rel = relative(realBoundary, realResolved);
-  if (rel.startsWith("..") || resolve(realBoundary, rel) !== realResolved) {
-    return {
-      ok: false,
-      reason: "out_of_bounds",
-      error: `Path "${rawPath}" resolves to "${realResolved}" which is outside the working directory "${realBoundary}"`,
-    };
-  }
+  return { resolved, realResolved, realBoundary };
+}
 
-  // Check both the logical path and the symlink-resolved path so a symlink
-  // with a non-denied name pointing at a denied file is still caught.
-  if (isDeniedBasename(resolved) || isDeniedBasename(realResolved)) {
+/** Whether the canonicalized target escapes the canonicalized boundary. */
+function isOutOfBounds(target: SandboxTarget): boolean {
+  const rel = relative(target.realBoundary, target.realResolved);
+  return (
+    rel.startsWith("..") ||
+    resolve(target.realBoundary, rel) !== target.realResolved
+  );
+}
+
+function outOfBoundsFailure(
+  rawPath: string,
+  target: SandboxTarget,
+): PathResult {
+  return {
+    ok: false,
+    reason: "out_of_bounds",
+    error: `Path "${rawPath}" resolves to "${target.realResolved}" which is outside the working directory "${target.realBoundary}"`,
+  };
+}
+
+// The denied check covers both the logical path and the symlink-resolved
+// path so a symlink with a non-denied name pointing at a denied file is
+// still caught.
+function deniedFailure(target: SandboxTarget): PathResult | null {
+  if (
+    isDeniedBasename(target.resolved) ||
+    isDeniedBasename(target.realResolved)
+  ) {
     return {
       ok: false,
       reason: "denied",
-      error: `Access to "${basename(resolved)}" is denied`,
+      error: `Access to "${basename(target.resolved)}" is denied`,
     };
   }
+  return null;
+}
 
-  return { ok: true, resolved };
+function evaluateSandboxPolicy(
+  rawPath: string,
+  boundaryDir: string,
+  options: { mustExist?: boolean } | undefined,
+  allowOutOfBounds: boolean,
+): PathResult {
+  const target = resolveSandboxTarget(
+    rawPath,
+    boundaryDir,
+    options?.mustExist ?? true,
+  );
+
+  if (!allowOutOfBounds && isOutOfBounds(target)) {
+    return outOfBoundsFailure(rawPath, target);
+  }
+
+  const denied = deniedFailure(target);
+  if (denied) {
+    return denied;
+  }
+
+  return { ok: true, resolved: target.resolved };
+}
+
+/**
+ * Resolve a user-supplied path against a boundary directory and verify
+ * that the result stays within it.
+ *
+ * For existing paths, symlinks are resolved via realpathSync so a symlink
+ * pointing outside the boundary is caught. For new paths (e.g. file_write),
+ * pass `mustExist: false` - the nearest existing ancestor directory is
+ * resolved via realpathSync to catch symlinks in parent dirs.
+ *
+ * Paths starting with `/workspace/` are treated as container-scoped and
+ * remapped relative to the boundary directory (the Docker sandbox mounts
+ * the host workspace at /workspace).
+ */
+export function sandboxPolicy(
+  rawPath: string,
+  boundaryDir: string,
+  options?: { mustExist?: boolean },
+): PathResult {
+  return evaluateSandboxPolicy(rawPath, boundaryDir, options, false);
+}
+
+/**
+ * Sandbox policy that permits out-of-workspace targets on non-containerized
+ * installs.
+ *
+ * Identical to {@link sandboxPolicy} for in-bounds targets. A target that
+ * escapes the boundary is allowed with host-style validation (the basename
+ * denylist still applies to both the logical and symlink-resolved paths).
+ * The permission lane runs before tool execution and classifies
+ * out-of-workspace file operations as elevated risk (see the gateway
+ * FileRiskClassifier), so an escape reaching this policy has already been
+ * threshold-approved or user-approved.
+ *
+ * In containerized mode the boundary stays hard: the container filesystem is
+ * not the host, and the host_file_* proxy tools are the escape hatch for the
+ * guardian's device.
+ */
+export function sandboxPolicyWithHostFallback(
+  rawPath: string,
+  boundaryDir: string,
+  options?: { mustExist?: boolean },
+): PathResult {
+  return evaluateSandboxPolicy(
+    rawPath,
+    boundaryDir,
+    options,
+    !getIsContainerized(),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -251,7 +251,11 @@ function securityDirConfigMirrorable(): boolean {
 }
 
 function isWithinDir(path: string, dir: string): boolean {
-  return path === dir || path.startsWith(dir + "/");
+  const normalized = dir !== "/" && dir.endsWith("/") ? dir.slice(0, -1) : dir;
+  if (normalized === "/") {
+    return isAbsolute(path);
+  }
+  return path === normalized || path.startsWith(normalized + "/");
 }
 
 /**

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -246,14 +246,15 @@ function evaluateSandboxPolicy(
     options?.mustExist ?? true,
   );
 
-  if (isOutOfBounds(target)) {
-    if (!allowOutOfBounds) {
-      return outOfBoundsFailure(rawPath, target);
-    }
-    const securityDenied = gatewaySecurityDenial(target);
-    if (securityDenied) {
-      return securityDenied;
-    }
+  if (!allowOutOfBounds && isOutOfBounds(target)) {
+    return outOfBoundsFailure(rawPath, target);
+  }
+
+  // Applied unconditionally — even a boundary configured to contain the
+  // gateway security dir must not expose it through the file tools.
+  const securityDenied = gatewaySecurityDenial(target);
+  if (securityDenied) {
+    return securityDenied;
   }
 
   const denied = deniedFailure(target);

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -188,23 +188,33 @@ function safeUserInfoHomedir(): string {
 }
 
 /**
- * Gateway-owned security directory (trust material, token signing keys).
- * The daemon must never read from or write to it — gateway-owned data flows
- * through the gateway's APIs instead (root AGENTS.md). Mirrors the
- * resolution in gateway/src/paths.ts `getGatewaySecurityDir()`, since the
- * cross-package import boundary bars importing it directly:
- * GATEWAY_SECURITY_DIR when set, else `<home>/.vellum/protected`.
+ * Security directories owned by other services: gateway trust material and
+ * token signing keys (GATEWAY_SECURITY_DIR) and CES credential keys
+ * (CREDENTIAL_SECURITY_DIR — `keys.enc`, `store.key`). The daemon must
+ * never read from or write to them — that data flows through the gateway
+ * and CES APIs (root AGENTS.md). The env-based resolution mirrors the
+ * owning services' own resolution, since the cross-package import boundary
+ * bars importing it; the shared bare-metal default `<home>/.vellum/protected`
+ * is always denied. A relative override resolves against the owning
+ * service's cwd, which this process cannot know — the daemon-cwd-resolved
+ * form is denied as a best effort alongside the always-denied default.
  */
-function getGatewaySecurityDirMirror(): string {
-  const override = process.env.GATEWAY_SECURITY_DIR?.trim();
-  if (override) {
-    return resolve(override);
-  }
-  return join(
-    process.env.HOME || safeUserInfoHomedir() || homedir(),
-    ".vellum",
-    "protected",
+function getServiceSecurityDirs(): string[] {
+  const dirs = new Set<string>();
+  dirs.add(
+    join(
+      process.env.HOME || safeUserInfoHomedir() || homedir(),
+      ".vellum",
+      "protected",
+    ),
   );
+  for (const name of ["GATEWAY_SECURITY_DIR", "CREDENTIAL_SECURITY_DIR"]) {
+    const override = process.env[name]?.trim();
+    if (override) {
+      dirs.add(resolve(override));
+    }
+  }
+  return [...dirs];
 }
 
 function isWithinDir(path: string, dir: string): boolean {
@@ -212,26 +222,27 @@ function isWithinDir(path: string, dir: string): boolean {
 }
 
 /**
- * Deny an out-of-workspace target that lands in the gateway security
- * directory. Both the lexical and symlink-resolved target are checked
- * against both the lexical and symlink-resolved directory, so neither a
- * symlinked target nor a symlinked directory prefix can mask the hit.
+ * Deny a target that lands in a service-owned security directory. Both the
+ * lexical and symlink-resolved target are checked against both the lexical
+ * and symlink-resolved directory, so neither a symlinked target nor a
+ * symlinked directory prefix can mask the hit.
  */
-function gatewaySecurityDenial(target: SandboxTarget): PathResult | null {
-  const securityDir = getGatewaySecurityDirMirror();
-  const realSecurityDir = resolveRealPath(securityDir);
-  const hit = [target.resolved, target.realResolved].some(
-    (path) =>
-      isWithinDir(path, securityDir) || isWithinDir(path, realSecurityDir),
-  );
-  if (!hit) {
-    return null;
+function securityDirDenial(target: SandboxTarget): PathResult | null {
+  for (const securityDir of getServiceSecurityDirs()) {
+    const realSecurityDir = resolveRealPath(securityDir);
+    const hit = [target.resolved, target.realResolved].some(
+      (path) =>
+        isWithinDir(path, securityDir) || isWithinDir(path, realSecurityDir),
+    );
+    if (hit) {
+      return {
+        ok: false,
+        reason: "denied",
+        error: "Access to the service security directory is denied",
+      };
+    }
   }
-  return {
-    ok: false,
-    reason: "denied",
-    error: "Access to the gateway security directory is denied",
-  };
+  return null;
 }
 
 function evaluateSandboxPolicy(
@@ -250,9 +261,9 @@ function evaluateSandboxPolicy(
     return outOfBoundsFailure(rawPath, target);
   }
 
-  // Applied unconditionally — even a boundary configured to contain the
-  // gateway security dir must not expose it through the file tools.
-  const securityDenied = gatewaySecurityDenial(target);
+  // Applied unconditionally — even a boundary configured to contain a
+  // service security dir must not expose it through the file tools.
+  const securityDenied = securityDirDenial(target);
   if (securityDenied) {
     return securityDenied;
   }
@@ -293,7 +304,7 @@ export function sandboxPolicy(
  * Identical to {@link sandboxPolicy} for in-bounds targets. A target that
  * escapes the boundary is allowed with host-style validation: the basename
  * denylist still applies to both the logical and symlink-resolved paths, and
- * the gateway security directory stays denied outright.
+ * the service security directories stay denied outright.
  * The permission lane runs before tool execution and classifies
  * out-of-workspace file operations as elevated risk (see the gateway
  * FileRiskClassifier), so an escape reaching this policy has already been

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -1,4 +1,4 @@
-import { lstatSync, readlinkSync, realpathSync } from "node:fs";
+import { realpathSync } from "node:fs";
 import { homedir, userInfo } from "node:os";
 import {
   basename,
@@ -10,6 +10,7 @@ import {
 } from "node:path";
 
 import { getIsContainerized } from "../../../config/env-registry.js";
+import { resolveTrailingLinkTarget } from "../../../util/fs-symlinks.js";
 
 /**
  * Result type shared by both sandbox and host path policies.
@@ -51,12 +52,15 @@ const CONTAINER_WORKSPACE_EXACT = "/workspace";
 /**
  * Resolve symlinks in an absolute path.
  *
- * For an existing path, returns its `realpathSync`. For a path that does not
- * exist yet (e.g. a `file_write` target), walks up to the nearest existing
- * ancestor, resolves that ancestor via `realpathSync`, then re-appends the
- * trailing (non-existent) components — so a symlink anywhere in the existing
- * prefix is still followed. Falls back to the lexical input when nothing on
- * the path resolves (e.g. the path lives on a filesystem this process cannot
+ * A trailing (possibly dangling) symlink chain is followed first — see
+ * {@link resolveTrailingLinkTarget} — so a link whose destination does not
+ * exist yet still reports that destination. For an existing path, returns
+ * its `realpathSync`. For a path that does not exist yet (e.g. a
+ * `file_write` target), walks up to the nearest existing ancestor, resolves
+ * that ancestor via `realpathSync`, then re-appends the trailing
+ * (non-existent) components — so a symlink anywhere in the existing prefix
+ * is still followed. Falls back to the lexical input when nothing on the
+ * path resolves (e.g. the path lives on a filesystem this process cannot
  * see, as with host_file paths proxied to a remote client).
  *
  * Used both for sandbox-boundary enforcement and to canonicalize paths before
@@ -64,7 +68,7 @@ const CONTAINER_WORKSPACE_EXACT = "/workspace";
  * file operation.
  */
 export function resolveRealPath(absolutePath: string): string {
-  let current = absolutePath;
+  let current = resolveTrailingLinkTarget(absolutePath);
   const trailing: string[] = [];
   while (current !== dirname(current)) {
     try {
@@ -89,34 +93,6 @@ interface SandboxTarget {
   realResolved: string;
   /** Symlink-canonicalized boundary directory. */
   realBoundary: string;
-}
-
-/**
- * Follow a trailing symlink chain manually so a DANGLING link reports its
- * destination. `realpathSync` throws on a link whose destination does not
- * exist, which makes canonicalization fall back to the benign link path —
- * but a write through the link creates the destination, so containment
- * checks must see it. The bound sits above every supported platform's own
- * traversal limit (Linux follows at most 40 links per resolution, macOS
- * 32), so any chain this loop cannot exhaust is one the filesystem itself
- * refuses to follow (ELOOP) — the eventual operation fails rather than
- * writing through an unchecked destination.
- */
-function resolveTrailingLinkTarget(path: string): string {
-  let current = path;
-  for (let depth = 0; depth < 64; depth++) {
-    let linkTarget: string;
-    try {
-      if (!lstatSync(current).isSymbolicLink()) {
-        return current;
-      }
-      linkTarget = readlinkSync(current);
-    } catch {
-      return current;
-    }
-    current = resolve(dirname(current), linkTarget);
-  }
-  return current;
 }
 
 /**

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -1,4 +1,5 @@
 import { realpathSync } from "node:fs";
+import { homedir, userInfo } from "node:os";
 import {
   basename,
   dirname,
@@ -178,6 +179,59 @@ function deniedFailure(target: SandboxTarget): PathResult | null {
   return null;
 }
 
+function safeUserInfoHomedir(): string {
+  try {
+    return userInfo().homedir;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Gateway-owned security directory (trust material, token signing keys).
+ * The daemon must never read from or write to it — gateway-owned data flows
+ * through the gateway's APIs instead (root AGENTS.md). Mirrors the
+ * resolution in gateway/src/paths.ts `getGatewaySecurityDir()`, since the
+ * cross-package import boundary bars importing it directly:
+ * GATEWAY_SECURITY_DIR when set, else `<home>/.vellum/protected`.
+ */
+function getGatewaySecurityDirMirror(): string {
+  const override = process.env.GATEWAY_SECURITY_DIR?.trim();
+  if (override) return resolve(override);
+  return join(
+    process.env.HOME || safeUserInfoHomedir() || homedir(),
+    ".vellum",
+    "protected",
+  );
+}
+
+function isWithinDir(path: string, dir: string): boolean {
+  return path === dir || path.startsWith(dir + "/");
+}
+
+/**
+ * Deny an out-of-workspace target that lands in the gateway security
+ * directory. Both the lexical and symlink-resolved target are checked
+ * against both the lexical and symlink-resolved directory, so neither a
+ * symlinked target nor a symlinked directory prefix can mask the hit.
+ */
+function gatewaySecurityDenial(target: SandboxTarget): PathResult | null {
+  const securityDir = getGatewaySecurityDirMirror();
+  const realSecurityDir = resolveRealPath(securityDir);
+  const hit = [target.resolved, target.realResolved].some(
+    (path) =>
+      isWithinDir(path, securityDir) || isWithinDir(path, realSecurityDir),
+  );
+  if (!hit) {
+    return null;
+  }
+  return {
+    ok: false,
+    reason: "denied",
+    error: "Access to the gateway security directory is denied",
+  };
+}
+
 function evaluateSandboxPolicy(
   rawPath: string,
   boundaryDir: string,
@@ -190,8 +244,14 @@ function evaluateSandboxPolicy(
     options?.mustExist ?? true,
   );
 
-  if (!allowOutOfBounds && isOutOfBounds(target)) {
-    return outOfBoundsFailure(rawPath, target);
+  if (isOutOfBounds(target)) {
+    if (!allowOutOfBounds) {
+      return outOfBoundsFailure(rawPath, target);
+    }
+    const securityDenied = gatewaySecurityDenial(target);
+    if (securityDenied) {
+      return securityDenied;
+    }
   }
 
   const denied = deniedFailure(target);
@@ -228,8 +288,9 @@ export function sandboxPolicy(
  * installs.
  *
  * Identical to {@link sandboxPolicy} for in-bounds targets. A target that
- * escapes the boundary is allowed with host-style validation (the basename
- * denylist still applies to both the logical and symlink-resolved paths).
+ * escapes the boundary is allowed with host-style validation: the basename
+ * denylist still applies to both the logical and symlink-resolved paths, and
+ * the gateway security directory stays denied outright.
  * The permission lane runs before tool execution and classifies
  * out-of-workspace file operations as elevated risk (see the gateway
  * FileRiskClassifier), so an escape reaching this policy has already been

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -197,7 +197,9 @@ function safeUserInfoHomedir(): string {
  */
 function getGatewaySecurityDirMirror(): string {
   const override = process.env.GATEWAY_SECURITY_DIR?.trim();
-  if (override) return resolve(override);
+  if (override) {
+    return resolve(override);
+  }
   return join(
     process.env.HOME || safeUserInfoHomedir() || homedir(),
     ".vellum",

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -96,12 +96,15 @@ interface SandboxTarget {
  * destination. `realpathSync` throws on a link whose destination does not
  * exist, which makes canonicalization fall back to the benign link path —
  * but a write through the link creates the destination, so containment
- * checks must see it. Bounded well above the kernel's own symlink-depth
- * limit; a deeper chain fails the eventual filesystem operation itself.
+ * checks must see it. The bound sits above every supported platform's own
+ * traversal limit (Linux follows at most 40 links per resolution, macOS
+ * 32), so any chain this loop cannot exhaust is one the filesystem itself
+ * refuses to follow (ELOOP) — the eventual operation fails rather than
+ * writing through an unchecked destination.
  */
 function resolveTrailingLinkTarget(path: string): string {
   let current = path;
-  for (let depth = 0; depth < 32; depth++) {
+  for (let depth = 0; depth < 64; depth++) {
     let linkTarget: string;
     try {
       if (!lstatSync(current).isSymbolicLink()) {

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -208,6 +208,11 @@ function safeUserInfoHomedir(): string {
  * service's cwd, which this process cannot know — the daemon-cwd-resolved
  * form is denied as a best effort alongside the always-denied default.
  */
+const SECURITY_DIR_ENV_VARS = [
+  "GATEWAY_SECURITY_DIR",
+  "CREDENTIAL_SECURITY_DIR",
+] as const;
+
 function getServiceSecurityDirs(): string[] {
   const dirs = new Set<string>();
   dirs.add(
@@ -217,13 +222,26 @@ function getServiceSecurityDirs(): string[] {
       "protected",
     ),
   );
-  for (const name of ["GATEWAY_SECURITY_DIR", "CREDENTIAL_SECURITY_DIR"]) {
+  for (const name of SECURITY_DIR_ENV_VARS) {
     const override = process.env[name]?.trim();
-    if (override) {
+    if (override && isAbsolute(override)) {
       dirs.add(resolve(override));
     }
   }
   return [...dirs];
+}
+
+/**
+ * Whether the security-dir deny set can be mirrored faithfully. A relative
+ * override resolves against the owning service's cwd, which this process
+ * cannot know — the true directory would be absent from the deny set, so
+ * the host fallback fails closed to the hard boundary instead.
+ */
+function securityDirConfigMirrorable(): boolean {
+  return SECURITY_DIR_ENV_VARS.every((name) => {
+    const override = process.env[name]?.trim();
+    return !override || isAbsolute(override);
+  });
 }
 
 function isWithinDir(path: string, dir: string): boolean {
@@ -332,7 +350,7 @@ export function sandboxPolicyWithHostFallback(
     rawPath,
     boundaryDir,
     options,
-    !getIsContainerized(),
+    !getIsContainerized() && securityDirConfigMirrorable(),
   );
 }
 

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -8,6 +8,7 @@ import type { ChannelId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import type { AutoApproveThreshold } from "../permissions/approval-policy.js";
 import { isDynamicSkillLoadInvocation } from "../permissions/checker.js";
+import { isOutOfWorkspaceFileInvocation } from "../permissions/workspace-policy.js";
 import {
   isUnparseableToolArgs,
   unparseableToolArgsMessage,
@@ -250,6 +251,7 @@ export function isSensitiveTool(
   toolName: string,
   executionTarget: ExecutionTarget,
   input?: Record<string, unknown>,
+  workingDir?: string,
 ): boolean {
   // UI surface tools are passive, user-visible operations (cards, forms,
   // tables). User input is voluntary and user-controlled — they are not
@@ -270,6 +272,21 @@ export function isSensitiveTool(
     toolName === "skill_load" &&
     input &&
     isDynamicSkillLoadInvocation(toolName, input)
+  ) {
+    return true;
+  }
+
+  // A sandbox file tool targeting a path outside the workspace reaches the
+  // host filesystem on non-containerized installs (the host-fallback path
+  // policy executes the escape once the permission lane approves). That is
+  // host-equivalent access — a read-only escape can leak local secrets — so
+  // it carries the same capability floor as executionTarget === "host":
+  // non-guardian actors escalate to the guardian, and no risk threshold or
+  // trust rule lifts it.
+  if (
+    input &&
+    workingDir &&
+    isOutOfWorkspaceFileInvocation(toolName, input, workingDir)
   ) {
     return true;
   }
@@ -506,7 +523,12 @@ export class ToolApprovalHandler {
       | Parameters<typeof consumeGrantForInvocation>[0]
       | null = null;
 
-    const sensitive = isSensitiveTool(name, executionTarget, input);
+    const sensitive = isSensitiveTool(
+      name,
+      executionTarget,
+      input,
+      context.workingDir,
+    );
     const { sensitiveToolApproval } = resolveCapabilities(context.trustClass);
     // cellThreshold stays unresolved: the decision does not consult it
     // (the floor is deterministic), and resolving a live threshold here

--- a/assistant/src/util/fs-symlinks.ts
+++ b/assistant/src/util/fs-symlinks.ts
@@ -1,0 +1,30 @@
+import { lstatSync, readlinkSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+/**
+ * Follow a trailing symlink chain manually so a DANGLING link reports its
+ * destination. `realpathSync` throws on a link whose destination does not
+ * exist, which makes canonicalization fall back to the benign link path —
+ * but a write through the link creates the destination, so containment and
+ * security checks must see it. The bound sits above every supported
+ * platform's own traversal limit (Linux follows at most 40 links per
+ * resolution, macOS 32), so any chain this loop cannot exhaust is one the
+ * filesystem itself refuses to follow (ELOOP) — the eventual operation
+ * fails rather than writing through an unchecked destination.
+ */
+export function resolveTrailingLinkTarget(path: string): string {
+  let current = path;
+  for (let depth = 0; depth < 64; depth++) {
+    let linkTarget: string;
+    try {
+      if (!lstatSync(current).isSymbolicLink()) {
+        return current;
+      }
+      linkTarget = readlinkSync(current);
+    } catch {
+      return current;
+    }
+    current = resolve(dirname(current), linkTarget);
+  }
+  return current;
+}

--- a/assistant/src/workflows/leaf-runner.test.ts
+++ b/assistant/src/workflows/leaf-runner.test.ts
@@ -472,6 +472,105 @@ describe("runLeaf — tool path", () => {
     expect(countConversations()).toBe(before);
   });
 
+  test("rejects out-of-workspace paths for sandbox file tools", async () => {
+    // Leaf tool calls bypass the ToolExecutor permission lane, so the file
+    // tools' out-of-workspace host fallback must be unreachable from a leaf.
+    const calls: Array<Record<string, unknown>> = [];
+    const fileRead: Tool = {
+      name: "file_read",
+      description: "Tool file_read",
+      category: "filesystem",
+      defaultRiskLevel: "low" as never,
+      executionTarget: "sandbox",
+      input_schema: { type: "object", properties: {}, required: [] },
+      async execute(
+        input: Record<string, unknown>,
+      ): Promise<ToolExecutionResult> {
+        calls.push(input);
+        return { content: "read ok", isError: false };
+      },
+    };
+
+    responseQueue = [
+      {
+        content: [
+          {
+            type: "tool_use",
+            name: "file_read",
+            id: "tu-1",
+            input: { path: "/etc/hosts" },
+          },
+        ],
+        model: "test",
+        usage: { inputTokens: 5, outputTokens: 2 },
+        stopReason: "tool_use",
+      },
+      {
+        content: [{ type: "text", text: "done" }],
+        model: "test",
+        usage: { inputTokens: 2, outputTokens: 1 },
+        stopReason: "end_turn",
+      },
+    ];
+
+    const result = await runLeaf({
+      prompt: "read the file",
+      tools: [fileRead],
+      trustContext,
+    });
+    expect(result.output).toBe("done");
+    // The workspace-bound guard fired before execute — the tool never ran.
+    expect(calls).toEqual([]);
+  });
+
+  test("in-workspace file tool paths still execute from a leaf", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const fileRead: Tool = {
+      name: "file_read",
+      description: "Tool file_read",
+      category: "filesystem",
+      defaultRiskLevel: "low" as never,
+      executionTarget: "sandbox",
+      input_schema: { type: "object", properties: {}, required: [] },
+      async execute(
+        input: Record<string, unknown>,
+      ): Promise<ToolExecutionResult> {
+        calls.push(input);
+        return { content: "read ok", isError: false };
+      },
+    };
+
+    responseQueue = [
+      {
+        content: [
+          {
+            type: "tool_use",
+            name: "file_read",
+            id: "tu-1",
+            input: { path: "notes.txt" },
+          },
+        ],
+        model: "test",
+        usage: { inputTokens: 5, outputTokens: 2 },
+        stopReason: "tool_use",
+      },
+      {
+        content: [{ type: "text", text: "done" }],
+        model: "test",
+        usage: { inputTokens: 2, outputTokens: 1 },
+        stopReason: "end_turn",
+      },
+    ];
+
+    const result = await runLeaf({
+      prompt: "read the file",
+      tools: [fileRead],
+      trustContext,
+    });
+    expect(result.output).toBe("done");
+    expect(calls).toEqual([{ path: "notes.txt" }]);
+  });
+
   test("a leaf with no schema and an empty tool set runs the tool path (no throw)", async () => {
     // An empty resolved tool set with no schema must NOT fall through to the
     // schema path (where schemaToInputSchema(undefined) throws) — it runs the
@@ -702,8 +801,11 @@ describe("runLeaf — persona path", () => {
       }>;
       expect(messages[0]?.content[0]?.text).not.toBe(MEMORY_BLOCK_TEXT);
     } finally {
-      if (savedAuth === undefined) delete process.env.DISABLE_HTTP_AUTH;
-      else process.env.DISABLE_HTTP_AUTH = savedAuth;
+      if (savedAuth === undefined) {
+        delete process.env.DISABLE_HTTP_AUTH;
+      } else {
+        process.env.DISABLE_HTTP_AUTH = savedAuth;
+      }
     }
   });
 });

--- a/assistant/src/workflows/leaf-runner.ts
+++ b/assistant/src/workflows/leaf-runner.ts
@@ -47,6 +47,7 @@ import { getConfig } from "../config/loader.js";
 import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { isPersonalMemoryAllowed } from "../daemon/trust-context.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
+import { isOutOfWorkspaceFileInvocation } from "../permissions/workspace-policy.js";
 import { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
 import {
@@ -133,10 +134,14 @@ async function injectPersonaMemory(
   opts: RunLeafOptions,
   messages: Message[],
 ): Promise<Message[]> {
-  if (!isPersonalMemoryAllowed(opts.trustContext)) {return messages;}
+  if (!isPersonalMemoryAllowed(opts.trustContext)) {
+    return messages;
+  }
 
   const config = getConfig();
-  if (config.memory?.enabled === false) {return messages;}
+  if (config.memory?.enabled === false) {
+    return messages;
+  }
 
   const ephemeralConversationId = `workflow-leaf:${randomUUID()}`;
   const graphMemory = new ConversationGraphMemory(ephemeralConversationId);
@@ -525,6 +530,17 @@ async function executeLeafTool(
     };
   }
 
+  // Leaf tool calls bypass the ToolExecutor's permission lane, so the file
+  // tools' out-of-workspace host fallback must not be reachable from here:
+  // the manifest consent covers workspace-scoped operation only, and leaves
+  // reject host tools outright. Keep the leaf workspace-bound.
+  if (isOutOfWorkspaceFileInvocation(name, input, ctx.workingDir)) {
+    return {
+      content: `Tool "${name}" may only access paths inside the workspace when invoked from a workflow leaf.`,
+      isError: true,
+    };
+  }
+
   const toolContext: ToolContext = {
     conversationId: ctx.ephemeralConversationId,
     workingDir: ctx.workingDir,
@@ -552,7 +568,9 @@ async function executeLeafTool(
 function finalAssistantText(history: Message[]): string {
   for (let i = history.length - 1; i >= 0; i--) {
     const msg = history[i];
-    if (msg.role !== "assistant") {continue;}
+    if (msg.role !== "assistant") {
+      continue;
+    }
     const text = msg.content
       .filter(
         (b): b is Extract<typeof b, { type: "text" }> => b.type === "text",

--- a/gateway/src/ipc/risk-classification-handlers.test.ts
+++ b/gateway/src/ipc/risk-classification-handlers.test.ts
@@ -245,6 +245,40 @@ describe("file classification", () => {
     expect(result.risk).toBe("low");
   });
 
+  test("file_write outside the working dir is medium risk", async () => {
+    const result = await classify({
+      tool: "file_write",
+      path: "/home/user/notes.txt",
+      workingDir: "/tmp",
+      resolvedPath: "/home/user/notes.txt",
+      resolvedWorkingDir: "/tmp",
+    });
+    expect(result.risk).toBe("medium");
+    expect(result.reason).toBe("File write outside the workspace");
+  });
+
+  test("file_write outside the working dir stays low when containerized", async () => {
+    const result = await classify({
+      tool: "file_write",
+      path: "/home/user/notes.txt",
+      workingDir: "/tmp",
+      resolvedPath: "/home/user/notes.txt",
+      resolvedWorkingDir: "/tmp",
+      isContainerized: true,
+    });
+    expect(result.risk).toBe("low");
+  });
+
+  test("file_read outside the working dir is medium via the lexical fallback", async () => {
+    const result = await classify({
+      tool: "file_read",
+      path: "/home/user/notes.txt",
+      workingDir: "/tmp",
+    });
+    expect(result.risk).toBe("medium");
+    expect(result.reason).toBe("File read outside the workspace");
+  });
+
   test("host_file_read defaults to medium risk", async () => {
     const result = await classify({
       tool: "host_file_read",

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -19,6 +19,7 @@ import { DEFAULT_COMMAND_REGISTRY } from "../risk/command-registry/index.js";
 import { generateDirectoryScopeOptions } from "../risk/directory-scope.js";
 import {
   fileRiskClassifier,
+  isPathWithinRoot,
   type FileClassificationContext,
 } from "../risk/file-risk-classifier.js";
 import type {
@@ -46,6 +47,10 @@ const ClassifyRiskSchema = z.object({
   // Used for security escalation checks so a symlink cannot mask the real
   // target. Falls back to lexical resolution of `path` when absent.
   resolvedPath: z.string().optional(),
+  // Symlink-resolved sandbox working dir, canonicalized by the daemon. Paired
+  // with resolvedPath for the workspace-boundary check so a symlinked
+  // workspace prefix does not read as an escape.
+  resolvedWorkingDir: z.string().optional(),
   skill: z.string().optional(),
   mode: z.string().optional(),
   script: z.string().optional(),
@@ -144,18 +149,6 @@ function lookupSpec(program: string): CommandRiskSpec | undefined {
   return Object.hasOwn(DEFAULT_COMMAND_REGISTRY, name)
     ? DEFAULT_COMMAND_REGISTRY[name as keyof typeof DEFAULT_COMMAND_REGISTRY]
     : undefined;
-}
-
-// ── Path-within-workspace check ─────────────────────────────────────────────
-
-function isPathWithinRoot(filePath: string, root: string): boolean {
-  if (!filePath || !root) return false;
-  const normalizedRoot = root.endsWith("/") ? root : root + "/";
-  const normalizedPath = resolve(filePath);
-  return (
-    normalizedPath === root.replace(/\/$/, "") ||
-    normalizedPath.startsWith(normalizedRoot)
-  );
 }
 
 // ── Sandbox auto-approve ────────────────────────────────────────────────────
@@ -496,6 +489,8 @@ export async function handleClassifyRisk(
           filePath,
           workingDir,
           resolvedPath: params.resolvedPath,
+          resolvedWorkingDir: params.resolvedWorkingDir,
+          isContainerized: params.isContainerized,
           transferSandboxDestPath: params.transferSandboxDestPath,
           transferSandboxWorkingDir: params.transferSandboxWorkingDir,
           resolvedTransferDestPath: params.resolvedTransferDestPath,

--- a/gateway/src/risk/file-risk-classifier.test.ts
+++ b/gateway/src/risk/file-risk-classifier.test.ts
@@ -60,6 +60,8 @@ function classifyInput(
       workingDir: input.workingDir ?? WORKING_DIR,
       toolName: input.toolName,
       resolvedPath: input.resolvedPath,
+      resolvedWorkingDir: input.resolvedWorkingDir,
+      isContainerized: input.isContainerized,
       transferSandboxDestPath: input.transferSandboxDestPath,
       transferSandboxWorkingDir: input.transferSandboxWorkingDir,
       resolvedTransferDestPath: input.resolvedTransferDestPath,
@@ -1071,6 +1073,135 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Writes to plugins directory");
+    });
+  });
+
+  // -- Out-of-workspace boundary escalation -----------------------------------
+
+  describe("out-of-workspace boundary escalation", () => {
+    test("file_write outside the working dir is medium", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "/tmp/outside.txt",
+        resolvedPath: "/tmp/outside.txt",
+        resolvedWorkingDir: WORKING_DIR,
+      });
+      expect(result.riskLevel).toBe("medium");
+      expect(result.reason).toBe("File write outside the workspace");
+      expect(result.matchType).toBe("registry");
+    });
+
+    test("file_edit outside the working dir is medium", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_edit",
+        filePath: "/tmp/outside.txt",
+        resolvedPath: "/tmp/outside.txt",
+        resolvedWorkingDir: WORKING_DIR,
+      });
+      expect(result.riskLevel).toBe("medium");
+      expect(result.reason).toBe("File edit outside the workspace");
+    });
+
+    test("file_read outside the working dir is medium", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_read",
+        filePath: "/tmp/outside.txt",
+        resolvedPath: "/tmp/outside.txt",
+        resolvedWorkingDir: WORKING_DIR,
+      });
+      expect(result.riskLevel).toBe("medium");
+      expect(result.reason).toBe("File read outside the workspace");
+    });
+
+    test("containerized suppresses the escalation", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "/tmp/outside.txt",
+        resolvedPath: "/tmp/outside.txt",
+        resolvedWorkingDir: WORKING_DIR,
+        isContainerized: true,
+      });
+      expect(result.riskLevel).toBe("low");
+      expect(result.reason).toBe("File write (default)");
+    });
+
+    test("code-injection sink outside the working dir stays high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: join(MOCK_PLUGINS_DIR, "evil", "register.ts"),
+        resolvedPath: join(MOCK_PLUGINS_DIR, "evil", "register.ts"),
+        resolvedWorkingDir: WORKING_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to plugins directory");
+    });
+
+    test("in-workspace symlink whose real target escapes is medium", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "notes/link.txt",
+        resolvedPath: "/tmp/real-target.txt",
+        resolvedWorkingDir: WORKING_DIR,
+      });
+      expect(result.riskLevel).toBe("medium");
+      expect(result.reason).toBe("File write outside the workspace");
+    });
+
+    test("outside symlink whose real target lands in the workspace is low", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "/tmp/link-into-workspace.txt",
+        resolvedPath: join(WORKING_DIR, "notes", "real.txt"),
+        resolvedWorkingDir: WORKING_DIR,
+      });
+      expect(result.riskLevel).toBe("low");
+      expect(result.reason).toBe("File write (default)");
+    });
+
+    test("falls back to a lexical comparison when canonical fields are absent", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "../outside.txt",
+      });
+      expect(result.riskLevel).toBe("medium");
+      expect(result.reason).toBe("File write outside the workspace");
+    });
+
+    test("lexical fallback keeps in-workspace relative paths low", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "notes/inside.txt",
+      });
+      expect(result.riskLevel).toBe("low");
+    });
+
+    test("container /workspace remap stays in-bounds under the lexical fallback", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "/workspace/notes/inside.txt",
+      });
+      expect(result.riskLevel).toBe("low");
+    });
+
+    test("host_file_write is unaffected by the boundary check", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "host_file_write",
+        filePath: "/tmp/outside.txt",
+        resolvedPath: "/tmp/outside.txt",
+      });
+      expect(result.riskLevel).toBe("medium");
+      expect(result.reason).toBe("Host file write (default)");
     });
   });
 

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -6,12 +6,16 @@
  * host_file_edit, host_file_transfer.
  *
  * Risk escalation paths:
- * - file_read: Low by default, High if targeting the actor token signing key
- *   or the monitoring data directory (snapshot files may contain secrets).
- * - file_write / file_edit: Low by default, High if targeting skill source
- *   code, the workspace hooks directory, the user plugins directory, the
- *   workspace tools directory, the workspace routes directory, the workspace
- *   workflows directory, or the monitoring data directory.
+ * - file_read: Low by default, Medium when the target resolves outside the
+ *   sandbox working directory on a non-containerized install, High if
+ *   targeting the actor token signing key or the monitoring data directory
+ *   (snapshot files may contain secrets).
+ * - file_write / file_edit: Low by default, Medium when the target resolves
+ *   outside the sandbox working directory on a non-containerized install,
+ *   High if targeting skill source code, the workspace hooks directory, the
+ *   user plugins directory, the workspace tools directory, the workspace
+ *   routes directory, the workspace workflows directory, or the monitoring
+ *   data directory.
  * - host_file_read: Medium (tool registry default; no special escalation).
  * - host_file_write / host_file_edit: Medium by default, High if targeting
  *   skill source code, the workspace hooks directory, the user plugins
@@ -122,6 +126,21 @@ export interface FileClassifierInput {
    */
   resolvedPath?: string;
   /**
+   * The sandbox working directory with symlinks resolved, canonicalized by the
+   * caller. Paired with {@link resolvedPath} for the workspace-boundary check
+   * so a symlinked workspace prefix (e.g. macOS /var → /private/var) does not
+   * read as an escape. When either canonical field is absent, the boundary
+   * check falls back to comparing lexical path against lexical workingDir.
+   */
+  resolvedWorkingDir?: string;
+  /**
+   * Whether the caller runs containerized. Suppresses the out-of-workspace
+   * escalation: containerized installs keep a hard workspace boundary at
+   * execution time, so an elevated classification would only prompt ahead of
+   * a guaranteed failure.
+   */
+  isContainerized?: boolean;
+  /**
    * For `host_file_transfer` with `direction: "to_sandbox"`: the workspace-side
    * destination path (where the copied file lands). `filePath` carries the
    * host-side `source_path`, so without this the workspace write destination —
@@ -180,6 +199,44 @@ function resolveSandboxPath(rawPath: string, workingDir: string): string {
     }
   }
   return resolve(workingDir, effectivePath);
+}
+
+/**
+ * Whether `filePath` resolves to `root` itself or a descendant of it.
+ * Lexical containment only — callers that need symlink awareness must pass
+ * pre-canonicalized paths. Shared with the IPC handler's bash
+ * sandbox-auto-approve path check.
+ */
+export function isPathWithinRoot(filePath: string, root: string): boolean {
+  if (!filePath || !root) return false;
+  const normalizedRoot = root.endsWith("/") ? root : root + "/";
+  const normalizedPath = resolve(filePath);
+  return (
+    normalizedPath === root.replace(/\/$/, "") ||
+    normalizedPath.startsWith(normalizedRoot)
+  );
+}
+
+/**
+ * Whether a sandbox file operation targets a path outside its working-dir
+ * boundary. Mirrors the execution-time predicate in the assistant's
+ * `sandboxPolicy`: the boundary check is on the real (symlink-resolved)
+ * target, so an in-workspace symlink pointing out escalates, while an
+ * outside path whose real target lands in the workspace does not.
+ * Containerized installs never escalate — execution keeps the hard
+ * workspace boundary there.
+ */
+function isOutsideSandboxBoundary(input: FileClassifierInput): boolean {
+  if (input.isContainerized || !input.filePath) {
+    return false;
+  }
+  if (input.resolvedPath && input.resolvedWorkingDir) {
+    return !isPathWithinRoot(input.resolvedPath, input.resolvedWorkingDir);
+  }
+  return !isPathWithinRoot(
+    resolveSandboxPath(input.filePath, input.workingDir),
+    input.workingDir,
+  );
 }
 
 /**
@@ -542,6 +599,16 @@ export class FileRiskClassifier implements RiskClassifier<
             break;
           }
         }
+        if (isOutsideSandboxBoundary(input)) {
+          assessment = {
+            riskLevel: "medium",
+            reason: "File read outside the workspace",
+            scopeOptions: [],
+            matchType: "registry",
+            allowlistOptions,
+          };
+          break;
+        }
         assessment = {
           riskLevel: "low",
           reason: "File read (default)",
@@ -568,6 +635,16 @@ export class FileRiskClassifier implements RiskClassifier<
             assessment = sink;
             break;
           }
+        }
+        if (isOutsideSandboxBoundary(input)) {
+          assessment = {
+            riskLevel: "medium",
+            reason: `File ${toolName === "file_write" ? "write" : "edit"} outside the workspace`,
+            scopeOptions: [],
+            matchType: "registry",
+            allowlistOptions,
+          };
+          break;
         }
         assessment = {
           riskLevel: "low",


### PR DESCRIPTION
## Summary
- `file_read`/`file_write`/`file_edit` targeting paths outside the workspace now classify as **Medium** risk in the gateway file-risk classifier ("File write outside the workspace"), flowing through the existing risk/threshold approval lane: prompt at the default threshold, auto-approve under Relaxed/Full access. Code-injection-sink High escalation keeps precedence, and a user trust rule can still lower a specific path (intentional per-path opt-out).
- At execution, the new `sandboxPolicyWithHostFallback` permits out-of-workspace targets on non-containerized installs (the basename denylist still applies to both lexical and symlink-resolved paths). Containerized installs keep the hard boundary — classification stays Low there so users are never prompted ahead of a guaranteed failure — and `file_write`/`file_edit` out-of-bounds errors gain the previously missing `host_file_write`/`host_file_edit` hints. `computePreviewDiff` uses the same policy so approval prompts for these operations show real diffs.
- The daemon sends a canonicalized `resolvedWorkingDir` and `isContainerized` with file-tool classification params so the gateway compares canonical-to-canonical (a symlinked workspace prefix like macOS `/var` → `/private/var` must not read as an escape), and folds the boundary into the risk cache key.

**Behavior change**: on non-containerized installs, out-of-workspace file tool operations that previously always errored now succeed after threshold auto-approval or an approval prompt. No new capability class: `host_file_write` (Medium) and local `bash` could already write these paths, and the sanctioned risk/threshold lane gates every newly permitted operation. No new deterministic approval mode is introduced (permission-controls-v2 compliant). No feature flag: containerized/managed installs keep exact current behavior aside from the added error hint.

## Original prompt
Requested after a failed assistant `file_write` to a repo path outside the workspace: instead of hard-failing on out-of-workspace writes, route `file_write` and similar tools through the permission flow — with the Full-access threshold set, the write should simply succeed rather than erroring and forcing the model to redo the work through another path. Planned in plan mode: classify out-of-workspace file ops as Medium (parity with `host_file_write`), relax the execution boundary on non-containerized installs only, keep `file_list`/`code_search` hard-failing with their existing `host_bash` hints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)