### PR TITLE
feat(cli): `vellum sleep --wait` drains in-flight background work before stopping

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16357,6 +16357,156 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/lifecycle/drain-status:
+    get:
+      operationId: lifecycle_drainstatus_get
+      summary: In-flight background work
+      description:
+        "Reports conversation turns, memory jobs, and schedule runs currently in flight, plus the active quiesce
+        lease. `idle: true` means it is safe to stop the assistant without interrupting work."
+      tags:
+        - system
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  quiescedUntil:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  idle:
+                    type: boolean
+                    description: True when no conversation turn, memory job, or schedule run is in flight.
+                  activeConversations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        conversationId:
+                          type: string
+                        title:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        originChannel:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        originInterface:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        processingStartedAt:
+                          type: number
+                      required:
+                        - conversationId
+                        - title
+                        - originChannel
+                        - originInterface
+                        - processingStartedAt
+                      additionalProperties: false
+                  memoryJobs:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          type: string
+                        startedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                      required:
+                        - id
+                        - type
+                        - startedAt
+                      additionalProperties: false
+                  scheduleRuns:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        runId:
+                          type: string
+                        scheduleName:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        startedAt:
+                          type: number
+                      required:
+                        - runId
+                        - scheduleName
+                        - startedAt
+                      additionalProperties: false
+                required:
+                  - quiescedUntil
+                  - idle
+                  - activeConversations
+                  - memoryJobs
+                  - scheduleRuns
+                additionalProperties: false
+  /v1/lifecycle/quiesce:
+    delete:
+      operationId: lifecycle_quiesce_delete
+      summary: Release the drain quiesce lease
+      description:
+        Resumes background work immediately instead of waiting for the lease TTL to expire (e.g. when a drain is
+        cancelled).
+      tags:
+        - system
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  released:
+                    type: boolean
+                required:
+                  - released
+                additionalProperties: false
+    post:
+      operationId: lifecycle_quiesce_post
+      summary: Arm or refresh the drain quiesce lease
+      description:
+        Pauses the starting of new background work (heartbeat, schedules, watchers, sequences, memory jobs) for the
+        lease TTL. Refresh by calling again; the lease self-expires so an abandoned drain never leaves background work
+        paused.
+      tags:
+        - system
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ttlMs:
+                  description: Lease TTL in ms (clamped to a sane range).
+                  type: number
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  quiescedUntil:
+                    type: number
+                    description: Epoch ms when the quiesce lease expires.
+                required:
+                  - quiescedUntil
+                additionalProperties: false
   /v1/live-voice/preflight:
     post:
       operationId: livevoice_preflight_post

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16362,8 +16362,9 @@ paths:
       operationId: lifecycle_drainstatus_get
       summary: In-flight background work
       description:
-        "Reports conversation turns, memory jobs, and schedule runs currently in flight, plus the active quiesce
-        lease. `idle: true` means it is safe to stop the assistant without interrupting work."
+        "Reports conversation turns, memory jobs, schedule runs, workflow runs, and heartbeat runs currently in
+        flight, plus the active quiesce lease. `idle: true` means it is safe to stop the assistant without interrupting
+        work."
       tags:
         - system
       responses:
@@ -16380,7 +16381,7 @@ paths:
                       - type: "null"
                   idle:
                     type: boolean
-                    description: True when no conversation turn, memory job, schedule run, or workflow run is in flight.
+                    description: True when no conversation turn, memory job, schedule run, workflow run, or heartbeat run is in flight.
                   activeConversations:
                     type: array
                     items:
@@ -16465,6 +16466,19 @@ paths:
                         - name
                         - startedAt
                       additionalProperties: false
+                  heartbeatRuns:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        runId:
+                          type: string
+                        startedAt:
+                          type: number
+                      required:
+                        - runId
+                        - startedAt
+                      additionalProperties: false
                 required:
                   - quiescedUntil
                   - idle
@@ -16472,6 +16486,7 @@ paths:
                   - memoryJobs
                   - scheduleRuns
                   - workflowRuns
+                  - heartbeatRuns
                 additionalProperties: false
   /v1/lifecycle/quiesce:
     delete:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16380,7 +16380,7 @@ paths:
                       - type: "null"
                   idle:
                     type: boolean
-                    description: True when no conversation turn, memory job, or schedule run is in flight.
+                    description: True when no conversation turn, memory job, schedule run, or workflow run is in flight.
                   activeConversations:
                     type: array
                     items:
@@ -16445,12 +16445,33 @@ paths:
                         - scheduleName
                         - startedAt
                       additionalProperties: false
+                  workflowRuns:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        runId:
+                          type: string
+                        name:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        startedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                      required:
+                        - runId
+                        - name
+                        - startedAt
+                      additionalProperties: false
                 required:
                   - quiescedUntil
                   - idle
                   - activeConversations
                   - memoryJobs
                   - scheduleRuns
+                  - workflowRuns
                 additionalProperties: false
   /v1/lifecycle/quiesce:
     delete:

