### PR TITLE
feat(providers): capability-gated native audio input for OpenAI-compatible providers (Inkling)

### DIFF
--- a/assistant/src/__tests__/context-token-estimator.test.ts
+++ b/assistant/src/__tests__/context-token-estimator.test.ts
@@ -7,7 +7,8 @@ import {
   estimatePromptTokens,
   estimateTextTokens,
 } from "../context/token-estimator.js";
-import type { Message } from "../providers/types.js";
+import { estimateOpenAICompatAudioTokens } from "../providers/openai/input-audio.js";
+import type { ContentBlock, Message } from "../providers/types.js";
 
 /** Build a minimal valid PNG header with the given dimensions, returned as base64. */
 function makePngBase64(width: number, height: number): string {
@@ -822,5 +823,57 @@ describe("tool_result estimation mirrors Anthropic wire format", () => {
       content,
     });
     expect(inflated).toBe(wireShape);
+  });
+});
+
+describe("audio-capable OpenAI-compatible models bill inline audio by duration", () => {
+  // 120 KB decoded → ~7.5 s at the compressed-audio byte-rate assumption.
+  const audioBase64 = "A".repeat(160_000);
+  const audioBytes = Math.floor((160_000 * 3) / 4);
+
+  const audioBlock = (mediaType: string): ContentBlock => ({
+    type: "file",
+    source: {
+      type: "base64",
+      media_type: mediaType,
+      data: audioBase64,
+      filename: "clip.wav",
+    },
+  });
+
+  test("catalog `supportsAudioInput` model adds the duration-based cost", () => {
+    const withModel = estimateContentBlockTokens(audioBlock("audio/wav"), {
+      providerName: "baseten",
+      model: "thinkingmachines/inkling",
+    });
+    const withoutModel = estimateContentBlockTokens(audioBlock("audio/wav"), {
+      providerName: "baseten",
+    });
+    expect(withModel - withoutModel).toBe(
+      estimateOpenAICompatAudioTokens(audioBytes),
+    );
+    expect(withModel - withoutModel).toBeGreaterThan(0);
+  });
+
+  test("non-flagged model and non-audio mime add nothing", () => {
+    const base = estimateContentBlockTokens(audioBlock("audio/wav"), {
+      providerName: "baseten",
+    });
+    expect(
+      estimateContentBlockTokens(audioBlock("audio/wav"), {
+        providerName: "baseten",
+        model: "some-other-model",
+      }),
+    ).toBe(base);
+    expect(
+      estimateContentBlockTokens(audioBlock("audio/x-m4a"), {
+        providerName: "baseten",
+        model: "thinkingmachines/inkling",
+      }),
+    ).toBe(
+      estimateContentBlockTokens(audioBlock("audio/x-m4a"), {
+        providerName: "baseten",
+      }),
+    );
   });
 });

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -1050,9 +1050,13 @@ function truncateHistoryToBudget(args: {
   systemPrompt: string;
   budgetTokens: number;
   providerName: string;
+  model?: string;
 }): Message[] {
-  const { messages, systemPrompt, budgetTokens, providerName } = args;
-  let estimate = estimatePromptTokens(messages, systemPrompt, { providerName });
+  const { messages, systemPrompt, budgetTokens, providerName, model } = args;
+  let estimate = estimatePromptTokens(messages, systemPrompt, {
+    providerName,
+    model,
+  });
   if (estimate <= budgetTokens || messages.length <= 1) {
     return messages;
   }
@@ -1061,6 +1065,7 @@ function truncateHistoryToBudget(args: {
     dropCount++;
     estimate = estimatePromptTokens(messages.slice(dropCount), systemPrompt, {
       providerName,
+      model,
     });
   }
   if (dropCount === 0) {
@@ -1155,6 +1160,7 @@ export async function runAssistantDrivenCompaction(
     systemPrompt: args.systemPrompt,
     budgetTokens: compactionPrefixBudget(args.maxInputTokens),
     providerName: args.provider.tokenEstimationProvider ?? args.provider.name,
+    model: args.provider.defaultModel,
   });
   const requestMessages = buildCompactionRequest(summaryHistory, instruction);
 
@@ -1354,7 +1360,7 @@ export async function runAssistantDrivenCompaction(
       estimatePromptTokens(
         [...fixedPrefix, ...stripInjectionsForCompaction(tail)],
         args.systemPrompt,
-        { providerName, toolTokenBudget },
+        { providerName, model: args.provider.defaultModel, toolTokenBudget },
       );
     const floorIndex = resolveTailFloorIndex(args.messages, pairedTailIndex);
     const advanced = advanceTailForBudget({
@@ -1616,6 +1622,7 @@ export async function runEmergencyCompaction(
     systemPrompt: args.systemPrompt,
     budgetTokens: compactionPrefixBudget(args.maxInputTokens),
     providerName: args.provider.tokenEstimationProvider ?? args.provider.name,
+    model: args.provider.defaultModel,
   });
 
   const instruction: Message = {

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -3,6 +3,11 @@ import {
   normalizeGeminiAudioMime,
 } from "../providers/gemini/inline-media.js";
 import { mediaSourceByteLength } from "../providers/media-resolve.js";
+import { modelSupportsAudioInput } from "../providers/model-catalog.js";
+import {
+  estimateOpenAICompatAudioTokens,
+  isOpenAICompatInlineAudio,
+} from "../providers/openai/input-audio.js";
 import type {
   ContentBlock,
   Message,
@@ -90,6 +95,12 @@ const TOOL_DEFINITION_OVERHEAD_TOKENS = 28;
 
 export interface TokenEstimatorOptions {
   providerName?: string;
+  /**
+   * Model id the estimated request dispatches to, for model-keyed rules
+   * (e.g. audio-capable OpenAI-compatible models). Callers pass the
+   * provider's `defaultModel` when available.
+   */
+  model?: string;
   /** Pre-computed tool token budget. When provided, added to the prompt total. */
   toolTokenBudget?: number;
 }
@@ -140,6 +151,16 @@ function estimateFileDataTokens(
     GEMINI_INLINE_FILE_MIME_TYPES.has(block.source.media_type)
   ) {
     return Math.ceil((Math.ceil(byteLength / 3) * 4) / CHARS_PER_TOKEN);
+  }
+
+  // Audio-native OpenAI-compatible models (catalog `supportsAudioInput`)
+  // receive eligible audio inline as `input_audio` parts, billed by duration.
+  if (
+    options?.model !== undefined &&
+    modelSupportsAudioInput(options.model) &&
+    isOpenAICompatInlineAudio(block.source.media_type, byteLength)
+  ) {
+    return estimateOpenAICompatAudioTokens(byteLength);
   }
 
   return 0;

--- a/assistant/src/plugins/defaults/compaction/window-manager.ts
+++ b/assistant/src/plugins/defaults/compaction/window-manager.ts
@@ -423,6 +423,10 @@ export class ContextWindowManager {
     return this.provider.tokenEstimationProvider ?? this.provider.name;
   }
 
+  private get estimationModel(): string | undefined {
+    return this.provider.defaultModel;
+  }
+
   private get systemPrompt(): string {
     const conversation = findConversationOrSubagent(this.conversationId);
     return conversation?.systemPrompt ?? "";
@@ -444,6 +448,7 @@ export class ContextWindowManager {
   estimateInputTokens(messages: Message[]): number {
     return estimatePromptTokens(messages, this.systemPrompt, {
       providerName: this.estimationProviderName,
+      model: this.estimationModel,
       toolTokenBudget: this.toolTokenBudget,
     });
   }
@@ -473,6 +478,7 @@ export class ContextWindowManager {
     if (!compaction.enabled) return { needed: false, estimatedTokens: 0 };
     const estimated = estimatePromptTokens(messages, this.systemPrompt, {
       providerName: this.estimationProviderName,
+      model: this.estimationModel,
       toolTokenBudget: this.toolTokenBudget,
     });
     const threshold = Math.floor(
@@ -634,6 +640,7 @@ export class ContextWindowManager {
       this.systemPrompt,
       {
         providerName: this.estimationProviderName,
+        model: this.estimationModel,
         toolTokenBudget: this.resolveTurnToolTokenBudget(),
       },
     );
@@ -713,6 +720,7 @@ export class ContextWindowManager {
       options?.precomputedEstimate ??
       estimatePromptTokens(messages, this.systemPrompt, {
         providerName: this.estimationProviderName,
+        model: this.estimationModel,
         toolTokenBudget: this.toolTokenBudget,
       });
     const thresholdTokens = Math.floor(
@@ -922,6 +930,7 @@ export class ContextWindowManager {
     try {
       return estimatePromptTokens(messages, this.systemPrompt, {
         providerName: this.estimationProviderName,
+        model: this.estimationModel,
         toolTokenBudget: this.toolTokenBudget,
       });
     } catch (err) {

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -52,6 +52,13 @@ export interface CatalogModel {
   adaptiveThinkingOnly?: boolean;
   supportsCaching?: boolean;
   supportsVision?: boolean;
+  /**
+   * The model's serving surface accepts OpenAI chat-completions `input_audio`
+   * content parts (base64 wav/mp3), so eligible audio attachments are sent
+   * inline instead of as a text placeholder. Daemon-only: not projected into
+   * the client catalog (see scripts/sync-llm-catalog.ts).
+   */
+  supportsAudioInput?: boolean;
   supportsToolUse?: boolean;
   pricing?: CatalogModelPricing;
   /**
@@ -2082,6 +2089,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsThinking: true,
         supportsCaching: true,
         supportsVision: true,
+        // Inkling ingests audio natively (dMel tokens); Baseten's serving
+        // surface accepts `input_audio` parts for it.
+        supportsAudioInput: true,
         supportsToolUse: true,
         // Baseten's reasoning_effort for Inkling tops out at "xhigh" (no
         // "max"), matching the chat-completions client's default ceiling.
@@ -2168,5 +2178,17 @@ export function getCatalogProviderForModel(
 export function isAdaptiveThinkingOnlyModel(modelId: string): boolean {
   return PROVIDER_CATALOG.some((p) =>
     p.models.some((m) => m.id === modelId && m.adaptiveThinkingOnly === true),
+  );
+}
+
+/**
+ * Whether a model's serving surface accepts OpenAI chat-completions
+ * `input_audio` content parts, driven by the `supportsAudioInput` capability
+ * in the catalog. Matches the model ID across every provider (same pattern as
+ * {@link isAdaptiveThinkingOnlyModel}).
+ */
+export function modelSupportsAudioInput(modelId: string): boolean {
+  return PROVIDER_CATALOG.some((p) =>
+    p.models.some((m) => m.id === modelId && m.supportsAudioInput === true),
   );
 }

--- a/assistant/src/providers/openai/__tests__/chat-completions-input-audio.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-input-audio.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Serialization tests for capability-gated native audio input on
+ * OpenAI-compatible providers: `file` blocks carrying eligible audio reach
+ * audio-capable models (catalog `supportsAudioInput`, e.g. Inkling) as
+ * `input_audio` content parts, while every other model keeps the
+ * text-placeholder serialization byte-for-byte.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { ContentBlock } from "../../types.js";
+import { OpenAIChatCompletionsProvider } from "../chat-completions-provider.js";
+
+type MockChunk = {
+  choices: Array<{
+    delta: { content?: string | null };
+    finish_reason?: string | null;
+  }>;
+  usage?: { prompt_tokens: number; completion_tokens: number };
+};
+
+const OK_CHUNKS: MockChunk[] = [
+  {
+    choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 1, completion_tokens: 1 },
+  },
+];
+
+function makeStream(chunks: MockChunk[]): AsyncIterable<MockChunk> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) yield c;
+    },
+  };
+}
+
+type CapturedParams = {
+  messages: Array<{
+    role: string;
+    content: string | Array<Record<string, unknown>>;
+  }>;
+};
+
+/** Swap `create` for a canned stream that records the request params. */
+function stubCreateCapture(provider: OpenAIChatCompletionsProvider): {
+  params: () => CapturedParams;
+} {
+  let captured: unknown;
+  const inner = provider as unknown as {
+    client: {
+      chat: {
+        completions: {
+          create: (params: unknown) => Promise<AsyncIterable<MockChunk>>;
+        };
+      };
+    };
+  };
+  inner.client.chat.completions.create = async (params) => {
+    captured = params;
+    return makeStream(OK_CHUNKS);
+  };
+  return { params: () => captured as CapturedParams };
+}
+
+// In the catalog with `supportsAudioInput: true` (Baseten's Inkling).
+const AUDIO_MODEL = "thinkingmachines/inkling";
+// Not in the catalog — must keep the text-placeholder serialization.
+const TEXT_MODEL = "test-model";
+
+function makeProvider(model: string): OpenAIChatCompletionsProvider {
+  return new OpenAIChatCompletionsProvider("test-key", model, {
+    providerName: "baseten",
+    providerLabel: "Baseten",
+  });
+}
+
+function audioFileBlock(mediaType: string, data = "QUJDRA=="): ContentBlock {
+  return {
+    type: "file",
+    source: {
+      type: "base64",
+      media_type: mediaType,
+      data,
+      filename: "clip.audio",
+    },
+  };
+}
+
+function userContentParts(params: CapturedParams): Record<string, unknown>[] {
+  return params.messages
+    .filter((m) => m.role === "user" && Array.isArray(m.content))
+    .flatMap((m) => m.content as Array<Record<string, unknown>>);
+}
+
+describe("chat-completions input_audio serialization", () => {
+  test("wav file block on an audio-capable model becomes an input_audio part", async () => {
+    const provider = makeProvider(AUDIO_MODEL);
+    const captured = stubCreateCapture(provider);
+
+    await provider.sendMessage([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "can you hear this?" },
+          audioFileBlock("audio/wav"),
+        ],
+      },
+    ]);
+
+    const parts = userContentParts(captured.params());
+    expect(parts).toContainEqual({
+      type: "input_audio",
+      input_audio: { data: "QUJDRA==", format: "wav" },
+    });
+    expect(JSON.stringify(parts)).not.toContain("<attached_file");
+  });
+
+  test("mp3 mime maps onto the mp3 format enum", async () => {
+    const provider = makeProvider(AUDIO_MODEL);
+    const captured = stubCreateCapture(provider);
+
+    await provider.sendMessage([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "listen" },
+          audioFileBlock("audio/mpeg"),
+        ],
+      },
+    ]);
+
+    const parts = userContentParts(captured.params());
+    expect(parts).toContainEqual({
+      type: "input_audio",
+      input_audio: { data: "QUJDRA==", format: "mp3" },
+    });
+  });
+
+  test("audio on a model without the capability keeps the text placeholder", async () => {
+    const provider = makeProvider(TEXT_MODEL);
+    const captured = stubCreateCapture(provider);
+
+    await provider.sendMessage([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "can you hear this?" },
+          audioFileBlock("audio/wav"),
+        ],
+      },
+    ]);
+
+    const parts = userContentParts(captured.params());
+    expect(JSON.stringify(parts)).not.toContain("input_audio");
+    expect(parts).toContainEqual({
+      type: "text",
+      text: `<attached_file name="clip.audio" type="audio/wav" />\nNo extracted text available.`,
+    });
+  });
+
+  test("oversize audio falls back to the text placeholder", async () => {
+    const provider = makeProvider(AUDIO_MODEL);
+    const captured = stubCreateCapture(provider);
+
+    // ~12.75 MB decoded (> 12 MB inline cap) without being a real payload.
+    const oversize = "A".repeat(17_000_000);
+    await provider.sendMessage([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "big one" },
+          audioFileBlock("audio/wav", oversize),
+        ],
+      },
+    ]);
+
+    const parts = userContentParts(captured.params());
+    expect(JSON.stringify(parts)).not.toContain("input_audio");
+  });
+
+  test("unsupported audio mime (m4a) falls back to the text placeholder", async () => {
+    const provider = makeProvider(AUDIO_MODEL);
+    const captured = stubCreateCapture(provider);
+
+    await provider.sendMessage([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "voice memo" },
+          audioFileBlock("audio/x-m4a"),
+        ],
+      },
+    ]);
+
+    const parts = userContentParts(captured.params());
+    expect(JSON.stringify(parts)).not.toContain("input_audio");
+    expect(JSON.stringify(parts)).toContain("audio/x-m4a");
+  });
+
+  test("tool_result nested audio is hoisted into the trailing user message when capable", async () => {
+    const provider = makeProvider(AUDIO_MODEL);
+    const captured = stubCreateCapture(provider);
+
+    await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "read the song file" }] },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "t1", name: "file_read", input: {} }],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t1",
+            content: "read 4 bytes",
+            contentBlocks: [audioFileBlock("audio/wav")],
+          },
+        ],
+      },
+    ]);
+
+    const params = captured.params();
+    const toolMessages = params.messages.filter((m) => m.role === "tool");
+    expect(toolMessages).toHaveLength(1);
+    expect(JSON.stringify(toolMessages)).not.toContain("input_audio");
+    expect(userContentParts(params)).toContainEqual({
+      type: "input_audio",
+      input_audio: { data: "QUJDRA==", format: "wav" },
+    });
+  });
+
+  test("tool_result nested audio stays dropped on a model without the capability", async () => {
+    const provider = makeProvider(TEXT_MODEL);
+    const captured = stubCreateCapture(provider);
+
+    await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "read the song file" }] },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "t1", name: "file_read", input: {} }],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t1",
+            content: "read 4 bytes",
+            contentBlocks: [audioFileBlock("audio/wav")],
+          },
+        ],
+      },
+    ]);
+
+    const serialized = JSON.stringify(captured.params());
+    expect(serialized).not.toContain("input_audio");
+    expect(serialized).not.toContain("QUJDRA==");
+  });
+});

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -6,7 +6,12 @@ import { ProviderError, type ProviderErrorReason } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
-import { base64Source, resolveMediaReferences } from "../media-resolve.js";
+import {
+  base64Source,
+  mediaSourceByteLength,
+  resolveMediaReferences,
+} from "../media-resolve.js";
+import { modelSupportsAudioInput } from "../model-catalog.js";
 import { PLACEHOLDER_EMPTY_TURN } from "../placeholder-sentinels.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import { createToolProgressEmitter } from "../tool-progress-events.js";
