### PR TITLE
test(fork): pin fixture base timestamp in past to eliminate compaction timing race in conversation-fork-crud.test.ts

### DIFF
--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -483,7 +483,7 @@ describe("forkConversation", () => {
     // message — same-millisecond inserts would otherwise make the event
     // "at-or-before" the branch point and inherit.
     const db = getDb();
-    const base = Date.now();
+    const base = Date.now() - 10_000;
     db.run(
       `UPDATE messages SET created_at = ${base} WHERE id = '${compactedBranchPoint.id}'`,
     );


### PR DESCRIPTION
## Description
This PR resolves issue #36930 by pinning the base fixture timestamp to the past (`Date.now() - 10_000`) in `conversation-fork-crud.test.ts`.

## Details
- Prevents same-millisecond race conditions between `compactedAt` and message `createdAt` timestamps during test execution.