### PR TITLE
fix(db): ensure PRAGMA journal_mode=WAL is set in runAsyncSqlite CLI prelude

### DIFF
--- a/assistant/src/persistence/db-async-query.ts
+++ b/assistant/src/persistence/db-async-query.ts
@@ -228,7 +228,7 @@ async function runViaCli(
   // corrupt) — the durability posture every daemon write already has, so
   // FULL here buys no end-to-end guarantee. Prepended to the piped SQL so
   // both take effect before the statement runs.
-  const sqlWithPragma = `PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS};\nPRAGMA synchronous=NORMAL;\n${sql}`;
+  const sqlWithPragma = `PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS};\nPRAGMA synchronous=NORMAL;\nPRAGMA journal_mode=WAL;\n${sql}`;
 
   // Write the SQL and close stdin so sqlite3 sees EOF and exits.
   proc.stdin.write(sqlWithPragma + "\n");


### PR DESCRIPTION
## Description
This PR resolves issue #37834 by adding `PRAGMA journal_mode=WAL;` to the `runAsyncSqlite` CLI prelude in `assistant/src/persistence/db-async-query.ts`.

## Details
- Prepends `PRAGMA journal_mode=WAL;` to piped SQL in `runViaCli`.
- Guarantees spawned `sqlite3` CLI processes operate in WAL mode matching the in-process daemon connection.