### PR TITLE
fix(daemon): stamp completedAt consistently whenever tool result lands in renderHistoryContent

### DIFF
--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -680,6 +680,9 @@ export function renderHistoryContent(
       if (matched) {
         matched.result = resultContent;
         matched.isError = isError;
+        if (matched.completedAt == null) {
+          matched.completedAt = typeof block._completedAt === "number" ? block._completedAt : Date.now();
+        }
       } else {
         toolCalls.push({
           name: "web_search",
@@ -722,6 +725,9 @@ export function renderHistoryContent(
       if (matched) {
         matched.result = resultContent;
         matched.isError = isError;
+        if (matched.completedAt == null) {
+          matched.completedAt = typeof block._completedAt === "number" ? block._completedAt : Date.now();
+        }
         // Carry the persisted error classification onto the history row so a
         // client can re-derive an error-specific surface after a reload (e.g.
         // `acp_claude_oauth_missing` re-raising the inline Connect card),


### PR DESCRIPTION
## Description
This PR resolves issue #33501 by stamping `completedAt` consistently whenever a `tool_result` or `web_search_tool_result` matches a pending tool use in `renderHistoryContent` (`assistant/src/daemon/handlers/shared.ts`).

## Details
- Previously, `result` was populated from matching `tool_result` content blocks, while `completedAt` was only stamped if `_completedAt` was present on the `tool_use` block.
- This led to a state mismatch where a tool call had a result but no `completedAt` on the wire.
- This PR ensures `matched.completedAt` is populated consistently from `block._completedAt` (or fallback to `Date.now()`) whenever a result is paired.