### PR TITLE
feat(ios): add a VoiceAudioSession plugin and enable background audio

### DIFF
--- a/clients/ios/App/App/Info.plist
+++ b/clients/ios/App/App/Info.plist
@@ -71,6 +71,7 @@
 	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -4,10 +4,10 @@ import WebKit
 
 /// Custom `CAPBridgeViewController` subclass that:
 ///
-/// 1. Registers `NativeAuthPlugin` and `NativeBiometricPlugin` as local
-///    plugin instances at bridge init time. These plugins live inside the
-///    App target (no SPM module) so the bridge won't discover them
-///    automatically.
+/// 1. Registers `NativeAuthPlugin`, `NativeBiometricPlugin`, and
+///    `VoiceAudioSessionPlugin` as local plugin instances at bridge init
+///    time. These plugins live inside the App target (no SPM module) so the
+///    bridge won't discover them automatically.
 ///
 /// 2. Injects `WKUserScript`s at `.atDocumentEnd` to:
 ///    a) Pin focusable fields to a minimum 16px font-size, preventing the
@@ -144,6 +144,7 @@ class MyViewController: CAPBridgeViewController {
     override open func capacitorDidLoad() {
         bridge?.registerPluginInstance(NativeAuthPlugin())
         bridge?.registerPluginInstance(NativeBiometricPlugin())
+        bridge?.registerPluginInstance(VoiceAudioSessionPlugin())
         installNavigationDelegateProxy()
         installInputZoomPreventionUserScript()
         installViewportZoomLockUserScript()

--- a/clients/ios/App/App/VoiceAudioSessionPlugin.swift
+++ b/clients/ios/App/App/VoiceAudioSessionPlugin.swift
@@ -1,0 +1,255 @@
+import AVFoundation
+import Capacitor
+
+/// Capacitor plugin that owns the app's `AVAudioSession` for the duration of a
+/// live-voice session, and reports the two system events that can interrupt or
+/// reroute it.
+///
+/// ## Why this exists
+///
+/// Live voice runs entirely in the web layer today (mic capture, the velay
+/// WebSocket, and TTS playback all live under
+/// `clients/web/src/domains/chat/voice/live-voice/`). `WKWebView` configures a
+/// default audio session on the app's behalf, and that default is wrong for a
+/// full-duplex voice assistant in two ways: it does not survive the app going
+/// to the background, and it does not engage the system voice-processing I/O
+/// unit. This plugin lets the web layer request the right session at the start
+/// of a voice session and hand it back at the end.
+///
+/// Paired with `audio` in `UIBackgroundModes` (see `Info.plist`), an active
+/// `.playAndRecord` session keeps the app's audio running while the app is
+/// backgrounded or the screen is locked. Note that the background mode buys
+/// *audio*; it does not by itself guarantee that a backgrounded web process
+/// keeps feeding that audio pipeline.
+///
+/// ## Unresolved: does the webview voice session actually survive backgrounding?
+///
+/// The empirical verdict is **still outstanding**. The device spike that was
+/// meant to answer it (does `getUserMedia` keep producing PCM, and does the
+/// velay WebSocket keep pumping, once `WKWebView` is backgrounded or the screen
+/// is locked?) has not been run, and no findings document exists. If that spike
+/// concludes "must move native", capture and the socket move to
+/// `AVAudioEngine` + `URLSessionWebSocketTask` in Swift — and this plugin
+/// becomes the audio-session half of that native path rather than a standalone
+/// hint to the webview. Either way a correctly configured `AVAudioSession` is a
+/// prerequisite, which is why this lands before the verdict is in. A native
+/// capture path may follow; it would extend this plugin, not replace it.
+///
+/// ## Why `.voiceChat` mode
+///
+/// `.voiceChat` is deliberate, not cosmetic. It selects the system
+/// voice-processing I/O unit, which gives us hardware echo cancellation and
+/// automatic gain control, and it routes AirPods and other Bluetooth headsets
+/// over HFP so the mic input actually comes from the headset.
+///
+/// This is expected to interact with the echo-adaptive barge-in gate
+/// (JARVIS-1296) in `clients/web/src/domains/chat/voice/live-voice/`: that gate
+/// exists to compensate, in software, for the assistant hearing its own TTS
+/// output. Hardware AEC reduces the echo the gate is tuned against, so the
+/// gate's thresholds may end up conservative on iOS once this ships. **Any
+/// barge-in retuning is a separate follow-up, explicitly not this PR** — this
+/// plugin deliberately changes only the audio session configuration so the
+/// barge-in behavior can be measured against a stable baseline.
+///
+/// ## Skew contract
+///
+/// The iOS app is a `server.url` shell: the web bundle updates continuously
+/// while this shell only changes on an App Store release, so an arbitrarily new
+/// bundle can be running against an arbitrarily old shell. `isAvailable` is the
+/// capability probe the web side uses to detect a shell that has this plugin;
+/// on an older shell the same call rejects with Capacitor's "not implemented"
+/// error, which `callNativeVoice` in `clients/web/src/runtime/native-voice.ts`
+/// swallows into its fallback. No method here may ever crash or hang — a failed
+/// bridge call must degrade to a voice session that behaves as it does today.
+///
+/// References:
+/// - https://developer.apple.com/documentation/avfaudio/avaudiosession
+/// - https://developer.apple.com/documentation/avfaudio/avaudiosession/mode/voicechat
+@objc(VoiceAudioSessionPlugin)
+public class VoiceAudioSessionPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "VoiceAudioSessionPlugin"
+    public let jsName = "VoiceAudioSession"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "activate", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "deactivate", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "isAvailable", returnType: CAPPluginReturnPromise),
+    ]
+
+    /// Event names forwarded to JS via `notifyListeners`. Must match the
+    /// listener names in `clients/web/src/runtime/`.
+    private static let interruptionEvent = "voiceAudioInterruption"
+    private static let routeChangeEvent = "voiceAudioRouteChange"
+
+    /// Stable rejection code for every `AVAudioSession` failure, so the web
+    /// side can branch on it without matching against a localized message.
+    private static let failureCode = "AUDIO_SESSION_FAILED"
+
+    // MARK: - Lifecycle
+
+    /// Subscribe to the session events for the plugin's lifetime. Capacitor
+    /// calls `load()` once, when the bridge instantiates the plugin, so these
+    /// observers outlive any individual voice session — a route change that
+    /// happens between sessions is still reported, and `notifyListeners` is a
+    /// no-op when JS has no listener attached.
+    override public func load() {
+        let center = NotificationCenter.default
+        let session = AVAudioSession.sharedInstance()
+        center.addObserver(
+            self,
+            selector: #selector(handleInterruption(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: session
+        )
+        center.addObserver(
+            self,
+            selector: #selector(handleRouteChange(_:)),
+            name: AVAudioSession.routeChangeNotification,
+            object: session
+        )
+    }
+
+    // MARK: - activate
+
+    /// Configure and activate the voice audio session.
+    ///
+    /// `.playAndRecord` is the only category that supports simultaneous capture
+    /// and playback, and the only one the `audio` background mode applies to
+    /// for a full-duplex session. `.defaultToSpeaker` keeps hands-free output on
+    /// the loudspeaker rather than the earpiece when no headset is attached —
+    /// without it, `.playAndRecord` routes playback to the receiver and the
+    /// assistant sounds like a phone call held to your ear.
+    ///
+    /// Resolves `{ activated: true }`. On an `AVAudioSession` throw it rejects
+    /// with the stable `AUDIO_SESSION_FAILED` code rather than crashing; the web
+    /// caller treats that as "no native audio session" and proceeds.
+    @objc public func activate(_ call: CAPPluginCall) {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            // `.allowBluetoothHFP` is the current spelling of the option long
+            // known as `.allowBluetooth`, which is now deprecated.
+            try session.setCategory(
+                .playAndRecord,
+                mode: .voiceChat,
+                options: [.allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
+            )
+            try session.setActive(true)
+            call.resolve(["activated": true])
+        } catch {
+            call.reject(
+                "Failed to activate the voice audio session: \(error.localizedDescription)",
+                Self.failureCode,
+                error
+            )
+        }
+    }
+
+    // MARK: - deactivate
+
+    /// Release the voice audio session.
+    ///
+    /// `.notifyOthersOnDeactivation` is what lets music, podcasts, and other
+    /// apps' audio that we interrupted resume where they left off. Without it
+    /// the user is left with silence after a voice session ends.
+    ///
+    /// Resolves `{}` on success and rejects with `AUDIO_SESSION_FAILED` on
+    /// throw. Deactivation failing is not fatal to anything — the caller
+    /// fire-and-forgets it.
+    @objc public func deactivate(_ call: CAPPluginCall) {
+        do {
+            try AVAudioSession.sharedInstance().setActive(
+                false,
+                options: .notifyOthersOnDeactivation
+            )
+            call.resolve()
+        } catch {
+            call.reject(
+                "Failed to deactivate the voice audio session: \(error.localizedDescription)",
+                Self.failureCode,
+                error
+            )
+        }
+    }
+
+    // MARK: - isAvailable
+
+    /// Capability probe. Resolving at all is the signal: a shell that predates
+    /// this plugin rejects the call with "not implemented" instead.
+    @objc public func isAvailable(_ call: CAPPluginCall) {
+        call.resolve(["available": true])
+    }
+
+    // MARK: - System events
+
+    /// Forward an audio-session interruption (an incoming phone call, Siri,
+    /// another app taking the session) to JS as `voiceAudioInterruption`
+    /// `{ type: "began" | "ended", shouldResume: Bool }`.
+    ///
+    /// `shouldResume` is only ever true on `.ended`, and only when the system
+    /// says the interrupting audio is finished and it is safe to reactivate.
+    @objc private func handleInterruption(_ notification: Notification) {
+        guard let raw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: raw)
+        else { return }
+
+        let shouldResume: Bool
+        if type == .ended,
+           let rawOptions = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt {
+            shouldResume = AVAudioSession.InterruptionOptions(rawValue: rawOptions).contains(.shouldResume)
+        } else {
+            shouldResume = false
+        }
+
+        emit(Self.interruptionEvent, data: [
+            "type": type == .began ? "began" : "ended",
+            "shouldResume": shouldResume,
+        ])
+    }
+
+    /// Forward a route change (AirPods removed, headphones unplugged, a
+    /// Bluetooth device connecting) to JS as `voiceAudioRouteChange`
+    /// `{ reason: String }`.
+    @objc private func handleRouteChange(_ notification: Notification) {
+        guard let raw = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt,
+              let reason = AVAudioSession.RouteChangeReason(rawValue: raw)
+        else { return }
+
+        emit(Self.routeChangeEvent, data: ["reason": Self.routeChangeReasonName(for: reason)])
+    }
+
+    /// `notifyListeners` walks the plugin's `eventListeners` dictionary, which
+    /// JS mutates on the main thread via `addListener`/`removeListener`.
+    /// `AVAudioSession` posts its notifications on an arbitrary thread, so hop
+    /// to main before touching it.
+    private func emit(_ event: String, data: [String: Any]) {
+        DispatchQueue.main.async { [weak self] in
+            self?.notifyListeners(event, data: data)
+        }
+    }
+
+    /// Stable JS-facing names for `AVAudioSession.RouteChangeReason`. Kept as an
+    /// explicit mapping rather than the raw integer so the web side reads as
+    /// intent, and so a future OS case degrades to `"unknown"` instead of a
+    /// number nothing handles.
+    private static func routeChangeReasonName(for reason: AVAudioSession.RouteChangeReason) -> String {
+        switch reason {
+        case .unknown:
+            return "unknown"
+        case .newDeviceAvailable:
+            return "newDeviceAvailable"
+        case .oldDeviceUnavailable:
+            return "oldDeviceUnavailable"
+        case .categoryChange:
+            return "categoryChange"
+        case .override:
+            return "override"
+        case .wakeFromSleep:
+            return "wakeFromSleep"
+        case .noSuitableRouteForCategory:
+            return "noSuitableRouteForCategory"
+        case .routeConfigurationChange:
+            return "routeConfigurationChange"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -30,9 +30,12 @@ which URL is baked into the build.
   process. With `server.url`, only native shell changes (Swift code,
   entitlements, Capacitor plugin updates) require a store submission.
 - **Thin native surface** — the IPC bridge between the WKWebView and
-  native code is minimal (two plugins: `NativeAuthPlugin` and
-  `NativeBiometricPlugin`), so version skew risk between the web app
-  and native shell is low. Contrast with the Electron app, where the
+  native code is minimal (three plugins: `NativeAuthPlugin`,
+  `NativeBiometricPlugin`, and `VoiceAudioSessionPlugin`), so version
+  skew risk between the web app and native shell is low. Every plugin
+  call from the web side must still be capability-probed, because a new
+  web bundle always ships ahead of the shell that hosts it. Contrast
+  with the Electron app, where the
   `window.vellum.*` IPC surface is broad and tightly coupled.
 - **WKWebView security model** — unlike Electron's renderer, `WKWebView`
   runs in a full iOS process sandbox with no access to native APIs
@@ -133,7 +136,7 @@ Apple's reference for the toolbar controls:
 
 The app has two layers — the **WKWebView contents** (the React app loaded
 from the configured server URL) and the **native Swift shell** (Capacitor
-bridge, `MyViewController`, the two native plugins). Each has its own
+bridge, `MyViewController`, the three native plugins). Each has its own
 debugger.
 
 ### Safari Web Inspector — for the web side (JS / CSS / network / `console.log`)
@@ -180,8 +183,8 @@ For a **physical iPhone**:
 
 ⌘R runs with `lldb` already attached. Click in the gutter next to any
 line in `AppDelegate.swift`, `MyViewController.swift`,
-`NativeAuthPlugin.swift`, or `NativeBiometricPlugin.swift` to set a
-breakpoint.
+`NativeAuthPlugin.swift`, `NativeBiometricPlugin.swift`, or
+`VoiceAudioSessionPlugin.swift` to set a breakpoint.
 
 - **Console / log output**: View → Debug Area → Activate Console (⇧⌘Y),
   or click the bottom-right console toggle. `print()` and `NSLog()` from
@@ -199,7 +202,8 @@ breakpoint.
 
 ### Common debugging recipes
 
-- **A native plugin call (`NativeAuth`, `NativeBiometric`) seems broken**:
+- **A native plugin call (`NativeAuth`, `NativeBiometric`,
+  `VoiceAudioSession`) seems broken**:
   set a Swift breakpoint in the relevant `@objc func` inside the plugin
   file and trigger the action from the web app. If the breakpoint never
   hits, the JS-side `Capacitor.Plugins.NativeAuth` lookup is wrong (check
@@ -551,6 +555,7 @@ clients/
     │   │   ├── MyViewController.swift  # CAPBridgeViewController subclass
     │   │   ├── NativeAuthPlugin.swift  # ASWebAuthenticationSession OIDC flow
     │   │   ├── NativeBiometricPlugin.swift # Face ID / Touch ID Keychain
+    │   │   ├── VoiceAudioSessionPlugin.swift # AVAudioSession for live voice
     │   │   └── Info.plist
     │   └── CapApp-SPM/               # SPM local package: pulls in @capacitor/ios
     │                                 # and any Capacitor plugin native deps


### PR DESCRIPTION
Adds the native audio-session half of iOS voice mode: a `VoiceAudioSession` Capacitor plugin plus the `audio` background mode, so a live-voice session can hold a correctly configured `AVAudioSession` for its lifetime and keep producing audio when the app is backgrounded.

## What changed

- **`clients/ios/App/App/VoiceAudioSessionPlugin.swift`** (new) — follows the `NativeBiometricPlugin` shape (`@objc(VoiceAudioSessionPlugin)`, `CAPPlugin, CAPBridgedPlugin`, `jsName = "VoiceAudioSession"`, `pluginMethods` of `CAPPluginReturnPromise`):
  - `activate` — `setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker])` then `setActive(true)`; resolves `{ activated: true }`, rejects with the stable `AUDIO_SESSION_FAILED` code on throw, never crashes. `.voiceChat` is deliberate — it selects the system voice-processing I/O unit (hardware AEC + AGC) and gets AirPods/Bluetooth-HFP routing right.
  - `deactivate` — `setActive(false, options: .notifyOthersOnDeactivation)` so other apps' audio resumes; resolves `{}`.
  - `isAvailable` — resolves `{ available: true }`. This is the capability probe the web side uses; an older App Store shell rejects the same call with "not implemented", which `callNativeVoice` swallows into its fallback.
  - Observes `AVAudioSession.interruptionNotification` and `routeChangeNotification`, forwarding them to JS as `voiceAudioInterruption` (`{ type: "began" | "ended", shouldResume: Bool }`) and `voiceAudioRouteChange` (`{ reason: String }`). Emitting both now keeps the native surface complete in one App Store submission rather than two. `notifyListeners` is hopped to the main queue because `AVAudioSession` posts on an arbitrary thread while JS mutates the listener map on main.
- **`clients/ios/App/App/Info.plist`** — `audio` added to `UIBackgroundModes` (was `[remote-notification]`).
- **`clients/ios/App/App/MyViewController.swift`** — registers `VoiceAudioSessionPlugin()` in `capacitorDidLoad()`; class docstring now enumerates three plugins.
- **`clients/ios/README.md`** — the "two plugins" claim is now three, in all four places it appears (architecture rationale, debugging intro, breakpoint list, file tree), plus a note that web-side calls must still be capability-probed.

`.allowBluetoothHFP` is used instead of the plan's `.allowBluetooth`: it is the same option (raw value `0x4`), available since iOS 1.0, and `.allowBluetooth` is now formally deprecated in favour of it. Behaviour is identical; this just keeps the build warning-free on the pinned Xcode 26.2 toolchain.

## App Store note

An app declaring the `audio` background mode **must** actually produce audible audio in the background or App Review will reject it. Live voice does — the assistant's TTS keeps playing while the app is backgrounded. **The reviewer notes for the submission that carries this change should say so explicitly.**

## Barge-in interaction (follow-up, not this PR)

`.voiceChat` engages hardware echo cancellation, which reduces the echo that the software echo-adaptive barge-in gate (JARVIS-1296) exists to compensate for. The gate's thresholds may end up conservative on iOS once this ships. Any retuning is a separate follow-up — this PR deliberately changes only the audio-session configuration so barge-in can be measured against a stable baseline.

## Note on PR 1 (the device spike)

The plan's PR 1 — the empirical spike on whether a WKWebView voice session survives backgrounding — **has not been run and no findings document exists**. Per the plan this PR lands as written either way: a correctly configured `AVAudioSession` is a prerequisite regardless of the verdict. The plugin docstring records that the background-survival verdict is still outstanding and that if the spike concludes "must move native", a Swift capture path (`AVAudioEngine` + `URLSessionWebSocketTask`) would extend this plugin rather than replace it.

## Verification

- `bun run ios:setup` run from `clients/web/`; XcodeGen wires the new file into all three targets (8 pbxproj references).
- `CapApp-SPM/Package.swift` is unmodified; `App.xcodeproj/` is gitignored and not committed.
- Local `xcodebuild` cannot resolve a `generic/platform=iOS` destination on this machine (Xcode 26.6, iOS platform components not installed) — a pre-existing, environmental failure verified against an unmodified baseline by a previous agent. The Swift package graph resolves cleanly, and the plugin typechecks clean against the iOS 26.5 SDK (`swiftc -typecheck -target arm64-apple-ios17.0`). **The `PR iOS Checks` workflow is the real build gate for this PR.**

## Unverified

Device verification was not possible in this environment. The following acceptance criteria are **untested** and need a pass on a physical iPhone (17.0+):

- **TTS stays audible when the app is backgrounded.** The `audio` background mode plus an active `.playAndRecord` session is what should buy this, but it has not been observed. This is the minimum bar the change is meant to clear.
- **TTS stays audible with the screen locked.** Same mechanism, separately unverified.
- **Music resumes after `deactivate`.** `.notifyOthersOnDeactivation` should let interrupted audio resume; not observed.
- **`voiceAudioInterruption` actually fires** on a real phone call or Siri invocation, with the correct `type` and `shouldResume` payload.
- **`voiceAudioRouteChange` actually fires** on AirPods removal / headphone unplug, with the expected `reason` string.
- **Whether hardware AEC via `.voiceChat` measurably changes echo behaviour** (spike case H) — unmeasured, which is why no barge-in retuning is attempted here.
- **The skew fallback path** — that a shell *without* this plugin rejects `isAvailable` and the web side degrades cleanly. This can only be confirmed once PR 7's probe exists to observe it.

Everything above is dependent on a device pass before this ships to the App Store.