### PR TITLE
docs(runtime): point question-resolution's second consumer at the resolver registry

### DIFF
--- a/assistant/src/runtime/question-resolution.ts
+++ b/assistant/src/runtime/question-resolution.ts
@@ -6,15 +6,16 @@
  *
  *  - `POST /v1/question-response` — an app/web client submits the user's
  *    batched selection (see `routes/question-routes.ts`).
- *  - the channel-native question wizard — a Telegram tap or free-text reply
- *    accumulates answers and submits the completed batch (see
- *    `channel-questions.ts`).
+ *  - the guardian-request pipeline — a channel option tap, request-code reply,
+ *    or bare-text answer routes through the guardian reply router to the
+ *    `pending_question` resolver, which builds the submission (see
+ *    `approvals/guardian-request-resolvers.ts`).
  *
  * Both funnel through {@link resolvePendingQuestion} so the validate → consume
  * → `rpcResolve` sequence has a single implementation. The helper is
  * transport-agnostic: it returns a discriminated outcome rather than throwing
  * route errors, so each caller maps the outcome to its own surface (HTTP status
- * codes for the route; silent state cleanup for a stale channel tap).
+ * codes for the route; a resolver failure reason for the pipeline).
  */
 
 import {


### PR DESCRIPTION
## Prompt / plan

Two-line comment-drift fix, follow-up to #39228. The header of `assistant/src/runtime/question-resolution.ts` still described its second consumer as "the channel-native question wizard (see `channel-questions.ts`)" — a module from the superseded design (#39147) that does not exist. The actual second consumer is the guardian-request pipeline: channel taps / codes / bare text route through the reply router to the `pending_question` resolver (`approvals/guardian-request-resolvers.ts`), which builds the submission. Per the repo's comment rule, headers must describe current state.

No code changes — comment only.

## Test plan

Comment-only change: pre-commit typecheck + lint + prettier green; `question-resolution.test.ts` passes unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiUW6fdeCuTGU7vJWu8Y5U

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiUW6fdeCuTGU7vJWu8Y5U)_