### PR TITLE
ci(ios): add a build-only PR check for the native shell

### DIFF
--- a/.github/workflows/pr-ios.yaml
+++ b/.github/workflows/pr-ios.yaml
@@ -1,0 +1,71 @@
+name: PR iOS Checks
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened]
+    paths:
+      - 'clients/ios/**'
+      - 'clients/web/capacitor.config.ts'
+      - 'clients/web/package.json'
+      - '.github/workflows/pr-ios.yaml'
+
+concurrency:
+  group: pr-ios-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    # Runner and Xcode match `release-ios.yaml` so this check exercises the
+    # same toolchain that produces TestFlight builds.
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Cache Bun packages
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        working-directory: clients/web
+        run: bun install --frozen-lockfile --filter=@vellumai/web
+
+      - name: Capacitor sync
+        working-directory: clients/web
+        env:
+          # `capacitor.config.ts` derives `server.url` and the Xcode scheme
+          # name from this, so it has to agree with the scheme built below.
+          VELLUM_ENVIRONMENT: dev
+        run: bunx cap sync ios
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        working-directory: clients/ios/App
+        run: xcodegen generate --spec project.yml
+
+      - name: Select Xcode 26.2
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Build (unsigned)
+        working-directory: clients/ios/App
+        # Unsigned so the check needs no repository secrets. Signing and
+        # TestFlight upload stay in `release-ios.yaml`.
+        run: |
+          xcodebuild build \
+            -project App.xcodeproj \
+            -scheme "App Dev" \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-ios.yaml`, a build-only PR check for the Capacitor iOS shell
- Builds the `App Dev` scheme unsigned, so it needs no repository secrets
- Lands ahead of the iOS voice-mode work, which adds substantial Swift and a new widget extension target

Part of plan: first-class-ios-voice-mode.md (PR 2 of 20)