### PR TITLE
fix(voice): strip control markers from broadcast text deltas in voice-session-bridge

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -1392,7 +1392,8 @@ export async function startVoiceTurn(
           // Strip raw voice control markers before broadcasting to observers
           let broadcastMsg = msg;
           if (msg.type === "assistant_text_delta") {
-            broadcastMsg = { ...msg, delta: stripInternalSpeechMarkers(msg.delta) };
+            const rawText = (msg as any).text ?? (msg as any).delta ?? "";
+            broadcastMsg = { ...msg, text: stripInternalSpeechMarkers(rawText) } as typeof msg;
           }
           broadcastMessage(broadcastMsg);
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -1389,7 +1389,12 @@ export async function startVoiceTurn(
           } else if (msg.type === "conversation_error") {
             lastError = msg.userMessage;
           }
-          broadcastMessage(msg);
+          // Strip raw voice control markers before broadcasting to observers
+          let broadcastMsg = msg;
+          if (msg.type === "assistant_text_delta") {
+            broadcastMsg = { ...msg, delta: stripInternalSpeechMarkers(msg.delta) };
+          }
+          broadcastMessage(broadcastMsg);
 
           // Forward voice-relevant events to the real-time event sink
           if (msg.type === "assistant_text_delta") {


### PR DESCRIPTION
## Description
This PR resolves issue #37850 by calling `stripInternalSpeechMarkers` on `assistant_text_delta` messages before passing them to `broadcastMessage` in `assistant/src/calls/voice-session-bridge.ts`.

## Details
- Previously, `runAgentLoop`'s `onEvent` handler broadcast raw assistant text deltas to the conversation hub prior to voice control marker suppression.
- As a result, live web/desktop observers watching voice calls saw raw protocol control markers (such as `[END_CALL]` and `[ASK_GUARDIAN: ...]`).
- Applying `stripInternalSpeechMarkers` on broadcast deltas ensures control markers are removed from live stream events.