### PR TITLE
feat(channels): add discord to the canonical channel vocabulary

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3999,6 +3999,7 @@ paths:
                             - email
                             - platform
                             - a2a
+                            - discord
                         label:
                           type: string
                         subtitle:
@@ -4282,6 +4283,7 @@ paths:
                             - email
                             - platform
                             - a2a
+                            - discord
                         ready:
                           type: boolean
                         setupStatus:
@@ -4371,6 +4373,7 @@ paths:
                     - email
                     - platform
                     - a2a
+                    - discord
                 includeRemote:
                   description: Include remote checks (default true)
                   type: boolean
@@ -4400,6 +4403,7 @@ paths:
                             - email
                             - platform
                             - a2a
+                            - discord
                         ready:
                           type: boolean
                         setupStatus:
@@ -21368,6 +21372,7 @@ paths:
                     - email
                     - platform
                     - a2a
+                    - discord
                     - scheduler
                     - watcher
                 sourceContextId:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6451,13 +6451,15 @@ paths:
           schema:
             type: string
             enum:
-              - slack
               - telegram
-              - whatsapp
-              - email
-              - a2a
-              - vellum
               - phone
+              - vellum
+              - whatsapp
+              - slack
+              - email
+              - platform
+              - a2a
+              - discord
           description:
             Filter by origin channel. When provided, only conversations with this exact origin_channel value are
             returned. Omit to include all channels.
@@ -6583,6 +6585,7 @@ paths:
                                 - email
                                 - platform
                                 - a2a
+                                - discord
                             - type: "null"
                         assistantAttention:
                           type: object
@@ -6936,6 +6939,7 @@ paths:
                               - email
                               - platform
                               - a2a
+                              - discord
                           - type: "null"
                       assistantAttention:
                         type: object
@@ -8145,6 +8149,7 @@ paths:
                               - email
                               - platform
                               - a2a
+                              - discord
                           - type: "null"
                       assistantAttention:
                         type: object

--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -75,9 +75,8 @@ const CHANNEL_POLICIES = {
   },
   discord: {
     notification: {
-      // Discord has no outbound transport yet — ingress-only. Enabling
-      // delivery before one exists would route notifications at a callback
-      // no transport owns. Flip to true alongside the Discord transport.
+      // Discord has no outbound transport, so enabling delivery would route
+      // notifications at a callback no transport owns.
       deliveryEnabled: false,
       conversationStrategy: "continue_existing_conversation",
     },

--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -73,6 +73,15 @@ const CHANNEL_POLICIES = {
       conversationStrategy: "continue_existing_conversation",
     },
   },
+  discord: {
+    notification: {
+      // Discord has no outbound transport yet — ingress-only. Enabling
+      // delivery before one exists would route notifications at a callback
+      // no transport owns. Flip to true alongside the Discord transport.
+      deliveryEnabled: false,
+      conversationStrategy: "continue_existing_conversation",
+    },
+  },
 } as const satisfies Record<ChannelId, ChannelNotificationPolicy>;
 
 export type ChannelPolicies = typeof CHANNEL_POLICIES;

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -136,6 +136,24 @@ export const CHANNEL_METADATA: Partial<Record<ChannelId, ChannelInfo>> = {
         "I'd like to connect with another assistant via A2A. Can you help me set that up?",
     },
   },
