### PR TITLE
fix(providers): expire the per-connection provider cache so rotated keys self-heal

### DIFF
--- a/assistant/src/providers/__tests__/registry-native-web-search.test.ts
+++ b/assistant/src/providers/__tests__/registry-native-web-search.test.ts
@@ -1,4 +1,12 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 import { LLMSchema } from "../../config/schemas/llm.js";
 import type { ProviderConnection } from "../inference/auth.js";
@@ -112,6 +120,44 @@ describe("resolveProviderFromConnection native web search selection", () => {
         useNativeWebSearch: true,
       }),
     ]);
+  });
+});
+
+describe("resolveProviderFromConnection connection cache TTL", () => {
+  beforeEach(() => {
+    adapterCalls.length = 0;
+    clearConnectionProviderCache();
+    setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    // Restore the real clock so later suites are not frozen.
+    setSystemTime();
+  });
+
+  test("serves a cached provider within the TTL, re-resolves after it expires", async () => {
+    // First resolution: a cache miss builds an adapter.
+    await resolveProviderFromConnection(openRouterConnection, makeConfig(), {
+      model: "anthropic/claude-opus-4-7",
+    });
+    expect(adapterCalls).toHaveLength(1);
+
+    // A second resolution 59s later is a cache hit — no new adapter, so the
+    // baked-in credential is reused.
+    setSystemTime(new Date("2026-01-01T00:00:59Z"));
+    await resolveProviderFromConnection(openRouterConnection, makeConfig(), {
+      model: "anthropic/claude-opus-4-7",
+    });
+    expect(adapterCalls).toHaveLength(1);
+
+    // Past the 60s TTL the entry is stale: the next resolution re-reads the
+    // credential and rebuilds the adapter, so a key rotated out-of-band is
+    // picked up without any explicit cache invalidation.
+    setSystemTime(new Date("2026-01-01T00:01:01Z"));
+    await resolveProviderFromConnection(openRouterConnection, makeConfig(), {
+      model: "anthropic/claude-opus-4-7",
+    });
+    expect(adapterCalls).toHaveLength(2);
   });
 });
 

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -35,8 +35,32 @@ const providers = new Map<string, Provider>();
 const routingSources = new Map<string, "user-key" | "managed-proxy">();
 const NATIVE_WEB_SEARCH_PROVIDER_IDS = new Set(["anthropic", "openai"]);
 
+/**
+ * A cached per-connection provider and the wall-clock time it goes stale.
+ *
+ * The credential store is the source of truth for a connection's API key; a
+ * resolved provider bakes that key into its auth headers and is only a cache of
+ * it. `expiresAt` bounds how long a cached provider is trusted before the key
+ * is re-read from the store, so a credential rotated out-of-band (e.g. the
+ * platform reprovisioning the assistant API key) is picked up on its own — in
+ * every process that holds this cache, with no cross-process invalidation.
+ */
+interface CachedConnectionProvider {
+  provider: Provider;
+  expiresAt: number;
+}
+
+/**
+ * How long a resolved per-connection provider is served from cache before it is
+ * re-resolved from the credential store. Bounds credential staleness in any
+ * process holding the cache (the daemon and each sidecar worker) to this
+ * window. Kept short enough that a rotated key self-heals quickly, long enough
+ * that repeated resolutions within a burst still reuse one adapter.
+ */
+const CONNECTION_PROVIDER_CACHE_TTL_MS = 60_000;
+
 /** Per-connection provider cache, keyed by connection name, effective provider, and model. */
