### PR TITLE
feat(web): rebuild the Pro package-switch confirmation to the new design

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.stories.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.stories.tsx
@@ -1,0 +1,151 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
+import type { ProPackage } from "@/domains/settings/billing/package-types";
+import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+
+const STORY_ASSISTANT_ID = "story-assistant";
+
+// The header tile draws the assistant avatar through `useAssistantAvatar`,
+// which has no daemon to fetch from here. Seeding the cache under both
+// manifest-gate values renders the creature instead of an empty square.
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+});
+for (const supportsManifest of [false, true]) {
+  queryClient.setQueryData(
+    [...avatarQueryKey(STORY_ASSISTANT_ID), supportsManifest],
+    { components: BUNDLED_COMPONENTS, traits: null, customImageUrl: null },
+  );
+}
+
+/** The Mighty catalog shape; override fields for another tier. */
+function proPackage(overrides: Partial<ProPackage> = {}): ProPackage {
+  return {
+    key: "mighty",
+    name: "Mighty",
+    description: "Small machine, 15 GB of storage, and $25 in monthly credits.",
+    version: 1,
+    machine_tier: null,
+    storage_tier: "s",
+    credit_tier: "credits_25",
+    machine_size: null,
+    storage_gib: 15,
+    credits_usd: 25,
+    include_platform_fee: true,
+    base_price_cents: 2000,
+    machine_price_cents: 0,
+    storage_price_cents: 500,
+    credit_price_cents: 2500,
+    total_price_cents: 5000,
+    ...overrides,
+  };
+}
+
+const SUPER_PACKAGE = proPackage({
+  key: "super",
+  name: "Super",
+  description: "Medium machine, 30 GB of storage, and $45 in monthly credits.",
+  machine_size: "medium",
+  storage_gib: 30,
+  credits_usd: 45,
+  total_price_cents: 12400,
+});
+
+const meta: Meta<typeof PackageSwitchConfirmModal> = {
+  title: "Settings/Billing/PackageSwitchConfirmModal",
+  component: PackageSwitchConfirmModal,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    relation: {
+      control: "select",
+      options: ["upgrade", "downgrade", "switch"],
+    },
+    pending: { control: "boolean" },
+  },
+  args: {
+    open: true,
+    pending: false,
+    onCancel: () => {},
+    onConfirm: () => {},
+  },
+  decorators: [
+    (Story) => {
+      // The avatar tile resolves its assistant from the active id, and holds an
+      // empty square while that is null.
+      useResolvedAssistantsStore.setState({
+        activeAssistantId: STORY_ASSISTANT_ID,
+      });
+      return (
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof PackageSwitchConfirmModal>;
+
+/** Moving up the catalog: the prorated difference is charged today. */
+export const Upgrade: Story = {
+  args: {
+    relation: "upgrade",
+    packageName: "Mighty",
+    targetPackage: proPackage(),
+  },
+};
+
+/**
+ * Moving down: the confirm turns destructive, names the target explicitly, and
+ * the no-refund safeguard note sits below the checklist.
+ */
+export const Downgrade: Story = {
+  args: {
+    relation: "downgrade",
+    packageName: "Mighty",
+    targetPackage: proPackage(),
+  },
+};
+
+/**
+ * A Custom sub's tiers can diverge from any stock package, so the switch has no
+ * knowable direction — neutral copy, non-destructive confirm. Super carries an
+ * extra feature row, so the checklist runs to four.
+ */
+export const NeutralSwitch: Story = {
+  args: {
+    relation: "switch",
+    packageName: "Super",
+    targetPackage: SUPER_PACKAGE,
+  },
+};
+
+/** A `change-package` call is in flight: both actions are disabled. */
+export const Pending: Story = {
+  args: {
+    relation: "upgrade",
+    packageName: "Super",
+    targetPackage: SUPER_PACKAGE,
+    pending: true,
+  },
+};
+
+/**
+ * No target package, so the body collapses to header + actions. Both call
+ * sites gate `open` on a resolved target and derive `packageName` from it, so
+ * the bare "Upgrade to" title this state produces stays off-screen.
+ */
+export const NoTargetPackage: Story = {
+  args: {
+    relation: "upgrade",
+    packageName: "",
+    targetPackage: null,
+  },
+};

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Tests for `PackageSwitchConfirmModal`. The dialog is pure layout over three
+ * pure helpers, so the harness only has to mock the assistant-avatar query at
+ * its module boundary — the header tile pulls it in transitively and there is
+ * no active assistant to resolve in a test.
+ *
+ * Radix portals the dialog, so queries come off `render`'s `baseElement`
+ * (document.body), not the mount container.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import type { ComponentProps } from "react";
+
+import type { ProPackage } from "@/generated/api/types.gen";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    components: null,
+    traits: null,
+    customImageUrl: null,
+    isLoading: false,
+    invalidate: () => {},
+  }),
+}));
+
+const { PackageSwitchConfirmModal } =
+  await import("./package-switch-confirm-modal");
+
+const UPGRADE_CAPTION = "Billed monthly · prorated difference charged today";
+const SWITCH_CAPTION =
+  "Billed monthly · prorated difference charged today or credited next invoice";
+const DOWNGRADE_CAPTION =
+  "Billed monthly · prorated credit on your next invoice";
+const DOWNGRADE_NOTE =
+  "Your machine downsizes now and your storage stays. No refund.";
+
+/** The Mighty catalog shape; override fields for another tier. */
+function proPackage(overrides: Partial<ProPackage> = {}): ProPackage {
+  return {
+    key: "mighty",
+    name: "Mighty",
+    description: "Small machine, 15 GB of storage, and $25 in monthly credits.",
+    version: 1,
+    machine_tier: null,
+    storage_tier: "s",
+    credit_tier: "credits_25",
+    machine_size: null,
+    storage_gib: 15,
+    credits_usd: 25,
+    include_platform_fee: true,
+    base_price_cents: 2000,
+    machine_price_cents: 0,
+    storage_price_cents: 500,
+    credit_price_cents: 2500,
+    total_price_cents: 5000,
+    ...overrides,
+  };
+}
+
+let onCancel = mock(() => {});
+let onConfirm = mock(() => {});
+
+function renderModal(
+  props: Partial<ComponentProps<typeof PackageSwitchConfirmModal>> = {},
+) {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <PackageSwitchConfirmModal
+        open
+        relation="upgrade"
+        packageName="Mighty"
+        targetPackage={proPackage()}
+        pending={false}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  onCancel = mock(() => {});
+  onConfirm = mock(() => {});
+  // No resolved assistant: the tile holds its square and draws nothing, which
+  // keeps the avatar compositor out of the run.
+  useResolvedAssistantsStore.setState({ activeAssistantId: null });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PackageSwitchConfirmModal", () => {
+  test("an upgrade prices the target package and lists what it includes", () => {
+    const { getByText, getByRole, getByTestId } = renderModal();
+
+    getByRole("heading", { name: "Upgrade to Mighty" });
+    // The tagline is the dialog's description, so it also carries the
+    // `aria-describedby` the old title-only dialog never had.
+    const describedBy = getByRole("dialog").getAttribute("aria-describedby");
+    expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
+      "More capacity for consistent use.",
+    );
+    getByText("$50/mo");
+    getByText(UPGRADE_CAPTION);
+    getByText("The plan includes");
+    getByText("Small machine (2 vCPU, 3 GiB)");
+    getByText("15 GB storage");
+    getByText("$25 of bundled credits");
+    expect(getByTestId("confirm-package-switch-button").textContent).toBe(
+      "Continue",
+    );
+  });
+
+  test("a downgrade keeps the explicit destructive label and the no-refund note", () => {
+    const { getByText, getByRole, getByTestId } = renderModal({
+      relation: "downgrade",
+    });
+
+    getByRole("heading", { name: "Downgrade to Mighty" });
+    getByText(DOWNGRADE_CAPTION);
+    getByText(DOWNGRADE_NOTE);
+    expect(getByTestId("confirm-package-switch-button").textContent).toBe(
+      "Downgrade to Mighty",
+    );
+  });
+
+  test("a direction-neutral switch names both proration outcomes", () => {
+    const { getByText, getByRole, getByTestId, queryByText } = renderModal({
+      relation: "switch",
+    });
+
+    getByRole("heading", { name: "Switch to Mighty" });
+    getByText(SWITCH_CAPTION);
+    expect(queryByText(DOWNGRADE_NOTE)).toBeNull();
+    expect(getByTestId("confirm-package-switch-button").textContent).toBe(
+      "Continue",
+    );
+  });
+
+  test("tier copy with extra features appends them after the derived rows", () => {
+    const { getByText, getAllByRole } = renderModal({
+      packageName: "Super",
+      targetPackage: proPackage({
+        key: "super",
+        name: "Super",
+        machine_size: "medium",
+        storage_gib: 30,
+        credits_usd: 45,
+        total_price_cents: 10000,
+      }),
+    });
+
+    getByText("$100/mo");
+    expect(getAllByRole("listitem").map((row) => row.textContent)).toEqual([
+      "Medium machine (2.5 vCPU, 5 GiB)",
+      "30 GB storage",
+      "$45 of bundled credits",
+      "Assistant email and subdomain",
+    ]);
+  });
+
+  test("an unresolved target renders the header and the actions only", () => {
+    const { getByText, getByRole, getByTestId, queryByText } = renderModal({
+      packageName: "",
+      targetPackage: null,
+    });
+
+    getByRole("heading", { name: "Upgrade to" });
+    getByTestId("assistant-avatar-tile");
+    expect(queryByText("The plan includes")).toBeNull();
+    expect(queryByText(UPGRADE_CAPTION)).toBeNull();
+    expect(queryByText("15 GB storage")).toBeNull();
+    getByTestId("confirm-package-switch-button");
+    getByText("Cancel");
+  });
+
+  test("a pending change disables both actions", () => {
+    const { getByTestId, getByRole } = renderModal({ pending: true });
+
+    expect(
+      (getByTestId("confirm-package-switch-button") as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (getByRole("button", { name: "Cancel" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  test("the actions call back to the parent, which owns the mutation", () => {
+    const { getByTestId, getByRole } = renderModal();
+
+    fireEvent.click(getByTestId("confirm-package-switch-button"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(0);
+
+    fireEvent.click(getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.test.tsx
@@ -98,8 +98,8 @@ describe("PackageSwitchConfirmModal", () => {
     const { getByText, getByRole, getByTestId } = renderModal();
 
     getByRole("heading", { name: "Upgrade to Mighty" });
-    // The tagline is the dialog's description, so it also carries the
-    // `aria-describedby` the old title-only dialog never had.
+    // The tagline renders as the dialog's description, so it is what
+    // `aria-describedby` points at.
     const describedBy = getByRole("dialog").getAttribute("aria-describedby");
     expect(document.getElementById(describedBy ?? "")?.textContent).toBe(
       "More capacity for consistent use.",

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
@@ -94,7 +94,7 @@ export function PackageSwitchConfirmModal({
         </Modal.Header>
         {details ? (
           <Modal.Body className="flex flex-col gap-4 p-0">
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-0.5">
               <Typography
                 as="p"
                 variant="title-large"
@@ -102,10 +102,11 @@ export function PackageSwitchConfirmModal({
               >
                 {details.price}
               </Typography>
+              {/* Explicit leading: this caption wraps on a neutral switch, and the variant's line-height of 1 collides the lines. */}
               <Typography
                 as="p"
                 variant="label-medium-default"
-                className="text-[var(--content-tertiary)]"
+                className="leading-[15px] text-[var(--content-tertiary)]"
               >
                 {copy.priceCaption}
               </Typography>

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
@@ -94,7 +94,7 @@ export function PackageSwitchConfirmModal({
         </Modal.Header>
         {details ? (
           <Modal.Body className="flex flex-col gap-4 p-0">
-            <div>
+            <div className="flex flex-col gap-1">
               <Typography
                 as="p"
                 variant="title-large"

--- a/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/package-switch-confirm-modal.tsx
@@ -1,7 +1,14 @@
-import { AlertTriangle } from "lucide-react";
+import { CircleCheck } from "lucide-react";
 
-import type { SwitchRelation } from "@/domains/settings/billing/package-types";
-import { downgradeLabel } from "@/domains/settings/billing/plans/plans-copy";
+import { AssistantAvatarTile } from "@/domains/settings/billing/assistant-avatar-tile";
+import type {
+  ProPackage,
+  SwitchRelation,
+} from "@/domains/settings/billing/package-types";
+import { packageHighlights } from "@/domains/settings/billing/plan-spec";
+import { packageSwitchCopy } from "@/domains/settings/billing/plans/package-switch-copy";
+import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
+import { formatMonthly } from "@/domains/settings/components/tier-pricing";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -16,50 +23,52 @@ export interface PackageSwitchConfirmModalProps {
   relation: SwitchRelation;
   /** Target package display name, e.g. "Mighty". */
   packageName: string;
+  /**
+   * Target package from the live catalog — drives the price line and the
+   * checklist. Null while the takeover has not resolved a target; the modal
+   * then renders header + actions only.
+   */
+  targetPackage: ProPackage | null;
   /** A change-package call is in flight — disable the actions. */
   pending: boolean;
   onCancel: () => void;
   onConfirm: () => void;
 }
 
-// Package switches apply immediately (no period-end deferral): an upgrade
-// charges the prorated difference now; a downgrade resizes the machine now and
-// nets a prorated credit against the next invoice — storage stays, no cash
-// refund. The copy must not imply the higher tier is kept until month end.
-const DOWNGRADE_NOTE =
-  "Your machine downsizes now and your storage stays. No refund — a prorated credit applies to your next invoice.";
-const UPGRADE_NOTE = "You'll be charged the prorated difference now.";
-// A Custom sub's direction is unknown, so the copy stays neutral: the change is
-// immediate and the prorated difference settles either way.
-const SWITCH_NOTE =
-  "Your plan changes now. Any prorated difference is charged now or credited to your next invoice.";
-
 /**
- * Reconfirm dialog for a one-click Pro package switch from the plans takeover.
- * A downgrade gets the AlertTriangle + danger confirm; an upgrade and a
- * direction-neutral switch get a lighter primary confirm. Layout-only — the
- * parent owns the mutation.
+ * Reconfirm dialog for a one-click Pro package switch. A downgrade gets the
+ * danger confirm plus its safeguard note; an upgrade and a direction-neutral
+ * switch get a lighter primary confirm. Layout-only for the mutation — the
+ * parent owns `change-package` — but it does read the assistant avatar through
+ * `AssistantAvatarTile`, so both call sites get the header glyph without
+ * duplicating that wiring.
  */
 export function PackageSwitchConfirmModal({
   open,
   relation,
   packageName,
+  targetPackage,
   pending,
   onCancel,
   onConfirm,
 }: PackageSwitchConfirmModalProps) {
-  const isDowngrade = relation === "downgrade";
-  const isSwitch = relation === "switch";
-  const title = isDowngrade
-    ? `Downgrade to ${packageName}?`
-    : isSwitch
-      ? `Switch to ${packageName}?`
-      : `Upgrade to ${packageName}?`;
-  const note = isDowngrade
-    ? DOWNGRADE_NOTE
-    : isSwitch
-      ? SWITCH_NOTE
-      : UPGRADE_NOTE;
+  const copy = packageSwitchCopy(
+    relation,
+    packageName,
+    targetPackage?.key ?? null,
+  );
+  // Everything below the header describes one concrete package, so it all
+  // resolves — or doesn't — together.
+  const details = targetPackage
+    ? {
+        price: formatMonthly(targetPackage.total_price_cents),
+        highlights: packageHighlights(
+          targetPackage,
+          getPlanTierCopy(targetPackage.key)?.extraFeatures ?? [],
+        ),
+      }
+    : null;
+
   return (
     <Modal.Root
       open={open}
@@ -69,34 +78,91 @@ export function PackageSwitchConfirmModal({
         }
       }}
     >
-      <Modal.Content size="md" hideCloseButton>
-        <Modal.Header>
-          <Modal.Title icon={isDowngrade ? AlertTriangle : undefined}>
-            {title}
-          </Modal.Title>
+      <Modal.Content size="sm" hideCloseButton className="gap-6 p-4">
+        <Modal.Header className="flex-row items-center gap-3 p-0">
+          <AssistantAvatarTile />
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <Modal.Title className="text-title-small text-[var(--content-emphasised)]">
+              {copy.title}
+            </Modal.Title>
+            {copy.subtitle ? (
+              <Modal.Description className="mt-0 text-body-medium-default text-[var(--content-tertiary)]">
+                {copy.subtitle}
+              </Modal.Description>
+            ) : null}
+          </div>
         </Modal.Header>
-        <Modal.Body>
-          <Typography
-            as="p"
-            variant="body-medium-default"
-            className="text-(--content-secondary)"
-          >
-            {note}
-          </Typography>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button variant="outlined" onClick={onCancel} disabled={pending}>
-            Cancel
-          </Button>
+        {details ? (
+          <Modal.Body className="flex flex-col gap-4 p-0">
+            <div>
+              <Typography
+                as="p"
+                variant="title-large"
+                className="text-[var(--content-default)]"
+              >
+                {details.price}
+              </Typography>
+              <Typography
+                as="p"
+                variant="label-medium-default"
+                className="text-[var(--content-tertiary)]"
+              >
+                {copy.priceCaption}
+              </Typography>
+            </div>
+            <div className="h-px w-full bg-[var(--border-hover)]" />
+            <Typography
+              as="p"
+              variant="body-small-default"
+              className="text-[var(--content-tertiary)]"
+            >
+              The plan includes
+            </Typography>
+            <ul className="flex flex-col gap-2">
+              {details.highlights.map((row) => (
+                <li key={row} className="flex items-center gap-1.5">
+                  <CircleCheck
+                    className="size-4 shrink-0 text-[var(--system-positive-strong)]"
+                    aria-hidden
+                  />
+                  <Typography
+                    as="span"
+                    variant="body-medium-default"
+                    className="text-[var(--content-default)]"
+                  >
+                    {row}
+                  </Typography>
+                </li>
+              ))}
+            </ul>
+            {copy.note ? (
+              <Typography
+                as="p"
+                variant="body-medium-default"
+                className="text-[var(--content-secondary)]"
+              >
+                {copy.note}
+              </Typography>
+            ) : null}
+          </Modal.Body>
+        ) : null}
+        <Modal.Footer className="flex-col gap-2 p-0">
           <Button
-            variant={isDowngrade ? "danger" : "primary"}
+            fullWidth
+            variant={copy.destructive ? "danger" : "primary"}
             onClick={onConfirm}
             disabled={pending}
             data-testid="confirm-package-switch-button"
           >
-            {isDowngrade
-              ? downgradeLabel(packageName)
-              : `Switch to ${packageName}`}
+            {copy.confirmLabel}
+          </Button>
+          <Button
+            fullWidth
+            variant="ghost"
+            onClick={onCancel}
+            disabled={pending}
+          >
+            Cancel
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -852,9 +852,9 @@ describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
     fireEvent.click(await findByRole("button", { name: "Power Up" }));
 
     // The direction-neutral switch confirm appears (not upgrade/downgrade copy).
-    await findByText("Switch to Mighty?");
+    await findByText("Switch to Mighty");
     await findByText(
-      "Your plan changes now. Any prorated difference is charged now or credited to your next invoice.",
+      "Billed monthly · prorated difference charged today or credited next invoice",
     );
 
     fireEvent.click(await findByTestId("confirm-package-switch-button"));
@@ -874,7 +874,7 @@ describe("PlansPage — Custom Pro subs switch via neutral confirm", () => {
     // The customized sub's own Mighty card is not "current" — its CTA is live.
     fireEvent.click(await findByRole("button", { name: "Power Up" }));
 
-    await findByText("Switch to Mighty?");
+    await findByText("Switch to Mighty");
     fireEvent.click(await findByTestId("confirm-package-switch-button"));
 
     await waitFor(() => expect(changePackageCall).not.toBeNull());

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -217,7 +217,8 @@ export function PlansPage() {
 
   // Pro features lost by downgrading to Free — the confirm dialog lists these.
   const baseFeatureSet = new Set(
-    plansQuery.data?.plans.find((p) => p.id === "base")?.included_features ?? [],
+    plansQuery.data?.plans.find((p) => p.id === "base")?.included_features ??
+      [],
   );
   const freeDowngradeLostFeatures = (proPlan?.included_features ?? []).filter(
     (f) => !baseFeatureSet.has(f),
@@ -575,7 +576,9 @@ export function PlansPage() {
         <CustomPlanRow
           className="mt-6 sm:mt-10"
           onConfigure={handleConfigure}
-          configureDisabled={(isProUser && !currentReady) || billingActionPending}
+          configureDisabled={
+            (isProUser && !currentReady) || billingActionPending
+          }
           isCurrent={showCurrentPlan}
           currentSummary={currentSummary}
         />
@@ -600,6 +603,7 @@ export function PlansPage() {
           open={switchTarget !== null}
           relation={switchRelation}
           packageName={switchTarget?.name ?? ""}
+          targetPackage={switchTarget}
           pending={changePackagePending}
           onCancel={() => setSwitchTarget(null)}
           onConfirm={() => void confirmSwitch()}

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -910,8 +910,10 @@ describe("PlanCard recommended upgrade — change-package", () => {
     // The banner CTA opens a confirm dialog (no immediate mutation). A clean pin
     // keeps the directional upgrade copy.
     fireEvent.click(await findByTestId("recommended-upgrade-button"));
-    await findByText("Upgrade to Super?");
-    await findByText("You'll be charged the prorated difference now.");
+    // Assert on copy unique to the dialog — the promo card behind it already
+    // renders the "Upgrade to Super" heading, so the title alone matches twice.
+    await findByText("Billed monthly · prorated difference charged today");
+    await findByText(PLAN_TIER_COPY.super.tagline);
     expect(changePackageBody).toBeNull();
 
     // Confirming posts the recommended package key to change-package.
@@ -1178,7 +1180,9 @@ describe("PlanCard recommended upgrade — change-package", () => {
       expect(onManage).toHaveBeenCalledTimes(1);
     });
     // No configurator opened, no navigation.
-    expect(document.querySelector("[data-testid='confirm-package-switch-button']")).toBeNull();
+    expect(
+      document.querySelector("[data-testid='confirm-package-switch-button']"),
+    ).toBeNull();
     expect(navigateArgs).toEqual([]);
   });
 

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -361,6 +361,7 @@ function RecommendedUpgrade({
           open={confirmOpen}
           relation={relation}
           packageName={recommended.name}
+          targetPackage={recommended}
           pending={isPending}
           onConfirm={() => void handleConfirmChange()}
           onCancel={() => setConfirmOpen(false)}


### PR DESCRIPTION
## Summary
- Rebuilds `PackageSwitchConfirmModal` to the Figma card: assistant-avatar header with the plan name and tagline, the target package's monthly price with a proration caption, a divider, a catalog-derived "The plan includes" checklist, and stacked full-width Continue/Cancel actions.
- Wires in the three helpers added by PRs 1-3 and deletes the modal's old inline relation-to-copy mapping, so there is a single source for the copy.
- All three relations (upgrade / downgrade / neutral switch) use the new layout; downgrade keeps its danger CTA and the no-refund note.

Part of plan: package-switch-modal-redesign.md (PR 4 of 4)