+  // Present so the metadata is ready for the ingress slice, but not yet listed
+  // in `BASE_AVAILABLE_CHANNELS` — `/v1/channels/available` builds from that
+  // list, so nothing surfaces Discord to clients until it is added there.
+  // `supportsVerification` stays false until a Discord verification flow
+  // exists; clients render the card display-only meanwhile.
+  discord: {
+    id: "discord",
+    label: "Discord",
+    subtitle: "Message your assistant from Discord",
+    icon: "message-circle",
+    supportsVerification: false,
+    setupMessages: {
+      guardian:
+        "I'd like to verify my identity as your guardian on Discord. Can you help me set that up?",
+      contact:
+        "I'd like to verify a contact's Discord identity. Can you walk me through it?",
+    },
+  },
 };
 
 export const INTERFACE_IDS = [
@@ -150,6 +168,7 @@ export const INTERFACE_IDS = [
   "email",
   "chrome-extension",
   "a2a",
+  "discord",
   // Turns injected by workspace custom routes (webhook receivers, cron jobs,
   // device/service callbacks). Non-interactive — permission prompts route
   // through the guardian system, not an interactive client — and non-host-proxy.

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -136,23 +136,6 @@ export const CHANNEL_METADATA: Partial<Record<ChannelId, ChannelInfo>> = {
         "I'd like to connect with another assistant via A2A. Can you help me set that up?",
     },
   },
-  // `/v1/channels/available` builds from `BASE_AVAILABLE_CHANNELS`, which
-  // omits Discord, so this metadata reaches no client. `supportsVerification`
-  // is false because there is no Discord verification flow — clients render
-  // the card display-only.
-  discord: {
-    id: "discord",
-    label: "Discord",
-    subtitle: "Message your assistant from Discord",
-    icon: "message-circle",
-    supportsVerification: false,
-    setupMessages: {
-      guardian:
-        "I'd like to verify my identity as your guardian on Discord. Can you help me set that up?",
-      contact:
-        "I'd like to verify a contact's Discord identity. Can you walk me through it?",
-    },
-  },
 };
 
 export const INTERFACE_IDS = [

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -136,11 +136,10 @@ export const CHANNEL_METADATA: Partial<Record<ChannelId, ChannelInfo>> = {
         "I'd like to connect with another assistant via A2A. Can you help me set that up?",
     },
   },
