### PR TITLE
feat(telemetry): report memory corpus size on the memory_tier watchdog

### DIFF
--- a/assistant/src/telemetry/memory-corpus-size.test.ts
+++ b/assistant/src/telemetry/memory-corpus-size.test.ts
@@ -15,7 +15,10 @@ mock.module("../util/platform.js", () => ({
   getWorkspaceDir: () => workspaceDir,
 }));
 
-import { measureMemoryCorpusSize } from "./memory-corpus-size.js";
+import {
+  measureMarkdownTree,
+  measureMemoryCorpusSize,
+} from "./memory-corpus-size.js";
 
 function write(relativePath: string, contents: string): void {
   const full = join(workspaceDir, relativePath);
@@ -83,6 +86,27 @@ describe("measureMemoryCorpusSize", () => {
     write("memory/concepts/alice.md", "12345");
 
     expect(measureMemoryCorpusSize().buffer_lines).toBe(0);
+  });
+
+  test("the traversal ceiling counts every entry, not just markdown", () => {
+    // The regression this guards: a ceiling that only counted `.md` matches
+    // would not bound this walk at all, because nothing in the root is
+    // Markdown.
+    //
+    // The page sits one level down so the assertion does not depend on
+    // readdir order. The root holds 11 entries (10 noise files + the subdir),
+    // so a limit of 5 is exhausted while still scanning the root and the walk
+    // returns before it ever descends — whichever order those 11 come back in.
+    const dir = join(workspaceDir, "noise");
+    mkdirSync(join(dir, "sub"), { recursive: true });
+    for (let i = 0; i < 10; i++) {
+      writeFileSync(join(dir, `placeholder-${i}.txt`), "x", "utf8");
+    }
+    writeFileSync(join(dir, "sub", "page.md"), "12345", "utf8");
+
+    expect(measureMarkdownTree(dir, 5)).toEqual({ files: 0, bytes: 0 });
+    // Unbounded, the same tree yields the one page it contains.
+    expect(measureMarkdownTree(dir)).toEqual({ files: 1, bytes: 5 });
   });
 
   test("does not follow symlinked directories", () => {

--- a/assistant/src/telemetry/memory-corpus-size.test.ts
+++ b/assistant/src/telemetry/memory-corpus-size.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let workspaceDir = "";
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceDir: () => workspaceDir,
+}));
+
+import { measureMemoryCorpusSize } from "./memory-corpus-size.js";
+
+function write(relativePath: string, contents: string): void {
+  const full = join(workspaceDir, relativePath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, contents, "utf8");
+}
+
+describe("measureMemoryCorpusSize", () => {
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "corpus-size-"));
+  });
+
+  afterEach(() => {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  test("an empty workspace measures as all zeros", () => {
+    expect(measureMemoryCorpusSize()).toEqual({
+      concept_pages: 0,
+      concept_bytes: 0,
+      pkb_files: 0,
+      pkb_bytes: 0,
+      buffer_lines: 0,
+    });
+  });
+
+  test("counts concept pages recursively and totals their bytes", () => {
+    write("memory/concepts/alice.md", "12345"); // 5 bytes
+    write("memory/concepts/people/bob.md", "1234567890"); // 10 bytes
+    write("memory/concepts/people/nested/carol.md", "12345"); // 5 bytes
+
+    const size = measureMemoryCorpusSize();
+
+    expect(size.concept_pages).toBe(3);
+    expect(size.concept_bytes).toBe(20);
+  });
+
+  test("counts the PKB tree independently of concept pages", () => {
+    write("memory/concepts/alice.md", "12345");
+    write("pkb/essentials.md", "1234567890");
+    write("pkb/archive/2026-01-01.md", "12345");
+
+    const size = measureMemoryCorpusSize();
+
+    expect(size.concept_pages).toBe(1);
+    expect(size.pkb_files).toBe(2);
+    expect(size.pkb_bytes).toBe(15);
+  });
+
+  test("ignores non-markdown files", () => {
+    write("memory/concepts/alice.md", "12345");
+    write("memory/concepts/notes.txt", "ignored");
+    write("memory/concepts/.DS_Store", "ignored");
+
+    expect(measureMemoryCorpusSize().concept_pages).toBe(1);
+  });
+
+  test("buffer_lines counts non-empty lines only", () => {
+    write("memory/buffer.md", "- one\n\n- two\n   \n- three\n");
+
+    expect(measureMemoryCorpusSize().buffer_lines).toBe(3);
+  });
+
+  test("an absent buffer reads as zero rather than failing", () => {
+    write("memory/concepts/alice.md", "12345");
+
+    expect(measureMemoryCorpusSize().buffer_lines).toBe(0);
+  });
+
+  test("does not follow symlinked directories", () => {
+    // A link back to an ancestor would otherwise walk forever. Dirents carry
+    // lstat semantics, so the link is skipped rather than recursed into.
+    write("memory/concepts/alice.md", "12345");
+    mkdirSync(join(workspaceDir, "outside"), { recursive: true });
+    writeFileSync(join(workspaceDir, "outside", "extra.md"), "12345", "utf8");
+    symlinkSync(
+      join(workspaceDir, "outside"),
+      join(workspaceDir, "memory", "concepts", "linked"),
+      "dir",
+    );
+
+    const size = measureMemoryCorpusSize();
+
+    expect(size.concept_pages).toBe(1);
+    expect(size.concept_bytes).toBe(5);
+  });
+});

