### PR TITLE
fix(cli): support setting avatar from any local file path in assistant avatar set

### DIFF
--- a/assistant/src/cli/commands/avatar.ts
+++ b/assistant/src/cli/commands/avatar.ts
@@ -1,6 +1,6 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { isAbsolute, join } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 
 import type { Command } from "commander";
 
@@ -47,11 +47,7 @@ export function registerAvatarCommand(program: Command): void {
         async (opts: { image: string }, cmd: Command) => {
           const resolvedSource = isAbsolute(opts.image)
             ? opts.image
-            : join(
-                process.env.VELLUM_WORKSPACE_DIR ||
-                  join(homedir(), ".vellum", "workspace"),
-                opts.image,
-              );
+            : resolve(process.cwd(), opts.image);
 
           if (!existsSync(resolvedSource)) {
             log.error(`Image file not found: ${resolvedSource}`);
@@ -59,9 +55,25 @@ export function registerAvatarCommand(program: Command): void {
             return;
           }
 
-          const r = await cliIpcCall<{ ok: boolean }>("avatar_set", {
-            body: { imagePath: resolvedSource },
-          });
+          const workspaceDir =
+            process.env.VELLUM_WORKSPACE_DIR ||
+            join(homedir(), ".vellum", "workspace");
+          const isInsideWorkspace =
+            resolvedSource === workspaceDir ||
+            resolvedSource.startsWith(workspaceDir + "/");
+
+          let r;
+          if (isInsideWorkspace) {
+            r = await cliIpcCall<{ ok: boolean }>("avatar_set", {
+              body: { imagePath: resolvedSource },
+            });
+          } else {
+            const content = readFileSync(resolvedSource).toString("base64");
+            r = await cliIpcCall<{ ok: boolean }>("avatar_upload_image", {
+              body: { content, encoding: "base64" },
+            });
+          }
+
           if (!r.ok)
             return exitFromIpcResult(
               r as { ok: false; error?: string; statusCode?: number },


### PR DESCRIPTION
## Description
This PR resolves issue #30323 by supporting avatar image selection from any local working directory or host path in `assistant avatar set`.

## Details
- Updates `avatar.ts` to resolve relative paths against `process.cwd()`.
- For files outside the workspace directory, uses `avatar_upload_image` with base64 data to safely pass host images to the avatar store without triggering workspace path safety errors.