### PR TITLE
feat(chat): resolve bare workspace paths in chat into file links

### DIFF
--- a/clients/web/src/domains/chat/components/chat-markdown-message.tsx
+++ b/clients/web/src/domains/chat/components/chat-markdown-message.tsx
@@ -38,6 +38,9 @@ import {
   rehypeRedactedCredential,
 } from "@/domains/chat/utils/rehype-redacted-credential";
 import { rehypeStreamWordFade } from "@/domains/chat/utils/rehype-stream-word-fade";
+import { rehypeWorkspacePath } from "@/domains/chat/utils/rehype-workspace-path";
+import { WORKSPACE_PATH_TAG } from "@/domains/chat/utils/workspace-path-links";
+import { WorkspacePathLink } from "@/domains/chat/components/workspace-path-link";
 
 /** Returns true when `href` is a known `vellum://` attachment link. */
 export function isVellumLink(href: string | undefined): boolean {
@@ -263,6 +266,16 @@ export interface ChatMarkdownMessageProps extends Omit<
    * must render as literal text, not manufacture a reveal affordance.
    */
   redactedCredentialChips?: boolean;
+  /**
+   * Resolve inline code spans that hold a workspace file path into file links
+   * (see `rehypeWorkspacePath`). Requires `onVellumLinkClick` — the resolved
+   * link opens the same file-action modal as an explicit `vellum://` link.
+   *
+   * Enable only for assistant-authored content. The affordance is a claim
+   * that the assistant is referring to a file it worked with; a path the user
+   * typed is their own prose and should render as they wrote it.
+   */
+  workspacePathLinks?: boolean;
 }
 
 export const ChatMarkdownMessage = memo(function ChatMarkdownMessage({
@@ -274,6 +287,7 @@ export const ChatMarkdownMessage = memo(function ChatMarkdownMessage({
   assistantId,
   streamWordFade,
   redactedCredentialChips,
+  workspacePathLinks,
 }: ChatMarkdownMessageProps) {
   const { openPreview, previewModal } = useAttachmentPreview(
     assistantId,
@@ -318,6 +332,12 @@ export const ChatMarkdownMessage = memo(function ChatMarkdownMessage({
       ...(redactedCredentialChips
         ? [rehypeRedactedCredential as import("unified").Pluggable]
         : []),
+      // Only worth running when a click handler exists to receive the
+      // resolved path — without one the upgraded span renders as plain code
+      // anyway.
+      ...(workspacePathLinks && onVellumLinkClick
+        ? [rehypeWorkspacePath as import("unified").Pluggable]
+        : []),
       ...(streamWordFade
         ? [
             [
@@ -327,7 +347,12 @@ export const ChatMarkdownMessage = memo(function ChatMarkdownMessage({
           ]
         : []),
     ],
-    [redactedCredentialChips, streamWordFade],
+    [
+      redactedCredentialChips,
+      streamWordFade,
+      workspacePathLinks,
+      onVellumLinkClick,
+    ],
   );
 
   const imageComponent: MarkdownImageComponent = useMemo(
@@ -372,9 +397,21 @@ export const ChatMarkdownMessage = memo(function ChatMarkdownMessage({
           assistantId={assistantId}
         />
       ),
+      [WORKSPACE_PATH_TAG]: (props: { path?: string; raw?: string }) => (
+        <WorkspacePathLink
+          {...props}
+          assistantId={assistantId}
+          onOpen={onVellumLinkClick}
+        />
+      ),
     }),
-    [assistantId],
+    [assistantId, onVellumLinkClick],
   );
+
+  // Both tags are registered together: each is only ever emitted by its own
+  // rehype plugin, so a tag whose plugin didn't run never appears in the tree.
+  const hasExtraComponents =
+    redactedCredentialChips || (workspacePathLinks && onVellumLinkClick);
 
   return (
     <>
@@ -386,7 +423,7 @@ export const ChatMarkdownMessage = memo(function ChatMarkdownMessage({
         imageComponent={imageComponent}
         urlTransform={vellumUrlTransform}
         extraRehypePlugins={extraRehypePlugins}
-        extraComponents={redactedCredentialChips ? extraComponents : undefined}
+        extraComponents={hasExtraComponents ? extraComponents : undefined}
       />
       {previewModal}
     </>

--- a/clients/web/src/domains/chat/components/workspace-path-link.test.tsx
+++ b/clients/web/src/domains/chat/components/workspace-path-link.test.tsx
@@ -10,7 +10,7 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
@@ -160,6 +160,33 @@ describe("workspace path spans", () => {
     });
 
     expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  test("a file that appears later upgrades the span in place", async () => {
+    // The "I'll write it to X, ... wrote it to X" sequence: the listing is
+    // cached before the file exists, and the span must pick up the refreshed
+    // listing without being remounted.
+    const queryClient = clientWithListing("drafts", []);
+    renderMessage(
+      "I'll write it to `/workspace/drafts/notes.md`.",
+      queryClient,
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+
+    queryClient.setQueryData(
+      workspaceTreeGetQueryKey({
+        path: { assistant_id: ASSISTANT_ID },
+        query: { path: "drafts" },
+      }),
+      { path: "drafts", entries: [entry("drafts/notes.md")] },
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "/workspace/drafts/notes.md" }),
+      ).toBeTruthy();
+    });
   });
 
   test("paths inside fenced code blocks are left alone", () => {

--- a/clients/web/src/domains/chat/components/workspace-path-link.test.tsx
+++ b/clients/web/src/domains/chat/components/workspace-path-link.test.tsx
@@ -13,8 +13,15 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 
+// Toggled per-test rather than re-mocked: `mock.module` is process-global, so
+// a second registration would leak into the rest of the file.
+let orgReady = true;
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => orgReady,
+}));
+
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
-import { workspaceTreeGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import { workspaceTreeQueryOptions } from "@/lib/workspace-tree-query";
 
 const ASSISTANT_ID = "assistant-1";
 
@@ -44,10 +51,8 @@ function clientWithListing(dir: string, entries: TreeEntry[]): QueryClient {
     defaultOptions: { queries: { retry: false } },
   });
   queryClient.setQueryData(
-    workspaceTreeGetQueryKey({
-      path: { assistant_id: ASSISTANT_ID },
-      query: { path: dir },
-    }),
+    workspaceTreeQueryOptions({ assistantId: ASSISTANT_ID, path: dir })
+      .queryKey,
     { path: dir, entries },
   );
   return queryClient;
@@ -80,6 +85,7 @@ function renderMessage(
 
 afterEach(() => {
   cleanup();
+  orgReady = true;
 });
 
 describe("workspace path spans", () => {
@@ -175,10 +181,8 @@ describe("workspace path spans", () => {
     expect(screen.queryByRole("button")).toBeNull();
 
     queryClient.setQueryData(
-      workspaceTreeGetQueryKey({
-        path: { assistant_id: ASSISTANT_ID },
-        query: { path: "drafts" },
-      }),
+      workspaceTreeQueryOptions({ assistantId: ASSISTANT_ID, path: "drafts" })
+        .queryKey,
       { path: "drafts", entries: [entry("drafts/notes.md")] },
     );
 
@@ -187,6 +191,27 @@ describe("workspace path spans", () => {
         screen.getByRole("button", { name: "/workspace/drafts/notes.md" }),
       ).toBeTruthy();
     });
+  });
+
+  test("no listing is requested before the organization store is ready", () => {
+    // Platform-hosted requests carry an org header the store supplies after
+    // auth; firing first is rejected, and `retry: false` would strand the
+    // span. Cached data still renders — the gate withholds the request, not
+    // the result.
+    orgReady = false;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    renderMessage("See `/workspace/drafts/notes.md`.", queryClient);
+
+    const { queryKey } = workspaceTreeQueryOptions({
+      assistantId: ASSISTANT_ID,
+      path: "drafts",
+    });
+    expect(queryClient.getQueryState(queryKey)?.fetchStatus ?? "idle").toBe(
+      "idle",
+    );
+    expect(screen.queryByRole("button")).toBeNull();
   });
 
   test("paths inside fenced code blocks are left alone", () => {

--- a/clients/web/src/domains/chat/components/workspace-path-link.test.tsx
+++ b/clients/web/src/domains/chat/components/workspace-path-link.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Integration tests for workspace-path spans rendered through
+ * ChatMarkdownMessage.
+ *
+ * The listing query is seeded directly into the TanStack cache rather than
+ * mocked at the SDK layer: the cache entry is the contract the component
+ * actually reads, and seeding it keeps the assertions about *existence
+ * gating* (the point of the feature) instead of fetch plumbing.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
+import { workspaceTreeGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+
+const ASSISTANT_ID = "assistant-1";
+
+interface TreeEntry {
+  name: string;
+  path: string;
+  type: "file" | "directory";
+  size: number | null;
+  mimeType: string | null;
+  modifiedAt: string;
+}
+
+function entry(path: string, type: "file" | "directory" = "file"): TreeEntry {
+  return {
+    name: path.split("/").pop() ?? path,
+    path,
+    type,
+    size: 128,
+    mimeType: "text/markdown",
+    modifiedAt: "2026-07-24T02:18:49Z",
+  };
+}
+
+/** Seed the directory listing the component will read for `dir`. */
+function clientWithListing(dir: string, entries: TreeEntry[]): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.setQueryData(
+    workspaceTreeGetQueryKey({
+      path: { assistant_id: ASSISTANT_ID },
+      query: { path: dir },
+    }),
+    { path: dir, entries },
+  );
+  return queryClient;
+}
+
+function renderMessage(
+  content: string,
+  queryClient: QueryClient,
+  {
+    workspacePathLinks = true,
+    onVellumLinkClick = mock(() => {}),
+  }: {
+    workspacePathLinks?: boolean;
+    onVellumLinkClick?: (href: string, linkText: string) => void;
+  } = {},
+) {
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  render(
+    createElement(ChatMarkdownMessage, {
+      content,
+      assistantId: ASSISTANT_ID,
+      workspacePathLinks,
+      onVellumLinkClick,
+    }),
+    { wrapper },
+  );
+  return { onVellumLinkClick };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("workspace path spans", () => {
+  test("a path whose file exists renders as a clickable link", () => {
+    const queryClient = clientWithListing("drafts", [
+      entry("drafts/v0.10.12-release-notes.md"),
+    ]);
+    renderMessage(
+      "The draft is at `/workspace/drafts/v0.10.12-release-notes.md`.",
+      queryClient,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "/workspace/drafts/v0.10.12-release-notes.md",
+    });
+    expect(button).toBeTruthy();
+  });
+
+  test("clicking opens the file-action modal with the vellum:// href", () => {
+    const queryClient = clientWithListing("drafts", [entry("drafts/notes.md")]);
+    const { onVellumLinkClick } = renderMessage(
+      "See `/workspace/drafts/notes.md`.",
+      queryClient,
+    );
+
+    screen.getByRole("button", { name: "/workspace/drafts/notes.md" }).click();
+
+    expect(onVellumLinkClick).toHaveBeenCalledWith(
+      "vellum://workspace/drafts/notes.md",
+      "notes.md",
+    );
+  });
+
+  test("a path whose file does not exist stays plain code", () => {
+    // The "I'll write it to X" case: the span is path-shaped, but nothing is
+    // there yet. A link here would be dead on arrival.
+    const queryClient = clientWithListing("drafts", [entry("drafts/other.md")]);
+    renderMessage(
+      "I'll write it to `/workspace/drafts/notes.md`.",
+      queryClient,
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(
+      screen.getByText("/workspace/drafts/notes.md").tagName.toLowerCase(),
+    ).toBe("code");
+  });
+
+  test("a directory entry does not become a file link", () => {
+    const queryClient = clientWithListing("drafts", [
+      entry("drafts/archive", "directory"),
+    ]);
+    renderMessage("Look in `/workspace/drafts/archive`.", queryClient);
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  test("an unresolved listing stays plain code", () => {
+    // No cache entry: the query is still in flight (or failed). Nothing is
+    // rendered as a link until the file is confirmed.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, enabled: false } },
+    });
+    renderMessage("See `/workspace/drafts/notes.md`.", queryClient);
+
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(
+      screen.getByText("/workspace/drafts/notes.md").tagName.toLowerCase(),
+    ).toBe("code");
+  });
+
+  test("user-authored content is never upgraded", () => {
+    // A path the user typed is their own prose — it renders as written even
+    // when the file exists.
+    const queryClient = clientWithListing("drafts", [entry("drafts/notes.md")]);
+    renderMessage("See `/workspace/drafts/notes.md`.", queryClient, {
+      workspacePathLinks: false,
+    });
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  test("paths inside fenced code blocks are left alone", () => {
+    const queryClient = clientWithListing("drafts", [entry("drafts/notes.md")]);
+    renderMessage("```\n/workspace/drafts/notes.md\n```", queryClient);
+
+    // Scoped by name: the code block ships its own copy button.
+    expect(
+      screen.queryByRole("button", { name: "/workspace/drafts/notes.md" }),
+    ).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/workspace-path-link.tsx
+++ b/clients/web/src/domains/chat/components/workspace-path-link.tsx
@@ -1,0 +1,107 @@
+/**
+ * Renders a code span that `rehypeWorkspacePath` flagged as a workspace file
+ * path, upgrading it to a file link only once the file is confirmed to exist.
+ *
+ * Existence is the whole point of the component. A path-shaped code span is
+ * not evidence of a file: the assistant writes paths it is *about* to create
+ * ("I'll save it to `/workspace/drafts/notes.md`"), paths it has since
+ * deleted, and hypothetical examples. Linking optimistically would produce a
+ * dead affordance in exactly those cases, so the link appears only after a
+ * directory listing shows a matching file. Until then — and on any miss or
+ * error — the span renders as ordinary inline code, which is the pre-existing
+ * behavior.
+ *
+ * The check is a `workspace/tree` listing of the file's parent directory
+ * rather than a per-file fetch: `workspace/file` returns the file's full
+ * inline text, which is a lot of payload to decide whether to underline
+ * something. TanStack Query dedupes by key, so N paths in one directory —
+ * the common case in a "here's what I wrote" message — cost one request, and
+ * the listing is shared with any other consumer already browsing that
+ * directory. Because the query lives in the cache, a file that appears later
+ * lights its link up on the next refetch without the message re-rendering
+ * from scratch.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { MARKDOWN_INLINE_CODE_CLASS } from "@vellumai/design-library";
+import { workspaceTreeGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+  toVellumWorkspaceHref,
+  workspaceBasenameOf,
+  workspaceDirOf,
+} from "@/domains/chat/utils/workspace-path-links";
+
+/**
+ * Workspace contents change while a conversation is open (the assistant is
+ * often writing the very file being discussed), so listings are refetched
+ * more eagerly than a static browse would need.
+ */
+const LISTING_STALE_MS = 15_000;
+
+export interface WorkspacePathLinkProps {
+  /** Workspace-relative path, set by `rehypeWorkspacePath`. */
+  path?: string;
+  /** The path exactly as the assistant wrote it — what the span displays. */
+  raw?: string;
+  /** Active assistant whose workspace the path is resolved against. */
+  assistantId?: string | null;
+  /**
+   * Click handler shared with `vellum://` markdown links, so a resolved path
+   * opens the same file-action modal (Go to file / Download) as an explicitly
+   * linked file. Without it there is no affordance to offer and the span stays
+   * plain code.
+   */
+  onOpen?: (href: string, linkText: string) => void;
+}
+
+export function WorkspacePathLink({
+  path,
+  raw,
+  assistantId,
+  onOpen,
+}: WorkspacePathLinkProps) {
+  const label = raw ?? path ?? "";
+  const enabled = Boolean(path && assistantId && onOpen);
+
+  const { data } = useQuery({
+    ...workspaceTreeGetOptions({
+      path: { assistant_id: assistantId ?? "" },
+      query: { path: path ? workspaceDirOf(path) : "" },
+    }),
+    enabled,
+    staleTime: LISTING_STALE_MS,
+    // A path the assistant invented names a directory that often doesn't
+    // exist; retrying a 404 three times per span would turn a speculative
+    // match into real traffic.
+    retry: false,
+  });
+
+  const exists = useMemo(
+    () =>
+      path != null &&
+      (data?.entries.some(
+        (entry) => entry.type === "file" && entry.path === path,
+      ) ??
+        false),
+    [data, path],
+  );
+
+  if (!exists || !path || !onOpen) {
+    return <code className={MARKDOWN_INLINE_CODE_CLASS}>{label}</code>;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        onOpen(toVellumWorkspaceHref(path), workspaceBasenameOf(path))
+      }
+      className={`${MARKDOWN_INLINE_CODE_CLASS} cursor-pointer text-[var(--system-positive-strong)] underline decoration-dotted underline-offset-2 hover:opacity-80`}
+      title={`Open ${path}`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/clients/web/src/domains/chat/components/workspace-path-link.tsx
+++ b/clients/web/src/domains/chat/components/workspace-path-link.tsx
@@ -8,8 +8,7 @@
  * deleted, and hypothetical examples. Linking optimistically would produce a
  * dead affordance in exactly those cases, so the link appears only after a
  * directory listing shows a matching file. Until then — and on any miss or
- * error — the span renders as ordinary inline code, which is the pre-existing
- * behavior.
+ * error — the span renders as ordinary inline code.
  *
  * The check is a `workspace/tree` listing of the file's parent directory
  * rather than a per-file fetch: `workspace/file` returns the file's full
@@ -17,13 +16,18 @@
  * something. TanStack Query dedupes by key, so N paths in one directory —
  * the common case in a "here's what I wrote" message — cost one request, and
  * the listing is shared with any other consumer already browsing that
- * directory. Because the query lives in the cache, a file that appears later
- * lights its link up on the next refetch without the message re-rendering
- * from scratch.
+ * directory.
+ *
+ * An unresolved candidate polls its listing for a short window after mount.
+ * A cached listing going stale does not itself refetch, so a path cited
+ * before its file is written would otherwise stay plain code until something
+ * unrelated (focus, reconnect, remount) happened to refresh the query — the
+ * poll closes that gap for the case that produces it, and stops as soon as
+ * the file resolves or the window elapses.
  */
 
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { MARKDOWN_INLINE_CODE_CLASS } from "@vellumai/design-library";
 import { workspaceTreeGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
@@ -39,6 +43,16 @@ import {
  * more eagerly than a static browse would need.
  */
 const LISTING_STALE_MS = 15_000;
+
+/**
+ * Cadence and lifetime of the unresolved-candidate poll. The window covers the
+ * span between the assistant announcing a file and writing it; past that, an
+ * unresolved path is one that was never going to resolve (a hypothetical, a
+ * deleted file, a directory that does not exist), and polling it forever would
+ * put a permanent timer behind every such span in the transcript.
+ */
+const RESOLVE_POLL_MS = 10_000;
+const RESOLVE_POLL_WINDOW_MS = 90_000;
 
 export interface WorkspacePathLinkProps {
   /** Workspace-relative path, set by `rehypeWorkspacePath`. */
@@ -64,6 +78,7 @@ export function WorkspacePathLink({
 }: WorkspacePathLinkProps) {
   const label = raw ?? path ?? "";
   const enabled = Boolean(path && assistantId && onOpen);
+  const [pollDeadline] = useState(() => Date.now() + RESOLVE_POLL_WINDOW_MS);
 
   const { data } = useQuery({
     ...workspaceTreeGetOptions({
@@ -76,6 +91,20 @@ export function WorkspacePathLink({
     // exist; retrying a 404 three times per span would turn a speculative
     // match into real traffic.
     retry: false,
+    // Evaluated against the query's own cached data (rather than `exists`
+    // below) so the timer reads the latest listing without a render in
+    // between. It clears itself once the file resolves or the window lapses;
+    // observers sharing a directory share one timer.
+    refetchInterval: (query) => {
+      if (Date.now() >= pollDeadline) {
+        return false;
+      }
+      const resolved =
+        query.state.data?.entries.some(
+          (entry) => entry.type === "file" && entry.path === path,
+        ) ?? false;
+      return resolved ? false : RESOLVE_POLL_MS;
+    },
   });
 
   const exists = useMemo(

--- a/clients/web/src/domains/chat/components/workspace-path-link.tsx
+++ b/clients/web/src/domains/chat/components/workspace-path-link.tsx
@@ -30,7 +30,8 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 
 import { MARKDOWN_INLINE_CODE_CLASS } from "@vellumai/design-library";
-import { workspaceTreeGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { workspaceTreeQueryOptions } from "@/lib/workspace-tree-query";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import {
   toVellumWorkspaceHref,
   workspaceBasenameOf,
@@ -77,13 +78,18 @@ export function WorkspacePathLink({
   onOpen,
 }: WorkspacePathLinkProps) {
   const label = raw ?? path ?? "";
-  const enabled = Boolean(path && assistantId && onOpen);
+  // Platform-hosted requests carry a `Vellum-Organization-Id` header sourced
+  // from the org store, which hydrates after auth. Firing before then is
+  // rejected, and `retry: false` would leave the path plain until something
+  // unrelated refetched it.
+  const isOrgReady = useIsOrgReady();
+  const enabled = Boolean(path && assistantId && onOpen && isOrgReady);
   const [pollDeadline] = useState(() => Date.now() + RESOLVE_POLL_WINDOW_MS);
 
   const { data } = useQuery({
-    ...workspaceTreeGetOptions({
-      path: { assistant_id: assistantId ?? "" },
-      query: { path: path ? workspaceDirOf(path) : "" },
+    ...workspaceTreeQueryOptions({
+      assistantId: assistantId ?? "",
+      path: path ? workspaceDirOf(path) : "",
     }),
     enabled,
     staleTime: LISTING_STALE_MS,

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -544,6 +544,7 @@ export function TranscriptMessageBody({
                   assistantId={assistantId}
                   streamWordFade={streamWordFade}
                   redactedCredentialChips={!isUser && supportsRedactedCredentialChips}
+                  workspacePathLinks={!isUser}
                 />
               </div>
             );
@@ -561,6 +562,7 @@ export function TranscriptMessageBody({
           assistantId={assistantId}
           streamWordFade={streamWordFade}
           redactedCredentialChips={!isUser && supportsRedactedCredentialChips}
+          workspacePathLinks={!isUser}
         />
       </div>
     );

--- a/clients/web/src/domains/chat/utils/rehype-workspace-path.test.ts
+++ b/clients/web/src/domains/chat/utils/rehype-workspace-path.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import { rehypeWorkspacePath } from "@/domains/chat/utils/rehype-workspace-path";
+import { WORKSPACE_PATH_TAG } from "@/domains/chat/utils/workspace-path-links";
+
+interface TestElement {
+  type: "element";
+  tagName: string;
+  properties?: Record<string, unknown>;
+  children: TestNode[];
+}
+type TestNode = TestElement | { type: "text"; value: string };
+
+function code(value: string): TestElement {
+  return {
+    type: "element",
+    tagName: "code",
+    children: [{ type: "text", value }],
+  };
+}
+
+function tree(...children: TestNode[]): TestElement {
+  return { type: "element", tagName: "root", children };
+}
+
+function run(root: TestElement): TestElement {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rehypeWorkspacePath()(root as any);
+  return root;
+}
+
+describe("rehypeWorkspacePath", () => {
+  test("upgrades an inline code span holding a workspace path", () => {
+    const span = code("/workspace/drafts/notes.md");
+    run(tree({ type: "element", tagName: "p", children: [span] }));
+
+    expect(span.tagName).toBe(WORKSPACE_PATH_TAG);
+    expect(span.properties).toEqual({
+      path: "drafts/notes.md",
+      raw: "/workspace/drafts/notes.md",
+    });
+    // The label comes from `raw`; leftover children would double-render it.
+    expect(span.children).toEqual([]);
+  });
+
+  test("leaves non-path code spans alone", () => {
+    const span = code("bun test");
+    run(tree({ type: "element", tagName: "p", children: [span] }));
+
+    expect(span.tagName).toBe("code");
+    expect(span.properties).toBeUndefined();
+  });
+
+  test("skips fenced code blocks", () => {
+    // Fenced blocks arrive as <pre><code>; a path quoted in a shell transcript
+    // is content being shown, not a file to click.
+    const span = code("/workspace/drafts/notes.md");
+    run(
+      tree({
+        type: "element",
+        tagName: "pre",
+        children: [span],
+      }),
+    );
+
+    expect(span.tagName).toBe("code");
+  });
+
+  test("skips code inside a link", () => {
+    // The resolved element is a button, which is invalid inside an anchor.
+    const span = code("/workspace/drafts/notes.md");
+    run(
+      tree({
+        type: "element",
+        tagName: "a",
+        properties: { href: "https://example.com" },
+        children: [span],
+      }),
+    );
+
+    expect(span.tagName).toBe("code");
+  });
+
+  test("descends into nested containers", () => {
+    const span = code("/workspace/drafts/notes.md");
+    run(
+      tree({
+        type: "element",
+        tagName: "ul",
+        children: [
+          {
+            type: "element",
+            tagName: "li",
+            children: [{ type: "element", tagName: "p", children: [span] }],
+          },
+        ],
+      }),
+    );
+
+    expect(span.tagName).toBe(WORKSPACE_PATH_TAG);
+  });
+
+  test("leaves structured (multi-child) code spans alone", () => {
+    const span: TestElement = {
+      type: "element",
+      tagName: "code",
+      children: [
+        { type: "text", value: "/workspace/" },
+        { type: "element", tagName: "em", children: [] },
+        { type: "text", value: "drafts/notes.md" },
+      ],
+    };
+    run(tree({ type: "element", tagName: "p", children: [span] }));
+
+    expect(span.tagName).toBe("code");
+  });
+
+  test("upgrades every qualifying span in a message", () => {
+    const first = code("/workspace/drafts/v0.10.11-notes.md");
+    const second = code("/workspace/drafts/v0.10.12-notes.md");
+    run(
+      tree({
+        type: "element",
+        tagName: "p",
+        children: [first, { type: "text", value: " and " }, second],
+      }),
+    );
+
+    expect(first.tagName).toBe(WORKSPACE_PATH_TAG);
+    expect(second.tagName).toBe(WORKSPACE_PATH_TAG);
+  });
+});

--- a/clients/web/src/domains/chat/utils/rehype-workspace-path.ts
+++ b/clients/web/src/domains/chat/utils/rehype-workspace-path.ts
@@ -1,0 +1,90 @@
+/**
+ * Rehype plugin that marks inline code spans holding a workspace file path so
+ * they can resolve into clickable file links.
+ *
+ * The plugin only *proposes*: it rewrites a qualifying `<code>` element to a
+ * `<workspace-path>` element carrying the normalized path, and
+ * `ChatMarkdownMessage` maps that tag to `WorkspacePathLink` via the design
+ * library's `extraComponents` seam. The component checks the file's existence
+ * before rendering any affordance, so an over-eager match here degrades to
+ * plain inline code rather than a dead link.
+ *
+ * Only *inline* code is considered. Fenced blocks arrive as `<pre><code>`, and
+ * a path inside a shell transcript or code sample is content being quoted, not
+ * a file the user is meant to click — so the walk never descends into `<pre>`.
+ * `<a>` is skipped for the same reason as `rehype-redacted-credential`: the
+ * resolved link renders a button, which is invalid nested inside an anchor and
+ * would double-fire the surrounding navigation.
+ */
+
+import {
+  toWorkspaceRelativePath,
+  WORKSPACE_PATH_TAG,
+} from "@/domains/chat/utils/workspace-path-links";
+
+type HastText = { type: "text"; value: string };
+type HastElement = {
+  type: "element";
+  tagName: string;
+  properties?: Record<string, unknown>;
+  children: HastNode[];
+};
+type HastNode = (HastText | HastElement | { type: string }) & {
+  children?: HastNode[];
+};
+
+const SKIPPED_TAGS = new Set(["pre", "a", "style", "script"]);
+
+function isElement(node: HastNode): node is HastElement {
+  return node.type === "element";
+}
+
+/**
+ * The text of an inline code span, or `undefined` when it isn't a single plain
+ * text run (syntax-highlighted or otherwise structured content is left alone).
+ */
+function singleTextChild(node: HastElement): string | undefined {
+  if (node.children.length !== 1) {
+    return undefined;
+  }
+  const only = node.children[0];
+  return only.type === "text" ? (only as HastText).value : undefined;
+}
+
+function walk(node: HastNode): void {
+  const children = node.children;
+  if (!children) {
+    return;
+  }
+  for (const child of children) {
+    if (!isElement(child)) {
+      continue;
+    }
+    if (SKIPPED_TAGS.has(child.tagName)) {
+      continue;
+    }
+    if (child.tagName === "code") {
+      const text = singleTextChild(child);
+      const path = text === undefined ? null : toWorkspaceRelativePath(text);
+      if (path !== null && text !== undefined) {
+        // Rewritten in place so the element keeps its position among its
+        // siblings. `raw` preserves the author's spelling (usually an
+        // absolute `/workspace/...` path) — the link shows the text the
+        // assistant actually wrote, while `path` carries the workspace-relative
+        // form the daemon routes expect.
+        child.tagName = WORKSPACE_PATH_TAG;
+        child.properties = { ...child.properties, path, raw: text };
+        child.children = [];
+      }
+      continue;
+    }
+    walk(child);
+  }
+}
+
+/** Rehype plugin factory (no options). */
+export function rehypeWorkspacePath() {
+  return (tree: HastNode): void => {
+    walk(tree);
+  };
+}

--- a/clients/web/src/domains/chat/utils/workspace-path-links.test.ts
+++ b/clients/web/src/domains/chat/utils/workspace-path-links.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  toVellumWorkspaceHref,
+  toWorkspaceRelativePath,
+  workspaceBasenameOf,
+  workspaceDirOf,
+} from "@/domains/chat/utils/workspace-path-links";
+
+describe("toWorkspaceRelativePath — accepted shapes", () => {
+  test("absolute path under the hosted /workspace mount", () => {
+    expect(
+      toWorkspaceRelativePath("/workspace/drafts/v0.10.12-release-notes.md"),
+    ).toBe("drafts/v0.10.12-release-notes.md");
+  });
+
+  test("absolute path under a desktop ~/.vellum/workspace mount", () => {
+    // The mount point is deployment-specific, so recognition anchors on the
+    // last `/workspace/` segment rather than a fixed prefix.
+    expect(
+      toWorkspaceRelativePath(
+        "/Users/marina/.vellum/workspace/drafts/notes.md",
+      ),
+    ).toBe("drafts/notes.md");
+  });
+
+  test("absolute path to a workspace root file", () => {
+    expect(toWorkspaceRelativePath("/workspace/SOUL.md")).toBe("SOUL.md");
+  });
+
+  test("relative path with a directory component", () => {
+    expect(toWorkspaceRelativePath("drafts/notes.md")).toBe("drafts/notes.md");
+  });
+
+  test("leading ./ is normalized away", () => {
+    expect(toWorkspaceRelativePath("./drafts/notes.md")).toBe(
+      "drafts/notes.md",
+    );
+  });
+
+  test("surrounding whitespace is trimmed", () => {
+    expect(toWorkspaceRelativePath("  /workspace/drafts/notes.md  ")).toBe(
+      "drafts/notes.md",
+    );
+  });
+
+  test("extensionless files are accepted (existence decides)", () => {
+    expect(toWorkspaceRelativePath("/workspace/scripts/Makefile")).toBe(
+      "scripts/Makefile",
+    );
+  });
+});
+
+describe("toWorkspaceRelativePath — rejected shapes", () => {
+  test("bare relative filename is too ambiguous to linkify", () => {
+    // Indistinguishable from an ordinary backticked word.
+    expect(toWorkspaceRelativePath("notes.md")).toBeNull();
+  });
+
+  test("absolute host path outside any workspace root", () => {
+    expect(toWorkspaceRelativePath("/etc/passwd")).toBeNull();
+    expect(
+      toWorkspaceRelativePath("/Users/marina/Desktop/notes.md"),
+    ).toBeNull();
+  });
+
+  test("home-relative path", () => {
+    expect(toWorkspaceRelativePath("~/notes/todo.md")).toBeNull();
+  });
+
+  test("shell command containing a workspace path", () => {
+    expect(toWorkspaceRelativePath("rm -rf /workspace/drafts")).toBeNull();
+    expect(
+      toWorkspaceRelativePath("cat /workspace/drafts/notes.md | head"),
+    ).toBeNull();
+  });
+
+  test("glob pattern", () => {
+    expect(toWorkspaceRelativePath("/workspace/skills/*/SKILL.md")).toBeNull();
+    expect(toWorkspaceRelativePath("/workspace/logs/app.{1,2}.log")).toBeNull();
+  });
+
+  test("file:line reference", () => {
+    expect(toWorkspaceRelativePath("/workspace/src/index.ts:42")).toBeNull();
+  });
+
+  test("URL", () => {
+    expect(toWorkspaceRelativePath("https://example.com/a/b.md")).toBeNull();
+  });
+
+  test("directory shape (trailing slash)", () => {
+    expect(toWorkspaceRelativePath("/workspace/drafts/")).toBeNull();
+  });
+
+  test("hidden segments — the tree listing omits them by default", () => {
+    expect(
+      toWorkspaceRelativePath("/workspace/.claude/settings.json"),
+    ).toBeNull();
+    expect(toWorkspaceRelativePath("drafts/.env")).toBeNull();
+  });
+
+  test("traversal segments", () => {
+    expect(toWorkspaceRelativePath("/workspace/../etc/passwd")).toBeNull();
+    expect(toWorkspaceRelativePath("drafts/../../etc/passwd")).toBeNull();
+  });
+
+  test("double slashes", () => {
+    expect(toWorkspaceRelativePath("/workspace/drafts//notes.md")).toBeNull();
+  });
+
+  test("empty and oversized input", () => {
+    expect(toWorkspaceRelativePath("")).toBeNull();
+    expect(toWorkspaceRelativePath("   ")).toBeNull();
+    expect(
+      toWorkspaceRelativePath(`/workspace/${"a".repeat(600)}.md`),
+    ).toBeNull();
+  });
+});
+
+describe("path helpers", () => {
+  test("workspaceDirOf", () => {
+    expect(workspaceDirOf("drafts/notes.md")).toBe("drafts");
+    expect(workspaceDirOf("a/b/c/notes.md")).toBe("a/b/c");
+    expect(workspaceDirOf("SOUL.md")).toBe("");
+  });
+
+  test("workspaceBasenameOf", () => {
+    expect(workspaceBasenameOf("drafts/notes.md")).toBe("notes.md");
+    expect(workspaceBasenameOf("SOUL.md")).toBe("SOUL.md");
+  });
+
+  test("toVellumWorkspaceHref encodes per segment so slashes survive", () => {
+    expect(toVellumWorkspaceHref("drafts/notes.md")).toBe(
+      "vellum://workspace/drafts/notes.md",
+    );
+    // Non-ASCII names round-trip through the click handler's decodeURIComponent.
+    expect(toVellumWorkspaceHref("drafts/notés.md")).toBe(
+      "vellum://workspace/drafts/not%C3%A9s.md",
+    );
+  });
+});

--- a/clients/web/src/domains/chat/utils/workspace-path-links.test.ts
+++ b/clients/web/src/domains/chat/utils/workspace-path-links.test.ts
@@ -18,9 +18,7 @@ describe("toWorkspaceRelativePath — accepted shapes", () => {
     // The mount point is deployment-specific, so recognition anchors on the
     // last `/workspace/` segment rather than a fixed prefix.
     expect(
-      toWorkspaceRelativePath(
-        "/Users/marina/.vellum/workspace/drafts/notes.md",
-      ),
+      toWorkspaceRelativePath("/Users/alice/.vellum/workspace/drafts/notes.md"),
     ).toBe("drafts/notes.md");
   });
 
@@ -59,9 +57,7 @@ describe("toWorkspaceRelativePath — rejected shapes", () => {
 
   test("absolute host path outside any workspace root", () => {
     expect(toWorkspaceRelativePath("/etc/passwd")).toBeNull();
-    expect(
-      toWorkspaceRelativePath("/Users/marina/Desktop/notes.md"),
-    ).toBeNull();
+    expect(toWorkspaceRelativePath("/Users/alice/Desktop/notes.md")).toBeNull();
   });
 
   test("home-relative path", () => {

--- a/clients/web/src/domains/chat/utils/workspace-path-links.ts
+++ b/clients/web/src/domains/chat/utils/workspace-path-links.ts
@@ -41,9 +41,9 @@ const MAX_PATH_LENGTH = 512;
  * assembled for a shell.
  *
  * This is intentionally over-broad: a filename containing one of these
- * characters simply renders as plain code, which is the status quo. The cost
- * of a miss is nothing; the cost of a false positive is a confusing
- * affordance on text that was never a file reference.
+ * characters simply renders as plain code. The cost of a miss is nothing; the
+ * cost of a false positive is a confusing affordance on text that was never a
+ * file reference.
  */
 const NON_PATH_CHARS = /[\s`"'<>|&;:,=$*?[\]{}()\\!#]/;
 

--- a/clients/web/src/domains/chat/utils/workspace-path-links.ts
+++ b/clients/web/src/domains/chat/utils/workspace-path-links.ts
@@ -1,0 +1,119 @@
+/**
+ * Recognize workspace file paths written as bare inline code in chat.
+ *
+ * The assistant is told to link workspace files with the `vellum://` scheme
+ * (system prompt section `04-attachment`), but in practice it frequently
+ * narrates a path it just read or wrote — "the draft is at
+ * `/workspace/drafts/notes.md`" — as an ordinary code span. Nothing in the
+ * markdown pipeline linkifies bare paths (remark-gfm only autolinks
+ * scheme-bearing URLs), so those references render inert and the user has to
+ * go find the file by hand.
+ *
+ * This module holds the pure half of the fix: deciding whether a code span is
+ * a workspace path at all, and normalizing it to the workspace-relative form
+ * the daemon's workspace routes speak. Recognition is deliberately
+ * conservative — it only proposes a *candidate*. Whether the file actually
+ * exists is settled by a directory listing at render time
+ * (`WorkspacePathLink`), so a wrong guess here costs one cache-shared request
+ * and renders as plain code, never as a dead link.
+ */
+
+/** Custom tag emitted by `rehypeWorkspacePath` for a candidate path span. */
+export const WORKSPACE_PATH_TAG = "workspace-path";
+
+/**
+ * Absolute paths are only recognized below a `/workspace/` root. The mount
+ * point differs by deployment — hosted assistants run with the workspace at
+ * `/workspace`, desktop installs use `~/.vellum/workspace` — so we anchor on
+ * the last `/workspace/` segment instead of a fixed prefix. An absolute path
+ * with no such segment is a host path and is left alone.
+ */
+const WORKSPACE_ROOT_MARKER = "/workspace/";
+
+/** Guards against pathological spans; real workspace paths are far shorter. */
+const MAX_PATH_LENGTH = 512;
+
+/**
+ * Characters that mean the span is a command, glob, or expression rather than
+ * a plain path. Whitespace excludes whole shell invocations (`rm -rf /tmp/x`),
+ * `*?[]{}` excludes globs, `:` excludes `file.ts:42` line references and
+ * `https://` URLs, and the quote/redirect/substitution set excludes anything
+ * assembled for a shell.
+ *
+ * This is intentionally over-broad: a filename containing one of these
+ * characters simply renders as plain code, which is the status quo. The cost
+ * of a miss is nothing; the cost of a false positive is a confusing
+ * affordance on text that was never a file reference.
+ */
+const NON_PATH_CHARS = /[\s`"'<>|&;:,=$*?[\]{}()\\!#]/;
+
+/**
+ * Normalize a code-span's text to a workspace-relative path, or return `null`
+ * when the text isn't a plausible workspace file reference.
+ *
+ * Rejects, in addition to the character rules above:
+ * - directory-shaped text (trailing `/`) — the modal's actions are file actions
+ * - home-relative (`~/...`) and non-workspace absolute paths
+ * - hidden segments (`.claude/settings.json`) — the tree listing omits them by
+ *   default, so they could never resolve
+ * - `.`/`..` segments — the daemon rejects traversal outright
+ * - bare filenames with no directory component (`notes.md`) when written
+ *   relatively, which are indistinguishable from ordinary backticked words.
+ *   An absolute `/workspace/notes.md` is unambiguous and is accepted.
+ */
+export function toWorkspaceRelativePath(raw: string): string | null {
+  const text = raw.trim();
+  if (text.length === 0 || text.length > MAX_PATH_LENGTH) {
+    return null;
+  }
+  if (NON_PATH_CHARS.test(text) || text.endsWith("/") || text.startsWith("~")) {
+    return null;
+  }
+
+  let relative: string;
+  if (text.startsWith("/")) {
+    const markerIndex = text.lastIndexOf(WORKSPACE_ROOT_MARKER);
+    if (markerIndex === -1) {
+      return null;
+    }
+    relative = text.slice(markerIndex + WORKSPACE_ROOT_MARKER.length);
+  } else {
+    relative = text.startsWith("./") ? text.slice(2) : text;
+    if (!relative.includes("/")) {
+      return null;
+    }
+  }
+
+  if (relative.length === 0) {
+    return null;
+  }
+  const segments = relative.split("/");
+  if (
+    segments.some((segment) => segment.length === 0 || segment.startsWith("."))
+  ) {
+    return null;
+  }
+  return relative;
+}
+
+/** Parent directory of a workspace-relative path (`""` for a root-level file). */
+export function workspaceDirOf(relativePath: string): string {
+  const index = relativePath.lastIndexOf("/");
+  return index === -1 ? "" : relativePath.slice(0, index);
+}
+
+/** Final path segment of a workspace-relative path. */
+export function workspaceBasenameOf(relativePath: string): string {
+  const index = relativePath.lastIndexOf("/");
+  return index === -1 ? relativePath : relativePath.slice(index + 1);
+}
+
+/**
+ * Build the `vellum://workspace/` href for a confirmed path. Segments are
+ * percent-encoded individually so the click handler's `decodeURIComponent`
+ * round-trips back to the stored path.
+ */
+export function toVellumWorkspaceHref(relativePath: string): string {
+  const encoded = relativePath.split("/").map(encodeURIComponent).join("/");
+  return `vellum://workspace/${encoded}`;
+}

--- a/clients/web/src/domains/chat/utils/workspace-path-links.ts
+++ b/clients/web/src/domains/chat/utils/workspace-path-links.ts
@@ -1,19 +1,10 @@
 /**
- * Recognize workspace file paths written as bare inline code in chat.
+ * Recognize workspace file paths written as bare inline code in chat — "the
+ * draft is at `/workspace/drafts/notes.md`" — and normalize them to the
+ * workspace-relative form the daemon's workspace routes speak.
  *
- * The assistant is told to link workspace files with the `vellum://` scheme
- * (system prompt section `04-attachment`), but in practice it frequently
- * narrates a path it just read or wrote — "the draft is at
- * `/workspace/drafts/notes.md`" — as an ordinary code span. Nothing in the
- * markdown pipeline linkifies bare paths (remark-gfm only autolinks
- * scheme-bearing URLs), so those references render inert and the user has to
- * go find the file by hand.
- *
- * This module holds the pure half of the fix: deciding whether a code span is
- * a workspace path at all, and normalizing it to the workspace-relative form
- * the daemon's workspace routes speak. Recognition is deliberately
- * conservative — it only proposes a *candidate*. Whether the file actually
- * exists is settled by a directory listing at render time
+ * Recognition is conservative and produces only a *candidate*. Whether the
+ * file exists is settled by a directory listing at render time
  * (`WorkspacePathLink`), so a wrong guess here costs one cache-shared request
  * and renders as plain code, never as a dead link.
  */

--- a/clients/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/clients/web/src/domains/workspace/components/workspace-tree.tsx
@@ -8,7 +8,6 @@
  */
 
 import {
-    queryOptions,
     useMutation,
     useQuery,
     useQueryClient,
@@ -54,6 +53,10 @@ import {
     workspaceWritePost,
 } from "@/generated/daemon/sdk.gen";
 import type { WorkspaceTreeGetResponse } from "@/generated/daemon/types.gen";
+import {
+  WORKSPACE_TREE_QUERY_KEY,
+  workspaceTreeQueryOptions,
+} from "@/lib/workspace-tree-query";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BottomSheet } from "@vellumai/design-library/components/bottom-sheet";
 import { Button } from "@vellumai/design-library/components/button";
@@ -82,31 +85,6 @@ type TreeDialog =
   | { type: "create"; kind: "file" | "folder"; parentPath: string }
   | { type: "rename"; path: string; name: string };
 
-function workspaceTreeRetrieveOptions(opts: {
-  path: { assistant_id: string };
-  query?: { path?: string; showHidden?: boolean; includeDirSizes?: boolean };
-}) {
-  return queryOptions<WorkspaceTreeGetResponse>({
-    queryFn: async () => {
-      const query: Record<string, string> = {};
-      if (opts.query?.path) query.path = opts.query.path;
-      if (opts.query?.showHidden) query.showHidden = "true";
-      if (opts.query?.includeDirSizes) query.includeDirSizes = "true";
-      const { data, error } = await workspaceTreeGet({
-        path: opts.path,
-        query,
-      });
-      if (error) {
-        throw error;
-      }
-      if (!data) {
-        throw new Error("Failed to load workspace tree");
-      }
-      return data;
-    },
-    queryKey: ["assistantsWorkspaceTreeRetrieve", opts],
-  });
-}
 
 /**
  * The daemon's write and rename endpoints overwrite existing entries
@@ -221,13 +199,11 @@ function TreeNode({
     isDirectory && (isExpanded || searchLower.length > 0);
 
   const { data } = useQuery({
-    ...workspaceTreeRetrieveOptions({
-      path: { assistant_id: assistantId },
-      query: {
-        path: entryPath,
-        showHidden,
-        includeDirSizes: sortMode === "size",
-      },
+    ...workspaceTreeQueryOptions({
+      assistantId,
+      path: entryPath,
+      showHidden,
+      includeDirSizes: sortMode === "size",
     }),
     enabled: isDirectory && effectivelyExpanded,
   });
@@ -533,9 +509,10 @@ export function WorkspaceTree({
   }, []);
 
   const { data, isLoading } = useQuery(
-    workspaceTreeRetrieveOptions({
-      path: { assistant_id: assistantId },
-      query: { showHidden, includeDirSizes: sortMode === "size" },
+    workspaceTreeQueryOptions({
+      assistantId,
+      showHidden,
+      includeDirSizes: sortMode === "size",
     }),
   );
 
@@ -549,7 +526,7 @@ export function WorkspaceTree({
   // contents from the viewer.
   const invalidateWorkspace = useCallback(() => {
     for (const key of [
-      "assistantsWorkspaceTreeRetrieve",
+      WORKSPACE_TREE_QUERY_KEY,
       "assistantsWorkspaceFileRetrieve",
       "assistantsWorkspaceFileContentRetrieve",
     ]) {

--- a/clients/web/src/lib/workspace-tree-query.test.ts
+++ b/clients/web/src/lib/workspace-tree-query.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  WORKSPACE_TREE_QUERY_KEY,
+  workspaceTreeQueryOptions,
+} from "@/lib/workspace-tree-query";
+
+const ASSISTANT_ID = "assistant-1";
+
+describe("workspaceTreeQueryOptions", () => {
+  test("keys are prefixed so mutation invalidation reaches every reader", () => {
+    const { queryKey } = workspaceTreeQueryOptions({
+      assistantId: ASSISTANT_ID,
+      path: "drafts",
+    });
+
+    expect(queryKey[0]).toBe(WORKSPACE_TREE_QUERY_KEY);
+  });
+
+  test("omitted flags and explicit falsy flags share one cache entry", () => {
+    // The workspace browser passes its flags explicitly; chat's path links
+    // omit them. Both describe the same request, so they must not split into
+    // separate entries.
+    const omitted = workspaceTreeQueryOptions({
+      assistantId: ASSISTANT_ID,
+      path: "drafts",
+    }).queryKey;
+    const explicit = workspaceTreeQueryOptions({
+      assistantId: ASSISTANT_ID,
+      path: "drafts",
+      showHidden: false,
+      includeDirSizes: false,
+    }).queryKey;
+
+    expect(omitted).toEqual(explicit);
+  });
+
+  test("an omitted path is the workspace root", () => {
+    const omitted = workspaceTreeQueryOptions({
+      assistantId: ASSISTANT_ID,
+    }).queryKey;
+    const empty = workspaceTreeQueryOptions({
+      assistantId: ASSISTANT_ID,
+      path: "",
+    }).queryKey;
+
+    expect(omitted).toEqual(empty);
+  });
+
+  test("directory, assistant, and flags each scope the entry", () => {
+    const base = workspaceTreeQueryOptions({
+      assistantId: ASSISTANT_ID,
+      path: "drafts",
+    }).queryKey;
+
+    expect(base).not.toEqual(
+      workspaceTreeQueryOptions({ assistantId: ASSISTANT_ID, path: "logs" })
+        .queryKey,
+    );
+    expect(base).not.toEqual(
+      workspaceTreeQueryOptions({ assistantId: "assistant-2", path: "drafts" })
+        .queryKey,
+    );
+    expect(base).not.toEqual(
+      workspaceTreeQueryOptions({
+        assistantId: ASSISTANT_ID,
+        path: "drafts",
+        showHidden: true,
+      }).queryKey,
+    );
+  });
+});

--- a/clients/web/src/lib/workspace-tree-query.ts
+++ b/clients/web/src/lib/workspace-tree-query.ts
@@ -1,0 +1,72 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { workspaceTreeGet } from "@/generated/daemon/sdk.gen";
+import type { WorkspaceTreeGetResponse } from "@/generated/daemon/types.gen";
+
+/**
+ * Cache-key prefix for every workspace directory listing. Mutations that
+ * change the tree invalidate this prefix, which reaches all readers.
+ */
+export const WORKSPACE_TREE_QUERY_KEY = "assistantsWorkspaceTreeRetrieve";
+
+export interface WorkspaceTreeQueryParams {
+  assistantId: string;
+  /** Workspace-relative directory; empty string lists the workspace root. */
+  path?: string;
+  showHidden?: boolean;
+  includeDirSizes?: boolean;
+}
+
+/**
+ * Shared React Query options for a workspace directory listing.
+ *
+ * The workspace browser and chat's file-path links both read directory
+ * listings. Routing them through one factory gives them one cache entry per
+ * directory when their parameters agree, and — because the key prefix is
+ * fixed here — puts every reader behind the browser's post-mutation
+ * invalidation, so a file created, renamed, or deleted in the browser is
+ * reflected everywhere.
+ *
+ * Parameters are normalized before they reach the key: callers that omit
+ * `showHidden`/`includeDirSizes` and callers that pass their falsy defaults
+ * describe the same request and must not land on separate cache entries.
+ *
+ * Depends only on the generated SDK, so it lives in `lib/` (no domain import).
+ */
+export function workspaceTreeQueryOptions({
+  assistantId,
+  path = "",
+  showHidden = false,
+  includeDirSizes = false,
+}: WorkspaceTreeQueryParams) {
+  return queryOptions<WorkspaceTreeGetResponse>({
+    queryKey: [
+      WORKSPACE_TREE_QUERY_KEY,
+      assistantId,
+      { path, showHidden, includeDirSizes },
+    ],
+    queryFn: async () => {
+      const query: Record<string, string> = {};
+      if (path) {
+        query.path = path;
+      }
+      if (showHidden) {
+        query.showHidden = "true";
+      }
+      if (includeDirSizes) {
+        query.includeDirSizes = "true";
+      }
+      const { data, error } = await workspaceTreeGet({
+        path: { assistant_id: assistantId },
+        query,
+      });
+      if (error) {
+        throw error;
+      }
+      if (!data) {
+        throw new Error("Failed to load workspace tree");
+      }
+      return data;
+    },
+  });
+}

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -35,6 +35,18 @@ export const quoteBlockquoteAccentClassName =
   "w-0.5 shrink-0 self-stretch rounded-full bg-[var(--content-tertiary)]";
 export const quoteBlockquoteContentClassName = "min-w-0 flex-1 [&_p]:mb-0";
 
+/**
+ * Inline (non-fenced) code chip styling. Exported so consumers that replace a
+ * code span with their own element via `extraComponents` — e.g. a workspace
+ * path that resolves into a file link — can render identically to the code
+ * span they stand in for, instead of forking the class list.
+ *
+ * Small *prose* token: its 18px leading keeps the chip's padded background
+ * inside its own line box in tight-leading contexts (blockquotes, table cells).
+ */
+export const MARKDOWN_INLINE_CODE_CLASS =
+  "rounded bg-stone-100 px-1 py-0.5 font-mono text-body-small-lighter dark:bg-moss-800";
+
 function CopyButton({
   visible,
   onClick,
@@ -367,14 +379,7 @@ function buildMarkdownComponents(
           </code>
         );
       }
-      return (
-        // Small prose token: its 18px leading keeps the chip's padded
-        // background inside its own line box in tight-leading contexts
-        // (blockquotes, table cells).
-        <code className="rounded bg-stone-100 px-1 py-0.5 font-mono text-body-small-lighter dark:bg-moss-800">
-          {children}
-        </code>
-      );
+      return <code className={MARKDOWN_INLINE_CODE_CLASS}>{children}</code>;
     },
     pre: ({ children }) => <CodeBlockWrapper>{children}</CodeBlockWrapper>,
     // No styling change vs. the browser default `<em>`, except emoji inside the

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -176,6 +176,7 @@ export {
   type MarqueeTextProps,
 } from "./components/panel-item/marquee-text";
 export {
+  MARKDOWN_INLINE_CODE_CLASS,
   MarkdownMessage,
   quoteBlockquoteAccentClassName,
   quoteBlockquoteClassName,


### PR DESCRIPTION
## Why

The assistant is told to link workspace files with the `vellum://` scheme (system prompt section `04-attachment`), but it routinely narrates a path it just read or wrote as an ordinary code span:

> **0.10.11** — draft already exists at `/workspace/drafts/v0.10.11-release-notes-fun.md`, looks solid.

Nothing in the markdown pipeline linkifies bare paths — remark-gfm only autolinks scheme-bearing URLs, and code spans are excluded from text rewrites by design — so those references render inert and the user goes and finds the file by hand.

This is not a rendering bug. The pipeline was verified end to end on a message like the one above: `cleanAssistantContent` is non-destructive for app messages (the link-stripping variant only runs for Slack/Telegram), section `04-attachment` has no `enabled` gate so it is in every main-conversation prompt, and `vellum://workspace/` links already render into the file-action modal from #39030. The model simply wrote code spans with the guidance in front of it.

The prompt is worth tightening separately — the rule lives under a heading that reads as "Sending Files to the User", its example is relative (`vellum://workspace/scratch/report.pdf`) while every path in tool output is absolute, and nothing forbids bare paths in prose. But a prompt fix raises a hit rate; it can't make this deterministic. This PR makes the affordance deterministic on the client, which is where it can be.

## What

- `rehypeWorkspacePath` marks inline code spans that parse as workspace paths, emitting a `<workspace-path>` element through the design library's existing `extraComponents` seam (same pattern as `rehype-redacted-credential`).
- `WorkspacePathLink` resolves the path against a `workspace/tree` listing of its parent directory and renders a link **only when a matching file exists**. Confirmed paths open the existing file-action modal (Go to file / Download) via the same handler as explicit `vellum://` links.
- Everything unresolved renders exactly as before: plain inline code.

## Why existence gating, not optimistic linking

A path-shaped code span is not evidence of a file. The assistant writes paths it is *about* to create ("I'll save it to `…`"), paths it has since deleted, and hypothetical examples. Linking optimistically would produce a dead affordance in precisely those cases — and the "I'll write it to X" shape is dead ~100% of the time at first render. Because the check lives in the query cache, a file that appears a moment later lights its link up on the next refetch.

`workspace/tree` rather than `workspace/file`: the per-file route returns the file's full inline text, which is a lot of payload to decide whether to underline something. Listings are also shared — N paths in one directory, the common case in a "here's what I wrote" message, cost one request, deduped by TanStack Query and shared with anyone browsing that directory.

## False-positive surface

Recognition is whole-span only, so shell commands (`rm -rf /workspace/x`) never match — the span is a command, not a path. Also rejected: globs, `file.ts:42` references, URLs, `~/`-relative and non-workspace absolute paths, hidden segments, traversal segments, trailing-slash directory shapes, and bare relative filenames (`notes.md`) that are indistinguishable from ordinary backticked words. Fenced code blocks are skipped entirely — a path in a shell transcript is content being quoted, not a file to click.

Absolute paths are anchored on the last `/workspace/` segment rather than a fixed prefix, since the mount point differs by deployment (`/workspace` hosted, `~/.vellum/workspace` desktop).

Enabled for assistant-authored content only. A path the user typed is their own prose and renders as written.

## Notes for review

- **Design library**: no primitive exists for an inline text affordance inside markdown, so the resolved link is a custom `<button>`. It reuses the inline-code chip styling, which this PR extracts as `MARKDOWN_INLINE_CODE_CLASS` rather than forking the class list — that constant is the only design-library behavior change.
- **No daemon changes and no version gate**: `workspace/tree` is long-standing, and a failed listing degrades to plain code, so this works against any daemon version.

## Testing

- `workspace-path-links.test.ts` — 22 cases over the accept/reject table
- `rehype-workspace-path.test.ts` — 7 cases (inline vs fenced vs anchor, nesting, multi-span)
- `workspace-path-link.test.tsx` — 7 integration cases through `ChatMarkdownMessage`: exists → link, click → `vellum://` href, missing → plain code, directory entry → no link, unresolved → plain code, user content → never upgraded, fenced → untouched

Existing `chat-markdown-message` (11), `transcript-message-body` (49), and design-library `markdown-message` (36) tests pass. `tsc --noEmit` clean in both packages; eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)