### PR TITLE
fix(history): set single imageAttachmentId field on matched tool_result for legacy client compatibility

### DIFF
--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -734,6 +734,7 @@ export function renderHistoryContent(
           matched.imageDataList = imageDataList;
         }
         if (imageAttachmentIds.length > 0) {
+          matched.imageAttachmentId = imageAttachmentIds[0];
           matched.imageAttachmentIds = imageAttachmentIds;
         }
       }


### PR DESCRIPTION
## Description
This PR resolves issue #39009 (M3 history rendering) by populating `matched.imageAttachmentId = imageAttachmentIds[0]` alongside `imageAttachmentIds` in `renderHistoryContent` (`assistant/src/daemon/handlers/shared.ts`).

## Details
- When persisted tool result content blocks contain image attachment IDs, populating `imageAttachmentId` ensures single-attachment legacy client versions render tool result thumbnails cleanly.