### PR TITLE
fix(memory): shadow-warning accuracy, injector entry point, and two correctness follow-ups

### DIFF
--- a/assistant/src/__tests__/injector-registry-order-guard.test.ts
+++ b/assistant/src/__tests__/injector-registry-order-guard.test.ts
@@ -20,10 +20,6 @@ import { channelInjectors } from "../plugins/defaults/channel/injectors.js";
 import { documentsInjectors } from "../plugins/defaults/documents/injectors.js";
 import { registerDefaultPluginInjectors } from "../plugins/defaults/index.js";
 import { memoryInjectors } from "../plugins/defaults/memory/injectors.js";
-import {
-  memoryV3Injector,
-  memoryV3SpotlightInjector,
-} from "../plugins/defaults/memory/v3/injector.js";
 import { sessionInjectors } from "../plugins/defaults/session/injectors.js";
 import { turnContextInjectors } from "../plugins/defaults/turn-context/injectors.js";
 import { workspaceInjectors } from "../plugins/defaults/workspace/injectors.js";
@@ -35,9 +31,10 @@ import {
 import type { Injector } from "../plugins/types.js";
 
 // Every injector every default plugin contributes — the registry-independent
-// union, gathered straight from the plugins' exported arrays. Sorting this by
-// `order` must reproduce what `getRegisteredInjectors()` returns once the
-// defaults are registered.
+// union, gathered straight from the plugins' exported arrays (the memory
+// plugin's whole set, memory-v3 injectors included, comes through
+// `memory/injectors.ts`). Sorting this by `order` must reproduce what
+// `getRegisteredInjectors()` returns once the defaults are registered.
 const ALL_CONTRIBUTED = [
   ...turnContextInjectors,
   ...workspaceInjectors,
@@ -45,8 +42,6 @@ const ALL_CONTRIBUTED = [
   ...channelInjectors,
   ...sessionInjectors,
   ...memoryInjectors,
-  memoryV3Injector,
-  memoryV3SpotlightInjector,
 ];
 
 // The ordered id sequence the chain must produce, by ascending `order`. This

--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -148,16 +148,14 @@ export function registerConfigCommand(program: Command): void {
                 : String(value),
             );
           }
-          // A `memory.v2` substrate tunable is not the effective value when
-          // its `memory.substrate` twin is set — print the key that wins so a
-          // read cannot confirm a value the runtime ignores.
-          const { findSubstrateShadowing } =
+          // A `memory.v2` substrate tunable whose `memory.substrate` twin is
+          // set has a second reader — print which key the runtime consults so
+          // the value above cannot be mistaken for the effective one.
+          const { describeShadowedConfigGet, findSubstrateShadowing } =
             await import("../../config/substrate-twin-shadowing.js");
           const shadowing = findSubstrateShadowing(raw, key);
           if (shadowing) {
-            log.warn(
-              `Shadowed: ${shadowing.substratePath} = ${JSON.stringify(shadowing.substrateValue)} takes precedence and is the effective value.`,
-            );
+            log.warn(describeShadowedConfigGet(shadowing, key));
           }
         },
       );

--- a/assistant/src/config/__tests__/substrate-twin-shadowing.test.ts
+++ b/assistant/src/config/__tests__/substrate-twin-shadowing.test.ts
@@ -3,9 +3,10 @@ import { describe, expect, test } from "bun:test";
 import { MemorySubstrateConfigSchema } from "../schemas/memory-substrate.js";
 import { MemoryV2ConfigSchema } from "../schemas/memory-v2.js";
 import {
+  describeShadowedConfigGet,
   describeShadowedConfigSet,
   findSubstrateShadowing,
-  SUBSTRATE_KEY_BY_V2_KEY,
+  SUBSTRATE_TWIN_BY_V2_KEY,
 } from "../substrate-twin-shadowing.js";
 
 describe("substrate twin table", () => {
@@ -13,16 +14,31 @@ describe("substrate twin table", () => {
     // Drift guard: a substrate key with no entry here is a tunable whose
     // shadowing goes unreported, which is the silent no-op this module exists
     // to prevent.
-    expect(new Set(Object.values(SUBSTRATE_KEY_BY_V2_KEY))).toEqual(
-      new Set(Object.keys(MemorySubstrateConfigSchema.shape)),
-    );
+    expect(
+      new Set(
+        Object.values(SUBSTRATE_TWIN_BY_V2_KEY).map((t) => t.substrateKey),
+      ),
+    ).toEqual(new Set(Object.keys(MemorySubstrateConfigSchema.shape)));
   });
 
   test("names a real memory.v2 key on every left-hand side", () => {
     const v2Keys = new Set(Object.keys(MemoryV2ConfigSchema.shape));
-    for (const v2Key of Object.keys(SUBSTRATE_KEY_BY_V2_KEY)) {
+    for (const v2Key of Object.keys(SUBSTRATE_TWIN_BY_V2_KEY)) {
       expect(v2Keys).toContain(v2Key);
     }
+  });
+
+  test("flags exactly the three twins the v2 injection engine reads directly", () => {
+    // `v2/injection.ts` destructures `k` / `hops` off `config.memory.v2` (as
+    // does `v2/backfill-jobs.ts`) and `v2/activation.ts` reads
+    // `config.memory.v2.ann_candidate_limit`. Every other twin's only reader
+    // is `resolveSubstrateTuning`. Widening this set without a matching
+    // direct read makes the warnings claim a divergence that cannot happen.
+    const engineRead = Object.entries(SUBSTRATE_TWIN_BY_V2_KEY)
+      .filter(([, twin]) => twin.alsoReadByV2Engine)
+      .map(([v2Key]) => v2Key)
+      .sort();
+    expect(engineRead).toEqual(["ann_candidate_limit", "hops", "k"]);
   });
 });
 
@@ -40,6 +56,7 @@ describe("findSubstrateShadowing", () => {
     ).toEqual({
       substratePath: "memory.substrate.consolidation_interval_hours",
       substrateValue: 876000,
+      alsoReadByV2Engine: false,
     });
   });
 
