### PR TITLE
fix(web): apply forced-open filtering to custom groups too

### DIFF
--- a/clients/web/src/components/collapsible-nav-section.tsx
+++ b/clients/web/src/components/collapsible-nav-section.tsx
@@ -211,7 +211,9 @@ function CollapsibleNavSectionSection({
       {trailing ? (
         <span
           data-slot="collapsible-nav-section-trailing"
-          className="flex items-center shrink-0 pr-[6px] max-md:pr-2"
+          /* `empty:hidden` so a trailing component that renders nothing (a
+             menu with no wired actions) doesn't leave a padded box behind. */
+          className="flex items-center shrink-0 pr-[6px] max-md:pr-2 empty:hidden"
           onClick={(event) => event.stopPropagation()}
         >
           {trailing}

--- a/clients/web/src/domains/chat/use-sidebar-state.test.tsx
+++ b/clients/web/src/domains/chat/use-sidebar-state.test.tsx
@@ -213,3 +213,43 @@ describe("useSidebarState open-section persistence", () => {
     );
   });
 });
+
+describe("useSidebarState custom-group open-section persistence", () => {
+  // Custom groups render in their own accordion root, but attention forces
+  // them open the same way the shared root's sections are forced open — so
+  // their writes need the same filter, or a group the user never opened
+  // stays expanded once the attention clears.
+  test("does not persist a custom group that only attention forced open", () => {
+    const conversations = [
+      makeConversation(0, { conversationId: "g1", groupId: "grp-a" }),
+      makeConversation(1, { conversationId: "g2", groupId: "grp-b" }),
+    ];
+    const conversationGroups = [
+      { id: "grp-a", name: "Alpha", sortPosition: 0, isSystemGroup: false },
+      { id: "grp-b", name: "Beta", sortPosition: 1, isSystemGroup: false },
+    ];
+
+    const { result } = renderHook(() =>
+      useSidebarState({
+        assistantId: "asst-1",
+        conversations,
+        conversationGroups,
+        attentionConversationIds: new Set(["g2"]),
+      }),
+    );
+
+    expect(result.current.effectiveOpenCustomGroups).toContain("grp-b");
+
+    // Opening Alpha emits Beta's forced key alongside the real change.
+    act(() =>
+      result.current.onOpenCustomGroupsChange([
+        ...result.current.effectiveOpenCustomGroups,
+        "grp-a",
+      ]),
+    );
+
+    const stored = useSidebarCollapseStore.getState().openCustomGroups;
+    expect(stored).toContain("grp-a");
+    expect(stored).not.toContain("grp-b");
+  });
+});

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -262,10 +262,6 @@ export function useSidebarState({
     if (!attentionConversationIds || attentionConversationIds.size === 0)
       return openCategories;
     const extra: string[] = [];
-    if (grouped.scheduled.length > 0 && hasAttentionIn(grouped.scheduled))
-      extra.push("scheduled");
-    if (grouped.background.length > 0 && hasAttentionIn(grouped.background))
-      extra.push("background");
     for (const section of grouped.channelSections) {
       if (
         section.conversations.length > 0 &&
@@ -279,8 +275,6 @@ export function useSidebarState({
   }, [
     openCategories,
     attentionConversationIds,
-    grouped.scheduled,
-    grouped.background,
     grouped.channelSections,
     hasAttentionIn,
   ]);
@@ -334,13 +328,26 @@ export function useSidebarState({
   // when the user toggles some *other* section — persisting them would outlive
   // the attention that opened them and leave the section stuck open.
   const forcedOpenKeys = useMemo(() => {
-    const stored = new Set([...openPrimary, ...openCategories]);
+    const stored = new Set([
+      ...openPrimary,
+      ...openCategories,
+      ...openCustomGroups,
+    ]);
     return new Set(
-      [...effectiveOpenPrimary, ...effectiveOpenCategories].filter(
-        (key) => !stored.has(key),
-      ),
+      [
+        ...effectiveOpenPrimary,
+        ...effectiveOpenCategories,
+        ...effectiveOpenCustomGroups,
+      ].filter((key) => !stored.has(key)),
     );
-  }, [openPrimary, openCategories, effectiveOpenPrimary, effectiveOpenCategories]);
+  }, [
+    openPrimary,
+    openCategories,
+    openCustomGroups,
+    effectiveOpenPrimary,
+    effectiveOpenCategories,
+    effectiveOpenCustomGroups,
+  ]);
 
   const onOpenSectionsChange = useCallback(
     (next: string[]) => {
@@ -351,6 +358,15 @@ export function useSidebarState({
     [forcedOpenKeys, setOpenPrimary, setOpenCategories],
   );
 
+  // Custom groups render in their own root but are force-opened by attention
+  // the same way, so their writes need the same filter.
+  const onOpenCustomGroupsChange = useCallback(
+    (next: string[]) => {
+      setOpenCustomGroups(next.filter((key) => !forcedOpenKeys.has(key)));
+    },
+    [forcedOpenKeys, setOpenCustomGroups],
+  );
+
   return {
     pinned: grouped.pinned,
     channelSections,
@@ -359,6 +375,6 @@ export function useSidebarState({
     effectiveOpenSections,
     onOpenSectionsChange,
     effectiveOpenCustomGroups,
-    onOpenCustomGroupsChange: setOpenCustomGroups,
+    onOpenCustomGroupsChange,
   };
 }


### PR DESCRIPTION
## Prompt / plan

Follow-up to #39220. After it merged, I did a deeper walkthrough of the sidebar section code looking for anything the review rounds missed. Three findings, all in the seams that PR created or left behind.

## What this fixes for the user

| | Before | After |
| --- | --- | --- |
| A **custom group** auto-opened because a chat needs attention | Expanding or collapsing any other group silently saved it as if you'd opened it — it stayed expanded after the attention cleared, across reloads | Reverts on its own once the attention clears |
| A section header whose menu has **no wired actions** | Left an empty padded box in the header | Nothing renders |

## The findings

**1. The forced-open fix only covered two of the three storage buckets.** (P1 — same defect Devin caught on #39220.)

#39220 stopped attention-forced sections from being written through to storage, but only for the shared accordion root. Custom groups render in their own root, and `onOpenCustomGroupsChange` was still the raw store setter:

```ts
onOpenCustomGroupsChange: setOpenCustomGroups,   // no filter
```

Every precondition for the original bug is present here: `effectiveOpenCustomGroups` appends ids forced open by attention, Radix's `AccordionImplMultiple` spreads the current value array into every `onValueChange` payload, and the handler wrote the lot. So toggling one group persisted every *other* force-opened group as user-opened.

`forcedOpenKeys` now spans all three buckets and both change handlers filter through it, so "open because of attention" is ephemeral wherever a section lives.

**2. Dead force-open branch for sections that no longer render.**

`effectiveOpenCategories` still pushed `"scheduled"` and `"background"` keys on attention. #39220 removed those sections, so the keys matched no accordion item — harmless, but it kept `grouped.scheduled` / `grouped.background` alive as pure overhead and reads as live logic. Removed alongside the sections it belonged to.

**3. Empty trailing slot renders a padded box.**

#39220 changed the custom-group `trailing` from a conditional to an unconditional `<GroupActionsMenu>`, which returns `null` when no action is wired. A React element is truthy regardless of what it renders, so `CollapsibleNavSection.Section`'s `trailing ? (...)` guard no longer gates anything and the `pr-[6px]` wrapper always mounts. Fixed with `empty:hidden` rather than a new conditional, so it holds for any trailing component that renders nothing.

## Why it's right

- **Finding 1 is a consistency fix, not a new mechanism.** It reuses the exact `forcedOpenKeys` set #39220 introduced; the change is widening its input and applying it at the second call site. Diffing against *stored* rather than *effective* state means explicitly collapsing a force-opened group still behaves as before — the key is absent from `next` either way, and force-open re-applies on the next render while the attention lasts.
- **Finding 2 removes logic that could not fire usefully.** The keys it produced had no matching accordion item.
- **Finding 3 fixes the general case.** `empty:hidden` covers any future trailing component that conditionally renders nothing, rather than re-adding a guard that the next caller has to remember.

## Why it's safe

- **No API, schema, or persistence-format changes.** Same localStorage keys, same shape. The only behavioral difference is which keys get written, and it's strictly *fewer* — a key that was never user-opened.
- **Nothing that was persisted before is dropped.** Only keys absent from stored state (i.e. present solely because of attention) are filtered. A group the user genuinely opened is in `stored`, so it never enters `forcedOpenKeys`.
- **The regression test fails without the fix.** I reverted the filter and confirmed the new test goes red before keeping it.
- **720 test files pass** under the repo's isolated runner, typecheck and lint clean.

## Test plan

- `bun scripts/run-tests.ts` — the isolated runner; plain `bun test` across many files leaks `mock.module` between them. **720 files, 0 failed.**
- New: "does not persist a custom group that only attention forced open" — asserts the user's real toggle persists while the forced key does not. **Verified to fail against the pre-fix handler.**
- `bunx tsc --noEmit` and `bun run lint` clean (0 errors).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRH6omRyuu1rgAoHG6Bh7f)_