### PR TITLE
test(cli): restore mock modules in local-ces.test.ts afterAll to prevent child_process leaks

### DIFF
--- a/cli/src/lib/__tests__/local-ces.test.ts
+++ b/cli/src/lib/__tests__/local-ces.test.ts
@@ -134,4 +134,11 @@ describe("startCes", () => {
     const cesPidFile = join(vellumDir, "ces.pid");
     expect(existsSync(cesPidFile)).toBe(true);
   }, 15_000);
+
+  afterAll(() => {
+    mock.module("node:child_process", () => realChildProcess);
+    mock.module("../xdg-log.js", () => realXdgLog);
+    mock.module("../process.js", () => realProcess);
+    mock.restore();
+  });
 });


### PR DESCRIPTION
## Description
This PR resolves issue #38443 by restoring real modules and invoking `mock.restore()` in an `afterAll` block in `cli/src/lib/__tests__/local-ces.test.ts`.

## Details
- Prevents `mock.module("node:child_process", ...)` in `local-ces.test.ts` from leaking into sibling test suites (such as `step-runner.test.ts` and `nginx-ingress.test.ts`) during Bun test execution.