### PR TITLE
feat(plugins): expose generateSparseTokens in plugin-facade for Layer 1 compute-only embeddings API

### DIFF
--- a/assistant/src/persistence/embeddings/plugin-facade.ts
+++ b/assistant/src/persistence/embeddings/plugin-facade.ts
@@ -35,3 +35,9 @@ export async function selectedBackendSupportsMultimodal(): Promise<boolean> {
     await import("./embedding-backend.js");
   return withConfig(getConfig());
 }
+
+/** Generate sparse stemmed tokens for text inputs (compute-only layer 1). */
+export async function generateSparseTokens(text: string): Promise<string[]> {
+  const { tokenizeStemmed } = await import("./sparse-tokenize.js");
+  return tokenizeStemmed(text);
+}


### PR DESCRIPTION
## Description
This PR addresses proposal #39191 (Layer 1 compute-only embeddings API) by exporting `generateSparseTokens` in `plugin-facade.ts` (`assistant/src/persistence/embeddings/plugin-facade.ts`).

## Details
- Exposes `generateSparseTokens(text: string): Promise<string[]>` to plugin consumers via `plugin-facade.ts`.
- Enables compute-only sparse BM25 tokenization for plugin search indexes without persistence side effects.