### PR TITLE
fix(backup): the export deadline is five minutes, not the sixty it asks for

### DIFF
--- a/gateway/src/__tests__/backup-worker-export-timeout.test.ts
+++ b/gateway/src/__tests__/backup-worker-export-timeout.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for the export deadline in the backup worker.
+ *
+ * `fetch` resolves as soon as the response headers arrive; the bundle streams
+ * in afterwards. The worker used to clear its abort timer in a `finally` on
+ * that call, which left the download — the part that actually takes an hour on
+ * a large workspace — with no deadline at all. A body that stalled after
+ * headers hung `performBackup` forever, and with it the `snapshotInProgress`
+ * mutex, so every later tick logged "snapshot already in progress" until the
+ * gateway was restarted.
+ *
+ * These drive a response whose headers arrive normally and whose body never
+ * produces a chunk, and assert the run gives up and lets go of the mutex.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let localDir: string;
+
+/**
+ * The failure this file guards against is a hang, which a bare `await` would
+ * inherit — a regression would stall the runner instead of reporting. Race
+ * every run against a deadline so it fails fast and says why.
+ */
+function withDeadline<T>(work: Promise<T>, label: string): Promise<T> {
+  return Promise.race([
+    work,
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`${label} did not settle within 10s`)),
+        10_000,
+      ),
+    ),
+  ]);
+}
+
+/** A response that sends headers immediately and then never sends a chunk. */
+function stalledBodyResponse(): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      // One chunk so the transfer visibly begins, then silence forever.
+      controller.enqueue(new Uint8Array([0x1f, 0x8b]));
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
+beforeEach(async () => {
+  localDir = await mkdtemp(join(tmpdir(), "backup-worker-timeout-"));
+
+  mock.module("../config-file-utils.js", () => ({
+    readConfigFileOrEmpty: () => ({
+      backup: {
+        enabled: true,
+        intervalHours: 6,
+        retention: 3,
+        // Offsite off keeps the run local: no encryption key is needed, so
+        // nothing touches the gateway security dir.
+        offsite: { enabled: false },
+        localDirectory: localDir,
+      },
+    }),
+  }));
+
+  mock.module("../auth/token-exchange.js", () => ({
+    mintServiceToken: () => "test-service-token",
+  }));
+
+  mock.module("../fetch.js", () => ({
+    fetchImpl: async (_input: string | URL | Request, init?: RequestInit) => {
+      init?.signal?.throwIfAborted();
+      return stalledBodyResponse();
+    },
+  }));
+});
+
+afterEach(async () => {
+  mock.restore();
+  await rm(localDir, { recursive: true, force: true });
+});
+
+describe("backup export deadline", () => {
+  test("a body that stalls after headers aborts instead of hanging", async () => {
+    const { createSnapshotNow } = await import("../backup/backup-worker.js");
+
+    const startedAt = Date.now();
+    const run = withDeadline(
+      createSnapshotNow({
+        assistantRuntimeBaseUrl: "http://127.0.0.1:7821",
+        exportTimeoutMs: 300,
+      }),
+      "stalled export",
+    );
+
+    await expect(run).rejects.toThrow(/aborted|abort/i);
+    // The deadline fired rather than the call returning on its own; the guard
+    // is that this resolved at all, well inside the real 60-minute budget.
+    expect(Date.now() - startedAt).toBeLessThan(15_000);
+  }, 30_000);
+
+  test("the concurrency mutex is released after a stalled transfer", async () => {
+    const { createSnapshotNow } = await import("../backup/backup-worker.js");
+
+    const deps = {
+      assistantRuntimeBaseUrl: "http://127.0.0.1:7821",
+      exportTimeoutMs: 300,
+    };
+
+    await expect(
+      withDeadline(createSnapshotNow(deps), "first stalled export"),
+    ).rejects.toThrow();
+
+    // A wedged mutex surfaces here: the second run is refused outright rather
+    // than getting as far as its own stalled transfer.
+    const secondFailure = await withDeadline(
+      createSnapshotNow(deps),
+      "second stalled export",
+    ).then(
+      () => null,
+      (err: unknown) => (err instanceof Error ? err.message : String(err)),
+    );
+
+    expect(secondFailure).not.toBeNull();
+    expect(secondFailure).not.toContain("already in progress");
+  }, 30_000);
+});

--- a/gateway/src/__tests__/backup-worker-export-timeout.test.ts
+++ b/gateway/src/__tests__/backup-worker-export-timeout.test.ts
@@ -37,6 +37,12 @@ function withDeadline<T>(work: Promise<T>, label: string): Promise<T> {
   ]);
 }
 
