### PR TITLE
feat(ios): add the VoiceSessionAttributes ActivityKit model

### DIFF
--- a/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
+++ b/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
@@ -1,0 +1,100 @@
+import ActivityKit
+import Foundation
+
+/// ActivityKit model describing a running live-voice session.
+///
+/// Compiled into both the app (which requests and updates the activity) and the
+/// widget extension (which renders it), so this file must stay free of UI and of
+/// app-only imports — `ActivityKit` and `Foundation` only.
+///
+/// `assistantName` is an attribute rather than part of `ContentState` because it
+/// is fixed for the lifetime of an activity; everything that changes mid-session
+/// lives in `ContentState`.
+struct VoiceSessionAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        /// Session phase, mirroring `LiveVoiceSessionState` in
+        /// `clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts`,
+        /// which is the source of truth. **The two enums must be changed
+        /// together**: the web side sends these raw values across the Capacitor
+        /// bridge, so a case added or renamed there without a matching change
+        /// here fails to decode.
+        ///
+        /// `idle` is deliberately absent. An idle session has no Live Activity,
+        /// so a case for it would be unreachable state the island UI would still
+        /// have to handle.
+        enum Phase: String, Codable, Hashable {
+            case connecting
+            case listening
+            case transcribing
+            case thinking
+            case speaking
+            case ending
+            case failed
+        }
+
+        /// Neutral accent (`systemGray`) used when `accentHex` is unparseable.
+        static let neutralAccentHex = "#8E8E93"
+
+        var phase: Phase
+
+        /// User-facing activity copy, passed through from the web side.
+        ///
+        /// `LIVE_VOICE_STATE_LABELS` and `liveVoiceStateLabel` (including its
+        /// `reconnecting` → "Reconnecting…" case) in `live-voice-store.ts` are
+        /// the single source of this copy. **The native side must never invent
+        /// its own phase wording** — the shell ships on App Store cadence while
+        /// that copy deploys continuously, so a native `switch` over `phase`
+        /// would silently fossilize old strings.
+        var label: String
+
+        /// Avatar accent the voice room renders, as `#RRGGBB` (`#RRGGBBAA` and
+        /// `#RGB` are accepted and canonicalized), so the island matches the
+        /// room. Always parseable: unrecognized input falls back to
+        /// ``neutralAccentHex`` rather than trapping.
+        var accentHex: String
+
+        var muted: Bool
+
+        init(phase: Phase, label: String, accentHex: String, muted: Bool) {
+            self.phase = phase
+            self.label = label
+            self.accentHex = Self.canonicalAccentHex(accentHex)
+            self.muted = muted
+        }
+
+        /// Decoding funnels through the validating initializer so the
+        /// always-parseable `accentHex` invariant survives the trip across the
+        /// process boundary into the widget extension.
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.init(
+                phase: try container.decode(Phase.self, forKey: .phase),
+                label: try container.decode(String.self, forKey: .label),
+                accentHex: try container.decode(String.self, forKey: .accentHex),
+                muted: try container.decode(Bool.self, forKey: .muted)
+            )
+        }
+
+        /// Canonicalizes a CSS hex color (`#RGB`, `#RRGGBB`, `#RRGGBBAA`, with
+        /// the `#` optional) to `#` plus uppercase digits, falling back to
+        /// ``neutralAccentHex`` for anything else. The accepted grammar matches
+        /// `UIColor(cssHex:)`, so the canonical form always parses.
+        static func canonicalAccentHex(_ raw: String) -> String {
+            var digits = raw.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+            if digits.hasPrefix("#") {
+                digits.removeFirst()
+            }
+            if digits.count == 3 {
+                digits = digits.map { "\($0)\($0)" }.joined()
+            }
+            guard digits.count == 6 || digits.count == 8,
+                  digits.allSatisfy({ $0.isASCII && $0.isHexDigit })
+            else {
+                return neutralAccentHex
+            }
+            return "#" + digits
+        }
+    }
+
+    var assistantName: String
+}


### PR DESCRIPTION
Adds the ActivityKit model for the live-voice Live Activity. Inert on merge — nothing requests an activity yet; this lands on its own so the widget-extension targets, the island presentations, and the `VoiceLiveActivity` plugin can proceed in parallel.

## What's here

`VoiceSessionAttributes` with a `ContentState` of `phase` / `label` / `accentHex` / `muted`, and `assistantName` as an attribute (fixed for the activity's lifetime, so it does not belong in `ContentState`).

**`ContentState.Phase` mirrors `LiveVoiceSessionState`** from `clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts` — seven cases, raw values string-matching the web union, with the docstring naming that file as the source of truth and stating the change-together rule (the web side sends these raw values over the bridge). `idle` is deliberately omitted: an idle session has no Live Activity, so the case would be unreachable state the island UI would still have to handle.

**`label` is passed through, never derived natively.** `LIVE_VOICE_STATE_LABELS` / `liveVoiceStateLabel` (including the `reconnecting` → "Reconnecting…" case) stay the single source of user-facing copy. The shell ships on App Store cadence while that copy deploys continuously, so a native `switch` over `phase` would silently fossilize old wording. That constraint is documented on the property.

**`accentHex` is validated, not trusted.** The initializer canonicalizes to `#` plus uppercase digits and falls back to a neutral `systemGray` hex on anything unparseable rather than trapping. `init(from:)` funnels through the same initializer so the always-parseable invariant survives decoding into the widget extension. The accepted grammar (`#RGB` / `#RRGGBB` / `#RRGGBBAA`, `#` optional) matches the existing `UIColor(cssHex:)` parser in `MyViewController.swift`, so the canonical form always parses.

The file imports only `ActivityKit` and `Foundation` — no UI, no `Capacitor`/`UIKit` — so a widget extension can compile it unchanged from one copy on disk.

## Verification

- `project.yml` needed **no change**: the `AppEnvironment` template's `App` source path already sweeps subdirectories. After `bun run ios:setup`, the generated pbxproj lists `VoiceSessionAttributes.swift` in the Sources build phase of all three app targets (`App`, `App Staging`, `App Dev`) from a single file reference.
- No `@available` annotations are needed with the deployment target at 17.0 — verified with `swiftc -typecheck -target arm64-apple-ios17.0` against the iOS SDK, which is clean.
- `CapApp-SPM/Package.swift` is untouched.
- No `#Preview` / `PreviewProvider` blocks.

Full `xcodebuild` could not run locally (this machine's Xcode resolves zero destinations for `generic/platform=iOS` — pre-existing and environmental, reproduced against an unmodified baseline), so the `PR iOS Checks` workflow is the real build gate.