### PR TITLE
refactor(events): route all emitters through broadcastMessage so events are sequenced

### DIFF
--- a/assistant/src/__tests__/disk-pressure-routes.test.ts
+++ b/assistant/src/__tests__/disk-pressure-routes.test.ts
@@ -21,11 +21,18 @@ mock.module("../runtime/assistant-event.js", () => ({
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
   AssistantEventHub: class {},
-  broadcastMessage: () => {},
+  broadcastMessage: (message: unknown, conversationId?: string) => {
+    const event = { message, conversationId };
+    for (const callback of eventSubscribers) {
+      callback(event);
+    }
+  },
   capabilityForMessageType: () => undefined,
   assistantEventHub: {
     publish: async (event: unknown) => {
-      for (const callback of eventSubscribers) callback(event);
+      for (const callback of eventSubscribers) {
+        callback(event);
+      }
     },
     subscribe: ({ callback }: { callback: (event: unknown) => void }) => {
       eventSubscribers.add(callback);
@@ -87,7 +94,9 @@ function getRoute(endpoint: string, method: string) {
   const route = ROUTES.find(
     (r) => r.endpoint === endpoint && r.method === method,
   );
-  if (!route) throw new Error(`${method} ${endpoint} route not registered`);
+  if (!route) {
+    throw new Error(`${method} ${endpoint} route not registered`);
+  }
   return route;
 }
 

--- a/assistant/src/daemon/conversation-launch.ts
+++ b/assistant/src/daemon/conversation-launch.ts
@@ -11,8 +11,7 @@ import { randomUUID } from "node:crypto";
 
 import { updateConversationTitle } from "../persistence/conversation-crud.js";
 import { getOrCreateConversation as getOrCreateConversationKey } from "../persistence/conversation-key-store.js";
-import { buildAssistantEvent } from "../runtime/assistant-event.js";
-import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
 import { getOrCreateConversation } from "./conversation-store.js";
 import { processMessageInBackground } from "./process-message.js";
@@ -72,19 +71,17 @@ export async function launchConversation(
     updateConversationTitle(conversationId, params.title, 0);
   }
 
-  await assistantEventHub.publish(
-    buildAssistantEvent(
-      {
-        type: "open_conversation",
-        conversationId,
-        ...(params.title ? { title: params.title } : {}),
-        ...(params.anchorMessageId
-          ? { anchorMessageId: params.anchorMessageId }
-          : {}),
-        ...(params.focus !== undefined ? { focus: params.focus } : {}),
-      },
+  broadcastMessage(
+    {
+      type: "open_conversation",
       conversationId,
-    ),
+      ...(params.title ? { title: params.title } : {}),
+      ...(params.anchorMessageId
+        ? { anchorMessageId: params.anchorMessageId }
+        : {}),
+      ...(params.focus !== undefined ? { focus: params.focus } : {}),
+    },
+    conversationId,
   );
 
   processMessageInBackground(conversationId, params.seedPrompt, {

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -3,8 +3,7 @@ import {
   type DiskPressureState,
   type DiskPressureStatus,
 } from "../api/events/disk-pressure-status-changed.js";
-import { buildAssistantEvent } from "../runtime/assistant-event.js";
-import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { cancelBackgroundTools } from "../tools/background-tool-registry.js";
 import { getDiskUsageInfo } from "../util/disk-usage.js";
 import { getLogger } from "../util/logger.js";
@@ -107,16 +106,10 @@ function statusFingerprint(status: DiskPressureStatus): string {
 function publishStatusChangedIfNeeded(previous: DiskPressureStatus): void {
   if (statusFingerprint(previous) === statusFingerprint(state.status)) return;
   const status = cloneStatus(state.status);
-  assistantEventHub
-    .publish(
-      buildAssistantEvent({
-        type: "disk_pressure_status_changed",
-        status,
-      }),
-    )
-    .catch((err) => {
-      log.warn({ err }, "Failed to publish disk pressure status change");
-    });
+  broadcastMessage({
+    type: "disk_pressure_status_changed",
+    status,
+  });
 }
 
 function replaceStatus(next: DiskPressureStatus): DiskPressureStatus {

--- a/assistant/src/home/__tests__/feed-writer.test.ts
+++ b/assistant/src/home/__tests__/feed-writer.test.ts
@@ -35,7 +35,9 @@ mock.module("../../runtime/assistant-event-hub.js", () => ({
     // hub's real shape has more fields. Tests never call them.
     subscribe: () => () => {},
   },
-  broadcastMessage: async () => {},
+  broadcastMessage: (message: unknown, conversationId?: string) => {
+    void publishSpy({ message, conversationId });
+  },
 }));
 
 // Dynamic import so the module resolves after the mock above is in
@@ -717,11 +719,7 @@ describe("feed-writer", () => {
         }),
       );
 
-      const count = await bulkSetFeedItemStatus(
-        ["new"],
-        "seen",
-        ["n1", "n3"],
-      );
+      const count = await bulkSetFeedItemStatus(["new"], "seen", ["n1", "n3"]);
       expect(count).toBe(2);
 
       const decoded = readFileJson();
@@ -734,7 +732,9 @@ describe("feed-writer", () => {
     test("ids scope with no matching ids returns 0", async () => {
       await appendFeedItem(makeItem({ id: "n1", status: "new" }));
 
-      const count = await bulkSetFeedItemStatus(["new"], "seen", ["nonexistent"]);
+      const count = await bulkSetFeedItemStatus(["new"], "seen", [
+        "nonexistent",
+      ]);
       expect(count).toBe(0);
 
       const decoded = readFileJson();

--- a/assistant/src/home/__tests__/home-content-refresh.test.ts
+++ b/assistant/src/home/__tests__/home-content-refresh.test.ts
@@ -26,6 +26,9 @@ mock.module("../suggested-prompts.js", () => ({
 const publishSpy = mock<(event: unknown) => Promise<void>>(async () => {});
 mock.module("../../runtime/assistant-event-hub.js", () => ({
   assistantEventHub: { publish: publishSpy },
+  broadcastMessage: (message: unknown) => {
+    void publishSpy(message);
+  },
 }));
 
 mock.module("../../runtime/assistant-event.js", () => ({

--- a/assistant/src/home/__tests__/suggested-prompts.test.ts
+++ b/assistant/src/home/__tests__/suggested-prompts.test.ts
@@ -61,6 +61,7 @@ mock.module("../../runtime/assistant-event.js", () => ({
 
 mock.module("../../runtime/assistant-event-hub.js", () => ({
   assistantEventHub: { publish: async () => {} },
+  broadcastMessage: () => {},
 }));
 
 const { getSuggestedPrompts, refreshAssistantSuggestedPrompts } =

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -37,8 +37,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { buildAssistantEvent } from "../runtime/assistant-event.js";
-import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
 import { getDataDir } from "../util/platform.js";
 import {
@@ -523,15 +522,9 @@ function compareFeedItems(a: FeedItem, b: FeedItem): number {
  * writer coalescing loop.
  */
 function publishHomeFeedUpdated(updatedAt: string, newItemCount: number): void {
-  assistantEventHub
-    .publish(
-      buildAssistantEvent({
-        type: "home_feed_updated",
-        updatedAt,
-        newItemCount,
-      }),
-    )
-    .catch((err) => {
-      log.warn({ err }, "Failed to publish home_feed_updated event");
-    });
+  broadcastMessage({
+    type: "home_feed_updated",
+    updatedAt,
+    newItemCount,
+  });
 }

--- a/assistant/src/home/home-content-refresh.ts
+++ b/assistant/src/home/home-content-refresh.ts
@@ -14,8 +14,7 @@
  * (4 hours each) bound how often a regeneration can happen.
  */
 
-import { buildAssistantEvent } from "../runtime/assistant-event.js";
-import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
 import { refreshPersonalizedGreeting } from "./home-greeting.js";
 import { refreshAssistantSuggestedPrompts } from "./suggested-prompts.js";
@@ -34,13 +33,11 @@ async function revalidateAll(): Promise<void> {
     return;
   }
 
-  await assistantEventHub.publish(
-    buildAssistantEvent({
-      type: "home_feed_updated",
-      updatedAt: new Date().toISOString(),
-      newItemCount: 0,
-    }),
-  );
+  broadcastMessage({
+    type: "home_feed_updated",
+    updatedAt: new Date().toISOString(),
+    newItemCount: 0,
+  });
 }
 
 /**

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -25,8 +25,7 @@ import { getGuardianDelivery } from "../contacts/guardian-delivery-reader.js";
 import { listConnections } from "../oauth/oauth-store.js";
 import { countConversations as countConversationsDb } from "../persistence/conversation-queries.js";
 import { resolveGuardianPersonaPath } from "../prompts/persona-resolver.js";
-import { buildAssistantEvent } from "../runtime/assistant-event.js";
-import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import type { OnboardingContext } from "../types/onboarding-context.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -316,16 +315,10 @@ export async function writeRelationshipState(): Promise<void> {
  * just landed on disk.
  */
 function publishRelationshipStateUpdated(updatedAt: string): void {
-  assistantEventHub
-    .publish(
-      buildAssistantEvent({
-        type: "relationship_state_updated",
-        updatedAt,
-      }),
-    )
-    .catch((err) => {
-      log.warn({ err }, "Failed to publish relationship_state_updated event");
-    });
+  broadcastMessage({
+    type: "relationship_state_updated",
+    updatedAt,
+  });
 }
 
 /**

--- a/assistant/src/home/suggested-prompts-cache.ts
+++ b/assistant/src/home/suggested-prompts-cache.ts
@@ -16,12 +16,8 @@ import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
 } from "../persistence/checkpoints.js";
-import { buildAssistantEvent } from "../runtime/assistant-event.js";
-import { assistantEventHub } from "../runtime/assistant-event-hub.js";
-import { getLogger } from "../util/logger.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import type { SuggestedPrompt } from "./feed-types.js";
-
-const log = getLogger("suggested-prompts-cache");
 
 const LLM_CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 
@@ -74,18 +70,9 @@ export function invalidateAssistantSuggestedPromptsCache(): void {
   } catch {
     // Invalidation failure is non-fatal — the TTL still bounds staleness.
   }
-  assistantEventHub
-    .publish(
-      buildAssistantEvent({
-        type: "home_feed_updated",
-        updatedAt: new Date().toISOString(),
-        newItemCount: 0,
-      }),
-    )
-    .catch((err) => {
-      log.warn(
-        { err },
-        "Failed to publish home_feed_updated after prompt cache invalidation",
-      );
-    });
+  broadcastMessage({
+    type: "home_feed_updated",
+    updatedAt: new Date().toISOString(),
+    newItemCount: 0,
+  });
 }

--- a/assistant/src/runtime/routes/__tests__/bookmark-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/bookmark-routes.test.ts
@@ -22,7 +22,9 @@ mock.module("../../assistant-event-hub.js", () => ({
     },
     subscribe: () => () => {},
   },
-  broadcastMessage: async () => {},
+  broadcastMessage: (message: unknown, conversationId?: string) => {
+    publishCalls.push({ message, conversationId });
+  },
 }));
 
 import { getDb } from "../../../persistence/db-connection.js";
@@ -47,7 +49,9 @@ await initializeDb();
 
 function findHandler(operationId: string): RouteDefinition["handler"] {
   const route = BOOKMARK_ROUTES.find((r) => r.operationId === operationId);
-  if (!route) throw new Error(`Route ${operationId} not found`);
+  if (!route) {
+    throw new Error(`Route ${operationId} not found`);
+  }
   return route.handler;
 }
 

--- a/assistant/src/runtime/routes/bookmark-routes.ts
+++ b/assistant/src/runtime/routes/bookmark-routes.ts
@@ -20,33 +20,21 @@ import {
 } from "../../persistence/bookmark-crud.js";
 import { getMessageById } from "../../persistence/conversation-crud.js";
 import { getDb } from "../../persistence/db-connection.js";
-import { getLogger } from "../../util/logger.js";
-import { buildAssistantEvent } from "../assistant-event.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import { broadcastMessage } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
-
-const log = getLogger("bookmark-routes");
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 function publishBookmarkCreated(bookmark: BookmarkSummary): void {
-  assistantEventHub
-    .publish(buildAssistantEvent({ type: "bookmark.created", bookmark }))
-    .catch((err) => {
-      log.warn({ err }, "Failed to publish bookmark.created");
-    });
+  broadcastMessage({ type: "bookmark.created", bookmark });
 }
 
 function publishBookmarkDeleted(payload: { messageId: string }): void {
-  assistantEventHub
-    .publish(buildAssistantEvent({ type: "bookmark.deleted", ...payload }))
-    .catch((err) => {
-      log.warn({ err }, "Failed to publish bookmark.deleted");
-    });
+  broadcastMessage({ type: "bookmark.deleted", ...payload });
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -30,8 +30,7 @@ import {
   getSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import { getExistingDeviceId } from "../../util/device-id.js";
-import { buildAssistantEvent } from "../assistant-event.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import { broadcastMessage } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS, LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import {
   BadRequestError,
@@ -193,9 +192,7 @@ async function handlePlatformConnect(
   }
 
   // Emit signal for connected clients to show the platform login UI
-  await assistantEventHub.publish(
-    buildAssistantEvent({ type: "show_platform_login" }),
-  );
+  broadcastMessage({ type: "show_platform_login" });
 
   return { showPlatformLogin: true };
 }
@@ -259,9 +256,7 @@ async function handlePlatformDisconnect(
   }
 
   // Notify connected clients
-  await assistantEventHub.publish(
-    buildAssistantEvent({ type: "platform_disconnected" }),
-  );
+  broadcastMessage({ type: "platform_disconnected" });
 
   return {
     disconnected: true,

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -69,8 +69,7 @@ import { generateAvatarImage } from "../../tools/system/avatar-generator.js";
 import { pathExists } from "../../util/fs.js";
 import { getLogger } from "../../util/logger.js";
 import { getAvatarImagePath, getWorkspaceDir } from "../../util/platform.js";
-import { buildAssistantEvent } from "../assistant-event.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import { broadcastMessage } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { publishAvatarChanged } from "../sync/resource-sync-events.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
@@ -250,22 +249,13 @@ async function handleOAuthConnectStart({ body = {} }: RouteHandlerArgs) {
           // DB not ready — use orchestrator value
         }
 
-        assistantEventHub
-          .publish(
-            buildAssistantEvent({
-              type: "oauth_connect_result",
-              success: deferredResult.success,
-              service: deferredResult.service,
-              accountInfo,
-              error: deferredResult.error,
-            }),
-          )
-          .catch((err) => {
-            log.warn(
-              { err, service: deferredResult.service },
-              "Failed to publish oauth_connect_result event",
-            );
-          });
+        broadcastMessage({
+          type: "oauth_connect_result",
+          success: deferredResult.success,
+          service: deferredResult.service,
+          accountInfo,
+          error: deferredResult.error,
+        });
 
         if (!deferredResult.success) {
           log.warn(

--- a/assistant/src/runtime/routes/upgrade-broadcast-routes.ts
+++ b/assistant/src/runtime/routes/upgrade-broadcast-routes.ts
@@ -8,8 +8,7 @@ import { z } from "zod";
 import type { ServiceGroupUpdateCompleteEvent } from "../../api/events/service-group-update-complete.js";
 import type { ServiceGroupUpdateProgressEvent } from "../../api/events/service-group-update-progress.js";
 import type { ServiceGroupUpdateStartingEvent } from "../../api/events/service-group-update-starting.js";
-import { buildAssistantEvent } from "../assistant-event.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import { broadcastMessage } from "../assistant-event-hub.js";
 import { GATEWAY_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -48,7 +47,7 @@ async function handleUpgradeBroadcast({ body }: RouteHandlerArgs) {
       expectedDowntimeSeconds: downtime,
     };
 
-    await assistantEventHub.publish(buildAssistantEvent(message));
+    broadcastMessage(message);
 
     return { ok: true };
   }
@@ -67,7 +66,7 @@ async function handleUpgradeBroadcast({ body }: RouteHandlerArgs) {
       statusMessage,
     };
 
-    await assistantEventHub.publish(buildAssistantEvent(message));
+    broadcastMessage(message);
 
     return { ok: true };
   }
@@ -108,7 +107,7 @@ async function handleUpgradeBroadcast({ body }: RouteHandlerArgs) {
         : {}),
     };
 
-    await assistantEventHub.publish(buildAssistantEvent(message));
+    broadcastMessage(message);
 
     return { ok: true };
   }

--- a/assistant/src/signals/emit-event.ts
+++ b/assistant/src/signals/emit-event.ts
@@ -16,8 +16,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { AssistantEvent } from "../daemon/message-protocol.js";
-import { buildAssistantEvent } from "../runtime/assistant-event.js";
-import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
 import { getSignalsDir } from "../util/platform.js";
 
@@ -28,11 +27,7 @@ export function handleEmitEventSignal(): void {
     const content = readFileSync(join(getSignalsDir(), "emit-event"), "utf-8");
     const message = JSON.parse(content) as AssistantEvent;
 
-    assistantEventHub
-      .publish(buildAssistantEvent(message))
-      .catch((err: unknown) => {
-        log.error({ err }, "Failed to publish event from signal");
-      });
+    broadcastMessage(message);
 
     log.info({ type: message.type }, "Emit-event signal handled");
   } catch (err) {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -731,7 +731,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-07-27T13:06:07.000Z"
+      "updatedAt": "2026-07-27T13:35:46.000Z"
     },
     {
       "id": "public-ingress",


### PR DESCRIPTION
## Why

Follow-up from the review of #39201: consolidate event emission onto a single sequenced path.

`broadcastMessage` (the hub's documented "primary entrypoint for emitting events") builds the envelope, stamps a monotonic `seq`, buffers the event in the replay ring, then publishes. But ~12 production call sites bypassed it — calling `buildAssistantEvent(...)` and `assistantEventHub.publish(...)` directly — so their events got **no `seq` and were never buffered for replay**. Conversation-scoped events emitted that way (e.g. `open_conversation`) silently couldn't be replayed on reconnect.

Per the direction you described (all events sequenced, building toward an immutable event log), this routes every emitter through `broadcastMessage`.

## What

Converted 12 call sites across 11 modules:

- **Routes:** `bookmark-routes` (create/delete), `settings-routes` (`oauth_connect_result`), `upgrade-broadcast-routes` (starting/progress/complete), `platform-routes` (`show_platform_login`, `platform_disconnected`)
- **Daemon:** `conversation-launch` (`open_conversation`), `disk-pressure-guard` (`disk_pressure_status_changed`)
- **Signals:** `emit-event` (relayed signal events)
- **Home:** `suggested-prompts-cache`, `relationship-state-writer`, `home-content-refresh`, `feed-writer` (`home_feed_updated` / `relationship_state_updated`)

`broadcastMessage` is fire-and-forget and logs publish failures internally, so the per-caller `await` / `.catch` handlers are removed (two files had a `log` binding that then became dead — removed with its import). `conversation-launch` keeps its explicit `conversationId`, so `open_conversation` is now conversation-scoped and enters the replay ring — the main behavior change.

`buildAssistantEvent` remains as the hub's internal builder (still used by `broadcastMessage` and by tests); no production site bypasses sequencing anymore.

### Tests

Suites that captured emitted events by stubbing `assistantEventHub.publish` now capture via the `broadcastMessage` mock instead (`bookmark-routes`, `disk-pressure-routes`, `feed-writer`, `home-content-refresh`, `suggested-prompts`). The seq/replay machinery itself is unchanged and stays covered by the existing SSE reconnect/parity suites.

## Test plan

- `bun run typecheck:fast` — clean
- `bun test` on every suite exercising a converted emitter (bookmark, disk-pressure guard/routes/tools, all four home writers, conversation-surfaces-launch, emit-event-signal) plus the core event suites (`runtime-events-sse-parity`, `daemon-assistant-events`, `assistant-event-hub`, `plugin-import-boundary-guard`) — pass in isolation
- `bun run generate:openapi -- --check` — unchanged (route handler bodies only)
- eslint (0 errors) + prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_