### PR TITLE
refactor(events): single-source AssistantEventEnvelope from the api package

### DIFF
--- a/assistant/src/__tests__/assistant-event-hub-self-exclusion.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub-self-exclusion.test.ts
@@ -14,7 +14,7 @@
  */
 import { describe, expect, test } from "bun:test";
 
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../api/index.js";
 import {
   AssistantEventHub,
   assistantEventHub,

--- a/assistant/src/__tests__/assistant-event-hub-targeted.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub-targeted.test.ts
@@ -13,7 +13,7 @@
  */
 import { describe, expect, test } from "bun:test";
 
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../api/index.js";
 import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
 
 function makeEvent(

--- a/assistant/src/__tests__/assistant-event-hub.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../api/index.js";
 import {
   AssistantEventHub,
   broadcastMessage,

--- a/assistant/src/__tests__/assistant-event.test.ts
+++ b/assistant/src/__tests__/assistant-event.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../api/index.js";
 import {
   formatSseFrame,
   formatSseHeartbeat,

--- a/assistant/src/__tests__/assistant-stream-state.test.ts
+++ b/assistant/src/__tests__/assistant-stream-state.test.ts
@@ -8,7 +8,7 @@ import {
 import { dirname, join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../api/index.js";
 import type {
   EventTargeting,
   ReplaySubscriber,
@@ -144,7 +144,9 @@ describe("assistant-stream-state", () => {
 
   describe("ring buffer eviction", () => {
     test("evicts oldest entries past the 200-event count cap", () => {
-      for (let i = 0; i < 250; i++) stampAndBuffer(mkEvent());
+      for (let i = 0; i < 250; i++) {
+        stampAndBuffer(mkEvent());
+      }
       const peek = _peekStreamForTesting();
       expect(peek.ringLength).toBe(200);
       // Newest is 250, oldest should be 51 (250 - 200 + 1)
@@ -214,7 +216,9 @@ describe("assistant-stream-state", () => {
 
     test("returns null when lastSeenSeq is older than oldest buffered entry", () => {
       // Force eviction by pushing past the count cap.
-      for (let i = 0; i < 250; i++) stampAndBuffer(mkEvent());
+      for (let i = 0; i < 250; i++) {
+        stampAndBuffer(mkEvent());
+      }
       const peek = _peekStreamForTesting();
       expect(peek.oldestSeq).toBe(51);
       // Client claims to have last seen seq=10 — that's far below oldest.
@@ -732,7 +736,9 @@ describe("assistant-stream-state", () => {
 
     test("stamping within a reserved block does not advance the persisted ceiling", () => {
       // GIVEN many stamps within one block
-      for (let i = 0; i < 100; i++) stampAndBuffer(mkEvent());
+      for (let i = 0; i < 100; i++) {
+        stampAndBuffer(mkEvent());
+      }
 
       // WHEN the daemon restarts
       _simulateRestartForTesting();
@@ -786,7 +792,9 @@ describe("assistant-stream-state", () => {
 
       // Stamp past the 200-event ring cap so the restarted process's
       // earliest events are genuinely evicted.
-      for (let i = 0; i < 205; i++) stampAndBuffer(mkEvent());
+      for (let i = 0; i < 205; i++) {
+        stampAndBuffer(mkEvent());
+      }
 
       // The gap now includes evicted post-restart events, so replay must
       // signal the snapshot fallback.

--- a/assistant/src/__tests__/avatar-identity-sync.test.ts
+++ b/assistant/src/__tests__/avatar-identity-sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { ROUTES as AVATAR_ROUTES } from "../runtime/routes/avatar-routes.js";
 import { publishIdentityChanged } from "../runtime/sync/resource-sync-events.js";

--- a/assistant/src/__tests__/config-sounds-sync.test.ts
+++ b/assistant/src/__tests__/config-sounds-sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import {
   publishConfigChanged,

--- a/assistant/src/__tests__/conversation-key-store-disk-view.test.ts
+++ b/assistant/src/__tests__/conversation-key-store-disk-view.test.ts
@@ -14,6 +14,7 @@ const testDir = process.env.VELLUM_WORKSPACE_DIR!;
 const conversationsDir = join(testDir, "conversations");
 mkdirSync(conversationsDir, { recursive: true });
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import { getOrCreateConversation } from "../persistence/conversation-key-store.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
@@ -21,7 +22,6 @@ import {
   conversationKeys,
   conversations,
 } from "../persistence/schema/index.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   _resetStreamStateForTesting,
   _simulateRestartForTesting,

--- a/assistant/src/__tests__/conversation-message-sync-tags.test.ts
+++ b/assistant/src/__tests__/conversation-message-sync-tags.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import {
   conversationMessagesSyncTag,
   type SyncChangedEvent,
 } from "../daemon/message-types/sync.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   assistantEventHub,
   broadcastMessage,

--- a/assistant/src/__tests__/conversation-sync-tags.test.ts
+++ b/assistant/src/__tests__/conversation-sync-tags.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import {
   conversationMetadataSyncTag,
   SYNC_TAGS,
@@ -14,7 +15,6 @@ import {
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { ROUTES as CONVERSATION_LIST_ROUTES } from "../runtime/routes/conversation-list-routes.js";
 import { ROUTES as CONVERSATION_MANAGEMENT_ROUTES } from "../runtime/routes/conversation-management-routes.js";

--- a/assistant/src/__tests__/daemon-assistant-events.test.ts
+++ b/assistant/src/__tests__/daemon-assistant-events.test.ts
@@ -8,9 +8,9 @@
  */
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 // ── Imports (after mocks) ────────────────────────────────────────────────────
 import type { AssistantEvent } from "../daemon/message-protocol.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
 

--- a/assistant/src/__tests__/emit-event-signal.test.ts
+++ b/assistant/src/__tests__/emit-event-signal.test.ts
@@ -10,8 +10,8 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import type { AssistantEvent } from "../daemon/message-protocol.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { handleEmitEventSignal } from "../signals/emit-event.js";
 import { getSignalsDir } from "../util/platform.js";

--- a/assistant/src/__tests__/events-tail-route.test.ts
+++ b/assistant/src/__tests__/events-tail-route.test.ts
@@ -13,7 +13,7 @@
  */
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../api/index.js";
 import {
   _resetStreamStateForTesting,
   stampAndBuffer,

--- a/assistant/src/__tests__/list-messages-page-latest.test.ts
+++ b/assistant/src/__tests__/list-messages-page-latest.test.ts
@@ -21,6 +21,7 @@ mock.module("../daemon/identity-helpers.js", () => ({
   getAssistantName: () => mockAssistantName,
 }));
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import { writeSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import {
   createConversation,
@@ -31,7 +32,6 @@ import {
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { messages } from "../persistence/schema/index.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   _resetStreamStateForTesting,
   getCurrentSeq,

--- a/assistant/src/__tests__/plugin-event-hub-facade.test.ts
+++ b/assistant/src/__tests__/plugin-event-hub-facade.test.ts
@@ -10,8 +10,8 @@
 
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import { assistantEventHub as pluginHub } from "../plugin-api/index.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub as rawHub } from "../runtime/assistant-event-hub.js";
 
 /** Minimal event envelope; the facade guard keys only off `message.type`. */

--- a/assistant/src/__tests__/runtime-events-sse-parity.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-parity.test.ts
@@ -17,11 +17,11 @@
  */
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getOrCreateConversation } from "../persistence/conversation-key-store.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 
@@ -68,7 +68,9 @@ async function publishAndReadFrame(
   const frame = new TextDecoder().decode(value);
   // SSE frame: "event: assistant_event\nid: <id>\ndata: <json>\n\n"
   const dataLine = frame.split("\n").find((l) => l.startsWith("data: "));
-  if (!dataLine) {throw new Error(`No data line in SSE frame:\n${frame}`);}
+  if (!dataLine) {
+    throw new Error(`No data line in SSE frame:\n${frame}`);
+  }
   return JSON.parse(dataLine.slice("data: ".length)) as AssistantEventEnvelope;
 }
 

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -38,6 +38,7 @@ mock.module("../daemon/conversation-store.js", () => ({
   },
 }));
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import {
   insertPendingHeartbeatRun,
@@ -51,7 +52,6 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { recordUsageEvent } from "../persistence/llm-usage-store.js";
 import { rawRun } from "../persistence/raw-query.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { BadRequestError, NotFoundError } from "../runtime/routes/errors.js";
 import { ROUTES as HEARTBEAT_ROUTES } from "../runtime/routes/heartbeat-routes.js";
@@ -82,7 +82,9 @@ function findRoute(endpoint: string, method: string): RouteDefinition {
   const route = SCHEDULE_ROUTES.find(
     (r) => r.endpoint === endpoint && r.method === method,
   );
-  if (!route) throw new Error(`Route ${method} ${endpoint} not found`);
+  if (!route) {
+    throw new Error(`Route ${method} ${endpoint} not found`);
+  }
   return route;
 }
 
@@ -90,7 +92,9 @@ function findHeartbeatRoute(endpoint: string, method: string): RouteDefinition {
   const route = HEARTBEAT_ROUTES.find(
     (r) => r.endpoint === endpoint && r.method === method,
   );
-  if (!route) throw new Error(`Route ${method} ${endpoint} not found`);
+  if (!route) {
+    throw new Error(`Route ${method} ${endpoint} not found`);
+  }
   return route;
 }
 
@@ -152,7 +156,9 @@ function setScheduleRunWindow({
 async function waitFor(predicate: () => boolean): Promise<void> {
   const deadline = Date.now() + 500;
   while (Date.now() < deadline) {
-    if (predicate()) return;
+    if (predicate()) {
+      return;
+    }
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   throw new Error("Timed out waiting for schedule route event");

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -12,10 +12,10 @@ mock.module("../background-wake/publisher.js", () => ({
   refreshBackgroundWakeIntent: () => {},
 }));
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import {
   cancelSchedule,

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -97,10 +97,10 @@ mock.module(
   () => gatewayGuardianRequestsStoreBridge,
 );
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import { __resetGuardianDeliveryCacheForTest } from "../contacts/guardian-delivery-reader.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import type { ApprovalConversationGenerator } from "../runtime/http-types.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";

--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -48,9 +48,13 @@ mock.module("../persistence/conversation-crud.js", () => ({
   provenanceFromTrustContext: () => ({}),
   reserveMessage: reserveMessageMock,
   recordConversationPersistedSeq: (id: string, seq: number) => {
-    if (!Number.isFinite(seq) || seq <= 0) {return;}
+    if (!Number.isFinite(seq) || seq <= 0) {
+      return;
+    }
     const prev = persistedSeqByConversation.get(id);
-    if (prev == null || prev < seq) {persistedSeqByConversation.set(id, seq);}
+    if (prev == null || prev < seq) {
+      persistedSeqByConversation.set(id, seq);
+    }
   },
   getConversationPersistedSeq: (id: string) =>
     persistedSeqByConversation.get(id) ?? null,
@@ -78,6 +82,7 @@ mock.module(
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 import type { AgentEvent } from "../agent/loop.js";
+import type { AssistantEventEnvelope } from "../api/index.js";
 import type {
   EventHandlerDeps,
   EventHandlerState,
@@ -93,7 +98,6 @@ import {
 } from "../daemon/conversation-agent-loop-handlers.js";
 import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getConversationPersistedSeq } from "../persistence/conversation-crud.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import {
   _resetStreamStateForTesting,
   getCurrentSeq,

--- a/assistant/src/ipc/routes/__tests__/conversation-sync-ipc-routes.test.ts
+++ b/assistant/src/ipc/routes/__tests__/conversation-sync-ipc-routes.test.ts
@@ -29,13 +29,13 @@ mock.module("../../../runtime/sync/resource-sync-events.js", () => ({
   },
 }));
 
+import type { AssistantEventEnvelope } from "../../../api/index.js";
 import type { EventHandlerState } from "../../../daemon/conversation-agent-loop-handlers.js";
 import { DB_MIGRATION_READINESS_EXEMPT_OPERATIONS } from "../../../daemon/daemon-readiness.js";
 import {
   registerInflightTurn,
   unregisterInflightTurn,
 } from "../../../daemon/inflight-turn-registry.js";
-import type { AssistantEventEnvelope } from "../../../runtime/assistant-event.js";
 import {
   _resetStreamStateForTesting,
   stampAndBuffer,

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -11,8 +11,6 @@ import type {
   SecretPromptResult,
 } from "./secret-prompt-types.js";
 
-type SecretRequestMessage = SecretRequestEvent;
-
 const log = getLogger("secret-prompter");
 
 export interface SecretPrompterChannelContext {
@@ -109,7 +107,7 @@ export class SecretPrompter {
       });
       this.ownedIds.add(requestId);
 
-      const msg: SecretRequestMessage = {
+      const msg: SecretRequestEvent = {
         type: "secret_request",
         requestId,
         service,

--- a/assistant/src/plugin-api/__tests__/publish-event.test.ts
+++ b/assistant/src/plugin-api/__tests__/publish-event.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import type { AssistantEventEnvelope } from "../../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../../api/index.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
 import { publishEvent } from "../publish-event.js";
 

--- a/assistant/src/plugin-api/event-hub-facade.ts
+++ b/assistant/src/plugin-api/event-hub-facade.ts
@@ -40,7 +40,7 @@
  * mid-fanout (the hub delivers one object to every subscriber in turn).
  */
 
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../api/index.js";
 import {
   type AssistantEventFilter,
   type AssistantEventHub,
@@ -86,8 +86,12 @@ function wireSnapshot<T>(value: T): T {
  * client receives it.
  */
 function deepFreeze<T>(value: T, seen: WeakSet<object> = new WeakSet()): T {
-  if (value === null || typeof value !== "object") return value;
-  if (seen.has(value)) return value;
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (seen.has(value)) {
+    return value;
+  }
   seen.add(value);
   for (const key of Object.keys(value)) {
     deepFreeze((value as Record<string, unknown>)[key], seen);

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -127,14 +127,7 @@ export { RiskLevel } from "./types.js";
 // Workspace-local plugins resolve these via the boot-time shim, which
 // re-binds each from the assistant's globalThis-parked namespace so they
 // share module identity with the assistant's own singletons.
-export type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
-/**
- * @deprecated Renamed to {@link AssistantEventEnvelope}. Retained as a
- * compatibility alias so existing plugins that import `AssistantEvent` from
- * `@vellumai/plugin-api` (the SSE envelope a hub subscriber receives) keep
- * compiling. Prefer `AssistantEventEnvelope` in new plugin code.
- */
-export type { AssistantEventEnvelope as AssistantEvent } from "../runtime/assistant-event.js";
+export type { AssistantEvent, AssistantEventEnvelope } from "../api/index.js";
 export type {
   AssistantEventCallback,
   AssistantEventFilter,

--- a/assistant/src/plugin-api/publish-event.ts
+++ b/assistant/src/plugin-api/publish-event.ts
@@ -14,7 +14,7 @@
  * `sync_changed`) so subscribed clients re-fetch the data that changed.
  */
 
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
+import type { AssistantEventEnvelope } from "../api/index.js";
 import {
   pluginAssistantEventHub,
   type PluginEventHub,

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -40,9 +40,9 @@ export function capabilityForMessageType(
   const stem = type.replace(/_(request|cancel)$/, "");
   return HOST_PREFIX_TO_CAPABILITY[stem];
 }
+import type { AssistantEventEnvelope } from "../api/index.js";
 import { appendEventToStream } from "../signals/event-stream.js";
 import { getLogger } from "../util/logger.js";
-import type { AssistantEventEnvelope } from "./assistant-event.js";
 import { buildAssistantEvent } from "./assistant-event.js";
 import { stampAndBuffer } from "./assistant-stream-state.js";
 
@@ -332,7 +332,9 @@ export class AssistantEventHub {
     const errors: unknown[] = [];
 
     for (const entry of snapshot) {
-      if (!entry.active) {continue;}
+      if (!entry.active) {
+        continue;
+      }
 
       // Self-echo suppression: the originating client never receives the
       // event back. Checked before every other rule so it composes with
@@ -349,27 +351,34 @@ export class AssistantEventHub {
       // the requested interface. Composes with `targetClientId` and
       // `targetCapability` below.
       if (targetInterfaceId != null) {
-        if (entry.type !== "client" || entry.interfaceId !== targetInterfaceId)
-          {continue;}
+        if (
+          entry.type !== "client" ||
+          entry.interfaceId !== targetInterfaceId
+        ) {
+          continue;
+        }
       }
 
       if (targetClientId != null) {
         // Targeted: bypass conversation filter, deliver only to the named client.
-        if (entry.type !== "client" || entry.clientId !== targetClientId)
-          {continue;}
+        if (entry.type !== "client" || entry.clientId !== targetClientId) {
+          continue;
+        }
         if (
           targetCapability != null &&
           !entry.capabilities.includes(targetCapability)
-        )
-          {continue;}
+        ) {
+          continue;
+        }
       } else {
         // Untargeted: existing conversation-scoped + capability logic.
         if (
           event.conversationId != null &&
           entry.filter.conversationId != null &&
           entry.filter.conversationId !== event.conversationId
-        )
-          {continue;}
+        ) {
+          continue;
+        }
 
         // Capability targeting: targeted events only go to subscribers that
         // declare the required capability.
@@ -377,8 +386,9 @@ export class AssistantEventHub {
           if (
             entry.type !== "client" ||
             !entry.capabilities.includes(targetCapability)
-          )
-            {continue;}
+          ) {
+            continue;
+          }
         }
       }
 
@@ -407,8 +417,9 @@ export class AssistantEventHub {
         entry.active &&
         entry.type === "client" &&
         entry.clientId === clientId
-      )
-        {return entry;}
+      ) {
+        return entry;
+      }
     }
     return undefined;
   }
@@ -433,7 +444,9 @@ export class AssistantEventHub {
     event: Pick<AssistantEventEnvelope, "conversationId">,
   ): boolean {
     for (const entry of this.subscribers) {
-      if (!entry.active) {continue;}
+      if (!entry.active) {
+        continue;
+      }
       if (
         event.conversationId != null &&
         entry.filter.conversationId != null &&

--- a/assistant/src/runtime/assistant-event.ts
+++ b/assistant/src/runtime/assistant-event.ts
@@ -41,24 +41,6 @@ interface BaseAssistantEvent<TMessage = unknown> {
   message: TMessage;
 }
 
-/**
- * Construct a `BaseAssistantEvent` envelope around a message payload.
- *
- * @param message         The outbound message payload.
- * @param conversationId  Optional conversation id -- pass when known.
- */
-function baseBuildAssistantEvent<TMessage>(
-  message: TMessage,
-  conversationId?: string,
-): BaseAssistantEvent<TMessage> {
-  return {
-    id: randomUUID(),
-    conversationId,
-    emittedAt: new Date().toISOString(),
-    message,
-  };
-}
-
 // -- SSE framing ---------------------------------------------------------------
 
 /**
@@ -94,10 +76,6 @@ export function formatSseHeartbeat(): string {
 
 // -- Daemon-side specialization ------------------------------------------------
 
-// Re-export the canonical envelope so daemon callers import it alongside the
-// builder below.
-export type { AssistantEventEnvelope };
-
 /**
  * Build a daemon event envelope (`AssistantEventEnvelope`) around an
  * `AssistantEvent` message payload.
@@ -106,5 +84,10 @@ export function buildAssistantEvent(
   message: AssistantEvent,
   conversationId?: string,
 ): AssistantEventEnvelope {
-  return baseBuildAssistantEvent<AssistantEvent>(message, conversationId);
+  return {
+    id: randomUUID(),
+    conversationId,
+    emittedAt: new Date().toISOString(),
+    message,
+  };
 }

--- a/assistant/src/runtime/assistant-stream-state.ts
+++ b/assistant/src/runtime/assistant-stream-state.ts
@@ -67,9 +67,9 @@ import {
   SSE_REPLAY_RING_AGE_LIMIT_MS,
   SSE_REPLAY_RING_COUNT_LIMIT,
 } from "../api/constants/sse-replay.js";
+import type { AssistantEventEnvelope } from "../api/index.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
-import type { AssistantEventEnvelope } from "./assistant-event.js";
 
 const log = getLogger("assistant-stream-state");
 

--- a/assistant/src/runtime/routes/workspace-routes.test.ts
+++ b/assistant/src/runtime/routes/workspace-routes.test.ts
@@ -17,8 +17,8 @@ import {
 import { join } from "node:path";
 import { beforeAll, describe, expect, test } from "bun:test";
 
+import type { AssistantEventEnvelope } from "../../api/index.js";
 import { SYNC_TAGS } from "../../daemon/message-types/sync.js";
-import type { AssistantEventEnvelope } from "../assistant-event.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
 
 // ---------------------------------------------------------------------------
@@ -66,15 +66,18 @@ beforeAll(() => {
 
 function getRoute(operationId: string): RouteDefinition {
   const route = ROUTES.find((r) => r.operationId === operationId);
-  if (!route)
+  if (!route) {
     throw new Error(`No shared route found for operationId: ${operationId}`);
+  }
   return route;
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {
   const deadline = Date.now() + 500;
   while (Date.now() < deadline) {
-    if (predicate()) return;
+    if (predicate()) {
+      return;
+    }
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   throw new Error("Timed out waiting for workspace route event");

--- a/assistant/src/runtime/sync/sync-publisher.test.ts
+++ b/assistant/src/runtime/sync/sync-publisher.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEventEnvelope } from "../../api/index.js";
 import { SYNC_TAGS } from "../../daemon/message-types/sync.js";
-import type { AssistantEventEnvelope } from "../assistant-event.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
 import { publishSyncInvalidation } from "./sync-publisher.js";
 

--- a/assistant/src/signals/event-stream.ts
+++ b/assistant/src/signals/event-stream.ts
@@ -24,8 +24,8 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import type { AssistantEventEnvelope } from "../api/index.js";
 import { getIsContainerized } from "../config/env-registry.js";
-import type { AssistantEventEnvelope } from "../runtime/assistant-event.js";
 import { getSignalsDir } from "../util/platform.js";
 
 // ── Write side (daemon) ──────────────────────────────────────────────
@@ -42,7 +42,9 @@ const CACHE_TTL_MS = 10_000;
 function getSubscriberDirs(conversationId: string): string[] {
   const now = Date.now();
   const cached = subscriberCache.get(conversationId);
-  if (cached && now < cached.expiry) return cached.dirs;
+  if (cached && now < cached.expiry) {
+    return cached.dirs;
+  }
 
   const dir = eventsDir();
   if (!existsSync(dir)) {
@@ -87,10 +89,14 @@ export function appendEventToStream(
   conversationId: string,
   event: AssistantEventEnvelope,
 ): void {
-  if (getIsContainerized()) return;
+  if (getIsContainerized()) {
+    return;
+  }
 
   const dirs = getSubscriberDirs(conversationId);
-  if (dirs.length === 0) return;
+  if (dirs.length === 0) {
+    return;
+  }
 
   const timestamp = `${Date.now()}-${String(sequence++).padStart(6, "0")}`;
   const payload = JSON.stringify(event);
@@ -148,7 +154,9 @@ export function watchEventStream(
   let disposed = false;
 
   const readNewEvents = (): void => {
-    if (disposed) return;
+    if (disposed) {
+      return;
+    }
     let files: string[];
     try {
       files = readdirSync(subDir).sort();
@@ -156,7 +164,9 @@ export function watchEventStream(
       return;
     }
     for (const file of files) {
-      if (processedFiles.has(file)) continue;
+      if (processedFiles.has(file)) {
+        continue;
+      }
       processedFiles.add(file);
       try {
         const data = readFileSync(join(subDir, file), "utf-8");

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -731,7 +731,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-24T21:02:01.000Z"
+      "updatedAt": "2026-07-27T13:06:07.000Z"
     },
     {
       "id": "public-ingress",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -869,7 +869,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-24T20:54:04.000Z"
+      "updatedAt": "2026-07-24T22:39:12.000Z"
     },
     {
       "id": "start-the-day",

--- a/skills/plugin-builder/references/plugins.md
+++ b/skills/plugin-builder/references/plugins.md
@@ -110,7 +110,8 @@ Values, not just types, that a plugin consumes at module-load or init time. A bo
 | Export                       | Kind  | Purpose                                                                                                |
 | ---------------------------- | ----- | ------------------------------------------------------------------------------------------------------ |
 | `assistantEventHub`          | value | The assistant's pub/sub hub for runtime events. Subscribe to react to activity outside the hook chain. |
-| `AssistantEventEnvelope`     | type  | Envelope a hub subscriber receives (`AssistantEvent` is a deprecated alias).                           |
+| `AssistantEvent`             | type  | A hub event message payload — the discriminated union of event types.                                  |
+| `AssistantEventEnvelope`     | type  | Envelope wrapping an `AssistantEvent` that a hub subscriber receives.                                  |
 | `AssistantEventHub`          | type  | Interface of the event hub itself.                                                                     |
 | `AssistantEventCallback`     | type  | Subscriber callback invoked for each matching event.                                                   |
 | `AssistantEventFilter`       | type  | Filter narrowing which events a subscription receives.                                                 |


### PR DESCRIPTION
## Why

Follow-up cleanup from the review of #39146, continuing the `AssistantEvent` unification. Now that the event union and its envelope are both canonical in `@vellumai/assistant-api`, the daemon's `runtime/assistant-event.ts` no longer needs to re-export the envelope or wrap a generic builder — callers can name the api types directly.

## What

- **`assistant-event`** — inline the generic `baseBuildAssistantEvent` into `buildAssistantEvent` (its only caller) and drop the `AssistantEventEnvelope` re-export. (both from the #39146 review)
- **~29 files** — repoint every `AssistantEventEnvelope` import from `runtime/assistant-event` to `../api`, the canonical source.
- **`plugin-api`** — export `AssistantEvent` and `AssistantEventEnvelope` directly from `../api`, dropping the deprecated compatibility alias. They're two distinct public types (the event message union and its SSE envelope), now documented separately in the plugin-builder reference. This is the intended breaking rename — the old `AssistantEvent`-as-envelope meaning is gone.
- **`secret-prompter`** — use `SecretRequestEvent` directly instead of the redundant `SecretRequestMessage` alias. (from the #39146 review)

Still to come as its own PR: dropping the `AssistantEvent` re-export from `daemon/message-protocol.ts` and repointing its ~40 importers to `../api`.

## Test plan

- `bun run typecheck:fast` — clean
- `bun test` on the touched suites (`assistant-event`, `assistant-event-hub`, `plugin-event-hub-facade`, `publish-event`, `runtime-events-sse-parity`, `daemon-assistant-events`, `secret-prompter-channel-fallback`, `plugin-import-boundary-guard`, `sync-publisher`) — pass in isolation
- `skills/catalog.json` regenerated for the plugin-builder reference edit
- eslint + prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_