### PR TITLE
refactor(events): single-source AssistantEvent from the api package (drop message-protocol re-export)

### DIFF
--- a/assistant/src/__tests__/acp-session.test.ts
+++ b/assistant/src/__tests__/acp-session.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { VellumAcpClientHandler } from "../acp/client-handler.js";
 import { AcpSessionManager } from "../acp/session-manager.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -11,7 +11,7 @@ import { Minimatch } from "minimatch";
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent } from "../agent/loop.js";
 import type { ConfirmationStateChangedEvent } from "../api/events/confirmation-state-changed.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 import type { ConfirmationDetails } from "../runtime/pending-interactions.js";
 

--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -6,8 +6,8 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { AssistantEvent } from "../api/index.js";
 import type { Conversation } from "../daemon/conversation.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { SecretPromptResult } from "../permissions/secret-prompt-types.js";
 
 mock.module("../config/env.js", () => ({

--- a/assistant/src/__tests__/channel-setup-panel-ack.test.ts
+++ b/assistant/src/__tests__/channel-setup-panel-ack.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { OpenPanelEvent } from "../api/events/open-panel.js";
+import type { AssistantEvent } from "../api/index.js";
 import {
   createSurfaceMutex,
   handleSurfaceAction,
@@ -19,7 +20,6 @@ import {
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
 import type {
-  AssistantEvent,
   SurfaceType,
 } from "../daemon/message-protocol.js";
 

--- a/assistant/src/__tests__/chat-reveal-guard-priming.test.ts
+++ b/assistant/src/__tests__/chat-reveal-guard-priming.test.ts
@@ -83,12 +83,12 @@ mock.module(
 // ── Imports (after mocks) ────────────────────────────────────────────────
 
 import type { AgentEvent } from "../agent/loop.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { EventHandlerDeps } from "../daemon/conversation-agent-loop-handlers.js";
 import {
   createEventHandlerState,
   dispatchAgentEvent,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { _resetStreamStateForTesting } from "../runtime/assistant-stream-state.js";
 import {
   recordForChatMint,

--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent } from "../agent/loop.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 

--- a/assistant/src/__tests__/conversation-agent-loop-disk-pressure.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-disk-pressure.test.ts
@@ -2,9 +2,9 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentLoop } from "../agent/loop.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { Conversation } from "../daemon/conversation.js";
 import type { DiskPressureStatus } from "../daemon/disk-pressure-guard.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 
 type Context = Conversation;
 

--- a/assistant/src/__tests__/conversation-agent-loop-fatal-cleanup.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-fatal-cleanup.test.ts
@@ -17,9 +17,9 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentLoop } from "../agent/loop.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { Conversation } from "../daemon/conversation.js";
 import type { DiskPressureStatus } from "../daemon/disk-pressure-guard.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { setConfig } from "./helpers/set-config.js";
 
 // Short turn-boundary commit wait and no second-pass retitling keep the loop

--- a/assistant/src/__tests__/conversation-agent-loop-handlers-max-tokens.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-handlers-max-tokens.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import type { AgentEvent } from "../agent/loop.js";
+import type { AssistantEvent } from "../api/index.js";
 import {
   createEventHandlerState,
   type EventHandlerDeps,
   handleMaxTokensReached,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 
 describe("max tokens reached handler", () => {
   test("emits and stores an inline continuation card", () => {

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -15,7 +15,7 @@ import { createRequire } from "node:module";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { LoopToolExecutor } from "../agent/loop.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import type { Message, Provider, ToolDefinition } from "../providers/types.js";
 import { ContextOverflowError } from "../providers/types.js";

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -12,11 +12,11 @@ import {
 } from "bun:test";
 
 import type { LoopToolExecutor } from "../agent/loop.js";
+import type { AssistantEvent } from "../api/index.js";
 import {
   queueConversationNotice,
   resetConversationNoticesForTests,
 } from "../daemon/conversation-notices.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getConversationDirName } from "../persistence/conversation-directories.js";
 import type { UserPromptSubmitContext } from "../plugin-api/types.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";

--- a/assistant/src/__tests__/conversation-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/conversation-confirmation-signals.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent } from "../agent/loop.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/conversation-loop-db-lock-resilience.test.ts
+++ b/assistant/src/__tests__/conversation-loop-db-lock-resilience.test.ts
@@ -78,6 +78,7 @@ mock.module(
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 import type { AgentEvent } from "../agent/loop.js";
+import type { AssistantEvent } from "../api/index.js";
 import type {
   EventHandlerDeps,
   EventHandlerState,
@@ -86,7 +87,6 @@ import {
   createEventHandlerState,
   handleMessageComplete,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getConversationPersistedSeq } from "../persistence/conversation-crud.js";
 
 const CONVERSATION_ID = "test-session-id";

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -9,7 +9,7 @@ import type {
   CheckpointInfo,
   ExitReason,
 } from "../agent/loop.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 import { stampAndBuffer } from "../runtime/assistant-stream-state.js";
 import { setConfig } from "./helpers/set-config.js";

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent, AgentLoopRunResult } from "../agent/loop.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import {
   conversationMessagesSyncTag,
   type SyncChangedEvent,

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent } from "../agent/loop.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/conversation-speed-override.test.ts
+++ b/assistant/src/__tests__/conversation-speed-override.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent, AgentLoopConfig } from "../agent/loop.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 
 let broadcastedMessages: AssistantEvent[] = [];
 const realEventHub = await import("../runtime/assistant-event-hub.js");

--- a/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 
 // Analytics consent is granted so recordActivationEvent writes rows.
 let shareAnalytics = true;

--- a/assistant/src/__tests__/conversation-surfaces-app-open.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-app-open.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEvent } from "../api/index.js";
 import { DynamicPagePreviewSchema } from "../api/surfaces.js";
 import {
   buildAppOpenPreview,
@@ -8,7 +9,6 @@ import {
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
 import type {
-  AssistantEvent,
   SurfaceType,
 } from "../daemon/message-protocol.js";
 

--- a/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 
 const realEventHub = await import("../runtime/assistant-event-hub.js");
 

--- a/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone-payloads.test.ts
@@ -19,7 +19,7 @@
 
 import { describe, expect, mock, test } from "bun:test";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 
 let broadcastImpl: (msg: AssistantEvent) => void = () => {};
 mock.module("../runtime/assistant-event-hub.js", () => ({

--- a/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-standalone.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { InteractiveUiResult } from "../runtime/interactive-ui.js";
 
 let broadcastImpl: (msg: AssistantEvent) => void = () => {};

--- a/assistant/src/__tests__/conversation-surfaces-state-update.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-state-update.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEvent } from "../api/index.js";
 import {
   createSurfaceMutex,
   handleSurfaceAction,
@@ -8,7 +9,6 @@ import {
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
 import type {
-  AssistantEvent,
   SurfaceType,
 } from "../daemon/message-protocol.js";
 

--- a/assistant/src/__tests__/conversation-surfaces-table-action.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-table-action.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEvent } from "../api/index.js";
 import {
   createSurfaceMutex,
   handleSurfaceAction,
   type SurfaceConversationContext,
 } from "../daemon/conversation-surfaces.js";
 import type {
-  AssistantEvent,
   SurfaceType,
 } from "../daemon/message-protocol.js";
 

--- a/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEvent } from "../api/index.js";
 import {
   createSurfaceMutex,
   type SurfaceConversationContext,
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
 import type {
-  AssistantEvent,
   CardSurfaceData,
   DynamicPageSurfaceData,
   SurfaceType,

--- a/assistant/src/__tests__/conversation-wait-for-idle.test.ts
+++ b/assistant/src/__tests__/conversation-wait-for-idle.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { CompactionCircuit } from "../agent/compaction-circuit.js";
 import type { AgentEvent } from "../agent/loop.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/daemon-assistant-events.test.ts
+++ b/assistant/src/__tests__/daemon-assistant-events.test.ts
@@ -8,9 +8,8 @@
  */
 import { describe, expect, test } from "bun:test";
 
-import type { AssistantEventEnvelope } from "../api/index.js";
+import type { AssistantEvent, AssistantEventEnvelope } from "../api/index.js";
 // ── Imports (after mocks) ────────────────────────────────────────────────────
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
 

--- a/assistant/src/__tests__/emit-event-signal.test.ts
+++ b/assistant/src/__tests__/emit-event-signal.test.ts
@@ -10,8 +10,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
-import type { AssistantEventEnvelope } from "../api/index.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent, AssistantEventEnvelope } from "../api/index.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { handleEmitEventSignal } from "../signals/emit-event.js";
 import { getSignalsDir } from "../util/platform.js";

--- a/assistant/src/__tests__/helpers/native-web-search-harness.ts
+++ b/assistant/src/__tests__/helpers/native-web-search-harness.ts
@@ -14,12 +14,12 @@
  * load time (config loader, conversation-crud, llm-request-log-store), because
  * Bun's `mock.module()` is scoped to the file that registers it.
  */
+import type { AssistantEvent } from "../../api/index.js";
 import type {
   EventHandlerDeps,
   EventHandlerState,
 } from "../../daemon/conversation-agent-loop-handlers.js";
 import { dispatchAgentEvent } from "../../daemon/conversation-agent-loop-handlers.js";
-import type { AssistantEvent } from "../../daemon/message-protocol.js";
 
 /** A `tool_result` `AssistantEvent` emitted by the handler. */
 export type ToolResultEvent = Extract<AssistantEvent, { type: "tool_result" }>;

--- a/assistant/src/__tests__/host-transfer-pending-interactions.test.ts
+++ b/assistant/src/__tests__/host-transfer-pending-interactions.test.ts
@@ -13,7 +13,7 @@ import type {
   HostTransferCancelEvent,
   HostTransferRequestEvent,
 } from "../api/events/host-transfer.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/memory-retrieval-hook.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-hook.test.ts
@@ -66,9 +66,9 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
 
 import type { UserPromptSubmitContext } from "@vellumai/plugin-api";
 
+import type { AssistantEvent } from "../api/index.js";
 import type { AssistantConfig } from "../config/schema.js";
 import type { Conversation } from "../daemon/conversation.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { QdrantSparseVector } from "../persistence/embeddings/qdrant-client.js";
 import type { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import userPromptSubmitMemoryRetrieval from "../plugins/defaults/memory/hooks/user-prompt-submit.js";

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -98,7 +98,7 @@ mock.module("../notifications/conversation-pairing.js", () => ({
   },
 }));
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { VellumAdapter } from "../notifications/adapters/macos.js";
 import { NotificationBroadcaster } from "../notifications/broadcaster.js";
 import type { NotificationSignal } from "../notifications/signal.js";

--- a/assistant/src/__tests__/notification-vellum-adapter.test.ts
+++ b/assistant/src/__tests__/notification-vellum-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { VellumAdapter } from "../notifications/adapters/macos.js";
 import type {
   ChannelDeliveryPayload,

--- a/assistant/src/__tests__/outbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/outbound-slack-persistence.test.ts
@@ -153,6 +153,7 @@ mock.module("../persistence/attachments-store.js", () => ({
 // ── Imports (after mocks) ──────────────────────────────────────────────────
 
 import type { AgentEvent } from "../agent/loop.js";
+import type { AssistantEvent } from "../api/index.js";
 import type {
   EventHandlerDeps,
   EventHandlerState,
@@ -162,7 +163,6 @@ import {
   handleLlmCallStarted,
   handleMessageComplete,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import { deliverReplyViaCallback } from "../runtime/channel-reply-delivery.js";
 import { setConfig } from "./helpers/set-config.js";

--- a/assistant/src/__tests__/pending-interactions-resolved-event.test.ts
+++ b/assistant/src/__tests__/pending-interactions-resolved-event.test.ts
@@ -10,7 +10,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 
 // Capture every broadcast emitted by the tracker. The real hub is replaced
 // with a thin recorder so we can assert payloads deterministically.

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -117,7 +117,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../../daemon/conversation-notices.js",
     "../../../../daemon/conversation-registry.js",
     "../../../../daemon/conversation-runtime-assembly.js",
-    "../../../../daemon/message-protocol.js",
     "../../../../daemon/trust-context.js",
     "../../../../daemon/turn-latency-sub-spans.js",
     "../../../../persistence/checkpoints.js",

--- a/assistant/src/__tests__/request-secret-standalone-channel-gate.test.ts
+++ b/assistant/src/__tests__/request-secret-standalone-channel-gate.test.ts
@@ -8,7 +8,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { setConfig } from "./helpers/set-config.js";
 
 // A short permission timeout keeps a leaked prompt from lingering; the default

--- a/assistant/src/__tests__/runtime-events-sse-parity.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-parity.test.ts
@@ -17,8 +17,7 @@
  */
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import type { AssistantEventEnvelope } from "../api/index.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent, AssistantEventEnvelope } from "../api/index.js";
 import { getOrCreateConversation } from "../persistence/conversation-key-store.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";

--- a/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
+++ b/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SecretRequestEvent } from "../api/events/secret-request.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { setConfig } from "./helpers/set-config.js";
 
 // Capture all logger calls so we can verify secret values never appear

--- a/assistant/src/__tests__/secret-prompter-channel-fallback.test.ts
+++ b/assistant/src/__tests__/secret-prompter-channel-fallback.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SecretRequestEvent } from "../api/events/secret-request.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { setConfig } from "./helpers/set-config.js";
 
 // Use a tiny timeout so the setTimeout branch fires quickly in tests

--- a/assistant/src/__tests__/secret-response-routing.test.ts
+++ b/assistant/src/__tests__/secret-response-routing.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SecretRequestEvent } from "../api/events/secret-request.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { SecretPromptResult } from "../permissions/secret-prompt-types.js";
 
 let broadcastedMessages: AssistantEvent[] = [];

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -10,8 +10,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
 
+import type { AssistantEvent } from "../api/index.js";
 import type { Conversation } from "../daemon/conversation.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import {
   getConversationByKey,
   getOrCreateConversation,

--- a/assistant/src/__tests__/starter-task-flow.test.ts
+++ b/assistant/src/__tests__/starter-task-flow.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
+import type { AssistantEvent } from "../api/index.js";
 import type {
-  AssistantEvent,
   SurfaceType,
 } from "../daemon/message-protocol.js";
 

--- a/assistant/src/__tests__/subagent-call-site-routing.test.ts
+++ b/assistant/src/__tests__/subagent-call-site-routing.test.ts
@@ -17,7 +17,7 @@
  */
 import { afterAll, describe, expect, mock, test } from "bun:test";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { getProvider as getProviderImport } from "../providers/registry.js";
 import { setConfig } from "./helpers/set-config.js";
 

--- a/assistant/src/__tests__/subagent-disposal.test.ts
+++ b/assistant/src/__tests__/subagent-disposal.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { SubagentManager } from "../subagent/manager.js";
 import type { SubagentState } from "../subagent/types.js";
 

--- a/assistant/src/__tests__/subagent-fork-notifications.test.ts
+++ b/assistant/src/__tests__/subagent-fork-notifications.test.ts
@@ -29,7 +29,7 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   broadcastMessage: () => {},
 }));
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { SubagentManager } from "../subagent/manager.js";
 import type { SubagentState } from "../subagent/types.js";
 

--- a/assistant/src/__tests__/subagent-fork-prompt-role.test.ts
+++ b/assistant/src/__tests__/subagent-fork-prompt-role.test.ts
@@ -15,7 +15,7 @@
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 
 // ── Captured constructor state ──────────────────────────────────────────────
 

--- a/assistant/src/__tests__/subagent-fork-spawn.test.ts
+++ b/assistant/src/__tests__/subagent-fork-spawn.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEvent } from "../api/index.js";
 import {
   clearConversations,
   findConversation,
   setConversation,
 } from "../daemon/conversation-registry.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { Message } from "../providers/types.js";
 import { SubagentManager } from "../subagent/manager.js";
 import type { SubagentConfig, SubagentState } from "../subagent/types.js";

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -29,7 +29,7 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   broadcastMessage: () => {},
 }));
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { SubagentManager } from "../subagent/manager.js";
 import type { SubagentState } from "../subagent/types.js";
 

--- a/assistant/src/__tests__/subagent-spawn-and-await.test.ts
+++ b/assistant/src/__tests__/subagent-spawn-and-await.test.ts
@@ -13,7 +13,7 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { Message } from "../providers/types.js";
 
 // ── Fake Conversation ───────────────────────────────────────────────────────

--- a/assistant/src/__tests__/sync-message-contract.test.ts
+++ b/assistant/src/__tests__/sync-message-contract.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEvent } from "../api/index.js";
 import {
-  type AssistantEvent,
   buildSyncChangedMessage,
   conversationMessagesSyncTag,
   SYNC_TAGS,

--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -82,7 +82,7 @@ mock.module(
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 import type { AgentEvent } from "../agent/loop.js";
-import type { AssistantEventEnvelope } from "../api/index.js";
+import type { AssistantEvent, AssistantEventEnvelope } from "../api/index.js";
 import type {
   EventHandlerDeps,
   EventHandlerState,
@@ -96,7 +96,6 @@ import {
   handleToolUse,
   handleToolUsePreviewStart,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getConversationPersistedSeq } from "../persistence/conversation-crud.js";
 import {
   _resetStreamStateForTesting,

--- a/assistant/src/__tests__/tool-result-metadata-plumbing.test.ts
+++ b/assistant/src/__tests__/tool-result-metadata-plumbing.test.ts
@@ -26,6 +26,7 @@ mock.module("../persistence/llm-request-log-store.js", () => ({
 }));
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
+import type { AssistantEvent } from "../api/index.js";
 import type {
   EventHandlerDeps,
   EventHandlerState,
@@ -34,7 +35,6 @@ import {
   createEventHandlerState,
   handleToolResult,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 
 type ToolResultEvent = Extract<AssistantEvent, { type: "tool_result" }>;

--- a/assistant/src/__tests__/tool-start-timestamp.test.ts
+++ b/assistant/src/__tests__/tool-start-timestamp.test.ts
@@ -39,6 +39,7 @@ mock.module("../runtime/assistant-stream-state.js", () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 import type { AgentEvent } from "../agent/loop.js";
+import type { AssistantEvent } from "../api/index.js";
 import type {
   EventHandlerDeps,
   EventHandlerState,
@@ -47,7 +48,6 @@ import {
   createEventHandlerState,
   handleToolUse,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/assistant/src/__tests__/ui-choice-copy-surfaces.test.ts
+++ b/assistant/src/__tests__/ui-choice-copy-surfaces.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEvent } from "../api/index.js";
 import {
   buildCompletionSummary,
   createSurfaceMutex,
@@ -7,7 +8,6 @@ import {
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
 import type {
-  AssistantEvent,
   ChoiceSurfaceData,
   CopyBlockSurfaceData,
   OAuthConnectSurfaceData,

--- a/assistant/src/__tests__/ui-work-result-surface.test.ts
+++ b/assistant/src/__tests__/ui-work-result-surface.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
+import type { AssistantEvent } from "../api/index.js";
 import {
   createSurfaceMutex,
   type SurfaceConversationContext,
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
 import type {
-  AssistantEvent,
   SurfaceType,
   UiSurfaceShow,
   UiSurfaceShowWorkResult,

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -60,13 +60,13 @@ mock.module("../daemon/conversation-store.js", () => ({
 
 import { and, eq } from "drizzle-orm";
 
+import type { AssistantEvent } from "../api/index.js";
 import {
   _internal,
   type CreateScopedApprovalGrantParams,
   revokeScopedApprovalGrantsForContext,
 } from "../approvals/scoped-approval-grants.js";
 import { startVoiceTurn } from "../calls/voice-session-bridge.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { scopedApprovalGrants } from "../persistence/schema/index.js";

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { AssistantEvent } from "../api/index.js";
 import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
 import type { Conversation } from "../daemon/conversation.js";
 import { persistUserMessage as persistUserMessageImpl } from "../daemon/conversation-messaging.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { setConfig } from "./helpers/set-config.js";
 
 /** Seed the config the voice bridge reads: disclosure copy, plus disabled

--- a/assistant/src/acp/__tests__/client-handler.test.ts
+++ b/assistant/src/acp/__tests__/client-handler.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { SessionNotification } from "@agentclientprotocol/sdk";
 
-import type { AssistantEvent } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../api/index.js";
 import { VellumAcpClientHandler } from "../client-handler.js";
 
 const ACP_SESSION_ID = "acp-session-abc";

--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -11,7 +11,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AcpSessionUpdateEvent } from "../../api/events/acp-session-update.js";
-import type { AssistantEvent } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../api/index.js";
 import { getSqlite } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import { VellumAcpClientHandler } from "../client-handler.js";

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -208,7 +208,7 @@ const BUN_BIN = "/usr/local/bin/bun";
 const BUN_ADD_KEY = `${BUN_BIN} add`;
 
 import type { AcpSessionUpdateEvent } from "../../api/events/acp-session-update.js";
-import type { AssistantEvent } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../api/index.js";
 import { getSqlite } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import type { AcpSessionState } from "../types.js";

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -32,7 +32,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 
 import type { AcpSessionUpdateEvent } from "../api/events/acp-session-update.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { redactJsonStringLeaves } from "../security/redact-json.js";
 import { redactSensitiveFields } from "../security/redaction.js";
 import { redactSecrets } from "../security/secret-scanner.js";

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -9,8 +9,8 @@ import { basename } from "node:path";
 import { eq, inArray } from "drizzle-orm";
 
 import type { AcpSessionUpdateEvent } from "../api/events/acp-session-update.js";
+import type { AssistantEvent } from "../api/index.js";
 import { findConversation } from "../daemon/conversation-registry.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { getDb } from "../persistence/db-connection.js";
 import { acpSessionHistory } from "../persistence/schema/index.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -8,6 +8,7 @@
  * barge-in, state machine, guardian verification).
  */
 
+import type { AssistantEvent } from "../api/index.js";
 import { revokeScopedApprovalGrantsForContext } from "../approvals/scoped-approval-grants.js";
 import {
   expireGuardianRequest,
@@ -16,7 +17,6 @@ import {
   getRequestByPendingQuestionOrNull,
   listGuardianRequestDeliveriesOrEmpty,
 } from "../channels/gateway-guardian-requests.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -9,6 +9,7 @@
 import { v7 as uuidv7 } from "uuid";
 
 import type {
+  AssistantEvent,
   AssistantTextDeltaEvent,
   GenerationCancelledEvent,
   MessageCompleteEvent,
@@ -25,7 +26,6 @@ import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
 import { CONVERSATION_BUSY_MESSAGE } from "../daemon/conversation-messaging.js";
 import { resolveChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import {
   deleteMessageById,

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -11,6 +11,7 @@ import {
 import { dirname, join } from "node:path";
 import * as readline from "node:readline";
 
+import type { AssistantEvent } from "./api/index.js";
 import {
   type MainScreenLayout,
   renderMainScreen,
@@ -18,7 +19,6 @@ import {
   updateStatusText,
 } from "./cli/main-screen.jsx";
 import { renderHistoryContent } from "./daemon/handlers/shared.js";
-import type { AssistantEvent } from "./daemon/message-protocol.js";
 import {
   getConversation,
   getMessages,

--- a/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-surfaces-launch.test.ts
@@ -126,7 +126,7 @@ const { createSurfaceMutex, handleSurfaceAction } =
 type SurfaceConversationContext =
   import("../conversation-surfaces.js").SurfaceConversationContext;
 type TrustContext = import("../trust-context-types.js").TrustContext;
-type AssistantEvent = import("../message-protocol.js").AssistantEvent;
+type AssistantEvent = import("../../api/index.js").AssistantEvent;
 type SurfaceType = import("../message-protocol.js").SurfaceType;
 
 // ── Harness reset helper ───────────────────────────────────────────

--- a/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
+++ b/assistant/src/daemon/__tests__/native-web-search-metadata.test.ts
@@ -29,6 +29,7 @@ mock.module("../../persistence/llm-request-log-store.js", () => ({
 }));
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
+import type { AssistantEvent } from "../../api/index.js";
 import { WEB_SEARCH_BACKEND_FAILURE_MESSAGE } from "../../tools/network/web-search-error.js";
 import type {
   EventHandlerDeps,
@@ -38,7 +39,6 @@ import {
   createEventHandlerState,
   dispatchAgentEvent,
 } from "../conversation-agent-loop-handlers.js";
-import type { AssistantEvent } from "../message-protocol.js";
 
 type ToolResultEvent = Extract<AssistantEvent, { type: "tool_result" }>;
 

--- a/assistant/src/daemon/__tests__/web-search-status-text.test.ts
+++ b/assistant/src/daemon/__tests__/web-search-status-text.test.ts
@@ -20,6 +20,7 @@ mock.module("../../persistence/llm-request-log-store.js", () => ({
 }));
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
+import type { AssistantEvent } from "../../api/index.js";
 import type {
   EventHandlerDeps,
   EventHandlerState,
@@ -30,7 +31,6 @@ import {
   formatFetchStatusText,
   formatSearchStatusText,
 } from "../conversation-agent-loop-handlers.js";
-import type { AssistantEvent } from "../message-protocol.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -11,6 +11,7 @@ import type pino from "pino";
 import { v4 as uuid } from "uuid";
 
 import type { AgentEvent } from "../agent/loop.js";
+import type { AssistantEvent } from "../api/index.js";
 import type {
   TurnChannelContext,
   TurnInterfaceContext,
@@ -130,7 +131,6 @@ import {
   type InflightContentWriter,
 } from "./inflight-message-content.js";
 import type {
-  AssistantEvent,
   CardSurfaceData,
   SurfaceAction,
   UiSurfaceShow,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -15,6 +15,7 @@ import type {
   CheckpointDecision,
 } from "../agent/loop.js";
 import { createAssistantMessage } from "../agent/message-types.js";
+import type { AssistantEvent } from "../api/index.js";
 import type {
   ChannelId,
   InterfaceId,
@@ -116,7 +117,7 @@ import {
   registerInflightTurn,
   unregisterInflightTurn,
 } from "./inflight-turn-registry.js";
-import type { AssistantEvent, UsageStats } from "./message-protocol.js";
+import type { UsageStats } from "./message-protocol.js";
 import type { TrustContext } from "./trust-context-types.js";
 import { resolveTurnCallSite } from "./turn-call-site.js";
 import { runWithLatencySubSpans } from "./turn-latency-sub-spans.js";

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -16,6 +16,7 @@ import {
 } from "../agent/attachments.js";
 import { optimizeImageForTransport } from "../agent/image-optimize.js";
 import { createUserMessage } from "../agent/message-types.js";
+import type { AssistantEvent } from "../api/index.js";
 import type {
   TurnChannelContext,
   TurnInterfaceContext,
@@ -64,7 +65,6 @@ import { withSqliteRetry } from "../util/sqlite-retry.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import type { SlackInboundMessageMetadata } from "./handlers/shared.js";
 import type {
-  AssistantEvent,
   UserMessageAttachment,
 } from "./message-protocol.js";
 import type { ConversationTransportMetadata } from "./message-types/conversations.js";

--- a/assistant/src/daemon/conversation-notifiers.ts
+++ b/assistant/src/daemon/conversation-notifiers.ts
@@ -8,6 +8,7 @@
  */
 
 import { createAssistantMessage } from "../agent/message-types.js";
+import type { AssistantEvent } from "../api/index.js";
 import { buildCallCompletionMessage } from "../calls/call-conversation-messages.js";
 import {
   registerCallCompletionNotifier,
@@ -23,7 +24,6 @@ import {
   provenanceFromTrustContext,
 } from "../persistence/conversation-crud.js";
 import type { Message } from "../providers/types.js";
-import type { AssistantEvent } from "./message-protocol.js";
 import type { TrustContext } from "./trust-context-types.js";
 
 /**

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -11,6 +11,7 @@ import {
   createAssistantMessage,
   createUserMessage,
 } from "../agent/message-types.js";
+import type { AssistantEvent } from "../api/index.js";
 import { listPendingRequestsByScopeOrEmpty } from "../channels/gateway-guardian-requests.js";
 import {
   parseChannelId,
@@ -57,7 +58,6 @@ import {
 import { getModelInfo } from "./handlers/config-model.js";
 import { preactivateHostProxySkills } from "./host-proxy-preactivation.js";
 import type {
-  AssistantEvent,
   UserMessageAttachment,
 } from "./message-protocol.js";
 import { buildTransportHints } from "./transport-hints.js";

--- a/assistant/src/daemon/conversation-queue-manager.ts
+++ b/assistant/src/daemon/conversation-queue-manager.ts
@@ -5,6 +5,7 @@
  * agent loop is in flight.
  */
 
+import type { AssistantEvent } from "../api/index.js";
 import type {
   TurnChannelContext,
   TurnInterfaceContext,
@@ -12,7 +13,6 @@ import type {
 import type { AuthContext } from "../runtime/auth/types.js";
 import { getLogger } from "../util/logger.js";
 import type {
-  AssistantEvent,
   UserMessageAttachment,
 } from "./message-protocol.js";
 import type { ConversationTransportMetadata } from "./message-types/conversations.js";

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2,6 +2,7 @@ import { v4 as uuid, v7 as uuidv7 } from "uuid";
 import { z } from "zod";
 
 import { SurfaceActionSchema } from "../api/events/ui-surface-show.js";
+import type { AssistantEvent } from "../api/index.js";
 import {
   CardSurfaceDataSchema,
   ChoiceSurfaceDataSchema,
@@ -70,7 +71,6 @@ import type { HostAppControlProxy } from "./host-app-control-proxy.js";
 import type { HostCuProxy } from "./host-cu-proxy.js";
 import type {
   AnySurfaceData,
-  AssistantEvent,
   CardSurfaceData,
   ChoiceSurfaceData,
   ConfirmationSurfaceData,

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -6,6 +6,7 @@
  * keeping the constructor body focused on wiring.
  */
 
+import type { AssistantEvent } from "../api/index.js";
 import {
   type HostProxyCapability,
   supportsHostProxy,
@@ -73,7 +74,6 @@ import {
   isDoordashCommand,
   markDoordashStepInProgress,
 } from "./doordash-steps.js";
-import type { AssistantEvent } from "./message-protocol.js";
 import { runPostExecutionSideEffects } from "./tool-side-effects.js";
 import { FALLBACK_TURN_TRUST, resolveTrustClass } from "./trust-context.js";
 

--- a/assistant/src/daemon/conversation-usage.ts
+++ b/assistant/src/daemon/conversation-usage.ts
@@ -1,3 +1,4 @@
+import type { AssistantEvent } from "../api/index.js";
 import { getConfig } from "../config/loader.js";
 import { updateConversationUsage } from "../persistence/conversation-crud.js";
 import { recordUsageEvent } from "../persistence/llm-usage-store.js";
@@ -16,7 +17,7 @@ import {
   resolvePricingForUsageWithOverrides,
   usesAnthropicPricingRules,
 } from "../util/pricing.js";
-import type { AssistantEvent, UsageStats } from "./message-protocol.js";
+import type { UsageStats } from "./message-protocol.js";
 
 const log = getLogger("conversation-usage");
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -19,6 +19,7 @@ import type { AgentLoopConfig } from "../agent/loop.js";
 import { AgentLoop } from "../agent/loop.js";
 import type { AssistantActivityStateEvent } from "../api/events/assistant-activity-state.js";
 import type { ConfirmationStateChangedEvent } from "../api/events/confirmation-state-changed.js";
+import type { AssistantEvent } from "../api/index.js";
 import { decideGuardianRequest } from "../channels/gateway-guardian-requests.js";
 import type {
   ChannelId,
@@ -164,7 +165,6 @@ import { HostAppControlProxy } from "./host-app-control-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
 import { shouldAttachHostProxyForCapability } from "./host-proxy-preactivation.js";
 import type {
-  AssistantEvent,
   SurfaceType,
   UsageStats,
 } from "./message-protocol.js";

--- a/assistant/src/daemon/host-proxy-base.ts
+++ b/assistant/src/daemon/host-proxy-base.ts
@@ -15,6 +15,7 @@
  */
 import { v4 as uuid } from "uuid";
 
+import type { AssistantEvent } from "../api/index.js";
 import type { HostProxyCapability } from "../channels/types.js";
 import {
   assistantEventHub,
@@ -24,7 +25,6 @@ import type { PendingInteraction } from "../runtime/pending-interactions.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
-import type { AssistantEvent } from "./message-protocol.js";
 
 const log = getLogger("host-proxy-base");
 

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -4,10 +4,6 @@
  * Client message types are defined in domain files under ./message-types/;
  * each exports a `_<Domain>ClientMessages` alias that this file composes into
  * the aggregate `ClientMessage` union.
- *
- * The server->client union `AssistantEvent` is single-sourced from the canonical
- * `AssistantEventSchema` in `../api` -- `AssistantEvent` is `z.infer` of that
- * schema, so every hub-published event type appears in it automatically.
  */
 
 // Re-export domain modules (all individual types remain importable)
@@ -23,11 +19,6 @@ export * from "./message-types/skills.js";
 export * from "./message-types/surfaces.js";
 export * from "./message-types/sync.js";
 export * from "./message-types/web-activity.js";
-
-// Canonical server->client event union: every message the daemon can send to a
-// client, single-sourced from `AssistantEventSchema` (`z.infer`). Re-exported
-// here so daemon code can import it alongside the ClientMessage union.
-export type { AssistantEvent } from "../api/index.js";
 
 // Client-message domain aliases for the ClientMessage union.
 import type { _ComputerUseClientMessages } from "./message-types/computer-use.js";

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -12,6 +12,7 @@ import {
   createAssistantMessage,
   createUserMessage,
 } from "../agent/message-types.js";
+import type { AssistantEvent } from "../api/index.js";
 import {
   type ChannelId,
   type InterfaceId,
@@ -69,7 +70,6 @@ import {
   preactivateHostProxySkills,
   shouldAttachHostProxyForCapability,
 } from "./host-proxy-preactivation.js";
-import type { AssistantEvent } from "./message-protocol.js";
 import type { SubagentToolGateMode } from "./tool-setup-types.js";
 
 const log = getLogger("process-message");

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -9,6 +9,7 @@
 
 import { isAbsolute, resolve, sep } from "node:path";
 
+import type { AssistantEvent } from "../api/index.js";
 import { addAppConversationId, getApp } from "../apps/app-store.js";
 import { findActiveSession } from "../channels/gateway-verification-sessions.js";
 import { getConfig } from "../config/loader.js";
@@ -26,7 +27,6 @@ import { getWorkspaceDir } from "../util/platform.js";
 import { ensureAppSourceWatcher } from "./app-source-watcher.js";
 import { refreshSurfacesForApp } from "./conversation-surfaces.js";
 import { isDoordashCommand, updateDoordashProgress } from "./doordash-steps.js";
-import type { AssistantEvent } from "./message-protocol.js";
 import type { ToolSetupContext } from "./tool-setup-types.js";
 
 const log = getLogger("tool-side-effects");

--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -13,6 +13,7 @@
  */
 
 import type { AgentEvent } from "../agent/loop.js";
+import type { AssistantEvent } from "../api/index.js";
 import {
   addMessage,
   getConversation,
@@ -27,7 +28,6 @@ import { publishConversationMessagesChanged } from "../runtime/sync/resource-syn
 import type { CompletedBackgroundTool } from "../tools/background-tool-registry.js";
 import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
-import type { AssistantEvent } from "./message-protocol.js";
 import type {
   SubagentToolGateMode,
   WakeToolContextPin,

--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -18,8 +18,8 @@
  * does not match their own identity.
  */
 
+import type { AssistantEvent } from "../../api/index.js";
 import type { InterfaceId } from "../../channels/types.js";
-import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import { getLogger } from "../../util/logger.js";
 import type {
   ChannelAdapter,

--- a/assistant/src/permissions/confirmation-guardian-request.test.ts
+++ b/assistant/src/permissions/confirmation-guardian-request.test.ts
@@ -50,7 +50,7 @@ mock.module("../runtime/confirmation-request-guardian-bridge.js", () => ({
   },
 }));
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { createGuardianRequestForConfirmation } from "./confirmation-guardian-request.js";
 
 const MSG = {

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from "uuid";
 
+import type { AssistantEvent } from "../api/index.js";
 import { getConfig } from "../config/loader.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { redactSensitiveFields } from "../security/redaction.js";
 import type { ExecutionTarget } from "../tools/tool-types.js";

--- a/assistant/src/permissions/question-prompter.test.ts
+++ b/assistant/src/permissions/question-prompter.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { setConfig } from "../__tests__/helpers/set-config.js";
 import type { QuestionRequestEvent } from "../api/events/question-request.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import type {
   QuestionBatchSubmission,
   QuestionPromptResult,

--- a/assistant/src/plugin-api/conversation-turn.ts
+++ b/assistant/src/plugin-api/conversation-turn.ts
@@ -13,8 +13,8 @@
  * context management.
  */
 
+import type { AssistantEvent } from "../api/index.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { UserMessageAttachment } from "../daemon/message-types/shared.js";
 import type { ContentBlock, MediaSource } from "../providers/types.js";
 

--- a/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/plugins/defaults/memory/graph/conversation-graph-memory.ts
@@ -6,13 +6,17 @@
 // retrieval mode based on conversation state.
 // ---------------------------------------------------------------------------
 
-import type { ContentBlock, ImageContent, Message } from "@vellumai/plugin-api";
+import type {
+  AssistantEvent,
+  ContentBlock,
+  ImageContent,
+  Message,
+} from "@vellumai/plugin-api";
 import { and, desc, eq, inArray, ne, notInArray } from "drizzle-orm";
 import { z } from "zod";
 
 import type { AssistantConfig } from "../../../../config/types.js";
 import { estimateTextTokens } from "../../../../context/token-estimator.js";
-import type { AssistantEvent } from "../../../../daemon/message-protocol.js";
 import { getDb } from "../../../../persistence/db-connection.js";
 import { embedWithRetry } from "../../../../persistence/embeddings/embed.js";
 import { generateSparseEmbedding } from "../../../../persistence/embeddings/embedding-backend.js";

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -12,8 +12,8 @@
  * Client-oriented queries (list, find-by-capability) are methods on the hub.
  */
 
+import type { AssistantEvent } from "../api/index.js";
 import type { HostProxyCapability, InterfaceId } from "../channels/types.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 
 // ---------------------------------------------------------------------------
 // Message type → capability inference

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -2,6 +2,7 @@
  * Periodic retry sweep for failed channel inbound events.
  */
 
+import type { AssistantEvent } from "../api/index.js";
 import {
   type ChannelId,
   isChannelId,
@@ -12,7 +13,6 @@ import { isConversationBusyError } from "../daemon/conversation-messaging.js";
 import { findConversation } from "../daemon/conversation-registry.js";
 import { getDiskPressureStatus } from "../daemon/disk-pressure-guard.js";
 import { classifyDiskPressureTurnPolicy } from "../daemon/disk-pressure-policy.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import { updateDeliveredSegmentCount } from "../persistence/delivery-channels.js";
 import {

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -16,7 +16,7 @@ import type {
 // Re-export so route modules (background-dispatch, etc.) can pull the type
 // from the runtime barrel without reaching into daemon internals.
 export type { SlackInboundMessageMetadata };
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import type { AssistantEventHub } from "./assistant-event-hub.js";
 
 export type {

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -18,8 +18,8 @@ import {
   AcpSessionNotFoundError,
 } from "../../acp/session-manager.js";
 import type { AcpSessionState } from "../../acp/types.js";
+import type { AssistantEvent } from "../../api/index.js";
 import { getConfig } from "../../config/loader.js";
-import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import { createGuardianRequestForConfirmation } from "../../permissions/confirmation-guardian-request.js";
 import type { UserDecision } from "../../permissions/types.js";
 import { getDb } from "../../persistence/db-connection.js";

--- a/assistant/src/runtime/routes/canned-message-complete.ts
+++ b/assistant/src/runtime/routes/canned-message-complete.ts
@@ -1,5 +1,5 @@
 import { createAssistantMessage } from "../../agent/message-types.js";
-import type { AssistantEvent } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../api/index.js";
 import {
   addMessage,
   recordConversationPersistedSeq,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -16,6 +16,7 @@ import {
   createAssistantMessage,
   createUserMessage,
 } from "../../agent/message-types.js";
+import type { AssistantEvent } from "../../api/index.js";
 import {
   BackgroundToolCompletionSchema,
   type ConversationContentBlock,
@@ -81,7 +82,6 @@ import {
   shouldAttachHostProxyForCapability,
 } from "../../daemon/host-proxy-preactivation.js";
 import { getAssistantName } from "../../daemon/identity-helpers.js";
-import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import type {
   HostProxyTransportMetadata,
   NonHostProxyTransportMetadata,

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -7,6 +7,7 @@
  * Extracted from inbound-message-handler.ts to keep the top-level handler
  * focused on orchestration.
  */
+import type { AssistantEvent } from "../../../api/index.js";
 import {
   extractMessageTsFromCallbackUrl,
   extractThreadTsFromCallbackUrl,
@@ -18,7 +19,6 @@ import {
   guardianForChannel,
 } from "../../../contacts/guardian-delivery-reader.js";
 import { isConversationBusyError } from "../../../daemon/conversation-messaging.js";
-import type { AssistantEvent } from "../../../daemon/message-protocol.js";
 import type { TrustContext } from "../../../daemon/trust-context-types.js";
 import {
   getSiblingStreamedReplyTs,

--- a/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/inject-failures.test.ts
@@ -3,8 +3,8 @@
  */
 import { describe, expect, mock, test } from "bun:test";
 
+import type { AssistantEvent } from "../../../../api/index.js";
 import type { Conversation } from "../../../../daemon/conversation.js";
-import type { AssistantEvent } from "../../../../daemon/message-protocol.js";
 
 let _mockConversation: MockConversation | undefined;
 

--- a/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
+++ b/assistant/src/runtime/routes/playground/__tests__/reset-circuit.test.ts
@@ -19,8 +19,8 @@ mock.module("../helpers.js", () => ({
   addPlaygroundMessage: async () => ({ id: "msg-test" }),
 }));
 
+import type { AssistantEvent } from "../../../../api/index.js";
 import type { Conversation } from "../../../../daemon/conversation.js";
-import type { AssistantEvent } from "../../../../daemon/message-protocol.js";
 import { RouteError } from "../../errors.js";
 import { ROUTES } from "../index.js";
 

--- a/assistant/src/runtime/slack-reply-session.test.ts
+++ b/assistant/src/runtime/slack-reply-session.test.ts
@@ -28,7 +28,7 @@ mock.module("./gateway-client.js", () => ({
   },
 }));
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { SLACK_STREAM_MARKDOWN_LIMIT } from "../messaging/providers/slack/api.js";
 import {
   createSlackReplySession,

--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -1,5 +1,6 @@
 import type { SlackStreamTask } from "@vellumai/gateway-client";
 
+import type { AssistantEvent } from "../api/index.js";
 import {
   extractThreadTsFromCallbackUrl,
   isSlackDeliveryCallbackUrl,
@@ -9,7 +10,6 @@ import {
   incompleteVellumLinkSuffixLength,
   stripVellumLinks,
 } from "../daemon/assistant-attachments.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { SLACK_STREAM_MARKDOWN_LIMIT } from "../messaging/providers/slack/api.js";
 import { renderSlackBlocks } from "../messaging/providers/slack/render.js";
 import { getLogger } from "../util/logger.js";

--- a/assistant/src/signals/emit-event.ts
+++ b/assistant/src/signals/emit-event.ts
@@ -15,7 +15,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import type { AssistantEvent } from "../daemon/message-protocol.js";
+import type { AssistantEvent } from "../api/index.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
 import { getSignalsDir } from "../util/platform.js";

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -10,6 +10,7 @@
 
 import { v4 as uuid } from "uuid";
 
+import type { AssistantEvent } from "../api/index.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { Conversation } from "../daemon/conversation.js";
@@ -18,7 +19,6 @@ import {
   removeSubagentConversation,
   setSubagentConversation,
 } from "../daemon/conversation-registry.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../persistence/conversation-bootstrap.js";
 import {
   deleteSubagentRecord,

--- a/assistant/src/tools/acp/context.ts
+++ b/assistant/src/tools/acp/context.ts
@@ -2,7 +2,7 @@
  * Shared ToolContext accessors for the ACP tools.
  */
 
-import type { AssistantEvent } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../api/index.js";
 import type { ToolContext } from "../types.js";
 
 /**

--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -1,4 +1,4 @@
-import type { AssistantEvent } from "../../daemon/message-protocol.js";
+import type { AssistantEvent } from "../../api/index.js";
 import { browserManager } from "./browser-manager.js";
 
 // Track which conversations have an active browser page.

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -1,8 +1,8 @@
+import type { AssistantEvent } from "../../api/index.js";
 import { validateInferenceProfileKey } from "../../config/inference-profile-validation.js";
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
 import { getConfig } from "../../config/loader.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
-import type { AssistantEvent } from "../../daemon/message-protocol.js";
 import {
   getConversationOverrideProfile,
   getMessages,

--- a/assistant/src/workflows/leaf-runner.ts
+++ b/assistant/src/workflows/leaf-runner.ts
@@ -42,9 +42,9 @@ import { randomUUID } from "node:crypto";
 import { z } from "zod";
 
 import { type AgentEvent, AgentLoop } from "../agent/loop.js";
+import type { AssistantEvent } from "../api/index.js";
 import { getEffectiveProfile } from "../config/default-profile-catalog.js";
 import { getConfig } from "../config/loader.js";
-import type { AssistantEvent } from "../daemon/message-protocol.js";
 import { isPersonalMemoryAllowed } from "../daemon/trust-context.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import { isOutOfWorkspaceFileInvocation } from "../permissions/workspace-policy.js";


### PR DESCRIPTION
## Why

The final step of the `AssistantEvent` unification. `daemon/message-protocol.ts` had been re-exporting `AssistantEvent` from `../api` purely as a convenience hop. This removes that re-export so `message-protocol.ts` is once again *only* the `ClientMessage` barrel, and every consumer imports `AssistantEvent` straight from its canonical home in `@vellumai/assistant-api` — no re-export indirection between `AssistantEventSchema` and the code that uses `z.infer` of it.

## What

- **`daemon/message-protocol.ts`** — dropped `export type { AssistantEvent } from "../api/index.js"` (and its now-stale doc comment). The file is purely the `ClientMessage` aggregate barrel.
- **~106 importers repointed** — `AssistantEvent` type imports moved from `.../daemon/message-protocol.js` to the correct-depth `.../api/index.js`. Import statements only; no `AssistantEvent` *usages* (`Extract<…>`, annotations, generics) were touched. The two multi-symbol imports (`{ AssistantEvent, UsageStats }`) were split so `UsageStats` stays on `message-protocol`.
- **Memory plugin** — `conversation-graph-memory.ts` now imports `AssistantEvent` from `@vellumai/plugin-api` (which exports it) rather than reaching into `../../../../api/index.js`, so the escaping import is gone from the plugin-import baseline (stale entry removed, no new escape added).

Purely mechanical: import repointing, no behavior change.

## Test plan

- `bun run typecheck:fast` — clean
- `bun test` on a broad sample of touched suites (`runtime-events-sse-parity`, `daemon-assistant-events`, `assistant-event-hub`, `plugin-import-boundary-guard` + reverse guard, `emit-event-signal`, `tool-preview-lifecycle`, `compaction-events`, `sync-message-contract`, `conversation-surfaces-*`) — pass
- `bun run generate:openapi -- --check` — unchanged (import-only changes to route files)
- eslint — 0 errors; grep confirms zero `AssistantEvent` imports from any `message-protocol.js` path remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV6fbS9mpcf7G2ucKHsrHQ)_