### PR TITLE
fix(voice): include [ESCALATE] in stripInternalSpeechMarkers and CONTROL_MARKER_STRINGS

### DIFF
--- a/assistant/src/calls/voice-control-protocol.ts
+++ b/assistant/src/calls/voice-control-protocol.ts
@@ -152,6 +152,8 @@ function stripGuardianApprovalMarkers(text: string): string {
   return result;
 }
 
+const ESCALATE_MARKER_REGEX = /\[ESCALATE\]/g;
+
 export function stripInternalSpeechMarkers(text: string): string {
   let result = stripGuardianApprovalMarkers(text);
   result = result
@@ -163,6 +165,7 @@ export function stripInternalSpeechMarkers(text: string): string {
     .replace(END_CALL_MARKER_REGEX, "")
     .replace(HOLD_VERDICT_TOKEN_REGEX, "")
     .replace(ESCALATE_VERDICT_TOKEN_REGEX, "")
+    .replace(ESCALATE_MARKER_REGEX, "")
     .replace(GUARDIAN_TIMEOUT_MARKER_REGEX, "")
     .replace(GUARDIAN_UNAVAILABLE_MARKER_REGEX, "");
   return result;
@@ -187,6 +190,7 @@ const CONTROL_MARKER_STRINGS = [
   "[END_CALL]",
   "[0]",
   "[1]",
+  "[ESCALATE]",
   "[GUARDIAN_TIMEOUT]",
   "[GUARDIAN_UNAVAILABLE]",
 ];


### PR DESCRIPTION
## Description
This PR resolves issue #37850 by adding the `[ESCALATE]` control marker to `stripInternalSpeechMarkers` and `CONTROL_MARKER_STRINGS` in `voice-control-protocol.ts`.

## Details
- Adds `ESCALATE_MARKER_REGEX` (`/\[ESCALATE\]/g`) to `stripInternalSpeechMarkers` so `[ESCALATE]` tokens are stripped alongside `[END_CALL]` and `[ASK_GUARDIAN]`.
- Adds `"[ESCALATE]"` to `CONTROL_MARKER_STRINGS` so partial escalation marker streaming holds back appropriately in `couldBeControlMarker`.