+/**
+ * Records the init the worker passed to fetch, so a test can assert on the
+ * deadline options rather than waiting one out.
+ */
+let lastInit: (RequestInit & { timeout?: boolean | number }) | undefined;
+
 /** A response that sends headers immediately and then never sends a chunk. */
 function stalledBodyResponse(): Response {
   const body = new ReadableStream<Uint8Array>({
@@ -70,7 +76,11 @@ beforeEach(async () => {
   }));
 
   mock.module("../fetch.js", () => ({
-    fetchImpl: async (_input: string | URL | Request, init?: RequestInit) => {
+    fetchImpl: async (
+      _input: string | URL | Request,
+      init?: RequestInit & { timeout?: boolean | number },
+    ) => {
+      lastInit = init;
       init?.signal?.throwIfAborted();
       return stalledBodyResponse();
     },
@@ -125,5 +135,30 @@ describe("backup export deadline", () => {
 
     expect(secondFailure).not.toBeNull();
     expect(secondFailure).not.toContain("already in progress");
+  }, 30_000);
+});
+
+describe("backup export request options", () => {
+  test("opts out of the runtime's default request timeout", async () => {
+    // The daemon builds the entire archive before it can write a response
+    // header, so on a large workspace no header arrives for many minutes. The
+    // runtime's 300-second default would kill that request — and it is NOT
+    // extended by the abort signal below, so the explicit budget alone does
+    // not save it. This is the option that makes the budget real.
+    const { createSnapshotNow } = await import("../backup/backup-worker.js");
+
+    await expect(
+      withDeadline(
+        createSnapshotNow({
+          assistantRuntimeBaseUrl: "http://127.0.0.1:7821",
+          exportTimeoutMs: 300,
+        }),
+        "stalled export",
+      ),
+    ).rejects.toThrow();
+
+    expect(lastInit?.timeout).toBe(false);
+    // The caller's own deadline is still what governs.
+    expect(lastInit?.signal).toBeInstanceOf(AbortSignal);
   }, 30_000);
 });

--- a/gateway/src/backup/backup-worker.ts
+++ b/gateway/src/backup/backup-worker.ts
@@ -30,7 +30,10 @@ import { getGatewaySecurityDir } from "../paths.js";
 import { ensureBackupKey } from "./backup-key.js";
 import type { SnapshotEntry } from "./list-snapshots.js";
 import { pruneLocalSnapshots, writeLocalSnapshot } from "./local-writer.js";
-import type { BackupDestination, OffsiteWriteResult } from "./offsite-writer.js";
+import type {
+  BackupDestination,
+  OffsiteWriteResult,
+} from "./offsite-writer.js";
 import {
   pruneOffsiteSnapshotsInAll,
   writeOffsiteSnapshotToAll,
@@ -89,8 +92,7 @@ function readBackupConfig(): BackupConfig {
   const enabled = backup.enabled === true;
   const intervalHours =
     typeof backup.intervalHours === "number" ? backup.intervalHours : 6;
-  const retention =
-    typeof backup.retention === "number" ? backup.retention : 3;
+  const retention = typeof backup.retention === "number" ? backup.retention : 3;
 
   const offsiteRaw = (backup.offsite ?? {}) as Record<string, unknown>;
   const offsiteEnabled = offsiteRaw.enabled !== false;
@@ -99,7 +101,9 @@ function readBackupConfig(): BackupConfig {
     destinations = offsiteRaw.destinations
       .filter(
         (d): d is { path: string; encrypt?: boolean } =>
-          d && typeof d === "object" && typeof (d as Record<string, unknown>).path === "string",
+          d &&
+          typeof d === "object" &&
+          typeof (d as Record<string, unknown>).path === "string",
       )
       .map((d) => ({
         path: d.path,
@@ -158,6 +162,11 @@ export interface BackupRunResult {
 interface BackupDeps {
   /** Base URL of the assistant daemon (e.g. http://localhost:7821). */
   assistantRuntimeBaseUrl: string;
+  /**
+   * Deadline covering the export request and its body transfer. Defaults to
+   * `EXPORT_TIMEOUT_MS`; tests shorten it to exercise a stalled transfer.
+   */
+  exportTimeoutMs?: number;
 }
 
 /**
@@ -186,14 +195,26 @@ async function performBackup(
     ? await ensureBackupKey(getBackupKeyPath())
     : null;
 
-  // Call the daemon's export endpoint to get a plaintext vbundle
+  // Call the daemon's export endpoint to get a plaintext vbundle.
+  //
+  // The deadline has to cover the body, not just the handshake: `fetch`
+  // resolves as soon as the response headers land, and the bundle streams in
+  // afterwards. Clearing the timer on that resolution leaves the download
+  // undeadlined, so a body that stalls mid-transfer hangs `performBackup`
+  // forever — and with it the `snapshotInProgress` mutex, which only releases
+  // in this function's caller. Every subsequent tick then logs "snapshot
+  // already in progress" until the gateway restarts.
   const serviceToken = mintServiceToken();
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), EXPORT_TIMEOUT_MS);
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    deps.exportTimeoutMs ?? EXPORT_TIMEOUT_MS,
+  );
 
-  let response: Response;
+  // Stream the response body to a temp file
+  const tempPath = join(tmpdir(), `vellum-backup-${randomUUID()}.vbundle`);
   try {
-    response = await fetchImpl(
+    const response = await fetchImpl(
       `${deps.assistantRuntimeBaseUrl}/v1/migrations/export`,
       {
         method: "POST",
@@ -205,20 +226,14 @@ async function performBackup(
         signal: controller.signal,
       },
     );
-  } finally {
-    clearTimeout(timeoutId);
-  }
 
-  if (!response.ok) {
-    const body = await response.text().catch(() => "");
-    throw new Error(
-      `Daemon export failed (${response.status}): ${body.slice(0, 500)}`,
-    );
-  }
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `Daemon export failed (${response.status}): ${body.slice(0, 500)}`,
+      );
+    }
 
-  // Stream the response body to a temp file
-  const tempPath = join(tmpdir(), `vellum-backup-${randomUUID()}.vbundle`);
-  try {
     const readableBody = response.body;
     if (!readableBody) {
       throw new Error("Daemon export returned an empty response body");
@@ -227,7 +242,14 @@ async function performBackup(
     const writeStream = createWriteStream(tempPath);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Bun's ReadableStream type doesn't match Node's web ReadableStream
     const nodeReadable = Readable.fromWeb(readableBody as any);
-    await pipeline(nodeReadable, writeStream);
+    // Aborting the controller tears the body stream down; passing the signal
+    // to the pipeline makes that abort reject here rather than leaving the
+    // write half waiting on a source that will never produce another chunk.
+    await pipeline(nodeReadable, writeStream, { signal: controller.signal });
+
+    // The transfer is done — everything past this point is local work under
+    // its own failure handling, so the export deadline has served its purpose.
+    clearTimeout(timeoutId);
 
     // Write the plaintext archive to the local backup directory
     const localResult = await writeLocalSnapshot(tempPath, localDir, now);
@@ -269,6 +291,10 @@ async function performBackup(
       // best-effort
     }
     throw err;
+  } finally {
+    // No-op once the transfer cleared it; the safety net for every path that
+    // leaves before that point.
+    clearTimeout(timeoutId);
   }
 }
 

--- a/gateway/src/backup/backup-worker.ts
+++ b/gateway/src/backup/backup-worker.ts
@@ -197,13 +197,22 @@ async function performBackup(
 
   // Call the daemon's export endpoint to get a plaintext vbundle.
   //
-  // The deadline has to cover the body, not just the handshake: `fetch`
-  // resolves as soon as the response headers land, and the bundle streams in
-  // afterwards. Clearing the timer on that resolution leaves the download
-  // undeadlined, so a body that stalls mid-transfer hangs `performBackup`
-  // forever — and with it the `snapshotInProgress` mutex, which only releases
-  // in this function's caller. Every subsequent tick then logs "snapshot
-  // already in progress" until the gateway restarts.
+  // Two separate deadlines have to be right here.
+  //
+  // `timeout: false` disables the runtime's own 300-second default. The daemon
+  // builds the whole archive before it can write a single response header, and
+  // on a large workspace that build runs for many minutes — so the default
+  // fires before any header arrives and the export fails with `TimeoutError`.
+  // Supplying `signal` is not enough: the runtime's default is not extended by
+  // a caller's abort signal, so without this the 60-minute budget below is
+  // silently capped at five.
+  //
+  // The abort deadline then has to cover the body, not just the handshake:
+  // `fetch` resolves as soon as the response headers land, and the bundle
+  // streams in afterwards. Clearing the timer on that resolution would leave
+  // the download undeadlined, so a body stalling mid-transfer would hang
+  // `performBackup` forever — and with it the `snapshotInProgress` mutex,
+  // which only releases in this function's caller.
   const serviceToken = mintServiceToken();
   const controller = new AbortController();
   const timeoutId = setTimeout(
@@ -224,6 +233,7 @@ async function performBackup(
         },
         body: JSON.stringify({ description: "Gateway backup worker" }),
         signal: controller.signal,
+        timeout: false,
       },
     );
 

--- a/gateway/src/fetch.ts
+++ b/gateway/src/fetch.ts
@@ -5,9 +5,22 @@
  * via this module allows tests to use mock.module() for deterministic,
  * cross-platform interception.
  */
+/**
+ * Request options plus the runtime's own extensions.
+ *
+ * `timeout` is not part of the Fetch standard. The runtime applies a 300-second
+ * default to every request and, critically, an `AbortSignal` supplied by the
+ * caller does NOT extend it — a request carrying a 60-minute abort deadline
+ * still dies at 300 seconds with `TimeoutError`. Setting `timeout: false` hands
+ * deadline control back to the caller's signal.
+ */
+export interface FetchInit extends RequestInit {
+  timeout?: boolean | number;
+}
+
 export function fetchImpl(
   input: string | URL | Request,
-  init?: RequestInit,
+  init?: FetchInit,
 ): Promise<Response> {
   return globalThis.fetch(input, init);
 }


### PR DESCRIPTION
Backups of a large workspace fail before a single byte moves. Two deadline bugs in the same function, both in the gateway.

Split out of #39225 so it can land on its own — it is the change that actually fixes the reported failure.

## 1. The 60-minute budget is silently five minutes

`performBackup` sets a 60-minute `AbortController` for the daemon export and assumes that is the deadline. It is not. The runtime applies its own 300-second default to every `fetch`, and **a caller's `AbortSignal` does not extend it**. Measured on Bun 1.3.11 against a server that withholds response headers:

| Request | Outcome |
| --- | --- |
| plain `fetch` | **FAILED after 300 s** — `TimeoutError`, no JS stack |
| `signal: AbortSignal.timeout(60min)` | **FAILED after 300 s** — `TimeoutError`, no JS stack |
| `timeout: false` | **RESOLVED after 330 s** |

The middle row is the bug: supplying the signal does not buy the time it claims to.

**Why that fails the export rather than just shortening it.** The daemon builds the entire archive before its handler returns, and `http-adapter.ts:123` awaits the handler before constructing the `Response` — so no response header can be written until the build finishes. A build longer than five minutes never sends one. Observed on a 15.5 GB workspace: a ~415-second build against a client that gave up around 250 seconds, with exactly the error signature above.

Fix: `timeout: false`, so the `AbortController` is once again the only deadline. Typed on the fetch shim (`FetchInit`) rather than cast at the call site.

## 2. The deadline stopped at the headers

`clearTimeout` sat in a `finally` on the `fetch` call — and `fetch` resolves on headers, not on the body. So the timer was cancelled before any of the bundle had been read, leaving the download undeadlined. A body that stalled mid-transfer hung `performBackup` forever, and with it the `snapshotInProgress` mutex, which only releases in the caller. Every later tick then logged "snapshot already in progress" until the gateway restarted.

Fix: move the response handling inside the deadline's scope, pass the signal to the `pipeline` so a fired deadline tears the transfer down instead of leaving the write half waiting, and clear the timer once on the way out.

The two compose: before this, even the stall-after-headers path was capped at 300 s by bug 1.

## Test plan

`gateway/src/__tests__/backup-worker-export-timeout.test.ts` (3):

- a body that stalls after headers aborts instead of hanging
- the concurrency mutex is released after a stalled transfer
- the export request opts out of the runtime's default timeout, and still carries its own signal

Verified the tests discriminate: against the previous code they **hang past 120 s** — the wedge, reproduced — and settle in ~1 s against this one. They race an internal deadline so a regression fails fast rather than stalling CI.

`bunx tsc --noEmit` and `eslint` clean.

### Reviewer notes

- `BackupDeps` gains an optional `exportTimeoutMs` purely so a test can drive a stalled transfer without waiting out the real 60-minute budget.
- `timeout` is not part of the Fetch standard, so `fetch.ts` declares a `FetchInit` extending `RequestInit`. No cast.
- Removing the 300-second default means a genuinely hung daemon is now bounded only by the 60-minute `AbortController` — which is the intent, and the mutex releases on abort either way.
- This does **not** make large exports fast, and it does not change that headers wait on the whole build. It makes the client wait as long as it already claimed it would. The durable fix is to stop gating response headers on build completion — tracked separately.