@@ -35,6 +40,11 @@ import {
   coerceObjectParamsToJsonString,
   decodeCoercedObjectArgs,
 } from "./coerce-object-args.js";
+import {
+  isOpenAICompatInlineAudio,
+  OPENAI_COMPAT_MAX_INLINE_AUDIO_BYTES,
+  openAIInputAudioFormat,
+} from "./input-audio.js";
 
 /**
  * Detect OpenAI-compatible context-overflow signals on an `OpenAI.APIError`.
@@ -336,6 +346,10 @@ export class OpenAIChatCompletionsProvider implements Provider {
       options.coerceObjectArgsToJsonString ?? false;
   }
 
+  get defaultModel(): string {
+    return this.model;
+  }
+
   async sendMessage(
     messages: Message[],
     options?: SendMessageOptions,
@@ -359,7 +373,11 @@ export class OpenAIChatCompletionsProvider implements Provider {
     const coercedObjectKeys = new Map<string, string[]>();
 
     try {
-      const openaiMessages = this.toOpenAIMessages(messages, systemPrompt);
+      const openaiMessages = this.toOpenAIMessages(
+        messages,
+        systemPrompt,
+        modelSupportsAudioInput(modelOverride ?? this.model),
+      );
 
       const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming =
         {
@@ -893,6 +911,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
   private toOpenAIMessages(
     messages: Message[],
     systemPrompt?: string,
+    audioInputEnabled = false,
   ): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
     // Swap any persisted attachment references back to inline base64 before
     // serializing, so the block transforms below can read `source.data`.
@@ -923,9 +942,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
         );
 
         // Emit tool results as separate tool-role messages
-        // OpenAI's API only supports string content in tool messages, so images
-        // from contentBlocks are collected and injected as a user message below.
-        const toolResultImages: ContentBlock[] = [];
+        // OpenAI's API only supports string content in tool messages, so media
+        // from contentBlocks is collected and injected as a user message below.
+        const toolResultMedia: ContentBlock[] = [];
         for (const tr of toolResults) {
           let textContent = tr.content;
           if (tr.contentBlocks && tr.contentBlocks.length > 0) {
@@ -939,7 +958,18 @@ export class OpenAIChatCompletionsProvider implements Provider {
               textContent = textContent + "\n" + extraText.join("\n");
             }
             for (const cb of tr.contentBlocks) {
-              if (cb.type === "image") toolResultImages.push(cb);
+              if (cb.type === "image") {
+                toolResultMedia.push(cb);
+              } else if (
+                audioInputEnabled &&
+                cb.type === "file" &&
+                isOpenAICompatInlineAudio(
+                  cb.source.media_type,
+                  mediaSourceByteLength(cb.source),
+                )
+              ) {
+                toolResultMedia.push(cb);
+              }
             }
           }
           result.push({
@@ -949,12 +979,13 @@ export class OpenAIChatCompletionsProvider implements Provider {
           });
         }
 
-        // Emit remaining content + any tool result images as a user message.
-        // Images from tool results (e.g. browser_screenshot) must go in a user
-        // message because OpenAI-compatible APIs don't support images in tool messages.
-        const userContent = [...otherBlocks, ...toolResultImages];
+        // Emit remaining content + any tool result media as a user message.
+        // Media from tool results (e.g. browser_screenshot, audio a tool read)
+        // must go in a user message because OpenAI-compatible APIs don't
+        // support media parts in tool messages.
+        const userContent = [...otherBlocks, ...toolResultMedia];
         if (userContent.length > 0) {
-          result.push(this.toOpenAIUserMessage(userContent));
+          result.push(this.toOpenAIUserMessage(userContent, audioInputEnabled));
         }
       }
     }
@@ -1035,9 +1066,10 @@ export class OpenAIChatCompletionsProvider implements Provider {
     return result;
   }
 
-  /** Convert user content blocks (text, image) to an OpenAI user message. */
+  /** Convert user content blocks (text, image, audio) to an OpenAI user message. */
   private toOpenAIUserMessage(
     blocks: ContentBlock[],
+    audioInputEnabled = false,
   ): OpenAI.Chat.Completions.ChatCompletionUserMessageParam {
     // If only a single text block, use plain string (simpler, fewer tokens)
     if (blocks.length === 1 && blocks[0].type === "text") {
@@ -1066,12 +1098,28 @@ export class OpenAIChatCompletionsProvider implements Provider {
             });
           }
           break;
