### PR TITLE
test(cli): mock IPC client in usage-cli.test.ts for CLI plumbing verification

### DIFF
--- a/assistant/src/__tests__/usage-cli.test.ts
+++ b/assistant/src/__tests__/usage-cli.test.ts
@@ -60,9 +60,20 @@ async function runCommand(args: string[]): Promise<{
   return { exitCode, output: logLines.join("\n") };
 }
 
+let mockCliIpcCallFn: (method: string, params?: unknown) => Promise<unknown> = async () => ({ ok: true });
+
+mock.module("../ipc/cli-client.js", () => ({
+  cliIpcCall: (method: string, params?: unknown) => mockCliIpcCallFn(method, params),
+  exitFromIpcResult: (r: { statusCode?: number; error?: string }) => {
+    process.exitCode = r.statusCode === undefined ? 10 : r.statusCode >= 500 ? 3 : r.statusCode >= 400 ? 2 : 1;
+    throw new Error(r.error ?? "Unknown error");
+  },
+}));
+
 describe("assistant usage CLI", () => {
   beforeEach(() => {
     logLines.length = 0;
+    mockCliIpcCallFn = async () => ({ ok: true });
   });
 
   test("rejects invalid breakdown dimensions", async () => {
@@ -77,5 +88,17 @@ describe("assistant usage CLI", () => {
     expect(result.output).toContain("Invalid --group-by value");
     expect(result.output).toContain("call_site");
     expect(result.output).toContain("inference_profile");
+  });
+
+  test("executes breakdown via IPC and outputs result", async () => {
+    let capturedMethod = "";
+    mockCliIpcCallFn = async (method) => {
+      capturedMethod = method;
+      return { ok: true, rows: [] };
+    };
+
+    const result = await runCommand(["usage", "breakdown", "--group-by", "call_site"]);
+    expect(result.exitCode).toBe(0);
+    expect(capturedMethod).toBe("usage_breakdown");
   });
 });


### PR DESCRIPTION
## Description
This PR resolves issue #30259 by mocking the IPC client in `assistant/src/__tests__/usage-cli.test.ts`.

## Details
- Mocks `cliIpcCall` and `exitFromIpcResult` in `usage-cli.test.ts` to verify command invocation and options passing without requiring a live daemon.
- Tests `usage breakdown` IPC dispatch and option validation.