--- a/assistant/src/__tests__/run-due-schedules.test.ts
+++ b/assistant/src/__tests__/run-due-schedules.test.ts
@@ -55,7 +55,10 @@ mock.module("../persistence/lifecycle-quiesce.js", () => ({
 
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { createSchedule } from "../schedule/schedule-store.js";
+import {
+  createSchedule,
+  deferClaimedSchedule,
+} from "../schedule/schedule-store.js";
 import { runDueSchedulesOnce } from "../schedule/scheduler.js";
 
 await initializeDb();
@@ -158,6 +161,34 @@ describe("runDueSchedulesOnce (the schedule worker's tick)", () => {
       .get(oneShot.id) as { status: string; next_run_at: number };
     expect(row.status).toBe("active");
     expect(row.next_run_at).toBeGreaterThan(Date.now());
+  });
+
+  test("deferClaimedSchedule restores an exhausted recurring claim", async () => {
+    const recurring = await createSchedule({
+      name: "Bounded recurring",
+      cronExpression: "* * * * *",
+      message: "final occurrence",
+      mode: "notify",
+    });
+    // A bounded recurring schedule's FINAL occurrence is claimed by
+    // exhausting the job: enabled = false, nextRunAt = 0.
+    rawDb().run(
+      "UPDATE cron_jobs SET enabled = 0, next_run_at = 0 WHERE id = ?",
+      [recurring.id],
+    );
+
+    await deferClaimedSchedule(recurring.id, Date.now() + 30_000);
+
+    const row = rawDb()
+      .query("SELECT enabled, next_run_at, status FROM cron_jobs WHERE id = ?")
+      .get(recurring.id) as {
+      enabled: number;
+      next_run_at: number;
+      status: string;
+    };
+    expect(row.enabled).toBe(1);
+    expect(row.next_run_at).toBeGreaterThan(Date.now());
+    expect(row.status).toBe("active");
   });
 
   test("records an error run and schedules a retry when a script fails", async () => {

--- a/assistant/src/__tests__/run-due-schedules.test.ts
+++ b/assistant/src/__tests__/run-due-schedules.test.ts
@@ -41,6 +41,18 @@ mock.module("../notifications/emit-signal.js", () => ({
   emitNotificationSignal: mockEmitNotificationSignal,
 }));
 
+// Scripted quiesce-lease answers, consumed one per isLifecycleQuiesced()
+// call; empty means "no lease" (the real fail-open default), so existing
+// tests run ungated. Lets a test arm the lease BETWEEN the claim-site check
+// and the per-job re-check, which no real interleaving can do determinstically.
+let quiesceAnswers: boolean[] = [];
+const realLifecycleQuiesce =
+  await import("../persistence/lifecycle-quiesce.js");
+mock.module("../persistence/lifecycle-quiesce.js", () => ({
+  ...realLifecycleQuiesce,
+  isLifecycleQuiesced: () => quiesceAnswers.shift() ?? false,
+}));
+
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { createSchedule } from "../schedule/schedule-store.js";
@@ -55,6 +67,7 @@ function rawDb(): import("bun:sqlite").Database {
 
 beforeEach(() => {
   mockEmitNotificationSignal.mockClear();
+  quiesceAnswers = [];
   const db = getDb();
   db.run("DELETE FROM cron_runs");
   db.run("DELETE FROM cron_jobs");
@@ -118,6 +131,33 @@ describe("runDueSchedulesOnce (the schedule worker's tick)", () => {
       .get(oneShot.id) as { status: string; enabled: number };
     expect(row.status).toBe("fired");
     expect(row.enabled).toBe(0);
+  });
+
+  test("a lease armed between claim and start defers the job back to the queue", async () => {
+    const oneShot = await createSchedule({
+      name: "Deferred notify",
+      cronExpression: null,
+      message: "ping",
+      mode: "notify",
+      nextRunAt: Date.now() - 1000,
+    });
+
+    // Call 1 is the claim-site gate (claimDueSchedules): no lease yet.
+    // Call 2 is the per-job re-check: the lease has landed.
+    quiesceAnswers = [false, true];
+    const result = await runDueSchedulesOnce();
+
+    expect(result.claimed).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.completed).toBe(0);
+    // Nothing executed and nothing was lost: no notification fired, and the
+    // one-shot is back in the queue with a near-future retry time.
+    expect(mockEmitNotificationSignal).not.toHaveBeenCalled();
+    const row = rawDb()
+      .query("SELECT status, next_run_at FROM cron_jobs WHERE id = ?")
+      .get(oneShot.id) as { status: string; next_run_at: number };
+    expect(row.status).toBe("active");
+    expect(row.next_run_at).toBeGreaterThan(Date.now());
   });
 
   test("records an error run and schedules a retry when a script fails", async () => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -243,6 +243,12 @@ export async function runDaemon(): Promise<void> {
   try {
     const { migrationsOk } = await initializeDb();
     dbReady = true;
+    // A quiesce lease can survive a stop that happened mid-drain; clear it so
+    // a fresh boot never starts with background work paused. Placed
+    // synchronously after DB init — before any await yields to the
+    // already-listening HTTP server — so it cannot delete a lease a client
+    // arms against THIS boot.
+    clearLifecycleQuiesce();
     // Floor the stream seq counter above every persisted conversation
     // anchor before turns can stamp events. Anchors are getCurrentSeq()
     // snapshots already served to clients, and a crashed process can have
@@ -655,10 +661,6 @@ export async function runDaemon(): Promise<void> {
 
   registerWatcherProviders();
   registerMessagingProviders();
-
-  // A quiesce lease can survive a stop that happened mid-drain; clear it so
-  // a fresh boot never starts with background work paused.
-  clearLifecycleQuiesce();
 
   try {
     await recoverStaleSchedules();

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -27,6 +27,7 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { startEmbeddingRuntimeManager } from "../persistence/embeddings/embedding-backend.js";
 import { maybeEnqueueLexicalBackfillOnUpgrade } from "../persistence/job-handlers/message-lexical-backfill.js";
+import { clearLifecycleQuiesce } from "../persistence/lifecycle-quiesce.js";
 import { startConsentRefresh } from "../platform/consent-cache.js";
 import { syncWorkspaceIdentityToPlatform } from "../platform/sync-identity.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
@@ -654,6 +655,10 @@ export async function runDaemon(): Promise<void> {
 
   registerWatcherProviders();
   registerMessagingProviders();
+
+  // A quiesce lease can survive a stop that happened mid-drain; clear it so
+  // a fresh boot never starts with background work paused.
+  clearLifecycleQuiesce();
 
   try {
     await recoverStaleSchedules();

--- a/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
@@ -202,6 +202,16 @@ mock.module("../../runtime/pre-first-message-gate.js", () => ({
   hasReceivedUserMessage: () => preFirstMessageGateOpen,
 }));
 
+// Stub the drain quiesce lease so tests can flip it without a database.
+// Defaults to INACTIVE so existing tests keep passing.
+const realLifecycleQuiesce =
+  await import("../../persistence/lifecycle-quiesce.js");
+let quiesceLeaseActive = false;
+mock.module("../../persistence/lifecycle-quiesce.js", () => ({
+  ...realLifecycleQuiesce,
+  isLifecycleQuiesced: () => quiesceLeaseActive,
+}));
+
 const { HeartbeatService } = await import("../heartbeat-service.js");
 
 let origWorkspaceDir: string | undefined;
@@ -387,6 +397,42 @@ describe("HeartbeatService", () => {
     expect(
       skipHeartbeatRunCalls.some((c) => c.reason === "pre_first_user_message"),
     ).toBe(false);
+  });
+
+  test("scheduled run skips with reason 'quiesced' while the drain lease is active", async () => {
+    quiesceLeaseActive = true;
+    const service = new HeartbeatService();
+    service.start();
+    skipHeartbeatRunCalls.length = 0;
+
+    try {
+      const result = await service.runOnce({ force: false });
+
+      expect(result).toBe(false);
+      expect(runBackgroundJobCalls).toHaveLength(0);
+      expect(skipHeartbeatRunCalls.some((c) => c.reason === "quiesced")).toBe(
+        true,
+      );
+    } finally {
+      await service.stop();
+      quiesceLeaseActive = false;
+    }
+  });
+
+  test("forced run bypasses the quiesce gate (manual operator action)", async () => {
+    quiesceLeaseActive = true;
+    const service = new HeartbeatService();
+
+    try {
+      await service.runOnce({ force: true });
+
+      expect(runBackgroundJobCalls).toHaveLength(1);
+      expect(skipHeartbeatRunCalls.some((c) => c.reason === "quiesced")).toBe(
+        false,
+      );
+    } finally {
+      quiesceLeaseActive = false;
+    }
   });
 
   describe("max consecutive runs cap", () => {

--- a/assistant/src/heartbeat/heartbeat-run-store.ts
+++ b/assistant/src/heartbeat/heartbeat-run-store.ts
@@ -25,7 +25,8 @@ export type HeartbeatSkipReason =
   | "overlap"
   | "pre_first_user_message"
   | "max_consecutive_runs"
-  | "max_daily_runs";
+  | "max_daily_runs"
+  | "quiesced";
 
 export interface HeartbeatRunRecord {
   id: string;

--- a/assistant/src/heartbeat/heartbeat-run-store.ts
+++ b/assistant/src/heartbeat/heartbeat-run-store.ts
@@ -1,4 +1,4 @@
-import { desc, eq, lt, sql } from "drizzle-orm";
+import { and, desc, eq, gt, isNotNull, lt, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../persistence/db-connection.js";
@@ -289,6 +289,32 @@ export function listHeartbeatRuns(
     .limit(limit)
     .all();
   return rows.map(parseRow);
+}
+
+/**
+ * Heartbeat runs currently `running`, capped to those started within
+ * `maxAgeMs`. The age bound matters: a run orphaned by a crash keeps its
+ * `running` status until a later boot's stale sweep relabels it, and an
+ * unbounded read would let that phantom row hold a drain open indefinitely.
+ */
+export function listRunningHeartbeatRuns(
+  maxAgeMs: number,
+): Array<{ runId: string; startedAt: number }> {
+  const db = getDb();
+  const cutoff = Date.now() - maxAgeMs;
+  return db
+    .select({ runId: heartbeatRuns.id, startedAt: heartbeatRuns.startedAt })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        eq(heartbeatRuns.status, "running"),
+        isNotNull(heartbeatRuns.startedAt),
+        gt(heartbeatRuns.startedAt, cutoff),
+      ),
+    )
+    .orderBy(desc(heartbeatRuns.startedAt))
+    .limit(20)
+    .all() as Array<{ runId: string; startedAt: number }>;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -11,6 +11,7 @@ import {
   shouldLogDiskPressureBackgroundSkip,
 } from "../daemon/disk-pressure-background-gate.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import { isLifecycleQuiesced } from "../persistence/lifecycle-quiesce.js";
 import {
   GUARDIAN_PERSONA_TEMPLATE,
   resolveGuardianPersona,
@@ -483,6 +484,20 @@ export class HeartbeatService {
         skipHeartbeatRun(runId, "disabled");
       }
       refreshBackgroundWakeIntentSoon("heartbeat-disabled");
+      return false;
+    }
+
+    // Drain guard: while a quiesce lease is active (a client is waiting for
+    // background work to finish before stopping the assistant), do not start
+    // new beats. Recorded as a skipped run so run history explains the gap.
+    if (!force && isLifecycleQuiesced()) {
+      log.info("Heartbeat skipped — quiesce lease active");
+      if (runId) {
+        skipHeartbeatRun(runId, "quiesced");
+      }
+      if (!this.cronMode) {
+        this.scheduleNextRun(config.intervalMs);
+      }
       return false;
     }
 

--- a/assistant/src/persistence/__tests__/lifecycle-quiesce.test.ts
+++ b/assistant/src/persistence/__tests__/lifecycle-quiesce.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The quiesce lease is the safety-critical piece of `vellum sleep --wait`:
+ * a stuck or misread lease would silently pause heartbeats, schedules, and
+ * memory jobs. These tests pin the fail-open contract (missing, malformed,
+ * or expired lease reads as "not quiesced") and the TTL clamps.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { setMemoryCheckpoint } from "../checkpoints.js";
+import { initializeDb } from "../db-init.js";
+import {
+  clearLifecycleQuiesce,
+  DEFAULT_QUIESCE_TTL_MS,
+  getLifecycleQuiesceUntil,
+  isLifecycleQuiesced,
+  MAX_QUIESCE_TTL_MS,
+  MIN_QUIESCE_TTL_MS,
+  setLifecycleQuiesce,
+} from "../lifecycle-quiesce.js";
+import { resetTestTables } from "../raw-query.js";
+
+const QUIESCE_KEY = "lifecycle:quiesce_until";
+
+await initializeDb();
+
+beforeEach(() => {
+  resetTestTables("memory_checkpoints");
+});
+
+describe("lifecycle-quiesce", () => {
+  test("no lease reads as not quiesced (fail-open default)", () => {
+    expect(isLifecycleQuiesced()).toBe(false);
+    expect(getLifecycleQuiesceUntil()).toBeNull();
+  });
+
+  test("setLifecycleQuiesce arms the lease for the requested TTL", () => {
+    const before = Date.now();
+    const until = setLifecycleQuiesce(DEFAULT_QUIESCE_TTL_MS);
+    expect(until).toBeGreaterThanOrEqual(before + DEFAULT_QUIESCE_TTL_MS);
+    expect(until).toBeLessThanOrEqual(Date.now() + DEFAULT_QUIESCE_TTL_MS);
+    expect(isLifecycleQuiesced()).toBe(true);
+    expect(getLifecycleQuiesceUntil()).toBe(until);
+  });
+
+  test("TTL is clamped to the sane range", () => {
+    const beforeMin = Date.now();
+    const untilMin = setLifecycleQuiesce(1);
+    expect(untilMin).toBeGreaterThanOrEqual(beforeMin + MIN_QUIESCE_TTL_MS);
+
+    const beforeMax = Date.now();
+    const untilMax = setLifecycleQuiesce(Number.MAX_SAFE_INTEGER);
+    expect(untilMax).toBeLessThanOrEqual(
+      Date.now() + MAX_QUIESCE_TTL_MS + 1_000,
+    );
+    expect(untilMax).toBeGreaterThanOrEqual(beforeMax + MAX_QUIESCE_TTL_MS);
+  });
+
+  test("re-arming extends the lease (refresh semantics)", () => {
+    const first = setLifecycleQuiesce(MIN_QUIESCE_TTL_MS);
+    const second = setLifecycleQuiesce(MAX_QUIESCE_TTL_MS);
+    expect(second).toBeGreaterThan(first);
+    expect(getLifecycleQuiesceUntil()).toBe(second);
+  });
+
+  test("an expired lease reads as not quiesced", () => {
+    setMemoryCheckpoint(QUIESCE_KEY, String(Date.now() - 1));
+    expect(isLifecycleQuiesced()).toBe(false);
+    expect(getLifecycleQuiesceUntil()).toBeNull();
+  });
+
+  test("a malformed lease value reads as not quiesced (fail-open)", () => {
+    setMemoryCheckpoint(QUIESCE_KEY, "not-a-number");
+    expect(isLifecycleQuiesced()).toBe(false);
+  });
+
+  test("clearLifecycleQuiesce releases an active lease", () => {
+    setLifecycleQuiesce(DEFAULT_QUIESCE_TTL_MS);
+    expect(isLifecycleQuiesced()).toBe(true);
+    clearLifecycleQuiesce();
+    expect(isLifecycleQuiesced()).toBe(false);
+  });
+});

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -2722,6 +2722,42 @@ export function isConversationProcessing(id: string): boolean {
 }
 
 /**
+ * Conversations currently mid-turn, longest-running first. Throws on a read
+ * failure — drain callers must distinguish "nothing processing" from "could
+ * not read", so this does not degrade to an empty list.
+ */
+export function listProcessingConversations(limit = 20): Array<{
+  conversationId: string;
+  title: string | null;
+  originChannel: string | null;
+  originInterface: string | null;
+  processingStartedAt: number;
+}> {
+  const rows = rawAll<{
+    id: string;
+    title: string | null;
+    origin_channel: string | null;
+    origin_interface: string | null;
+    processing_started_at: number;
+  }>(
+    "conversation:listProcessing",
+    `SELECT id, title, origin_channel, origin_interface, processing_started_at
+     FROM conversations
+     WHERE processing_started_at IS NOT NULL
+     ORDER BY processing_started_at ASC
+     LIMIT ?`,
+    limit,
+  );
+  return rows.map((row) => ({
+    conversationId: row.id,
+    title: row.title,
+    originChannel: row.origin_channel,
+    originInterface: row.origin_interface,
+    processingStartedAt: row.processing_started_at,
+  }));
+}
+
+/**
  * Highest stream `seq` whose content is durably persisted to this
  * conversation's message rows, read from the `conversations.seq` column. This
  * is the snapshot↔stream alignment baseline `/messages` returns so a client

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -895,6 +895,26 @@ export function resetRunningJobsToPending(): number {
   return rawMemoryChanges();
 }
 
+/** Currently-running memory jobs, oldest first — the drain-status view. */
+export function listRunningMemoryJobs(): Array<{
+  id: string;
+  type: string;
+  startedAt: number | null;
+}> {
+  const db = memoryDb();
+  return db
+    .select({
+      id: memoryJobs.id,
+      type: memoryJobs.type,
+      startedAt: memoryJobs.startedAt,
+    })
+    .from(memoryJobs)
+    .where(eq(memoryJobs.status, "running"))
+    .orderBy(asc(memoryJobs.startedAt))
+    .limit(20)
+    .all();
+}
+
 /**
  * Fail running jobs whose `startedAt` is older than `timeoutMs` ago.
  * Returns the number of jobs that were timed out.

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -13,6 +13,7 @@ import {
   isQdrantBreakerOpen,
   shouldAllowQdrantProbe,
 } from "./embeddings/qdrant-circuit-breaker.js";
+import { isLifecycleQuiesced } from "./lifecycle-quiesce.js";
 import { rawMemoryAll, rawMemoryChanges } from "./raw-query.js";
 import { memoryJobs } from "./schema/index.js";
 
@@ -642,6 +643,13 @@ export function claimMemoryJobs(
   restrictToTypes?: readonly MemoryJobType[],
 ): MemoryJob[] {
   if (limits.slowLlm <= 0 && limits.fast <= 0 && limits.embed <= 0) {
+    return [];
+  }
+
+  // Drain gate: while a quiesce lease is active, claim nothing so in-flight
+  // jobs finish and the queue drains to a stop. Enqueues are unaffected;
+  // claims resume when the lease expires. Fail-open via the lease read.
+  if (isLifecycleQuiesced()) {
     return [];
   }
 

--- a/assistant/src/persistence/lifecycle-quiesce.ts
+++ b/assistant/src/persistence/lifecycle-quiesce.ts
@@ -1,0 +1,80 @@
+/**
+ * Cross-process quiesce lease for graceful drains.
+ *
+ * `vellum sleep --wait` sets a short-TTL lease before stopping the assistant;
+ * every background-work claim/fire site (heartbeat, the daemon's
+ * watcher/sequence tick, the schedule worker's claim tick, the memory jobs
+ * worker) checks it and stops STARTING new work while it is active. Enqueue
+ * paths are unaffected — queued work runs after the restart.
+ *
+ * The lease is a single `memory_checkpoints` row on the main database so the
+ * daemon and both worker processes read the same value. The value is an
+ * epoch-ms deadline, refreshed by the waiting client, so a dead client can
+ * never silence background work for longer than one TTL. Readers fail OPEN —
+ * a missing, malformed, or unreadable lease means "not quiesced".
+ */
+
+import {
+  deleteMemoryCheckpoint,
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "./checkpoints.js";
+
+const QUIESCE_UNTIL_KEY = "lifecycle:quiesce_until";
+
+export const MIN_QUIESCE_TTL_MS = 5_000;
+export const MAX_QUIESCE_TTL_MS = 10 * 60_000;
+export const DEFAULT_QUIESCE_TTL_MS = 60_000;
+
+/**
+ * Arm (or refresh) the quiesce lease. Returns the lease deadline (epoch ms).
+ *
+ * Throws when the lease cannot be persisted — callers that promise a drain
+ * must surface the failure rather than pretend background work is paused.
+ */
+export function setLifecycleQuiesce(
+  ttlMs: number = DEFAULT_QUIESCE_TTL_MS,
+): number {
+  const clamped = Math.min(
+    Math.max(Math.floor(ttlMs), MIN_QUIESCE_TTL_MS),
+    MAX_QUIESCE_TTL_MS,
+  );
+  const quiescedUntil = Date.now() + clamped;
+  setMemoryCheckpoint(QUIESCE_UNTIL_KEY, String(quiescedUntil));
+  return quiescedUntil;
+}
+
+/**
+ * The active lease deadline, or null when no unexpired lease exists.
+ * Fail-open: any read or parse failure reads as "no lease".
+ */
+export function getLifecycleQuiesceUntil(): number | null {
+  let raw: string | null;
+  try {
+    raw = getMemoryCheckpoint(QUIESCE_UNTIL_KEY);
+  } catch {
+    return null;
+  }
+  if (raw == null) {
+    return null;
+  }
+  const until = Number.parseInt(raw, 10);
+  if (!Number.isFinite(until) || until <= Date.now()) {
+    return null;
+  }
+  return until;
+}
+
+/** True while an unexpired quiesce lease is active. Fail-open. */
+export function isLifecycleQuiesced(): boolean {
+  return getLifecycleQuiesceUntil() != null;
+}
+
+/** Drop the lease. Best-effort — a failure leaves the TTL to expire it. */
+export function clearLifecycleQuiesce(): void {
+  try {
+    deleteMemoryCheckpoint(QUIESCE_UNTIL_KEY);
+  } catch {
+    // Fail-soft: the lease self-expires.
+  }
+}

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-quiesce-gate.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-quiesce-gate.test.ts
@@ -1,13 +1,10 @@
 /**
- * The memory jobs worker's drain gate: while a quiesce lease is active,
- * `runMemoryJobsOnce` must claim nothing and enqueue no maintenance — and,
- * critically, an absent or expired lease must leave the worker fully open
- * (an inverted or stuck gate would silently stop retrospectives and
- * consolidation for every user).
- *
- * "Gate open" is probed through the sweep-checkpoint seed: an empty-queue
- * tick seeds `RETROSPECTIVE_SWEEP_CHECKPOINT` on its maintenance path, so
- * the checkpoint's presence proves the tick got past the gate.
+ * The memory queue's drain gate lives in `claimMemoryJobs` — while a quiesce
+ * lease is active the queue claims nothing, and, critically, an absent or
+ * expired lease must leave claiming fully open (an inverted or stuck gate
+ * would silently stop retrospectives and consolidation for every install).
+ * The gate sits in the persistence claim path rather than the worker loop so
+ * the plugin needs no import from outside its own directory.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -17,25 +14,23 @@ import { createMockLoggerModule } from "../../../../__tests__/helpers/mock-logge
 
 mock.module("../../../../util/logger.js", () => createMockLoggerModule());
 
-import {
-  getMemoryCheckpoint,
-  setMemoryCheckpoint,
-} from "../../../../persistence/checkpoints.js";
+import { setMemoryCheckpoint } from "../../../../persistence/checkpoints.js";
 import { getMemoryDb } from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
-import { enqueueMemoryJob } from "../../../../persistence/jobs-store.js";
+import {
+  claimMemoryJobs,
+  enqueueMemoryJob,
+} from "../../../../persistence/jobs-store.js";
 import {
   clearLifecycleQuiesce,
   setLifecycleQuiesce,
 } from "../../../../persistence/lifecycle-quiesce.js";
 import { resetTestTables } from "../../../../persistence/raw-query.js";
 import { memoryJobs } from "../../../../persistence/schema/index.js";
-import {
-  RETROSPECTIVE_SWEEP_CHECKPOINT,
-  runMemoryJobsOnce,
-} from "../jobs-worker.js";
+import { runMemoryJobsOnce } from "../jobs-worker.js";
 
 const QUIESCE_KEY = "lifecycle:quiesce_until";
+const ALL_LANES = { slowLlm: 1, fast: 1, embed: 1 };
 
 await initializeDb();
 getMemoryDb();
@@ -54,30 +49,43 @@ beforeEach(() => {
   clearLifecycleQuiesce();
 });
 
-describe("memory jobs worker quiesce gate", () => {
-  test("active lease: claims nothing and runs no maintenance", async () => {
-    const jobId = enqueueMemoryJob("memory_v2_consolidate", {});
+describe("memory job claim quiesce gate", () => {
+  test("active lease: claimMemoryJobs claims nothing", () => {
+    const jobId = enqueueMemoryJob("index_message_lexical", {});
+    setLifecycleQuiesce(60_000);
+
+    const claimed = claimMemoryJobs(ALL_LANES);
+
+    expect(claimed).toHaveLength(0);
+    expect(jobStatus(jobId)).toBe("pending");
+  });
+
+  test("no lease: claiming is fully open (fail-open default)", () => {
+    const jobId = enqueueMemoryJob("index_message_lexical", {});
+
+    const claimed = claimMemoryJobs(ALL_LANES);
+
+    expect(claimed).toHaveLength(1);
+    expect(jobStatus(jobId)).toBe("running");
+  });
+
+  test("expired lease: claiming is open again (TTL fail-open)", () => {
+    setMemoryCheckpoint(QUIESCE_KEY, String(Date.now() - 1));
+    const jobId = enqueueMemoryJob("index_message_lexical", {});
+
+    const claimed = claimMemoryJobs(ALL_LANES);
+
+    expect(claimed).toHaveLength(1);
+    expect(jobStatus(jobId)).toBe("running");
+  });
+
+  test("worker tick under an active lease leaves the queue untouched", async () => {
+    const jobId = enqueueMemoryJob("index_message_lexical", {});
     setLifecycleQuiesce(60_000);
 
     const processed = await runMemoryJobsOnce();
 
     expect(processed).toBe(0);
     expect(jobStatus(jobId)).toBe("pending");
-    // Maintenance never ran, so the sweep checkpoint was not seeded.
-    expect(getMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT)).toBeNull();
-  });
-
-  test("no lease: the tick reaches the maintenance path (gate open)", async () => {
-    await runMemoryJobsOnce();
-
-    expect(getMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT)).not.toBeNull();
-  });
-
-  test("expired lease: the gate is open again (TTL fail-open)", async () => {
-    setMemoryCheckpoint(QUIESCE_KEY, String(Date.now() - 1));
-
-    await runMemoryJobsOnce();
-
-    expect(getMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT)).not.toBeNull();
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-quiesce-gate.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/jobs-worker-quiesce-gate.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The memory jobs worker's drain gate: while a quiesce lease is active,
+ * `runMemoryJobsOnce` must claim nothing and enqueue no maintenance — and,
+ * critically, an absent or expired lease must leave the worker fully open
+ * (an inverted or stuck gate would silently stop retrospectives and
+ * consolidation for every user).
+ *
+ * "Gate open" is probed through the sweep-checkpoint seed: an empty-queue
+ * tick seeds `RETROSPECTIVE_SWEEP_CHECKPOINT` on its maintenance path, so
+ * the checkpoint's presence proves the tick got past the gate.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import { createMockLoggerModule } from "../../../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../../../util/logger.js", () => createMockLoggerModule());
+
+import {
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "../../../../persistence/checkpoints.js";
+import { getMemoryDb } from "../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../persistence/db-init.js";
+import { enqueueMemoryJob } from "../../../../persistence/jobs-store.js";
+import {
+  clearLifecycleQuiesce,
+  setLifecycleQuiesce,
+} from "../../../../persistence/lifecycle-quiesce.js";
+import { resetTestTables } from "../../../../persistence/raw-query.js";
+import { memoryJobs } from "../../../../persistence/schema/index.js";
+import {
+  RETROSPECTIVE_SWEEP_CHECKPOINT,
+  runMemoryJobsOnce,
+} from "../jobs-worker.js";
+
+const QUIESCE_KEY = "lifecycle:quiesce_until";
+
+await initializeDb();
+getMemoryDb();
+
+function jobStatus(id: string): string | undefined {
+  return getMemoryDb()!
+    .select({ status: memoryJobs.status })
+    .from(memoryJobs)
+    .where(eq(memoryJobs.id, id))
+    .get()?.status;
+}
+
+beforeEach(() => {
+  getMemoryDb()!.run("DELETE FROM memory_jobs");
+  resetTestTables("memory_checkpoints");
+  clearLifecycleQuiesce();
+});
+
+describe("memory jobs worker quiesce gate", () => {
+  test("active lease: claims nothing and runs no maintenance", async () => {
+    const jobId = enqueueMemoryJob("memory_v2_consolidate", {});
+    setLifecycleQuiesce(60_000);
+
+    const processed = await runMemoryJobsOnce();
+
+    expect(processed).toBe(0);
+    expect(jobStatus(jobId)).toBe("pending");
+    // Maintenance never ran, so the sweep checkpoint was not seeded.
+    expect(getMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT)).toBeNull();
+  });
+
+  test("no lease: the tick reaches the maintenance path (gate open)", async () => {
+    await runMemoryJobsOnce();
+
+    expect(getMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT)).not.toBeNull();
+  });
+
+  test("expired lease: the gate is open again (TTL fail-open)", async () => {
+    setMemoryCheckpoint(QUIESCE_KEY, String(Date.now() - 1));
+
+    await runMemoryJobsOnce();
+
+    expect(getMemoryCheckpoint(RETROSPECTIVE_SWEEP_CHECKPOINT)).not.toBeNull();
+  });
+});

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -57,6 +57,7 @@ import {
   resetRunningJobsToPending,
   SLOW_LLM_JOB_TYPES,
 } from "../../../persistence/jobs-store.js";
+import { isLifecycleQuiesced } from "../../../persistence/lifecycle-quiesce.js";
 import type { JobHandler } from "../../types.js";
 import { sweepOrphanConversationMemoryTables } from "./conversation-memory-orphan-sweep.js";
 import { getLogger } from "./logging.js";
@@ -361,6 +362,14 @@ export async function runMemoryJobsOnce(
         "Memory jobs worker skipped during disk pressure cleanup mode",
       );
     }
+    return 0;
+  }
+
+  // Drain guard: while a quiesce lease is active, claim nothing and enqueue
+  // no maintenance so the in-flight job (if any) finishes and the queue
+  // drains to a stop. Fail-open — an unreadable lease never pauses the queue.
+  if (isLifecycleQuiesced()) {
+    log.debug("Memory jobs worker idle — quiesce lease active");
     return 0;
   }
 

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -57,7 +57,6 @@ import {
   resetRunningJobsToPending,
   SLOW_LLM_JOB_TYPES,
 } from "../../../persistence/jobs-store.js";
-import { isLifecycleQuiesced } from "../../../persistence/lifecycle-quiesce.js";
 import type { JobHandler } from "../../types.js";
 import { sweepOrphanConversationMemoryTables } from "./conversation-memory-orphan-sweep.js";
 import { getLogger } from "./logging.js";
@@ -362,14 +361,6 @@ export async function runMemoryJobsOnce(
         "Memory jobs worker skipped during disk pressure cleanup mode",
       );
     }
-    return 0;
-  }
-
-  // Drain guard: while a quiesce lease is active, claim nothing and enqueue
-  // no maintenance so the in-flight job (if any) finishes and the queue
-  // drains to a stop. Fail-open — an unreadable lease never pauses the queue.
-  if (isLifecycleQuiesced()) {
-    log.debug("Memory jobs worker idle — quiesce lease active");
     return 0;
   }
 

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -101,6 +101,7 @@ import { ROUTES as VERCEL_ROUTES } from "./integrations/vercel.js";
 import { ROUTES as INTERNAL_OAUTH_ROUTES } from "./internal-oauth-routes.js";
 import { ROUTES as INTERNAL_TELEMETRY_ROUTES } from "./internal-telemetry-routes.js";
 import { ROUTES as INTERNAL_TWILIO_ROUTES } from "./internal-twilio-routes.js";
+import { ROUTES as LIFECYCLE_ROUTES } from "./lifecycle-routes.js";
 import { ROUTES as LIVE_VOICE_ROUTES } from "./live-voice-routes.js";
 import { ROUTES as LLM_CALL_SITES_ROUTES } from "./llm-call-sites-routes.js";
 import { ROUTES as LOG_EXPORT_ROUTES } from "./log-export-routes.js";
@@ -241,6 +242,7 @@ export const ROUTES: RouteDefinition[] = [
   ...MCP_AUTH_ROUTES,
   ...OAUTH_CONNECT_ROUTES,
   ...INTERNAL_TWILIO_ROUTES,
+  ...LIFECYCLE_ROUTES,
   ...LIVE_VOICE_ROUTES,
   ...LOG_EXPORT_ROUTES,
   ...LLM_CALL_SITES_ROUTES,

--- a/assistant/src/runtime/routes/lifecycle-routes.ts
+++ b/assistant/src/runtime/routes/lifecycle-routes.ts
@@ -1,0 +1,164 @@
+/**
+ * Lifecycle drain endpoints backing `vellum sleep --wait`.
+ *
+ * The quiesce lease pauses the STARTING of new background LLM work (heartbeat
+ * beats, schedule/watcher/sequence claims, memory-job claims) across the
+ * daemon and its worker processes; drain-status reports what is still in
+ * flight so a client can wait for the assistant to go idle before stopping
+ * it. Enqueue paths stay open — work queued during a drain runs after the
+ * next start. The lease is TTL-bound and refreshed by the waiting client, so
+ * an abandoned drain can never leave background work paused.
+ */
+
+import { z } from "zod";
+
+import { readActiveConversations } from "../../monitoring/active-conversations.js";
+import { listRunningMemoryJobs } from "../../persistence/jobs-store.js";
+import {
+  clearLifecycleQuiesce,
+  DEFAULT_QUIESCE_TTL_MS,
+  getLifecycleQuiesceUntil,
+  setLifecycleQuiesce,
+} from "../../persistence/lifecycle-quiesce.js";
+import { listRunningScheduleRuns } from "../../schedule/schedule-store.js";
+import { getLogger } from "../../util/logger.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { BadRequestError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const log = getLogger("lifecycle-routes");
+
+const quiesceResponseSchema = z.object({
+  quiescedUntil: z
+    .number()
+    .describe("Epoch ms when the quiesce lease expires."),
+});
+
+const activeConversationSchema = z.object({
+  conversationId: z.string(),
+  title: z.string().nullable(),
+  originChannel: z.string().nullable(),
+  originInterface: z.string().nullable(),
+  processingStartedAt: z.number(),
+});
+
+const runningMemoryJobSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  startedAt: z.number().nullable(),
+});
+
+const runningScheduleRunSchema = z.object({
+  runId: z.string(),
+  scheduleName: z.string().nullable(),
+  startedAt: z.number(),
+});
+
+const drainStatusResponseSchema = z.object({
+  quiescedUntil: z.number().nullable(),
+  idle: z
+    .boolean()
+    .describe(
+      "True when no conversation turn, memory job, or schedule run is in flight.",
+    ),
+  activeConversations: z.array(activeConversationSchema),
+  memoryJobs: z.array(runningMemoryJobSchema),
+  scheduleRuns: z.array(runningScheduleRunSchema),
+});
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "quiesceLifecycle",
+    endpoint: "lifecycle/quiesce",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Arm or refresh the drain quiesce lease",
+    description:
+      "Pauses the starting of new background work (heartbeat, schedules, watchers, sequences, memory jobs) for the lease TTL. Refresh by calling again; the lease self-expires so an abandoned drain never leaves background work paused.",
+    tags: ["system"],
+    requestBody: z.object({
+      ttlMs: z
+        .number()
+        .optional()
+        .describe("Lease TTL in ms (clamped to a sane range)."),
+    }),
+    responseBody: quiesceResponseSchema,
+    handler: (args: RouteHandlerArgs) => {
+      const raw = args.body?.ttlMs;
+      let ttlMs = DEFAULT_QUIESCE_TTL_MS;
+      if (raw !== undefined) {
+        if (typeof raw !== "number" || !Number.isFinite(raw)) {
+          throw new BadRequestError("ttlMs must be a finite number");
+        }
+        ttlMs = raw;
+      }
+      const quiescedUntil = setLifecycleQuiesce(ttlMs);
+      log.info({ quiescedUntil }, "Lifecycle quiesce lease armed");
+      return { quiescedUntil };
+    },
+  },
+  {
+    operationId: "releaseLifecycleQuiesce",
+    endpoint: "lifecycle/quiesce",
+    method: "DELETE",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Release the drain quiesce lease",
+    description:
+      "Resumes background work immediately instead of waiting for the lease TTL to expire (e.g. when a drain is cancelled).",
+    tags: ["system"],
+    responseBody: z.object({ released: z.boolean() }),
+    handler: () => {
+      clearLifecycleQuiesce();
+      log.info("Lifecycle quiesce lease released");
+      return { released: true };
+    },
+  },
+  {
+    operationId: "getLifecycleDrainStatus",
+    endpoint: "lifecycle/drain-status",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "In-flight background work",
+    description:
+      "Reports conversation turns, memory jobs, and schedule runs currently in flight, plus the active quiesce lease. `idle: true` means it is safe to stop the assistant without interrupting work.",
+    tags: ["system"],
+    responseBody: drainStatusResponseSchema,
+    handler: () => {
+      const activeConversations = readActiveConversations() ?? [];
+      // Best-effort per source: a store that cannot be read reports empty
+      // rather than failing the whole snapshot — the caller's wait then
+      // converges on what is observable.
+      let memoryJobs: ReturnType<typeof listRunningMemoryJobs> = [];
+      try {
+        memoryJobs = listRunningMemoryJobs();
+      } catch (err) {
+        log.warn({ err }, "Drain status: memory jobs unavailable");
+      }
+      let scheduleRuns: ReturnType<typeof listRunningScheduleRuns> = [];
+      try {
+        scheduleRuns = listRunningScheduleRuns();
+      } catch (err) {
+        log.warn({ err }, "Drain status: schedule runs unavailable");
+      }
+      return {
+        quiescedUntil: getLifecycleQuiesceUntil(),
+        idle:
+          activeConversations.length === 0 &&
+          memoryJobs.length === 0 &&
+          scheduleRuns.length === 0,
+        activeConversations,
+        memoryJobs,
+        scheduleRuns,
+      };
+    },
+  },
+];

--- a/assistant/src/runtime/routes/lifecycle-routes.ts
+++ b/assistant/src/runtime/routes/lifecycle-routes.ts
@@ -12,7 +12,8 @@
 
 import { z } from "zod";
 
-import { readActiveConversations } from "../../monitoring/active-conversations.js";
+import { listRunningHeartbeatRuns } from "../../heartbeat/heartbeat-run-store.js";
+import { listProcessingConversations } from "../../persistence/conversation-crud.js";
 import { listRunningMemoryJobs } from "../../persistence/jobs-store.js";
 import {
   clearLifecycleQuiesce,
@@ -61,18 +62,33 @@ const runningWorkflowRunSchema = z.object({
   startedAt: z.number().nullable(),
 });
 
+const runningHeartbeatRunSchema = z.object({
+  runId: z.string(),
+  startedAt: z.number(),
+});
+
 const drainStatusResponseSchema = z.object({
   quiescedUntil: z.number().nullable(),
   idle: z
     .boolean()
     .describe(
-      "True when no conversation turn, memory job, schedule run, or workflow run is in flight.",
+      "True when no conversation turn, memory job, schedule run, workflow run, or heartbeat run is in flight.",
     ),
   activeConversations: z.array(activeConversationSchema),
   memoryJobs: z.array(runningMemoryJobSchema),
   scheduleRuns: z.array(runningScheduleRunSchema),
   workflowRuns: z.array(runningWorkflowRunSchema),
+  heartbeatRuns: z.array(runningHeartbeatRunSchema),
 });
+
+/**
+ * Age cap for `running` heartbeat rows in the drain snapshot. A beat orphaned
+ * by a crash keeps its `running` status until a later boot's stale sweep, so
+ * an unbounded read would let a phantom row hold the drain open indefinitely.
+ * Real beats finish well inside this bound (the runner enforces its own
+ * timeout).
+ */
+const HEARTBEAT_RUN_MAX_AGE_MS = 15 * 60_000;
 
 export const ROUTES: RouteDefinition[] = [
   {
@@ -137,56 +153,46 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "In-flight background work",
     description:
-      "Reports conversation turns, memory jobs, and schedule runs currently in flight, plus the active quiesce lease. `idle: true` means it is safe to stop the assistant without interrupting work.",
+      "Reports conversation turns, memory jobs, schedule runs, workflow runs, and heartbeat runs currently in flight, plus the active quiesce lease. `idle: true` means it is safe to stop the assistant without interrupting work.",
     tags: ["system"],
     responseBody: drainStatusResponseSchema,
     handler: () => {
-      const activeConversations = readActiveConversations() ?? [];
-      // Best-effort per source: a store that cannot be read reports empty
-      // rather than failing the whole snapshot — the caller's wait then
-      // converges on what is observable.
-      let memoryJobs: ReturnType<typeof listRunningMemoryJobs> = [];
-      try {
-        memoryJobs = listRunningMemoryJobs();
-      } catch (err) {
-        log.warn({ err }, "Drain status: memory jobs unavailable");
-      }
-      let scheduleRuns: ReturnType<typeof listRunningScheduleRuns> = [];
-      try {
-        scheduleRuns = listRunningScheduleRuns();
-      } catch (err) {
-        log.warn({ err }, "Drain status: schedule runs unavailable");
-      }
+      // Every read THROWS on failure (surfacing as a 5xx the client retries):
+      // for a drain decision, a failed read must not pass for proof of
+      // absence, or the client stops the assistant over unobservable
+      // in-flight work. Only the quiesce GATES are fail-open — this snapshot
+      // fails closed.
+      const activeConversations = listProcessingConversations();
+      const memoryJobs = listRunningMemoryJobs();
+      const scheduleRuns = listRunningScheduleRuns();
       // Workflows launched by a schedule outlive their schedule run — the
       // scheduler fires them and completes its own run row immediately — so
       // a running workflow must hold the drain open in its own right.
-      let workflowRuns: Array<{
-        runId: string;
-        name: string | null;
-        startedAt: number | null;
-      }> = [];
-      try {
-        workflowRuns = listWorkflowRuns({ limit: 20, status: "running" }).map(
-          (run) => ({
-            runId: run.id,
-            name: run.name,
-            startedAt: run.createdAt,
-          }),
-        );
-      } catch (err) {
-        log.warn({ err }, "Drain status: workflow runs unavailable");
-      }
+      const workflowRuns = listWorkflowRuns({
+        limit: 20,
+        status: "running",
+      }).map((run) => ({
+        runId: run.id,
+        name: run.name,
+        startedAt: run.createdAt,
+      }));
+      // A beat between startHeartbeatRun() and its background conversation
+      // existing (e.g. mid credential-health check) has a running row but no
+      // processing conversation yet.
+      const heartbeatRuns = listRunningHeartbeatRuns(HEARTBEAT_RUN_MAX_AGE_MS);
       return {
         quiescedUntil: getLifecycleQuiesceUntil(),
         idle:
           activeConversations.length === 0 &&
           memoryJobs.length === 0 &&
           scheduleRuns.length === 0 &&
-          workflowRuns.length === 0,
+          workflowRuns.length === 0 &&
+          heartbeatRuns.length === 0,
         activeConversations,
         memoryJobs,
         scheduleRuns,
         workflowRuns,
+        heartbeatRuns,
       };
     },
   },

--- a/assistant/src/runtime/routes/lifecycle-routes.ts
+++ b/assistant/src/runtime/routes/lifecycle-routes.ts
@@ -22,6 +22,7 @@ import {
 } from "../../persistence/lifecycle-quiesce.js";
 import { listRunningScheduleRuns } from "../../schedule/schedule-store.js";
 import { getLogger } from "../../util/logger.js";
+import { listRuns as listWorkflowRuns } from "../../workflows/journal-store.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -54,16 +55,23 @@ const runningScheduleRunSchema = z.object({
   startedAt: z.number(),
 });
 
+const runningWorkflowRunSchema = z.object({
+  runId: z.string(),
+  name: z.string().nullable(),
+  startedAt: z.number().nullable(),
+});
+
 const drainStatusResponseSchema = z.object({
   quiescedUntil: z.number().nullable(),
   idle: z
     .boolean()
     .describe(
-      "True when no conversation turn, memory job, or schedule run is in flight.",
+      "True when no conversation turn, memory job, schedule run, or workflow run is in flight.",
     ),
   activeConversations: z.array(activeConversationSchema),
   memoryJobs: z.array(runningMemoryJobSchema),
   scheduleRuns: z.array(runningScheduleRunSchema),
+  workflowRuns: z.array(runningWorkflowRunSchema),
 });
 
 export const ROUTES: RouteDefinition[] = [
@@ -149,15 +157,36 @@ export const ROUTES: RouteDefinition[] = [
       } catch (err) {
         log.warn({ err }, "Drain status: schedule runs unavailable");
       }
+      // Workflows launched by a schedule outlive their schedule run — the
+      // scheduler fires them and completes its own run row immediately — so
+      // a running workflow must hold the drain open in its own right.
+      let workflowRuns: Array<{
+        runId: string;
+        name: string | null;
+        startedAt: number | null;
+      }> = [];
+      try {
+        workflowRuns = listWorkflowRuns({ limit: 20, status: "running" }).map(
+          (run) => ({
+            runId: run.id,
+            name: run.name,
+            startedAt: run.createdAt,
+          }),
+        );
+      } catch (err) {
+        log.warn({ err }, "Drain status: workflow runs unavailable");
+      }
       return {
         quiescedUntil: getLifecycleQuiesceUntil(),
         idle:
           activeConversations.length === 0 &&
           memoryJobs.length === 0 &&
-          scheduleRuns.length === 0,
+          scheduleRuns.length === 0 &&
+          workflowRuns.length === 0,
         activeConversations,
         memoryJobs,
         scheduleRuns,
+        workflowRuns,
       };
     },
   },

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -1114,6 +1114,45 @@ export function describeCronExpression(expr: string | null): string {
 }
 
 /**
+ * Return a claimed-but-not-started schedule to the queue (drain deferral).
+ *
+ * Restores everything the claim mutated before any execution began:
+ * `nextRunAt` is pulled to `nextRetryAt`, a one-shot's `firing` reverts to
+ * `active`, and `enabled` is restored — a bounded recurring schedule's final
+ * occurrence is claimed by exhausting the job (`enabled = false`,
+ * `nextRunAt = 0`), so without the restore that deferred final occurrence
+ * would never fire.
+ */
+export async function deferClaimedSchedule(
+  id: string,
+  nextRetryAt: number,
+): Promise<void> {
+  const db = getDb();
+  const now = Date.now();
+  await withSqliteRetry(
+    () => {
+      db.update(scheduleJobs)
+        .set({ nextRunAt: nextRetryAt, enabled: true, updatedAt: now })
+        .where(eq(scheduleJobs.id, id))
+        .run();
+      return rawChanges() > 0;
+    },
+    { op: "deferClaimedSchedule.requeue", context: { scheduleId: id } },
+  );
+  await withSqliteRetry(
+    () => {
+      db.update(scheduleJobs)
+        .set({ status: "active", updatedAt: now })
+        .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
+        .run();
+      return rawChanges() > 0;
+    },
+    { op: "deferClaimedSchedule.status", context: { scheduleId: id } },
+  );
+  notifySchedulesChanged();
+}
+
+/**
  * Set the next retry time for a schedule and revert one-shot status from
  * "firing" to "active" so the scheduler will claim it again when nextRetryAt
  * arrives. No-op for recurring schedules (they stay in their current status).

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -750,6 +750,27 @@ export async function createScheduleRun(
   return id;
 }
 
+/** Currently-running schedule runs with their job names, oldest first. */
+export function listRunningScheduleRuns(): Array<{
+  runId: string;
+  scheduleName: string | null;
+  startedAt: number;
+}> {
+  const db = getDb();
+  return db
+    .select({
+      runId: scheduleRuns.id,
+      scheduleName: scheduleJobs.name,
+      startedAt: scheduleRuns.startedAt,
+    })
+    .from(scheduleRuns)
+    .leftJoin(scheduleJobs, eq(scheduleRuns.jobId, scheduleJobs.id))
+    .where(eq(scheduleRuns.status, "running"))
+    .orderBy(asc(scheduleRuns.startedAt))
+    .limit(20)
+    .all();
+}
+
 export async function setScheduleRunConversationId(
   runId: string,
   conversationId: string,

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -3,6 +3,7 @@ import { and, asc, desc, eq, isNull, lt, lte, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../persistence/db-connection.js";
+import { isLifecycleQuiesced } from "../persistence/lifecycle-quiesce.js";
 import { rawChanges } from "../persistence/raw-query.js";
 import { scheduleJobs, scheduleRuns } from "../persistence/schema/index.js";
 import { publishSchedulesChanged } from "../runtime/sync/resource-sync-events.js";
@@ -465,6 +466,15 @@ export async function deleteSchedule(id: string): Promise<boolean> {
  * next_run_at <= now and enabled = true and cron_expression IS NULL.
  */
 export async function claimDueSchedules(now: number): Promise<ScheduleJob[]> {
+  // Drain gate: while a quiesce lease is active, claim nothing so in-flight
+  // runs can drain before a stop. The check lives here — immediately before
+  // the claim writes — rather than at the tick boundary, to shrink the window
+  // in which a lease armed mid-tick could miss a claim that already passed an
+  // earlier check. Fail-open via the lease read.
+  if (isLifecycleQuiesced()) {
+    return [];
+  }
+
   const db = getDb();
   const claimed: ScheduleJob[] = [];
 

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -9,6 +9,7 @@ import { processMessage } from "../daemon/process-message.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { getConversation } from "../persistence/conversation-crud.js";
+import { isLifecycleQuiesced } from "../persistence/lifecycle-quiesce.js";
 import { invalidateAssistantInferredItemsForConversation } from "../plugins/defaults/memory/task-memory-cleanup.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
@@ -434,6 +435,13 @@ export async function runScheduleDueWorkOnce(
     return result;
   }
 
+  // Drain guard: while a quiesce lease is active, start no new watcher or
+  // sequence work so in-flight turns can drain before a stop.
+  if (isLifecycleQuiesced()) {
+    log.debug("Schedule tick skipped — quiesce lease active");
+    return result;
+  }
+
   // ── Watchers (event-driven polling) ────────────────────────────────
   try {
     const watcherProcessed = await runWatchersOnce(emitWatcherNotifySignal);
@@ -487,6 +495,13 @@ export async function runDueSchedulesOnce(
         "Due-schedule run skipped during disk pressure cleanup mode",
       );
     }
+    return result;
+  }
+
+  // Drain guard: while a quiesce lease is active, claim no due schedules so
+  // in-flight runs can drain before a stop. Claims resume when it expires.
+  if (isLifecycleQuiesced()) {
+    log.debug("Due-schedule run skipped — quiesce lease active");
     return result;
   }
 

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -34,6 +34,7 @@ import {
   completeOneShot,
   completeScheduleRun,
   createScheduleRun,
+  deferClaimedSchedule,
   failOneShotPermanently,
   getLastScheduleConversationId,
   resetRetryCount,
@@ -503,13 +504,12 @@ export async function runDueSchedulesOnce(
   result.claimed = jobs.length;
   for (const job of jobs) {
     // Lease re-check per claimed job: a lease armed between the batch claim
-    // and this job's start returns the job to the queue untouched (nextRunAt
-    // pulled to the deferral time; a one-shot's `firing` reverts to `active`)
-    // instead of starting work the drain snapshot cannot see — notify mode
-    // especially, which emits before any run row exists.
+    // and this job's start returns the job to the queue untouched instead of
+    // starting work the drain snapshot cannot see — notify mode especially,
+    // which emits before any run row exists.
     if (isLifecycleQuiesced()) {
       try {
-        await scheduleRetry(job.id, Date.now() + QUIESCE_DEFER_MS);
+        await deferClaimedSchedule(job.id, Date.now() + QUIESCE_DEFER_MS);
       } catch (err) {
         log.warn(
           { err, jobId: job.id },

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -435,12 +435,8 @@ export async function runScheduleDueWorkOnce(
     return result;
   }
 
-  // Drain guard: while a quiesce lease is active, start no new watcher or
-  // sequence work so in-flight turns can drain before a stop.
-  if (isLifecycleQuiesced()) {
-    log.debug("Schedule tick skipped — quiesce lease active");
-    return result;
-  }
+  // The drain quiesce gates live inside claimDueWatchers and
+  // claimDueEnrollments, immediately before their claim writes.
 
   // ── Watchers (event-driven polling) ────────────────────────────────
   try {
@@ -471,6 +467,9 @@ export async function runScheduleDueWorkOnce(
  * (`worker.ts`). Claims are atomic in the schedule store, so overlapping ticks
  * cannot double-run a job another claim already took.
  */
+/** How far a claimed-but-quiesced schedule is pushed back into the queue. */
+const QUIESCE_DEFER_MS = 30_000;
+
 export async function runDueSchedulesOnce(
   now: number = Date.now(),
 ): Promise<SchedulerDueWorkResult> {
@@ -503,6 +502,24 @@ export async function runDueSchedulesOnce(
   const jobs = await claimDueSchedules(now);
   result.claimed = jobs.length;
   for (const job of jobs) {
+    // Lease re-check per claimed job: a lease armed between the batch claim
+    // and this job's start returns the job to the queue untouched (nextRunAt
+    // pulled to the deferral time; a one-shot's `firing` reverts to `active`)
+    // instead of starting work the drain snapshot cannot see — notify mode
+    // especially, which emits before any run row exists.
+    if (isLifecycleQuiesced()) {
+      try {
+        await scheduleRetry(job.id, Date.now() + QUIESCE_DEFER_MS);
+      } catch (err) {
+        log.warn(
+          { err, jobId: job.id },
+          "Failed to defer claimed schedule under quiesce",
+        );
+      }
+      result.skipped += 1;
+      continue;
+    }
+
     const isOneShot = job.expression == null;
 
     // ── Notify mode (one-shot or recurring) ─────────────────────────

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -498,13 +498,8 @@ export async function runDueSchedulesOnce(
     return result;
   }
 
-  // Drain guard: while a quiesce lease is active, claim no due schedules so
-  // in-flight runs can drain before a stop. Claims resume when it expires.
-  if (isLifecycleQuiesced()) {
-    log.debug("Due-schedule run skipped — quiesce lease active");
-    return result;
-  }
-
+  // The drain quiesce gate lives inside claimDueSchedules, immediately
+  // before the claim writes.
   const jobs = await claimDueSchedules(now);
   result.claimed = jobs.length;
   for (const job of jobs) {

--- a/assistant/src/sequence/store.ts
+++ b/assistant/src/sequence/store.ts
@@ -11,6 +11,7 @@ import { and, asc, eq, lte, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../persistence/db-connection.js";
+import { isLifecycleQuiesced } from "../persistence/lifecycle-quiesce.js";
 import { rawChanges } from "../persistence/raw-query.js";
 import { sequenceEnrollments, sequences } from "../persistence/schema/index.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
@@ -224,6 +225,13 @@ export function claimDueEnrollments(
   now: number,
   limit = 10,
 ): SequenceEnrollment[] {
+  // Drain gate: while a quiesce lease is active, claim nothing — a sequence
+  // step's outreach starts before any row the drain snapshot can see.
+  // Fail-open via the lease read.
+  if (isLifecycleQuiesced()) {
+    return [];
+  }
+
   const db = getDb();
   const candidates = db
     .select()

--- a/assistant/src/watcher/watcher-store.ts
+++ b/assistant/src/watcher/watcher-store.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, gte, lte } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../persistence/db-connection.js";
+import { isLifecycleQuiesced } from "../persistence/lifecycle-quiesce.js";
 import { rawChanges } from "../persistence/raw-query.js";
 import { watcherEvents, watchers } from "../persistence/schema/index.js";
 import { truncate } from "../util/truncate.js";
@@ -158,6 +159,13 @@ export function deleteWatcher(id: string): boolean {
  * to 'polling' using optimistic locking on the current nextPollAt.
  */
 export function claimDueWatchers(now: number): Watcher[] {
+  // Drain gate: while a quiesce lease is active, claim nothing — a watcher
+  // poll runs provider requests that create no row the drain snapshot can
+  // see, so it must not start at all. Fail-open via the lease read.
+  if (isLifecycleQuiesced()) {
+    return [];
+  }
+
   const db = getDb();
   const candidates = db
     .select()

--- a/cli/src/__tests__/drain.test.ts
+++ b/cli/src/__tests__/drain.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+
+import { drainAssistant, parseWaitDuration } from "../lib/drain.js";
+
+const BASE = "http://127.0.0.1:7823";
+
+interface RecordedCall {
+  url: string;
+  method: string;
+}
+
+/**
+ * Fetch stub: routes requests through `handler` and records every call.
+ * Throwing from the handler simulates a network failure.
+ */
+function fetchStub(
+  handler: (url: string, method: string) => Response | Promise<Response>,
+): {
+  impl: (url: string, init?: RequestInit) => Promise<Response>;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const impl = async (url: string, init?: RequestInit): Promise<Response> => {
+    const method = init?.method ?? "GET";
+    calls.push({ url, method });
+    return handler(url, method);
+  };
+  return { impl, calls };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function busyStatus(): unknown {
+  return {
+    quiescedUntil: Date.now() + 60_000,
+    idle: false,
+    activeConversations: [],
+    memoryJobs: [
+      { id: "job-1", type: "memory_retrospective", startedAt: Date.now() },
+    ],
+    scheduleRuns: [],
+  };
+}
+
+function idleStatus(): unknown {
+  return {
+    quiescedUntil: Date.now() + 60_000,
+    idle: true,
+    activeConversations: [],
+    memoryJobs: [],
+    scheduleRuns: [],
+  };
+}
+
+describe("parseWaitDuration", () => {
+  test("parses bare seconds, seconds, and minutes", () => {
+    expect(parseWaitDuration("90")).toBe(90_000);
+    expect(parseWaitDuration("90s")).toBe(90_000);
+    expect(parseWaitDuration("10m")).toBe(600_000);
+    expect(parseWaitDuration(" 5s ")).toBe(5_000);
+  });
+
+  test("rejects invalid durations", () => {
+    expect(parseWaitDuration("0")).toBeNull();
+    expect(parseWaitDuration("abc")).toBeNull();
+    expect(parseWaitDuration("5x")).toBeNull();
+    expect(parseWaitDuration("-5")).toBeNull();
+    expect(parseWaitDuration("")).toBeNull();
+  });
+});
+
+describe("drainAssistant", () => {
+  test("arms the lease, narrates, and returns drained when work finishes", async () => {
+    let statusCalls = 0;
+    const { impl, calls } = fetchStub((url, method) => {
+      if (url.endsWith("/v1/lifecycle/quiesce") && method === "POST") {
+        return jsonResponse({ quiescedUntil: Date.now() + 60_000 });
+      }
+      statusCalls += 1;
+      return jsonResponse(statusCalls < 3 ? busyStatus() : idleStatus());
+    });
+    const lines: string[] = [];
+
+    const outcome = await drainAssistant({
+      baseUrl: BASE,
+      token: "tok",
+      deadlineAt: null,
+      pollIntervalMs: 1,
+      fetchImpl: impl,
+      log: (line) => lines.push(line),
+    });
+
+    expect(outcome).toBe("drained");
+    expect(calls[0]).toEqual({
+      url: `${BASE}/v1/lifecycle/quiesce`,
+      method: "POST",
+    });
+    expect(lines.join("\n")).toContain("memory memory_retrospective");
+  });
+
+  test("returns unsupported when the assistant lacks the quiesce route", async () => {
+    const { impl } = fetchStub(() => jsonResponse({ error: "nope" }, 404));
+
+    const outcome = await drainAssistant({
+      baseUrl: BASE,
+      token: "tok",
+      deadlineAt: null,
+      fetchImpl: impl,
+      log: () => {},
+    });
+
+    expect(outcome).toBe("unsupported");
+  });
+
+  test("returns unreachable when the initial lease request fails", async () => {
+    const { impl } = fetchStub(() => {
+      throw new Error("connection refused");
+    });
+
+    const outcome = await drainAssistant({
+      baseUrl: BASE,
+      token: "tok",
+      deadlineAt: null,
+      fetchImpl: impl,
+      log: () => {},
+    });
+
+    expect(outcome).toBe("unreachable");
+  });
+
+  test("returns timeout when the deadline passes while still busy", async () => {
+    const { impl } = fetchStub((_url, method) =>
+      method === "POST"
+        ? jsonResponse({ quiescedUntil: Date.now() + 60_000 })
+        : jsonResponse(busyStatus()),
+    );
+
+    const outcome = await drainAssistant({
+      baseUrl: BASE,
+      token: "tok",
+      deadlineAt: Date.now() + 40,
+      pollIntervalMs: 1,
+      fetchImpl: impl,
+      log: () => {},
+    });
+
+    expect(outcome).toBe("timeout");
+  });
+
+  test("returns unreachable after sustained status failures", async () => {
+    const { impl } = fetchStub((_url, method) => {
+      if (method === "POST") {
+        return jsonResponse({ quiescedUntil: Date.now() + 60_000 });
+      }
+      throw new Error("boom");
+    });
+
+    const outcome = await drainAssistant({
+      baseUrl: BASE,
+      token: "tok",
+      deadlineAt: null,
+      pollIntervalMs: 1,
+      fetchImpl: impl,
+      log: () => {},
+    });
+
+    expect(outcome).toBe("unreachable");
+  });
+
+  test("cancel releases the lease and returns cancelled", async () => {
+    const controller = new AbortController();
+    const { impl, calls } = fetchStub((_url, method) => {
+      if (method === "POST") {
+        return jsonResponse({ quiescedUntil: Date.now() + 60_000 });
+      }
+      if (method === "DELETE") {
+        return jsonResponse({ released: true });
+      }
+      // First busy status arrives, then the user hits Ctrl-C.
+      controller.abort();
+      return jsonResponse(busyStatus());
+    });
+
+    const outcome = await drainAssistant({
+      baseUrl: BASE,
+      token: "tok",
+      deadlineAt: null,
+      pollIntervalMs: 1,
+      fetchImpl: impl,
+      signal: controller.signal,
+      log: () => {},
+    });
+
+    expect(outcome).toBe("cancelled");
+    expect(
+      calls.some(
+        (c) => c.method === "DELETE" && c.url.endsWith("/v1/lifecycle/quiesce"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/cli/src/__tests__/drain.test.ts
+++ b/cli/src/__tests__/drain.test.ts
@@ -75,6 +75,10 @@ function idleStatus(): unknown {
   };
 }
 
+function idleExpiredLeaseStatus(): unknown {
+  return { ...(idleStatus() as Record<string, unknown>), quiescedUntil: null };
+}
+
 describe("parseWaitDuration", () => {
   test("parses bare seconds, seconds, and minutes", () => {
     expect(parseWaitDuration("90")).toBe(90_000);
@@ -171,6 +175,63 @@ describe("drainAssistant", () => {
     expect(outcome).toBe("drained");
     // idle, busy (streak reset), idle, idle — four reads, not one.
     expect(statusCalls).toBe(4);
+  });
+
+  test("idle without a live lease re-arms instead of counting toward drained", async () => {
+    let statusCalls = 0;
+    let armCalls = 0;
+    const { impl } = fetchStub((_url, method) => {
+      if (method === "POST") {
+        armCalls += 1;
+        return jsonResponse({ quiescedUntil: Date.now() + 60_000 });
+      }
+      statusCalls += 1;
+      // The lease has lapsed on the first idle read; once re-armed, the
+      // subsequent idle reads carry a live lease.
+      return jsonResponse(
+        statusCalls === 1 ? idleExpiredLeaseStatus() : idleStatus(),
+      );
+    });
+
+    const outcome = await drainAssistant({
+      baseUrl: BASE,
+      token: "tok",
+      deadlineAt: null,
+      pollIntervalMs: 1,
+      fetchImpl: impl,
+      log: () => {},
+    });
+
+    expect(outcome).toBe("drained");
+    // Initial arm + the re-arm triggered by the lapsed lease.
+    expect(armCalls).toBeGreaterThanOrEqual(2);
+    // The expired-lease idle read did not count: two live-lease reads follow.
+    expect(statusCalls).toBeGreaterThanOrEqual(3);
+  });
+
+  test("an unmaintainable lease fails the drain instead of trusting idle", async () => {
+    let armCalls = 0;
+    const { impl } = fetchStub((_url, method) => {
+      if (method === "POST") {
+        armCalls += 1;
+        if (armCalls === 1) {
+          return jsonResponse({ quiescedUntil: Date.now() + 60_000 });
+        }
+        return jsonResponse({ error: "boom" }, 500);
+      }
+      return jsonResponse(idleExpiredLeaseStatus());
+    });
+
+    const outcome = await drainAssistant({
+      baseUrl: BASE,
+      token: "tok",
+      deadlineAt: null,
+      pollIntervalMs: 1,
+      fetchImpl: impl,
+      log: () => {},
+    });
+
+    expect(outcome).toBe("unreachable");
   });
 
   test("returns unsupported when the assistant lacks the quiesce route", async () => {

--- a/cli/src/__tests__/drain.test.ts
+++ b/cli/src/__tests__/drain.test.ts
@@ -44,6 +44,20 @@ function busyStatus(): unknown {
       { id: "job-1", type: "memory_retrospective", startedAt: Date.now() },
     ],
     scheduleRuns: [],
+    workflowRuns: [],
+  };
+}
+
+function workflowBusyStatus(): unknown {
+  return {
+    quiescedUntil: Date.now() + 60_000,
+    idle: false,
+    activeConversations: [],
+    memoryJobs: [],
+    scheduleRuns: [],
+    workflowRuns: [
+      { runId: "wf-1", name: "nightly-report", startedAt: Date.now() },
+    ],
   };
 }
 
@@ -54,6 +68,7 @@ function idleStatus(): unknown {
     activeConversations: [],
     memoryJobs: [],
     scheduleRuns: [],
+    workflowRuns: [],
   };
 }
 
@@ -101,6 +116,32 @@ describe("drainAssistant", () => {
       method: "POST",
     });
     expect(lines.join("\n")).toContain("memory memory_retrospective");
+  });
+
+  test("a running workflow keeps the drain busy and is narrated", async () => {
+    let statusCalls = 0;
+    const { impl } = fetchStub((_url, method) => {
+      if (method === "POST") {
+        return jsonResponse({ quiescedUntil: Date.now() + 60_000 });
+      }
+      statusCalls += 1;
+      return jsonResponse(
+        statusCalls < 2 ? workflowBusyStatus() : idleStatus(),
+      );
+    });
+    const lines: string[] = [];
+
+    const outcome = await drainAssistant({
+      baseUrl: BASE,
+      token: "tok",
+      deadlineAt: null,
+      pollIntervalMs: 1,
+      fetchImpl: impl,
+      log: (line) => lines.push(line),
+    });
+
+    expect(outcome).toBe("drained");
+    expect(lines.join("\n")).toContain('workflow "nightly-report"');
   });
 
   test("returns unsupported when the assistant lacks the quiesce route", async () => {

--- a/cli/src/__tests__/drain.test.ts
+++ b/cli/src/__tests__/drain.test.ts
@@ -45,6 +45,7 @@ function busyStatus(): unknown {
     ],
     scheduleRuns: [],
     workflowRuns: [],
+    heartbeatRuns: [],
   };
 }
 
@@ -58,6 +59,7 @@ function workflowBusyStatus(): unknown {
     workflowRuns: [
       { runId: "wf-1", name: "nightly-report", startedAt: Date.now() },
     ],
+    heartbeatRuns: [],
   };
 }
 
@@ -69,6 +71,7 @@ function idleStatus(): unknown {
     memoryJobs: [],
     scheduleRuns: [],
     workflowRuns: [],
+    heartbeatRuns: [],
   };
 }
 
@@ -142,6 +145,32 @@ describe("drainAssistant", () => {
 
     expect(outcome).toBe("drained");
     expect(lines.join("\n")).toContain('workflow "nightly-report"');
+  });
+
+  test("a single idle snapshot is not enough — drained needs two in a row", async () => {
+    let statusCalls = 0;
+    const sequence = [idleStatus(), busyStatus(), idleStatus(), idleStatus()];
+    const { impl } = fetchStub((_url, method) => {
+      if (method === "POST") {
+        return jsonResponse({ quiescedUntil: Date.now() + 60_000 });
+      }
+      const status = sequence[Math.min(statusCalls, sequence.length - 1)];
+      statusCalls += 1;
+      return jsonResponse(status);
+    });
+
+    const outcome = await drainAssistant({
+      baseUrl: BASE,
+      token: "tok",
+      deadlineAt: null,
+      pollIntervalMs: 1,
+      fetchImpl: impl,
+      log: () => {},
+    });
+
+    expect(outcome).toBe("drained");
+    // idle, busy (streak reset), idle, idle — four reads, not one.
+    expect(statusCalls).toBe(4);
   });
 
   test("returns unsupported when the assistant lacks the quiesce route", async () => {

--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -56,6 +56,21 @@ mock.module("../lib/guardian-token.js", () => ({
   loadGuardianToken: loadGuardianTokenMock,
 }));
 
+// Stub the token-refresh helper without importing the real client module
+// (it drags in the interactive chat client's dependency graph). Pass-through
+// by default: the stored token is returned as-is.
+const resolveFreshBearerTokenMock = mock(
+  async (
+    _runtimeUrl: string,
+    _assistantId: string,
+    bearerToken: string | undefined,
+    _cloud: string | undefined,
+  ) => bearerToken,
+);
+mock.module("../commands/client.js", () => ({
+  resolveFreshBearerToken: resolveFreshBearerTokenMock,
+}));
+
 // Restore the real modules once this file finishes so the mocks do not leak
 // into other test files in the same `bun test` run.
 afterAll(() => {
@@ -134,6 +149,10 @@ describe("sleep command", () => {
     loadGuardianTokenMock.mockReturnValue({
       accessToken: "test-guardian-token",
     } as unknown as ReturnType<typeof realGuardianToken.loadGuardianToken>);
+    resolveFreshBearerTokenMock.mockReset();
+    resolveFreshBearerTokenMock.mockImplementation(
+      async (_url, _id, bearerToken, _cloud) => bearerToken,
+    );
     rmSync(assistantRootDir, { recursive: true, force: true });
     writeLockfile();
   });

--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -30,10 +30,38 @@ mock.module("../lib/process.js", () => ({
   stopProcessByPidFile: stopProcessByPidFileMock,
 }));
 
-// Restore the real module once this file finishes so the mock does not leak
+// Mock the drain phase and the guardian-token loader so `--wait` tests can
+// steer outcomes without a live daemon. Both spread the real module so
+// untouched exports keep working (parseWaitDuration stays real).
+import type { DrainOptions, DrainOutcome } from "../lib/drain.js";
+
+const drainAssistantMock = mock(
+  async (_opts: DrainOptions): Promise<DrainOutcome> => "drained",
+);
+const realDrain = { ...(await import("../lib/drain.js")) };
+mock.module("../lib/drain.js", () => ({
+  ...realDrain,
+  drainAssistant: drainAssistantMock,
+}));
+
+const realGuardianToken = { ...(await import("../lib/guardian-token.js")) };
+const loadGuardianTokenMock = mock(
+  (_assistantId: string) =>
+    ({ accessToken: "test-guardian-token" }) as unknown as ReturnType<
+      typeof realGuardianToken.loadGuardianToken
+    >,
+);
+mock.module("../lib/guardian-token.js", () => ({
+  ...realGuardianToken,
+  loadGuardianToken: loadGuardianTokenMock,
+}));
+
+// Restore the real modules once this file finishes so the mocks do not leak
 // into other test files in the same `bun test` run.
 afterAll(() => {
   mock.module("../lib/process.js", () => realProcess);
+  mock.module("../lib/drain.js", () => realDrain);
+  mock.module("../lib/guardian-token.js", () => realGuardianToken);
 });
 
 import { sleep } from "../commands/sleep.js";
@@ -45,7 +73,7 @@ import {
 
 // Write a lockfile entry so the real resolveTargetAssistant() finds our test
 // assistant without needing to mock the entire assistant-config module.
-function writeLockfile(): void {
+function writeLockfile(extraEntryFields: Record<string, unknown> = {}): void {
   writeFileSync(
     join(testDir, ".vellum.lock.json"),
     JSON.stringify(
@@ -61,6 +89,7 @@ function writeLockfile(): void {
               gatewayPort: DEFAULT_GATEWAY_PORT,
               qdrantPort: DEFAULT_QDRANT_PORT,
             },
+            ...extraEntryFields,
           },
         ],
         activeAssistant: "sleep-test",
@@ -99,6 +128,12 @@ describe("sleep command", () => {
     isProcessAliveMock.mockReturnValue({ alive: false, pid: null });
     stopProcessByPidFileMock.mockReset();
     stopProcessByPidFileMock.mockResolvedValue(true);
+    drainAssistantMock.mockReset();
+    drainAssistantMock.mockResolvedValue("drained");
+    loadGuardianTokenMock.mockReset();
+    loadGuardianTokenMock.mockReturnValue({
+      accessToken: "test-guardian-token",
+    } as unknown as ReturnType<typeof realGuardianToken.loadGuardianToken>);
     rmSync(assistantRootDir, { recursive: true, force: true });
     writeLockfile();
   });
@@ -186,5 +221,120 @@ describe("sleep command", () => {
       join(assistantRootDir, "ces.pid"),
       "credential-executor",
     );
+  });
+
+  describe("--wait", () => {
+    test("runs the drain phase against localUrl before stopping", async () => {
+      writeLockfile({ localUrl: "http://127.0.0.1:9999" });
+      isProcessAliveMock.mockReturnValue({ alive: true, pid: 4321 });
+      process.argv = ["bun", "vellum", "sleep", "sleep-test", "--wait"];
+
+      const consoleLog = spyOn(console, "log").mockImplementation(() => {});
+      try {
+        await sleep();
+      } finally {
+        consoleLog.mockRestore();
+      }
+
+      expect(drainAssistantMock).toHaveBeenCalledTimes(1);
+      const opts = drainAssistantMock.mock.calls[0]![0];
+      expect(opts.baseUrl).toBe("http://127.0.0.1:9999");
+      expect(opts.token).toBe("test-guardian-token");
+      // Bare --wait waits as long as it takes.
+      expect(opts.deadlineAt).toBeNull();
+      expect(stopProcessByPidFileMock).toHaveBeenCalledTimes(3);
+    });
+
+    test("a duration bounds the wait with a deadline", async () => {
+      isProcessAliveMock.mockReturnValue({ alive: true, pid: 4321 });
+      process.argv = ["bun", "vellum", "sleep", "sleep-test", "--wait", "90s"];
+
+      const consoleLog = spyOn(console, "log").mockImplementation(() => {});
+      const before = Date.now();
+      try {
+        await sleep();
+      } finally {
+        consoleLog.mockRestore();
+      }
+
+      const opts = drainAssistantMock.mock.calls[0]![0];
+      expect(opts.deadlineAt).toBeGreaterThanOrEqual(before + 89_000);
+      expect(opts.deadlineAt).toBeLessThanOrEqual(Date.now() + 91_000);
+      expect(stopProcessByPidFileMock).toHaveBeenCalledTimes(3);
+    });
+
+    test("cancelled drain exits 130 without stopping anything", async () => {
+      isProcessAliveMock.mockReturnValue({ alive: true, pid: 4321 });
+      drainAssistantMock.mockResolvedValue("cancelled");
+      process.argv = ["bun", "vellum", "sleep", "sleep-test", "--wait"];
+
+      const consoleLog = spyOn(console, "log").mockImplementation(() => {});
+      const exitMock = mock((code?: number) => {
+        throw new Error(`process.exit:${code}`);
+      });
+      const originalExit = process.exit;
+      process.exit = exitMock as unknown as typeof process.exit;
+      try {
+        await expect(sleep()).rejects.toThrow("process.exit:130");
+      } finally {
+        process.exit = originalExit;
+        consoleLog.mockRestore();
+      }
+
+      expect(stopProcessByPidFileMock).not.toHaveBeenCalled();
+    });
+
+    test("skips the drain when the assistant is not running", async () => {
+      isProcessAliveMock.mockReturnValue({ alive: false, pid: null });
+      process.argv = ["bun", "vellum", "sleep", "sleep-test", "--wait"];
+
+      const consoleLog = spyOn(console, "log").mockImplementation(() => {});
+      try {
+        await sleep();
+      } finally {
+        consoleLog.mockRestore();
+      }
+
+      expect(drainAssistantMock).not.toHaveBeenCalled();
+      expect(stopProcessByPidFileMock).toHaveBeenCalledTimes(3);
+    });
+
+    test("stops without waiting when no guardian token is available", async () => {
+      isProcessAliveMock.mockReturnValue({ alive: true, pid: 4321 });
+      loadGuardianTokenMock.mockReturnValue(null);
+      process.argv = ["bun", "vellum", "sleep", "sleep-test", "--wait"];
+
+      const consoleLog = spyOn(console, "log").mockImplementation(() => {});
+      try {
+        await sleep();
+      } finally {
+        consoleLog.mockRestore();
+      }
+
+      expect(drainAssistantMock).not.toHaveBeenCalled();
+      expect(stopProcessByPidFileMock).toHaveBeenCalledTimes(3);
+    });
+
+    test("rejects an invalid --wait duration", async () => {
+      process.argv = ["bun", "vellum", "sleep", "sleep-test", "--wait=abc"];
+
+      const consoleError = spyOn(console, "error").mockImplementation(() => {});
+      const exitMock = mock((code?: number) => {
+        throw new Error(`process.exit:${code}`);
+      });
+      const originalExit = process.exit;
+      process.exit = exitMock as unknown as typeof process.exit;
+      try {
+        await expect(sleep()).rejects.toThrow("process.exit:1");
+        expect(consoleError).toHaveBeenCalledWith(
+          expect.stringContaining("invalid --wait duration"),
+        );
+      } finally {
+        process.exit = originalExit;
+        consoleError.mockRestore();
+      }
+
+      expect(stopProcessByPidFileMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -7,6 +7,12 @@ import {
 } from "../lib/assistant-config.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
 import { dockerResourceNames, sleepContainers } from "../lib/docker.js";
+import {
+  drainAssistant,
+  type DrainOutcome,
+  parseWaitDuration,
+} from "../lib/drain.js";
+import { loadGuardianToken } from "../lib/guardian-token.js";
 import { stopIngressNginx } from "../lib/nginx-ingress.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
 
@@ -49,7 +55,7 @@ function readActiveCallLeases(vellumDir: string): ActiveCallLease[] {
 export async function sleep(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum sleep [<name>] [--force]");
+    console.log("Usage: vellum sleep [<name>] [--force] [--wait [<duration>]]");
     console.log("");
     console.log("Stop the assistant and gateway processes.");
     console.log("");
@@ -62,14 +68,66 @@ export async function sleep(): Promise<void> {
     console.log(
       "  --force   Stop the assistant even if a phone call keepalive lease is active",
     );
+    console.log(
+      "  --wait    Wait for in-flight background work (heartbeats, memory jobs,",
+    );
+    console.log(
+      "            schedules) to finish before stopping. Waits as long as it",
+    );
+    console.log(
+      "            takes by default; pass a duration (e.g. --wait 90s, --wait 10m)",
+    );
+    console.log(
+      "            to bound the wait. Ctrl-C cancels and leaves the assistant running.",
+    );
     process.exit(0);
   }
 
   const force = args.includes("--force");
-  const nameArg = args.find((a) => !a.startsWith("-"));
+  let wait = false;
+  let waitMs: number | null = null;
+  let waitDurationToken: string | null = null;
+  const waitEqArg = args.find((a) => a.startsWith("--wait="));
+  if (waitEqArg) {
+    wait = true;
+    const raw = waitEqArg.slice("--wait=".length);
+    waitMs = parseWaitDuration(raw);
+    if (waitMs == null) {
+      console.error(
+        `Error: invalid --wait duration '${raw}'. Use seconds or a value like 90s or 10m.`,
+      );
+      process.exit(1);
+    }
+  } else {
+    const waitIndex = args.indexOf("--wait");
+    if (waitIndex !== -1) {
+      wait = true;
+      // A bare `--wait` waits indefinitely; a following duration token
+      // (e.g. `90s`, `10m`, `120`) bounds it. Anything else is the name arg.
+      const next = args[waitIndex + 1];
+      if (next !== undefined && /^\d+(s|m)?$/.test(next)) {
+        waitDurationToken = next;
+        waitMs = parseWaitDuration(next);
+        if (waitMs == null) {
+          console.error(
+            `Error: invalid --wait duration '${next}'. Use seconds or a value like 90s or 10m.`,
+          );
+          process.exit(1);
+        }
+      }
+    }
+  }
+  const nameArg = args.find(
+    (a) => !a.startsWith("-") && a !== waitDurationToken,
+  );
   const entry = resolveTargetAssistant(nameArg);
 
   if (entry.cloud === "docker") {
+    if (wait) {
+      console.log(
+        "--wait is not supported for Docker assistants yet — stopping containers now.",
+      );
+    }
     const res = dockerResourceNames(entry.assistantId);
     await sleepContainers(res);
     console.log("Docker containers stopped.");
@@ -135,6 +193,14 @@ export async function sleep(): Promise<void> {
     }
   }
 
+  if (wait) {
+    const outcome = await runDrainPhase(entry, assistantPidFile, waitMs);
+    if (outcome === "cancelled") {
+      console.log("Sleep cancelled — the assistant is still running.");
+      process.exit(130);
+    }
+  }
+
   // Stop assistant — use a generous timeout. On SIGTERM the daemon runs a
   // WAL checkpoint before exiting, which can take several seconds on a
   // multi-GB database. The default 2s grace in stopProcess() would SIGKILL a
@@ -184,5 +250,72 @@ export async function sleep(): Promise<void> {
   const ingressStopped = await stopIngressNginx(join(vellumDir, "workspace"));
   if (ingressStopped) {
     console.log("nginx ingress stopped.");
+  }
+}
+
+/**
+ * Wait for the assistant's in-flight background work (heartbeats, memory
+ * jobs, schedule runs, active conversation turns) to finish before the stop.
+ * Every failure mode falls back to a normal stop with a note — a drain must
+ * never make `vellum sleep` less reliable than it is without `--wait`.
+ */
+async function runDrainPhase(
+  entry: AssistantEntry,
+  assistantPidFile: string,
+  waitMs: number | null,
+): Promise<DrainOutcome | "skipped"> {
+  if (!isProcessAlive(assistantPidFile).alive) {
+    return "skipped";
+  }
+  const baseUrl = entry.localUrl ?? entry.runtimeUrl;
+  const token = loadGuardianToken(entry.assistantId)?.accessToken;
+  if (!baseUrl || !token) {
+    console.log(
+      "Cannot reach the assistant API to wait for background work (missing URL or guardian token) — stopping without waiting.",
+    );
+    return "skipped";
+  }
+
+  console.log(
+    waitMs == null
+      ? "Waiting for the assistant to finish background work (Ctrl-C cancels)…"
+      : `Waiting up to ${Math.round(waitMs / 1000)}s for the assistant to finish background work (Ctrl-C cancels)…`,
+  );
+
+  const controller = new AbortController();
+  const onSigint = (): void => controller.abort();
+  process.once("SIGINT", onSigint);
+  try {
+    const outcome = await drainAssistant({
+      baseUrl,
+      token,
+      deadlineAt: waitMs == null ? null : Date.now() + waitMs,
+      signal: controller.signal,
+    });
+    switch (outcome) {
+      case "drained":
+        console.log("Background work finished — stopping now.");
+        break;
+      case "timeout":
+        console.log(
+          "Wait limit reached — stopping now. Interrupted background jobs resume after the next start.",
+        );
+        break;
+      case "unsupported":
+        console.log(
+          "This assistant version does not support --wait — stopping without waiting.",
+        );
+        break;
+      case "unreachable":
+        console.log(
+          "Could not reach the assistant to check background work — stopping without waiting.",
+        );
+        break;
+      case "cancelled":
+        break;
+    }
+    return outcome;
+  } finally {
+    process.removeListener("SIGINT", onSigint);
   }
 }

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -15,6 +15,7 @@ import {
 import { loadGuardianToken } from "../lib/guardian-token.js";
 import { stopIngressNginx } from "../lib/nginx-ingress.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
+import { resolveFreshBearerToken } from "./client.js";
 
 const ACTIVE_CALL_LEASES_FILE = "active-call-leases.json";
 
@@ -268,8 +269,23 @@ async function runDrainPhase(
     return "skipped";
   }
   const baseUrl = entry.localUrl ?? entry.runtimeUrl;
-  const token = loadGuardianToken(entry.assistantId)?.accessToken;
-  if (!baseUrl || !token) {
+  const stored = loadGuardianToken(entry.assistantId)?.accessToken;
+  if (!baseUrl || !stored) {
+    console.log(
+      "Cannot reach the assistant API to wait for background work (missing URL or guardian token) — stopping without waiting.",
+    );
+    return "skipped";
+  }
+  // A token past its renewal point would 401 and read as "unreachable",
+  // silently skipping the wait — refresh-and-fall-back like other CLI
+  // request paths.
+  const token = await resolveFreshBearerToken(
+    baseUrl,
+    entry.assistantId,
+    stored,
+    entry.cloud,
+  );
+  if (!token) {
     console.log(
       "Cannot reach the assistant API to wait for background work (missing URL or guardian token) — stopping without waiting.",
     );

--- a/cli/src/lib/drain.ts
+++ b/cli/src/lib/drain.ts
@@ -49,6 +49,11 @@ interface DrainStatusResponse {
     scheduleName: string | null;
     startedAt: number;
   }>;
+  workflowRuns?: Array<{
+    runId: string;
+    name: string | null;
+    startedAt: number | null;
+  }>;
 }
 
 export interface DrainOptions {
@@ -107,6 +112,10 @@ function describeBusyWork(status: DrainStatusResponse, now: number): string[] {
     const label = run.scheduleName ?? run.runId.slice(0, 8);
     items.push(`schedule "${label}" (${formatElapsed(run.startedAt, now)})`);
   }
+  for (const run of status.workflowRuns ?? []) {
+    const label = run.name ?? run.runId.slice(0, 8);
+    items.push(`workflow "${label}" (${formatElapsed(run.startedAt, now)})`);
+  }
   return items;
 }
 
@@ -115,6 +124,7 @@ function busySignature(status: DrainStatusResponse): string {
     ...status.activeConversations.map((c) => c.conversationId),
     ...status.memoryJobs.map((j) => j.id),
     ...status.scheduleRuns.map((r) => r.runId),
+    ...(status.workflowRuns ?? []).map((r) => r.runId),
   ].join("|");
 }
 
@@ -191,7 +201,14 @@ export async function drainAssistant(
   try {
     response = await armLease();
   } catch {
-    return opts.signal?.aborted ? "cancelled" : "unreachable";
+    if (opts.signal?.aborted) {
+      // The abort may have landed after the server persisted the lease, so
+      // its outcome is ambiguous — release best-effort rather than leaving
+      // background work paused for a TTL on a cancelled sleep.
+      await releaseLease();
+      return "cancelled";
+    }
+    return "unreachable";
   }
   if (response.status === 404 || response.status === 405) {
     return "unsupported";

--- a/cli/src/lib/drain.ts
+++ b/cli/src/lib/drain.ts
@@ -54,6 +54,10 @@ interface DrainStatusResponse {
     name: string | null;
     startedAt: number | null;
   }>;
+  heartbeatRuns?: Array<{
+    runId: string;
+    startedAt: number;
+  }>;
 }
 
 export interface DrainOptions {
@@ -116,6 +120,9 @@ function describeBusyWork(status: DrainStatusResponse, now: number): string[] {
     const label = run.name ?? run.runId.slice(0, 8);
     items.push(`workflow "${label}" (${formatElapsed(run.startedAt, now)})`);
   }
+  for (const run of status.heartbeatRuns ?? []) {
+    items.push(`heartbeat (${formatElapsed(run.startedAt, now)})`);
+  }
   return items;
 }
 
@@ -125,6 +132,7 @@ function busySignature(status: DrainStatusResponse): string {
     ...status.memoryJobs.map((j) => j.id),
     ...status.scheduleRuns.map((r) => r.runId),
     ...(status.workflowRuns ?? []).map((r) => r.runId),
+    ...(status.heartbeatRuns ?? []).map((r) => r.runId),
   ].join("|");
 }
 
@@ -221,6 +229,7 @@ export async function drainAssistant(
   let consecutiveFailures = 0;
   let lastSignature: string | null = null;
   let lastNarratedAt = 0;
+  let idleStreak = 0;
 
   for (;;) {
     if (opts.signal?.aborted) {
@@ -242,8 +251,17 @@ export async function drainAssistant(
       consecutiveFailures = 0;
 
       if (status.idle) {
-        return "drained";
+        // Require two consecutive idle snapshots: work that raced past a
+        // pre-lease gate check lands its run row within a tick, so a second
+        // read one poll later rules out a stop landing on that window.
+        idleStreak += 1;
+        if (idleStreak >= 2) {
+          return "drained";
+        }
+        await sleepMs(pollIntervalMs, opts.signal);
+        continue;
       }
+      idleStreak = 0;
 
       const now = Date.now();
       const signature = busySignature(status);

--- a/cli/src/lib/drain.ts
+++ b/cli/src/lib/drain.ts
@@ -1,0 +1,272 @@
+/**
+ * Drain phase for `vellum sleep --wait`.
+ *
+ * Arms the assistant's quiesce lease (pausing the START of new background
+ * work — heartbeats, schedule claims, memory-job claims), then polls the
+ * drain-status endpoint until nothing is in flight. The lease is TTL-bound
+ * and refreshed while polling, so a killed CLI can never leave background
+ * work paused. The wait narrates what it is waiting on — background jobs can
+ * legitimately run for many minutes, and a silent wait is indistinguishable
+ * from a hang.
+ */
+
+import { loopbackSafeFetch } from "./loopback-fetch.js";
+
+const QUIESCE_TTL_MS = 60_000;
+const QUIESCE_REFRESH_INTERVAL_MS = 20_000;
+const REQUEST_TIMEOUT_MS = 2_500;
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const NARRATE_HEARTBEAT_MS = 15_000;
+/** Consecutive failed polls before giving up on the drain. Transient
+ * failures (a brief daemon event-loop stall) recover; a wall of failures
+ * means the assistant cannot report status and waiting is pointless. */
+const MAX_CONSECUTIVE_FAILURES = 10;
+
+export type DrainOutcome =
+  | "drained"
+  | "timeout"
+  | "unsupported"
+  | "unreachable"
+  | "cancelled";
+
+interface DrainStatusResponse {
+  quiescedUntil: number | null;
+  idle: boolean;
+  activeConversations: Array<{
+    conversationId: string;
+    title: string | null;
+    originChannel: string | null;
+    originInterface: string | null;
+    processingStartedAt: number;
+  }>;
+  memoryJobs: Array<{
+    id: string;
+    type: string;
+    startedAt: number | null;
+  }>;
+  scheduleRuns: Array<{
+    runId: string;
+    scheduleName: string | null;
+    startedAt: number;
+  }>;
+}
+
+export interface DrainOptions {
+  baseUrl: string;
+  token: string;
+  /** Epoch ms to stop waiting at, or null to wait as long as it takes. */
+  deadlineAt: number | null;
+  /** Aborted on Ctrl-C — releases the lease and returns "cancelled". */
+  signal?: AbortSignal;
+  pollIntervalMs?: number;
+  fetchImpl?: (url: string, init?: RequestInit) => Promise<Response>;
+  log?: (line: string) => void;
+}
+
+/**
+ * Parse a `--wait` duration: bare seconds (`90`), seconds (`90s`), or
+ * minutes (`10m`). Returns milliseconds, or null when not a valid duration.
+ */
+export function parseWaitDuration(raw: string): number | null {
+  const match = /^(\d+)(s|m)?$/.exec(raw.trim());
+  if (!match) {
+    return null;
+  }
+  const value = Number.parseInt(match[1]!, 10);
+  if (!Number.isFinite(value) || value < 1) {
+    return null;
+  }
+  return match[2] === "m" ? value * 60_000 : value * 1_000;
+}
+
+function formatElapsed(sinceMs: number | null, now: number): string {
+  if (sinceMs == null) {
+    return "just started";
+  }
+  const totalSeconds = Math.max(0, Math.floor((now - sinceMs) / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0
+    ? `${minutes}m${seconds.toString().padStart(2, "0")}s`
+    : `${seconds}s`;
+}
+
+function describeBusyWork(status: DrainStatusResponse, now: number): string[] {
+  const items: string[] = [];
+  for (const conv of status.activeConversations) {
+    const label =
+      conv.title != null && conv.title.length > 0
+        ? `conversation "${conv.title}"`
+        : `background turn (${conv.originInterface ?? conv.originChannel ?? "unknown origin"})`;
+    items.push(`${label} (${formatElapsed(conv.processingStartedAt, now)})`);
+  }
+  for (const job of status.memoryJobs) {
+    items.push(`memory ${job.type} (${formatElapsed(job.startedAt, now)})`);
+  }
+  for (const run of status.scheduleRuns) {
+    const label = run.scheduleName ?? run.runId.slice(0, 8);
+    items.push(`schedule "${label}" (${formatElapsed(run.startedAt, now)})`);
+  }
+  return items;
+}
+
+function busySignature(status: DrainStatusResponse): string {
+  return [
+    ...status.activeConversations.map((c) => c.conversationId),
+    ...status.memoryJobs.map((j) => j.id),
+    ...status.scheduleRuns.map((r) => r.runId),
+  ].join("|");
+}
+
+function sleepMs(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(done, ms);
+    function done(): void {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", done);
+      resolve();
+    }
+    signal?.addEventListener("abort", done, { once: true });
+  });
+}
+
+/**
+ * Wait for the assistant's in-flight background work to finish.
+ *
+ * Never throws: every failure mode maps onto a {@link DrainOutcome} so the
+ * caller can decide how to proceed with the stop.
+ */
+export async function drainAssistant(
+  opts: DrainOptions,
+): Promise<DrainOutcome> {
+  const fetchImpl = opts.fetchImpl ?? loopbackSafeFetch;
+  const log = opts.log ?? console.log;
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const base = opts.baseUrl.replace(/\/+$/, "");
+
+  const request = async (
+    path: string,
+    init: { method: string; body?: string },
+  ): Promise<Response> => {
+    // Per-request controller aborted by either the request timeout or the
+    // caller's cancel signal; listeners are removed per request so a long
+    // wait never accumulates them on the shared cancel signal.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    const onOuterAbort = (): void => controller.abort();
+    opts.signal?.addEventListener("abort", onOuterAbort, { once: true });
+    try {
+      return await fetchImpl(`${base}${path}`, {
+        method: init.method,
+        headers: {
+          Authorization: `Bearer ${opts.token}`,
+          "Content-Type": "application/json",
+        },
+        ...(init.body !== undefined && { body: init.body }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+      opts.signal?.removeEventListener("abort", onOuterAbort);
+    }
+  };
+
+  const armLease = () =>
+    request("/v1/lifecycle/quiesce", {
+      method: "POST",
+      body: JSON.stringify({ ttlMs: QUIESCE_TTL_MS }),
+    });
+
+  const releaseLease = async (): Promise<void> => {
+    try {
+      await request("/v1/lifecycle/quiesce", { method: "DELETE" });
+    } catch {
+      // Best-effort — the lease self-expires.
+    }
+  };
+
+  // Arm the lease before anything else: without it a busy queue keeps
+  // claiming new work and the wait never converges.
+  let response: Response;
+  try {
+    response = await armLease();
+  } catch {
+    return opts.signal?.aborted ? "cancelled" : "unreachable";
+  }
+  if (response.status === 404 || response.status === 405) {
+    return "unsupported";
+  }
+  if (!response.ok) {
+    return "unreachable";
+  }
+
+  let lastLeaseAt = Date.now();
+  let consecutiveFailures = 0;
+  let lastSignature: string | null = null;
+  let lastNarratedAt = 0;
+
+  for (;;) {
+    if (opts.signal?.aborted) {
+      await releaseLease();
+      return "cancelled";
+    }
+    if (opts.deadlineAt != null && Date.now() >= opts.deadlineAt) {
+      return "timeout";
+    }
+
+    try {
+      const statusResponse = await request("/v1/lifecycle/drain-status", {
+        method: "GET",
+      });
+      if (!statusResponse.ok) {
+        throw new Error(`drain-status returned ${statusResponse.status}`);
+      }
+      const status = (await statusResponse.json()) as DrainStatusResponse;
+      consecutiveFailures = 0;
+
+      if (status.idle) {
+        return "drained";
+      }
+
+      const now = Date.now();
+      const signature = busySignature(status);
+      if (
+        signature !== lastSignature ||
+        now - lastNarratedAt >= NARRATE_HEARTBEAT_MS
+      ) {
+        const items = describeBusyWork(status, now);
+        const shown = items.slice(0, 4);
+        const more = items.length - shown.length;
+        log(
+          `Waiting for the assistant to finish: ${shown.join(", ")}${
+            more > 0 ? ` and ${more} more` : ""
+          }…`,
+        );
+        lastSignature = signature;
+        lastNarratedAt = now;
+      }
+    } catch {
+      if (opts.signal?.aborted) {
+        await releaseLease();
+        return "cancelled";
+      }
+      consecutiveFailures += 1;
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        return "unreachable";
+      }
+    }
+
+    if (Date.now() - lastLeaseAt >= QUIESCE_REFRESH_INTERVAL_MS) {
+      try {
+        const refresh = await armLease();
+        if (refresh.ok) {
+          lastLeaseAt = Date.now();
+        }
+      } catch {
+        // Counted against the next status poll if the daemon is truly gone.
+      }
+    }
+
+    await sleepMs(pollIntervalMs, opts.signal);
+  }
+}

--- a/cli/src/lib/drain.ts
+++ b/cli/src/lib/drain.ts
@@ -21,6 +21,10 @@ const NARRATE_HEARTBEAT_MS = 15_000;
  * failures (a brief daemon event-loop stall) recover; a wall of failures
  * means the assistant cannot report status and waiting is pointless. */
 const MAX_CONSECUTIVE_FAILURES = 10;
+/** Consecutive failed lease arms/refreshes before giving up. Without a live
+ * lease the claim gates are open and an idle snapshot proves nothing, so an
+ * unmaintainable lease makes the drain unsound. */
+const MAX_LEASE_FAILURES = 3;
 
 export type DrainOutcome =
   | "drained"
@@ -227,6 +231,7 @@ export async function drainAssistant(
 
   let lastLeaseAt = Date.now();
   let consecutiveFailures = 0;
+  let leaseFailureStreak = 0;
   let lastSignature: string | null = null;
   let lastNarratedAt = 0;
   let idleStreak = 0;
@@ -251,6 +256,34 @@ export async function drainAssistant(
       consecutiveFailures = 0;
 
       if (status.idle) {
+        // Idle only counts under a LIVE lease: with the lease expired the
+        // claim gates are open again, so new work invisible to this snapshot
+        // could be starting. Re-arm and retry rather than trusting the read.
+        const leaseActive =
+          status.quiescedUntil != null && status.quiescedUntil > Date.now();
+        if (!leaseActive) {
+          idleStreak = 0;
+          try {
+            const rearm = await armLease();
+            if (rearm.ok) {
+              lastLeaseAt = Date.now();
+              leaseFailureStreak = 0;
+            } else {
+              leaseFailureStreak += 1;
+            }
+          } catch {
+            if (opts.signal?.aborted) {
+              await releaseLease();
+              return "cancelled";
+            }
+            leaseFailureStreak += 1;
+          }
+          if (leaseFailureStreak >= MAX_LEASE_FAILURES) {
+            return "unreachable";
+          }
+          await sleepMs(pollIntervalMs, opts.signal);
+          continue;
+        }
         // Require two consecutive idle snapshots: work that raced past a
         // pre-lease gate check lands its run row within a tick, so a second
         // read one poll later rules out a stop landing on that window.
@@ -296,9 +329,15 @@ export async function drainAssistant(
         const refresh = await armLease();
         if (refresh.ok) {
           lastLeaseAt = Date.now();
+          leaseFailureStreak = 0;
+        } else {
+          leaseFailureStreak += 1;
         }
       } catch {
-        // Counted against the next status poll if the daemon is truly gone.
+        leaseFailureStreak += 1;
+      }
+      if (leaseFailureStreak >= MAX_LEASE_FAILURES) {
+        return "unreachable";
       }
     }
 


### PR DESCRIPTION
## Summary
- `vellum sleep --wait [duration]` drains in-flight background work before stopping: it arms a TTL-bound quiesce lease over the assistant's HTTP API, polls a new drain-status endpoint until nothing is running, narrates what it is waiting on, then proceeds with the normal stop sequence. Bare `--wait` waits as long as it takes; `--wait 90s` / `--wait 10m` bounds it; Ctrl-C cancels the sleep and leaves the assistant running.
- The quiesce lease is a single `memory_checkpoints` row (`lifecycle:quiesce_until`, epoch-ms deadline) readable by every process. Claim/fire sites gate on it: heartbeat `runOnce`, the daemon's watcher/sequence tick (`runScheduleDueWorkOnce`), the schedule worker's due-schedule claim (`runDueSchedulesOnce`), and the memory jobs worker tick (`runMemoryJobsOnce`). Enqueue paths stay open — work queued during a drain runs after the restart.
- New shared route definitions `POST/DELETE /v1/lifecycle/quiesce` and `GET /v1/lifecycle/drain-status` (served over HTTP and auto-exposed over the IPC socket adapter), policy-gated like existing control routes (`settings.write` / `settings.read`, actor principals).

## Design notes
- **Fail-open everywhere.** A missing, malformed, unreadable, or expired lease reads as "not quiesced". The lease TTL is clamped (≤10 min) and refreshed by the polling CLI, so a killed CLI can never leave background work paused; the daemon also clears any stale lease at boot. Unit tests pin all of these invariants.
- **Drain, not "error if busy".** A busy instance is busy most of the time (retrospectives, heartbeats, schedules), so refusing to stop while busy turns restart into a manual retry loop and has a check-then-signal race. Pausing intake first is what makes the wait converge; job-level crash recovery (running→pending reset, schedule retry) is what makes the post-timeout abort safe.
- **Transport.** The vellum CLI reaches the local daemon over its HTTP API with the guardian token — the same authenticated channel `vellum ps` health checks use (`checkHealth` + `loopbackSafeFetch`). The CLI package has no Unix-socket IPC client today; because the route definitions are transport-shared, the daemon surface is already IPC-callable if the CLI grows a socket client later.
- **Reliability floor.** Every `--wait` failure mode (older daemon without the routes → 404, missing guardian token, unreachable API, sustained poll failures) falls back to the normal stop with a printed note — `--wait` can never make `vellum sleep` less reliable than it is today.

## Review focus
The four quiesce gate checks are **always-live** in background hot paths. An inverted or stuck gate would silently disable heartbeats, schedules, and retrospectives for every install. The fail-open tests (`lifecycle-quiesce.test.ts`, `jobs-worker-quiesce-gate.test.ts`, the new heartbeat-service cases) are the guardrail; please eyeball the four gate placements and the lease read path.

## Out of scope / follow-ups
- Daemon SIGTERM still aborts in-flight turns (no `waitForIdle` in `shutdown-handlers.ts`), and the memory/schedule workers still hard-exit on SIGTERM. The drain runs before any signal is sent, so planned stops no longer hit those paths.
- The existing active-call-lease guard in `sleep.ts` reads the pre-workspace-migration-023 path and never fires on real installs — left untouched; needs its own fix.
- `/update` still uses plain `vellum sleep`; adopting `--wait` there (and whether to bound it) is a separate decision.
- Docker-mode drain (`--wait` prints a not-supported note and stops containers as before).

## Original prompt
The conversation started from "whenever I restart the assistant I worry about interrupting background jobs (heartbeats, retrospectives, consolidation)" and weighed resumable jobs vs. a sleep command that errors out while busy. Investigation showed job-level crash recovery already exists (memory jobs reset running→pending at worker boot and re-run the identical span; schedules recover through the normal retry policy), so the requested build was an opt-in drain mode: `vellum sleep --wait`, defaulting to waiting as long as it takes, with quiesce-first semantics so the wait converges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)