-const connectionProviders = new Map<string, Provider>();
+const connectionProviders = new Map<string, CachedConnectionProvider>();
 
 function getConnectionProviderCacheKey(
   connection: ProviderConnection,
@@ -257,9 +281,12 @@ export async function initializeProviders(
 /**
  * Resolve a provider instance for a named `provider_connection`.
  *
- * Results are cached in `connectionProviders` for the lifetime of the
- * current `initializeProviders` invocation (cleared on next boot). This
- * prevents redundant vault reads for repeated calls to the same connection.
+ * Results are cached in `connectionProviders` to avoid redundant vault reads
+ * for repeated calls to the same connection. A cached provider bakes in the
+ * credential it resolved, so each entry carries a TTL
+ * ({@link CONNECTION_PROVIDER_CACHE_TTL_MS}): once it expires the credential is
+ * re-read from the store, bounding how long an out-of-band key rotation stays
+ * stale. Entries are also cleared eagerly on connection mutations and boot.
  *
  * Returns null when:
  *   - The connection doesn't exist in the DB
@@ -292,9 +319,12 @@ export async function resolveProviderFromConnection(
     effectiveProvider,
   );
   const cached = connectionProviders.get(cacheKey);
-  if (cached) {
-    return cached;
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.provider;
   }
+  // A stale entry is a miss: fall through to re-resolve. The credential is
+  // re-read from the store below, so a key rotated since the entry was cached
+  // is picked up here rather than served stale forever.
 
   const authResult = await resolveAuth(connection.auth, effectiveProvider, {
     baseUrl: connection.baseUrl,
@@ -341,7 +371,10 @@ export async function resolveProviderFromConnection(
   );
 
   if (provider) {
-    connectionProviders.set(cacheKey, provider);
+    connectionProviders.set(cacheKey, {
+      provider,
+      expiresAt: Date.now() + CONNECTION_PROVIDER_CACHE_TTL_MS,
+    });
   }
 
   return provider;


### PR DESCRIPTION
## Prompt / plan

Investigation ATL-1130: "Stale API key passed to scheduler worker."

**Root cause.** A resolved provider reads the credential from the store and bakes it into its `Authorization` header, then gets cached in a module-level map (`connectionProviders`) in `providers/registry.ts`. That entry lived for the whole process lifetime. When a credential changed out-of-band — e.g. the platform reprovisioning the assistant API key — a process that had already cached the provider kept sending the old key forever. The schedule and memory sidecar workers were hit hardest: they resolve providers in their own OS processes and never saw the daemon's in-process refresh, so scheduled and background-wake inference failed with auth errors.

**Fix.** Treat the cache as a cache instead of a source of truth. Each per-connection provider entry now carries a 60s TTL. An expired entry is a cache miss, and the miss path already re-reads the credential from the store (the source of truth) and rebuilds the adapter. Staleness is now self-bounded in every process that holds the cache — the daemon and each sidecar worker — with no cross-process invalidation signal, no IPC, and no per-process "you must be told when to let go" coupling.

The daemon's existing eager clear + re-init on a credential change (and the connection-mutation eviction in `inference/connections.ts`) still apply for instant local refresh; the TTL is the self-healing floor underneath them that also covers the sidecars.

Scope note: the inference path the scheduler/memory workers actually use is `resolveConfiguredProvider` → `tryResolveProviderForConnectionName` → `resolveProviderFromConnection`, i.e. the connection cache changed here. The separate `providers` registry map (`getProvider`) is refreshed in the daemon on credential change and is not the source of the stale-key inference in the sidecars.

## Test plan

- New unit test in `registry-native-web-search.test.ts` drives the cache through its TTL with `setSystemTime`: a resolution at t+0 builds one adapter, a resolution at t+59s is a cache hit (no rebuild), and a resolution at t+61s re-resolves and rebuilds — proving a rotated key is picked up without explicit invalidation.
- `bun test` for the registry + retry-callsite suites: 44 pass / 0 fail.
- `bunx tsc --noEmit` clean; `eslint` and `prettier --check` clean; pre-commit/pre-push hooks green.

<!-- Delete this section if your PR does not add any new routes. -->
No new routes are added — the change is internal to provider-cache resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUaEuqTp56riCVTwjjEWwS)_