### PR TITLE
fix(ci): allow prefixed client secret keys in pre-commit secret scan whitelist

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -174,7 +174,7 @@ declare -a SAFE_LINE_PATTERNS=(
     # `$ref:`, `description:`, etc.). Without that context, an indented bare
     # `clientSecret:` line would whitelist any structurally-similar line in
     # any file type, weakening secret scanning outside schema files.
-    "^[[:space:]]+[Cc]lient[_-]?[Ss]ecret:[[:space:]]*$"
+    "^[[:space:]]+[a-zA-Z0-9_-]*[Cc]lient[_-]?[Ss]ecret:[[:space:]]*$"
     # TS: optional property type annotation (e.g. `clientSecret?: string;`)
     # Must end with type + optional semicolon/comma — no `=` assignment.
     # Also covers union types like `clientSecret: string | undefined;`.


### PR DESCRIPTION
## Description
This PR resolves issue #37758 by updating the bare-key whitelist pattern in `.githooks/pre-commit`.

## Details
- Expands `^[[:space:]]+[Cc]lient[_-]?[Ss]ecret:[[:space:]]*$` to `^[[:space:]]+[a-zA-Z0-9_-]*[Cc]lient[_-]?[Ss]ecret:[[:space:]]*$`.
- Prevents false-positive secret scanner hits on bare YAML schema property keys such as `requires_client_secret:` when committing updates to `openapi.yaml`.