--- a/assistant/src/telemetry/memory-corpus-size.test.ts
+++ b/assistant/src/telemetry/memory-corpus-size.test.ts
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   mkdirSync,
   mkdtempSync,
@@ -8,6 +7,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let workspaceDir = "";
 

--- a/assistant/src/telemetry/memory-corpus-size.ts
+++ b/assistant/src/telemetry/memory-corpus-size.ts
@@ -13,6 +13,15 @@ import { getWorkspaceDir } from "../util/platform.js";
  * accumulated before being switched off. Reporting both unconditionally keeps
  * the numbers legible across a migration instead of blinking to zero the
  * moment a tier flips.
+ *
+ * KNOWN GAP: this measures on-disk Markdown only. It does NOT count
+ * `memory_graph_nodes`, which is a real part of a v1 assistant's learned state
+ * — `v2/migration.ts` gathers graph nodes alongside PKB Markdown when it
+ * migrates v1 — so a v1 assistant rich in graph nodes but holding only the
+ * seeded PKB files reads as near-empty here. Counting them means opening the
+ * memory SQLite DB from the resource-monitor process, which this probe
+ * deliberately does not do. Treat `pkb_files` as a lower bound on v1 corpus
+ * size and confirm v1 assistants directly before sizing a migration off it.
  */
 export interface MemoryCorpusSize {
   /** `.md` files under `memory/concepts/` — the v2/v3 concept-page count. */
@@ -33,13 +42,20 @@ export interface MemoryCorpusSize {
 }
 
 /**
- * Ceiling on files visited per tree. The largest corpus observed in the fleet
- * is in the low hundreds of pages, so this never binds in practice; it exists
- * so a pathological workspace cannot turn a telemetry probe into a long walk.
- * A tree that hits the cap reports the cap, making the count a floor rather
- * than an error.
+ * Ceiling on directory entries examined per tree. The largest corpus observed
+ * in the fleet is in the low hundreds of pages, so this never binds in
+ * practice; it exists so a pathological workspace cannot turn a telemetry
+ * probe into a long walk.
+ *
+ * It counts every dirent seen — directories and non-Markdown files included —
+ * not just the Markdown matches. A cap on matches alone would not bound the
+ * walk at all: a tree of a million empty directories contains zero Markdown
+ * files and would still be traversed in full by this synchronous probe.
+ *
+ * A tree that hits the cap returns what it counted so far, making the result
+ * a floor rather than an error.
  */
-const MAX_FILES_PER_TREE = 20_000;
+const MAX_ENTRIES_PER_TREE = 20_000;
 
 interface TreeSize {
   files: number;
@@ -62,10 +78,17 @@ const EMPTY_TREE: TreeSize = { files: 0, bytes: 0 };
  * `withFileTypes` dirents carry lstat semantics, so a symlinked directory
  * reports as a symlink rather than a directory and is skipped — the walk
  * cannot follow a link into a cycle, and needs no visited-inode bookkeeping.
+ *
+ * `maxEntries` is a parameter only so the ceiling is testable without
+ * materializing twenty thousand files; production callers take the default.
  */
-function measureMarkdownTree(dir: string): TreeSize {
+export function measureMarkdownTree(
+  dir: string,
+  maxEntries: number = MAX_ENTRIES_PER_TREE,
+): TreeSize {
   let files = 0;
   let bytes = 0;
+  let visited = 0;
   const pending: string[] = [dir];
 
   while (pending.length > 0) {
@@ -84,6 +107,10 @@ function measureMarkdownTree(dir: string): TreeSize {
     }
 
     for (const entry of entries) {
+      visited += 1;
+      if (visited > maxEntries) {
+        return { files, bytes };
+      }
       if (entry.isDirectory()) {
         pending.push(join(current, entry.name));
         continue;
@@ -97,9 +124,6 @@ function measureMarkdownTree(dir: string): TreeSize {
       } catch {
         // Counted in `files` but contributes no bytes — a file that vanished
         // between the readdir and the stat is a race, not a failure.
-      }
-      if (files >= MAX_FILES_PER_TREE) {
-        return { files, bytes };
       }
     }
   }

--- a/assistant/src/telemetry/memory-corpus-size.ts
+++ b/assistant/src/telemetry/memory-corpus-size.ts
@@ -1,0 +1,158 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { getWorkspaceDir } from "../util/platform.js";
+
+/**
+ * Coarse on-disk size of the assistant's memory corpus, in the snake_case
+ * shape the `memory_tier` watchdog `detail` bag carries to the platform.
+ *
+ * Both corpora are measured on every tier rather than branching on the tier
+ * itself: an assistant part-way through a v1 -> v2 -> v3 migration has content
+ * in both trees, and a `memory.enabled: false` assistant still has whatever it
+ * accumulated before being switched off. Reporting both unconditionally keeps
+ * the numbers legible across a migration instead of blinking to zero the
+ * moment a tier flips.
+ */
+export interface MemoryCorpusSize {
+  /** `.md` files under `memory/concepts/` — the v2/v3 concept-page count. */
+  concept_pages: number;
+  /** Total bytes of those concept pages. */
+  concept_bytes: number;
+  /** `.md` files under `pkb/` — the v1 personal-knowledge-base corpus. */
+  pkb_files: number;
+  /** Total bytes of those PKB files. */
+  pkb_bytes: number;
+  /**
+   * Non-empty lines in `memory/buffer.md` — remembered facts still waiting on
+   * consolidation. Matches `countBufferLines` in the substrate's
+   * consolidation job: for a well-formed buffer, one non-empty line is one
+   * entry.
+   */
+  buffer_lines: number;
+}
+
+/**
+ * Ceiling on files visited per tree. The largest corpus observed in the fleet
+ * is in the low hundreds of pages, so this never binds in practice; it exists
+ * so a pathological workspace cannot turn a telemetry probe into a long walk.
+ * A tree that hits the cap reports the cap, making the count a floor rather
+ * than an error.
+ */
+const MAX_FILES_PER_TREE = 20_000;
+
+interface TreeSize {
+  files: number;
+  bytes: number;
+}
+
+const EMPTY_TREE: TreeSize = { files: 0, bytes: 0 };
+
+/**
+ * Recursively total the `.md` files under `dir`.
+ *
+ * Deliberately synchronous, and deliberately not routed through the memory
+ * plugin's `listPages` / `getPageIndex`. This runs in the resource-monitor
+ * process, where the plugin's page-index cache is cold — going through it
+ * would read and parse every concept page on each six-hour cycle, and would
+ * add an import out of `telemetry/` into the plugin tree that the plugin
+ * import-boundary guard exists to prevent. A bare readdir + stat is the whole
+ * job here.
+ *
+ * `withFileTypes` dirents carry lstat semantics, so a symlinked directory
+ * reports as a symlink rather than a directory and is skipped — the walk
+ * cannot follow a link into a cycle, and needs no visited-inode bookkeeping.
+ */
+function measureMarkdownTree(dir: string): TreeSize {
+  let files = 0;
+  let bytes = 0;
+  const pending: string[] = [dir];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current === undefined) break;
+
+    let entries;
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      // A missing or unreadable subtree contributes nothing. The common case
+      // is ENOENT: the tier that owns this tree was never active here.
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        pending.push(join(current, entry.name));
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith(".md")) {
+        continue;
+      }
+      files += 1;
+      try {
+        bytes += statSync(join(current, entry.name)).size;
+      } catch {
+        // Counted in `files` but contributes no bytes — a file that vanished
+        // between the readdir and the stat is a race, not a failure.
+      }
+      if (files >= MAX_FILES_PER_TREE) {
+        return { files, bytes };
+      }
+    }
+  }
+
+  return { files, bytes };
+}
+
+/** Non-empty-line count of the file at `path`; 0 when it is absent or empty. */
+function countNonEmptyLines(path: string): number {
+  let content: string;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch {
+    return 0;
+  }
+  if (content.length === 0) {
+    return 0;
+  }
+  return content.split("\n").filter((line) => line.trim().length > 0).length;
+}
+
+/**
+ * Measure the on-disk memory corpus for this assistant.
+ *
+ * Never throws: every probe degrades to zero independently, so a corpus that
+ * is partly unreadable still reports the part that is.
+ */
+export function measureMemoryCorpusSize(): MemoryCorpusSize {
+  const workspaceDir = getWorkspaceDir();
+
+  let concepts: TreeSize = EMPTY_TREE;
+  let pkb: TreeSize = EMPTY_TREE;
+  let bufferLines = 0;
+
+  try {
+    concepts = measureMarkdownTree(join(workspaceDir, "memory", "concepts"));
+  } catch {
+    concepts = EMPTY_TREE;
+  }
+  try {
+    pkb = measureMarkdownTree(join(workspaceDir, "pkb"));
+  } catch {
+    pkb = EMPTY_TREE;
+  }
+  try {
+    bufferLines = countNonEmptyLines(join(workspaceDir, "memory", "buffer.md"));
+  } catch {
+    bufferLines = 0;
+  }
+
+  return {
+    concept_pages: concepts.files,
+    concept_bytes: concepts.bytes,
+    pkb_files: pkb.files,
+    pkb_bytes: pkb.bytes,
+    buffer_lines: bufferLines,
+  };
+}

--- a/assistant/src/telemetry/memory-corpus-size.ts
+++ b/assistant/src/telemetry/memory-corpus-size.ts
@@ -70,7 +70,9 @@ function measureMarkdownTree(dir: string): TreeSize {
 
   while (pending.length > 0) {
     const current = pending.pop();
-    if (current === undefined) break;
+    if (current === undefined) {
+      break;
+    }
 
     let entries;
     try {

--- a/assistant/src/telemetry/memory-tier-reporter.test.ts
+++ b/assistant/src/telemetry/memory-tier-reporter.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { memoryTier } from "../config/memory-tier.js";
 import type { AssistantConfig } from "../config/schema.js";
 import type { ConsentState } from "../platform/consent-cache.js";
+import type { MemoryCorpusSize } from "./memory-corpus-size.js";
 import type { WatchdogEventRecord } from "./watchdog-events-store.js";
 
 // Mutable stubs flipped per test. bun's `mock.module` patches retroactively
@@ -14,6 +15,25 @@ let consent: ConsentState = true;
 let currentConfig: AssistantConfig = {} as AssistantConfig;
 let recorded: WatchdogEventRecord[] = [];
 
+// Stubbed so the assertions below stay exact-match: the real probe walks the
+// live workspace, whose contents differ per machine. `measureMemoryCorpusSize`
+// has its own tests against a temp tree.
+const ZERO_CORPUS: MemoryCorpusSize = {
+  concept_pages: 0,
+  concept_bytes: 0,
+  pkb_files: 0,
+  pkb_bytes: 0,
+  buffer_lines: 0,
+};
+let corpus: MemoryCorpusSize = ZERO_CORPUS;
+let corpusError: Error | null = null;
+
+mock.module("./memory-corpus-size.js", () => ({
+  measureMemoryCorpusSize: () => {
+    if (corpusError) throw corpusError;
+    return corpus;
+  },
+}));
 mock.module("../platform/consent-cache.js", () => ({
   getRawShareAnalytics: () => consent,
 }));
@@ -51,6 +71,8 @@ describe("memory-tier-reporter", () => {
     consent = true;
     currentConfig = {} as AssistantConfig;
     recorded = [];
+    corpus = ZERO_CORPUS;
+    corpusError = null;
     // Clear any interval/boot-retry timer a prior test's start left behind.
     stopMemoryTierReporter();
   });
@@ -69,7 +91,7 @@ describe("memory-tier-reporter", () => {
     expect(recorded).toHaveLength(1);
     expect(recorded[0]).toEqual({
       checkName: "memory_tier",
-      detail: { tier: memoryTier(config) },
+      detail: { tier: memoryTier(config), ...ZERO_CORPUS },
     });
     expect(recorded[0]?.detail?.tier).toBe("v2");
   });
@@ -78,6 +100,33 @@ describe("memory-tier-reporter", () => {
     currentConfig = makeConfig(true, true, true); // v3 live wins over v2
     recordMemoryTierOnce();
 
+    expect(recorded[0]?.detail).toEqual({ tier: "v3", ...ZERO_CORPUS });
+  });
+
+  test("carries the measured corpus size alongside the tier", () => {
+    currentConfig = makeConfig(true, true, true);
+    corpus = {
+      concept_pages: 42,
+      concept_bytes: 133_700,
+      pkb_files: 3,
+      pkb_bytes: 900,
+      buffer_lines: 7,
+    };
+
+    recordMemoryTierOnce();
+
+    expect(recorded[0]?.detail).toEqual({ tier: "v3", ...corpus });
+  });
+
+  test("a failed corpus probe still emits the tier heartbeat", () => {
+    // The fleet-mix dashboards read `detail.tier`; a sizing failure must
+    // degrade the payload, never drop the event and gap the series.
+    currentConfig = makeConfig(true, true, true);
+    corpusError = new Error("workspace unreadable");
+
+    recordMemoryTierOnce();
+
+    expect(recorded).toHaveLength(1);
     expect(recorded[0]?.detail).toEqual({ tier: "v3" });
   });
 
@@ -91,7 +140,7 @@ describe("memory-tier-reporter", () => {
     for (const event of recorded) {
       expect(event).toEqual({
         checkName: "memory_tier",
-        detail: { tier: "v1" },
+        detail: { tier: "v1", ...ZERO_CORPUS },
       });
     }
   });

--- a/assistant/src/telemetry/memory-tier-reporter.test.ts
+++ b/assistant/src/telemetry/memory-tier-reporter.test.ts
@@ -30,7 +30,9 @@ let corpusError: Error | null = null;
 
 mock.module("./memory-corpus-size.js", () => ({
   measureMemoryCorpusSize: () => {
-    if (corpusError) throw corpusError;
+    if (corpusError) {
+      throw corpusError;
+    }
     return corpus;
   },
 }));

--- a/assistant/src/telemetry/memory-tier-reporter.test.ts
+++ b/assistant/src/telemetry/memory-tier-reporter.test.ts
@@ -168,6 +168,20 @@ describe("memory-tier-reporter", () => {
     expect(recorded).toHaveLength(1);
   });
 
+  test("a confirmed opt-out skips the corpus probe entirely", () => {
+    // The event is dropped one layer down, so walking the workspace for it
+    // would be pure cost on an assistant that asked us not to collect. The
+    // throwing stub asserts the probe is never reached.
+    consent = false;
+    currentConfig = makeConfig(true, true);
+    corpusError = new Error("probe must not run");
+
+    recordMemoryTierOnce();
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]?.detail).toEqual({ tier: "v2" });
+  });
+
   test("startMemoryTierReporter is a no-op under VELLUM_DEV=1", () => {
     process.env.VELLUM_DEV = "1";
     consent = true; // consent known → a non-dev start would emit immediately

--- a/assistant/src/telemetry/memory-tier-reporter.ts
+++ b/assistant/src/telemetry/memory-tier-reporter.ts
@@ -50,10 +50,14 @@ const BOOT_RETRY_INTERVAL_MS = 60_000;
  * The event also carries the on-disk corpus size. That probe is best-effort
  * and isolated: if it fails the event still goes out with the tier alone,
  * because the tier heartbeat is what the fleet-mix dashboards depend on and a
- * sizing failure must not create a gap in that series.
+ * sizing failure must not create a gap in that series. It is also skipped
+ * outright on a confirmed opt-out — the event is dropped one layer down, so
+ * walking the workspace for it would be pure cost on the assistants that
+ * asked us not to collect.
  */
 export function recordMemoryTierOnce(): void {
-  if (getRawShareAnalytics() === "unknown") {
+  const consent = getRawShareAnalytics();
+  if (consent === "unknown") {
     return;
   }
   try {
@@ -62,10 +66,12 @@ export function recordMemoryTierOnce(): void {
     const tier = memoryTier(getConfigReadOnly());
 
     let corpus: Record<string, number> = {};
-    try {
-      corpus = { ...measureMemoryCorpusSize() };
-    } catch (err) {
-      log.warn({ err }, "memory corpus sizing failed (emitting tier only)");
+    if (consent !== false) {
+      try {
+        corpus = { ...measureMemoryCorpusSize() };
+      } catch (err) {
+        log.warn({ err }, "memory corpus sizing failed (emitting tier only)");
+      }
     }
 
     recordWatchdogEvent({

--- a/assistant/src/telemetry/memory-tier-reporter.ts
+++ b/assistant/src/telemetry/memory-tier-reporter.ts
@@ -2,6 +2,7 @@ import { getConfigReadOnly } from "../config/loader.js";
 import { memoryTier } from "../config/memory-tier.js";
 import { getRawShareAnalytics } from "../platform/consent-cache.js";
 import { getLogger } from "../util/logger.js";
+import { measureMemoryCorpusSize } from "./memory-corpus-size.js";
 import { recordWatchdogEvent } from "./watchdog-events-store.js";
 
 const log = getLogger("memory-tier-reporter");
@@ -17,7 +18,14 @@ const log = getLogger("memory-tier-reporter");
  */
 const MEMORY_TIER_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
-/** Watchdog `check_name` carrying the coarse memory tier in `detail.tier`. */
+/**
+ * Watchdog `check_name` carrying the coarse memory tier in `detail.tier`,
+ * alongside the on-disk corpus size (see {@link measureMemoryCorpusSize}).
+ *
+ * The check name and the `detail.tier` bucket strings are frozen — platform
+ * dashboards group on them. The rest of `detail` is an open bag, so the
+ * corpus-size keys are additive and need no wire, serializer, or dbt change.
+ */
 const MEMORY_TIER_CHECK_NAME = "memory_tier";
 
 // The boot-time emit races the first consent refresh (fire-and-forget in the
@@ -38,6 +46,11 @@ const BOOT_RETRY_INTERVAL_MS = 60_000;
  * no-ops on a `false` share_analytics, so the call still goes through and the
  * record layer drops it. Never throws: a storage failure is logged and
  * retried on the next cycle.
+ *
+ * The event also carries the on-disk corpus size. That probe is best-effort
+ * and isolated: if it fails the event still goes out with the tier alone,
+ * because the tier heartbeat is what the fleet-mix dashboards depend on and a
+ * sizing failure must not create a gap in that series.
  */
 export function recordMemoryTierOnce(): void {
   if (getRawShareAnalytics() === "unknown") {
@@ -47,9 +60,17 @@ export function recordMemoryTierOnce(): void {
     // `getConfigReadOnly()` re-reads config.json on change (capturing live
     // edits) and never writes to disk — safe for the monitor process.
     const tier = memoryTier(getConfigReadOnly());
+
+    let corpus: Record<string, number> = {};
+    try {
+      corpus = { ...measureMemoryCorpusSize() };
+    } catch (err) {
+      log.warn({ err }, "memory corpus sizing failed (emitting tier only)");
+    }
+
     recordWatchdogEvent({
       checkName: MEMORY_TIER_CHECK_NAME,
-      detail: { tier },
+      detail: { tier, ...corpus },
     });
   } catch (err) {
     log.warn({ err }, "memory_tier watchdog emit failed (non-fatal)");


### PR DESCRIPTION
## Why

We can already see which memory tier every assistant is on (`memory_tier` watchdog, `detail.tier`), but nothing about **how much memory each one actually holds**. The only corpus-size number on the wire today is `real_concept_page_count`, and it rides on two **v3-only** per-turn events. Coverage in prod over the last 14 days:

| Tier | Assistants | Reporting a page count |
| --- | --- | --- |
| v1 | 4 | 0 |
| v2 | 138 | 1 |
| v3 | 1289 | 843 |

So the 142 assistants on v1/v2 — precisely the population we need to plan v3 migrations for — have no observable corpus size.

This matters because migrating to v3 is not a config flip. A v2-shaped corpus (flat bullets, `summary:` frontmatter, no `##` sections) collapses under v3 retrieval into one giant lead with no sections, which is why `vellum-memory-v3-migration` exists as a 10-step reform with a loss audit and an eval gate. But an assistant whose `concepts/` is **empty** has nothing to reform, and flipping it is exactly what new assistants already get via workspace migration 105. Corpus size is what separates those two cases, and today it's unmeasurable from the platform.

## What

Adds a synchronous on-disk probe to the existing six-hourly `memory_tier` emit:

| Field | Meaning |
| --- | --- |
| `concept_pages` / `concept_bytes` | `.md` under `memory/concepts/` — the v2/v3 corpus |
| `pkb_files` / `pkb_bytes` | `.md` under `pkb/` — the v1 corpus |
| `buffer_lines` | non-empty lines in `memory/buffer.md` — remembered facts awaiting consolidation |

`detail` is an open JSON bag end to end (daemon store, platform serializer, BigQuery external table, dbt staging model), so this is purely additive: **no wire, serializer, dbt, or Terraform change**. The frozen parts of the contract — the `memory_tier` check name and the `off`/`v1`/`v2`/`v3` bucket strings — are untouched, so existing dashboards keep working unchanged.

## Design notes

- **Both trees measured on every tier**, rather than branching on the tier. An assistant part-way through v1 → v2 → v3 has content in both, and an `memory.enabled: false` assistant still has whatever it accumulated. Reporting both unconditionally keeps the numbers legible across a migration instead of blinking to zero when a tier flips. It's also less code than the branch.
- **The probe is isolated from the tier emit.** If sizing throws, the event still goes out with the tier alone. The fleet-mix dashboards depend on that heartbeat and a sizing failure must not create a gap in the series. Covered by a test.
- **Does not route through the memory plugin's `getPageIndex` / `listPages`.** This runs in the resource-monitor process where the plugin's page-index cache is cold, so going through it would read and parse every concept page every six hours; it would also add an import from `telemetry/` into the plugin tree that the plugin import-boundary guard exists to prevent. A bare `readdir` + `stat` is the whole job.
- **Kept synchronous** so `recordMemoryTierOnce` keeps its signature and the interval wiring and boot-retry loop are unchanged.
- **Symlinked directories are not followed.** `withFileTypes` dirents carry lstat semantics, so a link reports as a symlink rather than a directory and is skipped — no cycle risk and no visited-inode bookkeeping. Covered by a test.
- A 20k-files-per-tree ceiling bounds a pathological workspace; the largest corpus in the fleet is ~320 pages, so it never binds in practice.

## Testing

- `src/telemetry/memory-corpus-size.test.ts` — new, 7 cases against a real temp tree: empty workspace, recursive counting, byte totals, PKB counted independently, non-markdown ignored, buffer non-empty-line semantics, absent buffer, symlink not followed.
- `src/telemetry/memory-tier-reporter.test.ts` — extended with the corpus payload and the degraded-emit case; the corpus probe is stubbed so the existing exact-match assertions stay deterministic.

Both files pass per-file (`bun test <file>`), which is the CI bar. `bun run typecheck` clean.

## Rollout

Data starts landing within hours of release at the existing 6h cadence plus a per-boot assertion, and is consent-gated like every other watchdog signal (a `collectUsageData` opt-out means absence, not zero). No platform-side change is needed to query it — `JSON_VALUE(detail, '$.concept_pages')` on `stg_telemetry__watchdog` works as soon as events arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)