### PR TITLE
feat(web): derive plan-highlight rows for the package-switch confirm modal

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-row-labels.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-row-labels.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+
+import { creditRowLabel, storageRowLabel } from "./plan-row-labels";
+
+describe("storageRowLabel", () => {
+  test("spells out the storage row", () => {
+    expect(storageRowLabel(30)).toBe("30 GB storage");
+  });
+});
+
+describe("creditRowLabel", () => {
+  test("drops the cents on a whole-dollar amount", () => {
+    expect(creditRowLabel(45)).toBe("$45 of bundled credits");
+  });
+
+  test("keeps the cents on a sub-dollar amount", () => {
+    expect(creditRowLabel(0.5)).toBe("$0.50 of bundled credits");
+  });
+});

--- a/clients/web/src/domains/settings/billing/plan-row-labels.ts
+++ b/clients/web/src/domains/settings/billing/plan-row-labels.ts
@@ -1,0 +1,18 @@
+/**
+ * The storage and bundled-credit row wordings shared by the package-switch plan
+ * highlights and the Custom Plan recap, so the two surfaces cannot drift apart.
+ * Kept in its own leaf module — `custom-plan-diff` is deliberately React-free,
+ * and importing these from `plan-spec` would drag React in transitively.
+ */
+
+import { formatDollars } from "@/domains/settings/components/tier-pricing";
+
+/** "30 GB storage" */
+export function storageRowLabel(storageGib: number): string {
+  return `${storageGib} GB storage`;
+}
+
+/** "$50 of bundled credits" — cents-aware, so a sub-dollar bundle reads "$0.50". */
+export function creditRowLabel(creditsUsd: number): string {
+  return `${formatDollars(creditsUsd * 100)} of bundled credits`;
+}

--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -7,7 +7,13 @@ import {
   FREE_STORAGE_GIB,
 } from "@/domains/settings/billing/plan-tier-meta";
 
