### PR TITLE
fix(cli): add Poolside to the provider inference and env-var tables (JARVIS-1352)

### DIFF
--- a/cli/src/lib/provider-secrets.ts
+++ b/cli/src/lib/provider-secrets.ts
@@ -76,6 +76,7 @@ const PROVIDER_LABELS: Record<LlmProviderId, string> = {
   atlascloud: "Atlas Cloud",
   together: "Together AI",
   baseten: "Baseten",
+  poolside: "Poolside",
 };
 
 export function formatProviderName(provider: LlmProviderId): string {
@@ -193,6 +194,9 @@ export function inferProviderFromModel(model: string): string | undefined {
   }
   if (model.startsWith("thinkingmachines/")) {
     return "baseten";
+  }
+  if (model.startsWith("poolside/")) {
+    return "poolside";
   }
   if (model.includes("/")) {
     return "openrouter";

--- a/cli/src/shared/provider-env-vars.ts
+++ b/cli/src/shared/provider-env-vars.ts
@@ -32,6 +32,7 @@ export const LLM_PROVIDER_ENV_VAR_NAMES: Record<string, string> = {
   together: "TOGETHER_API_KEY",
   litellm: "LITELLM_API_KEY",
   baseten: "BASETEN_API_KEY",
+  poolside: "POOLSIDE_API_KEY",
 };
 
 /** Search-provider env var names. Mirrors `SEARCH_PROVIDER_CATALOG` BYOK entries. */


### PR DESCRIPTION
Closes JARVIS-1352.

`main` is currently failing both CLI provider parity tests. #39140 added Poolside to `meta/llm-provider-catalog.json` but not to the CLI's hand-maintained mirrors of it:

- **`provider-inference-parity`** — `poolside/laguna-s-2.1` and `poolside/laguna-xs-2.1` fell through to the generic `model.includes("/")` branch and inferred `openrouter`.
- **`llm-provider-env-var-parity`** — `LLM_PROVIDER_ENV_VAR_NAMES` was missing `POOLSIDE_API_KEY`.

The CLI can't import `assistant/src/`, so these tables are mirrored by hand and the parity tests exist to catch exactly this drift. They worked — they just never ran: `ci-main-cli.yaml` is path-filtered to `cli/**` (plus `packages/local-mode`, `packages/environments`, `package.json`, `bun.lock`, `patches/**`), and #39140 touched only the catalog and assistant/web. The last main CLI run was `ec1a36e79e`, which predates Poolside. `pr-cli.yaml` has the same filter, so the break surfaces on the next PR touching `cli/` — currently #39222.

Verified on a pristine `origin/main` worktree: both tests fail there, `meta/llm-provider-catalog.json` has 5 poolside references while `cli/src/lib/*.ts` has zero.

## Notes

- The new inference branch sits **above** the generic `includes("/")` fallback, which would otherwise claim `poolside/...` first. Poolside is the only catalog provider listing those model IDs, so the test's first-provider-wins expectation resolves to `poolside`.
- Also added the `Poolside` display label, used by `formatProviderName` in the hatch/docker credential prompts.

## Verification

`bun test` in `cli/`: all three parity suites pass (inference, LLM env-var, search env-var). The only remaining failures in a local full run are the 3 `flags.test.ts --assistant routing` cases, which fail identically on unmodified `main` locally — they read the machine's assistant registry and pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)