### PR TITLE
fix(web): reset the test state the checkout funnel added

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -259,6 +259,29 @@ mock.module("@tanstack/react-query", () => ({
   useQueryClient: () => queryClientMock,
 }));
 
+// Platform hatches hold for the post-payment resize before handing off, which
+// reads the billing surface. These tests cover the lifecycle/avatar hand-off on
+// a plain org, so the subscription resolves as a confirmed non-Pro plan and the
+// wait returns without polling. Post-payment provisioning itself is covered in
+// pages/hatching-screen.test.tsx. Only the four calls the hatching screen makes
+// are overridden — the rest of the SDK stays real (the organization store binds
+// `organizationsList` from it).
+const actualSdk = await import("@/generated/api/sdk.gen");
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...actualSdk,
+  assistantsOperationalStatusDetailRead: async () => ({
+    data: { state: "active", active_operation: null },
+  }),
+  organizationsBillingSubscriptionOnboardingEnsureProvisionedCreate:
+    async () => ({ data: { state: "noop", reason: null, targets: {} } }),
+  organizationsBillingSubscriptionOnboardingRetrieve: async () => ({
+    data: { max_machine_tier: null, selected_storage_gib: null },
+  }),
+  organizationsBillingSubscriptionRetrieve: async () => ({
+    data: { plan_id: "base" },
+  }),
+}));
+
 mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
   assistantsActiveRetrieveOptions: () => ({}),
   assistantsOauthConnectionsListOptions: () => ({}),

--- a/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page-checkout.test.tsx
@@ -35,7 +35,10 @@ import type {
   ProPackage,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
-import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
+import {
+  clearCheckoutIntent,
+  readCheckoutIntent,
+} from "@/lib/billing/checkout-intent";
 
 const CHECKOUT_URL = "https://stripe.test/checkout/session";
 
@@ -207,7 +210,9 @@ function renderPage(subscription: SubscriptionResponse) {
 beforeEach(() => {
   upgradeCall = null;
   openedUrl = null;
-  sessionStorage.clear();
+  // The stash also keeps an in-memory mirror, so clearing sessionStorage alone
+  // leaves a prior test's intent readable.
+  clearCheckoutIntent();
 });
 
 afterEach(() => {

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.test.tsx
@@ -85,7 +85,10 @@ mock.module("@/runtime/browser", () => ({
   openUrlFinishedListener: () => () => {},
 }));
 
-import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
+import {
+  clearCheckoutIntent,
+  readCheckoutIntent,
+} from "@/lib/billing/checkout-intent";
 import { AdjustPlanModal } from "./adjust-plan-modal";
 
 const CREDIT_TIERS: CreditTier[] = [
@@ -259,7 +262,9 @@ beforeEach(() => {
   changeMachineTierCall = null;
   changeStorageTierCall = null;
   openedUrl = null;
-  sessionStorage.clear();
+  // The stash also keeps an in-memory mirror, so clearing sessionStorage alone
+  // leaves a prior test's intent readable.
+  clearCheckoutIntent();
 });
 
 afterEach(() => {


### PR DESCRIPTION
Fixes the red `Test` job on #39161. Three test files fail on the feature branch — all three reproduce locally and deterministically, and all three pass at `origin/main`, so this is a real regression from the branch, not a flake.

CI run [30136577451](https://github.com/vellum-ai/vellum-assistant/actions/runs/30136577451) failed **3 files** (not 3 tests):

| File | Modified by the branch? |
| --- | --- |
| `onboarding/onboarding-lifecycle-sync.test.tsx` | no |
| `settings/billing/plans/plans-page-checkout.test.tsx` | no |
| `settings/components/adjust-plan-modal.test.tsx` | no |

All three are pre-existing tests that the branch's **production** code broke by reaching a surface they never stubbed or reset.

## 1 — `onboarding-lifecycle-sync.test.tsx`

`hatching-screen.tsx` grew `awaitPurchasedProvisioning()`, which every platform hatch now awaits before `handleHatchReady()`. It reads the billing SDK (`organizationsBillingSubscriptionRetrieve`, the onboarding targets, the ensure-provisioned reconcile, operational status).

The test runs in platform mode (`isLocalMode()` is false, so the local short-circuit doesn't apply) and does not mock `@/generated/api/sdk.gen`, so those calls hit the real network → `ECONNREFUSED`. A failed subscription read is deliberately treated as `"unknown"`, not `"free"`, so the loop polled every 3s to its 90s cap. The lifecycle refresh and avatar persist sit *after* that wait and never ran inside the test's 2s budget — hence `toHaveBeenCalled()` receiving 0.

The production behaviour is correct and is not changed here: against a real platform a confirmed non-Pro plan returns immediately, which `pages/hatching-screen.test.tsx` already covers (`free org with null targets completes with no added wait`, `a base plan whose targets fetch fails still completes, never trapping`). The gap was purely the missing stub.

Only the four calls the hatching screen makes are overridden — the rest of the SDK stays real via the `...actualSdk` spread, because the organization store binds `organizationsList` from the same module and Bun rejects a mock whose export set isn't a superset. That spread pattern is already used in `settings/ai/language-model-card.test.tsx`.

## 2 & 3 — the two checkout-intent tests

`checkout-intent.ts` gained a module-level `inMemoryIntent` mirror (added in 56782ea7e3) so an unavailable `sessionStorage` can't drop the stash. `readCheckoutIntent()` falls back to that mirror whenever sessionStorage is empty.

Both tests reset with a bare `sessionStorage.clear()`, which leaves the mirror populated — so a prior test's intent stayed readable and the "never stashes a checkout intent" assertions saw a leaked `{kind: "package", packageKey: "ultra"}` / `{kind: "custom", …}`.

Fixed by resetting through `clearCheckoutIntent()`, which clears both copies. This matches every other checkout-intent test (`plan-card-checkout`, `native-auth`, `navigation-resolver`, `checkout-intent`, `post-auth-checkout`) — these two simply predate the mirror and were never updated. No assertion was weakened.

No production path clears the key via a bare `removeItem`; all three consumers (`checkout-page.tsx`, `billing-onboarding-modal.tsx`, `post-auth-checkout.ts`) call `clearCheckoutIntent()`, so the mirror is sound in production.

## Verification

- Baseline comparison: all three files pass at `origin/main` (`f3f5cd6b08`) in an otherwise identical worktree, and fail on the branch. That's the proof this is a regression rather than an environmental issue.
- `bun run test:ci`: **719 passed, 6 failed (725 test files)** — down from 8 failed. All three target files pass.
- The 6 remaining failures are local-environment only: `@vellumai/service-contracts` resolves through a shared `node_modules` symlink into another checkout, so `secret-detection` / `remote-web-pairing` exports are missing. They fail **identically at `origin/main`** and were not among CI's failures (CI installs cleanly). Same root cause as the 74 `tsc` errors, whose output is byte-identical between the branch and baseline.
- `bun run lint`: 0 errors (2821 pre-existing `curly` warnings, unchanged).
- Prettier does not touch any added line. Both billing test files were already prettier-unclean before this change; left alone to keep the diff minimal.

Test-only change — no production code touched. The 3 open Codex threads on `hatching-screen.tsx` are deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)