@@ -49,6 +66,7 @@ describe("findSubstrateShadowing", () => {
     expect(findSubstrateShadowing(raw, "memory.v2.k")).toEqual({
       substratePath: "memory.substrate.spread_k",
       substrateValue: 0.4,
+      alsoReadByV2Engine: true,
     });
     // hops has no twin set, so nothing shadows it.
     expect(findSubstrateShadowing(raw, "memory.v2.hops")).toBeUndefined();
@@ -69,6 +87,7 @@ describe("findSubstrateShadowing", () => {
     ).toEqual({
       substratePath: "memory.substrate.consolidation_max_buffer_lines",
       substrateValue: null,
+      alsoReadByV2Engine: false,
     });
   });
 
@@ -100,11 +119,12 @@ describe("findSubstrateShadowing", () => {
 });
 
 describe("describeShadowedConfigSet", () => {
-  test("names the winning key, its value, and the command that retunes it", () => {
+  test("a substrate-only twin reads as the no-op it is", () => {
     const message = describeShadowedConfigSet(
       {
         substratePath: "memory.substrate.consolidation_interval_hours",
         substrateValue: 876000,
+        alsoReadByV2Engine: false,
       },
       "memory.v2.consolidation_interval_hours",
     );
@@ -116,5 +136,56 @@ describe("describeShadowedConfigSet", () => {
     expect(message).toContain(
       "assistant config set memory.substrate.consolidation_interval_hours",
     );
+  });
+
+  test("an engine-read twin reports divergence, never inertness", () => {
+    // `memory.v2.k` still tunes the live v2 injection engine, so claiming the
+    // write is inert would send an operator chasing a phantom.
+    const message = describeShadowedConfigSet(
+      {
+        substratePath: "memory.substrate.spread_k",
+        substrateValue: 0.4,
+        alsoReadByV2Engine: true,
+      },
+      "memory.v2.k",
+    );
+
+    expect(message).toContain("does change its behavior");
+    expect(message).toContain("memory.substrate.spread_k (0.4)");
+    expect(message).toContain("diverge");
+    expect(message).not.toContain("does not change the effective value");
+  });
+});
+
+describe("describeShadowedConfigGet", () => {
+  test("a substrate-only twin names the key that is the effective value", () => {
+    const message = describeShadowedConfigGet(
+      {
+        substratePath: "memory.substrate.bm25_b",
+        substrateValue: 0.3,
+        alsoReadByV2Engine: false,
+      },
+      "memory.v2.bm25_b",
+    );
+
+    expect(message).toContain("Shadowed: memory.substrate.bm25_b = 0.3");
+    expect(message).toContain("is the effective value");
+  });
+
+  test("an engine-read twin names both readers", () => {
+    const message = describeShadowedConfigGet(
+      {
+        substratePath: "memory.substrate.ann_candidate_limit",
+        substrateValue: null,
+        alsoReadByV2Engine: true,
+      },
+      "memory.v2.ann_candidate_limit",
+    );
+
+    expect(message).toContain(
+      "Split: memory.substrate.ann_candidate_limit = null",
+    );
+    expect(message).toContain("substrate recall");
+    expect(message).toContain("memory.v2.ann_candidate_limit");
   });
 });

--- a/assistant/src/config/substrate-twin-shadowing.ts
+++ b/assistant/src/config/substrate-twin-shadowing.ts
@@ -2,43 +2,95 @@
 // Memory substrate — twin-namespace shadowing detection
 // ---------------------------------------------------------------------------
 
+/** One `memory.v2` tunable's `memory.substrate` twin. */
+interface SubstrateTwin {
+  /** The twin's `memory.substrate` key, e.g. `spread_k` for `k`. */
+  readonly substrateKey: string;
+  /**
+   * Whether the v2 injection engine reads the `memory.v2` key straight out of
+   * its own namespace (`v2/injection.ts`, `v2/activation.ts`,
+   * `v2/backfill-jobs.ts`) rather than through `resolveSubstrateTuning`. For
+   * these keys the two namespaces feed two different consumers, so a
+   * `memory.v2` write retunes the v2 engine while substrate recall keeps
+   * reading the substrate twin — the pair can hold different effective values
+   * at once.
+   */
+  readonly alsoReadByV2Engine: boolean;
+}
+
 /**
- * `memory.v2` key → `memory.substrate` key, for the fifteen substrate tunables
- * that exist in both namespaces. `k` / `hops` are the historical `memory.v2`
- * names for `spread_k` / `spread_hops`; every other key shares its name with
- * its twin.
+ * `memory.v2` key → its `memory.substrate` twin, for the fifteen substrate
+ * tunables that exist in both namespaces. `k` / `hops` are the historical
+ * `memory.v2` names for `spread_k` / `spread_hops`; every other key shares its
+ * name with its twin.
  *
- * The runtime precedence lives in `resolveSubstrateTuning`
+ * Substrate precedence lives in `resolveSubstrateTuning`
  * (`plugins/defaults/memory/substrate/tuning.ts`), which resolves each tunable
- * as `memory.substrate.X ?? memory.v2.X`. This table is the config surface's
- * view of the same pairing, kept honest by
+ * as `memory.substrate.X ?? memory.v2.X`. Twelve keys reach the runtime only
+ * through that resolver; the three carrying `alsoReadByV2Engine` are read a
+ * second time by the live v2 injection engine off `config.memory.v2` directly.
+ *
+ * This table is the config surface's view of the same pairing, kept honest by
  * `__tests__/substrate-twin-shadowing.test.ts`, which asserts it covers exactly
  * the `memory.substrate` schema's keys.
  */
-export const SUBSTRATE_KEY_BY_V2_KEY: Readonly<Record<string, string>> = {
-  sweep_enabled: "sweep_enabled",
-  dense_weight: "dense_weight",
-  sparse_weight: "sparse_weight",
-  min_sparse_spread: "min_sparse_spread",
-  full_sparse_spread: "full_sparse_spread",
-  bm25_k1: "bm25_k1",
-  bm25_b: "bm25_b",
-  consolidation_interval_hours: "consolidation_interval_hours",
-  consolidation_max_buffer_lines: "consolidation_max_buffer_lines",
-  consolidation_max_entries_per_run: "consolidation_max_entries_per_run",
-  max_page_chars: "max_page_chars",
-  consolidation_prompt_path: "consolidation_prompt_path",
-  k: "spread_k",
-  hops: "spread_hops",
-  ann_candidate_limit: "ann_candidate_limit",
-};
+export const SUBSTRATE_TWIN_BY_V2_KEY: Readonly<Record<string, SubstrateTwin>> =
+  {
+    sweep_enabled: { substrateKey: "sweep_enabled", alsoReadByV2Engine: false },
+    dense_weight: { substrateKey: "dense_weight", alsoReadByV2Engine: false },
+    sparse_weight: { substrateKey: "sparse_weight", alsoReadByV2Engine: false },
+    min_sparse_spread: {
+      substrateKey: "min_sparse_spread",
+      alsoReadByV2Engine: false,
+    },
+    full_sparse_spread: {
+      substrateKey: "full_sparse_spread",
+      alsoReadByV2Engine: false,
+    },
+    bm25_k1: { substrateKey: "bm25_k1", alsoReadByV2Engine: false },
+    bm25_b: { substrateKey: "bm25_b", alsoReadByV2Engine: false },
+    consolidation_interval_hours: {
+      substrateKey: "consolidation_interval_hours",
+      alsoReadByV2Engine: false,
+    },
+    consolidation_max_buffer_lines: {
+      substrateKey: "consolidation_max_buffer_lines",
+      alsoReadByV2Engine: false,
+    },
+    consolidation_max_entries_per_run: {
+      substrateKey: "consolidation_max_entries_per_run",
+      alsoReadByV2Engine: false,
+    },
+    max_page_chars: {
+      substrateKey: "max_page_chars",
+      alsoReadByV2Engine: false,
+    },
+    consolidation_prompt_path: {
+      substrateKey: "consolidation_prompt_path",
+      alsoReadByV2Engine: false,
+    },
+    // The v2 injection engine reads these three off `config.memory.v2`:
+    // `k` / `hops` in `v2/injection.ts` and `v2/backfill-jobs.ts`,
+    // `ann_candidate_limit` in `v2/activation.ts`.
+    k: { substrateKey: "spread_k", alsoReadByV2Engine: true },
+    hops: { substrateKey: "spread_hops", alsoReadByV2Engine: true },
+    ann_candidate_limit: {
+      substrateKey: "ann_candidate_limit",
+      alsoReadByV2Engine: true,
+    },
+  };
 
-/** A `memory.substrate` value that wins over the `memory.v2` key it shadows. */
+/** A `memory.substrate` value set on the twin of a given `memory.v2` key. */
 export type SubstrateShadowing = {
-  /** Dotted path of the winning key, e.g. `memory.substrate.spread_k`. */
+  /** Dotted path of the twin, e.g. `memory.substrate.spread_k`. */
   substratePath: string;
-  /** The winning key's persisted value — the effective tunable. */
+  /** The twin's persisted value — what substrate recall resolves to. */
   substrateValue: unknown;
+  /**
+   * Whether the v2 injection engine also reads the `memory.v2` key directly,
+   * so the write is not inert (see {@link SubstrateTwin.alsoReadByV2Engine}).
+   */
+  alsoReadByV2Engine: boolean;
 };
 
 function readPlainObject(value: unknown): Record<string, unknown> | undefined {
@@ -48,14 +100,16 @@ function readPlainObject(value: unknown): Record<string, unknown> | undefined {
 }
 
 /**
- * The `memory.substrate` twin that shadows `path`, or `undefined` when `path`
- * is not a shadowable `memory.v2` tunable or its twin is unset.
+ * The `memory.substrate` twin covering `path`, or `undefined` when `path` is
+ * not a shadowable `memory.v2` tunable or its twin is unset.
  *
- * `memory.substrate` is override-only and wins whenever its key is present, so
- * a write to (or read of) the `memory.v2` twin is inert once the substrate key
- * exists — including when it holds an explicit `null`, which
+ * `memory.substrate` is override-only and wins for substrate recall whenever
+ * its key is present — including when it holds an explicit `null`, which
  * `resolveSubstrateTuning` treats as present. Detection therefore keys on
- * presence, not truthiness.
+ * presence, not truthiness. What that means for the `memory.v2` key depends on
+ * `alsoReadByV2Engine`: for a substrate-only twin the `memory.v2` value has no
+ * remaining consumer, while for the three engine-read twins it still tunes v2
+ * injection.
  *
  * `raw` is the unparsed config object (`loadRawConfig()` / the `config_get`
  * payload), so the check sees exactly what is persisted.
@@ -72,33 +126,70 @@ export function findSubstrateShadowing(
   if (namespace !== "v2") {
     return undefined;
   }
-  const substrateKey = SUBSTRATE_KEY_BY_V2_KEY[key];
-  if (substrateKey === undefined) {
+  const twin = SUBSTRATE_TWIN_BY_V2_KEY[key];
+  if (twin === undefined) {
     return undefined;
   }
   const substrate = readPlainObject(readPlainObject(raw.memory)?.substrate);
-  if (!substrate || !(substrateKey in substrate)) {
+  if (!substrate || !(twin.substrateKey in substrate)) {
     return undefined;
   }
   return {
-    substratePath: `memory.substrate.${substrateKey}`,
-    substrateValue: substrate[substrateKey],
+    substratePath: `memory.substrate.${twin.substrateKey}`,
+    substrateValue: substrate[twin.substrateKey],
+    alsoReadByV2Engine: twin.alsoReadByV2Engine,
   };
 }
 
 /**
- * Operator-facing warning for a `config set` that lands on a shadowed
- * `memory.v2` tunable: the write persists but changes no behavior, so it names
- * the winning key and the command that actually retunes it.
+ * Operator-facing warning for a `config set` on a `memory.v2` tunable whose
+ * `memory.substrate` twin is set.
+ *
+ * Two classes, two messages. A substrate-only twin leaves the write with no
+ * consumer, so the warning names the winning key and the command that actually
+ * retunes it. An engine-read twin (`k`, `hops`, `ann_candidate_limit`) makes
+ * the write effective for v2 injection while substrate recall stays on the
+ * twin, so the warning reports the split rather than a no-op.
  */
 export function describeShadowedConfigSet(
   shadowing: SubstrateShadowing,
   path: string,
 ): string {
   const value = JSON.stringify(shadowing.substrateValue) ?? "undefined";
+  if (shadowing.alsoReadByV2Engine) {
+    return (
+      `${path} is read directly by the memory-v2 injection engine, so this write ` +
+      `does change its behavior. Substrate recall reads ${shadowing.substratePath} ` +
+      `(${value}) instead, so the two can diverge. ` +
+      `Run 'assistant config set ${shadowing.substratePath} <value>' to move substrate recall with it.`
+    );
+  }
   return (
     `${shadowing.substratePath} is set (${value}) and takes precedence over ${path}, ` +
     `so this write does not change the effective value. ` +
     `Run 'assistant config set ${shadowing.substratePath} <value>' to retune it.`
+  );
+}
+
+/**
+ * Operator-facing annotation for a `config get` of a `memory.v2` tunable whose
+ * `memory.substrate` twin is set — the read-side counterpart of
+ * {@link describeShadowedConfigSet}, split along the same two classes so a read
+ * never confirms a value the runtime ignores nor denies one it honors.
+ */
+export function describeShadowedConfigGet(
+  shadowing: SubstrateShadowing,
+  path: string,
+): string {
+  const value = JSON.stringify(shadowing.substrateValue) ?? "undefined";
+  if (shadowing.alsoReadByV2Engine) {
+    return (
+      `Split: ${shadowing.substratePath} = ${value} is the effective value for ` +
+      `substrate recall, while the memory-v2 injection engine reads ${path} above.`
+    );
+  }
+  return (
+    `Shadowed: ${shadowing.substratePath} = ${value} takes precedence and is ` +
+    `the effective value.`
   );
 }

--- a/assistant/src/persistence/jobs-store.ts
+++ b/assistant/src/persistence/jobs-store.ts
@@ -72,12 +72,12 @@ export type MemoryJobType =
   | "delete_message_lexical"
   | "backfill_lexical_index"
   | "skill_card_insert"
+  | "memory_retrospective"
   | "memory_retrospective_sweep"
   // Retired/legacy — no live handler; persisted rows drop via LEGACY_JOB_TYPES.
   | "memory_v3_consolidate"
   | "memory_v3_index_maintenance"
   | "memory_v3_edge_learning"
-  | "memory_retrospective"
   | "conversation_analyze";
 
 export const EMBED_JOB_TYPES: MemoryJobType[] = [

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -75,10 +75,6 @@ import memoryShutdown from "./memory/hooks/shutdown.js";
 import memoryUserPromptSubmit from "./memory/hooks/user-prompt-submit.js";
 import { memoryInjectors } from "./memory/injectors.js";
 import memoryPkg from "./memory/package.json" with { type: "json" };
-import {
-  memoryV3Injector,
-  memoryV3SpotlightInjector,
-} from "./memory/v3/injector.js";
 import platformHostedPkg from "./platform-hosted/package.json" with { type: "json" };
 import { sessionInjectors } from "./session/injectors.js";
 import sessionPkg from "./session/package.json" with { type: "json" };
@@ -187,14 +183,14 @@ export const defaultEmptyResponsePlugin: Plugin = {
  * the initial injection, and `post-compact` re-applies the injections onto
  * the compacted history after a mid-turn compaction; a `conversation-deleted`
  * hook fails the plugin's pending background jobs when a conversation is
- * deleted. It contributes its personal-memory
- * runtime injectors (PKB context/reminder and the memory-v2 static block, plus
- * the two memory-v3 injectors) to the global injector registry via the
- * `injectors` field; the registry unions them with the domain plugins'
- * injectors and sorts by `order` into the per-turn chain, and the v3 injectors
- * self-gate on `memory.v3.live`. Registered first among the default plugins so
- * later `user-prompt-submit` hooks (history repair, title) see the fully
- * memory-injected history.
+ * deleted. Its runtime injectors (PKB context/reminder, the memory-v2 static
+ * block, and the two memory-v3 injectors) reach the global injector registry
+ * through `memory/injectors.ts` — the plugin's single injector entry point, so
+ * the host stays off the tier directories; the registry unions them with the
+ * domain plugins' injectors and sorts by `order` into the per-turn chain, and
+ * the v3 injectors self-gate on `memory.v3.live`. Registered first among the
+ * default plugins so later `user-prompt-submit` hooks (history repair, title)
+ * see the fully memory-injected history.
  */
 export const defaultMemoryPlugin: Plugin = {
   manifest: {
@@ -209,7 +205,7 @@ export const defaultMemoryPlugin: Plugin = {
     "conversation-deleted": memoryConversationDeleted,
     "conversations-cleared": memoryConversationsCleared,
   },
-  injectors: [...memoryInjectors, memoryV3Injector, memoryV3SpotlightInjector],
+  injectors: memoryInjectors,
 };
 
 /**

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -89,6 +89,12 @@ Two conventions keep that grep honest, and both are load-bearing:
 `indexer.ts`, `injectors.ts`, and `context-search/sources/memory.ts` follow the
 same convention even where the file touches a single tier.
 
+**`injectors.ts` is the plugin's single injector entry point.** Its exported
+`memoryInjectors` is the complete set `defaultMemoryPlugin` contributes —
+including the v3 pair defined in `v3/injector.ts` — so `plugins/defaults/index.ts`
+imports the array and nothing else. A new tier injector is added to that array,
+never registered from the host.
+
 Both rules are enforced by `__tests__/memory-tier-boundary-guard.test.ts`, which
 also carries a reverse stale-exemption test: an allowlist entry whose multi-tier
 import disappears fails loudly instead of lingering. Related guards:
@@ -174,11 +180,20 @@ disjoint cases: the substrate schema's own refinement (both set), the v2
 schema's (neither set), and the parent `MemoryConfigSchema.superRefine` (the
 mixed case, over the RESOLVED pair). Keep all three when touching the weights.
 
-Because `memory.substrate` wins, a `config set` on a shadowed `memory.v2` twin
-persists but changes nothing. `config/substrate-twin-shadowing.ts` pairs the two
-namespaces so that no-op is visible: the `config_set` route returns a `warning`
-naming the winning key, and `assistant config get` prints a `Shadowed:` line
-with the value actually in effect.
+Twelve of the fifteen twins reach the runtime through `resolveSubstrateTuning`
+and nothing else, so once the `memory.substrate` key exists a `config set` on
+the `memory.v2` twin persists but changes nothing. The other three — `k`,
+`hops`, `ann_candidate_limit` — are read a **second** time by the live v2
+injection engine straight off `config.memory.v2` (`v2/injection.ts`,
+`v2/activation.ts`, `v2/backfill-jobs.ts`), so a write there retunes v2
+injection while substrate recall stays on the substrate twin: the two
+namespaces hold two effective values at once.
+
+`config/substrate-twin-shadowing.ts` pairs the namespaces and carries the
+`alsoReadByV2Engine` flag that separates the two classes, so neither case reads
+as the other: the `config_set` route returns a `warning` (a no-op notice for a
+substrate-only twin, a divergence notice for an engine-read one) and
+`assistant config get` prints the matching `Shadowed:` / `Split:` line.
 
 Workspace migration 135 copies explicitly-set NON-DEFAULT `memory.v2` substrate
 tunables into `memory.substrate`. It skips loader-seeded defaults — including

--- a/assistant/src/plugins/defaults/memory/__tests__/indexer-tier-dispatch.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/indexer-tier-dispatch.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Index-time trigger dispatch in `indexMessageNow`, one case per tier.
+ *
+ * The dispatch is three-way — memory off, v1 live, concept-page substrate —
+ * and the two config reads it straddles are separate: callers pass a memory
+ * slice they already hold while the dispatch re-loads the workspace config for
+ * the tier decision. A long-running caller (the v1 `backfill` job hands its
+ * `AssistantConfig` snapshot to every message in a 200-row batch) can therefore
+ * still be indexing under an `enabled: true` slice after the user switched
+ * Memory off, which is the memory-off case exercised here: the dispatch must
+ * read the live config's tier, not treat "no concept-page consumer" as v1.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../../persistence/embeddings/qdrant-client.js", () => ({
+  getQdrantClient: () => ({
+    searchWithFilter: async () => [],
+    hybridSearch: async () => [],
+    upsertPoints: async () => {},
+    deletePoints: async () => {},
+  }),
+  initQdrantClient: () => {},
+  resolveQdrantUrl: () => "http://127.0.0.1:6333",
+}));
+
+import { setConfig } from "../../../../__tests__/helpers/set-config.js";
+import { getConfig } from "../../../../config/loader.js";
+import type { MemoryConfig } from "../../../../config/types.js";
+import { getMemoryCheckpoint } from "../../../../persistence/checkpoints.js";
+import { getMemorySqlite } from "../../../../persistence/db-connection.js";
+import { initializeDb } from "../../../../persistence/db-init.js";
+import { indexMessageNow } from "../indexer.js";
+
+await initializeDb();
+
+/**
+ * Short enough to fall under `MIN_SEGMENT_CHARS`, so no segment rows and no
+ * embed jobs are written and the only enqueues left are the tier triggers.
+ */
+const MESSAGE_TEXT = "a short user message";
+
+let conversationSeq = 0;
+
+/** A fresh conversation id per case, so checkpoints never carry across. */
+function nextConversationId(): string {
+  conversationSeq += 1;
+  return `conv-tier-dispatch-${conversationSeq}`;
+}
+
+function seedMemory(memory: Record<string, unknown>): MemoryConfig {
+  setConfig("memory", memory);
+  return getConfig().memory;
+}
+
+async function indexOneMessage(
+  conversationId: string,
+  slice: MemoryConfig,
+): Promise<void> {
+  await indexMessageNow(
+    {
+      messageId: `${conversationId}:m1`,
+      conversationId,
+      role: "user",
+      content: MESSAGE_TEXT,
+      createdAt: Date.now(),
+    },
+    slice,
+  );
+}
+
+function enqueuedJobTypes(): string[] {
+  const rows = getMemorySqlite()!
+    .query("SELECT DISTINCT type FROM memory_jobs")
+    .all() as { type: string }[];
+  return rows.map((row) => row.type);
+}
+
+/** The v1 arm's per-conversation `graph_extract` debounce counter. */
+function graphExtractPendingCount(conversationId: string): string | null {
+  return getMemoryCheckpoint(`graph_extract:${conversationId}:pending_count`);
+}
+
+describe("indexMessageNow tier dispatch", () => {
+  beforeEach(() => {
+    getMemorySqlite()!.run("DELETE FROM memory_jobs");
+  });
+
+  test("memory off enqueues no tier triggers", async () => {
+    const conversationId = nextConversationId();
+    // The slice a caller captured while memory was still on.
+    const staleSlice = seedMemory({ enabled: true, v2: { enabled: false } });
+    seedMemory({ enabled: false, v2: { enabled: false } });
+
+    await indexOneMessage(conversationId, staleSlice);
+
+    expect(enqueuedJobTypes()).not.toContain("build_conversation_summary");
+    expect(enqueuedJobTypes()).not.toContain("graph_extract");
+    expect(enqueuedJobTypes()).not.toContain("memory_v2_sweep");
+    // Not even the debounce counter: a switch back to v1 must not inherit a
+    // batch's worth of counts accumulated while memory was off.
+    expect(graphExtractPendingCount(conversationId)).toBeNull();
+  });
+
+  test("v1 live enqueues the v1 extraction and summary triggers", async () => {
+    const conversationId = nextConversationId();
+    const slice = seedMemory({ enabled: true, v2: { enabled: false } });
+
+    await indexOneMessage(conversationId, slice);
+
+    expect(enqueuedJobTypes()).toContain("build_conversation_summary");
+    expect(graphExtractPendingCount(conversationId)).toBe("1");
+  });
+
+  test("a concept-page consumer enqueues the substrate sweep trigger", async () => {
+    const conversationId = nextConversationId();
+    const slice = seedMemory({
+      enabled: true,
+      v2: { enabled: true },
+      substrate: { sweep_enabled: true },
+    });
+
+    await indexOneMessage(conversationId, slice);
+
+    expect(enqueuedJobTypes()).toContain("memory_v2_sweep");
+    expect(enqueuedJobTypes()).not.toContain("build_conversation_summary");
+    expect(graphExtractPendingCount(conversationId)).toBeNull();
+  });
+});

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-tier-boundary-guard.test.ts
@@ -153,7 +153,6 @@ const HOST_TIER_IMPORT_ALLOWLIST: readonly HostTierImportExemption[] = [
   { path: "src/daemon/tool-side-effects.ts", tiers: ["substrate"] },
   { path: "src/daemon/trust-context.ts", tiers: ["substrate"] },
   { path: "src/persistence/steps.ts", tiers: ["v1"] },
-  { path: "src/plugins/defaults/index.ts", tiers: ["v3"] },
   { path: "src/runtime/routes/consolidation-routes.ts", tiers: ["substrate"] },
   {
     path: "src/runtime/routes/conversation-query-routes.ts",

--- a/assistant/src/plugins/defaults/memory/indexer.ts
+++ b/assistant/src/plugins/defaults/memory/indexer.ts
@@ -7,7 +7,10 @@ import { createHash } from "crypto";
 import { eq } from "drizzle-orm";
 
 import { getConfig } from "../../../config/loader.js";
-import { usesConceptPageMemory } from "../../../config/memory-v3-gate.js";
+import {
+  isMemoryV1Active,
+  usesConceptPageMemory,
+} from "../../../config/memory-v3-gate.js";
 import type { MemoryConfig } from "../../../config/types.js";
 import {
   getMemoryCheckpoint,
@@ -209,22 +212,31 @@ export async function indexMessageNow(
         ? triggerConfig
         : null;
 
-    // Per-tier trigger dispatch: the v1 extraction/summarization triggers
-    // run only when no concept-page consumer is active; the substrate sweep
-    // trigger runs otherwise. `isAutoAnalysisSource` is the recursion guard
-    // threaded into both arms: the analysis agent writes memory directly via
-    // tools, so extracting from its reflective musings would double-count
-    // and analyzing its own output would loop indefinitely.
+    // Per-tier trigger dispatch, three-way. Memory off enqueues nothing: no
+    // tier is live, and the pending counts the v1 arm would accumulate
+    // meanwhile fire an immediate batch on a later switch back to v1. The v1
+    // extraction/summarization triggers run when the legacy graph engine is
+    // the live tier, and the substrate sweep trigger runs under a concept-page
+    // consumer. `isAutoAnalysisSource` is the recursion guard threaded into
+    // both live arms: the analysis agent writes memory directly via tools, so
+    // extracting from its reflective musings would double-count and analyzing
+    // its own output would loop indefinitely.
     if (conceptConfig == null) {
-      // V1 — delete with v1. Dropping only the banner-marked function body
-      // below would leave this call dangling: collapse the branch to the
-      // substrate arm.
-      enqueueV1IndexTriggers(
-        input.conversationId,
-        isAutoAnalysisSource,
-        batchSize,
-        idleTimeoutMs,
-      );
+      // A null `conceptConfig` covers two states — v1 live and memory off — so
+      // the v1 arm asks the named predicate rather than assuming v1. A failed
+      // config load leaves `triggerConfig` null and fails open to v1: a
+      // transient read error must not silently drop indexing.
+      if (triggerConfig == null || isMemoryV1Active(triggerConfig)) {
+        // V1 — delete with v1. Dropping only the banner-marked function body
+        // below would leave this call dangling: collapse the branch to the
+        // substrate arm.
+        enqueueV1IndexTriggers(
+          input.conversationId,
+          isAutoAnalysisSource,
+          batchSize,
+          idleTimeoutMs,
+        );
+      }
     } else {
       enqueueSubstrateIndexTriggers(
         input.conversationId,
@@ -309,10 +321,10 @@ export async function indexMessageNow(
 
 /**
  * V1 extraction/summarization triggers; run only when the legacy graph engine
- * is the live tier (no concept-page consumer active — under the substrate the
- * v1 graph and `memorySummaries` would be stale data nobody consumes, and
- * pending-count tracking is suppressed too so a later switch back to v1 does
- * not fire an immediate batch from counts accumulated in the meantime).
+ * is the live tier (`isMemoryV1Active` — under the substrate, and with memory
+ * off, the v1 graph and `memorySummaries` would be stale data nobody consumes,
+ * and pending-count tracking is suppressed too so a later switch back to v1
+ * does not fire an immediate batch from counts accumulated in the meantime).
  *
  * Tracks the per-conversation pending-message count to debounce the
  * `graph_extract` batch job, and debounces the conversation-summary build

--- a/assistant/src/plugins/defaults/memory/injectors.ts
+++ b/assistant/src/plugins/defaults/memory/injectors.ts
@@ -1,16 +1,19 @@
 /**
- * `default-memory` plugin injectors — the personal-memory per-turn injections.
+ * `default-memory` plugin injectors — the personal-memory per-turn injections,
+ * and the plugin's single injector entry point: {@link memoryInjectors} is the
+ * complete set `defaultMemoryPlugin` contributes, so the host registers memory
+ * injectors without reaching into a tier directory for one.
  *
  * Contributes the PKB `<knowledge_base>` block, the PKB `<system_reminder>`
- * (with hybrid-search hints), and the memory-v2 static `<info>` block. Each
- * reads its inputs directly off the {@link TurnContext} (and the workspace
- * memory/PKB files), runs its own gating (injection mode, the personal-memory
- * trust gate, the memory-tier gate, null-input short-circuits), and returns an
+ * (with hybrid-search hints), the memory-v2 static `<info>` block, and the two
+ * memory-v3 injectors defined in `v3/injector.ts`. Each reads its inputs
+ * directly off the {@link TurnContext} (and the workspace memory/PKB files),
+ * runs its own gating (injection mode, the personal-memory trust gate, the
+ * memory-tier gate, null-input short-circuits), and returns an
  * {@link InjectionBlock} with the placement that yields the canonical
  * positional semantics.
  *
- * `defaultMemoryPlugin` contributes these (alongside the memory-v3 injectors in
- * `v3/injector.ts`) to the global injector registry
+ * `defaultMemoryPlugin` contributes the array to the global injector registry
  * (`plugins/injector-registry.ts`), which unions every plugin's injectors and
  * sorts by `order` into the single sequence `applyRuntimeInjections` walks each
  * turn. The shared ordering contract lives in {@link DEFAULT_INJECTOR_ORDER}.
@@ -44,6 +47,9 @@ import { getPkbAutoInjectList } from "./v1/pkb/autoinject.js";
 import { readPkbContext } from "./v1/pkb/context.js";
 import { searchPkbFiles } from "./v1/pkb/pkb-search.js";
 import { getPkbRoot } from "./v1/pkb/types.js";
+// V3 — delete with v3. Re-exported through `memoryInjectors` below so the
+// host registers them without importing `v3/` itself.
+import { memoryV3Injector, memoryV3SpotlightInjector } from "./v3/injector.js";
 
 const pkbReminderLog = getLogger("pkb-reminder");
 
@@ -405,11 +411,11 @@ function buildMemoryV2StaticBlock(content: string): string {
 }
 
 /**
- * The `default-memory` plugin's personal-memory injectors, in ascending
- * `order`. `defaultMemoryPlugin` contributes these alongside the memory-v3
- * injectors; the registry sorts the union by `order` (see
- * {@link DEFAULT_INJECTOR_ORDER}), so this array's literal order is only a
- * readability convenience.
+ * Every injector the `default-memory` plugin contributes, in ascending
+ * `order`. This is the plugin's whole injector surface — `defaultMemoryPlugin`
+ * passes the array straight through, and the registry sorts the cross-plugin
+ * union by `order` (see {@link DEFAULT_INJECTOR_ORDER}), so this array's
+ * literal order is only a readability convenience.
  */
 export const memoryInjectors: Injector[] = [
   // V1 — delete with v1. The PKB pair is the legacy engine's entire injection
@@ -422,4 +428,8 @@ export const memoryInjectors: Injector[] = [
   // `memory-v2-static` is FROZEN: `daemon/conversation-runtime-assembly.ts`
   // switches on it to capture the block into persisted message metadata.
   memoryV2StaticInjector,
+  // V3 — delete with v3. The frozen net-new card block and its ephemeral
+  // spotlight companion; both self-gate on `memory.v3.live`.
+  memoryV3Injector,
+  memoryV3SpotlightInjector,
 ];

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1601,10 +1601,11 @@ async function handleSetConfig({ body }: RouteHandlerArgs) {
   }
 
   await commitConfigWrite(raw, "set");
-  // A `memory.v2` substrate tunable whose `memory.substrate` twin is set
-  // persists but changes nothing — the substrate namespace wins in
-  // `resolveSubstrateTuning`. Report that alongside the success so the caller
-  // can tell the operator, rather than letting the write read as effective.
+  // A `memory.v2` substrate tunable whose `memory.substrate` twin is set does
+  // not mean what an unpaired write means: the substrate namespace wins in
+  // `resolveSubstrateTuning`, and for the three twins the v2 injection engine
+  // reads directly the two namespaces diverge instead. Report which case this
+  // is alongside the success so the caller can tell the operator.
   const shadowing = findSubstrateShadowing(raw, path);
   if (shadowing) {
     const warning = describeShadowedConfigSet(shadowing, path);


### PR DESCRIPTION
## Summary
- config set/get no longer claims a memory.v2 write is inert for the three twins the live v2 engine reads directly (k, hops, ann_candidate_limit)
- The plugin registry imports injectors only through memory/injectors.ts instead of reaching into memory/v3/
- indexer.ts stops enqueueing v1 triggers when memory is disabled
- jobs-store.ts no longer labels the live memory_retrospective job type as retired

Addresses Codex review on #39187 plus the three follow-ups called out in its description.