-import { machineLabel, packageHighlights, packageSpecs } from "./plan-spec";
+import {
+  creditRowLabel,
+  machineLabel,
+  packageHighlights,
+  packageSpecs,
+  storageRowLabel,
+} from "./plan-spec";
 
 describe("packageSpecs", () => {
   test("uses the free/base baseline for a null package", () => {
@@ -134,6 +140,22 @@ describe("packageHighlights", () => {
     expect(
       packageHighlights({ machine_size: "small" } as ProPackage),
     ).toHaveLength(3);
+  });
+});
+
+describe("storageRowLabel", () => {
+  test("spells out the storage row", () => {
+    expect(storageRowLabel(30)).toBe("30 GB storage");
+  });
+});
+
+describe("creditRowLabel", () => {
+  test("drops the cents on a whole-dollar amount", () => {
+    expect(creditRowLabel(45)).toBe("$45 of bundled credits");
+  });
+
+  test("keeps the cents on a sub-dollar amount", () => {
+    expect(creditRowLabel(0.5)).toBe("$0.50 of bundled credits");
   });
 });
 

--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -7,13 +7,7 @@ import {
   FREE_STORAGE_GIB,
 } from "@/domains/settings/billing/plan-tier-meta";
 
-import {
-  creditRowLabel,
-  machineLabel,
-  packageHighlights,
-  packageSpecs,
-  storageRowLabel,
-} from "./plan-spec";
+import { machineLabel, packageHighlights, packageSpecs } from "./plan-spec";
 
 describe("packageSpecs", () => {
   test("uses the free/base baseline for a null package", () => {
@@ -140,22 +134,6 @@ describe("packageHighlights", () => {
     expect(
       packageHighlights({ machine_size: "small" } as ProPackage),
     ).toHaveLength(3);
-  });
-});
-
-describe("storageRowLabel", () => {
-  test("spells out the storage row", () => {
-    expect(storageRowLabel(30)).toBe("30 GB storage");
-  });
-});
-
-describe("creditRowLabel", () => {
-  test("drops the cents on a whole-dollar amount", () => {
-    expect(creditRowLabel(45)).toBe("$45 of bundled credits");
-  });
-
-  test("keeps the cents on a sub-dollar amount", () => {
-    expect(creditRowLabel(0.5)).toBe("$0.50 of bundled credits");
   });
 });
 

--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -2,8 +2,12 @@ import { Coins, Computer, HardDrive } from "lucide-react";
 import { describe, expect, test } from "bun:test";
 
 import type { ProPackage } from "@/domains/settings/billing/package-types";
+import {
+  FREE_CREDITS_USD,
+  FREE_STORAGE_GIB,
+} from "@/domains/settings/billing/plan-tier-meta";
 
-import { machineLabel, packageSpecs } from "./plan-spec";
+import { machineLabel, packageHighlights, packageSpecs } from "./plan-spec";
 
 describe("packageSpecs", () => {
   test("uses the free/base baseline for a null package", () => {
@@ -51,6 +55,85 @@ describe("packageSpecs", () => {
       storage_gib: 8,
     } as ProPackage);
     expect(specs[1].label).toBe("$0 credits");
+  });
+});
+
+describe("packageHighlights", () => {
+  test("spells out the machine's resource detail for an explicit size", () => {
+    expect(
+      packageHighlights({
+        machine_size: "large",
+        credits_usd: 100,
+        storage_gib: 50,
+      } as ProPackage),
+    ).toEqual([
+      "Large machine (4 vCPU, 8 GiB)",
+      "50 GB storage",
+      "$100 of bundled credits",
+    ]);
+  });
+
+  test("reads a machine-less Pro package (Mighty) at the small baseline", () => {
+    expect(
+      packageHighlights({
+        machine_size: null,
+        credits_usd: 25,
+        storage_gib: 10,
+      } as ProPackage),
+    ).toEqual([
+      "Small machine (2 vCPU, 3 GiB)",
+      "10 GB storage",
+      "$25 of bundled credits",
+    ]);
+  });
+
+  test("uses the free/base baseline for a null package", () => {
+    expect(packageHighlights(null)).toEqual([
+      "Small machine (2 vCPU, 3 GiB)",
+      `${FREE_STORAGE_GIB} GB storage`,
+      `$${FREE_CREDITS_USD} of bundled credits`,
+    ]);
+  });
+
+  test("formats a sub-dollar credit amount cents-aware", () => {
+    expect(
+      packageHighlights({
+        machine_size: "small",
+        credits_usd: 0.5,
+        storage_gib: 8,
+      } as ProPackage)[2],
+    ).toBe("$0.50 of bundled credits");
+  });
+
+  test("appends extra rows in order after the derived rows", () => {
+    expect(
+      packageHighlights(
+        {
+          machine_size: "medium",
+          credits_usd: 45,
+          storage_gib: 30,
+        } as ProPackage,
+        ["Priority support", "Custom domains"],
+      ),
+    ).toEqual([
+      "Medium machine (2.5 vCPU, 5 GiB)",
+      "30 GB storage",
+      "$45 of bundled credits",
+      "Priority support",
+      "Custom domains",
+    ]);
+  });
+
+  test("omits the resource detail for an unrecognized machine size", () => {
+    expect(
+      packageHighlights({ machine_size: "gigantic" } as ProPackage)[0],
+    ).toBe("gigantic machine");
+  });
+
+  test("appends nothing when extra is omitted", () => {
+    expect(
+      packageHighlights({ machine_size: "small" } as ProPackage),
+    ).toHaveLength(3);
   });
 });
 

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -5,8 +5,9 @@ import {
   FREE_STORAGE_GIB,
 } from "@/domains/settings/billing/plan-tier-meta";
 import type { ProPackage } from "@/domains/settings/billing/package-types";
+import { formatDollars } from "@/domains/settings/components/tier-pricing";
 import type { MachineSizeEnum } from "@/generated/api/types.gen";
-import { SIZE_LABEL } from "@/lib/billing/machine-sizes";
+import { SIZE_DESCRIPTION, SIZE_LABEL } from "@/lib/billing/machine-sizes";
 
 /** A single spec chip: an icon and its label. */
 export interface PlanSpec {
@@ -31,6 +32,11 @@ export function machineLabel(pkg: ProPackage | null): string {
   return SIZE_LABEL[size] ?? pkg.machine_size;
 }
 
+/** A package with no `machine_size` runs on the shared small baseline. */
+function resolvedMachineSize(pkg: ProPackage | null): MachineSizeEnum {
+  return (pkg?.machine_size as MachineSizeEnum | null) ?? "small";
+}
+
 /**
  * The three absolute spec chips for a package, in mock order:
  * machine → credits → storage. A `null` package uses the free/base baseline.
@@ -42,5 +48,28 @@ export function packageSpecs(pkg: ProPackage | null): PlanSpec[] {
     { icon: Computer, label: `${machineLabel(pkg)} Machine` },
     { icon: Coins, label: `$${credits} credits` },
     { icon: HardDrive, label: `${storage} GB` },
+  ];
+}
+
+/**
+ * Sentence-case highlight rows for the package-switch confirm modal, in mock
+ * order: machine → storage → credits, then any static extras from the tier
+ * copy. Longer than `packageSpecs`' chips — the modal has the full card width
+ * for the machine's resource detail, e.g. "Large machine (4 vCPU, 8 GiB)".
+ */
+export function packageHighlights(
+  pkg: ProPackage | null,
+  extra: readonly string[] = [],
+): string[] {
+  const credits = pkg?.credits_usd ?? FREE_CREDITS_USD;
+  const storage = pkg?.storage_gib ?? FREE_STORAGE_GIB;
+  // `machine_size` is a loose string, so an unrecognized size has no preset —
+  // drop the detail rather than render "(undefined)", as `machineLabel` does.
+  const resources = SIZE_DESCRIPTION[resolvedMachineSize(pkg)];
+  return [
+    `${machineLabel(pkg)} machine${resources ? ` (${resources})` : ""}`,
+    `${storage} GB storage`,
+    `${formatDollars(credits * 100)} of bundled credits`,
+    ...extra,
   ];
 }

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -5,7 +5,10 @@ import {
   FREE_STORAGE_GIB,
 } from "@/domains/settings/billing/plan-tier-meta";
 import type { ProPackage } from "@/domains/settings/billing/package-types";
-import { formatDollars } from "@/domains/settings/components/tier-pricing";
+import {
+  creditRowLabel,
+  storageRowLabel,
+} from "@/domains/settings/billing/plan-row-labels";
 import type { MachineSizeEnum } from "@/generated/api/types.gen";
 import { SIZE_DESCRIPTION, SIZE_LABEL } from "@/lib/billing/machine-sizes";
 
@@ -49,16 +52,6 @@ export function packageSpecs(pkg: ProPackage | null): PlanSpec[] {
     { icon: Coins, label: `$${credits} credits` },
     { icon: HardDrive, label: `${storage} GB` },
   ];
-}
-
-/** Shared with the Custom Plan recap so the two surfaces cannot word storage differently. */
-export function storageRowLabel(storageGib: number): string {
-  return `${storageGib} GB storage`;
-}
-
-/** Shared with the Custom Plan recap so the two surfaces cannot format credits differently. */
-export function creditRowLabel(creditsUsd: number): string {
-  return `${formatDollars(creditsUsd * 100)} of bundled credits`;
 }
 
 /**

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -51,6 +51,16 @@ export function packageSpecs(pkg: ProPackage | null): PlanSpec[] {
   ];
 }
 
+/** Shared with the Custom Plan recap so the two surfaces cannot word storage differently. */
+export function storageRowLabel(storageGib: number): string {
+  return `${storageGib} GB storage`;
+}
+
+/** Shared with the Custom Plan recap so the two surfaces cannot format credits differently. */
+export function creditRowLabel(creditsUsd: number): string {
+  return `${formatDollars(creditsUsd * 100)} of bundled credits`;
+}
+
 /**
  * Sentence-case highlight rows for the package-switch confirm modal, in mock
  * order: machine → storage → credits, then any static extras from the tier
@@ -68,8 +78,8 @@ export function packageHighlights(
   const resources = SIZE_DESCRIPTION[resolvedMachineSize(pkg)];
   return [
     `${machineLabel(pkg)} machine${resources ? ` (${resources})` : ""}`,
-    `${storage} GB storage`,
-    `${formatDollars(credits * 100)} of bundled credits`,
+    storageRowLabel(storage),
+    creditRowLabel(credits),
     ...extra,
   ];
 }

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -7,7 +7,7 @@
 import {
   creditRowLabel,
   storageRowLabel,
-} from "@/domains/settings/billing/plan-spec";
+} from "@/domains/settings/billing/plan-row-labels";
 import { formatMonthly } from "@/domains/settings/components/tier-pricing";
 import type {
   CreditTierEnum,

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -5,15 +5,14 @@
  */
 
 import {
-  formatDollars,
-  formatMonthly,
-} from "@/domains/settings/components/tier-pricing";
+  creditRowLabel,
+  storageRowLabel,
+} from "@/domains/settings/billing/plan-spec";
+import { formatMonthly } from "@/domains/settings/components/tier-pricing";
 import type {
-  CreditTier,
   CreditTierEnum,
   MachineTierEnum,
   ProPlan,
-  StorageTier,
   StorageTierEnum,
 } from "@/generated/api/types.gen";
 
@@ -50,14 +49,6 @@ export interface CustomPlanDiff {
   previousTotalCents: number | null;
   deltaCents: number | null;
   rows: CustomPlanDiffRow[];
-}
-
-function storageLabel(tier: StorageTier): string {
-  return `${tier.storage_gib} GB storage`;
-}
-
-function creditLabel(tier: CreditTier): string {
-  return `${formatDollars(tier.credits_usd * 100)} of bundled credits`;
 }
 
 export function computeCustomPlanDiff(input: {
@@ -133,9 +124,11 @@ export function computeCustomPlanDiff(input: {
       seedStorage?.tier !== selectedStorage.tier;
     rows.push({
       key: "storage",
-      label: storageLabel(selectedStorage),
+      label: storageRowLabel(selectedStorage.storage_gib),
       previousLabel:
-        changed && seedStorage != null ? storageLabel(seedStorage) : undefined,
+        changed && seedStorage != null
+          ? storageRowLabel(seedStorage.storage_gib)
+          : undefined,
       changed,
     });
   }
@@ -146,7 +139,7 @@ export function computeCustomPlanDiff(input: {
     creditChoice === NO_EXTRA_CREDITS
       ? NO_CREDITS_LABEL
       : selectedCredit != null
-        ? creditLabel(selectedCredit)
+        ? creditRowLabel(selectedCredit.credits_usd)
         : null;
 
   if (selectedCreditLabel != null) {
@@ -158,7 +151,7 @@ export function computeCustomPlanDiff(input: {
       seed?.creditTier == null
         ? NO_CREDITS_LABEL
         : seedCredit != null
-          ? creditLabel(seedCredit)
+          ? creditRowLabel(seedCredit.credits_usd)
           : undefined;
     rows.push({
       key: "credit",


### PR DESCRIPTION
## Summary
- Adds `packageHighlights()` to `plan-spec.ts`: catalog-derived checklist rows (machine with its vCPU/RAM detail, storage, bundled credits) for the redesigned package-switch confirm modal.
- Purely additive — `packageSpecs`/`machineLabel` are untouched, so the existing spec chips do not shift.

Part of plan: package-switch-modal-redesign.md (PR 1 of 4)