### PR TITLE
feat(voice): make progress narration follow the work, not the clock (JARVIS-1353)

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -943,6 +943,8 @@ describe("AssistantConfigSchema", () => {
           enabled: true,
           opsThreshold: 3,
           idleIntervalMs: 5000,
+          maxSilenceMs: 35000,
+          longOpMs: 15000,
           minGapMs: 6000,
           generationTimeoutMs: 1500,
         },

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -144,6 +144,29 @@ describe("LiveVoiceFrontModelConfigSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  test("rejects a heartbeat ceiling shorter than the idle tick interval", () => {
+    // The heartbeat is only checked on the idle tick, so a shorter ceiling
+    // could be overshot by a full interval.
+    const result = LiveVoiceFrontModelConfigSchema.safeParse({
+      progress: { idleIntervalMs: 60_000, maxSilenceMs: 10_000 },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((issue) => issue.message);
+      expect(
+        msgs.some((msg) =>
+          msg.includes("liveVoice.frontModel.progress.maxSilenceMs"),
+        ),
+      ).toBe(true);
+    }
+    // The floor itself is allowed: the tick is exactly on the ceiling.
+    expect(
+      LiveVoiceFrontModelConfigSchema.safeParse({
+        progress: { idleIntervalMs: 60_000, maxSilenceMs: 60_000 },
+      }).success,
+    ).toBe(true);
+  });
+
   test("rejects a non-boolean progress.enabled", () => {
     const result = LiveVoiceFrontModelConfigSchema.safeParse({
       progress: { enabled: "yes" },

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -11,6 +11,8 @@ const PROGRESS_DEFAULTS = {
   enabled: true,
   opsThreshold: 3,
   idleIntervalMs: 5_000,
+  maxSilenceMs: 35_000,
+  longOpMs: 15_000,
   minGapMs: 6_000,
   generationTimeoutMs: 1_500,
 };
@@ -121,6 +123,8 @@ describe("LiveVoiceFrontModelConfigSchema", () => {
     expect(parsed.progress.opsThreshold).toBe(5);
     // Unspecified progress fields still get defaults
     expect(parsed.progress.idleIntervalMs).toBe(5_000);
+    expect(parsed.progress.maxSilenceMs).toBe(35_000);
+    expect(parsed.progress.longOpMs).toBe(15_000);
     expect(parsed.progress.minGapMs).toBe(6_000);
     expect(parsed.progress.generationTimeoutMs).toBe(1_500);
   });

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -91,7 +91,7 @@ export const LiveVoiceProgressConfigSchema = z
       )
       .default(35_000)
       .describe(
-        "Heartbeat ceiling (ms): narrate after this much unbroken silence even when nothing new has happened",
+        "Heartbeat ceiling (ms): narrate after this much unbroken silence even when nothing new has happened. Evaluated on the idle tick, so its resolution is idleIntervalMs and it must be at least that long",
       ),
     longOpMs: z
       .number({
@@ -132,6 +132,14 @@ export const LiveVoiceProgressConfigSchema = z
       .describe(
         "Budget (ms) for LLM-generated progress text — not latency-critical: it speaks into dead air",
       ),
+  })
+  // The heartbeat is checked when the idle tick finds the turn silent, so a
+  // ceiling shorter than the tick interval would be missed by up to a full
+  // interval — a promise the cadence cannot keep. Rejecting the combination
+  // beats silently overshooting it.
+  .refine((progress) => progress.maxSilenceMs >= progress.idleIntervalMs, {
+    error:
+      "liveVoice.frontModel.progress.maxSilenceMs must be at least idleIntervalMs — the heartbeat is evaluated on the idle tick",
   })
   .describe(
     "Progress-narration tuning for live voice sessions (spoken updates during long-running turns)",

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -79,7 +79,31 @@ export const LiveVoiceProgressConfigSchema = z
       )
       .default(5_000)
       .describe(
-        "Narrate after this much silence (ms) with the turn still running",
+        "How often (ms) a running turn's silence is checked, and so the soonest new tool activity is narrated",
+      ),
+    maxSilenceMs: z
+      .number({
+        error: "liveVoice.frontModel.progress.maxSilenceMs must be a number",
+      })
+      .int("liveVoice.frontModel.progress.maxSilenceMs must be an integer")
+      .positive(
+        "liveVoice.frontModel.progress.maxSilenceMs must be a positive integer",
+      )
+      .default(35_000)
+      .describe(
+        "Heartbeat ceiling (ms): narrate after this much unbroken silence even when nothing new has happened",
+      ),
+    longOpMs: z
+      .number({
+        error: "liveVoice.frontModel.progress.longOpMs must be a number",
+      })
+      .int("liveVoice.frontModel.progress.longOpMs must be an integer")
+      .positive(
+        "liveVoice.frontModel.progress.longOpMs must be a positive integer",
+      )
+      .default(15_000)
+      .describe(
+        "A tool operation that ran at least this long (ms) narrates the moment it completes, without waiting for opsThreshold",
       ),
     minGapMs: z
       .number({

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -147,6 +147,11 @@ function progressConfig(
       enabled: true,
       opsThreshold: 3,
       idleIntervalMs: 60_000,
+      // Below every tick interval these tests use, so a dead-air tick is
+      // heartbeat-eligible by default; tests that assert the new-activity gate
+      // raise it out of reach.
+      maxSilenceMs: 30,
+      longOpMs: 15_000,
       minGapMs: 10,
       generationTimeoutMs: 1_500,
       ...overrides,
@@ -738,6 +743,152 @@ describe("LiveVoiceSession progress narration", () => {
     // Only the tool-start ack spoke; the decider was never consulted.
     expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK]);
     expect(generateProgressText).not.toHaveBeenCalled();
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("idle ticks stay silent with nothing new, until the maxSilenceMs heartbeat", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({
+        idleIntervalMs: 20,
+        maxSilenceMs: 150,
+      }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    // Several ticks pass over a turn that has done nothing observable: the
+    // cadence follows the work, so none of them speak.
+    await sleep(70);
+    expect(generateProgressText).not.toHaveBeenCalled();
+
+    // The heartbeat ceiling is the one thing that speaks without news — a
+    // turn with no observable activity still has to prove it is alive.
+    await waitFor(() => ttsTexts.length === 1);
+    expect(ttsTexts).toEqual([GENERATED_NARRATION]);
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("new tool activity narrates once; later ticks over the same state stay silent", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({
+        // Only the idle trigger is in play: the ops threshold is out of reach
+        // and the heartbeat is far beyond the test's lifetime.
+        opsThreshold: 99,
+        idleIntervalMs: 20,
+        maxSilenceMs: 600_000,
+      }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    await sleep(60);
+    expect(generateProgressText).not.toHaveBeenCalled();
+
+    // A tool starting is news: the next tick narrates it.
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 2);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK, GENERATED_NARRATION]);
+
+    // Nothing has happened since, so the ticks that follow stay quiet
+    // instead of repeating the same update on a clock.
+    await sleep(80);
+    expect(generateProgressText).toHaveBeenCalledTimes(1);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK, GENERATED_NARRATION]);
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("op_complete: a long-running op narrates as it finishes, without the ops threshold", async () => {
+    const inputs: VoiceProgressTextInput[] = [];
+    const generateProgressText = mock(async (input: VoiceProgressTextInput) => {
+      inputs.push(input);
+      return GENERATED_NARRATION;
+    });
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({
+        // Neither the ops threshold nor an idle tick can fire: the completion
+        // beat is the only thing that can speak here.
+        opsThreshold: 99,
+        idleIntervalMs: 60_000,
+        longOpMs: 25,
+      }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 1);
+    await sleep(40);
+
+    emitToolResult(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 2);
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK, GENERATED_NARRATION]);
+    expect(inputs[0]?.completedOps).toEqual([
+      { toolName: "web_search", resultPreview: "ok" },
+    ]);
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("a quick op finishing does not earn the completion beat", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({
+        opsThreshold: 99,
+        idleIntervalMs: 60_000,
+        longOpMs: 60_000,
+      }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => ttsTexts.length === 1);
+    emitToolResult(getCallbacks, "web_search", "tool-1");
+    await sleep(60);
+
+    // Narrating every quick lookup is the chatter the cadence avoids.
+    expect(generateProgressText).not.toHaveBeenCalled();
+    expect(ttsTexts).toEqual([EXPECTED_TOOL_ACK]);
+
+    emitMessageComplete(getCallbacks);
+  });
+
+  test("activity during a generation is still news for the next tick", async () => {
+    const generation = deferred<string | null>();
+    let generationCalls = 0;
+    const generateProgressText = mock((): Promise<string | null> => {
+      generationCalls += 1;
+      return generationCalls === 1
+        ? generation.promise
+        : Promise.resolve("Second narration.");
+    });
+    const { session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({
+        opsThreshold: 99,
+        idleIntervalMs: 20,
+        maxSilenceMs: 600_000,
+      }),
+      frontDecider: makeProgressDecider(generateProgressText),
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    await waitFor(() => generateProgressText.mock.calls.length === 1);
+
+    // The op completes while the update describing its start is still being
+    // generated: that text cannot carry the news, so the update marks the
+    // state it described, not the state it enqueues into.
+    emitToolResult(getCallbacks, "web_search", "tool-1");
+    generation.resolve("First narration.");
+    await waitFor(() => ttsTexts.includes("First narration."));
+
+    await waitFor(() => ttsTexts.includes("Second narration."));
+    expect(generateProgressText).toHaveBeenCalledTimes(2);
 
     emitMessageComplete(getCallbacks);
   });

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -141,16 +141,17 @@ function makeProgressDecider(
 function progressConfig(
   overrides: Partial<LiveVoiceProgressConfig> = {},
 ): Partial<LiveVoiceFrontModelConfig> {
+  const idleIntervalMs = overrides.idleIntervalMs ?? 60_000;
   return {
     ackFirstDeltaTimeoutMs: GENEROUS_ACK_TIMEOUT_MS,
     progress: {
       enabled: true,
       opsThreshold: 3,
-      idleIntervalMs: 60_000,
-      // Below every tick interval these tests use, so a dead-air tick is
-      // heartbeat-eligible by default; tests that assert the new-activity gate
-      // raise it out of reach.
-      maxSilenceMs: 30,
+      idleIntervalMs,
+      // The schema floors the heartbeat at the tick interval; sitting exactly
+      // on that floor makes every dead-air tick heartbeat-eligible, and tests
+      // that assert the new-activity gate raise it out of reach.
+      maxSilenceMs: idleIntervalMs,
       longOpMs: 15_000,
       minGapMs: 10,
       generationTimeoutMs: 1_500,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -378,6 +378,13 @@ interface TurnProgressState {
   // op, on start (not completion), so a burst of slow tools still trips the
   // threshold while they run.
   opsSinceNarration: number;
+  // Bumped by every observable change to the turn's tool activity — an op
+  // starting or finishing. The idle trigger compares it against
+  // `narratedEpoch` so a tick with nothing new to report stays silent.
+  stateEpoch: number;
+  // The `stateEpoch` the last spoken narration described: the activity the
+  // user has already been told about.
+  narratedEpoch: number;
   // Narrations actually spoken this turn — the metrics count and the
   // decider's 1-based updateIndex. Rate, not count, bounds narration:
   // idleIntervalMs/minGapMs cap the cadence and the session duration cap
@@ -2445,6 +2452,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       progress: {
         ops: [],
         opsSinceNarration: 0,
+        // Equal epochs at launch: a turn that has done nothing observable yet
+        // has nothing to narrate, so the idle trigger waits for tool activity
+        // or the maxSilenceMs heartbeat.
+        stateEpoch: 0,
+        narratedEpoch: 0,
         updatesSpoken: 0,
         lastFloorHolderAtMs: null,
         lastAudibleAtMs: Date.now(),
@@ -2846,6 +2858,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               startedAtMs: Date.now(),
             });
             current.progress.opsSinceNarration += 1;
+            current.progress.stateEpoch += 1;
             log.debug({ turnId, toolName }, "Live voice turn started tool use");
             // Definitive tool use means the turn is guaranteed slow: speak
             // the floor-holding ack now instead of waiting out the
@@ -2879,14 +2892,27 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
                   )
                 : undefined) ??
               findLastIncompleteOp(current.progress.ops, event.toolName);
+            // A long-running op finishing is the beat the user has been
+            // waiting through: it narrates immediately rather than waiting for
+            // `opsThreshold` more ops, which on a one-slow-tool turn never
+            // arrive. Short ops stay on the ops trigger — narrating every
+            // quick lookup is the chatter this cadence exists to avoid.
+            let trigger: "ops" | "op_complete" = "ops";
             if (op) {
               op.completedAtMs = Date.now();
               if (event.isError !== undefined) {
                 op.isError = event.isError;
               }
               op.resultPreview = event.resultPreview;
+              if (
+                op.completedAtMs - op.startedAtMs >=
+                this.frontModelConfig.progress.longOpMs
+              ) {
+                trigger = "op_complete";
+              }
             }
-            this.maybeNarrateProgress(current, "ops");
+            current.progress.stateEpoch += 1;
+            this.maybeNarrateProgress(current, trigger);
           },
         },
         onError: (message) => {
@@ -3142,10 +3168,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // the user's ears — not time since launch, so it covers mid-turn silences
   // for the whole turn. On expiry with audio still pending, or with the
   // silence not yet a full interval old, it re-arms for the remainder; only a
-  // full interval of audible silence narrates. The cadence is deliberately
-  // flat and uncapped: long pauses feel longest, so updates keep coming at
-  // the same interval (minGapMs is the spacing floor) for as long as the
-  // turn stays silent.
+  // full interval of audible silence reaches the narration gatekeeper. The
+  // interval is a polling cadence, not a speaking cadence: most ticks find
+  // nothing new to report and stay quiet, so what the user hears follows the
+  // turn's tool activity (with `maxSilenceMs` as the heartbeat ceiling).
   private armProgressIdleTimer(
     turn: ActiveAssistantTurn,
     delayMs?: number,
@@ -3173,16 +3199,22 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }, delayMs ?? this.frontModelConfig.progress.idleIntervalMs);
   }
 
-  // Wall-clock instant the current audible silence turns a full interval old:
-  // measured from the latest of the last emitted segment, the estimated
-  // client playback end, and the last enqueued filler.
+  // Wall-clock instant the current audible silence turns a full interval old.
   private progressIdleDeadlineMs(turn: ActiveAssistantTurn): number {
     return (
-      Math.max(
-        turn.progress.lastAudibleAtMs,
-        this.assistantPlaybackTailUntilMs,
-        turn.progress.lastFloorHolderAtMs ?? 0,
-      ) + this.frontModelConfig.progress.idleIntervalMs
+      this.progressSilenceSinceMs(turn) +
+      this.frontModelConfig.progress.idleIntervalMs
+    );
+  }
+
+  // When the turn's current audible silence began: the latest of the last
+  // emitted segment, the estimated client playback end, and the last enqueued
+  // filler.
+  private progressSilenceSinceMs(turn: ActiveAssistantTurn): number {
+    return Math.max(
+      turn.progress.lastAudibleAtMs,
+      this.assistantPlaybackTailUntilMs,
+      turn.progress.lastFloorHolderAtMs ?? 0,
     );
   }
 
@@ -3250,17 +3282,39 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     );
   }
 
+  // The idle tick has something worth saying when the turn's tool activity has
+  // moved since the last narration described it, or when the silence has run
+  // past `maxSilenceMs` — the heartbeat ceiling that proves the assistant is
+  // still alive on a turn with no observable activity at all. Every other tick
+  // stays quiet, so the cadence follows the work rather than the clock.
+  private progressIdleHasSomethingToSay(turn: ActiveAssistantTurn): boolean {
+    const { progress } = turn;
+    if (progress.stateEpoch !== progress.narratedEpoch) {
+      return true;
+    }
+    const silentForMs = Date.now() - this.progressSilenceSinceMs(turn);
+    if (silentForMs >= this.frontModelConfig.progress.maxSilenceMs) {
+      return true;
+    }
+    log.debug(
+      { turnId: turn.turnId, silentForMs },
+      "Live voice progress narration held — nothing new since the last update",
+    );
+    return false;
+  }
+
   // Gatekeeper for spoken progress narration: it speaks only while the turn
   // is audibly silent, spaced `minGapMs` from any spoken floor-holder (ack or
-  // narration), one generation at a time, and — on the ops trigger — only
-  // once `opsThreshold` ops accumulated. No per-turn count cap: the cadence
-  // guards bound the rate, and going quiet deep into a long turn is the
-  // failure mode narration exists to prevent. Every failing guard
-  // short-circuits silently; a skipped ops trigger keeps its accumulated
-  // count, so the next tool event or idle tick retries.
+  // narration), one generation at a time, and — per trigger — only once the
+  // ops trigger has `opsThreshold` ops accumulated or the idle trigger has
+  // something new to report. No per-turn count cap: the cadence guards bound
+  // the rate, and going quiet deep into a long turn is the failure mode
+  // narration exists to prevent. Every failing guard short-circuits silently;
+  // a skipped ops trigger keeps its accumulated count, so the next tool event
+  // or idle tick retries.
   private maybeNarrateProgress(
     turn: ActiveAssistantTurn,
-    trigger: "ops" | "idle",
+    trigger: "ops" | "idle" | "op_complete",
   ): void {
     const cfg = this.frontModelConfig.progress;
     const { progress } = turn;
@@ -3277,7 +3331,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       progress.narrationInFlight ||
       (progress.lastFloorHolderAtMs !== null &&
         Date.now() - progress.lastFloorHolderAtMs < cfg.minGapMs) ||
-      (trigger === "ops" && progress.opsSinceNarration < cfg.opsThreshold)
+      (trigger === "ops" && progress.opsSinceNarration < cfg.opsThreshold) ||
+      (trigger === "idle" && !this.progressIdleHasSomethingToSay(turn))
     ) {
       return;
     }
@@ -3289,18 +3344,22 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // on the turn's ordered TTS queue. The decider internally bounds the call
   // by `progress.generationTimeoutMs` and resolves null on every failure
   // mode; on null the idle trigger falls back to a static phrase (silence is
-  // actively harmful there) while the ops trigger stays silent — a generic
-  // filler is not worth it when narration was merely opportunistic.
+  // actively harmful there) while the tool-activity triggers stay silent — a
+  // generic filler is not worth it when narration was merely opportunistic.
   private async speakProgressUpdate(
     turn: ActiveAssistantTurn,
     frontDecider: VoiceFrontDecider,
-    trigger: "ops" | "idle",
+    trigger: "ops" | "idle" | "op_complete",
   ): Promise<void> {
     const { progress } = turn;
     progress.narrationInFlight = true;
     // Any delta that lands while the decider call is in flight makes the
     // generated text stale — and proves the model is speaking again.
     const deltaEpochAtLaunch = turn.deltaEpoch;
+    // The activity this update describes. Tool events that land mid-generation
+    // are news the generated text cannot carry, so they must leave the idle
+    // trigger armed rather than count as already narrated.
+    const stateEpochAtLaunch = progress.stateEpoch;
     try {
       const now = Date.now();
       const currentOp = findLastIncompleteOp(progress.ops);
@@ -3360,7 +3419,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
       let raw = generated;
       if (raw === null) {
-        if (trigger === "ops") {
+        if (trigger !== "idle") {
           return;
         }
         raw = pickProgressPhrase(this.progressPhraseCounter++);
@@ -3369,6 +3428,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
       progress.opsSinceNarration = 0;
+      progress.narratedEpoch = stateEpochAtLaunch;
       progress.updatesSpoken += 1;
       // Like the ack mark, recorded only when narration audio actually
       // enqueued (decider text or static fallback alike).


### PR DESCRIPTION
Closes JARVIS-1353.

Progress narration spoke on a timer: every idle tick that found the turn audibly silent produced another update, whether or not anything had happened since the last one. On a long tool-heavy turn that is a filler phrase every few seconds.

## What changed

**The idle tick is now a polling cadence, not a speaking one.** Each turn carries a `stateEpoch` bumped by every tool start and completion, and a spoken update records the epoch it described. An idle tick whose epoch has not moved since the last update stays quiet — so what the user hears follows the turn's activity instead of a clock. `progress.maxSilenceMs` (default 35s) is the heartbeat ceiling: a turn with no observable activity at all still gets an occasional update, so a slow turn never goes fully dark.

The update stamps the epoch captured *before* its decider call rather than the one at enqueue time. A tool event landing mid-generation is news the already-generated text cannot carry, so it has to leave the next tick armed rather than count as narrated.

**A long-running op finishing gets its own trigger.** `progress.longOpMs` (default 15s) — an op that ran at least that long narrates the moment it completes, instead of waiting for `opsThreshold` more ops that a one-slow-tool turn never produces. Short ops stay on the ops threshold; narrating every quick lookup is the chatter this cadence exists to avoid. Like the ops trigger, the completion beat stays silent when the decider fails (only the idle trigger falls back to a static phrase) — the model's own first delta is imminent there.

Narration remains a floor-holder: no results, no conclusions, audio-only.

## Follow-ups (tracked on the ticket)

- Let the decider return deliberate silence — today `null` means failure and the idle path overrides it with a static phrase; also feed it the updates already spoken.
- The "I'll let you know when I'm done" hold contract: the decider returns an intent alongside its text, and the session suppresses narration until the referenced op completes.

## Testing

- 5 new cases in `live-voice-progress.test.ts`: heartbeat-only silence, narrate-once-then-stay-quiet, the long-op completion beat, a quick op earning no beat, and activity during a generation still counting as news for the next tick.
- Full `src/live-voice/` suite green (320 tests), typecheck, lint, and prettier clean.
- Note: running `src/live-voice/` and `src/config/` in one `bun test` invocation surfaces 6 unrelated failures from bun's `mock.module` cross-file leakage; they pass per-file on this branch and on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)