### PR TITLE
feat(web): add the assistant avatar tile for billing dialog headers

### DIFF
--- a/clients/web/src/domains/settings/billing/assistant-avatar-tile.test.tsx
+++ b/clients/web/src/domains/settings/billing/assistant-avatar-tile.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for `AssistantAvatarTile`. The avatar hook is mocked at its module
+ * boundary so readiness can be flipped per test — the point of the tile is that
+ * it holds its square before the creature resolves, so the dialog header it
+ * sits in never reflows.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render } from "@testing-library/react";
+
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+/** Flipped per-test to hold the avatar query in flight. */
+let avatarLoading = false;
+/** An uploaded avatar image, the simplest resolved avatar to assert on. */
+let avatarCustomImageUrl: string | null = null;
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    components: null,
+    traits: null,
+    customImageUrl: avatarCustomImageUrl,
+    isLoading: avatarLoading,
+    invalidate: () => {},
+  }),
+}));
+
+const { AssistantAvatarTile } = await import("./assistant-avatar-tile");
+
+beforeEach(() => {
+  avatarLoading = false;
+  avatarCustomImageUrl = null;
+  useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderTile() {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <AssistantAvatarTile />
+    </QueryClientProvider>,
+  );
+}
+
+describe("AssistantAvatarTile", () => {
+  test("renders the tile while the avatar query is still loading, with nothing inside it", () => {
+    avatarLoading = true;
+
+    const { getByTestId } = renderTile();
+
+    expect(getByTestId("assistant-avatar-tile").children.length).toBe(0);
+  });
+
+  test("renders the tile with no active assistant to resolve", () => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: null });
+
+    const { getByTestId } = renderTile();
+
+    expect(getByTestId("assistant-avatar-tile").children.length).toBe(0);
+  });
+
+  test("draws the avatar once the query settles", () => {
+    const { getByTestId } = renderTile();
+
+    expect(getByTestId("assistant-avatar-tile").children.length).toBe(1);
+  });
+
+  test("draws an uploaded avatar image inside the tile", () => {
+    avatarCustomImageUrl = "https://example.test/avatar.png";
+
+    const { getByTestId, getByAltText } = renderTile();
+
+    const image = getByAltText("Assistant avatar");
+    expect(getByTestId("assistant-avatar-tile").contains(image)).toBe(true);
+  });
+});

--- a/clients/web/src/domains/settings/billing/assistant-avatar-tile.tsx
+++ b/clients/web/src/domains/settings/billing/assistant-avatar-tile.tsx
@@ -1,0 +1,43 @@
+import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import { useTakeoverSurface } from "@/domains/settings/billing/pro-onboarding/use-takeover-surface";
+import { cn } from "@/utils/misc";
+
+export interface AssistantAvatarTileProps {
+  /** Avatar diameter in px, inside the tile's padding. */
+  size?: number;
+  className?: string;
+}
+
+/**
+ * The assistant's avatar on a rounded neutral tile — the header glyph for
+ * billing dialogs. The tile holds its square while the avatar query settles so
+ * the header does not reflow when the creature appears; `ChatAvatar`
+ * synthesizes fallback traits, so drawing early would flash the bundled green
+ * and then jump to the real color.
+ */
+export function AssistantAvatarTile({
+  size = 24,
+  className,
+}: AssistantAvatarTileProps) {
+  const { ready, avatar } = useTakeoverSurface();
+
+  return (
+    <div
+      aria-hidden
+      data-testid="assistant-avatar-tile"
+      className={cn(
+        "flex size-[52px] shrink-0 items-center justify-center rounded-xl bg-[var(--surface-active)]",
+        className,
+      )}
+    >
+      {ready ? (
+        <ChatAvatar
+          components={avatar.components}
+          traits={avatar.traits}
+          customImageUrl={avatar.customImageUrl}
+          size={size}
+        />
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `AssistantAvatarTile`: the assistant's avatar on a rounded neutral tile, the header glyph for the redesigned billing confirmation dialogs.
- Reuses `useTakeoverSurface()` for avatar resolution and holds the tile's square while the query settles, so the dialog header does not reflow when the creature appears.

Part of plan: package-switch-modal-redesign.md (PR 3 of 4)