### PR TITLE
feat(web): gate the pricing funnel behind marketing-pricing-takeover

### DIFF
--- a/clients/web/src/components/providers.tsx
+++ b/clients/web/src/components/providers.tsx
@@ -29,6 +29,7 @@ import { ProfileQuickAddProvider } from "@/components/profile-quick-add-provider
 import { useAuthStore, useIsAuthenticated } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { queryRetryDelay, shouldRetryQuery } from "@/utils/query-retry";
+import { requestScopeKey } from "@/utils/request-scope-key";
 
 function createQueryClient(): QueryClient {
   return new QueryClient({
@@ -76,9 +77,11 @@ function ScopeKeyedQueryClientProvider({
   const user = useAuthStore.use.user();
   const currentOrganizationId =
     useOrganizationStore.use.currentOrganizationId();
-  const scopeKey = `${
-    isAuthenticated ? `user:${user?.id ?? "unknown"}` : "anonymous"
-  }:org:${currentOrganizationId ?? "none"}`;
+  const scopeKey = requestScopeKey({
+    isAuthenticated,
+    userId: user?.id,
+    organizationId: currentOrganizationId,
+  });
 
   return (
     <RequestScopedQueryClientProvider key={scopeKey}>

--- a/clients/web/src/components/providers.tsx
+++ b/clients/web/src/components/providers.tsx
@@ -75,6 +75,13 @@ function ScopeKeyedQueryClientProvider({
 }) {
   const isAuthenticated = useIsAuthenticated();
   const user = useAuthStore.use.user();
+  // The organization comes from the store slice, not the request-header
+  // derivation the flag scope uses: a React key is only as current as the
+  // render that computes it, and the header's sessionStorage fallback can be
+  // revoked without moving any subscribed slice. Keying a cache on a value
+  // nothing re-reads would let it outlive the identity it holds; keying on the
+  // slice at worst rotates the cache a beat late, discarding entries rather
+  // than serving them to the wrong identity.
   const currentOrganizationId =
     useOrganizationStore.use.currentOrganizationId();
   const scopeKey = requestScopeKey({

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -34,8 +34,16 @@ mock.module("@/lib/consent/consent-persistence", () => ({
 // (see navigation-resolver post-auth). Mutable so individual tests can pre-seed
 // it or leave it absent.
 let checkoutIntentValue: unknown = null;
+const clearCheckoutIntentMock = mock(() => {});
 mock.module("@/lib/billing/checkout-intent", () => ({
   readCheckoutIntent: () => checkoutIntentValue,
+  clearCheckoutIntent: clearCheckoutIntentMock,
+}));
+
+// `marketing-pricing-takeover` state — the pricing funnel kill switch.
+let takeoverValue = "enabled";
+mock.module("@/hooks/use-marketing-pricing-takeover", () => ({
+  useMarketingPricingTakeover: () => takeoverValue,
 }));
 
 const emitFunnelStepCompletedMock = mock((..._args: unknown[]) => {});
@@ -109,15 +117,18 @@ describe("PrivacyScreen — Start navigation", () => {
     navigateMock.mockClear();
     saveConsentMock.mockClear();
     emitFunnelStepCompletedMock.mockClear();
+    clearCheckoutIntentMock.mockClear();
     nativePlatform = false;
     localMode = false;
     checkoutIntentValue = null;
+    takeoverValue = "enabled";
   });
   afterEach(() => {
     cleanup();
     nativePlatform = false;
     localMode = false;
     checkoutIntentValue = null;
+    takeoverValue = "enabled";
   });
 
   test("preview mode no-ops on Start without persisting consent", () => {
@@ -201,6 +212,51 @@ describe("PrivacyScreen — Start navigation", () => {
     // Consent is still recorded before checkout resumes — payment after consent.
     expect(saveConsentMock).toHaveBeenCalledTimes(1);
     expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith(
+      `${routes.checkout}?package=super`,
+    );
+  });
+
+  test("drops the carried package and proceeds when the pricing funnel is off", () => {
+    // Kill switch flipped between the pricing CTA and this click. Handing off
+    // would land on a checkout route that bounces to plans, dropping the user
+    // out of onboarding before research runs.
+    takeoverValue = "disabled";
+    checkoutIntentValue = {
+      kind: "package",
+      packageKey: "super",
+      savedAt: Date.now(),
+      resumeAfterOnboarding: true,
+    };
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(clearCheckoutIntentMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(routes.onboarding.research)).toBe(true);
+    expect(target).not.toContain(routes.checkout);
+  });
+
+  test("still resumes while the funnel flag is unresolved", () => {
+    // The flag defaults off; dropping the package before its real value lands
+    // would strand every legitimate pricing signup. The checkout route's own
+    // gate catches a genuinely-off funnel.
+    takeoverValue = "pending";
+    checkoutIntentValue = {
+      kind: "package",
+      packageKey: "super",
+      savedAt: Date.now(),
+      resumeAfterOnboarding: true,
+    };
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(clearCheckoutIntentMock).not.toHaveBeenCalled();
     expect(navigateMock).toHaveBeenCalledWith(
       `${routes.checkout}?package=super`,
     );

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -112,6 +112,12 @@ function clickStart(): void {
   fireEvent.click(screen.getByText("Start"));
 }
 
+/** The query of the single URL `navigate()` was called with. */
+function navigatedQuery(): URLSearchParams {
+  const target = navigateMock.mock.calls[0]?.[0] as string;
+  return new URLSearchParams(target.slice(target.indexOf("?")));
+}
+
 describe("PrivacyScreen — Start navigation", () => {
   beforeEach(() => {
     navigateMock.mockClear();
@@ -212,9 +218,9 @@ describe("PrivacyScreen — Start navigation", () => {
     // Consent is still recorded before checkout resumes — payment after consent.
     expect(saveConsentMock).toHaveBeenCalledTimes(1);
     expect(navigateMock).toHaveBeenCalledTimes(1);
-    expect(navigateMock).toHaveBeenCalledWith(
-      `${routes.checkout}?package=super`,
-    );
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(`${routes.checkout}?`)).toBe(true);
+    expect(navigatedQuery().get("package")).toBe("super");
   });
 
   test("drops the carried package and proceeds when the pricing funnel is off", () => {
@@ -240,10 +246,13 @@ describe("PrivacyScreen — Start navigation", () => {
     expect(target).not.toContain(routes.checkout);
   });
 
-  test("still resumes while the funnel flag is unresolved", () => {
+  test("still resumes while the funnel flag is unresolved, carrying the onboarding step", () => {
     // The flag defaults off; dropping the package before its real value lands
-    // would strand every legitimate pricing signup. The checkout route's own
-    // gate catches a genuinely-off funnel.
+    // would strand every legitimate pricing signup, and blocking Start until it
+    // resolves would put a network round-trip in front of the most important
+    // click in onboarding. So hand off — but carry the step this click would
+    // otherwise have taken, so a pending→disabled transition lands back in the
+    // funnel rather than on the plans takeover.
     takeoverValue = "pending";
     checkoutIntentValue = {
       kind: "package",
@@ -251,14 +260,44 @@ describe("PrivacyScreen — Start navigation", () => {
       savedAt: Date.now(),
       resumeAfterOnboarding: true,
     };
-    searchParamsValue = new URLSearchParams("hosting=managed");
+    searchParamsValue = new URLSearchParams(
+      "hosting=managed&plugin=coffee-aficionado",
+    );
     render(<PrivacyScreen />);
 
     clickStart();
 
     expect(clearCheckoutIntentMock).not.toHaveBeenCalled();
-    expect(navigateMock).toHaveBeenCalledWith(
-      `${routes.checkout}?package=super`,
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(`${routes.checkout}?`)).toBe(true);
+    const query = navigatedQuery();
+    expect(query.get("package")).toBe("super");
+    // The continuation is the exact URL the non-checkout branch would have
+    // navigated to, attribution and hosting included.
+    expect(query.get("continue")).toBe(
+      `${routes.onboarding.research}?hosting=managed&plugin=coffee-aficionado`,
+    );
+  });
+
+  test("the carried continuation follows the local-hatch destination", () => {
+    // Local hosting must run the foreground hatch first, so the continuation is
+    // `hatching`, not `research` — the checkout bail has to resume the same step
+    // the standard branch would have.
+    takeoverValue = "pending";
+    localMode = true;
+    checkoutIntentValue = {
+      kind: "package",
+      packageKey: "super",
+      savedAt: Date.now(),
+      resumeAfterOnboarding: true,
+    };
+    searchParamsValue = new URLSearchParams("hosting=local");
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(navigatedQuery().get("continue")).toBe(
+      `${routes.onboarding.hatching}?hosting=local`,
     );
   });
 
@@ -299,9 +338,9 @@ describe("PrivacyScreen — Start navigation", () => {
 
     clickStart();
 
-    expect(navigateMock).toHaveBeenCalledWith(
-      `${routes.checkout}?package=super`,
-    );
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(`${routes.checkout}?`)).toBe(true);
+    expect(navigatedQuery().get("package")).toBe("super");
   });
 });
 

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -14,7 +14,11 @@ import {
 } from "@/domains/onboarding/funnel-events";
 import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
-import { readCheckoutIntent } from "@/lib/billing/checkout-intent";
+import { useMarketingPricingTakeover } from "@/hooks/use-marketing-pricing-takeover";
+import {
+    clearCheckoutIntent,
+    readCheckoutIntent,
+} from "@/lib/billing/checkout-intent";
 import { isLocalMode } from "@/lib/local-mode";
 import {
     usePrivacyConsent,
@@ -42,6 +46,7 @@ export function PrivacyScreen() {
   const [tosAccepted, setTosAcceptedReal] = useTosAccepted();
   const [privacyConsent, setPrivacyConsentReal] = usePrivacyConsent();
   const hasPlatformSession = useHasPlatformSession();
+  const takeover = useMarketingPricingTakeover();
 
   useEffect(() => {
     if (!isNative) {
@@ -83,16 +88,24 @@ export function PrivacyScreen() {
     // re-stashing on a Stripe redirect, clearing it on an already-Pro no_op — so
     // this screen just hands off. Resuming only from this explicit Start click —
     // never a render effect — keeps consent and checkout from looping.
+    // A positively-off `marketing-pricing-takeover` drops the dead package and
+    // continues onboarding: handing off would bounce through a gated checkout
+    // route and out of the funnel before research runs. An unresolved flag
+    // still resumes — that route's own gate catches it.
     const checkoutIntent = readCheckoutIntent();
     if (
       checkoutIntent?.kind === "package" &&
       checkoutIntent.resumeAfterOnboarding === true
     ) {
-      const params = new URLSearchParams({
-        package: checkoutIntent.packageKey,
-      });
-      void navigate(`${routes.checkout}?${params.toString()}`);
-      return;
+      if (takeover === "disabled") {
+        clearCheckoutIntent();
+      } else {
+        const params = new URLSearchParams({
+          package: checkoutIntent.packageKey,
+        });
+        void navigate(`${routes.checkout}?${params.toString()}`);
+        return;
+      }
     }
 
     const hostingParam = searchParams.get("hosting");
@@ -122,6 +135,7 @@ export function PrivacyScreen() {
     navigate,
     searchParams,
     shareDiagnosticsChecked,
+    takeover,
     tosAccepted,
     userId,
   ]);

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -15,6 +15,7 @@ import {
 import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
 import { useMarketingPricingTakeover } from "@/hooks/use-marketing-pricing-takeover";
+import { CHECKOUT_CONTINUE_PARAM } from "@/lib/billing/checkout-continuation";
 import {
     clearCheckoutIntent,
     readCheckoutIntent,
@@ -78,36 +79,6 @@ export function PrivacyScreen() {
       });
     }
 
-    // A pricing-CTA signup stashes its chosen package (see navigation-resolver
-    // post-auth). With consent now recorded, resume checkout so payment happens
-    // after consent and before the assistant hatches. Resume ONLY a
-    // signup-marked intent (`resumeAfterOnboarding`): an ordinary billing-surface
-    // stash (an abandoned CheckoutPage/takeover checkout) carries no marker, so
-    // it's ignored here and left untouched for its own flow — onboarding proceeds
-    // normally. The checkout route owns the marked stash's lifecycle from here —
-    // re-stashing on a Stripe redirect, clearing it on an already-Pro no_op — so
-    // this screen just hands off. Resuming only from this explicit Start click —
-    // never a render effect — keeps consent and checkout from looping.
-    // A positively-off `marketing-pricing-takeover` drops the dead package and
-    // continues onboarding: handing off would bounce through a gated checkout
-    // route and out of the funnel before research runs. An unresolved flag
-    // still resumes — that route's own gate catches it.
-    const checkoutIntent = readCheckoutIntent();
-    if (
-      checkoutIntent?.kind === "package" &&
-      checkoutIntent.resumeAfterOnboarding === true
-    ) {
-      if (takeover === "disabled") {
-        clearCheckoutIntent();
-      } else {
-        const params = new URLSearchParams({
-          package: checkoutIntent.packageKey,
-        });
-        void navigate(`${routes.checkout}?${params.toString()}`);
-        return;
-      }
-    }
-
     const hostingParam = searchParams.get("hosting");
     const params = new URLSearchParams();
     if (hostingParam) params.set("hosting", hostingParam);
@@ -126,7 +97,42 @@ export function PrivacyScreen() {
       isNative,
       isLocalHatch,
     });
-    void navigate(`${destination}${qs ? `?${qs}` : ""}`);
+    const onboardingNext = `${destination}${qs ? `?${qs}` : ""}`;
+
+    // A pricing-CTA signup stashes its chosen package (see navigation-resolver
+    // post-auth). With consent now recorded, resume checkout so payment happens
+    // after consent and before the assistant hatches. Resume ONLY a
+    // signup-marked intent (`resumeAfterOnboarding`): an ordinary billing-surface
+    // stash (an abandoned CheckoutPage/takeover checkout) carries no marker, so
+    // it's ignored here and left untouched for its own flow — onboarding proceeds
+    // normally. The checkout route owns the marked stash's lifecycle from here —
+    // re-stashing on a Stripe redirect, clearing it on an already-Pro no_op — so
+    // this screen just hands off. Resuming only from this explicit Start click —
+    // never a render effect — keeps consent and checkout from looping.
+    // A positively-off `marketing-pricing-takeover` drops the dead package and
+    // continues onboarding: handing off would bounce through a gated checkout
+    // route and out of the funnel before research runs. An unresolved flag still
+    // resumes, carrying the onboarding step this click would otherwise have
+    // taken: if the flag lands off, checkout returns the user there instead of
+    // the plans takeover, so a pending→disabled race stays inside the funnel.
+    const checkoutIntent = readCheckoutIntent();
+    if (
+      checkoutIntent?.kind === "package" &&
+      checkoutIntent.resumeAfterOnboarding === true
+    ) {
+      if (takeover === "disabled") {
+        clearCheckoutIntent();
+      } else {
+        const checkoutParams = new URLSearchParams({
+          package: checkoutIntent.packageKey,
+          [CHECKOUT_CONTINUE_PARAM]: onboardingNext,
+        });
+        void navigate(`${routes.checkout}?${checkoutParams.toString()}`);
+        return;
+      }
+    }
+
+    void navigate(onboardingNext);
   }, [
     privacyConsent,
     hasPlatformSession,

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -290,12 +290,56 @@ describe("CheckoutPage", () => {
 
   test("a gated session skips the upgrade and falls back to plans", async () => {
     gateValue = "gated";
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
     const { getByTestId } = renderCheckout("/assistant/checkout?package=super");
 
     await waitFor(() =>
       expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
     );
     expect(upgradeCalls.length).toBe(0);
+    expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+  });
+
+  test("a session without a platform login drops the stash on the way out", async () => {
+    gateValue = "disabled";
+    // The signup carry's marked stash is still in place: the hand-off, which
+    // rewrites it without the marker, never ran. Nothing was bought, so the
+    // stash must not outlive the attempt.
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+    const { getByTestId } = renderCheckout(ONBOARDING_ENTRY);
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe(ONBOARDING_NEXT),
+    );
+    expect(upgradeCalls.length).toBe(0);
+    expect(openedUrl).toBeNull();
+    expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+  });
+
+  test("the hand-off rewrites a marked stash without the marker", async () => {
+    // The invariant the provisioning takeover reads the marker against: the
+    // hand-off replaces the record wholesale, so a stash that reaches the
+    // post-checkout return is always unmarked, and one that still carries the
+    // marker is proof no checkout ever handed off.
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+    renderCheckout(ONBOARDING_ENTRY);
+
+    await waitFor(() => expect(openedUrl).toBe(CHECKOUT_URL));
+    const stashed = JSON.parse(sessionStorage.getItem(INTENT_KEY)!);
+    expect(stashed).toMatchObject({ kind: "package", packageKey: "super" });
+    expect(stashed.resumeAfterOnboarding).toBeUndefined();
   });
 
   test("the pricing funnel switched off redirects to plans without charging", async () => {

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -10,7 +10,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MemoryRouter, useLocation } from "react-router";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 
 import { saveCheckoutIntent } from "@/lib/billing/checkout-intent";
 import * as sdkGen from "@/generated/api/sdk.gen";
@@ -23,6 +23,10 @@ import type { MarketingPricingTakeoverState } from "@/hooks/use-marketing-pricin
 
 const CHECKOUT_URL = "https://stripe.test/checkout/session";
 const INTENT_KEY = "vellum.pro-checkout-intent";
+// An onboarding hand-off: the package plus the onboarding step Start would
+// otherwise have taken, so a checkout that doesn't happen resumes the funnel.
+const ONBOARDING_NEXT = "/assistant/onboarding/research?hosting=managed";
+const ONBOARDING_ENTRY = `/assistant/checkout?package=super&continue=${encodeURIComponent(ONBOARDING_NEXT)}`;
 
 type Captured = { body?: unknown };
 const upgradeCalls: Captured[] = [];
@@ -83,18 +87,33 @@ function LocationProbe() {
   return <div data-testid="loc">{location.pathname + location.search}</div>;
 }
 
-function renderCheckout(entry: string) {
-  const client = new QueryClient({
+function freshQueryClient(): QueryClient {
+  return new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  return render(
+}
+
+/**
+ * The page mounted at its own path, matching `routes.tsx`. Rendering it
+ * unconditionally would leave it mounted after it redirects, where it re-reads
+ * the *destination's* search params and redirects a second time.
+ */
+function checkoutTree(entry: string, client: QueryClient) {
+  return (
     <MemoryRouter initialEntries={[entry]}>
       <QueryClientProvider client={client}>
-        <CheckoutPage />
+        <Routes>
+          <Route path="/assistant/checkout" element={<CheckoutPage />} />
+          <Route path="*" element={null} />
+        </Routes>
       </QueryClientProvider>
       <LocationProbe />
-    </MemoryRouter>,
+    </MemoryRouter>
   );
+}
+
+function renderCheckout(entry: string) {
+  return render(checkoutTree(entry, freshQueryClient()));
 }
 
 beforeEach(() => {
@@ -137,19 +156,11 @@ describe("CheckoutPage", () => {
 
   test("holds the upgrade until org is ready, then fires once it hydrates", async () => {
     orgReadyValue = false;
-    const client = new QueryClient({
-      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-    });
+    const client = freshQueryClient();
     // A fresh element each render so the rerender doesn't hit React's
     // same-reference bailout and actually re-reads the org-readiness value.
-    const makeTree = () => (
-      <MemoryRouter initialEntries={["/assistant/checkout?package=super"]}>
-        <QueryClientProvider client={client}>
-          <CheckoutPage />
-        </QueryClientProvider>
-        <LocationProbe />
-      </MemoryRouter>
-    );
+    const makeTree = () =>
+      checkoutTree("/assistant/checkout?package=super", client);
     const { getByLabelText, getByTestId, rerender } = render(makeTree());
 
     // Org store not yet hydrated: the spinner shows, nothing fires, and the
@@ -230,19 +241,73 @@ describe("CheckoutPage", () => {
     expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
   });
 
+  test("a pending→disabled transition resumes the carried onboarding step", async () => {
+    // The funnel-dropout race: a new user clicks Start before the flag has
+    // hydrated, onboarding hands off, and the flag then lands off. Bouncing to
+    // plans would drop the user out of onboarding short of research/hatching,
+    // so the continuation onboarding carried has to win here.
+    takeoverValue = "pending";
+    const client = freshQueryClient();
+    const makeTree = () => checkoutTree(ONBOARDING_ENTRY, client);
+    const { getByTestId, rerender } = render(makeTree());
+
+    expect(getByTestId("loc").textContent).toBe(ONBOARDING_ENTRY);
+
+    takeoverValue = "disabled";
+    rerender(makeTree());
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe(ONBOARDING_NEXT),
+    );
+    expect(upgradeCalls.length).toBe(0);
+    expect(openedUrl).toBeNull();
+  });
+
+  test("an already-off funnel returns to the continuation and drops the stash", async () => {
+    takeoverValue = "disabled";
+    // The marked stash from the signup carry is dead once the kill switch is
+    // off — it must not resurface on a provisioning surface within its TTL.
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+    const { getByTestId } = renderCheckout(ONBOARDING_ENTRY);
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe(ONBOARDING_NEXT),
+    );
+    expect(upgradeCalls.length).toBe(0);
+    expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+  });
+
+  test("a no_op result returns to the continuation when one is carried", async () => {
+    // Already Pro mid-onboarding still needs an assistant — plans is not it.
+    upgradeData = { status: "no_op", checkout_url: null, message: "" };
+    const { getByTestId } = renderCheckout(ONBOARDING_ENTRY);
+
+    await waitFor(() => expect(upgradeCalls.length).toBe(1));
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe(ONBOARDING_NEXT),
+    );
+  });
+
+  test("an off-site continuation is rejected in favor of plans", async () => {
+    takeoverValue = "disabled";
+    const { getByTestId } = renderCheckout(
+      `/assistant/checkout?package=super&continue=${encodeURIComponent("https://evil.example.com/steal")}`,
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
+    );
+  });
+
   test("holds while the funnel flag is unresolved, then fires once it lands", async () => {
     takeoverValue = "pending";
-    const client = new QueryClient({
-      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-    });
-    const makeTree = () => (
-      <MemoryRouter initialEntries={["/assistant/checkout?package=super"]}>
-        <QueryClientProvider client={client}>
-          <CheckoutPage />
-        </QueryClientProvider>
-        <LocationProbe />
-      </MemoryRouter>
-    );
+    const client = freshQueryClient();
+    const makeTree = () =>
+      checkoutTree("/assistant/checkout?package=super", client);
     const { getByLabelText, getByTestId, rerender } = render(makeTree());
 
     // The flag defaults off, so an unresolved value must neither fire checkout

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -18,6 +18,8 @@ import * as browserRuntime from "@/runtime/browser";
 import * as orgReadyMod from "@/hooks/use-is-org-ready";
 import * as platformGateMod from "@/hooks/use-platform-gate";
 import type { PlatformGateState } from "@/hooks/use-platform-gate";
+import * as takeoverMod from "@/hooks/use-marketing-pricing-takeover";
+import type { MarketingPricingTakeoverState } from "@/hooks/use-marketing-pricing-takeover";
 
 const CHECKOUT_URL = "https://stripe.test/checkout/session";
 const INTENT_KEY = "vellum.pro-checkout-intent";
@@ -29,6 +31,8 @@ let openedUrl: string | null = null;
 let gateValue: PlatformGateState = "full";
 // Org-readiness the mocked `useIsOrgReady` returns (default: hydrated/ready).
 let orgReadyValue = true;
+// `marketing-pricing-takeover` state (default: funnel on).
+let takeoverValue: MarketingPricingTakeoverState = "enabled";
 // When true the upgrade rejects — drives the error path. Otherwise it resolves
 // with `upgradeData`.
 let upgradeRejects = false;
@@ -67,6 +71,11 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReadyValue,
 }));
 
+mock.module("@/hooks/use-marketing-pricing-takeover", () => ({
+  ...takeoverMod,
+  useMarketingPricingTakeover: () => takeoverValue,
+}));
+
 const { CheckoutPage } = await import("./checkout-page");
 
 function LocationProbe() {
@@ -93,6 +102,7 @@ beforeEach(() => {
   openedUrl = null;
   gateValue = "full";
   orgReadyValue = true;
+  takeoverValue = "enabled";
   upgradeRejects = false;
   upgradeData = { status: "redirect", checkout_url: CHECKOUT_URL, message: "" };
   sessionStorage.removeItem(INTENT_KEY);
@@ -205,5 +215,46 @@ describe("CheckoutPage", () => {
       expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
     );
     expect(upgradeCalls.length).toBe(0);
+  });
+
+  test("the pricing funnel switched off redirects to plans without charging", async () => {
+    takeoverValue = "disabled";
+    const { getByTestId } = renderCheckout("/assistant/checkout?package=super");
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
+    );
+    // A link cached from while the funnel was on must not start a purchase.
+    expect(upgradeCalls.length).toBe(0);
+    expect(openedUrl).toBeNull();
+    expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+  });
+
+  test("holds while the funnel flag is unresolved, then fires once it lands", async () => {
+    takeoverValue = "pending";
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const makeTree = () => (
+      <MemoryRouter initialEntries={["/assistant/checkout?package=super"]}>
+        <QueryClientProvider client={client}>
+          <CheckoutPage />
+        </QueryClientProvider>
+        <LocationProbe />
+      </MemoryRouter>
+    );
+    const { getByLabelText, getByTestId, rerender } = render(makeTree());
+
+    // The flag defaults off, so an unresolved value must neither fire checkout
+    // nor bounce — bouncing here would strand every cold-loaded deep link.
+    getByLabelText("Preparing checkout");
+    expect(upgradeCalls.length).toBe(0);
+    expect(getByTestId("loc").textContent).toBe(
+      "/assistant/checkout?package=super",
+    );
+
+    takeoverValue = "enabled";
+    rerender(makeTree());
+    await waitFor(() => expect(upgradeCalls.length).toBe(1));
   });
 });

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -235,6 +235,50 @@ describe("CheckoutPage", () => {
     await waitFor(() => expect(upgradeCalls.length).toBe(2));
   });
 
+  test("the error escape falls back to plans and drops the stash", async () => {
+    upgradeRejects = true;
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+    const { findByRole, getByTestId } = renderCheckout(
+      "/assistant/checkout?package=super",
+    );
+
+    // No continuation carried, so the escape is literally the plans takeover.
+    fireEvent.click(await findByRole("link", { name: "View plans" }));
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
+    );
+    expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+  });
+
+  test("the error escape resumes the carried onboarding step", async () => {
+    upgradeRejects = true;
+    // The signup carry's marked stash survives into the failure. Walking away
+    // must not leave it readable by a later provisioning takeover.
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+    const { findByRole, getByTestId, queryByRole } =
+      renderCheckout(ONBOARDING_ENTRY);
+
+    // Mid-onboarding the escape goes back to onboarding, and says so.
+    const escape = await findByRole("link", { name: "Continue setup" });
+    expect(queryByRole("link", { name: "View plans" })).toBeNull();
+
+    fireEvent.click(escape);
+
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe(ONBOARDING_NEXT),
+    );
+    expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+  });
+
   test("missing package navigates to plans without firing the upgrade", async () => {
     const { getByTestId } = renderCheckout("/assistant/checkout");
 

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -40,6 +40,11 @@ let takeoverValue: MarketingPricingTakeoverState = "enabled";
 // When true the upgrade rejects — drives the error path. Otherwise it resolves
 // with `upgradeData`.
 let upgradeRejects = false;
+// When true the upgrade hangs until `releaseUpgrade()` — the mid-flight window
+// where a flag flip and the response race.
+let holdUpgrade = false;
+let releaseUpgrade: (() => void) | null = null;
+let heldUpgrade: Promise<unknown> | null = null;
 let upgradeData: { status: string; checkout_url: string | null; message: string } = {
   status: "redirect",
   checkout_url: CHECKOUT_URL,
@@ -52,6 +57,13 @@ mock.module("@/generated/api/sdk.gen", () => ({
     upgradeCalls.push(opts);
     if (upgradeRejects) {
       return Promise.reject(new Error("checkout failed"));
+    }
+    if (holdUpgrade) {
+      heldUpgrade = new Promise((resolve) => {
+        releaseUpgrade = () =>
+          resolve({ data: upgradeData, response: { ok: true } });
+      });
+      return heldUpgrade;
     }
     return Promise.resolve({ data: upgradeData, response: { ok: true } });
   },
@@ -116,6 +128,17 @@ function renderCheckout(entry: string) {
   return render(checkoutTree(entry, freshQueryClient()));
 }
 
+/**
+ * Run every pending microtask, so a released upgrade's continuation has fully
+ * settled before a test asserts that it did nothing. A `setTimeout` macrotask
+ * is scheduled behind the whole microtask queue the promise chain runs on.
+ */
+function flushPending(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
 beforeEach(() => {
   upgradeCalls.length = 0;
   openedUrl = null;
@@ -123,6 +146,9 @@ beforeEach(() => {
   orgReadyValue = true;
   takeoverValue = "enabled";
   upgradeRejects = false;
+  holdUpgrade = false;
+  releaseUpgrade = null;
+  heldUpgrade = null;
   upgradeData = { status: "redirect", checkout_url: CHECKOUT_URL, message: "" };
   sessionStorage.removeItem(INTENT_KEY);
 });
@@ -239,6 +265,56 @@ describe("CheckoutPage", () => {
     expect(upgradeCalls.length).toBe(0);
     expect(openedUrl).toBeNull();
     expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+  });
+
+  test("the funnel switched off mid-flight drops the late redirect", async () => {
+    holdUpgrade = true;
+    const client = freshQueryClient();
+    const makeTree = () =>
+      checkoutTree("/assistant/checkout?package=super", client);
+    const { getByTestId, rerender } = render(makeTree());
+
+    await waitFor(() => expect(upgradeCalls.length).toBe(1));
+
+    // The kill switch lands while the upgrade is still in flight.
+    takeoverValue = "disabled";
+    rerender(makeTree());
+    await waitFor(() =>
+      expect(getByTestId("loc").textContent).toBe("/assistant/plans"),
+    );
+
+    // The response arrives after the bail: it must neither open Stripe nor
+    // re-stash the package the bail just dropped.
+    releaseUpgrade!();
+    await heldUpgrade;
+    await flushPending();
+    expect(openedUrl).toBeNull();
+    expect(sessionStorage.getItem(INTENT_KEY)).toBeNull();
+  });
+
+  test("the funnel switched off after the hand-off keeps the stash", async () => {
+    const client = freshQueryClient();
+    const makeTree = () =>
+      checkoutTree("/assistant/checkout?package=super", client);
+    const { getByTestId, rerender } = render(makeTree());
+
+    await waitFor(() => expect(openedUrl).toBe(CHECKOUT_URL));
+
+    // Electron and native Capacitor open Stripe without unloading the page, so
+    // the flag flip reaches a route that is still mounted. The intent belongs
+    // to the return trip by now — the kill switch must not delete it, and must
+    // not navigate out from under the checkout in progress.
+    takeoverValue = "disabled";
+    rerender(makeTree());
+    await flushPending();
+
+    expect(JSON.parse(sessionStorage.getItem(INTENT_KEY)!)).toMatchObject({
+      kind: "package",
+      packageKey: "super",
+    });
+    expect(getByTestId("loc").textContent).toBe(
+      "/assistant/checkout?package=super",
+    );
   });
 
   test("a pending→disabled transition resumes the carried onboarding step", async () => {

--- a/clients/web/src/domains/settings/billing/checkout-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.test.tsx
@@ -258,7 +258,7 @@ describe("CheckoutPage", () => {
   test("the error escape resumes the carried onboarding step", async () => {
     upgradeRejects = true;
     // The signup carry's marked stash survives into the failure. Walking away
-    // must not leave it readable by a later provisioning takeover.
+    // must not leave it for the privacy screen to resume checkout from.
     saveCheckoutIntent({
       kind: "package",
       packageKey: "super",

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -8,6 +8,7 @@ import { organizationsBillingSubscriptionUpgradeCreateMutation } from "@/generat
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { useMarketingPricingTakeover } from "@/hooks/use-marketing-pricing-takeover";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
+import { checkoutContinuation } from "@/lib/billing/checkout-continuation";
 import {
   clearCheckoutIntent,
   saveCheckoutIntent,
@@ -35,6 +36,10 @@ import { Button } from "@vellumai/design-library/components/button";
  *   - Gate `"full"` → fire the upgrade once and either redirect to Stripe
  *     (`redirect`), fall back to plans (`no_op`, already Pro), or surface a
  *     retryable error. It never dead-ends.
+ *
+ * Every "no purchase happens here" exit honors the `continue` param when one is
+ * present (see `checkout-continuation`), so a caller mid-flow — onboarding —
+ * gets back to its own next step instead of the plans takeover.
  */
 export function CheckoutPage() {
   const navigate = useNavigate();
@@ -51,6 +56,11 @@ export function CheckoutPage() {
   // lands — the flag defaults off, so redirecting on the cold-load default
   // would bounce every legitimate deep link.
   const takeover = useMarketingPricingTakeover();
+  // Where to go when no purchase happens here. Onboarding hands off before the
+  // funnel flag has necessarily resolved and passes its own next step, so a
+  // pending→disabled transition resumes onboarding instead of stranding a new
+  // user on plans, outside the funnel and short of an assistant.
+  const bailTarget = checkoutContinuation(searchParams, routes.plans);
 
   const { mutateAsync } = useMutation(
     organizationsBillingSubscriptionUpgradeCreateMutation(),
@@ -79,25 +89,31 @@ export function CheckoutPage() {
       }
       // `no_op` — already Pro, nothing to provision. Clear the marked stash so
       // an already-Pro bounce doesn't leave it lingering for its TTL, then hand
-      // off to the plans takeover rather than stranding the user on a blank splash.
+      // off rather than stranding the user on a blank splash.
       clearCheckoutIntent();
-      navigate(routes.plans, { replace: true });
+      navigate(bailTarget, { replace: true });
     } catch {
       setFailed(true);
     }
-  }, [mutateAsync, navigate, packageKey]);
+  }, [bailTarget, mutateAsync, navigate, packageKey]);
 
   useEffect(() => {
     // No package to check out, a session that can't reach checkout, or the
-    // pricing funnel switched off: fall back to the plans takeover, which owns
-    // its own gating and messaging.
+    // pricing funnel switched off: fall back to the continuation, or to the
+    // plans takeover, which owns its own gating and messaging.
     if (
       !packageKey ||
       gate === "disabled" ||
       gate === "gated" ||
       takeover === "disabled"
     ) {
-      navigate(routes.plans, { replace: true });
+      if (takeover === "disabled") {
+        // The kill switch is decisive: the carried package is dead. Drop the
+        // stash so it can't resurface on a later provisioning surface within
+        // its TTL.
+        clearCheckoutIntent();
+      }
+      navigate(bailTarget, { replace: true });
       return;
     }
     // Hold until the funnel flag resolves, the platform gate is full, AND the
@@ -113,7 +129,7 @@ export function CheckoutPage() {
     }
     startedRef.current = true;
     void runCheckout();
-  }, [gate, isOrgReady, navigate, packageKey, runCheckout, takeover]);
+  }, [bailTarget, gate, isOrgReady, navigate, packageKey, runCheckout, takeover]);
 
   if (failed) {
     return (

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -6,6 +6,7 @@ import { useMutation } from "@tanstack/react-query";
 
 import { organizationsBillingSubscriptionUpgradeCreateMutation } from "@/generated/api/@tanstack/react-query.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { useMarketingPricingTakeover } from "@/hooks/use-marketing-pricing-takeover";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import {
   clearCheckoutIntent,
@@ -28,6 +29,9 @@ import { Button } from "@vellumai/design-library/components/button";
  *   - Missing `package` → back to the plans takeover.
  *   - Gate `"disabled"`/`"gated"` → back to plans (its own gating owns the
  *     messaging).
+ *   - `marketing-pricing-takeover` off → back to plans. The flag is the kill
+ *     switch over the whole pricing funnel; a marketing link cached from while
+ *     it was on still lands somewhere useful.
  *   - Gate `"full"` → fire the upgrade once and either redirect to Stripe
  *     (`redirect`), fall back to plans (`no_op`, already Pro), or surface a
  *     retryable error. It never dead-ends.
@@ -43,6 +47,10 @@ export function CheckoutPage() {
   // which hydrates asynchronously after auth. On a cold deep link the platform
   // session can settle before the org id lands, so gate the fire on this too.
   const isOrgReady = useIsOrgReady();
+  // Kill switch over the pricing funnel. `"pending"` until the real flag value
+  // lands — the flag defaults off, so redirecting on the cold-load default
+  // would bounce every legitimate deep link.
+  const takeover = useMarketingPricingTakeover();
 
   const { mutateAsync } = useMutation(
     organizationsBillingSubscriptionUpgradeCreateMutation(),
@@ -80,21 +88,32 @@ export function CheckoutPage() {
   }, [mutateAsync, navigate, packageKey]);
 
   useEffect(() => {
-    // No package to check out, or a session that can't reach checkout: fall
-    // back to the plans takeover, which owns its own gating and messaging.
-    if (!packageKey || gate === "disabled" || gate === "gated") {
+    // No package to check out, a session that can't reach checkout, or the
+    // pricing funnel switched off: fall back to the plans takeover, which owns
+    // its own gating and messaging.
+    if (
+      !packageKey ||
+      gate === "disabled" ||
+      gate === "gated" ||
+      takeover === "disabled"
+    ) {
       navigate(routes.plans, { replace: true });
       return;
     }
-    // Hold until the platform gate is full AND the org store is ready. Firing
-    // before the org id hydrates sends a header-less request that fails; the
-    // "Preparing checkout…" spinner keeps showing meanwhile.
-    if (gate !== "full" || !isOrgReady || startedRef.current) {
+    // Hold until the funnel flag resolves, the platform gate is full, AND the
+    // org store is ready. Firing before the org id hydrates sends a header-less
+    // request that fails; the "Preparing checkout…" spinner keeps showing meanwhile.
+    if (
+      takeover !== "enabled" ||
+      gate !== "full" ||
+      !isOrgReady ||
+      startedRef.current
+    ) {
       return;
     }
     startedRef.current = true;
     void runCheckout();
-  }, [gate, isOrgReady, navigate, packageKey, runCheckout]);
+  }, [gate, isOrgReady, navigate, packageKey, runCheckout, takeover]);
 
   if (failed) {
     return (

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -19,6 +19,21 @@ import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 
 /**
+ * How far a checkout attempt has got.
+ *
+ * - `idle` — mounted, nothing fired.
+ * - `running` — the upgrade POST is in flight.
+ * - `handed_off` — the package intent is stashed and Stripe is open.
+ * - `settled` — terminal: an already-Pro `no_op`, a failed upgrade, or a bail.
+ *
+ * `handed_off` is the line that matters. Before it, this route owns the stash
+ * and a bail clears it; after it, the stash belongs to the post-checkout return
+ * trip and nothing here may touch it. Electron and native Capacitor open Stripe
+ * without unloading the page, so the route is still mounted to enforce that.
+ */
+type CheckoutPhase = "idle" | "running" | "handed_off" | "settled";
+
+/**
  * Deep-link checkout entrypoint (`/assistant/checkout?package=<slug>`). The
  * marketing pricing CTAs route a chosen Pro package here — reachable by a
  * brand-new user with no assistant yet, so the route sits outside
@@ -32,7 +47,9 @@ import { Button } from "@vellumai/design-library/components/button";
  *     messaging).
  *   - `marketing-pricing-takeover` off → back to plans. The flag is the kill
  *     switch over the whole pricing funnel; a marketing link cached from while
- *     it was on still lands somewhere useful.
+ *     it was on still lands somewhere useful. Off landing mid-flight settles the
+ *     attempt so the response can't open Stripe behind the switch; off landing
+ *     after the hand-off leaves the checkout, and its stash, alone.
  *   - Gate `"full"` → fire the upgrade once and either redirect to Stripe
  *     (`redirect`), fall back to plans (`no_op`, already Pro), or surface a
  *     retryable error. It never dead-ends.
@@ -66,10 +83,14 @@ export function CheckoutPage() {
     organizationsBillingSubscriptionUpgradeCreateMutation(),
   );
   const [failed, setFailed] = useState(false);
-  // StrictMode double-invokes mount effects; the ref fires the upgrade once.
-  const startedRef = useRef(false);
+  // StrictMode double-invokes mount effects; the phase gates the upgrade to one
+  // fire. It is also how a bail and an in-flight upgrade agree on who won: the
+  // bail settles the attempt, and the continuation below drops a result that
+  // arrives after that.
+  const phaseRef = useRef<CheckoutPhase>("idle");
 
   const runCheckout = useCallback(async () => {
+    phaseRef.current = "running";
     setFailed(false);
     try {
       const result = await mutateAsync({
@@ -80,7 +101,18 @@ export function CheckoutPage() {
           return_target: checkoutReturnTarget(),
         },
       });
+      if (phaseRef.current !== "running") {
+        // A bail settled the attempt while the upgrade was in flight. Drop the
+        // result: opening Stripe would defeat the kill switch, and stashing the
+        // package would resurrect what the bail cleared. The server may already
+        // have minted a Checkout Session — an unvisited one bills nothing and
+        // Stripe expires it on its own.
+        return;
+      }
       if (result.status === "redirect" && result.checkout_url) {
+        // Past this point the stash belongs to the return trip, not to this
+        // route — see `CheckoutPhase`.
+        phaseRef.current = "handed_off";
         // Stash the selection so the post-checkout provisioning screen can show
         // the purchased package before the subscribe webhook lands.
         saveCheckoutIntent({ kind: "package", packageKey });
@@ -90,9 +122,14 @@ export function CheckoutPage() {
       // `no_op` — already Pro, nothing to provision. Clear the marked stash so
       // an already-Pro bounce doesn't leave it lingering for its TTL, then hand
       // off rather than stranding the user on a blank splash.
+      phaseRef.current = "settled";
       clearCheckoutIntent();
       navigate(bailTarget, { replace: true });
     } catch {
+      if (phaseRef.current !== "running") {
+        return;
+      }
+      phaseRef.current = "settled";
       setFailed(true);
     }
   }, [bailTarget, mutateAsync, navigate, packageKey]);
@@ -107,6 +144,15 @@ export function CheckoutPage() {
       gate === "gated" ||
       takeover === "disabled"
     ) {
+      if (phaseRef.current === "handed_off") {
+        // Checkout is already at Stripe and this route can't unwind it. The
+        // stash is what the post-checkout return reads, so leave it — and the
+        // route the hand-off left behind — alone.
+        return;
+      }
+      // The attempt is over. Settling it makes an in-flight upgrade's result a
+      // no-op, so a response landing after this can't open Stripe.
+      phaseRef.current = "settled";
       if (takeover === "disabled") {
         // The kill switch is decisive: the carried package is dead. Drop the
         // stash so it can't resurface on a later provisioning surface within
@@ -123,11 +169,10 @@ export function CheckoutPage() {
       takeover !== "enabled" ||
       gate !== "full" ||
       !isOrgReady ||
-      startedRef.current
+      phaseRef.current !== "idle"
     ) {
       return;
     }
-    startedRef.current = true;
     void runCheckout();
   }, [bailTarget, gate, isOrgReady, navigate, packageKey, runCheckout, takeover]);
 

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -156,14 +156,12 @@ export function CheckoutPage() {
         return;
       }
       // The attempt is over. Settling it makes an in-flight upgrade's result a
-      // no-op, so a response landing after this can't open Stripe.
+      // no-op, so a response landing after this can't open Stripe. The stash
+      // goes with it whatever ended the attempt: nothing was bought, and a
+      // package left readable for its TTL is one a later provisioning surface
+      // can name as purchased.
       phaseRef.current = "settled";
-      if (takeover === "disabled") {
-        // The kill switch is decisive: the carried package is dead. Drop the
-        // stash so it can't resurface on a later provisioning surface within
-        // its TTL.
-        clearCheckoutIntent();
-      }
+      clearCheckoutIntent();
       navigate(bailTarget, { replace: true });
       return;
     }

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -78,6 +78,11 @@ export function CheckoutPage() {
   // pending→disabled transition resumes onboarding instead of stranding a new
   // user on plans, outside the funnel and short of an assistant.
   const bailTarget = checkoutContinuation(searchParams, routes.plans);
+  // The escape offered on a failed attempt goes there too, and says so: a
+  // carried onboarding continuation is not the plans takeover, and a label
+  // naming one destination while taking another is worse than either wording.
+  const bailLabel =
+    bailTarget === routes.plans ? "View plans" : "Continue setup";
 
   const { mutateAsync } = useMutation(
     organizationsBillingSubscriptionUpgradeCreateMutation(),
@@ -174,7 +179,15 @@ export function CheckoutPage() {
       return;
     }
     void runCheckout();
-  }, [bailTarget, gate, isOrgReady, navigate, packageKey, runCheckout, takeover]);
+  }, [
+    bailTarget,
+    gate,
+    isOrgReady,
+    navigate,
+    packageKey,
+    runCheckout,
+    takeover,
+  ]);
 
   if (failed) {
     return (
@@ -184,11 +197,18 @@ export function CheckoutPage() {
         </p>
         <div className="flex items-center gap-4">
           <Button onClick={() => void runCheckout()}>Try again</Button>
+          {/*
+           * Taking the escape ends the attempt, so the stash goes with it. A
+           * marked signup intent left behind stays readable for its TTL by the
+           * provisioning takeover, which ignores the marker — it would render
+           * the package as purchased when nothing was bought.
+           */}
           <Link
-            to={routes.plans}
+            to={bailTarget}
+            onClick={clearCheckoutIntent}
             className="text-sm text-[var(--content-tertiary)] underline"
           >
-            View plans
+            {bailLabel}
           </Link>
         </div>
       </div>

--- a/clients/web/src/domains/settings/billing/checkout-page.tsx
+++ b/clients/web/src/domains/settings/billing/checkout-page.tsx
@@ -158,8 +158,8 @@ export function CheckoutPage() {
       // The attempt is over. Settling it makes an in-flight upgrade's result a
       // no-op, so a response landing after this can't open Stripe. The stash
       // goes with it whatever ended the attempt: nothing was bought, and a
-      // package left readable for its TTL is one a later provisioning surface
-      // can name as purchased.
+      // signup-marked intent left readable for its TTL is one the privacy
+      // screen resumes checkout from.
       phaseRef.current = "settled";
       clearCheckoutIntent();
       navigate(bailTarget, { replace: true });
@@ -196,10 +196,9 @@ export function CheckoutPage() {
         <div className="flex items-center gap-4">
           <Button onClick={() => void runCheckout()}>Try again</Button>
           {/*
-           * Taking the escape ends the attempt, so the stash goes with it. A
-           * marked signup intent left behind stays readable for its TTL by the
-           * provisioning takeover, which ignores the marker — it would render
-           * the package as purchased when nothing was bought.
+           * Taking the escape ends the attempt, so the stash goes with it.
+           * Nothing was bought, and a signup-marked intent left behind is one
+           * the privacy screen resumes checkout from for the rest of its TTL.
            */}
           <Link
             to={bailTarget}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -387,6 +387,26 @@ describe("BillingOnboardingModal", () => {
     });
   });
 
+  test("a stash still carrying the signup marker is not named as purchased", async () => {
+    // Keep the plan at base so CONFIRMING persists and the chip row is
+    // observable — the happy path above is the same screen with an unmarked
+    // stash, which does name its package. The marker only survives on a stash
+    // that never reached the Stripe hand-off, so nothing was bought and naming
+    // the package here would report a purchase that never happened.
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+    const { getByText, queryByText } = renderModal();
+
+    await waitFor(
+      () => expect(getByText("Confirming your upgrade…")).toBeTruthy(),
+      { timeout: 5000 },
+    );
+    expect(queryByText("Super package")).toBeNull();
+  });
+
   test("domain_setup_available false skips straight to complete and clears the intent stash", async () => {
     saveCheckoutIntent({ kind: "package", packageKey: "super" });
     subscriptionPlanId = "pro";

--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.tsx
@@ -12,7 +12,7 @@ import { assistantsDomainsListQueryKey } from "@/generated/api/@tanstack/react-q
 import type { CreditTierEnum } from "@/generated/api/types.gen";
 import {
   clearCheckoutIntent,
-  readCheckoutIntent,
+  readPurchasedCheckoutIntent,
   type CheckoutIntent,
 } from "@/lib/billing/checkout-intent";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
@@ -122,7 +122,7 @@ export function BillingOnboardingModal({
 
   useEffect(() => {
     if (open) {
-      setIntent(isResize ? null : readCheckoutIntent());
+      setIntent(isResize ? null : readPurchasedCheckoutIntent());
       // Fence the domains freshness check to this open before any domains fetch
       // can land, so a pre-open cached list never reads as fresh.
       setDomainsOpenedAt((prev) => prev ?? Date.now());

--- a/clients/web/src/domains/settings/components/show-tips-row.test.tsx
+++ b/clients/web/src/domains/settings/components/show-tips-row.test.tsx
@@ -14,7 +14,7 @@ function setProactiveTipsFlag(value: "off" | "on") {
   act(() => {
     useClientFeatureFlagStore
       .getState()
-      .setStringFlags({ proactiveTips: value });
+      .setStringFlags({ proactiveTips: value }, null);
   });
 }
 

--- a/clients/web/src/hooks/use-billing-cta-experiment.test.ts
+++ b/clients/web/src/hooks/use-billing-cta-experiment.test.ts
@@ -18,7 +18,7 @@ beforeEach(() => {
   // an earlier test can't leak in.
   useClientFeatureFlagStore
     .getState()
-    .setStringFlags({ experimentBillingCta20260723: "control" });
+    .setStringFlags({ experimentBillingCta20260723: "control" }, null);
 });
 
 afterEach(() => {
@@ -46,7 +46,7 @@ describe("useBillingCtaExperimentArm", () => {
   test("reflects the arm set on the store", () => {
     useClientFeatureFlagStore
       .getState()
-      .setStringFlags({ experimentBillingCta20260723: "upgrade-cta" });
+      .setStringFlags({ experimentBillingCta20260723: "upgrade-cta" }, null);
     const { result } = renderHook(() => useBillingCtaExperimentArm());
     expect(result.current).toBe("upgrade-cta");
   });

--- a/clients/web/src/hooks/use-client-feature-flag-sync.test.tsx
+++ b/clients/web/src/hooks/use-client-feature-flag-sync.test.tsx
@@ -1,15 +1,32 @@
-import type { ReactNode } from "react";
+import { useLayoutEffect, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from "@tanstack/react-query";
+import { cleanup, render, renderHook, waitFor } from "@testing-library/react";
 
 const originalFetch = globalThis.fetch;
-const fetchMock = mock(async () =>
-  new Response(JSON.stringify({ flags: {} }), {
+
+function jsonResponse(flags: Record<string, boolean | string>): Response {
+  return new Response(JSON.stringify({ flags }), {
     status: 200,
     headers: { "Content-Type": "application/json" },
-  }),
-);
+  });
+}
+
+/** A server evaluation of the pricing-funnel kill switch. */
+function flagResponse(marketingPricingTakeover: boolean): Response {
+  return jsonResponse({
+    "marketing-pricing-takeover": marketingPricingTakeover,
+  });
+}
+
+const fetchMock = mock(async () => jsonResponse({}));
+
+const ANONYMOUS_SCOPE = "anonymous:org:none";
+const SIGNED_IN_SCOPE = "user:user-123:org:org-abc";
 
 // Org-header readiness drives whether the authenticated fetch may go out at
 // all. Mutable so tests can hold it mid-resolution and then let it land.
@@ -49,6 +66,7 @@ function freshQueryClient(): QueryClient {
 beforeEach(() => {
   window.__VELLUM_CONFIG__ = undefined;
   fetchMock.mockClear();
+  fetchMock.mockImplementation(async () => jsonResponse({}));
   globalThis.fetch = fetchMock as unknown as typeof fetch;
   orgReadinessValue = "ready";
   useClientFeatureFlagStore.setState(initialFlagState, true);
@@ -123,7 +141,7 @@ describe("useClientFeatureFlagSync", () => {
     // funnel off mid-session, possibly with the user already in checkout.
     useClientFeatureFlagStore
       .getState()
-      .setFlags({ marketingPricingTakeover: true });
+      .setFlags({ marketingPricingTakeover: true }, null);
     globalThis.fetch = (() =>
       Promise.resolve(
         new Response("boom", { status: 500 }),
@@ -207,5 +225,61 @@ describe("useClientFeatureFlagSync", () => {
 
     await Promise.resolve();
     expect(useClientFeatureFlagStore.getState().hydrated).toBe(false);
+  });
+
+  test("hydrates the scope the response was fetched under", async () => {
+    useClientFeatureFlagStore.getState().beginScope(ANONYMOUS_SCOPE);
+    fetchMock.mockImplementation(async () => flagResponse(true));
+    const queryClient = freshQueryClient();
+    renderHook(() => useClientFeatureFlagSync(true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);
+    });
+    expect(
+      useClientFeatureFlagStore.getState().marketingPricingTakeover,
+    ).toBe(true);
+  });
+
+  test("drops a response whose scope was superseded before it applied", async () => {
+    // `beginScope` runs synchronously from a store subscription, so it can land
+    // between the render that produced `data` and that render's passive effect.
+    // `ScopeMover`'s layout effect occupies that same window: React runs every
+    // layout effect in a commit before any passive effect in it.
+    useClientFeatureFlagStore.getState().beginScope(ANONYMOUS_SCOPE);
+    fetchMock.mockImplementation(async () => flagResponse(true));
+    const queryClient = freshQueryClient();
+
+    function ScopeMover() {
+      const { data } = useQuery({
+        queryKey: FLAG_QUERY_KEY,
+        queryFn: () => Promise.reject(new Error("observer never fetches")),
+        enabled: false,
+      });
+      useLayoutEffect(() => {
+        if (data) {
+          useClientFeatureFlagStore.getState().beginScope(SIGNED_IN_SCOPE);
+        }
+      }, [data]);
+      return null;
+    }
+
+    function Harness() {
+      useClientFeatureFlagSync(true);
+      return <ScopeMover />;
+    }
+
+    render(<Harness />, { wrapper: createWrapper(queryClient) });
+
+    await waitFor(() => {
+      expect(useClientFeatureFlagStore.getState().scopeKey).toBe(
+        SIGNED_IN_SCOPE,
+      );
+    });
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.hydrated).toBe(false);
+    expect(state.marketingPricingTakeover).toBe(false);
   });
 });

--- a/clients/web/src/hooks/use-client-feature-flag-sync.test.tsx
+++ b/clients/web/src/hooks/use-client-feature-flag-sync.test.tsx
@@ -11,6 +11,14 @@ const fetchMock = mock(async () =>
   }),
 );
 
+// Org-header readiness drives whether the authenticated fetch may go out at
+// all. Mutable so tests can hold it mid-resolution and then let it land.
+let orgReadinessValue: "ready" | "resolving" | "unavailable" = "ready";
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useOrgHeaderReadiness: () => orgReadinessValue,
+  useIsOrgReady: () => orgReadinessValue === "ready",
+}));
+
 const { useClientFeatureFlagSync } = await import(
   "@/hooks/use-client-feature-flag-sync"
 );
@@ -42,12 +50,14 @@ beforeEach(() => {
   window.__VELLUM_CONFIG__ = undefined;
   fetchMock.mockClear();
   globalThis.fetch = fetchMock as unknown as typeof fetch;
+  orgReadinessValue = "ready";
   useClientFeatureFlagStore.setState(initialFlagState, true);
 });
 
 afterEach(() => {
   cleanup();
   window.__VELLUM_CONFIG__ = undefined;
+  orgReadinessValue = "ready";
   globalThis.fetch = originalFetch;
 });
 
@@ -132,6 +142,61 @@ describe("useClientFeatureFlagSync", () => {
     const state = useClientFeatureFlagStore.getState();
     expect(state.hydrated).toBe(true);
     expect(state.marketingPricingTakeover).toBe(true);
+  });
+
+  test("stays unsettled while the org header source is still resolving", async () => {
+    // Authenticated cold load with no stored organization id: the session has
+    // settled but the org store has not. Firing now sends a header-less request
+    // the endpoint rejects, and settling on that failure would publish the
+    // default-off registry value as the answer — bouncing a valid pricing deep
+    // link to plans before the real value could ever land.
+    orgReadinessValue = "resolving";
+    const queryClient = freshQueryClient();
+    renderHook(() => useClientFeatureFlagSync(true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(useClientFeatureFlagStore.getState().hydrated).toBe(false);
+  });
+
+  test("fetches once the org header source lands", async () => {
+    orgReadinessValue = "resolving";
+    const queryClient = freshQueryClient();
+    const { rerender } = renderHook(() => useClientFeatureFlagSync(true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    orgReadinessValue = "ready";
+    rerender();
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);
+    });
+  });
+
+  test("settles once org resolution concludes without an organization", async () => {
+    // The bound on the wait above: the org store lands on a terminal state for
+    // every fetch outcome, and a terminal failure means the header — and so the
+    // server value — is never arriving. Staying pending forever would leave the
+    // checkout page spinning, which is its own dead end.
+    orgReadinessValue = "unavailable";
+    const queryClient = freshQueryClient();
+    renderHook(() => useClientFeatureFlagSync(true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("stays unsettled until the session is ready", async () => {

--- a/clients/web/src/hooks/use-client-feature-flag-sync.test.tsx
+++ b/clients/web/src/hooks/use-client-feature-flag-sync.test.tsx
@@ -14,6 +14,9 @@ const fetchMock = mock(async () =>
 const { useClientFeatureFlagSync } = await import(
   "@/hooks/use-client-feature-flag-sync"
 );
+const { useClientFeatureFlagStore } = await import(
+  "@/stores/client-feature-flag-store"
+);
 
 function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -33,6 +36,7 @@ beforeEach(() => {
   window.__VELLUM_CONFIG__ = undefined;
   fetchMock.mockClear();
   globalThis.fetch = fetchMock as unknown as typeof fetch;
+  useClientFeatureFlagStore.setState({ hydrated: false });
 });
 
 afterEach(() => {
@@ -62,5 +66,48 @@ describe("useClientFeatureFlagSync", () => {
 
     await Promise.resolve();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("settles the store when no server values are coming", async () => {
+    // Surfaces that wait for `hydrated` before acting on a default-off flag
+    // would hang forever otherwise.
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+    const queryClient = freshQueryClient();
+    renderHook(() => useClientFeatureFlagSync(true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);
+    });
+  });
+
+  test("settles the store when the flag fetch fails", async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response("boom", { status: 500 }),
+      )) as unknown as typeof fetch;
+    const queryClient = freshQueryClient();
+    renderHook(() => useClientFeatureFlagSync(true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    // The query retries once before giving up, so allow for its backoff.
+    await waitFor(
+      () => {
+        expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  test("stays unsettled until the session is ready", async () => {
+    const queryClient = freshQueryClient();
+    renderHook(() => useClientFeatureFlagSync(false), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await Promise.resolve();
+    expect(useClientFeatureFlagStore.getState().hydrated).toBe(false);
   });
 });

--- a/clients/web/src/hooks/use-client-feature-flag-sync.test.tsx
+++ b/clients/web/src/hooks/use-client-feature-flag-sync.test.tsx
@@ -17,6 +17,12 @@ const { useClientFeatureFlagSync } = await import(
 const { useClientFeatureFlagStore } = await import(
   "@/stores/client-feature-flag-store"
 );
+const { featureFlagsClientFlagValuesRetrieveQueryKey } = await import(
+  "@/generated/api/@tanstack/react-query.gen"
+);
+
+const FLAG_QUERY_KEY = featureFlagsClientFlagValuesRetrieveQueryKey();
+const initialFlagState = useClientFeatureFlagStore.getState();
 
 function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -36,7 +42,7 @@ beforeEach(() => {
   window.__VELLUM_CONFIG__ = undefined;
   fetchMock.mockClear();
   globalThis.fetch = fetchMock as unknown as typeof fetch;
-  useClientFeatureFlagStore.setState({ hydrated: false });
+  useClientFeatureFlagStore.setState(initialFlagState, true);
 });
 
 afterEach(() => {
@@ -99,6 +105,33 @@ describe("useClientFeatureFlagSync", () => {
       },
       { timeout: 5000 },
     );
+  });
+
+  test("keeps the values it already has when a refresh fails", async () => {
+    // A failed background refresh is not evidence the feature turned off.
+    // Falling back to registry defaults would switch a legitimately-enabled
+    // funnel off mid-session, possibly with the user already in checkout.
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true });
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response("boom", { status: 500 }),
+      )) as unknown as typeof fetch;
+    const queryClient = freshQueryClient();
+    renderHook(() => useClientFeatureFlagSync(true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(
+      () => {
+        expect(queryClient.getQueryState(FLAG_QUERY_KEY)?.status).toBe("error");
+      },
+      { timeout: 5000 },
+    );
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.hydrated).toBe(true);
+    expect(state.marketingPricingTakeover).toBe(true);
   });
 
   test("stays unsettled until the session is ready", async () => {

--- a/clients/web/src/hooks/use-client-feature-flag-sync.ts
+++ b/clients/web/src/hooks/use-client-feature-flag-sync.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/feature-flags/feature-flag-catalog";
 import { useFlagQueryFreshness } from "@/lib/backwards-compat/flag-query-freshness";
 import { featureFlagsClientFlagValuesRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+import { useOrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 import { isRemoteGatewayMode } from "@/lib/local-mode";
 
 const VALID_BOOL_KEYS = new Set(Object.keys(CLIENT_FLAG_DEFAULTS));
@@ -46,7 +47,13 @@ function mapFlags(
 
 export function useClientFeatureFlagSync(enabled: boolean) {
   const freshness = useFlagQueryFreshness();
-  const shouldFetch = enabled && !isRemoteGatewayMode();
+  // The client-flag endpoint evaluates against the signed-in user + org, so an
+  // authenticated request without `Vellum-Organization-Id` is rejected. The org
+  // store hydrates asynchronously after auth, so an authenticated cold load can
+  // reach here before the header source can answer.
+  const orgReadiness = useOrgHeaderReadiness();
+  const modeAllowsFetch = enabled && !isRemoteGatewayMode();
+  const shouldFetch = modeAllowsFetch && orgReadiness === "ready";
   const { data, isError } = useQuery({
     queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
     queryFn: fetchClientFlagValues,
@@ -65,13 +72,22 @@ export function useClientFeatureFlagSync(enabled: boolean) {
       }
       return;
     }
-    // No server values are coming: the fetch is off for this mode, or it
-    // failed. Settle the store so surfaces that wait for `hydrated` before
-    // acting on a default-off flag stop waiting instead of hanging. The store
-    // decides what to settle on — registry defaults when this scope never got
-    // a response, its last values when a refresh failed after one.
-    if (enabled && (!shouldFetch || isError)) {
+    if (!enabled) {
+      // The session hasn't settled, so no answer is due yet.
+      return;
+    }
+    // Settle only when no server values are *coming*, never merely because none
+    // have arrived. Three ways nothing is coming: this mode never fetches, the
+    // org header the request needs will never arrive, or the fetch ran and
+    // failed. A fetch that simply hasn't happened yet — org still resolving —
+    // is none of them: settling there would publish the default-off registry
+    // value as the answer and bounce a valid pricing deep link to plans before
+    // the real value could land. `"unavailable"` is the bound on that wait; the
+    // org store reaches a terminal `ready`/`error` on every fetch outcome.
+    // The store decides what to settle on — registry defaults when this scope
+    // never got a response, its last values when a refresh failed after one.
+    if (!modeAllowsFetch || orgReadiness === "unavailable" || isError) {
       useClientFeatureFlagStore.getState().settleWithoutServerValues();
     }
-  }, [data, enabled, isError, shouldFetch]);
+  }, [data, enabled, isError, modeAllowsFetch, orgReadiness]);
 }

--- a/clients/web/src/hooks/use-client-feature-flag-sync.ts
+++ b/clients/web/src/hooks/use-client-feature-flag-sync.ts
@@ -18,7 +18,17 @@ import { isRemoteGatewayMode } from "@/lib/local-mode";
 const VALID_BOOL_KEYS = new Set(Object.keys(CLIENT_FLAG_DEFAULTS));
 const VALID_STRING_KEYS = new Set(Object.keys(CLIENT_STRING_FLAG_DEFAULTS));
 
-async function fetchClientFlagValues(): Promise<ClientFeatureFlagsResponse> {
+/** A flag evaluation together with the identity it was evaluated against. */
+interface ScopedClientFlagValues {
+  scopeKey: string | null;
+  flags: ClientFeatureFlagsResponse["flags"];
+}
+
+async function fetchClientFlagValues(): Promise<ScopedClientFlagValues> {
+  // Stamp the request with the scope it goes out under. The response is applied
+  // from a passive effect, by which point the identity may have moved on, and
+  // the stamp is what lets the store tell whose answer it is holding.
+  const scopeKey = useClientFeatureFlagStore.getState().scopeKey;
   const { data, error, response } = await featureFlagsClientFlagValuesRetrieve({
     throwOnError: false,
   });
@@ -26,7 +36,7 @@ async function fetchClientFlagValues(): Promise<ClientFeatureFlagsResponse> {
   if (!response.ok || !data) {
     throw new Error(`Failed to fetch client feature flags: ${response.status}`);
   }
-  return data;
+  return { scopeKey, flags: data.flags };
 }
 
 function mapFlags(
@@ -52,6 +62,10 @@ export function useClientFeatureFlagSync(enabled: boolean) {
   // store hydrates asynchronously after auth, so an authenticated cold load can
   // reach here before the header source can answer.
   const orgReadiness = useOrgHeaderReadiness();
+  // The identity in force for this render, and so the one the settle decision
+  // below is about. Captured here rather than read in the effect, which runs
+  // after a scope change may already have claimed a different one.
+  const claimedScopeKey = useClientFeatureFlagStore.use.scopeKey();
   const modeAllowsFetch = enabled && !isRemoteGatewayMode();
   const shouldFetch = modeAllowsFetch && orgReadiness === "ready";
   const { data, isError } = useQuery({
@@ -66,9 +80,9 @@ export function useClientFeatureFlagSync(enabled: boolean) {
     if (data?.flags) {
       const { boolFlags, stringFlags } = mapFlags(data.flags);
       const store = useClientFeatureFlagStore.getState();
-      store.setFlags(boolFlags);
+      store.setFlags(boolFlags, data.scopeKey);
       if (Object.keys(stringFlags).length > 0) {
-        store.setStringFlags(stringFlags);
+        store.setStringFlags(stringFlags, data.scopeKey);
       }
       return;
     }
@@ -87,7 +101,9 @@ export function useClientFeatureFlagSync(enabled: boolean) {
     // The store decides what to settle on — registry defaults when this scope
     // never got a response, its last values when a refresh failed after one.
     if (!modeAllowsFetch || orgReadiness === "unavailable" || isError) {
-      useClientFeatureFlagStore.getState().settleWithoutServerValues();
+      useClientFeatureFlagStore
+        .getState()
+        .settleWithoutServerValues(claimedScopeKey);
     }
-  }, [data, enabled, isError, modeAllowsFetch, orgReadiness]);
+  }, [claimedScopeKey, data, enabled, isError, modeAllowsFetch, orgReadiness]);
 }

--- a/clients/web/src/hooks/use-client-feature-flag-sync.ts
+++ b/clients/web/src/hooks/use-client-feature-flag-sync.ts
@@ -66,11 +66,12 @@ export function useClientFeatureFlagSync(enabled: boolean) {
       return;
     }
     // No server values are coming: the fetch is off for this mode, or it
-    // failed. Settle the store on the registry defaults so surfaces that wait
-    // for `hydrated` before acting on a default-off flag stop waiting instead
-    // of hanging. Passing no values leaves every flag where it is.
+    // failed. Settle the store so surfaces that wait for `hydrated` before
+    // acting on a default-off flag stop waiting instead of hanging. The store
+    // decides what to settle on — registry defaults when this scope never got
+    // a response, its last values when a refresh failed after one.
     if (enabled && (!shouldFetch || isError)) {
-      useClientFeatureFlagStore.getState().setFlags({});
+      useClientFeatureFlagStore.getState().settleWithoutServerValues();
     }
   }, [data, enabled, isError, shouldFetch]);
 }

--- a/clients/web/src/hooks/use-client-feature-flag-sync.ts
+++ b/clients/web/src/hooks/use-client-feature-flag-sync.ts
@@ -47,7 +47,7 @@ function mapFlags(
 export function useClientFeatureFlagSync(enabled: boolean) {
   const freshness = useFlagQueryFreshness();
   const shouldFetch = enabled && !isRemoteGatewayMode();
-  const { data } = useQuery({
+  const { data, isError } = useQuery({
     queryKey: featureFlagsClientFlagValuesRetrieveQueryKey(),
     queryFn: fetchClientFlagValues,
     enabled: shouldFetch,
@@ -63,6 +63,14 @@ export function useClientFeatureFlagSync(enabled: boolean) {
       if (Object.keys(stringFlags).length > 0) {
         store.setStringFlags(stringFlags);
       }
+      return;
     }
-  }, [data]);
+    // No server values are coming: the fetch is off for this mode, or it
+    // failed. Settle the store on the registry defaults so surfaces that wait
+    // for `hydrated` before acting on a default-off flag stop waiting instead
+    // of hanging. Passing no values leaves every flag where it is.
+    if (enabled && (!shouldFetch || isError)) {
+      useClientFeatureFlagStore.getState().setFlags({});
+    }
+  }, [data, enabled, isError, shouldFetch]);
 }

--- a/clients/web/src/hooks/use-is-org-ready.test.tsx
+++ b/clients/web/src/hooks/use-is-org-ready.test.tsx
@@ -17,12 +17,15 @@ mock.module("@/stores/auth-store", () => ({
   useHasPlatformSession: () => hasPlatformSessionMock,
 }));
 
-const { useIsOrgReady } = await import("./use-is-org-ready");
+const { useIsOrgReady, useOrgHeaderReadiness } = await import(
+  "./use-is-org-ready"
+);
 const { useOrganizationStore } = await import("@/stores/organization-store");
 
 const STORAGE_KEY = "vellum_active_organization_id";
 
 let latest: boolean | null = null;
+let latestReadiness: string | null = null;
 
 function Probe() {
   const ready = useIsOrgReady();
@@ -32,9 +35,18 @@ function Probe() {
   return null;
 }
 
+function ReadinessProbe() {
+  const readiness = useOrgHeaderReadiness();
+  useEffect(() => {
+    latestReadiness = readiness;
+  });
+  return null;
+}
+
 beforeEach(() => {
   hasPlatformSessionMock = true;
   latest = null;
+  latestReadiness = null;
   sessionStorage.clear();
   useOrganizationStore.setState({
     organizations: [],
@@ -95,5 +107,47 @@ describe("useIsOrgReady", () => {
       useOrganizationStore.getState().clearOrganization();
     });
     expect(latest).toBe(false);
+  });
+});
+
+describe("useOrgHeaderReadiness", () => {
+  // Callers that wait for the header need "no id yet" and "no id ever" to be
+  // different answers — the boolean gate collapses them, so a waiter can't tell
+  // a cold load from a dead end.
+  test("an in-flight org fetch is resolving, not unavailable", () => {
+    useOrganizationStore.setState({ status: "loading" });
+    render(<ReadinessProbe />);
+    expect(latestReadiness).toBe("resolving");
+  });
+
+  test("an unstarted org fetch is resolving", () => {
+    render(<ReadinessProbe />);
+    expect(latestReadiness).toBe("resolving");
+  });
+
+  test("a terminal org failure with no fallback id is unavailable", () => {
+    // `fetchOrganizations()` lands on `ready` or `error` on every exit path, so
+    // this is the bound on how long a waiter can sit in `resolving`.
+    useOrganizationStore.setState({
+      status: "error",
+      error: "Failed to load organizations.",
+    });
+    render(<ReadinessProbe />);
+    expect(latestReadiness).toBe("unavailable");
+  });
+
+  test("a hydrated org id is ready", () => {
+    useOrganizationStore.setState({
+      currentOrganizationId: "org-1",
+      status: "ready",
+    });
+    render(<ReadinessProbe />);
+    expect(latestReadiness).toBe("ready");
+  });
+
+  test("no platform session needs no header at all", () => {
+    hasPlatformSessionMock = false;
+    render(<ReadinessProbe />);
+    expect(latestReadiness).toBe("ready");
   });
 });

--- a/clients/web/src/hooks/use-is-org-ready.ts
+++ b/clients/web/src/hooks/use-is-org-ready.ts
@@ -5,6 +5,43 @@ import {
 } from "@/stores/organization-store";
 
 /**
+ * How close the `Vellum-Organization-Id` header source is to producing an id.
+ *
+ * - `"ready"` — a request can carry the header now: the hydrated store, its
+ *   sessionStorage fallback, or no platform session at all (self-hosted /
+ *   gateway-only auth, where the interceptor uses bearer auth instead).
+ * - `"resolving"` — the org list is still on its way. Transient by
+ *   construction: every exit path of `fetchOrganizations()` lands on `"ready"`
+ *   or `"error"`.
+ * - `"unavailable"` — org resolution concluded and produced no usable id (the
+ *   fetch failed, or the account has no organization). Requests that need the
+ *   header cannot succeed until something re-triggers the fetch, so callers
+ *   that would otherwise wait indefinitely can stop waiting here.
+ *
+ * The three-way answer exists because "not ready" conflates two opposite
+ * situations for a caller deciding whether to keep waiting: an id that hasn't
+ * arrived *yet* and an id that is never arriving.
+ */
+export type OrgHeaderReadiness = "ready" | "resolving" | "unavailable";
+
+export function useOrgHeaderReadiness(): OrgHeaderReadiness {
+  // Reactivity: the sessionStorage fallback only changes through store
+  // actions, but not every readiness-affecting action moves the id slice —
+  // `clearOrganization()` while the fallback carried readiness is null → null.
+  // The status slice changes on those transitions, so subscribe to both.
+  const currentOrgId = useOrganizationStore.use.currentOrganizationId();
+  const status = useOrganizationStore.use.status();
+  const hasPlatformSession = useHasPlatformSession();
+  if (!hasPlatformSession) {
+    return "ready";
+  }
+  if (currentOrgId != null || getActiveOrganizationIdForRequests() != null) {
+    return "ready";
+  }
+  return status === "error" ? "unavailable" : "resolving";
+}
+
+/**
  * Gate for queries that need the `Vellum-Organization-Id` header.
  *
  * Ready when the header source (`getActiveOrganizationIdForRequests()`)
@@ -14,15 +51,5 @@ import {
  * can't wedge gated queries when a previous session already knows the org.
  */
 export function useIsOrgReady(): boolean {
-  // Reactivity: the sessionStorage fallback only changes through store
-  // actions, but not every readiness-affecting action moves the id slice —
-  // `clearOrganization()` while the fallback carried readiness is null → null.
-  // The status slice changes on those transitions, so subscribe to both.
-  const currentOrgId = useOrganizationStore.use.currentOrganizationId();
-  useOrganizationStore.use.status();
-  const hasPlatformSession = useHasPlatformSession();
-  if (!hasPlatformSession) {
-    return true;
-  }
-  return currentOrgId != null || getActiveOrganizationIdForRequests() != null;
+  return useOrgHeaderReadiness() === "ready";
 }

--- a/clients/web/src/hooks/use-marketing-pricing-takeover.test.ts
+++ b/clients/web/src/hooks/use-marketing-pricing-takeover.test.ts
@@ -5,24 +5,20 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 
 import { useMarketingPricingTakeover } from "@/hooks/use-marketing-pricing-takeover";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
+const initialState = useClientFeatureFlagStore.getState();
+
 beforeEach(() => {
-  useClientFeatureFlagStore.setState({
-    marketingPricingTakeover: false,
-    hydrated: false,
-  });
+  useClientFeatureFlagStore.setState(initialState, true);
 });
 
 afterEach(() => {
   cleanup();
-  useClientFeatureFlagStore.setState({
-    marketingPricingTakeover: false,
-    hydrated: false,
-  });
+  useClientFeatureFlagStore.setState(initialState, true);
 });
 
 describe("useMarketingPricingTakeover", () => {
@@ -44,6 +40,30 @@ describe("useMarketingPricingTakeover", () => {
       marketingPricingTakeover: true,
     });
     const { result } = renderHook(() => useMarketingPricingTakeover());
+    expect(result.current).toBe("enabled");
+  });
+
+  test("a signed-out `false` does not read as disabled once the visitor signs in", () => {
+    // The marketing page evaluates this flag for an anonymous visitor and the
+    // app evaluates it for the signed-in user + org, so the two answers
+    // legitimately differ. Reading the pre-auth answer as settled would bounce
+    // a checkout deep link the signed-in user is entitled to.
+    const store = useClientFeatureFlagStore.getState();
+    store.beginScope("anonymous:org:none");
+    store.setFlags({ marketingPricingTakeover: false });
+
+    useClientFeatureFlagStore
+      .getState()
+      .beginScope("user:user-123:org:org-abc");
+
+    const { result } = renderHook(() => useMarketingPricingTakeover());
+    expect(result.current).toBe("pending");
+
+    act(() => {
+      useClientFeatureFlagStore
+        .getState()
+        .setFlags({ marketingPricingTakeover: true });
+    });
     expect(result.current).toBe("enabled");
   });
 

--- a/clients/web/src/hooks/use-marketing-pricing-takeover.test.ts
+++ b/clients/web/src/hooks/use-marketing-pricing-takeover.test.ts
@@ -28,17 +28,17 @@ describe("useMarketingPricingTakeover", () => {
   });
 
   test("is disabled once the flags hydrate off", () => {
-    useClientFeatureFlagStore.getState().setFlags({
-      marketingPricingTakeover: false,
-    });
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: false }, null);
     const { result } = renderHook(() => useMarketingPricingTakeover());
     expect(result.current).toBe("disabled");
   });
 
   test("is enabled once the flags hydrate on", () => {
-    useClientFeatureFlagStore.getState().setFlags({
-      marketingPricingTakeover: true,
-    });
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true }, null);
     const { result } = renderHook(() => useMarketingPricingTakeover());
     expect(result.current).toBe("enabled");
   });
@@ -50,7 +50,7 @@ describe("useMarketingPricingTakeover", () => {
     // a checkout deep link the signed-in user is entitled to.
     const store = useClientFeatureFlagStore.getState();
     store.beginScope("anonymous:org:none");
-    store.setFlags({ marketingPricingTakeover: false });
+    store.setFlags({ marketingPricingTakeover: false }, "anonymous:org:none");
 
     useClientFeatureFlagStore
       .getState()
@@ -62,7 +62,10 @@ describe("useMarketingPricingTakeover", () => {
     act(() => {
       useClientFeatureFlagStore
         .getState()
-        .setFlags({ marketingPricingTakeover: true });
+        .setFlags(
+          { marketingPricingTakeover: true },
+          "user:user-123:org:org-abc",
+        );
     });
     expect(result.current).toBe("enabled");
   });

--- a/clients/web/src/hooks/use-marketing-pricing-takeover.test.ts
+++ b/clients/web/src/hooks/use-marketing-pricing-takeover.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for the `marketing-pricing-takeover` read seam — in particular the
+ * three-state result, which keeps the default-off flag from reading as
+ * "disabled" before its real value has landed.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { useMarketingPricingTakeover } from "@/hooks/use-marketing-pricing-takeover";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+beforeEach(() => {
+  useClientFeatureFlagStore.setState({
+    marketingPricingTakeover: false,
+    hydrated: false,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  useClientFeatureFlagStore.setState({
+    marketingPricingTakeover: false,
+    hydrated: false,
+  });
+});
+
+describe("useMarketingPricingTakeover", () => {
+  test("is pending before the flag values land", () => {
+    const { result } = renderHook(() => useMarketingPricingTakeover());
+    expect(result.current).toBe("pending");
+  });
+
+  test("is disabled once the flags hydrate off", () => {
+    useClientFeatureFlagStore.getState().setFlags({
+      marketingPricingTakeover: false,
+    });
+    const { result } = renderHook(() => useMarketingPricingTakeover());
+    expect(result.current).toBe("disabled");
+  });
+
+  test("is enabled once the flags hydrate on", () => {
+    useClientFeatureFlagStore.getState().setFlags({
+      marketingPricingTakeover: true,
+    });
+    const { result } = renderHook(() => useMarketingPricingTakeover());
+    expect(result.current).toBe("enabled");
+  });
+
+  test("an override reads enabled without waiting for hydration", () => {
+    // Local/env overrides apply synchronously at store init, so a `true` value
+    // is decisive on its own.
+    useClientFeatureFlagStore.setState({
+      marketingPricingTakeover: true,
+      hydrated: false,
+    });
+    const { result } = renderHook(() => useMarketingPricingTakeover());
+    expect(result.current).toBe("enabled");
+  });
+});

--- a/clients/web/src/hooks/use-marketing-pricing-takeover.ts
+++ b/clients/web/src/hooks/use-marketing-pricing-takeover.ts
@@ -1,0 +1,27 @@
+/**
+ * Read seam for the `marketing-pricing-takeover` client flag — the kill switch
+ * over the marketing pricing funnel. One flag covers both halves: the rebuilt
+ * `www.vellum.ai/pricing` takeover (served by the platform) and the
+ * `/assistant/checkout?package=<slug>` deep link its package CTAs target.
+ */
+
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+/**
+ * `"pending"` until the flag's real value is known. The flag defaults off, so
+ * a surface that redirects when it reads `false` must treat the pre-hydration
+ * window as undecided — bouncing there would strand a legitimately-enabled
+ * funnel on every cold load.
+ */
+export type MarketingPricingTakeoverState = "pending" | "enabled" | "disabled";
+
+export function useMarketingPricingTakeover(): MarketingPricingTakeoverState {
+  const enabled = useClientFeatureFlagStore.use.marketingPricingTakeover();
+  const hydrated = useClientFeatureFlagStore.use.hydrated();
+  // Local and env overrides land synchronously at store init and win over the
+  // server value, so an `enabled` read is decisive without waiting.
+  if (enabled) {
+    return "enabled";
+  }
+  return hydrated ? "disabled" : "pending";
+}

--- a/clients/web/src/hooks/use-tip-card.test.ts
+++ b/clients/web/src/hooks/use-tip-card.test.ts
@@ -46,7 +46,9 @@ const UNGATED_TIPS = TIPS_CATALOG.filter((tip) => !tip.gates);
 const SECOND_UNGATED_TIP_ID = UNGATED_TIPS[1].id;
 
 function setFlag(value: "on" | "off") {
-  useClientFeatureFlagStore.getState().setStringFlags({ proactiveTips: value });
+  useClientFeatureFlagStore
+    .getState()
+    .setStringFlags({ proactiveTips: value }, null);
 }
 
 /** Stamp first-seen far enough in the past that the new-user grace has run. */

--- a/clients/web/src/lib/billing/checkout-continuation.ts
+++ b/clients/web/src/lib/billing/checkout-continuation.ts
@@ -1,0 +1,29 @@
+/**
+ * Where the deep-link checkout route sends the user when the checkout it was
+ * asked for doesn't happen — the pricing funnel flag turned out off, the
+ * platform gate can't reach checkout, there is no package, or the account is
+ * already Pro. Absent a continuation the answer is the plans takeover.
+ *
+ * Onboarding needs a different answer. Its Start click hands off to checkout
+ * before the `marketing-pricing-takeover` flag has necessarily resolved: the
+ * flag defaults off, so a pre-hydration read is undecided, and blocking Start
+ * on a network round-trip would put a wait in front of the most important click
+ * in the funnel. Without a continuation, a pending→disabled transition drops the
+ * user on plans — outside onboarding, before research or hatching ever runs.
+ * Carrying the onboarding step Start would otherwise have taken keeps that
+ * transition inside the funnel.
+ *
+ * The value is a same-app path, sanitized on read like every other
+ * URL-supplied destination.
+ */
+import { sanitizeReturnTo } from "@/utils/return-to";
+
+export const CHECKOUT_CONTINUE_PARAM = "continue";
+
+/** The checkout route's non-purchase destination, or `fallback` when none. */
+export function checkoutContinuation(
+  searchParams: URLSearchParams,
+  fallback: string,
+): string {
+  return sanitizeReturnTo(searchParams.get(CHECKOUT_CONTINUE_PARAM), fallback);
+}

--- a/clients/web/src/lib/billing/checkout-intent.test.ts
+++ b/clients/web/src/lib/billing/checkout-intent.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import {
   clearCheckoutIntent,
   readCheckoutIntent,
+  readPurchasedCheckoutIntent,
   saveCheckoutIntent,
 } from "@/lib/billing/checkout-intent";
 
@@ -116,6 +117,47 @@ describe("saveCheckoutIntent / readCheckoutIntent", () => {
 
     expect(readCheckoutIntent()).toBeNull();
     expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("readPurchasedCheckoutIntent", () => {
+  test("suppresses a signup-marked package — no hand-off ever ran", () => {
+    saveCheckoutIntent({
+      kind: "package",
+      packageKey: "super",
+      resumeAfterOnboarding: true,
+    });
+
+    expect(readPurchasedCheckoutIntent()).toBeNull();
+    // The stash itself is untouched: the privacy screen still resumes from it.
+    expect(readCheckoutIntent()).toMatchObject({
+      kind: "package",
+      resumeAfterOnboarding: true,
+    });
+  });
+
+  test("passes through an unmarked package — what the hand-off writes", () => {
+    saveCheckoutIntent({ kind: "package", packageKey: "mighty" });
+
+    expect(readPurchasedCheckoutIntent()).toMatchObject({
+      kind: "package",
+      packageKey: "mighty",
+    });
+  });
+
+  test("passes through a custom intent", () => {
+    saveCheckoutIntent({
+      kind: "custom",
+      machineTier: "medium",
+      storageTier: null,
+      creditTier: null,
+    });
+
+    expect(readPurchasedCheckoutIntent()).toMatchObject({ kind: "custom" });
+  });
+
+  test("returns null when nothing is stashed", () => {
+    expect(readPurchasedCheckoutIntent()).toBeNull();
   });
 });
 

--- a/clients/web/src/lib/billing/checkout-intent.ts
+++ b/clients/web/src/lib/billing/checkout-intent.ts
@@ -23,8 +23,11 @@ export type CheckoutIntent =
        * signup routed through consent). Only the onboarding privacy screen
        * resumes checkout from a marked intent, so an ordinary billing-surface
        * stash (CheckoutPage, the plans/adjust takeovers) can't hijack
-       * onboarding. Optional and backward-compatible: ordinary saves omit it,
-       * and the provisioning takeover ignores it.
+       * onboarding. Optional and backward-compatible: ordinary saves omit it.
+       *
+       * The Stripe hand-off rewrites the stash without the marker, so a marked
+       * stash is one no checkout ever handed off — see
+       * {@link readPurchasedCheckoutIntent}.
        */
       resumeAfterOnboarding?: true;
     }
@@ -99,6 +102,24 @@ export function readCheckoutIntent(): CheckoutIntent | null {
     return null;
   }
   return parsed;
+}
+
+/**
+ * The stashed intent when it names a package the user actually paid for, else
+ * `null`.
+ *
+ * A stash still carrying `resumeAfterOnboarding` never reached the Stripe
+ * hand-off — the hand-off replaces the record without the marker — so it names
+ * a package nobody bought. Surfaces that report a purchase to the user read
+ * this rather than {@link readCheckoutIntent}, which every bail path would
+ * otherwise leave able to render a phantom.
+ */
+export function readPurchasedCheckoutIntent(): CheckoutIntent | null {
+  const intent = readCheckoutIntent();
+  if (intent?.kind === "package" && intent.resumeAfterOnboarding === true) {
+    return null;
+  }
+  return intent;
 }
 
 export function clearCheckoutIntent(): void {

--- a/clients/web/src/lib/feature-flags/client-flag-scope.test.ts
+++ b/clients/web/src/lib/feature-flags/client-flag-scope.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the flag-scope watcher — in particular the anonymous → signed-in
+ * hand-off, where the pre-auth evaluation and the authenticated one can
+ * legitimately disagree and the pre-auth answer must not be read as settled.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  currentClientFlagScopeKey,
+  setupClientFlagScopeSync,
+} from "@/lib/feature-flags/client-flag-scope";
+import { useAuthStore } from "@/stores/auth-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { useOrganizationStore } from "@/stores/organization-store";
+
+const initialAuthState = useAuthStore.getState();
+const initialOrganizationState = useOrganizationStore.getState();
+const initialFlagState = useClientFeatureFlagStore.getState();
+
+let teardown: (() => void) | null = null;
+
+function signIn(userId: string) {
+  useAuthStore.setState({
+    sessionStatus: "authenticated",
+    user: {
+      kind: "platform",
+      id: userId,
+      username: null,
+      email: null,
+      isStaff: false,
+      firstName: "",
+      lastName: "",
+    },
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useAuthStore.setState(initialAuthState, true);
+  useOrganizationStore.setState(initialOrganizationState, true);
+  useClientFeatureFlagStore.setState(initialFlagState, true);
+});
+
+afterEach(() => {
+  teardown?.();
+  teardown = null;
+});
+
+describe("currentClientFlagScopeKey", () => {
+  test("reports the anonymous scope with no session", () => {
+    useAuthStore.setState({ sessionStatus: "unauthenticated", user: null });
+    expect(currentClientFlagScopeKey()).toBe("anonymous:org:none");
+  });
+
+  test("reports the user and org once both resolve", () => {
+    signIn("user-123");
+    useOrganizationStore.setState({ currentOrganizationId: "org-abc" });
+    expect(currentClientFlagScopeKey()).toBe("user:user-123:org:org-abc");
+  });
+});
+
+describe("setupClientFlagScopeSync", () => {
+  test("un-settles an anonymous evaluation when the visitor signs in", () => {
+    useAuthStore.setState({ sessionStatus: "unauthenticated", user: null });
+    teardown = setupClientFlagScopeSync();
+    // The `/account/*` screens sync flags for anonymous visitors: the flag
+    // evaluates off for a signed-out context and the store settles on it.
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: false });
+    expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);
+
+    signIn("user-123");
+
+    // The signed-in evaluation hasn't landed yet, so nothing is settled and a
+    // redirect-on-flag surface reads "pending" instead of bouncing.
+    expect(useClientFeatureFlagStore.getState().hydrated).toBe(false);
+  });
+
+  test("takes the authenticated evaluation over the anonymous one", () => {
+    useAuthStore.setState({ sessionStatus: "unauthenticated", user: null });
+    teardown = setupClientFlagScopeSync();
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: false });
+
+    signIn("user-123");
+    useOrganizationStore.setState({ currentOrganizationId: "org-abc" });
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true });
+
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.hydrated).toBe(true);
+    expect(state.marketingPricingTakeover).toBe(true);
+  });
+
+  test("drops an anonymous `true` rather than letting it stand for the user", () => {
+    useAuthStore.setState({ sessionStatus: "unauthenticated", user: null });
+    teardown = setupClientFlagScopeSync();
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true });
+
+    signIn("user-123");
+
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.marketingPricingTakeover).toBe(false);
+    expect(state.hydrated).toBe(false);
+  });
+
+  test("re-opens hydration when the org resolves after the user", () => {
+    signIn("user-123");
+    teardown = setupClientFlagScopeSync();
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true });
+
+    useOrganizationStore.setState({ currentOrganizationId: "org-abc" });
+
+    expect(useClientFeatureFlagStore.getState().hydrated).toBe(false);
+  });
+
+  test("leaves a settled scope alone on unrelated auth store writes", () => {
+    signIn("user-123");
+    useOrganizationStore.setState({ currentOrganizationId: "org-abc" });
+    teardown = setupClientFlagScopeSync();
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true });
+
+    useAuthStore.setState({ platformSession: "present" });
+
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.hydrated).toBe(true);
+    expect(state.marketingPricingTakeover).toBe(true);
+  });
+
+  test("stops watching once torn down", () => {
+    useAuthStore.setState({ sessionStatus: "unauthenticated", user: null });
+    setupClientFlagScopeSync()();
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: false });
+
+    signIn("user-123");
+
+    expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);
+  });
+});

--- a/clients/web/src/lib/feature-flags/client-flag-scope.test.ts
+++ b/clients/web/src/lib/feature-flags/client-flag-scope.test.ts
@@ -68,7 +68,10 @@ describe("setupClientFlagScopeSync", () => {
     // evaluates off for a signed-out context and the store settles on it.
     useClientFeatureFlagStore
       .getState()
-      .setFlags({ marketingPricingTakeover: false });
+      .setFlags(
+        { marketingPricingTakeover: false },
+        currentClientFlagScopeKey(),
+      );
     expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);
 
     signIn("user-123");
@@ -83,13 +86,19 @@ describe("setupClientFlagScopeSync", () => {
     teardown = setupClientFlagScopeSync();
     useClientFeatureFlagStore
       .getState()
-      .setFlags({ marketingPricingTakeover: false });
+      .setFlags(
+        { marketingPricingTakeover: false },
+        currentClientFlagScopeKey(),
+      );
 
     signIn("user-123");
     useOrganizationStore.setState({ currentOrganizationId: "org-abc" });
     useClientFeatureFlagStore
       .getState()
-      .setFlags({ marketingPricingTakeover: true });
+      .setFlags(
+        { marketingPricingTakeover: true },
+        currentClientFlagScopeKey(),
+      );
 
     const state = useClientFeatureFlagStore.getState();
     expect(state.hydrated).toBe(true);
@@ -101,7 +110,10 @@ describe("setupClientFlagScopeSync", () => {
     teardown = setupClientFlagScopeSync();
     useClientFeatureFlagStore
       .getState()
-      .setFlags({ marketingPricingTakeover: true });
+      .setFlags(
+        { marketingPricingTakeover: true },
+        currentClientFlagScopeKey(),
+      );
 
     signIn("user-123");
 
@@ -115,7 +127,10 @@ describe("setupClientFlagScopeSync", () => {
     teardown = setupClientFlagScopeSync();
     useClientFeatureFlagStore
       .getState()
-      .setFlags({ marketingPricingTakeover: true });
+      .setFlags(
+        { marketingPricingTakeover: true },
+        currentClientFlagScopeKey(),
+      );
 
     useOrganizationStore.setState({ currentOrganizationId: "org-abc" });
 
@@ -128,7 +143,10 @@ describe("setupClientFlagScopeSync", () => {
     teardown = setupClientFlagScopeSync();
     useClientFeatureFlagStore
       .getState()
-      .setFlags({ marketingPricingTakeover: true });
+      .setFlags(
+        { marketingPricingTakeover: true },
+        currentClientFlagScopeKey(),
+      );
 
     useAuthStore.setState({ platformSession: "present" });
 
@@ -142,7 +160,10 @@ describe("setupClientFlagScopeSync", () => {
     setupClientFlagScopeSync()();
     useClientFeatureFlagStore
       .getState()
-      .setFlags({ marketingPricingTakeover: false });
+      .setFlags(
+        { marketingPricingTakeover: false },
+        currentClientFlagScopeKey(),
+      );
 
     signIn("user-123");
 

--- a/clients/web/src/lib/feature-flags/client-flag-scope.test.ts
+++ b/clients/web/src/lib/feature-flags/client-flag-scope.test.ts
@@ -14,6 +14,8 @@ import { useAuthStore } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 
+const ORGANIZATION_STORAGE_KEY = "vellum_active_organization_id";
+
 const initialAuthState = useAuthStore.getState();
 const initialOrganizationState = useOrganizationStore.getState();
 const initialFlagState = useClientFeatureFlagStore.getState();
@@ -37,6 +39,7 @@ function signIn(userId: string) {
 
 beforeEach(() => {
   localStorage.clear();
+  sessionStorage.clear();
   useAuthStore.setState(initialAuthState, true);
   useOrganizationStore.setState(initialOrganizationState, true);
   useClientFeatureFlagStore.setState(initialFlagState, true);
@@ -56,6 +59,16 @@ describe("currentClientFlagScopeKey", () => {
   test("reports the user and org once both resolve", () => {
     signIn("user-123");
     useOrganizationStore.setState({ currentOrganizationId: "org-abc" });
+    expect(currentClientFlagScopeKey()).toBe("user:user-123:org:org-abc");
+  });
+
+  test("names the org the request header carries, not the store slice", () => {
+    // Before the org list lands the store's id slice is null while the
+    // sessionStorage fallback still answers, and that fallback is what
+    // `Vellum-Organization-Id` is built from — so the evaluation the server
+    // returns is org-abc's.
+    signIn("user-123");
+    sessionStorage.setItem(ORGANIZATION_STORAGE_KEY, "org-abc");
     expect(currentClientFlagScopeKey()).toBe("user:user-123:org:org-abc");
   });
 });
@@ -153,6 +166,47 @@ describe("setupClientFlagScopeSync", () => {
     const state = useClientFeatureFlagStore.getState();
     expect(state.hydrated).toBe(true);
     expect(state.marketingPricingTakeover).toBe(true);
+  });
+
+  test("drops fallback-scoped values when clearOrganization revokes the fallback", () => {
+    // The store's id slice is null throughout: readiness, the request header,
+    // and therefore the evaluation all come from the sessionStorage fallback.
+    // Dropping it is a real identity change even though no slice moves.
+    signIn("user-123");
+    sessionStorage.setItem(ORGANIZATION_STORAGE_KEY, "org-abc");
+    teardown = setupClientFlagScopeSync();
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true }, currentClientFlagScopeKey());
+    expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);
+
+    useOrganizationStore.getState().clearOrganization();
+
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.marketingPricingTakeover).toBe(false);
+    expect(state.hydrated).toBe(false);
+  });
+
+  test("refuses to re-apply the revoked org's cached response", () => {
+    // The request-scoped query cache is keyed on the store's id slice, which
+    // never moved, so the flag query still holds org-abc's response. Its scope
+    // stamp is what keeps it from hydrating the scope that replaced it.
+    signIn("user-123");
+    sessionStorage.setItem(ORGANIZATION_STORAGE_KEY, "org-abc");
+    teardown = setupClientFlagScopeSync();
+    const cachedScopeKey = currentClientFlagScopeKey();
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true }, cachedScopeKey);
+
+    useOrganizationStore.getState().clearOrganization();
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true }, cachedScopeKey);
+
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.marketingPricingTakeover).toBe(false);
+    expect(state.hydrated).toBe(false);
   });
 
   test("stops watching once torn down", () => {

--- a/clients/web/src/lib/feature-flags/client-flag-scope.ts
+++ b/clients/web/src/lib/feature-flags/client-flag-scope.ts
@@ -13,8 +13,9 @@
  * The watcher runs outside React rather than from a layout effect. The store
  * writes that move the scope (session settle, login, org resolution) happen in
  * plain callbacks, so a subscription resets the flag store before React
- * re-renders — child route effects (which run ahead of any layout's) can no
- * longer read the previous identity's values as settled.
+ * re-renders. A layout effect would lose the race: a child route's own redirect
+ * effect runs ahead of its parent layout's, and would read the previous
+ * identity's values as settled.
  */
 import { useAuthStore } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";

--- a/clients/web/src/lib/feature-flags/client-flag-scope.ts
+++ b/clients/web/src/lib/feature-flags/client-flag-scope.ts
@@ -1,0 +1,54 @@
+/**
+ * Ties the client feature-flag store's hydration to the identity its values
+ * were evaluated for.
+ *
+ * The platform evaluates client flags against the signed-in user + org, or
+ * against an anonymous context when there is no session — so the two answers
+ * legitimately differ. The `/account/*` screens sync flags for anonymous
+ * visitors, which means a pre-sign-in value is already in the store when the
+ * authenticated app mounts. Left alone it reads as settled, and a surface that
+ * redirects on a default-off flag bounces before the authenticated response
+ * lands.
+ *
+ * The watcher runs outside React rather than from a layout effect. The store
+ * writes that move the scope (session settle, login, org resolution) happen in
+ * plain callbacks, so a subscription resets the flag store before React
+ * re-renders — child route effects (which run ahead of any layout's) can no
+ * longer read the previous identity's values as settled.
+ */
+import { useAuthStore } from "@/stores/auth-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { useOrganizationStore } from "@/stores/organization-store";
+import { isAuthenticated } from "@/stores/session-status";
+import { requestScopeKey } from "@/utils/request-scope-key";
+
+/**
+ * The identity client flags currently evaluate against. Built from the same
+ * inputs as the request-scoped query cache's key, so the store and the cache
+ * can never disagree about which identity a response belongs to.
+ */
+export function currentClientFlagScopeKey(): string {
+  const { sessionStatus, user } = useAuthStore.getState();
+  return requestScopeKey({
+    isAuthenticated: isAuthenticated(sessionStatus),
+    userId: user?.id,
+    organizationId: useOrganizationStore.getState().currentOrganizationId,
+  });
+}
+
+/** Call once at startup. Returns an unsubscribe for tests. */
+export function setupClientFlagScopeSync(): () => void {
+  const claimCurrentScope = () => {
+    useClientFeatureFlagStore
+      .getState()
+      .beginScope(currentClientFlagScopeKey());
+  };
+  claimCurrentScope();
+  const unsubscribeAuth = useAuthStore.subscribe(claimCurrentScope);
+  const unsubscribeOrganization =
+    useOrganizationStore.subscribe(claimCurrentScope);
+  return () => {
+    unsubscribeAuth();
+    unsubscribeOrganization();
+  };
+}

--- a/clients/web/src/lib/feature-flags/client-flag-scope.ts
+++ b/clients/web/src/lib/feature-flags/client-flag-scope.ts
@@ -19,27 +19,44 @@
  */
 import { useAuthStore } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
-import { useOrganizationStore } from "@/stores/organization-store";
+import {
+  getActiveOrganizationIdForRequests,
+  useOrganizationStore,
+} from "@/stores/organization-store";
 import { isAuthenticated } from "@/stores/session-status";
 import { requestScopeKey } from "@/utils/request-scope-key";
 
 /**
- * The identity client flags currently evaluate against. Built from the same
- * inputs as the request-scoped query cache's key, so a move rotates the cache
- * and the claimed scope together. Agreement is enforced rather than assumed:
- * values carry the scope they were produced under, and the store drops any the
- * scope in hand no longer answers.
+ * The identity client flags currently evaluate against.
+ *
+ * The organization comes from `getActiveOrganizationIdForRequests()` — the
+ * same derivation that builds `Vellum-Organization-Id` and that
+ * `useOrgHeaderReadiness()` releases the fetch on — so the scope names whoever
+ * the server actually evaluated for. The store's id slice alone would not: it
+ * is null while the sessionStorage fallback is carrying requests, which stamps
+ * an organization's evaluation as belonging to no organization at all.
+ *
+ * Agreement is enforced rather than assumed: values carry the scope they were
+ * produced under, and the store drops any the scope in hand no longer answers.
  */
 export function currentClientFlagScopeKey(): string {
   const { sessionStatus, user } = useAuthStore.getState();
   return requestScopeKey({
     isAuthenticated: isAuthenticated(sessionStatus),
     userId: user?.id,
-    organizationId: useOrganizationStore.getState().currentOrganizationId,
+    organizationId: getActiveOrganizationIdForRequests(),
   });
 }
 
-/** Call once at startup. Returns an unsubscribe for tests. */
+/**
+ * Call once at startup. Returns an unsubscribe for tests.
+ *
+ * Subscribing without a selector is what lets the scope follow a non-reactive
+ * source: every write to the sessionStorage fallback is immediately followed by
+ * an organization-store `set()`, and a selectorless subscriber runs on all of
+ * them — including the ones that leave every slice untouched, like
+ * `clearOrganization()` revoking a fallback the id slice never held.
+ */
 export function setupClientFlagScopeSync(): () => void {
   const claimCurrentScope = () => {
     useClientFeatureFlagStore

--- a/clients/web/src/lib/feature-flags/client-flag-scope.ts
+++ b/clients/web/src/lib/feature-flags/client-flag-scope.ts
@@ -25,8 +25,10 @@ import { requestScopeKey } from "@/utils/request-scope-key";
 
 /**
  * The identity client flags currently evaluate against. Built from the same
- * inputs as the request-scoped query cache's key, so the store and the cache
- * can never disagree about which identity a response belongs to.
+ * inputs as the request-scoped query cache's key, so a move rotates the cache
+ * and the claimed scope together. Agreement is enforced rather than assumed:
+ * values carry the scope they were produced under, and the store drops any the
+ * scope in hand no longer answers.
  */
 export function currentClientFlagScopeKey(): string {
   const { sessionStatus, user } = useAuthStore.getState();

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -356,6 +356,14 @@
       "label": "Composer Secret Guard",
       "description": "Detect API keys/secrets typed into the chat composer and offer secure credential storage before send",
       "defaultEnabled": false
+    },
+    {
+      "id": "marketing-pricing-takeover",
+      "scope": "client",
+      "key": "marketing-pricing-takeover",
+      "label": "Marketing Pricing Takeover",
+      "description": "Gates the marketing pricing takeover page (www.vellum.ai/pricing) and the `/assistant/checkout?package=<slug>` deep link its package CTAs target. One flag covers both halves of the funnel so they can never be enabled independently and strand a CTA. When off, the checkout deep link redirects to the in-app plans takeover.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/clients/web/src/main.tsx
+++ b/clients/web/src/main.tsx
@@ -11,6 +11,7 @@ import { RouterProvider } from "react-router";
 import { AppProviders } from "@/components/providers";
 import { WindowDragRegion } from "@/components/window-drag-region";
 import { isChunkLoadError } from "@/lib/chunk-errors";
+import { setupClientFlagScopeSync } from "@/lib/feature-flags/client-flag-scope";
 import { installConsentRefreshListeners } from "@/lib/consent/consent-refresh";
 import { isLocalMode, loadLockfile } from "@/lib/local-mode";
 import { initSentry } from "@/lib/sentry/sentry-init";
@@ -39,6 +40,10 @@ async function boot() {
   installConsentRefreshListeners();
 
   setupOrganizationStore();
+  // Register before initSession so no identity transition is missed: client
+  // flags are evaluated per (user, org) and must be re-fetched, not re-read,
+  // when either moves.
+  setupClientFlagScopeSync();
   // Register before initSession so the boot `unknown → present` transition it
   // drives is caught and the platform assistants list is loaded.
   setupPlatformAssistantsSync();

--- a/clients/web/src/stores/client-feature-flag-store.test.ts
+++ b/clients/web/src/stores/client-feature-flag-store.test.ts
@@ -1,5 +1,7 @@
 /**
- * Tests for how the client flag store handles a change of evaluation scope.
+ * Tests for the two ways the client flag store leaves the pre-hydration
+ * window: claiming a new evaluation scope, and settling when no server values
+ * are coming.
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
@@ -15,6 +17,49 @@ const initialState = useClientFeatureFlagStore.getState();
 beforeEach(() => {
   localStorage.clear();
   useClientFeatureFlagStore.setState(initialState, true);
+});
+
+describe("settleWithoutServerValues", () => {
+  test("settles an unhydrated scope on the registry defaults", () => {
+    // A value left over from somewhere other than this scope's own response.
+    useClientFeatureFlagStore.setState({
+      marketingPricingTakeover: true,
+      hydrated: false,
+    });
+
+    useClientFeatureFlagStore.getState().settleWithoutServerValues();
+
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.hydrated).toBe(true);
+    expect(state.marketingPricingTakeover).toBe(
+      CLIENT_FLAG_DEFAULTS.marketingPricingTakeover,
+    );
+  });
+
+  test("keeps the last server values when a refresh fails after a success", () => {
+    // A failed background refresh must not switch a legitimately-enabled
+    // feature off mid-session — potentially while the user is in checkout.
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true });
+    expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);
+
+    useClientFeatureFlagStore.getState().settleWithoutServerValues();
+
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.hydrated).toBe(true);
+    expect(state.marketingPricingTakeover).toBe(true);
+  });
+
+  test("keeps a local override rather than the registry default", () => {
+    localStorage.setItem("vellum:ff:marketingPricingTakeover", "true");
+
+    useClientFeatureFlagStore.getState().settleWithoutServerValues();
+
+    expect(
+      useClientFeatureFlagStore.getState().marketingPricingTakeover,
+    ).toBe(true);
+  });
 });
 
 describe("beginScope", () => {

--- a/clients/web/src/stores/client-feature-flag-store.test.ts
+++ b/clients/web/src/stores/client-feature-flag-store.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for how the client flag store handles a change of evaluation scope.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import {
+  CLIENT_FLAG_DEFAULTS,
+  CLIENT_STRING_FLAG_DEFAULTS,
+} from "@/lib/feature-flags/feature-flag-catalog";
+
+const initialState = useClientFeatureFlagStore.getState();
+
+beforeEach(() => {
+  localStorage.clear();
+  useClientFeatureFlagStore.setState(initialState, true);
+});
+
+describe("beginScope", () => {
+  test("drops the previous identity's values and re-opens hydration", () => {
+    useClientFeatureFlagStore.getState().beginScope("anonymous:org:none");
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true });
+
+    useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
+
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.hydrated).toBe(false);
+    expect(state.marketingPricingTakeover).toBe(
+      CLIENT_FLAG_DEFAULTS.marketingPricingTakeover,
+    );
+  });
+
+  test("drops the previous identity's string values too", () => {
+    useClientFeatureFlagStore.getState().beginScope("anonymous:org:none");
+    useClientFeatureFlagStore
+      .getState()
+      .setStringFlags({ proactiveTips: "on" });
+
+    useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
+
+    expect(
+      useClientFeatureFlagStore.getState().stringFlags.proactiveTips,
+    ).toBe(CLIENT_STRING_FLAG_DEFAULTS.proactiveTips);
+  });
+
+  test("is a no-op for the scope already claimed", () => {
+    useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true });
+
+    useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
+
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.hydrated).toBe(true);
+    expect(state.marketingPricingTakeover).toBe(true);
+  });
+
+  test("keeps local overrides across a scope change", () => {
+    localStorage.setItem("vellum:ff:marketingPricingTakeover", "true");
+    useClientFeatureFlagStore.getState().beginScope("anonymous:org:none");
+
+    useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
+
+    expect(
+      useClientFeatureFlagStore.getState().marketingPricingTakeover,
+    ).toBe(true);
+  });
+});

--- a/clients/web/src/stores/client-feature-flag-store.test.ts
+++ b/clients/web/src/stores/client-feature-flag-store.test.ts
@@ -27,7 +27,7 @@ describe("settleWithoutServerValues", () => {
       hydrated: false,
     });
 
-    useClientFeatureFlagStore.getState().settleWithoutServerValues();
+    useClientFeatureFlagStore.getState().settleWithoutServerValues(null);
 
     const state = useClientFeatureFlagStore.getState();
     expect(state.hydrated).toBe(true);
@@ -41,10 +41,10 @@ describe("settleWithoutServerValues", () => {
     // feature off mid-session — potentially while the user is in checkout.
     useClientFeatureFlagStore
       .getState()
-      .setFlags({ marketingPricingTakeover: true });
+      .setFlags({ marketingPricingTakeover: true }, null);
     expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);
 
-    useClientFeatureFlagStore.getState().settleWithoutServerValues();
+    useClientFeatureFlagStore.getState().settleWithoutServerValues(null);
 
     const state = useClientFeatureFlagStore.getState();
     expect(state.hydrated).toBe(true);
@@ -54,7 +54,7 @@ describe("settleWithoutServerValues", () => {
   test("keeps a local override rather than the registry default", () => {
     localStorage.setItem("vellum:ff:marketingPricingTakeover", "true");
 
-    useClientFeatureFlagStore.getState().settleWithoutServerValues();
+    useClientFeatureFlagStore.getState().settleWithoutServerValues(null);
 
     expect(
       useClientFeatureFlagStore.getState().marketingPricingTakeover,
@@ -67,7 +67,7 @@ describe("beginScope", () => {
     useClientFeatureFlagStore.getState().beginScope("anonymous:org:none");
     useClientFeatureFlagStore
       .getState()
-      .setFlags({ marketingPricingTakeover: true });
+      .setFlags({ marketingPricingTakeover: true }, "anonymous:org:none");
 
     useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
 
@@ -82,7 +82,7 @@ describe("beginScope", () => {
     useClientFeatureFlagStore.getState().beginScope("anonymous:org:none");
     useClientFeatureFlagStore
       .getState()
-      .setStringFlags({ proactiveTips: "on" });
+      .setStringFlags({ proactiveTips: "on" }, "anonymous:org:none");
 
     useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
 
@@ -95,7 +95,7 @@ describe("beginScope", () => {
     useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
     useClientFeatureFlagStore
       .getState()
-      .setFlags({ marketingPricingTakeover: true });
+      .setFlags({ marketingPricingTakeover: true }, "user:user-123:org:org-abc");
 
     useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
 
@@ -113,5 +113,78 @@ describe("beginScope", () => {
     expect(
       useClientFeatureFlagStore.getState().marketingPricingTakeover,
     ).toBe(true);
+  });
+});
+
+describe("scope guarding", () => {
+  test("drops flags evaluated for a superseded scope", () => {
+    useClientFeatureFlagStore.getState().beginScope("anonymous:org:none");
+    useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
+
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true }, "anonymous:org:none");
+
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.hydrated).toBe(false);
+    expect(state.marketingPricingTakeover).toBe(
+      CLIENT_FLAG_DEFAULTS.marketingPricingTakeover,
+    );
+  });
+
+  test("drops string flags evaluated for a superseded scope", () => {
+    useClientFeatureFlagStore.getState().beginScope("anonymous:org:none");
+    useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
+
+    useClientFeatureFlagStore
+      .getState()
+      .setStringFlags({ proactiveTips: "on" }, "anonymous:org:none");
+
+    expect(
+      useClientFeatureFlagStore.getState().stringFlags.proactiveTips,
+    ).toBe(CLIENT_STRING_FLAG_DEFAULTS.proactiveTips);
+  });
+
+  test("applies flags evaluated for the scope in hand", () => {
+    useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
+
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true }, "user:user-123:org:org-abc");
+
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.hydrated).toBe(true);
+    expect(state.marketingPricingTakeover).toBe(true);
+  });
+
+  test("drops a settle decided under a superseded scope", () => {
+    useClientFeatureFlagStore.getState().beginScope("anonymous:org:none");
+    useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
+
+    useClientFeatureFlagStore
+      .getState()
+      .settleWithoutServerValues("anonymous:org:none");
+
+    expect(useClientFeatureFlagStore.getState().hydrated).toBe(false);
+  });
+
+  test("settles the scope the decision was made under", () => {
+    useClientFeatureFlagStore.getState().beginScope("user:user-123:org:org-abc");
+
+    useClientFeatureFlagStore
+      .getState()
+      .settleWithoutServerValues("user:user-123:org:org-abc");
+
+    expect(useClientFeatureFlagStore.getState().hydrated).toBe(true);
+  });
+
+  test("applies unscoped values when no identity has been claimed", () => {
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ marketingPricingTakeover: true }, null);
+
+    const state = useClientFeatureFlagStore.getState();
+    expect(state.hydrated).toBe(true);
+    expect(state.marketingPricingTakeover).toBe(true);
   });
 });

--- a/clients/web/src/stores/client-feature-flag-store.ts
+++ b/clients/web/src/stores/client-feature-flag-store.ts
@@ -46,6 +46,23 @@ const localOverrides = readOverrides();
 const localStringOverrides = readStringOverrides();
 const envOverrides = getEnvFlagOverridesForScope("client");
 
+/**
+ * The values to hold when no server response stands behind them: registry
+ * defaults, with local and env overrides layered back on top. Overrides are
+ * the developer's answer for every identity, so they survive a scope change.
+ */
+function flagsWithoutServerValues(): Record<string, boolean> {
+  return { ...CLIENT_FLAG_DEFAULTS, ...readOverrides(), ...envOverrides.bool };
+}
+
+function stringFlagsWithoutServerValues(): Record<string, string> {
+  return {
+    ...CLIENT_STRING_FLAG_DEFAULTS,
+    ...readStringOverrides(),
+    ...envOverrides.str,
+  };
+}
+
 interface ClientFeatureFlagMeta {
   stringFlags: Record<string, string>;
   /**
@@ -57,10 +74,18 @@ interface ClientFeatureFlagMeta {
    * synchronously at store init and win over the server value anyway.
    */
   hydrated: boolean;
+  /**
+   * The identity the current server values were evaluated against — the same
+   * `requestScopeKey` the request-scoped query cache is keyed by — or `null`
+   * before any scope has been claimed. Flags are evaluated per (user, org),
+   * so a value is only an answer for the scope it was fetched in.
+   */
+  scopeKey: string | null;
 }
 
 interface ClientFeatureFlagActions {
   setFlags: (flags: Record<string, boolean>) => void;
+  beginScope: (scopeKey: string) => void;
   setFlag: (key: string, value: boolean) => void;
   clearOverride: (key: string) => void;
   setStringFlags: (flags: Record<string, string>) => void;
@@ -72,13 +97,22 @@ type ClientFeatureFlagStore = Record<string, boolean> &
   ClientFeatureFlagMeta &
   ClientFeatureFlagActions;
 
-// See assistant-feature-flag-store.ts for why setStr() is needed.
+/**
+ * A partial the store accepts but `Partial<ClientFeatureFlagStore>` rejects:
+ * the `Record<string, boolean>` index signature makes every non-boolean meta
+ * field (`stringFlags`, `scopeKey`) incompatible. See
+ * assistant-feature-flag-store.ts for the same workaround.
+ */
+type ClientFeatureFlagPartial = Partial<ClientFeatureFlagMeta> & {
+  [key: string]: boolean | string | null | Record<string, string> | undefined;
+};
+
 const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
   (set) => {
-    const setStr = set as unknown as (
+    const setMeta = set as unknown as (
       partial:
-        | { stringFlags: Record<string, string> }
-        | ((state: ClientFeatureFlagStore) => { stringFlags: Record<string, string> } | ClientFeatureFlagStore),
+        | ClientFeatureFlagPartial
+        | ((state: ClientFeatureFlagStore) => ClientFeatureFlagPartial | ClientFeatureFlagStore),
     ) => void;
 
     return ({
@@ -87,6 +121,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
       ...envOverrides.bool,
       stringFlags: { ...CLIENT_STRING_FLAG_DEFAULTS, ...localStringOverrides, ...envOverrides.str },
       hydrated: false,
+      scopeKey: null,
 
       setFlags: (flags: Record<string, boolean>) =>
         set((prev) => {
@@ -102,6 +137,29 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
             return prev.hydrated ? prev : { hydrated: true };
           }
           return { ...merged, hydrated: true };
+        }),
+
+      /**
+       * Claim `scopeKey` as the identity the next server values belong to.
+       *
+       * A different identity means the values in hand answer a question nobody
+       * asked: an anonymous evaluation says nothing about the signed-in one, in
+       * either direction. So a scope change drops the previous identity's
+       * server values and re-opens the pre-hydration window, leaving surfaces
+       * that gate on `hydrated` waiting for the new identity's response rather
+       * than acting on the old one's.
+       */
+      beginScope: (scopeKey: string) =>
+        setMeta((prev) => {
+          if (prev.scopeKey === scopeKey) {
+            return prev;
+          }
+          return {
+            ...flagsWithoutServerValues(),
+            stringFlags: stringFlagsWithoutServerValues(),
+            hydrated: false,
+            scopeKey,
+          };
         }),
 
       setFlag: (key: string, value: boolean) => {
@@ -126,7 +184,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
       },
 
       setStringFlags: (flags: Record<string, string>) =>
-        setStr((prev) => {
+        setMeta((prev) => {
           const overrides = readStringOverrides();
           const merged = { ...flags, ...overrides, ...envOverrides.str };
           const prevStr = prev.stringFlags;
@@ -142,7 +200,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
         } catch {
           // localStorage unavailable
         }
-        setStr((prev) => ({
+        setMeta((prev) => ({
           stringFlags: { ...prev.stringFlags, [key]: envOverrides.str[key] ?? value },
         }));
       },
@@ -154,7 +212,7 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
           // localStorage unavailable
         }
         const defaultValue = envOverrides.str[key] ?? CLIENT_STRING_FLAG_DEFAULTS[key];
-        setStr((prev) => ({
+        setMeta((prev) => ({
           stringFlags: {
             ...prev.stringFlags,
             [key]: defaultValue ?? "",

--- a/clients/web/src/stores/client-feature-flag-store.ts
+++ b/clients/web/src/stores/client-feature-flag-store.ts
@@ -78,10 +78,10 @@ interface ClientFeatureFlagMeta {
    */
   hydrated: boolean;
   /**
-   * The identity the current server values were evaluated against — the same
-   * `requestScopeKey` the request-scoped query cache is keyed by — or `null`
-   * before any scope has been claimed. Flags are evaluated per (user, org),
-   * so a value is only an answer for the scope it was fetched in.
+   * The identity the current server values were evaluated against — the
+   * `requestScopeKey` of the session and organization the request carried — or
+   * `null` before any scope has been claimed. Flags are evaluated per (user,
+   * org), so a value is only an answer for the scope it was fetched in.
    */
   scopeKey: string | null;
 }

--- a/clients/web/src/stores/client-feature-flag-store.ts
+++ b/clients/web/src/stores/client-feature-flag-store.ts
@@ -49,7 +49,8 @@ const envOverrides = getEnvFlagOverridesForScope("client");
 /**
  * The values to hold when no server response stands behind them: registry
  * defaults, with local and env overrides layered back on top. Overrides are
- * the developer's answer for every identity, so they survive a scope change.
+ * the developer's answer for every identity and every fetch outcome, so they
+ * survive both a scope change and a settle.
  */
 function flagsWithoutServerValues(): Record<string, boolean> {
   return { ...CLIENT_FLAG_DEFAULTS, ...readOverrides(), ...envOverrides.bool };
@@ -86,6 +87,7 @@ interface ClientFeatureFlagMeta {
 interface ClientFeatureFlagActions {
   setFlags: (flags: Record<string, boolean>) => void;
   beginScope: (scopeKey: string) => void;
+  settleWithoutServerValues: () => void;
   setFlag: (key: string, value: boolean) => void;
   clearOverride: (key: string) => void;
   setStringFlags: (flags: Record<string, string>) => void;
@@ -160,6 +162,27 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
             hydrated: false,
             scopeKey,
           };
+        }),
+
+      /**
+       * Settle hydration when no server values are coming. Two situations
+       * reach here and they want different answers:
+       *
+       * - Nothing has landed for this scope — the fetch is off for this mode,
+       *   or the first attempt failed. Registry defaults are the honest answer,
+       *   and settling stops surfaces that wait on `hydrated` from hanging.
+       * - A refresh failed after an earlier success in the same scope. The last
+       *   values the server gave for this identity remain the best answer;
+       *   falling back to defaults would switch a legitimately-enabled feature
+       *   off mid-session over one failed request. Hydration is already
+       *   settled, so nothing needs to change.
+       */
+      settleWithoutServerValues: () =>
+        set((prev) => {
+          if (prev.hydrated) {
+            return prev;
+          }
+          return { ...flagsWithoutServerValues(), hydrated: true };
         }),
 
       setFlag: (key: string, value: boolean) => {

--- a/clients/web/src/stores/client-feature-flag-store.ts
+++ b/clients/web/src/stores/client-feature-flag-store.ts
@@ -67,12 +67,14 @@ function stringFlagsWithoutServerValues(): Record<string, string> {
 interface ClientFeatureFlagMeta {
   stringFlags: Record<string, string>;
   /**
-   * False until the first server flag response has been applied via
-   * `setFlags`. Routes that redirect on a default-off flag must wait for this
-   * before bouncing — otherwise a cold load races the async LD fetch and
-   * redirects away before the real value (possibly `true`) arrives. Stays
-   * meaningful regardless of local/env overrides, which are applied
-   * synchronously at store init and win over the server value anyway.
+   * Whether the values in hand are a real answer for {@link scopeKey} — set by
+   * `setFlags` when this scope's server response lands, or by
+   * `settleWithoutServerValues` when none is coming, and cleared by
+   * `beginScope` when the identity moves. Routes that redirect on a default-off
+   * flag must wait for this before bouncing — otherwise a cold load races the
+   * async LD fetch and redirects away before the real value (possibly `true`)
+   * arrives. Stays meaningful regardless of local/env overrides, which are
+   * applied synchronously at store init and win over the server value anyway.
    */
   hydrated: boolean;
   /**

--- a/clients/web/src/stores/client-feature-flag-store.ts
+++ b/clients/web/src/stores/client-feature-flag-store.ts
@@ -87,14 +87,37 @@ interface ClientFeatureFlagMeta {
 }
 
 interface ClientFeatureFlagActions {
-  setFlags: (flags: Record<string, boolean>) => void;
+  setFlags: (flags: Record<string, boolean>, scopeKey: string | null) => void;
   beginScope: (scopeKey: string) => void;
-  settleWithoutServerValues: () => void;
+  settleWithoutServerValues: (scopeKey: string | null) => void;
   setFlag: (key: string, value: boolean) => void;
   clearOverride: (key: string) => void;
-  setStringFlags: (flags: Record<string, string>) => void;
+  setStringFlags: (
+    flags: Record<string, string>,
+    scopeKey: string | null,
+  ) => void;
   setStringFlag: (key: string, value: string) => void;
   clearStringOverride: (key: string) => void;
+}
+
+/**
+ * Whether values produced for `scopeKey` still answer the identity the store
+ * has claimed.
+ *
+ * Flags are evaluated per (user, org), so a response — or a decision that none
+ * is coming — is only an answer for the scope it was produced under. The two
+ * can drift apart because `beginScope` runs synchronously from a store
+ * subscription while the values are applied from a passive effect that closed
+ * over an earlier render: the claim lands first, and the write that follows
+ * carries the previous identity's answer. Enforcing the match here rather than
+ * at the call site keeps "values may only hydrate the scope they were produced
+ * for" a property of the store.
+ *
+ * A `null` on either side is an unclaimed store or an unscoped write, which
+ * nothing contradicts.
+ */
+function answersScope(claimed: string | null, scopeKey: string | null): boolean {
+  return claimed === null || scopeKey === null || claimed === scopeKey;
 }
 
 type ClientFeatureFlagStore = Record<string, boolean> &
@@ -127,8 +150,11 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
       hydrated: false,
       scopeKey: null,
 
-      setFlags: (flags: Record<string, boolean>) =>
+      setFlags: (flags: Record<string, boolean>, scopeKey: string | null) =>
         set((prev) => {
+          if (!answersScope(prev.scopeKey, scopeKey)) {
+            return prev;
+          }
           const overrides = readOverrides();
           const merged = { ...flags, ...overrides, ...envOverrides.bool };
           const changed = Object.keys(merged).some(
@@ -179,9 +205,9 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
        *   off mid-session over one failed request. Hydration is already
        *   settled, so nothing needs to change.
        */
-      settleWithoutServerValues: () =>
+      settleWithoutServerValues: (scopeKey: string | null) =>
         set((prev) => {
-          if (prev.hydrated) {
+          if (prev.hydrated || !answersScope(prev.scopeKey, scopeKey)) {
             return prev;
           }
           return { ...flagsWithoutServerValues(), hydrated: true };
@@ -208,8 +234,14 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
         }
       },
 
-      setStringFlags: (flags: Record<string, string>) =>
+      setStringFlags: (
+        flags: Record<string, string>,
+        scopeKey: string | null,
+      ) =>
         setMeta((prev) => {
+          if (!answersScope(prev.scopeKey, scopeKey)) {
+            return prev;
+          }
           const overrides = readStringOverrides();
           const merged = { ...flags, ...overrides, ...envOverrides.str };
           const prevStr = prev.stringFlags;

--- a/clients/web/src/utils/request-scope-key.ts
+++ b/clients/web/src/utils/request-scope-key.ts
@@ -1,0 +1,20 @@
+/**
+ * The (user, organization) identity a platform response was produced for.
+ *
+ * The platform evaluates per-request state against this pair — feature flags
+ * most visibly, since the LaunchDarkly context is the signed-in user + org, or
+ * an anonymous context when there is no session, and the two evaluations
+ * legitimately differ. Anything that caches or stores a platform response keys
+ * it by this string so a value fetched for one identity is never read as the
+ * answer for another.
+ */
+export function requestScopeKey(input: {
+  isAuthenticated: boolean;
+  userId: string | null | undefined;
+  organizationId: string | null | undefined;
+}): string {
+  const identity = input.isAuthenticated
+    ? `user:${input.userId ?? "unknown"}`
+    : "anonymous";
+  return `${identity}:org:${input.organizationId ?? "none"}`;
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -356,6 +356,14 @@
       "label": "Composer Secret Guard",
       "description": "Detect API keys/secrets typed into the chat composer and offer secure credential storage before send",
       "defaultEnabled": false
+    },
+    {
+      "id": "marketing-pricing-takeover",
+      "scope": "client",
+      "key": "marketing-pricing-takeover",
+      "label": "Marketing Pricing Takeover",
+      "description": "Gates the marketing pricing takeover page (www.vellum.ai/pricing) and the `/assistant/checkout?package=<slug>` deep link its package CTAs target. One flag covers both halves of the funnel so they can never be enabled independently and strand a CTA. When off, the checkout deep link redirects to the in-app plans takeover.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Depends on

**[vellum-assistant-platform#9515](https://github.com/vellum-ai/vellum-assistant-platform/pull/9515) must merge and apply first.** That Terraform PR creates the `marketing-pricing-takeover` LaunchDarkly flag. Until it applies, this registry entry has no remote counterpart and every client resolves the registry default — off — so the checkout deep link redirects to plans for everyone. That is the intended fail-closed behavior, but the funnel cannot be turned on until the flag exists.

Based on `Jasonnnz/pricing-checkout-flow`, not `main`.

## What

Registers the `marketing-pricing-takeover` client flag (default off) and gates the app half of the marketing pricing funnel behind it.

One flag covers both halves of the funnel — the rebuilt `www.vellum.ai/pricing` takeover (platform repo, separate PR) and the `/assistant/checkout?package=<slug>` deep link its package CTAs target — so the two can never be enabled independently and strand a CTA.

## The three-state read

The flag defaults off, so `false` is ambiguous on a cold load: it means "off" *or* "the real value hasn't arrived yet". `useMarketingPricingTakeover()` reports `pending` / `enabled` / `disabled` and every consumer only acts on `disabled`. Redirecting on the cold-load default would bounce every legitimate deep link before LaunchDarkly answered.

`useClientFeatureFlagSync` now settles the flag store when no server values are coming — the fetch is disabled for the mode (remote-gateway), or it failed — so `pending` is always bounded by the query lifecycle and a checkout deep link can never hang waiting on a flag that will never arrive.

## Route gate

`CheckoutPage` redirects to the in-app plans takeover (`routes.plans`) when the flag is positively off, alongside its existing `!packageKey` / `gate === "disabled" | "gated"` bounces. A marketing link cached from while the funnel was live lands somewhere useful instead of dead-ending or starting a purchase. The upgrade POST is held while the flag is `pending`.

Worth noting the contexts differ on the two halves: the marketing page evaluates the flag against an anonymous visitor, the app against an authenticated user. A percentage rollout can legitimately serve one `true` and the other `false`, so the redirect is a real path, not just a kill-switch race.

## Post-auth carry: gated at the resume end, not the stash end

The signup carry (`post-auth-checkout.ts` stashes the package → `privacy-screen.tsx` resumes it after consent) is deliberately **not** gated at the stash.

`resolveSignupCheckoutDestination` runs the instant auth completes, well before the client flag query resolves. Reading the flag there would see the default `false` on essentially every signup and drop the package for flag-**on** users — breaking the exact happy path the flag is meant to protect.

The resume is gated instead. By the time the user reads the consent screen and clicks Start, the flag has settled. Without that gate, a flag-off user carrying a stash would hand off to `/assistant/checkout`, get redirected to `/assistant/plans`, and — having no assistant yet — be funneled by the navigation resolver to `onboarding/hatching`, **skipping research onboarding entirely**. Gating the resume drops the dead package (`clearCheckoutIntent()`) and lets onboarding continue normally down `onboardingDestinationAfterConsent`. An unresolved flag still resumes; the checkout route's own gate catches it.

## Files

- `meta/feature-flags/feature-flag-registry.json` + the synced `clients/web` bundled copy (`bun run meta/sync-bundled-copies.ts`)
- `clients/web/src/hooks/use-marketing-pricing-takeover.ts` — the read seam (new)
- `clients/web/src/hooks/use-client-feature-flag-sync.ts` — settle on unavailable flags
- `clients/web/src/domains/settings/billing/checkout-page.tsx` — route gate
- `clients/web/src/domains/onboarding/pages/privacy-screen.tsx` — resume gate

## Verification

- `bun run test:ci` (clients/web) — 726 passed, 0 failed
- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (only pre-existing `curly` warnings on untouched lines)
- `bun run audit:cross-domain:check` — clean
- `bun run meta/sync-bundled-copies.ts --check` — in sync
- assistant + gateway feature-flag guard/resolver suites — 70 passed, 0 failed

Manual QA once #9515 applies:
1. Flag off → `/assistant/checkout?package=<slug>` redirects to `/assistant/plans`, no upgrade POST, no Stripe redirect.
2. Flag on → checkout fires once and hands off to Stripe as before.
3. Flag off mid-signup → pricing CTA → signup → consent → Start lands on research onboarding, not checkout.
4. Cold load with the flag on → spinner briefly, then checkout fires (never an early bounce to plans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)