### PR TITLE
feat(web): add the capability-probed native voice bridge scaffold

### DIFF
--- a/clients/web/src/runtime/native-voice.test.ts
+++ b/clients/web/src/runtime/native-voice.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, mock, test } from "bun:test";
+
+let onNativeIOS = false;
+
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeIOS: () => onNativeIOS,
+}));
+
+import { callNativeVoice } from "@/runtime/native-voice";
+
+// ---------------------------------------------------------------------------
+// `callNativeVoice` is the skew-safe seam every native voice bridge call goes
+// through. The iOS shell ships through App Store review while this bundle
+// deploys continuously (`clients/ios/README.md` § "Web content delivery"), so
+// an arbitrarily old shell can host this bundle and the plugin may simply not
+// be there. The contract these tests pin: the helper never throws and never
+// rejects, so a missing bridge degrades to a working voice session.
+// ---------------------------------------------------------------------------
+
+describe("callNativeVoice", () => {
+  test("returns the fallback off-native without invoking the bridge", async () => {
+    onNativeIOS = false;
+    const invoke = mock(async () => "native");
+
+    expect(await callNativeVoice(invoke, "fallback")).toBe("fallback");
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  test("returns the invoke result on native iOS", async () => {
+    onNativeIOS = true;
+    const invoke = mock(async () => "native");
+
+    expect(await callNativeVoice(invoke, "fallback")).toBe("native");
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns the fallback when the bridge call rejects", async () => {
+    onNativeIOS = true;
+    // The shape of an older shell missing the plugin entirely.
+    const invoke = mock(async () => {
+      throw new Error("VoiceAudioSession does not have web implementation.");
+    });
+
+    expect(await callNativeVoice(invoke, "fallback")).toBe("fallback");
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  test("never rethrows, for a synchronous throw or a non-Error rejection", async () => {
+    onNativeIOS = true;
+
+    expect(
+      await callNativeVoice(() => {
+        throw new Error("synchronous bridge failure");
+      }, "fallback"),
+    ).toBe("fallback");
+
+    expect(
+      await callNativeVoice(() => Promise.reject("not an Error"), "fallback"),
+    ).toBe("fallback");
+  });
+
+  // A falsy fallback is the common case for these bridges ("did the native
+  // side take over? no"), so guard against it being coerced away by a
+  // `fallback ?? …` or truthiness check on either return path.
+  test("returns a falsy fallback unchanged on both paths", async () => {
+    const failing = async () => {
+      throw new Error("bridge failure");
+    };
+
+    onNativeIOS = false;
+    expect(await callNativeVoice(failing, false)).toBe(false);
+
+    onNativeIOS = true;
+    expect(await callNativeVoice(failing, false)).toBe(false);
+  });
+});

--- a/clients/web/src/runtime/native-voice.ts
+++ b/clients/web/src/runtime/native-voice.ts
@@ -1,0 +1,59 @@
+import { isNativeIOS } from "@/runtime/platform-detection";
+
+/**
+ * Skew-safe seam for every JS → native call that supports iOS voice mode.
+ *
+ * **The skew contract.** The iOS app is a Capacitor `server.url` shell: it
+ * bundles no web assets and navigates `WKWebView` straight at the deployed web
+ * origin at launch (`clients/ios/README.md` § "Web content delivery"). So this
+ * bundle deploys continuously and is live for every iOS user on their next app
+ * load, while the shell that hosts it only changes after an App Store review
+ * cycle. At any moment an arbitrarily old shell can be running an arbitrarily
+ * new bundle. Every call site must therefore assume the native plugin it wants
+ * does not exist, and must degrade to a working voice session without it —
+ * a missing bridge may cost a native flourish (a Live Activity, an audio
+ * session hint) but must never fail, block, or end the session itself.
+ *
+ * Route every native voice call through {@link callNativeVoice}. This module
+ * stays deliberately plugin-agnostic: it neither calls `registerPlugin` nor
+ * imports any `@capacitor/*` package. Plugin registration and the inline
+ * destructuring required by `docs/CAPACITOR.md` § "Capacitor plugins must be
+ * destructured inline" live in each plugin's own module.
+ */
+
+/**
+ * Run a native voice bridge call, resolving to `fallback` whenever the bridge
+ * is unavailable or fails. Never throws and never rejects.
+ *
+ * @param invoke Performs the bridge call. Destructure the plugin inline here —
+ *   never let a plugin Proxy cross an `async` return.
+ * @param fallback Returned off-iOS and on any bridge failure. Must be a value
+ *   the caller can proceed with.
+ */
+export async function callNativeVoice<T>(
+  invoke: () => Promise<T>,
+  fallback: T,
+): Promise<T> {
+  // Platform short-circuit, cited per `docs/CAPACITOR.md` § "Platform
+  // short-circuits in capability detection". The constraint here is not a
+  // broken web API but the absence of a host: these bridges are custom
+  // Capacitor plugins compiled into the iOS shell (`clients/ios/README.md`
+  // § "Web content delivery"), so in a browser, in Electron, or in a
+  // Capacitor Android runtime there is no native side to call and no feature
+  // probe that could find one. Invalidated if an equivalent plugin ever ships
+  // in another shell — widen the gate then.
+  if (!isNativeIOS()) {
+    return fallback;
+  }
+  try {
+    return await invoke();
+  } catch (err) {
+    // Deliberately `console.debug`, not the `captureError` that
+    // `docs/CONVENTIONS.md` § "Manual error reporting from imperative code"
+    // otherwise prescribes: an older App Store shell without the plugin is an
+    // expected state on every web deploy, not a fault, and reporting it would
+    // spam Sentry once per skewed install.
+    console.debug("[native-voice] bridge call unavailable:", err);
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `callNativeVoice`, the skew-safe seam every native voice bridge call routes through
- Returns a caller-supplied fallback off-iOS and on any bridge failure, so an older App Store shell missing a plugin degrades to a working voice session instead of an error
- Inert on merge: nothing calls it yet, so consumer and plugin PRs can land in parallel

Part of plan: first-class-ios-voice-mode.md (PR 4 of 20)