### PR TITLE
fix(migrations): stop leaking vbundle export temp files on abort and restart

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20354,6 +20354,10 @@ paths:
       responses:
         "200":
           description: Successful response
+        "499":
+          description:
+            The client disconnected while the archive was being built. No body is returned and the staged archive is
+            discarded.
   /v1/migrations/export-to-gcs:
     post:
       operationId: migrations_exporttogcs_post

--- a/assistant/src/runtime/routes/__tests__/migration-export-abort-cleanup.test.ts
+++ b/assistant/src/runtime/routes/__tests__/migration-export-abort-cleanup.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for temp-file cleanup on the direct-download export route.
+ *
+ * `handleMigrationExport` took its `RouteHandlerArgs` as `_args` and dropped
+ * them, so `req.signal` — which both adapters already pass — was available and
+ * unused. Cleanup hung off a single trigger, the read stream's `close` event,
+ * which fires on a completed transfer but not on a client abort or connection
+ * drop. Every disconnect stranded a workspace-sized archive in `$TMPDIR`.
+ *
+ * These drive the real handler against a real workspace so the assertions are
+ * about files on disk, not about a mocked call being made.
+ *
+ * **What is not covered, and why.** The disconnect itself is not reproducible
+ * in-process. Calling the handler directly leaves no socket to die, and the
+ * runtime drains the response stream to EOF whether or not anything is reading
+ * it — so `close` fires and the pre-existing cleanup runs regardless. The abort
+ * binding exists for the case a unit test cannot create: a real connection that
+ * goes away, leaving the body unread and the stream open. A test asserting it
+ * here would pass against the unfixed code and prove nothing.
+ */
+
+import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { assertNotLiveDb } from "../../../__tests__/assert-not-live-db.js";
+import { waitFor } from "../../../__tests__/helpers/wait-for.js";
+import { handleMigrationExport } from "../migration-routes.js";
+
+let workspaceDir: string;
+let previousWorkspaceDir: string | undefined;
+
+/** Export archives staged in the temp directory right now. */
+function stagedExports(): string[] {
+  return readdirSync(tmpdir()).filter(
+    (name) => name.startsWith("vbundle-export-") && name.endsWith(".tmp"),
+  );
+}
+
+beforeEach(() => {
+  workspaceDir = join(tmpdir(), `export-abort-ws-${crypto.randomUUID()}`);
+  mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+  writeFileSync(join(workspaceDir, "config.json"), JSON.stringify({}));
+  writeFileSync(join(workspaceDir, "data", "db", "assistant.db"), "db-bytes");
+
+  previousWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+});
+
+afterEach(async () => {
+  if (previousWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceDir;
+  }
+  assertNotLiveDb(workspaceDir);
+  await rm(workspaceDir, { recursive: true, force: true });
+});
+
+describe("handleMigrationExport — abort cleanup", () => {
+  test("a client already gone is not built for at all", async () => {
+    const before = new Set(stagedExports());
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await handleMigrationExport({
+      abortSignal: controller.signal,
+    });
+
+    // Reported as a disconnect rather than handed a body nobody is reading.
+    expect(result.status).toBe(499);
+    expect(result.body).toBeNull();
+
+    // And nothing was staged: the build is skipped outright, which on a large
+    // workspace is an hour of CPU and tens of gigabytes not spent.
+    expect(stagedExports().filter((n) => !before.has(n))).toEqual([]);
+  }, 60_000);
+
+  test("a completed transfer still evicts via the stream's own close", async () => {
+    const before = new Set(stagedExports());
+
+    const result = await handleMigrationExport({});
+
+    expect(result.headers["Content-Type"]).toBe("application/octet-stream");
+    expect(Number(result.headers["Content-Length"])).toBeGreaterThan(0);
+
+    // Draining the body to completion closes the read stream, which is the
+    // trigger that already worked and must keep working.
+    await new Response(result.body).arrayBuffer();
+
+    await waitFor(() => stagedExports().every((name) => before.has(name)), {
+      timeoutMs: 5_000,
+      message: "staged archive was never evicted after a completed transfer",
+    });
+  }, 60_000);
+});

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -362,12 +362,36 @@ export async function handleMigrationValidate({
  *
  * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, svc_daemon, local.
  */
-export async function handleMigrationExport(
-  _args: RouteHandlerArgs,
-): Promise<RouteResponse> {
+/** The client hung up; there is no one left to send a body to. */
+function clientGoneResponse(): RouteResponse {
+  log.info("Export client disconnected before the archive was served");
+  return new RouteResponse(null, {}, 499);
+}
+
+export async function handleMigrationExport({
+  abortSignal,
+}: RouteHandlerArgs): Promise<RouteResponse> {
   // The legacy `description` field is no longer carried on the v1
   // manifest. Older clients still POST it; we silently ignore it.
   let cleanup: (() => Promise<void>) | undefined;
+
+  /**
+   * Evict the staged archive, at most once however many triggers fire. Safe to
+   * run while the runtime is still streaming it: on POSIX the unlink drops the
+   * directory entry and the open descriptor keeps the remaining bytes
+   * readable.
+   */
+  const evictTempFile = async (): Promise<void> => {
+    const run = cleanup;
+    cleanup = undefined;
+    await run?.();
+  };
+
+  // Building the archive costs an hour and tens of gigabytes on a large
+  // workspace. If the client is already gone there is nothing to build for.
+  if (abortSignal?.aborted) {
+    return clientGoneResponse();
+  }
 
   try {
     const manifestInputs = await buildExportManifestInputs();
@@ -423,14 +447,33 @@ export async function handleMigrationExport(
     cleanup = result.cleanup;
     const { tempPath, size, manifest } = result;
 
+    // Nothing between here and the listeners below awaits, so a disconnect is
+    // caught by exactly one of them.
+    if (abortSignal?.aborted) {
+      await evictTempFile();
+      return clientGoneResponse();
+    }
+
     const timestamp = manifest.created_at.replace(/[:.]/g, "-");
     const filename = `export-${timestamp}.vbundle`;
 
     const fileStream = createReadStream(tempPath);
+    // Fires once the body has been read to the end, or when the stream is
+    // destroyed — the successful-transfer case.
     fileStream.on("close", () => {
-      cleanup?.();
-      cleanup = undefined;
+      void evictTempFile();
     });
+    // A client that disconnects mid-transfer does not reliably tear the read
+    // stream down, which is how a leaked archive outlived the export. The
+    // adapters already hand the connection's signal to the handler, so bind
+    // it as the second trigger; the eviction itself runs at most once.
+    abortSignal?.addEventListener(
+      "abort",
+      () => {
+        void evictTempFile();
+      },
+      { once: true },
+    );
 
     const streamBody = Readable.toWeb(fileStream) as unknown as ReadableStream;
 
@@ -447,7 +490,7 @@ export async function handleMigrationExport(
       "X-Vbundle-Credentials-Included": String(credentials.length),
     });
   } catch (err) {
-    await cleanup?.();
+    await evictTempFile();
     log.error({ err }, "Failed to build export bundle");
     throw new InternalError(
       err instanceof Error ? err.message : "Unexpected export error",
@@ -2114,6 +2157,12 @@ export const ROUTES: RouteDefinition[] = [
     requestBody: z.object({
       description: z.string().describe("Human-readable export description"),
     }),
+    additionalResponses: {
+      "499": {
+        description:
+          "The client disconnected while the archive was being built. No body is returned and the staged archive is discarded.",
+      },
+    },
     handler: handleMigrationExport,
   },
   {


### PR DESCRIPTION
Binds temp-file cleanup on the direct-download vbundle export to the request's abort signal, so a client that disconnects does not strand a workspace-sized archive in `$TMPDIR`.

Not merged — see the closing comment.