### PR TITLE
feat(web): add relation-keyed copy for the package-switch confirm modal

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/package-switch-copy.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-copy.test.ts
@@ -27,7 +27,8 @@ describe("packageSwitchCopy", () => {
     expect(packageSwitchCopy("switch", "Ultra", "ultra")).toEqual({
       title: "Switch to Ultra",
       subtitle: PLAN_TIER_COPY.ultra.tagline,
-      priceCaption: "Billed monthly · prorated difference settled today",
+      priceCaption:
+        "Billed monthly · prorated difference charged today or credited next invoice",
       note: "",
       confirmLabel: "Continue",
       destructive: false,
@@ -43,6 +44,15 @@ describe("packageSwitchCopy", () => {
       confirmLabel: "Downgrade to Mighty",
       destructive: true,
     });
+  });
+
+  test("the neutral switch caption keeps the next-invoice credit path", () => {
+    // A Custom sub can be net cheaper, so the caption must not claim the
+    // difference settles today.
+    const { priceCaption } = packageSwitchCopy("switch", "Custom", null);
+    expect(priceCaption).toContain("charged today");
+    expect(priceCaption).toContain("credited next invoice");
+    expect(priceCaption).not.toContain("settled today");
   });
 
   test("only a downgrade is destructive", () => {

--- a/clients/web/src/domains/settings/billing/plans/package-switch-copy.test.ts
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-copy.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the relation-keyed package-switch confirm copy.
+ *
+ * The downgrade variant carries the safeguards: an explicit destructive CTA
+ * label (never a neutral "Continue") and the "machine downsizes now / no
+ * refund" note.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { packageSwitchCopy } from "./package-switch-copy";
+import { PLAN_TIER_COPY } from "./plans-copy";
+
+describe("packageSwitchCopy", () => {
+  test("upgrade", () => {
+    expect(packageSwitchCopy("upgrade", "Super", "super")).toEqual({
+      title: "Upgrade to Super",
+      subtitle: PLAN_TIER_COPY.super.tagline,
+      priceCaption: "Billed monthly · prorated difference charged today",
+      note: "",
+      confirmLabel: "Continue",
+      destructive: false,
+    });
+  });
+
+  test("switch", () => {
+    expect(packageSwitchCopy("switch", "Ultra", "ultra")).toEqual({
+      title: "Switch to Ultra",
+      subtitle: PLAN_TIER_COPY.ultra.tagline,
+      priceCaption: "Billed monthly · prorated difference settled today",
+      note: "",
+      confirmLabel: "Continue",
+      destructive: false,
+    });
+  });
+
+  test("downgrade", () => {
+    expect(packageSwitchCopy("downgrade", "Mighty", "mighty")).toEqual({
+      title: "Downgrade to Mighty",
+      subtitle: PLAN_TIER_COPY.mighty.tagline,
+      priceCaption: "Billed monthly · prorated credit on your next invoice",
+      note: "Your machine downsizes now and your storage stays. No refund.",
+      confirmLabel: "Downgrade to Mighty",
+      destructive: true,
+    });
+  });
+
+  test("only a downgrade is destructive", () => {
+    expect(packageSwitchCopy("downgrade", "Mighty", "mighty").destructive).toBe(
+      true,
+    );
+    expect(packageSwitchCopy("upgrade", "Mighty", "mighty").destructive).toBe(
+      false,
+    );
+    expect(packageSwitchCopy("switch", "Mighty", "mighty").destructive).toBe(
+      false,
+    );
+  });
+
+  test("the downgrade confirm label stays explicit", () => {
+    const { confirmLabel } = packageSwitchCopy("downgrade", "Mighty", "mighty");
+    expect(confirmLabel).toBe("Downgrade to Mighty");
+    expect(confirmLabel).not.toBe("Continue");
+  });
+
+  test("only a downgrade carries the safeguard note", () => {
+    expect(packageSwitchCopy("downgrade", "Mighty", "mighty").note).toContain(
+      "No refund",
+    );
+    expect(packageSwitchCopy("upgrade", "Mighty", "mighty").note).toBe("");
+    expect(packageSwitchCopy("switch", "Mighty", "mighty").note).toBe("");
+  });
+
+  test("subtitle is empty for an unknown or absent tier key", () => {
+    expect(
+      packageSwitchCopy("upgrade", "Enterprise", "enterprise").subtitle,
+    ).toBe("");
+    expect(packageSwitchCopy("switch", "Custom", null).subtitle).toBe("");
+  });
+});

--- a/clients/web/src/domains/settings/billing/plans/package-switch-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-copy.ts
@@ -32,7 +32,10 @@ export interface PackageSwitchCopy {
 // nets a prorated credit against the next invoice — storage stays, no cash
 // refund. The copy must not imply the higher tier is kept until month end.
 const UPGRADE_CAPTION = "Billed monthly · prorated difference charged today";
-const SWITCH_CAPTION = "Billed monthly · prorated difference settled today";
+// A Custom sub's direction is unknown, so the neutral caption must name both
+// outcomes — a net-cheaper switch credits the next invoice, it is not settled today.
+const SWITCH_CAPTION =
+  "Billed monthly · prorated difference charged today or credited next invoice";
 const DOWNGRADE_CAPTION =
   "Billed monthly · prorated credit on your next invoice";
 const DOWNGRADE_NOTE =

--- a/clients/web/src/domains/settings/billing/plans/package-switch-copy.ts
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-copy.ts
@@ -1,0 +1,79 @@
+/**
+ * Copy for the Pro package-switch confirm modal, keyed by `SwitchRelation`.
+ *
+ * Pure and catalog-free: the caller supplies the target's display name and
+ * tier key, this returns every string the modal renders plus the destructive
+ * flag for the confirm CTA.
+ */
+
+import type { SwitchRelation } from "@/domains/settings/billing/package-types";
+import {
+  downgradeLabel,
+  getPlanTierCopy,
+} from "@/domains/settings/billing/plans/plans-copy";
+
+export interface PackageSwitchCopy {
+  /** Header line, e.g. "Upgrade to Mighty". Statement, not a question. */
+  title: string;
+  /** Tier tagline under the title; empty when the catalog key has no copy. */
+  subtitle: string;
+  /** Caption under the price — where the money actually lands. */
+  priceCaption: string;
+  /** Extra safeguard prose shown below the checklist; empty when none. */
+  note: string;
+  /** Full-width primary CTA label. */
+  confirmLabel: string;
+  /** Render the confirm CTA in the danger variant. */
+  destructive: boolean;
+}
+
+// Package switches apply immediately (no period-end deferral): an upgrade
+// charges the prorated difference now; a downgrade resizes the machine now and
+// nets a prorated credit against the next invoice — storage stays, no cash
+// refund. The copy must not imply the higher tier is kept until month end.
+const UPGRADE_CAPTION = "Billed monthly · prorated difference charged today";
+const SWITCH_CAPTION = "Billed monthly · prorated difference settled today";
+const DOWNGRADE_CAPTION =
+  "Billed monthly · prorated credit on your next invoice";
+const DOWNGRADE_NOTE =
+  "Your machine downsizes now and your storage stays. No refund.";
+const CONTINUE_LABEL = "Continue";
+
+/** Every string the confirm modal renders for one target package. */
+export function packageSwitchCopy(
+  relation: SwitchRelation,
+  packageName: string,
+  tierKey: string | null,
+): PackageSwitchCopy {
+  const subtitle = tierKey ? (getPlanTierCopy(tierKey)?.tagline ?? "") : "";
+
+  switch (relation) {
+    case "downgrade":
+      return {
+        title: `Downgrade to ${packageName}`,
+        subtitle,
+        priceCaption: DOWNGRADE_CAPTION,
+        note: DOWNGRADE_NOTE,
+        confirmLabel: downgradeLabel(packageName),
+        destructive: true,
+      };
+    case "switch":
+      return {
+        title: `Switch to ${packageName}`,
+        subtitle,
+        priceCaption: SWITCH_CAPTION,
+        note: "",
+        confirmLabel: CONTINUE_LABEL,
+        destructive: false,
+      };
+    default:
+      return {
+        title: `Upgrade to ${packageName}`,
+        subtitle,
+        priceCaption: UPGRADE_CAPTION,
+        note: "",
+        confirmLabel: CONTINUE_LABEL,
+        destructive: false,
+      };
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a pure `packageSwitchCopy()` builder that returns title, tagline subtitle, price caption, safeguard note, CTA label and destructive flag per `SwitchRelation`.
- The downgrade variant keeps its explicit destructive CTA and the "machine downsizes now / no refund" note, so no existing safeguard is lost in the redesign.

Part of plan: package-switch-modal-redesign.md (PR 2 of 4)