-        case "file":
-          parts.push({
-            type: "text",
-            text: this.fileBlockToText(block),
-          });
+        case "file": {
+          const audioFormat = audioInputEnabled
+            ? openAIInputAudioFormat(block.source.media_type)
+            : null;
+          if (
+            audioFormat !== null &&
+            mediaSourceByteLength(block.source) <=
+              OPENAI_COMPAT_MAX_INLINE_AUDIO_BYTES
+          ) {
+            const audioSrc = base64Source(block.source);
+            parts.push({
+              type: "input_audio",
+              input_audio: { data: audioSrc.data, format: audioFormat },
+            });
+          } else {
+            parts.push({
+              type: "text",
+              text: this.fileBlockToText(block),
+            });
+          }
           break;
+        }
         case "server_tool_use":
           parts.push({
             type: "text",

--- a/assistant/src/providers/openai/input-audio.ts
+++ b/assistant/src/providers/openai/input-audio.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared source of truth for how OpenAI-compatible chat-completions providers
+ * ingest inline audio: which MIME types map onto the wire `input_audio.format`
+ * enum, the inline size cap, and the token-cost heuristic. The provider
+ * transform (`chat-completions-provider.ts`) and the context budgeter
+ * (`context/token-estimator.ts`) both read these — if they disagreed about
+ * which audio is sent inline, the budgeter would mis-count what the provider
+ * actually ships.
+ *
+ * Wire shape (OpenAI chat-completions spec):
+ *   { type: "input_audio", input_audio: { data: <base64>, format: "wav"|"mp3" } }
+ *
+ * m4a/ogg/flac/opus are deliberately absent: the spec's `format` enum is
+ * wav|mp3 only. Whether a given model receives audio at all is gated by the
+ * catalog `supportsAudioInput` capability (`modelSupportsAudioInput`), not
+ * here — this module only decides eligibility of the payload itself.
+ */
+
+export type OpenAIInputAudioFormat = "wav" | "mp3";
+
+const MIME_TO_INPUT_AUDIO_FORMAT: ReadonlyMap<string, OpenAIInputAudioFormat> =
+  new Map([
+    ["audio/wav", "wav"],
+    ["audio/x-wav", "wav"],
+    ["audio/wave", "wav"],
+    ["audio/mpeg", "mp3"],
+    ["audio/mp3", "mp3"],
+  ]);
+
+/**
+ * Map a stored attachment MIME type onto the `input_audio.format` enum, or
+ * `null` when the type is not sent inline.
+ */
+export function openAIInputAudioFormat(
+  mimeType: string,
+): OpenAIInputAudioFormat | null {
+  return MIME_TO_INPUT_AUDIO_FORMAT.get(mimeType.toLowerCase()) ?? null;
+}
+
+/**
+ * Max raw bytes of audio sent inline. Base64 inflates the payload ~4/3, so
+ * 12 MB raw ≈ 16 MB encoded — headroom for the rest of the prompt under
+ * typical request-size limits (same rationale as the Gemini inline-audio cap).
+ */
+export const OPENAI_COMPAT_MAX_INLINE_AUDIO_BYTES = 12 * 1024 * 1024;
+
+/**
+ * True when an audio media source of this MIME type and byte length is
+ * eligible to be sent inline as an `input_audio` part (given a model whose
+ * catalog entry carries `supportsAudioInput`).
+ */
+export function isOpenAICompatInlineAudio(
+  mimeType: string,
+  byteLength: number,
+): boolean {
+  return (
+    openAIInputAudioFormat(mimeType) !== null &&
+    byteLength <= OPENAI_COMPAT_MAX_INLINE_AUDIO_BYTES
+  );
+}
+
+/**
+ * Audio-native chat-completions models bill audio by duration, not payload
+ * size (measured on Baseten's Inkling: ~20 tokens/sec — 127 audio tokens for
+ * a 6.3 s clip). Duration is approximated from byte length at compressed-audio
+ * rates (~16 KB/s); for uncompressed PCM wavs this overestimates duration and
+ * therefore tokens — the safe direction for the compaction pre-check
+ * (compact early, never overflow).
+ */
+const AUDIO_TOKENS_PER_SECOND = 20;
+const APPROX_AUDIO_BYTES_PER_SECOND = 16_000;
+
+export function estimateOpenAICompatAudioTokens(byteLength: number): number {
+  const approxSeconds = byteLength / APPROX_AUDIO_BYTES_PER_SECOND;
+  return Math.ceil(approxSeconds * AUDIO_TOKENS_PER_SECOND);
+}

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -118,7 +118,6 @@ export class OpenRouterResponsesProvider extends OpenAIResponsesProvider {
 
 export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
   private readonly openRouterApiKey: string;
-  private readonly defaultModel: string;
   private readonly resolvedBaseURL: string;
   private readonly providerStreamTimeoutMs: number | undefined;
   private readonly useNativeWebSearch: boolean;
@@ -141,7 +140,6 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
       backfillEmptyAssistantContent: true,
     });
     this.openRouterApiKey = apiKey;
-    this.defaultModel = model;
     this.resolvedBaseURL = baseURL;
     this.providerStreamTimeoutMs = options.streamTimeoutMs;
     this.useNativeWebSearch = options.useNativeWebSearch ?? false;

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -338,6 +338,13 @@ export interface Provider {
    */
   tokenEstimationProvider?: string;
   /**
+   * Model id this instance dispatches when a call carries no per-call model
+   * override. Consumed by the local token estimator for model-keyed rules
+   * (e.g. audio-capable OpenAI-compatible models). Optional: providers whose
+   * estimation rules are provider-wide need not expose it.
+   */
+  defaultModel?: string;
+  /**
    * True when this provider instance was constructed to run web search
    * server-side (provider-native). The native search only activates when a
    * `web_search`-named tool is passed in the request, so callers that want to

--- a/assistant/src/providers/vercel-ai-gateway/client.ts
+++ b/assistant/src/providers/vercel-ai-gateway/client.ts
@@ -26,7 +26,6 @@ const DEFAULT_VERCEL_AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1";
 
 export class VercelAIGatewayProvider extends OpenAIChatCompletionsProvider {
   private readonly gatewayApiKey: string;
-  private readonly defaultModel: string;
   private readonly resolvedBaseURL: string;
   private readonly providerStreamTimeoutMs: number | undefined;
   private readonly useNativeWebSearch: boolean;
@@ -50,7 +49,6 @@ export class VercelAIGatewayProvider extends OpenAIChatCompletionsProvider {
       backfillEmptyAssistantContent: true,
     });
     this.gatewayApiKey = apiKey;
-    this.defaultModel = model;
     this.resolvedBaseURL = baseURL;
     this.providerStreamTimeoutMs = options.streamTimeoutMs;
     this.useNativeWebSearch = options.useNativeWebSearch ?? false;


### PR DESCRIPTION
## Summary
- Add a `supportsAudioInput` capability to the model catalog (set on `thinkingmachines/inkling`) plus a shared `providers/openai/input-audio.ts` module: MIME → `input_audio.format` mapping (wav/mp3 only, per the OpenAI spec enum), a 12 MB inline cap, and a duration-based token heuristic (~20 tok/s, measured on Inkling).
- The OpenAI-compatible chat-completions serializer now sends eligible audio `file` blocks as spec-shape `input_audio` content parts for models carrying the capability — both user attachments and audio nested in tool results (hoisted into the trailing user message alongside images). Everything else falls back to the existing `<attached_file>` text placeholder.
- The token estimator gains a matching duration-based arm: `TokenEstimatorOptions.model` is threaded from the compaction window-manager and compactor via a new optional `Provider.defaultModel`. OpenRouter and Vercel AI Gateway clients drop their duplicate private `defaultModel` fields in favor of the inherited base-class getter (same value, single source).

**Probe evidence** (live Baseten `thinkingmachines/inkling`, 6.3 s speech wav): both `{"type":"input_audio",...}` (OpenAI spec) and vLLM-style `audio_url` data URIs returned HTTP 200 with accurate transcription and `prompt_tokens_details.audio_tokens: 127`. The spec shape was chosen. Before this change the model received only `<attached_file name="..." type="audio/wav" />\nNo extracted text available.` — zero audio bytes.

**No-op guarantee**: only catalog models flagged `supportsAudioInput` (currently Inkling alone) get the new serialization; for every other model the request bytes are unchanged. Covered by serializer tests (capable/non-capable/oversize/unsupported-mime/tool-result-hoist) and estimator tests.

## Original prompt
Investigation of an audio attachment sent to an Inkling-backed (Baseten) assistant showed via the LLM request logs that the model received only a text placeholder — the daemon never ships audio bytes to OpenAI-compatible providers; native audio-in existed only in the Gemini provider transform. The request: probe Baseten's chat-completions surface for audio content-part support, then add capability-gated native audio input for OpenAI-compatible providers, mirroring the Gemini inline-media pattern (shared mime allowlist / size cap / token estimate consumed by both the provider transform and the context budgeter).