-  // Present so the metadata is ready for the ingress slice, but not yet listed
-  // in `BASE_AVAILABLE_CHANNELS` — `/v1/channels/available` builds from that
-  // list, so nothing surfaces Discord to clients until it is added there.
-  // `supportsVerification` stays false until a Discord verification flow
-  // exists; clients render the card display-only meanwhile.
+  // `/v1/channels/available` builds from `BASE_AVAILABLE_CHANNELS`, which
+  // omits Discord, so this metadata reaches no client. `supportsVerification`
+  // is false because there is no Discord verification flow — clients render
+  // the card display-only.
   discord: {
     id: "discord",
     label: "Discord",

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -25,6 +25,7 @@ export const NOTIFICATION_SOURCE_CHANNELS = [
   { id: "email", description: "Email channel" },
   { id: "platform", description: "Platform-managed channel" },
   { id: "a2a", description: "Agent-to-agent protocol channel" },
+  { id: "discord", description: "Discord channel" },
   { id: "scheduler", description: "Scheduled task runner (reminders, cron)" },
   { id: "watcher", description: "File/event watcher subsystem" },
 ] as const;

--- a/assistant/src/runtime/routes/conversation-list-routes.ts
+++ b/assistant/src/runtime/routes/conversation-list-routes.ts
@@ -10,6 +10,7 @@
 
 import { z } from "zod";
 
+import { CHANNEL_IDS } from "../../channels/types.js";
 import { channelBindingSchema } from "../../messaging/channel-binding-schema.js";
 import {
   type Confidence,
@@ -57,16 +58,7 @@ const log = getLogger("conversation-list-routes");
 // Response schemas
 // ---------------------------------------------------------------------------
 
-const channelIdSchema = z.enum([
-  "telegram",
-  "phone",
-  "vellum",
-  "whatsapp",
-  "slack",
-  "email",
-  "platform",
-  "a2a",
-]);
+const channelIdSchema = z.enum(CHANNEL_IDS);
 
 const assistantAttentionSchema = z.object({
   hasUnseenLatestAssistantMessage: z.boolean(),
@@ -453,15 +445,7 @@ export const ROUTES: RouteDefinition[] = [
           "Filter by origin channel. When provided, only conversations with this exact origin_channel value are returned. Omit to include all channels.",
         schema: {
           type: "string",
-          enum: [
-            "slack",
-            "telegram",
-            "whatsapp",
-            "email",
-            "a2a",
-            "vellum",
-            "phone",
-          ],
+          enum: [...CHANNEL_IDS],
         },
       },
     ],

--- a/clients/web/src/lib/channel-admission-policy/types.ts
+++ b/clients/web/src/lib/channel-admission-policy/types.ts
@@ -31,7 +31,11 @@ export const INTERNAL_CHANNELS = new Set<string>(["platform", "a2a"]);
  * them into the UI. Mirrors `ADMISSION_POLICY_HIDDEN_CHANNELS` in
  * `packages/gateway-client/src/admission-policy-contract.ts`.
  */
-export const HIDDEN_CHANNELS = new Set<string>(["vellum", "whatsapp"]);
+export const HIDDEN_CHANNELS = new Set<string>([
+  "vellum",
+  "whatsapp",
+  "discord",
+]);
 
 export function isHiddenChannel(channelType: string): boolean {
   return HIDDEN_CHANNELS.has(channelType);

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -130,7 +130,7 @@ A default row per enforced channel is **seeded at startup** (`seedAdmissionPolic
 
 For exempt ids, `PUT /v1/assistants/:id/channel-admission-policy/:channelType` returns **403**, the GET list omits them, and the runtime short-circuits `admitted: true` in `admission-policy.ts` (defense in depth). Codex finding from #35006 review: exemption checks must live in _both_ the gateway route handler AND the runtime stage — single-side enforcement creates a misuse wedge.
 
-**Hidden channels** (`ADMISSION_POLICY_HIDDEN_CHANNELS` = `vellum`, `whatsapp`) — managed automatically, **not** user-configurable, but (unlike exempt channels) **still enforced at runtime**:
+**Hidden channels** (`ADMISSION_POLICY_HIDDEN_CHANNELS` = `vellum`, `whatsapp`, `discord`) — managed automatically, **not** user-configurable, but (unlike exempt channels) **still enforced at runtime**:
 
 - The GET list omits them, and `PUT`/`DELETE` return **403** (`isAdmissionPolicyHiddenChannel`).
 - They are **not** exempt — the runtime still evaluates rank-vs-floor, so a real inbound channel like `whatsapp` keeps its admission floor.

--- a/gateway/src/__tests__/seed-admission-policy.test.ts
+++ b/gateway/src/__tests__/seed-admission-policy.test.ts
@@ -64,11 +64,9 @@ describe("seedAdmissionPolicyDefaults", () => {
     // Enforced — not skipped as exempt — at the universal default.
     expect(store.get("discord")).toBe("trusted_contacts");
 
-    // Hidden while the channel has no ingress: it is absent from the Channel
-    // Trust Floors list, so the seed must re-pin any row rather than leave a
-    // floor the user cannot see or reset. Drop Discord from
-    // ADMISSION_POLICY_HIDDEN_CHANNELS in the slice that lands ingress, and
-    // this expectation flips to the configurable behaviour asserted above.
+    // Hidden: Discord is absent from the Channel Trust Floors list, so the
+    // seed re-pins any row rather than leaving a floor the user cannot see or
+    // reset.
     store.set("discord", "strangers", "drifted row");
     seedAdmissionPolicyDefaults(store);
     expect(store.get("discord")).toBe("trusted_contacts");

--- a/gateway/src/__tests__/seed-admission-policy.test.ts
+++ b/gateway/src/__tests__/seed-admission-policy.test.ts
@@ -55,22 +55,23 @@ describe("seedAdmissionPolicyDefaults", () => {
     expect(store.get("email")).toBe("trusted_contacts");
   });
 
-  test("picks up discord generically — enforced, configurable, default floor", () => {
+  test("picks up discord generically — enforced, hidden, pinned at the default floor", () => {
     // Discord carries no entry in CHANNEL_ADMISSION_DEFAULTS and no special
-    // casing anywhere in the seed. Adding it to CHANNEL_IDS must be enough to
-    // put it in the enforced-and-configurable bucket, so a new channel can
-    // never reach ingress without an admission floor. If Discord is ever
-    // added to the exempt or hidden set, this test fails loudly.
+    // casing in the seed: adding it to CHANNEL_IDS is enough to give it a
+    // floor, so a channel id can never reach ingress unenforced.
     seedAdmissionPolicyDefaults(store);
 
-    // Enforced (not skipped as exempt) and seeded at the universal default.
+    // Enforced — not skipped as exempt — at the universal default.
     expect(store.get("discord")).toBe("trusted_contacts");
 
-    // Configurable (not hidden): a user-set floor survives re-seeding, unlike
-    // the hidden channels asserted below.
-    store.set("discord", "strangers", "user widened discord");
+    // Hidden while the channel has no ingress: it is absent from the Channel
+    // Trust Floors list, so the seed must re-pin any row rather than leave a
+    // floor the user cannot see or reset. Drop Discord from
+    // ADMISSION_POLICY_HIDDEN_CHANNELS in the slice that lands ingress, and
+    // this expectation flips to the configurable behaviour asserted above.
+    store.set("discord", "strangers", "drifted row");
     seedAdmissionPolicyDefaults(store);
-    expect(store.get("discord")).toBe("strangers");
+    expect(store.get("discord")).toBe("trusted_contacts");
   });
 
   test("resets a stranded hidden-channel row back to its default", () => {

--- a/gateway/src/__tests__/seed-admission-policy.test.ts
+++ b/gateway/src/__tests__/seed-admission-policy.test.ts
@@ -23,7 +23,9 @@ describe("seedAdmissionPolicyDefaults", () => {
   test("seeds enforced channels with their defaults (vellum → guardian_only, rest → trusted_contacts)", () => {
     seedAdmissionPolicyDefaults(store);
 
-    const byChannel = new Map(store.list().map((r) => [r.channelType, r.policy]));
+    const byChannel = new Map(
+      store.list().map((r) => [r.channelType, r.policy]),
+    );
     expect(byChannel.get("vellum")).toBe("guardian_only");
     expect(byChannel.get("slack")).toBe("trusted_contacts");
     expect(byChannel.get("telegram")).toBe("trusted_contacts");
@@ -51,6 +53,24 @@ describe("seedAdmissionPolicyDefaults", () => {
     expect(store.get("telegram")).toBe("any_contact");
     // A channel the user never touched still gets its seeded default.
     expect(store.get("email")).toBe("trusted_contacts");
+  });
+
+  test("picks up discord generically — enforced, configurable, default floor", () => {
+    // Discord carries no entry in CHANNEL_ADMISSION_DEFAULTS and no special
+    // casing anywhere in the seed. Adding it to CHANNEL_IDS must be enough to
+    // put it in the enforced-and-configurable bucket, so a new channel can
+    // never reach ingress without an admission floor. If Discord is ever
+    // added to the exempt or hidden set, this test fails loudly.
+    seedAdmissionPolicyDefaults(store);
+
+    // Enforced (not skipped as exempt) and seeded at the universal default.
+    expect(store.get("discord")).toBe("trusted_contacts");
+
+    // Configurable (not hidden): a user-set floor survives re-seeding, unlike
+    // the hidden channels asserted below.
+    store.set("discord", "strangers", "user widened discord");
+    seedAdmissionPolicyDefaults(store);
+    expect(store.get("discord")).toBe("strangers");
   });
 
   test("resets a stranded hidden-channel row back to its default", () => {

--- a/gateway/src/channels/inbound-event.ts
+++ b/gateway/src/channels/inbound-event.ts
@@ -71,10 +71,10 @@ export type SlackInboundEvent = InboundEventBase<"slack">;
 export type EmailInboundEvent = InboundEventBase<"email">;
 export type A2aInboundEvent = InboundEventBase<"a2a">;
 /**
- * Discord carries no normalizer yet — the variant exists so the ingress
- * vocabulary is complete ahead of the Gateway client. `conversationExternalId`
- * will be the channel snowflake, `actorExternalId` the author's user snowflake,
- * and `source.threadId` a thread / forum-post snowflake.
+ * Discord has no normalizer, so nothing constructs this variant. It defines the
+ * shape one produces: `conversationExternalId` is the channel snowflake,
+ * `actorExternalId` the author's user snowflake, and `source.threadId` a thread
+ * or forum-post snowflake.
  */
 export type DiscordInboundEvent = InboundEventBase<"discord">;
 

--- a/gateway/src/channels/inbound-event.ts
+++ b/gateway/src/channels/inbound-event.ts
@@ -10,7 +10,7 @@ import type { ChannelId } from "./types.js";
 
 export type InboundChannelId = Extract<
   ChannelId,
-  "telegram" | "whatsapp" | "slack" | "email" | "a2a"
+  "telegram" | "whatsapp" | "slack" | "email" | "a2a" | "discord"
 >;
 
 interface InboundEventBase<C extends InboundChannelId> {
@@ -70,10 +70,18 @@ export type WhatsAppInboundEvent = InboundEventBase<"whatsapp">;
 export type SlackInboundEvent = InboundEventBase<"slack">;
 export type EmailInboundEvent = InboundEventBase<"email">;
 export type A2aInboundEvent = InboundEventBase<"a2a">;
+/**
+ * Discord carries no normalizer yet — the variant exists so the ingress
+ * vocabulary is complete ahead of the Gateway client. `conversationExternalId`
+ * will be the channel snowflake, `actorExternalId` the author's user snowflake,
+ * and `source.threadId` a thread / forum-post snowflake.
+ */
+export type DiscordInboundEvent = InboundEventBase<"discord">;
 
 export type GatewayInboundEvent =
   | TelegramInboundEvent
   | WhatsAppInboundEvent
   | SlackInboundEvent
   | EmailInboundEvent
-  | A2aInboundEvent;
+  | A2aInboundEvent
+  | DiscordInboundEvent;

--- a/gateway/src/channels/types.ts
+++ b/gateway/src/channels/types.ts
@@ -16,6 +16,7 @@ export const CHANNEL_IDS = [
   "slack",
   "email",
   "a2a",
+  "discord",
 ] as const satisfies readonly CanonicalChannelId[];
 
 export type ChannelId = (typeof CHANNEL_IDS)[number];

--- a/packages/gateway-client/src/admission-policy-contract.ts
+++ b/packages/gateway-client/src/admission-policy-contract.ts
@@ -80,11 +80,10 @@ export function isAdmissionPolicyExemptChannel(channelType: string): boolean {
  * `vellum` is the local desktop/web client surface; the guardian is always
  * max-rank there, so the seed default admits them regardless of the floor.
  *
- * `discord` is hidden because the channel id exists ahead of its ingress
- * implementation. Hiding keeps the floor enforced and pinned at the seed
- * default while there is nothing to configure, so the Channel Trust Floors
- * list can't offer a Discord row the user cannot yet use. Remove it from this
- * set in the slice that lands Discord ingress.
+ * `discord` has no ingress implementation, so there is nothing for a floor to
+ * gate and nothing for the user to configure. Hiding keeps it pinned at the
+ * seed default rather than offering a Channel Trust Floors row for a channel
+ * that receives nothing.
  */
 export const ADMISSION_POLICY_HIDDEN_CHANNELS: ReadonlySet<string> = new Set([
   "vellum",

--- a/packages/gateway-client/src/admission-policy-contract.ts
+++ b/packages/gateway-client/src/admission-policy-contract.ts
@@ -79,10 +79,17 @@ export function isAdmissionPolicyExemptChannel(channelType: string): boolean {
  *
  * `vellum` is the local desktop/web client surface; the guardian is always
  * max-rank there, so the seed default admits them regardless of the floor.
+ *
+ * `discord` is hidden because the channel id exists ahead of its ingress
+ * implementation. Hiding keeps the floor enforced and pinned at the seed
+ * default while there is nothing to configure, so the Channel Trust Floors
+ * list can't offer a Discord row the user cannot yet use. Remove it from this
+ * set in the slice that lands Discord ingress.
  */
 export const ADMISSION_POLICY_HIDDEN_CHANNELS: ReadonlySet<string> = new Set([
   "vellum",
   "whatsapp",
+  "discord",
 ]);
 
 export function isAdmissionPolicyHiddenChannel(channelType: string): boolean {

--- a/packages/service-contracts/src/__tests__/channels.test.ts
+++ b/packages/service-contracts/src/__tests__/channels.test.ts
@@ -18,8 +18,16 @@ describe("isChannelId", () => {
     expect(isChannelId("vellum")).toBe(true);
   });
 
+  test("includes discord", () => {
+    // Discord is canonical vocabulary ahead of its ingress implementation:
+    // the gateway's inbound list and the admission-policy seed both derive
+    // from CHANNEL_IDS, so it must be here for a Discord message to be
+    // routable and to carry an admission floor at all.
+    expect(isChannelId("discord")).toBe(true);
+  });
+
   test("rejects unknown strings and non-string values", () => {
-    expect(isChannelId("discord")).toBe(false);
+    expect(isChannelId("mastodon")).toBe(false);
     expect(isChannelId("")).toBe(false);
     expect(isChannelId(undefined)).toBe(false);
     expect(isChannelId(null)).toBe(false);

--- a/packages/service-contracts/src/channels.ts
+++ b/packages/service-contracts/src/channels.ts
@@ -29,6 +29,7 @@ export const CHANNEL_IDS = [
   "email",
   "platform",
   "a2a",
+  "discord",
 ] as const;
 
 export type ChannelId = (typeof CHANNEL_IDS)[number];


### PR DESCRIPTION
Closes LUM-2835. First slice of the LUM-2834 Discord arc — step 1 of the PR sequence in §6 of the investigation attached to LUM-2834.

Vocabulary only. No ingress, no egress, no user-visible change.

## What this does for the user

Nothing visible — **and that is the deliverable.** This adds `"discord"` as a routable channel id so the ingress slice has somewhere to land, while making sure a half-built channel cannot leak into any surface the user touches.

| Surface | Before this PR | After |
| --- | --- | --- |
| **Channel Trust Floors** ("Who Can Reach") | A **Discord** row would have appeared, editable, for a channel that can't receive anything | Hidden from the list; `PUT`/`DELETE` return 403 |
| **Channels / Contacts** (`/v1/channels/available`) | — | Still absent; `BASE_AVAILABLE_CHANNELS` untouched and no metadata entry |
| **Discord admission floor** | No row at all — a channel id with no floor | Seeded `trusted_contacts`, enforced, re-pinned on drift |
| **Conversation list / filter** | A Discord-origin conversation would fail response validation; clients couldn't model or filter it | Enums derived from `CHANNEL_IDS`, so it validates and filters |
| **Sending to Discord** | `deliverDirect` throws `unsupported callback` | Unchanged — still throws, still asserted by tests |
| **Notification delivery to Discord** | n/a | `deliveryEnabled: false` — never routed at a missing transport |

The Trust Floors row is the one that would actually have shipped a bug. The GET handler builds its list from `CHANNEL_IDS` minus the exempt and hidden sets (`channel-admission-policy.ts:92`), so adding the id alone would have put a configurable Discord row in settings. Caught in review and fixed in `1aa662e`.

## Why this is right

**Five vocabularies needed the entry. Three were found by the compiler, one in review:**

| Vocabulary | Why |
| --- | --- |
| `packages/service-contracts/src/channels.ts` | The canonical set. |
| `gateway/src/channels/types.ts` | The gateway keeps its **own** subset asserted against the canonical one. `InboundChannelId` is `Extract<>`-ed from *that*, so without it the extract silently yielded `never`. |
| `assistant/src/channels/config.ts` | An exhaustive `Record<ChannelId, …>`, built to fail compilation until a new channel declares a policy. It worked as designed. |
| `assistant/src/notifications/signal.ts` | The notification source-channel registry (channels + synthetic sources). |
| `assistant/src/runtime/routes/conversation-list-routes.ts` | Two hand-maintained `z.enum([...])` string-literal copies. **The compiler could not catch these** — nothing is keyed on `ChannelId`. Both now derive from `CHANNEL_IDS`. |

That last one is the interesting result: the type system caught three copies and silently missed the two that were plain string literals. They also revealed pre-existing drift — the `originChannel` query enum was missing `platform` independently of this PR. Deriving both restores it.

**No `CHANNEL_METADATA` entry.** An earlier revision added one; it is removed in `ffc6cc5`. `/v1/channels/available` is the only production consumer and builds from `BASE_AVAILABLE_CHANNELS`, so the entry was unreachable — but the real problem was its content. It carried invented copy for the wrong product shape: a `subtitle` describing a personal DM assistant when v1 is a **guild-scoped community bot**, `setupMessages` inviting a verification flow that does not exist (`supportsVerification` was `false` in the same object), and a placeholder icon despite a real `discord-logo.tsx` in the web client. Copy that looks finished but encodes the wrong model is worse than an obvious gap, because the ingress slice would inherit it rather than write copy that fits. The map now matches its own docstring, alongside `vellum` and `platform`.

**Hidden, not exempt.** Not interchangeable. Exempt channels short-circuit the admission check in *both* the gateway and the runtime — an exempt Discord could reach ingress with no floor at all. Hidden keeps the floor fully enforced and re-pinned at the seed default, and only removes the row from the UI. That is the treatment `whatsapp` already gets, and `gateway/AGENTS.md` names it as the correct mechanism for exactly this case.

**`deliveryEnabled: false`.** Discord has no outbound transport; enabling delivery would route notifications at a callback no transport owns. Matches the WhatsApp precedent.

**`INTERFACE_IDS` gained `"discord"`** — the one addition beyond the ticket's file list. Every other ingress channel has a matching interface id and `handle-inbound` sets `interface: event.sourceChannel`, so omitting it leaves a gap for the ingress slice. Verified inert: no exhaustive `Record<InterfaceId, …>` exists, and `INTERACTIVE_INTERFACES` is an allow-set that correctly excludes it.

## Why this is safe

**Egress is provably absent.** `git diff --stat -- assistant/src/messaging/` is empty. `DIRECT_DELIVERY_CHANNELS` and every transport are untouched, and the `deliver/discord` negative assertions in `transport-dispatch.test.ts:84,91,209` and `callback-routing.test.ts:16` are **green and unchanged** — they remain the proof egress doesn't exist.

**Fail-closed by construction.** Discord seeds at `trusted_contacts` (rank 3) and every Discord actor would classify `unknown` (rank 1), so nothing would be admitted even if ingress appeared tomorrow. The floor exists *before* the channel does.

**Every channel-listing surface was checked, not assumed:**
- `channel-permission-overrides` validates a submitted adapter but never enumerates one.
- `/v1/channels/available` builds from `BASE_AVAILABLE_CHANNELS` — Discord deliberately absent, with no metadata entry either.
- Web `SETUP_CHANNEL_IDS` and `KNOWN_CHANNEL_IDS` are independent hardcoded lists.

## What the next slice flips

Code comments describe present state only (per root `AGENTS.md`), so the rollout sequencing lives here instead:

| Flip | Where | To |
| --- | --- | --- |
| Show the Trust Floors row | `ADMISSION_POLICY_HIDDEN_CHANNELS` + web `HIDDEN_CHANNELS` | remove `"discord"` |
| Surface in Channels/Contacts | `BASE_AVAILABLE_CHANNELS` **+ a new `CHANNEL_METADATA.discord`** | add together; **write the copy for a guild-scoped community bot**, not the Slack/Telegram "message your assistant" pattern, and use the existing `discord-logo.tsx` rather than a lucide placeholder |
| Enable notification delivery | `channels/config.ts` | `deliveryEnabled: true`, once a transport exists |
| Enable egress | `DIRECT_DELIVERY_CHANNELS` + `TRANSPORTS` | add `"discord"`; the three negative assertions become positive |
| Verification flow | `CHANNEL_METADATA.discord.supportsVerification` | `true`, once a flow exists |
| Seed test | `seed-admission-policy.test.ts` | hidden/re-pin assertion → configurable assertion |

Per LUM-2834 scoping, mention-only default in guild channels + the channel allow-list land in the **ingress** slice, not polish.

## Test plan

Run with the repo's own runners (`bun run test`), which give each file its own process — Bun's `mock.module` is process-global, so a bare `bun test <dir>` produces hundreds of bogus cross-file failures.

- **Gateway: all 215 test files pass.** Includes `seed-admission-policy` + `channel-admission-policy-routes` (19 pass / 0 fail).
- **Assistant:** 22/22 relevant files pass in isolation, plus all five `conversation-*-routes` suites after the enum change, plus `channel-availability-routes` (9 pass) after the metadata removal.
- **service-contracts: 171 pass / 0 fail.** The removed negative assertion is replaced by an explicit `isChannelId("discord") === true` pin, with `"mastodon"` as the unknown-string sentinel.
- **Typecheck clean:** assistant, gateway, gateway-client, clients/web all exit 0. Two `service-contracts` errors are pre-existing and byte-identical at baseline (verified by stashing).
- **Admission seed confirmed, not assumed** (as the ticket asked): a new test pins that Discord is picked up generically at `trusted_contacts`, is enforced rather than exempt, and — while hidden — has drifted rows re-pinned.
- **OpenAPI:** regenerated; `--check` clean. The gateway spec publishes no channel enum and is unaffected; its version-line drift against `package.json` predates this branch and is left alone.

Rebased onto `1459b1b`.

<sub>An earlier revision of this description claimed ~490 pre-existing gateway test failures. That was wrong — an artifact of invoking `bun test` directly instead of the isolation runner. The suite is fully green.</sub>

## CLI verb checklist

N/A — no routes added.