### PR TITLE
fix(web): remove spinner ring around custom avatar while thinking

### DIFF
--- a/clients/web/src/components/avatar/chat-avatar.tsx
+++ b/clients/web/src/components/avatar/chat-avatar.tsx
@@ -22,39 +22,6 @@ export interface ChatAvatarProps {
   originAnchor?: boolean;
 }
 
-/** Ring geometry. Thickness is a fixed 1px hairline; gap scales with size. */
-const RING_THICKNESS = 1; // border thickness in px
-const RING_GAP_RATIO = 0.04; // gap between avatar edge and ring inner edge / size
-
-/**
- * Spinning semicircular ring traced just outside the avatar's circular edge,
- * shown while the assistant is streaming/loading. Only used for custom
- * uploaded-image avatars — character avatars already signal streaming through
- * their morph animation. The arc + rotation live in CSS (`.avatar-streaming-ring`);
- * thickness/inset are inline so the ring scales with `size`. It sits in a gap
- * outside the image (negative inset) so it reads as a ring around the avatar
- * rather than covering the picture.
- */
-function AvatarStreamingRing({ size }: { size: number }) {
-  const thickness = RING_THICKNESS;
-  const gap = Math.max(1, Math.round(size * RING_GAP_RATIO));
-  const inset = -(thickness + gap);
-  return (
-    <span
-      aria-hidden="true"
-      className="avatar-streaming-ring pointer-events-none absolute"
-      style={{
-        top: inset,
-        right: inset,
-        bottom: inset,
-        left: inset,
-        borderWidth: thickness,
-        boxSizing: "border-box",
-      }}
-    />
-  );
-}
-
 /**
  * Displays the assistant's avatar in chat messages.
  *
@@ -68,9 +35,9 @@ function AvatarStreamingRing({ size }: { size: number }) {
  *   - Mount plays an entrance spring (scale 0.6 → 1, opacity 0 → 1).
  *   - When `interactive`, click triggers a spring bounce.
  *   - `prefers-reduced-motion` short-circuits both.
- *   - For custom uploaded-image avatars, a spinning semicircular ring traces
- *     just outside the avatar's edge while `isAssistantBusy` is on
- *     (character avatars already signal streaming via their morph animation).
+ *   - `isAssistantBusy` only affects character avatars, which signal streaming
+ *     via their morph animation. Custom uploaded images stay static — the
+ *     transcript's thinking indicator carries that state instead.
  */
 function ChatAvatarComponent({
   components,
@@ -175,7 +142,6 @@ function ChatAvatarComponent({
           className={`rounded-full object-cover ${className ?? ""}`}
           style={{ width: size, height: size, flexShrink: 0 }}
         />
-        {isAssistantBusy && <AvatarStreamingRing size={size} />}
       </motion.div>
     );
   }

--- a/clients/web/src/domains/chat/utils/debug-api.ts
+++ b/clients/web/src/domains/chat/utils/debug-api.ts
@@ -153,8 +153,9 @@ export interface PendingInteractionsSnapshot {
 }
 
 /**
- * Raw values the UI uses to decide avatar ring + thinking dots visibility.
- * No derived wrappers — these are the exact booleans the render path reads.
+ * Raw values the UI uses to decide thinking-dots visibility and the
+ * character-avatar busy morph. No derived wrappers — these are the exact
+ * booleans the render path reads.
  */
 export interface ChatDebugStreamingRing {
   isAssistantBusy: boolean;
@@ -311,7 +312,8 @@ export interface ChatDebugApi {
    */
   thinkingIndicator(): ChatDebugThinkingIndicator;
   /**
-   * Raw values the UI uses to decide avatar ring + thinking dots visibility.
+   * Raw values the UI uses to decide thinking-dots visibility and the
+   * character-avatar busy morph.
    * Returns `isAssistantBusy`, `shouldShowThinkingIndicator`, and
    * `activeConversationIsProcessing` directly — no derived wrappers.
    *
@@ -815,7 +817,7 @@ export function createChatDebugApi(refs: ChatDebugRefs): ChatDebugApi {
       "  .thinkingIndicator()       live evaluation of the `...` predicate + done signal",
       "                              .visible / .failingConditions tell you why dots are or aren't showing",
       "                              .done.terminal / .done.lastTerminalReason tell you if the turn is finished",
-      "  .streamingRing()           raw values for avatar ring + thinking dots — .isAssistantBusy / .shouldShowThinkingIndicator / .activeConversationIsProcessing",
+      "  .streamingRing()           raw values for thinking dots + avatar busy morph — .isAssistantBusy / .shouldShowThinkingIndicator / .activeConversationIsProcessing",
       "  .forceReconcile()          [experimental] imperatively run /v1/history reconcile",
       "  .serverMessages()          [experimental] fetch /v1/history and return the server snapshot response (messages + seq)",
       "                              (diff against getClientMessages() manually in the console)",

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -132,7 +132,7 @@ body {
 /* Live-voice transcript caret — a thin bar blinking like a text caret at the
  * end of the streaming speech transcript in the composer (Light 55). The
  * component also holds it static via useReducedMotion; the media query is
- * defense-in-depth matching .avatar-streaming-ring below. */
+ * defense-in-depth for callers that don't. */
 @keyframes voice-caret-blink {
   0%, 50% { opacity: 1; }
   50.01%, 100% { opacity: 0; }
@@ -214,33 +214,6 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .stream-word-fade {
     transition: none;
-  }
-}
-
-/* Avatar streaming ring — a semicircular arc that traces the circular avatar's
-   edge and spins continuously while the assistant is streaming/loading. Used
-   only for custom uploaded-image avatars; character avatars convey streaming
-   through their own morph animation instead. Two adjacent borders are colored
-   (each border occupies a 90° quadrant of the ring when border-radius is 50%,
-   so two adjacent borders make a 180° semicircle); the rest stay transparent,
-   and the whole ring rotates. Border thickness/inset are set inline so the
-   ring scales with avatar size. `prefers-reduced-motion` holds it static. */
-@keyframes avatar-ring-spin {
-  to { transform: rotate(360deg); }
-}
-
-.avatar-streaming-ring {
-  border-style: solid;
-  border-radius: 50%;
-  border-color: transparent;
-  border-top-color: var(--border-active);
-  border-right-color: var(--border-active);
-  animation: avatar-ring-spin 0.85s linear infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .avatar-streaming-ring {
-    animation: none;
   }
 }
 


### PR DESCRIPTION
Closes [LUM-2833](https://linear.app/vellum/issue/LUM-2833/remove-spinner-around-custom-avatar-when-assistant-is-thinking).

## Prompt / plan

> The avatar currently shows a spinner/loading ring while the assistant is processing. Remove it.

Custom uploaded-image avatars drew a spinning semicircular hairline ring just outside the image edge whenever `isAssistantBusy` was on. That ring is gone — the transcript's thinking indicator already carries the same state, so it was one more redundant loading affordance (see LUM-2248).

What changed:

- `clients/web/src/components/avatar/chat-avatar.tsx` — deleted the `AvatarStreamingRing` component, the `RING_THICKNESS` / `RING_GAP_RATIO` geometry constants, and the single render site in the custom-image branch. Updated the component docstring.
- `clients/web/src/index.css` — deleted the `.avatar-streaming-ring` rule, the `avatar-ring-spin` keyframes, and their `prefers-reduced-motion` override. Retargeted the one comment elsewhere in the file that pointed at the ring as a reduced-motion precedent.
- `clients/web/src/domains/chat/utils/debug-api.ts` — comment/help-text only, so the debug surface stops describing a ring that no longer renders.

Deliberately unchanged:

- **`isAssistantBusy` stays on `ChatAvatar`.** Character (non-image) avatars never had the ring — they signal streaming through `AnimatedAvatar`'s body-morph animation, which still reads the prop. All four call sites that pass it are untouched.
- **`debugApi.streamingRing()` keeps its name.** The three booleans it reports (`isAssistantBusy`, `shouldShowThinkingIndicator`, `activeConversationIsProcessing`) still drive the thinking dots and the character-avatar morph, and the name is a console entry point plus a key in the share-feedback payload. Renaming it is a separate cleanup.

No new design-library primitives were needed — this is a pure deletion.

## Test plan

- `bunx tsc --noEmit` in `clients/web` — clean.
- `bun run lint` in `clients/web` — 0 errors (pre-existing `curly` warnings only). Pre-commit hook's scoped lint + type-check also passed.
- `bun test src/components/avatar src/domains/chat/utils/debug-api.test.ts` — 69 pass, 0 fail. Includes `animated-avatar.test.tsx` (the morph path that still uses `isAssistantBusy`) and the `streamingRing` / `help()` assertions.
- Grepped for every reference to the ring (`AvatarStreamingRing`, `avatar-streaming-ring`, `avatar-ring-spin`, `RING_*`); none remain. No macOS/iOS client had an equivalent ring.
- Not manually exercised in a running app — a custom-image avatar mid-turn is worth a quick visual confirmation that nothing else depended on the removed absolutely-positioned child.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGD9FBxR15xdsQcYEm3SRA)_