### PR TITLE
fix(events): replay current subagent statuses for conversation on SSE subscribe

### DIFF
--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -506,25 +506,24 @@ export function handleSubscribeAssistantEvents(
           try {
             const manager = getSubagentManager();
             const children = manager.getChildrenOf(filter.conversationId);
-            for (const childId of children) {
-              const childState = manager.getSubagentState(childId);
-              if (childState) {
-                controller.enqueue(
-                  encoder.encode(
-                    formatSseFrame({
-                      type: "subagent_status_changed",
-                      subagentId: childId,
-                      status: childState.status,
-                      error: childState.error,
-                      usage: childState.usage,
-                    }),
-                  ),
-                );
-                instrumentation.eventsDelivered += 1;
-              }
+            const MAX_SUBAGENT_REPLAY = 50;
+            const itemsToReplay = children.slice(-MAX_SUBAGENT_REPLAY);
+            for (const child of itemsToReplay) {
+              controller.enqueue(
+                encoder.encode(
+                  formatSseFrame({
+                    type: "subagent_status_changed",
+                    subagentId: child.config.id,
+                    status: child.status,
+                    ...(child.error != null ? { error: child.error } : {}),
+                    usage: child.usage,
+                  }),
+                ),
+              );
+              instrumentation.eventsDelivered += 1;
             }
           } catch {
-            /* best-effort subagent status sync */
+            // Subagent manager might not be initialized in minimal contexts
           }
         }
 

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -43,6 +43,7 @@ import { getReplayWindow } from "../assistant-stream-state.js";
 import { ACTOR_PRINCIPALS, GATEWAY_PRINCIPALS } from "../auth/route-policy.js";
 import { DEFAULT_HEARTBEAT_INTERVAL_MS } from "../client-health.js";
 import { resolveActorPrincipalIdForLocalGuardianSync } from "../local-actor-identity.js";
+import { getSubagentManager } from "../../subagent/index.js";
 import {
   BadRequestError,
   NotFoundError,
@@ -497,6 +498,33 @@ export function handleSubscribeAssistantEvents(
                 highWaterReplaySeq = replayed.seq;
               }
             }
+          }
+        }
+
+        // On (re)subscribe for a specific conversation, sync subagent statuses if any children exist
+        if (filter.conversationId) {
+          try {
+            const manager = getSubagentManager();
+            const children = manager.getChildrenOf(filter.conversationId);
+            for (const childId of children) {
+              const childState = manager.getSubagentState(childId);
+              if (childState) {
+                controller.enqueue(
+                  encoder.encode(
+                    formatSseFrame({
+                      type: "subagent_status_changed",
+                      subagentId: childId,
+                      status: childState.status,
+                      error: childState.error,
+                      usage: childState.usage,
+                    }),
+                  ),
+                );
+                instrumentation.eventsDelivered += 1;
+              }
+            }
+          } catch {
+            /* best-effort subagent status sync */
           }
         }
 


### PR DESCRIPTION
## Description
This PR resolves issue #36718 by syncing current subagent statuses to client streams upon SSE subscription/reconnect in `handleSubscribeAssistantEvents` (`assistant/src/runtime/routes/events-routes.ts`).

## Details
- On subscription with a conversation filter (`filter.conversationId`), queries `getSubagentManager()` for child subagents.
- Emits a `subagent_status_changed` SSE frame per child so open web/desktop sessions immediately reflect rehydrated subagent statuses (such as `interrupted`) across daemon restarts without requiring a manual page refresh or message send.